### PR TITLE
fix(showcase): verify-deploy skips probe-ineligible services per env (prod verify-prod crash)

### DIFF
--- a/showcase/scripts/__tests__/verify-deploy.test.ts
+++ b/showcase/scripts/__tests__/verify-deploy.test.ts
@@ -43,12 +43,12 @@ describe("verify-deploy argv parsing", () => {
     );
   });
 
-  it("defaults skipIneligible to false (strict mode)", () => {
+  it("defaults skipIneligible to true (skip-by-default — known-but-ineligible names are a legitimate state)", () => {
     const parsed = parseArgs(["--env", "staging"]);
-    expect(parsed.skipIneligible).toBeFalsy();
+    expect(parsed.skipIneligible).toBe(true);
   });
 
-  it("accepts --skip-ineligible (opt-in skip of probe.staging=false services)", () => {
+  it("accepts --skip-ineligible as an explicit no-op (now the default; back-compat with the staging precondition caller)", () => {
     const parsed = parseArgs([
       "--env",
       "staging",
@@ -57,6 +57,17 @@ describe("verify-deploy argv parsing", () => {
       "--skip-ineligible",
     ]);
     expect(parsed.skipIneligible).toBe(true);
+  });
+
+  it("accepts --strict-eligibility to opt OUT of skip-by-default (restore hard-refuse)", () => {
+    const parsed = parseArgs([
+      "--env",
+      "prod",
+      "--services",
+      "harness-workers",
+      "--strict-eligibility",
+    ]);
+    expect(parsed.skipIneligible).toBe(false);
   });
 
   it("rejects bare trailing --env (no following value)", () => {
@@ -125,11 +136,13 @@ describe("resolveProbeTargets", () => {
     ).toThrow(/unknown service/i);
   });
 
-  it("REFUSES a non-probe-eligible service by default (strict mode for explicit probes)", () => {
-    // Find a real SSOT service whose probe.staging===false (e.g. a
-    // starter-*). The default (strict) path must still throw the
-    // distinct "not probe-eligible" error — an operator who explicitly
-    // typed a single non-eligible service deserves a hard refusal.
+  it("REFUSES a non-probe-eligible service when skipIneligible is unset (function-level strict; CLI passes skipIneligible=true)", () => {
+    // The resolveProbeTargets PRIMITIVE stays strict when skipIneligible is
+    // not passed — an explicit caller that wants the hard refusal (or the
+    // CLI's `--strict-eligibility` opt-out) gets the distinct "not
+    // probe-eligible" error. The CLI itself now defaults skipIneligible=true
+    // (see parseArgs), so the verify-prod gate composes; this test pins the
+    // primitive's unset-flag contract, not the CLI default.
     const ineligible = Object.keys(SERVICES).find(
       (n) => SERVICES[n] !== undefined && !probeEnabled(n, "staging"),
     );
@@ -332,6 +345,32 @@ describe("runVerify driver dispatch", () => {
     expect(calls).toContain("docs");
     expect(calls).not.toContain(ineligible);
     expect(summary.exitCode).toBe(0);
+  });
+
+  it("exits 0 (nothing to probe) when EVERY requested service is known-but-ineligible (verify-prod prod-only case)", async () => {
+    // The verify-prod gate calls verify-deploy directly with the promoted
+    // set, which can be entirely probe-ineligible services (e.g. just
+    // `harness-workers`, probe.prod=false). All are skipped → zero targets,
+    // but this is an EXPECTED no-op, NOT the vacuous-green fault: exit 0 with
+    // a clear "nothing to probe" note. Distinct from the empty-filter FAIL
+    // case below (length 0 there; here length>0 + all-ineligible).
+    const ineligible = Object.keys(SERVICES).find(
+      (n) => SERVICES[n] !== undefined && !probeEnabled(n, "prod"),
+    );
+    expect(ineligible).toBeDefined();
+    let probed = false;
+    const summary = await runVerify({
+      env: "prod",
+      services: [ineligible as string],
+      skipIneligible: true,
+      runner: async () => {
+        probed = true;
+        return { ok: true };
+      },
+    });
+    expect(probed).toBe(false);
+    expect(summary.exitCode).toBe(0);
+    expect(summary.failed.length).toBe(0);
   });
 
   it("FAILS LOUD on zero resolved targets (never silently exit 0)", async () => {

--- a/showcase/scripts/verify-deploy.ts
+++ b/showcase/scripts/verify-deploy.ts
@@ -29,12 +29,19 @@ export interface ParsedArgs {
   env: EnvName;
   services?: string[];
   /**
-   * Opt-in: when a `--services` filter names a service that exists in the
-   * SSOT but is NOT probe-eligible for `--env` (`probe.<env>=false`), SKIP
-   * it with a clear status line instead of throwing. Off by default so an
-   * explicit single-service probe still hard-refuses a non-eligible name;
-   * the promote staging precondition (which probes the FULL promote set,
-   * legitimately mixing in non-eligible starters) passes this flag.
+   * When a `--services` filter names a service that exists in the SSOT but
+   * is NOT probe-eligible for `--env` (`probe.<env>=false`), SKIP it with a
+   * clear `N/A` status line instead of throwing. ON by default: a probe
+   * target set legitimately mixes in services that are deployable but not
+   * probe-eligible for the requested env (e.g. `harness-workers`, which is
+   * `probe.staging=false` AND `probe.prod=false`, and the `starter-*` fleet
+   * for staging). The verify gate probes only the eligible subset and never
+   * crashes on an ineligible-but-known name. An UNKNOWN (non-SSOT) name is
+   * STILL a hard error — a typo is a real fault, never a legitimate skip.
+   *
+   * `--strict-eligibility` flips this off, restoring the hard-refuse for any
+   * known-but-ineligible name (useful when an operator wants an explicit
+   * single-service probe to fail loud rather than no-op).
    */
   skipIneligible?: boolean;
 }
@@ -42,7 +49,13 @@ export interface ParsedArgs {
 export function parseArgs(argv: string[]): ParsedArgs {
   let envRaw: string | undefined;
   let services: string[] | undefined;
-  let skipIneligible = false;
+  // Skip-by-default: a known-but-ineligible service is a legitimate state
+  // for the probe set (see ParsedArgs.skipIneligible), not a fault. The
+  // verify-prod CI gate calls verify-deploy.ts directly with the promote
+  // target set (which can include `harness-workers`, probe.prod=false), and
+  // a hard-refuse there crashes the gate after a successful promote. Skipping
+  // ineligible names — for ANY env — is the correct, composable default.
+  let skipIneligible = true;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--env") {
@@ -89,7 +102,16 @@ export function parseArgs(argv: string[]): ParsedArgs {
         throw new Error("--services requires a CSV value");
       }
     } else if (a === "--skip-ineligible") {
+      // Now the default (see `skipIneligible` init above). Still accepted as
+      // an explicit no-op for back-compat with callers wired before the
+      // default flipped (e.g. the promote staging precondition in
+      // showcase_promote.yml passes it).
       skipIneligible = true;
+    } else if (a === "--strict-eligibility") {
+      // Opt OUT of skip-by-default: restore the hard-refuse for a
+      // known-but-ineligible name. An UNKNOWN name is a hard error on
+      // BOTH paths regardless.
+      skipIneligible = false;
     } else {
       throw new Error(`Unknown argument: ${a}`);
     }
@@ -221,11 +243,11 @@ export interface ResolveOpts {
   env: EnvName;
   services?: string[];
   /**
-   * When true, a `--services` entry that is in the SSOT but not
-   * probe-eligible for `env` (`probe.<env>=false`) is SKIPPED (with a
-   * status line) rather than throwing. Unknown (non-SSOT) names are STILL
-   * a hard error — a typo is a real fault, not a legitimate skip. See
-   * `ParsedArgs.skipIneligible`.
+   * When true (the default — see `ParsedArgs.skipIneligible`), a
+   * `--services` entry that is in the SSOT but not probe-eligible for `env`
+   * (`probe.<env>=false`) is SKIPPED (with an `N/A` status line) rather than
+   * throwing. Unknown (non-SSOT) names are STILL a hard error — a typo is a
+   * real fault, not a legitimate skip.
    */
   skipIneligible?: boolean;
   /**
@@ -244,14 +266,15 @@ export function resolveProbeTargets(opts: ResolveOpts): ProbeTarget[] {
   // for the target env must surface as a clear, distinct error, not a
   // silent zero-targets vacuous green.
   //
-  // EXCEPTION (opts.skipIneligible): the promote staging precondition
-  // probes the FULL promote set (service=all), which legitimately mixes
-  // in services that are promotable but NOT probe-eligible for staging
-  // (the starter-* fleet carries probe.staging=false in the SSOT). For
-  // that caller a non-eligible service is an expected state, not a fault,
-  // so SKIP it (with a clear status line) instead of crashing the gate.
-  // An UNKNOWN (non-SSOT) name stays a hard error on BOTH paths — a typo
-  // is a real fault, never a legitimate skip.
+  // DEFAULT (opts.skipIneligible, on unless `--strict-eligibility`): a
+  // probe target set legitimately mixes in services that are deployable but
+  // NOT probe-eligible for the requested env — the verify-prod gate probes
+  // the promoted set (which can include `harness-workers`, probe.prod=false),
+  // and the staging precondition probes the FULL promote set (the starter-*
+  // fleet carries probe.staging=false). For those callers a non-eligible
+  // service is an expected state, not a fault, so SKIP it (with a clear `N/A`
+  // status line) instead of crashing the gate. An UNKNOWN (non-SSOT) name
+  // stays a hard error on BOTH paths — a typo is a real fault, never a skip.
   if (filter) {
     for (const name of filter) {
       const entry = SERVICES[name];
@@ -263,7 +286,7 @@ export function resolveProbeTargets(opts: ResolveOpts): ProbeTarget[] {
       if (!probeEnabled(name, opts.env)) {
         if (opts.skipIneligible) {
           process.stdout.write(
-            `  ${name.padEnd(36)} (skipped — not probe-eligible for ${opts.env}, probe.${opts.env}=false)\n`,
+            `  ${name.padEnd(36)} N/A — not probe-eligible for env ${opts.env} (probe.${opts.env}=false in SSOT), skipped\n`,
           );
           continue;
         }
@@ -325,11 +348,31 @@ export async function runVerify(opts: VerifyOpts): Promise<VerifySummary> {
   const passed: Array<{ name: string }> = [];
   const failed: Array<{ name: string; error: string }> = [];
 
-  // Zero-targets is NEVER a success. A verify gate that prints
-  // "targets=0" and exits 0 is the worst outcome — a vacuous green.
-  // Fail loud with a clear diagnostic so the operator knows the run
-  // verified nothing.
+  // Zero-targets is normally NEVER a success — a verify gate that prints
+  // "targets=0" and exits 0 is the worst outcome, a vacuous green — so it
+  // fails loud.
+  //
+  // EXCEPTION: when an explicit `--services` filter was supplied and EVERY
+  // named service is known-but-not-probe-eligible for this env (so they were
+  // all legitimately skipped under skipIneligible), there is genuinely
+  // nothing to probe. That is the verify-prod case when the promoted set is
+  // entirely probe-ineligible services (e.g. just `harness-workers`): the
+  // ineligible names were already validated as known in resolveProbeTargets,
+  // so this is an expected no-op, not a fault. Exit 0 with a clear note.
   if (targets.length === 0) {
+    const allRequestedIneligible =
+      opts.skipIneligible === true &&
+      opts.services !== undefined &&
+      opts.services.length > 0 &&
+      opts.services.every((name) => !probeEnabled(name, opts.env));
+    if (allRequestedIneligible) {
+      process.stdout.write(
+        `verify-deploy --env=${opts.env} targets=0 — ` +
+          `nothing to probe (all requested services are not probe-eligible ` +
+          `for env ${opts.env}, skipped)\n`,
+      );
+      return { env: opts.env, passed, failed, exitCode: 0 };
+    }
     const error =
       `no probe-required services resolved for env "${opts.env}" — ` +
       `check --services and SSOT probe flags`;


### PR DESCRIPTION
## The crash

Promote CI run [28333317081](https://github.com/CopilotKit/CopilotKit/actions/runs/28333317081) PROMOTED llamaindex into prod successfully, but the `verify-prod` job then crashed:

```
verify-deploy crashed: service "harness-workers" is not probe-eligible for env "prod" (probe.prod=false in SSOT)
```

exit 2 → the whole run was marked failed even though the promote itself succeeded.

`verify-prod` runs `npx tsx verify-deploy.ts --env prod --services "<promoted set>"`. That set includes `harness-workers`, which is intentionally `probe.prod=false` (and `probe.staging=false`) in the SSOT. `verify-deploy.ts` HARD-ERRORED (exit 2) on any `--services` entry that wasn't probe-eligible for the target env.

Sibling fix #5752 fixed the **staging** path by passing an opt-in `--skip-ineligible` flag from the promote staging precondition. But the `verify-prod` job calls `verify-deploy.ts` **directly without that flag**, so the prod path still crashed.

## The fix

Generalize the eligibility filter into `verify-deploy.ts` itself instead of relying on each caller to remember a flag:

- `parseArgs` now defaults `skipIneligible` to **true** (skip-by-default). A known-but-not-probe-eligible service for the requested env is SKIPPED with an `N/A — not probe-eligible for env <env> (probe.<env>=false in SSOT), skipped` status line, and only the eligible subset is probed. Works for **any** `--env`, so it composes with #5752's staging path and fixes the direct prod-verify call — no workflow change needed.
- When **every** requested service is ineligible (e.g. the promoted set is just `harness-workers`), `runVerify` exits **0** with a clear "nothing to probe" note, distinct from the empty-filter vacuous-green fault (which still fails loud).
- **Unknown (non-SSOT) names STILL hard-error** on every path — a typo is a real fault, never a legitimate skip.
- Added `--strict-eligibility` to opt back into the old hard-refuse for an explicit single-service probe. `--skip-ineligible` is kept as an explicit no-op for back-compat with the #5752 staging-precondition caller.

This completes #5752 for the prod path.

## Red → green (real surface, `showcase/scripts`)

**RED** (before):
```
$ npx tsx verify-deploy.ts --env prod --services harness-workers
verify-deploy crashed: service "harness-workers" is not probe-eligible for env "prod" (probe.prod=false in SSOT)
EXIT=2
```

**GREEN** (after):
```
$ npx tsx verify-deploy.ts --env prod --services harness-workers
  harness-workers                      N/A — not probe-eligible for env prod (probe.prod=false in SSOT), skipped
verify-deploy --env=prod targets=0 — nothing to probe (all requested services are not probe-eligible for env prod, skipped)
EXIT=0
```

**Regression — eligible service still probed and red-gated:**
```
$ npx tsx verify-deploy.ts --env prod --services harness-workers,showcase-llamaindex
  harness-workers                      N/A — not probe-eligible for env prod (probe.prod=false in SSOT), skipped
verify-deploy --env=prod targets=1
  showcase-llamaindex                  showcase-llamaindex-production.up.railway.app FAIL: agent: Railway GraphQL errors [...]: Not Authorized
1 service(s) failed verify in prod
```
`harness-workers` is skipped; `showcase-llamaindex` is resolved (`targets=1`) and the live probe **runs** (reaches the Railway GraphQL call). It reports red here only because the local env has **no `RAILWAY_TOKEN`** ("Not Authorized") — that live-probe step is env-blocked locally, but it proves the eligible service is still probed and gates red, not silently skipped. `showcase-llamaindex` alone behaves identically (`targets=1`, probe runs).

**Guards preserved:**
```
$ npx tsx verify-deploy.ts --env prod --services harness-workers --strict-eligibility
verify-deploy crashed: service "harness-workers" is not probe-eligible for env "prod" ...  (exit 2)

$ npx tsx verify-deploy.ts --env prod --services bogus-typo
verify-deploy crashed: unknown service "bogus-typo" (not in SSOT). ...  (exit 2)
```

## Tests

`npx vitest run __tests__/verify-deploy.test.ts` → **37 passed**. Updated the default-flag assertions, added `--strict-eligibility` parse coverage, and added a runVerify test for the all-ineligible "nothing to probe" exit-0 path. (4 pre-existing `emit-railway-envs-json.test.ts` failures are an unrelated `oxfmt` tooling issue — confirmed failing on clean `origin/main` without this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)