### PR TITLE
docs(shared-state): add state initialization pattern to rendering-in-app guide

### DIFF
--- a/showcase/shell-docs/src/content/docs/shared-state/rendering-in-app.mdx
+++ b/showcase/shell-docs/src/content/docs/shared-state/rendering-in-app.mdx
@@ -151,12 +151,13 @@ For LangGraph agents, define defaults in your state class:
     ```python title="agent.py"
     from copilotkit import CopilotKitState
     from dataclasses import field
+    from langchain_core.runnables import RunnableConfig
 
     class AgentState(CopilotKitState):
         title: str = "Default Title"
         items: list[dict] = field(default_factory=list)
 
-    def your_node(state: AgentState, config):
+    def your_node(state: AgentState, config: RunnableConfig):
         # Read with fallback: class defaults may not be read at runtime
         title = state.get("title", "Default Title")
         items = state.get("items", [])
@@ -168,6 +169,7 @@ For LangGraph agents, define defaults in your state class:
     ```ts title="agent.ts"
     import { StateSchema } from "@langchain/langgraph";
     import { CopilotKitStateSchema } from "@copilotkit/sdk-js/langgraph";
+    import { RunnableConfig } from "@langchain/core/runnables";
     import { z } from "zod";
 
     export const AgentStateSchema = new StateSchema({
@@ -180,7 +182,7 @@ For LangGraph agents, define defaults in your state class:
       ...CopilotKitStateSchema.fields,
     });
 
