### PR TITLE
feat(core): subagent registry + useSubagent hook

### DIFF
--- a/examples/showcases/generative-ui-playground/package.json
+++ b/examples/showcases/generative-ui-playground/package.json
@@ -13,6 +13,7 @@
     "@ag-ui/a2a": "^0.0.6",
     "@ag-ui/a2a-middleware": "^0.0.2",
     "@ag-ui/client": "^0.0.42",
+    "@ag-ui/core": "https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350",
     "@ag-ui/mcp-apps-middleware": "^0.0.1",
     "@copilotkit/a2ui-renderer": "workspace:*",
     "@copilotkit/core": "workspace:*",

--- a/examples/v2/angular/demo-server/package.json
+++ b/examples/v2/angular/demo-server/package.json
@@ -9,6 +9,8 @@
     "start": "tsx --env-file-if-exists ../demo/.env --env-file-if-exists .env src/index.ts"
   },
   "dependencies": {
+    "@ag-ui/client": "https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350",
+    "@ag-ui/core": "https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350",
     "@ag-ui/langgraph": "^0.0.11",
     "@ai-sdk/openai": "3.0.36",
     "@copilotkit/demo-agents": "workspace:^",

--- a/examples/v2/vue/demo/package.json
+++ b/examples/v2/vue/demo/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint \"**/*.{js,mjs,cjs,ts,vue}\""
   },
   "dependencies": {
+    "@ag-ui/client": "https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350",
     "@ag-ui/core": "0.0.52",
     "@ag-ui/mcp-apps-middleware": "0.0.2",
     "@copilotkit/core": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,11 @@
       }
     },
     "overrides": {
+      "@ag-ui/core": "0.0.59-canary.1784325892.0",
+      "@ag-ui/client": "0.0.59-canary.1784325892.0",
+      "@ag-ui/encoder": "0.0.59-canary.1784325892.0",
+      "@ag-ui/proto": "0.0.59-canary.1784325892.0",
+      "@ag-ui/langgraph": "0.0.43-canary.1784331649.0",
       "@ag-ui/mcp-middleware>@ag-ui/client": "0.0.53",
       "streamdown>react": "^19.0.0",
       "@types/react": "19.1.8",

--- a/package.json
+++ b/package.json
@@ -90,11 +90,11 @@
       }
     },
     "overrides": {
-      "@ag-ui/core": "0.0.59-canary.1784325892.0",
-      "@ag-ui/client": "0.0.59-canary.1784325892.0",
-      "@ag-ui/encoder": "0.0.59-canary.1784325892.0",
-      "@ag-ui/proto": "0.0.59-canary.1784325892.0",
-      "@ag-ui/langgraph": "0.0.43-canary.1784331649.0",
+      "@ag-ui/core": "0.0.59-canary.1785518626.0",
+      "@ag-ui/client": "0.0.59-canary.1785518626.0",
+      "@ag-ui/encoder": "0.0.59-canary.1785518626.0",
+      "@ag-ui/proto": "0.0.59-canary.1785518626.0",
+      "@ag-ui/langgraph": "0.0.43-canary.1785518626.0",
       "@ag-ui/mcp-middleware>@ag-ui/client": "0.0.53",
       "streamdown>react": "^19.0.0",
       "@types/react": "19.1.8",

--- a/package.json
+++ b/package.json
@@ -90,11 +90,11 @@
       }
     },
     "overrides": {
-      "@ag-ui/core": "0.0.59-canary.1785518626.0",
-      "@ag-ui/client": "0.0.59-canary.1785518626.0",
-      "@ag-ui/encoder": "0.0.59-canary.1785518626.0",
-      "@ag-ui/proto": "0.0.59-canary.1785518626.0",
-      "@ag-ui/langgraph": "0.0.43-canary.1785518626.0",
+      "@ag-ui/core": "https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350",
+      "@ag-ui/client": "https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350",
+      "@ag-ui/encoder": "https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/encoder@2350",
+      "@ag-ui/proto": "https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/proto@2350",
+      "@ag-ui/langgraph": "https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350",
       "@ag-ui/mcp-middleware>@ag-ui/client": "0.0.53",
       "streamdown>react": "^19.0.0",
       "@types/react": "19.1.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
+    "@ag-ui/client": "0.0.58",
     "@copilotkit/shared": "workspace:*",
     "@tanstack/pacer": "^0.20.1",
     "phoenix": "^1.8.4",

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -30,6 +30,8 @@ import type {
 import { RunHandler } from "./run-handler";
 import type { DebugConfig } from "@copilotkit/shared";
 import { StateManager } from "./state-manager";
+import { SubagentRegistry } from "./subagent-registry";
+import type { SubagentState } from "./subagent-registry";
 import { ThreadStoreRegistry } from "./thread-store-registry";
 import type { ɵThreadStore } from "../threads";
 import { ɵcreateMemoryStore } from "../memory";
@@ -173,6 +175,11 @@ export interface CopilotKitCoreSubscriber {
   onSuggestionsFinishedLoading?: (event: {
     copilotkit: CopilotKitCore;
     agentId: string;
+  }) => void | Promise<void>;
+  onSubagentsChanged?: (event: {
+    copilotkit: CopilotKitCore;
+    agentId: string;
+    subagents: Readonly<Record<string, SubagentState>>;
   }) => void | Promise<void>;
   onPropertiesChanged?: (event: {
     copilotkit: CopilotKitCore;
@@ -378,6 +385,7 @@ export class CopilotKitCore {
   private suggestionEngine: SuggestionEngine;
   private runHandler: RunHandler;
   private stateManager: StateManager;
+  private subagentRegistry: SubagentRegistry;
   private threadStoreRegistry: ThreadStoreRegistry;
   /**
    * The single core-owned memory store, created lazily on first
@@ -416,6 +424,7 @@ export class CopilotKitCore {
     this.suggestionEngine = new SuggestionEngine(this);
     this.runHandler = new RunHandler(this);
     this.stateManager = new StateManager(this);
+    this.subagentRegistry = new SubagentRegistry(this);
     this.threadStoreRegistry = new ThreadStoreRegistry(this);
 
     // Initialize each subsystem
@@ -450,6 +459,7 @@ export class CopilotKitCore {
         Object.values(agents).forEach((agent) => {
           if (agent.agentId) {
             this.stateManager.subscribeToAgent(agent);
+            this.subagentRegistry.subscribeToAgent(agent);
           }
         });
 
@@ -496,6 +506,14 @@ export class CopilotKitCore {
             } catch (err) {
               console.error(
                 `CopilotKitCore.onAgentsChanged: stateManager.unsubscribeFromAgent failed for "${agentId}":`,
+                err,
+              );
+            }
+            try {
+              this.subagentRegistry.unsubscribeFromAgent(agentId);
+            } catch (err) {
+              console.error(
+                `CopilotKitCore.onAgentsChanged: subagentRegistry.unsubscribeFromAgent failed for "${agentId}":`,
                 err,
               );
             }
@@ -944,6 +962,17 @@ export class CopilotKitCore {
 
   getSuggestions(agentId: string): CopilotKitCoreGetSuggestionsResult {
     return this.suggestionEngine.getSuggestions(agentId);
+  }
+
+  /**
+   * Subagent registry (delegated to SubagentRegistry).
+   *
+   * Returns the subagents observed for an owning agent during its run(s),
+   * keyed by `subagentId`, each carrying `name` / `description` / `status`.
+   * Empty for runs that never emit SUBAGENT_* events.
+   */
+  getSubagents(agentId: string): Readonly<Record<string, SubagentState>> {
+    return this.subagentRegistry.getSubagents(agentId);
   }
 
   /**

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -968,7 +968,7 @@ export class CopilotKitCore {
    * Subagent registry (delegated to SubagentRegistry).
    *
    * Returns the subagents observed for an owning agent during its run(s),
-   * keyed by `subagentId`, each carrying `name` / `description` / `status`.
+   * keyed by `subagentRunId`, each carrying `name` / `description` / `status`.
    * Empty for runs that never emit SUBAGENT_* events.
    */
   getSubagents(agentId: string): Readonly<Record<string, SubagentState>> {

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -4,3 +4,4 @@ export * from "./context-store";
 export * from "./suggestion-engine";
 export * from "./run-handler";
 export * from "./state-manager";
+export * from "./subagent-registry";

--- a/packages/core/src/core/subagent-registry.ts
+++ b/packages/core/src/core/subagent-registry.ts
@@ -121,12 +121,13 @@ export class SubagentRegistry {
   }
 
   private handleFinished(agentId: string, event: SubagentFinishedEvent): void {
-    const existing = this._subagents[agentId]?.[event.subagentId];
-    if (!existing) {
+    const bucket = this._subagents[agentId];
+    const existing = bucket?.[event.subagentId];
+    if (!bucket || !existing) {
       return; // FINISHED without a prior STARTED — nothing to update
     }
     // Replace (not mutate) so the object identity changes for React consumers.
-    this._subagents[agentId][event.subagentId] = {
+    bucket[event.subagentId] = {
       ...existing,
       status: "finished",
     };

--- a/packages/core/src/core/subagent-registry.ts
+++ b/packages/core/src/core/subagent-registry.ts
@@ -1,0 +1,165 @@
+import type {
+  AbstractAgent,
+  SubagentStartedEvent,
+  SubagentFinishedEvent,
+  SubagentErrorEvent,
+} from "@ag-ui/client";
+import type { CopilotKitCore } from "./core";
+import type { CopilotKitCoreFriendsAccess } from "./core";
+
+export type SubagentStatus = "running" | "finished" | "error";
+
+/**
+ * The observed lifecycle state of a single subagent invocation, keyed in the
+ * registry by its `subagentId`. `name`/`description` come from SUBAGENT_STARTED
+ * so the UI can show a friendly label instead of the opaque id.
+ */
+export interface SubagentState {
+  subagentId: string;
+  name: string;
+  description?: string;
+  parentSubagentId?: string;
+  status: SubagentStatus;
+  /** Set only when `status === "error"` (from SUBAGENT_ERROR.message). */
+  error?: string;
+}
+
+/**
+ * Tracks subagent lifecycle events (SUBAGENT_STARTED / FINISHED / ERROR) per
+ * owning agent so consumers can resolve a message's `subagentId` to a name,
+ * description, and running status.
+ *
+ * Modeled on {@link SuggestionEngine}: an in-memory `Record` keyed by (owning)
+ * agentId, mutated from streamed AG-UI events, made reactive by calling
+ * `notifySubscribers(onSubagentsChanged)` after every change. It owns its own
+ * per-agent `agent.subscribe` (like {@link StateManager}) so it is fully
+ * self-contained and adds no coupling to the state/message tracking path.
+ *
+ * No-op for runs without subagents (a normal LangGraph run never emits
+ * SUBAGENT_* events), so the registry simply stays empty.
+ */
+export class SubagentRegistry {
+  // agentId -> subagentId -> state
+  private _subagents: Record<string, Record<string, SubagentState>> = {};
+
+  // agentId -> unsubscribe fn (for cleanup + idempotent re-subscription)
+  private agentSubscriptions: Map<string, () => void> = new Map();
+
+  constructor(private core: CopilotKitCore) {}
+
+  /**
+   * Subscribe to an agent's subagent lifecycle events. Idempotent per agentId:
+   * an existing subscription for the same agent is revoked and replaced.
+   */
+  subscribeToAgent(agent: AbstractAgent): void {
+    if (!agent.agentId) {
+      return; // Skip agents without IDs
+    }
+    const agentId = agent.agentId;
+
+    const existingUnsubscribe = this.agentSubscriptions.get(agentId);
+    if (existingUnsubscribe) {
+      existingUnsubscribe();
+      this.agentSubscriptions.delete(agentId);
+    }
+
+    // `revoked` turns the callbacks into no-ops once this subscription is
+    // replaced, mirroring StateManager's revocation guard: a still-running
+    // ag-ui pipeline captured at runAgent() start may keep calling these.
+    let revoked = false;
+    const { unsubscribe } = agent.subscribe({
+      onSubagentStartedEvent: ({ event }) => {
+        if (revoked) return;
+        this.handleStarted(agentId, event);
+      },
+      onSubagentFinishedEvent: ({ event }) => {
+        if (revoked) return;
+        this.handleFinished(agentId, event);
+      },
+      onSubagentErrorEvent: ({ event }) => {
+        if (revoked) return;
+        this.handleError(agentId, event);
+      },
+    });
+
+    this.agentSubscriptions.set(agentId, () => {
+      revoked = true;
+      unsubscribe();
+    });
+  }
+
+  /**
+   * Unsubscribe an agent's subscription (symmetric with StateManager cleanup).
+   */
+  unsubscribeFromAgent(agentId: string): void {
+    const unsubscribe = this.agentSubscriptions.get(agentId);
+    if (unsubscribe) {
+      unsubscribe();
+      this.agentSubscriptions.delete(agentId);
+    }
+  }
+
+  /**
+   * Get the subagents observed for an owning agent, keyed by subagentId.
+   * Returns a fresh shallow copy each call so consumers (and React state) see
+   * a new reference when anything changed.
+   */
+  getSubagents(agentId: string): Record<string, SubagentState> {
+    return { ...this._subagents[agentId] };
+  }
+
+  private handleStarted(agentId: string, event: SubagentStartedEvent): void {
+    const bucket = (this._subagents[agentId] ??= {});
+    bucket[event.subagentId] = {
+      subagentId: event.subagentId,
+      name: event.name,
+      description: event.description,
+      parentSubagentId: event.parentSubagentId,
+      status: "running",
+    };
+    void this.notifySubagentsChanged(agentId);
+  }
+
+  private handleFinished(agentId: string, event: SubagentFinishedEvent): void {
+    const existing = this._subagents[agentId]?.[event.subagentId];
+    if (!existing) {
+      return; // FINISHED without a prior STARTED — nothing to update
+    }
+    // Replace (not mutate) so the object identity changes for React consumers.
+    this._subagents[agentId][event.subagentId] = {
+      ...existing,
+      status: "finished",
+    };
+    void this.notifySubagentsChanged(agentId);
+  }
+
+  private handleError(agentId: string, event: SubagentErrorEvent): void {
+    const bucket = (this._subagents[agentId] ??= {});
+    const existing = bucket[event.subagentId];
+    bucket[event.subagentId] = existing
+      ? { ...existing, status: "error", error: event.message }
+      : {
+          subagentId: event.subagentId,
+          // No prior STARTED seen — fall back to the id as the display name.
+          name: event.subagentId,
+          status: "error",
+          error: event.message,
+        };
+    void this.notifySubagentsChanged(agentId);
+  }
+
+  private async notifySubagentsChanged(agentId: string): Promise<void> {
+    const subagents = this.getSubagents(agentId);
+    await (
+      this.core as unknown as CopilotKitCoreFriendsAccess
+    ).notifySubscribers(
+      (subscriber) =>
+        subscriber.onSubagentsChanged?.({
+          copilotkit: this.core,
+          agentId,
+          subagents,
+        }),
+      "Subscriber onSubagentsChanged error:",
+    );
+  }
+}

--- a/packages/core/src/core/subagent-registry.ts
+++ b/packages/core/src/core/subagent-registry.ts
@@ -11,14 +11,14 @@ export type SubagentStatus = "running" | "finished" | "error";
 
 /**
  * The observed lifecycle state of a single subagent invocation, keyed in the
- * registry by its `subagentId`. `name`/`description` come from SUBAGENT_STARTED
+ * registry by its `subagentRunId`. `name`/`description` come from SUBAGENT_STARTED
  * so the UI can show a friendly label instead of the opaque id.
  */
 export interface SubagentState {
-  subagentId: string;
+  subagentRunId: string;
   name: string;
   description?: string;
-  parentSubagentId?: string;
+  parentSubagentRunId?: string;
   status: SubagentStatus;
   /** Set only when `status === "error"` (from SUBAGENT_ERROR.message). */
   error?: string;
@@ -26,7 +26,7 @@ export interface SubagentState {
 
 /**
  * Tracks subagent lifecycle events (SUBAGENT_STARTED / FINISHED / ERROR) per
- * owning agent so consumers can resolve a message's `subagentId` to a name,
+ * owning agent so consumers can resolve a message's `subagentRunId` to a name,
  * description, and running status.
  *
  * Modeled on {@link SuggestionEngine}: an in-memory `Record` keyed by (owning)
@@ -39,7 +39,7 @@ export interface SubagentState {
  * SUBAGENT_* events), so the registry simply stays empty.
  */
 export class SubagentRegistry {
-  // agentId -> subagentId -> state
+  // agentId -> subagentRunId -> state
   private _subagents: Record<string, Record<string, SubagentState>> = {};
 
   // agentId -> unsubscribe fn (for cleanup + idempotent re-subscription)
@@ -100,7 +100,7 @@ export class SubagentRegistry {
   }
 
   /**
-   * Get the subagents observed for an owning agent, keyed by subagentId.
+   * Get the subagents observed for an owning agent, keyed by subagentRunId.
    * Returns a fresh shallow copy each call so consumers (and React state) see
    * a new reference when anything changed.
    */
@@ -110,11 +110,11 @@ export class SubagentRegistry {
 
   private handleStarted(agentId: string, event: SubagentStartedEvent): void {
     const bucket = (this._subagents[agentId] ??= {});
-    bucket[event.subagentId] = {
-      subagentId: event.subagentId,
+    bucket[event.subagentRunId] = {
+      subagentRunId: event.subagentRunId,
       name: event.name,
       description: event.description,
-      parentSubagentId: event.parentSubagentId,
+      parentSubagentRunId: event.parentSubagentRunId,
       status: "running",
     };
     void this.notifySubagentsChanged(agentId);
@@ -122,12 +122,12 @@ export class SubagentRegistry {
 
   private handleFinished(agentId: string, event: SubagentFinishedEvent): void {
     const bucket = this._subagents[agentId];
-    const existing = bucket?.[event.subagentId];
+    const existing = bucket?.[event.subagentRunId];
     if (!bucket || !existing) {
       return; // FINISHED without a prior STARTED — nothing to update
     }
     // Replace (not mutate) so the object identity changes for React consumers.
-    bucket[event.subagentId] = {
+    bucket[event.subagentRunId] = {
       ...existing,
       status: "finished",
     };
@@ -136,13 +136,13 @@ export class SubagentRegistry {
 
   private handleError(agentId: string, event: SubagentErrorEvent): void {
     const bucket = (this._subagents[agentId] ??= {});
-    const existing = bucket[event.subagentId];
-    bucket[event.subagentId] = existing
+    const existing = bucket[event.subagentRunId];
+    bucket[event.subagentRunId] = existing
       ? { ...existing, status: "error", error: event.message }
       : {
-          subagentId: event.subagentId,
+          subagentRunId: event.subagentRunId,
           // No prior STARTED seen — fall back to the id as the display name.
-          name: event.subagentId,
+          name: event.subagentRunId,
           status: "error",
           error: event.message,
         };

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -74,8 +74,8 @@
     "attw": "attw --pack . --profile node16 --ignore-rules internal-resolution-error"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
-    "@ag-ui/core": "0.0.57",
+    "@ag-ui/client": "0.0.58",
+    "@ag-ui/core": "0.0.58",
     "@copilotkit/a2ui-renderer": "workspace:*",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/runtime-client-gql": "workspace:*",

--- a/packages/react-core/src/v2/hooks/index.ts
+++ b/packages/react-core/src/v2/hooks/index.ts
@@ -8,6 +8,8 @@ export { useRenderTool } from "./use-render-tool";
 export { useDefaultRenderTool } from "./use-default-render-tool";
 export { useHumanInTheLoop } from "./use-human-in-the-loop";
 export { useAgent, UseAgentUpdate } from "./use-agent";
+export { useSubagent } from "./use-subagent";
+export type { UseSubagentParams, SubagentView } from "./use-subagent";
 export { useCapabilities } from "./use-capabilities";
 export { useAgentContext } from "./use-agent-context";
 export type { AgentContextInput, JsonSerializable } from "./use-agent-context";

--- a/packages/react-core/src/v2/hooks/use-subagent.tsx
+++ b/packages/react-core/src/v2/hooks/use-subagent.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useMemo, useState } from "react";
+import type { SubagentState } from "@copilotkit/core";
+import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
+import { useCopilotKit } from "../context";
+import { useCopilotChatConfiguration } from "../providers/CopilotChatConfigurationProvider";
+
+export interface UseSubagentParams {
+  /** The subagent's opaque id (exact, always unambiguous). */
+  subagentId?: string;
+  /**
+   * The declared subagent name (`subagent_type`). Not guaranteed unique — if
+   * more than one subagent currently carries this name, the most recently
+   * started match is returned, `isAmbiguous`/`matchCount` are set, and a
+   * dev-only warning is logged once. Pass `subagentId` for a stable reference.
+   */
+  subagentName?: string;
+  /** Owning agent id. Defaults to the chat's configured agent (like useAgent). */
+  agentId?: string;
+}
+
+export interface SubagentView extends SubagentState {
+  /** True when a `subagentName` lookup matched more than one subagent. */
+  isAmbiguous?: boolean;
+  /** Number of subagents that matched a `subagentName` lookup (when >1). */
+  matchCount?: number;
+}
+
+// Dev-only, warn-once dedup across the whole app so an ambiguous name lookup
+// doesn't spam the console on every render.
+const warnedAmbiguousNames = new Set<string>();
+
+function resolveSubagent(
+  subagents: Record<string, SubagentState>,
+  subagentId: string | undefined,
+  subagentName: string | undefined,
+): SubagentView | undefined {
+  if (subagentId) {
+    const match = subagents[subagentId];
+    return match ? { ...match } : undefined;
+  }
+  if (subagentName) {
+    // Insertion order = started order, so the last match is the most recent.
+    const matches = Object.values(subagents).filter(
+      (s) => s.name === subagentName,
+    );
+    if (matches.length === 0) {
+      return undefined;
+    }
+    const chosen = matches[matches.length - 1];
+    return matches.length > 1
+      ? { ...chosen, isAmbiguous: true, matchCount: matches.length }
+      : { ...chosen };
+  }
+  return undefined;
+}
+
+/**
+ * Read a subagent's live lifecycle state (name, description, running status)
+ * from the CopilotKit core subagent registry, by id or by declared name.
+ *
+ * @example
+ * const sub = useSubagent({ subagentId: message.subagentId });
+ * // sub?.name, sub?.description, sub?.status
+ */
+export function useSubagent(
+  params: UseSubagentParams,
+): SubagentView | undefined {
+  const { subagentId, subagentName, agentId } = params;
+  const { copilotkit } = useCopilotKit();
+  const config = useCopilotChatConfiguration();
+  const resolvedAgentId = useMemo(
+    () => agentId ?? config?.agentId ?? DEFAULT_AGENT_ID,
+    [agentId, config?.agentId],
+  );
+
+  const [subagent, setSubagent] = useState<SubagentView | undefined>(() =>
+    resolveSubagent(
+      copilotkit.getSubagents(resolvedAgentId),
+      subagentId,
+      subagentName,
+    ),
+  );
+
+  // Resync when the target (agent/id/name) changes.
+  useEffect(() => {
+    setSubagent(
+      resolveSubagent(
+        copilotkit.getSubagents(resolvedAgentId),
+        subagentId,
+        subagentName,
+      ),
+    );
+  }, [copilotkit, resolvedAgentId, subagentId, subagentName]);
+
+  // Subscribe to registry changes for the owning agent.
+  useEffect(() => {
+    const subscription = copilotkit.subscribe({
+      onSubagentsChanged: ({ agentId: changedAgentId, subagents }) => {
+        if (changedAgentId !== resolvedAgentId) {
+          return;
+        }
+        setSubagent(resolveSubagent(subagents, subagentId, subagentName));
+      },
+    });
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [copilotkit, resolvedAgentId, subagentId, subagentName]);
+
+  // Warn once (dev only) when a name lookup is ambiguous.
+  useEffect(() => {
+    if (
+      process.env.NODE_ENV === "production" ||
+      !subagentName ||
+      !subagent?.isAmbiguous
+    ) {
+      return;
+    }
+    const key = `${subagentName}:${subagent.matchCount}`;
+    if (warnedAmbiguousNames.has(key)) {
+      return;
+    }
+    warnedAmbiguousNames.add(key);
+    console.warn(
+      `[CopilotKit] useSubagent({ subagentName: ${JSON.stringify(subagentName)} }) ` +
+        `matched ${subagent.matchCount} subagents. Returning the most recently ` +
+        `started one; pass a subagentId for a stable reference.`,
+    );
+  }, [subagentName, subagent?.isAmbiguous, subagent?.matchCount]);
+
+  return subagent;
+}

--- a/packages/react-core/src/v2/hooks/use-subagent.tsx
+++ b/packages/react-core/src/v2/hooks/use-subagent.tsx
@@ -6,12 +6,12 @@ import { useCopilotChatConfiguration } from "../providers/CopilotChatConfigurati
 
 export interface UseSubagentParams {
   /** The subagent's opaque id (exact, always unambiguous). */
-  subagentId?: string;
+  subagentRunId?: string;
   /**
    * The declared subagent name (`subagent_type`). Not guaranteed unique — if
    * more than one subagent currently carries this name, the most recently
    * started match is returned, `isAmbiguous`/`matchCount` are set, and a
-   * dev-only warning is logged once. Pass `subagentId` for a stable reference.
+   * dev-only warning is logged once. Pass `subagentRunId` for a stable reference.
    */
   subagentName?: string;
   /** Owning agent id. Defaults to the chat's configured agent (like useAgent). */
@@ -31,11 +31,11 @@ const warnedAmbiguousNames = new Set<string>();
 
 function resolveSubagent(
   subagents: Record<string, SubagentState>,
-  subagentId: string | undefined,
+  subagentRunId: string | undefined,
   subagentName: string | undefined,
 ): SubagentView | undefined {
-  if (subagentId) {
-    const match = subagents[subagentId];
+  if (subagentRunId) {
+    const match = subagents[subagentRunId];
     return match ? { ...match } : undefined;
   }
   if (subagentName) {
@@ -59,13 +59,13 @@ function resolveSubagent(
  * from the CopilotKit core subagent registry, by id or by declared name.
  *
  * @example
- * const sub = useSubagent({ subagentId: message.subagentId });
+ * const sub = useSubagent({ subagentRunId: message.subagentRunId });
  * // sub?.name, sub?.description, sub?.status
  */
 export function useSubagent(
   params: UseSubagentParams,
 ): SubagentView | undefined {
-  const { subagentId, subagentName, agentId } = params;
+  const { subagentRunId, subagentName, agentId } = params;
   const { copilotkit } = useCopilotKit();
   const config = useCopilotChatConfiguration();
   const resolvedAgentId = useMemo(
@@ -76,7 +76,7 @@ export function useSubagent(
   const [subagent, setSubagent] = useState<SubagentView | undefined>(() =>
     resolveSubagent(
       copilotkit.getSubagents(resolvedAgentId),
-      subagentId,
+      subagentRunId,
       subagentName,
     ),
   );
@@ -86,11 +86,11 @@ export function useSubagent(
     setSubagent(
       resolveSubagent(
         copilotkit.getSubagents(resolvedAgentId),
-        subagentId,
+        subagentRunId,
         subagentName,
       ),
     );
-  }, [copilotkit, resolvedAgentId, subagentId, subagentName]);
+  }, [copilotkit, resolvedAgentId, subagentRunId, subagentName]);
 
   // Subscribe to registry changes for the owning agent.
   useEffect(() => {
@@ -99,13 +99,13 @@ export function useSubagent(
         if (changedAgentId !== resolvedAgentId) {
           return;
         }
-        setSubagent(resolveSubagent(subagents, subagentId, subagentName));
+        setSubagent(resolveSubagent(subagents, subagentRunId, subagentName));
       },
     });
     return () => {
       subscription.unsubscribe();
     };
-  }, [copilotkit, resolvedAgentId, subagentId, subagentName]);
+  }, [copilotkit, resolvedAgentId, subagentRunId, subagentName]);
 
   // Warn once (dev only) when a name lookup is ambiguous.
   useEffect(() => {
@@ -124,7 +124,7 @@ export function useSubagent(
     console.warn(
       `[CopilotKit] useSubagent({ subagentName: ${JSON.stringify(subagentName)} }) ` +
         `matched ${subagent.matchCount} subagents. Returning the most recently ` +
-        `started one; pass a subagentId for a stable reference.`,
+        `started one; pass a subagentRunId for a stable reference.`,
     );
   }, [subagentName, subagent?.isAmbiguous, subagent?.matchCount]);
 

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -59,6 +59,8 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
+    "@ag-ui/client": "https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350",
+    "@ag-ui/core": "https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350",
     "@ag-ui/langgraph": "0.0.42",
     "@copilotkit/shared": "workspace:*",
     "@standard-schema/spec": "^1.0.0"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -50,7 +50,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
+    "@ag-ui/client": "0.0.58",
     "@copilotkit/license-verifier": "~0.5.0",
     "@segment/analytics-node": "^2.1.2",
     "@standard-schema/spec": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,11 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@ag-ui/core': 0.0.59-canary.1784325892.0
+  '@ag-ui/client': 0.0.59-canary.1784325892.0
+  '@ag-ui/encoder': 0.0.59-canary.1784325892.0
+  '@ag-ui/proto': 0.0.59-canary.1784325892.0
+  '@ag-ui/langgraph': 0.0.43-canary.1784331649.0
   '@ag-ui/mcp-middleware>@ag-ui/client': 0.0.53
   streamdown>react: ^19.0.0
   '@types/react': 19.1.8
@@ -132,7 +137,7 @@ importers:
         version: 0.13.0
       jscodeshift:
         specifier: ^17.3.0
-        version: 17.3.0(@babel/preset-env@7.29.2(@babel/core@7.28.5))
+        version: 17.3.0(@babel/preset-env@7.29.2(@babel/core@7.29.0))
       lefthook:
         specifier: ^2.1.1
         version: 2.1.1
@@ -337,16 +342,16 @@ importers:
         version: 0.8.3(signal-polyfill@0.2.2)
       '@ag-ui/a2a':
         specifier: ^0.0.6
-        version: 0.0.6(@ag-ui/client@0.0.42)(@ag-ui/core@0.0.57)
+        version: 0.0.6(@ag-ui/client@0.0.59-canary.1784325892.0)(@ag-ui/core@0.0.59-canary.1784325892.0)
       '@ag-ui/a2a-middleware':
         specifier: ^0.0.2
         version: 0.0.2(rxjs@7.8.1)
       '@ag-ui/client':
-        specifier: ^0.0.42
-        version: 0.0.42
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@ag-ui/mcp-apps-middleware':
         specifier: ^0.0.1
-        version: 0.0.1(@ag-ui/client@0.0.42)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
+        version: 0.0.1(@ag-ui/client@0.0.59-canary.1784325892.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
       '@copilotkit/a2ui-renderer':
         specifier: workspace:*
         version: link:../../../packages/a2ui-renderer
@@ -373,7 +378,7 @@ importers:
         version: 4.12.15
       next:
         specifier: 16.2.3
-        version: 16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
+        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
       openai:
         specifier: ^6.16.0
         version: 6.24.0(ws@8.19.0)(zod@3.25.76)
@@ -553,7 +558,7 @@ importers:
         version: 0.476.0(react@19.2.3)
       next:
         specifier: 16.2.3
-        version: 16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
+        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -638,7 +643,7 @@ importers:
         version: 0.476.0(react@19.2.3)
       next:
         specifier: ^16.0.10
-        version: 16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
+        version: 16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -717,7 +722,7 @@ importers:
         version: 0.1.13
       eslint-config-next:
         specifier: ^15.0.2
-        version: 15.4.4(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)
+        version: 15.4.4(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
       flowtoken:
         specifier: ^1.0.40
         version: 1.0.40(@types/react@19.1.8)(react@19.2.3)
@@ -729,10 +734,10 @@ importers:
         version: 0.3.37(@langchain/anthropic@0.3.34(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(zod@3.25.76))(@langchain/aws@1.1.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)))(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(axios@1.15.2)(encoding@0.1.13)(handlebars@4.7.9)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       next:
         specifier: ^16.0.10
-        version: 16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
+        version: 16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.2.1(next@16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       openai:
         specifier: ^4.85.1
         version: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
@@ -811,7 +816,7 @@ importers:
         version: 1.2.1
       next:
         specifier: ^16.0.10
-        version: 16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
+        version: 16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
       openai:
         specifier: ^4.85.1
         version: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
@@ -958,7 +963,7 @@ importers:
         version: 0.451.0(react@19.2.3)
       next:
         specifier: ^16.0.10
-        version: 16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
+        version: 16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
       openai:
         specifier: ^4.85.1
         version: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
@@ -1019,7 +1024,7 @@ importers:
         version: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next:
         specifier: ^16.0.10
-        version: 16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
+        version: 16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -1119,7 +1124,7 @@ importers:
         version: 0.414.0(react@19.2.3)
       next:
         specifier: ^16.0.10
-        version: 16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
+        version: 16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
       openai:
         specifier: ^4.85.1
         version: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
@@ -1176,17 +1181,17 @@ importers:
         specifier: 0.9.0
         version: 0.9.0
       '@ag-ui/client':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@ag-ui/core':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@ag-ui/encoder':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@ag-ui/proto':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@angular/animations':
         specifier: ^21.2.15
         version: 21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1))
@@ -1312,8 +1317,8 @@ importers:
   examples/v2/angular/demo-server:
     dependencies:
       '@ag-ui/langgraph':
-        specifier: ^0.0.11
-        version: 0.0.11(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.19.0)
+        specifier: 0.0.43-canary.1784331649.0
+        version: 0.0.43-canary.1784331649.0(@ag-ui/client@0.0.59-canary.1784325892.0)(@ag-ui/core@0.0.59-canary.1784325892.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))
       '@ai-sdk/openai':
         specifier: 3.0.36
         version: 3.0.36(zod@3.25.76)
@@ -1343,8 +1348,8 @@ importers:
   examples/v2/angular/storybook:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.51
-        version: 0.0.51
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@angular/animations':
         specifier: ^21.2.15
         version: 21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1))
@@ -1494,7 +1499,7 @@ importers:
         version: link:../../../../../packages/runtime
       next:
         specifier: 16.2.3
-        version: 16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
+        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -1543,7 +1548,7 @@ importers:
         version: link:../../../packages/react-core
       next:
         specifier: ^16.0.10
-        version: 16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
+        version: 16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -1766,11 +1771,11 @@ importers:
   examples/v2/react/demo:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.51
-        version: 0.0.51
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@ag-ui/mcp-apps-middleware':
         specifier: 0.0.2
-        version: 0.0.2(@ag-ui/client@0.0.51)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
+        version: 0.0.2(@ag-ui/client@0.0.59-canary.1784325892.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: 3.0.36
         version: 3.0.36(zod@3.25.76)
@@ -1803,7 +1808,7 @@ importers:
         version: 4.12.15
       next:
         specifier: ^16.0.10
-        version: 16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
+        version: 16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
       openai:
         specifier: ^5.9.0
         version: 5.23.2(ws@8.19.0)(zod@3.25.76)
@@ -2023,11 +2028,11 @@ importers:
   examples/v2/vue/demo:
     dependencies:
       '@ag-ui/core':
-        specifier: 0.0.52
-        version: 0.0.52
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@ag-ui/mcp-apps-middleware':
         specifier: 0.0.2
-        version: 0.0.2(@ag-ui/client@0.0.57)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
+        version: 0.0.2(@ag-ui/client@0.0.59-canary.1784325892.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../../../../packages/core
@@ -2048,7 +2053,7 @@ importers:
         version: 4.12.15
       nuxt:
         specifier: 3.17.5
-        version: 3.17.5(@parcel/watcher@2.5.6)(@types/node@22.19.11)(better-sqlite3@12.5.0)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4(better-sqlite3@12.5.0))(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(less@4.5.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.3)(rollup@4.60.2)(sass@1.97.3)(srvx@0.11.15)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.2)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.8.2))(xml2js@0.6.2)(yaml@2.9.0)
+        version: 3.17.5(@parcel/watcher@2.5.6)(@types/node@22.19.11)(better-sqlite3@12.5.0)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4(better-sqlite3@12.5.0))(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(less@4.5.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.60.2)(sass@1.97.3)(srvx@0.11.15)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.2)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.8.2))(xml2js@0.6.2)(yaml@2.9.0)
       openai:
         specifier: ^5.9.0
         version: 5.23.2(ws@8.19.0)(zod@3.25.76)
@@ -2103,8 +2108,8 @@ importers:
         version: 3.5.34(typescript@5.8.2)
     devDependencies:
       '@ag-ui/core':
-        specifier: 0.0.52
-        version: 0.0.52
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@copilotkit/typescript-config':
         specifier: workspace:*
         version: link:../../../../packages/typescript-config
@@ -2188,8 +2193,8 @@ importers:
   packages/agentcore-runner:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@copilotkit/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -2216,11 +2221,11 @@ importers:
   packages/angular:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@ag-ui/core':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@copilotkit/a2ui-renderer':
         specifier: workspace:*
         version: link:../a2ui-renderer
@@ -2358,11 +2363,11 @@ importers:
   packages/bot:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@ag-ui/core':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@copilotkit/bot-ui':
         specifier: workspace:~
         version: link:../bot-ui
@@ -2395,8 +2400,8 @@ importers:
   packages/bot-discord:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@copilotkit/bot':
         specifier: workspace:*
         version: link:../bot
@@ -2426,11 +2431,11 @@ importers:
   packages/bot-slack:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@ag-ui/core':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@copilotkit/bot':
         specifier: workspace:~
         version: link:../bot
@@ -2478,11 +2483,11 @@ importers:
   packages/bot-teams:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@ag-ui/core':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@copilotkit/bot':
         specifier: workspace:~
         version: link:../bot
@@ -2533,8 +2538,8 @@ importers:
   packages/bot-telegram:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@copilotkit/bot':
         specifier: workspace:~
         version: link:../bot
@@ -2583,8 +2588,8 @@ importers:
   packages/bot-whatsapp:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@copilotkit/bot':
         specifier: workspace:~
         version: link:../bot
@@ -2608,8 +2613,8 @@ importers:
   packages/core:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@copilotkit/shared':
         specifier: workspace:*
         version: link:../shared
@@ -2666,8 +2671,8 @@ importers:
   packages/demo-agents:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       openai:
         specifier: ^4.85.1
         version: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
@@ -2694,11 +2699,11 @@ importers:
   packages/react-core:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@ag-ui/core':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@copilotkit/a2ui-renderer':
         specifier: workspace:*
         version: link:../a2ui-renderer
@@ -2866,8 +2871,8 @@ importers:
   packages/react-native:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -3122,22 +3127,22 @@ importers:
     dependencies:
       '@ag-ui/a2ui-middleware':
         specifier: 0.0.10
-        version: 0.0.10(@ag-ui/client@0.0.57)(rxjs@7.8.1)
+        version: 0.0.10(@ag-ui/client@0.0.59-canary.1784325892.0)(rxjs@7.8.1)
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@ag-ui/core':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@ag-ui/encoder':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@ag-ui/langgraph':
-        specifier: 0.0.42
-        version: 0.0.42(@ag-ui/client@0.0.57)(@ag-ui/core@0.0.57)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
+        specifier: 0.0.43-canary.1784331649.0
+        version: 0.0.43-canary.1784331649.0(@ag-ui/client@0.0.59-canary.1784325892.0)(@ag-ui/core@0.0.59-canary.1784325892.0)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
       '@ag-ui/mcp-apps-middleware':
         specifier: 0.0.3
-        version: 0.0.3(@ag-ui/client@0.0.57)(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+        version: 0.0.3(@ag-ui/client@0.0.59-canary.1784325892.0)(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@ag-ui/mcp-middleware':
         specifier: 0.0.1
         version: 0.0.1(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
@@ -3408,8 +3413,8 @@ importers:
   packages/sdk-js:
     dependencies:
       '@ag-ui/langgraph':
-        specifier: 0.0.42
-        version: 0.0.42(@ag-ui/client@0.0.57)(@ag-ui/core@0.0.57)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
+        specifier: 0.0.43-canary.1784331649.0
+        version: 0.0.43-canary.1784331649.0(@ag-ui/client@0.0.59-canary.1784325892.0)(@ag-ui/core@0.0.59-canary.1784325892.0)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
       '@copilotkit/shared':
         specifier: workspace:*
         version: link:../shared
@@ -3466,11 +3471,11 @@ importers:
   packages/shared:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@ag-ui/core':
-        specifier: '>=0.0.48'
-        version: 0.0.51
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@copilotkit/license-verifier':
         specifier: ~0.5.0
         version: 0.5.0
@@ -3530,8 +3535,8 @@ importers:
   packages/sqlite-runner:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@copilotkit/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -3602,11 +3607,11 @@ importers:
         specifier: 0.9.0
         version: 0.9.0
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@ag-ui/core':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -3756,8 +3761,8 @@ importers:
   packages/web-inspector:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59-canary.1784325892.0
+        version: 0.0.59-canary.1784325892.0
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -3962,114 +3967,60 @@ packages:
   '@ag-ui/a2a@0.0.6':
     resolution: {integrity: sha512-wvrBXU6214wuC5O+FBy7QiZFvobIlt3Lo0Ph2N+hBkeaBjPHvmMp/egIg4k9WyB60PzKjJDv5o21WxbvaYtzCw==}
     peerDependencies:
-      '@ag-ui/client': '>=0.0.42'
-      '@ag-ui/core': '>=0.0.42'
+      '@ag-ui/client': 0.0.59-canary.1784325892.0
+      '@ag-ui/core': 0.0.59-canary.1784325892.0
 
   '@ag-ui/a2ui-middleware@0.0.10':
     resolution: {integrity: sha512-2BQFUQ9vJzUAQSR0dNW/ijhyH8KpiRWISSLTP6mIe6ENyQ2cM1/XLG38/Dcb69olcs36gtZADZzAQWcno5H6fA==}
     peerDependencies:
-      '@ag-ui/client': '>=0.0.40'
+      '@ag-ui/client': 0.0.59-canary.1784325892.0
       rxjs: 7.8.1
 
   '@ag-ui/a2ui-toolkit@0.0.4':
     resolution: {integrity: sha512-9VPmgpCAsFVICk7z23kh+Kp/BwYMxw0D0KGjOiKXhm1MAH+Wid2iC3yKsXso+q7UZZiyhWgeDUSgaAkltyLmGg==}
 
-  '@ag-ui/client@0.0.36':
-    resolution: {integrity: sha512-1Ey2KqK9KQpRJcnJvKPfVyLiTK4+CLBQZ085oJvr6T1nznw224j0KyzXNJ7cRjXeEGnuafmXTgpU+xEbN3xuYQ==}
-
-  '@ag-ui/client@0.0.42':
-    resolution: {integrity: sha512-zAbP+sZJImR5bUpR2ni7RtuuNZMuesaxviynyIgzKlr1k2VCM49mFpbDUKU4TH4Cneu+Xe7OEnO8qCOCIzBAww==}
-
-  '@ag-ui/client@0.0.51':
-    resolution: {integrity: sha512-i95TVJWOIqOOBPDKkg10Db00lkmyPfQ/Bqi0SBVxnJu7qHSXHojvEB3JDUDybVlWhOHEzhMn75EZaDZwYjHaJA==}
-
   '@ag-ui/client@0.0.53':
     resolution: {integrity: sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==}
 
-  '@ag-ui/client@0.0.57':
-    resolution: {integrity: sha512-Xap2alG9Z0/j5kb3x4D7oTpe2sw1dfrC9rgJJr2NZu5vKcm8dzIPNd31mF2B4zS3BKqYIu245yxKPhEtT30MHw==}
+  '@ag-ui/client@0.0.59-canary.1784325892.0':
+    resolution: {integrity: sha512-weXQrXCkBfH1zzwb0tRfXkZFBW0Pb0428/OGmyA4ypN5sNXL6Id7woH6CN7UeRQkNYT2+21Zau/Z87DU1ZWGdA==}
 
-  '@ag-ui/core@0.0.36':
-    resolution: {integrity: sha512-uYUrzw6uxuw4qVQ61mdSeiG0mFh2n/VAWmWsWzwETDuhqJZT7rFmd07IajcFWcyItMr1wjqxFDdlklucAyEYNA==}
+  '@ag-ui/core@0.0.59-canary.1784325892.0':
+    resolution: {integrity: sha512-V21bv0EygcgTAyeNR8e39A5yHLGAwTQQW2ldxIhPL/Y27N6X/S04zc0kXlSlcaHqFOWdXA2qqa9vB5zBqBObUg==}
 
-  '@ag-ui/core@0.0.42':
-    resolution: {integrity: sha512-C2hMg4Gs5oiUDgK9cA2RsTwSSmFZdIsqPklDrFw/Ue+quH6EU3vKp5YoOq7nuaQYO4pO8Em+Z+l5/M5PpcvP1g==}
+  '@ag-ui/encoder@0.0.59-canary.1784325892.0':
+    resolution: {integrity: sha512-LjruNlkwslb3B+y7totvafp/z22ou/EUW13XPreMbj50XvGG8fI9if/kSDajogCMJ8bDs2jjqvnJvQ3VNz3HMA==}
 
-  '@ag-ui/core@0.0.49':
-    resolution: {integrity: sha512-9ywypwjUGtIvTxJ2eKQjhPZgLnSFAfNK7vZUcT7Bz4ur4yAIB+lAFtzvu7VDYe6jsUx/6N/71Dh4R0zX5woNVw==}
-
-  '@ag-ui/core@0.0.51':
-    resolution: {integrity: sha512-/n7k/s9aGWW7a81+K/GTurYoQ9LoFEukEtWz9Z8mJ5D5nCdsUDAf/ZWleCI8NbD9xO0ImVw2Wlyye0ORrTv7Mw==}
-
-  '@ag-ui/core@0.0.52':
-    resolution: {integrity: sha512-Xo0bUaNV56EqylzcrAuhUkQX7et7+SZIrqZZtEByGwEq/I1EHny6ZMkWHLkKR7UNi0FJZwJyhKYmKJS3B2SEgA==}
-
-  '@ag-ui/core@0.0.53':
-    resolution: {integrity: sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ==}
-
-  '@ag-ui/core@0.0.57':
-    resolution: {integrity: sha512-gho1OWjNE6E3Rl7ZEZ1wr2CEpUHjLFU0FqzCZZk439TicLu+BfLCMkMokB07bMGlRmbJ60hM6LW60iOVauCx+Q==}
-
-  '@ag-ui/encoder@0.0.36':
-    resolution: {integrity: sha512-p8UNh6a77G/oe/4EZmwkTeYCN/5SnqSY2Cz8f8psZpk4LKzzrPkRNykrUAIBsi1wMp50/VQiM27oTRaade/Qkw==}
-
-  '@ag-ui/encoder@0.0.42':
-    resolution: {integrity: sha512-97B5MMCSs82t/y41uk2NrLBYFhbvn4kYsKQHMCfy8tjSWubyxh3zP7N9yHo8zJeSPe3WvzTvclyXNiGxSOsorg==}
-
-  '@ag-ui/encoder@0.0.51':
-    resolution: {integrity: sha512-cZ+cSo4Wlksrv8Q4Kk/LrjdtF7SjXlc8/FPnZvAHuNUthmrBj57SNFhtgCXvjWyGxC6vWJp9QRRLM4VGkvlMfw==}
-
-  '@ag-ui/encoder@0.0.53':
-    resolution: {integrity: sha512-bAOcfVdm6U4H6G6tW+DZfwPEQm1w/snVBTwaFn9nJcEMW69M7/HZuwvEc/7Zo0rK1jRL32N/j60PwTAeky19fw==}
-
-  '@ag-ui/encoder@0.0.57':
-    resolution: {integrity: sha512-ifD9NctR4xyPDR58xF9GK1bj/S8oECFkTeDfuYD8tXdbcOstIJ2TOqU2zhiCKnw7Vw+zR9Qv3TbsM9E7Gi9X3Q==}
-
-  '@ag-ui/langgraph@0.0.11':
-    resolution: {integrity: sha512-3xUkaOelnpQ5tbsbuoOTin71tTgWEN0GDZBjGs/7xAwly2Dn4fahbBAoscXullO/pH9kTGGgbuJ0rWDUgo6fKQ==}
-
-  '@ag-ui/langgraph@0.0.42':
-    resolution: {integrity: sha512-dXasEbGQFJcasdoy5khYyDHZHYoD1/i7hioaP8cejfw+Dss4tLvN8ndzD6c5j0hmANaKscekl+zkF7UQq3sI9w==}
+  '@ag-ui/langgraph@0.0.43-canary.1784331649.0':
+    resolution: {integrity: sha512-z0RIe+6VrWJj1amMZOQvSzaBOnUfdEmzFfNo1v/eOhxH34hH1Jg/MjZjbqySZl96uqMwmdGnjzStrH/fhaO9hg==}
     peerDependencies:
-      '@ag-ui/client': '>=0.0.42'
-      '@ag-ui/core': '>=0.0.42'
+      '@ag-ui/client': 0.0.59-canary.1784325892.0
+      '@ag-ui/core': 0.0.59-canary.1784325892.0
 
   '@ag-ui/mcp-apps-middleware@0.0.1':
     resolution: {integrity: sha512-GndsrxBr12Ji/Ioa4zYALbmEGD7cglExIwL7wlco3/PVyqk1WsjybxRNyDj+p9NQh2HJ3s/ctEJWGxwVUyC+fw==}
     peerDependencies:
-      '@ag-ui/client': '>=0.0.40'
+      '@ag-ui/client': 0.0.59-canary.1784325892.0
       rxjs: 7.8.1
 
   '@ag-ui/mcp-apps-middleware@0.0.2':
     resolution: {integrity: sha512-EMHm65hs3aNfoCpxZ1RYDLvZejmit0yipvzg39jwKrGTzqvB3CZuZUenDS9o2eWu2PZIvcFuvU15nEwH7SZb8A==}
     peerDependencies:
-      '@ag-ui/client': '>=0.0.40'
+      '@ag-ui/client': 0.0.59-canary.1784325892.0
       rxjs: 7.8.1
 
   '@ag-ui/mcp-apps-middleware@0.0.3':
     resolution: {integrity: sha512-Z+NZQXj4J+Y/2PLNsiyhNzRWFtTT2sAoC5dztoAlIsdfzvLvYEa52YGdHesNTN85JJqaIrYxQ8e31IBpKjrnoA==}
     peerDependencies:
-      '@ag-ui/client': '>=0.0.40'
+      '@ag-ui/client': 0.0.59-canary.1784325892.0
 
   '@ag-ui/mcp-middleware@0.0.1':
     resolution: {integrity: sha512-TayUu7kB+jXUTPRUJesNvJYrP+0weTL9F2VJJ8QQ4sWxY/Ihjo+GgFYgJZYNcLwbo1DKgmVJtdm2XUouPCbxeg==}
     peerDependencies:
       rxjs: 7.8.1
 
-  '@ag-ui/proto@0.0.36':
-    resolution: {integrity: sha512-yaWLwJQmBaCtFstSoZEALztVckCYv+RD8guU91kL5AvywRXvZPP5mjiN+bEwvtw8VU3idXoee1ZbJGpSlSAQ8A==}
-
-  '@ag-ui/proto@0.0.42':
-    resolution: {integrity: sha512-NDUwSgMnGEqxZGkWIJ1ge5t3Q7Kiddj360x2JAWaIfv9w+7tDJ0pmgyzf3/SXp605aY2wZiDLBtJ6jKZeg1lFg==}
-
-  '@ag-ui/proto@0.0.51':
-    resolution: {integrity: sha512-aQC9eOU54zKnho3xOmBEPWRegdqdJ8yXWxBFoqPPB0oh8J/kB4JzecRybp9BfleyqaIGGnzn/yC7TsXh1Ir7Kw==}
-
-  '@ag-ui/proto@0.0.53':
-    resolution: {integrity: sha512-swjz22xWT8YUZt5OhmUwkARDQdwt8XM1hmGZbQrhRnNPXKwrKJX9ELlbnQ4iFUQIKkMWpphzE3vA3yNKs2bbKw==}
-
-  '@ag-ui/proto@0.0.57':
-    resolution: {integrity: sha512-pPENOZt0P6ibH8sCTgq05wLYXi5t3P9B5r/1bWYehXjUxtyOdnukSlWM++SsCIwUXsQdm/b3aBgGjEeTF7RenA==}
+  '@ag-ui/proto@0.0.59-canary.1784325892.0':
+    resolution: {integrity: sha512-t1Wf6XHWVsElkKeyy6arYjLGc0CstBhUYVF0iPakaiSKMVZZj9RsgjmINdn8N/PmViKHxIoddHY8sly3vwWa3Q==}
 
   '@ai-sdk/anthropic@2.0.71':
     resolution: {integrity: sha512-JXTtAwlyxGzzRtpiAXk/O93aOTgdfoVX28EoUuRNVqZRgtkoniLQTtqeb8uZ4oXljNJlXzaJLNasS/U90w/wjw==}
@@ -8261,10 +8212,6 @@ packages:
       youtubei.js:
         optional: true
 
-  '@langchain/core@0.3.80':
-    resolution: {integrity: sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==}
-    engines: {node: '>=18'}
-
   '@langchain/core@1.1.27':
     resolution: {integrity: sha512-YVtEz3nqCh8WxtdVXUICmt2BR2An+mn4YRJUBwcHX47Yrh2VwxpO0l97B2N/sNi658m65HnGyz2/hAjF3fzc1w==}
     engines: {node: '>=20'}
@@ -8314,20 +8261,6 @@ packages:
     resolution: {integrity: sha512-+aA34oFbp5jea3hQiqs8x0FohumyIGEPkX7ros+jMlOR22qAt2fh8qua/54T+e9CIK8NFbKtaQQwDvuCKoxkYg==}
     engines: {node: ^18.19.0 || >=20.16.0}
     hasBin: true
-
-  '@langchain/langgraph-sdk@0.0.105':
-    resolution: {integrity: sha512-3DD1W1wnbP48807qq+5gY248mFcwwNGqKdmZt05P3zeLpfP5Sfm6ELzVvqHGpr+qumP0yGRZs/7qArYGXRRfcQ==}
-    peerDependencies:
-      '@langchain/core': '>=0.2.31 <0.4.0'
-      react: 19.2.3
-      react-dom: 19.2.3
-    peerDependenciesMeta:
-      '@langchain/core':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@langchain/langgraph-sdk@1.8.9':
     resolution: {integrity: sha512-vpz90auS4iFTNy2X/CFexOEoeFSvaK+MyI7iSmzYs9gGcfzwRjWUJ4MWsuc5ZNRecLStwho0PExVXRgGOXtcRw==}
@@ -24641,11 +24574,6 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
   uvu@0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
     engines: {node: '>=8'}
@@ -24990,8 +24918,8 @@ packages:
   vue-component-type-helpers@3.3.1:
     resolution: {integrity: sha512-pu58kqxmVyEH6VfNYW1UyEfR3XAnJ27ZXT3yzXxxpjLxVzAbyC35Zk/nm/RMs7ijWnJNSd9fWkeex2OhUsx3MA==}
 
-  vue-component-type-helpers@3.3.6:
-    resolution: {integrity: sha512-FkljacAwJ9BUoSUdpFe3VDy0sGigNlTH9+2zcXUWmZOjN8swiCkl3t48wOJun0OsUd2cEIda1l04tsxMiKIIrQ==}
+  vue-component-type-helpers@3.3.7:
+    resolution: {integrity: sha512-Skkhw9agYSgsWqv7bxSOGJZa9SaiJbZVGdXuFWnrzKaQYHnw9qbjD630rw6RyMqDbp54nfLCLw5SZA55if7JLg==}
 
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
@@ -25645,74 +25573,36 @@ snapshots:
   '@ag-ui/a2a-middleware@0.0.2(rxjs@7.8.1)':
     dependencies:
       '@a2a-js/sdk': 0.2.5
-      '@ag-ui/client': 0.0.42
+      '@ag-ui/client': 0.0.59-canary.1784325892.0
       ai: 6.0.156(zod@3.25.76)
       rxjs: 7.8.1
       zod: 3.25.76
     transitivePeerDependencies:
       - supports-color
 
-  '@ag-ui/a2a@0.0.6(@ag-ui/client@0.0.42)(@ag-ui/core@0.0.57)':
+  '@ag-ui/a2a@0.0.6(@ag-ui/client@0.0.59-canary.1784325892.0)(@ag-ui/core@0.0.59-canary.1784325892.0)':
     dependencies:
       '@a2a-js/sdk': 0.2.5
-      '@ag-ui/client': 0.0.42
-      '@ag-ui/core': 0.0.57
+      '@ag-ui/client': 0.0.59-canary.1784325892.0
+      '@ag-ui/core': 0.0.59-canary.1784325892.0
       rxjs: 7.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ag-ui/a2ui-middleware@0.0.10(@ag-ui/client@0.0.57)(rxjs@7.8.1)':
+  '@ag-ui/a2ui-middleware@0.0.10(@ag-ui/client@0.0.59-canary.1784325892.0)(rxjs@7.8.1)':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.4
-      '@ag-ui/client': 0.0.57
+      '@ag-ui/client': 0.0.59-canary.1784325892.0
       clarinet: 0.12.6
       rxjs: 7.8.1
 
   '@ag-ui/a2ui-toolkit@0.0.4': {}
 
-  '@ag-ui/client@0.0.36':
-    dependencies:
-      '@ag-ui/core': 0.0.36
-      '@ag-ui/encoder': 0.0.36
-      '@ag-ui/proto': 0.0.36
-      '@types/uuid': 10.0.0
-      fast-json-patch: 3.1.1
-      rxjs: 7.8.1
-      untruncate-json: 0.0.1
-      uuid: 11.1.0
-      zod: 3.25.76
-
-  '@ag-ui/client@0.0.42':
-    dependencies:
-      '@ag-ui/core': 0.0.42
-      '@ag-ui/encoder': 0.0.42
-      '@ag-ui/proto': 0.0.42
-      '@types/uuid': 10.0.0
-      compare-versions: 6.1.1
-      fast-json-patch: 3.1.1
-      rxjs: 7.8.1
-      untruncate-json: 0.0.1
-      uuid: 11.1.0
-      zod: 3.25.76
-
-  '@ag-ui/client@0.0.51':
-    dependencies:
-      '@ag-ui/core': 0.0.51
-      '@ag-ui/encoder': 0.0.51
-      '@ag-ui/proto': 0.0.51
-      '@types/uuid': 10.0.0
-      compare-versions: 6.1.1
-      fast-json-patch: 3.1.1
-      rxjs: 7.8.1
-      untruncate-json: 0.0.1
-      uuid: 11.1.0
-      zod: 3.25.76
-
   '@ag-ui/client@0.0.53':
     dependencies:
-      '@ag-ui/core': 0.0.53
-      '@ag-ui/encoder': 0.0.53
-      '@ag-ui/proto': 0.0.53
+      '@ag-ui/core': 0.0.59-canary.1784325892.0
+      '@ag-ui/encoder': 0.0.59-canary.1784325892.0
+      '@ag-ui/proto': 0.0.59-canary.1784325892.0
       '@types/uuid': 10.0.0
       compare-versions: 6.1.1
       fast-json-patch: 3.1.1
@@ -25721,11 +25611,11 @@ snapshots:
       uuid: 11.1.0
       zod: 3.25.76
 
-  '@ag-ui/client@0.0.57':
+  '@ag-ui/client@0.0.59-canary.1784325892.0':
     dependencies:
-      '@ag-ui/core': 0.0.57
-      '@ag-ui/encoder': 0.0.57
-      '@ag-ui/proto': 0.0.57
+      '@ag-ui/core': 0.0.59-canary.1784325892.0
+      '@ag-ui/encoder': 0.0.59-canary.1784325892.0
+      '@ag-ui/proto': 0.0.59-canary.1784325892.0
       '@types/uuid': 10.0.0
       compare-versions: 6.1.1
       fast-json-patch: 3.1.1
@@ -25734,82 +25624,20 @@ snapshots:
       uuid: 11.1.0
       zod: 3.25.76
 
-  '@ag-ui/core@0.0.36':
-    dependencies:
-      rxjs: 7.8.1
-      zod: 3.25.76
-
-  '@ag-ui/core@0.0.42':
-    dependencies:
-      rxjs: 7.8.1
-      zod: 3.25.76
-
-  '@ag-ui/core@0.0.49':
+  '@ag-ui/core@0.0.59-canary.1784325892.0':
     dependencies:
       zod: 3.25.76
 
-  '@ag-ui/core@0.0.51':
+  '@ag-ui/encoder@0.0.59-canary.1784325892.0':
     dependencies:
-      zod: 3.25.76
+      '@ag-ui/core': 0.0.59-canary.1784325892.0
+      '@ag-ui/proto': 0.0.59-canary.1784325892.0
 
-  '@ag-ui/core@0.0.52':
-    dependencies:
-      zod: 3.25.76
-
-  '@ag-ui/core@0.0.53':
-    dependencies:
-      zod: 3.25.76
-
-  '@ag-ui/core@0.0.57':
-    dependencies:
-      zod: 3.25.76
-
-  '@ag-ui/encoder@0.0.36':
-    dependencies:
-      '@ag-ui/core': 0.0.36
-      '@ag-ui/proto': 0.0.36
-
-  '@ag-ui/encoder@0.0.42':
-    dependencies:
-      '@ag-ui/core': 0.0.42
-      '@ag-ui/proto': 0.0.42
-
-  '@ag-ui/encoder@0.0.51':
-    dependencies:
-      '@ag-ui/core': 0.0.51
-      '@ag-ui/proto': 0.0.51
-
-  '@ag-ui/encoder@0.0.53':
-    dependencies:
-      '@ag-ui/core': 0.0.53
-      '@ag-ui/proto': 0.0.53
-
-  '@ag-ui/encoder@0.0.57':
-    dependencies:
-      '@ag-ui/core': 0.0.57
-      '@ag-ui/proto': 0.0.57
-
-  '@ag-ui/langgraph@0.0.11(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.19.0)':
-    dependencies:
-      '@ag-ui/client': 0.0.36
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
-      '@langchain/langgraph-sdk': 0.0.105(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      partial-json: 0.1.7
-      rxjs: 7.8.1
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - openai
-      - react
-      - react-dom
-      - ws
-
-  '@ag-ui/langgraph@0.0.42(@ag-ui/client@0.0.57)(@ag-ui/core@0.0.57)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
+  '@ag-ui/langgraph@0.0.43-canary.1784331649.0(@ag-ui/client@0.0.59-canary.1784325892.0)(@ag-ui/core@0.0.59-canary.1784325892.0)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.4
-      '@ag-ui/client': 0.0.57
-      '@ag-ui/core': 0.0.57
+      '@ag-ui/client': 0.0.59-canary.1784325892.0
+      '@ag-ui/core': 0.0.59-canary.1784325892.0
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))
       langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
@@ -25827,11 +25655,11 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  '@ag-ui/langgraph@0.0.42(@ag-ui/client@0.0.57)(@ag-ui/core@0.0.57)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
+  '@ag-ui/langgraph@0.0.43-canary.1784331649.0(@ag-ui/client@0.0.59-canary.1784325892.0)(@ag-ui/core@0.0.59-canary.1784325892.0)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.4
-      '@ag-ui/client': 0.0.57
-      '@ag-ui/core': 0.0.57
+      '@ag-ui/client': 0.0.59-canary.1784325892.0
+      '@ag-ui/core': 0.0.59-canary.1784325892.0
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))
       langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
@@ -25849,9 +25677,31 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  '@ag-ui/mcp-apps-middleware@0.0.1(@ag-ui/client@0.0.42)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
+  '@ag-ui/langgraph@0.0.43-canary.1784331649.0(@ag-ui/client@0.0.59-canary.1784325892.0)(@ag-ui/core@0.0.59-canary.1784325892.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))':
     dependencies:
-      '@ag-ui/client': 0.0.42
+      '@ag-ui/a2ui-toolkit': 0.0.4
+      '@ag-ui/client': 0.0.59-canary.1784325892.0
+      '@ag-ui/core': 0.0.59-canary.1784325892.0
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))
+      langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0))(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))
+      partial-json: 0.1.7
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
+      - svelte
+      - vue
+      - ws
+      - zod-to-json-schema
+
+  '@ag-ui/mcp-apps-middleware@0.0.1(@ag-ui/client@0.0.59-canary.1784325892.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
+    dependencies:
+      '@ag-ui/client': 0.0.59-canary.1784325892.0
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       rxjs: 7.8.1
     transitivePeerDependencies:
@@ -25859,9 +25709,9 @@ snapshots:
       - supports-color
       - zod
 
-  '@ag-ui/mcp-apps-middleware@0.0.2(@ag-ui/client@0.0.51)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
+  '@ag-ui/mcp-apps-middleware@0.0.2(@ag-ui/client@0.0.59-canary.1784325892.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
     dependencies:
-      '@ag-ui/client': 0.0.51
+      '@ag-ui/client': 0.0.59-canary.1784325892.0
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       rxjs: 7.8.1
     transitivePeerDependencies:
@@ -25869,19 +25719,9 @@ snapshots:
       - supports-color
       - zod
 
-  '@ag-ui/mcp-apps-middleware@0.0.2(@ag-ui/client@0.0.57)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
+  '@ag-ui/mcp-apps-middleware@0.0.3(@ag-ui/client@0.0.59-canary.1784325892.0)(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@ag-ui/client': 0.0.57
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
-      rxjs: 7.8.1
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-      - zod
-
-  '@ag-ui/mcp-apps-middleware@0.0.3(@ag-ui/client@0.0.57)(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
-    dependencies:
-      '@ag-ui/client': 0.0.57
+      '@ag-ui/client': 0.0.59-canary.1784325892.0
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       rxjs: 7.8.1
     transitivePeerDependencies:
@@ -25899,33 +25739,9 @@ snapshots:
       - supports-color
       - zod
 
-  '@ag-ui/proto@0.0.36':
+  '@ag-ui/proto@0.0.59-canary.1784325892.0':
     dependencies:
-      '@ag-ui/core': 0.0.36
-      '@bufbuild/protobuf': 2.11.0
-      '@protobuf-ts/protoc': 2.11.1
-
-  '@ag-ui/proto@0.0.42':
-    dependencies:
-      '@ag-ui/core': 0.0.42
-      '@bufbuild/protobuf': 2.11.0
-      '@protobuf-ts/protoc': 2.11.1
-
-  '@ag-ui/proto@0.0.51':
-    dependencies:
-      '@ag-ui/core': 0.0.51
-      '@bufbuild/protobuf': 2.11.0
-      '@protobuf-ts/protoc': 2.11.1
-
-  '@ag-ui/proto@0.0.53':
-    dependencies:
-      '@ag-ui/core': 0.0.53
-      '@bufbuild/protobuf': 2.11.0
-      '@protobuf-ts/protoc': 2.11.1
-
-  '@ag-ui/proto@0.0.57':
-    dependencies:
-      '@ag-ui/core': 0.0.57
+      '@ag-ui/core': 0.0.59-canary.1784325892.0
       '@bufbuild/protobuf': 2.11.0
       '@protobuf-ts/protoc': 2.11.1
 
@@ -27755,20 +27571,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-member-expression-to-functions': 7.29.7
-      '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.28.5)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/traverse': 7.29.7
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -27807,14 +27609,6 @@ snapshots:
   '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
-      '@babel/helper-annotate-as-pure': 7.29.7
-      regexpu-core: 6.4.0
-      semver: 6.3.1
-    optional: true
-
-  '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.29.7
       regexpu-core: 6.4.0
       semver: 6.3.1
@@ -27864,18 +27658,6 @@ snapshots:
   '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.3(supports-color@5.5.0)
-      lodash.debounce: 4.0.8
-      resolve: 1.22.11
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3(supports-color@5.5.0)
@@ -28070,16 +27852,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/helper-replace-supers@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-member-expression-to-functions': 7.29.7
-      '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/traverse': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -28259,15 +28031,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -28416,12 +28179,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
-  '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
   '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -28440,12 +28197,6 @@ snapshots:
   '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -28653,16 +28404,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -28711,16 +28452,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -28762,12 +28493,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
-  '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
   '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -28799,15 +28524,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -28828,15 +28544,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.28.3)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@babel/plugin-transform-class-static-block@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -28887,19 +28594,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-classes@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-globals': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.28.5)
-      '@babel/traverse': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-classes@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -28927,13 +28621,6 @@ snapshots:
   '@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/template': 7.29.7
-    optional: true
-
-  '@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/template': 7.29.7
     optional: true
@@ -28969,15 +28656,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -28996,13 +28674,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.28.3)
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-transform-dotall-regex@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -29038,13 +28709,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.28.3)
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -29087,15 +28751,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.28.5)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -29112,12 +28767,6 @@ snapshots:
   '@babel/plugin-transform-exponentiation-operator@7.29.7(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-transform-exponentiation-operator@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -29218,12 +28867,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
-  '@babel/plugin-transform-json-strings@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
   '@babel/plugin-transform-json-strings@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -29253,12 +28896,6 @@ snapshots:
   '@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -29333,15 +28970,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -29364,17 +28992,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.28.3)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@babel/plugin-transform-modules-systemjs@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.7
@@ -29437,13 +29054,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
   '@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -29483,12 +29093,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
   '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -29502,12 +29106,6 @@ snapshots:
   '@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -29534,18 +29132,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.28.3)
       '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.28.3)
-      '@babel/traverse': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.28.5)
       '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -29604,12 +29190,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
-  '@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
   '@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -29649,15 +29229,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -29679,12 +29250,6 @@ snapshots:
   '@babel/plugin-transform-parameters@7.29.7(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-transform-parameters@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -29714,15 +29279,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.28.3)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -29760,16 +29316,6 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.28.3)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@babel/plugin-transform-private-property-in-object@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -29906,12 +29452,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
-  '@babel/plugin-transform-regenerator@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
   '@babel/plugin-transform-regenerator@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -29927,13 +29467,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.28.3)
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-transform-regexp-modifiers@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -30050,15 +29583,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-spread@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-spread@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -30166,13 +29690,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
-  '@babel/plugin-transform-unicode-property-regex@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
   '@babel/plugin-transform-unicode-property-regex@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -30208,13 +29725,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.28.3)
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
-  '@babel/plugin-transform-unicode-sets-regex@7.29.7(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -30376,83 +29886,6 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/preset-env@7.29.2(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/compat-data': 7.29.7
-      '@babel/core': 7.28.5
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.5)
-      '@babel/plugin-syntax-import-assertions': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.28.5)
-      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-class-static-block': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-computed-properties': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-transform-dotall-regex': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-explicit-resource-management': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-exponentiation-operator': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-json-strings': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-logical-assignment-operators': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-modules-systemjs': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-numeric-separator': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-object-rest-spread': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-regenerator': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-regexp-modifiers': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-spread': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-unicode-property-regex': 7.29.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-unicode-sets-regex': 7.29.7(@babel/core@7.28.5)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.28.5)
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.28.5)
-      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.28.5)
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.28.5)
-      core-js-compat: 3.49.0
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@babel/preset-env@7.29.2(@babel/core@7.29.0)':
     dependencies:
@@ -31255,6 +30688,11 @@ snapshots:
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
     dependencies:
       eslint: 8.57.1
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@1.21.7))':
+    dependencies:
+      eslint: 9.39.2(jiti@1.21.7)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
@@ -33305,27 +32743,6 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - peggy
 
