### PR TITLE
fix(runtime): derive thread-name fallback from first user message

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/thread-names.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/thread-names.test.ts
@@ -1,12 +1,31 @@
-import { describe, expect, it } from "vitest";
-import type { Message } from "@ag-ui/client";
+import { describe, expect, it, vi } from "vitest";
+import type { AbstractAgent, Message, RunAgentInput } from "@ag-ui/client";
 
 import {
   ɵnormalizeGeneratedTitle as normalizeGeneratedTitle,
   ɵselectGeneratedTitleFromMessages as selectGeneratedTitleFromMessages,
   ɵbuildThreadTitlePrompt as buildThreadTitlePrompt,
   ɵhasThreadName as hasThreadName,
+  ɵderiveFallbackTitleFromMessages as deriveFallbackTitleFromMessages,
 } from "../handlers/intelligence/thread-names";
+import { generateThreadNameForNewThread } from "../handlers/intelligence/thread-names";
+import type { CopilotIntelligenceRuntimeLike } from "../core/runtime";
+
+const MAX_TITLE_LENGTH = 80;
+const MAX_TITLE_WORDS = 8;
+
+// The mock LLM's catch-all reply — long enough to normalize to null because it
+// exceeds the title word limit, which is exactly why mock-mode threads used to
+// fall through to the generic "Untitled".
+const MOCK_CATCH_ALL_REPLY =
+  "👋 This is the demo's local mock LLM and I do not have a real model wired up, " +
+  "so I am replying with this canned message instead of answering your question.";
+
+const userMessage = (content: string): Message =>
+  ({ id: "msg-user", role: "user", content }) as Message;
+
+const systemMessage = (content: string): Message =>
+  ({ id: "msg-system", role: "system", content }) as Message;
 
 // ---------------------------------------------------------------------------
 // normalizeGeneratedTitle
