### PR TITLE
feat(showcase): fix slot-liveness false-positive, add kept-stack TTL + 'showcase reap'

### DIFF
--- a/showcase/scripts/__tests__/isolate-liveness-real.bats
+++ b/showcase/scripts/__tests__/isolate-liveness-real.bats
@@ -1,0 +1,372 @@
+#!/usr/bin/env bats
+# REAL-SURFACE liveness tests for the Change-1 false-positive fix in
+# scripts/cli/_common.sh. Unlike isolate.bats (which drives a docker STUB),
+# these tests exercise the actual failure surface the spec mandates:
+#
+#   * real slot dirs under a temp XDG_STATE_HOME,
+#   * a real DEAD owning PID (spawn `sleep` then `wait` for it to exit —
+#     provably dead via kill -0),
+#   * a REAL one-container `docker compose` project so containers ARE running.
+#
+# The bug: when a slot's recorded compose project has RUNNING containers, the
+# old _slot_liveness short-circuited to `live` BEFORE checking the owning PID.
+# A --keep'd stack (owner process exited, containers still up) was therefore
+# classified `live` forever and never reaped → unbounded slot accumulation.
+# The fix introduces the `kept` state (running containers + dead/unverifiable
+# owner) and a start-time-verified owner probe.
+#
+# Hermeticity: every throwaway compose project uses a UNIQUE disposable name
+# (showcase-isotest-s1-<rand>), NEVER the base `showcase` name, and is torn
+# down in teardown() with `docker compose -p <name> down --remove-orphans
+# --volumes`. We are fixing a stack-leak bug — these tests must not leak stacks.
+#
+# All real-docker tests `skip` cleanly when the docker daemon is unreachable or
+# the tiny test image cannot be obtained, so the suite stays green on hosts /
+# CI runners without docker.
+
+fail() {
+  echo "$1"
+  return 1
+}
+
+# The tiny image the throwaway one-container project runs. Pinned digest-free
+# but version-tagged; pulled in setup() if absent. `sleep infinity` keeps the
+# container RUNNING so `docker ps -q --filter label=...` reports it.
+TEST_IMAGE="alpine:3.20"
+
+# _docker_ok — true when a docker daemon is reachable. Used to skip the
+# real-docker tests on hosts/CI without docker.
+_docker_ok() {
+  command -v docker >/dev/null 2>&1 || return 1
+  docker info >/dev/null 2>&1 || return 1
+  return 0
+}
+
+# _ensure_test_image — make sure $TEST_IMAGE exists locally, pulling once if
+# needed. Returns nonzero (→ caller skips) when it cannot be obtained.
+_ensure_test_image() {
+  docker image inspect "$TEST_IMAGE" >/dev/null 2>&1 && return 0
+  docker pull "$TEST_IMAGE" >/dev/null 2>&1
+}
+
+setup() {
+  COMMON="$BATS_TEST_DIRNAME/../cli/_common.sh"
+
+  # Real XDG state root (no docker stub on PATH — these tests use REAL docker).
+  export XDG_STATE_HOME="$BATS_TEST_TMPDIR/xdg"
+
+  # Minimal real SHOWCASE_ROOT so _slot_offset_ports has a ports file to read
+  # (we override the function per-test anyway, but load_common references it).
+  export SHOWCASE_ROOT_OVERRIDE="$BATS_TEST_TMPDIR/root"
+  mkdir -p "$SHOWCASE_ROOT_OVERRIDE/shared"
+  cat > "$SHOWCASE_ROOT_OVERRIDE/shared/local-ports.json" <<'JSON'
+{ "mastra": 3104 }
+JSON
+  cat > "$SHOWCASE_ROOT_OVERRIDE/docker-compose.local.yml" <<'YML'
+services:
+  aimock:
+    container_name: showcase-aimock
+    ports:
+      - "4010:4010"
+YML
+
+  # Unique disposable project name for this test's throwaway stack — NEVER the
+  # base `showcase` name. Recorded so teardown() can compose it down even if
+  # the test aborts mid-way.
+  TEST_PROJ="showcase-isotest-s1-${BATS_TEST_NUMBER}-$$-${RANDOM}"
+  TEST_PORT=""   # set by the tests that bind a host port; torn down in teardown
+}
+
+teardown() {
+  # Tear down the throwaway stack unconditionally (the stack-leak guarantee):
+  # remove containers, orphans, and named volumes for the unique project.
+  if command -v docker >/dev/null 2>&1 && [ -n "${TEST_PROJ:-}" ]; then
+    docker compose -p "$TEST_PROJ" down --remove-orphans --volumes >/dev/null 2>&1 || true
+  fi
+}
+
+load_common() {
+  # shellcheck disable=SC1090
+  source "$COMMON"
+  SHOWCASE_ROOT="$SHOWCASE_ROOT_OVERRIDE"
+  COMPOSE_FILE="$SHOWCASE_ROOT/docker-compose.local.yml"
+  PORTS_FILE="$SHOWCASE_ROOT/shared/local-ports.json"
+  COMPOSE_CMD="docker compose -f $COMPOSE_FILE"
+}
+
+# _start_real_project <proj> [host_port] — start a REAL one-container compose
+# project named <proj> running `sleep infinity` (so the container is RUNNING
+# and carries the com.docker.compose.project=<proj> label). If host_port is
+# given, the container publishes it (binds a real host listener) so the
+# port-probe tests have a genuine docker-held port to exercise lsof against.
+_start_real_project() {
+  local proj="$1" host_port="${2:-}"
+  local cdir="$BATS_TEST_TMPDIR/compose-$proj"
+  mkdir -p "$cdir"
+  if [ -n "$host_port" ]; then
+    cat > "$cdir/docker-compose.yml" <<YML
+services:
+  keeper:
+    image: $TEST_IMAGE
+    command: ["sleep", "infinity"]
+    ports:
+      - "127.0.0.1:${host_port}:9"
+YML
+  else
+    cat > "$cdir/docker-compose.yml" <<YML
+services:
+  keeper:
+    image: $TEST_IMAGE
+    command: ["sleep", "infinity"]
+YML
+  fi
+  docker compose -f "$cdir/docker-compose.yml" -p "$proj" up -d >/dev/null 2>&1
+}
+
+# _make_dead_pid — spawn a short-lived process, wait for it to exit, and echo
+# its (now dead) pid. Skips the test if the OS recycled the pid to a live
+# process between wait and the check (the dead-owner fixture would be invalid).
+_make_dead_pid() {
+  local p
+  bash -c 'exit 0' &
+  p=$!
+  wait "$p" 2>/dev/null || true
+  if kill -0 "$p" 2>/dev/null; then
+    skip "PID $p was recycled to a live process — dead-PID fixture invalid"
+  fi
+  echo "$p"
+}
+
+# ── Change 1: liveness false-positive (the FOUNDATION) ───────────────────────
+
+@test "REAL: a kept stack (dead owner + running containers) classifies kept, not live" {
+  _docker_ok || skip "docker daemon unavailable"
+  _ensure_test_image || skip "cannot obtain $TEST_IMAGE"
+  load_common
+
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  # Recorded project + a provably DEAD owner pid (no pid.start → unverifiable
+  # even if the number were alive). This is exactly a --keep'd stack: the
+  # owning `showcase test --keep` process has exited, the containers live on.
+  echo "$TEST_PROJ" > "$slots/0/project"
+  local dead_pid
+  dead_pid="$(_make_dead_pid)"
+  echo "$dead_pid" > "$slots/0/pid"
+
+  # Real running container under the recorded project name.
+  _start_real_project "$TEST_PROJ" || skip "could not start throwaway compose project"
+  # Sanity: docker really does report a running container for this project.
+  [ -n "$(docker ps -q --filter "label=com.docker.compose.project=$TEST_PROJ")" ] \
+    || skip "throwaway project has no running container — environment issue"
+
+  # GREEN expectation (fix in place): the container check wins, but the owner
+  # is dead → kept, NOT live. The PID column annotates the dead owner.
+  run _slot_liveness 0
+  [ "$status" -eq 0 ] || fail "_slot_liveness 0 failed: $output"
+  [ "$output" = "kept" ] \
+    || fail "expected liveness 'kept' for dead-owner+running-containers slot, got '$output' (pre-fix bug returns 'live')"
+
+  # _slot_state's PID column shows <pid>(dead), and LIVE=kept — never a bare
+  # numeric PID with LIVE=live (the exact false-positive from the bug report).
+  run _slot_state 0
+  [ "$status" -eq 0 ] || fail "_slot_state 0 failed: $output"
+  local -a fields
+  IFS='|' read -ra fields <<< "$output"
+  [ "${fields[2]}" = "${dead_pid}(dead)" ] \
+    || fail "expected PID column '${dead_pid}(dead)', got '${fields[2]}' (pre-fix bug shows bare '$dead_pid')"
+  [ "${fields[3]}" = "kept" ] \
+    || fail "expected LIVE column 'kept', got '${fields[3]}' (pre-fix bug shows 'live')"
+}
+
+@test "REAL: a live, start-time-verified owner with running containers stays live" {
+  _docker_ok || skip "docker daemon unavailable"
+  _ensure_test_image || skip "cannot obtain $TEST_IMAGE"
+  load_common
+
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  echo "$TEST_PROJ" > "$slots/0/project"
+  # LIVE owner: this bats process, with a matching pid.start fingerprint.
+  echo "$$" > "$slots/0/pid"
+  _pid_start_time "$$" > "$slots/0/pid.start"
+
+  _start_real_project "$TEST_PROJ" || skip "could not start throwaway compose project"
+  [ -n "$(docker ps -q --filter "label=com.docker.compose.project=$TEST_PROJ")" ] \
+    || skip "throwaway project has no running container — environment issue"
+
+  # A live verified owner UPGRADES kept → live (protect indefinitely).
+  run _slot_liveness 0
+  [ "$status" -eq 0 ] || fail "_slot_liveness 0 failed: $output"
+  [ "$output" = "live" ] \
+    || fail "expected 'live' for verified-live-owner+running-containers, got '$output'"
+}
+
+@test "REAL: a reused owner PID with running containers is kept, not live (reuse guard)" {
+  _docker_ok || skip "docker daemon unavailable"
+  _ensure_test_image || skip "cannot obtain $TEST_IMAGE"
+  load_common
+
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  echo "$TEST_PROJ" > "$slots/0/project"
+  # Reuse hazard: the recorded pid is THIS live process, but the recorded
+  # start-time fingerprint belongs to a DIFFERENT (now-gone) process. The
+  # start-time guard must catch the mismatch and treat the owner as gone.
+  echo "$$" > "$slots/0/pid"
+  echo "definitely-not-our-start-time" > "$slots/0/pid.start"
+
+  _start_real_project "$TEST_PROJ" || skip "could not start throwaway compose project"
+  [ -n "$(docker ps -q --filter "label=com.docker.compose.project=$TEST_PROJ")" ] \
+    || skip "throwaway project has no running container — environment issue"
+
+  run _slot_liveness 0
+  [ "$status" -eq 0 ] || fail "_slot_liveness 0 failed: $output"
+  [ "$output" = "kept" ] \
+    || fail "expected 'kept' for reused-PID+running-containers (start-time mismatch), got '$output'"
+
+  # And the table flags the reuse explicitly.
+  run _slot_state 0
+  local -a fields
+  IFS='|' read -ra fields <<< "$output"
+  [ "${fields[2]}" = "$$(reused)" ] \
+    || fail "expected PID column '$$(reused)', got '${fields[2]}'"
+}
+
+@test "REAL: sweep leaves a kept stack standing but reaps it once classified stale" {
+  _docker_ok || skip "docker daemon unavailable"
+  _ensure_test_image || skip "cannot obtain $TEST_IMAGE"
+  load_common
+
+  local base="$XDG_STATE_HOME/copilotkit/showcase"
+  local slots="$base/slots"
+  mkdir -p "$slots/0"
+  echo "$TEST_PROJ" > "$slots/0/project"
+  local dead_pid
+  dead_pid="$(_make_dead_pid)"
+  echo "$dead_pid" > "$slots/0/pid"
+
+  _start_real_project "$TEST_PROJ" || skip "could not start throwaway compose project"
+  [ -n "$(docker ps -q --filter "label=com.docker.compose.project=$TEST_PROJ")" ] \
+    || skip "throwaway project has no running container — environment issue"
+
+  # Part 1: a sweep must NOT reap a kept slot (Change 1 — no TTL yet, kept is
+  # always protected). The claim runs a sweep opportunistically.
+  _claim_isolate_slot
+  [ -d "$slots/0" ] || fail "sweep reaped a kept stack (dead owner + RUNNING containers)"
+  run cat "$slots/0/project"
+  [ "$output" = "$TEST_PROJ" ] || fail "kept slot 0 project mangled after sweep: $output"
+  # The claim landed on slot 1 (slot 0 reserved + kept-protected).
+  [ "$ISOLATE_SLOT" != "0" ] || fail "claim landed on the protected kept slot 0"
+
+  # Part 2: once the containers are gone, the same slot classifies stale and a
+  # sweep reaps it (this is the existing stopped-keeper reclamation path, now
+  # routed through the kept→(no containers)→stale transition). Compose the
+  # throwaway project down so no RUNNING containers protect it anymore.
+  docker compose -p "$TEST_PROJ" down --remove-orphans --volumes >/dev/null 2>&1 || true
+  run _slot_liveness 0
+  [ "$status" -eq 0 ] || fail "_slot_liveness 0 failed after teardown: $output"
+  [ "$output" = "stale" ] \
+    || fail "expected 'stale' for dead owner + NO running containers, got '$output'"
+}
+
+# ── Change 1b: _slot_ports_free own-port regression (the rename hazard) ──────
+
+@test "REAL: pinned claim onto a kept slot treats its OWN container ports as own (not foreign)" {
+  _docker_ok || skip "docker daemon unavailable"
+  _ensure_test_image || skip "cannot obtain $TEST_IMAGE"
+  command -v lsof >/dev/null 2>&1 || skip "lsof required for the port-probe path"
+  load_common
+
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  # Pin slot 9. Constrain the probed port set to a SINGLE deterministic host
+  # port (override _slot_offset_ports for slot 9) so the test exercises the
+  # own-project filter against a real docker-held listener without flaking on
+  # whatever else happens to be bound on this host. real lsof + real docker ps
+  # still drive the filter decision.
+  TEST_PORT=39619
+  _slot_offset_ports() { printf '%d\n' "$TEST_PORT"; }
+
+  mkdir -p "$slots/9"
+  echo "$TEST_PROJ" > "$slots/9/project"
+  local dead_pid
+  dead_pid="$(_make_dead_pid)"
+  echo "$dead_pid" > "$slots/9/pid"   # dead owner → this is a KEPT stack
+
+  # Real container holding the slot's (overridden) offset port on the host.
+  _start_real_project "$TEST_PROJ" "$TEST_PORT" || skip "could not start throwaway compose project"
+  [ -n "$(docker ps -q --filter "label=com.docker.compose.project=$TEST_PROJ")" ] \
+    || skip "throwaway project has no running container — environment issue"
+  # Confirm the host port really is held (by docker) before asserting the filter.
+  lsof -nP -i :"$TEST_PORT" -sTCP:LISTEN >/dev/null 2>&1 \
+    || skip "host port $TEST_PORT not observed as LISTEN — docker port-publish unavailable in this env"
+
+  # Liveness is `kept` (dead owner + running containers). With the own-project
+  # filter widened to live OR kept, the kept slot's own docker listener on its
+  # own port is NOT a foreign hold → _slot_ports_free returns 0 (free).
+  run _slot_liveness 9
+  [ "$output" = "kept" ] || fail "precondition: slot 9 should be 'kept', got '$output'"
+
+  run _slot_ports_free 9
+  [ "$status" -eq 0 ] \
+    || fail "kept slot's OWN docker port treated as foreign (pre-fix bug): status=$status output=$output"
+
+  # End-to-end: a pinned claim onto the kept slot must NOT die "ports are held
+  # by a foreign process". The pinned EEXIST path reaps stale/inconclusive and
+  # retries — but `kept` is neither, so it reaches the port probe, which now
+  # accepts its own ports. (Pre-fix: liveness=='live'-only filter → die.)
+  export SHOWCASE_ISO_SLOT=9
+  run _claim_isolate_slot
+  [ "$status" -eq 0 ] \
+    || fail "pinned claim onto kept slot died (own ports seen as foreign): $output"
+  [[ "$output" != *"held by a foreign process"* ]] \
+    || fail "pinned claim reported its own kept-stack ports as foreign: $output"
+}
+
+@test "REAL: a foreign (non-docker) listener on a slot's port is still seen as held" {
+  _docker_ok || skip "docker daemon unavailable"
+  command -v lsof >/dev/null 2>&1 || skip "lsof required for the port-probe path"
+  command -v python3 >/dev/null 2>&1 || skip "python3 used to bind a real foreign listener"
+  load_common
+
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  TEST_PORT=39620
+  _slot_offset_ports() { printf '%d\n' "$TEST_PORT"; }
+
+  mkdir -p "$slots/9"
+  echo "$TEST_PROJ" > "$slots/9/project"
+  echo "$$" > "$slots/9/pid"
+  _pid_start_time "$$" > "$slots/9/pid.start"   # live verified owner → liveness 'live'
+
+  # Bind the port with a REAL non-docker process (python3) so the own-project
+  # docker filter does NOT apply — it must be reported as a foreign hold even
+  # though the slot's own liveness is live/kept.
+  python3 -c "
+import socket, time, sys
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('127.0.0.1', $TEST_PORT))
+s.listen(1)
+sys.stderr.write('bound\n'); sys.stderr.flush()
+time.sleep(30)
+" 2>"$BATS_TEST_TMPDIR/binder.err" &
+  local binder_pid=$!
+  # Wait for the binder to actually be listening (poll up to ~3s).
+  local i=0
+  while [ $i -lt 30 ]; do
+    if lsof -nP -i :"$TEST_PORT" -sTCP:LISTEN >/dev/null 2>&1; then break; fi
+    sleep 0.1; i=$((i+1))
+  done
+  if ! lsof -nP -i :"$TEST_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    kill "$binder_pid" 2>/dev/null || true
+    skip "could not bind foreign listener on $TEST_PORT"
+  fi
+
+  run _slot_ports_free 9
+  local rc="$status"
+  kill "$binder_pid" 2>/dev/null || true
+  wait "$binder_pid" 2>/dev/null || true
+
+  [ "$rc" -ne 0 ] \
+    || fail "a foreign (non-docker) listener on the slot's port was wrongly treated as free"
+}

