### PR TITLE
fix(showcase): update multimodal aimock fixture keys to match current autoPrompt strings

### DIFF
--- a/showcase/aimock/d6/ag2/agentic-chat.json
+++ b/showcase/aimock/d6/ag2/agentic-chat.json
@@ -6,7 +6,7 @@
   },
   "fixtures": [
     {
-      "_comment": "agentic-chat turn 1 — goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to proxy.",
+      "_comment": "agentic-chat turn 1 \u2014 goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to proxy.",
       "match": {
         "userMessage": "good name for a goldfish",
         "context": "ag2"
@@ -16,7 +16,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 2 — tank name. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 2 \u2014 tank name. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "name for its tank",
         "context": "ag2"
@@ -26,7 +26,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 3 — recall. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 3 \u2014 recall. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "what we named the goldfish",
         "context": "ag2"
@@ -46,7 +46,7 @@
           {
             "id": "call_d5_generate_haiku_001",
             "name": "generate_haiku",
-            "arguments": "{\"japanese\":[\"古池や\",\"蛙飛び込む\",\"水の音\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
+            "arguments": "{\"japanese\":[\"\u53e4\u6c60\u3084\",\"\u86d9\u98db\u3073\u8fbc\u3080\",\"\u6c34\u306e\u97f3\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
           }
         ]
       }
@@ -58,12 +58,12 @@
         "context": "ag2"
       },
       "response": {
-        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
+        "content": "Haiku generated above \u2014 a beautiful verse about nature with an accompanying image."
       }
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "ag2"
       },
@@ -73,7 +73,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "ag2"
       },
@@ -88,7 +88,7 @@
         "context": "ag2"
       },
       "response": {
-        "content": "Hello from the popup — the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
+        "content": "Hello from the popup \u2014 the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
       }
     },
     {
@@ -98,7 +98,7 @@
         "context": "ag2"
       },
       "response": {
-        "content": "Hello from the sidebar — the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
+        "content": "Hello from the sidebar \u2014 the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
       }
     },
     {

--- a/showcase/aimock/d6/agno/agentic-chat.json
+++ b/showcase/aimock/d6/agno/agentic-chat.json
@@ -7,7 +7,7 @@
   },
   "fixtures": [
     {
-      "_comment": "agentic-chat turn 1 — goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to proxy.",
+      "_comment": "agentic-chat turn 1 \u2014 goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to proxy.",
       "match": {
         "userMessage": "good name for a goldfish",
         "context": "agno"
@@ -17,7 +17,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 2 — tank name. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 2 \u2014 tank name. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "name for its tank",
         "context": "agno"
@@ -27,7 +27,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 3 — recall. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 3 \u2014 recall. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "what we named the goldfish",
         "context": "agno"
@@ -47,7 +47,7 @@
           {
             "id": "call_d5_generate_haiku_001",
             "name": "generate_haiku",
-            "arguments": "{\"japanese\":[\"古池や\",\"蛙飛び込む\",\"水の音\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
+            "arguments": "{\"japanese\":[\"\u53e4\u6c60\u3084\",\"\u86d9\u98db\u3073\u8fbc\u3080\",\"\u6c34\u306e\u97f3\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
           }
         ]
       }
@@ -59,12 +59,12 @@
         "context": "agno"
       },
       "response": {
-        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
+        "content": "Haiku generated above \u2014 a beautiful verse about nature with an accompanying image."
       }
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "agno"
       },
@@ -74,7 +74,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "agno"
       },
@@ -89,7 +89,7 @@
         "context": "agno"
       },
       "response": {
-        "content": "Hello from the popup — the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
+        "content": "Hello from the popup \u2014 the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
       }
     },
     {
@@ -99,7 +99,7 @@
         "context": "agno"
       },
       "response": {
-        "content": "Hello from the sidebar — the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
+        "content": "Hello from the sidebar \u2014 the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
       }
     },
     {

--- a/showcase/aimock/d6/agno/multimodal.json
+++ b/showcase/aimock/d6/agno/multimodal.json
@@ -6,9 +6,9 @@
   },
   "fixtures": [
     {
-      "_comment": "Multimodal image turn — the D5 script clicks the 'Try with sample image' button which auto-sends a message. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage match uses the describe prompt keyed in agentic-chat.json.",
+      "_comment": "Multimodal image turn \u2014 the D5 script clicks the 'Try with sample image' button which auto-sends a message. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage match uses the describe prompt keyed in agentic-chat.json.",
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "agno"
       },
       "response": {
@@ -16,9 +16,9 @@
       }
     },
     {
-      "_comment": "Multimodal PDF turn — the D5 script clicks the 'Try with sample PDF' button which auto-sends a message. The assertion checks the assistant transcript contains the keyword 'document'.",
+      "_comment": "Multimodal PDF turn \u2014 the D5 script clicks the 'Try with sample PDF' button which auto-sends a message. The assertion checks the assistant transcript contains the keyword 'document'.",
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "agno"
       },
       "response": {

--- a/showcase/aimock/d6/built-in-agent/agentic-chat.json
+++ b/showcase/aimock/d6/built-in-agent/agentic-chat.json
@@ -7,7 +7,7 @@
   },
   "fixtures": [
     {
-      "_comment": "agentic-chat turn 1 — goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to strict-503. Mirrors langgraph-python.",
+      "_comment": "agentic-chat turn 1 \u2014 goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to strict-503. Mirrors langgraph-python.",
       "match": {
         "userMessage": "good name for a goldfish",
         "context": "built-in-agent"
@@ -17,7 +17,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 2 — tank name. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 2 \u2014 tank name. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "name for its tank",
         "context": "built-in-agent"
@@ -27,7 +27,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 3 — recall. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 3 \u2014 recall. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "what we named the goldfish",
         "context": "built-in-agent"
@@ -47,7 +47,7 @@
           {
             "id": "call_d5_generate_haiku_001",
             "name": "generate_haiku",
-            "arguments": "{\"japanese\":[\"古池や\",\"蛙飛び込む\",\"水の音\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
+            "arguments": "{\"japanese\":[\"\u53e4\u6c60\u3084\",\"\u86d9\u98db\u3073\u8fbc\u3080\",\"\u6c34\u306e\u97f3\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
           }
         ]
       }
@@ -59,12 +59,12 @@
         "context": "built-in-agent"
       },
       "response": {
-        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
+        "content": "Haiku generated above \u2014 a beautiful verse about nature with an accompanying image."
       }
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "built-in-agent"
       },
@@ -74,7 +74,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "built-in-agent"
       },
