### PR TITLE
Fix/5813 forward frontend tools direct runagent

### DIFF
--- a/packages/core/src/__tests__/proxied-runtime-transport.test.ts
+++ b/packages/core/src/__tests__/proxied-runtime-transport.test.ts
@@ -234,6 +234,117 @@ describe("ProxiedCopilotRuntimeAgent capabilities", () => {
   });
 });
 
+// Regression test for CopilotKit/CopilotKit#5813: a direct `agent.runAgent()`
+// call (bypassing `CopilotKitCore.runAgent`) must still forward frontend tools
+// supplied by `toolsProvider` in `RunAgentInput.tools`.
+describe("ProxiedCopilotRuntimeAgent frontend tools forwarding (#5813)", () => {
+  const originalFetch = global.fetch;
+  const runtimeUrl = "https://runtime.example/tools";
+
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(() => Promise.resolve(createSseResponse()));
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  const frontendTool = {
+    name: "confirmSkillMd",
+    description: "Confirm the generated SKILL.md",
+    parameters: {
+      type: "object" as const,
+      properties: {},
+    },
+  };
+
+  it("merges toolsProvider tools into a direct run() request", async () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl,
+      agentId: "skill-agent",
+      transport: "rest",
+      toolsProvider: () => [frontendTool],
+    });
+
+    await agent.runAgent({});
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.tools).toEqual([frontendTool]);
+  });
+
+  it("merges toolsProvider tools into a direct connect() request", async () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl,
+      agentId: "skill-agent",
+      transport: "rest",
+      toolsProvider: () => [frontendTool],
+    });
+
+    await agent.connectAgent({});
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.tools).toEqual([frontendTool]);
+  });
+
+  it("does not duplicate a tool already present on the input (input wins)", async () => {
+    const inputTool = {
+      name: "confirmSkillMd",
+      description: "input-provided version",
+      parameters: { type: "object" as const, properties: {} },
+    };
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl,
+      agentId: "skill-agent",
+      transport: "rest",
+      toolsProvider: () => [frontendTool],
+    });
+
+    await agent.runAgent({ tools: [inputTool] });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.tools).toEqual([inputTool]);
+  });
+
+  it("is a no-op when toolsProvider is not set", async () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl,
+      agentId: "skill-agent",
+      transport: "rest",
+    });
+
+    await agent.runAgent({});
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.tools ?? []).toEqual([]);
+  });
+
+  it("clone() preserves toolsProvider", async () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl,
+      agentId: "skill-agent",
+      transport: "rest",
+      toolsProvider: () => [frontendTool],
+    });
+
+    const cloned = agent.clone();
+    await cloned.runAgent({});
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.tools).toEqual([frontendTool]);
+  });
+});
+
 describe("ProxiedCopilotRuntimeAgent cloning", () => {
   const originalFetch = global.fetch;
   const runtimeUrl = "https://runtime.example/single";

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -7,6 +7,7 @@ import type {
   RunAgentInput,
   RunAgentParameters,
   RunAgentResult,
+  Tool,
 } from "@ag-ui/client";
 import {
   HttpAgent,
@@ -95,6 +96,16 @@ export interface ProxiedCopilotRuntimeAgentConfig extends Omit<
    * bookkeeping; only outbound routing is overridden.
    */
   runtimeAgentId?: string;
+  /**
+   * Supplies CopilotKit frontend tools (registered via `useFrontendTool`) for
+   * a given agent id. When present, `run()`/`connect()` merge these into
+   * `input.tools` so a DIRECT `agent.runAgent()` call still forwards frontend
+   * tools — matching the behaviour of `CopilotKitCore.runAgent({ agent })`,
+   * which is the only path that calls `buildFrontendTools()`. Without this,
+   * runs started via the raw agent (e.g. a custom starter chip) reach the
+   * backend with `tools: []`. See CopilotKit/CopilotKit#5813.
+   */
+  toolsProvider?: (agentId?: string) => Tool[];
 }
 
 export class ProxiedCopilotRuntimeAgent extends HttpAgent {
@@ -112,6 +123,7 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
   private _capabilities?: AgentCapabilities;
   private delegate?: AbstractAgent;
   private runtimeInfoPromise?: Promise<void>;
+  private toolsProvider?: (agentId?: string) => Tool[];
 
   constructor(config: ProxiedCopilotRuntimeAgentConfig) {
     const normalizedRuntimeUrl = config.runtimeUrl
@@ -141,6 +153,7 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
     this.runtimeMode = config.runtimeMode ?? RUNTIME_MODE_SSE;
     this.intelligence = config.intelligence;
     this._capabilities = config.capabilities;
+    this.toolsProvider = config.toolsProvider;
     if (config.debug) {
       this.debug = config.debug;
     }
@@ -336,18 +349,48 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
     }
   }
 
-  connect(input: RunAgentInput): Observable<BaseEvent> {
-    if (this.runtimeMode === RUNTIME_MODE_INTELLIGENCE) {
-      return this.#connectViaDelegate(input);
+  /**
+   * Merge CopilotKit frontend tools (from `toolsProvider`) into the run input
+   * so a DIRECT `agent.runAgent()` call forwards them just like
+   * `CopilotKitCore.runAgent({ agent })` does. Tools already present on the
+   * input take precedence on a name collision, so callers that go through the
+   * core (which pre-populates `input.tools`) are never overwritten.
+   * See CopilotKit/CopilotKit#5813.
+   */
+  #withFrontendTools(input: RunAgentInput): RunAgentInput {
+    if (!this.toolsProvider) {
+      return input;
     }
-    return this.#connectViaHttp(input);
+    const frontendTools = this.toolsProvider(this.routedAgentId());
+    if (!frontendTools || frontendTools.length === 0) {
+      return input;
+    }
+    const existing = input.tools ?? [];
+    const existingNames = new Set(existing.map((t) => t.name));
+    const merged = [
+      ...existing,
+      ...frontendTools.filter((t) => !existingNames.has(t.name)),
+    ];
+    if (merged.length === existing.length) {
+      return input;
+    }
+    return { ...input, tools: merged };
+  }
+
+  connect(input: RunAgentInput): Observable<BaseEvent> {
+    const withTools = this.#withFrontendTools(input);
+    if (this.runtimeMode === RUNTIME_MODE_INTELLIGENCE) {
+      return this.#connectViaDelegate(withTools);
+    }
+    return this.#connectViaHttp(withTools);
   }
 
   public run(input: RunAgentInput): Observable<BaseEvent> {
+    const withTools = this.#withFrontendTools(input);
     if (this.runtimeMode === RUNTIME_MODE_INTELLIGENCE) {
-      return this.#runViaDelegate(input);
+      return this.#runViaDelegate(withTools);
     }
-    return this.#runViaHttp(input);
+    return this.#runViaHttp(withTools);
   }
 
   #connectViaDelegate(input: RunAgentInput): Observable<BaseEvent> {
@@ -425,6 +468,7 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
       intelligence: this.intelligence,
       capabilities: this._capabilities,
       debug: this.debug,
+      toolsProvider: this.toolsProvider,
     });
     cloned.threadId = this.threadId;
     cloned.setState(this.state);

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -279,6 +279,9 @@ export class AgentRegistry {
         : RUNTIME_MODE_SSE,
       intelligence: this._intelligence,
       debug: debug ? resolveDebugConfig(debug) : undefined,
+      // Forward frontend tools on direct agent.runAgent()/connectAgent() calls
+      // (CopilotKit/CopilotKit#5813).
+      toolsProvider: (id) => friends.buildFrontendTools(id),
     });
     this.applyHeadersToAgent(agent);
 
