### PR TITLE
feat(runtime): configurable inbound-header forwarding policy with default infra/platform denylist

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/agent-header-precedence.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/agent-header-precedence.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { HttpAgent } from "@ag-ui/client";
+import { configureAgentForRequest } from "../handlers/shared/agent-utils";
+import type { CopilotRuntimeLike } from "../core/runtime";
+
+/**
+ * Regression tests for #5712.
+ *
+ * The v2 runtime forwards inbound `authorization` / `x-*` request headers onto
+ * the outgoing agent call. Before the fix the forwarded inbound headers were
+ * spread LAST, so an inbound header silently overrode the value the server
+ * explicitly configured on the agent (e.g. a service-to-service bearer token),
+ * breaking auth to a secured backend.
+ *
+ * After the fix, server-configured `agent.headers` are authoritative on
+ * collision, while non-colliding inbound headers still forward (no regression
+ * to the existing forward-for-auth use case).
+ */
+// Minimal runtime: configureAgentForRequest only reads a2ui / mcpApps /
+// openGenerativeUI (all unset here) before performing the header merge.
+const runtime = {
+  a2ui: undefined,
+  mcpApps: undefined,
+  openGenerativeUI: undefined,
+} as unknown as CopilotRuntimeLike;
+
+function makeRequest(headers: Record<string, string>): Request {
+  return new Request("https://example.com/api/copilotkit", {
+    method: "POST",
+    headers,
+  });
+}
+
+// Case-insensitive lookup — the server configures canonical casing
+// (`Authorization`) while forwarded inbound keys are lowercased.
+function getHeader(
+  headers: Record<string, string>,
+  name: string,
+): string | undefined {
+  const lower = name.toLowerCase();
+  const match = Object.keys(headers).find((k) => k.toLowerCase() === lower);
+  return match ? headers[match] : undefined;
+}
+
+describe("configureAgentForRequest — header precedence (#5712)", () => {
+  it("server-configured agent headers win over a colliding inbound header", () => {
+    // Server explicitly configures a service-to-service bearer + custom header.
+    const agent = new HttpAgent({
+      url: "https://agent.internal/run",
+      headers: {
+        Authorization: "Bearer SERVER-SERVICE-TOKEN",
+        "X-Service-Key": "server-key",
+      },
+    });
+
+    // Inbound request carries COLLIDING authorization + x-* (e.g. an
+    // edge/platform-injected token) plus a non-colliding forwarded header.
+    const request = makeRequest({
+      Authorization: "Bearer INBOUND-CLIENT-TOKEN",
+      "X-Service-Key": "inbound-key",
+      "X-Request-Id": "req-123",
+    });
+
+    configureAgentForRequest({ runtime, request, agentId: "a", agent });
+
+    const headers = (agent as unknown as { headers: Record<string, string> })
+      .headers;
+
+    // The server-configured values must reach the outgoing agent call.
+    expect(getHeader(headers, "authorization")).toBe(
+      "Bearer SERVER-SERVICE-TOKEN",
+    );
+    expect(getHeader(headers, "x-service-key")).toBe("server-key");
+
+    // And there must be exactly ONE authorization key — a case-mismatched
+    // duplicate (server `Authorization` + inbound `authorization`) is what
+    // undici comma-joins into an invalid "multiple JWTs" value.
+    const authKeys = Object.keys(headers).filter(
+      (k) => k.toLowerCase() === "authorization",
+    );
+    expect(authKeys).toHaveLength(1);
+
+    // Same single-key uniqueness must hold for the x-* family: server
+    // `X-Service-Key` + inbound `x-service-key` is the same case-mismatched
+    // collision, and only the SERVER value may survive (an inbound-wins
+    // regression would either flip the value or emit both keys).
+    const serviceKeyKeys = Object.keys(headers).filter(
+      (k) => k.toLowerCase() === "x-service-key",
+    );
+    expect(serviceKeyKeys).toHaveLength(1);
+    expect(headers[serviceKeyKeys[0]]).toBe("server-key");
+  });
+
+  it("forwards non-colliding inbound headers (no regression)", () => {
+    const agent = new HttpAgent({
+      url: "https://agent.internal/run",
+      headers: {
+        Authorization: "Bearer SERVER-SERVICE-TOKEN",
+      },
+    });
+
+    const request = makeRequest({
+      Authorization: "Bearer INBOUND-CLIENT-TOKEN",
+      "X-Request-Id": "req-123",
+    });
+
+    configureAgentForRequest({ runtime, request, agentId: "a", agent });
+
+    const headers = (agent as unknown as { headers: Record<string, string> })
+      .headers;
+
+    // Server header still authoritative...
+    expect(getHeader(headers, "authorization")).toBe(
+      "Bearer SERVER-SERVICE-TOKEN",
+    );
+    // ...and a header the server did NOT set still forwards through.
+    expect(getHeader(headers, "x-request-id")).toBe("req-123");
+  });
+});

--- a/packages/runtime/src/v2/runtime/__tests__/agent-header-precedence.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/agent-header-precedence.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { HttpAgent } from "@ag-ui/client";
 import { configureAgentForRequest } from "../handlers/shared/agent-utils";
+import { resolveForwardHeadersPolicy } from "../handlers/header-utils";
 import type { CopilotRuntimeLike } from "../core/runtime";
 
 /**
@@ -22,6 +23,8 @@ const runtime = {
   a2ui: undefined,
   mcpApps: undefined,
   openGenerativeUI: undefined,
+  // The /run call site reads the resolved forwarding policy off the runtime.
+  forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
 } as unknown as CopilotRuntimeLike;
 
 function makeRequest(headers: Record<string, string>): Request {
@@ -58,7 +61,7 @@ describe("configureAgentForRequest — header precedence (#5712)", () => {
     const request = makeRequest({
       Authorization: "Bearer INBOUND-CLIENT-TOKEN",
       "X-Service-Key": "inbound-key",
-      "X-Request-Id": "req-123",
+      "X-Tenant-Id": "tenant-123",
     });
 
     configureAgentForRequest({ runtime, request, agentId: "a", agent });
@@ -101,7 +104,10 @@ describe("configureAgentForRequest — header precedence (#5712)", () => {
 
     const request = makeRequest({
       Authorization: "Bearer INBOUND-CLIENT-TOKEN",
-      "X-Request-Id": "req-123",
+      // A non-denylisted custom header — the default forwarding policy strips
+      // `x-request-id`, so use `x-tenant-id` to exercise the no-regression
+      // forward path without colliding with the breadth change.
+      "X-Tenant-Id": "tenant-123",
     });
 
     configureAgentForRequest({ runtime, request, agentId: "a", agent });
@@ -114,6 +120,6 @@ describe("configureAgentForRequest — header precedence (#5712)", () => {
       "Bearer SERVER-SERVICE-TOKEN",
     );
     // ...and a header the server did NOT set still forwards through.
-    expect(getHeader(headers, "x-request-id")).toBe("req-123");
+    expect(getHeader(headers, "x-tenant-id")).toBe("tenant-123");
   });
 });

--- a/packages/runtime/src/v2/runtime/__tests__/agent-utils-header-forwarding.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/agent-utils-header-forwarding.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { configureAgentForRequest } from "../handlers/shared/agent-utils";
+import { resolveForwardHeadersPolicy } from "../handlers/header-utils";
 import type { AbstractAgent } from "@ag-ui/client";
 import type { CopilotRuntimeLike } from "../core/runtime";
 
@@ -18,6 +19,10 @@ function createMockAgent(headers?: Record<string, string>): AbstractAgent {
 function createMockRuntime(): CopilotRuntimeLike {
   return {
     agents: Promise.resolve({}),
+    // The /run call site reads the resolved policy off the runtime; default
+    // (built-in denylist on) is fine here since these tests use non-denylisted
+    // custom headers.
+    forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
   } as unknown as CopilotRuntimeLike;
 }
 
@@ -192,6 +197,68 @@ describe("configureAgentForRequest – header forwarding", () => {
     const headers = (agent as any).headers as Record<string, string>;
     expect(headers["authorization"]).toBe("Bearer secret-token");
     expect(headers["content-type"]).toBeUndefined();
+  });
+
+  it("strips denylisted infra/platform headers while forwarding custom x-* (#5712 breadth)", () => {
+    const agent = createMockAgent();
+    const request = createRequest({
+      "Content-Type": "application/json",
+      // Denylisted infra/platform headers — the leak we're closing.
+      "X-Forwarded-For": "203.0.113.7",
+      "X-Real-IP": "203.0.113.7",
+      "X-Vercel-Id": "iad1::abc",
+      "X-Copilotcloud-Public-Api-Key": "ck_pub_secret",
+      // Legitimate custom headers — must still forward.
+      "X-Tenant-Id": "tenant-123",
+      Authorization: "Bearer user-token",
+    });
+
+    configureAgentForRequest({
+      runtime: createMockRuntime(),
+      request,
+      agentId: "test-agent",
+      agent,
+    });
+
+    const headers = (agent as any).headers as Record<string, string>;
+
+    // Denylisted headers must NOT reach the outgoing agent call.
+    expect(headers["x-forwarded-for"]).toBeUndefined();
+    expect(headers["x-real-ip"]).toBeUndefined();
+    expect(headers["x-vercel-id"]).toBeUndefined();
+    expect(headers["x-copilotcloud-public-api-key"]).toBeUndefined();
+    // Custom application headers + authorization still forward.
+    expect(headers["x-tenant-id"]).toBe("tenant-123");
+    expect(headers["authorization"]).toBe("Bearer user-token");
+  });
+
+  it("applies a custom forwardHeaders policy from the runtime (plumb-through)", () => {
+    const agent = createMockAgent();
+    const request = createRequest({
+      "X-Forwarded-For": "203.0.113.7",
+      "X-Tenant-Id": "tenant-123",
+    });
+
+    // useDefaultDenylist:false restores the old wide-open behavior.
+    const runtime = {
+      agents: Promise.resolve({}),
+      forwardHeadersPolicy: resolveForwardHeadersPolicy({
+        useDefaultDenylist: false,
+      }),
+    } as unknown as CopilotRuntimeLike;
+
+    configureAgentForRequest({
+      runtime,
+      request,
+      agentId: "test-agent",
+      agent,
+    });
+
+    const headers = (agent as any).headers as Record<string, string>;
+    // With the denylist disabled, the infra header forwards again — proving the
+    // runtime-resolved policy is actually applied on the /run path.
+    expect(headers["x-forwarded-for"]).toBe("203.0.113.7");
+    expect(headers["x-tenant-id"]).toBe("tenant-123");
   });
 
   it("results in empty headers object when request has no forwardable headers and agent.headers is undefined", () => {

--- a/packages/runtime/src/v2/runtime/__tests__/agent-utils-header-forwarding.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/agent-utils-header-forwarding.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { configureAgentForRequest } from "../handlers/shared/agent-utils";
+import {
+  cloneAgentForRequest,
+  configureAgentForRequest,
+} from "../handlers/shared/agent-utils";
 import { resolveForwardHeadersPolicy } from "../handlers/header-utils";
 import type { AbstractAgent } from "@ag-ui/client";
 import type { CopilotRuntimeLike } from "../core/runtime";
@@ -314,5 +317,96 @@ describe("configureAgentForRequest – header forwarding", () => {
     // Even with no forwardable headers, agent.headers should be set (not undefined)
     expect((agent as any).headers).toBeDefined();
     expect((agent as any).headers).toEqual({});
+  });
+});
+
+describe("clone isolation – registered agent is never mutated by a request (#5712)", () => {
+  /**
+   * Builds a registered agent whose `clone()` returns a SEPARATE object with a
+   * fresh copy of `headers`, mirroring the real per-request clone the run/connect
+   * paths take via `cloneAgentForRequest`. The registered instance must stay
+   * untouched so a bearer token forwarded for one request can never leak into
+   * the shared registration and onto a subsequent, different request.
+   */
+  function createRegisteredAgent(
+    headers?: Record<string, string>,
+  ): AbstractAgent {
+    const agent = {
+      headers,
+      use: () => {},
+      clone() {
+        return {
+          // Alias the same headers object — the registration is protected only
+          // if the merge does NOT mutate its `base` in place. This deliberately
+          // does NOT deep-copy so the test also guards against an in-place
+          // mutation regression in mergeForwardableHeaders (a reassignment-style
+          // merge leaves the aliased registration untouched; an in-place merge
+          // would leak the inbound keys into it).
+          headers: this.headers,
+          use: () => {},
+        } as unknown as AbstractAgent;
+      },
+    };
+    return agent as unknown as AbstractAgent;
+  }
+
+  function createRuntimeWith(agent: AbstractAgent): CopilotRuntimeLike {
+    return {
+      agents: Promise.resolve({ "test-agent": agent }),
+      forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
+    } as unknown as CopilotRuntimeLike;
+  }
+
+  it("merges inbound headers onto the clone WITHOUT touching the registered agent's headers", async () => {
+    const registered = createRegisteredAgent({
+      authorization: "Bearer SERVER-TOKEN",
+      "x-existing": "keep-me",
+    });
+    const runtime = createRuntimeWith(registered);
+
+    // Snapshot of the registered agent's headers BEFORE the request is handled.
+    const before = {
+      ...((registered as any).headers as Record<string, string>),
+    };
+
+    const request = createRequest({
+      "x-aimock-context": "langgraph-python",
+      "x-tenant-id": "tenant-123",
+    });
+
+    const clone = (await cloneAgentForRequest(
+      runtime,
+      "test-agent",
+      request,
+    )) as AbstractAgent;
+
+    configureAgentForRequest({
+      runtime,
+      request,
+      agentId: "test-agent",
+      agent: clone,
+    });
+
+    const cloneHeaders = (clone as any).headers as Record<string, string>;
+    const registeredHeaders = (registered as any).headers as Record<
+      string,
+      string
+    >;
+
+    // The clone carries the server headers PLUS the merged inbound set...
+    expect(cloneHeaders["authorization"]).toBe("Bearer SERVER-TOKEN");
+    expect(cloneHeaders["x-existing"]).toBe("keep-me");
+    expect(cloneHeaders["x-aimock-context"]).toBe("langgraph-python");
+    expect(cloneHeaders["x-tenant-id"]).toBe("tenant-123");
+
+    // ...while the SHARED registered agent is byte-for-byte unchanged. If the
+    // impl mutated the registration in place (e.g. assigned merged headers back
+    // onto the shared object, or the clone aliased the same headers reference),
+    // these inbound keys would have leaked in and this would fail.
+    expect(registeredHeaders).toEqual(before);
+    expect(registeredHeaders["x-aimock-context"]).toBeUndefined();
+    expect(registeredHeaders["x-tenant-id"]).toBeUndefined();
+    // The clone must be a DISTINCT object from the registration (no aliasing).
+    expect(cloneHeaders).not.toBe(registeredHeaders);
   });
 });

