### PR TITLE
refactor(core): share one metadata socket across threads + memory

### DIFF
--- a/packages/angular/src/lib/memories.spec.ts
+++ b/packages/angular/src/lib/memories.spec.ts
@@ -2,7 +2,10 @@ import { Component } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Mock } from "vitest";
-import { ɵcreateMemoryStore } from "@copilotkit/core";
+import {
+  ɵcreateMemoryStore,
+  ɵcreateMetadataRealtimeConnection,
+} from "@copilotkit/core";
 import type { ɵMemoryStore } from "@copilotkit/core";
 import { CopilotKit } from "./copilotkit";
 import { injectMemories, type MemoriesController } from "./memories";
@@ -97,7 +100,13 @@ class CopilotKitStub {
   activate(): void {
     this.store.setContext({
       runtimeUrl: RUNTIME_URL,
-      wsUrl: WS_URL,
+      metadata: ɵcreateMetadataRealtimeConnection({
+        wsUrl: WS_URL,
+        fetchSubscription: async () => ({
+          joinToken: "jt-1",
+          joinCode: "jc-1",
+        }),
+      }),
       headers: {},
     });
   }

--- a/packages/angular/src/lib/memories.spec.ts
+++ b/packages/angular/src/lib/memories.spec.ts
@@ -2,11 +2,8 @@ import { Component } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Mock } from "vitest";
-import {
-  ɵcreateMemoryStore,
-  ɵcreateMetadataRealtimeConnection,
-} from "@copilotkit/core";
-import type { ɵMemoryStore } from "@copilotkit/core";
+import { ɵcreateMemoryStore, ɵcreateMetadataSocket } from "@copilotkit/core";
+import type { ɵMemoryStore, ɵMetadataSocket } from "@copilotkit/core";
 import { CopilotKit } from "./copilotkit";
 import { injectMemories, type MemoriesController } from "./memories";
 
@@ -97,16 +94,22 @@ class CopilotKitStub {
    * dispatches a real runtime context, which fires the snapshot fetch through
    * the real reducer/effects/selectors.
    */
+  #metadataSocket: ɵMetadataSocket | undefined;
+
   activate(): void {
     this.store.setContext({
       runtimeUrl: RUNTIME_URL,
-      metadata: ɵcreateMetadataRealtimeConnection({
-        wsUrl: WS_URL,
-        fetchSubscription: async () => ({
-          joinToken: "jt-1",
-          joinCode: "jc-1",
-        }),
-      }),
+      // Mirror `CopilotKitCore.ɵgetMetadataSocket`: ONE credential-agnostic
+      // socket, memoized so repeated resolves return the same instance. The
+      // store fetches its own `/memories/subscribe` creds and hands the token
+      // here.
+      getMetadataSocket: (joinToken: string): ɵMetadataSocket => {
+        this.#metadataSocket ??= ɵcreateMetadataSocket({
+          wsUrl: WS_URL,
+          joinToken,
+        }).socket;
+        return this.#metadataSocket;
+      },
       headers: {},
     });
   }

--- a/packages/angular/src/lib/threads.spec.ts
+++ b/packages/angular/src/lib/threads.spec.ts
@@ -3,8 +3,8 @@ import { TestBed } from "@angular/core/testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CopilotKitCoreRuntimeConnectionStatus,
-  ɵcreateMetadataRealtimeConnection,
-  type ɵMetadataRealtimeConnection,
+  ɵcreateMetadataSocket,
+  type ɵMetadataSocket,
   type ɵThreadStore,
 } from "@copilotkit/core";
 import { CopilotKit } from "./copilotkit";
@@ -76,11 +76,11 @@ class CopilotKitStub {
     undefined,
   );
   readonly #intelligence = signal<{ wsUrl: string } | undefined>(undefined);
-  // Lazily-created shared realtime connection, memoized to mirror
-  // `CopilotKitCore.ɵgetMetadataRealtime()` (which returns one stable instance
-  // per connection). The phoenix socket never connects under jsdom, so this is
-  // just a well-formed connection object the thread store can subscribe to.
-  #metadataConnection: ɵMetadataRealtimeConnection | undefined;
+  // Lazily-created shared, credential-agnostic socket, memoized to mirror
+  // `CopilotKitCore.ɵgetMetadataSocket()` (which returns one stable instance
+  // once seeded). The phoenix socket never connects under jsdom, so this is
+  // just a well-formed socket the thread store can subscribe to.
+  #metadataSocket: ɵMetadataSocket | undefined;
 
   readonly runtimeConnectionStatus = this.#runtimeConnectionStatus.asReadonly();
   readonly runtimeUrl = this.#runtimeUrl.asReadonly();
@@ -101,17 +101,14 @@ class CopilotKitStub {
     get threadEndpoints() {
       return stub.threadEndpoints();
     },
-    ɵgetMetadataRealtime: (): ɵMetadataRealtimeConnection | undefined => {
+    ɵgetMetadataSocket: (joinToken: string): ɵMetadataSocket | undefined => {
       const wsUrl = stub.intelligence()?.wsUrl;
       if (!wsUrl) return undefined;
-      stub.#metadataConnection ??= ɵcreateMetadataRealtimeConnection({
+      stub.#metadataSocket ??= ɵcreateMetadataSocket({
         wsUrl,
-        fetchSubscription: async () => ({
-          joinToken: "jt-1",
-          joinCode: "jc-1",
-        }),
-      });
-      return stub.#metadataConnection;
+        joinToken,
+      }).socket;
+      return stub.#metadataSocket;
     },
   };
 

--- a/packages/angular/src/lib/threads.spec.ts
+++ b/packages/angular/src/lib/threads.spec.ts
@@ -498,6 +498,53 @@ describe("injectThreads", () => {
     expect(listCalls.length).toBe(2);
   });
 
+  it("re-dispatches on a Disconnected→Connected cycle with unchanged primitives (B1)", async () => {
+    active!.fetchMock.mockResolvedValue(jsonResponse({ threads: [] }));
+
+    @Component({ standalone: true, template: "" })
+    class Host {
+      readonly threads = injectThreads({ agentId: "agent-1" });
+    }
+
+    const fixture = TestBed.createComponent(Host);
+    fixture.detectChanges();
+
+    // Connect with a fixed wsUrl so the dispatched context's primitives are
+    // identical before and after the reconnect — isolating the B1 dedup reset
+    // (not a primitive change) as the sole reason a second dispatch fires.
+    active!.connect({ wsUrl: "wss://runtime.local/ws" });
+    fixture.detectChanges();
+    await active!.flush();
+
+    const listCallsBefore = active!.fetchMock.mock.calls.filter(([url]) =>
+      String(url).includes("/threads?"),
+    );
+    expect(listCallsBefore.length).toBe(1);
+
+    // Runtime drops to Disconnected: core disposes the shared metadata socket.
+    active!.stub.setRuntimeConnectionStatus(
+      CopilotKitCoreRuntimeConnectionStatus.Disconnected,
+    );
+    fixture.detectChanges();
+    await active!.flush();
+
+    // ...then back to Connected with IDENTICAL primitives.
+    active!.stub.setRuntimeConnectionStatus(
+      CopilotKitCoreRuntimeConnectionStatus.Connected,
+    );
+    fixture.detectChanges();
+    await active!.flush();
+
+    // Leaving Connected reset the dedup signature (`lastDispatchedContext = null`),
+    // so the return to Connected re-dispatches `setContext` — re-resolving a
+    // fresh socket — instead of being deduped and stranded on the disposed one.
+    // Two list fetches total. Without the reset this stays at one.
+    const listCallsAfter = active!.fetchMock.mock.calls.filter(([url]) =>
+      String(url).includes("/threads?"),
+    );
+    expect(listCallsAfter.length).toBe(2);
+  });
+
   it("does not re-dispatch when headers change key order only", async () => {
     active!.fetchMock.mockResolvedValue(jsonResponse({ threads: [] }));
     active!.stub.setHeaders({ a: "1", b: "2" });

--- a/packages/angular/src/lib/threads.spec.ts
+++ b/packages/angular/src/lib/threads.spec.ts
@@ -3,6 +3,8 @@ import { TestBed } from "@angular/core/testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CopilotKitCoreRuntimeConnectionStatus,
+  ɵcreateMetadataRealtimeConnection,
+  type ɵMetadataRealtimeConnection,
   type ɵThreadStore,
 } from "@copilotkit/core";
 import { CopilotKit } from "./copilotkit";
@@ -74,6 +76,11 @@ class CopilotKitStub {
     undefined,
   );
   readonly #intelligence = signal<{ wsUrl: string } | undefined>(undefined);
+  // Lazily-created shared realtime connection, memoized to mirror
+  // `CopilotKitCore.ɵgetMetadataRealtime()` (which returns one stable instance
+  // per connection). The phoenix socket never connects under jsdom, so this is
+  // just a well-formed connection object the thread store can subscribe to.
+  #metadataConnection: ɵMetadataRealtimeConnection | undefined;
 
   readonly runtimeConnectionStatus = this.#runtimeConnectionStatus.asReadonly();
   readonly runtimeUrl = this.#runtimeUrl.asReadonly();
@@ -93,6 +100,18 @@ class CopilotKitStub {
     },
     get threadEndpoints() {
       return stub.threadEndpoints();
+    },
+    ɵgetMetadataRealtime: (): ɵMetadataRealtimeConnection | undefined => {
+      const wsUrl = stub.intelligence()?.wsUrl;
+      if (!wsUrl) return undefined;
+      stub.#metadataConnection ??= ɵcreateMetadataRealtimeConnection({
+        wsUrl,
+        fetchSubscription: async () => ({
+          joinToken: "jt-1",
+          joinCode: "jc-1",
+        }),
+      });
+      return stub.#metadataConnection;
     },
   };
 

--- a/packages/angular/src/lib/threads.ts
+++ b/packages/angular/src/lib/threads.ts
@@ -341,8 +341,11 @@ export class ThreadsStore implements InjectThreadsResult {
     });
 
     // Sync the runtime context. Defer until the runtime reports Connected so
-    // the initial context carries `intelligence.wsUrl` and avoids a redundant
-    // second list fetch + subscribe round-trip (mirrors react-core).
+    // the context's `getMetadataSocket` provider can resolve the shared socket
+    // on the first dispatch — otherwise an early dispatch fetches the list with
+    // realtime silently absent and then re-dispatches (a new session, so a
+    // second list fetch + subscribe) once Connected. Waiting collapses it to a
+    // single list + subscribe (mirrors react-core).
     //
     // The store dispatches `setContext` onto an `asapScheduler` queue, and its
     // bootstrap effect issues a list fetch for every queued `contextChanged`
