### PR TITLE
fix(showcase/railway): promote pins replicas via real ServiceInstanceUpdateInput shape (drop nonexistent ServiceMultiRegionConfigInput type)

### DIFF
--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -814,27 +814,15 @@ module Railway
             }
         GQL
 
-        # Variant of UPDATE_IMAGE_MUTATION that ALSO re-asserts the SSOT
-        # healthcheckPath alongside source.image. Railway's
-        # ServiceInstanceUpdateInput accepts healthcheckPath next to source (see
-        # deploy-to-railway.ts / provision-starter-fleet.ts, which set it via the
-        # same mutation), and treats an absent input key as "leave as-is" — so a
-        # partial update of {source, healthcheckPath} is safe.
-        #
-        # CRITICAL: this variant is used ONLY when the SSOT declares a path for
-        # the target service+env. When the SSOT has NO path (a live-null
-        # service), the caller uses the plain UPDATE_IMAGE_MUTATION above so the
-        # `healthcheckPath` key is OMITTED entirely — we MUST NOT send
-        # `healthcheckPath: null`, which would actively CLEAR it on Railway.
-        UPDATE_IMAGE_AND_HEALTHCHECK_MUTATION = <<~GQL
-            mutation UpdateImage($serviceId: String!, $envId: String!, $image: String!, $healthcheckPath: String!) {
-                serviceInstanceUpdate(
-                    serviceId: $serviceId
-                    environmentId: $envId
-                    input: { source: { image: $image }, healthcheckPath: $healthcheckPath }
-                )
-            }
-        GQL
+        # NOTE: the {source, healthcheckPath} variant that re-asserts the SSOT
+        # healthcheckPath alongside source.image is now produced dynamically by
+        # `build_update_image_mutation` (below), which composes source.image with
+        # any subset of the optional SSOT-tracked keys (healthcheckPath,
+        # multiRegionConfig). Railway's ServiceInstanceUpdateInput accepts those
+        # keys next to source (see deploy-to-railway.ts / provision-starter-fleet.ts,
+        # which set them via the same mutation) and treats an ABSENT input key as
+        # "leave as-is" — the builder omits any key whose SSOT value is absent so
+        # we NEVER send an explicit null (which would CLEAR the field on Railway).
 
         # serviceInstanceDeployV2 spawns a NEW deployment that pulls the current
         # source.image (just advanced by UPDATE_IMAGE_MUTATION) and returns the
@@ -847,6 +835,66 @@ module Railway
                 )
             }
         GQL
+
+        # Build a serviceInstanceUpdate mutation + vars that ALWAYS pins
+        # source.image and OPTIONALLY re-asserts SSOT-tracked fields alongside
+        # it. This replaces the old static {image} / {image,healthcheckPath}
+        # heredocs: adding a second optional dimension (multiRegionConfig) would
+        # otherwise explode into a 4-way matrix of constants. Each optional key
+        # is OMITTED entirely when its arg is absent — we NEVER send an explicit
+        # null (which Railway treats as "clear this field"), so a service that
+        # tracks none of these keeps its live config untouched.
+        #
+        #   healthcheck_path:  SSOT healthcheckPath (the aimock silent-null fix).
+        #                      nil/empty -> omitted (a live-null service stays null).
+        #   replica_config:    SSOT multiRegionConfig as { region => numReplicas },
+        #                      e.g. { "us-west2" => 6 } for harness-workers (the
+        #                      de-scale fix). nil/empty -> omitted. When present,
+        #                      sent as multiRegionConfig: { region => { numReplicas } }
+        #                      so the redeploy preserves the intended scale instead
+        #                      of falling back to Railway's default single region
+        #                      at 1 replica.
+        #
+        # Returns [mutation_string, vars_hash].
+        #
+        # SHAPE: the whole serviceInstanceUpdate input rides as ONE variable
+        # `$input: ServiceInstanceUpdateInput!` — exactly how the repo's working
+        # TS provisioners issue this mutation (showcase/scripts/deploy-to-railway.ts
+        # ~501-509 and provision-starter-fleet.ts ~594-602 both pass a single
+        # `$input: ServiceInstanceUpdateInput!` and put source/healthcheckPath/
+        # region/registryCredentials/etc as KEYS inside it). Railway resolves each
+        # nested field's type from the ServiceInstanceUpdateInput schema, so we do
+        # NOT name nested types ourselves. The earlier attempt declared a separate
+        # `$multiRegionConfig: ServiceMultiRegionConfigInput!` variable — that type
+        # DOES NOT EXIST in Railway's schema and made the live promote fail with
+        # `HTTP 400: Unknown type "ServiceMultiRegionConfigInput"`, de-scaling
+        # harness-workers to 1 replica. Passing it as a nested input key avoids
+        # ever naming the type.
+        def self.build_update_image_mutation(image:, healthcheck_path: nil, replica_config: nil)
+            input = { source: { image: image } }
+
+            unless healthcheck_path.nil? || healthcheck_path.to_s.empty?
+                input[:healthcheckPath] = healthcheck_path
+            end
+
+            unless replica_config.nil? || replica_config.empty?
+                # Railway's multiRegionConfig is { <region> => { numReplicas } }.
+                input[:multiRegionConfig] = replica_config.each_with_object({}) do |(region, n), acc|
+                    acc[region] = { numReplicas: n }
+                end
+            end
+
+            mutation = <<~GQL
+                mutation UpdateImage($serviceId: String!, $envId: String!, $input: ServiceInstanceUpdateInput!) {
+                    serviceInstanceUpdate(
+                        serviceId: $serviceId
+                        environmentId: $envId
+                        input: $input
+                    )
+                }
+            GQL
+            [mutation, { input: input }]
+        end
 
         # Helper used by RestoreCommand, PinCommand: pin then deploy a NEW
         # deployment that pulls the updated source.image.
