### PR TITLE
fix(showcase): reclaimable leases — reclaim-wins-until-cap reaper with consecutive-orphan budget

### DIFF
--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -118,9 +118,14 @@ interface JobRow extends JobView {
   family?: string;
   /** PB system column; seeded by prune tests (real PB stamps it on create). */
   created?: string;
-  /** Durable per-job reclaim tally (migration 1779990200) the fleet-claim CAS
-   * bumps; read by the reaper as the MAX_RECLAIM_ATTEMPTS cap signal. */
+  /** Durable per-job lifetime reclaim tally (migration 1779990200) the
+   * fleet-claim CAS bumps on every expired-lease steal AND sweeper re-queue.
+   * Dashboard diagnostic only — NOT the cap signal. */
   reclaim_count?: number;
+  /** CONSECUTIVE re-orphan counter (migration 1779990400) — bumped ONLY by the
+   * sweeper re-queue path and reset on terminal done|failed. The reaper reads
+   * THIS (not reclaim_count) for the MAX_RECLAIM_ATTEMPTS cap check. */
+  consecutive_orphan_count?: number;
   /** Re-anchor timestamp (migration 1779990300) the release CAS stamps on a
    * pending re-queue; the reaper's stale-age anchor for a reclaimed row. */
   requeued_at?: string;
@@ -3035,14 +3040,22 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
         async claimJob(jobId, workerId): Promise<ClaimResult> {
           const r = store.find((x) => x.id === jobId);
           if (!r) return { won: false };
-          const reclaimable =
-            r.status === "pending" ||
-            (["claimed", "running"].includes(r.status) &&
-              leaseExpired(r.lease_expires_at, nowMs));
+          const wasExpiredSteal =
+            ["claimed", "running"].includes(r.status) &&
+            leaseExpired(r.lease_expires_at, nowMs);
+          const reclaimable = r.status === "pending" || wasExpiredSteal;
           if (!reclaimable) return { won: false };
           r.status = "claimed";
           r.claimed_by = workerId;
           r.version += 1;
+          // Mirror the claim CAS: an expired-lease steal bumps the LIFETIME
+          // reclaim tally (`reclaim_count`) but does NOT touch the consecutive
+          // re-orphan counter (`consecutive_orphan_count`). A plain pending
+          // claim bumps neither.
+          if (wasExpiredSteal) {
+            r.reclaim_count = (r.reclaim_count ?? 0) + 1;
+            // consecutive_orphan_count is intentionally NOT bumped here.
+          }
           return { won: true, job: { ...r } };
         },
         renewLease: vi.fn(
@@ -3053,9 +3066,16 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
           if (!r || r.claimed_by !== workerId) return { released: false };
           if (status === "pending") {
             sink?.releasedPending.push(jobId);
-            // Mirror the release CAS: bump the reclaim tally and re-anchor.
+            // Mirror the release CAS: bump BOTH tallies and re-anchor.
+            // `reclaim_count` is the lifetime diagnostic; `consecutive_orphan_count`
+            // is the cap counter (sweeper re-queue path only).
             r.reclaim_count = (r.reclaim_count ?? 0) + 1;
+            r.consecutive_orphan_count = (r.consecutive_orphan_count ?? 0) + 1;
             r.requeued_at = new Date(nowMs).toISOString();
+          } else {
+            // Terminal release: reset the consecutive counter so a LATER
+            // re-orphan starts with a fresh budget. Lifetime tally is NOT reset.
+            r.consecutive_orphan_count = 0;
           }
           r.status = status;
           r.claimed_by = "";
@@ -3114,12 +3134,13 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       expect(row?.requeued_at).toBe(new Date(T).toISOString());
     });
 