-  '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)':
-    dependencies:
-      '@cfworker/json-schema': 4.1.1
-      ansi-styles: 5.2.0
-      camelcase: 6.3.0
-      decamelize: 1.2.0
-      js-tiktoken: 1.0.21
-      langsmith: 0.5.25(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
-      mustache: 4.2.0
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      uuid: 10.0.0
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - openai
-      - ws
-
   '@langchain/core@1.1.27(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
@@ -33458,6 +32875,11 @@ snapshots:
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       uuid: 10.0.0
 
+  '@langchain/langgraph-checkpoint@1.0.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0))':
+    dependencies:
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      uuid: 10.0.0
+
   '@langchain/langgraph-cli@1.1.13(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@langchain/langgraph-checkpoint@1.0.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)))(@langchain/langgraph-sdk@1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3)))(@langchain/langgraph@1.2.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76))(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(typescript@5.9.3)(ws@8.19.0)':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -33494,17 +32916,6 @@ snapshots:
       - typescript
       - ws
 
-  '@langchain/langgraph-sdk@0.0.105(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@types/json-schema': 7.0.15
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      uuid: 9.0.1
-    optionalDependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-
   '@langchain/langgraph-sdk@1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@types/json-schema': 7.0.15
@@ -33528,6 +32939,18 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       vue: 3.5.34(typescript@5.9.3)
+
+  '@langchain/langgraph-sdk@1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      p-queue: 9.1.1
+      p-retry: 7.1.1
+      uuid: 13.0.0
+    optionalDependencies:
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      vue: 3.5.34(typescript@5.9.2)
 
   '@langchain/langgraph-sdk@2.0.0(@langchain/core@1.1.27(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -33613,6 +33036,20 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+      - svelte
+      - vue
+
+  '@langchain/langgraph@1.2.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))(zod@3.25.76)':
+    dependencies:
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0))
+      '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))
+      '@standard-schema/spec': 1.1.0
+      uuid: 10.0.0
+      zod: 3.25.76
     transitivePeerDependencies:
       - react
       - react-dom