--- a/packages/runtime/src/v2/runtime/__tests__/agent-utils-header-forwarding.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/agent-utils-header-forwarding.test.ts
@@ -95,12 +95,12 @@ describe("configureAgentForRequest – header forwarding", () => {
     expect(headers["x-test-id"]).toBe("run-99");
   });
 
-  it("request forwardable headers override matching pre-existing agent headers", () => {
+  it("server-configured agent headers WIN over a colliding forwarded header (#5712)", () => {
     const agent = createMockAgent({
-      "x-aimock-context": "old-context",
+      "x-aimock-context": "server-context",
     });
     const request = createRequest({
-      "x-aimock-context": "new-context",
+      "x-aimock-context": "inbound-context",
     });
 
     configureAgentForRequest({
@@ -110,8 +110,35 @@ describe("configureAgentForRequest – header forwarding", () => {
       agent,
     });
 
-    // The spread order is { ...agent.headers, ...extracted } so request wins
-    expect((agent as any).headers["x-aimock-context"]).toBe("new-context");
+    // Headers the server explicitly configured on the agent are authoritative:
+    // an inbound request header must not silently override them (#5712).
+    expect((agent as any).headers["x-aimock-context"]).toBe("server-context");
+  });
+
+  it("drops a forwarded header that collides case-insensitively with a server header (#5712)", () => {
+    // Server uses canonical casing; inbound is normalized to lowercase. Without
+    // a case-insensitive match both keys would survive and undici would
+    // comma-join them into an invalid "multiple JWTs" value.
+    const agent = createMockAgent({
+      Authorization: "Bearer SERVER-TOKEN",
+    });
+    const request = createRequest({
+      Authorization: "Bearer INBOUND-TOKEN",
+    });
+
+    configureAgentForRequest({
+      runtime: createMockRuntime(),
+      request,
+      agentId: "test-agent",
+      agent,
+    });
+
+    const headers = (agent as any).headers as Record<string, string>;
+    const authKeys = Object.keys(headers).filter(
+      (k) => k.toLowerCase() === "authorization",
+    );
+    expect(authKeys).toHaveLength(1);
+    expect(headers[authKeys[0]!]).toBe("Bearer SERVER-TOKEN");
   });
 
   it("does NOT forward non-forwardable headers like content-type or origin", () => {

--- a/packages/runtime/src/v2/runtime/__tests__/agent-utils-header-forwarding.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/agent-utils-header-forwarding.test.ts
@@ -261,6 +261,42 @@ describe("configureAgentForRequest – header forwarding", () => {
     expect(headers["x-tenant-id"]).toBe("tenant-123");
   });
 
+  it("does NOT throw and applies the default denylist when the runtime omits forwardHeadersPolicy (non-breaking interface)", () => {
+    const agent = createMockAgent();
+    const request = createRequest({
+      "Content-Type": "application/json",
+      // Denylisted infra header — must be stripped by the default policy.
+      "X-Forwarded-For": "203.0.113.7",
+      // Legitimate custom + authorization — must still forward.
+      "X-Tenant-Id": "tenant-123",
+      Authorization: "Bearer user-token",
+    });
+
+    // A policy-less external `CopilotRuntimeLike` implementor: `forwardHeadersPolicy`
+    // is OMITTED entirely (optional on the published interface). Before the fix the
+    // /run call site passed `undefined` straight into the merge, which dereffed
+    // `policy.allow` and threw. After the fix it coalesces to the default resolved
+    // policy (default-on denylist).
+    const policylessRuntime = {
+      agents: Promise.resolve({}),
+    } as unknown as CopilotRuntimeLike;
+
+    expect(() =>
+      configureAgentForRequest({
+        runtime: policylessRuntime,
+        request,
+        agentId: "test-agent",
+        agent,
+      }),
+    ).not.toThrow();
+
+    const headers = (agent as any).headers as Record<string, string>;
+    // Default denylist applied: infra header dropped, custom x-* + authorization forwarded.
+    expect(headers["x-forwarded-for"]).toBeUndefined();
+    expect(headers["x-tenant-id"]).toBe("tenant-123");
+    expect(headers["authorization"]).toBe("Bearer user-token");
+  });
+
   it("results in empty headers object when request has no forwardable headers and agent.headers is undefined", () => {
     const agent = createMockAgent();
     const request = createRequest({

--- a/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
@@ -1,5 +1,6 @@
 import { handleGetRuntimeInfo } from "../handlers/get-runtime-info";
 import { CopilotRuntime } from "../core/runtime";
+import { resolveForwardHeadersPolicy } from "../handlers/header-utils";
 import type {
   CopilotIntelligenceRuntimeLike,
   CopilotRuntimeLike,
@@ -69,6 +70,7 @@ describe("handleGetRuntimeInfo", () => {
     openGenerativeUI: undefined,
     mode: "intelligence",
     debug: { enabled: false, events: false, lifecycle: false, verbose: false },
+    forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
     intelligence: new CopilotKitIntelligence({
       apiUrl: "https://runtime.example",
       wsUrl: "wss://runtime.example",

--- a/packages/runtime/src/v2/runtime/__tests__/handle-connect.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handle-connect.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 import type { BaseEvent } from "@ag-ui/client";
 import { handleConnectAgent } from "../handlers/handle-connect";
 import type { CopilotRuntime } from "../core/runtime";
+import { resolveForwardHeadersPolicy } from "../handlers/header-utils";
 import type { AgentRunnerConnectRequest } from "../runner/agent-runner";
 import { IntelligenceAgentRunner } from "../runner/intelligence";
 
@@ -18,6 +19,7 @@ describe("handleConnectAgent", () => {
       transcriptionService: undefined,
       beforeRequestMiddleware: undefined,
       afterRequestMiddleware: undefined,
+      forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
       runner: {
         run: () =>
           new Observable<BaseEvent>((subscriber) => {

--- a/packages/runtime/src/v2/runtime/__tests__/handle-run.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handle-run.test.ts
@@ -5,6 +5,7 @@ import { AbstractAgent, EventType, HttpAgent } from "@ag-ui/client";
 import { A2UIMiddleware } from "@ag-ui/a2ui-middleware";
 import { handleRunAgent } from "../handlers/handle-run";
 import { CopilotRuntime } from "../core/runtime";
+import { resolveForwardHeadersPolicy } from "../handlers/header-utils";
 import { IntelligenceAgentRunner } from "../runner/intelligence";
 import { InMemoryAgentRunner } from "../runner/in-memory";
 
@@ -17,6 +18,7 @@ describe("handleRunAgent", () => {
       transcriptionService: undefined,
       beforeRequestMiddleware: undefined,
       afterRequestMiddleware: undefined,
+      forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
     } as unknown as CopilotRuntime;
   };
 
@@ -53,6 +55,7 @@ describe("handleRunAgent", () => {
       transcriptionService: undefined,
       beforeRequestMiddleware: undefined,
       afterRequestMiddleware: undefined,
+      forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
     } as unknown as CopilotRuntime;
     const request = createMockRequest();
     const agentId = "test-agent";
@@ -108,6 +111,7 @@ describe("handleRunAgent", () => {
       transcriptionService: undefined,
       beforeRequestMiddleware: undefined,
       afterRequestMiddleware: undefined,
+      forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
       runner: {
         run: ({ agent }: { agent: AbstractAgent }) =>
           new Observable<BaseEvent>((subscriber) => {
@@ -208,6 +212,7 @@ describe("handleRunAgent", () => {
       transcriptionService: undefined,
       beforeRequestMiddleware: undefined,
       afterRequestMiddleware: undefined,
+      forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
       runner: createMockRunner(),
       a2ui: { enabled: true, injectA2UITool: true },
     } as unknown as CopilotRuntime;
@@ -233,6 +238,7 @@ describe("handleRunAgent", () => {
         transcriptionService: undefined,
         beforeRequestMiddleware: undefined,
         afterRequestMiddleware: undefined,
+        forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
         runner: createMockRunner(),
         a2ui: { enabled: true, agents: ["my-agent"] },
       }) as unknown as CopilotRuntime;
@@ -275,6 +281,7 @@ describe("handleRunAgent", () => {
       transcriptionService: undefined,
       beforeRequestMiddleware: undefined,
       afterRequestMiddleware: undefined,
+      forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
       runner: createMockRunner(),
     } as unknown as CopilotRuntime;
 
@@ -295,6 +302,7 @@ describe("handleRunAgent", () => {
       transcriptionService: undefined,
       beforeRequestMiddleware: undefined,
       afterRequestMiddleware: undefined,
+      forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
       runner: createMockRunner(),
       // Config object present but explicitly disabled — the run path must
       // honor the opt-out, not just `!!runtime.a2ui`.
@@ -341,6 +349,7 @@ describe("handleRunAgent", () => {
       transcriptionService: undefined,
       beforeRequestMiddleware: undefined,
       afterRequestMiddleware: undefined,
+      forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
       runner: createMockRunner(),
       // No `a2ui` config at all — the provider's catalog alone must enable it.
     } as unknown as CopilotRuntime;
@@ -367,6 +376,7 @@ describe("handleRunAgent", () => {
       transcriptionService: undefined,
       beforeRequestMiddleware: undefined,
       afterRequestMiddleware: undefined,
+      forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
       runner: createMockRunner(),
       // Deeper, explicit opt-out — the catalog default must NOT override it.
       a2ui: { enabled: true, injectA2UITool: false },
@@ -394,6 +404,7 @@ describe("handleRunAgent", () => {
       transcriptionService: undefined,
       beforeRequestMiddleware: undefined,
       afterRequestMiddleware: undefined,
+      forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
       runner: createMockRunner(),
       a2ui: { enabled: false },
     } as unknown as CopilotRuntime;
@@ -415,6 +426,7 @@ describe("handleRunAgent", () => {
       transcriptionService: undefined,
       beforeRequestMiddleware: undefined,
       afterRequestMiddleware: undefined,
+      forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
       runner: createMockRunner(),
       a2ui: { enabled: true },
     } as unknown as CopilotRuntime;
@@ -441,6 +453,7 @@ describe("handleRunAgent", () => {
       transcriptionService: undefined,
       beforeRequestMiddleware: undefined,
       afterRequestMiddleware: undefined,
+      forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
       runner: createMockRunner(),
     } as unknown as CopilotRuntime;
 
@@ -485,6 +498,7 @@ describe("handleRunAgent", () => {
         transcriptionService: undefined,
         beforeRequestMiddleware: undefined,
         afterRequestMiddleware: undefined,
+        forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
         runner,
         mode: "intelligence",
         generateThreadNames: options?.generateThreadNames ?? false,

--- a/packages/runtime/src/v2/runtime/__tests__/header-utils.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/header-utils.test.ts
@@ -160,6 +160,33 @@ describe("header-utils", () => {
       expect(shouldForwardHeader("x-forwarded-for", policy)).toBe(false);
     });
 
+    it("handles the bare 'x' name and the empty-string name under both policies", () => {
+      // Default (denylist) policy: base eligibility is `authorization` or any
+      // `x-*`. A header literally named "x" is NOT `x-`-prefixed, and the
+      // empty-string name is neither — both are ineligible, so neither forwards.
+      expect(shouldForwardHeader("x", defaultPolicy)).toBe(false);
+      expect(shouldForwardHeader("", defaultPolicy)).toBe(false);
+
+      // Allowlist mode short-circuits the usual eligibility entirely: forward
+      // iff the (lowercased) name is explicitly listed. Neither "x" nor "" is in
+      // this allowlist, so both are dropped...
+      const allowPolicy = resolveForwardHeadersPolicy({
+        allow: ["authorization", "x-tenant-id"],
+      });
+      expect(shouldForwardHeader("x", allowPolicy)).toBe(false);
+      expect(shouldForwardHeader("", allowPolicy)).toBe(false);
+
+      // ...but allowlist mode is purely membership-driven, so explicitly listing
+      // these otherwise-ineligible names DOES make them forward (the allowlist
+      // overrides the `x-*`/`authorization` eligibility rule entirely).
+      const explicitPolicy = resolveForwardHeadersPolicy({ allow: ["x", ""] });
+      expect(shouldForwardHeader("x", explicitPolicy)).toBe(true);
+      expect(shouldForwardHeader("", explicitPolicy)).toBe(true);
+      // And a normally-eligible header is now dropped, confirming allowlist mode
+      // is active and exclusive.
+      expect(shouldForwardHeader("authorization", explicitPolicy)).toBe(false);
+    });
+
     it("allow is case-insensitive", () => {
       const policy = resolveForwardHeadersPolicy({ allow: ["X-Tenant-Id"] });
       expect(shouldForwardHeader("x-tenant-id", policy)).toBe(true);
@@ -312,6 +339,38 @@ describe("header-utils", () => {
 
       expect(authKeys(merged)).toHaveLength(1);
       expect(merged["Authorization"]).toBe("Bearer SERVER-TOKEN");
+    });
+
+    it("server Authorization wins over inbound lowercase authorization with a DIFFERENT value (case-insensitive #5712)", () => {
+      // The core #5712 scenario at the lowest layer: the server configured the
+      // canonical-cased `Authorization`, the inbound request sends the
+      // lowercased `authorization` (as the `Headers` iterator yields it) with a
+      // DIFFERENT value. Exactly one authorization-family key may survive, and
+      // it must carry the SERVER value — the inbound token must not win, and the
+      // two case-variants must not both survive (which undici would comma-join
+      // into an invalid "multiple JWTs" value).
+      const serverHeaders: Record<string, string> = {
+        Authorization: "Bearer SERVER-TOKEN",
+      };
+      const request = new Request("https://example.com/api/copilotkit", {
+        method: "POST",
+        headers: { authorization: "Bearer INBOUND-TOKEN" },
+      });
+
+      const merged = mergeForwardableHeaders(
+        serverHeaders,
+        request,
+        defaultPolicy,
+      );
+
+      // Exactly one authorization-family key, carrying the SERVER value under
+      // the server's original (canonical) casing.
+      expect(authKeys(merged)).toHaveLength(1);
+      const key = authKeys(merged)[0];
+      expect(key).toBe("Authorization");
+      expect(merged[key]).toBe("Bearer SERVER-TOKEN");
+      // Belt-and-suspenders: the inbound value never appears anywhere.
+      expect(Object.values(merged)).not.toContain("Bearer INBOUND-TOKEN");
     });
 
     it("a denylisted header never reaches the merge, so it cannot collide with a server header", () => {

--- a/packages/runtime/src/v2/runtime/__tests__/header-utils.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/header-utils.test.ts
@@ -3,7 +3,14 @@ import {
   shouldForwardHeader,
   extractForwardableHeaders,
   mergeForwardableHeaders,
+  resolveForwardHeadersPolicy,
 } from "../handlers/header-utils";
+import type { ResolvedForwardHeadersPolicy } from "../handlers/header-utils";
+
+// Default resolved policy (built-in infra/platform denylist active) — the
+// behavior every integrator gets on upgrade unless they opt out.
+const defaultPolicy: ResolvedForwardHeadersPolicy =
+  resolveForwardHeadersPolicy(undefined);
 
 // No forwardable inbound headers, so a merge's result is driven purely by the
 // server-configured `serverHeaders`.
@@ -21,49 +28,168 @@ function authKeys(headers: Record<string, string>): string[] {
 }
 
 describe("header-utils", () => {
-  describe("shouldForwardHeader", () => {
+  describe("shouldForwardHeader — default policy", () => {
     it("forwards authorization header (case-insensitive)", () => {
-      expect(shouldForwardHeader("authorization")).toBe(true);
-      expect(shouldForwardHeader("Authorization")).toBe(true);
-      expect(shouldForwardHeader("AUTHORIZATION")).toBe(true);
+      expect(shouldForwardHeader("authorization", defaultPolicy)).toBe(true);
+      expect(shouldForwardHeader("Authorization", defaultPolicy)).toBe(true);
+      expect(shouldForwardHeader("AUTHORIZATION", defaultPolicy)).toBe(true);
     });
 
-    it("forwards x-* custom headers", () => {
-      expect(shouldForwardHeader("x-custom")).toBe(true);
-      expect(shouldForwardHeader("X-Custom")).toBe(true);
-      expect(shouldForwardHeader("x-request-id")).toBe(true);
-      expect(shouldForwardHeader("X-Forwarded-For")).toBe(true);
+    it("forwards legitimate custom x-* application headers", () => {
+      expect(shouldForwardHeader("x-custom", defaultPolicy)).toBe(true);
+      expect(shouldForwardHeader("X-Custom", defaultPolicy)).toBe(true);
+      expect(shouldForwardHeader("x-tenant-id", defaultPolicy)).toBe(true);
+      expect(shouldForwardHeader("x-api-key", defaultPolicy)).toBe(true);
+      expect(shouldForwardHeader("x-user-id", defaultPolicy)).toBe(true);
+      expect(shouldForwardHeader("x-feature-flag", defaultPolicy)).toBe(true);
     });
 
-    it("blocks standard headers", () => {
-      expect(shouldForwardHeader("content-type")).toBe(false);
-      expect(shouldForwardHeader("Content-Type")).toBe(false);
-      expect(shouldForwardHeader("origin")).toBe(false);
-      expect(shouldForwardHeader("user-agent")).toBe(false);
-      expect(shouldForwardHeader("accept")).toBe(false);
-      expect(shouldForwardHeader("cookie")).toBe(false);
-      expect(shouldForwardHeader("host")).toBe(false);
+    it("blocks standard non-x non-auth headers", () => {
+      expect(shouldForwardHeader("content-type", defaultPolicy)).toBe(false);
+      expect(shouldForwardHeader("Content-Type", defaultPolicy)).toBe(false);
+      expect(shouldForwardHeader("origin", defaultPolicy)).toBe(false);
+      expect(shouldForwardHeader("user-agent", defaultPolicy)).toBe(false);
+      expect(shouldForwardHeader("accept", defaultPolicy)).toBe(false);
+      expect(shouldForwardHeader("cookie", defaultPolicy)).toBe(false);
+      expect(shouldForwardHeader("host", defaultPolicy)).toBe(false);
+      // RFC 7239 `forwarded` lacks the x- prefix, so base eligibility already
+      // drops it before the denylist is consulted.
+      expect(shouldForwardHeader("forwarded", defaultPolicy)).toBe(false);
+    });
+
+    it("strips known infra/proxy/platform headers by exact name", () => {
+      // These were forwarded by the old wide-open `x-*` allowlist — the leak.
+      expect(shouldForwardHeader("x-forwarded-for", defaultPolicy)).toBe(false);
+      expect(shouldForwardHeader("x-forwarded-proto", defaultPolicy)).toBe(
+        false,
+      );
+      expect(shouldForwardHeader("x-forwarded-host", defaultPolicy)).toBe(
+        false,
+      );
+      expect(shouldForwardHeader("x-forwarded-port", defaultPolicy)).toBe(
+        false,
+      );
+      expect(shouldForwardHeader("x-forwarded-server", defaultPolicy)).toBe(
+        false,
+      );
+      expect(shouldForwardHeader("x-real-ip", defaultPolicy)).toBe(false);
+      expect(shouldForwardHeader("x-amzn-trace-id", defaultPolicy)).toBe(false);
+      expect(shouldForwardHeader("x-cloud-trace-context", defaultPolicy)).toBe(
+        false,
+      );
+      expect(shouldForwardHeader("x-cache", defaultPolicy)).toBe(false);
+      expect(shouldForwardHeader("x-served-by", defaultPolicy)).toBe(false);
+      // The old assertions at lines 34-35 INVERT under the default policy:
+      // these used to forward, now they are stripped.
+      expect(shouldForwardHeader("x-request-id", defaultPolicy)).toBe(false);
+      expect(shouldForwardHeader("X-Forwarded-For", defaultPolicy)).toBe(false);
+      // The highest-severity item: the Copilot Cloud platform key.
+      expect(
+        shouldForwardHeader("x-copilotcloud-public-api-key", defaultPolicy),
+      ).toBe(false);
+    });
+
+    it("strips known infra/platform header families by prefix", () => {
+      expect(shouldForwardHeader("x-amz-cf-id", defaultPolicy)).toBe(false);
+      expect(shouldForwardHeader("x-amz-anything", defaultPolicy)).toBe(false);
+      expect(shouldForwardHeader("x-azure-ref", defaultPolicy)).toBe(false);
+      expect(shouldForwardHeader("x-azure-clientip", defaultPolicy)).toBe(
+        false,
+      );
+      expect(shouldForwardHeader("x-fastly-foo", defaultPolicy)).toBe(false);
+      expect(shouldForwardHeader("x-vercel-id", defaultPolicy)).toBe(false);
+      expect(shouldForwardHeader("x-vercel-ip-country", defaultPolicy)).toBe(
+        false,
+      );
+      expect(shouldForwardHeader("x-middleware-rewrite", defaultPolicy)).toBe(
+        false,
+      );
+      expect(
+        shouldForwardHeader("x-copilotcloud-internal", defaultPolicy),
+      ).toBe(false);
+    });
+
+    it("strips denylisted headers case-insensitively", () => {
+      expect(shouldForwardHeader("X-Forwarded-For", defaultPolicy)).toBe(false);
+      expect(
+        shouldForwardHeader("X-COPILOTCLOUD-PUBLIC-API-KEY", defaultPolicy),
+      ).toBe(false);
+      expect(shouldForwardHeader("X-Vercel-Id", defaultPolicy)).toBe(false);
     });
   });
 
-  describe("extractForwardableHeaders", () => {
-    it("extracts only forwardable headers from request", () => {
+  describe("shouldForwardHeader — config overrides", () => {
+    it("useDefaultDenylist:false restores the old wide-open behavior", () => {
+      const policy = resolveForwardHeadersPolicy({ useDefaultDenylist: false });
+      // The pre-fix behavior: x-* infra headers forward again.
+      expect(shouldForwardHeader("x-forwarded-for", policy)).toBe(true);
+      expect(shouldForwardHeader("x-request-id", policy)).toBe(true);
+      expect(shouldForwardHeader("x-copilotcloud-public-api-key", policy)).toBe(
+        true,
+      );
+      expect(shouldForwardHeader("authorization", policy)).toBe(true);
+    });
+
+    it("deny extends the default set with additional exact names", () => {
+      const policy = resolveForwardHeadersPolicy({ deny: ["x-internal"] });
+      // The extra custom header is stripped...
+      expect(shouldForwardHeader("x-internal", policy)).toBe(false);
+      // ...while the built-in defaults stay active...
+      expect(shouldForwardHeader("x-forwarded-for", policy)).toBe(false);
+      // ...and unrelated custom headers still forward.
+      expect(shouldForwardHeader("x-tenant-id", policy)).toBe(true);
+    });
+
+    it("denyPrefixes extends the default set with additional prefixes", () => {
+      const policy = resolveForwardHeadersPolicy({ denyPrefixes: ["x-acme-"] });
+      expect(shouldForwardHeader("x-acme-secret", policy)).toBe(false);
+      expect(shouldForwardHeader("x-acme-anything", policy)).toBe(false);
+      expect(shouldForwardHeader("x-tenant-id", policy)).toBe(true);
+    });
+
+    it("allow switches to allowlist mode — only listed headers forward", () => {
+      const policy = resolveForwardHeadersPolicy({
+        allow: ["authorization", "x-tenant-id"],
+      });
+      expect(shouldForwardHeader("authorization", policy)).toBe(true);
+      expect(shouldForwardHeader("x-tenant-id", policy)).toBe(true);
+      // Allowlist mode short-circuits the usual x-*/authorization eligibility:
+      // anything not explicitly allowed is dropped, including custom x-* and
+      // denylisted infra.
+      expect(shouldForwardHeader("x-other-custom", policy)).toBe(false);
+      expect(shouldForwardHeader("x-forwarded-for", policy)).toBe(false);
+    });
+
+    it("allow is case-insensitive", () => {
+      const policy = resolveForwardHeadersPolicy({ allow: ["X-Tenant-Id"] });
+      expect(shouldForwardHeader("x-tenant-id", policy)).toBe(true);
+      expect(shouldForwardHeader("X-TENANT-ID", policy)).toBe(true);
+      expect(shouldForwardHeader("authorization", policy)).toBe(false);
+    });
+  });
+
+  describe("extractForwardableHeaders — default policy", () => {
+    it("extracts only forwardable headers, dropping denylisted x-* infra", () => {
       const request = new Request("https://example.com", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           "X-Custom": "custom-value",
+          // Denylisted by default — must NOT appear in the result.
           "X-Request-ID": "req-123",
+          "X-Forwarded-For": "203.0.113.7",
+          "X-Vercel-Id": "iad1::abc",
           Authorization: "Bearer token",
           Origin: "http://localhost",
         },
       });
 
-      const result = extractForwardableHeaders(request);
+      const result = extractForwardableHeaders(request, defaultPolicy);
 
+      // The old expected object included `x-request-id`; under the default
+      // policy that entry INVERTS out, leaving the custom + auth headers.
       expect(result).toEqual({
         "x-custom": "custom-value",
-        "x-request-id": "req-123",
         authorization: "Bearer token",
       });
     });
@@ -77,7 +203,7 @@ describe("header-utils", () => {
         },
       });
 
-      const result = extractForwardableHeaders(request);
+      const result = extractForwardableHeaders(request, defaultPolicy);
 
       expect(result).toEqual({});
     });
@@ -91,7 +217,7 @@ describe("header-utils", () => {
         },
       });
 
-      const result = extractForwardableHeaders(request);
+      const result = extractForwardableHeaders(request, defaultPolicy);
 
       expect(result.authorization).toBe(
         "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
@@ -112,7 +238,11 @@ describe("header-utils", () => {
         authorization: "Bearer SECOND",
       };
 
-      const merged = mergeForwardableHeaders(serverHeaders, noForwardRequest());
+      const merged = mergeForwardableHeaders(
+        serverHeaders,
+        noForwardRequest(),
+        defaultPolicy,
+      );
 
       // Exactly one authorization-family key may survive...
       expect(authKeys(merged)).toHaveLength(1);
@@ -129,7 +259,11 @@ describe("header-utils", () => {
         "x-service-key": "second",
       };
 
-      const merged = mergeForwardableHeaders(serverHeaders, noForwardRequest());
+      const merged = mergeForwardableHeaders(
+        serverHeaders,
+        noForwardRequest(),
+        defaultPolicy,
+      );
 
       const keys = Object.keys(merged).filter(
         (k) => k.toLowerCase() === "x-service-key",
@@ -146,13 +280,62 @@ describe("header-utils", () => {
       };
       const request = new Request("https://example.com/api/copilotkit", {
         method: "POST",
-        headers: { "X-Request-Id": "req-123" },
+        headers: { "X-Tenant-Id": "tenant-123" },
       });
 
-      const merged = mergeForwardableHeaders(serverHeaders, request);
+      const merged = mergeForwardableHeaders(
+        serverHeaders,
+        request,
+        defaultPolicy,
+      );
 
       expect(authKeys(merged)).toHaveLength(1);
-      expect(merged["x-request-id"]).toBe("req-123");
+      expect(merged["x-tenant-id"]).toBe("tenant-123");
+    });
+  });
+
+  describe("mergeForwardableHeaders — breadth + precedence interaction (#5712)", () => {
+    it("server-configured Authorization still wins over inbound authorization", () => {
+      const serverHeaders: Record<string, string> = {
+        Authorization: "Bearer SERVER-TOKEN",
+      };
+      const request = new Request("https://example.com/api/copilotkit", {
+        method: "POST",
+        headers: { Authorization: "Bearer INBOUND-TOKEN" },
+      });
+
+      const merged = mergeForwardableHeaders(
+        serverHeaders,
+        request,
+        defaultPolicy,
+      );
+
+      expect(authKeys(merged)).toHaveLength(1);
+      expect(merged["Authorization"]).toBe("Bearer SERVER-TOKEN");
+    });
+
+    it("a denylisted header never reaches the merge, so it cannot collide with a server header", () => {
+      const serverHeaders: Record<string, string> = {
+        "X-Forwarded-For": "server-set-value",
+      };
+      const request = new Request("https://example.com/api/copilotkit", {
+        method: "POST",
+        headers: { "X-Forwarded-For": "203.0.113.7" },
+      });
+
+      const merged = mergeForwardableHeaders(
+        serverHeaders,
+        request,
+        defaultPolicy,
+      );
+
+      // The inbound x-forwarded-for is stripped by the denylist before merge,
+      // so only the server-configured entry survives (no comma-join collision).
+      const xffKeys = Object.keys(merged).filter(
+        (k) => k.toLowerCase() === "x-forwarded-for",
+      );
+      expect(xffKeys).toHaveLength(1);
+      expect(merged[xffKeys[0]]).toBe("server-set-value");
     });
   });
 });

--- a/packages/runtime/src/v2/runtime/__tests__/header-utils.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/header-utils.test.ts
@@ -2,7 +2,23 @@ import { describe, it, expect } from "vitest";
 import {
   shouldForwardHeader,
   extractForwardableHeaders,
+  mergeForwardableHeaders,
 } from "../handlers/header-utils";
+
+// No forwardable inbound headers, so a merge's result is driven purely by the
+// server-configured `serverHeaders`.
+function noForwardRequest(): Request {
+  return new Request("https://example.com/api/copilotkit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function authKeys(headers: Record<string, string>): string[] {
+  return Object.keys(headers).filter(
+    (k) => k.toLowerCase() === "authorization",
+  );
+}
 
 describe("header-utils", () => {
   describe("shouldForwardHeader", () => {
@@ -83,6 +99,60 @@ describe("header-utils", () => {
       expect(result["x-complex-value"]).toBe(
         "value with spaces and special=chars&more",
       );
+    });
+  });
+
+  describe("mergeForwardableHeaders — server-vs-server case collision", () => {
+    it("collapses a server-self authorization case-collision to a single first-occurrence-wins entry", () => {
+      // The agent itself is configured with BOTH case-variants of the same
+      // header. A plain `{ ...base }` spread keeps both keys, which undici
+      // comma-joins into an invalid "multiple JWTs" value.
+      const serverHeaders: Record<string, string> = {
+        Authorization: "Bearer FIRST",
+        authorization: "Bearer SECOND",
+      };
+
+      const merged = mergeForwardableHeaders(serverHeaders, noForwardRequest());
+
+      // Exactly one authorization-family key may survive...
+      expect(authKeys(merged)).toHaveLength(1);
+      // ...carrying the documented winner (first occurrence: canonical
+      // `Authorization` with value `Bearer FIRST`).
+      const key = authKeys(merged)[0];
+      expect(key).toBe("Authorization");
+      expect(merged[key]).toBe("Bearer FIRST");
+    });
+
+    it("collapses a server-self x-* case-collision to a single first-occurrence-wins entry", () => {
+      const serverHeaders: Record<string, string> = {
+        "X-Service-Key": "first",
+        "x-service-key": "second",
+      };
+
+      const merged = mergeForwardableHeaders(serverHeaders, noForwardRequest());
+
+      const keys = Object.keys(merged).filter(
+        (k) => k.toLowerCase() === "x-service-key",
+      );
+      expect(keys).toHaveLength(1);
+      expect(keys[0]).toBe("X-Service-Key");
+      expect(merged[keys[0]]).toBe("first");
+    });
+
+    it("still lets non-colliding inbound headers forward after server-self dedup", () => {
+      const serverHeaders: Record<string, string> = {
+        Authorization: "Bearer FIRST",
+        authorization: "Bearer SECOND",
+      };
+      const request = new Request("https://example.com/api/copilotkit", {
+        method: "POST",
+        headers: { "X-Request-Id": "req-123" },
+      });
+
+      const merged = mergeForwardableHeaders(serverHeaders, request);
+
+      expect(authKeys(merged)).toHaveLength(1);
+      expect(merged["x-request-id"]).toBe("req-123");
     });
   });
 });

--- a/packages/runtime/src/v2/runtime/__tests__/header-utils.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/header-utils.test.ts
@@ -177,12 +177,15 @@ describe("header-utils", () => {
       expect(shouldForwardHeader("", allowPolicy)).toBe(false);
 
       // ...but allowlist mode is purely membership-driven, so explicitly listing
-      // these otherwise-ineligible names DOES make them forward (the allowlist
-      // overrides the `x-*`/`authorization` eligibility rule entirely).
+      // a NON-EMPTY otherwise-ineligible name (`x`) DOES make it forward (the
+      // allowlist overrides the `x-*`/`authorization` eligibility rule entirely).
+      // The empty-string entry is filtered out during resolution (see the
+      // empty-string validation tests), so `""` never forwards — and because a
+      // non-empty entry remains, allowlist mode is still active and exclusive.
       const explicitPolicy = resolveForwardHeadersPolicy({ allow: ["x", ""] });
       expect(shouldForwardHeader("x", explicitPolicy)).toBe(true);
-      expect(shouldForwardHeader("", explicitPolicy)).toBe(true);
-      // And a normally-eligible header is now dropped, confirming allowlist mode
+      expect(shouldForwardHeader("", explicitPolicy)).toBe(false);
+      // And a normally-eligible header is dropped, confirming allowlist mode
       // is active and exclusive.
       expect(shouldForwardHeader("authorization", explicitPolicy)).toBe(false);
     });
@@ -191,6 +194,103 @@ describe("header-utils", () => {
       const policy = resolveForwardHeadersPolicy({ allow: ["X-Tenant-Id"] });
       expect(shouldForwardHeader("x-tenant-id", policy)).toBe(true);
       expect(shouldForwardHeader("X-TENANT-ID", policy)).toBe(true);
+      expect(shouldForwardHeader("authorization", policy)).toBe(false);
+    });
+  });
+
+  describe("shouldForwardHeader — deny wins in allowlist mode", () => {
+    it("deny subtracts an exact name from allow (a header in BOTH is NOT forwarded)", () => {
+      // The footgun: an integrator lists a header in allow AND explicitly denies
+      // it. deny is authoritative — the denied header must not forward, even
+      // though it is also allowed, while the other allowed header still does.
+      const policy = resolveForwardHeadersPolicy({
+        allow: ["x-keep", "x-secret"],
+        deny: ["x-secret"],
+      });
+      expect(shouldForwardHeader("x-secret", policy)).toBe(false);
+      expect(shouldForwardHeader("x-keep", policy)).toBe(true);
+    });
+
+    it("deny in allow mode is case-insensitive", () => {
+      const policy = resolveForwardHeadersPolicy({
+        allow: ["X-Keep", "X-Secret"],
+        deny: ["X-SECRET"],
+      });
+      expect(shouldForwardHeader("x-secret", policy)).toBe(false);
+      expect(shouldForwardHeader("X-Secret", policy)).toBe(false);
+      expect(shouldForwardHeader("x-keep", policy)).toBe(true);
+    });
+
+    it("denyPrefixes subtracts a matching allowed header in allowlist mode", () => {
+      // A header allowed by exact name but matched by an integrator denyPrefix
+      // is still stripped — deny (prefix form) is authoritative in allow mode.
+      const policy = resolveForwardHeadersPolicy({
+        allow: ["x-internal-token", "x-tenant-id"],
+        denyPrefixes: ["x-internal-"],
+      });
+      expect(shouldForwardHeader("x-internal-token", policy)).toBe(false);
+      expect(shouldForwardHeader("x-tenant-id", policy)).toBe(true);
+    });
+
+    it("the DEFAULT denylist does NOT subtract in allow mode — explicit allow opts back in", () => {
+      // Only the integrator's OWN deny subtracts from an allowlist. A header on
+      // the built-in default denylist that the integrator explicitly allows is
+      // forwarded — the allow is a deliberate opt-in, not a footgun.
+      const policy = resolveForwardHeadersPolicy({
+        allow: ["x-forwarded-for", "x-request-id"],
+      });
+      expect(shouldForwardHeader("x-forwarded-for", policy)).toBe(true);
+      expect(shouldForwardHeader("x-request-id", policy)).toBe(true);
+    });
+  });
+
+  describe("resolveForwardHeadersPolicy — empty/whitespace entry validation", () => {
+    it("filters an empty-string denyPrefix so it cannot deny ALL forwarding", () => {
+      // `denyPrefixes: [""]` would make `startsWith("")` true for every header,
+      // silently denying ALL forwarding. The empty entry must be filtered so
+      // normal headers still forward under the default policy.
+      const policy = resolveForwardHeadersPolicy({ denyPrefixes: [""] });
+      expect(shouldForwardHeader("x-tenant-id", policy)).toBe(true);
+      expect(shouldForwardHeader("authorization", policy)).toBe(true);
+      // The default denylist is still intact.
+      expect(shouldForwardHeader("x-forwarded-for", policy)).toBe(false);
+    });
+
+    it("filters whitespace-only denyPrefix and deny entries", () => {
+      const policy = resolveForwardHeadersPolicy({
+        denyPrefixes: ["   "],
+        deny: [" \t"],
+      });
+      expect(shouldForwardHeader("x-tenant-id", policy)).toBe(true);
+      expect(shouldForwardHeader("authorization", policy)).toBe(true);
+    });
+
+    it("filters whitespace-only allow entries so allowlist mode is not silently seeded", () => {
+      // `allow: [" "]` would (pre-fix) switch on the exclusive allowlist with an
+      // entry that can never match a real header — forwarding nothing. After the
+      // fix the whitespace entry is filtered, leaving no allowlist, so the
+      // default denylist behavior applies and normal headers forward.
+      const policy = resolveForwardHeadersPolicy({ allow: [" "] });
+      expect(shouldForwardHeader("x-tenant-id", policy)).toBe(true);
+      expect(shouldForwardHeader("authorization", policy)).toBe(true);
+    });
+
+    it("trims surrounding whitespace on entries before matching", () => {
+      const policy = resolveForwardHeadersPolicy({
+        deny: ["  x-secret  "],
+        denyPrefixes: [" x-internal- "],
+        allow: undefined,
+      });
+      expect(shouldForwardHeader("x-secret", policy)).toBe(false);
+      expect(shouldForwardHeader("x-internal-token", policy)).toBe(false);
+      expect(shouldForwardHeader("x-tenant-id", policy)).toBe(true);
+    });
+
+    it("trims and lowercases allow entries", () => {
+      const policy = resolveForwardHeadersPolicy({
+        allow: ["  X-Tenant-Id  "],
+      });
+      expect(shouldForwardHeader("x-tenant-id", policy)).toBe(true);
       expect(shouldForwardHeader("authorization", policy)).toBe(false);
     });
   });

--- a/packages/runtime/src/v2/runtime/__tests__/intelligence-run-telemetry.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/intelligence-run-telemetry.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { handleRunAgent } from "../handlers/handle-run";
 import { IntelligenceAgentRunner } from "../runner/intelligence";
 import { telemetry } from "../telemetry";
+import { resolveForwardHeadersPolicy } from "../handlers/header-utils";
 import type { CopilotRuntime } from "../core/runtime";
 
 // --- Minimal helpers (mirroring handle-run.test.ts's intelligence block) ---
@@ -76,6 +77,7 @@ function makeIntelligenceRuntime(
     transcriptionService: undefined,
     beforeRequestMiddleware: undefined,
     afterRequestMiddleware: undefined,
+    forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
     runner,
     mode: "intelligence",
     generateThreadNames: false,

--- a/packages/runtime/src/v2/runtime/core/runtime.ts
+++ b/packages/runtime/src/v2/runtime/core/runtime.ts
@@ -217,8 +217,15 @@ export interface CopilotRuntimeLike {
   debugEventBus?: DebugEventBus;
   debug: ResolvedDebugConfig;
   debugLogger?: CopilotRuntimeLogger;
-  /** Resolved inbound-header forwarding policy read by the /run and /connect call sites. */
-  forwardHeadersPolicy: ResolvedForwardHeadersPolicy;
+  /**
+   * Resolved inbound-header forwarding policy read by the /run and /connect call
+   * sites. Optional on the published interface so an external `CopilotRuntimeLike`
+   * implementor predating this field stays source-compatible (non-breaking minor
+   * release). Concrete runtimes (`BaseCopilotRuntime`) always resolve and set it;
+   * the call sites coalesce a missing value to the default resolved policy
+   * (`resolveForwardHeadersPolicy(undefined)` — default-on denylist).
+   */
+  forwardHeadersPolicy?: ResolvedForwardHeadersPolicy;
 }
 
 export interface CopilotSseRuntimeLike extends CopilotRuntimeLike {

--- a/packages/runtime/src/v2/runtime/core/runtime.ts
+++ b/packages/runtime/src/v2/runtime/core/runtime.ts
@@ -11,6 +11,11 @@ import { createLicenseChecker } from "@copilotkit/license-verifier";
 import type { LicenseChecker } from "@copilotkit/license-verifier";
 import { resolveDebugConfig } from "@copilotkit/shared";
 import type { ResolvedDebugConfig, DebugConfig } from "@copilotkit/shared";
+import { resolveForwardHeadersPolicy } from "../handlers/header-utils";
+import type {
+  ForwardHeadersConfig,
+  ResolvedForwardHeadersPolicy,
+} from "../handlers/header-utils";
 import type { AbstractAgent } from "@ag-ui/client";
 import type { MCPClientConfig } from "@ag-ui/mcp-apps-middleware";
 import type { A2UIMiddlewareConfig } from "@ag-ui/a2ui-middleware";
@@ -146,6 +151,15 @@ interface BaseCopilotRuntimeOptions extends CopilotRuntimeMiddlewares {
   licenseToken?: string;
   /** Enable debug logging for the event pipeline. */
   debug?: DebugConfig;
+  /**
+   * Policy controlling which inbound HTTP headers are forwarded onto the
+   * outgoing agent call. By default a built-in denylist strips known
+   * infrastructure/proxy/platform headers (`x-forwarded-*`, `x-real-ip`,
+   * `x-vercel-*`, `x-copilotcloud-*`, etc.) while `authorization` and custom
+   * `x-*` application headers continue to forward (#5712). Set
+   * `{ useDefaultDenylist: false }` to restore the previous wide-open behavior.
+   */
+  forwardHeaders?: ForwardHeadersConfig;
 }
 
 export interface CopilotRuntimeUser {
@@ -203,6 +217,8 @@ export interface CopilotRuntimeLike {
   debugEventBus?: DebugEventBus;
   debug: ResolvedDebugConfig;
   debugLogger?: CopilotRuntimeLogger;
+  /** Resolved inbound-header forwarding policy read by the /run and /connect call sites. */
+  forwardHeadersPolicy: ResolvedForwardHeadersPolicy;
 }
 
 export interface CopilotSseRuntimeLike extends CopilotRuntimeLike {
@@ -233,6 +249,7 @@ abstract class BaseCopilotRuntime implements CopilotRuntimeLike {
   public readonly debugEventBus?: DebugEventBus;
   public debug: ResolvedDebugConfig;
   public debugLogger?: CopilotRuntimeLogger;
+  public readonly forwardHeadersPolicy: ResolvedForwardHeadersPolicy;
 
   /**
    * License token resolved once with the env fallback, so telemetry
@@ -285,6 +302,13 @@ abstract class BaseCopilotRuntime implements CopilotRuntimeLike {
     if (process.env.NODE_ENV !== "production") {
       this.debugEventBus = new DebugEventBus();
     }
+    // Resolve the inbound-header forwarding policy once (mirroring the
+    // `debug` → `ResolvedDebugConfig` resolve-once above) so both the /run and
+    // /connect call sites read the exact same resolved policy off the runtime
+    // and can never diverge.
+    this.forwardHeadersPolicy = resolveForwardHeadersPolicy(
+      options.forwardHeaders,
+    );
     this.debug = resolveDebugConfig(options.debug);
     if (this.debug.enabled) {
       this.debugLogger = createLogger({
@@ -478,5 +502,9 @@ export class CopilotRuntime implements CopilotRuntimeLike {
 
   get debugLogger(): CopilotRuntimeLogger | undefined {
     return this.delegate.debugLogger;
+  }
+
+  get forwardHeadersPolicy(): ResolvedForwardHeadersPolicy {
+    return this.delegate.forwardHeadersPolicy;
   }
 }

--- a/packages/runtime/src/v2/runtime/handlers/handle-connect.ts
+++ b/packages/runtime/src/v2/runtime/handlers/handle-connect.ts
@@ -2,9 +2,9 @@ import { handleIntelligenceConnect } from "./intelligence/connect";
 import { handleSseConnect } from "./sse/connect";
 import { isIntelligenceRuntime } from "../core/runtime";
 import { telemetry } from "../telemetry";
+import type { RunAgentParameters as ConnectAgentParameters } from "./shared/agent-utils";
 import {
   parseConnectRequest,
-  RunAgentParameters as ConnectAgentParameters,
   cloneAgentForRequest,
 } from "./shared/agent-utils";
 
@@ -29,6 +29,12 @@ export async function handleConnectAgent({
   });
 
   try {
+    // Runs on BOTH branches deliberately: this is the only place the connect
+    // path validates that `agentId` exists, returning a 404 `Response` for an
+    // unknown agent. The intelligence branch below never re-checks the id (it
+    // hands `agentId` straight to `ɵconnectThread`), so this clone/resolve must
+    // happen before the branch split or unknown agents would slip through. The
+    // SSE branch additionally uses the returned clone's `agent.headers`.
     const agent = await cloneAgentForRequest(runtime, agentId, request);
     if (agent instanceof Response) {
       return agent;
@@ -53,6 +59,11 @@ export async function handleConnectAgent({
       request,
       agentId,
       threadId: connectRequest.input.threadId,
+      // Pass the per-request clone so its server-configured `agent.headers` are
+      // folded into the merged header set threaded into `runner.connect`. That
+      // merge is forward-looking plumbing — no shipped runner consumes
+      // connect-path headers yet; see the note in `sse/connect.ts`.
+      agent,
     });
   } catch (error) {
     console.error("Error running agent:", error);

--- a/packages/runtime/src/v2/runtime/handlers/header-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/header-utils.ts
@@ -63,7 +63,10 @@ export interface ResolvedForwardHeadersPolicy {
   denyNames: ReadonlySet<string>;
   /** Extra prefixes to strip (lowercased). */
   denyPrefixes: readonly string[];
-  /** If set, allowlist mode: ONLY these (lowercased) names forward. */
+  /**
+   * If set, allowlist mode: ONLY these (lowercased) names are candidates to
+   * forward — and `denyNames` / `denyPrefixes` still subtract from them.
+   */
   allow?: ReadonlySet<string>;
 }
 
@@ -79,8 +82,10 @@ export interface ForwardHeadersConfig {
   /** Additional header-name prefixes to strip (case-insensitive). */
   denyPrefixes?: string[];
   /**
-   * If set, switch to allowlist mode: ONLY these headers forward, overriding
-   * the default `x-*` / `authorization` eligibility (case-insensitive).
+   * If set, switch to allowlist mode: ONLY these headers are candidates to
+   * forward, overriding the default `x-*` / `authorization` eligibility
+   * (case-insensitive). `deny` / `denyPrefixes` still apply and subtract from
+   * this set — a header listed in both `allow` and `deny` is NOT forwarded.
    */
   allow?: string[];
 }
@@ -94,23 +99,29 @@ export interface ForwardHeadersConfig {
  * - `deny` / `denyPrefixes` extend (do not replace) the defaults.
  * - `allow`, if non-empty, switches to allowlist mode.
  *
- * All names/prefixes are lowercased so matching against the lowercased inbound
- * keys is a plain set/prefix check.
+ * All names/prefixes are trimmed, lowercased, and stripped of empty/
+ * whitespace-only entries before use. Trimming/lowercasing keeps matching a
+ * plain set/prefix check against the lowercased inbound keys; dropping empties
+ * is a safety guard: a stray `denyPrefixes: [""]` would make `startsWith("")`
+ * true for every header (silently denying ALL forwarding), and an
+ * `allow: [""]` / `allow: [" "]` would seed the allowlist with an entry that
+ * can never match a real header while still switching on the exclusive
+ * allowlist mode — both are integrator typos, not intent, so we filter them.
  */
+function normalizeHeaderEntries(entries: string[] | undefined): string[] {
+  return (entries ?? [])
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.length > 0);
+}
+
 export function resolveForwardHeadersPolicy(
   config: ForwardHeadersConfig | undefined,
 ): ResolvedForwardHeadersPolicy {
-  const denyNames = new Set<string>(
-    (config?.deny ?? []).map((name) => name.toLowerCase()),
-  );
-  const denyPrefixes = (config?.denyPrefixes ?? []).map((prefix) =>
-    prefix.toLowerCase(),
-  );
-  const allowList = config?.allow;
+  const denyNames = new Set<string>(normalizeHeaderEntries(config?.deny));
+  const denyPrefixes = normalizeHeaderEntries(config?.denyPrefixes);
+  const allowEntries = normalizeHeaderEntries(config?.allow);
   const allow =
-    allowList && allowList.length > 0
-      ? new Set<string>(allowList.map((name) => name.toLowerCase()))
-      : undefined;
+    allowEntries.length > 0 ? new Set<string>(allowEntries) : undefined;
 
   return {
     useDefaultDenylist: config?.useDefaultDenylist ?? true,
@@ -121,13 +132,42 @@ export function resolveForwardHeadersPolicy(
 }
 
 /**
+ * True iff the (already-lowercased) header name matches the integrator's OWN
+ * `deny` / `denyPrefixes`. This is the authoritative subtractive check: it is
+ * consulted in BOTH allowlist and denylist mode. It deliberately does NOT
+ * include the built-in {@link DEFAULT_DENY_HEADER_NAMES} /
+ * {@link DEFAULT_DENY_HEADER_PREFIXES} — an explicit `allow` opts the integrator
+ * back into a default-denied header on purpose, so only their own `deny`
+ * subtracts from an allowlist.
+ */
+function matchesIntegratorDeny(
+  lower: string,
+  policy: ResolvedForwardHeadersPolicy,
+): boolean {
+  if (policy.denyNames.has(lower)) return true;
+  return policy.denyPrefixes.some((prefix) => lower.startsWith(prefix));
+}
+
+/**
  * Determines if a header should be forwarded under the given resolved policy.
  *
+ * The integrator's `deny` / `denyPrefixes` ALWAYS strip, including in allowlist
+ * mode: `allow` selects the candidate set, `deny` removes from it. A header the
+ * integrator lists in BOTH `allow` and `deny` is NOT forwarded — deny is
+ * authoritative so a security-motivated `deny` can never be silently defeated
+ * by an overlapping `allow` (the footgun this hardens against).
+ *
  * Modes:
- * - Allowlist (`policy.allow` set): forward iff the name is explicitly allowed.
+ * - Allowlist (`policy.allow` set): forward iff the name is in `allow` AND is
+ *   NOT matched by the integrator's `deny` / `denyPrefixes`. Nothing else
+ *   forwards — not even the usual `authorization` / `x-*` eligibility.
  * - Denylist (default): base eligibility is `authorization` or any `x-*`, then
- *   the built-in denylist (when enabled) and any integrator-supplied
+ *   the built-in denylist (when enabled) and the integrator's own
  *   names/prefixes strip from that set.
+ *
+ * Note: the built-in default denylist applies ONLY in denylist mode; an
+ * explicit `allow` is treated as the integrator deliberately opting back into
+ * those headers, so only their OWN `deny` subtracts in allowlist mode.
  */
 export function shouldForwardHeader(
   headerName: string,
@@ -135,10 +175,11 @@ export function shouldForwardHeader(
 ): boolean {
   const lower = headerName.toLowerCase();
 
-  // Allowlist mode: forward iff explicitly allowed; nothing else, not even the
+  // Allowlist mode: forward iff explicitly allowed AND not subtracted by the
+  // integrator's own deny/denyPrefixes. Nothing else forwards — not even the
   // usual `authorization` / `x-*` eligibility.
   if (policy.allow) {
-    return policy.allow.has(lower);
+    return policy.allow.has(lower) && !matchesIntegratorDeny(lower, policy);
   }
 
   // Base eligibility (unchanged): authorization + any x-*.
@@ -156,10 +197,7 @@ export function shouldForwardHeader(
   }
 
   // Integrator-supplied additions extend the denylist regardless of the default.
-  if (policy.denyNames.has(lower)) return false;
-  if (policy.denyPrefixes.some((prefix) => lower.startsWith(prefix))) {
-    return false;
-  }
+  if (matchesIntegratorDeny(lower, policy)) return false;
 
   return true;
 }

--- a/packages/runtime/src/v2/runtime/handlers/header-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/header-utils.ts
@@ -82,10 +82,18 @@ export interface ForwardHeadersConfig {
   /** Additional header-name prefixes to strip (case-insensitive). */
   denyPrefixes?: string[];
   /**
-   * If set, switch to allowlist mode: ONLY these headers are candidates to
-   * forward, overriding the default `x-*` / `authorization` eligibility
-   * (case-insensitive). `deny` / `denyPrefixes` still apply and subtract from
-   * this set — a header listed in both `allow` and `deny` is NOT forwarded.
+   * If set (with at least one non-empty entry), switch to allowlist mode: ONLY
+   * these headers are candidates to forward, overriding the default `x-*` /
+   * `authorization` eligibility (case-insensitive). `deny` / `denyPrefixes`
+   * still apply and subtract from this set — a header listed in both `allow` and
+   * `deny` is NOT forwarded.
+   *
+   * Footgun: in allowlist mode the built-in DEFAULT denylist (and
+   * `useDefaultDenylist`) is BYPASSED — only your `allow` set, minus your own
+   * `deny` / `denyPrefixes`, is forwarded. Do NOT allow-list protected/platform
+   * headers (e.g. `x-copilotcloud-public-api-key`, `x-forwarded-*`) unless you
+   * truly intend to forward them, since the default protection does not apply
+   * here.
    */
   allow?: string[];
 }
@@ -97,16 +105,19 @@ export interface ForwardHeadersConfig {
  * - `useDefaultDenylist` defaults to `true` (the built-in denylist is active
  *   on upgrade); pass `false` to restore the previous wide-open behavior.
  * - `deny` / `denyPrefixes` extend (do not replace) the defaults.
- * - `allow`, if non-empty, switches to allowlist mode.
+ * - `allow` activates allowlist mode only when it has at least one non-empty
+ *   entry after normalization.
  *
  * All names/prefixes are trimmed, lowercased, and stripped of empty/
  * whitespace-only entries before use. Trimming/lowercasing keeps matching a
  * plain set/prefix check against the lowercased inbound keys; dropping empties
  * is a safety guard: a stray `denyPrefixes: [""]` would make `startsWith("")`
- * true for every header (silently denying ALL forwarding), and an
- * `allow: [""]` / `allow: [" "]` would seed the allowlist with an entry that
- * can never match a real header while still switching on the exclusive
- * allowlist mode — both are integrator typos, not intent, so we filter them.
+ * true for every header (silently denying ALL forwarding). Because empties are
+ * dropped BEFORE the allowlist-mode decision, an `allow: [""]` / `allow: [" "]`
+ * normalizes to an empty set and does NOT switch on allowlist mode — the runtime
+ * stays in denylist mode. Allowlist mode activates only when `allow` has at
+ * least one non-empty entry; these empty/whitespace-only entries are integrator
+ * typos, not intent, so we filter them.
  */
 function normalizeHeaderEntries(entries: string[] | undefined): string[] {
   return (entries ?? [])

--- a/packages/runtime/src/v2/runtime/handlers/header-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/header-utils.ts
@@ -1,22 +1,181 @@
 /**
- * Determines if a header should be forwarded based on the allowlist.
- * Forwards: authorization header and all x-* custom headers.
+ * Exact header names (lowercased) stripped from forwarding by default.
+ *
+ * These are infrastructure/proxy/platform artifacts that no legitimate agent
+ * integration depends on receiving *forwarded from the inbound edge* — the
+ * inbound request has already traversed a browser, CDN/edge, load balancer, and
+ * hosting platform, each of which stamps its own `x-*` headers. Forwarding them
+ * verbatim to an arbitrary configured agent URL leaks client topology and, in
+ * the Copilot Cloud case, a platform credential (#5712).
+ *
+ * `x-amz-cf-id` and `x-copilotcloud-public-api-key` are also covered by the
+ * `x-amz-` / `x-copilotcloud-` prefixes below; the exact entries are kept
+ * intentionally as documentation anchors for the highest-severity headers
+ * (notably the platform API key), not as drift/oversight.
  */
-export function shouldForwardHeader(headerName: string): boolean {
-  const lower = headerName.toLowerCase();
-  return lower === "authorization" || lower.startsWith("x-");
+export const DEFAULT_DENY_HEADER_NAMES: ReadonlySet<string> = new Set([
+  // Hop-by-hop / proxy topology
+  "x-forwarded-for",
+  "x-forwarded-proto",
+  "x-forwarded-host",
+  "x-forwarded-port",
+  "x-forwarded-server",
+  "x-real-ip",
+  // Cloud / CDN tracing + infra
+  "x-amzn-trace-id",
+  "x-amz-cf-id",
+  "x-cloud-trace-context",
+  "x-cache",
+  "x-served-by",
+  "x-request-id",
+  // CopilotKit platform credentials/identifiers
+  "x-copilotcloud-public-api-key",
+]);
+
+/**
+ * Header-name prefixes (lowercased) stripped from forwarding by default.
+ *
+ * Prefix matching covers the well-known platform/CDN families so a new member
+ * of a family (e.g. a future `x-vercel-foo`) is denied without a constant edit.
+ */
+export const DEFAULT_DENY_HEADER_PREFIXES: readonly string[] = [
+  "x-amz-", // AWS
+  "x-azure-", // Azure Front Door
+  "x-fastly-", // Fastly
+  "x-vercel-", // Vercel
+  "x-middleware-", // Next.js
+  "x-copilotcloud-", // CopilotKit platform-internal
+];
+
+/**
+ * Fully-resolved inbound-header forwarding policy read by the call sites.
+ *
+ * Distinct from the public `ForwardHeadersConfig` option an integrator passes:
+ * the runtime resolves that option ONCE in its constructor into this shape
+ * (lowercasing names/prefixes, defaulting `useDefaultDenylist`, building the
+ * `allow` set) so the predicate stays branch-simple and the policy can never be
+ * re-resolved divergently at a call site. See `resolveForwardHeadersPolicy`.
+ */
+export interface ResolvedForwardHeadersPolicy {
+  /** When true, the built-in infra/platform denylist is active. */
+  useDefaultDenylist: boolean;
+  /** Extra exact names to strip (lowercased). */
+  denyNames: ReadonlySet<string>;
+  /** Extra prefixes to strip (lowercased). */
+  denyPrefixes: readonly string[];
+  /** If set, allowlist mode: ONLY these (lowercased) names forward. */
+  allow?: ReadonlySet<string>;
 }
 
 /**
- * Extracts headers that should be forwarded from a Request object.
- * Forwards only authorization and x-* headers.
+ * Public, integrator-facing config for inbound-header forwarding. Resolved into
+ * a {@link ResolvedForwardHeadersPolicy} by {@link resolveForwardHeadersPolicy}.
+ */
+export interface ForwardHeadersConfig {
+  /** Strip the built-in infra/platform denylist. @default true */
+  useDefaultDenylist?: boolean;
+  /** Additional exact header names to strip (case-insensitive). */
+  deny?: string[];
+  /** Additional header-name prefixes to strip (case-insensitive). */
+  denyPrefixes?: string[];
+  /**
+   * If set, switch to allowlist mode: ONLY these headers forward, overriding
+   * the default `x-*` / `authorization` eligibility (case-insensitive).
+   */
+  allow?: string[];
+}
+
+/**
+ * Normalizes a public {@link ForwardHeadersConfig} (or `undefined`) into a
+ * fully-resolved {@link ResolvedForwardHeadersPolicy}.
+ *
+ * - `useDefaultDenylist` defaults to `true` (the built-in denylist is active
+ *   on upgrade); pass `false` to restore the previous wide-open behavior.
+ * - `deny` / `denyPrefixes` extend (do not replace) the defaults.
+ * - `allow`, if non-empty, switches to allowlist mode.
+ *
+ * All names/prefixes are lowercased so matching against the lowercased inbound
+ * keys is a plain set/prefix check.
+ */
+export function resolveForwardHeadersPolicy(
+  config: ForwardHeadersConfig | undefined,
+): ResolvedForwardHeadersPolicy {
+  const denyNames = new Set<string>(
+    (config?.deny ?? []).map((name) => name.toLowerCase()),
+  );
+  const denyPrefixes = (config?.denyPrefixes ?? []).map((prefix) =>
+    prefix.toLowerCase(),
+  );
+  const allowList = config?.allow;
+  const allow =
+    allowList && allowList.length > 0
+      ? new Set<string>(allowList.map((name) => name.toLowerCase()))
+      : undefined;
+
+  return {
+    useDefaultDenylist: config?.useDefaultDenylist ?? true,
+    denyNames,
+    denyPrefixes,
+    allow,
+  };
+}
+
+/**
+ * Determines if a header should be forwarded under the given resolved policy.
+ *
+ * Modes:
+ * - Allowlist (`policy.allow` set): forward iff the name is explicitly allowed.
+ * - Denylist (default): base eligibility is `authorization` or any `x-*`, then
+ *   the built-in denylist (when enabled) and any integrator-supplied
+ *   names/prefixes strip from that set.
+ */
+export function shouldForwardHeader(
+  headerName: string,
+  policy: ResolvedForwardHeadersPolicy,
+): boolean {
+  const lower = headerName.toLowerCase();
+
+  // Allowlist mode: forward iff explicitly allowed; nothing else, not even the
+  // usual `authorization` / `x-*` eligibility.
+  if (policy.allow) {
+    return policy.allow.has(lower);
+  }
+
+  // Base eligibility (unchanged): authorization + any x-*.
+  const eligible = lower === "authorization" || lower.startsWith("x-");
+  if (!eligible) return false;
+
+  // Built-in denylist (default-on): strip known infra/platform headers.
+  if (policy.useDefaultDenylist) {
+    if (DEFAULT_DENY_HEADER_NAMES.has(lower)) return false;
+    if (
+      DEFAULT_DENY_HEADER_PREFIXES.some((prefix) => lower.startsWith(prefix))
+    ) {
+      return false;
+    }
+  }
+
+  // Integrator-supplied additions extend the denylist regardless of the default.
+  if (policy.denyNames.has(lower)) return false;
+  if (policy.denyPrefixes.some((prefix) => lower.startsWith(prefix))) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Extracts headers that should be forwarded from a Request object, applying the
+ * resolved forwarding policy. Keys are normalized to the lowercased form the
+ * `Headers` iterator yields.
  */
 export function extractForwardableHeaders(
   request: Request,
+  policy: ResolvedForwardHeadersPolicy,
 ): Record<string, string> {
   const forwardableHeaders: Record<string, string> = {};
   request.headers.forEach((value, key) => {
-    if (shouldForwardHeader(key)) {
+    if (shouldForwardHeader(key, policy)) {
       forwardableHeaders[key] = value;
     }
   });
@@ -46,10 +205,15 @@ export function extractForwardableHeaders(
  * exact casing and value, and any later case-variant of that name is dropped.
  * Server-wins-over-inbound and case-insensitive inbound suppression are
  * otherwise unchanged.
+ *
+ * Breadth (which inbound headers are eligible to forward at all) is decided by
+ * `policy` upstream in `extractForwardableHeaders` → `shouldForwardHeader`; the
+ * merge never re-widens or re-narrows the set.
  */
 export function mergeForwardableHeaders(
   serverHeaders: Record<string, string> | undefined,
   request: Request,
+  policy: ResolvedForwardHeadersPolicy,
 ): Record<string, string> {
   const base = serverHeaders ?? {};
   const merged: Record<string, string> = {};
@@ -65,7 +229,7 @@ export function mergeForwardableHeaders(
     merged[name] = value;
   }
   for (const [name, value] of Object.entries(
-    extractForwardableHeaders(request),
+    extractForwardableHeaders(request, policy),
   )) {
     if (!serverHeaderNames.has(name.toLowerCase())) {
       merged[name] = value;

--- a/packages/runtime/src/v2/runtime/handlers/header-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/header-utils.ts
@@ -22,3 +22,37 @@ export function extractForwardableHeaders(
   });
   return forwardableHeaders;
 }
+
+/**
+ * Merges forwardable inbound request headers onto the headers a server
+ * explicitly configured on an agent, letting the SERVER-CONFIGURED headers WIN
+ * on collision — a server-set service-to-service token (e.g. an IAM bearer)
+ * must never be silently overridden by a browser/edge/platform-injected inbound
+ * header (#5712).
+ *
+ * The collision check is case-insensitive: `extractForwardableHeaders`
+ * normalizes inbound keys to lowercase (`authorization`) while the server
+ * typically configures canonical casing (`Authorization`). A plain object
+ * spread would treat those as distinct keys and emit BOTH — which downstream
+ * (undici) comma-joins into a single invalid "multiple JWTs" value. So we drop
+ * any forwarded header the agent already sets, matched case-insensitively, and
+ * let non-colliding inbound headers pass through unchanged.
+ */
+export function mergeForwardableHeaders(
+  serverHeaders: Record<string, string> | undefined,
+  request: Request,
+): Record<string, string> {
+  const base = serverHeaders ?? {};
+  const serverHeaderNames = new Set(
+    Object.keys(base).map((name) => name.toLowerCase()),
+  );
+  const merged: Record<string, string> = { ...base };
+  for (const [name, value] of Object.entries(
+    extractForwardableHeaders(request),
+  )) {
+    if (!serverHeaderNames.has(name.toLowerCase())) {
+      merged[name] = value;
+    }
+  }
+  return merged;
+}

--- a/packages/runtime/src/v2/runtime/handlers/header-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/header-utils.ts
@@ -37,16 +37,33 @@ export function extractForwardableHeaders(
  * (undici) comma-joins into a single invalid "multiple JWTs" value. So we drop
  * any forwarded header the agent already sets, matched case-insensitively, and
  * let non-colliding inbound headers pass through unchanged.
+ *
+ * The same comma-join hazard exists if the SERVER CONFIG ITSELF contains two
+ * case-variants of one header (e.g. both `Authorization` and `authorization`
+ * in `agent.headers`). A plain `{ ...serverHeaders }` spread would keep both,
+ * so we additionally collapse server-self case-collisions to a SINGLE entry,
+ * FIRST-OCCURRENCE WINS: the first key seen (in `Object.keys` order) keeps its
+ * exact casing and value, and any later case-variant of that name is dropped.
+ * Server-wins-over-inbound and case-insensitive inbound suppression are
+ * otherwise unchanged.
  */
 export function mergeForwardableHeaders(
   serverHeaders: Record<string, string> | undefined,
   request: Request,
 ): Record<string, string> {
   const base = serverHeaders ?? {};
-  const serverHeaderNames = new Set(
-    Object.keys(base).map((name) => name.toLowerCase()),
-  );
-  const merged: Record<string, string> = { ...base };
+  const merged: Record<string, string> = {};
+  const serverHeaderNames = new Set<string>();
+  // Collapse server-self case-collisions: first occurrence wins, later
+  // case-variants of the same name are dropped.
+  for (const [name, value] of Object.entries(base)) {
+    const lower = name.toLowerCase();
+    if (serverHeaderNames.has(lower)) {
+      continue;
+    }
+    serverHeaderNames.add(lower);
+    merged[name] = value;
+  }
   for (const [name, value] of Object.entries(
     extractForwardableHeaders(request),
   )) {

--- a/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
@@ -11,7 +11,10 @@ import {
 } from "../../core/runtime";
 import { OpenGenerativeUIMiddleware } from "../../open-generative-ui-middleware";
 import { INTELLIGENCE_USER_ID_HEADER } from "../../intelligence-platform/client";
-import { mergeForwardableHeaders } from "../header-utils";
+import {
+  mergeForwardableHeaders,
+  resolveForwardHeadersPolicy,
+} from "../header-utils";
 import { resolveIntelligenceUser } from "./resolve-intelligence-user";
 import { logger } from "@copilotkit/shared";
 
@@ -149,7 +152,12 @@ export function configureAgentForRequest(params: {
   agent.headers = mergeForwardableHeaders(
     agent.headers,
     request,
-    runtime.forwardHeadersPolicy,
+    // `forwardHeadersPolicy` is optional on the published `CopilotRuntimeLike`
+    // interface (non-breaking minor release). Concrete runtimes always set it;
+    // a policy-less external implementor falls back to the default resolved
+    // policy (default-on denylist) so behavior stays identical and never derefs
+    // undefined.
+    runtime.forwardHeadersPolicy ?? resolveForwardHeadersPolicy(undefined),
   );
 }
 

--- a/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
@@ -138,13 +138,19 @@ export function configureAgentForRequest(params: {
     }
   }
 
-  // Forward inbound `authorization` / `x-*` headers onto the outgoing agent
-  // call, but let headers the server explicitly configured on the agent WIN on
-  // collision (case-insensitively) — a server-set service-to-service token
+  // Forward eligible inbound headers onto the outgoing agent call under the
+  // runtime's resolved forwarding policy (`authorization` / custom `x-*`, with
+  // known infra/proxy/platform headers stripped by the default denylist —
+  // #5712), but let headers the server explicitly configured on the agent WIN
+  // on collision (case-insensitively): a server-set service-to-service token
   // (e.g. an IAM bearer) must never be silently overridden by a
-  // browser/edge/platform-injected inbound header (#5712). See
-  // `mergeForwardableHeaders` for the casing/duplicate-key rationale.
-  agent.headers = mergeForwardableHeaders(agent.headers, request);
+  // browser/edge/platform-injected inbound header. See `mergeForwardableHeaders`
+  // for the casing/duplicate-key rationale and `shouldForwardHeader` for breadth.
+  agent.headers = mergeForwardableHeaders(
+    agent.headers,
+    request,
+    runtime.forwardHeadersPolicy,
+  );
 }
 
 /**

--- a/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
@@ -11,7 +11,7 @@ import {
 } from "../../core/runtime";
 import { OpenGenerativeUIMiddleware } from "../../open-generative-ui-middleware";
 import { INTELLIGENCE_USER_ID_HEADER } from "../../intelligence-platform/client";
-import { extractForwardableHeaders } from "../header-utils";
+import { mergeForwardableHeaders } from "../header-utils";
 import { resolveIntelligenceUser } from "./resolve-intelligence-user";
 import { logger } from "@copilotkit/shared";
 
@@ -30,6 +30,22 @@ export interface ConnectRequestBody extends RunAgentInput {
   lastSeenEventId?: string | null;
 }
 
+/**
+ * Resolve `agentId` against the runtime's agents and return a per-request
+ * clone of the matching agent.
+ *
+ * Dual return contract — both callers (`handle-run.ts`, `handle-connect.ts`)
+ * depend on it:
+ * - Returns a cloned `AbstractAgent` when the agent exists.
+ * - Returns a 404 `Response` (`{ error: "Agent not found", ... }`) when the
+ *   agent is unknown. Callers MUST `instanceof Response`-check the result and
+ *   return it directly; this doubles as the connect/run path's agent-existence
+ *   guard, so skipping the check would let unknown agent ids slip through.
+ *
+ * The clone is what subsequent per-request mutation (middleware attach,
+ * `agent.headers` merge) operates on, leaving the shared agent registration
+ * untouched.
+ */
 export async function cloneAgentForRequest(
   runtime: CopilotRuntimeLike,
   agentId: string,
@@ -122,10 +138,13 @@ export function configureAgentForRequest(params: {
     }
   }
 
-  agent.headers = {
-    ...agent.headers,
-    ...extractForwardableHeaders(request),
-  };
+  // Forward inbound `authorization` / `x-*` headers onto the outgoing agent
+  // call, but let headers the server explicitly configured on the agent WIN on
+  // collision (case-insensitively) — a server-set service-to-service token
+  // (e.g. an IAM bearer) must never be silently overridden by a
+  // browser/edge/platform-injected inbound header (#5712). See
+  // `mergeForwardableHeaders` for the casing/duplicate-key rationale.
+  agent.headers = mergeForwardableHeaders(agent.headers, request);
 }
 
 /**

--- a/packages/runtime/src/v2/runtime/handlers/sse/__tests__/sse-connect-agent-id.test.ts
+++ b/packages/runtime/src/v2/runtime/handlers/sse/__tests__/sse-connect-agent-id.test.ts
@@ -16,6 +16,12 @@ vi.mock("../../../telemetry", () => ({
 
 import { handleSseConnect } from "../connect";
 import { DebugEventBus } from "../../../core/debug-event-bus";
+import { resolveForwardHeadersPolicy } from "../../header-utils";
+import type { ResolvedForwardHeadersPolicy } from "../../header-utils";
+
+// Default resolved policy (built-in denylist on), shared across the fake
+// runtimes below so the /connect call site has a policy to read.
+const defaultPolicy = resolveForwardHeadersPolicy(undefined);
 
 /**
  * Regression guard for the agentId forwarding fix. `handleSseConnect` used
@@ -41,6 +47,7 @@ describe("handleSseConnect → debug envelope agentId", () => {
 
     const fakeRuntime = {
       debugEventBus: bus,
+      forwardHeadersPolicy: defaultPolicy,
       runner: {
         connect: () => of(event),
       },
@@ -106,6 +113,7 @@ describe("handleSseConnect → header precedence (#5712)", () => {
     );
     const fakeRuntime = {
       debugEventBus: new DebugEventBus(),
+      forwardHeadersPolicy: defaultPolicy,
       runner: { connect: connectSpy },
     } as any;
 
@@ -116,8 +124,11 @@ describe("handleSseConnect → header precedence (#5712)", () => {
         headers: {
           // Inbound headers that collide (canonical-cased server vs lowercased
           // inbound) — must lose — and one that doesn't — must still forward.
+          // Use a non-denylisted custom header so the default forwarding policy
+          // (which strips `x-request-id`) doesn't drop it for an unrelated
+          // reason; this test is about precedence, not breadth.
           Authorization: "Bearer inbound-user-token",
-          "x-request-id": "req-123",
+          "x-tenant-id": "tenant-123",
         },
       }),
       agentId: "weather-agent",
@@ -145,7 +156,7 @@ describe("handleSseConnect → header precedence (#5712)", () => {
     );
     expect(authKeys).toHaveLength(1);
     // ...and a non-colliding forwarded header still passes through.
-    expect(getHeader(headers, "x-request-id")).toBe("req-123");
+    expect(getHeader(headers, "x-tenant-id")).toBe("tenant-123");
   });
 
   it("forwards inbound allowlisted headers when no server agent.headers exist", async () => {
@@ -165,6 +176,7 @@ describe("handleSseConnect → header precedence (#5712)", () => {
     );
     const fakeRuntime = {
       debugEventBus: new DebugEventBus(),
+      forwardHeadersPolicy: defaultPolicy,
       runner: { connect: connectSpy },
     } as any;
 
@@ -173,10 +185,10 @@ describe("handleSseConnect → header precedence (#5712)", () => {
       request: new Request("http://localhost/agent/weather-agent/connect", {
         method: "POST",
         headers: {
-          // Allowlisted inbound headers (lowercased on extraction)...
+          // Forwardable inbound headers (lowercased on extraction)...
           Authorization: "Bearer inbound-user-token",
-          "x-request-id": "req-123",
-          // ...and a non-allowlisted one that must NOT forward.
+          "x-tenant-id": "tenant-123",
+          // ...and a non-forwardable one that must NOT forward.
           "content-type": "application/json",
         },
       }),
@@ -194,13 +206,88 @@ describe("handleSseConnect → header precedence (#5712)", () => {
     expect(connectSpy).toHaveBeenCalledTimes(1);
     const headers = connectSpy.mock.calls[0][0].headers;
 
-    // With no server headers to win, the inbound allowlisted headers forward
+    // With no server headers to win, the inbound forwardable headers forward
     // through unchanged...
     expect(getHeader(headers, "authorization")).toBe(
       "Bearer inbound-user-token",
     );
-    expect(getHeader(headers, "x-request-id")).toBe("req-123");
-    // ...and a non-allowlisted header is dropped (no crash, no over-forwarding).
+    expect(getHeader(headers, "x-tenant-id")).toBe("tenant-123");
+    // ...and a non-forwardable header is dropped (no crash, no over-forwarding).
     expect(getHeader(headers, "content-type")).toBeUndefined();
+  });
+});
+
+/**
+ * Regression guard for #5712 breadth on the /connect path: the default
+ * forwarding policy must strip known infra/proxy/platform headers, mirroring
+ * the /run path so the two never diverge.
+ */
+describe("handleSseConnect → forwarding-policy breadth (#5712)", () => {
+  function drainAndGetHeaders(
+    connectSpy: ReturnType<typeof vi.fn>,
+    policy: ResolvedForwardHeadersPolicy,
+    requestHeaders: Record<string, string>,
+  ): Promise<Record<string, string>> {
+    const event: BaseEvent = {
+      type: EventType.RUN_STARTED,
+      threadId: "t-1",
+      runId: "r-1",
+    } as BaseEvent;
+    connectSpy.mockImplementation(() => of(event));
+
+    const fakeRuntime = {
+      debugEventBus: new DebugEventBus(),
+      forwardHeadersPolicy: policy,
+      runner: { connect: connectSpy },
+    } as any;
+
+    const response = handleSseConnect({
+      runtime: fakeRuntime,
+      request: new Request("http://localhost/agent/weather-agent/connect", {
+        method: "POST",
+        headers: requestHeaders,
+      }),
+      agentId: "weather-agent",
+      threadId: "t-1",
+    });
+
+    return (async () => {
+      const reader = response.body!.getReader();
+      while (true) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+      return connectSpy.mock.calls[0][0].headers as Record<string, string>;
+    })();
+  }
+
+  it("strips denylisted infra/platform headers while forwarding custom x-*", async () => {
+    const connectSpy = vi.fn();
+    const headers = await drainAndGetHeaders(connectSpy, defaultPolicy, {
+      "X-Forwarded-For": "203.0.113.7",
+      "X-Vercel-Id": "iad1::abc",
+      "X-Copilotcloud-Public-Api-Key": "ck_pub_secret",
+      "X-Tenant-Id": "tenant-123",
+      Authorization: "Bearer user-token",
+    });
+
+    expect(getHeader(headers, "x-forwarded-for")).toBeUndefined();
+    expect(getHeader(headers, "x-vercel-id")).toBeUndefined();
+    expect(getHeader(headers, "x-copilotcloud-public-api-key")).toBeUndefined();
+    expect(getHeader(headers, "x-tenant-id")).toBe("tenant-123");
+    expect(getHeader(headers, "authorization")).toBe("Bearer user-token");
+  });
+
+  it("applies a custom forwardHeaders policy from the runtime (plumb-through)", async () => {
+    const connectSpy = vi.fn();
+    const headers = await drainAndGetHeaders(
+      connectSpy,
+      resolveForwardHeadersPolicy({ useDefaultDenylist: false }),
+      { "X-Forwarded-For": "203.0.113.7", "X-Tenant-Id": "tenant-123" },
+    );
+
+    // Denylist disabled → infra header forwards again, proving plumb-through.
+    expect(getHeader(headers, "x-forwarded-for")).toBe("203.0.113.7");
+    expect(getHeader(headers, "x-tenant-id")).toBe("tenant-123");
   });
 });

--- a/packages/runtime/src/v2/runtime/handlers/sse/__tests__/sse-connect-agent-id.test.ts
+++ b/packages/runtime/src/v2/runtime/handlers/sse/__tests__/sse-connect-agent-id.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { of } from "rxjs";
-import { EventType, type BaseEvent } from "@ag-ui/client";
+import { EventType } from "@ag-ui/client";
+import type { BaseEvent } from "@ag-ui/client";
 
 vi.mock("pino", () => ({
   default: vi.fn(() => ({
@@ -67,5 +68,139 @@ describe("handleSseConnect → debug envelope agentId", () => {
       // positive assertion — no need for a separate not-toBe guard.
       expect(env.agentId).toBe("weather-agent");
     }
+  });
+});
+
+/**
+ * Regression guard for issue #5712 on the /connect path. `handleSseConnect`
+ * used to forward raw inbound `authorization`/`x-*` headers straight to
+ * `runner.connect`, ignoring server-configured `agent.headers` entirely — so
+ * an inbound bearer silently clobbered service-to-service auth. The fix merges
+ * with server config winning on collision (case-insensitively), while
+ * non-colliding forwarded headers still pass through. The /run-based coverage
+ * (agent-header-precedence.test.ts) wouldn't catch a /connect regression — it
+ * is a separate code path.
+ */
+// Case-insensitive lookup — the server configures canonical casing
+// (`Authorization`) while forwarded inbound keys are lowercased.
+function getHeader(
+  headers: Record<string, string>,
+  name: string,
+): string | undefined {
+  const lower = name.toLowerCase();
+  const match = Object.keys(headers).find((k) => k.toLowerCase() === lower);
+  return match ? headers[match] : undefined;
+}
+
+describe("handleSseConnect → header precedence (#5712)", () => {
+  it("server-configured agent headers win over a colliding forwarded header", async () => {
+    const event: BaseEvent = {
+      type: EventType.RUN_STARTED,
+      threadId: "t-1",
+      runId: "r-1",
+    } as BaseEvent;
+
+    const connectSpy = vi.fn(
+      (_req: { threadId: string; headers: Record<string, string> }) =>
+        of(event),
+    );
+    const fakeRuntime = {
+      debugEventBus: new DebugEventBus(),
+      runner: { connect: connectSpy },
+    } as any;
+
+    const response = handleSseConnect({
+      runtime: fakeRuntime,
+      request: new Request("http://localhost/agent/weather-agent/connect", {
+        method: "POST",
+        headers: {
+          // Inbound headers that collide (canonical-cased server vs lowercased
+          // inbound) — must lose — and one that doesn't — must still forward.
+          Authorization: "Bearer inbound-user-token",
+          "x-request-id": "req-123",
+        },
+      }),
+      agentId: "weather-agent",
+      threadId: "t-1",
+      agent: {
+        headers: { Authorization: "Bearer service-token" },
+      } as any,
+    });
+
+    const reader = response.body!.getReader();
+    while (true) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+    const headers = connectSpy.mock.calls[0][0].headers;
+
+    // Server-set auth wins on collision...
+    expect(getHeader(headers, "authorization")).toBe("Bearer service-token");
+    // ...with exactly one authorization key (no case-mismatched duplicate that
+    // undici would comma-join into an invalid "multiple JWTs" value)...
+    const authKeys = Object.keys(headers).filter(
+      (k) => k.toLowerCase() === "authorization",
+    );
+    expect(authKeys).toHaveLength(1);
+    // ...and a non-colliding forwarded header still passes through.
+    expect(getHeader(headers, "x-request-id")).toBe("req-123");
+  });
+
+  it("forwards inbound allowlisted headers when no server agent.headers exist", async () => {
+    // The connect path passes `agent?.headers` (undefined when no agent clone
+    // carries server-configured headers) into `mergeForwardableHeaders`, which
+    // must degrade to `?? {}` without crashing and forward the inbound
+    // allowlisted headers only.
+    const event: BaseEvent = {
+      type: EventType.RUN_STARTED,
+      threadId: "t-1",
+      runId: "r-1",
+    } as BaseEvent;
+
+    const connectSpy = vi.fn(
+      (_req: { threadId: string; headers: Record<string, string> }) =>
+        of(event),
+    );
+    const fakeRuntime = {
+      debugEventBus: new DebugEventBus(),
+      runner: { connect: connectSpy },
+    } as any;
+
+    const response = handleSseConnect({
+      runtime: fakeRuntime,
+      request: new Request("http://localhost/agent/weather-agent/connect", {
+        method: "POST",
+        headers: {
+          // Allowlisted inbound headers (lowercased on extraction)...
+          Authorization: "Bearer inbound-user-token",
+          "x-request-id": "req-123",
+          // ...and a non-allowlisted one that must NOT forward.
+          "content-type": "application/json",
+        },
+      }),
+      agentId: "weather-agent",
+      threadId: "t-1",
+      // No `agent` — the `agent?.headers ?? {}` path.
+    });
+
+    const reader = response.body!.getReader();
+    while (true) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+    const headers = connectSpy.mock.calls[0][0].headers;
+
+    // With no server headers to win, the inbound allowlisted headers forward
+    // through unchanged...
+    expect(getHeader(headers, "authorization")).toBe(
+      "Bearer inbound-user-token",
+    );
+    expect(getHeader(headers, "x-request-id")).toBe("req-123");
+    // ...and a non-allowlisted header is dropped (no crash, no over-forwarding).
+    expect(getHeader(headers, "content-type")).toBeUndefined();
   });
 });

--- a/packages/runtime/src/v2/runtime/handlers/sse/connect.ts
+++ b/packages/runtime/src/v2/runtime/handlers/sse/connect.ts
@@ -55,7 +55,11 @@ export function handleSseConnect({
         // runner can pick the merged headers up without a route change; the
         // collision precedence noted here is purely about that merge, not about
         // middleware/mutation parity with /run.
-        headers: mergeForwardableHeaders(agent?.headers, request),
+        headers: mergeForwardableHeaders(
+          agent?.headers,
+          request,
+          runtime.forwardHeadersPolicy,
+        ),
       }),
   });
 }

--- a/packages/runtime/src/v2/runtime/handlers/sse/connect.ts
+++ b/packages/runtime/src/v2/runtime/handlers/sse/connect.ts
@@ -1,7 +1,10 @@
 import type { AbstractAgent } from "@ag-ui/client";
 import type { CopilotRuntimeLike } from "../../core/runtime";
 import { createSseEventResponse } from "../shared/sse-response";
-import { mergeForwardableHeaders } from "../header-utils";
+import {
+  mergeForwardableHeaders,
+  resolveForwardHeadersPolicy,
+} from "../header-utils";
 
 /**
  * `headers` lives on the HTTP-backed agent configs (e.g. `HttpAgent`), not on
@@ -58,7 +61,11 @@ export function handleSseConnect({
         headers: mergeForwardableHeaders(
           agent?.headers,
           request,
-          runtime.forwardHeadersPolicy,
+          // Optional on `CopilotRuntimeLike` (non-breaking minor release);
+          // coalesce a policy-less external implementor to the default resolved
+          // policy (default-on denylist) instead of dereffing undefined.
+          runtime.forwardHeadersPolicy ??
+            resolveForwardHeadersPolicy(undefined),
         ),
       }),
   });

--- a/packages/runtime/src/v2/runtime/handlers/sse/connect.ts
+++ b/packages/runtime/src/v2/runtime/handlers/sse/connect.ts
@@ -1,12 +1,30 @@
-import { CopilotRuntimeLike } from "../../core/runtime";
+import type { AbstractAgent } from "@ag-ui/client";
+import type { CopilotRuntimeLike } from "../../core/runtime";
 import { createSseEventResponse } from "../shared/sse-response";
-import { extractForwardableHeaders } from "../header-utils";
+import { mergeForwardableHeaders } from "../header-utils";
+
+/**
+ * `headers` lives on the HTTP-backed agent configs (e.g. `HttpAgent`), not on
+ * the base `AbstractAgent`. Mirror the runtime's own optional-headers shape so
+ * we can read server-configured headers off the per-request clone without a
+ * cast. See `agent-utils.ts`.
+ */
+type AgentWithHeaders = AbstractAgent & {
+  headers?: Record<string, string>;
+};
 
 interface HandleSseConnectParams {
   runtime: CopilotRuntimeLike;
   request: Request;
   agentId: string;
   threadId: string;
+  /**
+   * The per-request agent clone, carrying any server-configured `agent.headers`
+   * (e.g. service-to-service auth). Used only to compute the merged header set
+   * threaded into `runner.connect` below — see the note there for why that
+   * merge is forward-looking plumbing rather than active outbound auth today.
+   */
+  agent?: AgentWithHeaders;
 }
 
 export function handleSseConnect({
@@ -14,6 +32,7 @@ export function handleSseConnect({
   request,
   agentId,
   threadId,
+  agent,
 }: HandleSseConnectParams): Response {
   return createSseEventResponse({
     request,
@@ -24,7 +43,19 @@ export function handleSseConnect({
     observableFactory: () =>
       runtime.runner.connect({
         threadId,
-        headers: extractForwardableHeaders(request),
+        // Forward-looking plumbing: we compute the merged header set (server
+        // `agent.headers` win on collision, case-insensitively; non-colliding
+        // inbound headers still forward — see `mergeForwardableHeaders`, #5712)
+        // and thread it into `runner.connect`. NO shipped runner consumes the
+        // `headers` field of `AgentRunnerConnectRequest` today — every runner
+        // (in-memory, intelligence, telemetry, sqlite) reads only `threadId`.
+        // The real outbound header forwarding is the /run path, where
+        // `cloneAgentForRequest` mutates `agent.headers` directly
+        // (agent-utils.ts). This wiring exists so a future outbound-connecting
+        // runner can pick the merged headers up without a route change; the
+        // collision precedence noted here is purely about that merge, not about
+        // middleware/mutation parity with /run.
+        headers: mergeForwardableHeaders(agent?.headers, request),
       }),
   });
 }

--- a/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
@@ -152,6 +152,59 @@ const runtime = new CopilotRuntime({
 
 Each server entry optionally accepts an `agentId` field to scope that server to a single agent. Without it, the server is available to all agents.
 
+## Forwarding request headers to your agent
+
+When a request reaches the runtime, some inbound headers are forwarded onto the outgoing call to your agent (the `/run` path that actually dispatches the agent). This is how a token set on `<CopilotKit headers={...}>` reaches a self-hosted agent — see [Authentication](/auth).
+
+By default the runtime forwards `authorization` and any `x-*` header, **minus** a built-in denylist of infrastructure, proxy, and platform headers that no legitimate agent integration needs forwarded from the edge. The denylist strips, among others:
+
+- **Proxy / topology:** `x-forwarded-*`, `x-real-ip`
+- **Cloud / CDN tracing:** `x-amzn-trace-id`, `x-amz-*` (AWS), `x-azure-*`, `x-fastly-*`, `x-cloud-trace-context`, `x-cache`, `x-served-by`
+- **Platform-injected:** `x-vercel-*`, `x-middleware-*` (Next.js)
+- **CopilotKit platform:** `x-copilotcloud-*`, including `x-copilotcloud-public-api-key`
+
+Everything else still forwards: `authorization`, and any custom application header like `x-tenant-id`, `x-api-key`, or `x-user-id`.
+
+<Callout type="warn" title="Upgrade note: x-request-id is now stripped">
+Earlier runtime versions forwarded `x-request-id`. It is now stripped by default because it is predominantly a proxy-assigned trace id. If your agent relies on receiving your own `x-request-id`, re-enable it with `forwardHeaders: { allow: [...] }` or `useDefaultDenylist: false` (below).
+</Callout>
+
+### Server-configured headers win
+
+Headers you set on an agent (e.g. `new HttpAgent({ headers: { Authorization: "Bearer <service-token>" } })`) take precedence over a forwarded inbound header of the same name, matched case-insensitively. A service-to-service token you configured on the server is never silently overridden by a browser- or edge-injected inbound header ([#5782](https://github.com/CopilotKit/CopilotKit/pull/5782)).
+
+### Configuring the policy
+
+Pass `forwardHeaders` to `CopilotRuntime` to tune what forwards:
+
+```ts title="app/api/copilotkit/route.ts"
+const runtime = new CopilotRuntime({
+  agents: { default: myAgent },
+  forwardHeaders: {
+    // Strip additional headers on top of the default denylist:
+    deny: ["x-internal-debug"],
+    denyPrefixes: ["x-acme-"],
+  },
+});
+```
+
+The options:
+
+- **`deny`** / **`denyPrefixes`** — extra exact names / name-prefixes to strip. These **always** strip (deny wins), even in allowlist mode, so a security-motivated `deny` can never be defeated by an overlapping `allow`.
+- **`allow`** — switches to **allowlist mode**: only the listed headers forward, and the usual `authorization` / `x-*` eligibility no longer applies. Your `deny` / `denyPrefixes` still subtract from this set.
+- **`useDefaultDenylist`** — defaults to `true`. Set `false` to opt out of the built-in denylist and restore the previous wide-open behavior.
+
+Empty or whitespace-only entries are ignored in every list.
+
+```ts
+// Allowlist mode: forward ONLY these two, nothing else.
+forwardHeaders: { allow: ["authorization", "x-tenant-id"] }
+```
+
+<Callout type="warn" title="Allowlist mode bypasses the default denylist">
+In allowlist mode the built-in denylist does **not** apply — only your `allow` set (minus your own `deny`) forwards. Don't allow-list protected headers such as `x-copilotcloud-public-api-key` or `x-forwarded-*` unless you truly intend to forward them, since the default protection isn't there to catch them.
+</Callout>
+
 ## Connecting to an AG-UI agent directly
 
 CopilotKit is built on the [AG-UI protocol](/backend/ag-ui), which is an open standard. If you want to connect your frontend directly to an AG-UI-compatible agent without the runtime, you can do so by passing agent instances straight to the `CopilotKit`:


### PR DESCRIPTION
## Problem — the leak

The v2 runtime's `shouldForwardHeader` forwarded `authorization` **and any header whose name starts with `x-`** onto the outgoing agent call. In a real deployment the inbound request has already traversed a browser, CDN/edge, load balancer, and hosting platform — each stamping its own `x-*` headers — so the wide `x-*` wildcard silently forwarded:

- **Hop-by-hop / topology:** `x-forwarded-for`, `x-real-ip`, `x-forwarded-proto/host/port`
- **Cloud / CDN tracing:** `x-amzn-trace-id`, `x-amz-cf-id`, `x-cloud-trace-context`, `x-azure-*`, `x-fastly-*`, `x-request-id`
- **Platform-injected:** `x-vercel-*`, `x-middleware-*`
- **CopilotKit Cloud platform credential:** `x-copilotcloud-public-api-key`

The last item is a real credential-exfiltration concern: a platform key scoped to Copilot Cloud reaching a third-party agent URL. This is the **breadth** half of #5712 (option 3); the **precedence** half was fixed in #5782.

## Design — denylist default + config knob, both paths

- **Default denylist (safe default).** Keep the `authorization` + `x-*` base eligibility, but strip a curated, greppable set of known infra/proxy/platform headers (exact names + prefix families) before forwarding. Legitimate custom `x-*` application headers (`x-tenant-id`, `x-api-key`, …) keep flowing untouched. The authoritative list is a single exported constant in `header-utils.ts`.
- **Configurable policy (`forwardHeaders` runtime option).**
  - `useDefaultDenylist?: boolean` (default **true**) — `false` restores the previous wide-open behavior.
  - `deny?` / `denyPrefixes?` — extend the default denylist.
  - `allow?` — opt into strict allowlist mode (only listed headers forward).
- **Resolve once.** The constructor resolves `forwardHeaders` into a `forwardHeadersPolicy: ResolvedForwardHeadersPolicy` field (mirroring the existing `debug` → `ResolvedDebugConfig` resolve-once), exposed on `CopilotRuntimeLike` / `BaseCopilotRuntime` with a passthrough getter on the `CopilotRuntime` shim.
- **Both paths.** The resolved policy is read at **/run** (`configureAgentForRequest`) and **/connect** (`handleSseConnect`) via `mergeForwardableHeaders`, so the two can never diverge. Server-wins precedence and server-self case-dedup from #5782 are untouched.

## Semver

**Minor with an opt-out.** Removing a leak is a fix, not a contract change, and we ship a documented escape hatch: `new CopilotRuntime({ agents, forwardHeaders: { useDefaultDenylist: false } })` restores the prior behavior. Custom-header forwarders (the common case) are unaffected.

## Red-green proof (real surface, both paths)

RED — with the predicate reverted to the old wide-open `authorization || x-*` (policy ignored), the new behavior assertions fail; the leak reproduces (`x-forwarded-for: 203.0.113.7` forwards on both /run and /connect):

```
 ❯ header-utils.test.ts (19 tests | 8 failed)
   × strips known infra/proxy/platform headers by exact name → expected true to be false
   × strips known infra/platform header families by prefix   → expected true to be false
   × strips denylisted headers case-insensitively            → expected true to be false
   × deny extends the default set                            → expected true to be false
   × denyPrefixes extends the default set                    → expected true to be false
   × allow switches to allowlist mode                        → expected true to be false
   × extractForwardableHeaders drops denylisted x-* infra    → expected {…4} to deeply equal {…1}
 ❯ agent-utils-header-forwarding.test.ts (/run) (10 tests | 1 failed)
   × strips denylisted infra/platform headers (#5712 breadth) → expected '203.0.113.7' to be undefined
 ❯ sse-connect-agent-id.test.ts (/connect) (5 tests | 1 failed)
   × strips denylisted infra/platform headers                → expected '203.0.113.7' to be undefined
```

GREEN — with the real policy in place:

```
 ✓ header-utils.test.ts (19 tests)
 ✓ agent-utils-header-forwarding.test.ts (10 tests)   # /run path
 ✓ sse-connect-agent-id.test.ts (5 tests)             # /connect path
 ✓ agent-header-precedence.test.ts (2 tests)
 Test Files  4 passed (4)
      Tests  36 passed (36)
```

Full `@copilotkit/runtime` suite: **113 files / 1593 tests passed.** Typecheck, oxlint (0 errors), oxfmt, and build all green.

## Builds on #5782

This branches off #5782's head (`636bcad05`) and reuses that PR's `mergeForwardableHeaders` (server-wins precedence + server-self case-dedup). It should land **after #5782**. It addresses the **forwarding-breadth half of #5712** — #5712's precedence core is fixed by #5782; this is the breadth follow-up (not `Fixes #5712`).