### PR TITLE
fix(ci): scope format auto-commit trigger to PR files to avoid empty-commit failures

### DIFF
--- a/.github/workflows/static_quality.yml
+++ b/.github/workflows/static_quality.yml
@@ -123,7 +123,18 @@ jobs:
           if [ -n "$py_files" ]; then
             echo "$py_files" | xargs ruff format || echo "::warning::ruff format exited with error"
           fi
-          if [ -n "$(git diff --name-only)" ]; then
+          # Trigger the auto-commit only when one of the SCOPED PR files
+          # actually changed. A whole-tree `git diff` here also trips on
+          # unrelated working-tree drift (e.g. an LFS smudge on a tracked
+          # `*.png filter=lfs` file), which would set format_fixed=true while
+          # the scoped `git add` below stages nothing — making `git commit`
+          # fail with "nothing to commit". Diffing only the scoped files keeps
+          # the trigger aligned with what the commit step can actually stage.
+          # shellcheck disable=SC2046 # intentional split: each path is a
+          # separate `git diff` pathspec arg; the `-s` guard rules out the
+          # empty-arg (whole-tree) case, and PR paths never contain spaces.
+          if [ -s .pr-format-files.existing.txt ] && \
+             ! git diff --quiet -- $(cat .pr-format-files.existing.txt); then
             echo "format_fixed=true" >> "$GITHUB_ENV"
           fi
           # Check mode: verify everything is formatted
@@ -161,6 +172,14 @@ jobs:
           # leaving formatting violations on the PR branch and (post-
           # merge) on main.
           xargs -a .pr-format-files.existing.txt git add --
+          # Guard against an empty staged set: if the scoped `git add` staged
+          # nothing (e.g. the whole-tree drift that set format_fixed=true lives
+          # entirely outside the scoped files), `git commit` would exit 1 and
+          # fail the job. Treat an empty index as a no-op instead.
+          if git diff --cached --quiet; then
+            echo "No scoped formatting changes to commit"
+            exit 0
+          fi
           git commit -m "style: auto-fix formatting"
           git push
 


### PR DESCRIPTION
## Root cause

The shared `static / quality` workflow's **`format`** job auto-formats PR files and pushes a fixup commit. Two pieces were misaligned:

- **"Run formatter (fix on PR)"** set `format_fixed=true` from a **whole-tree** `git diff --name-only` (old line ~126).
- **"Commit formatting fixes"** (gated on `format_fixed == 'true'`) staged **only the scoped** PR files (`xargs -a .pr-format-files.existing.txt git add --`, old line ~163) and ran a bare `git commit` (old line ~164).

When a PR's own files are already formatter-clean **but the runner's working tree is dirty for an unrelated reason** — e.g. an LFS smudge on `examples/teams/appPackage/*.png` (declared `*.png filter=lfs`) — the whole-tree diff falsely set `format_fixed=true`, the **scoped `git add` staged nothing**, and `git commit` exited **1** ("nothing to commit") → the job **failed**.

This intermittently red-flagged any PR depending on per-runner LFS-smudge state (cf. #5715, where the format check failed and then passed on re-run with no code change).

## The fix (minimal, `format` job only)

1. **Scope the trigger.** Set `format_fixed` from a **scoped** diff (`git diff --quiet -- <scoped files>`) guarded by `[ -s .pr-format-files.existing.txt ]` so unrelated working-tree drift no longer triggers the commit path, and the empty case never degrades to a whole-tree diff.
2. **Guard the commit.** After the scoped `git add`, treat an empty index as a no-op (`git diff --cached --quiet && exit 0`) instead of letting `git commit` exit 1.

The real behavior is preserved: when a scoped PR file genuinely needs formatting, the job still stages, commits, and pushes the fix. No other job is touched.

```diff
@@ Run formatter (fix on PR) @@
-          if [ -n "$(git diff --name-only)" ]; then
+          # shellcheck disable=SC2046 # intentional split: each path is a
+          # separate `git diff` pathspec arg; the `-s` guard rules out the
+          # empty-arg (whole-tree) case, and PR paths never contain spaces.
+          if [ -s .pr-format-files.existing.txt ] && \
+             ! git diff --quiet -- $(cat .pr-format-files.existing.txt); then
             echo "format_fixed=true" >> "$GITHUB_ENV"
           fi
@@ Commit formatting fixes @@
           xargs -a .pr-format-files.existing.txt git add --
+          if git diff --cached --quiet; then
+            echo "No scoped formatting changes to commit"
+            exit 0
+          fi
           git commit -m "style: auto-fix formatting"
           git push
```

## Local RED → GREEN proof

GitHub Actions can't run locally, so the job's **exact shell** was reproduced in a throwaway `/tmp` git repo, using real `oxfmt@0.36` and GNU `gxargs` for Linux-runner fidelity (`xargs -a` is GNU-only). Scoped PR file = `app.js`; unrelated tracked file = `unrelated.bin`, left **dirty** to simulate the LFS smudge.

**RED — current logic (whole-tree trigger + scoped add + bare commit):**
```
[RED] trigger env='format_fixed=true'        # whole-tree diff saw unrelated.bin
[staged after scoped add]: ''                 # app.js already clean → nothing staged
nothing to commit
>>> RED git commit exit code: 1  (JOB FAILS)
```

**GREEN — fixed logic, same repo state:**
```
[GREEN] trigger env=''                         # scoped app.js clean; unrelated.bin ignored
[gate] format_fixed NOT set -> Commit step SKIPPED
>>> GREEN exit code: 0  (job passes, no false trigger)
```

**POSITIVE — scoped file genuinely needs formatting (committed-unformatted `app.js`, `unrelated.bin` still dirty):**
```
after oxfmt — app.js: const z = 3;
[POS] trigger env='format_fixed=true'
[staged]: 'app.js'                             # only the scoped file
[POS] commit exit=0
[POS] git log: 46d4849 style: auto-fix formatting
[POS] worktree: ' M unrelated.bin'            # unrelated drift left uncommitted
```

So: false-trigger failure is eliminated (RED→GREEN), and the real auto-format path still commits & pushes exactly the scoped fix (positive).

## Validation

- `python3 yaml.safe_load(...)` → YAML OK
- `actionlint .github/workflows/static_quality.yml` → exit 0 (baseline on `main` is also clean; the SC2046 word-split warning introduced by the scoped diff is suppressed with a narrowly-scoped, commented `shellcheck disable` for the intentional split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
