### PR TITLE
fix(showcase/railway): promote re-asserts SSOT replica config so redeploy doesn't de-scale harness-workers to 1

### DIFF
--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -814,27 +814,15 @@ module Railway
             }
         GQL
 
-        # Variant of UPDATE_IMAGE_MUTATION that ALSO re-asserts the SSOT
-        # healthcheckPath alongside source.image. Railway's
-        # ServiceInstanceUpdateInput accepts healthcheckPath next to source (see
-        # deploy-to-railway.ts / provision-starter-fleet.ts, which set it via the
-        # same mutation), and treats an absent input key as "leave as-is" — so a
-        # partial update of {source, healthcheckPath} is safe.
-        #
-        # CRITICAL: this variant is used ONLY when the SSOT declares a path for
-        # the target service+env. When the SSOT has NO path (a live-null
-        # service), the caller uses the plain UPDATE_IMAGE_MUTATION above so the
-        # `healthcheckPath` key is OMITTED entirely — we MUST NOT send
-        # `healthcheckPath: null`, which would actively CLEAR it on Railway.
-        UPDATE_IMAGE_AND_HEALTHCHECK_MUTATION = <<~GQL
-            mutation UpdateImage($serviceId: String!, $envId: String!, $image: String!, $healthcheckPath: String!) {
-                serviceInstanceUpdate(
-                    serviceId: $serviceId
-                    environmentId: $envId
-                    input: { source: { image: $image }, healthcheckPath: $healthcheckPath }
-                )
-            }
-        GQL
+        # NOTE: the {source, healthcheckPath} variant that re-asserts the SSOT
+        # healthcheckPath alongside source.image is now produced dynamically by
+        # `build_update_image_mutation` (below), which composes source.image with
+        # any subset of the optional SSOT-tracked keys (healthcheckPath,
+        # multiRegionConfig). Railway's ServiceInstanceUpdateInput accepts those
+        # keys next to source (see deploy-to-railway.ts / provision-starter-fleet.ts,
+        # which set them via the same mutation) and treats an ABSENT input key as
+        # "leave as-is" — the builder omits any key whose SSOT value is absent so
+        # we NEVER send an explicit null (which would CLEAR the field on Railway).
 
         # serviceInstanceDeployV2 spawns a NEW deployment that pulls the current
         # source.image (just advanced by UPDATE_IMAGE_MUTATION) and returns the
@@ -847,6 +835,58 @@ module Railway
                 )
             }
         GQL