--- a/showcase/scripts/__tests__/isolate-reap-real.bats
+++ b/showcase/scripts/__tests__/isolate-reap-real.bats
@@ -1,0 +1,405 @@
+#!/usr/bin/env bats
+# REAL-SURFACE tests for `showcase reap` (Change 2) in scripts/cli/cmd-reap.sh.
+# These exercise the actual failure surface the spec mandates — real leaked
+# compose projects under a temp XDG_STATE_HOME, real slot records, real running
+# containers and named volumes — never vi.mock-style fakes.
+#
+# The bug being fixed: --keep'd / crashed isolated stacks accumulate with no
+# tool to list or tear them down. `showcase reap` is that tool: dry-run by
+# default (lists, changes nothing), --force executes, and it NEVER touches the
+# base `showcase` stack or BuildKit resources.
+#
+# Hermeticity: every throwaway project uses a UNIQUE disposable name
+# (showcase-isotest-s3-<rand>), NEVER the base `showcase` name, and every
+# stack/volume/probe container this file creates is torn down in teardown().
+# We are FIXING a stack-leak bug — these tests must not leak stacks.
+#
+# All real-docker tests `skip` cleanly when the daemon is unreachable or the
+# tiny image cannot be obtained, so the suite stays green without docker.
+
+fail() {
+  echo "$1"
+  return 1
+}
+
+TEST_IMAGE="alpine:3.20"
+
+_docker_ok() {
+  command -v docker >/dev/null 2>&1 || return 1
+  docker info >/dev/null 2>&1 || return 1
+  return 0
+}
+
+_ensure_test_image() {
+  docker image inspect "$TEST_IMAGE" >/dev/null 2>&1 && return 0
+  docker pull "$TEST_IMAGE" >/dev/null 2>&1
+}
+
+setup() {
+  COMMON="$BATS_TEST_DIRNAME/../cli/_common.sh"
+  REAP="$BATS_TEST_DIRNAME/../cli/cmd-reap.sh"
+
+  export XDG_STATE_HOME="$BATS_TEST_TMPDIR/xdg"
+
+  export SHOWCASE_ROOT_OVERRIDE="$BATS_TEST_TMPDIR/root"
+  mkdir -p "$SHOWCASE_ROOT_OVERRIDE/shared"
+  cat > "$SHOWCASE_ROOT_OVERRIDE/shared/local-ports.json" <<'JSON'
+{ "mastra": 3104 }
+JSON
+  cat > "$SHOWCASE_ROOT_OVERRIDE/docker-compose.local.yml" <<'YML'
+services:
+  aimock:
+    container_name: showcase-aimock
+    ports:
+      - "4010:4010"
+YML
+
+  # Unique disposable names for this test's throwaway stacks — NEVER `showcase`.
+  RAND="${BATS_TEST_NUMBER}-$$-${RANDOM}"
+  TEST_PROJ_A="showcase-isotest-s3-${RAND}-a"
+  TEST_PROJ_B="showcase-isotest-s3-${RAND}-b"
+  # Fake base-stack + fake-buildkit probe projects to prove the safety guards.
+  FAKE_BASE="showcase"               # the reserved base project name itself
+  FAKE_BASE_CTR="showcase-isotest-s3-${RAND}-fakebase"
+  FAKE_BK_CTR="buildx_buildkit_showcase-isotest-s3-${RAND}"
+}
+
+teardown() {
+  # Kill the live-owner helper process if a test started one.
+  [ -n "${LIVE_OWNER_PID:-}" ] && kill "$LIVE_OWNER_PID" >/dev/null 2>&1 || true
+  if command -v docker >/dev/null 2>&1; then
+    local p
+    for p in "${TEST_PROJ_A:-}" "${TEST_PROJ_B:-}"; do
+      [ -n "$p" ] && docker compose -p "$p" down --remove-orphans --volumes >/dev/null 2>&1 || true
+    done
+    # The fake-base + fake-buildkit probe containers are plain `docker run`
+    # containers (not compose stacks) — remove them by name. They are labelled
+    # with com.docker.compose.project so reap's scan would SEE them, but the
+    # guards must leave them standing; teardown removes them regardless.
+    [ -n "${FAKE_BASE_CTR:-}" ] && docker rm -f "$FAKE_BASE_CTR" >/dev/null 2>&1 || true
+    [ -n "${FAKE_BK_CTR:-}" ] && docker rm -f "$FAKE_BK_CTR" >/dev/null 2>&1 || true
+    # Defensive: should NEVER exist (the base name is reserved), but if a
+    # regression composed it down/up, clean any stray base-named volumes.
+    docker volume ls --filter "label=com.docker.compose.project=showcase" -q 2>/dev/null \
+      | grep -q . && docker compose -p showcase down --volumes >/dev/null 2>&1 || true
+  fi
+}
+
+load_reap() {
+  # shellcheck disable=SC1090
+  source "$COMMON"
+  # shellcheck disable=SC1090
+  source "$REAP"
+  SHOWCASE_ROOT="$SHOWCASE_ROOT_OVERRIDE"
+  COMPOSE_FILE="$SHOWCASE_ROOT/docker-compose.local.yml"
+  PORTS_FILE="$SHOWCASE_ROOT/shared/local-ports.json"
+  COMPOSE_CMD="docker compose -f $COMPOSE_FILE"
+}
+
+# Start a REAL one-container compose project + a hand-written slot record, so
+# the project is a leaked iso stack reap must find. A named volume is attached
+# so the volume-count + --volumes teardown are exercised.
+_leak_iso_project() {
+  local proj="$1" slot="$2"
+  local cdir="$BATS_TEST_TMPDIR/compose-$proj"
+  mkdir -p "$cdir"
+  cat > "$cdir/docker-compose.yml" <<YML
+services:
+  keeper:
+    image: $TEST_IMAGE
+    command: ["sleep", "infinity"]
+    volumes:
+      - data:/data
+volumes:
+  data:
+YML
+  docker compose -f "$cdir/docker-compose.yml" -p "$proj" up -d >/dev/null 2>&1 || return 1
+  # Slot record (the canonical pointer reap routes teardown through). A dead
+  # owner pid → the slot classifies kept/stale; --force / --all reap it.
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/$slot"
+  echo "$proj" > "$slots/$slot/project"
+  # provably-dead pid: spawn + reap.
+  local p; bash -c 'exit 0' & p=$!; wait "$p" 2>/dev/null || true
+  echo "$p" > "$slots/$slot/pid"
+  # A run dir, so reap's rundir removal is exercised too.
+  mkdir -p "$XDG_STATE_HOME/copilotkit/showcase/runs/$proj"
+}
+
+_proj_has_container() {
+  [ -n "$(docker ps -a -q --filter "label=com.docker.compose.project=$1" 2>/dev/null)" ]
+}
+
+# Stand up a REAL iso project owned by a LIVE owner: a running container PLUS a
+# slot record whose pid+pid.start fingerprint a process we control and keep
+# alive for the duration of the test. With running containers and an alive,
+# start-time-verified owner, _slot_liveness classifies the slot as `live` — the
+# "actively owned, in use" class reap must PRESERVE. The owner is a real
+# backgrounded `sleep` process; its pid is recorded in LIVE_OWNER_PID and killed
+# in teardown(). Returns non-zero (for `skip`) if the container won't start.
+_leak_live_iso_project() {
+  local proj="$1" slot="$2"
+  local cdir="$BATS_TEST_TMPDIR/compose-$proj"
+  mkdir -p "$cdir"
+  cat > "$cdir/docker-compose.yml" <<YML
+services:
+  keeper:
+    image: $TEST_IMAGE
+    command: ["sleep", "infinity"]
+    volumes:
+      - data:/data
+volumes:
+  data:
+YML
+  docker compose -f "$cdir/docker-compose.yml" -p "$proj" up -d >/dev/null 2>&1 || return 1
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/$slot"
+  echo "$proj" > "$slots/$slot/project"
+  mkdir -p "$XDG_STATE_HOME/copilotkit/showcase/runs/$proj"
+  # A REAL backgrounded process as the live owner; record a start-time-verified
+  # fingerprint (pid + pid.start) so _owner_liveness reads `alive`.
+  sleep 300 &
+  LIVE_OWNER_PID=$!
+  type _pid_start_time >/dev/null 2>&1 || source "$COMMON"
+  echo "$LIVE_OWNER_PID" > "$slots/$slot/pid"
+  _pid_start_time "$LIVE_OWNER_PID" > "$slots/$slot/pid.start"
+}
+
+# ── RED → GREEN: dry-run lists; --force tears down; guards hold ───────────────
+
+@test "REAL: reap dry-run lists leaked projects and changes NOTHING (RED baseline)" {
+  _docker_ok || skip "docker daemon unavailable"
+  _ensure_test_image || skip "cannot obtain $TEST_IMAGE"
+  load_reap
+
+  _leak_iso_project "$TEST_PROJ_A" 11 || skip "could not start throwaway project A"
+  _leak_iso_project "$TEST_PROJ_B" 12 || skip "could not start throwaway project B"
+  _proj_has_container "$TEST_PROJ_A" || skip "project A has no container — env issue"
+  _proj_has_container "$TEST_PROJ_B" || skip "project B has no container — env issue"
+
+  # Dry-run (no --force): both projects appear in the plan with a non-zero
+  # container count, and NOTHING is torn down.
+  run cmd_reap
+  [ "$status" -eq 0 ] || fail "reap dry-run failed: $output"
+  [[ "$output" == *"$TEST_PROJ_A"* ]] || fail "dry-run plan omitted project A: $output"
+  [[ "$output" == *"$TEST_PROJ_B"* ]] || fail "dry-run plan omitted project B: $output"
+  [[ "$output" == *"DRY-RUN"* ]] || fail "dry-run banner missing: $output"
+
+  # Dry-run changed nothing — both leaked stacks still standing.
+  _proj_has_container "$TEST_PROJ_A" || fail "dry-run reaped project A (must change nothing)"
+  _proj_has_container "$TEST_PROJ_B" || fail "dry-run reaped project B (must change nothing)"
+}
+
+@test "REAL: reap --force tears down leaked stacks (volumes, slot, run dirs) while base showcase + buildkit are UNTOUCHED (GREEN)" {
+  _docker_ok || skip "docker daemon unavailable"
+  _ensure_test_image || skip "cannot obtain $TEST_IMAGE"
+  load_reap
+
+  _leak_iso_project "$TEST_PROJ_A" 11 || skip "could not start throwaway project A"
+  _leak_iso_project "$TEST_PROJ_B" 12 || skip "could not start throwaway project B"
+  _proj_has_container "$TEST_PROJ_A" || skip "project A has no container — env issue"
+  _proj_has_container "$TEST_PROJ_B" || skip "project B has no container — env issue"
+
+  # A fake BASE-stack container, labelled exactly like the live default stack
+  # (com.docker.compose.project=showcase). reap MUST NEVER touch it.
+  docker run -d --name "$FAKE_BASE_CTR" \
+    --label "com.docker.compose.project=showcase" \
+    "$TEST_IMAGE" sleep infinity >/dev/null 2>&1 || skip "could not start fake-base probe"
+  # A fake BuildKit container (buildx_buildkit_*). reap MUST NEVER touch it.
+  docker run -d --name "$FAKE_BK_CTR" \
+    --label "com.docker.compose.project=$FAKE_BK_CTR" \
+    "$TEST_IMAGE" sleep infinity >/dev/null 2>&1 || skip "could not start fake-buildkit probe"
+
+  # Execute. --all reaps every identified iso project regardless of TTL/keep —
+  # exactly the "tear down everything isolated now" path the spec mandates.
+  run cmd_reap --all --force
+  [ "$status" -eq 0 ] || fail "reap --all --force failed: $output"
+
+  # Both leaked stacks fully gone: containers, named volumes, slot + run dirs.
+  _proj_has_container "$TEST_PROJ_A" && fail "project A containers survived --force"
+  _proj_has_container "$TEST_PROJ_B" && fail "project B containers survived --force"
+  [ -z "$(docker volume ls --filter "label=com.docker.compose.project=$TEST_PROJ_A" -q 2>/dev/null)" ] \
+    || fail "project A named volume survived --force"
+  [ -z "$(docker volume ls --filter "label=com.docker.compose.project=$TEST_PROJ_B" -q 2>/dev/null)" ] \
+    || fail "project B named volume survived --force"
+  [ ! -d "$XDG_STATE_HOME/copilotkit/showcase/slots/11" ] || fail "slot 11 dir survived --force"
+  [ ! -d "$XDG_STATE_HOME/copilotkit/showcase/slots/12" ] || fail "slot 12 dir survived --force"
+  [ ! -d "$XDG_STATE_HOME/copilotkit/showcase/runs/$TEST_PROJ_A" ] || fail "run dir A survived --force"
+  [ ! -d "$XDG_STATE_HOME/copilotkit/showcase/runs/$TEST_PROJ_B" ] || fail "run dir B survived --force"
+
+  # HARD SAFETY: the base-showcase container and the buildkit container are
+  # STILL RUNNING — reap must never have touched them.
+  [ -n "$(docker ps -q --filter "name=^${FAKE_BASE_CTR}\$" 2>/dev/null)" ] \
+    || fail "reap TORE DOWN the base 'showcase' stack (catastrophic safety failure)"
+  [ -n "$(docker ps -q --filter "name=^${FAKE_BK_CTR}\$" 2>/dev/null)" ] \
+    || fail "reap TORE DOWN a buildx_buildkit_* container (safety failure)"
+}
+
+@test "REAL: a single named target reaps exactly that project, leaving siblings standing" {
+  _docker_ok || skip "docker daemon unavailable"
+  _ensure_test_image || skip "cannot obtain $TEST_IMAGE"
+  load_reap
+
+  _leak_iso_project "$TEST_PROJ_A" 11 || skip "could not start throwaway project A"
+  _leak_iso_project "$TEST_PROJ_B" 12 || skip "could not start throwaway project B"
+  _proj_has_container "$TEST_PROJ_A" || skip "project A has no container — env issue"
+  _proj_has_container "$TEST_PROJ_B" || skip "project B has no container — env issue"
+
+  run cmd_reap "$TEST_PROJ_A" --force
+  [ "$status" -eq 0 ] || fail "single-target reap failed: $output"
+
+  _proj_has_container "$TEST_PROJ_A" && fail "named target project A survived its reap"
+  _proj_has_container "$TEST_PROJ_B" || fail "sibling project B was wrongly reaped by a single-target reap"
+}
+
+@test "REAL: single-target dry-run does NOT mislabel a harness-owned sibling as unidentified (RED→GREEN)" {
+  _docker_ok || skip "docker daemon unavailable"
+  _ensure_test_image || skip "cannot obtain $TEST_IMAGE"
+  load_reap
+
+  # TWO real harness-owned iso projects (compose-managed, slot records). Both
+  # are unambiguously harness-owned via their slot records, so NEITHER should
+  # ever appear in the "Unidentified — NOT harness-owned" review listing.
+  _leak_iso_project "$TEST_PROJ_A" 11 || skip "could not start throwaway project A"
+  _leak_iso_project "$TEST_PROJ_B" 12 || skip "could not start throwaway project B"
+  _proj_has_container "$TEST_PROJ_A" || skip "project A has no container — env issue"
+  _proj_has_container "$TEST_PROJ_B" || skip "project B has no container — env issue"
+
+  # Single-target dry-run on A. Before the fix, the unidentified listing was
+  # computed against the narrowed single-target set ({A}), so harness-owned B
+  # was falsely surfaced as "NOT harness-owned". After the fix, the listing is
+  # computed against the FULL identification union, so B is excluded.
+  run cmd_reap "$TEST_PROJ_A"
+  [ "$status" -eq 0 ] || fail "single-target dry-run failed: $output"
+
+  # Isolate the unidentified review section (everything after its warn header).
+  local unident_section="${output##*Unidentified compose projects}"
+  # The header is only emitted when there ARE unidentified projects; if the
+  # whole output lacks it, the section is empty (the trivially-correct case).
+  if [[ "$output" == *"Unidentified compose projects"* ]]; then
+    [[ "$unident_section" != *"$TEST_PROJ_B"* ]] \
+      || fail "harness-owned sibling B was mislabeled 'NOT harness-owned' in single-target mode: $output"
+    [[ "$unident_section" != *"$TEST_PROJ_A"* ]] \
+      || fail "the single target A was mislabeled 'NOT harness-owned': $output"
+  fi
+
+  # Sanity: dry-run changed nothing — both stacks still standing.
+  _proj_has_container "$TEST_PROJ_A" || fail "dry-run reaped project A (must change nothing)"
+  _proj_has_container "$TEST_PROJ_B" || fail "dry-run reaped project B (must change nothing)"
+}
+
+@test "REAL: an explicit target with a LIVE owner is PRESERVED (warned, not torn down) without an override" {
+  _docker_ok || skip "docker daemon unavailable"
+  _ensure_test_image || skip "cannot obtain $TEST_IMAGE"
+  load_reap
+
+  # A real iso project actively owned by a LIVE process (live pid+pid.start +
+  # running container) → _slot_liveness reads `live`.
+  _leak_live_iso_project "$TEST_PROJ_A" 11 || skip "could not start live-owner project A"
+  _proj_has_container "$TEST_PROJ_A" || skip "project A has no container — env issue"
+  [ "$(_slot_liveness 11)" = "live" ] || skip "project A did not classify as live — env issue"
+
+  # Naming a LIVE-owned project explicitly must NOT silently tear it down: reap
+  # preserves it and emits a loud live-owner warning naming the project.
+  run cmd_reap "$TEST_PROJ_A" --force
+  [ "$status" -eq 0 ] || fail "reap of live target failed unexpectedly: $output"
+  _proj_has_container "$TEST_PROJ_A" \
+    || fail "reap TORE DOWN a LIVE-owned explicit target without an override (safety failure): $output"
+  [[ "$output" == *"$TEST_PROJ_A"* && "$output" == *"live owner"* ]] \
+    || fail "no live-owner warning naming the project was emitted: $output"
+  # State preserved too — slot + run dir intact.
+  [ -d "$XDG_STATE_HOME/copilotkit/showcase/slots/11" ] || fail "live target's slot dir was removed"
+  [ -d "$XDG_STATE_HOME/copilotkit/showcase/runs/$TEST_PROJ_A" ] || fail "live target's run dir was removed"
+}
+
+@test "REAL: an explicit LIVE target IS torn down WITH the --include-live override" {
+  _docker_ok || skip "docker daemon unavailable"
+  _ensure_test_image || skip "cannot obtain $TEST_IMAGE"
+  load_reap
+
+  _leak_live_iso_project "$TEST_PROJ_A" 11 || skip "could not start live-owner project A"
+  _proj_has_container "$TEST_PROJ_A" || skip "project A has no container — env issue"
+  [ "$(_slot_liveness 11)" = "live" ] || skip "project A did not classify as live — env issue"
+
+  # The explicit override flag opts in to reaping a live-owner target.
+  run cmd_reap "$TEST_PROJ_A" --force --include-live
+  [ "$status" -eq 0 ] || fail "reap --include-live of live target failed: $output"
+  _proj_has_container "$TEST_PROJ_A" \
+    && fail "live target survived --include-live (override must tear it down): $output"
+  [ -d "$XDG_STATE_HOME/copilotkit/showcase/slots/11" ] \
+    && fail "live target's slot dir survived --include-live: $output"
+  return 0
+}
+
+@test "REAL: the self-id label identifies a record-LESS orphan (no slot, no run dir)" {
+  _docker_ok || skip "docker daemon unavailable"
+  _ensure_test_image || skip "cannot obtain $TEST_IMAGE"
+  load_reap
+
+  # A REAL compose project carrying ONLY the com.copilotkit.showcase.isolate=1
+  # label apply_isolation stamps — NO slot record, NO run dir. This is the
+  # user-supplied `--isolate <name>` orphan whose slot record was lost: the
+  # label scan is the ONLY mechanism that can find it.
+  local cdir="$BATS_TEST_TMPDIR/compose-$TEST_PROJ_A"
+  mkdir -p "$cdir"
+  cat > "$cdir/docker-compose.yml" <<YML
+services:
+  keeper:
+    image: $TEST_IMAGE
+    command: ["sleep", "infinity"]
+    labels:
+      com.copilotkit.showcase.isolate: "1"
+YML
+  docker compose -f "$cdir/docker-compose.yml" -p "$TEST_PROJ_A" up -d >/dev/null 2>&1 \
+    || skip "could not start label-only orphan project"
+  _proj_has_container "$TEST_PROJ_A" || skip "orphan has no container — env issue"
+
+  # Identified via the label scan despite no slot record → in the plan.
+  run cmd_reap
+  [ "$status" -eq 0 ] || fail "reap dry-run failed: $output"
+  [[ "$output" == *"$TEST_PROJ_A"* ]] || fail "label-only orphan not identified by the label scan: $output"
+
+  # And --force reaps it (real compose project → compose down removes it).
+  run cmd_reap --force
+  [ "$status" -eq 0 ] || fail "reap --force failed: $output"
+  _proj_has_container "$TEST_PROJ_A" && fail "label-only orphan survived --force"
+  return 0
+}
+
+@test "REAL: refusing to reap the reserved base 'showcase' name as an explicit target" {
+  load_reap
+  run cmd_reap showcase --force
+  [ "$status" -ne 0 ] || fail "reap allowed the reserved base 'showcase' target (must refuse)"
+  [[ "$output" == *"showcase"* ]] || fail "refusal message should name 'showcase': $output"
+}
+
+# ── An explicit target with NOTHING to tear down must not claim a phantom reap ──
+# A name with no slot record, no run dir, and (when docker is reachable) zero
+# containers + zero volumes classifies `inconclusive`. Tearing it down removes
+# nothing, so reap must report nothing-to-reap and count 0 — not "Reaped 1".
+@test "REAL: reap --force on a nonexistent target reaps NOTHING and counts 0 (no phantom reap)" {
+  load_reap
+  # A syntactically valid, harness-safe, but entirely nonexistent project name.
+  local missing="showcase-isotest-s3-${RAND}-ghost"
+  run cmd_reap "$missing" --force
+  [ "$status" -eq 0 ] || fail "reap of a nonexistent target should exit 0: $output"
+  [[ "$output" == *"Reaped 1"* ]] && fail "reap claimed a phantom teardown (Reaped 1) for a nonexistent target: $output"
+  [[ "$output" == *"Nothing to reap"* ]] \
+    || fail "reap should report nothing-to-reap for a nonexistent target: $output"
+}
+
+# A REAL existing target must still report reaped:1 (happy path preserved).
+@test "REAL: reap --force on a REAL existing target still counts it as reaped (happy path)" {
+  _docker_ok || skip "docker daemon unavailable"
+  _ensure_test_image || skip "cannot obtain $TEST_IMAGE"
+  load_reap
+
+  _leak_iso_project "$TEST_PROJ_A" 11 || skip "could not start throwaway project A"
+  _proj_has_container "$TEST_PROJ_A" || skip "project A has no container — env issue"
+
+  run cmd_reap "$TEST_PROJ_A" --force
+  [ "$status" -eq 0 ] || fail "single-target reap failed: $output"
+  [[ "$output" == *"Reaped 1"* ]] || fail "real target should report Reaped 1: $output"
+  _proj_has_container "$TEST_PROJ_A" && fail "real target survived its reap"
+  return 0
+}

