### PR TITLE
fix(showcase/langroid): emit a2ui container via TOOL_CALL_RESULT so the card mounts

### DIFF
--- a/showcase/aimock/d6/langroid/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/langroid/gen-ui-a2ui-fixed.json
@@ -1,0 +1,37 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for langroid / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-07"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill — 'Find me a flight from SFO to JFK on United for $289.' The langroid backend calls OpenAI with the `display_flight` tool; the tool emits an a2ui_operations container (v0.9 shape) via TOOL_CALL_RESULT which the runtime A2UI middleware detects and forwards to the frontend renderer (Card renderer with data-testid='a2ui-fixed-card'). Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "langroid"
+      },
+      "response": {
+        "content": "Here is the SFO to JFK flight on United.",
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_langroid_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing, preventing a tool-invocation loop.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "langroid"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/integrations/langroid/src/agents/a2ui_fixed_agent.py
+++ b/showcase/integrations/langroid/src/agents/a2ui_fixed_agent.py
@@ -51,6 +51,7 @@ from ag_ui.core import (
     TextMessageStartEvent,
     ToolCallArgsEvent,
     ToolCallEndEvent,
+    ToolCallResultEvent,
     ToolCallStartEvent,
 )
 from fastapi import Request
@@ -117,34 +118,42 @@ _DISPLAY_FLIGHT_TOOL: dict[str, Any] = {
 def _build_a2ui_operations(
     *, origin: str, destination: str, airline: str, price: str
 ) -> dict[str, Any]:
-    """Build the ``a2ui_operations`` container the runtime middleware
-    detects in tool results and forwards to the frontend renderer.
+    """Build the ``a2ui_operations`` container (v0.9 shape) the runtime
+    middleware detects in TOOL_CALL_RESULT events and forwards to the
+    frontend renderer.
 
-    Mirrors ``ag2``'s ``a2ui_fixed.display_flight`` exactly so the frontend
-    catalog binding in
-    ``src/app/demos/a2ui-fixed-schema/a2ui/catalog.ts`` resolves the
-    component names against the local React components.
+    Uses the v0.9 nested form (``{"version": "v0.9", "createSurface": {...}}``)
+    matching the ``copilotkit`` Python SDK's ``a2ui.render(...)`` output and
+    the claude-sdk-python / strands / google-adk peers. The legacy flat form
+    (``{"type": "create_surface", ...}``) is silently dropped by the renderer.
     """
     return {
         "a2ui_operations": [
             {
-                "type": "create_surface",
-                "surfaceId": SURFACE_ID,
-                "catalogId": CATALOG_ID,
+                "version": "v0.9",
+                "createSurface": {
+                    "surfaceId": SURFACE_ID,
+                    "catalogId": CATALOG_ID,
+                },
             },
             {
-                "type": "update_components",
-                "surfaceId": SURFACE_ID,
-                "components": FLIGHT_SCHEMA,
+                "version": "v0.9",
+                "updateComponents": {
+                    "surfaceId": SURFACE_ID,
+                    "components": FLIGHT_SCHEMA,
+                },
             },
             {
-                "type": "update_data_model",
-                "surfaceId": SURFACE_ID,
-                "data": {
-                    "origin": origin,
-                    "destination": destination,
-                    "airline": airline,
-                    "price": price,
+                "version": "v0.9",
+                "updateDataModel": {
+                    "surfaceId": SURFACE_ID,
+                    "path": "/",
+                    "value": {
+                        "origin": origin,
+                        "destination": destination,
+                        "airline": airline,
+                        "price": price,
+                    },
                 },
             },
         ]
@@ -392,40 +401,30 @@ async def handle_run(request: Request) -> StreamingResponse:
 
             # Build the tool result containing the a2ui_operations
             # container. The Next.js runtime A2UI middleware detects
-            # this shape and forwards the surface ops to the frontend.
+            # this shape in TOOL_CALL_RESULT events and forwards the
+            # surface ops to the frontend renderer.
             operations = _build_a2ui_operations(
                 origin=str(tool_args.get("origin", "")),
                 destination=str(tool_args.get("destination", "")),
                 airline=str(tool_args.get("airline", "")),
                 price=str(tool_args.get("price", "")),
             )
-            tool_result_id = str(uuid.uuid4())
+            tool_result_msg_id = str(uuid.uuid4())
             yield _sse_line(
                 TextMessageEndEvent(
                     type=EventType.TEXT_MESSAGE_END,
                     message_id=parent_id,
                 )
             )
-            # Emit the tool result as a fresh text block so the runtime
-            # middleware-sse-parser sees the JSON payload as a tool-call
-            # response.
+            # Emit the a2ui_operations container via TOOL_CALL_RESULT so
+            # the A2UI middleware detects it. TextMessageContentEvent is
+            # not scanned for a2ui_operations — only tool results are.
             yield _sse_line(
-                TextMessageStartEvent(
-                    type=EventType.TEXT_MESSAGE_START,
-                    message_id=tool_result_id,
-                )
-            )
-            yield _sse_line(
-                TextMessageContentEvent(
-                    type=EventType.TEXT_MESSAGE_CONTENT,
-                    message_id=tool_result_id,
-                    delta=json.dumps(operations),
-                )
-            )
-            yield _sse_line(
-                TextMessageEndEvent(
-                    type=EventType.TEXT_MESSAGE_END,
-                    message_id=tool_result_id,
+                ToolCallResultEvent(
+                    type=EventType.TOOL_CALL_RESULT,
+                    tool_call_id=call_id,
+                    message_id=tool_result_msg_id,
+                    content=json.dumps(operations),
                 )
             )
 


### PR DESCRIPTION
## Summary

- Fixes langroid `a2ui-fixed-schema` D6 cell (`d6:langroid/gen-ui-a2ui-fixed`): the a2ui container was emitting via `TextMessageContentEvent` so the A2UI middleware never detected it and the flight card never mounted — raw JSON rendered as plain text in chat
- Fixed by emitting `ToolCallResultEvent` (matching the claude-sdk-python peer)
- Also fixed the operation shape: upgraded from legacy flat form (`{"type": "create_surface", ...}`) to v0.9 nested form (`{"version": "v0.9", "createSurface": {...}}`) — the renderer silently ignores the flat form
- Adds the missing langroid aimock D6 fixture for `gen-ui-a2ui-fixed` (without it, aimock returned 'no fixture match', causing a fetch error)

## Changes

**`showcase/integrations/langroid/src/agents/a2ui_fixed_agent.py`**
- Added `ToolCallResultEvent` import
- Replaced `TextMessageStart` + `TextMessageContent` + `TextMessageEnd` block with a single `ToolCallResultEvent(tool_call_id=call_id, content=json.dumps(operations))`
- Upgraded `_build_a2ui_operations()` to emit v0.9 nested op shape

**`showcase/aimock/d6/langroid/gen-ui-a2ui-fixed.json`** (new file)
- Adds aimock fixtures: turn 1 (no-tool-result → call `display_flight`) and turn 2 (has-tool-result → confirmation text)

**Peer matched:** claude-sdk-python (event path), strands / google-adk (v0.9 op shape)

## RED → GREEN Proof

### RED (before fix)
```
✗ d6:langroid/gen-ui-a2ui-fixed red  (0.0s)
  state=red
0 passed, 1 failed
```
Flap-diagnostics: `expected [data-testid="a2ui-fixed-card"] to mount within 60000ms` — bodyTextSnippet showed raw `{"a2ui_operations": [{"type": "create_surface"...` text rendered inline in chat.

### GREEN (after fix — rebuilt container + v0.9 ops + ToolCallResultEvent + aimock fixture)
```
langroid [d6]
[conversation-runner] turn 1/1 — assertions passed
[conversation-runner] conversation completed successfully { turnsCompleted: 1, totalDurationMs: 2121 }
✓ d6:langroid green  (2.6s)
1 passed (2.6s)
```