@@ -359,8 +362,10 @@ export class ThreadsStore implements InjectThreadsResult {
     effect(() => {
       // Track every reactive input the dispatched context depends on, so the
       // effect re-runs when any of them changes — including `wsUrl`, which
-      // arrives with `/info` and (via the dedup signature below) triggers a
-      // single re-dispatch carrying the realtime URL.
+      // arrives with `/info`. Once it lands the shared metadata socket becomes
+      // resolvable, so (via the dedup signature below) a single re-dispatch
+      // re-runs `setContext` and the context's `getMetadataSocket` provider now
+      // resolves a socket.
       const active = isEnabled();
       const url = runtimeUrl();
       const status = runtimeStatus();

--- a/packages/angular/src/lib/threads.ts
+++ b/packages/angular/src/lib/threads.ts
@@ -404,7 +404,7 @@ export class ThreadsStore implements InjectThreadsResult {
         const context: ɵThreadRuntimeContext = {
           runtimeUrl: url,
           headers: { ...headers },
-          wsUrl,
+          metadata: this.#copilotkit.core.ɵgetMetadataRealtime() ?? null,
           agentId: id,
           includeArchived: archived,
           limit: pageLimit,
@@ -414,12 +414,18 @@ export class ThreadsStore implements InjectThreadsResult {
         // same-content header map with a different key order does not trigger
         // a redundant setContext (and the refetch + resubscribe it causes).
         // Mirrors react-core's `headersKey`. The dispatched context keeps its
-        // original header order; only the signature is normalized.
+        // original header order; only the signature is normalized. `metadata`
+        // is a live connection object (not serializable), so the signature
+        // keys off the source `wsUrl` — its identity/URL — instead.
         const signature = JSON.stringify({
-          ...context,
+          runtimeUrl: url,
           headers: Object.entries(headers).sort(([left], [right]) =>
             left.localeCompare(right),
           ),
+          wsUrl,
+          agentId: id,
+          includeArchived: archived,
+          limit: pageLimit,
         });
         if (signature === lastDispatchedContext) {
           return;

--- a/packages/angular/src/lib/threads.ts
+++ b/packages/angular/src/lib/threads.ts
@@ -393,6 +393,13 @@ export class ThreadsStore implements InjectThreadsResult {
         }
 
         if (status !== CopilotKitCoreRuntimeConnectionStatus.Connected) {
+          // Core disposes the shared metadata socket whenever the runtime
+          // leaves Connected. Reset the dedup signature so the next return to
+          // Connected ALWAYS re-dispatches `setContext` — otherwise a status
+          // blip that leaves the primitives unchanged would not re-dispatch,
+          // stranding the store on a disposed socket. On reconnect the store
+          // re-fetches creds and re-resolves a fresh socket.
+          lastDispatchedContext = null;
           return;
         }
 
@@ -404,7 +411,8 @@ export class ThreadsStore implements InjectThreadsResult {
         const context: ɵThreadRuntimeContext = {
           runtimeUrl: url,
           headers: { ...headers },
-          metadata: this.#copilotkit.core.ɵgetMetadataRealtime() ?? null,
+          getMetadataSocket: (joinToken) =>
+            this.#copilotkit.core.ɵgetMetadataSocket(joinToken) ?? null,
           agentId: id,
           includeArchived: archived,
           limit: pageLimit,
@@ -414,9 +422,10 @@ export class ThreadsStore implements InjectThreadsResult {
         // same-content header map with a different key order does not trigger
         // a redundant setContext (and the refetch + resubscribe it causes).
         // Mirrors react-core's `headersKey`. The dispatched context keeps its
-        // original header order; only the signature is normalized. `metadata`
-        // is a live connection object (not serializable), so the signature
-        // keys off the source `wsUrl` — its identity/URL — instead.
+        // original header order; only the signature is normalized. The
+        // `getMetadataSocket` provider is a live closure (not serializable), so
+        // the signature keys off the source `wsUrl` — its identity/URL —
+        // instead.
         const signature = JSON.stringify({
           runtimeUrl: url,
           headers: Object.entries(headers).sort(([left], [right]) =>

--- a/packages/core/src/__tests__/memory-store.test.ts
+++ b/packages/core/src/__tests__/memory-store.test.ts
@@ -1,5 +1,30 @@
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
-import { CopilotKitCore, CopilotKitCoreRuntimeConnectionStatus } from "../core";
+import { MockSocket } from "./test-utils";
+
+// Phoenix mock harness: seeding the shared metadata socket
+// (`core.ɵgetMetadataSocket(joinToken)`) constructs a real
+// `ɵcreateMetadataSocket`, which connects through the mocked `phoenix` module
+// below. `phoenix.sockets` captures every socket constructed so tests can
+// assert the underlying socket was disposed (`disconnected`) on
+// disconnect/header-change.
+const phoenix = vi.hoisted(() => ({
+  sockets: [] as MockSocket[],
+}));
+
+vi.mock("phoenix", () => ({
+  Socket: class extends MockSocket {
+    constructor(url = "", opts: Record<string, any> = {}) {
+      super(url, opts);
+      phoenix.sockets.push(this);
+    }
+  },
+}));
+
+// Dynamic import (mirrors memory.test.ts): the `../core` module transitively
+// loads `phoenix-observable` -> `phoenix`, so it must be imported AFTER the
+// `vi.mock("phoenix", ...)` factory's captured variables are initialized.
+const { CopilotKitCore, CopilotKitCoreRuntimeConnectionStatus } =
+  await import("../core");
 
 const originalWindow = (globalThis as { window?: unknown }).window;
 
@@ -22,6 +47,7 @@ beforeEach(() => {
   // Simulate a browser environment so `updateRuntimeConnection` proceeds past
   // the SSR guard (`typeof window === "undefined"` check in agent-registry).
   (globalThis as { window?: unknown }).window = {};
+  phoenix.sockets.splice(0);
 });
 
 afterEach(() => {
@@ -67,11 +93,11 @@ test("context set when connected + intelligence configured: getState().context i
   const store = core.getMemoryStore();
 
   expect(store.getState().context).not.toBeNull();
-  expect(store.getState().context?.metadata).toBeDefined();
+  expect(typeof store.getState().context?.getMetadataSocket).toBe("function");
   expect(store.getState().context?.runtimeUrl).toBe(runtimeUrl);
 });
 
-test("ɵgetMetadataRealtime(): returns a single memoized instance while connected", async () => {
+test("ɵgetMetadataSocket(): seeds ONE memoized socket while connected; undefined before connected", async () => {
   const runtimeUrl = "https://runtime.example.com";
 
   const fetchMock = vi.fn().mockResolvedValue(
@@ -87,20 +113,29 @@ test("ɵgetMetadataRealtime(): returns a single memoized instance while connecte
     runtimeTransport: "rest",
   });
 
+  // Before the `/info` fetch resolves the runtime is not yet connected, so no
+  // shared socket can be seeded.
+  expect(core.ɵgetMetadataSocket("t1")).toBeUndefined();
+
   await vi.waitFor(() => {
     expect(core.runtimeConnectionStatus).toBe(
       CopilotKitCoreRuntimeConnectionStatus.Connected,
     );
   });
 
-  const a = core.ɵgetMetadataRealtime();
-  const b = core.ɵgetMetadataRealtime();
+  // The socket is seeded from the FIRST consumer's joinToken and memoized: a
+  // second call with a DIFFERENT token returns the SAME socket (the token arg
+  // is ignored after the first seed — the socket is already authenticated).
+  const a = core.ɵgetMetadataSocket("t1");
+  const b = core.ɵgetMetadataSocket("t2");
 
   expect(a).toBeDefined();
   expect(a).toBe(b);
+  // Exactly one underlying phoenix socket was constructed.
+  expect(phoenix.sockets.length).toBe(1);
 });
 
-test("ɵgetMetadataRealtime(): disposes the connection when the runtime disconnects", async () => {
+test("B6: disposes the shared socket when the runtime disconnects", async () => {
   const runtimeUrl = "https://runtime.example.com";
 
   const fetchMock = vi.fn().mockResolvedValue(
@@ -122,23 +157,65 @@ test("ɵgetMetadataRealtime(): disposes the connection when the runtime disconne
     );
   });
 
-  const connection = core.ɵgetMetadataRealtime();
-  expect(connection).toBeDefined();
-  const disposeSpy = vi.spyOn(connection!, "dispose");
+  // Seed the shared socket.
+  const s = core.ɵgetMetadataSocket("jt");
+  expect(s).toBeDefined();
+  expect(phoenix.sockets.length).toBe(1);
+  const underlying = phoenix.sockets[0];
 
   // Real disconnect: dropping the runtime URL moves the connection status to
   // Disconnected and fires `onRuntimeConnectionStatusChanged`, which disposes
-  // the shared metadata connection.
+  // the shared metadata socket (tearing down the underlying phoenix socket).
   core.setRuntimeUrl(undefined);
 
   await vi.waitFor(() => {
-    expect(disposeSpy).toHaveBeenCalled();
+    expect(underlying.disconnected).toBe(true);
   });
 
   expect(core.runtimeConnectionStatus).toBe(
     CopilotKitCoreRuntimeConnectionStatus.Disconnected,
   );
-  expect(core.ɵgetMetadataRealtime()).toBeUndefined();
+  // No socket can be seeded while disconnected.
+  expect(core.ɵgetMetadataSocket("jt")).toBeUndefined();
+});
+
+test("B7: setHeaders tears down the socket and the next consumer re-seeds a fresh one", async () => {
+  const runtimeUrl = "https://runtime.example.com";
+
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(infoResponseWithIntelligence), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+  global.fetch = fetchMock;
+
+  const core = new CopilotKitCore({
+    runtimeUrl,
+    runtimeTransport: "rest",
+  });
+
+  await vi.waitFor(() => {
+    expect(core.runtimeConnectionStatus).toBe(
+      CopilotKitCoreRuntimeConnectionStatus.Connected,
+    );
+  });
+
+  const first = core.ɵgetMetadataSocket("jt1");
+  expect(first).toBeDefined();
+  expect(phoenix.sockets.length).toBe(1);
+
+  // A header change re-mints the join token, so the shared socket is torn down;
+  // the next consumer re-seeds a fresh socket with the fresh token.
+  core.setHeaders({ Authorization: "Bearer rotated" });
+
+  const second = core.ɵgetMetadataSocket("jt2");
+  expect(second).toBeDefined();
+  // A DIFFERENT instance — the old one was disposed and a fresh socket seeded.
+  expect(second).not.toBe(first);
+  expect(phoenix.sockets.length).toBe(2);
+  // The first underlying socket was disconnected on the header change.
+  expect(phoenix.sockets[0].disconnected).toBe(true);
 });
 
 test("context null without intelligence / not connected: getState().context is null when no intelligence is present", async () => {

--- a/packages/core/src/__tests__/memory-store.test.ts
+++ b/packages/core/src/__tests__/memory-store.test.ts
@@ -162,6 +162,8 @@ test("B6: disposes the shared socket when the runtime disconnects", async () => 
   expect(s).toBeDefined();
   expect(phoenix.sockets.length).toBe(1);
   const underlying = phoenix.sockets[0];
+  expect(underlying).toBeDefined();
+  if (!underlying) throw new Error("expected a seeded phoenix socket");
 
   // Real disconnect: dropping the runtime URL moves the connection status to
   // Disconnected and fires `onRuntimeConnectionStatusChanged`, which disposes
@@ -215,7 +217,9 @@ test("B7: setHeaders tears down the socket and the next consumer re-seeds a fres
   expect(second).not.toBe(first);
   expect(phoenix.sockets.length).toBe(2);
   // The first underlying socket was disconnected on the header change.
-  expect(phoenix.sockets[0].disconnected).toBe(true);
+  const firstUnderlying = phoenix.sockets[0];
+  expect(firstUnderlying).toBeDefined();
+  expect(firstUnderlying?.disconnected).toBe(true);
 });
 
 test("context null without intelligence / not connected: getState().context is null when no intelligence is present", async () => {

--- a/packages/core/src/__tests__/memory-store.test.ts
+++ b/packages/core/src/__tests__/memory-store.test.ts
@@ -30,6 +30,16 @@ const { ɵMETADATA_MAX_SOCKET_RETRIES } =
 
 const originalWindow = (globalThis as { window?: unknown }).window;
 
+// Flush the store's effect pipeline (micro-redux schedules effect action
+// observation on `asapScheduler`) plus the `/memories/subscribe` fetch and the
+// deferred give-up dispose (`queueMicrotask`). Mirrors memory.test.ts.
+const flushEffects = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
 const infoResponseWithIntelligence = {
   version: "1.0.0",
   agents: {},
@@ -263,6 +273,12 @@ test("FIX-C: a health give-up disposes the shared socket and the next consumer r
     underlying.triggerError();
   }
 
+  // The give-up dispose is deferred one microtask (so the synchronous
+  // `socketFatal$` fan-out reaches every store subscriber — e.g. memory's
+  // `fatal$ -> realtimeUnavailable` — before `dispose()` completes the shared
+  // subject). Flush the microtask before asserting the teardown.
+  await Promise.resolve();
+
   // The give-up tore down the underlying socket.
   expect(underlying.disconnected).toBe(true);
   expect(warn).toHaveBeenCalled();
@@ -274,6 +290,91 @@ test("FIX-C: a health give-up disposes the shared socket and the next consumer r
   expect(second).not.toBe(first);
   expect(phoenix.sockets.length).toBe(2);
   expect(phoenix.sockets[1]?.disconnected).toBe(false);
+
+  warn.mockRestore();
+  core.setRuntimeUrl(undefined);
+});
+
+// Regression (re-entrancy): wires a REAL core-owned memory store through core's
+// REAL shared socket. On a health give-up, the single synchronous
+// `socketFatal$` emission fans out to subscribers in subscription order. Core's
+// `_metadataSocketFatalSub` (subscribed at socket-creation time, BEFORE any
+// store's own `fatal$`) must NOT synchronously `dispose()` — doing so completes
+// the shared `socketFatal$` subject before the fan-out reaches memory's
+// `fatal$ -> realtimeUnavailable` subscriber, leaving memory stuck at
+// "connecting" over a dead socket. The dispose is deferred one microtask so the
+// fan-out reaches every subscriber first. WITHOUT the `queueMicrotask` wrapper
+// in core.ts this test fails (status stays "connecting").
+test("FIX-C regression: a health give-up flips the core-owned memory store's realtimeStatus to 'unavailable'", async () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  const runtimeUrl = "https://runtime.example.com";
+
+  // URL-aware fetch: `/info` connects the runtime with intelligence.wsUrl;
+  // `/memories/subscribe` returns join credentials so the store's socketEffect
+  // seeds the shared socket via `getMetadataSocket`; `/memories` lists empty.
+  const fetchMock = vi.fn((input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.endsWith("/info")) {
+      return Promise.resolve(
+        new Response(JSON.stringify(infoResponseWithIntelligence), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    }
+    if (url.endsWith("/memories/subscribe")) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ joinToken: "jt", joinCode: "jc" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    }
+    // `/memories` (list) — possibly with a query string.
+    return Promise.resolve(
+      new Response(JSON.stringify({ memories: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+
+  const core = new CopilotKitCore({
+    runtimeUrl,
+    runtimeTransport: "rest",
+  });
+
+  await vi.waitFor(() => {
+    expect(core.runtimeConnectionStatus).toBe(
+      CopilotKitCoreRuntimeConnectionStatus.Connected,
+    );
+  });
+
+  // Obtain the core-owned memory store. Its socketEffect fetches
+  // `/memories/subscribe`, then calls `getMetadataSocket(joinToken)` — which
+  // seeds the shared phoenix socket through core.
+  const store = core.getMemoryStore();
+
+  // Let the credentials fetch resolve and the socketEffect seed the socket.
+  await vi.waitFor(() => {
+    expect(phoenix.sockets.length).toBe(1);
+  });
+  const underlying = phoenix.sockets[0];
+  if (!underlying) throw new Error("expected a seeded phoenix socket");
+  // The channel join is never acknowledged, so realtime is still "connecting".
+  expect(store.getState().realtimeStatus).toBe("connecting");
+
+  // Drive the shared socket to a terminal give-up.
+  for (let i = 0; i < ɵMETADATA_MAX_SOCKET_RETRIES; i += 1) {
+    underlying.triggerError();
+  }
+  await flushEffects();
+
+  // The give-up's `socketFatal$` fan-out reached memory's `fatal$` before
+  // core's deferred dispose completed the shared subject, so the store
+  // surfaced `realtimeUnavailable`.
+  expect(store.getState().realtimeStatus).toBe("unavailable");
 
   warn.mockRestore();
   core.setRuntimeUrl(undefined);

--- a/packages/core/src/__tests__/memory-store.test.ts
+++ b/packages/core/src/__tests__/memory-store.test.ts
@@ -25,6 +25,8 @@ vi.mock("phoenix", () => ({
 // `vi.mock("phoenix", ...)` factory's captured variables are initialized.
 const { CopilotKitCore, CopilotKitCoreRuntimeConnectionStatus } =
   await import("../core");
+const { ɵMETADATA_MAX_SOCKET_RETRIES } =
+  await import("../core/metadata-realtime");
 
 const originalWindow = (globalThis as { window?: unknown }).window;
 
@@ -220,6 +222,61 @@ test("B7: setHeaders tears down the socket and the next consumer re-seeds a fres
   const firstUnderlying = phoenix.sockets[0];
   expect(firstUnderlying).toBeDefined();
   expect(firstUnderlying?.disconnected).toBe(true);
+});
+
+test("FIX-C: a health give-up disposes the shared socket and the next consumer re-seeds a fresh one", async () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  const runtimeUrl = "https://runtime.example.com";
+
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(infoResponseWithIntelligence), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+  global.fetch = fetchMock;
+
+  const core = new CopilotKitCore({
+    runtimeUrl,
+    runtimeTransport: "rest",
+  });
+
+  await vi.waitFor(() => {
+    expect(core.runtimeConnectionStatus).toBe(
+      CopilotKitCoreRuntimeConnectionStatus.Connected,
+    );
+  });
+
+  // Seed the shared socket.
+  const first = core.ɵgetMetadataSocket("jt");
+  expect(first).toBeDefined();
+  expect(phoenix.sockets.length).toBe(1);
+  const underlying = phoenix.sockets[0];
+  if (!underlying) throw new Error("expected a seeded phoenix socket");
+  expect(underlying.disconnected).toBe(false);
+
+  // Drive ɵMETADATA_MAX_SOCKET_RETRIES consecutive transport errors with no
+  // intervening `open`, exhausting the shared socket's health monitor so its
+  // `socketFatal$` fires. The give-up must be TERMINAL: core disposes the
+  // socket (stops the Phoenix reconnect loop) rather than latching forever.
+  for (let i = 0; i < ɵMETADATA_MAX_SOCKET_RETRIES; i += 1) {
+    underlying.triggerError();
+  }
+
+  // The give-up tore down the underlying socket.
+  expect(underlying.disconnected).toBe(true);
+  expect(warn).toHaveBeenCalled();
+
+  // The runtime is still connected, so the next consumer access re-seeds a
+  // FRESH socket (`_metadataSocket` was nulled by the give-up dispose).
+  const second = core.ɵgetMetadataSocket("jt");
+  expect(second).toBeDefined();
+  expect(second).not.toBe(first);
+  expect(phoenix.sockets.length).toBe(2);
+  expect(phoenix.sockets[1]?.disconnected).toBe(false);
+
+  warn.mockRestore();
+  core.setRuntimeUrl(undefined);
 });
 
 test("context null without intelligence / not connected: getState().context is null when no intelligence is present", async () => {

--- a/packages/core/src/__tests__/memory-store.test.ts
+++ b/packages/core/src/__tests__/memory-store.test.ts
@@ -67,8 +67,78 @@ test("context set when connected + intelligence configured: getState().context i
   const store = core.getMemoryStore();
 
   expect(store.getState().context).not.toBeNull();
-  expect(store.getState().context?.wsUrl).toBe("wss://gw.example.com/client");
+  expect(store.getState().context?.metadata).toBeDefined();
   expect(store.getState().context?.runtimeUrl).toBe(runtimeUrl);
+});
+
+test("ɵgetMetadataRealtime(): returns a single memoized instance while connected", async () => {
+  const runtimeUrl = "https://runtime.example.com";
+
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(infoResponseWithIntelligence), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+  global.fetch = fetchMock;
+
+  const core = new CopilotKitCore({
+    runtimeUrl,
+    runtimeTransport: "rest",
+  });
+
+  await vi.waitFor(() => {
+    expect(core.runtimeConnectionStatus).toBe(
+      CopilotKitCoreRuntimeConnectionStatus.Connected,
+    );
+  });
+
+  const a = core.ɵgetMetadataRealtime();
+  const b = core.ɵgetMetadataRealtime();
+
+  expect(a).toBeDefined();
+  expect(a).toBe(b);
+});
+
+test("ɵgetMetadataRealtime(): disposes the connection when the runtime disconnects", async () => {
+  const runtimeUrl = "https://runtime.example.com";
+
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(infoResponseWithIntelligence), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+  global.fetch = fetchMock;
+
+  const core = new CopilotKitCore({
+    runtimeUrl,
+    runtimeTransport: "rest",
+  });
+
+  await vi.waitFor(() => {
+    expect(core.runtimeConnectionStatus).toBe(
+      CopilotKitCoreRuntimeConnectionStatus.Connected,
+    );
+  });
+
+  const connection = core.ɵgetMetadataRealtime();
+  expect(connection).toBeDefined();
+  const disposeSpy = vi.spyOn(connection!, "dispose");
+
+  // Real disconnect: dropping the runtime URL moves the connection status to
+  // Disconnected and fires `onRuntimeConnectionStatusChanged`, which disposes
+  // the shared metadata connection.
+  core.setRuntimeUrl(undefined);
+
+  await vi.waitFor(() => {
+    expect(disposeSpy).toHaveBeenCalled();
+  });
+
+  expect(core.runtimeConnectionStatus).toBe(
+    CopilotKitCoreRuntimeConnectionStatus.Disconnected,
+  );
+  expect(core.ɵgetMetadataRealtime()).toBeUndefined();
 });
 
 test("context null without intelligence / not connected: getState().context is null when no intelligence is present", async () => {

--- a/packages/core/src/__tests__/memory.test.ts
+++ b/packages/core/src/__tests__/memory.test.ts
@@ -320,12 +320,10 @@ describe("memory store realtime", () => {
    * `user_meta:memories:<joinCode>` channel. Returns the connected store.
    */
   async function connectedRealtimeStore() {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ memories: [] }),
-      });
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ memories: [] }),
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = createMemoryStore(memoryEnvironment(fetchMock));
@@ -530,6 +528,46 @@ describe("memory store realtime", () => {
     await flushEffects();
 
     expect(store.getState().realtimeStatus).toBe("connecting");
+  });
+
+  it("subscribe failure -> silent degrade (store stays alive, realtimeStatus 'unavailable')", async () => {
+    // The shared metadata connection's `fetchSubscription` rejects (a transient
+    // non-2xx on `/threads/subscribe`), which errors `joinCode$`. Micro-redux is
+    // fail-fast, so without the socket effect's `catchError` this would kill the
+    // whole store — `getState()` would throw and the REST list/mutations would
+    // break. It must instead degrade silently: the store stays alive, the REST
+    // list & `available`/`error` are untouched, and only `realtimeStatus` flips.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ memories: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const store = createMemoryStore(memoryEnvironment(fetchMock));
+    store.start();
+    store.setContext({
+      ...realtimeContext,
+      metadata: ɵcreateMetadataRealtimeConnection({
+        wsUrl: "wss://gw/client",
+        fetchSubscription: async () => {
+          throw new Error("boom");
+        },
+      }),
+    });
+    await flushEffects();
+
+    // The store did NOT crash: getState()/select still work.
+    expect(() => store.getState()).not.toThrow();
+    // The REST-backed list settled from its own fetch, unaffected by realtime.
+    expect(store.getState().memories).toEqual([]);
+    expect(store.getState().available).toBe(true);
+    expect(store.getState().error).toBeNull();
+    // Realtime degraded to unavailable rather than getting stuck "connecting".
+    expect(store.getState().realtimeStatus).toBe("unavailable");
+
+    warn.mockRestore();
+    store.stop();
   });
 });
 

--- a/packages/core/src/__tests__/memory.test.ts
+++ b/packages/core/src/__tests__/memory.test.ts
@@ -39,6 +39,7 @@ import type {
   ɵMemoryEnvironment as MemoryEnvironment,
 } from "../memory";
 import { MemoryError } from "../memory-errors";
+import { ɵcreateMetadataRealtimeConnection } from "../core/metadata-realtime";
 
 function memoryEnvironment(fetchImpl: Mock): MemoryEnvironment {
   return {
@@ -299,27 +300,40 @@ describe("memory_metadata realtime mapping", () => {
 describe("memory store realtime", () => {
   const realtimeContext = {
     runtimeUrl: "https://runtime.example.com",
-    wsUrl: "wss://gw.example.com/client",
     headers: { Authorization: "Bearer token", "X-Cpki-User-Id": "u1" },
   };
 
+  /** Fresh shared metadata connection per call: the phoenix module is mocked
+   * (see the hoisted `vi.mock("phoenix", ...)` above), so this connects
+   * through `phoenix.sockets` exactly like the real `CopilotKitCore`-owned
+   * connection would. */
+  function fakeMetadataConnection(joinCode = "jc-1") {
+    return ɵcreateMetadataRealtimeConnection({
+      wsUrl: "wss://gw.example.com/client",
+      fetchSubscription: async () => ({ joinToken: "jt-1", joinCode }),
+    });
+  }
+
   /**
-   * Boots a store, sets context, and lets it fetch credentials so it opens its
-   * own `user_meta:memories:<joinCode>` channel. Returns the connected store.
+   * Boots a store, sets context with a real (mock-phoenix-backed) shared
+   * metadata connection, and lets it join its own
+   * `user_meta:memories:<joinCode>` channel. Returns the connected store.
    */
   async function connectedRealtimeStore() {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+        json: async () => ({ memories: [] }),
       });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = createMemoryStore(memoryEnvironment(fetchMock));
     store.start();
-    store.setContext(realtimeContext);
+    store.setContext({
+      ...realtimeContext,
+      metadata: fakeMetadataConnection(),
+    });
     await flushEffects();
     return store;
   }
@@ -390,10 +404,6 @@ describe("memory store realtime", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
         json: async () => ({
           id: "m1",
           kind: "topical",
@@ -408,7 +418,10 @@ describe("memory store realtime", () => {
 
     const store = createMemoryStore(memoryEnvironment(fetchMock));
     store.start();
-    store.setContext(realtimeContext);
+    store.setContext({
+      ...realtimeContext,
+      metadata: fakeMetadataConnection(),
+    });
     await flushEffects();
 
     // REST create: applied locally from the POST response.
@@ -496,8 +509,8 @@ describe("memory store realtime", () => {
 
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
-      wsUrl: "wss://gw.example.com/client",
       headers: { Authorization: "Bearer token", "X-Cpki-User-Id": "u2" },
+      metadata: fakeMetadataConnection("jc-2"),
     });
     await flushEffects();
 
@@ -522,8 +535,8 @@ describe("memory store realtime", () => {
 
 const sampleContext = {
   runtimeUrl: "https://runtime.example.com",
-  wsUrl: "wss://gw.example.com/client",
   headers: { Authorization: "Bearer token", "X-Cpki-User-Id": "u1" },
+  metadata: null,
 };
 
 describe("memory store REST snapshot", () => {
@@ -676,11 +689,6 @@ describe("memory store REST snapshot", () => {
           ],
         }),
       })
-      // credentials subscribe POST fires concurrently with the initial list GET
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
-      })
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
@@ -715,8 +723,8 @@ describe("memory store REST snapshot", () => {
     // The promise must resolve only after the re-pull settles.
     await store.refresh();
 
-    // 3 calls: initial list GET + credentials subscribe POST + refresh list GET
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    // 2 calls: initial list GET + refresh list GET
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(store.getState().memories.map((m) => m.id)).toEqual(["m1", "m2"]);
 
     store.stop();
@@ -742,11 +750,6 @@ describe("memory store REST snapshot", () => {
         ok: true,
         json: async () => ({ memories: [] }),
       })
-      // credentials subscribe POST fires concurrently with the initial list GET
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
-      })
       .mockResolvedValueOnce({ ok: false, status: 500 });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -765,12 +768,8 @@ describe("memory store REST snapshot", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
-      // credentials subscribe POST fires concurrently with the initial list GET
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
-      })
-      // Second list pull never settles on its own: the store is stopped first.
+      // The refresh's list pull never settles on its own: the store is
+      // stopped first.
       .mockImplementationOnce(() => new Promise(() => undefined));
     vi.stubGlobal("fetch", fetchMock);
 
@@ -815,10 +814,6 @@ describe("memory store mutations", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
         json: async () => ({ ...userMemory("m1", "hi"), absorbed: false }),
       });
     const store = await connectedStore(fetchMock);
@@ -839,10 +834,6 @@ describe("memory store mutations", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
-      })
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ ...userMemory("m1", "hi"), absorbed: false }),
@@ -869,10 +860,6 @@ describe("memory store mutations", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
         json: async () => ({ ...userMemory("m1", "hi"), absorbed: false }),
       });
     const store = await connectedStore(fetchMock);
@@ -892,10 +879,6 @@ describe("memory store mutations", () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ memories: [userMemory("m1")] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
       })
       .mockResolvedValueOnce({ ok: true });
     const store = await connectedStore(fetchMock);
@@ -918,10 +901,6 @@ describe("memory store mutations", () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ memories: [userMemory("m1", "old")] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -948,10 +927,6 @@ describe("memory store mutations", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
-      })
       .mockResolvedValueOnce({ ok: false, status: 500 });
     const store = await connectedStore(fetchMock);
 
@@ -993,10 +968,6 @@ describe("memory store mutations", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
-      })
       .mockResolvedValueOnce({ ok: false, status: 500 });
     const store = await connectedStore(fetchMock);
 
@@ -1020,33 +991,8 @@ describe("memory store mutations", () => {
   });
 });
 
-it("fetches memory subscribe credentials when context is set", async () => {
-  const fetchMock = vi
-    .fn()
-    .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
-    .mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
-    });
-  vi.stubGlobal("fetch", fetchMock);
-  const store = createMemoryStore(memoryEnvironment(fetchMock));
-  store.start();
-  store.setContext(sampleContext);
-
-  await flushEffects();
-
-  expect(fetchMock).toHaveBeenCalledWith(
-    "https://runtime.example.com/memories/subscribe",
-    expect.objectContaining({ method: "POST" }),
-  );
-  store.stop();
-});
-
 test("snapshot 404 → available: false, error: null, memories: []", async () => {
-  const fetchMock = vi
-    .fn()
-    .mockResolvedValueOnce({ ok: false, status: 404 })
-    .mockResolvedValueOnce({ ok: false, status: 404 });
+  const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 404 });
   vi.stubGlobal("fetch", fetchMock);
 
   const store = createMemoryStore(memoryEnvironment(fetchMock));
@@ -1063,10 +1009,7 @@ test("snapshot 404 → available: false, error: null, memories: []", async () =>
 });
 
 test("snapshot 500 → error not null, available: true", async () => {
-  const fetchMock = vi
-    .fn()
-    .mockResolvedValueOnce({ ok: false, status: 500 })
-    .mockResolvedValueOnce({ ok: false, status: 500 });
+  const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 500 });
   vi.stubGlobal("fetch", fetchMock);
 
   const store = createMemoryStore(memoryEnvironment(fetchMock));
@@ -1084,10 +1027,7 @@ test("snapshot 500 → error not null, available: true", async () => {
 // must take the graceful "not available" path (listUnavailable), not a hard
 // listFailed/error.
 test("snapshot 422 → available: false, error: null, memories: []", async () => {
-  const fetchMock = vi
-    .fn()
-    .mockResolvedValueOnce({ ok: false, status: 422 })
-    .mockResolvedValueOnce({ ok: false, status: 422 });
+  const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 422 });
   vi.stubGlobal("fetch", fetchMock);
 
   const store = createMemoryStore(memoryEnvironment(fetchMock));
@@ -1107,10 +1047,7 @@ test("snapshot 422 → available: false, error: null, memories: []", async () =>
 // must take the graceful listUnavailable path (available:false, error:null), not
 // a hard listFailed/error.
 test("snapshot 501 → available: false, error: null, memories: []", async () => {
-  const fetchMock = vi
-    .fn()
-    .mockResolvedValueOnce({ ok: false, status: 501 })
-    .mockResolvedValueOnce({ ok: false, status: 501 });
+  const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 501 });
   vi.stubGlobal("fetch", fetchMock);
 
   const store = createMemoryStore(memoryEnvironment(fetchMock));
@@ -1131,8 +1068,7 @@ test("snapshot 501 → available: false, error: null, memories: []", async () =>
 test("refresh() against a 404 route resolves (does not hang) and leaves available:false", async () => {
   const fetchMock = vi
     .fn()
-    // initial bootstrap: list + credentials both unavailable
-    .mockResolvedValueOnce({ ok: false, status: 404 })
+    // initial bootstrap: list unavailable
     .mockResolvedValueOnce({ ok: false, status: 404 })
     // refresh's re-pulled list: also unavailable
     .mockResolvedValueOnce({ ok: false, status: 404 });
@@ -1165,12 +1101,8 @@ test("refresh() resolves when a new setContext supersedes it before the fetch se
   let resolveSecondList: ((value: unknown) => void) | undefined;
   const fetchMock = vi
     .fn()
-    // initial bootstrap: list + credentials
+    // initial bootstrap: list
     .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
-    .mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
-    })
     // refresh's re-pulled list: never settles on its own — we drive the
     // supersede before it resolves.
     .mockReturnValueOnce(
@@ -1178,12 +1110,8 @@ test("refresh() resolves when a new setContext supersedes it before the fetch se
         resolveSecondList = resolve;
       }),
     )
-    // the new context's bootstrap (list + credentials)
-    .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
-    .mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ joinToken: "jt-2", joinCode: "jc-2" }),
-    });
+    // the new context's bootstrap (list)
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) });
   vi.stubGlobal("fetch", fetchMock);
 
   const store = createMemoryStore(memoryEnvironment(fetchMock));
@@ -1210,52 +1138,19 @@ test("refresh() resolves when a new setContext supersedes it before the fetch se
   store.stop();
 });
 
-// A credentials (subscribe) 404 is a SILENT degrade: the list route succeeded,
-// so the only correct observable effect is that realtime simply never connects.
-// It must NOT flip `available`/`error` (those are list-driven), must NOT advance
-// `realtimeStatus` past its "connecting" default (the socket effect runs only on
-// credentials SUCCESS), and must NOT log a console.warn. Asserting all three
-// pins the silent-degrade contract so the test can't pass for the wrong reason.
-test("subscribe 404 → silent degrade: list-driven state intact, realtimeStatus default, no warn", async () => {
-  const fetchMock = vi
-    .fn()
-    .mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => ({ memories: [] }),
-    })
-    .mockResolvedValueOnce({ ok: false, status: 404 });
-  vi.stubGlobal("fetch", fetchMock);
-
-  const warnSpy = vi.spyOn(console, "warn");
-
-  const store = createMemoryStore(memoryEnvironment(fetchMock));
-  store.start();
-  store.setContext(sampleContext);
-  await flushEffects();
-
-  // The successful list still drives availability — credentials failure is silent.
-  expect(store.getState().available).toBe(true);
-  expect(store.getState().error).toBeNull();
-  // The socket effect only runs on credentials SUCCESS, so realtimeStatus must
-  // stay at its "connecting" default — it never reaches connected/unavailable.
-  expect(store.getState().realtimeStatus).toBe("connecting");
-  // And nothing is logged.
-  expect(warnSpy).not.toHaveBeenCalled();
-
-  warnSpy.mockRestore();
-  store.stop();
-});
-
-it("setContext stores wsUrl alongside runtimeUrl", () => {
+it("setContext stores the metadata connection alongside runtimeUrl", () => {
   const store = createMemoryStore(memoryEnvironment(vi.fn()));
   store.start();
+  const metadata = ɵcreateMetadataRealtimeConnection({
+    wsUrl: "wss://gw.example.com/client",
+    fetchSubscription: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+  });
   store.setContext({
     runtimeUrl: "https://runtime.example.com",
-    wsUrl: "wss://gw.example.com/client",
     headers: {},
+    metadata,
   });
-  expect(store.getState().context?.wsUrl).toBe("wss://gw.example.com/client");
+  expect(store.getState().context?.metadata).toBe(metadata);
   store.stop();
 });
 
@@ -1359,77 +1254,6 @@ describe("memory mutation session guard and error handling", () => {
     expect(cleared.error).toBeNull();
   });
 
-  // A2: credentials outcomes are a SILENT degrade — `available`/`error` are
-  // driven only by the REST list route, so credentials events must NOT touch
-  // them. Otherwise `available` would be order-dependent on which concurrent
-  // bootstrap (list vs credentials) responds last.
-  test("credentialsUnavailable does not change available (stays list-driven)", () => {
-    const listed = memoryReducer(
-      undefined,
-      memoryRestEvents.listSucceeded({
-        sessionId: 0,
-        memories: [memory("m1")],
-      }),
-    );
-    expect(ɵselectMemoriesAvailable(listed)).toBe(true);
-
-    const next = memoryReducer(
-      listed,
-      memoryRestEvents.credentialsUnavailable({ sessionId: 0 }),
-    );
-
-    expect(ɵselectMemoriesAvailable(next)).toBe(true);
-  });
-
-  test("credentialsFailed does not surface an error (stays list-driven)", () => {
-    const listed = memoryReducer(
-      undefined,
-      memoryRestEvents.listSucceeded({
-        sessionId: 0,
-        memories: [memory("m1")],
-      }),
-    );
-    expect(ɵselectMemoriesError(listed)).toBeNull();
-
-    const next = memoryReducer(
-      listed,
-      memoryRestEvents.credentialsFailed({
-        sessionId: 0,
-        error: new Error("creds boom"),
-      }),
-    );
-
-    expect(ɵselectMemoriesError(next)).toBeNull();
-    expect(ɵselectMemoriesAvailable(next)).toBe(true);
-  });
-
-  // CF1: list succeeds but credentials route is unavailable (404/501) — the
-  // final `available` must not depend on response arrival order. It stays
-  // driven by the list route, so `available` remains true regardless.
-  test("list-succeeds + credentials-unavailable leaves available:true", () => {
-    const listed = memoryReducer(
-      undefined,
-      memoryRestEvents.listSucceeded({
-        sessionId: 0,
-        memories: [memory("m1")],
-      }),
-    );
-
-    const credsThenList = memoryReducer(
-      memoryReducer(
-        listed,
-        memoryRestEvents.credentialsUnavailable({ sessionId: 0 }),
-      ),
-      memoryRestEvents.listSucceeded({
-        sessionId: 0,
-        memories: [memory("m1")],
-      }),
-    );
-
-    expect(ɵselectMemoriesAvailable(credsThenList)).toBe(true);
-    expect(ɵselectMemoriesError(credsThenList)).toBeNull();
-  });
-
   // A4: a successful list proves the route is available.
   test("listSucceeded sets available:true", () => {
     const unavailable = memoryReducer(
@@ -1524,10 +1348,6 @@ describe("memory mutation session guard and error handling", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
         // No retiredId on the response.
         json: async () => ({ ...userMemory("m2", "new") }),
       });
@@ -1553,10 +1373,6 @@ describe("memory mutation session guard and error handling", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
-      })
       .mockResolvedValueOnce({
         ok: true,
         // No `id` on the response.
@@ -1592,10 +1408,6 @@ describe("memory mutation session guard and error handling", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
         // `sourceThreadIds` is missing (effectively non-array / undefined).
         json: async () => ({
           id: "m1",
@@ -1625,10 +1437,6 @@ describe("memory mutation session guard and error handling", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
-      })
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({

--- a/packages/core/src/__tests__/memory.test.ts
+++ b/packages/core/src/__tests__/memory.test.ts
@@ -429,9 +429,11 @@ describe("memory store realtime", () => {
     });
     await flushEffects();
 
-    // Dropped + warned, and the store state is untouched by the bad event.
+    // Dropped + warned (with the offending event's operation + id so the report
+    // is actionable), and the store state is untouched by the bad event.
     expect(warn).toHaveBeenCalledWith(
       "[memory] dropping malformed memory_metadata event",
+      { operation: "created", memoryId: "bad" },
       expect.anything(),
     );
     expect(store.getState().memories).toEqual([]);
@@ -555,8 +557,70 @@ describe("memory store realtime", () => {
     store.stop();
   });
 
+  // SF1: credentials SUCCEED but `getMetadataSocket` returns null (the runtime
+  // is connected without a ws URL, so no shared metadata socket exists). Rather
+  // than silently dropping live updates, the socket effect must warn AND resolve
+  // `realtimeStatus` to "unavailable" so the live indicator doesn't hang at
+  // "connecting". The REST list is unaffected.
+  it("warns and flips realtimeStatus to 'unavailable' when the shared socket is null after credentials succeed", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const store = createMemoryStore(memoryEnvironment(fetchMock));
+    store.start();
+    store.setContext({
+      ...realtimeContext,
+      // Connected (credentials succeed) but no shared socket available.
+      getMetadataSocket: () => null,
+    });
+    await flushEffects();
+
+    expect(store.getState().realtimeStatus).toBe("unavailable");
+    expect(warn).toHaveBeenCalledWith(
+      "[memory] realtime unavailable: no shared metadata socket; memories will not receive live updates",
+    );
+    // No socket was opened, and the REST list is intact.
+    expect(phoenix.sockets).toHaveLength(0);
+    expect(store.getState().memories).toEqual([]);
+    expect(store.getState().available).toBe(true);
+    expect(store.getState().error).toBeNull();
+
+    warn.mockRestore();
+    store.stop();
+  });
+
   it("resets realtimeStatus to 'connecting' on contextChanged", async () => {
-    const store = await connectedRealtimeStore();
+    // URL-routed fetch so BOTH the initial and the re-context bootstraps get a
+    // valid list + credentials response. (A sequenced mock would exhaust after
+    // the first context and the re-context's credentials fetch would fail, which
+    // now — per SF2 — resolves realtimeStatus to "unavailable", masking the
+    // contextChanged reset this test is asserting.)
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      const href = String(url);
+      if (href.endsWith("/memories/subscribe")) {
+        return {
+          ok: true,
+          json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+        } as Response;
+      }
+      return { ok: true, json: async () => ({ memories: [] }) } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const store = createMemoryStore(memoryEnvironment(fetchMock));
+    store.start();
+    store.setContext({
+      ...realtimeContext,
+      getMetadataSocket: makeGetMetadataSocket(),
+    });
+    await flushEffects();
 
     memoryChannel().triggerJoin("ok");
     await flushEffects();
@@ -1281,14 +1345,14 @@ test("refresh() resolves when a new setContext supersedes it before the fetch se
   store.stop();
 });
 
-// A credentials (subscribe) 404 is a SILENT degrade: the list route succeeded,
-// so the only correct observable effect is that realtime simply never connects.
-// It must NOT flip `available`/`error` (those are list-driven), must NOT advance
-// `realtimeStatus` past its "connecting" default (the socket effect runs only on
-// credentials SUCCESS), and must NOT log a console.warn (404 is the expected
-// "not configured" case, distinct from a genuine failure). Asserting all three
-// pins the silent-degrade contract so the test can't pass for the wrong reason.
-test("subscribe 404 → silent degrade: list-driven state intact, realtimeStatus default, no warn", async () => {
+// A credentials (subscribe) 404 is a SILENT degrade for the LIST: the list route
+// succeeded, so it must NOT flip `available`/`error` (those are list-driven) and
+// must NOT log a console.warn (404 is the expected "not configured" case,
+// distinct from a genuine failure). But it MUST resolve `realtimeStatus` to
+// "unavailable" — otherwise the live indicator hangs at "connecting" forever
+// when credentials never succeed. Asserting all of these pins the contract so
+// the test can't pass for the wrong reason.
+test("subscribe 404 → silent list degrade (no warn), but realtimeStatus resolves to unavailable", async () => {
   const fetchMock = vi
     .fn()
     .mockResolvedValueOnce({
@@ -1309,10 +1373,10 @@ test("subscribe 404 → silent degrade: list-driven state intact, realtimeStatus
   // The successful list still drives availability — credentials failure is silent.
   expect(store.getState().available).toBe(true);
   expect(store.getState().error).toBeNull();
-  // The socket effect only runs on credentials SUCCESS, so realtimeStatus must
-  // stay at its "connecting" default — it never reaches connected/unavailable.
-  expect(store.getState().realtimeStatus).toBe("connecting");
-  // And nothing is logged for a not-configured (404) route.
+  // `credentialsUnavailable` resolves the realtime status so the UI stops
+  // showing a perpetual "connecting" live indicator.
+  expect(store.getState().realtimeStatus).toBe("unavailable");
+  // And nothing is logged for a not-configured (404) route — it stays warn-silent.
   expect(warnSpy).not.toHaveBeenCalled();
 
   warnSpy.mockRestore();
@@ -1343,9 +1407,9 @@ test("subscribe fetch failure → silent degrade for list, but warns that realti
   expect(store.getState().memories).toEqual([]);
   expect(store.getState().available).toBe(true);
   expect(store.getState().error).toBeNull();
-  // Credentials failed, so the socket effect never runs and realtimeStatus stays
-  // at its "connecting" default rather than advancing.
-  expect(store.getState().realtimeStatus).toBe("connecting");
+  // Credentials failed permanently, so `realtimeStatus` resolves to
+  // "unavailable" rather than hanging at its "connecting" default.
+  expect(store.getState().realtimeStatus).toBe("unavailable");
   // B5: the degrade is visible.
   expect(warn).toHaveBeenCalledWith(
     "[memory] realtime subscribe failed; memories will not receive live updates",

--- a/packages/core/src/__tests__/memory.test.ts
+++ b/packages/core/src/__tests__/memory.test.ts
@@ -3,10 +3,13 @@ import type { Mock } from "vitest";
 import type { MockChannel } from "./test-utils";
 import { MockSocket } from "./test-utils";
 
-// Phoenix mock harness: the memory store opens its OWN socket/channel, so the
-// `phoenix` module is mocked here (mirrors `thread-store-user-meta.test.ts`).
-// `phoenix.sockets` captures every socket the store constructs so tests can
-// reach the joined channel and `serverPush` events onto it.
+// Phoenix mock harness: the memory store joins its channel off the SHARED
+// metadata socket (mirrors `thread-store-user-meta.test.ts`). The tests build a
+// real `ɵcreateMetadataSocket` per store (memoized so repeated
+// `getMetadataSocket(joinToken)` calls return the SAME shared socket), which
+// connects through the mocked `phoenix` module below. `phoenix.sockets`
+// captures every socket constructed so tests can reach the joined channel and
+// `serverPush` events onto it.
 const phoenix = vi.hoisted(() => ({
   sockets: [] as MockSocket[],
 }));
@@ -39,7 +42,11 @@ import type {
   ɵMemoryEnvironment as MemoryEnvironment,
 } from "../memory";
 import { MemoryError } from "../memory-errors";
-import { ɵcreateMetadataRealtimeConnection } from "../core/metadata-realtime";
+import {
+  ɵcreateMetadataSocket,
+  ɵMETADATA_MAX_SOCKET_RETRIES,
+} from "../core/metadata-realtime";
+import type { ɵMetadataSocket } from "../core/metadata-realtime";
 
 function memoryEnvironment(fetchImpl: Mock): MemoryEnvironment {
   return {
@@ -47,7 +54,26 @@ function memoryEnvironment(fetchImpl: Mock): MemoryEnvironment {
   };
 }
 
-/** Returns the channel the store joined (its own `user_meta:memories:*` topic). */
+/**
+ * Builds a `getMetadataSocket` for a context that lazily creates ONE real
+ * (mock-phoenix-backed) shared metadata socket and memoizes it, so repeated
+ * `getMetadataSocket(joinToken)` calls return the SAME socket — exactly like the
+ * single `CopilotKitCore`-owned socket the store joins in production.
+ */
+function makeGetMetadataSocket(): (joinToken: string) => ɵMetadataSocket {
+  let socket: ɵMetadataSocket | null = null;
+  return (joinToken: string) => {
+    if (!socket) {
+      socket = ɵcreateMetadataSocket({
+        wsUrl: "wss://gw/client",
+        joinToken,
+      }).socket;
+    }
+    return socket;
+  };
+}
+
+/** Returns the channel the store joined (its `user_meta:memories:*` topic). */
 function memoryChannel(): MockChannel {
   const channel = phoenix.sockets[0]?.channels[0];
   if (!channel) {
@@ -303,34 +329,26 @@ describe("memory store realtime", () => {
     headers: { Authorization: "Bearer token", "X-Cpki-User-Id": "u1" },
   };
 
-  /** Fresh shared metadata connection per call: the phoenix module is mocked
-   * (see the hoisted `vi.mock("phoenix", ...)` above), so this connects
-   * through `phoenix.sockets` exactly like the real `CopilotKitCore`-owned
-   * connection would. */
-  function fakeMetadataConnection(joinCode = "jc-1") {
-    return ɵcreateMetadataRealtimeConnection({
-      wsUrl: "wss://gw.example.com/client",
-      fetchSubscription: async () => ({ joinToken: "jt-1", joinCode }),
-    });
-  }
-
   /**
-   * Boots a store, sets context with a real (mock-phoenix-backed) shared
-   * metadata connection, and lets it join its own
-   * `user_meta:memories:<joinCode>` channel. Returns the connected store.
+   * Boots a store, sets context, and lets it fetch credentials so it joins its
+   * `user_meta:memories:<joinCode>` channel off the shared metadata socket.
+   * Returns the connected store.
    */
   async function connectedRealtimeStore() {
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ memories: [] }),
-    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+      });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = createMemoryStore(memoryEnvironment(fetchMock));
     store.start();
     store.setContext({
       ...realtimeContext,
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
     });
     await flushEffects();
     return store;
@@ -341,7 +359,7 @@ describe("memory store realtime", () => {
     vi.unstubAllGlobals();
   });
 
-  it("delivers memory_metadata over its own user_meta:memories channel (no thread store)", async () => {
+  it("delivers memory_metadata over its user_meta:memories channel", async () => {
     const store = await connectedRealtimeStore();
 
     // The store must actually JOIN the channel — `ɵphoenixChannel$` only creates
@@ -392,6 +410,41 @@ describe("memory store realtime", () => {
     store.stop();
   });
 
+  // B4: a single malformed `memory_metadata` payload must be dropped + warned
+  // and must NOT tear down the realtime stream — a subsequent VALID event still
+  // applies. `mapMemoryMetadataEvent` -> `toMemory` throws on a `created` event
+  // whose `memory` is missing; without the per-event guard that error would kill
+  // the channel stream and stop all future deltas.
+  it("drops a malformed memory_metadata event without killing the stream", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const store = await connectedRealtimeStore();
+
+    // Malformed `created`: no `memory` field, so `toMemory(event.memory)` throws.
+    memoryChannel().serverPush("memory_metadata", {
+      operation: "created",
+      memoryId: "bad",
+      organizationId: "org-1",
+      projectId: "proj-1",
+      occurredAt: "2026-01-01T00:00:00Z",
+    });
+    await flushEffects();
+
+    // Dropped + warned, and the store state is untouched by the bad event.
+    expect(warn).toHaveBeenCalledWith(
+      "[memory] dropping malformed memory_metadata event",
+      expect.anything(),
+    );
+    expect(store.getState().memories).toEqual([]);
+
+    // The stream survived: a subsequent valid event still applies.
+    memoryChannel().serverPush("memory_metadata", createdEvent("m1"));
+    await flushEffects();
+    expect(store.getState().memories.map((m) => m.id)).toEqual(["m1"]);
+
+    warn.mockRestore();
+    store.stop();
+  });
+
   // Upsert-by-id idempotency across transports: a memory created over REST
   // (addMemory's POST response is applied locally) followed by the realtime
   // `created` echo for the SAME id must NOT produce a duplicate row. The store's
@@ -400,6 +453,10 @@ describe("memory store realtime", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+      })
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
@@ -418,7 +475,7 @@ describe("memory store realtime", () => {
     store.start();
     store.setContext({
       ...realtimeContext,
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
     });
     await flushEffects();
 
@@ -457,7 +514,7 @@ describe("memory store realtime", () => {
     store.stop();
   });
 
-  it("flips realtimeStatus to 'unavailable' when the socket exhausts its retries", async () => {
+  it("flips realtimeStatus to 'unavailable' when the shared socket exhausts its retries", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const store = await connectedRealtimeStore();
     const socket = phoenix.sockets[0];
@@ -465,10 +522,10 @@ describe("memory store realtime", () => {
       throw new Error("expected a phoenix socket to exist");
     }
 
-    // Drive MAX_SOCKET_RETRIES (5) consecutive transport errors with no
-    // intervening `open`, exhausting `ɵobservePhoenixSocketHealth$` so the
-    // realtime stream gives up.
-    for (let i = 0; i < 5; i += 1) {
+    // Drive ɵMETADATA_MAX_SOCKET_RETRIES consecutive transport errors with no
+    // intervening `open`, exhausting the SHARED socket's health monitor so its
+    // `socketFatal$` fires and the store surfaces `realtimeUnavailable`.
+    for (let i = 0; i < ɵMETADATA_MAX_SOCKET_RETRIES; i += 1) {
       socket.triggerError();
     }
     await flushEffects();
@@ -508,7 +565,7 @@ describe("memory store realtime", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: { Authorization: "Bearer token", "X-Cpki-User-Id": "u2" },
-      metadata: fakeMetadataConnection("jc-2"),
+      getMetadataSocket: makeGetMetadataSocket(),
     });
     await flushEffects();
 
@@ -529,52 +586,15 @@ describe("memory store realtime", () => {
 
     expect(store.getState().realtimeStatus).toBe("connecting");
   });
-
-  it("subscribe failure -> silent degrade (store stays alive, realtimeStatus 'unavailable')", async () => {
-    // The shared metadata connection's `fetchSubscription` rejects (a transient
-    // non-2xx on `/threads/subscribe`), which errors `joinCode$`. Micro-redux is
-    // fail-fast, so without the socket effect's `catchError` this would kill the
-    // whole store — `getState()` would throw and the REST list/mutations would
-    // break. It must instead degrade silently: the store stays alive, the REST
-    // list & `available`/`error` are untouched, and only `realtimeStatus` flips.
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ memories: [] }),
-    });
-    vi.stubGlobal("fetch", fetchMock);
-
-    const store = createMemoryStore(memoryEnvironment(fetchMock));
-    store.start();
-    store.setContext({
-      ...realtimeContext,
-      metadata: ɵcreateMetadataRealtimeConnection({
-        wsUrl: "wss://gw/client",
-        fetchSubscription: async () => {
-          throw new Error("boom");
-        },
-      }),
-    });
-    await flushEffects();
-
-    // The store did NOT crash: getState()/select still work.
-    expect(() => store.getState()).not.toThrow();
-    // The REST-backed list settled from its own fetch, unaffected by realtime.
-    expect(store.getState().memories).toEqual([]);
-    expect(store.getState().available).toBe(true);
-    expect(store.getState().error).toBeNull();
-    // Realtime degraded to unavailable rather than getting stuck "connecting".
-    expect(store.getState().realtimeStatus).toBe("unavailable");
-
-    warn.mockRestore();
-    store.stop();
-  });
 });
 
 const sampleContext = {
   runtimeUrl: "https://runtime.example.com",
   headers: { Authorization: "Bearer token", "X-Cpki-User-Id": "u1" },
-  metadata: null,
+  // The REST/mutation suites don't exercise realtime; a socket-less context (no
+  // shared socket available) keeps the socket effect a silent no-op (returns
+  // EMPTY) while the credentials fetch still fires.
+  getMetadataSocket: () => null,
 };
 
 describe("memory store REST snapshot", () => {
@@ -727,6 +747,11 @@ describe("memory store REST snapshot", () => {
           ],
         }),
       })
+      // credentials subscribe POST fires concurrently with the initial list GET
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+      })
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
@@ -761,8 +786,8 @@ describe("memory store REST snapshot", () => {
     // The promise must resolve only after the re-pull settles.
     await store.refresh();
 
-    // 2 calls: initial list GET + refresh list GET
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // 3 calls: initial list GET + credentials subscribe POST + refresh list GET
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(store.getState().memories.map((m) => m.id)).toEqual(["m1", "m2"]);
 
     store.stop();
@@ -788,6 +813,11 @@ describe("memory store REST snapshot", () => {
         ok: true,
         json: async () => ({ memories: [] }),
       })
+      // credentials subscribe POST fires concurrently with the initial list GET
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+      })
       .mockResolvedValueOnce({ ok: false, status: 500 });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -806,8 +836,12 @@ describe("memory store REST snapshot", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
-      // The refresh's list pull never settles on its own: the store is
-      // stopped first.
+      // credentials subscribe POST fires concurrently with the initial list GET
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+      })
+      // Second list pull never settles on its own: the store is stopped first.
       .mockImplementationOnce(() => new Promise(() => undefined));
     vi.stubGlobal("fetch", fetchMock);
 
@@ -852,6 +886,10 @@ describe("memory store mutations", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: async () => ({ ...userMemory("m1", "hi"), absorbed: false }),
       });
     const store = await connectedStore(fetchMock);
@@ -872,6 +910,10 @@ describe("memory store mutations", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+      })
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ ...userMemory("m1", "hi"), absorbed: false }),
@@ -898,6 +940,10 @@ describe("memory store mutations", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: async () => ({ ...userMemory("m1", "hi"), absorbed: false }),
       });
     const store = await connectedStore(fetchMock);
@@ -917,6 +963,10 @@ describe("memory store mutations", () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ memories: [userMemory("m1")] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
       })
       .mockResolvedValueOnce({ ok: true });
     const store = await connectedStore(fetchMock);
@@ -939,6 +989,10 @@ describe("memory store mutations", () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ memories: [userMemory("m1", "old")] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -965,6 +1019,10 @@ describe("memory store mutations", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+      })
       .mockResolvedValueOnce({ ok: false, status: 500 });
     const store = await connectedStore(fetchMock);
 
@@ -1006,6 +1064,10 @@ describe("memory store mutations", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+      })
       .mockResolvedValueOnce({ ok: false, status: 500 });
     const store = await connectedStore(fetchMock);
 
@@ -1029,8 +1091,33 @@ describe("memory store mutations", () => {
   });
 });
 
+it("fetches memory subscribe credentials when context is set", async () => {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+    });
+  vi.stubGlobal("fetch", fetchMock);
+  const store = createMemoryStore(memoryEnvironment(fetchMock));
+  store.start();
+  store.setContext(sampleContext);
+
+  await flushEffects();
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    "https://runtime.example.com/memories/subscribe",
+    expect.objectContaining({ method: "POST" }),
+  );
+  store.stop();
+});
+
 test("snapshot 404 → available: false, error: null, memories: []", async () => {
-  const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 404 });
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce({ ok: false, status: 404 })
+    .mockResolvedValueOnce({ ok: false, status: 404 });
   vi.stubGlobal("fetch", fetchMock);
 
   const store = createMemoryStore(memoryEnvironment(fetchMock));
@@ -1047,7 +1134,10 @@ test("snapshot 404 → available: false, error: null, memories: []", async () =>
 });
 
 test("snapshot 500 → error not null, available: true", async () => {
-  const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 500 });
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce({ ok: false, status: 500 })
+    .mockResolvedValueOnce({ ok: false, status: 500 });
   vi.stubGlobal("fetch", fetchMock);
 
   const store = createMemoryStore(memoryEnvironment(fetchMock));
@@ -1065,7 +1155,10 @@ test("snapshot 500 → error not null, available: true", async () => {
 // must take the graceful "not available" path (listUnavailable), not a hard
 // listFailed/error.
 test("snapshot 422 → available: false, error: null, memories: []", async () => {
-  const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 422 });
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce({ ok: false, status: 422 })
+    .mockResolvedValueOnce({ ok: false, status: 422 });
   vi.stubGlobal("fetch", fetchMock);
 
   const store = createMemoryStore(memoryEnvironment(fetchMock));
@@ -1085,7 +1178,10 @@ test("snapshot 422 → available: false, error: null, memories: []", async () =>
 // must take the graceful listUnavailable path (available:false, error:null), not
 // a hard listFailed/error.
 test("snapshot 501 → available: false, error: null, memories: []", async () => {
-  const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 501 });
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce({ ok: false, status: 501 })
+    .mockResolvedValueOnce({ ok: false, status: 501 });
   vi.stubGlobal("fetch", fetchMock);
 
   const store = createMemoryStore(memoryEnvironment(fetchMock));
@@ -1106,7 +1202,8 @@ test("snapshot 501 → available: false, error: null, memories: []", async () =>
 test("refresh() against a 404 route resolves (does not hang) and leaves available:false", async () => {
   const fetchMock = vi
     .fn()
-    // initial bootstrap: list unavailable
+    // initial bootstrap: list + credentials both unavailable
+    .mockResolvedValueOnce({ ok: false, status: 404 })
     .mockResolvedValueOnce({ ok: false, status: 404 })
     // refresh's re-pulled list: also unavailable
     .mockResolvedValueOnce({ ok: false, status: 404 });
@@ -1139,8 +1236,12 @@ test("refresh() resolves when a new setContext supersedes it before the fetch se
   let resolveSecondList: ((value: unknown) => void) | undefined;
   const fetchMock = vi
     .fn()
-    // initial bootstrap: list
+    // initial bootstrap: list + credentials
     .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+    })
     // refresh's re-pulled list: never settles on its own — we drive the
     // supersede before it resolves.
     .mockReturnValueOnce(
@@ -1148,8 +1249,12 @@ test("refresh() resolves when a new setContext supersedes it before the fetch se
         resolveSecondList = resolve;
       }),
     )
-    // the new context's bootstrap (list)
-    .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) });
+    // the new context's bootstrap (list + credentials)
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ joinToken: "jt-2", joinCode: "jc-2" }),
+    });
   vi.stubGlobal("fetch", fetchMock);
 
   const store = createMemoryStore(memoryEnvironment(fetchMock));
@@ -1176,19 +1281,91 @@ test("refresh() resolves when a new setContext supersedes it before the fetch se
   store.stop();
 });
 
-it("setContext stores the metadata connection alongside runtimeUrl", () => {
+// A credentials (subscribe) 404 is a SILENT degrade: the list route succeeded,
+// so the only correct observable effect is that realtime simply never connects.
+// It must NOT flip `available`/`error` (those are list-driven), must NOT advance
+// `realtimeStatus` past its "connecting" default (the socket effect runs only on
+// credentials SUCCESS), and must NOT log a console.warn (404 is the expected
+// "not configured" case, distinct from a genuine failure). Asserting all three
+// pins the silent-degrade contract so the test can't pass for the wrong reason.
+test("subscribe 404 → silent degrade: list-driven state intact, realtimeStatus default, no warn", async () => {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ memories: [] }),
+    })
+    .mockResolvedValueOnce({ ok: false, status: 404 });
+  vi.stubGlobal("fetch", fetchMock);
+
+  const warnSpy = vi.spyOn(console, "warn");
+
+  const store = createMemoryStore(memoryEnvironment(fetchMock));
+  store.start();
+  store.setContext(sampleContext);
+  await flushEffects();
+
+  // The successful list still drives availability — credentials failure is silent.
+  expect(store.getState().available).toBe(true);
+  expect(store.getState().error).toBeNull();
+  // The socket effect only runs on credentials SUCCESS, so realtimeStatus must
+  // stay at its "connecting" default — it never reaches connected/unavailable.
+  expect(store.getState().realtimeStatus).toBe("connecting");
+  // And nothing is logged for a not-configured (404) route.
+  expect(warnSpy).not.toHaveBeenCalled();
+
+  warnSpy.mockRestore();
+  store.stop();
+});
+
+// B5: a genuine credentials-fetch FAILURE (non-404, e.g. a transient 500) also
+// degrades realtime silently for `available`/`error`/the list — but unlike a 404
+// it is now VISIBLE via a single console.warn so operators can see that live
+// updates won't arrive. The store must stay fully alive.
+test("subscribe fetch failure → silent degrade for list, but warns that realtime won't update", async () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
+    // credentials subscribe POST fails with a transient 500 (not a 404)
+    .mockResolvedValueOnce({ ok: false, status: 500 });
+  vi.stubGlobal("fetch", fetchMock);
+
+  const store = createMemoryStore(memoryEnvironment(fetchMock));
+  store.start();
+  store.setContext(sampleContext);
+  await flushEffects();
+
+  // The store did NOT crash: getState()/select still work.
+  expect(() => store.getState()).not.toThrow();
+  // The REST-backed list settled from its own fetch, unaffected by realtime.
+  expect(store.getState().memories).toEqual([]);
+  expect(store.getState().available).toBe(true);
+  expect(store.getState().error).toBeNull();
+  // Credentials failed, so the socket effect never runs and realtimeStatus stays
+  // at its "connecting" default rather than advancing.
+  expect(store.getState().realtimeStatus).toBe("connecting");
+  // B5: the degrade is visible.
+  expect(warn).toHaveBeenCalledWith(
+    "[memory] realtime subscribe failed; memories will not receive live updates",
+    expect.anything(),
+  );
+
+  warn.mockRestore();
+  store.stop();
+});
+
+it("setContext stores the getMetadataSocket resolver alongside runtimeUrl", () => {
   const store = createMemoryStore(memoryEnvironment(vi.fn()));
   store.start();
-  const metadata = ɵcreateMetadataRealtimeConnection({
-    wsUrl: "wss://gw.example.com/client",
-    fetchSubscription: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
-  });
+  const getMetadataSocket = makeGetMetadataSocket();
   store.setContext({
     runtimeUrl: "https://runtime.example.com",
     headers: {},
-    metadata,
+    getMetadataSocket,
   });
-  expect(store.getState().context?.metadata).toBe(metadata);
+  expect(store.getState().context?.getMetadataSocket).toBe(getMetadataSocket);
   store.stop();
 });
 
@@ -1292,6 +1469,77 @@ describe("memory mutation session guard and error handling", () => {
     expect(cleared.error).toBeNull();
   });
 
+  // A2: credentials outcomes are a SILENT degrade — `available`/`error` are
+  // driven only by the REST list route, so credentials events must NOT touch
+  // them. Otherwise `available` would be order-dependent on which concurrent
+  // bootstrap (list vs credentials) responds last.
+  test("credentialsUnavailable does not change available (stays list-driven)", () => {
+    const listed = memoryReducer(
+      undefined,
+      memoryRestEvents.listSucceeded({
+        sessionId: 0,
+        memories: [memory("m1")],
+      }),
+    );
+    expect(ɵselectMemoriesAvailable(listed)).toBe(true);
+
+    const next = memoryReducer(
+      listed,
+      memoryRestEvents.credentialsUnavailable({ sessionId: 0 }),
+    );
+
+    expect(ɵselectMemoriesAvailable(next)).toBe(true);
+  });
+
+  test("credentialsFailed does not surface an error (stays list-driven)", () => {
+    const listed = memoryReducer(
+      undefined,
+      memoryRestEvents.listSucceeded({
+        sessionId: 0,
+        memories: [memory("m1")],
+      }),
+    );
+    expect(ɵselectMemoriesError(listed)).toBeNull();
+
+    const next = memoryReducer(
+      listed,
+      memoryRestEvents.credentialsFailed({
+        sessionId: 0,
+        error: new Error("creds boom"),
+      }),
+    );
+
+    expect(ɵselectMemoriesError(next)).toBeNull();
+    expect(ɵselectMemoriesAvailable(next)).toBe(true);
+  });
+
+  // CF1: list succeeds but credentials route is unavailable (404/501) — the
+  // final `available` must not depend on response arrival order. It stays
+  // driven by the list route, so `available` remains true regardless.
+  test("list-succeeds + credentials-unavailable leaves available:true", () => {
+    const listed = memoryReducer(
+      undefined,
+      memoryRestEvents.listSucceeded({
+        sessionId: 0,
+        memories: [memory("m1")],
+      }),
+    );
+
+    const credsThenList = memoryReducer(
+      memoryReducer(
+        listed,
+        memoryRestEvents.credentialsUnavailable({ sessionId: 0 }),
+      ),
+      memoryRestEvents.listSucceeded({
+        sessionId: 0,
+        memories: [memory("m1")],
+      }),
+    );
+
+    expect(ɵselectMemoriesAvailable(credsThenList)).toBe(true);
+    expect(ɵselectMemoriesError(credsThenList)).toBeNull();
+  });
+
   // A4: a successful list proves the route is available.
   test("listSucceeded sets available:true", () => {
     const unavailable = memoryReducer(
@@ -1386,6 +1634,10 @@ describe("memory mutation session guard and error handling", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         // No retiredId on the response.
         json: async () => ({ ...userMemory("m2", "new") }),
       });
@@ -1411,6 +1663,10 @@ describe("memory mutation session guard and error handling", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+      })
       .mockResolvedValueOnce({
         ok: true,
         // No `id` on the response.
@@ -1446,6 +1702,10 @@ describe("memory mutation session guard and error handling", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         // `sourceThreadIds` is missing (effectively non-array / undefined).
         json: async () => ({
           id: "m1",
@@ -1475,6 +1735,10 @@ describe("memory mutation session guard and error handling", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+      })
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({

--- a/packages/core/src/__tests__/threads.test.ts
+++ b/packages/core/src/__tests__/threads.test.ts
@@ -3,6 +3,13 @@ import type { Mock } from "vitest";
 import type { MockChannel } from "./test-utils";
 import { MockSocket } from "./test-utils";
 
+// Phoenix mock harness: the thread store joins its channel off the SHARED
+// metadata socket (mirrors `memory.test.ts`). The tests build a real
+// `ɵcreateMetadataSocket` per context (memoized so repeated
+// `getMetadataSocket(joinToken)` calls return the SAME shared socket), which
+// connects through the mocked `phoenix` module below. `phoenix.sockets`
+// captures every socket constructed so tests can reach the joined channel and
+// `serverPush` events onto it.
 const phoenix = vi.hoisted(() => ({
   sockets: [] as MockSocket[],
 }));
@@ -25,7 +32,8 @@ const {
   ɵselectIsFetchingNextPage,
   ɵselectIsMutating,
 } = await import("../threads");
-import { ɵcreateMetadataRealtimeConnection } from "../core/metadata-realtime";
+import { ɵcreateMetadataSocket } from "../core/metadata-realtime";
+import type { ɵMetadataSocket } from "../core/metadata-realtime";
 
 type ThreadRecord = import("../threads").ɵThread;
 
@@ -37,15 +45,24 @@ const flushEffects = async (): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, 0));
 };
 
-/** Fresh shared metadata connection per call: the phoenix module is mocked
- * (see the hoisted `vi.mock("phoenix", ...)` above), so this connects
- * through `phoenix.sockets` exactly like the real `CopilotKitCore`-owned
- * connection would. Mirrors `memory.test.ts`'s `fakeMetadataConnection`. */
-function fakeMetadataConnection(joinCode = "jc-1") {
-  return ɵcreateMetadataRealtimeConnection({
-    wsUrl: "wss://gw.example.com/client",
-    fetchSubscription: async () => ({ joinToken: "jt-1", joinCode }),
-  });
+/**
+ * Builds a `getMetadataSocket` for a context that lazily creates ONE real
+ * (mock-phoenix-backed) shared metadata socket and memoizes it, so repeated
+ * `getMetadataSocket(joinToken)` calls return the SAME socket — exactly like the
+ * single `CopilotKitCore`-owned socket the store joins in production. Mirrors
+ * `memory.test.ts`'s `makeGetMetadataSocket`.
+ */
+function makeGetMetadataSocket(): (joinToken: string) => ɵMetadataSocket {
+  let socket: ɵMetadataSocket | null = null;
+  return (joinToken: string) => {
+    if (!socket) {
+      socket = ɵcreateMetadataSocket({
+        wsUrl: "wss://gw/client",
+        joinToken,
+      }).socket;
+    }
+    return socket;
+  };
 }
 
 const sampleThreads: ThreadRecord[] = [
@@ -108,13 +125,21 @@ describe("thread store", () => {
   });
 
   it("bootstraps threads and sorts them by updatedAt descending", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        threads: [sampleThreads[0], sampleThreads[1]],
-        joinCode: "jc-1",
-      }),
-    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          threads: [sampleThreads[0], sampleThreads[1]],
+          joinCode: "jc-1",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          joinToken: "jt-1",
+        }),
+      });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -123,8 +148,8 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: { Authorization: "Bearer token" },
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
-      metadata: fakeMetadataConnection(),
     });
 
     await flushEffects();
@@ -133,53 +158,18 @@ describe("thread store", () => {
       "https://runtime.example.com/threads?agentId=agent-1",
       expect.objectContaining({ method: "GET" }),
     );
+    // The store fetches its OWN realtime join-token from /threads/subscribe.
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://runtime.example.com/threads/subscribe",
+      expect.objectContaining({ method: "POST" }),
+    );
     expect(ɵselectThreads(store.getState()).map((thread) => thread.id)).toEqual(
       ["thread-2", "thread-1"],
     );
     expect(ɵselectThreadsIsLoading(store.getState())).toBe(false);
+    // One SHARED socket, joined on the list response's join code.
     expect(phoenix.sockets).toHaveLength(1);
     expect(getChannel().topic).toBe("user_meta:jc-1");
-  });
-
-  it("subscribe failure does not crash the store", async () => {
-    // The shared metadata connection's `fetchSubscription` rejects (a transient
-    // non-2xx on `/threads/subscribe`), which errors `joinCode$`. Micro-redux is
-    // fail-fast, so without the socket effect's `catchError` this would kill the
-    // whole store — `getState()` would throw and the REST list/pagination would
-    // break. Threads has no realtime-status signal, so it must degrade silently:
-    // the store stays alive and the list is intact.
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ threads: [sampleThreads[0]], joinCode: "jc-1" }),
-    });
-    vi.stubGlobal("fetch", fetchMock);
-
-    const store = ɵcreateThreadStore(createEnvironment(fetchMock));
-    stores.push(store);
-    store.start();
-    store.setContext({
-      runtimeUrl: "https://runtime.example.com",
-      headers: { Authorization: "Bearer token" },
-      agentId: "agent-1",
-      metadata: ɵcreateMetadataRealtimeConnection({
-        wsUrl: "wss://gw/client",
-        fetchSubscription: async () => {
-          throw new Error("boom");
-        },
-      }),
-    });
-
-    await flushEffects();
-
-    // The store did NOT crash: getState()/selectors still work and the
-    // REST-backed list settled from its own fetch, unaffected by the realtime
-    // subscribe failure.
-    expect(() => store.getState()).not.toThrow();
-    expect(ɵselectThreads(store.getState()).map((thread) => thread.id)).toEqual(
-      ["thread-1"],
-    );
-    expect(ɵselectThreadsIsLoading(store.getState())).toBe(false);
-    expect(ɵselectThreadsError(store.getState())).toBeNull();
   });
 
   it("uses the thread environment fetch instead of global fetch", async () => {
@@ -201,8 +191,8 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
-      metadata: null,
     });
 
     await flushEffects();
@@ -218,13 +208,21 @@ describe("thread store", () => {
   });
 
   it("upserts realtime thread metadata without refetching", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        threads: sampleThreads,
-        joinCode: "jc-1",
-      }),
-    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          threads: sampleThreads,
+          joinCode: "jc-1",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          joinToken: "jt-1",
+        }),
+      });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -233,8 +231,8 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
-      metadata: fakeMetadataConnection(),
     });
 
     await flushEffects();