+
+        # Build a serviceInstanceUpdate mutation + vars that ALWAYS pins
+        # source.image and OPTIONALLY re-asserts SSOT-tracked fields alongside
+        # it. This replaces the old static {image} / {image,healthcheckPath}
+        # heredocs: adding a second optional dimension (multiRegionConfig) would
+        # otherwise explode into a 4-way matrix of constants. Each optional key
+        # is OMITTED entirely when its arg is absent — we NEVER send an explicit
+        # null (which Railway treats as "clear this field"), so a service that
+        # tracks none of these keeps its live config untouched.
+        #
+        #   healthcheck_path:  SSOT healthcheckPath (the aimock silent-null fix).
+        #                      nil/empty -> omitted (a live-null service stays null).
+        #   replica_config:    SSOT multiRegionConfig as { region => numReplicas },
+        #                      e.g. { "us-west2" => 6 } for harness-workers (the
+        #                      de-scale fix). nil/empty -> omitted. When present,
+        #                      sent as multiRegionConfig: { region => { numReplicas } }
+        #                      so the redeploy preserves the intended scale instead
+        #                      of falling back to Railway's default single region
+        #                      at 1 replica.
+        #
+        # Returns [mutation_string, vars_hash].
+        def self.build_update_image_mutation(image:, healthcheck_path: nil, replica_config: nil)
+            decls   = ["$serviceId: String!", "$envId: String!", "$image: String!"]
+            inputs  = ["source: { image: $image }"]
+            vars    = { image: image }
+
+            unless healthcheck_path.nil? || healthcheck_path.to_s.empty?
+                decls  << "$healthcheckPath: String!"
+                inputs << "healthcheckPath: $healthcheckPath"
+                vars[:healthcheckPath] = healthcheck_path
+            end
+
+            unless replica_config.nil? || replica_config.empty?
+                decls  << "$multiRegionConfig: ServiceMultiRegionConfigInput!"
+                inputs << "multiRegionConfig: $multiRegionConfig"
+                # Railway's multiRegionConfig is { <region> => { numReplicas } }.
+                vars[:multiRegionConfig] = replica_config.each_with_object({}) do |(region, n), acc|
+                    acc[region] = { numReplicas: n }
+                end
+            end
+
+            mutation = <<~GQL
+                mutation UpdateImage(#{decls.join(', ')}) {
+                    serviceInstanceUpdate(
+                        serviceId: $serviceId
+                        environmentId: $envId
+                        input: { #{inputs.join(', ')} }
+                    )
+                }
+            GQL
+            [mutation, vars]
+        end
 
         # Helper used by RestoreCommand, PinCommand: pin then deploy a NEW
         # deployment that pulls the updated source.image.
@@ -1159,11 +1199,22 @@ module Railway
         # service+env, or nil when the SSOT tracks NONE. When present, the pin
         # mutation RE-ASSERTS it alongside source.image so a prod instance whose
         # healthcheckPath silently went null (the aimock incident) self-heals to
-        # the tracked value on the next promote. When nil, the plain
-        # image-only mutation is used and the `healthcheckPath` key is OMITTED
-        # entirely — we NEVER send `healthcheckPath: null` (which would actively
-        # CLEAR it). This is the durable lever the SSOT-tracking change adds.
-        def self.pin_and_verify(gql, service_id:, env_id:, image:, healthcheck_path: nil, sleeper: ->(n) { sleep(n) })
+        # the tracked value on the next promote. When nil, the `healthcheckPath`
+        # key is OMITTED entirely — we NEVER send `healthcheckPath: null` (which
+        # would actively CLEAR it). This is the durable lever the SSOT-tracking
+        # change adds.
+        #
+        # `replica_config:` — the SSOT-declared multiRegionConfig replica map for
+        # this service+env as { region => numReplicas } (e.g. { "us-west2" => 6 }
+        # for harness-workers), or nil when the SSOT tracks NO replica override.
+        # When present, the pin mutation RE-ASSERTS multiRegionConfig alongside
+        # source.image so the subsequent serviceInstanceDeployV2 preserves the
+        # intended scale. Without it, a promote that updates only source.image
+        # lets Railway fall back to its default single region (us-west1) at 1
+        # replica on redeploy — the confirmed harness-workers -> 1 de-scale
+        # incident. When nil/empty, the key is OMITTED (never sent as null), so a
+        # service without an override keeps its live config untouched.
+        def self.pin_and_verify(gql, service_id:, env_id:, image:, healthcheck_path: nil, replica_config: nil, sleeper: ->(n) { sleep(n) })
             # Upfront guard: this method's contract is to pin a DIGEST-form
             # image. Pre-fix, a stray tag ref would fall through to retries
             # (since expected_digest stayed nil and image_ok was always false)
@@ -1184,18 +1235,16 @@ module Railway
             pre_inst = pre_data && pre_data["serviceInstance"]
             pre_update_ts = pre_inst && pre_inst["updatedAt"]
 
-            # Re-assert the SSOT healthcheckPath alongside source.image ONLY when
-            # the SSOT declares one. A nil/empty path uses the image-only
-            # mutation so the healthcheckPath key is OMITTED (never sent as
-            # null, which would clear it) — a live-null service stays null.
-            if healthcheck_path.nil? || healthcheck_path.to_s.empty?
-                updated = gql.query(RestoreCommand::UPDATE_IMAGE_MUTATION,
-                    serviceId: service_id, envId: env_id, image: image)
-            else
-                updated = gql.query(RestoreCommand::UPDATE_IMAGE_AND_HEALTHCHECK_MUTATION,
-                    serviceId: service_id, envId: env_id, image: image,
-                    healthcheckPath: healthcheck_path)
-            end
+            # Re-assert the SSOT-tracked healthcheckPath AND multiRegionConfig
+            # replica count alongside source.image, each ONLY when the SSOT
+            # declares it. The builder omits any absent key entirely (never sends
+            # an explicit null, which Railway would treat as "clear this field"),
+            # so a service tracking neither keeps its live config untouched.
+            mutation, vars = RestoreCommand.build_update_image_mutation(
+                image: image, healthcheck_path: healthcheck_path,
+                replica_config: replica_config)
+            updated = gql.query(mutation,
+                { serviceId: service_id, envId: env_id }.merge(vars))
             unless updated && updated["serviceInstanceUpdate"] == true
                 raise MutationError,
                     "P5: serviceInstanceUpdate returned #{updated.inspect} (expected true) for #{service_id} -> #{image}"
@@ -2140,6 +2189,29 @@ module Railway
             (Railway::SSOT_DATA["services"] || []).find { |s| s["name"] == name }
         end
 
+        # Region key the multiRegionConfig replica override is keyed on. The
+        # only service with a replica override (harness-workers) is single-region
+        # us-west2 — Railway derives its live replica count from
+        # `multiRegionConfig.us-west2.numReplicas`. See showcase/scripts/
+        # railway-envs.ts (WorkerProvisioning) and RAILWAY.md "Effective replica
+        # count". A fixed constant here (rather than an SSOT-emitted field)
+        # because the region is a stable platform invariant for this service.
+        REPLICA_REGION = "us-west2"
+
+        # SSOT-declared replica override for (service, env) as a
+        # { region => numReplicas } map, or nil when the service tracks NONE.
+        # Only `harness-workers` carries `workerProvisioning.<env>` today; every
+        # other service returns nil so pin_and_verify OMITS multiRegionConfig and
+        # leaves their live (single-replica) config untouched. The authoritative
+        # count is `effectiveReplicas` (= multiRegionConfig.<region>.numReplicas,
+        # the value Railway honors), NOT the top-level `numReplicas` mirror.
+        def ssot_replica_config(name, env)
+            replicas = (ssot_service(name) || {})
+                .dig("workerProvisioning", env, "effectiveReplicas")
+            return nil if replicas.nil?
+            { REPLICA_REGION => replicas }
+        end
+
         # Union of per-service `replicateKeys` declared in the SSOT for the
         # services being promoted (§5.3.1). EMPTY for every service today — the
         # replicate-class env-write mechanism is opt-in and copies nothing until
@@ -2381,11 +2453,20 @@ module Railway
                     # pin_and_verify then OMITS the field rather than clearing it.
                     ssot_healthcheck = (ssot_service(svc["name"]) || {})
                         .dig("healthcheckPath", "prod")
+                    # Re-assert the SSOT-tracked prod replica count on every
+                    # promote (the durable fix for the harness-workers -> 1
+                    # de-scale: a promote that updates only source.image lets
+                    # Railway fall back to its default single region at 1
+                    # replica). nil for every service WITHOUT a replica override —
+                    # pin_and_verify then OMITS multiRegionConfig rather than
+                    # touching it.
+                    ssot_replicas = ssot_replica_config(svc["name"], "prod")
                     PromoteCommand.pin_and_verify(gql,
                         service_id: pmatch["service_id"],
                         env_id: PRODUCTION_ENV_ID,
                         image: image,
-                        healthcheck_path: ssot_healthcheck)
+                        healthcheck_path: ssot_healthcheck,
+                        replica_config: ssot_replicas)
                     puts "promoted #{svc['name']} -> #{image}"
                     already_pinned << svc["name"]
                 # Broadened rescue: a transient GraphQL or network error

