### PR TITLE
fix(showcase): emit A2UI v0.9 nested op format for a2ui-middleware v0.0.10

### DIFF
--- a/showcase/integrations/ag2/tools/search_flights.py
+++ b/showcase/integrations/ag2/tools/search_flights.py
@@ -100,19 +100,16 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
     return {
         "a2ui_operations": [
             {
-                "type": "create_surface",
-                "surfaceId": SURFACE_ID,
-                "catalogId": CATALOG_ID,
+                "version": "v0.9",
+                "createSurface": {"surfaceId": SURFACE_ID, "catalogId": CATALOG_ID},
             },
             {
-                "type": "update_components",
-                "surfaceId": SURFACE_ID,
-                "components": _flight_schema,
+                "version": "v0.9",
+                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
             },
             {
-                "type": "update_data_model",
-                "surfaceId": SURFACE_ID,
-                "data": {"flights": flights},
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
             },
         ]
     }

--- a/showcase/integrations/ag2/tools/search_flights.py
+++ b/showcase/integrations/ag2/tools/search_flights.py
@@ -105,11 +105,18 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
             },
             {
                 "version": "v0.9",
-                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
+                "updateComponents": {
+                    "surfaceId": SURFACE_ID,
+                    "components": _flight_schema,
+                },
             },
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
+                "updateDataModel": {
+                    "surfaceId": SURFACE_ID,
+                    "path": "/",
+                    "value": {"flights": flights},
+                },
             },
         ]
     }

