### PR TITLE
docs(shell-docs): ungate Slack and Teams docs

### DIFF
--- a/showcase/shell-docs/src/app/reference/[...slug]/page.tsx
+++ b/showcase/shell-docs/src/app/reference/[...slug]/page.tsx
@@ -34,8 +34,6 @@ import {
 } from "fumadocs-ui/page";
 import { ShellDocsLayout } from "@/components/shell-docs-layout";
 import { ReferenceVersionSelector } from "@/components/reference-version-selector";
-import { EarlyAccessGate } from "@/components/early-access-gate";
-import { getEarlyAccessGate } from "@/lib/early-access";
 import {
   REFERENCE_VERSIONS,
   buildReferencePageTree,
@@ -190,99 +188,78 @@ export default async function ReferenceSlugPage({
         breadcrumb={{ enabled: false }}
         footer={{ enabled: false }}
       >
-        {/* The whole `bot` reference section documents the Slack bot
-            SDK, so it sits behind the same early-access gate as the
-            Slack guide. */}
-        <MaybeEarlyAccessGate gate={version === "bot" ? "slack" : undefined}>
-          <div className="docs-inner-content max-w-[900px] mx-auto px-4 md:px-6 pt-2 pb-6 md:pt-3 xl:pt-4">
-            <nav className="mb-2 flex flex-wrap items-center gap-1 text-[11px] font-medium leading-none text-[var(--text-muted)]">
-              {breadcrumbs.map((crumb, i) => {
-                const isLast = i === breadcrumbs.length - 1;
-                const labelClass = `truncate ${isLast ? "text-[var(--text)] font-medium" : ""}`;
-                return (
-                  <Fragment key={`${crumb.label}-${i}`}>
-                    {i > 0 && (
-                      <ChevronRight
-                        className="size-3 shrink-0"
-                        aria-hidden="true"
-                      />
-                    )}
-                    {crumb.href && !isLast ? (
-                      <Link
-                        href={crumb.href}
-                        className={`${labelClass} transition-opacity hover:opacity-80`}
-                      >
-                        {crumb.label}
-                      </Link>
-                    ) : (
-                      <span className={labelClass}>{crumb.label}</span>
-                    )}
-                  </Fragment>
-                );
-              })}
-            </nav>
+        <div className="docs-inner-content max-w-[900px] mx-auto px-4 md:px-6 pt-2 pb-6 md:pt-3 xl:pt-4">
+          <nav className="mb-2 flex flex-wrap items-center gap-1 text-[11px] font-medium leading-none text-[var(--text-muted)]">
+            {breadcrumbs.map((crumb, i) => {
+              const isLast = i === breadcrumbs.length - 1;
+              const labelClass = `truncate ${isLast ? "text-[var(--text)] font-medium" : ""}`;
+              return (
+                <Fragment key={`${crumb.label}-${i}`}>
+                  {i > 0 && (
+                    <ChevronRight
+                      className="size-3 shrink-0"
+                      aria-hidden="true"
+                    />
+                  )}
+                  {crumb.href && !isLast ? (
+                    <Link
+                      href={crumb.href}
+                      className={`${labelClass} transition-opacity hover:opacity-80`}
+                    >
+                      {crumb.label}
+                    </Link>
+                  ) : (
+                    <span className={labelClass}>{crumb.label}</span>
+                  )}
+                </Fragment>
+              );
+            })}
+          </nav>
 
-            <DocsTitle className="text-[32px] md:text-[40px] font-medium leading-[1.2]">
-              {title}
-            </DocsTitle>
-            {description && (
-              <DocsDescription className="text-lg text-[var(--text-muted)] mt-5 leading-relaxed">
-                {description}
-              </DocsDescription>
-            )}
+          <DocsTitle className="text-[32px] md:text-[40px] font-medium leading-[1.2]">
+            {title}
+          </DocsTitle>
+          {description && (
+            <DocsDescription className="text-lg text-[var(--text-muted)] mt-5 leading-relaxed">
+              {description}
+            </DocsDescription>
+          )}
 
-            <div className="flex min-w-0 flex-row flex-wrap gap-2 items-center my-6">
-              <MarkdownCopyButton markdownUrl={markdownUrl} />
-              <ViewOptionsPopover
-                markdownUrl={markdownUrl}
-                githubUrl={buildGitHubUrl(filePath)}
-              />
-            </div>
-
-            <hr className="border-t border-[var(--border)] mt-2 mb-6" />
-
-            <DocsBody className="reference-content">
-              <MDXRemote
-                source={cleanedContent}
-                components={mdxComponents}
-                options={{
-                  mdxOptions: {
-                    remarkPlugins: [remarkGfm],
-                    rehypePlugins: [
-                      [
-                        rehypeCode,
-                        {
-                          fallbackLanguage: "plaintext",
-                          transformers: [
-                            ...(rehypeCodeDefaultOptions.transformers ?? []),
-                            transformerMeta(),
-                          ],
-                        },
-                      ],
-                    ],
-                  },
-                }}
-              />
-            </DocsBody>
+          <div className="flex min-w-0 flex-row flex-wrap gap-2 items-center my-6">
+            <MarkdownCopyButton markdownUrl={markdownUrl} />
+            <ViewOptionsPopover
+              markdownUrl={markdownUrl}
+              githubUrl={buildGitHubUrl(filePath)}
+            />
           </div>
-        </MaybeEarlyAccessGate>
+
+          <hr className="border-t border-[var(--border)] mt-2 mb-6" />
+
+          <DocsBody className="reference-content">
+            <MDXRemote
+              source={cleanedContent}
+              components={mdxComponents}
+              options={{
+                mdxOptions: {
+                  remarkPlugins: [remarkGfm],
+                  rehypePlugins: [
+                    [
+                      rehypeCode,
+                      {
+                        fallbackLanguage: "plaintext",
+                        transformers: [
+                          ...(rehypeCodeDefaultOptions.transformers ?? []),
+                          transformerMeta(),
+                        ],
+                      },
+                    ],
+                  ],
+                },
+              }}
+            />
+          </DocsBody>
+        </div>
       </DocsPage>
     </ShellDocsLayout>
   );
-}
-
-/**
- * Server-side gate hook-up — mirrors the helper in `docs-page-view.tsx`.
- * Absent or unknown gate ids render children directly so ungated
- * reference versions never mount the client-side gate component.
- */
-function MaybeEarlyAccessGate({
-  gate,
-  children,
-}: {
-  gate?: string;
-  children: React.ReactNode;
-}) {
-  if (!gate || !getEarlyAccessGate(gate)) return <>{children}</>;
-  return <EarlyAccessGate gate={gate}>{children}</EarlyAccessGate>;
 }

--- a/showcase/shell-docs/src/components/__tests__/early-access-gate.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/early-access-gate.test.tsx
@@ -6,35 +6,22 @@ import { EARLY_ACCESS_GATES, getEarlyAccessGate } from "@/lib/early-access";
 
 describe("early-access config", () => {
   it("registers early-access gates with the shared password", () => {
-    expect(EARLY_ACCESS_GATES.slack.password).toBe("earlyaccess");
-    expect(EARLY_ACCESS_GATES.slack.storageKey).toBe(
-      "shell-docs-early-access:slack",
-    );
-    expect(EARLY_ACCESS_GATES.teams.password).toBe("earlyaccess");
-    expect(EARLY_ACCESS_GATES.teams.storageKey).toBe(
-      "shell-docs-early-access:microsoft-teams",
+    expect(EARLY_ACCESS_GATES.whatsapp.password).toBe("earlyaccess");
+    expect(EARLY_ACCESS_GATES.whatsapp.storageKey).toBe(
+      "shell-docs-early-access:whatsapp",
     );
   });
 
   it("points the request-access CTA at the beyond-the-web form", () => {
-    expect(EARLY_ACCESS_GATES.slack.requestUrl).toBe(
+    expect(EARLY_ACCESS_GATES.whatsapp.requestUrl).toBe(
       "https://go.copilotkit.ai/beyond-the-web-form",
     );
-    expect(EARLY_ACCESS_GATES.teams.requestUrl).toBe(
-      "https://go.copilotkit.ai/beyond-the-web-form",
-    );
-  });
-
-  it("registers Microsoft Teams gate preview images", () => {
-    expect(EARLY_ACCESS_GATES.teams.image).toMatchObject({
-      lightSrc: "/images/teams-preview-light.png",
-      darkSrc: "/images/teams-preview-dark.png",
-    });
   });
 
   it("resolves known ids and rejects unknown ones", () => {
-    expect(getEarlyAccessGate("slack")).toBe(EARLY_ACCESS_GATES.slack);
-    expect(getEarlyAccessGate("teams")).toBe(EARLY_ACCESS_GATES.teams);
+    expect(getEarlyAccessGate("whatsapp")).toBe(EARLY_ACCESS_GATES.whatsapp);
+    expect(getEarlyAccessGate("slack")).toBeNull();
+    expect(getEarlyAccessGate("teams")).toBeNull();
     expect(getEarlyAccessGate("nope")).toBeNull();
     expect(getEarlyAccessGate(undefined)).toBeNull();
   });
@@ -43,13 +30,13 @@ describe("early-access config", () => {
 describe("EarlyAccessGate", () => {
   it("server-renders gated content blurred, inert, and hidden from AT", () => {
     const markup = renderToStaticMarkup(
-      <EarlyAccessGate gate="slack">
-        <p>secret slack guide</p>
+      <EarlyAccessGate gate="whatsapp">
+        <p>secret whatsapp guide</p>
       </EarlyAccessGate>,
     );
 
     // Content stays in the DOM (it's what gets blurred)…
-    expect(markup).toContain("secret slack guide");
+    expect(markup).toContain("secret whatsapp guide");
     // …but is visually blurred and unreachable.
     expect(markup).toContain("blur-");
     expect(markup).toContain("inert=");
@@ -59,8 +46,8 @@ describe("EarlyAccessGate", () => {
 
   it("does not server-render the unlock card (it mounts client-side)", () => {
     const markup = renderToStaticMarkup(
-      <EarlyAccessGate gate="slack">
-        <p>secret slack guide</p>
+      <EarlyAccessGate gate="whatsapp">
+        <p>secret whatsapp guide</p>
       </EarlyAccessGate>,
     );
 

--- a/showcase/shell-docs/src/components/early-access-gate.tsx
+++ b/showcase/shell-docs/src/components/early-access-gate.tsx
@@ -13,20 +13,9 @@
 
 import React, { useEffect, useId, useState } from "react";
 import Image from "next/image";
-import { Lock, Slack, Users } from "lucide-react";
+import { Lock } from "lucide-react";
 import { getEarlyAccessGate } from "@/lib/early-access";
 import type { EarlyAccessGateConfig } from "@/lib/early-access";
-
-// Icon shown in the card header tile, per gate id. Kept here (not in
-// the config module) so the server-importable config stays free of
-// client-only component values.
-const GATE_ICONS: Record<
-  string,
-  React.ComponentType<{ className?: string }>
-> = {
-  slack: Slack,
-  teams: Users,
-};
 
 const UNLOCKED_VALUE = "unlocked";
 
@@ -57,19 +46,13 @@ export function EarlyAccessGate({
 }) {
   const config = getEarlyAccessGate(gate);
   if (!config) return <>{children}</>;
-  return (
-    <GateShell gate={gate} config={config}>
-      {children}
-    </GateShell>
-  );
+  return <GateShell config={config}>{children}</GateShell>;
 }
 
 function GateShell({
-  gate,
   config,
   children,
 }: {
-  gate: string;
   config: EarlyAccessGateConfig;
   children: React.ReactNode;
 }) {
@@ -106,7 +89,6 @@ function GateShell({
               the card's max-height) tracks the visible content area. */}
           <div className="sticky top-0 flex h-[calc(100svh-var(--fd-nav-height,64px)-var(--fd-banner-height,0px))] items-center justify-center px-4 sm:px-6">
             <UnlockCard
-              gate={gate}
               config={config}
               onUnlock={() => {
                 persistUnlocked(config.storageKey);
@@ -121,11 +103,9 @@ function GateShell({
 }
 
 function UnlockCard({
-  gate,
   config,
   onUnlock,
 }: {
-  gate: string;
   config: EarlyAccessGateConfig;
   onUnlock: () => void;
 }) {
@@ -134,7 +114,6 @@ function UnlockCard({
   const errorId = useId();
   const [value, setValue] = useState("");
   const [error, setError] = useState(false);
-  const Icon = GATE_ICONS[gate] ?? Lock;
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -155,7 +134,7 @@ function UnlockCard({
           className="flex size-[52px] shrink-0 items-center justify-center rounded-xl bg-[var(--accent-dim)] text-[var(--text)]"
           aria-hidden="true"
         >
-          <Icon className="size-[26px]" />
+          <Lock className="size-[26px]" />
         </div>
         <div className="min-w-0">
           <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--accent)]">

--- a/showcase/shell-docs/src/content/docs/bots/index.mdx
+++ b/showcase/shell-docs/src/content/docs/bots/index.mdx
@@ -2,11 +2,19 @@
 title: Bots
 description: Build durable, cross-platform AI bots with CopilotKit — a platform adapter, an AG-UI agent, and optional persistence wired together in a single createBot call.
 icon: "lucide/Bot"
-earlyAccess: slack
 hideTOC: true
 ---
 
 The bot stack is three pieces: **`@copilotkit/bot`** (core runtime), a **platform adapter** (e.g. `@copilotkit/bot-slack`), and an **AG-UI agent** — any CopilotKit runtime or compatible backend. Plug them together with `createBot` and you get a bot that streams agent replies into the platform, handles interactive buttons, and — once you add a store — survives restarts and spans multiple instances.
+
+<OpsPlatformCTA
+  variant="inline"
+  title="Join the waitlist for managed Slack and Teams agents"
+  body="Start here when you want to own the adapter, runtime, and store. Join the waitlist if you want CopilotKit Intelligence to manage Slack and Teams setup, identity, durable state, approvals, and production operations."
+  ctaLabel="Join the waitlist"
+  surface="docs_bots_managed_agents_waitlist"
+  href="https://www.copilotkit.ai/opentag-managed"
+/>
 
 <Cards>
   <Card

--- a/showcase/shell-docs/src/content/docs/bots/persistence.mdx
+++ b/showcase/shell-docs/src/content/docs/bots/persistence.mdx
@@ -2,12 +2,20 @@
 title: Persistence
 description: Make bot state, interactive actions, and per-thread data survive restarts and scale across multiple instances with a durable store backend.
 icon: "lucide/Database"
-earlyAccess: slack
 ---
 
 **Where you're starting from:** a dev bot where every restart wipes button handlers, resets thread state, and drops duplicate-detection memory. A user clicks a button five minutes after a deploy and nothing happens.
 
 **Where you're headed:** the same bot, wired to a durable store, where actions survive restarts, concurrent turns are serialised with a turn lock, and each thread carries typed state that persists across runs.
+
+<OpsPlatformCTA
+  variant="inline"
+  title="Join the waitlist for managed Slack and Teams agents"
+  body="This page shows how to bring your own Redis or PostgreSQL store. Join the waitlist if you want CopilotKit Intelligence to manage durable state, runtime handoff, approvals, analytics, and release operations for Slack and Teams."
+  ctaLabel="Join the waitlist"
+  surface="docs_bots_persistence_managed_agents_waitlist"
+  href="https://www.copilotkit.ai/opentag-managed"
+/>
 
 <Steps>
   <Step>

--- a/showcase/shell-docs/src/content/docs/bots/transcripts.mdx
+++ b/showcase/shell-docs/src/content/docs/bots/transcripts.mdx
@@ -2,12 +2,20 @@
 title: Transcripts
 description: Give your bot a cross-platform memory that follows users across Slack, Teams, and any other channel — with automatic context injection and GDPR-ready delete.
 icon: "lucide/MessageSquare"
-earlyAccess: slack
 ---
 
 **Where you're starting from:** a bot that forgets the user entirely between messages. The agent has no awareness that this Slack user is the same person who asked a related question on Teams yesterday, or what they said there.
 
 **Where you're headed:** one cross-platform memory indexed by user identity, automatically injected into every agent run, and deletable on request.
+
+<OpsPlatformCTA
+  variant="inline"
+  title="Join the waitlist for managed Slack and Teams agents"
+  body="This page shows how to map users and store transcripts yourself. Join the waitlist if you want CopilotKit Intelligence to manage identity, permissions, durable state, and Slack and Teams setup around the same agent runtime."
+  ctaLabel="Join the waitlist"
+  surface="docs_bots_transcripts_managed_agents_waitlist"
+  href="https://www.copilotkit.ai/opentag-managed"
+/>
 
 <Steps>
   <Step>

--- a/showcase/shell-docs/src/content/docs/frontends/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/slack.mdx
@@ -3,10 +3,18 @@ title: Slack
 description: Build an AI Slack bot with CopilotKit, Copilot Runtime, createBot, the Slack adapter over Socket Mode, and interactive JSX messages rendered as Block Kit.
 icon: "lucide/Slack"
 hideTOC: true
-earlyAccess: slack
 ---
 
 This guide takes you from zero to a Slack bot you can @-mention in a channel, then adds an interactive button card. You write handlers in TypeScript, Copilot Runtime hosts the agent, and rich messages are JSX that the adapter renders to Block Kit (Slack's message-UI format). No public URL needed.
+
+<OpsPlatformCTA
+  variant="inline"
+  title="Join the waitlist for managed Slack and Teams agents"
+  body="Want CopilotKit Intelligence to carry Slack and Teams setup, identity and permissions, durable state, approvals, and runtime operations for you?"
+  ctaLabel="Join the waitlist"
+  surface="docs_slack_managed_agents_waitlist"
+  href="https://www.copilotkit.ai/opentag-managed"
+/>
 
 ## Prerequisites
 

--- a/showcase/shell-docs/src/content/docs/frontends/teams.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/teams.mdx
@@ -2,10 +2,18 @@
 title: Microsoft Teams
 description: Build an AI Microsoft Teams bot with CopilotKit using createBot, the Teams adapter, agent runs with thread.runAgent, and interactive JSX messages rendered as Adaptive Cards.
 hideTOC: true
-earlyAccess: teams
 ---
 
 This guide takes you from zero to a Microsoft Teams bot you can chat with, then adds an interactive Adaptive Card and a human-approval gate. You write handlers in TypeScript, the agent's replies stream into the conversation, and rich messages are JSX that the adapter renders to Adaptive Cards (Teams' message-UI format). You can run the whole thing locally in the **M365 Agents Playground** with no Microsoft account, then sideload it into real Teams when you're ready.
+
+<OpsPlatformCTA
+  variant="inline"
+  title="Join the waitlist for managed Slack and Teams agents"
+  body="Want CopilotKit Intelligence to manage the app setup, identity and permissions, durable state, approvals, and runtime operations for Slack and Teams?"
+  ctaLabel="Join the waitlist"
+  surface="docs_teams_managed_agents_waitlist"
+  href="https://www.copilotkit.ai/opentag-managed"
+/>
 
 ## Prerequisites
 

--- a/showcase/shell-docs/src/content/reference/bot/index.mdx
+++ b/showcase/shell-docs/src/content/reference/bot/index.mdx
@@ -22,6 +22,15 @@ pnpm add @copilotkit/bot @copilotkit/bot-ui @copilotkit/bot-discord
   New to the stack? Start with the [Slack quickstart](/slack) — zero to a working bot, then come back here for the API surface.
 </Callout>
 
+<OpsPlatformCTA
+  variant="inline"
+  title="Join the waitlist for managed Slack and Teams agents"
+  body="The APIs below let you own the adapter, runtime, platform credentials, tools, and storage. Join the waitlist if you want CopilotKit Intelligence to manage Slack and Teams rollout, identity, durable state, approvals, observability, and release workflows."
+  ctaLabel="Join the waitlist"
+  surface="reference_bot_managed_agents_waitlist"
+  href="https://www.copilotkit.ai/opentag-managed"
+/>
+
 ## Setup
 
 The packages ship as **ES modules only** (`"type": "module"` required). To author messages as JSX, point the TypeScript JSX factory at `@copilotkit/bot-ui` and write `.tsx` files:

--- a/showcase/shell-docs/src/content/reference/bot/slack/index.mdx
+++ b/showcase/shell-docs/src/content/reference/bot/slack/index.mdx
@@ -9,6 +9,15 @@ description: "The Slack platform adapter factory — Socket Mode ingress via Bol
 
 For app creation, tokens, and first run, see the [Slack quickstart](/slack).
 
+<OpsPlatformCTA
+  variant="inline"
+  title="Join the waitlist for managed Slack and Teams agents"
+  body="The adapter keeps Slack-specific work at the platform boundary. Join the waitlist if you want CopilotKit Intelligence to manage Slack and Teams setup, identity and permissions, durable state, approvals, and runtime operations."
+  ctaLabel="Join the waitlist"
+  surface="reference_bot_slack_managed_agents_waitlist"
+  href="https://www.copilotkit.ai/opentag-managed"
+/>
+
 ## Signature
 
 ```ts

--- a/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
@@ -337,14 +337,21 @@ describe("cookbook nav", () => {
 });
 
 describe("framework nav", () => {
-  it("loads early-access frontmatter for gated platform guides", () => {
+  it("leaves Slack and Teams platform guides ungated", () => {
     const slack = loadDoc("frontends/slack")?.fm;
     const teams = loadDoc("frontends/teams")?.fm;
 
-    expect(slack?.earlyAccess).toBe("slack");
+    expect(slack?.earlyAccess).toBeUndefined();
     expect(slack?.hideTOC).toBe(true);
-    expect(teams?.earlyAccess).toBe("teams");
+    expect(teams?.earlyAccess).toBeUndefined();
     expect(teams?.hideTOC).toBe(true);
+  });
+
+  it("loads early-access frontmatter for gated platform guides", () => {
+    const whatsapp = loadDoc("frontends/whatsapp")?.fm;
+
+    expect(whatsapp?.earlyAccess).toBe("whatsapp");
+    expect(whatsapp?.hideTOC).toBe(true);
   });
 
   it("keeps frontend platform guides out of generated framework nav", () => {

--- a/showcase/shell-docs/src/lib/early-access.ts
+++ b/showcase/shell-docs/src/lib/early-access.ts
@@ -31,24 +31,6 @@ export interface EarlyAccessGateConfig {
 }
 
 export const EARLY_ACCESS_GATES = {
-  slack: {
-    storageKey: "shell-docs-early-access:slack",
-    password: "earlyaccess",
-    eyebrow: "Early access",
-    title: "Slack is in early access",
-    description: [
-      "The Slack docs are behind a password while Slack support is in early access.",
-      "CopilotKit for Slack turns your agent into a Slack bot: streaming replies in threads, calling tools, and rendering interactive messages.",
-    ],
-    requestPrompt: "Don't have the password?",
-    requestLinkLabel: "Reach out to request early access to Slack",
-    requestUrl: "https://go.copilotkit.ai/beyond-the-web-form",
-    image: {
-      alt: "A Slack thread where a user asks the Kite bot for a chart and the bot replies with an interactive generative UI chart.",
-      lightSrc: "/images/slack-bot-generative-ui-light.png",
-      darkSrc: "/images/slack-bot-generative-ui-dark.png",
-    },
-  },
   whatsapp: {
     storageKey: "shell-docs-early-access:whatsapp",
     password: "earlyaccess",
@@ -61,24 +43,6 @@ export const EARLY_ACCESS_GATES = {
     requestPrompt: "Don't have the password?",
     requestLinkLabel: "Reach out to request early access to WhatsApp",
     requestUrl: "https://go.copilotkit.ai/beyond-the-web-form",
-  },
-  teams: {
-    storageKey: "shell-docs-early-access:microsoft-teams",
-    password: "earlyaccess",
-    eyebrow: "Early access",
-    title: "Microsoft Teams is in early access",
-    description: [
-      "The Microsoft Teams guide is behind a password while Teams support is in early access.",
-      "CopilotKit for Microsoft Teams turns your agent into a Teams bot: streamed Adaptive Cards, human approvals, and file-driven chart rendering.",
-    ],
-    requestPrompt: "Don't have the Microsoft Teams password?",
-    requestLinkLabel: "Reach out to request early access to Microsoft Teams",
-    requestUrl: "https://go.copilotkit.ai/beyond-the-web-form",
-    image: {
-      alt: "A Microsoft Teams bot conversation showing a CopilotKit assistant response rendered in Teams.",
-      lightSrc: "/images/teams-preview-light.png",
-      darkSrc: "/images/teams-preview-dark.png",
-    },
   },
 } as const satisfies Record<string, EarlyAccessGateConfig>;
 


### PR DESCRIPTION
## Summary
- remove Slack and Teams early-access gates from frontend and bot docs
- remove the bot reference early-access wrapper
- add inline CopilotKit Intelligence waitlist CTAs for managed Slack and Teams agents

## Verification
- `npm exec -- vitest run src/components/__tests__/early-access-gate.test.tsx src/lib/__tests__/docs-render.test.ts -t "Slack and Teams|early-access frontmatter"`
- `npm run typecheck`
- `npm run build`
- `curl -I --max-time 10 https://www.copilotkit.ai/opentag-managed`