-    it("ATTEMPT CAP (layer a): a stale-aged long-expired orphan AT MAX_RECLAIM_ATTEMPTS is claim-DELETED — a poison job cannot re-queue forever", async () => {
+    it("ATTEMPT CAP (layer a): a stale-aged long-expired orphan AT MAX_RECLAIM_ATTEMPTS consecutive orphans is claim-DELETED — a poison job cannot re-queue forever", async () => {
       // The reclaim-wins inversion is bounded: a row that has already been
-      // reclaimed MAX_RECLAIM_ATTEMPTS times and STILL re-orphaned (it crashes
-      // the worker every run) falls through to the carve-out delete — no
-      // re-queue, no comm error, counted with the stale expiries — so the
-      // queue cannot loop on a genuinely poison job.
+      // reclaimed MAX_RECLAIM_ATTEMPTS times CONSECUTIVELY (consecutive_orphan_count
+      // at cap) and STILL re-orphaned (it crashes the worker every run) falls
+      // through to the carve-out delete — no re-queue, no comm error, counted
+      // with the stale expiries — so the queue cannot loop on a genuinely poison
+      // job.
       const poison: CreatedJobRow = {
         ...jobView({
           id: "poison",
@@ -3130,8 +3151,8 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
         }),
         payload: samplePayload({ probeKey: "d6:a" }),
         created: new Date(T - 8 * HOUR).toISOString(),
-        // Already at the cap.
-        reclaim_count: MAX_RECLAIM_ATTEMPTS,
+        // Already at the cap: consecutive re-orphans, never completed.
+        consecutive_orphan_count: MAX_RECLAIM_ATTEMPTS,
       };
       const { pb, store } = makePagingPb([poison]);
       const sink = { releasedPending: [] as string[] };
@@ -3197,6 +3218,126 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       const sweep2 = await q.sweepExpired(T2);
       expect(store.find((r) => r.id === "long-dead")?.status).toBe("pending");
       expect(sweep2.expiredPending).toBe(0);
+    });
+
+    // ── P1-A RED-GREEN REGRESSION ────────────────────────────────────────────
+    // A job that has accrued N benign peer steals over its lifetime (high
+    // reclaim_count) but ZERO consecutive sweeper re-orphans must be RE-QUEUED
+    // on its first real orphan — NOT deleted. Pre-fix this was broken because
+    // the cap used `reclaim_count` (bumped by both steal + re-queue paths), so
+    // a long-lived job with many peer steals would hit the cap and get
+    // claim-DELETED on its first fresh orphan.
+    it("P1-A CAP SCOPE: a job with benign peer steals (high reclaim_count) but no consecutive orphans is RE-QUEUED on its first fresh orphan, never deleted", async () => {
+      // Simulate a job that has been stolen by peers 3 times (reclaim_count=3
+      // — already AT the old cap) but has consecutive_orphan_count=0 (never
+      // been re-queued by the sweeper — it always re-ran successfully).
+      const longLived: CreatedJobRow = {
+        ...jobView({
+          id: "long-lived",
+          probe_key: "d6:a",
+          status: "running",
+          claimed_by: "worker-dead",
+          // Lease expired 4h ago — LONGER than the 3h (3×60min) stale window.
+          lease_expires_at: new Date(T - 4 * HOUR).toISOString(),
+        }),
+        payload: samplePayload({ probeKey: "d6:a" }),
+        created: new Date(T - 8 * HOUR).toISOString(), // stale-aged
+        // LIFETIME tally at the old-cap value (3 benign steals).
+        reclaim_count: MAX_RECLAIM_ATTEMPTS,
+        // But ZERO consecutive sweeper re-orphans: should NOT be deleted.
+        consecutive_orphan_count: 0,
+      };
+      const { pb, store } = makePagingPb([longLived]);
+      const sink = { releasedPending: [] as string[] };
+      const claim = makeReclaimClaim(store, T, sink);
+      const q = createFleetQueueClient({ pb, claim, logger });
+
+      const sweep = await q.sweepExpired(T);
+
+      // Must be RE-QUEUED (non-lossy), not deleted.
+      const row = store.find((r) => r.id === "long-lived");
+      expect(row).toBeDefined();
+      expect(row?.status).toBe("pending");
+      expect(sink.releasedPending).toContain("long-lived");
+      expect(sweep.reclaimed).toBe(1);
+      expect(sweep.expiredPending).toBe(0);
+      // consecutive_orphan_count was 0 before → 1 after first sweeper re-queue.
+      expect(row?.consecutive_orphan_count).toBe(1);
+      // lifetime tally still increases (the re-queue path bumps it too).
+      expect(row?.reclaim_count).toBe(MAX_RECLAIM_ATTEMPTS + 1);
+    });
+
+    // ── P1-B LOW-BOUNDARY TEST ───────────────────────────────────────────────
+    // The LOW boundary of the cap must be pinned: a row at consecutive_orphan_count
+    // = MAX-1 (= 2) must be RE-QUEUED (pending), never deleted. Without this
+    // test, a mutation `>= MAX` → `>= MAX-1` (delete one attempt too early)
+    // passes all other tests undetected.
+    it("P1-B CAP LOW BOUNDARY: a stale-aged orphan at consecutive_orphan_count = MAX-1 is RE-QUEUED (not deleted) — the low boundary is pinned", async () => {
+      const nearCap: CreatedJobRow = {
+        ...jobView({
+          id: "near-cap",
+          probe_key: "d6:a",
+          status: "running",
+          claimed_by: "worker-dead",
+          lease_expires_at: new Date(T - 4 * HOUR).toISOString(),
+        }),
+        payload: samplePayload({ probeKey: "d6:a" }),
+        created: new Date(T - 8 * HOUR).toISOString(),
+        // ONE BELOW the cap (= 2 when MAX = 3): must be RE-QUEUED.
+        consecutive_orphan_count: MAX_RECLAIM_ATTEMPTS - 1,
+      };
+      const { pb, store } = makePagingPb([nearCap]);
+      const sink = { releasedPending: [] as string[] };
+      const claim = makeReclaimClaim(store, T, sink);
+      const q = createFleetQueueClient({ pb, claim, logger });
+
+      const sweep = await q.sweepExpired(T);
+
+      // Must be RE-QUEUED at MAX-1 (not at cap yet).
+      const row = store.find((r) => r.id === "near-cap");
+      expect(row).toBeDefined();
+      expect(row?.status).toBe("pending");
+      expect(sink.releasedPending).toContain("near-cap");
+      expect(sweep.reclaimed).toBe(1);
+      expect(sweep.expiredPending).toBe(0);
+      // Counter now at MAX_RECLAIM_ATTEMPTS (cap) — NEXT orphan would be deleted.
+      expect(row?.consecutive_orphan_count).toBe(MAX_RECLAIM_ATTEMPTS);
+    });
+
+    // ── STEAL-BUDGET PIN ─────────────────────────────────────────────────────
+    // Explicit test that an expired-lease steal (peer claim of an abandoned row)
+    // does NOT increment consecutive_orphan_count — steals must never consume
+    // the reclaim budget.
+    it("peer-worker expired-lease steal does NOT consume the consecutive_orphan_count budget (steals bump lifetime reclaim_count only)", async () => {
+      // A row with consecutive_orphan_count near the cap but with an
+      // expired-lease that will be claimed (stolen) by a peer worker.
+      const contested: CreatedJobRow = {
+        ...jobView({
+          id: "contested",
+          probe_key: "d6:a",
+          status: "running",
+          claimed_by: "worker-old",
+          // Lease expired but NOT stale-aged — so the carve-out does NOT apply;
+          // this tests the claim steal path in isolation.
+          lease_expires_at: new Date(T - 5 * MIN).toISOString(),
+        }),
+        payload: samplePayload({ probeKey: "d6:a" }),
+        // Recent: not stale-aged, won't hit the carve-out.
+        created: new Date(T - 10 * MIN).toISOString(),
+        reclaim_count: 2,
+        consecutive_orphan_count: MAX_RECLAIM_ATTEMPTS - 1,
+      };
+      const store = [contested];
+      // Claim the row as a "peer" via the fake's claimJob (the steal path).
+      const claim = makeReclaimClaim(store, T);
+      const result = await claim.claimJob("contested", "worker-peer", 30);
+      expect(result.won).toBe(true);
+
+      const row = store.find((r) => r.id === "contested");
+      // Lifetime tally bumped by the steal.
+      expect(row?.reclaim_count).toBe(3);
+      // Consecutive budget NOT consumed by the steal.
+      expect(row?.consecutive_orphan_count).toBe(MAX_RECLAIM_ATTEMPTS - 1);
     });
 
     it("a release that THROWS after committing server-side still graces the row AND synthesizes its comm error (timeout-after-commit)", async () => {

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -6,6 +6,7 @@ import {
   leaseExpired,
   PB_DATE_SEP_RE,
   PoisonedBacklogCountError,
+  MAX_RECLAIM_ATTEMPTS,
   RESULT_WRITE_MAX_ATTEMPTS,
   RESULT_WRITE_RETRY_DELAY_MS,
   PRUNE_TERMINAL_MAX_AGE_MS,
@@ -117,6 +118,12 @@ interface JobRow extends JobView {
   family?: string;
   /** PB system column; seeded by prune tests (real PB stamps it on create). */
   created?: string;
+  /** Durable per-job reclaim tally (migration 1779990200) the fleet-claim CAS
+   * bumps; read by the reaper as the MAX_RECLAIM_ATTEMPTS cap signal. */
+  reclaim_count?: number;
+  /** Re-anchor timestamp (migration 1779990300) the release CAS stamps on a
+   * pending re-queue; the reaper's stale-age anchor for a reclaimed row. */
+  requeued_at?: string;
 }
 
 /**
@@ -2958,44 +2965,80 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       expect(store.find((r) => r.id === "long-runner")).toBeUndefined();
     });
 
-    it("an UNPARSEABLE lease on a stale-aged expired row is claim-DELETED in the lease phase — two sweeps compose honestly (no falsified 'back in flight')", async () => {
-      // COMPOSE HOLE: the long-expired carve-out used to require a FINITE
-      // parsed lease, so an expired claimed/running row with an
-      // unparseable lease_expires_at fell to the conservative re-queue —
-      // emitting worker-reclaimed-pending ("back in flight"). But the NEXT
-      // sweep's recent-lease protection ALSO requires a finite lease, so
-      // the re-queued row was claim-DELETED off its stale created age —
-      // the dashboard permanently showed "re-queued" for silently
-      // discarded work. An unparseable lease carries NO recent-flight
-      // evidence either phase can honor, so the lease phase must treat it
-      // as long-expired and delete directly: the emitted signal (none)
-      // matches the eventual outcome (discard).
+    it("an UNPARSEABLE lease on a stale-aged orphan below the cap is RE-QUEUED — requeued_at re-anchors so the next sweep does NOT falsify 'back in flight' (layer a)", async () => {
+      // COMPOSE HOLE, now closed by requeued_at: the carve-out USED to delete
+      // an expired claimed/running row with an unparseable lease, because
+      // re-queueing it emitted "back in flight" yet the NEXT sweep's
+      // (lease-based) recent-lease protection could not read the junk lease,
+      // so the row was claim-deleted off its stale `created` age — falsifying
+      // the signal. The reclaimable-leases re-anchor removes the lease from
+      // the cross-sweep protection entirely: a re-queued row carries
+      // requeued_at, and the next sweep ages it off THAT (genuinely young),
+      // not the unparseable lease. So an unparseable-lease orphan below the
+      // cap is now RE-CLAIMED (non-lossy) and the signal HOLDS — the lease's
+      // parseability no longer matters.
       const junkLease: CreatedJobRow = {
         ...jobView({
           id: "junk-lease",
           probe_key: "d6:a",
           status: "running",
           claimed_by: "worker-dead",
-          // Unparseable: leaseExpired(NaN) → expired (never wedge), but
-          // neither the carve-out's finite-lease check nor the stale
-          // phase's recent-lease protection could read it.
+          // Unparseable: leaseExpired(NaN) → expired (never wedge). Its
+          // parseability is now irrelevant to the cross-sweep protection.
           lease_expires_at: "not-a-date",
         }),
         payload: samplePayload({ probeKey: "d6:a" }),
         created: new Date(T - 4 * HOUR).toISOString(), // > 3 × 60min window
+        reclaim_count: 0,
       };
       const { pb, store } = makePagingPb([junkLease]);
-      const releasedPending: string[] = [];
-      const claim: JobClaimClient = {
-        // CAS-faithful claim: admits pending rows AND claimed/running rows
-        // whose lease has expired (the hook's reclaim safety net).
+      const sink = { releasedPending: [] as string[] };
+      const claim = makeReclaimClaim(store, T, sink);
+      const q = createFleetQueueClient({ pb, claim, logger });
+
+      // Sweep 1: RE-CLAIMED (non-lossy), an honest "back in flight" gray.
+      const first = await q.sweepExpired(T);
+      const row = store.find((r) => r.id === "junk-lease");
+      expect(row?.status).toBe("pending");
+      expect(sink.releasedPending).toEqual(["junk-lease"]);
+      expect(first.commErrors).toHaveLength(1);
+      expect(first.commErrors[0].kind).toBe("worker-reclaimed-pending");
+      expect(first.reclaimed).toBe(1);
+      expect(first.expiredPending).toBe(0);
+      expect(row?.requeued_at).toBe(new Date(T).toISOString());
+
+      // Sweep 2 a stale-window later: the row is still pending and still stale
+      // by `created`, but YOUNG by requeued_at — so it is NOT claim-deleted.
+      // The signal from sweep 1 stands (the unparseable lease never mattered).
+      const second = await q.sweepExpired(T + MIN);
+      expect(store.find((r) => r.id === "junk-lease")?.status).toBe("pending");
+      expect(second.expiredPending).toBe(0);
+      expect(second.reclaimed).toBe(0);
+    });
+
+    /**
+     * Hook-faithful CAS over the paging store for the reclaimable-leases
+     * tests: `claimJob` admits pending rows AND expired-lease claimed/running
+     * rows (the reclaim safety net), and `releaseJob(..., "pending")` mirrors
+     * the fleet-claim.pb.js release CAS — it bumps the durable `reclaim_count`
+     * tally and stamps `requeued_at = now` (the stale-age re-anchor). Without
+     * those two field writes the reaper's attempt cap and honesty-bind
+     * dissolution would not be exercised, so this fake models them exactly as
+     * the server does.
+     */
+    function makeReclaimClaim(
+      store: CreatedJobRow[],
+      nowMs: number,
+      sink?: { releasedPending: string[] },
+    ): JobClaimClient {
+      return {
         async claimJob(jobId, workerId): Promise<ClaimResult> {
           const r = store.find((x) => x.id === jobId);
           if (!r) return { won: false };
           const reclaimable =
             r.status === "pending" ||
             (["claimed", "running"].includes(r.status) &&
-              leaseExpired(r.lease_expires_at, T));
+              leaseExpired(r.lease_expires_at, nowMs));
           if (!reclaimable) return { won: false };
           r.status = "claimed";
           r.claimed_by = workerId;
@@ -3008,44 +3051,31 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
         async releaseJob(jobId, workerId, status): Promise<ReleaseResult> {
           const r = store.find((x) => x.id === jobId);
           if (!r || r.claimed_by !== workerId) return { released: false };
-          if (status === "pending") releasedPending.push(jobId);
+          if (status === "pending") {
+            sink?.releasedPending.push(jobId);
+            // Mirror the release CAS: bump the reclaim tally and re-anchor.
+            r.reclaim_count = (r.reclaim_count ?? 0) + 1;
+            r.requeued_at = new Date(nowMs).toISOString();
+          }
           r.status = status;
           r.claimed_by = "";
           r.version += 1;
           return { released: true, job: { ...r } };
         },
       };
-      const q = createFleetQueueClient({ pb, claim, logger });
+    }
 
-      // Sweep 1: deleted directly — no re-queue, no "back in flight" comm
-      // error to falsify, counted with the stale expiries.
-      const first = await q.sweepExpired(T);
-      expect(store.find((r) => r.id === "junk-lease")).toBeUndefined();
-      expect(releasedPending).toEqual([]);
-      expect(first.commErrors).toHaveLength(0);
-      expect(first.reclaimed).toBe(0);
-      expect(first.expiredPending).toBe(1);
-
-      // Sweep 2: nothing left to act on — the phases composed in ONE sweep
-      // instead of sweep 1 promising a re-run sweep 2 silently revokes.
-      const second = await q.sweepExpired(T);
-      expect(second.commErrors).toHaveLength(0);
-      expect(second.expiredPending).toBe(0);
-      expect(second.reclaimed).toBe(0);
-    });
-
-    it("a LONG-expired lease on a stale-aged row is claim-DELETED in the lease phase — never re-queued with a 'back in flight' signal the next sweep falsifies (G1d)", async () => {
-      // CROSS-SWEEP FALSIFICATION: a row whose lease expired BEYOND the
-      // family's stale window is past every protection the re-queue path
-      // offers — the per-call grace evaporates with the call, and the stale
-      // phase's recent-lease heuristic only covers leases expired WITHIN the
-      // window. Re-queueing it emits worker-reclaimed-pending ("back in
-      // flight"), and the NEXT sweep claim-deletes the very row that signal
-      // promised was re-running — the dashboard permanently shows
-      // "re-queued" for silently-discarded work. If the row is ALREADY
-      // stale-expirable (created-age past the window AND lease expired
-      // longer than the window), delete it claim-first like the stale phase
-      // — no comm error (the work is being discarded, not re-run).
+    it("RECLAIM-WINS (layer a): a stale-aged long-expired orphan below the reclaim cap is RE-QUEUED (not dropped) — the abrupt-bounce floor", async () => {
+      // RED→GREEN PROOF (proposal §5). A worker died mid-sweep leaving an
+      // in-flight (running) row whose lease expired LONGER than the family's
+      // stale window AND whose created-age is past that window. TODAY (the
+      // long-expired carve-out G1d, pre-fix) this row is claim-DELETED:
+      // reclaimed=0, expiredPending=1, the work silently dropped. AFTER the
+      // fix reclaim WINS until MAX_RECLAIM_ATTEMPTS: the orphan is re-queued
+      // to pending (reclaimed=1, expiredPending=0), its reclaim_count bumped
+      // and requeued_at stamped, so it RE-RUNS. The honesty bind is dissolved
+      // by requeued_at (see the next-sweep test below), so the "back in
+      // flight" comm error is honest.
       const longDead: CreatedJobRow = {
         ...jobView({
           id: "long-dead",
@@ -3057,66 +3087,116 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
         }),
         payload: samplePayload({ probeKey: "d6:a" }),
         created: new Date(T - 8 * HOUR).toISOString(), // stale-aged
+        // Never reclaimed before — below the cap.
+        reclaim_count: 0,
       };
-      // CONTRAST: a recently-expired lease (1min ago) on an equally
-      // stale-aged row keeps today's re-queue + comm-error path — the
-      // recent-lease heuristic protects it across sweeps.
-      const recentDead: CreatedJobRow = {
-        ...jobView({
-          id: "recent-dead",
-          probe_key: "d6:b",
-          status: "running",
-          claimed_by: "worker-dead",
-          lease_expires_at: new Date(T - MIN).toISOString(),
-        }),
-        payload: samplePayload({ probeKey: "d6:b" }),
-        created: new Date(T - 4 * HOUR).toISOString(),
-      };
-      const { pb, store } = makePagingPb([longDead, recentDead]);
-      const releasedPending: string[] = [];
-      const claim: JobClaimClient = {
-        // CAS-faithful claim: admits pending rows AND claimed/running rows
-        // whose lease has expired (the hook's reclaim safety net — the
-        // lease-phase delete claims a long-dead claimed/running row).
-        async claimJob(jobId, workerId): Promise<ClaimResult> {
-          const r = store.find((x) => x.id === jobId);
-          if (!r) return { won: false };
-          const reclaimable =
-            r.status === "pending" ||
-            (["claimed", "running"].includes(r.status) &&
-              leaseExpired(r.lease_expires_at, T));
-          if (!reclaimable) return { won: false };
-          r.status = "claimed";
-          r.claimed_by = workerId;
-          r.version += 1;
-          return { won: true, job: { ...r } };
-        },
-        renewLease: vi.fn(
-          async (): Promise<RenewResult> => ({ renewed: false }),
-        ),
-        async releaseJob(jobId, workerId, status): Promise<ReleaseResult> {
-          const r = store.find((x) => x.id === jobId);
-          if (!r || r.claimed_by !== workerId) return { released: false };
-          if (status === "pending") releasedPending.push(jobId);
-          r.status = status;
-          r.claimed_by = "";
-          r.version += 1;
-          return { released: true, job: { ...r } };
-        },
-      };
+      const { pb, store } = makePagingPb([longDead]);
+      const sink = { releasedPending: [] as string[] };
+      const claim = makeReclaimClaim(store, T, sink);
       const q = createFleetQueueClient({ pb, claim, logger });
 
       const sweep = await q.sweepExpired(T);
 
-      // The long-dead row was DELETED (no re-queue, no comm error, not
-      // counted as reclaimed) and counted with the stale expiries.
-      expect(store.find((r) => r.id === "long-dead")).toBeUndefined();
-      expect(releasedPending).not.toContain("long-dead");
-      expect(sweep.commErrors.map((e) => e.jobId)).toEqual(["recent-dead"]);
+      // RE-CLAIMED, not dropped: the row survives as pending and re-runs.
+      const row = store.find((r) => r.id === "long-dead");
+      expect(row).toBeDefined();
+      expect(row?.status).toBe("pending");
+      expect(sink.releasedPending).toContain("long-dead");
+      // Telemetry flips: the orphan is reclaimed, NOT expired-deleted.
       expect(sweep.reclaimed).toBe(1);
+      expect(sweep.expiredPending).toBe(0);
+      // Honest "back in flight" gray, attributed to the dead holder.
+      expect(sweep.commErrors).toHaveLength(1);
+      expect(sweep.commErrors[0].kind).toBe("worker-reclaimed-pending");
+      expect(sweep.commErrors[0].jobId).toBe("long-dead");
+      // The reclaim tally was bumped and the stale-age clock re-anchored.
+      expect(row?.reclaim_count).toBe(1);
+      expect(row?.requeued_at).toBe(new Date(T).toISOString());
+    });
+
+    it("ATTEMPT CAP (layer a): a stale-aged long-expired orphan AT MAX_RECLAIM_ATTEMPTS is claim-DELETED — a poison job cannot re-queue forever", async () => {
+      // The reclaim-wins inversion is bounded: a row that has already been
+      // reclaimed MAX_RECLAIM_ATTEMPTS times and STILL re-orphaned (it crashes
+      // the worker every run) falls through to the carve-out delete — no
+      // re-queue, no comm error, counted with the stale expiries — so the
+      // queue cannot loop on a genuinely poison job.
+      const poison: CreatedJobRow = {
+        ...jobView({
+          id: "poison",
+          probe_key: "d6:a",
+          status: "running",
+          claimed_by: "worker-dead",
+          lease_expires_at: new Date(T - 4 * HOUR).toISOString(),
+        }),
+        payload: samplePayload({ probeKey: "d6:a" }),
+        created: new Date(T - 8 * HOUR).toISOString(),
+        // Already at the cap.
+        reclaim_count: MAX_RECLAIM_ATTEMPTS,
+      };
+      const { pb, store } = makePagingPb([poison]);
+      const sink = { releasedPending: [] as string[] };
+      const claim = makeReclaimClaim(store, T, sink);
+      const q = createFleetQueueClient({ pb, claim, logger });
+
+      const sweep = await q.sweepExpired(T);
+
+      // DELETED (terminal): no re-queue, no comm error, counted as expired.
+      expect(store.find((r) => r.id === "poison")).toBeUndefined();
+      expect(sink.releasedPending).not.toContain("poison");
+      expect(sweep.commErrors).toHaveLength(0);
+      expect(sweep.reclaimed).toBe(0);
       expect(sweep.expiredPending).toBe(1);
-      // The recently-expired row took today's path: re-queued to pending.
-      expect(store.find((r) => r.id === "recent-dead")?.status).toBe("pending");
+      expect(logger.warn).toHaveBeenCalledWith(
+        "queue-client.sweep-lease-stale-deleted",
+        expect.objectContaining({
+          jobId: "poison",
+          reclaimAttempts: MAX_RECLAIM_ATTEMPTS,
+        }),
+      );
+    });
+
+    it("HONESTY BIND DISSOLVED (layer a): the sweep AFTER a reclaim does NOT falsify the 'back in flight' signal — requeued_at re-anchors the stale-age clock", async () => {
+      // The carve-out USED to delete-rather-than-reclaim precisely because the
+      // NEXT sweep would age a re-queued row off its renewal-immune `created`
+      // and claim-delete it — falsifying the just-emitted "back in flight"
+      // gray. With requeued_at the next sweep ages the row off its RE-QUEUE
+      // time: still pending, still stale by `created`, but YOUNG by
+      // requeued_at, so drainStalePending SKIPS it (no delete). The signal
+      // holds. Sweep 1 reclaims; sweep 2 (a stale-window later) must NOT
+      // delete the still-pending row.
+      const longDead: CreatedJobRow = {
+        ...jobView({
+          id: "long-dead",
+          probe_key: "d6:a",
+          status: "running",
+          claimed_by: "worker-dead",
+          lease_expires_at: new Date(T - 4 * HOUR).toISOString(),
+        }),
+        payload: samplePayload({ probeKey: "d6:a" }),
+        created: new Date(T - 8 * HOUR).toISOString(),
+        reclaim_count: 0,
+      };
+      const { pb, store } = makePagingPb([longDead]);
+      const sink = { releasedPending: [] as string[] };
+      const claim = makeReclaimClaim(store, T, sink);
+      const q = createFleetQueueClient({ pb, claim, logger });
+
+      // Sweep 1 at T: reclaim to pending, requeued_at = T.
+      const sweep1 = await q.sweepExpired(T);
+      expect(sweep1.reclaimed).toBe(1);
+      expect(sweep1.expiredPending).toBe(0);
+      const afterReclaim = store.find((r) => r.id === "long-dead");
+      expect(afterReclaim?.status).toBe("pending");
+      expect(afterReclaim?.requeued_at).toBe(new Date(T).toISOString());
+
+      // Sweep 2 a stale-window later (T + 1min): the row is STILL pending and
+      // STILL stale by its 8h-old `created`, but requeued_at = T makes it only
+      // 1min old by the re-anchor — far inside the 3h window — so it is NOT
+      // claim-deleted. The "back in flight" signal from sweep 1 stands.
+      const T2 = T + MIN;
+      const sweep2 = await q.sweepExpired(T2);
+      expect(store.find((r) => r.id === "long-dead")?.status).toBe("pending");
+      expect(sweep2.expiredPending).toBe(0);
     });
 
     it("a release that THROWS after committing server-side still graces the row AND synthesizes its comm error (timeout-after-commit)", async () => {

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -154,10 +154,17 @@ export const RESULT_WRITE_RETRY_DELAY_MS = 250;
  * an abrupt worker bounce (SIGKILL past grace / OOM / crash) is non-LOSSY. At
  * or above the cap the row is treated as terminally expired (claim-deleted, no
  * re-run) so a poison job that crashes the worker every run cannot re-queue
- * forever. The per-job tally is the durable `reclaim_count` column the
- * fleet-claim release CAS already bumps on every pending re-queue (and the
- * claim CAS bumps on every expired-lease steal) — so the cap survives the
- * last-write-wins overwrite of `result` without a second counter.
+ * forever.
+ *
+ * The counter is `consecutive_orphan_count` — the number of CONSECUTIVE
+ * re-orphans of THIS job (i.e. sweeper re-queues that were never followed by
+ * a terminal done/failed). It is bumped ONLY by the sweeper re-queue path
+ * (fleet-claim release CAS with target "pending") and reset to 0 on every
+ * terminal release (done|failed) or fresh claim. It is NOT bumped by the
+ * peer-worker expired-lease steal (claim CAS `wasExpiredSteal` branch), so a
+ * healthy long-lived job that accrues peer steals does NOT consume its reclaim
+ * budget. The lifetime steal+requeue tally remains the separate `reclaim_count`
+ * column (dashboard diagnostic).
  *
  * Exported so the cap test pins THIS constant rather than a magic number that
  * could drift from the implementation (mirrors RESULT_WRITE_MAX_ATTEMPTS).
@@ -328,10 +335,17 @@ interface ProbeJobRecord extends JobView {
    * retry-idempotency guard before any rewrite. */
   result?: unknown;
   result_processed?: boolean;
-  /** Durable per-job reclaim tally (migration 1779990200) — bumped by the
-   * fleet-claim CAS on every expired-lease steal AND every sweeper re-queue.
-   * Read here as the reclaim ATTEMPT count for the MAX_RECLAIM_ATTEMPTS cap. */
+  /** Durable per-job lifetime reclaim tally (migration 1779990200) — bumped by
+   * the fleet-claim CAS on every expired-lease steal AND every sweeper re-queue.
+   * Dashboard diagnostic: `reclaim_count > 0` → `jobs.reclaimed`. Never reset. */
   reclaim_count?: number;
+  /** CONSECUTIVE re-orphan counter (migration 1779990400) — bumped ONLY by the
+   * sweeper re-queue path (fleet-claim release CAS, target "pending"); reset to
+   * 0 on every terminal release (done|failed). NOT bumped by the claim CAS's
+   * expired-lease steal, so a healthy long-lived job that accrues peer steals
+   * does NOT exhaust the MAX_RECLAIM_ATTEMPTS budget. This is what the reaper
+   * uses for the cap check. */
+  consecutive_orphan_count?: number;
   /** Re-anchor timestamp (migration 1779990300) — stamped by the fleet-claim
    * release CAS on every pending re-queue. Re-anchors the stale-age clock so a
    * just-reclaimed row is NOT immediately claim-deleted off its (renewal-immune)
@@ -1810,7 +1824,7 @@ export function createFleetQueueClient(
     // long-expired carve-out to delete-rather-than-re-queue a stale-aged row:
     // re-queueing now emits a "back in flight" signal the next sweep HONORS.
     // The carve-out (G1d, below) therefore no longer deletes on the FIRST
-    // expired sweep — it RE-CLAIMS until `reclaim_count` reaches
+    // expired sweep — it RE-CLAIMS until `consecutive_orphan_count` reaches
     // MAX_RECLAIM_ATTEMPTS, only then claim-deleting a row that keeps
     // re-orphaning (a poison job) so the queue cannot loop forever. The
     // lease-based RECENT-LEASE heuristic in drainStalePending is retained as a
@@ -1888,7 +1902,7 @@ export function createFleetQueueClient(
       // it has been reclaimed, else `created`) past its family's window AND
       // its lease expired LONGER than that window — used to be claim-DELETED
       // here, dropping orphaned in-flight work on an abrupt worker bounce. It
-      // is now RE-CLAIMED to pending (the path below) until its `reclaim_count`
+      // is now RE-CLAIMED to pending (the path below) until its `consecutive_orphan_count`
       // reaches MAX_RECLAIM_ATTEMPTS, so a bounce is NON-LOSSY (the work
       // re-runs; idempotent probes make at-least-once safe). The honesty bind
       // the original carve-out dodged — re-queueing a `created`-stale row emits
@@ -1918,10 +1932,13 @@ export function createFleetQueueClient(
           (!Number.isFinite(leaseMs) || leaseMs <= nowMs - maxAgeMs);
         // RECLAIM-WINS-UNTIL-CAP: only delete a stale-expirable row once it
         // has exhausted its reclaim budget; below the cap it falls through to
-        // the re-queue path (reclaim WINS over the carve-out). `reclaim_count`
-        // is the durable per-job tally the fleet-claim CAS bumps on every
-        // reclaim (absent → 0 for a pre-migration row, i.e. never reclaimed).
-        const reclaimAttempts = row.reclaim_count ?? 0;
+        // the re-queue path (reclaim WINS over the carve-out).
+        // `consecutive_orphan_count` is the CONSECUTIVE re-orphan tally —
+        // bumped ONLY by the sweeper re-queue path and reset on terminal
+        // done|failed — so a healthy long-lived job that accrues peer steals
+        // (expired-lease claim steals) does NOT exhaust its budget (absent → 0
+        // for pre-migration rows, i.e. no consecutive orphans yet).
+        const reclaimAttempts = row.consecutive_orphan_count ?? 0;
         if (staleExpirable && reclaimAttempts >= MAX_RECLAIM_ATTEMPTS) {
           // PER-ROW containment mirrors the stale phase: a thrown claim is
           // indeterminate (skip this sweep; the row is unchanged for the

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -147,6 +147,24 @@ export const RESULT_WRITE_MAX_ATTEMPTS = 3;
 export const RESULT_WRITE_RETRY_DELAY_MS = 250;
 
 /**
+ * Max times the reaper RE-CLAIMS an orphaned in-flight (claimed/running) row
+ * whose lease has lapsed and whose created-age is past its family's stale
+ * window. Below the cap, reclaim WINS over the long-expired carve-out (G1d):
+ * the row is re-queued to pending and re-run rather than silently deleted, so
+ * an abrupt worker bounce (SIGKILL past grace / OOM / crash) is non-LOSSY. At
+ * or above the cap the row is treated as terminally expired (claim-deleted, no
+ * re-run) so a poison job that crashes the worker every run cannot re-queue
+ * forever. The per-job tally is the durable `reclaim_count` column the
+ * fleet-claim release CAS already bumps on every pending re-queue (and the
+ * claim CAS bumps on every expired-lease steal) — so the cap survives the
+ * last-write-wins overwrite of `result` without a second counter.
+ *
+ * Exported so the cap test pins THIS constant rather than a magic number that
+ * could drift from the implementation (mirrors RESULT_WRITE_MAX_ATTEMPTS).
+ */
+export const MAX_RECLAIM_ATTEMPTS = 3;
+
+/**
  * Default multiple of a family's production period after which an unclaimed
  * pending job is STALE (its family has enqueued ~3 fresher batches since; the
  * job's eventual result would be ancient data). Tunable via
@@ -302,12 +320,23 @@ interface ProbeJobRecord extends JobView {
   /** The serialized per-service work (migration 1779989500 adds this column). */
   payload?: unknown;
   /** PB system timestamp (space-separated date form) — the stale-pending
-   * sweep's age anchor. */
+   * sweep's age anchor when the row has NEVER been reclaimed (no
+   * `requeued_at`). A re-queue does NOT touch `created`, so a reclaimed row's
+   * age is anchored on `requeued_at` instead (see `staleAgeAnchorMs`). */
   created?: string;
   /** Result-flow columns (migration 1779989700) — read by report()'s
    * retry-idempotency guard before any rewrite. */
   result?: unknown;
   result_processed?: boolean;
+  /** Durable per-job reclaim tally (migration 1779990200) — bumped by the
+   * fleet-claim CAS on every expired-lease steal AND every sweeper re-queue.
+   * Read here as the reclaim ATTEMPT count for the MAX_RECLAIM_ATTEMPTS cap. */
+  reclaim_count?: number;
+  /** Re-anchor timestamp (migration 1779990300) — stamped by the fleet-claim
+   * release CAS on every pending re-queue. Re-anchors the stale-age clock so a
+   * just-reclaimed row is NOT immediately claim-deleted off its (renewal-immune)
+   * `created` age, dissolving the long-expired carve-out's honesty bind. */
+  requeued_at?: string;
 }
 
 /**
@@ -588,6 +617,38 @@ export function leaseExpired(
   const t = Date.parse(String(leaseExpiresAt).replace(PB_DATE_SEP_RE, "$1T"));
   if (Number.isNaN(t)) return true;
   return t <= nowMs;
+}
+
+/**
+ * Parse a PB date column (space-separated form) to epoch ms, anchored exactly
+ * like `leaseExpired` so the stale-age math agrees with the lease math. Returns
+ * NaN for a null/empty/unparseable value — the caller decides what NaN means
+ * (the stale-pending drain SKIPS such a row; the lease-phase carve-out treats
+ * an unparseable `created` as a no-carve-out conservative re-queue).
+ */
+function pbDateMs(value: string | null | undefined): number {
+  return Date.parse(String(value ?? "").replace(PB_DATE_SEP_RE, "$1T"));
+}
+
+/**
+ * The stale-age anchor for a probe-jobs row, in epoch ms. A re-queue does NOT
+ * touch PB's renewal-immune `created`, so a reclaimed row carries a
+ * `requeued_at` stamped by the release CAS — age it off THAT (its effective
+ * "back in flight" time) so the next sweep does not measure a just-reclaimed
+ * row against its ORIGINAL enqueue time and immediately claim-delete it. This
+ * re-anchoring is what dissolves the long-expired carve-out's honesty bind:
+ * the row is genuinely young again, so re-queueing it emits a "back in flight"
+ * signal the next sweep does NOT falsify. Falls back to `created` for a row
+ * that has never been reclaimed (absent `requeued_at`), preserving pre-migration
+ * row parity. Returns NaN only when BOTH anchors are unparseable.
+ */
+function staleAgeAnchorMs(row: {
+  created?: string;
+  requeued_at?: string;
+}): number {
+  const requeuedMs = pbDateMs(row.requeued_at);
+  if (!Number.isNaN(requeuedMs)) return requeuedMs;
+  return pbDateMs(row.created);
 }
 
 /**
@@ -1738,25 +1799,22 @@ export function createFleetQueueClient(
     // states and filter by lease in-process.
     //
     // ONE SWEEP OF GRACE: rows the lease phase re-queues below are tracked
-    // and EXCLUDED from this call's stale-pending phase. The stale phase
-    // ages off PB's system `created` (the ORIGINAL enqueue time — re-queue
-    // does not touch it), so a long-claimed job would otherwise be re-queued
-    // ("back in flight" per the worker-reclaimed-pending comm error) and
-    // then immediately claimed-and-deleted by the SAME call — falsifying the
-    // comm error and nulling downstream aggregate-key resolution on the
-    // deleted row. ACROSS calls the protection is split by HOW LONG the
-    // lease has been expired: a RECENTLY-expired lease (within the stale
-    // window) is re-queued, and the stale phase's RECENT-LEASE heuristic
-    // (see drainStalePending) protects it on later sweeps — the release
-    // hook retains the expired lease on re-queue, so a recently-in-flight
-    // row is not expired off its original `created` age by the NEXT sweep.
-    // A lease expired LONGER than the stale window on a stale-aged row is
-    // PAST that heuristic's reach: re-queueing it would emit a "back in
-    // flight" signal the NEXT sweep falsifies by claim-deleting the row —
-    // so the lease phase claim-deletes it DIRECTLY (G1d), with no comm
-    // error (the work is discarded, not re-run). (Re-anchoring the age to
-    // the re-queue time would need a column; the retained lease is the
-    // schema-free approximation.)
+    // and EXCLUDED from this call's stale-pending phase (the in-process
+    // same-call protection). ACROSS calls the protection is the `requeued_at`
+    // RE-ANCHOR: the release CAS stamps `requeued_at = now` on every pending
+    // re-queue, and BOTH the stale phases (this lease-phase carve-out and
+    // drainStalePending) age off `staleAgeAnchorMs` = `requeued_at ?? created`.
+    // So a re-queued row is measured from its re-queue time — genuinely young
+    // again — and the NEXT sweep does NOT claim-delete it off its renewal-immune
+    // `created` age. This DISSOLVES the old honesty bind that forced the
+    // long-expired carve-out to delete-rather-than-re-queue a stale-aged row:
+    // re-queueing now emits a "back in flight" signal the next sweep HONORS.
+    // The carve-out (G1d, below) therefore no longer deletes on the FIRST
+    // expired sweep — it RE-CLAIMS until `reclaim_count` reaches
+    // MAX_RECLAIM_ATTEMPTS, only then claim-deleting a row that keeps
+    // re-orphaning (a poison job) so the queue cannot loop forever. The
+    // lease-based RECENT-LEASE heuristic in drainStalePending is retained as a
+    // SECONDARY guard for pre-migration rows that lack `requeued_at`.
     //
     // MASS-CRASH PAGING: with >CLAIM_CANDIDATE_PAGE claimed/running rows
     // (mass worker crash), an UNSORTED single page left the contents to PB's
@@ -1825,43 +1883,46 @@ export function createFleetQueueClient(
       // ownership, and the special-case + comm-error attribution below must
       // reflect who HELD the expired lease, not the post-release row.
       const holder = row.claimed_by;
-      // LONG-EXPIRED CARVE-OUT (G1d): a row that is ALREADY
-      // stale-expirable — created-age past its family's stale window AND
-      // its lease expired LONGER than that window — is past the
-      // recent-lease heuristic's protection (see the header). Re-queueing
-      // it would emit a "back in flight" comm error the NEXT sweep
-      // falsifies by claim-deleting the row off its original `created`
-      // age. Delete it HERE, claim-first like the stale phase (the claim
-      // CAS admits an expired-lease claimed/running row — its reclaim
-      // safety net — so the delete stays race-free). No comm error and no
-      // reclaimed++: the work is discarded, not re-run. The carve-out
-      // requires a PARSEABLE created — an unparseable created stays on
-      // the conservative re-queue path below, and that COMPOSES honestly:
-      // the stale phase skips unparseable-created rows too, so the
-      // re-queued row stays claimable and "back in flight" stays true. An
-      // UNPARSEABLE (or empty) lease is the opposite: it carries no
-      // recent-flight evidence EITHER phase can honor — the stale phase's
-      // recent-lease protection needs a finite lease — so re-queueing
-      // would emit a "back in flight" signal the next sweep falsifies by
-      // claim-deleting the row off its stale created age. Treat it as
-      // long-expired and delete it HERE, so the emitted signal (none)
-      // matches the eventual outcome (discard). Sweeper-held rows
-      // (stale garbage mid-deletion, 60s lease) are always RECENTLY
-      // expired, so they keep their silent re-queue retry contract.
+      // LONG-EXPIRED CARVE-OUT (G1d), INVERTED to RECLAIM-WINS (§4.2): a row
+      // that is stale-expirable — its STALE-AGE (anchored on `requeued_at` if
+      // it has been reclaimed, else `created`) past its family's window AND
+      // its lease expired LONGER than that window — used to be claim-DELETED
+      // here, dropping orphaned in-flight work on an abrupt worker bounce. It
+      // is now RE-CLAIMED to pending (the path below) until its `reclaim_count`
+      // reaches MAX_RECLAIM_ATTEMPTS, so a bounce is NON-LOSSY (the work
+      // re-runs; idempotent probes make at-least-once safe). The honesty bind
+      // the original carve-out dodged — re-queueing a `created`-stale row emits
+      // a "back in flight" signal the NEXT sweep falsifies by claim-deleting it
+      // off its renewal-immune `created` age — is DISSOLVED by `requeued_at`:
+      // the release CAS re-anchors the stale-age clock on re-queue, so the
+      // next sweep measures the row from its re-queue time (genuinely young
+      // again) and does NOT delete it. The carve-out fires ONLY at the
+      // attempt cap: a row reclaimed MAX_RECLAIM_ATTEMPTS times that is STILL
+      // stale-expirable (a poison job that re-orphans every run) is deleted
+      // claim-first like the stale phase (the claim CAS admits an expired-lease
+      // claimed/running row — its reclaim safety net — so the delete stays
+      // race-free), with no comm error and no reclaimed++ (the work is
+      // discarded, not re-run) so it cannot re-queue forever. An UNPARSEABLE
+      // stale-age anchor stays on the conservative re-queue path below (the
+      // stale phase skips unparseable-anchor rows too, so "back in flight"
+      // stays true). Sweeper-held rows (stale garbage mid-deletion, 60s lease)
+      // keep their silent re-queue retry contract.
       if (staleExpiryPeriods > 0 && holder !== STALE_PENDING_SWEEPER_ID) {
         const family = probeKeyFamily(row.probe_key);
         const maxAgeMs = staleExpiryPeriods * stalePeriodMsFor(family);
-        const createdMs = Date.parse(
-          String(row.created ?? "").replace(PB_DATE_SEP_RE, "$1T"),
-        );
-        const leaseMs = Date.parse(
-          String(row.lease_expires_at ?? "").replace(PB_DATE_SEP_RE, "$1T"),
-        );
+        const anchorMs = staleAgeAnchorMs(row);
+        const leaseMs = pbDateMs(row.lease_expires_at);
         const staleExpirable =
-          !Number.isNaN(createdMs) &&
-          nowMs - createdMs > maxAgeMs &&
+          !Number.isNaN(anchorMs) &&
+          nowMs - anchorMs > maxAgeMs &&
           (!Number.isFinite(leaseMs) || leaseMs <= nowMs - maxAgeMs);
-        if (staleExpirable) {
+        // RECLAIM-WINS-UNTIL-CAP: only delete a stale-expirable row once it
+        // has exhausted its reclaim budget; below the cap it falls through to
+        // the re-queue path (reclaim WINS over the carve-out). `reclaim_count`
+        // is the durable per-job tally the fleet-claim CAS bumps on every
+        // reclaim (absent → 0 for a pre-migration row, i.e. never reclaimed).
+        const reclaimAttempts = row.reclaim_count ?? 0;
+        if (staleExpirable && reclaimAttempts >= MAX_RECLAIM_ATTEMPTS) {
           // PER-ROW containment mirrors the stale phase: a thrown claim is
           // indeterminate (skip this sweep; the row is unchanged for the
           // next), a lost claim means a peer acted on the row, and a
@@ -1898,8 +1959,8 @@ export function createFleetQueueClient(
             continue;
           }
           // COUNT-NAME CAVEAT: despite the name, `expiredPending` here
-          // counts a CLAIMED/RUNNING row (long-expired lease, stale
-          // created-age) deleted by this carve-out — not just stale
+          // counts a CLAIMED/RUNNING row (long-expired lease, stale-aged)
+          // deleted by this carve-out at the reclaim cap — not just stale
           // PENDING rows from the drain phase. The shared contract doc
           // (`SweepResult.expiredPending` in contracts.ts) documents this
           // lease-phase carve-out explicitly — the two sides agree.
@@ -1910,6 +1971,7 @@ export function createFleetQueueClient(
             family,
             workerId: holder,
             maxAgeMs,
+            reclaimAttempts,
           });
           continue;
         }
@@ -2123,47 +2185,40 @@ export function createFleetQueueClient(
             logger.debug("queue-client.sweep-stale-grace", { jobId: row.id });
             continue;
           }
-          // Age off PB's system `created` (space-separated date form —
-          // normalize with the SAME anchored rewrite as leaseExpired). Unlike
-          // the lease path, an unparseable value is conservatively SKIPPED:
-          // delete is destructive, and "never wedge the queue" doesn't apply —
-          // a pending row is claimable regardless.
-          const createdMs = Date.parse(
-            String(row.created ?? "").replace(PB_DATE_SEP_RE, "$1T"),
-          );
-          if (Number.isNaN(createdMs)) {
+          // Age off the STALE-AGE ANCHOR (`requeued_at` if the row has been
+          // reclaimed, else PB's system `created`) — the SAME anchored rewrite
+          // as leaseExpired. Unlike the lease path, an unparseable anchor is
+          // conservatively SKIPPED: delete is destructive, and "never wedge the
+          // queue" doesn't apply — a pending row is claimable regardless.
+          const anchorMs = staleAgeAnchorMs(row);
+          if (Number.isNaN(anchorMs)) {
             logger.warn("queue-client.sweep-stale-unparseable-created", {
               jobId: row.id,
               created: row.created ?? null,
+              requeuedAt: row.requeued_at ?? null,
             });
             continue;
           }
           const family = probeKeyFamily(row.probe_key);
           const maxAgeMs = staleExpiryPeriods * stalePeriodMsFor(family);
-          const ageMs = nowMs - createdMs;
+          const ageMs = nowMs - anchorMs;
           if (ageMs <= maxAgeMs) continue;
-          // RECENT-LEASE HEURISTIC (no schema change): the age above is
-          // anchored on PB `created`, which a re-queue does NOT touch — so
-          // a job that legitimately ran LONGER than its family's STALE
-          // WINDOW (`maxAgeMs` = expiryPeriods × the family period — 3
-          // periods by default, NOT one) comes back from the lease sweep
-          // already "stale" and would be claim-deleted by the NEXT sweep
-          // before any plausible re-run (the dashboard then permanently
-          // shows "re-queued" for silently-discarded work). The release
-          // hook RETAINS the expired lease_expires_at on a pending
-          // re-queue, so a PARSEABLE lease within that stale window means
-          // the row was IN FLIGHT recently and its `created`-based age is
-          // stale evidence — skip it; it expires normally once a full
-          // stale window passes with no re-claim. (A `requeued_at` column
-          // would be exact; the retained lease is the schema-free
-          // approximation.) Tradeoff: a sweeper-claimed row whose delete
-          // failed also carries a recent (60s) lease after its silent
-          // re-queue, so stale GARBAGE can linger up to one extra stale
-          // window before the retry delete — harmless, and the
+          // RECENT-LEASE HEURISTIC (secondary, retained): the PRIMARY age
+          // re-anchor is `requeued_at` (above) — a job re-queued by the lease
+          // sweep gets its stale-age clock reset, so it is YOUNG again and the
+          // `ageMs <= maxAgeMs` check above already skips it (this is what
+          // dissolves the carve-out's honesty bind). This lease-based heuristic
+          // stays as a secondary guard for the cross-call window of a
+          // PRE-MIGRATION row (no `requeued_at`) whose retained expired lease is
+          // its only "recently in flight" evidence: a PARSEABLE lease within the
+          // stale window means the row was in flight recently and its
+          // `created`-based age is stale evidence — skip it; it expires normally
+          // once a full stale window passes with no re-claim. Tradeoff: a
+          // sweeper-claimed row whose delete failed also carries a recent (60s)
+          // lease after its silent re-queue, so stale GARBAGE can linger up to
+          // one extra stale window before the retry delete — harmless, and the
           // self-healing contract still holds.
-          const leaseMs = Date.parse(
-            String(row.lease_expires_at ?? "").replace(PB_DATE_SEP_RE, "$1T"),
-          );
+          const leaseMs = pbDateMs(row.lease_expires_at);
           if (Number.isFinite(leaseMs) && leaseMs > nowMs - maxAgeMs) {
             logger.debug("queue-client.sweep-stale-recent-lease-skip", {
               jobId: row.id,

--- a/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
+++ b/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
@@ -478,6 +478,13 @@ routerAdd(
           // stays untouched (null until a TERMINAL release): a re-queued job
           // has not finished.
           rec.set("reclaim_count", (rec.get("reclaim_count") || 0) + 1);
+          // RECLAIMABLE-LEASES re-anchor (§4.2, layer a): stamp the re-queue
+          // time so the queue-client's stale-age math ages this row off
+          // `requeued_at` (not the renewal-immune `created`). This re-anchor is
+          // what lets the lease-phase carve-out RE-CLAIM a stale-aged orphan
+          // instead of claim-deleting it: the next sweep measures the row as
+          // young again, so its "back in flight" signal is not falsified.
+          rec.set("requeued_at", new Date().toISOString());
         } else {
           // Run-metadata (§4.2): terminal release (done|failed) stamps the
           // finish time so run duration (finished_at − claimed_at) is readable

--- a/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
+++ b/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
@@ -474,10 +474,21 @@ routerAdd(
           rec.set("claimed_by", "");
           // Run-metadata (§4.2): the sweeper re-queue is the second reclaim
           // choke point (the first is the claim CAS's expired-lease steal) —
-          // bump the durable per-job reclaim tally. finished_at deliberately
-          // stays untouched (null until a TERMINAL release): a re-queued job
-          // has not finished.
+          // bump the durable per-job lifetime reclaim tally. finished_at
+          // deliberately stays untouched (null until a TERMINAL release): a
+          // re-queued job has not finished.
           rec.set("reclaim_count", (rec.get("reclaim_count") || 0) + 1);
+          // CONSECUTIVE-ORPHAN CAP (§4.2, reclaimable-leases): bump the
+          // per-job CONSECUTIVE re-orphan counter — distinct from the lifetime
+          // `reclaim_count`. The sweeper re-queue path is the ONLY writer; the
+          // claim CAS's expired-lease steal does NOT bump this counter, so a
+          // healthy long-lived job that accrues peer steals does NOT exhaust
+          // the MAX_RECLAIM_ATTEMPTS budget. The queue-client reads this field
+          // (not `reclaim_count`) for the deletion gate.
+          rec.set(
+            "consecutive_orphan_count",
+            (rec.get("consecutive_orphan_count") || 0) + 1,
+          );
           // RECLAIMABLE-LEASES re-anchor (§4.2, layer a): stamp the re-queue
           // time so the queue-client's stale-age math ages this row off
           // `requeued_at` (not the renewal-immune `created`). This re-anchor is
@@ -490,6 +501,11 @@ routerAdd(
           // finish time so run duration (finished_at − claimed_at) is readable
           // without parsing the `result` JSON.
           rec.set("finished_at", new Date().toISOString());
+          // CONSECUTIVE-ORPHAN CAP: reset the consecutive counter on every
+          // terminal release so that a LATER re-orphan of this job starts with
+          // a fresh budget. The lifetime `reclaim_count` is NOT reset — it
+          // remains as the dashboard diagnostic for "this job was ever reclaimed".
+          rec.set("consecutive_orphan_count", 0);
         }
         rec.set("version", (rec.get("version") || 0) + 1);
         txDao.saveRecord(rec);

--- a/showcase/pocketbase/pb_migrations/1779990300_probe_jobs_add_requeued_at.js
+++ b/showcase/pocketbase/pb_migrations/1779990300_probe_jobs_add_requeued_at.js
@@ -1,0 +1,63 @@
+/// <reference path="../pb_data/types.d.ts" />
+//
+// Reclaimable-leases re-anchor column on the pull-queue row (worker
+// reclamation, layer a — proposal §4.1).
+//
+//   - requeued_at (date, nullable): stamped by the fleet-claim.pb.js RELEASE
+//                   CAS on EVERY pending re-queue (the sweeper reclaiming an
+//                   expired-lease orphan back to claimable). It re-anchors the
+//                   stale-age clock so the queue-client's reaper ages a
+//                   reclaimed row off `requeued_at` instead of the
+//                   renewal-immune system `created`. That dissolves the old
+//                   long-expired carve-out's honesty bind (re-queueing a
+//                   `created`-stale row used to emit a "back in flight" signal
+//                   the next sweep falsified by claim-deleting it), letting the
+//                   carve-out RE-CLAIM an orphaned in-flight row up to
+//                   MAX_RECLAIM_ATTEMPTS (driven by the existing reclaim_count
+//                   column, migration 1779990200) instead of dropping it.
+//
+// Nullable with NO backfill: a pre-migration / never-reclaimed row has an
+// absent `requeued_at`, which the reaper's `staleAgeAnchorMs` falls back to
+// `created` for — pre-migration row parity. Stamping in the PB hook (not the
+// worker) keeps a ZERO worker-code dependency: the hook is the single
+// transactional choke point all releases already pass through (§8 rollout).
+//
+// Additive + idempotent: the presence-check makes a re-run after a partial
+// apply a no-op (mirrors 1779990200_probe_jobs_add_run_metadata.js). The down
+// migration drops the field but leaves the collection.
+migrate(
+  (db) => {
+    const dao = new Dao(db);
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("probe_jobs");
+    } catch (e) {
+      // Base collection not present yet (S0 create runs first, lower prefix).
+      // No-op rather than a hard failure.
+      return;
+    }
+    if (!c.schema.getFieldByName("requeued_at")) {
+      c.schema.addField(
+        new SchemaField({
+          name: "requeued_at",
+          type: "date",
+        }),
+      );
+      dao.saveCollection(c);
+    }
+  },
+  (db) => {
+    const dao = new Dao(db);
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("probe_jobs");
+    } catch (e) {
+      return;
+    }
+    const f = c.schema.getFieldByName("requeued_at");
+    if (f) {
+      c.schema.removeField(f.id);
+      dao.saveCollection(c);
+    }
+  },
+);

--- a/showcase/pocketbase/pb_migrations/1779990400_probe_jobs_add_consecutive_orphan_count.js
+++ b/showcase/pocketbase/pb_migrations/1779990400_probe_jobs_add_consecutive_orphan_count.js
@@ -1,0 +1,66 @@
+/// <reference path="../pb_data/types.d.ts" />
+//
+// Consecutive-orphan counter column on the pull-queue row (reclaimable-leases
+// cap fix, P1-A).
+//
+//   - consecutive_orphan_count (number, nullable): the number of CONSECUTIVE
+//                   sweeper re-queues that have NOT been followed by a terminal
+//                   done|failed release. Bumped ONLY by the fleet-claim.pb.js
+//                   RELEASE CAS on a pending re-queue (the sweeper reclaim
+//                   path); reset to 0 on every terminal release (done|failed).
+//                   NOT bumped by the claim CAS's expired-lease steal branch.
+//
+// WHY A SEPARATE COLUMN: the existing `reclaim_count` column is a LIFETIME
+// tally (dashboard diagnostic: `reclaim_count > 0` → `jobs.reclaimed`). Using
+// it for the MAX_RECLAIM_ATTEMPTS cap means a healthy long-lived job that
+// accrues benign peer steals over its lifetime can exhaust its 3-budget, so a
+// LATER unrelated orphan of that job gets claim-DELETED instead of reclaimed.
+// `consecutive_orphan_count` scopes the budget to CONSECUTIVE re-orphans so
+// only a poison job (re-orphans every run without ever completing) hits the
+// cap, while `reclaim_count` is left as the intact lifetime diagnostic.
+//
+// Nullable with NO backfill: a pre-migration row has an absent field, which
+// the reaper treats as 0 consecutive orphans (never re-orphaned under the new
+// semantics → conservative re-queue, not delete). Stamping in the PB hook
+// (not the worker) keeps a ZERO worker-code dependency (§8 rollout ordering).
+//
+// Additive + idempotent: the presence-check makes a re-run after a partial
+// apply a no-op (mirrors 1779990200_probe_jobs_add_run_metadata.js). The down
+// migration drops the field but leaves the collection.
+migrate(
+  (db) => {
+    const dao = new Dao(db);
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("probe_jobs");
+    } catch {
+      // Base collection not present yet (S0 create runs first, lower prefix).
+      // No-op rather than a hard failure.
+      return;
+    }
+    if (!c.schema.getFieldByName("consecutive_orphan_count")) {
+      c.schema.addField(
+        new SchemaField({
+          name: "consecutive_orphan_count",
+          type: "number",
+          options: { min: 0 },
+        }),
+      );
+      dao.saveCollection(c);
+    }
+  },
+  (db) => {
+    const dao = new Dao(db);
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("probe_jobs");
+    } catch {
+      return;
+    }
+    const f = c.schema.getFieldByName("consecutive_orphan_count");
+    if (f) {
+      c.schema.removeField(f.id);
+      dao.saveCollection(c);
+    }
+  },
+);


### PR DESCRIPTION
## What
Replaces the queue reaper's delete-wins behavior for stale long-expired orphaned in-flight rows with **reclaim-wins-until-cap**: an orphaned row is re-queued (not deleted) up to a bounded number of CONSECUTIVE re-orphans before final claim-delete. This is layer (a) of the worker-reclamation + graceful-rollover redesign — it makes a worker bounce mid-column non-lossy (the column's in-flight work is reclaimed by surviving workers instead of dropped).

## How
- **Reclaim-wins-until-cap** in `runSweepExpired` (`showcase/harness/src/fleet/queue-client.ts`): stale long-expired orphaned in-flight rows are re-queued; the prior delete-wins carve-out is inverted.
- **Consecutive-orphan budget** (`consecutive_orphan_count`, migration `1779990400`): the reclaim cap (`MAX_RECLAIM_ATTEMPTS=3`) is scoped to *consecutive* sweeper re-orphans — incremented only on the sweeper re-queue path, **reset to 0 on terminal `done`/`failed`**. Peer-worker expired-lease *steals* bump the lifetime `reclaim_count` (retained as a dashboard diagnostic) but do NOT consume the reclaim budget.
- **Stale-age re-anchoring** (`requeued_at ?? created`, migration `1779990300`): a reclaimed row's staleness clock restarts so it isn't immediately re-expired.

## Review
7-agent CR + 7-agent confirmation round → **0 P0 / 0 P1**. Highlights:
- **Red-green GENUINE (empirically re-verified):** P1-A — a long-lived job with lifetime `reclaim_count=3` but `consecutive_orphan_count=0` is RE-QUEUED on a fresh orphan (pre-fix: wrongly deleted); P1-B — low boundary at `MAX-1=2` re-queues, mutation-killed. Both non-tautological (the test fake bumps `consecutive_orphan_count` only on reclaim, never on steal; a dedicated pin test confirms steals don't consume budget).
- **No regression / terminates / fails-safe:** 248/248 tests, tsc + oxlint clean; reclaim loop terminates at 3 consecutive orphans → claim-delete; queue cannot grow unbounded; SweepResult metrics + `reclaim_count` dashboard consumers (run-view `jobs.reclaimed`, family-silence) unbroken.
- **Migration `1779990400`** additive, nullable, default-0; pre-migration rows evaluate to 0 → safe re-queue path.

## Follow-on (not in this PR)
- Layer (b) graceful worker drain and layer (c) rolling restart are the remaining phases of the redesign — see the Notion proposal: https://app.notion.com/p/38b3aa381852817bacf5c9cda1f11cc0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