--- a/showcase/integrations/agno/src/agents/a2ui_fixed_agent.py
+++ b/showcase/integrations/agno/src/agents/a2ui_fixed_agent.py
@@ -66,23 +66,24 @@ def display_flight(origin: str, destination: str, airline: str, price: str):
     """
     operations = [
         {
-            "type": "create_surface",
-            "surfaceId": SURFACE_ID,
-            "catalogId": CATALOG_ID,
+            "version": "v0.9",
+            "createSurface": {"surfaceId": SURFACE_ID, "catalogId": CATALOG_ID},
         },
         {
-            "type": "update_components",
-            "surfaceId": SURFACE_ID,
-            "components": FLIGHT_SCHEMA,
+            "version": "v0.9",
+            "updateComponents": {"surfaceId": SURFACE_ID, "components": FLIGHT_SCHEMA},
         },
         {
-            "type": "update_data_model",
-            "surfaceId": SURFACE_ID,
-            "data": {
-                "origin": origin,
-                "destination": destination,
-                "airline": airline,
-                "price": price,
+            "version": "v0.9",
+            "updateDataModel": {
+                "surfaceId": SURFACE_ID,
+                "path": "/",
+                "value": {
+                    "origin": origin,
+                    "destination": destination,
+                    "airline": airline,
+                    "price": price,
+                },
             },
         },
     ]

--- a/showcase/integrations/agno/tools/generate_a2ui.py
+++ b/showcase/integrations/agno/tools/generate_a2ui.py
@@ -113,7 +113,11 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         ops.append(
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": surface_id, "path": "/", "value": data},
+                "updateDataModel": {
+                    "surfaceId": surface_id,
+                    "path": "/",
+                    "value": data,
+                },
             }
         )
 

--- a/showcase/integrations/agno/tools/generate_a2ui.py
+++ b/showcase/integrations/agno/tools/generate_a2ui.py
@@ -99,15 +99,22 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         )
     data = args.get("data")
 
-    ops = [
-        {"type": "create_surface", "surfaceId": surface_id, "catalogId": catalog_id},
+    ops: list[dict[str, Any]] = [
         {
-            "type": "update_components",
-            "surfaceId": surface_id,
-            "components": components,
+            "version": "v0.9",
+            "createSurface": {"surfaceId": surface_id, "catalogId": catalog_id},
+        },
+        {
+            "version": "v0.9",
+            "updateComponents": {"surfaceId": surface_id, "components": components},
         },
     ]
     if data:
-        ops.append({"type": "update_data_model", "surfaceId": surface_id, "data": data})
+        ops.append(
+            {
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": surface_id, "path": "/", "value": data},
+            }
+        )
 
     return {"a2ui_operations": ops}

--- a/showcase/integrations/agno/tools/search_flights.py
+++ b/showcase/integrations/agno/tools/search_flights.py
@@ -100,19 +100,16 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
     return {
         "a2ui_operations": [
             {
-                "type": "create_surface",
-                "surfaceId": SURFACE_ID,
-                "catalogId": CATALOG_ID,
+                "version": "v0.9",
+                "createSurface": {"surfaceId": SURFACE_ID, "catalogId": CATALOG_ID},
             },
             {
-                "type": "update_components",
-                "surfaceId": SURFACE_ID,
-                "components": _flight_schema,
+                "version": "v0.9",
+                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
             },
             {
-                "type": "update_data_model",
-                "surfaceId": SURFACE_ID,
-                "data": {"flights": flights},
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
             },
         ]
     }

--- a/showcase/integrations/agno/tools/search_flights.py
+++ b/showcase/integrations/agno/tools/search_flights.py
@@ -105,11 +105,18 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
             },
             {
                 "version": "v0.9",
-                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
+                "updateComponents": {
+                    "surfaceId": SURFACE_ID,
+                    "components": _flight_schema,
+                },
             },
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
+                "updateDataModel": {
+                    "surfaceId": SURFACE_ID,
+                    "path": "/",
+                    "value": {"flights": flights},
+                },
             },
         ]
     }

--- a/showcase/integrations/claude-sdk-python/tools/generate_a2ui.py
+++ b/showcase/integrations/claude-sdk-python/tools/generate_a2ui.py
@@ -113,7 +113,11 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         ops.append(
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": surface_id, "path": "/", "value": data},
+                "updateDataModel": {
+                    "surfaceId": surface_id,
+                    "path": "/",
+                    "value": data,
+                },
             }
         )
 

--- a/showcase/integrations/claude-sdk-python/tools/generate_a2ui.py
+++ b/showcase/integrations/claude-sdk-python/tools/generate_a2ui.py
@@ -99,15 +99,22 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         )
     data = args.get("data")
 
-    ops = [
-        {"type": "create_surface", "surfaceId": surface_id, "catalogId": catalog_id},
+    ops: list[dict[str, Any]] = [
         {
-            "type": "update_components",
-            "surfaceId": surface_id,
-            "components": components,
+            "version": "v0.9",
+            "createSurface": {"surfaceId": surface_id, "catalogId": catalog_id},
+        },
+        {
+            "version": "v0.9",
+            "updateComponents": {"surfaceId": surface_id, "components": components},
         },
     ]
     if data:
-        ops.append({"type": "update_data_model", "surfaceId": surface_id, "data": data})
+        ops.append(
+            {
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": surface_id, "path": "/", "value": data},
+            }
+        )
 
     return {"a2ui_operations": ops}

--- a/showcase/integrations/claude-sdk-python/tools/search_flights.py
+++ b/showcase/integrations/claude-sdk-python/tools/search_flights.py
@@ -100,19 +100,16 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
     return {
         "a2ui_operations": [
             {
-                "type": "create_surface",
-                "surfaceId": SURFACE_ID,
-                "catalogId": CATALOG_ID,
+                "version": "v0.9",
+                "createSurface": {"surfaceId": SURFACE_ID, "catalogId": CATALOG_ID},
             },
             {
-                "type": "update_components",
-                "surfaceId": SURFACE_ID,
-                "components": _flight_schema,
+                "version": "v0.9",
+                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
             },
             {
-                "type": "update_data_model",
-                "surfaceId": SURFACE_ID,
-                "data": {"flights": flights},
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
             },
         ]
     }

--- a/showcase/integrations/claude-sdk-python/tools/search_flights.py
+++ b/showcase/integrations/claude-sdk-python/tools/search_flights.py
@@ -105,11 +105,18 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
             },
             {
                 "version": "v0.9",
-                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
+                "updateComponents": {
+                    "surfaceId": SURFACE_ID,
+                    "components": _flight_schema,
+                },
             },
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
+                "updateDataModel": {
+                    "surfaceId": SURFACE_ID,
+                    "path": "/",
+                    "value": {"flights": flights},
+                },
             },
         ]
     }

--- a/showcase/integrations/crewai-crews/src/agents/a2ui_fixed.py
+++ b/showcase/integrations/crewai-crews/src/agents/a2ui_fixed.py
@@ -79,7 +79,10 @@ class DisplayFlightTool(BaseTool):
             },
             {
                 "version": "v0.9",
-                "updateComponents": {"surfaceId": SURFACE_ID, "components": _FLIGHT_SCHEMA},
+                "updateComponents": {
+                    "surfaceId": SURFACE_ID,
+                    "components": _FLIGHT_SCHEMA,
+                },
             },
             {
                 "version": "v0.9",

--- a/showcase/integrations/crewai-crews/src/agents/a2ui_fixed.py
+++ b/showcase/integrations/crewai-crews/src/agents/a2ui_fixed.py
@@ -74,23 +74,24 @@ class DisplayFlightTool(BaseTool):
         # frontend catalog resolves component names to local React components.
         ops: list[dict[str, Any]] = [
             {
-                "type": "create_surface",
-                "surfaceId": SURFACE_ID,
-                "catalogId": CATALOG_ID,
+                "version": "v0.9",
+                "createSurface": {"surfaceId": SURFACE_ID, "catalogId": CATALOG_ID},
             },
             {
-                "type": "update_components",
-                "surfaceId": SURFACE_ID,
-                "components": _FLIGHT_SCHEMA,
+                "version": "v0.9",
+                "updateComponents": {"surfaceId": SURFACE_ID, "components": _FLIGHT_SCHEMA},
             },
             {
-                "type": "update_data_model",
-                "surfaceId": SURFACE_ID,
-                "data": {
-                    "origin": origin,
-                    "destination": destination,
-                    "airline": airline,
-                    "price": price,
+                "version": "v0.9",
+                "updateDataModel": {
+                    "surfaceId": SURFACE_ID,
+                    "path": "/",
+                    "value": {
+                        "origin": origin,
+                        "destination": destination,
+                        "airline": airline,
+                        "price": price,
+                    },
                 },
             },
         ]

--- a/showcase/integrations/crewai-crews/tools/generate_a2ui.py
+++ b/showcase/integrations/crewai-crews/tools/generate_a2ui.py
@@ -113,7 +113,11 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         ops.append(
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": surface_id, "path": "/", "value": data},
+                "updateDataModel": {
+                    "surfaceId": surface_id,
+                    "path": "/",
+                    "value": data,
+                },
             }
         )
 

--- a/showcase/integrations/crewai-crews/tools/generate_a2ui.py
+++ b/showcase/integrations/crewai-crews/tools/generate_a2ui.py
@@ -99,15 +99,22 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         )
     data = args.get("data")
 
-    ops = [
-        {"type": "create_surface", "surfaceId": surface_id, "catalogId": catalog_id},
+    ops: list[dict[str, Any]] = [
         {
-            "type": "update_components",
-            "surfaceId": surface_id,
-            "components": components,
+            "version": "v0.9",
+            "createSurface": {"surfaceId": surface_id, "catalogId": catalog_id},
+        },
+        {
+            "version": "v0.9",
+            "updateComponents": {"surfaceId": surface_id, "components": components},
         },
     ]
     if data:
-        ops.append({"type": "update_data_model", "surfaceId": surface_id, "data": data})
+        ops.append(
+            {
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": surface_id, "path": "/", "value": data},
+            }
+        )
 
     return {"a2ui_operations": ops}

--- a/showcase/integrations/crewai-crews/tools/search_flights.py
+++ b/showcase/integrations/crewai-crews/tools/search_flights.py
@@ -100,19 +100,16 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
     return {
         "a2ui_operations": [
             {
-                "type": "create_surface",
-                "surfaceId": SURFACE_ID,
-                "catalogId": CATALOG_ID,
+                "version": "v0.9",
+                "createSurface": {"surfaceId": SURFACE_ID, "catalogId": CATALOG_ID},
             },
             {
-                "type": "update_components",
-                "surfaceId": SURFACE_ID,
-                "components": _flight_schema,
+                "version": "v0.9",
+                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
             },
             {
-                "type": "update_data_model",
-                "surfaceId": SURFACE_ID,
-                "data": {"flights": flights},
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
             },
         ]
     }

--- a/showcase/integrations/crewai-crews/tools/search_flights.py
+++ b/showcase/integrations/crewai-crews/tools/search_flights.py
@@ -105,11 +105,18 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
             },
             {
                 "version": "v0.9",
-                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
+                "updateComponents": {
+                    "surfaceId": SURFACE_ID,
+                    "components": _flight_schema,
+                },
             },
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
+                "updateDataModel": {
+                    "surfaceId": SURFACE_ID,
+                    "path": "/",
+                    "value": {"flights": flights},
+                },
             },
         ]
     }

--- a/showcase/integrations/langgraph-fastapi/tools/generate_a2ui.py
+++ b/showcase/integrations/langgraph-fastapi/tools/generate_a2ui.py
@@ -113,7 +113,11 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         ops.append(
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": surface_id, "path": "/", "value": data},
+                "updateDataModel": {
+                    "surfaceId": surface_id,
+                    "path": "/",
+                    "value": data,
+                },
             }
         )
 

--- a/showcase/integrations/langgraph-fastapi/tools/generate_a2ui.py
+++ b/showcase/integrations/langgraph-fastapi/tools/generate_a2ui.py
@@ -99,15 +99,22 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         )
     data = args.get("data")
 
-    ops = [
-        {"type": "create_surface", "surfaceId": surface_id, "catalogId": catalog_id},
+    ops: list[dict[str, Any]] = [
         {
-            "type": "update_components",
-            "surfaceId": surface_id,
-            "components": components,
+            "version": "v0.9",
+            "createSurface": {"surfaceId": surface_id, "catalogId": catalog_id},
+        },
+        {
+            "version": "v0.9",
+            "updateComponents": {"surfaceId": surface_id, "components": components},
         },
     ]
     if data:
-        ops.append({"type": "update_data_model", "surfaceId": surface_id, "data": data})
+        ops.append(
+            {
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": surface_id, "path": "/", "value": data},
+            }
+        )
 
     return {"a2ui_operations": ops}

--- a/showcase/integrations/langgraph-fastapi/tools/search_flights.py
+++ b/showcase/integrations/langgraph-fastapi/tools/search_flights.py
@@ -100,19 +100,16 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
     return {
         "a2ui_operations": [
             {
-                "type": "create_surface",
-                "surfaceId": SURFACE_ID,
-                "catalogId": CATALOG_ID,
+                "version": "v0.9",
+                "createSurface": {"surfaceId": SURFACE_ID, "catalogId": CATALOG_ID},
             },
             {
-                "type": "update_components",
-                "surfaceId": SURFACE_ID,
-                "components": _flight_schema,
+                "version": "v0.9",
+                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
             },
             {
-                "type": "update_data_model",
-                "surfaceId": SURFACE_ID,
-                "data": {"flights": flights},
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
             },
         ]
     }

--- a/showcase/integrations/langgraph-fastapi/tools/search_flights.py
+++ b/showcase/integrations/langgraph-fastapi/tools/search_flights.py
@@ -105,11 +105,18 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
             },
             {
                 "version": "v0.9",
-                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
+                "updateComponents": {
+                    "surfaceId": SURFACE_ID,
+                    "components": _flight_schema,
+                },
             },
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
+                "updateDataModel": {
+                    "surfaceId": SURFACE_ID,
+                    "path": "/",
+                    "value": {"flights": flights},
+                },
             },
         ]
     }

--- a/showcase/integrations/langgraph-python/tools/generate_a2ui.py
+++ b/showcase/integrations/langgraph-python/tools/generate_a2ui.py
@@ -113,7 +113,11 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         ops.append(
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": surface_id, "path": "/", "value": data},
+                "updateDataModel": {
+                    "surfaceId": surface_id,
+                    "path": "/",
+                    "value": data,
+                },
             }
         )
 

--- a/showcase/integrations/langgraph-python/tools/generate_a2ui.py
+++ b/showcase/integrations/langgraph-python/tools/generate_a2ui.py
@@ -99,15 +99,22 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         )
     data = args.get("data")
 
-    ops = [
-        {"type": "create_surface", "surfaceId": surface_id, "catalogId": catalog_id},
+    ops: list[dict[str, Any]] = [
         {
-            "type": "update_components",
-            "surfaceId": surface_id,
-            "components": components,
+            "version": "v0.9",
+            "createSurface": {"surfaceId": surface_id, "catalogId": catalog_id},
+        },
+        {
+            "version": "v0.9",
+            "updateComponents": {"surfaceId": surface_id, "components": components},
         },
     ]
     if data:
-        ops.append({"type": "update_data_model", "surfaceId": surface_id, "data": data})
+        ops.append(
+            {
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": surface_id, "path": "/", "value": data},
+            }
+        )
 
     return {"a2ui_operations": ops}

--- a/showcase/integrations/langgraph-python/tools/search_flights.py
+++ b/showcase/integrations/langgraph-python/tools/search_flights.py
@@ -100,19 +100,16 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
     return {
         "a2ui_operations": [
             {
-                "type": "create_surface",
-                "surfaceId": SURFACE_ID,
-                "catalogId": CATALOG_ID,
+                "version": "v0.9",
+                "createSurface": {"surfaceId": SURFACE_ID, "catalogId": CATALOG_ID},
             },
             {
-                "type": "update_components",
-                "surfaceId": SURFACE_ID,
-                "components": _flight_schema,
+                "version": "v0.9",
+                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
             },
             {
-                "type": "update_data_model",
-                "surfaceId": SURFACE_ID,
-                "data": {"flights": flights},
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
             },
         ]
     }

--- a/showcase/integrations/langgraph-python/tools/search_flights.py
+++ b/showcase/integrations/langgraph-python/tools/search_flights.py
@@ -105,11 +105,18 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
             },
             {
                 "version": "v0.9",
-                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
+                "updateComponents": {
+                    "surfaceId": SURFACE_ID,
+                    "components": _flight_schema,
+                },
             },
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
+                "updateDataModel": {
+                    "surfaceId": SURFACE_ID,
+                    "path": "/",
+                    "value": {"flights": flights},
+                },
             },
         ]
     }

--- a/showcase/integrations/langroid/src/agents/a2ui_fixed_agent.py
+++ b/showcase/integrations/langroid/src/agents/a2ui_fixed_agent.py
@@ -128,23 +128,24 @@ def _build_a2ui_operations(
     return {
         "a2ui_operations": [
             {
-                "type": "create_surface",
-                "surfaceId": SURFACE_ID,
-                "catalogId": CATALOG_ID,
+                "version": "v0.9",
+                "createSurface": {"surfaceId": SURFACE_ID, "catalogId": CATALOG_ID},
             },
             {
-                "type": "update_components",
-                "surfaceId": SURFACE_ID,
-                "components": FLIGHT_SCHEMA,
+                "version": "v0.9",
+                "updateComponents": {"surfaceId": SURFACE_ID, "components": FLIGHT_SCHEMA},
             },
             {
-                "type": "update_data_model",
-                "surfaceId": SURFACE_ID,
-                "data": {
-                    "origin": origin,
-                    "destination": destination,
-                    "airline": airline,
-                    "price": price,
+                "version": "v0.9",
+                "updateDataModel": {
+                    "surfaceId": SURFACE_ID,
+                    "path": "/",
+                    "value": {
+                        "origin": origin,
+                        "destination": destination,
+                        "airline": airline,
+                        "price": price,
+                    },
                 },
             },
         ]

--- a/showcase/integrations/langroid/src/agents/a2ui_fixed_agent.py
+++ b/showcase/integrations/langroid/src/agents/a2ui_fixed_agent.py
@@ -133,7 +133,10 @@ def _build_a2ui_operations(
             },
             {
                 "version": "v0.9",
-                "updateComponents": {"surfaceId": SURFACE_ID, "components": FLIGHT_SCHEMA},
+                "updateComponents": {
+                    "surfaceId": SURFACE_ID,
+                    "components": FLIGHT_SCHEMA,
+                },
             },
             {
                 "version": "v0.9",

--- a/showcase/integrations/langroid/tools/generate_a2ui.py
+++ b/showcase/integrations/langroid/tools/generate_a2ui.py
@@ -113,7 +113,11 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         ops.append(
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": surface_id, "path": "/", "value": data},
+                "updateDataModel": {
+                    "surfaceId": surface_id,
+                    "path": "/",
+                    "value": data,
+                },
             }
         )
 

--- a/showcase/integrations/langroid/tools/generate_a2ui.py
+++ b/showcase/integrations/langroid/tools/generate_a2ui.py
@@ -99,15 +99,22 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         )
     data = args.get("data")
 
-    ops = [
-        {"type": "create_surface", "surfaceId": surface_id, "catalogId": catalog_id},
+    ops: list[dict[str, Any]] = [
         {
-            "type": "update_components",
-            "surfaceId": surface_id,
-            "components": components,
+            "version": "v0.9",
+            "createSurface": {"surfaceId": surface_id, "catalogId": catalog_id},
+        },
+        {
+            "version": "v0.9",
+            "updateComponents": {"surfaceId": surface_id, "components": components},
         },
     ]
     if data:
-        ops.append({"type": "update_data_model", "surfaceId": surface_id, "data": data})
+        ops.append(
+            {
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": surface_id, "path": "/", "value": data},
+            }
+        )
 
     return {"a2ui_operations": ops}

--- a/showcase/integrations/langroid/tools/search_flights.py
+++ b/showcase/integrations/langroid/tools/search_flights.py
@@ -100,19 +100,16 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
     return {
         "a2ui_operations": [
             {
-                "type": "create_surface",
-                "surfaceId": SURFACE_ID,
-                "catalogId": CATALOG_ID,
+                "version": "v0.9",
+                "createSurface": {"surfaceId": SURFACE_ID, "catalogId": CATALOG_ID},
             },
             {
-                "type": "update_components",
-                "surfaceId": SURFACE_ID,
-                "components": _flight_schema,
+                "version": "v0.9",
+                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
             },
             {
-                "type": "update_data_model",
-                "surfaceId": SURFACE_ID,
-                "data": {"flights": flights},
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
             },
         ]
     }

--- a/showcase/integrations/langroid/tools/search_flights.py
+++ b/showcase/integrations/langroid/tools/search_flights.py
@@ -105,11 +105,18 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
             },
             {
                 "version": "v0.9",
-                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
+                "updateComponents": {
+                    "surfaceId": SURFACE_ID,
+                    "components": _flight_schema,
+                },
             },
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
+                "updateDataModel": {
+                    "surfaceId": SURFACE_ID,
+                    "path": "/",
+                    "value": {"flights": flights},
+                },
             },
         ]
     }

--- a/showcase/integrations/llamaindex/tools/generate_a2ui.py
+++ b/showcase/integrations/llamaindex/tools/generate_a2ui.py
@@ -113,7 +113,11 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         ops.append(
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": surface_id, "path": "/", "value": data},
+                "updateDataModel": {
+                    "surfaceId": surface_id,
+                    "path": "/",
+                    "value": data,
+                },
             }
         )
 

--- a/showcase/integrations/llamaindex/tools/generate_a2ui.py
+++ b/showcase/integrations/llamaindex/tools/generate_a2ui.py
@@ -99,15 +99,22 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         )
     data = args.get("data")
 
-    ops = [
-        {"type": "create_surface", "surfaceId": surface_id, "catalogId": catalog_id},
+    ops: list[dict[str, Any]] = [
         {
-            "type": "update_components",
-            "surfaceId": surface_id,
-            "components": components,
+            "version": "v0.9",
+            "createSurface": {"surfaceId": surface_id, "catalogId": catalog_id},
+        },
+        {
+            "version": "v0.9",
+            "updateComponents": {"surfaceId": surface_id, "components": components},
         },
     ]
     if data:
-        ops.append({"type": "update_data_model", "surfaceId": surface_id, "data": data})
+        ops.append(
+            {
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": surface_id, "path": "/", "value": data},
+            }
+        )
 
     return {"a2ui_operations": ops}

--- a/showcase/integrations/llamaindex/tools/search_flights.py
+++ b/showcase/integrations/llamaindex/tools/search_flights.py
@@ -100,19 +100,16 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
     return {
         "a2ui_operations": [
             {
-                "type": "create_surface",
-                "surfaceId": SURFACE_ID,
-                "catalogId": CATALOG_ID,
+                "version": "v0.9",
+                "createSurface": {"surfaceId": SURFACE_ID, "catalogId": CATALOG_ID},
             },
             {
-                "type": "update_components",
-                "surfaceId": SURFACE_ID,
-                "components": _flight_schema,
+                "version": "v0.9",
+                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
             },
             {
-                "type": "update_data_model",
-                "surfaceId": SURFACE_ID,
-                "data": {"flights": flights},
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
             },
         ]
     }

--- a/showcase/integrations/llamaindex/tools/search_flights.py
+++ b/showcase/integrations/llamaindex/tools/search_flights.py
@@ -105,11 +105,18 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
             },
             {
                 "version": "v0.9",
-                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
+                "updateComponents": {
+                    "surfaceId": SURFACE_ID,
+                    "components": _flight_schema,
+                },
             },
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
+                "updateDataModel": {
+                    "surfaceId": SURFACE_ID,
+                    "path": "/",
+                    "value": {"flights": flights},
+                },
             },
         ]
     }

--- a/showcase/integrations/ms-agent-python/tools/search_flights.py
+++ b/showcase/integrations/ms-agent-python/tools/search_flights.py
@@ -100,19 +100,16 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
     return {
         "a2ui_operations": [
             {
-                "type": "create_surface",
-                "surfaceId": SURFACE_ID,
-                "catalogId": CATALOG_ID,
+                "version": "v0.9",
+                "createSurface": {"surfaceId": SURFACE_ID, "catalogId": CATALOG_ID},
             },
             {
-                "type": "update_components",
-                "surfaceId": SURFACE_ID,
-                "components": _flight_schema,
+                "version": "v0.9",
+                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
             },
             {
-                "type": "update_data_model",
-                "surfaceId": SURFACE_ID,
-                "data": {"flights": flights},
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
             },
         ]
     }

--- a/showcase/integrations/ms-agent-python/tools/search_flights.py
+++ b/showcase/integrations/ms-agent-python/tools/search_flights.py
@@ -105,11 +105,18 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
             },
             {
                 "version": "v0.9",
-                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
+                "updateComponents": {
+                    "surfaceId": SURFACE_ID,
+                    "components": _flight_schema,
+                },
             },
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
+                "updateDataModel": {
+                    "surfaceId": SURFACE_ID,
+                    "path": "/",
+                    "value": {"flights": flights},
+                },
             },
         ]
     }

--- a/showcase/integrations/pydantic-ai/src/agents/a2ui_fixed.py
+++ b/showcase/integrations/pydantic-ai/src/agents/a2ui_fixed.py
@@ -91,23 +91,24 @@ def display_flight(
     # frontend catalog resolves component names to local React components.
     operations = [
         {
-            "type": "create_surface",
-            "surfaceId": SURFACE_ID,
-            "catalogId": CATALOG_ID,
+            "version": "v0.9",
+            "createSurface": {"surfaceId": SURFACE_ID, "catalogId": CATALOG_ID},
         },
         {
-            "type": "update_components",
-            "surfaceId": SURFACE_ID,
-            "components": FLIGHT_SCHEMA,
+            "version": "v0.9",
+            "updateComponents": {"surfaceId": SURFACE_ID, "components": FLIGHT_SCHEMA},
         },
         {
-            "type": "update_data_model",
-            "surfaceId": SURFACE_ID,
-            "data": {
-                "origin": origin,
-                "destination": destination,
-                "airline": airline,
-                "price": price,
+            "version": "v0.9",
+            "updateDataModel": {
+                "surfaceId": SURFACE_ID,
+                "path": "/",
+                "value": {
+                    "origin": origin,
+                    "destination": destination,
+                    "airline": airline,
+                    "price": price,
+                },
             },
         },
     ]

--- a/showcase/integrations/pydantic-ai/src/agents/beautiful_chat.py
+++ b/showcase/integrations/pydantic-ai/src/agents/beautiful_chat.py
@@ -178,11 +178,17 @@ def search_flights(
     operations = [
         {
             "version": "v0.9",
-            "createSurface": {"surfaceId": FLIGHT_SURFACE_ID, "catalogId": FLIGHT_CATALOG_ID},
+            "createSurface": {
+                "surfaceId": FLIGHT_SURFACE_ID,
+                "catalogId": FLIGHT_CATALOG_ID,
+            },
         },
         {
             "version": "v0.9",
-            "updateComponents": {"surfaceId": FLIGHT_SURFACE_ID, "components": FLIGHT_SCHEMA},
+            "updateComponents": {
+                "surfaceId": FLIGHT_SURFACE_ID,
+                "components": FLIGHT_SCHEMA,
+            },
         },
         {
             "version": "v0.9",

--- a/showcase/integrations/pydantic-ai/src/agents/beautiful_chat.py
+++ b/showcase/integrations/pydantic-ai/src/agents/beautiful_chat.py
@@ -177,19 +177,20 @@ def search_flights(
     """
     operations = [
         {
-            "type": "create_surface",
-            "surfaceId": FLIGHT_SURFACE_ID,
-            "catalogId": FLIGHT_CATALOG_ID,
+            "version": "v0.9",
+            "createSurface": {"surfaceId": FLIGHT_SURFACE_ID, "catalogId": FLIGHT_CATALOG_ID},
         },
         {
-            "type": "update_components",
-            "surfaceId": FLIGHT_SURFACE_ID,
-            "components": FLIGHT_SCHEMA,
+            "version": "v0.9",
+            "updateComponents": {"surfaceId": FLIGHT_SURFACE_ID, "components": FLIGHT_SCHEMA},
         },
         {
-            "type": "update_data_model",
-            "surfaceId": FLIGHT_SURFACE_ID,
-            "data": {"flights": flights},
+            "version": "v0.9",
+            "updateDataModel": {
+                "surfaceId": FLIGHT_SURFACE_ID,
+                "path": "/",
+                "value": {"flights": flights},
+            },
         },
     ]
     return json.dumps({"a2ui_operations": operations})

