### PR TITLE
fix(showcase): Add Intelligence Platform support to starter template (FAC-70)

### DIFF
--- a/showcase/shared/starter-template/app/api/copilotkit/route.ts
+++ b/showcase/shared/starter-template/app/api/copilotkit/route.ts
@@ -73,6 +73,7 @@ const runtime = new CopilotRuntime({
         }),
         // Demo stub — replace with real auth-derived user identity for multi-user deployments
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),
 });

--- a/showcase/shared/starter-template/app/api/copilotkit/route.ts
+++ b/showcase/shared/starter-template/app/api/copilotkit/route.ts
@@ -1,11 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
   CopilotKitIntelligence,
-} from "@copilotkit/runtime";
+  createCopilotEndpoint,
+  InMemoryAgentRunner,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
+import { handle } from "hono/vercel";
 
 const AGENT_URL =
   process.env.AGENT_URL ||
@@ -61,56 +61,28 @@ for (const name of agentNames) {
   agents[name] = createAgent();
 }
 
-export const POST = async (req: NextRequest) => {
-  try {
-    // Conditionally instantiate CopilotKitIntelligence when all env vars are present
-    const intelligence = intelligenceEnabled
-      ? new CopilotKitIntelligence({
+const runtime = new CopilotRuntime({
+  agents,
+  // Conditionally configure intelligence when all three env vars are present
+  ...(intelligenceEnabled
+    ? {
+        intelligence: new CopilotKitIntelligence({
+          apiKey: intelligenceApiKey!,
           apiUrl: intelligenceApiUrl!,
           wsUrl: intelligenceWsUrl!,
-          apiKey: intelligenceApiKey!,
-        })
-      : undefined;
+        }),
+        // Demo stub — replace with real auth-derived user identity for multi-user deployments
+        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+      }
+    : { runner: new InMemoryAgentRunner() }),
+});
 
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
-      runtime: new CopilotRuntime({
-        // @ts-expect-error -- type wrapping mismatch, fixed in source pending release
-        agents,
-        ...(intelligence ? { intelligence } : {}),
-      }),
-    });
+const app = createCopilotEndpoint({
+  runtime,
+  basePath: "/api/copilotkit",
+});
 
-    return await handleRequest(req);
-  } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : "Unknown error";
-    console.error("[copilotkit/route] ERROR:", error);
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
-};
-
-export const GET = async () => {
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${AGENT_URL}/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "reachable" : `error (${res.status})`;
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    agentStatus = `unreachable (${msg})`;
-  }
-
-  const topStatus = agentStatus.startsWith("unreachable") ? "degraded" : "ok";
-
-  return NextResponse.json({
-    status: topStatus,
-    agent_url: AGENT_URL,
-    agent_status: agentStatus,
-    env: {
-      OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-      NODE_ENV: process.env.NODE_ENV,
-    },
-  });
-};
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);

--- a/showcase/shared/starter-template/app/api/copilotkit/route.ts
+++ b/showcase/shared/starter-template/app/api/copilotkit/route.ts
@@ -3,6 +3,7 @@ import {
   CopilotRuntime,
   ExperimentalEmptyAdapter,
   copilotRuntimeNextJSAppRouterEndpoint,
+  CopilotKitIntelligence,
 } from "@copilotkit/runtime";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
@@ -17,8 +18,21 @@ if (!process.env.AGENT_URL && !process.env.LANGGRAPH_DEPLOYMENT_URL) {
   );
 }
 
+const intelligenceApiUrl = process.env.INTELLIGENCE_API_URL;
+const intelligenceWsUrl = process.env.INTELLIGENCE_GATEWAY_WS_URL;
+const intelligenceApiKey = process.env.INTELLIGENCE_API_KEY;
+
+const intelligenceEnabled = Boolean(
+  intelligenceApiUrl && intelligenceWsUrl && intelligenceApiKey,
+);
+
 console.log("[copilotkit/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit/route] AGENT_URL: ${AGENT_URL}`);
+console.log(
+  `[copilotkit/route] Intelligence mode: ${
+    intelligenceEnabled ? "enabled" : "disabled (OSS)"
+  }`,
+);
 
 function createAgent(graphId: string = "sample_agent") {
   return new LangGraphAgent({
@@ -49,12 +63,22 @@ for (const name of agentNames) {
 
 export const POST = async (req: NextRequest) => {
   try {
+    // Conditionally instantiate CopilotKitIntelligence when all env vars are present
+    const intelligence = intelligenceEnabled
+      ? new CopilotKitIntelligence({
+          apiUrl: intelligenceApiUrl!,
+          wsUrl: intelligenceWsUrl!,
+          apiKey: intelligenceApiKey!,
+        })
+      : undefined;
+
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
       endpoint: "/api/copilotkit",
       serviceAdapter: new ExperimentalEmptyAdapter(),
       runtime: new CopilotRuntime({
         // @ts-expect-error -- type wrapping mismatch, fixed in source pending release
         agents,
+        ...(intelligence ? { intelligence } : {}),
       }),
     });
 


### PR DESCRIPTION
## Summary

Fixes quickstart CLI prompting failures with 500 from /api/threads in starter setup by wiring Intelligence through the v2 runtime in the starter template.

## Problem

When users run `npx copilotkit@latest create`, the CLI writes Intelligence Platform environment variables (`INTELLIGENCE_API_URL`, `INTELLIGENCE_GATEWAY_WS_URL`, `INTELLIGENCE_API_KEY`) to `.env`, but the starter template was using the legacy top-level `@copilotkit/runtime` imports and `copilotRuntimeNextJSAppRouterEndpoint`.

The compatibility wrapper only forwards selected fields (`agents`, `runner`, `licenseToken`, `debug`, `middleware`, `a2ui`, `mcpApps`, `openGenerativeUI`) into the underlying v2 runtime—it does NOT forward `intelligence`. So even when the env vars are present and a CopilotKitIntelligence instance is created, the constructed runtime remains SSE/OSS and `/api/threads` returns 500 "Intelligence not configured."

## Solution

Switch to the v2 runtime path (matching integration examples and banking showcase):
- Import from `@copilotkit/runtime/v2` (`CopilotRuntime`, `CopilotKitIntelligence`, `createCopilotEndpoint`, `InMemoryAgentRunner`)
- Use `createCopilotEndpoint` + Hono's `handle()` from `hono/vercel` instead of the legacy `copilotRuntimeNextJSAppRouterEndpoint`
- Pass `intelligence` directly to `CopilotRuntime` constructor (properly forwarded in v2)
- Add `identifyUser` stub (required when intelligence is configured)
- Export GET/POST/PATCH/DELETE through `handle(app)` per v2 pattern

When `INTELLIGENCE_API_URL`, `INTELLIGENCE_GATEWAY_WS_URL`, and `INTELLIGENCE_API_KEY` are all present (written by CLI during setup), the runtime now instantiates `CopilotKitIntelligence` and threads are properly initialized. When absent, falls back to `InMemoryAgentRunner` (OSS mode).

## Testing

- Pattern matches working implementations in `examples/integrations/langgraph-python` and `examples/showcases/banking`
- Conditional logic ensures backward compatibility with OSS mode

## Related

Fixes: FAC-70
Addresses PR review feedback from MikeRyanDev
