### PR TITLE
fix(runtime): consolidate state deltas across runs

### DIFF
--- a/packages/runtime/src/v2/runtime/runner/__tests__/in-memory-runner.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/in-memory-runner.test.ts
@@ -818,5 +818,93 @@ describe("InMemoryAgentRunner — listThreads / getThreadMessages", () => {
       );
       expect(runner.getThreadState("thread-multi-state")).toEqual(second);
     });
+
+    it("consolidates STATE_SNAPSHOT and STATE_DELTA across multiple runs", async () => {
+      // Regression test for FAC-110: Multi-run state event replay.
+      // Run 1 emits STATE_SNAPSHOT {tasks: ["task1"]}
+      // Run 2 emits STATE_DELTA to add "task2"
+      // connect() should produce a final STATE_SNAPSHOT with both tasks.
+      const threadId = "thread-multi-delta";
+
+      // Run 1: emit initial snapshot
+      const agent1 = new TestAgent(
+        [
+          {
+            type: EventType.STATE_SNAPSHOT,
+            snapshot: { tasks: ["task1"] },
+          } as BaseEvent,
+        ],
+        true,
+      );
+      await firstValueFrom(
+        runner
+          .run({
+            threadId,
+            agent: agent1,
+            input: {
+              threadId,
+              runId: "run-1",
+              messages: [],
+              state: {},
+              tools: [],
+              context: [],
+            },
+          })
+          .pipe(toArray()),
+      );
+
+      // Run 2: emit delta to add task2
+      const agent2 = new TestAgent(
+        [
+          {
+            type: EventType.STATE_DELTA,
+            delta: [{ op: "add", path: "/tasks/-", value: "task2" }],
+          } as BaseEvent,
+        ],
+        true,
+      );
+      await firstValueFrom(
+        runner
+          .run({
+            threadId,
+            agent: agent2,
+            input: {
+              threadId,
+              runId: "run-2",
+              messages: [],
+              state: { tasks: ["task1"] }, // Frontend passes prior state
+              tools: [],
+              context: [],
+            },
+          })
+          .pipe(toArray()),
+      );
+
+      // Connect and verify the compacted events include a proper snapshot
+      const connectEvents = await firstValueFrom(
+        runner.connect({ threadId }).pipe(toArray()),
+      );
+
+      const stateSnapshots = connectEvents.filter(
+        (e) => e.type === EventType.STATE_SNAPSHOT,
+      );
+      const stateDeltas = connectEvents.filter(
+        (e) => e.type === EventType.STATE_DELTA,
+      );
+
+      // After compaction, we should have a single snapshot, no deltas
+      expect(stateSnapshots).toHaveLength(1);
+      expect(stateDeltas).toHaveLength(0);
+
+      // The snapshot should include both tasks
+      expect((stateSnapshots[0] as any).snapshot).toEqual({
+        tasks: ["task1", "task2"],
+      });
+
+      // getThreadState should also return the consolidated state
+      expect(runner.getThreadState(threadId)).toEqual({
+        tasks: ["task1", "task2"],
+      });
+    });
   });
 });

--- a/packages/runtime/src/v2/runtime/runner/in-memory.ts
+++ b/packages/runtime/src/v2/runtime/runner/in-memory.ts
@@ -13,8 +13,10 @@ import type {
   Message,
   RunStartedEvent,
   StateSnapshotEvent,
+  StateDeltaEvent,
 } from "@ag-ui/client";
 import { EventType, compactEvents } from "@ag-ui/client";