@@ -1159,11 +1207,22 @@ module Railway
         # service+env, or nil when the SSOT tracks NONE. When present, the pin
         # mutation RE-ASSERTS it alongside source.image so a prod instance whose
         # healthcheckPath silently went null (the aimock incident) self-heals to
-        # the tracked value on the next promote. When nil, the plain
-        # image-only mutation is used and the `healthcheckPath` key is OMITTED
-        # entirely — we NEVER send `healthcheckPath: null` (which would actively
-        # CLEAR it). This is the durable lever the SSOT-tracking change adds.
-        def self.pin_and_verify(gql, service_id:, env_id:, image:, healthcheck_path: nil, sleeper: ->(n) { sleep(n) })
+        # the tracked value on the next promote. When nil, the `healthcheckPath`
+        # key is OMITTED entirely — we NEVER send `healthcheckPath: null` (which
+        # would actively CLEAR it). This is the durable lever the SSOT-tracking
+        # change adds.
+        #
+        # `replica_config:` — the SSOT-declared multiRegionConfig replica map for
+        # this service+env as { region => numReplicas } (e.g. { "us-west2" => 6 }
+        # for harness-workers), or nil when the SSOT tracks NO replica override.
+        # When present, the pin mutation RE-ASSERTS multiRegionConfig alongside
+        # source.image so the subsequent serviceInstanceDeployV2 preserves the
+        # intended scale. Without it, a promote that updates only source.image
+        # lets Railway fall back to its default single region (us-west1) at 1
+        # replica on redeploy — the confirmed harness-workers -> 1 de-scale
+        # incident. When nil/empty, the key is OMITTED (never sent as null), so a
+        # service without an override keeps its live config untouched.
+        def self.pin_and_verify(gql, service_id:, env_id:, image:, healthcheck_path: nil, replica_config: nil, sleeper: ->(n) { sleep(n) })
             # Upfront guard: this method's contract is to pin a DIGEST-form
             # image. Pre-fix, a stray tag ref would fall through to retries
             # (since expected_digest stayed nil and image_ok was always false)
@@ -1184,18 +1243,16 @@ module Railway
             pre_inst = pre_data && pre_data["serviceInstance"]
             pre_update_ts = pre_inst && pre_inst["updatedAt"]
 
-            # Re-assert the SSOT healthcheckPath alongside source.image ONLY when
-            # the SSOT declares one. A nil/empty path uses the image-only
-            # mutation so the healthcheckPath key is OMITTED (never sent as
-            # null, which would clear it) — a live-null service stays null.
-            if healthcheck_path.nil? || healthcheck_path.to_s.empty?
-                updated = gql.query(RestoreCommand::UPDATE_IMAGE_MUTATION,
-                    serviceId: service_id, envId: env_id, image: image)
-            else
-                updated = gql.query(RestoreCommand::UPDATE_IMAGE_AND_HEALTHCHECK_MUTATION,
-                    serviceId: service_id, envId: env_id, image: image,
-                    healthcheckPath: healthcheck_path)
-            end
+            # Re-assert the SSOT-tracked healthcheckPath AND multiRegionConfig
+            # replica count alongside source.image, each ONLY when the SSOT
+            # declares it. The builder omits any absent key entirely (never sends
+            # an explicit null, which Railway would treat as "clear this field"),
+            # so a service tracking neither keeps its live config untouched.
+            mutation, vars = RestoreCommand.build_update_image_mutation(
+                image: image, healthcheck_path: healthcheck_path,
+                replica_config: replica_config)
+            updated = gql.query(mutation,
+                { serviceId: service_id, envId: env_id }.merge(vars))
             unless updated && updated["serviceInstanceUpdate"] == true
                 raise MutationError,
                     "P5: serviceInstanceUpdate returned #{updated.inspect} (expected true) for #{service_id} -> #{image}"
