### PR TITLE
fix(chat): keep message padding in sub-viewport panes via container query (ENT-1020)

### DIFF
--- a/packages/angular/src/lib/components/chat/copilot-chat-suggestion-view.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat-suggestion-view.ts
@@ -11,7 +11,7 @@ import { cn } from "../../utils";
 import { CopilotChatSuggestionPill } from "./copilot-chat-suggestion-pill";
 
 const suggestionViewClass = cn(
-  "cpk:flex cpk:flex-wrap cpk:items-center cpk:gap-1.5 cpk:sm:gap-2 cpk:pl-0 cpk:pr-4 cpk:sm:px-0",
+  "cpk:flex cpk:flex-wrap cpk:items-center cpk:gap-1.5 cpk:sm:gap-2 cpk:pl-0 cpk:pr-4 cpk:@3xl:px-0",
   "cpk:pointer-events-none",
 );
 

--- a/packages/angular/src/lib/components/chat/copilot-chat-view-input-container.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat-view-input-container.ts
@@ -35,7 +35,9 @@ import { CopilotChatAttachmentQueue } from "./copilot-chat-attachment-queue";
     <div [class]="computedClass">
       <!-- Input component -->
       @if ((chatState?.attachments() ?? []).length > 0) {
-        <div class="cpk:max-w-3xl cpk:mx-auto cpk:w-full cpk:pointer-events-auto">
+        <div
+          class="cpk:max-w-3xl cpk:mx-auto cpk:w-full cpk:pointer-events-auto"
+        >
           <copilot-chat-attachment-queue
             [attachments]="chatState?.attachments() ?? []"
             inputClass="cpk:px-4"
@@ -44,7 +46,7 @@ import { CopilotChatAttachmentQueue } from "./copilot-chat-attachment-queue";
         </div>
       }
 
-      <div class="cpk:max-w-3xl cpk:mx-auto cpk:py-0 cpk:px-4 cpk:sm:px-0">
+      <div class="cpk:max-w-3xl cpk:mx-auto cpk:py-0 cpk:px-4 cpk:@3xl:px-0">
         <copilot-slot
           [slot]="input()"
           [context]="{ inputClass: inputClass() }"

