### PR TITLE
fix(python-sdk): fold App Context into system prompt

### DIFF
--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -338,6 +338,61 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
             system_message=SystemMessage(content=f"{base}\n\n{note}")
         )
 
+    def _build_app_context_note(
+        self,
+        state: dict[str, Any],
+        runtime_context: Any = None,
+    ) -> str | None:
+        copilotkit_state = state.get("copilotkit", {})
+        app_context = copilotkit_state.get("context") or runtime_context
+
+        if isinstance(app_context, dict):
+            app_context = {
+                k: v
+                for k, v in app_context.items()
+                if k != "copilotkit_forwarded_headers"
+            }
+
+        if not app_context:
+            return None
+        if isinstance(app_context, str) and app_context.strip() == "":
+            return None
+        if isinstance(app_context, dict) and len(app_context) == 0:
+            return None
+
+        if isinstance(app_context, str):
+            context_content = app_context
+        else:
+            if hasattr(app_context, "model_dump"):
+                app_context = app_context.model_dump()
+            elif isinstance(app_context, list):
+                app_context = [
+                    item.model_dump() if hasattr(item, "model_dump") else item
+                    for item in app_context
+                ]
+            context_content = json.dumps(app_context, indent=2)
+
+        return f"App Context:\n{context_content}"
+
+    def _apply_app_context_note(self, request: ModelRequest) -> ModelRequest:
+        note = self._build_app_context_note(
+            request.state or {},
+            getattr(request.runtime, "context", None),
+        )
+        if not note:
+            return request
+        existing = request.system_message
+        if existing is None:
+            return request.override(system_message=SystemMessage(content=note))
+        base = (
+            existing.content
+            if isinstance(existing.content, str)
+            else str(existing.content)
+        )
+        return request.override(
+            system_message=SystemMessage(content=f"{base}\n\n{note}")
+        )
+
     # ------------------------------------------------------------------
     # Auto-A2UI tool injection
     # ------------------------------------------------------------------
@@ -481,6 +536,7 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         _extract_forwarded_headers_from_config()
         _ensure_httpx_hook(request.model)
         request = self._apply_state_note(request)
+        request = self._apply_app_context_note(request)
 
         a2ui_tool = self._maybe_build_a2ui_tool(request)
         frontend_tools = request.state.get("copilotkit", {}).get("actions", [])
@@ -684,6 +740,7 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         _ensure_httpx_hook(request.model)
         self._fix_messages_for_bedrock(request.messages)
         request = self._apply_state_note(request)
+        request = self._apply_app_context_note(request)
 
         a2ui_tool = self._maybe_build_a2ui_tool(request)
         frontend_tools = request.state.get("copilotkit", {}).get("actions", [])
@@ -747,117 +804,7 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         state: StateSchema,
         runtime: Runtime[Any],
     ) -> dict[str, Any] | None:
