### PR TITLE
fix(showcase): stop Railway crashes — log-flood gating + langgraph persistence/OOM hardening

### DIFF
--- a/showcase/integrations/ag2/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/ag2/src/app/api/copilotkit/route.ts
@@ -13,6 +13,14 @@ const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 console.log("[copilotkit/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit/route] AGENT_URL: ${AGENT_URL}`);
 
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
+
 function createAgent(path = "/") {
   return new HttpAgent({ url: `${AGENT_URL}${path}` });
 }
@@ -101,7 +109,11 @@ console.log(
 export const POST = async (req: NextRequest) => {
   const url = req.url;
   const contentType = req.headers.get("content-type");
-  console.log(`[copilotkit/route] POST ${url} (content-type: ${contentType})`);
+  if (ROUTE_DEBUG) {
+    console.log(
+      `[copilotkit/route] POST ${url} (content-type: ${contentType})`,
+    );
+  }
 
   try {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
@@ -114,7 +126,11 @@ export const POST = async (req: NextRequest) => {
     });
 
     const response = await handleRequest(req);
-    console.log(`[copilotkit/route] Response status: ${response.status}`);
+    if (!response.ok) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    } else if (ROUTE_DEBUG) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    }
     return response;
   } catch (error: unknown) {
     // Log full details server-side (operators grep `errorId` to correlate),
@@ -140,7 +156,9 @@ export const POST = async (req: NextRequest) => {
 };
 
 export const GET = async () => {
-  console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  if (ROUTE_DEBUG) {
+    console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  }
 
   let agentStatus = "unknown";
   try {

--- a/showcase/integrations/agno/src/app/api/copilotkit-byoc-hashbrown/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-byoc-hashbrown/route.ts
@@ -12,6 +12,14 @@ const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
 console.log(`[copilotkit-byoc-hashbrown/route] AGENT_URL: ${AGENT_URL}`);
 
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
+
 function createByocHashbrownAgent() {
   return new HttpAgent({
     url: `${AGENT_URL}/byoc-hashbrown/agui`,
@@ -27,7 +35,9 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   const url = req.url;
-  console.log(`[copilotkit-byoc-hashbrown/route] POST ${url}`);
+  if (ROUTE_DEBUG) {
+    console.log(`[copilotkit-byoc-hashbrown/route] POST ${url}`);
+  }
 
   try {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
@@ -39,9 +49,15 @@ export const POST = async (req: NextRequest) => {
       }),
     });
     const response = await handleRequest(req);
-    console.log(
-      `[copilotkit-byoc-hashbrown/route] Response status: ${response.status}`,
-    );
+    if (!response.ok) {
+      console.log(
+        `[copilotkit-byoc-hashbrown/route] Response status: ${response.status}`,
+      );
+    } else if (ROUTE_DEBUG) {
+      console.log(
+        `[copilotkit-byoc-hashbrown/route] Response status: ${response.status}`,
+      );
+    }
     return response;
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };

--- a/showcase/integrations/agno/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -17,6 +17,14 @@ const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
 console.log(`[copilotkit-declarative-hashbrown/route] AGENT_URL: ${AGENT_URL}`);
 
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
+
 function createDeclarativeHashbrownAgent() {
   return new HttpAgent({
     url: `${AGENT_URL}/byoc-hashbrown/agui`,
@@ -32,7 +40,9 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   const url = req.url;
-  console.log(`[copilotkit-declarative-hashbrown/route] POST ${url}`);
+  if (ROUTE_DEBUG) {
+    console.log(`[copilotkit-declarative-hashbrown/route] POST ${url}`);
+  }
 
   try {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
@@ -44,9 +54,15 @@ export const POST = async (req: NextRequest) => {
       }),
     });
     const response = await handleRequest(req);
-    console.log(
-      `[copilotkit-declarative-hashbrown/route] Response status: ${response.status}`,
-    );
+    if (!response.ok) {
+      console.log(
+        `[copilotkit-declarative-hashbrown/route] Response status: ${response.status}`,
+      );
+    } else if (ROUTE_DEBUG) {
+      console.log(
+        `[copilotkit-declarative-hashbrown/route] Response status: ${response.status}`,
+      );
+    }
     return response;
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };

--- a/showcase/integrations/agno/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit/route.ts
@@ -13,6 +13,14 @@ const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 console.log("[copilotkit/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit/route] AGENT_URL: ${AGENT_URL}`);
 
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
+
 function createMainAgent() {
   return new HttpAgent({ url: `${AGENT_URL}/agui` });
 }
@@ -121,7 +129,11 @@ console.log(
 export const POST = async (req: NextRequest) => {
   const url = req.url;
   const contentType = req.headers.get("content-type");
-  console.log(`[copilotkit/route] POST ${url} (content-type: ${contentType})`);
+  if (ROUTE_DEBUG) {
+    console.log(
+      `[copilotkit/route] POST ${url} (content-type: ${contentType})`,
+    );
+  }
 
   try {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
@@ -134,7 +146,11 @@ export const POST = async (req: NextRequest) => {
     });
 
     const response = await handleRequest(req);
-    console.log(`[copilotkit/route] Response status: ${response.status}`);
+    if (!response.ok) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    } else if (ROUTE_DEBUG) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    }
     return response;
   } catch (error: unknown) {
     const err = error as Error;
@@ -148,7 +164,9 @@ export const POST = async (req: NextRequest) => {
 };
 
 export const GET = async () => {
-  console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  if (ROUTE_DEBUG) {
+    console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  }
 
   let agentStatus = "unknown";
   try {

--- a/showcase/integrations/claude-sdk-python/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/api/copilotkit/route.ts
@@ -14,6 +14,14 @@ const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 console.log("[copilotkit/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit/route] AGENT_URL: ${AGENT_URL}`);
 
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
+
 function createAgent(path = "/") {
   return new HttpAgent({ url: `${AGENT_URL}${path}` });
 }
@@ -78,7 +86,11 @@ console.log(
 export const POST = async (req: NextRequest) => {
   const url = req.url;
   const contentType = req.headers.get("content-type");
-  console.log(`[copilotkit/route] POST ${url} (content-type: ${contentType})`);
+  if (ROUTE_DEBUG) {
+    console.log(
+      `[copilotkit/route] POST ${url} (content-type: ${contentType})`,
+    );
+  }
 
   try {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
@@ -91,7 +103,11 @@ export const POST = async (req: NextRequest) => {
     });
 
     const response = await handleRequest(req);
-    console.log(`[copilotkit/route] Response status: ${response.status}`);
+    if (!response.ok) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    } else if (ROUTE_DEBUG) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    }
     return response;
   } catch (error: unknown) {
     // Log the full error server-side with a correlation id, but only return
@@ -118,7 +134,9 @@ export const POST = async (req: NextRequest) => {
 };
 
 export const GET = async () => {
-  console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  if (ROUTE_DEBUG) {
+    console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  }
 
   let agentStatus = "unknown";
   try {

--- a/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit/route.ts
@@ -18,6 +18,14 @@ const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 console.log("[copilotkit/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit/route] AGENT_URL: ${AGENT_URL}`);
 
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
+
 function createAgent() {
   return new HttpAgent({ url: `${AGENT_URL}/` });
 }
@@ -173,7 +181,11 @@ console.log(
 const copilotkitPost = async (req: NextRequest): Promise<Response> => {
   const url = req.url;
   const contentType = req.headers.get("content-type");
-  console.log(`[copilotkit/route] POST ${url} (content-type: ${contentType})`);
+  if (ROUTE_DEBUG) {
+    console.log(
+      `[copilotkit/route] POST ${url} (content-type: ${contentType})`,
+    );
+  }
 
   try {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
@@ -186,7 +198,11 @@ const copilotkitPost = async (req: NextRequest): Promise<Response> => {
     });
 
     const response = await handleRequest(req);
-    console.log(`[copilotkit/route] Response status: ${response.status}`);
+    if (!response.ok) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    } else if (ROUTE_DEBUG) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    }
     return response;
   } catch (error: unknown) {
     const err = error as Error;
@@ -207,7 +223,9 @@ export const POST = withCvdiagBackend(copilotkitPost, {
 });
 
 export const GET = async () => {
-  console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  if (ROUTE_DEBUG) {
+    console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  }
 
   let agentStatus = "unknown";
   try {

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit/route.ts
@@ -15,6 +15,14 @@ const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 console.log("[copilotkit/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit/route] AGENT_URL: ${AGENT_URL}`);
 
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
+
 function createAgent(path = "/") {
   return new HttpAgent({ url: `${AGENT_URL}${path}` });
 }
@@ -113,7 +121,11 @@ console.log(
 export const POST = async (req: NextRequest) => {
   const url = req.url;
   const contentType = req.headers.get("content-type");
-  console.log(`[copilotkit/route] POST ${url} (content-type: ${contentType})`);
+  if (ROUTE_DEBUG) {
+    console.log(
+      `[copilotkit/route] POST ${url} (content-type: ${contentType})`,
+    );
+  }
 
   try {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
@@ -126,7 +138,11 @@ export const POST = async (req: NextRequest) => {
     });
 
     const response = await handleRequest(req);
-    console.log(`[copilotkit/route] Response status: ${response.status}`);
+    if (!response.ok) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    } else if (ROUTE_DEBUG) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    }
     return response;
   } catch (error: unknown) {
     // Log full details server-side (operators grep `errorId` to correlate),
@@ -152,7 +168,9 @@ export const POST = async (req: NextRequest) => {
 };
 
 export const GET = async () => {
-  console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  if (ROUTE_DEBUG) {
+    console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  }
 
   let agentStatus = "unknown";
   try {

--- a/showcase/integrations/langgraph-fastapi/entrypoint.sh
+++ b/showcase/integrations/langgraph-fastapi/entrypoint.sh
@@ -24,14 +24,24 @@ else
 fi
 
 echo "[entrypoint] Starting LangGraph agent server on port 8123..."
+# Disable langgraph_runtime_inmem's pickle-flush-to-disk loop. Without this,
+# the inmem runtime periodically flushes unbounded thread/checkpoint state to
+# .langgraph_api/*.pckl files, which is a slow-burn OOM risk on Railway.
+# The env var is checked at import time in langgraph_runtime_inmem
+# _persistence.py and checkpoint.py (langgraph-api==0.7.101 / runtime==0.27.4).
+export LANGGRAPH_DISABLE_FILE_PERSISTENCE=true
+
 # `python -u` + `awk ... fflush()`: unbuffered stdout at the interpreter
 # level + line-flushed awk prefixer so tracebacks reach the container log
 # immediately rather than block-buffered in pipe buffers.
+# `--no-reload` disables watchfiles hot-reload, which fires on every request
+# and causes "1 change detected" log spam → Railway 500-logs/sec kill.
 python -u -m langgraph_cli dev \
   --config langgraph.json \
   --host 0.0.0.0 \
   --port 8123 \
-  --no-browser &> >(awk '{print "[agent] " $0; fflush()}') &
+  --no-browser \
+  --no-reload &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 
 sleep 3

--- a/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit/route.ts
@@ -32,6 +32,14 @@ const AGENT_URL = process.env.AGENT_URL || "http://localhost:8123";
 console.log("[copilotkit/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit/route] AGENT_URL: ${AGENT_URL}`);
 
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
+
 function createAgent(graphId: string = "sample_agent") {
   return new LangGraphAgent({
     deploymentUrl: `${AGENT_URL}/`,
@@ -124,7 +132,11 @@ export const POST = async (req: NextRequest) => {
     });
 
     const response = await handleRequest(req);
-    console.log(`[copilotkit/route] Response status: ${response.status}`);
+    if (!response.ok) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    } else if (ROUTE_DEBUG) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    }
     return response;
   } catch (error: unknown) {
     // Log full message + stack server-side under a correlation id; return

--- a/showcase/integrations/langgraph-python/entrypoint.sh
+++ b/showcase/integrations/langgraph-python/entrypoint.sh
@@ -53,17 +53,27 @@ echo "========================================="
 echo "[entrypoint] Starting LangGraph agent server on port 8123..."
 echo "========================================="
 
+# Disable langgraph_runtime_inmem's pickle-flush-to-disk loop. Without this,
+# the inmem runtime periodically flushes unbounded thread/checkpoint state to
+# .langgraph_api/*.pckl files, which is a slow-burn OOM risk on Railway.
+# The env var is checked at import time in langgraph_runtime_inmem
+# _persistence.py and checkpoint.py (langgraph-api==0.7.101 / runtime==0.27.4).
+export LANGGRAPH_DISABLE_FILE_PERSISTENCE=true
+
 # `python -u` forces unbuffered stdout/stderr at the interpreter level
 # (belt-and-suspenders with PYTHONUNBUFFERED=1 above) so langgraph_cli boot
 # failures surface in the Railway log stream immediately rather than sitting
 # in a pipe buffer until the process exits. `awk ... fflush()` replaces the
 # previous `sed` formulation — process substitution leaves $! pointing at
 # the real python process (pipe form made $! point at sed).
+# `--no-reload` disables watchfiles hot-reload, which fires on every request
+# and causes "1 change detected" log spam → Railway 500-logs/sec kill.
 python -u -m langgraph_cli dev \
   --config langgraph.json \
   --host 0.0.0.0 \
   --port 8123 \
-  --no-browser &> >(awk '{print "[langgraph] " $0; fflush()}') &
+  --no-browser \
+  --no-reload &> >(awk '{print "[langgraph] " $0; fflush()}') &
 LANGGRAPH_PID=$!
 
 # Give langgraph a moment to start

--- a/showcase/integrations/langgraph-python/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/langgraph-python/src/app/api/copilotkit/route.ts
@@ -12,6 +12,14 @@ const LANGGRAPH_URL =
 
 console.log("[copilotkit/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit/route] LANGGRAPH_URL: ${LANGGRAPH_URL}`);
+
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
 console.log(
   `[copilotkit/route] LANGSMITH_API_KEY: ${process.env.LANGSMITH_API_KEY ? "set" : "not set"}`,
 );
@@ -112,7 +120,11 @@ console.log(
 export const POST = async (req: NextRequest) => {
   const url = req.url;
   const contentType = req.headers.get("content-type");
-  console.log(`[copilotkit/route] POST ${url} (content-type: ${contentType})`);
+  if (ROUTE_DEBUG) {
+    console.log(
+      `[copilotkit/route] POST ${url} (content-type: ${contentType})`,
+    );
+  }
 
   try {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
@@ -136,7 +148,11 @@ export const POST = async (req: NextRequest) => {
     });
 
     const response = await handleRequest(req);
-    console.log(`[copilotkit/route] Response status: ${response.status}`);
+    if (!response.ok) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    } else if (ROUTE_DEBUG) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    }
     return response;
   } catch (error: any) {
     console.error(`[copilotkit/route] ERROR: ${error.message}`);
@@ -149,7 +165,9 @@ export const POST = async (req: NextRequest) => {
 };
 
 export const GET = async () => {
-  console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  if (ROUTE_DEBUG) {
+    console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  }
 
   let langGraphStatus = "unknown";
   try {

--- a/showcase/integrations/langgraph-typescript/.dockerignore
+++ b/showcase/integrations/langgraph-typescript/.dockerignore
@@ -10,3 +10,7 @@ test-results
 **/*.test.tsx
 **/*.spec.ts
 **/*.spec.tsx
+# LangGraph FileSystemPersistence state — can grow to hundreds of MB after
+# many local dev runs. Never bake developer-machine state into the image;
+# entrypoint.sh deletes it on every fresh container boot anyway.
+src/agent/.langgraph_api

--- a/showcase/integrations/langgraph-typescript/entrypoint.sh
+++ b/showcase/integrations/langgraph-typescript/entrypoint.sh
@@ -3,8 +3,79 @@ set -e
 
 cleanup() {
   kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+  # NOTE: SIZE_PID is intentionally NOT killed here.  SIZE_PID is assigned
+  # inside the watchdog subshell ( ) & so it is never visible in this outer
+  # shell.  The subshell registers its own EXIT trap to kill its SIZE_PID; see
+  # the "trap ... EXIT" inside the ( ) & block below.
 }
 trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Size-check seam: extract the per-cycle size-check-and-kill decision so it
+# can be exercised directly in tests without running the full entrypoint stack.
+#
+# Usage (normal): called by the watchdog size sub-loop below.
+# Usage (test):   LANGGRAPH_SIZE_THRESHOLD_MB=X LANGGRAPH_PERSIST_DIR_OVERRIDE=Y
+#                 AGENT_PID=Z bash entrypoint.sh --check-size-once
+#
+# Returns 0 if no action taken, 1 if the agent was killed (threshold exceeded).
+# Callers under set -e should invoke with || true if 1 is acceptable.
+# ---------------------------------------------------------------------------
+_watchdog_check_size_once() {
+  local persist_dir="${PERSIST_DIR}"
+  local threshold_mb="${SIZE_THRESHOLD_MB}"
+  local agent_pid="${AGENT_PID}"
+
+  if ! kill -0 "$agent_pid" 2>/dev/null; then
+    return 0
+  fi
+  if [ ! -d "$persist_dir" ]; then
+    echo "[watchdog:size] Persistence dir ${persist_dir} does not exist — skipping size check"
+    return 0
+  fi
+  # du -sm returns on-disk size in MiB as an integer.  This is a heuristic
+  # proxy for the in-memory superjson-serialised string size: @langchain/
+  # langgraph-api serialises state to disk on a 3-second timer, so on-disk
+  # size closely tracks serialised size but is NOT a proven bound.  We set a
+  # conservative threshold (200 MB, well under V8's ~512 MB string ceiling)
+  # to leave margin for this approximation.
+  # || true prevents set -e from killing this subshell if du fails.
+  DIR_SIZE_MB=$(du -sm "$persist_dir" 2>/dev/null | awk '{print $1}') || true
+  if [ -z "$DIR_SIZE_MB" ]; then
+    echo "[watchdog:size] WARNING: Could not read size of ${persist_dir} — size guard inactive this cycle"
+    return 0
+  fi
+  echo "[watchdog:size] Persistence dir size: ${DIR_SIZE_MB}MB (threshold: ${threshold_mb}MB)"
+  if [ "$DIR_SIZE_MB" -ge "$threshold_mb" ]; then
+    echo "[watchdog:size] Size threshold exceeded (${DIR_SIZE_MB}MB >= ${threshold_mb}MB) — killing agent PID $agent_pid to trigger container restart and boot-purge"
+    # NOTE: this kill WILL terminate any in-flight streaming runs — accepted
+    # tradeoff vs OOM/crash.  The gate is threshold-based (not a fixed timer)
+    # so it fires only when state has grown dangerously large.
+    kill -9 "$agent_pid" 2>/dev/null || true
+    return 1
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test seam: --check-size-once mode
+# Runs exactly one size-check cycle using env vars for configuration, then
+# exits.  Designed to be called from tests with a stubbed `du` on PATH.
+# Exit code: 0 = under threshold (no kill), 1 = threshold exceeded (kill issued).
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--check-size-once" ]; then
+  # In test-seam mode the caller owns the agent PID lifecycle.  Clearing the
+  # EXIT trap ensures cleanup() does NOT send a spurious SIGTERM to AGENT_PID
+  # on the way out, which would mask whether the size gate actually fired
+  # (gate fires → SIGKILL; cleanup fires → SIGTERM; both make poll() non-None,
+  # but only SIGKILL proves the gate killed the right PID).
+  trap - EXIT
+  PERSIST_DIR=${LANGGRAPH_PERSIST_DIR_OVERRIDE:-/app/src/agent/.langgraph_api}
+  SIZE_THRESHOLD_MB=${LANGGRAPH_SIZE_THRESHOLD_MB:-200}
+  AGENT_PID=${AGENT_PID:-0}
+  _watchdog_check_size_once
+  exit $?
+fi
 
 echo "========================================="
 echo "[entrypoint] Starting showcase package: langgraph-typescript"
@@ -12,6 +83,26 @@ echo "[entrypoint] Time: $(date -u)"
 echo "[entrypoint] PORT=${PORT:-not set}"
 echo "[entrypoint] NODE_ENV=${NODE_ENV:-not set}"
 echo "========================================="
+
+# Purge any persisted FileSystemPersistence state from a prior container.
+# @langchain/langgraph-api (v1.1.17) serialises ALL accumulated thread/run/
+# checkpoint state via superjson.stringify on a 3-second timer; after enough
+# runs the serialised string exceeds V8's ~512 MB string limit → uncaught
+# RangeError in a Timeout callback → event-loop hang → watchdog kill.
+# Because the state persists to disk, a plain container restart reloads the
+# bloated file and re-crashes immediately. Deleting on every fresh boot breaks
+# the cycle.
+#
+# PERSIST_DIR can be overridden by env var (useful for tests; defaults to the
+# in-container path used by @langchain/langgraph-api's FileSystemPersistence).
+PERSIST_DIR=${LANGGRAPH_PERSIST_DIR_OVERRIDE:-/app/src/agent/.langgraph_api}
+if [ -d "$PERSIST_DIR" ]; then
+  echo "[entrypoint] Purging stale LangGraph persistence state from prior container boot (${PERSIST_DIR})"
+  rm -rf "$PERSIST_DIR"
+  echo "[entrypoint] Purge complete"
+else
+  echo "[entrypoint] No prior persistence state found — clean boot"
+fi
 
 # Start LangGraph agent server in background.
 # `npm start` runs `node --import tsx liveness.mjs` (see src/agent/package.json).
@@ -79,6 +170,29 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # healthy /ok probe before arming the strike counter; if /ok comes up
 # sooner, fall through immediately. If 180s elapses without success, arm
 # the counter anyway — the steady-state watchdog will handle a true hang.
+#
+# Size-gated restart: the watchdog also periodically checks the on-disk size
+# of the PERSIST_DIR. @langchain/langgraph-api serialises state on a 3-second
+# timer; if the state grows excessively (threads accumulating across a long
+# deployment) the serialised string can approach V8's ~512 MB string limit.
+# We set a conservative SIZE_THRESHOLD_MB (200 MB — well under the ceiling,
+# with margin for the on-disk→in-memory approximation) and kill the agent
+# when crossed, triggering a container restart which re-runs the boot-purge
+# above.  This kill WILL terminate any in-flight streaming runs — accepted
+# tradeoff vs OOM/crash.  The gate is threshold-based, not a fixed timer,
+# so it fires only when state has grown dangerously large.
+# We do NOT call POST /internal/truncate because:
+#   1. ops.truncate with runs+threads+checkpointer+store=true wipes ALL runs
+#      including in-flight ones — the "in-flight not disrupted" comment on the
+#      original implementation was incorrect (R7-C1).
+#   2. /internal/truncate is an unpinned internal library route with no
+#      stability guarantee across patch releases (C2).
+SIZE_THRESHOLD_MB=${LANGGRAPH_SIZE_THRESHOLD_MB:-200}
+# 60s interval: the 3-second serialize timer means state can grow rapidly
+# under heavy probe fan-out (the original crash scenario).  300s (5 min)
+# leaves too large a window — at typical probe rates state can exceed 512MB
+# before the next check.  60s keeps the check-to-ceiling budget comfortable.
+SIZE_CHECK_INTERVAL=${LANGGRAPH_SIZE_CHECK_INTERVAL:-60}
 (
   GRACE=180
   echo "[watchdog] Startup grace: waiting up to ${GRACE}s for first successful health probe before arming strike counter"
@@ -98,6 +212,24 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
   if [ $ELAPSED -ge $GRACE ]; then
     echo "[watchdog] Grace window elapsed without successful probe — arming strike counter anyway"
   fi
+
+  # Size-gated restart sub-loop: periodically check the persistence dir size
+  # and kill the agent if it exceeds SIZE_THRESHOLD_MB. The container restart
+  # will re-run the boot-purge, clearing accumulated state safely.
+  (
+    echo "[watchdog:size] Starting size-gated restart monitor (threshold=${SIZE_THRESHOLD_MB}MB, interval=${SIZE_CHECK_INTERVAL}s, dir=${PERSIST_DIR})"
+    while sleep $SIZE_CHECK_INTERVAL; do
+      _watchdog_check_size_once || break
+    done
+  ) &
+  SIZE_PID=$!
+  # Register EXIT trap INSIDE this watchdog subshell so the size sub-loop is
+  # reaped on any exit path (normal, kill, SIGTERM from outer cleanup).
+  # This is the only reliable cleanup path: SIZE_PID is local to this subshell
+  # and is never visible in the outer shell, so the outer cleanup() cannot
+  # kill it.
+  trap 'kill "$SIZE_PID" 2>/dev/null || true' EXIT
+
   FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -117,7 +249,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
   done
 ) &
 WATCHDOG_PID=$!
-echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8124/ok, startup grace 180s)"
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8124/ok, startup grace 180s, size-guard threshold ${SIZE_THRESHOLD_MB}MB every ${SIZE_CHECK_INTERVAL}s)"
 echo "[entrypoint] All processes running. Waiting..."
 
 # Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to

--- a/showcase/integrations/langgraph-typescript/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/langgraph-typescript/src/app/api/copilotkit/route.ts
@@ -17,6 +17,14 @@ import { withCvdiagBackend } from "@/cvdiag-backend";
 const AGENT_URL =
   process.env.LANGGRAPH_DEPLOYMENT_URL || "http://localhost:8123";
 
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
+
 console.log("[copilotkit/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit/route] AGENT_URL: ${AGENT_URL}`);
 
@@ -95,7 +103,11 @@ console.log(
 const copilotkitPost = async (req: NextRequest): Promise<Response> => {
   const url = req.url;
   const contentType = req.headers.get("content-type");
-  console.log(`[copilotkit/route] POST ${url} (content-type: ${contentType})`);
+  if (ROUTE_DEBUG) {
+    console.log(
+      `[copilotkit/route] POST ${url} (content-type: ${contentType})`,
+    );
+  }
 
   try {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
@@ -107,7 +119,11 @@ const copilotkitPost = async (req: NextRequest): Promise<Response> => {
     });
 
     const response = await handleRequest(req);
-    console.log(`[copilotkit/route] Response status: ${response.status}`);
+    if (!response.ok) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    } else if (ROUTE_DEBUG) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    }
     return response;
   } catch (error: unknown) {
     // Log full error details server-side with a correlation id, but only
@@ -144,7 +160,9 @@ export const POST = withCvdiagBackend(copilotkitPost, {
 });
 
 export const GET = async () => {
-  console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  if (ROUTE_DEBUG) {
+    console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  }
 
   let agentStatus = "unknown";
   try {

--- a/showcase/integrations/langgraph-typescript/tests/python/test_entrypoint_watchdog.py
+++ b/showcase/integrations/langgraph-typescript/tests/python/test_entrypoint_watchdog.py
@@ -1,0 +1,617 @@
+"""Subprocess tests for entrypoint.sh watchdog / persistence-bounding mechanism.
+
+Covers:
+  C1 - Under set -e, TRUNC_RESPONSE=$(curl -fsS ...) exits the subshell on
+       first non-2xx, making the truncate loop dead code.
+  C2 - /internal/truncate exists in @langchain/langgraph-api@1.1.17 but wipes
+       ALL in-flight runs/threads (R7-C1), making a fixed-interval timer unsafe.
+  Fix verification:
+    - Boot-purge (.langgraph_api removal) still fires on every start.
+    - No fixed-interval POST to /internal/truncate in watchdog.
+    - Size-gated restart mechanism: fires restart only when dir exceeds threshold,
+      NOT on a fixed timer; watchdog kills the agent (triggering container restart
+      which re-runs boot-purge).
+    - Failure escalation: size-check errors are logged, not silently swallowed.
+    - Behavioral: the size-gate logic actually executes under test (not just grep).
+
+We stub node/npm/npx/curl via PATH prepend (same pattern as google-adk tests).
+The stub executables exit 0 immediately so the script can progress through the
+boot-purge section and we observe behavior without actually launching the stack.
+
+For size-gate behavioral tests, we use the --check-size-once seam:
+  bash entrypoint.sh --check-size-once
+This executes exactly one size-check-and-kill cycle using env vars for
+configuration, with a stubbed `du` on PATH returning a controlled value.
+This allows mutation-sensitive tests that catch reversed comparisons or broken
+du|awk extraction.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from textwrap import dedent
+from typing import NamedTuple
+
+import pytest
+
+
+_PKG_ROOT = Path(__file__).resolve().parents[2]
+_ENTRYPOINT = _PKG_ROOT / "entrypoint.sh"
+
+
+class CheckSizeResult(NamedTuple):
+    """Return value of _run_check_size_once.
+
+    result:          CompletedProcess from the entrypoint --check-size-once run.
+    dummy_was_killed: True if the dummy agent process was killed by the gate
+                      (poll() returned non-None before the finally reaper ran);
+                      False if it was still alive (gate did not fire).
+    """
+
+    result: subprocess.CompletedProcess
+    dummy_was_killed: bool
+
+
+def _make_stubs(
+    stub_dir: Path,
+    *,
+    curl_truncate_rc: int = 0,
+    du_size_mb: int | None = None,
+) -> None:
+    """Create stub binaries in stub_dir.
+
+    curl stub: all requests exit 0 (liveness probes pass).
+    node / npm / npx → exit 0 immediately.
+    du stub: if du_size_mb is set, returns that value as the size output;
+      otherwise falls through to the real du.
+    """
+    stub_dir.mkdir(parents=True, exist_ok=True)
+
+    curl_script = dedent(f"""\
+        #!/bin/sh
+        # Detect which URL is being called by scanning positional args
+        for arg in "$@"; do
+          case "$arg" in
+            *8123/internal/truncate*)
+              exit {curl_truncate_rc}
+              ;;
+          esac
+        done
+        # Default: succeed (liveness probes, etc.)
+        exit 0
+    """)
+    (stub_dir / "curl").write_text(curl_script)
+    (stub_dir / "curl").chmod(0o755)
+
+    for name in ("node", "npm", "npx"):
+        stub = stub_dir / name
+        stub.write_text("#!/bin/sh\nexit 0\n")
+        stub.chmod(0o755)
+
+    if du_size_mb is not None:
+        # Stub du to return a controlled size regardless of the actual dir.
+        # Mimics `du -sm <dir>` output format: "<size_mb>\t<path>"
+        du_script = dedent(f"""\
+            #!/bin/sh
+            # Return controlled size for any argument
+            last_arg=""
+            for arg in "$@"; do
+              case "$arg" in
+                -*) ;;
+                *) last_arg="$arg" ;;
+              esac
+            done
+            echo "{du_size_mb}\t${{last_arg:-.}}"
+            exit 0
+        """)
+        (stub_dir / "du").write_text(du_script)
+        (stub_dir / "du").chmod(0o755)
+
+
+def _run_entrypoint(
+    tmp_path: Path,
+    *,
+    extra_env: dict[str, str] | None = None,
+    stub_curl_truncate_rc: int = 0,
+    timeout: int = 10,
+) -> subprocess.CompletedProcess:
+    stub_dir = tmp_path / "stubs"
+    _make_stubs(stub_dir, curl_truncate_rc=stub_curl_truncate_rc)
+
+    persist_dir = tmp_path / "langgraph_api"
+    clean_env = {
+        "PATH": f"{stub_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+        "HOME": os.environ.get("HOME", "/tmp"),
+        "PORT": "10000",
+        # Allow PERSIST_DIR to be overridden for testing without Docker
+        "LANGGRAPH_PERSIST_DIR_OVERRIDE": str(persist_dir),
+    }
+    if extra_env:
+        clean_env.update(extra_env)
+
+    return subprocess.run(
+        ["/bin/bash", str(_ENTRYPOINT)],
+        env=clean_env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _run_check_size_once(
+    tmp_path: Path,
+    *,
+    persist_dir: Path,
+    size_threshold_mb: int,
+    du_size_mb: int,
+    timeout: int = 5,
+) -> CheckSizeResult:
+    """Run entrypoint.sh --check-size-once with a stubbed du returning du_size_mb.
+
+    This exercises the _watchdog_check_size_once seam directly, without needing
+    the full entrypoint stack (no cd /app/src/agent, no real npm start, etc.).
+
+    We spawn a real long-running dummy process (sleep 30) as the AGENT_PID so
+    that:
+      - kill -0 $AGENT_PID succeeds (process is alive), and
+      - kill -9 $AGENT_PID terminates the dummy process (not the test runner).
+
+    dummy.poll() is captured BEFORE the finally reaper so callers can assert
+    whether the gate actually killed the process (poll() is not None = killed)
+    or left it alive (poll() is None = not killed).  The finally block then
+    always reaps any survivor so no zombie/orphan remains.
+    """
+    stub_dir = tmp_path / "stubs_size"
+    _make_stubs(stub_dir, du_size_mb=du_size_mb)
+
+    # Spawn a real dummy "agent" process that can safely be killed.
+    dummy = subprocess.Popen(["sleep", "30"])
+    try:
+        clean_env = {
+            "PATH": f"{stub_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+            "HOME": os.environ.get("HOME", "/tmp"),
+            "LANGGRAPH_PERSIST_DIR_OVERRIDE": str(persist_dir),
+            "LANGGRAPH_SIZE_THRESHOLD_MB": str(size_threshold_mb),
+            "AGENT_PID": str(dummy.pid),
+        }
+
+        result = subprocess.run(
+            ["/bin/bash", str(_ENTRYPOINT), "--check-size-once"],
+            env=clean_env,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        # Capture whether the gate killed the dummy BEFORE the finally reaper
+        # runs — once finally calls dummy.kill(), poll() would always be non-None
+        # regardless of whether the script killed it.
+        dummy_was_killed = dummy.poll() is not None
+        return CheckSizeResult(result=result, dummy_was_killed=dummy_was_killed)
+    finally:
+        # Reap the dummy process (may already be dead if kill -9 landed).
+        dummy.kill()
+        dummy.wait(timeout=2)
+
+
+@pytest.mark.skipif(not _ENTRYPOINT.exists(), reason="entrypoint.sh not found")
+class TestBootPurge:
+    """Boot-purge (.langgraph_api removal) must fire on every start."""
+
+    def test_purges_existing_persist_dir(self, tmp_path):
+        """If persist dir exists at boot, entrypoint must purge it.
+
+        The script will fail at `cd /app/src/agent` (not present outside
+        container). We only check that the purge log appears and the dir
+        was actually removed — both happen before that cd line.
+        """
+        persist_dir = tmp_path / "langgraph_api"
+        persist_dir.mkdir(parents=True)
+        (persist_dir / "state.json").write_text('{"runs":{}}')
+
+        result = _run_entrypoint(
+            tmp_path,
+            extra_env={"LANGGRAPH_PERSIST_DIR_OVERRIDE": str(persist_dir)},
+        )
+        output = result.stdout + result.stderr
+        assert "Purging stale LangGraph persistence state" in output, (
+            f"Expected purge log in output. output={output!r}"
+        )
+        assert not persist_dir.exists(), (
+            "Expected persist dir to be removed by boot-purge"
+        )
+
+    def test_clean_boot_logs_no_prior_state(self, tmp_path):
+        """If persist dir does NOT exist, entrypoint logs clean boot."""
+        persist_dir = tmp_path / "langgraph_api"
+        # Do NOT create it
+
+        result = _run_entrypoint(
+            tmp_path,
+            extra_env={"LANGGRAPH_PERSIST_DIR_OVERRIDE": str(persist_dir)},
+        )
+        output = result.stdout + result.stderr
+        assert "clean boot" in output, (
+            f"Expected 'clean boot' log when no prior state. output={output!r}"
+        )
+
+    def test_persist_dir_uses_env_override(self):
+        """entrypoint.sh must respect LANGGRAPH_PERSIST_DIR_OVERRIDE env var."""
+        source = _ENTRYPOINT.read_text()
+        assert "LANGGRAPH_PERSIST_DIR_OVERRIDE" in source, (
+            "PERSIST_DIR must be overridable via LANGGRAPH_PERSIST_DIR_OVERRIDE "
+            "for test isolation (no /app in test environment)"
+        )
+
+
+@pytest.mark.skipif(not _ENTRYPOINT.exists(), reason="entrypoint.sh not found")
+class TestNoFixedIntervalTruncate:
+    """The fixed-interval POST /internal/truncate loop must NOT exist.
+
+    R7-C1: ops.truncate with runs+threads+checkpointer+store=true wipes ALL
+    runs/threads including in-flight ones. A fixed timer is unsafe.
+    C2: The endpoint exists in 1.1.17 but is an unpinned internal contract.
+    """
+
+    def test_truncate_loop_absent_from_entrypoint(self):
+        """No fixed-interval truncate loop in entrypoint source."""
+        source = _ENTRYPOINT.read_text()
+        assert "TRUNCATE_INTERVAL" not in source, (
+            "Fixed-interval TRUNCATE_INTERVAL variable found — truncate loop "
+            "must be removed (R7-C1: wipes in-flight runs on a timer)"
+        )
+
+    def test_no_truncate_curl_call_in_source(self):
+        """entrypoint.sh must not have an executable curl call to /internal/truncate.
+
+        Comments may mention the route for documentation; we only ban live calls.
+        A live call looks like: curl ... http://...8123/internal/truncate
+        """
+        import re
+
+        source = _ENTRYPOINT.read_text()
+        # Strip comment lines (lines starting with optional whitespace + #)
+        non_comment_lines = [
+            line for line in source.splitlines() if not line.lstrip().startswith("#")
+        ]
+        non_comment_source = "\n".join(non_comment_lines)
+        live_call = re.search(r"curl\b.*internal/truncate", non_comment_source)
+        assert live_call is None, (
+            f"Live curl call to /internal/truncate found (R7-C1 + C2): "
+            f"{live_call.group() if live_call else ''}"
+        )
+
+    def test_no_periodic_truncate_comment(self):
+        """Old 'periodic /internal/truncate loop' comment must be gone."""
+        source = _ENTRYPOINT.read_text()
+        assert "periodic state truncation every" not in source, (
+            "Old truncate loop comment still present — must be updated"
+        )
+
+
+@pytest.mark.skipif(not _ENTRYPOINT.exists(), reason="entrypoint.sh not found")
+class TestSizeGatedRestart:
+    """Size-gated restart mechanism: BEHAVIORAL tests via --check-size-once seam.
+
+    These tests exercise the actual size-check-and-kill logic by running
+    `entrypoint.sh --check-size-once` with a stubbed `du` returning a
+    controlled value.  They are mutation-sensitive: a reversed comparison
+    (-ge → -lt) or broken du|awk extraction causes test failures.
+    """
+
+    def test_gate_fires_when_over_threshold(self, tmp_path):
+        """Size gate MUST kill agent (exit 1) when du reports OVER threshold.
+
+        This test is mutation-sensitive: if the comparison is reversed
+        (-ge → -lt), this test fails (gate would NOT fire over threshold).
+        Also asserts the dummy agent PID was ACTUALLY killed by the gate
+        (not just that the script logged "killing" — dummy.poll() must be
+        non-None, proving kill -9 landed on the real PID, not a bogus one).
+        """
+        persist_dir = tmp_path / "langgraph_api"
+        persist_dir.mkdir()
+
+        r = _run_check_size_once(
+            tmp_path,
+            persist_dir=persist_dir,
+            size_threshold_mb=100,
+            du_size_mb=150,  # 150 MB > 100 MB threshold → should fire
+        )
+        output = r.result.stdout + r.result.stderr
+        assert r.result.returncode == 1, (
+            f"Expected exit 1 (gate fires) when du reports 150MB > 100MB threshold. "
+            f"returncode={r.result.returncode}, output={output!r}"
+        )
+        assert "Size threshold exceeded" in output, (
+            f"Expected 'Size threshold exceeded' log when over threshold. output={output!r}"
+        )
+        assert "killing agent" in output.lower() or "killing agent PID" in output, (
+            f"Expected kill log when threshold exceeded. output={output!r}"
+        )
+        assert r.dummy_was_killed, (
+            "Gate fired (exit 1 + kill log) but dummy agent PID was NOT actually "
+            "killed — kill targeted a wrong or nonexistent PID. "
+            f"output={output!r}"
+        )
+
+    def test_gate_does_not_fire_when_under_threshold(self, tmp_path):
+        """Size gate must NOT fire (exit 0) when du reports UNDER threshold.
+
+        This test is mutation-sensitive: if the comparison is reversed
+        (-ge → -lt), this test fails (gate would fire under threshold).
+        Also asserts the dummy agent PID was NOT killed — the process must
+        still be alive after the gate runs under threshold.
+        """
+        persist_dir = tmp_path / "langgraph_api"
+        persist_dir.mkdir()
+
+        r = _run_check_size_once(
+            tmp_path,
+            persist_dir=persist_dir,
+            size_threshold_mb=200,
+            du_size_mb=50,  # 50 MB < 200 MB threshold → should NOT fire
+        )
+        output = r.result.stdout + r.result.stderr
+        assert r.result.returncode == 0, (
+            f"Expected exit 0 (gate does not fire) when du reports 50MB < 200MB threshold. "
+            f"returncode={r.result.returncode}, output={output!r}"
+        )
+        assert "Size threshold exceeded" not in output, (
+            f"Gate must NOT fire when under threshold. output={output!r}"
+        )
+        assert not r.dummy_was_killed, (
+            "Gate must NOT kill the agent when under threshold, "
+            "but dummy agent PID was killed. "
+            f"output={output!r}"
+        )
+
+    def test_gate_fires_at_exact_threshold(self, tmp_path):
+        """Size gate MUST fire when du reports exactly the threshold (>= not >).
+
+        Also asserts the dummy agent PID was ACTUALLY killed when gate fires
+        at the boundary — confirms kill -9 targeted the real PID.
+        """
+        persist_dir = tmp_path / "langgraph_api"
+        persist_dir.mkdir()
+
+        r = _run_check_size_once(
+            tmp_path,
+            persist_dir=persist_dir,
+            size_threshold_mb=200,
+            du_size_mb=200,  # exactly at threshold → should fire (-ge)
+        )
+        output = r.result.stdout + r.result.stderr
+        assert r.result.returncode == 1, (
+            f"Expected exit 1 (gate fires) when du reports exactly threshold (200MB >= 200MB). "
+            f"returncode={r.result.returncode}, output={output!r}"
+        )
+        assert r.dummy_was_killed, (
+            "Gate fired (exit 1) at exact threshold but dummy agent PID was NOT "
+            "actually killed — kill targeted a wrong or nonexistent PID. "
+            f"output={output!r}"
+        )
+
+    def test_gate_skipped_when_persist_dir_missing(self, tmp_path):
+        """Size gate must skip gracefully (exit 0) when persist dir does not exist."""
+        persist_dir = tmp_path / "nonexistent_langgraph_api"
+        # Do NOT create it
+
+        r = _run_check_size_once(
+            tmp_path,
+            persist_dir=persist_dir,
+            size_threshold_mb=100,
+            du_size_mb=999,  # would fire if dir existed — but it doesn't
+        )
+        output = r.result.stdout + r.result.stderr
+        assert r.result.returncode == 0, (
+            f"Expected exit 0 (skip) when persist dir missing. "
+            f"returncode={r.result.returncode}, output={output!r}"
+        )
+        assert "does not exist" in output, (
+            f"Expected 'does not exist' log when persist dir missing. output={output!r}"
+        )
+
+    def test_gate_logs_size_on_each_cycle(self, tmp_path):
+        """Size gate must log current size and threshold every cycle."""
+        persist_dir = tmp_path / "langgraph_api"
+        persist_dir.mkdir()
+
+        r = _run_check_size_once(
+            tmp_path,
+            persist_dir=persist_dir,
+            size_threshold_mb=200,
+            du_size_mb=75,
+        )
+        output = r.result.stdout + r.result.stderr
+        assert "75MB" in output and "200MB" in output, (
+            f"Expected size and threshold logged each cycle. output={output!r}"
+        )
+
+    def test_size_check_interval_default_is_60s(self):
+        """Default SIZE_CHECK_INTERVAL must be 60s (not 300s) for tighter coverage.
+
+        At 300s, state can exceed 512MB between checks under heavy probe fan-out
+        (the original crash scenario). 60s keeps the check-to-ceiling budget safe.
+        """
+        source = _ENTRYPOINT.read_text()
+        import re
+
+        # Find the default assignment: SIZE_CHECK_INTERVAL=${..:-<N>}
+        m = re.search(r"SIZE_CHECK_INTERVAL=\$\{[^}]+:-(\d+)\}", source)
+        assert m is not None, "Expected SIZE_CHECK_INTERVAL variable with default value"
+        default_val = int(m.group(1))
+        assert default_val <= 60, (
+            f"SIZE_CHECK_INTERVAL default must be <= 60s (got {default_val}s). "
+            "At 300s, state can exceed 512MB before the next check under heavy load."
+        )
+
+    def test_size_threshold_configurable(self):
+        """SIZE_THRESHOLD_MB must be configurable via env var."""
+        source = _ENTRYPOINT.read_text()
+        assert "LANGGRAPH_SIZE_THRESHOLD_MB" in source, (
+            "Expected LANGGRAPH_SIZE_THRESHOLD_MB env override for threshold"
+        )
+
+
+@pytest.mark.skipif(not _ENTRYPOINT.exists(), reason="entrypoint.sh not found")
+class TestSizePidOrphanGuard:
+    """The size-check sub-loop PID must be captured and cleaned up on watchdog exit.
+
+    I1/I3: SIZE_PID is assigned INSIDE the watchdog subshell ( ) & so it is
+    never visible in the outer shell.  The fix: register
+    `trap 'kill "$SIZE_PID" 2>/dev/null || true' EXIT` INSIDE the watchdog
+    subshell right after SIZE_PID=$!, so the sub-loop is reaped on any
+    watchdog exit path (normal, kill from outer cleanup, SIGTERM).
+
+    The outer cleanup() must NOT contain a dead SIZE_PID block since it will
+    never be reached.
+    """
+
+    def test_size_pid_captured_in_watchdog(self):
+        """Watchdog subshell must capture the size sub-loop PID after forking it."""
+        source = _ENTRYPOINT.read_text()
+        assert "SIZE_PID=$!" in source, (
+            "Expected SIZE_PID=$! to capture size sub-loop PID for cleanup (I1 orphan guard)"
+        )
+
+    def test_size_pid_reaped_by_in_subshell_trap(self):
+        """SIZE_PID must be reaped by an EXIT trap INSIDE the watchdog subshell.
+
+        Source-level check: the trap must appear inside the ( ) & block,
+        after SIZE_PID=$!, not in the outer cleanup() function.
+        """
+        source = _ENTRYPOINT.read_text()
+        # The trap must be registered inside the watchdog subshell (after SIZE_PID=$!)
+        # and must reference SIZE_PID.
+        assert (
+            'trap \'kill "$SIZE_PID"' in source or "trap 'kill \"$SIZE_PID\"'" in source
+        ), (
+            "Expected `trap 'kill \"$SIZE_PID\" ...' EXIT` inside watchdog subshell "
+            "(I1: SIZE_PID is subshell-local, outer cleanup cannot reach it)"
+        )
+        # The outer cleanup() must NOT contain an EXECUTABLE kill for SIZE_PID
+        # (it would be dead code since SIZE_PID is never set in the outer shell).
+        # Comments mentioning SIZE_PID are acceptable (they explain WHY it's absent).
+        import re
+
+        cleanup_match = re.search(r"cleanup\(\)\s*\{([^}]*)\}", source, re.DOTALL)
+        if cleanup_match:
+            cleanup_body = cleanup_match.group(1)
+            # Strip comment lines before checking for executable SIZE_PID references.
+            exec_lines = [
+                line
+                for line in cleanup_body.splitlines()
+                if line.strip() and not line.lstrip().startswith("#")
+            ]
+            exec_body = "\n".join(exec_lines)
+            assert "SIZE_PID" not in exec_body, (
+                "cleanup() must NOT have executable references to SIZE_PID — "
+                "it is a subshell-local variable and is always unset in the outer shell.  "
+                "Any kill of SIZE_PID here would be dead code."
+            )
+
+    def test_size_pid_reaped_on_watchdog_exit_behavioral(self, tmp_path):
+        """BEHAVIORAL: size sub-loop is actually reaped when its parent subshell exits.
+
+        Simulates the watchdog subshell lifecycle:
+          1. Fork a long-running "size sub-loop" process (sleep 60, stands in for the
+             real size-check loop).
+          2. Register `trap 'kill "$SIZE_PID" 2>/dev/null || true' EXIT` in a subshell,
+             exactly as the fixed entrypoint does.
+          3. Send SIGTERM to the subshell (simulating the outer cleanup() killing the
+             watchdog).
+          4. Assert the size sub-loop was reaped (poll() is not None).
+
+        This exercises the trap FIRING, not just its registration.
+        """
+        import time
+
+        # Spawn the "size sub-loop" process (long-lived, safe to kill).
+        size_loop = subprocess.Popen(["sleep", "60"])
+        size_pid = size_loop.pid
+
+        # Write a minimal shell that mimics the fixed watchdog subshell:
+        # register the in-subshell EXIT trap, then sleep (simulating the
+        # watchdog's health-probe loop blocked in sleep).
+        watchdog_script = dedent(f"""\
+            #!/bin/bash
+            set -e
+            SIZE_PID={size_pid}
+            trap 'kill "$SIZE_PID" 2>/dev/null || true' EXIT
+            # Simulate watchdog blocked in health-probe sleep.
+            sleep 60
+        """)
+        script_path = tmp_path / "mock_watchdog.sh"
+        script_path.write_text(watchdog_script)
+        script_path.chmod(0o755)
+
+        watchdog = subprocess.Popen(["/bin/bash", str(script_path)])
+        # Let the script register its trap.
+        time.sleep(0.1)
+
+        # Simulate outer cleanup() sending SIGTERM to the watchdog.
+        watchdog.terminate()
+        watchdog.wait(timeout=3)
+
+        # The EXIT trap should have reaped the size sub-loop.
+        # Give the OS a moment to deliver the kill.
+        for _ in range(20):
+            if size_loop.poll() is not None:
+                break
+            time.sleep(0.05)
+
+        size_exit = size_loop.poll()
+        assert size_exit is not None, (
+            f"Size sub-loop (PID {size_pid}) is still alive after watchdog subshell "
+            "exited — EXIT trap did NOT fire or did not kill it.  "
+            "This is the I1 orphan: the sub-loop outlives the watchdog."
+        )
+        # Clean up in case assertion is skipped.
+        size_loop.kill()
+        size_loop.wait()
+
+
+@pytest.mark.skipif(not _ENTRYPOINT.exists(), reason="entrypoint.sh not found")
+class TestSetECorrectness:
+    """C1: set -e subshell correctness — no command substitution swallowed."""
+
+    def test_no_bare_command_substitution_for_curl_truncate(self):
+        """Curl calls must not use bare VARNAME=$(curl -fsS ...) for truncate
+        under set -e without error-trapping (C1 pattern).
+
+        The fix removes the truncate loop entirely — this test confirms it.
+        If it were retained, the correct pattern would be:
+          a) VARNAME=$(curl ...) || true
+          b) explicit rc check with || true
+        But removal is the correct fix.
+        """
+        import re
+
+        source = _ENTRYPOINT.read_text()
+        # Old broken pattern from C1 finding:
+        bad_pattern = re.search(r"TRUNC_RESPONSE=\$\(curl\s+-fsS", source)
+        assert bad_pattern is None, (
+            "C1: bare TRUNC_RESPONSE=$(curl -fsS ...) found under set -e. "
+            "This kills the subshell on first non-2xx. "
+            "The truncate loop must be removed entirely."
+        )
+
+    def test_du_in_size_check_has_error_guard(self):
+        """du call in size-check must have || true to prevent set -e kill."""
+        source = _ENTRYPOINT.read_text()
+        # The size-check uses du -sm ... | awk, and must guard against du failures.
+        # Skip comment lines (lines whose first non-whitespace char is #).
+        import re
+
+        du_lines = [
+            line
+            for line in source.splitlines()
+            if "du -sm" in line and not line.lstrip().startswith("#")
+        ]
+        assert du_lines, "Expected a 'du -sm' executable line for size measurement"
+        for line in du_lines:
+            assert "|| true" in line or "2>/dev/null" in line, (
+                f"du line lacks error guard (|| true or 2>/dev/null): {line!r}\n"
+                "Under set -e, du failure (e.g. permission error) kills the subshell"
+            )

--- a/showcase/integrations/langroid/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit/route.ts
@@ -10,6 +10,14 @@ import { AbstractAgent, HttpAgent } from "@ag-ui/client";
 // This runtime proxies CopilotKit requests to it via AG-UI protocol.
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
+
 console.log("[copilotkit/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit/route] AGENT_URL: ${AGENT_URL}`);
 
@@ -103,7 +111,11 @@ console.log(
 export const POST = async (req: NextRequest) => {
   const url = req.url;
   const contentType = req.headers.get("content-type");
-  console.log(`[copilotkit/route] POST ${url} (content-type: ${contentType})`);
+  if (ROUTE_DEBUG) {
+    console.log(
+      `[copilotkit/route] POST ${url} (content-type: ${contentType})`,
+    );
+  }
 
   try {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
@@ -116,7 +128,11 @@ export const POST = async (req: NextRequest) => {
     });
 
     const response = await handleRequest(req);
-    console.log(`[copilotkit/route] Response status: ${response.status}`);
+    if (!response.ok) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    } else if (ROUTE_DEBUG) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    }
     return response;
   } catch (error: unknown) {
     // Log full details server-side (operators grep `errorId` to correlate),
@@ -142,7 +158,9 @@ export const POST = async (req: NextRequest) => {
 };
 
 export const GET = async () => {
-  console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  if (ROUTE_DEBUG) {
+    console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  }
 
   let agentStatus = "unknown";
   try {

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit/route.ts
@@ -131,7 +131,9 @@ export const POST = async (req: NextRequest) => {
     });
 
     const response = await handleRequest(req);
-    if (ROUTE_DEBUG) {
+    if (!response.ok) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    } else if (ROUTE_DEBUG) {
       console.log(`[copilotkit/route] Response status: ${response.status}`);
     }
     return response;
@@ -147,7 +149,9 @@ export const POST = async (req: NextRequest) => {
 };
 
 export const GET = async () => {
-  console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  if (ROUTE_DEBUG) {
+    console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  }
 
   let agentStatus = "unknown";
   try {

--- a/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit/route.ts
@@ -14,6 +14,14 @@ import { Observable } from "rxjs";
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 const REPLAY_SAFE_TOOL_CALL_ID_SUFFIX = /__ck_run_[0-9a-f-]+$/i;
 
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
+
 console.log("[copilotkit/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit/route] AGENT_URL: ${AGENT_URL}`);
 
@@ -761,7 +769,11 @@ console.log(
 export const POST = async (req: NextRequest) => {
   const url = req.url;
   const contentType = req.headers.get("content-type");
-  console.log(`[copilotkit/route] POST ${url} (content-type: ${contentType})`);
+  if (ROUTE_DEBUG) {
+    console.log(
+      `[copilotkit/route] POST ${url} (content-type: ${contentType})`,
+    );
+  }
 
   try {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
@@ -774,7 +786,11 @@ export const POST = async (req: NextRequest) => {
     });
 
     const response = await handleRequest(req);
-    console.log(`[copilotkit/route] Response status: ${response.status}`);
+    if (!response.ok) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    } else if (ROUTE_DEBUG) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    }
     return response;
   } catch (error: unknown) {
     const err = error as Error;
@@ -788,7 +804,9 @@ export const POST = async (req: NextRequest) => {
 };
 
 export const GET = async () => {
-  console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  if (ROUTE_DEBUG) {
+    console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  }
 
   let agentStatus = "unknown";
   try {

--- a/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit/route.ts
@@ -14,6 +14,14 @@ import { Observable } from "rxjs";
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 const REPLAY_SAFE_TOOL_CALL_ID_SUFFIX = /__ck_run_[0-9a-f-]+$/i;
 
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
+
 console.log("[copilotkit/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit/route] AGENT_URL: ${AGENT_URL}`);
 
@@ -761,7 +769,11 @@ console.log(
 export const POST = async (req: NextRequest) => {
   const url = req.url;
   const contentType = req.headers.get("content-type");
-  console.log(`[copilotkit/route] POST ${url} (content-type: ${contentType})`);
+  if (ROUTE_DEBUG) {
+    console.log(
+      `[copilotkit/route] POST ${url} (content-type: ${contentType})`,
+    );
+  }
 
   try {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
@@ -774,7 +786,11 @@ export const POST = async (req: NextRequest) => {
     });
 
     const response = await handleRequest(req);
-    console.log(`[copilotkit/route] Response status: ${response.status}`);
+    if (!response.ok) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    } else if (ROUTE_DEBUG) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    }
     return response;
   } catch (error: unknown) {
     const err = error as Error;
@@ -788,7 +804,9 @@ export const POST = async (req: NextRequest) => {
 };
 
 export const GET = async () => {
-  console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  if (ROUTE_DEBUG) {
+    console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  }
 
   let agentStatus = "unknown";
   try {

--- a/showcase/integrations/ms-agent-python/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/ms-agent-python/src/app/api/copilotkit/route.ts
@@ -14,6 +14,14 @@ import { Observable } from "rxjs";
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 const REPLAY_SAFE_TOOL_CALL_ID_SUFFIX = /__ck_run_[0-9a-f-]+$/i;
 
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
+
 console.log("[copilotkit/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit/route] AGENT_URL: ${AGENT_URL}`);
 
@@ -681,7 +689,11 @@ console.log(
 export const POST = async (req: NextRequest) => {
   const url = req.url;
   const contentType = req.headers.get("content-type");
-  console.log(`[copilotkit/route] POST ${url} (content-type: ${contentType})`);
+  if (ROUTE_DEBUG) {
+    console.log(
+      `[copilotkit/route] POST ${url} (content-type: ${contentType})`,
+    );
+  }
 
   try {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
@@ -694,7 +706,11 @@ export const POST = async (req: NextRequest) => {
     });
 
     const response = await handleRequest(req);
-    console.log(`[copilotkit/route] Response status: ${response.status}`);
+    if (!response.ok) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    } else if (ROUTE_DEBUG) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    }
     return response;
   } catch (error: unknown) {
     const err = error as Error;
@@ -708,7 +724,9 @@ export const POST = async (req: NextRequest) => {
 };
 
 export const GET = async () => {
-  console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  if (ROUTE_DEBUG) {
+    console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  }
 
   let agentStatus = "unknown";
   try {

--- a/showcase/integrations/pydantic-ai/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/pydantic-ai/src/app/api/copilotkit/route.ts
@@ -11,6 +11,14 @@ import crypto from "node:crypto";
 // This runtime proxies CopilotKit requests to it via AG-UI protocol.
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
+
 console.log("[copilotkit/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit/route] AGENT_URL: ${AGENT_URL}`);
 
@@ -115,7 +123,11 @@ console.log(
 export const POST = async (req: NextRequest) => {
   const url = req.url;
   const contentType = req.headers.get("content-type");
-  console.log(`[copilotkit/route] POST ${url} (content-type: ${contentType})`);
+  if (ROUTE_DEBUG) {
+    console.log(
+      `[copilotkit/route] POST ${url} (content-type: ${contentType})`,
+    );
+  }
 
   try {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
@@ -128,7 +140,11 @@ export const POST = async (req: NextRequest) => {
     });
 
     const response = await handleRequest(req);
-    console.log(`[copilotkit/route] Response status: ${response.status}`);
+    if (!response.ok) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    } else if (ROUTE_DEBUG) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    }
     return response;
   } catch (error: unknown) {
     const err = error instanceof Error ? error : new Error(String(error));
@@ -155,7 +171,9 @@ export const POST = async (req: NextRequest) => {
 };
 
 export const GET = async () => {
-  console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  if (ROUTE_DEBUG) {
+    console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  }
 
   let agentStatus = "unknown";
   try {

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit/route.ts
@@ -10,6 +10,14 @@ import { AbstractAgent, HttpAgent } from "@ag-ui/client";
 // This runtime proxies CopilotKit requests to it via AG-UI protocol.
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
+
 console.log("[copilotkit/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit/route] AGENT_URL: ${AGENT_URL}`);
 
@@ -117,7 +125,11 @@ console.log(
 export const POST = async (req: NextRequest) => {
   const url = req.url;
   const contentType = req.headers.get("content-type");
-  console.log(`[copilotkit/route] POST ${url} (content-type: ${contentType})`);
+  if (ROUTE_DEBUG) {
+    console.log(
+      `[copilotkit/route] POST ${url} (content-type: ${contentType})`,
+    );
+  }
 
   try {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
@@ -132,7 +144,11 @@ export const POST = async (req: NextRequest) => {
     });
 
     const response = await handleRequest(req);
-    console.log(`[copilotkit/route] Response status: ${response.status}`);
+    if (!response.ok) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    } else if (ROUTE_DEBUG) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    }
     return response;
   } catch (error: unknown) {
     // Log full details server-side (operators grep `errorId` to correlate),
@@ -158,7 +174,9 @@ export const POST = async (req: NextRequest) => {
 };
 
 export const GET = async () => {
-  console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  if (ROUTE_DEBUG) {
+    console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  }
 
   let agentStatus = "unknown";
   try {

--- a/showcase/integrations/strands-typescript/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/strands-typescript/src/app/api/copilotkit/route.ts
@@ -13,6 +13,14 @@ import { AsyncLocalStorage } from "node:async_hooks";
 // This runtime proxies CopilotKit requests to it via AG-UI protocol.
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
+
 console.log("[copilotkit/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit/route] AGENT_URL: ${AGENT_URL}`);
 
@@ -21,7 +29,7 @@ console.log(`[copilotkit/route] AGENT_URL: ${AGENT_URL}`);
 // @ag-ui/client's HttpAgent `headers` are STATIC (construction-time), so the
 // per-request seam is its `fetch` option: a custom fetch that reads an
 // AsyncLocalStorage snapshot (seeded by the POST handler below) and injects the
-// inbound x-* (incl. X-AIMock-Strict / x-test-id / x-diag-*) onto the outbound
+// inbound x-* (incl. x-aimock-strict / x-test-id / x-diag-*) onto the outbound
 // POST. These then arrive on req.headers at the Express endpoint, where the
 // agent-side middleware reads them. Byte-identical to a plain fetch when no x-*
 // are in scope, so demo traffic proxies unchanged.
@@ -129,9 +137,11 @@ export const POST = async (req: NextRequest) =>
   proxyHeaders.run(extractXHeaders(req), async () => {
     const url = req.url;
     const contentType = req.headers.get("content-type");
-    console.log(
-      `[copilotkit/route] POST ${url} (content-type: ${contentType})`,
-    );
+    if (ROUTE_DEBUG) {
+      console.log(
+        `[copilotkit/route] POST ${url} (content-type: ${contentType})`,
+      );
+    }
 
     try {
       const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
@@ -144,7 +154,11 @@ export const POST = async (req: NextRequest) =>
       });
 
       const response = await handleRequest(req);
-      console.log(`[copilotkit/route] Response status: ${response.status}`);
+      if (!response.ok) {
+        console.log(`[copilotkit/route] Response status: ${response.status}`);
+      } else if (ROUTE_DEBUG) {
+        console.log(`[copilotkit/route] Response status: ${response.status}`);
+      }
       return response;
     } catch (error: unknown) {
       const err = error as Error;
@@ -158,7 +172,9 @@ export const POST = async (req: NextRequest) =>
   });
 
 export const GET = async () => {
-  console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  if (ROUTE_DEBUG) {
+    console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  }
 
   let agentStatus = "unknown";
   try {

--- a/showcase/integrations/strands/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit/route.ts
@@ -10,6 +10,14 @@ import { AbstractAgent, HttpAgent } from "@ag-ui/client";
 // This runtime proxies CopilotKit requests to it via AG-UI protocol.
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
+// Per-request request/response logging is gated behind this flag (default off).
+// Under d6 probe fan-out, unconditional per-request logs flooded Railway's
+// 500-logs/sec cap and killed the replica ("Messages dropped" → container stop).
+// Set SHOWCASE_ROUTE_DEBUG=1 to re-enable verbose per-request tracing locally.
+const ROUTE_DEBUG =
+  process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
+  process.env.SHOWCASE_ROUTE_DEBUG === "true";
+
 console.log("[copilotkit/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit/route] AGENT_URL: ${AGENT_URL}`);
 
@@ -91,7 +99,11 @@ console.log(
 export const POST = async (req: NextRequest) => {
   const url = req.url;
   const contentType = req.headers.get("content-type");
-  console.log(`[copilotkit/route] POST ${url} (content-type: ${contentType})`);
+  if (ROUTE_DEBUG) {
+    console.log(
+      `[copilotkit/route] POST ${url} (content-type: ${contentType})`,
+    );
+  }
 
   try {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
@@ -104,7 +116,11 @@ export const POST = async (req: NextRequest) => {
     });
 
     const response = await handleRequest(req);
-    console.log(`[copilotkit/route] Response status: ${response.status}`);
+    if (!response.ok) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    } else if (ROUTE_DEBUG) {
+      console.log(`[copilotkit/route] Response status: ${response.status}`);
+    }
     return response;
   } catch (error: unknown) {
     const err = error as Error;
@@ -118,7 +134,9 @@ export const POST = async (req: NextRequest) => {
 };
 
 export const GET = async () => {
-  console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  if (ROUTE_DEBUG) {
+    console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+  }
 
   let agentStatus = "unknown";
   try {


### PR DESCRIPTION
## What & why
Showcase services were being killed on Railway. Root causes, all fixed here:

1. **langgraph-python / langgraph-fastapi — watchfiles log flood → Railway 500-logs/sec replica kill.** `langgraph dev` ran with hot-reload, emitting "1 change detected" per request; under D6 probe fan-out this blew past Railway's 500 logs/sec cap and killed the replica. Fix: `--no-reload` + `export LANGGRAPH_DISABLE_FILE_PERSISTENCE=true` (also stops unbounded pickle-state OOM).
2. **langgraph-typescript — `FileSystemPersistence` RangeError crash loop.** `@langchain/langgraph-api` serialized unbounded thread state via `JSON.stringify`; past V8's ~512MB string ceiling it threw `RangeError` in a timer, hung the event loop, and the watchdog kill-looped (state persisted on disk, so restarts re-crashed). Fix: boot-purge stale state + a **size-gated** restart (checks dir size, only restarts near the ceiling — no in-flight-wiping timer, no unpinned `/internal/truncate`).
3 & 4. **Per-request proxy log flood across all integrations.** `[copilotkit/route] POST` + `Response status` logged on every sub-request, unconditionally, in 19 `route.ts`. Fix: gate them behind `SHOWCASE_ROUTE_DEBUG` (off in prod) — **but keep non-2xx responses logged unconditionally** so production errors stay visible, and gate the health-probe GET too.

## Verification
- Every fix carries local red-green. langgraph-typescript entrypoint: **18 mutation-sensitive subprocess tests** (reversed comparison / broken du|awk / wrong-kill-target all caught; orphan-cleanup reaped). route.ts gating verified on the real Next.js surface across ≥3 integrations (non-2xx logged, 2xx+health gated, `SHOWCASE_ROUTE_DEBUG=1` restores verbose).
- Code review: Round 1 (7 agents) → fixes → Round 2 (7-agent confirmation) → fix → Round 3 (3-lens targeted) → fix → converged to zero mandatory findings.

## ⚠ Before merge
The two entrypoint changes (`--no-reload` + `LANGGRAPH_DISABLE_FILE_PERSISTENCE` on pinned `langgraph-cli 0.4.21`) are **source-verified but could not be run locally** (the langgraph packages are on a private index; `0.4.21`'s `--no-reload` was confirmed only in public `0.4.3`). **Requires live-Railway validation** (branch deploy: boots, serves 200, no watchfiles spam, no pickle files) before merge. Kept as a **draft** until validated and the maintainer approves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)