@@ -89,7 +89,7 @@
         "context": "built-in-agent"
       },
       "response": {
-        "content": "Hello from the popup — the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
+        "content": "Hello from the popup \u2014 the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
       }
     },
     {
@@ -99,7 +99,7 @@
         "context": "built-in-agent"
       },
       "response": {
-        "content": "Hello from the sidebar — the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
+        "content": "Hello from the sidebar \u2014 the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
       }
     },
     {

--- a/showcase/aimock/d6/built-in-agent/multimodal.json
+++ b/showcase/aimock/d6/built-in-agent/multimodal.json
@@ -6,9 +6,9 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal image turn — the D5 script clicks the sample-image button which auto-sends a message. The assertion checks for 'image' keyword in the assistant transcript. The input text is 'image-sample-button (auto-sent)' but skipSend=true, so the actual userMessage comes from the sample button's inject. We match on 'describe the sample image' which is what the sample button sends.",
+      "_comment": "multimodal image turn \u2014 the D5 script clicks the sample-image button which auto-sends a message. The assertion checks for 'image' keyword in the assistant transcript. The input text is 'image-sample-button (auto-sent)' but skipSend=true, so the actual userMessage comes from the sample button's inject. We match on 'can you tell me what is in this demo image I just attached' which is what the sample button sends.",
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "built-in-agent"
       },
       "response": {
@@ -16,9 +16,9 @@
       }
     },
     {
-      "_comment": "multimodal pdf turn — the D5 script clicks the sample-pdf button which auto-sends. The assertion checks for 'document' keyword in the assistant transcript.",
+      "_comment": "multimodal pdf turn \u2014 the D5 script clicks the sample-pdf button which auto-sends. The assertion checks for 'document' keyword in the assistant transcript.",
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "built-in-agent"
       },
       "response": {

--- a/showcase/aimock/d6/claude-sdk-python/agentic-chat.json
+++ b/showcase/aimock/d6/claude-sdk-python/agentic-chat.json
@@ -44,7 +44,7 @@
           {
             "id": "call_d5_generate_haiku_001",
             "name": "generate_haiku",
-            "arguments": "{\"japanese\":[\"古池や\",\"蛙飛び込む\",\"水の音\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
+            "arguments": "{\"japanese\":[\"\u53e4\u6c60\u3084\",\"\u86d9\u98db\u3073\u8fbc\u3080\",\"\u6c34\u306e\u97f3\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
           }
         ]
       }
@@ -56,12 +56,12 @@
         "context": "claude-sdk-python"
       },
       "response": {
-        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
+        "content": "Haiku generated above \u2014 a beautiful verse about nature with an accompanying image."
       }
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "claude-sdk-python"
       },
@@ -71,7 +71,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "claude-sdk-python"
       },
@@ -86,7 +86,7 @@
         "context": "claude-sdk-python"
       },
       "response": {
-        "content": "Hello from the popup — the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
+        "content": "Hello from the popup \u2014 the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
       }
     },
     {
@@ -96,7 +96,7 @@
         "context": "claude-sdk-python"
       },
       "response": {
-        "content": "Hello from the sidebar — the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
+        "content": "Hello from the sidebar \u2014 the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
       }
     },
     {

--- a/showcase/aimock/d6/claude-sdk-python/multimodal.json
+++ b/showcase/aimock/d6/claude-sdk-python/multimodal.json
@@ -6,9 +6,9 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal image turn — preFill clicks the sample-image button which auto-sends. The D5 script asserts the assistant transcript contains 'image'. The input text is descriptive only (skipSend=true in the script).",
+      "_comment": "multimodal image turn \u2014 preFill clicks the sample-image button which auto-sends. The D5 script asserts the assistant transcript contains 'image'. The input text is descriptive only (skipSend=true in the script).",
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "claude-sdk-python"
       },
@@ -17,9 +17,9 @@
       }
     },
     {
-      "_comment": "multimodal PDF turn — preFill clicks the sample-pdf button which auto-sends. The D5 script asserts the assistant transcript contains 'document'.",
+      "_comment": "multimodal PDF turn \u2014 preFill clicks the sample-pdf button which auto-sends. The D5 script asserts the assistant transcript contains 'document'.",
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "claude-sdk-python"
       },

--- a/showcase/aimock/d6/claude-sdk-typescript/agentic-chat.json
+++ b/showcase/aimock/d6/claude-sdk-typescript/agentic-chat.json
@@ -61,7 +61,7 @@
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "claude-sdk-typescript"
       },
@@ -71,7 +71,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "claude-sdk-typescript"
       },

--- a/showcase/aimock/d6/claude-sdk-typescript/multimodal.json
+++ b/showcase/aimock/d6/claude-sdk-typescript/multimodal.json
@@ -6,9 +6,9 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal image turn — the D5 script clicks the sample-image button which auto-sends. The user message comes from the sample button's injected text. Response must contain 'image' keyword for the assertion.",
+      "_comment": "multimodal image turn \u2014 the D5 script clicks the sample-image button which auto-sends. The user message comes from the sample button's injected text. Response must contain 'image' keyword for the assertion.",
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "claude-sdk-typescript"
       },
       "response": {
@@ -16,9 +16,9 @@
       }
     },
     {
-      "_comment": "multimodal PDF turn — the D5 script clicks the sample-pdf button which auto-sends. Response must contain 'document' keyword for the assertion.",
+      "_comment": "multimodal PDF turn \u2014 the D5 script clicks the sample-pdf button which auto-sends. Response must contain 'document' keyword for the assertion.",
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "claude-sdk-typescript"
       },
       "response": {
@@ -26,13 +26,13 @@
       }
     },
     {
-      "_comment": "multimodal fallback — matches common auto-sent messages from the sample attachment buttons that may vary across integrations.",
+      "_comment": "multimodal fallback \u2014 matches common auto-sent messages from the sample attachment buttons that may vary across integrations.",
       "match": {
         "userMessage": "Describe this image",
         "context": "claude-sdk-typescript"
       },
       "response": {
-        "content": "The image shows a small test pattern — a colorful abstract composition used to validate the multimodal image upload pipeline."
+        "content": "The image shows a small test pattern \u2014 a colorful abstract composition used to validate the multimodal image upload pipeline."
       }
     },
     {

--- a/showcase/aimock/d6/crewai-crews/agentic-chat.json
+++ b/showcase/aimock/d6/crewai-crews/agentic-chat.json
@@ -7,7 +7,7 @@
   },
   "fixtures": [
     {
-      "_comment": "agentic-chat turn 1 — goldfish name. No turnIndex gate: multi-turn conversation in a single thread; turnIndex would restrict to first turn only, causing turns 2-3 to fall through to proxy.",
+      "_comment": "agentic-chat turn 1 \u2014 goldfish name. No turnIndex gate: multi-turn conversation in a single thread; turnIndex would restrict to first turn only, causing turns 2-3 to fall through to proxy.",
       "match": {
         "userMessage": "good name for a goldfish",
         "context": "crewai-crews"
@@ -17,7 +17,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 2 — tank name. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 2 \u2014 tank name. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "name for its tank",
         "context": "crewai-crews"
@@ -27,7 +27,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 3 — recall. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 3 \u2014 recall. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "what we named the goldfish",
         "context": "crewai-crews"
@@ -47,7 +47,7 @@
           {
             "id": "call_d5_generate_haiku_001",
             "name": "generate_haiku",
-            "arguments": "{\"japanese\":[\"古池や\",\"蛙飛び込む\",\"水の音\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
+            "arguments": "{\"japanese\":[\"\u53e4\u6c60\u3084\",\"\u86d9\u98db\u3073\u8fbc\u3080\",\"\u6c34\u306e\u97f3\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
           }
         ]
       }
@@ -59,12 +59,12 @@
         "context": "crewai-crews"
       },
       "response": {
-        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
+        "content": "Haiku generated above \u2014 a beautiful verse about nature with an accompanying image."
       }
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "crewai-crews"
       },
