### PR TITLE
fix(showcase/spring-ai): emit v0.9 nested A2UI ops in DisplayFlightTool

### DIFF
--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/tools/DisplayFlightTool.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/tools/DisplayFlightTool.java
@@ -71,25 +71,31 @@ public class DisplayFlightTool implements Function<DisplayFlightTool.Request, St
     @Override
     public String apply(Request request) {
         try {
-            // The A2UI middleware detects the `a2ui_operations` container in
-            // this tool result and forwards the ops to the frontend renderer.
-            // The frontend catalog resolves component names to the local
-            // React components.
+            // Emit v0.9 nested A2UI operations. The middleware parses
+            // `a2ui_operations` from any TOOL_CALL_RESULT and expects each op
+            // to carry `"version":"v0.9"` with a camelCase operation key
+            // (`createSurface`, `updateComponents`, `updateDataModel`) and the
+            // data nested under `value` (not `data`). This matches the Python
+            // SDK shape in sdk-python/copilotkit/a2ui.py.
             var ops = List.of(
-                    Map.of("type", "create_surface",
-                            "surfaceId", SURFACE_ID,
-                            "catalogId", CATALOG_ID),
-                    Map.of("type", "update_components",
-                            "surfaceId", SURFACE_ID,
-                            "components", FLIGHT_SCHEMA),
-                    Map.of("type", "update_data_model",
-                            "surfaceId", SURFACE_ID,
-                            "data", Map.of(
-                                    "origin", request.origin(),
-                                    "destination", request.destination(),
-                                    "airline", request.airline(),
-                                    "price", request.price()
-                            ))
+                    Map.of("version", "v0.9",
+                            "createSurface", Map.of(
+                                    "surfaceId", SURFACE_ID,
+                                    "catalogId", CATALOG_ID)),
+                    Map.of("version", "v0.9",
+                            "updateComponents", Map.of(
+                                    "surfaceId", SURFACE_ID,
+                                    "components", FLIGHT_SCHEMA)),
+                    Map.of("version", "v0.9",
+                            "updateDataModel", Map.of(
+                                    "surfaceId", SURFACE_ID,
+                                    "path", "/",
+                                    "value", Map.of(
+                                            "origin", request.origin(),
+                                            "destination", request.destination(),
+                                            "airline", request.airline(),
+                                            "price", request.price()
+                                    )))
             );
             return MAPPER.writeValueAsString(Map.of("a2ui_operations", ops));
             // @endregion[backend-render-operations]


### PR DESCRIPTION
## Summary

Spring-ai's `DisplayFlightTool` was emitting legacy flat A2UI operations
(`{"type":"create_surface",...}`) but the A2UI middleware expects v0.9
nested operations (`{"version":"v0.9","createSurface":{...}}`). This is
the same flat→nested migration done for Python/TS in #5832 and langroid
in #5839. The flat shape was silently ignored by the middleware, so the
flight card never mounted and the `a2ui-fixed-schema` D6 cell was
permanently red.

**Root cause** (confirmed by prior local red-green on the disproven TS fix):
`DisplayFlightTool.apply()` emitted `a2ui_operations` in the legacy flat
format. The middleware's `tryParseA2UIOperations` parses the container
correctly, but the op dispatchers inside require the v0.9 shape. No surface
was ever created → card never mounted.

## Fix

Updated the three operations in `DisplayFlightTool.java` to v0.9 nested format:

| Before (flat, ignored) | After (v0.9 nested, works) |
|---|---|
| `{"type":"create_surface","surfaceId":...,"catalogId":...}` | `{"version":"v0.9","createSurface":{"surfaceId":...,"catalogId":...}}` |
| `{"type":"update_components","surfaceId":...,"components":...}` | `{"version":"v0.9","updateComponents":{"surfaceId":...,"components":...}}` |
| `{"type":"update_data_model","surfaceId":...,"data":{...}}` | `{"version":"v0.9","updateDataModel":{"surfaceId":...,"path":"/","value":{...}}}` |

Shape matches `sdk-python/copilotkit/a2ui.py` and the shared Python tools.

## Local Red-Green Proof (real control-plane probe, `--rebuild` both runs)

**RED — original flat ops (`{"type":"create_surface",...}`):**
```
$ showcase test spring-ai:a2ui-fixed-schema --d6 --rebuild --keep
  ✗ d6:spring-ai/gen-ui-a2ui-fixed  red  (0.0s)
    state=red
⚠ Tests failed for spring-ai:a2ui-fixed-schema (exit 1)
```

**GREEN — v0.9 nested ops (`{"version":"v0.9","createSurface":{...}}`):**
```
$ showcase test spring-ai:a2ui-fixed-schema --d6 --rebuild --keep
  ✓ d6:spring-ai/gen-ui-a2ui-fixed  green  (0.0s)
1 passed
✓ Tests passed for spring-ai:a2ui-fixed-schema
```

## Java Build & Tests

All 64 existing spring-ai JUnit tests pass after the change (`mvn test`: 64 run, 0 failures, 0 errors). Code compiles cleanly (`mvn compile -q`).

## Files Changed

- `showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/tools/DisplayFlightTool.java` — v0.9 nested op format

The `route.ts` file is unchanged from main (the prior no-op `a2ui: { injectA2UITool: true }` addition has been reverted — it was disproven as a fix by a real local red-green).