### PR TITLE
docs(showcase): add missing component definitions to tool rendering docs [FAC-71]

### DIFF
--- a/showcase/integrations/google-adk/manifest.yaml
+++ b/showcase/integrations/google-adk/manifest.yaml
@@ -211,6 +211,7 @@ demos:
       - src/agents/tool_rendering_agent.py
       - src/agents/tool_rendering_common.py
       - src/app/demos/tool-rendering/page.tsx
+      - src/app/demos/_shared/parse-json-result.ts
       - src/app/api/copilotkit/route.ts
   - id: gen-ui-tool-based
     name: Tool-Based Generative UI

--- a/showcase/integrations/google-adk/src/app/demos/_shared/parse-json-result.ts
+++ b/showcase/integrations/google-adk/src/app/demos/_shared/parse-json-result.ts
@@ -1,3 +1,4 @@
+// @region[parse-json-result-helper]
 // Coerces a tool-call result into a typed object. Tool results arrive
 // as strings when the agent emits JSON or as already-parsed objects
 // when the runtime decoded them upstream — this helper handles both
@@ -10,3 +11,4 @@ export function parseJsonResult<T>(result: unknown): T {
     return {} as T;
   }
 }
+// @endregion[parse-json-result-helper]

--- a/showcase/integrations/google-adk/src/app/demos/tool-rendering/flight-list-card.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/tool-rendering/flight-list-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+// @region[flight-list-card-component]
 import React from "react";
 
 // Rich per-tool renderer for the `search_flights` backend tool.
@@ -108,3 +109,4 @@ function Skeleton() {
     <div className="h-10 animate-pulse rounded-xl bg-[#F0F0F4]" aria-hidden />
   );
 }
+// @endregion[flight-list-card-component]

--- a/showcase/integrations/google-adk/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/tool-rendering/page.tsx
@@ -12,8 +12,7 @@
 //   roll_d20        → <D20Card />           (per-tool renderer)
 //   *               → <CustomCatchallRenderer /> (wildcard fallback)
 
-// @region[render-flight-tool]
-// @region[render-weather-tool]
+// @region[tool-rendering-imports]
 import React from "react";
 import {
   CopilotKit,
@@ -32,6 +31,7 @@ import {
 } from "./custom-catchall-renderer";
 import { parseJsonResult } from "../_shared/parse-json-result";
 import { useSuggestions } from "./suggestions";
+// @endregion[tool-rendering-imports]
 
 interface WeatherResult {
   city?: string;
@@ -72,6 +72,7 @@ export default function ToolRenderingDemo() {
 }
 
 function Chat() {
+  // @region[render-weather-tool]
   // Per-tool renderer #1: get_weather → branded WeatherCard.
   useRenderTool(
     {
@@ -98,6 +99,7 @@ function Chat() {
   );
   // @endregion[render-weather-tool]
 
+  // @region[render-flight-tool]
   // Per-tool renderer #2: search_flights → branded FlightListCard.
   useRenderTool(
     {

--- a/showcase/integrations/google-adk/src/app/demos/tool-rendering/weather-card.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/tool-rendering/weather-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+// @region[weather-card-component]
 import React from "react";
 
 export interface WeatherCardProps {
@@ -85,3 +86,4 @@ function conditionsEmoji(conditions?: string): string {
   if (c.includes("snow")) return "snow";
   return "";
 }
+// @endregion[weather-card-component]

--- a/showcase/shell-docs/src/content/docs/generative-ui/tool-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/tool-rendering.mdx
@@ -75,9 +75,21 @@ The most expressive path is one renderer per tool name. The primary
 `tool-rendering` cell wires two: `get_weather` draws a branded
 `WeatherCard`, `search_flights` draws a `FlightListCard`. Each renderer
 receives the tool's parsed arguments, a live `status`, and (once the agent
-returns) the `result`:
+returns) the `result`.
+
+### Imports
+
+First, import the necessary dependencies and your custom components:
+
+<Snippet region="tool-rendering-imports" title="frontend/src/app/page.tsx — imports" />
+
+### Weather tool renderer
+
+The weather renderer uses the `WeatherCard` component and the `parseJsonResult` helper to parse the tool result:
 
 <Snippet region="render-weather-tool" title="frontend/src/app/page.tsx — weather renderer" />
+
+### Flight tool renderer
 
 The flight renderer follows the same pattern with a different component and schema:
 
@@ -87,6 +99,28 @@ The flight renderer follows the same pattern with a different component and sche
   The `name` you pass to `useRenderTool` must match the tool name the agent
   exposes; that's how the runtime routes the call to your component.
 </Callout>
+
+### Component implementations
+
+Here are the complete implementations of the custom components used above:
+
+#### WeatherCard component
+
+The `WeatherCard` is a branded UI component that displays weather information:
+
+<Snippet region="weather-card-component" title="frontend/src/app/weather-card.tsx — WeatherCard component" />
+
+#### FlightListCard component
+
+The `FlightListCard` displays a list of flight search results:
+
+<Snippet region="flight-list-card-component" title="frontend/src/app/flight-list-card.tsx — FlightListCard component" />
+
+#### parseJsonResult helper
+
+The `parseJsonResult` helper safely parses tool results that may arrive as JSON strings or already-parsed objects:
+
+<Snippet region="parse-json-result-helper" title="frontend/src/app/parse-json-result.ts — parseJsonResult helper" />
 
 Per-tool renderers compose with a catch-all: named renderers claim the
 "interesting" tools and a wildcard handles everything else. In the primary


### PR DESCRIPTION
## Summary

Fixes missing , , and  definitions in the Google ADK Tool Call Rendering documentation.

## Changes

1. **Added region markers to component files**:
   - Added  to 
   - Added  to 
   - Added  to 

2. **Reorganized region boundaries in demo code**:
   - Created new  to isolate imports
   - Moved  and  markers to eliminate duplicate import blocks

3. **Enhanced documentation structure**:
   - Added clear sections for imports, renderers, and component implementations
   - Included complete code snippets for all referenced components
   - Improved reader experience with step-by-step component explanations

## Problem Solved

Previously, the docs showed usage of `WeatherCard`, `FlightListCard`, and `parseJsonResult` without showing their implementations. Readers would see imports and usage but not know how to create these components.

Now readers can:
- Copy complete, working examples
- Understand the full pattern from imports to implementation
- See exactly how to structure their own custom tool renderers

## Testing

The changes are documentation-only and affect:
- Root docs at `showcase/shell-docs/src/content/docs/generative-ui/tool-rendering.mdx`
- Demo source code region markers (no functional changes)

Related issue: https://linear.app/copilotkit/issue/FAC-71