@@ -74,7 +74,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "crewai-crews"
       },
@@ -89,7 +89,7 @@
         "context": "crewai-crews"
       },
       "response": {
-        "content": "Hello from the popup — the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
+        "content": "Hello from the popup \u2014 the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
       }
     },
     {
@@ -99,7 +99,7 @@
         "context": "crewai-crews"
       },
       "response": {
-        "content": "Hello from the sidebar — the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
+        "content": "Hello from the sidebar \u2014 the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
       }
     },
     {

--- a/showcase/aimock/d6/crewai-crews/multimodal.json
+++ b/showcase/aimock/d6/crewai-crews/multimodal.json
@@ -7,9 +7,9 @@
   },
   "fixtures": [
     {
-      "_comment": "Image attachment turn — probe clicks sample-image-button, attaches sample.png, sends 'describe the sample image'.",
+      "_comment": "Image attachment turn \u2014 probe clicks sample-image-button, attaches sample.png, sends 'can you tell me what is in this demo image I just attached'.",
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "crewai-crews"
       },
@@ -18,9 +18,9 @@
       }
     },
     {
-      "_comment": "PDF attachment turn — probe clicks sample-pdf-button, attaches sample.pdf, sends 'summarize the sample document'.",
+      "_comment": "PDF attachment turn \u2014 probe clicks sample-pdf-button, attaches sample.pdf, sends 'can you tell me what is in this demo pdf I just attached'.",
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "crewai-crews"
       },

--- a/showcase/aimock/d6/google-adk/agentic-chat.json
+++ b/showcase/aimock/d6/google-adk/agentic-chat.json
@@ -63,7 +63,7 @@
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "google-adk"
       },
@@ -73,7 +73,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "google-adk"
       },

--- a/showcase/aimock/d6/google-adk/multimodal.json
+++ b/showcase/aimock/d6/google-adk/multimodal.json
@@ -6,9 +6,9 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal \u2014 sample image turn. The probe clicks 'Try with sample image' which auto-sends via agent.addMessage. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage here matches the agentic-chat fixture for 'describe the sample image' which is the message the sample-attachment-buttons component dispatches.",
+      "_comment": "multimodal \u2014 sample image turn. The probe clicks 'Try with sample image' which auto-sends via agent.addMessage. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage here matches the agentic-chat fixture for 'can you tell me what is in this demo image I just attached' which is the message the sample-attachment-buttons component dispatches.",
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "google-adk"
       },
@@ -19,7 +19,7 @@
     {
       "_comment": "multimodal \u2014 sample PDF turn. The probe clicks 'Try with sample PDF' which auto-sends. The assertion checks the assistant transcript contains the keyword 'document'.",
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "google-adk"
       },

--- a/showcase/aimock/d6/langgraph-fastapi/agentic-chat.json
+++ b/showcase/aimock/d6/langgraph-fastapi/agentic-chat.json
@@ -7,7 +7,7 @@
   },
   "fixtures": [
     {
-      "_comment": "agentic-chat turn 1 — goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to proxy.",
+      "_comment": "agentic-chat turn 1 \u2014 goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to proxy.",
       "match": {
         "userMessage": "good name for a goldfish",
         "context": "langgraph-fastapi"
@@ -17,7 +17,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 2 — tank name. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 2 \u2014 tank name. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "name for its tank",
         "context": "langgraph-fastapi"
@@ -27,7 +27,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 3 — recall. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 3 \u2014 recall. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "what we named the goldfish",
         "context": "langgraph-fastapi"
@@ -47,7 +47,7 @@
           {
             "id": "call_d5_generate_haiku_001",
             "name": "generate_haiku",
-            "arguments": "{\"japanese\":[\"古池や\",\"蛙飛び込む\",\"水の音\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
+            "arguments": "{\"japanese\":[\"\u53e4\u6c60\u3084\",\"\u86d9\u98db\u3073\u8fbc\u3080\",\"\u6c34\u306e\u97f3\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
           }
         ]
       }
@@ -59,12 +59,12 @@
         "context": "langgraph-fastapi"
       },
       "response": {
-        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
+        "content": "Haiku generated above \u2014 a beautiful verse about nature with an accompanying image."
       }
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "langgraph-fastapi"
       },
@@ -74,7 +74,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "langgraph-fastapi"
       },
@@ -89,7 +89,7 @@
         "context": "langgraph-fastapi"
       },
       "response": {
-        "content": "Hello from the popup — the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
+        "content": "Hello from the popup \u2014 the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
       }
     },
     {
@@ -99,7 +99,7 @@
         "context": "langgraph-fastapi"
       },
       "response": {
-        "content": "Hello from the sidebar — the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
+        "content": "Hello from the sidebar \u2014 the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
       }
     },
     {

--- a/showcase/aimock/d6/langgraph-fastapi/multimodal.json
+++ b/showcase/aimock/d6/langgraph-fastapi/multimodal.json
@@ -6,9 +6,9 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal — image attachment pill. The script clicks the sample-image button, attaches sample.png, then sends this query.",
+      "_comment": "multimodal \u2014 image attachment pill. The script clicks the sample-image button, attaches sample.png, then sends this query.",
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "langgraph-fastapi"
       },
       "response": {
@@ -16,9 +16,9 @@
       }
     },
     {
-      "_comment": "multimodal — PDF attachment pill. The script attaches the sample PDF, then sends this query.",
+      "_comment": "multimodal \u2014 PDF attachment pill. The script attaches the sample PDF, then sends this query.",
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "langgraph-fastapi"
       },
       "response": {

--- a/showcase/aimock/d6/langgraph-python/agentic-chat.json
+++ b/showcase/aimock/d6/langgraph-python/agentic-chat.json
@@ -6,7 +6,7 @@
   },
   "fixtures": [
     {
-      "_comment": "agentic-chat turn 1 — goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to proxy.",
+      "_comment": "agentic-chat turn 1 \u2014 goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to proxy.",
       "match": {
         "userMessage": "good name for a goldfish",
         "context": "langgraph-python"
@@ -16,7 +16,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 2 — tank name. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 2 \u2014 tank name. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "name for its tank",
         "context": "langgraph-python"
@@ -26,7 +26,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 3 — recall. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 3 \u2014 recall. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "what we named the goldfish",
         "context": "langgraph-python"
@@ -46,7 +46,7 @@
           {
             "id": "call_d5_generate_haiku_001",
             "name": "generate_haiku",
-            "arguments": "{\"japanese\":[\"古池や\",\"蛙飛び込む\",\"水の音\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
+            "arguments": "{\"japanese\":[\"\u53e4\u6c60\u3084\",\"\u86d9\u98db\u3073\u8fbc\u3080\",\"\u6c34\u306e\u97f3\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
           }
         ]
       }
@@ -58,12 +58,12 @@
         "context": "langgraph-python"
       },
       "response": {
-        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
+        "content": "Haiku generated above \u2014 a beautiful verse about nature with an accompanying image."
       }
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "langgraph-python"
       },