@@ -255,7 +253,8 @@ describe("thread store", () => {
 
     await flushEffects();
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Two fetches: the list GET and the /threads/subscribe POST — no refetch.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(ɵselectThreads(store.getState())[0]).toMatchObject({
       id: "thread-1",
       name: "Renamed Thread",
@@ -263,13 +262,21 @@ describe("thread store", () => {
   });
 
   it("applies realtime events without client-side user filtering", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        threads: sampleThreads,
-        joinCode: "jc-1",
-      }),
-    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          threads: sampleThreads,
+          joinCode: "jc-1",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          joinToken: "jt-1",
+        }),
+      });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -278,7 +285,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
     });
 
@@ -299,13 +306,21 @@ describe("thread store", () => {
   });
 
   it("notifies run-activity subscribers without mutating the thread list", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        threads: sampleThreads,
-        joinCode: "jc-1",
-      }),
-    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          threads: sampleThreads,
+          joinCode: "jc-1",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          joinToken: "jt-1",
+        }),
+      });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -319,7 +334,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
     });
 
@@ -377,6 +392,12 @@ describe("thread store", () => {
           ],
           joinCode: "jc-2",
         }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          joinToken: "jt-2",
+        }),
       });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -386,7 +407,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
     });
     await flushEffects();
@@ -394,7 +415,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-2",
     });
 
@@ -407,7 +428,7 @@ describe("thread store", () => {
 
     await flushEffects();
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(ɵselectThreads(store.getState())).toEqual([
       expect.objectContaining({
         id: "thread-next",
@@ -426,6 +447,12 @@ describe("thread store", () => {
           joinCode: "jc-1",
         }),
       })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          joinToken: "jt-1",
+        }),
+      })
       .mockResolvedValue({
         ok: true,
         json: async () => ({}),
@@ -438,7 +465,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: { Authorization: "Bearer token" },
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
     });
 
@@ -448,7 +475,8 @@ describe("thread store", () => {
     await store.archiveThread("thread-2");
     await store.deleteThread("thread-2");
 
-    const renameCall = getFetchCall(fetchMock, 1);
+    // Fetch 0 = list GET, fetch 1 = /threads/subscribe POST, then the mutations.
+    const renameCall = getFetchCall(fetchMock, 2);
     expect(renameCall[0]).toBe("https://runtime.example.com/threads/thread-1");
     expect(renameCall[1]).toMatchObject({ method: "PATCH" });
     expect(JSON.parse(renameCall[1].body)).toMatchObject({
@@ -456,7 +484,7 @@ describe("thread store", () => {
       name: "Renamed",
     });
 
-    const archiveCall = getFetchCall(fetchMock, 2);
+    const archiveCall = getFetchCall(fetchMock, 3);
     expect(archiveCall[0]).toBe(
       "https://runtime.example.com/threads/thread-2/archive",
     );
@@ -464,7 +492,7 @@ describe("thread store", () => {
       agentId: "agent-1",
     });
 
-    const deleteCall = getFetchCall(fetchMock, 3);
+    const deleteCall = getFetchCall(fetchMock, 4);
     expect(deleteCall[0]).toBe("https://runtime.example.com/threads/thread-2");
     expect(deleteCall[1]).toMatchObject({ method: "DELETE" });
     expect(JSON.parse(deleteCall[1].body)).toMatchObject({
@@ -482,6 +510,12 @@ describe("thread store", () => {
           joinCode: "jc-1",
         }),
       })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          joinToken: "jt-1",
+        }),
+      })
       .mockResolvedValue({
         ok: true,
         json: async () => ({}),
@@ -494,7 +528,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: { Authorization: "Bearer token" },
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
     });
 
@@ -502,7 +536,7 @@ describe("thread store", () => {
 
     await store.unarchiveThread("thread-2");
 
-    const unarchiveCall = getFetchCall(fetchMock, 1);
+    const unarchiveCall = getFetchCall(fetchMock, 2);
     expect(unarchiveCall[0]).toBe(
       "https://runtime.example.com/threads/thread-2",
     );
@@ -526,7 +560,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
     });
 
@@ -536,10 +570,16 @@ describe("thread store", () => {
   });
 
   it("passes includeArchived=true as a query param when set", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
-    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1" }),
+      });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -548,7 +588,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
       includeArchived: true,
     });
@@ -562,10 +602,16 @@ describe("thread store", () => {
   });
 
   it("passes limit as a query param when set", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
-    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1" }),
+      });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -574,7 +620,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
       limit: 10,
     });
@@ -610,6 +656,10 @@ describe("thread store", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => ({ joinToken: "jt-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: async () => ({
           threads: [page2Thread],
           nextCursor: null,
@@ -623,7 +673,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
       limit: 2,
     });
@@ -646,10 +696,16 @@ describe("thread store", () => {
   });
 
   it("removes thread on archived WS event when includeArchived is false", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
-    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1" }),
+      });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -658,7 +714,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
     });
 
@@ -682,10 +738,16 @@ describe("thread store", () => {
   });
 
   it("keeps thread on archived WS event when includeArchived is true", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
-    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1" }),
+      });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -694,7 +756,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
       includeArchived: true,
     });
@@ -765,10 +827,16 @@ describe("thread store", () => {
       },
     ];
 
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ threads: mixedThreads, joinCode: "jc-1" }),
-    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ threads: mixedThreads, joinCode: "jc-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1" }),
+      });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -777,7 +845,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
       includeArchived: true,
     });
@@ -800,6 +868,10 @@ describe("thread store", () => {
         ok: true,
         json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
       })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1" }),
+      })
       .mockImplementationOnce(
         () => new Promise((resolve) => (resolveDelete = resolve)),
       );
@@ -811,7 +883,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
     });
     await flushEffects();
@@ -842,6 +914,10 @@ describe("thread store", () => {
         ok: true,
         json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
       })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1" }),
+      })
       .mockResolvedValueOnce({ ok: false, status: 500 });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -851,7 +927,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
     });
     await flushEffects();
@@ -875,6 +951,10 @@ describe("thread store", () => {
         ok: true,
         json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
       })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1" }),
+      })
       .mockResolvedValueOnce({ ok: false, status: 500 });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -884,7 +964,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
     });
     await flushEffects();
@@ -909,6 +989,10 @@ describe("thread store", () => {
         ok: true,
         json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
       })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1" }),
+      })
       .mockResolvedValueOnce({ ok: false, status: 500 });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -922,7 +1006,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
     });
     await flushEffects();
@@ -944,7 +1028,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
     });
     await flushEffects();
@@ -967,6 +1051,10 @@ describe("thread store", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => ({ joinToken: "jt-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: async () => ({ threads: [sampleThreads[0]] }),
       });
     vi.stubGlobal("fetch", fetchMock);
@@ -977,7 +1065,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
     });
     await flushEffects();
@@ -997,16 +1085,20 @@ describe("thread store", () => {
     let resolveDelete: (value: unknown) => void = () => {};
     const fetchMock = vi
       .fn()
-      // session 1: initial list
+      // session 1: initial list + subscribe
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1" }),
       })
       // session 1: the DELETE — left pending until after the context switches
       .mockImplementationOnce(
         () => new Promise((resolve) => (resolveDelete = resolve)),
       )
-      // session 2 (after contextChanged): new list
+      // session 2 (after contextChanged): new list + subscribe
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
@@ -1020,6 +1112,10 @@ describe("thread store", () => {
           ],
           joinCode: "jc-2",
         }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-2" }),
       });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -1033,7 +1129,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
     });
     await flushEffects();
@@ -1045,7 +1141,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-2",
     });
     await flushEffects();
@@ -1066,9 +1162,18 @@ describe("thread store", () => {
 
   it("isolates selector memo caches across concurrent stores", async () => {
     // Route a single stub by request host so both concurrent stores share the
-    // same deterministic environment fetch while receiving distinct lists.
+    // same deterministic environment fetch while receiving distinct lists. The
+    // /threads/subscribe POST is answered with a join token; the stores use a
+    // socket-less resolver (`() => null`) so the socket effect is a no-op —
+    // this test only exercises REST + selector isolation.
     const routedFetch = vi.fn(async (url: string | URL | Request) => {
       const href = String(url);
+      if (href.endsWith("/threads/subscribe")) {
+        return {
+          ok: true,
+          json: async () => ({ joinToken: "jt" }),
+        } as Response;
+      }
       const id = href.includes("a.example.com") ? "thread-a" : "thread-b";
       return {
         ok: true,
@@ -1091,13 +1196,13 @@ describe("thread store", () => {
       runtimeUrl: "https://a.example.com",
       headers: {},
       agentId: "agent-1",
-      metadata: null,
+      getMetadataSocket: () => null,
     });
     storeB.setContext({
       runtimeUrl: "https://b.example.com",
       headers: {},
       agentId: "agent-1",
-      metadata: null,
+      getMetadataSocket: () => null,
     });
     await flushEffects();
 
@@ -1123,10 +1228,16 @@ describe("thread store", () => {
 
   it("warns and keeps the list on a realtime channel join failure", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
-    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1" }),
+      });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -1135,7 +1246,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      metadata: fakeMetadataConnection(),
+      getMetadataSocket: makeGetMetadataSocket(),
       agentId: "agent-1",
     });
     await flushEffects();
@@ -1152,6 +1263,153 @@ describe("thread store", () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("realtime"));
 
     warnSpy.mockRestore();
+  });
+
+  it("keeps the list and warns (B5) when the realtime subscribe fetch fails", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
+      })
+      // The realtime join-token fetch (runs after the list) fails.
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const store = ɵcreateThreadStore(createEnvironment(fetchMock));
+    stores.push(store);
+    store.start();
+    store.setContext({
+      runtimeUrl: "https://runtime.example.com",
+      headers: {},
+      getMetadataSocket: makeGetMetadataSocket(),
+      agentId: "agent-1",
+    });
+    await flushEffects();
+
+    // Silent degrade for the list: the realtime credential fetch ran after a
+    // successful list, so the already-loaded list survives, no hard list error
+    // is set, the store did not crash, and no socket was opened.
+    expect(() => store.getState()).not.toThrow();
+    expect(ɵselectThreads(store.getState()).length).toBeGreaterThan(0);
+    expect(ɵselectThreadsError(store.getState())).toBeNull();
+    expect(phoenix.sockets).toHaveLength(0);
+    // B5: the degrade is VISIBLE via a single, specific console.warn.
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[threads] realtime subscribe failed; the thread list will not receive live updates",
+      expect.anything(),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("retries realtime metadata credentials after a failed credential fetch", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-2" }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const store = ɵcreateThreadStore(createEnvironment(fetchMock));
+    stores.push(store);
+    store.start();
+    store.setContext({
+      runtimeUrl: "https://runtime.example.com",
+      headers: {},
+      getMetadataSocket: makeGetMetadataSocket(),
+      agentId: "agent-1",
+    });
+    await flushEffects();
+
+    store.refetchThreads();
+    await flushEffects();
+
+    expect(
+      fetchMock.mock.calls
+        .map(([url]) => String(url))
+        .filter((url) => url.endsWith("/threads/subscribe")),
+    ).toEqual([
+      "https://runtime.example.com/threads/subscribe",
+      "https://runtime.example.com/threads/subscribe",
+    ]);
+    // Only the successful (second) credential fetch resolves a join token, so
+    // exactly one shared socket is opened and joined on jc-1.
+    expect(phoenix.sockets).toHaveLength(1);
+    expect(getChannel().topic).toBe("user_meta:jc-1");
+
+    warnSpy.mockRestore();
+  });
+
+  it("re-joins on the shared socket when a refetch rotates the join code", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ threads: sampleThreads, joinCode: "jc-2" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-2" }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const store = ɵcreateThreadStore(createEnvironment(fetchMock));
+    stores.push(store);
+    store.start();
+    store.setContext({
+      runtimeUrl: "https://runtime.example.com",
+      headers: {},
+      getMetadataSocket: makeGetMetadataSocket(),
+      agentId: "agent-1",
+    });
+    await flushEffects();
+
+    store.refetchThreads();
+    await flushEffects();
+
+    expect(
+      fetchMock.mock.calls
+        .map(([url]) => String(url))
+        .filter((url) => url.endsWith("/threads/subscribe")),
+    ).toEqual([
+      "https://runtime.example.com/threads/subscribe",
+      "https://runtime.example.com/threads/subscribe",
+    ]);
+    // The metadata socket is SHARED (owned by CopilotKitCore), so a rotated join
+    // code re-joins a new channel off the SAME socket rather than opening a
+    // second one.
+    expect(phoenix.sockets).toHaveLength(1);
+    expect(phoenix.sockets[0]?.channels[0]?.topic).toBe("user_meta:jc-1");
+    expect(phoenix.sockets[0]?.channels[1]?.topic).toBe("user_meta:jc-2");
   });
 
   it("exposes a stable empty server snapshot for SSR", () => {

--- a/packages/core/src/__tests__/threads.test.ts
+++ b/packages/core/src/__tests__/threads.test.ts
@@ -1308,6 +1308,51 @@ describe("thread store", () => {
     warnSpy.mockRestore();
   });
 
+  // SF1: the list loads and `/threads/subscribe` SUCCEEDS, but
+  // `getMetadataSocket` returns null (the runtime is connected without a ws URL;
+  // the threads context is not gated on wsUrl). Because this null is reached
+  // AFTER a successful subscribe, silently dropping live updates would leave no
+  // signal — so the socket effect must warn. The (already fetched) list survives
+  // intact, no socket is opened, and the store does not crash.
+  it("warns and keeps the list when getMetadataSocket returns null after a successful subscribe", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1" }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const store = ɵcreateThreadStore(createEnvironment(fetchMock));
+    stores.push(store);
+    store.start();
+    store.setContext({
+      runtimeUrl: "https://runtime.example.com",
+      headers: {},
+      // Connected (subscribe succeeds) but no shared socket available.
+      getMetadataSocket: () => null,
+      agentId: "agent-1",
+    });
+    await flushEffects();
+
+    // The list is intact, the store did not crash, and no socket was opened.
+    expect(() => store.getState()).not.toThrow();
+    expect(ɵselectThreads(store.getState())).toHaveLength(2);
+    expect(ɵselectThreadsError(store.getState())).toBeNull();
+    expect(phoenix.sockets).toHaveLength(0);
+    // SF1: the missing shared socket is surfaced (not silently dropped).
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[threads] realtime unavailable: no shared metadata socket (runtime connected without a ws URL?); the thread list will not receive live updates",
+    );
+
+    warnSpy.mockRestore();
+  });
+
   it("retries realtime metadata credentials after a failed credential fetch", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const fetchMock = vi

--- a/packages/core/src/__tests__/threads.test.ts
+++ b/packages/core/src/__tests__/threads.test.ts
@@ -25,6 +25,7 @@ const {
   ɵselectIsFetchingNextPage,
   ɵselectIsMutating,
 } = await import("../threads");
+import { ɵcreateMetadataRealtimeConnection } from "../core/metadata-realtime";
 
 type ThreadRecord = import("../threads").ɵThread;
 
@@ -35,6 +36,17 @@ const flushEffects = async (): Promise<void> => {
   await Promise.resolve();
   await new Promise((resolve) => setTimeout(resolve, 0));
 };
+
+/** Fresh shared metadata connection per call: the phoenix module is mocked
+ * (see the hoisted `vi.mock("phoenix", ...)` above), so this connects
+ * through `phoenix.sockets` exactly like the real `CopilotKitCore`-owned
+ * connection would. Mirrors `memory.test.ts`'s `fakeMetadataConnection`. */
+function fakeMetadataConnection(joinCode = "jc-1") {
+  return ɵcreateMetadataRealtimeConnection({
+    wsUrl: "wss://gw.example.com/client",
+    fetchSubscription: async () => ({ joinToken: "jt-1", joinCode }),
+  });
+}
 
 const sampleThreads: ThreadRecord[] = [
   {
@@ -96,21 +108,13 @@ describe("thread store", () => {
   });
 
   it("bootstraps threads and sorts them by updatedAt descending", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          threads: [sampleThreads[0], sampleThreads[1]],
-          joinCode: "jc-1",
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          joinToken: "jt-1",
-        }),
-      });
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        threads: [sampleThreads[0], sampleThreads[1]],
+        joinCode: "jc-1",
+      }),
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -119,8 +123,8 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: { Authorization: "Bearer token" },
-      wsUrl: "ws://localhost:4000/client",
       agentId: "agent-1",
+      metadata: fakeMetadataConnection(),
     });
 
     await flushEffects();
@@ -128,10 +132,6 @@ describe("thread store", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       "https://runtime.example.com/threads?agentId=agent-1",
       expect.objectContaining({ method: "GET" }),
-    );
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://runtime.example.com/threads/subscribe",
-      expect.objectContaining({ method: "POST" }),
     );
     expect(ɵselectThreads(store.getState()).map((thread) => thread.id)).toEqual(
       ["thread-2", "thread-1"],
@@ -161,6 +161,7 @@ describe("thread store", () => {
       runtimeUrl: "https://runtime.example.com",
       headers: {},
       agentId: "agent-1",
+      metadata: null,
     });
 
     await flushEffects();
@@ -176,21 +177,13 @@ describe("thread store", () => {
   });
 
   it("upserts realtime thread metadata without refetching", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          threads: sampleThreads,
-          joinCode: "jc-1",
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          joinToken: "jt-1",
-        }),
-      });
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        threads: sampleThreads,
+        joinCode: "jc-1",
+      }),
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -199,8 +192,8 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
       agentId: "agent-1",
+      metadata: fakeMetadataConnection(),
     });
 
     await flushEffects();
@@ -221,7 +214,7 @@ describe("thread store", () => {
 
     await flushEffects();
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(ɵselectThreads(store.getState())[0]).toMatchObject({
       id: "thread-1",
       name: "Renamed Thread",
@@ -229,21 +222,13 @@ describe("thread store", () => {
   });
 
   it("applies realtime events without client-side user filtering", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          threads: sampleThreads,
-          joinCode: "jc-1",
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          joinToken: "jt-1",
-        }),
-      });
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        threads: sampleThreads,
+        joinCode: "jc-1",
+      }),
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -252,7 +237,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
     });
 
@@ -273,21 +258,13 @@ describe("thread store", () => {
   });
 
   it("notifies run-activity subscribers without mutating the thread list", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          threads: sampleThreads,
-          joinCode: "jc-1",
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          joinToken: "jt-1",
-        }),
-      });
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        threads: sampleThreads,
+        joinCode: "jc-1",
+      }),
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -301,7 +278,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
     });
 
@@ -359,12 +336,6 @@ describe("thread store", () => {
           ],
           joinCode: "jc-2",
         }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          joinToken: "jt-2",
-        }),
       });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -374,7 +345,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
     });
     await flushEffects();
@@ -382,7 +353,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-2",
     });
 
@@ -395,7 +366,7 @@ describe("thread store", () => {
 
     await flushEffects();
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(ɵselectThreads(store.getState())).toEqual([
       expect.objectContaining({
         id: "thread-next",
@@ -414,12 +385,6 @@ describe("thread store", () => {
           joinCode: "jc-1",
         }),
       })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          joinToken: "jt-1",
-        }),
-      })
       .mockResolvedValue({
         ok: true,
         json: async () => ({}),
@@ -432,7 +397,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: { Authorization: "Bearer token" },
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
     });
 
@@ -442,7 +407,7 @@ describe("thread store", () => {
     await store.archiveThread("thread-2");
     await store.deleteThread("thread-2");
 
-    const renameCall = getFetchCall(fetchMock, 2);
+    const renameCall = getFetchCall(fetchMock, 1);
     expect(renameCall[0]).toBe("https://runtime.example.com/threads/thread-1");
     expect(renameCall[1]).toMatchObject({ method: "PATCH" });
     expect(JSON.parse(renameCall[1].body)).toMatchObject({
@@ -450,7 +415,7 @@ describe("thread store", () => {
       name: "Renamed",
     });
 
-    const archiveCall = getFetchCall(fetchMock, 3);
+    const archiveCall = getFetchCall(fetchMock, 2);
     expect(archiveCall[0]).toBe(
       "https://runtime.example.com/threads/thread-2/archive",
     );
@@ -458,7 +423,7 @@ describe("thread store", () => {
       agentId: "agent-1",
     });
 
-    const deleteCall = getFetchCall(fetchMock, 4);
+    const deleteCall = getFetchCall(fetchMock, 3);
     expect(deleteCall[0]).toBe("https://runtime.example.com/threads/thread-2");
     expect(deleteCall[1]).toMatchObject({ method: "DELETE" });
     expect(JSON.parse(deleteCall[1].body)).toMatchObject({
@@ -476,12 +441,6 @@ describe("thread store", () => {
           joinCode: "jc-1",
         }),
       })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          joinToken: "jt-1",
-        }),
-      })
       .mockResolvedValue({
         ok: true,
         json: async () => ({}),
@@ -494,7 +453,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: { Authorization: "Bearer token" },
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
     });
 
@@ -502,7 +461,7 @@ describe("thread store", () => {
 
     await store.unarchiveThread("thread-2");
 
-    const unarchiveCall = getFetchCall(fetchMock, 2);
+    const unarchiveCall = getFetchCall(fetchMock, 1);
     expect(unarchiveCall[0]).toBe(
       "https://runtime.example.com/threads/thread-2",
     );
@@ -526,7 +485,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
     });
 
@@ -536,16 +495,10 @@ describe("thread store", () => {
   });
 
   it("passes includeArchived=true as a query param when set", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1" }),
-      });
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -554,7 +507,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
       includeArchived: true,
     });
@@ -568,16 +521,10 @@ describe("thread store", () => {
   });
 
   it("passes limit as a query param when set", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1" }),
-      });
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -586,7 +533,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
       limit: 10,
     });
@@ -622,10 +569,6 @@ describe("thread store", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ joinToken: "jt-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
         json: async () => ({
           threads: [page2Thread],
           nextCursor: null,
@@ -639,7 +582,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
       limit: 2,
     });
@@ -662,16 +605,10 @@ describe("thread store", () => {
   });
 
   it("removes thread on archived WS event when includeArchived is false", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1" }),
-      });
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -680,7 +617,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
     });
 
@@ -704,16 +641,10 @@ describe("thread store", () => {
   });
 
   it("keeps thread on archived WS event when includeArchived is true", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1" }),
-      });
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -722,7 +653,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
       includeArchived: true,
     });
@@ -793,16 +724,10 @@ describe("thread store", () => {
       },
     ];
 
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ threads: mixedThreads, joinCode: "jc-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1" }),
-      });
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ threads: mixedThreads, joinCode: "jc-1" }),
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -811,7 +736,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
       includeArchived: true,
     });
@@ -834,10 +759,6 @@ describe("thread store", () => {
         ok: true,
         json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
       })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1" }),
-      })
       .mockImplementationOnce(
         () => new Promise((resolve) => (resolveDelete = resolve)),
       );
@@ -849,7 +770,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
     });
     await flushEffects();
@@ -880,10 +801,6 @@ describe("thread store", () => {
         ok: true,
         json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
       })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1" }),
-      })
       .mockResolvedValueOnce({ ok: false, status: 500 });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -893,7 +810,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
     });
     await flushEffects();
@@ -917,10 +834,6 @@ describe("thread store", () => {
         ok: true,
         json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
       })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1" }),
-      })
       .mockResolvedValueOnce({ ok: false, status: 500 });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -930,7 +843,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
     });
     await flushEffects();
@@ -955,10 +868,6 @@ describe("thread store", () => {
         ok: true,
         json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
       })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1" }),
-      })
       .mockResolvedValueOnce({ ok: false, status: 500 });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -972,7 +881,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
     });
     await flushEffects();
@@ -994,7 +903,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
     });
     await flushEffects();
@@ -1017,10 +926,6 @@ describe("thread store", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ joinToken: "jt-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
         json: async () => ({ threads: [sampleThreads[0]] }),
       });
     vi.stubGlobal("fetch", fetchMock);
@@ -1031,7 +936,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
     });
     await flushEffects();
@@ -1051,20 +956,16 @@ describe("thread store", () => {
     let resolveDelete: (value: unknown) => void = () => {};
     const fetchMock = vi
       .fn()
-      // session 1: initial list + subscribe
+      // session 1: initial list
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1" }),
       })
       // session 1: the DELETE — left pending until after the context switches
       .mockImplementationOnce(
         () => new Promise((resolve) => (resolveDelete = resolve)),
       )
-      // session 2 (after contextChanged): new list + subscribe
+      // session 2 (after contextChanged): new list
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
@@ -1078,10 +979,6 @@ describe("thread store", () => {
           ],
           joinCode: "jc-2",
         }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-2" }),
       });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -1095,7 +992,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
     });
     await flushEffects();
@@ -1107,7 +1004,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-2",
     });
     await flushEffects();
@@ -1153,11 +1050,13 @@ describe("thread store", () => {
       runtimeUrl: "https://a.example.com",
       headers: {},
       agentId: "agent-1",
+      metadata: null,
     });
     storeB.setContext({
       runtimeUrl: "https://b.example.com",
       headers: {},
       agentId: "agent-1",
+      metadata: null,
     });
     await flushEffects();
 
