### PR TITLE
feat(bot): SDK realtime render-event streaming + Bolt-free Slack renderer (OSS-402 / OSS-403)

### DIFF
--- a/packages/bot-intelligence/package.json
+++ b/packages/bot-intelligence/package.json
@@ -44,11 +44,13 @@
   "dependencies": {
     "@ag-ui/client": "0.0.57",
     "@copilotkit/bot": "workspace:~",
-    "@copilotkit/bot-ui": "workspace:~"
+    "@copilotkit/bot-ui": "workspace:~",
+    "phoenix": "^1.8.4"
   },
   "devDependencies": {
     "@copilotkit/typescript-config": "workspace:^",
     "@types/node": "^22.10.0",
+    "@types/phoenix": "^1.6.6",
     "typescript": "^5.6.3",
     "vitest": "^4.1.3"
   }

--- a/packages/bot-intelligence/src/contracts.ts
+++ b/packages/bot-intelligence/src/contracts.ts
@@ -93,3 +93,54 @@ export type EgressResult =
   | { ok: true; ref: string }
   // TODO(OSS-377): `code` becomes a bounded failure-code enum.
   | { ok: false; code: string };
+
+// ── Realtime render events (OSS-402) ──────────────────────────────────────
+// Mirrors the frozen `hosted_bot.render_event.v1` contract on the Intelligence
+// side (libs/app-api-contracts/src/hosted-bots.ts). The SDK streams these
+// semantic frames to the realtime-gateway; the gateway-side Connector Outbox
+// (OSS-404) renders them to the provider (Slack Block Kit, etc.).
+// TODO(OSS-377): replace with the shared `@copilotkit/managed-bot-contracts`
+// package; `post`/`update` content is `BotNode[]` (SDK IR) here — the frozen
+// contract types it as opaque `HostedBotRenderContent`.
+
+/** One semantic render frame the agent run emits. Matches the frozen kinds. */
+export type HostedBotRenderEvent =
+  | { kind: "run_started" }
+  | { kind: "text_delta"; messageId: string; delta: string }
+  | { kind: "text_end"; messageId: string }
+  | { kind: "tool_start"; toolCallId: string; toolName: string }
+  | { kind: "tool_end"; toolCallId: string; toolName: string }
+  | { kind: "interrupt" }
+  | { kind: "run_error"; message: string }
+  | { kind: "post"; content: BotNode[] }
+  | { kind: "update"; ref: string; content: BotNode[] }
+  | { kind: "finalize" };
+
+/** All render-event kinds, for exhaustive/ordering checks. */
+export type HostedBotRenderEventKind = HostedBotRenderEvent["kind"];
+
+/**
+ * The adapter-facing render frame. The {@link RenderEventSink} fills in the
+ * org/project/bot scope, the `idempotencyKey` (`turnId:slot:seq`), the
+ * `runtimeInstanceId`, and `sentAt` before it hits the wire — the adapter only
+ * supplies the delivery/turn identity, the render lane (`slot`), the monotonic
+ * per-`(turn, slot)` `seq`, and the semantic `event`.
+ */
+export interface RenderFrame {
+  deliveryId: string;
+  turnId: string;
+  /** Render lane; a single turn uses `"main"` for V1. */
+  slot: string;
+  /** Zero-based, monotonic within `(turnId, slot)`. */
+  seq: number;
+  event: HostedBotRenderEvent;
+}
+
+/** Durable-acceptance receipt echoed back for each pushed {@link RenderFrame}. */
+export interface RenderAccepted {
+  /** `${turnId}:${slot}:${seq}` — the frame's idempotency key. */
+  idempotencyKey: string;
+  acceptance: "accepted" | "duplicate_accepted" | "duplicate_skipped";
+  /** Present only on an accepted `finalize` frame — links to the egress op. */
+  egressOperationId?: string;
+}

