### PR TITLE
fix(showcase): tighten D4/BE probe gate to a provenance check (catch the BIA-style dead-agent false-pass)

### DIFF
--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -276,22 +276,40 @@ describe("e2eChatToolsDriver L3 (chat)", () => {
     expect(evaluateCalls).toBeGreaterThan(1);
   });
 
-  it("falls back to body scraping when the assistant selector never resolves", async () => {
-    // Reference helper's fallback path: slice <body> after the sent
-    // message, strip UI chrome, keep substantive text.
+  it("red when the assistant bubble never renders even though static page text trails the message (BIA false-pass guard)", async () => {
+    // Regression for the BIA outage: the agent run finished with ZERO
+    // assistant content (RUN_STARTED → RUN_FINISHED, no TEXT_MESSAGE), so
+    // the `[data-testid="copilot-assistant-message"]` bubble never produced
+    // text. The probe then fell back to scraping <body>, where unrelated
+    // STATIC page text trailing the sent message (nav links, footer copy,
+    // demo blurb) is long enough to pass the old `text.length > 0` gate —
+    // turning a dead agent into a false GREEN.
+    //
+    // The distinguishing signal is provenance: a REAL turn fills the
+    // assistant-message container; a body-scrape leak does not. With the
+    // container selector throwing AND no real assistant content, the gate
+    // must report RED. (Pre-fix this returned GREEN because the body tail
+    // was non-empty — the false-pass this test pins.)
     const { browser } = makeBrowser([
       {
         throwOnAssistantSelector: new Error("selector timeout"),
         bodyText:
-          "Hello, please respond with a brief greeting.\nAlright, here is a warm greeting for you from the assistant response.",
+          "Hello, please respond with a brief greeting.\n" +
+          "Documentation Pricing Blog GitHub Star us on GitHub. " +
+          "This demo shows an agentic chat experience built with CopilotKit.",
       },
     ]);
     const driver = createE2eSmokeDriver({ launcher: async () => browser });
-    const result = await driver.run(baseCtx(), {
+    const writer = new CapturingWriter();
+    const result = await driver.run(baseCtx({ writer }), {
       key: "e2e-smoke:foo",
       backendUrl: "https://x.example.com",
     });
-    expect(result.state).toBe("green");
+    expect(result.state).toBe("red");
+    const sig = result.signal as E2eSmokeSignal;
+    expect(sig.l3).toBe("red");
+    const chat = writer.results.find((r) => r.key === "chat:foo");
+    expect(chat?.state).toBe("red");
   });
 });
 

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -970,10 +970,30 @@ export function createE2eSmokeDriver(
           cvdiagBufferDir,
           cvdiagPbWriter,
           cvdiagDebugAllowList,
-          assertResponse: (text) => ({
-            ok: text.length > 0,
-            summary: text.length === 0 ? "empty assistant response" : "",
-          }),
+          assertResponse: ({ text, fromAssistantContainer }) => {
+            // Tightened L3 gate (BIA false-pass guard). A REAL turn renders
+            // its content INTO the assistant-message container — at the DOM
+            // layer that is the equivalent of "RUN_FINISHED + ≥1 non-empty
+            // TEXT_MESSAGE". The old `text.length > 0` check also accepted the
+            // <body>-scrape FALLBACK, where unrelated static page text trailing
+            // the sent message (nav links, footer copy, demo blurb) is non-empty
+            // — so a dead agent that emitted ZERO assistant content (the BIA
+            // outage) false-PASSED on that static text. Require BOTH non-empty
+            // content AND that it came from the assistant-message container, so
+            // the gate reflects a genuine assistant turn rather than incidental
+            // page chrome.
+            if (text.length === 0) {
+              return { ok: false, summary: "empty assistant response" };
+            }
+            if (!fromAssistantContainer) {
+              return {
+                ok: false,
+                summary:
+                  "no assistant message rendered (response text came only from a <body> fallback scrape, not the assistant-message container)",
+              };
+            }
+            return { ok: true, summary: "" };
+          },
         });
         if (ctx.writer) {
           try {
@@ -1073,9 +1093,18 @@ export function createE2eSmokeDriver(
             cvdiagBufferDir,
             cvdiagPbWriter,
             cvdiagDebugAllowList,
-            assertResponse: (text) => {
+            assertResponse: ({ text, fromAssistantContainer }) => {
               if (text.length === 0) {
                 return { ok: false, summary: "empty assistant response" };
+              }
+              // Same BIA false-pass guard as L3: weather content must come from
+              // a genuine assistant-message turn, not a <body> fallback scrape.
+              if (!fromAssistantContainer) {
+                return {
+                  ok: false,
+                  summary:
+                    "no assistant message rendered (response text came only from a <body> fallback scrape, not the assistant-message container)",
+                };
               }
               const lc = text.toLowerCase();
               const hit = WEATHER_VOCAB.some((v) => lc.includes(v));
@@ -1227,7 +1256,19 @@ async function runLevel(opts: {
    * to these slugs (per-slug match in `captureRawBytes`); empty → no capture.
    */
   cvdiagDebugAllowList: ReadonlySet<string>;
-  assertResponse: (text: string) => { ok: boolean; summary: string };
+  /**
+   * Apply the level's red/green assertion to the captured response. Receives
+   * BOTH the trimmed response text AND its provenance: `fromAssistantContainer`
+   * is true only when the text came from the `[data-testid=
+   * "copilot-assistant-message"]` container (a genuine assistant turn), and
+   * false when it came only from the `<body>` fallback scrape. The L3/L4 gates
+   * require container provenance so a dead agent whose static page text leaks
+   * through the body fallback (the BIA outage) does not false-PASS.
+   */
+  assertResponse: (response: {
+    text: string;
+    fromAssistantContainer: boolean;
+  }) => { ok: boolean; summary: string };
 }): Promise<{
   result: ProbeResult<E2eSmokeLevelSignal>;
   /**
@@ -1437,6 +1478,12 @@ async function runLevel(opts: {
     // showcases don't set the testid, so we fall back to scraping the
     // <body> for substantive text that appeared after our message.
     let responseText = "";
+    // Provenance of `responseText`: true once it is read from the
+    // assistant-message container (a genuine assistant turn), false while it is
+    // still empty or was salvaged from the `<body>` fallback scrape. The
+    // tightened L3/L4 gate requires container provenance so a dead agent whose
+    // static page text leaks through the fallback (BIA) does not false-PASS.
+    let fromAssistantContainer = false;
     try {
       await page.waitForSelector('[data-testid="copilot-assistant-message"]', {
         state: "visible",
@@ -1503,6 +1550,9 @@ async function runLevel(opts: {
       }
       responseText = raw.trim();
       if (responseText.length > 0) {
+        // Real content read from the assistant-message container → a genuine
+        // assistant turn (the gate's required provenance).
+        fromAssistantContainer = true;
         cvdiagResponseEmpty = false;
         // probe.dom.firsttoken — first non-empty assistant textContent.
         cvdiag?.firstToken(nowMonoMs(), responseText.length);
@@ -1608,7 +1658,10 @@ async function runLevel(opts: {
       }
     }
 
-    const assertion = assertResponse(responseText);
+    const assertion = assertResponse({
+      text: responseText,
+      fromAssistantContainer,
+    });
     // probe.exit (completion path). A missing-VOCAB response is still a clean
     // MECHANICAL run (real response present) → `terminal_outcome=ok`, reflecting
     // probe mechanics not the green/red vocab assertion. But a run that produced


### PR DESCRIPTION
## What

Tightens the **D4/BE chat-roundtrip probe gate** from `text.length > 0` to a **provenance check**. A turn now only counts green if the assistant text came from the `[data-testid="copilot-assistant-message"]` container — not from the `<body>` fallback scrape (which picks up static page chrome).

## Why

This is the gate weakness that **masked the BIA prod outage**: a dead agent (RUN_STARTED→RUN_FINISHED with zero `TEXT_MESSAGE`) left the page chrome on screen, the `<body>` scrape returned non-empty text, and the old `text.length > 0` gate reported **green** while the agent was actually broken. The new gate threads a `fromAssistantContainer` flag (set true only on the testid-container read path) so a body-scrape-only result fails (`!fromAssistantContainer` → red). The same guard is applied at L4 (tool-rendering).

## Review

**7-agent CR → 0 P0 / 0 P1.** Highlights:
- **Red-green genuine** (empirical): old gate false-passes BIA (1/52 RED); post-fix 52/52. 3-way guard (green / empty-via-unchanged-length-guard / BIA-via-provenance).
- **Blast radius: no false-fail risk** — all 20 integrations' `agentic-chat` + `tool-rendering` demos use the shared v2 `CopilotChat` which mounts the testid unconditionally; aimock `d4/<slug>/chat.json` fixtures are text-bearing for all 20. Verdict: **ship as a blocking gate, no soak.**
- **No lost coverage** — the `<body>`-scrape fallback *code* is retained (diagnostics); only the gate *semantics* narrowed. No D4-probed cell relied on the fallback to pass.
- **No cross-family regression** — change is confined to `d4-chat-roundtrip.ts`; other probe drivers untouched; 169/0 tests pass; tsc clean.

## Notes / follow-ups (non-blocking, P2)
- A *future* probed demo using a `CopilotChatAssistantMessage` children-render override (which doesn't emit the testid) would false-fail — worth a one-line note near the fallback comment if that pattern is ever added to a D4 route.

Part of the 2026-06-26 incident remediation (companion to #5733); this gate would have surfaced the BIA failure that the dashboard masked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