--- a/showcase/integrations/pydantic-ai/tools/generate_a2ui.py
+++ b/showcase/integrations/pydantic-ai/tools/generate_a2ui.py
@@ -113,7 +113,11 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         ops.append(
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": surface_id, "path": "/", "value": data},
+                "updateDataModel": {
+                    "surfaceId": surface_id,
+                    "path": "/",
+                    "value": data,
+                },
             }
         )
 

--- a/showcase/integrations/pydantic-ai/tools/generate_a2ui.py
+++ b/showcase/integrations/pydantic-ai/tools/generate_a2ui.py
@@ -99,15 +99,22 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         )
     data = args.get("data")
 
-    ops = [
-        {"type": "create_surface", "surfaceId": surface_id, "catalogId": catalog_id},
+    ops: list[dict[str, Any]] = [
         {
-            "type": "update_components",
-            "surfaceId": surface_id,
-            "components": components,
+            "version": "v0.9",
+            "createSurface": {"surfaceId": surface_id, "catalogId": catalog_id},
+        },
+        {
+            "version": "v0.9",
+            "updateComponents": {"surfaceId": surface_id, "components": components},
         },
     ]
     if data:
-        ops.append({"type": "update_data_model", "surfaceId": surface_id, "data": data})
+        ops.append(
+            {
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": surface_id, "path": "/", "value": data},
+            }
+        )
 
     return {"a2ui_operations": ops}

--- a/showcase/integrations/pydantic-ai/tools/search_flights.py
+++ b/showcase/integrations/pydantic-ai/tools/search_flights.py
@@ -100,19 +100,16 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
     return {
         "a2ui_operations": [
             {
-                "type": "create_surface",
-                "surfaceId": SURFACE_ID,
-                "catalogId": CATALOG_ID,
+                "version": "v0.9",
+                "createSurface": {"surfaceId": SURFACE_ID, "catalogId": CATALOG_ID},
             },
             {
-                "type": "update_components",
-                "surfaceId": SURFACE_ID,
-                "components": _flight_schema,
+                "version": "v0.9",
+                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
             },
             {
-                "type": "update_data_model",
-                "surfaceId": SURFACE_ID,
-                "data": {"flights": flights},
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
             },
         ]
     }

--- a/showcase/integrations/pydantic-ai/tools/search_flights.py
+++ b/showcase/integrations/pydantic-ai/tools/search_flights.py
@@ -105,11 +105,18 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
             },
             {
                 "version": "v0.9",
-                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
+                "updateComponents": {
+                    "surfaceId": SURFACE_ID,
+                    "components": _flight_schema,
+                },
             },
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
+                "updateDataModel": {
+                    "surfaceId": SURFACE_ID,
+                    "path": "/",
+                    "value": {"flights": flights},
+                },
             },
         ]
     }