--- a/showcase/bin/spec/test_promote_replicas_reassert.rb
+++ b/showcase/bin/spec/test_promote_replicas_reassert.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+# Re-assertion of the SSOT multiRegionConfig replica count on the promote pin
+# (the durable fix for the harness-workers -> 1 de-scale incident). A promote
+# that issues serviceInstanceUpdate WITHOUT a multiRegionConfig key lets Railway
+# fall back to its default region (us-west1) at 1 replica on the subsequent
+# serviceInstanceDeployV2 — collapsing the staged
+# `multiRegionConfig.us-west2.numReplicas = 6`. pin_and_verify must:
+#   - INCLUDE multiRegionConfig in the serviceInstanceUpdate input when the SSOT
+#     declares a replica override for the service+env (harness-workers -> 6 in
+#     us-west2), and
+#   - OMIT it entirely (never send a multiRegionConfig key) when the SSOT tracks
+#     no replica override, so a normal single-replica service is never touched.
+class PromoteReplicasReassertTest < Minitest::Test
+    class FakeGQL
+        def initialize(plan); @plan = plan; @calls = []; end
+        attr_reader :calls
+
+        def query(q, vars = {})
+            @calls << [q, vars]
+            step = @plan.shift
+            raise "fake exhausted at call ##{@calls.size}: #{q[0, 40]}" unless step
+            raise step[:raise] if step[:raise]
+            step[:data]
+        end
+    end
+
+    NEW_DEPLOY_ID = "dep-new"
+
+    def pre(ts) = { data: { "serviceInstance" => { "id" => "i", "source" => { "image" => "ghcr.io/copilotkit/x@sha256:OLD" }, "updatedAt" => ts } } }
+    def post(image:, ts:) = { data: { "serviceInstance" => { "id" => "i", "source" => { "image" => image }, "updatedAt" => ts } } }
+    def deploy_ok(id = NEW_DEPLOY_ID) = { data: { "serviceInstanceDeployV2" => id } }
+
+    def serving(digest:, status: "SUCCESS", deploy_id: NEW_DEPLOY_ID)
+        {
+            data: {
+                "serviceInstance" => {
+                    "id" => "i",
+                    "source" => { "image" => "ghcr.io/copilotkit/x@#{digest}" },
+                    "updatedAt" => "2026-05-28T03:00:00Z",
+                    "latestDeployment" => {
+                        "id" => deploy_id, "status" => status,
+                        "meta" => { "imageDigest" => digest },
+                    },
+                },
+            },
+        }
+    end
+
+    def happy_plan
+        [
+            pre("2026-05-27T00:00:00Z"),
+            { data: { "serviceInstanceUpdate" => true } },
+            deploy_ok,
+            post(image: "ghcr.io/copilotkit/x@sha256:NEW", ts: "2026-05-28T01:00:00Z"),
+            serving(digest: "sha256:NEW"),
+        ]
+    end
+
+    # The serviceInstanceUpdate is always the 2nd GQL call (after the pre-update
+    # snapshot). Returns [query_string, vars] for that call.
+    def update_call(gql) = gql.calls[1]
+
+    def test_includes_multiregion_replicas_when_ssot_declares_override
+        gql = FakeGQL.new(happy_plan)
+        Railway::PromoteCommand.pin_and_verify(gql,
+            service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+            replica_config: { "us-west2" => 6 }, sleeper: ->(_n) {})
+
+        query, vars = update_call(gql)
+        # The mutation must DECLARE + USE a multiRegionConfig input variable, and
+        # the vars must carry the SSOT region->numReplicas map.
+        assert_match(/\$multiRegionConfig:\s*ServiceMultiRegionConfigInput/, query,
+            "update mutation should declare a multiRegionConfig variable")
+        assert_match(/multiRegionConfig:\s*\$multiRegionConfig/, query,
+            "update mutation input should set multiRegionConfig")
+        assert_equal({ "us-west2" => { numReplicas: 6 } }, vars[:multiRegionConfig],
+            "update vars should carry the SSOT region -> numReplicas map")
+    end
+
+    def test_omits_multiregion_when_ssot_has_no_override
+        gql = FakeGQL.new(happy_plan)
+        # nil replica_config == a normal service with no replica override.
+        Railway::PromoteCommand.pin_and_verify(gql,
+            service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+            replica_config: nil, sleeper: ->(_n) {})
+
+        query, vars = update_call(gql)
+        # NO multiRegionConfig anywhere — we must NEVER send a multiRegionConfig
+        # key for a service without an override (would risk clobbering config).
+        refute_match(/multiRegionConfig/, query,
+            "image-only mutation must not mention multiRegionConfig")
+        refute vars.key?(:multiRegionConfig),
+            "update vars must omit multiRegionConfig for a non-override service"
+    end
+
+    def test_empty_replica_config_is_treated_as_omitted
+        gql = FakeGQL.new(happy_plan)
+        Railway::PromoteCommand.pin_and_verify(gql,
+            service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+            replica_config: {}, sleeper: ->(_n) {})
+
+        query, vars = update_call(gql)
+        refute_match(/multiRegionConfig/, query)
+        refute vars.key?(:multiRegionConfig)
+    end
+
+    # multiRegionConfig and healthcheckPath are INDEPENDENT re-assertion
+    # dimensions: a service can declare both (harness-workers tracks /health AND
+    # 6 replicas). Both must ride in the same serviceInstanceUpdate input.
+    def test_includes_both_healthcheck_and_replicas
+        gql = FakeGQL.new(happy_plan)
+        Railway::PromoteCommand.pin_and_verify(gql,
+            service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+            healthcheck_path: "/health", replica_config: { "us-west2" => 6 },
+            sleeper: ->(_n) {})
+
+        query, vars = update_call(gql)
+        assert_match(/healthcheckPath:\s*\$healthcheckPath/, query)
+        assert_match(/multiRegionConfig:\s*\$multiRegionConfig/, query)
+        assert_equal "/health", vars[:healthcheckPath]
+        assert_equal({ "us-west2" => { numReplicas: 6 } }, vars[:multiRegionConfig])
+    end
+
+    # SSOT resolution: the promote loop pulls replica intent from the REAL SSOT
+    # (railway-envs.generated.json) via ssot_replica_config. harness-workers
+    # carries workerProvisioning.prod.effectiveReplicas=6 -> { us-west2 => 6 };
+    # every other service tracks no override -> nil (so multiRegionConfig is
+    # omitted and their live config is never touched).
+    def cmd
+        c = Railway::PromoteCommand.new(["--non-interactive", "--yes"])
+        c.parser.parse!(c.argv)
+        c
+    end
+
+    def test_ssot_resolves_harness_workers_to_six_replicas_in_us_west2
+        assert_equal({ "us-west2" => 6 },
+            cmd.ssot_replica_config("harness-workers", "prod"),
+            "harness-workers prod must resolve to 6 replicas in us-west2 from SSOT")
+    end
+
+    def test_ssot_replica_config_is_nil_for_a_non_override_service
+        # Pick any non-worker service the SSOT tracks; it must have NO override.
+        sample = (Railway::SSOT_DATA["services"] || [])
+            .map { |s| s["name"] }
+            .reject { |n| n == "harness-workers" }
+            .first
+        refute_nil sample, "expected at least one non-worker service in the SSOT"
+        assert_nil cmd.ssot_replica_config(sample, "prod"),
+            "#{sample} has no replica override -> ssot_replica_config must be nil"
+    end
+end