-        messages = state.get("messages", [])
-
-        if not messages:
-            return None
-
-        # Get app context from state or runtime
-        copilotkit_state = state.get("copilotkit", {})
-        app_context = copilotkit_state.get("context") or getattr(
-            runtime, "context", None
-        )
-
-        # Strip the reserved transport-layer key ``copilotkit_forwarded_headers``
-        # so it is never rendered into the LLM prompt. langgraph-api auto-copies
-        # ``config.configurable`` into ``runtime.context``, which means the
-        # forwarded-headers wrapper dict shows up here even though it is only
-        # meant for the httpx hook (which reads it from a separate ContextVar
-        # via ``_extract_forwarded_headers_from_config``).
-        if isinstance(app_context, dict):
-            app_context = {
-                k: v
-                for k, v in app_context.items()
-                if k != "copilotkit_forwarded_headers"
-            }
-
-        # Check if app_context is missing or empty
-        if not app_context:
-            return None
-        if isinstance(app_context, str) and app_context.strip() == "":
-            return None
-        if isinstance(app_context, dict) and len(app_context) == 0:
-            return None
-
-        # Create the context content
-        if isinstance(app_context, str):
-            context_content = app_context
-        else:
-            # Handle Pydantic models (e.g. ag_ui Context)
-            if hasattr(app_context, "model_dump"):
-                app_context = app_context.model_dump()
-            elif isinstance(app_context, list):
-                app_context = [
-                    item.model_dump() if hasattr(item, "model_dump") else item
-                    for item in app_context
-                ]
-            context_content = json.dumps(app_context, indent=2)
-
-        context_message_content = f"App Context:\n{context_content}"
-        context_message_prefix = "App Context:\n"
-
-        # Helper to get message content as string
-        def get_content_string(msg: Any) -> str | None:
-            content = getattr(msg, "content", None)
-            if isinstance(content, str):
-                return content
-            if isinstance(content, list) and content and isinstance(content[0], dict):
-                return content[0].get("text")
-            return None
-
-        # Find the first system/developer message (not our context message)
-        # to determine where to insert our context message (right after it)
-        first_system_index = -1
-
-        for i, msg in enumerate(messages):
-            msg_type = getattr(msg, "type", None)
-            if msg_type in ("system", "developer"):
-                content = get_content_string(msg)
-                # Skip if this is our own context message
-                if content and content.startswith(context_message_prefix):
-                    continue
-                first_system_index = i
-                break
-
-        # Check if our context message already exists
-        existing_context_index = -1
-        for i, msg in enumerate(messages):
-            msg_type = getattr(msg, "type", None)
-            if msg_type in ("system", "developer"):
-                content = get_content_string(msg)
-                if content and content.startswith(context_message_prefix):
-                    existing_context_index = i
-                    break
-
-        # Create the context message.
-        # When replacing an existing context message, reuse its ID so the
-        # add_messages reducer updates in-place instead of appending a
-        # duplicate at the end of the message list.
-        if existing_context_index != -1:
-            existing_id = getattr(messages[existing_context_index], "id", None)
-            context_message = SystemMessage(
-                content=context_message_content, id=existing_id
-            )
-        else:
-            context_message = SystemMessage(content=context_message_content)
-
-        if existing_context_index != -1:
-            # Replace existing context message
-            updated_messages = list(messages)
-            updated_messages[existing_context_index] = context_message
-        else:
-            # Insert after the first system message, or at position 0 if no system message
-            insert_index = first_system_index + 1 if first_system_index != -1 else 0
-            updated_messages = [
-                *messages[:insert_index],
-                context_message,
-                *messages[insert_index:],
-            ]
-
-        return {
-            **state,
-            "messages": updated_messages,
-        }
+        return None
 
     async def abefore_agent(
         self,

--- a/sdk-python/tests/test_copilotkit_lg_middleware.py
+++ b/sdk-python/tests/test_copilotkit_lg_middleware.py
@@ -8,8 +8,8 @@ and what state updates the middleware emits):
   the agent's own tools when the model is called. When there are no frontend
   tools the request reaches the model unchanged.
 * App context from ``state["copilotkit"]["context"]`` (or ``runtime.context``)
-  becomes a ``SystemMessage`` containing ``"App Context:\\n<json>"``. Empty
-  context is a no-op. Re-running ``before_agent`` does not duplicate the note.
+  is appended to ``ModelRequest.system_message`` as ``"App Context:\\n<json>"``.
+  Empty context is a no-op. ``before_agent`` does not mutate message history.
 * ``after_model`` peels frontend tool calls off the last AIMessage so the
   ToolNode does not try to execute them; ``after_agent`` re-attaches them
   before the run ends.
@@ -64,7 +64,7 @@ def _make_request(
         system_message=system_message,
         tools=tools if tools is not None else [],
         state=state if state is not None else {"messages": []},
-        runtime=MagicMock(name="runtime"),
+        runtime=MagicMock(name="runtime", context=None),
     )
 
 
@@ -373,6 +373,52 @@ def test_expose_state_allowlist_never_surfaces_forwarded_headers():
 
 
 # ---------------------------------------------------------------------------