--- a/showcase/integrations/strands/tools/generate_a2ui.py
+++ b/showcase/integrations/strands/tools/generate_a2ui.py
@@ -113,7 +113,11 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         ops.append(
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": surface_id, "path": "/", "value": data},
+                "updateDataModel": {
+                    "surfaceId": surface_id,
+                    "path": "/",
+                    "value": data,
+                },
             }
         )
 

--- a/showcase/integrations/strands/tools/generate_a2ui.py
+++ b/showcase/integrations/strands/tools/generate_a2ui.py
@@ -99,15 +99,22 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         )
     data = args.get("data")
 
-    ops = [
-        {"type": "create_surface", "surfaceId": surface_id, "catalogId": catalog_id},
+    ops: list[dict[str, Any]] = [
         {
-            "type": "update_components",
-            "surfaceId": surface_id,
-            "components": components,
+            "version": "v0.9",
+            "createSurface": {"surfaceId": surface_id, "catalogId": catalog_id},
+        },
+        {
+            "version": "v0.9",
+            "updateComponents": {"surfaceId": surface_id, "components": components},
         },
     ]
     if data:
-        ops.append({"type": "update_data_model", "surfaceId": surface_id, "data": data})
+        ops.append(
+            {
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": surface_id, "path": "/", "value": data},
+            }
+        )
 
     return {"a2ui_operations": ops}

--- a/showcase/integrations/strands/tools/search_flights.py
+++ b/showcase/integrations/strands/tools/search_flights.py
@@ -100,19 +100,16 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
     return {
         "a2ui_operations": [
             {
-                "type": "create_surface",
-                "surfaceId": SURFACE_ID,
-                "catalogId": CATALOG_ID,
+                "version": "v0.9",
+                "createSurface": {"surfaceId": SURFACE_ID, "catalogId": CATALOG_ID},
             },
             {
-                "type": "update_components",
-                "surfaceId": SURFACE_ID,
-                "components": _flight_schema,
+                "version": "v0.9",
+                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
             },
             {
-                "type": "update_data_model",
-                "surfaceId": SURFACE_ID,
-                "data": {"flights": flights},
+                "version": "v0.9",
+                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
             },
         ]
     }

--- a/showcase/integrations/strands/tools/search_flights.py
+++ b/showcase/integrations/strands/tools/search_flights.py
@@ -105,11 +105,18 @@ def search_flights_impl(flights: list[Flight]) -> dict[str, Any]:
             },
             {
                 "version": "v0.9",
-                "updateComponents": {"surfaceId": SURFACE_ID, "components": _flight_schema},
+                "updateComponents": {
+                    "surfaceId": SURFACE_ID,
+                    "components": _flight_schema,
+                },
             },
             {
                 "version": "v0.9",
-                "updateDataModel": {"surfaceId": SURFACE_ID, "path": "/", "value": {"flights": flights}},
+                "updateDataModel": {
+                    "surfaceId": SURFACE_ID,
+                    "path": "/",
+                    "value": {"flights": flights},
+                },
             },
         ]
     }