@@ -2140,6 +2197,29 @@ module Railway
             (Railway::SSOT_DATA["services"] || []).find { |s| s["name"] == name }
         end
 
+        # Region key the multiRegionConfig replica override is keyed on. The
+        # only service with a replica override (harness-workers) is single-region
+        # us-west2 — Railway derives its live replica count from
+        # `multiRegionConfig.us-west2.numReplicas`. See showcase/scripts/
+        # railway-envs.ts (WorkerProvisioning) and RAILWAY.md "Effective replica
+        # count". A fixed constant here (rather than an SSOT-emitted field)
+        # because the region is a stable platform invariant for this service.
+        REPLICA_REGION = "us-west2"
+
+        # SSOT-declared replica override for (service, env) as a
+        # { region => numReplicas } map, or nil when the service tracks NONE.
+        # Only `harness-workers` carries `workerProvisioning.<env>` today; every
+        # other service returns nil so pin_and_verify OMITS multiRegionConfig and
+        # leaves their live (single-replica) config untouched. The authoritative
+        # count is `effectiveReplicas` (= multiRegionConfig.<region>.numReplicas,
+        # the value Railway honors), NOT the top-level `numReplicas` mirror.
+        def ssot_replica_config(name, env)
+            replicas = (ssot_service(name) || {})
+                .dig("workerProvisioning", env, "effectiveReplicas")
+            return nil if replicas.nil?
+            { REPLICA_REGION => replicas }
+        end
+
         # Union of per-service `replicateKeys` declared in the SSOT for the
         # services being promoted (§5.3.1). EMPTY for every service today — the
         # replicate-class env-write mechanism is opt-in and copies nothing until
@@ -2381,11 +2461,20 @@ module Railway
                     # pin_and_verify then OMITS the field rather than clearing it.
                     ssot_healthcheck = (ssot_service(svc["name"]) || {})
                         .dig("healthcheckPath", "prod")
+                    # Re-assert the SSOT-tracked prod replica count on every
+                    # promote (the durable fix for the harness-workers -> 1
+                    # de-scale: a promote that updates only source.image lets
+                    # Railway fall back to its default single region at 1
+                    # replica). nil for every service WITHOUT a replica override —
+                    # pin_and_verify then OMITS multiRegionConfig rather than
+                    # touching it.
+                    ssot_replicas = ssot_replica_config(svc["name"], "prod")
                     PromoteCommand.pin_and_verify(gql,
                         service_id: pmatch["service_id"],
                         env_id: PRODUCTION_ENV_ID,
                         image: image,
-                        healthcheck_path: ssot_healthcheck)
+                        healthcheck_path: ssot_healthcheck,
+                        replica_config: ssot_replicas)
                     puts "promoted #{svc['name']} -> #{image}"
                     already_pinned << svc["name"]
                 # Broadened rescue: a transient GraphQL or network error

--- a/showcase/bin/spec/test_promote_cr_fixes.rb
+++ b/showcase/bin/spec/test_promote_cr_fixes.rb
@@ -235,7 +235,7 @@ class PromoteCRFixesTest < Minitest::Test
             if q.include?("serviceInstanceUpdate")
                 call_count += 1
                 raise Railway::GraphQL::Error, "boom on update #2" if call_count == 2
-                pinned_ref = vars[:image]
+                pinned_ref = vars.dig(:input, :source, :image)
                 { "serviceInstanceUpdate" => true }
             elsif q.include?("serviceInstanceDeployV2")
                 { "serviceInstanceDeployV2" => "dep-new" }
@@ -369,7 +369,7 @@ class PromoteCRFixesTest < Minitest::Test
         pinned = nil
         gql.define_singleton_method(:query) do |q, vars = {}|
             if q.include?("serviceInstanceUpdate")
-                pinned = vars[:image]
+                pinned = vars.dig(:input, :source, :image)
                 { "serviceInstanceUpdate" => true }
             elsif q.include?("serviceInstanceDeployV2")
                 { "serviceInstanceDeployV2" => "dep-new" }

--- a/showcase/bin/spec/test_promote_execute.rb
+++ b/showcase/bin/spec/test_promote_execute.rb
@@ -19,7 +19,7 @@ class PromoteExecuteTest < Minitest::Test
         def query(q, vars = {})
             @calls << [q, vars]
             if q.include?("serviceInstanceUpdate")