@@ -424,10 +427,9 @@ export class AgentRegistry {
         threadEndpoints?: ThreadEndpointRuntimeInfo;
       } = runtimeInfoResponse;
 
-      const credentials = (this.core as unknown as CopilotKitCoreFriendsAccess)
-        .credentials;
-      const rawDebug = (this.core as unknown as CopilotKitCoreFriendsAccess)
-        .debug;
+      const friends = this.core as unknown as CopilotKitCoreFriendsAccess;
+      const credentials = friends.credentials;
+      const rawDebug = friends.debug;
       const agents: Record<string, AbstractAgent> = Object.fromEntries(
         Object.entries(runtimeInfo.agents).map(
           ([id, { description, capabilities }]) => {
@@ -462,6 +464,9 @@ export class AgentRegistry {
               intelligence: runtimeInfoResponse.intelligence,
               capabilities,
               debug: rawDebug ? resolveDebugConfig(rawDebug) : undefined,
+              // Forward frontend tools on direct agent.runAgent()/connectAgent()
+              // calls (CopilotKit/CopilotKit#5813).
+              toolsProvider: (aid) => friends.buildFrontendTools(aid),
             });
             this.applyHeadersToAgent(agent);
             return [id, agent];


### PR DESCRIPTION
## What does this PR do?

Fixes #5813.

Frontend tools registered via `useFrontendTool` were not forwarded to the backend
when a run was started by calling `agent.runAgent()` / `agent.connectAgent()`
directly (the raw agent returned by `useAgent()`).

**Root cause:** Only `CopilotKitCore.runAgent({ agent })` calls
`buildFrontendTools(agentId)` and merges the result into `RunAgentInput.tools`.
A direct `agent.runAgent()` call uses the base AG-UI method, which has no
knowledge of the CopilotKit frontend-tool registry — so the backend received
`tools: []` and could not call frontend-defined HITL tools (e.g. `confirmSkillMd`,
`askUserQuestion`).

**Fix:** `ProxiedCopilotRuntimeAgent` now accepts a `toolsProvider` callback
(wired to `core.buildFrontendTools`) and merges those tools into `input.tools`
inside its `run()` / `connect()` paths — with input-provided tools taking
precedence on name collisions. This makes the public `agent.runAgent()` API
forward frontend tools for all AG-UI backends, without touching the
`didMountRef` / `setTools` timing logic in `CopilotKitProvider`.

Wired at every registry construction site so all real (non-provisional) runs
are covered.

## Related PRs and Issues

- Fixes #5813 

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked