### PR TITLE
docs(deepagents): add complete TypeScript state streaming examples

### DIFF
--- a/examples/integrations/a2a-middleware/tsconfig.json
+++ b/examples/integrations/a2a-middleware/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -22,9 +18,7 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     },
     "target": "ES2017"
   },
@@ -35,7 +29,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/examples/integrations/langgraph-js/fixtures/default.json
+++ b/examples/integrations/langgraph-js/fixtures/default.json
@@ -121,7 +121,9 @@
       }
     },
     {
-      "match": { "userMessage": "Use Excalidraw to create a simple network diagram" },
+      "match": {
+        "userMessage": "Use Excalidraw to create a simple network diagram"
+      },
       "response": {
         "content": "In a live run I'd use the Excalidraw MCP app to sketch a network diagram: one router connected to two switches, each connected to two computers. (This is a scripted mock reply -- add your OPENAI_API_KEY to .env to draw it for real.)"
       }
@@ -136,7 +138,11 @@
       "match": { "userMessage": "Toggle the app theme" },
       "response": {
         "toolCalls": [
-          { "name": "toggleTheme", "arguments": "{}", "id": "call_toggle_theme_001" }
+          {
+            "name": "toggleTheme",
+            "arguments": "{}",
+            "id": "call_toggle_theme_001"
+          }
         ]
       }
     },

