### PR TITLE
chore(showcase): ratchet validate-pins baseline to 37 after agno exact-pin

### DIFF
--- a/showcase/scripts/fail-baseline.json
+++ b/showcase/scripts/fail-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Drift ratchet baseline for showcase_validate.yml. `validatePinsFailCount` holds the last-known FAIL count; `validatePinsFailHash` is a SHA-256 of the stderr-only `[FAIL] ...` lines from validate-pins.ts, deduplicated and sorted with `LC_ALL=C sort -u`. CI compares BOTH: if the count changes, it tells you to ratchet (up rejected, down instructed). If the count is equal but the hash differs, the FAIL *set* has drifted (one item fixed, another regressed) and CI fails with a diff. Never raise the count without an explicit review + sign-off. `baselineDemoCount` is the exact expected demo count per package (single source of truth consumed by both the workflow and validate-parity.ts); deviation in either direction triggers a baseline-deviation warning. NOTE: validate-parity.ts `BASELINE_DEMO_COUNT` default must match `baselineDemoCount` here; keep them in sync. See .github/workflows/showcase_validate.yml 'Run validate-pins (ratchet)' step.",
-  "validatePinsFailCount": 38,
-  "validatePinsFailHash": "81189453f62fd38b5a5fd83e23b3ffb2538dde49f8320977f5da8984105b81db",
+  "validatePinsFailCount": 37,
+  "validatePinsFailHash": "a98c723c8db24ea8dd49f8965e212f8d31a4db0b789637c6e54702660ae0f74f",
   "baselineDemoCount": 9
 }


### PR DESCRIPTION
## Summary

- PR #5827 (agno==2.6.19 exact pin) reduced the validate-pins FAIL count from 38 → 37.
- The ratchet baseline was not updated at merge time, leaving `validate-pins (ratchet)` failing on main with: _"Pin drift decreased: 37 FAIL(s) vs baseline 38."_
- This PR ratchets the baseline down to match the improved state.

## Change

`showcase/scripts/fail-baseline.json`:
- `validatePinsFailCount`: 38 → **37**
- `validatePinsFailHash`: `81189453...` → **`a98c723c...`**

## Red-green proof

**BEFORE (baseline=38, actual=37):**
```
validate-pins FAIL: actual=37 baseline=38
→ "Pin drift decreased: 37 FAIL(s) vs baseline 38. Ratchet down..."
EXIT 1
```

**AFTER (baseline=37, actual=37, hash matches):**
```
[OK] langgraph-fastapi
[OK] strands
[OK] strands-typescript
Summary: OK=3 SKIP=0 WARN=3 FAIL=37
actual_hash=a98c723c8db24ea8dd49f8965e212f8d31a4db0b789637c6e54702660ae0f74f
baseline_hash=a98c723c8db24ea8dd49f8965e212f8d31a4db0b789637c6e54702660ae0f74f
match=YES
→ "Pin drift unchanged at baseline (37, hash a98c723...)."
EXIT 0
```

Both count (37 == 37) and hash match confirmed locally.