@@ -34712,7 +34149,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/vite-builder@3.17.5(@types/node@22.19.11)(eslint@9.39.2(jiti@2.6.1))(less@4.5.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.3)(rollup@4.60.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.2)(vue-tsc@2.2.12(typescript@5.8.2))(vue@3.5.34(typescript@5.8.2))(yaml@2.9.0)':
+  '@nuxt/vite-builder@3.17.5(@types/node@22.19.11)(eslint@9.39.2(jiti@2.6.1))(less@4.5.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.60.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.2)(vue-tsc@2.2.12(typescript@5.8.2))(vue@3.5.34(typescript@5.8.2))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 3.17.5(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.2)
@@ -34738,7 +34175,7 @@ snapshots:
       perfect-debounce: 1.0.0
       pkg-types: 2.3.0
       postcss: 8.5.15
-      rollup-plugin-visualizer: 6.0.11(rolldown@1.0.0-rc.3)(rollup@4.60.2)
+      rollup-plugin-visualizer: 6.0.11(rollup@4.60.2)
       std-env: 3.10.0
       ufo: 1.6.2
       unenv: 2.0.0-rc.24
@@ -36678,9 +36115,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
     optional: true
 
   '@react-native/normalize-colors@0.85.2': {}
@@ -38409,7 +37844,7 @@ snapshots:
       storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.34(typescript@5.8.2)