-                @pinned_image = vars[:image]
+                @pinned_image = vars.dig(:input, :source, :image)
                 { "serviceInstanceUpdate" => true }
             elsif q.include?("serviceInstanceDeployV2")
                 # New deployment spawned; returns the new deployment id.
@@ -59,7 +59,7 @@ class PromoteExecuteTest < Minitest::Test
         # Find the `image:` arg passed to the serviceInstanceUpdate mutation.
         def pinned_image
             row = @calls.find { |q, _| q.include?("serviceInstanceUpdate") }
-            row && row[1][:image]
+            row && row[1].dig(:input, :source, :image)
         end
     end
 

--- a/showcase/bin/spec/test_promote_fleet_target_invariant.rb
+++ b/showcase/bin/spec/test_promote_fleet_target_invariant.rb
@@ -55,7 +55,7 @@ class PromoteFleetTargetInvariantTest < Minitest::Test
             @calls << [q, vars]
             sid = vars[:serviceId]
             if q.include?("serviceInstanceUpdate")
-                @pinned_by_service[sid] = vars[:image]
+                @pinned_by_service[sid] = vars.dig(:input, :source, :image)
                 { "serviceInstanceUpdate" => true }
             elsif q.include?("serviceInstanceDeployV2")
                 { "serviceInstanceDeployV2" => "dep-#{sid}" }
@@ -91,7 +91,7 @@ class PromoteFleetTargetInvariantTest < Minitest::Test
 
         def pinned_services
             @calls.select { |q, _| q.include?("serviceInstanceUpdate") }
-                  .map { |_, vars| [vars[:serviceId], vars[:image]] }
+                  .map { |_, vars| [vars[:serviceId], vars.dig(:input, :source, :image)] }
         end
     end
 

--- a/showcase/bin/spec/test_promote_healthcheck_reassert.rb
+++ b/showcase/bin/spec/test_promote_healthcheck_reassert.rb
@@ -66,14 +66,16 @@ class PromoteHealthcheckReassertTest < Minitest::Test
             healthcheck_path: "/health", sleeper: ->(_n) {})
 
         query, vars = update_call(gql)
-        # The mutation must DECLARE + USE $healthcheckPath in the input, and the
-        # vars must carry the SSOT value.
-        assert_match(/\$healthcheckPath:\s*String/, query,
-            "update mutation should declare a healthcheckPath variable")
-        assert_match(/healthcheckPath:\s*\$healthcheckPath/, query,
-            "update mutation input should set healthcheckPath")
-        assert_equal "/health", vars[:healthcheckPath],
-            "update vars should carry the SSOT healthcheckPath"
+        # The whole input rides as a single $input: ServiceInstanceUpdateInput!
+        # variable; healthcheckPath is a NESTED key of that input (Railway infers
+        # its type from the input schema). See deploy-to-railway.ts /
+        # provision-starter-fleet.ts, which set healthcheckPath the same way.
+        assert_match(/\$input:\s*ServiceInstanceUpdateInput!/, query,
+            "update mutation should pass a single $input: ServiceInstanceUpdateInput! variable")
+        assert_match(/input:\s*\$input/, query,
+            "serviceInstanceUpdate should receive the input via $input")
+        assert_equal "/health", vars.dig(:input, :healthcheckPath),
+            "input.healthcheckPath should carry the SSOT healthcheckPath"
     end
 
     def test_omits_healthcheck_path_when_ssot_has_none
@@ -88,8 +90,8 @@ class PromoteHealthcheckReassertTest < Minitest::Test
         # must NEVER send `healthcheckPath: null`, which would clear it.
         refute_match(/healthcheckPath/, query,
             "image-only mutation must not mention healthcheckPath")
-        refute vars.key?(:healthcheckPath),
-            "update vars must omit healthcheckPath for a live-null service"
+        refute vars.dig(:input)&.key?(:healthcheckPath),
+            "input must omit healthcheckPath for a live-null service"
     end
 
     def test_empty_string_path_is_treated_as_omitted
@@ -100,6 +102,6 @@ class PromoteHealthcheckReassertTest < Minitest::Test
 
         query, vars = update_call(gql)
         refute_match(/healthcheckPath/, query)
-        refute vars.key?(:healthcheckPath)
+        refute vars.dig(:input)&.key?(:healthcheckPath)
     end
 end

