### PR TITLE
fix(showcase): incident remediation — dashboard SWR + family-silence grace + llamaindex log-gate + SSOT worker-provisioning

### DIFF
--- a/showcase/RAILWAY.md
+++ b/showcase/RAILWAY.md
@@ -270,31 +270,49 @@ captures these values for CI drift detection.
 ### Worker model (1-worker-per-replica)
 
 Railway runs **one worker process per replica container** (keyed on `HOSTNAME`).
-There is no per-process forking. The live worker count equals `numReplicas`
-strictly 1:1. `HARNESS_POOL_COUNT` is an **informational-only** control-plane
-hint — it does NOT fork additional workers. The authoritative per-worker
-concurrency knob is `BROWSER_POOL_MAX_CONTEXTS`.
+There is no per-process forking. The live worker count equals the **effective
+replica count** strictly 1:1. `HARNESS_POOL_COUNT` is an **informational-only**
+control-plane hint — it does NOT fork additional workers. The authoritative
+per-worker concurrency knob is `BROWSER_POOL_MAX_CONTEXTS`.
+
+### Effective replica count — `multiRegionConfig`, not top-level `numReplicas`
+
+`harness-workers` is a single-region service (`us-west2`). Railway derives the
+LIVE running replica count from the per-region
+`multiRegionConfig.us-west2.numReplicas` field — **this is the effective knob the
+deploy honors**. The top-level `numReplicas` is a legacy aggregate that Railway
+keeps in sync with the region sum, but it is NOT the field that drives reality.
+The SSOT therefore models the effective count as `effectiveReplicas`
+(= `multiRegionConfig.us-west2.numReplicas`) and keeps the top-level
+`numReplicas` only as a documented mirror. The CI drift gate asserts
+`effectiveReplicas`.
 
 ### Current declared values (live reality as of 2026-06-26)
 
-| Env     | `numReplicas` (live workers) | `BROWSER_POOL_MAX_CONTEXTS` |
-|---------|------------------------------|-----------------------------|
-| prod    | 3                            | 40                          |
-| staging | 6                            | 40                          |
+Verified live via the Railway GraphQL `environment.config` staged-config read —
+both envs carry `deploy.multiRegionConfig = {"us-west2":{"numReplicas":6}}`.
 
-**Staging config-field drift**: the Railway staging replicas config field was
-observed as `2` at audit time, but `6` instances were live. The SSOT records `6`
-(live reality). Follow-up: update the Railway staging replicas config field to 6.
+| Env     | `effectiveReplicas` (= `multiRegionConfig.us-west2.numReplicas`, live workers) | `numReplicas` (mirror) | `BROWSER_POOL_MAX_CONTEXTS` |
+| ------- | ------------------------------------------------------------------------------ | ---------------------- | --------------------------- |
+| prod    | 6                                                                              | 6                      | 40                          |
+| staging | 6                                                                              | 6                      | 40                          |
 
-**Prod/staging parity**: prod runs 3 replicas vs. staging's 6. Bringing prod
-to parity is a deliberate one-field change (`numReplicas: 3 → 6`) that is
-deferred to a follow-up operational item.
+**Prod/staging parity achieved**: B-reconcile scaled prod `harness-workers`
+from 3 → 6 replicas (updating BOTH the top-level `numReplicas` AND
+`multiRegionConfig.us-west2.numReplicas`) to match staging (6). Prod and staging
+are now at parity (6/6). The earlier prod=3 state and the prior staging
+config-field-vs-live drift (config field `2` / `6` live) are both resolved — the
+live staged config now reads `6` in both envs.
 
 ### SSOT fields
 
-- `workerProvisioning.{prod,staging}.numReplicas` — authoritative worker count
-  (= Railway replica count, 1:1). This is the ONLY field to update when
-  changing the replica count.
+- `workerProvisioning.{prod,staging}.effectiveReplicas` — AUTHORITATIVE worker
+  count (= `multiRegionConfig.us-west2.numReplicas`, the field Railway honors;
+  1:1 with live workers). This is the field the drift gate watches and the ONLY
+  field that drives the live replica count.
+- `workerProvisioning.{prod,staging}.numReplicas` — top-level Railway field,
+  retained as a DOCUMENTED MIRROR of `effectiveReplicas` (equal on a
+  single-region service). Not an authoritative knob.
 - `workerProvisioning.{prod,staging}.BROWSER_POOL_MAX_CONTEXTS` — per-worker
   Playwright context budget.
 - `workerProvisioning.{prod,staging}.HARNESS_POOL_COUNT` — INFORMATIONAL ONLY;
@@ -304,18 +322,21 @@ deferred to a follow-up operational item.
 ### Applying a replica count change (MANUAL)
 
 The `emit-railway-envs-json.ts` emitter and `bin/railway` tooling are
-**VERIFY-ONLY** with respect to `numReplicas` — they do not write replica counts
-to Railway. To change the replica count:
+**VERIFY-ONLY** with respect to the replica count — they do not write replica
+counts to Railway. To change the replica count:
 
-1. Change the `numReplicas` value in `railway-envs.ts` (SSOT).
+1. Change the `effectiveReplicas` value in `railway-envs.ts` (SSOT) — and the
+   `numReplicas` mirror alongside it (keep them equal for this single-region
+   service).
 2. Regenerate the snapshot: `npx tsx showcase/scripts/emit-railway-envs-json.ts`
 3. Commit both files (`railway-envs.ts` + `railway-envs.generated.json`).
 4. Apply the change to Railway manually via the Railway Dashboard (Service >
-   Settings > Replicas) or the Railway GraphQL API.
+   Settings > Replicas, which edits `multiRegionConfig.us-west2.numReplicas`) or
+   the Railway GraphQL API.
 
 The CI drift gate (`showcase/scripts/__tests__/harness-workers-provisioning.test.ts`)
 will fail if `railway-envs.ts` and `railway-envs.generated.json` disagree on
-`numReplicas`, catching a forgotten regeneration step.
+`effectiveReplicas`, catching a forgotten regeneration step.
 
 ## Environment IDs
 

--- a/showcase/RAILWAY.md
+++ b/showcase/RAILWAY.md
@@ -260,6 +260,63 @@ never renders.
 > `showcase_build.yml` ("Build & Push"), with `showcase_deploy.yml` now the
 > staging verify gate. Correct §B.3 in a follow-up.
 
+## harness-workers Replica Count (Worker Provisioning)
+
+The `harness-workers` fleet provisioning is tracked in the SSOT at
+`showcase/scripts/railway-envs.ts` under the `harness-workers` entry's
+`workerProvisioning` field. The `railway-envs.generated.json` snapshot
+captures these values for CI drift detection.
+
+### Worker model (1-worker-per-replica)
+
+Railway runs **one worker process per replica container** (keyed on `HOSTNAME`).
+There is no per-process forking. The live worker count equals `numReplicas`
+strictly 1:1. `HARNESS_POOL_COUNT` is an **informational-only** control-plane
+hint — it does NOT fork additional workers. The authoritative per-worker
+concurrency knob is `BROWSER_POOL_MAX_CONTEXTS`.
+
+### Current declared values (live reality as of 2026-06-26)
+
+| Env     | `numReplicas` (live workers) | `BROWSER_POOL_MAX_CONTEXTS` |
+|---------|------------------------------|-----------------------------|
+| prod    | 3                            | 40                          |
+| staging | 6                            | 40                          |
+
+**Staging config-field drift**: the Railway staging replicas config field was
+observed as `2` at audit time, but `6` instances were live. The SSOT records `6`
+(live reality). Follow-up: update the Railway staging replicas config field to 6.
+
+**Prod/staging parity**: prod runs 3 replicas vs. staging's 6. Bringing prod
+to parity is a deliberate one-field change (`numReplicas: 3 → 6`) that is
+deferred to a follow-up operational item.
+
+### SSOT fields
+
+- `workerProvisioning.{prod,staging}.numReplicas` — authoritative worker count
+  (= Railway replica count, 1:1). This is the ONLY field to update when
+  changing the replica count.
+- `workerProvisioning.{prod,staging}.BROWSER_POOL_MAX_CONTEXTS` — per-worker
+  Playwright context budget.
+- `workerProvisioning.{prod,staging}.HARNESS_POOL_COUNT` — INFORMATIONAL ONLY;
+  records what the `HARNESS_POOL_COUNT` env var is set to on Railway for audit
+  visibility. Never use this as a worker count or fork factor.
+
+### Applying a replica count change (MANUAL)
+
+The `emit-railway-envs-json.ts` emitter and `bin/railway` tooling are
+**VERIFY-ONLY** with respect to `numReplicas` — they do not write replica counts
+to Railway. To change the replica count:
+
+1. Change the `numReplicas` value in `railway-envs.ts` (SSOT).
+2. Regenerate the snapshot: `npx tsx showcase/scripts/emit-railway-envs-json.ts`
+3. Commit both files (`railway-envs.ts` + `railway-envs.generated.json`).
+4. Apply the change to Railway manually via the Railway Dashboard (Service >
+   Settings > Replicas) or the Railway GraphQL API.
+
+The CI drift gate (`showcase/scripts/__tests__/harness-workers-provisioning.test.ts`)
+will fail if `railway-envs.ts` and `railway-envs.generated.json` disagree on
+`numReplicas`, catching a forgotten regeneration step.
+
 ## Environment IDs
 
 - Project: `<project-id>`

--- a/showcase/harness/src/fleet/control-plane/family-silence-monitor.test.ts
+++ b/showcase/harness/src/fleet/control-plane/family-silence-monitor.test.ts
@@ -13,6 +13,7 @@ import type {
   FamilySummaryResponse,
   InflightState,
   RunBatch,
+  WorkerView,
 } from "./run-view.js";
 import type { ProducerSchedule } from "./control-plane.js";
 import type { JobProducer } from "./job-producer.js";
@@ -136,8 +137,27 @@ function withD6(
   );
 }
 
-function response(families: FamilySummaryEntry[]): FamilySummaryResponse {
-  return { families, workers: [] };
+function response(
+  families: FamilySummaryEntry[],
+  workers: WorkerView[] = [],
+): FamilySummaryResponse {
+  return { families, workers };
+}
+
+/**
+ * A worker strip entry whose `registeredAt` is the post-bounce drain signal
+ * the grace window keys off. Only the fields the monitor reads are pinned;
+ * the rest mirror a healthy online worker.
+ */
+function workerView(registeredAtMs: number): WorkerView {
+  return {
+    workerId: "worker-railway-abc",
+    health: "online",
+    lastHeartbeatAt: iso(registeredAtMs),
+    registeredAt: iso(registeredAtMs),
+    currentJobId: null,
+    capacity: { inUse: 0, available: 24, max: 24 },
+  };
 }
 
 function makeFakeStore(): AlertStateStore & {
@@ -406,6 +426,107 @@ describe("family-silence monitor — silence alert", () => {
     });
     await monitor.tick(now);
     expect(posts).toEqual([]);
+  });
+});
+
+describe("family-silence monitor — post-bounce drain grace window", () => {
+  // A NORMAL harness deploy rebuilds the shared `showcase-harness` image and
+  // bounces the pool workers (PR #5715). After the bounce the workers
+  // re-register (fresh `registered_at`), the producers re-arm, and each
+  // family is mid-sweep — `lastSuccessAt` legitimately still points at the
+  // PRE-bounce success and so reads stale against the 3×period silence gate.
+  // Without a bounce-keyed grace this trips a FALSE silence alert during the
+  // expected drain. The grace window is `BOUNCE_GRACE_PERIOD_MULTIPLIER`
+  // (=2) × period since the freshest worker `registeredAt`: long enough for
+  // the family to land its first post-bounce success, after which a still-
+  // silent family is a GENUINE outage and alerts as before.
+
+  it("RED→GREEN: a recent fleet bounce suppresses the silence alert during the drain window", async () => {
+    // lastSuccessAt is 4×period stale (the elapsed-time gate fires), but the
+    // freshest worker re-registered just before the first evaluated tick, so
+    // every observed silent tick falls inside the 2×period bounce grace and
+    // the consecutive-tick gate can never reach threshold.
+    const lastSuccessMs = BASE - 2 * PERIOD;
+    const t1 = BASE + 2 * PERIOD; // 4×period since lastSuccess
+    const t2 = BASE + 3 * PERIOD;
+    const t3 = BASE + 4 * PERIOD;
+    // Bounce at t1 − 1 min: t1/t2/t3 are all inside t1 + 2×period grace.
+    const bounceMs = t1 - 60_000;
+    const { monitor, posts } = makeMonitor({
+      get: async () =>
+        response(
+          withD6(t3, {
+            lastSuccessAt: iso(lastSuccessMs),
+            lastRun: batch({
+              enqueuedAt: iso(lastSuccessMs - 120_000),
+              finishedAt: iso(lastSuccessMs),
+            }),
+          }),
+          [workerView(bounceMs)],
+        ),
+    });
+    await monitor.tick(t1);
+    await monitor.tick(t2);
+    await monitor.tick(t3);
+    expect(posts).toEqual([]);
+  });
+
+  it("GREEN: a genuinely silent family STILL alerts once the bounce grace has elapsed", async () => {
+    // Same shape, but the bounce is OLD (well before lastSuccessAt) — the
+    // family has had many full periods since the last (re)start to land a
+    // success and has not, so this is a real outage and must still fire.
+    const lastSuccessMs = BASE - 2 * PERIOD;
+    const bounceMs = BASE - 10 * PERIOD; // ancient — grace long elapsed
+    const t1 = BASE + 2 * PERIOD;
+    const t2 = BASE + 3 * PERIOD;
+    const t3 = BASE + 4 * PERIOD;
+    const { monitor, posts } = makeMonitor({
+      get: async () =>
+        response(
+          withD6(t3, {
+            lastSuccessAt: iso(lastSuccessMs),
+            lastRun: batch({
+              enqueuedAt: iso(lastSuccessMs - 120_000),
+              finishedAt: iso(lastSuccessMs),
+            }),
+          }),
+          [workerView(bounceMs)],
+        ),
+    });
+    await monitor.tick(t1);
+    await monitor.tick(t2);
+    await monitor.tick(t3);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toContain("worker family D6 all-pills silent");
+    expect(posts[0]).toContain(`no successful run since ${iso(lastSuccessMs)}`);
+  });
+
+  it("GREEN: an empty worker strip (no bounce signal) preserves today's alerting", async () => {
+    // Defensive: when no workers are registered (PB strip empty / pre-fix
+    // payloads), there is no bounce instant to grace against, so the monitor
+    // behaves exactly as before — a stale family still alerts.
+    const lastSuccessMs = BASE - 2 * PERIOD;
+    const t1 = BASE + 2 * PERIOD;
+    const t2 = BASE + 3 * PERIOD;
+    const t3 = BASE + 4 * PERIOD;
+    const { monitor, posts } = makeMonitor({
+      get: async () =>
+        response(
+          withD6(t3, {
+            lastSuccessAt: iso(lastSuccessMs),
+            lastRun: batch({
+              enqueuedAt: iso(lastSuccessMs - 120_000),
+              finishedAt: iso(lastSuccessMs),
+            }),
+          }),
+          [],
+        ),
+    });
+    await monitor.tick(t1);
+    await monitor.tick(t2);
+    await monitor.tick(t3);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toContain("worker family D6 all-pills silent");
   });
 });
 

--- a/showcase/harness/src/fleet/control-plane/family-silence-monitor.test.ts
+++ b/showcase/harness/src/fleet/control-plane/family-silence-monitor.test.ts
@@ -530,6 +530,112 @@ describe("family-silence monitor — post-bounce drain grace window", () => {
   });
 });
 
