### PR TITLE
fix(runtime): route proxied MCP reads over SSE

### DIFF
--- a/packages/core/src/__tests__/intelligence-agent.test.ts
+++ b/packages/core/src/__tests__/intelligence-agent.test.ts
@@ -1847,6 +1847,74 @@ describe("IntelligenceAgent", () => {
 });
 
 describe("ProxiedCopilotRuntimeAgent (intelligence mode)", () => {
+  it("runs proxied MCP requests over HTTP instead of the intelligence delegate", async () => {
+    const sseBody = [
+      `data: ${JSON.stringify({
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+      })}`,
+      "",
+      `data: ${JSON.stringify({
+        type: EventType.RUN_FINISHED,
+        threadId: "thread-1",
+        runId: "run-1",
+      })}`,
+      "",
+    ].join("\n");
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(sseBody, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    );
+
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "http://localhost:4000/api/copilotkit",
+      agentId: "default",
+      runtimeMode: RUNTIME_MODE_INTELLIGENCE,
+      intelligence: { wsUrl: "ws://localhost:4401/client" },
+    });
+
+    const events: BaseEvent[] = [];
+    await new Promise<void>((resolve, reject) => {
+      agent
+        .run({
+          ...defaultInput,
+          forwardedProps: {
+            __proxiedMCPRequest: {
+              method: "resources/read",
+              serverId: "example_mcp_app",
+              serverHash: "server-hash",
+              params: { uri: "ui://excalidraw/mcp-app.html" },
+            },
+          },
+        })
+        .subscribe({
+          next: (event) => events.push(event),
+          complete: resolve,
+          error: reject,
+        });
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toBe("http://localhost:4000/api/copilotkit/agent/default/run");
+    expect(JSON.parse(init.body)).toMatchObject({
+      forwardedProps: {
+        __proxiedMCPRequest: {
+          method: "resources/read",
+          serverId: "example_mcp_app",
+        },
+      },
+    });
+    expect(events.map((event) => event.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_FINISHED,
+    ]);
+  });
+
   // Mirrors the real demo wiring: Vite app → BFF runtime that exposes a
   // ProxiedCopilotRuntimeAgent in intelligence mode → IntelligenceAgent delegate
   // talking to the realtime gateway. On thread resume, gateway replay emits

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -344,7 +344,10 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
   }
 
   public run(input: RunAgentInput): Observable<BaseEvent> {
-    if (this.runtimeMode === RUNTIME_MODE_INTELLIGENCE) {
+    if (
+      this.runtimeMode === RUNTIME_MODE_INTELLIGENCE &&
+      input.forwardedProps?.__proxiedMCPRequest === undefined
+    ) {
       return this.#runViaDelegate(input);
     }
     return this.#runViaHttp(input);

--- a/packages/runtime/src/v2/runtime/__tests__/handle-run.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handle-run.test.ts
@@ -1,12 +1,60 @@
 import { EMPTY, Observable } from "rxjs";
 import { describe, it, expect, vi } from "vitest";
-import type { BaseEvent, RunAgentInput, RunAgentResult } from "@ag-ui/client";
+import type {
+  BaseEvent,
+  Message,
+  RunAgentInput,
+  RunAgentResult,
+} from "@ag-ui/client";
 import { AbstractAgent, EventType, HttpAgent } from "@ag-ui/client";
 import { A2UIMiddleware } from "@ag-ui/a2ui-middleware";
 import { handleRunAgent } from "../handlers/handle-run";
 import { CopilotRuntime } from "../core/runtime";
 import { IntelligenceAgentRunner } from "../runner/intelligence";
 import { InMemoryAgentRunner } from "../runner/in-memory";
+
+type RunCallbacks = {
+  onEvent: (event: { event: BaseEvent }) => void | Promise<void>;
+  onNewMessage?: (args: { message: Message }) => void | Promise<void>;
+  onRunStartedEvent?: () => void | Promise<void>;
+};
+
+class ProxiedMCPTestAgent extends AbstractAgent {
+  async runAgent(
+    input: RunAgentInput,
+    callbacks: RunCallbacks,
+  ): Promise<RunAgentResult> {
+    await callbacks.onEvent({
+      event: {
+        type: EventType.RUN_STARTED,
+        threadId: input.threadId,
+        runId: input.runId,
+      },
+    });
+    await callbacks.onRunStartedEvent?.();
+    await callbacks.onEvent({
+      event: {
+        type: EventType.RUN_FINISHED,
+        threadId: input.threadId,
+        runId: input.runId,
+      },
+    });
+
+    return { result: undefined, newMessages: [] };
+  }
+
+  run(): ReturnType<AbstractAgent["run"]> {
+    return EMPTY;
+  }
+
+  protected connect(): ReturnType<AbstractAgent["connect"]> {
+    return EMPTY;
+  }
+
+  clone(): AbstractAgent {
+    return new ProxiedMCPTestAgent();
+  }
+}
 
 describe("handleRunAgent", () => {
   const createMockRuntime = (
@@ -161,6 +209,69 @@ describe("handleRunAgent", () => {
     });
     expect(recordedHeaders[0]).not.toHaveProperty("origin");
     expect(recordedHeaders[0]).not.toHaveProperty("content-type");
+  });
+
+  it("serves proxied MCP resource runs over SSE for intelligence runtimes", async () => {
+    const runtime = {
+      mode: "intelligence",
+      intelligence: {},
+      agents: Promise.resolve({ "test-agent": new ProxiedMCPTestAgent() }),
+      transcriptionService: undefined,
+      beforeRequestMiddleware: undefined,
+      afterRequestMiddleware: undefined,
+      runner: new IntelligenceAgentRunner({
+        url: "ws://localhost:4000/runner",
+      }),
+      a2ui: undefined,
+      mcpApps: undefined,
+      openGenerativeUI: undefined,
+      debug: false,
+    } as unknown as CopilotRuntime;
+
+    const request = new Request("https://example.com/agent/test-agent/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        threadId: "thread-1",
+        runId: "run-1",
+        state: {},
+        messages: [],
+        tools: [],
+        context: [],
+        forwardedProps: {
+          __proxiedMCPRequest: {
+            method: "resources/read",
+            serverId: "example_mcp_app",
+            serverHash: "server-hash",
+            params: { uri: "ui://excalidraw/mcp-app.html" },
+          },
+        },
+      }),
+    });
+
+    const response = await handleRunAgent({
+      runtime,
+      request,
+      agentId: "test-agent",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+
+    const reader = response.body!.getReader();
+    const chunks: string[] = [];
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      chunks.push(
+        typeof value === "string" ? value : new TextDecoder().decode(value),
+      );
+    }
+    const body = chunks.join("");
+
+    expect(body).toContain('data: {"type":"RUN_STARTED"');
+    expect(body).toContain('data: {"type":"RUN_FINISHED"');
+    expect(() => JSON.parse(body)).toThrow();
   });
 
   const createMockAgentWithUse = () => {

--- a/packages/runtime/src/v2/runtime/__tests__/handle-run.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handle-run.test.ts
@@ -1,50 +1,30 @@
 import { EMPTY, Observable } from "rxjs";
-import { describe, it, expect, vi } from "vitest";
-import type {
-  BaseEvent,
-  Message,
-  RunAgentInput,
-  RunAgentResult,
-} from "@ag-ui/client";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { BaseEvent, RunAgentInput, RunAgentResult } from "@ag-ui/client";
 import { AbstractAgent, EventType, HttpAgent } from "@ag-ui/client";
 import { A2UIMiddleware } from "@ag-ui/a2ui-middleware";
+import { getServerHash } from "@ag-ui/mcp-apps-middleware";
+import { LLMock, MCPMock } from "@copilotkit/aimock";
 import { handleRunAgent } from "../handlers/handle-run";
 import { CopilotRuntime } from "../core/runtime";
 import { IntelligenceAgentRunner } from "../runner/intelligence";
 import { InMemoryAgentRunner } from "../runner/in-memory";
 
-type RunCallbacks = {
-  onEvent: (event: { event: BaseEvent }) => void | Promise<void>;
-  onNewMessage?: (args: { message: Message }) => void | Promise<void>;
-  onRunStartedEvent?: () => void | Promise<void>;
-};
-
 class ProxiedMCPTestAgent extends AbstractAgent {
-  async runAgent(
-    input: RunAgentInput,
-    callbacks: RunCallbacks,
-  ): Promise<RunAgentResult> {
-    await callbacks.onEvent({
-      event: {
+  run(input: RunAgentInput): ReturnType<AbstractAgent["run"]> {
+    return new Observable<BaseEvent>((subscriber) => {
+      subscriber.next({
         type: EventType.RUN_STARTED,
         threadId: input.threadId,
         runId: input.runId,
-      },
-    });
-    await callbacks.onRunStartedEvent?.();
-    await callbacks.onEvent({
-      event: {
+      });
+      subscriber.next({
         type: EventType.RUN_FINISHED,
         threadId: input.threadId,
         runId: input.runId,
-      },
+      });
+      subscriber.complete();
     });
-
-    return { result: undefined, newMessages: [] };
-  }
-
-  run(): ReturnType<AbstractAgent["run"]> {
-    return EMPTY;
   }
 
   protected connect(): ReturnType<AbstractAgent["connect"]> {
@@ -57,6 +37,32 @@ class ProxiedMCPTestAgent extends AbstractAgent {
 }
 
 describe("handleRunAgent", () => {
+  let llm: LLMock | undefined;
+  let mcpMock: MCPMock | undefined;
+
+  afterEach(async () => {
+    await llm?.stop().catch(() => {});
+    llm = undefined;
+    mcpMock = undefined;
+  });
+
+  async function startMcpServer(): Promise<string> {
+    mcpMock = new MCPMock();
+    mcpMock.addResource(
+      {
+        uri: "ui://excalidraw/mcp-app.html",
+        name: "Excalidraw MCP App",
+        mimeType: "text/html+mcp",
+      },
+      { text: "<html><body>Excalidraw MCP app</body></html>" },
+    );
+
+    llm = new LLMock({ port: 0 });
+    llm.mount("/mcp", mcpMock);
+    await llm.start();
+    return `${llm.url}/mcp`;
+  }
+
   const createMockRuntime = (
     agents: Record<string, unknown> = {},
   ): CopilotRuntime => {
@@ -212,6 +218,79 @@ describe("handleRunAgent", () => {
   });
 
   it("serves proxied MCP resource runs over SSE for intelligence runtimes", async () => {
+    const mcpUrl = await startMcpServer();
+    const mcpServer = {
+      type: "http" as const,
+      url: mcpUrl,
+      serverId: "example_mcp_app",
+    };
+
+    const runtime = {
+      mode: "intelligence",
+      intelligence: {},
+      agents: Promise.resolve({ "test-agent": new ProxiedMCPTestAgent() }),
+      transcriptionService: undefined,
+      beforeRequestMiddleware: undefined,
+      afterRequestMiddleware: undefined,
+      runner: new IntelligenceAgentRunner({
+        url: "ws://localhost:4000/runner",
+      }),
+      a2ui: undefined,
+      mcpApps: {
+        servers: [mcpServer],
+      },
+      openGenerativeUI: undefined,
+      debug: false,
+    } as unknown as CopilotRuntime;
+
+    const request = new Request("https://example.com/agent/test-agent/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        threadId: "thread-1",
+        runId: "run-1",
+        state: {},
+        messages: [],
+        tools: [],
+        context: [],
+        forwardedProps: {
+          __proxiedMCPRequest: {
+            method: "resources/read",
+            serverId: "example_mcp_app",
+            serverHash: getServerHash(mcpServer),
+            params: { uri: "ui://excalidraw/mcp-app.html" },
+          },
+        },
+      }),
+    });
+
+    const response = await handleRunAgent({
+      runtime,
+      request,
+      agentId: "test-agent",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+
+    const reader = response.body!.getReader();
+    const chunks: string[] = [];
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      chunks.push(
+        typeof value === "string" ? value : new TextDecoder().decode(value),
+      );
+    }
+    const body = chunks.join("");
+
+    expect(body).toContain('data: {"type":"RUN_STARTED"');
+    expect(body).toContain('data: {"type":"RUN_FINISHED"');
+    expect(body).toContain("Excalidraw MCP app");
+    expect(() => JSON.parse(body)).toThrow();
+  });
+
+  it("rejects proxied MCP resource runs for intelligence runtimes without matching MCP Apps config", async () => {
     const runtime = {
       mode: "intelligence",
       intelligence: {},
@@ -255,23 +334,11 @@ describe("handleRunAgent", () => {
       agentId: "test-agent",
     });
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get("Content-Type")).toBe("text/event-stream");
-
-    const reader = response.body!.getReader();
-    const chunks: string[] = [];
-    while (true) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      chunks.push(
-        typeof value === "string" ? value : new TextDecoder().decode(value),
-      );
-    }
-    const body = chunks.join("");
-
-    expect(body).toContain('data: {"type":"RUN_STARTED"');
-    expect(body).toContain('data: {"type":"RUN_FINISHED"');
-    expect(() => JSON.parse(body)).toThrow();
+    expect(response.status).toBe(400);
+    expect(response.headers.get("Content-Type")).toBe("application/json");
+    await expect(response.json()).resolves.toMatchObject({
+      error: "MCP Apps proxy request is not configured",
+    });
   });
 
   const createMockAgentWithUse = () => {

--- a/packages/runtime/src/v2/runtime/handlers/handle-run.ts
+++ b/packages/runtime/src/v2/runtime/handlers/handle-run.ts
@@ -1,4 +1,5 @@
 import { isIntelligenceRuntime } from "../core/runtime";
+import { InMemoryAgentRunner } from "../runner/in-memory";
 import { telemetry } from "../telemetry";
 import type { RunAgentParameters } from "./shared/agent-utils";
 import {
@@ -9,6 +10,12 @@ import {
 } from "./shared/agent-utils";
 import { handleIntelligenceRun } from "./intelligence/run";
 import { handleSseRun } from "./sse/run";
+
+function isProxiedMCPRequest(input: {
+  forwardedProps?: Record<string, unknown>;
+}): boolean {
+  return input.forwardedProps?.__proxiedMCPRequest !== undefined;
+}
 
 export async function handleRunAgent({
   runtime,
@@ -76,7 +83,7 @@ export async function handleRunAgent({
       );
     }
 
-    if (isIntelligenceRuntime(runtime)) {
+    if (isIntelligenceRuntime(runtime) && !isProxiedMCPRequest(input)) {
       return handleIntelligenceRun({
         runtime,
         request,
@@ -87,7 +94,9 @@ export async function handleRunAgent({
     }
 
     return handleSseRun({
-      runtime,
+      runtime: isProxiedMCPRequest(input)
+        ? { ...runtime, runner: new InMemoryAgentRunner() }
+        : runtime,
       request,
       agent,
       input,

--- a/packages/runtime/src/v2/runtime/handlers/handle-run.ts
+++ b/packages/runtime/src/v2/runtime/handlers/handle-run.ts
@@ -1,6 +1,7 @@
 import { isIntelligenceRuntime } from "../core/runtime";
 import { InMemoryAgentRunner } from "../runner/in-memory";
 import { telemetry } from "../telemetry";
+import { getServerHash } from "@ag-ui/mcp-apps-middleware";
 import type { RunAgentParameters } from "./shared/agent-utils";
 import {
   attachIntelligenceEnterpriseLearning,
@@ -11,10 +12,100 @@ import {
 import { handleIntelligenceRun } from "./intelligence/run";
 import { handleSseRun } from "./sse/run";
 
-function isProxiedMCPRequest(input: {
+type ProxiedMCPRequestCandidate = {
+  method?: unknown;
+  serverHash?: unknown;
+  serverId?: unknown;
+};
+
+function getProxiedMCPRequest(input: {
   forwardedProps?: Record<string, unknown>;
-}): boolean {
-  return input.forwardedProps?.__proxiedMCPRequest !== undefined;
+}): ProxiedMCPRequestCandidate | undefined {
+  const proxiedRequest = input.forwardedProps?.__proxiedMCPRequest;
+  if (proxiedRequest === undefined) {
+    return undefined;
+  }
+  if (
+    proxiedRequest === null ||
+    typeof proxiedRequest !== "object" ||
+    Array.isArray(proxiedRequest)
+  ) {
+    return {};
+  }
+  return proxiedRequest as ProxiedMCPRequestCandidate;
+}
+
+function validateMCPAppsProxyRequest({
+  runtime,
+  agentId,
+  proxiedRequest,
+}: RunAgentParameters & {
+  proxiedRequest: ProxiedMCPRequestCandidate;
+}): Response | undefined {
+  if (typeof proxiedRequest.method !== "string") {
+    return new Response(
+      JSON.stringify({
+        error: "Invalid MCP Apps proxy request",
+        message: "Proxied MCP request must include a string method.",
+      }),
+      {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  const serverId =
+    typeof proxiedRequest.serverId === "string"
+      ? proxiedRequest.serverId
+      : undefined;
+  const serverHash =
+    typeof proxiedRequest.serverHash === "string"
+      ? proxiedRequest.serverHash
+      : undefined;
+
+  if (!serverId && !serverHash) {
+    return new Response(
+      JSON.stringify({
+        error: "Invalid MCP Apps proxy request",
+        message:
+          "Proxied MCP request must include a string serverId or serverHash.",
+      }),
+      {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  const applicableServers =
+    runtime.mcpApps?.servers?.filter(
+      (server) => !server.agentId || server.agentId === agentId,
+    ) ?? [];
+
+  const hasMatchingServer = applicableServers.some((server) => {
+    const { agentId: _agentId, ...mcpServer } = server;
+    return (
+      (serverId !== undefined && mcpServer.serverId === serverId) ||
+      (serverHash !== undefined && getServerHash(mcpServer) === serverHash)
+    );
+  });
+
+  if (!hasMatchingServer) {
+    return new Response(
+      JSON.stringify({
+        error: "MCP Apps proxy request is not configured",
+        message:
+          "No configured MCP Apps server for this agent matches the proxied request.",
+      }),
+      {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  return undefined;
 }
 
 export async function handleRunAgent({
@@ -83,7 +174,8 @@ export async function handleRunAgent({
       );
     }
 
-    if (isIntelligenceRuntime(runtime) && !isProxiedMCPRequest(input)) {
+    const proxiedMCPRequest = getProxiedMCPRequest(input);
+    if (isIntelligenceRuntime(runtime) && proxiedMCPRequest === undefined) {
       return handleIntelligenceRun({
         runtime,
         request,
@@ -93,8 +185,23 @@ export async function handleRunAgent({
       });
     }
 
+    const useLocalMCPAppsProxyRunner =
+      isIntelligenceRuntime(runtime) && proxiedMCPRequest !== undefined;
+
+    if (useLocalMCPAppsProxyRunner) {
+      const invalidProxyRequest = validateMCPAppsProxyRequest({
+        runtime,
+        request,
+        agentId,
+        proxiedRequest: proxiedMCPRequest,
+      });
+      if (invalidProxyRequest) {
+        return invalidProxyRequest;
+      }
+    }
+
     return handleSseRun({
-      runtime: isProxiedMCPRequest(input)
+      runtime: useLocalMCPAppsProxyRunner
         ? { ...runtime, runner: new InMemoryAgentRunner() }
         : runtime,
       request,


### PR DESCRIPTION
## Summary
- route proxied MCP Apps resource reads over the HTTP/SSE path instead of the Intelligence delegate in `ProxiedCopilotRuntimeAgent`
- only bypass the Intelligence run handler for proxy-shaped MCP Apps requests that match configured MCP Apps servers for the target agent
- reject malformed or unconfigured proxied MCP attempts with JSON errors instead of falling through to local agent runs
- add core and runtime regressions covering the Excalidraw-style `resources/read` flow and the unconfigured-proxy rejection path

## Testing
- `NX_TUI=false fnm exec --using 22 pnpm nx run @copilotkit/core:test -- src/__tests__/intelligence-agent.test.ts`
- `NX_TUI=false fnm exec --using 22 pnpm nx run @copilotkit/runtime:test -- src/v2/runtime/__tests__/handle-run.test.ts`
- `NX_TUI=false fnm exec --using 22 pnpm nx run @copilotkit/core:check-types`
- `NX_TUI=false fnm exec --using 22 pnpm nx run @copilotkit/runtime:check-types`
- `NX_TUI=false fnm exec --using 22 pnpm nx run @copilotkit/core:build`
- `NX_TUI=false fnm exec --using 22 pnpm nx run @copilotkit/runtime:build`
- `fnm exec --using 22 pnpm oxlint packages/core/src/agent.ts packages/core/src/__tests__/intelligence-agent.test.ts packages/runtime/src/v2/runtime/handlers/handle-run.ts packages/runtime/src/v2/runtime/__tests__/handle-run.test.ts`
- `fnm exec --using 22 pnpm oxfmt --check packages/core/src/agent.ts packages/core/src/__tests__/intelligence-agent.test.ts packages/runtime/src/v2/runtime/handlers/handle-run.ts packages/runtime/src/v2/runtime/__tests__/handle-run.test.ts`
- pre-commit hook: `test, publint, attw` for affected packages passed; Nx reported `@copilotkit/sqlite-runner:test` as flaky after it passed