-      vue-component-type-helpers: 3.3.6
+      vue-component-type-helpers: 3.3.7
 
   '@swc/core-darwin-arm64@1.15.8':
     optional: true
@@ -38744,13 +38179,13 @@ snapshots:
 
   '@tanstack/ai@0.14.0':
     dependencies:
-      '@ag-ui/core': 0.0.49
+      '@ag-ui/core': 0.0.59-canary.1784325892.0
       '@tanstack/ai-event-client': 0.2.8(@tanstack/ai@0.14.0)
       partial-json: 0.1.7
 
   '@tanstack/ai@0.31.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@ag-ui/core': 0.0.52
+      '@ag-ui/core': 0.0.59-canary.1784325892.0
       '@standard-schema/spec': 1.1.0
       '@tanstack/ai-event-client': 0.6.2(@tanstack/ai@0.31.0(@opentelemetry/api@1.9.0))
       partial-json: 0.1.7
@@ -38759,7 +38194,7 @@ snapshots:
 
   '@tanstack/ai@0.32.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@ag-ui/core': 0.0.52
+      '@ag-ui/core': 0.0.59-canary.1784325892.0
       '@standard-schema/spec': 1.1.0
       '@tanstack/ai-event-client': 0.6.3(@tanstack/ai@0.32.0(@opentelemetry/api@1.9.0))
       partial-json: 0.1.7