--- a/showcase/bin/spec/test_promote_replicas_reassert.rb
+++ b/showcase/bin/spec/test_promote_replicas_reassert.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+# Re-assertion of the SSOT multiRegionConfig replica count on the promote pin
+# (the durable fix for the harness-workers -> 1 de-scale incident). A promote
+# that issues serviceInstanceUpdate WITHOUT a multiRegionConfig key lets Railway
+# fall back to its default region (us-west1) at 1 replica on the subsequent
+# serviceInstanceDeployV2 — collapsing the staged
+# `multiRegionConfig.us-west2.numReplicas = 6`. pin_and_verify must:
+#   - INCLUDE multiRegionConfig in the serviceInstanceUpdate input when the SSOT
+#     declares a replica override for the service+env (harness-workers -> 6 in
+#     us-west2), and
+#   - OMIT it entirely (never send a multiRegionConfig key) when the SSOT tracks
+#     no replica override, so a normal single-replica service is never touched.
+class PromoteReplicasReassertTest < Minitest::Test
+    class FakeGQL
+        def initialize(plan); @plan = plan; @calls = []; end
+        attr_reader :calls
+
+        def query(q, vars = {})
+            @calls << [q, vars]
+            step = @plan.shift
+            raise "fake exhausted at call ##{@calls.size}: #{q[0, 40]}" unless step
+            raise step[:raise] if step[:raise]
+            step[:data]
+        end
+    end
+
+    NEW_DEPLOY_ID = "dep-new"
+
+    def pre(ts) = { data: { "serviceInstance" => { "id" => "i", "source" => { "image" => "ghcr.io/copilotkit/x@sha256:OLD" }, "updatedAt" => ts } } }
+    def post(image:, ts:) = { data: { "serviceInstance" => { "id" => "i", "source" => { "image" => image }, "updatedAt" => ts } } }
+    def deploy_ok(id = NEW_DEPLOY_ID) = { data: { "serviceInstanceDeployV2" => id } }
+
+    def serving(digest:, status: "SUCCESS", deploy_id: NEW_DEPLOY_ID)
+        {
+            data: {
+                "serviceInstance" => {
+                    "id" => "i",
+                    "source" => { "image" => "ghcr.io/copilotkit/x@#{digest}" },
+                    "updatedAt" => "2026-05-28T03:00:00Z",
+                    "latestDeployment" => {
+                        "id" => deploy_id, "status" => status,
+                        "meta" => { "imageDigest" => digest },
+                    },
+                },
+            },
+        }
+    end
+
+    def happy_plan
+        [
+            pre("2026-05-27T00:00:00Z"),
+            { data: { "serviceInstanceUpdate" => true } },
+            deploy_ok,
+            post(image: "ghcr.io/copilotkit/x@sha256:NEW", ts: "2026-05-28T01:00:00Z"),
+            serving(digest: "sha256:NEW"),
+        ]
+    end
+
+    # The serviceInstanceUpdate is always the 2nd GQL call (after the pre-update
+    # snapshot). Returns [query_string, vars] for that call.
+    def update_call(gql) = gql.calls[1]
+
+    def test_includes_multiregion_replicas_when_ssot_declares_override
+        gql = FakeGQL.new(happy_plan)
+        Railway::PromoteCommand.pin_and_verify(gql,
+            service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+            replica_config: { "us-west2" => 6 }, sleeper: ->(_n) {})
+
+        query, vars = update_call(gql)
+        # The mutation passes the WHOLE input object as a single $input variable
+        # typed ServiceInstanceUpdateInput! (the type Railway actually defines).
+        # multiRegionConfig is a NESTED key of that input — Railway infers its
+        # type from the ServiceInstanceUpdateInput schema, so we must NOT name a
+        # standalone `ServiceMultiRegionConfigInput` type (it DOES NOT EXIST and
+        # made the live promote 400). See deploy-to-railway.ts / provision-
+        # starter-fleet.ts, which set healthcheckPath/region/etc the same way.
+        refute_match(/ServiceMultiRegionConfigInput/, query,
+            "must not reference the nonexistent ServiceMultiRegionConfigInput type")
+        assert_match(/\$input:\s*ServiceInstanceUpdateInput!/, query,
+            "update mutation should pass a single $input: ServiceInstanceUpdateInput! variable")
+        assert_match(/input:\s*\$input/, query,
+            "serviceInstanceUpdate should receive the input via $input")
+        # The replica map rides INSIDE the input hash as the multiRegionConfig key.
+        assert_equal({ "us-west2" => { numReplicas: 6 } },
+            vars.dig(:input, :multiRegionConfig),
+            "input.multiRegionConfig should carry the SSOT region -> { numReplicas } map")
+        assert_equal({ image: "ghcr.io/copilotkit/x@sha256:NEW" },
+            vars.dig(:input, :source),
+            "input.source.image should always pin the target image")
+    end
+
+    def test_omits_multiregion_when_ssot_has_no_override
+        gql = FakeGQL.new(happy_plan)
+        # nil replica_config == a normal service with no replica override.
+        Railway::PromoteCommand.pin_and_verify(gql,
+            service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+            replica_config: nil, sleeper: ->(_n) {})
+
+        query, vars = update_call(gql)
+        # NO multiRegionConfig anywhere — we must NEVER send a multiRegionConfig
+        # key for a service without an override (would risk clobbering config).
+        refute_match(/multiRegionConfig/, query,
+            "image-only mutation must not mention multiRegionConfig")
+        refute vars.dig(:input)&.key?(:multiRegionConfig),
+            "input must omit multiRegionConfig for a non-override service"
+    end
+
+    def test_empty_replica_config_is_treated_as_omitted
+        gql = FakeGQL.new(happy_plan)
+        Railway::PromoteCommand.pin_and_verify(gql,
+            service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+            replica_config: {}, sleeper: ->(_n) {})
+
+        query, vars = update_call(gql)
+        refute_match(/multiRegionConfig/, query)
+        refute vars.dig(:input)&.key?(:multiRegionConfig)
+    end
+
+    # multiRegionConfig and healthcheckPath are INDEPENDENT re-assertion
+    # dimensions: a service can declare both (harness-workers tracks /health AND
+    # 6 replicas). Both must ride in the same serviceInstanceUpdate input.
+    def test_includes_both_healthcheck_and_replicas
+        gql = FakeGQL.new(happy_plan)
+        Railway::PromoteCommand.pin_and_verify(gql,
+            service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+            healthcheck_path: "/health", replica_config: { "us-west2" => 6 },
+            sleeper: ->(_n) {})
+
+        query, vars = update_call(gql)
+        # Both ride as nested keys inside the single $input object.
+        assert_match(/\$input:\s*ServiceInstanceUpdateInput!/, query)
+        refute_match(/ServiceMultiRegionConfigInput/, query)
+        assert_equal "/health", vars.dig(:input, :healthcheckPath)
+        assert_equal({ "us-west2" => { numReplicas: 6 } },
+            vars.dig(:input, :multiRegionConfig))
+    end
+
+    # SSOT resolution: the promote loop pulls replica intent from the REAL SSOT
+    # (railway-envs.generated.json) via ssot_replica_config. harness-workers
+    # carries workerProvisioning.prod.effectiveReplicas=6 -> { us-west2 => 6 };
+    # every other service tracks no override -> nil (so multiRegionConfig is
+    # omitted and their live config is never touched).
+    def cmd
+        c = Railway::PromoteCommand.new(["--non-interactive", "--yes"])
+        c.parser.parse!(c.argv)
+        c
+    end
+
+    def test_ssot_resolves_harness_workers_to_six_replicas_in_us_west2
+        assert_equal({ "us-west2" => 6 },
+            cmd.ssot_replica_config("harness-workers", "prod"),
+            "harness-workers prod must resolve to 6 replicas in us-west2 from SSOT")
+    end
+
+    def test_ssot_replica_config_is_nil_for_a_non_override_service
+        # Pick any non-worker service the SSOT tracks; it must have NO override.
+        sample = (Railway::SSOT_DATA["services"] || [])
+            .map { |s| s["name"] }
+            .reject { |n| n == "harness-workers" }
+            .first
+        refute_nil sample, "expected at least one non-worker service in the SSOT"
+        assert_nil cmd.ssot_replica_config(sample, "prod"),
+            "#{sample} has no replica override -> ssot_replica_config must be nil"
+    end
+end