@@ -73,7 +73,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "langgraph-python"
       },
@@ -88,7 +88,7 @@
         "context": "langgraph-python"
       },
       "response": {
-        "content": "Hello from the popup — the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
+        "content": "Hello from the popup \u2014 the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
       }
     },
     {
@@ -98,7 +98,7 @@
         "context": "langgraph-python"
       },
       "response": {
-        "content": "Hello from the sidebar — the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
+        "content": "Hello from the sidebar \u2014 the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
       }
     },
     {

--- a/showcase/aimock/d6/langgraph-python/multimodal.json
+++ b/showcase/aimock/d6/langgraph-python/multimodal.json
@@ -6,9 +6,9 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal — sample image turn. The probe clicks 'Try with sample image' which auto-sends via agent.addMessage. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage here matches the agentic-chat fixture for 'describe the sample image' which is the message the sample-attachment-buttons component dispatches.",
+      "_comment": "multimodal \u2014 sample image turn. The probe clicks 'Try with sample image' which auto-sends via agent.addMessage. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage here matches the agentic-chat fixture for 'can you tell me what is in this demo image I just attached' which is the message the sample-attachment-buttons component dispatches.",
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "langgraph-python"
       },
@@ -17,9 +17,9 @@
       }
     },
     {
-      "_comment": "multimodal — sample PDF turn. The probe clicks 'Try with sample PDF' which auto-sends. The assertion checks the assistant transcript contains the keyword 'document'.",
+      "_comment": "multimodal \u2014 sample PDF turn. The probe clicks 'Try with sample PDF' which auto-sends. The assertion checks the assistant transcript contains the keyword 'document'.",
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "langgraph-python"
       },

--- a/showcase/aimock/d6/langgraph-typescript/agentic-chat.json
+++ b/showcase/aimock/d6/langgraph-typescript/agentic-chat.json
@@ -64,7 +64,7 @@
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "langgraph-typescript"
       },
@@ -74,7 +74,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "langgraph-typescript"
       },

--- a/showcase/aimock/d6/langgraph-typescript/multimodal.json
+++ b/showcase/aimock/d6/langgraph-typescript/multimodal.json
@@ -6,9 +6,9 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal image pill — the probe clicks the sample-image button to attach a test PNG, then sends this query.",
+      "_comment": "multimodal image pill \u2014 the probe clicks the sample-image button to attach a test PNG, then sends this query.",
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "langgraph-typescript"
       },
       "response": {
@@ -16,9 +16,9 @@
       }
     },
     {
-      "_comment": "multimodal document pill — the probe attaches a test PDF, then sends this query.",
+      "_comment": "multimodal document pill \u2014 the probe attaches a test PDF, then sends this query.",
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "langgraph-typescript"
       },
       "response": {

--- a/showcase/aimock/d6/langroid/agentic-chat.json
+++ b/showcase/aimock/d6/langroid/agentic-chat.json
@@ -7,7 +7,7 @@
   },
   "fixtures": [
     {
-      "_comment": "agentic-chat turn 1 — goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through.",
+      "_comment": "agentic-chat turn 1 \u2014 goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through.",
       "match": {
         "userMessage": "good name for a goldfish",
         "context": "langroid"
@@ -17,7 +17,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 2 — tank name. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 2 \u2014 tank name. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "name for its tank",
         "context": "langroid"
@@ -27,7 +27,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 3 — recall. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 3 \u2014 recall. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "what we named the goldfish",
         "context": "langroid"
@@ -47,7 +47,7 @@
           {
             "id": "call_d5_generate_haiku_001",
             "name": "generate_haiku",
-            "arguments": "{\"japanese\":[\"古池や\",\"蛙飛び込む\",\"水の音\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
+            "arguments": "{\"japanese\":[\"\u53e4\u6c60\u3084\",\"\u86d9\u98db\u3073\u8fbc\u3080\",\"\u6c34\u306e\u97f3\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
           }
         ]
       }
@@ -59,12 +59,12 @@
         "context": "langroid"
       },
       "response": {
-        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
+        "content": "Haiku generated above \u2014 a beautiful verse about nature with an accompanying image."
       }
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "langroid"
       },
@@ -74,7 +74,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "langroid"
       },
