### PR TITLE
fix(banking-demo): cap native TEI warmup batch to survive Metal fault

### DIFF
--- a/examples/showcases/banking/run-demo.sh
+++ b/examples/showcases/banking/run-demo.sh
@@ -70,8 +70,16 @@ if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
     command -v text-embeddings-router >/dev/null 2>&1 \
       || die "native TEI missing. Install it:  brew install text-embeddings-inference"
     say "    starting native Metal TEI (Qwen/Qwen3-Embedding-0.6B)"
+    # --max-batch-tokens caps the warmup forward pass. TEI's default (16384) can
+    # fault the Metal backend during warmup on some Apple Silicon setups: the
+    # process either deadlocks (all threads parked, 0% CPU) or dies silently
+    # without a panic — a GPU-level abort — so :7067 never binds and the health
+    # wait below times out. A small warmup batch clears warmup reliably. It only
+    # bounds per-request tokens (memory texts are short), not the embedding
+    # vectors themselves, so recall stays byte-identical.
     nohup text-embeddings-router --model-id 'Qwen/Qwen3-Embedding-0.6B' \
-      --port 7067 --auto-truncate > "$LOG_DIR/tei-metal.log" 2>&1 & disown
+      --port 7067 --auto-truncate --max-batch-tokens 512 \
+      > "$LOG_DIR/tei-metal.log" 2>&1 & disown
   fi
   wait_http "http://localhost:7067/health" "native Metal TEI" 300
   # Warm the model so the first real recall isn't a cold forward pass.


### PR DESCRIPTION
## What

`examples/showcases/banking/run-demo.sh` launches a native Metal `text-embeddings-router` (TEI) on `:7067` for the self-hosted durable-memory path. This passes `--max-batch-tokens 512` so TEI's warmup uses a small forward pass.

## Why

On some Apple Silicon machines, TEI's default `--max-batch-tokens` (16384) **faults the Metal backend during its warmup forward pass**. Observed two failure modes at the exact same step (`Warming up model`):

- **Deadlock** — every thread, including the main thread, parked in `__psynch_cvwait` at 0% CPU. Never binds `:7067`.
- **Silent death** — process exits mid-warmup with no panic / no OOM line (the signature of a GPU-level abort).

Either way `:7067` never comes up, the script's `wait_http … 300` times out, and the demo appears to "crash" with only:

```
ERROR: native Metal TEI did not come up at http://localhost:7067/health within 300s
```

The 300s timeout looks like a slow model download (the weights are ~1.1 GB), but that's a red herring — with weights cached the process still hangs at warmup. Two different `--dtype` values (fp16, float32) both failed identically, ruling out dtype; the variable is the warmup batch size.

## Fix

`--max-batch-tokens 512` shrinks the warmup forward pass, which clears reliably (`Ready` in ~3s, health `200`, verified 1024-dim `/embed`). It bounds only per-request tokens — memory texts are short — **not** the embedding vectors, so recall stays byte-identical to the docker/CI embedder (the runbook's byte-identical guarantee holds).

## Scope

One-line flag change + explanatory comment. Only affects the Apple Silicon native-TEI branch of the self-hosted demo path; amd64/CI (docker `tei`) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)