### PR TITLE
feat(showcase): banking wow moments — proactive copilot, chart pills, report artifacts

### DIFF
--- a/examples/showcases/banking/src/app/api/v1/data.ts
+++ b/examples/showcases/banking/src/app/api/v1/data.ts
@@ -77,6 +77,17 @@ export interface NewCardRequest {
   pin: string;
 }
 
+// A copilot-generated report artifact, filed in the dashboard's Reports tab.
+// Narrative fields come from the agent; id/createdAt are server-set.
+export interface Report {
+  id: string;
+  title: string;
+  summary: string;
+  highlights: string[];
+  createdAt: string;
+  createdBy: string;
+}
+
 export function generateUniqueId() {
   return Math.random().toString(36).slice(2, 15);
 }

--- a/examples/showcases/banking/src/app/api/v1/reports/route.ts
+++ b/examples/showcases/banking/src/app/api/v1/reports/route.ts
@@ -1,0 +1,30 @@
+import * as store from "@/lib/store";
+
+// Get all reports (newest first — the store unshifts on file)
+export const GET = async () => {
+  return new Response(JSON.stringify(store.reports()), { status: 200 });
+};
+
+// File a new copilot-generated report
+export const POST = async (req: Request) => {
+  const body = await req.json().catch(() => null);
+  const title = typeof body?.title === "string" ? body.title.trim() : "";
+  const summary = typeof body?.summary === "string" ? body.summary.trim() : "";
+  const highlights = Array.isArray(body?.highlights)
+    ? body.highlights.filter((h: unknown): h is string => typeof h === "string")
+    : [];
+  const createdBy =
+    typeof body?.createdBy === "string" && body.createdBy.trim()
+      ? body.createdBy.trim()
+      : "Copilot";
+
+  if (!title || !summary) {
+    return new Response(
+      JSON.stringify({ error: "title and summary are required" }),
+      { status: 400 },
+    );
+  }
+
+  const report = store.addReport({ title, summary, highlights, createdBy });
+  return new Response(JSON.stringify(report), { status: 201 });
+};

--- a/examples/showcases/banking/src/app/dashboard/page.tsx
+++ b/examples/showcases/banking/src/app/dashboard/page.tsx
@@ -2,17 +2,13 @@
 import useCreditCards from "@/app/actions";
 import { useMemo, useState } from "react";
 import type { Transaction } from "@/app/api/v1/data";
-import {
-  ArrowDownRight,
-  ArrowUpRight,
-  Eye,
-  Plus,
-  ArrowRight,
-} from "lucide-react";
+import { ArrowDownRight, ArrowUpRight, Plus, ArrowRight } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TransactionsList } from "@/components/transactions-list";
 import { GradientCreditCard } from "@/components/card-visual";
 import { StatisticsChart } from "@/components/statistics-chart";
+import { AnalyticsView } from "@/components/wow/analytics-view";
+import { ReportsView } from "@/components/wow/reports-view";
 import { useAuthContext } from "@/components/auth-context";
 import { useRecording } from "@/components/recording-context";
 import { formatCurrency } from "@/lib/utils";