--- a/showcase/bin/spec/test_promote_resolve_once.rb
+++ b/showcase/bin/spec/test_promote_resolve_once.rb
@@ -68,7 +68,7 @@ class PromoteResolveOnceTest < Minitest::Test
                     return { "serviceInstanceUpdate" => false }
                 end
                 @ts_counter += 1
-                @post[sid] = { image: vars[:image], ts: "2026-05-29T00:00:%02dZ" % @ts_counter }
+                @post[sid] = { image: vars.dig(:input, :source, :image), ts: "2026-05-29T00:00:%02dZ" % @ts_counter }
                 { "serviceInstanceUpdate" => true }
             elsif q.include?("serviceInstanceDeployV2")
                 # @redeploy_result false → return nil id so the DeployV2 guard
@@ -104,7 +104,7 @@ class PromoteResolveOnceTest < Minitest::Test
         end
 
         def pinned_images
-            @calls.select { |q, _| q.include?("serviceInstanceUpdate") }.map { |_, v| v[:image] }
+            @calls.select { |q, _| q.include?("serviceInstanceUpdate") }.map { |_, v| v.dig(:input, :source, :image) }
         end
     end
 

--- a/showcase/bin/spec/test_promote_single_service.rb
+++ b/showcase/bin/spec/test_promote_single_service.rb
@@ -27,7 +27,7 @@ class PromoteSingleServiceTest < Minitest::Test
             @calls << [q, vars]
             sid = vars[:serviceId]
             if q.include?("serviceInstanceUpdate")