@@ -89,7 +89,7 @@
         "context": "langroid"
       },
       "response": {
-        "content": "Hello from the popup — the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
+        "content": "Hello from the popup \u2014 the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
       }
     },
     {
@@ -99,7 +99,7 @@
         "context": "langroid"
       },
       "response": {
-        "content": "Hello from the sidebar — the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
+        "content": "Hello from the sidebar \u2014 the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
       }
     },
     {

--- a/showcase/aimock/d6/langroid/multimodal.json
+++ b/showcase/aimock/d6/langroid/multimodal.json
@@ -6,9 +6,9 @@
   },
   "fixtures": [
     {
-      "_comment": "Image sample turn — the D5 script clicks the sample-image button (which auto-sends). The assertion checks for 'image' keyword in the assistant transcript.",
+      "_comment": "Image sample turn \u2014 the D5 script clicks the sample-image button (which auto-sends). The assertion checks for 'image' keyword in the assistant transcript.",
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "langroid"
       },
       "response": {
@@ -16,9 +16,9 @@
       }
     },
     {
-      "_comment": "PDF sample turn — the D5 script clicks the sample-pdf button (which auto-sends). The assertion checks for 'document' keyword in the assistant transcript.",
+      "_comment": "PDF sample turn \u2014 the D5 script clicks the sample-pdf button (which auto-sends). The assertion checks for 'document' keyword in the assistant transcript.",
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "langroid"
       },
       "response": {
@@ -26,17 +26,17 @@
       }
     },
     {
-      "_comment": "Fallback for auto-sent image prompt — the sample button sends a canned user message that may differ from 'describe the sample image'. Match on 'image' substring to catch it.",
+      "_comment": "Fallback for auto-sent image prompt \u2014 the sample button sends a canned user message that may differ from 'can you tell me what is in this demo image I just attached'. Match on 'image' substring to catch it.",
       "match": {
         "userMessage": "sample image",
         "context": "langroid"
       },
       "response": {
-        "content": "The image shows a small test pattern — confirming the image upload pipeline round-tripped through the runtime successfully."
+        "content": "The image shows a small test pattern \u2014 confirming the image upload pipeline round-tripped through the runtime successfully."
       }
     },
     {
-      "_comment": "Fallback for auto-sent PDF prompt — match on 'sample' + 'pdf' or 'document' substring.",
+      "_comment": "Fallback for auto-sent PDF prompt \u2014 match on 'sample' + 'pdf' or 'document' substring.",
       "match": {
         "userMessage": "sample pdf",
         "context": "langroid"

--- a/showcase/aimock/d6/llamaindex/agentic-chat.json
+++ b/showcase/aimock/d6/llamaindex/agentic-chat.json
@@ -7,7 +7,7 @@
   },
   "fixtures": [
     {
-      "_comment": "agentic-chat turn 1 — goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to proxy.",
+      "_comment": "agentic-chat turn 1 \u2014 goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to proxy.",
       "match": {
         "userMessage": "good name for a goldfish",
         "context": "llamaindex"
@@ -17,7 +17,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 2 — tank name. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 2 \u2014 tank name. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "name for its tank",
         "context": "llamaindex"
@@ -27,7 +27,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 3 — recall. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 3 \u2014 recall. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "what we named the goldfish",
         "context": "llamaindex"
@@ -47,7 +47,7 @@
           {
             "id": "call_d5_generate_haiku_001",
             "name": "generate_haiku",
-            "arguments": "{\"japanese\":[\"古池や\",\"蛙飛び込む\",\"水の音\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
+            "arguments": "{\"japanese\":[\"\u53e4\u6c60\u3084\",\"\u86d9\u98db\u3073\u8fbc\u3080\",\"\u6c34\u306e\u97f3\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
           }
         ]
       }
@@ -59,12 +59,12 @@
         "context": "llamaindex"
       },
       "response": {
-        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
+        "content": "Haiku generated above \u2014 a beautiful verse about nature with an accompanying image."
       }
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "llamaindex"
       },
@@ -74,7 +74,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "llamaindex"
       },
@@ -89,7 +89,7 @@
         "context": "llamaindex"
       },
       "response": {
-        "content": "Hello from the popup — the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
+        "content": "Hello from the popup \u2014 the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
       }
     },
     {
@@ -99,7 +99,7 @@
         "context": "llamaindex"
       },
       "response": {
-        "content": "Hello from the sidebar — the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
+        "content": "Hello from the sidebar \u2014 the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
       }
     },
     {

--- a/showcase/aimock/d6/llamaindex/multimodal.json
+++ b/showcase/aimock/d6/llamaindex/multimodal.json
@@ -6,9 +6,9 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal image turn — the sample image button auto-sends 'describe the sample image'. The D5 assertion checks assistant transcript contains 'image'. Already present in agentic-chat.json but duplicated here for the dedicated multimodal fixture file match.",
+      "_comment": "multimodal image turn \u2014 the sample image button auto-sends 'can you tell me what is in this demo image I just attached'. The D5 assertion checks assistant transcript contains 'image'. Already present in agentic-chat.json but duplicated here for the dedicated multimodal fixture file match.",
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "llamaindex"
       },
@@ -17,9 +17,9 @@
       }
     },
     {
-      "_comment": "multimodal PDF turn — the sample PDF button auto-sends 'summarize the sample document'. The D5 assertion checks assistant transcript contains 'document'.",
+      "_comment": "multimodal PDF turn \u2014 the sample PDF button auto-sends 'can you tell me what is in this demo pdf I just attached'. The D5 assertion checks assistant transcript contains 'document'.",
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "llamaindex"
       },

--- a/showcase/aimock/d6/mastra/agentic-chat.json
+++ b/showcase/aimock/d6/mastra/agentic-chat.json
@@ -65,7 +65,7 @@
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "mastra"
       },
@@ -75,7 +75,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "mastra"
       },

--- a/showcase/aimock/d6/mastra/multimodal.json
+++ b/showcase/aimock/d6/mastra/multimodal.json
@@ -7,9 +7,9 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal \u2014 sample image turn. The probe clicks 'Try with sample image' which auto-sends via agent.addMessage. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage here matches the agentic-chat fixture for 'describe the sample image' which is the message the sample-attachment-buttons component dispatches.",
+      "_comment": "multimodal \u2014 sample image turn. The probe clicks 'Try with sample image' which auto-sends via agent.addMessage. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage here matches the agentic-chat fixture for 'can you tell me what is in this demo image I just attached' which is the message the sample-attachment-buttons component dispatches.",
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "mastra"
       },
@@ -20,7 +20,7 @@
     {
       "_comment": "multimodal \u2014 sample PDF turn. The probe clicks 'Try with sample PDF' which auto-sends. The assertion checks the assistant transcript contains the keyword 'document'.",
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "mastra"
       },

--- a/showcase/aimock/d6/ms-agent-dotnet/agentic-chat.json
+++ b/showcase/aimock/d6/ms-agent-dotnet/agentic-chat.json
@@ -63,7 +63,7 @@
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "ms-agent-dotnet"
       },
@@ -73,7 +73,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "ms-agent-dotnet"
       },

--- a/showcase/aimock/d6/ms-agent-dotnet/multimodal.json
+++ b/showcase/aimock/d6/ms-agent-dotnet/multimodal.json
@@ -6,9 +6,9 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal image turn — the D5 script clicks 'Try with sample image' which auto-sends a message with the image attachment. The assertion checks for 'image' keyword in the assistant transcript.",
+      "_comment": "multimodal image turn \u2014 the D5 script clicks 'Try with sample image' which auto-sends a message with the image attachment. The assertion checks for 'image' keyword in the assistant transcript.",
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "ms-agent-dotnet"
       },