+describe("family-silence monitor — bounce-grace window edge (2×period boundary)", () => {
+  // Pin the exact 2×period boundary of the bounce grace. The suppression
+  // predicate is `nowMs - bounceMs < BOUNCE_GRACE_PERIOD_MULTIPLIER × period`
+  // (strict <), evaluated per-tick. To isolate the boundary we want the
+  // FINAL evaluated tick to be the one that straddles the edge, so the
+  // earlier ticks must ALSO fall on the same side — otherwise an earlier
+  // outside-grace tick would advance the consecutive-silent counter and
+  // confound the edge under test. We therefore place the bounce so that all
+  // three pre-warm ticks share the boundary relationship being pinned.
+
+  it("a bounce JUST INSIDE 2×period (grace strictly holds across all ticks) suppresses the alert", async () => {
+    // lastSuccessAt is 4×period stale so the elapsed-time gate fires every
+    // tick. Bounce is positioned so the LAST tick (t3) sits 1 min before the
+    // 2×period edge: nowMs - bounceMs = 2×period − 60s < 2×period → inside.
+    // t1/t2 are earlier, so even closer to the bounce → also inside.
+    const lastSuccessMs = BASE - 2 * PERIOD;
+    const t1 = BASE + 2 * PERIOD;
+    const t2 = BASE + 3 * PERIOD;
+    const t3 = BASE + 4 * PERIOD;
+    // bounce so that t3 is just inside: t3 - bounce = 2×period - 60s.
+    const bounceMs = t3 - (2 * PERIOD - 60_000);
+    const { monitor, posts } = makeMonitor({
+      get: async () =>
+        response(
+          withD6(t3, {
+            lastSuccessAt: iso(lastSuccessMs),
+            lastRun: batch({
+              enqueuedAt: iso(lastSuccessMs - 120_000),
+              finishedAt: iso(lastSuccessMs),
+            }),
+          }),
+          [workerView(bounceMs)],
+        ),
+    });
+    await monitor.tick(t1);
+    await monitor.tick(t2);
+    await monitor.tick(t3);
+    expect(posts).toEqual([]);
+  });
+
+  it("a bounce JUST OUTSIDE 2×period on every tick lets the alert fire", async () => {
+    // Same shape, but the bounce is old enough that EVERY tick is past the
+    // 2×period grace by ≥1 min: t1 - bounce = 2×period + 60s > 2×period →
+    // outside on t1, and t2/t3 are even further out. With grace lapsed on all
+    // three ticks the consecutive-silent counter reaches threshold and posts.
+    const lastSuccessMs = BASE - 2 * PERIOD;
+    const t1 = BASE + 2 * PERIOD;
+    const t2 = BASE + 3 * PERIOD;
+    const t3 = BASE + 4 * PERIOD;
+    const bounceMs = t1 - (2 * PERIOD + 60_000);
+    const { monitor, posts } = makeMonitor({
+      get: async () =>
+        response(
+          withD6(t3, {
+            lastSuccessAt: iso(lastSuccessMs),
+            lastRun: batch({
+              enqueuedAt: iso(lastSuccessMs - 120_000),
+              finishedAt: iso(lastSuccessMs),
+            }),
+          }),
+          [workerView(bounceMs)],
+        ),
+    });
+    await monitor.tick(t1);
+    await monitor.tick(t2);
+    await monitor.tick(t3);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toContain("worker family D6 all-pills silent");
+  });
+
+  it("grace does NOT apply when the bounce predates last-success + 1 period (the family already succeeded after the bounce)", async () => {
+    // Intent: the grace covers the post-bounce DRAIN — the gap before the
+    // family lands its first success after a (re)start. If the family ALREADY
+    // succeeded well after the bounce (lastSuccessAt is more than one period
+    // newer than the bounce) the drain is over; a subsequent silence is a
+    // GENUINE outage and the stale bounce must not re-grant grace. Here the
+    // bounce is 5×period old while lastSuccessAt is only 2×period old — i.e.
+    // lastSuccess is ~3 periods AFTER the bounce, comfortably past
+    // last-success+1period — so the grace window (2×period since the OLD
+    // bounce) has long elapsed and the alert fires.
+    const bounceMs = BASE - 5 * PERIOD;
+    const lastSuccessMs = BASE - 2 * PERIOD; // 3 periods after the bounce
+    const t1 = BASE + 2 * PERIOD;
+    const t2 = BASE + 3 * PERIOD;
+    const t3 = BASE + 4 * PERIOD;
+    const { monitor, posts } = makeMonitor({
+      get: async () =>
+        response(
+          withD6(t3, {
+            lastSuccessAt: iso(lastSuccessMs),
+            lastRun: batch({
+              enqueuedAt: iso(lastSuccessMs - 120_000),
+              finishedAt: iso(lastSuccessMs),
+            }),
+          }),
+          [workerView(bounceMs)],
+        ),
+    });
+    await monitor.tick(t1);
+    await monitor.tick(t2);
+    await monitor.tick(t3);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toContain("worker family D6 all-pills silent");
+  });
+});
+
 describe("family-silence monitor — boot grace", () => {
   it("boot grace (1x period) suppresses the silence alert AND the meta-alert failing-since clock", async () => {
     // (a) silence alert suppressed inside the grace window.

--- a/showcase/harness/src/fleet/control-plane/family-silence-monitor.test.ts
+++ b/showcase/harness/src/fleet/control-plane/family-silence-monitor.test.ts
@@ -533,36 +533,54 @@ describe("family-silence monitor — post-bounce drain grace window", () => {
 describe("family-silence monitor — bounce-grace window edge (2×period boundary)", () => {
   // Pin the exact 2×period boundary of the bounce grace. The suppression
   // predicate is `nowMs - bounceMs < BOUNCE_GRACE_PERIOD_MULTIPLIER × period`
-  // (strict <), evaluated per-tick. To isolate the boundary we want the
-  // FINAL evaluated tick to be the one that straddles the edge, so the
-  // earlier ticks must ALSO fall on the same side — otherwise an earlier
-  // outside-grace tick would advance the consecutive-silent counter and
-  // confound the edge under test. We therefore place the bounce so that all
-  // three pre-warm ticks share the boundary relationship being pinned.
+  // (strict <), evaluated per-tick against the freshest worker registration.
+  //
+  // To make this a GENUINE pin of the 2× term (not merely a "grace exists"
+  // smoke test), the FINAL tick must straddle the 2×period edge while the
+  // consecutive-silent counter has ALREADY been primed to threshold−1 by
+  // earlier ticks — so the boundary tick is the deciding 3rd observation.
+  // The earlier (priming) ticks see an ANCIENT bounce that is outside the
+  // grace at ANY positive multiplier (so they bind identically whether the
+  // term is 1, 2, or 3 and reliably advance the counter 1→2); the final tick
+  // sees a FRESH bounce placed exactly 1 min inside 2×period. That asymmetry
+  // is realistic: the old registration is the pre-deploy worker, and a fresh
+  // image-rebuild bounce (PR #5715) re-registers the worker just before the
+  // last observed tick. The bounce is always in the PAST of the tick that
+  // reads it (positive elapsed), never future-dated.
 
-  it("a bounce JUST INSIDE 2×period (grace strictly holds across all ticks) suppresses the alert", async () => {
-    // lastSuccessAt is 4×period stale so the elapsed-time gate fires every
-    // tick. Bounce is positioned so the LAST tick (t3) sits 1 min before the
-    // 2×period edge: nowMs - bounceMs = 2×period − 60s < 2×period → inside.
-    // t1/t2 are earlier, so even closer to the bounce → also inside.
+  it("a bounce JUST INSIDE 2×period (deciding 3rd tick) suppresses the alert", async () => {
+    // lastSuccessAt is 2×period before BASE so every tick observes ≥4×period
+    // of silence — the elapsed-time gate fires on all three. t1/t2 read an
+    // ancient bounce (10×period old → outside grace at any multiplier) and so
+    // advance the consecutive-silent counter to 2. The fresh bounce served on
+    // the t3 read sits 1 min inside the 2×period edge:
+    //   t3 − freshBounceMs = 2×period − 60s.
+    // At BOUNCE_GRACE_PERIOD_MULTIPLIER = 2 that is < 2×period → INSIDE →
+    // the deciding 3rd tick is suppressed, the counter resets, no alert.
+    // This is the load-bearing pin: mutate the multiplier to 1 and the same
+    // 2×period − 60s elapsed becomes ≥ 1×period → OUTSIDE → the 3rd silent
+    // tick posts the alert and this expectation flips RED.
     const lastSuccessMs = BASE - 2 * PERIOD;
-    const t1 = BASE + 2 * PERIOD;
-    const t2 = BASE + 3 * PERIOD;
-    const t3 = BASE + 4 * PERIOD;
-    // bounce so that t3 is just inside: t3 - bounce = 2×period - 60s.
-    const bounceMs = t3 - (2 * PERIOD - 60_000);
+    const t1 = BASE + 2 * PERIOD; // 4×period since lastSuccess
+    const t2 = BASE + 3 * PERIOD; // 5×period
+    const t3 = BASE + 4 * PERIOD; // 6×period
+    const oldBounceMs = BASE - 10 * PERIOD; // ancient → outside grace always
+    const freshBounceMs = t3 - (2 * PERIOD - 60_000); // 1 min inside 2×period
+    const d6 = {
+      lastSuccessAt: iso(lastSuccessMs),
+      lastRun: batch({
+        enqueuedAt: iso(lastSuccessMs - 120_000),
+        finishedAt: iso(lastSuccessMs),
+      }),
+    };
+    let call = 0;
     const { monitor, posts } = makeMonitor({
-      get: async () =>
-        response(
-          withD6(t3, {
-            lastSuccessAt: iso(lastSuccessMs),
-            lastRun: batch({
-              enqueuedAt: iso(lastSuccessMs - 120_000),
-              finishedAt: iso(lastSuccessMs),
-            }),
-          }),
-          [workerView(bounceMs)],
-        ),
+      // t1/t2 reads (calls 0,1) see the ancient pre-deploy registration; the
+      // t3 read (call 2) sees the fresh post-bounce registration.
+      get: async () => {
+        const bounceMs = call++ < 2 ? oldBounceMs : freshBounceMs;
+        return response(withD6(t3, d6), [workerView(bounceMs)]);
+      },
     });
     await monitor.tick(t1);
     await monitor.tick(t2);

--- a/showcase/harness/src/fleet/control-plane/family-silence-monitor.ts
+++ b/showcase/harness/src/fleet/control-plane/family-silence-monitor.ts
@@ -101,11 +101,19 @@ export const SILENCE_CONSECUTIVE_TICK_THRESHOLD = 3;
  * VALUE = 2: the family needs roughly one full period to enqueue + run its
  * first post-bounce sweep and a second for headroom against scheduling skew
  * and a sweep that runs slightly long — it must clear ~1–2 full sweep cycles
- * before a fresh `lastSuccessAt` can exist. Two periods is also the §7.4
- * banner's own silence threshold, so the banner (which keys off the same
- * `registeredAt` shipped in the `/api/runs` workers strip) and this alert
- * stay consistent: within two periods of a bounce neither surface flags
- * silence, beyond it both do. Past the grace with still-no-success → a
+ * before a fresh `lastSuccessAt` can exist. This 2×period bounce-grace TERM is
+ * identical on both surfaces: the §7.4 dashboard banner applies the same
+ * `BOUNCE_GRACE_PERIOD_MULTIPLIER` (=2) keyed off the same worker
+ * `registeredAt` shipped in the `/api/runs` workers strip, so for the grace
+ * window specifically the banner and this Slack alert agree — within two
+ * periods of a bounce neither flags silence, beyond it both can. NOTE the
+ * silence-ONSET thresholds are NOT identical and were never meant to be: the
+ * dashboard treats a family silent at 2×period of staleness, while this
+ * server gate requires 3×period of staleness AND 3 consecutive silent ticks
+ * (see `SILENCE_PERIOD_MULTIPLIER` / `SILENCE_CONSECUTIVE_TICK_THRESHOLD`).
+ * That onset asymmetry is pre-existing / by-design (the dashboard is a
+ * lower-latency visual hint; the pager is deliberately slower to fire) — only
+ * the bounce-grace term is shared. Past the grace with still-no-success → a
  * GENUINE outage, alerts exactly as before.
  *
  * The grace keys off the freshest worker `registeredAt` (NOT CP `bootAtMs`):
@@ -588,8 +596,7 @@ export function createFamilySilenceMonitor(
         // Fleet-wide bounce signal for this cycle: the freshest worker
         // (re)registration across the shared workers strip. One read serves
         // every due family (a deploy bounces the whole pool at once).
-        const bounceMs =
-          body !== null ? freshestBounceMs(body.workers) : null;
+        const bounceMs = body !== null ? freshestBounceMs(body.workers) : null;
 
         const metaTrips: Array<{ family: string; sinceMs: number }> = [];
         const metaRecoveries: string[] = [];

--- a/showcase/harness/src/fleet/control-plane/family-silence-monitor.ts
+++ b/showcase/harness/src/fleet/control-plane/family-silence-monitor.ts
@@ -53,6 +53,7 @@ import type {
   FamilySummaryEntry,
   FleetFamily,
   MemoizedFamilySummary,
+  WorkerView,
 } from "./run-view.js";
 
 /** Alert-state keying (§9): silence alerts — `rule_id` + `dedupe_key: family`. */
@@ -81,6 +82,40 @@ export const SILENCE_PERIOD_MULTIPLIER = 3;
  * applied along the orthogonal axis. Exported so tests pin the SSOT.
  */
 export const SILENCE_CONSECUTIVE_TICK_THRESHOLD = 3;
+
+/**
+ * Post-bounce drain grace: a family is NOT considered silent while the time
+ * since the fleet's most-recent worker (re)registration is below this many
+ * resolved periods.
+ *
+ * WHY THIS EXISTS — a NORMAL harness deploy rebuilds the shared
+ * `showcase-harness` image and bounces the pool workers (PR #5715: the prod
+ * worker is now in the image-rebuild redeploy scope, so an image push restarts
+ * it). Immediately after the bounce the workers re-register, the producers
+ * re-arm, and every family is legitimately MID-SWEEP: `lastSuccessAt` still
+ * points at the PRE-bounce success, which reads stale against the 3×period
+ * silence gate. Without a bounce-keyed grace, a routine deploy fires a FALSE
+ * "worker family … silent" alert (and the matching §7.4 dashboard banner)
+ * for the whole drain window.
+ *
+ * VALUE = 2: the family needs roughly one full period to enqueue + run its
+ * first post-bounce sweep and a second for headroom against scheduling skew
+ * and a sweep that runs slightly long — it must clear ~1–2 full sweep cycles
+ * before a fresh `lastSuccessAt` can exist. Two periods is also the §7.4
+ * banner's own silence threshold, so the banner (which keys off the same
+ * `registeredAt` shipped in the `/api/runs` workers strip) and this alert
+ * stay consistent: within two periods of a bounce neither surface flags
+ * silence, beyond it both do. Past the grace with still-no-success → a
+ * GENUINE outage, alerts exactly as before.
+ *
+ * The grace keys off the freshest worker `registeredAt` (NOT CP `bootAtMs`):
+ * a worker can be bounced while the CP stays up (or vice-versa), so the
+ * worker-registration instant is the correct, independent bounce signal.
+ * When the workers strip is empty (no bounce signal — PB strip unavailable or
+ * pre-migration rows) there is nothing to grace against and the monitor
+ * behaves exactly as it did before this change. Exported so tests pin the SSOT.
+ */
+export const BOUNCE_GRACE_PERIOD_MULTIPLIER = 2;
 
 export interface FamilySilenceMonitorDeps {
   /** The SHARED memoized §5.2.1 projection instance (§5.2 — same one the routes get). */
@@ -147,6 +182,24 @@ function lastAttemptText(entry: FamilySummaryEntry): string {
  * else the oldest known batch's `enqueuedAt` (never-succeeded variant), else
  * null (zero batches — stay silent).
  */
+/**
+ * The fleet's most-recent worker (re)registration instant — the bounce signal
+ * the post-bounce drain grace keys off. Returns the freshest parseable
+ * `registeredAt` across the workers strip, or null when none is present (empty
+ * strip / pre-migration rows / unparseable values) — null disables the grace,
+ * preserving pre-change behavior.
+ */
+function freshestBounceMs(workers: readonly WorkerView[]): number | null {
+  let freshest = Number.NaN;
+  for (const worker of workers) {
+    const ms = parseIso(worker.registeredAt);
+    if (!Number.isNaN(ms) && (Number.isNaN(freshest) || ms > freshest)) {
+      freshest = ms;
+    }
+  }
+  return Number.isNaN(freshest) ? null : freshest;
+}
+
 function silenceReference(
   entry: FamilySummaryEntry,
 ): { refMs: number; neverSucceeded: boolean } | null {
@@ -415,6 +468,7 @@ export function createFamilySilenceMonitor(
     monitored: MonitoredFamily,
     entry: FamilySummaryEntry,
     nowMs: number,
+    bounceMs: number | null,
   ): Promise<void> {
     const { fam, periodMs, graceEndMs } = monitored;
 
@@ -439,6 +493,27 @@ export function createFamilySilenceMonitor(
     }
 
     if (nowMs < graceEndMs) return; // boot grace (1×period, §9)
+
+    // Post-bounce drain grace: a NORMAL deploy bounces the pool workers
+    // (PR #5715), after which the family is legitimately mid-sweep and its
+    // pre-bounce `lastSuccessAt` reads stale. While the freshest worker
+    // (re)registration is inside the 2×period drain window, the family is
+    // DRAINING, not silent — suppress, and reset the consecutive-silent
+    // counter so a tick observed during the drain can never accumulate
+    // toward the threshold once the grace lapses. A null bounce instant
+    // (empty workers strip) leaves today's behavior untouched.
+    if (
+      bounceMs !== null &&
+      nowMs - bounceMs < BOUNCE_GRACE_PERIOD_MULTIPLIER * periodMs
+    ) {
+      consecutiveSilentTicks.delete(fam.family);
+      logger.debug("fleet.family-silence.bounce-grace-suppressed", {
+        family: fam.family,
+        bounceAt: iso(bounceMs),
+        graceWindowMs: BOUNCE_GRACE_PERIOD_MULTIPLIER * periodMs,
+      });
+      return;
+    }
 
     // Consecutive-silent-tick gate (Change 3 — 2026-06-17 Cloudflare-WAF
     // incident remediation). The elapsed-time gate above (3×period) shows
@@ -510,6 +585,12 @@ export function createFamilySilenceMonitor(
           });
         }
 
+        // Fleet-wide bounce signal for this cycle: the freshest worker
+        // (re)registration across the shared workers strip. One read serves
+        // every due family (a deploy bounces the whole pool at once).
+        const bounceMs =
+          body !== null ? freshestBounceMs(body.workers) : null;
+
         const metaTrips: Array<{ family: string; sinceMs: number }> = [];
         const metaRecoveries: string[] = [];
         for (const entry of due) {
@@ -533,7 +614,7 @@ export function createFamilySilenceMonitor(
             if (metaAlertActive.has(entry.fam.family)) {
               metaRecoveries.push(entry.fam.family);
             }
-            await evaluateFamily(entry, familyEntry, nowMs);
+            await evaluateFamily(entry, familyEntry, nowMs, bounceMs);
           }
         }
         await postMetaAlert(metaTrips, nowMs);

--- a/showcase/harness/src/fleet/control-plane/run-view.test.ts
+++ b/showcase/harness/src/fleet/control-plane/run-view.test.ts
@@ -619,6 +619,7 @@ describe("projectWorker", () => {
       capacity_max: 24,
       current_job_id: "",
       last_heartbeat_at: iso(-100),
+      registered_at: iso(-3_600_000),
       ...overrides,
     };
   }
@@ -669,9 +670,30 @@ describe("projectWorker", () => {
       workerId: "worker-railway-abc",
       health: "online",
       lastHeartbeatAt: iso(-100),
+      registeredAt: iso(-3_600_000),
       currentJobId: null,
       capacity: { inUse: 1, available: 23, max: 24 },
     });
+  });
+
+  it("projects registered_at to registeredAt, falling back to '' when the column is absent", () => {
+    // The bounce signal the §7.4 banner / §9 monitor grace off; an absent
+    // column (pre-migration / never-registered row) projects to "" (no
+    // bounce instant), which disables the grace and preserves prior behavior.
+    expect(
+      projectWorker(
+        workerRow({ registered_at: iso(-7_200_000) }),
+        STALE_AFTER_MS,
+        NOW_MS,
+      ).registeredAt,
+    ).toBe(iso(-7_200_000));
+    expect(
+      projectWorker(
+        workerRow({ registered_at: undefined }),
+        STALE_AFTER_MS,
+        NOW_MS,
+      ).registeredAt,
+    ).toBe("");
   });
 
   it("maps an empty current_job_id to null and a set one to its value", () => {
@@ -1064,6 +1086,7 @@ describe("createMemoizedFamilySummary", () => {
           capacity_max: 24,
           current_job_id: "",
           last_heartbeat_at: iso(-1_000),
+          registered_at: iso(-5_000),
         },
       ],
     });
@@ -1075,6 +1098,8 @@ describe("createMemoizedFamilySummary", () => {
         workerId: "worker-railway-abc",
         health: "online",
         lastHeartbeatAt: iso(-1_000),
+        // The bounce signal the §7.4 banner / §9 monitor grace off.
+        registeredAt: iso(-5_000),
         currentJobId: null,
         capacity: { inUse: 0, available: 24, max: 24 },
       },

--- a/showcase/harness/src/fleet/control-plane/run-view.ts
+++ b/showcase/harness/src/fleet/control-plane/run-view.ts
@@ -141,6 +141,14 @@ export interface WorkerRow {
   capacity_max?: number;
   current_job_id?: string;
   last_heartbeat_at?: string;
+  /**
+   * ISO instant the worker last (re)registered — seeded on every worker boot
+   * upsert (worker/registration.ts) and preserved verbatim across heartbeats.
+   * The freshest value across the strip is the fleet's most-recent BOUNCE
+   * instant (PR #5715: an image rebuild bounces the pool workers), which the
+   * §7.4 banner / §9 silence monitor key their post-bounce drain grace off.
+   */
+  registered_at?: string;
 }
 
 /** The `probe_runs` row fields the reds read path consumes (§4.2). */
@@ -207,6 +215,16 @@ export interface WorkerView {
   workerId: string;
   health: WorkerHealthState;
   lastHeartbeatAt: string;
+  /**
+   * ISO instant the worker last (re)registered (`registered_at`), or "" when
+   * the column is absent (pre-migration / never-registered row). The freshest
+   * non-empty value across the strip is the fleet's most-recent bounce instant
+   * — the §7.4 banner / §9 silence monitor use it to grace a post-deploy drain
+   * (workers just restarted, families legitimately mid-sweep) instead of
+   * flagging false silence. A non-secret identifier timestamp, same exposure
+   * carve-out as `lastHeartbeatAt`.
+   */
+  registeredAt: string;
   currentJobId: string | null;
   capacity: { inUse: number; available: number; max: number };
 }
@@ -722,6 +740,7 @@ export function projectWorker(
     workerId: row.worker_id,
     health,
     lastHeartbeatAt: heartbeat,
+    registeredAt: row.registered_at ?? "",
     currentJobId:
       row.current_job_id && row.current_job_id !== ""
         ? row.current_job_id

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit/route.ts
@@ -12,6 +12,14 @@ import { HttpAgent } from "@ag-ui/client";
 // This runtime proxies CopilotKit requests to it via AG-UI protocol.
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
+
 console.log("[copilotkit/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit/route] AGENT_URL: ${AGENT_URL}`);
 
@@ -100,7 +108,11 @@ console.log(
 export const POST = async (req: NextRequest) => {
   const url = req.url;
   const contentType = req.headers.get("content-type");
-  console.log(`[copilotkit/route] POST ${url} (content-type: ${contentType})`);
+  if (ROUTE_DEBUG) {
+    console.log(
+      `[copilotkit/route] POST ${url} (content-type: ${contentType})`,
+    );
+  }
 
   try {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
@@ -115,7 +127,9 @@ export const POST = async (req: NextRequest) => {
     });
 
     const response = await handleRequest(req);
-    console.log(`[copilotkit/route] Response status: ${response.status}`);
+    if (ROUTE_DEBUG) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    }
     return response;
   } catch (error: unknown) {
     const err = error as Error;

--- a/showcase/scripts/__tests__/harness-workers-provisioning.test.ts
+++ b/showcase/scripts/__tests__/harness-workers-provisioning.test.ts
@@ -34,7 +34,10 @@ const GENERATED_JSON_PATH = resolve(
 function loadGeneratedSnapshot(): {
   services: Array<{
     name: string;
-    workerProvisioning?: { prod: WorkerProvisioning; staging: WorkerProvisioning };
+    workerProvisioning?: {
+      prod: WorkerProvisioning;
+      staging: WorkerProvisioning;
+    };
   }>;
 } {
   return JSON.parse(readFileSync(GENERATED_JSON_PATH, "utf8"));
@@ -182,28 +185,10 @@ describe("harness-workers provisioning drift gate (SSOT vs generated JSON snapsh
 
 describe("harness-workers provisioning with injected test data", () => {
   /**
-   * These tests use injected SSOT data to verify the drift detection logic
-   * itself — proving the gate FAILS when SSOT and snapshot disagree.
-   * They do NOT modify the real SERVICES map; they exercise the same
-   * comparison logic the drift gate uses with synthetic inputs.
+   * This test injects a synthetic SSOT entry and confirms the accessor
+   * returns the correct fields. It does NOT modify the real SERVICES map
+   * beyond the sentinel, which is removed in the finally block.
    */
-
-  it("drift gate logic: detects mismatched numReplicas", () => {
-    // Simulate: SSOT says numReplicas=99, snapshot still says 3.
-    // The gate must FAIL (i.e. the values differ).
-    const ssotValue = 99;
-    const snapshotValue = 3;
-    // This IS the assertion the drift gate performs — if this fails, the gate
-    // correctly catches the drift.
-    expect(ssotValue).not.toBe(snapshotValue);
-  });
-
-  it("drift gate logic: passes when SSOT and snapshot agree", () => {
-    // Simulate: SSOT says numReplicas=3, snapshot says 3 → PASS.
-    const ssotValue = 3;
-    const snapshotValue = 3;
-    expect(ssotValue).toBe(snapshotValue);
-  });
 
   it("transient injected SSOT entry: workerProvisioningFor returns correct values", () => {
     // Inject a synthetic harness-workers-like entry and confirm the accessor
@@ -216,7 +201,17 @@ describe("harness-workers provisioning with injected test data", () => {
     (
       SERVICES as Record<
         string,
-        { serviceId: string; environments: Record<string, unknown>; probeDriver: string; ciBuilt: boolean; gateValidated: boolean; workerProvisioning?: { prod: WorkerProvisioning; staging: WorkerProvisioning } }
+        {
+          serviceId: string;
+          environments: Record<string, unknown>;
+          probeDriver: string;
+          ciBuilt: boolean;
+          gateValidated: boolean;
+          workerProvisioning?: {
+            prod: WorkerProvisioning;
+            staging: WorkerProvisioning;
+          };
+        }
       >
     )[sentinel] = {
       serviceId: "00000000-0000-0000-0000-000000000099",
@@ -224,8 +219,14 @@ describe("harness-workers provisioning with injected test data", () => {
       gateValidated: false,
       probeDriver: "harness",
       environments: {
-        prod: { instanceId: "11111111-1111-1111-1111-111111111111", probe: false },
-        staging: { instanceId: "22222222-2222-2222-2222-222222222222", probe: false },
+        prod: {
+          instanceId: "11111111-1111-1111-1111-111111111111",
+          probe: false,
+        },
+        staging: {
+          instanceId: "22222222-2222-2222-2222-222222222222",
+          probe: false,
+        },
       },
       workerProvisioning: mockProv,
     };

--- a/showcase/scripts/__tests__/harness-workers-provisioning.test.ts
+++ b/showcase/scripts/__tests__/harness-workers-provisioning.test.ts
@@ -1,0 +1,242 @@
+/**
+ * harness-workers-provisioning.test.ts — CI drift gate for harness-workers
+ * worker-fleet provisioning fields (`numReplicas`, `BROWSER_POOL_MAX_CONTEXTS`).
+ *
+ * Style note: mirrors `verify-railway-image-refs.test.ts` — pure validators
+ * against synthesized or committed-snapshot inputs, NO live Railway API calls.
+ *
+ * The drift gate works by comparing SSOT `numReplicas` (declared in
+ * `railway-envs.ts`) against the value committed to
+ * `railway-envs.generated.json` (a static snapshot, NOT a live Railway API
+ * response). When the SSOT and the snapshot agree, the gate passes. When they
+ * diverge (someone edited the SSOT but forgot to re-run emit-railway-envs-json,
+ * or forgot to update the SSOT to match reality), the gate fails.
+ *
+ * WORKER MODEL CONFIRMED: 1-worker-per-replica (NOT replicas × pool count).
+ * `HARNESS_POOL_COUNT` is INFORMATIONAL ONLY — not a fork factor. The
+ * authoritative worker count is `numReplicas`. The authoritative per-worker
+ * concurrency is `BROWSER_POOL_MAX_CONTEXTS`.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { SERVICES, workerProvisioningFor } from "../railway-envs";
+import type { WorkerProvisioning } from "../railway-envs";
+
+const GENERATED_JSON_PATH = resolve(
+  __dirname,
+  "..",
+  "railway-envs.generated.json",
+);
+
+/** Load the committed generated-JSON snapshot (never calls the Railway API). */
+function loadGeneratedSnapshot(): {
+  services: Array<{
+    name: string;
+    workerProvisioning?: { prod: WorkerProvisioning; staging: WorkerProvisioning };
+  }>;
+} {
+  return JSON.parse(readFileSync(GENERATED_JSON_PATH, "utf8"));
+}
+
+describe("harness-workers provisioning SSOT", () => {
+  it("harness-workers declares workerProvisioning in the SSOT", () => {
+    const prodProv = workerProvisioningFor("harness-workers", "prod");
+    const stagingProv = workerProvisioningFor("harness-workers", "staging");
+    expect(prodProv).not.toBeUndefined();
+    expect(stagingProv).not.toBeUndefined();
+  });
+
+  it("prod numReplicas = 3 (current live reality, 2026-06-26)", () => {
+    const prov = workerProvisioningFor("harness-workers", "prod");
+    expect(prov?.numReplicas).toBe(3);
+  });
+
+  it("staging numReplicas = 6 (live reality — config-field read 2, but 6 instances live)", () => {
+    // STAGING CONFIG DRIFT: Railway staging replicas config field was 2 at
+    // audit time, but 6 instances were observed LIVE. This test asserts 6
+    // (live reality). Follow-up: align Railway staging config field to 6.
+    const prov = workerProvisioningFor("harness-workers", "staging");
+    expect(prov?.numReplicas).toBe(6);
+  });
+
+  it("BROWSER_POOL_MAX_CONTEXTS = 40 for both envs (per-worker concurrency, not a fleet total)", () => {
+    const prodProv = workerProvisioningFor("harness-workers", "prod");
+    const stagingProv = workerProvisioningFor("harness-workers", "staging");
+    expect(prodProv?.BROWSER_POOL_MAX_CONTEXTS).toBe(40);
+    expect(stagingProv?.BROWSER_POOL_MAX_CONTEXTS).toBe(40);
+  });
+
+  it("HARNESS_POOL_COUNT is recorded as informational only — NOT used as a fork factor", () => {
+    // The worker boots 1 process per replica (keyed on HOSTNAME). HARNESS_POOL_COUNT
+    // is forwarded to each worker as a control-plane hint but NEVER forks additional
+    // worker processes. The authoritative worker count is numReplicas.
+    const prodProv = workerProvisioningFor("harness-workers", "prod");
+    const stagingProv = workerProvisioningFor("harness-workers", "staging");
+    // Presence is optional; assert its value only when set.
+    if (prodProv?.HARNESS_POOL_COUNT !== undefined) {
+      expect(typeof prodProv.HARNESS_POOL_COUNT).toBe("number");
+    }
+    if (stagingProv?.HARNESS_POOL_COUNT !== undefined) {
+      expect(typeof stagingProv.HARNESS_POOL_COUNT).toBe("number");
+    }
+  });
+
+  it("workerProvisioningFor returns undefined for non-worker services", () => {
+    // Only harness-workers carries this field; every other service returns undefined.
+    expect(workerProvisioningFor("harness", "prod")).toBeUndefined();
+    expect(workerProvisioningFor("aimock", "prod")).toBeUndefined();
+    expect(workerProvisioningFor("pocketbase", "staging")).toBeUndefined();
+  });
+});
+
+describe("harness-workers provisioning drift gate (SSOT vs generated JSON snapshot)", () => {
+  /**
+   * This is the CI drift gate. It compares the SSOT-declared `numReplicas`
+   * values against the committed `railway-envs.generated.json` snapshot.
+   *
+   * If someone edits `railway-envs.ts` (SSOT) but forgets to regenerate the
+   * JSON, OR edits the JSON directly without updating the SSOT, this test
+   * catches the drift.
+   *
+   * The comparison source is the COMMITTED JSON SNAPSHOT — NOT a live Railway
+   * API call. This is intentional: live API calls are inappropriate for a unit
+   * test (flaky, requires auth, slow). The snapshot is updated by running:
+   *   npx tsx showcase/scripts/emit-railway-envs-json.ts
+   */
+  it("SSOT prod numReplicas matches committed generated JSON snapshot", () => {
+    const snapshot = loadGeneratedSnapshot();
+    const snapshotEntry = snapshot.services.find(
+      (s) => s.name === "harness-workers",
+    );
+    expect(
+      snapshotEntry,
+      "harness-workers missing from railway-envs.generated.json",
+    ).not.toBeUndefined();
+
+    const ssotProd = workerProvisioningFor("harness-workers", "prod");
+    expect(
+      ssotProd,
+      "harness-workers prod workerProvisioning missing from SSOT",
+    ).not.toBeUndefined();
+
+    const snapshotProdReplicas =
+      snapshotEntry?.workerProvisioning?.prod?.numReplicas;
+    expect(
+      snapshotProdReplicas,
+      "workerProvisioning.prod.numReplicas missing from generated JSON snapshot",
+    ).not.toBeUndefined();
+
+    expect(ssotProd?.numReplicas).toBe(snapshotProdReplicas);
+  });
+
+  it("SSOT staging numReplicas matches committed generated JSON snapshot", () => {
+    const snapshot = loadGeneratedSnapshot();
+    const snapshotEntry = snapshot.services.find(
+      (s) => s.name === "harness-workers",
+    );
+    expect(
+      snapshotEntry,
+      "harness-workers missing from railway-envs.generated.json",
+    ).not.toBeUndefined();
+
+    const ssotStaging = workerProvisioningFor("harness-workers", "staging");
+    expect(
+      ssotStaging,
+      "harness-workers staging workerProvisioning missing from SSOT",
+    ).not.toBeUndefined();
+
+    const snapshotStagingReplicas =
+      snapshotEntry?.workerProvisioning?.staging?.numReplicas;
+    expect(
+      snapshotStagingReplicas,
+      "workerProvisioning.staging.numReplicas missing from generated JSON snapshot",
+    ).not.toBeUndefined();
+
+    expect(ssotStaging?.numReplicas).toBe(snapshotStagingReplicas);
+  });
+
+  it("SSOT prod BROWSER_POOL_MAX_CONTEXTS matches committed generated JSON snapshot", () => {
+    const snapshot = loadGeneratedSnapshot();
+    const snapshotEntry = snapshot.services.find(
+      (s) => s.name === "harness-workers",
+    );
+    const ssotProd = workerProvisioningFor("harness-workers", "prod");
+    expect(ssotProd?.BROWSER_POOL_MAX_CONTEXTS).toBe(
+      snapshotEntry?.workerProvisioning?.prod?.BROWSER_POOL_MAX_CONTEXTS,
+    );
+  });
+
+  it("SSOT staging BROWSER_POOL_MAX_CONTEXTS matches committed generated JSON snapshot", () => {
+    const snapshot = loadGeneratedSnapshot();
+    const snapshotEntry = snapshot.services.find(
+      (s) => s.name === "harness-workers",
+    );
+    const ssotStaging = workerProvisioningFor("harness-workers", "staging");
+    expect(ssotStaging?.BROWSER_POOL_MAX_CONTEXTS).toBe(
+      snapshotEntry?.workerProvisioning?.staging?.BROWSER_POOL_MAX_CONTEXTS,
+    );
+  });
+});
+
+describe("harness-workers provisioning with injected test data", () => {
+  /**
+   * These tests use injected SSOT data to verify the drift detection logic
+   * itself — proving the gate FAILS when SSOT and snapshot disagree.
+   * They do NOT modify the real SERVICES map; they exercise the same
+   * comparison logic the drift gate uses with synthetic inputs.
+   */
+
+  it("drift gate logic: detects mismatched numReplicas", () => {
+    // Simulate: SSOT says numReplicas=99, snapshot still says 3.
+    // The gate must FAIL (i.e. the values differ).
+    const ssotValue = 99;
+    const snapshotValue = 3;
+    // This IS the assertion the drift gate performs — if this fails, the gate
+    // correctly catches the drift.
+    expect(ssotValue).not.toBe(snapshotValue);
+  });
+
+  it("drift gate logic: passes when SSOT and snapshot agree", () => {
+    // Simulate: SSOT says numReplicas=3, snapshot says 3 → PASS.
+    const ssotValue = 3;
+    const snapshotValue = 3;
+    expect(ssotValue).toBe(snapshotValue);
+  });
+
+  it("transient injected SSOT entry: workerProvisioningFor returns correct values", () => {
+    // Inject a synthetic harness-workers-like entry and confirm the accessor
+    // returns the correct fields. Remove the injection in the finally block.
+    const sentinel = "__test-workers-sentinel__";
+    const mockProv = {
+      prod: { numReplicas: 5, BROWSER_POOL_MAX_CONTEXTS: 20 },
+      staging: { numReplicas: 10, BROWSER_POOL_MAX_CONTEXTS: 20 },
+    };
+    (
+      SERVICES as Record<
+        string,
+        { serviceId: string; environments: Record<string, unknown>; probeDriver: string; ciBuilt: boolean; gateValidated: boolean; workerProvisioning?: { prod: WorkerProvisioning; staging: WorkerProvisioning } }
+      >
+    )[sentinel] = {
+      serviceId: "00000000-0000-0000-0000-000000000099",
+      ciBuilt: false,
+      gateValidated: false,
+      probeDriver: "harness",
+      environments: {
+        prod: { instanceId: "11111111-1111-1111-1111-111111111111", probe: false },
+        staging: { instanceId: "22222222-2222-2222-2222-222222222222", probe: false },
+      },
+      workerProvisioning: mockProv,
+    };
+    try {
+      const prodProv = workerProvisioningFor(sentinel, "prod");
+      const stagingProv = workerProvisioningFor(sentinel, "staging");
+      expect(prodProv?.numReplicas).toBe(5);
+      expect(stagingProv?.numReplicas).toBe(10);
+      expect(prodProv?.BROWSER_POOL_MAX_CONTEXTS).toBe(20);
+    } finally {
+      delete (SERVICES as Record<string, unknown>)[sentinel];
+    }
+  });
+});

--- a/showcase/scripts/__tests__/harness-workers-provisioning.test.ts
+++ b/showcase/scripts/__tests__/harness-workers-provisioning.test.ts
@@ -1,21 +1,29 @@
 /**
  * harness-workers-provisioning.test.ts — CI drift gate for harness-workers
- * worker-fleet provisioning fields (`numReplicas`, `BROWSER_POOL_MAX_CONTEXTS`).
+ * worker-fleet provisioning fields (`effectiveReplicas`,
+ * `BROWSER_POOL_MAX_CONTEXTS`).
  *
  * Style note: mirrors `verify-railway-image-refs.test.ts` — pure validators
  * against synthesized or committed-snapshot inputs, NO live Railway API calls.
  *
- * The drift gate works by comparing SSOT `numReplicas` (declared in
- * `railway-envs.ts`) against the value committed to
- * `railway-envs.generated.json` (a static snapshot, NOT a live Railway API
- * response). When the SSOT and the snapshot agree, the gate passes. When they
- * diverge (someone edited the SSOT but forgot to re-run emit-railway-envs-json,
- * or forgot to update the SSOT to match reality), the gate fails.
+ * The drift gate works by comparing the SSOT EFFECTIVE replica count
+ * (`effectiveReplicas`, declared in `railway-envs.ts`) against the value
+ * committed to `railway-envs.generated.json` (a static snapshot, NOT a live
+ * Railway API response). When the SSOT and the snapshot agree, the gate passes.
+ * When they diverge (someone edited the SSOT but forgot to re-run
+ * emit-railway-envs-json, or forgot to update the SSOT to match reality), the
+ * gate fails.
+ *
+ * EFFECTIVE REPLICA COUNT: the gate watches `effectiveReplicas`, which models
+ * `multiRegionConfig.us-west2.numReplicas` — the field Railway actually honors
+ * to derive the live replica count for this single-region service. The
+ * top-level `numReplicas` is a documented mirror only; watching it would gate
+ * a field that does not drive reality.
  *
  * WORKER MODEL CONFIRMED: 1-worker-per-replica (NOT replicas × pool count).
  * `HARNESS_POOL_COUNT` is INFORMATIONAL ONLY — not a fork factor. The
- * authoritative worker count is `numReplicas`. The authoritative per-worker
- * concurrency is `BROWSER_POOL_MAX_CONTEXTS`.
+ * authoritative worker count is `effectiveReplicas`. The authoritative
+ * per-worker concurrency is `BROWSER_POOL_MAX_CONTEXTS`.
  */
 
 import { readFileSync } from "node:fs";
@@ -51,17 +59,28 @@ describe("harness-workers provisioning SSOT", () => {
     expect(stagingProv).not.toBeUndefined();
   });
 
-  it("prod numReplicas = 3 (current live reality, 2026-06-26)", () => {
+  it("prod effectiveReplicas = 6 (parity achieved — B-reconcile scaled prod 3 → 6, 2026-06-26)", () => {
+    // multiRegionConfig.us-west2.numReplicas is the field Railway honors.
+    // Verified live: deploy.multiRegionConfig = {"us-west2":{"numReplicas":6}}.
     const prov = workerProvisioningFor("harness-workers", "prod");
-    expect(prov?.numReplicas).toBe(3);
+    expect(prov?.effectiveReplicas).toBe(6);
   });
 
-  it("staging numReplicas = 6 (live reality — config-field read 2, but 6 instances live)", () => {
-    // STAGING CONFIG DRIFT: Railway staging replicas config field was 2 at
-    // audit time, but 6 instances were observed LIVE. This test asserts 6
-    // (live reality). Follow-up: align Railway staging config field to 6.
+  it("staging effectiveReplicas = 6 (multiRegionConfig.us-west2.numReplicas, verified live)", () => {
+    // Verified live: deploy.multiRegionConfig = {"us-west2":{"numReplicas":6}}.
     const prov = workerProvisioningFor("harness-workers", "staging");
-    expect(prov?.numReplicas).toBe(6);
+    expect(prov?.effectiveReplicas).toBe(6);
+  });
+
+  it("top-level numReplicas mirrors effectiveReplicas in both envs (6 / 6)", () => {
+    // Single-region service: the top-level numReplicas is a documented mirror of
+    // the effective per-region count, not an authoritative knob.
+    const prodProv = workerProvisioningFor("harness-workers", "prod");
+    const stagingProv = workerProvisioningFor("harness-workers", "staging");
+    expect(prodProv?.numReplicas).toBe(6);
+    expect(stagingProv?.numReplicas).toBe(6);
+    expect(prodProv?.numReplicas).toBe(prodProv?.effectiveReplicas);
+    expect(stagingProv?.numReplicas).toBe(stagingProv?.effectiveReplicas);
   });
 
   it("BROWSER_POOL_MAX_CONTEXTS = 40 for both envs (per-worker concurrency, not a fleet total)", () => {
@@ -108,7 +127,7 @@ describe("harness-workers provisioning drift gate (SSOT vs generated JSON snapsh
    * test (flaky, requires auth, slow). The snapshot is updated by running:
    *   npx tsx showcase/scripts/emit-railway-envs-json.ts
    */
-  it("SSOT prod numReplicas matches committed generated JSON snapshot", () => {
+  it("SSOT prod effectiveReplicas matches committed generated JSON snapshot", () => {
     const snapshot = loadGeneratedSnapshot();
     const snapshotEntry = snapshot.services.find(
       (s) => s.name === "harness-workers",
@@ -125,16 +144,16 @@ describe("harness-workers provisioning drift gate (SSOT vs generated JSON snapsh
     ).not.toBeUndefined();
 
     const snapshotProdReplicas =
-      snapshotEntry?.workerProvisioning?.prod?.numReplicas;
+      snapshotEntry?.workerProvisioning?.prod?.effectiveReplicas;
     expect(
       snapshotProdReplicas,
-      "workerProvisioning.prod.numReplicas missing from generated JSON snapshot",
+      "workerProvisioning.prod.effectiveReplicas missing from generated JSON snapshot",
     ).not.toBeUndefined();
 
-    expect(ssotProd?.numReplicas).toBe(snapshotProdReplicas);
+    expect(ssotProd?.effectiveReplicas).toBe(snapshotProdReplicas);
   });
 
-  it("SSOT staging numReplicas matches committed generated JSON snapshot", () => {
+  it("SSOT staging effectiveReplicas matches committed generated JSON snapshot", () => {
     const snapshot = loadGeneratedSnapshot();
     const snapshotEntry = snapshot.services.find(
       (s) => s.name === "harness-workers",
@@ -151,13 +170,13 @@ describe("harness-workers provisioning drift gate (SSOT vs generated JSON snapsh
     ).not.toBeUndefined();
 
     const snapshotStagingReplicas =
-      snapshotEntry?.workerProvisioning?.staging?.numReplicas;
+      snapshotEntry?.workerProvisioning?.staging?.effectiveReplicas;
     expect(
       snapshotStagingReplicas,
-      "workerProvisioning.staging.numReplicas missing from generated JSON snapshot",
+      "workerProvisioning.staging.effectiveReplicas missing from generated JSON snapshot",
     ).not.toBeUndefined();
 
-    expect(ssotStaging?.numReplicas).toBe(snapshotStagingReplicas);
+    expect(ssotStaging?.effectiveReplicas).toBe(snapshotStagingReplicas);
   });
 
   it("SSOT prod BROWSER_POOL_MAX_CONTEXTS matches committed generated JSON snapshot", () => {
@@ -195,8 +214,16 @@ describe("harness-workers provisioning with injected test data", () => {
     // returns the correct fields. Remove the injection in the finally block.
     const sentinel = "__test-workers-sentinel__";
     const mockProv = {
-      prod: { numReplicas: 5, BROWSER_POOL_MAX_CONTEXTS: 20 },
-      staging: { numReplicas: 10, BROWSER_POOL_MAX_CONTEXTS: 20 },
+      prod: {
+        effectiveReplicas: 5,
+        numReplicas: 5,
+        BROWSER_POOL_MAX_CONTEXTS: 20,
+      },
+      staging: {
+        effectiveReplicas: 10,
+        numReplicas: 10,
+        BROWSER_POOL_MAX_CONTEXTS: 20,
+      },
     };
     (
       SERVICES as Record<
@@ -233,8 +260,9 @@ describe("harness-workers provisioning with injected test data", () => {
     try {
       const prodProv = workerProvisioningFor(sentinel, "prod");
       const stagingProv = workerProvisioningFor(sentinel, "staging");
+      expect(prodProv?.effectiveReplicas).toBe(5);
+      expect(stagingProv?.effectiveReplicas).toBe(10);
       expect(prodProv?.numReplicas).toBe(5);
-      expect(stagingProv?.numReplicas).toBe(10);
       expect(prodProv?.BROWSER_POOL_MAX_CONTEXTS).toBe(20);
     } finally {
       delete (SERVICES as Record<string, unknown>)[sentinel];

--- a/showcase/scripts/emit-railway-envs-json.ts
+++ b/showcase/scripts/emit-railway-envs-json.ts
@@ -49,7 +49,7 @@ import {
   STAGING_ENV_ID,
   computePromoteClosure,
 } from "./railway-envs";
-import type { ClosurePlan } from "./railway-envs";
+import type { ClosurePlan, WorkerProvisioning } from "./railway-envs";
 
 const DEFAULT_OUTPUT_PATH = resolve(
   new URL(".", import.meta.url).pathname,
@@ -95,6 +95,12 @@ interface Emitted {
     // sending `null`). The whole `healthcheckPath` object is omitted when
     // NEITHER env declares one, so live-null services keep the frozen shape.
     healthcheckPath?: { prod?: string; staging?: string };
+    // Worker-fleet provisioning record (ADDITIVE, SSOT). Only present for
+    // `harness-workers`; omitted for all other services. The drift-gate test
+    // (`harness-workers-provisioning.test.ts`) asserts that the SSOT
+    // numReplicas values match this committed snapshot — the authoritative
+    // worker-count source.
+    workerProvisioning?: { prod: WorkerProvisioning; staging: WorkerProvisioning };
   }>;
   // --- Top-level promote-closure plan (ADDITIVE, U2). The tier-ordered
   // closure for the FULL fleet (`all`), computed via `computePromoteClosure`.
@@ -205,6 +211,14 @@ function projectServiceToLegacyJson(
     // golden test projects only LEGACY_KEYS so this stays byte-safe; omitted
     // entirely for live-null services so their frozen shape is preserved.
     ...(healthcheckPath !== undefined ? { healthcheckPath } : {}),
+    // Worker-fleet provisioning (ADDITIVE). Only emitted for `harness-workers`;
+    // omitted for all other services so the frozen per-service shape is
+    // preserved. The drift-gate test (`harness-workers-provisioning.test.ts`)
+    // asserts SSOT numReplicas matches this committed snapshot — compare SSOT
+    // vs. snapshot, never vs. a live Railway API call.
+    ...(entry.workerProvisioning !== undefined
+      ? { workerProvisioning: entry.workerProvisioning }
+      : {}),
   };
 }
 

--- a/showcase/scripts/emit-railway-envs-json.ts
+++ b/showcase/scripts/emit-railway-envs-json.ts
@@ -98,9 +98,13 @@ interface Emitted {
     // Worker-fleet provisioning record (ADDITIVE, SSOT). Only present for
     // `harness-workers`; omitted for all other services. The drift-gate test
     // (`harness-workers-provisioning.test.ts`) asserts that the SSOT
-    // numReplicas values match this committed snapshot — the authoritative
-    // worker-count source.
-    workerProvisioning?: { prod: WorkerProvisioning; staging: WorkerProvisioning };
+    // `effectiveReplicas` values (multiRegionConfig.us-west2.numReplicas — the
+    // field Railway honors) match this committed snapshot — the authoritative
+    // worker-count source. The top-level `numReplicas` mirror rides along.
+    workerProvisioning?: {
+      prod: WorkerProvisioning;
+      staging: WorkerProvisioning;
+    };
   }>;
   // --- Top-level promote-closure plan (ADDITIVE, U2). The tier-ordered
   // closure for the FULL fleet (`all`), computed via `computePromoteClosure`.
@@ -214,8 +218,8 @@ function projectServiceToLegacyJson(
     // Worker-fleet provisioning (ADDITIVE). Only emitted for `harness-workers`;
     // omitted for all other services so the frozen per-service shape is
     // preserved. The drift-gate test (`harness-workers-provisioning.test.ts`)
-    // asserts SSOT numReplicas matches this committed snapshot — compare SSOT
-    // vs. snapshot, never vs. a live Railway API call.
+    // asserts SSOT effectiveReplicas matches this committed snapshot — compare
+    // SSOT vs. snapshot, never vs. a live Railway API call.
     ...(entry.workerProvisioning !== undefined
       ? { workerProvisioning: entry.workerProvisioning }
       : {}),

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -154,6 +154,18 @@
       "healthcheckPath": {
         "prod": "/health",
         "staging": "/health"
+      },
+      "workerProvisioning": {
+        "prod": {
+          "numReplicas": 3,
+          "BROWSER_POOL_MAX_CONTEXTS": 40,
+          "HARNESS_POOL_COUNT": 3
+        },
+        "staging": {
+          "numReplicas": 6,
+          "BROWSER_POOL_MAX_CONTEXTS": 40,
+          "HARNESS_POOL_COUNT": 6
+        }
       }
     },
     {

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -157,14 +157,16 @@
       },
       "workerProvisioning": {
         "prod": {
-          "numReplicas": 3,
+          "effectiveReplicas": 6,
+          "numReplicas": 6,
           "BROWSER_POOL_MAX_CONTEXTS": 40,
           "HARNESS_POOL_COUNT": 3
         },
         "staging": {
+          "effectiveReplicas": 6,
           "numReplicas": 6,
           "BROWSER_POOL_MAX_CONTEXTS": 40,
-          "HARNESS_POOL_COUNT": 6
+          "HARNESS_POOL_COUNT": 2
         }
       }
     },

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -144,30 +144,59 @@ export type ProbeDriver =
  *
  * The worker model is strictly 1-worker-per-replica: Railway runs ONE worker
  * process per replica container (keyed on HOSTNAME), so the REAL live worker
- * count equals `numReplicas`. `HARNESS_POOL_COUNT` is the control-plane's
- * informational "expected worker count" hint — it does NOT fork additional
- * workers per replica and MUST NOT be treated as a multiplier or fork factor.
- * The authoritative concurrency knob per worker is `BROWSER_POOL_MAX_CONTEXTS`.
+ * count equals the EFFECTIVE replica count. `HARNESS_POOL_COUNT` is the
+ * control-plane's informational "expected worker count" hint — it does NOT fork
+ * additional workers per replica and MUST NOT be treated as a multiplier or fork
+ * factor. The authoritative concurrency knob per worker is
+ * `BROWSER_POOL_MAX_CONTEXTS`.
+ *
+ * EFFECTIVE REPLICA COUNT — `multiRegionConfig.<region>.numReplicas`, NOT the
+ * top-level `numReplicas`. The harness-workers service is single-region
+ * (us-west2), and Railway derives the LIVE running replica count from the
+ * per-region `multiRegionConfig.us-west2.numReplicas` field. The top-level
+ * `numReplicas` is the legacy/aggregate knob; on a multiRegion service it is
+ * Railway-maintained to mirror the region sum but it is NOT the field the
+ * deploy honors. The SSOT therefore models `multiRegionConfig.us-west2.
+ * numReplicas` as the authoritative `effectiveReplicas` and keeps the
+ * top-level `numReplicas` only as a documented mirror. Verified live
+ * 2026-06-26 via the Railway GraphQL `environment.config` staged-config read:
+ * BOTH envs carry `deploy.multiRegionConfig = {"us-west2":{"numReplicas":6}}`.
  *
  * This is a DECLARE-AND-VERIFY record. The tooling (`emit-railway-envs-json.ts`,
- * `bin/railway`) is VERIFY-ONLY with respect to numReplicas — it does not write
- * replica counts to Railway. Applying a replica-count change is a MANUAL
- * operation (Railway Dashboard > Service > Settings > Replicas, or the Railway
- * GraphQL API). See `showcase/RAILWAY.md` for the manual procedure.
+ * `bin/railway`) is VERIFY-ONLY with respect to the replica count — it does not
+ * write replica counts to Railway. Applying a replica-count change is a MANUAL
+ * operation (Railway Dashboard > Service > Settings > Replicas, which edits the
+ * per-region `multiRegionConfig.us-west2.numReplicas`, or the Railway GraphQL
+ * API). See `showcase/RAILWAY.md` for the manual procedure.
  */
 export interface WorkerProvisioning {
   /**
-   * Number of Railway replicas for the `harness-workers` service in this env.
-   * Strictly 1:1 with live worker processes — each replica runs exactly ONE
-   * worker process (keyed on HOSTNAME). This is the authoritative worker-count
-   * field; `HARNESS_POOL_COUNT` is informational only.
+   * EFFECTIVE replica count — the AUTHORITATIVE worker-count field. This is the
+   * `multiRegionConfig.us-west2.numReplicas` value Railway actually uses to
+   * derive the LIVE running replica count for this single-region (us-west2)
+   * service. The drift gate watches THIS field because it is the one that
+   * drives reality; the top-level `numReplicas` mirror below does NOT (Railway
+   * keeps it in sync as an aggregate, but the deploy honors the per-region
+   * config). Strictly 1:1 with live worker processes — each replica runs
+   * exactly ONE worker process (keyed on HOSTNAME). `HARNESS_POOL_COUNT` is
+   * informational only.
+   */
+  effectiveReplicas: number;
+  /**
+   * Top-level Railway `numReplicas` field for this env. Retained as a
+   * DOCUMENTED MIRROR of `effectiveReplicas` (Railway keeps it equal to the
+   * region sum on a multiRegion service), NOT as an authoritative knob — the
+   * deploy honors `multiRegionConfig.<region>.numReplicas` (`effectiveReplicas`).
+   * Kept here so the SSOT records both and makes the effective-vs-mirror
+   * distinction explicit. For harness-workers (single region) it always equals
+   * `effectiveReplicas`.
    */
   numReplicas: number;
   /**
    * Per-worker in-process concurrency budget: the `BROWSER_POOL_MAX_CONTEXTS`
    * env var that caps how many Playwright browser contexts each worker may hold
    * open simultaneously. NOT a per-fleet total; the fleet-wide budget is
-   * `numReplicas × BROWSER_POOL_MAX_CONTEXTS`.
+   * `effectiveReplicas × BROWSER_POOL_MAX_CONTEXTS`.
    */
   BROWSER_POOL_MAX_CONTEXTS: number;
   /**
@@ -393,25 +422,27 @@ export interface ServiceEntry {
    * Harness-worker fleet provisioning record. ONLY populated on the
    * `harness-workers` entry — all other services omit this field.
    *
-   * These values match CURRENT LIVE REALITY as of 2026-06-26:
-   *   prod:    numReplicas=3, BROWSER_POOL_MAX_CONTEXTS=40
-   *   staging: numReplicas=6, BROWSER_POOL_MAX_CONTEXTS=40
+   * These values match CURRENT LIVE REALITY as of 2026-06-26, VERIFIED via the
+   * Railway GraphQL `environment.config` staged-config read (both envs carry
+   * `deploy.multiRegionConfig = {"us-west2":{"numReplicas":6}}`):
+   *   prod:    effectiveReplicas=6, numReplicas(mirror)=6, BROWSER_POOL_MAX_CONTEXTS=40
+   *   staging: effectiveReplicas=6, numReplicas(mirror)=6, BROWSER_POOL_MAX_CONTEXTS=40
    *
-   * NOTE — PROD/STAGING PARITY: prod currently runs 3 replicas, staging 6.
-   * Bringing prod to 6 (parity with staging) is a deliberate one-field
-   * change (numReplicas: 3 → 6 on the prod entry). That change is
-   * INTENTIONALLY NOT made here — this commit records current live reality
-   * only and defers the parity decision to a follow-up.
+   * EFFECTIVE FIELD: `effectiveReplicas` models `multiRegionConfig.us-west2.
+   * numReplicas` — the field Railway actually honors for this single-region
+   * service. The top-level `numReplicas` is a documented mirror only. The drift
+   * gate asserts `effectiveReplicas`.
    *
-   * NOTE — STAGING CONFIG-FIELD-VS-LIVE DRIFT: The Railway config field for
-   * staging numReplicas was observed as 2 at the time of this audit, but
-   * the LIVE running instance count is 6. The declared value here (6) reflects
-   * LIVE REALITY, not the stale config field. This drift (config=2, live=6)
-   * should be reconciled by updating the Railway staging config field to 6.
-   * Follow-up item: align Railway staging replicas config to 6.
+   * PROD/STAGING PARITY ACHIEVED: B-reconcile scaled prod harness-workers to 6
+   * replicas (both the top-level field AND `multiRegionConfig.us-west2.
+   * numReplicas`) to match staging (6). Prod and staging are now at parity
+   * (6/6). The earlier prod=3 state and the staging config-field-vs-live drift
+   * (config=2 / live=6) are both RESOLVED: the live staged config now reads 6
+   * in both envs, verified above.
    *
    * See the `WorkerProvisioning` interface (above) for the 1-worker-per-replica
-   * model and HARNESS_POOL_COUNT informational semantics.
+   * model, the effective-vs-mirror replica distinction, and HARNESS_POOL_COUNT
+   * informational semantics.
    */
   workerProvisioning?: {
     prod: WorkerProvisioning;
@@ -649,36 +680,41 @@ export const SERVICES: Record<
         staging: "harness-staging-2ee4.up.railway.app",
       },
     },
-    // Worker-fleet provisioning (SSOT). Values = CURRENT LIVE REALITY (2026-06-26).
-    // 1-worker-per-replica model: numReplicas IS the worker count (strictly 1:1).
-    // HARNESS_POOL_COUNT is INFORMATIONAL ONLY — it does NOT fork workers.
-    // The authoritative per-worker concurrency knob is BROWSER_POOL_MAX_CONTEXTS.
+    // Worker-fleet provisioning (SSOT). Values = CURRENT LIVE REALITY (2026-06-26),
+    // verified via the Railway GraphQL environment.config staged-config read.
+    // 1-worker-per-replica model: the EFFECTIVE replica count IS the worker count
+    // (strictly 1:1). The authoritative field is `effectiveReplicas` =
+    // multiRegionConfig.us-west2.numReplicas — the value Railway honors. The
+    // top-level `numReplicas` is a documented mirror only (always equal here,
+    // single-region). HARNESS_POOL_COUNT is INFORMATIONAL ONLY — it does NOT
+    // fork workers. Per-worker concurrency knob is BROWSER_POOL_MAX_CONTEXTS.
     //
-    // prod:    3 replicas → 3 live workers. Staging runs 6 (see note below).
-    // staging: 6 replicas → 6 live workers. The Railway staging config FIELD
-    //          read 2 at audit time, but 6 instances were LIVE. The declared
-    //          value here (6) reflects live reality. Follow-up: align the
-    //          Railway staging replicas config field from 2 → 6.
-    //
-    // PARITY DECISION DEFERRED: bringing prod to 6 replicas (to match staging)
-    // is a deliberate one-field change (numReplicas: 3 → 6 on the prod entry).
-    // That change is INTENTIONALLY NOT made in this commit — this commit records
-    // current live reality only. The parity change is a follow-up operational item.
+    // PARITY ACHIEVED (B-reconcile): prod was scaled 3 → 6 to match staging, in
+    // BOTH the top-level numReplicas and multiRegionConfig.us-west2.numReplicas.
+    // Live staged config now reads {"us-west2":{"numReplicas":6}} in both envs.
+    //   prod:    effectiveReplicas=6 → 6 live workers.
+    //   staging: effectiveReplicas=6 → 6 live workers.
+    // The earlier staging config-field-vs-live drift (config=2 / live=6) is also
+    // resolved: the staged config field now reads 6.
     workerProvisioning: {
       prod: {
-        numReplicas: 3,
+        // EFFECTIVE = multiRegionConfig.us-west2.numReplicas (Railway honors this).
+        effectiveReplicas: 6,
+        // Top-level mirror (equal, single-region).
+        numReplicas: 6,
         BROWSER_POOL_MAX_CONTEXTS: 40,
         // INFORMATIONAL ONLY — not a fork factor.
         HARNESS_POOL_COUNT: 3,
       },
       staging: {
-        // STAGING CONFIG DRIFT: Railway staging replicas config field = 2,
-        // but 6 instances are LIVE. numReplicas here = 6 (live reality).
-        // Follow-up item: update Railway staging config field to 6.
+        // EFFECTIVE = multiRegionConfig.us-west2.numReplicas (Railway honors this).
+        effectiveReplicas: 6,
+        // Top-level mirror (equal, single-region).
         numReplicas: 6,
         BROWSER_POOL_MAX_CONTEXTS: 40,
-        // INFORMATIONAL ONLY — not a fork factor.
-        HARNESS_POOL_COUNT: 6,
+        // INFORMATIONAL ONLY — not a fork factor. Live staging value is 2
+        // (verified via the variables read); it does not gate the worker count.
+        HARNESS_POOL_COUNT: 2,
       },
     },
   },

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -139,6 +139,49 @@ export type ProbeDriver =
   | "starter";
 
 /**
+ * Provisioning configuration for the `harness-workers` pool fleet. Carried on
+ * `ServiceEntry.workerProvisioning` and ONLY populated for `harness-workers`.
+ *
+ * The worker model is strictly 1-worker-per-replica: Railway runs ONE worker
+ * process per replica container (keyed on HOSTNAME), so the REAL live worker
+ * count equals `numReplicas`. `HARNESS_POOL_COUNT` is the control-plane's
+ * informational "expected worker count" hint — it does NOT fork additional
+ * workers per replica and MUST NOT be treated as a multiplier or fork factor.
+ * The authoritative concurrency knob per worker is `BROWSER_POOL_MAX_CONTEXTS`.
+ *
+ * This is a DECLARE-AND-VERIFY record. The tooling (`emit-railway-envs-json.ts`,
+ * `bin/railway`) is VERIFY-ONLY with respect to numReplicas — it does not write
+ * replica counts to Railway. Applying a replica-count change is a MANUAL
+ * operation (Railway Dashboard > Service > Settings > Replicas, or the Railway
+ * GraphQL API). See `showcase/RAILWAY.md` for the manual procedure.
+ */
+export interface WorkerProvisioning {
+  /**
+   * Number of Railway replicas for the `harness-workers` service in this env.
+   * Strictly 1:1 with live worker processes — each replica runs exactly ONE
+   * worker process (keyed on HOSTNAME). This is the authoritative worker-count
+   * field; `HARNESS_POOL_COUNT` is informational only.
+   */
+  numReplicas: number;
+  /**
+   * Per-worker in-process concurrency budget: the `BROWSER_POOL_MAX_CONTEXTS`
+   * env var that caps how many Playwright browser contexts each worker may hold
+   * open simultaneously. NOT a per-fleet total; the fleet-wide budget is
+   * `numReplicas × BROWSER_POOL_MAX_CONTEXTS`.
+   */
+  BROWSER_POOL_MAX_CONTEXTS: number;
+  /**
+   * INFORMATIONAL ONLY — the `HARNESS_POOL_COUNT` env var forwarded to each
+   * worker as a control-plane "expected worker count" hint. The worker code
+   * does NOT fork additional processes per pool count; it runs exactly one
+   * process per replica. The authoritative concurrency knob is
+   * `BROWSER_POOL_MAX_CONTEXTS`. This field is recorded here purely for
+   * operational visibility / config-audit purposes.
+   */
+  HARNESS_POOL_COUNT?: number;
+}
+
+/**
  * Per-env configuration for a service. One of these lives under each key of
  * `ServiceEntry.environments`. A service that exists in only one env has a
  * single key here (no placeholder for the missing env).
@@ -345,6 +388,34 @@ export interface ServiceEntry {
      * `repoNameOverride` object stays byte-identical.
      */
     repoNameOverride?: { prod?: string; staging?: string };
+  };
+  /**
+   * Harness-worker fleet provisioning record. ONLY populated on the
+   * `harness-workers` entry — all other services omit this field.
+   *
+   * These values match CURRENT LIVE REALITY as of 2026-06-26:
+   *   prod:    numReplicas=3, BROWSER_POOL_MAX_CONTEXTS=40
+   *   staging: numReplicas=6, BROWSER_POOL_MAX_CONTEXTS=40
+   *
+   * NOTE — PROD/STAGING PARITY: prod currently runs 3 replicas, staging 6.
+   * Bringing prod to 6 (parity with staging) is a deliberate one-field
+   * change (numReplicas: 3 → 6 on the prod entry). That change is
+   * INTENTIONALLY NOT made here — this commit records current live reality
+   * only and defers the parity decision to a follow-up.
+   *
+   * NOTE — STAGING CONFIG-FIELD-VS-LIVE DRIFT: The Railway config field for
+   * staging numReplicas was observed as 2 at the time of this audit, but
+   * the LIVE running instance count is 6. The declared value here (6) reflects
+   * LIVE REALITY, not the stale config field. This drift (config=2, live=6)
+   * should be reconciled by updating the Railway staging config field to 6.
+   * Follow-up item: align Railway staging replicas config to 6.
+   *
+   * See the `WorkerProvisioning` interface (above) for the 1-worker-per-replica
+   * model and HARNESS_POOL_COUNT informational semantics.
+   */
+  workerProvisioning?: {
+    prod: WorkerProvisioning;
+    staging: WorkerProvisioning;
   };
 }
 
@@ -576,6 +647,38 @@ export const SERVICES: Record<
       domains: {
         prod: "showcase-harness-production.up.railway.app",
         staging: "harness-staging-2ee4.up.railway.app",
+      },
+    },
+    // Worker-fleet provisioning (SSOT). Values = CURRENT LIVE REALITY (2026-06-26).
+    // 1-worker-per-replica model: numReplicas IS the worker count (strictly 1:1).
+    // HARNESS_POOL_COUNT is INFORMATIONAL ONLY — it does NOT fork workers.
+    // The authoritative per-worker concurrency knob is BROWSER_POOL_MAX_CONTEXTS.
+    //
+    // prod:    3 replicas → 3 live workers. Staging runs 6 (see note below).
+    // staging: 6 replicas → 6 live workers. The Railway staging config FIELD
+    //          read 2 at audit time, but 6 instances were LIVE. The declared
+    //          value here (6) reflects live reality. Follow-up: align the
+    //          Railway staging replicas config field from 2 → 6.
+    //
+    // PARITY DECISION DEFERRED: bringing prod to 6 replicas (to match staging)
+    // is a deliberate one-field change (numReplicas: 3 → 6 on the prod entry).
+    // That change is INTENTIONALLY NOT made in this commit — this commit records
+    // current live reality only. The parity change is a follow-up operational item.
+    workerProvisioning: {
+      prod: {
+        numReplicas: 3,
+        BROWSER_POOL_MAX_CONTEXTS: 40,
+        // INFORMATIONAL ONLY — not a fork factor.
+        HARNESS_POOL_COUNT: 3,
+      },
+      staging: {
+        // STAGING CONFIG DRIFT: Railway staging replicas config field = 2,
+        // but 6 instances are LIVE. numReplicas here = 6 (live reality).
+        // Follow-up item: update Railway staging config field to 6.
+        numReplicas: 6,
+        BROWSER_POOL_MAX_CONTEXTS: 40,
+        // INFORMATIONAL ONLY — not a fork factor.
+        HARNESS_POOL_COUNT: 6,
       },
     },
   },
@@ -1778,6 +1881,26 @@ export function healthcheckPathFor(
  */
 export function isTrackedService(serviceName: string): boolean {
   return findEntry(serviceName) !== undefined;
+}
+
+/**
+ * Resolve the `WorkerProvisioning` record for a (serviceName, env) pair, or
+ * `undefined` when the service declares no `workerProvisioning` or has no
+ * entry for the given env. Returns undefined (rather than throwing) on unknown
+ * service, missing field, or undeclared env — the caller decides whether absence
+ * is an error (the drift-gate test requires it to be non-null for
+ * `harness-workers`).
+ *
+ * Only `harness-workers` carries this field today. Use it to read the
+ * authoritative `numReplicas` and `BROWSER_POOL_MAX_CONTEXTS` for a given env.
+ */
+export function workerProvisioningFor(
+  serviceName: string,
+  env: "prod" | "staging",
+): WorkerProvisioning | undefined {
+  const entry = findEntry(serviceName);
+  if (entry === undefined) return undefined;
+  return entry.workerProvisioning?.[env];
 }
 
 /**

--- a/showcase/shell-dashboard/src/components/__tests__/depth-chip.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-chip.test.tsx
@@ -302,6 +302,54 @@ describe("DepthChip", () => {
     expect(chip.textContent).toContain("⟳");
   });
 
+  // A11Y: an EXPLICIT gray chipColor means "no live probe data", so a grey
+  // depth>0 chip is NOT genuinely prior-good — it must fall through to the
+  // honest grey ⟳ chip (data-has-prior="false"), not claim a prior result.
+  it("pending with gray chipColor + depth>0 is NOT prior-good (honest grey ⟳)", () => {
+    const { getByTestId } = render(
+      <DepthChip depth={3} status="wired" chipColor="gray" pending />,
+    );
+    const chip = getByTestId("depth-chip");
+    expect(chip.getAttribute("data-has-prior")).toBe("false");
+    expect(chip.getAttribute("data-refreshing")).toBe("true");
+    expect(chip.className).toContain("text-muted");
+    expect(chip.className).not.toContain("emerald");
+    expect(chip.textContent).toContain("⟳");
+  });
+
+  // A11Y: the refreshing aria-label says "regression" ONLY for an actually-
+  // flagged regression — a danger-COLOURED-but-not-flagged pending cell (deep
+  // below ceiling) suppresses the spinner the same way but must not be
+  // announced as a regression.
+  it("pending danger-coloured (not flagged) chip does NOT say 'regression' in its label", () => {
+    const { getByTestId } = render(
+      // depth 1, maxDepth 6 → danger colour via depthColorClass, but
+      // regression flag is NOT set.
+      <DepthChip depth={1} status="wired" maxDepth={6} pending />,
+    );
+    const chip = getByTestId("depth-chip");
+    // Failure colour ⇒ no spinner (colour passthrough), but the label must be
+    // the neutral depth form, never "regression".
+    expect(chip.className).toContain("danger");
+    expect(chip.getAttribute("aria-label")).toBe("Depth 1");
+    expect(chip.getAttribute("aria-label")).not.toContain("regression");
+    expect(chip.getAttribute("data-refreshing")).not.toBe("true");
+  });
+
+  it("pending FLAGGED regression still announces 'regression' in its label", () => {
+    const { getByTestId } = render(
+      <DepthChip
+        depth={5}
+        status="wired"
+        chipColor="green"
+        regression
+        pending
+      />,
+    );
+    const chip = getByTestId("depth-chip");
+    expect(chip.getAttribute("aria-label")).toBe("Depth 5 — regression");
+  });
+
   // A pending re-run must NEVER read as a failure — no red, no indigo overlay,
   // regardless of whether there is a prior-good result.
   it("pending never reads as a failure (no danger, no indigo overlay)", () => {

--- a/showcase/shell-dashboard/src/components/__tests__/depth-chip.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-chip.test.tsx
@@ -250,12 +250,15 @@ describe("DepthChip", () => {
     expect(chip.className).toContain("emerald");
   });
 
-  // ── flap-band #70: pending (reclaimed) treatment ────────────────────
+  // ── flap-band #70 / stale-while-revalidate: pending (reclaimed) ──────
 
-  it("renders a NEUTRAL pending treatment when pending=true (not red, not the indigo unreachable overlay)", () => {
+  // STALE-WHILE-REVALIDATE: a pending re-run over a prior known-good GREEN cell
+  // must KEEP its green colour and add a non-destructive refreshing affordance —
+  // NOT flip to grey. This is the core green→grey→green flap fix.
+  it("pending over a prior-good GREEN cell keeps GREEN + adds a refreshing affordance (no grey flap)", () => {
     const { getByTestId } = render(
       <DepthChip
-        depth={5}
+        depth={6}
         status="wired"
         chipColor="green"
         pending
@@ -263,14 +266,51 @@ describe("DepthChip", () => {
       />,
     );
     const chip = getByTestId("depth-chip");
+    // Surface state hooks preserved for the matrix / e2e DOM inspection.
     expect(chip.getAttribute("data-status")).toBe("pending");
     expect(chip.getAttribute("data-surface-state")).toBe("pending");
     expect(chip.getAttribute("title")).toContain("worker-reclaimed-pending");
-    // NEUTRAL — never the red danger class, never the indigo "unreachable"
-    // overlay. A routine teardown must not read as a failure.
+    // Colour PRESERVED — the green coverage chip is NOT replaced by grey.
+    expect(chip.className).toContain("emerald");
     expect(chip.className).not.toContain("danger");
     expect(chip.className).not.toContain("indigo");
+    // Must NOT use the destructive grey "no-data" fill.
+    expect(chip.className).not.toContain("bg-[var(--text-muted)]/20");
+    // Non-destructive refreshing affordance: a ⟳ glyph (shape, not colour) and
+    // an explicit data hook for tests / e2e.
+    expect(chip.getAttribute("data-refreshing")).toBe("true");
+    expect(chip.getAttribute("data-has-prior")).toBe("true");
+    expect(chip.textContent).toContain("⟳");
+    // The depth label still reads (stale-but-valid), so D6 is still legible.
+    expect(chip.textContent).toContain("D6");
+  });
+
+  // CONTRACT PIN (never-run / first load): no prior known-good result
+  // (chipColor gray + depth 0) → keep today's honest grey ⟳ chip.
+  it("pending with NO prior-good (gray + depth=0) still renders the grey ⟳ chip", () => {
+    const { getByTestId } = render(
+      <DepthChip depth={0} status="wired" chipColor="gray" pending />,
+    );
+    const chip = getByTestId("depth-chip");
+    expect(chip.getAttribute("data-status")).toBe("pending");
+    expect(chip.getAttribute("data-surface-state")).toBe("pending");
+    expect(chip.getAttribute("data-refreshing")).toBe("true");
+    expect(chip.getAttribute("data-has-prior")).toBe("false");
+    // Honest no-data grey — nothing to preserve.
+    expect(chip.className).toContain("text-muted");
     expect(chip.className).not.toContain("emerald");
+    expect(chip.textContent).toContain("⟳");
+  });
+
+  // A pending re-run must NEVER read as a failure — no red, no indigo overlay,
+  // regardless of whether there is a prior-good result.
+  it("pending never reads as a failure (no danger, no indigo overlay)", () => {
+    const { getByTestId } = render(
+      <DepthChip depth={6} status="wired" chipColor="green" pending />,
+    );
+    const chip = getByTestId("depth-chip");
+    expect(chip.className).not.toContain("danger");
+    expect(chip.className).not.toContain("indigo");
   });
 
   it("unreachable takes precedence over pending (a known crash outranks an ambiguous reclaim)", () => {

--- a/showcase/shell-dashboard/src/components/__tests__/depth-chip.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-chip.test.tsx
@@ -313,6 +313,28 @@ describe("DepthChip", () => {
     expect(chip.className).not.toContain("indigo");
   });
 
+  // DECISION-TABLE GUARD ("failure → no spinner"): a regression-coloured cell
+  // that is also pending must render the failure RED (colour passthrough) and
+  // must NOT show the ⟳ refreshing spinner — a failure is not "re-running".
+  it("regression + pending renders the failure red and NO ⟳ spinner / data-refreshing", () => {
+    const { getByTestId } = render(
+      <DepthChip
+        depth={5}
+        status="wired"
+        chipColor="green"
+        regression
+        pending
+      />,
+    );
+    const chip = getByTestId("depth-chip");
+    // Failure colour wins (regression overrides green → danger red).
+    expect(chip.className).toContain("danger");
+    expect(chip.className).not.toContain("emerald");
+    // No spinner glyph and no refreshing hook — colour passthrough only.
+    expect(chip.textContent).not.toContain("⟳");
+    expect(chip.getAttribute("data-refreshing")).not.toBe("true");
+  });
+
   it("unreachable takes precedence over pending (a known crash outranks an ambiguous reclaim)", () => {
     const { getByTestId } = render(
       <DepthChip

--- a/showcase/shell-dashboard/src/components/cell-pieces.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.tsx
@@ -14,6 +14,7 @@ import {
   useWorkerRuns,
   isFamilySilent,
   familyForProbeKey,
+  freshestBounceMs,
 } from "@/lib/worker-runs-context";
 
 export function urlsFor(ctx: CellContext): {
@@ -245,10 +246,13 @@ function LiveBadge({
   // only ever DECORATES an already stale-degraded badge (§7.3).
   const isStaleDegraded =
     badge.tone === "amber" && badge.row !== null && badge.row.fail_count === 0;
-  const families =
-    workerRuns !== null && workerRuns.status === "ok"
-      ? workerRuns.data.families
-      : null;
+  const okRuns =
+    workerRuns !== null && workerRuns.status === "ok" ? workerRuns : null;
+  const families = okRuns ? okRuns.data.families : null;
+  // Post-bounce drain grace (PR #5715): a recent fleet bounce suppresses the
+  // §7.3 silence glyph just as it suppresses the §7.4 banner and §9 alert,
+  // keyed off the same worker `registeredAt`.
+  const bounceAtMs = okRuns ? freshestBounceMs(okRuns.data.workers) : null;
   // Family mapping is payload-driven via the `probeKeyPrefix` each family
   // entry echoes (§5.2.1) — never a dashboard-side prefix table.
   const silentFamily =
@@ -256,7 +260,8 @@ function LiveBadge({
       ? familyForProbeKey(badge.row.key, families)
       : undefined;
   const clockGlyph =
-    silentFamily !== undefined && isFamilySilent(silentFamily, Date.now());
+    silentFamily !== undefined &&
+    isFamilySilent(silentFamily, Date.now(), bounceAtMs);
   // Minimal per §7.3: a label SUFFIX only — tone, tooltip machinery, and the
   // amber branch above stay intact.
   const label = clockGlyph ? `${badge.label} ·⏱` : badge.label;

--- a/showcase/shell-dashboard/src/components/depth-chip.tsx
+++ b/showcase/shell-dashboard/src/components/depth-chip.tsx
@@ -46,9 +46,20 @@ export interface DepthChipProps {
    * Pool RECLAIM-PENDING state (flap-band #70). When set, the job's lease
    * lapsed and the control-plane RE-QUEUED it (back in flight). The sweep
    * boundary cannot tell a real crash from an expected platform teardown, so
-   * this is NEUTRAL — a gray "⟳ pending" treatment, distinct from both the red
-   * `unreachable` overlay and a real probe colour, so a routine teardown never
-   * reads as a failure. `unreachable` takes precedence when both are set.
+   * this is NEUTRAL — never red — and stale-while-revalidate applies:
+   *
+   *   - PRIOR-GOOD (a real last-known result exists: `chipColor` is a real
+   *     colour, i.e. not "gray", OR `depth > 0`): keep rendering the
+   *     last-known-good COLOURED chip and overlay a NON-DESTRUCTIVE refreshing
+   *     affordance (a `⟳` corner badge + a subtle pulsing ring in the chip's
+   *     own colour). The colour does NOT change to grey — a re-run of a healthy
+   *     cell no longer flaps green → grey → green.
+   *   - NO-PRIOR (never-run / first load: `chipColor` is gray/undefined AND
+   *     `depth === 0`): render the honest grey `⟳` chip — there is nothing to
+   *     preserve yet.
+   *
+   * `unreachable` takes precedence when both are set (a known crash outranks an
+   * ambiguous reclaim).
    */
   pending?: boolean;
   /** Tooltip text for the unreachable / pending treatment (names the kind). */
@@ -133,17 +144,70 @@ export function DepthChip({
     );
   }
 
-  // Reclaim-pending overlay (flap-band #70): the job's lease lapsed and was
-  // re-queued (back in flight). NEUTRAL — a gray fill + ⟳ glyph, distinct from
-  // the red `unreachable` overlay above, so an expected platform teardown never
-  // flaps the service red. Resolved before unshipped/unsupported so it always
-  // shows, but AFTER `unreachable` (a known crash outranks an ambiguous reclaim).
+  // Reclaim-pending overlay (flap-band #70) — STALE-WHILE-REVALIDATE: the job's
+  // lease lapsed and was re-queued (back in flight). NEUTRAL — never red, never
+  // the indigo `unreachable` overlay above, so an expected platform teardown
+  // never flaps the service red. Resolved before unshipped/unsupported so it
+  // always shows, but AFTER `unreachable` (a known crash outranks an ambiguous
+  // reclaim).
   if (pending) {
+    // Prior-good: a real last-known result exists. A non-gray chipColor OR a
+    // depth above zero means the cell HAS data worth preserving while the
+    // re-run is in flight — keep its colour, add a non-destructive refreshing
+    // affordance. (Never-run / first load falls through to the grey ⟳ below.)
+    const hasPrior = (chipColor !== undefined && chipColor !== "gray") || depth > 0;
+
+    if (hasPrior) {
+      // Reuse the default branch's EXACT colour derivation, threading
+      // `regression` through so a regression-coloured cell that is also pending
+      // keeps its red treatment rather than mis-painting.
+      const colorClass = chipColor
+        ? chipColorToClass(chipColor, regression)
+        : depthColorClass(depth, regression, maxDepth);
+
+      return (
+        <span
+          data-testid="depth-chip"
+          data-status="pending"
+          data-surface-state="pending"
+          data-refreshing="true"
+          data-has-prior="true"
+          data-depth={String(depth)}
+          className={`relative inline-flex items-center justify-center min-w-[32px] h-5 px-1.5 rounded text-[10px] font-semibold tabular-nums ${colorClass}`}
+          title={commTooltip ?? "re-queued — pending re-run"}
+        >
+          {/* Subtle pulsing ring in the chip's own colour. The ring is the
+              motion cue; it respects prefers-reduced-motion (motion-reduce
+              disables the pulse) so the static ⟳ glyph still carries the
+              "refreshing" meaning by SHAPE alone — never by colour. */}
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 rounded ring-1 ring-inset ring-white/60 animate-pulse motion-reduce:animate-none"
+          />
+          <span className="relative inline-flex items-center">
+            D{depth}
+            {/* Corner refreshing glyph — a distinct SHAPE, not a colour shift,
+                so colour-blind operators still perceive "re-running". */}
+            <span
+              aria-hidden="true"
+              className="ml-0.5 text-[8px] leading-none animate-spin motion-reduce:animate-none"
+            >
+              ⟳
+            </span>
+          </span>
+        </span>
+      );
+    }
+
+    // No-prior (never-run / first load): nothing to preserve — keep today's
+    // honest grey ⟳ chip exactly as before.
     return (
       <span
         data-testid="depth-chip"
         data-status="pending"
         data-surface-state="pending"
+        data-refreshing="true"
+        data-has-prior="false"
         className="inline-flex items-center justify-center min-w-[32px] h-5 px-1.5 rounded text-[10px] font-semibold tabular-nums border border-[var(--text-muted)]/40 bg-[var(--text-muted)]/20 text-[var(--text-muted)]"
         title={commTooltip ?? "re-queued — pending re-run"}
       >

--- a/showcase/shell-dashboard/src/components/depth-chip.tsx
+++ b/showcase/shell-dashboard/src/components/depth-chip.tsx
@@ -151,12 +151,15 @@ export function DepthChip({
   // always shows, but AFTER `unreachable` (a known crash outranks an ambiguous
   // reclaim).
   if (pending) {
-    // Prior-good: a real last-known result exists. A non-gray chipColor OR a
-    // depth above zero means the cell HAS data worth preserving while the
-    // re-run is in flight — keep its colour, add a non-destructive refreshing
-    // affordance. (Never-run / first load falls through to the grey ⟳ below.)
+    // Prior-good: a real last-known result exists. A non-gray chipColor means
+    // the cell HAS a genuine last-known colour worth preserving; when no
+    // chipColor is supplied a depth above zero stands in for that signal.
+    // An EXPLICIT gray chipColor means "no live probe data" (the muted
+    // no-data fill), so it is NOT prior-good even at depth>0 — a grey depth>0
+    // chip falls through to the honest grey ⟳ below rather than claiming a
+    // prior result. (Never-run / first load also falls through.)
     const hasPrior =
-      (chipColor !== undefined && chipColor !== "gray") || depth > 0;
+      chipColor === "gray" ? false : chipColor !== undefined || depth > 0;
 
     if (hasPrior) {
       // Reuse the default branch's EXACT colour derivation, threading
@@ -196,9 +199,16 @@ export function DepthChip({
           data-depth={String(depth)}
           role="status"
           aria-label={
-            isFailureColor
+            // "regression" is reserved for an ACTUALLY-flagged regression —
+            // not any cell that merely resolves to the danger colour (e.g. a
+            // depth far below ceiling). A danger-coloured-but-not-flagged cell
+            // suppresses the ⟳ spinner the same way (failure → no spinner) but
+            // must not be announced as a regression.
+            regression
               ? `Depth ${depth} — regression`
-              : `Depth ${depth} — re-running`
+              : isFailureColor
+                ? `Depth ${depth}`
+                : `Depth ${depth} — re-running`
           }
           className={`relative inline-flex items-center justify-center min-w-[32px] h-5 px-1.5 rounded text-[10px] font-semibold tabular-nums ${colorClass}`}
           title={commTooltip ?? "re-queued — pending re-run"}

--- a/showcase/shell-dashboard/src/components/depth-chip.tsx
+++ b/showcase/shell-dashboard/src/components/depth-chip.tsx
@@ -35,7 +35,7 @@ export interface DepthChipProps {
   chipColor?: "green" | "amber" | "red" | "gray";
   /**
    * Pool COMMUNICATION error (REQ-B). When set, the chip renders a DISTINCT
-   * "couldn't reach the pool" treatment — a purple/indigo fill with a "⚡"
+   * "couldn't reach the pool" treatment — an indigo fill with a "⚡"
    * glyph — that is visually unlike green/amber/red/gray, so an operator can
    * tell "the pool was unreachable" apart from "the test went red". The
    * underlying depth/colour is intentionally suppressed in favour of the
@@ -155,7 +155,8 @@ export function DepthChip({
     // depth above zero means the cell HAS data worth preserving while the
     // re-run is in flight — keep its colour, add a non-destructive refreshing
     // affordance. (Never-run / first load falls through to the grey ⟳ below.)
-    const hasPrior = (chipColor !== undefined && chipColor !== "gray") || depth > 0;
+    const hasPrior =
+      (chipColor !== undefined && chipColor !== "gray") || depth > 0;
 
     if (hasPrior) {
       // Reuse the default branch's EXACT colour derivation, threading
@@ -165,14 +166,40 @@ export function DepthChip({
         ? chipColorToClass(chipColor, regression)
         : depthColorClass(depth, regression, maxDepth);
 
+      // Decision-table guard: a failure-coloured cell (regression, or any path
+      // that resolves to the danger red) must NOT show the ⟳ spinner — it is
+      // colour-passthrough only ("failure → no spinner"). Today the data layer
+      // never marks a failure pending, so this is defensive; it keeps a red
+      // pending cell from reading as "re-running a failure".
+      const isFailureColor =
+        Boolean(regression) || colorClass.includes("--danger");
+
+      // Pulsing ring in the chip's OWN colour (a translucent emerald/amber/
+      // danger ring) rather than a generic white, so the motion cue matches the
+      // chip instead of washing it out. Falls back to white only for the gray
+      // tier where there is no strong own-colour to tint.
+      const ringClass = colorClass.includes("emerald")
+        ? "ring-emerald-300/70"
+        : colorClass.includes("--amber")
+          ? "ring-[var(--amber)]/70"
+          : colorClass.includes("--danger")
+            ? "ring-[var(--danger)]/70"
+            : "ring-white/60";
+
       return (
         <span
           data-testid="depth-chip"
           data-status="pending"
           data-surface-state="pending"
-          data-refreshing="true"
+          {...(isFailureColor ? {} : { "data-refreshing": "true" })}
           data-has-prior="true"
           data-depth={String(depth)}
+          role="status"
+          aria-label={
+            isFailureColor
+              ? `Depth ${depth} — regression`
+              : `Depth ${depth} — re-running`
+          }
           className={`relative inline-flex items-center justify-center min-w-[32px] h-5 px-1.5 rounded text-[10px] font-semibold tabular-nums ${colorClass}`}
           title={commTooltip ?? "re-queued — pending re-run"}
         >
@@ -182,18 +209,26 @@ export function DepthChip({
               "refreshing" meaning by SHAPE alone — never by colour. */}
           <span
             aria-hidden="true"
-            className="pointer-events-none absolute inset-0 rounded ring-1 ring-inset ring-white/60 animate-pulse motion-reduce:animate-none"
+            className={`pointer-events-none absolute inset-0 rounded ring-1 ring-inset ${ringClass} animate-pulse motion-reduce:animate-none`}
           />
+          {/* Visually-hidden status text so screen readers announce the
+              re-running affordance — the `title` alone is not reliably
+              surfaced by assistive tech. Suppressed for failure-coloured
+              cells (colour passthrough only — not "re-running"). */}
+          {!isFailureColor && <span className="sr-only">re-running</span>}
           <span className="relative inline-flex items-center">
             D{depth}
             {/* Corner refreshing glyph — a distinct SHAPE, not a colour shift,
-                so colour-blind operators still perceive "re-running". */}
-            <span
-              aria-hidden="true"
-              className="ml-0.5 text-[8px] leading-none animate-spin motion-reduce:animate-none"
-            >
-              ⟳
-            </span>
+                so colour-blind operators still perceive "re-running".
+                Suppressed for failure-coloured cells (colour passthrough only). */}
+            {!isFailureColor && (
+              <span
+                aria-hidden="true"
+                className="ml-0.5 text-[10px] leading-none animate-spin motion-reduce:animate-none"
+              >
+                ⟳
+              </span>
+            )}
           </span>
         </span>
       );

--- a/showcase/shell-dashboard/src/components/worker-runs-table.test.tsx
+++ b/showcase/shell-dashboard/src/components/worker-runs-table.test.tsx
@@ -76,6 +76,7 @@ function worker(overrides: Partial<WorkerView> = {}): WorkerView {
     workerId: "worker-railway-abc",
     health: "online",
     lastHeartbeatAt: new Date(NOW - 5_000).toISOString(),
+    registeredAt: new Date(NOW - 3_600_000).toISOString(),
     currentJobId: null,
     capacity: { inUse: 0, available: 24, max: 24 },
     ...overrides,

--- a/showcase/shell-dashboard/src/components/worker-silence-banner.test.tsx
+++ b/showcase/shell-dashboard/src/components/worker-silence-banner.test.tsx
@@ -23,6 +23,7 @@ import type {
   WorkerFamilySummary,
   WorkerRunBatch,
   WorkerRunsResponse,
+  WorkerView,
 } from "../lib/ops-api";
 
 const NOW = new Date("2026-06-10T12:00:00Z").getTime();
@@ -72,9 +73,24 @@ function makeFamily(
   };
 }
 
-function okStatus(families: WorkerFamilySummary[]): WorkerRunsStatus {
-  const data: WorkerRunsResponse = { families, workers: [] };
+function okStatus(
+  families: WorkerFamilySummary[],
+  workers: WorkerView[] = [],
+): WorkerRunsStatus {
+  const data: WorkerRunsResponse = { families, workers };
   return { status: "ok", data, fetchedAt: NOW };
+}
+
+/** A worker strip entry whose `registeredAt` is the bounce signal. */
+function makeWorker(registeredAtMs: number): WorkerView {
+  return {
+    workerId: "worker-railway-abc",
+    health: "online",
+    lastHeartbeatAt: new Date(registeredAtMs).toISOString(),
+    registeredAt: new Date(registeredAtMs).toISOString(),
+    currentJobId: null,
+    capacity: { inUse: 0, available: 24, max: 24 },
+  };
 }
 
 function renderBanner(value: WorkerRunsStatus | null) {
@@ -106,6 +122,41 @@ describe("WorkerSilenceBanner", () => {
     );
     expect(banner.textContent).toContain("see Ops tab.");
     expect(banner.textContent).not.toContain("E2E smoke");
+  });
+
+  it("suppresses the banner during the post-bounce drain window (recent worker registration)", () => {
+    // A NORMAL deploy bounced the pool (PR #5715): the worker re-registered
+    // 0.5 period ago, so although lastSuccessAt is 2.5 periods stale (the
+    // pre-bounce success), the family is legitimately mid-sweep and within
+    // the 2×period bounce grace — no banner.
+    const silent = makeFamily({
+      family: "d5",
+      label: "D5 e2e-deep",
+      lastSuccessAt: new Date(NOW - 2.5 * PERIOD_MS).toISOString(),
+    });
+    const { queryByTestId } = renderBanner(
+      okStatus([silent], [makeWorker(NOW - 0.5 * PERIOD_MS)]),
+    );
+    expect(queryByTestId("worker-silence-banner")).toBeNull();
+  });
+
+  it("still banners a genuinely silent family once the bounce grace has elapsed", () => {
+    // Same stale family, but the freshest worker registration is 3 periods
+    // old — well past the 2×period grace — so this is a real outage and the
+    // banner must still fire.
+    const silent = makeFamily({
+      family: "d5",
+      label: "D5 e2e-deep",
+      lastSuccessAt: new Date(NOW - 2.5 * PERIOD_MS).toISOString(),
+    });
+    const { getByTestId } = renderBanner(
+      okStatus([silent], [makeWorker(NOW - 3 * PERIOD_MS)]),
+    );
+    const banner = getByTestId("worker-silence-banner");
+    expect(banner.getAttribute("data-variant")).toBe("silence");
+    expect(banner.textContent).toContain(
+      "Worker family D5 e2e-deep has not completed successfully since",
+    );
   });
 
   it("uses the server periodMs verbatim — a longer period keeps the same age quiet", () => {

--- a/showcase/shell-dashboard/src/components/worker-silence-banner.tsx
+++ b/showcase/shell-dashboard/src/components/worker-silence-banner.tsx
@@ -85,8 +85,10 @@ export function WorkerSilenceBanner() {
     ];
   } else {
     // Post-bounce drain grace: a recent fleet bounce (PR #5715) suppresses
-    // both this banner and the §9 Slack alert, keyed off the same worker
-    // `registeredAt` shipped in the strip.
+    // both this banner and the §9 Slack alert via the SAME 2×period grace
+    // term, keyed off the same worker `registeredAt` shipped in the strip.
+    // (Only the grace term is shared — the banner's silence ONSET is 2×period
+    // vs. the pager's 3×period + 3-tick debounce, an intentional asymmetry.)
     const bounceAtMs = freshestBounceMs(status.data.workers);
     const silentFamilies = status.data.families.filter((family) =>
       isFamilySilent(family, nowMs, bounceAtMs),

--- a/showcase/shell-dashboard/src/components/worker-silence-banner.tsx
+++ b/showcase/shell-dashboard/src/components/worker-silence-banner.tsx
@@ -29,7 +29,11 @@
 import { useState } from "react";
 
 import type { WorkerFamilySummary } from "@/lib/ops-api";
-import { isFamilySilent, useWorkerRuns } from "@/lib/worker-runs-context";
+import {
+  freshestBounceMs,
+  isFamilySilent,
+  useWorkerRuns,
+} from "@/lib/worker-runs-context";
 import { formatRelative } from "./status-table";
 
 /**
@@ -80,8 +84,12 @@ export function WorkerSilenceBanner() {
         : "Worker run telemetry unreachable — ops endpoint not responding; see Ops tab.",
     ];
   } else {
+    // Post-bounce drain grace: a recent fleet bounce (PR #5715) suppresses
+    // both this banner and the §9 Slack alert, keyed off the same worker
+    // `registeredAt` shipped in the strip.
+    const bounceAtMs = freshestBounceMs(status.data.workers);
     const silentFamilies = status.data.families.filter((family) =>
-      isFamilySilent(family, nowMs),
+      isFamilySilent(family, nowMs, bounceAtMs),
     );
     if (silentFamilies.length === 0) return null;
     variant = "silence";

--- a/showcase/shell-dashboard/src/lib/ops-api.ts
+++ b/showcase/shell-dashboard/src/lib/ops-api.ts
@@ -486,6 +486,13 @@ export interface WorkerView {
   workerId: string;
   health: WorkerHealthState;
   lastHeartbeatAt: string;
+  /**
+   * ISO instant the worker last (re)registered, or "" when absent. The
+   * freshest non-empty value across the strip is the fleet's most-recent
+   * bounce instant; the §7.3 glyph / §7.4 banner grace a post-deploy drain
+   * off it (PR #5715), consistent with the §9 Slack monitor.
+   */
+  registeredAt: string;
   currentJobId: string | null;
   capacity: { inUse: number; available: number; max: number };
 }

--- a/showcase/shell-dashboard/src/lib/worker-runs-context.tsx
+++ b/showcase/shell-dashboard/src/lib/worker-runs-context.tsx
@@ -15,21 +15,27 @@
  * `not.toThrow`). `null` is also the provider-mounted value until the
  * first poll settles, so consumers have exactly one no-data case.
  */
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, useContext } from "react";
+import type { ReactNode } from "react";
 
 import type { WorkerFamilySummary, WorkerView } from "./ops-api";
 import type { WorkerRunsStatus } from "../hooks/use-worker-runs";
 
 /**
  * Post-bounce drain grace, in resolved periods — mirrors the §9 monitor's
- * `BOUNCE_GRACE_PERIOD_MULTIPLIER`. A NORMAL harness deploy rebuilds the
+ * `BOUNCE_GRACE_PERIOD_MULTIPLIER` (=2). A NORMAL harness deploy rebuilds the
  * shared image and bounces the pool workers (PR #5715); for ~1–2 sweep cycles
  * afterward each family is legitimately mid-sweep with a still-stale
  * `lastSuccessAt`, so neither the §7.3 glyph nor the §7.4 banner should flag
- * silence. Two periods == the silence threshold itself, keeping the dashboard
- * and the Slack alert consistent (both key off the same worker `registeredAt`
- * shipped in the `/api/runs` workers strip): within 2 periods of a bounce
- * neither surfaces silence, beyond it both do.
+ * silence. This 2×period bounce-grace TERM is the one piece the dashboard and
+ * the §9 Slack monitor share verbatim (both key off the same worker
+ * `registeredAt` shipped in the `/api/runs` workers strip): within 2 periods
+ * of a bounce neither surface flags silence, beyond it both can. The
+ * silence-ONSET threshold, by contrast, is NOT shared — the dashboard treats
+ * a family silent at 2×period (see `isFamilySilent` below) while the server
+ * pager requires 3×period plus a 3-tick debounce; that onset asymmetry is
+ * pre-existing / by-design (visual hint vs. pager) and only the grace term is
+ * intentionally kept in lockstep.
  */
 export const BOUNCE_GRACE_PERIOD_MULTIPLIER = 2;
 
@@ -111,8 +117,11 @@ export function useWorkerRuns(): WorkerRunsContextValue {
  *   `registeredAt`, via `freshestBounceMs`) is within
  *   `BOUNCE_GRACE_PERIOD_MULTIPLIER` periods of now, the family is
  *   legitimately mid-sweep after a deploy bounce (PR #5715) and is NOT
- *   silent — the same grace the §9 Slack monitor applies, so banner/glyph
- *   and alert stay consistent. Pass `null` (or omit) to disable the grace.
+ *   silent — this is the SAME 2×period bounce-grace term the §9 Slack monitor
+ *   applies, so for the grace window banner/glyph and pager agree. (The
+ *   silence-onset thresholds differ — 2×period here vs. 3×period + 3-tick
+ *   debounce server-side — by design; see the module-level grace JSDoc.) Pass
+ *   `null` (or omit) to disable the grace.
  */
 export function isFamilySilent(
   entry: WorkerFamilySummary,

--- a/showcase/shell-dashboard/src/lib/worker-runs-context.tsx
+++ b/showcase/shell-dashboard/src/lib/worker-runs-context.tsx
@@ -17,8 +17,44 @@
  */
 import { createContext, useContext, type ReactNode } from "react";
 
-import type { WorkerFamilySummary } from "./ops-api";
+import type { WorkerFamilySummary, WorkerView } from "./ops-api";
 import type { WorkerRunsStatus } from "../hooks/use-worker-runs";
+
+/**
+ * Post-bounce drain grace, in resolved periods — mirrors the §9 monitor's
+ * `BOUNCE_GRACE_PERIOD_MULTIPLIER`. A NORMAL harness deploy rebuilds the
+ * shared image and bounces the pool workers (PR #5715); for ~1–2 sweep cycles
+ * afterward each family is legitimately mid-sweep with a still-stale
+ * `lastSuccessAt`, so neither the §7.3 glyph nor the §7.4 banner should flag
+ * silence. Two periods == the silence threshold itself, keeping the dashboard
+ * and the Slack alert consistent (both key off the same worker `registeredAt`
+ * shipped in the `/api/runs` workers strip): within 2 periods of a bounce
+ * neither surfaces silence, beyond it both do.
+ */
+export const BOUNCE_GRACE_PERIOD_MULTIPLIER = 2;
+
+/**
+ * The fleet's most-recent worker (re)registration instant — the bounce signal
+ * the post-bounce drain grace keys off. Returns the freshest parseable
+ * `registeredAt` across the workers strip, or null when none is present (empty
+ * strip / pre-migration rows), which disables the grace and preserves
+ * pre-change behavior. A worker can be bounced while the control-plane stays
+ * up, so the worker-registration instant — not any CP-side timer — is the
+ * correct, independent bounce signal.
+ */
+export function freshestBounceMs(
+  workers: readonly WorkerView[] | undefined,
+): number | null {
+  if (!workers) return null;
+  let freshest: number | null = null;
+  for (const worker of workers) {
+    if (!worker.registeredAt) continue;
+    const ms = Date.parse(worker.registeredAt);
+    if (Number.isNaN(ms)) continue;
+    if (freshest === null || ms > freshest) freshest = ms;
+  }
+  return freshest;
+}
 
 /**
  * `null` = no provider mounted OR the first poll has not settled yet.
@@ -71,10 +107,17 @@ export function useWorkerRuns(): WorkerRunsContextValue {
  * - A degraded entry (`error: "history_unavailable"` — no `periodMs`) is
  *   never classified silent here; §6.1 surfaces that as the `unavailable`
  *   incident class instead.
+ * - POST-BOUNCE DRAIN: when `bounceAtMs` (the fleet's freshest worker
+ *   `registeredAt`, via `freshestBounceMs`) is within
+ *   `BOUNCE_GRACE_PERIOD_MULTIPLIER` periods of now, the family is
+ *   legitimately mid-sweep after a deploy bounce (PR #5715) and is NOT
+ *   silent — the same grace the §9 Slack monitor applies, so banner/glyph
+ *   and alert stay consistent. Pass `null` (or omit) to disable the grace.
  */
 export function isFamilySilent(
   entry: WorkerFamilySummary,
   nowMs: number,
+  bounceAtMs: number | null = null,
 ): boolean {
   const periodMs = entry.periodMs;
   if (typeof periodMs !== "number" || periodMs <= 0) return false;
@@ -88,7 +131,16 @@ export function isFamilySilent(
   // Unparseable reference time: conservatively not-silent — a malformed
   // payload must not paint silence glyphs across the matrix.
   if (Number.isNaN(referenceMs)) return false;
-  return nowMs - referenceMs > 2 * periodMs;
+  if (nowMs - referenceMs <= 2 * periodMs) return false;
+  // Post-bounce drain grace: a recent fleet bounce means the family is
+  // draining, not silent (see the JSDoc + the §9 monitor's matching gate).
+  if (
+    bounceAtMs !== null &&
+    nowMs - bounceAtMs < BOUNCE_GRACE_PERIOD_MULTIPLIER * periodMs
+  ) {
+    return false;
+  }
+  return true;
 }
 
 /**


### PR DESCRIPTION
## What

Bundles the four code fixes from the 2026-06-26 showcase prod incident remediation. (Prod config reconciles — fleet image promotes, worker scaling, CVDIAG keys — were applied directly to Railway and are not code; the post-incident debugging lesson shipped separately in #5727.)

## Incident context (why these exist)

Prod's coverage dashboard cascaded to a wall of red. Root cause was **staleness, not a feature break**: the harness worker pool was starved (a deploy-bounce + under-provisioning), so probe sweeps couldn't complete within the staleness windows → cells aged out → rendered red/BE✗ even though the apps were fine. Compounded by a `llamaindex` container crash (per-request log flood tripping Railway's log cap) and a 2-day-stale prod image fleet. See #5727 for the debugging lesson, and the Notion proposal below for the durable worker-reclamation redesign.

## The four fixes

1. **Dashboard stale-while-revalidate** (`shell-dashboard/depth-chip.tsx`) — a passing (green) cell keeps its color + a non-destructive `⟳` refreshing affordance during a re-probe instead of flapping to grey; never-run stays grey; failure/regression keeps its color with no spinner; staleness bound preserved. + a11y (`role=status`, flag-gated regression label, `motion-reduce`).
2. **Family-silence grace window** (`harness/fleet/control-plane/*` + dashboard banner) — a normal harness deploy's post-bounce worker drain no longer fires a false "worker family silent" banner/alert (suppressed within a `2×period` bounce grace keyed on the freshest worker registration), while genuine silence beyond the window still fires on both the Slack-alert and banner paths. No silent failure (PB-down → grace disabled → real outages still alert).
3. **llamaindex per-request log gate** (`integrations/llamaindex/.../route.ts`) — gates the chatty `[copilotkit/route]` per-request logs behind `SHOWCASE_ROUTE_DEBUG` (default off) so they can't flood Railway's log cap and kill the container. Error logging untouched.
4. **SSOT worker-provisioning** (`scripts/railway-envs.ts` + drift gate) — brings harness-workers replica provisioning under SSOT so prod/staging can't silently drift. Models the **effective** field (`multiRegionConfig.<region>.numReplicas`) + `BROWSER_POOL_MAX_CONTEXTS`, declares current reconciled reality (prod=staging=6 replicas, 40 contexts), with a CI drift-detection test.

## Review

7-agent CR round + 7-agent confirmation round → converged to **0 P0 / 0 P1**. Two post-CR fixes (SSOT effective-field model after discovering `multiRegionConfig` is the live knob; re-anchoring a grace-edge test to genuinely pin the 2× boundary) each re-confirmed clean. Suites: shell-dashboard 92 + harness 63 + scripts 12 = **167 passed, 0 failed**. No new tsc errors (pre-existing only).

## Notes / follow-ups (non-blocking)

- llamaindex log-gate is logging-only and untested (acceptable); the chatty pattern exists in ~16 integrations incl. the gold standard — a **fleet-wide log-flood gate** is a worthwhile follow-up.
- `freshestBounceMs` has two equivalent impls (harness `parseIso` / dashboard `Date.parse`) — flagged for future lockstep.
- The D4/BE probe gate weakness (asserts `text.length>0`, which masked the BIA outage) is being addressed in a **separate** PR (`fix/d4-gate-tighten`).

## Refs
- Post-incident debugging lesson: #5727
- Worker reclamation + graceful-rollover redesign (Notion proposal): https://app.notion.com/p/38b3aa381852817bacf5c9cda1f11cc0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
