### PR TITLE
fix(runtime): don't forward hop-by-hop/platform headers to agents

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/header-utils.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/header-utils.test.ts
@@ -16,7 +16,6 @@ describe("header-utils", () => {
       expect(shouldForwardHeader("x-custom")).toBe(true);
       expect(shouldForwardHeader("X-Custom")).toBe(true);
       expect(shouldForwardHeader("x-request-id")).toBe(true);
-      expect(shouldForwardHeader("X-Forwarded-For")).toBe(true);
     });
 
     it("blocks standard headers", () => {
@@ -27,6 +26,16 @@ describe("header-utils", () => {
       expect(shouldForwardHeader("accept")).toBe(false);
       expect(shouldForwardHeader("cookie")).toBe(false);
       expect(shouldForwardHeader("host")).toBe(false);
+    });
+
+    it("blocks hop-by-hop and platform headers from the inbound hop", () => {
+      expect(shouldForwardHeader("x-forwarded-for")).toBe(false);
+      expect(shouldForwardHeader("X-Forwarded-For")).toBe(false);
+      expect(shouldForwardHeader("x-forwarded-proto")).toBe(false);
+      expect(shouldForwardHeader("x-real-ip")).toBe(false);
+      expect(shouldForwardHeader("x-cloud-trace-context")).toBe(false);
+      expect(shouldForwardHeader("X-Serverless-Authorization")).toBe(false);
+      expect(shouldForwardHeader("x-vercel-id")).toBe(false);
     });
   });
 
@@ -49,6 +58,26 @@ describe("header-utils", () => {
         "x-custom": "custom-value",
         "x-request-id": "req-123",
         authorization: "Bearer token",
+      });
+    });
+
+    it("drops platform headers so they don't reach the upstream agent", () => {
+      const request = new Request("https://example.com", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer service-token",
+          "X-Serverless-Authorization": "Bearer platform-token",
+          "X-Forwarded-For": "203.0.113.1",
+          "X-Cloud-Trace-Context": "trace/span",
+          "X-Custom": "keep-me",
+        },
+      });
+
+      const result = extractForwardableHeaders(request);
+
+      expect(result).toEqual({
+        authorization: "Bearer service-token",
+        "x-custom": "keep-me",
       });
     });
 

--- a/packages/runtime/src/v2/runtime/handlers/header-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/header-utils.ts
@@ -1,9 +1,27 @@
 /**
+ * Hop-by-hop and platform/proxy headers that describe the inbound
+ * client→runtime hop and must not leak to the upstream agent. They match the
+ * `x-*` allowlist but shouldn't cross the trust boundary — e.g. Cloud Run
+ * validates `x-serverless-authorization` in preference to `authorization`, so
+ * forwarding it lets a platform-injected token shadow the service-to-service
+ * token the server set on the agent (see #5712).
+ */
+const NON_FORWARDABLE_HEADERS = new Set(["x-real-ip", "x-cloud-trace-context"]);
+const NON_FORWARDABLE_PREFIXES = ["x-forwarded-", "x-serverless-", "x-vercel-"];
+
+/**
  * Determines if a header should be forwarded based on the allowlist.
- * Forwards: authorization header and all x-* custom headers.
+ * Forwards the authorization header and x-* custom headers, except hop-by-hop
+ * and platform/proxy headers that belong to the inbound hop.
  */
 export function shouldForwardHeader(headerName: string): boolean {
   const lower = headerName.toLowerCase();
+  if (
+    NON_FORWARDABLE_HEADERS.has(lower) ||
+    NON_FORWARDABLE_PREFIXES.some((prefix) => lower.startsWith(prefix))
+  ) {
+    return false;
+  }
   return lower === "authorization" || lower.startsWith("x-");
 }
 


### PR DESCRIPTION
Closes #5712.

The v2 runtime forwards inbound `authorization` and every `x-*` header onto the agent's outgoing call. That sweeps up platform/proxy headers that only describe the client→runtime hop and shouldn't cross the trust boundary to the upstream agent.

The concrete breakage from the issue: on Cloud Run, the platform injects `X-Serverless-Authorization`, and Cloud Run's IAM frontend validates *that* in preference to `Authorization`. Since it's an `x-*` header it got forwarded, so the agent service validated the foreign platform token instead of the service-to-service bearer the server set on the `HttpAgent` → 401.

Fix is in the allowlist: `shouldForwardHeader` now drops the well-known hop-by-hop/platform headers (`x-forwarded-*`, `x-serverless-*`, `x-vercel-*`, `x-real-ip`, `x-cloud-trace-context`) while still forwarding `authorization` and ordinary `x-*` app headers. Kept it narrow on purpose — this doesn't touch the precedence/override behavior (client `x-*` headers can still override agent defaults, which #5712's existing test relies on), it just stops infra headers from leaking upstream.

Updated the existing `X-Forwarded-For` assertion (it was asserting the buggy behavior) and added tests for the dropped headers.