@@ -17,9 +17,9 @@
       }
     },
     {
-      "_comment": "multimodal PDF turn — the D5 script clicks 'Try with sample PDF' which auto-sends a message with the PDF attachment. The assertion checks for 'document' keyword in the assistant transcript.",
+      "_comment": "multimodal PDF turn \u2014 the D5 script clicks 'Try with sample PDF' which auto-sends a message with the PDF attachment. The assertion checks for 'document' keyword in the assistant transcript.",
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "ms-agent-dotnet"
       },

--- a/showcase/aimock/d6/ms-agent-harness-dotnet/agentic-chat.json
+++ b/showcase/aimock/d6/ms-agent-harness-dotnet/agentic-chat.json
@@ -63,7 +63,7 @@
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "ms-agent-harness-dotnet"
       },
@@ -73,7 +73,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "ms-agent-harness-dotnet"
       },

--- a/showcase/aimock/d6/ms-agent-harness-dotnet/multimodal.json
+++ b/showcase/aimock/d6/ms-agent-harness-dotnet/multimodal.json
@@ -6,9 +6,9 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal image turn — the D5 script clicks 'Try with sample image' which auto-sends a message with the image attachment. The assertion checks for 'image' keyword in the assistant transcript.",
+      "_comment": "multimodal image turn \u2014 the D5 script clicks 'Try with sample image' which auto-sends a message with the image attachment. The assertion checks for 'image' keyword in the assistant transcript.",
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "ms-agent-harness-dotnet"
       },
@@ -17,9 +17,9 @@
       }
     },
     {
-      "_comment": "multimodal PDF turn — the D5 script clicks 'Try with sample PDF' which auto-sends a message with the PDF attachment. The assertion checks for 'document' keyword in the assistant transcript.",
+      "_comment": "multimodal PDF turn \u2014 the D5 script clicks 'Try with sample PDF' which auto-sends a message with the PDF attachment. The assertion checks for 'document' keyword in the assistant transcript.",
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "ms-agent-harness-dotnet"
       },

--- a/showcase/aimock/d6/ms-agent-python/agentic-chat.json
+++ b/showcase/aimock/d6/ms-agent-python/agentic-chat.json
@@ -7,7 +7,7 @@
   },
   "fixtures": [
     {
-      "_comment": "agentic-chat turn 1 — goldfish name. No turnIndex gate: probe sends 3 sequential turns in one thread; turnIndex would restrict to turn 1 and cause turns 2-3 to 503. Mirrors langgraph-python.",
+      "_comment": "agentic-chat turn 1 \u2014 goldfish name. No turnIndex gate: probe sends 3 sequential turns in one thread; turnIndex would restrict to turn 1 and cause turns 2-3 to 503. Mirrors langgraph-python.",
       "match": {
         "userMessage": "good name for a goldfish",
         "context": "ms-agent-python"
@@ -17,7 +17,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 2 — tank name. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 2 \u2014 tank name. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "name for its tank",
         "context": "ms-agent-python"
@@ -27,7 +27,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 3 — recall. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 3 \u2014 recall. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "what we named the goldfish",
         "context": "ms-agent-python"
@@ -47,7 +47,7 @@
           {
             "id": "call_d5_generate_haiku_001",
             "name": "generate_haiku",
-            "arguments": "{\"japanese\":[\"古池や\",\"蛙飛び込む\",\"水の音\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
+            "arguments": "{\"japanese\":[\"\u53e4\u6c60\u3084\",\"\u86d9\u98db\u3073\u8fbc\u3080\",\"\u6c34\u306e\u97f3\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
           }
         ]
       }
@@ -59,12 +59,12 @@
         "context": "ms-agent-python"
       },
       "response": {
-        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
+        "content": "Haiku generated above \u2014 a beautiful verse about nature with an accompanying image."
       }
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "ms-agent-python"
       },
@@ -74,7 +74,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "ms-agent-python"
       },
@@ -89,7 +89,7 @@
         "context": "ms-agent-python"
       },
       "response": {
-        "content": "Hello from the popup — the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
+        "content": "Hello from the popup \u2014 the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
       }
     },
     {
@@ -99,7 +99,7 @@
         "context": "ms-agent-python"
       },
       "response": {
-        "content": "Hello from the sidebar — the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
+        "content": "Hello from the sidebar \u2014 the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
       }
     },
     {

--- a/showcase/aimock/d6/ms-agent-python/multimodal.json
+++ b/showcase/aimock/d6/ms-agent-python/multimodal.json
@@ -7,7 +7,7 @@
   "fixtures": [
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "ms-agent-python"
       },
       "response": {
@@ -16,7 +16,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "ms-agent-python"
       },
       "response": {

--- a/showcase/aimock/d6/pydantic-ai/agentic-chat.json
+++ b/showcase/aimock/d6/pydantic-ai/agentic-chat.json
@@ -7,7 +7,7 @@
   },
   "fixtures": [
     {
-      "_comment": "agentic-chat turn 1 — goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to proxy.",
+      "_comment": "agentic-chat turn 1 \u2014 goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to proxy.",
       "match": {
         "userMessage": "good name for a goldfish",
         "context": "pydantic-ai"
@@ -17,7 +17,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 2 — tank name. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 2 \u2014 tank name. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "name for its tank",
         "context": "pydantic-ai"
@@ -27,7 +27,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 3 — recall. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 3 \u2014 recall. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "what we named the goldfish",
         "context": "pydantic-ai"
@@ -47,7 +47,7 @@
           {
             "id": "call_d5_generate_haiku_001",
             "name": "generate_haiku",
-            "arguments": "{\"japanese\":[\"古池や\",\"蛙飛び込む\",\"水の音\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
+            "arguments": "{\"japanese\":[\"\u53e4\u6c60\u3084\",\"\u86d9\u98db\u3073\u8fbc\u3080\",\"\u6c34\u306e\u97f3\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
           }
         ]
       }
@@ -59,12 +59,12 @@
         "context": "pydantic-ai"
       },
       "response": {
-        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
+        "content": "Haiku generated above \u2014 a beautiful verse about nature with an accompanying image."
       }
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "pydantic-ai"
       },
@@ -74,7 +74,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "pydantic-ai"
       },