@@ -400,18 +396,10 @@ export default function HomePage() {
         </TabsContent>
 
         <TabsContent value="analytics">
-          <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-hairline bg-surface/60 p-12 text-center">
-            <Eye className="h-8 w-8 text-ink-muted" />
-            <p className="text-sm text-ink-muted">
-              Analytics view coming soon.
-            </p>
-          </div>
+          <AnalyticsView />
         </TabsContent>
         <TabsContent value="reports">
-          <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-hairline bg-surface/60 p-12 text-center">
-            <Eye className="h-8 w-8 text-ink-muted" />
-            <p className="text-sm text-ink-muted">Reports view coming soon.</p>
-          </div>
+          <ReportsView />
         </TabsContent>
       </Tabs>
     </div>

--- a/examples/showcases/banking/src/app/wrapper.tsx
+++ b/examples/showcases/banking/src/app/wrapper.tsx
@@ -12,6 +12,8 @@ import { ChatInboxProvider } from "@/components/chat/chat-inbox-context";
 import { ChatPanel } from "@/components/chat/chat-panel";
 import { RecordingProvider } from "@/components/recording-context";
 import { RecordingVignette } from "@/components/recording-vignette";
+import { ProactiveNotice } from "@/components/wow/proactive-notice";
+import { ReportCopilotTools } from "@/components/wow/report-tool";
 
 // Static suggestion pills shown on the welcome screen / before-first-message.
 // In v2, suggestions are registered via `useConfigureSuggestions` rather than a
@@ -139,6 +141,8 @@ export function CopilotKitWrapper({ children }: { children: React.ReactNode }) {
               <CopilotContext>{children}</CopilotContext>
             </LayoutComponent>
             <ChatPanel threadId={threadId} />
+            <ProactiveNotice />
+            <ReportCopilotTools />
             <RecordingVignette />
           </RecordingProvider>
         </ChatInboxProvider>

--- a/examples/showcases/banking/src/app/wrapper.tsx
+++ b/examples/showcases/banking/src/app/wrapper.tsx
@@ -15,7 +15,9 @@ import { RecordingVignette } from "@/components/recording-vignette";
 import { ProactiveNotice } from "@/components/wow/proactive-notice";
 import { ReportCopilotTools } from "@/components/wow/report-tool";
 
-// Static suggestion pills shown on the welcome screen / before-first-message.
+// Static suggestion pills — the demo's full use-case catalog, available at
+// ALL times (`available: "always"`), not just the welcome screen: the demo
+// must stay fully click-drivable after every exchange, with zero typing.
 // In v2, suggestions are registered via `useConfigureSuggestions` rather than a
 // prop on the chat component (the v1 `suggestions` prop does not exist on the
 // v2 component — it's omitted from `CopilotChatProps` and supplied via the hook
@@ -35,9 +37,16 @@ import { ReportCopilotTools } from "@/components/wow/report-tool";
 //      learned procedure to a DIFFERENT over-limit charge it was never taught.
 // Titles stay symptom-only: they must NOT hint at the exception path the agent
 // is meant to learn on its own.
+//
+// The remaining pills cover every other use case the demo ships: gen-UI
+// charts, the approvals explainer, report artifacts, and the cross-page
+// operations (PIN change, team invite) that ride navigateToPageAndPerform.
+// Page-scoped fire-and-forget tools (spend alert, card replacement, flag for
+// review) are deliberately NOT pilled: they only exist on the home route, so
+// a global pill for them would be a broken promise on every other page.
 function BankingSuggestions() {
   useConfigureSuggestions({
-    available: "before-first-message",
+    available: "always",
     suggestions: [
       {
         // BEAT 1 — the teachable ask. Seed t-1: Google Ads, -$5,000, Marketing
@@ -71,6 +80,43 @@ function BankingSuggestions() {
         // Breadth — a clean non-arc capability (the generative-UI card flow).
         title: "Add an expense card",
         message: "Add a new expense card",
+      },
+      // ── Gen-UI charts ────────────────────────────────────────────────────
+      {
+        title: "Show the spending trend",
+        message: "Show me the spending trend over time.",
+      },
+      {
+        title: "Budgets near their limit?",
+        message:
+          "Show me budget usage by policy — which ones are close to or over their limit?",
+      },
+      {
+        title: "Where is the money going?",
+        message: "Where is the money going? Break down spend by team.",
+      },
+      {
+        title: "How's our cash flow?",
+        message: "Compare our income vs expenses — how is our cash flow?",
+      },
+      {
+        title: "How do approvals work?",
+        message: "Explain how an over-limit charge gets cleared and approved.",
+      },
+      // ── Work product ─────────────────────────────────────────────────────
+      {
+        title: "Prep the Q2 spend report",
+        message:
+          "Prepare a Q2 spend report for the board: summarize spend against budgets, call out anything over limit or pending, and file it as a report.",
+      },
+      // ── Cross-page operations (navigateToPageAndPerform fallbacks) ──────
+      {
+        title: "Change my card PIN",
+        message: "I want to change the PIN on my Visa card.",
+      },
+      {
+        title: "Invite a team member",
+        message: "Invite a new member to my team.",
       },
     ],
   });

--- a/examples/showcases/banking/src/components/chat/chat-inbox.tsx
+++ b/examples/showcases/banking/src/components/chat/chat-inbox.tsx
@@ -74,7 +74,7 @@ export function ChatInbox({
       data-testid="chat-inbox"
       aria-label="Conversations"
       aria-hidden={!visible}
-      style={{ "--inbox-width": `${width}px` }}
+      style={{ "--inbox-width": `${width}px` } as React.CSSProperties}
       className={cn(
         "fixed top-0 right-0 z-[1300] flex h-[100dvh] max-h-screen w-full flex-col",
         "w-full md:w-[var(--inbox-width)]",

--- a/examples/showcases/banking/src/components/chat/chat-panel.tsx
+++ b/examples/showcases/banking/src/components/chat/chat-panel.tsx
@@ -3,16 +3,18 @@
 import { useLayoutEffect, useRef, useState } from "react";
 import {
   CopilotSidebar,
-  type CopilotSidebarProps,
   useCopilotChatConfiguration,
 } from "@copilotkit/react-core/v2";
+import type { CopilotSidebarProps } from "@copilotkit/react-core/v2";
 
 import { IDENTITY } from "@/lib/identity";
 import { ChatPanelHeader } from "./chat-panel-header";
 import { ChatInbox } from "./chat-inbox";
 
-/** Docked panel width on desktop (px). Mobile falls back to full width. */
-const PANEL_WIDTH = 440;
+/** Docked panel width on desktop (px). Mobile falls back to full width.
+ * Sized so the always-on suggestion pills flow two-per-row instead of
+ * stacking into a single tall column. */
+const PANEL_WIDTH = 560;
 
 /**
  * The docked chat experience: a right-side `CopilotSidebar` that pushes page

--- a/examples/showcases/banking/src/components/copilot-context.tsx
+++ b/examples/showcases/banking/src/components/copilot-context.tsx
@@ -4,7 +4,7 @@ import {
   useComponent,
   useHumanInTheLoop,
 } from "@copilotkit/react-core/v2";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { z } from "zod";
 import useCreditCards from "@/app/actions";
 import { useAuthContext } from "@/components/auth-context";
@@ -68,6 +68,7 @@ const canonicalProcedure = (code: string): string =>
 const CopilotContext = ({ children }: { children: React.ReactNode }) => {
   const { currentUser } = useAuthContext();
   const pathname = usePathname();
+  const router = useRouter();
   const {
     cards,
     policies,
@@ -182,9 +183,17 @@ const CopilotContext = ({ children }: { children: React.ReactNode }) => {
             size="icon"
             onClick={() => {
               const operationParams = `?operation=${operation}`;
-              window.location.href = `${page!.toLowerCase()}${
-                operationAvailable ? operationParams : ""
-              }`;
+              // `/cards` mirrors the dashboard; the card tools/operations
+              // (add card, change PIN) are registered on the home route, so
+              // card requests must land on `/` or the operation dies on
+              // arrival.
+              const target = page === "/cards" ? "/" : page!.toLowerCase();
+              // Client-side navigation: a full reload (window.location) tears
+              // down the chat panel mid-run, so the conversation — and the
+              // in-flight operation — is lost the moment we navigate.
+              router.push(
+                `${target}${operationAvailable ? operationParams : ""}`,
+              );
               respond?.(page!);
             }}
             aria-label="Confirm Navigation"

--- a/examples/showcases/banking/src/components/copilot-context.tsx
+++ b/examples/showcases/banking/src/components/copilot-context.tsx
@@ -11,7 +11,7 @@ import { useAuthContext } from "@/components/auth-context";
 import { useRecording } from "@/components/recording-context";
 import { ApprovalButtons } from "@/components/approval-buttons";
 import { RecordingSteps } from "@/components/recording-feed";
-import { TransactionsList } from "@/components/transactions-list";
+import { PendingApprovalsChat } from "@/components/wow/pending-approvals-chat";
 import {
   SpendingTrendChart,
   BudgetUsageChart,
@@ -216,18 +216,21 @@ const CopilotContext = ({ children }: { children: React.ReactNode }) => {
   });
 
   // Generative-UI: the pending-approval queue, rendered IN the chat. Mirrors the
-  // dashboard's "Pending approval" tab (TransactionsList in approval mode) so the
-  // officer can triage and clear over-limit charges without leaving the
-  // conversation — over-limit rows keep Approve gated and offer "File policy
-  // exception", exactly like the dashboard. Display-only `useComponent` (not
-  // useFrontendTool) so the table persists in the transcript after the call;
+  // dashboard's "Pending approval" tab behaviors (identical over-limit gating,
+  // exception filing, and teach-mode recording payloads) so the officer can
+  // triage and clear over-limit charges without leaving the conversation.
+  // Rendered via PendingApprovalsChat — the dashboard's 4-column table is
+  // ~550px wide and its Actions column lands past the ~375px chat card's edge
+  // (buttons render but cannot be clicked), so the chat uses a stacked layout
+  // with labeled actions instead. Display-only `useComponent` (not
+  // useFrontendTool) so the card persists in the transcript after the call;
   // re-registers when the data changes, or the closure captures empty arrays.
   useComponent(
     {
       name: "showPendingApprovals",
       description:
         "Show the queue of transactions awaiting approval (including over-limit " +
-        "charges) as an interactive table in the chat. Call this whenever the " +
+        "charges) as an interactive list in the chat. Call this whenever the " +
         "user asks what is pending, what needs approval, or to review pending or " +
         "over-limit charges — do NOT answer those in plain text.",
       parameters: z.object({}),
@@ -245,19 +248,17 @@ const CopilotContext = ({ children }: { children: React.ReactNode }) => {
             <h3 className="text-lg font-semibold text-ink">
               Pending approvals
             </h3>
-            <TransactionsList
+            <PendingApprovalsChat
               transactions={pending}
               policies={policies}
               openPolicyException={openPolicyException}
               finalizePolicyException={finalizePolicyException}
-              showApprovalInterface
-              approvalInterfaceProps={{
-                onApprove: async (id) =>
-                  (await changeTransactionStatus({ id, status: "approved" }))
-                    .ok,
-                onDeny: async (id) =>
-                  (await changeTransactionStatus({ id, status: "denied" })).ok,
-              }}
+              onApprove={async (id) =>
+                (await changeTransactionStatus({ id, status: "approved" })).ok
+              }
+              onDeny={async (id) =>
+                (await changeTransactionStatus({ id, status: "denied" })).ok
+              }
             />
           </div>
         );

--- a/examples/showcases/banking/src/components/statistics-chart.tsx
+++ b/examples/showcases/banking/src/components/statistics-chart.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo } from "react";
+import { useId, useMemo, useRef, useState } from "react";
 import { formatCurrency } from "@/lib/utils";
 
 interface StatisticsChartProps {
@@ -12,11 +12,19 @@ interface StatisticsChartProps {
   className?: string;
 }
 
+/** Compact dollar label for axis ticks: $6.4k, $980. */
+const fmtCompact = (v: number): string =>
+  Math.abs(v) >= 1000
+    ? `$${(v / 1000).toFixed(1).replace(/\.0$/, "")}k`
+    : formatCurrency(v);
+
 /**
- * Lightweight hand-rolled SVG area + line "sparkline" — no charting dependency.
- * Renders a violet→indigo gradient stroke over a soft gradient area fill, with
- * the most recent point emphasized and labelled. Purely presentational; the
- * caller feeds it numbers derived from real data (falls back to seeded points).
+ * Lightweight hand-rolled SVG area + line chart — no charting dependency.
+ * Violet→indigo gradient stroke over a soft area fill, with a labelled y-axis
+ * (three $-gridlines), x-axis labels, and an interactive hover: moving the
+ * pointer across the chart highlights the nearest point and shows its exact
+ * label + amount in a tooltip. The caller feeds it numbers derived from real
+ * data (falls back to seeded points).
  */
 export function StatisticsChart({
   data,
@@ -27,24 +35,31 @@ export function StatisticsChart({
 }: StatisticsChartProps) {
   const gradientId = useId();
   const areaId = useId();
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [hovered, setHovered] = useState<number | null>(null);
 
-  const { linePath, areaPath, points, max, min } = useMemo(() => {
+  // Left gutter reserves room for the y-axis dollar labels.
+  const padL = 40;
+  const padR = 10;
+  const padY = 16;
+
+  const { linePath, areaPath, points, ticks } = useMemo(() => {
     const series = data.length >= 2 ? data : [0, 0];
-    const padX = 8;
-    const padY = 16;
-    const innerW = width - padX * 2;
+    const innerW = width - padL - padR;
     const innerH = height - padY * 2;
 
     const maxV = Math.max(...series);
     const minV = Math.min(...series);
     const span = maxV - minV || 1;
 
-    const pts = series.map((value, i) => {
-      const x = padX + (innerW * i) / (series.length - 1);
-      // Invert Y (SVG origin is top-left); keep a little headroom.
-      const y = padY + innerH - ((value - minV) / span) * innerH;
-      return { x, y, value };
-    });
+    const toY = (value: number) =>
+      padY + innerH - ((value - minV) / span) * innerH;
+
+    const pts = series.map((value, i) => ({
+      x: padL + (innerW * i) / (series.length - 1),
+      y: toY(value),
+      value,
+    }));
 
     // Smooth-ish line via simple cubic segments between consecutive points.
     const toPath = (nodes: typeof pts) =>
@@ -60,50 +75,114 @@ export function StatisticsChart({
     const line = toPath(pts);
     const area = `${line} L ${pts[pts.length - 1].x} ${height - padY} L ${pts[0].x} ${height - padY} Z`;
 
-    return {
-      linePath: line,
-      areaPath: area,
-      points: pts,
-      max: maxV,
-      min: minV,
-    };
+    // Three horizontal gridlines: min, midpoint, max of the series.
+    const tickValues = [minV, minV + span / 2, maxV];
+    const axisTicks = tickValues.map((value) => ({ value, y: toY(value) }));
+
+    return { linePath: line, areaPath: area, points: pts, ticks: axisTicks };
   }, [data, width, height]);
 
   const last = points[points.length - 1];
+  const active = hovered != null ? points[hovered] : null;
+
+  // Map pointer x (container px) to the nearest data point. Points are evenly
+  // spaced, so a proportional index lookup is exact.
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const el = wrapRef.current;
+    if (!el || points.length < 2) return;
+    const rect = el.getBoundingClientRect();
+    const relX = ((e.clientX - rect.left) / rect.width) * width;
+    const innerW = width - padL - padR;
+    const idx = Math.round(((relX - padL) / innerW) * (points.length - 1));
+    setHovered(Math.max(0, Math.min(points.length - 1, idx)));
+  };
 
   return (
     <div className={className}>
-      <svg
-        viewBox={`0 0 ${width} ${height}`}
-        className="h-auto w-full overflow-visible"
-        role="img"
-        aria-label="Spending statistics trend"
-        preserveAspectRatio="none"
+      <div
+        ref={wrapRef}
+        className="relative"
+        onPointerMove={onPointerMove}
+        onPointerLeave={() => setHovered(null)}
+        data-testid="statistics-chart"
       >
-        <defs>
-          <linearGradient id={gradientId} x1="0" y1="0" x2="1" y2="0">
-            <stop offset="0%" stopColor="hsl(252 83% 67%)" />
-            <stop offset="100%" stopColor="hsl(248 84% 60%)" />
-          </linearGradient>
-          <linearGradient id={areaId} x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stopColor="hsl(252 83% 67% / 0.28)" />
-            <stop offset="100%" stopColor="hsl(252 83% 67% / 0)" />
-          </linearGradient>
-        </defs>
+        <svg
+          viewBox={`0 0 ${width} ${height}`}
+          className="h-auto w-full overflow-visible"
+          role="img"
+          aria-label="Spending statistics trend"
+        >
+          <defs>
+            <linearGradient id={gradientId} x1="0" y1="0" x2="1" y2="0">
+              <stop offset="0%" stopColor="hsl(252 83% 67%)" />
+              <stop offset="100%" stopColor="hsl(248 84% 60%)" />
+            </linearGradient>
+            <linearGradient id={areaId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="hsl(252 83% 67% / 0.28)" />
+              <stop offset="100%" stopColor="hsl(252 83% 67% / 0)" />
+            </linearGradient>
+          </defs>
 
-        <path d={areaPath} fill={`url(#${areaId})`} />
-        <path
-          d={linePath}
-          fill="none"
-          stroke={`url(#${gradientId})`}
-          strokeWidth={2.5}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
+          {/* Y-axis gridlines + compact dollar labels */}
+          {ticks.map((tick) => (
+            <g key={tick.y}>
+              <line
+                x1={padL}
+                x2={width - padR}
+                y1={tick.y}
+                y2={tick.y}
+                stroke="currentColor"
+                className="text-hairline"
+                strokeDasharray="3 4"
+                strokeWidth={1}
+              />
+              <text
+                x={padL - 6}
+                y={tick.y + 3}
+                textAnchor="end"
+                fontSize={10}
+                fill="currentColor"
+                className="text-ink-muted"
+              >
+                {fmtCompact(tick.value)}
+              </text>
+            </g>
+          ))}
 
-        {/* Emphasized latest point */}
-        {last && (
-          <>
+          <path d={areaPath} fill={`url(#${areaId})`} />
+          <path
+            d={linePath}
+            fill="none"
+            stroke={`url(#${gradientId})`}
+            strokeWidth={2.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+
+          {/* Hover guide: vertical line + highlighted point */}
+          {active && (
+            <>
+              <line
+                x1={active.x}
+                x2={active.x}
+                y1={padY}
+                y2={height - padY}
+                stroke="hsl(248 84% 60% / 0.35)"
+                strokeWidth={1}
+              />
+              <circle
+                cx={active.x}
+                cy={active.y}
+                r={5}
+                fill="white"
+                stroke="hsl(248 84% 60%)"
+                strokeWidth={2.5}
+              />
+            </>
+          )}
+
+          {/* Emphasized latest point (hidden while hovering another) */}
+          {last && (!active || active === last) && (
             <circle
               cx={last.x}
               cy={last.y}
@@ -112,12 +191,38 @@ export function StatisticsChart({
               stroke="hsl(248 84% 60%)"
               strokeWidth={3}
             />
-          </>
-        )}
-      </svg>
+          )}
+        </svg>
 
-      {/* Emphasized value label + axis labels, in HTML for crisp text. */}
-      <div className="mt-2 flex items-center justify-between text-[0.7rem] text-ink-muted">
+        {/* Tooltip: exact label + amount for the hovered point */}
+        {active && (
+          <div
+            className="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-lg border border-hairline bg-surface px-2.5 py-1.5 text-xs shadow-soft"
+            style={{
+              left: `${(active.x / width) * 100}%`,
+              top: `${(active.y / height) * 100}%`,
+              marginTop: "-8px",
+            }}
+            data-testid="statistics-chart-tooltip"
+          >
+            {hovered != null && labels?.[hovered] ? (
+              <span className="mr-1.5 text-ink-muted">{labels[hovered]}</span>
+            ) : null}
+            <span className="font-semibold text-ink">
+              {formatCurrency(active.value)}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* X-axis labels, in HTML for crisp text; aligned under the plot area. */}
+      <div
+        className="mt-2 flex items-center justify-between text-[0.7rem] text-ink-muted"
+        style={{
+          paddingLeft: `${(padL / width) * 100}%`,
+          paddingRight: `${(padR / width) * 100}%`,
+        }}
+      >
         {(labels ?? []).map((label, i) => (
           <span
             key={`${label}-${i}`}
@@ -132,8 +237,8 @@ export function StatisticsChart({
         ))}
       </div>
       <p className="sr-only">
-        Latest {formatCurrency(last?.value ?? 0)}; range {formatCurrency(min)}–
-        {formatCurrency(max)}.
+        Latest {formatCurrency(last?.value ?? 0)}; range{" "}
+        {formatCurrency(Math.min(...data))}–{formatCurrency(Math.max(...data))}.
       </p>
     </div>
   );

--- a/examples/showcases/banking/src/components/wow/analytics-view.tsx
+++ b/examples/showcases/banking/src/components/wow/analytics-view.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import useCreditCards from "@/app/actions";
+import {
+  SpendingTrendChart,
+  BudgetUsageChart,
+  SpendBreakdownChart,
+  IncomeExpenseChart,
+} from "@/components/analytics-charts";
+import { ChartCard } from "./chart-pills";
+
+/**
+ * The dashboard's Analytics tab: the four brand charts (previously summonable
+ * only inside the chat) rendered as a dashboard view, each carrying its own
+ * conversation-starter pills. Every question a viewer might ask of a chart is
+ * one click away — no typing.
+ */
+export function AnalyticsView() {
+  const { policies, transactions } = useCreditCards();
+
+  return (
+    <div className="grid gap-5 md:grid-cols-2">
+      <ChartCard
+        title="Spending trend"
+        pills={[
+          {
+            label: "Explain this spike",
+            message:
+              "Looking at the spending trend chart on the Analytics tab: explain the biggest spike — which transactions caused it?",
+          },
+          {
+            label: "Summarize the trend",
+            message:
+              "Summarize the spending trend over time in a couple of sentences. What should I be paying attention to?",
+          },
+        ]}
+      >
+        <SpendingTrendChart transactions={transactions} />
+      </ChartCard>
+
+      <ChartCard
+        title="Budget usage by policy"
+        pills={[
+          {
+            label: "Who's closest to their limit?",
+            message:
+              "Looking at the budget usage chart: which expense policy is closest to its limit, and what's driving that usage?",
+          },
+          {
+            label: "Anything over budget?",
+            message:
+              "Are any expense policies over their limit, or at risk of going over? Show me the budget usage.",
+          },
+        ]}
+      >
+        <BudgetUsageChart policies={policies} />
+      </ChartCard>
+
+      <ChartCard
+        title="Spend breakdown"
+        pills={[
+          {
+            label: "Where is the money going?",
+            message:
+              "Looking at the spend breakdown chart: where is most of the money going, by team?",
+          },
+          {
+            label: "Which team drove this?",
+            message:
+              "Which team drove the most spend, and which transactions were the biggest contributors?",
+          },
+        ]}
+      >
+        <SpendBreakdownChart policies={policies} />
+      </ChartCard>
+
+      <ChartCard
+        title="Income vs expenses"
+        pills={[
+          {
+            label: "Explain our net position",
+            message:
+              "Looking at the income vs expenses chart: explain our net position in plain terms.",
+          },
+          {
+            label: "How's our cash flow?",
+            message:
+              "How does our income compare to our expenses right now, and is anything unusual?",
+          },
+        ]}
+      >
+        <IncomeExpenseChart transactions={transactions} />
+      </ChartCard>
+    </div>
+  );
+}
+
+export default AnalyticsView;

--- a/examples/showcases/banking/src/components/wow/chart-pills.tsx
+++ b/examples/showcases/banking/src/components/wow/chart-pills.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Sparkles } from "lucide-react";
+import { useAskCopilot } from "./use-ask-copilot";
+
+export interface ChartPill {
+  /** Short label shown on the pill. */
+  label: string;
+  /** Full message sent to the copilot when the pill is clicked. */
+  message: string;
+}
+
+/**
+ * "Talk to what you see": wraps a dashboard chart in a card that carries its
+ * own conversation starters. Each pill sends a preset, chart-specific prompt
+ * to the copilot — the agent already sees the full dataset via the global
+ * useAgentContext readables, so the answer is grounded in exactly the data
+ * the chart renders, and its gen-UI drill-down components (showBudgetUsage
+ * etc.) give the visual follow-up in chat.
+ */
+export function ChartCard({
+  title,
+  pills,
+  children,
+}: {
+  title: string;
+  pills: ChartPill[];
+  children: React.ReactNode;
+}) {
+  const askCopilot = useAskCopilot();
+
+  return (
+    <section
+      data-testid={`chart-card-${title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`}
+      className="flex flex-col gap-3 rounded-2xl border border-hairline bg-surface p-5 shadow-soft"
+    >
+      <h3 className="section-heading text-base">{title}</h3>
+      <div className="flex-1">{children}</div>
+      <div className="flex flex-wrap items-center gap-2 border-t border-hairline pt-3">
+        <Sparkles
+          className="h-3.5 w-3.5 shrink-0 text-brand-indigo dark:text-brand-violet"
+          aria-hidden
+        />
+        {pills.map((pill) => (
+          <button
+            key={pill.label}
+            type="button"
+            onClick={() => askCopilot(pill.message)}
+            className="rounded-full border border-hairline bg-brand-soft/60 px-3 py-1 text-xs font-medium text-brand-indigo transition-colors hover:bg-brand-soft dark:text-brand-violet"
+          >
+            {pill.label}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default ChartCard;

--- a/examples/showcases/banking/src/components/wow/pending-approvals-chat.tsx
+++ b/examples/showcases/banking/src/components/wow/pending-approvals-chat.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useState } from "react";
+import {
+  AlertTriangle,
+  ArrowDownRight,
+  ArrowUpRight,
+  FileText,
+  ShieldCheck,
+} from "lucide-react";
+import type {
+  ExpensePolicy,
+  PolicyException,
+  Transaction,
+} from "@/app/api/v1/data";
+import { Button } from "@/components/ui/button";
+import { PolicyExceptionInline } from "@/components/policy-exception-inline";
+import { useRecording } from "@/components/recording-context";
+import { useRecordUserActionInCurrentThread } from "@/lib/record-user-action";
+import { cn, formatCurrency } from "@/lib/utils";
+
+// Same locally-declared result shape every exception-filing surface uses
+// (transactions-list, policy-exception-inline/-modal).
+type ExceptionResult = {
+  ok: boolean;
+  data?: PolicyException;
+  error?: string;
+};
+
+interface PendingApprovalsChatProps {
+  transactions: Transaction[];
+  policies: ExpensePolicy[];
+  onApprove: (id: string) => Promise<boolean>;
+  onDeny: (id: string) => Promise<boolean>;
+  openPolicyException: (args: {
+    transactionId: string;
+    code: string;
+  }) => Promise<ExceptionResult>;
+  finalizePolicyException: (args: {
+    exceptionId: string;
+  }) => Promise<ExceptionResult>;
+}
+
+/**
+ * Chat-width pending-approvals queue. The dashboard's approval table
+ * (TransactionsList) is a 4-column, ~550px layout — inside the ~375px chat
+ * card its Actions column lands past the card edge, so the buttons render
+ * but cannot be clicked. This stacks each charge as a card with labeled,
+ * full-width actions instead.
+ *
+ * Behavioral parity with the dashboard table is deliberate and exact:
+ * identical over-limit/cleared derivation, identical recordUserAction
+ * payloads and logStep narration (teach-mode distills from these), and the
+ * same PolicyExceptionInline form for filing exceptions — so an officer can
+ * demonstrate the unlock inside the chat exactly as they can on the
+ * dashboard.
+ */
+export function PendingApprovalsChat({
+  transactions,
+  policies,
+  onApprove,
+  onDeny,
+  openPolicyException,
+  finalizePolicyException,
+}: PendingApprovalsChatProps) {
+  const recordUserAction = useRecordUserActionInCurrentThread();
+  const { beginRecording, endRecording, logStep } = useRecording();
+  const [exceptionTxnId, setExceptionTxnId] = useState<string | null>(null);
+
+  const statusOf = (transaction: Transaction) => {
+    const policy = policies.find((p) => p.id === transaction.policyId);
+    const policyOver =
+      !!policy && policy.spent + Math.abs(transaction.amount) > policy.limit;
+    return {
+      overLimit: policyOver && !transaction.activeExceptionId,
+      cleared: policyOver && !!transaction.activeExceptionId,
+    };
+  };
+
+  // Mirrors TransactionsList.handleApprove: record only when the server
+  // mutation took effect, with the identical payload the distiller expects.
+  const handleApprove = async (id: string): Promise<void> => {
+    const ok = await onApprove(id);
+    if (!ok) return;
+    logStep("Approved the charge");
+    beginRecording();
+    recordUserAction({
+      title: "transaction.approved",
+      description:
+        "User approved a pending transaction from the transactions view.",
+      previousData: { status: "pending" },
+      newData: { status: "approved" },
+      metadata: { transactionId: id },
+    })
+      .catch(console.error)
+      .finally(() => endRecording());
+  };
+
+  const handleDeny = async (id: string): Promise<void> => {
+    const ok = await onDeny(id);
+    if (!ok) return;
+    beginRecording();
+    recordUserAction({
+      title: "transaction.denied",
+      description:
+        "User denied a pending transaction from the transactions view.",
+      previousData: { status: "pending" },
+      newData: { status: "denied" },
+      metadata: { transactionId: id },
+    })
+      .catch(console.error)
+      .finally(() => endRecording());
+  };
+
+  if (!transactions.length) {
+    return (
+      <p className="text-sm text-ink-muted">
+        No transactions are pending approval.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3" data-testid="pending-approvals-chat">
+      {transactions.map((transaction) => {
+        const isIncome = transaction.amount > 0;
+        const { overLimit, cleared } = statusOf(transaction);
+        const isExpanded = exceptionTxnId === transaction.id;
+        return (
+          <div
+            key={transaction.id}
+            className="space-y-3 rounded-xl border border-hairline/70 bg-surface-muted/40 p-3"
+          >
+            <div className="flex items-center gap-3">
+              <span
+                className={cn(
+                  "flex h-9 w-9 flex-none items-center justify-center rounded-full",
+                  isIncome
+                    ? "bg-positive-soft text-positive"
+                    : "bg-negative-soft text-negative",
+                )}
+              >
+                {isIncome ? (
+                  <ArrowUpRight className="h-4 w-4" />
+                ) : (
+                  <ArrowDownRight className="h-4 w-4" />
+                )}
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="truncate font-semibold leading-tight text-ink">
+                  {transaction.title}
+                </p>
+                <p className="text-xs leading-tight text-ink-muted">
+                  {transaction.date}
+                </p>
+              </div>
+              <p
+                className={cn(
+                  "whitespace-nowrap font-semibold tabular-nums",
+                  isIncome ? "text-positive" : "text-negative",
+                )}
+              >
+                {isIncome ? "+" : ""}
+                {formatCurrency(transaction.amount)}
+              </p>
+            </div>
+
+            {overLimit ? (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-negative-soft px-2.5 py-1 text-xs font-medium text-negative ring-1 ring-inset ring-negative/30">
+                <AlertTriangle className="h-3.5 w-3.5" />
+                Over limit — file a policy exception to approve
+              </span>
+            ) : cleared ? (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-positive-soft px-2.5 py-1 text-xs font-medium text-positive ring-1 ring-inset ring-positive/30">
+                <ShieldCheck className="h-3.5 w-3.5" />
+                Cleared
+              </span>
+            ) : null}
+
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={overLimit}
+                onClick={() => void handleApprove(transaction.id)}
+                className="rounded-full border-transparent bg-positive-soft text-positive hover:bg-positive-soft hover:brightness-95 disabled:opacity-40"
+              >
+                Approve
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => void handleDeny(transaction.id)}
+                className="rounded-full border-transparent bg-negative-soft text-negative hover:bg-negative-soft hover:brightness-95"
+              >
+                Deny
+              </Button>
+              {overLimit && !isExpanded && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    logStep("Opened the exception form");
+                    setExceptionTxnId(transaction.id);
+                  }}
+                  className="rounded-full bg-surface text-ink-muted hover:bg-surface-muted"
+                >
+                  <FileText className="mr-1.5 h-3.5 w-3.5" />
+                  File exception
+                </Button>
+              )}
+            </div>
+
+            {isExpanded && (
+              <PolicyExceptionInline
+                transactionId={transaction.id}
+                openPolicyException={openPolicyException}
+                finalizePolicyException={finalizePolicyException}
+                onFiled={() => setExceptionTxnId(null)}
+                onCancel={() => setExceptionTxnId(null)}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default PendingApprovalsChat;

--- a/examples/showcases/banking/src/components/wow/proactive-notice.tsx
+++ b/examples/showcases/banking/src/components/wow/proactive-notice.tsx
@@ -10,9 +10,10 @@ import { useAskCopilot } from "./use-ask-copilot";
 // reads as a static banner, arriving late reads as an agent observation.
 const APPEAR_DELAY_MS = 1200;
 
-// Session-scoped so a dismiss doesn't nag on every navigation, but a fresh
-// browser context (each booth visitor / each Playwright run) sees it again.
-const DISMISSED_KEY = "banking-proactive-notice-dismissed";
+// Dismissal is per page load (component state), NOT persisted: the notice is
+// the demo's opening beat, so every fresh load must fire it again. Within a
+// load it never re-nags — the wrapper stays mounted across client-side route
+// changes, so the `engaged` flag survives navigation until a hard reload.
 
 /**
  * Proactive copilot opener: on load, when pending charges have breached their
@@ -51,7 +52,6 @@ export function ProactiveNotice() {
 
   useEffect(() => {
     if (engaged || breachedCount === 0) return;
-    if (sessionStorage.getItem(DISMISSED_KEY)) return;
     const timer = setTimeout(() => setVisible(true), APPEAR_DELAY_MS);
     return () => clearTimeout(timer);
   }, [breachedCount, engaged]);
@@ -59,14 +59,11 @@ export function ProactiveNotice() {
   if (!visible || engaged || breachedCount === 0) return null;
 
   const dismiss = () => {
-    sessionStorage.setItem(DISMISSED_KEY, "1");
+    setEngaged(true);
     setVisible(false);
   };
 
   const review = () => {
-    // Mark the session either way: once the user has engaged, the observation
-    // is delivered — re-surfacing it on the next navigation reads as nagging.
-    sessionStorage.setItem(DISMISSED_KEY, "1");
     setEngaged(true);
     setVisible(false);
     void askCopilot(

--- a/examples/showcases/banking/src/components/wow/proactive-notice.tsx
+++ b/examples/showcases/banking/src/components/wow/proactive-notice.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import useCreditCards from "@/app/actions";
+import { Button } from "@/components/ui/button";
+import { useAskCopilot } from "./use-ask-copilot";
+
+// How long after page paint the notice appears. The beat matters: the
+// dashboard renders first, then the copilot "notices" — arriving together
+// reads as a static banner, arriving late reads as an agent observation.
+const APPEAR_DELAY_MS = 1200;
+
+// Session-scoped so a dismiss doesn't nag on every navigation, but a fresh
+// browser context (each booth visitor / each Playwright run) sees it again.
+const DISMISSED_KEY = "banking-proactive-notice-dismissed";
+
+/**
+ * Proactive copilot opener: on load, when pending charges have breached their
+ * policy limit, the copilot surfaces the observation unprompted and offers to
+ * walk through them. Accepting opens the docked panel and sends the request on
+ * the user's behalf — the same addMessage + runAgent path a suggestion-pill
+ * click takes, so the conversation reads exactly as if the user had asked.
+ *
+ * The offer deliberately asks the agent to REVIEW the breaches (which renders
+ * the interactive pending-approvals queue), not to clear them: clearing an
+ * over-limit charge is the teach-mode arc's territory, and this notice must
+ * work identically before and after the agent has learned that procedure.
+ */
+export function ProactiveNotice() {
+  const { policies, transactions } = useCreditCards();
+  const askCopilot = useAskCopilot();
+
+  const [visible, setVisible] = useState(false);
+  const [engaged, setEngaged] = useState(false);
+
+  // Same over-limit formula the agent context uses: over the policy limit and
+  // not already covered by an active exception.
+  const breachedCount = useMemo(
+    () =>
+      transactions.filter((t) => {
+        if (t.status !== "pending") return false;
+        const policy = policies.find((p) => p.id === t.policyId);
+        return (
+          !!policy &&
+          policy.spent + Math.abs(t.amount) > policy.limit &&
+          !t.activeExceptionId
+        );
+      }).length,
+    [transactions, policies],
+  );
+
+  useEffect(() => {
+    if (engaged || breachedCount === 0) return;
+    if (sessionStorage.getItem(DISMISSED_KEY)) return;
+    const timer = setTimeout(() => setVisible(true), APPEAR_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [breachedCount, engaged]);
+
+  if (!visible || engaged || breachedCount === 0) return null;
+
+  const dismiss = () => {
+    sessionStorage.setItem(DISMISSED_KEY, "1");
+    setVisible(false);
+  };
+
+  const review = () => {
+    // Mark the session either way: once the user has engaged, the observation
+    // is delivered — re-surfacing it on the next navigation reads as nagging.
+    sessionStorage.setItem(DISMISSED_KEY, "1");
+    setEngaged(true);
+    setVisible(false);
+    void askCopilot(
+      "Show me the pending charges that have breached their policy limits and walk me through what needs attention.",
+    );
+  };
+
+  return (
+    <div
+      role="status"
+      data-testid="proactive-notice"
+      className="fixed bottom-24 right-6 z-50 w-[22rem] max-w-[calc(100vw-3rem)] animate-in fade-in slide-in-from-bottom-4 space-y-3 rounded-2xl border border-hairline bg-surface p-4 text-ink shadow-soft"
+    >
+      <div className="flex items-center gap-2">
+        <span className="relative flex h-2.5 w-2.5" aria-hidden>
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-brand-indigo opacity-60" />
+          <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-brand-indigo" />
+        </span>
+        <h3 className="text-sm font-semibold text-ink">
+          Your copilot noticed something
+        </h3>
+      </div>
+      <p className="text-sm text-ink-muted">
+        {breachedCount === 1
+          ? "A pending charge has breached its policy limit."
+          : `${breachedCount} pending charges have breached their policy limits.`}{" "}
+        Want me to walk you through {breachedCount === 1 ? "it" : "them"}?
+      </p>
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          onClick={review}
+          data-testid="proactive-notice-review"
+          className="rounded-full bg-brand-soft text-brand-indigo hover:bg-brand-soft/70 dark:text-brand-violet"
+          variant="outline"
+        >
+          Review with Copilot
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={dismiss}
+          data-testid="proactive-notice-dismiss"
+          className="rounded-full bg-surface-muted text-ink-muted hover:bg-surface-muted/70"
+        >
+          Dismiss
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default ProactiveNotice;

--- a/examples/showcases/banking/src/components/wow/report-tool.tsx
+++ b/examples/showcases/banking/src/components/wow/report-tool.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+import { useAuthContext } from "@/components/auth-context";
+
+/** Window event fired whenever a report is filed, so the Reports tab refetches. */
+export const REPORTS_CHANGED_EVENT = "banking:reports-changed";
+
+/**
+ * Registers the copilot's report-writing capability. Global (mounted in the
+ * wrapper) so "prep a report" works from any page. The agent writes the
+ * narrative from the data it already sees via useAgentContext; the artifact
+ * is filed to the store through the REST layer and lands in the dashboard's
+ * Reports tab — durable work product, not a chat bubble.
+ */
+export function ReportCopilotTools() {
+  const { currentUser } = useAuthContext();
+
+  useFrontendTool({
+    name: "createReport",
+    description:
+      "Create a written report and file it in the dashboard's Reports tab. " +
+      "Call this whenever the user asks for a report, a summary for the " +
+      "board, or a write-up of spend/budgets/transactions. Base the summary " +
+      "and highlights on the actual card/policy/transaction data you can " +
+      "see. After filing, tell the user the report is waiting in the " +
+      "Reports tab of the dashboard.",
+    parameters: z.object({
+      title: z
+        .string()
+        .describe('A concise report title, e.g. "Q2 Spend Report".'),
+      summary: z
+        .string()
+        .describe(
+          "2-4 sentence executive summary of the findings, grounded in the real data.",
+        ),
+      highlights: z
+        .array(z.string())
+        .describe(
+          "3-6 short bullet highlights: key figures, risks, and recommendations.",
+        ),
+    }),
+    handler: async ({ title, summary, highlights }) => {
+      const res = await fetch("/api/v1/reports", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title,
+          summary,
+          highlights,
+          createdBy: `Copilot, for ${currentUser.name}`,
+        }),
+      });
+      if (!res.ok) {
+        return `Could not file the report (HTTP ${res.status}).`;
+      }
+      const report = await res.json();
+      window.dispatchEvent(new Event(REPORTS_CHANGED_EVENT));
+      return (
+        `Report "${report.title}" filed in the dashboard's Reports tab. ` +
+        "Tell the user it is ready there and give a one-line summary — do not repeat the whole report in chat."
+      );
+    },
+  });
+
+  return null;
+}
+
+export default ReportCopilotTools;

--- a/examples/showcases/banking/src/components/wow/reports-view.tsx
+++ b/examples/showcases/banking/src/components/wow/reports-view.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { FileText, Sparkles } from "lucide-react";
+import type { Report } from "@/app/api/v1/data";
+import useCreditCards from "@/app/actions";
+import {
+  SpendBreakdownChart,
+  IncomeExpenseChart,
+} from "@/components/analytics-charts";
+import { useAskCopilot } from "./use-ask-copilot";
+import { REPORTS_CHANGED_EVENT } from "./report-tool";
+
+const REPORT_PILL_MESSAGE =
+  "Prepare a Q2 spend report for the board: summarize spend against budgets, call out anything over limit or pending, and file it as a report.";
+
+/**
+ * The dashboard's Reports tab: copilot-generated artifacts that outlive the
+ * conversation. The narrative (summary + highlights) is the agent's; the
+ * charts are rendered live from the same data the narrative describes. Empty
+ * state carries the pill that asks the copilot to write the first one.
+ */
+export function ReportsView() {
+  const askCopilot = useAskCopilot();
+  const { policies, transactions } = useCreditCards();
+  const [reports, setReports] = useState<Report[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch("/api/v1/reports");
+      if (res.ok) setReports(await res.json());
+    } finally {
+      setLoaded(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    window.addEventListener(REPORTS_CHANGED_EVENT, refresh);
+    return () => window.removeEventListener(REPORTS_CHANGED_EVENT, refresh);
+  }, [refresh]);
+
+  if (!loaded) return null;
+
+  if (!reports.length) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-hairline bg-surface/60 p-12 text-center">
+        <FileText className="h-8 w-8 text-ink-muted" />
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-ink">No reports yet</p>
+          <p className="text-sm text-ink-muted">
+            Ask the copilot to write one — it files the finished report right
+            here.
+          </p>
+        </div>
+        <button
+          type="button"
+          data-testid="reports-empty-pill"
+          onClick={() => askCopilot(REPORT_PILL_MESSAGE)}
+          className="flex items-center gap-2 rounded-full border border-hairline bg-brand-soft/60 px-4 py-2 text-sm font-medium text-brand-indigo transition-colors hover:bg-brand-soft dark:text-brand-violet"
+        >
+          <Sparkles className="h-4 w-4" aria-hidden />
+          Prep the Q2 spend report for the board
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      {reports.map((report) => (
+        <article
+          key={report.id}
+          data-testid="report-card"
+          className="space-y-4 rounded-2xl border border-hairline bg-surface p-6 shadow-soft"
+        >
+          <header className="flex flex-wrap items-baseline justify-between gap-2">
+            <h3 className="text-lg font-semibold text-ink">{report.title}</h3>
+            <p className="text-xs text-ink-muted">
+              {new Date(report.createdAt).toLocaleString()} · {report.createdBy}
+            </p>
+          </header>
+          <p className="text-sm leading-relaxed text-ink">{report.summary}</p>
+          {report.highlights.length > 0 && (
+            <ul className="list-disc space-y-1 pl-5 text-sm text-ink">
+              {report.highlights.map((highlight) => (
+                <li key={highlight}>{highlight}</li>
+              ))}
+            </ul>
+          )}
+          <div className="grid gap-5 border-t border-hairline pt-4 md:grid-cols-2">
+            <div>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-ink-muted">
+                Spend breakdown
+              </p>
+              <SpendBreakdownChart policies={policies} />
+            </div>
+            <div>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-ink-muted">
+                Income vs expenses
+              </p>
+              <IncomeExpenseChart transactions={transactions} />
+            </div>
+          </div>
+        </article>
+      ))}
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => askCopilot(REPORT_PILL_MESSAGE)}
+          className="flex items-center gap-2 rounded-full border border-hairline bg-brand-soft/60 px-3 py-1.5 text-xs font-medium text-brand-indigo transition-colors hover:bg-brand-soft dark:text-brand-violet"
+        >
+          <Sparkles className="h-3.5 w-3.5" aria-hidden />
+          Ask for another report
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default ReportsView;

--- a/examples/showcases/banking/src/components/wow/use-ask-copilot.ts
+++ b/examples/showcases/banking/src/components/wow/use-ask-copilot.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useCallback } from "react";
+import {
+  useAgent,
+  useCopilotChatConfiguration,
+  useCopilotKit,
+} from "@copilotkit/react-core/v2";
+
+/**
+ * Send a message to the copilot on the user's behalf: opens the docked panel,
+ * appends the message, and starts a run — the same addMessage + runAgent path
+ * a suggestion-pill click takes inside CopilotChat, so the conversation reads
+ * exactly as if the user had typed it. Used by every in-app "ask the copilot"
+ * surface (proactive notice, chart pills, report actions).
+ */
+export function useAskCopilot() {
+  const { agent } = useAgent({ agentId: "default" });
+  const { copilotkit } = useCopilotKit();
+  const configuration = useCopilotChatConfiguration();
+  const setModalOpen = configuration?.setModalOpen;
+
+  return useCallback(
+    async (message: string) => {
+      setModalOpen?.(true);
+      agent.addMessage({
+        id: crypto.randomUUID(),
+        role: "user",
+        content: message,
+      });
+      try {
+        await copilotkit.runAgent({ agent });
+      } catch (error) {
+        console.error("askCopilot: runAgent failed", error);
+      }
+    },
+    [agent, copilotkit, setModalOpen],
+  );
+}
+
+export default useAskCopilot;

--- a/examples/showcases/banking/src/lib/store.ts
+++ b/examples/showcases/banking/src/lib/store.ts
@@ -4,6 +4,7 @@ import type {
   ExpensePolicy,
   Member,
   PolicyException,
+  Report,
   Transaction,
 } from "@/app/api/v1/data";
 import { generateUniqueId } from "@/app/api/v1/data";
@@ -31,9 +32,15 @@ type DB = {
   policies: ExpensePolicy[];
   transactions: Transaction[];
   exceptions: PolicyException[];
+  reports: Report[];
 };
 
-const db = structuredClone(seed) as DB;
+// Reports are copilot-generated at runtime and never seeded, so the JSON
+// seam cast covers only the seeded collections.
+const db: DB = {
+  ...(structuredClone(seed) as Omit<DB, "reports">),
+  reports: [],
+};
 // Older seeds (pre-policy-exception) may not carry an `exceptions` array.
 // Guarantee it exists so the accessors/mutators below never hit undefined.
 if (!db.exceptions) db.exceptions = [];
@@ -45,6 +52,7 @@ export const team = (): Member[] => db.team;
 export const policies = (): ExpensePolicy[] => db.policies;
 export const transactions = (): Transaction[] => db.transactions;
 export const exceptions = (): PolicyException[] => db.exceptions;
+export const reports = (): Report[] => db.reports;
 
 export const findCard = (id: string): Card | undefined =>
   db.cards.find((c) => c.id === id);
@@ -97,6 +105,17 @@ export const canApprove = (txn: Transaction): boolean =>
 export const addCard = (card: Card): Card => {
   db.cards.push(card);
   return card;
+};
+
+/** File a copilot-generated report; newest first so the Reports tab leads with it. */
+export const addReport = (report: Omit<Report, "id" | "createdAt">): Report => {
+  const filed: Report = {
+    ...report,
+    id: generateUniqueId(),
+    createdAt: new Date().toISOString(),
+  };
+  db.reports.unshift(filed);
+  return filed;
 };
 
 export const updateCardPin = (


### PR DESCRIPTION
## What

Makes the banking showcase pass the click-around test — every moment reachable by clicking, zero typing — and turns the two dead dashboard tabs into real views. Tracks [FOR-190](https://linear.app/copilotkit/issue/FOR-190); claims [FOR-178](https://linear.app/copilotkit/issue/FOR-178).

### Three new "wow moments" (all additive, under `src/components/wow/`)

1. **Proactive copilot** — on every fresh load the copilot has already noticed the overnight policy breaches and offers to walk through them, before the user types or clicks anything. Tap-to-accept opens the panel and sends the request on the user's behalf (same `addMessage` + `runAgent` path a suggestion-pill click takes). Dismissal is per page load — the opening beat replays on every reload, never re-nags within one.
2. **Talk to what you see** — the four brand charts (previously summonable only inside chat) now render as the dashboard's **Analytics tab** (was "coming soon"), each carrying contextual conversation-starter pills ("Explain this spike", "Who's closest to their limit?"). Answers are grounded via the existing `useAgentContext` readables and drill down with the existing gen-UI components.
3. **Real work product** — "Prep the Q2 spend report for the board" files a durable artifact (agent-written summary + highlights, live embedded charts) in the **Reports tab** (was "coming soon") through a new `createReport` frontend tool, `/api/v1/reports` route, and store collection.

### Fully click-drivable chat

- **The complete use-case catalog (12 pills) is always available** (`available: "always"`), not just on the welcome screen: the 4 self-learning arc beats plus charts, breakdowns, cash flow, approvals explainer, report prep, PIN change, and team invite. Bubbles persist after every exchange — no typing ever required. Panel widened 440→560px so pills flow two-per-row.
- **In-chat pending approvals are actually usable**: the dashboard's ~550px approval table rendered its Actions column past the chat card's edge — visible but unclickable. New `PendingApprovalsChat` stacks each charge as a chat-width card with labeled Approve/Deny/File-exception actions, with exact behavioral parity (over-limit gating, `PolicyExceptionInline` form, identical teach-mode recording payloads and step narration) — an officer can demonstrate the unlock entirely inside the chat.

### Correctness / quality fixes (found by Playwright click-through sweeps)

- **`navigateToPageAndPerform` killed the conversation**: `window.location.href` did a full reload, tearing down the chat panel mid-run. Now `router.push`; card operations also land on `/` (where the card tools are registered) instead of `/cards`, which mirrors the dashboard and has none.
- **`StatisticsChart` is a real chart now** (dashboard rail + spending-trend gen-UI): y-axis dollar gridlines, aligned x-axis labels, and hover showing the exact month + amount with a guide line. Still hand-rolled SVG, no charting dependency.
- **`next build` was failing on `main`** (`chat-inbox.tsx` CSS custom property typing) — production build now compiles, unblocking deploy (FOR-176).

## Scope boundary

Deliberately additive: no changes to the teach-mode arc, memory substrate, runtime prompt, or A2UI surface (all separately owned and in flight, see #5763). Shared-seam edits are minimal registrations plus the surgical fixes above.

## Validation

Driven end-to-end with Playwright against a live agent (`gpt-5.4-mini`), screenshots captured for every beat:
- All three wow moments, click-through to grounded agent payoff
- Full **teach → demonstrate (live step feed) → save → recall** arc in OSS mode: the agent applied the learned procedure to a different over-limit charge unaided
- In-chat approval flow end-to-end: file exception → row flips to Cleared → approve → queue drains
- Pills persist after exchanges; chart tooltip renders on hover
- `tsc`, oxlint, oxfmt, and `next build` all clean

Known issue observed during validation, **not addressed here**: HITL/message cards occasionally render twice (one stale, one live) — the mid-stream `message.id` remount bug that #5340 / #5354 fix in react-core; this demo inherits the fix when one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)