+# App Context system prompt injection
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_model_call_appends_app_context_to_existing_system_message():
+    middleware = CopilotKitMiddleware()
+    request = _make_request(
+        state={
+            "messages": [HumanMessage("previous turn")],
+            "copilotkit": {
+                "context": [{"description": "viewer role", "value": "admin"}]
+            },
+        },
+        messages=[HumanMessage("previous turn")],
+        system_message=SystemMessage(content="You are a helpful assistant."),
+    )
+
+    seen, _ = _run_wrap(middleware, request)
+
+    assert seen.system_message is not None
+    body = seen.system_message.content
+    assert isinstance(body, str)
+    assert "You are a helpful assistant." in body
+    assert "App Context:" in body
+    assert "admin" in body
+    assert body.index("You are a helpful assistant.") < body.index("App Context:")
+    assert all(
+        "App Context:" not in (m.content if isinstance(m.content, str) else "")
+        for m in seen.messages
+    )
+
+
+def test_before_agent_does_not_inject_app_context_into_message_state():
+    middleware = CopilotKitMiddleware()
+    state = {
+        "messages": [HumanMessage("hi")],
+        "copilotkit": {"context": [{"description": "viewer role", "value": "admin"}]},
+    }
+    runtime = MagicMock(name="runtime", context=None)
+
+    result = middleware.before_agent(state, runtime)
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
 # Async wrapper parity
 # ---------------------------------------------------------------------------
 
@@ -408,16 +454,15 @@ def test_async_wrap_mirrors_sync_behavior_for_state_and_tools():
 
 
 # ---------------------------------------------------------------------------
-# before_agent — App Context injection
+# App Context injection
 # ---------------------------------------------------------------------------
 
 
-def _system_contents(messages: list[Any]) -> list[str]:
-    return [
-        m.content if isinstance(m.content, str) else str(m.content)
-        for m in messages
-        if isinstance(m, SystemMessage)
-    ]
+def _system_message_text(request: ModelRequest) -> str:
+    assert request.system_message is not None
+    content = request.system_message.content
+    assert isinstance(content, str)
+    return content
 
 
 def test_before_agent_no_context_returns_no_update():
@@ -430,23 +475,25 @@ def test_before_agent_no_context_returns_no_update():
     assert result is None
 
 
-def test_before_agent_injects_app_context_system_message():
+def test_wrap_model_call_injects_app_context_system_message():
     middleware = CopilotKitMiddleware()
-    state = {
-        "messages": [HumanMessage("hi")],
-        "copilotkit": {"context": [{"description": "viewer role", "value": "admin"}]},
-    }
-    runtime = MagicMock(name="runtime", context=None)
+    request = _make_request(
+        state={
+            "messages": [HumanMessage("hi")],
+            "copilotkit": {
+                "context": [{"description": "viewer role", "value": "admin"}]
+            },
+        }
+    )
 
-    result = middleware.before_agent(state, runtime)
+    seen, _ = _run_wrap(middleware, request)
 