-    async function yourNode(state: typeof AgentStateSchema.State, config) {
+    async function yourNode(state: typeof AgentStateSchema.State, config: RunnableConfig) {
       // Read with fallback
       const title = state.title ?? "Default Title";
       const items = state.items ?? [];

--- a/showcase/shell-docs/src/content/docs/shared-state/rendering-in-app.mdx
+++ b/showcase/shell-docs/src/content/docs/shared-state/rendering-in-app.mdx
@@ -29,13 +29,13 @@ export function Canvas() {
   const state = (agent.state ?? {}) as Partial<CanvasState>;
 
   // Seed initial state so the canvas has content before the agent runs.
-  // Check each field independently so we don't overwrite existing values.
+  // Check each field for undefined so we don't overwrite intentional empty values.
   useEffect(() => {
     const updates: Partial<CanvasState> = {};
-    if (!state.title) {
+    if (state.title === undefined) {
       updates.title = "My Canvas";
     }
-    if (!state.items || state.items.length === 0) {
+    if (state.items === undefined) {
       updates.items = [
         { id: "1", label: "First item", done: false },
         { id: "2", label: "Second item", done: true },

--- a/showcase/shell-docs/src/content/docs/shared-state/rendering-in-app.mdx
+++ b/showcase/shell-docs/src/content/docs/shared-state/rendering-in-app.mdx
@@ -29,19 +29,22 @@ export function Canvas() {
   const state = (agent.state ?? {}) as Partial<CanvasState>;
 
   // Seed initial state so the canvas has content before the agent runs.
-  // Skip if state is already populated (e.g., restored from a previous session).
+  // Check each field independently so we don't overwrite existing values.
   useEffect(() => {
+    const updates: Partial<CanvasState> = {};
     if (!state.title) {
-      agent.setState({
-        ...agent.state,
-        title: "My Canvas",
-        items: [
-          { id: "1", label: "First item", done: false },
-          { id: "2", label: "Second item", done: true },
-        ],
-      } satisfies CanvasState);
+      updates.title = "My Canvas";
     }
-  }, [agent, state.title]);
+    if (!state.items || state.items.length === 0) {
+      updates.items = [
+        { id: "1", label: "First item", done: false },
+        { id: "2", label: "Second item", done: true },
+      ];
+    }
+    if (Object.keys(updates).length > 0) {
+      agent.setState({ ...agent.state, ...updates });
+    }
+  }, [agent, state.title, state.items]);
 
   return (
     <main className="canvas">

--- a/showcase/shell-docs/src/content/docs/shared-state/rendering-in-app.mdx
+++ b/showcase/shell-docs/src/content/docs/shared-state/rendering-in-app.mdx
@@ -101,7 +101,6 @@ export default function Page() {
 `<Canvas>` and `<CopilotSidebar>` both call `useAgent()` for the same `agentId`,
 so they share one agent instance and one state object. There's nothing chat-specific
 about reading `agent.state`. The sidebar is not special.
-about reading `agent.state`. The sidebar is not special.
 </Callout>
 
 ## Writing back from the main view

--- a/showcase/shell-docs/src/content/docs/shared-state/rendering-in-app.mdx
+++ b/showcase/shell-docs/src/content/docs/shared-state/rendering-in-app.mdx
@@ -33,6 +33,7 @@ export function Canvas() {
   useEffect(() => {
     if (!state.title) {
       agent.setState({
+        ...agent.state,
         title: "My Canvas",
         items: [
           { id: "1", label: "First item", done: false },
@@ -40,8 +41,7 @@ export function Canvas() {
         ],
       } satisfies CanvasState);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [agent, state.title]);
 
   return (
     <main className="canvas">

--- a/showcase/shell-docs/src/content/docs/shared-state/rendering-in-app.mdx
+++ b/showcase/shell-docs/src/content/docs/shared-state/rendering-in-app.mdx
@@ -15,6 +15,7 @@ your tree and render it however you like.
 near the chat. Call it in your main-view component, read `agent.state`, and render:
 
 ```tsx title="components/Canvas.tsx"
+import { useEffect } from "react";
 import { useAgent } from "@copilotkit/react-core/v2";
 
 type CanvasState = {
@@ -26,6 +27,21 @@ export function Canvas() {
   // No agentId means the "default" agent. Pass { agentId } to target another.
   const { agent } = useAgent();
   const state = (agent.state ?? {}) as Partial<CanvasState>;
+
+  // Seed initial state so the canvas has content before the agent runs.
+  // Skip if state is already populated (e.g., restored from a previous session).
+  useEffect(() => {
+    if (!state.title) {
+      agent.setState({
+        title: "My Canvas",
+        items: [
+          { id: "1", label: "First item", done: false },
+          { id: "2", label: "Second item", done: true },
+        ],
+      } satisfies CanvasState);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <main className="canvas">
@@ -41,6 +57,13 @@ export function Canvas() {
   );
 }
 ```
+
+<Callout type="info">
+The `useEffect` hook seeds initial state on mount so the canvas displays content
+immediately, before any agent interaction. The defensive fallbacks (`?? "Untitled"`,
+`?? []`) remain as a safety net for mid-stream renders, but users see actual content,
+not just fallback values.
+</Callout>
 
 Every time the agent mutates its state, whether from a tool call, node
 transition, or [streamed update](/shared-state/streaming), `useAgent` re-renders this component
@@ -98,6 +121,84 @@ function toggleItem(id: string) {
 This is the same two-way channel described in [Shared State](/shared-state). The
 only difference here is that the reads and writes happen in your application's main
 surface rather than in the chat.
+
+## State initialization patterns
+
+Agent state can be initialized in two ways, depending on your needs:
+
+### Frontend seeding (recommended for UI-driven defaults)
+
+Seed initial state from the frontend using `useEffect` and `agent.setState`, as shown
+in the Canvas example above. This approach is ideal when:
+
+- The initial state represents UI defaults or placeholder content
+- The state depends on frontend-only context (route params, localStorage, etc.)
+- You want the UI to show content immediately, before the agent runs
+
+### Backend defaults (for agent-owned state)
+
+Alternatively, define default values in your backend agent state schema. This approach
+is better when:
+
+- The agent should own the initial state values
+- Backend logic determines the starting state
+- The state has server-side dependencies (database lookups, etc.)
+
+For LangGraph agents, define defaults in your state class:
+
+<Tabs groupId="language_langgraph" items={["Python", "TypeScript"]} persist>
+  <Tab value="Python">
+    ```python title="agent.py"
+    from copilotkit import CopilotKitState
+    from dataclasses import field
+
+    class AgentState(CopilotKitState):
+        title: str = "Default Title"
+        items: list[dict] = field(default_factory=list)
+
+    def your_node(state: AgentState, config):
+        # Read with fallback: class defaults may not be read at runtime
+        title = state.get("title", "Default Title")
+        items = state.get("items", [])
+        # ... your node logic
+        return {"title": title, "items": items}
+    ```
+  </Tab>
+  <Tab value="TypeScript">
+    ```ts title="agent.ts"
+    import { StateSchema } from "@langchain/langgraph";
+    import { CopilotKitStateSchema } from "@copilotkit/sdk-js/langgraph";
+    import { z } from "zod";
+
+    export const AgentStateSchema = new StateSchema({
+      title: z.string().default("Default Title"),
+      items: z.array(z.object({
+        id: z.string(),
+        label: z.string(),
+        done: z.boolean(),
+      })).default([]),
+      ...CopilotKitStateSchema.fields,
+    });
+
+    async function yourNode(state: typeof AgentStateSchema.State, config) {
+      // Read with fallback
+      const title = state.title ?? "Default Title";
+      const items = state.items ?? [];
+      // ... your node logic
+      return { title, items };
+    }
+    ```
+  </Tab>
+</Tabs>
+
+<Callout type="warning">
+**Important**: Backend class defaults may not be read at runtime in some frameworks.
+Always check for undefined and provide fallback values when reading state in your
+agent nodes, as shown above.
+</Callout>
+
+In practice, many applications use **both** patterns: frontend seeding for immediate
+UI feedback, and backend defaults as the agent's internal fallbacks.
 
 ## Tips
 


### PR DESCRIPTION
## Summary

This PR fixes the LangGraph shared-state documentation issue where the rendering-in-app example showed only fallback values because it was missing the state initialization pattern.

## Changes

- Added backend AgentState schema examples for both LangGraph Python and TypeScript
- Added frontend `useEffect` initialization pattern with `agent.setState`
- Added guidance section explaining when to use frontend vs backend initialization
- Included callout explaining that backend state schema defaults may not auto-initialize at runtime
- Fixed duplicate line in existing Callout about sidebar

## Issue

Fixes: FAC-105

## Testing

- Verified the documentation renders correctly
- The complete example now shows:
  1. Backend state schema definition
  2. Frontend initialization with useEffect
  3. Defensive rendering with ?? fallbacks
  4. Clear guidance on initialization options

Users following this updated example will see actual content (title and items) instead of just fallback values.