-                @pinned_by_service[sid] = vars[:image]
+                @pinned_by_service[sid] = vars.dig(:input, :source, :image)
                 { "serviceInstanceUpdate" => true }
             elsif q.include?("serviceInstanceDeployV2")
                 { "serviceInstanceDeployV2" => "dep-#{sid}" }
@@ -63,12 +63,12 @@ class PromoteSingleServiceTest < Minitest::Test
 
         def pinned_services
             @calls.select { |q, _| q.include?("serviceInstanceUpdate") }
-                  .map { |_, vars| [vars[:serviceId], vars[:image]] }
+                  .map { |_, vars| [vars[:serviceId], vars.dig(:input, :source, :image)] }
         end
 
         def pinned_image_for(service_id)
             row = @calls.find { |q, vars| q.include?("serviceInstanceUpdate") && vars[:serviceId] == service_id }
-            row && row[1][:image]
+            row && row[1].dig(:input, :source, :image)
         end
     end
 

--- a/showcase/bin/spec/test_promote_single_service_fleet_invariants.rb
+++ b/showcase/bin/spec/test_promote_single_service_fleet_invariants.rb
@@ -60,7 +60,7 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
             @calls << [q, vars]
             sid = vars[:serviceId]
             if q.include?("serviceInstanceUpdate")
-                @pinned_by_service[sid] = vars[:image]
+                @pinned_by_service[sid] = vars.dig(:input, :source, :image)
                 { "serviceInstanceUpdate" => true }
             elsif q.include?("serviceInstanceDeployV2")
                 { "serviceInstanceDeployV2" => "dep-#{sid}" }
@@ -96,12 +96,12 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
 
         def pinned_services
             @calls.select { |q, _| q.include?("serviceInstanceUpdate") }
-                  .map { |_, vars| [vars[:serviceId], vars[:image]] }
+                  .map { |_, vars| [vars[:serviceId], vars.dig(:input, :source, :image)] }
         end
 
         def pinned_image_for(service_id)
             row = @calls.find { |q, vars| q.include?("serviceInstanceUpdate") && vars[:serviceId] == service_id }
-            row && row[1][:image]
+            row && row[1].dig(:input, :source, :image)
         end
     end
 

--- a/showcase/bin/spec/test_snapshot_ivar_lint.rb
+++ b/showcase/bin/spec/test_snapshot_ivar_lint.rb
@@ -54,33 +54,33 @@ class SnapshotIvarLintTest < Minitest::Test
     #                       prose (do not perform a read)
     ALLOWED_LINES = [
         # `run` — capture full-fleet view before optional narrowing.
-        '1447:@full_staging_snapshot = @staging_snapshot',
-        '1448:@full_prod_snapshot    = @prod_snapshot',
+        '1504:@full_staging_snapshot = @staging_snapshot',
+        '1505:@full_prod_snapshot    = @prod_snapshot',
 
         # Doc comment above narrow_snapshots_to_single_service!.
-        '1456:# Narrow @staging_snapshot and @prod_snapshot to only the named',
+        '1513:# Narrow @staging_snapshot and @prod_snapshot to only the named',
 
         # narrow_snapshots_to_single_service! — the WRITE site.
-        '1464:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1469:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
-        '1470:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1471:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
+        '1521:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1526:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
+        '1527:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1528:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
 
         # Doc comment above capture_snapshots.
-        '1475:# @staging_snapshot / @prod_snapshot directly.',
+        '1532:# @staging_snapshot / @prod_snapshot directly.',
 
         # capture_snapshots — single test-seam assignment site.
-        '1477:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
-        '1478:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
+        '1534:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
+        '1535:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
 
         # Doc comment above the accessor block (explains test seam).
-        '1502:# promote tests stub @staging_snapshot/@prod_snapshot directly',
+        '1559:# promote tests stub @staging_snapshot/@prod_snapshot directly',
 
         # The four accessor bodies — the ONLY sanctioned reads.
-        '1514:@full_staging_snapshot || @staging_snapshot',
-        '1518:@full_prod_snapshot || @prod_snapshot',
-        '1522:@staging_snapshot',
-        '1526:@prod_snapshot',
+        '1571:@full_staging_snapshot || @staging_snapshot',
+        '1575:@full_prod_snapshot || @prod_snapshot',
+        '1579:@staging_snapshot',
+        '1583:@prod_snapshot',
     ].freeze
 
     def setup


### PR DESCRIPTION
## The bug

