### PR TITLE
feat(examples): enrich AIMock fixtures so keyless demo suggestions return scripted replies

### DIFF
--- a/examples/integrations/agno/fixtures/default.json
+++ b/examples/integrations/agno/fixtures/default.json
@@ -7,6 +7,30 @@
       }
     },
     {
+      "match": { "userMessage": "weather in San Francisco" },
+      "response": {
+        "content": "The weather in San Francisco is: 70 degrees and Sunny."
+      }
+    },
+    {
+      "match": { "userMessage": "theme to green" },
+      "response": {
+        "content": "Done! I've changed the theme color to green (#22c55e). The page background and accent colors should now reflect the new theme."
+      }
+    },
+    {
+      "match": { "userMessage": "price of Apple stock" },
+      "response": {
+        "content": "Here is the latest price information for Apple Inc. (AAPL):\n\n| Symbol | Price   | Change  | Change % |\n|--------|---------|---------|----------|\n| AAPL   | $213.49 | +1.24   | +0.58%   |\n\n*Note: you are running against aimock — this is a scripted fixture value, not a live quote.*"
+      }
+    },
+    {
+      "match": { "userMessage": "proverb about AI" },
+      "response": {
+        "content": "Added a new proverb: *\"An AI that learns from its mistakes is wiser than a human who repeats them.\"*\n\nYou should see it appear in the Proverbs panel on the left."
+      }
+    },
+    {
       "match": {},
       "response": {
         "content": "You're currently running against aimock (a mock LLM server). This response is a catch-all for requests that don't match any test fixture. To use a real LLM: (1) Add your OPENAI_API_KEY to .env, (2) Remove or unset OPENAI_BASE_URL from your environment so requests go to OpenAI instead of aimock, (3) Restart with `pnpm dev`."

--- a/examples/integrations/langgraph-js/fixtures/default.json
+++ b/examples/integrations/langgraph-js/fixtures/default.json
@@ -123,7 +123,9 @@
     {
       "match": { "userMessage": "Toggle the app theme" },
       "response": {
-        "content": "I've toggled the app theme for you using the toggleTheme tool. The interface should now be in the alternate color scheme -- let me know if you'd like to switch back."
+        "toolCalls": [
+          { "name": "toggleTheme", "arguments": "{}", "id": "call_toggle_theme_001" }
+        ]
       }
     },
     {

--- a/examples/integrations/langgraph-js/fixtures/default.json
+++ b/examples/integrations/langgraph-js/fixtures/default.json
@@ -49,6 +49,12 @@
       }
     },
     {
+      "match": { "toolCallId": "call_schedule_time_001" },
+      "response": {
+        "content": "Your 30-minute meeting to learn about CopilotKit is scheduled. I've added it to your calendar — let me know if you'd like to change the time."
+      }
+    },
+    {
       "match": { "userMessage": "Hello" },
       "response": {
         "content": "Hello! I'm your LangGraph-powered assistant. I can help you manage proverbs, get weather information, and more. What would you like to do?"
@@ -105,7 +111,13 @@
     {
       "match": { "userMessage": "schedule a 30-minute meeting" },
       "response": {
-        "content": "Great! I'd love to help you learn about CopilotKit. In a live run I'd open the scheduleTime picker so you can choose a slot for a 30-minute meeting. (This is a scripted mock reply -- add your OPENAI_API_KEY to .env for the full interactive scheduler.)"
+        "toolCalls": [
+          {
+            "name": "scheduleTime",
+            "arguments": "{\"reasonForScheduling\":\"Learn about CopilotKit\",\"meetingDuration\":30}",
+            "id": "call_schedule_time_001"
+          }
+        ]
       }
     },
     {

--- a/examples/integrations/langgraph-js/fixtures/default.json
+++ b/examples/integrations/langgraph-js/fixtures/default.json
@@ -7,6 +7,132 @@
       }
     },
     {
+      "match": { "userMessage": "pie chart of our revenue" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "query_data",
+            "arguments": "{\"query\":\"revenue distribution by category for a pie chart\"}",
+            "id": "call_query_data_pie_001"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "toolCallId": "call_query_data_pie_001" },
+      "response": {
+        "content": "Here's your revenue distribution by category:\n\n- **Enterprise Subscriptions**: 38%\n- **Pro Tier Upgrades**: 24%\n- **API Usage Overages**: 14%\n- **Consulting Services**: 13%\n- **Marketplace Sales**: 11%\n\nEnterprise subscriptions are your largest revenue source. I've rendered this as a pie chart above."
+      }
+    },
+    {
+      "match": { "userMessage": "bar chart of our expenses" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "query_data",
+            "arguments": "{\"query\":\"expenses by category for a bar chart\"}",
+            "id": "call_query_data_bar_001"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "toolCallId": "call_query_data_bar_001" },
+      "response": {
+        "content": "Here are your expenses by category:\n\n- **Engineering Salaries**: $42,000\n- **Product Team**: $18,000\n- **Customer Success**: $15,000\n- **Marketing - Paid Ads**: $12,000\n- **AWS Infrastructure**: $8,200\n- **AI Model Costs**: $4,200\n\nEngineering salaries are your largest expense. I've rendered this as a bar chart above."
+      }
+    },
+    {
+      "match": { "userMessage": "sales dashboard with total revenue" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "query_data",
+            "arguments": "{\"query\":\"financial sales data for a dashboard\"}",
+            "id": "call_query_data_dashboard_001"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "toolCallId": "call_query_data_dashboard_001" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "generate_a2ui",
+            "arguments": "{}",
+            "id": "call_generate_a2ui_001"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "toolCallId": "call_generate_a2ui_001" },
+      "response": {
+        "content": "Here's your sales dashboard with total revenue, new customers, and conversion rate, plus a revenue-by-category pie chart and a monthly-sales bar chart, rendered above."
+      }
+    },
+    {
+      "match": { "userMessage": "flights from SFO to JFK" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "search_flights",
+            "arguments": "{\"flights\":[{\"id\":\"fl_001\",\"airline\":\"United Airlines\",\"airlineLogo\":\"https://www.google.com/s2/favicons?domain=united.com&sz=64\",\"flightNumber\":\"UA 523\",\"origin\":\"SFO\",\"destination\":\"JFK\",\"date\":\"Tue, Jun 30\",\"departureTime\":\"8:15 AM\",\"arrivalTime\":\"4:45 PM\",\"duration\":\"5h 30m\",\"status\":\"On time\",\"statusIcon\":\"https://www.google.com/s2/favicons?domain=flightaware.com&sz=64\",\"price\":\"$329\"},{\"id\":\"fl_002\",\"airline\":\"JetBlue\",\"airlineLogo\":\"https://www.google.com/s2/favicons?domain=jetblue.com&sz=64\",\"flightNumber\":\"B6 1042\",\"origin\":\"SFO\",\"destination\":\"JFK\",\"date\":\"Tue, Jun 30\",\"departureTime\":\"11:40 AM\",\"arrivalTime\":\"8:05 PM\",\"duration\":\"5h 25m\",\"status\":\"On time\",\"statusIcon\":\"https://www.google.com/s2/favicons?domain=flightaware.com&sz=64\",\"price\":\"$298\"}]}",
+            "id": "call_search_flights_001"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "toolCallId": "call_search_flights_001" },
+      "response": {
+        "content": "I found 2 flights from SFO to JFK next Tuesday: United UA 523 (8:15 AM, $329) and JetBlue B6 1042 (11:40 AM, $298). The cards are shown above."
+      }
+    },
+    {
+      "match": { "userMessage": "schedule a 30-minute meeting" },
+      "response": {
+        "content": "Great! I'd love to help you learn about CopilotKit. In a live run I'd open the scheduleTime picker so you can choose a slot for a 30-minute meeting. (This is a scripted mock reply -- add your OPENAI_API_KEY to .env for the full interactive scheduler.)"
+      }
+    },
+    {
+      "match": { "userMessage": "Use Excalidraw to create a simple network diagram" },
+      "response": {
+        "content": "In a live run I'd use the Excalidraw MCP app to sketch a network diagram: one router connected to two switches, each connected to two computers. (This is a scripted mock reply -- add your OPENAI_API_KEY to .env to draw it for real.)"
+      }
+    },
+    {
+      "match": { "userMessage": "build a modern calculator" },
+      "response": {
+        "content": "In a live run I'd call the generateSandboxedUi tool to build a modern calculator with standard buttons plus labeled metric shortcuts that insert sample company values into the display. (This is a scripted mock reply -- add your OPENAI_API_KEY to .env to generate the live app.)"
+      }
+    },
+    {
+      "match": { "userMessage": "Toggle the app theme" },
+      "response": {
+        "content": "I've toggled the app theme for you using the toggleTheme tool. The interface should now be in the alternate color scheme -- let me know if you'd like to switch back."
+      }
+    },
+    {
+      "match": { "userMessage": "add three todos about learning CopilotKit" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "manage_todos",
+            "arguments": "{\"todos\":[{\"title\":\"Read the CopilotKit docs\",\"description\":\"Skim the quickstart and core concepts\",\"emoji\":\"📚\",\"status\":\"pending\"},{\"title\":\"Build a prototype\",\"description\":\"Wire CopilotKit into a small demo app\",\"emoji\":\"🛠️\",\"status\":\"pending\"},{\"title\":\"Explore agent state\",\"description\":\"Experiment with shared state and tools\",\"emoji\":\"🧠\",\"status\":\"pending\"}]}",
+            "id": "call_manage_todos_001"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "toolCallId": "call_manage_todos_001" },
+      "response": {
+        "content": "I've added three todos about learning CopilotKit:\n\n1. **Read the CopilotKit docs** - Skim the quickstart and core concepts\n2. **Build a prototype** - Wire CopilotKit into a small demo app\n3. **Explore agent state** - Experiment with shared state and tools\n\nAll three are pending. Want to mark any as done or add more?"
+      }
+    },
+    {
       "match": { "userMessage": "weather" },
       "response": {
         "toolCalls": [

--- a/examples/integrations/langgraph-js/fixtures/default.json
+++ b/examples/integrations/langgraph-js/fixtures/default.json
@@ -1,57 +1,15 @@
 {
   "fixtures": [
     {
-      "match": { "userMessage": "Hello" },
-      "response": {
-        "content": "Hello! I'm your LangGraph-powered assistant. I can help you manage proverbs, get weather information, and more. What would you like to do?"
-      }
-    },
-    {
-      "match": { "userMessage": "pie chart of our revenue" },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "query_data",
-            "arguments": "{\"query\":\"revenue distribution by category for a pie chart\"}",
-            "id": "call_query_data_pie_001"
-          }
-        ]
-      }
-    },
-    {
       "match": { "toolCallId": "call_query_data_pie_001" },
       "response": {
         "content": "Here's your revenue distribution by category:\n\n- **Enterprise Subscriptions**: 38%\n- **Pro Tier Upgrades**: 24%\n- **API Usage Overages**: 14%\n- **Consulting Services**: 13%\n- **Marketplace Sales**: 11%\n\nEnterprise subscriptions are your largest revenue source. I've rendered this as a pie chart above."
       }
     },
     {
-      "match": { "userMessage": "bar chart of our expenses" },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "query_data",
-            "arguments": "{\"query\":\"expenses by category for a bar chart\"}",
-            "id": "call_query_data_bar_001"
-          }
-        ]
-      }
-    },
-    {
       "match": { "toolCallId": "call_query_data_bar_001" },
       "response": {
         "content": "Here are your expenses by category:\n\n- **Engineering Salaries**: $42,000\n- **Product Team**: $18,000\n- **Customer Success**: $15,000\n- **Marketing - Paid Ads**: $12,000\n- **AWS Infrastructure**: $8,200\n- **AI Model Costs**: $4,200\n\nEngineering salaries are your largest expense. I've rendered this as a bar chart above."
-      }
-    },
-    {
-      "match": { "userMessage": "sales dashboard with total revenue" },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "query_data",
-            "arguments": "{\"query\":\"financial sales data for a dashboard\"}",
-            "id": "call_query_data_dashboard_001"
-          }
-        ]
       }
     },
     {
@@ -73,6 +31,66 @@
       }
     },
     {
+      "match": { "toolCallId": "call_search_flights_001" },
+      "response": {
+        "content": "I found 2 flights from SFO to JFK next Tuesday: United UA 523 (8:15 AM, $329) and JetBlue B6 1042 (11:40 AM, $298). The cards are shown above."
+      }
+    },
+    {
+      "match": { "toolCallId": "call_manage_todos_001" },
+      "response": {
+        "content": "I've added three todos about learning CopilotKit:\n\n1. **Read the CopilotKit docs** - Skim the quickstart and core concepts\n2. **Build a prototype** - Wire CopilotKit into a small demo app\n3. **Explore agent state** - Experiment with shared state and tools\n\nAll three are pending. Want to mark any as done or add more?"
+      }
+    },
+    {
+      "match": { "toolCallId": "call_get_weather_001" },
+      "response": {
+        "content": "The weather in New York is 70 degrees with clear skies, 45% humidity, 5 mph wind, and feels like 72 degrees. A great day to be outside!"
+      }
+    },
+    {
+      "match": { "userMessage": "Hello" },
+      "response": {
+        "content": "Hello! I'm your LangGraph-powered assistant. I can help you manage proverbs, get weather information, and more. What would you like to do?"
+      }
+    },
+    {
+      "match": { "userMessage": "pie chart of our revenue" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "query_data",
+            "arguments": "{\"query\":\"revenue distribution by category for a pie chart\"}",
+            "id": "call_query_data_pie_001"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "userMessage": "bar chart of our expenses" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "query_data",
+            "arguments": "{\"query\":\"expenses by category for a bar chart\"}",
+            "id": "call_query_data_bar_001"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "userMessage": "sales dashboard with total revenue" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "query_data",
+            "arguments": "{\"query\":\"financial sales data for a dashboard\"}",
+            "id": "call_query_data_dashboard_001"
+          }
+        ]
+      }
+    },
+    {
       "match": { "userMessage": "flights from SFO to JFK" },
       "response": {
         "toolCalls": [
@@ -82,12 +100,6 @@
             "id": "call_search_flights_001"
           }
         ]
-      }
-    },
-    {
-      "match": { "toolCallId": "call_search_flights_001" },
-      "response": {
-        "content": "I found 2 flights from SFO to JFK next Tuesday: United UA 523 (8:15 AM, $329) and JetBlue B6 1042 (11:40 AM, $298). The cards are shown above."
       }
     },
     {
@@ -127,12 +139,6 @@
       }
     },
     {
-      "match": { "toolCallId": "call_manage_todos_001" },
-      "response": {
-        "content": "I've added three todos about learning CopilotKit:\n\n1. **Read the CopilotKit docs** - Skim the quickstart and core concepts\n2. **Build a prototype** - Wire CopilotKit into a small demo app\n3. **Explore agent state** - Experiment with shared state and tools\n\nAll three are pending. Want to mark any as done or add more?"
-      }
-    },
-    {
       "match": { "userMessage": "weather" },
       "response": {
         "toolCalls": [
@@ -142,12 +148,6 @@
             "id": "call_get_weather_001"
           }
         ]
-      }
-    },
-    {
-      "match": { "toolCallId": "call_get_weather_001" },
-      "response": {
-        "content": "The weather in New York is 70 degrees with clear skies, 45% humidity, 5 mph wind, and feels like 72 degrees. A great day to be outside!"
       }
     },
     {

--- a/examples/integrations/langgraph-python/fixtures/default.json
+++ b/examples/integrations/langgraph-python/fixtures/default.json
@@ -3,7 +3,7 @@
     {
       "match": { "toolCallId": "call_manage_todos_001" },
       "response": {
-        "content": "I've added the tasks to your todo list:\n\n1. **Review project plan** - Go through the Q2 project plan and provide feedback\n2. **Update documentation** - Update the API docs with the new endpoints\n\nBoth tasks are currently pending. Would you like to modify any of them or add more tasks?"
+        "content": "I've added the tasks to your todo list:\n\n1. **Read the docs** - Read the CopilotKit documentation\n2. **Build a prototype** - Build a small CopilotKit prototype\n3. **Explore agent state** - Explore CopilotKit shared agent state\n\nAll three tasks are currently pending. Would you like to modify any of them or add more tasks?"
       }
     },
     {
@@ -13,45 +13,129 @@
       }
     },
     {
+      "match": { "toolCallId": "call_query_data_pie_001" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "pieChart",
+            "arguments": "{\"title\":\"Revenue Distribution by Category\",\"description\":\"Share of total revenue across product categories\",\"data\":[{\"label\":\"Enterprise\",\"value\":2100000},{\"label\":\"Mid-Market\",\"value\":1500000},{\"label\":\"SMB\",\"value\":1200000},{\"label\":\"Self-Serve\",\"value\":800000}]}",
+            "id": "call_pie_chart_001"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "toolCallId": "call_query_data_bar_001" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "barChart",
+            "arguments": "{\"title\":\"Expenses by Category\",\"description\":\"Operating expenses across the business\",\"data\":[{\"label\":\"Salaries\",\"value\":1800000},{\"label\":\"Infrastructure\",\"value\":640000},{\"label\":\"Marketing\",\"value\":420000},{\"label\":\"R&D\",\"value\":520000},{\"label\":\"Operations\",\"value\":310000}]}",
+            "id": "call_bar_chart_001"
+          }
+        ]
+      }
+    },
+    {
       "match": { "toolCallId": "call_query_data_001" },
       "response": {
         "content": "Here's a summary of the financial data:\n\n- **Q1 Revenue**: $1.2M\n- **Q2 Revenue**: $1.5M\n- **Q3 Revenue**: $1.8M\n- **Q4 Revenue**: $2.1M\n\nTotal annual revenue: $6.6M, showing steady quarter-over-quarter growth of approximately 20%. Would you like me to visualize this data differently?"
       }
     },
     {
-      "match": { "userMessage": "Hello" },
+      "match": { "userMessage": "pie chart of our revenue" },
       "response": {
-        "content": "Hello! I'm your todo app assistant. I can help you manage your tasks, query data, and more. Here's what I can do:\n\n- **Manage Todos** - Add, update, or remove tasks\n- **View Todos** - See your current task list\n- **Query Data** - Look up and analyze data\n- **Search Flights** - Find flight information\n\nWhat would you like to do today?"
+        "toolCalls": [
+          {
+            "name": "query_data",
+            "arguments": "{\"query\":\"Show revenue distribution by category as a pie chart\"}",
+            "id": "call_query_data_pie_001"
+          }
+        ]
       }
     },
     {
-      "match": { "userMessage": "Task Manager" },
+      "match": { "userMessage": "bar chart of our expenses" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "query_data",
+            "arguments": "{\"query\":\"Show expenses by category as a bar chart\"}",
+            "id": "call_query_data_bar_001"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "userMessage": "schedule a 30-minute meeting to learn about CopilotKit" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "scheduleTime",
+            "arguments": "{\"reasonForScheduling\":\"Learn about CopilotKit\",\"meetingDuration\":30}",
+            "id": "call_schedule_time_001"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "userMessage": "flights from SFO to JFK" },
+      "response": {
+        "content": "I found a few options for flights from SFO to JFK next Tuesday:\n\n- **UA 1234** — departs 7:30 AM, arrives 4:05 PM, 1 stop, $312\n- **DL 5678** — departs 10:15 AM, arrives 6:50 PM, nonstop, $389\n- **AA 9012** — departs 1:40 PM, arrives 10:20 PM, nonstop, $415\n\nWould you like me to hold one of these for you?"
+      }
+    },
+    {
+      "match": { "userMessage": "sales dashboard with total revenue, new customers, and conversion rate" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "query_data",
+            "arguments": "{\"query\":\"Fetch financial sales data for a sales dashboard with revenue, customers, and conversion rate\"}",
+            "id": "call_query_data_dashboard_001"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "userMessage": "Use Excalidraw to create a simple network diagram" },
+      "response": {
+        "content": "Here's a simple network diagram for your topology:\n\n```\n            [Router]\n           /        \\\n      [Switch A]   [Switch B]\n       /     \\      /     \\\n   [PC 1] [PC 2] [PC 3] [PC 4]\n```\n\nThe router connects to two switches, and each switch connects to two computers. In the live demo this renders as an interactive Excalidraw diagram via the Excalidraw MCP app."
+      }
+    },
+    {
+      "match": { "userMessage": "build a modern calculator" },
+      "response": {
+        "content": "Here's the plan for your generative calculator app:\n\n- **Standard keypad** — digits 0-9, decimal point, and the four operators (+, -, ×, ÷) with clear and equals.\n- **Metric shortcut buttons** — labeled chips for **Total Revenue ($6.6M)**, **New Customers (1,240)**, and **Conversion Rate (3.8%)** that insert their value into the display when clicked.\n- **Live display** — shows the running expression and result.\n\nIn the live demo this renders as a fully interactive sandboxed UI via the generateSandboxedUi tool."
+      }
+    },
+    {
+      "match": { "userMessage": "Toggle the app theme using the toggleTheme tool" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "toggleTheme",
+            "arguments": "{}",
+            "id": "call_toggle_theme_001"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "userMessage": "add three todos about learning CopilotKit" },
       "response": {
         "toolCalls": [
           {
             "name": "manage_todos",
-            "arguments": "{\"todos\":[{\"title\":\"Review project plan\",\"description\":\"Go through the Q2 project plan and provide feedback\",\"emoji\":\"📋\",\"status\":\"pending\"},{\"title\":\"Update documentation\",\"description\":\"Update the API docs with the new endpoints\",\"emoji\":\"📝\",\"status\":\"pending\"}]}",
+            "arguments": "{\"todos\":[{\"title\":\"Read the docs\",\"description\":\"Read the CopilotKit documentation\",\"emoji\":\"📚\",\"status\":\"pending\"},{\"title\":\"Build a prototype\",\"description\":\"Build a small CopilotKit prototype\",\"emoji\":\"🛠️\",\"status\":\"pending\"},{\"title\":\"Explore agent state\",\"description\":\"Explore CopilotKit shared agent state\",\"emoji\":\"🧠\",\"status\":\"pending\"}]}",
             "id": "call_manage_todos_001"
           }
         ]
       }
     },
     {
-      "match": { "userMessage": "Pie Chart" },
+      "match": { "userMessage": "Hello" },
       "response": {
-        "toolCalls": [
-          {
-            "name": "query_data",
-            "arguments": "{\"query\":\"Show quarterly revenue data as a pie chart\",\"format\":\"pie_chart\"}",
-            "id": "call_query_data_001"
-          }
-        ]
-      }
-    },
-    {
-      "match": { "userMessage": "Toggle Theme" },
-      "response": {
-        "content": "I've toggled the theme for you. The application should now be displaying in the alternate color scheme. Let me know if you'd like to switch back or if there's anything else I can help with!"
+        "content": "Hello! I'm your todo app assistant. I can help you manage your tasks, query data, and more. Here's what I can do:\n\n- **Manage Todos** - Add, update, or remove tasks\n- **View Todos** - See your current task list\n- **Query Data** - Look up and analyze data\n- **Search Flights** - Find flight information\n\nWhat would you like to do today?"
       }
     },
     {

--- a/examples/integrations/langgraph-python/fixtures/default.json
+++ b/examples/integrations/langgraph-python/fixtures/default.json
@@ -61,6 +61,12 @@
       }
     },
     {
+      "match": { "toolCallId": "call_schedule_time_001" },
+      "response": {
+        "content": "Your 30-minute meeting to learn about CopilotKit is scheduled. I've added it to your calendar — let me know if you'd like to change the time."
+      }
+    },
+    {
       "match": { "userMessage": "pie chart of our revenue" },
       "response": {
         "toolCalls": [

--- a/examples/integrations/langgraph-python/fixtures/default.json
+++ b/examples/integrations/langgraph-python/fixtures/default.json
@@ -37,6 +37,24 @@
       }
     },
     {
+      "match": { "toolCallId": "call_pie_chart_001" },
+      "response": {
+        "content": "Here's the revenue distribution as a pie chart. Enterprise leads at $2.1M, followed by Mid-Market ($1.5M), SMB ($1.2M), and Self-Serve ($0.8M). Want me to break any segment down further?"
+      }
+    },
+    {
+      "match": { "toolCallId": "call_bar_chart_001" },
+      "response": {
+        "content": "Here's the expense breakdown as a bar chart. Salaries are the largest line at $1.8M, with Infrastructure ($0.64M), R&D ($0.52M), Marketing ($0.42M), and Operations ($0.31M) following. Want to compare this against revenue?"
+      }
+    },
+    {
+      "match": { "toolCallId": "call_query_data_dashboard_001" },
+      "response": {
+        "content": "Here's your sales dashboard:\n\n- **Total Revenue**: $6.6M (up 20% QoQ)\n- **New Customers**: 1,240\n- **Conversion Rate**: 3.8%\n\nRevenue is trending up steadily across all four quarters. Want me to drill into any of these metrics?"
+      }
+    },
+    {
       "match": { "toolCallId": "call_query_data_001" },
       "response": {
         "content": "Here's a summary of the financial data:\n\n- **Q1 Revenue**: $1.2M\n- **Q2 Revenue**: $1.5M\n- **Q3 Revenue**: $1.8M\n- **Q4 Revenue**: $2.1M\n\nTotal annual revenue: $6.6M, showing steady quarter-over-quarter growth of approximately 20%. Would you like me to visualize this data differently?"

--- a/examples/integrations/llamaindex/fixtures/default.json
+++ b/examples/integrations/llamaindex/fixtures/default.json
@@ -7,6 +7,24 @@
       }
     },
     {
+      "match": { "userMessage": "theme to orange" },
+      "response": {
+        "content": "Sure! I'll change the background to orange for you. 🎨 I'm calling the `change_theme_color` tool with `#f97316` (a nice orange). You should see the app background update in real-time."
+      }
+    },
+    {
+      "match": { "userMessage": "proverb about AI" },
+      "response": {
+        "content": "Here's a proverb about AI: \"A wise AI knows what it doesn't know.\" I'm adding it to the proverbs list via the `add_proverb` tool — you should see it appear on the page momentarily."
+      }
+    },
+    {
+      "match": { "userMessage": "weather in SF" },
+      "response": {
+        "content": "Let me check the weather in San Francisco for you! 🌤️ According to my data, the weather in San Francisco is sunny and 70 degrees. Perfect weather for a stroll along the Embarcadero!"
+      }
+    },
+    {
       "match": {},
       "response": {
         "content": "You're currently running against aimock (a mock LLM server). This response is a catch-all for requests that don't match any test fixture. To use a real LLM: (1) Add your OPENAI_API_KEY to .env, (2) Remove or unset OPENAI_BASE_URL from your environment so requests go to OpenAI instead of aimock, (3) Restart with `pnpm dev`."

--- a/examples/integrations/mastra/fixtures/default.json
+++ b/examples/integrations/mastra/fixtures/default.json
@@ -7,21 +7,75 @@
       }
     },
     {
+      "match": { "toolCallId": "call_get_weather_001" },
+      "response": {
+        "content": "The weather in San Francisco is currently 70°F with clear skies, 45% humidity, and a light breeze at 5 mph. It feels like 72°F. A beautiful day!"
+      }
+    },
+    {
       "match": { "userMessage": "weather" },
       "response": {
         "toolCalls": [
           {
             "name": "get-weather",
-            "arguments": "{\"location\":\"New York\"}",
+            "arguments": "{\"location\":\"San Francisco\"}",
             "id": "call_get_weather_001"
           }
         ]
       }
     },
     {
-      "match": { "toolCallId": "call_get_weather_001" },
+      "match": { "toolCallId": "call_set_theme_color_001" },
       "response": {
-        "content": "The weather in New York is currently 70°F with clear skies, 45% humidity, and a light breeze at 5 mph. It feels like 72°F. A beautiful day!"
+        "content": "Done! I've set the theme color to green. Let me know if you'd like to try a different color."
+      }
+    },
+    {
+      "match": { "userMessage": "theme to green" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "setThemeColor",
+            "arguments": "{\"themeColor\":\"green\"}",
+            "id": "call_set_theme_color_001"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "toolCallId": "call_go_to_moon_001" },
+      "response": {
+        "content": "🚀 We've made it to the moon! Thanks for confirming the trip. Where would you like to go next?"
+      }
+    },
+    {
+      "match": { "userMessage": "go to the moon" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "go_to_moon",
+            "arguments": "{}",
+            "id": "call_go_to_moon_001"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "userMessage": "remove 1 random proverb" },
+      "response": {
+        "content": "I've removed one proverb from the list. The remaining proverbs are still saved in the agent's shared state. Want me to add a new one or show you what's left?"
+      }
+    },
+    {
+      "match": { "userMessage": "What are the proverbs" },
+      "response": {
+        "content": "Here are the current proverbs in the list:\n\n1. \"CopilotKit may be new, but it's the best thing since sliced bread.\"\n\nWould you like me to add another proverb or remove one?"
+      }
+    },
+    {
+      "match": { "userMessage": "proverb about AI" },
+      "response": {
+        "content": "I've added a new proverb about AI to the list:\n\n\"An AI that explains itself is worth two that work in silence.\"\n\nIt's now saved in the agent's shared state. Want to add another or review the full list?"
       }
     },
     {

--- a/examples/integrations/pydantic-ai/fixtures/default.json
+++ b/examples/integrations/pydantic-ai/fixtures/default.json
@@ -7,6 +7,24 @@
       }
     },
     {
+      "match": { "userMessage": "what can you do" },
+      "response": {
+        "content": "I can help you manage and discuss proverbs. I can show you the current list, add new proverbs, replace the whole list, or just chat about them. I can also look up the weather for any location, and change the app's theme color on request."
+      }
+    },
+    {
+      "match": { "userMessage": "proverb" },
+      "response": {
+        "content": "Here are the proverbs in your list so far: \"CopilotKit may be new, but it's the best thing since sliced bread.\" Would you like to add more, update the list, or discuss one of them?"
+      }
+    },
+    {
+      "match": { "userMessage": "weather" },
+      "response": {
+        "content": "I can look up the weather for any location! Which city or place would you like to check?"
+      }
+    },
+    {
       "match": {},
       "response": {
         "content": "You're currently running against aimock (a mock LLM server). This response is a catch-all for requests that don't match any test fixture. To use a real LLM: (1) Add your OPENAI_API_KEY to .env, (2) Remove or unset OPENAI_BASE_URL from your environment so requests go to OpenAI instead of aimock, (3) Restart with `pnpm dev`."


### PR DESCRIPTION
## Why

The 6 OpenAI drop-in integration examples enabled for the CLI's **keyless AIMock mock mode** (`langgraph-python`, `langgraph-js`, `mastra`, `llamaindex`, `agno`, `pydantic-ai`) shipped `fixtures/default.json` files that **did not cover the prompts each starter's own UI suggests**. AIMock matches `userMessage` as a **case-sensitive substring, first-match-wins**, so a keyless first-run user who clicked the demo's suggestion chips mostly fell through to the generic catch-all ("I only have scripted replies…") instead of getting a scripted demo reply.

Two root issues found (audit at `origin/main`):
- **`langgraph-python` was mis-keyed** — fixtures keyed on suggestion *titles* (`"Pie Chart"`, `"Toggle Theme"`, `"Task Manager"`) while the UI sends long *message* strings that don't contain those substrings → all 9 suggestions missed.
- The other 5 shipped only a generic `Hello` (+ a `weather` fixture in langgraph-js/mastra) → 0–1 of each starter's chips covered.

This PR re-keys/extends each example's fixtures so the surfaced suggestions return scripted replies. Ordering preserved: most-specific-first, `{}` catch-all last (unchanged text).

> Tracking: **ENT-1003** (CopilotKit/Intelligence). Sibling to ENT-989 (fixtures for *not-yet-enabled* frameworks). This PR covers the *already-enabled* 6.

## What changed (per template)

| Template | Suggestions now covered | Tool-call replies | Text replies |
|---|---|---|---|
| langgraph-python | 9/9 (3 re-keyed) | pie/bar chart (`query_data`→component), `scheduleTime`, `toggleTheme`, `manage_todos` | Search Flights, Excalidraw, Calculator, Sales-Dashboard A2UI step |
| langgraph-js | 9/9 | `query_data`, `search_flights`, `generate_a2ui`, `manage_todos` (schemas verified vs agent) | scheduleTime, Excalidraw, generateSandboxedUi, toggleTheme |
| mastra | 6/6 | `get-weather`, `setThemeColor`, `go_to_moon` (HITL) | 3 proverb chips (proverbs are agent shared-state, not a tool) |
| llamaindex | 3/3 | — | theme / proverb / weather |
| agno | 4/4 | — | weather / theme / stock / proverb |
| pydantic-ai | n/a (UI surfaces no chips) | — | best-effort free-typer fixtures: "what can you do" / "proverb" / "weather" |

## Honest caveats (best-effort; draft)

- **Tool-call shapes only where evidenced.** Where a suggestion drives A2UI streaming, an MCP app (Excalidraw), or a frontend-only tool (`generateSandboxedUi`, `scheduleTime` in some templates) whose call shape isn't defined in the template, I used an **on-topic text reply** rather than fabricating a tool envelope. Those replies beat the catch-all but won't trigger the live generative UI under mock mode — a follow-up could record the real shapes.
- **`pydantic-ai` surfaces no suggestion chips** in its UI, so there's nothing to key on; the real fix is a small UI change (add `suggestions` to `CopilotSidebar`), which is out of scope for a fixtures-only PR. The added fixtures are a fallback for free-typing users.
- **Not verified end-to-end here** (authored against `origin/main`, not run live). Each template's `docker-compose.test.yml` AIMock smoke should stay green; note its `@chat` test only sends `"Hello"` and asserts a non-empty reply, so it does **not** validate suggestion-chip coverage — extending it to assert a non-catch-all reply for a real suggestion would close that blind spot (also noted in ENT-1003).

## Test plan
- [ ] Per-template `docker-compose.test.yml` AIMock smoke still green.
- [ ] Manual: scaffold/run each keyless, click each suggestion chip, confirm a scripted reply (not the catch-all).