### PR TITLE
fix(runtime): server-configured agent headers take precedence over forwarded inbound headers

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/agent-header-precedence.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/agent-header-precedence.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { HttpAgent } from "@ag-ui/client";
+import { configureAgentForRequest } from "../handlers/shared/agent-utils";
+import type { CopilotRuntimeLike } from "../core/runtime";
+
+/**
+ * Regression tests for #5712.
+ *
+ * The v2 runtime forwards inbound `authorization` / `x-*` request headers onto
+ * the outgoing agent call. Before the fix the forwarded inbound headers were
+ * spread LAST, so an inbound header silently overrode the value the server
+ * explicitly configured on the agent (e.g. a service-to-service bearer token),
+ * breaking auth to a secured backend.
+ *
+ * After the fix, server-configured `agent.headers` are authoritative on
+ * collision, while non-colliding inbound headers still forward (no regression
+ * to the existing forward-for-auth use case).
+ */
+// Minimal runtime: configureAgentForRequest only reads a2ui / mcpApps /
+// openGenerativeUI (all unset here) before performing the header merge.
+const runtime = {
+  a2ui: undefined,
+  mcpApps: undefined,
+  openGenerativeUI: undefined,
+} as unknown as CopilotRuntimeLike;
+
+function makeRequest(headers: Record<string, string>): Request {
+  return new Request("https://example.com/api/copilotkit", {
+    method: "POST",
+    headers,
+  });
+}
+
+// Case-insensitive lookup — the server configures canonical casing
+// (`Authorization`) while forwarded inbound keys are lowercased.
+function getHeader(
+  headers: Record<string, string>,
+  name: string,
+): string | undefined {
+  const lower = name.toLowerCase();
+  const match = Object.keys(headers).find((k) => k.toLowerCase() === lower);
+  return match ? headers[match] : undefined;
+}
+
+describe("configureAgentForRequest — header precedence (#5712)", () => {
+  it("server-configured agent headers win over a colliding inbound header", () => {
+    // Server explicitly configures a service-to-service bearer + custom header.
+    const agent = new HttpAgent({
+      url: "https://agent.internal/run",
+      headers: {
+        Authorization: "Bearer SERVER-SERVICE-TOKEN",
+        "X-Service-Key": "server-key",
+      },
+    });
+
+    // Inbound request carries COLLIDING authorization + x-* (e.g. an
+    // edge/platform-injected token) plus a non-colliding forwarded header.
+    const request = makeRequest({
+      Authorization: "Bearer INBOUND-CLIENT-TOKEN",
+      "X-Service-Key": "inbound-key",
+      "X-Request-Id": "req-123",
+    });
+
+    configureAgentForRequest({ runtime, request, agentId: "a", agent });
+
+    const headers = (agent as unknown as { headers: Record<string, string> })
+      .headers;
+
+    // The server-configured values must reach the outgoing agent call.
+    expect(getHeader(headers, "authorization")).toBe(
+      "Bearer SERVER-SERVICE-TOKEN",
+    );
+    expect(getHeader(headers, "x-service-key")).toBe("server-key");
+
+    // And there must be exactly ONE authorization key — a case-mismatched
+    // duplicate (server `Authorization` + inbound `authorization`) is what
+    // undici comma-joins into an invalid "multiple JWTs" value.
+    const authKeys = Object.keys(headers).filter(
+      (k) => k.toLowerCase() === "authorization",
+    );
+    expect(authKeys).toHaveLength(1);
+
+    // Same single-key uniqueness must hold for the x-* family: server
+    // `X-Service-Key` + inbound `x-service-key` is the same case-mismatched
+    // collision, and only the SERVER value may survive (an inbound-wins
+    // regression would either flip the value or emit both keys).
+    const serviceKeyKeys = Object.keys(headers).filter(
+      (k) => k.toLowerCase() === "x-service-key",
+    );
+    expect(serviceKeyKeys).toHaveLength(1);
+    expect(headers[serviceKeyKeys[0]]).toBe("server-key");
+  });
+
+  it("forwards non-colliding inbound headers (no regression)", () => {
+    const agent = new HttpAgent({
+      url: "https://agent.internal/run",
+      headers: {
+        Authorization: "Bearer SERVER-SERVICE-TOKEN",
+      },
+    });
+
+    const request = makeRequest({
+      Authorization: "Bearer INBOUND-CLIENT-TOKEN",
+      "X-Request-Id": "req-123",
+    });
+
+    configureAgentForRequest({ runtime, request, agentId: "a", agent });
+
+    const headers = (agent as unknown as { headers: Record<string, string> })
+      .headers;
+
+    // Server header still authoritative...
+    expect(getHeader(headers, "authorization")).toBe(
+      "Bearer SERVER-SERVICE-TOKEN",
+    );
+    // ...and a header the server did NOT set still forwards through.
+    expect(getHeader(headers, "x-request-id")).toBe("req-123");
+  });
+});