@@ -89,7 +89,7 @@
         "context": "pydantic-ai"
       },
       "response": {
-        "content": "Hello from the popup — the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
+        "content": "Hello from the popup \u2014 the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
       }
     },
     {
@@ -99,7 +99,7 @@
         "context": "pydantic-ai"
       },
       "response": {
-        "content": "Hello from the sidebar — the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
+        "content": "Hello from the sidebar \u2014 the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
       }
     },
     {

--- a/showcase/aimock/d6/pydantic-ai/multimodal.json
+++ b/showcase/aimock/d6/pydantic-ai/multimodal.json
@@ -7,7 +7,7 @@
   "fixtures": [
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "pydantic-ai"
       },
       "response": {
@@ -16,7 +16,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "pydantic-ai"
       },
       "response": {

--- a/showcase/aimock/d6/spring-ai/agentic-chat.json
+++ b/showcase/aimock/d6/spring-ai/agentic-chat.json
@@ -7,7 +7,7 @@
   },
   "fixtures": [
     {
-      "_comment": "agentic-chat turn 1 — goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to proxy.",
+      "_comment": "agentic-chat turn 1 \u2014 goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to proxy.",
       "match": {
         "userMessage": "good name for a goldfish",
         "context": "spring-ai"
@@ -17,7 +17,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 2 — tank name. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 2 \u2014 tank name. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "name for its tank",
         "context": "spring-ai"
@@ -27,7 +27,7 @@
       }
     },
     {
-      "_comment": "agentic-chat turn 3 — recall. No turnIndex gate (multi-turn conversation).",
+      "_comment": "agentic-chat turn 3 \u2014 recall. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "what we named the goldfish",
         "context": "spring-ai"
@@ -47,7 +47,7 @@
           {
             "id": "call_d5_generate_haiku_001",
             "name": "generate_haiku",
-            "arguments": "{\"japanese\":[\"古池や\",\"蛙飛び込む\",\"水の音\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
+            "arguments": "{\"japanese\":[\"\u53e4\u6c60\u3084\",\"\u86d9\u98db\u3073\u8fbc\u3080\",\"\u6c34\u306e\u97f3\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
           }
         ]
       }
@@ -59,12 +59,12 @@
         "context": "spring-ai"
       },
       "response": {
-        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
+        "content": "Haiku generated above \u2014 a beautiful verse about nature with an accompanying image."
       }
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "spring-ai"
       },
@@ -74,7 +74,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "spring-ai"
       },
@@ -89,7 +89,7 @@
         "context": "spring-ai"
       },
       "response": {
-        "content": "Hello from the popup — the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
+        "content": "Hello from the popup \u2014 the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
       }
     },
     {
@@ -99,7 +99,7 @@
         "context": "spring-ai"
       },
       "response": {
-        "content": "Hello from the sidebar — the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
+        "content": "Hello from the sidebar \u2014 the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
       }
     },
     {

--- a/showcase/aimock/d6/spring-ai/multimodal.json
+++ b/showcase/aimock/d6/spring-ai/multimodal.json
@@ -6,9 +6,9 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal image turn — the probe clicks 'Try with sample image' which auto-sends. Response must contain 'image' keyword for the assertion.",
+      "_comment": "multimodal image turn \u2014 the probe clicks 'Try with sample image' which auto-sends. Response must contain 'image' keyword for the assertion.",
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "spring-ai"
       },
       "response": {
@@ -16,9 +16,9 @@
       }
     },
     {
-      "_comment": "multimodal PDF turn — the probe clicks 'Try with sample PDF' which auto-sends. Response must contain 'document' keyword for the assertion.",
+      "_comment": "multimodal PDF turn \u2014 the probe clicks 'Try with sample PDF' which auto-sends. Response must contain 'document' keyword for the assertion.",
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "spring-ai"
       },
       "response": {

--- a/showcase/aimock/d6/strands-typescript/agentic-chat.json
+++ b/showcase/aimock/d6/strands-typescript/agentic-chat.json
@@ -44,7 +44,7 @@
           {
             "id": "call_d5_generate_haiku_001",
             "name": "generate_haiku",
-            "arguments": "{\"japanese\":[\"古池や\",\"蛙飛び込む\",\"水の音\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
+            "arguments": "{\"japanese\":[\"\u53e4\u6c60\u3084\",\"\u86d9\u98db\u3073\u8fbc\u3080\",\"\u6c34\u306e\u97f3\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
           }
         ]
       }
@@ -56,12 +56,12 @@
         "context": "strands-typescript"
       },
       "response": {
-        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
+        "content": "Haiku generated above \u2014 a beautiful verse about nature with an accompanying image."
       }
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "strands-typescript"
       },
@@ -71,7 +71,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "strands-typescript"
       },
@@ -86,7 +86,7 @@
         "context": "strands-typescript"
       },
       "response": {
-        "content": "Hello from the popup — the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
+        "content": "Hello from the popup \u2014 the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
       }
     },
     {
@@ -96,7 +96,7 @@
         "context": "strands-typescript"
       },
       "response": {
-        "content": "Hello from the sidebar — the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
+        "content": "Hello from the sidebar \u2014 the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
       }
     },
     {

--- a/showcase/aimock/d6/strands-typescript/multimodal.json
+++ b/showcase/aimock/d6/strands-typescript/multimodal.json
@@ -6,9 +6,9 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal — image upload turn. The D5 script clicks the 'Try with sample image' button (auto-sends), then asserts the assistant transcript contains 'image'. The input text is a label only (skipSend:true in the script).",
+      "_comment": "multimodal \u2014 image upload turn. The D5 script clicks the 'Try with sample image' button (auto-sends), then asserts the assistant transcript contains 'image'. The input text is a label only (skipSend:true in the script).",
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "strands-typescript"
       },
       "response": {
@@ -16,9 +16,9 @@
       }
     },
     {
-      "_comment": "multimodal — PDF upload turn. The D5 script clicks the 'Try with sample PDF' button (auto-sends), then asserts the assistant transcript contains 'document'.",
+      "_comment": "multimodal \u2014 PDF upload turn. The D5 script clicks the 'Try with sample PDF' button (auto-sends), then asserts the assistant transcript contains 'document'.",
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "strands-typescript"
       },
       "response": {
@@ -26,7 +26,7 @@
       }
     },
     {
-      "_comment": "multimodal — fallback for image analysis when the auto-send injects a different message shape.",
+      "_comment": "multimodal \u2014 fallback for image analysis when the auto-send injects a different message shape.",
       "match": {
         "userMessage": "image",
         "turnIndex": 0,
@@ -37,7 +37,7 @@
       }
     },
     {
-      "_comment": "multimodal — fallback for document analysis when the auto-send injects a different message shape.",
+      "_comment": "multimodal \u2014 fallback for document analysis when the auto-send injects a different message shape.",
       "match": {
         "userMessage": "document",
         "turnIndex": 0,

--- a/showcase/aimock/d6/strands/agentic-chat.json
+++ b/showcase/aimock/d6/strands/agentic-chat.json
@@ -44,7 +44,7 @@
           {
             "id": "call_d5_generate_haiku_001",
             "name": "generate_haiku",
-            "arguments": "{\"japanese\":[\"古池や\",\"蛙飛び込む\",\"水の音\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
+            "arguments": "{\"japanese\":[\"\u53e4\u6c60\u3084\",\"\u86d9\u98db\u3073\u8fbc\u3080\",\"\u6c34\u306e\u97f3\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
           }
         ]
       }