-    assert result is not None
-    sys_contents = _system_contents(result["messages"])
-    assert any("App Context:" in s for s in sys_contents)
-    assert any("admin" in s for s in sys_contents)
+    body = _system_message_text(seen)
+    assert "App Context:" in body
+    assert "admin" in body
 
 
-def test_before_agent_idempotent_does_not_duplicate_context():
+def test_before_agent_repeated_calls_do_not_mutate_messages():
     middleware = CopilotKitMiddleware()
     state = {
         "messages": [HumanMessage("hi")],
@@ -457,25 +504,20 @@ def test_before_agent_idempotent_does_not_duplicate_context():
     first = middleware.before_agent(state, runtime) or state
     second = middleware.before_agent(first, runtime) or first
 
-    sys_messages = [m for m in second["messages"] if isinstance(m, SystemMessage)]
-    app_context_messages = [
-        m
-        for m in sys_messages
-        if isinstance(m.content, str) and m.content.startswith("App Context:")
-    ]
-    assert len(app_context_messages) == 1
+    assert first is state
+    assert second is state
+    assert second["messages"] == [HumanMessage("hi")]
 
 
-def test_before_agent_uses_runtime_context_when_state_context_empty():
+def test_wrap_model_call_uses_runtime_context_when_state_context_empty():
     middleware = CopilotKitMiddleware()
-    state = {"messages": [HumanMessage("hi")], "copilotkit": {}}
-    runtime = MagicMock(name="runtime", context="route=/dashboard")
+    request = _make_request(state={"messages": [HumanMessage("hi")], "copilotkit": {}})
+    request.runtime.context = "route=/dashboard"
 
-    result = middleware.before_agent(state, runtime)
+    seen, _ = _run_wrap(middleware, request)
 
-    assert result is not None
-    sys_contents = _system_contents(result["messages"])
-    assert any("/dashboard" in s for s in sys_contents)
+    body = _system_message_text(seen)
+    assert "/dashboard" in body
 
 
 def test_before_agent_strips_copilotkit_forwarded_headers_from_runtime_context():
@@ -518,36 +560,33 @@ def test_before_agent_strips_copilotkit_forwarded_headers_from_runtime_context()
     )
 
 
-def test_before_agent_strips_forwarded_headers_but_keeps_real_app_context():
+def test_wrap_model_call_strips_forwarded_headers_but_keeps_real_app_context():
     """When ``runtime.context`` contains both a genuine app key AND the
     transport-only ``copilotkit_forwarded_headers`` wrapper, the App Context
-    system message must still be injected with the real key, but the forwarded
+    system note must still be injected with the real key, but the forwarded
     headers must be filtered out.
     """
     middleware = CopilotKitMiddleware()
-    state = {"messages": [HumanMessage("hi")], "copilotkit": {}}
-    runtime = MagicMock(
-        name="runtime",
-        context={
-            "user_tier": "pro",
-            "copilotkit_forwarded_headers": {
-                "x-aimock-context": "showcase/d6",
-            },
+    request = _make_request(state={"messages": [HumanMessage("hi")], "copilotkit": {}})
+    request.runtime.context = {
+        "user_tier": "pro",
+        "copilotkit_forwarded_headers": {
+            "x-aimock-context": "showcase/d6",
         },
-    )
+    }
 
-    result = middleware.before_agent(state, runtime)
+    seen, _ = _run_wrap(middleware, request)
 
-    assert result is not None
-    sys_contents = _system_contents(result["messages"])
+    body = _system_message_text(seen)
     # The genuine app context is still surfaced.
-    assert any("App Context:" in s for s in sys_contents)
-    assert any("user_tier" in s and "pro" in s for s in sys_contents)
+    assert "App Context:" in body
+    assert "user_tier" in body
+    assert "pro" in body
     # The transport-layer wrapper is stripped from the rendered prompt.
-    assert not any("copilotkit_forwarded_headers" in s for s in sys_contents), (
+    assert "copilotkit_forwarded_headers" not in body, (
         "copilotkit_forwarded_headers must be filtered out of the App Context message"
     )
-    assert not any("x-aimock-context" in s for s in sys_contents), (
+    assert "x-aimock-context" not in body, (
         "forwarded header values must never appear in a system prompt"
     )
 


### PR DESCRIPTION
## Summary
- folds CopilotKit App Context into `ModelRequest.system_message` during LangGraph model calls
- stops injecting App Context as a separate `SystemMessage` from `before_agent`, avoiding non-consecutive system messages after LangGraph reducers run
- updates middleware regression tests for state context, runtime context, forwarded-header filtering, and message-history no-op behavior

## Root cause
`before_agent` inserted a new App Context `SystemMessage` into `state["messages"]`, but the LangGraph message reducer can append new message IDs rather than preserving positional insertion. With an existing system prompt and prior conversation turns, this can produce multiple non-consecutive system messages, which `langchain-anthropic` rejects.

Fixes #5610.

## Validation
- `uv run pytest -q`