### PR TITLE
feat(openbox-governed-copilotkit): governance-feed / execution-tree side panel

### DIFF
--- a/examples/showcases/openbox-governed-copilotkit/frontend/e2e/governance-feed.spec.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/e2e/governance-feed.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * OpenBox Governance-Feed / Execution-Tree side panel — E2E.
+ *
+ * Structural assertions (panel mounts, empty state, populates after a run)
+ * run against the unprovisioned permissive local stack. Verdict-matrix
+ * assertions require live OpenBox creds and are gated like governance.spec.ts.
+ */
+import { test, expect } from "@playwright/test";
+import {
+  openFresh,
+  clickSuggestion,
+  expectOpenBoxDecision,
+  expectFeedVisible,
+  expectFeedRunCountAtLeast,
+  expectFeedNodeVerdict,
+} from "./helpers";
+
+const HAS_OPENBOX = Boolean(
+  process.env.OPENBOX_API_KEY && process.env.OPENBOX_CORE_URL,
+);
+
+test.describe("OpenBox governance feed · structural", () => {
+  test.describe.configure({ timeout: 300_000 });
+
+  test("panel mounts with an empty state on load", async ({ page }) => {
+    await openFresh(page, "feed-empty");
+    await expectFeedVisible(page);
+    await expect(page.getByTestId("openbox-feed-empty")).toBeVisible();
+  });
+
+  test("running a governed action populates the tree", async ({ page }) => {
+    await openFresh(page, "feed-populate");
+    await expectFeedVisible(page);
+    await clickSuggestion(page, "Review Work Queue");
+    // A decision card appears in chat...
+    await expectOpenBoxDecision(
+      page,
+      /Allowed|Redacted|Constrained|Blocked|Halted|Rejected/i,
+    );
+    // ...and the feed gains at least one run group.
+    await expectFeedRunCountAtLeast(page, 1);
+  });
+});
+
+const describeMatrix = HAS_OPENBOX ? test.describe : test.describe.skip;
+
+describeMatrix("OpenBox governance feed · verdict matrix", () => {
+  test.describe.configure({ timeout: 900_000 });
+
+  test("allow action renders an allow badge in the feed", async ({ page }) => {
+    await openFresh(page, "feed-allow");
+    await clickSuggestion(page, "Review Work Queue");
+    await expectOpenBoxDecision(page, /Allowed/i);
+    await expectFeedNodeVerdict(page, "allow");
+  });
+
+  test("block action renders a block badge in the feed", async ({ page }) => {
+    await openFresh(page, "feed-block");
+    await clickSuggestion(page, "Send Exception IDs");
+    await expectOpenBoxDecision(page, /Blocked|Halted|Rejected/i);
+    await expectFeedNodeVerdict(page, "block");
+  });
+
+  test("halt action renders a halt badge in the feed", async ({ page }) => {
+    await openFresh(page, "feed-halt");
+    await clickSuggestion(page, "Update Vendor Bank");
+    await expectOpenBoxDecision(page, /Halted|Blocked/i);
+    await expectFeedNodeVerdict(page, "halt");
+  });
+});

--- a/examples/showcases/openbox-governed-copilotkit/frontend/e2e/helpers.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/e2e/helpers.ts
@@ -172,3 +172,40 @@ export async function expectNoUnsafeOutput(page: Page): Promise<void> {
   expect(text).not.toContain("session_id:");
   expect(text).not.toContain("workflow_id:");
 }
+
+/** Assert the governance-feed side panel is mounted and visible. */
+export async function expectFeedVisible(page: Page): Promise<void> {
+  await expect(page.getByTestId("openbox-governance-feed")).toBeVisible({
+    timeout: OPENBOX_VISIBLE_TIMEOUT_MS,
+  });
+}
+
+/** Assert the feed shows at least `n` run groups (GitBranch rows). */
+export async function expectFeedRunCountAtLeast(
+  page: Page,
+  n: number,
+): Promise<void> {
+  const empty = page.getByTestId("openbox-feed-empty");
+  await expect
+    .poll(
+      async () => {
+        if ((await empty.count()) > 0 && (await empty.isVisible())) return 0;
+        return page
+          .getByTestId("openbox-governance-feed")
+          .locator(".openbox-feed-run")
+          .count();
+      },
+      { timeout: OPENBOX_VISIBLE_TIMEOUT_MS },
+    )
+    .toBeGreaterThanOrEqual(n);
+}
+
+/** Assert at least one node badge with the given verdict key is present. */
+export async function expectFeedNodeVerdict(
+  page: Page,
+  verdict: string,
+): Promise<void> {
+  await expect(
+    page.getByTestId(`openbox-feed-verdict-${verdict}`).first(),
+  ).toBeVisible({ timeout: OPENBOX_VISIBLE_TIMEOUT_MS });
+}

--- a/examples/showcases/openbox-governed-copilotkit/frontend/package-lock.json
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/package-lock.json
@@ -26,7 +26,8 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "3.2.6"
       },
       "engines": {
         "node": ">=20"
@@ -794,6 +795,448 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -3034,6 +3477,395 @@
       "integrity": "sha512-TaoVksZRSx2KWYYpyLQtMQXXeS98VsgZImzW65xmiVgbYhXLk+aEsmzPLirqVuE4/XuUapH2iMtxUzaBNDzdSQ==",
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@scarf/scarf": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
@@ -3542,6 +4374,17 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -3804,6 +4647,13 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -3958,6 +4808,121 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@whatwg-node/disposablestack": {
@@ -4159,6 +5124,16 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -4297,6 +5272,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -4356,6 +5341,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4410,6 +5412,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/clarinet": {
@@ -5186,6 +6198,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/delaunator": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
@@ -5370,6 +6392,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -5391,6 +6420,48 @@
         "docs",
         "benchmarks"
       ]
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
@@ -5418,6 +6489,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/etag": {
@@ -5472,6 +6553,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -5583,6 +6674,24 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -7599,6 +8708,13 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -14997,6 +16113,23 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/phoenix": {
       "version": "1.8.8",
       "resolved": "https://registry.npmjs.org/phoenix/-/phoenix-1.8.8.tgz",
@@ -15008,6 +16141,19 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/pino": {
       "version": "9.14.0",
@@ -16395,6 +17541,51 @@
       "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
       "license": "Unlicense"
     },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/roughjs": {
       "version": "4.6.6",
       "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
@@ -16756,6 +17947,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -16793,6 +17991,13 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -16801,6 +18006,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/streamdown": {
       "version": "1.6.11",
@@ -17640,6 +18852,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -17754,6 +18986,13 @@
         "real-require": "^0.2.0"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
@@ -17761,6 +19000,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -18331,6 +19617,249 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -18379,6 +19908,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wonka": {

--- a/examples/showcases/openbox-governed-copilotkit/frontend/package.json
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build --webpack",
     "start": "next start -H 0.0.0.0 -p ${PORT:-3000}",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest"
   },
   "dependencies": {
     "@copilotkit/core": "^1.59.3",
@@ -29,7 +31,8 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "3.2.6"
   },
   "overrides": {
     "@langchain/core": "1.1.48",

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/app/globals.css
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/app/globals.css
@@ -206,3 +206,122 @@ html {
 .openbox-business-row dl > div {
   min-width: 0;
 }
+
+/* ── OpenBox Governance Feed (execution-tree side panel) ─────────────── */
+:root {
+  --openbox-feed-reviewing: #64748b; /* slate */
+  --openbox-feed-allow: #16a34a; /* green */
+  --openbox-feed-constrain: #d97706; /* amber */
+  --openbox-feed-approval: #2563eb; /* blue */
+  --openbox-feed-block: #dc2626; /* red */
+  --openbox-feed-halt: #7f1d1d; /* dark red */
+}
+:root.dark,
+.dark {
+  --openbox-feed-reviewing: #94a3b8;
+  --openbox-feed-allow: #4ade80;
+  --openbox-feed-constrain: #fbbf24;
+  --openbox-feed-approval: #60a5fa;
+  --openbox-feed-block: #f87171;
+  --openbox-feed-halt: #b91c1c;
+}
+
+.openbox-feed-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: 9999px;
+  padding: 0.0625rem 0.5rem;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.4;
+  border: 1px solid transparent;
+}
+.openbox-feed-badge--reviewing {
+  color: var(--openbox-feed-reviewing);
+  border-color: color-mix(
+    in srgb,
+    var(--openbox-feed-reviewing) 40%,
+    transparent
+  );
+  background: color-mix(
+    in srgb,
+    var(--openbox-feed-reviewing) 12%,
+    transparent
+  );
+}
+.openbox-feed-badge--allow {
+  color: var(--openbox-feed-allow);
+  border-color: color-mix(in srgb, var(--openbox-feed-allow) 40%, transparent);
+  background: color-mix(in srgb, var(--openbox-feed-allow) 12%, transparent);
+}
+.openbox-feed-badge--constrain {
+  color: var(--openbox-feed-constrain);
+  border-color: color-mix(
+    in srgb,
+    var(--openbox-feed-constrain) 40%,
+    transparent
+  );
+  background: color-mix(
+    in srgb,
+    var(--openbox-feed-constrain) 14%,
+    transparent
+  );
+}
+.openbox-feed-badge--approval {
+  color: var(--openbox-feed-approval);
+  border-color: color-mix(
+    in srgb,
+    var(--openbox-feed-approval) 40%,
+    transparent
+  );
+  background: color-mix(in srgb, var(--openbox-feed-approval) 12%, transparent);
+}
+.openbox-feed-badge--block {
+  color: var(--openbox-feed-block);
+  border-color: color-mix(in srgb, var(--openbox-feed-block) 45%, transparent);
+  background: color-mix(in srgb, var(--openbox-feed-block) 12%, transparent);
+}
+.openbox-feed-badge--halt {
+  color: #fff;
+  border-color: var(--openbox-feed-halt);
+  background: var(--openbox-feed-halt);
+}
+
+.openbox-feed-pillar {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 4px;
+  padding: 0.0625rem 0.375rem;
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--muted-foreground) 8%, transparent);
+}
+
+.openbox-feed-json-node,
+.openbox-feed-json-leaf {
+  font-family: var(--font-code);
+  font-size: 11px;
+  line-height: 1.5;
+}
+.openbox-feed-json-children {
+  padding-left: 0.75rem;
+  border-left: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+}
+.openbox-feed-json-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: var(--muted-foreground);
+}
+.openbox-feed-json-key {
+  color: var(--foreground);
+}
+.openbox-feed-json-value {
+  color: var(--openbox-feed-approval);
+}
+.openbox-feed-json-summary {
+  color: var(--muted-foreground);
+}

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/app/page.tsx
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/app/page.tsx
@@ -10,6 +10,8 @@ import {
   initializeOpenBoxHaltState,
   onOpenBoxSessionHalted,
 } from "@/lib/openbox-halt-state";