--- a/examples/integrations/langgraph-python/fixtures/default.json
+++ b/examples/integrations/langgraph-python/fixtures/default.json
@@ -91,7 +91,9 @@
       }
     },
     {
-      "match": { "userMessage": "schedule a 30-minute meeting to learn about CopilotKit" },
+      "match": {
+        "userMessage": "schedule a 30-minute meeting to learn about CopilotKit"
+      },
       "response": {
         "toolCalls": [
           {
@@ -109,7 +111,9 @@
       }
     },
     {
-      "match": { "userMessage": "sales dashboard with total revenue, new customers, and conversion rate" },
+      "match": {
+        "userMessage": "sales dashboard with total revenue, new customers, and conversion rate"
+      },
       "response": {
         "toolCalls": [
           {
@@ -121,7 +125,9 @@
       }
     },
     {
-      "match": { "userMessage": "Use Excalidraw to create a simple network diagram" },
+      "match": {
+        "userMessage": "Use Excalidraw to create a simple network diagram"
+      },
       "response": {
         "content": "Here's a simple network diagram for your topology:\n\n```\n            [Router]\n           /        \\\n      [Switch A]   [Switch B]\n       /     \\      /     \\\n   [PC 1] [PC 2] [PC 3] [PC 4]\n```\n\nThe router connects to two switches, and each switch connects to two computers. In the live demo this renders as an interactive Excalidraw diagram via the Excalidraw MCP app."
       }
@@ -133,7 +139,9 @@
       }
     },
     {
-      "match": { "userMessage": "Toggle the app theme using the toggleTheme tool" },
+      "match": {
+        "userMessage": "Toggle the app theme using the toggleTheme tool"
+      },
       "response": {
         "toolCalls": [
           {

--- a/examples/showcases/oracle-agent-memory/agent/pyproject.toml
+++ b/examples/showcases/oracle-agent-memory/agent/pyproject.toml
@@ -5,16 +5,16 @@ description = "Oracle Agent Spec × Agent Memory × CopilotKit — travel concie
 # oracleagentmemory 26.4.0 ships a cp312-only wheel, so pin to 3.12.
 requires-python = ">=3.12,<3.13"
 dependencies = [
-    # Agent Spec → AG-UI adapter (not on PyPI; installed from the ag-ui monorepo).
-    # The [langgraph] extra transitively brings langgraph + langchain + pyagentspec.
-    "ag-ui-agent-spec[langgraph] @ git+https://github.com/ag-ui-protocol/ag-ui.git#subdirectory=integrations/agent-spec/python",
-    # Persistent agent memory on Oracle AI Database, and the DB driver it talks to.
-    "oracleagentmemory==26.4.0",
-    "oracledb>=2.2.0",
-    "langgraph-oracledb>=1.0.1",
-    # HTTP server + env loading.
-    "uvicorn[standard]>=0.30",
-    "python-dotenv>=1.0",
+  # Agent Spec → AG-UI adapter (not on PyPI; installed from the ag-ui monorepo).
+  # The [langgraph] extra transitively brings langgraph + langchain + pyagentspec.
+  "ag-ui-agent-spec[langgraph] @ git+https://github.com/ag-ui-protocol/ag-ui.git#subdirectory=integrations/agent-spec/python",
+  # Persistent agent memory on Oracle AI Database, and the DB driver it talks to.
+  "oracleagentmemory==26.4.0",
+  "oracledb>=2.2.0",
+  "langgraph-oracledb>=1.0.1",
+  # HTTP server + env loading.
+  "uvicorn[standard]>=0.30",
+  "python-dotenv>=1.0",
 ]
 
 # Runnable app, not a distributable library.
@@ -22,10 +22,7 @@ dependencies = [
 package = false
 
 [dependency-groups]
-dev = [
-    "pytest>=9.1.1",
-    "pytest-asyncio>=1.4.0",
-]
+dev = ["pytest>=9.1.1", "pytest-asyncio>=1.4.0"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/examples/showcases/oracle-agent-memory/frontend/tsconfig.json
+++ b/examples/showcases/oracle-agent-memory/frontend/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -23,9 +19,7 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     }
   },
   "include": [
@@ -35,7 +29,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx
@@ -221,59 +221,141 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                     </Tab>
                     <Tab value="TypeScript">
                         ```ts
-                        import { copilotkitCustomizeConfig } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
-                        import { tool } from "langchain";
-                        import { ChatOpenAI } from "@langchain/openai";
-                        import { SystemMessage } from "@langchain/core/messages";
-                        import { Command } from "@langchain/langgraph";
+                        import { randomUUID } from "node:crypto";
                         import { z } from "zod";
+                        import type { RunnableConfig } from "@langchain/core/runnables";
+                        import { tool } from "@langchain/core/tools";
+                        import type { ToolRunnableConfig } from "@langchain/core/tools";
+                        import { ToolNode } from "@langchain/langgraph/prebuilt";
+                        import type { AIMessage } from "@langchain/core/messages";
+                        import { SystemMessage, ToolMessage } from "@langchain/core/messages";
+                        import {
+                          Annotation,
+                          Command,
+                          MemorySaver,
+                          START,
+                          StateGraph,
+                        } from "@langchain/langgraph";
+                        import { ChatOpenAI } from "@langchain/openai";
+                        import {
+                          copilotkitCustomizeConfig, // [!code highlight]
+                          convertActionsToDynamicStructuredTools,
+                          CopilotKitStateAnnotation,
+                        } from "@copilotkit/sdk-js/langgraph";
 
+                        // 1. Define shared state with CopilotKit annotations
+                        const AgentStateAnnotation = Annotation.Root({
+                          ...CopilotKitStateAnnotation.spec,
+                          observed_steps: Annotation<string[]>,
+                        });
+
+                        type AgentState = typeof AgentStateAnnotation.State;
+
+                        // 2. Define the tool with proper ToolMessage handling
                         const stepProgressTool = tool(
-                            async (args) => args,
-                            {
-                                name: "step_progress_tool",
-                                description: "Reports the current steps being executed",
-                                schema: z.object({ steps: z.array(z.string()) }),
+                          async ({ steps }, config: ToolRunnableConfig) => {
+                            const toolCallId = config.toolCall?.id;
+                            if (typeof toolCallId !== "string" || toolCallId.length === 0) {
+                              throw new Error(
+                                "step_progress_tool: missing tool_call_id — tool was invoked outside a " +
+                                "ToolNode context. Refusing to emit a ToolMessage with an empty " +
+                                "tool_call_id (OpenAI rejects those)."
+                              );
                             }
+
+                            return new Command({
+                              update: {
+                                observed_steps: steps,
+                                messages: [
+                                  new ToolMessage({
+                                    content: "Steps recorded to shared state.",
+                                    name: "step_progress_tool",
+                                    id: randomUUID(),
+                                    tool_call_id: toolCallId,
+                                  }),
+                                ],
+                              },
+                            });
+                          },
+                          {
+                            name: "step_progress_tool",
+                            description: "Reports the current steps being executed",
+                            schema: z.object({ steps: z.array(z.string()) }),
+                          }
                         );
 
-                        async function frontendActionsNode(state: any, config: any) {
-                            // Configure CopilotKit to treat step_progress_tool calls as predictive of the final state
-                            const modifiedConfig = copilotkitCustomizeConfig(config, {
-                                emitIntermediateState: [
-                                    {
-                                        stateKey: "observed_steps",
-                                        tool: "step_progress_tool",
-                                        toolArgument: "steps",
-                                    },
-                                ],
+                        const tools = [stepProgressTool];
+
+                        // 3. Define the chat node
+                        async function chatNode(state: AgentState, config: RunnableConfig) {
+                          const model = new ChatOpenAI({
+                            model: "gpt-5.4",
+                            modelKwargs: { parallel_tool_calls: false },
+                          });
+
+                          const modelWithTools = model.bindTools!([
+                            ...convertActionsToDynamicStructuredTools(state.copilotkit?.actions ?? []),
+                            ...tools,
+                          ]);
+
+                          // Configure CopilotKit to stream tool arguments into state
+                          const streamingConfig = copilotkitCustomizeConfig(config, {
+                            emitIntermediateState: [
+                              {
+                                stateKey: "observed_steps",
+                                tool: "step_progress_tool",
+                                toolArgument: "steps",
+                              },
+                            ],
+                          });
+
+                          const response = await modelWithTools.invoke(
+                            [
+                              new SystemMessage(
+                                "You are a task performer. Pretend doing tasks you are given, " +
+                                "report the steps using step_progress_tool."
+                              ),
+                              ...state.messages,
+                            ],
+                            streamingConfig
+                          );
+
+                          return { messages: response };
+                        }
+
+                        // 4. Define routing logic
+                        function shouldContinue({ messages, copilotkit }: AgentState) {
+                          const lastMessage = messages[messages.length - 1] as AIMessage;
+
+                          if (lastMessage.tool_calls?.length) {
+                            const actions = copilotkit?.actions;
+                            const hasBackendToolCall = lastMessage.tool_calls.some((toolCall) => {
+                              return (
+                                !actions || actions.every((action) => action.name !== toolCall.name)
+                              );
                             });
 
-                            const model = new ChatOpenAI({ model: "gpt-4" }).bindTools([
-                                ...(state.copilotkit?.actions ?? []),
-                                stepProgressTool,
-                            ]);
-
-                            const response = await model.invoke(
-                                [
-                                    new SystemMessage("You are a task performer. Pretend doing tasks you are given, report the steps using step_progress_tool."),
-                                    ...state.messages,
-                                ],
-                                modifiedConfig,
-                            );
-
-                            if (response.tool_calls?.[0]?.name === "step_progress_tool") {
-                                return new Command({
-                                    goto: "__end__",
-                                    update: {
-                                        messages: response,
-                                        observed_steps: response.tool_calls[0].args.steps,
-                                    },
-                                });
+                            if (hasBackendToolCall) {
+                              return "tool_node";
                             }
+                          }
 
-                            return new Command({ goto: "__end__", update: { messages: response } });
+                          return "__end__";
                         }
+
+                        // 5. Compile the graph
+                        const workflow = new StateGraph(AgentStateAnnotation)
+                          .addNode("chat_node", chatNode)
+                          .addNode("tool_node", new ToolNode(tools))
+                          .addEdge(START, "chat_node")
+                          .addEdge("tool_node", "chat_node")
+                          .addConditionalEdges("chat_node", shouldContinue as any);
+
+                        const memory = new MemorySaver();
+
+                        export const graph = workflow.compile({
+                          checkpointer: memory,
+                        });
                         ```
                     </Tab>
                 </Tabs>

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/shared-state/predictive-state-updates.mdx
@@ -221,46 +221,143 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                     </Tab>
                     <Tab value="TypeScript">
                         ```typescript
-                        import { copilotkitCustomizeConfig } from '@copilotkit/sdk-js/langgraph';
+                        import { randomUUID } from "node:crypto";
+                        import { z } from "zod";
+                        import type { RunnableConfig } from "@langchain/core/runnables";
+                        import { tool } from "@langchain/core/tools";
+                        import type { ToolRunnableConfig } from "@langchain/core/tools";
+                        import { ToolNode } from "@langchain/langgraph/prebuilt";
+                        import type { AIMessage } from "@langchain/core/messages";
+                        import { SystemMessage, ToolMessage } from "@langchain/core/messages";
+                        import {
+                          Annotation,
+                          Command,
+                          MemorySaver,
+                          START,
+                          StateGraph,
+                        } from "@langchain/langgraph";
+                        import { ChatOpenAI } from "@langchain/openai";
+                        import {
+                          copilotkitCustomizeConfig,
+                          convertActionsToDynamicStructuredTools,
+                          CopilotKitStateAnnotation,
+                        } from "@copilotkit/sdk-js/langgraph";
 
-                        async function frontendActionsNode(state: AgentState, config: RunnableConfig): Promise<AgentState> {
-                            const modifiedConfig = copilotkitCustomizeConfig(config, {
-                                emitIntermediateState: [
-                                {
-                                    stateKey: "observed_steps",
-                                    tool: "StepProgressTool",
-                                    toolArgument: "steps",
-                                },
+                        // 1. Define shared state with CopilotKit annotations
+                        const AgentStateAnnotation = Annotation.Root({
+                          ...CopilotKitStateAnnotation.spec,
+                          observed_steps: Annotation<string[]>,
+                        });
+
+                        type AgentState = typeof AgentStateAnnotation.State;
+
+                        // 2. Define the tool with proper ToolMessage handling
+                        const stepProgressTool = tool(
+                          async ({ steps }, config: ToolRunnableConfig) => {
+                            const toolCallId = config.toolCall?.id;
+                            if (typeof toolCallId !== "string" || toolCallId.length === 0) {
+                              throw new Error(
+                                "StepProgressTool: missing tool_call_id — tool was invoked outside a " +
+                                "ToolNode context. Refusing to emit a ToolMessage with an empty " +
+                                "tool_call_id (OpenAI rejects those)."
+                              );
+                            }
+
+                            return new Command({
+                              update: {
+                                observed_steps: steps,
+                                messages: [
+                                  new ToolMessage({
+                                    content: "Steps recorded to shared state.",
+                                    name: "StepProgressTool",
+                                    id: randomUUID(),
+                                    tool_call_id: toolCallId,
+                                  }),
                                 ],
+                              },
+                            });
+                          },
+                          {
+                            name: "StepProgressTool",
+                            description: "Records progress by updating the steps array",
+                            schema: z.object({
+                              steps: z.array(z.string()),
+                            }),
+                          }
+                        );
+
+                        const tools = [stepProgressTool];
+
+                        // 3. Define the chat node
+                        async function chatNode(state: AgentState, config: RunnableConfig) {
+                          const model = new ChatOpenAI({
+                            model: "gpt-5.4",
+                            modelKwargs: { parallel_tool_calls: false },
+                          });
+
+                          const modelWithTools = model.bindTools!([
+                            ...convertActionsToDynamicStructuredTools(state.copilotkit?.actions ?? []),
+                            ...tools,
+                          ]);
+
+                          // Configure CopilotKit to stream tool arguments into state
+                          const streamingConfig = copilotkitCustomizeConfig(config, {
+                            emitIntermediateState: [
+                              {
+                                stateKey: "observed_steps",
+                                tool: "StepProgressTool",
+                                toolArgument: "steps",
+                              },
+                            ],
+                          });
+
+                          const response = await modelWithTools.invoke(
+                            [
+                              new SystemMessage(
+                                "You are a task performer. Pretend doing tasks you are given, " +
+                                "report the steps using StepProgressTool."
+                              ),
+                              ...state.messages,
+                            ],
+                            streamingConfig
+                          );
+
+                          return { messages: response };
+                        }
+
+                        // 4. Define routing logic
+                        function shouldContinue({ messages, copilotkit }: AgentState) {
+                          const lastMessage = messages[messages.length - 1] as AIMessage;
+
+                          if (lastMessage.tool_calls?.length) {
+                            const actions = copilotkit?.actions;
+                            const hasBackendToolCall = lastMessage.tool_calls.some((toolCall) => {
+                              return (
+                                !actions || actions.every((action) => action.name !== toolCall.name)
+                              );
                             });
 
-                            const stepProgress = tool(
-                                async (args) => args,
-                                {
-                                    name: "StepProgressTool",
-                                    description: "Records progress by updating the steps array",
-                                    schema: z.object({
-                                        steps: z.array(z.string()),
-                                    }),
-                                }
-                            );
+                            if (hasBackendToolCall) {
+                              return "tool_node";
+                            }
+                          }
 
-                            const model = new ChatOpenAI({
-                                model: "gpt-5.4",
-                            }).bindTools([stepProgress]);
-
-                            const system_message = new SystemMessage("You are a task performer. Pretend doing tasks you are given, report the steps using StepProgressTool.")
-                            const response = await model.invoke([system_message, ...state.messages], modifiedConfig);
-
-
-                            if (response.tool_calls?.length) {
-                                return {
-                                    messages: response;
-                                    observed_steps: response.tool_calls[0].args.steps,
-                                }
-
-                            return { messages: response };
+                          return "__end__";
                         }
+
+                        // 5. Compile the graph
+                        const workflow = new StateGraph(AgentStateAnnotation)
+                          .addNode("chat_node", chatNode)
+                          .addNode("tool_node", new ToolNode(tools))
+                          .addEdge(START, "chat_node")
+                          .addEdge("tool_node", "chat_node")
+                          .addConditionalEdges("chat_node", shouldContinue as any);
+
+                        const memory = new MemorySaver();
+
+                        export const graph = workflow.compile({
+                          checkpointer: memory,
+                        });
                         ```
                     </Tab>
                 </Tabs>


### PR DESCRIPTION
## Summary

Fixes FAC-101: Deep Agents TS tool call hangs inProgress in state streaming example

The Deep Agents and LangGraph state streaming documentation previously showed only an isolated `frontendActionsNode` function without the full graph setup needed to make it work. This caused confusion and non-functional code when users tried to implement the pattern.

## Changes

### Documentation Fixes
- **Added complete state annotation** with `Annotation.Root` and `CopilotKitStateAnnotation.spec`
- **Added proper tool implementation** that returns `Command` with `ToolMessage` including matching `tool_call_id`
- **Added full graph setup** with `StateGraph`, nodes, edges, and routing logic
- **Added graph compilation** example with `MemorySaver` checkpointer

### Pattern Source
- Patterned after the working reference in `showcase/integrations/langgraph-typescript/src/agent/shared-state-streaming.ts`
- Ensures tool calls properly transition from `inProgress` to `complete` when observed via `useDefaultRenderTool`

### Files Updated
- `showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx` - TypeScript example
- `showcase/shell-docs/src/content/docs/integrations/langgraph/shared-state/predictive-state-updates.mdx` - Parallel LangGraph example

### Formatter Changes
- Applied oxfmt formatter to ensure code consistency
- Includes formatting updates to JSON and other config files

## Testing

The updated examples:
- ✅ Include all necessary imports and type definitions
- ✅ Show complete graph wiring with proper tool routing
- ✅ Demonstrate proper `ToolMessage` handling with `tool_call_id`
- ✅ Match the pattern from the working showcase integration

## Related
- Linear: https://linear.app/copilotkit/issue/FAC-101/deep-agents-ts-tool-call-hangs-inprogress-in-state-streaming-example