@@ -39410,16 +38845,16 @@ snapshots:
       '@types/node': 22.19.11
     optional: true
 
-  '@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)
+      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 7.2.0
-      '@typescript-eslint/type-utils': 7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)
-      '@typescript-eslint/utils': 7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)
+      '@typescript-eslint/type-utils': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
+      '@typescript-eslint/utils': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 7.2.0
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.2(jiti@2.7.0)
+      eslint: 9.39.2(jiti@1.21.7)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -39478,14 +38913,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)':
+  '@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.2.0
       '@typescript-eslint/types': 7.2.0
       '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 7.2.0
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.2(jiti@2.7.0)
+      eslint: 9.39.2(jiti@1.21.7)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -39563,12 +38998,12 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)':
+  '@typescript-eslint/type-utils@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)
+      '@typescript-eslint/utils': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.2(jiti@2.7.0)
+      eslint: 9.39.2(jiti@1.21.7)
       ts-api-utils: 1.4.3(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
@@ -39660,15 +39095,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)':
+  '@typescript-eslint/utils@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@1.21.7))
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 7.2.0
       '@typescript-eslint/types': 7.2.0
       '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.9.2)
-      eslint: 9.39.2(jiti@2.7.0)
+      eslint: 9.39.2(jiti@1.21.7)
       semver: 7.8.1
     transitivePeerDependencies:
       - supports-color
@@ -39941,7 +39376,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@22.19.11)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@22.19.11)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -40286,6 +39721,13 @@ snapshots:
       '@vue/compiler-ssr': 3.5.34
       '@vue/shared': 3.5.34
       vue: 3.5.34(typescript@5.8.2)
+
+  '@vue/server-renderer@3.5.34(vue@3.5.34(typescript@5.9.2))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.34
+      '@vue/shared': 3.5.34
+      vue: 3.5.34(typescript@5.9.2)
+    optional: true
 
   '@vue/server-renderer@3.5.34(vue@3.5.34(typescript@5.9.3))':
     dependencies:
@@ -41048,16 +40490,6 @@ snapshots:
       - supports-color
     optional: true
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.28.5):
-    dependencies:
-      '@babel/compat-data': 7.29.7
-      '@babel/core': 7.28.5
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.28.5)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
     dependencies:
       '@babel/compat-data': 7.29.7
@@ -41092,15 +40524,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.28.5):
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.28.5)
-      core-js-compat: 3.49.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
@@ -41127,14 +40550,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.28.3)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.28.5):
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.28.5)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -43633,19 +43048,19 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-next@15.4.4(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2):
+  eslint-config-next@15.4.4(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2):
     dependencies:
       '@next/eslint-plugin-next': 15.4.4
       '@rushstack/eslint-patch': 1.15.0
-      '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)
-      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)
-      eslint: 9.39.2(jiti@2.7.0)
+      '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
+      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
+      eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@1.21.7))
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -43701,6 +43116,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3(supports-color@5.5.0)
+      eslint: 9.39.2(jiti@1.21.7)
+      get-tsconfig: 4.13.6
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -43716,18 +43146,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)
+      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
+      eslint: 9.39.2(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -43736,9 +43176,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@2.7.0)
+      eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -43750,7 +43190,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)
+      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -43767,7 +43207,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -43782,6 +43222,25 @@ snapshots:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@1.21.7)):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.11.1
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 9.39.2(jiti@1.21.7)
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 10.2.4
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
 
   eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
@@ -43802,9 +43261,9 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
-      eslint: 9.39.2(jiti@2.7.0)
+      eslint: 9.39.2(jiti@1.21.7)
 
   eslint-plugin-react-hooks@7.1.1(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
@@ -43816,6 +43275,28 @@ snapshots:
       zod-validation-error: 4.0.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@1.21.7)):
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.3
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.2.2
+      eslint: 9.39.2(jiti@1.21.7)
+      estraverse: 5.3.0
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      minimatch: 10.2.4
+      object.entries: 1.1.9
+      object.fromentries: 2.0.8
+      object.values: 1.2.1
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.5
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.12
+      string.prototype.repeat: 1.0.0
 
   eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
@@ -43926,6 +43407,47 @@ snapshots:
       optionator: 0.9.4
       strip-ansi: 6.0.1
       text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint@9.39.2(jiti@1.21.7):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@1.21.7))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.2
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.14.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3(supports-color@5.5.0)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 10.2.4
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 1.21.7
     transitivePeerDependencies:
       - supports-color
 
@@ -46877,7 +46399,7 @@ snapshots:
 
   jsc-safe-url@0.2.4: {}
 
-  jscodeshift@17.3.0(@babel/preset-env@7.29.2(@babel/core@7.28.5)):
+  jscodeshift@17.3.0(@babel/preset-env@7.29.2(@babel/core@7.29.0)):
     dependencies:
       '@babel/core': 7.28.5
       '@babel/parser': 7.28.5
@@ -46898,7 +46420,7 @@ snapshots:
       tmp: 0.2.5
       write-file-atomic: 5.0.1
     optionalDependencies:
-      '@babel/preset-env': 7.29.2(@babel/core@7.28.5)
+      '@babel/preset-env': 7.29.2(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -47230,6 +46752,25 @@ snapshots:
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       '@langchain/langgraph': 1.2.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)
       '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
+      langsmith: 0.5.25(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
+      - svelte
+      - vue
+      - ws
+      - zod-to-json-schema
+
+  langchain@1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0))(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2)):
+    dependencies:
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/langgraph': 1.2.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0))
       langsmith: 0.5.25(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -49187,39 +48728,11 @@ snapshots:
       - supports-color
       - unified
 
-  next-themes@0.2.1(next@16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next-themes@0.2.1(next@16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      next: 16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
+      next: 16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-
-  next@16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3):
-    dependencies:
-      '@next/env': 16.1.3
-      '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.9.13
-      caniuse-lite: 1.0.30001769
-      postcss: 8.4.31
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.3)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 16.1.3
-      '@next/swc-darwin-x64': 16.1.3
-      '@next/swc-linux-arm64-gnu': 16.1.3
-      '@next/swc-linux-arm64-musl': 16.1.3
-      '@next/swc-linux-x64-gnu': 16.1.3
-      '@next/swc-linux-x64-musl': 16.1.3
-      '@next/swc-win32-arm64-msvc': 16.1.3
-      '@next/swc-win32-x64-msvc': 16.1.3
-      '@opentelemetry/api': 1.9.0
-      '@playwright/test': 1.59.1
-      babel-plugin-react-compiler: 1.0.0
-      sass: 1.97.3
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
 
   next@16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3):
     dependencies:
@@ -49240,34 +48753,6 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.3
       '@next/swc-win32-arm64-msvc': 16.1.3
       '@next/swc-win32-x64-msvc': 16.1.3
-      '@opentelemetry/api': 1.9.0
-      '@playwright/test': 1.59.1
-      babel-plugin-react-compiler: 1.0.0
-      sass: 1.97.3
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
-  next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.3):
-    dependencies:
-      '@next/env': 16.2.3
-      '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.24
-      caniuse-lite: 1.0.30001793
-      postcss: 8.4.31
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.3)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.3
-      '@next/swc-darwin-x64': 16.2.3
-      '@next/swc-linux-arm64-gnu': 16.2.3
-      '@next/swc-linux-arm64-musl': 16.2.3
-      '@next/swc-linux-x64-gnu': 16.2.3
-      '@next/swc-linux-x64-musl': 16.2.3
-      '@next/swc-win32-arm64-msvc': 16.2.3
-      '@next/swc-win32-x64-msvc': 16.2.3
       '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.59.1
       babel-plugin-react-compiler: 1.0.0
@@ -49376,7 +48861,7 @@ snapshots:
       jsonpath-plus: 10.3.0
       lodash.topath: 4.5.2
 
-  nitropack@2.13.4(better-sqlite3@12.5.0)(encoding@0.1.13)(oxc-parser@0.72.3)(rolldown@1.0.0-rc.3)(srvx@0.11.15)(xml2js@0.6.2):
+  nitropack@2.13.4(better-sqlite3@12.5.0)(encoding@0.1.13)(oxc-parser@0.72.3)(srvx@0.11.15)(xml2js@0.6.2):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.2)
@@ -49429,7 +48914,7 @@ snapshots:
       pretty-bytes: 7.1.0
       radix3: 1.1.2
       rollup: 4.60.2
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.0-rc.3)(rollup@4.60.2)
+      rollup-plugin-visualizer: 7.0.1(rollup@4.60.2)
       scule: 1.3.0
       semver: 7.8.1
       serve-placeholder: 2.0.2
@@ -49441,7 +48926,7 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.5.0
       unenv: 2.0.0-rc.24
-      unimport: 6.3.0(oxc-parser@0.72.3)(rolldown@1.0.0-rc.3)
+      unimport: 6.3.0(oxc-parser@0.72.3)
       unplugin-utils: 0.3.1
       unstorage: 1.17.5(db0@0.3.4(better-sqlite3@12.5.0))(ioredis@5.10.1)
       untyped: 2.0.0
@@ -49702,7 +49187,7 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
-  nuxt@3.17.5(@parcel/watcher@2.5.6)(@types/node@22.19.11)(better-sqlite3@12.5.0)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4(better-sqlite3@12.5.0))(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(less@4.5.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.3)(rollup@4.60.2)(sass@1.97.3)(srvx@0.11.15)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.2)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.8.2))(xml2js@0.6.2)(yaml@2.9.0):
+  nuxt@3.17.5(@parcel/watcher@2.5.6)(@types/node@22.19.11)(better-sqlite3@12.5.0)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4(better-sqlite3@12.5.0))(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.1)(less@4.5.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.60.2)(sass@1.97.3)(srvx@0.11.15)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.2)(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.8.2))(xml2js@0.6.2)(yaml@2.9.0):
     dependencies:
       '@nuxt/cli': 3.35.2(@nuxt/schema@3.17.5)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)
       '@nuxt/devalue': 2.0.2
@@ -49710,7 +49195,7 @@ snapshots:
       '@nuxt/kit': 3.17.5(magicast@0.5.2)
       '@nuxt/schema': 3.17.5
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@3.17.5(magicast@0.5.2))
-      '@nuxt/vite-builder': 3.17.5(@types/node@22.19.11)(eslint@9.39.2(jiti@2.6.1))(less@4.5.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.3)(rollup@4.60.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.2)(vue-tsc@2.2.12(typescript@5.8.2))(vue@3.5.34(typescript@5.8.2))(yaml@2.9.0)
+      '@nuxt/vite-builder': 3.17.5(@types/node@22.19.11)(eslint@9.39.2(jiti@2.6.1))(less@4.5.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.60.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.2)(vue-tsc@2.2.12(typescript@5.8.2))(vue@3.5.34(typescript@5.8.2))(yaml@2.9.0)
       '@unhead/vue': 2.1.15(vue@3.5.34(typescript@5.8.2))
       '@vue/shared': 3.5.34
       c12: 3.3.4(magicast@0.5.2)
@@ -49737,7 +49222,7 @@ snapshots:
       mlly: 1.8.0
       mocked-exports: 0.1.1
       nanotar: 0.2.1
-      nitropack: 2.13.4(better-sqlite3@12.5.0)(encoding@0.1.13)(oxc-parser@0.72.3)(rolldown@1.0.0-rc.3)(srvx@0.11.15)(xml2js@0.6.2)
+      nitropack: 2.13.4(better-sqlite3@12.5.0)(encoding@0.1.13)(oxc-parser@0.72.3)(srvx@0.11.15)(xml2js@0.6.2)
       nypm: 0.6.6
       ofetch: 1.5.1
       ohash: 2.0.11
@@ -52478,24 +51963,22 @@ snapshots:
     optionalDependencies:
       '@babel/code-frame': 7.29.7
 
-  rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.3)(rollup@4.60.2):
+  rollup-plugin-visualizer@6.0.11(rollup@4.60.2):
     dependencies:
       open: 8.4.2
       picomatch: 4.0.4
       source-map: 0.7.6
       yargs: 17.7.2
     optionalDependencies:
-      rolldown: 1.0.0-rc.3
       rollup: 4.60.2
 
-  rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.3)(rollup@4.60.2):
+  rollup-plugin-visualizer@7.0.1(rollup@4.60.2):
     dependencies:
       open: 11.0.0
       picomatch: 4.0.4
       source-map: 0.7.6
       yargs: 18.0.0
     optionalDependencies:
-      rolldown: 1.0.0-rc.3
       rollup: 4.60.2
 
   rollup@4.59.0:
@@ -53652,13 +53135,6 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.3):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.3
-    optionalDependencies:
-      '@babel/core': 7.28.5
-
   styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@19.2.3):
     dependencies:
       client-only: 0.0.1
@@ -54714,7 +54190,7 @@ snapshots:
       unplugin: 2.3.11
       unplugin-utils: 0.3.1
 
-  unimport@6.3.0(oxc-parser@0.72.3)(rolldown@1.0.0-rc.3):
+  unimport@6.3.0(oxc-parser@0.72.3):
     dependencies:
       acorn: 8.16.0
       escape-string-regexp: 5.0.0
@@ -54732,7 +54208,6 @@ snapshots:
       unplugin-utils: 0.3.1
     optionalDependencies:
       oxc-parser: 0.72.3
-      rolldown: 1.0.0-rc.3
 
   unist-builder@4.0.0:
     dependencies:
@@ -55058,8 +54533,6 @@ snapshots:
   uuid@7.0.3: {}
 
   uuid@8.3.2: {}
-
-  uuid@9.0.1: {}
 
   uvu@0.5.6:
     dependencies:
@@ -56098,7 +55571,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.1: {}
 
-  vue-component-type-helpers@3.3.6: {}
+  vue-component-type-helpers@3.3.7: {}
 
   vue-devtools-stub@0.1.0: {}
 
@@ -56166,6 +55639,17 @@ snapshots:
       '@vue/shared': 3.5.34
     optionalDependencies:
       typescript: 5.8.2
+
+  vue@3.5.34(typescript@5.9.2):
+    dependencies:
+      '@vue/compiler-dom': 3.5.34
+      '@vue/compiler-sfc': 3.5.34
+      '@vue/runtime-dom': 3.5.34
+      '@vue/server-renderer': 3.5.34(vue@3.5.34(typescript@5.9.2))
+      '@vue/shared': 3.5.34
+    optionalDependencies:
+      typescript: 5.9.2
+    optional: true
 
   vue@3.5.34(typescript@5.9.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,13 +342,16 @@ importers:
         version: 0.8.3(signal-polyfill@0.2.2)
       '@ag-ui/a2a':
         specifier: ^0.0.6
-        version: 0.0.6(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@ag-ui/core@0.0.59-canary.1785518626.0)
+        version: 0.0.6(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@ag-ui/core@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350)
       '@ag-ui/a2a-middleware':
         specifier: ^0.0.2
         version: 0.0.2(rxjs@7.8.1)
       '@ag-ui/client':
         specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
         version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+      '@ag-ui/core':
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@ag-ui/mcp-apps-middleware':
         specifier: ^0.0.1
         version: 0.0.1(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
@@ -1316,9 +1319,15 @@ importers:
 
   examples/v2/angular/demo-server:
     dependencies:
+      '@ag-ui/client':
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+      '@ag-ui/core':
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@ag-ui/langgraph':
         specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350
-        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@ag-ui/core@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))
       '@ai-sdk/openai':
         specifier: 3.0.36
         version: 3.0.36(zod@3.25.76)
@@ -2027,12 +2036,15 @@ importers:
 
   examples/v2/vue/demo:
     dependencies:
+      '@ag-ui/client':
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@ag-ui/core':
         specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
         version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@ag-ui/mcp-apps-middleware':
         specifier: 0.0.2
