### PR TITLE
fix(react-core): style Streamdown table action controls in packaged CSS

### DIFF
--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -241,6 +241,22 @@
     @apply cpk:overflow-x-auto;
   }
 
+  /*
+   * Table action controls row + buttons. Streamdown renders these with raw
+   * (unprefixed) Tailwind utilities and no data-streamdown attribute, so they
+   * are unstyled when the host app only ships CopilotKit's packaged CSS. Scope
+   * to the first child of the wrapper, but only when a table container also
+   * follows (:not(:last-child)) so a controls-disabled table (single child) is
+   * never treated as a controls row. Buttons mirror the code-block controls.
+   */
+  [data-copilotkit] [data-streamdown="table-wrapper"] > div:first-child:not(:last-child) {
+    @apply cpk:flex cpk:items-center cpk:justify-end cpk:gap-1;
+  }
+
+  [data-copilotkit] [data-streamdown="table-wrapper"] > div:first-child:not(:last-child) button {
+    @apply cpk:cursor-pointer cpk:p-1 cpk:text-muted-foreground cpk:transition-all cpk:hover:text-foreground cpk:disabled:cursor-not-allowed cpk:disabled:opacity-50;
+  }
+
   [data-copilotkit] [data-streamdown="table"] {
     @apply cpk:w-full cpk:border-collapse cpk:border cpk:border-border;
   }


### PR DESCRIPTION
Fixes #5775

## Problem

After #5099 the Streamdown table wrapper, table container, headers, rows, and cells are styled by CopilotKit's packaged v2 stylesheet. The **table action controls row** (the copy/download buttons rendered above a table) is not.

In `streamdown@1.6.11` that row is rendered with raw, unprefixed Tailwind utilities and no `data-streamdown` attribute:

```tsx
<div data-streamdown="table-wrapper" className="my-4 flex flex-col space-y-2">
  <div className="flex items-center justify-end gap-1">   {/* controls row — no data-streamdown, raw utilities */}
    <CopyTableButton />
    <DownloadTableButton />
  </div>
  <div className="overflow-x-auto"><table data-streamdown="table" /></div>
</div>
```

When the host app only ships `@copilotkit/react-core/v2/styles.css` (and not Streamdown's unprefixed utilities), `.flex`, `.items-center`, `.justify-end`, `.gap-1`, `.cursor-pointer`, `.p-1` etc. are absent, so the controls render as vertically stacked plain icons instead of a right-aligned row.

## Fix

Add scoped rules in `packages/react-core/src/v2/styles/globals.css` for the wrapper's first child (the controls row) and its buttons, mirroring the existing `code-block-copy-button`/`code-block-download-button` styling.

The row selector is `> div:first-child:not(:last-child)`: the existing `> div:last-child` rule already styles the table scroll container, and when table controls are disabled Streamdown renders only that single child. `:not(:last-child)` ensures the controls-row rules apply only when a table container also follows, so a single-child table is never mistaken for a controls row.

```css
[data-copilotkit] [data-streamdown="table-wrapper"] > div:first-child:not(:last-child) {
  @apply cpk:flex cpk:items-center cpk:justify-end cpk:gap-1;
}
[data-copilotkit] [data-streamdown="table-wrapper"] > div:first-child:not(:last-child) button {
  @apply cpk:cursor-pointer cpk:p-1 cpk:text-muted-foreground cpk:transition-all cpk:hover:text-foreground cpk:disabled:cursor-not-allowed cpk:disabled:opacity-50;
}
```

All utilities used already appear elsewhere in this stylesheet, so no new Tailwind classes are introduced.

## Notes

Scoped to the concrete reported case (the controls row + buttons). The control popovers/dropdowns noted as "at risk" in the issue emit raw utilities with no stable hook; if desired they can be addressed in the broader Streamdown-chunk scoping follow-up mentioned in #5099.

🤖 Generated with [Claude Code](https://claude.com/claude-code)