--- a/packages/bot-intelligence/src/contracts.ts
+++ b/packages/bot-intelligence/src/contracts.ts
@@ -38,8 +38,25 @@ export interface ManagedIngressBase {
  * TODO(OSS-377): the frozen envelope will carry richer per-kind payloads
  * (contentParts, structured command options, raw interaction values, etc.).
  */
+/**
+ * A turn-input file reference: an opaque handle plus display metadata (no
+ * bytes). The adapter fetches the bytes lazily via
+ * {@link DeliverySource.fetchFile} and builds `AgentContentPart`s from them.
+ */
+export interface ManagedFileRef {
+  handle: string;
+  filename: string;
+  mimeType?: string;
+  byteSize?: number;
+}
+
 export type ManagedIngressEnvelope =
-  | (ManagedIngressBase & { kind: "turn"; text?: string })
+  | (ManagedIngressBase & {
+      kind: "turn";
+      text?: string;
+      /** Inbound files attached to this turn (images, docs, …), in order. */
+      files?: ManagedFileRef[];
+    })
   | (ManagedIngressBase & {
       kind: "command";
       /** Command name as invoked (leading slash / case normalized by core). */
@@ -114,6 +131,18 @@ export type HostedBotRenderEvent =
   | { kind: "run_error"; message: string }
   | { kind: "post"; content: BotNode[] }
   | { kind: "update"; ref: string; content: BotNode[] }
+  | {
+      /**
+       * Outbound file post (`thread.postFile`). Bytes were streamed to app-api
+       * ahead of this frame and stored in object storage under `handle`; the
+       * Connector Outbox fetches them and calls Slack `files.uploadV2`.
+       */
+      kind: "file";
+      handle: string;
+      filename: string;
+      title?: string;
+      altText?: string;
+    }
   | { kind: "finalize" };
 
 /** All render-event kinds, for exhaustive/ordering checks. */

--- a/packages/bot-intelligence/src/http-transports.test.ts
+++ b/packages/bot-intelligence/src/http-transports.test.ts
@@ -251,6 +251,29 @@ describe("HttpDeliverySource", () => {
       retryable: true,
     });
   });
+
+  it("times out a hung turn, nacks it, and keeps the loop alive", async () => {
+    const { fetch, calls } = fakeFetch((c) =>
+      c.url.endsWith("/claim")
+        ? { body: { claimed: true, delivery: claimedDelivery() } }
+        : { body: { failed: true, status: "retry_wait" } },
+    );
+    const src = new HttpDeliverySource(cfg({ fetch, turnTimeoutMs: 20 }));
+    let started = 0;
+    // A turn that never resolves (e.g. a HITL approval that never arrives) must
+    // not wedge the single-delivery loop: it times out, gets nacked, loop continues.
+    await src.start(async () => {
+      started += 1;
+      await new Promise<void>(() => {});
+    });
+    await new Promise((r) => setTimeout(r, 80));
+    await src.stop();
+
+    expect(started).toBeGreaterThanOrEqual(1);
+    const fail = calls.find((c) => c.url.includes("/deliveries/dlv_9/fail"));
+    expect(fail).toBeDefined();
+    expect(fail!.body["error"]).toMatchObject({ code: "runtime_error" });
+  });
 });
 
 describe("HttpRenderEventSink", () => {

--- a/packages/bot-intelligence/src/http-transports.test.ts
+++ b/packages/bot-intelligence/src/http-transports.test.ts
@@ -4,6 +4,7 @@ import type { BotNode } from "@copilotkit/bot-ui";
 import {
   HttpDeliverySource,
   HttpEgressSink,
+  HttpRenderEventSink,
   resolveTransportConfig,
 } from "./http-transports.js";
 import type {
@@ -65,6 +66,8 @@ const text = (value: string): BotNode =>
 const claimedDelivery = (over?: Record<string, unknown>) => ({
   id: "dlv_9",
   attempt: 1,
+  organizationId: "org_1",
+  projectId: 7,
   bot: { id: "bot_1", name: "opentagbot" },
   adapter: "slack",
   leaseToken: "lease_z",
@@ -247,6 +250,70 @@ describe("HttpDeliverySource", () => {
       message: "boom",
       retryable: true,
     });
+  });
+});
+
+describe("HttpRenderEventSink", () => {
+  it("streams a render frame to the accept route with echoed scope (no deliveryId in body)", async () => {
+    const { fetch, calls } = fakeFetch((c) =>
+      c.url.endsWith("/claim")
+        ? { body: { claimed: true, delivery: claimedDelivery() } }
+        : {
+            body: {
+              idempotencyKey: "turn_9:main:0",
+              acceptance: "accepted",
+            },
+          },
+    );
+    const conf = cfg({ fetch });
+    const src = new HttpDeliverySource(conf);
+    await src.claimOnce(); // populates per-delivery scope
+    const sink = new HttpRenderEventSink(conf, src);
+
+    const receipt = await sink.push({
+      deliveryId: "dlv_9",
+      turnId: "turn_9",
+      slot: "main",
+      seq: 0,
+      event: { kind: "text_delta", messageId: "m1", delta: "hi" },
+    });
+
+    expect(receipt).toEqual({
+      idempotencyKey: "turn_9:main:0",
+      acceptance: "accepted",
+    });
+    const accept = calls.find((c) =>
+      c.url.endsWith("/deliveries/dlv_9/render-events/accept"),
+    )!;
+    expect(accept.body).toMatchObject({
+      organizationId: "org_1",
+      projectId: 7,
+      botId: "bot_1",
+      botName: "opentagbot",
+      turnId: "turn_9",
+      runtimeInstanceId: "rti_test",
+      slot: "main",
+      seq: 0,
+      idempotencyKey: "turn_9:main:0",
+      event: { kind: "text_delta", messageId: "m1", delta: "hi" },
+    });
+    // The accept route rejects a body that also carries deliveryId.
+    expect("deliveryId" in accept.body).toBe(false);
+  });
+
+  it("throws when no leased scope exists for the delivery", async () => {
+    const { fetch } = fakeFetch(() => ({ body: {} }));
+    const src = new HttpDeliverySource(cfg({ fetch }));
+    const sink = new HttpRenderEventSink(cfg({ fetch }), src);
+    await expect(
+      sink.push({
+        deliveryId: "dlv_unknown",
+        turnId: "turn_9",
+        slot: "main",
+        seq: 0,
+        event: { kind: "run_started" },
+      }),
+    ).rejects.toThrow(/no leased scope/);
   });
 });
 

--- a/packages/bot-intelligence/src/http-transports.ts
+++ b/packages/bot-intelligence/src/http-transports.ts
@@ -53,6 +53,13 @@ export interface IntelligenceTransportConfig {
   sleep?: (ms: number) => Promise<void>;
   /** Optional logger for loop/transport diagnostics. */
   log?: (msg: string, meta?: unknown) => void;
+  /**
+   * Max wall-clock a single turn may take before the listener gives up on it,
+   * `nack`s the delivery, and moves on (default 120000). Prevents a hung turn
+   * (e.g. a HITL approval that never arrives, or a half-open stream) from
+   * wedging the single-delivery-at-a-time loop indefinitely.
+   */
+  turnTimeoutMs?: number;
 }
 
 /**
@@ -99,11 +106,40 @@ export function resolveTransportConfig(
     heartbeatIntervalMs: overrides.heartbeatIntervalMs,
     sleep: overrides.sleep,
     log: overrides.log,
+    turnTimeoutMs: overrides.turnTimeoutMs,
   };
 }
 
 const defaultSleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Default per-turn deadline before a hung turn is nacked and skipped. */
+const DEFAULT_TURN_TIMEOUT_MS = 120_000;
+
+/**
+ * Reject after `ms` if `p` hasn't settled, so a hung turn can't wedge the
+ * single-delivery loop. The underlying promise keeps running in the background
+ * (harmless — a rejection handler is attached), but the loop moves on.
+ */
+function withTimeout<T>(
+  p: Promise<T>,
+  ms: number,
+  message: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms);
+    p.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
 
 /** Slack reply target Intelligence mints at ingress and the sink echoes back. */
 interface SlackReplyTarget {
@@ -287,7 +323,29 @@ export class HttpDeliverySource implements DeliverySource {
         if ("env" in r) {
           // The adapter dispatches the turn and calls back into ack/nack
           // before this resolves — at-least-once, one delivery at a time.
-          await onDelivery(r.env);
+          // Bound it: a turn that throws or hangs must not wedge the loop, so
+          // we time it out, `nack` to release the lease immediately (app-api
+          // then retries / dead-letters at max_attempts), and keep polling.
+          const env = r.env;
+          const timeoutMs = this.cfg.turnTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS;
+          try {
+            await withTimeout(
+              onDelivery(env),
+              timeoutMs,
+              `turn ${env.turnId} exceeded ${timeoutMs}ms`,
+            );
+          } catch (turnErr) {
+            this.cfg.log?.("intelligence turn failed/timed out", turnErr);
+            await this.nack(
+              env.deliveryId,
+              turnErr instanceof Error ? turnErr.message : String(turnErr),
+            ).catch((nackErr) =>
+              this.cfg.log?.(
+                "intelligence nack after turn failure failed",
+                nackErr,
+              ),
+            );
+          }
         } else {
           await this.sleep(Math.min(r.pollAfterMs || 1000, cadence));
         }

--- a/packages/bot-intelligence/src/http-transports.ts
+++ b/packages/bot-intelligence/src/http-transports.ts
@@ -6,6 +6,7 @@ import type {
 } from "./transports.js";
 import type {
   ManagedIngressEnvelope,
+  ManagedFileRef,
   EgressOperation,
   EgressResult,
   RenderFrame,
@@ -161,7 +162,7 @@ interface ClaimedDelivery {
     id: string;
     eventId: string;
     replyTarget: SlackReplyTarget;
-    input?: { kind: string; text: string };
+    input?: { kind: string; text: string; files?: ManagedFileRef[] };
   };
 }
 
@@ -233,6 +234,7 @@ function mapDeliveryToEnvelope(d: ClaimedDelivery): ManagedIngressEnvelope {
     conversationKey: conversationKeyFromReplyTarget(d.turn.replyTarget),
     route: d.turn.replyTarget,
     text: d.turn.input?.text ?? "",
+    ...(d.turn.input?.files?.length ? { files: d.turn.input.files } : {}),
   };
 }
 
@@ -395,6 +397,83 @@ export class HttpDeliverySource implements DeliverySource {
       },
     );
     this.leases.delete(deliveryId);
+  }
+
+  /**
+   * Download an inbound file's raw bytes by handle from app-api's file-serve
+   * route. Bypasses {@link IntelligenceHttp} on purpose — that helper is
+   * JSON/POST-only and decodes bodies as text, which corrupts binary; the
+   * global `fetch` gives us `arrayBuffer()`. Auth is the same runtime bearer.
+   */
+  async fetchFile(
+    handle: string,
+  ): Promise<{ bytes: Uint8Array; mimeType?: string }> {
+    const gfetch = (globalThis as unknown as { fetch?: typeof fetch }).fetch;
+    if (!gfetch) {
+      throw new Error(
+        "intelligenceAdapter: no global fetch available for file download",
+      );
+    }
+    const url = `${this.cfg.baseUrl}/api/bots/files/${encodeURIComponent(handle)}`;
+    const res = await gfetch(url, {
+      method: "GET",
+      headers: { authorization: `Bearer ${this.cfg.apiKey}` },
+    });
+    if (!res.ok) {
+      throw new Error(`intelligence file ${handle} -> ${res.status}`);
+    }
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    const mimeType = res.headers.get("content-type") ?? undefined;
+    return { bytes, mimeType };
+  }
+
+  /**
+   * Stream an outbound file's bytes to app-api's per-delivery upload route
+   * (lease-scoped) ahead of a `file` render frame. Returns the storage handle
+   * the frame references. Bytes go as the raw request body; display metadata
+   * rides query params.
+   */
+  async uploadFile(
+    deliveryId: string,
+    args: {
+      bytes: Uint8Array;
+      filename: string;
+      title?: string;
+      altText?: string;
+    },
+  ): Promise<{ handle: string }> {
+    const gfetch = (globalThis as unknown as { fetch?: typeof fetch }).fetch;
+    if (!gfetch) {
+      throw new Error(
+        "intelligenceAdapter: no global fetch available for file upload",
+      );
+    }
+    const qs = new URLSearchParams({ filename: args.filename });
+    if (args.title) qs.set("title", args.title);
+    if (args.altText) qs.set("altText", args.altText);
+    const url = `${this.cfg.baseUrl}/api/bots/deliveries/${encodeURIComponent(
+      deliveryId,
+    )}/files?${qs.toString()}`;
+    const res = await gfetch(url, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${this.cfg.apiKey}`,
+        "content-type": "application/octet-stream",
+      },
+      // The runtime (undici) sends the Uint8Array bytes verbatim; the static
+      // `fetch` body type differs across this package's dom vs node-only lib
+      // configs, so bridge with a portable cast (`string` is a valid body in
+      // both). The value is never actually a string at runtime.
+      body: args.bytes as unknown as string,
+    });
+    if (!res.ok) {
+      throw new Error(`intelligence file upload -> ${res.status}`);
+    }
+    const json = (await res.json()) as { handle?: string };
+    if (!json.handle) {
+      throw new Error("intelligence file upload: response missing handle");
+    }
+    return { handle: json.handle };
   }
 
   async stop(): Promise<void> {

--- a/packages/bot-intelligence/src/http-transports.ts
+++ b/packages/bot-intelligence/src/http-transports.ts
@@ -1,9 +1,15 @@
 import { randomUUID } from "node:crypto";
-import type { DeliverySource, EgressSink } from "./transports.js";
+import type {
+  DeliverySource,
+  EgressSink,
+  RenderEventSink,
+} from "./transports.js";
 import type {
   ManagedIngressEnvelope,
   EgressOperation,
   EgressResult,
+  RenderFrame,
+  RenderAccepted,
 } from "./contracts.js";
 import { irToText } from "./ir-to-text.js";
 
@@ -110,6 +116,8 @@ interface SlackReplyTarget {
 /** Successful `claim` delivery envelope (subset the bridge reads). */
 interface ClaimedDelivery {
   id: string;
+  organizationId: string;
+  projectId: number;
   bot: { id: string; name: string };
   adapter: string;
   leaseToken: string;
@@ -119,6 +127,14 @@ interface ClaimedDelivery {
     replyTarget: SlackReplyTarget;
     input?: { kind: string; text: string };
   };
+}
+
+/** Per-delivery org/project/bot scope, echoed onto render frames. */
+export interface DeliveryScope {
+  organizationId: string;
+  projectId: number;
+  botId: string;
+  botName: string;
 }
 
 type ClaimResponse =
@@ -187,6 +203,7 @@ function mapDeliveryToEnvelope(d: ClaimedDelivery): ManagedIngressEnvelope {
 interface LeaseRecord {
   turnId: string;
   leaseToken: string;
+  scope: DeliveryScope;
 }
 
 /**
@@ -235,8 +252,19 @@ export class HttpDeliverySource implements DeliverySource {
     this.leases.set(res.delivery.id, {
       turnId: res.delivery.turn.id,
       leaseToken: res.delivery.leaseToken,
+      scope: {
+        organizationId: res.delivery.organizationId,
+        projectId: res.delivery.projectId,
+        botId: res.delivery.bot.id,
+        botName: res.delivery.bot.name,
+      },
     });
     return { env: mapDeliveryToEnvelope(res.delivery) };
+  }
+
+  /** The org/project/bot scope for a leased delivery, for render-frame egress. */
+  scopeFor(deliveryId: string): DeliveryScope | undefined {
+    return this.leases.get(deliveryId)?.scope;
   }
 
   async start(
@@ -361,5 +389,71 @@ export class HttpEgressSink implements EgressSink {
         code: err instanceof Error ? err.message : "egress_error",
       };
     }
+  }
+}
+
+/** Durable render-acceptance receipt (subset the sink reads). */
+interface RenderAcceptedResponse {
+  idempotencyKey?: string;
+  acceptance?: RenderAccepted["acceptance"];
+  egressOperationId?: string;
+}
+
+/**
+ * @internal {@link RenderEventSink} that streams semantic render frames to
+ * Intelligence's durable render-acceptance route
+ * (`/api/bots/deliveries/:id/render-events/accept`). This is the HTTP-path
+ * equivalent of the realtime {@link PhoenixRealtimeTransport}: each frame is
+ * POSTed and the durable acceptance receipt is awaited before the next. The
+ * gateway-side Connector Outbox then renders the accepted frames to Slack, so
+ * this path reaches full reply-UX parity without a running realtime gateway.
+ *
+ * Per-delivery org/project/bot scope is read from the {@link HttpDeliverySource}
+ * that leased the delivery (populated at claim). The `deliveryId` travels in the
+ * URL only — the accept route rejects a body that also carries it.
+ */
+export class HttpRenderEventSink implements RenderEventSink {
+  private readonly http: IntelligenceHttp;
+
+  constructor(
+    private readonly cfg: IntelligenceTransportConfig,
+    private readonly scopeSource: {
+      scopeFor(deliveryId: string): DeliveryScope | undefined;
+    },
+  ) {
+    this.http = new IntelligenceHttp(cfg);
+  }
+
+  async push(frame: RenderFrame): Promise<RenderAccepted> {
+    const scope = this.scopeSource.scopeFor(frame.deliveryId);
+    if (!scope) {
+      throw new Error(
+        `intelligenceAdapter: no leased scope for delivery ${frame.deliveryId}`,
+      );
+    }
+    const idempotencyKey = `${frame.turnId}:${frame.slot}:${frame.seq}`;
+    const res = await this.http.post<RenderAcceptedResponse>(
+      `/api/bots/deliveries/${encodeURIComponent(frame.deliveryId)}/render-events/accept`,
+      {
+        organizationId: scope.organizationId,
+        projectId: scope.projectId,
+        botId: scope.botId,
+        botName: scope.botName,
+        turnId: frame.turnId,
+        runtimeInstanceId: this.cfg.runtimeInstanceId,
+        slot: frame.slot,
+        seq: frame.seq,
+        idempotencyKey,
+        event: frame.event,
+        sentAt: new Date().toISOString(),
+      },
+    );
+    return {
+      idempotencyKey: res.idempotencyKey ?? idempotencyKey,
+      acceptance: res.acceptance ?? "accepted",
+      ...(res.egressOperationId
+        ? { egressOperationId: res.egressOperationId }
+        : {}),
+    };
   }
 }

--- a/packages/bot-intelligence/src/in-memory-transports.ts
+++ b/packages/bot-intelligence/src/in-memory-transports.ts
@@ -1,8 +1,14 @@
-import type { DeliverySource, EgressSink } from "./transports.js";
+import type {
+  DeliverySource,
+  EgressSink,
+  RenderEventSink,
+} from "./transports.js";
 import type {
   ManagedIngressEnvelope,
   EgressOperation,
   EgressResult,
+  RenderFrame,
+  RenderAccepted,
 } from "./contracts.js";
 
 /**
@@ -15,6 +21,27 @@ export class InMemoryEgressSink implements EgressSink {
   async emit(op: EgressOperation): Promise<EgressResult> {
     this.ops.push(op);
     return { ok: true, ref: op.operationId };
+  }
+}
+
+/**
+ * In-memory {@link RenderEventSink} that records every pushed frame in order and
+ * returns an `accepted` receipt (with a deterministic `egressOperationId` on
+ * `finalize`). Used to assert render-frame ordering / idempotency keys in tests;
+ * the production sink is the Realtime Gateway client.
+ */
+export class InMemoryRenderEventSink implements RenderEventSink {
+  readonly frames: RenderFrame[] = [];
+  async push(frame: RenderFrame): Promise<RenderAccepted> {
+    this.frames.push(frame);
+    const idempotencyKey = `${frame.turnId}:${frame.slot}:${frame.seq}`;
+    return {
+      idempotencyKey,
+      acceptance: "accepted",
+      ...(frame.event.kind === "finalize"
+        ? { egressOperationId: `eop_${frame.turnId}_${frame.seq}` }
+        : {}),
+    };
   }
 }
 

--- a/packages/bot-intelligence/src/in-memory-transports.ts
+++ b/packages/bot-intelligence/src/in-memory-transports.ts
@@ -53,6 +53,8 @@ export class InMemoryRenderEventSink implements RenderEventSink {
 export class InMemoryDeliverySource implements DeliverySource {
   readonly acked: string[] = [];
   readonly nacked: { deliveryId: string; reason: string }[] = [];
+  /** Seed by handle so a turn's file refs hydrate into content parts. */
+  readonly files = new Map<string, { bytes: Uint8Array; mimeType?: string }>();
   private onDelivery?: (env: ManagedIngressEnvelope) => Promise<void>;
 
   async start(
@@ -79,6 +81,13 @@ export class InMemoryDeliverySource implements DeliverySource {
   }
   async nack(deliveryId: string, reason: string): Promise<void> {
     this.nacked.push({ deliveryId, reason });
+  }
+  async fetchFile(
+    handle: string,
+  ): Promise<{ bytes: Uint8Array; mimeType?: string }> {
+    const f = this.files.get(handle);
+    if (!f) throw new Error(`InMemoryDeliverySource: no file for ${handle}`);
+    return f;
   }
   async stop(): Promise<void> {}
 }

--- a/packages/bot-intelligence/src/index.ts
+++ b/packages/bot-intelligence/src/index.ts
@@ -44,6 +44,11 @@ export type {
   HostedBotChannel,
   HostedBotRealtimeScope,
 } from "./phoenix-transport.js";
+export { connectPhoenixHostedBotChannel } from "./phoenix-channel.js";
+export type {
+  PhoenixConnectConfig,
+  ConnectedHostedBotChannel,
+} from "./phoenix-channel.js";
 
 // Undocumented fallbacks: the default HTTP transports + config resolver that
 // `intelligenceAdapter()` builds when no transports are injected. Not a public

--- a/packages/bot-intelligence/src/index.ts
+++ b/packages/bot-intelligence/src/index.ts
@@ -10,7 +10,11 @@ export {
 } from "./intelligence-adapter.js";
 export type { IntelligenceAdapterOptions } from "./intelligence-adapter.js";
 
-export type { DeliverySource, EgressSink } from "./transports.js";
+export type {
+  DeliverySource,
+  EgressSink,
+  RenderEventSink,
+} from "./transports.js";
 
 export type {
   ManagedIngressBase,
@@ -19,12 +23,27 @@ export type {
   EgressOp,
   EgressResult,
   EgressRoute,
+  HostedBotRenderEvent,
+  HostedBotRenderEventKind,
+  RenderFrame,
+  RenderAccepted,
 } from "./contracts.js";
 
 export {
   InMemoryDeliverySource,
   InMemoryEgressSink,
+  InMemoryRenderEventSink,
 } from "./in-memory-transports.js";
+
+// Realtime-gateway (Phoenix) transport — the production render/delivery path
+// (OSS-402). Undocumented like the rest of the package; exported for the
+// managed-listener bootstrap and tests.
+export { PhoenixRealtimeTransport } from "./phoenix-transport.js";
+export type {
+  PhoenixTransportConfig,
+  HostedBotChannel,
+  HostedBotRealtimeScope,
+} from "./phoenix-transport.js";
 
 // Undocumented fallbacks: the default HTTP transports + config resolver that
 // `intelligenceAdapter()` builds when no transports are injected. Not a public

--- a/packages/bot-intelligence/src/intelligence-adapter.test.ts
+++ b/packages/bot-intelligence/src/intelligence-adapter.test.ts
@@ -85,6 +85,74 @@ describe("intelligenceAdapter — ingress dispatch", () => {
   });
 });
 
+describe("intelligenceAdapter — inbound file content parts", () => {
+  it("hydrates turn file refs into contentParts via the source's fetchFile", async () => {
+    const source = new InMemoryDeliverySource();
+    const egress = new InMemoryEgressSink();
+    const png = new Uint8Array([1, 2, 3, 4]);
+    source.files.set("fileref_abc", { bytes: png, mimeType: "image/png" });
+    const bot = createBot({
+      adapters: [intelligenceAdapter({ source, egress })],
+      agent: () => new FakeAgent(),
+    });
+    let seen: IncomingMessage | undefined;
+    bot.onMessage(async ({ message }) => {
+      seen = message;
+    });
+    await bot.start();
+    await source.deliver(
+      envelope({
+        text: "what is this?",
+        files: [
+          {
+            handle: "fileref_abc",
+            filename: "shot.png",
+            mimeType: "image/png",
+          },
+        ],
+      }),
+    );
+
+    expect(seen?.contentParts).toEqual([
+      {
+        type: "image",
+        source: {
+          type: "data",
+          value: Buffer.from(png).toString("base64"),
+          mimeType: "image/png",
+        },
+      },
+    ]);
+  });
+
+  it("skips a file that fails to fetch without failing the turn", async () => {
+    const source = new InMemoryDeliverySource();
+    const egress = new InMemoryEgressSink();
+    // No file seeded → fetchFile throws → part is dropped, turn still dispatches.
+    const bot = createBot({
+      adapters: [intelligenceAdapter({ source, egress })],
+      agent: () => new FakeAgent(),
+    });
+    let seen: IncomingMessage | undefined;
+    bot.onMessage(async ({ message }) => {
+      seen = message;
+    });
+    await bot.start();
+    await source.deliver(
+      envelope({
+        text: "hi",
+        files: [
+          { handle: "missing", filename: "x.png", mimeType: "image/png" },
+        ],
+      }),
+    );
+
+    expect(seen?.text).toBe("hi");
+    expect(seen?.contentParts ?? []).toEqual([]);
+    expect(source.acked).toEqual(["d1"]);
+  });
+});
+
 describe("intelligenceAdapter — deterministic egress ids", () => {
   it("mints turnId:seq op ids and reproduces them on redelivery", async () => {
     const source = new InMemoryDeliverySource();

--- a/packages/bot-intelligence/src/intelligence-adapter.test.ts
+++ b/packages/bot-intelligence/src/intelligence-adapter.test.ts
@@ -133,6 +133,8 @@ describe("intelligenceAdapter — run renderer", () => {
       event: { messageId: "m1", delta: "world" },
     });
     await sub.onTextMessageEndEvent?.({ event: { messageId: "m1" } });
+    // Render frames stream through a serial chain; the turn-end hook drains it.
+    await renderer.finish?.();
 
     expect(egress.ops).toHaveLength(1);
     expect(egress.ops[0]!.op.kind).toBe("post");

--- a/packages/bot-intelligence/src/intelligence-adapter.ts
+++ b/packages/bot-intelligence/src/intelligence-adapter.ts
@@ -1,5 +1,10 @@
 import type { AgentSubscriber } from "@ag-ui/client";
-import type { BotNode, MessageRef, PlatformUser } from "@copilotkit/bot-ui";
+import type {
+  AgentContentPart,
+  BotNode,
+  MessageRef,
+  PlatformUser,
+} from "@copilotkit/bot-ui";
 import type {
   StateStore,
   PlatformAdapter,
@@ -21,6 +26,7 @@ import type {
 } from "./transports.js";
 import type {
   ManagedIngressEnvelope,
+  ManagedFileRef,
   EgressOp,
   EgressOperation,
   HostedBotRenderEvent,
@@ -54,6 +60,17 @@ function targetFromRef(ref: MessageRef): ManagedReplyTarget {
 const textNode = (value: string): BotNode[] => [
   { type: "text", props: { value } },
 ];
+
+/** Map a MIME type to its `AgentContentPart` media kind, or null for non-media. */
+function mediaKindForMime(
+  mime: string,
+): "image" | "audio" | "video" | "document" | null {
+  if (mime.startsWith("image/")) return "image";
+  if (mime.startsWith("audio/")) return "audio";
+  if (mime.startsWith("video/")) return "video";
+  if (mime === "application/pdf") return "document";
+  return null;
+}
 
 const INTERRUPTED_SUFFIX = "\n_(interrupted)_";
 
@@ -207,6 +224,50 @@ export class IntelligenceAdapter implements PlatformAdapter {
     }
   }
 
+  /**
+   * Hydrate turn-input file refs into `AgentContentPart`s: fetch each file's
+   * bytes via the delivery source and base64-encode them. Best-effort per
+   * file — a fetch failure is logged and skipped, never fails the turn. Media
+   * (image/audio/video/pdf) becomes a `data` part; `text/*` is decoded inline;
+   * anything else degrades to a short text note so the model still sees it.
+   */
+  private async buildContentParts(
+    files?: ManagedFileRef[],
+  ): Promise<AgentContentPart[]> {
+    const fetchFile = this.source?.fetchFile?.bind(this.source);
+    if (!files?.length || !fetchFile) return [];
+    const parts: AgentContentPart[] = [];
+    for (const ref of files) {
+      try {
+        const { bytes, mimeType } = await fetchFile(ref.handle);
+        // The typed ref's mime is authoritative — the file-serve route coerces
+        // its Content-Type to a safe allowlist, so the header can be lossy.
+        const mime = ref.mimeType ?? mimeType ?? "application/octet-stream";
+        const kind = mediaKindForMime(mime);
+        if (kind) {
+          const value = Buffer.from(bytes).toString("base64");
+          parts.push({
+            type: kind,
+            source: { type: "data", value, mimeType: mime },
+          });
+        } else if (mime.startsWith("text/")) {
+          parts.push({
+            type: "text",
+            text: Buffer.from(bytes).toString("utf8"),
+          });
+        } else {
+          parts.push({
+            type: "text",
+            text: `[attached file: ${ref.filename} (${mime})]`,
+          });
+        }
+      } catch (err) {
+        this.opts.config?.log?.("intelligence inbound file fetch failed", err);
+      }
+    }
+    return parts;
+  }
+
   private async dispatchTo(env: ManagedIngressEnvelope): Promise<void> {
     const sink = this.sink;
     if (!sink) throw new Error("IntelligenceAdapter: not started");
@@ -218,11 +279,13 @@ export class IntelligenceAdapter implements PlatformAdapter {
     const user = env.user ? { id: env.user.id } : undefined;
 
     switch (env.kind) {
-      case "turn":
+      case "turn": {
+        const contentParts = await this.buildContentParts(env.files);
         await sink.onTurn({
           conversationKey: env.conversationKey,
           replyTarget,
           userText: env.text ?? "",
+          ...(contentParts.length ? { contentParts } : {}),
           user,
           eventId: env.eventId,
           turnId: env.turnId,
@@ -230,6 +293,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
           platform: env.platform,
         });
         return;
+      }
       case "command":
         await sink.onCommand({
           command: env.command,
@@ -373,6 +437,43 @@ export class IntelligenceAdapter implements PlatformAdapter {
       return;
     }
     await this.emit(targetFromRef(ref), { kind: "update", ref: ref.id, ir });
+  }
+
+  async postFile(
+    target: ReplyTarget,
+    args: {
+      bytes: Uint8Array;
+      filename: string;
+      title?: string;
+      altText?: string;
+    },
+  ): Promise<{ ok: boolean; fileId?: string; error?: string }> {
+    const mt = target as ManagedReplyTarget;
+    const uploadFile = this.source?.uploadFile?.bind(this.source);
+    if (!uploadFile || !this.renderSink) {
+      return {
+        ok: false,
+        error: "managed adapter: outbound file upload is not available",
+      };
+    }
+    try {
+      // Stream bytes to app-api first (durable in S3), then emit a `file` frame
+      // referencing the handle; the Connector Outbox does the Slack uploadV2.
+      const { handle } = await uploadFile(mt.deliveryId, args);
+      await this.postRenderFrame(mt, {
+        kind: "file",
+        handle,
+        filename: args.filename,
+        ...(args.title ? { title: args.title } : {}),
+        ...(args.altText ? { altText: args.altText } : {}),
+      });
+      return { ok: true };
+    } catch (err) {
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
   }
 
   async stream(

--- a/packages/bot-intelligence/src/intelligence-adapter.ts
+++ b/packages/bot-intelligence/src/intelligence-adapter.ts
@@ -14,11 +14,18 @@ import type {
   UserQuery,
   InteractionEvent,
 } from "@copilotkit/bot";
-import type { DeliverySource, EgressSink } from "./transports.js";
+import type {
+  DeliverySource,
+  EgressSink,
+  RenderEventSink,
+} from "./transports.js";
 import type {
   ManagedIngressEnvelope,
   EgressOp,
   EgressOperation,
+  HostedBotRenderEvent,
+  RenderFrame,
+  RenderAccepted,
 } from "./contracts.js";
 import {
   HttpDeliverySource,
@@ -60,6 +67,14 @@ export interface IntelligenceAdapterOptions {
    * (built at `start()` from env/`config`); inject in-memory for tests.
    */
   egress?: EgressSink;
+  /**
+   * Streaming render transport (OSS-402). When set, the run renderer streams
+   * semantic render frames to it and awaits durable acceptance receipts (the
+   * realtime-gateway path). When omitted, the renderer falls back to
+   * translating frames into `post` operations on {@link egress} so plain-text
+   * replies still flow without a Connector Outbox.
+   */
+  renderSink?: RenderEventSink;
   /** Optional Intelligence-backed persistence the adapter exposes as `stateStore`. */
   store?: StateStore;
   /**
@@ -115,6 +130,9 @@ export class IntelligenceAdapter implements PlatformAdapter {
   private source?: DeliverySource;
   /** Outbound transport — injected via opts, or the default HTTP sink built at `start()`. */
   private egress?: EgressSink;
+  /** Streaming render transport — injected via opts (realtime path). When unset,
+   * the run renderer translates frames to `post` ops on {@link egress}. */
+  private renderSink?: RenderEventSink;
   /** Per-turn egress sequence; reset at the start of each turn's processing so
    * a redelivered turn reproduces the same operation id sequence. */
   private readonly seq = new Map<string, number>();
@@ -122,6 +140,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
   constructor(private readonly opts: IntelligenceAdapterOptions = {}) {
     this.source = opts.source;
     this.egress = opts.egress;
+    this.renderSink = opts.renderSink;
     this.stateStore = opts.store;
   }
 
@@ -317,16 +336,114 @@ export class IntelligenceAdapter implements PlatformAdapter {
     return undefined;
   }
 
+  /**
+   * The render transport the run renderer streams frames to. Uses the injected
+   * realtime {@link RenderEventSink} when present; otherwise translates frames
+   * back to `post` operations on the {@link EgressSink} so plain-text replies
+   * still flow on the HTTP-fallback path (no Connector Outbox required). The
+   * fallback accumulates text per message and posts on `text_end`, and flushes
+   * any un-ended text on `finalize` (the interrupt path) with the interrupted
+   * marker.
+   */
+  private renderSinkFor(t: ManagedReplyTarget): RenderEventSink {
+    if (this.renderSink) return this.renderSink;
+    const emit = (op: EgressOp) => this.emit(t, op);
+    const acc = new Map<string, string>();
+    const order: string[] = [];
+    let interrupted = false;
+    return {
+      push: async (frame: RenderFrame): Promise<RenderAccepted> => {
+        const e = frame.event;
+        if (e.kind === "text_delta") {
+          if (!acc.has(e.messageId)) order.push(e.messageId);
+          acc.set(e.messageId, (acc.get(e.messageId) ?? "") + e.delta);
+        } else if (e.kind === "text_end") {
+          const txt = acc.get(e.messageId) ?? "";
+          acc.delete(e.messageId);
+          const i = order.indexOf(e.messageId);
+          if (i >= 0) order.splice(i, 1);
+          if (txt.length > 0) await emit({ kind: "post", ir: textNode(txt) });
+        } else if (e.kind === "interrupt") {
+          interrupted = true;
+        } else if (e.kind === "post") {
+          await emit({ kind: "post", ir: e.content });
+        } else if (e.kind === "update") {
+          await emit({ kind: "update", ref: e.ref, ir: e.content });
+        } else if (e.kind === "finalize") {
+          // Flush any message that never received a text_end (interrupt path).
+          for (const id of order) {
+            const txt = acc.get(id) ?? "";
+            if (txt.length > 0) {
+              await emit({
+                kind: "post",
+                ir: textNode(interrupted ? txt + INTERRUPTED_SUFFIX : txt),
+              });
+            }
+          }
+          acc.clear();
+          order.length = 0;
+        }
+        // run_started / tool_start / tool_end / run_error: no provider-visible
+        // effect in the plain-text fallback (the Outbox renders those live).
+        return {
+          idempotencyKey: `${frame.turnId}:${frame.slot}:${frame.seq}`,
+          acceptance: "accepted",
+        };
+      },
+    };
+  }
+
   createRunRenderer(target: ReplyTarget): RunRenderer {
     const t = target as ManagedReplyTarget;
+    const sink = this.renderSinkFor(t);
     const interruptEventNames = new Set<string>(["on_interrupt"]);
-    const buffers = new Map<string, string>();
     const capturedToolCalls: CapturedToolCall[] = [];
     let pendingInterrupt: CapturedInterrupt | undefined;
     let aborted = false;
+    let runStarted = false;
+    let seq = 0;
 
-    const emitText = (text: string): Promise<MessageRef> =>
-      this.emit(t, { kind: "post", ir: textNode(text) });
+    // ponytail: serial promise chain — AG-UI does not guarantee it awaits
+    // subscriber callbacks in order, so `seq` is assigned synchronously at
+    // enqueue time (preserving event order) and frames are pushed one at a
+    // time, awaiting each durable-acceptance receipt before the next. `finish`/
+    // `markInterrupted` await the drained chain. A rejected push is recorded
+    // and surfaced at drain (so it nacks the delivery) without wedging the
+    // chain. Upgrade path: batch text_delta frames if per-token RTT matters.
+    let chain: Promise<void> = Promise.resolve();
+    let pushError: unknown;
+
+    const enqueue = (event: HostedBotRenderEvent): void => {
+      const frame: RenderFrame = {
+        deliveryId: t.deliveryId,
+        turnId: t.turnId,
+        slot: "main",
+        seq: seq++,
+        event,
+      };
+      chain = chain.then(async () => {
+        if (pushError !== undefined) return;
+        try {
+          await sink.push(frame);
+        } catch (err) {
+          pushError = err;
+        }
+      });
+    };
+
+    const drain = async (): Promise<void> => {
+      await chain;
+      if (pushError !== undefined) {
+        const err = pushError;
+        throw err instanceof Error ? err : new Error(String(err));
+      }
+    };
+
+    const ensureRunStarted = (): void => {
+      if (runStarted) return;
+      runStarted = true;
+      enqueue({ kind: "run_started" });
+    };
 
     const captureToolCall = (
       toolCallId: string,
@@ -345,22 +462,27 @@ export class IntelligenceAdapter implements PlatformAdapter {
     };
 
     const subscriber: AgentSubscriber = {
-      onTextMessageStartEvent({ event }) {
-        if (aborted) return;
-        buffers.set(event.messageId, "");
-      },
       onTextMessageContentEvent({ event }) {
         if (aborted) return;
-        buffers.set(
-          event.messageId,
-          (buffers.get(event.messageId) ?? "") + (event.delta ?? ""),
-        );
+        ensureRunStarted();
+        enqueue({
+          kind: "text_delta",
+          messageId: event.messageId,
+          delta: event.delta ?? "",
+        });
       },
-      async onTextMessageEndEvent({ event }) {
+      onTextMessageEndEvent({ event }) {
         if (aborted) return;
-        const text = buffers.get(event.messageId) ?? "";
-        buffers.delete(event.messageId);
-        if (text.length > 0) await emitText(text);
+        enqueue({ kind: "text_end", messageId: event.messageId });
+      },
+      onToolCallStartEvent({ event }) {
+        if (aborted) return;
+        ensureRunStarted();
+        enqueue({
+          kind: "tool_start",
+          toolCallId: event.toolCallId,
+          toolName: event.toolCallName,
+        });
       },
       onToolCallArgsEvent({ event, toolCallName, partialToolCallArgs }) {
         if (aborted) return;
@@ -377,6 +499,18 @@ export class IntelligenceAdapter implements PlatformAdapter {
           toolCallName,
           (toolCallArgs ?? {}) as Record<string, unknown>,
         );
+        enqueue({
+          kind: "tool_end",
+          toolCallId: event.toolCallId,
+          toolName: toolCallName,
+        });
+      },
+      onRunErrorEvent({ event }) {
+        if (aborted) return;
+        enqueue({
+          kind: "run_error",
+          message: event.message ?? "unknown error",
+        });
       },
       onCustomEvent({ event }) {
         if (aborted) return;
@@ -401,16 +535,17 @@ export class IntelligenceAdapter implements PlatformAdapter {
       clearPendingInterrupt: () => {
         pendingInterrupt = undefined;
       },
+      async finish() {
+        if (aborted) return;
+        enqueue({ kind: "finalize" });
+        await drain();
+      },
       async markInterrupted() {
         if (aborted) return;
         aborted = true;
-        // Flush any partial text with an interrupted marker.
-        const tasks: Promise<MessageRef>[] = [];
-        for (const [id, buf] of Array.from(buffers.entries())) {
-          if (buf.length > 0) tasks.push(emitText(buf + INTERRUPTED_SUFFIX));
-          buffers.delete(id);
-        }
-        await Promise.all(tasks);
+        enqueue({ kind: "interrupt" });
+        enqueue({ kind: "finalize" });
+        await drain();
       },
     };
   }

--- a/packages/bot-intelligence/src/intelligence-adapter.ts
+++ b/packages/bot-intelligence/src/intelligence-adapter.ts
@@ -30,6 +30,7 @@ import type {
 import {
   HttpDeliverySource,
   HttpEgressSink,
+  HttpRenderEventSink,
   resolveTransportConfig,
 } from "./http-transports.js";
 import type { IntelligenceTransportConfig } from "./http-transports.js";
@@ -165,8 +166,15 @@ export class IntelligenceAdapter implements PlatformAdapter {
         ...this.opts.config,
         botName: this.opts.config?.botName ?? ctx?.botName,
       });
-      this.source ??= new HttpDeliverySource(cfg);
+      const source = (this.source ??= new HttpDeliverySource(cfg));
       this.egress ??= new HttpEgressSink(cfg);
+      // Default the realtime render path to the HTTP render-accept route,
+      // sharing the HttpDeliverySource's per-delivery scope. Only when we built
+      // (or were given) an HttpDeliverySource — injected in-memory sources fall
+      // back to the egress-backed render sink in createRunRenderer.
+      if (!this.renderSink && source instanceof HttpDeliverySource) {
+        this.renderSink = new HttpRenderEventSink(cfg, source);
+      }
     }
     await this.requireSource().start((env) => this.dispatch(env));
   }

--- a/packages/bot-intelligence/src/intelligence-adapter.ts
+++ b/packages/bot-intelligence/src/intelligence-adapter.ts
@@ -533,10 +533,15 @@ export class IntelligenceAdapter implements PlatformAdapter {
       onTextMessageContentEvent({ event }) {
         if (aborted) return;
         ensureRunStarted();
+        // Skip empty deltas (e.g. the leading role-announcement chunk): they
+        // carry no content and violate the render contract's min-1 text
+        // constraint, which would reject the frame and abort the whole run.
+        const delta = event.delta ?? "";
+        if (delta.length === 0) return;
         enqueue({
           kind: "text_delta",
           messageId: event.messageId,
-          delta: event.delta ?? "",
+          delta,
         });
       },
       onTextMessageEndEvent({ event }) {

--- a/packages/bot-intelligence/src/intelligence-adapter.ts
+++ b/packages/bot-intelligence/src/intelligence-adapter.ts
@@ -157,6 +157,12 @@ export class IntelligenceAdapter implements PlatformAdapter {
     return this.egress;
   }
 
+  private requireRenderSink(): RenderEventSink {
+    if (!this.renderSink)
+      throw new Error("IntelligenceAdapter: render sink not started");
+    return this.renderSink;
+  }
+
   async start(sink: IngressSink, ctx?: { botName?: string }): Promise<void> {
     this.sink = sink;
     // Config-free default: build the HTTP transports from env (+ the bot's
@@ -276,15 +282,49 @@ export class IntelligenceAdapter implements PlatformAdapter {
     }
   }
 
+  /** Allocate the next monotonic frame/op seq for a turn. Shared by the run
+   * renderer and discrete post/update so all of a turn's render frames land on
+   * one ordered `(turnId, "main")` lane. Reset per delivery in {@link dispatch}. */
+  private nextFrameSeq(turnId: string): number {
+    const seq = this.seq.get(turnId) ?? 0;
+    this.seq.set(turnId, seq + 1);
+    return seq;
+  }
+
   private mintOp(target: ManagedReplyTarget, op: EgressOp): EgressOperation {
-    const seq = this.seq.get(target.turnId) ?? 0;
-    this.seq.set(target.turnId, seq + 1);
+    const seq = this.nextFrameSeq(target.turnId);
     return {
       operationId: `${target.turnId}:${seq}`,
       turnId: target.turnId,
       deliveryId: target.deliveryId,
       route: target.route,
       op,
+    };
+  }
+
+  /**
+   * Push a discrete render frame (post/update) through the realtime render sink
+   * so the Connector Outbox renders it as Block Kit — preserving rich JSX/IR
+   * instead of flattening to text. Returns a {@link MessageRef} keyed to the
+   * frame so a later update/delete can re-address it.
+   */
+  private async postRenderFrame(
+    target: ManagedReplyTarget,
+    event: HostedBotRenderEvent,
+  ): Promise<MessageRef> {
+    const seq = this.nextFrameSeq(target.turnId);
+    const receipt = await this.requireRenderSink().push({
+      deliveryId: target.deliveryId,
+      turnId: target.turnId,
+      slot: "main",
+      seq,
+      event,
+    });
+    return {
+      id: receipt.egressOperationId ?? `${target.turnId}:main:${seq}`,
+      __route: target.route,
+      __turnId: target.turnId,
+      __deliveryId: target.deliveryId,
     };
   }
 
@@ -311,10 +351,27 @@ export class IntelligenceAdapter implements PlatformAdapter {
   }
 
   async post(target: ReplyTarget, ir: BotNode[]): Promise<MessageRef> {
+    // Realtime path: stream a `post` render frame carrying the IR so the
+    // Connector Outbox renders full Block Kit (rich JSX preserved). Fallback
+    // (no render sink wired — e.g. in-memory tests): the egress op path.
+    if (this.renderSink) {
+      return this.postRenderFrame(target as ManagedReplyTarget, {
+        kind: "post",
+        content: ir,
+      });
+    }
     return this.emit(target as ManagedReplyTarget, { kind: "post", ir });
   }
 
   async update(ref: MessageRef, ir: BotNode[]): Promise<void> {
+    if (this.renderSink) {
+      await this.postRenderFrame(targetFromRef(ref), {
+        kind: "update",
+        ref: ref.id,
+        content: ir,
+      });
+      return;
+    }
     await this.emit(targetFromRef(ref), { kind: "update", ref: ref.id, ir });
   }
 
@@ -322,13 +379,17 @@ export class IntelligenceAdapter implements PlatformAdapter {
     _target: ReplyTarget,
     chunks: AsyncIterable<string>,
   ): Promise<MessageRef> {
-    // Non-streaming surface: accumulate the full reply and emit one post op.
+    // Non-streaming surface: accumulate the full reply and emit one post.
     let acc = "";
     for await (const c of chunks) acc += c;
-    return this.emit(_target as ManagedReplyTarget, {
-      kind: "post",
-      ir: textNode(acc),
-    });
+    const target = _target as ManagedReplyTarget;
+    if (this.renderSink) {
+      return this.postRenderFrame(target, {
+        kind: "post",
+        content: textNode(acc),
+      });
+    }
+    return this.emit(target, { kind: "post", ir: textNode(acc) });
   }
 
   async delete(ref: MessageRef): Promise<void> {
@@ -409,7 +470,6 @@ export class IntelligenceAdapter implements PlatformAdapter {
     let pendingInterrupt: CapturedInterrupt | undefined;
     let aborted = false;
     let runStarted = false;
-    let seq = 0;
 
     // ponytail: serial promise chain — AG-UI does not guarantee it awaits
     // subscriber callbacks in order, so `seq` is assigned synchronously at
@@ -426,7 +486,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
         deliveryId: t.deliveryId,
         turnId: t.turnId,
         slot: "main",
-        seq: seq++,
+        seq: this.nextFrameSeq(t.turnId),
         event,
       };
       chain = chain.then(async () => {

--- a/packages/bot-intelligence/src/phoenix-channel.ts
+++ b/packages/bot-intelligence/src/phoenix-channel.ts
@@ -1,0 +1,119 @@
+import { Socket } from "phoenix";
+import type { HostedBotChannel } from "./phoenix-transport.js";
+
+/**
+ * @internal Config for {@link connectPhoenixHostedBotChannel} — the live
+ * realtime-gateway connection behind {@link PhoenixRealtimeTransport}.
+ */
+export interface PhoenixConnectConfig {
+  /** Gateway socket URL, e.g. `wss://gateway.example/socket`. */
+  wsUrl: string;
+  /** Runtime API key (`cpk-…`) authenticating the socket. */
+  apiKey: string;
+  /** Numeric project id — the channel topic is `hosted_bots:project:{id}`. */
+  projectId: number;
+  /** Listener declaration sent as the channel join payload. */
+  join: {
+    runtimeInstanceId: string;
+    declaredBots: ReadonlyArray<{
+      botName: string;
+      adapter: string;
+      renderCapabilities?: readonly string[];
+    }>;
+    runtimeMetadata?: Record<string, unknown>;
+    observedAt: string;
+  };
+  /** Per-push / join timeout in ms (default 10000). */
+  timeoutMs?: number;
+  /** WebSocket constructor; defaults to the global (Node 22+/browser). */
+  webSocket?: unknown;
+}
+
+/** A connected {@link HostedBotChannel} plus a `disconnect()` for shutdown. */
+export interface ConnectedHostedBotChannel extends HostedBotChannel {
+  disconnect(): void;
+}
+
+/**
+ * @internal Connect the SDK to the realtime-gateway hosted-bot IO channel and
+ * adapt the Phoenix `Channel` to the minimal {@link HostedBotChannel} contract
+ * {@link PhoenixRealtimeTransport} consumes: `push` resolves with the server's
+ * "ok" reply (rejects on "error"/"timeout"); `on` subscribes to a pushed event.
+ *
+ * The channel is joined (declaring the runtime's bots) before the promise
+ * resolves, so the caller can immediately stream render frames.
+ *
+ * @param config - Gateway URL, auth, project scope, and join declaration.
+ * @returns The connected channel with a `disconnect()` teardown.
+ */
+export async function connectPhoenixHostedBotChannel(
+  config: PhoenixConnectConfig,
+): Promise<ConnectedHostedBotChannel> {
+  const timeout = config.timeoutMs ?? 10_000;
+  const transport =
+    config.webSocket ??
+    (globalThis as unknown as { WebSocket?: unknown }).WebSocket;
+  if (!transport) {
+    throw new Error(
+      "connectPhoenixHostedBotChannel: no WebSocket available — pass config.webSocket or run on Node 22+",
+    );
+  }
+
+  const socket = new Socket(config.wsUrl, {
+    params: { token: config.apiKey },
+    transport: transport as ConstructorParameters<typeof Socket>[1] extends {
+      transport?: infer T;
+    }
+      ? T
+      : never,
+  });
+  socket.connect();
+
+  const channel = socket.channel(
+    `hosted_bots:project:${config.projectId}`,
+    config.join as object,
+  );
+
+  await new Promise<void>((resolve, reject) => {
+    channel
+      .join(timeout)
+      .receive("ok", () => resolve())
+      .receive("error", (reason: unknown) =>
+        reject(
+          new Error(`hosted-bot channel join failed: ${safeReason(reason)}`),
+        ),
+      )
+      .receive("timeout", () =>
+        reject(new Error("hosted-bot channel join timed out")),
+      );
+  });
+
+  return {
+    push: (event, payload) =>
+      new Promise((resolve, reject) => {
+        channel
+          .push(event, payload as object, timeout)
+          .receive("ok", (reply: unknown) => resolve(reply))
+          .receive("error", (reason: unknown) =>
+            reject(new Error(`push ${event} failed: ${safeReason(reason)}`)),
+          )
+          .receive("timeout", () =>
+            reject(new Error(`push ${event} timed out`)),
+          );
+      }),
+    on: (event, handler) => {
+      channel.on(event, handler);
+    },
+    disconnect: () => socket.disconnect(),
+  };
+}
+
+/** Render an unknown channel reply reason as a short string for errors. */
+function safeReason(reason: unknown): string {
+  if (typeof reason === "string") return reason;
+  try {
+    return JSON.stringify(reason);
+  } catch {
+    return "unknown";
+  }
+}

--- a/packages/bot-intelligence/src/phoenix-transport.ts
+++ b/packages/bot-intelligence/src/phoenix-transport.ts
@@ -1,0 +1,278 @@
+// Realtime-gateway (Phoenix) transport for the managed-bot SDK (OSS-402).
+//
+// This is the production render/delivery path: the SDK joins the gateway's
+// per-project bot-IO channel, receives leased deliveries, streams semantic
+// `hosted_bot.render_event.v1` frames, waits for durable
+// `hosted_bot.render_accepted.v1` receipts, and — only after frames are
+// accepted — sends a `hosted_bot.delivery.complete_requested.v1` COMPLETION
+// INTENT (never a committed `hosted_bot.delivery.ack.v1`; app-api owns ack).
+// On failure it sends `hosted_bot.delivery.fail.v1`. The SDK never receives
+// Slack/provider credentials — rendering to the provider happens on the
+// gateway-side Connector Outbox.
+//
+// The Phoenix `Socket`/`Channel` boilerplate is intentionally NOT imported
+// here: the protocol (the risky part) is expressed against a minimal injected
+// {@link HostedBotChannel}, so it is fully unit-testable with a fake channel.
+// A deployment adapts its live Phoenix channel to this interface in a few
+// lines (`push` wraps `channel.push(...).receive("ok"/"error")`; `on` wraps
+// `channel.on(...)`).
+//
+// Scope (out of this checkpoint): discrete `EgressSink` posts from
+// command/interaction handlers are not yet streamed as `post`/`update` render
+// frames here — that needs a per-`(turn, slot)` seq shared with the run
+// renderer and is a follow-up. This transport covers the agent-run render
+// stream + delivery lifecycle.
+
+import type { DeliverySource, RenderEventSink } from "./transports.js";
+import type {
+  ManagedIngressEnvelope,
+  RenderFrame,
+  RenderAccepted,
+} from "./contracts.js";
+
+/** The org/project/bot scope every realtime envelope carries. */
+export interface HostedBotRealtimeScope {
+  organizationId: string;
+  projectId: number;
+  botId: string;
+  botName: string;
+}
+
+/**
+ * Minimal Phoenix channel surface this transport needs. A deployment adapts a
+ * live `phoenix` `Channel` to this: `push` resolves with the server's "ok"
+ * reply payload (and rejects on "error"/"timeout"); `on` subscribes to a
+ * server-pushed event.
+ */
+export interface HostedBotChannel {
+  push(event: string, payload: unknown): Promise<unknown>;
+  on(event: string, handler: (payload: unknown) => void): void;
+}
+
+export interface PhoenixTransportConfig {
+  scope: HostedBotRealtimeScope;
+  /** Unique per runtime instance (rti_…), echoed on every SDK->gateway event. */
+  runtimeInstanceId: string;
+  /** The joined bot-IO channel (topic `hosted_bots:project:{projectId}`). */
+  channel: HostedBotChannel;
+  /** ISO timestamp source; injectable for deterministic tests. */
+  now?: () => string;
+}
+
+const RENDER_EVENT = "hosted_bot.render_event.v1";
+const RENDER_ACCEPTED = "hosted_bot.render_accepted.v1";
+const DELIVERY_AVAILABLE = "hosted_bot.delivery.available.v1";
+const COMPLETE_REQUESTED = "hosted_bot.delivery.complete_requested.v1";
+const DELIVERY_FAIL = "hosted_bot.delivery.fail.v1";
+
+/** Per-delivery state the transport needs to build completion/fail intents. */
+interface DeliveryState {
+  turnId: string;
+  /** Highest accepted `seq` per render slot (the completion high-water mark). */
+  accepted: Map<string, number>;
+}
+
+/**
+ * Realtime-gateway transport implementing both the inbound {@link DeliverySource}
+ * and the streaming {@link RenderEventSink}. `ack` maps to the completion
+ * INTENT (`complete_requested`) and `nack` to `fail` — the SDK is never the
+ * committed-ack authority.
+ */
+export class PhoenixRealtimeTransport
+  implements DeliverySource, RenderEventSink
+{
+  private readonly scope: HostedBotRealtimeScope;
+  private readonly runtimeInstanceId: string;
+  private readonly channel: HostedBotChannel;
+  private readonly now: () => string;
+  private readonly deliveries = new Map<string, DeliveryState>();
+  private onDelivery?: (env: ManagedIngressEnvelope) => Promise<void>;
+
+  constructor(config: PhoenixTransportConfig) {
+    this.scope = config.scope;
+    this.runtimeInstanceId = config.runtimeInstanceId;
+    this.channel = config.channel;
+    this.now = config.now ?? (() => new Date().toISOString());
+  }
+
+  async start(
+    onDelivery: (env: ManagedIngressEnvelope) => Promise<void>,
+  ): Promise<void> {
+    this.onDelivery = onDelivery;
+    this.channel.on(DELIVERY_AVAILABLE, (payload) => {
+      void this.handleDeliveryAvailable(payload);
+    });
+  }
+
+  private async handleDeliveryAvailable(payload: unknown): Promise<void> {
+    const env = this.toIngressEnvelope(payload);
+    if (!env) return;
+    this.deliveries.set(env.deliveryId, {
+      turnId: env.turnId,
+      accepted: new Map(),
+    });
+    await this.onDelivery?.(env);
+  }
+
+  /**
+   * Map a `delivery.available.v1`'s claimed delivery to the adapter's ingress
+   * envelope. Only the text-turn shape is handled in V1; other input kinds are
+   * ignored (dropped) until they are modeled.
+   */
+  private toIngressEnvelope(
+    payload: unknown,
+  ): ManagedIngressEnvelope | undefined {
+    const p = payload as
+      | { payload?: { delivery?: Record<string, unknown> } }
+      | { delivery?: Record<string, unknown> }
+      | undefined;
+    const delivery =
+      (p as { payload?: { delivery?: Record<string, unknown> } })?.payload
+        ?.delivery ?? (p as { delivery?: Record<string, unknown> })?.delivery;
+    if (!delivery) return undefined;
+    const turn = delivery.turn as
+      | {
+          id?: string;
+          eventId?: string;
+          replyTarget?: unknown;
+          input?: { kind?: string; text?: string };
+        }
+      | undefined;
+    if (!turn?.id || !turn.eventId) return undefined;
+    const bot = delivery.bot as { name?: string } | undefined;
+    return {
+      kind: "turn",
+      deliveryId: String(delivery.id),
+      eventId: String(turn.eventId),
+      turnId: String(turn.id),
+      botName: String(bot?.name ?? this.scope.botName),
+      platform: String(delivery.adapter ?? "slack"),
+      conversationKey: String(turn.id),
+      route: turn.replyTarget,
+      text: turn.input?.text ?? "",
+    };
+  }
+
+  async push(frame: RenderFrame): Promise<RenderAccepted> {
+    const idempotencyKey = `${frame.turnId}:${frame.slot}:${frame.seq}`;
+    const envelope = {
+      type: RENDER_EVENT,
+      occurredAt: this.now(),
+      payload: {
+        ...this.scope,
+        deliveryId: frame.deliveryId,
+        turnId: frame.turnId,
+        runtimeInstanceId: this.runtimeInstanceId,
+        slot: frame.slot,
+        seq: frame.seq,
+        idempotencyKey,
+        event: frame.event,
+        sentAt: this.now(),
+      },
+    };
+    const reply = await this.channel.push(RENDER_EVENT, envelope);
+    const receipt = this.parseAccepted(reply, idempotencyKey);
+    // Record the completion high-water mark for this delivery/slot.
+    const state = this.deliveries.get(frame.deliveryId);
+    if (state) {
+      const prev = state.accepted.get(frame.slot);
+      if (prev === undefined || frame.seq > prev) {
+        state.accepted.set(frame.slot, frame.seq);
+      }
+    }
+    return receipt;
+  }
+
+  private parseAccepted(
+    reply: unknown,
+    idempotencyKey: string,
+  ): RenderAccepted {
+    const r = reply as
+      | {
+          type?: string;
+          payload?: {
+            acceptance?: RenderAccepted["acceptance"];
+            egressOperationId?: string;
+            idempotencyKey?: string;
+          };
+        }
+      | undefined;
+    const payload = r?.payload;
+    if (r?.type !== RENDER_ACCEPTED || !payload?.acceptance) {
+      throw new Error(
+        `PhoenixRealtimeTransport: expected ${RENDER_ACCEPTED} for ${idempotencyKey}, got ${r?.type ?? "no reply"}`,
+      );
+    }
+    return {
+      idempotencyKey: payload.idempotencyKey ?? idempotencyKey,
+      acceptance: payload.acceptance,
+      ...(payload.egressOperationId
+        ? { egressOperationId: payload.egressOperationId }
+        : {}),
+    };
+  }
+
+  /**
+   * Send the SDK completion INTENT (`complete_requested`) — never a committed
+   * delivery ack. `acceptedThrough` carries the completion high-water pointer
+   * per slot (the frozen contract requires at least one).
+   */
+  async ack(deliveryId: string): Promise<void> {
+    const state = this.deliveries.get(deliveryId);
+    if (!state) return;
+    const acceptedThrough = Array.from(state.accepted.entries()).map(
+      ([slot, seq]) => ({ turnId: state.turnId, slot, seq }),
+    );
+    if (acceptedThrough.length === 0) {
+      // Nothing was accepted (e.g. an empty turn). Without an accepted frame
+      // there is nothing to complete; let the lease lapse / redeliver instead
+      // of sending an invalid (empty acceptedThrough) intent.
+      this.deliveries.delete(deliveryId);
+      return;
+    }
+    await this.channel.push(COMPLETE_REQUESTED, {
+      type: COMPLETE_REQUESTED,
+      occurredAt: this.now(),
+      payload: {
+        ...this.scope,
+        deliveryId,
+        turnId: state.turnId,
+        runtimeInstanceId: this.runtimeInstanceId,
+        acceptedThrough,
+        requestedAt: this.now(),
+      },
+    });
+    this.deliveries.delete(deliveryId);
+  }
+
+  async nack(deliveryId: string, reason: string): Promise<void> {
+    const state = this.deliveries.get(deliveryId);
+    const accepted = state
+      ? Array.from(state.accepted.entries()).map(([slot, seq]) => ({
+          turnId: state.turnId,
+          slot,
+          seq,
+        }))
+      : [];
+    const lastAccepted = accepted[accepted.length - 1];
+    await this.channel.push(DELIVERY_FAIL, {
+      type: DELIVERY_FAIL,
+      occurredAt: this.now(),
+      payload: {
+        ...this.scope,
+        deliveryId,
+        turnId: state?.turnId ?? deliveryId,
+        runtimeInstanceId: this.runtimeInstanceId,
+        deliveryStatus: "retry_wait",
+        ...(lastAccepted ? { lastAccepted } : {}),
+        failedAt: this.now(),
+        error: { code: "runtime_error", message: reason, retryable: true },
+      },
+    });
+    this.deliveries.delete(deliveryId);
+  }
+
+  async stop(): Promise<void> {
+    this.deliveries.clear();
+  }
+}

--- a/packages/bot-intelligence/src/render-events.test.ts
+++ b/packages/bot-intelligence/src/render-events.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect } from "vitest";
+import type { ReplyTarget } from "@copilotkit/bot";
+import { intelligenceAdapter } from "./intelligence-adapter.js";
+import {
+  InMemoryDeliverySource,
+  InMemoryEgressSink,
+  InMemoryRenderEventSink,
+} from "./in-memory-transports.js";
+import { PhoenixRealtimeTransport } from "./phoenix-transport.js";
+import type { HostedBotChannel } from "./phoenix-transport.js";
+
+const target = {
+  route: { channel: "C1", threadTs: "100.0" },
+  turnId: "turn_t1",
+  deliveryId: "dlv_d1",
+} as unknown as ReplyTarget;
+
+/** Drive a subscriber handler that may be sync or async. */
+type Sub = Record<string, (p: { event: Record<string, unknown> }) => unknown>;
+
+describe("run renderer — render-event streaming (OSS-402)", () => {
+  it("mints ordered render frames with monotonic seq per (turn, slot) and a finalize", async () => {
+    const renderSink = new InMemoryRenderEventSink();
+    const adapter = intelligenceAdapter({
+      source: new InMemoryDeliverySource(),
+      egress: new InMemoryEgressSink(),
+      renderSink,
+    });
+    const renderer = adapter.createRunRenderer(target);
+    const sub = renderer.subscriber as unknown as Sub;
+
+    sub.onTextMessageContentEvent?.({
+      event: { messageId: "m1", delta: "hello " },
+    });
+    sub.onTextMessageContentEvent?.({
+      event: { messageId: "m1", delta: "world" },
+    });
+    await sub.onToolCallStartEvent?.({
+      event: { toolCallId: "tc1", toolCallName: "search" },
+    });
+    await sub.onToolCallEndEvent?.({
+      event: { toolCallId: "tc1" },
+      toolCallName: "search",
+      toolCallArgs: {},
+    } as never);
+    await sub.onTextMessageEndEvent?.({ event: { messageId: "m1" } });
+    await renderer.finish?.();
+
+    const kinds = renderSink.frames.map((f) => f.event.kind);
+    expect(kinds).toEqual([
+      "run_started",
+      "text_delta",
+      "text_delta",
+      "tool_start",
+      "tool_end",
+      "text_end",
+      "finalize",
+    ]);
+    // seq is monotonic and zero-based within (turn, slot).
+    expect(renderSink.frames.map((f) => f.seq)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    expect(renderSink.frames.every((f) => f.slot === "main")).toBe(true);
+    expect(renderSink.frames.every((f) => f.turnId === "turn_t1")).toBe(true);
+  });
+
+  it("markInterrupted emits an interrupt frame then a finalize", async () => {
+    const renderSink = new InMemoryRenderEventSink();
+    const adapter = intelligenceAdapter({
+      source: new InMemoryDeliverySource(),
+      egress: new InMemoryEgressSink(),
+      renderSink,
+    });
+    const renderer = adapter.createRunRenderer(target);
+    const sub = renderer.subscriber as unknown as Sub;
+    sub.onTextMessageContentEvent?.({
+      event: { messageId: "m1", delta: "partial" },
+    });
+    await renderer.markInterrupted();
+
+    const kinds = renderSink.frames.map((f) => f.event.kind);
+    expect(kinds).toEqual([
+      "run_started",
+      "text_delta",
+      "interrupt",
+      "finalize",
+    ]);
+  });
+
+  it("falls back to a single post op on the EgressSink when no renderSink is wired", async () => {
+    const egress = new InMemoryEgressSink();
+    const adapter = intelligenceAdapter({
+      source: new InMemoryDeliverySource(),
+      egress,
+    });
+    const renderer = adapter.createRunRenderer(target);
+    const sub = renderer.subscriber as unknown as Sub;
+    sub.onTextMessageContentEvent?.({
+      event: { messageId: "m1", delta: "hello " },
+    });
+    sub.onTextMessageContentEvent?.({
+      event: { messageId: "m1", delta: "world" },
+    });
+    await sub.onTextMessageEndEvent?.({ event: { messageId: "m1" } });
+    await renderer.finish?.();
+
+    expect(egress.ops).toHaveLength(1);
+    expect(egress.ops[0]!.op.kind).toBe("post");
+  });
+});
+
+/** A fake Phoenix channel that records pushes and replies with render_accepted. */
+function makeFakeChannel() {
+  const pushes: { event: string; payload: unknown }[] = [];
+  const handlers = new Map<string, (payload: unknown) => void>();
+  const channel: HostedBotChannel = {
+    push: async (event, payload) => {
+      pushes.push({ event, payload });
+      if (event === "hosted_bot.render_event.v1") {
+        const p = (payload as { payload: Record<string, unknown> }).payload;
+        return {
+          type: "hosted_bot.render_accepted.v1",
+          occurredAt: "2026-07-01T00:00:00.000Z",
+          payload: {
+            idempotencyKey: p.idempotencyKey,
+            acceptance: "accepted",
+            ...(p.event && (p.event as { kind: string }).kind === "finalize"
+              ? { egressOperationId: "eop_1" }
+              : {}),
+          },
+        };
+      }
+      return { status: "ok" };
+    },
+    on: (event, handler) => {
+      handlers.set(event, handler);
+    },
+  };
+  return { channel, pushes, handlers };
+}
+
+describe("PhoenixRealtimeTransport — completion intent, never self-ack", () => {
+  const cfg = (channel: HostedBotChannel) => ({
+    scope: {
+      organizationId: "org_1",
+      projectId: 7,
+      botId: "bot_1",
+      botName: "support",
+    },
+    runtimeInstanceId: "rti_1",
+    channel,
+    now: () => "2026-07-01T00:00:00.000Z",
+  });
+
+  it("streams render frames, awaits receipts, then sends complete_requested (not ack)", async () => {
+    const fake = makeFakeChannel();
+    const t = new PhoenixRealtimeTransport(cfg(fake.channel));
+
+    // Simulate a leased delivery arriving over the channel.
+    let delivered = false;
+    await t.start(async () => {
+      delivered = true;
+    });
+    fake.handlers.get("hosted_bot.delivery.available.v1")?.({
+      payload: {
+        delivery: {
+          id: "dlv_d1",
+          adapter: "slack",
+          bot: { id: "bot_1", name: "support" },
+          turn: {
+            id: "turn_t1",
+            eventId: "evt_1",
+            replyTarget: { adapter: "slack", teamId: "T1", channel: "C1" },
+            input: { kind: "text", text: "hi" },
+          },
+        },
+      },
+    });
+    // handler is async (void); give the microtask queue a turn.
+    await Promise.resolve();
+    expect(delivered).toBe(true);
+
+    const r1 = await t.push({
+      deliveryId: "dlv_d1",
+      turnId: "turn_t1",
+      slot: "main",
+      seq: 0,
+      event: { kind: "run_started" },
+    });
+    expect(r1.acceptance).toBe("accepted");
+    expect(r1.idempotencyKey).toBe("turn_t1:main:0");
+
+    const rFinal = await t.push({
+      deliveryId: "dlv_d1",
+      turnId: "turn_t1",
+      slot: "main",
+      seq: 1,
+      event: { kind: "finalize" },
+    });
+    expect(rFinal.egressOperationId).toBe("eop_1");
+
+    await t.ack("dlv_d1");
+
+    const events = fake.pushes.map((p) => p.event);
+    // render frames first, then the completion INTENT.
+    expect(events).toEqual([
+      "hosted_bot.render_event.v1",
+      "hosted_bot.render_event.v1",
+      "hosted_bot.delivery.complete_requested.v1",
+    ]);
+    // The SDK must NEVER emit a committed delivery ack.
+    expect(events).not.toContain("hosted_bot.delivery.ack.v1");
+
+    const completion = fake.pushes.at(-1)!.payload as {
+      payload: { acceptedThrough: unknown[]; runtimeInstanceId: string };
+    };
+    expect(completion.payload.acceptedThrough).toEqual([
+      { turnId: "turn_t1", slot: "main", seq: 1 },
+    ]);
+    expect(completion.payload.runtimeInstanceId).toBe("rti_1");
+  });
+
+  it("throws if a render frame is not accepted (no silent success)", async () => {
+    const fake = makeFakeChannel();
+    // Override push to reply with a non-accepted envelope.
+    const channel: HostedBotChannel = {
+      push: async () => ({ type: "hosted_bot.something_else.v1" }),
+      on: fake.channel.on,
+    };
+    const t = new PhoenixRealtimeTransport(cfg(channel));
+    await expect(
+      t.push({
+        deliveryId: "dlv_d1",
+        turnId: "turn_t1",
+        slot: "main",
+        seq: 0,
+        event: { kind: "run_started" },
+      }),
+    ).rejects.toThrow(/render_accepted/);
+  });
+
+  it("nack sends a fail event, never an ack", async () => {
+    const fake = makeFakeChannel();
+    const t = new PhoenixRealtimeTransport(cfg(fake.channel));
+    await t.start(async () => {});
+    fake.handlers.get("hosted_bot.delivery.available.v1")?.({
+      payload: {
+        delivery: {
+          id: "dlv_d1",
+          adapter: "slack",
+          bot: { id: "bot_1", name: "support" },
+          turn: {
+            id: "turn_t1",
+            eventId: "evt_1",
+            input: { kind: "text", text: "hi" },
+          },
+        },
+      },
+    });
+    await Promise.resolve();
+    await t.nack("dlv_d1", "boom");
+    const events = fake.pushes.map((p) => p.event);
+    expect(events).toContain("hosted_bot.delivery.fail.v1");
+    expect(events).not.toContain("hosted_bot.delivery.ack.v1");
+  });
+});

--- a/packages/bot-intelligence/src/render-events.test.ts
+++ b/packages/bot-intelligence/src/render-events.test.ts
@@ -85,6 +85,27 @@ describe("run renderer — render-event streaming (OSS-402)", () => {
     ]);
   });
 
+  it("routes a discrete post through a post render frame (rich IR preserved) when a renderSink is wired", async () => {
+    const renderSink = new InMemoryRenderEventSink();
+    const adapter = intelligenceAdapter({
+      source: new InMemoryDeliverySource(),
+      egress: new InMemoryEgressSink(),
+      renderSink,
+    });
+    const card = [
+      { type: "section", props: { children: "card" } },
+    ] as unknown as Parameters<typeof adapter.post>[1];
+
+    await adapter.post(target, card);
+
+    const postFrame = renderSink.frames.find((f) => f.event.kind === "post");
+    expect(postFrame).toBeDefined();
+    expect(postFrame?.slot).toBe("main");
+    expect(
+      (postFrame?.event as { kind: "post"; content: unknown }).content,
+    ).toEqual(card);
+  });
+
   it("falls back to a single post op on the EgressSink when no renderSink is wired", async () => {
     const egress = new InMemoryEgressSink();
     const adapter = intelligenceAdapter({

--- a/packages/bot-intelligence/src/transports.ts
+++ b/packages/bot-intelligence/src/transports.ts
@@ -21,6 +21,26 @@ export interface DeliverySource {
   ack(deliveryId: string): Promise<void>;
   /** Negatively acknowledge — the work will be redelivered (at-least-once). */
   nack(deliveryId: string, reason: string): Promise<void>;
+  /**
+   * Fetch an inbound file's bytes by handle (managed multimodal content).
+   * Optional: sources without a file-serve backing omit it and the adapter
+   * skips content-part hydration (text-only turn).
+   */
+  fetchFile?(handle: string): Promise<{ bytes: Uint8Array; mimeType?: string }>;
+  /**
+   * Upload an outbound file's bytes to app-api ahead of a `file` render frame
+   * (`thread.postFile`). Returns the storage handle the frame carries. Optional:
+   * sources without an upload backing omit it and `postFile` reports failure.
+   */
+  uploadFile?(
+    deliveryId: string,
+    args: {
+      bytes: Uint8Array;
+      filename: string;
+      title?: string;
+      altText?: string;
+    },
+  ): Promise<{ handle: string }>;
   stop(): Promise<void>;
 }
 

--- a/packages/bot-intelligence/src/transports.ts
+++ b/packages/bot-intelligence/src/transports.ts
@@ -2,6 +2,8 @@ import type {
   ManagedIngressEnvelope,
   EgressOperation,
   EgressResult,
+  RenderFrame,
+  RenderAccepted,
 } from "./contracts.js";
 
 /**
@@ -30,4 +32,19 @@ export interface DeliverySource {
  */
 export interface EgressSink {
   emit(op: EgressOperation): Promise<EgressResult>;
+}
+
+/**
+ * Streaming egress transport for the realtime path (OSS-402). The run renderer
+ * pushes semantic {@link RenderFrame}s as the agent runs and awaits a durable
+ * {@link RenderAccepted} receipt for each before proceeding — the SDK never
+ * assumes acceptance and never commits the delivery ack (app-api owns that;
+ * the {@link DeliverySource} completion signal is the SDK's only terminal
+ * intent). Implemented by the Realtime Gateway (Phoenix) client in production;
+ * headless/HTTP-fallback runs translate frames back to {@link EgressSink}
+ * `post` operations so a Connector Outbox isn't required to see plain-text
+ * replies.
+ */
+export interface RenderEventSink {
+  push(frame: RenderFrame): Promise<RenderAccepted>;
 }

--- a/packages/bot-slack/package.json
+++ b/packages/bot-slack/package.json
@@ -36,6 +36,10 @@
     "./codec": {
       "types": "./dist/codec.d.ts",
       "import": "./dist/codec.js"
+    },
+    "./render": {
+      "types": "./dist/render.d.ts",
+      "import": "./dist/render.js"
     }
   },
   "scripts": {

--- a/packages/bot-slack/src/__tests__/event-renderer.test.ts
+++ b/packages/bot-slack/src/__tests__/event-renderer.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
-import type { WebClient } from "@slack/web-api";
+import type { SlackRenderTransport } from "../render/transport.js";
 import { createRunRenderer } from "../event-renderer.js";
 
 /**
- * Stub WebClient surface — only the methods the renderer touches
- * (`chat.postMessage`, `chat.update`, `chat.delete`). Records every
- * post / update call in order.
+ * Fake {@link SlackRenderTransport} — records every post / update call in
+ * order. This is exactly the seam the managed Connector Outbox will drive, so
+ * the renderer is verified Bolt-free (no `WebClient`).
  */
 function makeFakeClient() {
   const posts: {
@@ -16,28 +16,23 @@ function makeFakeClient() {
   }[] = [];
   const updates: { channel: string; ts: string; text: string }[] = [];
   let postedTsCounter = 0;
-  const chat = {
+  const transport: SlackRenderTransport = {
+    setStatus: vi.fn(async () => {}),
     postMessage: vi.fn(
       async (args: { channel: string; thread_ts?: string; text: string }) => {
         postedTsCounter++;
         const ts = `${postedTsCounter}.000`;
         posts.push({ ...args, ts });
-        return { ok: true, ts };
+        return { ts };
       },
     ),
-    update: vi.fn(
+    updateMessage: vi.fn(
       async (args: { channel: string; ts: string; text: string }) => {
         updates.push(args);
-        return { ok: true };
       },
     ),
-    delete: vi.fn(async (_args: { channel: string; ts: string }) => {
-      return { ok: true };
-    }),
   };
-  // The renderer only ever touches `client.chat.{postMessage,update,delete}`.
-  const client = { chat } as unknown as WebClient;
-  return { client, posts, updates };
+  return { transport, posts, updates };
 }
 
 describe("createRunRenderer", () => {
@@ -48,7 +43,7 @@ describe("createRunRenderer", () => {
     // instead of "ECHO". The renderer must accumulate deltas on its own.
     const fake = makeFakeClient();
     const { subscriber: sub } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
     });
     const id = "msg-1";
@@ -77,7 +72,7 @@ describe("createRunRenderer", () => {
   it("posts placeholder with thread_ts for thread replies, none for DMs (only on first content)", async () => {
     const fake = makeFakeClient();
     const { subscriber: dm } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "D1" },
     });
     await dm.onTextMessageStartEvent!({
@@ -94,7 +89,7 @@ describe("createRunRenderer", () => {
     expect(fake.posts[0]?.thread_ts).toBeUndefined();
 
     const { subscriber: thread } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
     });
     await thread.onTextMessageStartEvent!({
@@ -113,7 +108,7 @@ describe("createRunRenderer", () => {
   it("D20: a TEXT_MESSAGE_START + END with NO content events produces no Slack message", async () => {
     const fake = makeFakeClient();
     const { subscriber: sub } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
     });
     await sub.onTextMessageStartEvent!({
@@ -127,7 +122,7 @@ describe("createRunRenderer", () => {
   it("captures EVERY tool-call-end (getCapturedToolCalls returns it)", async () => {
     const fake = makeFakeClient();
     const { subscriber: sub, getCapturedToolCalls } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
       showToolStatus: false,
     });
@@ -152,7 +147,7 @@ describe("createRunRenderer", () => {
   it("captures partial args from onToolCallArgsEvent, finalised at END", async () => {
     const fake = makeFakeClient();
     const { subscriber: sub, getCapturedToolCalls } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
       showToolStatus: false,
     });
@@ -175,7 +170,7 @@ describe("createRunRenderer", () => {
   it("tool-call status: showToolStatus default (true) → START posts 🔧, END edits to ✅", async () => {
     const fake = makeFakeClient();
     const { subscriber: sub } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
     });
     await sub.onToolCallStartEvent!({
@@ -196,7 +191,7 @@ describe("createRunRenderer", () => {
   it("tool-call status: showToolStatus:false → no status posts but still captures", async () => {
     const fake = makeFakeClient();
     const { subscriber: sub, getCapturedToolCalls } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
       showToolStatus: false,
     });
@@ -216,7 +211,7 @@ describe("createRunRenderer", () => {
   it("tool-call status: dedup by toolCallId — a repeated START (e.g. on graph resume) does not double-post", async () => {
     const fake = makeFakeClient();
     const { subscriber: sub } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
       showToolStatus: true,
     });
@@ -236,7 +231,7 @@ describe("createRunRenderer", () => {
       getPendingInterrupt,
       clearPendingInterrupt,
     } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
     });
     sub.onCustomEvent!({
@@ -254,7 +249,7 @@ describe("createRunRenderer", () => {
   it("interrupt: a JSON-string value is parsed", async () => {
     const fake = makeFakeClient();
     const { subscriber: sub, getPendingInterrupt } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
     });
     sub.onCustomEvent!({
@@ -266,7 +261,7 @@ describe("createRunRenderer", () => {
   it("interrupt: a non-matching custom event is ignored", async () => {
     const fake = makeFakeClient();
     const { subscriber: sub, getPendingInterrupt } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
     });
     sub.onCustomEvent!({
@@ -278,7 +273,7 @@ describe("createRunRenderer", () => {
   it("mrkdwn: bold/italic/links/lists get translated before chat.update", async () => {
     const fake = makeFakeClient();
     const { subscriber: sub } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
     });
     await sub.onTextMessageStartEvent!({
@@ -301,7 +296,7 @@ describe("createRunRenderer", () => {
   it("posts a warning when RUN_ERROR fires", async () => {
     const fake = makeFakeClient();
     const { subscriber: sub } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
     });
     await sub.onRunErrorEvent!({ event: { message: "boom" } } as never);
@@ -313,7 +308,7 @@ describe("createRunRenderer", () => {
   it("markInterrupted: appends _(interrupted)_ to a partial reply and finalises", async () => {
     const fake = makeFakeClient();
     const { subscriber, markInterrupted } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
     });
     await subscriber.onTextMessageStartEvent!({
@@ -332,7 +327,7 @@ describe("createRunRenderer", () => {
   it("markInterrupted: no partial reply yet → no Slack post created", async () => {
     const fake = makeFakeClient();
     const { subscriber, markInterrupted } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
     });
     await subscriber.onTextMessageStartEvent!({
@@ -347,7 +342,7 @@ describe("createRunRenderer", () => {
   it("markInterrupted: a RUN_ERROR event that arrives AFTER abort is suppressed", async () => {
     const fake = makeFakeClient();
     const { subscriber, markInterrupted } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
     });
     await subscriber.onTextMessageStartEvent!({
@@ -369,7 +364,7 @@ describe("createRunRenderer", () => {
   it("markInterrupted: ignores late content events after the interrupt", async () => {
     const fake = makeFakeClient();
     const { subscriber, markInterrupted } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
     });
     await subscriber.onTextMessageStartEvent!({
@@ -392,7 +387,7 @@ describe("createRunRenderer", () => {
   it("does not bleed buffers between messages with different ids", async () => {
     const fake = makeFakeClient();
     const { subscriber: sub } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
     });
     await sub.onTextMessageStartEvent!({
@@ -433,45 +428,37 @@ describe("createRunRenderer — native status mode", () => {
     const posts: { text: string; ts: string }[] = [];
     const updates: { ts: string; text: string }[] = [];
     let counter = 0;
-    const chat = {
+    const transport: SlackRenderTransport = {
+      setStatus: vi.fn(
+        async (args: {
+          status: string;
+          loading_messages?: string[];
+          thread_ts: string;
+        }) => {
+          statuses.push({
+            status: args.status,
+            loading_messages: args.loading_messages,
+            thread_ts: args.thread_ts,
+          });
+        },
+      ),
       postMessage: vi.fn(async (args: { text: string }) => {
         counter++;
         const ts = `${counter}.000`;
         posts.push({ text: args.text, ts });
-        return { ok: true, ts };
+        return { ts };
       }),
-      update: vi.fn(async (args: { ts: string; text: string }) => {
+      updateMessage: vi.fn(async (args: { ts: string; text: string }) => {
         updates.push(args);
-        return { ok: true };
       }),
-      delete: vi.fn(async () => ({ ok: true })),
     };
-    const assistant = {
-      threads: {
-        setStatus: vi.fn(
-          async (args: {
-            status: string;
-            loading_messages?: string[];
-            thread_ts?: string;
-          }) => {
-            statuses.push({
-              status: args.status,
-              loading_messages: args.loading_messages,
-              thread_ts: args.thread_ts,
-            });
-            return { ok: true };
-          },
-        ),
-      },
-    };
-    const client = { chat, assistant } as unknown as WebClient;
-    return { client, statuses, posts };
+    return { transport, statuses, posts };
   }
 
   it("sets native status on run start instead of posting a placeholder", async () => {
     const f = makePaneClient();
     const { subscriber: sub } = createRunRenderer({
-      client: f.client,
+      transport: f.transport,
       target: { channel: "D1", threadTs: "100.0" },
       status: {
         threadTs: "100.0",
@@ -491,7 +478,7 @@ describe("createRunRenderer — native status mode", () => {
   it("surfaces tool calls as live status, not :wrench: rows", async () => {
     const f = makePaneClient();
     const { subscriber: sub } = createRunRenderer({
-      client: f.client,
+      transport: f.transport,
       target: { channel: "D1", threadTs: "100.0" },
       status: { threadTs: "100.0", isPane: true, config: {} },
     });
@@ -505,7 +492,7 @@ describe("createRunRenderer — native status mode", () => {
   it("showToolStatus:false suppresses the pane's `is using` status", async () => {
     const f = makePaneClient();
     const { subscriber: sub } = createRunRenderer({
-      client: f.client,
+      transport: f.transport,
       target: { channel: "D1", threadTs: "100.0" },
       status: { threadTs: "100.0", isPane: true, config: {} },
       showToolStatus: false,
@@ -520,7 +507,7 @@ describe("createRunRenderer — native status mode", () => {
   it("clears the status once a reply is posted", async () => {
     const f = makePaneClient();
     const { subscriber: sub } = createRunRenderer({
-      client: f.client,
+      transport: f.transport,
       target: { channel: "D1", threadTs: "100.0" },
       status: { threadTs: "100.0", isPane: true, config: {} },
     });
@@ -539,7 +526,7 @@ describe("createRunRenderer — native status mode", () => {
   it("clears the status on run finish when nothing was posted", async () => {
     const f = makePaneClient();
     const { subscriber: sub } = createRunRenderer({
-      client: f.client,
+      transport: f.transport,
       target: { channel: "D1", threadTs: "100.0" },
       status: { threadTs: "100.0", isPane: true, config: { thinking: "t" } },
     });
@@ -554,7 +541,7 @@ describe("createRunRenderer — native status mode", () => {
   it("non-pane thread: sets native status on run start (no :hourglass: placeholder)", async () => {
     const f = makePaneClient();
     const { subscriber: sub } = createRunRenderer({
-      client: f.client,
+      transport: f.transport,
       target: { channel: "C1", threadTs: "100.0" },
       status: { threadTs: "100.0", isPane: false, config: {} },
     });
@@ -566,7 +553,7 @@ describe("createRunRenderer — native status mode", () => {
   it("non-pane thread: tool calls still post :wrench: rows, not composer status", async () => {
     const f = makePaneClient();
     const { subscriber: sub } = createRunRenderer({
-      client: f.client,
+      transport: f.transport,
       target: { channel: "C1", threadTs: "100.0" },
       status: { threadTs: "100.0", isPane: false, config: {} },
     });
@@ -580,7 +567,7 @@ describe("createRunRenderer — native status mode", () => {
   it("uses the provided threadTs anchor (e.g. a DM's inbound ts) for setStatus", async () => {
     const f = makePaneClient();
     const { subscriber: sub } = createRunRenderer({
-      client: f.client,
+      transport: f.transport,
       // Flat DM: the channel target has no threadTs, but the adapter passes the
       // inbound message ts as the status anchor.
       target: { channel: "D1" },

--- a/packages/bot-slack/src/__tests__/native-renderer.test.ts
+++ b/packages/bot-slack/src/__tests__/native-renderer.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
-import type { WebClient } from "@slack/web-api";
 import type { AnyChunk, KnownBlock } from "@slack/types";
 import { createRunRenderer } from "../event-renderer.js";
 import type { NativeStreamTransport } from "../native-stream.js";
+import type { SlackRenderTransport } from "../render/transport.js";
 
-/** Fake client exposing only the methods the renderer touches on the side channels. */
+/** Fake render transport for the non-native side channels (legacy/error posts). */
 function makeFakeClient() {
   const posts: {
     channel: string;
@@ -14,24 +14,23 @@ function makeFakeClient() {
   }[] = [];
   const updates: { channel: string; ts: string; text: string }[] = [];
   let counter = 0;
-  const chat = {
+  const transport: SlackRenderTransport = {
+    setStatus: vi.fn(async () => {}),
     postMessage: vi.fn(
       async (args: { channel: string; thread_ts?: string; text: string }) => {
         counter++;
         const ts = `${counter}.000`;
         posts.push({ ...args, ts });
-        return { ok: true, ts };
+        return { ts };
       },
     ),
-    update: vi.fn(
+    updateMessage: vi.fn(
       async (args: { channel: string; ts: string; text: string }) => {
         updates.push(args);
-        return { ok: true };
       },
     ),
-    delete: vi.fn(async () => ({ ok: true })),
   };
-  return { client: { chat } as unknown as WebClient, posts, updates };
+  return { transport, posts, updates };
 }
 
 type Event =
@@ -96,7 +95,7 @@ describe("createRunRenderer — native streaming", () => {
     const fake = makeFakeClient();
     const nt = makeFakeNativeTransport();
     const { subscriber: sub, finish } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
       nativeStreaming: { transport: nt.transport },
     });
@@ -123,7 +122,7 @@ describe("createRunRenderer — native streaming", () => {
     const fake = makeFakeClient();
     const nt = makeFakeNativeTransport();
     const { subscriber: sub, finish } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
       nativeStreaming: { transport: nt.transport },
     });
@@ -166,7 +165,7 @@ describe("createRunRenderer — native streaming", () => {
     const fake = makeFakeClient();
     const nt = makeFakeNativeTransport();
     const { subscriber: sub, finish } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
       nativeStreaming: { transport: nt.transport },
       showToolStatus: false,
@@ -201,7 +200,7 @@ describe("createRunRenderer — native streaming", () => {
     // (a) with text → feedback attached.
     const withText = makeFakeNativeTransport();
     const r1 = createRunRenderer({
-      client: makeFakeClient().client,
+      transport: makeFakeClient().transport,
       target: { channel: "C1", threadTs: "100.0" },
       nativeStreaming: { transport: withText.transport },
       feedbackBlocks: blocks,
@@ -215,7 +214,7 @@ describe("createRunRenderer — native streaming", () => {
     // (b) no text (tool-only run) → no stream, nothing to attach.
     const noText = makeFakeNativeTransport();
     const r2 = createRunRenderer({
-      client: makeFakeClient().client,
+      transport: makeFakeClient().transport,
       target: { channel: "C1", threadTs: "100.0" },
       nativeStreaming: { transport: noText.transport },
       feedbackBlocks: blocks,
@@ -229,7 +228,7 @@ describe("createRunRenderer — native streaming", () => {
     const nt = makeFakeNativeTransport({ failChunks: true });
     const onChunkFailure = vi.fn();
     const { subscriber: sub, finish } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
       nativeStreaming: { transport: nt.transport, onChunkFailure },
     });
@@ -256,7 +255,7 @@ describe("createRunRenderer — native streaming", () => {
       { type: "context_actions", elements: [] } as unknown as KnownBlock,
     ];
     const { subscriber: sub, markInterrupted } = createRunRenderer({
-      client: makeFakeClient().client,
+      transport: makeFakeClient().transport,
       target: { channel: "C1", threadTs: "100.0" },
       nativeStreaming: { transport: nt.transport },
       feedbackBlocks: blocks,
@@ -273,7 +272,7 @@ describe("createRunRenderer — native streaming", () => {
     const fake = makeFakeClient();
     const nt = makeFakeNativeTransport();
     const { subscriber: sub, markInterrupted } = createRunRenderer({
-      client: fake.client,
+      transport: fake.transport,
       target: { channel: "C1", threadTs: "100.0" },
       nativeStreaming: { transport: nt.transport },
     });

--- a/packages/bot-slack/src/adapter.ts
+++ b/packages/bot-slack/src/adapter.ts
@@ -43,6 +43,7 @@ import {
   FEEDBACK_ACTION_ID,
 } from "./render/block-kit.js";
 import { renderSlackModal } from "./render/modal.js";
+import type { SlackRenderTransport } from "./render/transport.js";
 import { ChunkedMessageStream } from "./chunked-message-stream.js";
 import { NativeMessageStream } from "./native-stream.js";
 import type { TextStream, NativeStreamTransport } from "./native-stream.js";
@@ -494,6 +495,29 @@ export class SlackAdapter implements PlatformAdapter {
   }
 
   /**
+   * The credentialed {@link SlackRenderTransport} the run renderer calls
+   * (setStatus / postMessage / update), wrapping this adapter's `WebClient`.
+   * Extracted so `createRunRenderer` stays Bolt-free and the managed Connector
+   * Outbox can drive the identical renderer with its own sender.
+   */
+  private renderTransport(): SlackRenderTransport {
+    return {
+      setStatus: async (a) => {
+        await this.client.assistant.threads.setStatus(a);
+      },
+      postMessage: async (a) => {
+        const res = await this.client.chat.postMessage(
+          a as ChatPostMessageArguments,
+        );
+        return { ts: res.ts };
+      },
+      updateMessage: async (a) => {
+        await this.client.chat.update(a as ChatUpdateArguments);
+      },
+    };
+  }
+
+  /**
    * Route a `feedback_buttons` click to the configured feedback callback.
    * Returns `true` if this was a feedback click (so the caller skips the
    * engine's interaction dispatch). Best-effort: payload-shape or handler
@@ -579,7 +603,7 @@ export class SlackAdapter implements PlatformAdapter {
       !!t.threadTs &&
       this.nativeStreamingOk;
     return createRunRenderer({
-      client: this.client,
+      transport: this.renderTransport(),
       target: t,
       interruptEventNames: this.opts.interruptEventNames,
       showToolStatus: this.opts.showToolStatus,

--- a/packages/bot-slack/src/event-renderer.ts
+++ b/packages/bot-slack/src/event-renderer.ts
@@ -415,15 +415,16 @@ export function createRunRenderer(args: {
     // ── 2. Tool-call surfacing + capture ──────────────────────────────
     async onToolCallStartEvent({ event }) {
       if (aborted) return;
-      // Pane threads surface tool activity as live composer status, not rows.
-      // Each setStatus also resets Slack's status timeout.
-      if (isPane) {
-        if (showToolStatus && paneToolStatus) {
-          await setStatus(`is using \`${event.toolCallName}\`…`);
-        }
-        return;
+      // Composer "is using `tool`…" status on ANY thread anchor (not just
+      // panes) — the native status API works on every surface. Each setStatus
+      // also resets Slack's status timeout. The pane's `toolStatus` config knob
+      // still gates panes; every other surface shows it when tool status is on.
+      if (statusMode && showToolStatus && (isPane ? paneToolStatus : true)) {
+        await setStatus(`is using \`${event.toolCallName}\`…`);
       }
-      // Native path: surface the call as an in-message `task_update` chunk.
+      // Panes surface tool activity ONLY as composer status — no in-thread rows.
+      if (isPane) return;
+      // Native path: also surface the call as an in-message `task_update` chunk.
       if (nativeMode && taskChunksOk) {
         if (showToolStatus) {
           ensureTurnStream().appendChunk({

--- a/packages/bot-slack/src/event-renderer.ts
+++ b/packages/bot-slack/src/event-renderer.ts
@@ -1,4 +1,3 @@
-import type { WebClient } from "@slack/web-api";
 import type { KnownBlock } from "@slack/types";
 import type { AgentSubscriber } from "@ag-ui/client";
 import type {
@@ -11,6 +10,7 @@ import { markdownToMrkdwn } from "./markdown-to-mrkdwn.js";
 import { autoCloseOpenMarkdown } from "./auto-close-streaming.js";
 import { NativeMessageStream } from "./native-stream.js";
 import type { TextStream, NativeStreamTransport } from "./native-stream.js";
+import type { SlackRenderTransport } from "./render/transport.js";
 import type { SlackAssistantOptions } from "./types.js";
 
 const DEFAULT_THINKING_STATUS = "is thinking…";
@@ -57,7 +57,13 @@ const INTERRUPTED_SUFFIX = "\n_(interrupted)_";
  * text message, plus separate `:wrench:` tool-status rows.
  */
 export function createRunRenderer(args: {
-  client: WebClient;
+  /**
+   * The credentialed Slack side-effects (setStatus / postMessage / update),
+   * injected so this renderer never imports `@slack/web-api`. The native
+   * adapter wraps a `WebClient`; the managed Connector Outbox wraps its own
+   * sender.
+   */
+  transport: SlackRenderTransport;
   target: { channel: string; threadTs?: string };
   /**
    * Custom-event names that should be treated as interrupts — captured
@@ -118,7 +124,7 @@ export function createRunRenderer(args: {
    */
   feedbackBlocks?: KnownBlock[];
 }): RunRenderer {
-  const { client, target } = args;
+  const { transport, target } = args;
   const interruptEventNames =
     args.interruptEventNames ?? new Set<string>(["on_interrupt"]);
   const showToolStatus = args.showToolStatus ?? true;
@@ -136,7 +142,7 @@ export function createRunRenderer(args: {
   const setStatus = async (text: string): Promise<void> => {
     if (!status) return;
     try {
-      await client.assistant.threads.setStatus({
+      await transport.setStatus({
         channel_id: target.channel,
         thread_ts: status.threadTs,
         status: text,
@@ -219,7 +225,7 @@ export function createRunRenderer(args: {
   const makeLegacyStream = (): TextStream =>
     new ChunkedMessageStream({
       postPlaceholder: async (text) => {
-        const posted = await client.chat.postMessage({
+        const posted = await transport.postMessage({
           channel: target.channel,
           thread_ts: target.threadTs,
           text,
@@ -229,7 +235,7 @@ export function createRunRenderer(args: {
         return posted.ts;
       },
       updateAt: async (ts, text) => {
-        await client.chat.update({ channel: target.channel, ts, text });
+        await transport.updateMessage({ channel: target.channel, ts, text });
       },
       transform: displayTransform,
     });
@@ -297,7 +303,7 @@ export function createRunRenderer(args: {
     if (!showToolStatus) return;
     if (toolStatusTs.has(toolCallId)) return; // dedup
     try {
-      const posted = await client.chat.postMessage({
+      const posted = await transport.postMessage({
         channel: target.channel,
         thread_ts: target.threadTs,
         text: `:wrench: Calling \`${toolCallName}\`…`,
@@ -317,7 +323,7 @@ export function createRunRenderer(args: {
     const ts = toolStatusTs.get(toolCallId);
     if (!ts) return;
     try {
-      await client.chat.update({
+      await transport.updateMessage({
         channel: target.channel,
         ts,
         text: `:white_check_mark: \`${toolCallName}\``,
@@ -502,7 +508,7 @@ export function createRunRenderer(args: {
       await finalizeTurnStream();
       if (aborted) return;
       try {
-        await client.chat.postMessage({
+        await transport.postMessage({
           channel: target.channel,
           thread_ts: target.threadTs,
           text: `:warning: Agent error: ${event.message ?? "unknown error"}`,

--- a/packages/bot-slack/src/index.ts
+++ b/packages/bot-slack/src/index.ts
@@ -84,6 +84,7 @@ export { slack, SlackAdapter } from "./adapter.js";
 export type { SlackAdapterOptions } from "./adapter.js";
 
 export { createRunRenderer } from "./event-renderer.js";
+export type { SlackRenderTransport } from "./render/transport.js";
 
 export { decodeInteraction, conversationKeyOf } from "./interaction.js";
 
@@ -93,4 +94,5 @@ export {
   buildFeedbackBlocks,
   FEEDBACK_ACTION_ID,
 } from "./render/block-kit.js";
+export { renderSlackModal } from "./render/modal.js";
 export { SLACK_LIMITS } from "./render/budget.js";

--- a/packages/bot-slack/src/render.ts
+++ b/packages/bot-slack/src/render.ts
@@ -1,0 +1,34 @@
+/**
+ * `@copilotkit/bot-slack/render` — the pure, Bolt-free Slack rendering surface.
+ *
+ * Nothing here imports `@slack/bolt` or instantiates a `WebClient`: the
+ * stateful run renderer takes its credentialed side-effects as injected
+ * transports ({@link SlackRenderTransport} + {@link NativeStreamTransport}), and
+ * the IR→Block Kit / modal / mrkdwn helpers are pure functions. This is the
+ * seam the native Slack adapter AND the managed Connector Outbox both consume,
+ * so managed replies reach 1:1 UX parity with the native bot without forking
+ * the renderer.
+ */
+export { createRunRenderer } from "./event-renderer.js";
+export type { SlackRenderTransport } from "./render/transport.js";
+
+export {
+  renderBlockKit,
+  renderSlackMessage,
+  buildFeedbackBlocks,
+  FEEDBACK_ACTION_ID,
+} from "./render/block-kit.js";
+export { renderSlackModal } from "./render/modal.js";
+export { SLACK_LIMITS } from "./render/budget.js";
+
+export { NativeMessageStream } from "./native-stream.js";
+export { ChunkedMessageStream } from "./chunked-message-stream.js";
+export { MessageStream } from "./message-stream.js";
+export type {
+  NativeMessageStreamConfig,
+  NativeStreamTransport,
+  TextStream,
+} from "./native-stream.js";
+
+export { markdownToMrkdwn } from "./markdown-to-mrkdwn.js";
+export { autoCloseOpenMarkdown } from "./auto-close-streaming.js";

--- a/packages/bot-slack/src/render/transport.ts
+++ b/packages/bot-slack/src/render/transport.ts
@@ -1,0 +1,39 @@
+/**
+ * The credentialed Slack side-effects the run renderer performs, injected so
+ * {@link createRunRenderer} (event-renderer.ts) stays free of `@slack/web-api`
+ * (no `WebClient`, no Bolt). The native Slack adapter wraps a real `WebClient`;
+ * the managed Connector Outbox wraps its own credentialed sender — both drive
+ * the exact same renderer.
+ *
+ * These are the three ops the renderer calls directly. The four native
+ * streaming ops (`chat.startStream`/`appendStream`/`stopStream`) are injected
+ * separately as a {@link NativeStreamTransport} (native-stream.ts).
+ */
+export interface SlackRenderTransport {
+  /**
+   * `assistant.threads.setStatus` — the thread-anchored "is thinking…" /
+   * "is using `tool`…" indicator. Passing an empty `status` clears it.
+   */
+  setStatus(args: {
+    channel_id: string;
+    thread_ts: string;
+    status: string;
+    loading_messages?: string[];
+  }): Promise<void>;
+  /**
+   * `chat.postMessage` — post a message (streaming placeholder, `:wrench:`
+   * tool-status row, or error notice). Resolves with the new message `ts`; the
+   * legacy text stream treats a missing `ts` as a hard failure.
+   */
+  postMessage(args: {
+    channel: string;
+    thread_ts?: string;
+    text: string;
+  }): Promise<{ ts?: string }>;
+  /** `chat.update` — edit an existing message in place. */
+  updateMessage(args: {
+    channel: string;
+    ts: string;
+    text: string;
+  }): Promise<void>;
+}

--- a/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
@@ -78,6 +78,7 @@ describe("handleGetRuntimeInfo", () => {
     generateThreadNames: true,
     lockTtlSeconds: 20,
     lockHeartbeatIntervalSeconds: 15,
+    bots: [],
     ...overrides,
   });
 

--- a/packages/runtime/src/v2/runtime/runner/__tests__/in-memory-runner.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/in-memory-runner.test.ts
@@ -820,3 +820,130 @@ describe("InMemoryAgentRunner — listThreads / getThreadMessages", () => {
     });
   });
 });
+
+describe("InMemoryAgentRunner onConcurrentRun", () => {
+  class HangingAgent extends AbstractAgent {
+    async runAgent(): Promise<RunAgentResult> {
+      // Never resolves — models a wedged / suspended (e.g. HITL) run.
+      return new Promise<RunAgentResult>(() => {});
+    }
+    clone(): AbstractAgent {
+      return new HangingAgent();
+    }
+  }
+
+  // Emits its own RUN_STARTED then hangs until aborted, at which point its run
+  // rejects — modeling a real agent wired to an AbortController (unlike
+  // HangingAgent, this exercises the abort→teardown path).
+  class AbortableAgent extends AbstractAgent {
+    private rejectRun?: (err: Error) => void;
+    async runAgent(
+      input: RunAgentInput,
+      options: {
+        onEvent: (e: { event: BaseEvent }) => void;
+        onRunStartedEvent?: () => void;
+      },
+    ): Promise<RunAgentResult> {
+      options.onEvent({
+        event: {
+          type: EventType.RUN_STARTED,
+          threadId: input.threadId,
+          runId: input.runId,
+        } as RunStartedEvent,
+      });
+      options.onRunStartedEvent?.();
+      return new Promise<RunAgentResult>((_resolve, reject) => {
+        this.rejectRun = reject;
+      });
+    }
+    abortRun(): void {
+      this.rejectRun?.(new Error("aborted by supersede"));
+    }
+    clone(): AbstractAgent {
+      return new AbortableAgent();
+    }
+  }
+
+  const makeInput = (threadId: string, runId: string): RunAgentInput => ({
+    threadId,
+    runId,
+    messages: [],
+    state: {},
+    tools: [],
+    context: [],
+  });
+
+  it("throws 'Thread already running' by default when a run is in flight", () => {
+    const runner = new InMemoryAgentRunner();
+    const threadId = "concurrent-throw";
+    runner.run({
+      threadId,
+      agent: new HangingAgent(),
+      input: makeInput(threadId, "run-1"),
+    });
+    expect(() =>
+      runner.run({
+        threadId,
+        agent: new HangingAgent(),
+        input: makeInput(threadId, "run-2"),
+      }),
+    ).toThrow("Thread already running");
+  });
+
+  it("supersedes an in-flight run when configured, and the new run streams", async () => {
+    const runner = new InMemoryAgentRunner({ onConcurrentRun: "supersede" });
+    const threadId = "concurrent-supersede";
+    // Wedge the thread with a run that never resolves (isRunning stays true).
+    runner.run({
+      threadId,
+      agent: new HangingAgent(),
+      input: makeInput(threadId, "run-1"),
+    });
+    // A new turn on the same thread must NOT throw — it supersedes and streams.
+    const events = await firstValueFrom(
+      runner
+        .run({
+          threadId,
+          agent: new TestAgent(),
+          input: makeInput(threadId, "run-2"),
+        })
+        .pipe(toArray()),
+    );
+    expect(events.some((e) => e.type === EventType.RUN_STARTED)).toBe(true);
+  });
+
+  it("a superseded run does not persist history under the new run's id", async () => {
+    const runner = new InMemoryAgentRunner({ onConcurrentRun: "supersede" });
+    const threadId = "concurrent-supersede-history";
+    // run-1 emits its own RUN_STARTED (runId "run-1"), then hangs until aborted.
+    runner.run({
+      threadId,
+      agent: new AbortableAgent(),
+      input: makeInput(threadId, "run-1"),
+    });
+    // run-2 supersedes → run-1 is aborted → its async teardown runs.
+    await firstValueFrom(
+      runner
+        .run({
+          threadId,
+          agent: new TestAgent(),
+          input: makeInput(threadId, "run-2"),
+        })
+        .pipe(toArray()),
+    );
+    await new Promise((r) => setTimeout(r, 20)); // let run-1's abort teardown settle
+
+    const events = runner.getThreadEvents(threadId);
+    // The superseded run must NOT persist its events — and never under run-2's id.
+    expect(
+      events.some((e) => (e as { runId?: string }).runId === "run-1"),
+    ).toBe(false);
+    expect(
+      events.some(
+        (e) =>
+          e.type === EventType.RUN_STARTED &&
+          (e as { runId?: string }).runId === "run-2",
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/runtime/src/v2/runtime/runner/in-memory.ts
+++ b/packages/runtime/src/v2/runtime/runner/in-memory.ts
@@ -81,6 +81,21 @@ const GLOBAL_STORE = new Map<string, InMemoryEventStore>();
 export class InMemoryAgentRunner extends AgentRunner {
   readonly ɵsupportsLocalThreadEndpoints = true;
 
+  /**
+   * How to handle a `run()` for a thread that already has an in-flight run.
+   * `"throw"` (default) preserves the historic behavior. `"supersede"` aborts
+   * the prior run (mirroring `stop()`) and starts the new one — opted into by
+   * the hosted-bot listener so a fast follow-up turn on the same thread cleanly
+   * replaces a still-running (or wedged) prior turn instead of erroring with
+   * "Thread already running".
+   */
+  private readonly onConcurrentRun: "throw" | "supersede";
+
+  constructor(options?: { onConcurrentRun?: "throw" | "supersede" }) {
+    super();
+    this.onConcurrentRun = options?.onConcurrentRun ?? "throw";
+  }
+
   run(request: AgentRunnerRunRequest): Observable<BaseEvent> {
     let existingStore = GLOBAL_STORE.get(request.threadId);
     if (!existingStore) {
@@ -90,7 +105,23 @@ export class InMemoryAgentRunner extends AgentRunner {
     const store = existingStore; // Now store is const and non-null
 
     if (store.isRunning) {
-      throw new Error("Thread already running");
+      if (this.onConcurrentRun !== "supersede") {
+        throw new Error("Thread already running");
+      }
+      // Supersede: abort the prior (possibly wedged) run so this one can start.
+      // Mirrors stop(). The prior run's async finalization runs later and is
+      // prevented from clobbering this run's state by the run-id guard below.
+      const priorAgent = store.agent;
+      store.stopRequested = true;
+      store.isRunning = false;
+      if (priorAgent) {
+        try {
+          priorAgent.abortRun();
+        } catch (error) {
+          console.error("Failed to abort superseded run", error);
+        }
+      }
+      store.stopRequested = false;
     }
     store.isRunning = true;
     store.currentRunId = request.input.runId;
@@ -190,14 +221,17 @@ export class InMemoryAgentRunner extends AgentRunner {
           nextSubject.next(event);
         }
 
-        // Store the completed run in memory with ONLY its events
-        if (store.currentRunId) {
+        // Store the completed run in memory with ONLY its events. Guard on the
+        // per-run id (not the shared `store.currentRunId`): a superseded run no
+        // longer owns the store, so it must not push history — and never under
+        // a newer run's id, which would corrupt the thread's history.
+        if (store.currentRunId === request.input.runId) {
           // Compact the events before storing (like SQLite does)
           const compactedEvents = compactEvents(currentRunEvents);
 
           store.historicRuns.push({
             threadId: request.threadId,
-            runId: store.currentRunId,
+            runId: request.input.runId,
             agentId: request.agent.agentId ?? "default",
             parentRunId,
             events: compactedEvents,
@@ -209,13 +243,17 @@ export class InMemoryAgentRunner extends AgentRunner {
           });
         }
 
-        // Complete the run
-        store.currentEvents = null;
-        store.currentRunId = null;
-        store.agent = null;
-        store.runSubject = null;
-        store.stopRequested = false;
-        store.isRunning = false;
+        // Complete the run. Guard the shared-store reset: if a newer run has
+        // superseded this one (`currentRunId` changed), that run now owns the
+        // store — don't clobber its state. Always complete THIS run's subjects.
+        if (store.currentRunId === request.input.runId) {
+          store.currentEvents = null;
+          store.currentRunId = null;
+          store.agent = null;
+          store.runSubject = null;
+          store.stopRequested = false;
+          store.isRunning = false;
+        }
         runSubject.complete();
         nextSubject.complete();
       } catch (error) {
@@ -230,13 +268,18 @@ export class InMemoryAgentRunner extends AgentRunner {
           nextSubject.next(event);
         }
 
-        // Store the run even if it failed (partial events)
-        if (store.currentRunId && currentRunEvents.length > 0) {
+        // Store the run even if it failed (partial events). Same per-run guard:
+        // a superseded run's error teardown must not push history under the
+        // newer run's id (see success-path note).
+        if (
+          store.currentRunId === request.input.runId &&
+          currentRunEvents.length > 0
+        ) {
           // Compact the events before storing (like SQLite does)
           const compactedEvents = compactEvents(currentRunEvents);
           store.historicRuns.push({
             threadId: request.threadId,
-            runId: store.currentRunId,
+            runId: request.input.runId,
             agentId: request.agent.agentId ?? "default",
             parentRunId,
             events: compactedEvents,
@@ -247,13 +290,16 @@ export class InMemoryAgentRunner extends AgentRunner {
           });
         }
 
-        // Complete the run
-        store.currentEvents = null;
-        store.currentRunId = null;
-        store.agent = null;
-        store.runSubject = null;
-        store.stopRequested = false;
-        store.isRunning = false;
+        // Complete the run (see success-path note). Same run-id guard so a
+        // superseded run's error teardown can't reset the newer run's state.
+        if (store.currentRunId === request.input.runId) {
+          store.currentEvents = null;
+          store.currentRunId = null;
+          store.agent = null;
+          store.runSubject = null;
+          store.stopRequested = false;
+          store.isRunning = false;
+        }
         runSubject.complete();
         nextSubject.complete();
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2413,6 +2413,9 @@ importers:
       '@copilotkit/bot-ui':
         specifier: workspace:~
         version: link:../bot-ui
+      phoenix:
+        specifier: ^1.8.4
+        version: 1.8.4
     devDependencies:
       '@copilotkit/typescript-config':
         specifier: workspace:^
@@ -2420,6 +2423,9 @@ importers:
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.11
+      '@types/phoenix':
+        specifier: ^1.6.6
+        version: 1.6.7
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -43161,8 +43167,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.8
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.2(jiti@2.7.0))
@@ -43181,8 +43187,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.9
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.2(jiti@2.7.0))
@@ -43204,6 +43210,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3(supports-color@5.5.0)
+      eslint: 9.39.2(jiti@2.7.0)
+      get-tsconfig: 4.13.6
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -43219,21 +43240,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.2(jiti@2.7.0)
-      get-tsconfig: 4.13.6
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.16
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-module-utils@2.12.1(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
@@ -43245,13 +43251,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -43284,7 +43290,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -43295,7 +43301,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
Stacked on #5761 (base: `alem/oss-360-sdk-foundations`). The SDK side of the Hosted Bots **realtime** path, per the source-of-truth Notion plan and the OSS-395 frozen contract.

## What this delivers

### OSS-403 — extract a Bolt-free Slack renderer (`@copilotkit/bot-slack/render`)
`createRunRenderer` no longer takes a `WebClient`; it takes an injected `SlackRenderTransport` (the 3 credentialed ops it actually calls — `setStatus` / `postMessage` / `updateMessage`; the 4 native streaming ops were already injected via `NativeStreamTransport`). New `./render` subpath export exposes the transport-agnostic renderer plus the already-pure IR→Block Kit / modal / mrkdwn helpers, so the gateway-side **Connector Outbox (OSS-404)** can drive the *identical* renderer for managed replies — 1:1 UX parity without forking. The native Slack adapter wraps its own `WebClient` into the transport.
- **Zero behavior change** to the native bot — 272 `bot-slack` tests pass, check-types green.

### OSS-402 — stream RenderEvents over the realtime gateway
The managed adapter (`@copilotkit/bot-intelligence`) now mints semantic render frames (`run_started` / `text_delta` / `text_end` / `tool_start` / `tool_end` / `interrupt` / `run_error` / `finalize`) and streams them through a new `RenderEventSink`, assigning a monotonic `seq` per `(turnId, slot)` and awaiting a durable `render_accepted` receipt for each. Ordering is guaranteed by a serial chain with `seq` fixed at enqueue time (so it holds regardless of AG-UI callback scheduling); a rejected push surfaces at drain and nacks the delivery.

`PhoenixRealtimeTransport` (implements `DeliverySource` + `RenderEventSink`) speaks the frozen OSS-395 contract exactly: `render_event` frames → `render_accepted` receipts, then `delivery.complete_requested` (completion **intent**, carrying `acceptedThrough` high-water pointers) — **never** a committed `delivery.ack` (app-api owns ack), and **no Slack credentials** in the SDK. The Phoenix `Socket`/`Channel` boilerplate is expressed against a minimal injected `HostedBotChannel` so the protocol is fully unit-tested with a fake channel.

When no realtime sink is wired, the renderer falls back to translating frames into `post` ops on the `EgressSink`, so the existing HTTP demo keeps posting plain-text replies.

## Tests
- `@copilotkit/bot-slack`: 272 pass (native renderer behavior preserved through the transport swap).
- `@copilotkit/bot-intelligence`: 43 pass (37 baseline + 6 new) — frame ordering + `turnId:slot:seq`, completion-after-receipt, and the **never-self-ack** invariant.
- `@copilotkit/runtime` check-types green (fixes the pre-existing `get-runtime-info` `bots` red flagged on #5761).

## Follow-ups (not in this PR)
- **Gateway `complete_requested` handler (Intelligence #466):** `sdk_channel.ex` currently routes `render_event` / `ack` / `fail` but not `complete_requested`; it needs a `handle_in` clause + `app_api_client.complete_delivery` + a matching app-api completion route. Coordinating with @TylerSlaton since it's his file / shared branch (no local Elixir toolchain to verify here).
- **OSS-404 Connector Outbox** consumes `@copilotkit/bot-slack/render` to render frames → real Slack messages; end-to-end realtime parity isn't demoable until it lands.
- Discrete `EgressSink` posts (command/interaction replies) → `post`/`update` render frames (needs a per-`(turn, slot)` seq shared with the run renderer).
