### PR TITLE
fix(shared): don't append cleanup events after a terminal event

### DIFF
--- a/packages/runtime/src/v2/runtime/runner/__tests__/finalize-events.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/finalize-events.test.ts
@@ -82,7 +82,7 @@ describe("finalizeRunEvents", () => {
     expect(errorEvent?.message).toContain("terminal event");
   });
 
-  it("only appends structural fixes when a terminal event already exists", () => {
+  it("appends nothing once a terminal event already exists", () => {
     const events: BaseEvent[] = [
       createTextStart("msg-1"),
       createToolStart("tool-1"),
@@ -91,19 +91,27 @@ describe("finalizeRunEvents", () => {
 
     const appended = finalizeRunEvents(events);
 
-    expect(appended.map((event) => event.type)).toEqual([
-      EventType.TEXT_MESSAGE_END,
-      EventType.TOOL_CALL_END,
-    ]);
+    // The terminal event was already emitted, so any cleanup would land after
+    // it and break the AG-UI ordering invariant. Nothing may be appended.
+    expect(appended).toEqual([]);
+    expect(events.at(-1)?.type).toBe(EventType.RUN_FINISHED);
+  });
 
+  it("does not append TEXT_MESSAGE_END after a RUN_ERROR when stopped mid-message", () => {
+    // Repro for the stop-button crash: an agent errors on abort with a text
+    // message still open. Emitting a synthetic TEXT_MESSAGE_END afterwards made
+    // the AG-UI client throw "the run has already errored".
+    const events: BaseEvent[] = [
+      createTextStart("msg-1"),
+      { type: EventType.RUN_ERROR, message: "aborted" } as BaseEvent,
+    ];
+
+    const appended = finalizeRunEvents(events, { stopRequested: true });
+
+    expect(appended).toEqual([]);
     expect(
-      appended.some((event) => event.type === EventType.TOOL_CALL_RESULT),
+      events.some((event) => event.type === EventType.TEXT_MESSAGE_END),
     ).toBe(false);
-    expect(appended.some((event) => event.type === EventType.RUN_ERROR)).toBe(
-      false,
-    );
-    expect(
-      appended.some((event) => event.type === EventType.RUN_FINISHED),
-    ).toBe(false);
+    expect(events.at(-1)?.type).toBe(EventType.RUN_ERROR);
   });
 });

--- a/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
@@ -496,11 +496,11 @@ describe("IntelligenceAgentRunner", () => {
       });
     });
 
-    it("finalizes open message streams before completing", async () => {
+    it("does not append cleanup after the agent's own terminal event", async () => {
       const threadId = "t-finalize";
       const input = createRunInput({ threadId, runId: "r-fin" });
 
-      // Emit an unclosed text message, then RUN_FINISHED.
+      // Agent leaves a text message open and then emits RUN_FINISHED itself.
       const agentEvents: BaseEvent[] = [
         {
           type: EventType.TEXT_MESSAGE_START,
@@ -519,14 +519,16 @@ describe("IntelligenceAgentRunner", () => {
 
       await eventsPromise;
 
-      // finalizeRunEvents appends TEXT_MESSAGE_END for the unclosed message.
-      // Verify the channel received both agent and finalization events.
+      // The terminal was already emitted, so finalize must not push a synthetic
+      // TEXT_MESSAGE_END afterwards — that would violate the AG-UI ordering
+      // invariant and the client rejects events sent after the terminal.
       const chPayloadTypes = ch.pushLog.map((p) => p.payload.type);
       expect(chPayloadTypes).toContain(EventType.RUN_STARTED);
       expect(chPayloadTypes).toContain(EventType.TEXT_MESSAGE_START);
-      expect(chPayloadTypes).toContain(EventType.TEXT_MESSAGE_END);
+      expect(chPayloadTypes).not.toContain(EventType.TEXT_MESSAGE_END);
+      expect(chPayloadTypes.at(-1)).toBe(EventType.RUN_FINISHED);
       expect(ch.pushLog.map((p) => p.payload.metadata.cpki_event_seq)).toEqual([
-        1, 2, 3, 4,
+        1, 2, 3,
       ]);
     });
 

--- a/packages/shared/src/finalize-events.ts
+++ b/packages/shared/src/finalize-events.ts
@@ -85,8 +85,15 @@ export function finalizeRunEvents(
   const hasRunError = events.some(
     (event) => event.type === EventType.RUN_ERROR,
   );
-  const hasTerminalEvent = hasRunFinished || hasRunError;
-  const terminalEventMissing = !hasTerminalEvent;
+
+  // A terminal event (RUN_FINISHED / RUN_ERROR) was already emitted for this
+  // run — e.g. the agent errored on abort before closing an open message.
+  // Appending structural cleanup now would place TEXT_MESSAGE_END / TOOL_CALL_END
+  // after the terminal, which the AG-UI client rejects ("the run has already
+  // errored"). Leave the stream as-is once it has terminated.
+  if (hasRunFinished || hasRunError) {
+    return appended;
+  }
 
   for (const messageId of openMessageIds) {
     const endEvent = {
@@ -107,7 +114,7 @@ export function finalizeRunEvents(
       appended.push(endEvent);
     }
 
-    if (terminalEventMissing && !info.hasResult) {
+    if (!info.hasResult) {
       const resultEvent = {
         type: EventType.TOOL_CALL_RESULT,
         toolCallId,
@@ -132,22 +139,20 @@ export function finalizeRunEvents(
     }
   }
 
-  if (terminalEventMissing) {
-    if (stopRequested) {
-      const finishedEvent = {
-        type: EventType.RUN_FINISHED,
-      } as BaseEvent;
-      events.push(finishedEvent);
-      appended.push(finishedEvent);
-    } else {
-      const errorEvent: RunErrorEvent = {
-        type: EventType.RUN_ERROR,
-        message: resolvedAbruptMessage,
-        code: "INCOMPLETE_STREAM",
-      };
-      events.push(errorEvent);
-      appended.push(errorEvent);
-    }
+  if (stopRequested) {
+    const finishedEvent = {
+      type: EventType.RUN_FINISHED,
+    } as BaseEvent;
+    events.push(finishedEvent);
+    appended.push(finishedEvent);
+  } else {
+    const errorEvent: RunErrorEvent = {
+      type: EventType.RUN_ERROR,
+      message: resolvedAbruptMessage,
+      code: "INCOMPLETE_STREAM",
+    };
+    events.push(errorEvent);
+    appended.push(errorEvent);
   }
 
   return appended;


### PR DESCRIPTION
Closes #5812. Pressing Stop while an agent is still streaming text throws `Cannot send event type 'TEXT_MESSAGE_END': The run has already errored with 'RUN_ERROR'` in the browser and leaves the chat unusable.

`finalizeRunEvents` closed any open message/tool call unconditionally. When the agent already emitted a terminal event (an abort-time `RUN_ERROR` from e.g. pydantic-ai's `AGUIAdapter`, or a normal `RUN_FINISHED`) that terminal has already been dispatched to the client by the time finalize runs, so the appended `TEXT_MESSAGE_END`/`TOOL_CALL_END` land after it and the AG-UI client rejects them. Now finalize bails out as soon as a terminal event is present — the synthetic cleanup only exists to repair streams that ended without a terminal, so there's nothing to do once the run has terminated.

Added a regression for the stop-mid-message case and updated the existing terminal-present tests, which were asserting the old append-after-terminal behavior.