@@ -229,5 +248,182 @@ describe("hasThreadName", () => {
   it("returns false for empty or whitespace-only strings", () => {
     expect(hasThreadName("")).toBe(false);
     expect(hasThreadName("   ")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveFallbackTitleFromMessages
+// ---------------------------------------------------------------------------
+
+describe("deriveFallbackTitleFromMessages", () => {
+  it("derives a short cleaned title from the first user message", () => {
+    const result = deriveFallbackTitleFromMessages([
+      userMessage("Hello, can you help me plan a trip to Japan?"),
+    ]);
+
+    expect(result).not.toBe("Untitled");
+    expect(result.split(/\s+/).length).toBeLessThanOrEqual(MAX_TITLE_WORDS);
+    expect(result.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
+    // Bounded to 8 words (dropping the trailing "to Japan?"); the mid-title
+    // comma is preserved since only trailing punctuation is stripped.
+    expect(result).toBe("Hello, can you help me plan a trip");
+  });
+
+  it("returns Untitled when there is no user message", () => {
+    expect(
+      deriveFallbackTitleFromMessages([systemMessage("You are helpful.")]),
+    ).toBe("Untitled");
+  });
+
+  it("returns Untitled for undefined or empty messages", () => {
+    expect(deriveFallbackTitleFromMessages(undefined)).toBe("Untitled");
+    expect(deriveFallbackTitleFromMessages([])).toBe("Untitled");
+  });
+
+  it("returns Untitled when the user message has only empty content", () => {
+    expect(deriveFallbackTitleFromMessages([userMessage("   ")])).toBe(
+      "Untitled",
+    );
+  });
+
+  it("uses the FIRST user message, not later ones", () => {
+    const result = deriveFallbackTitleFromMessages([
+      systemMessage("You are helpful."),
+      userMessage("Track my fitness goals"),
+      userMessage("Something else entirely"),
+    ]);
+
+    expect(result).toBe("Track my fitness goals");
+  });
+
+  it("strips markdown and collapses whitespace", () => {
+    const result = deriveFallbackTitleFromMessages([
+      userMessage("**Budget**   _review_ please"),
+    ]);
+
+    expect(result).toBe("Budget review please");
+  });
+
+  it("bounds a long single-word message to the character limit", () => {
+    const result = deriveFallbackTitleFromMessages([
+      userMessage("A".repeat(120)),
+    ]);
+
+    expect(result.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateThreadNameForNewThread — fallback wiring
+// ---------------------------------------------------------------------------
+
+interface ThreadNameSetup {
+  updateThread: ReturnType<typeof vi.fn>;
+  runtime: CopilotIntelligenceRuntimeLike;
+  request: Request;
+}
+
+/**
+ * Builds a minimal runtime + agent stub for `generateThreadNameForNewThread`.
+ * `assistantReply` is the single assistant message the stubbed agent run
+ * returns; pass `null` to simulate an agent that produces no usable reply
+ * (forcing all attempts to yield no valid title).
+ */
+function setup(assistantReply: string | null): ThreadNameSetup {
+  const updateThread = vi.fn().mockResolvedValue({ id: "thread-1" });
+
+  const makeAgentStub = (): AbstractAgent => {
+    const stub: Record<string, unknown> = {
+      setMessages: vi.fn(),
+      setState: vi.fn(),
+      threadId: undefined,
+      headers: {},
+      runAgent: vi.fn().mockResolvedValue({
+        newMessages:
+          assistantReply === null
+            ? []
+            : [{ id: "reply", role: "assistant", content: assistantReply }],
+      }),
+    };
+    stub.clone = vi.fn(() => makeAgentStub());
+    return stub as unknown as AbstractAgent;
+  };
+
+  const runtime = {
+    agents: { "my-agent": makeAgentStub() },
+    a2ui: undefined,
+    mcpApps: undefined,
+    openGenerativeUI: undefined,
+    mode: "intelligence",
+    generateThreadNames: true,
+    intelligence: { updateThread },
+  } as unknown as CopilotIntelligenceRuntimeLike;
+
+  const request = new Request("https://example.com/agent/my-agent/run", {
+    method: "POST",
+  });
+
+  return { updateThread, runtime, request };
+}
+
+const runWith = async (
+  s: ThreadNameSetup,
+  messages: Message[],
+): Promise<string> => {
+  await generateThreadNameForNewThread({
+    runtime: s.runtime,
+    request: s.request,
+    agentId: "my-agent",
+    sourceInput: { messages } as unknown as RunAgentInput,
+    thread: { id: "thread-1", name: null } as never,
+    userId: "user-1",
+  });
+
+  expect(s.updateThread).toHaveBeenCalledTimes(1);
+  return s.updateThread.mock.calls[0][0].updates.name as string;
+};
+
+describe("generateThreadNameForNewThread — fallback title", () => {
+  it("derives the name from the first user message when generation never yields a valid title", async () => {
+    const s = setup(null);
+
+    const name = await runWith(s, [
+      userMessage("Hello, can you help me plan a trip to Japan?"),
+    ]);
+
+    expect(name).not.toBe("Untitled");
+    expect(name.split(/\s+/).length).toBeLessThanOrEqual(MAX_TITLE_WORDS);
+    expect(name.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
+    expect(name).toBe("Hello, can you help me plan a trip");
+  });
+
+  it("falls back to Untitled when there is no user message", async () => {
+    const s = setup(null);
+
+    const name = await runWith(s, [systemMessage("You are helpful.")]);
+
+    expect(name).toBe("Untitled");
+  });
+
+  it("treats the mock catch-all reply as invalid and derives from the user message", async () => {
+    const s = setup(MOCK_CATCH_ALL_REPLY);
+
+    const name = await runWith(s, [
+      userMessage("Hello, can you help me plan a trip to Japan?"),
+    ]);
+
+    expect(name).not.toBe("Untitled");
+    expect(name).not.toContain("mock LLM");
+    expect(name).toBe("Hello, can you help me plan a trip");
+  });
+
+  it("uses a valid generated title when generation succeeds (regression)", async () => {
+    const s = setup('{"title":"Trip to Japan"}');
+
+    const name = await runWith(s, [
+      userMessage("Hello, can you help me plan a trip to Japan?"),
+    ]);
+
+    expect(name).toBe("Trip to Japan");
   });
 });

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/thread-names.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/thread-names.ts
@@ -89,7 +89,8 @@ export async function generateThreadNameForNewThread({
     userId,
     agentId,
     updates: {
-      name: generatedTitle ?? deriveFallbackTitleFromMessages(sourceInput.messages),
+      name:
+        generatedTitle ?? deriveFallbackTitleFromMessages(sourceInput.messages),
     },
   });
 }

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/thread-names.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/thread-names.ts
@@ -88,7 +88,9 @@ export async function generateThreadNameForNewThread({
     threadId: thread.id,
     userId,
     agentId,
-    updates: { name: generatedTitle ?? FALLBACK_THREAD_TITLE },
+    updates: {
+      name: generatedTitle ?? deriveFallbackTitleFromMessages(sourceInput.messages),
+    },
   });
 }
 
@@ -214,12 +216,7 @@ function normalizeGeneratedTitle(rawTitle: string): string | null {
     }
   }
 
-  candidate = candidate
-    .replace(/^["'`]+|["'`]+$/g, "")
-    .replace(/[*_#[\]()!~>|]+/g, "")
-    .replace(/[.!?,;:]+$/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
+  candidate = cleanupTitleText(candidate);
 
   if (!candidate) {
     return null;
@@ -234,6 +231,71 @@ function normalizeGeneratedTitle(rawTitle: string): string | null {
   }
 
   return candidate;
+}
+
+/**
+ * Strips the markdown, surrounding quotes and trailing punctuation that an LLM
+ * tends to wrap a title in, then collapses internal whitespace. Shared by both
+ * the LLM-title normalizer and the first-user-message fallback so the two paths
+ * clean text identically.
+ *
+ * @param text - Raw candidate title text.
+ * @returns The cleaned text (may be empty if everything was stripped).
+ */
+function cleanupTitleText(text: string): string {
+  return text
+    .replace(/^["'`]+|["'`]+$/g, "")
+    .replace(/[*_#[\]()!~>|]+/g, "")
+    .replace(/[.!?,;:]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Derives a short, human-readable thread title from the first user message when
+ * LLM title generation could not produce a valid title (for example when the
+ * runtime is pointed at a mock LLM whose catch-all reply is not a title). Reuses
+ * the same text cleanup as the LLM-title normalizer, then bounds the result to
+ * {@link MAX_TITLE_WORDS} words and {@link MAX_TITLE_LENGTH} characters so the
+ * fallback reads like a title rather than a sentence fragment.
+ *
+ * @param messages - The source conversation messages, if any.
+ * @returns A derived short title, or {@link FALLBACK_THREAD_TITLE} when there is
+ *   no usable user message.
+ */
+function deriveFallbackTitleFromMessages(
+  messages: Message[] | undefined,
+): string {
+  const firstUserMessage = (messages ?? []).find(
+    (message) =>
+      message.role === "user" &&
+      stringifyMessageContent(message.content).length > 0,
+  );
+
+  if (!firstUserMessage) {
+    return FALLBACK_THREAD_TITLE;
+  }
+
+  const cleaned = cleanupTitleText(
+    stringifyMessageContent(firstUserMessage.content),
+  );
+
+  if (!cleaned) {
+    return FALLBACK_THREAD_TITLE;
+  }
+
+  let title = cleaned;
+
+  const words = title.split(/\s+/);
+  if (words.length > MAX_TITLE_WORDS) {
+    title = words.slice(0, MAX_TITLE_WORDS).join(" ");
+  }
+
+  if (title.length > MAX_TITLE_LENGTH) {
+    title = title.slice(0, MAX_TITLE_LENGTH).trim();
+  }
+
+  return title || FALLBACK_THREAD_TITLE;
 }
 
 function selectGeneratedTitleFromMessages(messages: Message[]): string | null {
@@ -272,3 +334,5 @@ export const ɵselectGeneratedTitleFromMessages =
 export const ɵbuildThreadTitlePrompt = buildThreadTitlePrompt;
 /** @internal Exported for testing only. */
 export const ɵhasThreadName = hasThreadName;
+/** @internal Exported for testing only. */
+export const ɵderiveFallbackTitleFromMessages = deriveFallbackTitleFromMessages;


### PR DESCRIPTION
## Why
On a keyless mock-mode thread, the CopilotKit runtime asks the LLM to summarize a thread title; the mock's catch-all reply isn't a valid title, so all 3 attempts fail and the thread is named the generic **"Untitled"** (with repeated `Thread name generation returned an empty or invalid title` warnings). More broadly, any time title generation can't produce a valid title, "Untitled" is a poor result.

## What
`packages/runtime/src/v2/runtime/handlers/intelligence/thread-names.ts`: when generation yields no valid title after its retries, **derive the fallback from the first user message** (cleaned via the same normalizer + bounded to the existing word/char limits) instead of the bare "Untitled". 

- Valid LLM-generated titles are still used as-is (unchanged happy path).
- "Untitled" remains only when there is genuinely no usable user message.
- Retry count and warning logging are unchanged (kept scope tight).
- The shared title-cleanup regex was factored into a `cleanupTitleText` helper used by both the normalizer and the new fallback (no duplication).

## Tests
`__tests__/thread-names.test.ts` (38 pass): derived-title bounds/cleanup; "Untitled" only when no user message; the mock catch-all reply is treated invalid → derives from the user message (asserts the title isn't the catch-all); valid generated title still used (regression). Red→green verified.

## Scope / tracking
Part of the **AIMock × mastra Responses-API** EPIC (ENT-1008). This PR is **Piece 2** (thread-name fallback, runtime). Piece 1 ("Hello" Responses-API stream parse error) is a **published-`@copilotkit/aimock` version** matter (the repo source streams `/v1/responses` correctly; the mastra template already pins a working `@ai-sdk/openai`), tracked separately in the EPIC — not in this PR. Sibling fixture work is in #5728.