### PR TITLE
docs(pydantic-ai): Fix Quickstart 'Use an Existing Agent' Section

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -128,7 +128,7 @@ Before you begin, you'll need the following:
                 Add Pydantic AI with AG-UI support and uvicorn to your project:
 
                 ```bash
-                uv add 'pydantic-ai-slim[ag-ui]' 'pydantic-ai-slim[openai]' uvicorn starlette==0.45.3
+                uv add 'pydantic-ai-slim[ag-ui,openai]' uvicorn starlette==0.45.3
                 ```
             </Step>
             <Step>
@@ -197,7 +197,6 @@ Before you begin, you'll need the following:
                 import { CopilotRuntime, createCopilotEndpoint } from "@copilotkit/runtime/v2";
                 import { HttpAgent } from "@ag-ui/client";
                 import { handle } from "hono/vercel";
-                import { NextRequest } from "next/server";
 
                 // Create the CopilotRuntime instance with your agent
                 const runtime = new CopilotRuntime({

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -225,10 +225,11 @@ Before you begin, you'll need the following:
                 ```tsx title="app/layout.tsx"
                 import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
                 import "@copilotkit/react-core/v2/styles.css"; // [!code highlight]
+                import type { ReactNode } from "react"; // [!code highlight]
 
                 // ...
 
-                export default function RootLayout({ children }: {children: React.ReactNode}) {
+                export default function RootLayout({ children }: { children: ReactNode }) {
                   return (
                     <html lang="en">
                       <body>

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -335,6 +335,7 @@ Before you begin, you'll need the following:
         </Accordions>
 
     </Step>
+
 </Steps>
 
 ## What's next?

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -156,25 +156,67 @@ Before you begin, you'll need the following:
                 app = agent.to_ag_ui()
 
                 if __name__ == "__main__":
+                    import uvicorn
+                    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)
+                ```
+            </Step>
+            <Step>
+                ### Install frontend dependencies
 
-                const serviceAdapter = new ExperimentalEmptyAdapter();
+                Create a Next.js app if you don't have one already, then install the required packages:
 
+                <Tabs groupId="package-manager" items={['npm', 'pnpm', 'yarn', 'bun']}>
+                    <Tab value="npm">
+                        ```bash
+                        npm install @copilotkit/react-core @copilotkit/runtime @ag-ui/client hono
+                        ```
+                    </Tab>
+                    <Tab value="pnpm">
+                        ```bash
+                        pnpm add @copilotkit/react-core @copilotkit/runtime @ag-ui/client hono
+                        ```
+                    </Tab>
+                    <Tab value="yarn">
+                        ```bash
+                        yarn add @copilotkit/react-core @copilotkit/runtime @ag-ui/client hono
+                        ```
+                    </Tab>
+                    <Tab value="bun">
+                        ```bash
+                        bun add @copilotkit/react-core @copilotkit/runtime @ag-ui/client hono
+                        ```
+                    </Tab>
+                </Tabs>
+            </Step>
+            <Step>
+                ### Create the API route
+
+                Create a route handler to connect your frontend to your agent:
+
+                ```typescript title="app/api/copilotkit/[[...slug]]/route.ts"
+                import { CopilotRuntime, createCopilotEndpoint } from "@copilotkit/runtime/v2";
+                import { HttpAgent } from "@ag-ui/client";
+                import { handle } from "hono/vercel";
+                import { NextRequest } from "next/server";
+
+                // Create the CopilotRuntime instance with your agent
                 const runtime = new CopilotRuntime({
                   agents: {
                     my_agent: new HttpAgent({ url: "http://localhost:8000/" }),
-                  }
+                  },
                 });
 
-                export const POST = async (req: NextRequest) => {
-                  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-                    runtime,
-                    serviceAdapter,
-                    endpoint: "/api/copilotkit",
-                  });
+                // Create the API endpoint
+                const app = createCopilotEndpoint({
+                  runtime,
+                  basePath: "/api/copilotkit",
+                });
 
-                  return handleRequest(req);
-                };
-               ```
+                export const GET = handle(app);
+                export const POST = handle(app);
+                export const PATCH = handle(app);
+                export const DELETE = handle(app);
+                ```
             </Step>
             <Step>
                 ### Configure CopilotKit Provider
@@ -183,6 +225,7 @@ Before you begin, you'll need the following:
 
                 ```tsx title="app/layout.tsx"
                 import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
+                import "@copilotkit/react-core/v2/styles.css"; // [!code highlight]
 
                 // ...
 

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart/pydantic-ai.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart/pydantic-ai.mdx
@@ -94,7 +94,7 @@ Before you begin, you'll need the following:
                 Our examples will also use uvicorn to run the agent.
 
                 ```sh
-                pip install 'pydantic-ai-slim[ag-ui]' uvicorn
+                pip install 'pydantic-ai-slim[ag-ui,openai]' uvicorn
                 ```
             </Step>
             <Step>
@@ -130,7 +130,6 @@ Before you begin, you'll need the following:
                 import { CopilotRuntime, createCopilotEndpoint } from "@copilotkit/runtime/v2";
                 import { HttpAgent } from "@ag-ui/client";
                 import { handle } from "hono/vercel";
-                import { NextRequest } from "next/server";
 
                 // Create the CopilotRuntime instance with your agent
                 const runtime = new CopilotRuntime({
@@ -159,6 +158,7 @@ Before you begin, you'll need the following:
                 ```tsx title="app/layout.tsx"
                 import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
                 import "@copilotkit/react-core/v2/styles.css"; // [!code highlight]
+                import type { ReactNode } from "react"; // [!code highlight]
 
                 export default function RootLayout({ children }: { children: ReactNode }) {
                   return (

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart/pydantic-ai.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart/pydantic-ai.mdx
@@ -4,7 +4,6 @@ description: Turn your Pydantic AI Agents into an agent-native application in 10
 icon: "lucide/Play"
 ---
 
-
 <video
   src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/chat-example.mp4"
   className="rounded-lg shadow-xl"
@@ -117,9 +116,28 @@ Before you begin, you'll need the following:
 
                 Create a Next.js app if you don't have one already, then install the required packages:
 
-                ```bash
-                npm install @copilotkit/react-core @copilotkit/runtime @ag-ui/client hono
-                ```
+                <Tabs groupId="package-manager" items={['npm', 'pnpm', 'yarn', 'bun']}>
+                    <Tab value="npm">
+                        ```bash
+                        npm install @copilotkit/react-core @copilotkit/runtime @ag-ui/client hono
+                        ```
+                    </Tab>
+                    <Tab value="pnpm">
+                        ```bash
+                        pnpm add @copilotkit/react-core @copilotkit/runtime @ag-ui/client hono
+                        ```
+                    </Tab>
+                    <Tab value="yarn">
+                        ```bash
+                        yarn add @copilotkit/react-core @copilotkit/runtime @ag-ui/client hono
+                        ```
+                    </Tab>
+                    <Tab value="bun">
+                        ```bash
+                        bun add @copilotkit/react-core @copilotkit/runtime @ag-ui/client hono
+                        ```
+                    </Tab>
+                </Tabs>
             </Step>
             <Step>
                 ### Create the API route

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart/pydantic-ai.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart/pydantic-ai.mdx
@@ -108,31 +108,48 @@ Before you begin, you'll need the following:
 
                 # If you want the server to run on invocation, you can do the following:
                 if __name__ == "__main__":
+                    import uvicorn
+                    uvicorn.run("agent:app", host="0.0.0.0", port=8000, reload=True)
+                ```
+            </Step>
+            <Step>
+                ### Install frontend dependencies
 
-                // 1. You can use any service adapter here for multi-agent support. We use
-                //    the empty adapter since we're only using one agent.
-                const serviceAdapter = new ExperimentalEmptyAdapter();
+                Create a Next.js app if you don't have one already, then install the required packages:
 
-                // 2. Create the CopilotRuntime instance and utilize the PydanticAI AG-UI
-                //    integration to setup the connection.
+                ```bash
+                npm install @copilotkit/react-core @copilotkit/runtime @ag-ui/client hono
+                ```
+            </Step>
+            <Step>
+                ### Create the API route
+
+                Create a route handler to connect your frontend to your agent:
+
+                ```typescript title="app/api/copilotkit/[[...slug]]/route.ts"
+                import { CopilotRuntime, createCopilotEndpoint } from "@copilotkit/runtime/v2";
+                import { HttpAgent } from "@ag-ui/client";
+                import { handle } from "hono/vercel";
+                import { NextRequest } from "next/server";
+
+                // Create the CopilotRuntime instance with your agent
                 const runtime = new CopilotRuntime({
                   agents: {
-                    // Our AG-UI endpoint URL
-                    "my_agent": new HttpAgent({ url: "http://localhost:8000/" }),
-                  }
+                    my_agent: new HttpAgent({ url: "http://localhost:8000/" }),
+                  },
                 });
 
-                // 3. Build a Next.js API route that handles the CopilotKit runtime requests.
-                export const POST = async (req: NextRequest) => {
-                  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-                    runtime,
-                    serviceAdapter,
-                    endpoint: "/api/copilotkit",
-                  });
+                // Create the API endpoint
+                const app = createCopilotEndpoint({
+                  runtime,
+                  basePath: "/api/copilotkit",
+                });
 
-                  return handleRequest(req);
-                };
-               ```
+                export const GET = handle(app);
+                export const POST = handle(app);
+                export const PATCH = handle(app);
+                export const DELETE = handle(app);
+                ```
             </Step>
             <Step>
                 ### Setup the CopilotKit provider
@@ -140,6 +157,8 @@ Before you begin, you'll need the following:
                 users will wrap their entire application in the CopilotKit provider.
 
                 ```tsx title="app/layout.tsx"
+                import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
+                import "@copilotkit/react-core/v2/styles.css"; // [!code highlight]
 
                 export default function RootLayout({ children }: { children: ReactNode }) {
                   return (
@@ -162,7 +181,7 @@ Before you begin, you'll need the following:
                 this is done alongside your core page components, e.g. in your `page.tsx` file.
 
                 ```tsx title="page.tsx"
-                // [!code highlight:2]
+                import { CopilotSidebar } from "@copilotkit/react-core/v2"; // [!code highlight]
 
                 export function YourApp() {
                 return (


### PR DESCRIPTION
## Summary

This PR fixes the Pydantic AI Quickstart documentation for the "Use an Existing Agent" path, which had several critical issues preventing users from successfully following the integration guide.

## Changes

### Python Code Block Fixes
- **Completed the Python code blocks** with proper uvicorn startup code
- **Removed mixed TypeScript code** that was incorrectly embedded in the Python code block
- The `main.py`/`agent.py` examples now show complete, runnable Python code

### Added Missing Frontend Setup Steps
- **Added frontend package installation step** with instructions for npm, pnpm, yarn, and bun
- **Added complete route.ts file** with proper imports and setup using `createCopilotEndpoint` and Hono
- **Added required styles import** (`@copilotkit/react-core/v2/styles.css`) to layout.tsx
- **Fixed missing CopilotSidebar import** in the page.tsx example

### Files Changed
- `showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx`
- `showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart/pydantic-ai.mdx`

## Testing

The changes have been verified to:
- Use correct Python syntax throughout Python code blocks
- Use correct TypeScript syntax in separate TypeScript code blocks
- Follow the pattern established in the working example at `examples/integrations/pydantic-ai/`
- Include all necessary dependencies and imports
- Present steps in a logical order that users can follow end-to-end

## Issue

Fixes https://linear.app/copilotkit/issue/FAC-62/