@@ -56,12 +56,12 @@
         "context": "strands"
       },
       "response": {
-        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
+        "content": "Haiku generated above \u2014 a beautiful verse about nature with an accompanying image."
       }
     },
     {
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "turnIndex": 0,
         "context": "strands"
       },
@@ -71,7 +71,7 @@
     },
     {
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "turnIndex": 0,
         "context": "strands"
       },
@@ -86,7 +86,7 @@
         "context": "strands"
       },
       "response": {
-        "content": "Hello from the popup — the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
+        "content": "Hello from the popup \u2014 the CopilotPopup prebuilt component is wired up and reachable. The launcher floats in the corner and the chat sits in an overlay panel."
       }
     },
     {
@@ -96,7 +96,7 @@
         "context": "strands"
       },
       "response": {
-        "content": "Hello from the sidebar — the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
+        "content": "Hello from the sidebar \u2014 the CopilotSidebar prebuilt component is wired up and reachable. Anything else you would like me to confirm from inside the sidebar?"
       }
     },
     {

--- a/showcase/aimock/d6/strands/multimodal.json
+++ b/showcase/aimock/d6/strands/multimodal.json
@@ -6,9 +6,9 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal — image upload turn. The D5 script clicks the 'Try with sample image' button (auto-sends), then asserts the assistant transcript contains 'image'. The input text is a label only (skipSend:true in the script).",
+      "_comment": "multimodal \u2014 image upload turn. The D5 script clicks the 'Try with sample image' button (auto-sends), then asserts the assistant transcript contains 'image'. The input text is a label only (skipSend:true in the script).",
       "match": {
-        "userMessage": "describe the sample image",
+        "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "strands"
       },
       "response": {
@@ -16,9 +16,9 @@
       }
     },
     {
-      "_comment": "multimodal — PDF upload turn. The D5 script clicks the 'Try with sample PDF' button (auto-sends), then asserts the assistant transcript contains 'document'.",
+      "_comment": "multimodal \u2014 PDF upload turn. The D5 script clicks the 'Try with sample PDF' button (auto-sends), then asserts the assistant transcript contains 'document'.",
       "match": {
-        "userMessage": "summarize the sample document",
+        "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "strands"
       },
       "response": {
@@ -26,7 +26,7 @@
       }
     },
     {
-      "_comment": "multimodal — fallback for image analysis when the auto-send injects a different message shape.",
+      "_comment": "multimodal \u2014 fallback for image analysis when the auto-send injects a different message shape.",
       "match": {
         "userMessage": "image",
         "turnIndex": 0,
@@ -37,7 +37,7 @@
       }
     },
     {
-      "_comment": "multimodal — fallback for document analysis when the auto-send injects a different message shape.",
+      "_comment": "multimodal \u2014 fallback for document analysis when the auto-send injects a different message shape.",
       "match": {
         "userMessage": "document",
         "turnIndex": 0,

--- a/showcase/harness/fixtures/d5/multimodal.json
+++ b/showcase/harness/fixtures/d5/multimodal.json
@@ -1,14 +1,18 @@
 {
-  "_comment": "D5 fixture for /demos/multimodal. The script clicks [data-testid='multimodal-sample-image-button'] to attach the bundled sample.png, then sends a query about it; second turn does the same with the PDF sample. The aimock response references 'image' / 'document' so the assertion can verify a non-trivial substring lands in the assistant transcript. Substrings 'describe the sample image' and 'summarize the sample document' are unique.",
+  "_comment": "D5 fixture for /demos/multimodal. The script clicks [data-testid=\"multimodal-sample-image-button\"] to attach the bundled sample.png and auto-sends via agent.addMessage; second turn does the same with the PDF sample. The aimock response references \"image\" / \"document\" so the assertion can verify a non-trivial substring lands in the assistant transcript. Substrings are unique autoPrompt phrases.",
   "fixtures": [
     {
-      "match": { "userMessage": "describe the sample image" },
+      "match": {
+        "userMessage": "can you tell me what is in this demo image I just attached"
+      },
       "response": {
         "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
       }
     },
     {
-      "match": { "userMessage": "summarize the sample document" },
+      "match": {
+        "userMessage": "can you tell me what is in this demo pdf I just attached"
+      },
       "response": {
         "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
       }

--- a/showcase/scripts/split-fixtures.ts
+++ b/showcase/scripts/split-fixtures.ts
@@ -308,10 +308,12 @@ function inferFeatureType(fixture: Fixture): string {
 
   // Image/document analysis
   if (
-    userMsg.includes("describe the sample image") ||
-    userMsg.includes("summarize the sample document")
+    userMsg.includes(
+      "can you tell me what is in this demo image I just attached",
+    ) ||
+    userMsg.includes("can you tell me what is in this demo pdf I just attached")
   )
-    return "agentic-chat";
+    return "multimodal";
 
   return "unknown";
 }


### PR DESCRIPTION
## Summary

- Commit `7c3edca2b7` (May 11) changed the `autoPrompt` strings in all `sample-attachment-buttons.tsx` from `"describe the sample image"` / `"summarize the sample document"` to `"can you tell me what is in this demo image I just attached"` / `"can you tell me what is in this demo pdf I just attached"` — but never updated the 41 aimock fixture files
- Every integration that uses the auto-send pattern was sending a message matching no fixture → strict MISS → 404 → agent error banner → `dom-missing` / `done-signal-missing` D6 timeouts
- Fixed 19 `multimodal.json` D6 fixtures, 20 `agentic-chat.json` D6 fallback fixtures, 1 shared D5 `multimodal.json`, and the `split-fixtures.ts` router

## Red-Green Proof

**RED (before fix) — `langgraph-typescript:multimodal --d6 --direct`:**
```
turn 1: TIMEOUT dom-missing (60s) — aimock 404, no assistant text rendered
turn 2: TIMEOUT dom-missing (60s) — same
```

**GREEN (after fix) — `langgraph-typescript:multimodal --d6 --direct`:**
```
turn 1: PASS — assistant text "The attached image is the CopilotKit logo..." settled
turn 2: PASS — assistant text with document summary settled
```

## Remaining failures (out of scope, separate issues)

- `ms-agent-python`, `crewai-crews`: Python backend `ChatClientException` when receiving binary (image/PDF) AG-UI content parts — same class as active `wt-pydantic-multimodal` worktree
- `built-in-agent`, `claude-sdk-python`: DOM-inject only (no `agent.addMessage` / `copilotkit.runAgent` auto-send) — probe design mismatch, not a fixture issue

## Test plan

- [x] `langgraph-typescript:multimodal --d6 --direct` RED before / GREEN after
- [ ] D6 repro sweep after merge to confirm cluster clears for auto-send integrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)