### PR TITLE
fix(vue): enable A2UI via catalog-on-provider path

### DIFF
--- a/examples/v2/vue/demo/pages/a2ui-catalog.vue
+++ b/examples/v2/vue/demo/pages/a2ui-catalog.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import {
+  CopilotChat,
+  CopilotKitProvider,
+  vueBasicCatalog,
+} from "@copilotkit/vue";
+
+// Catalog-on-provider path (#5774): the runtime at /api/copilotkit-catalog has
+// NO a2ui config. A2UI must switch on purely because we pass a catalog here,
+// which also forwards `a2uiCatalogAvailable` to the runtime.
+</script>
+
+<template>
+  <CopilotKitProvider
+    runtime-url="/api/copilotkit-catalog"
+    :a2ui="{ catalog: vueBasicCatalog }"
+    show-dev-console="auto"
+  >
+    <div style="height: 100vh; margin: 0; padding: 0; overflow: hidden">
+      <CopilotChat agent-id="demo-button" thread-id="a2ui-catalog-thread" />
+    </div>
+  </CopilotKitProvider>
+</template>

--- a/examples/v2/vue/demo/server/api/copilotkit-catalog/[...slug].ts
+++ b/examples/v2/vue/demo/server/api/copilotkit-catalog/[...slug].ts
@@ -1,0 +1,4 @@
+import { copilotCatalogEndpoint } from "../../utils/endpoints";
+import { defineHonoEventHandler } from "../../utils/hono-handler";
+
+export default defineHonoEventHandler(copilotCatalogEndpoint);

--- a/examples/v2/vue/demo/server/api/copilotkit-catalog/index.ts
+++ b/examples/v2/vue/demo/server/api/copilotkit-catalog/index.ts
@@ -1,0 +1,4 @@
+import { copilotCatalogEndpoint } from "../../utils/endpoints";
+import { defineHonoEventHandler } from "../../utils/hono-handler";
+
+export default defineHonoEventHandler(copilotCatalogEndpoint);

--- a/examples/v2/vue/demo/server/utils/endpoints.ts
+++ b/examples/v2/vue/demo/server/utils/endpoints.ts
@@ -2,11 +2,16 @@ import {
   createCopilotEndpoint,
   createCopilotEndpointSingleRoute,
 } from "@copilotkit/runtime/v2";
-import { createDefaultRuntime, createMcpRuntime } from "./runtime";
+import {
+  createCatalogOnlyRuntime,
+  createDefaultRuntime,
+  createMcpRuntime,
+} from "./runtime";
 
 const defaultRuntime = createDefaultRuntime();
 const singleRuntime = createDefaultRuntime();
 const mcpRuntime = createMcpRuntime();
