### PR TITLE
docs: fix deepagents/langgraph A2UI Python API to match SDK

### DIFF
--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui/index.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui/index.mdx
@@ -41,22 +41,23 @@ frontend renderer. The difference is *where the schema comes from* and
 Every A2UI surface is assembled from three kinds of operations emitted
 by the agent and consumed by the frontend renderer:
 
-1. **`createSurface` / `surfaceUpdate`** declares (or pins) the
-   component tree (the schema) for a surface.
-2. **`updateComponents` / `dataModelUpdate`** supplies the data that
-   populates the components via JSON Pointer paths.
-3. **`beginRendering`** tells the client the first frame is ready.
+1. **`createSurface`** declares the component catalog and surface ID.
+2. **`updateComponents`** supplies the component tree (the schema).
+3. **`updateDataModel`** populates the components with data via JSON Pointer paths.
 
-The CopilotKit Python SDK provides helpers for each:
+The CopilotKit Python SDK provides helpers for each, wrapped in a single `render()` call:
 
 ```python
 from copilotkit import a2ui
 
-a2ui.create_surface(surface_id, catalog_id=...)
-a2ui.update_components(surface_id, components)
-a2ui.update_data_model(surface_id, {"items": data})
-a2ui.begin_rendering(surface_id, root_id)
-a2ui.render(operations=[...])  # wraps and serializes for a tool result
+# Render a complete A2UI surface
+a2ui.render(
+    operations=[
+        a2ui.create_surface(surface_id, catalog_id="..."),
+        a2ui.update_components(surface_id, components),
+        a2ui.update_data_model(surface_id, {"items": data}),
+    ]
+)  # wraps and serializes for a tool result
 ```
 
 ## Setup

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/fixed-schema.mdx
@@ -8,7 +8,7 @@ In the fixed-schema approach, you design the UI schema once (in a JSON file or u
 
 1. Schema is loaded from a JSON file at startup
 2. Agent tool receives data from the LLM (e.g., flight search results)
-3. Tool returns `a2ui.render()` with surfaceUpdate + dataModelUpdate + beginRendering
+3. Tool returns `a2ui.render()` with createSurface + updateComponents + updateDataModel operations
 4. The A2UI middleware intercepts the tool result and renders the surface
 
 ## Implementation
@@ -48,12 +48,10 @@ class Flight(TypedDict):
     statusIcon: str
     price: str
 
+CATALOG_ID = "copilotkit://flight-fixed-catalog"
 SURFACE_ID = "flight-search-results"
 FLIGHT_SCHEMA = a2ui.load_schema(
     Path(__file__).parent / "a2ui" / "schemas" / "flight_schema.json"
-)
-BOOKED_SCHEMA = a2ui.load_schema(
-    Path(__file__).parent / "a2ui" / "schemas" / "booked_schema.json"
 )
 
 @tool
@@ -61,34 +59,17 @@ def search_flights(flights: list[Flight]) -> str:
     """Search for flights and display results as rich cards."""
     return a2ui.render(
         operations=[
-            a2ui.surface_update(SURFACE_ID, FLIGHT_SCHEMA),
-            a2ui.data_model_update(SURFACE_ID, {"flights": flights}),
-            a2ui.begin_rendering(SURFACE_ID, "root"),
+            a2ui.create_surface(SURFACE_ID, catalog_id=CATALOG_ID),
+            a2ui.update_components(SURFACE_ID, FLIGHT_SCHEMA),
+            a2ui.update_data_model(SURFACE_ID, {"flights": flights}),
         ],
-        action_handlers={
-            # Exact match: fires when a button with action.name="book_flight" is clicked
-            "book_flight": [
-                a2ui.surface_update(SURFACE_ID, BOOKED_SCHEMA),
-                a2ui.data_model_update(SURFACE_ID, {
-                    "title": "Booking Confirmed",
-                    "detail": "Your flight has been booked.",
-                }),
-                a2ui.begin_rendering(SURFACE_ID, "root"),
-            ],
-            # Catch-all: fires for any button action without a specific match
-            "*": [
-                a2ui.data_model_update(SURFACE_ID, {
-                    "status": "Action received",
-                }),
-            ],
-        },
     )
 ```
 
 Key points:
 - The `Flight` TypedDict is essential — LangChain serializes it into the tool's JSON schema, which is what the LLM sees when deciding what data to generate.
-- `action_handlers` declares optimistic UI responses. When a user clicks a button, the matching handler replaces the surface instantly — no round-trip to the server.
-- `"book_flight"` matches the `action.name` from the schema button. `"*"` is a catch-all for any unmatched action.
+- The three operations — `create_surface`, `update_components`, and `update_data_model` — define the surface, its schema, and its data in sequence.
+- The `catalog_id` connects the backend schema to the frontend component implementations registered in your catalog.
 </Step>
 
 <Step>
@@ -121,31 +102,10 @@ const runtime = new CopilotRuntime({
 </Step>
 </Steps>
 
-## Action handler details
-
-The `action_handlers` in the example above work together with buttons defined in the A2UI schema. Here's how the schema side looks:
-
-### Button with action context
-
-In your `flight_schema.json`, buttons declare an `action` with data-bound context fields. When clicked, the values are resolved from that specific card's data:
-
-```json
-{
-  "Button": {
-    "label": "Book",
-    "action": {
-      "name": "book_flight",
-      "context": [
-        { "key": "flightNumber", "value": { "path": "/flightNumber" } },
-        { "key": "price", "value": { "path": "/price" } }
-      ]
-    }
-  }
-}
-```
-
-When this button is clicked on a card showing flight AA100 at $350, the `"book_flight"` handler fires with `context: { flightNumber: "AA100", price: "$350" }`, and the surface instantly replaces with the booking confirmation.
+<Callout type="warn">
+**Action handlers in Python SDK:** The `action_handlers` parameter for `a2ui.render()` is not yet available in the Python SDK. For now, button actions must be handled via frontend hooks using `useA2UIActionHandler`. Backend-declared action handlers (optimistic UI updates without server round-trip) are planned for a future release.
+</Callout>
 
 <Callout type="info">
-For custom frontend handling with `useA2UIActionHandler`, custom orchestrators, and the full resolution chain, see the [Advanced — Action Handlers](./advanced#action-handlers) guide.
+For frontend action handling with `useA2UIActionHandler` and the full resolution chain, see the [Advanced — Action Handlers](./advanced#action-handlers) guide.
 </Callout>

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/index.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/index.mdx
@@ -59,19 +59,19 @@ All three approaches use the same A2UI protocol and renderer. The difference is 
 
 Every A2UI surface is built from three operations:
 
-1. **`surfaceUpdate`** — defines the component tree (the schema)
-2. **`dataModelUpdate`** — provides the data that populates the components
-3. **`beginRendering`** — tells the client to start rendering
+1. **`createSurface`** — creates the surface and declares its catalog
+2. **`updateComponents`** — defines the component tree (the schema)
+3. **`updateDataModel`** — provides the data that populates the components
 
 The CopilotKit Python SDK provides helpers to build these operations:
 
 ```python
 from copilotkit import a2ui
 
-a2ui.surface_update(surface_id, components)
-a2ui.data_model_update(surface_id, {"items": data})
-a2ui.begin_rendering(surface_id, root_id)
-a2ui.render(operations)  # wraps and serializes
+a2ui.create_surface(surface_id, catalog_id="copilotkit://my-catalog")
+a2ui.update_components(surface_id, components)
+a2ui.update_data_model(surface_id, {"items": data})
+a2ui.render(operations=[...])  # wraps and serializes
 ```
 
 Continue to one of the approach guides above to see the full implementation.

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx
@@ -8,7 +8,7 @@ In the fixed-schema approach, you design the UI schema once (in a JSON file or u
 
 1. Schema is loaded from a JSON file at startup
 2. Agent tool receives data from the LLM (e.g., flight search results)
-3. Tool returns `a2ui.render()` with surfaceUpdate + dataModelUpdate + beginRendering
+3. Tool returns `a2ui.render()` with createSurface + updateComponents + updateDataModel operations
 4. The A2UI middleware intercepts the tool result and renders the surface
 
 ## Implementation
@@ -48,12 +48,10 @@ class Flight(TypedDict):
     statusIcon: str
     price: str
 
+CATALOG_ID = "copilotkit://flight-fixed-catalog"
 SURFACE_ID = "flight-search-results"
 FLIGHT_SCHEMA = a2ui.load_schema(
     Path(__file__).parent / "a2ui" / "schemas" / "flight_schema.json"
-)
-BOOKED_SCHEMA = a2ui.load_schema(
-    Path(__file__).parent / "a2ui" / "schemas" / "booked_schema.json"
 )
 
 @tool
@@ -61,34 +59,17 @@ def search_flights(flights: list[Flight]) -> str:
     """Search for flights and display results as rich cards."""
     return a2ui.render(
         operations=[
-            a2ui.surface_update(SURFACE_ID, FLIGHT_SCHEMA),
-            a2ui.data_model_update(SURFACE_ID, {"flights": flights}),
-            a2ui.begin_rendering(SURFACE_ID, "root"),
+            a2ui.create_surface(SURFACE_ID, catalog_id=CATALOG_ID),
+            a2ui.update_components(SURFACE_ID, FLIGHT_SCHEMA),
+            a2ui.update_data_model(SURFACE_ID, {"flights": flights}),
         ],
-        action_handlers={
-            # Exact match: fires when a button with action.name="book_flight" is clicked
-            "book_flight": [
-                a2ui.surface_update(SURFACE_ID, BOOKED_SCHEMA),
-                a2ui.data_model_update(SURFACE_ID, {
-                    "title": "Booking Confirmed",
-                    "detail": "Your flight has been booked.",
-                }),
-                a2ui.begin_rendering(SURFACE_ID, "root"),
-            ],
-            # Catch-all: fires for any button action without a specific match
-            "*": [
-                a2ui.data_model_update(SURFACE_ID, {
-                    "status": "Action received",
-                }),
-            ],
-        },
     )
 ```
 
 Key points:
 - The `Flight` TypedDict is essential — LangGraph serializes it into the tool's JSON schema, which is what the LLM sees when deciding what data to generate.
-- `action_handlers` declares optimistic UI responses. When a user clicks a button, the matching handler replaces the surface instantly — no round-trip to the server.
-- `"book_flight"` matches the `action.name` from the schema button. `"*"` is a catch-all for any unmatched action.
+- The three operations — `create_surface`, `update_components`, and `update_data_model` — define the surface, its schema, and its data in sequence.
+- The `catalog_id` connects the backend schema to the frontend component implementations registered in your catalog.
 </Step>
 
 <Step>
@@ -118,31 +99,10 @@ const runtime = new CopilotRuntime({
 </Step>
 </Steps>
 
-## Action handler details
-
-The `action_handlers` in the example above work together with buttons defined in the A2UI schema. Here's how the schema side looks:
-
-### Button with action context
-
-In your `flight_schema.json`, buttons declare an `action` with data-bound context fields. When clicked, the values are resolved from that specific card's data:
-
-```json
-{
-  "Button": {
-    "label": "Book",
-    "action": {
-      "name": "book_flight",
-      "context": [
-        { "key": "flightNumber", "value": { "path": "/flightNumber" } },
-        { "key": "price", "value": { "path": "/price" } }
-      ]
-    }
-  }
-}
-```
-
-When this button is clicked on a card showing flight AA100 at $350, the `"book_flight"` handler fires with `context: { flightNumber: "AA100", price: "$350" }`, and the surface instantly replaces with the booking confirmation.
+<Callout type="warn">
+**Action handlers in Python SDK:** The `action_handlers` parameter for `a2ui.render()` is not yet available in the Python SDK. For now, button actions must be handled via frontend hooks using `useA2UIActionHandler`. Backend-declared action handlers (optimistic UI updates without server round-trip) are planned for a future release.
+</Callout>
 
 <Callout type="info">
-For custom frontend handling with `useA2UIActionHandler`, custom orchestrators, and the full resolution chain, see the [Advanced — Action Handlers](./advanced#action-handlers) guide.
+For frontend action handling with `useA2UIActionHandler` and the full resolution chain, see the [Advanced — Action Handlers](./advanced#action-handlers) guide.
 </Callout>


### PR DESCRIPTION
## Problem

The Deep Agents and LangGraph A2UI fixed-schema documentation examples reference non-existent Python SDK methods:

- `a2ui.surface_update()` - never existed in the SDK
- `a2ui.data_model_update()` - never existed (correct method is `update_data_model`)
- `a2ui.begin_rendering()` - never existed
- `action_handlers` parameter on `a2ui.render()` - not yet implemented in Python SDK

This causes AttributeError when developers try to use the documented code.

## Solution

Updated all affected documentation files to use the correct SDK API:

- Replace `a2ui.surface_update()` with `a2ui.create_surface()` + `a2ui.update_components()`
- Replace `a2ui.data_model_update()` with `a2ui.update_data_model()`
- Remove `a2ui.begin_rendering()` calls (not part of SDK)
- Remove `action_handlers` parameter and examples
- Add warning callout explaining that action_handlers are not yet available in Python SDK

The corrected examples now match the working showcase code in `showcase/integrations/langgraph-python/src/agents/a2ui_fixed.py`.

## Testing

- Verified all incorrect method references removed via grep
- Cross-referenced with `sdk-python/copilotkit/a2ui.py` exports
- Matched pattern from working showcase examples

## Files Changed

- `showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/fixed-schema.mdx`
- `showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/index.mdx`
- `showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx`

Fixes: [FAC-97](https://linear.app/copilotkit/issue/FAC-97/deep-agents-a2ui-fixed-schema-docs-example-calls-missing)