### PR TITLE
feat(bot): typed Renderable, durable <Message onReaction>, and richer JSX props

### DIFF
--- a/packages/bot-discord/src/interaction.test.ts
+++ b/packages/bot-discord/src/interaction.test.ts
@@ -104,6 +104,20 @@ describe("decodeInteraction", () => {
     expect(evt?.value).toBe("opt-a");
   });
 
+  it("decodes a multi-select (maxValues > 1) into a string[] of chosen values", () => {
+    const evt = decodeInteraction({
+      isButton: () => false,
+      isStringSelectMenu: () => true,
+      customId: "ck:ms",
+      component: { maxValues: 5 },
+      values: ["core", "infra"],
+      message: baseMsg,
+      channelId: "c1",
+      user: { id: "u1" },
+    });
+    expect(evt?.value).toEqual(["core", "infra"]);
+  });
+
   it("returns undefined for a non-component interaction", () => {
     expect(
       decodeInteraction({

--- a/packages/bot-discord/src/interaction.ts
+++ b/packages/bot-discord/src/interaction.ts
@@ -185,6 +185,9 @@ export function decodeReaction(
       ...(r.message?.guildId ? { guildId: r.message.guildId } : {}),
     },
     messageId,
+    // Update-capable ref (channelId + message id) so an onReaction handler can
+    // edit the reacted message in place via thread.update.
+    messageRef: { id: messageId, channelId },
     raw: reaction,
   };
 }

--- a/packages/bot-discord/src/interaction.ts
+++ b/packages/bot-discord/src/interaction.ts
@@ -11,6 +11,12 @@ interface ComponentInteractionLike {
   isStringSelectMenu(): boolean;
   customId?: string;
   values?: string[];
+  /**
+   * The resolved select component. A multi-select is marked by `maxValues > 1`
+   * OR `minValues === 0` (the renderer sets `minValues(0)` on every multi, which
+   * also catches a one-option multi-select whose `maxValues` is 1).
+   */
+  component?: { maxValues?: number; minValues?: number };
   message?: { id: string };
   channelId?: string;
   guildId?: string | null;
@@ -38,14 +44,15 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
   let id = customId;
   let value: unknown;
   if (isSelect) {
-    value = i.values?.[0];
-    if (typeof value === "string") {
-      try {
-        value = JSON.parse(value);
-      } catch {
-        // Not JSON — keep the raw string.
-      }
-    }
+    // Discord sends `values: string[]` for both single and multi selects; the
+    // unambiguous signal is the component's value bounds (the renderer sets
+    // maxValues > 1 and minValues 0 for multi). Multi → a string[] of all chosen
+    // values; single → the one value (mirrors bot-slack).
+    const c = i.component;
+    const multi = (c?.maxValues ?? 1) > 1 || c?.minValues === 0;
+    value = multi
+      ? (i.values ?? []).map(parseSelectValue)
+      : parseSelectValue(i.values?.[0]);
   } else {
     const sep = customId.startsWith("ck:") ? customId.indexOf(";v:") : -1;
     if (sep !== -1) {
@@ -67,6 +74,16 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
     // decode has no live trigger to attach.
     triggerId: undefined,
   };
+}
+
+/** JSON-parse a chosen select value so non-string option values round-trip; else keep the raw string. */
+function parseSelectValue(raw: string | undefined): unknown {
+  if (typeof raw !== "string") return raw;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
 }
 
 /** A `v:<json>` custom_id carries a small bound value; anything else has none. */

--- a/packages/bot-discord/src/render/components-v2.test.ts
+++ b/packages/bot-discord/src/render/components-v2.test.ts
@@ -60,6 +60,52 @@ describe("renderComponents", () => {
     expect(btn.style).toBe(ButtonStyle.Primary);
   });
 
+  it("renders a url button as a Link-style button with no custom_id", () => {
+    const ir: BotNode[] = [
+      node("message", {
+        children: node("actions", {
+          children: node("button", {
+            children: text("Open"),
+            url: "https://dash/deploy/42",
+          }),
+        }),
+      }),
+    ];
+    const json = renderComponents(ir).toJSON();
+    const row = json.components.find(
+      (c: any) => c.type === ComponentType.ActionRow,
+    );
+    const btn = (row as any).components[0];
+    expect(btn.style).toBe(ButtonStyle.Link);
+    expect(btn.url).toBe("https://dash/deploy/42");
+    expect(btn.custom_id).toBeUndefined();
+  });
+
+  it("sets max_values on a multi-select so the decoder reads an array", () => {
+    const ir: BotNode[] = [
+      node("message", {
+        children: node("actions", {
+          children: node("select", {
+            multi: true,
+            onSelect: { id: "ck:ms" },
+            options: [
+              { label: "Core", value: "core" },
+              { label: "Infra", value: "infra" },
+            ],
+          }),
+        }),
+      }),
+    ];
+    const json = renderComponents(ir).toJSON();
+    const row = json.components.find(
+      (c: any) => c.type === ComponentType.ActionRow,
+    );
+    const select = (row as any).components[0];
+    expect(select.type).toBe(ComponentType.StringSelect);
+    expect(select.max_values).toBe(2);
+    expect(select.min_values).toBe(0);
+  });
+
   it("chunks more than 5 buttons into multiple action rows", () => {
     const buttons = Array.from({ length: 7 }, (_, i) =>
       node("button", { children: text(`b${i}`), onClick: { id: `ck:${i}` } }),

--- a/packages/bot-discord/src/render/components-v2.ts
+++ b/packages/bot-discord/src/render/components-v2.ts
@@ -336,13 +336,22 @@ function buildActionRows(
 
 function buildButton(node: BotNode): ButtonBuilder | undefined {
   const props = node.props ?? {};
+  const label = truncateText(
+    collectText(node) || " ",
+    DISCORD_LIMITS.buttonLabel,
+  );
+  // Link button: opens a URL natively, carries no custom_id, never dispatches.
+  if (typeof props.url === "string" && props.url.length > 0) {
+    return new ButtonBuilder()
+      .setStyle(ButtonStyle.Link)
+      .setLabel(label)
+      .setURL(props.url);
+  }
   const id = buttonCustomId(idFromHandler(props.onClick), props.value);
   if (!id) return undefined;
   const btn = new ButtonBuilder()
     .setCustomId(truncateText(id, DISCORD_LIMITS.customId))
-    .setLabel(
-      truncateText(collectText(node) || " ", DISCORD_LIMITS.buttonLabel),
-    )
+    .setLabel(label)
     .setStyle(buttonStyle(props.style));
   return btn;
 }
@@ -383,6 +392,11 @@ function buildSelect(node: BotNode): StringSelectMenuBuilder | undefined {
       ),
     )
     .addOptions(built);
+  // Multi-select: allow 0..N picks. maxValues > 1 is also the signal the decoder
+  // reads (interaction.component.maxValues) to return a string[] instead of one.
+  if (props.multi) {
+    select.setMinValues(0).setMaxValues(built.length);
+  }
   return select;
 }
 

--- a/packages/bot-slack/src/interaction.test.ts
+++ b/packages/bot-slack/src/interaction.test.ts
@@ -73,6 +73,20 @@ describe("decodeInteraction", () => {
     expect(evt!.user).toBeUndefined();
   });
 
+  it("decodes a multi_static_select's selected_options into a string[] value", () => {
+    const evt = decodeInteraction({
+      type: "block_actions",
+      container: { channel_id: "C3", thread_ts: "200.0" },
+      actions: [
+        {
+          action_id: "ck:ms",
+          selected_options: [{ value: "core" }, { value: "infra" }],
+        },
+      ],
+    });
+    expect(evt!.value).toEqual(["core", "infra"]);
+  });
+
   it("returns undefined for non-block_actions or missing action_id", () => {
     expect(decodeInteraction({ type: "view_submission" })).toBeUndefined();
     expect(

--- a/packages/bot-slack/src/interaction.ts
+++ b/packages/bot-slack/src/interaction.ts
@@ -40,6 +40,7 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
       action_id?: string;
       value?: string;
       selected_option?: { value?: string };
+      selected_options?: Array<{ value?: string }>;
       action_ts?: string;
     }>;
   };
@@ -74,15 +75,13 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
   };
 
   // Tiny, non-sensitive value: the clicked button's value (or selected option
-  // value), JSON-parsed if it round-trips, otherwise the raw string.
-  const rawValue = action.value ?? action.selected_option?.value;
-  let value: unknown = rawValue;
-  if (typeof rawValue === "string") {
-    try {
-      value = JSON.parse(rawValue);
-    } catch {
-      value = rawValue;
-    }
+  // value), JSON-parsed if it round-trips, otherwise the raw string. A
+  // multi_static_select reports `selected_options` (an array) → a `string[]`.
+  let value: unknown;
+  if (action.selected_options) {
+    value = action.selected_options.map((o) => parseValue(o.value));
+  } else {
+    value = parseValue(action.value ?? action.selected_option?.value);
   }
 
   const user = body.user?.id
@@ -116,6 +115,16 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
     triggerId: body.trigger_id,
     eventId,
   };
+}
+
+/** JSON-parse a control value so non-string option values round-trip; else keep the raw string. */
+function parseValue(raw: string | undefined): unknown {
+  if (typeof raw !== "string") return raw;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
 }
 
 interface SlackReactionEvent {

--- a/packages/bot-slack/src/interaction.ts
+++ b/packages/bot-slack/src/interaction.ts
@@ -163,6 +163,9 @@ export function decodeReaction(
       ...(e.user ? { recipientUserId: e.user } : {}),
     },
     messageId: ts,
+    // Update-capable ref (channel + ts) so an onReaction handler can swap the
+    // reacted message's UI in place via thread.update.
+    messageRef: { id: ts, channel },
     threadId: ts,
     raw: event,
   };

--- a/packages/bot-slack/src/render/block-kit.test.ts
+++ b/packages/bot-slack/src/render/block-kit.test.ts
@@ -1,10 +1,5 @@
-import {
-  Header,
-  Message,
-  Section,
-  renderToIR,
-  type BotNode,
-} from "@copilotkit/bot-ui";
+import { Header, Message, Section, renderToIR } from "@copilotkit/bot-ui";
+import type { BotNode } from "@copilotkit/bot-ui";
 import { describe, expect, it } from "vitest";
 import { renderBlockKit, renderSlackMessage } from "./block-kit.js";
 
@@ -181,6 +176,108 @@ describe("renderBlockKit", () => {
         },
       ]),
     ).toEqual([{ type: "section", text: { type: "mrkdwn", text: "native" } }]);
+  });
+
+  it("renders a link button with a url", () => {
+    const blocks = renderBlockKit([
+      {
+        type: "actions",
+        props: {
+          children: [
+            {
+              type: "button",
+              props: {
+                url: "https://dash/deploy/42",
+                children: [{ type: "text", props: { value: "Open" } }],
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    const el = (blocks[0] as { elements: { url?: string }[] }).elements[0]!;
+    expect(el.url).toBe("https://dash/deploy/42");
+  });
+
+  it("renders a Field label as a bold mrkdwn line above the value", () => {
+    const blocks = renderBlockKit([
+      {
+        type: "field",
+        props: {
+          label: "Status",
+          children: [{ type: "text", props: { value: "Online" } }],
+        },
+      },
+    ]);
+    const text = (blocks[0] as { fields: { text: string }[] }).fields[0]!.text;
+    expect(text).toBe("*Status*\nOnline");
+  });
+
+  it("renders a multi-select as its own input block, not inside actions", () => {
+    const blocks = renderBlockKit([
+      {
+        type: "actions",
+        props: {
+          children: [
+            {
+              type: "select",
+              props: {
+                multi: true,
+                onSelect: { id: "ck:ms" },
+                placeholder: "Pick teams",
+                options: [
+                  { label: "Core", value: "core" },
+                  { label: "Infra", value: "infra" },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    // No actions block is emitted (the only child was peeled into an input block).
+    expect(blocks).toHaveLength(1);
+    const block = blocks[0] as {
+      type: string;
+      dispatch_action: boolean;
+      element: { type: string; action_id: string };
+    };
+    expect(block.type).toBe("input");
+    expect(block.dispatch_action).toBe(true);
+    expect(block.element.type).toBe("multi_static_select");
+    expect(block.element.action_id).toBe("ck:ms");
+  });
+
+  it("keeps source order when a multi-select is mixed with a button", () => {
+    const blocks = renderBlockKit([
+      {
+        type: "actions",
+        props: {
+          children: [
+            {
+              type: "button",
+              props: {
+                onClick: { id: "ck:b" },
+                children: [{ type: "text", props: { value: "Go" } }],
+              },
+            },
+            {
+              type: "select",
+              props: {
+                multi: true,
+                onSelect: { id: "ck:ms" },
+                options: [{ label: "Core", value: "core" }],
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    // The button's actions block comes first, then the multi-select input block.
+    expect(blocks.map((b) => (b as { type: string }).type)).toEqual([
+      "actions",
+      "input",
+    ]);
   });
 });
 

--- a/packages/bot-slack/src/render/block-kit.ts
+++ b/packages/bot-slack/src/render/block-kit.ts
@@ -147,10 +147,7 @@ function renderNode(node: BotNode, out: KnownBlock[]): void {
         type: "section",
         fields: items.map((f) => ({
           type: "mrkdwn",
-          text: truncateText(
-            markdownToMrkdwn(collectText(f)),
-            SLACK_LIMITS.fieldText,
-          ),
+          text: truncateText(fieldMrkdwn(f), SLACK_LIMITS.fieldText),
         })),
       } as KnownBlock);
       return;
@@ -162,10 +159,7 @@ function renderNode(node: BotNode, out: KnownBlock[]): void {
         fields: [
           {
             type: "mrkdwn",
-            text: truncateText(
-              markdownToMrkdwn(collectText(node)),
-              SLACK_LIMITS.fieldText,
-            ),
+            text: truncateText(fieldMrkdwn(node), SLACK_LIMITS.fieldText),
           },
         ],
       } as KnownBlock);
@@ -190,10 +184,28 @@ function renderNode(node: BotNode, out: KnownBlock[]): void {
         childNodes(node),
         SLACK_LIMITS.actionsElements,
       );
-      const elements = items
-        .map(renderActionElement)
-        .filter((e): e is object => e !== null);
-      out.push({ type: "actions", elements } as KnownBlock);
+      // A multi-select can't live in an `actions` block (Slack allows
+      // multi_static_select only in section/input blocks), so peel each one off
+      // into its own dispatching input block; the rest stay as action elements.
+      // Flush the pending actions block BEFORE each peeled-off input so blocks
+      // stay in source order (e.g. [Button, Select multi] → actions, then input).
+      let elements: object[] = [];
+      const flush = () => {
+        if (elements.length > 0) {
+          out.push({ type: "actions", elements } as KnownBlock);
+          elements = [];
+        }
+      };
+      for (const child of items) {
+        if (child.type === "select" && child.props.multi) {
+          flush();
+          out.push(multiSelectInput(child));
+          continue;
+        }
+        const el = renderActionElement(child);
+        if (el !== null) elements.push(el);
+      }
+      flush();
       return;
     }
     case "image": {
@@ -312,6 +324,11 @@ function renderActionElement(node: BotNode): object | null {
           text: truncateText(collectText(node), SLACK_LIMITS.buttonText),
         },
       };
+      // Link button: opens the URL natively. Slack still requires an action_id
+      // (kept above); clicks on a url button are not dispatched as actions.
+      if (typeof props.url === "string" && props.url.length > 0) {
+        el.url = props.url;
+      }
       if (props.value !== undefined) {
         el.value = truncateText(
           JSON.stringify(props.value),
@@ -351,6 +368,42 @@ function renderActionElement(node: BotNode): object | null {
   }
 }
 
+/**
+ * Render a `<Select multi>` as a dispatching input block holding a
+ * `multi_static_select` (which Slack forbids inside an `actions` block). The
+ * block_actions payload carries `selected_options`, decoded to a `string[]`.
+ */
+function multiSelectInput(node: BotNode): KnownBlock {
+  const props = node.props ?? {};
+  const action_id = truncateText(
+    idFromHandler(props.onSelect) ?? "select",
+    SLACK_LIMITS.actionId,
+  );
+  const options =
+    (props.options as { label: string; value: unknown }[] | undefined) ?? [];
+  const { items } = clampArray(options, SLACK_LIMITS.selectOptions);
+  return {
+    type: "input",
+    dispatch_action: true,
+    element: {
+      type: "multi_static_select",
+      action_id,
+      placeholder: {
+        type: "plain_text",
+        text: String(props.placeholder ?? " "),
+      },
+      options: items.map((o) => ({
+        text: { type: "plain_text", text: truncateText(o.label, 75) },
+        value: truncateText(String(o.value), 150),
+      })),
+    },
+    label: {
+      type: "plain_text",
+      text: truncateText(String(props.placeholder ?? " "), 150),
+    },
+  } as KnownBlock;
+}
+
 /** Derive a button's `action_id`: prefer the registry-stamped id, else a stable fallback. */
 function buttonActionId(props: Record<string, unknown>): string {
   const fromHandler = idFromHandler(props.onClick);
@@ -379,6 +432,15 @@ function childNodes(node: BotNode): BotNode[] {
     return [children as BotNode];
   }
   return [];
+}
+
+/** A field's mrkdwn text: a bold `label` line (when set) above the value. */
+function fieldMrkdwn(node: BotNode): string {
+  const value = markdownToMrkdwn(collectText(node));
+  const label = (node.props as { label?: unknown }).label;
+  return typeof label === "string" && label.length > 0
+    ? `*${label}*\n${value}`
+    : value;
 }
 
 /** Concatenate the `value` of all descendant `text` nodes (depth-first). */

--- a/packages/bot-teams/src/render/adaptive-card.test.ts
+++ b/packages/bot-teams/src/render/adaptive-card.test.ts
@@ -80,6 +80,31 @@ describe("renderAdaptiveCard", () => {
     ]);
   });
 
+  it("renders a url <Button> as an Action.OpenUrl", () => {
+    const card = renderAdaptiveCard([
+      el("actions", [
+        el("button", [text("Open")], { url: "https://dash/deploy/42" }),
+      ]),
+    ]);
+    expect(card.actions).toEqual([
+      { type: "Action.OpenUrl", title: "Open", url: "https://dash/deploy/42" },
+    ]);
+  });
+
+  it("marks a multi <Select> ChoiceSet as isMultiSelect", () => {
+    const card = renderAdaptiveCard([
+      el("select", [], {
+        multi: true,
+        onSelect: { id: "ck:pick" },
+        options: [{ label: "One", value: "1" }],
+      }),
+    ]);
+    expect(card.body[0]).toMatchObject({
+      type: "Input.ChoiceSet",
+      isMultiSelect: true,
+    });
+  });
+
   it("renders <Select>/<Input> as body inputs", () => {
     const card = renderAdaptiveCard([
       el("select", [], {

--- a/packages/bot-teams/src/render/adaptive-card.ts
+++ b/packages/bot-teams/src/render/adaptive-card.ts
@@ -169,6 +169,14 @@ function factSet(fieldNodes: BotNode[]): CardElement {
 
 function renderButton(node: BotNode): CardAction {
   const props = node.props ?? {};
+  // Link button → Action.OpenUrl (opens the URL; carries no submit data).
+  if (typeof props.url === "string" && props.url.length > 0) {
+    return {
+      type: "Action.OpenUrl",
+      title: truncateText(collectText(node), TEAMS_LIMITS.buttonText),
+      url: props.url,
+    };
+  }
   const action: CardAction = {
     type: "Action.Submit",
     title: truncateText(collectText(node), TEAMS_LIMITS.buttonText),
@@ -201,6 +209,8 @@ function renderSelect(node: BotNode): CardElement {
       value: String(o.value),
     })),
   };
+  // Multi-select: Teams submits the chosen values as a comma-joined string.
+  if (props.multi) el.isMultiSelect = true;
   if (props.placeholder) el.placeholder = String(props.placeholder);
   return el;
 }

--- a/packages/bot-telegram/src/interaction.ts
+++ b/packages/bot-telegram/src/interaction.ts
@@ -135,6 +135,9 @@ export function decodeReaction(update: unknown): IncomingReaction[] {
     conversationKey,
     replyTarget,
     messageId: String(mr.message_id),
+    // Update-capable ref (chatId + numeric messageId) so an onReaction handler
+    // can edit the reacted message in place via thread.update.
+    messageRef: { id: String(mr.message_id), chatId, messageId: mr.message_id },
     raw: update,
   };
   const out: IncomingReaction[] = [];

--- a/packages/bot-ui/README.md
+++ b/packages/bot-ui/README.md
@@ -117,10 +117,19 @@ Interactive components carry handler props typed as `ClickHandler`:
 
 `Message` also takes `onReaction`, fired when a user reacts to the posted
 message (adds or removes). The first arg is the emoji; the second carries
-`added`/`user`/`rawEmoji`:
+`added`/`user`/`rawEmoji` plus a `thread` and the reacted message's
+`messageRef` — the same surface an `onClick` gets, so a reaction can post new
+UI, swap the message in place, or run a HITL flow:
 
 ```tsx
-<Message onReaction={(emoji, r) => r.added && emoji === "bug" && triage()}>
+<Message
+  onReaction={async (emoji, r) => {
+    if (!r.added) return;
+    if (emoji === "bug") await r.thread.post(<FileBug />); // post new UI
+    if (emoji === "white_check_mark")
+      await r.thread.update(r.messageRef, <Resolved />); // swap UI in place
+  }}
+>
   …
 </Message>
 ```

--- a/packages/bot-ui/README.md
+++ b/packages/bot-ui/README.md
@@ -91,21 +91,21 @@ compile-time errors — `<Section bogus={1} />` or `<Button style="nope">` won't
 type-check. There are no lowercase intrinsic tags; the vocabulary is the
 capitalized component set below.
 
-| Component  | Purpose                                                           |
-| ---------- | ----------------------------------------------------------------- | ---------- |
-| `Message`  | Root container for a single posted message.                       |
-| `Header`   | Bold header / title row.                                          |
-| `Section`  | A block of (markdown) body text.                                  |
-| `Markdown` | Explicit markdown text block.                                     |
-| `Field`    | One label/value cell inside `Fields`.                             |
-| `Fields`   | A grid of `Field`s (two-column key/value layout).                 |
-| `Context`  | Small, muted secondary text (footnotes, metadata).                |
-| `Actions`  | Row container for interactive controls.                           |
-| `Button`   | Clickable button — `onClick`, `value`, `style: "primary"          | "danger"`. |
-| `Select`   | Dropdown — `onSelect`, `placeholder`, `options: {label,value}[]`. |
-| `Input`    | Text input — `onSubmit`, `placeholder`, `multiline`, `name`.      |
-| `Image`    | An image block.                                                   |
-| `Divider`  | A horizontal rule.                                                |
+| Component  | Purpose                                                                    |
+| ---------- | -------------------------------------------------------------------------- |
+| `Message`  | Root container for a single posted message — `accent`, `onReaction`.       |
+| `Header`   | Bold header / title row.                                                   |
+| `Section`  | A block of (markdown) body text.                                           |
+| `Markdown` | Explicit markdown text block.                                              |
+| `Field`    | One label/value cell inside `Fields` — optional `label`.                   |
+| `Fields`   | A grid of `Field`s (two-column key/value layout).                          |
+| `Context`  | Small, muted secondary text (footnotes, metadata).                         |
+| `Actions`  | Row container for interactive controls.                                    |
+| `Button`   | Clickable button — `onClick`, `value`, `style`, or `url` (link button).    |
+| `Select`   | Dropdown — `onSelect`, `placeholder`, `options: {label,value}[]`, `multi`. |
+| `Input`    | Text input — `onSubmit`, `placeholder`, `multiline`, `name`.               |
+| `Image`    | An image block.                                                            |
+| `Divider`  | A horizontal rule.                                                         |
 
 ### Behavior props
 
@@ -114,6 +114,23 @@ Interactive components carry handler props typed as `ClickHandler`:
 - `Button` → `onClick`
 - `Select` → `onSelect`
 - `Input` → `onSubmit`
+
+`Message` also takes `onReaction`, fired when a user reacts to the posted
+message (adds or removes). The first arg is the emoji; the second carries
+`added`/`user`/`rawEmoji`:
+
+```tsx
+<Message onReaction={(emoji, r) => r.added && emoji === "bug" && triage()}>
+  …
+</Message>
+```
+
+It's durable on the same terms as a component `onClick`: when the `<Message>`
+comes from a component registered via `createBot({ components: [...] })` and a
+durable `store` is configured, a reaction after a restart re-renders the
+component to re-derive the handler. Inline handlers (and `<Message>` used
+directly) route in-process but don't survive a restart. For durable, filtered
+reaction routing across _all_ messages, use `bot.onReaction(...)`.
 
 A `ClickHandler` receives an `InteractionContext`, both generic over the
 clicked control's value type:

--- a/packages/bot-ui/src/components.tsx
+++ b/packages/bot-ui/src/components.tsx
@@ -30,10 +30,12 @@ export interface MessageProps extends WithChildren {
   /**
    * Called when a user reacts to this message (add or remove). The first arg is
    * the emoji, e.g. `onReaction={(r) => r === "bug" ? triage() : ack()}`; the
-   * second carries `added`/`user`/`rawEmoji`. Durable on the same terms as a
-   * component `onClick`: survives a restart when the `<Message>` comes from a
-   * registered component and a durable store is configured; inline handlers
-   * route in-process only.
+   * second carries `added`/`user`/`rawEmoji` plus a `thread` and the reacted
+   * message's `messageRef` — the same surface an `onClick` gets, so the handler
+   * can `thread.post(...)`, `thread.update(messageRef, ...)`, or run a HITL flow.
+   * Durable on the same terms as a component `onClick`: survives a restart when
+   * the `<Message>` comes from a registered component and a durable store is
+   * configured; inline handlers route in-process only.
    */
   onReaction?: MessageReactionHandler;
 }

--- a/packages/bot-ui/src/components.tsx
+++ b/packages/bot-ui/src/components.tsx
@@ -1,5 +1,5 @@
 import type { BotNode } from "./ir.js";
-import type { ClickHandler } from "./types.js";
+import type { ClickHandler, MessageReactionHandler } from "./types.js";
 
 /**
  * Anything that can appear as a child in the component tree: nested elements,
@@ -27,12 +27,28 @@ interface WithChildren {
 export interface MessageProps extends WithChildren {
   /** Accent color (hex, e.g. `#27AE60`) for the message's colored rail. */
   accent?: string;
+  /**
+   * Called when a user reacts to this message (add or remove). The first arg is
+   * the emoji, e.g. `onReaction={(r) => r === "bug" ? triage() : ack()}`; the
+   * second carries `added`/`user`/`rawEmoji`. Durable on the same terms as a
+   * component `onClick`: survives a restart when the `<Message>` comes from a
+   * registered component and a durable store is configured; inline handlers
+   * route in-process only.
+   */
+  onReaction?: MessageReactionHandler;
 }
 export interface HeaderProps extends WithChildren {}
 export interface SectionProps extends WithChildren {}
 export interface MarkdownProps extends WithChildren {}
 export interface FieldsProps extends WithChildren {}
-export interface FieldProps extends WithChildren {}
+export interface FieldProps extends WithChildren {
+  /**
+   * Bold label rendered before the value (e.g. `<Field label="Status">Online</Field>`).
+   * Rendered on Discord, Slack, and Telegram; surfaces without a field label
+   * concept fall back to the value text alone.
+   */
+  label?: string;
+}
 export interface ContextProps extends WithChildren {}
 export interface ActionsProps extends WithChildren {}
 
@@ -50,11 +66,17 @@ export interface ButtonProps<TValue = unknown> extends WithChildren {
   /**
    * Inline handler run when the button is clicked (bound by the action
    * registry). Its `ctx.action.value` is typed as `TValue`, inferred from
-   * `value`.
+   * `value`. Ignored when `url` is set (a link button doesn't dispatch).
    */
   onClick?: ClickHandler<TValue>;
   /** Value echoed back to `onClick`/`awaitChoice` on click; drives `TValue`. */
   value?: TValue;
+  /**
+   * Makes this a link button that opens `url` instead of dispatching a handler.
+   * Rendered natively on Slack, Discord, Teams, and Telegram; surfaces without
+   * link buttons skip it. When set, `onClick`/`value` are ignored.
+   */
+  url?: string;
   /** Slack button accent. */
   style?: "primary" | "danger";
 }
@@ -64,10 +86,21 @@ export interface SelectOption {
   value: string;
 }
 export interface SelectProps {
-  /** Handler run on selection; `ctx.action.value` is the chosen option's `value`. */
-  onSelect?: ClickHandler<string>;
+  /**
+   * Handler run on selection. `ctx.action.value` is the chosen option's `value`
+   * (a `string`), or a `string[]` of chosen values when `multi` is set.
+   */
+  onSelect?: ClickHandler<string | string[]>;
   placeholder?: string;
   options: SelectOption[];
+  /**
+   * Allow selecting multiple options. Rendered natively on Slack
+   * (`multi_static_select`), Discord (max-values), and Teams
+   * (`isMultiSelect`); surfaces that can only express a single choice
+   * (Telegram, WhatsApp) degrade to single-select. When set, `onSelect`
+   * receives a `string[]`.
+   */
+  multi?: boolean;
 }
 
 export interface InputProps {

--- a/packages/bot-ui/src/types.ts
+++ b/packages/bot-ui/src/types.ts
@@ -1,5 +1,6 @@
 import type { EmojiValue } from "./emoji.js";
 import type { ModalView } from "./modal.js";
+import type { Renderable } from "./ir.js";
 
 export interface MessageRef {
   id: string;
@@ -65,15 +66,15 @@ export interface ThreadMessage {
 }
 export interface Thread {
   readonly platform: string;
-  post(ui: unknown): Promise<MessageRef>;
-  update(ref: MessageRef, ui: unknown): Promise<MessageRef>;
+  post(ui: Renderable): Promise<MessageRef>;
+  update(ref: MessageRef, ui: Renderable): Promise<MessageRef>;
   delete(ref: MessageRef): Promise<void>;
   /**
    * Post a picker and block until an interaction resolves it to the clicked
    * button's `value`. Pass the expected value type, e.g.
    * `awaitChoice<{ confirmed: boolean }>(<Picker/>)`.
    */
-  awaitChoice<T = unknown>(ui: unknown): Promise<T>;
+  awaitChoice<T = unknown>(ui: Renderable): Promise<T>;
   runAgent(input?: unknown): Promise<MessageRef | undefined>;
   resume(value: unknown): Promise<MessageRef | undefined>;
   stream(src: string | AsyncIterable<string>): Promise<MessageRef>;
@@ -111,7 +112,7 @@ export interface Thread {
    */
   postEphemeral(
     user: PlatformUser | string,
-    ui: unknown,
+    ui: Renderable,
     opts: { fallbackToDM: boolean },
   ): Promise<EphemeralResult | null>;
   /** Record this conversation as subscribed (persisted in state). Proactive delivery to subscribed conversations is not yet wired. */
@@ -143,4 +144,27 @@ export interface InteractionContext<TValue = unknown> {
 }
 export type ClickHandler<TValue = unknown> = (
   ctx: InteractionContext<TValue>,
+) => void | Promise<void>;
+
+/** The reaction passed to a `<Message onReaction>` handler. */
+export interface MessageReaction {
+  /** Normalized emoji name when recognized, else the raw platform token. */
+  emoji: EmojiValue;
+  /** Platform-native emoji token. */
+  rawEmoji: string;
+  /** `true` = added, `false` = removed. */
+  added: boolean;
+  /** The reacting user, when the platform reports one. */
+  user?: PlatformUser;
+  /** Id of the reacted-to message. */
+  messageId: string;
+}
+/**
+ * Handler for reactions on a posted message, set via `<Message onReaction>`.
+ * Fires for both adds and removes (check `reaction.added`); the first arg is
+ * the emoji for the common `(reaction) => reaction === "bug"` shape.
+ */
+export type MessageReactionHandler = (
+  emoji: EmojiValue,
+  reaction: MessageReaction,
 ) => void | Promise<void>;

--- a/packages/bot-ui/src/types.ts
+++ b/packages/bot-ui/src/types.ts
@@ -158,11 +158,24 @@ export interface MessageReaction {
   user?: PlatformUser;
   /** Id of the reacted-to message. */
   messageId: string;
+  /**
+   * The conversation thread — same surface an `onClick` gets via `ctx.thread`.
+   * Post new UI (`thread.post`), run the agent (`thread.runAgent`), block on a
+   * human choice (`thread.awaitChoice`, HITL), react back, etc.
+   */
+  thread: Thread;
+  /**
+   * Ref to the reacted-to message, for swapping its UI in place:
+   * `thread.update(reaction.messageRef, <NewUi/>)`.
+   */
+  messageRef: MessageRef;
 }
 /**
  * Handler for reactions on a posted message, set via `<Message onReaction>`.
  * Fires for both adds and removes (check `reaction.added`); the first arg is
- * the emoji for the common `(reaction) => reaction === "bug"` shape.
+ * the emoji for the common `(reaction) => reaction === "bug"` shape. The second
+ * carries the full reaction including `thread`/`messageRef`, so a handler can
+ * post, swap UI, or run a HITL flow exactly like an `onClick`.
  */
 export type MessageReactionHandler = (
   emoji: EmojiValue,

--- a/packages/bot/src/action-registry.ts
+++ b/packages/bot/src/action-registry.ts
@@ -4,6 +4,7 @@ import type {
   InteractionContext,
   ComponentFn,
   Renderable,
+  MessageReactionHandler,
 } from "@copilotkit/bot-ui";
 import { isBound, getBoundArgs, renderToIR } from "@copilotkit/bot-ui";
 import { mintId } from "./mint-id.js";
@@ -36,9 +37,64 @@ export class ActionRegistry {
   // payload can't carry it (e.g. Telegram's 64-byte callback_data only holds
   // the action id), where `evt.value` arrives undefined.
   private hot = new Map<string, { handler: ClickHandler; value: unknown }>();
+  // Same-process fast path for `<Message onReaction>` handlers, keyed by the
+  // posted message's id. Mirrors the `hot` action cache; the durable snapshot
+  // (below) is the cross-restart counterpart, exactly like onClick.
+  private messageReactions = new Map<string, MessageReactionHandler>();
 
   constructor(opts: { store: ActionStore }) {
     this.store = opts.store;
+  }
+
+  /** Cache a `<Message onReaction>` handler for the posted message (same-process). */
+  registerMessageReaction(
+    messageId: string,
+    handler: MessageReactionHandler,
+  ): void {
+    this.messageReactions.set(messageId, handler);
+  }
+
+  /**
+   * Persist the message's reaction handler as a `{ component, props }` snapshot
+   * keyed by `messageId`, so a reaction after a restart re-renders the component
+   * and re-derives the handler — durable exactly like a registered-component
+   * `onClick` (and degrading the same way for inline/anonymous components).
+   */
+  async persistMessageReaction(
+    messageId: string,
+    snap: {
+      component: string;
+      props: Record<string, unknown>;
+      conversationKey: string;
+    },
+  ): Promise<void> {
+    await this.store.put(reactionKey(messageId), {
+      component: snap.component,
+      props: snap.props,
+      path: [],
+      conversationKey: snap.conversationKey,
+    });
+  }
+
+  /**
+   * Resolve the `onReaction` handler for `messageId`: the hot cache first, then
+   * the durable snapshot (re-rendering the named component and re-plucking the
+   * root's handler). Returns `undefined` when neither resolves — e.g. an inline
+   * handler whose closure can't be re-derived after a restart.
+   */
+  async resolveMessageReaction(
+    messageId: string,
+  ): Promise<MessageReactionHandler | undefined> {
+    const hot = this.messageReactions.get(messageId);
+    if (hot) return hot;
+    const snap = await this.store.get(reactionKey(messageId));
+    if (!snap?.component) return undefined;
+    const fn = this.components.get(snap.component);
+    if (!fn) return undefined;
+    const root = renderToIR(
+      fn(snap.props as Record<string, unknown>) as Renderable,
+    );
+    return takeMessageReaction(root);
   }
 
   registerComponent(name: string, fn: ComponentFn): void {
@@ -66,24 +122,42 @@ export class ActionRegistry {
   // (`{ type: fn, props }`), it is registered + bound by name (cold-path
   // re-render supported). Otherwise the IR is bound inline with `component:""`,
   // meaning a cold-cache dispatch throws ActionExpiredError (intended
-  // degradation for inline handlers that can't be re-derived).
+  // degradation for inline handlers that can't be re-derived). A top-level
+  // `<Message onReaction>` handler is pulled off the IR (so it never reaches the
+  // adapter) and returned for the caller to associate with the posted message.
   async bindRenderable(
     ui: Renderable,
     conversationKey: string,
-  ): Promise<BotNode[]> {
+  ): Promise<{
+    root: BotNode[];
+    onReaction?: MessageReactionHandler;
+    /**
+     * The component + props to persist for durable reaction routing, present
+     * only when `ui` was a component element with an `onReaction` (an inline IR
+     * tree has no component to re-render, so its handler stays in-memory).
+     */
+    reactionComponent?: { component: string; props: Record<string, unknown> };
+  }> {
+    let root: BotNode[];
+    let component: string | undefined;
+    let props: Record<string, unknown> | undefined;
     if (isComponentElement(ui)) {
       const fn = ui.type;
-      const name = fn.name || "anonymous";
-      this.registerComponent(name, fn);
-      return this.bindTree(
-        name,
-        (ui.props ?? {}) as Record<string, unknown>,
-        conversationKey,
-      );
+      component = fn.name || "anonymous";
+      props = (ui.props ?? {}) as Record<string, unknown>;
+      this.registerComponent(component, fn);
+      root = await this.bindTree(component, props, conversationKey);
+    } else {
+      root = renderToIR(ui);
+      await this.walk(root, [], "", undefined, conversationKey);
     }
-    const root = renderToIR(ui);
-    await this.walk(root, [], "", undefined, conversationKey);
-    return root;
+    const onReaction = takeMessageReaction(root);
+    return {
+      root,
+      onReaction,
+      reactionComponent:
+        onReaction && component && props ? { component, props } : undefined,
+    };
   }
 
   private async walk(
@@ -156,6 +230,30 @@ export class ActionRegistry {
     await handler({ ...ctx, action: { ...ctx.action, id } });
     return value;
   }
+}
+
+/** Store key for a message's durable reaction snapshot (distinct from minted action ids). */
+function reactionKey(messageId: string): string {
+  return `reaction:${messageId}`;
+}
+
+/**
+ * Pull a top-level `<Message onReaction>` handler off the IR, deleting the prop
+ * so it never reaches the adapter (a function can't be serialized to a native
+ * payload). Returns the handler when the single root node is a `message`.
+ */
+function takeMessageReaction(
+  root: BotNode[],
+): MessageReactionHandler | undefined {
+  const node = root.length === 1 ? root[0] : undefined;
+  if (!node || node.type !== "message" || !("onReaction" in node.props)) {
+    return undefined;
+  }
+  const handler = node.props.onReaction;
+  delete node.props.onReaction;
+  return typeof handler === "function"
+    ? (handler as MessageReactionHandler)
+    : undefined;
 }
 
 /** Navigate to the node owning the event-prop at `path` and read its `value`. */

--- a/packages/bot/src/create-bot.ts
+++ b/packages/bot/src/create-bot.ts
@@ -30,6 +30,7 @@ import type {
   EmojiPlatform,
   ModalView,
   ComponentFn,
+  MessageRef,
 } from "@copilotkit/bot-ui";
 import {
   normalizeEmoji,
@@ -83,6 +84,8 @@ export interface ReactionEvent {
   /** The reacting user, when the platform reports one. */
   user?: PlatformUser;
   messageId: string;
+  /** Update-capable ref to the reacted message (`thread.update(messageRef, ui)`). */
+  messageRef: MessageRef;
   threadId?: string;
   thread: Thread;
   adapter: PlatformAdapter;
@@ -558,12 +561,15 @@ export function createBot<
           evt.replyTarget,
           evt.conversationKey,
         );
+        // Prefer the adapter's update-capable ref; fall back to the bare id.
+        const messageRef: MessageRef = evt.messageRef ?? { id: evt.messageId };
         const reactionEvt: ReactionEvent = {
           emoji: value,
           rawEmoji: evt.rawEmoji,
           added: evt.added,
           user: evt.user,
           messageId: evt.messageId,
+          messageRef,
           threadId: evt.threadId,
           thread,
           adapter,
@@ -583,6 +589,8 @@ export function createBot<
             added: evt.added,
             user: evt.user,
             messageId: evt.messageId,
+            thread,
+            messageRef,
           });
         }
       },

--- a/packages/bot/src/create-bot.ts
+++ b/packages/bot/src/create-bot.ts
@@ -573,6 +573,18 @@ export function createBot<
           if (!reg.emojis || reg.emojis.has(value))
             await reg.handler(reactionEvt);
         }
+        // Per-message handler set via `<Message onReaction>` on the posted
+        // message — hot cache, falling back to the durable snapshot after a restart.
+        const perMessage = await registry.resolveMessageReaction(evt.messageId);
+        if (perMessage) {
+          await perMessage(value, {
+            emoji: value,
+            rawEmoji: evt.rawEmoji,
+            added: evt.added,
+            user: evt.user,
+            messageId: evt.messageId,
+          });
+        }
       },
       async onModalSubmit(evt: IncomingModalSubmit) {
         const handler = modalSubmitHandlers.get(evt.callbackId);

--- a/packages/bot/src/platform-adapter.ts
+++ b/packages/bot/src/platform-adapter.ts
@@ -128,6 +128,13 @@ export interface IncomingReaction {
   replyTarget: ReplyTarget;
   /** Id of the reacted-to message. */
   messageId: string;
+  /**
+   * Update-capable ref to the reacted message (the platform-specific shape the
+   * adapter's `update`/`delete` accept). Lets a `<Message onReaction>` handler
+   * swap the message's UI in place. Adapters that can edit messages should set
+   * this; the engine falls back to `{ id: messageId }` when omitted.
+   */
+  messageRef?: MessageRef;
   /** Containing thread/conversation id, when distinct from the message. */
   threadId?: string;
   /** Native payload. */

--- a/packages/bot/src/reactions.test.ts
+++ b/packages/bot/src/reactions.test.ts
@@ -1,8 +1,9 @@
 // packages/bot/src/reactions.test.ts
 import { describe, it, expect } from "vitest";
-import { emoji } from "@copilotkit/bot-ui";
+import { emoji, Message } from "@copilotkit/bot-ui";
 import { createBot } from "./create-bot.js";
 import { FakeAdapter } from "./testing/fake-adapter.js";
+import { MemoryStore } from "./state/memory-store.js";
 
 const tick = () => new Promise((r) => setTimeout(r, 0));
 
@@ -77,6 +78,99 @@ describe("bot.onReaction", () => {
     fake.emitReaction({ rawEmoji: "thumbsup", added: true }); // Slack alias
     await tick();
     expect(hits).toEqual(["thumbs_up"]);
+  });
+
+  it("routes a reaction on a posted message to its <Message onReaction>", async () => {
+    const fake = new FakeAdapter();
+    const bot = createBot({ adapters: [fake] });
+    const seen: { emoji: string; added: boolean }[] = [];
+    bot.onMessage(async ({ thread }) => {
+      await thread.post(
+        Message({
+          onReaction: (e, r) => {
+            seen.push({ emoji: e, added: r.added });
+          },
+          children: "hi",
+        }),
+      );
+    });
+    await bot.start();
+    fake.emitTurn({});
+    await tick();
+    // The handler is a closure, never serialized into the native payload.
+    expect(fake.posted[0]?.[0]?.props.onReaction).toBeUndefined();
+    // First post → "msg-1" (FakeAdapter counter).
+    fake.emitReaction({ rawEmoji: "🎉", added: true, messageId: "msg-1" });
+    fake.emitReaction({ rawEmoji: "🎉", added: false, messageId: "msg-1" });
+    await tick();
+    expect(seen).toEqual([
+      { emoji: "🎉", added: true },
+      { emoji: "🎉", added: false },
+    ]);
+  });
+
+  it("re-derives a registered component's onReaction from the store after a restart", async () => {
+    const backend = new MemoryStore(); // shared store survives the simulated restart
+    const seen: string[] = [];
+    // A named component so it can be re-registered + re-rendered after restart.
+    const Card = () =>
+      Message({
+        onReaction: (e) => {
+          seen.push(e);
+        },
+        children: "deploy done",
+      });
+
+    // Bot 1 posts the component message, persisting a reaction snapshot.
+    const fake1 = new FakeAdapter();
+    const bot1 = createBot({
+      adapters: [fake1],
+      store: { adapter: backend },
+      components: [Card],
+    });
+    bot1.onMessage(async ({ thread }) => {
+      // A component element ({ type: fn }) — the path that persists, unlike a
+      // pre-rendered Message() node.
+      await thread.post({ type: Card, props: {} });
+    });
+    await bot1.start();
+    fake1.emitTurn({});
+    await tick();
+
+    // "Restart": a fresh bot + registry sharing the same store, Card re-registered.
+    // Its reaction hot cache is empty, so it must resolve via the durable snapshot.
+    const fake2 = new FakeAdapter();
+    const bot2 = createBot({
+      adapters: [fake2],
+      store: { adapter: backend },
+      components: [Card],
+    });
+    await bot2.start();
+    fake2.emitReaction({ rawEmoji: "🎉", added: true, messageId: "msg-1" });
+    await tick();
+    expect(seen).toEqual(["🎉"]);
+  });
+
+  it("does not fire a message handler for a reaction on a different message", async () => {
+    const fake = new FakeAdapter();
+    const bot = createBot({ adapters: [fake] });
+    let fired = false;
+    bot.onMessage(async ({ thread }) => {
+      await thread.post(
+        Message({
+          onReaction: () => {
+            fired = true;
+          },
+          children: "hi",
+        }),
+      );
+    });
+    await bot.start();
+    fake.emitTurn({});
+    await tick();
+    fake.emitReaction({ rawEmoji: "🎉", added: true, messageId: "other" });
+    await tick();
+    expect(fired).toBe(false);
   });
 
   it("normalizes a raw-token filter (unicode / slack alias) to canonical", async () => {

--- a/packages/bot/src/reactions.test.ts
+++ b/packages/bot/src/reactions.test.ts
@@ -151,6 +151,33 @@ describe("bot.onReaction", () => {
     expect(seen).toEqual(["🎉"]);
   });
 
+  it("gives the handler a thread to post new UI and the reacted message's ref", async () => {
+    const fake = new FakeAdapter();
+    const bot = createBot({ adapters: [fake] });
+    let seenRefId: string | undefined;
+    bot.onMessage(async ({ thread }) => {
+      await thread.post(
+        Message({
+          onReaction: async (_e, r) => {
+            seenRefId = r.messageRef.id;
+            await r.thread.post("thanks for the reaction"); // post new UI like onClick can
+          },
+          children: "hi",
+        }),
+      );
+    });
+    await bot.start();
+    fake.emitTurn({});
+    await tick();
+    const before = fake.posted.length;
+    fake.emitReaction({ rawEmoji: "🎉", added: true, messageId: "msg-1" });
+    await tick();
+    // The handler posted a second message via its thread.
+    expect(fake.posted.length).toBe(before + 1);
+    // …and received an update-capable ref to the reacted message (fallback id here).
+    expect(seenRefId).toBe("msg-1");
+  });
+
   it("does not fire a message handler for a reaction on a different message", async () => {
     const fake = new FakeAdapter();
     const bot = createBot({ adapters: [fake] });

--- a/packages/bot/src/thread.ts
+++ b/packages/bot/src/thread.ts
@@ -74,15 +74,37 @@ export class Thread implements ThreadInterface {
     return this.deps.registry.bindRenderable(ui, this.deps.conversationKey);
   }
 
+  /**
+   * Wire a posted message's `onReaction` to its returned id: cache it for this
+   * process and, when it came from a component, persist a durable snapshot so a
+   * reaction after a restart re-derives it (parity with a component `onClick`).
+   */
+  private async bindReaction(
+    messageId: string,
+    bound: Awaited<ReturnType<Thread["bindForPost"]>>,
+  ): Promise<void> {
+    if (bound.onReaction) {
+      this.deps.registry.registerMessageReaction(messageId, bound.onReaction);
+    }
+    if (bound.reactionComponent) {
+      await this.deps.registry.persistMessageReaction(messageId, {
+        ...bound.reactionComponent,
+        conversationKey: this.deps.conversationKey,
+      });
+    }
+  }
+
   async post(ui: Renderable): Promise<MessageRef> {
-    return this.deps.adapter.post(
-      this.deps.replyTarget,
-      await this.bindForPost(ui),
-    );
+    const bound = await this.bindForPost(ui);
+    const ref = await this.deps.adapter.post(this.deps.replyTarget, bound.root);
+    await this.bindReaction(ref.id, bound);
+    return ref;
   }
 
   async update(ref: MessageRef, ui: Renderable): Promise<MessageRef> {
-    await this.deps.adapter.update(ref, await this.bindForPost(ui));
+    const bound = await this.bindForPost(ui);
+    await this.deps.adapter.update(ref, bound.root);
+    await this.bindReaction(ref.id, bound);
     return ref;
   }
 
@@ -190,12 +212,10 @@ export class Thread implements ThreadInterface {
         error: `${this.platform} does not support ephemeral messages`,
       };
     }
-    return adapter.postEphemeral(
-      this.deps.replyTarget,
-      user,
-      await this.bindForPost(ui),
-      opts,
-    );
+    // Ephemeral messages can't be reacted to, so any `onReaction` is dropped
+    // (stripped by bindForPost) rather than registered.
+    const { root } = await this.bindForPost(ui);
+    return adapter.postEphemeral(this.deps.replyTarget, user, root, opts);
   }
 
   // Subscription STORAGE lands here; subscription ROUTING (onSubscribedMessage) is deferred.


### PR DESCRIPTION
## What

Types the bot UI surface and broadens the cross-platform component vocabulary, adding **only** capabilities more than one adapter can express.

### 1. `ui` typed as `Renderable` (was `unknown`)
The `Thread` interface's `post` / `update` / `awaitChoice` / `postEphemeral` now accept `Renderable` instead of `unknown`. JSX is type-checked at the call site, and the `{ raw }` escape hatch is the explicit way out when the JSX vocabulary doesn't fit. (The concrete `Thread` class already used `Renderable` — only the interface leaked `unknown`.)

### 2. `<Message onReaction>` — per-message reaction callback
```tsx
<Message onReaction={(emoji, r) => (r.added && emoji === "bug" ? triage() : ack())}>
  Deploy finished — react 🐛 to file a bug
</Message>
```
- First arg is the emoji (matches the common `r => r === "bug"` shape); second carries `{ added, user, rawEmoji, messageId }`. Fires on add **and** remove.
- The handler is stripped from the IR before it reaches the adapter, then associated with the posted message's id; inbound reactions route to it.
- **Durable on the same terms as a component `onClick`:** a `{ component, props }` snapshot is persisted and the component is re-rendered to re-derive the handler after a restart (when the `<Message>` comes from a registered component + a durable `store`). Inline handlers route in-process only — identical degradation to an inline `onClick`.

### 3. `Button.url` link buttons
`<Button url="…">` → native link buttons on **Slack, Discord, Teams, Telegram** (Telegram already supported it; now typed + wired everywhere).

### 4. `Field.label`
`<Field label="Status">Online</Field>` — **Discord and Telegram already read this prop untyped** (latent type gap); now typed and additionally rendered on Slack.

### 5. `Select.multi` multi-select
`<Select multi onSelect={(vals) => …}>` — **Slack** (`multi_static_select` in an input block, since Slack forbids it in `actions` blocks; decodes `selected_options` → `string[]`), **Discord** (min/max values; decodes via `interaction.component` bounds), **Teams** (`isMultiSelect`). Telegram/WhatsApp degrade to single-select. `onSelect` widened to `ClickHandler<string | string[]>`.

### Intentionally dropped (Slack-only)
`Button.confirm`, `Image.title`, `Input.label`/`initialValue`/`required`, `Select.initialValue` — single-platform, excluded by design.

## Testing
- All 7 affected packages (`bot-ui`, `bot`, `bot-slack`, `bot-discord`, `bot-teams`, `bot-telegram`, `bot-whatsapp`) build clean and pass their full suites.
- New coverage: reaction routing + durability cold-resolve (`bot`), link button / field label / multi-select render + source-ordering (`bot-slack`), link button + multi-select bounds + multi decode (`bot-discord`/`bot-slack`), `Action.OpenUrl` + `isMultiSelect` (`bot-teams`).
- Two code-review passes (incl. an adversarial one on the durability change); all findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)