### PR TITLE
docs: Add stop_on_terminal_text definition to Google ADK state rendering docs (FAC-72)

### DIFF
--- a/showcase/integrations/google-adk/src/agents/shared_chat.py
+++ b/showcase/integrations/google-adk/src/agents/shared_chat.py
@@ -44,6 +44,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_MODEL = "gemini-3.1-flash-lite"
 
 
+# @region[stop-on-terminal-text]
 def stop_on_terminal_text(
     callback_context: CallbackContext, llm_response: LlmResponse
 ) -> Optional[LlmResponse]:
@@ -122,6 +123,7 @@ def stop_on_terminal_text(
             "end_invocation; ADK private-API shape may have drifted."
         )
     return None
+# @endregion[stop-on-terminal-text]
 
 
 def get_model(model: str = DEFAULT_MODEL) -> Union[str, Gemini]:

--- a/showcase/integrations/google-adk/src/agents/shared_chat.py
+++ b/showcase/integrations/google-adk/src/agents/shared_chat.py
@@ -123,6 +123,8 @@ def stop_on_terminal_text(
             "end_invocation; ADK private-API shape may have drifted."
         )
     return None
+
+
 # @endregion[stop-on-terminal-text]
 
 

--- a/showcase/shell-docs/src/content/docs/generative-ui/state-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/state-rendering.mdx
@@ -39,22 +39,6 @@ between node transitions.
 
 <Snippet region="state-streaming-middleware" title="backend — StateStreamingMiddleware" />
 
-<Accordions>
-  <Accordion title="What is stop_on_terminal_text?">
-    The backend example above imports `stop_on_terminal_text` as the
-    `after_model_callback`. This callback is required for Google ADK agents
-    because Gemini models don't naturally terminate their agentic loop after a
-    successful tool call — without it, they keep re-issuing the same tool
-    indefinitely.
-
-    The callback inspects each model response and signals the ADK runtime to
-    end the invocation when it detects a final text-only turn (no pending
-    function calls). Here's the full implementation:
-
-    <Snippet region="stop-on-terminal-text" cell="agentic-chat" title="shared_chat.py — stop_on_terminal_text" />
-  </Accordion>
-</Accordions>
-
 <IntegrationGrid
   path="generative-ui/state-rendering"
   exclude={["agno", "agent-spec"]}

--- a/showcase/shell-docs/src/content/docs/generative-ui/state-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/state-rendering.mdx
@@ -51,7 +51,7 @@ between node transitions.
     end the invocation when it detects a final text-only turn (no pending
     function calls). Here's the full implementation:
 
-    <Snippet region="stop-on-terminal-text" title="shared_chat.py — stop_on_terminal_text" />
+    <Snippet region="stop-on-terminal-text" cell="agentic-chat" title="shared_chat.py — stop_on_terminal_text" />
   </Accordion>
 </Accordions>
 

--- a/showcase/shell-docs/src/content/docs/generative-ui/state-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/state-rendering.mdx
@@ -39,6 +39,22 @@ between node transitions.
 
 <Snippet region="state-streaming-middleware" title="backend — StateStreamingMiddleware" />
 
+<Accordions>
+  <Accordion title="What is stop_on_terminal_text?">
+    The backend example above imports `stop_on_terminal_text` as the
+    `after_model_callback`. This callback is required for Google ADK agents
+    because Gemini models don't naturally terminate their agentic loop after a
+    successful tool call — without it, they keep re-issuing the same tool
+    indefinitely.
+
+    The callback inspects each model response and signals the ADK runtime to
+    end the invocation when it detects a final text-only turn (no pending
+    function calls). Here's the full implementation:
+
+    <Snippet region="stop-on-terminal-text" title="shared_chat.py — stop_on_terminal_text" />
+  </Accordion>
+</Accordions>
+
 <IntegrationGrid
   path="generative-ui/state-rendering"
   exclude={["agno", "agent-spec"]}

--- a/showcase/shell-docs/src/content/docs/integrations/adk/generative-ui/state-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/generative-ui/state-rendering.mdx
@@ -166,6 +166,32 @@ is a situation where a user and an agent are working together to solve a problem
 
   </Step>
   <Step>
+    ### Understanding ADK-specific helpers
+
+    When implementing state streaming with ADK agents, you may encounter the `stop_on_terminal_text` callback in code examples. This callback is required for Google ADK agents because Gemini models don't naturally terminate their agentic loop after a successful tool call — without it, they keep re-issuing the same tool indefinitely.
+
+    <Accordions>
+      <Accordion title="What is stop_on_terminal_text?">
+        The `stop_on_terminal_text` callback inspects each model response and signals the ADK runtime to end the invocation when it detects a final text-only turn (no pending function calls). Here's the full implementation:
+
+        <Snippet region="stop-on-terminal-text" cell="agentic-chat" title="shared_chat.py — stop_on_terminal_text" />
+
+        This callback is used as the `after_model_callback` parameter when creating ADK agents:
+
+        ```python
+        from agents.shared_chat import stop_on_terminal_text
+
+        agent = LlmAgent(
+            name="my_agent",
+            model="gemini-3.1-flash-lite",
+            after_model_callback=stop_on_terminal_text,
+            # ... other configuration
+        )
+        ```
+      </Accordion>
+    </Accordions>
+  </Step>
+  <Step>
     ### Give it a try!
 
     You've now created a component that will render the agent's state in the chat.


### PR DESCRIPTION
## Problem

The Google ADK state rendering documentation example imports and uses `stop_on_terminal_text` from `agents.shared_chat`, but the function definition is not shown or referenced in the docs. This makes the example incomplete and not copy-pastable.

## Solution

1. Added region marker `@region[stop-on-terminal-text]` around the `stop_on_terminal_text` function definition in `shared_chat.py`
2. Added an accordion in `state-rendering.mdx` that explains what the function does and shows the full implementation via a `<Snippet>` component

## Details

The `stop_on_terminal_text` callback is essential for Google ADK agents because Gemini models don't naturally terminate their agentic loop after successful tool calls — without it, they keep re-issuing the same tool indefinitely. The accordion provides context and shows the ~80-line implementation in a collapsible format to avoid overwhelming readers.

## Testing

- Verified region markers are properly balanced in `shared_chat.py`
- Confirmed the new accordion follows the same pattern as other accordions in the docs
- The `<Snippet>` component will extract the region content at docs build time

Fixes https://linear.app/copilotkit/issue/FAC-72/google-adk-state-rendering-example-missing-stop-on-terminal-text