--- a/showcase/bin/spec/test_snapshot_ivar_lint.rb
+++ b/showcase/bin/spec/test_snapshot_ivar_lint.rb
@@ -54,33 +54,33 @@ class SnapshotIvarLintTest < Minitest::Test
     #                       prose (do not perform a read)
     ALLOWED_LINES = [
         # `run` — capture full-fleet view before optional narrowing.
-        '1447:@full_staging_snapshot = @staging_snapshot',
-        '1448:@full_prod_snapshot    = @prod_snapshot',
+        '1496:@full_staging_snapshot = @staging_snapshot',
+        '1497:@full_prod_snapshot    = @prod_snapshot',
 
         # Doc comment above narrow_snapshots_to_single_service!.
-        '1456:# Narrow @staging_snapshot and @prod_snapshot to only the named',
+        '1505:# Narrow @staging_snapshot and @prod_snapshot to only the named',
 
         # narrow_snapshots_to_single_service! — the WRITE site.
-        '1464:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1469:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
-        '1470:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1471:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
+        '1513:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1518:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
+        '1519:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1520:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
 
         # Doc comment above capture_snapshots.
-        '1475:# @staging_snapshot / @prod_snapshot directly.',
+        '1524:# @staging_snapshot / @prod_snapshot directly.',
 
         # capture_snapshots — single test-seam assignment site.
-        '1477:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
-        '1478:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
+        '1526:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
+        '1527:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
 
         # Doc comment above the accessor block (explains test seam).
-        '1502:# promote tests stub @staging_snapshot/@prod_snapshot directly',
+        '1551:# promote tests stub @staging_snapshot/@prod_snapshot directly',
 
         # The four accessor bodies — the ONLY sanctioned reads.
-        '1514:@full_staging_snapshot || @staging_snapshot',
-        '1518:@full_prod_snapshot || @prod_snapshot',
-        '1522:@staging_snapshot',
-        '1526:@prod_snapshot',
+        '1563:@full_staging_snapshot || @staging_snapshot',
+        '1567:@full_prod_snapshot || @prod_snapshot',
+        '1571:@staging_snapshot',
+        '1575:@prod_snapshot',
     ].freeze
 
     def setup


