### PR TITLE
feat(web-inspector): rename the Memories tab to Learning

### DIFF
--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -1029,7 +1029,7 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
 //
 // 6.1  Helpers: makeCoreWithMemory / makeCoreNoIntelligence / mountMemories
 // 6.2  Subscription: inspector._memories is seeded from store
-// 6.3  Tab presence: "Memories" label appears in the rendered menu
+// 6.3  Tab presence: "Learning" label appears in the rendered menu
 // 6.4  View states: locked teaser vs. enabled empty vs. enabled with cards
 // 6.5  cpk-memory-list: cards, kind filter, search filter, empty state
 // 6.6  Passive guard: inspector reads from core.getMemoryStore(), never creates its own
@@ -1248,7 +1248,7 @@ describe("WebInspectorElement memories — tab presence", () => {
     vi.unstubAllGlobals();
   });
 
-  it("renders a Memories tab button in the inspector menu", async () => {
+  it("renders a Learning tab button in the inspector menu", async () => {
     const core = makeCoreWithMemory([]);
     const el = await mountMemories(core);
 
@@ -1256,10 +1256,10 @@ describe("WebInspectorElement memories — tab presence", () => {
       el.shadowRoot?.querySelectorAll<HTMLButtonElement>("button") ?? [],
     );
     const memoriesButton = buttons.find((btn) =>
-      btn.textContent?.trim().includes("Memories"),
+      btn.textContent?.trim().includes("Learning"),
     );
 
-    expect(memoriesButton, "Memories tab button should render").toBeDefined();
+    expect(memoriesButton, "Learning tab button should render").toBeDefined();
   });
 });
 

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -2943,7 +2943,7 @@ export class WebInspectorElement extends LitElement {
         label: "Threads",
         icon: "MessageSquare" as LucideIconName,
       },
-      { key: "memories", label: "Memories", icon: "Brain" as LucideIconName },
+      { key: "memories", label: "Learning", icon: "Brain" as LucideIconName },
     ];
   }
 
@@ -7054,7 +7054,7 @@ ${argsString}</pre
     return html`
       <div style="display:flex;height:100%;overflow:hidden;flex-direction:column;">
         <div class="cpk-section-header" style="display:flex;align-items:center;justify-content:space-between;">
-          <h4>Memory store</h4>
+          <h4>Learning</h4>
           <div style="display:flex;align-items:center;gap:6px;">
             ${this.renderMemoryRealtimeIndicator()}
             <span


### PR DESCRIPTION
## What

Renames the inspector's user-facing feature name from **Memories** to **Learning**:

- The menu tab label (`Memories` → `Learning`).
- The enabled-state panel heading (`Memory store` → `Learning`).

## What's intentionally left unchanged

- The internal `"memories"` menu key, the `Brain` icon, and the REST wiring.
- Entry-level copy that refers to individual records (the `Search memories…` box, the `No memories yet` empty state) — the *feature* is "Learning" but the *entries* are still memories.

## Notes

- Not touched here: the locked-teaser copy (`Long-term memory` / "isn't enabled on this deployment") — flagged for a separate decision on whether the teaser should also say "Learning".
- Updated the tab-presence test accordingly; `web-inspector` tests pass (71).

Targets `mme/memory-core`.