### PR DESCRIPTION
## Problem

`@ag-ui/a2ui-middleware` v0.0.10's `getOperationSurfaceId()` reads only the A2UI v0.9 NESTED op format:

```json
{"version": "v0.9", "createSurface": {"surfaceId": "...", "catalogId": "..."}}
```

The integrations were emitting the legacy FLAT format:

```json
{"type": "create_surface", "surfaceId": "...", "catalogId": "..."}
```

Result: all ops fell back to the "default" surface key → frontend never mounted the named surface → `surface-missing` failure on `declarative-gen-ui` across ~11 integrations.

## Fix

Convert all a2ui op builders and inline ops to the nested v0.9 format in:

- `tools/generate_a2ui.py` — 9 integrations (agno, claude-sdk-python, crewai-crews, langgraph-fastapi, langgraph-python, langroid, llamaindex, pydantic-ai, strands)
- `tools/search_flights.py` — 11 integrations (ag2, agno, claude-sdk-python, crewai-crews, langgraph-fastapi, langgraph-python, langroid, llamaindex, ms-agent-python, pydantic-ai, strands)
- `src/agents/a2ui_fixed_agent.py` / `a2ui_fixed.py` / `beautiful_chat.py` — agno, crewai-crews, langroid, pydantic-ai

Already-correct integrations skipped: google-adk, ms-agent-python/generate_a2ui.py, ag2/generate_a2ui.py.