### PR DESCRIPTION
## Incident (confirmed, observed)

Running `bin/railway promote` (via `showcase_promote.yml`) **reset prod `harness-workers` (us-west) to 1 replica**. The SSOT intends **6** (`workerProvisioning.{prod,staging}.effectiveReplicas = 6`, i.e. `multiRegionConfig.us-west2.numReplicas = 6`). The fleet ran de-scaled until manually restored to 6.

## Root cause

`PromoteCommand.pin_and_verify` (`showcase/bin/railway`) promotes each service with:

1. `serviceInstanceUpdate(input: { source: { image } })` — *only* the image (plus the optional SSOT `healthcheckPath`), and
2. `serviceInstanceDeployV2` — spawns the new deployment.

Neither call carries the per-region replica config. The authoritative replica knob is **`multiRegionConfig.us-west2.numReplicas`** (documented in `showcase/scripts/railway-envs.ts` ~150-194 and `RAILWAY.md` ~278-345; the top-level `numReplicas` is only a mirror). When a `serviceInstanceUpdate` omits `multiRegionConfig` and is followed by a redeploy, Railway falls back to its **default single region (`us-west1`) at 1 replica**, collapsing the staged `multiRegionConfig.us-west2.numReplicas = 6`.

This is the same class of bug as the earlier healthcheckPath silent-null incident: the promote path did not re-assert an SSOT-tracked instance field, so a redeploy reset it to a platform default.