--- a/showcase/scripts/__tests__/isolate-ttl-real.bats
+++ b/showcase/scripts/__tests__/isolate-ttl-real.bats
@@ -1,0 +1,264 @@
+#!/usr/bin/env bats
+# REAL-SURFACE TTL tests for Change 3 (ISOLATE_KEEP_TTL) in
+# scripts/cli/_common.sh. These mirror isolate-liveness-real.bats: real slot
+# dirs under a temp XDG_STATE_HOME, a real DEAD owning PID (spawn-then-`wait`),
+# and a REAL one-container `docker compose` project so containers ARE running.
+#
+# Change 3: a `kept` stack (running containers + dead/unverifiable owner — a
+# forgotten `--keep` leak) is protected only until it outlives ISOLATE_KEEP_TTL
+# (default 4h). The TTL age anchors on the slot's `pid`-file mtime, which is
+# aged via `touch -t`:
+#   * pid mtime now-5h (PAST the 4h TTL)  → liveness flips kept → stale, the
+#     sweep reaps it (containers + volumes + slot gone) and emits a LOUD warning
+#     naming project / age / TTL.
+#   * pid mtime now-1h (WITHIN the 4h TTL) → still `kept`, sweep leaves it alone.
+#
+# Hermeticity: every throwaway compose project uses a UNIQUE disposable name
+# (showcase-isotest-s2-<rand>), NEVER the base `showcase` name, and is torn
+# down in teardown(). All real-docker tests `skip` cleanly when docker is
+# unreachable or the test image cannot be obtained.
+
+fail() {
+  echo "$1"
+  return 1
+}
+
+TEST_IMAGE="alpine:3.20"
+
+_docker_ok() {
+  command -v docker >/dev/null 2>&1 || return 1
+  docker info >/dev/null 2>&1 || return 1
+  return 0
+}
+
+_ensure_test_image() {
+  docker image inspect "$TEST_IMAGE" >/dev/null 2>&1 && return 0
+  docker pull "$TEST_IMAGE" >/dev/null 2>&1
+}
+
+setup() {
+  COMMON="$BATS_TEST_DIRNAME/../cli/_common.sh"
+
+  export XDG_STATE_HOME="$BATS_TEST_TMPDIR/xdg"
+
+  export SHOWCASE_ROOT_OVERRIDE="$BATS_TEST_TMPDIR/root"
+  mkdir -p "$SHOWCASE_ROOT_OVERRIDE/shared"
+  cat > "$SHOWCASE_ROOT_OVERRIDE/shared/local-ports.json" <<'JSON'
+{ "mastra": 3104 }
+JSON
+  cat > "$SHOWCASE_ROOT_OVERRIDE/docker-compose.local.yml" <<'YML'
+services:
+  aimock:
+    container_name: showcase-aimock
+    ports:
+      - "4010:4010"
+YML
+
+  # Unique disposable project name — NEVER base `showcase`. S2-namespaced.
+  TEST_PROJ="showcase-isotest-s2-${BATS_TEST_NUMBER}-$$-${RANDOM}"
+}
+
+teardown() {
+  if command -v docker >/dev/null 2>&1 && [ -n "${TEST_PROJ:-}" ]; then
+    docker compose -p "$TEST_PROJ" down --remove-orphans --volumes >/dev/null 2>&1 || true
+  fi
+}
+
+load_common() {
+  # shellcheck disable=SC1090
+  source "$COMMON"
+  SHOWCASE_ROOT="$SHOWCASE_ROOT_OVERRIDE"
+  COMPOSE_FILE="$SHOWCASE_ROOT/docker-compose.local.yml"
+  PORTS_FILE="$SHOWCASE_ROOT/shared/local-ports.json"
+  COMPOSE_CMD="docker compose -f $COMPOSE_FILE"
+}
+
+# Start a REAL one-container compose project named <proj> running `sleep
+# infinity` so the container is RUNNING and carries the compose-project label.
+_start_real_project() {
+  local proj="$1"
+  local cdir="$BATS_TEST_TMPDIR/compose-$proj"
+  mkdir -p "$cdir"
+  cat > "$cdir/docker-compose.yml" <<YML
+services:
+  keeper:
+    image: $TEST_IMAGE
+    command: ["sleep", "infinity"]
+YML
+  docker compose -f "$cdir/docker-compose.yml" -p "$proj" up -d >/dev/null 2>&1
+}
+
+# Spawn a short-lived process, wait for exit, echo its (now dead) pid.
+_make_dead_pid() {
+  local p
+  bash -c 'exit 0' &
+  p=$!
+  wait "$p" 2>/dev/null || true
+  if kill -0 "$p" 2>/dev/null; then
+    skip "PID $p was recycled to a live process — dead-PID fixture invalid"
+  fi
+  echo "$p"
+}
+
+# _age_pid_file <pidfile> <hours_ago> — set the pid file's mtime to N hours in
+# the past (the TTL anchor). Cross-platform `touch -t [[CC]YY]MMDDhhmm.ss`.
+_age_pid_file() {
+  local pidfile="$1" hours_ago="$2" stamp
+  if [[ "$OSTYPE" == darwin* ]]; then
+    stamp="$(date -v-"${hours_ago}"H +%Y%m%d%H%M.%S)"
+  else
+    stamp="$(date -d "${hours_ago} hours ago" +%Y%m%d%H%M.%S)"
+  fi
+  touch -t "$stamp" "$pidfile"
+}
+
+# ── Change 3: TTL on running kept stacks ─────────────────────────────────────
+
+@test "REAL: a kept slot aged PAST the keep TTL classifies stale (not kept)" {
+  _docker_ok || skip "docker daemon unavailable"
+  _ensure_test_image || skip "cannot obtain $TEST_IMAGE"
+  load_common
+
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  echo "$TEST_PROJ" > "$slots/0/project"
+  local dead_pid
+  dead_pid="$(_make_dead_pid)"
+  echo "$dead_pid" > "$slots/0/pid"
+
+  _start_real_project "$TEST_PROJ" || skip "could not start throwaway compose project"
+  [ -n "$(docker ps -q --filter "label=com.docker.compose.project=$TEST_PROJ")" ] \
+    || skip "throwaway project has no running container — environment issue"
+
+  # Within TTL (pid mtime ~now): a kept stack is protected.
+  run _slot_liveness 0
+  [ "$status" -eq 0 ] || fail "_slot_liveness 0 failed: $output"
+  [ "$output" = "kept" ] \
+    || fail "expected 'kept' for fresh dead-owner+running-containers slot, got '$output'"
+
+  # Age the pid-file anchor to 5h ago — past the 4h default TTL.
+  _age_pid_file "$slots/0/pid" 5
+
+  # PAST the TTL: the kept stack reclassifies stale (the kept→stale transition).
+  run _slot_liveness 0
+  [ "$status" -eq 0 ] || fail "_slot_liveness 0 failed after aging: $output"
+  [ "$output" = "stale" ] \
+    || fail "expected 'stale' for kept slot aged past keep TTL, got '$output' (pre-TTL bug returns 'kept')"
+}
+
+@test "REAL: sweep reaps a kept stack past the TTL and emits the loud project/age/TTL warning" {
+  _docker_ok || skip "docker daemon unavailable"
+  _ensure_test_image || skip "cannot obtain $TEST_IMAGE"
+  load_common
+
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  echo "$TEST_PROJ" > "$slots/0/project"
+  local dead_pid
+  dead_pid="$(_make_dead_pid)"
+  echo "$dead_pid" > "$slots/0/pid"
+
+  _start_real_project "$TEST_PROJ" || skip "could not start throwaway compose project"
+  [ -n "$(docker ps -q --filter "label=com.docker.compose.project=$TEST_PROJ")" ] \
+    || skip "throwaway project has no running container — environment issue"
+
+  # Age the kept slot past the TTL so the sweep will reclassify + reap it.
+  _age_pid_file "$slots/0/pid" 5
+
+  # Sweep (real path the claim runs opportunistically). Capture its output.
+  run _sweep_isolate_slots
+  [ "$status" -eq 0 ] || fail "_sweep_isolate_slots failed: $output"
+
+  # The loud warning names the project, an age, and the keep TTL.
+  [[ "$output" == *"reaping kept stack '$TEST_PROJ'"* ]] \
+    || fail "warning did not name the project: $output"
+  [[ "$output" == *"keep TTL ${ISOLATE_KEEP_TTL}s"* ]] \
+    || fail "warning did not name the keep TTL: $output"
+  [[ "$output" == *"age "*"s >"* ]] \
+    || fail "warning did not name the age: $output"
+  [[ "$output" == *"forgotten --keep leak"* ]] \
+    || fail "warning did not flag the forgotten --keep leak: $output"
+
+  # Reaped: containers gone, volumes gone, slot dir gone.
+  [ -z "$(docker ps -aq --filter "label=com.docker.compose.project=$TEST_PROJ")" ] \
+    || fail "kept stack's containers survived the past-TTL sweep"
+  [ -z "$(docker volume ls -q --filter "label=com.docker.compose.project=$TEST_PROJ")" ] \
+    || fail "kept stack's volumes survived the past-TTL sweep"
+  [ ! -d "$slots/0" ] \
+    || fail "kept stack's slot dir survived the past-TTL sweep"
+}
+
+@test "REAL: sweep PRESERVES a kept stack still within the TTL" {
+  _docker_ok || skip "docker daemon unavailable"
+  _ensure_test_image || skip "cannot obtain $TEST_IMAGE"
+  load_common
+
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  echo "$TEST_PROJ" > "$slots/0/project"
+  local dead_pid
+  dead_pid="$(_make_dead_pid)"
+  echo "$dead_pid" > "$slots/0/pid"
+
+  _start_real_project "$TEST_PROJ" || skip "could not start throwaway compose project"
+  [ -n "$(docker ps -q --filter "label=com.docker.compose.project=$TEST_PROJ")" ] \
+    || skip "throwaway project has no running container — environment issue"
+
+  # Age to 1h ago — WITHIN the 4h default TTL: still kept, must survive a sweep.
+  _age_pid_file "$slots/0/pid" 1
+
+  run _slot_liveness 0
+  [ "$output" = "kept" ] || fail "precondition: within-TTL slot should be 'kept', got '$output'"
+
+  run _sweep_isolate_slots
+  [ "$status" -eq 0 ] || fail "_sweep_isolate_slots failed: $output"
+  [[ "$output" != *"reaping kept stack"* ]] \
+    || fail "sweep wrongly reaped a within-TTL kept stack: $output"
+
+  [ -d "$slots/0" ] \
+    || fail "within-TTL kept slot dir was reaped"
+  [ -n "$(docker ps -q --filter "label=com.docker.compose.project=$TEST_PROJ")" ] \
+    || fail "within-TTL kept stack's containers were torn down"
+  run cat "$slots/0/project"
+  [ "$output" = "$TEST_PROJ" ] || fail "within-TTL kept slot project mangled: $output"
+}
+
+# Mandatory-fallback regression: a kept slot whose `pid` and `project` files are
+# unstattable must still age out via the slot-dir mtime → ISOLATE_STALE_THRESHOLD
+# path rather than living forever. Here the pid/project mtimes are aged past the
+# 4h TTL too, but the point is the anchor chain never returns empty for a
+# present slot, so the transition fires. (Direct empty-anchor injection is not
+# possible on a real slot dir — every present file is stattable — so we assert
+# the chain's resilience: removing pid/project still yields a stale verdict via
+# slot-dir mtime under a low ISOLATE_STALE_THRESHOLD.)
+@test "REAL: a kept stack with no pid/project anchor still ages out via the fallback chain" {
+  _docker_ok || skip "docker daemon unavailable"
+  _ensure_test_image || skip "cannot obtain $TEST_IMAGE"
+  load_common
+
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  echo "$TEST_PROJ" > "$slots/0/project"
+  local dead_pid
+  dead_pid="$(_make_dead_pid)"
+  echo "$dead_pid" > "$slots/0/pid"
+
+  _start_real_project "$TEST_PROJ" || skip "could not start throwaway compose project"
+  [ -n "$(docker ps -q --filter "label=com.docker.compose.project=$TEST_PROJ")" ] \
+    || skip "throwaway project has no running container — environment issue"
+
+  # Force the anchor chain onto its LAST link: pid + project both aged past the
+  # TTL. _kept_slot_age must pick up the pid mtime (first stattable link) and
+  # return a > TTL age → stale. This exercises that a present slot always yields
+  # a numeric age (never empty) so the transition cannot silently no-op.
+  _age_pid_file "$slots/0/pid" 6
+  _age_pid_file "$slots/0/project" 6
+
+  run _kept_slot_age 0
+  [ "$status" -eq 0 ] || fail "_kept_slot_age 0 failed: $output"
+  [[ "$output" =~ ^[0-9]+$ ]] || fail "_kept_slot_age returned non-numeric (would skip TTL): '$output'"
+  [ "$output" -gt "$ISOLATE_KEEP_TTL" ] || fail "expected age > TTL, got '$output'"
+
+  run _slot_liveness 0
+  [ "$output" = "stale" ] || fail "expected 'stale' via fallback-chain anchor, got '$output'"
+}

