### PR TITLE
fix(react-core): sync tools on first render so HttpAgent backends receive frontend tools

### DIFF
--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -737,16 +737,25 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   ]);
 
   // Sync render/tool arrays to the stable instance via setters.
-  // On mount, the constructor already receives the correct initial values,
-  // so we skip the first invocation. This is critical because child hooks
-  // (e.g., useFrontendTool, useHumanInTheLoop) register tools dynamically
-  // via addTool()/setRenderToolCalls() in their own effects, which fire
-  // BEFORE parent effects (React fires effects bottom-up). If the parent
-  // setter effects ran on mount, they would overwrite the children's tools.
+  //
+  // setTools — runs on every change including the first render cycle.
+  // This is intentional: when useFrontendTool hooks register via addTool()
+  // (child effects, which fire BEFORE parent effects in React), allTools
+  // updates on the same render cycle. We must call setTools() to replace
+  // the initial empty _tools array that was set during construction with the
+  // fully-populated list. Skipping the first invocation (as the guards below
+  // do for render/activity/custom arrays) would leave backends that receive
+  // RunAgentInput.tools (e.g. HttpAgent via CopilotRuntime) with an empty
+  // tools array on the first run. See: https://github.com/CopilotKit/CopilotKit/issues/5813
+  //
+  // setRenderToolCalls / setRenderActivityMessages / setRenderCustomMessages —
+  // skip the first invocation via didMountRef. This is still critical for
+  // these arrays because their child hooks register via addHookRenderToolCall()
+  // which bypasses setRenderToolCalls entirely, so running the setter on mount
+  // would overwrite already-registered child renderers.
   const didMountRef = useRef(false);
 
   useEffect(() => {
-    if (!didMountRef.current) return;
     copilotkit.setTools(allTools);
   }, [copilotkit, allTools]);
 


### PR DESCRIPTION
## What does this PR do?

When `CopilotKitProvider` is initialized, `runHandler.initialize(tools)` receives
`tools = []` because `useFrontendTool` effects haven't fired yet. The `setTools`
effect was guarded by `didMountRef` — same as the render/activity/custom array
setters — which blocked it from running on the first render cycle when
`useFrontendTool` hooks register their tools.

This means `buildFrontendTools()` returns `[]` when `runAgent` fires on the first
user message, so `RunAgentInput.tools = []` reaches the backend. Any AG-UI
`HttpAgent` backend using `AGUIToolset` for HITL tools (e.g. `confirmSkillMd`,
`askUserQuestion`) never receives them — the agent cannot call frontend tools at all.

**Fix:** Remove the `didMountRef` guard from the `setTools` effect only.

The guard remains correct for `setRenderToolCalls`, `setRenderActivityMessages`, and
`setRenderCustomMessages` because those use `addHookRenderToolCall()` which bypasses
the setter. But `setTools` must run on every `allTools` change to stay in sync with
dynamically registered `useFrontendTool` hooks.

The block comment above the effects has been updated to explain why `setTools` is now
treated differently from the other setters.

**Verified with:**
- `@copilotkit/react-core` v1.62.1
- `ag-ui-adk` v0.5.1 + `google-adk` v1.27.3
- Backend: `HttpAgent` proxied via `CopilotRuntime`

## Related PRs and Issues

- Fixes #5813
- Related to #4952 (same symptom with `openGenerativeUI` enabled)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation (comment updated)
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)