+import { applyPatch } from "fast-json-patch";
 import { finalizeRunEvents } from "@copilotkit/shared";
 
 interface HistoricRun {
@@ -297,8 +299,54 @@ export class InMemoryAgentRunner extends AgentRunner {
       allHistoricEvents.push(...run.events);
     }
 
-    // Apply compaction to all historic events together (like SQLite)
-    const compactedEvents = compactEvents(allHistoricEvents);
+    // Manually consolidate state events across runs (FAC-110 fix).
+    // compactEvents() from @ag-ui/client can't apply STATE_DELTA from run N
+    // to STATE_SNAPSHOT from run N-1, so we track state ourselves.
+    const stateEvents = allHistoricEvents.filter(
+      (e) =>
+        e.type === EventType.STATE_SNAPSHOT || e.type === EventType.STATE_DELTA,
+    );
+    const nonStateEvents = allHistoricEvents.filter(
+      (e) =>
+        e.type !== EventType.STATE_SNAPSHOT && e.type !== EventType.STATE_DELTA,
+    );
+
+    let consolidatedState: Record<string, unknown> | null = null;
+    for (const event of stateEvents) {
+      if (event.type === EventType.STATE_SNAPSHOT) {
+        const snapshot = (event as StateSnapshotEvent).snapshot;
+        consolidatedState =
+          snapshot && typeof snapshot === "object"
+            ? (snapshot as Record<string, unknown>)
+            : null;
+      } else if (
+        event.type === EventType.STATE_DELTA &&
+        consolidatedState !== null
+      ) {
+        const delta = (event as StateDeltaEvent).delta;
+        if (Array.isArray(delta) && delta.length > 0) {
+          try {
+            applyPatch(consolidatedState, delta);
+          } catch (err) {
+            // If patch fails, skip it but log for debugging
+            console.warn("Failed to apply STATE_DELTA in connect():", err);
+          }
+        }
+      }
+    }
+
+    // Compact non-state events
+    const compactedNonStateEvents = compactEvents(nonStateEvents);
+
+    // Build final event stream: consolidated state snapshot first, then other events
+    const compactedEvents: BaseEvent[] = [];
+    if (consolidatedState !== null) {
+      compactedEvents.push({
+        type: EventType.STATE_SNAPSHOT,
+        snapshot: consolidatedState,
+      });
+    }
+    compactedEvents.push(...compactedNonStateEvents);
 
     // Emit compacted events and track message IDs
     const emittedMessageIds = new Set<string>();
@@ -429,7 +477,56 @@ export class InMemoryAgentRunner extends AgentRunner {
     if (!store || store.historicRuns.length === 0) return [];
     const all: BaseEvent[] = [];
     for (const run of store.historicRuns) all.push(...run.events);
-    return compactEvents(all);
+
+    // Manually consolidate state events across runs (FAC-110 fix)
+    const stateEvents = all.filter(
+      (e) =>
+        e.type === EventType.STATE_SNAPSHOT || e.type === EventType.STATE_DELTA,
+    );
+    const nonStateEvents = all.filter(
+      (e) =>
+        e.type !== EventType.STATE_SNAPSHOT && e.type !== EventType.STATE_DELTA,
+    );
+
+    let consolidatedState: Record<string, unknown> | null = null;
+    for (const event of stateEvents) {
+      if (event.type === EventType.STATE_SNAPSHOT) {
+        const snapshot = (event as StateSnapshotEvent).snapshot;
+        consolidatedState =
+          snapshot && typeof snapshot === "object"
+            ? (snapshot as Record<string, unknown>)
+            : null;
+      } else if (
+        event.type === EventType.STATE_DELTA &&
+        consolidatedState !== null
+      ) {
+        const delta = (event as StateDeltaEvent).delta;
+        if (Array.isArray(delta) && delta.length > 0) {
+          try {
+            applyPatch(consolidatedState, delta);
+          } catch (err) {
+            console.warn(
+              "Failed to apply STATE_DELTA in getThreadEvents():",
+              err,
+            );
+          }
+        }
+      }
+    }
+
+    // Compact non-state events
+    const compactedNonStateEvents = compactEvents(nonStateEvents);
+
+    // Build final event list: consolidated state snapshot first, then other events
+    const result: BaseEvent[] = [];
+    if (consolidatedState !== null) {
+      result.push({
+        type: EventType.STATE_SNAPSHOT,
+        snapshot: consolidatedState,
+      });
+    }
+    result.push(...compactedNonStateEvents);
+    return result;
   }
 
   /**

--- a/packages/runtime/src/v2/runtime/runner/in-memory.ts
+++ b/packages/runtime/src/v2/runtime/runner/in-memory.ts
@@ -192,15 +192,17 @@ export class InMemoryAgentRunner extends AgentRunner {
 
         // Store the completed run in memory with ONLY its events
         if (store.currentRunId) {
-          // Compact the events before storing (like SQLite does)
-          const compactedEvents = compactEvents(currentRunEvents);
+          // Store raw events without per-run compaction. Compaction is applied
+          // during connect() and getThreadEvents() over ALL runs' events together,
+          // which allows STATE_DELTA events from later runs to be properly applied
+          // to STATE_SNAPSHOT events from earlier runs (FAC-110 fix).
 
           store.historicRuns.push({
             threadId: request.threadId,
             runId: store.currentRunId,
             agentId: request.agent.agentId ?? "default",
             parentRunId,
-            events: compactedEvents,
+            events: currentRunEvents,
             // Snapshot all messages (input + generated) for the thread-messages endpoint
             messages: Array.isArray(request.agent.messages)
               ? [...request.agent.messages]
@@ -232,14 +234,16 @@ export class InMemoryAgentRunner extends AgentRunner {
 
         // Store the run even if it failed (partial events)
         if (store.currentRunId && currentRunEvents.length > 0) {
-          // Compact the events before storing (like SQLite does)
-          const compactedEvents = compactEvents(currentRunEvents);
+          // Store raw events without per-run compaction. Compaction is applied
+          // during connect() and getThreadEvents() over ALL runs' events together,
+          // which allows STATE_DELTA events from later runs to be properly applied
+          // to STATE_SNAPSHOT events from earlier runs (FAC-110 fix).
           store.historicRuns.push({
             threadId: request.threadId,
             runId: store.currentRunId,
             agentId: request.agent.agentId ?? "default",
             parentRunId,
-            events: compactedEvents,
+            events: currentRunEvents,
             messages: Array.isArray(request.agent.messages)
               ? [...request.agent.messages]
               : [],


### PR DESCRIPTION
## Summary\n- Fixes FAC-110 by preserving raw in-memory runner events across runs\n- Compacts events only when reading thread events so state deltas can apply across run boundaries\n- Adds regression coverage for multi-run state consolidation\n\n## Test plan\n- See local agent result in the QA Agent Pipeline run artifacts\n\nLinear: FAC-110