### PR TITLE
feat(showcase): deploy rollover (overlap/draining) config-as-code + test cleanups (reclamation layer c)

### DIFF
--- a/showcase/RAILWAY.md
+++ b/showcase/RAILWAY.md
@@ -318,6 +318,12 @@ live staged config now reads `6` in both envs.
 - `workerProvisioning.{prod,staging}.HARNESS_POOL_COUNT` — INFORMATIONAL ONLY;
   records what the `HARNESS_POOL_COUNT` env var is set to on Railway for audit
   visibility. Never use this as a worker count or fork factor.
+- `workerProvisioning.{prod,staging}.overlapSeconds` — deploy-rollover capacity
+  floor (= Railway `serviceInstance.overlapSeconds`, env mirror
+  `RAILWAY_DEPLOYMENT_OVERLAP_SECONDS`). See **Deploy rollover** below.
+- `workerProvisioning.{prod,staging}.drainingSeconds` — graceful-drain window
+  (= Railway `serviceInstance.drainingSeconds`, env mirror
+  `RAILWAY_DEPLOYMENT_DRAINING_SECONDS`). See **Deploy rollover** below.
 
 ### Applying a replica count change (MANUAL)
 
@@ -337,6 +343,72 @@ counts to Railway. To change the replica count:
 The CI drift gate (`showcase/scripts/__tests__/harness-workers-provisioning.test.ts`)
 will fail if `railway-envs.ts` and `railway-envs.generated.json` disagree on
 `effectiveReplicas`, catching a forgotten regeneration step.
+
+### Deploy rollover (overlap + draining)
+
+A `harness-workers` redeploy is the moment the staleness dip + cut-short worker
+drains used to happen. Two Railway service settings — **pure config, no custom
+rolling-restart code** — make a rollover non-lossy (no dip) and let the shipped
+graceful worker drain finish. Both are tracked in the SSOT
+(`workerProvisioning.{prod,staging}.overlapSeconds` / `.drainingSeconds`) and
+guarded by the same drift gate as the replica count.
+
+| Setting           | Railway field (env mirror)                                                | Value | What it does                                                                                                                                                                                   |
+| ----------------- | ------------------------------------------------------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `overlapSeconds`  | `serviceInstance.overlapSeconds` (`RAILWAY_DEPLOYMENT_OVERLAP_SECONDS`)   | `45`  | Capacity floor: keep the OLD deployment serving for 45s after the NEW one goes Active, so the live worker count never dips while new workers boot, register on the roster, and start claiming. |
+| `drainingSeconds` | `serviceInstance.drainingSeconds` (`RAILWAY_DEPLOYMENT_DRAINING_SECONDS`) | `180` | Graceful-drain window: the SIGTERM→SIGKILL budget the platform grants a draining worker before hard-killing it.                                                                                |
+
+**Rationale.**
+
+- **`overlapSeconds = 45`** holds the capacity floor: a new worker is not useful
+  the instant its container is Active — it must boot, register its roster row,
+  and start claiming. Overlapping the old deployment for 45s bridges that window
+  so there is no observable staleness dip during a rollover.
+- **`drainingSeconds = 180`** is set to `PLATFORM_STOP_GRACE_MS` (180s, defined
+  in `showcase/harness/src/fleet/worker/worker-loop.ts`) so the shipped composed
+  worker-drain budget fits under the platform kill: `DRAIN_DEREGISTER_TIMEOUT_MS`
+  (3s roster-delete cap) + `DEFAULT_WORKER_DRAIN_GRACE_MS` (90s finish-and-report
+  grace, layer b) + the small serial teardown remainder, all `< 180s`. The
+  Railway default is `0s` (the field is `null` → `0`, confirmed via the live
+  config read) — i.e. an effectively immediate SIGKILL after SIGTERM, which would
+  cut the 90s drain short and abandon the in-flight cell; at 180s the worker
+  finishes and reports its in-flight cell instead.
+  Keep this `≥ PLATFORM_STOP_GRACE_MS`; if the layer-(b) grace is retuned, raise
+  this in lockstep (the composed-budget test in `worker-loop.test.ts` is the
+  source of truth for the relation).
+
+**Composition with the drain layers** (full rationale in the
+`PLATFORM_STOP_GRACE_MS` / `DEFAULT_WORKER_DRAIN_GRACE_MS` docs in
+`worker-loop.ts`):
+
+- **Layer (a)** — reaper backstop: a worker that genuinely overruns the 90s grace
+  is abandoned; its lease lapses and the control-plane sweeper re-queues the cell
+  neutral-gray. `drainingSeconds` does not change this — it is the long-tail
+  fallback.
+- **Layer (b)** — graceful drain: on SIGTERM the worker STOPS CLAIMING, lets its
+  in-flight cell FINISH within the 90s grace, and REPORTS its real terminal
+  result. `drainingSeconds = 180` is the platform-side budget that lets layer (b)
+  actually complete.
+- **Layer (c)** — this config: `overlapSeconds` removes the dip; `drainingSeconds`
+  hosts the drain. No code — it is the two service settings alone.
+
+**Applying (MANUAL).** Like the replica count, the emitter/`bin/railway` tooling
+is **verify-only** for these fields. To apply or change them:
+
+1. Edit `overlapSeconds` / `drainingSeconds` in `railway-envs.ts` (SSOT) for the
+   env(s).
+2. Regenerate: `npx tsx showcase/scripts/emit-railway-envs-json.ts`, commit both
+   files.
+3. Apply to Railway manually, via EITHER:
+   - **GraphQL** — `serviceInstanceUpdate(serviceId, environmentId, input: { overlapSeconds: 45, drainingSeconds: 180 })`;
+     both fields are `Int` on `ServiceInstanceUpdateInput`.
+   - **Dashboard** — Service > Settings, the deploy **Teardown**/overlap card (or
+     set the `RAILWAY_DEPLOYMENT_OVERLAP_SECONDS` / `RAILWAY_DEPLOYMENT_DRAINING_SECONDS`
+     service variables).
+
+The CI drift gate also asserts `overlapSeconds` and `drainingSeconds` match
+between `railway-envs.ts` and `railway-envs.generated.json`, catching a forgotten
+regeneration.
 
 ## Environment IDs
 

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -3207,7 +3207,7 @@ describe("drainFleetWorker — deregister-FIRST drain ordering", () => {
     await worker.stop();
   });
 