--- a/showcase/scripts/__tests__/isolate.bats
+++ b/showcase/scripts/__tests__/isolate.bats
@@ -65,6 +65,29 @@ _assert_stub_sentinel_logged() {
     || fail "sentinel 'docker version' invocation not logged — stub/DOCKER_LOG pipeline broken: $(cat "$DOCKER_LOG")"
 }
 
+# _seed_live_owner <slot-dir> [pid] — record a LIVE, start-time-VERIFIED owner
+# in <slot-dir>: write the pid file AND a matching pid.start (the new
+# anti-PID-reuse fingerprint). Under the post-Change-1 owner contract a bare
+# `pid` file with NO pid.start is "unverifiable" (treated as dead), so every
+# fixture that wants a slot to read `live` via its owning PID must seed BOTH
+# files — that is what this helper does. Defaults to $$ (the bats process,
+# definitely alive). The pid.start is produced by the SAME _pid_start_time
+# helper the classifier reads, so the recorded and current values match. The
+# pid file is written FIRST (preserving the claim-time write order the
+# classifier's "missing pid ⇒ owner gone" signal relies on).
+#
+# NB: this sources _common.sh into the CURRENT shell to reach _pid_start_time.
+# Tests that have already run load_common are unaffected; tests that have not
+# get a harmless extra source (the path vars are re-pointed by load_common).
+_seed_live_owner() {
+  local slotdir="${1:?slot dir required}"
+  local pid="${2:-$$}"
+  # shellcheck disable=SC1090
+  type _pid_start_time >/dev/null 2>&1 || source "$COMMON"
+  echo "$pid" > "$slotdir/pid"
+  _pid_start_time "$pid" > "$slotdir/pid.start"
+}
+
 setup() {
   COMMON="$BATS_TEST_DIRNAME/../cli/_common.sh"
 
@@ -254,6 +277,31 @@ load_common() {
   [ -d "$ISOLATE_TMPDIR" ] || fail "run dir not created: $ISOLATE_TMPDIR"
 }
 
+@test "apply_isolation stamps the com.copilotkit.showcase.isolate label on every service" {
+  # The forward-stack self-id label is what lets `showcase reap` identify a
+  # harness-owned isolated project even when its slot record + run dir are both
+  # gone (a user-supplied --isolate <name> orphan). Drive the REAL rewrite and
+  # assert the label landed on the (only) service, right under its rewritten
+  # container_name, as a compose-native labels: block.
+  require_python3
+  load_common
+  apply_isolation foo
+  local rewritten="$ISOLATE_TMPDIR/docker-compose.local.yml"
+  [ -f "$rewritten" ] || fail "rewritten compose not created: $rewritten"
+  grep -q 'com.copilotkit.showcase.isolate: "1"' "$rewritten" \
+    || fail "self-id label not stamped into the rewritten compose:
+$(cat "$rewritten")"
+  # The label must sit under a labels: block, not be orphaned at the wrong
+  # indent — assert the labels: key is present too.
+  grep -q '^    labels:$' "$rewritten" \
+    || fail "labels: block missing/mis-indented in the rewritten compose:
+$(cat "$rewritten")"
+  # And it never touched the source compose (originals stay pristine).
+  grep -q 'com.copilotkit.showcase.isolate' "$SHOWCASE_ROOT/docker-compose.local.yml" \
+    && fail "source compose was mutated with the label (must rewrite a COPY only)"
+  return 0
+}
+
 # ── Change 2: stale-slot reaping by compose-project liveness ─────────────────
 
 @test "claim reaps a slot whose project has no live containers and no live owning PID" {
@@ -315,7 +363,7 @@ load_common() {
   local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
   mkdir -p "$slots/0"
   echo "racer-proj" > "$slots/0/project"
-  echo "$$" > "$slots/0/pid"   # this bats process — definitely alive
+  _seed_live_owner "$slots/0"   # this bats process — definitely alive (pid + pid.start)
 
   export DOCKER_PS_OUTPUT=""   # no containers yet (still building)
   _claim_isolate_slot
@@ -867,6 +915,42 @@ load_common() {
   [ "$status" -ne 0 ] || fail "keep path composed the kept stack down: $output"
 }
 
+# The survival notice's human-readable hours must track ISOLATE_KEEP_TTL, not a
+# hardcoded "(4h)". SHOWCASE_ISOLATE_KEEP_TTL is read at source time, so it must
+# be exported BEFORE load_common sources _common.sh.
+@test "survival notice's human-readable hours track an overridden ISOLATE_KEEP_TTL (not a stale (4h))" {
+  require_python3
+  export SHOWCASE_ISOLATE_KEEP_TTL=7200   # 2h, not the 4h default
+  load_common
+  [ "$ISOLATE_KEEP_TTL" = 7200 ] || fail "precondition: TTL override not picked up, got '$ISOLATE_KEEP_TTL'"
+  apply_isolation keepttl
+
+  ISOLATE_KEEP=true
+  run restore_isolation
+  [ "$status" -eq 0 ] || fail "restore_isolation failed under keep: $output"
+
+  # The seconds value must reflect the override.
+  [[ "$output" == *"7200s"* ]] || fail "notice missing overridden TTL seconds: $output"
+  # And the parenthetical hours must NOT contradict it with a stale 4h.
+  [[ "$output" != *"(4h)"* ]] || fail "notice still says (4h) for a 2h TTL: $output"
+  # The computed hours should read sensibly (2h here).
+  [[ "$output" == *"(2h)"* ]] || fail "notice missing computed (2h): $output"
+}
+
+@test "survival notice reads sensibly at the default ISOLATE_KEEP_TTL (4h)" {
+  require_python3
+  load_common
+  [ "$ISOLATE_KEEP_TTL" = 14400 ] || fail "precondition: expected default TTL 14400, got '$ISOLATE_KEEP_TTL'"
+  apply_isolation keepdef
+
+  ISOLATE_KEEP=true
+  run restore_isolation
+  [ "$status" -eq 0 ] || fail "restore_isolation failed under keep: $output"
+
+  [[ "$output" == *"14400s"* ]] || fail "notice missing default TTL seconds: $output"
+  [[ "$output" == *"(4h)"* ]] || fail "notice missing default (4h): $output"
+}
+
 # ── Change 4: a FAILED apply_isolation must never down the default stack ─────
 #
 # cmd-test.sh registers `trap restore_isolation EXIT` BEFORE calling
@@ -1073,7 +1157,7 @@ load_common() {
   local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
   mkdir -p "$slots/0"
   echo "dupename" > "$slots/0/project"
-  echo "$$" > "$slots/0/pid"
+  _seed_live_owner "$slots/0"
 
   export DOCKER_PS_OUTPUT=""   # zero containers (still building) — PID protects
   run apply_isolation dupename
@@ -1117,7 +1201,7 @@ load_common() {
   # Winner: slot 0 already holds 'dup' (live owning PID) plus its run dir.
   mkdir -p "$slots/0"
   echo "dup" > "$slots/0/project"
-  echo "$$" > "$slots/0/pid"
+  _seed_live_owner "$slots/0"
   mkdir -p "$base/runs/dup"
   touch "$base/runs/dup/docker-compose.local.yml"
   export DOCKER_PS_OUTPUT=""   # zero containers (still building) — PID protects
@@ -1177,7 +1261,7 @@ load_common() {
   local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
   mkdir -p "$slots/0"
   echo "tiename" > "$slots/0/project"
-  echo "$$" > "$slots/0/pid"           # live owner — sweep must not reap it
+  _seed_live_owner "$slots/0"          # live owner — sweep must not reap it
   export DOCKER_PS_OUTPUT=""
 
   _file_mtime() { echo 1700000000; }   # our record and theirs: EQUAL mtimes
@@ -1434,7 +1518,7 @@ FIXTURE
   local n
   for n in 1 2 3; do
     mkdir -p "$slots/$n"
-    echo "$$" > "$slots/$n/pid"   # this bats process — definitely alive
+    _seed_live_owner "$slots/$n"   # this bats process — definitely alive (pid + pid.start)
   done
 
   export SHOWCASE_ISO_SLOT=9
@@ -1461,7 +1545,7 @@ FIXTURE
   load_common
   local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
   mkdir -p "$slots/9"
-  echo "$$" > "$slots/9/pid"   # this bats process — _slot_liveness → live
+  _seed_live_owner "$slots/9"   # this bats process — _slot_liveness → live
 
   export SHOWCASE_ISO_SLOT=9
   run _claim_isolate_slot
@@ -1621,7 +1705,7 @@ FIXTURE
   local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
   mkdir -p "$slots/8"
   echo "iso8-proj" > "$slots/8/project"
-  echo "$$" > "$slots/8/pid"   # _slot_liveness 8 → live (pid live, no containers needed)
+  _seed_live_owner "$slots/8"   # _slot_liveness 8 → live (pid live + pid.start, no containers needed)
 
   # Case A: docker listener on slot 8's dashboard port → filtered as own-project.
   export DOCKER_PS_OUTPUT=""   # no docker containers; pid-liveness still wins
@@ -1663,7 +1747,7 @@ FIXTURE
   local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
   mkdir -p "$slots/5"
   echo "iso5-proj" > "$slots/5/project"
-  echo "$$" > "$slots/5/pid"   # this bats process — _slot_liveness → live
+  _seed_live_owner "$slots/5"   # this bats process — _slot_liveness → live (pid + pid.start)
 
   # No held ports → _slot_ports_free returns 0 → ports="free".
   export LSOF_HOLD_PORTS=""
@@ -1754,7 +1838,7 @@ FIXTURE
   local n
   for n in 1 2 3 4 5 6 7 8; do
     mkdir -p "$slots/$n"
-    echo "$$" > "$slots/$n/pid"   # this bats process — definitely alive
+    _seed_live_owner "$slots/$n"   # this bats process — definitely alive (pid + pid.start)
   done
 
   # No held ports for any slot's offset range → _slot_ports_free returns 0

--- a/showcase/scripts/cli/_common.sh
+++ b/showcase/scripts/cli/_common.sh
@@ -147,6 +147,12 @@ _showcase_state_base() { printf '%s/copilotkit/showcase' "${XDG_STATE_HOME:-$HOM
 # protection via pid is also unreliable.
 ISOLATE_SLOT_DIR="$(_showcase_state_base)/slots"
 ISOLATE_STALE_THRESHOLD=7200  # 2 hours in seconds — slot-age fallback
+# TTL on a `kept` stack (running containers whose owning process is gone or
+# unverifiable — a forgotten `--keep` leak). Once a kept slot's age exceeds this
+# TTL it is reclassified `stale` and reaped by the sweep, so a --keep'd stack
+# left running with no owner cannot accumulate indefinitely. Default 4 hours.
+# Overridable via SHOWCASE_ISOLATE_KEEP_TTL (e.g. for tests / longer sessions).
+ISOLATE_KEEP_TTL="${SHOWCASE_ISOLATE_KEEP_TTL:-14400}"  # 4 hours in seconds
 # The sweep lock is held only for the duration of one sweep pass (seconds, even
 # with all 46 slots populated). A crashed sweeper's leftover lock must not
 # disable stale reaping for the full 2-hour SLOT threshold — give the lock its
@@ -163,6 +169,65 @@ _file_mtime() {
     stat -f %m "$1" 2>/dev/null || true
   else
     stat -c %Y "$1" 2>/dev/null || true
+  fi
+}
+
+# _kept_slot_age <slot> — age in seconds of a slot for the ISOLATE_KEEP_TTL
+# comparison, or empty when no anchor can be stat'ed. The TTL anchor is the
+# `pid` file's mtime: it is written ONCE at claim (~line 406) and never
+# rewritten, so it is a stable claim-time stamp (and `pid.start` is a SIBLING
+# file, so writing it never disturbs `pid`'s mtime). Mandatory fallback chain so
+# a kept slot is never immortal even if `pid` is gone: pid-file mtime →
+# `project`-file mtime → slot-dir mtime. If NONE of these can be stat'ed the
+# caller falls back to the existing ISOLATE_STALE_THRESHOLD age path; without
+# that fallback an unstattable anchor would skip the age comparison and the
+# kept→stale transition would silently never fire.
+_kept_slot_age() {
+  local slot_entry="$ISOLATE_SLOT_DIR/${1:?slot required}"
+  local anchor anchor_mtime
+  for anchor in "$slot_entry/pid" "$slot_entry/project" "$slot_entry"; do
+    anchor_mtime="$(_file_mtime "$anchor")"
+    if [[ "$anchor_mtime" =~ ^[0-9]+$ ]]; then
+      printf '%d\n' "$(( $(date +%s) - anchor_mtime ))"
+      return 0
+    fi
+  done
+  return 0
+}
+
+# _pid_start_time <pid> — the process start time of <pid> as an opaque,
+# platform-native string, or empty when it cannot be read (no such pid, EPERM
+# on a cross-user pid, or an unsupported platform). This is the anti-PID-reuse
+# fingerprint: a recycled pid lands on a DIFFERENT process with a DIFFERENT
+# start time, so a recorded-vs-current mismatch means the original owner is
+# gone. The exact textual format is never interpreted — it only has to be
+# stable for one process's lifetime and to DIFFER across a pid recycle, which
+# both forms below satisfy. Written to a `pid.start` sibling of the slot's
+# `pid` file at claim and re-read at verify; the SAME function produces both
+# sides so the comparison can never drift across a format change.
+#   macOS:  `ps -o lstart=` — the full "Wed Jun 26 11:33:20 2026" start stamp.
+#   Linux:  field 22 of /proc/<pid>/stat — starttime in clock ticks since boot.
+_pid_start_time() {
+  local pid="${1:?pid required}"
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 0
+  if [[ "$OSTYPE" == darwin* ]]; then
+    # ps prints a fixed-format date; trim surrounding whitespace so a stray
+    # leading/trailing space can never manufacture a spurious mismatch.
+    local out
+    out="$(ps -o lstart= -p "$pid" 2>/dev/null || true)"
+    printf '%s' "$out" | awk '{$1=$1; print}'
+  elif [ -r "/proc/$pid/stat" ]; then
+    # /proc/<pid>/stat: comm (field 2) is parenthesized and may contain spaces;
+    # split on the LAST ')' so the numeric fields after it line up regardless.
+    local stat rest
+    stat="$(cat "/proc/$pid/stat" 2>/dev/null || true)"
+    [ -n "$stat" ] || return 0
+    rest="${stat##*) }"
+    # After comm+state, starttime is field 22 of the full line == field 20 of
+    # `rest` (rest begins at field 3 = state). state ppid pgrp session tty_nr
+    # tpgid flags minflt cminflt majflt cmajflt utime stime cutime cstime
+    # priority nice num_threads itrealvalue starttime → 20th token.
+    printf '%s' "$rest" | awk '{print $20}'
   fi
 }
 
@@ -402,31 +467,126 @@ _claim_isolate_slot() {
     [ -n "${ISOLATE_SLOT:-}" ] || die "No isolation slots available (1-$ISOLATE_MAX_SLOT exhausted)"
   fi
 
-  # Common post-claim
+  # Common post-claim. Write order is load-bearing: `pid` FIRST (preserving the
+  # "pid written before the project record" invariant the liveness classifier
+  # relies on — a missing pid file with a recorded project means the owner is
+  # genuinely gone), THEN `pid.start`. `pid.start` is the anti-reuse
+  # fingerprint: the owning process's start time, re-read and compared at
+  # liveness time so a recycled pid (same number, different process, different
+  # start time) reads as "owner gone" rather than spuriously alive. It is a
+  # SIBLING file, written AFTER pid, so it never perturbs the `pid` file's own
+  # mtime (which the kept-slot TTL anchor depends on). A crash between the two
+  # writes leaves `pid` but no `pid.start` → owner "unverifiable" → treated as
+  # dead, which is the safe direction.
   echo "$$" > "$ISOLATE_SLOT_DIR/$ISOLATE_SLOT/pid"
+  _pid_start_time "$$" > "$ISOLATE_SLOT_DIR/$ISOLATE_SLOT/pid.start"
   ISOLATE_PORT_OFFSET=$(( (ISOLATE_SLOT + 1) * 200 ))
   return 0
 }
 
-# Classify a single isolation slot as live | stale | inconclusive — pure
-# classification, no reaping, no info logging. Shared between
+# _owner_liveness <slot> — classify the slot's OWNING PROCESS, independent of
+# any container state. Prints exactly one word and exits 0:
+#   alive        — pid file present + numeric + kill -0 succeeds AND the pid's
+#                  current start time matches the recorded pid.start.
+#   reused       — kill -0 succeeds but the current start time DIFFERS from the
+#                  recorded pid.start: the pid was recycled to a NEW process,
+#                  so the original owner is gone.
+#   dead         — pid file present + numeric but kill -0 fails (ESRCH, or
+#                  EPERM on a cross-user pid — both read as "not our owner",
+#                  matching the single-user model documented at the top of
+#                  this file; we do NOT parse kill -0 stderr, which is
+#                  locale/platform fragile).
+#   unverifiable — pid file present + numeric + alive, but no readable
+#                  pid.start to verify against (legacy slot written before the
+#                  pid.start invariant, a crash between the pid and pid.start
+#                  writes, or a platform that cannot read process start times).
+#                  Treated as "owner gone" by every caller — REMOVES the old
+#                  bare-kill-0 reuse hole at the cost of demoting a legacy
+#                  live-owner slot to kept (TTL-reaped) instead of protected.
+#   absent       — no pid file, or its contents are empty/non-numeric
+#                  (inconclusive: a truncated pid write, or a project-less
+#                  legacy slot). Distinct from `dead`: callers route this to
+#                  the age fallback, never to an immediate PID-driven reap.
+#
+# This is the SINGLE source of truth for owner liveness, shared by
+# _slot_liveness (the live|kept|stale classifier) and _slot_state (the table's
+# PID annotation) so the two can never diverge.
+_owner_liveness() {
+  local slot="${1:?slot required}"
+  local slot_entry="$ISOLATE_SLOT_DIR/$slot"
+  local slot_pid_file="$slot_entry/pid"
+  local slot_pid=""
+  if [ -f "$slot_pid_file" ]; then
+    slot_pid="$(cat "$slot_pid_file" 2>/dev/null || true)"
+  fi
+  if ! [[ "$slot_pid" =~ ^[0-9]+$ ]]; then
+    printf 'absent\n'
+    return 0
+  fi
+  # kill -0 failure (ESRCH or EPERM) → the pid is not a process we own → dead.
+  if ! kill -0 "$slot_pid" 2>/dev/null; then
+    printf 'dead\n'
+    return 0
+  fi
+  # Pid is alive — but is it the SAME process we recorded? Verify start time.
+  local recorded_start=""
+  if [ -f "$slot_entry/pid.start" ]; then
+    recorded_start="$(cat "$slot_entry/pid.start" 2>/dev/null || true)"
+  fi
+  if [ -z "$recorded_start" ]; then
+    # No fingerprint to verify against — cannot prove this is our owner.
+    printf 'unverifiable\n'
+    return 0
+  fi
+  local current_start
+  current_start="$(_pid_start_time "$slot_pid")"
+  if [ -z "$current_start" ]; then
+    # Pid is alive (kill -0 ok) but its start time is unreadable (e.g. EPERM on
+    # a cross-user pid) — cannot confirm identity → treat as unverifiable.
+    printf 'unverifiable\n'
+    return 0
+  fi
+  if [ "$current_start" = "$recorded_start" ]; then
+    printf 'alive\n'
+  else
+    printf 'reused\n'
+  fi
+  return 0
+}
+
+# Classify a single isolation slot as live | kept | stale | inconclusive —
+# pure classification, no reaping, no info logging. Shared between
 # _sweep_isolate_slots (which reaps stale slots) and the picker (which avoids
 # binding to live slots). Always prints exactly one word to stdout and exits 0.
 #
-# Signals (in order, matching the sweeper's documented staleness contract):
-#   1. Compose-project liveness — live containers under the slot's recorded
-#      compose project → live. Docker-ps failure → inconclusive (warn and
-#      leave it alone, same as the sweeper).
-#   2. Owning-PID liveness — pid file present + numeric + kill -0 succeeds
-#      → live. Numeric pid but kill -0 fails → stale.
-#   3. Project recorded + no pid file at all → stale (claim writes the pid
-#      file BEFORE the project record, so missing pid means owner state is
-#      genuinely gone).
-#   4. Age fallback — pid check inconclusive (pid file missing on a
-#      project-less legacy slot, OR present-but-empty/non-numeric on any
-#      slot) AND age > ISOLATE_STALE_THRESHOLD → stale.
-#   5. Otherwise → inconclusive (slot dir vanished mid-check, fresh slot
-#      whose pid write hasn't landed yet, etc.).
+# Governing rule: when a slot has RUNNING containers, the container check wins
+# → the slot is `kept` or `live`, NEVER reaped solely on an owner-PID result.
+# Owner liveness only UPGRADES a running-container slot from TTL-bounded `kept`
+# to indefinitely-protected `live`; it can never by itself make a
+# running-container slot eligible for immediate reaping.
+#
+# Signals (in order):
+#   1. Compose-project containers first. Docker-ps failure → inconclusive
+#      (warn and leave it alone, unchanged). If containers ARE running, branch
+#      on owner liveness:
+#        - owner alive (start-time-verified)            → live
+#        - owner dead / reused / unverifiable / absent  → kept: owning
+#          process gone (or unprovable) but the project still has running
+#          containers. NOT live, NOT immediately stale. The kept-slot TTL
+#          (below) governs the kept→stale transition: a `kept` slot is left
+#          alone until it outlives ISOLATE_KEEP_TTL, then ages out to stale.
+#   2. No running containers (or none recorded). The owner PID is authoritative
+#      for "in active use":
+#        - owner alive (start-time-verified)            → live (e.g. mid-build
+#          before any container exists)
+#        - owner dead OR reused                         → stale
+#   3. Project recorded + no pid file (owner absent) + no running containers
+#      → stale (claim writes the pid file BEFORE the project record, so a
+#      missing pid means the owner state is genuinely gone). Unchanged.
+#   4. Age fallback — owner absent/unverifiable (missing/empty/non-numeric pid,
+#      or a live-but-unverifiable owner on a project-less legacy slot) AND age
+#      > ISOLATE_STALE_THRESHOLD → stale. Unchanged.
+#   5. Otherwise → inconclusive.
 _slot_liveness() {
   local slot="${1:?slot required}"
   local slot_entry="$ISOLATE_SLOT_DIR/$slot"
@@ -434,6 +594,8 @@ _slot_liveness() {
     printf 'inconclusive\n'
     return 0
   fi
+  local owner
+  owner="$(_owner_liveness "$slot")"
   local slot_proj has_proj=false
   slot_proj="$(cat "$slot_entry/project" 2>/dev/null || true)"
   if [ -n "$slot_proj" ]; then
@@ -445,25 +607,68 @@ _slot_liveness() {
       return 0
     fi
     if [ -n "$live_containers" ]; then
-      printf 'live\n'
+      # Running containers → the container check wins. A live, start-time-
+      # verified owner protects the slot indefinitely (`live`); any other
+      # owner state (dead/reused/unverifiable/absent) means the owning process
+      # is gone or unprovable while containers still run → `kept`.
+      if [ "$owner" = "alive" ]; then
+        printf 'live\n'
+        return 0
+      fi
+      # ── TTL on running kept stacks ────────────────────────────────────────
+      # The owner is gone/unprovable while containers still run → `kept`. A
+      # `kept` stack is protected only until it outlives ISOLATE_KEEP_TTL: a
+      # forgotten `--keep` must not accumulate indefinitely. Age anchors on the
+      # `pid`-file mtime (stable claim-time stamp), with the mandatory fallback
+      # chain in _kept_slot_age (pid → project → slot-dir mtime → the existing
+      # ISOLATE_STALE_THRESHOLD path) so a kept slot is never immortal.
+      local kept_age
+      kept_age="$(_kept_slot_age "$slot")"
+      if [[ "$kept_age" =~ ^[0-9]+$ ]]; then
+        if [ "$kept_age" -gt "$ISOLATE_KEEP_TTL" ]; then
+          printf 'stale\n'
+          return 0
+        fi
+        printf 'kept\n'
+        return 0
+      fi
+      # No anchor was stat'able: fall back to the slot-age / ISOLATE_STALE_
+      # THRESHOLD path below so an unanchored kept slot still ages out to stale
+      # rather than living forever.
+      local fallback_mtime
+      fallback_mtime="$(_file_mtime "$slot_entry")"
+      if [[ "$fallback_mtime" =~ ^[0-9]+$ ]]; then
+        local fallback_age
+        fallback_age=$(( $(date +%s) - fallback_mtime ))
+        if [ "$fallback_age" -gt "$ISOLATE_STALE_THRESHOLD" ]; then
+          printf 'stale\n'
+          return 0
+        fi
+      fi
+      printf 'kept\n'
       return 0
     fi
   fi
-  local slot_pid_file="$slot_entry/pid"
-  local slot_pid="" pid_file_present=false
-  if [ -f "$slot_pid_file" ]; then
-    pid_file_present=true
-    slot_pid="$(cat "$slot_pid_file" 2>/dev/null || true)"
+  # No running containers (or none recorded): the owner PID is authoritative.
+  if [ "$owner" = "alive" ]; then
+    printf 'live\n'
+    return 0
   fi
-  if [[ "$slot_pid" =~ ^[0-9]+$ ]]; then
-    if kill -0 "$slot_pid" 2>/dev/null; then
-      printf 'live\n'
-      return 0
-    fi
+  # A numeric owner pid that is dead, reused, or alive-but-unverifiable is
+  # authoritative proof the original owner is gone (no containers to defer to)
+  # → stale. `absent` (no numeric pid at all) is NOT proof — it routes to the
+  # project / age fallbacks below.
+  if [ "$owner" = "dead" ] || [ "$owner" = "reused" ] || [ "$owner" = "unverifiable" ]; then
     printf 'stale\n'
     return 0
   fi
-  if [ "$has_proj" = true ] && [ "$pid_file_present" = false ]; then
+  # owner is `absent` from here on (no pid file, or empty/non-numeric contents).
+  if [ "$has_proj" = true ] && [ ! -f "$slot_entry/pid" ]; then
+    # Project recorded, no live containers, and no pid file AT ALL — the claim
+    # writes the pid file BEFORE the project record, so a missing pid means the
+    # owner state is genuinely gone → stale. A present-but-empty/non-numeric
+    # pid file is NOT this case: it may be a live owner mid-build whose pid
+    # write was truncated, so it defers to the age fallback below.
     printf 'stale\n'
     return 0
   fi
@@ -527,11 +732,15 @@ _sweep_isolate_slots() {
     slot_name="$(basename "$slot_entry")"
     local liveness
     liveness="$(_slot_liveness "$slot_name")"
-    if [ "$liveness" = "live" ] || [ "$liveness" = "inconclusive" ]; then
-      # `live` → in use (running containers or live owning PID). `inconclusive`
-      # → docker-ps failure (already warned by _slot_liveness), or a slot dir
-      # that vanished mid-check, or a fresh-but-not-yet-aged slot whose pid
-      # write hasn't landed. Either way: leave it alone.
+    if [ "$liveness" = "live" ] || [ "$liveness" = "kept" ] || [ "$liveness" = "inconclusive" ]; then
+      # `live` → in active use (running containers + live verified owner, or a
+      # live verified owner mid-build). `kept` → running containers whose owner
+      # is gone/unprovable — a --keep'd stack — protected until it outlives
+      # ISOLATE_KEEP_TTL, at which point _slot_liveness returns `stale` and the
+      # reap path below (with the loud kept-past-TTL warning) fires.
+      # `inconclusive` → docker-ps failure (already warned by _slot_liveness),
+      # or a slot dir that vanished mid-check, or a fresh-but-not-yet-aged slot
+      # whose pid write hasn't landed. Either way: leave it alone.
       continue
     fi
     # Stale. Re-derive the evidence to emit the exact reason in the info line
@@ -547,7 +756,29 @@ _sweep_isolate_slots() {
       slot_pid="$(cat "$slot_pid_file" 2>/dev/null || true)"
     fi
     if [[ "$slot_pid" =~ ^[0-9]+$ ]]; then
-      info "Attempting to reclaim stale slot $slot_name (PID $slot_pid dead)"
+      # The classifier called this stale with a numeric pid: the owner is dead,
+      # the pid was reused, or it is alive-but-unverifiable (no pid.start). Name
+      # the shared owner verdict so the reason matches the classifier exactly.
+      local owner_verdict
+      owner_verdict="$(_owner_liveness "$slot_name")"
+      # Distinguish a kept stack reaped PAST its TTL: a recorded project whose
+      # containers are STILL RUNNING, yet liveness came back `stale` — the only
+      # way that happens for a numeric-pid slot is the ISOLATE_KEEP_TTL
+      # transition (a forgotten `--keep` leak). Emit a LOUD warning naming
+      # project / age / TTL so the leak is visible, not a quiet info line.
+      if [ "$has_proj" = true ]; then
+        local running_containers=""
+        running_containers="$(docker ps -q --filter "label=com.docker.compose.project=$slot_proj" 2>/dev/null || true)"
+        if [ -n "$running_containers" ]; then
+          local kept_age
+          kept_age="$(_kept_slot_age "$slot_name")"
+          [[ "$kept_age" =~ ^[0-9]+$ ]] || kept_age="?"
+          warn "reaping kept stack '$slot_proj' (slot $slot_name): owner PID $slot_pid $owner_verdict, containers still running, age ${kept_age}s > keep TTL ${ISOLATE_KEEP_TTL}s — forgotten --keep leak"
+          _reap_isolate_slot "$slot_entry" "$slot_proj"
+          continue
+        fi
+      fi
+      info "Attempting to reclaim stale slot $slot_name (PID $slot_pid owner $owner_verdict)"
       _reap_isolate_slot "$slot_entry" "$slot_proj"
       continue
     fi
@@ -635,12 +866,19 @@ _slot_offset_ports() {
   done
 }
 
-# _slot_ports_free <slot> — probe every port the slot would bind for non-self
-# listeners. Returns 0 if all ports are free (or only held by this slot's own
-# compose project), 1 if any port is held by a foreign process. Emits one
-# `info` line per held port. Requires lsof (matches cmd-doctor.sh convention).
+# _slot_ports_free <slot> [precomputed_liveness] — probe every port the slot
+# would bind for non-self listeners. Returns 0 if all ports are free (or only
+# held by this slot's own compose project), 1 if any port is held by a foreign
+# process. Emits one `info` line per held port. Requires lsof (matches
+# cmd-doctor.sh convention).
+#
+# A caller that has ALREADY computed the slot's liveness (e.g. _slot_state,
+# which probes it once and reuses the value) may pass it as the second arg to
+# avoid a redundant docker-ps round-trip; an empty/absent second arg falls back
+# to a lazy on-demand probe.
 _slot_ports_free() {
   local slot="${1:?slot required}"
+  local precomputed_liveness="${2:-}"
   if ! command -v lsof &>/dev/null; then
     die "--isolate requires lsof; install it"
   fi
@@ -651,7 +889,9 @@ _slot_ports_free() {
     slot_proj="$(cat "$slot_proj_file" 2>/dev/null || true)"
   fi
 
-  local liveness=""
+  # Honor a non-empty precomputed value so liveness is probed at most once per
+  # slot; otherwise leave empty and lazily probe on first need below.
+  local liveness="$precomputed_liveness"
   local any_held=0
   local port
   while IFS= read -r port; do
@@ -666,14 +906,25 @@ _slot_ports_free() {
       local proc_name
       proc_name="$(printf '%s\n' "$line" | awk '{print $1}')"
       # Own-project filter: a docker/com.docker listener on a slot whose own
-      # compose project is recorded and live is treated as the slot's own
-      # binding, not a foreign hold.
-      if printf '%s' "$proc_name" | grep -qiE 'docker|com\.docker'; then
+      # compose project is recorded and either `live` (live verified owner) OR
+      # `kept` (running containers, owner gone/unprovable — a --keep'd stack) is
+      # the slot's OWN binding, not a foreign hold. `kept` MUST be accepted here
+      # too: with the new vocabulary a kept stack returns `kept`, and without
+      # this a subsequent pinned/auto claim onto it would see its own
+      # containers' ports as foreign and die "ports are held by a foreign
+      # process".
+      #
+      # The `com\.docke` alternative matches macOS lsof's 9-char COMMAND
+      # truncation of `com.docker.vmnetd`/`com.docker.backend` to `com.docke`
+      # (the full names never fit the column) — without it the own-project
+      # filter silently never fired on macOS and a kept stack's own published
+      # port read as a foreign hold. `Python`/other names still do not match.
+      if printf '%s' "$proc_name" | grep -qiE 'docker|com\.docke'; then
         if [ -n "$slot_proj" ]; then
           if [ -z "$liveness" ]; then
             liveness="$(_slot_liveness "$slot")"
           fi
-          if [ "$liveness" = "live" ]; then
+          if [ "$liveness" = "live" ] || [ "$liveness" = "kept" ]; then
             continue
           fi
         fi
@@ -700,12 +951,28 @@ _slot_state() {
   local dir="absent"
   [ -d "$slot_entry" ] && dir="present"
 
+  # PID annotation derived from the SHARED _owner_liveness helper so the
+  # table's render can never diverge from the classifier's verdict. The four
+  # owner outputs map to exactly three render tokens:
+  #   alive                  → <pid>          (start-time-verified our owner)
+  #   reused                 → <pid>(reused)  (start-time mismatch — recycled)
+  #   dead | unverifiable    → <pid>(dead)    (ESRCH/EPERM, or no pid.start)
+  # `absent` (no numeric pid) keeps the bare "-". A `(dead)` annotation can
+  # accompany EITHER LIVE=kept (dead owner + running containers) or LIVE=stale
+  # (dead owner + no containers).
   local pid="-"
   if [ -f "$slot_entry/pid" ]; then
     local raw_pid
     raw_pid="$(cat "$slot_entry/pid" 2>/dev/null || true)"
     if [[ "$raw_pid" =~ ^[0-9]+$ ]]; then
-      pid="$raw_pid"
+      local owner
+      owner="$(_owner_liveness "$slot")"
+      case "$owner" in
+        alive)            pid="$raw_pid" ;;
+        reused)           pid="${raw_pid}(reused)" ;;
+        dead|unverifiable) pid="${raw_pid}(dead)" ;;
+        *)                pid="$raw_pid" ;;
+      esac
     fi
   fi
 
@@ -718,6 +985,9 @@ _slot_state() {
     fi
   fi
 
+  # Probe liveness ONCE, BEFORE the port probe, and thread the value into
+  # _slot_ports_free so the own-project filter sees the same verdict without a
+  # second docker-ps round-trip.
   local liveness
   liveness="$(_slot_liveness "$slot")"
 
@@ -725,7 +995,7 @@ _slot_state() {
   if [ "$dir" = "present" ]; then
     if ! command -v lsof >/dev/null 2>&1; then
       ports="?"
-    elif _slot_ports_free "$slot" >/dev/null 2>&1; then
+    elif _slot_ports_free "$slot" "$liveness" >/dev/null 2>&1; then
       ports="free"
     else
       ports="held"
@@ -914,6 +1184,23 @@ def offset_port(m):
 content = re.sub(r'(\s+)- \"(\d+):(\d+)\"', offset_port, content)
 content = content.replace('container_name: showcase-', 'container_name: $name-')
 
+# Forward-stack self-id label: stamp every isolated service's container with
+# 'com.copilotkit.showcase.isolate=1' so 'showcase reap' can identify a
+# harness-owned isolated project even when its slot record and run dir are
+# both gone (e.g. a user-supplied --isolate <name> orphan). Injected as a
+# 'labels:' block right after each service-level 'container_name:' directive
+# (4-space indent, line start — a commented mention like the 8-space
+# '# container_name:' note never matches). 'labels' under a service is a
+# compose-native key; a service may legitimately already define labels, but
+# this compose file defines none, so a fresh block is unambiguous.
+content = re.sub(
+    r'(?m)^(    )container_name: ([^\n]+)$',
+    lambda m: m.group(1) + 'container_name: ' + m.group(2) + '\n'
+              + m.group(1) + 'labels:\n'
+              + m.group(1) + '  com.copilotkit.showcase.isolate: \"1\"',
+    content,
+)
+
 # Rewrite relative paths to absolute, anchored at SHOWCASE_ROOT. Without this,
 # docker compose resolves them against the temp dir holding the rewritten
 # compose file and fails (env_file: .env, build: ./pocketbase, volume mounts).
@@ -1072,6 +1359,15 @@ restore_isolation() {
       info "  dashboard:  http://localhost:${dashboard_host_port}"
       info "  pocketbase: http://localhost:${pocketbase_host_port}"
       info "  tear down:  docker compose -p $ISOLATE_NAME down --remove-orphans --volumes && rm -rf \"$ISOLATE_TMPDIR\" \"$ISOLATE_SLOT_DIR/$ISOLATE_SLOT\""
+      # Derive the human-readable hours from ISOLATE_KEEP_TTL so an overridden
+      # SHOWCASE_ISOLATE_KEEP_TTL can't leave a stale "(4h)" contradicting the
+      # seconds. Only append the parenthetical for a whole number of hours; a
+      # non-integer-hour TTL drops it rather than print a misleading fraction.
+      local ttl_hours_note=""
+      if [ $(( ISOLATE_KEEP_TTL % 3600 )) -eq 0 ]; then
+        ttl_hours_note=" ($(( ISOLATE_KEEP_TTL / 3600 ))h)"
+      fi
+      info "  NOTE: this kept stack is auto-reaped after ${ISOLATE_KEEP_TTL}s${ttl_hours_note} if left running with no owner — run 'showcase reap' to tear down sooner, or 'showcase up' to keep using it."
       ISOLATE_ACTIVE=false
       # Disown the surviving state: with ISOLATE_ACTIVE back to false, a
       # repeated restore_isolation would otherwise hit the half-initialized

--- a/showcase/scripts/cli/cmd-reap.sh
+++ b/showcase/scripts/cli/cmd-reap.sh
@@ -1,0 +1,434 @@
+#!/usr/bin/env bash
+# showcase reap — tear down leaked/forgotten isolated stacks and orphaned state.
+# Sourced by the main dispatcher; do not execute directly.
+#
+# Background. The isolation harness reserves a slot + a uniquely-named compose
+# project (showcase-iso<N>, or a user-supplied --isolate <name>) per run, with
+# per-run scratch under runs/<project> and a slot record under slots/<N>. A
+# clean exit reaps everything; a --keep'd run (or a crash) deliberately leaves
+# the stack standing. Over time those forgotten stacks accumulate — running
+# containers, named volumes, slot dirs, run dirs — with no single tool to list
+# or sweep them. `showcase reap` is that tool.
+#
+# Safety is the whole point of this command, so it errs hard toward NOT
+# destroying anything by surprise:
+#   * DRY-RUN BY DEFAULT — `showcase reap` with no flags prints the full plan
+#     and changes nothing. Teardown happens only with --force (alias --yes,-f).
+#   * NEVER touches the base `showcase` project (the live default stack — its
+#     --volumes teardown would destroy PocketBase data) or BuildKit builder
+#     resources (buildx_buildkit_* / *_buildx). These exclusions apply to the
+#     dry-run/--all "unidentified — review manually" listing too, not only to
+#     teardown.
+#   * Per-project teardown reuses _reap_isolate_slot where a slot record exists
+#     (so the charset/path-traversal/reserved-name guards there are honored),
+#     and otherwise mirrors its exact teardown: compose -p <name> down
+#     --remove-orphans --volumes, then rm -rf runs/<name>.
+
+CMD_REAP_DESC="Tear down leaked/forgotten isolated stacks"
+
+usage_reap() {
+  cat <<'HELP'
+Usage: showcase reap [<name|slot>] [options]
+
+Tear down leaked/forgotten isolated showcase stacks (running containers, named
+volumes, slot dirs, run dirs) left behind by --keep'd or crashed runs.
+
+DRY-RUN BY DEFAULT: with no --force, `reap` only prints the plan and changes
+nothing (exit 0). Pass --force to actually tear things down.
+
+Targets (no positional arg = sweep all harness-owned isolated state):
+  <name|slot>   Reap exactly one named compose project, or the project recorded
+                for one slot number. Requires --force to execute.
+
+Options:
+  -f, --force   Execute the teardown (alias: --yes). Reaps stale/orphaned state
+                plus kept stacks past their keep-TTL; PRESERVES kept stacks
+                within TTL and any project with a live owner.
+      --yes     Alias of --force.
+      --all     With --force, reap EVERY harness-owned isolated project
+                regardless of age/keep state (the "tear down everything
+                isolated now" escape hatch). Never touches base `showcase` or
+                BuildKit. Projects not identifiable as harness-owned are listed
+                "unidentified — review manually" and left alone. PRESERVES
+                projects with a live owner unless --include-live is also given.
+      --include-live
+                Opt in to reaping projects classified `live` (an actively-owned,
+                in-use stack). Without it, a live-owner project is PRESERVED and
+                a loud warning is emitted even when named as an explicit target
+                or swept by --all. Use this only when you intend to tear down a
+                stack that is still in active use.
+      --json    Emit one JSON object per project (JSONL), instead of the table.
+  -h, --help    Show this help.
+
+Never touches the base `showcase` stack or BuildKit (buildx_buildkit_* /
+*_buildx) resources under any flag.
+HELP
+}
+
+# A project name is reapable-safe only if it passes the same guard
+# _reap_isolate_slot enforces (compose charset) AND is neither the reserved
+# base `showcase` project nor a BuildKit builder resource. The buildkit/buildx
+# exclusion is belt-and-suspenders: those names never appear in our slot
+# records, but a label/docker scan could surface them, and they must never be
+# torn down OR listed as candidates.
+_reap_name_safe() {
+  local name="$1"
+  [ -n "$name" ] || return 1
+  [ "$name" = "showcase" ] && return 1
+  case "$name" in
+    *buildkit*|*buildx*) return 1 ;;
+  esac
+  [[ "$name" =~ ^[a-z0-9][a-z0-9_-]*$ ]] || return 1
+  return 0
+}
+
+# Resolve the slot number whose `project` record names <proj>, or empty if no
+# slot records it. Used to annotate the plan and to route teardown through
+# _reap_isolate_slot (which removes the slot dir too).
+_reap_slot_for_project() {
+  local proj="$1" n entry
+  for entry in "$ISOLATE_SLOT_DIR"/[0-9]*; do
+    [ -d "$entry" ] || continue
+    n="$(basename "$entry")"
+    [[ "$n" =~ ^[0-9]+$ ]] || continue
+    [ "$(cat "$entry/project" 2>/dev/null || true)" = "$proj" ] && { printf '%s' "$n"; return 0; }
+  done
+  return 0
+}
+
+# Count RUNNING+stopped containers for a compose project (so the plan reflects
+# what teardown will actually remove, not just what is up right now). Empty
+# docker → 0. Counts non-empty lines via a while-read loop (portable, and never
+# emits the stray whitespace `grep -c` can on some platforms — the result is
+# compared numerically by the caller).
+_reap_container_count() {
+  local proj="$1" id count=0
+  while IFS= read -r id; do
+    [ -n "$id" ] && count=$((count + 1))
+  done < <(docker ps -a --filter "label=com.docker.compose.project=$proj" -q 2>/dev/null)
+  printf '%s' "$count"
+}
+
+# Count named volumes for a compose project (see _reap_container_count).
+_reap_volume_count() {
+  local proj="$1" v count=0
+  while IFS= read -r v; do
+    [ -n "$v" ] && count=$((count + 1))
+  done < <(docker volume ls --filter "label=com.docker.compose.project=$proj" -q 2>/dev/null)
+  printf '%s' "$count"
+}
+
+# Print the de-duplicated identification UNION of harness-owned isolated
+# project names, one per line. Sources (any one suffices):
+#   1. slots/<N>/project records — the canonical registry.
+#   2. runs/<name> scratch dirs — orphaned run dirs whose slot is gone.
+#   3. Docker compose-project label scan, kept when the name is showcase-iso<N>,
+#      already in a slot record / run dir, OR carries our self-id label
+#      com.copilotkit.showcase.isolate=1 (the ONLY signal that catches a
+#      user-supplied --isolate <name> orphan whose slot record was lost).
+# The base `showcase` project and BuildKit resources are filtered here so they
+# can never enter the candidate set. Names failing the compose charset guard
+# are dropped (a corrupt record can't drive a teardown).
+_reap_identify() {
+  local -a names=()
+  local n entry proj
+
+  # 1. slot records
+  for entry in "$ISOLATE_SLOT_DIR"/[0-9]*; do
+    [ -d "$entry" ] || continue
+    n="$(basename "$entry")"
+    [[ "$n" =~ ^[0-9]+$ ]] || continue
+    proj="$(cat "$entry/project" 2>/dev/null || true)"
+    [ -n "$proj" ] && names+=("$proj")
+  done
+
+  # 2. orphaned run dirs
+  local runs_base
+  runs_base="$(_showcase_state_base)/runs"
+  if [ -d "$runs_base" ]; then
+    for entry in "$runs_base"/*; do
+      [ -d "$entry" ] || continue
+      names+=("$(basename "$entry")")
+    done
+  fi
+
+  # 3. docker scans (compose-project label + our self-id label). Both are
+  # best-effort: a docker failure leaves the registry/run-dir sources intact.
+  if command -v docker >/dev/null 2>&1; then
+    # Self-id label scan: every project carrying com.copilotkit.showcase.isolate=1
+    # is harness-owned by construction, so it is always a candidate.
+    while IFS= read -r proj; do
+      [ -n "$proj" ] && names+=("$proj")
+    done < <(docker ps -a \
+      --filter "label=com.copilotkit.showcase.isolate=1" \
+      --format '{{.Label "com.docker.compose.project"}}' 2>/dev/null | sort -u)
+
+    # Generic compose-project scan: keep showcase-iso<N>, or any name already
+    # known from a slot record / run dir (a name not matching either pattern is
+    # left for the --all "unidentified" listing, NOT auto-reaped).
+    local existing
+    existing="$(printf '%s\n' "${names[@]+"${names[@]}"}")"
+    while IFS= read -r proj; do
+      [ -n "$proj" ] || continue
+      if [[ "$proj" =~ ^showcase-iso[0-9]+$ ]] || printf '%s\n' "$existing" | grep -qxF "$proj"; then
+        names+=("$proj")
+      fi
+    done < <(docker ps -a \
+      --filter "label=com.docker.compose.project" \
+      --format '{{.Label "com.docker.compose.project"}}' 2>/dev/null | sort -u)
+  fi
+
+  # De-dupe + apply the hard safety filter (base showcase / buildkit / charset).
+  printf '%s\n' "${names[@]+"${names[@]}"}" | sort -u | while IFS= read -r proj; do
+    _reap_name_safe "$proj" && printf '%s\n' "$proj"
+  done
+}
+
+# Print every running/stopped compose project Docker knows about that is NOT in
+# our identification union and is NOT base showcase / BuildKit — the
+# "unidentified — review manually" set surfaced by --all and the dry-run plan.
+_reap_unidentified() {
+  command -v docker >/dev/null 2>&1 || return 0
+  local identified="$1" proj
+  while IFS= read -r proj; do
+    [ -n "$proj" ] || continue
+    [ "$proj" = "showcase" ] && continue
+    case "$proj" in *buildkit*|*buildx*) continue ;; esac
+    printf '%s\n' "$identified" | grep -qxF "$proj" && continue
+    printf '%s\n' "$proj"
+  done < <(docker ps -a \
+    --filter "label=com.docker.compose.project" \
+    --format '{{.Label "com.docker.compose.project"}}' 2>/dev/null | sort -u)
+}
+
+# Tear down ONE identified project. Routes through _reap_isolate_slot when a
+# slot records it (removes the slot dir + run dir + compose state in the
+# guarded order); otherwise mirrors that exact teardown for a record-less
+# orphan (compose down --volumes, then rm -rf runs/<name>). The caller has
+# already confirmed _reap_name_safe.
+_reap_teardown_project() {
+  local proj="$1" slot
+  slot="$(_reap_slot_for_project "$proj")"
+  if [ -n "$slot" ]; then
+    _reap_isolate_slot "$ISOLATE_SLOT_DIR/$slot" "$proj"
+  else
+    docker compose -p "$proj" down --remove-orphans --volumes >/dev/null 2>&1 || true
+    rm -rf "$(_showcase_state_base)/runs/$proj" 2>/dev/null || true
+  fi
+}
+
+cmd_reap() {
+  local opt_force=false
+  local opt_all=false
+  local opt_json=false
+  local opt_include_live=false
+  local target=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -f|--force|--yes) opt_force=true; shift ;;
+      --all)            opt_all=true;   shift ;;
+      --include-live)   opt_include_live=true; shift ;;
+      --json)           opt_json=true;  shift ;;
+      -h|--help)        usage_reap; return 0 ;;
+      -*)               die "Unknown flag: $1 (see 'showcase reap --help')" ;;
+      *)
+        [ -n "$target" ] && die "Only one <name|slot> target may be given (see 'showcase reap --help')"
+        target="$1"; shift ;;
+    esac
+  done
+
+  if $opt_all && [ -n "$target" ]; then
+    die "--all and a <name|slot> target are mutually exclusive (see 'showcase reap --help')"
+  fi
+
+  # Build the candidate list of (project, classification) pairs.
+  #   classification ∈ live | kept | stale | orphaned-rundir | inconclusive
+  # plus the per-project slot/rundir/container/volume facts.
+  local -a all_projects=()
+  while IFS= read -r proj; do
+    [ -n "$proj" ] && all_projects+=("$proj")
+  done < <(_reap_identify)
+
+  # The FULL harness-owned identification union — captured BEFORE any
+  # single-target narrowing below. The "unidentified — review manually" listing
+  # must always be computed against this complete set, NEVER the narrowed
+  # single-target set; otherwise every OTHER harness-owned iso project would be
+  # falsely surfaced as "NOT harness-owned" in single-target mode.
+  local full_identified_list
+  full_identified_list="$(printf '%s\n' "${all_projects[@]+"${all_projects[@]}"}")"
+
+  # A single named/slot target narrows the candidate set to exactly that one
+  # project (resolving a numeric slot to its recorded project first).
+  if [ -n "$target" ]; then
+    local resolved="$target"
+    if [[ "$target" =~ ^[0-9]+$ ]]; then
+      resolved="$(cat "$ISOLATE_SLOT_DIR/$target/project" 2>/dev/null || true)"
+      [ -n "$resolved" ] || die "Slot $target has no recorded project to reap"
+    fi
+    _reap_name_safe "$resolved" \
+      || die "Refusing to reap '$resolved' — it is the base 'showcase' stack, a BuildKit resource, or an invalid project name"
+    all_projects=("$resolved")
+  fi
+
+  # ── Classify every candidate ────────────────────────────────────────────────
+  # Parallel arrays (bash 3 compatible — no associative arrays).
+  local -a p_name=() p_class=() p_slot=() p_rundir=() p_containers=() p_volumes=() p_reap=()
+  # Live-owner projects we deliberately PRESERVE (no --include-live). Collected
+  # so a single loud warning naming them is emitted, regardless of selection.
+  local -a live_preserved=()
+  local proj slot class rundir ncont nvol reap runs_base
+  runs_base="$(_showcase_state_base)/runs"
+  for proj in "${all_projects[@]+"${all_projects[@]}"}"; do
+    slot="$(_reap_slot_for_project "$proj")"
+    ncont="$(_reap_container_count "$proj")"; ncont="${ncont:-0}"
+    nvol="$(_reap_volume_count "$proj")"; nvol="${nvol:-0}"
+    if [ -n "$slot" ]; then
+      class="$(_slot_liveness "$slot")"
+    elif [ -d "$runs_base/$proj" ] || [ "$ncont" -gt 0 ] || [ "$nvol" -gt 0 ]; then
+      # Record-less orphan: a leftover run dir and/or stray containers/volumes
+      # with no slot. There is no owner/TTL state to consult, so it is reapable
+      # as a plain orphan (reaped under --force; --all reaps it too).
+      class="orphaned-rundir"
+    else
+      class="inconclusive"
+    fi
+    rundir="-"; [ -d "$runs_base/$proj" ] && rundir="$runs_base/$proj"
+
+    # Reapability decision:
+    #   --all       → reap every identified project (TTL/keep ignored) EXCEPT a
+    #                 live-owner stack, which is PRESERVED unless --include-live.
+    #   --force     → reap stale + orphaned-rundir; PRESERVE live + kept (kept
+    #                 is reaped only once the kept-slot TTL flips it to stale, at
+    #                 which point _slot_liveness already returns 'stale' here).
+    #   <target>    → an explicit single target is reaped regardless of class
+    #                 (the user named it); base/buildkit already excluded above.
+    #                 BUT a `live` target — an actively-owned, in-use stack — is
+    #                 NOT torn down silently: it is PRESERVED with a loud warning
+    #                 unless the operator opts in with --include-live. This
+    #                 honors the subcommand's safety stance (PRESERVES any
+    #                 project with a live owner).
+    # A class 'inconclusive' project (no slot, no run dir, zero containers AND
+    # zero volumes) is NEVER reaped: teardown would remove nothing, so counting
+    # it would report a phantom "Reaped 1" — even for a named target that simply
+    # does not exist.
+    reap=false
+    if [ "$class" = "live" ] && ! $opt_include_live; then
+      # Actively-owned, in-use stack — never reaped without an explicit
+      # --include-live opt-in, no matter how it was selected (named target or
+      # --all). Record it so a single loud warning is emitted before teardown.
+      reap=false
+      live_preserved+=("$proj")
+    elif [ "$class" = "inconclusive" ]; then
+      reap=false
+    elif [ -n "$target" ]; then
+      reap=true
+    elif $opt_all; then
+      reap=true
+    else
+      case "$class" in
+        stale|orphaned-rundir) reap=true ;;
+      esac
+    fi
+
+    p_name+=("$proj"); p_class+=("$class"); p_slot+=("${slot:--}")
+    p_rundir+=("$rundir"); p_containers+=("$ncont"); p_volumes+=("$nvol"); p_reap+=("$reap")
+  done
+
+  # ── Live-owner preservation warning ──────────────────────────────────────────
+  # Any project classified `live` (an actively-owned, in-use stack) is PRESERVED
+  # — including one named as an explicit target or swept by --all — unless the
+  # operator passed --include-live. Emit a single loud warning naming each one so
+  # the operator knows why their target/sweep left it standing (the JSON branch
+  # already carries this as classification:"live" with reap:false).
+  if ! $opt_json && [ "${#live_preserved[@]}" -gt 0 ]; then
+    for proj in "${live_preserved[@]}"; do
+      warn "Preserving '$proj' — it has a live owner (actively in use). Pass --include-live to reap it anyway."
+    done
+  fi
+
+  # ── Output: plan (always) + teardown (only with --force) ─────────────────────
+  local i n_planned=0
+  if $opt_json; then
+    # One JSON object per identified project (mirrors `slots --json`, which
+    # emits all rows). `reap` marks whether the project is in the teardown plan.
+    for i in "${!p_name[@]}"; do
+      [ "${p_reap[$i]}" = "true" ] && n_planned=$((n_planned + 1))
+      jq -nc \
+        --arg     project    "${p_name[$i]}" \
+        --arg     classification "${p_class[$i]}" \
+        --arg     slot       "${p_slot[$i]}" \
+        --arg     rundir     "${p_rundir[$i]}" \
+        --argjson containers "${p_containers[$i]}" \
+        --argjson volumes    "${p_volumes[$i]}" \
+        --argjson reap       "${p_reap[$i]}" \
+        --argjson executed   "$($opt_force && echo true || echo false)" \
+        '{project: $project, classification: $classification, slot: $slot, rundir: $rundir, containers: $containers, volumes: $volumes, reap: $reap, executed: $executed}'
+    done
+  else
+    if [ "${#p_name[@]}" -eq 0 ]; then
+      info "No harness-owned isolated projects found — nothing to reap."
+    else
+      $opt_force || info "DRY-RUN (no --force): printing plan only; nothing will be torn down."
+      printf '%-28s  %-15s  %-5s  %-5s  %-5s  %s\n' \
+        "PROJECT" "CLASS" "SLOT" "CONT" "VOLS" "ACTION"
+      for i in "${!p_name[@]}"; do
+        local action="preserve"
+        if [ "${p_reap[$i]}" = "true" ]; then
+          action="$($opt_force && echo reap || echo "reap (planned)")"
+          n_planned=$((n_planned + 1))
+        fi
+        printf '%-28s  %-15s  %-5s  %-5s  %-5s  %s\n' \
+          "${p_name[$i]}" "${p_class[$i]}" "${p_slot[$i]}" \
+          "${p_containers[$i]}" "${p_volumes[$i]}" "$action"
+      done
+    fi
+  fi
+
+  # ── Unidentified review listing (dry-run plan + --all) ───────────────────────
+  # Always SHOWN, never torn down — base showcase / buildkit already excluded.
+  if ! $opt_json; then
+    # Exclude the FULL harness-owned union (computed before target narrowing) —
+    # not just the in-plan rows — so a single-target reap never mislabels its
+    # harness-owned siblings as "NOT harness-owned". Also exclude the explicit
+    # target itself (it may be a safe-but-unidentified name the user named) so
+    # it never appears in the review listing while it is being reaped.
+    local identified_list="$full_identified_list"
+    [ -n "$target" ] && identified_list="$(printf '%s\n%s\n' "$full_identified_list" "${all_projects[0]:-}")"
+    local -a unidentified=()
+    while IFS= read -r proj; do
+      [ -n "$proj" ] && unidentified+=("$proj")
+    done < <(_reap_unidentified "$identified_list")
+    if [ "${#unidentified[@]}" -gt 0 ]; then
+      echo ""
+      warn "Unidentified compose projects (NOT harness-owned — review manually, never auto-reaped):"
+      for proj in "${unidentified[@]}"; do
+        printf '  %s\n' "$proj"
+      done
+    fi
+  fi
+
+  # ── Teardown ─────────────────────────────────────────────────────────────────
+  if ! $opt_force; then
+    $opt_json || info "Summary: $n_planned project(s) would be reaped (run with --force to execute)."
+    return 0
+  fi
+
+  local n_reaped=0
+  for i in "${!p_name[@]}"; do
+    [ "${p_reap[$i]}" = "true" ] || continue
+    _reap_teardown_project "${p_name[$i]}"
+    n_reaped=$((n_reaped + 1))
+  done
+  if ! $opt_json; then
+    if [ "$n_reaped" -eq 0 ]; then
+      # Nothing was in the teardown plan — e.g. an explicit target that no
+      # longer exists (class 'inconclusive'). Report nothing-to-reap rather
+      # than a misleading "Reaped 0" success.
+      info "Nothing to reap — no project had containers, volumes, slot, or run dir to tear down."
+    else
+      success "Reaped $n_reaped project(s)."
+    fi
+  fi
+  return 0
+}

--- a/showcase/scripts/cli/cmd-slots.sh
+++ b/showcase/scripts/cli/cmd-slots.sh
@@ -11,29 +11,38 @@ Usage: showcase slots [options]
 Show the status of all isolation slots (0..ISOLATE_MAX_SLOT).
 
 Options:
-  --json    Emit one JSON object per slot (JSONL format)
-  --free    Filter to slots that are free (unclaimed, no live pid/containers, no held ports)
-  --brief   Output only numeric slot IDs of matching slots, one per line
+  --json     Emit one JSON object per slot (JSONL format)
+  --free     Filter to slots that are free (unclaimed, no live pid/containers, no held ports)
+  --reapable Filter to slots that are reapable (liveness == stale)
+  --brief    Output only numeric slot IDs of matching slots, one per line
 
-Flags may be combined: --free --brief  → one integer per line for each free slot
-                       --free --json   → JSONL for free slots only
+Flags may be combined: --free --brief      → one integer per line for each free slot
+                       --free --json       → JSONL for free slots only
+                       --reapable --brief  → one integer per line for each reapable slot
 
 Notes:
   Slot 0 is reserved for the base (non-isolate) stack and is never reported as free.
   Free = dir absent + liveness not live + ports not held.
+  Reapable = liveness == stale. The LIVE column reads live | kept | stale |
+  inconclusive: a `kept` slot (a --keep'd stack — running containers whose
+  owner is gone) is protected, NOT reapable. The PID column annotates a
+  recorded owner as <pid> (alive), <pid>(reused) (pid recycled), or
+  <pid>(dead) (owner gone / unverifiable).
 HELP
 }
 
 cmd_slots() {
   local opt_json=false
   local opt_free=false
+  local opt_reapable=false
   local opt_brief=false
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --json)   opt_json=true;   shift ;;
-      --free)   opt_free=true;   shift ;;
-      --brief)  opt_brief=true;  shift ;;
+      --json)     opt_json=true;     shift ;;
+      --free)     opt_free=true;     shift ;;
+      --reapable) opt_reapable=true; shift ;;
+      --brief)    opt_brief=true;    shift ;;
       -h|--help)
         usage_slots
         return 0
@@ -47,6 +56,10 @@ cmd_slots() {
     esac
   done
 
+  if $opt_free && $opt_reapable; then
+    die "--free and --reapable are mutually exclusive (see 'showcase slots --help')"
+  fi
+
   # Collect all slot records
   local -a rows=()
   local n
@@ -54,18 +67,35 @@ cmd_slots() {
     rows+=("$(_slot_state "$n")")
   done
 
+  # _row_included <slot> <dir> <liveness> <ports> — apply the active filter.
+  # Returns 0 (include) when no filter is set, or when the row satisfies the
+  # active --free / --reapable predicate; 1 (skip) otherwise. Slot 0 (the base
+  # stack) is excluded from BOTH filters: it is never free, and never reapable.
+  #   --free     = dir absent + liveness not live + ports not held
+  #   --reapable = liveness == stale  (a `kept` slot is protected, NOT reapable;
+  #                the kept-slot TTL is what flips an over-age kept slot to stale)
+  _row_included() {
+    local r_slot="$1" r_dir="$2" r_liveness="$3" r_ports="$4"
+    if $opt_free; then
+      [ "$r_slot" = "0" ] && return 1
+      [ "$r_dir" = "absent" ] && [ "$r_liveness" != "live" ] && [ "$r_ports" != "held" ]
+      return
+    fi
+    if $opt_reapable; then
+      [ "$r_slot" = "0" ] && return 1
+      [ "$r_liveness" = "stale" ]
+      return
+    fi
+    return 0
+  }
+
   # ── Output ────────────────────────────────────────────────────────────────
 
   if $opt_brief; then
     # Brief: numeric slot IDs only, one per line
     for row in "${rows[@]}"; do
       IFS='|' read -r slot dir pid liveness ports offset project <<< "$row"
-      # Slot 0 is never free (reserved for base stack)
-      if $opt_free; then
-        [ "$slot" = "0" ] && continue
-        # Free = dir absent, liveness not live, ports not held
-        [ "$dir" = "absent" ] && [ "$liveness" != "live" ] && [ "$ports" != "held" ] || continue
-      fi
+      _row_included "$slot" "$dir" "$liveness" "$ports" || continue
       printf '%s\n' "$slot"
     done
     return 0
@@ -75,10 +105,7 @@ cmd_slots() {
     # JSONL: one JSON object per slot
     for row in "${rows[@]}"; do
       IFS='|' read -r slot dir pid liveness ports offset project <<< "$row"
-      if $opt_free; then
-        [ "$slot" = "0" ] && continue
-        [ "$dir" = "absent" ] && [ "$liveness" != "live" ] && [ "$ports" != "held" ] || continue
-      fi
+      _row_included "$slot" "$dir" "$liveness" "$ports" || continue
       # Slot 0 project label
       local proj_display="$project"
       [ "$slot" = "0" ] && proj_display="showcase (base)"
@@ -96,20 +123,18 @@ cmd_slots() {
   fi
 
   # Default: fixed-width table
-  # Header: SLOT(4) DIR(7) PID(6) LIVE(12) PORTS(6) OFFSET(6) PROJECT(remainder)
-  printf '%-4s  %-7s  %-6s  %-12s  %-6s  %-6s  %s\n' \
+  # Header: SLOT(4) DIR(7) PID(11) LIVE(12) PORTS(6) OFFSET(6) PROJECT(remainder)
+  # PID is 11 wide to fit the annotated forms (e.g. "79371(reused)").
+  printf '%-4s  %-7s  %-11s  %-12s  %-6s  %-6s  %s\n' \
     "SLOT" "DIR" "PID" "LIVE" "PORTS" "OFFSET" "PROJECT"
 
   for row in "${rows[@]}"; do
     IFS='|' read -r slot dir pid liveness ports offset project <<< "$row"
-    if $opt_free; then
-      [ "$slot" = "0" ] && continue
-      [ "$dir" = "absent" ] && [ "$liveness" != "live" ] && [ "$ports" != "held" ] || continue
-    fi
+    _row_included "$slot" "$dir" "$liveness" "$ports" || continue
     # Slot 0 project label
     local proj_display="$project"
     [ "$slot" = "0" ] && proj_display="showcase (base)"
-    printf '%-4s  %-7s  %-6s  %-12s  %-6s  %-6s  %s\n' \
+    printf '%-4s  %-7s  %-11s  %-12s  %-6s  %-6s  %s\n' \
       "$slot" "$dir" "$pid" "$liveness" "$ports" "+$offset" "$proj_display"
   done
 

--- a/showcase/scripts/cli/cmd-test.sh
+++ b/showcase/scripts/cli/cmd-test.sh
@@ -22,7 +22,9 @@ Options:
   --repeat <n>     Run N times
   --keep           Don't stop auto-started packages after test; with --isolate,
                    also leaves the isolated stack standing (teardown command
-                   printed at exit)
+                   printed at exit). A kept stack left running with no owner is
+                   auto-reaped after its keep TTL (default 4h); run
+                   'showcase reap' to tear it down sooner.
   --live           Write results to PocketBase for dashboard
   --rebuild        Force Docker rebuild before running
   --cycle          On failure, auto-dump aimock logs from the test window


### PR DESCRIPTION
## Summary
Hardens the showcase `--isolate` slot lifecycle to stop leaked Docker stacks (we had 16 leaked `--keep` stacks accumulate: 89 containers, 16 volumes).

1. **Slot-liveness false-positive fix** — a `--keep`'d stack whose owning process exited (but whose containers kept running) was classified `live` forever and never reaped. New start-time-verified `_owner_liveness` probe + a `kept` state; `slots` now renders `<pid>(dead)`/`(reused)` and adds a `--reapable` filter.
2. **Kept-stack TTL** — `ISOLATE_KEEP_TTL` (4h, `SHOWCASE_ISOLATE_KEEP_TTL`-overridable) flips an over-age `kept` slot to `stale` so the claim-time sweep reclaims it (with a loud warning).
3. **`showcase reap` subcommand** — dry-run by default; `--force`/`--all`/`--include-live`/`<name|slot>`; identifies harness-owned stacks via slot-record ∪ run-dir ∪ `showcase-iso<N>` ∪ a new `com.copilotkit.showcase.isolate` self-id label stamped by `apply_isolation`; never touches the base `showcase` stack or BuildKit resources.

Spec: https://app.notion.com/p/38b3aa3818528137a399fafee3750463

## Tests
Real-surface bats (real slot dirs, real dead PIDs via spawn+wait, real running compose projects — never mocks): `bats showcase/scripts/__tests__/` = 161/0. CR converged in 2 rounds (4 fixes), Procedure 3 promotion audit clean.

## Deferred to a follow-up PR (pre-existing, out of this PR's subject)
- `_slot_ports_free` die-in-subshell defeats the port-conflict guard for a bad slot (byte-identical in `main`).
- `cmd-test.sh` `--isolate <name> <slug>` (name-before-slug) mis-parse + bare `--isolate=` validation gap.
- `slots` table shows slot 0's PORTS at offset +200 while displaying OFFSET +0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)