-        version: 0.0.2(@ag-ui/client@0.0.59-canary.1785518626.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
+        version: 0.0.2(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../../../../packages/core
@@ -3412,9 +3424,15 @@ importers:
 
   packages/sdk-js:
     dependencies:
+      '@ag-ui/client':
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+      '@ag-ui/core':
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@ag-ui/langgraph':
         specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350
-        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@ag-ui/core@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
       '@copilotkit/shared':
         specifier: workspace:*
         version: link:../shared
@@ -3988,15 +4006,9 @@ packages:
   '@ag-ui/client@0.0.53':
     resolution: {integrity: sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==}
 
-  '@ag-ui/client@0.0.59-canary.1785518626.0':
-    resolution: {integrity: sha512-BImvzllJOLCX114ELiswr4pnDFtKFbeK5SbSg8fHyfsxS0pINlhoHogWwau108foZriF73rxIVPviK3IfxYFVQ==}
-
   '@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350':
     resolution: {tarball: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350}
     version: 0.0.58
-
-  '@ag-ui/core@0.0.59-canary.1785518626.0':
-    resolution: {integrity: sha512-M+CK6GPqAKazEoN0H3R41Nous8F92t5sw5WymFld+WpWyrPWw5u/GHAgyrLsISJ0DOPvutaM74VMJFDfWVHxZg==}
 
   '@ag-ui/core@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350':
     resolution: {tarball: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350}
@@ -25600,11 +25612,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ag-ui/a2a@0.0.6(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@ag-ui/core@0.0.59-canary.1785518626.0)':
+  '@ag-ui/a2a@0.0.6(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@ag-ui/core@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350)':
     dependencies:
       '@a2a-js/sdk': 0.2.5
       '@ag-ui/client': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
-      '@ag-ui/core': 0.0.59-canary.1785518626.0
+      '@ag-ui/core': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       rxjs: 7.8.1
     transitivePeerDependencies:
       - supports-color
@@ -25633,19 +25645,6 @@ snapshots:
       uuid: 11.1.0
       zod: 3.25.76
 
-  '@ag-ui/client@0.0.59-canary.1785518626.0':
-    dependencies:
-      '@ag-ui/core': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
-      '@ag-ui/encoder': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/encoder@2350
-      '@ag-ui/proto': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/proto@2350
-      '@types/uuid': 10.0.0
-      compare-versions: 6.1.1
-      fast-json-patch: 3.1.1
-      rxjs: 7.8.1
-      untruncate-json: 0.0.1
-      uuid: 11.1.0
-      zod: 3.25.76
-
   '@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350':
     dependencies:
       '@ag-ui/core': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
@@ -25659,10 +25658,6 @@ snapshots:
       uuid: 11.1.0
       zod: 3.25.76
 
-  '@ag-ui/core@0.0.59-canary.1785518626.0':
-    dependencies:
-      zod: 3.25.76
-
   '@ag-ui/core@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350':
     dependencies:
       zod: 3.25.76
@@ -25671,50 +25666,6 @@ snapshots:
     dependencies:
       '@ag-ui/core': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@ag-ui/proto': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/proto@2350
-
-  '@ag-ui/langgraph@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
-    dependencies:
-      '@ag-ui/a2ui-toolkit': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/a2ui-toolkit@3b6c5c76847797163beec3cf6f87559733549051
-      '@ag-ui/client': 0.0.59-canary.1785518626.0
-      '@ag-ui/core': 0.0.59-canary.1785518626.0
-      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
-      '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))
-      langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
-      partial-json: 0.1.7
-      rxjs: 7.8.1
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - openai
-      - react
-      - react-dom
-      - svelte
-      - vue
-      - ws
-      - zod-to-json-schema
-
-  '@ag-ui/langgraph@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))':
-    dependencies:
-      '@ag-ui/a2ui-toolkit': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/a2ui-toolkit@3b6c5c76847797163beec3cf6f87559733549051
-      '@ag-ui/client': 0.0.59-canary.1785518626.0
-      '@ag-ui/core': 0.0.59-canary.1785518626.0
-      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
-      '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))
-      langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0))(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))
-      partial-json: 0.1.7
-      rxjs: 7.8.1
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - openai
-      - react
-      - react-dom
-      - svelte
-      - vue
-      - ws
-      - zod-to-json-schema
 
   '@ag-ui/langgraph@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@ag-ui/core@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
@@ -25738,19 +25689,53 @@ snapshots:
       - ws
       - zod-to-json-schema
 
+  '@ag-ui/langgraph@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@ag-ui/core@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
+    dependencies:
+      '@ag-ui/a2ui-toolkit': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/a2ui-toolkit@3b6c5c76847797163beec3cf6f87559733549051
+      '@ag-ui/client': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+      '@ag-ui/core': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))
+      langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
+      partial-json: 0.1.7
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
+      - svelte
+      - vue
+      - ws
+      - zod-to-json-schema
+
+  '@ag-ui/langgraph@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@ag-ui/core@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))':
+    dependencies:
+      '@ag-ui/a2ui-toolkit': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/a2ui-toolkit@3b6c5c76847797163beec3cf6f87559733549051
+      '@ag-ui/client': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+      '@ag-ui/core': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))
+      langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0))(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))
+      partial-json: 0.1.7
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
+      - svelte
+      - vue
+      - ws
+      - zod-to-json-schema
+
   '@ag-ui/mcp-apps-middleware@0.0.1(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
     dependencies:
       '@ag-ui/client': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
-      rxjs: 7.8.1
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-      - zod
-
-  '@ag-ui/mcp-apps-middleware@0.0.2(@ag-ui/client@0.0.59-canary.1785518626.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
-    dependencies:
-      '@ag-ui/client': 0.0.59-canary.1785518626.0
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       rxjs: 7.8.1
     transitivePeerDependencies:
@@ -43122,8 +43107,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.8
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.2(jiti@2.7.0))
@@ -43142,8 +43127,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.9
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.2(jiti@2.7.0))
@@ -43165,6 +43150,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3(supports-color@5.5.0)
+      eslint: 9.39.2(jiti@2.7.0)
+      get-tsconfig: 4.13.6
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -43180,21 +43180,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.2(jiti@2.7.0)
-      get-tsconfig: 4.13.6
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.16
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-module-utils@2.12.1(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
@@ -43206,13 +43191,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -43245,7 +43230,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -43256,7 +43241,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,11 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@ag-ui/core': 0.0.59-canary.1784325892.0
-  '@ag-ui/client': 0.0.59-canary.1784325892.0
-  '@ag-ui/encoder': 0.0.59-canary.1784325892.0
-  '@ag-ui/proto': 0.0.59-canary.1784325892.0
-  '@ag-ui/langgraph': 0.0.43-canary.1784331649.0
+  '@ag-ui/core': 0.0.59-canary.1785518626.0
+  '@ag-ui/client': 0.0.59-canary.1785518626.0
+  '@ag-ui/encoder': 0.0.59-canary.1785518626.0
+  '@ag-ui/proto': 0.0.59-canary.1785518626.0
+  '@ag-ui/langgraph': 0.0.43-canary.1785518626.0
   '@ag-ui/mcp-middleware>@ag-ui/client': 0.0.53
   streamdown>react: ^19.0.0
   '@types/react': 19.1.8
@@ -342,16 +342,16 @@ importers:
         version: 0.8.3(signal-polyfill@0.2.2)
       '@ag-ui/a2a':
         specifier: ^0.0.6
-        version: 0.0.6(@ag-ui/client@0.0.59-canary.1784325892.0)(@ag-ui/core@0.0.59-canary.1784325892.0)
+        version: 0.0.6(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)
       '@ag-ui/a2a-middleware':
         specifier: ^0.0.2
         version: 0.0.2(rxjs@7.8.1)
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@ag-ui/mcp-apps-middleware':
         specifier: ^0.0.1
-        version: 0.0.1(@ag-ui/client@0.0.59-canary.1784325892.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
+        version: 0.0.1(@ag-ui/client@0.0.59-canary.1785518626.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
       '@copilotkit/a2ui-renderer':
         specifier: workspace:*
         version: link:../../../packages/a2ui-renderer
@@ -1181,17 +1181,17 @@ importers:
         specifier: 0.9.0
         version: 0.9.0
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@ag-ui/encoder':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@ag-ui/proto':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@angular/animations':
         specifier: ^21.2.15
         version: 21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1))
@@ -1317,8 +1317,8 @@ importers:
   examples/v2/angular/demo-server:
     dependencies:
       '@ag-ui/langgraph':
-        specifier: 0.0.43-canary.1784331649.0
-        version: 0.0.43-canary.1784331649.0(@ag-ui/client@0.0.59-canary.1784325892.0)(@ag-ui/core@0.0.59-canary.1784325892.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))
+        specifier: 0.0.43-canary.1785518626.0
+        version: 0.0.43-canary.1785518626.0(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))
       '@ai-sdk/openai':
         specifier: 3.0.36
         version: 3.0.36(zod@3.25.76)
@@ -1348,8 +1348,8 @@ importers:
   examples/v2/angular/storybook:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@angular/animations':
         specifier: ^21.2.15
         version: 21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1))
@@ -1771,11 +1771,11 @@ importers:
   examples/v2/react/demo:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@ag-ui/mcp-apps-middleware':
         specifier: 0.0.2
-        version: 0.0.2(@ag-ui/client@0.0.59-canary.1784325892.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
+        version: 0.0.2(@ag-ui/client@0.0.59-canary.1785518626.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: 3.0.36
         version: 3.0.36(zod@3.25.76)
@@ -2028,11 +2028,11 @@ importers:
   examples/v2/vue/demo:
     dependencies:
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@ag-ui/mcp-apps-middleware':
         specifier: 0.0.2
-        version: 0.0.2(@ag-ui/client@0.0.59-canary.1784325892.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
+        version: 0.0.2(@ag-ui/client@0.0.59-canary.1785518626.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../../../../packages/core
@@ -2108,8 +2108,8 @@ importers:
         version: 3.5.34(typescript@5.8.2)
     devDependencies:
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@copilotkit/typescript-config':
         specifier: workspace:*
         version: link:../../../../packages/typescript-config
@@ -2193,8 +2193,8 @@ importers:
   packages/agentcore-runner:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@copilotkit/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -2221,11 +2221,11 @@ importers:
   packages/angular:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@copilotkit/a2ui-renderer':
         specifier: workspace:*
         version: link:../a2ui-renderer
@@ -2363,11 +2363,11 @@ importers:
   packages/bot:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@copilotkit/bot-ui':
         specifier: workspace:~
         version: link:../bot-ui
@@ -2400,8 +2400,8 @@ importers:
   packages/bot-discord:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@copilotkit/bot':
         specifier: workspace:*
         version: link:../bot
@@ -2431,11 +2431,11 @@ importers:
   packages/bot-slack:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@copilotkit/bot':
         specifier: workspace:~
         version: link:../bot
@@ -2483,11 +2483,11 @@ importers:
   packages/bot-teams:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@copilotkit/bot':
         specifier: workspace:~
         version: link:../bot
@@ -2538,8 +2538,8 @@ importers:
   packages/bot-telegram:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@copilotkit/bot':
         specifier: workspace:~
         version: link:../bot
@@ -2588,8 +2588,8 @@ importers:
   packages/bot-whatsapp:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@copilotkit/bot':
         specifier: workspace:~
         version: link:../bot
@@ -2613,8 +2613,8 @@ importers:
   packages/core:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@copilotkit/shared':
         specifier: workspace:*
         version: link:../shared
@@ -2671,8 +2671,8 @@ importers:
   packages/demo-agents:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       openai:
         specifier: ^4.85.1
         version: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
@@ -2699,11 +2699,11 @@ importers:
   packages/react-core:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@copilotkit/a2ui-renderer':
         specifier: workspace:*
         version: link:../a2ui-renderer
@@ -2871,8 +2871,8 @@ importers:
   packages/react-native:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -3127,22 +3127,22 @@ importers:
     dependencies:
       '@ag-ui/a2ui-middleware':
         specifier: 0.0.10
-        version: 0.0.10(@ag-ui/client@0.0.59-canary.1784325892.0)(rxjs@7.8.1)
+        version: 0.0.10(@ag-ui/client@0.0.59-canary.1785518626.0)(rxjs@7.8.1)
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@ag-ui/encoder':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@ag-ui/langgraph':
-        specifier: 0.0.43-canary.1784331649.0
-        version: 0.0.43-canary.1784331649.0(@ag-ui/client@0.0.59-canary.1784325892.0)(@ag-ui/core@0.0.59-canary.1784325892.0)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
+        specifier: 0.0.43-canary.1785518626.0
+        version: 0.0.43-canary.1785518626.0(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
       '@ag-ui/mcp-apps-middleware':
         specifier: 0.0.3
-        version: 0.0.3(@ag-ui/client@0.0.59-canary.1784325892.0)(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+        version: 0.0.3(@ag-ui/client@0.0.59-canary.1785518626.0)(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@ag-ui/mcp-middleware':
         specifier: 0.0.1
         version: 0.0.1(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
@@ -3413,8 +3413,8 @@ importers:
   packages/sdk-js:
     dependencies:
       '@ag-ui/langgraph':
-        specifier: 0.0.43-canary.1784331649.0
-        version: 0.0.43-canary.1784331649.0(@ag-ui/client@0.0.59-canary.1784325892.0)(@ag-ui/core@0.0.59-canary.1784325892.0)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
+        specifier: 0.0.43-canary.1785518626.0
+        version: 0.0.43-canary.1785518626.0(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
       '@copilotkit/shared':
         specifier: workspace:*
         version: link:../shared
@@ -3471,11 +3471,11 @@ importers:
   packages/shared:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@copilotkit/license-verifier':
         specifier: ~0.5.0
         version: 0.5.0
@@ -3535,8 +3535,8 @@ importers:
   packages/sqlite-runner:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@copilotkit/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -3607,11 +3607,11 @@ importers:
         specifier: 0.9.0
         version: 0.9.0
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -3761,8 +3761,8 @@ importers:
   packages/web-inspector:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1784325892.0
-        version: 0.0.59-canary.1784325892.0
+        specifier: 0.0.59-canary.1785518626.0
+        version: 0.0.59-canary.1785518626.0
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -3967,13 +3967,13 @@ packages:
   '@ag-ui/a2a@0.0.6':
     resolution: {integrity: sha512-wvrBXU6214wuC5O+FBy7QiZFvobIlt3Lo0Ph2N+hBkeaBjPHvmMp/egIg4k9WyB60PzKjJDv5o21WxbvaYtzCw==}
     peerDependencies:
-      '@ag-ui/client': 0.0.59-canary.1784325892.0
-      '@ag-ui/core': 0.0.59-canary.1784325892.0
+      '@ag-ui/client': 0.0.59-canary.1785518626.0
+      '@ag-ui/core': 0.0.59-canary.1785518626.0
 
   '@ag-ui/a2ui-middleware@0.0.10':
     resolution: {integrity: sha512-2BQFUQ9vJzUAQSR0dNW/ijhyH8KpiRWISSLTP6mIe6ENyQ2cM1/XLG38/Dcb69olcs36gtZADZzAQWcno5H6fA==}
     peerDependencies:
-      '@ag-ui/client': 0.0.59-canary.1784325892.0
+      '@ag-ui/client': 0.0.59-canary.1785518626.0
       rxjs: 7.8.1
 
   '@ag-ui/a2ui-toolkit@0.0.4':
@@ -3982,45 +3982,45 @@ packages:
   '@ag-ui/client@0.0.53':
     resolution: {integrity: sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==}
 
-  '@ag-ui/client@0.0.59-canary.1784325892.0':
-    resolution: {integrity: sha512-weXQrXCkBfH1zzwb0tRfXkZFBW0Pb0428/OGmyA4ypN5sNXL6Id7woH6CN7UeRQkNYT2+21Zau/Z87DU1ZWGdA==}
+  '@ag-ui/client@0.0.59-canary.1785518626.0':
+    resolution: {integrity: sha512-BImvzllJOLCX114ELiswr4pnDFtKFbeK5SbSg8fHyfsxS0pINlhoHogWwau108foZriF73rxIVPviK3IfxYFVQ==}
 
-  '@ag-ui/core@0.0.59-canary.1784325892.0':
-    resolution: {integrity: sha512-V21bv0EygcgTAyeNR8e39A5yHLGAwTQQW2ldxIhPL/Y27N6X/S04zc0kXlSlcaHqFOWdXA2qqa9vB5zBqBObUg==}
+  '@ag-ui/core@0.0.59-canary.1785518626.0':
+    resolution: {integrity: sha512-M+CK6GPqAKazEoN0H3R41Nous8F92t5sw5WymFld+WpWyrPWw5u/GHAgyrLsISJ0DOPvutaM74VMJFDfWVHxZg==}
 
-  '@ag-ui/encoder@0.0.59-canary.1784325892.0':
-    resolution: {integrity: sha512-LjruNlkwslb3B+y7totvafp/z22ou/EUW13XPreMbj50XvGG8fI9if/kSDajogCMJ8bDs2jjqvnJvQ3VNz3HMA==}
+  '@ag-ui/encoder@0.0.59-canary.1785518626.0':
+    resolution: {integrity: sha512-eI6BiMLm8DmDnTiK5o3eyqdcdoRpviWOfuY0srjnODdzQwdVHtohT+cFBBg9vvnbyhKF/4cG9+JypUV1gxVHtw==}
 
-  '@ag-ui/langgraph@0.0.43-canary.1784331649.0':
-    resolution: {integrity: sha512-z0RIe+6VrWJj1amMZOQvSzaBOnUfdEmzFfNo1v/eOhxH34hH1Jg/MjZjbqySZl96uqMwmdGnjzStrH/fhaO9hg==}
+  '@ag-ui/langgraph@0.0.43-canary.1785518626.0':
+    resolution: {integrity: sha512-Vg3YTussNW/sAcy4qo7sTvIwqoSO7UVgVIVgdmesBveuzMqxHb9+ApcPcDUaNOovh2rnLLYhcwXMcpTcGLZkkA==}
     peerDependencies:
-      '@ag-ui/client': 0.0.59-canary.1784325892.0
-      '@ag-ui/core': 0.0.59-canary.1784325892.0
+      '@ag-ui/client': 0.0.59-canary.1785518626.0
+      '@ag-ui/core': 0.0.59-canary.1785518626.0
 
   '@ag-ui/mcp-apps-middleware@0.0.1':
     resolution: {integrity: sha512-GndsrxBr12Ji/Ioa4zYALbmEGD7cglExIwL7wlco3/PVyqk1WsjybxRNyDj+p9NQh2HJ3s/ctEJWGxwVUyC+fw==}
     peerDependencies:
-      '@ag-ui/client': 0.0.59-canary.1784325892.0
+      '@ag-ui/client': 0.0.59-canary.1785518626.0
       rxjs: 7.8.1
 
   '@ag-ui/mcp-apps-middleware@0.0.2':
     resolution: {integrity: sha512-EMHm65hs3aNfoCpxZ1RYDLvZejmit0yipvzg39jwKrGTzqvB3CZuZUenDS9o2eWu2PZIvcFuvU15nEwH7SZb8A==}
     peerDependencies:
-      '@ag-ui/client': 0.0.59-canary.1784325892.0
+      '@ag-ui/client': 0.0.59-canary.1785518626.0
       rxjs: 7.8.1
 
   '@ag-ui/mcp-apps-middleware@0.0.3':
     resolution: {integrity: sha512-Z+NZQXj4J+Y/2PLNsiyhNzRWFtTT2sAoC5dztoAlIsdfzvLvYEa52YGdHesNTN85JJqaIrYxQ8e31IBpKjrnoA==}
     peerDependencies:
-      '@ag-ui/client': 0.0.59-canary.1784325892.0
+      '@ag-ui/client': 0.0.59-canary.1785518626.0
 
   '@ag-ui/mcp-middleware@0.0.1':
     resolution: {integrity: sha512-TayUu7kB+jXUTPRUJesNvJYrP+0weTL9F2VJJ8QQ4sWxY/Ihjo+GgFYgJZYNcLwbo1DKgmVJtdm2XUouPCbxeg==}
     peerDependencies:
       rxjs: 7.8.1
 
-  '@ag-ui/proto@0.0.59-canary.1784325892.0':
-    resolution: {integrity: sha512-t1Wf6XHWVsElkKeyy6arYjLGc0CstBhUYVF0iPakaiSKMVZZj9RsgjmINdn8N/PmViKHxIoddHY8sly3vwWa3Q==}
+  '@ag-ui/proto@0.0.59-canary.1785518626.0':
+    resolution: {integrity: sha512-13ggjeCUwdk5RQEto6hrPyDTWF+GaudM0zekcUSmWuybIN5lFoH8OPlAA3c87Msu1Sv5LGAl61IxJtO0lGzwnA==}
 
   '@ai-sdk/anthropic@2.0.71':
     resolution: {integrity: sha512-JXTtAwlyxGzzRtpiAXk/O93aOTgdfoVX28EoUuRNVqZRgtkoniLQTtqeb8uZ4oXljNJlXzaJLNasS/U90w/wjw==}
@@ -24918,8 +24918,8 @@ packages:
   vue-component-type-helpers@3.3.1:
     resolution: {integrity: sha512-pu58kqxmVyEH6VfNYW1UyEfR3XAnJ27ZXT3yzXxxpjLxVzAbyC35Zk/nm/RMs7ijWnJNSd9fWkeex2OhUsx3MA==}
 
-  vue-component-type-helpers@3.3.7:
-    resolution: {integrity: sha512-Skkhw9agYSgsWqv7bxSOGJZa9SaiJbZVGdXuFWnrzKaQYHnw9qbjD630rw6RyMqDbp54nfLCLw5SZA55if7JLg==}
+  vue-component-type-helpers@3.3.8:
+    resolution: {integrity: sha512-troqCMmQodQDqUqn63NQaFi+CDSclSe7sc8VEBFqf5GFLqmGR2Ph3P2WEC7qwpRVyEWsTi/aAr4vyOe/B1hU3g==}
 
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
@@ -25573,26 +25573,26 @@ snapshots:
   '@ag-ui/a2a-middleware@0.0.2(rxjs@7.8.1)':
     dependencies:
       '@a2a-js/sdk': 0.2.5
-      '@ag-ui/client': 0.0.59-canary.1784325892.0
+      '@ag-ui/client': 0.0.59-canary.1785518626.0
       ai: 6.0.156(zod@3.25.76)
       rxjs: 7.8.1
       zod: 3.25.76
     transitivePeerDependencies:
       - supports-color
 
-  '@ag-ui/a2a@0.0.6(@ag-ui/client@0.0.59-canary.1784325892.0)(@ag-ui/core@0.0.59-canary.1784325892.0)':
+  '@ag-ui/a2a@0.0.6(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)':
     dependencies:
       '@a2a-js/sdk': 0.2.5
-      '@ag-ui/client': 0.0.59-canary.1784325892.0
-      '@ag-ui/core': 0.0.59-canary.1784325892.0
+      '@ag-ui/client': 0.0.59-canary.1785518626.0
+      '@ag-ui/core': 0.0.59-canary.1785518626.0
       rxjs: 7.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ag-ui/a2ui-middleware@0.0.10(@ag-ui/client@0.0.59-canary.1784325892.0)(rxjs@7.8.1)':
+  '@ag-ui/a2ui-middleware@0.0.10(@ag-ui/client@0.0.59-canary.1785518626.0)(rxjs@7.8.1)':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.4
-      '@ag-ui/client': 0.0.59-canary.1784325892.0
+      '@ag-ui/client': 0.0.59-canary.1785518626.0
       clarinet: 0.12.6
       rxjs: 7.8.1
 
@@ -25600,9 +25600,9 @@ snapshots:
 
   '@ag-ui/client@0.0.53':
     dependencies:
-      '@ag-ui/core': 0.0.59-canary.1784325892.0
-      '@ag-ui/encoder': 0.0.59-canary.1784325892.0
-      '@ag-ui/proto': 0.0.59-canary.1784325892.0
+      '@ag-ui/core': 0.0.59-canary.1785518626.0
+      '@ag-ui/encoder': 0.0.59-canary.1785518626.0
+      '@ag-ui/proto': 0.0.59-canary.1785518626.0
       '@types/uuid': 10.0.0
       compare-versions: 6.1.1
       fast-json-patch: 3.1.1
@@ -25611,11 +25611,11 @@ snapshots:
       uuid: 11.1.0
       zod: 3.25.76
 
-  '@ag-ui/client@0.0.59-canary.1784325892.0':
+  '@ag-ui/client@0.0.59-canary.1785518626.0':
     dependencies:
-      '@ag-ui/core': 0.0.59-canary.1784325892.0
-      '@ag-ui/encoder': 0.0.59-canary.1784325892.0
-      '@ag-ui/proto': 0.0.59-canary.1784325892.0
+      '@ag-ui/core': 0.0.59-canary.1785518626.0
+      '@ag-ui/encoder': 0.0.59-canary.1785518626.0
+      '@ag-ui/proto': 0.0.59-canary.1785518626.0
       '@types/uuid': 10.0.0
       compare-versions: 6.1.1
       fast-json-patch: 3.1.1
@@ -25624,20 +25624,20 @@ snapshots:
       uuid: 11.1.0
       zod: 3.25.76
 
-  '@ag-ui/core@0.0.59-canary.1784325892.0':
+  '@ag-ui/core@0.0.59-canary.1785518626.0':
     dependencies:
       zod: 3.25.76
 
-  '@ag-ui/encoder@0.0.59-canary.1784325892.0':
+  '@ag-ui/encoder@0.0.59-canary.1785518626.0':
     dependencies:
-      '@ag-ui/core': 0.0.59-canary.1784325892.0
-      '@ag-ui/proto': 0.0.59-canary.1784325892.0
+      '@ag-ui/core': 0.0.59-canary.1785518626.0
+      '@ag-ui/proto': 0.0.59-canary.1785518626.0
 
-  '@ag-ui/langgraph@0.0.43-canary.1784331649.0(@ag-ui/client@0.0.59-canary.1784325892.0)(@ag-ui/core@0.0.59-canary.1784325892.0)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
+  '@ag-ui/langgraph@0.0.43-canary.1785518626.0(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.4
-      '@ag-ui/client': 0.0.59-canary.1784325892.0
-      '@ag-ui/core': 0.0.59-canary.1784325892.0
+      '@ag-ui/client': 0.0.59-canary.1785518626.0
+      '@ag-ui/core': 0.0.59-canary.1785518626.0
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))
       langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
@@ -25655,11 +25655,11 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  '@ag-ui/langgraph@0.0.43-canary.1784331649.0(@ag-ui/client@0.0.59-canary.1784325892.0)(@ag-ui/core@0.0.59-canary.1784325892.0)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
+  '@ag-ui/langgraph@0.0.43-canary.1785518626.0(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.4
-      '@ag-ui/client': 0.0.59-canary.1784325892.0
-      '@ag-ui/core': 0.0.59-canary.1784325892.0
+      '@ag-ui/client': 0.0.59-canary.1785518626.0
+      '@ag-ui/core': 0.0.59-canary.1785518626.0
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))
       langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
@@ -25677,11 +25677,11 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  '@ag-ui/langgraph@0.0.43-canary.1784331649.0(@ag-ui/client@0.0.59-canary.1784325892.0)(@ag-ui/core@0.0.59-canary.1784325892.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))':
+  '@ag-ui/langgraph@0.0.43-canary.1785518626.0(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.4
-      '@ag-ui/client': 0.0.59-canary.1784325892.0
-      '@ag-ui/core': 0.0.59-canary.1784325892.0
+      '@ag-ui/client': 0.0.59-canary.1785518626.0
+      '@ag-ui/core': 0.0.59-canary.1785518626.0
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))
       langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0))(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))
