### PR TITLE
fix: inspector shows no AG-UI events for per-thread agent clones

### DIFF
--- a/packages/core/src/__tests__/core-agent-run-started.test.ts
+++ b/packages/core/src/__tests__/core-agent-run-started.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { CopilotKitCore } from "../core";
+import { MockAgent } from "./test-utils";
+
+// Regression test for the inspector losing AG-UI events during runs.
+//
+// `useAgent` runs a per-thread *clone* of the registry agent. Clones are not
+// added to the registry, so `onAgentsChanged` never fires for them and any
+// subscriber that only tracks registry agents (the inspector) never sees the
+// instance that actually runs. `onAgentRunStarted` bridges that gap by
+// notifying subscribers with the real run instance at the start of every run.
+describe("CopilotKitCore onAgentRunStarted", () => {
+  let core: CopilotKitCore;
+
+  beforeEach(() => {
+    core = new CopilotKitCore({});
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fires with the actual run instance (a per-thread clone not in the registry)", async () => {
+    const registryAgent = new MockAgent({ agentId: "default" });
+    core.addAgent__unsafe_dev_only({
+      id: "default",
+      agent: registryAgent as any,
+    });
+
+    // The per-thread clone useAgent would run — same agentId, separate instance,
+    // never registered.
+    const clone = registryAgent.clone();
+    expect(clone).not.toBe(registryAgent);
+    expect(core.agents["default"]).toBe(registryAgent);
+
+    const onAgentRunStarted = vi.fn();
+    core.subscribe({ onAgentRunStarted });
+
+    await core.runAgent({ agent: clone as any });
+
+    expect(onAgentRunStarted).toHaveBeenCalledTimes(1);
+    expect(onAgentRunStarted).toHaveBeenCalledWith({
+      copilotkit: core,
+      agent: clone,
+    });
+  });
+
+  it("does not re-notify on recursive follow-up runs within the same top-level run", async () => {
+    const onAgentRunStarted = vi.fn();
+    core.subscribe({ onAgentRunStarted });
+
+    // A tool follow-up re-enters runAgent while the top-level run is still on
+    // the stack; the run depth guard must keep the notification to once.
+    const agent = new MockAgent({
+      agentId: "default",
+      runAgentCallback: () => {
+        if (agent.runAgentCalls.length === 1) {
+          void core.runAgent({ agent: agent as any });
+        }
+      },
+    });
+
+    await core.runAgent({ agent: agent as any });
+
+    expect(agent.runAgentCalls.length).toBeGreaterThan(1);
+    expect(onAgentRunStarted).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -141,6 +141,16 @@ export interface CopilotKitCoreSubscriber {
     copilotkit: CopilotKitCore;
     agents: Readonly<Record<string, AbstractAgent>>;
   }) => void | Promise<void>;
+  /**
+   * Fired when an agent run or connect begins. The `agent` may be a per-thread
+   * clone that is not present in `core.agents`, so `onAgentsChanged` never fires
+   * for it. Subscribers (e.g. the inspector) can use this to subscribe to the
+   * running instance's AG-UI events.
+   */
+  onAgentRunStarted?: (event: {
+    copilotkit: CopilotKitCore;
+    agent: AbstractAgent;
+  }) => void | Promise<void>;
   onContextChanged?: (event: {
     copilotkit: CopilotKitCore;
     context: Readonly<Record<string, Context>>;

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -249,6 +249,19 @@ export class RunHandler {
       // late header update is picked up without clobbering per-agent headers.
       this._internal.applyHeadersToAgent(agent);
 
+      // Notify subscribers (e.g. the inspector) about the agent that is about
+      // to run. Per-thread clones are not in the agent registry, so
+      // onAgentsChanged never fires for them and they would otherwise be
+      // invisible to subscribers.
+      await this._internal.notifySubscribers(
+        (subscriber) =>
+          subscriber.onAgentRunStarted?.({
+            copilotkit: this.core,
+            agent,
+          }),
+        "Subscriber onAgentRunStarted error:",
+      );
+
       const runAgentResult = await agent.connectAgent(
         {
           forwardedProps: this._internal.properties,
@@ -336,6 +349,20 @@ export class RunHandler {
         controller.abort();
         originalAbortRun!();
       };
+
+      // Notify subscribers (e.g. the inspector) about the agent that is about
+      // to run. Per-thread clones are not in the agent registry, so
+      // onAgentsChanged never fires for them and they would otherwise be
+      // invisible to subscribers. Fired once per top-level run; recursive
+      // follow-up runs reuse the same instance and need no re-notification.
+      await this._internal.notifySubscribers(
+        (subscriber) =>
+          subscriber.onAgentRunStarted?.({
+            copilotkit: this.core,
+            agent,
+          }),
+        "Subscriber onAgentRunStarted error:",
+      );
     }
 
     this._runDepth++;

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -2760,6 +2760,14 @@ export class WebInspectorElement extends LitElement {
       onAgentsChanged: ({ agents }) => {
         this.processAgentsChanged(agents);
       },
+      onAgentRunStarted: ({ agent }) => {
+        // Per-thread clones (from useAgent) are not in the agent registry, so
+        // onAgentsChanged never fires for them. Subscribe to the running
+        // instance here so its AG-UI events reach the event timeline.
+        if (agent?.agentId) {
+          this.subscribeToAgent(agent);
+        }
+      },
       onContextChanged: ({ context }) => {
         this.contextStore = this.normalizeContextStore(context);
         this.requestUpdate();


### PR DESCRIPTION
Fixes #5773, a regression of #3872. The inspector event timeline stays empty during runs — no `RUN_STARTED`, `TEXT_MESSAGE_*`, `TOOL_CALL_*`, etc. — while connection status, agents, context and tools still populate.

The cause is the same one #3872 fixed and that has since been dropped: `useAgent` runs a per-thread *clone* of the registry agent, and clones are never added to the registry. The inspector only subscribes to AG-UI events via `onAgentsChanged`, so it never sees the clone that actually runs, and every `recordAgentEvent` sits on the wrong instance. The `onAgentRunStarted` bridge #3872 added is no longer declared on `CopilotKitCoreSubscriber`.

Re-landing it against the current run path: `RunHandler` fires `onAgentRunStarted` with the real run instance at the start of `runAgent` (top-level only, so recursive tool follow-ups don't re-subscribe) and `connectAgent`, and the inspector subscribes to that instance. `subscribeToAgent` already keys by `agentId` and replaces, so the clone cleanly supersedes the registry subscription and there's no leak. Per-thread cloning is untouched.

Added a core regression test driving a run on a clone that isn't in the registry and asserting the event fires once with that instance, plus that recursive follow-up runs don't re-notify. Core and web-inspector both typecheck; core suite green.