### PR TITLE
fix(angular): skip chat input submit during IME composition

### DIFF
--- a/packages/angular/src/lib/components/chat/copilot-chat-input.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat-input.ts
@@ -539,6 +539,12 @@ export class CopilotChatInput implements AfterViewInit, OnDestroy {
   }
 
   handleKeyDown(event: KeyboardEvent): void {
+    // Skip key handling during IME composition (e.g. CJK input).
+    // The compositionend event will fire separately when composition ends.
+    if (event.isComposing || event.keyCode === 229) {
+      return;
+    }
+
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
       this.send();


### PR DESCRIPTION
### What

The Angular `CopilotChatInput.handleKeyDown` submits the message when Enter is pressed without Shift, but it never checks whether an IME composition is in progress. When typing CJK text (Japanese, Chinese, Korean), the Enter that confirms an IME candidate also fires a `keydown`, so the half-composed text gets sent instead of the candidate being committed.

The React and Vue bindings of the same v2 `CopilotChatInput` already guard against this; Angular was the one binding still missing it:

- `packages/react-core/src/v2/components/chat/CopilotChatInput.tsx` — `handleKeyDown` returns early on `e.nativeEvent.isComposing || e.keyCode === 229`
- `packages/vue/src/v2/components/chat/CopilotChatInput.vue` — `handleKeydown` returns early on `isComposing.value || event.isComposing || event.keyCode === 229`, and has a test asserting it does not submit while composing

### Change

Add the same early return to the Angular `handleKeyDown`, using the native `KeyboardEvent` (`event.isComposing || event.keyCode === 229`), which matches the Vue binding's idiom.

### Notes

When composition is not active `isComposing` is `false`, so Enter submits exactly as before and Shift+Enter still inserts a newline. The most visible case is Safari with a Japanese IME, where the confirming Enter reports `key === "Enter"` with `isComposing === true`; the `keyCode === 229` arm mirrors the sibling guards for browsers that report the composing key that way.

I verified the handler logic in isolation (Enter while composing no longer submits; plain Enter and Shift+Enter are unchanged). I did not run the full Angular suite locally.
