### PR TITLE
feat(bot): anonymous oss.bot.* usage telemetry (adoption funnel)

### DIFF
--- a/packages/bot/src/create-bot.ts
+++ b/packages/bot/src/create-bot.ts
@@ -40,6 +40,22 @@ import {
 import { Transcripts } from "./transcripts.js";
 import type { Identity, TranscriptsConfig } from "./transcripts.js";
 import type { StandardSchemaV1, InferSchemaOutput } from "./standard-schema.js";
+import { BotTelemetry } from "./telemetry/bot-telemetry.js";
+import { errorClass } from "./telemetry/sanitize-error.js";
+import { createRequire } from "node:module";
+
+const pkg = createRequire(import.meta.url)("../package.json") as {
+  name: string;
+  version: string;
+};
+
+function storeKind(s: StateStore): "memory" | "postgres" | "redis" | "custom" {
+  const n = s.constructor?.name;
+  if (n === "MemoryStore") return "memory";
+  if (n === "PostgresStore") return "postgres";
+  if (n === "RedisStore") return "redis";
+  return "custom";
+}
 
 /** Platforms whose tokens the emoji table can normalize. */
 const EMOJI_PLATFORMS: ReadonlySet<EmojiPlatform> = new Set([
@@ -249,6 +265,11 @@ export function createBot<
   }
 
   const backend: StateStore = cfg.adapter ?? new MemoryStore();
+  const telemetry = new BotTelemetry({
+    backend,
+    packageName: pkg.name,
+    packageVersion: pkg.version,
+  });
   const transcripts = new Transcripts(backend, cfg.transcripts ?? {});
   const registry = new ActionRegistry({
     store: opts.actionStore ?? kvActionStore(backend),
@@ -327,6 +348,7 @@ export function createBot<
       transcripts,
       userKey: extras?.userKey,
       message: extras?.message,
+      telemetry,
     };
     return new Thread(deps);
   }
@@ -710,14 +732,36 @@ export function createBot<
       const startResults = await Promise.allSettled(
         opts.adapters.map((a) => a.start(makeSink(a))),
       );
+      const startedPlatforms: string[] = [];
+      const failedPlatforms: string[] = [];
       startResults.forEach((r, i) => {
+        const platform = opts.adapters[i]!.platform;
         if (r.status === "rejected") {
+          failedPlatforms.push(platform);
           console.error(
-            `[bot] adapter "${opts.adapters[i]!.platform}" failed to start:`,
+            `[bot] adapter "${platform}" failed to start:`,
             r.reason,
           );
+          telemetry.capture("oss.bot.start_failed", {
+            platform,
+            errorClass: errorClass(r.reason),
+          });
+        } else {
+          startedPlatforms.push(platform);
         }
       });
+      if (startedPlatforms.length > 0) {
+        telemetry.capture("oss.bot.started", {
+          platforms: startedPlatforms,
+          startedCount: startedPlatforms.length,
+          failedCount: failedPlatforms.length,
+          hasMentionHandler: mentionHandlers.length > 0,
+          hasMessageHandler: messageHandlers.length > 0,
+          interruptHandlers: interruptHandlers.size,
+          commandsCount: commandHandlers.size,
+          toolsCount: toolMap.size,
+        });
+      }
       // Hand declared commands to adapters that register them up front (e.g.
       // Discord); adapters without `registerCommands` are skipped. Per-adapter
       // failures are isolated the same way as start().
@@ -752,5 +796,17 @@ export function createBot<
       });
     },
   };
+  telemetry.capture("oss.bot.configured", {
+    platforms: opts.adapters.map((a) => a.platform),
+    adapterCount: opts.adapters.length,
+    store: storeKind(backend),
+    hasComponents: (opts.components?.length ?? 0) > 0,
+    componentsCount: opts.components?.length ?? 0,
+    toolsCount: toolMap.size,
+    commandsCount: commandHandlers.size,
+    contextCount: context.length,
+    transcripts: !!cfg.transcripts,
+    identity: !!cfg.identity,
+  });
   return bot;
 }

--- a/packages/bot/src/create-bot.ts
+++ b/packages/bot/src/create-bot.ts
@@ -41,7 +41,7 @@ import { Transcripts } from "./transcripts.js";
 import type { Identity, TranscriptsConfig } from "./transcripts.js";
 import type { StandardSchemaV1, InferSchemaOutput } from "./standard-schema.js";
 import { BotTelemetry } from "./telemetry/bot-telemetry.js";