@@ -1183,16 +1082,10 @@ describe("thread store", () => {
 
   it("warns and keeps the list on a realtime channel join failure", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1" }),
-      });
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
@@ -1201,7 +1094,7 @@ describe("thread store", () => {
     store.setContext({
       runtimeUrl: "https://runtime.example.com",
       headers: {},
-      wsUrl: "ws://localhost:4000/client",
+      metadata: fakeMetadataConnection(),
       agentId: "agent-1",
     });
     await flushEffects();
@@ -1218,142 +1111,6 @@ describe("thread store", () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("realtime"));
 
     warnSpy.mockRestore();
-  });
-
-  it("keeps the list and warns when the realtime metadata-credentials fetch fails", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
-      })
-      // The realtime join-token fetch (runs after the list) fails.
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        json: async () => ({}),
-      });
-    vi.stubGlobal("fetch", fetchMock);
-
-    const store = ɵcreateThreadStore(createEnvironment(fetchMock));
-    stores.push(store);
-    store.start();
-    store.setContext({
-      runtimeUrl: "https://runtime.example.com",
-      headers: {},
-      wsUrl: "ws://localhost:4000/client",
-      agentId: "agent-1",
-    });
-    await flushEffects();
-
-    // Non-fatal: the realtime credential fetch ran after a successful list, so
-    // the already-loaded list survives, no hard list error is set, but the
-    // failure is surfaced as a diagnostic warning.
-    expect(ɵselectThreads(store.getState()).length).toBeGreaterThan(0);
-    expect(ɵselectThreadsError(store.getState())).toBeNull();
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("realtime"));
-
-    warnSpy.mockRestore();
-  });
-
-  it("retries realtime metadata credentials after a failed credential fetch", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        json: async () => ({}),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-2" }),
-      });
-    vi.stubGlobal("fetch", fetchMock);
-
-    const store = ɵcreateThreadStore(createEnvironment(fetchMock));
-    stores.push(store);
-    store.start();
-    store.setContext({
-      runtimeUrl: "https://runtime.example.com",
-      headers: {},
-      wsUrl: "ws://localhost:4000/client",
-      agentId: "agent-1",
-    });
-    await flushEffects();
-
-    store.refetchThreads();
-    await flushEffects();
-
-    expect(
-      fetchMock.mock.calls
-        .map(([url]) => String(url))
-        .filter((url) => url.endsWith("/threads/subscribe")),
-    ).toEqual([
-      "https://runtime.example.com/threads/subscribe",
-      "https://runtime.example.com/threads/subscribe",
-    ]);
-    expect(phoenix.sockets).toHaveLength(1);
-    expect(getChannel().topic).toBe("user_meta:jc-1");
-
-    warnSpy.mockRestore();
-  });
-
-  it("refreshes realtime metadata credentials when a refetch rotates the join code", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ threads: sampleThreads, joinCode: "jc-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ threads: sampleThreads, joinCode: "jc-2" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ joinToken: "jt-2" }),
-      });
-    vi.stubGlobal("fetch", fetchMock);
-
-    const store = ɵcreateThreadStore(createEnvironment(fetchMock));
-    stores.push(store);
-    store.start();
-    store.setContext({
-      runtimeUrl: "https://runtime.example.com",
-      headers: {},
-      wsUrl: "ws://localhost:4000/client",
-      agentId: "agent-1",
-    });
-    await flushEffects();
-
-    store.refetchThreads();
-    await flushEffects();
-
-    expect(
-      fetchMock.mock.calls
-        .map(([url]) => String(url))
-        .filter((url) => url.endsWith("/threads/subscribe")),
-    ).toEqual([
-      "https://runtime.example.com/threads/subscribe",
-      "https://runtime.example.com/threads/subscribe",
-    ]);
-    expect(phoenix.sockets).toHaveLength(2);
-    expect(phoenix.sockets[0]?.channels[0]?.topic).toBe("user_meta:jc-1");
-    expect(phoenix.sockets[1]?.channels[0]?.topic).toBe("user_meta:jc-2");
   });
 
   it("exposes a stable empty server snapshot for SSR", () => {

--- a/packages/core/src/__tests__/threads.test.ts
+++ b/packages/core/src/__tests__/threads.test.ts
@@ -141,6 +141,47 @@ describe("thread store", () => {
     expect(getChannel().topic).toBe("user_meta:jc-1");
   });
 
+  it("subscribe failure does not crash the store", async () => {
+    // The shared metadata connection's `fetchSubscription` rejects (a transient
+    // non-2xx on `/threads/subscribe`), which errors `joinCode$`. Micro-redux is
+    // fail-fast, so without the socket effect's `catchError` this would kill the
+    // whole store — `getState()` would throw and the REST list/pagination would
+    // break. Threads has no realtime-status signal, so it must degrade silently:
+    // the store stays alive and the list is intact.
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ threads: [sampleThreads[0]], joinCode: "jc-1" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const store = ɵcreateThreadStore(createEnvironment(fetchMock));
+    stores.push(store);
+    store.start();
+    store.setContext({
+      runtimeUrl: "https://runtime.example.com",
+      headers: { Authorization: "Bearer token" },
+      agentId: "agent-1",
+      metadata: ɵcreateMetadataRealtimeConnection({
+        wsUrl: "wss://gw/client",
+        fetchSubscription: async () => {
+          throw new Error("boom");
+        },
+      }),
+    });
+
+    await flushEffects();
+
+    // The store did NOT crash: getState()/selectors still work and the
+    // REST-backed list settled from its own fetch, unaffected by the realtime
+    // subscribe failure.
+    expect(() => store.getState()).not.toThrow();
+    expect(ɵselectThreads(store.getState()).map((thread) => thread.id)).toEqual(
+      ["thread-1"],
+    );
+    expect(ɵselectThreadsIsLoading(store.getState())).toBe(false);
+    expect(ɵselectThreadsError(store.getState())).toBeNull();
+  });
+
   it("uses the thread environment fetch instead of global fetch", async () => {
     const globalFetch = vi.fn(async () => {
       throw new Error("global fetch should not be used");

--- a/packages/core/src/core/__tests__/metadata-realtime.test.ts
+++ b/packages/core/src/core/__tests__/metadata-realtime.test.ts
@@ -1,0 +1,72 @@
+import { firstValueFrom } from "rxjs";
+import { describe, expect, it, vi } from "vitest";
+import { MockSocket } from "../../__tests__/test-utils";
+
+// Phoenix mock harness: `ɵcreateMetadataRealtimeConnection` opens a real
+// Phoenix socket via `ɵphoenixSocket$`, so the `phoenix` module is mocked
+// here (mirrors `memory.test.ts` / `threads.test.ts`). `phoenix.sockets`
+// captures every socket constructed so tests could inspect it if needed.
+const phoenix = vi.hoisted(() => ({
+  sockets: [] as MockSocket[],
+}));
+
+vi.mock("phoenix", () => ({
+  Socket: class extends MockSocket {
+    constructor(url = "", opts: Record<string, any> = {}) {
+      super(url, opts);
+      phoenix.sockets.push(this);
+    }
+  },
+}));
+
+// Must come after vi.mock so phoenix is mocked when the module is loaded.
+const { ɵcreateMetadataRealtimeConnection } =
+  await import("../metadata-realtime");
+
+describe("ɵcreateMetadataRealtimeConnection", () => {
+  it("does not fetch the subscription or connect until socket$ is subscribed", () => {
+    const fetchSubscription = vi
+      .fn()
+      .mockResolvedValue({ joinToken: "t", joinCode: "R" });
+    const conn = ɵcreateMetadataRealtimeConnection({
+      wsUrl: "wss://gw/client",
+      fetchSubscription,
+    });
+
+    expect(fetchSubscription).not.toHaveBeenCalled(); // lazy
+
+    conn.dispose();
+  });
+
+  it("fetches the subscription exactly once across multiple socket$ subscribers", async () => {
+    const fetchSubscription = vi
+      .fn()
+      .mockResolvedValue({ joinToken: "t", joinCode: "R" });
+    const conn = ɵcreateMetadataRealtimeConnection({
+      wsUrl: "wss://gw/client",
+      fetchSubscription,
+    });
+
+    const s1 = conn.socket$.subscribe();
+    const s2 = conn.socket$.subscribe();
+    await Promise.resolve();
+
+    expect(fetchSubscription).toHaveBeenCalledTimes(1); // shared, refCount:false
+
+    s1.unsubscribe();
+    s2.unsubscribe();
+    conn.dispose();
+  });
+
+  it("replays joinCode R to late subscribers", async () => {
+    const conn = ɵcreateMetadataRealtimeConnection({
+      wsUrl: "wss://gw/client",
+      fetchSubscription: async () => ({ joinToken: "t", joinCode: "R" }),
+    });
+
+    await firstValueFrom(conn.socket$); // trigger the fetch
+    await expect(firstValueFrom(conn.joinCode$)).resolves.toBe("R");
+
+    conn.dispose();
+  });
+});

--- a/packages/core/src/core/__tests__/metadata-realtime.test.ts
+++ b/packages/core/src/core/__tests__/metadata-realtime.test.ts
@@ -1,11 +1,11 @@
 import { firstValueFrom } from "rxjs";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MockSocket } from "../../__tests__/test-utils";
 
-// Phoenix mock harness: `ɵcreateMetadataRealtimeConnection` opens a real
-// Phoenix socket via `ɵphoenixSocket$`, so the `phoenix` module is mocked
-// here (mirrors `memory.test.ts` / `threads.test.ts`). `phoenix.sockets`
-// captures every socket constructed so tests could inspect it if needed.
+// Phoenix mock harness: `ɵcreateMetadataSocket` opens a real Phoenix socket
+// via `ɵphoenixSocket$`, so the `phoenix` module is mocked here (mirrors
+// `memory.test.ts` / `threads.test.ts`). `phoenix.sockets` captures every
+// socket constructed so tests can inspect it.
 const phoenix = vi.hoisted(() => ({
   sockets: [] as MockSocket[],
 }));
@@ -20,53 +20,110 @@ vi.mock("phoenix", () => ({
 }));
 
 // Must come after vi.mock so phoenix is mocked when the module is loaded.
-const { ɵcreateMetadataRealtimeConnection } =
+const { ɵcreateMetadataSocket, ɵMETADATA_MAX_SOCKET_RETRIES } =
   await import("../metadata-realtime");
 
-describe("ɵcreateMetadataRealtimeConnection", () => {
-  it("does not fetch the subscription or connect until socket$ is subscribed", () => {
-    const fetchSubscription = vi
-      .fn()
-      .mockResolvedValue({ joinToken: "t", joinCode: "R" });
-    const conn = ɵcreateMetadataRealtimeConnection({
-      wsUrl: "wss://gw/client",
-      fetchSubscription,
-    });
-
-    expect(fetchSubscription).not.toHaveBeenCalled(); // lazy
-
-    conn.dispose();
+describe("ɵcreateMetadataSocket", () => {
+  beforeEach(() => {
+    phoenix.sockets.length = 0;
   });
 
-  it("fetches the subscription exactly once across multiple socket$ subscribers", async () => {
-    const fetchSubscription = vi
-      .fn()
-      .mockResolvedValue({ joinToken: "t", joinCode: "R" });
-    const conn = ɵcreateMetadataRealtimeConnection({
+  it("opens exactly one socket with the given join_token and yields the session", async () => {
+    const handle = ɵcreateMetadataSocket({
       wsUrl: "wss://gw/client",
-      fetchSubscription,
+      joinToken: "tok-123",
     });
 
-    const s1 = conn.socket$.subscribe();
-    const s2 = conn.socket$.subscribe();
+    const session = await firstValueFrom(handle.socket.socket$);
+
+    expect(phoenix.sockets).toHaveLength(1);
+    expect(phoenix.sockets[0]!.opts.params).toEqual({ join_token: "tok-123" });
+    expect(session.socket).toBe(phoenix.sockets[0]);
+
+    handle.dispose();
+  });
+
+  it("shares ONE socket across multiple socket$ subscribers", async () => {
+    const handle = ɵcreateMetadataSocket({
+      wsUrl: "wss://gw/client",
+      joinToken: "tok-123",
+    });
+
+    const s1 = handle.socket.socket$.subscribe();
+    const s2 = handle.socket.socket$.subscribe();
     await Promise.resolve();
 
-    expect(fetchSubscription).toHaveBeenCalledTimes(1); // shared, refCount:false
+    expect(phoenix.sockets).toHaveLength(1); // shared, refCount:false
 
     s1.unsubscribe();
     s2.unsubscribe();
-    conn.dispose();
+    handle.dispose();
   });
 
-  it("replays joinCode R to late subscribers", async () => {
-    const conn = ɵcreateMetadataRealtimeConnection({
+  it("dispose() disconnects the socket and is idempotent", () => {
+    const handle = ɵcreateMetadataSocket({
       wsUrl: "wss://gw/client",
-      fetchSubscription: async () => ({ joinToken: "t", joinCode: "R" }),
+      joinToken: "tok-123",
     });
 
-    await firstValueFrom(conn.socket$); // trigger the fetch
-    await expect(firstValueFrom(conn.joinCode$)).resolves.toBe("R");
+    // Eager health subscribe opens the socket at creation.
+    expect(phoenix.sockets).toHaveLength(1);
+    expect(phoenix.sockets[0]!.disconnected).toBe(false);
 
-    conn.dispose();
+    handle.dispose();
+    expect(phoenix.sockets[0]!.disconnected).toBe(true);
+
+    // Idempotent: a second call must not throw.
+    expect(() => handle.dispose()).not.toThrow();
+  });
+
+  it("socketFatal$ emits once after MAX consecutive errors and replays to late subscribers", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const handle = ɵcreateMetadataSocket({
+      wsUrl: "wss://gw/client",
+      joinToken: "tok-123",
+    });
+
+    let earlyEmissions = 0;
+    const early = handle.socket.socketFatal$.subscribe(() => {
+      earlyEmissions += 1;
+    });
+
+    const socket = phoenix.sockets[0];
+    if (!socket) {
+      throw new Error("expected a phoenix socket to exist");
+    }
+
+    // Drive MAX consecutive transport errors with no intervening `open`.
+    for (let i = 0; i < ɵMETADATA_MAX_SOCKET_RETRIES; i += 1) {
+      socket.triggerError();
+    }
+
+    expect(earlyEmissions).toBe(1);
+    expect(warn).toHaveBeenCalled();
+
+    // A LATE subscriber (after the give-up) still receives it via the latch.
+    await expect(
+      firstValueFrom(handle.socket.socketFatal$),
+    ).resolves.toBeUndefined();
+
+    early.unsubscribe();
+    warn.mockRestore();
+    handle.dispose();
+  });
+
+  it("hands out a consumer view with no dispose (only socket$ and socketFatal$)", () => {
+    const handle = ɵcreateMetadataSocket({
+      wsUrl: "wss://gw/client",
+      joinToken: "tok-123",
+    });
+
+    expect(Object.keys(handle.socket).sort()).toEqual([
+      "socket$",
+      "socketFatal$",
+    ]);
+    expect("dispose" in handle.socket).toBe(false);
+
+    handle.dispose();
   });
 });

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -969,6 +969,14 @@ export class CopilotKitCore {
       throw new Error(`metadata subscribe failed: ${res.status}`);
     }
     const { joinToken, joinCode } = await res.json();
+    if (
+      typeof joinToken !== "string" ||
+      joinToken.length === 0 ||
+      typeof joinCode !== "string" ||
+      joinCode.length === 0
+    ) {
+      throw new Error("metadata subscribe: malformed response");
+    }
     return { joinToken, joinCode };
   }
 

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -34,6 +34,8 @@ import { ThreadStoreRegistry } from "./thread-store-registry";
 import type { ɵThreadStore } from "../threads";
 import { ɵcreateMemoryStore } from "../memory";
 import type { ɵMemoryStore } from "../memory";
+import { ɵcreateMetadataRealtimeConnection } from "./metadata-realtime";
+import type { ɵMetadataRealtimeConnection } from "./metadata-realtime";
 
 /** Configuration options for `CopilotKitCore`. */
 export interface CopilotKitCoreConfig {
@@ -387,6 +389,13 @@ export class CopilotKitCore {
    */
   private _memoryStore?: ɵMemoryStore;
   /**
+   * The shared per-user metadata realtime connection (threads + memory ride the
+   * same socket). Lazily created by `ɵgetMetadataRealtime()` while the runtime
+   * is connected and a ws URL is known; disposed when the runtime disconnects or
+   * the headers change. `undefined` when no live connection exists.
+   */
+  private _metadataRealtime?: ɵMetadataRealtimeConnection;
+  /**
    * Tracks the agent IDs from the most recent `onAgentsChanged` notification.
    * Used to gate thread-store auto-unregister so the FIRST empty-agents
    * notification (before published agents are merged in) does not rip out a
@@ -444,6 +453,17 @@ export class CopilotKitCore {
       // so this single hook covers both connection and intelligence changes.
       // Guarded so we never instantiate the store just to sync it.
       onRuntimeConnectionStatusChanged: () => {
+        // Tear down the shared metadata connection whenever we are no longer in
+        // the connected+wsUrl state; the next `ɵgetMetadataRealtime()` /
+        // `syncMemoryContext()` lazily rebuilds it once we are live again.
+        if (
+          this.runtimeConnectionStatus !==
+            CopilotKitCoreRuntimeConnectionStatus.Connected ||
+          !this.intelligence?.wsUrl ||
+          !this.runtimeUrl
+        ) {
+          this.disposeMetadataRealtime();
+        }
         if (this._memoryStore) this.syncMemoryContext();
       },
       onAgentsChanged: ({ agents }) => {
@@ -735,6 +755,10 @@ export class CopilotKitCore {
    */
   setHeaders(headers: Record<string, string | null | undefined>): void {
     this._headers = normalizeHeaders(headers);
+    // Headers changed — the metadata subscription token is minted from them, so
+    // re-mint the shared connection with the new headers (accepting the socket
+    // teardown/reconnect cost). `syncMemoryContext()` lazily rebuilds it.
+    this.disposeMetadataRealtime();
     if (this._memoryStore) this.syncMemoryContext();
     this.agentRegistry.applyHeadersToAgents(
       this.agentRegistry.agents as Record<string, AbstractAgent>,
@@ -899,24 +923,76 @@ export class CopilotKitCore {
   }
 
   /**
-   * Pushes the current runtime wiring into the memory store. When the runtime
-   * is connected and both the intelligence WebSocket URL and runtime URL are
-   * available, the store receives a context (runtime URL, WebSocket URL, and a
-   * copy of the current headers); otherwise its context is cleared. No-op when
-   * the store has not been created yet.
+   * The shared per-user metadata realtime connection (threads + memory ride the
+   * same socket). Lazily created when the runtime is connected and a ws URL is
+   * known; `undefined` otherwise. Consumers (the memory store via
+   * `syncMemoryContext`, the thread store via the `useThreads` hook) join their
+   * own channel off `socket$`.
+   */
+  ɵgetMetadataRealtime(): ɵMetadataRealtimeConnection | undefined {
+    if (
+      this.runtimeConnectionStatus !==
+        CopilotKitCoreRuntimeConnectionStatus.Connected ||
+      !this.intelligence?.wsUrl ||
+      !this.runtimeUrl
+    ) {
+      return undefined;
+    }
+    if (!this._metadataRealtime) {
+      const runtimeUrl = this.runtimeUrl;
+      const headers = { ...this.headers };
+      this._metadataRealtime = ɵcreateMetadataRealtimeConnection({
+        wsUrl: this.intelligence.wsUrl,
+        fetchSubscription: () =>
+          this.fetchMetadataSubscription(runtimeUrl, headers),
+      });
+    }
+    return this._metadataRealtime;
+  }
+
+  /**
+   * Mints the metadata subscription (join token + per-user join code `R`).
+   * Hidden behind one function so swapping `/threads/subscribe` for a future
+   * generic `/metadata/subscribe` is a one-line change. Both existing routes
+   * return the same per-user metadata join code + a metadata-scoped token.
+   */
+  private async fetchMetadataSubscription(
+    runtimeUrl: string,
+    headers: Record<string, string>,
+  ): Promise<{ joinToken: string; joinCode: string }> {
+    const res = await globalThis.fetch(`${runtimeUrl}/threads/subscribe`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: "{}",
+    });
+    if (!res.ok) {
+      throw new Error(`metadata subscribe failed: ${res.status}`);
+    }
+    const { joinToken, joinCode } = await res.json();
+    return { joinToken, joinCode };
+  }
+
+  /** Idempotent teardown of the shared metadata connection. */
+  private disposeMetadataRealtime(): void {
+    this._metadataRealtime?.dispose();
+    this._metadataRealtime = undefined;
+  }
+
+  /**
+   * Pushes the current runtime wiring into the memory store. When a shared
+   * metadata realtime connection is available (runtime connected + ws URL
+   * known) and a runtime URL is set, the store receives a context (runtime URL,
+   * a copy of the current headers, and the shared connection); otherwise its
+   * context is cleared. No-op when the store has not been created yet.
    */
   private syncMemoryContext(): void {
     if (!this._memoryStore) return;
-    if (
-      this.runtimeConnectionStatus ===
-        CopilotKitCoreRuntimeConnectionStatus.Connected &&
-      this.intelligence?.wsUrl &&
-      this.runtimeUrl
-    ) {
+    const metadata = this.ɵgetMetadataRealtime();
+    if (metadata && this.runtimeUrl) {
       this._memoryStore.setContext({
         runtimeUrl: this.runtimeUrl,
-        wsUrl: this.intelligence.wsUrl,
         headers: { ...this.headers },
+        metadata,
       });
     } else {
       this._memoryStore.setContext(null);

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -34,8 +34,11 @@ import { ThreadStoreRegistry } from "./thread-store-registry";
 import type { ɵThreadStore } from "../threads";
 import { ɵcreateMemoryStore } from "../memory";
 import type { ɵMemoryStore } from "../memory";
-import { ɵcreateMetadataRealtimeConnection } from "./metadata-realtime";
-import type { ɵMetadataRealtimeConnection } from "./metadata-realtime";
+import { ɵcreateMetadataSocket } from "./metadata-realtime";
+import type {
+  ɵMetadataSocket,
+  ɵMetadataSocketHandle,
+} from "./metadata-realtime";
 
 /** Configuration options for `CopilotKitCore`. */
 export interface CopilotKitCoreConfig {
@@ -389,12 +392,13 @@ export class CopilotKitCore {
    */
   private _memoryStore?: ɵMemoryStore;
   /**
-   * The shared per-user metadata realtime connection (threads + memory ride the
-   * same socket). Lazily created by `ɵgetMetadataRealtime()` while the runtime
-   * is connected and a ws URL is known; disposed when the runtime disconnects or
-   * the headers change. `undefined` when no live connection exists.
+   * The ONE shared metadata socket (threads + memory ride the same socket).
+   * Lazily seeded by `ɵgetMetadataSocket(joinToken)` from the FIRST consumer's
+   * joinToken while the runtime is connected and a ws URL is known; disposed
+   * when the runtime disconnects or the headers change. `undefined` when no
+   * live socket exists.
    */
-  private _metadataRealtime?: ɵMetadataRealtimeConnection;
+  private _metadataSocket?: ɵMetadataSocketHandle;
   /**
    * Tracks the agent IDs from the most recent `onAgentsChanged` notification.
    * Used to gate thread-store auto-unregister so the FIRST empty-agents
@@ -453,16 +457,15 @@ export class CopilotKitCore {
       // so this single hook covers both connection and intelligence changes.
       // Guarded so we never instantiate the store just to sync it.
       onRuntimeConnectionStatusChanged: () => {
-        // Tear down the shared metadata connection whenever we are no longer in
-        // the connected+wsUrl state; the next `ɵgetMetadataRealtime()` /
-        // `syncMemoryContext()` lazily rebuilds it once we are live again.
+        // Tear down the shared metadata socket whenever we are no longer in the
+        // connected+wsUrl state; the next consumer re-seeds a fresh socket via
+        // `ɵgetMetadataSocket(joinToken)` once we are live again.
         if (
           this.runtimeConnectionStatus !==
             CopilotKitCoreRuntimeConnectionStatus.Connected ||
-          !this.intelligence?.wsUrl ||
-          !this.runtimeUrl
+          !this.intelligence?.wsUrl
         ) {
-          this.disposeMetadataRealtime();
+          this.disposeMetadataSocket();
         }
         if (this._memoryStore) this.syncMemoryContext();
       },
@@ -755,10 +758,12 @@ export class CopilotKitCore {
    */
   setHeaders(headers: Record<string, string | null | undefined>): void {
     this._headers = normalizeHeaders(headers);
-    // Headers changed — the metadata subscription token is minted from them, so
-    // re-mint the shared connection with the new headers (accepting the socket
-    // teardown/reconnect cost). `syncMemoryContext()` lazily rebuilds it.
-    this.disposeMetadataRealtime();
+    // Headers changed — the metadata join token is minted (by the consumer)
+    // from them, so tear down the shared socket (accepting the socket
+    // teardown/reconnect cost). The next consumer (memory re-fetching its
+    // credentials with the new headers) re-seeds a fresh socket with a fresh
+    // token via `ɵgetMetadataSocket`. `syncMemoryContext()` re-pushes context.
+    this.disposeMetadataSocket();
     if (this._memoryStore) this.syncMemoryContext();
     this.agentRegistry.applyHeadersToAgents(
       this.agentRegistry.agents as Record<string, AbstractAgent>,
@@ -923,84 +928,59 @@ export class CopilotKitCore {
   }
 
   /**
-   * The shared per-user metadata realtime connection (threads + memory ride the
-   * same socket). Lazily created when the runtime is connected and a ws URL is
-   * known; `undefined` otherwise. Consumers (the memory store via
-   * `syncMemoryContext`, the thread store via the `useThreads` hook) join their
-   * own channel off `socket$`.
+   * Lazily creates (seeds) the ONE shared metadata socket from the first
+   * consumer's `joinToken`, memoizes it, and hands back the consumer view
+   * (threads + memory ride the same socket, each joining its own channel off
+   * `socket$`). Returns `undefined` until the runtime is connected with a ws
+   * URL. Subsequent calls return the SAME socket — the `joinToken` argument is
+   * used only to seed the first time, since the socket is already authenticated
+   * after that.
    */
-  ɵgetMetadataRealtime(): ɵMetadataRealtimeConnection | undefined {
+  ɵgetMetadataSocket(joinToken: string): ɵMetadataSocket | undefined {
     if (
       this.runtimeConnectionStatus !==
         CopilotKitCoreRuntimeConnectionStatus.Connected ||
-      !this.intelligence?.wsUrl ||
-      !this.runtimeUrl
+      !this.intelligence?.wsUrl
     ) {
       return undefined;
     }
-    if (!this._metadataRealtime) {
-      const runtimeUrl = this.runtimeUrl;
-      const headers = { ...this.headers };
-      this._metadataRealtime = ɵcreateMetadataRealtimeConnection({
+    if (!this._metadataSocket) {
+      this._metadataSocket = ɵcreateMetadataSocket({
         wsUrl: this.intelligence.wsUrl,
-        fetchSubscription: () =>
-          this.fetchMetadataSubscription(runtimeUrl, headers),
+        joinToken,
       });
     }
-    return this._metadataRealtime;
+    return this._metadataSocket.socket;
+  }
+
+  /** Idempotent teardown of the shared metadata socket. */
+  private disposeMetadataSocket(): void {
+    this._metadataSocket?.dispose();
+    this._metadataSocket = undefined;
   }
 
   /**
-   * Mints the metadata subscription (join token + per-user join code `R`).
-   * Hidden behind one function so swapping `/threads/subscribe` for a future
-   * generic `/metadata/subscribe` is a one-line change. Both existing routes
-   * return the same per-user metadata join code + a metadata-scoped token.
-   */
-  private async fetchMetadataSubscription(
-    runtimeUrl: string,
-    headers: Record<string, string>,
-  ): Promise<{ joinToken: string; joinCode: string }> {
-    const res = await globalThis.fetch(`${runtimeUrl}/threads/subscribe`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", ...headers },
-      body: "{}",
-    });
-    if (!res.ok) {
-      throw new Error(`metadata subscribe failed: ${res.status}`);
-    }
-    const { joinToken, joinCode } = await res.json();
-    if (
-      typeof joinToken !== "string" ||
-      joinToken.length === 0 ||
-      typeof joinCode !== "string" ||
-      joinCode.length === 0
-    ) {
-      throw new Error("metadata subscribe: malformed response");
-    }
-    return { joinToken, joinCode };
-  }
-
-  /** Idempotent teardown of the shared metadata connection. */
-  private disposeMetadataRealtime(): void {
-    this._metadataRealtime?.dispose();
-    this._metadataRealtime = undefined;
-  }
-
-  /**
-   * Pushes the current runtime wiring into the memory store. When a shared
-   * metadata realtime connection is available (runtime connected + ws URL
-   * known) and a runtime URL is set, the store receives a context (runtime URL,
-   * a copy of the current headers, and the shared connection); otherwise its
-   * context is cleared. No-op when the store has not been created yet.
+   * Pushes the current runtime wiring into the memory store. When the runtime
+   * is connected with a ws URL and a runtime URL is set, the store receives a
+   * context (runtime URL, a copy of the current headers, and a provider that
+   * lazily seeds/returns the shared metadata socket); otherwise its context is
+   * cleared. The provider closes over `this`, so it always reflects the current
+   * socket — including after a re-mint. No-op when the store has not been
+   * created yet.
    */
   private syncMemoryContext(): void {
     if (!this._memoryStore) return;
-    const metadata = this.ɵgetMetadataRealtime();
-    if (metadata && this.runtimeUrl) {
+    if (
+      this.runtimeConnectionStatus ===
+        CopilotKitCoreRuntimeConnectionStatus.Connected &&
+      this.intelligence?.wsUrl &&
+      this.runtimeUrl
+    ) {
       this._memoryStore.setContext({
         runtimeUrl: this.runtimeUrl,
         headers: { ...this.headers },
-        metadata,
+        getMetadataSocket: (joinToken) =>
+          this.ɵgetMetadataSocket(joinToken) ?? null,
       });
     } else {
       this._memoryStore.setContext(null);

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -34,6 +34,7 @@ import { ThreadStoreRegistry } from "./thread-store-registry";
 import type { ɵThreadStore } from "../threads";
 import { ɵcreateMemoryStore } from "../memory";
 import type { ɵMemoryStore } from "../memory";
+import type { Subscription } from "rxjs";
 import { ɵcreateMetadataSocket } from "./metadata-realtime";
 import type {
   ɵMetadataSocket,
@@ -399,6 +400,12 @@ export class CopilotKitCore {
    * live socket exists.
    */
   private _metadataSocket?: ɵMetadataSocketHandle;
+  /**
+   * Subscription to the shared socket's `socketFatal$`, held so a health
+   * give-up disposes the socket (see `ɵgetMetadataSocket`). Torn down alongside
+   * the socket in `disposeMetadataSocket`.
+   */
+  private _metadataSocketFatalSub?: Subscription;
   /**
    * Tracks the agent IDs from the most recent `onAgentsChanged` notification.
    * Used to gate thread-store auto-unregister so the FIRST empty-agents
@@ -935,8 +942,13 @@ export class CopilotKitCore {
    * URL. Subsequent calls return the SAME socket — the `joinToken` argument is
    * used only to seed the first time, since the socket is already authenticated
    * after that.
+   *
+   * The `seedJoinToken` seeds the socket on the FIRST call only; later calls
+   * return the already-authenticated socket and ignore the argument. (Both
+   * stores' tokens are scoped to the same per-user meta_join_code, so the first
+   * consumer's token authorizes every channel joined off the shared socket.)
    */
-  ɵgetMetadataSocket(joinToken: string): ɵMetadataSocket | undefined {
+  ɵgetMetadataSocket(seedJoinToken: string): ɵMetadataSocket | undefined {
     if (
       this.runtimeConnectionStatus !==
         CopilotKitCoreRuntimeConnectionStatus.Connected ||
@@ -945,16 +957,32 @@ export class CopilotKitCore {
       return undefined;
     }
     if (!this._metadataSocket) {
-      this._metadataSocket = ɵcreateMetadataSocket({
+      const handle = ɵcreateMetadataSocket({
         wsUrl: this.intelligence.wsUrl,
-        joinToken,
+        joinToken: seedJoinToken,
       });
+      this._metadataSocket = handle;
+      // Give-up must be terminal. When the shared socket's health chain gives
+      // up (`socketFatal$` fires after ɵMETADATA_MAX_SOCKET_RETRIES consecutive
+      // errors), dispose the socket so it stops reconnecting forever; the next
+      // consumer access re-seeds a fresh socket (matching "give up now; a later
+      // reconnect starts over"). `socketFatal$` completes on teardown and this
+      // subscription is torn down in `disposeMetadataSocket`, so it cannot leak;
+      // both `disposeMetadataSocket` and the handle's `dispose` are idempotent,
+      // so the give-up path cannot double-dispose.
+      this._metadataSocketFatalSub = handle.socket.socketFatal$.subscribe(
+        () => {
+          this.disposeMetadataSocket();
+        },
+      );
     }
     return this._metadataSocket.socket;
   }
 
   /** Idempotent teardown of the shared metadata socket. */
   private disposeMetadataSocket(): void {
+    this._metadataSocketFatalSub?.unsubscribe();
+    this._metadataSocketFatalSub = undefined;
     this._metadataSocket?.dispose();
     this._metadataSocket = undefined;
   }

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -972,7 +972,17 @@ export class CopilotKitCore {
       // so the give-up path cannot double-dispose.
       this._metadataSocketFatalSub = handle.socket.socketFatal$.subscribe(
         () => {
-          this.disposeMetadataSocket();
+          // Defer teardown one microtask so the synchronous socketFatal$
+          // fan-out reaches every store subscriber (memory's
+          // fatal$ -> realtimeUnavailable) BEFORE dispose() completes the
+          // shared subject and preempts them. Without the defer, this
+          // callback — subscribed at socket-creation time, ahead of any
+          // store's own fatal$ subscriber — would synchronously
+          // `teardown$.complete()` the shared `socketFatal$`, so later
+          // subscribers receive `complete()` instead of their mapped value
+          // and never dispatch `realtimeUnavailable`. The socket lives one
+          // microtask longer, which is harmless.
+          queueMicrotask(() => this.disposeMetadataSocket());
         },
       );
     }

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -4,3 +4,4 @@ export * from "./context-store";
 export * from "./suggestion-engine";
 export * from "./run-handler";
 export * from "./state-manager";
+export * from "./metadata-realtime";

--- a/packages/core/src/core/metadata-realtime.ts
+++ b/packages/core/src/core/metadata-realtime.ts
@@ -2,12 +2,10 @@ import type { Observable } from "rxjs";
 import {
   Subject,
   catchError,
-  defer,
   map,
   of,
   share,
   shareReplay,
-  switchMap,
   takeUntil,
 } from "rxjs";
 import { phoenixExponentialBackoff } from "@copilotkit/shared";
@@ -21,54 +19,53 @@ import type { ɵPhoenixSocketSession } from "../utils/phoenix-observable";
 export const ɵMETADATA_MAX_SOCKET_RETRIES = 5;
 
 /**
- * The shared per-user metadata realtime connection. Threads and memory each
- * join their own channel off the same `socket$`, so both feeds share one
- * lazily-created, kept-open Phoenix socket instead of opening their own.
+ * Consumer-facing view of the shared metadata socket handed to stores.
+ *
+ * Credential-agnostic: the module never fetches anything. The consumer
+ * (CopilotKitCore) supplies the `joinToken`; threads and memory each join
+ * their own channel off the same `socket$`, so both feeds share one
+ * kept-open Phoenix socket instead of opening their own.
+ *
+ * Intentionally has NO `dispose` — stores must not be able to tear down the
+ * shared socket. Only the owner (CopilotKitCore) can, via the handle.
  */
-export interface ɵMetadataRealtimeConnection {
-  /** Hot, shared, lazily-connected Phoenix socket. refCount:false — stays open
-   *  across channel churn; only dispose() (or a fatal give-up) tears it down. */
+export interface ɵMetadataSocket {
+  /** Hot, shared, kept-open Phoenix socket. refCount:false — stays open
+   *  across channel churn; only the owner's dispose() tears it down. */
   socket$: Observable<ɵPhoenixSocketSession>;
-  /** The per-user metadata join code `R`, replayed to late subscribers. */
-  joinCode$: Observable<string>;
-  /** Fatal socket give-up (after MAX_SOCKET_RETRIES). Shared by all channels;
-   *  emits once then completes. Never throws. */
+  /** Fatal give-up after {@link ɵMETADATA_MAX_SOCKET_RETRIES} consecutive
+   *  socket errors. Latched (replayed to late subscribers), emits at most
+   *  once, never throws. */
   socketFatal$: Observable<void>;
+}
+
+/**
+ * Owner handle for the shared metadata socket, held ONLY by CopilotKitCore.
+ * Exposes the consumer view plus the sole teardown entry point.
+ */
+export interface ɵMetadataSocketHandle {
+  readonly socket: ɵMetadataSocket;
   /** Idempotent teardown: disconnects the socket and completes all streams. */
   dispose(): void;
 }
 
-export function ɵcreateMetadataRealtimeConnection(deps: {
+export function ɵcreateMetadataSocket(deps: {
   wsUrl: string;
-  fetchSubscription: () => Promise<{ joinToken: string; joinCode: string }>;
-}): ɵMetadataRealtimeConnection {
+  joinToken: string;
+}): ɵMetadataSocketHandle {
   const teardown$ = new Subject<void>();
 
-  // One-shot metadata subscription (join token + code R), shared by all
-  // subscribers. Matches today's behavior: fetched once per connection.
-  const subscription$ = defer(() => deps.fetchSubscription()).pipe(
-    shareReplay(1),
-  );
-
-  const joinCode$ = subscription$.pipe(
-    map((s) => s.joinCode),
-    shareReplay(1),
-  );
-
-  const socket$ = subscription$.pipe(
-    switchMap(({ joinToken }) =>
-      ɵphoenixSocket$({
-        url: deps.wsUrl,
-        options: {
-          params: { join_token: joinToken },
-          reconnectAfterMs: phoenixExponentialBackoff(100, 10_000),
-          rejoinAfterMs: phoenixExponentialBackoff(1_000, 30_000),
-        },
-      }),
-    ),
+  const socket$ = ɵphoenixSocket$({
+    url: deps.wsUrl,
+    options: {
+      params: { join_token: deps.joinToken },
+      reconnectAfterMs: phoenixExponentialBackoff(100, 10_000),
+      rejoinAfterMs: phoenixExponentialBackoff(1_000, 30_000),
+    },
+  }).pipe(
     takeUntil(teardown$),
-    // Lazy + hot + no per-subscriber refcount: connects on first subscribe,
-    // stays open across channel churn, closed only by dispose()/fatal.
+    // Hot + no per-subscriber refcount: connects on first subscribe, stays
+    // open across channel churn, closed only by dispose().
     shareReplay({ bufferSize: 1, refCount: false }),
   );
 
@@ -85,17 +82,26 @@ export function ɵcreateMetadataRealtimeConnection(deps: {
     }),
     map(() => undefined),
     takeUntil(teardown$),
-    share(),
+    // shareReplay (not share) so a late subscriber — a store re-subscribing
+    // after a prior give-up — immediately observes the terminal give-up.
+    shareReplay({ bufferSize: 1, refCount: false }),
   );
 
+  // Eagerly subscribe the health chain so socket-health monitoring and the
+  // give-up warn run regardless of which/whether stores subscribe. This also
+  // opens the socket immediately, which is correct: the module is only
+  // constructed once a consumer has decided to connect.
+  const healthSub = socketFatal$.subscribe();
+
+  const socket: ɵMetadataSocket = { socket$, socketFatal$ };
+
   return {
-    socket$,
-    joinCode$,
-    socketFatal$,
+    socket,
     dispose: () => {
       if (!teardown$.closed) {
         teardown$.next();
         teardown$.complete();
+        healthSub.unsubscribe();
       }
     },
   };

--- a/packages/core/src/core/metadata-realtime.ts
+++ b/packages/core/src/core/metadata-realtime.ts
@@ -1,0 +1,102 @@
+import type { Observable } from "rxjs";
+import {
+  Subject,
+  catchError,
+  defer,
+  map,
+  of,
+  share,
+  shareReplay,
+  switchMap,
+  takeUntil,
+} from "rxjs";
+import { phoenixExponentialBackoff } from "@copilotkit/shared";
+import {
+  ɵobservePhoenixSocketHealth$,
+  ɵobservePhoenixSocketSignals$,
+  ɵphoenixSocket$,
+} from "../utils/phoenix-observable";
+import type { ɵPhoenixSocketSession } from "../utils/phoenix-observable";
+
+export const ɵMETADATA_MAX_SOCKET_RETRIES = 5;
+
+/**
+ * The shared per-user metadata realtime connection. Threads and memory each
+ * join their own channel off the same `socket$`, so both feeds share one
+ * lazily-created, kept-open Phoenix socket instead of opening their own.
+ */
+export interface ɵMetadataRealtimeConnection {
+  /** Hot, shared, lazily-connected Phoenix socket. refCount:false — stays open
+   *  across channel churn; only dispose() (or a fatal give-up) tears it down. */
+  socket$: Observable<ɵPhoenixSocketSession>;
+  /** The per-user metadata join code `R`, replayed to late subscribers. */
+  joinCode$: Observable<string>;
+  /** Fatal socket give-up (after MAX_SOCKET_RETRIES). Shared by all channels;
+   *  emits once then completes. Never throws. */
+  socketFatal$: Observable<void>;
+  /** Idempotent teardown: disconnects the socket and completes all streams. */
+  dispose(): void;
+}
+
+export function ɵcreateMetadataRealtimeConnection(deps: {
+  wsUrl: string;
+  fetchSubscription: () => Promise<{ joinToken: string; joinCode: string }>;
+}): ɵMetadataRealtimeConnection {
+  const teardown$ = new Subject<void>();
+
+  // One-shot metadata subscription (join token + code R), shared by all
+  // subscribers. Matches today's behavior: fetched once per connection.
+  const subscription$ = defer(() => deps.fetchSubscription()).pipe(
+    shareReplay(1),
+  );
+
+  const joinCode$ = subscription$.pipe(
+    map((s) => s.joinCode),
+    shareReplay(1),
+  );
+
+  const socket$ = subscription$.pipe(
+    switchMap(({ joinToken }) =>
+      ɵphoenixSocket$({
+        url: deps.wsUrl,
+        options: {
+          params: { join_token: joinToken },
+          reconnectAfterMs: phoenixExponentialBackoff(100, 10_000),
+          rejoinAfterMs: phoenixExponentialBackoff(1_000, 30_000),
+        },
+      }),
+    ),
+    takeUntil(teardown$),
+    // Lazy + hot + no per-subscriber refcount: connects on first subscribe,
+    // stays open across channel churn, closed only by dispose()/fatal.
+    shareReplay({ bufferSize: 1, refCount: false }),
+  );
+
+  const socketSignals$ = ɵobservePhoenixSocketSignals$(socket$).pipe(share());
+  const socketFatal$ = ɵobservePhoenixSocketHealth$(
+    socketSignals$,
+    ɵMETADATA_MAX_SOCKET_RETRIES,
+  ).pipe(
+    catchError(() => {
+      console.warn(
+        `[metadata] WebSocket failed after ${ɵMETADATA_MAX_SOCKET_RETRIES} attempts, giving up`,
+      );
+      return of(undefined);
+    }),
+    map(() => undefined),
+    takeUntil(teardown$),
+    share(),
+  );
+
+  return {
+    socket$,
+    joinCode$,
+    socketFatal$,
+    dispose: () => {
+      if (!teardown$.closed) {
+        teardown$.next();
+        teardown$.complete();
+      }
+    },
+  };
+}

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -1075,6 +1075,17 @@ function createMemoryStore(environment: MemoryEnvironment): MemoryStore {
                 fatal$,
               ).pipe(takeUntil(shutdown$));
             }),
+            // A subscribe-credentials fetch failure errors `joinCode$` (it
+            // derives from the shared connection's `fetchSubscription`, which
+            // THROWS on a non-2xx `/threads/subscribe`). Micro-redux is
+            // fail-fast, so an unhandled error here would kill the whole store
+            // (`getState()` would then throw), taking down the REST-backed
+            // list and mutations. Realtime is a silent degrade: map the error
+            // to `realtimeUnavailable` (flip only `realtimeStatus`) so the
+            // store stays alive and `available`/`error`/the list are untouched.
+            catchError(() =>
+              of(memoryDomainEvents.realtimeUnavailable({ sessionId })),
+            ),
             takeUntil(shutdown$),
           );
         }),

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -1,22 +1,12 @@
-import { phoenixExponentialBackoff } from "@copilotkit/shared";
 import type { Observable } from "rxjs";
-import {
-  asapScheduler,
-  defer,
-  firstValueFrom,
-  merge,
-  observeOn,
-  of,
-} from "rxjs";
+import { defer, firstValueFrom, merge, of } from "rxjs";
 import { fromFetch } from "rxjs/fetch";
 import {
   catchError,
   concatWith,
   filter,
-  finalize,
   map,
   mergeMap,
-  share,
   shareReplay,
   switchMap,
   take,
@@ -39,23 +29,18 @@ import type { Reducer, Store } from "./utils/micro-redux";
 import { MemoryError, isRetryableStatus } from "./memory-errors";
 import {
   ɵphoenixChannel$,
-  ɵphoenixSocket$,
   ɵjoinPhoenixChannel$,
   ɵobservePhoenixEvent$,
-  ɵobservePhoenixSocketHealth$,
-  ɵobservePhoenixSocketSignals$,
 } from "./utils/phoenix-observable";
 import type { ɵPhoenixChannelSession } from "./utils/phoenix-observable";
+import type { ɵMetadataRealtimeConnection } from "./core/metadata-realtime";
 
 // Runtime-relative path, mirroring the thread store's `/threads` (NOT
 // `/api/threads`): `runtimeUrl` is the CopilotKit runtime mount (e.g.
 // `/api/copilotkit`), and the runtime maps `/memories` to the app-api's
 // `/api/memories` the same way it maps `/threads` -> `/api/threads`.
 const MEMORIES_PATH = "/memories";
-const MEMORIES_SUBSCRIBE_PATH = "/memories/subscribe";
 const REQUEST_TIMEOUT_MS = 15_000;
-/** Consecutive socket errors tolerated before the realtime stream gives up. */
-const MAX_SOCKET_RETRIES = 5;
 /**
  * HTTP status codes that indicate memory routes are not configured (non-fatal).
  * 404/501 mean the route is absent/unimplemented; 422 is the runtime's
@@ -138,10 +123,15 @@ type MemoryMutationOutcome =
  */
 interface MemoryRuntimeContext {
   runtimeUrl: string;
-  /** WebSocket URL for the realtime gateway (e.g. `wss://gw.example.com/client`). */
-  wsUrl: string;
   headers: Record<string, string>;
   includeInvalidated?: boolean;
+  /**
+   * The shared per-user metadata realtime connection (owned by `CopilotKitCore`,
+   * shared with the thread store). `null` when no realtime connection is
+   * available yet (e.g. runtime not connected) — the store simply never opens
+   * its `user_meta:memories:<joinCode>` channel in that case.
+   */
+  metadata: ɵMetadataRealtimeConnection | null;
 }
 
 /**
@@ -198,18 +188,6 @@ const memoryRestEvents = createActionGroup("Memory REST", {
   listFailed: props<{ sessionId: number; error: Error }>(),
   listUnavailable: props<{ sessionId: number }>(),
   mutationFinished: props<{ outcome: MemoryMutationOutcome }>(),
-  credentialsRequested: props<{ sessionId: number }>(),
-  credentialsSucceeded: props<{
-    sessionId: number;
-    joinToken: string;
-    joinCode: string;
-  }>(),
-  // Credentials outcomes are a SILENT degrade: they feed only the realtime
-  // socket effect and deliberately do NOT touch the reducer's `available`/
-  // `error`, which describe the REST list route. See the reducer note near the
-  // list handlers.
-  credentialsFailed: props<{ sessionId: number; error: Error }>(),
-  credentialsUnavailable: props<{ sessionId: number }>(),
 });
 
 const memoryDomainEvents = createActionGroup("Memory Domain", {
@@ -419,16 +397,14 @@ const memoryReducer = createReducer(
       };
     },
   ),
-  // NOTE: `credentialsFailed` and `credentialsUnavailable` intentionally have NO
-  // reducer cases. `available`/`error` describe the REST list route only and are
-  // driven exclusively by the list events above. The credentials/realtime path
-  // is a silent degrade by design: a missing/unconfigured `/memories/subscribe`
-  // route (404/501/422) or a credentials error must not flip `available` or
-  // surface an `error`, because the list route can still be perfectly healthy.
-  // Otherwise `available` would be order-dependent on whichever of the two
-  // concurrent `contextChanged` bootstraps responds last. Realtime failures are
-  // handled where they occur (the socket effect retries and gives up via
-  // console.warn); they do not belong in the REST availability state.
+  // NOTE: realtime connection/join failures intentionally have NO reducer
+  // cases here. `available`/`error` describe the REST list route only and are
+  // driven exclusively by the list events above — the realtime path (the
+  // shared metadata connection / channel join) is a silent degrade by design:
+  // it must not flip `available` or surface an `error`, because the list
+  // route can still be perfectly healthy. Realtime failures are handled where
+  // they occur (the socket effect retries and gives up via console.warn) and
+  // surfaced only through `realtimeStatus` below.
   on(
     memoryDomainEvents.memoryUpserted,
     (state: MemoryState, { sessionId, memory }) => {
@@ -531,9 +507,11 @@ const selectMemoriesRealtimeStatus = createSelector(
 );
 
 /**
- * Dependencies injected into the memory store. The store opens its own
- * `user_meta:memories:<joinCode>` socket/channel and does not share the
- * thread store's socket, so only a `fetch` implementation is required.
+ * Dependencies injected into the memory store. The store joins its own
+ * `user_meta:memories:<joinCode>` channel over the shared metadata realtime
+ * connection supplied via `MemoryRuntimeContext.metadata` (owned by
+ * `CopilotKitCore`, shared with the thread store), so only a `fetch`
+ * implementation is required here for the REST surface.
  */
 interface MemoryEnvironment {
   fetch: typeof fetch;
@@ -641,79 +619,6 @@ function createMemoryFetchObservable(
       }),
     );
   });
-}
-
-/**
- * Fetches join credentials from the `/memories/subscribe` endpoint and maps
- * the response to a success/failure action. Requires both `joinToken` and
- * `joinCode` to be non-empty strings; throws otherwise so the `catchError`
- * path emits `credentialsFailed`.
- */
-function createMemoryCredentialsFetchObservable(
-  environment: MemoryEnvironment,
-  context: MemoryRuntimeContext,
-  sessionId: number,
-): Observable<
-  | ReturnType<typeof memoryRestEvents.credentialsSucceeded>
-  | ReturnType<typeof memoryRestEvents.credentialsFailed>
-  | ReturnType<typeof memoryRestEvents.credentialsUnavailable>
-> {
-  return defer(() =>
-    memoryFromFetch(`${context.runtimeUrl}${MEMORIES_SUBSCRIBE_PATH}`, {
-      selector: async (response) => {
-        if (!response.ok) {
-          if (ROUTE_UNAVAILABLE_STATUSES.has(response.status)) {
-            throw new MemoryRouteUnavailableError(String(response.status));
-          }
-          throw new MemoryError("MEMORY_CREDENTIALS_FAILED", {
-            message: `Failed to fetch memory subscribe credentials: ${response.status}`,
-            retryable: isRetryableStatus(response.status),
-          });
-        }
-
-        return response.json() as Promise<{
-          joinToken: string;
-          joinCode: string;
-        }>;
-      },
-      fetch: environment.fetch,
-      method: "POST",
-      headers: { ...context.headers, "Content-Type": "application/json" },
-      body: JSON.stringify({}),
-    }).pipe(
-      timeout({
-        first: REQUEST_TIMEOUT_MS,
-        with: () => {
-          throw new MemoryError("MEMORY_REQUEST_TIMEOUT");
-        },
-      }),
-      map((data) => {
-        if (typeof data.joinToken !== "string" || data.joinToken.length === 0) {
-          throw new Error("missing joinToken");
-        }
-        if (typeof data.joinCode !== "string" || data.joinCode.length === 0) {
-          throw new Error("missing joinCode");
-        }
-
-        return memoryRestEvents.credentialsSucceeded({
-          sessionId,
-          joinToken: data.joinToken,
-          joinCode: data.joinCode,
-        });
-      }),
-      catchError((error) => {
-        if (error instanceof MemoryRouteUnavailableError) {
-          return of(memoryRestEvents.credentialsUnavailable({ sessionId }));
-        }
-        return of(
-          memoryRestEvents.credentialsFailed({
-            sessionId,
-            error: error instanceof Error ? error : new Error(String(error)),
-          }),
-        );
-      }),
-    ),
-  );
 }
 
 type MemoryMutationAction =
@@ -992,50 +897,6 @@ function createMemoryStore(environment: MemoryEnvironment): MemoryStore {
       ),
   );
 
-  const credentialsBootstrapEffect = createEffect(
-    (actions$, state$: Observable<MemoryState>) =>
-      actions$.pipe(
-        ofType(memoryAdapterEvents.contextChanged),
-        withLatestFrom(state$),
-        filter(([, state]) => Boolean(state.context)),
-        map(([, state]) =>
-          memoryRestEvents.credentialsRequested({ sessionId: state.sessionId }),
-        ),
-      ),
-  );
-
-  const credentialsFetchEffect = createEffect(
-    (actions$, state$: Observable<MemoryState>) =>
-      actions$.pipe(
-        ofType(memoryRestEvents.credentialsRequested),
-        switchMap((action) =>
-          state$.pipe(
-            map((state) => state.context),
-            filter((context): context is MemoryRuntimeContext =>
-              Boolean(context),
-            ),
-            take(1),
-            map((context) => ({ action, context })),
-            takeUntil(
-              actions$.pipe(
-                ofType(
-                  memoryAdapterEvents.contextChanged,
-                  memoryAdapterEvents.stopped,
-                ),
-              ),
-            ),
-            switchMap(({ action: currentAction, context }) =>
-              createMemoryCredentialsFetchObservable(
-                environment,
-                context,
-                currentAction.sessionId,
-              ),
-            ),
-          ),
-        ),
-      ),
-  );
-
   const fetchEffect = createEffect(
     (actions$, state$: Observable<MemoryState>) =>
       actions$.pipe(
@@ -1120,21 +981,22 @@ function createMemoryStore(environment: MemoryEnvironment): MemoryStore {
       ),
   );
 
+  // Joins `user_meta:memories:<joinCode>` off the SHARED metadata realtime
+  // connection (`context.metadata`, owned by `CopilotKitCore` and shared with
+  // the thread store) instead of opening its own socket. Preserves the exact
+  // realtime-status policy: `realtimeConnecting` on every (re)subscribe,
+  // `realtimeConnected` once the channel join succeeds, `realtimeUnavailable`
+  // on a failed/timed-out join OR when the shared connection gives up for
+  // good (`metadata.socketFatal$`).
   const socketEffect = createEffect(
     (actions$, state$: Observable<MemoryState>) =>
       actions$.pipe(
-        ofType(memoryRestEvents.credentialsSucceeded),
+        ofType(memoryAdapterEvents.contextChanged),
         withLatestFrom(state$),
-        filter(([action, state]) => {
-          return (
-            action.sessionId === state.sessionId &&
-            Boolean(state.context?.wsUrl)
-          );
-        }),
-        switchMap(([action, state]) => {
-          const context = state.context as MemoryRuntimeContext;
-          const { joinToken, joinCode } = action;
-          const sessionId = action.sessionId;
+        filter(([, state]) => Boolean(state.context?.metadata)),
+        switchMap(([, state]) => {
+          const { metadata } = state.context as MemoryRuntimeContext;
+          const sessionId = state.sessionId;
           const shutdown$ = actions$.pipe(
             ofType(
               memoryAdapterEvents.contextChanged,
@@ -1142,129 +1004,86 @@ function createMemoryStore(environment: MemoryEnvironment): MemoryStore {
             ),
           );
 
-          return defer(() => {
-            const socket$ = ɵphoenixSocket$({
-              url: context.wsUrl,
-              options: {
-                params: { join_token: joinToken },
-                reconnectAfterMs: phoenixExponentialBackoff(100, 10_000),
-                rejoinAfterMs: phoenixExponentialBackoff(1_000, 30_000),
-              },
-            }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
-            const channel$ = ɵphoenixChannel$({
-              socket$,
-              topic: `user_meta:memories:${joinCode}`,
-            }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
-            const socketSignals$ =
-              ɵobservePhoenixSocketSignals$(socket$).pipe(share());
-            // The socket give-up signal: completes the realtime stream after the
-            // health check throws. ALSO surfaces the give-up as a status delta
-            // (`realtimeUnavailable`) so the UI can drop its "live" indicator —
-            // this is the permanent-death signal that was previously only a
-            // `console.warn`. `available`/`error` stay untouched by design (the
-            // realtime path is a silent degrade for the REST list route).
-            const fatalSocketShutdown$ = ɵobservePhoenixSocketHealth$(
-              socketSignals$,
-              MAX_SOCKET_RETRIES,
-            ).pipe(
-              catchError(() => {
-                console.warn(
-                  `[memory] WebSocket failed after ${MAX_SOCKET_RETRIES} attempts, giving up`,
-                );
-                return of(undefined);
-              }),
-              share(),
-            );
-            // The give-up mapped to a status delta. Emitted from the merged stream
-            // (not the `takeUntil` notifier) so the `realtimeUnavailable` action is
-            // dispatched BEFORE teardown: the merged stream is `takeUntil`'d by a
-            // microtask-deferred copy of the give-up signal, so this synchronous
-            // emission always wins the race and the action reaches the reducer.
-            const fatalStatus$ = fatalSocketShutdown$.pipe(
-              map(() => memoryDomainEvents.realtimeUnavailable({ sessionId })),
-            );
-            const metadata$ = channel$.pipe(
-              switchMap(({ channel }: ɵPhoenixChannelSession) =>
-                ɵobservePhoenixEvent$<MemoryMetadataEvent>(
-                  channel,
-                  MEMORY_METADATA_EVENT,
-                ),
-              ),
-              map((event) => mapMemoryMetadataEvent(event, action.sessionId)),
-            );
+          return metadata!.joinCode$.pipe(
+            switchMap((joinCode) => {
+              const channel$ = ɵphoenixChannel$({
+                socket$: metadata!.socket$,
+                topic: `user_meta:memories:${joinCode}`,
+              }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
 
-            // Drives the actual `channel.join()` AND maps the join outcome to a
-            // realtime-status delta. `ɵphoenixChannel$` only creates the channel +
-            // a lazy join-outcome stream; the join is sent when that stream is
-            // subscribed. Observing channel events (`metadata$`) alone does NOT
-            // subscribe it, so without this the socket connects but never joins
-            // `user_meta:memories:<code>` and no realtime deltas arrive. The thread
-            // store joins for the same reason (its merged `joinOutcome$`).
-            //
-            // On a successful join -> `realtimeConnected` (the "live" signal). On a
-            // failed/timed-out join we KEEP the `console.warn` and emit
-            // `realtimeUnavailable`, then swallow the error so a transient
-            // rejection doesn't tear down the metadata stream (Phoenix re-attempts
-            // the join on socket reconnect); the next successful join re-emits
-            // `realtimeConnected`.
-            const join$ = ɵjoinPhoenixChannel$(channel$).pipe(
-              // `ɵjoinPhoenixChannel$` emits `never` (it completes on success), so
-              // this concat surfaces the connected status once the join resolves.
-              concatWith(
-                of(memoryDomainEvents.realtimeConnected({ sessionId })),
-              ),
-              catchError((error) => {
-                console.warn(
-                  `[memory] failed to join user_meta:memories:${joinCode}`,
-                  error,
-                );
-                return of(
+              const metadata$ = channel$.pipe(
+                switchMap(({ channel }: ɵPhoenixChannelSession) =>
+                  ɵobservePhoenixEvent$<MemoryMetadataEvent>(
+                    channel,
+                    MEMORY_METADATA_EVENT,
+                  ),
+                ),
+                map((event) => mapMemoryMetadataEvent(event, sessionId)),
+              );
+
+              // Drives the actual `channel.join()` AND maps the join outcome
+              // to a realtime-status delta. `ɵphoenixChannel$` only creates
+              // the channel + a lazy join-outcome stream; the join is sent
+              // when that stream is subscribed. Observing channel events
+              // (`metadata$`) alone does NOT subscribe it, so without this
+              // the socket connects but never joins
+              // `user_meta:memories:<code>` and no realtime deltas arrive.
+              //
+              // On a successful join -> `realtimeConnected` (the "live"
+              // signal). On a failed/timed-out join we KEEP the
+              // `console.warn` and emit `realtimeUnavailable`, then swallow
+              // the error so a transient rejection doesn't tear down the
+              // metadata stream (Phoenix re-attempts the join on socket
+              // reconnect); the next successful join re-emits
+              // `realtimeConnected`.
+              const join$ = ɵjoinPhoenixChannel$(channel$).pipe(
+                // `ɵjoinPhoenixChannel$` emits `never` (it completes on
+                // success), so this concat surfaces the connected status
+                // once the join resolves.
+                concatWith(
+                  of(memoryDomainEvents.realtimeConnected({ sessionId })),
+                ),
+                catchError((error) => {
+                  console.warn(
+                    `[memory] failed to join user_meta:memories:${joinCode}`,
+                    error,
+                  );
+                  return of(
+                    memoryDomainEvents.realtimeUnavailable({ sessionId }),
+                  );
+                }),
+              );
+
+              // The shared connection's fatal give-up (after
+              // `ɵMETADATA_MAX_SOCKET_RETRIES`) — it already `console.warn`s
+              // internally, so this only needs to surface the status delta.
+              const fatal$ = metadata!.socketFatal$.pipe(
+                map(() =>
                   memoryDomainEvents.realtimeUnavailable({ sessionId }),
-                );
-              }),
-            );
-
-            return merge(
-              // Surface "connecting" immediately when the realtime stream starts
-              // (credentials succeeded -> socket subscribing/joining). Reset to
-              // this on every (re)subscribe so a prior session's terminal status
-              // can't bleed through before the new join resolves.
-              of(memoryDomainEvents.realtimeConnecting({ sessionId })),
-              metadata$,
-              join$,
-              fatalStatus$,
-            ).pipe(
-              takeUntil(
-                merge(
-                  shutdown$,
-                  // Defer the give-up teardown by a microtask so `fatalStatus$`'s
-                  // synchronous `realtimeUnavailable` emission is dispatched before
-                  // the stream is torn down. `observeOn(asapScheduler)` schedules
-                  // the teardown after the current microtask drains.
-                  fatalSocketShutdown$.pipe(observeOn(asapScheduler)),
                 ),
-              ),
-              finalize(() => {
-                // Socket/channel teardown is handled by the `finalize` operators
-                // inside `ɵphoenixSocket$`/`ɵphoenixChannel$`; this hook exists to
-                // mirror the thread store's socket-effect lifecycle shape.
-              }),
-            );
-          });
+              );
+
+              return merge(
+                // Surface "connecting" immediately when the realtime stream
+                // starts (context carries a metadata connection -> joining
+                // its channel). Reset to this on every (re)subscribe so a
+                // prior session's terminal status can't bleed through before
+                // the new join resolves.
+                of(memoryDomainEvents.realtimeConnecting({ sessionId })),
+                metadata$,
+                join$,
+                fatal$,
+              ).pipe(takeUntil(shutdown$));
+            }),
+            takeUntil(shutdown$),
+          );
         }),
       ),
   );
 
   const store = createStore<MemoryState>({
     reducer: memoryReducer,
-    effects: [
-      bootstrapEffect,
-      credentialsBootstrapEffect,
-      fetchEffect,
-      credentialsFetchEffect,
-      mutationEffect,
-      socketEffect,
-    ],
+    effects: [bootstrapEffect, fetchEffect, mutationEffect, socketEffect],
   });
 
   function trackMutation<T>(

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -1210,9 +1210,9 @@ function createMemoryStore(environment: MemoryEnvironment): MemoryStore {
             console.warn(
               "[memory] realtime unavailable: no shared metadata socket; memories will not receive live updates",
             );
-            return of(memoryDomainEvents.realtimeUnavailable({ sessionId })).pipe(
-              takeUntil(shutdown$),
-            );
+            return of(
+              memoryDomainEvents.realtimeUnavailable({ sessionId }),
+            ).pipe(takeUntil(shutdown$));
           }
 
           const channel$ = ɵphoenixChannel$({

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -1,5 +1,5 @@
 import type { Observable } from "rxjs";
-import { defer, firstValueFrom, merge, of } from "rxjs";
+import { EMPTY, defer, firstValueFrom, merge, of } from "rxjs";
 import { fromFetch } from "rxjs/fetch";
 import {
   catchError,
@@ -33,13 +33,14 @@ import {
   ɵobservePhoenixEvent$,
 } from "./utils/phoenix-observable";
 import type { ɵPhoenixChannelSession } from "./utils/phoenix-observable";
-import type { ɵMetadataRealtimeConnection } from "./core/metadata-realtime";
+import type { ɵMetadataSocket } from "./core/metadata-realtime";
 
 // Runtime-relative path, mirroring the thread store's `/threads` (NOT
 // `/api/threads`): `runtimeUrl` is the CopilotKit runtime mount (e.g.
 // `/api/copilotkit`), and the runtime maps `/memories` to the app-api's
 // `/api/memories` the same way it maps `/threads` -> `/api/threads`.
 const MEMORIES_PATH = "/memories";
+const MEMORIES_SUBSCRIBE_PATH = "/memories/subscribe";
 const REQUEST_TIMEOUT_MS = 15_000;
 /**
  * HTTP status codes that indicate memory routes are not configured (non-fatal).
@@ -117,21 +118,26 @@ type MemoryMutationOutcome =
   | { requestId: string; sessionId: number; ok: false; error: Error };
 
 /**
- * Runtime wiring for the memory store: where to reach the REST surface and the
- * headers (auth + `X-Cpki-User-Id`) to send. Scoped to the current user; v1
- * surfaces user-scoped memories only.
+ * Runtime wiring for the memory store: where to reach the REST surface, the
+ * headers (auth + `X-Cpki-User-Id`) to send, and how to obtain the shared
+ * metadata socket. Scoped to the current user; v1 surfaces user-scoped
+ * memories only.
  */
 interface MemoryRuntimeContext {
   runtimeUrl: string;
   headers: Record<string, string>;
   includeInvalidated?: boolean;
   /**
-   * The shared per-user metadata realtime connection (owned by `CopilotKitCore`,
-   * shared with the thread store). `null` when no realtime connection is
-   * available yet (e.g. runtime not connected) — the store simply never opens
-   * its `user_meta:memories:<joinCode>` channel in that case.
+   * Resolves the SHARED, credential-agnostic metadata socket for a given
+   * `joinToken` (the store fetches its own `/memories/subscribe` credentials
+   * and hands the resulting `joinToken` here). Owned by `CopilotKitCore` and
+   * shared with the thread store: memory joins its own
+   * `user_meta:memories:<joinCode>` channel off the returned socket instead of
+   * opening one of its own. Returns `null` when no shared socket is available
+   * yet (e.g. the runtime is not connected) — the store then simply never
+   * joins its channel and realtime silently stays absent.
    */
-  metadata: ɵMetadataRealtimeConnection | null;
+  getMetadataSocket: (joinToken: string) => ɵMetadataSocket | null;
 }
 
 /**
@@ -188,6 +194,18 @@ const memoryRestEvents = createActionGroup("Memory REST", {
   listFailed: props<{ sessionId: number; error: Error }>(),
   listUnavailable: props<{ sessionId: number }>(),
   mutationFinished: props<{ outcome: MemoryMutationOutcome }>(),
+  credentialsRequested: props<{ sessionId: number }>(),
+  credentialsSucceeded: props<{
+    sessionId: number;
+    joinToken: string;
+    joinCode: string;
+  }>(),
+  // Credentials outcomes are a SILENT degrade: they feed only the realtime
+  // socket effect and deliberately do NOT touch the reducer's `available`/
+  // `error`, which describe the REST list route. See the reducer note near the
+  // list handlers.
+  credentialsFailed: props<{ sessionId: number; error: Error }>(),
+  credentialsUnavailable: props<{ sessionId: number }>(),
 });
 
 const memoryDomainEvents = createActionGroup("Memory Domain", {
@@ -397,14 +415,17 @@ const memoryReducer = createReducer(
       };
     },
   ),
-  // NOTE: realtime connection/join failures intentionally have NO reducer
-  // cases here. `available`/`error` describe the REST list route only and are
-  // driven exclusively by the list events above — the realtime path (the
-  // shared metadata connection / channel join) is a silent degrade by design:
-  // it must not flip `available` or surface an `error`, because the list
-  // route can still be perfectly healthy. Realtime failures are handled where
-  // they occur (the socket effect retries and gives up via console.warn) and
-  // surfaced only through `realtimeStatus` below.
+  // NOTE: `credentialsFailed` and `credentialsUnavailable` intentionally have NO
+  // reducer cases. `available`/`error` describe the REST list route only and are
+  // driven exclusively by the list events above. The credentials/realtime path
+  // is a silent degrade by design: a missing/unconfigured `/memories/subscribe`
+  // route (404/501/422) or a credentials error must not flip `available` or
+  // surface an `error`, because the list route can still be perfectly healthy.
+  // Otherwise `available` would be order-dependent on whichever of the two
+  // concurrent `contextChanged` bootstraps responds last. Realtime failures are
+  // handled where they occur (the credentials fetch warns on failure; the
+  // socket effect surfaces the give-up via console.warn); they do not belong in
+  // the REST availability state.
   on(
     memoryDomainEvents.memoryUpserted,
     (state: MemoryState, { sessionId, memory }) => {
@@ -507,10 +528,11 @@ const selectMemoriesRealtimeStatus = createSelector(
 );
 
 /**
- * Dependencies injected into the memory store. The store joins its own
- * `user_meta:memories:<joinCode>` channel over the shared metadata realtime
- * connection supplied via `MemoryRuntimeContext.metadata` (owned by
- * `CopilotKitCore`, shared with the thread store), so only a `fetch`
+ * Dependencies injected into the memory store. The store fetches its own
+ * `/memories/subscribe` credentials and then joins its
+ * `user_meta:memories:<joinCode>` channel off the SHARED metadata socket
+ * (supplied via `MemoryRuntimeContext.getMetadataSocket`, owned by
+ * `CopilotKitCore` and shared with the thread store), so only a `fetch`
  * implementation is required here for the REST surface.
  */
 interface MemoryEnvironment {
@@ -619,6 +641,89 @@ function createMemoryFetchObservable(
       }),
     );
   });
+}
+
+/**
+ * Fetches join credentials from the `/memories/subscribe` endpoint and maps
+ * the response to a success/failure action. Requires both `joinToken` and
+ * `joinCode` to be non-empty strings; throws otherwise so the `catchError`
+ * path emits `credentialsFailed`.
+ */
+function createMemoryCredentialsFetchObservable(
+  environment: MemoryEnvironment,
+  context: MemoryRuntimeContext,
+  sessionId: number,
+): Observable<
+  | ReturnType<typeof memoryRestEvents.credentialsSucceeded>
+  | ReturnType<typeof memoryRestEvents.credentialsFailed>
+  | ReturnType<typeof memoryRestEvents.credentialsUnavailable>
+> {
+  return defer(() =>
+    memoryFromFetch(`${context.runtimeUrl}${MEMORIES_SUBSCRIBE_PATH}`, {
+      selector: async (response) => {
+        if (!response.ok) {
+          if (ROUTE_UNAVAILABLE_STATUSES.has(response.status)) {
+            throw new MemoryRouteUnavailableError(String(response.status));
+          }
+          throw new MemoryError("MEMORY_CREDENTIALS_FAILED", {
+            message: `Failed to fetch memory subscribe credentials: ${response.status}`,
+            retryable: isRetryableStatus(response.status),
+          });
+        }
+
+        return response.json() as Promise<{
+          joinToken: string;
+          joinCode: string;
+        }>;
+      },
+      fetch: environment.fetch,
+      method: "POST",
+      headers: { ...context.headers, "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    }).pipe(
+      timeout({
+        first: REQUEST_TIMEOUT_MS,
+        with: () => {
+          throw new MemoryError("MEMORY_REQUEST_TIMEOUT");
+        },
+      }),
+      map((data) => {
+        if (typeof data.joinToken !== "string" || data.joinToken.length === 0) {
+          throw new Error("missing joinToken");
+        }
+        if (typeof data.joinCode !== "string" || data.joinCode.length === 0) {
+          throw new Error("missing joinCode");
+        }
+
+        return memoryRestEvents.credentialsSucceeded({
+          sessionId,
+          joinToken: data.joinToken,
+          joinCode: data.joinCode,
+        });
+      }),
+      catchError((error) => {
+        // A missing/unconfigured `/memories/subscribe` route (404/422/501) is
+        // the expected "not configured" case — degrade silently, no warn.
+        if (error instanceof MemoryRouteUnavailableError) {
+          return of(memoryRestEvents.credentialsUnavailable({ sessionId }));
+        }
+        // B5: a genuine credentials-fetch failure degrades realtime silently for
+        // `available`/`error`/the list (no reducer case flips those), but the
+        // degrade should be VISIBLE — mirror the join-failure warn so operators
+        // can see that live updates won't arrive.
+        console.warn(
+          "[memory] realtime subscribe failed; memories will not receive live updates",
+          error,
+        );
+        return of(
+          memoryRestEvents.credentialsFailed({
+            sessionId,
+            error: error instanceof Error ? error : new Error(String(error)),
+          }),
+        );
+      }),
+    ),
+  );
 }
 
 type MemoryMutationAction =
@@ -897,6 +1002,50 @@ function createMemoryStore(environment: MemoryEnvironment): MemoryStore {
       ),
   );
 
+  const credentialsBootstrapEffect = createEffect(
+    (actions$, state$: Observable<MemoryState>) =>
+      actions$.pipe(
+        ofType(memoryAdapterEvents.contextChanged),
+        withLatestFrom(state$),
+        filter(([, state]) => Boolean(state.context)),
+        map(([, state]) =>
+          memoryRestEvents.credentialsRequested({ sessionId: state.sessionId }),
+        ),
+      ),
+  );
+
+  const credentialsFetchEffect = createEffect(
+    (actions$, state$: Observable<MemoryState>) =>
+      actions$.pipe(
+        ofType(memoryRestEvents.credentialsRequested),
+        switchMap((action) =>
+          state$.pipe(
+            map((state) => state.context),
+            filter((context): context is MemoryRuntimeContext =>
+              Boolean(context),
+            ),
+            take(1),
+            map((context) => ({ action, context })),
+            takeUntil(
+              actions$.pipe(
+                ofType(
+                  memoryAdapterEvents.contextChanged,
+                  memoryAdapterEvents.stopped,
+                ),
+              ),
+            ),
+            switchMap(({ action: currentAction, context }) =>
+              createMemoryCredentialsFetchObservable(
+                environment,
+                context,
+                currentAction.sessionId,
+              ),
+            ),
+          ),
+        ),
+      ),
+  );
+
   const fetchEffect = createEffect(
     (actions$, state$: Observable<MemoryState>) =>
       actions$.pipe(
@@ -981,22 +1130,27 @@ function createMemoryStore(environment: MemoryEnvironment): MemoryStore {
       ),
   );
 
-  // Joins `user_meta:memories:<joinCode>` off the SHARED metadata realtime
-  // connection (`context.metadata`, owned by `CopilotKitCore` and shared with
-  // the thread store) instead of opening its own socket. Preserves the exact
-  // realtime-status policy: `realtimeConnecting` on every (re)subscribe,
-  // `realtimeConnected` once the channel join succeeds, `realtimeUnavailable`
-  // on a failed/timed-out join OR when the shared connection gives up for
-  // good (`metadata.socketFatal$`).
+  // Joins `user_meta:memories:<joinCode>` off the SHARED metadata socket
+  // (resolved via `context.getMetadataSocket(joinToken)`, owned by
+  // `CopilotKitCore` and shared with the thread store) instead of opening its
+  // own socket. The store still fetches its OWN `/memories/subscribe`
+  // credentials (see `credentialsFetchEffect`) — only the socket SOURCE
+  // changed. Preserves the exact realtime-status policy: `realtimeConnecting`
+  // on every (re)subscribe, `realtimeConnected` once the channel join succeeds,
+  // `realtimeUnavailable` on a failed/timed-out join OR when the shared socket
+  // gives up for good (`socket.socketFatal$`).
   const socketEffect = createEffect(
     (actions$, state$: Observable<MemoryState>) =>
       actions$.pipe(
-        ofType(memoryAdapterEvents.contextChanged),
+        ofType(memoryRestEvents.credentialsSucceeded),
         withLatestFrom(state$),
-        filter(([, state]) => Boolean(state.context?.metadata)),
-        switchMap(([, state]) => {
-          const { metadata } = state.context as MemoryRuntimeContext;
-          const sessionId = state.sessionId;
+        filter(([action, state]) => {
+          return action.sessionId === state.sessionId && Boolean(state.context);
+        }),
+        switchMap(([action, state]) => {
+          const context = state.context as MemoryRuntimeContext;
+          const { joinToken, joinCode } = action;
+          const sessionId = action.sessionId;
           const shutdown$ = actions$.pipe(
             ofType(
               memoryAdapterEvents.contextChanged,
@@ -1004,97 +1158,106 @@ function createMemoryStore(environment: MemoryEnvironment): MemoryStore {
             ),
           );
 
-          return metadata!.joinCode$.pipe(
-            switchMap((joinCode) => {
-              const channel$ = ɵphoenixChannel$({
-                socket$: metadata!.socket$,
-                topic: `user_meta:memories:${joinCode}`,
-              }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
+          // Resolve the SHARED socket for this joinToken. `null` means no shared
+          // socket is available (e.g. the runtime is not connected yet): realtime
+          // silently stays absent and the REST list is unaffected.
+          const socket = context.getMetadataSocket(joinToken);
+          if (!socket) {
+            return EMPTY;
+          }
 
-              const metadata$ = channel$.pipe(
-                switchMap(({ channel }: ɵPhoenixChannelSession) =>
-                  ɵobservePhoenixEvent$<MemoryMetadataEvent>(
-                    channel,
-                    MEMORY_METADATA_EVENT,
-                  ),
-                ),
-                map((event) => mapMemoryMetadataEvent(event, sessionId)),
-              );
+          const channel$ = ɵphoenixChannel$({
+            socket$: socket.socket$,
+            topic: `user_meta:memories:${joinCode}`,
+          }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
 
-              // Drives the actual `channel.join()` AND maps the join outcome
-              // to a realtime-status delta. `ɵphoenixChannel$` only creates
-              // the channel + a lazy join-outcome stream; the join is sent
-              // when that stream is subscribed. Observing channel events
-              // (`metadata$`) alone does NOT subscribe it, so without this
-              // the socket connects but never joins
-              // `user_meta:memories:<code>` and no realtime deltas arrive.
-              //
-              // On a successful join -> `realtimeConnected` (the "live"
-              // signal). On a failed/timed-out join we KEEP the
-              // `console.warn` and emit `realtimeUnavailable`, then swallow
-              // the error so a transient rejection doesn't tear down the
-              // metadata stream (Phoenix re-attempts the join on socket
-              // reconnect); the next successful join re-emits
-              // `realtimeConnected`.
-              const join$ = ɵjoinPhoenixChannel$(channel$).pipe(
-                // `ɵjoinPhoenixChannel$` emits `never` (it completes on
-                // success), so this concat surfaces the connected status
-                // once the join resolves.
-                concatWith(
-                  of(memoryDomainEvents.realtimeConnected({ sessionId })),
-                ),
-                catchError((error) => {
-                  console.warn(
-                    `[memory] failed to join user_meta:memories:${joinCode}`,
-                    error,
-                  );
-                  return of(
-                    memoryDomainEvents.realtimeUnavailable({ sessionId }),
-                  );
-                }),
-              );
-
-              // The shared connection's fatal give-up (after
-              // `ɵMETADATA_MAX_SOCKET_RETRIES`) — it already `console.warn`s
-              // internally, so this only needs to surface the status delta.
-              const fatal$ = metadata!.socketFatal$.pipe(
-                map(() =>
-                  memoryDomainEvents.realtimeUnavailable({ sessionId }),
-                ),
-              );
-
-              return merge(
-                // Surface "connecting" immediately when the realtime stream
-                // starts (context carries a metadata connection -> joining
-                // its channel). Reset to this on every (re)subscribe so a
-                // prior session's terminal status can't bleed through before
-                // the new join resolves.
-                of(memoryDomainEvents.realtimeConnecting({ sessionId })),
-                metadata$,
-                join$,
-                fatal$,
-              ).pipe(takeUntil(shutdown$));
-            }),
-            // A subscribe-credentials fetch failure errors `joinCode$` (it
-            // derives from the shared connection's `fetchSubscription`, which
-            // THROWS on a non-2xx `/threads/subscribe`). Micro-redux is
-            // fail-fast, so an unhandled error here would kill the whole store
-            // (`getState()` would then throw), taking down the REST-backed
-            // list and mutations. Realtime is a silent degrade: map the error
-            // to `realtimeUnavailable` (flip only `realtimeStatus`) so the
-            // store stays alive and `available`/`error`/the list are untouched.
-            catchError(() =>
-              of(memoryDomainEvents.realtimeUnavailable({ sessionId })),
+          const metadata$ = channel$.pipe(
+            switchMap(({ channel }: ɵPhoenixChannelSession) =>
+              ɵobservePhoenixEvent$<MemoryMetadataEvent>(
+                channel,
+                MEMORY_METADATA_EVENT,
+              ),
             ),
-            takeUntil(shutdown$),
+            // B4: `mapMemoryMetadataEvent` -> `toMemory` can throw on a malformed
+            // `created`/`updated` payload (e.g. a missing `memory`). A single bad
+            // event must NOT error the realtime stream and tear the channel down;
+            // map it defensively to a sentinel, warn, and filter it out so valid
+            // events keep flowing.
+            map((event) => {
+              try {
+                return mapMemoryMetadataEvent(event, sessionId);
+              } catch (error) {
+                console.warn(
+                  "[memory] dropping malformed memory_metadata event",
+                  error,
+                );
+                return null;
+              }
+            }),
+            filter(
+              (mapped): mapped is NonNullable<typeof mapped> => mapped !== null,
+            ),
           );
+
+          // Drives the actual `channel.join()` AND maps the join outcome to a
+          // realtime-status delta. `ɵphoenixChannel$` only creates the channel +
+          // a lazy join-outcome stream; the join is sent when that stream is
+          // subscribed. Observing channel events (`metadata$`) alone does NOT
+          // subscribe it, so without this the socket connects but never joins
+          // `user_meta:memories:<code>` and no realtime deltas arrive.
+          //
+          // On a successful join -> `realtimeConnected` (the "live" signal). On a
+          // failed/timed-out join we KEEP the `console.warn` and emit
+          // `realtimeUnavailable`, then swallow the error so a transient
+          // rejection doesn't tear down the metadata stream (Phoenix re-attempts
+          // the join on socket reconnect); the next successful join re-emits
+          // `realtimeConnected`.
+          const join$ = ɵjoinPhoenixChannel$(channel$).pipe(
+            // `ɵjoinPhoenixChannel$` emits `never` (it completes on success), so
+            // this concat surfaces the connected status once the join resolves.
+            concatWith(of(memoryDomainEvents.realtimeConnected({ sessionId }))),
+            catchError((error) => {
+              console.warn(
+                `[memory] failed to join user_meta:memories:${joinCode}`,
+                error,
+              );
+              return of(memoryDomainEvents.realtimeUnavailable({ sessionId }));
+            }),
+          );
+
+          // The SHARED socket's fatal give-up (after
+          // `ɵMETADATA_MAX_SOCKET_RETRIES` consecutive socket errors). The shared
+          // socket already `console.warn`s internally, so this only surfaces the
+          // status delta. It does NOT tear down this channel stream — teardown is
+          // exclusively `takeUntil(shutdown$)`.
+          const fatal$ = socket.socketFatal$.pipe(
+            map(() => memoryDomainEvents.realtimeUnavailable({ sessionId })),
+          );
+
+          return merge(
+            // Surface "connecting" immediately when the realtime stream starts
+            // (credentials succeeded -> joining the shared socket's channel).
+            // Reset to this on every (re)subscribe so a prior session's terminal
+            // status can't bleed through before the new join resolves.
+            of(memoryDomainEvents.realtimeConnecting({ sessionId })),
+            metadata$,
+            join$,
+            fatal$,
+          ).pipe(takeUntil(shutdown$));
         }),
       ),
   );
 
   const store = createStore<MemoryState>({
     reducer: memoryReducer,
-    effects: [bootstrapEffect, fetchEffect, mutationEffect, socketEffect],
+    effects: [
+      bootstrapEffect,
+      credentialsBootstrapEffect,
+      fetchEffect,
+      credentialsFetchEffect,
+      mutationEffect,
+      socketEffect,
+    ],
   });
 
   function trackMutation<T>(

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -1,5 +1,5 @@
 import type { Observable } from "rxjs";
-import { EMPTY, defer, firstValueFrom, merge, of } from "rxjs";
+import { defer, firstValueFrom, merge, of } from "rxjs";
 import { fromFetch } from "rxjs/fetch";
 import {
   catchError,
@@ -136,6 +136,12 @@ interface MemoryRuntimeContext {
    * opening one of its own. Returns `null` when no shared socket is available
    * yet (e.g. the runtime is not connected) — the store then simply never
    * joins its channel and realtime silently stays absent.
+   *
+   * Resolves the shared metadata socket for the given joinToken (seed-once; see
+   * core.ɵgetMetadataSocket). Core DISPOSES the shared socket on disconnect,
+   * header change, and health give-up — so a binding MUST re-dispatch setContext
+   * on return-to-Connected (and header change) to re-resolve a fresh socket,
+   * else the store is stranded on a disposed socket.
    */
   getMetadataSocket: (joinToken: string) => ɵMetadataSocket | null;
 }
@@ -200,10 +206,11 @@ const memoryRestEvents = createActionGroup("Memory REST", {
     joinToken: string;
     joinCode: string;
   }>(),
-  // Credentials outcomes are a SILENT degrade: they feed only the realtime
-  // socket effect and deliberately do NOT touch the reducer's `available`/
-  // `error`, which describe the REST list route. See the reducer note near the
-  // list handlers.
+  // Credentials outcomes are a SILENT degrade for the LIST: they deliberately
+  // do NOT touch the reducer's `available`/`error`, which describe the REST list
+  // route. They DO resolve `realtimeStatus` to "unavailable" so the live
+  // indicator doesn't hang at "connecting" when credentials never succeed. See
+  // the reducer note near the list handlers.
   credentialsFailed: props<{ sessionId: number; error: Error }>(),
   credentialsUnavailable: props<{ sessionId: number }>(),
 });
@@ -415,17 +422,49 @@ const memoryReducer = createReducer(
       };
     },
   ),
-  // NOTE: `credentialsFailed` and `credentialsUnavailable` intentionally have NO
-  // reducer cases. `available`/`error` describe the REST list route only and are
-  // driven exclusively by the list events above. The credentials/realtime path
-  // is a silent degrade by design: a missing/unconfigured `/memories/subscribe`
-  // route (404/501/422) or a credentials error must not flip `available` or
-  // surface an `error`, because the list route can still be perfectly healthy.
-  // Otherwise `available` would be order-dependent on whichever of the two
-  // concurrent `contextChanged` bootstraps responds last. Realtime failures are
-  // handled where they occur (the credentials fetch warns on failure; the
-  // socket effect surfaces the give-up via console.warn); they do not belong in
-  // the REST availability state.
+  // NOTE: `credentialsFailed` and `credentialsUnavailable` deliberately leave
+  // `available`/`error`/`memories` UNTOUCHED. Those describe the REST list route
+  // only and are driven exclusively by the list events above. The
+  // credentials/realtime path is a silent degrade for the LIST by design: a
+  // missing/unconfigured `/memories/subscribe` route (404/501/422) or a
+  // credentials error must not flip `available` or surface an `error`, because
+  // the list route can still be perfectly healthy. Otherwise `available` would
+  // be order-dependent on whichever of the two concurrent `contextChanged`
+  // bootstraps responds last.
+  //
+  // What they DO resolve is `realtimeStatus`: both terminal credential outcomes
+  // flip it to "unavailable" so the live indicator does not hang at "connecting"
+  // forever when credentials never succeed (the socket effect — which is what
+  // otherwise transitions `realtimeStatus` — only runs on credentials SUCCESS).
+  // `credentialsFailed` (genuine failure) warns at the fetch site (B5);
+  // `credentialsUnavailable` (404 "not configured") stays warn-silent but still
+  // resolves the status here.
+  on(
+    memoryRestEvents.credentialsFailed,
+    (state: MemoryState, { sessionId }) => {
+      if (sessionId !== state.sessionId) {
+        return state;
+      }
+
+      return {
+        ...state,
+        realtimeStatus: "unavailable" as MemoryRealtimeStatus,
+      };
+    },
+  ),
+  on(
+    memoryRestEvents.credentialsUnavailable,
+    (state: MemoryState, { sessionId }) => {
+      if (sessionId !== state.sessionId) {
+        return state;
+      }
+
+      return {
+        ...state,
+        realtimeStatus: "unavailable" as MemoryRealtimeStatus,
+      };
+    },
+  ),
   on(
     memoryDomainEvents.memoryUpserted,
     (state: MemoryState, { sessionId, memory }) => {
@@ -976,8 +1015,9 @@ function createMemoryMutationObservable(
 /**
  * Creates the framework-agnostic memory store: a REST snapshot on `setContext`,
  * server-authoritative add/update/remove mutations, and realtime
- * `memory_metadata` deltas off the injected `user_meta` event source — all
- * reduced into observable state.
+ * `memory_metadata` deltas from the `user_meta:memories:<joinCode>` channel
+ * joined off the shared metadata socket (resolved via
+ * `context.getMetadataSocket`) — all reduced into observable state.
  */
 function createMemoryStore(environment: MemoryEnvironment): MemoryStore {
   // Per-store request-id counter. Kept as a closure variable (not a
@@ -1158,12 +1198,21 @@ function createMemoryStore(environment: MemoryEnvironment): MemoryStore {
             ),
           );
 
-          // Resolve the SHARED socket for this joinToken. `null` means no shared
-          // socket is available (e.g. the runtime is not connected yet): realtime
-          // silently stays absent and the REST list is unaffected.
+          // Resolve the SHARED socket for this joinToken. `null` here is reached
+          // AFTER a successful credentials fetch, so it means the runtime is
+          // connected but has no shared metadata socket (e.g. connected without a
+          // ws URL). Rather than silently dropping live updates with no signal,
+          // warn AND resolve `realtimeStatus` to "unavailable" so the live
+          // indicator doesn't hang at "connecting" forever. The REST list is
+          // unaffected (this is a realtime-only degrade).
           const socket = context.getMetadataSocket(joinToken);
           if (!socket) {
-            return EMPTY;
+            console.warn(
+              "[memory] realtime unavailable: no shared metadata socket; memories will not receive live updates",
+            );
+            return of(memoryDomainEvents.realtimeUnavailable({ sessionId })).pipe(
+              takeUntil(shutdown$),
+            );
           }
 
           const channel$ = ɵphoenixChannel$({
@@ -1187,8 +1236,17 @@ function createMemoryStore(environment: MemoryEnvironment): MemoryStore {
               try {
                 return mapMemoryMetadataEvent(event, sessionId);
               } catch (error) {
+                // Include the offending event's `operation` and id (memoryId /
+                // invalidated.id when present) so a malformed-payload report is
+                // actionable, not just the bare error.
+                const offending = event as Partial<MemoryMetadataEvent>;
+                const memoryId =
+                  offending?.memoryId ??
+                  (offending as { invalidated?: { id?: string } })?.invalidated
+                    ?.id;
                 console.warn(
                   "[memory] dropping malformed memory_metadata event",
+                  { operation: offending?.operation, memoryId },
                   error,
                 );
                 return null;

--- a/packages/core/src/threads.ts
+++ b/packages/core/src/threads.ts
@@ -31,10 +31,11 @@ import {
   ɵobservePhoenixJoinOutcome$,
 } from "./utils/phoenix-observable";
 import type { ɵPhoenixChannelSession } from "./utils/phoenix-observable";
-import type { ɵMetadataRealtimeConnection } from "./core/metadata-realtime";
+import type { ɵMetadataSocket } from "./core/metadata-realtime";
 
 const THREADS_CHANNEL_EVENT = "thread_metadata";
 const THREAD_RUN_ACTIVITY_CHANNEL_EVENT = "thread_run_activity";
+const THREAD_SUBSCRIBE_PATH = "/threads/subscribe";
 const REQUEST_TIMEOUT_MS = 15_000;
 
 interface ThreadRecord {
@@ -56,12 +57,16 @@ interface ThreadRuntimeContext {
   includeArchived?: boolean;
   limit?: number;
   /**
-   * The shared per-user metadata realtime connection (owned by `CopilotKitCore`,
-   * shared with the memory store). `null` when no realtime connection is
-   * available yet (e.g. runtime not connected) — the store simply never opens
-   * its `user_meta:<joinCode>` channel in that case.
+   * Resolves the SHARED, credential-agnostic metadata socket for a given
+   * `joinToken` (the store fetches its own `/threads/subscribe` credentials and
+   * hands the resulting `joinToken` here). Owned by `CopilotKitCore` and shared
+   * with the memory store: threads join their own `user_meta:<joinCode>` channel
+   * off the returned socket instead of opening one of their own. Returns `null`
+   * when no shared socket is available yet (e.g. the runtime is not connected) —
+   * the store then simply never joins its channel and realtime silently stays
+   * absent.
    */
-  metadata: ɵMetadataRealtimeConnection | null;
+  getMetadataSocket: (joinToken: string) => ɵMetadataSocket | null;
 }
 
 type ThreadMetadataEvent =
@@ -116,6 +121,10 @@ interface ThreadListResponse {
   nextCursor?: string | null;
 }
 
+interface ThreadMetadataCredentialsResponse {
+  joinToken: string;
+}
+
 interface MutationRequest {
   requestId: string;
   /** Session the mutation was dispatched in; stale results are dropped. */
@@ -149,6 +158,8 @@ interface ThreadState {
   error: Error | null;
   context: ThreadRuntimeContext | null;
   sessionId: number;
+  metadataCredentialsRequested: boolean;
+  metadataJoinCode: string | null;
   nextCursor: string | null;
   /** Number of thread mutations currently awaiting a server response. */
   inFlightMutationCount: number;
@@ -169,6 +180,8 @@ const initialThreadState: ThreadState = {
   error: null,
   context: null,
   sessionId: 0,
+  metadataCredentialsRequested: false,
+  metadataJoinCode: null,
   nextCursor: null,
   inFlightMutationCount: 0,
   pendingDeletes: {},
@@ -205,6 +218,12 @@ const threadRestEvents = createActionGroup("Thread REST", {
     nextCursor: string | null;
   }>(),
   nextPageFailed: props<{ sessionId: number; error: Error }>(),
+  metadataCredentialsRequested: props<{ sessionId: number }>(),
+  metadataCredentialsSucceeded: props<{
+    sessionId: number;
+    joinToken: string;
+  }>(),
+  metadataCredentialsFailed: props<{ sessionId: number; error: Error }>(),
   mutationFinished: props<{ outcome: MutationOutcome }>(),
 });
 
@@ -293,6 +312,8 @@ const threadReducer = createReducer(
     isLoading: Boolean(context),
     isFetchingNextPage: false,
     error: null,
+    metadataCredentialsRequested: false,
+    metadataJoinCode: null,
     nextCursor: null,
     inFlightMutationCount: 0,
     pendingDeletes: {},
@@ -303,6 +324,8 @@ const threadReducer = createReducer(
     isLoading: false,
     isFetchingNextPage: false,
     error: null,
+    metadataCredentialsRequested: false,
+    metadataJoinCode: null,
     nextCursor: null,
     inFlightMutationCount: 0,
     pendingDeletes: {},
@@ -320,16 +343,21 @@ const threadReducer = createReducer(
   }),
   on(
     threadRestEvents.listSucceeded,
-    (state: ThreadState, { sessionId, threads, nextCursor }) => {
+    (state: ThreadState, { sessionId, threads, joinCode, nextCursor }) => {
       if (sessionId !== state.sessionId) {
         return state;
       }
+      const joinCodeChanged = joinCode !== state.metadataJoinCode;
 
       return {
         ...state,
         threads: sortThreadsByRecency(threads),
         isLoading: false,
         error: null,
+        metadataJoinCode: joinCode,
+        metadataCredentialsRequested: joinCodeChanged
+          ? false
+          : state.metadataCredentialsRequested,
         nextCursor,
       };
     },
@@ -379,6 +407,41 @@ const threadReducer = createReducer(
         ...state,
         isFetchingNextPage: false,
         error,
+      };
+    },
+  ),
+  on(
+    threadRestEvents.metadataCredentialsFailed,
+    (state: ThreadState, { sessionId }) => {
+      if (sessionId !== state.sessionId) {
+        return state;
+      }
+
+      // Non-fatal: the metadata-credentials (realtime join-token) fetch runs
+      // AFTER the thread list has already loaded and only powers the realtime
+      // channel. A failure means realtime won't connect, but the fetched list
+      // is still valid — so we do NOT write `state.error` (which would replace
+      // the whole list with a "couldn't load" panel). The failure is surfaced
+      // as a diagnostic warning instead (the B5 warn in
+      // `createThreadMetadataCredentialsObservable`), mirroring the stay-stale
+      // handling of a realtime channel join failure. Clear the request latch so
+      // a later list refresh can retry realtime setup.
+      return {
+        ...state,
+        metadataCredentialsRequested: false,
+      };
+    },
+  ),
+  on(
+    threadRestEvents.metadataCredentialsRequested,
+    (state: ThreadState, { sessionId }) => {
+      if (sessionId !== state.sessionId) {
+        return state;
+      }
+
+      return {
+        ...state,
+        metadataCredentialsRequested: true,
       };
     },
   ),
@@ -761,6 +824,70 @@ function createThreadFetchObservable(
   });
 }
 
+function createThreadMetadataCredentialsObservable(
+  environment: ThreadEnvironment,
+  context: ThreadRuntimeContext,
+  sessionId: number,
+): Observable<
+  | ReturnType<typeof threadRestEvents.metadataCredentialsSucceeded>
+  | ReturnType<typeof threadRestEvents.metadataCredentialsFailed>
+> {
+  return defer(() => {
+    return threadFromFetch(`${context.runtimeUrl}${THREAD_SUBSCRIBE_PATH}`, {
+      selector: async (response) => {
+        if (!response.ok) {
+          throw new Error(
+            `Failed to fetch thread metadata credentials: ${response.status}`,
+          );
+        }
+
+        return response.json() as Promise<ThreadMetadataCredentialsResponse>;
+      },
+      fetch: environment.fetch,
+      method: "POST",
+      headers: {
+        ...context.headers,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({}),
+    }).pipe(
+      timeout({
+        first: REQUEST_TIMEOUT_MS,
+        with: () => {
+          throw new Error("Request timed out");
+        },
+      }),
+      map((data) => {
+        if (typeof data.joinToken !== "string" || data.joinToken.length === 0) {
+          throw new Error("missing joinToken");
+        }
+
+        return threadRestEvents.metadataCredentialsSucceeded({
+          sessionId,
+          joinToken: data.joinToken,
+        });
+      }),
+      catchError((error) => {
+        // B5: a genuine credentials-fetch failure degrades realtime silently
+        // for the list — `metadataCredentialsFailed` deliberately does NOT write
+        // `state.error` or touch the fetched list (see its reducer case). But
+        // the degrade should be VISIBLE so operators can see that live updates
+        // won't arrive; mirror the join-failure warn (and memory.ts's B5 warn).
+        console.warn(
+          "[threads] realtime subscribe failed; the thread list will not receive live updates",
+          error,
+        );
+        return of(
+          threadRestEvents.metadataCredentialsFailed({
+            sessionId,
+            error: error instanceof Error ? error : new Error(String(error)),
+          }),
+        );
+      }),
+    );
+  });
+}
+
 function createThreadMutationObservable(
   environment: ThreadEnvironment,
   context: ThreadRuntimeContext,
@@ -860,21 +987,81 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
       ),
   );
 
-  // Joins `user_meta:<joinCode>` off the SHARED metadata realtime connection
-  // (`context.metadata`, owned by `CopilotKitCore` and shared with the memory
-  // store) instead of opening its own socket. Socket lifecycle/health is the
-  // shared connection's concern; this store only cares about the channel join
-  // outcome (surfaced via `joinFailed`/`joinTimedOut`, warned by
-  // `socketDiagnosticsEffect` below) and the two channel events it maps.
+  const metadataCredentialsEffect = createEffect(
+    (actions$, state$: Observable<ThreadState>) =>
+      actions$.pipe(
+        ofType(threadRestEvents.listSucceeded),
+        withLatestFrom(state$),
+        filter(([action, state]) => {
+          return (
+            action.sessionId === state.sessionId &&
+            !state.metadataCredentialsRequested &&
+            Boolean(state.metadataJoinCode)
+          );
+        }),
+        map(([action]) =>
+          threadRestEvents.metadataCredentialsRequested({
+            sessionId: action.sessionId,
+          }),
+        ),
+      ),
+  );
+
+  const metadataCredentialsFetchEffect = createEffect(
+    (actions$, state$: Observable<ThreadState>) =>
+      actions$.pipe(
+        ofType(threadRestEvents.metadataCredentialsRequested),
+        switchMap((action) =>
+          state$.pipe(
+            map((state) => state.context),
+            filter((context): context is ThreadRuntimeContext =>
+              Boolean(context),
+            ),
+            take(1),
+            map((context) => ({ action, context })),
+            takeUntil(
+              actions$.pipe(
+                ofType(
+                  threadAdapterEvents.contextChanged,
+                  threadAdapterEvents.stopped,
+                ),
+              ),
+            ),
+            switchMap(({ action: currentAction, context }) =>
+              createThreadMetadataCredentialsObservable(
+                environment,
+                context,
+                currentAction.sessionId,
+              ),
+            ),
+          ),
+        ),
+      ),
+  );
+
+  // Joins `user_meta:<joinCode>` off the SHARED metadata socket (resolved via
+  // `context.getMetadataSocket(joinToken)`, owned by `CopilotKitCore` and shared
+  // with the memory store) instead of opening its own socket. The store still
+  // fetches its OWN `/threads/subscribe` credentials (see
+  // `metadataCredentialsFetchEffect`) and reads the `joinCode` from the LIST
+  // response — only the socket SOURCE changed. Socket lifecycle/health is the
+  // shared socket's concern (it warns internally on fatal give-up); this store
+  // only cares about the channel join outcome (surfaced via
+  // `joinFailed`/`joinTimedOut`, warned by `socketDiagnosticsEffect` below) and
+  // the two channel events it maps.
   const socketEffect = createEffect(
     (actions$, state$: Observable<ThreadState>) =>
       actions$.pipe(
-        ofType(threadAdapterEvents.contextChanged),
+        ofType(threadRestEvents.metadataCredentialsSucceeded),
         withLatestFrom(state$),
-        filter(([, state]) => Boolean(state.context?.metadata)),
-        switchMap(([, state]) => {
-          const { metadata } = state.context as ThreadRuntimeContext;
-          const sessionId = state.sessionId;
+        filter(([action, state]) => {
+          return action.sessionId === state.sessionId && Boolean(state.context);
+        }),
+        switchMap(([action, state]) => {
+          const context = state.context as ThreadRuntimeContext;
+          const { joinToken } = action;
+          const joinCode = state.metadataJoinCode as string;
+          const sessionId = action.sessionId;
           const shutdown$ = actions$.pipe(
             ofType(
               threadAdapterEvents.contextChanged,
@@ -882,71 +1069,61 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
             ),
           );
 
-          return metadata!.joinCode$.pipe(
-            switchMap((joinCode) => {
-              const channel$ = ɵphoenixChannel$({
-                socket$: metadata!.socket$,
-                topic: `user_meta:${joinCode}`,
-              }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
+          // Resolve the SHARED socket for this joinToken. `null` means no shared
+          // socket is available (e.g. the runtime is not connected yet):
+          // realtime silently stays absent and the REST list is unaffected.
+          const socket = context.getMetadataSocket(joinToken);
+          if (!socket) {
+            return EMPTY;
+          }
 
-              const metadata$ = channel$.pipe(
-                switchMap(({ channel }: ɵPhoenixChannelSession) =>
-                  ɵobservePhoenixEvent$<ThreadMetadataEvent>(
-                    channel,
-                    THREADS_CHANNEL_EVENT,
-                  ),
-                ),
-                map((payload) =>
-                  threadSocketEvents.metadataReceived({ sessionId, payload }),
-                ),
-              );
+          const channel$ = ɵphoenixChannel$({
+            socket$: socket.socket$,
+            topic: `user_meta:${joinCode}`,
+          }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
 
-              const runActivity$ = channel$.pipe(
-                switchMap(({ channel }: ɵPhoenixChannelSession) =>
-                  ɵobservePhoenixEvent$<ThreadRunActivityGatewayPayload>(
-                    channel,
-                    THREAD_RUN_ACTIVITY_CHANNEL_EVENT,
-                  ),
-                ),
-                map((payload) =>
-                  normalizeThreadRunActivityNotification(payload),
-                ),
-                filter(
-                  (
-                    notification,
-                  ): notification is ThreadRunActivityNotification =>
-                    notification !== null,
-                ),
-                map((notification) =>
-                  threadSocketEvents.runActivityReceived({
-                    sessionId,
-                    notification,
-                  }),
-                ),
-              );
+          const metadata$ = channel$.pipe(
+            switchMap(({ channel }: ɵPhoenixChannelSession) =>
+              ɵobservePhoenixEvent$<ThreadMetadataEvent>(
+                channel,
+                THREADS_CHANNEL_EVENT,
+              ),
+            ),
+            map((payload) =>
+              threadSocketEvents.metadataReceived({ sessionId, payload }),
+            ),
+          );
 
-              const joinOutcome$ = ɵobservePhoenixJoinOutcome$(channel$).pipe(
-                filter((outcome) => outcome.type !== "joined"),
-                map((outcome) =>
-                  outcome.type === "timeout"
-                    ? threadSocketEvents.joinTimedOut({ sessionId })
-                    : threadSocketEvents.joinFailed({ sessionId }),
-                ),
-              );
+          const runActivity$ = channel$.pipe(
+            switchMap(({ channel }: ɵPhoenixChannelSession) =>
+              ɵobservePhoenixEvent$<ThreadRunActivityGatewayPayload>(
+                channel,
+                THREAD_RUN_ACTIVITY_CHANNEL_EVENT,
+              ),
+            ),
+            map((payload) => normalizeThreadRunActivityNotification(payload)),
+            filter(
+              (notification): notification is ThreadRunActivityNotification =>
+                notification !== null,
+            ),
+            map((notification) =>
+              threadSocketEvents.runActivityReceived({
+                sessionId,
+                notification,
+              }),
+            ),
+          );
 
-              return merge(metadata$, runActivity$, joinOutcome$).pipe(
-                takeUntil(shutdown$),
-              );
-            }),
-            // A subscribe-credentials fetch failure errors `joinCode$` (it
-            // derives from the shared connection's `fetchSubscription`, which
-            // THROWS on a non-2xx `/threads/subscribe`). Micro-redux is
-            // fail-fast, so an unhandled error here would kill the whole store
-            // (`getState()` would then throw), taking down the REST-backed
-            // list and pagination. Threads deliberately has no realtime-status
-            // signal, so degrade SILENTLY: swallow the error to EMPTY, keeping
-            // the store alive and the list intact.
-            catchError(() => EMPTY),
+          const joinOutcome$ = ɵobservePhoenixJoinOutcome$(channel$).pipe(
+            filter((outcome) => outcome.type !== "joined"),
+            map((outcome) =>
+              outcome.type === "timeout"
+                ? threadSocketEvents.joinTimedOut({ sessionId })
+                : threadSocketEvents.joinFailed({ sessionId }),
+            ),
+          );
+
+          return merge(metadata$, runActivity$, joinOutcome$).pipe(
             takeUntil(shutdown$),
           );
         }),
@@ -993,10 +1170,10 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
   // (already fetched) list is present must NOT become a hard list error —
   // the user keeps the stale list. Without this the actions would be
   // silently swallowed, leaving a realtime-join failure with zero signal.
-  // Socket-level lifecycle/health is now the shared metadata connection's
-  // concern (it warns internally on fatal give-up); this effect only covers
-  // the channel-level join outcome. Session-guarded so a superseded session
-  // stays quiet.
+  // Socket-level lifecycle/health is now the shared metadata socket's concern
+  // (it warns internally on fatal give-up), and the credentials-fetch failure
+  // warns itself (the B5 warn); this effect only covers the channel-level join
+  // outcome. Session-guarded so a superseded session stays quiet.
   const socketDiagnosticsEffect = createEffect(
     (actions$, state$: Observable<ThreadState>) =>
       actions$.pipe(
@@ -1171,6 +1348,8 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
     effects: [
       bootstrapEffect,
       fetchEffect,
+      metadataCredentialsEffect,
+      metadataCredentialsFetchEffect,
       socketEffect,
       realtimeMappingEffect,
       socketDiagnosticsEffect,

--- a/packages/core/src/threads.ts
+++ b/packages/core/src/threads.ts
@@ -1,5 +1,5 @@
 import type { Subscription } from "rxjs";
-import { defer, firstValueFrom, merge, Observable, of } from "rxjs";
+import { defer, EMPTY, firstValueFrom, merge, Observable, of } from "rxjs";
 import {
   catchError,
   filter,
@@ -938,6 +938,15 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
                 takeUntil(shutdown$),
               );
             }),
+            // A subscribe-credentials fetch failure errors `joinCode$` (it
+            // derives from the shared connection's `fetchSubscription`, which
+            // THROWS on a non-2xx `/threads/subscribe`). Micro-redux is
+            // fail-fast, so an unhandled error here would kill the whole store
+            // (`getState()` would then throw), taking down the REST-backed
+            // list and pagination. Threads deliberately has no realtime-status
+            // signal, so degrade SILENTLY: swallow the error to EMPTY, keeping
+            // the store alive and the list intact.
+            catchError(() => EMPTY),
             takeUntil(shutdown$),
           );
         }),

--- a/packages/core/src/threads.ts
+++ b/packages/core/src/threads.ts
@@ -65,6 +65,12 @@ interface ThreadRuntimeContext {
    * when no shared socket is available yet (e.g. the runtime is not connected) —
    * the store then simply never joins its channel and realtime silently stays
    * absent.
+   *
+   * Resolves the shared metadata socket for the given joinToken (seed-once; see
+   * core.ɵgetMetadataSocket). Core DISPOSES the shared socket on disconnect,
+   * header change, and health give-up — so a binding MUST re-dispatch setContext
+   * on return-to-Connected (and header change) to re-resolve a fresh socket,
+   * else the store is stranded on a disposed socket.
    */
   getMetadataSocket: (joinToken: string) => ɵMetadataSocket | null;
 }
@@ -1069,11 +1075,20 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
             ),
           );
 
-          // Resolve the SHARED socket for this joinToken. `null` means no shared
-          // socket is available (e.g. the runtime is not connected yet):
-          // realtime silently stays absent and the REST list is unaffected.
+          // Resolve the SHARED socket for this joinToken. `null` here is reached
+          // AFTER a successful `/threads/subscribe`, so the runtime is connected
+          // but has no shared metadata socket (e.g. connected without a ws URL;
+          // the threads context is not gated on wsUrl). Rather than silently
+          // dropping live updates with no signal, warn so operators can see that
+          // the list will not receive live updates. The (already fetched) REST
+          // list is unaffected. This branch only runs after a successful
+          // subscribe, so it can't false-positive on the normal not-connected
+          // path.
           const socket = context.getMetadataSocket(joinToken);
           if (!socket) {
+            console.warn(
+              "[threads] realtime unavailable: no shared metadata socket (runtime connected without a ws URL?); the thread list will not receive live updates",
+            );
             return EMPTY;
           }
 

--- a/packages/core/src/threads.ts
+++ b/packages/core/src/threads.ts
@@ -1,4 +1,3 @@
-import { phoenixExponentialBackoff } from "@copilotkit/shared";
 import type { Subscription } from "rxjs";
 import { defer, firstValueFrom, merge, Observable, of } from "rxjs";
 import {
@@ -6,7 +5,6 @@ import {
   filter,
   map,
   mergeMap,
-  share,
   shareReplay,
   switchMap,
   take,
@@ -29,18 +27,14 @@ import {
 import type { Reducer, Store } from "./utils/micro-redux";
 import {
   ɵphoenixChannel$,
-  ɵphoenixSocket$,
   ɵobservePhoenixEvent$,
   ɵobservePhoenixJoinOutcome$,
-  ɵobservePhoenixSocketHealth$,
-  ɵobservePhoenixSocketSignals$,
 } from "./utils/phoenix-observable";
 import type { ɵPhoenixChannelSession } from "./utils/phoenix-observable";
+import type { ɵMetadataRealtimeConnection } from "./core/metadata-realtime";
 
 const THREADS_CHANNEL_EVENT = "thread_metadata";
 const THREAD_RUN_ACTIVITY_CHANNEL_EVENT = "thread_run_activity";
-const THREAD_SUBSCRIBE_PATH = "/threads/subscribe";
-const MAX_SOCKET_RETRIES = 5;
 const REQUEST_TIMEOUT_MS = 15_000;
 
 interface ThreadRecord {
@@ -58,10 +52,16 @@ interface ThreadRecord {
 interface ThreadRuntimeContext {
   runtimeUrl: string;
   headers: Record<string, string>;
-  wsUrl?: string;
   agentId: string;
   includeArchived?: boolean;
   limit?: number;
+  /**
+   * The shared per-user metadata realtime connection (owned by `CopilotKitCore`,
+   * shared with the memory store). `null` when no realtime connection is
+   * available yet (e.g. runtime not connected) — the store simply never opens
+   * its `user_meta:<joinCode>` channel in that case.
+   */
+  metadata: ɵMetadataRealtimeConnection | null;
 }
 
 type ThreadMetadataEvent =
@@ -116,10 +116,6 @@ interface ThreadListResponse {
   nextCursor?: string | null;
 }
 
-interface ThreadMetadataCredentialsResponse {
-  joinToken: string;
-}
-
 interface MutationRequest {
   requestId: string;
   /** Session the mutation was dispatched in; stale results are dropped. */
@@ -153,8 +149,6 @@ interface ThreadState {
   error: Error | null;
   context: ThreadRuntimeContext | null;
   sessionId: number;
-  metadataCredentialsRequested: boolean;
-  metadataJoinCode: string | null;
   nextCursor: string | null;
   /** Number of thread mutations currently awaiting a server response. */
   inFlightMutationCount: number;
@@ -175,8 +169,6 @@ const initialThreadState: ThreadState = {
   error: null,
   context: null,
   sessionId: 0,
-  metadataCredentialsRequested: false,
-  metadataJoinCode: null,
   nextCursor: null,
   inFlightMutationCount: 0,
   pendingDeletes: {},
@@ -213,18 +205,10 @@ const threadRestEvents = createActionGroup("Thread REST", {
     nextCursor: string | null;
   }>(),
   nextPageFailed: props<{ sessionId: number; error: Error }>(),
-  metadataCredentialsRequested: props<{ sessionId: number }>(),
-  metadataCredentialsSucceeded: props<{
-    sessionId: number;
-    joinToken: string;
-  }>(),
-  metadataCredentialsFailed: props<{ sessionId: number; error: Error }>(),
   mutationFinished: props<{ outcome: MutationOutcome }>(),
 });
 
 const threadSocketEvents = createActionGroup("Thread Socket", {
-  opened: props<{ sessionId: number }>(),
-  errored: props<{ sessionId: number }>(),
   joinFailed: props<{ sessionId: number }>(),
   joinTimedOut: props<{ sessionId: number }>(),
   metadataReceived: props<{
@@ -309,8 +293,6 @@ const threadReducer = createReducer(
     isLoading: Boolean(context),
     isFetchingNextPage: false,
     error: null,
-    metadataCredentialsRequested: false,
-    metadataJoinCode: null,
     nextCursor: null,
     inFlightMutationCount: 0,
     pendingDeletes: {},
@@ -321,8 +303,6 @@ const threadReducer = createReducer(
     isLoading: false,
     isFetchingNextPage: false,
     error: null,
-    metadataCredentialsRequested: false,
-    metadataJoinCode: null,
     nextCursor: null,
     inFlightMutationCount: 0,
     pendingDeletes: {},
@@ -340,21 +320,16 @@ const threadReducer = createReducer(
   }),
   on(
     threadRestEvents.listSucceeded,
-    (state: ThreadState, { sessionId, threads, joinCode, nextCursor }) => {
+    (state: ThreadState, { sessionId, threads, nextCursor }) => {
       if (sessionId !== state.sessionId) {
         return state;
       }
-      const joinCodeChanged = joinCode !== state.metadataJoinCode;
 
       return {
         ...state,
         threads: sortThreadsByRecency(threads),
         isLoading: false,
         error: null,
-        metadataJoinCode: joinCode,
-        metadataCredentialsRequested: joinCodeChanged
-          ? false
-          : state.metadataCredentialsRequested,
         nextCursor,
       };
     },
@@ -404,40 +379,6 @@ const threadReducer = createReducer(
         ...state,
         isFetchingNextPage: false,
         error,
-      };
-    },
-  ),
-  on(
-    threadRestEvents.metadataCredentialsFailed,
-    (state: ThreadState, { sessionId }) => {
-      if (sessionId !== state.sessionId) {
-        return state;
-      }
-
-      // Non-fatal: the metadata-credentials (realtime join-token) fetch runs
-      // AFTER the thread list has already loaded and only powers the realtime
-      // channel. A failure means realtime won't connect, but the fetched list
-      // is still valid — so we do NOT write `state.error` (which would replace
-      // the whole list with a "couldn't load" panel). The failure is surfaced
-      // as a diagnostic warning instead (socketDiagnosticsEffect), mirroring the
-      // stay-stale handling of a realtime channel join failure. Clear the
-      // request latch so a later list refresh can retry realtime setup.
-      return {
-        ...state,
-        metadataCredentialsRequested: false,
-      };
-    },
-  ),
-  on(
-    threadRestEvents.metadataCredentialsRequested,
-    (state: ThreadState, { sessionId }) => {
-      if (sessionId !== state.sessionId) {
-        return state;
-      }
-
-      return {
-        ...state,
-        metadataCredentialsRequested: true,
       };
     },
   ),
@@ -820,61 +761,6 @@ function createThreadFetchObservable(
   });
 }
 
-function createThreadMetadataCredentialsObservable(
-  environment: ThreadEnvironment,
-  context: ThreadRuntimeContext,
-  sessionId: number,
-): Observable<
-  | ReturnType<typeof threadRestEvents.metadataCredentialsSucceeded>
-  | ReturnType<typeof threadRestEvents.metadataCredentialsFailed>
-> {
-  return defer(() => {
-    return threadFromFetch(`${context.runtimeUrl}${THREAD_SUBSCRIBE_PATH}`, {
-      selector: async (response) => {
-        if (!response.ok) {
-          throw new Error(
-            `Failed to fetch thread metadata credentials: ${response.status}`,
-          );
-        }
-
-        return response.json() as Promise<ThreadMetadataCredentialsResponse>;
-      },
-      fetch: environment.fetch,
-      method: "POST",
-      headers: {
-        ...context.headers,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({}),
-    }).pipe(
-      timeout({
-        first: REQUEST_TIMEOUT_MS,
-        with: () => {
-          throw new Error("Request timed out");
-        },
-      }),
-      map((data) => {
-        if (typeof data.joinToken !== "string" || data.joinToken.length === 0) {
-          throw new Error("missing joinToken");
-        }
-
-        return threadRestEvents.metadataCredentialsSucceeded({
-          sessionId,
-          joinToken: data.joinToken,
-        });
-      }),
-      catchError((error) => {
-        return of(
-          threadRestEvents.metadataCredentialsFailed({
-            sessionId,
-            error: error instanceof Error ? error : new Error(String(error)),
-          }),
-        );
-      }),
-    );
-  });
-}
-
 function createThreadMutationObservable(
   environment: ThreadEnvironment,
   context: ThreadRuntimeContext,
@@ -974,74 +860,21 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
       ),
   );
 
-  const metadataCredentialsEffect = createEffect(
-    (actions$, state$: Observable<ThreadState>) =>
-      actions$.pipe(
-        ofType(threadRestEvents.listSucceeded),
-        withLatestFrom(state$),
-        filter(([action, state]) => {
-          return (
-            action.sessionId === state.sessionId &&
-            !state.metadataCredentialsRequested &&
-            Boolean(state.context?.wsUrl) &&
-            Boolean(state.metadataJoinCode)
-          );
-        }),
-        map(([action]) =>
-          threadRestEvents.metadataCredentialsRequested({
-            sessionId: action.sessionId,
-          }),
-        ),
-      ),
-  );
-
-  const metadataCredentialsFetchEffect = createEffect(
-    (actions$, state$: Observable<ThreadState>) =>
-      actions$.pipe(
-        ofType(threadRestEvents.metadataCredentialsRequested),
-        switchMap((action) =>
-          state$.pipe(
-            map((state) => state.context),
-            filter((context): context is ThreadRuntimeContext =>
-              Boolean(context),
-            ),
-            take(1),
-            map((context) => ({ action, context })),
-            takeUntil(
-              actions$.pipe(
-                ofType(
-                  threadAdapterEvents.contextChanged,
-                  threadAdapterEvents.stopped,
-                ),
-              ),
-            ),
-            switchMap(({ action: currentAction, context }) =>
-              createThreadMetadataCredentialsObservable(
-                environment,
-                context,
-                currentAction.sessionId,
-              ),
-            ),
-          ),
-        ),
-      ),
-  );
-
+  // Joins `user_meta:<joinCode>` off the SHARED metadata realtime connection
+  // (`context.metadata`, owned by `CopilotKitCore` and shared with the memory
+  // store) instead of opening its own socket. Socket lifecycle/health is the
+  // shared connection's concern; this store only cares about the channel join
+  // outcome (surfaced via `joinFailed`/`joinTimedOut`, warned by
+  // `socketDiagnosticsEffect` below) and the two channel events it maps.
   const socketEffect = createEffect(
     (actions$, state$: Observable<ThreadState>) =>
       actions$.pipe(
-        ofType(threadRestEvents.metadataCredentialsSucceeded),
+        ofType(threadAdapterEvents.contextChanged),
         withLatestFrom(state$),
-        filter(([action, state]) => {
-          return (
-            action.sessionId === state.sessionId &&
-            Boolean(state.context?.wsUrl)
-          );
-        }),
-        switchMap(([action, state]) => {
-          const context = state.context as ThreadRuntimeContext;
-          const joinToken = action.joinToken as string;
-          const joinCode = state.metadataJoinCode as string;
+        filter(([, state]) => Boolean(state.context?.metadata)),
+        switchMap(([, state]) => {
+          const { metadata } = state.context as ThreadRuntimeContext;
+          const sessionId = state.sessionId;
           const shutdown$ = actions$.pipe(
             ofType(
               threadAdapterEvents.contextChanged,
@@ -1049,93 +882,64 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
             ),
           );
 
-          return defer(() => {
-            const socket$ = ɵphoenixSocket$({
-              url: context.wsUrl!,
-              options: {
-                params: { join_token: joinToken },
-                reconnectAfterMs: phoenixExponentialBackoff(100, 10_000),
-                rejoinAfterMs: phoenixExponentialBackoff(1_000, 30_000),
-              },
-            }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
-            const channel$ = ɵphoenixChannel$({
-              socket$,
-              topic: `user_meta:${joinCode}`,
-            }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
-            const socketSignals$ =
-              ɵobservePhoenixSocketSignals$(socket$).pipe(share());
-            const fatalSocketShutdown$ = ɵobservePhoenixSocketHealth$(
-              socketSignals$,
-              MAX_SOCKET_RETRIES,
-            ).pipe(
-              catchError(() => {
-                console.warn(
-                  `[threads] WebSocket failed after ${MAX_SOCKET_RETRIES} attempts, giving up`,
-                );
-                return of(undefined);
-              }),
-              share(),
-            );
-            const socketLifecycle$ = socketSignals$.pipe(
-              map((signal) =>
-                signal.type === "open"
-                  ? threadSocketEvents.opened({ sessionId: action.sessionId })
-                  : threadSocketEvents.errored({ sessionId: action.sessionId }),
-              ),
-            );
-            const metadata$ = channel$.pipe(
-              switchMap(({ channel }: ɵPhoenixChannelSession) =>
-                ɵobservePhoenixEvent$<ThreadMetadataEvent>(
-                  channel,
-                  THREADS_CHANNEL_EVENT,
-                ),
-              ),
-              map((payload) =>
-                threadSocketEvents.metadataReceived({
-                  sessionId: action.sessionId,
-                  payload,
-                }),
-              ),
-            );
-            const runActivity$ = channel$.pipe(
-              switchMap(({ channel }: ɵPhoenixChannelSession) =>
-                ɵobservePhoenixEvent$<ThreadRunActivityGatewayPayload>(
-                  channel,
-                  THREAD_RUN_ACTIVITY_CHANNEL_EVENT,
-                ),
-              ),
-              map((payload) => normalizeThreadRunActivityNotification(payload)),
-              filter(
-                (notification): notification is ThreadRunActivityNotification =>
-                  notification !== null,
-              ),
-              map((notification) =>
-                threadSocketEvents.runActivityReceived({
-                  sessionId: action.sessionId,
-                  notification,
-                }),
-              ),
-            );
-            const joinOutcome$ = ɵobservePhoenixJoinOutcome$(channel$).pipe(
-              filter((outcome) => outcome.type !== "joined"),
-              map((outcome) =>
-                outcome.type === "timeout"
-                  ? threadSocketEvents.joinTimedOut({
-                      sessionId: action.sessionId,
-                    })
-                  : threadSocketEvents.joinFailed({
-                      sessionId: action.sessionId,
-                    }),
-              ),
-            );
+          return metadata!.joinCode$.pipe(
+            switchMap((joinCode) => {
+              const channel$ = ɵphoenixChannel$({
+                socket$: metadata!.socket$,
+                topic: `user_meta:${joinCode}`,
+              }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
 
-            return merge(
-              socketLifecycle$,
-              metadata$,
-              runActivity$,
-              joinOutcome$,
-            ).pipe(takeUntil(merge(shutdown$, fatalSocketShutdown$)));
-          });
+              const metadata$ = channel$.pipe(
+                switchMap(({ channel }: ɵPhoenixChannelSession) =>
+                  ɵobservePhoenixEvent$<ThreadMetadataEvent>(
+                    channel,
+                    THREADS_CHANNEL_EVENT,
+                  ),
+                ),
+                map((payload) =>
+                  threadSocketEvents.metadataReceived({ sessionId, payload }),
+                ),
+              );
+
+              const runActivity$ = channel$.pipe(
+                switchMap(({ channel }: ɵPhoenixChannelSession) =>
+                  ɵobservePhoenixEvent$<ThreadRunActivityGatewayPayload>(
+                    channel,
+                    THREAD_RUN_ACTIVITY_CHANNEL_EVENT,
+                  ),
+                ),
+                map((payload) =>
+                  normalizeThreadRunActivityNotification(payload),
+                ),
+                filter(
+                  (
+                    notification,
+                  ): notification is ThreadRunActivityNotification =>
+                    notification !== null,
+                ),
+                map((notification) =>
+                  threadSocketEvents.runActivityReceived({
+                    sessionId,
+                    notification,
+                  }),
+                ),
+              );
+
+              const joinOutcome$ = ɵobservePhoenixJoinOutcome$(channel$).pipe(
+                filter((outcome) => outcome.type !== "joined"),
+                map((outcome) =>
+                  outcome.type === "timeout"
+                    ? threadSocketEvents.joinTimedOut({ sessionId })
+                    : threadSocketEvents.joinFailed({ sessionId }),
+                ),
+              );
+
+              return merge(metadata$, runActivity$, joinOutcome$).pipe(
+                takeUntil(shutdown$),
+              );
+            }),
+            takeUntil(shutdown$),
+          );
         }),
       ),
   );
@@ -1174,33 +978,26 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
       ),
   );
 
-  // Observability-only effect for realtime-join health. The socket effect
-  // dispatches `joinFailed`/`joinTimedOut`/`errored` but the reducer has no
-  // handler for them by design: a transient WS drop while the (already
-  // fetched) list is present must NOT become a hard list error — the user
-  // keeps the stale list. Previously these actions were silently swallowed,
-  // leaving a realtime-join failure with zero signal. This effect emits a
-  // non-fatal warning (mirroring the MAX_SOCKET_RETRIES warn) so the failure
-  // is diagnosable. Session-guarded so a superseded session stays quiet.
+  // Observability-only effect for realtime channel-join health. The socket
+  // effect dispatches `joinFailed`/`joinTimedOut` but the reducer has no
+  // handler for them by design: a transient channel-join failure while the
+  // (already fetched) list is present must NOT become a hard list error —
+  // the user keeps the stale list. Without this the actions would be
+  // silently swallowed, leaving a realtime-join failure with zero signal.
+  // Socket-level lifecycle/health is now the shared metadata connection's
+  // concern (it warns internally on fatal give-up); this effect only covers
+  // the channel-level join outcome. Session-guarded so a superseded session
+  // stays quiet.
   const socketDiagnosticsEffect = createEffect(
     (actions$, state$: Observable<ThreadState>) =>
       actions$.pipe(
-        ofType(
-          threadSocketEvents.joinFailed,
-          threadSocketEvents.joinTimedOut,
-          threadSocketEvents.errored,
-          threadRestEvents.metadataCredentialsFailed,
-        ),
+        ofType(threadSocketEvents.joinFailed, threadSocketEvents.joinTimedOut),
         withLatestFrom(state$),
         filter(([action, state]) => action.sessionId === state.sessionId),
         tap(([action]) => {
           const reason = threadSocketEvents.joinTimedOut.match(action)
             ? "channel join timed out"
-            : threadSocketEvents.joinFailed.match(action)
-              ? "channel join was rejected"
-              : threadRestEvents.metadataCredentialsFailed.match(action)
-                ? "metadata credentials fetch failed"
-                : "socket errored";
+            : "channel join was rejected";
           console.warn(
             `[threads] realtime ${reason}; the thread list may be stale until reconnect`,
           );
@@ -1365,8 +1162,6 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
     effects: [
       bootstrapEffect,
       fetchEffect,
-      metadataCredentialsEffect,
-      metadataCredentialsFetchEffect,
       socketEffect,
       realtimeMappingEffect,
       socketDiagnosticsEffect,
@@ -1549,10 +1344,3 @@ export const ɵselectHasNextPage = selectHasNextPage;
 export const ɵselectIsFetchingNextPage = selectIsFetchingNextPage;
 export const ɵselectIsMutating = selectIsMutating;
 export { createThreadStore as ɵcreateThreadStore };
-/**
- * Number of consecutive WebSocket connection failures after which the
- * threads channel tears itself down rather than retrying indefinitely.
- * Exposed for tests so they can assert teardown semantics without
- * hardcoding the threshold separately from production.
- */
-export const ɵMAX_SOCKET_RETRIES = MAX_SOCKET_RETRIES;

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -446,7 +446,7 @@ export function CopilotChat({
         ? {
             runtimeUrl: copilotkit.runtimeUrl,
             headers: { ...copilotkit.headers },
-            wsUrl: copilotkit.intelligence?.wsUrl,
+            metadata: copilotkit.ɵgetMetadataRealtime() ?? null,
             agentId: resolvedAgentId,
           }
         : null;

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -446,7 +446,8 @@ export function CopilotChat({
         ? {
             runtimeUrl: copilotkit.runtimeUrl,
             headers: { ...copilotkit.headers },
-            metadata: copilotkit.ɵgetMetadataRealtime() ?? null,
+            getMetadataSocket: (joinToken) =>
+              copilotkit.ɵgetMetadataSocket(joinToken) ?? null,
             agentId: resolvedAgentId,
           }
         : null;

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.runActivityReconnect.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.runActivityReconnect.test.tsx
@@ -180,15 +180,13 @@ function createTestCore(
     ),
     headers: {},
     intelligence: options.intelligence,
-    // Mirrors `CopilotKitCore.ɵgetMetadataRealtime()`: the shared realtime
-    // connection while a realtime `wsUrl` is known, else undefined. The
-    // standalone run-activity store here is a vi.fn mock that never consumes
-    // the connection, so an opaque marker is enough to prove the chat threaded
-    // `metadata` into the dispatched context.
-    ɵgetMetadataRealtime: vi.fn(() =>
-      options.intelligence?.wsUrl
-        ? { ɵmetadataConnectionStub: true }
-        : undefined,
+    // Mirrors `CopilotKitCore.ɵgetMetadataSocket(joinToken)`: the shared
+    // credential-agnostic socket while a realtime `wsUrl` is known, else
+    // undefined. The standalone run-activity store here is a vi.fn mock that
+    // never consumes the socket, so an opaque marker is enough to prove the chat
+    // threaded `getMetadataSocket` into the dispatched context.
+    ɵgetMetadataSocket: vi.fn((_joinToken: string) =>
+      options.intelligence?.wsUrl ? { ɵmetadataSocketStub: true } : undefined,
     ),
     registerThreadStore: vi.fn(),
     runtimeConnectionStatus:

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.runActivityReconnect.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.runActivityReconnect.test.tsx
@@ -180,6 +180,16 @@ function createTestCore(
     ),
     headers: {},
     intelligence: options.intelligence,
+    // Mirrors `CopilotKitCore.ɵgetMetadataRealtime()`: the shared realtime
+    // connection while a realtime `wsUrl` is known, else undefined. The
+    // standalone run-activity store here is a vi.fn mock that never consumes
+    // the connection, so an opaque marker is enough to prove the chat threaded
+    // `metadata` into the dispatched context.
+    ɵgetMetadataRealtime: vi.fn(() =>
+      options.intelligence?.wsUrl
+        ? { ɵmetadataConnectionStub: true }
+        : undefined,
+    ),
     registerThreadStore: vi.fn(),
     runtimeConnectionStatus:
       options.runtimeConnectionStatus ??

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.runActivityReconnect.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.runActivityReconnect.test.tsx
@@ -183,8 +183,9 @@ function createTestCore(
     // Mirrors `CopilotKitCore.ɵgetMetadataSocket(joinToken)`: the shared
     // credential-agnostic socket while a realtime `wsUrl` is known, else
     // undefined. The standalone run-activity store here is a vi.fn mock that
-    // never consumes the socket, so an opaque marker is enough to prove the chat
-    // threaded `getMetadataSocket` into the dispatched context.
+    // never consumes the socket; the standalone test below asserts only that the
+    // chat threaded a `getMetadataSocket` provider (a function) into the
+    // dispatched context, not this return value.
     ɵgetMetadataSocket: vi.fn((_joinToken: string) =>
       options.intelligence?.wsUrl ? { ɵmetadataSocketStub: true } : undefined,
     ),
@@ -286,6 +287,17 @@ test("standalone explicit Intelligence chat subscribes to run activity without a
     registeredStore: null,
   });
   await settleInitialConnect(rendered);
+
+  // Verifies the react-side wiring at CopilotChat.tsx: when the chat owns the
+  // standalone run-activity store it dispatches a context that threads a
+  // `getMetadataSocket` provider (a live closure over `core.ɵgetMetadataSocket`),
+  // so the store can re-resolve the shared metadata socket. We assert only that
+  // a function was threaded, not its return value.
+  await waitFor(() => {
+    expect(standaloneStore.setContext).toHaveBeenCalledWith(
+      expect.objectContaining({ getMetadataSocket: expect.any(Function) }),
+    );
+  });
 
   emitRunActivity(standaloneStore);
 

--- a/packages/react-core/src/v2/hooks/__tests__/use-memories.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-memories.test.tsx
@@ -12,7 +12,10 @@ import {
 } from "vitest";
 import type { Mock } from "vitest";
 import { useCopilotKit } from "../../context";
-import { ɵcreateMemoryStore } from "@copilotkit/core";
+import {
+  ɵcreateMemoryStore,
+  ɵcreateMetadataRealtimeConnection,
+} from "@copilotkit/core";
 import type { ɵMemoryStore } from "@copilotkit/core";
 import { useMemories } from "../use-memories";
 
@@ -126,7 +129,10 @@ function setupCopilotKit(mock: Mock): void {
 function activateStore(): void {
   store.setContext({
     runtimeUrl: RUNTIME_URL,
-    wsUrl: "wss://gw.example.com/client",
+    metadata: ɵcreateMetadataRealtimeConnection({
+      wsUrl: "wss://gw.example.com/client",
+      fetchSubscription: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+    }),
     headers: {},
   });
 }

--- a/packages/react-core/src/v2/hooks/__tests__/use-memories.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-memories.test.tsx
@@ -12,11 +12,8 @@ import {
 } from "vitest";
 import type { Mock } from "vitest";
 import { useCopilotKit } from "../../context";
-import {
-  ɵcreateMemoryStore,
-  ɵcreateMetadataRealtimeConnection,
-} from "@copilotkit/core";
-import type { ɵMemoryStore } from "@copilotkit/core";
+import { ɵcreateMemoryStore, ɵcreateMetadataSocket } from "@copilotkit/core";
+import type { ɵMemoryStore, ɵMetadataSocket } from "@copilotkit/core";
 import { useMemories } from "../use-memories";
 
 vi.mock("../../context", () => ({
@@ -127,12 +124,22 @@ function setupCopilotKit(mock: Mock): void {
  * subscribed when the async response arrives.
  */
 function activateStore(): void {
+  // Mirror `CopilotKitCore.ɵgetMetadataSocket`: ONE credential-agnostic socket
+  // created on first call and memoized, so repeated resolves return the same
+  // instance. The store fetches its own `/memories/subscribe` creds and hands
+  // the token here.
+  let socket: ɵMetadataSocket | undefined;
   store.setContext({
     runtimeUrl: RUNTIME_URL,
-    metadata: ɵcreateMetadataRealtimeConnection({
-      wsUrl: "wss://gw.example.com/client",
-      fetchSubscription: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
-    }),
+    getMetadataSocket: (joinToken: string) => {
+      if (!socket) {
+        socket = ɵcreateMetadataSocket({
+          wsUrl: "wss://gw.example.com/client",
+          joinToken,
+        }).socket;
+      }
+      return socket;
+    },
     headers: {},
   });
 }

--- a/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
@@ -12,8 +12,9 @@ import {
 import { useCopilotKit } from "../../context";
 import {
   CopilotKitCoreRuntimeConnectionStatus,
-  ɵMAX_SOCKET_RETRIES,
+  ɵcreateMetadataRealtimeConnection,
 } from "@copilotkit/core";
+import type { ɵMetadataRealtimeConnection } from "@copilotkit/core";
 
 vi.mock("../../context", () => ({
   useCopilotKit: vi.fn(),
@@ -205,16 +206,48 @@ const supportedThreadEndpoints = {
   realtimeMetadata: true,
 };
 
+/**
+ * Builds a `ɵgetMetadataRealtime` stand-in that mirrors `CopilotKitCore`'s
+ * real lazy-memoized behavior: the shared connection is created on first
+ * call (via the real `ɵcreateMetadataRealtimeConnection`) and the same
+ * instance is returned on subsequent calls, so the mocked `phoenix` module
+ * exercises the same code path production wiring does.
+ *
+ * `fetchSubscription` resolves synthetically (mirrors `fakeMetadataConnection`
+ * in `@copilotkit/core`'s `threads.test.ts`/`memory.test.ts`) rather than
+ * going through the shared `fetchMock`: minting the join token/code is
+ * `CopilotKitCore.fetchMetadataSubscription`'s concern (covered by core's own
+ * tests), and it runs on its own schedule relative to the unrelated
+ * `/threads` list fetch this store issues — routing it through the same
+ * `fetchMock` queue would race the two and make call order nondeterministic.
+ */
+function createMetadataRealtimeFactory(
+  wsUrl: string,
+  joinCode = "jc-1",
+): () => ɵMetadataRealtimeConnection {
+  let connection: ɵMetadataRealtimeConnection | undefined;
+  return () => {
+    if (!connection) {
+      connection = ɵcreateMetadataRealtimeConnection({
+        wsUrl,
+        fetchSubscription: async () => ({ joinToken: "jt-1", joinCode }),
+      });
+    }
+    return connection;
+  };
+}
+
 function setupCopilotKit(runtimeUrl = "http://localhost:4000") {
+  const headers = { Authorization: "Bearer test-token" };
+  const wsUrl = "ws://localhost:4000/client";
   mockUseCopilotKit.mockReturnValue({
     copilotkit: {
       runtimeUrl,
       runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Connected,
-      headers: { Authorization: "Bearer test-token" },
+      headers,
       threadEndpoints: supportedThreadEndpoints,
-      intelligence: {
-        wsUrl: "ws://localhost:4000/client",
-      },
+      intelligence: { wsUrl },
+      ɵgetMetadataRealtime: createMetadataRealtimeFactory(wsUrl),
       registerThreadStore: vi.fn(),
       unregisterThreadStore: vi.fn(),
     },
@@ -280,11 +313,9 @@ describe("useThreads", () => {
   });
 
   it("fetches threads and subscribes to the user metadata channel", async () => {
-    fetchMock
-      .mockReturnValueOnce(
-        jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
-      )
-      .mockReturnValueOnce(jsonResponse({ joinToken: "jt-1" }));
+    fetchMock.mockReturnValueOnce(
+      jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
+    );
 
     const { result } = renderHook(() => useThreads(defaultInput));
 
@@ -301,11 +332,11 @@ describe("useThreads", () => {
       expect.stringContaining("/threads?agentId=agent-1"),
       expect.objectContaining({ method: "GET" }),
     );
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining("/threads/subscribe"),
-      expect.objectContaining({ method: "POST" }),
-    );
-
+    // Minting the join token/code (`POST /threads/subscribe`) is
+    // `CopilotKitCore.ɵgetMetadataRealtime()`'s concern now, not this store's
+    // — it's exercised via the mocked `ɵgetMetadataRealtime`, not `fetchMock`.
+    // This hook only owns joining the `user_meta:<joinCode>` channel off the
+    // resulting shared socket, asserted below.
     const socket = getMockSockets()[0];
     expect(socket.connected).toBe(true);
     expect(socket.channels[0].topic).toBe("user_meta:jc-1");
@@ -373,6 +404,9 @@ describe("useThreads", () => {
         headers: {},
         threadEndpoints: supportedThreadEndpoints,
         intelligence: { wsUrl: "ws://localhost:4000/client" },
+        ɵgetMetadataRealtime: createMetadataRealtimeFactory(
+          "ws://localhost:4000/client",
+        ),
         registerThreadStore,
         unregisterThreadStore,
       },
@@ -397,6 +431,7 @@ describe("useThreads", () => {
           realtimeMetadata: false,
         },
         intelligence: undefined,
+        ɵgetMetadataRealtime: () => undefined,
         registerThreadStore: vi.fn(),
         unregisterThreadStore: vi.fn(),
       },
@@ -424,6 +459,7 @@ describe("useThreads", () => {
         headers: { Authorization: "Bearer test-token" },
         threadEndpoints: undefined,
         intelligence: undefined,
+        ɵgetMetadataRealtime: () => undefined,
         registerThreadStore: vi.fn(),
         unregisterThreadStore: vi.fn(),
       },
@@ -461,6 +497,7 @@ describe("useThreads", () => {
           realtimeMetadata: false,
         },
         intelligence: undefined,
+        ɵgetMetadataRealtime: () => undefined,
         registerThreadStore: vi.fn(),
         unregisterThreadStore: vi.fn(),
       },
@@ -488,11 +525,9 @@ describe("useThreads", () => {
   });
 
   it("updates local state directly from realtime metadata events", async () => {
-    fetchMock
-      .mockReturnValueOnce(
-        jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
-      )
-      .mockReturnValueOnce(jsonResponse({ joinToken: "jt-1" }));
+    fetchMock.mockReturnValueOnce(
+      jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
+    );
 
     const { result } = renderHook(() => useThreads(defaultInput));
 
@@ -521,15 +556,15 @@ describe("useThreads", () => {
       expect(result.current.threads[0].name).toBe("Renamed Thread");
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // The realtime metadata push updates the store directly — it must NOT
+    // trigger an extra REST refetch beyond the initial list call.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("applies realtime metadata without client-side user filtering", async () => {
-    fetchMock
-      .mockReturnValueOnce(
-        jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
-      )
-      .mockReturnValueOnce(jsonResponse({ joinToken: "jt-1" }));
+    fetchMock.mockReturnValueOnce(
+      jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
+    );
 
     const { result } = renderHook(() => useThreads(defaultInput));
 
@@ -561,7 +596,6 @@ describe("useThreads", () => {
       .mockReturnValueOnce(
         jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
       )
-      .mockReturnValueOnce(jsonResponse({ joinToken: "jt-1" }))
       .mockReturnValueOnce(jsonResponse({}));
 
     const { result } = renderHook(() => useThreads(defaultInput));
@@ -596,7 +630,6 @@ describe("useThreads", () => {
       .mockReturnValueOnce(
         jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
       )
-      .mockReturnValueOnce(jsonResponse({ joinToken: "jt-1" }))
       .mockReturnValueOnce(jsonResponse({}))
       .mockReturnValueOnce(jsonResponse({}));
 
@@ -643,7 +676,6 @@ describe("useThreads", () => {
       .mockReturnValueOnce(
         jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
       )
-      .mockReturnValueOnce(jsonResponse({ joinToken: "jt-1" }))
       .mockReturnValueOnce(jsonResponse({}));
 
     const { result } = renderHook(() => useThreads(defaultInput));
@@ -669,15 +701,13 @@ describe("useThreads", () => {
   });
 
   it("exposes thread-scoped pagination properties", async () => {
-    fetchMock
-      .mockReturnValueOnce(
-        jsonResponse({
-          threads: sampleThreads,
-          joinCode: "jc-1",
-          nextCursor: "cursor-abc",
-        }),
-      )
-      .mockReturnValueOnce(jsonResponse({ joinToken: "jt-1" }));
+    fetchMock.mockReturnValueOnce(
+      jsonResponse({
+        threads: sampleThreads,
+        joinCode: "jc-1",
+        nextCursor: "cursor-abc",
+      }),
+    );
 
     const { result } = renderHook(() => useThreads(defaultInput));
 
@@ -719,7 +749,6 @@ describe("useThreads", () => {
           nextCursor: "cursor-abc",
         }),
       )
-      .mockReturnValueOnce(jsonResponse({ joinToken: "jt-1" }))
       .mockReturnValueOnce(
         jsonResponse({ threads: nextPageThreads, joinCode: "jc-1" }),
       );
@@ -755,11 +784,9 @@ describe("useThreads", () => {
   });
 
   it("does not expose organizationId or createdById on threads", async () => {
-    fetchMock
-      .mockReturnValueOnce(
-        jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
-      )
-      .mockReturnValueOnce(jsonResponse({ joinToken: "jt-1" }));
+    fetchMock.mockReturnValueOnce(
+      jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
+    );
 
     const { result } = renderHook(() => useThreads(defaultInput));
 
@@ -779,48 +806,21 @@ describe("useThreads", () => {
     }
   });
 
-  it("tears down sockets after repeated connection failures", async () => {
-    fetchMock
-      .mockReturnValueOnce(
-        jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
-      )
-      .mockReturnValueOnce(jsonResponse({ joinToken: "jt-1" }));
+  // NOTE: a "tears down sockets after repeated connection failures" test
+  // previously lived here, asserting that the thread store itself gave up
+  // and disconnected its socket after `ɵMAX_SOCKET_RETRIES` consecutive
+  // errors. That behavior has moved: the shared metadata realtime connection
+  // (`ɵcreateMetadataRealtimeConnection` in `@copilotkit/core`) now owns
+  // socket retry/give-up, and `threads.ts` no longer references
+  // `ɵMETADATA_MAX_SOCKET_RETRIES`, `dispose()`, or the socket's `error`
+  // signal at all — it only joins a channel off the shared `socket$`. The
+  // give-up path is covered where it now lives: `metadata-realtime.test.ts`
+  // and `memory.test.ts` in `@copilotkit/core`.
 
-    renderHook(() => useThreads(defaultInput));
-
-    await waitFor(() => {
-      expect(getMockSockets().length).toBe(1);
-    });
-
-    const socket = getMockSockets()[0];
-    const channel = socket.channels[0];
-
-    // Threshold is sourced from production (ɵMAX_SOCKET_RETRIES) so a
-    // future change to the retry budget cannot silently desync the test.
-    // We fire all errors inside a single act to keep the rxjs cleanup
-    // synchronous with the assertions, then check the pre-threshold and
-    // post-threshold states by inspecting the socket between iterations.
-    act(() => {
-      for (let index = 0; index < ɵMAX_SOCKET_RETRIES - 1; index += 1) {
-        socket.triggerError();
-      }
-      // Pre-threshold: teardown must NOT be premature.
-      expect(channel.left).toBe(false);
-      expect(socket.disconnected).toBe(false);
-      // The Nth error crosses the threshold and triggers teardown.
-      socket.triggerError();
-    });
-
-    expect(channel.left).toBe(true);
-    expect(socket.disconnected).toBe(true);
-  });
-
-  it("tears down the active socket on unmount", async () => {
-    fetchMock
-      .mockReturnValueOnce(
-        jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
-      )
-      .mockReturnValueOnce(jsonResponse({ joinToken: "jt-1" }));
+  it("leaves the channel on unmount but keeps the shared socket alive for other consumers", async () => {
+    fetchMock.mockReturnValueOnce(
+      jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
+    );
 
     const { unmount } = renderHook(() => useThreads(defaultInput));
 
@@ -833,8 +833,13 @@ describe("useThreads", () => {
 
     unmount();
 
+    // The store leaves ITS channel on unmount...
     expect(channel.left).toBe(true);
-    expect(socket.disconnected).toBe(true);
+    // ...but the underlying socket is owned by the shared connection
+    // (`CopilotKitCore.ɵgetMetadataRealtime()`, refCount:false), not by this
+    // one hook instance, so a single consumer unmounting must not disconnect
+    // it out from under other consumers (e.g. the memory store) sharing it.
+    expect(socket.disconnected).toBe(false);
   });
 
   it("registers thread store on mount and unregisters on unmount", async () => {
@@ -854,16 +859,17 @@ describe("useThreads", () => {
         headers: { Authorization: "Bearer test-token" },
         threadEndpoints: supportedThreadEndpoints,
         intelligence: { wsUrl: "ws://localhost:4000/client" },
+        ɵgetMetadataRealtime: createMetadataRealtimeFactory(
+          "ws://localhost:4000/client",
+        ),
         registerThreadStore,
         unregisterThreadStore,
       },
     });
 
-    fetchMock
-      .mockReturnValueOnce(
-        jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
-      )
-      .mockReturnValueOnce(jsonResponse({ joinToken: "jt-1" }));
+    fetchMock.mockReturnValueOnce(
+      jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
+    );
 
     const { unmount } = renderHook(() => useThreads(defaultInput));
 
@@ -891,16 +897,15 @@ describe("useThreads", () => {
         headers: { Authorization: "Bearer test-token" },
         threadEndpoints: supportedThreadEndpoints,
         intelligence: undefined,
+        ɵgetMetadataRealtime: () => undefined,
         registerThreadStore: vi.fn(),
         unregisterThreadStore: vi.fn(),
       },
     });
 
-    fetchMock
-      .mockReturnValueOnce(
-        jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
-      )
-      .mockReturnValueOnce(jsonResponse({ joinToken: "jt-1" }));
+    fetchMock.mockReturnValueOnce(
+      jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
+    );
 
     const { result, rerender } = renderHook(() => useThreads(defaultInput));
 
@@ -932,6 +937,9 @@ describe("useThreads", () => {
         headers: { Authorization: "Bearer test-token" },
         threadEndpoints: supportedThreadEndpoints,
         intelligence: { wsUrl: "ws://localhost:4000/client" },
+        ɵgetMetadataRealtime: createMetadataRealtimeFactory(
+          "ws://localhost:4000/client",
+        ),
         registerThreadStore: vi.fn(),
         unregisterThreadStore: vi.fn(),
       },

--- a/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import {
   afterAll,
@@ -13,8 +12,12 @@ import { useCopilotKit } from "../../context";
 import {
   CopilotKitCoreRuntimeConnectionStatus,
   ɵcreateMetadataRealtimeConnection,
+  ɵcreateMemoryStore,
 } from "@copilotkit/core";
-import type { ɵMetadataRealtimeConnection } from "@copilotkit/core";
+import type {
+  ɵMetadataRealtimeConnection,
+  ɵMemoryStore,
+} from "@copilotkit/core";
 
 vi.mock("../../context", () => ({
   useCopilotKit: vi.fn(),
@@ -964,5 +967,92 @@ describe("useThreads", () => {
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
     });
+  });
+
+  it("threads + memory share a single core-owned socket (one socket, two channels)", async () => {
+    // Both feeds must derive their connection from the SAME memoized factory
+    // call the real `CopilotKitCore.ɵgetMetadataRealtime()` would produce —
+    // mirrors `core.ts`'s own `_metadataRealtime` memoization so the thread
+    // store (via the hook) and the memory store (via `getMemoryStore()`) are
+    // wired to one shared `ɵMetadataRealtimeConnection`, exactly like
+    // production `syncMemoryContext()` does off the same core instance.
+    const wsUrl = "ws://localhost:4000/client";
+    const runtimeUrl = "http://localhost:4000";
+    const headers = { Authorization: "Bearer test-token" };
+    const metadataFactory = createMetadataRealtimeFactory(wsUrl);
+
+    let memoryStore: ɵMemoryStore | undefined;
+    function getMemoryStore(): ɵMemoryStore {
+      if (!memoryStore) {
+        memoryStore = ɵcreateMemoryStore({
+          fetch: fetchMock as unknown as typeof fetch,
+        });
+        memoryStore.start();
+        memoryStore.setContext({
+          runtimeUrl,
+          headers,
+          // Calling the SAME factory instance returns the memoized shared
+          // connection created by the hook below (or creates it here first —
+          // either way there is exactly one instance to go around).
+          metadata: metadataFactory(),
+        });
+      }
+      return memoryStore;
+    }
+
+    mockUseCopilotKit.mockReturnValue({
+      copilotkit: {
+        runtimeUrl,
+        runtimeConnectionStatus:
+          CopilotKitCoreRuntimeConnectionStatus.Connected,
+        headers,
+        threadEndpoints: supportedThreadEndpoints,
+        intelligence: { wsUrl },
+        ɵgetMetadataRealtime: metadataFactory,
+        registerThreadStore: vi.fn(),
+        unregisterThreadStore: vi.fn(),
+      },
+    });
+
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/threads")) {
+        return jsonResponse({ threads: sampleThreads, joinCode: "jc-1" });
+      }
+      if (url.includes("/memories")) {
+        return jsonResponse({ memories: [] });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    // 1. Mount `useThreads` — joins `user_meta:jc-1` off the shared connection.
+    const { result } = renderHook(() => useThreads(defaultInput));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // 2. Pull the core-owned memory store — joins `user_meta:memories:jc-1`
+    // off the SAME shared connection.
+    const store = getMemoryStore();
+
+    // Headline assertion: exactly ONE phoenix socket was ever constructed,
+    // even though two independent stores each opened their own channel. If
+    // the lift-websocket-creation refactor were reverted (each store minting
+    // its own socket instead of riding the core-owned one), this would fail
+    // with `phoenix.sockets.length === 2`.
+    await waitFor(() => {
+      expect(phoenix.sockets.length).toBe(1);
+    });
+
+    const socket = phoenix.sockets[0];
+    await waitFor(() => {
+      expect(socket.channels.length).toBe(2);
+    });
+
+    const topics = socket.channels.map((channel) => channel.topic);
+    expect(topics).toContain("user_meta:jc-1");
+    expect(topics).toContain("user_meta:memories:jc-1");
+
+    store.stop();
   });
 });

--- a/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
@@ -11,13 +11,10 @@ import {
 import { useCopilotKit } from "../../context";
 import {
   CopilotKitCoreRuntimeConnectionStatus,
-  ɵcreateMetadataRealtimeConnection,
+  ɵcreateMetadataSocket,
   ɵcreateMemoryStore,
 } from "@copilotkit/core";
-import type {
-  ɵMetadataRealtimeConnection,
-  ɵMemoryStore,
-} from "@copilotkit/core";
+import type { ɵMetadataSocket, ɵMemoryStore } from "@copilotkit/core";
 
 vi.mock("../../context", () => ({
   useCopilotKit: vi.fn(),
@@ -210,33 +207,27 @@ const supportedThreadEndpoints = {
 };
 
 /**
- * Builds a `ɵgetMetadataRealtime` stand-in that mirrors `CopilotKitCore`'s
- * real lazy-memoized behavior: the shared connection is created on first
- * call (via the real `ɵcreateMetadataRealtimeConnection`) and the same
- * instance is returned on subsequent calls, so the mocked `phoenix` module
- * exercises the same code path production wiring does.
+ * Builds a `ɵgetMetadataSocket(joinToken)` stand-in that mirrors
+ * `CopilotKitCore`'s real lazy-memoized behavior: the ONE shared,
+ * credential-agnostic metadata socket is created on first call (via the real
+ * `ɵcreateMetadataSocket`) and the same instance is returned on subsequent
+ * calls regardless of `joinToken`, so the mocked `phoenix` module exercises the
+ * same code path production wiring does. Mirrors `makeGetMetadataSocket` in
+ * `@copilotkit/core`'s `threads.test.ts`/`memory.test.ts`.
  *
- * `fetchSubscription` resolves synthetically (mirrors `fakeMetadataConnection`
- * in `@copilotkit/core`'s `threads.test.ts`/`memory.test.ts`) rather than
- * going through the shared `fetchMock`: minting the join token/code is
- * `CopilotKitCore.fetchMetadataSubscription`'s concern (covered by core's own
- * tests), and it runs on its own schedule relative to the unrelated
- * `/threads` list fetch this store issues — routing it through the same
- * `fetchMock` queue would race the two and make call order nondeterministic.
+ * The store fetches its OWN realtime credentials (join token via
+ * `/threads/subscribe`, join code from the list response) through the shared
+ * `fetchMock`, then hands the token here to resolve the shared socket.
  */
-function createMetadataRealtimeFactory(
+function createMetadataSocketFactory(
   wsUrl: string,
-  joinCode = "jc-1",
-): () => ɵMetadataRealtimeConnection {
-  let connection: ɵMetadataRealtimeConnection | undefined;
-  return () => {
-    if (!connection) {
-      connection = ɵcreateMetadataRealtimeConnection({
-        wsUrl,
-        fetchSubscription: async () => ({ joinToken: "jt-1", joinCode }),
-      });
+): (joinToken: string) => ɵMetadataSocket {
+  let socket: ɵMetadataSocket | undefined;
+  return (joinToken: string) => {
+    if (!socket) {
+      socket = ɵcreateMetadataSocket({ wsUrl, joinToken }).socket;
     }
-    return connection;
+    return socket;
   };
 }
 
@@ -250,7 +241,7 @@ function setupCopilotKit(runtimeUrl = "http://localhost:4000") {
       headers,
       threadEndpoints: supportedThreadEndpoints,
       intelligence: { wsUrl },
-      ɵgetMetadataRealtime: createMetadataRealtimeFactory(wsUrl),
+      ɵgetMetadataSocket: createMetadataSocketFactory(wsUrl),
       registerThreadStore: vi.fn(),
       unregisterThreadStore: vi.fn(),
     },
@@ -263,6 +254,28 @@ function jsonResponse(body: unknown, status = 200) {
     status,
     json: () => Promise.resolve(body),
     text: () => Promise.resolve(JSON.stringify(body)),
+  });
+}
+
+/**
+ * Primes `fetchMock` for the store's two initial requests: the `/threads` list
+ * GET (carries the realtime `joinCode`) and the `/threads/subscribe` POST (mints
+ * the realtime `joinToken`). The store now fetches its OWN realtime credentials,
+ * so realtime-asserting tests must answer both — routing by URL keeps the two
+ * responses independent of call order.
+ */
+function primeThreadFetches(
+  threads: unknown = sampleThreads,
+  joinCode = "jc-1",
+) {
+  fetchMock.mockImplementation((url: string) => {
+    if (typeof url === "string" && url.includes("/threads/subscribe")) {
+      return jsonResponse({ joinToken: "jt-1" });
+    }
+    if (typeof url === "string" && url.includes("/threads")) {
+      return jsonResponse({ threads, joinCode });
+    }
+    return jsonResponse({}, 404);
   });
 }
 
@@ -316,9 +329,7 @@ describe("useThreads", () => {
   });
 
   it("fetches threads and subscribes to the user metadata channel", async () => {
-    fetchMock.mockReturnValueOnce(
-      jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
-    );
+    primeThreadFetches();
 
     const { result } = renderHook(() => useThreads(defaultInput));
 
@@ -335,11 +346,13 @@ describe("useThreads", () => {
       expect.stringContaining("/threads?agentId=agent-1"),
       expect.objectContaining({ method: "GET" }),
     );
-    // Minting the join token/code (`POST /threads/subscribe`) is
-    // `CopilotKitCore.ɵgetMetadataRealtime()`'s concern now, not this store's
-    // — it's exercised via the mocked `ɵgetMetadataRealtime`, not `fetchMock`.
-    // This hook only owns joining the `user_meta:<joinCode>` channel off the
-    // resulting shared socket, asserted below.
+    // The store fetches its OWN realtime join-token via `POST /threads/subscribe`
+    // (join code comes from the list response), then joins the
+    // `user_meta:<joinCode>` channel off the shared core-owned socket resolved
+    // via `getMetadataSocket(joinToken)`.
+    await waitFor(() => {
+      expect(getMockSockets()[0]?.channels[0]?.topic).toBe("user_meta:jc-1");
+    });
     const socket = getMockSockets()[0];
     expect(socket.connected).toBe(true);
     expect(socket.channels[0].topic).toBe("user_meta:jc-1");
@@ -407,7 +420,7 @@ describe("useThreads", () => {
         headers: {},
         threadEndpoints: supportedThreadEndpoints,
         intelligence: { wsUrl: "ws://localhost:4000/client" },
-        ɵgetMetadataRealtime: createMetadataRealtimeFactory(
+        ɵgetMetadataSocket: createMetadataSocketFactory(
           "ws://localhost:4000/client",
         ),
         registerThreadStore,
@@ -434,7 +447,7 @@ describe("useThreads", () => {
           realtimeMetadata: false,
         },
         intelligence: undefined,
-        ɵgetMetadataRealtime: () => undefined,
+        ɵgetMetadataSocket: () => undefined,
         registerThreadStore: vi.fn(),
         unregisterThreadStore: vi.fn(),
       },
@@ -462,7 +475,7 @@ describe("useThreads", () => {
         headers: { Authorization: "Bearer test-token" },
         threadEndpoints: undefined,
         intelligence: undefined,
-        ɵgetMetadataRealtime: () => undefined,
+        ɵgetMetadataSocket: () => undefined,
         registerThreadStore: vi.fn(),
         unregisterThreadStore: vi.fn(),
       },
@@ -500,7 +513,7 @@ describe("useThreads", () => {
           realtimeMetadata: false,
         },
         intelligence: undefined,
-        ɵgetMetadataRealtime: () => undefined,
+        ɵgetMetadataSocket: () => undefined,
         registerThreadStore: vi.fn(),
         unregisterThreadStore: vi.fn(),
       },
@@ -528,9 +541,7 @@ describe("useThreads", () => {
   });
 
   it("updates local state directly from realtime metadata events", async () => {
-    fetchMock.mockReturnValueOnce(
-      jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
-    );
+    primeThreadFetches();
 
     const { result } = renderHook(() => useThreads(defaultInput));
 
@@ -538,6 +549,9 @@ describe("useThreads", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
+    await waitFor(() => {
+      expect(getMockSockets()[0]?.channels[0]).toBeDefined();
+    });
     const channel = getMockSockets()[0].channels[0];
 
     act(() => {
@@ -560,14 +574,13 @@ describe("useThreads", () => {
     });
 
     // The realtime metadata push updates the store directly — it must NOT
-    // trigger an extra REST refetch beyond the initial list call.
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // trigger an extra REST refetch beyond the two initial calls (the list GET
+    // plus the `/threads/subscribe` credentials POST).
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("applies realtime metadata without client-side user filtering", async () => {
-    fetchMock.mockReturnValueOnce(
-      jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
-    );
+    primeThreadFetches();
 
     const { result } = renderHook(() => useThreads(defaultInput));
 
@@ -575,6 +588,9 @@ describe("useThreads", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
+    await waitFor(() => {
+      expect(getMockSockets()[0]?.channels[0]).toBeDefined();
+    });
     act(() => {
       getMockSockets()[0].channels[0].serverPush("thread_metadata", {
         operation: "deleted",
@@ -595,11 +611,9 @@ describe("useThreads", () => {
   });
 
   it("renames a thread through the runtime contract", async () => {
-    fetchMock
-      .mockReturnValueOnce(
-        jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
-      )
-      .mockReturnValueOnce(jsonResponse({}));
+    // URL-routed so the store's own `/threads/subscribe` POST resolves cleanly
+    // without consuming the mutation's response (mutations only check `ok`).
+    primeThreadFetches();
 
     const { result } = renderHook(() => useThreads(defaultInput));
 
@@ -629,12 +643,7 @@ describe("useThreads", () => {
   });
 
   it("archives and deletes threads through the runtime contract", async () => {
-    fetchMock
-      .mockReturnValueOnce(
-        jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
-      )
-      .mockReturnValueOnce(jsonResponse({}))
-      .mockReturnValueOnce(jsonResponse({}));
+    primeThreadFetches();
 
     const { result } = renderHook(() => useThreads(defaultInput));
 
@@ -675,11 +684,7 @@ describe("useThreads", () => {
   });
 
   it("unarchives a thread through the runtime contract", async () => {
-    fetchMock
-      .mockReturnValueOnce(
-        jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
-      )
-      .mockReturnValueOnce(jsonResponse({}));
+    primeThreadFetches();
 
     const { result } = renderHook(() => useThreads(defaultInput));
 
@@ -744,17 +749,25 @@ describe("useThreads", () => {
       },
     ];
 
-    fetchMock
-      .mockReturnValueOnce(
-        jsonResponse({
+    // URL-routed so the store's own `/threads/subscribe` POST doesn't consume
+    // the next-page response: the first list GET (no cursor) carries the
+    // nextCursor, the cursor GET returns the next page.
+    fetchMock.mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/threads/subscribe")) {
+        return jsonResponse({ joinToken: "jt-1" });
+      }
+      if (typeof url === "string" && url.includes("cursor=cursor-abc")) {
+        return jsonResponse({ threads: nextPageThreads, joinCode: "jc-1" });
+      }
+      if (typeof url === "string" && url.includes("/threads")) {
+        return jsonResponse({
           threads: sampleThreads,
           joinCode: "jc-1",
           nextCursor: "cursor-abc",
-        }),
-      )
-      .mockReturnValueOnce(
-        jsonResponse({ threads: nextPageThreads, joinCode: "jc-1" }),
-      );
+        });
+      }
+      return jsonResponse({}, 404);
+    });
 
     const { result } = renderHook(() => useThreads(defaultInput));
 
@@ -812,8 +825,8 @@ describe("useThreads", () => {
   // NOTE: a "tears down sockets after repeated connection failures" test
   // previously lived here, asserting that the thread store itself gave up
   // and disconnected its socket after `ɵMAX_SOCKET_RETRIES` consecutive
-  // errors. That behavior has moved: the shared metadata realtime connection
-  // (`ɵcreateMetadataRealtimeConnection` in `@copilotkit/core`) now owns
+  // errors. That behavior has moved: the shared metadata socket
+  // (`ɵcreateMetadataSocket` in `@copilotkit/core`) now owns
   // socket retry/give-up, and `threads.ts` no longer references
   // `ɵMETADATA_MAX_SOCKET_RETRIES`, `dispose()`, or the socket's `error`
   // signal at all — it only joins a channel off the shared `socket$`. The
@@ -821,14 +834,15 @@ describe("useThreads", () => {
   // and `memory.test.ts` in `@copilotkit/core`.
 
   it("leaves the channel on unmount but keeps the shared socket alive for other consumers", async () => {
-    fetchMock.mockReturnValueOnce(
-      jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
-    );
+    primeThreadFetches();
 
     const { unmount } = renderHook(() => useThreads(defaultInput));
 
     await waitFor(() => {
       expect(getMockSockets().length).toBe(1);
+    });
+    await waitFor(() => {
+      expect(getMockSockets()[0]?.channels[0]).toBeDefined();
     });
 
     const socket = getMockSockets()[0];
@@ -838,10 +852,10 @@ describe("useThreads", () => {
 
     // The store leaves ITS channel on unmount...
     expect(channel.left).toBe(true);
-    // ...but the underlying socket is owned by the shared connection
-    // (`CopilotKitCore.ɵgetMetadataRealtime()`, refCount:false), not by this
-    // one hook instance, so a single consumer unmounting must not disconnect
-    // it out from under other consumers (e.g. the memory store) sharing it.
+    // ...but the underlying socket is owned by the shared core-owned socket
+    // (`CopilotKitCore.ɵgetMetadataSocket()`, refCount:false), not by this one
+    // hook instance, so a single consumer unmounting must not disconnect it out
+    // from under other consumers (e.g. the memory store) sharing it.
     expect(socket.disconnected).toBe(false);
   });
 
@@ -862,7 +876,7 @@ describe("useThreads", () => {
         headers: { Authorization: "Bearer test-token" },
         threadEndpoints: supportedThreadEndpoints,
         intelligence: { wsUrl: "ws://localhost:4000/client" },
-        ɵgetMetadataRealtime: createMetadataRealtimeFactory(
+        ɵgetMetadataSocket: createMetadataSocketFactory(
           "ws://localhost:4000/client",
         ),
         registerThreadStore,
@@ -900,7 +914,7 @@ describe("useThreads", () => {
         headers: { Authorization: "Bearer test-token" },
         threadEndpoints: supportedThreadEndpoints,
         intelligence: undefined,
-        ɵgetMetadataRealtime: () => undefined,
+        ɵgetMetadataSocket: () => undefined,
         registerThreadStore: vi.fn(),
         unregisterThreadStore: vi.fn(),
       },
@@ -940,7 +954,7 @@ describe("useThreads", () => {
         headers: { Authorization: "Bearer test-token" },
         threadEndpoints: supportedThreadEndpoints,
         intelligence: { wsUrl: "ws://localhost:4000/client" },
-        ɵgetMetadataRealtime: createMetadataRealtimeFactory(
+        ɵgetMetadataSocket: createMetadataSocketFactory(
           "ws://localhost:4000/client",
         ),
         registerThreadStore: vi.fn(),
@@ -970,16 +984,17 @@ describe("useThreads", () => {
   });
 
   it("threads + memory share a single core-owned socket (one socket, two channels)", async () => {
-    // Both feeds must derive their connection from the SAME memoized factory
-    // call the real `CopilotKitCore.ɵgetMetadataRealtime()` would produce —
-    // mirrors `core.ts`'s own `_metadataRealtime` memoization so the thread
-    // store (via the hook) and the memory store (via `getMemoryStore()`) are
-    // wired to one shared `ɵMetadataRealtimeConnection`, exactly like
-    // production `syncMemoryContext()` does off the same core instance.
+    // Both feeds must resolve their socket from the SAME memoized factory the
+    // real `CopilotKitCore.ɵgetMetadataSocket()` would produce — mirrors
+    // `core.ts`'s own `_metadataSocket` memoization so the thread store (via the
+    // hook) and the memory store (via `getMemoryStore()`) ride one shared
+    // `ɵMetadataSocket`, exactly like production `syncMemoryContext()` does off
+    // the same core instance. Each store fetches its own realtime credentials
+    // and joins its own channel off that ONE socket.
     const wsUrl = "ws://localhost:4000/client";
     const runtimeUrl = "http://localhost:4000";
     const headers = { Authorization: "Bearer test-token" };
-    const metadataFactory = createMetadataRealtimeFactory(wsUrl);
+    const metadataSocketFactory = createMetadataSocketFactory(wsUrl);
 
     let memoryStore: ɵMemoryStore | undefined;
     function getMemoryStore(): ɵMemoryStore {
@@ -991,10 +1006,11 @@ describe("useThreads", () => {
         memoryStore.setContext({
           runtimeUrl,
           headers,
-          // Calling the SAME factory instance returns the memoized shared
-          // connection created by the hook below (or creates it here first —
-          // either way there is exactly one instance to go around).
-          metadata: metadataFactory(),
+          // The SAME factory instance the hook's core mock uses: the first
+          // caller creates the ONE shared socket, every later call returns it —
+          // so both stores ride a single socket regardless of who resolves it
+          // first.
+          getMetadataSocket: metadataSocketFactory,
         });
       }
       return memoryStore;
@@ -1008,13 +1024,22 @@ describe("useThreads", () => {
         headers,
         threadEndpoints: supportedThreadEndpoints,
         intelligence: { wsUrl },
-        ɵgetMetadataRealtime: metadataFactory,
+        ɵgetMetadataSocket: metadataSocketFactory,
         registerThreadStore: vi.fn(),
         unregisterThreadStore: vi.fn(),
       },
     });
 
     fetchMock.mockImplementation((url: string) => {
+      // Each store fetches its OWN realtime credentials before joining its
+      // channel off the shared socket — route the subscribe endpoints first so
+      // the broader `/threads`/`/memories` matches don't swallow them.
+      if (url.includes("/threads/subscribe")) {
+        return jsonResponse({ joinToken: "jt-1" });
+      }
+      if (url.includes("/memories/subscribe")) {
+        return jsonResponse({ joinToken: "jt-1", joinCode: "jc-1" });
+      }
       if (url.includes("/threads")) {
         return jsonResponse({ threads: sampleThreads, joinCode: "jc-1" });
       }

--- a/packages/react-core/src/v2/hooks/use-threads.tsx
+++ b/packages/react-core/src/v2/hooks/use-threads.tsx
@@ -351,11 +351,12 @@ export function useThreads({
     };
   }, [store]);
 
-  // Defer setting the context until the runtime reports Connected. Before
-  // `/info` resolves we don't know `intelligence.wsUrl`, so dispatching the
-  // context early would issue a list fetch with `wsUrl: undefined`, then a
-  // second list fetch (and a `/threads/subscribe`) once the flag lands.
-  // Waiting lets the hook issue just one `/threads?…` + one `/threads/subscribe`.
+  // Defer setting the context until the runtime reports Connected. Before then
+  // the shared metadata socket isn't seeded, so the context's `getMetadataSocket`
+  // provider can't resolve one — dispatching early would fetch the list with
+  // realtime silently absent, then re-dispatch once Connected (a new session, so
+  // a second list fetch and a `/threads/subscribe`). Waiting lets the hook issue
+  // just one `/threads?…` + one `/threads/subscribe`.
   //
   // When `runtimeUrl` is absent we dispatch `null` to clear the store. For
   // transient states (Disconnected/Connecting/Error with a URL still set) we
@@ -390,8 +391,9 @@ export function useThreads({
       return;
     }
 
-    // Wait for /info to land so we can include `wsUrl` in the initial
-    // context and avoid a redundant second list fetch.
+    // Wait for Connected so the shared metadata socket is seeded and the
+    // context's `getMetadataSocket` provider resolves it on the first dispatch —
+    // avoiding a redundant second list fetch (+ subscribe) on reconnect.
     if (runtimeStatus !== CopilotKitCoreRuntimeConnectionStatus.Connected) {
       return;
     }

--- a/packages/react-core/src/v2/hooks/use-threads.tsx
+++ b/packages/react-core/src/v2/hooks/use-threads.tsx
@@ -405,7 +405,8 @@ export function useThreads({
     const context: ɵThreadRuntimeContext = {
       runtimeUrl: copilotkit.runtimeUrl,
       headers: { ...copilotkit.headers },
-      metadata: copilotkit.ɵgetMetadataRealtime() ?? null,
+      getMetadataSocket: (joinToken) =>
+        copilotkit.ɵgetMetadataSocket(joinToken) ?? null,
       agentId,
       includeArchived,
       limit,

--- a/packages/react-core/src/v2/hooks/use-threads.tsx
+++ b/packages/react-core/src/v2/hooks/use-threads.tsx
@@ -405,7 +405,7 @@ export function useThreads({
     const context: ɵThreadRuntimeContext = {
       runtimeUrl: copilotkit.runtimeUrl,
       headers: { ...copilotkit.headers },
-      wsUrl: copilotkit.intelligence?.wsUrl,
+      metadata: copilotkit.ɵgetMetadataRealtime() ?? null,
       agentId,
       includeArchived,
       limit,

--- a/packages/vue/src/v2/hooks/__tests__/use-threads.test.ts
+++ b/packages/vue/src/v2/hooks/__tests__/use-threads.test.ts
@@ -375,11 +375,12 @@ const supportedThreadEndpoints: ThreadEndpointRuntimeInfo = {
   realtimeMetadata: true,
 };
 
-// Stand-in for the shared realtime connection returned by
-// `ɵgetMetadataRealtime()`. The mocked `@copilotkit/core` thread store never
-// consumes the connection (it opens its own MockSocket), so an opaque marker
-// is enough to prove the hook threaded `metadata` into the dispatched context.
-const metadataConnectionStub = { ɵmetadataConnectionStub: true } as const;
+// Stand-in for the shared, credential-agnostic socket returned by
+// `ɵgetMetadataSocket(joinToken)`. The mocked `@copilotkit/core` thread store
+// never consumes the socket (it opens its own MockSocket), so an opaque marker
+// is enough to prove the hook threaded `getMetadataSocket` into the dispatched
+// context.
+const metadataSocketStub = { ɵmetadataSocketStub: true } as const;
 
 type MockCopilotKit = {
   runtimeUrl: string | undefined;
@@ -389,9 +390,11 @@ type MockCopilotKit = {
   threadEndpoints: ThreadEndpointRuntimeInfo | undefined;
   registerThreadStore: ReturnType<typeof vi.fn>;
   unregisterThreadStore: ReturnType<typeof vi.fn>;
-  // Mirrors `CopilotKitCore.ɵgetMetadataRealtime()`: returns the shared
-  // connection while a realtime `wsUrl` is known, else `undefined`.
-  ɵgetMetadataRealtime: () => typeof metadataConnectionStub | undefined;
+  // Mirrors `CopilotKitCore.ɵgetMetadataSocket(joinToken)`: returns the shared
+  // socket while a realtime `wsUrl` is known, else `undefined`.
+  ɵgetMetadataSocket: (
+    joinToken: string,
+  ) => typeof metadataSocketStub | undefined;
 };
 
 function setupCopilotKit(
@@ -411,8 +414,8 @@ function setupCopilotKit(
     threadEndpoints: supportedThreadEndpoints,
     registerThreadStore: vi.fn(),
     unregisterThreadStore: vi.fn(),
-    ɵgetMetadataRealtime: function (this: MockCopilotKit) {
-      return this.intelligence?.wsUrl ? metadataConnectionStub : undefined;
+    ɵgetMetadataSocket: function (this: MockCopilotKit, _joinToken: string) {
+      return this.intelligence?.wsUrl ? metadataSocketStub : undefined;
     },
     ...overrides,
   });
@@ -942,18 +945,25 @@ describe("useThreads", () => {
       );
       expect(listCalls).toHaveLength(1);
 
-      // The dispatched context must carry the shared realtime `metadata`
-      // connection, otherwise the store would re-fetch once /info eventually
-      // populates it.
+      // The dispatched context must carry the shared realtime socket provider,
+      // otherwise the store would re-fetch once /info eventually populates it.
       const nonNullContexts = getDispatchedContexts().filter(
         (context) => context !== null,
       );
       expect(nonNullContexts).toHaveLength(1);
       expect(nonNullContexts[0]).toMatchObject({
         runtimeUrl: "http://localhost:4000",
-        metadata: metadataConnectionStub,
+        getMetadataSocket: expect.any(Function),
         agentId: "agent-1",
       });
+      // The provider resolves to the shared socket for any join token.
+      expect(
+        (
+          nonNullContexts[0] as {
+            getMetadataSocket: (joinToken: string) => unknown;
+          }
+        ).getMetadataSocket("jt-1"),
+      ).toBe(metadataSocketStub);
 
       await vi.waitFor(() => {
         expect(getResult().isLoading.value).toBe(false);

--- a/packages/vue/src/v2/hooks/__tests__/use-threads.test.ts
+++ b/packages/vue/src/v2/hooks/__tests__/use-threads.test.ts
@@ -26,7 +26,7 @@ type ThreadState = {
   context: {
     runtimeUrl: string;
     headers: Record<string, string>;
-    wsUrl?: string;
+    metadata?: unknown;
     agentId: string;
     includeArchived?: boolean;
     limit?: number;
@@ -375,6 +375,12 @@ const supportedThreadEndpoints: ThreadEndpointRuntimeInfo = {
   realtimeMetadata: true,
 };
 
+// Stand-in for the shared realtime connection returned by
+// `ɵgetMetadataRealtime()`. The mocked `@copilotkit/core` thread store never
+// consumes the connection (it opens its own MockSocket), so an opaque marker
+// is enough to prove the hook threaded `metadata` into the dispatched context.
+const metadataConnectionStub = { ɵmetadataConnectionStub: true } as const;
+
 type MockCopilotKit = {
   runtimeUrl: string | undefined;
   runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus;
@@ -383,6 +389,9 @@ type MockCopilotKit = {
   threadEndpoints: ThreadEndpointRuntimeInfo | undefined;
   registerThreadStore: ReturnType<typeof vi.fn>;
   unregisterThreadStore: ReturnType<typeof vi.fn>;
+  // Mirrors `CopilotKitCore.ɵgetMetadataRealtime()`: returns the shared
+  // connection while a realtime `wsUrl` is known, else `undefined`.
+  ɵgetMetadataRealtime: () => typeof metadataConnectionStub | undefined;
 };
 
 function setupCopilotKit(
@@ -402,6 +411,9 @@ function setupCopilotKit(
     threadEndpoints: supportedThreadEndpoints,
     registerThreadStore: vi.fn(),
     unregisterThreadStore: vi.fn(),
+    ɵgetMetadataRealtime: function (this: MockCopilotKit) {
+      return this.intelligence?.wsUrl ? metadataConnectionStub : undefined;
+    },
     ...overrides,
   });
   mockUseCopilotKit.mockReturnValue({ copilotkit });
@@ -930,15 +942,16 @@ describe("useThreads", () => {
       );
       expect(listCalls).toHaveLength(1);
 
-      // The dispatched context must carry wsUrl, otherwise the store would
-      // re-fetch once /info eventually populates it.
+      // The dispatched context must carry the shared realtime `metadata`
+      // connection, otherwise the store would re-fetch once /info eventually
+      // populates it.
       const nonNullContexts = getDispatchedContexts().filter(
         (context) => context !== null,
       );
       expect(nonNullContexts).toHaveLength(1);
       expect(nonNullContexts[0]).toMatchObject({
         runtimeUrl: "http://localhost:4000",
-        wsUrl: "ws://localhost:4000/client",
+        metadata: metadataConnectionStub,
         agentId: "agent-1",
       });
 

--- a/packages/vue/src/v2/hooks/__tests__/use-threads.test.ts
+++ b/packages/vue/src/v2/hooks/__tests__/use-threads.test.ts
@@ -26,7 +26,6 @@ type ThreadState = {
   context: {
     runtimeUrl: string;
     headers: Record<string, string>;
-    metadata?: unknown;
     agentId: string;
     includeArchived?: boolean;
     limit?: number;

--- a/packages/vue/src/v2/hooks/use-threads.ts
+++ b/packages/vue/src/v2/hooks/use-threads.ts
@@ -241,7 +241,8 @@ export function useThreads(input: UseThreadsInput): UseThreadsResult {
       const context: ɵThreadRuntimeContext = {
         runtimeUrl,
         headers: { ...copilotkit.value.headers },
-        metadata: copilotkit.value.ɵgetMetadataRealtime() ?? null,
+        getMetadataSocket: (joinToken) =>
+          copilotkit.value.ɵgetMetadataSocket(joinToken) ?? null,
         agentId,
         includeArchived,
         limit,

--- a/packages/vue/src/v2/hooks/use-threads.ts
+++ b/packages/vue/src/v2/hooks/use-threads.ts
@@ -212,7 +212,7 @@ export function useThreads(input: UseThreadsInput): UseThreadsResult {
       runtimeUrl,
       runtimeStatus,
       ,
-      wsUrl,
+      ,
       agentId,
       includeArchived,
       limit,
@@ -241,7 +241,7 @@ export function useThreads(input: UseThreadsInput): UseThreadsResult {
       const context: ɵThreadRuntimeContext = {
         runtimeUrl,
         headers: { ...copilotkit.value.headers },
-        wsUrl,
+        metadata: copilotkit.value.ɵgetMetadataRealtime() ?? null,
         agentId,
         includeArchived,
         limit,

--- a/packages/vue/src/v2/hooks/use-threads.ts
+++ b/packages/vue/src/v2/hooks/use-threads.ts
@@ -185,11 +185,12 @@ export function useThreads(input: UseThreadsInput): UseThreadsResult {
   // isLoading takes over).
   const hasDispatchedContext = ref(false);
 
-  // Defer setting the context until the runtime reports Connected. Before
-  // `/info` resolves we don't know `intelligence.wsUrl`, so dispatching the
-  // context early would issue a list fetch with `wsUrl: undefined`, then a
-  // second list fetch (and a `/threads/subscribe`) once the flag lands.
-  // Waiting lets the hook issue just one `/threads?…` + one `/threads/subscribe`.
+  // Defer setting the context until the runtime reports Connected. Before then
+  // the shared metadata socket isn't seeded, so the context's `getMetadataSocket`
+  // provider can't resolve one — dispatching early would fetch the list with
+  // realtime silently absent, then re-dispatch once Connected (a new session, so
+  // a second list fetch and a `/threads/subscribe`). Waiting lets the hook issue
+  // just one `/threads?…` + one `/threads/subscribe`.
   //
   // When `runtimeUrl` is absent we dispatch `null` to clear the store. For
   // transient states (Disconnected/Connecting/Error with a URL still set) we

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -1447,6 +1447,7 @@ type HeaderMockCore = {
   registerThreadStore: (agentId: string, store: unknown) => void;
   unregisterThreadStore: (agentId: string) => void;
   getMemoryStore: () => ReturnType<typeof createNoopMemoryStore>;
+  ɵgetMetadataRealtime: () => undefined;
 };
 
 function createHeaderMockCore(
@@ -1485,6 +1486,12 @@ function createHeaderMockCore(
     unregisterThreadStore() {},
     getMemoryStore() {
       return createNoopMemoryStore();
+    },
+    // These tests exercise only /threads header forwarding, not realtime.
+    // Returning undefined means the owned thread store's context carries
+    // `metadata: null`, so it never opens a realtime channel here.
+    ɵgetMetadataRealtime() {
+      return undefined;
     },
   };
 

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -1509,6 +1509,12 @@ function createHeaderMockCore(
         s.onHeadersChanged?.({ copilotkit: asCore(), headers: nextHeaders }),
       );
     },
+    emitConnectionStatusChanged(status: CopilotKitCoreRuntimeConnectionStatus) {
+      core.runtimeConnectionStatus = status;
+      subscribers.forEach((s) =>
+        s.onRuntimeConnectionStatusChanged?.({ copilotkit: asCore(), status }),
+      );
+    },
   };
 }
 
@@ -1601,6 +1607,62 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     expect(headersOf(threadListCalls().at(-1)!)).toMatchObject({
       "X-CSRF": "2",
     });
+  });
+
+  it("re-dispatches setContext on owned stores on reconnect (re-resolving a fresh metadata socket), not a REST-only refresh (B2)", async () => {
+    const { agent } = createMockAgent("alpha");
+    const harness = createHeaderMockCore({ alpha: agent }, { "X-CSRF": "1" });
+
+    // The owned store's realtime flow needs a `joinCode` on the list response
+    // and a `joinToken` on `/threads/subscribe` so it reaches
+    // `context.getMetadataSocket(joinToken)`. Spying on core.ɵgetMetadataSocket
+    // then distinguishes a fresh `setContext` (new session → re-fetches creds →
+    // re-resolves the shared socket) from a REST-only `refresh()` (same session,
+    // no cred re-fetch, socket never re-resolved).
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes("/threads/subscribe")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ joinToken: "join-token" }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ threads: [], joinCode: "join-code" }),
+      });
+    });
+    const socketSpy = vi.spyOn(harness.core, "ɵgetMetadataSocket");
+
+    const inspector = new WebInspectorElement();
+    document.body.appendChild(inspector);
+    inspector.core = harness.core as unknown as WebInspectorElement["core"];
+    harness.emitAgentsChanged();
+
+    // Initial owned-store dispatch resolves the shared socket once.
+    await vi.waitFor(() => {
+      expect(socketSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+    });
+    const socketCallsBefore = socketSpy.mock.calls.length;
+    const listCallsBefore = threadListCalls().length;
+
+    // Runtime drops then recovers: core disposes the shared socket on disconnect.
+    harness.emitConnectionStatusChanged(
+      CopilotKitCoreRuntimeConnectionStatus.Disconnected,
+    );
+    harness.emitConnectionStatusChanged(
+      CopilotKitCoreRuntimeConnectionStatus.Connected,
+    );
+
+    // Reconnect re-dispatches `setContext` per owned store → new session → new
+    // `/threads` list + `/threads/subscribe` → `getMetadataSocket` invoked
+    // AGAIN. A REST-only `refreshOwnedThreadStore` loop would reuse the session
+    // and never re-resolve the socket, leaving this at the initial count.
+    await vi.waitFor(() => {
+      expect(socketSpy.mock.calls.length).toBeGreaterThan(socketCallsBefore);
+    });
+    expect(threadListCalls().length).toBeGreaterThan(listCallsBefore);
   });
 
   it("rerenders selected thread details so core header changes refetch events with new headers", async () => {

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -1447,7 +1447,7 @@ type HeaderMockCore = {
   registerThreadStore: (agentId: string, store: unknown) => void;
   unregisterThreadStore: (agentId: string) => void;
   getMemoryStore: () => ReturnType<typeof createNoopMemoryStore>;
-  ɵgetMetadataRealtime: () => undefined;
+  ɵgetMetadataSocket: (joinToken: string) => undefined;
 };
 
 function createHeaderMockCore(
@@ -1488,9 +1488,9 @@ function createHeaderMockCore(
       return createNoopMemoryStore();
     },
     // These tests exercise only /threads header forwarding, not realtime.
-    // Returning undefined means the owned thread store's context carries
-    // `metadata: null`, so it never opens a realtime channel here.
-    ɵgetMetadataRealtime() {
+    // Returning undefined means the owned thread store's `getMetadataSocket`
+    // provider resolves to `null`, so it never opens a realtime channel here.
+    ɵgetMetadataSocket() {
       return undefined;
     },
   };

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -4144,7 +4144,8 @@ export class WebInspectorElement extends LitElement {
     store.setContext({
       runtimeUrl: core.runtimeUrl,
       headers: { ...core.headers },
-      metadata: core.ɵgetMetadataRealtime() ?? null,
+      getMetadataSocket: (joinToken) =>
+        core.ɵgetMetadataSocket(joinToken) ?? null,
       agentId,
     });
     this._ownedThreadStores.set(agentId, store);
@@ -4176,7 +4177,8 @@ export class WebInspectorElement extends LitElement {
       store.setContext({
         runtimeUrl: core.runtimeUrl,
         headers: { ...headers },
-        metadata: core.ɵgetMetadataRealtime() ?? null,
+        getMetadataSocket: (joinToken) =>
+          core.ɵgetMetadataSocket(joinToken) ?? null,
         agentId,
       });
     }
@@ -4213,9 +4215,12 @@ export class WebInspectorElement extends LitElement {
           }
           this.flushPendingBannerViewed();
           if (this.areThreadEndpointsAvailable()) {
-            for (const agentId of this._ownedThreadStores.keys()) {
-              this.refreshOwnedThreadStore(agentId);
-            }
+            // Core disposes the shared metadata socket on disconnect, so a plain
+            // refresh() (REST-only) would leave owned stores stranded on a dead
+            // socket. Re-dispatch setContext for each owned store so they
+            // re-fetch creds and re-resolve a fresh socket; this also refreshes
+            // the REST list.
+            this.updateOwnedThreadStoreHeaders(core.headers);
           } else {
             this.teardownOwnedThreadStores();
           }

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -4144,7 +4144,7 @@ export class WebInspectorElement extends LitElement {
     store.setContext({
       runtimeUrl: core.runtimeUrl,
       headers: { ...core.headers },
-      wsUrl: core.intelligence?.wsUrl,
+      metadata: core.ɵgetMetadataRealtime() ?? null,
       agentId,
     });
     this._ownedThreadStores.set(agentId, store);
@@ -4176,7 +4176,7 @@ export class WebInspectorElement extends LitElement {
       store.setContext({
         runtimeUrl: core.runtimeUrl,
         headers: { ...headers },
-        wsUrl: core.intelligence?.wsUrl,
+        metadata: core.ɵgetMetadataRealtime() ?? null,
         agentId,
       });
     }


### PR DESCRIPTION
## Summary

Lifts WebSocket creation into a single, shared, **credential-agnostic**, core-owned Phoenix socket. The thread-metadata feed (`user_meta:{joinCode}`) and the memory feed (`user_meta:memories:{joinCode}`) now ride **one** socket instead of each opening its own.

Previously the memory store and each thread store each opened their own Phoenix socket to the same gateway host — distinguished only by join token + topic. Since a single per-user metadata join token authorizes joining both channels, they can share one connection.

## Design

- **`core/metadata-realtime.ts` (new)** — `ɵcreateMetadataSocket({ wsUrl, joinToken })` returns an owner handle `{ socket: { socket$, socketFatal$ }, dispose() }`. Socket-only and credential-agnostic: the **consumer provides the `joinToken`**; the module never fetches and has no `joinCode`. `refCount:false` keeps it open across channel churn; `socketFatal$` is latched (replays the terminal give-up to late subscribers) and the health chain is eagerly subscribed so monitoring runs regardless of which stores attach.
- **`CopilotKitCore.ɵgetMetadataSocket(seedJoinToken)`** — lazily seeds one socket from the **first** consumer's token, memoizes it, and disposes it on disconnect, header change (re-mint), and health give-up. A consumer-view type (no `dispose`) is what's threaded into the stores, so a store cannot tear down the shared socket for the others.
- **Stores unchanged except the socket source** — the memory and thread stores keep their existing credential fetches (memory: `/memories/subscribe`; threads: list `joinCode` + `/threads/subscribe` token) and simply call `context.getMetadataSocket(joinToken)` instead of opening their own socket. No backend change.
- **Bindings** (React `useThreads`/`CopilotChat`, Vue, Angular, web-inspector) inject the provider and re-dispatch on reconnect so a re-minted socket is picked up.

## Notable behavior

- **Re-mint on header change** (intentional): a `setHeaders` while connected disposes and re-seeds the socket so it authenticates with the fresh token.
- **Give-up is terminal**: after `ɵMETADATA_MAX_SOCKET_RETRIES` consecutive failures the shared socket is disposed (stops reconnecting) and `realtimeStatus` resolves to `unavailable` — matching pre-refactor semantics.
- Realtime failures degrade silently for the REST-backed list (`available`/`error`/the list are never affected); memory surfaces `realtimeStatus`, threads stays deliberately silent (with a slim join-failure warn).

## Testing

- New integration test asserts threads + memory share **one** socket with two channels (fails if reverted to two sockets).
- Reconnect re-dispatch regression tests for Angular and web-inspector (each verified to fail if its fix is reverted).
- `dispose→disconnect`, `setHeaders` re-mint, give-up-disposes, latched-fatal, credential-failure-degrades, and malformed-event-drop paths all covered.
- `check-types` green across all projects; `@copilotkit/core` (565), `react-core` (1413), `vue` (1066), `angular` (168), `web-inspector` (88) test suites pass; builds green.

## Follow-ups (not blocking)

- Confirm the gateway authorizes a single per-user metadata token for both the threads and memory channels (graceful degrade — `joinFailed`/`realtimeUnavailable` — if not).
- A future generic `/api/metadata/subscribe` endpoint would retire the current use of `/threads/subscribe` purely for its token.
- The agent-run stream (`thread:{id}`) remains a separate socket (distinct token scope); folding it in requires a gateway multi-scope change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
