### PR TITLE
docs(langgraph,crewai-flows): remove broken useCopilotContext example

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/persistence/loading-message-history.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/persistence/loading-message-history.mdx
@@ -58,18 +58,3 @@ const YourApp = ({ setThreadId }) => {
   );
 };
 ```
-
-### Using setThreadId
-
-CopilotKit provides the current `threadId` and a `setThreadId` function from the `useCopilotContext` hook:
-
-```tsx
-const ChangeThreadButton = () => {
-  const { threadId, setThreadId } = useCopilotContext();
-  return (
-    <Button onClick={() => setThreadId("d73c22f3-1f8e-4a93-99db-5c986068d64f")}>
-      Change Thread
-    </Button>
-  );
-};
-```

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/advanced/persistence/loading-message-history.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/advanced/persistence/loading-message-history.mdx
@@ -49,20 +49,3 @@ const YourApp = ({ setThreadId }) => {
   )
 }
 ```
-
-## Using setThreadId
-
-CopilotKit will also return the current `threadId` and a `setThreadId` function from the `useCopilotContext` hook. You can use `setThreadId` to change the `threadId`.
-
-```tsx
-
-const ChangeThreadButton = () => {
-  const { threadId, setThreadId } = useCopilotContext(); // [!code highlight]
-  return (
-    {/* [!code highlight:1] */}
-    <Button onClick={() => setThreadId("d73c22f3-1f8e-4a93-99db-5c986068d64f")}>
-      Change Thread
-    </Button>
-  )
-}
-```


### PR DESCRIPTION
## What does this PR do?

Removes the "Using setThreadId" example from the LangGraph and CrewAI Flows persistence docs. That example calls `useCopilotContext()`, which is a v1-only hook not exported from `@copilotkit/react-core/v2` — following the example as written throws a module resolution error for v2 users.

The preceding "Dynamically Switching Threads" section on the same page already documents the correct, working pattern (plain React state + the `threadId` prop on `<CopilotKit>`), so removing the broken section doesn't leave a gap.

## Related PRs and Issues

Closes #3860

## Files changed

- `showcase/shell-docs/src/content/docs/integrations/langgraph/advanced/persistence/loading-message-history.mdx`
- `showcase/shell-docs/src/content/docs/integrations/crewai-flows/persistence/loading-message-history.mdx`

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] Docs-only change; no functionality updated
- [x] Allow edits by maintainers