### PR TITLE
docs: add zodState and proper node context to Deep Agents state rendering (FAC-63)

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/state-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/state-rendering.mdx
@@ -49,16 +49,16 @@ Use state rendering when you want to:
       <Tab value="TypeScript">
         ```ts title="agent.ts"
         import { createMiddleware } from "langchain";
-        import { copilotkitMiddleware } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
+        import { copilotkitMiddleware, zodState } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
         import { z } from "zod";
 
         export const searchesStateMiddleware = createMiddleware({
             name: "AgentState",
             stateSchema: z.object({
-                searches: z.array(z.object({
+                searches: zodState(z.array(z.object({
                     query: z.string(),
                     done: z.boolean(),
-                })).default([]),
+                })).default([])),
             }),
         });
 
@@ -99,8 +99,8 @@ Use state rendering when you want to:
         ```ts title="agent.ts"
         import { copilotkitEmitState } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
 
-        // Inside a custom tool or middleware hook where you have config/state:
-        async function emitResearchProgress(state: any, config: any) {
+        // Inside a custom graph node function that has access to state and config:
+        async function chatNode(state: any, config: any) {
             state.searches = [
                 { query: "Initial research", done: false },
                 { query: "Retrieving sources", done: false },
@@ -113,6 +113,8 @@ Use state rendering when you want to:
                 search.done = true;
                 await copilotkitEmitState(config, state); // [!code highlight]
             }
+
+            // ... rest of your node logic
         }
         ```
       </Tab>


### PR DESCRIPTION
## Summary

Fixes https://linear.app/copilotkit/issue/FAC-63/deep-agents-ts-state-rendering-docs-need-integrated-example-and

This PR updates the Deep Agents TypeScript State Rendering documentation to include the required `zodState` wrapper and shows state emission within a proper node function context.

## Changes

### Step 2: Define your agent state (TypeScript tab)
- Add `zodState` to the import from `@copilotkit/sdk-js/langgraph`
- Wrap the `searches` array schema with `zodState()` to ensure it appears in STATE_SNAPSHOT events

### Step 3: Emit state updates (TypeScript tab)
- Change example from standalone `emitResearchProgress` function to `chatNode` with proper signature
- Add comment clarifying this is inside a custom graph node function
- Show complete node context with `state` and `config` parameters

## Technical Context

Without `zodState()`, custom state properties are silently dropped from `STATE_SNAPSHOT` events because Zod v4 schemas lack the `~standard.jsonSchema.input` hook required by LangGraph's `getJsonSchemaFromSchema`. The `zodState` wrapper adds this hook, ensuring the field is included in the output schema.

The updated pattern now aligns with:
- The LangGraph State Rendering docs (`showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/state-rendering.mdx`)
- The Deep Agents Predictive State Updates docs (`showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx`)
- Working examples in `examples/integrations/langgraph-js/agent/src/agent.ts`

## Testing

- [x] Verified MDX syntax and structure
- [x] Confirmed alignment with LangGraph docs pattern
- [x] Cross-referenced with working examples using `zodState`
- [x] Validated import paths and function signatures