### PR TITLE
fix(core): add circuit breaker for identical follow-up loops

### DIFF
--- a/packages/core/src/__tests__/core-follow-up.test.ts
+++ b/packages/core/src/__tests__/core-follow-up.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { CopilotKitCore } from "../core";
-import { FrontendTool } from "../types";
+import type { FrontendTool } from "../types";
 import {
   MockAgent,
   createAssistantMessage,
@@ -203,6 +203,121 @@ describe("CopilotKitCore.runAgent - Follow-up Logic", () => {
     const result = await copilotKitCore.runAgent({ agent: agent as any });
 
     expect(result.newMessages).toEqual([finalMessage]);
+  });
+
+  it("stops follow-up runs after 3 consecutive identical tool calls", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = vi.fn(async () => "Result");
+    copilotKitCore.addTool(
+      createTool({ name: "loopTool", handler, followUp: true }),
+    );
+
+    // Same tool call (fresh id) every run — loops forever without a breaker.
+    // runAgentDelay lets vitest time out instead of hanging if it does.
+    const agent = new MockAgent({ newMessages: [], runAgentDelay: 1 });
+    agent.runAgentCallback = () => {
+      agent.setNewMessages([createToolCallMessage("loopTool", { q: "same" })]);
+    };
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "test",
+      agent: agent as any,
+    });
+
+    await copilotKitCore.runAgent({ agent: agent as any });
+
+    expect(agent.runAgentCalls).toHaveLength(3);
+    expect(handler).toHaveBeenCalledTimes(3);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("follow-up"));
+  });
+
+  it("allows the same tool to be called repeatedly with changing arguments", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    copilotKitCore.addTool(
+      createTool({
+        name: "pagerTool",
+        handler: vi.fn(async () => "Result"),
+        followUp: true,
+      }),
+    );
+
+    const agent = new MockAgent({ newMessages: [] });
+    let callCount = 0;
+    agent.runAgentCallback = () => {
+      callCount++;
+      if (callCount <= 5) {
+        agent.setNewMessages([
+          createToolCallMessage("pagerTool", { page: callCount }),
+        ]);
+      } else {
+        agent.setNewMessages([createAssistantMessage({ content: "Done" })]);
+      }
+    };
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "test",
+      agent: agent as any,
+    });
+
+    await copilotKitCore.runAgent({ agent: agent as any });
+
+    expect(agent.runAgentCalls).toHaveLength(6);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("treats identical arguments with different key order as identical", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    copilotKitCore.addTool(
+      createTool({
+        name: "loopTool",
+        handler: vi.fn(async () => "Result"),
+        followUp: true,
+      }),
+    );
+
+    const agent = new MockAgent({ newMessages: [], runAgentDelay: 1 });
+    let callCount = 0;
+    agent.runAgentCallback = () => {
+      callCount++;
+      const args =
+        callCount % 2 === 0 ? { a: 1, b: { c: 2 } } : { b: { c: 2 }, a: 1 };
+      agent.setNewMessages([createToolCallMessage("loopTool", args)]);
+    };
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "test",
+      agent: agent as any,
+    });
+
+    await copilotKitCore.runAgent({ agent: agent as any });
+
+    expect(agent.runAgentCalls).toHaveLength(3);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the breaker between top-level runs", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    copilotKitCore.addTool(
+      createTool({
+        name: "loopTool",
+        handler: vi.fn(async () => "Result"),
+        followUp: true,
+      }),
+    );
+
+    const agent = new MockAgent({ newMessages: [], runAgentDelay: 1 });
+    agent.runAgentCallback = () => {
+      agent.setNewMessages([createToolCallMessage("loopTool", { q: "same" })]);
+    };
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "test",
+      agent: agent as any,
+    });
+
+    await copilotKitCore.runAgent({ agent: agent as any });
+    await copilotKitCore.runAgent({ agent: agent as any });
+
+    // Each top-level run gets a fresh breaker: 3 calls per run, not 3 total.
+    expect(agent.runAgentCalls).toHaveLength(6);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
   });
 
   it("should handle multiple recursive follow-ups (chain)", async () => {

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -102,6 +102,15 @@ export class RunHandler {
   private _runDepth = 0;
 
   /**
+   * Circuit breaker for recursive follow-up runs (see `processAgentResult`):
+   * tracks the tool-call signature of the previous follow-up round so that
+   * consecutive identical rounds can be detected and stopped. Reset on every
+   * top-level `runAgent` call.
+   */
+  private _lastFollowUpSignature = "";
+  private _identicalFollowUpRounds = 0;
+
+  /**
    * Tracks the threadId of the most recent `connectAgent` call so we
    * can distinguish a fresh thread restore (different threadId than
    * last time — chat is rebuilding state from scratch, must clear
@@ -379,6 +388,8 @@ export class RunHandler {
     let originalAbortRun: (() => void) | undefined;
 
     if (isTopLevel) {
+      this._lastFollowUpSignature = "";
+      this._identicalFollowUpRounds = 0;
       this._runAbortController = new AbortController();
 
       // Intercept agent.abortRun() so that calling it directly (not via
@@ -514,12 +525,30 @@ export class RunHandler {
     }
 
     if (needsFollowUp && !this._runAbortController?.signal.aborted) {
-      // Yield to the framework scheduler before the follow-up run so that any
-      // deferred state updates (e.g. React useEffect in useAgentContext) can
-      // complete and write fresh values into the context store before runAgent
-      // reads it. The base implementation is a no-op; React overrides this.
-      await this._internal.waitForPendingFrameworkUpdates();
-      return await this.runAgent({ agent });
+      // Circuit breaker: when the agent keeps producing the exact same tool
+      // calls (same names, same arguments) round after round, it is stuck in
+      // a loop — stop recursing instead of running forever (#4819).
+      const signature = followUpSignature(newMessages);
+      if (signature === this._lastFollowUpSignature) {
+        this._identicalFollowUpRounds++;
+      } else {
+        this._lastFollowUpSignature = signature;
+        this._identicalFollowUpRounds = 1;
+      }
+      if (
+        this._identicalFollowUpRounds >= MAX_CONSECUTIVE_IDENTICAL_FOLLOW_UPS
+      ) {
+        logger.warn(
+          `CopilotKit: stopping follow-up runs after ${this._identicalFollowUpRounds} consecutive identical tool-call rounds — the agent appears to be stuck in a loop. Returning the current result.`,
+        );
+      } else {
+        // Yield to the framework scheduler before the follow-up run so that any
+        // deferred state updates (e.g. React useEffect in useAgentContext) can
+        // complete and write fresh values into the context store before runAgent
+        // reads it. The base implementation is a no-op; React overrides this.
+        await this._internal.waitForPendingFrameworkUpdates();
+        return await this.runAgent({ agent });
+      }
     }
 
     void this._internal.suggestionEngine.reloadSuggestions(agentId);
@@ -1140,4 +1169,45 @@ export function parseToolArguments(
   }
   const parsed = typeof rawArgs === "string" ? JSON.parse(rawArgs) : rawArgs;
   return ensureObjectArgs(parsed, toolName);
+}
+
+const MAX_CONSECUTIVE_IDENTICAL_FOLLOW_UPS = 3;
+
+/**
+ * Signature of a follow-up round: every assistant tool call in the run's new
+ * messages as name + arguments, with JSON object keys sorted so that equal
+ * payloads compare equal regardless of key order.
+ */
+function followUpSignature(newMessages: Message[]): string {
+  return newMessages
+    .flatMap((message) =>
+      message.role === "assistant" ? (message.toolCalls ?? []) : [],
+    )
+    .map(
+      (toolCall) =>
+        `${toolCall.function.name}:${normalizeArguments(toolCall.function.arguments)}`,
+    )
+    .join("|");
+}
+
+function normalizeArguments(args: string): string {
+  try {
+    return JSON.stringify(sortObjectKeys(JSON.parse(args)));
+  } catch {
+    return args;
+  }
+}
+
+function sortObjectKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortObjectKeys);
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([a], [b]) => (a < b ? -1 : 1))
+        .map(([key, child]) => [key, sortObjectKeys(child)]),
+    );
+  }
+  return value;
 }


