### PR TITLE
fix(showcase): add missing gen-ui-a2ui-fixed D6 aimock fixtures

### DIFF
--- a/showcase/aimock/d6/ag2/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/ag2/gen-ui-a2ui-fixed.json
@@ -1,0 +1,36 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for ag2 / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-06"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill leg 1 — 'Find me a flight from SFO to JFK on United for $289.' Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "ag2"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_flight_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill leg 2 — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "ag2"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/agno/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/agno/gen-ui-a2ui-fixed.json
@@ -1,0 +1,36 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for agno / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-06"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill leg 1 — 'Find me a flight from SFO to JFK on United for $289.' Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "agno"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_flight_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill leg 2 — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "agno"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/claude-sdk-typescript/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/claude-sdk-typescript/gen-ui-a2ui-fixed.json
@@ -1,0 +1,36 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for claude-sdk-typescript / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-06"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill leg 1 — 'Find me a flight from SFO to JFK on United for $289.' Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "claude-sdk-typescript"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_flight_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill leg 2 — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "claude-sdk-typescript"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/langgraph-python/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/langgraph-python/gen-ui-a2ui-fixed.json
@@ -1,0 +1,36 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for langgraph-python / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-06"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill leg 1 — 'Find me a flight from SFO to JFK on United for $289.' Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "langgraph-python"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_flight_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill leg 2 — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "langgraph-python"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/langroid/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/langroid/gen-ui-a2ui-fixed.json
@@ -1,0 +1,36 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for langroid / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-06"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill leg 1 — 'Find me a flight from SFO to JFK on United for $289.' Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "langroid"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_flight_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill leg 2 — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "langroid"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/llamaindex/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/llamaindex/gen-ui-a2ui-fixed.json
@@ -1,0 +1,36 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for llamaindex / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-06"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill leg 1 — 'Find me a flight from SFO to JFK on United for $289.' Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "llamaindex"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_flight_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill leg 2 — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "llamaindex"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/mastra/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/mastra/gen-ui-a2ui-fixed.json
@@ -1,0 +1,36 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for mastra / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-06"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill leg 1 — 'Find me a flight from SFO to JFK on United for $289.' Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "mastra"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_flight_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill leg 2 — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "mastra"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/ms-agent-dotnet/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/ms-agent-dotnet/gen-ui-a2ui-fixed.json
@@ -1,0 +1,36 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for ms-agent-dotnet / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-06"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill leg 1 — 'Find me a flight from SFO to JFK on United for $289.' Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_flight_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill leg 2 — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/ms-agent-harness-dotnet/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/ms-agent-harness-dotnet/gen-ui-a2ui-fixed.json
@@ -1,0 +1,36 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for ms-agent-harness-dotnet / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-06"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill leg 1 — 'Find me a flight from SFO to JFK on United for $289.' Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "ms-agent-harness-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_flight_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill leg 2 — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "ms-agent-harness-dotnet"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/ms-agent-python/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/ms-agent-python/gen-ui-a2ui-fixed.json
@@ -1,0 +1,36 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for ms-agent-python / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-06"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill leg 1 — 'Find me a flight from SFO to JFK on United for $289.' Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "ms-agent-python"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_flight_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill leg 2 — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "ms-agent-python"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/pydantic-ai/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/pydantic-ai/gen-ui-a2ui-fixed.json
@@ -1,0 +1,36 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for pydantic-ai / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-06"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill leg 1 — 'Find me a flight from SFO to JFK on United for $289.' Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "pydantic-ai"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_flight_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill leg 2 — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "pydantic-ai"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/spring-ai/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/spring-ai/gen-ui-a2ui-fixed.json
@@ -1,0 +1,36 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for spring-ai / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-06"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill leg 1 — 'Find me a flight from SFO to JFK on United for $289.' Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "spring-ai"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_flight_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill leg 2 — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "spring-ai"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/strands-typescript/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/strands-typescript/gen-ui-a2ui-fixed.json
@@ -1,0 +1,36 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for strands-typescript / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-06"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill leg 1 — 'Find me a flight from SFO to JFK on United for $289.' Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "strands-typescript"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_flight_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill leg 2 — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "strands-typescript"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/strands/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/strands/gen-ui-a2ui-fixed.json
@@ -1,0 +1,36 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for strands / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-06"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill leg 1 — 'Find me a flight from SFO to JFK on United for $289.' Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "strands"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_flight_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill leg 2 — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "strands"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds 14 integration-specific aimock context-routed fixtures for the `gen-ui-a2ui-fixed` D6 probe (driven by the `a2ui-fixed-schema` demo)
- Each fixture matches the `display_flight` tool call for the pill prompt "Find me a flight from SFO to JFK on United for $289" with `context: <slug>` context-routing (two legs: `hasToolResult:false` routes the tool call, `hasToolResult:true` returns the confirmation content)
- Without these files, the D6 `gen-ui-a2ui-fixed` probe hits aimock with no matching fixture. Because the local/CI aimock runs WITHOUT `--proxy-only`, an unmatched request fails loud (`no_fixture_match`, HTTP 404) instead of falling through to a real provider — the D6 probe never receives `display_flight`, `[data-testid="a2ui-fixed-card"]` never mounts, and the cell fails surface-missing.
- Fixtures are a faithful per-slug clone of the proven `built-in-agent` / `claude-sdk-python` pattern (only `match.context` changes).

