### PR TITLE
docs(deepagents): add agentId param and complete agent setup to interrupt examples

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/your-components/interrupt-based.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/your-components/interrupt-based.mdx
@@ -112,6 +112,21 @@ We're going to have the agent ask us to name it, so we'll need a state property 
                         name = interrupt("Before we start, what would you like to call me?") # [!code highlight]
                         return {"agent_name": name}
                     return None
+
+            # Now create the agent with the middleware
+            from langchain.agents import create_agent # [!code highlight]
+            from langchain_openai import ChatOpenAI # [!code highlight]
+            from copilotkit import CopilotKitMiddleware # [!code highlight]
+
+            model = ChatOpenAI(model="gpt-5.4")
+
+            graph = create_agent( # [!code highlight:6]
+                model=model,
+                tools=[],  # Add your tools here
+                middleware=[AgentNameMiddleware(), CopilotKitMiddleware(expose_state=["agent_name"])],
+                state_schema=AgentState,
+                system_prompt="You are a helpful assistant."
+            )
             ```
         </Tab>
         <Tab value="TypeScript">
@@ -155,6 +170,7 @@ We're going to have the agent ask us to name it, so we'll need a state property 
     // [!code highlight:15]
     // styles omitted for brevity
     useInterrupt({
+        agentId: "sample_agent", // [!code highlight]
         render: ({ event, resolve }) => (
             <div>
                 <p>{event.value}</p>

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/your-components/interrupt-based.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/your-components/interrupt-based.mdx
@@ -114,17 +114,13 @@ We're going to have the agent ask us to name it, so we'll need a state property 
                     return None
 
             # Now create the agent with the middleware
-            from langchain.agents import create_agent # [!code highlight]
-            from langchain_openai import ChatOpenAI # [!code highlight]
+            from deepagents import create_deep_agent # [!code highlight]
             from copilotkit import CopilotKitMiddleware # [!code highlight]
 
-            model = ChatOpenAI(model="gpt-5.4")
-
-            graph = create_agent( # [!code highlight:6]
-                model=model,
+            graph = create_deep_agent( # [!code highlight:5]
+                model="openai:gpt-4o",
                 tools=[],  # Add your tools here
                 middleware=[AgentNameMiddleware(), CopilotKitMiddleware(expose_state=["agent_name"])],
-                state_schema=AgentState,
                 system_prompt="You are a helpful assistant."
             )
             ```

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/human-in-the-loop/interrupt-flow.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/human-in-the-loop/interrupt-flow.mdx
@@ -112,6 +112,21 @@ We're going to have the agent ask us to name it, so we'll need a state property 
                         name = interrupt("Before we start, what would you like to call me?") # [!code highlight]
                         return {"agent_name": name}
                     return None
+
+            # Now create the agent with the middleware
+            from langchain.agents import create_agent # [!code highlight]
+            from langchain_openai import ChatOpenAI # [!code highlight]
+            from copilotkit import CopilotKitMiddleware # [!code highlight]
+
+            model = ChatOpenAI(model="gpt-5.4")
+
+            graph = create_agent( # [!code highlight:6]
+                model=model,
+                tools=[],  # Add your tools here
+                middleware=[AgentNameMiddleware(), CopilotKitMiddleware(expose_state=["agent_name"])],
+                state_schema=AgentState,
+                system_prompt="You are a helpful assistant."
+            )
             ```
         </Tab>
         <Tab value="TypeScript">
@@ -155,6 +170,7 @@ We're going to have the agent ask us to name it, so we'll need a state property 
     // [!code highlight:15]
     // styles omitted for brevity
     useInterrupt({
+        agentId: "sample_agent", // [!code highlight]
         render: ({ event, resolve }) => (
             <div>
                 <p>{event.value}</p>

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/human-in-the-loop/interrupt-flow.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/human-in-the-loop/interrupt-flow.mdx
@@ -114,17 +114,13 @@ We're going to have the agent ask us to name it, so we'll need a state property 
                     return None
 
             # Now create the agent with the middleware
-            from langchain.agents import create_agent # [!code highlight]
-            from langchain_openai import ChatOpenAI # [!code highlight]
+            from deepagents import create_deep_agent # [!code highlight]
             from copilotkit import CopilotKitMiddleware # [!code highlight]
 
-            model = ChatOpenAI(model="gpt-5.4")
-
-            graph = create_agent( # [!code highlight:6]
-                model=model,
+            graph = create_deep_agent( # [!code highlight:5]
+                model="openai:gpt-4o",
                 tools=[],  # Add your tools here
                 middleware=[AgentNameMiddleware(), CopilotKitMiddleware(expose_state=["agent_name"])],
-                state_schema=AgentState,
                 system_prompt="You are a helpful assistant."
             )
             ```


### PR DESCRIPTION
## Summary

Fixes missing `agentId` parameter and incomplete agent setup in Deep Agents Python interrupt-based documentation examples.

## Changes

### Frontend (Step 4)
- Added `agentId: 'sample_agent'` parameter to `useInterrupt()` hook
- This fixes "Agent 'default' not found" errors when the agent name doesn't match

### Backend (Step 3 - Python tab)
- Added complete agent creation example with `create_agent()`
- Showed full middleware list including:
  - `AgentNameMiddleware()` (the custom middleware from the example)
  - `CopilotKitMiddleware(expose_state=['agent_name'])` to expose custom state to frontend
- This ensures the agent name is properly persisted and accessible in AG-UI inspector

## Testing

- MDX syntax validated
- Lint passed (0 errors, 18 pre-existing warnings)
- Formatter passed (no changes needed)

## Files Changed

- `showcase/shell-docs/src/content/docs/integrations/deepagents/human-in-the-loop/interrupt-flow.mdx`
- `showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/your-components/interrupt-based.mdx`

Both files had identical issues in their Step 3 and Step 4 sections, now consistently fixed.

Fixes https://linear.app/copilotkit/issue/FAC-67