`bin/railway` promote re-asserts the SSOT replica config on the `serviceInstanceUpdate` pin, but built the mutation by declaring a standalone variable:

```graphql
$multiRegionConfig: ServiceMultiRegionConfigInput!
```

**That input type does not exist in Railway's schema.** The prior promote attempt (#5754) failed live with `HTTP 400: Unknown type "ServiceMultiRegionConfigInput"`, so the redeploy went out **without** the replica config and Railway de-scaled `harness-workers` (us-west2) from the SSOT-intended **6** replicas to **1**. The wrong type name was a guess, never verified against the real schema.

## Real schema — source of truth

Railway's mutation is `serviceInstanceUpdate(serviceId: String!, environmentId: String!, input: ServiceInstanceUpdateInput!)`. The correct pattern — already used by this repo's own working TypeScript provisioners — is to pass the **entire input object as one `$input: ServiceInstanceUpdateInput!` variable** and put every field (`source`, `healthcheckPath`, `region`, `registryCredentials`, `multiRegionConfig`) as a **nested key** of that input. Railway resolves each nested field's type from the `ServiceInstanceUpdateInput` schema, so you never name nested input types yourself:

- `showcase/scripts/deploy-to-railway.ts` ~472-509 — builds `instanceInput = { region, healthcheckPath, registryCredentials, ... }`, then `serviceInstanceUpdate($serviceId, $environmentId, $input: ServiceInstanceUpdateInput!)` passing `input: instanceInput`.
- `showcase/scripts/provision-starter-fleet.ts` ~575-602 — same single-`$input` pattern.

The replica shape itself (`multiRegionConfig.<region>.numReplicas`, e.g. `{ "us-west2": { "numReplicas": 6 } }`) is confirmed in `showcase/scripts/railway-envs.ts` ~150-194, ~719-752 and `railway-envs.generated.json` ~161-169 — and was already correct in the Ruby. **Only the GraphQL type declaration was wrong.**

## The fix

`showcase/bin/railway` — `RestoreCommand.build_update_image_mutation` (~859):

**Before** — one typed variable per optional key (and the invented type):

```graphql
mutation UpdateImage($serviceId: String!, $envId: String!, $image: String!,
                     $healthcheckPath: String!,
                     $multiRegionConfig: ServiceMultiRegionConfigInput!) {
  serviceInstanceUpdate(serviceId: $serviceId, environmentId: $envId,
    input: { source: { image: $image }, healthcheckPath: $healthcheckPath,
             multiRegionConfig: $multiRegionConfig })
}
```

**After** — the whole input as one `ServiceInstanceUpdateInput!`, fields nested:

```graphql
mutation UpdateImage($serviceId: String!, $envId: String!,
                     $input: ServiceInstanceUpdateInput!) {
  serviceInstanceUpdate(serviceId: $serviceId, environmentId: $envId, input: $input)
}
```

with `vars = { input: { source: { image: ... }, healthcheckPath: ..., multiRegionConfig: { "us-west2" => { numReplicas: 6 } } } }`. Omit-when-absent discipline preserved: a key is added only when its SSOT value is present — never an explicit `null`.

## Red → green proof

The replica/healthcheck spec assertions previously asserted the **buggy** `ServiceMultiRegionConfigInput` shape — that wrong assertion is exactly why the bug shipped "green". They were rewritten to demand the real `$input: ServiceInstanceUpdateInput!` shape (and to assert the nonexistent type is **absent**).

**RED** (new assertions vs the pristine buggy `bin/railway`):

```
$ ruby showcase/bin/spec/test_promote_replicas_reassert.rb
must not reference the nonexistent ServiceMultiRegionConfigInput type.
Expected /ServiceMultiRegionConfigInput/ to not match
  "...$multiRegionConfig: ServiceMultiRegionConfigInput!) { serviceInstanceUpdate(... )}"
6 runs, 13 assertions, 2 failures, 0 errors, 0 skips
```

**GREEN** (same spec, with the fix applied):

```
$ ruby showcase/bin/spec/test_promote_replicas_reassert.rb
6 runs, 23 assertions, 0 failures, 0 errors, 0 skips
```

**Full `bin/railway` suite** (after updating integration fakes to read `input.source.image` and refreshing the line-pinned ivar-lint allowlist for shifted line numbers):

```
$ ruby showcase/bin/spec/all_tests.rb
183 runs, 710 assertions, 0 failures, 0 errors, 0 skips
```

`ruby -c showcase/bin/railway` → Syntax OK.

## Note

This fixes the GraphQL shape and the unit/integration coverage. **The orchestrator will live-value-test the promote workflow against real Railway from this branch before merge** — confirming the redeploy actually preserves `harness-workers` at 6 replicas in us-west2 rather than de-scaling to 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)