### PR TITLE
ci(showcase): drop unused runner apt repos before installing bats

### DIFF
--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -568,6 +568,14 @@ jobs:
 
       - name: Install bats
         run: |
+          # GitHub's ubuntu-latest runner image preconfigures third-party apt
+          # repos (Microsoft / azure-cli) for preinstalled tooling this job does
+          # not use. When one of those repos serves invalid release metadata,
+          # `apt-get update` exits non-zero and `bash -e` aborts the step —
+          # even though bats comes from Ubuntu's own `universe` repo, which is
+          # unaffected. This job only needs Ubuntu packages, so drop those unused
+          # third-party repos before updating.
+          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure-cli*
           sudo apt-get update
           sudo apt-get install -y bats
 


### PR DESCRIPTION
## Problem

The **Shell script tests (bats + shellcheck)** job in `showcase_validate.yml` installs `bats` with:

```yaml
sudo apt-get update
sudo apt-get install -y bats
```

GitHub's `ubuntu-latest` runner image preconfigures third-party apt repos (Microsoft / `azure-cli`, pointing at `packages.microsoft.com`) for preinstalled tooling. `apt-get update` refreshes **every** configured repo, not just the ones a job needs. When one of those Microsoft repos serves invalid release metadata:

```
E: Failed to fetch https://packages.microsoft.com/.../InRelease  Clearsigned file isn't valid, got 'NOSPLIT'
##[error]Process completed with exit code 100.
```

`apt-get update` exits non-zero and — because the step runs under `bash -e` — the whole step aborts before `bats` installs. This fails the job even though `bats` comes from Ubuntu's own `universe` repo, which is unaffected. It's a runner-image / external-repo outage, not anything in the shell tests.

## Fix

This job only needs Ubuntu packages, so remove the unused third-party repos before updating:

```yaml
sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure-cli*
sudo apt-get update
sudo apt-get install -y bats
```

Ubuntu's archive (where `bats` lives) is in the base `sources.list` and is untouched, so `bats` still installs; `apt-get update` no longer refreshes the broken, unused Microsoft repos, so it stops failing the job.

## Testing

- Change is confined to the `Install bats` step of the `shell-script-tests` job. The rest of the job (shellcheck + the bats suite) is unchanged.
- CI on this PR exercises the modified step directly — a green `shell-script-tests` run here confirms the install path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