**Total: 25 files changed.**

## Red→Green

Proved locally against the real failure surface (Docker containers built from this branch, `bin/showcase test <slug>:declarative-gen-ui --d6 --direct --rebuild`, aimock fixtures — no live API keys). `--rebuild` is required: without it the harness serves a stale cached image, so the first `--direct` runs must force a rebuild to bake in the source change.

### 1. Structural — the middleware only reads nested keys

`getOperationSurfaceId()` in `@ag-ui/a2ui-middleware@0.0.10` (from npm) reads exclusively the nested keys:

```js
function getOperationSurfaceId(o){
  let t=o.createSurface, e=o.updateComponents, n=o.updateDataModel, r=o.deleteSurface;
  return t?.surfaceId ?? e?.surfaceId ?? n?.surfaceId ?? r?.surfaceId;
}
```

The old flat shape (`{type, surfaceId}`) has none of these keys → returns `undefined` → every op groups under the fallback `"default"` surface → the named surface never mounts.

### 2. Controlled live RED→GREEN on pydantic-ai (same container, same prompt, only op format swapped)

Triggered `"Show me my sales dashboard for this quarter."` on `/demos/declarative-gen-ui` via Playwright and inspected the live SSE payload + DOM:

| Container code | SSE ops | A2UI surface DOM (`declarative-metric` / `-pie-chart` / `-bar-chart`) |
|---|---|---|
| **FLAT (pre-fix)** | `create_surface_flat: 1`, `createSurface_nested: 0` | **0 / 0 / 0 — surface does NOT mount (RED)** |
| **NESTED (this fix)** | `createSurface: 2`, `create_surface_flat: 0` | **4 / 1 / 1 — surface MOUNTS (GREEN)** |