--- a/packages/angular/src/lib/components/chat/copilot-chat-view-input-container.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat-view-input-container.ts
@@ -35,9 +35,7 @@ import { CopilotChatAttachmentQueue } from "./copilot-chat-attachment-queue";
     <div [class]="computedClass">
       <!-- Input component -->
       @if ((chatState?.attachments() ?? []).length > 0) {
-        <div
-          class="cpk:max-w-3xl cpk:mx-auto cpk:w-full cpk:pointer-events-auto"
-        >
+        <div class="cpk:max-w-3xl cpk:mx-auto cpk:w-full cpk:pointer-events-auto">
           <copilot-chat-attachment-queue
             [attachments]="chatState?.attachments() ?? []"
             inputClass="cpk:px-4"

--- a/packages/angular/src/lib/components/chat/copilot-chat-view-scroll-view.html
+++ b/packages/angular/src/lib/components/chat/copilot-chat-view-scroll-view.html
@@ -23,7 +23,7 @@
       >
       </copilot-chat-message-view>
       } @if (hasSuggestions()) {
-      <div class="cpk:pl-0 cpk:pr-4 cpk:sm:px-0 cpk:mt-4">
+      <div class="cpk:pl-0 cpk:pr-4 cpk:@3xl:px-0 cpk:mt-4">
         <copilot-chat-suggestion-view
           [suggestions]="chatState?.suggestions?.() ?? []"
           inputClass="cpk:mb-3 cpk:lg:ml-4 cpk:lg:mr-4 cpk:ml-0 cpk:mr-0"
@@ -42,7 +42,7 @@
 <div
   class="cpk:h-full cpk:max-h-full cpk:flex cpk:flex-col cpk:flex-1 cpk:min-h-0 cpk:overflow-y-auto cpk:overflow-x-hidden"
 >
-  <div class="cpk:px-4 cpk:sm:px-0">
+  <div class="cpk:px-4 cpk:@3xl:px-0">
     <ng-content></ng-content>
   </div>
 </div>
@@ -66,7 +66,7 @@
     class="cpk:flex-1 cpk:min-h-0 cpk:overflow-y-auto cpk:overflow-x-hidden"
   >
     <!-- Scrollable content wrapper -->
-    <div class="cpk:px-4 cpk:sm:px-0">
+    <div class="cpk:px-4 cpk:@3xl:px-0">
       <!-- Content with padding-bottom matching React -->
       <ng-container [ngTemplateOutlet]="scrollContent"></ng-container>
     </div>
@@ -79,7 +79,7 @@
     [class]="computedClass()"
     class="cpk:flex-1 cpk:min-h-0 cpk:overflow-y-auto cpk:overflow-x-hidden"
   >
-    <div #contentContainer class="cpk:px-4 cpk:sm:px-0">
+    <div #contentContainer class="cpk:px-4 cpk:@3xl:px-0">
       <!-- Content with padding-bottom matching React -->
       <ng-container [ngTemplateOutlet]="scrollContent"></ng-container>
     </div>

--- a/packages/angular/src/lib/components/chat/copilot-chat-view.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat-view.ts
@@ -306,7 +306,9 @@ export class CopilotChatView
 
   // Computed signals
   protected computedClass = computed(() =>
-    cn("copilotKitChat cpk:relative cpk:h-full cpk:flex cpk:flex-col"),
+    cn(
+      "copilotKitChat cpk:@container cpk:relative cpk:h-full cpk:flex cpk:flex-col",
+    ),
   );
   protected dropOverlayClass = computed(() =>
     cn(

--- a/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
@@ -1134,7 +1134,7 @@ export function CopilotChatInput({
       }}
       {...props}
     >
-      <div className="cpk:max-w-3xl cpk:mx-auto cpk:py-0 cpk:px-4 cpk:sm:px-0 cpk:[div[data-sidebar-chat]_&]:px-8 cpk:[div[data-popup-chat]_&]:px-4 cpk:pointer-events-auto">
+      <div className="cpk:max-w-3xl cpk:mx-auto cpk:py-0 cpk:px-4 cpk:@3xl:px-0 cpk:[div[data-sidebar-chat]_&]:px-8 cpk:[div[data-popup-chat]_&]:px-4 cpk:pointer-events-auto">
         {inputPill}
       </div>
       {shouldShowDisclaimer && BoundDisclaimer}

--- a/packages/react-core/src/v2/components/chat/CopilotChatSuggestionView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatSuggestionView.tsx
@@ -16,7 +16,7 @@ const DefaultContainer = React.forwardRef<
       data-copilotkit
       data-testid="copilot-suggestions"
       className={cn(
-        "cpk:flex cpk:flex-wrap cpk:items-center cpk:gap-1.5 cpk:sm:gap-2 cpk:pl-0 cpk:pr-4 cpk:sm:px-0 cpk:pointer-events-none",
+        "cpk:flex cpk:flex-wrap cpk:items-center cpk:gap-1.5 cpk:sm:gap-2 cpk:pl-0 cpk:pr-4 cpk:@3xl:px-0 cpk:pointer-events-none",
         className,
       )}
       {...props}

--- a/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
@@ -306,7 +306,7 @@ export function CopilotChatView({
         <div className="cpk:max-w-3xl cpk:mx-auto">
           {BoundMessageView}
           {hasSuggestions ? (
-            <div className="cpk:pl-0 cpk:pr-4 cpk:sm:px-0 cpk:mt-4">
+            <div className="cpk:pl-0 cpk:pr-4 cpk:@3xl:px-0 cpk:mt-4">
               {BoundSuggestionView}
             </div>
           ) : null}
@@ -382,7 +382,7 @@ export function CopilotChatView({
         onDragLeave={onDragLeave}
         onDrop={onDrop}
         className={cn(
-          "copilotKitChat cpk:relative cpk:h-full cpk:flex cpk:flex-col",
+          "copilotKitChat cpk:@container cpk:relative cpk:h-full cpk:flex cpk:flex-col",
           className,
         )}
         {...props}
@@ -415,7 +415,7 @@ export function CopilotChatView({
       onDragLeave={onDragLeave}
       onDrop={onDrop}
       className={cn(
-        "copilotKitChat cpk:relative cpk:h-full cpk:flex cpk:flex-col",
+        "copilotKitChat cpk:@container cpk:relative cpk:h-full cpk:flex cpk:flex-col",
         className,
       )}
       {...props}
@@ -484,7 +484,7 @@ export namespace CopilotChatView {
             className="cpk:overflow-y-auto cpk:overflow-x-hidden"
             style={{ flex: "1 1 0%", minHeight: 0 }}
           >
-            <div className="cpk:px-4 cpk:sm:px-0 cpk:[div[data-sidebar-chat]_&]:px-8 cpk:[div[data-popup-chat]_&]:px-6">
+            <div className="cpk:px-4 cpk:@3xl:px-0 cpk:[div[data-sidebar-chat]_&]:px-8 cpk:[div[data-popup-chat]_&]:px-6">
               {children}
             </div>
           </StickToBottom.Content>
@@ -575,7 +575,7 @@ export namespace CopilotChatView {
           >
             <div
               ref={contentRef}
-              className="cpk:px-4 cpk:sm:px-0 cpk:[div[data-sidebar-chat]_&]:px-8 cpk:[div[data-popup-chat]_&]:px-6"
+              className="cpk:px-4 cpk:@3xl:px-0 cpk:[div[data-sidebar-chat]_&]:px-8 cpk:[div[data-popup-chat]_&]:px-6"
             >
               {children}
             </div>
@@ -696,7 +696,7 @@ export namespace CopilotChatView {
     if (!hasMounted) {
       return (
         <div className="cpk:h-full cpk:max-h-full cpk:flex cpk:flex-col cpk:min-h-0 cpk:overflow-y-auto cpk:overflow-x-hidden">
-          <div className="cpk:px-4 cpk:sm:px-0 cpk:[div[data-sidebar-chat]_&]:px-8 cpk:[div[data-popup-chat]_&]:px-6">
+          <div className="cpk:px-4 cpk:@3xl:px-0 cpk:[div[data-sidebar-chat]_&]:px-8 cpk:[div[data-popup-chat]_&]:px-6">
             {children}
           </div>
         </div>
@@ -720,7 +720,7 @@ export namespace CopilotChatView {
           >
             <div
               ref={contentRef}
-              className="cpk:px-4 cpk:sm:px-0 cpk:[div[data-sidebar-chat]_&]:px-8 cpk:[div[data-popup-chat]_&]:px-6"
+              className="cpk:px-4 cpk:@3xl:px-0 cpk:[div[data-sidebar-chat]_&]:px-8 cpk:[div[data-popup-chat]_&]:px-6"
             >
               {children}
             </div>

--- a/packages/vue/src/v2/components/chat/CopilotChatInput.vue
+++ b/packages/vue/src/v2/components/chat/CopilotChatInput.vue
@@ -963,7 +963,7 @@ onBeforeUnmount(() => {
     v-bind="rootAttrs"
   >
     <div
-      class="cpk:pointer-events-auto cpk:mx-auto cpk:max-w-3xl cpk:px-4 cpk:py-0 cpk:sm:px-0 cpk:[div[data-sidebar-chat]_&]:px-8 cpk:[div[data-popup-chat]_&]:px-4"
+      class="cpk:pointer-events-auto cpk:mx-auto cpk:max-w-3xl cpk:px-4 cpk:py-0 cpk:@3xl:px-0 cpk:[div[data-sidebar-chat]_&]:px-8 cpk:[div[data-popup-chat]_&]:px-4"
     >
       <slot
         name="layout"

--- a/packages/vue/src/v2/components/chat/CopilotChatSuggestionView.vue
+++ b/packages/vue/src/v2/components/chat/CopilotChatSuggestionView.vue
@@ -33,7 +33,7 @@ const emit = defineEmits<{
 const attrs = useAttrs();
 const loadingSet = computed(() => new Set(props.loadingIndexes));
 const containerClass = computed(() => [
-  "cpk:flex cpk:flex-wrap cpk:items-center cpk:gap-1.5 cpk:pl-0 cpk:pr-4 cpk:pointer-events-none cpk:sm:gap-2 cpk:sm:px-0",
+  "cpk:flex cpk:flex-wrap cpk:items-center cpk:gap-1.5 cpk:pl-0 cpk:pr-4 cpk:pointer-events-none cpk:sm:gap-2 cpk:@3xl:px-0",
   attrs.class,
 ]);
 const containerAttrs = computed(() => {

--- a/packages/vue/src/v2/components/chat/CopilotChatView.vue
+++ b/packages/vue/src/v2/components/chat/CopilotChatView.vue
@@ -458,7 +458,7 @@ onBeforeUnmount(() => {
 <template>
   <div
     data-copilotkit
-    class="cpk:relative cpk:h-full"
+    class="cpk:@container cpk:relative cpk:h-full"
     data-testid="copilot-chat-view"
     v-bind="$attrs"
     @dragover="handleDragOver"
@@ -590,7 +590,7 @@ onBeforeUnmount(() => {
           @scroll="handleScroll"
         >
           <div
-            class="cpk:px-4 cpk:sm:px-0 cpk:[div[data-sidebar-chat]_&]:px-8 cpk:[div[data-popup-chat]_&]:px-6"
+            class="cpk:px-4 cpk:@3xl:px-0 cpk:[div[data-sidebar-chat]_&]:px-8 cpk:[div[data-popup-chat]_&]:px-6"
           >
             <div
               ref="scrollContentRef"
@@ -618,7 +618,7 @@ onBeforeUnmount(() => {
                 </slot>
                 <div
                   v-if="hasSuggestions"
-                  class="cpk:mt-4 cpk:pl-0 cpk:pr-4 cpk:sm:px-0"
+                  class="cpk:mt-4 cpk:pl-0 cpk:pr-4 cpk:@3xl:px-0"
                 >
                   <slot
                     name="suggestion-view"


### PR DESCRIPTION
## What & why

Fixes **ENT-1020**. In a side-by-side layout (the threads drawer rail next to the chat), at iPad-portrait / tablet widths the chat **message text sat flush against both pane edges** — no horizontal padding — while the input stayed correctly inset. Surfaced while manually testing the Angular `CopilotDrawer` (#5746), but it is **not a drawer bug**: it reproduces in any layout that puts `CopilotChat` in a pane narrower than the viewport.

### Root cause
The message column is `max-w-3xl` (768px) centered; its wrappers used `cpk:px-4 cpk:sm:px-0` — 16px below 640px, then **0 at viewport ≥640px**. There was no `container-type` on the chat root, so the `sm:` variant keyed on the **viewport**, not the chat's own width. In a sub-viewport pane (~580px chat on an 820px viewport) `sm:px-0` still fired (viewport ≥640) while the 768px column overflowed the pane edge-to-edge → flush text.

## The fix (robust / container-relative)
- Add `cpk:@container` (`container-type: inline-size`) to the chat root (React ×2 render paths, Angular, Vue).
- Switch every message / input / suggestion wrapper from viewport `cpk:sm:px-0` to the **container** variant `cpk:@3xl:px-0`.

Padding now tracks the chat's **own** width and drops to 0 only once the container is at least as wide as the column's `max-w-3xl`, i.e. once the column has real side gutters. In any narrower pane the `px-4` inner padding is retained. **React, Angular, and Vue kept in lockstep.**

### Why `@3xl`, not the `@sm` the ticket suggested
Tailwind v4 **container-query** breakpoints are a *different scale* from viewport breakpoints: `@sm` = **24rem/384px** (viewport `sm` = 640px). A mechanical `sm:` → `@sm:` swap would still collapse the ~580px repro pane (580 ≥ 384). `@3xl` = **48rem/768px**, which exactly matches the column's `max-w-3xl` — the width at which gutters first appear — so it is the semantically correct breakpoint.

> Vue was not named in the ticket scope but shares the identical `sm:px-0` pattern; left unfixed it would reproduce the bug there, so it is included for true framework lockstep. web-components only *hosts* the chat (no `sm:px-0`), so it is correctly untouched.

## Testing

**Browser behavior — real built CSS, exact DOM (`copilotKitChat`/`@container` root → `cpk:max-w-3xl cpk:mx-auto` → `cpk:px-4 cpk:@3xl:px-0` message wrapper), `getComputedStyle().paddingLeft`:**

| Scenario | Result | Expectation |
|---|---|---|
| **580px narrow pane** (the repro) | `padding-left: 16px` | ✅ `px-4` retained — text no longer flush |
| **900px wide pane** (full desktop) | `padding-left: 0px` | ✅ `px-0` — column has gutters, behavior preserved |
| **No `@container` ancestor** (render-prop path) | `padding-left: 16px` | ✅ graceful `px-4`, no flush |

**Generated CSS confirmed** (Tailwind v4.1.18): root emits `container-type: inline-size`; wrapper emits `@container (min-width: 48rem) { padding-inline: 0 }` (verified in both react-core and angular builds — a true container query, not a media query).

**Unit/component tests (pass):**
- react-core — full chat suite: **645 tests / 39 files** green (incl. `CopilotChatCssClasses`).
- angular — `copilot-chat-view` + `copilot-chat-input` specs: **10** green.
- vue — `CopilotChatView.connectingGate` + `CopilotChatSuggestionView.slots.e2e`: **30** green.
- pre-commit `test-and-check-packages` (test + publint + attw across all 4 affected projects) passed.

No tests assert these class strings and no snapshots capture them, so nothing needed regenerating.

## Acceptance criteria
- [x] Messages retain horizontal padding when the chat is in a narrow (<~768px) pane at viewports ≥640px.
- [x] Full-width chat behavior preserved (container ≥768px → `px-0`), verified in React, Angular, Vue.
- [x] No regression to input / disclaimer / suggestion alignment with the message column (all share the same `@3xl` switch).

Closes ENT-1020

🤖 Generated with [Claude Code](https://claude.com/claude-code)
