### PR TITLE
docs(deep-agents): Add missing zodState wrapper in shared-state TypeScript examples

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/in-app-agent-read.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/in-app-agent-read.mdx
@@ -54,14 +54,14 @@ state updates, you can reflect these updates natively in your application.
       <Tab value="TypeScript">
         ```ts title="agent.ts"
         import { createMiddleware } from "langchain";
-        import { copilotkitMiddleware } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
+        import { copilotkitMiddleware, zodState } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
         import { z } from "zod";
 
         // Define the state as a middleware. The default flows through automatically.
         export const languageStateMiddleware = createMiddleware({
             name: "AgentState",
             stateSchema: z.object({
-                language: z.enum(["english", "spanish"]).default("english"),
+                language: zodState(z.enum(["english", "spanish"]).default("english")),
             }),
         });
 

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/in-app-agent-write.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/in-app-agent-write.mdx
@@ -51,13 +51,13 @@ when your agent is calling tools. CopilotKit allows you to fully customize how t
       <Tab value="TypeScript">
         ```ts title="agent.ts"
         import { createMiddleware } from "langchain";
-        import { copilotkitMiddleware } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
+        import { copilotkitMiddleware, zodState } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
         import { z } from "zod";
 
         export const languageStateMiddleware = createMiddleware({
             name: "AgentState",
             stateSchema: z.object({
-                language: z.enum(["english", "spanish"]).default("english"),
+                language: zodState(z.enum(["english", "spanish"]).default("english")),
             }),
         });
 


### PR DESCRIPTION
## Problem

The TypeScript examples in "Reading agent state" and "Writing agent state" docs were missing the `zodState` wrapper and import, causing custom state fields to be silently dropped from the graph's `output_schema`. This prevented the `language` field from appearing in the AG-UI inspector and in `useAgent().state`.

## Solution

- Added `zodState` to the import statement from `@copilotkit/sdk-js/langgraph`
- Wrapped the `language` field with `zodState()` in both docs
- Pattern now matches the working example in `predictive-state-updates.mdx`

## Files Changed

- `showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/in-app-agent-read.mdx`
- `showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/in-app-agent-write.mdx`

## Testing

- Verified changes match the pattern in `predictive-state-updates.mdx`
- Confirmed Python examples remain unchanged (they use `CopilotKitState` base class)

Fixes https://linear.app/copilotkit/issue/FAC-48