### PR TITLE
docs(telemetry): document bot SDK telemetry on the /telemetry page

### DIFF
--- a/showcase/shell-docs/src/content/docs/(other)/telemetry/index.mdx
+++ b/showcase/shell-docs/src/content/docs/(other)/telemetry/index.mdx
@@ -11,13 +11,27 @@ We use anonymous telemetry (metadata-only) to learn how to improve CopilotKit.
 - We do not use cookies or trackers in open-source telemetry
 - To minimize the frequency of data sent, we apply batching and sampling to telemetry
 
+## Bot SDK telemetry
+
+The CopilotKit bot packages (`@copilotkit/bot` and its platform adapters) send the same kind of anonymous, metadata-only telemetry so we can understand how the bot SDK is adopted. No message content, user identities, channel names, or application data are ever collected, and errors are recorded only as a sanitized category — never the error message.
+
+The bot SDK records a small set of lifecycle events:
+
+- `oss.bot.configured` — a bot was created (which platform adapters and store backend, plus counts of tools/commands/components — never their names or values)
+- `oss.bot.started` — the bot connected to at least one platform
+- `oss.bot.start_failed` — an adapter failed to start (sanitized error category only)
+- `oss.bot.agent_run` — an agent run completed (platform, duration, tool-call count)
+- `oss.bot.agent_run_failed` — an agent run errored (sanitized error category only)
+
+Unlike runtime telemetry, bot SDK telemetry is **not sampled** — every event is sent. The opt-out below disables it along with all other CopilotKit telemetry.
+
 ## How to opt out of anonymous telemetry
 
-Set `COPILOTKIT_TELEMETRY_DISABLED=true` in your runtime environment. This disables telemetry for both the CopilotRuntime and the Inspector dev-console. We also respect [Do Not Track (DNT)](https://consoledonottrack.com/).
+Set `COPILOTKIT_TELEMETRY_DISABLED=true` in your environment. This disables all CopilotKit open-source telemetry — the CopilotRuntime, the Inspector dev-console, and the bot SDK packages (`@copilotkit/bot`). We also respect [Do Not Track (DNT)](https://consoledonottrack.com/).
 
 ## How to adjust telemetry sample rate
 
-The default sample rate is `0.05` (5%). You can adjust it by setting the `COPILOTKIT_TELEMETRY_SAMPLE_RATE` to any value between 0 and 1.
+The default sample rate is `0.05` (5%). You can adjust it by setting the `COPILOTKIT_TELEMETRY_SAMPLE_RATE` to any value between 0 and 1. This applies to runtime telemetry; bot SDK telemetry is not sampled.
 
 ## Get in touch
 

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/telemetry.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/telemetry.mdx
@@ -11,13 +11,27 @@ We use anonymous telemetry (metadata-only) to learn how to improve CopilotKit.
 - We do not use cookies or trackers in open-source telemetry
 - To minimize the frequency of data sent, we apply batching and sampling to telemetry
 
+## Bot SDK telemetry
+
+The CopilotKit bot packages (`@copilotkit/bot` and its platform adapters) send the same kind of anonymous, metadata-only telemetry so we can understand how the bot SDK is adopted. No message content, user identities, channel names, or application data are ever collected, and errors are recorded only as a sanitized category — never the error message.
+
+The bot SDK records a small set of lifecycle events:
+
+- `oss.bot.configured` — a bot was created (which platform adapters and store backend, plus counts of tools/commands/components — never their names or values)
+- `oss.bot.started` — the bot connected to at least one platform
+- `oss.bot.start_failed` — an adapter failed to start (sanitized error category only)
+- `oss.bot.agent_run` — an agent run completed (platform, duration, tool-call count)
+- `oss.bot.agent_run_failed` — an agent run errored (sanitized error category only)
+
+Unlike runtime telemetry, bot SDK telemetry is **not sampled** — every event is sent. The opt-out below disables it along with all other CopilotKit telemetry.
+
 ## How to opt out of anonymous telemetry
 
-Set `COPILOTKIT_TELEMETRY_DISABLED=true` in your runtime environment. This disables telemetry for both the CopilotRuntime and the Inspector dev-console. We also respect [Do Not Track (DNT)](https://consoledonottrack.com/).
+Set `COPILOTKIT_TELEMETRY_DISABLED=true` in your environment. This disables all CopilotKit open-source telemetry — the CopilotRuntime, the Inspector dev-console, and the bot SDK packages (`@copilotkit/bot`). We also respect [Do Not Track (DNT)](https://consoledonottrack.com/).
 
 ## How to adjust telemetry sample rate
 
-The default sample rate is `0.05` (5%). You can adjust it by setting the `COPILOTKIT_TELEMETRY_SAMPLE_RATE` to any value between 0 and 1.
+The default sample rate is `0.05` (5%). You can adjust it by setting the `COPILOTKIT_TELEMETRY_SAMPLE_RATE` to any value between 0 and 1. This applies to runtime telemetry; bot SDK telemetry is not sampled.
 
 ## Get in touch
 


### PR DESCRIPTION
## What

The bot SDK's one-time disclosure points at `docs.copilotkit.ai/telemetry`, but that page documented only the CopilotRuntime + Inspector. This adds a **Bot SDK telemetry** section describing the anonymous `oss.bot.*` events, notes that bot telemetry is **unsampled**, and broadens the opt-out wording to make clear `COPILOTKIT_TELEMETRY_DISABLED`/`DO_NOT_TRACK` disables the bot SDK too.

Follows the bot telemetry feature (`@copilotkit/bot` 0.1.0) and its lambda support.

## Scope

Only the two source files that render at the bare `/telemetry` route are touched — `docs/(other)/telemetry/index.mdx` and `docs/integrations/built-in-agent/telemetry.mdx` (kept identical). The 8 per-framework `/integrations/<fw>/telemetry` pages are intentionally left alone — the bot SDK is framework-agnostic, so its events don't belong on a LangGraph/Mastra/etc. telemetry page.

## Testing

- Confirmed via routing which source files serve `docs.copilotkit.ai/telemetry` (built-in-agent override + `(other)` fallback) and edited both identically so the page is consistent regardless of which the router resolves.
- Docs-only change: plain MDX markdown sections (headings + bullet list + inline code), no components or imports added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)