Same demo, same prompt, same live container — flipping only the op format flips the surface from missing to mounted.

### 3. Full harness D6 probe GREEN on two integrations

```
✓ d6:langgraph-python  green   1 passed   (4/4 turns — surface-mount assertions passed)
✓ d6:strands           green   1 passed   (4/4 turns — surface-mount assertions passed)
```

Both mount the named A2UI surface across all four declarative-gen-ui pills (metric, pie-chart, bar-chart, data-table, status-badge, info-row).

### Notes

- pydantic-ai's harness probe mounts the surface on turn 1 (`count=4` metrics — GREEN as proven in §2) but fails on turn 2 of the 4-turn conversation for a **separate, unrelated pydantic-ai catalog parity gap**: its declarative catalog is missing the `DataTable` component / `declarative-data-table` renderer (renders "Unknown component: DataTable"), which langgraph-python does register (`definitions.ts` + `renderers.tsx`). That gap is orthogonal to this op-format fix and must be closed separately for pydantic-ai's cell to fully pass. The controlled A/B in §2 isolates this fix's effect on the same integration.
- agno fails `declarative-gen-ui` with `reason=dom-missing` / `assistantMsgCount:0` (the agent produces no response at all — a fixture/agent issue upstream of A2UI), orthogonal to this change.

## Verification

Zero flat-format ops remain in non-comment/non-test code. 96 occurrences of `"version": "v0.9"` present in changed integrations (excluding google-adk which was already correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
