### PR TITLE
fix(web-inspector): collapse timeline event details

### DIFF
--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -1119,12 +1119,17 @@ describe("CpkThreadInspector provider contract", () => {
 
     expect(internals.activeTimelineItems).toHaveLength(1);
     expect(el.shadowRoot?.textContent ?? "").toContain("THREAD_STATE_WRITTEN");
-    expect(el.shadowRoot?.textContent ?? "").toContain("Show details");
+    expect(el.shadowRoot?.textContent ?? "").toContain("Details");
     expect(el.shadowRoot?.textContent ?? "").not.toContain("checkpointId");
     expect(el.shadowRoot?.textContent ?? "").toContain("Source event #1");
     expect(el.shadowRoot?.textContent ?? "").not.toContain(
       "No timeline events captured",
     );
+    expect(
+      el.shadowRoot
+        ?.querySelector<HTMLButtonElement>(".cpk-td__timeline-details-toggle")
+        ?.getAttribute("aria-label"),
+    ).toBe("Show event details");
 
     el.shadowRoot
       ?.querySelector<HTMLButtonElement>(".cpk-td__timeline-details-toggle")
@@ -1160,10 +1165,15 @@ describe("CpkThreadInspector provider contract", () => {
     await flushProviderWork(el);
 
     expect(el.shadowRoot?.textContent ?? "").toContain("Run started");
-    expect(el.shadowRoot?.textContent ?? "").toContain("Show details");
+    expect(el.shadowRoot?.textContent ?? "").toContain("Details");
     expect(el.shadowRoot?.textContent ?? "").not.toContain(
       "very chonky run-started payload",
     );
+    expect(
+      el.shadowRoot
+        ?.querySelector<HTMLButtonElement>(".cpk-td__timeline-details-toggle")
+        ?.getAttribute("aria-label"),
+    ).toBe("Show event details");
 
     el.shadowRoot
       ?.querySelector<HTMLButtonElement>(".cpk-td__timeline-details-toggle")

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -935,7 +935,22 @@ describe("CpkThreadInspector provider contract", () => {
       ?.click();
     await flushProviderWork(el);
 
+    const rawEvent = el.shadowRoot?.querySelector<HTMLElement>(
+      '.cpk-td__event[data-source-index="1"]',
+    );
+    expect(rawEvent?.textContent ?? "").toContain("Show details");
+    expect(rawEvent?.textContent ?? "").not.toContain("top-level-run");
+    expect(rawEvent?.textContent ?? "").not.toContain("sequence");
+    expect(rawEvent?.textContent ?? "").not.toContain("messageId");
+    expect(rawEvent?.textContent ?? "").not.toContain("hello");
+
+    rawEvent
+      ?.querySelector<HTMLButtonElement>(".cpk-td__timeline-details-toggle")
+      ?.click();
+    await el.updateComplete;
+
     const text = el.shadowRoot?.textContent ?? "";
+    expect(text).toContain("Hide details");
     expect(text).toContain("top-level-run");
     expect(text).toContain("sequence");
     expect(text).toContain("messageId");
@@ -1119,18 +1134,12 @@ describe("CpkThreadInspector provider contract", () => {
 
     expect(internals.activeTimelineItems).toHaveLength(1);
     expect(el.shadowRoot?.textContent ?? "").toContain("THREAD_STATE_WRITTEN");
-    expect(el.shadowRoot?.textContent ?? "").toContain("Details");
+    expect(el.shadowRoot?.textContent ?? "").toContain("Show details");
     expect(el.shadowRoot?.textContent ?? "").not.toContain("checkpointId");
     expect(el.shadowRoot?.textContent ?? "").toContain("Source event #1");
     expect(el.shadowRoot?.textContent ?? "").not.toContain(
       "No timeline events captured",
     );
-    expect(
-      el.shadowRoot
-        ?.querySelector<HTMLButtonElement>(".cpk-td__timeline-details-toggle")
-        ?.getAttribute("aria-label"),
-    ).toBe("Show event details");
-
     el.shadowRoot
       ?.querySelector<HTMLButtonElement>(".cpk-td__timeline-details-toggle")
       ?.click();
@@ -1165,16 +1174,10 @@ describe("CpkThreadInspector provider contract", () => {
     await flushProviderWork(el);
 
     expect(el.shadowRoot?.textContent ?? "").toContain("Run started");
-    expect(el.shadowRoot?.textContent ?? "").toContain("Details");
+    expect(el.shadowRoot?.textContent ?? "").toContain("Show details");
     expect(el.shadowRoot?.textContent ?? "").not.toContain(
       "very chonky run-started payload",
     );
-    expect(
-      el.shadowRoot
-        ?.querySelector<HTMLButtonElement>(".cpk-td__timeline-details-toggle")
-        ?.getAttribute("aria-label"),
-    ).toBe("Show event details");
-
     el.shadowRoot
       ?.querySelector<HTMLButtonElement>(".cpk-td__timeline-details-toggle")
       ?.click();

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -339,6 +339,7 @@ type ThreadDetailsInternals = {
   } | null;
   _expandedTools: Set<string>;
   _expandedMessages: Set<string>;
+  _expandedTimelineDetails: Set<string>;
   _stateNotAvailable: boolean;
   _eventsNotAvailable: boolean;
   _loadingMessages: boolean;
@@ -1118,10 +1119,60 @@ describe("CpkThreadInspector provider contract", () => {
 
     expect(internals.activeTimelineItems).toHaveLength(1);
     expect(el.shadowRoot?.textContent ?? "").toContain("THREAD_STATE_WRITTEN");
-    expect(el.shadowRoot?.textContent ?? "").toContain("checkpointId");
+    expect(el.shadowRoot?.textContent ?? "").toContain("Show details");
+    expect(el.shadowRoot?.textContent ?? "").not.toContain("checkpointId");
     expect(el.shadowRoot?.textContent ?? "").toContain("Source event #1");
     expect(el.shadowRoot?.textContent ?? "").not.toContain(
       "No timeline events captured",
+    );
+
+    el.shadowRoot
+      ?.querySelector<HTMLButtonElement>(".cpk-td__timeline-details-toggle")
+      ?.click();
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.textContent ?? "").toContain("checkpointId");
+  });
+
+  it("collapses structured timeline event details by default", async () => {
+    const provider: ThreadDebuggerProvider = {
+      getEvents: vi.fn().mockResolvedValue([
+        {
+          type: "RUN_STARTED",
+          timestamp: "2026-06-25T10:00:00.000Z",
+          payload: {
+            input: {
+              tools: [
+                {
+                  name: "generateSandboxedUi",
+                  description: "very chonky run-started payload",
+                },
+              ],
+            },
+          },
+        },
+      ]),
+    };
+    const { el, internals } = createThreadInspector();
+
+    internals.provider = provider;
+    internals.threadId = "thread-chonky-run-started";
+    await flushProviderWork(el);
+
+    expect(el.shadowRoot?.textContent ?? "").toContain("Run started");
+    expect(el.shadowRoot?.textContent ?? "").toContain("Show details");
+    expect(el.shadowRoot?.textContent ?? "").not.toContain(
+      "very chonky run-started payload",
+    );
+
+    el.shadowRoot
+      ?.querySelector<HTMLButtonElement>(".cpk-td__timeline-details-toggle")
+      ?.click();
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.textContent ?? "").toContain("Hide details");
+    expect(el.shadowRoot?.textContent ?? "").toContain(
+      "very chonky run-started payload",
     );
   });
 

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -1189,6 +1189,37 @@ describe("CpkThreadInspector provider contract", () => {
     );
   });
 
+  it("shows expanded timeline details when an event also has a summary body", async () => {
+    const provider: ThreadDebuggerProvider = {
+      getEvents: vi.fn().mockResolvedValue([
+        {
+          type: "RUN_ERROR",
+          timestamp: "2026-06-25T10:00:00.000Z",
+          payload: {
+            message: "Tool failed",
+            errorCode: "ERR_TOOL_TIMEOUT",
+          },
+        },
+      ]),
+    };
+    const { el, internals } = createThreadInspector();
+
+    internals.provider = provider;
+    internals.threadId = "thread-error-details";
+    await flushProviderWork(el);
+
+    expect(el.shadowRoot?.textContent ?? "").toContain("Tool failed");
+    expect(el.shadowRoot?.textContent ?? "").toContain("Show details");
+    expect(el.shadowRoot?.textContent ?? "").not.toContain("ERR_TOOL_TIMEOUT");
+    el.shadowRoot
+      ?.querySelector<HTMLButtonElement>(".cpk-td__timeline-details-toggle")
+      ?.click();
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.textContent ?? "").toContain("Hide details");
+    expect(el.shadowRoot?.textContent ?? "").toContain("ERR_TOOL_TIMEOUT");
+  });
+
   it("keeps the first-visible timeline intentional while provider message fallback is loading", async () => {
     const messages =
       createDeferred<

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -780,6 +780,7 @@ export class CpkThreadInspector extends LitElement {
     _expandedTools: { state: true },
     _expandedMessages: { state: true },
     _expandedTimelineDetails: { state: true },
+    _expandedRawEvents: { state: true },
     _showDetailPanel: { state: true },
     _detailPanelWidth: { state: true },
     _eventsNotAvailable: { state: true },
@@ -818,6 +819,7 @@ export class CpkThreadInspector extends LitElement {
   private _expandedTools = new Set<string>();
   private _expandedMessages = new Set<string>();
   private _expandedTimelineDetails = new Set<string>();
+  private _expandedRawEvents = new Set<string>();
   private _showDetailPanel = false;
   private _detailPanelWidth = 250;
   /** True when the /events endpoint returned 501 — don't fall back to live data. */
@@ -1104,12 +1106,21 @@ export class CpkThreadInspector extends LitElement {
 
     .cpk-td__metadata-strip {
       display: flex;
+      align-items: center;
       gap: 6px;
       flex-wrap: wrap;
       padding: 10px 16px;
       border-bottom: 1px solid #e9e9ef;
       background: #fbfbfd;
       flex-shrink: 0;
+    }
+
+    .cpk-td__metadata-pills {
+      display: flex;
+      gap: 6px;
+      flex: 1;
+      flex-wrap: wrap;
+      min-width: 0;
     }
 
     .cpk-td__metadata-pill {
@@ -1406,13 +1417,44 @@ export class CpkThreadInspector extends LitElement {
     }
 
     .cpk-td__timeline-body {
-      padding: 9px 10px;
+      margin: 0;
+      padding: 0 10px 9px;
       font-size: 12px;
       line-height: 1.55;
       color: #57575b;
       white-space: pre-wrap;
       word-break: break-word;
-      border-top: 1px solid #e9e9ef;
+    }
+
+    .cpk-td__timeline-toolbar {
+      display: flex;
+      gap: 6px;
+      margin-left: auto;
+    }
+
+    .cpk-td__timeline-bulk-toggle {
+      margin: 0;
+      padding: 4px 8px;
+      border: 1px solid #dcdce8;
+      border-radius: 6px;
+      background: #ffffff;
+      color: #36363a;
+      cursor: pointer;
+      font-family: "Inter", sans-serif;
+      font-size: 11px;
+      font-weight: 600;
+      line-height: 1.2;
+    }
+
+    .cpk-td__timeline-bulk-toggle:hover {
+      border-color: rgba(85, 88, 178, 0.38);
+      background: #f7f7ff;
+      color: #010507;
+    }
+
+    .cpk-td__timeline-bulk-toggle:disabled {
+      cursor: not-allowed;
+      opacity: 0.45;
     }
 
     .cpk-td__source-link {
@@ -1435,26 +1477,23 @@ export class CpkThreadInspector extends LitElement {
 
     .cpk-td__timeline-details-toggle {
       margin: 0;
-      padding: 4px 8px;
-      border: 1px solid rgba(85, 88, 178, 0.24);
-      border-radius: 999px;
+      padding: 5px 10px;
+      border: none;
       background: #ffffff;
-      color: #30337f;
+      color: #5558b2;
       cursor: pointer;
       display: inline-flex;
       align-items: center;
-      gap: 4px;
+      gap: 5px;
       font-family: "Inter", sans-serif;
-      font-size: 11px;
+      font-size: 12px;
       font-weight: 600;
-      line-height: 1;
-      flex-shrink: 0;
-      box-shadow: 0 1px 2px rgba(16, 24, 40, 0.05);
+      line-height: 1.2;
+      width: 100%;
     }
 
     .cpk-td__timeline-details-toggle:hover {
-      border-color: rgba(85, 88, 178, 0.44);
-      background: #f3f3ff;
+      background: #f7f7ff;
       color: #010507;
     }
 
@@ -1754,6 +1793,7 @@ export class CpkThreadInspector extends LitElement {
     this._expandedTools = new Set();
     this._expandedMessages = new Set();
     this._expandedTimelineDetails = new Set();
+    this._expandedRawEvents = new Set();
     this._metadataAbort?.abort();
     this._metadataAbort = null;
     this._messagesAbort?.abort();
@@ -2432,6 +2472,40 @@ export class CpkThreadInspector extends LitElement {
     this._expandedTimelineDetails = next;
   }
 
+  private expandTimelineDetails(ids: string[]): void {
+    this._expandedTimelineDetails = new Set([
+      ...this._expandedTimelineDetails,
+      ...ids,
+    ]);
+  }
+
+  private collapseTimelineDetails(ids: string[]): void {
+    const next = new Set(this._expandedTimelineDetails);
+    for (const id of ids) next.delete(id);
+    this._expandedTimelineDetails = next;
+  }
+
+  private toggleRawEventDetails(id: string): void {
+    const next = new Set(this._expandedRawEvents);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    this._expandedRawEvents = next;
+  }
+
+  private expandRawEventDetails(ids: string[]): void {
+    this._expandedRawEvents = new Set([...this._expandedRawEvents, ...ids]);
+  }
+
+  private collapseRawEventDetails(ids: string[]): void {
+    const next = new Set(this._expandedRawEvents);
+    for (const id of ids) next.delete(id);
+    this._expandedRawEvents = next;
+  }
+
+  private rawEventId(event: ApiAgentEvent): string {
+    return `raw-event-${event.sourceIndex ?? event.timestamp ?? event.type}`;
+  }
+
   private get activeEvents(): ApiAgentEvent[] {
     // When the endpoint explicitly returned 501 we report no events rather
     // than leaking the parent's agent-keyed live events across historical
@@ -2603,23 +2677,93 @@ export class CpkThreadInspector extends LitElement {
       },
       { label: "Status", value: metadata?.status },
     ].filter((pill) => pill.value != null && pill.value !== "");
+    const bulkControls = this.renderActiveBulkControls();
 
-    if (pills.length === 0) return nothing;
+    if (pills.length === 0 && bulkControls === nothing) return nothing;
 
     return html`
       <div class="cpk-td__metadata-strip" aria-label="Thread metadata">
-        ${pills.map(
-          (pill) => html`
-            <span class="cpk-td__metadata-pill" title=${pill.value ?? ""}>
-              <span class="cpk-td__metadata-label">${pill.label}</span>
-              <span class="cpk-td__metadata-value"
-                >${this.shortId(pill.value)}</span
-              >
-            </span>
-          `,
-        )}
+        <div class="cpk-td__metadata-pills">
+          ${pills.map(
+            (pill) => html`
+              <span class="cpk-td__metadata-pill" title=${pill.value ?? ""}>
+                <span class="cpk-td__metadata-label">${pill.label}</span>
+                <span class="cpk-td__metadata-value"
+                  >${this.shortId(pill.value)}</span
+                >
+              </span>
+            `,
+          )}
+        </div>
+        ${bulkControls}
       </div>
     `;
+  }
+
+  private renderActiveBulkControls() {
+    if (this._eventsNotAvailable) return nothing;
+    if (this._tab === "raw-events") return this.renderRawEventBulkControls();
+    if (this._tab !== "timeline") return nothing;
+
+    const detailIds = this.timelineItemsForEvents(this.activeEvents)
+      .filter((item) => item.details)
+      .map((item) => item.id);
+    if (detailIds.length <= 1) return nothing;
+
+    const allExpanded = detailIds.every((id) =>
+      this._expandedTimelineDetails.has(id),
+    );
+    const allCollapsed = detailIds.every(
+      (id) => !this._expandedTimelineDetails.has(id),
+    );
+
+    return html`<div class="cpk-td__timeline-toolbar">
+      <button
+        type="button"
+        class="cpk-td__timeline-bulk-toggle"
+        ?disabled=${allExpanded}
+        @click=${() => this.expandTimelineDetails(detailIds)}
+      >
+        Expand all
+      </button>
+      <button
+        type="button"
+        class="cpk-td__timeline-bulk-toggle"
+        ?disabled=${allCollapsed}
+        @click=${() => this.collapseTimelineDetails(detailIds)}
+      >
+        Collapse all
+      </button>
+    </div>`;
+  }
+
+  private renderRawEventBulkControls() {
+    const eventIds = this.activeEvents.map((event) => this.rawEventId(event));
+    if (eventIds.length <= 1) return nothing;
+
+    const allExpanded = eventIds.every((id) => this._expandedRawEvents.has(id));
+    const allCollapsed = eventIds.every(
+      (id) => !this._expandedRawEvents.has(id),
+    );
+
+    return html`<div class="cpk-td__timeline-toolbar">
+      <button
+        type="button"
+        class="cpk-td__timeline-bulk-toggle"
+        ?disabled=${allExpanded}
+        @click=${() => this.expandRawEventDetails(eventIds)}
+      >
+        Expand all
+      </button>
+      <button
+        type="button"
+        class="cpk-td__timeline-bulk-toggle"
+        ?disabled=${allCollapsed}
+        @click=${() => this.collapseRawEventDetails(eventIds)}
+      >
+        Collapse all
+      </button>
+    </div>`;
   }
 
   private revealSourceEvent(sourceIndex: number): void {
@@ -2709,62 +2853,57 @@ export class CpkThreadInspector extends LitElement {
           >
             Source event #${item.sourceIndex}
           </button>
-          ${
-            item.details
-              ? html`<button
-                  type="button"
-                  class="cpk-td__timeline-details-toggle"
-                  aria-expanded=${detailsExpanded ? "true" : "false"}
-                  aria-label=${
-                    detailsExpanded
-                      ? "Hide event details"
-                      : "Show event details"
-                  }
-                  @click=${() => this.toggleTimelineDetails(item.id)}
-                >
-                  ${
-                    detailsExpanded
-                      ? html`
-                          <svg
-                            aria-hidden="true"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                          >
-                            <path d="m6 9 6 6 6-6" />
-                          </svg>
-                        `
-                      : html`
-                          <svg
-                            aria-hidden="true"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                          >
-                            <path d="m9 18 6-6-6-6" />
-                          </svg>
-                        `
-                  }
-                  <span>${detailsExpanded ? "Hide details" : "Details"}</span>
-                </button>`
-              : nothing
-          }
           <span class="cpk-td__timeline-time"
             >${formatTimestamp(item.timestamp)}</span
           >
         </div>
         ${
+          item.details
+            ? html`<button
+                type="button"
+                class="cpk-td__timeline-details-toggle"
+                aria-expanded=${detailsExpanded ? "true" : "false"}
+                @click=${() => this.toggleTimelineDetails(item.id)}
+              >
+                ${
+                  detailsExpanded
+                    ? html`
+                        <svg
+                          aria-hidden="true"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                        >
+                          <path d="m6 9 6 6 6-6" />
+                        </svg>
+                      `
+                    : html`
+                        <svg
+                          aria-hidden="true"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                        >
+                          <path d="m9 18 6-6-6-6" />
+                        </svg>
+                      `
+                }
+                <span>${detailsExpanded ? "Hide details" : "Show details"}</span>
+              </button>`
+            : nothing
+        }
+        ${
           item.body
             ? html`<div class="cpk-td__timeline-body">${item.body}</div>`
             : item.details
               ? detailsExpanded
-                ? html`<pre class="cpk-td__timeline-body">
-${unsafeHTML(highlightedJson(item.details))}</pre
-                >`
+                ? html`<pre class="cpk-td__timeline-body">${unsafeHTML(
+                    highlightedJson(item.details),
+                  )}</pre>`
                 : nothing
               : nothing
         }
@@ -3104,10 +3243,15 @@ ${unsafeHTML(highlightedJson(stateValue))}</pre
         </div>
       `;
     }
-    return this.cachedPanelTpl("raw-events", [events], () => {
-      return html`${events.map((event) => {
-        const { bg, fg } = eventColors(event.type);
-        return html`
+    return this.cachedPanelTpl(
+      "raw-events",
+      [events, this._expandedRawEvents],
+      () => {
+        return html`${events.map((event) => {
+          const { bg, fg } = eventColors(event.type);
+          const eventId = this.rawEventId(event);
+          const detailsExpanded = this._expandedRawEvents.has(eventId);
+          return html`
           <div class="cpk-td__event" data-source-index=${event.sourceIndex}>
             <div class="cpk-td__event-header" style="background:${bg}">
               <span class="cpk-td__event-type" style="color:${fg}"
@@ -3117,13 +3261,53 @@ ${unsafeHTML(highlightedJson(stateValue))}</pre
                 >${formatTimestamp(event.timestamp)}</span
               >
             </div>
-            <pre class="cpk-td__event-payload">
-${unsafeHTML(highlightedJson(event.rawEvent ?? event))}</pre
+            <button
+              type="button"
+              class="cpk-td__timeline-details-toggle"
+              aria-expanded=${detailsExpanded ? "true" : "false"}
+              @click=${() => this.toggleRawEventDetails(eventId)}
             >
+              ${
+                detailsExpanded
+                  ? html`
+                      <svg
+                        aria-hidden="true"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <path d="m6 9 6 6 6-6" />
+                      </svg>
+                    `
+                  : html`
+                      <svg
+                        aria-hidden="true"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <path d="m9 18 6-6-6-6" />
+                      </svg>
+                    `
+              }
+              <span>${detailsExpanded ? "Hide details" : "Show details"}</span>
+            </button>
+            ${
+              detailsExpanded
+                ? html`<pre class="cpk-td__event-payload">${unsafeHTML(
+                    highlightedJson(event.rawEvent ?? event),
+                  )}</pre>`
+                : nothing
+            }
           </div>
         `;
-      })}`;
-    });
+        })}`;
+      },
+    );
   }
 
   private renderPanelToggle() {

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -779,6 +779,7 @@ export class CpkThreadInspector extends LitElement {
     _stateError: { state: true },
     _expandedTools: { state: true },
     _expandedMessages: { state: true },
+    _expandedTimelineDetails: { state: true },
     _showDetailPanel: { state: true },
     _detailPanelWidth: { state: true },
     _eventsNotAvailable: { state: true },
@@ -816,6 +817,7 @@ export class CpkThreadInspector extends LitElement {
   private _stateError: string | null = null;
   private _expandedTools = new Set<string>();
   private _expandedMessages = new Set<string>();
+  private _expandedTimelineDetails = new Set<string>();
   private _showDetailPanel = false;
   private _detailPanelWidth = 250;
   /** True when the /events endpoint returned 501 — don't fall back to live data. */
@@ -1431,6 +1433,24 @@ export class CpkThreadInspector extends LitElement {
       color: #010507;
     }
 
+    .cpk-td__timeline-details-toggle {
+      margin: 0;
+      padding: 0;
+      border: none;
+      background: transparent;
+      color: #5558b2;
+      cursor: pointer;
+      font-family: "Spline Sans Mono", monospace;
+      font-size: 9px;
+      text-decoration: underline;
+      text-underline-offset: 2px;
+      flex-shrink: 0;
+    }
+
+    .cpk-td__timeline-details-toggle:hover {
+      color: #010507;
+    }
+
     /* ── Generative UI ──────────────────────────────────────────────── */
     @keyframes cpk-genui-enter {
       from {
@@ -1720,6 +1740,7 @@ export class CpkThreadInspector extends LitElement {
     this._liveEventsWithSourceIndexCache = null;
     this._expandedTools = new Set();
     this._expandedMessages = new Set();
+    this._expandedTimelineDetails = new Set();
     this._metadataAbort?.abort();
     this._metadataAbort = null;
     this._messagesAbort?.abort();
@@ -2391,6 +2412,13 @@ export class CpkThreadInspector extends LitElement {
     this._expandedMessages = next;
   }
 
+  private toggleTimelineDetails(id: string): void {
+    const next = new Set(this._expandedTimelineDetails);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    this._expandedTimelineDetails = next;
+  }
+
   private get activeEvents(): ApiAgentEvent[] {
     // When the endpoint explicitly returned 501 we report no events rather
     // than leaking the parent's agent-keyed live events across historical
@@ -2619,7 +2647,10 @@ export class CpkThreadInspector extends LitElement {
     }
 
     const events = this.activeEvents;
-    const cachedTimeline = this.getCachedPanelTpl("timeline", [events]);
+    const cachedTimeline = this.getCachedPanelTpl("timeline", [
+      events,
+      this._expandedTimelineDetails,
+    ]);
     if (cachedTimeline) return cachedTimeline;
 
     const timelineItems = this.timelineItemsForEvents(events);
@@ -2637,13 +2668,16 @@ export class CpkThreadInspector extends LitElement {
       `;
     }
 
-    return this.cachedPanelTpl("timeline", [events], () => {
-      return html`${timelineItems.map((item) => this.renderTimelineItem(item))}`;
-    });
+    return this.cachedPanelTpl(
+      "timeline",
+      [events, this._expandedTimelineDetails],
+      () => html`${timelineItems.map((item) => this.renderTimelineItem(item))}`,
+    );
   }
 
   private renderTimelineItem(item: TimelineItem) {
     const isWarning = item.kind === "warning";
+    const detailsExpanded = this._expandedTimelineDetails.has(item.id);
     return html`
       <div
         class="cpk-td__timeline-item ${
@@ -2662,6 +2696,18 @@ export class CpkThreadInspector extends LitElement {
           >
             Source event #${item.sourceIndex}
           </button>
+          ${
+            item.details
+              ? html`<button
+                  type="button"
+                  class="cpk-td__timeline-details-toggle"
+                  aria-expanded=${detailsExpanded ? "true" : "false"}
+                  @click=${() => this.toggleTimelineDetails(item.id)}
+                >
+                  ${detailsExpanded ? "Hide details" : "Show details"}
+                </button>`
+              : nothing
+          }
           <span class="cpk-td__timeline-time"
             >${formatTimestamp(item.timestamp)}</span
           >
@@ -2670,9 +2716,11 @@ export class CpkThreadInspector extends LitElement {
           item.body
             ? html`<div class="cpk-td__timeline-body">${item.body}</div>`
             : item.details
-              ? html`<pre class="cpk-td__timeline-body">
+              ? detailsExpanded
+                ? html`<pre class="cpk-td__timeline-body">
 ${unsafeHTML(highlightedJson(item.details))}</pre
-              >`
+                >`
+                : nothing
               : nothing
         }
       </div>

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -2899,13 +2899,14 @@ export class CpkThreadInspector extends LitElement {
         ${
           item.body
             ? html`<div class="cpk-td__timeline-body">${item.body}</div>`
-            : item.details
-              ? detailsExpanded
-                ? html`<pre class="cpk-td__timeline-body">${unsafeHTML(
-                    highlightedJson(item.details),
-                  )}</pre>`
-                : nothing
-              : nothing
+            : nothing
+        }
+        ${
+          item.details && detailsExpanded
+            ? html`<pre class="cpk-td__timeline-body">${unsafeHTML(
+                highlightedJson(item.details),
+              )}</pre>`
+            : nothing
         }
       </div>
     `;

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -1435,20 +1435,33 @@ export class CpkThreadInspector extends LitElement {
 
     .cpk-td__timeline-details-toggle {
       margin: 0;
-      padding: 0;
-      border: none;
-      background: transparent;
-      color: #5558b2;
+      padding: 4px 8px;
+      border: 1px solid rgba(85, 88, 178, 0.24);
+      border-radius: 999px;
+      background: #ffffff;
+      color: #30337f;
       cursor: pointer;
-      font-family: "Spline Sans Mono", monospace;
-      font-size: 9px;
-      text-decoration: underline;
-      text-underline-offset: 2px;
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      font-family: "Inter", sans-serif;
+      font-size: 11px;
+      font-weight: 600;
+      line-height: 1;
       flex-shrink: 0;
+      box-shadow: 0 1px 2px rgba(16, 24, 40, 0.05);
     }
 
     .cpk-td__timeline-details-toggle:hover {
+      border-color: rgba(85, 88, 178, 0.44);
+      background: #f3f3ff;
       color: #010507;
+    }
+
+    .cpk-td__timeline-details-toggle svg {
+      width: 12px;
+      height: 12px;
+      stroke-width: 2;
     }
 
     /* ── Generative UI ──────────────────────────────────────────────── */
@@ -2702,9 +2715,41 @@ export class CpkThreadInspector extends LitElement {
                   type="button"
                   class="cpk-td__timeline-details-toggle"
                   aria-expanded=${detailsExpanded ? "true" : "false"}
+                  aria-label=${
+                    detailsExpanded
+                      ? "Hide event details"
+                      : "Show event details"
+                  }
                   @click=${() => this.toggleTimelineDetails(item.id)}
                 >
-                  ${detailsExpanded ? "Hide details" : "Show details"}
+                  ${
+                    detailsExpanded
+                      ? html`
+                          <svg
+                            aria-hidden="true"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          >
+                            <path d="m6 9 6 6 6-6" />
+                          </svg>
+                        `
+                      : html`
+                          <svg
+                            aria-hidden="true"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          >
+                            <path d="m9 18 6-6-6-6" />
+                          </svg>
+                        `
+                  }
+                  <span>${detailsExpanded ? "Hide details" : "Details"}</span>
                 </button>`
               : nothing
           }


### PR DESCRIPTION
## Summary
- Collapse structured timeline event details by default in `<cpk-thread-inspector>`.
- Add an accessible `Show details` / `Hide details` toggle with `aria-expanded` for timeline JSON payloads.
- Keep timeline row headers and source-event links visible while leaving plain message bodies unchanged.

## Test Plan
- `NX_TUI=false ./node_modules/.bin/nx run @copilotkit/web-inspector:test -- --run src/__tests__/web-inspector.spec.ts -t "collapses structured timeline event details"`
- `PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true NX_TUI=false ./node_modules/.bin/nx run @copilotkit/web-inspector:test`
- `PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true NX_TUI=false ./node_modules/.bin/nx run @copilotkit/web-inspector:check-types`
- `PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true NX_TUI=false ./node_modules/.bin/nx run @copilotkit/web-inspector:build`
- `./node_modules/.bin/oxfmt --check packages/web-inspector/src/index.ts packages/web-inspector/src/__tests__/web-inspector.spec.ts`
- `./node_modules/.bin/oxlint packages/web-inspector/src/index.ts packages/web-inspector/src/__tests__/web-inspector.spec.ts` (warnings only, pre-existing in touched files)

## Notes
- Local pnpm 11 ignores the repo's legacy `package.json#pnpm.overrides` config, so local installs needed the existing overrides represented during install to avoid unrelated React 18/19 mismatches in downstream package tests. No lockfile or workspace config changes are included in this PR.