@@ -25699,9 +25699,9 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  '@ag-ui/mcp-apps-middleware@0.0.1(@ag-ui/client@0.0.59-canary.1784325892.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
+  '@ag-ui/mcp-apps-middleware@0.0.1(@ag-ui/client@0.0.59-canary.1785518626.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
     dependencies:
-      '@ag-ui/client': 0.0.59-canary.1784325892.0
+      '@ag-ui/client': 0.0.59-canary.1785518626.0
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       rxjs: 7.8.1
     transitivePeerDependencies:
@@ -25709,9 +25709,9 @@ snapshots:
       - supports-color
       - zod
 
-  '@ag-ui/mcp-apps-middleware@0.0.2(@ag-ui/client@0.0.59-canary.1784325892.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
+  '@ag-ui/mcp-apps-middleware@0.0.2(@ag-ui/client@0.0.59-canary.1785518626.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
     dependencies:
-      '@ag-ui/client': 0.0.59-canary.1784325892.0
+      '@ag-ui/client': 0.0.59-canary.1785518626.0
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       rxjs: 7.8.1
     transitivePeerDependencies:
@@ -25719,9 +25719,9 @@ snapshots:
       - supports-color
       - zod
 
-  '@ag-ui/mcp-apps-middleware@0.0.3(@ag-ui/client@0.0.59-canary.1784325892.0)(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+  '@ag-ui/mcp-apps-middleware@0.0.3(@ag-ui/client@0.0.59-canary.1785518626.0)(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@ag-ui/client': 0.0.59-canary.1784325892.0
+      '@ag-ui/client': 0.0.59-canary.1785518626.0
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       rxjs: 7.8.1
     transitivePeerDependencies:
@@ -25739,9 +25739,9 @@ snapshots:
       - supports-color
       - zod
 
-  '@ag-ui/proto@0.0.59-canary.1784325892.0':
+  '@ag-ui/proto@0.0.59-canary.1785518626.0':
     dependencies:
-      '@ag-ui/core': 0.0.59-canary.1784325892.0
+      '@ag-ui/core': 0.0.59-canary.1785518626.0
       '@bufbuild/protobuf': 2.11.0
       '@protobuf-ts/protoc': 2.11.1
 
@@ -37844,7 +37844,7 @@ snapshots:
       storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.34(typescript@5.8.2)
-      vue-component-type-helpers: 3.3.7
+      vue-component-type-helpers: 3.3.8
 
   '@swc/core-darwin-arm64@1.15.8':
     optional: true
@@ -38179,13 +38179,13 @@ snapshots:
 
   '@tanstack/ai@0.14.0':
     dependencies:
-      '@ag-ui/core': 0.0.59-canary.1784325892.0
+      '@ag-ui/core': 0.0.59-canary.1785518626.0
       '@tanstack/ai-event-client': 0.2.8(@tanstack/ai@0.14.0)
       partial-json: 0.1.7
 
   '@tanstack/ai@0.31.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@ag-ui/core': 0.0.59-canary.1784325892.0
+      '@ag-ui/core': 0.0.59-canary.1785518626.0
       '@standard-schema/spec': 1.1.0
       '@tanstack/ai-event-client': 0.6.2(@tanstack/ai@0.31.0(@opentelemetry/api@1.9.0))
       partial-json: 0.1.7
@@ -38194,7 +38194,7 @@ snapshots:
 
   '@tanstack/ai@0.32.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@ag-ui/core': 0.0.59-canary.1784325892.0
+      '@ag-ui/core': 0.0.59-canary.1785518626.0
       '@standard-schema/spec': 1.1.0
       '@tanstack/ai-event-client': 0.6.3(@tanstack/ai@0.32.0(@opentelemetry/api@1.9.0))
       partial-json: 0.1.7
@@ -55571,7 +55571,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.1: {}
 
-  vue-component-type-helpers@3.3.7: {}
+  vue-component-type-helpers@3.3.8: {}
 
   vue-devtools-stub@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,11 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@ag-ui/core': 0.0.59-canary.1785518626.0
-  '@ag-ui/client': 0.0.59-canary.1785518626.0
-  '@ag-ui/encoder': 0.0.59-canary.1785518626.0
-  '@ag-ui/proto': 0.0.59-canary.1785518626.0
-  '@ag-ui/langgraph': 0.0.43-canary.1785518626.0
+  '@ag-ui/core': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+  '@ag-ui/client': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+  '@ag-ui/encoder': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/encoder@2350
+  '@ag-ui/proto': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/proto@2350
+  '@ag-ui/langgraph': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350
   '@ag-ui/mcp-middleware>@ag-ui/client': 0.0.53
   streamdown>react: ^19.0.0
   '@types/react': 19.1.8
@@ -342,16 +342,16 @@ importers:
         version: 0.8.3(signal-polyfill@0.2.2)
       '@ag-ui/a2a':
         specifier: ^0.0.6
-        version: 0.0.6(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)
+        version: 0.0.6(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@ag-ui/core@0.0.59-canary.1785518626.0)
       '@ag-ui/a2a-middleware':
         specifier: ^0.0.2
         version: 0.0.2(rxjs@7.8.1)
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@ag-ui/mcp-apps-middleware':
         specifier: ^0.0.1
-        version: 0.0.1(@ag-ui/client@0.0.59-canary.1785518626.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
+        version: 0.0.1(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
       '@copilotkit/a2ui-renderer':
         specifier: workspace:*
         version: link:../../../packages/a2ui-renderer
@@ -1181,17 +1181,17 @@ importers:
         specifier: 0.9.0
         version: 0.9.0
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@ag-ui/encoder':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/encoder@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/encoder@2350
       '@ag-ui/proto':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/proto@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/proto@2350
       '@angular/animations':
         specifier: ^21.2.15
         version: 21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1))
@@ -1317,8 +1317,8 @@ importers:
   examples/v2/angular/demo-server:
     dependencies:
       '@ag-ui/langgraph':
-        specifier: 0.0.43-canary.1785518626.0
-        version: 0.0.43-canary.1785518626.0(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))
       '@ai-sdk/openai':
         specifier: 3.0.36
         version: 3.0.36(zod@3.25.76)
@@ -1348,8 +1348,8 @@ importers:
   examples/v2/angular/storybook:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@angular/animations':
         specifier: ^21.2.15
         version: 21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1))
@@ -1771,11 +1771,11 @@ importers:
   examples/v2/react/demo:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@ag-ui/mcp-apps-middleware':
         specifier: 0.0.2
