### PR TITLE
docs(langgraph): fix TypeScript input/output schemas example

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/shared-state/state-inputs-outputs.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/shared-state/state-inputs-outputs.mdx
@@ -36,16 +36,18 @@ In addition, some state properties contain a lot of information. Syncing them ba
         </Tab>
         <Tab value="TypeScript">
         ```typescript title="agent-js/sample_agent/agent.ts"
-        import { StateSchema } from "@langchain/langgraph";
-        import { CopilotKitStateSchema } from "@copilotkit/sdk-js/langgraph";
+        import { Annotation } from "@langchain/langgraph";
+        import { CopilotKitStateAnnotation } from "@copilotkit/sdk-js/langgraph";
         import { z } from "zod";
 
-        const AgentState = new StateSchema({
-          ...CopilotKitStateSchema.fields,
-          question: z.string(),
-          answer: z.string(),
-          resources: z.array(z.string()).default(() => []),
-        })
+        const AgentStateAnnotation = Annotation.Root({
+          ...CopilotKitStateAnnotation.spec,
+          question: Annotation<string>,
+          answer: Annotation<string>,
+          resources: Annotation<string[]>,
+        });
+
+        export type AgentState = typeof AgentStateAnnotation.State;
         ```
         </Tab>
     </Tabs>
@@ -118,68 +120,73 @@ In addition, some state properties contain a lot of information. Syncing them ba
           </Tab>
           <Tab value="TypeScript">
             ```typescript title="agent-js/sample_agent/agent.ts"
-              import { StateSchema } from "@langchain/langgraph";
-              import { CopilotKitStateSchema } from "@copilotkit/sdk-js/langgraph";
-              import { z } from "zod";
+              import { Annotation, StateGraph, START, END } from "@langchain/langgraph";
+              import { CopilotKitStateAnnotation } from "@copilotkit/sdk-js/langgraph";
+              import { ChatOpenAI } from "@langchain/openai";
+              import { SystemMessage } from "@langchain/core/messages";
+              import type { RunnableConfig } from "@langchain/core/runnables";
 
               // Divide the state to 3 parts
 
-              // An input schema for inputs you are willing to accept from the frontend
-              const InputSchema = new StateSchema({
-                ...CopilotKitStateSchema.fields,
-                question: z.string(),
+              // An input annotation for inputs you are willing to accept from the frontend
+              const InputAnnotation = Annotation.Root({
+                ...CopilotKitStateAnnotation.spec,
+                question: Annotation<string>,
               });
 
-              // Output schema for output you are willing to pass to the frontend
-              const OutputSchema = new StateSchema({
-                ...CopilotKitStateSchema.fields,
-                answer: z.string(),
+              // Output annotation for output you are willing to pass to the frontend
+              const OutputAnnotation = Annotation.Root({
+                ...CopilotKitStateAnnotation.spec,
+                answer: Annotation<string>,
               });
 
-              // The full schema, including the inputs, outputs and internal state ("resources" in our case)
-              export const AgentStateSchema = new StateSchema({
-                ...CopilotKitStateSchema.fields,
-                ...OutputSchema.fields,
-                ...InputSchema.fields,
-                resources: z.array(z.string()).default(() => []),
+              // The full annotation, including the inputs, outputs and internal state ("resources" in our case)
+              const AgentStateAnnotation = Annotation.Root({
+                ...CopilotKitStateAnnotation.spec,
+                question: Annotation<string>,
+                answer: Annotation<string>,
+                resources: Annotation<string[]>,
               });
 
-              // Define a typed state that supports the entire
-              export type AgentState = typeof AgentStateSchema.State;
+              export type AgentState = typeof AgentStateAnnotation.State;
 
               async function answerNode(state: AgentState, config: RunnableConfig) {
-                const model = new ChatOpenAI()
+                const model = new ChatOpenAI();
 
                 const systemMessage = new SystemMessage({
                   content: `You are a helpful assistant. Answer the question: ${state.question}.`,
                 });
 
-                const response = await modelWithTools.invoke(
+                const response = await model.invoke(
                   [systemMessage, ...state.messages],
                   config
                 );
 
                 // ...add the rest of the agent implementation
                 // extract the answer, which will be assigned to the state soon
-                const answer = response.content
+                const answer = typeof response.content === 'string' 
+                  ? response.content 
+                  : JSON.stringify(response.content);
 
                 return {
-                  messages: response,
+                  messages: [response],
                   // include the answer in the returned state
                   answer,
                 }
               }
 
               // finally, before compiling the graph, we define the 3 state components
-              const workflow = new StateGraph({
-                input: InputSchema,
-                output: OutputSchema,
-                stateSchema: AgentStateSchema,
+              // StateGraph accepts the full state annotation as the first parameter,
+              // with optional input/output annotations to filter what's communicated with the frontend
+              const workflow = new StateGraph(AgentStateAnnotation, {
+                input: InputAnnotation,
+                output: OutputAnnotation,
               })
-                .addNode("answer_node", answerNode) // add all the different nodes and edges and compile the graph
+                .addNode("answer_node", answerNode)
                 .addEdge(START, "answer_node")
-                .addEdge("answer_node", END)
-              export const graph = workflow.compile()
+                .addEdge("answer_node", END);
+
+              export const graph = workflow.compile();
             ```
           </Tab>
       </Tabs>


### PR DESCRIPTION
## Summary\n- Fixes the LangGraph TypeScript input/output schemas docs example\n- Uses the current Annotation.Root and StateGraph constructor pattern\n- Adds missing imports and safer response content handling\n\n## Test plan\n- Documentation-only change; no runtime checks run by repair step\n\nLinear: FAC-113