**Mechanism evidence:** the Railway GraphQL `ServiceInstanceUpdateInput.multiRegionConfig` (shape `{ <region>: { numReplicas } }`) is the documented replica field, and Railway is known to inject `us-west1`/a placeholder replica when `multiRegionConfig` is absent on update+deploy (Railway Help Station: ["serviceInstanceUpdate with multiRegionConfig"](https://station.railway.com/questions/service-instance-update-with-multi-region-co-d7c0d260), ["Problem with multi region"](https://station.railway.com/questions/problem-with-multi-region-44e04e90)).

> **Honest scope note:** the precise live-side reconciliation could not be re-confirmed against the Railway API from here (auth-blocked locally). The fix is therefore designed **defensively** — it re-asserts the SSOT replica config on every promote so the redeploy preserves the intended scale regardless of Railway's exact fallback timing, exactly mirroring the proven healthcheckPath re-assertion pattern already in this file.

## Fix

`showcase/bin/railway`:

- **`RestoreCommand.build_update_image_mutation`** (new, ~line 851): dynamically composes `serviceInstanceUpdate` from `source.image` plus any subset of the optional SSOT keys (`healthcheckPath`, `multiRegionConfig`). Any absent key is **omitted entirely** — never sent as an explicit `null` (which Railway treats as "clear this field"). Replaces the static 2-constant fork that would have exploded to a 4-way matrix.
- **`PromoteCommand.pin_and_verify`** (~line 1199): gains a `replica_config:` kwarg and builds the mutation via the new builder. The `@sha256:` guard and all P5/serving-digest verification are unchanged.
- **`PromoteCommand#ssot_replica_config`** (new, ~line 2204) + `REPLICA_REGION = "us-west2"`: resolves the SSOT replica override as `{ region => numReplicas }` from `workerProvisioning.<env>.effectiveReplicas`, or `nil` when the service tracks none.
- **Promote loop** (~line 2468): reads `ssot_replica_config(svc, "prod")` and threads it into `pin_and_verify` alongside the existing `healthcheck_path`.

**Guard:** only `harness-workers` carries `workerProvisioning` today, so every other service resolves `nil` and promotes with **no** `multiRegionConfig`/region key sent — its live config is untouched. The dead `{image,healthcheckPath}` heredoc constant is removed (the builder supersedes it); `test_snapshot_ivar_lint.rb`'s line-keyed allowlist is renumbered for the resulting shift (content unchanged).

## Red → green proof

New spec `showcase/bin/spec/test_promote_replicas_reassert.rb` asserts the promote update carries `multiRegionConfig {us-west2:{numReplicas:6}}` for harness-workers, omits it for a non-override service, and that `ssot_replica_config` resolves the real SSOT. (Live Railway calls are auth-blocked locally; the mutation/variable-construction layer is the real failure surface for this bug, per the incident.)

**RED — against pre-fix `bin/railway`** (the promote path has no way to carry replica config, so the mutation omits it → Railway de-scales to 1):

```
PromoteReplicasReassertTest#test_includes_both_healthcheck_and_replicas:
ArgumentError: unknown keyword: :replica_config
    bin/railway:1166:in `pin_and_verify'

PromoteReplicasReassertTest#test_ssot_resolves_harness_workers_to_six_replicas_in_us_west2:
NoMethodError: undefined method `ssot_replica_config' for #<Railway::PromoteCommand ...>

6 runs, 1 assertions, 0 failures, 6 errors, 0 skips
```

**GREEN — against the fix** (mutation vars now carry `multiRegionConfig {us-west2:{numReplicas:6}}` for harness-workers):

```
......
6 runs, 20 assertions, 0 failures, 0 errors, 0 skips
```

**Regression — full Ruby suite green** (includes the healthcheckPath re-assert test, the P6 advisory tests, and the renumbered snapshot-ivar lint):

```
183 runs, 707 assertions, 0 failures, 0 errors, 0 skips
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)