-        version: 0.0.2(@ag-ui/client@0.0.59-canary.1785518626.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
+        version: 0.0.2(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: 3.0.36
         version: 3.0.36(zod@3.25.76)
@@ -2028,8 +2028,8 @@ importers:
   examples/v2/vue/demo:
     dependencies:
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@ag-ui/mcp-apps-middleware':
         specifier: 0.0.2
         version: 0.0.2(@ag-ui/client@0.0.59-canary.1785518626.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
@@ -2108,8 +2108,8 @@ importers:
         version: 3.5.34(typescript@5.8.2)
     devDependencies:
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@copilotkit/typescript-config':
         specifier: workspace:*
         version: link:../../../../packages/typescript-config
@@ -2193,8 +2193,8 @@ importers:
   packages/agentcore-runner:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@copilotkit/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -2221,11 +2221,11 @@ importers:
   packages/angular:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@copilotkit/a2ui-renderer':
         specifier: workspace:*
         version: link:../a2ui-renderer
@@ -2363,11 +2363,11 @@ importers:
   packages/bot:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@copilotkit/bot-ui':
         specifier: workspace:~
         version: link:../bot-ui
@@ -2400,8 +2400,8 @@ importers:
   packages/bot-discord:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@copilotkit/bot':
         specifier: workspace:*
         version: link:../bot
@@ -2431,11 +2431,11 @@ importers:
   packages/bot-slack:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@copilotkit/bot':
         specifier: workspace:~
         version: link:../bot
@@ -2483,11 +2483,11 @@ importers:
   packages/bot-teams:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@copilotkit/bot':
         specifier: workspace:~
         version: link:../bot
@@ -2538,8 +2538,8 @@ importers:
   packages/bot-telegram:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@copilotkit/bot':
         specifier: workspace:~
         version: link:../bot
@@ -2588,8 +2588,8 @@ importers:
   packages/bot-whatsapp:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@copilotkit/bot':
         specifier: workspace:~
         version: link:../bot
@@ -2613,8 +2613,8 @@ importers:
   packages/core:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@copilotkit/shared':
         specifier: workspace:*
         version: link:../shared
@@ -2671,8 +2671,8 @@ importers:
   packages/demo-agents:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       openai:
         specifier: ^4.85.1
         version: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
@@ -2699,11 +2699,11 @@ importers:
   packages/react-core:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@copilotkit/a2ui-renderer':
         specifier: workspace:*
         version: link:../a2ui-renderer
@@ -2871,8 +2871,8 @@ importers:
   packages/react-native:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -3127,22 +3127,22 @@ importers:
     dependencies:
       '@ag-ui/a2ui-middleware':
         specifier: 0.0.10
-        version: 0.0.10(@ag-ui/client@0.0.59-canary.1785518626.0)(rxjs@7.8.1)
+        version: 0.0.10(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(rxjs@7.8.1)
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@ag-ui/encoder':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/encoder@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/encoder@2350
       '@ag-ui/langgraph':
-        specifier: 0.0.43-canary.1785518626.0
-        version: 0.0.43-canary.1785518626.0(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@ag-ui/core@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
       '@ag-ui/mcp-apps-middleware':
         specifier: 0.0.3
-        version: 0.0.3(@ag-ui/client@0.0.59-canary.1785518626.0)(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+        version: 0.0.3(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@ag-ui/mcp-middleware':
         specifier: 0.0.1
         version: 0.0.1(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
@@ -3413,8 +3413,8 @@ importers:
   packages/sdk-js:
     dependencies:
       '@ag-ui/langgraph':
-        specifier: 0.0.43-canary.1785518626.0
-        version: 0.0.43-canary.1785518626.0(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
       '@copilotkit/shared':
         specifier: workspace:*
         version: link:../shared
@@ -3471,11 +3471,11 @@ importers:
   packages/shared:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@copilotkit/license-verifier':
         specifier: ~0.5.0
         version: 0.5.0
@@ -3535,8 +3535,8 @@ importers:
   packages/sqlite-runner:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@copilotkit/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -3607,11 +3607,11 @@ importers:
         specifier: 0.9.0
         version: 0.9.0
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@ag-ui/core':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -3761,8 +3761,8 @@ importers:
   packages/web-inspector:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59-canary.1785518626.0
-        version: 0.0.59-canary.1785518626.0
+        specifier: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+        version: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -3966,18 +3966,24 @@ packages:
 
   '@ag-ui/a2a@0.0.6':
     resolution: {integrity: sha512-wvrBXU6214wuC5O+FBy7QiZFvobIlt3Lo0Ph2N+hBkeaBjPHvmMp/egIg4k9WyB60PzKjJDv5o21WxbvaYtzCw==}
+    version: 0.0.6
     peerDependencies:
-      '@ag-ui/client': 0.0.59-canary.1785518626.0
-      '@ag-ui/core': 0.0.59-canary.1785518626.0
+      '@ag-ui/client': '>=0.0.42'
+      '@ag-ui/core': '>=0.0.42'
 
   '@ag-ui/a2ui-middleware@0.0.10':
     resolution: {integrity: sha512-2BQFUQ9vJzUAQSR0dNW/ijhyH8KpiRWISSLTP6mIe6ENyQ2cM1/XLG38/Dcb69olcs36gtZADZzAQWcno5H6fA==}
+    version: 0.0.10
     peerDependencies:
-      '@ag-ui/client': 0.0.59-canary.1785518626.0
+      '@ag-ui/client': '>=0.0.40'
       rxjs: 7.8.1
 
   '@ag-ui/a2ui-toolkit@0.0.4':
     resolution: {integrity: sha512-9VPmgpCAsFVICk7z23kh+Kp/BwYMxw0D0KGjOiKXhm1MAH+Wid2iC3yKsXso+q7UZZiyhWgeDUSgaAkltyLmGg==}
+
+  '@ag-ui/a2ui-toolkit@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/a2ui-toolkit@3b6c5c76847797163beec3cf6f87559733549051':
+    resolution: {tarball: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/a2ui-toolkit@3b6c5c76847797163beec3cf6f87559733549051}
+    version: 0.0.4
 
   '@ag-ui/client@0.0.53':
     resolution: {integrity: sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==}
@@ -3985,42 +3991,56 @@ packages:
   '@ag-ui/client@0.0.59-canary.1785518626.0':
     resolution: {integrity: sha512-BImvzllJOLCX114ELiswr4pnDFtKFbeK5SbSg8fHyfsxS0pINlhoHogWwau108foZriF73rxIVPviK3IfxYFVQ==}
 
+  '@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350':
+    resolution: {tarball: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350}
+    version: 0.0.58
+
   '@ag-ui/core@0.0.59-canary.1785518626.0':
     resolution: {integrity: sha512-M+CK6GPqAKazEoN0H3R41Nous8F92t5sw5WymFld+WpWyrPWw5u/GHAgyrLsISJ0DOPvutaM74VMJFDfWVHxZg==}
 
-  '@ag-ui/encoder@0.0.59-canary.1785518626.0':
-    resolution: {integrity: sha512-eI6BiMLm8DmDnTiK5o3eyqdcdoRpviWOfuY0srjnODdzQwdVHtohT+cFBBg9vvnbyhKF/4cG9+JypUV1gxVHtw==}
+  '@ag-ui/core@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350':
+    resolution: {tarball: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350}
+    version: 0.0.58
 
-  '@ag-ui/langgraph@0.0.43-canary.1785518626.0':
-    resolution: {integrity: sha512-Vg3YTussNW/sAcy4qo7sTvIwqoSO7UVgVIVgdmesBveuzMqxHb9+ApcPcDUaNOovh2rnLLYhcwXMcpTcGLZkkA==}
+  '@ag-ui/encoder@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/encoder@2350':
+    resolution: {tarball: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/encoder@2350}
+    version: 0.0.57
+
+  '@ag-ui/langgraph@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350':
+    resolution: {tarball: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350}
+    version: 0.0.42
     peerDependencies:
-      '@ag-ui/client': 0.0.59-canary.1785518626.0
-      '@ag-ui/core': 0.0.59-canary.1785518626.0
+      '@ag-ui/client': '>=0.0.42'
+      '@ag-ui/core': '>=0.0.42'
 
   '@ag-ui/mcp-apps-middleware@0.0.1':
     resolution: {integrity: sha512-GndsrxBr12Ji/Ioa4zYALbmEGD7cglExIwL7wlco3/PVyqk1WsjybxRNyDj+p9NQh2HJ3s/ctEJWGxwVUyC+fw==}
+    version: 0.0.1
     peerDependencies:
-      '@ag-ui/client': 0.0.59-canary.1785518626.0
+      '@ag-ui/client': '>=0.0.40'
       rxjs: 7.8.1
 
   '@ag-ui/mcp-apps-middleware@0.0.2':
     resolution: {integrity: sha512-EMHm65hs3aNfoCpxZ1RYDLvZejmit0yipvzg39jwKrGTzqvB3CZuZUenDS9o2eWu2PZIvcFuvU15nEwH7SZb8A==}
+    version: 0.0.2
     peerDependencies:
-      '@ag-ui/client': 0.0.59-canary.1785518626.0
+      '@ag-ui/client': '>=0.0.40'
       rxjs: 7.8.1
 
   '@ag-ui/mcp-apps-middleware@0.0.3':
     resolution: {integrity: sha512-Z+NZQXj4J+Y/2PLNsiyhNzRWFtTT2sAoC5dztoAlIsdfzvLvYEa52YGdHesNTN85JJqaIrYxQ8e31IBpKjrnoA==}
+    version: 0.0.3
     peerDependencies:
-      '@ag-ui/client': 0.0.59-canary.1785518626.0
+      '@ag-ui/client': '>=0.0.40'
 
   '@ag-ui/mcp-middleware@0.0.1':
     resolution: {integrity: sha512-TayUu7kB+jXUTPRUJesNvJYrP+0weTL9F2VJJ8QQ4sWxY/Ihjo+GgFYgJZYNcLwbo1DKgmVJtdm2XUouPCbxeg==}
     peerDependencies:
       rxjs: 7.8.1
 
-  '@ag-ui/proto@0.0.59-canary.1785518626.0':
-    resolution: {integrity: sha512-13ggjeCUwdk5RQEto6hrPyDTWF+GaudM0zekcUSmWuybIN5lFoH8OPlAA3c87Msu1Sv5LGAl61IxJtO0lGzwnA==}
+  '@ag-ui/proto@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/proto@2350':
+    resolution: {tarball: https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/proto@2350}
+    version: 0.0.57
 
   '@ai-sdk/anthropic@2.0.71':
     resolution: {integrity: sha512-JXTtAwlyxGzzRtpiAXk/O93aOTgdfoVX28EoUuRNVqZRgtkoniLQTtqeb8uZ4oXljNJlXzaJLNasS/U90w/wjw==}
@@ -24918,8 +24938,8 @@ packages:
   vue-component-type-helpers@3.3.1:
     resolution: {integrity: sha512-pu58kqxmVyEH6VfNYW1UyEfR3XAnJ27ZXT3yzXxxpjLxVzAbyC35Zk/nm/RMs7ijWnJNSd9fWkeex2OhUsx3MA==}
 
-  vue-component-type-helpers@3.3.8:
-    resolution: {integrity: sha512-troqCMmQodQDqUqn63NQaFi+CDSclSe7sc8VEBFqf5GFLqmGR2Ph3P2WEC7qwpRVyEWsTi/aAr4vyOe/B1hU3g==}
+  vue-component-type-helpers@3.3.9:
+    resolution: {integrity: sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==}
 
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
@@ -25573,36 +25593,38 @@ snapshots:
   '@ag-ui/a2a-middleware@0.0.2(rxjs@7.8.1)':
     dependencies:
       '@a2a-js/sdk': 0.2.5
-      '@ag-ui/client': 0.0.59-canary.1785518626.0
+      '@ag-ui/client': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       ai: 6.0.156(zod@3.25.76)
       rxjs: 7.8.1
       zod: 3.25.76
     transitivePeerDependencies:
       - supports-color
 
-  '@ag-ui/a2a@0.0.6(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)':
+  '@ag-ui/a2a@0.0.6(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@ag-ui/core@0.0.59-canary.1785518626.0)':
     dependencies:
       '@a2a-js/sdk': 0.2.5
-      '@ag-ui/client': 0.0.59-canary.1785518626.0
+      '@ag-ui/client': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@ag-ui/core': 0.0.59-canary.1785518626.0
       rxjs: 7.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ag-ui/a2ui-middleware@0.0.10(@ag-ui/client@0.0.59-canary.1785518626.0)(rxjs@7.8.1)':
+  '@ag-ui/a2ui-middleware@0.0.10(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(rxjs@7.8.1)':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.4
-      '@ag-ui/client': 0.0.59-canary.1785518626.0
+      '@ag-ui/client': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       clarinet: 0.12.6
       rxjs: 7.8.1
 
   '@ag-ui/a2ui-toolkit@0.0.4': {}
 
+  '@ag-ui/a2ui-toolkit@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/a2ui-toolkit@3b6c5c76847797163beec3cf6f87559733549051': {}
+
   '@ag-ui/client@0.0.53':
     dependencies:
-      '@ag-ui/core': 0.0.59-canary.1785518626.0
-      '@ag-ui/encoder': 0.0.59-canary.1785518626.0
-      '@ag-ui/proto': 0.0.59-canary.1785518626.0
+      '@ag-ui/core': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+      '@ag-ui/encoder': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/encoder@2350
+      '@ag-ui/proto': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/proto@2350
       '@types/uuid': 10.0.0
       compare-versions: 6.1.1
       fast-json-patch: 3.1.1
@@ -25613,9 +25635,22 @@ snapshots:
 
   '@ag-ui/client@0.0.59-canary.1785518626.0':
     dependencies:
-      '@ag-ui/core': 0.0.59-canary.1785518626.0
-      '@ag-ui/encoder': 0.0.59-canary.1785518626.0
-      '@ag-ui/proto': 0.0.59-canary.1785518626.0
+      '@ag-ui/core': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+      '@ag-ui/encoder': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/encoder@2350
+      '@ag-ui/proto': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/proto@2350
+      '@types/uuid': 10.0.0
+      compare-versions: 6.1.1
+      fast-json-patch: 3.1.1
+      rxjs: 7.8.1
+      untruncate-json: 0.0.1
+      uuid: 11.1.0
+      zod: 3.25.76
+
+  '@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350':
+    dependencies:
+      '@ag-ui/core': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+      '@ag-ui/encoder': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/encoder@2350
+      '@ag-ui/proto': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/proto@2350
       '@types/uuid': 10.0.0
       compare-versions: 6.1.1
       fast-json-patch: 3.1.1
@@ -25628,36 +25663,18 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  '@ag-ui/encoder@0.0.59-canary.1785518626.0':
+  '@ag-ui/core@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350':
     dependencies:
-      '@ag-ui/core': 0.0.59-canary.1785518626.0
-      '@ag-ui/proto': 0.0.59-canary.1785518626.0
+      zod: 3.25.76
 
-  '@ag-ui/langgraph@0.0.43-canary.1785518626.0(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
+  '@ag-ui/encoder@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/encoder@2350':
     dependencies:
-      '@ag-ui/a2ui-toolkit': 0.0.4
-      '@ag-ui/client': 0.0.59-canary.1785518626.0
-      '@ag-ui/core': 0.0.59-canary.1785518626.0
-      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
-      '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))
-      langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
-      partial-json: 0.1.7
-      rxjs: 7.8.1
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - openai
-      - react
-      - react-dom
-      - svelte
-      - vue
-      - ws
-      - zod-to-json-schema
+      '@ag-ui/core': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+      '@ag-ui/proto': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/proto@2350
 
-  '@ag-ui/langgraph@0.0.43-canary.1785518626.0(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
+  '@ag-ui/langgraph@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
-      '@ag-ui/a2ui-toolkit': 0.0.4
+      '@ag-ui/a2ui-toolkit': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/a2ui-toolkit@3b6c5c76847797163beec3cf6f87559733549051
       '@ag-ui/client': 0.0.59-canary.1785518626.0
       '@ag-ui/core': 0.0.59-canary.1785518626.0
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
@@ -25677,9 +25694,9 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  '@ag-ui/langgraph@0.0.43-canary.1785518626.0(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))':
+  '@ag-ui/langgraph@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350(@ag-ui/client@0.0.59-canary.1785518626.0)(@ag-ui/core@0.0.59-canary.1785518626.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.2))':
     dependencies:
-      '@ag-ui/a2ui-toolkit': 0.0.4
+      '@ag-ui/a2ui-toolkit': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/a2ui-toolkit@3b6c5c76847797163beec3cf6f87559733549051
       '@ag-ui/client': 0.0.59-canary.1785518626.0
       '@ag-ui/core': 0.0.59-canary.1785518626.0
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
@@ -25699,9 +25716,31 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  '@ag-ui/mcp-apps-middleware@0.0.1(@ag-ui/client@0.0.59-canary.1785518626.0)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
+  '@ag-ui/langgraph@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/langgraph@2350(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@ag-ui/core@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
-      '@ag-ui/client': 0.0.59-canary.1785518626.0
+      '@ag-ui/a2ui-toolkit': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/a2ui-toolkit@3b6c5c76847797163beec3cf6f87559733549051
+      '@ag-ui/client': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+      '@ag-ui/core': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))
+      langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
+      partial-json: 0.1.7
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
+      - svelte
+      - vue
+      - ws
+      - zod-to-json-schema
+
+  '@ag-ui/mcp-apps-middleware@0.0.1(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
+    dependencies:
+      '@ag-ui/client': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       rxjs: 7.8.1
     transitivePeerDependencies:
@@ -25719,9 +25758,19 @@ snapshots:
       - supports-color
       - zod
 
-  '@ag-ui/mcp-apps-middleware@0.0.3(@ag-ui/client@0.0.59-canary.1785518626.0)(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+  '@ag-ui/mcp-apps-middleware@0.0.2(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
     dependencies:
-      '@ag-ui/client': 0.0.59-canary.1785518626.0
+      '@ag-ui/client': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - zod
+
+  '@ag-ui/mcp-apps-middleware@0.0.3(@ag-ui/client@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350)(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+    dependencies:
+      '@ag-ui/client': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/client@2350
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       rxjs: 7.8.1
     transitivePeerDependencies:
@@ -25739,9 +25788,9 @@ snapshots:
       - supports-color
       - zod
 
-  '@ag-ui/proto@0.0.59-canary.1785518626.0':
+  '@ag-ui/proto@https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/proto@2350':
     dependencies:
-      '@ag-ui/core': 0.0.59-canary.1785518626.0
+      '@ag-ui/core': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@bufbuild/protobuf': 2.11.0
       '@protobuf-ts/protoc': 2.11.1
 
@@ -37844,7 +37893,7 @@ snapshots:
       storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.34(typescript@5.8.2)
-      vue-component-type-helpers: 3.3.8
+      vue-component-type-helpers: 3.3.9
 
   '@swc/core-darwin-arm64@1.15.8':
     optional: true
@@ -38179,13 +38228,13 @@ snapshots:
 
   '@tanstack/ai@0.14.0':
     dependencies:
-      '@ag-ui/core': 0.0.59-canary.1785518626.0
+      '@ag-ui/core': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@tanstack/ai-event-client': 0.2.8(@tanstack/ai@0.14.0)
       partial-json: 0.1.7
 
   '@tanstack/ai@0.31.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@ag-ui/core': 0.0.59-canary.1785518626.0
+      '@ag-ui/core': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@standard-schema/spec': 1.1.0
       '@tanstack/ai-event-client': 0.6.2(@tanstack/ai@0.31.0(@opentelemetry/api@1.9.0))
       partial-json: 0.1.7
@@ -38194,7 +38243,7 @@ snapshots:
 
   '@tanstack/ai@0.32.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@ag-ui/core': 0.0.59-canary.1785518626.0
+      '@ag-ui/core': https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/core@2350
       '@standard-schema/spec': 1.1.0
       '@tanstack/ai-event-client': 0.6.3(@tanstack/ai@0.32.0(@opentelemetry/api@1.9.0))
       partial-json: 0.1.7
@@ -55571,7 +55620,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.1: {}
 
-  vue-component-type-helpers@3.3.8: {}
+  vue-component-type-helpers@3.3.9: {}
 
   vue-devtools-stub@0.1.0: {}
 


### PR DESCRIPTION
Draft. Adds subagent lifecycle tracking to CopilotKit core and a `useSubagent` hook.

- **`SubagentRegistry`** delegate on `CopilotKitCore` — tracks `SUBAGENT_STARTED/FINISHED/ERROR` per owning agent (modeled on `SuggestionEngine`; owns its own per-agent `agent.subscribe` like `StateManager`). Exposed via `getSubagents(agentId)` + an `onSubagentsChanged` subscription.
- **`useSubagent({ subagentRunId | subagentName, agentId? })`** (react-core v2) — resolves a message's `subagentRunId` to a friendly `name`, `description`, and running `status`. Warns once (dev) when a `subagentName` is ambiguous.

### Field name: `subagentRunId` (renamed from `subagentId`)

AG-UI renamed the attribution field because the old name implied a reusable subagent *definition* when the value identifies **one invocation** — two runs of the same subagent get two different values. See ag-ui-protocol/ag-ui#2350.

    subagentId       -> subagentRunId
    parentSubagentId -> parentSubagentRunId

Both sides of this package moved:

- **Reading the wire.** `SubagentRegistry` consumes `event.subagentRunId`. This part *had* to move: the events are typed as `SubagentStartedEvent` etc. from `@ag-ui/core`, so against the renamed protocol the old field is simply absent and the registry would silently stay empty — every lookup returning `undefined`, with no error.
- **This package's own API.** `useSubagent({ subagentRunId })` and `SubagentState.subagentRunId`. This is a **breaking change** to the hook, taken now because it has never shipped — it exists only on this branch, so there is no released consumer to migrate and no alias to maintain. It also makes the API self-consistent: the hook already distinguishes `subagentRunId` (exact, one invocation) from `subagentName` (the declared `subagent_type`, not unique), which is precisely the split the old name blurred.

### Dependency: consumed via pkg.pr.new (no @ag-ui release needed)

Requires the AG-UI subagent event schemas + `AgentSubscriber` callbacks. The `@ag-ui/*` overrides point at the **pkg.pr.new** preview of ag-ui-protocol/ag-ui#2350 (`https://pkg.pr.new/ag-ui-protocol/ag-ui/@ag-ui/*@2350`), which carries the rename — verified before pinning: that build's `@ag-ui/core` has 584 occurrences of `subagentRunId` and zero of `subagentId`.

All five overrides move together on purpose. `@ag-ui/langgraph` depends on `@ag-ui/client`, so leaving it on the old canary while `client` moves would resolve two incompatible copies of the same package.

**Reviewer notes:**
- `.npmrc` keeps `block-exotic-subdeps=true`. An earlier revision of this description said it was set to `false`; that is no longer the case and the guard does **not** need weakening. `pnpm install --frozen-lockfile` succeeds against the committed lockfile with the guard on; only a *fresh* re-resolution of the five `@ag-ui` packages needs `npm_config_block_exotic_subdeps=false` for that single run, because `@ag-ui/encoder` declares `@ag-ui/proto` and that now resolves via url.
- These are preview URLs from an unmerged PR, not durable artifacts, and the `@2350` tag tracks that PR's *latest* build — only the committed lockfile holds this to one specific artifact. Swap for a released version once ag-ui#2350 merges and ships.
- The registry and hook still have **no tests of their own**; the only subagent assertions live downstream in the AG-UI dojo demo. Worth adding before this leaves draft.
- This branch is ~1750 commits behind `main` and will need a rebase before merge.

Verified: `@copilotkit/core` and `@copilotkit/react-core` typecheck against the renamed protocol, and react-core's 1424 tests pass. The typecheck is load-bearing rather than incidental — injecting a deliberately wrong field name produces 5 TS errors, so a green check really does prove the field matches `@ag-ui/core`'s types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
