### PR TITLE
fix(react-ui): reduce sidebar CSS specificity

### DIFF
--- a/packages/react-ui/src/css/header.css
+++ b/packages/react-ui/src/css/header.css
@@ -14,7 +14,7 @@
   z-index: 2;
 }
 
-.copilotKitSidebar .copilotKitHeader {
+:where(.copilotKitSidebar) .copilotKitHeader {
   border-radius: 0;
 }
 

--- a/packages/react-ui/src/css/header.css
+++ b/packages/react-ui/src/css/header.css
@@ -34,6 +34,10 @@
     border-top-left-radius: 8px;
     border-top-right-radius: 8px;
   }
+
+  :where(.copilotKitSidebar) .copilotKitHeader {
+    border-radius: 0;
+  }
 }
 
 .copilotKitHeader > button {

--- a/packages/react-ui/src/css/input.css
+++ b/packages/react-ui/src/css/input.css
@@ -19,7 +19,7 @@
   border-bottom-right-radius: 0.75rem;
 }
 
-.copilotKitSidebar .copilotKitInputContainer {
+:where(.copilotKitSidebar) .copilotKitInputContainer {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }

--- a/packages/react-ui/src/css/sidebar-specificity.test.ts
+++ b/packages/react-ui/src/css/sidebar-specificity.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const cssRoot = path.resolve(__dirname);
+
+const sidebarScopedSelectors = [
+  {
+    file: "window.css",
+    selector: ".copilotKitWindow",
+  },
+  {
+    file: "header.css",
+    selector: ".copilotKitHeader",
+  },
+  {
+    file: "input.css",
+    selector: ".copilotKitInputContainer",
+  },
+];
+
+describe("sidebar CSS specificity", () => {
+  it("keeps sidebar variant selectors easy to override", () => {
+    for (const { file, selector } of sidebarScopedSelectors) {
+      const css = fs.readFileSync(path.join(cssRoot, file), "utf-8");
+
+      expect(css).not.toContain(`.copilotKitSidebar ${selector}`);
+      expect(css).toContain(`:where(.copilotKitSidebar) ${selector}`);
+    }
+  });
+});

--- a/packages/react-ui/src/css/window.css
+++ b/packages/react-ui/src/css/window.css
@@ -16,7 +16,7 @@
   pointer-events: none;
 }
 
-.copilotKitSidebar .copilotKitWindow {
+:where(.copilotKitSidebar) .copilotKitWindow {
   border-radius: 0;
   opacity: 1;
   transform: translateX(100%);
@@ -28,7 +28,7 @@
   pointer-events: auto;
 }
 
-.copilotKitSidebar .copilotKitWindow.open {
+:where(.copilotKitSidebar) .copilotKitWindow.open {
   transform: translateX(0);
 }
 
@@ -54,7 +54,7 @@
     max-height: calc(100% - 6rem);
   }
 
-  .copilotKitSidebar .copilotKitWindow {
+  :where(.copilotKitSidebar) .copilotKitWindow {
     bottom: 0;
     right: 0;
     top: auto;


### PR DESCRIPTION
## Summary
- lowers CopilotSidebar-scoped CSS selector specificity with `:where(.copilotKitSidebar)`
- keeps the existing sidebar styles and layout behavior unchanged
- adds a regression test to keep sidebar selectors easy for app CSS to override

## Root cause
Sidebar-specific selectors such as `.copilotKitSidebar .copilotKitWindow` were more specific than ordinary user overrides like `.copilotKitWindow`, so user CSS could lose precedence in Chrome.

Fixes #263.

## Validation
- `pnpm -C packages/react-ui test`
- `pnpm exec oxfmt --check packages/react-ui/src/css/sidebar-specificity.test.ts packages/react-ui/src/css/window.css packages/react-ui/src/css/header.css packages/react-ui/src/css/input.css`
- `pnpm exec oxlint packages/react-ui/src/css/sidebar-specificity.test.ts`