### PR TITLE
docs(showcase): Fix Python state streaming examples in Deep Agents and LangGraph docs

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx
@@ -120,7 +120,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                             ]
 
                             for step in steps:
-                                self.state["observed_steps"] = self.state.get("observed_steps", []) + [step]
+                                state["observed_steps"] = state.get("observed_steps", []) + [step]
                                 await copilotkit_emit_state(config, state) # [!code highlight]
                                 await asyncio.sleep(1)
 
@@ -171,7 +171,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
 
                         # Define a step progress tool for the llm to report the steps
                         @tool
-                        def step_progress_tool(steps: list[str])
+                        def step_progress_tool(steps: list[str]):
                             """Reads and reports steps"""
 
                         async def frontend_actions_node(state: AgentState, config: RunnableConfig):

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/shared-state/predictive-state-updates.mdx
@@ -117,7 +117,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                             ]
 
                             for step in steps:
-                                self.state["observed_steps"] = self.state.get("observed_steps", []) + [step]
+                                state["observed_steps"] = state.get("observed_steps", []) + [step]
                                 await copilotkit_emit_state(config, state) # [!code highlight]
                                 await asyncio.sleep(1)
 
@@ -171,7 +171,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
 
                         # Define a step progress tool for the llm to report the steps
                         @tool
-                        def step_progress_tool(steps: list[str])
+                        def step_progress_tool(steps: list[str]):
                             """Reads and reports steps"""
 
                         async def frontend_actions_node(state: AgentState, config: RunnableConfig):


### PR DESCRIPTION
## Summary

Fixes incomplete and incorrect Python code examples in the Deep Agents and LangGraph state streaming documentation.

## Changes

### Deep Agents (`/integrations/deepagents/shared-state/predictive-state-updates.mdx`)
- ✅ Fixed Manual Predictive State Updates example: replaced `self.state` with `state` parameter
- ✅ Fixed Tool-Based Predictive State Updates example: added missing colon in `step_progress_tool` function definition

### LangGraph (`/integrations/langgraph/shared-state/predictive-state-updates.mdx`)
- ✅ Fixed Manual Predictive State Updates example: replaced `self.state` with `state` parameter  
- ✅ Fixed Tool-Based Predictive State Updates example: added missing colon in `step_progress_tool` function definition

## Root Cause

The Python examples contained patterns that would cause runtime errors:
1. Using `self.state` in standalone async functions (not class methods) - would throw `NameError: name 'self' is not defined`
2. Missing colon after function parameter list in tool decorator - would cause `SyntaxError`

## Verification

Aligned Python examples with working patterns from `examples/v1/travel/agent/src/search.py`:
- Standalone async node functions use `state` parameter directly
- Proper Python syntax for function definitions

## Related

Closes FAC-53