-import { errorClass } from "./telemetry/sanitize-error.js";
+import { errorClass, normalizePlatform } from "./telemetry/sanitize-error.js";
 import { createRequire } from "node:module";
 
 const pkg = createRequire(import.meta.url)("../package.json") as {
@@ -735,11 +735,13 @@ export function createBot<
       const startedPlatforms: string[] = [];
       const failedPlatforms: string[] = [];
       startResults.forEach((r, i) => {
-        const platform = opts.adapters[i]!.platform;
+        const rawPlatform = opts.adapters[i]!.platform;
+        // Raw label for the human-facing log; normalized label for telemetry.
+        const platform = normalizePlatform(rawPlatform);
         if (r.status === "rejected") {
           failedPlatforms.push(platform);
           console.error(
-            `[bot] adapter "${platform}" failed to start:`,
+            `[bot] adapter "${rawPlatform}" failed to start:`,
             r.reason,
           );
           telemetry.capture("oss.bot.start_failed", {
@@ -797,7 +799,7 @@ export function createBot<
     },
   };
   telemetry.capture("oss.bot.configured", {
-    platforms: opts.adapters.map((a) => a.platform),
+    platforms: opts.adapters.map((a) => normalizePlatform(a.platform)),
     adapterCount: opts.adapters.length,
     store: storeKind(backend),
     hasComponents: (opts.components?.length ?? 0) > 0,

--- a/packages/bot/src/run-loop.test.ts
+++ b/packages/bot/src/run-loop.test.ts
@@ -90,4 +90,57 @@ describe("runAgentLoop", () => {
     expect(agent.runAgentCalls).toBe(1);
     expect(agent.messages.some((m) => m.role === "tool")).toBe(false);
   });
+
+  it("returns interrupted=true and an iteration count when the agent interrupts", async () => {
+    const renderer = makeFakeRunRenderer();
+    const tools = new Map<string, BotTool>();
+    const handleInterrupt = vi.fn<(i: CapturedInterrupt) => void>();
+
+    const agent = new FakeAgent([
+      (sub: AgentSubscriber) => {
+        sub.onCustomEvent?.({
+          event: { name: "on_interrupt", value: { q: 1 } },
+        } as never);
+        sub.onRunFinishedEvent?.({ event: {} } as never);
+      },
+    ]);
+
+    const args = {
+      agent,
+      renderer,
+      tools,
+      toolDescriptors,
+      context,
+      makeToolCtx: () => ({ thread: {} as never, platform: "fake" }),
+      handleInterrupt,
+    };
+
+    const result = await runAgentLoop(args);
+    expect(result.interrupted).toBe(true);
+    expect(result.iterations).toBeGreaterThanOrEqual(1);
+  });
+
+  it("returns interrupted=false on a normal completion", async () => {
+    const renderer = makeFakeRunRenderer();
+    const tools = new Map<string, BotTool>();
+
+    const agent = new FakeAgent([
+      (sub: AgentSubscriber) => {
+        sub.onRunFinishedEvent?.({ event: {} } as never);
+      },
+    ]);
+
+    const args = {
+      agent,
+      renderer,
+      tools,
+      toolDescriptors,
+      context,
+      makeToolCtx: () => ({ thread: {} as never, platform: "fake" }),
+    };
+
+    const result = await runAgentLoop(args);
+    expect(result.interrupted).toBe(false);
+    expect(result.iterations).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/packages/bot/src/run-loop.ts
+++ b/packages/bot/src/run-loop.ts
@@ -37,7 +37,9 @@ export interface RunLoopArgs {
  * and returns immediately ("ack-first") — `thread.resume` re-enters later
  * with `initialResume` set.
  */
-export async function runAgentLoop(args: RunLoopArgs): Promise<void> {
+export async function runAgentLoop(
+  args: RunLoopArgs,
+): Promise<{ iterations: number; interrupted: boolean }> {
   const {
     agent,
     renderer,
@@ -66,19 +68,20 @@ export async function runAgentLoop(args: RunLoopArgs): Promise<void> {
         renderer.subscriber,
       );
     }
-    if (isAborted?.()) return;
+    if (isAborted?.()) return { iterations: i + 1, interrupted: false };
 
     const pending = renderer.getPendingInterrupt();
     if (pending) {
       renderer.clearPendingInterrupt();
       if (handleInterrupt) await handleInterrupt(pending);
-      return; // ack-first: picker posted; thread.resume re-enters later
+      // ack-first: picker posted; thread.resume re-enters later
+      return { iterations: i + 1, interrupted: true };
     }
 
     const calls = renderer
       .getCapturedToolCalls()
       .filter((c) => tools.has(c.toolCallName) && !executed.has(c.toolCallId));
-    if (calls.length === 0) return;
+    if (calls.length === 0) return { iterations: i + 1, interrupted: false };
 
     ensureAssistantToolCallMessage(agent, calls);
     for (const call of calls) {
@@ -105,6 +108,7 @@ export async function runAgentLoop(args: RunLoopArgs): Promise<void> {
       executed.add(call.toolCallId);
     }
   }
+  return { iterations: maxIterations, interrupted: false };
 }
 
 /**

--- a/packages/bot/src/telemetry/bot-telemetry.test.ts
+++ b/packages/bot/src/telemetry/bot-telemetry.test.ts
@@ -3,37 +3,56 @@ import { BotTelemetry, BOT_TELEMETRY_EVENTS } from "./bot-telemetry.js";
 import { MemoryStore } from "../state/memory-store.js";
 
 const tick = () => new Promise((r) => setTimeout(r, 0));
-const base = { backend: new MemoryStore(), packageName: "@copilotkit/bot", packageVersion: "0.0.3" };
+const base = {
+  backend: new MemoryStore(),
+  packageName: "@copilotkit/bot",
+  packageVersion: "0.0.3",
+};
 
 describe("BotTelemetry", () => {
-	it("sends event with anonymous_id + bot_session_id in global_properties", async () => {
-		const send = vi.fn().mockResolvedValue(undefined);
-		const t = new BotTelemetry({ ...base, disabled: false, send, sessionId: "S1", resolveId: async () => "ANON" });
-		t.capture("oss.bot.configured", { platforms: ["slack"] });
-		await tick();
-		expect(send).toHaveBeenCalledTimes(1);
-		const arg = send.mock.calls[0]![0];
-		expect(arg.event).toBe("oss.bot.configured");
-		expect(arg.properties).toEqual({ platforms: ["slack"] });
-		expect(arg.globalProperties.anonymous_id).toBe("ANON");
-		expect(arg.globalProperties.bot_session_id).toBe("S1");
-	});
-	it("is a no-op when disabled", async () => {
-		const send = vi.fn();
-		const t = new BotTelemetry({ ...base, disabled: true, send });
-		t.capture("oss.bot.started", {});
-		await tick();
-		expect(send).not.toHaveBeenCalled();
-	});
-	it("never throws when send rejects", async () => {
-		const send = vi.fn().mockRejectedValue(new Error("boom"));
-		const t = new BotTelemetry({ ...base, disabled: false, send, resolveId: async () => "X" });
-		expect(() => t.capture("oss.bot.agent_run", {})).not.toThrow();
-		await tick();
-	});
-	it("exposes the five event names", () => {
-		expect([...BOT_TELEMETRY_EVENTS].sort()).toEqual(
-			["oss.bot.agent_run", "oss.bot.agent_run_failed", "oss.bot.configured", "oss.bot.start_failed", "oss.bot.started"]
-		);
-	});
+  it("sends event with anonymous_id + bot_session_id in global_properties", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const t = new BotTelemetry({
+      ...base,
+      disabled: false,
+      send,
+      sessionId: "S1",
+      resolveId: async () => "ANON",
+    });
+    t.capture("oss.bot.configured", { platforms: ["slack"] });
+    await tick();
+    expect(send).toHaveBeenCalledTimes(1);
+    const arg = send.mock.calls[0]![0];
+    expect(arg.event).toBe("oss.bot.configured");
+    expect(arg.properties).toEqual({ platforms: ["slack"] });
+    expect(arg.globalProperties.anonymous_id).toBe("ANON");
+    expect(arg.globalProperties.bot_session_id).toBe("S1");
+  });
+  it("is a no-op when disabled", async () => {
+    const send = vi.fn();
+    const t = new BotTelemetry({ ...base, disabled: true, send });
+    t.capture("oss.bot.started", {});
+    await tick();
+    expect(send).not.toHaveBeenCalled();
+  });
+  it("never throws when send rejects", async () => {
+    const send = vi.fn().mockRejectedValue(new Error("boom"));
+    const t = new BotTelemetry({
+      ...base,
+      disabled: false,
+      send,
+      resolveId: async () => "X",
+    });
+    expect(() => t.capture("oss.bot.agent_run", {})).not.toThrow();
+    await tick();
+  });
+  it("exposes the five event names", () => {
+    expect([...BOT_TELEMETRY_EVENTS].sort()).toEqual([
+      "oss.bot.agent_run",
+      "oss.bot.agent_run_failed",
+      "oss.bot.configured",
+      "oss.bot.start_failed",
+      "oss.bot.started",
+    ]);
+  });
 });

--- a/packages/bot/src/telemetry/bot-telemetry.test.ts
+++ b/packages/bot/src/telemetry/bot-telemetry.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { BotTelemetry, BOT_TELEMETRY_EVENTS } from "./bot-telemetry.js";
+import { MemoryStore } from "../state/memory-store.js";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+const base = { backend: new MemoryStore(), packageName: "@copilotkit/bot", packageVersion: "0.0.3" };
+
+describe("BotTelemetry", () => {
+	it("sends event with anonymous_id + bot_session_id in global_properties", async () => {
+		const send = vi.fn().mockResolvedValue(undefined);
+		const t = new BotTelemetry({ ...base, disabled: false, send, sessionId: "S1", resolveId: async () => "ANON" });
+		t.capture("oss.bot.configured", { platforms: ["slack"] });
+		await tick();
+		expect(send).toHaveBeenCalledTimes(1);
+		const arg = send.mock.calls[0]![0];
+		expect(arg.event).toBe("oss.bot.configured");
+		expect(arg.properties).toEqual({ platforms: ["slack"] });
+		expect(arg.globalProperties.anonymous_id).toBe("ANON");
+		expect(arg.globalProperties.bot_session_id).toBe("S1");
+	});
+	it("is a no-op when disabled", async () => {
+		const send = vi.fn();
+		const t = new BotTelemetry({ ...base, disabled: true, send });
+		t.capture("oss.bot.started", {});
+		await tick();
+		expect(send).not.toHaveBeenCalled();
+	});
+	it("never throws when send rejects", async () => {
+		const send = vi.fn().mockRejectedValue(new Error("boom"));
+		const t = new BotTelemetry({ ...base, disabled: false, send, resolveId: async () => "X" });
+		expect(() => t.capture("oss.bot.agent_run", {})).not.toThrow();
+		await tick();
+	});
+	it("exposes the five event names", () => {
+		expect([...BOT_TELEMETRY_EVENTS].sort()).toEqual(
+			["oss.bot.agent_run", "oss.bot.agent_run_failed", "oss.bot.configured", "oss.bot.start_failed", "oss.bot.started"]
+		);
+	});
+});

--- a/packages/bot/src/telemetry/bot-telemetry.ts
+++ b/packages/bot/src/telemetry/bot-telemetry.ts
@@ -1,0 +1,87 @@
+import { lambdaClient, isTelemetryDisabled } from "@copilotkit/shared";
+import type { LambdaSendOptions } from "@copilotkit/shared";
+import type { StateStore } from "../state/state-store.js";
+import { resolveInstallId } from "./install-id.js";
+
+export const BOT_TELEMETRY_EVENTS = [
+	"oss.bot.configured",
+	"oss.bot.started",
+	"oss.bot.start_failed",
+	"oss.bot.agent_run",
+	"oss.bot.agent_run_failed",
+] as const;
+export type BotTelemetryEvent = (typeof BOT_TELEMETRY_EVENTS)[number];
+
+export function isTestEnv(): boolean {
+	const env = process.env as Record<string, string | undefined>;
+	return env.NODE_ENV === "test" || !!env.VITEST || !!env.JEST_WORKER_ID;
+}
+
+export function resolveEnvironment(): string {
+	const e = (process.env.NODE_ENV ?? "").toLowerCase();
+	if (e === "production" || e === "development" || e === "test") return e;
+	return "unknown";
+}
+
+export interface BotTelemetryOptions {
+	backend: StateStore;
+	packageName: string;
+	packageVersion: string;
+	environment?: string;
+	disabled?: boolean;
+	sessionId?: string;
+	send?: (o: LambdaSendOptions) => Promise<void>;
+	resolveId?: () => Promise<string>;
+}
+
+export class BotTelemetry {
+	private readonly disabled: boolean;
+	private readonly sendFn: (o: LambdaSendOptions) => Promise<void>;
+	private readonly sessionId: string;
+	private readonly environment: string;
+	private readonly resolveId: () => Promise<string>;
+	private idPromise?: Promise<string>;
+	private static disclosed = false;
+
+	constructor(private readonly opts: BotTelemetryOptions) {
+		this.disabled = opts.disabled ?? (isTelemetryDisabled() || isTestEnv());
+		this.sendFn = opts.send ?? lambdaClient.send;
+		this.sessionId = opts.sessionId ?? globalThis.crypto.randomUUID();
+		this.environment = opts.environment ?? resolveEnvironment();
+		this.resolveId = opts.resolveId ?? (() => resolveInstallId({ backend: opts.backend }));
+	}
+
+	capture(event: BotTelemetryEvent, properties: Record<string, unknown>): void {
+		if (this.disabled) return;
+		this.disclose();
+		void this.dispatch(event, properties);
+	}
+
+	private disclose(): void {
+		if (BotTelemetry.disclosed) return;
+		BotTelemetry.disclosed = true;
+		console.info(
+			"[CopilotKit Bot] anonymous telemetry enabled — see https://docs.copilotkit.ai/telemetry to opt out (set COPILOTKIT_TELEMETRY_DISABLED=true).",
+		);
+	}
+
+	private async dispatch(event: BotTelemetryEvent, properties: Record<string, unknown>): Promise<void> {
+		try {
+			this.idPromise ??= this.resolveId();
+			const anonymous_id = await this.idPromise;
+			await this.sendFn({
+				event,
+				properties,
+				globalProperties: {
+					anonymous_id,
+					bot_session_id: this.sessionId,
+					environment: this.environment,
+				},
+				packageName: this.opts.packageName,
+				packageVersion: this.opts.packageVersion,
+			});
+		} catch {
+			/* best-effort: telemetry must not break the host app */
+		}
+	}
+}

--- a/packages/bot/src/telemetry/bot-telemetry.ts
+++ b/packages/bot/src/telemetry/bot-telemetry.ts
@@ -4,84 +4,88 @@ import type { StateStore } from "../state/state-store.js";
 import { resolveInstallId } from "./install-id.js";
 
 export const BOT_TELEMETRY_EVENTS = [
-	"oss.bot.configured",
-	"oss.bot.started",
-	"oss.bot.start_failed",
-	"oss.bot.agent_run",
-	"oss.bot.agent_run_failed",
+  "oss.bot.configured",
+  "oss.bot.started",
+  "oss.bot.start_failed",
+  "oss.bot.agent_run",
+  "oss.bot.agent_run_failed",
 ] as const;
 export type BotTelemetryEvent = (typeof BOT_TELEMETRY_EVENTS)[number];
 
 export function isTestEnv(): boolean {
-	const env = process.env as Record<string, string | undefined>;
-	return env.NODE_ENV === "test" || !!env.VITEST || !!env.JEST_WORKER_ID;
+  const env = process.env as Record<string, string | undefined>;
+  return env.NODE_ENV === "test" || !!env.VITEST || !!env.JEST_WORKER_ID;
 }
 
 export function resolveEnvironment(): string {
-	const e = (process.env.NODE_ENV ?? "").toLowerCase();
-	if (e === "production" || e === "development" || e === "test") return e;
-	return "unknown";
+  const e = (process.env.NODE_ENV ?? "").toLowerCase();
+  if (e === "production" || e === "development" || e === "test") return e;
+  return "unknown";
 }
 
 export interface BotTelemetryOptions {
-	backend: StateStore;
-	packageName: string;
-	packageVersion: string;
-	environment?: string;
-	disabled?: boolean;
-	sessionId?: string;
-	send?: (o: LambdaSendOptions) => Promise<void>;
-	resolveId?: () => Promise<string>;
+  backend: StateStore;
+  packageName: string;
+  packageVersion: string;
+  environment?: string;
+  disabled?: boolean;
+  sessionId?: string;
+  send?: (o: LambdaSendOptions) => Promise<void>;
+  resolveId?: () => Promise<string>;
 }
 
 export class BotTelemetry {
-	private readonly disabled: boolean;
-	private readonly sendFn: (o: LambdaSendOptions) => Promise<void>;
-	private readonly sessionId: string;
-	private readonly environment: string;
-	private readonly resolveId: () => Promise<string>;
-	private idPromise?: Promise<string>;
-	private static disclosed = false;
+  private readonly disabled: boolean;
+  private readonly sendFn: (o: LambdaSendOptions) => Promise<void>;
+  private readonly sessionId: string;
+  private readonly environment: string;
+  private readonly resolveId: () => Promise<string>;
+  private idPromise?: Promise<string>;
+  private static disclosed = false;
 
-	constructor(private readonly opts: BotTelemetryOptions) {
-		this.disabled = opts.disabled ?? (isTelemetryDisabled() || isTestEnv());
-		this.sendFn = opts.send ?? lambdaClient.send;
-		this.sessionId = opts.sessionId ?? globalThis.crypto.randomUUID();
-		this.environment = opts.environment ?? resolveEnvironment();
-		this.resolveId = opts.resolveId ?? (() => resolveInstallId({ backend: opts.backend }));
-	}
+  constructor(private readonly opts: BotTelemetryOptions) {
+    this.disabled = opts.disabled ?? (isTelemetryDisabled() || isTestEnv());
+    this.sendFn = opts.send ?? lambdaClient.send;
+    this.sessionId = opts.sessionId ?? globalThis.crypto.randomUUID();
+    this.environment = opts.environment ?? resolveEnvironment();
+    this.resolveId =
+      opts.resolveId ?? (() => resolveInstallId({ backend: opts.backend }));
+  }
 
-	capture(event: BotTelemetryEvent, properties: Record<string, unknown>): void {
-		if (this.disabled) return;
-		this.disclose();
-		void this.dispatch(event, properties);
-	}
+  capture(event: BotTelemetryEvent, properties: Record<string, unknown>): void {
+    if (this.disabled) return;
+    this.disclose();
+    void this.dispatch(event, properties);
+  }
 
-	private disclose(): void {
-		if (BotTelemetry.disclosed) return;
-		BotTelemetry.disclosed = true;
-		console.info(
-			"[CopilotKit Bot] anonymous telemetry enabled — see https://docs.copilotkit.ai/telemetry to opt out (set COPILOTKIT_TELEMETRY_DISABLED=true).",
-		);
-	}
+  private disclose(): void {
+    if (BotTelemetry.disclosed) return;
+    BotTelemetry.disclosed = true;
+    console.info(
+      "[CopilotKit Bot] anonymous telemetry enabled — see https://docs.copilotkit.ai/telemetry to opt out (set COPILOTKIT_TELEMETRY_DISABLED=true).",
+    );
+  }
 
-	private async dispatch(event: BotTelemetryEvent, properties: Record<string, unknown>): Promise<void> {
-		try {
-			this.idPromise ??= this.resolveId();
-			const anonymous_id = await this.idPromise;
-			await this.sendFn({
-				event,
-				properties,
-				globalProperties: {
-					anonymous_id,
-					bot_session_id: this.sessionId,
-					environment: this.environment,
-				},
-				packageName: this.opts.packageName,
-				packageVersion: this.opts.packageVersion,
-			});
-		} catch {
-			/* best-effort: telemetry must not break the host app */
-		}
-	}
+  private async dispatch(
+    event: BotTelemetryEvent,
+    properties: Record<string, unknown>,
+  ): Promise<void> {
+    try {
+      this.idPromise ??= this.resolveId();
+      const anonymous_id = await this.idPromise;
+      await this.sendFn({
+        event,
+        properties,
+        globalProperties: {
+          anonymous_id,
+          bot_session_id: this.sessionId,
+          environment: this.environment,
+        },
+        packageName: this.opts.packageName,
+        packageVersion: this.opts.packageVersion,
+      });
+    } catch {
+      /* best-effort: telemetry must not break the host app */
+    }
+  }
 }

--- a/packages/bot/src/telemetry/create-bot-telemetry.test.ts
+++ b/packages/bot/src/telemetry/create-bot-telemetry.test.ts
@@ -32,7 +32,7 @@ describe("createBot telemetry wiring", () => {
     });
     const call = capture.mock.calls.find((c) => c[0] === "oss.bot.configured");
     expect(call).toBeDefined();
-    expect(call![1].platforms).toEqual(["fake"]);
+    expect(call![1].platforms).toEqual(["custom"]); // FakeAdapter.platform "fake" → normalized
     expect(call![1].store).toBe("memory");
     expect(call![1].hasComponents).toBe(true);
   });
@@ -73,7 +73,7 @@ describe("createBot telemetry wiring", () => {
     await tick();
     const run = capture.mock.calls.find((c) => c[0] === "oss.bot.agent_run");
     expect(run).toBeDefined();
-    expect(run![1].platform).toBe("fake");
+    expect(run![1].platform).toBe("custom"); // "fake" → normalized
     expect(typeof run![1].durationMs).toBe("number");
     expect(run![1].interrupted).toBe(false);
   });

--- a/packages/bot/src/telemetry/create-bot-telemetry.test.ts
+++ b/packages/bot/src/telemetry/create-bot-telemetry.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const capture = vi.fn();
+vi.mock("./bot-telemetry.js", () => ({
+  // A `function` (not an arrow) so `new BotTelemetry(...)` in create-bot.ts is
+  // constructible under vitest's mock — an arrow implementation throws
+  // "is not a constructor".
+  BotTelemetry: vi.fn().mockImplementation(function () {
+    return { capture };
+  }),
+  BOT_TELEMETRY_EVENTS: [],
+}));
+
+import { createBot } from "../create-bot.js";
+import { FakeAdapter } from "../testing/fake-adapter.js";
+import { FakeAgent } from "../testing/fake-agent.js";
+import { Section } from "@copilotkit/bot-ui";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+describe("createBot telemetry wiring", () => {
+  beforeEach(() => capture.mockClear());
+
+  it("emits oss.bot.configured with a config snapshot", () => {
+    createBot({
+      adapters: [new FakeAdapter()],
+      components: [
+        function Card() {
+          return Section({ children: "x" });
+        },
+      ],
+    });
+    const call = capture.mock.calls.find((c) => c[0] === "oss.bot.configured");
+    expect(call).toBeDefined();
+    expect(call![1].platforms).toEqual(["fake"]);
+    expect(call![1].store).toBe("memory");
+    expect(call![1].hasComponents).toBe(true);
+  });
+
+  it("emits oss.bot.started on start, start_failed (category only) on a throwing adapter", async () => {
+    const ok = new FakeAdapter();
+    const bot = createBot({ adapters: [ok] });
+    await bot.start();
+    expect(
+      capture.mock.calls.find((c) => c[0] === "oss.bot.started")?.[1]
+        .startedCount,
+    ).toBe(1);
+
+    capture.mockClear();
+    const bad = new FakeAdapter();
+    bad.start = () =>
+      Promise.reject(
+        Object.assign(new Error("xoxb-SECRET token bad"), { code: "EAUTH" }),
+      );
+    const bot2 = createBot({ adapters: [bad] });
+    await bot2.start();
+    const f = capture.mock.calls.find((c) => c[0] === "oss.bot.start_failed");
+    expect(f).toBeDefined();
+    expect(f![1].errorClass).toBe("auth");
+    expect(JSON.stringify(f![1])).not.toContain("SECRET");
+  });
+
+  it("emits oss.bot.agent_run on a successful run", async () => {
+    const fake = new FakeAdapter();
+    const bot = createBot({ adapters: [fake], agent: () => new FakeAgent() });
+    bot.onMention(async ({ thread }) => {
+      await thread.runAgent();
+    });
+    await bot.start();
+    capture.mockClear();
+    fake.emitTurn({ userText: "hi", conversationKey: "c1" });
+    await tick();
+    await tick();
+    const run = capture.mock.calls.find((c) => c[0] === "oss.bot.agent_run");
+    expect(run).toBeDefined();
+    expect(run![1].platform).toBe("fake");
+    expect(typeof run![1].durationMs).toBe("number");
+    expect(run![1].interrupted).toBe(false);
+  });
+});

--- a/packages/bot/src/telemetry/e2e-telemetry.test.ts
+++ b/packages/bot/src/telemetry/e2e-telemetry.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// vi.hoisted so the spy exists before the hoisted vi.mock factory runs
+// (otherwise "Cannot access 'sendSpy' before initialization").
+const { sendSpy } = vi.hoisted(() => ({
+  sendSpy: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@copilotkit/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@copilotkit/shared")>();
+  return { ...actual, lambdaClient: { send: sendSpy } };
+});
+
+import { createBot } from "../create-bot.js";
+import { FakeAdapter } from "../testing/fake-adapter.js";
+import { FakeAgent } from "../testing/fake-agent.js";
+
+const waitFor = async (pred: () => boolean, ms = 1000) => {
+  const start = Date.now();
+  while (!pred() && Date.now() - start < ms)
+    await new Promise((r) => setTimeout(r, 10));
+};
+
+describe("oss.bot.* end-to-end (real BotTelemetry, only network boundary stubbed)", () => {
+  const saved = { ...process.env };
+  beforeEach(() => {
+    sendSpy.mockClear();
+    // Enable telemetry: clear the test-runner suppressors + any opt-out.
+    delete process.env.VITEST;
+    delete process.env.JEST_WORKER_ID;
+    delete process.env.COPILOTKIT_TELEMETRY_DISABLED;
+    delete process.env.DO_NOT_TRACK;
+    process.env.NODE_ENV = "production";
+    // Deliberately set NO COPILOTKIT_TELEMETRY_URL / license / API key — zero-config.
+  });
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  it("flows configured -> started -> agent_run with anonymous_id + bot_session_id and no env config", async () => {
+    const fake = new FakeAdapter();
+    const bot = createBot({ adapters: [fake], agent: () => new FakeAgent() });
+    bot.onMention(async ({ thread }) => {
+      await thread.runAgent();
+    });
+    await bot.start();
+    fake.emitTurn({ userText: "hi", conversationKey: "c1" });
+
+    await waitFor(() =>
+      sendSpy.mock.calls.some((c) => c[0].event === "oss.bot.agent_run"),
+    );
+
+    const events = sendSpy.mock.calls.map((c) => c[0].event);
+    expect(events).toContain("oss.bot.configured");
+    expect(events).toContain("oss.bot.started");
+    expect(events).toContain("oss.bot.agent_run");
+    for (const [arg] of sendSpy.mock.calls) {
+      expect(typeof arg.globalProperties.anonymous_id).toBe("string");
+      expect(typeof arg.globalProperties.bot_session_id).toBe("string");
+      expect(arg.licenseToken).toBeUndefined(); // anonymous: no license ever attached
+    }
+    const run = sendSpy.mock.calls.find(
+      (c) => c[0].event === "oss.bot.agent_run",
+    )![0];
+    expect(run.properties.platform).toBe("fake");
+    expect(typeof run.properties.durationMs).toBe("number");
+  });
+});

--- a/packages/bot/src/telemetry/e2e-telemetry.test.ts
+++ b/packages/bot/src/telemetry/e2e-telemetry.test.ts
@@ -61,7 +61,7 @@ describe("oss.bot.* end-to-end (real BotTelemetry, only network boundary stubbed
     const run = sendSpy.mock.calls.find(
       (c) => c[0].event === "oss.bot.agent_run",
     )![0];
-    expect(run.properties.platform).toBe("fake");
+    expect(run.properties.platform).toBe("custom"); // "fake" → normalized
     expect(typeof run.properties.durationMs).toBe("number");
   });
 });

--- a/packages/bot/src/telemetry/events-catalog.test.ts
+++ b/packages/bot/src/telemetry/events-catalog.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from "vitest";
+import catalog from "../../telemetry-events.json" with { type: "json" };
+import { BOT_TELEMETRY_EVENTS } from "./bot-telemetry.js";
+
+describe("telemetry-events.json", () => {
+	it("documents exactly the emitted events", () => {
+		expect(Object.keys(catalog.events).sort()).toEqual([...BOT_TELEMETRY_EVENTS].sort());
+	});
+});

--- a/packages/bot/src/telemetry/events-catalog.test.ts
+++ b/packages/bot/src/telemetry/events-catalog.test.ts
@@ -3,7 +3,9 @@ import catalog from "../../telemetry-events.json" with { type: "json" };
 import { BOT_TELEMETRY_EVENTS } from "./bot-telemetry.js";
 
 describe("telemetry-events.json", () => {
-	it("documents exactly the emitted events", () => {
-		expect(Object.keys(catalog.events).sort()).toEqual([...BOT_TELEMETRY_EVENTS].sort());
-	});
+  it("documents exactly the emitted events", () => {
+    expect(Object.keys(catalog.events).sort()).toEqual(
+      [...BOT_TELEMETRY_EVENTS].sort(),
+    );
+  });
 });

--- a/packages/bot/src/telemetry/install-id.test.ts
+++ b/packages/bot/src/telemetry/install-id.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveInstallId } from "./install-id.js";
+import { MemoryStore } from "../state/memory-store.js";
+import type { StateStore } from "../state/state-store.js";
+
+class FakeDurableStore implements StateStore {
+  map = new Map<string, unknown>();
+  kv = {
+    get: async <T>(k: string) => this.map.get(k) as T | undefined,
+    set: async <T>(k: string, v: T) => void this.map.set(k, v),
+    delete: async (k: string) => void this.map.delete(k),
+  };
+  list = {} as StateStore["list"];
+  lock = {} as StateStore["lock"];
+  dedup = {} as StateStore["dedup"];
+  queue = {} as StateStore["queue"];
+}
+
+describe("resolveInstallId", () => {
+  it("persists + reuses in a durable store", async () => {
+    const backend = new FakeDurableStore();
+    const a = await resolveInstallId({ backend });
+    const b = await resolveInstallId({ backend });
+    expect(a).toBe(b);
+    expect(backend.map.get("cpk:telemetry:install_id")).toBe(a);
+  });
+  it("persists + reuses in a file for MemoryStore", async () => {
+    const cacheDir = mkdtempSync(join(tmpdir(), "cpk-"));
+    const backend = new MemoryStore();
+    const a = await resolveInstallId({ backend, cacheDir });
+    const b = await resolveInstallId({ backend, cacheDir });
+    expect(a).toBe(b);
+  });
+  it("falls back to a uuid when the file dir is unwritable", async () => {
+    const backend = new MemoryStore();
+    const id = await resolveInstallId({
+      backend,
+      cacheDir: "/dev/null/nope",
+      uuid: () => "FALLBACK",
+    });
+    expect(id).toBe("FALLBACK");
+  });
+});

--- a/packages/bot/src/telemetry/install-id.ts
+++ b/packages/bot/src/telemetry/install-id.ts
@@ -1,0 +1,50 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { MemoryStore } from "../state/memory-store.js";
+import type { StateStore } from "../state/state-store.js";
+
+const STORE_KEY = "cpk:telemetry:install_id";
+const FILE_NAME = "telemetry-id";
+const defaultUuid = () => globalThis.crypto.randomUUID();
+const defaultCacheDir = () =>
+  join(process.cwd(), "node_modules", ".cache", "copilotkit");
+
+export interface ResolveInstallIdDeps {
+  backend: StateStore;
+  cacheDir?: string;
+  uuid?: () => string;
+}
+
+export async function resolveInstallId(
+  deps: ResolveInstallIdDeps,
+): Promise<string> {
+  const uuid = deps.uuid ?? defaultUuid;
+  if (!(deps.backend instanceof MemoryStore)) {
+    try {
+      const existing = await deps.backend.kv.get<string>(STORE_KEY);
+      if (existing) return existing;
+      const id = uuid();
+      await deps.backend.kv.set(STORE_KEY, id);
+      return id;
+    } catch {
+      /* fall through */
+    }
+  }
+  try {
+    const dir = deps.cacheDir ?? defaultCacheDir();
+    const file = join(dir, FILE_NAME);
+    try {
+      const existing = readFileSync(file, "utf8").trim();
+      if (existing) return existing;
+    } catch {
+      /* not created yet */
+    }
+    mkdirSync(dir, { recursive: true });
+    const id = uuid();
+    writeFileSync(file, id, "utf8");
+    return id;
+  } catch {
+    /* fall through */
+  }
+  return uuid();
+}

--- a/packages/bot/src/telemetry/platform-allowlist-coverage.test.ts
+++ b/packages/bot/src/telemetry/platform-allowlist-coverage.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { normalizePlatform } from "./sanitize-error.js";
+
+// Monorepo invariant: every official bot adapter's `platform` label must be in
+// normalizePlatform()'s allow-list, otherwise a newly-added adapter's events
+// silently bucket to "custom" and we lose its per-platform telemetry signal.
+//
+// We can't import the adapter packages (they depend on @copilotkit/bot, not the
+// reverse), so we discover them by scanning sibling bot-* packages on disk. This
+// runs only in the monorepo (tests aren't published), which is exactly where the
+// drift would be introduced.
+
+// packages/bot/src/telemetry/ -> packages/
+const packagesDir = fileURLToPath(new URL("../../../", import.meta.url));
+
+function discoverAdapterPlatforms(): { pkg: string; platform: string }[] {
+  const found: { pkg: string; platform: string }[] = [];
+  for (const entry of readdirSync(packagesDir)) {
+    if (!entry.startsWith("bot-")) continue;
+    // Adapter packages declare `readonly platform = "x"` in src/adapter.ts;
+    // non-adapter bot-* packages (bot-ui, bot-store-*) have no such file/field.
+    const adapterFile = join(packagesDir, entry, "src", "adapter.ts");
+    if (!existsSync(adapterFile)) continue;
+    const src = readFileSync(adapterFile, "utf8");
+    const m = src.match(/readonly\s+platform\s*=\s*["']([^"']+)["']/);
+    if (m) found.push({ pkg: entry, platform: m[1]! });
+  }
+  return found;
+}
+
+describe("normalizePlatform allow-list coverage (monorepo invariant)", () => {
+  it("covers every official bot adapter's declared platform", () => {
+    const discovered = discoverAdapterPlatforms();
+    // Guard against a broken scan path silently passing: we ship at least
+    // slack/discord/telegram/whatsapp.
+    expect(
+      discovered.length,
+      `expected to discover the official bot adapters under ${packagesDir}`,
+    ).toBeGreaterThanOrEqual(4);
+
+    const missing = discovered.filter(
+      ({ platform }) => normalizePlatform(platform) !== platform,
+    );
+    expect(
+      missing,
+      `These adapter platforms are NOT in normalizePlatform's allow-list, so their ` +
+        `telemetry would bucket to "custom". Add them to KNOWN_PLATFORMS in ` +
+        `packages/bot/src/telemetry/sanitize-error.ts: ` +
+        missing.map((m) => `"${m.platform}" (${m.pkg})`).join(", "),
+    ).toEqual([]);
+  });
+});

--- a/packages/bot/src/telemetry/sanitize-error.test.ts
+++ b/packages/bot/src/telemetry/sanitize-error.test.ts
@@ -7,6 +7,7 @@ describe("normalizePlatform", () => {
     expect(normalizePlatform("discord")).toBe("discord");
     expect(normalizePlatform("telegram")).toBe("telegram");
     expect(normalizePlatform("whatsapp")).toBe("whatsapp");
+    expect(normalizePlatform("teams")).toBe("teams");
     // Free-form / custom adapter labels must not leak through.
     expect(normalizePlatform("acme-internal-tenant")).toBe("custom");
     expect(normalizePlatform("fake")).toBe("custom");

--- a/packages/bot/src/telemetry/sanitize-error.test.ts
+++ b/packages/bot/src/telemetry/sanitize-error.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { errorClass } from "./sanitize-error.js";
+
+describe("errorClass", () => {
+  it("never leaks the error message", () => {
+    const err = new Error("postgres://user:s3cret@db/prod failed");
+    const out = errorClass(err);
+    expect(out).not.toContain("s3cret");
+    expect(["auth", "network", "timeout", "validation", "unknown"]).toContain(
+      out,
+    );
+  });
+  it("categorizes by name/code", () => {
+    expect(
+      errorClass(
+        new (class extends Error {
+          name = "AbortError";
+        })(),
+      ),
+    ).toBe("timeout");
+    expect(
+      errorClass(Object.assign(new Error("x"), { code: "ENOTFOUND" })),
+    ).toBe("network");
+    expect(
+      errorClass(
+        new (class extends Error {
+          name = "ZodError";
+        })(),
+      ),
+    ).toBe("validation");
+    expect(errorClass("plain string")).toBe("unknown");
+  });
+});

--- a/packages/bot/src/telemetry/sanitize-error.test.ts
+++ b/packages/bot/src/telemetry/sanitize-error.test.ts
@@ -1,5 +1,18 @@
 import { describe, it, expect } from "vitest";
-import { errorClass } from "./sanitize-error.js";
+import { errorClass, normalizePlatform } from "./sanitize-error.js";
+
+describe("normalizePlatform", () => {
+  it("passes through known platforms and buckets the rest as custom", () => {
+    expect(normalizePlatform("slack")).toBe("slack");
+    expect(normalizePlatform("discord")).toBe("discord");
+    expect(normalizePlatform("telegram")).toBe("telegram");
+    expect(normalizePlatform("whatsapp")).toBe("whatsapp");
+    // Free-form / custom adapter labels must not leak through.
+    expect(normalizePlatform("acme-internal-tenant")).toBe("custom");
+    expect(normalizePlatform("fake")).toBe("custom");
+    expect(normalizePlatform("")).toBe("custom");
+  });
+});
 
 describe("errorClass", () => {
   it("never leaks the error message", () => {

--- a/packages/bot/src/telemetry/sanitize-error.ts
+++ b/packages/bot/src/telemetry/sanitize-error.ts
@@ -13,3 +13,12 @@ export function errorClass(err: unknown): string {
   if (/zod|valid|schema|parse/.test(hay)) return "validation";
   return "unknown";
 }
+
+// `Adapter.platform` is a free-form string an adapter author sets, so a custom
+// third-party adapter could put a tenant/project name there. Bound it to the
+// known platforms and bucket everything else as "custom" — prevents leaking
+// caller-chosen labels and caps telemetry cardinality.
+const KNOWN_PLATFORMS = new Set(["slack", "discord", "telegram", "whatsapp"]);
+export function normalizePlatform(platform: string): string {
+  return KNOWN_PLATFORMS.has(platform) ? platform : "custom";
+}

--- a/packages/bot/src/telemetry/sanitize-error.ts
+++ b/packages/bot/src/telemetry/sanitize-error.ts
@@ -1,0 +1,15 @@
+// Map an arbitrary thrown value to a bounded, non-identifying category.
+// NEVER returns the error message or stack — only a fixed-cardinality label.
+export function errorClass(err: unknown): string {
+  const e = err as { name?: unknown; code?: unknown } | null;
+  const name = typeof e?.name === "string" ? e.name : "";
+  const code = typeof e?.code === "string" ? e.code : "";
+  const hay = `${name} ${code}`.toLowerCase();
+  if (/abort|timeout|etimedout|deadline/.test(hay)) return "timeout";
+  if (/network|fetch|econn|enotfound|socket|dns|epipe/.test(hay))
+    return "network";
+  if (/auth|unauthorized|forbidden|token|credential|401|403/.test(hay))
+    return "auth";
+  if (/zod|valid|schema|parse/.test(hay)) return "validation";
+  return "unknown";
+}

--- a/packages/bot/src/telemetry/sanitize-error.ts
+++ b/packages/bot/src/telemetry/sanitize-error.ts
@@ -18,7 +18,13 @@ export function errorClass(err: unknown): string {
 // third-party adapter could put a tenant/project name there. Bound it to the
 // known platforms and bucket everything else as "custom" — prevents leaking
 // caller-chosen labels and caps telemetry cardinality.
-const KNOWN_PLATFORMS = new Set(["slack", "discord", "telegram", "whatsapp"]);
+const KNOWN_PLATFORMS = new Set([
+  "slack",
+  "discord",
+  "telegram",
+  "whatsapp",
+  "teams",
+]);
 export function normalizePlatform(platform: string): string {
   return KNOWN_PLATFORMS.has(platform) ? platform : "custom";
 }

--- a/packages/bot/src/thread.ts
+++ b/packages/bot/src/thread.ts
@@ -12,6 +12,7 @@ import type {
   EphemeralResult,
 } from "@copilotkit/bot-ui";
 import { runAgentLoop } from "./run-loop.js";
+import { errorClass } from "./telemetry/sanitize-error.js";
 import type { Transcripts } from "./transcripts.js";
 import { toAgentToolDescriptors } from "./tools.js";
 import type {
@@ -55,6 +56,13 @@ export interface ThreadDeps {
   userKey?: string;
   /** The inbound message that triggered this turn (for transcript bridging). */
   message?: IncomingMessage;
+  /**
+   * Optional anonymous telemetry sink. Structural type (not the concrete
+   * BotTelemetry) avoids an import cycle; the real BotTelemetry satisfies it.
+   */
+  telemetry?: {
+    capture(event: string, properties: Record<string, unknown>): void;
+  };
 }
 
 /** A concrete conversation thread: posts UI, runs the agent loop, and resolves HITL waiters. */
@@ -394,21 +402,41 @@ export class Thread implements ThreadInterface {
     // assistant messages this run produced (step 4).
     const messagesBefore = session.agent.messages.length;
 
-    await runAgentLoop({
-      agent: session.agent,
-      renderer,
-      tools,
-      toolDescriptors,
-      context,
-      makeToolCtx: (): BotToolContext => ({
-        thread: this,
+    const startedAt = Date.now();
+    let loopResult: { iterations: number; interrupted: boolean };
+    try {
+      loopResult = await runAgentLoop({
+        agent: session.agent,
+        renderer,
+        tools,
+        toolDescriptors,
+        context,
+        makeToolCtx: (): BotToolContext => ({
+          thread: this,
+          platform: this.platform,
+        }),
+        handleInterrupt: async (interrupt) => {
+          const h = this.deps.interruptHandlers.get(interrupt.eventName);
+          if (h) await h({ payload: interrupt.value, thread: this });
+        },
+        initialResume,
+      });
+    } catch (err) {
+      // Tool-handler errors are swallowed inside the loop and returned as JSON
+      // results, so a throw here is an agent-level failure.
+      this.deps.telemetry?.capture("oss.bot.agent_run_failed", {
         platform: this.platform,
-      }),
-      handleInterrupt: async (interrupt) => {
-        const h = this.deps.interruptHandlers.get(interrupt.eventName);
-        if (h) await h({ payload: interrupt.value, thread: this });
-      },
-      initialResume,
+        errorClass: errorClass(err),
+        stage: "agent",
+      });
+      throw err;
+    }
+    this.deps.telemetry?.capture("oss.bot.agent_run", {
+      platform: this.platform,
+      durationMs: Date.now() - startedAt,
+      toolCallCount: renderer.getCapturedToolCalls().length,
+      iterations: loopResult.iterations,
+      interrupted: loopResult.interrupted,
     });
     // Transcript auto-bridge (step 4): capture the assistant text this run
     // produced and append it. Only when the bridge actually applied (transcripts

--- a/packages/bot/src/thread.ts
+++ b/packages/bot/src/thread.ts
@@ -12,7 +12,7 @@ import type {
   EphemeralResult,
 } from "@copilotkit/bot-ui";
 import { runAgentLoop } from "./run-loop.js";
-import { errorClass } from "./telemetry/sanitize-error.js";
+import { errorClass, normalizePlatform } from "./telemetry/sanitize-error.js";
 import type { Transcripts } from "./transcripts.js";
 import { toAgentToolDescriptors } from "./tools.js";
 import type {
@@ -404,6 +404,11 @@ export class Thread implements ThreadInterface {
 
     const startedAt = Date.now();
     let loopResult: { iterations: number; interrupted: boolean };
+    // Telemetry stage: "agent" while the run loop runs, "finalize" for the
+    // transcript-append + renderer.finish() steps below. A throw in either is
+    // reported as agent_run_failed (with the right stage) instead of being
+    // hidden behind an already-sent success event.
+    let stage: "agent" | "finalize" = "agent";
     try {
       loopResult = await runAgentLoop({
         agent: session.agent,
@@ -421,51 +426,55 @@ export class Thread implements ThreadInterface {
         },
         initialResume,
       });
+      stage = "finalize";
+      // Transcript auto-bridge (step 4): capture the assistant text this run
+      // produced and append it. Only when the bridge actually applied (transcripts
+      // + userKey both present and `transcript` was requested).
+      if (extra?.transcript && transcripts && userKey) {
+        const produced = session.agent.messages.slice(messagesBefore);
+        const text = produced
+          .filter(
+            (m) =>
+              m.role === "assistant" &&
+              typeof m.content === "string" &&
+              m.content.trim().length > 0,
+          )
+          .map((m) => m.content as string)
+          .join("\n\n");
+        if (text.length > 0) {
+          await transcripts.append(
+            this,
+            { role: "assistant", text },
+            { userKey },
+          );
+        }
+      }
+
+      // Turn-end hook: lets a renderer finalize any turn-scoped resource it kept
+      // open across runAgent iterations (e.g. a native streaming message). A
+      // no-op for renderers whose per-message streams already self-terminate, and
+      // for runs that were interrupted (the renderer guards that internally).
+      await renderer.finish?.();
     } catch (err) {
-      // Tool-handler errors are swallowed inside the loop and returned as JSON
-      // results, so a throw here is an agent-level failure.
+      // A throw is a run failure — in the agent loop (tool-handler errors are
+      // swallowed inside the loop, so a throw is agent-level) or in finalization.
+      // `stage` distinguishes the two.
       this.deps.telemetry?.capture("oss.bot.agent_run_failed", {
-        platform: this.platform,
+        platform: normalizePlatform(this.platform),
         errorClass: errorClass(err),
-        stage: "agent",
+        stage,
       });
       throw err;
     }
+    // Emit success ONLY after the loop AND finalization both completed, so a
+    // late transcript/finish rejection can never follow a success event.
     this.deps.telemetry?.capture("oss.bot.agent_run", {
-      platform: this.platform,
+      platform: normalizePlatform(this.platform),
       durationMs: Date.now() - startedAt,
       toolCallCount: renderer.getCapturedToolCalls().length,
       iterations: loopResult.iterations,
       interrupted: loopResult.interrupted,
     });
-    // Transcript auto-bridge (step 4): capture the assistant text this run
-    // produced and append it. Only when the bridge actually applied (transcripts
-    // + userKey both present and `transcript` was requested).
-    if (extra?.transcript && transcripts && userKey) {
-      const produced = session.agent.messages.slice(messagesBefore);
-      const text = produced
-        .filter(
-          (m) =>
-            m.role === "assistant" &&
-            typeof m.content === "string" &&
-            m.content.trim().length > 0,
-        )
-        .map((m) => m.content as string)
-        .join("\n\n");
-      if (text.length > 0) {
-        await transcripts.append(
-          this,
-          { role: "assistant", text },
-          { userKey },
-        );
-      }
-    }
-
-    // Turn-end hook: lets a renderer finalize any turn-scoped resource it kept
-    // open across runAgent iterations (e.g. a native streaming message). A
-    // no-op for renderers whose per-message streams already self-terminate, and
-    // for runs that were interrupted (the renderer guards that internally).
-    await renderer.finish?.();
     return undefined;
   }
 }

--- a/packages/bot/telemetry-events.json
+++ b/packages/bot/telemetry-events.json
@@ -1,14 +1,62 @@
 {
-	"global_properties": {
-		"anonymous_id": "Persisted per-install UUID (durable store -> project-local cache file -> per-process).",
-		"bot_session_id": "Random UUID minted per createBot() call.",
-		"environment": "development | production | test | unknown"
-	},
-	"events": {
-		"oss.bot.configured": { "description": "createBot() returned; repeats per process start.", "properties": { "platforms": "string[]", "adapterCount": "number", "store": "memory|postgres|redis|custom", "hasComponents": "boolean", "componentsCount": "number", "toolsCount": "number", "commandsCount": "number", "contextCount": "number", "transcripts": "boolean", "identity": "boolean" } },
-		"oss.bot.started": { "description": "bot.start() connected at least one adapter.", "properties": { "platforms": "string[]", "startedCount": "number", "failedCount": "number", "hasMentionHandler": "boolean", "hasMessageHandler": "boolean", "interruptHandlers": "number", "commandsCount": "number", "toolsCount": "number" } },
-		"oss.bot.start_failed": { "description": "An adapter threw during start().", "properties": { "platform": "string", "errorClass": "auth|network|timeout|validation|unknown" } },
-		"oss.bot.agent_run": { "description": "A successful agent invocation completed. Note: an interrupt->resume turn emits two agent_run events (interrupted:true at the ack-first return, then interrupted:false after resume); filter interrupted===false to count completed runs.", "properties": { "platform": "string", "durationMs": "number", "toolCallCount": "number", "iterations": "number", "interrupted": "boolean" } },
-		"oss.bot.agent_run_failed": { "description": "An agent run errored.", "properties": { "platform": "string", "errorClass": "auth|network|timeout|validation|unknown", "stage": "agent" } }
-	}
+  "global_properties": {
+    "anonymous_id": "Persisted per-install UUID (durable store -> project-local cache file -> per-process).",
+    "bot_session_id": "Random UUID minted per createBot() call.",
+    "environment": "development | production | test | unknown"
+  },
+  "events": {
+    "oss.bot.configured": {
+      "description": "createBot() returned; repeats per process start.",
+      "properties": {
+        "platforms": "string[]",
+        "adapterCount": "number",
+        "store": "memory|postgres|redis|custom",
+        "hasComponents": "boolean",
+        "componentsCount": "number",
+        "toolsCount": "number",
+        "commandsCount": "number",
+        "contextCount": "number",
+        "transcripts": "boolean",
+        "identity": "boolean"
+      }
+    },
+    "oss.bot.started": {
+      "description": "bot.start() connected at least one adapter.",
+      "properties": {
+        "platforms": "string[]",
+        "startedCount": "number",
+        "failedCount": "number",
+        "hasMentionHandler": "boolean",
+        "hasMessageHandler": "boolean",
+        "interruptHandlers": "number",
+        "commandsCount": "number",
+        "toolsCount": "number"
+      }
+    },
+    "oss.bot.start_failed": {
+      "description": "An adapter threw during start().",
+      "properties": {
+        "platform": "string",
+        "errorClass": "auth|network|timeout|validation|unknown"
+      }
+    },
+    "oss.bot.agent_run": {
+      "description": "A successful agent invocation completed. Note: an interrupt->resume turn emits two agent_run events (interrupted:true at the ack-first return, then interrupted:false after resume); filter interrupted===false to count completed runs.",
+      "properties": {
+        "platform": "string",
+        "durationMs": "number",
+        "toolCallCount": "number",
+        "iterations": "number",
+        "interrupted": "boolean"
+      }
+    },
+    "oss.bot.agent_run_failed": {
+      "description": "An agent run errored.",
+      "properties": {
+        "platform": "string",
+        "errorClass": "auth|network|timeout|validation|unknown",
+        "stage": "agent"
+      }
+    }
+  }
 }

--- a/packages/bot/telemetry-events.json
+++ b/packages/bot/telemetry-events.json
@@ -8,7 +8,7 @@
     "oss.bot.configured": {
       "description": "createBot() returned; repeats per process start.",
       "properties": {
-        "platforms": "string[] (each normalized: slack|discord|telegram|whatsapp|custom)",
+        "platforms": "string[] (each normalized: slack|discord|telegram|whatsapp|teams|custom)",
         "adapterCount": "number",
         "store": "memory|postgres|redis|custom",
         "hasComponents": "boolean",
@@ -23,7 +23,7 @@
     "oss.bot.started": {
       "description": "bot.start() connected at least one adapter.",
       "properties": {
-        "platforms": "string[] (each normalized: slack|discord|telegram|whatsapp|custom)",
+        "platforms": "string[] (each normalized: slack|discord|telegram|whatsapp|teams|custom)",
         "startedCount": "number",
         "failedCount": "number",
         "hasMentionHandler": "boolean",
@@ -36,14 +36,14 @@
     "oss.bot.start_failed": {
       "description": "An adapter threw during start().",
       "properties": {
-        "platform": "string (normalized: slack|discord|telegram|whatsapp|custom)",
+        "platform": "string (normalized: slack|discord|telegram|whatsapp|teams|custom)",
         "errorClass": "auth|network|timeout|validation|unknown"
       }
     },
     "oss.bot.agent_run": {
       "description": "A successful agent invocation completed (emitted after the run loop AND finalization/transcript steps succeed). Note: an interrupt->resume turn emits two agent_run events (interrupted:true at the ack-first return, then interrupted:false after resume); filter interrupted===false to count completed runs.",
       "properties": {
-        "platform": "string (normalized: slack|discord|telegram|whatsapp|custom)",
+        "platform": "string (normalized: slack|discord|telegram|whatsapp|teams|custom)",
         "durationMs": "number",
         "toolCallCount": "number",
         "iterations": "number",
@@ -53,7 +53,7 @@
     "oss.bot.agent_run_failed": {
       "description": "An agent run errored. Emitted instead of agent_run; stage=agent for run-loop failures, stage=finalize for transcript-append/renderer-finish failures after the loop.",
       "properties": {
-        "platform": "string (normalized: slack|discord|telegram|whatsapp|custom)",
+        "platform": "string (normalized: slack|discord|telegram|whatsapp|teams|custom)",
         "errorClass": "auth|network|timeout|validation|unknown",
         "stage": "agent|finalize"
       }

--- a/packages/bot/telemetry-events.json
+++ b/packages/bot/telemetry-events.json
@@ -1,0 +1,14 @@
+{
+	"global_properties": {
+		"anonymous_id": "Persisted per-install UUID (durable store -> project-local cache file -> per-process).",
+		"bot_session_id": "Random UUID minted per createBot() call.",
+		"environment": "development | production | test | unknown"
+	},
+	"events": {
+		"oss.bot.configured": { "description": "createBot() returned; repeats per process start.", "properties": { "platforms": "string[]", "adapterCount": "number", "store": "memory|postgres|redis|custom", "hasComponents": "boolean", "componentsCount": "number", "toolsCount": "number", "commandsCount": "number", "contextCount": "number", "transcripts": "boolean", "identity": "boolean" } },
+		"oss.bot.started": { "description": "bot.start() connected at least one adapter.", "properties": { "platforms": "string[]", "startedCount": "number", "failedCount": "number", "hasMentionHandler": "boolean", "hasMessageHandler": "boolean", "interruptHandlers": "number", "commandsCount": "number", "toolsCount": "number" } },
+		"oss.bot.start_failed": { "description": "An adapter threw during start().", "properties": { "platform": "string", "errorClass": "auth|network|timeout|validation|unknown" } },
+		"oss.bot.agent_run": { "description": "A successful agent invocation completed. Note: an interrupt->resume turn emits two agent_run events (interrupted:true at the ack-first return, then interrupted:false after resume); filter interrupted===false to count completed runs.", "properties": { "platform": "string", "durationMs": "number", "toolCallCount": "number", "iterations": "number", "interrupted": "boolean" } },
+		"oss.bot.agent_run_failed": { "description": "An agent run errored.", "properties": { "platform": "string", "errorClass": "auth|network|timeout|validation|unknown", "stage": "agent" } }
+	}
+}

--- a/packages/bot/telemetry-events.json
+++ b/packages/bot/telemetry-events.json
@@ -8,7 +8,7 @@
     "oss.bot.configured": {
       "description": "createBot() returned; repeats per process start.",
       "properties": {
-        "platforms": "string[]",
+        "platforms": "string[] (each normalized: slack|discord|telegram|whatsapp|custom)",
         "adapterCount": "number",
         "store": "memory|postgres|redis|custom",
         "hasComponents": "boolean",
@@ -23,7 +23,7 @@
     "oss.bot.started": {
       "description": "bot.start() connected at least one adapter.",
       "properties": {
-        "platforms": "string[]",
+        "platforms": "string[] (each normalized: slack|discord|telegram|whatsapp|custom)",
         "startedCount": "number",
         "failedCount": "number",
         "hasMentionHandler": "boolean",
@@ -36,14 +36,14 @@
     "oss.bot.start_failed": {
       "description": "An adapter threw during start().",
       "properties": {
-        "platform": "string",
+        "platform": "string (normalized: slack|discord|telegram|whatsapp|custom)",
         "errorClass": "auth|network|timeout|validation|unknown"
       }
     },
     "oss.bot.agent_run": {
-      "description": "A successful agent invocation completed. Note: an interrupt->resume turn emits two agent_run events (interrupted:true at the ack-first return, then interrupted:false after resume); filter interrupted===false to count completed runs.",
+      "description": "A successful agent invocation completed (emitted after the run loop AND finalization/transcript steps succeed). Note: an interrupt->resume turn emits two agent_run events (interrupted:true at the ack-first return, then interrupted:false after resume); filter interrupted===false to count completed runs.",
       "properties": {
-        "platform": "string",
+        "platform": "string (normalized: slack|discord|telegram|whatsapp|custom)",
         "durationMs": "number",
         "toolCallCount": "number",
         "iterations": "number",
@@ -51,11 +51,11 @@
       }
     },
     "oss.bot.agent_run_failed": {
-      "description": "An agent run errored.",
+      "description": "An agent run errored. Emitted instead of agent_run; stage=agent for run-loop failures, stage=finalize for transcript-append/renderer-finish failures after the loop.",
       "properties": {
-        "platform": "string",
+        "platform": "string (normalized: slack|discord|telegram|whatsapp|custom)",
         "errorClass": "auth|network|timeout|validation|unknown",
-        "stage": "agent"
+        "stage": "agent|finalize"
       }
     }
   }


### PR DESCRIPTION
## What

Adds anonymous **`oss.bot.*`** usage telemetry to the `@copilotkit/bot` SDK — a **configured → started → agent_run** adoption funnel that answers "what are people doing with the bot packages?" (which adapters, which store backends, how they iterate on config, where they fail) — without knowing *who* the customer is.

Design spec: [Bot SDK Telemetry — oss.bot.* Adoption Funnel](https://app.notion.com/p/38b3aa3818528177a3abfda9ce35bdbc) · Plan: [Implementation Plan](https://app.notion.com/p/38b3aa38185281d5a09cfea114df8897)

## Events (all 100%, anonymous, metadata-only)

| Event | When | Notable props |
|-------|------|---------------|
| `oss.bot.configured` | `createBot()` returns (repeats per restart → iteration signal) | `platforms`, `store`, `toolsCount`, `hasComponents`, … |
| `oss.bot.started` | `bot.start()` connected ≥1 adapter | `platforms`, `startedCount`, `failedCount`, handler flags |
| `oss.bot.start_failed` | an adapter threw during start | `platform`, `errorClass` |
| `oss.bot.agent_run` | a successful agent run | `platform`, `durationMs`, `toolCallCount`, `iterations`, `interrupted` |
| `oss.bot.agent_run_failed` | an agent run errored | `platform`, `errorClass`, `stage` |

Catalog + property reference: `packages/bot/telemetry-events.json`.

## Design

- **Anonymous.** Bot deployments carry no `telemetry_id`/license/API key, so events are stitched by a persisted `anonymous_id` (durable `StateStore` → project-local cache file → per-process UUID) plus a per-`createBot` `bot_session_id`. Reuses `lambdaClient.send` from `@copilotkit/shared` (no new deps).
- **Zero-config.** Works out of the box; **no new env vars**. Reads only the pre-existing optional `COPILOTKIT_TELEMETRY_URL` (override) and `COPILOTKIT_TELEMETRY_DISABLED` / `DO_NOT_TRACK` (opt-out), and `NODE_ENV`/`VITEST` for the `environment` tag + test suppression.
- **Fire-and-forget.** `capture()` never throws into or blocks the host app; all dispatch/fetch/fs failures are swallowed.
- **PII guardrails.** Snapshots are scalars/counts only (never adapter/store option objects → no token/connection-string leakage); errors are mapped to a bounded `errorClass` category (`auth`/`network`/`timeout`/`validation`/`unknown`) — never a raw message or stack; no message text, user ids, or channel names anywhere.

**Sink side** (`oss.bot.` allow-list prefix + `anonymous_id` → PostHog `distinct_id`) shipped separately in oss-path-to-production PR #175 (already merged).

## Testing

**Unit (TDD, red→green per module):**
- `sanitize-error.test.ts` — category mapping + a "never leaks the message" secret-redaction assertion (2)
- `install-id.test.ts` — durable-store persistence, file persistence, unwritable-dir fallback (3)
- `bot-telemetry.test.ts` — global-props shape, disabled no-op, never-throws-on-send-reject, event-name set (4)
- `events-catalog.test.ts` — drift guard: catalog keys == emitted event names (1)
- `run-loop.test.ts` — new `{iterations, interrupted}` return value (interrupt + normal paths)
- `create-bot-telemetry.test.ts` — mocked-telemetry wiring: configured snapshot, started/start_failed (with `xoxb-SECRET` redaction assertion), agent_run

**End-to-end:**
- `e2e-telemetry.test.ts` — drives the **real `BotTelemetry`** through `createBot → start → runAgent` (only the network boundary is stubbed), asserts the `configured → started → agent_run` payloads carry `anonymous_id`/`bot_session_id` and **runs with an empty telemetry env** (proves zero-config; asserts no license token attached).

**Full suite (authoritative, on a real `pnpm install` in the integration worktree):**
- `tsc --noEmit` → 0 errors · `@copilotkit/bot` vitest → **26 files / 141 tests pass**

**In-session manual smoke (real wire bytes):** stubbed `globalThis.fetch`, drove a real bot through one turn, captured the actual serialized POSTs:
```
sink URL (no env var set → default): https://telemetry.copilotkit.ai/ingest
oss.bot.configured  {"properties":{"platforms":["fake"],"adapterCount":1,"store":"memory",...},
                     "global_properties":{"anonymous_id":"74b3c598-…","bot_session_id":"7cddd757-…","environment":"production"},
                     "package":{"name":"@copilotkit/bot","version":"0.0.3"},"ts":1782502088}
oss.bot.started     {"properties":{"platforms":["fake"],"startedCount":1,"failedCount":0,"hasMentionHandler":true,...}, "global_properties":{ same anonymous_id + bot_session_id }}
oss.bot.agent_run   {"properties":{"platform":"fake","durationMs":0,"toolCallCount":0,"iterations":1,"interrupted":false}, "global_properties":{ same anonymous_id + bot_session_id }}
```
All three share one `anonymous_id` + `bot_session_id` (funnel stitching), default sink URL with no env var set, no license/key anywhere.

**No new env vars (verified):** `git diff origin/main -- packages/bot/src/create-bot.ts packages/bot/src/thread.ts | grep process.env` → none; wiring code reads no env var directly.

**Code review:** one focused reviewer pass on the full diff — no blocker/high findings; PII, fire-and-forget, zero-config, and no-regression axes all confirmed clean. Two low/nit findings applied (dropped `TypeError`→`validation` mis-categorization; documented the interrupt→resume `agent_run` double-count in the catalog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
