### PR TITLE
docs(showcase): session-stack discipline + cleanup guidance for isolated runs

### DIFF
--- a/showcase/TESTING.md
+++ b/showcase/TESTING.md
@@ -43,6 +43,49 @@ services (aimock, pocketbase, dashboard, harness, harness-pool-worker) reuse
 cached images from the local Docker store. Cold-build is ~30s–2 min per slug
 instead of 10+ min full-stack rebuild.
 
+### Session-stack discipline / Cleanup after isolated runs
+
+This governs every `--isolate`/`--keep` invocation below. The leak it prevents:
+agents minting a _new_ named kept stack per cell (`cvtest2`, `greenproof`,
+`gp1`..`gp10`, `showcase-iso2/4`, …) and never tearing them down — each one
+holds a slot and burns offset ports until the host fills up.
+
+1. **One stack per session, reused.** At the start of a debugging/testing
+   session, choose ONE stable isolate name and use
+   `--isolate <session-name> --keep` for ALL tests in that session. Every
+   subsequent test in the same session MUST reuse ONE `--isolate <session-name>`
+   — never mint a new named stack per individual cell/feature/pill (that is what
+   leaks named stacks). Derive the session name from the primary slug under test
+   so reuse is unambiguous, e.g. `--isolate <slug>-session`. Each `--keep` re-run
+   with the same name pre-cleans (`docker compose -p <name> down`) and recreates
+   that ONE stack, so you never pile up N named stacks. (Re-running the same name
+   while the prior kept stack is still live fails loudly with a duplicate-name
+   guard — another reason to keep to ONE name and tear down between fresh
+   builds.)
+
+2. **`--keep` is for intra-session reuse only, never a license to leak.** It
+   exists so a session-long stack survives between tests; if you pass `--keep`,
+   you OWN teardown at session end.
+
+3. **Tear down at session end.** When the session's work is done — and as part
+   of the Done criteria — tear down every stack the session created and release
+   its slot, using the survival-notice teardown command (printed at exit):
+
+   ```sh
+   docker compose -p <name> down --remove-orphans --volumes && rm -rf <run-dir> <slot-dir>
+   ```
+
+   `bin/showcase down` does NOT tear down an isolated stack — it only stops the
+   default (non-isolated) `showcase-*` project. Use the explicit
+   `docker compose -p <name> down …` from the notice (run-dir and slot-dir are
+   the real paths it prints). Bare `--isolate` (no `--keep`) auto-cleans on exit
+   and frees its slot — prefer it for one-off tests that don't need to persist
+   across the session.
+
+The teardown mechanics, the RUNNING-only slot protection, and the scratch/slot
+paths are documented once in [`DEBUGGING.md` → Cleanup](./DEBUGGING.md#cleanup);
+this section owns the discipline (reuse ONE, tear down at end).
+
 ## SOP: turning a cell red → green
 
 1. **Run the harness LOCALLY FIRST.** Capture the RED log via the production-equivalent


### PR DESCRIPTION
## What

Adds a **Session-stack discipline / Cleanup after isolated runs** subsection to `showcase/TESTING.md`, governing how `--isolate`/`--keep` is used across a debugging/testing session.

## Why

`--keep` correctly lets an `--isolate <name>` stack survive a run so it can be reused for a session-long test set. The leak was **agent discipline**, not the flag:

1. Agents minted a **new** named kept stack per individual cell instead of reusing ONE stack for the whole session — which is how Docker accumulated `cvtest2`, `greenproof`, `conformred`, `conformgreen`, `gp1`..`gp10`, `showcase-iso2/4`, etc.
2. When the session's work was done, the stacks it created were never torn down — each one holds a slot and offset ports until the host fills up.

## The discipline encoded

1. **One stack per session, reused** — choose ONE stable `--isolate <session-name> --keep` and reuse it for ALL tests in the session (derive the name from the primary slug, e.g. `--isolate <slug>-session`). Never mint a new named stack per cell/feature/pill.
2. **`--keep` is for intra-session reuse only, never a license to leak** — if you pass `--keep`, you OWN teardown at session end.
3. **Tear down at session end** — use the survival-notice command `docker compose -p <name> down --remove-orphans --volumes && rm -rf <run-dir> <slot-dir>`. `bin/showcase down` does NOT tear down isolated stacks (it only stops the default `showcase-*` project). Bare `--isolate` (no `--keep`) auto-cleans and is preferred for one-off tests.

Teardown mechanics live once in `DEBUGGING.md → Cleanup` (cross-linked); this section owns the discipline.

## Verification

This is a docs-only behavior change — no probe/Playwright/code red-green surface applies. Doc quality gates run instead:

- `oxfmt --check showcase/TESTING.md` → passes (the file was correctly formatted on `main`; the only formatter touch was `*new*` → `_new_`).
- Diff is purely additive (+49 lines, one file).
- Cross-link anchor `DEBUGGING.md#cleanup` verified against the `### Cleanup` heading.

The three harness facts the guidance relies on were verified by reading `scripts/cli/_common.sh`, `cmd-test.sh`, and `bin/showcase`: each `--keep` run claims a fresh slot + idempotent pre-down + brings the stack up (no attach); a same-name re-run against a still-live kept stack fails loudly on the duplicate-name guard; the exact teardown command matches the survival notice at `_common.sh:~1074`.

## Follow-up (not in this PR)

The harness could make this self-enforcing — e.g. warn when a session uses >1 distinct kept `--isolate` name, or add a `bin/showcase slots --reap-mine` convenience to tear down all stacks this user created. Noted for later; no harness changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
