### PR TITLE
docs(cookbook): mark OpenBox recipe source as "to follow" until the showcase lands

### DIFF
--- a/showcase/shell-docs/src/content/docs/cookbook/openbox-governed-copilotkit.mdx
+++ b/showcase/shell-docs/src/content/docs/cookbook/openbox-governed-copilotkit.mdx
@@ -259,6 +259,6 @@ Walk me through it step by step, starting with the agent and its governed tools.
 
 ## Get the code
 
-Full source: [`examples/showcases/openbox-governed-copilotkit`](https://github.com/CopilotKit/CopilotKit/tree/main/examples/showcases/openbox-governed-copilotkit) — `agent/` (the LangGraph agent with OpenBox middleware) and `frontend/` (the CopilotKit V2 chat with the wrapped runtime and approval route).
+Full source to follow — the runnable showcase (the `agent/` LangGraph service with OpenBox middleware and the `frontend/` CopilotKit V2 chat with the wrapped runtime and approval route) will be published under `examples/showcases/openbox-governed-copilotkit`.
 
 For the upstream OpenBox × CopilotKit integration this recipe is based on, see the reference repo: [OpenBox-AI/openbox-x-copilotkit](https://github.com/OpenBox-AI/openbox-x-copilotkit).


### PR DESCRIPTION
## What does this PR do?

The **OpenBox Governance** cookbook recipe (#5686) merged to `main` ahead of its companion showcase (#5685), so the recipe's **"Get the code"** section linked to:

`https://github.com/CopilotKit/CopilotKit/tree/main/examples/showcases/openbox-governed-copilotkit`

…which **404s** today because that code isn't on `main` yet.

This swaps the broken link for a plain-text **"Full source to follow"** note (no hyperlink, so nothing 404s) that still describes what the showcase will contain. The live **upstream reference-repo** link directly below it is kept.

```diff
- Full source: [`examples/showcases/openbox-governed-copilotkit`](https://github.com/.../tree/main/examples/showcases/openbox-governed-copilotkit) — `agent/` … and `frontend/` …
+ Full source to follow — the runnable showcase (the `agent/` LangGraph service with OpenBox middleware and the `frontend/` CopilotKit V2 chat with the wrapped runtime and approval route) will be published under `examples/showcases/openbox-governed-copilotkit`.
```

**Follow-up:** once the showcase merges to `main`, restore the direct `tree/main/...` link.

_Note:_ the recipe's run-instructions still `cd` into that path (expected — the whole "run it yourself" flow assumes the code), so those steps only work once the showcase lands. Left as-is since they read as setup instructions, not a clickable link.

## Related PRs and Issues

- Docs recipe (merged): #5686
- Companion showcase (pending): #5685

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fr5HVeDzDyC4S6DjyhAFWZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fr5HVeDzDyC4S6DjyhAFWZ)_