### PR TITLE
fix(showcase/agno): pin agno==2.6.19 to restore agui.utils import

### DIFF
--- a/showcase/integrations/agno/requirements.txt
+++ b/showcase/integrations/agno/requirements.txt
@@ -1,4 +1,4 @@
-agno>=2.5.17
+agno==2.6.19
 openai>=1.88.0
 fastapi>=0.115.13
 uvicorn[standard]>=0.34.3

--- a/showcase/integrations/agno/src/agent_server.py
+++ b/showcase/integrations/agno/src/agent_server.py
@@ -70,6 +70,8 @@ from agno.agent import Agent, RemoteAgent
 from agno.models.message import Message
 from agno.os import AgentOS
 from agno.os.interfaces.agui import AGUI
+
+# TODO: migrate to agno 2.6.20+ API once agui.utils replacement is identified
 from agno.os.interfaces.agui.utils import (
     async_stream_agno_response_as_agui_events,
     extract_agui_user_input,


### PR DESCRIPTION
## Root Cause

`agno 2.6.20` removed `agno.os.interfaces.agui.utils`. The floating `agno>=2.5.17` pin in `requirements.txt` caused staging to pull the breaking version on the next build, causing a startup failure.

## Red-Green Proof

**RED** — with `agno>=2.6.20` installed:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'agno.os.interfaces.agui.utils'
```

**GREEN** — with `agno==2.6.19` installed:
```
GREEN: all 3 symbols OK
```
(Symbols confirmed: `async_stream_agno_response_as_agui_events`, `extract_agui_user_input`, `validate_agui_state`)

## Changes

- `showcase/integrations/agno/requirements.txt`: pinned `agno>=2.5.17` → `agno==2.6.19` (exact pin, last version with `agui.utils`)
- `showcase/integrations/agno/src/agent_server.py`: added TODO comment at line 73 import site noting migration to agno 2.6.20+ API is a follow-up; no structural changes to imports

## Follow-up

Migration of `agent_server.py` imports to the agno 2.6.20+ API (once the replacement for `agui.utils` is identified) is tracked in the TODO comment at line 73.

## Note on CI

The `validate-pins` CI check will likely flag pre-existing non-exact pins across ~15 other integrations (`openai ^5.9.0`, `crewai` ranges, etc.). This is pre-existing debt not introduced by this PR.