+import { GovernanceFeedPanel } from "@/components/governance-feed/governance-feed-panel";
+import { resetFeed } from "@/lib/governance-feed/feed-store";
 
 import {
   CopilotChat,
@@ -66,6 +68,7 @@ export default function HomePage() {
     const params = new URLSearchParams(window.location.search);
     if (params.has("reset")) {
       clearOpenBoxHaltState();
+      resetFeed();
       setIsOpenBoxHalted(false);
     }
 
@@ -110,6 +113,7 @@ function OpenBoxDemoContent({ isOpenBoxHalted }: { isOpenBoxHalted: boolean }) {
         </div>
       }
       chatOverlay={<>{isOpenBoxHalted ? <OpenBoxHaltedOverlay /> : null}</>}
+      sidePanel={<GovernanceFeedPanel />}
     />
   );
 }

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/components/example-layout/index.tsx
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/components/example-layout/index.tsx
@@ -6,15 +6,22 @@ import { withBasePath } from "@/lib/base-path";
 interface ExampleLayoutProps {
   chatContent: ReactNode;
   chatOverlay?: ReactNode;
+  sidePanel?: ReactNode;
 }
 
 export function ExampleLayout({
   chatContent,
   chatOverlay,
+  sidePanel,
 }: ExampleLayoutProps) {
+  const hasSidePanel = Boolean(sidePanel);
   return (
     <div className="h-full pb-6">
-      <div className="relative mx-auto flex h-full max-h-full max-w-5xl flex-col px-4 dark:bg-stone-950">
+      <div
+        className={`relative mx-auto flex h-full max-h-full flex-col px-4 dark:bg-stone-950 ${
+          hasSidePanel ? "max-w-7xl" : "max-w-5xl"
+        }`}
+      >
         <div className="shrink-0 pt-6 pl-6 pb-2 max-lg:pl-4 max-lg:pt-4 flex gap-1.5 items-center align-center">
           <span className="font-extrabold text-2xl pb-1.5">
             OpenBox x CopilotKit
@@ -25,8 +32,17 @@ export function ExampleLayout({
             className="h-7"
           />
         </div>
-        <div className="flex-1 min-h-0 overflow-y-auto">{chatContent}</div>
-        {chatOverlay}
+        <div className="flex min-h-0 flex-1 gap-4">
+          <div className="relative flex min-h-0 flex-1 flex-col">
+            <div className="flex-1 min-h-0 overflow-y-auto">{chatContent}</div>
+            {chatOverlay}
+          </div>
+          {hasSidePanel ? (
+            <div className="hidden min-h-0 w-[22rem] shrink-0 lg:flex xl:w-[26rem]">
+              {sidePanel}
+            </div>
+          ) : null}
+        </div>
       </div>
     </div>
   );

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/components/governance-feed/governance-feed-panel.tsx
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/components/governance-feed/governance-feed-panel.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Activity,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  GitBranch,
+  ListTree,
+  Lock,
+  Workflow,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useGovernanceFeed } from "@/lib/governance-feed/use-governance-feed";
+import { VERDICT_STYLE } from "@/lib/governance-feed/verdict-style";
+import { pillarLabel } from "@/lib/governance-feed/pillars";
+import type {
+  ActionNode,
+  RunNode,
+  StepNode,
+} from "@/lib/governance-feed/types";
+import { JsonTree } from "./json-tree";
+
+export function GovernanceFeedPanel() {
+  const { runs, halted, reset } = useGovernanceFeed();
+  const actionCount = runs.reduce((sum, run) => sum + run.actions.length, 0);
+
+  return (
+    <aside
+      data-testid="openbox-governance-feed"
+      className="openbox-feed flex h-full min-h-0 flex-col rounded-md border border-[var(--border)] bg-[var(--card)]"
+    >
+      <header className="shrink-0 border-b border-[var(--border)] px-4 py-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <ListTree size={16} aria-hidden="true" />
+            <h2 className="text-sm font-semibold">Governance Feed</h2>
+          </div>
+          <button
+            type="button"
+            onClick={reset}
+            className="rounded-md border border-[var(--border)] px-2 py-1 text-[11px] font-medium text-[var(--muted-foreground)] hover:bg-[var(--secondary)]"
+          >
+            Reset
+          </button>
+        </div>
+        <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+          Live OpenBox execution tree — runs, governed actions, timing, and the
+          Authorize pillars.
+        </p>
+        <div className="mt-2 flex flex-wrap items-center gap-3 text-[11px] text-[var(--muted-foreground)]">
+          <span className="inline-flex items-center gap-1">
+            <Workflow size={12} aria-hidden="true" /> {runs.length} runs
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <Activity size={12} aria-hidden="true" /> {actionCount} actions
+          </span>
+          {halted ? (
+            <span className="inline-flex items-center gap-1 text-[var(--openbox-feed-halt)]">
+              <Lock size={12} aria-hidden="true" /> session halted
+            </span>
+          ) : null}
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
+        {runs.length === 0 ? (
+          <p
+            data-testid="openbox-feed-empty"
+            className="px-3 py-6 text-center text-xs text-[var(--muted-foreground)]"
+          >
+            No governed actions yet. Run a workflow to populate the tree.
+          </p>
+        ) : (
+          runs.map((run) => <RunRow key={run.id} run={run} />)
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function RunRow({ run }: { run: RunNode }) {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="openbox-feed-run mb-2">
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-[var(--secondary)]"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+      >
+        {open ? (
+          <ChevronDown size={14} aria-hidden="true" />
+        ) : (
+          <ChevronRight size={14} aria-hidden="true" />
+        )}
+        <GitBranch size={14} aria-hidden="true" />
+        <span className="text-xs font-semibold">{run.label}</span>
+        <span className="ml-auto text-[10px] text-[var(--muted-foreground)]">
+          {run.actions.length} actions
+        </span>
+      </button>
+      {open ? (
+        <div className="openbox-feed-children ml-3 border-l border-[var(--border)] pl-3">
+          {run.actions.map((action) => (
+            <ActionRow key={action.id} action={action} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ActionRow({
+  action,
+  continuation = false,
+}: {
+  action: ActionNode;
+  continuation?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [showJson, setShowJson] = useState(false);
+  const style = VERDICT_STYLE[action.verdict];
+  const Icon = style.icon;
+  const isReviewing = action.verdict === "reviewing";
+
+  return (
+    <div
+      className={cn("openbox-feed-action py-1.5", continuation && "opacity-95")}
+    >
+      <div className="flex items-start gap-2">
+        <button
+          type="button"
+          className="mt-0.5"
+          onClick={() => setOpen((prev) => !prev)}
+          aria-expanded={open}
+          aria-label={open ? "Collapse action" : "Expand action"}
+        >
+          {open ? (
+            <ChevronDown size={13} aria-hidden="true" />
+          ) : (
+            <ChevronRight size={13} aria-hidden="true" />
+          )}
+        </button>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            {continuation ? (
+              <span className="text-[10px] uppercase text-[var(--muted-foreground)]">
+                resume
+              </span>
+            ) : null}
+            <span className="truncate text-xs font-semibold">
+              {action.title}
+            </span>
+            <span
+              className={cn(style.badgeClass, isReviewing && "animate-pulse")}
+              data-testid={`openbox-feed-verdict-${action.verdict}`}
+            >
+              <Icon size={11} aria-hidden="true" />
+              {style.label}
+            </span>
+            <span className="openbox-feed-pillar" data-pillar={action.pillar}>
+              {pillarLabel(action.pillar)}
+            </span>
+          </div>
+          <p className="mt-0.5 truncate text-[11px] text-[var(--muted-foreground)]">
+            {action.reason || action.request}
+          </p>
+
+          {open ? (
+            <div className="mt-2 space-y-2">
+              {action.redactionSummary ? (
+                <p className="text-[11px] text-[var(--openbox-feed-constrain)]">
+                  Sensitive data adjusted before this result was shown.
+                </p>
+              ) : null}
+              {action.steps.length > 0 ? (
+                <ul className="space-y-1">
+                  {action.steps.map((step) => (
+                    <StepRow key={step.id} step={step} />
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-[11px] text-[var(--muted-foreground)]">
+                  No timing sub-steps recorded.
+                </p>
+              )}
+              <button
+                type="button"
+                className="text-[11px] underline text-[var(--muted-foreground)]"
+                onClick={() => setShowJson((prev) => !prev)}
+              >
+                {showJson ? "Hide raw result" : "Show raw result"}
+              </button>
+              {showJson ? (
+                <div className="rounded-md border border-[var(--border)] bg-[var(--background)] p-2">
+                  <JsonTree value={action.raw} defaultOpen />
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+
+          {action.continuation ? (
+            <div className="mt-2 border-l border-dashed border-[var(--border)] pl-2">
+              <ActionRow action={action.continuation} continuation />
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StepRow({ step }: { step: StepNode }) {
+  return (
+    <li className="flex items-center gap-2 text-[11px] text-[var(--muted-foreground)]">
+      <Clock size={11} aria-hidden="true" />
+      <span className="truncate">{step.label}</span>
+      <span className="ml-auto tabular-nums">
+        {step.pending ? "…" : formatMs(step.ms)}
+      </span>
+    </li>
+  );
+}
+
+function formatMs(ms?: number): string {
+  if (ms === undefined) return "";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/components/governance-feed/json-tree.tsx
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/components/governance-feed/json-tree.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface JsonTreeProps {
+  value: unknown;
+  name?: string;
+  depth?: number;
+  defaultOpen?: boolean;
+}
+
+function isExpandable(value: unknown): value is object {
+  return value !== null && typeof value === "object";
+}
+
+export function JsonTree({
+  value,
+  name,
+  depth = 0,
+  defaultOpen = false,
+}: JsonTreeProps) {
+  const [open, setOpen] = useState(defaultOpen || depth < 1);
+
+  if (!isExpandable(value)) {
+    return (
+      <div className="openbox-feed-json-leaf">
+        {name ? <span className="openbox-feed-json-key">{name}:</span> : null}
+        <span className="openbox-feed-json-value">{formatScalar(value)}</span>
+      </div>
+    );
+  }
+
+  const entries = Array.isArray(value)
+    ? value.map((v, i) => [String(i), v] as const)
+    : Object.entries(value as Record<string, unknown>);
+
+  return (
+    <div className="openbox-feed-json-node">
+      <button
+        type="button"
+        className="openbox-feed-json-toggle"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+      >
+        {open ? (
+          <ChevronDown size={12} aria-hidden="true" />
+        ) : (
+          <ChevronRight size={12} aria-hidden="true" />
+        )}
+        {name ? <span className="openbox-feed-json-key">{name}</span> : null}
+        <span className="openbox-feed-json-summary">
+          {Array.isArray(value) ? `[${entries.length}]` : `{${entries.length}}`}
+        </span>
+      </button>
+      {open ? (
+        <div className={cn("openbox-feed-json-children")}>
+          {entries.map(([key, child]) => (
+            <JsonTree key={key} name={key} value={child} depth={depth + 1} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function formatScalar(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "string") return `"${value}"`;
+  return String(value);
+}

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/feed-store.test.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/feed-store.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   resetFeed,
   getFeedSnapshot,
+  subscribeToFeed,
   ingestResultsFromMessages,
   ingestTimingFromState,
   ingestHalt,
 } from "./feed-store";
 
 const RESULT_SCHEMA = "openbox.copilotkit.result.v1";
+const TIMING_SCHEMA = "openbox.copilotkit.timing.v1";
 
 function toolMessage(id: string, body: Record<string, unknown>) {
   return {
@@ -17,12 +19,38 @@ function toolMessage(id: string, body: Record<string, unknown>) {
   };
 }
 
+function timingState(
+  action: string,
+  key: string,
+  phase: "started" | "finished",
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    openboxTimingEvent: {
+      schemaVersion: TIMING_SCHEMA,
+      action,
+      request: "req",
+      event: {
+        phase,
+        key,
+        label: `${key} label`,
+        kind: "tool",
+        ...extra,
+      },
+      emittedAt: new Date().toISOString(),
+    },
+  };
+}
+
+// resetFeed now PRESERVES seen-ids (durable clear), so any tool_call_id used in
+// one test is permanently "seen" for the rest of the module's lifetime. To keep
+// tests isolated, every test uses ids unique to that test.
 describe("feed-store (append-only)", () => {
   beforeEach(() => resetFeed());
 
   it("ingests governed result tool messages and dedupes by id", () => {
     const messages = [
-      toolMessage("tc1", {
+      toolMessage("dedupe-tc1", {
         action: "create_support_ticket",
         status: "executed",
         runId: "run-1",
@@ -38,38 +66,28 @@ describe("feed-store (append-only)", () => {
 
   it("ignores non-OpenBox tool messages", () => {
     ingestResultsFromMessages(
-      [{ role: "tool", tool_call_id: "x", content: '{"foo":1}' }],
+      [{ role: "tool", tool_call_id: "nonbox-x", content: '{"foo":1}' }],
       { messages: [] },
     );
     expect(getFeedSnapshot().results).toHaveLength(0);
   });
 
   it("does NOT wipe on a new ingest (append-only)", () => {
-    ingestResultsFromMessages([toolMessage("a", { status: "executed" })], {
-      messages: [],
-    });
-    ingestResultsFromMessages([toolMessage("b", { status: "blocked" })], {
-      messages: [],
-    });
+    ingestResultsFromMessages(
+      [toolMessage("append-a", { status: "executed" })],
+      { messages: [] },
+    );
+    ingestResultsFromMessages(
+      [toolMessage("append-b", { status: "blocked" })],
+      { messages: [] },
+    );
     expect(getFeedSnapshot().results).toHaveLength(2);
   });
 
   it("ingests timing.v1 from agent state and dedupes by action+key+phase", () => {
-    const state = {
-      openboxTimingEvent: {
-        schemaVersion: "openbox.copilotkit.timing.v1",
-        action: "review_data_handoff",
-        request: "req",
-        event: {
-          phase: "finished",
-          key: "policy",
-          label: "Policy check",
-          kind: "tool",
-          ms: 12,
-        },
-        emittedAt: new Date().toISOString(),
-      },
-    };
+    const state = timingState("review_data_handoff", "policy", "finished", {
+      ms: 12,
+    });
     ingestTimingFromState(state);
     ingestTimingFromState(state); // duplicate phase
     const snap = getFeedSnapshot();
@@ -83,9 +101,10 @@ describe("feed-store (append-only)", () => {
   });
 
   it("resetFeed clears everything", () => {
-    ingestResultsFromMessages([toolMessage("a", { status: "executed" })], {
-      messages: [],
-    });
+    ingestResultsFromMessages(
+      [toolMessage("clearall-a", { status: "executed" })],
+      { messages: [] },
+    );
     ingestHalt();
     resetFeed();
     const snap = getFeedSnapshot();
@@ -95,9 +114,207 @@ describe("feed-store (append-only)", () => {
 
   it("bumps revision on mutation", () => {
     const before = getFeedSnapshot().revision;
-    ingestResultsFromMessages([toolMessage("a", { status: "executed" })], {
+    ingestResultsFromMessages(
+      [toolMessage("bumprev-a", { status: "executed" })],
+      { messages: [] },
+    );
+    expect(getFeedSnapshot().revision).toBeGreaterThan(before);
+  });
+
+  // --- resetFeed: monotonic + durable ---------------------------------------
+
+  it("resetFeed is monotonic: revision strictly increases past the ingest", () => {
+    ingestResultsFromMessages(
+      [toolMessage("monotonic-a", { status: "executed" })],
+      { messages: [] },
+    );
+    const afterIngest = getFeedSnapshot().revision; // N
+    expect(getFeedSnapshot().results).toHaveLength(1);
+
+    resetFeed();
+    const snap = getFeedSnapshot();
+    expect(snap.results).toHaveLength(0);
+    expect(snap.revision).toBeGreaterThan(afterIngest); // strictly > N (not 0)
+  });
+
+  it("resetFeed is durable: a re-ingest of an already-seen message is not re-added", () => {
+    const msg = [toolMessage("durable-tc1", { status: "executed" })];
+    ingestResultsFromMessages(msg, { messages: [] });
+    expect(getFeedSnapshot().results).toHaveLength(1);
+
+    resetFeed();
+    ingestResultsFromMessages(msg, { messages: [] }); // same id — preserved as seen
+    expect(getFeedSnapshot().results).toHaveLength(0);
+  });
+
+  it("reset then a genuinely new action ingests only the new one", () => {
+    ingestResultsFromMessages(
+      [toolMessage("resetnew-tc1", { status: "executed" })],
+      { messages: [] },
+    );
+    resetFeed();
+    ingestResultsFromMessages(
+      [toolMessage("resetnew-tc1", { status: "executed" })], // already seen
+      { messages: [] },
+    );
+    ingestResultsFromMessages(
+      [toolMessage("resetnew-tc2", { status: "blocked" })], // new
+      { messages: [] },
+    );
+    expect(getFeedSnapshot().results).toHaveLength(1);
+  });
+
+  // --- resume detection -----------------------------------------------------
+
+  it("flags a terminal result carrying an approvalId as a resume", () => {
+    ingestResultsFromMessages(
+      [
+        toolMessage("resume-exec", {
+          status: "executed",
+          approvalId: "ap1",
+        }),
+      ],
+      { messages: [] },
+    );
+    expect(getFeedSnapshot().results[0].isResume).toBe(true);
+  });
+
+  it("does not flag an approval_pending result with an approvalId as a resume", () => {
+    ingestResultsFromMessages(
+      [
+        toolMessage("resume-pending", {
+          status: "approval_pending",
+          approvalId: "ap1",
+        }),
+      ],
+      { messages: [] },
+    );
+    expect(getFeedSnapshot().results[0].isResume).toBe(false);
+  });
+
+  it("keeps raw clean (no synthetic __isResume key) on a resume result", () => {
+    ingestResultsFromMessages(
+      [
+        toolMessage("rawclean-exec", {
+          status: "executed",
+          approvalId: "ap1",
+        }),
+      ],
+      { messages: [] },
+    );
+    const result = getFeedSnapshot().results[0];
+    expect(result.isResume).toBe(true);
+    expect("__isResume" in result.raw).toBe(false);
+  });
+
+  // --- field extraction -----------------------------------------------------
+
+  it("passes through governance fields and flags a guardrails signal", () => {
+    ingestResultsFromMessages(
+      [
+        toolMessage("fields-gold", {
+          status: "executed",
+          riskScore: 0.7,
+          trustTier: "gold",
+          redactionSummary: "x",
+          guardrailsResult: { redactedFields: ["ssn"] },
+        }),
+      ],
+      { messages: [] },
+    );
+    const result = getFeedSnapshot().results[0];
+    expect(result.riskScore).toBe(0.7);
+    expect(result.trustTier).toBe("gold");
+    expect(result.redactionSummary).toBe("x");
+    expect(result.hasGuardrailsSignal).toBe(true);
+  });
+
+  it("accepts a numeric trustTier", () => {
+    ingestResultsFromMessages(
+      [
+        toolMessage("fields-numeric", {
+          status: "executed",
+          trustTier: 3,
+        }),
+      ],
+      { messages: [] },
+    );
+    expect(getFeedSnapshot().results[0].trustTier).toBe(3);
+  });
+
+  it("does not flag a guardrails signal for an empty guardrailsResult", () => {
+    ingestResultsFromMessages(
+      [
+        toolMessage("fields-empty", {
+          status: "executed",
+          guardrailsResult: {},
+        }),
+      ],
+      { messages: [] },
+    );
+    expect(getFeedSnapshot().results[0].hasGuardrailsSignal).toBe(false);
+  });
+
+  // --- timing dedupe distinguishes phase ------------------------------------
+
+  it("keeps both phases of the same action+key (dedupe is by action:key:phase)", () => {
+    ingestTimingFromState(timingState("phase-a", "k", "started"));
+    ingestTimingFromState(timingState("phase-a", "k", "finished", { ms: 5 }));
+    const snap = getFeedSnapshot();
+    expect(snap.timings).toHaveLength(2);
+    expect(snap.timings.map((t) => t.phase).sort()).toEqual([
+      "finished",
+      "started",
+    ]);
+  });
+
+  // --- ingestHalt idempotency -----------------------------------------------
+
+  it("ingestHalt is idempotent: a second call does not bump revision", () => {
+    ingestHalt();
+    const snap = getFeedSnapshot();
+    expect(snap.halted).toBe(true);
+    expect(typeof snap.haltedAtMs).toBe("number");
+    const revisionAfterFirst = snap.revision;
+
+    ingestHalt(); // early-return, no commit
+    expect(getFeedSnapshot().revision).toBe(revisionAfterFirst);
+  });
+
+  // --- subscribe / notify / unsubscribe -------------------------------------
+
+  it("notifies subscribers on a committing ingest and stops after unsubscribe", () => {
+    let calls = 0;
+    const unsubscribe = subscribeToFeed(() => {
+      calls += 1;
+    });
+
+    ingestResultsFromMessages([toolMessage("sub-a", { status: "executed" })], {
       messages: [],
     });
-    expect(getFeedSnapshot().revision).toBeGreaterThan(before);
+    expect(calls).toBe(1);
+
+    unsubscribe();
+    ingestResultsFromMessages([toolMessage("sub-b", { status: "executed" })], {
+      messages: [],
+    });
+    expect(calls).toBe(1); // not invoked again
+  });
+
+  // --- no-op ingest does not bump revision ----------------------------------
+
+  it("a no-op ingest (empty array or already-seen message) leaves revision unchanged", () => {
+    const baseline = getFeedSnapshot().revision;
+
+    ingestResultsFromMessages([], { messages: [] });
+    expect(getFeedSnapshot().revision).toBe(baseline);
+
+    const msg = [toolMessage("noop-tc1", { status: "executed" })];
+    ingestResultsFromMessages(msg, { messages: [] });
+    const afterFirst = getFeedSnapshot().revision;
+    expect(afterFirst).toBeGreaterThan(baseline);
+
+    ingestResultsFromMessages(msg, { messages: [] }); // already seen
+    expect(getFeedSnapshot().revision).toBe(afterFirst);
   });
 });

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/feed-store.test.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/feed-store.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  resetFeed,
+  getFeedSnapshot,
+  ingestResultsFromMessages,
+  ingestTimingFromState,
+  ingestHalt,
+} from "./feed-store";
+
+const RESULT_SCHEMA = "openbox.copilotkit.result.v1";
+
+function toolMessage(id: string, body: Record<string, unknown>) {
+  return {
+    role: "tool",
+    tool_call_id: id,
+    content: JSON.stringify({ schemaVersion: RESULT_SCHEMA, ...body }),
+  };
+}
+
+describe("feed-store (append-only)", () => {
+  beforeEach(() => resetFeed());
+
+  it("ingests governed result tool messages and dedupes by id", () => {
+    const messages = [
+      toolMessage("tc1", {
+        action: "create_support_ticket",
+        status: "executed",
+        runId: "run-1",
+      }),
+    ];
+    ingestResultsFromMessages(messages, { messages });
+    ingestResultsFromMessages(messages, { messages }); // duplicate
+    const snap = getFeedSnapshot();
+    expect(snap.results).toHaveLength(1);
+    expect(snap.results[0].verdict).toBe("allow");
+    expect(snap.results[0].runId).toBe("run-1");
+  });
+
+  it("ignores non-OpenBox tool messages", () => {
+    ingestResultsFromMessages(
+      [{ role: "tool", tool_call_id: "x", content: '{"foo":1}' }],
+      { messages: [] },
+    );
+    expect(getFeedSnapshot().results).toHaveLength(0);
+  });
+
+  it("does NOT wipe on a new ingest (append-only)", () => {
+    ingestResultsFromMessages([toolMessage("a", { status: "executed" })], {
+      messages: [],
+    });
+    ingestResultsFromMessages([toolMessage("b", { status: "blocked" })], {
+      messages: [],
+    });
+    expect(getFeedSnapshot().results).toHaveLength(2);
+  });
+
+  it("ingests timing.v1 from agent state and dedupes by action+key+phase", () => {
+    const state = {
+      openboxTimingEvent: {
+        schemaVersion: "openbox.copilotkit.timing.v1",
+        action: "review_data_handoff",
+        request: "req",
+        event: {
+          phase: "finished",
+          key: "policy",
+          label: "Policy check",
+          kind: "tool",
+          ms: 12,
+        },
+        emittedAt: new Date().toISOString(),
+      },
+    };
+    ingestTimingFromState(state);
+    ingestTimingFromState(state); // duplicate phase
+    const snap = getFeedSnapshot();
+    expect(snap.timings).toHaveLength(1);
+    expect(snap.timings[0].key).toBe("policy");
+  });
+
+  it("records a halt", () => {
+    ingestHalt();
+    expect(getFeedSnapshot().halted).toBe(true);
+  });
+
+  it("resetFeed clears everything", () => {
+    ingestResultsFromMessages([toolMessage("a", { status: "executed" })], {
+      messages: [],
+    });
+    ingestHalt();
+    resetFeed();
+    const snap = getFeedSnapshot();
+    expect(snap.results).toHaveLength(0);
+    expect(snap.halted).toBe(false);
+  });
+
+  it("bumps revision on mutation", () => {
+    const before = getFeedSnapshot().revision;
+    ingestResultsFromMessages([toolMessage("a", { status: "executed" })], {
+      messages: [],
+    });
+    expect(getFeedSnapshot().revision).toBeGreaterThan(before);
+  });
+});

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/feed-store.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/feed-store.ts
@@ -43,11 +43,19 @@ function commit(next: FeedStoreSnapshot) {
 }
 
 export function resetFeed(): void {
-  snapshot = EMPTY;
-  arrivalCounter = 0;
-  seenResultIds.clear();
-  seenTimingKeys.clear();
-  subscribers.forEach((listener) => listener());
+  // Durable clear: bump revision via commit() (monotonic — useGovernanceFeed's
+  // useMemo is keyed on snapshot.revision, so a non-monotonic reset-to-0 would
+  // serve a stale tree when the number repeats). KEEP seenResultIds/seenTimingKeys
+  // and arrivalCounter so already-ingested messages are NOT re-added when the agent
+  // subscription next fires — the clear sticks until genuinely new actions arrive.
+  // revision is carried for the type; commit() overwrites it with snapshot.revision + 1.
+  commit({
+    ...snapshot,
+    results: [],
+    timings: [],
+    halted: false,
+    haltedAtMs: undefined,
+  });
 }
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -69,6 +77,7 @@ function numberValue(value: unknown): number | undefined {
 function toResultRecord(
   id: string,
   record: Record<string, unknown>,
+  isResume: boolean,
 ): FeedResultRecord {
   const guardrails = asRecord(record.guardrailsResult);
   // Use ingest (arrival) time, not expiresAt: for approval_required results
@@ -100,7 +109,7 @@ function toResultRecord(
     activityId: textValue(record.activityId) || undefined,
     approvalId: textValue(record.approvalId) || undefined,
     governanceEventId: textValue(record.governanceEventId) || undefined,
-    isResume: record.__isResume === true,
+    isResume,
     arrivalIndex: arrivalCounter++,
     emittedAtMs,
     raw: record,
@@ -134,18 +143,17 @@ export function ingestResultsFromMessages(
       `${textValue(parsed.action)}:${textValue(parsed.approvalId)}:${textValue(parsed.status)}`;
     if (!id || seenResultIds.has(id)) continue;
 
-    // Resume detection: a result that has an approvalId AND an executed/
-    // constrained/blocked terminal status following an approval is a resume.
-    // The reliable signal is the resume tool name, resolved upstream; here we
-    // treat any result carrying approvalId with a terminal (non-approval)
-    // status as a resume continuation.
+    // Resume detection (heuristic only): a result carrying an approvalId with a
+    // terminal status — anything other than approval_required / approval_pending
+    // — is treated as a resume continuation of an earlier approval. This is the
+    // sole signal used; there is no upstream resume-tool-name resolution.
     const isResume =
       Boolean(textValue(parsed.approvalId)) &&
       parsed.status !== "approval_required" &&
       parsed.status !== "approval_pending";
 
     seenResultIds.add(id);
-    additions.push(toResultRecord(id, { ...parsed, __isResume: isResume }));
+    additions.push(toResultRecord(id, parsed, isResume));
   }
 
   if (additions.length === 0) return;

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/feed-store.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/feed-store.ts
@@ -1,0 +1,185 @@
+import type {
+  FeedResultRecord,
+  FeedStoreSnapshot,
+  FeedTimingRecord,
+} from "./types";
+import {
+  findOpenBoxResultContent,
+  isOpenBoxResultRecord,
+  parseFeedToolResult,
+  verdictFromResultRecord,
+} from "./result-parsing";
+
+const TIMING_STATE_KEY = "openboxTimingEvent";
+const TIMING_SCHEMA = "openbox.copilotkit.timing.v1";
+
+const EMPTY: FeedStoreSnapshot = {
+  results: [],
+  timings: [],
+  halted: false,
+  revision: 0,
+};
+
+let snapshot: FeedStoreSnapshot = EMPTY;
+let arrivalCounter = 0;
+const seenResultIds = new Set<string>();
+const seenTimingKeys = new Set<string>();
+const subscribers = new Set<() => void>();
+
+export function getFeedSnapshot(): FeedStoreSnapshot {
+  return snapshot;
+}
+
+export function subscribeToFeed(listener: () => void): () => void {
+  subscribers.add(listener);
+  return () => {
+    subscribers.delete(listener);
+  };
+}
+
+function commit(next: FeedStoreSnapshot) {
+  snapshot = { ...next, revision: snapshot.revision + 1 };
+  subscribers.forEach((listener) => listener());
+}
+
+export function resetFeed(): void {
+  snapshot = EMPTY;
+  arrivalCounter = 0;
+  seenResultIds.clear();
+  seenTimingKeys.clear();
+  subscribers.forEach((listener) => listener());
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function textValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function toResultRecord(
+  id: string,
+  record: Record<string, unknown>,
+): FeedResultRecord {
+  const guardrails = asRecord(record.guardrailsResult);
+  const emittedAtMs = Date.parse(textValue(record.expiresAt)) || Date.now();
+  return {
+    kind: "result",
+    id,
+    action: textValue(record.action),
+    request: textValue(record.request),
+    verdict: verdictFromResultRecord(record),
+    status: textValue(record.status),
+    reason: textValue(record.reason),
+    message: textValue(record.message),
+    redactionSummary:
+      typeof record.redactionSummary === "string"
+        ? record.redactionSummary
+        : undefined,
+    hasGuardrailsSignal: Object.keys(guardrails).length > 0,
+    riskScore: numberValue(record.riskScore),
+    trustTier:
+      typeof record.trustTier === "string" ||
+      typeof record.trustTier === "number"
+        ? (record.trustTier as string | number)
+        : undefined,
+    runId: textValue(record.runId) || undefined,
+    workflowId: textValue(record.workflowId) || undefined,
+    activityId: textValue(record.activityId) || undefined,
+    approvalId: textValue(record.approvalId) || undefined,
+    governanceEventId: textValue(record.governanceEventId) || undefined,
+    isResume: record.__isResume === true,
+    arrivalIndex: arrivalCounter++,
+    emittedAtMs,
+    raw: record,
+  };
+}
+
+/**
+ * Ingest governed result tool-messages from a messages array + state snapshot.
+ * Append-only and idempotent: each result is keyed by its tool_call_id (or a
+ * derived stable id) and ingested once.
+ */
+export function ingestResultsFromMessages(
+  messages: unknown[],
+  stateSnapshot: unknown,
+): void {
+  if (!Array.isArray(messages) || messages.length === 0) return;
+  const additions: FeedResultRecord[] = [];
+
+  for (const message of messages) {
+    const msgRecord = asRecord(message);
+    const content = findOpenBoxResultContent(msgRecord, stateSnapshot);
+    if (!content) continue;
+    const parsed = parseFeedToolResult(content);
+    if (!isOpenBoxResultRecord(parsed)) continue;
+
+    // Stable id: prefer tool_call_id, else governanceEventId, else
+    // action+approvalId+status composite.
+    const id =
+      textValue(msgRecord.tool_call_id ?? msgRecord.toolCallId) ||
+      textValue(parsed.governanceEventId) ||
+      `${textValue(parsed.action)}:${textValue(parsed.approvalId)}:${textValue(parsed.status)}`;
+    if (!id || seenResultIds.has(id)) continue;
+
+    // Resume detection: a result that has an approvalId AND an executed/
+    // constrained/blocked terminal status following an approval is a resume.
+    // The reliable signal is the resume tool name, resolved upstream; here we
+    // treat any result carrying approvalId with a terminal (non-approval)
+    // status as a resume continuation.
+    const isResume =
+      Boolean(textValue(parsed.approvalId)) &&
+      parsed.status !== "approval_required" &&
+      parsed.status !== "approval_pending";
+
+    seenResultIds.add(id);
+    additions.push(toResultRecord(id, { ...parsed, __isResume: isResume }));
+  }
+
+  if (additions.length === 0) return;
+  commit({ ...snapshot, results: [...snapshot.results, ...additions] });
+}
+
+/** Ingest a timing.v1 event from agent state (append-only, dedupe by key). */
+export function ingestTimingFromState(state: unknown): void {
+  const stateRecord = asRecord(state);
+  const payload = asRecord(stateRecord[TIMING_STATE_KEY]);
+  if (payload.schemaVersion !== TIMING_SCHEMA) return;
+  const event = asRecord(payload.event);
+  const action = textValue(payload.action);
+  const key = textValue(event.key);
+  const phase = textValue(event.phase);
+  if (!action || !key || (phase !== "started" && phase !== "finished")) return;
+
+  const dedupeKey = `${action}:${key}:${phase}`;
+  if (seenTimingKeys.has(dedupeKey)) return;
+  seenTimingKeys.add(dedupeKey);
+
+  const record: FeedTimingRecord = {
+    kind: "timing",
+    action,
+    request: textValue(payload.request),
+    key,
+    label: textValue(event.label) || key,
+    timingKind: textValue(event.kind) || "tool",
+    phase,
+    startedAtMs: Date.parse(textValue(event.startedAt)) || Date.now(),
+    ms: numberValue(event.ms),
+    arrivalIndex: arrivalCounter++,
+  };
+  commit({ ...snapshot, timings: [...snapshot.timings, record] });
+}
+
+export function ingestHalt(): void {
+  if (snapshot.halted) return;
+  commit({ ...snapshot, halted: true, haltedAtMs: Date.now() });
+}

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/feed-store.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/feed-store.ts
@@ -71,7 +71,10 @@ function toResultRecord(
   record: Record<string, unknown>,
 ): FeedResultRecord {
   const guardrails = asRecord(record.guardrailsResult);
-  const emittedAtMs = Date.parse(textValue(record.expiresAt)) || Date.now();
+  // Use ingest (arrival) time, not expiresAt: for approval_required results
+  // expiresAt is a future approval-expiry, which would future-date the record.
+  // emittedAtMs is only a tie-breaker after arrivalIndex; arrival time is correct.
+  const emittedAtMs = Date.now();
   return {
     kind: "result",
     id,

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/pillars.test.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/pillars.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { derivePillar, pillarLabel } from "./pillars";
+
+describe("derivePillar", () => {
+  it("attributes guardrails when a redaction summary is present", () => {
+    expect(
+      derivePillar(
+        {
+          verdict: "constrain",
+          redactionSummary: "redacted output.artifact.body",
+          hasGuardrailsSignal: false,
+        },
+        undefined,
+      ),
+    ).toBe("guardrails");
+  });
+  it("attributes guardrails when a guardrails signal is present", () => {
+    expect(
+      derivePillar(
+        { verdict: "constrain", hasGuardrailsSignal: true },
+        undefined,
+      ),
+    ).toBe("guardrails");
+  });
+  it("attributes policies for block/halt without guardrails signals", () => {
+    expect(
+      derivePillar({ verdict: "block", hasGuardrailsSignal: false }, undefined),
+    ).toBe("policies");
+    expect(
+      derivePillar({ verdict: "halt", hasGuardrailsSignal: false }, undefined),
+    ).toBe("policies");
+  });
+  it("attributes behavioral_rules for approval gates", () => {
+    expect(
+      derivePillar(
+        { verdict: "approval", hasGuardrailsSignal: false },
+        undefined,
+      ),
+    ).toBe("behavioral_rules");
+  });
+  it("falls back to scenario capability copy when ambiguous", () => {
+    // allow with no signals -> use scenario capability text
+    expect(
+      derivePillar(
+        { verdict: "allow", hasGuardrailsSignal: false },
+        { capability: "Output guardrails, redaction, audit trail" },
+      ),
+    ).toBe("guardrails");
+    expect(
+      derivePillar(
+        { verdict: "allow", hasGuardrailsSignal: false },
+        { capability: "Internal workflow policy" },
+      ),
+    ).toBe("policies");
+    expect(
+      derivePillar(
+        { verdict: "allow", hasGuardrailsSignal: false },
+        { capability: "Human-in-the-loop approval" },
+      ),
+    ).toBe("behavioral_rules");
+  });
+  it("returns unknown when nothing matches", () => {
+    expect(
+      derivePillar({ verdict: "allow", hasGuardrailsSignal: false }, undefined),
+    ).toBe("unknown");
+  });
+});
+
+describe("pillarLabel", () => {
+  it("renders human labels", () => {
+    expect(pillarLabel("guardrails")).toBe("Guardrails");
+    expect(pillarLabel("policies")).toBe("Policies");
+    expect(pillarLabel("behavioral_rules")).toBe("Behavioral rules");
+    expect(pillarLabel("unknown")).toBe("Governance");
+  });
+});

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/pillars.test.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/pillars.test.ts
@@ -64,6 +64,57 @@ describe("derivePillar", () => {
       derivePillar({ verdict: "allow", hasGuardrailsSignal: false }, undefined),
     ).toBe("unknown");
   });
+
+  it("guardrails signal short-circuits BEFORE block→policies check", () => {
+    // hasGuardrailsSignal: true must win even when verdict is "block"
+    expect(
+      derivePillar({ verdict: "block", hasGuardrailsSignal: true }, undefined),
+    ).toBe("guardrails");
+    // same for verdict: "approval" — guardrails signal still wins
+    expect(
+      derivePillar(
+        { verdict: "approval", hasGuardrailsSignal: true },
+        undefined,
+      ),
+    ).toBe("guardrails");
+  });
+
+  it("empty redactionSummary does NOT trigger guardrails", () => {
+    // An empty string must NOT satisfy the redactionSummary.length > 0 guard,
+    // so the call falls through to the capability/unknown path.
+    expect(
+      derivePillar(
+        { verdict: "allow", redactionSummary: "", hasGuardrailsSignal: false },
+        undefined,
+      ),
+    ).toBe("unknown");
+  });
+
+  it("capability containing 'drift' resolves to policies", () => {
+    expect(
+      derivePillar(
+        { verdict: "allow", hasGuardrailsSignal: false },
+        { capability: "Drift detection and policy enforcement" },
+      ),
+    ).toBe("policies");
+  });
+
+  it("non-allow verdict falls through to capability branch when no guardrails signal", () => {
+    // "constrain" is not approval/block/halt, so the capability branch is reached
+    expect(
+      derivePillar(
+        { verdict: "constrain", hasGuardrailsSignal: false },
+        { capability: "Internal workflow policy" },
+      ),
+    ).toBe("policies");
+    // "reviewing" similarly falls through to capability branch
+    expect(
+      derivePillar(
+        { verdict: "reviewing", hasGuardrailsSignal: false },
+        { capability: "Human-in-the-loop approval" },
+      ),
+    ).toBe("behavioral_rules");
+  });
 });
 
 describe("pillarLabel", () => {

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/pillars.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/pillars.ts
@@ -56,16 +56,3 @@ export function pillarLabel(pillar: GovernancePillar): string {
       return "Governance";
   }
 }
-
-export function pillarCopy(pillar: GovernancePillar): string {
-  switch (pillar) {
-    case "guardrails":
-      return "Input/output guardrails and redaction.";
-    case "policies":
-      return "Rego policy and destination/goal-drift checks.";
-    case "behavioral_rules":
-      return "Behavioral rules and human-in-the-loop approval.";
-    default:
-      return "OpenBox runtime governance.";
-  }
-}

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/pillars.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/pillars.ts
@@ -1,0 +1,71 @@
+import type { GovernancePillar, GovernanceVerdict } from "./types";
+
+/** Minimal scenario shape consumed for fallback copy. */
+export interface PillarScenario {
+  capability?: string;
+}
+
+export interface PillarSignals {
+  verdict: GovernanceVerdict;
+  redactionSummary?: string;
+  hasGuardrailsSignal: boolean;
+}
+
+/**
+ * Derive the triggering Authorize pillar.
+ * Precedence:
+ *   1. Guardrails/redaction signals -> guardrails.
+ *   2. Approval gate -> behavioral_rules.
+ *   3. block/halt without guardrails signals -> policies.
+ *   4. Fall back to scenario capability copy.
+ *   5. unknown.
+ */
+export function derivePillar(
+  signals: PillarSignals,
+  scenario: PillarScenario | undefined,
+): GovernancePillar {
+  const hasRedaction =
+    typeof signals.redactionSummary === "string" &&
+    signals.redactionSummary.length > 0;
+  if (hasRedaction || signals.hasGuardrailsSignal) return "guardrails";
+  if (signals.verdict === "approval") return "behavioral_rules";
+  if (signals.verdict === "block" || signals.verdict === "halt")
+    return "policies";
+
+  const capability = (scenario?.capability ?? "").toLowerCase();
+  if (capability) {
+    if (capability.includes("approval") || capability.includes("behavior"))
+      return "behavioral_rules";
+    if (capability.includes("guardrail") || capability.includes("redaction"))
+      return "guardrails";
+    if (capability.includes("policy") || capability.includes("drift"))
+      return "policies";
+  }
+  return "unknown";
+}
+
+export function pillarLabel(pillar: GovernancePillar): string {
+  switch (pillar) {
+    case "guardrails":
+      return "Guardrails";
+    case "policies":
+      return "Policies";
+    case "behavioral_rules":
+      return "Behavioral rules";
+    default:
+      return "Governance";
+  }
+}
+
+export function pillarCopy(pillar: GovernancePillar): string {
+  switch (pillar) {
+    case "guardrails":
+      return "Input/output guardrails and redaction.";
+    case "policies":
+      return "Rego policy and destination/goal-drift checks.";
+    case "behavioral_rules":
+      return "Behavioral rules and human-in-the-loop approval.";
+    default:
+      return "OpenBox runtime governance.";
+  }
+}

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/result-parsing.test.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/result-parsing.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseFeedToolResult,
+  isOpenBoxResultRecord,
+  verdictFromResultRecord,
+  findOpenBoxResultContent,
+} from "./result-parsing";
+
+const RESULT_SCHEMA = "openbox.copilotkit.result.v1";
+
+describe("parseFeedToolResult", () => {
+  it("parses a JSON string into a record", () => {
+    expect(parseFeedToolResult('{"a":1}')).toEqual({ a: 1 });
+  });
+  it("returns {} for invalid json / nullish", () => {
+    expect(parseFeedToolResult("not json")).toEqual({});
+    expect(parseFeedToolResult(undefined)).toEqual({});
+    expect(parseFeedToolResult(null)).toEqual({});
+  });
+  it("passes objects through", () => {
+    const obj = { schemaVersion: RESULT_SCHEMA };
+    expect(parseFeedToolResult(obj)).toBe(obj);
+  });
+});
+
+describe("isOpenBoxResultRecord", () => {
+  it("accepts only the result schema version", () => {
+    expect(isOpenBoxResultRecord({ schemaVersion: RESULT_SCHEMA })).toBe(true);
+    expect(isOpenBoxResultRecord({ schemaVersion: "other" })).toBe(false);
+    expect(isOpenBoxResultRecord({})).toBe(false);
+  });
+});
+
+describe("verdictFromResultRecord", () => {
+  it("maps approval_required -> approval", () => {
+    expect(verdictFromResultRecord({ status: "approval_required" })).toBe(
+      "approval",
+    );
+  });
+  it("maps halt + halted", () => {
+    expect(verdictFromResultRecord({ verdict: "halt" })).toBe("halt");
+    expect(verdictFromResultRecord({ status: "halted" })).toBe("halt");
+  });
+  it("treats allow + redactionSummary as constrain", () => {
+    expect(
+      verdictFromResultRecord({
+        status: "executed",
+        verdict: "allow",
+        redactionSummary: "redacted output.artifact.body",
+      }),
+    ).toBe("constrain");
+  });
+  it("maps plain executed/allow -> allow", () => {
+    expect(verdictFromResultRecord({ status: "executed" })).toBe("allow");
+    expect(verdictFromResultRecord({ verdict: "allow" })).toBe("allow");
+  });
+  it("maps blocked/approval_pending/block -> block", () => {
+    expect(verdictFromResultRecord({ status: "blocked" })).toBe("block");
+    expect(verdictFromResultRecord({ verdict: "block" })).toBe("block");
+    expect(verdictFromResultRecord({ status: "approval_pending" })).toBe(
+      "block",
+    );
+  });
+  it("maps error + rejected", () => {
+    expect(verdictFromResultRecord({ status: "error" })).toBe("error");
+    expect(verdictFromResultRecord({ verdict: "error" })).toBe("error");
+    expect(verdictFromResultRecord({ status: "rejected" })).toBe("rejected");
+  });
+  it("falls back to reviewing", () => {
+    expect(verdictFromResultRecord({})).toBe("reviewing");
+  });
+});
+
+describe("findOpenBoxResultContent", () => {
+  it("returns content directly for a tool message", () => {
+    expect(findOpenBoxResultContent({ role: "tool", content: "{}" }, {})).toBe(
+      "{}",
+    );
+  });
+  it("resolves an assistant governed tool call via the state snapshot", () => {
+    const assistant = {
+      role: "assistant",
+      toolCalls: [{ id: "tc1", function: { name: "openbox_governed_action" } }],
+    };
+    const snapshot = {
+      messages: [{ role: "tool", tool_call_id: "tc1", content: '{"ok":true}' }],
+    };
+    expect(findOpenBoxResultContent(assistant, snapshot)).toBe('{"ok":true}');
+  });
+  it("returns null for non-governed assistant calls", () => {
+    const assistant = {
+      role: "assistant",
+      toolCalls: [{ id: "tc1", function: { name: "some_other_tool" } }],
+    };
+    expect(findOpenBoxResultContent(assistant, { messages: [] })).toBeNull();
+  });
+});

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/result-parsing.test.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/result-parsing.test.ts
@@ -4,6 +4,8 @@ import {
   isOpenBoxResultRecord,
   verdictFromResultRecord,
   findOpenBoxResultContent,
+  extractToolCalls,
+  toolCallName,
 } from "./result-parsing";
 
 const RESULT_SCHEMA = "openbox.copilotkit.result.v1";
@@ -20,6 +22,13 @@ describe("parseFeedToolResult", () => {
   it("passes objects through", () => {
     const obj = { schemaVersion: RESULT_SCHEMA };
     expect(parseFeedToolResult(obj)).toBe(obj);
+  });
+  it("returns {} for JSON primitives (number, null)", () => {
+    expect(parseFeedToolResult("123")).toEqual({});
+    expect(parseFeedToolResult("null")).toEqual({});
+  });
+  it("returns the parsed array for a JSON array string (typeof [] === object)", () => {
+    expect(parseFeedToolResult("[1,2]")).toEqual([1, 2]);
   });
 });
 
@@ -54,11 +63,45 @@ describe("verdictFromResultRecord", () => {
     expect(verdictFromResultRecord({ status: "executed" })).toBe("allow");
     expect(verdictFromResultRecord({ verdict: "allow" })).toBe("allow");
   });
-  it("maps blocked/approval_pending/block -> block", () => {
+  it("maps blocked/block -> block", () => {
     expect(verdictFromResultRecord({ status: "blocked" })).toBe("block");
     expect(verdictFromResultRecord({ verdict: "block" })).toBe("block");
+  });
+  it("maps approval_pending -> approval (pending approval, not block)", () => {
     expect(verdictFromResultRecord({ status: "approval_pending" })).toBe(
-      "block",
+      "approval",
+    );
+    expect(
+      verdictFromResultRecord({ status: "approval_pending", approvalId: "x" }),
+    ).toBe("approval");
+  });
+  it("maps constrained/constrain -> constrain", () => {
+    expect(verdictFromResultRecord({ status: "constrained" })).toBe(
+      "constrain",
+    );
+    expect(verdictFromResultRecord({ verdict: "constrain" })).toBe("constrain");
+  });
+  it("maps require_approval verdict -> approval", () => {
+    expect(verdictFromResultRecord({ verdict: "require_approval" })).toBe(
+      "approval",
+    );
+  });
+  it("does not force constrain when redactionSummary is empty", () => {
+    expect(
+      verdictFromResultRecord({ status: "executed", redactionSummary: "" }),
+    ).toBe("allow");
+  });
+  it("ignores redactionSummary unless executed/allow", () => {
+    expect(
+      verdictFromResultRecord({ status: "blocked", redactionSummary: "pii" }),
+    ).toBe("block");
+  });
+  it("gives status precedence over verdict for rejected/error", () => {
+    expect(
+      verdictFromResultRecord({ status: "rejected", verdict: "halt" }),
+    ).toBe("rejected");
+    expect(verdictFromResultRecord({ status: "error", verdict: "block" })).toBe(
+      "error",
     );
   });
   it("maps error + rejected", () => {
@@ -93,5 +136,53 @@ describe("findOpenBoxResultContent", () => {
       toolCalls: [{ id: "tc1", function: { name: "some_other_tool" } }],
     };
     expect(findOpenBoxResultContent(assistant, { messages: [] })).toBeNull();
+  });
+  it("returns null when the matched tool message content is not a string", () => {
+    expect(
+      findOpenBoxResultContent({ role: "tool", content: { ok: true } }, {}),
+    ).toBeNull();
+  });
+  it("returns null when the snapshot tool message belongs to a non-governed call", () => {
+    const assistant = {
+      role: "assistant",
+      toolCalls: [{ id: "tc1", function: { name: "openbox_governed_action" } }],
+    };
+    // snapshot has a tool message, but its tool_call_id matches a NON-governed
+    // assistant tool call id (tc2), so the governed-id filter must reject it.
+    const snapshot = {
+      messages: [{ role: "tool", tool_call_id: "tc2", content: '{"ok":true}' }],
+    };
+    expect(findOpenBoxResultContent(assistant, snapshot)).toBeNull();
+  });
+});
+
+describe("extractToolCalls", () => {
+  it("discovers snake_case tool_calls", () => {
+    const message = {
+      tool_calls: [
+        { id: "tc1", function: { name: "openbox_governed_action" } },
+      ],
+    };
+    expect(extractToolCalls(message)).toEqual([
+      { id: "tc1", function: { name: "openbox_governed_action" } },
+    ]);
+  });
+  it("discovers nested additional_kwargs.tool_calls", () => {
+    const message = {
+      additional_kwargs: {
+        tool_calls: [{ id: "tc2", function: { name: "some_tool" } }],
+      },
+    };
+    expect(extractToolCalls(message)).toEqual([
+      { id: "tc2", function: { name: "some_tool" } },
+    ]);
+  });
+});
+
+describe("toolCallName", () => {
+  it("falls back to the top-level name when there is no function", () => {
+    expect(toolCallName({ name: "openbox_governed_action" })).toBe(
+      "openbox_governed_action",
+    );
   });
 });

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/result-parsing.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/result-parsing.ts
@@ -1,4 +1,5 @@
-import { OPENBOX_COPILOTKIT_RESULT_SCHEMA_VERSION } from "@openbox-ai/openbox-sdk/copilotkit";
+// mirrors OPENBOX_COPILOTKIT_RESULT_SCHEMA_VERSION from @openbox-ai/openbox-sdk/copilotkit (not imported: that subpath is Node-only and breaks the client bundle)
+const OPENBOX_COPILOTKIT_RESULT_SCHEMA_VERSION = "openbox.copilotkit.result.v1";
 import type { GovernanceVerdict } from "./types";
 
 /** Governed tool names that produce OpenBox result tool-messages. */

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/result-parsing.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/result-parsing.ts
@@ -1,0 +1,144 @@
+import { OPENBOX_COPILOTKIT_RESULT_SCHEMA_VERSION } from "@openbox-ai/openbox-sdk/copilotkit";
+import type { GovernanceVerdict } from "./types";
+
+/** Governed tool names that produce OpenBox result tool-messages. */
+export const GOVERNED_TOOL_NAMES = [
+  "openbox_governed_action",
+  "openbox_governed_approval_action",
+  "openbox_resume_governed_action",
+] as const;
+
+export const RESUME_TOOL_NAME = "openbox_resume_governed_action";
+
+/** Mirror of the SDK's parseToolResult (also exported by the SDK, kept local for purity). */
+export function parseFeedToolResult(value: unknown): Record<string, unknown> {
+  if (!value) return {};
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object"
+        ? (parsed as Record<string, unknown>)
+        : {};
+    } catch {
+      return {};
+    }
+  }
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+/** True when a parsed record is an OpenBox CopilotKit result envelope. */
+export function isOpenBoxResultRecord(
+  record: Record<string, unknown>,
+): boolean {
+  return record.schemaVersion === OPENBOX_COPILOTKIT_RESULT_SCHEMA_VERSION;
+}
+
+/**
+ * Mirror of the SDK-internal verdictFromResult (NOT exported by the SDK).
+ * Verified verbatim against react.js. Returns the feed badge verdict.
+ */
+export function verdictFromResultRecord(
+  result: Record<string, unknown>,
+): GovernanceVerdict {
+  if (result.status === "approval_required") return "approval";
+  if (result.status === "rejected") return "rejected";
+  if (result.status === "error" || result.verdict === "error") return "error";
+  if (result.status === "halted" || result.verdict === "halt") return "halt";
+  if (result.status === "constrained" || result.verdict === "constrain")
+    return "constrain";
+  if (
+    typeof result.redactionSummary === "string" &&
+    result.redactionSummary.length > 0 &&
+    (result.status === "executed" || result.verdict === "allow")
+  ) {
+    return "constrain";
+  }
+  if (result.status === "executed" || result.verdict === "allow")
+    return "allow";
+  if (
+    result.status === "blocked" ||
+    result.status === "approval_pending" ||
+    result.verdict === "block"
+  ) {
+    return "block";
+  }
+  if (result.verdict === "require_approval") return "approval";
+  return "reviewing";
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function textValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/** Extract tool calls from an assistant message across the known shapes. */
+export function extractToolCalls(
+  message: Record<string, unknown>,
+): Record<string, unknown>[] {
+  if (Array.isArray(message.toolCalls)) return message.toolCalls.map(asRecord);
+  if (Array.isArray(message.tool_calls))
+    return message.tool_calls.map(asRecord);
+  const additional = asRecord(message.additional_kwargs);
+  if (Array.isArray(additional.tool_calls))
+    return additional.tool_calls.map(asRecord);
+  return [];
+}
+
+export function toolCallName(toolCall: Record<string, unknown>): string {
+  const fn = asRecord(toolCall.function);
+  return textValue(toolCall.name ?? fn.name);
+}
+
+export function toolCallArgs(
+  toolCall: Record<string, unknown>,
+): Record<string, unknown> {
+  const fn = asRecord(toolCall.function);
+  const args = fn.arguments ?? toolCall.args;
+  return parseFeedToolResult(args);
+}
+
+/**
+ * Mirror of the SDK-internal findOpenBoxResult (NOT exported by the SDK).
+ * For a tool message returns its content; for an assistant message that
+ * called a governed tool, resolves the matching tool message content from
+ * the state snapshot by tool_call_id.
+ */
+export function findOpenBoxResultContent(
+  message: Record<string, unknown>,
+  stateSnapshot: unknown,
+): string | null {
+  const kind = textValue(message.role ?? message.type);
+  if (kind === "tool") {
+    const content = message.content;
+    return typeof content === "string" ? content : null;
+  }
+  if (kind !== "assistant" && kind !== "ai") return null;
+  const toolCalls = extractToolCalls(message);
+  const governedIds = new Set(
+    toolCalls
+      .filter((tc) =>
+        (GOVERNED_TOOL_NAMES as readonly string[]).includes(toolCallName(tc)),
+      )
+      .map((tc) => textValue(tc.id))
+      .filter(Boolean),
+  );
+  if (governedIds.size === 0) return null;
+  const snapshot = asRecord(stateSnapshot);
+  const snapshotMessages = Array.isArray(snapshot.messages)
+    ? snapshot.messages.map(asRecord)
+    : [];
+  const toolMessage = snapshotMessages.find((item) => {
+    if (item.type !== "tool" && item.role !== "tool") return false;
+    const toolCallId = textValue(item.tool_call_id ?? item.toolCallId);
+    return Boolean(toolCallId) && governedIds.has(toolCallId);
+  });
+  const content = toolMessage?.content;
+  return typeof content === "string" ? content : null;
+}

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/result-parsing.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/result-parsing.ts
@@ -9,8 +9,6 @@ export const GOVERNED_TOOL_NAMES = [
   "openbox_resume_governed_action",
 ] as const;
 
-export const RESUME_TOOL_NAME = "openbox_resume_governed_action";
-
 /** Mirror of the SDK's parseToolResult (also exported by the SDK, kept local for purity). */
 export function parseFeedToolResult(value: unknown): Record<string, unknown> {
   if (!value) return {};
@@ -95,14 +93,6 @@ export function extractToolCalls(
 export function toolCallName(toolCall: Record<string, unknown>): string {
   const fn = asRecord(toolCall.function);
   return textValue(toolCall.name ?? fn.name);
-}
-
-export function toolCallArgs(
-  toolCall: Record<string, unknown>,
-): Record<string, unknown> {
-  const fn = asRecord(toolCall.function);
-  const args = fn.arguments ?? toolCall.args;
-  return parseFeedToolResult(args);
 }
 
 /**

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/result-parsing.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/result-parsing.ts
@@ -9,7 +9,7 @@ export const GOVERNED_TOOL_NAMES = [
   "openbox_resume_governed_action",
 ] as const;
 
-/** Mirror of the SDK's parseToolResult (also exported by the SDK, kept local for purity). */
+/** Local result-content parser (kept dependency-free so this module stays in the client bundle). Returns {} for any non-object input. */
 export function parseFeedToolResult(value: unknown): Record<string, unknown> {
   if (!value) return {};
   if (typeof value === "string") {
@@ -35,13 +35,18 @@ export function isOpenBoxResultRecord(
 }
 
 /**
- * Mirror of the SDK-internal verdictFromResult (NOT exported by the SDK).
- * Verified verbatim against react.js. Returns the feed badge verdict.
+ * Adapted from the SDK-internal verdictFromResult (NOT exported by the SDK).
+ * Maps a raw result envelope to the feed badge verdict; note `approval_pending`
+ * is shown as `approval` (a pending-approval state), not `block`.
  */
 export function verdictFromResultRecord(
   result: Record<string, unknown>,
 ): GovernanceVerdict {
-  if (result.status === "approval_required") return "approval";
+  if (
+    result.status === "approval_required" ||
+    result.status === "approval_pending"
+  )
+    return "approval";
   if (result.status === "rejected") return "rejected";
   if (result.status === "error" || result.verdict === "error") return "error";
   if (result.status === "halted" || result.verdict === "halt") return "halt";
@@ -56,13 +61,7 @@ export function verdictFromResultRecord(
   }
   if (result.status === "executed" || result.verdict === "allow")
     return "allow";
-  if (
-    result.status === "blocked" ||
-    result.status === "approval_pending" ||
-    result.verdict === "block"
-  ) {
-    return "block";
-  }
+  if (result.status === "blocked" || result.verdict === "block") return "block";
   if (result.verdict === "require_approval") return "approval";
   return "reviewing";
 }

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/tree-builder.test.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/tree-builder.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import { buildExecutionTree } from "./tree-builder";
+import type {
+  FeedResultRecord,
+  FeedTimingRecord,
+  FeedStoreSnapshot,
+} from "./types";
+
+function result(
+  over: Partial<FeedResultRecord> & Pick<FeedResultRecord, "id">,
+): FeedResultRecord {
+  return {
+    kind: "result",
+    action: "review_data_handoff",
+    request: "req",
+    verdict: "allow",
+    status: "executed",
+    reason: "",
+    message: "",
+    hasGuardrailsSignal: false,
+    isResume: false,
+    arrivalIndex: 0,
+    emittedAtMs: 0,
+    raw: {},
+    ...over,
+  };
+}
+
+function timing(
+  over: Partial<FeedTimingRecord> & Pick<FeedTimingRecord, "action" | "key">,
+): FeedTimingRecord {
+  return {
+    kind: "timing",
+    request: "req",
+    label: over.key,
+    timingKind: "tool",
+    phase: "finished",
+    startedAtMs: 0,
+    ms: 10,
+    arrivalIndex: 0,
+    ...over,
+  } as FeedTimingRecord;
+}
+
+function snapshot(
+  results: FeedResultRecord[],
+  timings: FeedTimingRecord[] = [],
+): FeedStoreSnapshot {
+  return { results, timings, halted: false, revision: 1 };
+}
+
+describe("buildExecutionTree", () => {
+  it("groups actions under a Run keyed by runId", () => {
+    const tree = buildExecutionTree(
+      snapshot([
+        result({ id: "a", runId: "run-1", action: "create_support_ticket" }),
+        result({
+          id: "b",
+          runId: "run-1",
+          action: "send_public_status_update",
+        }),
+      ]),
+    );
+    expect(tree).toHaveLength(1);
+    expect(tree[0].id).toBe("run-1");
+    expect(tree[0].synthetic).toBe(false);
+    expect(tree[0].actions).toHaveLength(2);
+  });
+
+  it("falls back to workflowId, then to a synthetic run id", () => {
+    const tree = buildExecutionTree(
+      snapshot([
+        result({ id: "a", workflowId: "wf-9" }),
+        result({ id: "b" }), // no run/workflow -> synthetic
+      ]),
+    );
+    const ids = tree.map((r) => r.id);
+    expect(ids).toContain("wf-9");
+    expect(tree.some((r) => r.synthetic)).toBe(true);
+  });
+
+  it("attaches timing sub-steps to the matching action", () => {
+    const tree = buildExecutionTree(
+      snapshot(
+        [result({ id: "a", runId: "run-1", action: "review_data_handoff" })],
+        [
+          timing({ action: "review_data_handoff", key: "policy", ms: 12 }),
+          timing({
+            action: "review_data_handoff",
+            key: "guardrails",
+            phase: "started",
+            ms: undefined,
+          }),
+        ],
+      ),
+    );
+    const action = tree[0].actions[0];
+    expect(action.steps).toHaveLength(2);
+    expect(action.steps.find((s) => s.id.includes("guardrails"))?.pending).toBe(
+      true,
+    );
+  });
+
+  it("joins a resume result onto the matching approval node as a continuation", () => {
+    const tree = buildExecutionTree(
+      snapshot([
+        result({
+          id: "appr",
+          runId: "run-1",
+          action: "issue_large_refund",
+          verdict: "approval",
+          status: "approval_required",
+          approvalId: "ap-1",
+        }),
+        result({
+          id: "resume",
+          runId: "run-1",
+          action: "issue_large_refund",
+          verdict: "allow",
+          status: "executed",
+          approvalId: "ap-1",
+          isResume: true,
+        }),
+      ]),
+    );
+    // Only the approval node remains at top level; resume is nested.
+    expect(tree[0].actions).toHaveLength(1);
+    const node = tree[0].actions[0];
+    expect(node.verdict).toBe("approval");
+    expect(node.continuation?.verdict).toBe("allow");
+    expect(node.continuation?.isResume).toBe(true);
+  });
+
+  it("orders runs and actions by arrivalIndex then emittedAt", () => {
+    const tree = buildExecutionTree(
+      snapshot([
+        result({ id: "a", runId: "run-1", arrivalIndex: 2, emittedAtMs: 200 }),
+        result({ id: "b", runId: "run-1", arrivalIndex: 1, emittedAtMs: 100 }),
+      ]),
+    );
+    expect(tree[0].actions.map((a) => a.id)).toEqual(["b", "a"]);
+  });
+});

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/tree-builder.test.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/tree-builder.test.ts
@@ -131,6 +131,29 @@ describe("buildExecutionTree", () => {
     expect(node.continuation?.isResume).toBe(true);
   });
 
+  it("renders a resume with no matching approval as its own top-level action", () => {
+    const tree = buildExecutionTree(
+      snapshot([
+        result({
+          id: "resume",
+          runId: "run-1",
+          action: "issue_large_refund",
+          verdict: "allow",
+          status: "executed",
+          approvalId: "ap-orphan",
+          isResume: true,
+        }),
+      ]),
+    );
+    // No approval_required node for ap-orphan: the resume is neither nested
+    // nor dropped — it stands on its own at the top level.
+    expect(tree[0].actions).toHaveLength(1);
+    const node = tree[0].actions[0];
+    expect(node.id).toBe("resume");
+    expect(node.isResume).toBe(true);
+    expect(node.continuation).toBeUndefined();
+  });
+
   it("orders runs and actions by arrivalIndex then emittedAt", () => {
     const tree = buildExecutionTree(
       snapshot([

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/tree-builder.test.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/tree-builder.test.ts
@@ -163,4 +163,114 @@ describe("buildExecutionTree", () => {
     );
     expect(tree[0].actions.map((a) => a.id)).toEqual(["b", "a"]);
   });
+
+  it("collapses a started/finished pair for the same key into one step (finished wins)", () => {
+    const tree = buildExecutionTree(
+      snapshot(
+        [result({ id: "a", runId: "run-1", action: "review_data_handoff" })],
+        [
+          timing({
+            action: "review_data_handoff",
+            key: "policy",
+            phase: "started",
+            ms: undefined,
+          }),
+          timing({
+            action: "review_data_handoff",
+            key: "policy",
+            phase: "finished",
+            ms: 12,
+          }),
+        ],
+      ),
+    );
+    const action = tree[0].actions[0];
+    // Same action+key collapses to a single step...
+    expect(action.steps).toHaveLength(1);
+    // ...and finished wins, so the surviving step is not pending.
+    expect(action.steps[0].id).toBe("review_data_handoff:policy");
+    expect(action.steps[0].pending).toBe(false);
+    expect(action.steps[0].ms).toBe(12);
+  });
+
+  it("treats step pending asymmetrically by phase and ms", () => {
+    const tree = buildExecutionTree(
+      snapshot(
+        [result({ id: "a", runId: "run-1", action: "review_data_handoff" })],
+        [
+          // started WITH a numeric ms -> not pending
+          timing({
+            action: "review_data_handoff",
+            key: "started-with-ms",
+            phase: "started",
+            ms: 5,
+          }),
+          // finished -> not pending
+          timing({
+            action: "review_data_handoff",
+            key: "done",
+            phase: "finished",
+            ms: 8,
+          }),
+          // started with NO ms -> pending
+          timing({
+            action: "review_data_handoff",
+            key: "started-no-ms",
+            phase: "started",
+            ms: undefined,
+          }),
+        ],
+      ),
+    );
+    const steps = tree[0].actions[0].steps;
+    const byKey = (k: string) => steps.find((s) => s.id.endsWith(`:${k}`));
+    expect(byKey("started-with-ms")?.pending).toBe(false);
+    expect(byKey("done")?.pending).toBe(false);
+    expect(byKey("started-no-ms")?.pending).toBe(true);
+  });
+
+  it("produces one RunNode per distinct real runId, ordered by arrival", () => {
+    const tree = buildExecutionTree(
+      snapshot([
+        result({ id: "a", runId: "run-late", arrivalIndex: 1 }),
+        result({ id: "b", runId: "run-early", arrivalIndex: 0 }),
+      ]),
+    );
+    expect(tree).toHaveLength(2);
+    // Runs are ordered by the arrival of their first record.
+    expect(tree.map((r) => r.id)).toEqual(["run-early", "run-late"]);
+  });
+
+  it("does not consume a resume when the matching approvalId resolves to a non-approval verdict", () => {
+    const tree = buildExecutionTree(
+      snapshot([
+        result({
+          id: "blocked",
+          runId: "run-1",
+          action: "issue_large_refund",
+          verdict: "block",
+          status: "blocked",
+          approvalId: "ap1",
+        }),
+        result({
+          id: "resume",
+          runId: "run-1",
+          action: "issue_large_refund",
+          verdict: "allow",
+          status: "executed",
+          approvalId: "ap1",
+          isResume: true,
+        }),
+      ]),
+    );
+    // The record with approvalId "ap1" is a block, not an approval, so the
+    // r.verdict === "approval" guard keeps the resume from being skipped.
+    const node = tree[0].actions.find((a) => a.id === "resume");
+    expect(node).toBeDefined();
+    expect(node?.isResume).toBe(true);
+    // The blocked record carries no continuation (it isn't an approval node).
+    const blocked = tree[0].actions.find((a) => a.id === "blocked");
+    expect(blocked?.continuation).toBeUndefined();
+    expect(tree[0].actions).toHaveLength(2);
+  });
 });

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/tree-builder.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/tree-builder.ts
@@ -104,10 +104,11 @@ function orderByArrival<T extends { arrivalIndex: number }>(
 /**
  * Pure flat-records -> Run→Action→Step tree.
  *
- * Ordering caveat: no monotonic server sequence field exists client-side, so
- * order is synthesized from client arrival order (arrivalIndex) and then
- * emittedAt/startedAt timestamps. Concurrent same-millisecond events keep
- * arrival order.
+ * Ordering caveat: there is no server sequence field, so order is by
+ * arrivalIndex — a single monotonic client-side counter shared across results
+ * and timings. Because that counter is drawn from one source, every value is
+ * unique and the resulting order is total; the secondary timestamp tiebreaker
+ * is effectively unused since arrivalIndex never ties.
  *
  * Approval->resume join: a resume result (isResume) whose approvalId matches
  * an earlier approval_required result is nested as that node's `continuation`
@@ -123,7 +124,6 @@ export function buildExecutionTree(snapshot: FeedStoreSnapshot): RunNode[] {
       resumesByApproval.set(record.approvalId, record);
     }
   }
-  const consumedResumeIds = new Set<string>();
 
   const runs = new Map<string, RunNode>();
   let runArrival = 0;
@@ -138,7 +138,6 @@ export function buildExecutionTree(snapshot: FeedStoreSnapshot): RunNode[] {
           r.verdict === "approval",
       );
       if (approvalExists) {
-        consumedResumeIds.add(record.id);
         continue;
       }
     }
@@ -174,7 +173,5 @@ export function buildExecutionTree(snapshot: FeedStoreSnapshot): RunNode[] {
   for (const run of out) {
     run.actions = orderByArrival(run.actions, (a) => a.arrivalIndex);
   }
-  // Mark consumed resumes as referenced (no-op guard for lint clarity).
-  void consumedResumeIds;
   return out;
 }

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/tree-builder.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/tree-builder.ts
@@ -161,7 +161,7 @@ export function buildExecutionTree(snapshot: FeedStoreSnapshot): RunNode[] {
     // Attach the resume continuation if this is the approval node.
     if (record.verdict === "approval" && record.approvalId) {
       const resume = resumesByApproval.get(record.approvalId);
-      if (resume && !resume.isResume === false) {
+      if (resume) {
         node.continuation = toActionNode(resume, snapshot.timings);
       }
     }

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/tree-builder.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/tree-builder.ts
@@ -1,0 +1,180 @@
+import { openBoxDemoScenarios } from "@/lib/openbox-demo-scenarios";
+import { derivePillar } from "./pillars";
+import type {
+  ActionNode,
+  FeedResultRecord,
+  FeedStoreSnapshot,
+  FeedTimingRecord,
+  RunNode,
+  StepNode,
+} from "./types";
+
+const SYNTHETIC_RUN_ID = "openbox-local-session";
+
+function scenarioFor(action: string) {
+  return openBoxDemoScenarios.find((item) => item.action === action);
+}
+
+function titleFor(action: string): string {
+  return (
+    scenarioFor(action)?.title ??
+    (action ? action.replace(/_/g, " ") : "Governed Action")
+  );
+}
+
+function runKey(record: FeedResultRecord): {
+  id: string;
+  synthetic: boolean;
+} {
+  if (record.runId) return { id: record.runId, synthetic: false };
+  if (record.workflowId) return { id: record.workflowId, synthetic: false };
+  return { id: SYNTHETIC_RUN_ID, synthetic: true };
+}
+
+function runLabel(id: string, synthetic: boolean): string {
+  if (synthetic) return "Session (local)";
+  return `Run ${id.slice(0, 8)}`;
+}
+
+function stepsForAction(
+  action: string,
+  timings: FeedTimingRecord[],
+): StepNode[] {
+  const matching = timings.filter((t) => t.action === action);
+  // Collapse started/finished pairs by key: a finished record wins.
+  const byKey = new Map<string, FeedTimingRecord>();
+  for (const t of matching) {
+    const existing = byKey.get(t.key);
+    if (!existing || t.phase === "finished") byKey.set(t.key, t);
+  }
+  return Array.from(byKey.values())
+    .sort(
+      (a, b) =>
+        a.arrivalIndex - b.arrivalIndex || a.startedAtMs - b.startedAtMs,
+    )
+    .map((t) => ({
+      id: `${action}:${t.key}`,
+      label: t.label,
+      kind: t.timingKind,
+      startedAtMs: t.startedAtMs,
+      ms: t.ms,
+      pending: t.phase === "started" && typeof t.ms !== "number",
+    }));
+}
+
+function toActionNode(
+  record: FeedResultRecord,
+  timings: FeedTimingRecord[],
+): ActionNode {
+  const pillar = derivePillar(
+    {
+      verdict: record.verdict,
+      redactionSummary: record.redactionSummary,
+      hasGuardrailsSignal: record.hasGuardrailsSignal,
+    },
+    scenarioFor(record.action),
+  );
+  return {
+    id: record.id,
+    action: record.action,
+    title: titleFor(record.action),
+    request: record.request,
+    verdict: record.verdict,
+    pillar,
+    reason: record.reason,
+    redactionSummary: record.redactionSummary,
+    riskScore: record.riskScore,
+    trustTier: record.trustTier,
+    isResume: record.isResume,
+    steps: stepsForAction(record.action, timings),
+    arrivalIndex: record.arrivalIndex,
+    raw: record.raw,
+  };
+}
+
+function orderByArrival<T extends { arrivalIndex: number }>(
+  items: T[],
+  secondary: (item: T) => number,
+): T[] {
+  return [...items].sort(
+    (a, b) => a.arrivalIndex - b.arrivalIndex || secondary(a) - secondary(b),
+  );
+}
+
+/**
+ * Pure flat-records -> Run→Action→Step tree.
+ *
+ * Ordering caveat: no monotonic server sequence field exists client-side, so
+ * order is synthesized from client arrival order (arrivalIndex) and then
+ * emittedAt/startedAt timestamps. Concurrent same-millisecond events keep
+ * arrival order.
+ *
+ * Approval->resume join: a resume result (isResume) whose approvalId matches
+ * an earlier approval_required result is nested as that node's `continuation`
+ * rather than appearing as a sibling.
+ */
+export function buildExecutionTree(snapshot: FeedStoreSnapshot): RunNode[] {
+  const results = orderByArrival(snapshot.results, (r) => r.emittedAtMs);
+
+  // Index resume continuations by approvalId.
+  const resumesByApproval = new Map<string, FeedResultRecord>();
+  for (const record of results) {
+    if (record.isResume && record.approvalId) {
+      resumesByApproval.set(record.approvalId, record);
+    }
+  }
+  const consumedResumeIds = new Set<string>();
+
+  const runs = new Map<string, RunNode>();
+  let runArrival = 0;
+
+  for (const record of results) {
+    // Skip resume records that will be nested under their approval node.
+    if (record.isResume && record.approvalId) {
+      const approvalExists = results.some(
+        (r) =>
+          !r.isResume &&
+          r.approvalId === record.approvalId &&
+          r.verdict === "approval",
+      );
+      if (approvalExists) {
+        consumedResumeIds.add(record.id);
+        continue;
+      }
+    }
+
+    const { id, synthetic } = runKey(record);
+    let run = runs.get(id);
+    if (!run) {
+      run = {
+        id,
+        label: runLabel(id, synthetic),
+        synthetic,
+        actions: [],
+        arrivalIndex: runArrival++,
+      };
+      runs.set(id, run);
+    }
+
+    const node = toActionNode(record, snapshot.timings);
+
+    // Attach the resume continuation if this is the approval node.
+    if (record.verdict === "approval" && record.approvalId) {
+      const resume = resumesByApproval.get(record.approvalId);
+      if (resume && !resume.isResume === false) {
+        node.continuation = toActionNode(resume, snapshot.timings);
+      }
+    }
+
+    run.actions.push(node);
+  }
+
+  // Final ordering of actions inside each run.
+  const out = orderByArrival(Array.from(runs.values()), (r) => 0);
+  for (const run of out) {
+    run.actions = orderByArrival(run.actions, (a) => a.arrivalIndex);
+  }
+  // Mark consumed resumes as referenced (no-op guard for lint clarity).
+  void consumedResumeIds;
+  return out;
+}

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/tree-builder.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/tree-builder.ts
@@ -169,7 +169,7 @@ export function buildExecutionTree(snapshot: FeedStoreSnapshot): RunNode[] {
   }
 
   // Final ordering of actions inside each run.
-  const out = orderByArrival(Array.from(runs.values()), (r) => 0);
+  const out = orderByArrival(Array.from(runs.values()), () => 0);
   for (const run of out) {
     run.actions = orderByArrival(run.actions, (a) => a.arrivalIndex);
   }

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/types.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/types.ts
@@ -1,0 +1,125 @@
+// Single source of truth for all Governance-Feed types. Defined once here and
+// imported everywhere — never re-declared in another module.
+
+/**
+ * Feed badge vocabulary. Mirrors the SDK's OpenBoxUiVerdict
+ * (note: 'approval', NOT 'require_approval') plus the spec's 5 verdicts.
+ * The spec verdicts map onto these as:
+ *   allow -> "allow", constrain/redact -> "constrain",
+ *   require_approval -> "approval", block -> "block", halt -> "halt".
+ * 'reviewing' is the pre-decision state; 'rejected'/'error' are terminal extras.
+ */
+export type GovernanceVerdict =
+  | "reviewing"
+  | "allow"
+  | "constrain"
+  | "approval"
+  | "block"
+  | "halt"
+  | "rejected"
+  | "error";
+
+/** The three OpenBox "Authorize" pillars, plus an unknown fallback. */
+export type GovernancePillar =
+  | "guardrails"
+  | "policies"
+  | "behavioral_rules"
+  | "unknown";
+
+/**
+ * A normalized governed tool-message result, as ingested into the store.
+ * `raw` is the parsed OpenBoxCopilotActionResult record (kept for the JSON
+ * viewer). `arrivalIndex` is a monotonic client-side counter used to
+ * synthesize ordering (no server sequence field exists client-side).
+ */
+export interface FeedResultRecord {
+  kind: "result";
+  /** tool_call_id of the originating governed tool call (stable id). */
+  id: string;
+  action: string;
+  request: string;
+  verdict: GovernanceVerdict;
+  status: string;
+  reason: string;
+  message: string;
+  redactionSummary?: string;
+  hasGuardrailsSignal: boolean;
+  riskScore?: number;
+  trustTier?: string | number;
+  runId?: string;
+  workflowId?: string;
+  activityId?: string;
+  approvalId?: string;
+  governanceEventId?: string;
+  /** True when this result is a resume continuation (resume tool call). */
+  isResume: boolean;
+  arrivalIndex: number;
+  emittedAtMs: number;
+  raw: Record<string, unknown>;
+}
+
+/** A timing sub-step record (one per timing.v1 event), keyed by action+key. */
+export interface FeedTimingRecord {
+  kind: "timing";
+  action: string;
+  request: string;
+  key: string;
+  label: string;
+  timingKind: string;
+  phase: "started" | "finished";
+  startedAtMs: number;
+  ms?: number;
+  arrivalIndex: number;
+}
+
+/** Append-only store snapshot consumed by the pure tree-builder. */
+export interface FeedStoreSnapshot {
+  results: FeedResultRecord[];
+  timings: FeedTimingRecord[];
+  halted: boolean;
+  haltedAtMs?: number;
+  /** Bumped on every mutation so useSyncExternalStore re-renders. */
+  revision: number;
+}
+
+/** Level 3 — timing sub-step. */
+export interface StepNode {
+  id: string;
+  label: string;
+  kind: string;
+  startedAtMs: number;
+  ms?: number;
+  /** True while the step has started but not finished. */
+  pending: boolean;
+}
+
+/** Level 2 — one governed Action (one per governed tool-message result). */
+export interface ActionNode {
+  id: string;
+  action: string;
+  title: string;
+  request: string;
+  verdict: GovernanceVerdict;
+  pillar: GovernancePillar;
+  reason: string;
+  redactionSummary?: string;
+  riskScore?: number;
+  trustTier?: string | number;
+  isResume: boolean;
+  /** A resume continuation joined to this action (approval -> resume). */
+  continuation?: ActionNode;
+  steps: StepNode[];
+  arrivalIndex: number;
+  raw: Record<string, unknown>;
+}
+
+/** Level 1 — Run / Session. */
+export interface RunNode {
+  id: string;
+  /** Display label, e.g. "Run a1b2c3d4" or "Session (local)". */
+  label: string;
+  /** True when id is a synthetic fallback (no runId/workflowId present). */
+  synthetic: boolean;
+  actions: ActionNode[];
+  arrivalIndex: number;
+}

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/use-governance-feed.tsx
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/use-governance-feed.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
+import { useAgent } from "@copilotkit/react-core/v2";
+import { onOpenBoxSessionHalted } from "@/lib/openbox-halt-state";
+import {
+  getFeedSnapshot,
+  ingestHalt,
+  ingestResultsFromMessages,
+  ingestTimingFromState,
+  resetFeed,
+  subscribeToFeed,
+} from "./feed-store";
+import { buildExecutionTree } from "./tree-builder";
+import type { RunNode } from "./types";
+
+const OPENBOX_AGENT_ID = "default";
+
+export interface GovernanceFeedValue {
+  runs: RunNode[];
+  halted: boolean;
+  reset: () => void;
+}
+
+export function useGovernanceFeed(): GovernanceFeedValue {
+  const { agent } = useAgent({ agentId: OPENBOX_AGENT_ID });
+
+  const snapshot = useSyncExternalStore(
+    subscribeToFeed,
+    getFeedSnapshot,
+    getFeedSnapshot,
+  );
+
+  // Ingest current agent snapshot on mount and whenever agent identity changes.
+  useEffect(() => {
+    ingestResultsFromMessages(
+      agent.messages as unknown[],
+      agent.state as unknown,
+    );
+    ingestTimingFromState(agent.state as unknown);
+
+    const subscription = agent.subscribe({
+      onMessagesChanged: ({ messages, state }) => {
+        ingestResultsFromMessages(messages as unknown[], state as unknown);
+      },
+      onStateChanged: ({ state }) => {
+        ingestResultsFromMessages(
+          agent.messages as unknown[],
+          state as unknown,
+        );
+        ingestTimingFromState(state as unknown);
+      },
+    });
+    return () => subscription.unsubscribe();
+  }, [agent]);
+
+  // Mirror halt into the store.
+  useEffect(() => {
+    const off = onOpenBoxSessionHalted(() => ingestHalt());
+    return off;
+  }, []);
+
+  const reset = useCallback(() => resetFeed(), []);
+
+  const runs = useMemo(
+    () => buildExecutionTree(snapshot),
+    // snapshot.revision is the change signal from the external store.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [snapshot.revision],
+  );
+
+  return { runs, halted: snapshot.halted, reset };
+}

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/verdict-style.test.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/verdict-style.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { VERDICT_STYLE } from "./verdict-style";
+import type { GovernanceVerdict } from "./types";
+
+const ALL_VERDICTS: GovernanceVerdict[] = [
+  "reviewing",
+  "allow",
+  "constrain",
+  "approval",
+  "block",
+  "halt",
+  "rejected",
+  "error",
+];
+
+describe("VERDICT_STYLE", () => {
+  it("has an entry for every GovernanceVerdict", () => {
+    for (const verdict of ALL_VERDICTS) {
+      const style = VERDICT_STYLE[verdict];
+      expect(style, `missing entry for verdict "${verdict}"`).toBeDefined();
+      expect(style.icon, `verdict "${verdict}" has no icon`).toBeDefined();
+      expect(style.label, `verdict "${verdict}" has no label`).toBeDefined();
+      expect(
+        style.badgeClass,
+        `verdict "${verdict}" has no badgeClass`,
+      ).toBeDefined();
+    }
+  });
+
+  it("emits the exact human labels (label contract)", () => {
+    expect(VERDICT_STYLE.reviewing.label).toBe("Reviewing");
+    expect(VERDICT_STYLE.allow.label).toBe("Allowed");
+    expect(VERDICT_STYLE.constrain.label).toBe("Constrained");
+    expect(VERDICT_STYLE.approval.label).toBe("Approval");
+    expect(VERDICT_STYLE.block.label).toBe("Blocked");
+    expect(VERDICT_STYLE.halt.label).toBe("Halted");
+    expect(VERDICT_STYLE.rejected.label).toBe("Rejected");
+    expect(VERDICT_STYLE.error.label).toBe("Error");
+  });
+
+  it("every badgeClass is a non-empty string", () => {
+    for (const verdict of ALL_VERDICTS) {
+      const { badgeClass } = VERDICT_STYLE[verdict];
+      expect(typeof badgeClass).toBe("string");
+      expect(badgeClass.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/verdict-style.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/verdict-style.ts
@@ -18,9 +18,10 @@ export interface VerdictStyle {
 }
 
 /**
- * Verdict -> presentation. Labels intentionally match the terminal-verdict
- * regex used by the e2e suite: Allowed | Redacted | Constrained | Blocked |
- * Halted | Rejected. "Reviewing" is the pre-decision state.
+ * Verdict -> presentation. Labels emitted by this map:
+ *   Reviewing (pre-decision) | Allowed | Constrained | Approval |
+ *   Blocked | Halted | Rejected | Error.
+ * No "Redacted" label is produced — constrain renders as "Constrained".
  */
 export const VERDICT_STYLE: Record<GovernanceVerdict, VerdictStyle> = {
   reviewing: {

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/verdict-style.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/verdict-style.ts
@@ -13,8 +13,6 @@ export interface VerdictStyle {
   /** Human label shown in the badge (matches e2e regexes where relevant). */
   label: string;
   icon: LucideIcon;
-  /** CSS variable name (defined in globals.css) for the accent color. */
-  accentVar: string;
   /** Utility classes for the badge container. */
   badgeClass: string;
 }
@@ -28,49 +26,41 @@ export const VERDICT_STYLE: Record<GovernanceVerdict, VerdictStyle> = {
   reviewing: {
     label: "Reviewing",
     icon: Circle,
-    accentVar: "--openbox-feed-reviewing",
     badgeClass: "openbox-feed-badge openbox-feed-badge--reviewing",
   },
   allow: {
     label: "Allowed",
     icon: CircleCheck,
-    accentVar: "--openbox-feed-allow",
     badgeClass: "openbox-feed-badge openbox-feed-badge--allow",
   },
   constrain: {
     label: "Constrained",
     icon: ShieldAlert,
-    accentVar: "--openbox-feed-constrain",
     badgeClass: "openbox-feed-badge openbox-feed-badge--constrain",
   },
   approval: {
     label: "Approval",
     icon: ShieldQuestion,
-    accentVar: "--openbox-feed-approval",
     badgeClass: "openbox-feed-badge openbox-feed-badge--approval",
   },
   block: {
     label: "Blocked",
     icon: CircleX,
-    accentVar: "--openbox-feed-block",
     badgeClass: "openbox-feed-badge openbox-feed-badge--block",
   },
   halt: {
     label: "Halted",
     icon: OctagonX,
-    accentVar: "--openbox-feed-halt",
     badgeClass: "openbox-feed-badge openbox-feed-badge--halt",
   },
   rejected: {
     label: "Rejected",
     icon: CircleX,
-    accentVar: "--openbox-feed-block",
     badgeClass: "openbox-feed-badge openbox-feed-badge--block",
   },
   error: {
     label: "Error",
     icon: OctagonX,
-    accentVar: "--openbox-feed-halt",
     badgeClass: "openbox-feed-badge openbox-feed-badge--halt",
   },
 };

--- a/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/verdict-style.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/src/lib/governance-feed/verdict-style.ts
@@ -1,0 +1,76 @@
+import {
+  CircleCheck,
+  CircleX,
+  OctagonX,
+  ShieldAlert,
+  ShieldQuestion,
+  Circle,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { GovernanceVerdict } from "./types";
+
+export interface VerdictStyle {
+  /** Human label shown in the badge (matches e2e regexes where relevant). */
+  label: string;
+  icon: LucideIcon;
+  /** CSS variable name (defined in globals.css) for the accent color. */
+  accentVar: string;
+  /** Utility classes for the badge container. */
+  badgeClass: string;
+}
+
+/**
+ * Verdict -> presentation. Labels intentionally match the terminal-verdict
+ * regex used by the e2e suite: Allowed | Redacted | Constrained | Blocked |
+ * Halted | Rejected. "Reviewing" is the pre-decision state.
+ */
+export const VERDICT_STYLE: Record<GovernanceVerdict, VerdictStyle> = {
+  reviewing: {
+    label: "Reviewing",
+    icon: Circle,
+    accentVar: "--openbox-feed-reviewing",
+    badgeClass: "openbox-feed-badge openbox-feed-badge--reviewing",
+  },
+  allow: {
+    label: "Allowed",
+    icon: CircleCheck,
+    accentVar: "--openbox-feed-allow",
+    badgeClass: "openbox-feed-badge openbox-feed-badge--allow",
+  },
+  constrain: {
+    label: "Constrained",
+    icon: ShieldAlert,
+    accentVar: "--openbox-feed-constrain",
+    badgeClass: "openbox-feed-badge openbox-feed-badge--constrain",
+  },
+  approval: {
+    label: "Approval",
+    icon: ShieldQuestion,
+    accentVar: "--openbox-feed-approval",
+    badgeClass: "openbox-feed-badge openbox-feed-badge--approval",
+  },
+  block: {
+    label: "Blocked",
+    icon: CircleX,
+    accentVar: "--openbox-feed-block",
+    badgeClass: "openbox-feed-badge openbox-feed-badge--block",
+  },
+  halt: {
+    label: "Halted",
+    icon: OctagonX,
+    accentVar: "--openbox-feed-halt",
+    badgeClass: "openbox-feed-badge openbox-feed-badge--halt",
+  },
+  rejected: {
+    label: "Rejected",
+    icon: CircleX,
+    accentVar: "--openbox-feed-block",
+    badgeClass: "openbox-feed-badge openbox-feed-badge--block",
+  },
+  error: {
+    label: "Error",
+    icon: OctagonX,
+    accentVar: "--openbox-feed-halt",
+    badgeClass: "openbox-feed-badge openbox-feed-badge--halt",
+  },
+};

--- a/examples/showcases/openbox-governed-copilotkit/frontend/vitest.config.ts
+++ b/examples/showcases/openbox-governed-copilotkit/frontend/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    globals: false,
+    passWithNoTests: true,
+  },
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
## What this adds

A live **Governance-Feed / Execution-Tree side panel** for the `openbox-governed-copilotkit` showcase. It visualizes OpenBox runtime-governance decisions as a **Run → Action → Step tree** next to the chat — surfacing all **5 verdicts** (allow / constrain-redact / approval / block / halt) and the **3 OpenBox "Authorize" pillars** (guardrails, policies, behavioral rules) per action, with live "reviewing → resolved" transitions, timing sub-steps, approval→resume nesting, and a raw-payload JSON viewer.

It is driven **entirely by data the showcase already emits client-side** — the `openbox.copilotkit.result.v1` governance tool-messages + the `openbox.copilotkit.timing.v1` agent-state stream — so it needs **no live OpenBox backend / Agent-Log key**. Inspired by the execution-tree viewer the OpenBox team built ([`ash-krnl/ob_execution_tree_demo`](https://github.com/ash-krnl/ob_execution_tree_demo)); the scaffold (tree grouping, JSON viewer, stats) is lifted in spirit, but the verdict + pillar visual language is new (the reference only renders a binary "valid" count).

## Stacked on #5685

> **Base branch is `showcase/openbox-governed-copilotkit` (PR #5685), not `main`.** This is a stacked PR — its diff is only the feed-UI addition. It rebases onto `main` once #5685 merges.

## Layout (all under `examples/showcases/openbox-governed-copilotkit/frontend/`)

- `src/lib/governance-feed/` — pure, framework-free core: `types.ts`, `result-parsing.ts` (schema filter + verdict mapping), `pillars.ts` (3-pillar derivation), `verdict-style.ts` (verdict → badge/icon), `tree-builder.ts` (Run→Action→Step + approval→resume `continuation` join), `feed-store.ts` (append-only `useSyncExternalStore`), and `use-governance-feed.tsx` (subscribes the live agent → store → tree).
- `src/components/governance-feed/` — `json-tree.tsx` (collapsible raw viewer) + `governance-feed-panel.tsx` (the panel).
- `src/components/example-layout/index.tsx` — new optional `sidePanel` slot (single-column layout unchanged when absent).
- `src/app/page.tsx` — mounts the panel; `src/app/globals.css` — `.openbox-feed-*` styles (verdict accent vars via `color-mix`).
- Tooling/tests: `vitest.config.ts` + `vitest` dev-dep (new unit runner); `e2e/governance-feed.spec.ts` + helpers.

## Verification

- **71 unit tests** (vitest, new) green — result-parsing, pillars, tree-builder, append-only store, verdict-style.
- `tsc --noEmit` ✅, **`next build`** ✅ (all routes), **oxlint 0 warnings / 0 errors**.
- Reviewed across the build (per-wave + integration reviews) **plus a full 7-agent CR pass** that caught and fixed real issues: a stale-tree-after-reset bug (non-monotonic store revision vs. the `useMemo` key), a self-undoing panel "reset", and an `approval_pending`→"Blocked" mislabel — each shipped with covering tests.
- Standalone showcase conventions (npm + committed lockfile; not in `pnpm-workspace.yaml`).

## ⚠️ Draft — notes

- **SDK:** builds against the **current** CopilotKit SDK; the pending internal SDK bug-fix release is independent of this UI (the panel consumes governance/timing data the runtime already surfaces).
- **E2E:** the structural `governance-feed.spec.ts` describe runs against a full local stack (frontend + agent); the verdict-matrix describe is creds-gated (same pattern as #5685's `governance.spec.ts`).
- **Follow-ups (deferred, non-blocking):** type-design hardening (a validated result-envelope type predicate + status/verdict unions), tighter un-gated e2e panel assertions + pure-formatter unit tests, and resume-detection hardening for multi-step approval chains.

## Companion

Builds on the showcase from **https://github.com/CopilotKit/CopilotKit/pull/5685** (and its recipe, #5686).

> Draft — not for merge.
