### PR TITLE
docs(shell-docs): update Slack and Teams agent framing

### DIFF
--- a/showcase/shell-docs/src/content/docs/frontends/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/slack.mdx
@@ -1,18 +1,18 @@
 ---
 title: Slack
-description: Build an AI Slack bot with CopilotKit, Copilot Runtime, createBot, the Slack adapter over Socket Mode, and interactive JSX messages rendered as Block Kit.
+description: Bring custom agents into Slack with native cards, streaming replies, approvals, and durable thread context.
 icon: "lucide/Slack"
 hideTOC: true
 ---
 
-This guide takes you from zero to a Slack bot you can @-mention in a channel, then adds an interactive button card. You write handlers in TypeScript, Copilot Runtime hosts the agent, and rich messages are JSX that the adapter renders to Block Kit (Slack's message-UI format). No public URL needed.
+Slack can be the frontend for agents built on any harness or framework, so your team can get work done in the conversations, approvals, and handoffs they already use. The open source Bot SDK gives you the adapter path for TypeScript handlers and JSX-authored Block Kit messages. CopilotKit Enterprise Intelligence adds the self-hosted or cloud-hosted production layer for thread mapping, durable agent state, approvals, observability, and release operations when Slack becomes a critical workflow.
 
 <OpsPlatformCTA
   variant="inline"
-  title="Join the waitlist for managed Slack and Teams agents"
-  body="Want CopilotKit Intelligence to carry Slack and Teams setup, identity and permissions, durable state, approvals, and runtime operations for you?"
-  ctaLabel="Join the waitlist"
-  surface="docs_slack_managed_agents_waitlist"
+  title="Get early access to Slack and Teams agents in CopilotKit Enterprise Intelligence"
+  body="Use the open source Bot SDK to run the adapter, runtime, platform credentials, tools, and storage inside your stack. CopilotKit Enterprise Intelligence adds the self-hosted or cloud-hosted production layer around that SDK: durable agent threads, platform conversation mapping, approvals, observability, and release operations for Slack and Teams."
+  ctaLabel="Get early access"
+  surface="docs_slack_agents_early_access"
   href="https://www.copilotkit.ai/opentag-managed"
 />
 

--- a/showcase/shell-docs/src/content/docs/frontends/teams.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/teams.mdx
@@ -1,17 +1,17 @@
 ---
 title: Microsoft Teams
-description: Build an AI Microsoft Teams bot with CopilotKit using createBot, the Teams adapter, agent runs with thread.runAgent, and interactive JSX messages rendered as Adaptive Cards.
+description: Bring custom agents into Microsoft Teams with Adaptive Cards, streaming updates, approvals, and durable conversation context.
 hideTOC: true
 ---
 
-This guide takes you from zero to a Microsoft Teams bot you can chat with, then adds an interactive Adaptive Card and a human-approval gate. You write handlers in TypeScript, the agent's replies stream into the conversation, and rich messages are JSX that the adapter renders to Adaptive Cards (Teams' message-UI format). You can run the whole thing locally in the **M365 Agents Playground** with no Microsoft account, then sideload it into real Teams when you're ready.
+Microsoft Teams can be the frontend for agents built on any harness or framework, so your organization can get work done where conversations, decisions, and approvals already happen. The open source Bot SDK gives you the adapter path for TypeScript handlers and JSX-authored Adaptive Cards. CopilotKit Enterprise Intelligence adds the self-hosted or cloud-hosted production layer for conversation mapping, durable agent state, approvals, observability, and release operations when Teams becomes a critical workflow.
 
 <OpsPlatformCTA
   variant="inline"
-  title="Join the waitlist for managed Slack and Teams agents"
-  body="Want CopilotKit Intelligence to manage the app setup, identity and permissions, durable state, approvals, and runtime operations for Slack and Teams?"
-  ctaLabel="Join the waitlist"
-  surface="docs_teams_managed_agents_waitlist"
+  title="Get early access to Slack and Teams agents in CopilotKit Enterprise Intelligence"
+  body="Use the open source Bot SDK to run the adapter, runtime, platform credentials, tools, and storage inside your stack. CopilotKit Enterprise Intelligence adds the self-hosted or cloud-hosted production layer around that SDK: durable agent threads, platform conversation mapping, approvals, observability, and release operations for Slack and Teams."
+  ctaLabel="Get early access"
+  surface="docs_teams_agents_early_access"
   href="https://www.copilotkit.ai/opentag-managed"
 />
 

--- a/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
@@ -403,7 +403,6 @@ describe("framework nav", () => {
       "Self-Hosting Enterprise Intelligence",
       "Enterprise Intelligence Architecture",
       "Threads & Persistence Architecture",
-      "Threads",
     ]);
   });
 });


### PR DESCRIPTION
## Summary

- Backport the website messaging from CopilotKit/website#398 into the shell-docs Slack and Microsoft Teams frontend pages.
- Replace the stale waitlist/managed-only framing with "get early access" copy that presents CopilotKit Enterprise Intelligence as the self-hosted or cloud-hosted production layer around the open source Bot SDK.
- Frame Slack and Teams as frontends for agents built on any harness or framework, while reserving production-layer terminology for CopilotKit Enterprise Intelligence.
- Address browser review annotations on both pages: remove filler in the opener, avoid setup-heavy lead copy, use "open source" without a hyphen, add the full CopilotKit Enterprise Intelligence name to the CTA titles, and keep CTA telemetry surfaces intact.
- Update the shell-docs nav test expectation so it matches the current root IA, where Threads lives under Build Chat UIs rather than the generated Intelligence Platform section.

## Validation

- `npm run lint` from `showcase/shell-docs` (passes with existing warnings)
- `npm run typecheck` from `showcase/shell-docs`
- `npm run test` from `showcase/shell-docs`
- `npm run build` from `showcase/shell-docs`

## Notes

- Hydrated Git LFS assets locally with `git lfs pull` so the shell-docs public asset tests could read real PNG bytes.