### PR TITLE
fix(bot-intelligence): preserve managed command reaction deliveries

### DIFF
--- a/packages/bot-intelligence/src/http-transports.test.ts
+++ b/packages/bot-intelligence/src/http-transports.test.ts
@@ -208,6 +208,95 @@ describe("HttpDeliverySource", () => {
     expect(r.env.conversationKey).toBe("slack:T1:C1:thread:1.2");
   });
 
+  it("claimOnce maps a claimed slash command delivery to a command envelope", async () => {
+    const { fetch } = fakeFetch(() => ({
+      body: {
+        claimed: true,
+        delivery: claimedDelivery({
+          turn: {
+            id: "turn_9",
+            eventId: "evt_command",
+            receivedAt: "2026-06-30T00:00:00.000Z",
+            replyTarget: {
+              adapter: "slack",
+              teamId: "T1",
+              channel: "C1",
+            },
+            input: {
+              kind: "command",
+              command: "/opentagbot",
+              text: "summarize this channel",
+              triggerId: "13345224609.738474920.8088930838d88f008e0",
+            },
+          },
+        }),
+      },
+    }));
+    const src = new HttpDeliverySource(cfg({ fetch }));
+    const r = await src.claimOnce();
+    expect("env" in r).toBe(true);
+    if (!("env" in r)) throw new Error("expected env");
+    expect(r.env).toMatchObject({
+      kind: "command",
+      deliveryId: "dlv_9",
+      turnId: "turn_9",
+      eventId: "evt_command",
+      botName: "opentagbot",
+      platform: "slack",
+      command: "/opentagbot",
+      text: "summarize this channel",
+      triggerId: "13345224609.738474920.8088930838d88f008e0",
+      route: { teamId: "T1", channel: "C1" },
+    });
+    expect(r.env.conversationKey).toBe("slack:T1:C1:thread:root");
+  });
+
+  it("claimOnce maps a claimed reaction delivery to a reaction envelope", async () => {
+    const { fetch } = fakeFetch(() => ({
+      body: {
+        claimed: true,
+        delivery: claimedDelivery({
+          turn: {
+            id: "turn_9",
+            eventId: "evt_reaction",
+            receivedAt: "2026-06-30T00:00:00.000Z",
+            replyTarget: {
+              adapter: "slack",
+              teamId: "T1",
+              channel: "C1",
+              threadTs: "1.2",
+            },
+            input: {
+              kind: "reaction",
+              rawEmoji: "thumbsup",
+              added: true,
+              messageId: "1.2",
+              threadId: "1.2",
+            },
+          },
+        }),
+      },
+    }));
+    const src = new HttpDeliverySource(cfg({ fetch }));
+    const r = await src.claimOnce();
+    expect("env" in r).toBe(true);
+    if (!("env" in r)) throw new Error("expected env");
+    expect(r.env).toMatchObject({
+      kind: "reaction",
+      deliveryId: "dlv_9",
+      turnId: "turn_9",
+      eventId: "evt_reaction",
+      botName: "opentagbot",
+      platform: "slack",
+      rawEmoji: "thumbsup",
+      added: true,
+      messageId: "1.2",
+      threadId: "1.2",
+      route: { teamId: "T1", channel: "C1", threadTs: "1.2" },
+    });
+    expect(r.env.conversationKey).toBe("slack:T1:C1:thread:1.2");
+  });
+
   it("claimOnce returns pollAfterMs when idle", async () => {
     const { fetch } = fakeFetch(() => ({
       body: { claimed: false, pollAfterMs: 500 },

--- a/packages/bot-intelligence/src/http-transports.ts
+++ b/packages/bot-intelligence/src/http-transports.ts
@@ -162,7 +162,22 @@ interface ClaimedDelivery {
     id: string;
     eventId: string;
     replyTarget: SlackReplyTarget;
-    input?: { kind: string; text: string; files?: ManagedFileRef[] };
+    input?:
+      | { kind: "text"; text?: string; files?: ManagedFileRef[] }
+      | {
+          kind: "command";
+          command: string;
+          text?: string;
+          triggerId?: string;
+          rawOptions?: Record<string, unknown>;
+        }
+      | {
+          kind: "reaction";
+          rawEmoji: string;
+          added: boolean;
+          messageId: string;
+          threadId?: string;
+        };
   };
 }
 
@@ -224,8 +239,7 @@ function conversationKeyFromReplyTarget(rt: SlackReplyTarget): string {
 }
 
 function mapDeliveryToEnvelope(d: ClaimedDelivery): ManagedIngressEnvelope {
-  return {
-    kind: "turn",
+  const base = {
     deliveryId: d.id,
     eventId: d.turn.eventId,
     turnId: d.turn.id,
@@ -233,8 +247,36 @@ function mapDeliveryToEnvelope(d: ClaimedDelivery): ManagedIngressEnvelope {
     platform: d.adapter,
     conversationKey: conversationKeyFromReplyTarget(d.turn.replyTarget),
     route: d.turn.replyTarget,
-    text: d.turn.input?.text ?? "",
-    ...(d.turn.input?.files?.length ? { files: d.turn.input.files } : {}),
+  };
+  const input = d.turn.input;
+
+  if (input?.kind === "command") {
+    return {
+      ...base,
+      kind: "command",
+      command: input.command,
+      text: input.text ?? "",
+      ...(input.triggerId ? { triggerId: input.triggerId } : {}),
+      ...(input.rawOptions ? { rawOptions: input.rawOptions } : {}),
+    };
+  }
+
+  if (input?.kind === "reaction") {
+    return {
+      ...base,
+      kind: "reaction",
+      rawEmoji: input.rawEmoji,
+      added: input.added,
+      messageId: input.messageId,
+      ...(input.threadId ? { threadId: input.threadId } : {}),
+    };
+  }
+
+  return {
+    ...base,
+    kind: "turn",
+    text: input?.text ?? "",
+    ...(input?.files?.length ? { files: input.files } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

- Preserves managed `command` and `reaction` delivery inputs in `HttpDeliverySource` instead of coercing every claim into a normal turn.
- Adds focused HTTP transport coverage for slash command and reaction claim mapping.

## Why

The Intelligence managed Slack path now leases slash commands and reactions as typed turn inputs. The SDK runtime must preserve those variants so bot-core dispatch reaches `onCommand` and `onReaction`.

This PR is intentionally stacked on Alem's `codex/oss-402-sdk-render-events` branch and does not modify that branch.

## How

- Narrows the claimed delivery input type to the managed text/command/reaction variants currently delivered by app-api.
- Maps `input.kind === "command"` to a managed command envelope with command text, trigger id, and raw options when present.
- Maps `input.kind === "reaction"` to a managed reaction envelope with emoji, add/remove state, and message/thread ids.

Verification:
- `vitest run --config vitest.config.ts src/http-transports.test.ts`
- `vitest run --config vitest.config.ts`
- `tsc --noEmit -p tsconfig.json`
- `tsc --noEmit -p tsconfig.check.json`
- Pre-commit hook ran package build/test/publint/attw for `@copilotkit/bot-intelligence`.