### PR TITLE
docs(voice): Clarify CopilotChat usage and route structure for Google ADK

### DIFF
--- a/showcase/integrations/google-adk/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/voice/page.tsx
@@ -1,9 +1,25 @@
 "use client";
 
-// @region[voice-page]
 import { CopilotKit } from "@copilotkit/react-core/v2";
 import { VoiceChat } from "./voice-chat";
 
+// @region[voice-page]
+import { CopilotChat } from "@copilotkit/react-core/v2";
+
+function VoicePage() {
+  return (
+    <CopilotKit
+      runtimeUrl="/api/copilotkit-voice"
+      agent="voice-demo"
+      useSingleEndpoint={false}
+    >
+      <CopilotChat />
+    </CopilotKit>
+  );
+}
+// @endregion[voice-page]
+
+// Actual demo page uses VoiceChat wrapper with sample button for testing
 export default function VoiceDemoPage() {
   return (
     <CopilotKit
@@ -23,4 +39,3 @@ export default function VoiceDemoPage() {
     </CopilotKit>
   );
 }
-// @endregion[voice-page]

--- a/showcase/integrations/google-adk/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/voice/page.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { CopilotKit } from "@copilotkit/react-core/v2";
 import { VoiceChat } from "./voice-chat";
 
 // @region[voice-page]
-import { CopilotChat } from "@copilotkit/react-core/v2";
+import { CopilotChat, CopilotKit } from "@copilotkit/react-core/v2";
 
 export function VoicePage() {
   return (

--- a/showcase/integrations/google-adk/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/voice/page.tsx
@@ -6,7 +6,7 @@ import { VoiceChat } from "./voice-chat";
 // @region[voice-page]
 import { CopilotChat } from "@copilotkit/react-core/v2";
 
-function VoicePage() {
+export function VoicePage() {
   return (
     <CopilotKit
       runtimeUrl="/api/copilotkit-voice"

--- a/showcase/shell-docs/src/content/docs/voice.mdx
+++ b/showcase/shell-docs/src/content/docs/voice.mdx
@@ -27,7 +27,7 @@ The `runtimeUrl="/api/copilotkit-voice"` points to your Next.js API route. When 
 
 ### Driving the demo without a mic
 
-For Playwright runs, screenshots, or any flow where prompting for mic permissions is awkward, ship a button that POSTs a bundled audio clip directly to the same `/transcribe` endpoint:
+For Playwright runs, screenshots, or any flow where prompting for mic permissions is awkward, ship a button that synchronously injects a canned sample phrase directly into the composer textarea, bypassing the transcription endpoint entirely:
 
 <Snippet
   region="sample-audio-button"

--- a/showcase/shell-docs/src/content/docs/voice.mdx
+++ b/showcase/shell-docs/src/content/docs/voice.mdx
@@ -19,27 +19,43 @@ If you only need file uploads (audio, images, video, documents), use [Multimodal
 
 ## Frontend
 
-`<CopilotChat />` renders the mic button automatically when the runtime advertises `audioFileTranscriptionEnabled: true` on its `/info` endpoint. There's nothing to wire up on the chat surface itself:
+`<CopilotChat />` from `@copilotkit/react-core/v2` renders the mic button automatically when the runtime advertises `audioFileTranscriptionEnabled: true` on its `/info` endpoint. There's nothing to wire up on the chat surface itself:
 
 <Snippet region="voice-page" title="frontend/src/app/page.tsx — chat surface" />
 
-When the user clicks the mic, the chat captures audio, POSTs it to the runtime's `/transcribe` endpoint, drops the resulting transcript into the composer, and submits.
+The `runtimeUrl="/api/copilotkit-voice"` points to your Next.js API route. When the user clicks the mic, the chat captures audio, POSTs it to the runtime's `/transcribe` endpoint, drops the resulting transcript into the composer, and submits.
 
 ### Driving the demo without a mic
 
 For Playwright runs, screenshots, or any flow where prompting for mic permissions is awkward, ship a button that POSTs a bundled audio clip directly to the same `/transcribe` endpoint:
 
-<Snippet region="sample-audio-button" title="frontend/src/app/sample-audio-button.tsx" />
+<Snippet
+  region="sample-audio-button"
+  title="frontend/src/app/sample-audio-button.tsx"
+/>
 
 The caller can drop the resulting text into the composer's textarea (matched via `data-testid="copilot-chat-textarea"`) using the native value setter and a synthetic `input` event so React's managed state updates correctly.
 
 ## Backend
 
-Wire up the V2 runtime with a `TranscriptionService`. The V1 wrapper drops the `transcriptionService` option, so use `createCopilotRuntimeHandler` from `@copilotkit/runtime/v2` directly:
+### Next.js API Route
 
-<Snippet region="voice-runtime" title="app/api/copilotkit-voice/[[...slug]]/route.ts" />
+Create a dedicated API route at `app/api/copilotkit-voice/[[...slug]]/route.ts`. The `[[...slug]]` catch-all pattern lets the V2 runtime handle its internal URL routing (`/info`, `/agent/:id/run`, `/transcribe`, etc.) under the `/api/copilotkit-voice` base path:
 
-With `transcriptionService` set, the runtime advertises `audioFileTranscriptionEnabled: true` on `/info` (which is what tells the chat to render the mic button) and routes `POST /transcribe` to the service.
+<Snippet
+  region="voice-runtime"
+  title="app/api/copilotkit-voice/[[...slug]]/route.ts"
+/>
+
+The `basePath: "/api/copilotkit-voice"` in `createCopilotRuntimeHandler` must match the API route's directory path. With `transcriptionService` set, the runtime advertises `audioFileTranscriptionEnabled: true` on `/info` (which is what tells the chat to render the mic button) and routes `POST /transcribe` to the service.
+
+<Callout type="info">
+  **For Google ADK (Python/FastAPI) backends:** The voice route shown above is
+  frontend-only for transcription. There is **no corresponding `path="/voice"`
+  needed** in your Python backend's `add_adk_fastapi_endpoint` call. The
+  standard `path="/"` works with the frontend's dedicated voice runtime. Your
+  agent receives the transcribed text as a regular message.
+</Callout>
 
 ### Custom transcription backends
 
@@ -47,6 +63,9 @@ With `transcriptionService` set, the runtime advertises `audioFileTranscriptionE
 
 A useful pattern is wrapping your service in a guard that returns a clean 4xx when credentials aren't configured, instead of an opaque 5xx from the underlying SDK:
 
-<Snippet region="transcription-service-guard" title="backend — guarded transcription service" />
+<Snippet
+  region="transcription-service-guard"
+  title="backend — guarded transcription service"
+/>
 
 <IntegrationGrid path="voice" />


### PR DESCRIPTION
## Summary

Fixes documentation gaps in the Google ADK Voice integration docs identified in FAC-61:
- Voice docs snippet now shows the correct `<CopilotChat />` component users should implement, instead of the demo's `<VoiceChat />` wrapper
- Clarifies that `<CopilotChat />` is from `@copilotkit/react-core/v2`
- Explains the `[[...slug]]` catch-all pattern in the API route path and how it maps to the runtime's internal URL routing
- Clarifies the relationship between `runtimeUrl="/api/copilotkit-voice"` and the `basePath` parameter
- Adds explicit callout for ADK Python/FastAPI users that **no `path="/voice"` is needed** in their backend's `add_adk_fastapi_endpoint` call — the voice route is frontend-only for transcription

## Changes

1. **showcase/integrations/google-adk/src/app/demos/voice/page.tsx**:
   - Moved `voice-page` region to show clean `<CopilotChat />` usage
   - Actual demo page continues to use `VoiceChat` wrapper for testing purposes
   
2. **showcase/shell-docs/src/content/docs/voice.mdx**:
   - Added component package qualifier: `<CopilotChat />` from `@copilotkit/react-core/v2`
   - Added "Next.js API Route" subsection explaining the full route path
   - Explained `[[...slug]]` catch-all pattern and basePath mapping
   - Added info callout for ADK Python users about not needing `path="/voice"`

## Related Issue

Closes FAC-61