-  it("deregisters BEFORE teardown completes, never reports the abandoned job, and latches out the post-deregister job-settle heartbeat", async () => {
+  it("deregisters BEFORE teardown completes, reports the run that settles within grace (finish-and-report), and latches out the post-deregister job-settle heartbeat", async () => {
     // Shrink the drain grace (like test A) so the assertion is insensitive to
     // the default's value and the grace detach stays fast under test.
     vi.stubEnv("WORKER_DRAIN_GRACE_MS", "200");
@@ -3260,17 +3260,24 @@ describe("drainFleetWorker — deregister-FIRST drain ordering", () => {
     await vi.waitFor(() => expect(events).toContain("roster-delete"));
     expect(events).not.toContain("teardown-complete");
 
-    // …then the wedged teardown "completes" the run GREEN. The drain signal
-    // (not stop() completion) keys the report-skip, so it is still abandoned.
+    // …then the wedged teardown "completes" the run GREEN. This release lands
+    // BEFORE the 200ms drain grace expires, so the run FINISHES under its own
+    // steam — `runAbort` never fires (worker-loop.ts:1353) — and layer (b)
+    // falls through to the finish-and-report path. This is the intended
+    // finish-and-report behavior: a drained run that settles within grace
+    // produces a usable terminal result and IS reported; only a run that
+    // overruns past grace (genuinely abandoned — see sibling test A) is left
+    // unreported. The report decision keys on `abortedWithoutResult`
+    // (grace-expiry runAbort), NOT on the drain signal.
     //
     // GRACE-RACE NOTE: with the 200ms grace stubbed above, stop() either (a)
     // observes the released run settle first, or (b) detaches at grace expiry
-    // while the release's microtasks land moments later. BOTH outcomes are
-    // safe for the assertions below: the roster delete already happened (so
-    // the roster-delete < teardown-complete ordering holds either way), the
-    // report-skip keys on the drain SIGNAL (so the green settle is never
-    // reported in either branch), and `teardown-complete` is pushed by the
-    // driver's own settle, not by stop() resolving.
+    // while the release's microtasks land moments later. BOTH outcomes report
+    // the green terminal: the released run settled within grace so `runAbort`
+    // never fired in either branch. The roster delete already happened (so the
+    // roster-delete < teardown-complete ordering holds either way), and
+    // `teardown-complete` is pushed by the driver's own settle, not by stop()
+    // resolving.
     release();
     await drainPromise;
 
@@ -3287,7 +3294,12 @@ describe("drainFleetWorker — deregister-FIRST drain ordering", () => {
     expect(events.indexOf("roster-delete")).toBeLessThan(
       events.indexOf("teardown-complete"),
     );
-    expect(reportSpy).not.toHaveBeenCalled();
+    // The released run settled GREEN within the drain grace, so layer (b)
+    // reports the real terminal (finish-and-report), mirroring the canonical
+    // worker-loop.test.ts "settles green after drain (before grace-expiry) is
+    // REPORTED" assertion.
+    expect(reportSpy).toHaveBeenCalledTimes(1);
+    expect(reportSpy.mock.calls[0]![0].result.aggregateState).toBe("green");
     // The run-settle heartbeat fired AFTER deregister was latched out: the
     // delete is the LAST roster write — no resurrection upsert follows it.
     expect(settled[settled.length - 1]).toBe("delete");

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -3642,29 +3642,33 @@ export async function verifyWorkerRegistered(deps: {
  * GRACEFUL-DRAIN STOP SEQUENCE for the fleet worker role — deregister FIRST,
  * teardown best-effort AFTER (the platform-kill hardening).
  *
- * WHY THIS ORDER: live Railway redeploys showed the platform's stop grace
- * (~10s after SIGTERM) is SHORTER than the drain grace the worker shipped
- * with (WORKER_DRAIN_GRACE_MS — grace history: 25s at the 2026-06-10 live
- * incident → an 8s interim → the composed 6s default, so the SERIAL
- * deregister-cap + grace budget fits UNDER the platform window). The
- * previous sequence
- * (`await worker.stop()`
+ * WHY THIS ORDER: live Railway redeploys (2026-06-10) showed the platform's
+ * DEFAULT stop grace (~10s after SIGTERM) is far SHORTER than the drain grace
+ * the worker needs (WORKER_DRAIN_GRACE_MS, now a 90s FINISH-AND-REPORT budget —
+ * layer b). Layer (c) fixes the platform side by raising the Railway
+ * `drainingSeconds`/`terminationGracePeriodSeconds` to PLATFORM_STOP_GRACE_MS
+ * (180s) so the SERIAL deregister-cap + grace budget fits UNDER the platform
+ * window (see PLATFORM_STOP_GRACE_MS in worker-loop.ts + showcase/RAILWAY.md).
+ * Even so, the ORDER matters: the previous sequence (`await worker.stop()`
  * → deregister) gated the <1s roster delete on slow browser-context teardown:
  * workers stuck in teardown were HARD-KILLED before deregistering, stranding
  * stale roster rows that fleet-health reclaimed red at its 180s stale mark —
- * the exact deploy red-splash the drain was built to remove. Abandon +
- * deregister take <1s; teardown is best-effort on a process that is dying
- * anyway (a SIGKILL mid-teardown is harmless once the roster row is gone).
+ * the exact deploy red-splash the drain was built to remove. The deregister
+ * takes <1s; the in-flight run's finish-and-report (and the rest of teardown)
+ * is best-effort behind it, bounded by the drain grace (a SIGKILL
+ * mid-teardown is harmless once the roster row is gone).
  *
- *   1. `worker.drain()` — SYNCHRONOUS: fires the loop's drain signal, aborting
- *      the in-flight run and recording the abandon decision
- *      (`fleet.worker.drain-requested` with the abandoned jobId). The loop's
- *      report-skip keys on the SIGNAL — not on `stop()` completing — so a run
- *      that has not begun reporting can never be reported, even if a wedged
- *      teardown later "completes" the run; its lease lapses and the sweeper
- *      re-queues it neutral-gray (unchanged abandon semantics). (A report the
- *      loop already initiated before the signal is past the abandon point and
- *      may land — it is not recorded as abandoned.)
+ *   1. `worker.drain()` — SYNCHRONOUS: fires the loop's drain signal. Layer (b)
+ *      made this signal STOP-CLAIMING-only, NOT an abandon: an in-flight run is
+ *      left to FINISH within the drain grace (`DEFAULT_WORKER_DRAIN_GRACE_MS`,
+ *      90s) and is REPORTED with its real terminal result. The run is only
+ *      abandoned if it OVERRUNS that grace — at grace-expiry `stop()` fires the
+ *      separate `runAbort` signal (the `abortedWithoutResult` discriminator),
+ *      hard-cancelling the run; that case leaves the row claimed/running, lets
+ *      the lease lapse, and lets the sweeper re-queue it neutral-gray → layer
+ *      (a) reclaim is the backstop. So `drain()` returns immediately while the
+ *      finish-and-report (or, only on overrun, the abandon) plays out inside the
+ *      grace spent by `stop()` in step 4.
  *   2. `registration.stop()` — cancel the periodic heartbeat timer so no
  *      further periodic upsert can follow the delete.
  *   3. `await registration.deregister()` — latch the handle (every later
@@ -4112,13 +4116,15 @@ export async function runWorker(
     bus: worker.bus,
     async stop(): Promise<void> {
       // DEREGISTER-FIRST GRACEFUL DRAIN — see `drainFleetWorker` for the full
-      // ordering rationale (the platform kill grace is shorter than the drain
-      // grace, so the <1s abandon + roster delete must NOT gate on slow
-      // browser-context teardown). The no-re-upsert guarantee lives in the
-      // registration HANDLE (deregister latches synchronously, and the delete
-      // is the terminal link of its write-serialization chain), so the
-      // abandoned run's eventual fire-and-forget job-settle heartbeat —
-      // which now fires AFTER the delete — is latched into a logged no-op.
+      // ordering rationale. drain() (step 1) only STOPS CLAIMING — layer (b)
+      // lets the in-flight run finish-and-report within the drain grace; the
+      // FAST work that must beat the platform kill is the <1s deregister +
+      // roster delete (step 3), which must NOT gate on slow browser-context
+      // teardown. The no-re-upsert guarantee lives in the registration HANDLE
+      // (deregister latches synchronously, and the delete is the terminal link
+      // of its write-serialization chain), so the run's eventual fire-and-forget
+      // job-settle heartbeat — which now fires AFTER the delete — is latched
+      // into a logged no-op.
       // We injected BOTH budgetSource and drivers, so fleet runWorker did NOT
       // construct its own pool — WE own it and shut it down here (last).
       await drainFleetWorker({
@@ -4204,20 +4210,24 @@ export async function bootFleet(
       // worker process dies mid-job, leaving its claimed/running row to lapse so
       // the control-plane sweeper reclaims it as a comm error — a FALSE flap on
       // every routine teardown. The drain (worker.stop() in runWorker's stop
-      // path) does NOT report a terminal result for the in-flight job: a reported
-      // partial would paint RED (terminalJobStatus maps any non-green aggregate
-      // to "failed", and the result-consumer has no neutral aggregate state). So
-      // the drain instead ABANDONS the partial — the driver suppresses its red
-      // per-cell side-emits (ctx.drainReason === "shutdown"), the loop skips
-      // queue.report, and the worker DEREGISTERS its registry row. With no row,
-      // fleet-health can't reclaim a gracefully-drained worker red at its 180s
-      // stale window; the abandoned job's claimed/running row lapses at the 300s
-      // lease expiry where the sweeper re-queues it as the neutral
-      // `worker-reclaimed-pending` (gray), accepting an up-to-lease-window re-run
-      // delay for ZERO red paint on a routine redeploy. Deregistration is THE
-      // distinction the sweep boundary cannot make on its own (an expired lease
-      // looks the same for a crash and a SIGTERM teardown): a CRASH leaves the
-      // row (→ today's red reclaim, unchanged), a graceful drain deletes it.
+      // path) STOPS CLAIMING and, per layer (b), lets the in-flight job FINISH
+      // within the drain grace (`DEFAULT_WORKER_DRAIN_GRACE_MS`, 90s) and REPORTS
+      // its real terminal result — a run that was seconds from done is not thrown
+      // away. The driver still soft-winds-down its red per-cell side-emits while
+      // draining (ctx.drainReason === "shutdown") so a redeploy never paints those
+      // intermediate reds, and the worker DEREGISTERS its registry row. The ABANDON
+      // path is now only the long tail: a job that OVERRUNS the grace is hard-cut
+      // at grace-expiry (the separate `runAbort` signal) WITHOUT a terminal result
+      // (a reported partial would paint RED — terminalJobStatus maps any non-green
+      // aggregate to "failed", and the result-consumer has no neutral aggregate
+      // state), so its claimed/running row is left to lapse at the 300s lease
+      // expiry where the sweeper re-queues it neutral `worker-reclaimed-pending`
+      // (gray) → layer (a) reclaim. With the row deregistered, fleet-health can't
+      // reclaim a gracefully-drained worker red at its 180s stale window.
+      // Deregistration is THE distinction the sweep boundary cannot make on its
+      // own (an expired lease looks the same for a crash and a SIGTERM teardown):
+      // a CRASH leaves the row (→ today's red reclaim, unchanged), a graceful
+      // drain deletes it.
       let draining = false;
       const drainAndExit = (signal: NodeJS.Signals): void => {
         if (draining) return;

--- a/showcase/harness/src/probes/loader/probe-invoker.test.ts
+++ b/showcase/harness/src/probes/loader/probe-invoker.test.ts
@@ -514,6 +514,32 @@ describe("buildProbeInvoker", () => {
     // timeout ProbeResult as soon as the AbortController fires, rather
     // than waiting for the driver's promise to settle. This is the
     // load-bearing contract: a misbehaved driver cannot stall the tick.
+    //
+    // DETERMINISM (was a wall-clock flake): the prior version measured
+    // `Date.now()` around `await invoker()` and asserted
+    // `elapsed < 100ms`, on the theory that a regression awaiting the
+    // driver's full 80ms sleep would blow past the bound. But the driver
+    // sleep (80ms) and the bound (100ms) were only 20ms apart, so on a
+    // loaded host the harness/promise-settle overhead alone pushed
+    // `elapsed` to 100-150ms and the assertion failed INTERMITTENTLY even
+    // though the timeout LOGIC was correct (the synthetic timeout result
+    // was returned and the slow driver never resolved). Real wall-clock
+    // duration is not the invariant under test.
+    //
+    // We now drive the timeout with FAKE timers and assert the BEHAVIOR
+    // directly: advance fake time to exactly the timeout boundary
+    // (timeout_ms=20) — NOT to the driver's 80ms sleep — and confirm the
+    // invoker returns a synthetic timeout `error` result WITHOUT the slow
+    // driver ever having resolved. That proves the invoker times out fast
+    // (does not await the driver) with zero dependence on real-clock
+    // overhead. The driver's 80ms timer is left pending: a regression that
+    // awaited `driverPromise` instead would never settle while only 20ms
+    // of fake time has elapsed, so `await invocation` would hang to the
+    // per-test timeout — the exact failure mode we want to catch.
+    vi.useFakeTimers();
+    onTestFinished(() => {
+      vi.useRealTimers();
+    });
     const inputSchema = z.object({ key: z.string() }).passthrough();
     let driverResolved = false;
     const driver: ProbeDriver = {
@@ -539,28 +565,27 @@ describe("buildProbeInvoker", () => {
       targets: [{ key: "smoke:ignores-abort" }],
     };
     const { writer, writes } = mkWriter();
-    const start = Date.now();
-    await buildProbeInvoker(cfg, {
+    const invocation = buildProbeInvoker(cfg, {
       driver,
       schedulerId: cfg.id,
       discoveryRegistry: createDiscoveryRegistry(),
       writer,
       ...BASE_DEPS,
     })();
-    const elapsed = Date.now() - start;
+    // Advance fake time to the timeout boundary (20ms) — well short of
+    // the driver's 80ms sleep. `advanceTimersByTimeAsync` flushes the
+    // microtask queue between timer fires so the invoker's Promise.race
+    // resolves on the timeout branch and the invocation settles
+    // deterministically.
+    await vi.advanceTimersByTimeAsync(cfg.timeout_ms!);
+    await invocation;
     expect(writes).toHaveLength(1);
     expect(writes[0]!.state).toBe("error");
-    // The invoker must return promptly on timeout — NOT wait for the
-    // driver's 80ms sleep to complete. Allow ample slack for CI jitter:
-    // we care that the invoker isn't blocking on the driver's full
-    // 80ms sleep, not that it returns inside any particular tight bound.
-    // 100ms is well under the 80ms+race-settle absolute lower bound for
-    // a regression where the invoker awaited driverPromise instead.
-    expect(elapsed).toBeLessThan(100);
-    // The slow driver has NOT fired its setTimeout callback yet at the
-    // time the invoker returned (timeout_ms=20 < driver-sleep=80), so
-    // this assertion is deterministic: we read driverResolved
-    // synchronously after `await invoker()` returns.
+    // The slow driver's 80ms timer never fired (we advanced only 20ms of
+    // fake time before the invoker returned), so its body — which sets
+    // `driverResolved = true` — never ran. This is the load-bearing
+    // invariant: the invoker returned on TIMEOUT, not by awaiting the
+    // driver's full sleep.
     expect(driverResolved).toBe(false);
   });
 

--- a/showcase/scripts/__tests__/harness-workers-provisioning.test.ts
+++ b/showcase/scripts/__tests__/harness-workers-provisioning.test.ts
@@ -90,6 +90,27 @@ describe("harness-workers provisioning SSOT", () => {
     expect(stagingProv?.BROWSER_POOL_MAX_CONTEXTS).toBe(40);
   });
 
+  it("overlapSeconds = 45 for both envs (deploy-rollover capacity floor, layer c)", () => {
+    // RAILWAY_DEPLOYMENT_OVERLAP_SECONDS — keep the old deployment serving until
+    // the new one is Active so the capacity floor holds across a rollover (no
+    // staleness dip). See showcase/RAILWAY.md "Deploy rollover".
+    const prodProv = workerProvisioningFor("harness-workers", "prod");
+    const stagingProv = workerProvisioningFor("harness-workers", "staging");
+    expect(prodProv?.overlapSeconds).toBe(45);
+    expect(stagingProv?.overlapSeconds).toBe(45);
+  });
+
+  it("drainingSeconds = 180 for both envs (graceful-drain window, ≥ PLATFORM_STOP_GRACE_MS)", () => {
+    // RAILWAY_DEPLOYMENT_DRAINING_SECONDS — the SIGTERM→SIGKILL window. Sized to
+    // host the shipped composed worker-drain budget (layer b: 3s deregister cap +
+    // 90s finish-and-report grace + teardown remainder, all < PLATFORM_STOP_GRACE_MS
+    // = 180s). See showcase/RAILWAY.md "Deploy rollover".
+    const prodProv = workerProvisioningFor("harness-workers", "prod");
+    const stagingProv = workerProvisioningFor("harness-workers", "staging");
+    expect(prodProv?.drainingSeconds).toBe(180);
+    expect(stagingProv?.drainingSeconds).toBe(180);
+  });
+
   it("HARNESS_POOL_COUNT is recorded as informational only — NOT used as a fork factor", () => {
     // The worker boots 1 process per replica (keyed on HOSTNAME). HARNESS_POOL_COUNT
     // is forwarded to each worker as a control-plane hint but NEVER forks additional
@@ -198,6 +219,66 @@ describe("harness-workers provisioning drift gate (SSOT vs generated JSON snapsh
     const ssotStaging = workerProvisioningFor("harness-workers", "staging");
     expect(ssotStaging?.BROWSER_POOL_MAX_CONTEXTS).toBe(
       snapshotEntry?.workerProvisioning?.staging?.BROWSER_POOL_MAX_CONTEXTS,
+    );
+  });
+
+  it("SSOT prod overlapSeconds matches committed generated JSON snapshot", () => {
+    const snapshot = loadGeneratedSnapshot();
+    const snapshotEntry = snapshot.services.find(
+      (s) => s.name === "harness-workers",
+    );
+    const ssotProd = workerProvisioningFor("harness-workers", "prod");
+    expect(
+      snapshotEntry?.workerProvisioning?.prod?.overlapSeconds,
+      "workerProvisioning.prod.overlapSeconds missing from generated JSON snapshot",
+    ).not.toBeUndefined();
+    expect(ssotProd?.overlapSeconds).toBe(
+      snapshotEntry?.workerProvisioning?.prod?.overlapSeconds,
+    );
+  });
+
+  it("SSOT staging overlapSeconds matches committed generated JSON snapshot", () => {
+    const snapshot = loadGeneratedSnapshot();
+    const snapshotEntry = snapshot.services.find(
+      (s) => s.name === "harness-workers",
+    );
+    const ssotStaging = workerProvisioningFor("harness-workers", "staging");
+    expect(
+      snapshotEntry?.workerProvisioning?.staging?.overlapSeconds,
+      "workerProvisioning.staging.overlapSeconds missing from generated JSON snapshot",
+    ).not.toBeUndefined();
+    expect(ssotStaging?.overlapSeconds).toBe(
+      snapshotEntry?.workerProvisioning?.staging?.overlapSeconds,
+    );
+  });
+
+  it("SSOT prod drainingSeconds matches committed generated JSON snapshot", () => {
+    const snapshot = loadGeneratedSnapshot();
+    const snapshotEntry = snapshot.services.find(
+      (s) => s.name === "harness-workers",
+    );
+    const ssotProd = workerProvisioningFor("harness-workers", "prod");
+    expect(
+      snapshotEntry?.workerProvisioning?.prod?.drainingSeconds,
+      "workerProvisioning.prod.drainingSeconds missing from generated JSON snapshot",
+    ).not.toBeUndefined();
+    expect(ssotProd?.drainingSeconds).toBe(
+      snapshotEntry?.workerProvisioning?.prod?.drainingSeconds,
+    );
+  });
+
+  it("SSOT staging drainingSeconds matches committed generated JSON snapshot", () => {
+    const snapshot = loadGeneratedSnapshot();
+    const snapshotEntry = snapshot.services.find(
+      (s) => s.name === "harness-workers",
+    );
+    const ssotStaging = workerProvisioningFor("harness-workers", "staging");
+    expect(
+      snapshotEntry?.workerProvisioning?.staging?.drainingSeconds,
+      "workerProvisioning.staging.drainingSeconds missing from generated JSON snapshot",
+    ).not.toBeUndefined();
+    expect(ssotStaging?.drainingSeconds).toBe(
+      snapshotEntry?.workerProvisioning?.staging?.drainingSeconds,
     );
   });
 });

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -160,13 +160,17 @@
           "effectiveReplicas": 6,
           "numReplicas": 6,
           "BROWSER_POOL_MAX_CONTEXTS": 40,
-          "HARNESS_POOL_COUNT": 3
+          "HARNESS_POOL_COUNT": 3,
+          "overlapSeconds": 45,
+          "drainingSeconds": 180
         },
         "staging": {
           "effectiveReplicas": 6,
           "numReplicas": 6,
           "BROWSER_POOL_MAX_CONTEXTS": 40,
-          "HARNESS_POOL_COUNT": 2
+          "HARNESS_POOL_COUNT": 2,
+          "overlapSeconds": 45,
+          "drainingSeconds": 180
         }
       }
     },

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -208,6 +208,38 @@ export interface WorkerProvisioning {
    * operational visibility / config-audit purposes.
    */
   HARNESS_POOL_COUNT?: number;
+  /**
+   * DEPLOY-ROLLOVER CAPACITY FLOOR (seconds) — the Railway
+   * `serviceInstance.overlapSeconds` setting (env mirror
+   * `RAILWAY_DEPLOYMENT_OVERLAP_SECONDS`). Railway keeps the OLD deployment
+   * serving for this many seconds after the NEW deployment goes Active, so the
+   * live worker count never dips during a rollover (no staleness dip while new
+   * workers boot, register on the roster, and start claiming). This is PURE
+   * RAILWAY CONFIG — there is no custom rolling-restart code; the mechanism is
+   * the service setting alone. Composes with the layer-(b) graceful drain
+   * (`DEFAULT_WORKER_DRAIN_GRACE_MS`) and the layer-(a) reaper backstop. See
+   * `showcase/RAILWAY.md` "Deploy rollover" for the rationale and how to apply
+   * it (GraphQL `serviceInstanceUpdate` / dashboard). DECLARE-AND-VERIFY: the
+   * tooling is verify-only with respect to this field; applying it is a manual
+   * Railway operation.
+   */
+  overlapSeconds?: number;
+  /**
+   * GRACEFUL-DRAIN WINDOW (seconds) — the Railway
+   * `serviceInstance.drainingSeconds` setting (env mirror
+   * `RAILWAY_DEPLOYMENT_DRAINING_SECONDS`): the SIGTERM→SIGKILL window the
+   * platform grants a draining worker before hard-killing it. Sized to HOST the
+   * shipped composed worker-drain budget (layer b): the 3s deregister cap
+   * (`DRAIN_DEREGISTER_TIMEOUT_MS`) + the 90s finish-and-report grace
+   * (`DEFAULT_WORKER_DRAIN_GRACE_MS`) + the small serial teardown remainder, all
+   * of which must fit under `PLATFORM_STOP_GRACE_MS` (180s). Keeping this ≥
+   * `PLATFORM_STOP_GRACE_MS` lets a worker finish and report its in-flight cell
+   * before the kill instead of having the drain cut short. PURE RAILWAY CONFIG
+   * (no custom code). See `showcase/RAILWAY.md` "Deploy rollover" + the
+   * `PLATFORM_STOP_GRACE_MS` doc in `worker-loop.ts` (the C3 requirement). If the
+   * layer-(b) grace is retuned, raise this in lockstep.
+   */
+  drainingSeconds?: number;
 }
 
 /**
@@ -705,6 +737,13 @@ export const SERVICES: Record<
         BROWSER_POOL_MAX_CONTEXTS: 40,
         // INFORMATIONAL ONLY — not a fork factor.
         HARNESS_POOL_COUNT: 3,
+        // DEPLOY ROLLOVER (layer c) — pure Railway config, no rolling-restart code.
+        // overlap=45s holds the capacity floor (old deployment serves until new
+        // workers register+claim); draining=180s ≥ PLATFORM_STOP_GRACE_MS so the
+        // 3s+90s composed worker-drain (layer b) completes before SIGKILL. See
+        // showcase/RAILWAY.md "Deploy rollover".
+        overlapSeconds: 45,
+        drainingSeconds: 180,
       },
       staging: {
         // EFFECTIVE = multiRegionConfig.us-west2.numReplicas (Railway honors this).
@@ -715,6 +754,13 @@ export const SERVICES: Record<
         // INFORMATIONAL ONLY — not a fork factor. Live staging value is 2
         // (verified via the variables read); it does not gate the worker count.
         HARNESS_POOL_COUNT: 2,
+        // DEPLOY ROLLOVER (layer c) — pure Railway config, no rolling-restart code.
+        // overlap=45s holds the capacity floor (old deployment serves until new
+        // workers register+claim); draining=180s ≥ PLATFORM_STOP_GRACE_MS so the
+        // 3s+90s composed worker-drain (layer b) completes before SIGKILL. See
+        // showcase/RAILWAY.md "Deploy rollover".
+        overlapSeconds: 45,
+        drainingSeconds: 180,
       },
     },
   },


### PR DESCRIPTION
## What

Layer (c) of the worker-reclamation redesign: **deploy rollover as Railway config-as-code** — no custom rolling-restart code. Brings the two Railway deploy-teardown knobs under SSOT so a harness-workers redeploy is **non-lossy and capacity-stable**, completing the a/b/c reclamation arc.

## The two knobs (currently `0`/unset on staging — which is exactly why deploys cause the staleness dip *and* SIGKILL-lose in-flight cells)

| Knob (`serviceInstanceUpdate` field / env var) | Effect | Target |
|---|---|---|
| **`overlapSeconds`** (`RAILWAY_DEPLOYMENT_OVERLAP_SECONDS`) — the "Teardown" card | New deployment goes Active (healthy) **before** the old is torn down → capacity overlap across all 6 replicas → **no capacity-floor drop** | **45** |
| **`drainingSeconds`** (`RAILWAY_DEPLOYMENT_DRAINING_SECONDS`) | SIGTERM→SIGKILL buffer → lets layer (b)'s 90s graceful drain finish-and-report before the kill | **180** |

Sequence: *new Active → overlap (capacity held) → SIGTERM old → drain (in-flight cell finishes+reports) → SIGKILL.* Composes with the merged layer (a) (reclaim backstop) + layer (b) (graceful drain).

## Why config, not code

Investigation (with research against Railway's docs + live GraphQL) established that **`/health` only flips Active once a worker is registered AND claiming** (`worker-health.ts` returns 200 iff `pb() && loopAlive() && registered()`; the `/health` socket binds *after* the claim loop). So `overlapSeconds` genuinely holds the capacity floor — the load-bearing promise of layer (c) — without any custom rolling-restart code. A single-worker drain (the original B-VAL plan) is **infeasible** on staging's 6-replica single-deployment topology (Railway has no per-replica primitive); the real-world operation is a full redeploy, which is what we validate.

## Changes

- **SSOT**: `overlapSeconds=45` + `drainingSeconds=180` declared for prod+staging in `railway-envs.ts`, regenerated `railway-envs.generated.json`, drift-gate extended (bites on wrong/missing values).
- **RAILWAY.md**: "Deploy rollover" section — knobs, rationale, layer a/b/c composition, GraphQL/dashboard apply instructions.
- **`orchestrator.ts`**: comments-only — corrected stale pre-layer-(b) prose ("drain abandons / never reports / 6s grace / ~10s stop") to the current finish-and-report behavior.

## Pre-existing test cleanups (flushed out while validating this)

- **Stale `orchestrator.test.ts` drain test** — layer (b) (#5743) changed drain to finish-and-report but missed this assertion (it lives outside the `src/fleet/` subset #5743's CR ran), leaving it **deterministically RED on `main`** (`expect(report).not.toHaveBeenCalled()` where report *is* called — the run finishes before grace). Flipped to the finish-and-report contract, matching the canonical `worker-loop.test.ts:2162`. The sibling abandon test (releases *after* grace) is unchanged and still passes.
- **`probe-invoker.test.ts` timing flake** — a brittle wall-clock assertion (`elapsed < 100ms`, only 20ms above the driver's sleep) flaked under load (12/15 fail). Made deterministic with fake timers + a behavioral assertion (times-out-fast invariant preserved, now stronger).

## Validation

- Config CR'd (full reviewer round, 0 P0/P1) + test-gated confirmation on the combined branch.
- Full harness suite **3209 / 0 failed**; probe-invoker **10/10** deterministic; orchestrator flip red-green proven; tsc + oxlint clean; SSOT generated.json byte-canonical.

## Pending your GO (not done in this PR)

- **Apply** `overlapSeconds=45`/`drainingSeconds=180` to staging harness-workers.
- **Validate** via a real staging redeploy: capacity floor never 0 + zero lost cells + no false family-silence alert (before/after dashboard screenshots).
- **Merge**.

## Follow-ups (non-blocking)

- `registered` is a one-shot boot flag (not re-derived from heartbeats); a PB blip during boot-verify could 503 `/health` forever — but it **fails safe** (holds the old deployment longer, never releases early).
- `showcase/scripts` emit-railway-envs-json tests need the root-declared `oxfmt` binary to run in isolation (scripts-only `npm ci` → `spawnSync ENOENT`); declare it in `scripts/package.json` or skip-with-diagnostic.

Refs the reclamation redesign Notion proposal.
