### PR TITLE
fix(showcase): chdir to scripts when running staging-green probe (unblock prod promotes)

### DIFF
--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -2058,7 +2058,8 @@ module Railway
                 output = IO.popen(child_env, ["npx", "--yes", "tsx", probe_bin,
                     "--env", "staging",
                     "--services", services_arg,
-                    err: [:child, :out]]) { |io| io.read }
+                    err: [:child, :out]],
+                    chdir: File.expand_path("../scripts", __dir__)) { |io| io.read }
             rescue Errno::ENOENT, StandardError => e
                 return { ok: false, summary: "staging probe failed to launch: #{e.class}: #{e.message}" }
             end


### PR DESCRIPTION
One-line fix: `bin/railway`'s `run_staging_probe` invoked `npx --yes tsx verify-deploy.ts` from the repo root with no `chdir`, so under Node 22 tsx failed to resolve (MODULE_NOT_FOUND in the ESM preload) → the promoter misread it as 'staging not green' → hard REFUSE. This tier-gated all prod promotes (incl. the langgraph fix in #5825). Fix adds `chdir: File.expand_path("../scripts", __dir__)` so tsx resolves from `showcase/scripts/node_modules`.

Red-green: from repo root `npm ls tsx` is empty and `npx tsx` crashes; from showcase/scripts it resolves (tsx declared in showcase/scripts/package.json).

NOTE: the agno `<2.6.20` pin (originally bundled here) was split out — it edits a requirements file which trips the fleet-wide validate-pins ratchet (pre-existing non-exact-pin debt across ~15 integrations). Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)