### PR TITLE
docs(memory): memory guide, self-hosting enablement, and useMemories/injectMemories reference

### DIFF
--- a/showcase/shell-docs/src/content/docs/meta.json
+++ b/showcase/shell-docs/src/content/docs/meta.json
@@ -46,6 +46,7 @@
     "premium/self-hosting",
     "premium/intelligence-platform",
     "premium/threads-explained",
+    "premium/memory",
     "---Bots---",
     "bots",
     "---Deploy---",

--- a/showcase/shell-docs/src/content/docs/premium/memory.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/memory.mdx
@@ -1,0 +1,243 @@
+---
+title: "Memory"
+description: "How CopilotKit memory works — the topical, episodic, and operational memory types, the agent's recall_memory/save_memory/forget_memory tools, embeddings-based hybrid recall, deduplication, non-lossy supersession, enabling memory on the runtime with enableEnterpriseLearning, and reading memories in your app with useMemories (React) and injectMemories (Angular)."
+icon: "lucide/Brain"
+doc_type: how-to
+---
+
+<OpsPlatformCTA
+  variant="inline"
+  title="Want long-term memory in your own app?"
+  body="Memory ships with the Enterprise Intelligence Platform on the free Developer tier."
+  surface="docs_memory"
+/>
+
+## What is memory?
+
+Memory is durable, long-term knowledge that an agent accumulates across conversations and recalls later. Where a [thread](/premium/threads-explained) stores the full event history of a single conversation, a memory captures a distilled fact, preference, or procedure that should outlive any one conversation — so the agent can answer "based on what you told me last week" instead of starting cold every time.
+
+The agent writes and reads memories itself during a run, using built-in `recall_memory`, `save_memory`, and `forget_memory` tools. Your app can also list and manage a user's memories with the `useMemories` hook (React) or the `injectMemories` injectable (Angular). Memory is a platform-level capability: it works the same regardless of which agent framework runs your backend.
+
+## The three memory types
+
+Every memory has a **kind** — one of three types, used with the same names across the agent's tools, the SDK, and the platform:
+
+| Kind | What it holds | Recency behavior |
+|------|---------------|------------------|
+| `topical` | Durable facts and preferences — "what is true." A user's role, their preferred units, a naming convention. | Timeless. Ranked purely on relevance. |
+| `episodic` | Things that happened during interactions — "what occurred." That the user shipped a release on a date, or hit a particular error. | Decays with age. Recent episodes get a recency boost during recall. |
+| `operational` | Procedures and workflows — "how it's done." A trigger plus the steps and parameter values that worked. | Timeless. Ranked purely on relevance. |
+
+## How memory works
+
+### The agent's memory tools
+
+When memory is [enabled on your runtime](#enable-memory-on-the-runtime), every agent run gets three tools:
+
+- **`recall_memory`** — search long-term memory before answering, so responses are grounded in what was learned earlier instead of guessed.
+- **`save_memory`** — store a durable fact, preference, or procedure, tagged with the right `kind`.
+- **`forget_memory`** — retire a memory that is no longer true.
+
+The agent decides when to call these as part of its normal reasoning — there is no separate background process. You steer that behavior through the agent's system prompt (see [enabling](#enable-memory-on-the-runtime) below).
+
+### How recall ranks results
+
+Recall is a hybrid search, not a single similarity score. The platform embeds each memory's content into a vector, and ranks candidates for a query by combining three signals:
+
+- **Semantic similarity** — vector search over meaning, so a recalled memory doesn't have to share the query's exact words.
+- **Keyword match** — full-text search, so exact terms and identifiers still score when phrasing differs.
+- **Recency** — applied to `episodic` memories only, so a recent episode is boosted. `topical` and `operational` facts are timeless and rank on relevance alone.
+
+The recency boost is bounded — a recent episode is nudged up, never allowed to bury a far stronger match. The embedding model is configured on the platform; see [enabling memory](/premium/self-hosting#memory) for self-hosted deployments.
+
+### Deduplication
+
+The platform avoids piling up near-identical memories. When the agent saves content that closely restates an existing memory of the same kind, the save is merged into that existing memory rather than creating a duplicate. Only genuine restatements of the same fact merge; merely-related content is kept distinct.
+
+### Supersession and retirement
+
+Memory is non-lossy — there is no in-place edit and no destructive delete:
+
+- **Supersede** — correcting a memory retires the old one and creates a new memory with the corrected content. The new memory has its own id; the old one leaves the live list but is preserved. The agent supersedes whenever the user contradicts or corrects something it remembered.
+- **Retire** — `forget_memory` (and the SDK's `removeMemory`) marks a memory invalid and excludes it from all future recall, but never hard-deletes it.
+
+This keeps an auditable trail of what the agent used to believe and what replaced it.
+
+### Realtime sync
+
+Memory changes are pushed to connected clients over a WebSocket. When a memory is created, superseded, or retired — whether by the agent during a run or by your own app — the change appears in `useMemories` / `injectMemories` automatically, across tabs and devices, without polling.
+
+## Enable memory on the runtime
+
+Memory has two enable surfaces, and you need both:
+
+1. **The platform** must have memory turned on (the feature gate plus an embeddings provider). For self-hosted clusters, see [Enabling memory](/premium/self-hosting#memory).
+2. **Your runtime** must opt in, so the agent receives the memory tools.
+
+To opt in on the runtime, construct `CopilotKitIntelligence` with `enableEnterpriseLearning: true` and pass it to your `CopilotRuntime`.
+
+<Steps>
+  <Step>
+    ### Enable enterprise learning on the Intelligence client
+
+    `enableEnterpriseLearning` is opt-in and defaults to `false`. Turning it on attaches the `recall_memory`, `save_memory`, and `forget_memory` tools to every agent run.
+
+    ```ts title="server.ts"
+    import {
+      CopilotRuntime,
+      CopilotKitIntelligence,
+    } from "@copilotkit/runtime/v2";
+
+    const intelligence = new CopilotKitIntelligence({
+      apiKey: process.env.INTELLIGENCE_API_KEY,
+      apiUrl: process.env.INTELLIGENCE_API_URL,
+      wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL,
+      enableEnterpriseLearning: true, // [!code highlight]
+    });
+    ```
+  </Step>
+  <Step>
+    ### Resolve the end user on the runtime
+
+    Memory is scoped per end user, so the runtime needs to know who is making the request. Provide `identifyUser` to return the authenticated user for each request.
+
+    ```ts title="server.ts"
+    const runtime = new CopilotRuntime({
+      intelligence,
+      identifyUser: (request) => resolveUser(request), // [!code highlight]
+      agents,
+    });
+    ```
+
+    The memory tools attach only when `identifyUser` resolves a user and the agent framework supports middleware. If it can't attach, the run proceeds without the tools.
+  </Step>
+  <Step>
+    ### Tell the agent when to remember
+
+    The tools are available, but the agent needs guidance on when to use them. Add instructions to its system prompt.
+
+    ```text title="agent system prompt"
+    You have long-term memory tools: recall_memory, save_memory, forget_memory.
+
+    - Before answering anything that could depend on prior conversations or
+      stated preferences, call recall_memory first.
+    - When the user states a durable fact or preference, or teaches you a
+      procedure, call save_memory with the right kind (topical, episodic, or
+      operational).
+    - If save_memory returns near-duplicates: same fact → don't re-save;
+      updated fact → save with `supersedes` set to the old memory's id.
+    - When the user corrects something you remembered, save the correction
+      and supersede the old memory.
+    - Never store secrets or verbatim PII; reference threads by id.
+    - Speak about memories naturally ("earlier you mentioned…"); never name
+      the tools or ids to the user.
+    ```
+  </Step>
+</Steps>
+
+## Read and manage memories in your app
+
+Beyond what the agent does on its own, you can surface and manage a user's memories directly. The `useMemories` hook (React) and `injectMemories` injectable (Angular) expose the live list plus `addMemory`, `updateMemory`, and `removeMemory`.
+
+The list is the current user's memories, newest first, and stays current via realtime sync. Mutations are server-authoritative: each returns a promise that resolves once the platform confirms the operation and rejects on failure. `updateMemory` supersedes (it resolves to a **new** memory), and `removeMemory` retires (a non-lossy delete).
+
+<Tabs items={["React", "Angular"]}>
+  <Tab value="React">
+    ```tsx title="MemoryList.tsx"
+    import { useMemories } from "@copilotkit/react-core/v2";
+
+    function MemoryList() {
+      const { memories, isLoading, isAvailable, removeMemory } = useMemories();
+
+      if (!isAvailable) return null; // memory not enabled on this runtime
+      if (isLoading) return <p>Loading memories…</p>;
+
+      return (
+        <ul>
+          {memories.map((memory) => (
+            <li key={memory.id}>
+              <strong>{memory.kind}</strong> {memory.content}
+              <button onClick={() => removeMemory(memory.id)}>Forget</button>
+            </li>
+          ))}
+        </ul>
+      );
+    }
+    ```
+
+    Create and correct memories from your app:
+
+    ```tsx title="Adding and superseding"
+    const { addMemory, updateMemory } = useMemories();
+
+    // create a new memory
+    await addMemory({ kind: "topical", content: "Prefers metric units" });
+
+    // correcting a memory supersedes it — this resolves to a new memory
+    await updateMemory(existingId, {
+      kind: "topical",
+      content: "Prefers imperial units",
+    });
+    ```
+  </Tab>
+  <Tab value="Angular">
+    `injectMemories` returns Angular signals, so read `memories()`, `isLoading()`, and `isAvailable()` as signal calls.
+
+    ```ts title="memories.component.ts"
+    import { Component } from "@angular/core";
+    import { injectMemories } from "@copilotkit/angular";
+
+    @Component({
+      selector: "app-memories",
+      template: `
+        @if (memory.isAvailable()) {
+          @if (memory.isLoading()) {
+            <p>Loading memories…</p>
+          } @else {
+            <ul>
+              @for (m of memory.memories(); track m.id) {
+                <li>
+                  <strong>{{ m.kind }}</strong> {{ m.content }}
+                  <button (click)="memory.removeMemory(m.id)">Forget</button>
+                </li>
+              }
+            </ul>
+          }
+        }
+      `,
+    })
+    export class MemoriesComponent {
+      readonly memory = injectMemories();
+
+      async addPreference() {
+        await this.memory.addMemory({
+          kind: "topical",
+          content: "Prefers metric units",
+        });
+      }
+    }
+    ```
+  </Tab>
+</Tabs>
+
+## Error handling
+
+### Availability
+
+Memory is an opt-in capability. When it isn't enabled for the connected runtime, the memory routes are unavailable and `isAvailable` is `false` — your UI can hide memory affordances rather than show errors. `isAvailable` stays `true` while memory is reachable and the snapshot loads normally.
+
+### Mutation failures
+
+`addMemory`, `updateMemory`, and `removeMemory` return promises that reject with an `Error` when the platform can't complete the operation — a network failure, a memory that was already retired or superseded by another client, or content that failed validation. The `error` field always reflects the most recent failure and resets to `null` on the next successful fetch.
+
+### WebSocket disconnection
+
+If the WebSocket connection drops (network change, server restart, laptop sleep), the memory list stops receiving live updates and becomes stale until the connection is re-established. Reconnection is automatic with backoff; you can also call `refresh()` to re-pull the snapshot immediately.
+
+## Next steps
+
+- **React API reference:** [useMemories](/reference/hooks/useMemories) — parameters, return values, and types
+- **Angular API reference:** [injectMemories](/reference/angular/functions/injectMemories) — the signals-based equivalent
+- **Enable memory on a self-hosted cluster:** [Self-Hosting Enterprise Intelligence](/premium/self-hosting#memory) — the `memory.enabled` gate and embeddings configuration
+- **Platform architecture:** [Enterprise Intelligence Architecture](/premium/intelligence-platform) — how runtimes connect to platform projects, durable history, and realtime sync
+- **Related capability:** [Threads & Persistence Architecture](/premium/threads-explained) — durable per-conversation history, the companion to long-term memory

--- a/showcase/shell-docs/src/content/docs/premium/meta.json
+++ b/showcase/shell-docs/src/content/docs/premium/meta.json
@@ -5,6 +5,7 @@
     "managed-intelligence-platform",
     "self-hosting",
     "intelligence-platform",
-    "threads-explained"
+    "threads-explained",
+    "memory"
   ]
 }

--- a/showcase/shell-docs/src/content/reference/angular/functions/injectMemories.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/injectMemories.mdx
@@ -1,0 +1,162 @@
+---
+title: "injectMemories"
+description: "Angular function that returns signals of a user's long-term memories plus create, supersede, and retire callbacks for @copilotkit/angular."
+---
+
+## Overview
+
+`injectMemories` reads and manages a user's long-term [memories](/premium/memory) on the Enterprise Intelligence Platform. It returns a `MemoriesController` whose state members are Angular signals — the live list plus loading, error, and availability — together with stable callbacks to create, supersede, and retire memories.
+
+This is the Angular equivalent of React's [`useMemories()`](/reference/hooks/useMemories). Call it from an injection context (a constructor or a field initializer); the underlying subscription is torn down automatically when the owning component or service is destroyed.
+
+Memory must be enabled on the runtime ([`enableEnterpriseLearning`](/premium/memory#enable-memory-on-the-runtime)) and the platform for the list to populate.
+
+## Signature
+
+```ts
+import { injectMemories } from "@copilotkit/angular";
+
+function injectMemories(): MemoriesController;
+```
+
+## Parameters
+
+This function takes no parameters.
+
+## Return Value
+
+<PropertyReference name="controller" type="MemoriesController">
+  A controller whose state members are signals and whose mutation members are stable callbacks.
+
+  ### State
+
+  <PropertyReference name="memories" type="Signal<Memory[]>">
+    A signal of the current user's memories, newest first, kept current by realtime updates. Read it with `controller.memories()`. Each `Memory` contains:
+    - `id: string` — unique memory identifier (superseding produces a new `id`)
+    - `kind: "topical" | "episodic" | "operational"` — the memory type
+    - `scope: "user"` — the memory's visibility; the SDK surfaces user-scoped memories
+    - `content: string` — the memory text
+    - `sourceThreadIds: readonly string[]` — ids of the threads this memory was learned from
+    - `invalidatedAt: string | null` — ISO 8601 timestamp set when the memory is retired, or `null` while live
+  </PropertyReference>
+
+  <PropertyReference name="isLoading" type="Signal<boolean>">
+    `true` while the initial memory snapshot is being fetched. Read it with `controller.isLoading()`. Subsequent realtime updates do not re-enter the loading state.
+  </PropertyReference>
+
+  <PropertyReference name="error" type="Signal<Error | null>">
+    A signal of the most recent error from fetching memories or running a mutation, or `null`. Read it with `controller.error()`. Resets to `null` on the next successful fetch.
+  </PropertyReference>
+
+  <PropertyReference name="isAvailable" type="Signal<boolean>">
+    `true` when the runtime's memory routes are reachable. `false` after a 404 or 501, indicating memory is not enabled on the current runtime. Read it with `controller.isAvailable()` to hide memory UI rather than show an error.
+  </PropertyReference>
+
+  ### Methods
+
+  <PropertyReference name="refresh" type="() => Promise<void>">
+    Re-fetch the memory snapshot from the platform without clearing the current list. Resolves once the re-pull settles; rejects if it fails or the store is torn down mid-flight.
+  </PropertyReference>
+
+  <PropertyReference name="addMemory" type="(input: NewMemory) => Promise<Memory>">
+    Create a memory. Resolves to the stored memory (server-authoritative); rejects on failure. `NewMemory` is `{ content: string; kind: "topical" | "episodic" | "operational"; scope?: "user"; sourceThreadIds?: readonly string[] }`.
+  </PropertyReference>
+
+  <PropertyReference name="updateMemory" type="(id: string, changes: NewMemory) => Promise<Memory>">
+    Supersede a memory: the old memory is retired and a new one is created. Resolves to the **new** memory — its `id` differs from the supplied `id`. Rejects on failure.
+  </PropertyReference>
+
+  <PropertyReference name="removeMemory" type="(id: string) => Promise<void>">
+    Retire a memory — a non-lossy delete that excludes the memory from future recall without hard-deleting it. Resolves when the platform confirms; rejects on failure.
+  </PropertyReference>
+</PropertyReference>
+
+## Usage
+
+### List and remove memories
+
+```ts title="src/app/memories.component.ts"
+import { Component } from "@angular/core";
+import { injectMemories } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-memories",
+  standalone: true,
+  template: `
+    @if (memory.isAvailable()) {
+      @if (memory.isLoading()) {
+        <p>Loading memories…</p>
+      } @else {
+        <ul>
+          @for (m of memory.memories(); track m.id) {
+            <li>
+              <strong>{{ m.kind }}</strong> {{ m.content }}
+              <button (click)="memory.removeMemory(m.id)">Forget</button>
+            </li>
+          }
+        </ul>
+      }
+    }
+  `,
+})
+export class MemoriesComponent {
+  readonly memory = injectMemories();
+}
+```
+
+### Create and correct memories
+
+```ts title="src/app/edit-memory.component.ts"
+import { Component } from "@angular/core";
+import { injectMemories } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-edit-memory",
+  standalone: true,
+  template: `<button (click)="addPreference()">Save preference</button>`,
+})
+export class EditMemoryComponent {
+  readonly memory = injectMemories();
+
+  async addPreference() {
+    // create
+    await this.memory.addMemory({
+      kind: "topical",
+      content: "Prefers metric units",
+    });
+  }
+
+  async correct(existingId: string) {
+    // supersedes the old memory and resolves to a new one
+    await this.memory.updateMemory(existingId, {
+      kind: "topical",
+      content: "Prefers imperial units",
+    });
+  }
+}
+```
+
+## Behavior
+
+- **Injection context required.** Call `injectMemories()` from a constructor or field initializer so the selector→signal bridges tear down with the host.
+- **Server-authoritative mutations.** `addMemory`, `updateMemory`, and `removeMemory` resolve only after the platform confirms, and reject on failure.
+- **Supersede, not edit.** `updateMemory` never edits in place. It retires the target and creates a successor with a new `id`; the returned memory is the successor.
+- **Realtime updates.** The underlying store opens its own subscription and applies create/supersede/retire deltas, so the signals stay current across tabs and devices without polling.
+- **Availability.** A 404/501 from a runtime without memory enabled sets `isAvailable()` to `false` rather than surfacing an error.
+
+## Related
+
+<Cards>
+  <Card
+    title="useMemories"
+    description="The React equivalent — same contract, returned as plain values instead of signals."
+    href="/reference/hooks/useMemories"
+    icon={<LinkIcon />}
+  />
+  <Card
+    title="Memory"
+    description="How memory works, the memory types, recall, and enabling memory on the runtime."
+    href="/premium/memory"
+    icon={<LinkIcon />}
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/hooks/useMemories.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useMemories.mdx
@@ -1,0 +1,131 @@
+---
+title: "useMemories"
+description: "React hook for listing and managing a user's long-term memories with useMemories — create, supersede, and retire memories with realtime updates via WebSocket."
+doc_type: reference
+---
+
+<OpsPlatformCTA
+  variant="card"
+  title="useMemories needs an Enterprise Intelligence Platform project"
+  body="Create a cloud-hosted project or connect a self-hosted deployment to start syncing memories."
+  ctaLabel="Create a free account"
+  surface="docs_reference_use_memories"
+/>
+
+## Overview
+
+`useMemories` is a React hook for reading and managing a user's long-term [memories](/premium/memory) on the Enterprise Intelligence Platform. It fetches the memory list, keeps it synchronized in realtime via WebSocket, and exposes mutation methods to create, supersede, and retire memories.
+
+Memories are sorted newest first. The hook consumes the memory store owned by `CopilotKitCore` — it does not create or configure the store. Memory must be enabled on the runtime ([`enableEnterpriseLearning`](/premium/memory#enable-memory-on-the-runtime)) and the platform for the list to populate.
+
+## Signature
+
+```tsx
+import { useMemories } from "@copilotkit/react-core/v2";
+
+function useMemories(): UseMemoriesResult
+```
+
+## Parameters
+
+This hook takes no parameters.
+
+## Return Value
+
+<PropertyReference name="result" type="UseMemoriesResult">
+
+  ### State
+
+  <PropertyReference name="memories" type="Memory[]">
+    The current user's memories, newest first, kept current by realtime updates. Each `Memory` contains:
+    - `id: string` — unique memory identifier (superseding produces a new `id`)
+    - `kind: "topical" | "episodic" | "operational"` — the memory type
+    - `scope: "user"` — the memory's visibility; the SDK surfaces user-scoped memories
+    - `content: string` — the memory text
+    - `sourceThreadIds: readonly string[]` — ids of the threads this memory was learned from
+    - `invalidatedAt: string | null` — ISO 8601 timestamp set when the memory is retired, or `null` while live
+  </PropertyReference>
+
+  <PropertyReference name="isLoading" type="boolean">
+    `true` while the initial memory snapshot is being fetched. Subsequent realtime updates do not re-enter the loading state.
+  </PropertyReference>
+
+  <PropertyReference name="error" type="Error | null">
+    The most recent error from fetching memories or running a mutation, or `null`. Resets to `null` on the next successful fetch.
+  </PropertyReference>
+
+  <PropertyReference name="isAvailable" type="boolean">
+    `true` when the runtime's memory routes are reachable. `false` after a 404 or 501, indicating memory is not enabled on the current runtime — use it to hide memory UI rather than show an error.
+  </PropertyReference>
+
+  ### Methods
+
+  <PropertyReference name="refresh" type="() => Promise<void>">
+    Re-fetch the memory snapshot from the platform without clearing the current list. Resolves once the re-pull settles; rejects if it fails or the store is torn down mid-flight.
+  </PropertyReference>
+
+  <PropertyReference name="addMemory" type="(input: NewMemory) => Promise<Memory>">
+    Create a memory. Resolves to the stored memory (server-authoritative); rejects on failure. `NewMemory` is `{ content: string; kind: "topical" | "episodic" | "operational"; scope?: "user"; sourceThreadIds?: readonly string[] }`.
+  </PropertyReference>
+
+  <PropertyReference name="updateMemory" type="(id: string, changes: NewMemory) => Promise<Memory>">
+    Supersede a memory: the old memory is retired and a new one is created. Resolves to the **new** memory — its `id` differs from the supplied `id`. Rejects on failure.
+  </PropertyReference>
+
+  <PropertyReference name="removeMemory" type="(id: string) => Promise<void>">
+    Retire a memory — a non-lossy delete that excludes the memory from future recall without hard-deleting it. Resolves when the platform confirms; rejects on failure.
+  </PropertyReference>
+</PropertyReference>
+
+## Usage
+
+```tsx title="MemoryList.tsx"
+import { useMemories } from "@copilotkit/react-core/v2"; // [!code highlight]
+
+function MemoryList() {
+  const { memories, isLoading, isAvailable, removeMemory } = useMemories(); // [!code highlight]
+
+  if (!isAvailable) return null;
+  if (isLoading) return <div>Loading memories…</div>;
+
+  return (
+    <ul>
+      {memories.map((memory) => (
+        <li key={memory.id}>
+          <strong>{memory.kind}</strong> {memory.content}
+          <button onClick={() => removeMemory(memory.id)}>Forget</button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+Create a memory, and correct one by superseding it:
+
+```tsx title="EditMemory.tsx"
+const { addMemory, updateMemory } = useMemories();
+
+// create
+await addMemory({ kind: "topical", content: "Prefers metric units" });
+
+// correct — supersedes the old memory and resolves to a new one
+const updated = await updateMemory(existingId, {
+  kind: "topical",
+  content: "Prefers imperial units",
+});
+```
+
+## Behavior
+
+- On mount, fetches the memory snapshot and establishes a realtime WebSocket subscription.
+- If the runtime does not advertise memory endpoints, `isAvailable` becomes `false` and no error is surfaced.
+- Memory creates, supersedes, and retirements from any client (including the agent during a run) are reflected without polling.
+- Mutations are **server-authoritative** — `addMemory`, `updateMemory`, and `removeMemory` resolve only after the platform confirms, and reject on failure.
+- `updateMemory` never edits in place. It retires the target and creates a successor with a new `id`; the returned memory is the successor.
+- The `error` state updates with the most recent error and resets to `null` on the next successful fetch.
+
+## Next steps
+
+- **How memory works:** [Memory](/premium/memory) — types, recall, enabling memory, and the Angular equivalent
+- **Platform architecture:** [Enterprise Intelligence Architecture](/premium/intelligence-platform) — the platform behind memory and realtime sync

--- a/showcase/shell-docs/src/content/snippets/shared/premium/self-hosting.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/premium/self-hosting.mdx
@@ -444,6 +444,26 @@ The tables below summarize the most common values. For every option, see `values
 | `auth.providerName` | Display name shown in the UI | `Enterprise SSO` |
 | `auth.trustHost` | Trust the `X-Forwarded-Host` header (set behind a reverse proxy) | `"true"` |
 
+### Memory
+
+Long-term [memory](/premium/memory) is off by default. Setting `memory.enabled: true` registers the agent memory tools on the platform's `/mcp` endpoint and deploys an embeddings workload. Memory requires the **pgvector** extension on your Postgres database.
+
+By default an in-cluster [text-embeddings-inference](https://github.com/huggingface/text-embeddings-inference) (TEI) sidecar is deployed to embed memory content. Alternatively, point `embeddings.external` at any hosted OpenAI-compatible embeddings endpoint and the sidecar is not deployed. Either way, embeddings must be **1024-dimensional** to match the storage schema — app-api refuses to start otherwise.
+
+| Key | Description | Default |
+|---|---|---|
+| `memory.enabled` | Enable memory: register memory tools on `/mcp` and deploy the embeddings workload | `false` |
+| `embeddings.modelId` | Embedding model served by the in-cluster TEI sidecar (1024-dim) | `Qwen/Qwen3-Embedding-0.6B` |
+| `embeddings.persistence.enabled` | Persist the downloaded model in a PVC (avoids re-download on restart) | `true` |
+| `embeddings.external.enabled` | Use a hosted OpenAI-compatible endpoint instead of the TEI sidecar | `false` |
+| `embeddings.external.url` | Base URL of the OpenAI-compatible endpoint (e.g. `https://api.openai.com`) | `""` |
+| `embeddings.external.model` | Model id sent to the endpoint (e.g. `text-embedding-3-small`) | `""` |
+| `embeddings.external.dimensions` | Output dimensionality; must be `1024` | `1024` |
+| `embeddings.external.apiKey.existingSecret` | Secret holding the embeddings API key | `""` |
+| `embeddings.external.apiKey.secretKey` | Key within that Secret | `""` |
+
+Enabling memory on the cluster makes the platform able to store and serve memories. Your CopilotKit runtime must also opt in so the agent actually uses them — see [Memory](/premium/memory#enable-memory-on-the-runtime).
+
 ### Ingress
 
 | Key | Description | Default |


### PR DESCRIPTION
## RD-41 — Memory docs

Documents memory in the CopilotKit docs (shell-docs). Stacks on `mme/memory-core` alongside the implementation it describes.

### What's included

- **Memory guide** (`premium/memory`) — the `topical` / `episodic` / `operational` memory types, the agent's `recall_memory` / `save_memory` / `forget_memory` tools, embeddings-based hybrid recall, deduplication, non-lossy supersession and retirement, enabling memory on the runtime via `enableEnterpriseLearning`, and `useMemories` / `injectMemories` usage examples.
- **Self-hosting** — a Memory section in the self-hosting guide: the `memory.enabled` gate and embeddings configuration (in-cluster TEI sidecar vs. external OpenAI-compatible provider), plus the pgvector requirement.
- **API reference** — `useMemories` (React) and `injectMemories` (Angular).

### Notes

- The recall hooks named in the ticket (`useMemoryRecall` / `injectMemoryRecall`) are intentionally **not** documented — they don't exist yet; recall is currently agent-only via the memory tools.
- Project scope is intentionally not surfaced — the SDK lists user-scoped memories today.

### Verified

- Docs dev server renders all four pages (HTTP 200, no build errors).
- The guide appears in the sidebar under **Intelligence Platform**; the reference pages auto-register under **Hooks** (React) and **Functions** (Angular).
