### PR TITLE
docs(langgraph): remove internal makeChatOpenAI from doc-extracted regions

### DIFF
--- a/showcase/integrations/langgraph-typescript/src/agent/a2ui-fixed.ts
+++ b/showcase/integrations/langgraph-typescript/src/agent/a2ui-fixed.ts
@@ -9,6 +9,8 @@
  * Ported from `src/agents/a2ui_fixed.py`.
  */
 
+import { makeChatOpenAI } from "./openai-headers";
+
 // @region[backend-render-operations]
 // @region[backend-schema-json-load]
 import { readFileSync } from "fs";
@@ -16,10 +18,11 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 import { z } from "zod";
-import { RunnableConfig } from "@langchain/core/runnables";
+import type { RunnableConfig } from "@langchain/core/runnables";
 import { tool } from "@langchain/core/tools";
 import { ToolNode } from "@langchain/langgraph/prebuilt";
-import { AIMessage, SystemMessage } from "@langchain/core/messages";
+import type { AIMessage } from "@langchain/core/messages";
+import { SystemMessage } from "@langchain/core/messages";
 import {
   MemorySaver,
   START,
@@ -27,7 +30,6 @@ import {
   Annotation,
 } from "@langchain/langgraph";
 import { ChatOpenAI } from "@langchain/openai";
-import { makeChatOpenAI } from "./openai-headers";
 
 import {
   convertActionsToDynamicStructuredTools,

--- a/showcase/integrations/langgraph-typescript/src/agent/agent-config.ts
+++ b/showcase/integrations/langgraph-typescript/src/agent/agent-config.ts
@@ -11,6 +11,8 @@
  * the system prompt from three small rulebooks before invoking the model.
  */
 
+import { makeChatOpenAI } from "./openai-headers";
+
 // @region[agent-config-setup]
 import type { RunnableConfig } from "@langchain/core/runnables";
 import type { AIMessage } from "@langchain/core/messages";
@@ -22,7 +24,6 @@ import {
   Annotation,
 } from "@langchain/langgraph";
 import { ChatOpenAI } from "@langchain/openai";
-import { makeChatOpenAI } from "./openai-headers";
 
 import { CopilotKitStateAnnotation } from "@copilotkit/sdk-js/langgraph";
 
@@ -151,6 +152,25 @@ function buildSystemPrompt(props: ResolvedProps): string {
 }
 
 async function chatNode(state: AgentState, config: RunnableConfig) {
+  const model = new ChatOpenAI({
+    model: "gpt-4o-mini",
+    temperature: 0.4,
+  });
+  const props = readConfig(state, config);
+  const systemPrompt = buildSystemPrompt(props);
+
+  const response = (await model.invoke(
+    [new SystemMessage({ content: systemPrompt }), ...state.messages],
+    config,
+  )) as AIMessage;
+
+  return { messages: response };
+}
+// @endregion[agent-config-setup]
+
+// Showcase-specific wrapper: uses makeChatOpenAI for aimock header forwarding.
+// The chatNode above (inside the region) uses the public ChatOpenAI API for docs.
+async function chatNodeWithHeaders(state: AgentState, config: RunnableConfig) {
   const model = makeChatOpenAI(config, {
     model: "gpt-4o-mini",
     temperature: 0.4,
@@ -167,11 +187,10 @@ async function chatNode(state: AgentState, config: RunnableConfig) {
 }
 
 const workflow = new StateGraph(AgentStateAnnotation)
-  .addNode("chat_node", chatNode)
+  .addNode("chat_node", chatNodeWithHeaders)
   .addEdge(START, "chat_node")
   .addEdge("chat_node", "__end__");
 
 const memory = new MemorySaver();
 
 export const graph = workflow.compile({ checkpointer: memory });
-// @endregion[agent-config-setup]

--- a/showcase/integrations/langgraph-typescript/src/agent/interrupt-agent.ts
+++ b/showcase/integrations/langgraph-typescript/src/agent/interrupt-agent.ts
@@ -10,6 +10,8 @@
  * Ported from `src/agents/interrupt_agent.py` in the langgraph-python package.
  */
 
+import { makeChatOpenAI } from "./openai-headers";
+
 // @region[backend-interrupt-tool]
 import { z } from "zod";
 import type { RunnableConfig } from "@langchain/core/runnables";
@@ -25,7 +27,6 @@ import {
   interrupt,
 } from "@langchain/langgraph";
 import { ChatOpenAI } from "@langchain/openai";
-import { makeChatOpenAI } from "./openai-headers";
 
 import {
   convertActionsToDynamicStructuredTools,

--- a/showcase/integrations/langgraph-typescript/src/agent/readonly-state.ts
+++ b/showcase/integrations/langgraph-typescript/src/agent/readonly-state.ts
@@ -34,7 +34,7 @@ const SYSTEM_PROMPT =
 
 // @region[agent-context-setup]
 async function chatNode(state: AgentState, config: RunnableConfig) {
-  const model = makeChatOpenAI(config, { model: "gpt-5.4" });
+  const model = new ChatOpenAI({ model: "gpt-4o", temperature: 0 });
 
   // Inject read-only context from useAgentContext / useCopilotReadable.
   // Mirrors the `createAppContextBeforeAgent` logic in CopilotKitMiddleware:
@@ -69,8 +69,41 @@ async function chatNode(state: AgentState, config: RunnableConfig) {
 }
 // @endregion[agent-context-setup]
 
+// Showcase-specific wrapper: uses makeChatOpenAI for aimock header forwarding.
+// The chatNode above (inside the region) uses the public ChatOpenAI API for docs.
+async function chatNodeWithHeaders(state: AgentState, config: RunnableConfig) {
+  const model = makeChatOpenAI(config, { model: "gpt-5.4" });
+
+  const appContext = state.copilotkit?.context;
+  const isEmptyContext =
+    !appContext ||
+    (typeof appContext === "string" && appContext.trim() === "") ||
+    (typeof appContext === "object" && Object.keys(appContext).length === 0);
+
+  const systemMessages: SystemMessage[] = [
+    new SystemMessage({ content: SYSTEM_PROMPT }),
+  ];
+
+  if (!isEmptyContext) {
+    const contextContent =
+      typeof appContext === "string"
+        ? appContext
+        : JSON.stringify(appContext, null, 2);
+    systemMessages.push(
+      new SystemMessage({ content: `App Context:\n${contextContent}` }),
+    );
+  }
+
+  const response = await model.invoke(
+    [...systemMessages, ...state.messages],
+    config,
+  );
+
+  return { messages: response };
+}
+
 const workflow = new StateGraph(AgentStateAnnotation)
-  .addNode("chat_node", chatNode)
+  .addNode("chat_node", chatNodeWithHeaders)
   .addEdge(START, "chat_node")
   .addEdge("chat_node", "__end__");
 

--- a/showcase/integrations/langgraph-typescript/src/agent/subagents.ts
+++ b/showcase/integrations/langgraph-typescript/src/agent/subagents.ts
@@ -133,37 +133,6 @@ async function invokeSubAgent(
 }
 // @endregion[subagent-setup]
 
-// Showcase-specific wrapper: uses makeChatOpenAI for aimock header forwarding.
-// The invokeSubAgent above (inside the region) uses the public ChatOpenAI API for docs.
-async function invokeSubAgentWithHeaders(
-  agent: SubAgentName,
-  task: string,
-  config?: RunnableConfig,
-): Promise<string> {
-  const subModel = makeChatOpenAI(config, {
-    temperature: 0,
-    model: "gpt-4o-mini",
-  });
-  const result = await subModel.invoke([
-    new SystemMessage({ content: SUB_AGENT_PROMPTS[agent] }),
-    new HumanMessage({ content: task }),
-  ]);
-  const content = (result as AIMessage).content;
-  if (typeof content === "string") return content;
-  if (Array.isArray(content)) {
-    return content
-      .map((part) =>
-        typeof part === "string"
-          ? part
-          : "text" in (part as Record<string, unknown>)
-            ? String((part as { text?: unknown }).text ?? "")
-            : "",
-      )
-      .join("");
-  }
-  return String(content ?? "");
-}
-
 // ---------------------------------------------------------------------------
 // 3. Helper — emit a single delegation entry plus a ToolMessage.
 //
@@ -215,7 +184,7 @@ async function runSubAgentSafely(
   config?: RunnableConfig,
 ): Promise<{ ok: true; result: string } | { ok: false; result: string }> {
   try {
-    const result = await invokeSubAgentWithHeaders(agent, task, config);
+    const result = await invokeSubAgent(agent, task, config);
     return { ok: true, result };
   } catch (err) {
     const errName = err instanceof Error ? err.constructor.name : typeof err;
@@ -332,7 +301,159 @@ const critiqueAgentTool = tool(
 );
 // @endregion[supervisor-delegation-tools]
 
-const tools = [researchAgentTool, writingAgentTool, critiqueAgentTool];
+// ---------------------------------------------------------------------------
+// Showcase-specific wrappers for aimock header forwarding.
+// ---------------------------------------------------------------------------
+
+// Showcase-specific wrapper: uses makeChatOpenAI for aimock header forwarding.
+// The invokeSubAgent above (inside the region) uses the public ChatOpenAI API for docs.
+async function invokeSubAgentWithHeaders(
+  agent: SubAgentName,
+  task: string,
+  config?: RunnableConfig,
+): Promise<string> {
+  const subModel = makeChatOpenAI(config, {
+    temperature: 0,
+    model: "gpt-4o-mini",
+  });
+  const result = await subModel.invoke([
+    new SystemMessage({ content: SUB_AGENT_PROMPTS[agent] }),
+    new HumanMessage({ content: task }),
+  ]);
+  const content = (result as AIMessage).content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        typeof part === "string"
+          ? part
+          : "text" in (part as Record<string, unknown>)
+            ? String((part as { text?: unknown }).text ?? "")
+            : "",
+      )
+      .join("");
+  }
+  return String(content ?? "");
+}
+
+// Showcase-specific wrapper for runSubAgentSafely that uses makeChatOpenAI.
+async function runSubAgentSafelyWithHeaders(
+  agent: SubAgentName,
+  task: string,
+  config?: RunnableConfig,
+): Promise<{ ok: true; result: string } | { ok: false; result: string }> {
+  try {
+    const result = await invokeSubAgentWithHeaders(agent, task, config);
+    return { ok: true, result };
+  } catch (err) {
+    const errName = err instanceof Error ? err.constructor.name : typeof err;
+    console.error(`[subagents] ${agent} sub-agent invocation failed:`, err);
+    return {
+      ok: false,
+      result: `sub-agent call failed: ${errName} (see server logs)`,
+    };
+  }
+}
+
+// Showcase-specific tool wrappers that use makeChatOpenAI for aimock testing.
+const researchAgentToolWithHeaders = tool(
+  async ({ task }, config: ToolRunnableConfig) => {
+    const toolCallId = requireToolCallId(config, "research_agent");
+    const outcome = await runSubAgentSafelyWithHeaders(
+      "research_agent",
+      task,
+      config,
+    );
+    return delegationUpdate(
+      "research_agent",
+      task,
+      outcome.result,
+      toolCallId,
+      outcome.ok ? "completed" : "failed",
+    );
+  },
+  {
+    name: "research_agent",
+    description:
+      "Delegate a research task to the research sub-agent. " +
+      "Use for: gathering facts, background, definitions, statistics. " +
+      "Returns a bulleted list of key facts.",
+    schema: z.object({
+      task: z
+        .string()
+        .describe("The research question or topic to investigate."),
+    }),
+  },
+);
+
+const writingAgentToolWithHeaders = tool(
+  async ({ task }, config: ToolRunnableConfig) => {
+    const toolCallId = requireToolCallId(config, "writing_agent");
+    const outcome = await runSubAgentSafelyWithHeaders(
+      "writing_agent",
+      task,
+      config,
+    );
+    return delegationUpdate(
+      "writing_agent",
+      task,
+      outcome.result,
+      toolCallId,
+      outcome.ok ? "completed" : "failed",
+    );
+  },
+  {
+    name: "writing_agent",
+    description:
+      "Delegate a drafting task to the writing sub-agent. " +
+      "Use for: producing a polished paragraph, draft, or summary. Pass " +
+      "relevant facts from prior research inside `task`.",
+    schema: z.object({
+      task: z
+        .string()
+        .describe(
+          "Brief + optional source facts. The sub-agent returns a 1-paragraph draft.",
+        ),
+    }),
+  },
+);
+
+const critiqueAgentToolWithHeaders = tool(
+  async ({ task }, config: ToolRunnableConfig) => {
+    const toolCallId = requireToolCallId(config, "critique_agent");
+    const outcome = await runSubAgentSafelyWithHeaders(
+      "critique_agent",
+      task,
+      config,
+    );
+    return delegationUpdate(
+      "critique_agent",
+      task,
+      outcome.result,
+      toolCallId,
+      outcome.ok ? "completed" : "failed",
+    );
+  },
+  {
+    name: "critique_agent",
+    description:
+      "Delegate a critique task to the critique sub-agent. " +
+      "Use for: reviewing a draft and suggesting concrete improvements.",
+    schema: z.object({
+      task: z
+        .string()
+        .describe(
+          "The draft to critique. The sub-agent returns 2-3 critiques.",
+        ),
+    }),
+  },
+);
+
+const tools = [
+  researchAgentToolWithHeaders,
+  writingAgentToolWithHeaders,
+  critiqueAgentToolWithHeaders,
+];
 
 // ---------------------------------------------------------------------------
 // 5. Supervisor chat node.

--- a/showcase/integrations/langgraph-typescript/src/agent/subagents.ts
+++ b/showcase/integrations/langgraph-typescript/src/agent/subagents.ts
@@ -19,16 +19,18 @@
  * package.
  */
 
+import { makeChatOpenAI } from "./openai-headers";
+
 // @region[supervisor-delegation-tools]
 // @region[subagent-setup]
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
-import { RunnableConfig } from "@langchain/core/runnables";
+import type { RunnableConfig } from "@langchain/core/runnables";
 import { tool } from "@langchain/core/tools";
 import type { ToolRunnableConfig } from "@langchain/core/tools";
 import { ToolNode } from "@langchain/langgraph/prebuilt";
+import type { AIMessage } from "@langchain/core/messages";
 import {
-  AIMessage,
   HumanMessage,
   SystemMessage,
   ToolMessage,
@@ -41,7 +43,6 @@ import {
   StateGraph,
 } from "@langchain/langgraph";
 import { ChatOpenAI } from "@langchain/openai";
-import { makeChatOpenAI } from "./openai-headers";
 import {
   convertActionsToDynamicStructuredTools,
   CopilotKitStateAnnotation,
@@ -106,7 +107,7 @@ async function invokeSubAgent(
   task: string,
   config?: RunnableConfig,
 ): Promise<string> {
-  const subModel = makeChatOpenAI(config, {
+  const subModel = new ChatOpenAI({
     temperature: 0,
     model: "gpt-4o-mini",
   });
@@ -131,6 +132,37 @@ async function invokeSubAgent(
   return String(content ?? "");
 }
 // @endregion[subagent-setup]
+
+// Showcase-specific wrapper: uses makeChatOpenAI for aimock header forwarding.
+// The invokeSubAgent above (inside the region) uses the public ChatOpenAI API for docs.
+async function invokeSubAgentWithHeaders(
+  agent: SubAgentName,
+  task: string,
+  config?: RunnableConfig,
+): Promise<string> {
+  const subModel = makeChatOpenAI(config, {
+    temperature: 0,
+    model: "gpt-4o-mini",
+  });
+  const result = await subModel.invoke([
+    new SystemMessage({ content: SUB_AGENT_PROMPTS[agent] }),
+    new HumanMessage({ content: task }),
+  ]);
+  const content = (result as AIMessage).content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        typeof part === "string"
+          ? part
+          : "text" in (part as Record<string, unknown>)
+            ? String((part as { text?: unknown }).text ?? "")
+            : "",
+      )
+      .join("");
+  }
+  return String(content ?? "");
+}
 
 // ---------------------------------------------------------------------------
 // 3. Helper — emit a single delegation entry plus a ToolMessage.
@@ -183,7 +215,7 @@ async function runSubAgentSafely(
   config?: RunnableConfig,
 ): Promise<{ ok: true; result: string } | { ok: false; result: string }> {
   try {
-    const result = await invokeSubAgent(agent, task, config);
+    const result = await invokeSubAgentWithHeaders(agent, task, config);
     return { ok: true, result };
   } catch (err) {
     const errName = err instanceof Error ? err.constructor.name : typeof err;

--- a/showcase/integrations/langgraph-typescript/src/agent/subagents.ts
+++ b/showcase/integrations/langgraph-typescript/src/agent/subagents.ts
@@ -105,7 +105,7 @@ const SUB_AGENT_PROMPTS: Record<SubAgentName, string> = {
 async function invokeSubAgent(
   agent: SubAgentName,
   task: string,
-  config?: RunnableConfig,
+  _config?: RunnableConfig,
 ): Promise<string> {
   const subModel = new ChatOpenAI({
     temperature: 0,
@@ -449,6 +449,10 @@ const critiqueAgentToolWithHeaders = tool(
   },
 );
 
+// Export the doc-region tools for reference (used in extracted docs).
+export { researchAgentTool, writingAgentTool, critiqueAgentTool };
+
+// Use the showcase-specific wrappers in the actual graph.
 const tools = [
   researchAgentToolWithHeaders,
   writingAgentToolWithHeaders,

--- a/showcase/integrations/langgraph-typescript/src/agent/tool-rendering.ts
+++ b/showcase/integrations/langgraph-typescript/src/agent/tool-rendering.ts
@@ -10,12 +10,15 @@
  * renders the same tool calls.
  */
 
+import { makeChatOpenAI } from "./openai-headers";
+
 // @region[weather-tool-backend]
 import { z } from "zod";
-import { RunnableConfig } from "@langchain/core/runnables";
+import type { RunnableConfig } from "@langchain/core/runnables";
 import { tool } from "@langchain/core/tools";
 import { ToolNode } from "@langchain/langgraph/prebuilt";
-import { AIMessage, SystemMessage } from "@langchain/core/messages";
+import type { AIMessage } from "@langchain/core/messages";
+import { SystemMessage } from "@langchain/core/messages";
 import {
   Annotation,
   MemorySaver,
@@ -23,7 +26,6 @@ import {
   StateGraph,
 } from "@langchain/langgraph";
 import { ChatOpenAI } from "@langchain/openai";
-import { makeChatOpenAI } from "./openai-headers";
 
 import {
   convertActionsToDynamicStructuredTools,

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/tool-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/tool-rendering.mdx
@@ -48,7 +48,7 @@ when your agent is calling tools. CopilotKit allows you to fully customize how t
 ### Give your agent a tool to call
 
 The agent in the live demo above exposes a mock `get_weather` tool. This is
-the definition straight from the Python backend:
+the TypeScript implementation of the tool:
 
 <Snippet region="weather-tool-backend" />
 


### PR DESCRIPTION
## Summary

Fixes FAC-104: LangGraph TS tool-rendering docs use unavailable makeChatOpenAI wrapper

Removes internal  import from  markers so doc snippets only show the public  API that users can actually use.

## Changes

### Agent Files (showcase/integrations/langgraph-typescript/src/agent/)

- **tool-rendering.ts**: Moved  import outside  region
- **a2ui-fixed.ts**: Moved import outside  region
- **agent-config.ts**: Replaced  usage with public  API inside region, added  wrapper for showcase
- **interrupt-agent.ts**: Moved import outside  region
- **readonly-state.ts**: Replaced usage with public API inside region, added  wrapper for showcase
- **subagents.ts**: Replaced usage with public API inside region, added  wrapper for showcase

### Documentation
- **tool-rendering.mdx**: Fixed incorrect copy "Python backend" → "TypeScript implementation"

## Pattern

For files where the model instantiation happens inside a doc-extracted region (agent-config.ts, readonly-state.ts, subagents.ts):
- Inside the region: Use  for documentation
- Outside the region: Added  wrapper functions that use  for aimock testing
- The workflow/graph uses the wrapper function, not the doc-friendly one

For files where only imports are in the region (tool-rendering.ts, a2ui-fixed.ts, interrupt-agent.ts):
- Moved the  import outside the region
- The actual usage remains unchanged

## Testing

- ✅ Verified no  remains inside any  blocks
- ✅ Syntax validation passed for all modified files
- ✅ Commit hooks (lint, commitlint) passed

## Related

- Issue: FAC-104
- Research plan: /Users/agent/Projects/qa-agent-pipeline-experiment/runs/FAC-104/claude-sonnet-4-5/validation-plan-output-webhook.md