+const catalogOnlyRuntime = createCatalogOnlyRuntime();
 
 export const copilotEndpoint = createCopilotEndpoint({
   runtime: defaultRuntime,
@@ -21,4 +26,9 @@ export const copilotSingleEndpoint = createCopilotEndpointSingleRoute({
 export const copilotMcpEndpoint = createCopilotEndpoint({
   runtime: mcpRuntime,
   basePath: "/api/copilotkit-mcp",
+});
+
+export const copilotCatalogEndpoint = createCopilotEndpoint({
+  runtime: catalogOnlyRuntime,
+  basePath: "/api/copilotkit-catalog",
 });

--- a/examples/v2/vue/demo/server/utils/runtime.ts
+++ b/examples/v2/vue/demo/server/utils/runtime.ts
@@ -79,53 +79,46 @@ class DemoButtonAgent extends AbstractAgent {
           messageId: activityId,
           activityType: "a2ui-surface",
           content: {
-            operations: [
+            // Canonical A2UI v0.9 content key + operation format (matches
+            // @ag-ui/a2ui-middleware, @copilotkit/vue's A2UIMessageRenderer,
+            // @a2ui/web_core, and the Python SDK). The root component must
+            // have id "root".
+            a2ui_operations: [
               {
-                beginRendering: {
+                version: "v0.9",
+                createSurface: {
                   surfaceId: "demo-surface",
-                  root: "container",
+                  catalogId:
+                    "https://a2ui.org/specification/v0_9/basic_catalog.json",
                 },
               },
               {
-                surfaceUpdate: {
+                version: "v0.9",
+                updateComponents: {
                   surfaceId: "demo-surface",
                   components: [
                     {
-                      id: "container",
-                      component: {
-                        Column: {
-                          children: {
-                            explicitList: ["prompt-text", "confirm-btn"],
-                          },
-                        },
-                      },
+                      id: "root",
+                      component: "Column",
+                      children: ["prompt-text", "confirm-btn"],
                     },
                     {
                       id: "prompt-text",
-                      component: {
-                        Text: {
-                          text: {
-                            literalString:
-                              "Click the button to trigger a response:",
-                          },
-                        },
-                      },
+                      component: "Text",
+                      text: "Click the button to trigger a response:",
+                      variant: "body",
                     },
                     {
                       id: "btn-label",
-                      component: {
-                        Text: { text: { literalString: "Confirm" } },
-                      },
+                      component: "Text",
+                      text: "Confirm",
                     },
                     {
                       id: "confirm-btn",
-                      component: {
-                        Button: {
-                          child: "btn-label",
-                          action: { name: "confirm" },
-                          primary: true,
-                        },
-                      },
+                      component: "Button",
+                      child: "btn-label",
+                      variant: "primary",
+                      action: { event: { name: "confirm" } },
                     },
                   ],
                 },
@@ -175,6 +168,20 @@ export const createDefaultRuntime = () =>
     runner: new InMemoryAgentRunner(),
     transcriptionService: createTranscriptionService(),
     a2ui: {},
+  });
+
+/**
+ * Catalog-on-provider runtime: same DemoButtonAgent, but the runtime has NO
+ * `a2ui` config. A2UI is meant to switch on purely from the client passing
+ * `a2ui.catalog` to the provider (which forwards `a2uiCatalogAvailable`).
+ * Used by `/a2ui-catalog` to validate the #5774 fix in isolation.
+ */
+export const createCatalogOnlyRuntime = () =>
+  new CopilotRuntime({
+    agents: {
+      "demo-button": new DemoButtonAgent(),
+    },
+    runner: new InMemoryAgentRunner(),
   });
 
 export const createMcpRuntime = () => {

--- a/packages/vue/src/v2/__tests__/exports.test.ts
+++ b/packages/vue/src/v2/__tests__/exports.test.ts
@@ -25,6 +25,13 @@ describe("package exports", () => {
     expect(typeof VuePackage.A2UISurfaceActivityRenderer).toBe("object");
   });
 
+  it("exports the default A2UI catalog for the catalog-on-provider path", () => {
+    // Users pass this to `a2ui.catalog` to enable A2UI from the provider.
+    // Guards against the library build tree-shaking the re-export away.
+    expect(VuePackage.vueBasicCatalog).toBeDefined();
+    expect(VuePackage.vueBasicCatalog.components.size).toBeGreaterThan(0);
+  });
+
   it("exports the vue stylesheet entrypoint", () => {
     const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
       exports?: Record<string, unknown>;

--- a/packages/vue/src/v2/index.ts
+++ b/packages/vue/src/v2/index.ts
@@ -4,6 +4,11 @@ export * from "@ag-ui/client";
 
 // Local V2 vue code
 export * from "./components";
+// Explicit re-export so the default A2UI catalog is reachable as a public
+// named export. Vue users need a catalog to pass to `a2ui.catalog` for the
+// catalog-on-provider path; the nested `export *` barrel above gets
+// tree-shaken by the library build, so surface it directly here.
+export { vueBasicCatalog } from "./components/a2ui/catalog";
 export * from "./hooks";
 export * from "./providers";
 export * from "./types";

--- a/packages/vue/src/v2/providers/CopilotKitProvider.vue
+++ b/packages/vue/src/v2/providers/CopilotKitProvider.vue
@@ -295,6 +295,21 @@ const runtimeLicenseStatus = ref<RuntimeLicenseStatus | undefined>(undefined);
 const openGenerativeUIActive = computed(
   () => runtimeOpenGenerativeUIEnabled.value || !!props.openGenerativeUI,
 );
+// A catalog passed to the provider is enough to turn A2UI on: render the
+// surfaces locally and forward the catalog signal so the runtime injects the
+// render tool — no runtime-side `a2ui` config required.
+const a2uiCatalogProvided = computed(() => !!props.a2ui?.catalog);
+const a2uiActive = computed(
+  () => runtimeA2UIEnabled.value || a2uiCatalogProvided.value,
+);
+// Forward a per-run signal when the provider has an A2UI catalog so the
+// runtime can turn A2UI on (and inject the render tool) without a separate
+// `a2ui.injectA2UITool` flag on the runtime.
+const resolvedProperties = computed(() =>
+  a2uiCatalogProvided.value
+    ? { ...props.properties, a2uiCatalogAvailable: true }
+    : props.properties,
+);
 const sandboxFunctions = computed<readonly SandboxFunction[]>(
   () => props.openGenerativeUI?.sandboxFunctions ?? [],
 );
@@ -343,7 +358,7 @@ const builtInActivityRenderers = computed<
     });
   }
 
-  if (runtimeA2UIEnabled.value) {
+  if (a2uiActive.value) {
     renderers.unshift(
       createA2UIMessageRenderer({
         theme: props.a2ui?.theme ?? viewerTheme,
@@ -384,7 +399,7 @@ const createCopilotKit = () => {
           : "auto",
     headers: mergedHeaders.value,
     credentials: props.credentials,
-    properties: props.properties,
+    properties: resolvedProperties.value,
     agents__unsafe_dev_only: mergedAgents.value,
     tools: allTools.value,
     renderToolCalls: allRenderToolCalls.value,
@@ -503,7 +518,7 @@ function syncRuntimeConfig() {
   );
   copilotkit.value.setHeaders(mergedHeaders.value);
   copilotkit.value.setCredentials(props.credentials);
-  copilotkit.value.setProperties(props.properties);
+  copilotkit.value.setProperties(resolvedProperties.value);
   copilotkit.value.setAgents__unsafe_dev_only(mergedAgents.value);
   copilotkit.value.setDebug(props.debug);
   applyDefaultThrottleMs(copilotkit.value);
@@ -514,7 +529,7 @@ watch(
     () => chatApiEndpoint.value,
     () => mergedHeaders.value,
     () => props.credentials,
-    () => props.properties,
+    () => resolvedProperties.value,
     () => mergedAgents.value,
     () => props.useSingleEndpoint,
     () => props.debug,
@@ -549,11 +564,11 @@ const a2uiLoadingComponent = computed(() => props.a2ui?.loadingComponent);
 const a2uiIncludeSchema = computed(() => props.a2ui?.includeSchema ?? true);
 
 // A2UI tool call renderer (progress indicator) — auto-registered when A2UI enabled
-registerA2UIBuiltInToolCallRenderer(copilotkit, () => runtimeA2UIEnabled.value);
+registerA2UIBuiltInToolCallRenderer(copilotkit, () => a2uiActive.value);
 
 // A2UI catalog context, schema, and generation/design guidelines
 registerA2UICatalogContext(copilotkit, {
-  enabled: () => runtimeA2UIEnabled.value,
+  enabled: () => a2uiActive.value,
   catalog: () => props.a2ui?.catalog,
   includeSchema: () => props.a2ui?.includeSchema ?? true,
 });

--- a/packages/vue/src/v2/providers/__tests__/CopilotKitProvider.a2ui.test.ts
+++ b/packages/vue/src/v2/providers/__tests__/CopilotKitProvider.a2ui.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { defineComponent, h, ref } from "vue";
+import { mount } from "@vue/test-utils";
+import CopilotKitProvider from "../CopilotKitProvider.vue";
+import { useCopilotKit } from "../useCopilotKit";
+
+function mountProvider(props: Record<string, unknown>) {
+  const observedCore =
+    ref<ReturnType<typeof useCopilotKit>["copilotkit"]["value"]>();
+
+  const Child = defineComponent({
+    setup() {
+      const { copilotkit } = useCopilotKit();
+      observedCore.value = copilotkit.value;
+      return () => h("div");
+    },
+  });
+
+  const wrapper = mount(CopilotKitProvider, {
+    props: {
+      runtimeUrl: "/api/copilotkit",
+      ...props,
+    },
+    slots: {
+      default: () => h(Child),
+    },
+  });
+
+  return { wrapper, observedCore };
+}
+
+describe("CopilotKitProvider a2ui catalog auto-enable", () => {
+  it("forwards a2uiCatalogAvailable when a catalog is passed to the provider", () => {
+    const { observedCore } = mountProvider({
+      a2ui: { catalog: { id: "test", components: new Map() } },
+    });
+
+    expect(observedCore.value?.properties.a2uiCatalogAvailable).toBe(true);
+  });
+
+  it("does not forward a2uiCatalogAvailable when no catalog is passed", () => {
+    const { observedCore } = mountProvider({ a2ui: {} });
+
+    expect(observedCore.value?.properties.a2uiCatalogAvailable).toBeUndefined();
+  });
+
+  it("preserves user-provided properties alongside the catalog signal", () => {
+    const { observedCore } = mountProvider({
+      a2ui: { catalog: { id: "test", components: new Map() } },
+      properties: { tenant: "acme" },
+    });
+
+    expect(observedCore.value?.properties).toMatchObject({
+      tenant: "acme",
+      a2uiCatalogAvailable: true,
+    });
+  });
+
+  it("registers an a2ui-surface renderer when a catalog is provided, without a runtime signal", () => {
+    const { observedCore } = mountProvider({
+      a2ui: { catalog: { id: "test", components: new Map() } },
+    });
+
+    const a2uiRenderer = observedCore.value?.renderActivityMessages.find(
+      (r) => r.activityType === "a2ui-surface",
+    );
+    expect(a2uiRenderer).toBeDefined();
+  });
+
+  it("does not register an a2ui-surface renderer when no catalog is provided and runtime has not signaled a2uiEnabled", () => {
+    const { observedCore } = mountProvider({ a2ui: { theme: {} } });
+
+    const a2uiRenderer = observedCore.value?.renderActivityMessages.find(
+      (r) => r.activityType === "a2ui-surface",
+    );
+    expect(a2uiRenderer).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #5774. A2UI did not work when using `@copilotkit/vue` with a CopilotRuntime.

The Vue `CopilotKitProvider` gated **all** A2UI activation on the runtime signal (`core.a2uiEnabled`). Passing an `a2ui.catalog` to the provider did nothing:

- the A2UI surface activity renderer was never registered locally, and
- the runtime was never told to inject the render tool.

React supports the catalog-on-provider path as of 1.61.2: a catalog on the provider turns A2UI on and forwards an `a2uiCatalogAvailable` run property so the runtime injects the render tool without a separate runtime-side `a2ui` config.

## Fix

**Provider wiring** (`packages/vue/src/v2/providers/CopilotKitProvider.vue`), mirroring React:

- `a2uiCatalogProvided` = a catalog was passed to the provider.
- `a2uiActive` = `runtimeA2UIEnabled || a2uiCatalogProvided`, now gating the surface renderer, the built-in tool-call renderer, and the catalog context registration.
- `resolvedProperties` forwards `a2uiCatalogAvailable: true` when a catalog is present, preserving user-provided `properties`. Wired into core construction, `syncRuntimeConfig`, and the reactive watch.

**Catalog export** (`packages/vue/src/v2/index.ts`): the catalog-on-provider path needs a catalog to pass to `a2ui.catalog`, but the library build tree-shook the nested barrel re-export so `vueBasicCatalog` was unreachable at runtime (present only in `.d.ts`). Re-exported explicitly, mirroring React's `basicCatalog` from `@copilotkit/a2ui-renderer`.

No behavior change for the runtime-side `a2ui` config path; that still flips `runtimeA2UIEnabled`.

## Tests

- `CopilotKitProvider.a2ui.test.ts` (new): forwards `a2uiCatalogAvailable` when a catalog is passed; does not when absent; preserves user properties; registers the `a2ui-surface` renderer from a catalog alone (no runtime signal); does not register it when neither catalog nor runtime signal present.
- `exports.test.ts`: asserts `vueBasicCatalog` is a runtime export (guards the tree-shaking regression).
- Full Vue suite: **1011 passing**. `nx run @copilotkit/vue:build` (incl. `vue-tsc`) passes.

## Visual validation

Added a `/a2ui-catalog` demo page (`examples/v2/vue/demo`) wired to a runtime endpoint with **no** `a2ui` config, so A2UI activates purely from the provider catalog. Drove it in a browser:

1. Surface paints: "Click the button to trigger a response:" + a **Confirm** button.
2. Click Confirm -> agent replies **"Confirmed! ... the fix is working."**

Network request to the no-a2ui runtime confirms both halves of the fix: `"a2uiCatalogAvailable":true` is forwarded and the "A2UI Component Schema" catalog context is sent.

While building the demo I also fixed `DemoButtonAgent`, which never actually rendered — it emitted the wrong activity content key (`operations` -> `a2ui_operations`) and a non-canonical op/component format. Rewritten to the A2UI v0.9 wire format (`createSurface`/`updateComponents`, flat components, root id `root`).