### PR TITLE
fix(showcase): resolve aimock exact-duplicate ceiling regression from #5426

### DIFF
--- a/showcase/aimock/d6/ag2/agentic-chat.json
+++ b/showcase/aimock/d6/ag2/agentic-chat.json
@@ -63,26 +63,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "ag2"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "ag2"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "ag2"


### PR DESCRIPTION
## Summary

- PR #5426 added `showcase/aimock/d6/ag2/multimodal.json` with two fixtures keyed on `userMessage + turnIndex:0 + context:ag2` (the image and PDF multimodal probes).
- Those exact same match keys were already present in `showcase/aimock/d6/ag2/agentic-chat.json` (placed there at the same time #5426 updated the agentic-chat file).
- Result: 2 exact duplicates within the `ag2` context scope → collision count 297→299, tripping the ceiling (297).

## Fix

Dedupe: remove the two multimodal-probe entries from `agentic-chat.json`. The dedicated `multimodal.json` (added by #5426) is the authoritative home. The `agentic-chat` probe never sends image/PDF turns; aimock routes those to `multimodal.json` via `context: ag2`.

## RED → GREEN

**RED** (origin/main at `81c577f067`): CI run #28840506865 (`Showcase: Validate main`):
```
AssertionError: Exact duplicate count (299) exceeds ceiling (297).
```

**GREEN** (this branch, `fe96b3f254`): local run against worktree fixtures:
```
✓ fixture collision detection > no exact duplicate match keys within the same context scope  2ms
Tests  824 passed (824)
```

## Test plan

- [x] `__tests__/aimock-fixtures.test.ts > fixture collision detection > no exact duplicate match keys` passes (count ≤ 297)
- [x] No new fixtures added or ceiling bumped — pure dedupe
- [ ] CI `Showcase: Validate main` flips green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)