--- a/packages/runtime/src/v2/runtime/__tests__/agent-utils-header-forwarding.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/agent-utils-header-forwarding.test.ts
@@ -95,12 +95,12 @@ describe("configureAgentForRequest – header forwarding", () => {
     expect(headers["x-test-id"]).toBe("run-99");
   });
 
-  it("request forwardable headers override matching pre-existing agent headers", () => {
+  it("server-configured agent headers WIN over a colliding forwarded header (#5712)", () => {
     const agent = createMockAgent({
-      "x-aimock-context": "old-context",
+      "x-aimock-context": "server-context",
     });
     const request = createRequest({
-      "x-aimock-context": "new-context",
+      "x-aimock-context": "inbound-context",
     });
 
     configureAgentForRequest({
@@ -110,8 +110,35 @@ describe("configureAgentForRequest – header forwarding", () => {
       agent,
     });
 
-    // The spread order is { ...agent.headers, ...extracted } so request wins
-    expect((agent as any).headers["x-aimock-context"]).toBe("new-context");
+    // Headers the server explicitly configured on the agent are authoritative:
+    // an inbound request header must not silently override them (#5712).
+    expect((agent as any).headers["x-aimock-context"]).toBe("server-context");
+  });
+
+  it("drops a forwarded header that collides case-insensitively with a server header (#5712)", () => {
+    // Server uses canonical casing; inbound is normalized to lowercase. Without
+    // a case-insensitive match both keys would survive and undici would
+    // comma-join them into an invalid "multiple JWTs" value.
+    const agent = createMockAgent({
+      Authorization: "Bearer SERVER-TOKEN",
+    });
+    const request = createRequest({
+      Authorization: "Bearer INBOUND-TOKEN",
+    });
+
+    configureAgentForRequest({
+      runtime: createMockRuntime(),
+      request,
+      agentId: "test-agent",
+      agent,
+    });
+
+    const headers = (agent as any).headers as Record<string, string>;
+    const authKeys = Object.keys(headers).filter(
+      (k) => k.toLowerCase() === "authorization",
+    );
+    expect(authKeys).toHaveLength(1);
+    expect(headers[authKeys[0]!]).toBe("Bearer SERVER-TOKEN");
   });
 
   it("does NOT forward non-forwardable headers like content-type or origin", () => {

--- a/packages/runtime/src/v2/runtime/__tests__/header-utils.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/header-utils.test.ts
@@ -2,7 +2,23 @@ import { describe, it, expect } from "vitest";
 import {
   shouldForwardHeader,
   extractForwardableHeaders,
+  mergeForwardableHeaders,
 } from "../handlers/header-utils";
+
+// No forwardable inbound headers, so a merge's result is driven purely by the
+// server-configured `serverHeaders`.
+function noForwardRequest(): Request {
+  return new Request("https://example.com/api/copilotkit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function authKeys(headers: Record<string, string>): string[] {
+  return Object.keys(headers).filter(
+    (k) => k.toLowerCase() === "authorization",
+  );
+}
 
 describe("header-utils", () => {
   describe("shouldForwardHeader", () => {
@@ -83,6 +99,60 @@ describe("header-utils", () => {
       expect(result["x-complex-value"]).toBe(
         "value with spaces and special=chars&more",
       );
+    });
+  });
+
+  describe("mergeForwardableHeaders — server-vs-server case collision", () => {
+    it("collapses a server-self authorization case-collision to a single first-occurrence-wins entry", () => {
+      // The agent itself is configured with BOTH case-variants of the same
+      // header. A plain `{ ...base }` spread keeps both keys, which undici
+      // comma-joins into an invalid "multiple JWTs" value.
+      const serverHeaders: Record<string, string> = {
+        Authorization: "Bearer FIRST",
+        authorization: "Bearer SECOND",
+      };
+
+      const merged = mergeForwardableHeaders(serverHeaders, noForwardRequest());
+
+      // Exactly one authorization-family key may survive...
+      expect(authKeys(merged)).toHaveLength(1);
+      // ...carrying the documented winner (first occurrence: canonical
+      // `Authorization` with value `Bearer FIRST`).
+      const key = authKeys(merged)[0];
+      expect(key).toBe("Authorization");
+      expect(merged[key]).toBe("Bearer FIRST");
+    });
+
+    it("collapses a server-self x-* case-collision to a single first-occurrence-wins entry", () => {
+      const serverHeaders: Record<string, string> = {
+        "X-Service-Key": "first",
+        "x-service-key": "second",
+      };
+
+      const merged = mergeForwardableHeaders(serverHeaders, noForwardRequest());
+
+      const keys = Object.keys(merged).filter(
+        (k) => k.toLowerCase() === "x-service-key",
+      );
+      expect(keys).toHaveLength(1);
+      expect(keys[0]).toBe("X-Service-Key");
+      expect(merged[keys[0]]).toBe("first");
+    });
+
+    it("still lets non-colliding inbound headers forward after server-self dedup", () => {
+      const serverHeaders: Record<string, string> = {
+        Authorization: "Bearer FIRST",
+        authorization: "Bearer SECOND",
+      };
+      const request = new Request("https://example.com/api/copilotkit", {
+        method: "POST",
+        headers: { "X-Request-Id": "req-123" },
+      });
+
+      const merged = mergeForwardableHeaders(serverHeaders, request);
+
+      expect(authKeys(merged)).toHaveLength(1);
+      expect(merged["x-request-id"]).toBe("req-123");
     });
   });
 });

--- a/packages/runtime/src/v2/runtime/handlers/handle-connect.ts
+++ b/packages/runtime/src/v2/runtime/handlers/handle-connect.ts
@@ -2,9 +2,9 @@ import { handleIntelligenceConnect } from "./intelligence/connect";
 import { handleSseConnect } from "./sse/connect";
 import { isIntelligenceRuntime } from "../core/runtime";
 import { telemetry } from "../telemetry";
+import type { RunAgentParameters as ConnectAgentParameters } from "./shared/agent-utils";
 import {
   parseConnectRequest,
-  RunAgentParameters as ConnectAgentParameters,
   cloneAgentForRequest,
 } from "./shared/agent-utils";
 
@@ -29,6 +29,12 @@ export async function handleConnectAgent({
   });
 
   try {
+    // Runs on BOTH branches deliberately: this is the only place the connect
+    // path validates that `agentId` exists, returning a 404 `Response` for an
+    // unknown agent. The intelligence branch below never re-checks the id (it
+    // hands `agentId` straight to `ɵconnectThread`), so this clone/resolve must
+    // happen before the branch split or unknown agents would slip through. The
+    // SSE branch additionally uses the returned clone's `agent.headers`.
     const agent = await cloneAgentForRequest(runtime, agentId, request);
     if (agent instanceof Response) {
       return agent;
@@ -53,6 +59,11 @@ export async function handleConnectAgent({
       request,
       agentId,
       threadId: connectRequest.input.threadId,
+      // Pass the per-request clone so its server-configured `agent.headers` are
+      // folded into the merged header set threaded into `runner.connect`. That
+      // merge is forward-looking plumbing — no shipped runner consumes
+      // connect-path headers yet; see the note in `sse/connect.ts`.
+      agent,
     });
   } catch (error) {
     console.error("Error running agent:", error);

--- a/packages/runtime/src/v2/runtime/handlers/header-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/header-utils.ts
@@ -22,3 +22,37 @@ export function extractForwardableHeaders(
   });
   return forwardableHeaders;
 }
+
+/**
+ * Merges forwardable inbound request headers onto the headers a server
+ * explicitly configured on an agent, letting the SERVER-CONFIGURED headers WIN
+ * on collision — a server-set service-to-service token (e.g. an IAM bearer)
+ * must never be silently overridden by a browser/edge/platform-injected inbound
+ * header (#5712).
+ *
+ * The collision check is case-insensitive: `extractForwardableHeaders`
+ * normalizes inbound keys to lowercase (`authorization`) while the server
+ * typically configures canonical casing (`Authorization`). A plain object
+ * spread would treat those as distinct keys and emit BOTH — which downstream
+ * (undici) comma-joins into a single invalid "multiple JWTs" value. So we drop
+ * any forwarded header the agent already sets, matched case-insensitively, and
+ * let non-colliding inbound headers pass through unchanged.
+ */
+export function mergeForwardableHeaders(
+  serverHeaders: Record<string, string> | undefined,
+  request: Request,
+): Record<string, string> {
+  const base = serverHeaders ?? {};
+  const serverHeaderNames = new Set(
+    Object.keys(base).map((name) => name.toLowerCase()),
+  );
+  const merged: Record<string, string> = { ...base };
+  for (const [name, value] of Object.entries(
+    extractForwardableHeaders(request),
+  )) {
+    if (!serverHeaderNames.has(name.toLowerCase())) {
+      merged[name] = value;
+    }
+  }
+  return merged;
+}

--- a/packages/runtime/src/v2/runtime/handlers/header-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/header-utils.ts
@@ -37,16 +37,33 @@ export function extractForwardableHeaders(
  * (undici) comma-joins into a single invalid "multiple JWTs" value. So we drop
  * any forwarded header the agent already sets, matched case-insensitively, and
  * let non-colliding inbound headers pass through unchanged.
+ *
+ * The same comma-join hazard exists if the SERVER CONFIG ITSELF contains two
+ * case-variants of one header (e.g. both `Authorization` and `authorization`
+ * in `agent.headers`). A plain `{ ...serverHeaders }` spread would keep both,
+ * so we additionally collapse server-self case-collisions to a SINGLE entry,
+ * FIRST-OCCURRENCE WINS: the first key seen (in `Object.keys` order) keeps its
+ * exact casing and value, and any later case-variant of that name is dropped.
+ * Server-wins-over-inbound and case-insensitive inbound suppression are
+ * otherwise unchanged.
  */
 export function mergeForwardableHeaders(
   serverHeaders: Record<string, string> | undefined,
   request: Request,
 ): Record<string, string> {
   const base = serverHeaders ?? {};
-  const serverHeaderNames = new Set(
-    Object.keys(base).map((name) => name.toLowerCase()),
-  );
-  const merged: Record<string, string> = { ...base };
+  const merged: Record<string, string> = {};
+  const serverHeaderNames = new Set<string>();
+  // Collapse server-self case-collisions: first occurrence wins, later
+  // case-variants of the same name are dropped.
+  for (const [name, value] of Object.entries(base)) {
+    const lower = name.toLowerCase();
+    if (serverHeaderNames.has(lower)) {
+      continue;
+    }
+    serverHeaderNames.add(lower);
+    merged[name] = value;
+  }
   for (const [name, value] of Object.entries(
     extractForwardableHeaders(request),
   )) {

--- a/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
@@ -11,7 +11,7 @@ import {
 } from "../../core/runtime";
 import { OpenGenerativeUIMiddleware } from "../../open-generative-ui-middleware";
 import { INTELLIGENCE_USER_ID_HEADER } from "../../intelligence-platform/client";
-import { extractForwardableHeaders } from "../header-utils";
+import { mergeForwardableHeaders } from "../header-utils";
 import { resolveIntelligenceUser } from "./resolve-intelligence-user";
 import { logger } from "@copilotkit/shared";
 
@@ -30,6 +30,22 @@ export interface ConnectRequestBody extends RunAgentInput {
   lastSeenEventId?: string | null;
 }
 
+/**
+ * Resolve `agentId` against the runtime's agents and return a per-request
+ * clone of the matching agent.
+ *
+ * Dual return contract — both callers (`handle-run.ts`, `handle-connect.ts`)
+ * depend on it:
+ * - Returns a cloned `AbstractAgent` when the agent exists.
+ * - Returns a 404 `Response` (`{ error: "Agent not found", ... }`) when the
+ *   agent is unknown. Callers MUST `instanceof Response`-check the result and
+ *   return it directly; this doubles as the connect/run path's agent-existence
+ *   guard, so skipping the check would let unknown agent ids slip through.
+ *
+ * The clone is what subsequent per-request mutation (middleware attach,
+ * `agent.headers` merge) operates on, leaving the shared agent registration
+ * untouched.
+ */
 export async function cloneAgentForRequest(
   runtime: CopilotRuntimeLike,
   agentId: string,
@@ -122,10 +138,13 @@ export function configureAgentForRequest(params: {
     }
   }
 
-  agent.headers = {
-    ...agent.headers,
-    ...extractForwardableHeaders(request),
-  };
+  // Forward inbound `authorization` / `x-*` headers onto the outgoing agent
+  // call, but let headers the server explicitly configured on the agent WIN on
+  // collision (case-insensitively) — a server-set service-to-service token
+  // (e.g. an IAM bearer) must never be silently overridden by a
+  // browser/edge/platform-injected inbound header (#5712). See
+  // `mergeForwardableHeaders` for the casing/duplicate-key rationale.
+  agent.headers = mergeForwardableHeaders(agent.headers, request);
 }
 
 /**

--- a/packages/runtime/src/v2/runtime/handlers/sse/__tests__/sse-connect-agent-id.test.ts
+++ b/packages/runtime/src/v2/runtime/handlers/sse/__tests__/sse-connect-agent-id.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { of } from "rxjs";
-import { EventType, type BaseEvent } from "@ag-ui/client";
+import { EventType } from "@ag-ui/client";
+import type { BaseEvent } from "@ag-ui/client";
 
 vi.mock("pino", () => ({
   default: vi.fn(() => ({
@@ -67,5 +68,139 @@ describe("handleSseConnect → debug envelope agentId", () => {
       // positive assertion — no need for a separate not-toBe guard.
       expect(env.agentId).toBe("weather-agent");
     }
+  });
+});
+
+/**
+ * Regression guard for issue #5712 on the /connect path. `handleSseConnect`
+ * used to forward raw inbound `authorization`/`x-*` headers straight to
+ * `runner.connect`, ignoring server-configured `agent.headers` entirely — so
+ * an inbound bearer silently clobbered service-to-service auth. The fix merges
+ * with server config winning on collision (case-insensitively), while
+ * non-colliding forwarded headers still pass through. The /run-based coverage
+ * (agent-header-precedence.test.ts) wouldn't catch a /connect regression — it
+ * is a separate code path.
+ */
+// Case-insensitive lookup — the server configures canonical casing
+// (`Authorization`) while forwarded inbound keys are lowercased.
+function getHeader(
+  headers: Record<string, string>,
+  name: string,
+): string | undefined {
+  const lower = name.toLowerCase();
+  const match = Object.keys(headers).find((k) => k.toLowerCase() === lower);
+  return match ? headers[match] : undefined;
+}
+
+describe("handleSseConnect → header precedence (#5712)", () => {
+  it("server-configured agent headers win over a colliding forwarded header", async () => {
+    const event: BaseEvent = {
+      type: EventType.RUN_STARTED,
+      threadId: "t-1",
+      runId: "r-1",
+    } as BaseEvent;
+
+    const connectSpy = vi.fn(
+      (_req: { threadId: string; headers: Record<string, string> }) =>
+        of(event),
+    );
+    const fakeRuntime = {
+      debugEventBus: new DebugEventBus(),
+      runner: { connect: connectSpy },
+    } as any;
+
+    const response = handleSseConnect({
+      runtime: fakeRuntime,
+      request: new Request("http://localhost/agent/weather-agent/connect", {
+        method: "POST",
+        headers: {
+          // Inbound headers that collide (canonical-cased server vs lowercased
+          // inbound) — must lose — and one that doesn't — must still forward.
+          Authorization: "Bearer inbound-user-token",
+          "x-request-id": "req-123",
+        },
+      }),
+      agentId: "weather-agent",
+      threadId: "t-1",
+      agent: {
+        headers: { Authorization: "Bearer service-token" },
+      } as any,
+    });
+
+    const reader = response.body!.getReader();
+    while (true) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+    const headers = connectSpy.mock.calls[0][0].headers;
+
+    // Server-set auth wins on collision...
+    expect(getHeader(headers, "authorization")).toBe("Bearer service-token");
+    // ...with exactly one authorization key (no case-mismatched duplicate that
+    // undici would comma-join into an invalid "multiple JWTs" value)...
+    const authKeys = Object.keys(headers).filter(
+      (k) => k.toLowerCase() === "authorization",
+    );
+    expect(authKeys).toHaveLength(1);
+    // ...and a non-colliding forwarded header still passes through.
+    expect(getHeader(headers, "x-request-id")).toBe("req-123");
+  });
+
+  it("forwards inbound allowlisted headers when no server agent.headers exist", async () => {
+    // The connect path passes `agent?.headers` (undefined when no agent clone
+    // carries server-configured headers) into `mergeForwardableHeaders`, which
+    // must degrade to `?? {}` without crashing and forward the inbound
+    // allowlisted headers only.
+    const event: BaseEvent = {
+      type: EventType.RUN_STARTED,
+      threadId: "t-1",
+      runId: "r-1",
+    } as BaseEvent;
+
+    const connectSpy = vi.fn(
+      (_req: { threadId: string; headers: Record<string, string> }) =>
+        of(event),
+    );
+    const fakeRuntime = {
+      debugEventBus: new DebugEventBus(),
+      runner: { connect: connectSpy },
+    } as any;
+
+    const response = handleSseConnect({
+      runtime: fakeRuntime,
+      request: new Request("http://localhost/agent/weather-agent/connect", {
+        method: "POST",
+        headers: {
+          // Allowlisted inbound headers (lowercased on extraction)...
+          Authorization: "Bearer inbound-user-token",
+          "x-request-id": "req-123",
+          // ...and a non-allowlisted one that must NOT forward.
+          "content-type": "application/json",
+        },
+      }),
+      agentId: "weather-agent",
+      threadId: "t-1",
+      // No `agent` — the `agent?.headers ?? {}` path.
+    });
+
+    const reader = response.body!.getReader();
+    while (true) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+    const headers = connectSpy.mock.calls[0][0].headers;
+
+    // With no server headers to win, the inbound allowlisted headers forward
+    // through unchanged...
+    expect(getHeader(headers, "authorization")).toBe(
+      "Bearer inbound-user-token",
+    );
+    expect(getHeader(headers, "x-request-id")).toBe("req-123");
+    // ...and a non-allowlisted header is dropped (no crash, no over-forwarding).
+    expect(getHeader(headers, "content-type")).toBeUndefined();
   });
 });

--- a/packages/runtime/src/v2/runtime/handlers/sse/connect.ts
+++ b/packages/runtime/src/v2/runtime/handlers/sse/connect.ts
@@ -1,12 +1,30 @@
-import { CopilotRuntimeLike } from "../../core/runtime";
+import type { AbstractAgent } from "@ag-ui/client";
+import type { CopilotRuntimeLike } from "../../core/runtime";
 import { createSseEventResponse } from "../shared/sse-response";
-import { extractForwardableHeaders } from "../header-utils";
+import { mergeForwardableHeaders } from "../header-utils";
+
+/**
+ * `headers` lives on the HTTP-backed agent configs (e.g. `HttpAgent`), not on
+ * the base `AbstractAgent`. Mirror the runtime's own optional-headers shape so
+ * we can read server-configured headers off the per-request clone without a
+ * cast. See `agent-utils.ts`.
+ */
+type AgentWithHeaders = AbstractAgent & {
+  headers?: Record<string, string>;
+};
 
 interface HandleSseConnectParams {
   runtime: CopilotRuntimeLike;
   request: Request;
   agentId: string;
   threadId: string;
+  /**
+   * The per-request agent clone, carrying any server-configured `agent.headers`
+   * (e.g. service-to-service auth). Used only to compute the merged header set
+   * threaded into `runner.connect` below — see the note there for why that
+   * merge is forward-looking plumbing rather than active outbound auth today.
+   */
+  agent?: AgentWithHeaders;
 }
 
 export function handleSseConnect({
@@ -14,6 +32,7 @@ export function handleSseConnect({
   request,
   agentId,
   threadId,
+  agent,
 }: HandleSseConnectParams): Response {
   return createSseEventResponse({
     request,
@@ -24,7 +43,19 @@ export function handleSseConnect({
     observableFactory: () =>
       runtime.runner.connect({
         threadId,
-        headers: extractForwardableHeaders(request),
+        // Forward-looking plumbing: we compute the merged header set (server
+        // `agent.headers` win on collision, case-insensitively; non-colliding
+        // inbound headers still forward — see `mergeForwardableHeaders`, #5712)
+        // and thread it into `runner.connect`. NO shipped runner consumes the
+        // `headers` field of `AgentRunnerConnectRequest` today — every runner
+        // (in-memory, intelligence, telemetry, sqlite) reads only `threadId`.
+        // The real outbound header forwarding is the /run path, where
+        // `cloneAgentForRequest` mutates `agent.headers` directly
+        // (agent-utils.ts). This wiring exists so a future outbound-connecting
+        // runner can pick the merged headers up without a route change; the
+        // collision precedence noted here is purely about that merge, not about
+        // middleware/mutation parity with /run.
+        headers: mergeForwardableHeaders(agent?.headers, request),
       }),
   });
 }


### PR DESCRIPTION
## Problem

When a self-hosted v2 `CopilotRuntime` is configured with a server-side agent (an `@ag-ui/client` `HttpAgent` with static `headers` for service-to-service auth), the runtime forwards inbound `authorization`/`x-*` request headers onto the agent's outgoing call **and lets them override the headers the server configured** — silently breaking service-to-service auth to a secured backend (e.g. a private Cloud Run agent behind IAM).

`Fixes #5712`

## Root cause

`packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts:125-128` merged forwarded inbound headers **last**, so they won on collision:

```ts
agent.headers = {
  ...agent.headers,                      // server-configured
  ...extractForwardableHeaders(request), // inbound — overrode the above
};
```

There are actually **two** failure modes:

1. **Same-case collision** — inbound `authorization` overwrites a server `authorization` (last-write-wins).
2. **Case-mismatch collision** — `extractForwardableHeaders` lowercases inbound keys (`authorization`), while the server typically configures canonical casing (`Authorization`). A plain spread treats those as *distinct* keys and emits **both** — which undici downstream comma-joins into a single invalid `"Bearer A, Bearer B"` ("multiple JWTs") value. Flipping the spread order alone does **not** fix this case.

## Fix

In `agent-utils.ts`, make server-configured `agent.headers` authoritative on collision, matched **case-insensitively**: drop any forwarded inbound header whose name (case-insensitively) is already set on the agent, and let non-colliding inbound headers pass through unchanged. This preserves the existing forward-for-auth behavior for headers the server does *not* set, while guaranteeing a server-set token is never overridden or duplicated.

The merge logic lives in a shared `mergeForwardableHeaders(serverHeaders, request)` helper in `packages/runtime/src/v2/runtime/handlers/header-utils.ts` so the precedence semantics are defined in exactly one place.

### Scope note

This is the conservative precedence + case-insensitive-dedup fix (the issue's suggested fix #1). I did **not** tighten the default allowlist to drop hop-by-hop/platform `x-*` headers (`x-serverless-*`, `x-forwarded-*`, …) or add an opt-out — those alter existing forwarding behavior and are worth a separate, deliberate change. The precedence fix alone resolves the reported breakage (the server-set token now wins regardless of what the platform injects on a colliding header name).

A documented workaround already exists for users on released versions: pass a custom `fetch` to the `HttpAgent` that builds outgoing headers from scratch (it runs after `configureAgentForRequest` and survives the per-request `agent.clone()`).

## Red-green proof (the real fix — `/run` path)

The load-bearing assertion: there must be exactly **one** authorization header carrying the **server** value.

### RED (fix stashed, against unmodified `agent-utils.ts`)

```
 ❯ src/v2/runtime/__tests__/agent-header-precedence.test.ts (2 tests | 1 failed)
   × configureAgentForRequest — header precedence (#5712) > server-configured agent headers win over a colliding inbound header
AssertionError: expected [ 'Authorization', 'authorization' ] to have a length of 1 but got 2
     81|     expect(authKeys).toHaveLength(1);
 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

The pre-existing `agent-utils-header-forwarding.test.ts` also failed, because it explicitly encoded the buggy behavior (`expect(...["x-aimock-context"]).toBe("new-context")` — inbound winning):

```
 FAIL  src/v2/runtime/__tests__/agent-utils-header-forwarding.test.ts > ... > request forwardable headers override matching pre-existing agent headers
AssertionError: expected 'old-context' to be 'new-context'
```

### GREEN (fix applied)

```
 ✓ src/v2/runtime/__tests__/agent-header-precedence.test.ts (2 tests) 2ms
 ✓ src/v2/runtime/__tests__/agent-utils-header-forwarding.test.ts (8 tests) 3ms
 Test Files  2 passed (2)
      Tests  10 passed (10)
```

The colliding test (`agent-utils-header-forwarding.test.ts`) was updated from asserting the old bug to asserting corrected precedence + a new case-insensitive-dedup guard. The non-colliding-forward test is retained unchanged as a regression guard.

## Quality gates

```
NX  Successfully ran target check-types for project @copilotkit/runtime
NX  Successfully ran target test for project @copilotkit/runtime  — Test Files 113 passed (113), Tests 1576 passed (1576)
```

---

## `/connect`-path change — forward-looking plumbing, inert today

The original issue and a prior eval flagged the same forwarding pattern at `handlers/sse/connect.ts`. To keep the two paths' merge semantics consistent, the `/connect` path now builds the same server-wins merged headers (via the shared `mergeForwardableHeaders` helper) and passes them into `runner.connect()`.

**This is not an active auth fix, and it is not red-green-proven as one — because there is no live bug to fix on the connect path today.** No shipped runner consumes the `headers` field of `AgentRunnerConnectRequest`: the in-memory, intelligence, telemetry, and sqlite runners all destructure only `threadId` from the connect request and ignore `headers` entirely. Connect is a thread replay/reconnect, not a fresh outgoing agent call. So whatever headers we pass into `runner.connect()` are dropped on the floor by every runner that ships.

What this change actually does:

- Threads the per-request agent clone through `handle-connect.ts → handleSseConnect` so the connect path *has access to* the server-configured `agent.headers` (it previously did not).
- Passes `mergeForwardableHeaders(agent?.headers, request)` into `runner.connect()` — the correct, server-wins argument **shape** for a future outbound-connecting runner that *would* consume connect-path headers.
- Rewrites the comments/JSDoc on this path to say this plainly, rather than implying an active auth fix. It also documents that the connect-site `cloneAgentForRequest` call is the sole `agentId`-existence guard (the intelligence branch never re-validates the id), and documents `cloneAgentForRequest`'s `AbstractAgent | Response` (404) dual-return contract that both callers depend on.

The real outbound header forwarding — the thing that fixes #5712 — is the `/run` path's `agent.headers` mutation described above. The connect change is staged plumbing so that if/when a runner starts honoring connect-path headers, it inherits the same server-wins precedence without a second fix.

### Tests on the `/connect` path

The connect tests assert the *merge shape* that reaches `runner.connect()` (server value wins on collision, exactly one `authorization` key, non-colliding `x-*` still forwards) and that the agent-undefined case (no server `agent.headers`) degrades to forwarding allowlisted inbound headers only and does not crash. These verify the argument we construct is correctly shaped — not that any shipped runner consumes it.

## Files

- `packages/runtime/src/v2/runtime/handlers/header-utils.ts` — shared `mergeForwardableHeaders` helper (case-insensitive, server-wins).
- `packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts` — `/run` path uses the helper so server headers win on collision (**the real fix**).
- `packages/runtime/src/v2/runtime/handlers/sse/connect.ts` — `/connect` path uses the helper; forward-looking plumbing, inert until a runner consumes connect-path headers.
- `packages/runtime/src/v2/runtime/handlers/handle-connect.ts` — threads the per-request agent clone into `handleSseConnect`.
- `packages/runtime/src/v2/runtime/__tests__/agent-header-precedence.test.ts` — `/run` regression test exercising the real `configureAgentForRequest` surface with a real `HttpAgent`.
- `packages/runtime/src/v2/runtime/__tests__/agent-utils-header-forwarding.test.ts` — updated the test that encoded the old (buggy) precedence; added a case-mismatch dedup guard.
- `packages/runtime/src/v2/runtime/handlers/sse/__tests__/sse-connect-agent-id.test.ts` — connect-path merge-shape + agent-undefined coverage.

### Notes

- A documented `@ag-ui/client` `HttpAgent` `fetch` workaround already exists for attaching service-to-service auth the runtime can't override (see the issue). This change makes the workaround unnecessary for the `/run` precedence case.
- Conservative scope: this is the **precedence flip on `/run`** plus forward-looking connect plumbing. Tightening the default allowlist (dropping hop-by-hop / platform `x-serverless-*`, `x-forwarded-*`, `x-cloud-trace-context`, …) and an opt-out switch — issue suggestions #2/#3 — are intentionally left as a follow-up to keep the security-policy change minimal.