## Integrations covered (14)

ag2, agno, claude-sdk-typescript, langgraph-python, langroid, llamaindex, mastra, ms-agent-dotnet, ms-agent-harness-dotnet, ms-agent-python, pydantic-ai, spring-ai, strands-typescript, strands

All 14 integrations already have `a2ui-fixed-schema` listed in their `manifest.yaml` features arrays.

## RED-GREEN evidence (real aimock replay surface)

These fixtures are passive replay data consumed by the aimock server that the D6 `gen-ui-a2ui-fixed` probe drives (via `showcase test <slug>:a2ui-fixed-schema --d6`). The strongest proof that exercises the REAL failure surface is to POST the exact chat-completion the probe sends (user message + `X-AIMock-Context: <slug>`) at an aimock and observe fixture MISS vs HIT. aimock matches `d6/<slug>/*.json` fixtures by `match.context == X-AIMock-Context`.

**Control — `built-in-agent` (fixture already on `main`), against the live fleet aimock:**
```
POST /v1/chat/completions  X-AIMock-Context: built-in-agent
→ HTTP 200  tool_calls[0].function.name = "display_flight"
          arguments = {"origin":"SFO","destination":"JFK","airline":"United","price":"$289"}
```

**RED — fixture ABSENT (this branch's 3 sample slugs), against the same live aimock whose d6 mount does NOT contain them:**
```
POST /v1/chat/completions  X-AIMock-Context: pydantic-ai      → HTTP 404 {"code":"no_fixture_match","message":"No fixture matched"}
POST /v1/chat/completions  X-AIMock-Context: langgraph-python → HTTP 404 {"code":"no_fixture_match","message":"No fixture matched"}
POST /v1/chat/completions  X-AIMock-Context: spring-ai        → HTTP 404 {"code":"no_fixture_match","message":"No fixture matched"}
```
(Confirmed absent on disk: `ls /showcase-fixtures/d6/{pydantic-ai,langgraph-python,spring-ai}/gen-ui-a2ui-fixed.json` → No such file.)

**GREEN — same three requests against an aimock mounting THIS branch's `showcase/aimock/d6` tree:**
```
POST /v1/chat/completions  X-AIMock-Context: pydantic-ai      → HTTP 200  display_flight {origin:SFO,destination:JFK,airline:United,price:$289}
POST /v1/chat/completions  X-AIMock-Context: langgraph-python → HTTP 200  display_flight {origin:SFO,destination:JFK,airline:United,price:$289}
POST /v1/chat/completions  X-AIMock-Context: spring-ai        → HTTP 200  display_flight {origin:SFO,destination:JFK,airline:United,price:$289}
```

All three probe requests flip from `no_fixture_match` (404) to the `display_flight` tool call (200) — i.e. the fixture-miss → surface-missing cluster the fixtures fix. Same identical mechanism the D6 `a2ui-fixed-schema` cell exercises end-to-end.

**JSON validity:** all 14 files pass `python3 -m json.tool`.

## Test plan

- [x] RED/GREEN against the real aimock replay surface for spring-ai, pydantic-ai, langgraph-python (above)
- [ ] CI `showcase_validate` workflow passes (fixture schema validation)