### PR DESCRIPTION
## What does this PR do?

`processAgentResult` recurses into `runAgent` whenever `needsFollowUp` is true, with no safeguard against the agent repeating itself. Any scenario that keeps producing the same tool calls (LLM repeating a call, backend `RunError` after tool results, reprocessed tool messages) loops forever and silently consumes API quota (#4819).

This PR adds a signature-based circuit breaker to `processAgentResult`:

- Each follow-up round gets a signature: every assistant tool call in the run's new messages, as tool name + arguments normalized by recursively sorting JSON object keys. Two generations of the same call compare equal regardless of key order.
- Consecutive identical rounds are counted within one top-level run. After 3 identical rounds the breaker trips: a `logger.warn` is emitted and the current result is returned normally, so tool messages already inserted are preserved.
- The same tool called repeatedly with changing arguments never trips the breaker, so legitimate multi-step workflows (search, fill form, confirm, update, send) are unaffected.
- Breaker state is reset on every top-level `runAgent` call, so a tripped run never leaks into the next one.

Complementary to #5158 (absolute depth cap): the depth cap bounds any runaway recursion regardless of pattern, including alternating cycles this breaker does not target, while this breaker catches the common identical-loop case after 3 rounds instead of 100.

### Tests

- 4 new tests in `core-follow-up.test.ts` (breaker trips at 3, changing args allowed, key-order normalization, per-run reset), written before the fix and verified to fail against current `main`.
- `@copilotkit/core`: 49 files / 555 tests pass. `tsc --noEmit`, `oxlint`, `oxfmt --check` and `build` all pass.
- Downstream suites verified: `@copilotkit/react-core` (1413 tests) and `@copilotkit/vue` (1066 tests) pass.

## Related PRs and Issues

- Fixes #4819
- Complementary to #5158

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation (no user-facing API change, internal safeguard with a console warning)
- [x] "Allow edits by maintainers" is checked