### PR TITLE
fix(showcase/langgraph-typescript): tree-kill agent so size-watchdog restart actually fires

### DIFF
--- a/showcase/integrations/langgraph-typescript/entrypoint.sh
+++ b/showcase/integrations/langgraph-typescript/entrypoint.sh
@@ -1,15 +1,6 @@
 #!/bin/bash
 set -e
 
-cleanup() {
-  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
-  # NOTE: SIZE_PID is intentionally NOT killed here.  SIZE_PID is assigned
-  # inside the watchdog subshell ( ) & so it is never visible in this outer
-  # shell.  The subshell registers its own EXIT trap to kill its SIZE_PID; see
-  # the "trap ... EXIT" inside the ( ) & block below.
-}
-trap cleanup EXIT
-
 # ---------------------------------------------------------------------------
 # Agent process-tree kill.
 #
@@ -29,6 +20,10 @@ trap cleanup EXIT
 # shell's process group, so a group kill would take out the whole entrypoint.
 # Instead we walk the process tree via /proc (node:22-slim ships neither
 # `ps` nor `pgrep`) and SIGKILL every descendant, deepest-first, then the root.
+#
+# Defined ABOVE cleanup() on purpose: cleanup() (the EXIT/SIGTERM trap) calls
+# _kill_agent_tree, so the helper must already exist whenever the trap can
+# first fire — including the early `exit 1` below if the agent fails to start.
 # ---------------------------------------------------------------------------
 _agent_descendants() {
   # Print all descendant PIDs of $1 (children, grandchildren, …), deepest-first.
@@ -55,6 +50,21 @@ _kill_agent_tree() {
   done
   kill -9 "$root" 2>/dev/null || true
 }
+
+cleanup() {
+  # Tree-kill the agent (not a bare `kill $AGENT_PID`): $AGENT_PID is the
+  # process-sub subshell, so a single-PID kill on the normal shutdown path
+  # (graceful exit / SIGTERM on every Railway redeploy/rollover) would reap
+  # only the subshell and ORPHAN the real npm→node server — reparented to
+  # PID 1, still holding :8123 across the restart.  See _kill_agent_tree.
+  _kill_agent_tree "$AGENT_PID"
+  kill $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+  # NOTE: SIZE_PID is intentionally NOT killed here.  SIZE_PID is assigned
+  # inside the watchdog subshell ( ) & so it is never visible in this outer
+  # shell.  The subshell registers its own EXIT trap to kill its SIZE_PID; see
+  # the "trap ... EXIT" inside the ( ) & block below.
+}
+trap cleanup EXIT
 
 # ---------------------------------------------------------------------------
 # Size-check seam: extract the per-cycle size-check-and-kill decision so it

--- a/showcase/integrations/langgraph-typescript/entrypoint.sh
+++ b/showcase/integrations/langgraph-typescript/entrypoint.sh
@@ -30,6 +30,18 @@ set -e
 _agent_descendants() {
   # Print all descendant PIDs of $1 (children, grandchildren, …), deepest-first.
   local root="$1" pid ppid stat
+  # Fail closed on a dangerous or meaningless root.  An empty / non-numeric root
+  # would make the PPID comparison below match nothing (harmless) but a root of
+  # "0" or "1" is catastrophic: "0" means "every process in the caller's process
+  # group" and "1" is init — a caller that then fed the result to a kill could
+  # wipe the whole container.  Refuse anything that is not an integer >= 2.
+  case "$root" in
+    ''|*[!0-9]*) echo "[proctree] WARNING: refusing descendant scan for non-numeric root '${root}'" >&2; return 0 ;;
+  esac
+  if [ "$root" -le 1 ]; then
+    echo "[proctree] WARNING: refusing descendant scan for reserved root ${root} (0=process-group, 1=init)" >&2
+    return 0
+  fi
   for pid in $(cd /proc 2>/dev/null && ls -d [0-9]* 2>/dev/null); do
     [ -r "/proc/$pid/stat" ] || continue
     # /proc/PID/stat is: "PID (comm) STATE PPID PGRP …". comm can contain
@@ -69,7 +81,20 @@ _kill_agent_tree() {
   # without job control (no ps/pgrep in node:22-slim; job control off in a
   # non-interactive script, so no process-group kill). The agent's npm→node tree
   # does not daemonize, so this loop covers the real failure surface.
+  #
+  # Fail closed on a dangerous or meaningless root, BEFORE any kill runs.  If the
+  # caller passes an empty / non-numeric PID, or the reserved 0 (SIGKILL to the
+  # WHOLE caller process group) or 1 (init), refuse outright — a bare `kill -9 0`
+  # here would SIGKILL the entire entrypoint.  This makes `kill -9 0`/`kill -9 1`
+  # structurally impossible regardless of what the caller passes.
   local root="$1" p descendants
+  case "$root" in
+    ''|*[!0-9]*) echo "[proctree] WARNING: refusing tree-kill for non-numeric PID '${root}'" >&2; return 0 ;;
+  esac
+  if [ "$root" -le 1 ]; then
+    echo "[proctree] WARNING: refusing tree-kill for reserved PID ${root} (0=process-group, 1=init)" >&2
+    return 0
+  fi
   for _ in 1 2 3 4 5; do
     descendants=$(_agent_descendants "$root")
     [ -z "$descendants" ] && break
@@ -81,6 +106,41 @@ _kill_agent_tree() {
   kill -9 "$root" 2>/dev/null || true
 }
 
+# ---------------------------------------------------------------------------
+# Numeric-config validator.
+#
+# Every operator-overridable numeric knob (size threshold, check intervals,
+# strike budgets, grace/timeout windows) is read from an env var with a `:-`
+# default.  A non-integer or empty override (e.g. LANGGRAPH_SIZE_CHECK_INTERVAL
+# ="60s") does NOT fall back to the default on its own — it propagates as a bad
+# value into an arithmetic test (`[ .. -ge .. ]`), a `sleep`, or a loop count.
+# Under `set -e` those failures are inconsistent: a bad `sleep $INTERVAL` makes
+# the size-monitor loop exit on its FIRST iteration, silently disabling the
+# whole size guard for the container's lifetime; a bad arithmetic test inside an
+# `if` evaluates false and skips the guard with no warning.  Either way an
+# operator typo silently DISABLES a guard.
+#
+# _require_int validates ONE such var by name and rewrites it in place: if the
+# current value is a positive integer it is kept; otherwise a WARNING is logged
+# and the documented default is substituted.  It fails SAFE — it never aborts
+# and never leaves a guard fed by a bad value.  Run over EVERY numeric config
+# var at startup (see the validation pass below) so no `sleep`/loop-count/
+# arithmetic test downstream can be silently broken by a bad override.
+#
+# Args: $1 = variable NAME (validated + reassigned via printf -v)
+#       $2 = documented default (used verbatim on fallback)
+#       $3 = human label for the warning
+_require_int() {
+  local name="$1" default="$2" label="$3" value
+  eval "value=\${$name}"
+  case "$value" in
+    ''|*[!0-9]*)
+      echo "[entrypoint] WARNING: ${label} (${name}) is not a positive integer (got: '${value}') — falling back to default ${default}"
+      printf -v "$name" '%s' "$default"
+      ;;
+  esac
+}
+
 cleanup() {
   # Tree-kill the agent (not a bare `kill $AGENT_PID`): $AGENT_PID is the
   # process-sub subshell, so a single-PID kill on the normal shutdown path
@@ -88,7 +148,17 @@ cleanup() {
   # only the subshell and ORPHAN the real npm→node server — reparented to
   # PID 1, still holding :8123 across the restart.  See _kill_agent_tree.
   _kill_agent_tree "$AGENT_PID"
-  kill $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+  # Tree-kill Next.js too: NEXTJS_PID is ALSO a process-sub subshell wrapping
+  # `npx next start` (which forks npm→node), exactly like AGENT_PID.  A bare
+  # `kill $NEXTJS_PID` would reap only the wrapper subshell and ORPHAN the real
+  # Next.js node server — reparented to PID 1, still holding $PORT across the
+  # Railway redeploy/rollover SIGTERM, so the new container cannot bind $PORT.
+  # (Same orphan class already fixed for the agent; route the frontend through
+  # the same guarded walk.)  WATCHDOG_PID is a genuine single-PID subshell we
+  # spawn directly (`( … ) &`, not process-sub-wrapped) that forks nothing that
+  # outlives it, so a bare kill is correct for it.
+  _kill_agent_tree "$NEXTJS_PID"
+  kill $WATCHDOG_PID 2>/dev/null || true
   # NOTE: SIZE_PID is intentionally NOT killed here.  SIZE_PID is assigned
   # inside the watchdog subshell ( ) & so it is never visible in this outer
   # shell.  The subshell registers its own EXIT trap to kill its SIZE_PID; see
@@ -186,7 +256,19 @@ if [ "${1:-}" = "--check-size-once" ]; then
   trap - EXIT
   PERSIST_DIR=${LANGGRAPH_PERSIST_DIR_OVERRIDE:-/app/src/agent/.langgraph_api}
   SIZE_THRESHOLD_MB=${LANGGRAPH_SIZE_THRESHOLD_MB:-200}
-  AGENT_PID=${AGENT_PID:-0}
+  _require_int SIZE_THRESHOLD_MB 200 "LangGraph persistence size threshold (MB)"
+  # Do NOT default AGENT_PID to 0.  The old `AGENT_PID=${AGENT_PID:-0}` sentinel
+  # meant that an unset/empty AGENT_PID flowed into `_kill_agent_tree "0"` →
+  # `kill -9 0`, SIGKILLing the caller's ENTIRE process group.  If AGENT_PID is
+  # unset/empty here, skip the check with a warning rather than defaulting to a
+  # dangerous PID.  (_kill_agent_tree/_watchdog_check_size_once also fail closed
+  # on PID <= 1, but we refuse earlier so no bogus PID is ever passed at all.)
+  case "${AGENT_PID:-}" in
+    ''|*[!0-9]*)
+      echo "[watchdog:size] WARNING: AGENT_PID is unset or non-numeric (got: '${AGENT_PID:-}') — skipping size check" >&2
+      exit 0
+      ;;
+  esac
   _watchdog_check_size_once
   exit $?
 fi
@@ -307,8 +389,29 @@ SIZE_THRESHOLD_MB=${LANGGRAPH_SIZE_THRESHOLD_MB:-200}
 # leaves too large a window — at typical probe rates state can exceed 512MB
 # before the next check.  60s keeps the check-to-ceiling budget comfortable.
 SIZE_CHECK_INTERVAL=${LANGGRAPH_SIZE_CHECK_INTERVAL:-60}
+# Startup grace window, steady-state health-probe interval and strike budget.
+# All operator-overridable so deploy tuning does not require an image rebuild.
+STARTUP_GRACE_SECONDS=${LANGGRAPH_STARTUP_GRACE_SECONDS:-180}
+HEALTH_CHECK_INTERVAL=${LANGGRAPH_HEALTH_CHECK_INTERVAL:-30}
+HEALTH_STRIKE_LIMIT=${LANGGRAPH_HEALTH_STRIKE_LIMIT:-3}
+
+# ---------------------------------------------------------------------------
+# Numeric-config validation pass (CLASS 1 structural guard).
+#
+# Validate EVERY operator-overridable numeric knob at STARTUP, before any of
+# them can feed a `sleep`, a loop count, or an arithmetic test.  A bad override
+# (non-integer / empty) on ANY of these would otherwise silently disable a guard
+# — most dangerously LANGGRAPH_SIZE_CHECK_INTERVAL="60s", which makes the very
+# first `while sleep $SIZE_CHECK_INTERVAL` fail and kills the size-monitor loop
+# for the container's lifetime.  Each bad value WARNs and falls back to the
+# documented default (fail-safe: never abort, never leave a guard disabled).
+_require_int SIZE_THRESHOLD_MB      200 "LangGraph persistence size threshold (MB)"
+_require_int SIZE_CHECK_INTERVAL     60 "LangGraph size-check interval (s)"
+_require_int STARTUP_GRACE_SECONDS  180 "LangGraph startup grace window (s)"
+_require_int HEALTH_CHECK_INTERVAL   30 "LangGraph health-probe interval (s)"
+_require_int HEALTH_STRIKE_LIMIT      3 "LangGraph health strike limit"
 (
-  GRACE=180
+  GRACE=$STARTUP_GRACE_SECONDS
   echo "[watchdog] Startup grace: waiting up to ${GRACE}s for first successful health probe before arming strike counter"
   ELAPSED=0
   while [ $ELAPSED -lt $GRACE ]; do
@@ -364,7 +467,7 @@ SIZE_CHECK_INTERVAL=${LANGGRAPH_SIZE_CHECK_INTERVAL:-60}
   trap 'kill "$SIZE_PID" 2>/dev/null || true' EXIT
 
   FAILS=0
-  while sleep 30; do
+  while sleep "$HEALTH_CHECK_INTERVAL"; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       break
     fi
@@ -373,8 +476,8 @@ SIZE_CHECK_INTERVAL=${LANGGRAPH_SIZE_CHECK_INTERVAL:-60}
     else
       FAILS=$((FAILS + 1))
       echo "[watchdog] Agent health probe failed (count=$FAILS)"
-      if [ $FAILS -ge 3 ]; then
-        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID (and its npm→node tree) to trigger container restart"
+      if [ $FAILS -ge "$HEALTH_STRIKE_LIMIT" ]; then
+        echo "[watchdog] Agent unresponsive for ~$((HEALTH_CHECK_INTERVAL * HEALTH_STRIKE_LIMIT))s — killing PID $AGENT_PID (and its npm→node tree) to trigger container restart"
         # Tree-kill for the same reason as the size gate: $AGENT_PID is the
         # process-sub subshell; a single-PID kill would orphan npm→node and
         # leave :8123 bound to a hung agent that `wait -n` never observes dying.
@@ -385,7 +488,7 @@ SIZE_CHECK_INTERVAL=${LANGGRAPH_SIZE_CHECK_INTERVAL:-60}
   done
 ) &
 WATCHDOG_PID=$!
-echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8124/ok, startup grace 180s, size-guard threshold ${SIZE_THRESHOLD_MB}MB every ${SIZE_CHECK_INTERVAL}s)"
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8124/ok, startup grace ${STARTUP_GRACE_SECONDS}s, size-guard threshold ${SIZE_THRESHOLD_MB}MB every ${SIZE_CHECK_INTERVAL}s)"
 echo "[entrypoint] All processes running. Waiting..."
 
 # Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to

--- a/showcase/integrations/langgraph-typescript/entrypoint.sh
+++ b/showcase/integrations/langgraph-typescript/entrypoint.sh
@@ -19,7 +19,9 @@ set -e
 # OFF: the agent subshell, npm, node, next.js AND the main shell all share the
 # shell's process group, so a group kill would take out the whole entrypoint.
 # Instead we walk the process tree via /proc (node:22-slim ships neither
-# `ps` nor `pgrep`) and SIGKILL every descendant, deepest-first, then the root.
+# `ps` nor `pgrep`) and SIGKILL every descendant, deepest-first, in a BOUNDED
+# re-scan loop that keeps the root alive as the walk anchor until the subtree
+# is drained, then kills the root last (see _kill_agent_tree for why).
 #
 # Defined ABOVE cleanup() on purpose: cleanup() (the EXIT/SIGTERM trap) calls
 # _kill_agent_tree, so the helper must already exist whenever the trap can
@@ -30,8 +32,12 @@ _agent_descendants() {
   local root="$1" pid ppid stat
   for pid in $(cd /proc 2>/dev/null && ls -d [0-9]* 2>/dev/null); do
     [ -r "/proc/$pid/stat" ] || continue
-    # comm (field 2) can contain spaces/parens, so strip through the final ')'
-    # before splitting; PPID is then the 2nd field of the remainder.
+    # /proc/PID/stat is: "PID (comm) STATE PPID PGRP …". comm can contain
+    # spaces AND parens, so strip through the final ") " before splitting; PPID
+    # is then the 2nd field of the remainder (1st is STATE). "${x##*) }" takes
+    # the LONGEST prefix up to the LAST ") ", and no field after the real
+    # closing paren contains ")", so even a comm like "(evil) S 1)" parses to
+    # the true PPID — the last ") " is always the comm's real terminator.
     stat=$(cat "/proc/$pid/stat" 2>/dev/null) || continue
     ppid=$(echo "${stat##*) }" | awk '{print $2}')
     if [ "$ppid" = "$root" ]; then
@@ -44,9 +50,33 @@ _agent_descendants() {
 _kill_agent_tree() {
   # SIGKILL the agent subshell AND its npm→node descendants so the real server
   # actually dies and frees :8123 — not just the log-pipeline subshell.
-  local root="$1" p
-  for p in $(_agent_descendants "$root"); do
-    kill -9 "$p" 2>/dev/null || true
+  #
+  # A single snapshot-then-kill is racy: a descendant that forks a new child (or
+  # a child that reparents) BETWEEN the scan and the kill is missed by the walk,
+  # reparents to PID 1, and keeps :8123 bound — defeating the whole tree-kill.
+  # So we re-scan in a BOUNDED loop, killing the currently-live descendants
+  # deepest-first each pass, until a scan comes back empty (or the bound is
+  # hit). Crucially we keep the ROOT alive as the walk anchor across passes and
+  # kill it LAST: killing root first would immediately reparent every descendant
+  # to PID 1, making them unreachable by a root-anchored PPID walk. Leaving root
+  # alive (it is an idle subshell that spawns nothing on its own) means a child
+  # that forks between two passes is still attached to a live chain from root
+  # and is reaped on the next pass.
+  #
+  # Residual limitation: a descendant that FULLY reparents to PID 1 (double-fork
+  # / daemonize) before we reach it is no longer on any PPID chain from root and
+  # cannot be found by a /proc PPID walk. That is inherent to PPID-based reaping
+  # without job control (no ps/pgrep in node:22-slim; job control off in a
+  # non-interactive script, so no process-group kill). The agent's npm→node tree
+  # does not daemonize, so this loop covers the real failure surface.
+  local root="$1" p descendants
+  for _ in 1 2 3 4 5; do
+    descendants=$(_agent_descendants "$root")
+    [ -z "$descendants" ] && break
+    for p in $descendants; do
+      kill -9 "$p" 2>/dev/null || true
+    done
+    sleep 0.2
   done
   kill -9 "$root" 2>/dev/null || true
 }

--- a/showcase/integrations/langgraph-typescript/entrypoint.sh
+++ b/showcase/integrations/langgraph-typescript/entrypoint.sh
@@ -141,6 +141,21 @@ _watchdog_check_size_once() {
       return 0
       ;;
   esac
+  # Validate the THRESHOLD for numericity too — same set -e hazard class as
+  # DIR_SIZE_MB above.  threshold_mb comes from LANGGRAPH_SIZE_THRESHOLD_MB, an
+  # operator-supplied override.  A non-integer value (e.g. "200MB", "abc") would
+  # otherwise reach the `[ "$DIR_SIZE_MB" -ge "$threshold_mb" ]` comparison and
+  # throw "integer expression expected"; because that comparison sits inside an
+  # `if`, set -e is suppressed and the failed test evaluates false — SILENTLY
+  # skipping the size gate EVERY cycle with NO warning.  Match on ^[0-9]+$ and
+  # emit the SAME "size guard inactive" WARNING so the gate can never silently
+  # disappear behind a bad override.
+  case "$threshold_mb" in
+    ''|*[!0-9]*)
+      echo "[watchdog:size] WARNING: LANGGRAPH_SIZE_THRESHOLD_MB is not a positive integer (got: '${threshold_mb}') — size guard inactive this cycle"
+      return 0
+      ;;
+  esac
   echo "[watchdog:size] Persistence dir size: ${DIR_SIZE_MB}MB (threshold: ${threshold_mb}MB)"
   if [ "$DIR_SIZE_MB" -ge "$threshold_mb" ]; then
     echo "[watchdog:size] Size threshold exceeded (${DIR_SIZE_MB}MB >= ${threshold_mb}MB) — killing agent PID $agent_pid (and its npm→node tree) to trigger container restart and boot-purge"
@@ -377,8 +392,18 @@ echo "[entrypoint] All processes running. Waiting..."
 # kill the agent when it hangs; if the watchdog exits first, `wait -n` would
 # otherwise return with the watchdog's exit code and short-circuit before
 # the agent's true exit status is observable.
-wait -n $AGENT_PID $NEXTJS_PID
-EXIT_CODE=$?
+#
+# `|| EXIT_CODE=$?` is LOAD-BEARING under `set -e`: the PRIMARY designed exit
+# path here is a NON-ZERO wait (137 = the size-gate / watchdog SIGKILL of the
+# agent tree, or an agent crash).  Without the `||` guard, `set -e` aborts the
+# script AT this line on exactly those interesting exits, making the entire
+# "which process exited with code N" diagnostic below AND the final explicit
+# `exit $EXIT_CODE` dead code — the container still restarts (EXIT trap runs
+# cleanup, script exits non-zero) but the operator-facing diagnostic never
+# prints.  Capturing the code preserves it exactly (incl. 137) for both the
+# diagnostic and the final exit, and the container-restart path is unchanged.
+EXIT_CODE=0
+wait -n "$AGENT_PID" "$NEXTJS_PID" || EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
   echo "[entrypoint] Agent (PID: $AGENT_PID) exited with code $EXIT_CODE"
 elif ! kill -0 $NEXTJS_PID 2>/dev/null; then

--- a/showcase/integrations/langgraph-typescript/entrypoint.sh
+++ b/showcase/integrations/langgraph-typescript/entrypoint.sh
@@ -11,6 +11,52 @@ cleanup() {
 trap cleanup EXIT
 
 # ---------------------------------------------------------------------------
+# Agent process-tree kill.
+#
+# The agent is launched as a compound command through a process substitution:
+#   cd /app/src/agent && ... npm start &> >(awk …) &
+# so $AGENT_PID (=$!) is the *outer subshell* wrapping that pipeline — NOT the
+# `npm` wrapper nor the `node` server it forks.  A plain `kill -9 $AGENT_PID`
+# therefore reaps only the subshell: `npm` and `node` are reparented to PID 1
+# and KEEP RUNNING — still bound to :8123, still holding the bloated in-memory
+# state.  The size-gate's whole promise ("kill agent → container restart →
+# boot-purge") is then broken: the frontend proxies to a dead-but-not-restarted
+# agent forever (edge 502s), and even if the container does exit, a surviving
+# orphan can still hold :8123 across the restart.
+#
+# We cannot `kill -- -$PGID` because a non-interactive script has job control
+# OFF: the agent subshell, npm, node, next.js AND the main shell all share the
+# shell's process group, so a group kill would take out the whole entrypoint.
+# Instead we walk the process tree via /proc (node:22-slim ships neither
+# `ps` nor `pgrep`) and SIGKILL every descendant, deepest-first, then the root.
+# ---------------------------------------------------------------------------
+_agent_descendants() {
+  # Print all descendant PIDs of $1 (children, grandchildren, …), deepest-first.
+  local root="$1" pid ppid stat
+  for pid in $(cd /proc 2>/dev/null && ls -d [0-9]* 2>/dev/null); do
+    [ -r "/proc/$pid/stat" ] || continue
+    # comm (field 2) can contain spaces/parens, so strip through the final ')'
+    # before splitting; PPID is then the 2nd field of the remainder.
+    stat=$(cat "/proc/$pid/stat" 2>/dev/null) || continue
+    ppid=$(echo "${stat##*) }" | awk '{print $2}')
+    if [ "$ppid" = "$root" ]; then
+      _agent_descendants "$pid"
+      echo "$pid"
+    fi
+  done
+}
+
+_kill_agent_tree() {
+  # SIGKILL the agent subshell AND its npm→node descendants so the real server
+  # actually dies and frees :8123 — not just the log-pipeline subshell.
+  local root="$1" p
+  for p in $(_agent_descendants "$root"); do
+    kill -9 "$p" 2>/dev/null || true
+  done
+  kill -9 "$root" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
 # Size-check seam: extract the per-cycle size-check-and-kill decision so it
 # can be exercised directly in tests without running the full entrypoint stack.
 #
@@ -47,11 +93,14 @@ _watchdog_check_size_once() {
   fi
   echo "[watchdog:size] Persistence dir size: ${DIR_SIZE_MB}MB (threshold: ${threshold_mb}MB)"
   if [ "$DIR_SIZE_MB" -ge "$threshold_mb" ]; then
-    echo "[watchdog:size] Size threshold exceeded (${DIR_SIZE_MB}MB >= ${threshold_mb}MB) — killing agent PID $agent_pid to trigger container restart and boot-purge"
+    echo "[watchdog:size] Size threshold exceeded (${DIR_SIZE_MB}MB >= ${threshold_mb}MB) — killing agent PID $agent_pid (and its npm→node tree) to trigger container restart and boot-purge"
     # NOTE: this kill WILL terminate any in-flight streaming runs — accepted
     # tradeoff vs OOM/crash.  The gate is threshold-based (not a fixed timer)
     # so it fires only when state has grown dangerously large.
-    kill -9 "$agent_pid" 2>/dev/null || true
+    # Tree-kill (not a bare `kill -9 $agent_pid`): $agent_pid is the process-sub
+    # subshell, so a single-PID kill would orphan the real npm→node server,
+    # leaving :8123 bound and the boot-purge never re-run.  See _kill_agent_tree.
+    _kill_agent_tree "$agent_pid"
     return 1
   fi
   return 0
@@ -241,8 +290,11 @@ SIZE_CHECK_INTERVAL=${LANGGRAPH_SIZE_CHECK_INTERVAL:-60}
       FAILS=$((FAILS + 1))
       echo "[watchdog] Agent health probe failed (count=$FAILS)"
       if [ $FAILS -ge 3 ]; then
-        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
-        kill -9 $AGENT_PID 2>/dev/null || true
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID (and its npm→node tree) to trigger container restart"
+        # Tree-kill for the same reason as the size gate: $AGENT_PID is the
+        # process-sub subshell; a single-PID kill would orphan npm→node and
+        # leave :8123 bound to a hung agent that `wait -n` never observes dying.
+        _kill_agent_tree "$AGENT_PID"
         break
       fi
     fi

--- a/showcase/integrations/langgraph-typescript/entrypoint.sh
+++ b/showcase/integrations/langgraph-typescript/entrypoint.sh
@@ -133,8 +133,30 @@ _kill_agent_tree() {
 _require_int() {
   local name="$1" default="$2" label="$3" value
   eval "value=\${$name}"
+  # Valid ONLY if a positive integer with no leading zero: first digit 1-9,
+  # rest digits ([1-9][0-9]*).  This rejects — and falls back to the default
+  # for — every operator-typo class that would break a guard:
+  #   • empty / non-numeric ("", "60s", "abc")
+  #   • "0" — a zero threshold/interval/limit turns a guard into an instant-fire
+  #     kill loop (SIZE_THRESHOLD_MB=0 kills on cycle 1) or a busy-spin
+  #     (SIZE_CHECK_INTERVAL=0 → `while sleep 0`)
+  #   • leading-zero / octal forms ("010", "08") — bash arithmetic reads a
+  #     leading-zero literal as OCTAL, so "010" becomes 8 (wrong value) and an
+  #     "08"/"09" digit aborts the script under `set -e` ("value too great for
+  #     base").
+  # The `[1-9]*([0-9])` extglob-free equivalent is written as two arms: a lone
+  # single digit 1-9, or a 1-9 lead followed by one-or-more digits.
   case "$value" in
-    ''|*[!0-9]*)
+    [1-9]) : ;;                # single positive digit
+    [1-9][0-9]*)               # multi-digit, must be all digits after the lead
+      case "$value" in
+        *[!0-9]*)
+          echo "[entrypoint] WARNING: ${label} (${name}) is not a positive integer (got: '${value}') — falling back to default ${default}"
+          printf -v "$name" '%s' "$default"
+          ;;
+      esac
+      ;;
+    *)
       echo "[entrypoint] WARNING: ${label} (${name}) is not a positive integer (got: '${value}') — falling back to default ${default}"
       printf -v "$name" '%s' "$default"
       ;;

--- a/showcase/integrations/langgraph-typescript/entrypoint.sh
+++ b/showcase/integrations/langgraph-typescript/entrypoint.sh
@@ -127,10 +127,20 @@ _watchdog_check_size_once() {
   # to leave margin for this approximation.
   # || true prevents set -e from killing this subshell if du fails.
   DIR_SIZE_MB=$(du -sm "$persist_dir" 2>/dev/null | awk '{print $1}') || true
-  if [ -z "$DIR_SIZE_MB" ]; then
-    echo "[watchdog:size] WARNING: Could not read size of ${persist_dir} — size guard inactive this cycle"
-    return 0
-  fi
+  # Validate for NUMERICITY, not merely emptiness.  A non-integer value (junk
+  # du output, a transient error, a test-seam stub) would otherwise reach the
+  # `[ "$DIR_SIZE_MB" -ge ... ]` comparison below and throw "integer expression
+  # expected".  Because that comparison sits inside an `if`, set -e is
+  # suppressed and the failed test evaluates false — SILENTLY skipping the size
+  # gate for this cycle with NO warning (unlike the empty-string case).  Match
+  # on ^[0-9]+$ and emit the SAME "size guard inactive" WARNING so the gate can
+  # never silently disappear.
+  case "$DIR_SIZE_MB" in
+    ''|*[!0-9]*)
+      echo "[watchdog:size] WARNING: Could not read a numeric size of ${persist_dir} (got: '${DIR_SIZE_MB}') — size guard inactive this cycle"
+      return 0
+      ;;
+  esac
   echo "[watchdog:size] Persistence dir size: ${DIR_SIZE_MB}MB (threshold: ${threshold_mb}MB)"
   if [ "$DIR_SIZE_MB" -ge "$threshold_mb" ]; then
     echo "[watchdog:size] Size threshold exceeded (${DIR_SIZE_MB}MB >= ${threshold_mb}MB) — killing agent PID $agent_pid (and its npm→node tree) to trigger container restart and boot-purge"
@@ -308,7 +318,26 @@ SIZE_CHECK_INTERVAL=${LANGGRAPH_SIZE_CHECK_INTERVAL:-60}
   (
     echo "[watchdog:size] Starting size-gated restart monitor (threshold=${SIZE_THRESHOLD_MB}MB, interval=${SIZE_CHECK_INTERVAL}s, dir=${PERSIST_DIR})"
     while sleep $SIZE_CHECK_INTERVAL; do
-      _watchdog_check_size_once || break
+      # _watchdog_check_size_once returns:
+      #   0 = no action (under threshold, dir missing, or a transient/junk read
+      #       that left the guard inactive for this cycle only)
+      #   1 = REAL threshold kill issued (agent tree SIGKILLed)
+      # A bare `|| break` treated ANY non-zero identically, so a transient check
+      # error would PERMANENTLY end the monitor for the container's lifetime.
+      # Break ONLY on the real-kill signal (rc==1): after that kill the agent is
+      # dead, the outer `wait -n $AGENT_PID` fires, and Railway restarts the
+      # container (re-running the boot-purge) — so the monitor correctly stops.
+      # For rc==0 (including transient errors, which are surfaced as a WARNING
+      # inside the function) the monitor MUST stay live and re-check next cycle.
+      _watchdog_check_size_once && continue
+      rc=$?
+      if [ "$rc" -eq 1 ]; then
+        # Real kill issued — agent is terminating; stop the monitor and let the
+        # container restart flow (wait -n → exit → Railway restart) proceed.
+        break
+      fi
+      # Any other non-zero is a transient hiccup, not a kill: keep monitoring.
+      echo "[watchdog:size] Size check returned transient status ${rc} — keeping monitor active"
     done
   ) &
   SIZE_PID=$!

--- a/showcase/integrations/strands-typescript/entrypoint.sh
+++ b/showcase/integrations/strands-typescript/entrypoint.sh
@@ -6,6 +6,52 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# ---------------------------------------------------------------------------
+# Agent process-tree kill.
+#
+# The agent is launched as a compound command through a process substitution:
+#   cd /app/src/agent && ... npm start &> >(awk …) &
+# so $AGENT_PID (=$!) is the *outer subshell* wrapping that pipeline — NOT the
+# `npm` wrapper nor the `node` server it forks.  A plain `kill -9 $AGENT_PID`
+# therefore reaps only the subshell: `npm` and `node` are reparented to PID 1
+# and KEEP RUNNING — still bound to :8000.  The watchdog's whole promise
+# ("kill agent → wait -n returns → container restart") is then broken: the
+# frontend proxies to a dead-but-not-restarted agent forever (edge 502s), and
+# even if the container does exit, a surviving orphan can still hold :8000
+# across the restart.
+#
+# We cannot `kill -- -$PGID` because a non-interactive script has job control
+# OFF: the agent subshell, npm, node, next.js AND the main shell all share the
+# shell's process group, so a group kill would take out the whole entrypoint.
+# Instead we walk the process tree via /proc (node:22-slim ships neither
+# `ps` nor `pgrep`) and SIGKILL every descendant, deepest-first, then the root.
+# ---------------------------------------------------------------------------
+_agent_descendants() {
+  # Print all descendant PIDs of $1 (children, grandchildren, …), deepest-first.
+  local root="$1" pid ppid stat
+  for pid in $(cd /proc 2>/dev/null && ls -d [0-9]* 2>/dev/null); do
+    [ -r "/proc/$pid/stat" ] || continue
+    # comm (field 2) can contain spaces/parens, so strip through the final ')'
+    # before splitting; PPID is then the 2nd field of the remainder.
+    stat=$(cat "/proc/$pid/stat" 2>/dev/null) || continue
+    ppid=$(echo "${stat##*) }" | awk '{print $2}')
+    if [ "$ppid" = "$root" ]; then
+      _agent_descendants "$pid"
+      echo "$pid"
+    fi
+  done
+}
+
+_kill_agent_tree() {
+  # SIGKILL the agent subshell AND its npm→node descendants so the real server
+  # actually dies and frees :8000 — not just the log-pipeline subshell.
+  local root="$1" p
+  for p in $(_agent_descendants "$root"); do
+    kill -9 "$p" 2>/dev/null || true
+  done
+  kill -9 "$root" 2>/dev/null || true
+}
+
 echo "========================================="
 echo "[entrypoint] Starting showcase package: strands-typescript"
 echo "[entrypoint] Time: $(date -u)"
@@ -68,8 +114,11 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
       FAILS=$((FAILS + 1))
       echo "[watchdog] Agent health probe failed (count=$FAILS)"
       if [ $FAILS -ge 3 ]; then
-        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
-        kill -9 $AGENT_PID 2>/dev/null || true
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID (and its npm→node tree) to trigger container restart"
+        # Tree-kill (not a bare `kill -9 $AGENT_PID`): $AGENT_PID is the process-sub
+        # subshell, so a single-PID kill would orphan the real npm→node server,
+        # leaving :8000 bound to a hung agent that `wait -n` never observes dying.
+        _kill_agent_tree "$AGENT_PID"
         break
       fi
     fi

--- a/showcase/integrations/strands-typescript/entrypoint.sh
+++ b/showcase/integrations/strands-typescript/entrypoint.sh
@@ -30,6 +30,18 @@ set -e
 _agent_descendants() {
   # Print all descendant PIDs of $1 (children, grandchildren, …), deepest-first.
   local root="$1" pid ppid stat
+  # Fail closed on a dangerous or meaningless root.  An empty / non-numeric root
+  # would make the PPID comparison below match nothing (harmless) but a root of
+  # "0" or "1" is catastrophic: "0" means "every process in the caller's process
+  # group" and "1" is init — a caller that then fed the result to a kill could
+  # wipe the whole container.  Refuse anything that is not an integer >= 2.
+  case "$root" in
+    ''|*[!0-9]*) echo "[proctree] WARNING: refusing descendant scan for non-numeric root '${root}'" >&2; return 0 ;;
+  esac
+  if [ "$root" -le 1 ]; then
+    echo "[proctree] WARNING: refusing descendant scan for reserved root ${root} (0=process-group, 1=init)" >&2
+    return 0
+  fi
   for pid in $(cd /proc 2>/dev/null && ls -d [0-9]* 2>/dev/null); do
     [ -r "/proc/$pid/stat" ] || continue
     # /proc/PID/stat is: "PID (comm) STATE PPID PGRP …". comm can contain
@@ -69,7 +81,20 @@ _kill_agent_tree() {
   # without job control (no ps/pgrep in node:22-slim; job control off in a
   # non-interactive script, so no process-group kill). The agent's npm→node tree
   # does not daemonize, so this loop covers the real failure surface.
+  #
+  # Fail closed on a dangerous or meaningless root, BEFORE any kill runs.  If the
+  # caller passes an empty / non-numeric PID, or the reserved 0 (SIGKILL to the
+  # WHOLE caller process group) or 1 (init), refuse outright — a bare `kill -9 0`
+  # here would SIGKILL the entire entrypoint.  This makes `kill -9 0`/`kill -9 1`
+  # structurally impossible regardless of what the caller passes.
   local root="$1" p descendants
+  case "$root" in
+    ''|*[!0-9]*) echo "[proctree] WARNING: refusing tree-kill for non-numeric PID '${root}'" >&2; return 0 ;;
+  esac
+  if [ "$root" -le 1 ]; then
+    echo "[proctree] WARNING: refusing tree-kill for reserved PID ${root} (0=process-group, 1=init)" >&2
+    return 0
+  fi
   for _ in 1 2 3 4 5; do
     descendants=$(_agent_descendants "$root")
     [ -z "$descendants" ] && break
@@ -81,6 +106,41 @@ _kill_agent_tree() {
   kill -9 "$root" 2>/dev/null || true
 }
 
+# ---------------------------------------------------------------------------
+# Numeric-config validator.
+#
+# Every operator-overridable numeric knob (size threshold, check intervals,
+# strike budgets, grace/timeout windows) is read from an env var with a `:-`
+# default.  A non-integer or empty override (e.g. LANGGRAPH_SIZE_CHECK_INTERVAL
+# ="60s") does NOT fall back to the default on its own — it propagates as a bad
+# value into an arithmetic test (`[ .. -ge .. ]`), a `sleep`, or a loop count.
+# Under `set -e` those failures are inconsistent: a bad `sleep $INTERVAL` makes
+# the size-monitor loop exit on its FIRST iteration, silently disabling the
+# whole size guard for the container's lifetime; a bad arithmetic test inside an
+# `if` evaluates false and skips the guard with no warning.  Either way an
+# operator typo silently DISABLES a guard.
+#
+# _require_int validates ONE such var by name and rewrites it in place: if the
+# current value is a positive integer it is kept; otherwise a WARNING is logged
+# and the documented default is substituted.  It fails SAFE — it never aborts
+# and never leaves a guard fed by a bad value.  Run over EVERY numeric config
+# var at startup (see the validation pass below) so no `sleep`/loop-count/
+# arithmetic test downstream can be silently broken by a bad override.
+#
+# Args: $1 = variable NAME (validated + reassigned via printf -v)
+#       $2 = documented default (used verbatim on fallback)
+#       $3 = human label for the warning
+_require_int() {
+  local name="$1" default="$2" label="$3" value
+  eval "value=\${$name}"
+  case "$value" in
+    ''|*[!0-9]*)
+      echo "[entrypoint] WARNING: ${label} (${name}) is not a positive integer (got: '${value}') — falling back to default ${default}"
+      printf -v "$name" '%s' "$default"
+      ;;
+  esac
+}
+
 cleanup() {
   # Tree-kill the agent (not a bare `kill $AGENT_PID`): $AGENT_PID is the
   # process-sub subshell, so a single-PID kill on the normal shutdown path
@@ -88,7 +148,17 @@ cleanup() {
   # only the subshell and ORPHAN the real npm→node server — reparented to
   # PID 1, still holding :8000 across the restart.  See _kill_agent_tree.
   _kill_agent_tree "$AGENT_PID"
-  kill $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+  # Tree-kill Next.js too: NEXTJS_PID is ALSO a process-sub subshell wrapping
+  # `npx next start` (which forks npm→node), exactly like AGENT_PID.  A bare
+  # `kill $NEXTJS_PID` would reap only the wrapper subshell and ORPHAN the real
+  # Next.js node server — reparented to PID 1, still holding $PORT across the
+  # Railway redeploy/rollover SIGTERM, so the new container cannot bind $PORT.
+  # (Same orphan class already fixed for the agent; route the frontend through
+  # the same guarded walk.)  WATCHDOG_PID is a genuine single-PID subshell we
+  # spawn directly (`( … ) &`, not process-sub-wrapped) that forks nothing that
+  # outlives it, so a bare kill is correct for it.
+  _kill_agent_tree "$NEXTJS_PID"
+  kill $WATCHDOG_PID 2>/dev/null || true
 }
 trap cleanup EXIT
 
@@ -152,8 +222,28 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # counter; if /health comes up sooner, fall through immediately. If 180s
 # elapses without success, arm the counter anyway — the steady-state watchdog
 # will handle a true hang. Mirrors langgraph-typescript/entrypoint.sh.
+#
+# Startup grace window, steady-state health-probe interval and strike budget.
+# All operator-overridable so deploy tuning does not require an image rebuild.
+STARTUP_GRACE_SECONDS=${STRANDS_STARTUP_GRACE_SECONDS:-180}
+HEALTH_CHECK_INTERVAL=${STRANDS_HEALTH_CHECK_INTERVAL:-30}
+HEALTH_STRIKE_LIMIT=${STRANDS_HEALTH_STRIKE_LIMIT:-3}
+
+# ---------------------------------------------------------------------------
+# Numeric-config validation pass (CLASS 1 structural guard).
+#
+# Validate EVERY operator-overridable numeric knob at STARTUP, before any of
+# them can feed a `sleep`, a loop count, or an arithmetic test.  A bad override
+# (non-integer / empty) on ANY of these would otherwise silently disable a guard
+# — e.g. STRANDS_HEALTH_CHECK_INTERVAL="30s" makes the very first
+# `while sleep $HEALTH_CHECK_INTERVAL` fail and kills the health monitor loop
+# for the container's lifetime.  Each bad value WARNs and falls back to the
+# documented default (fail-safe: never abort, never leave a guard disabled).
+_require_int STARTUP_GRACE_SECONDS  180 "Strands startup grace window (s)"
+_require_int HEALTH_CHECK_INTERVAL   30 "Strands health-probe interval (s)"
+_require_int HEALTH_STRIKE_LIMIT      3 "Strands health strike limit"
 (
-  GRACE=180
+  GRACE=$STARTUP_GRACE_SECONDS
   echo "[watchdog] Startup grace: waiting up to ${GRACE}s for first successful health probe before arming strike counter"
   ELAPSED=0
   while [ $ELAPSED -lt $GRACE ]; do
@@ -173,7 +263,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
   fi
 
   FAILS=0
-  while sleep 30; do
+  while sleep "$HEALTH_CHECK_INTERVAL"; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       break
     fi
@@ -182,8 +272,8 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
     else
       FAILS=$((FAILS + 1))
       echo "[watchdog] Agent health probe failed (count=$FAILS)"
-      if [ $FAILS -ge 3 ]; then
-        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID (and its npm→node tree) to trigger container restart"
+      if [ $FAILS -ge "$HEALTH_STRIKE_LIMIT" ]; then
+        echo "[watchdog] Agent unresponsive for ~$((HEALTH_CHECK_INTERVAL * HEALTH_STRIKE_LIMIT))s — killing PID $AGENT_PID (and its npm→node tree) to trigger container restart"
         # Tree-kill (not a bare `kill -9 $AGENT_PID`): $AGENT_PID is the process-sub
         # subshell, so a single-PID kill would orphan the real npm→node server,
         # leaving :8000 bound to a hung agent that `wait -n` never observes dying.
@@ -195,7 +285,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 ) &
 WATCHDOG_PID=$!
 
-echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8000/health, startup grace 180s)"
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8000/health, startup grace ${STARTUP_GRACE_SECONDS}s)"
 echo "[entrypoint] All processes running. Waiting..."
 
 # Only wait on agent + next.js — NOT the watchdog.

--- a/showcase/integrations/strands-typescript/entrypoint.sh
+++ b/showcase/integrations/strands-typescript/entrypoint.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 set -e
 
-cleanup() {
-  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
-}
-trap cleanup EXIT
-
 # ---------------------------------------------------------------------------
 # Agent process-tree kill.
 #
@@ -25,6 +20,10 @@ trap cleanup EXIT
 # shell's process group, so a group kill would take out the whole entrypoint.
 # Instead we walk the process tree via /proc (node:22-slim ships neither
 # `ps` nor `pgrep`) and SIGKILL every descendant, deepest-first, then the root.
+#
+# Defined ABOVE cleanup() on purpose: cleanup() (the EXIT/SIGTERM trap) calls
+# _kill_agent_tree, so the helper must already exist whenever the trap can
+# first fire — including the early `exit 1` below if the agent fails to start.
 # ---------------------------------------------------------------------------
 _agent_descendants() {
   # Print all descendant PIDs of $1 (children, grandchildren, …), deepest-first.
@@ -51,6 +50,17 @@ _kill_agent_tree() {
   done
   kill -9 "$root" 2>/dev/null || true
 }
+
+cleanup() {
+  # Tree-kill the agent (not a bare `kill $AGENT_PID`): $AGENT_PID is the
+  # process-sub subshell, so a single-PID kill on the normal shutdown path
+  # (graceful exit / SIGTERM on every Railway redeploy/rollover) would reap
+  # only the subshell and ORPHAN the real npm→node server — reparented to
+  # PID 1, still holding :8000 across the restart.  See _kill_agent_tree.
+  _kill_agent_tree "$AGENT_PID"
+  kill $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+}
+trap cleanup EXIT
 
 echo "========================================="
 echo "[entrypoint] Starting showcase package: strands-typescript"

--- a/showcase/integrations/strands-typescript/entrypoint.sh
+++ b/showcase/integrations/strands-typescript/entrypoint.sh
@@ -19,7 +19,9 @@ set -e
 # OFF: the agent subshell, npm, node, next.js AND the main shell all share the
 # shell's process group, so a group kill would take out the whole entrypoint.
 # Instead we walk the process tree via /proc (node:22-slim ships neither
-# `ps` nor `pgrep`) and SIGKILL every descendant, deepest-first, then the root.
+# `ps` nor `pgrep`) and SIGKILL every descendant, deepest-first, in a BOUNDED
+# re-scan loop that keeps the root alive as the walk anchor until the subtree
+# is drained, then kills the root last (see _kill_agent_tree for why).
 #
 # Defined ABOVE cleanup() on purpose: cleanup() (the EXIT/SIGTERM trap) calls
 # _kill_agent_tree, so the helper must already exist whenever the trap can
@@ -30,8 +32,12 @@ _agent_descendants() {
   local root="$1" pid ppid stat
   for pid in $(cd /proc 2>/dev/null && ls -d [0-9]* 2>/dev/null); do
     [ -r "/proc/$pid/stat" ] || continue
-    # comm (field 2) can contain spaces/parens, so strip through the final ')'
-    # before splitting; PPID is then the 2nd field of the remainder.
+    # /proc/PID/stat is: "PID (comm) STATE PPID PGRP …". comm can contain
+    # spaces AND parens, so strip through the final ") " before splitting; PPID
+    # is then the 2nd field of the remainder (1st is STATE). "${x##*) }" takes
+    # the LONGEST prefix up to the LAST ") ", and no field after the real
+    # closing paren contains ")", so even a comm like "(evil) S 1)" parses to
+    # the true PPID — the last ") " is always the comm's real terminator.
     stat=$(cat "/proc/$pid/stat" 2>/dev/null) || continue
     ppid=$(echo "${stat##*) }" | awk '{print $2}')
     if [ "$ppid" = "$root" ]; then
@@ -44,9 +50,33 @@ _agent_descendants() {
 _kill_agent_tree() {
   # SIGKILL the agent subshell AND its npm→node descendants so the real server
   # actually dies and frees :8000 — not just the log-pipeline subshell.
-  local root="$1" p
-  for p in $(_agent_descendants "$root"); do
-    kill -9 "$p" 2>/dev/null || true
+  #
+  # A single snapshot-then-kill is racy: a descendant that forks a new child (or
+  # a child that reparents) BETWEEN the scan and the kill is missed by the walk,
+  # reparents to PID 1, and keeps :8000 bound — defeating the whole tree-kill.
+  # So we re-scan in a BOUNDED loop, killing the currently-live descendants
+  # deepest-first each pass, until a scan comes back empty (or the bound is
+  # hit). Crucially we keep the ROOT alive as the walk anchor across passes and
+  # kill it LAST: killing root first would immediately reparent every descendant
+  # to PID 1, making them unreachable by a root-anchored PPID walk. Leaving root
+  # alive (it is an idle subshell that spawns nothing on its own) means a child
+  # that forks between two passes is still attached to a live chain from root
+  # and is reaped on the next pass.
+  #
+  # Residual limitation: a descendant that FULLY reparents to PID 1 (double-fork
+  # / daemonize) before we reach it is no longer on any PPID chain from root and
+  # cannot be found by a /proc PPID walk. That is inherent to PPID-based reaping
+  # without job control (no ps/pgrep in node:22-slim; job control off in a
+  # non-interactive script, so no process-group kill). The agent's npm→node tree
+  # does not daemonize, so this loop covers the real failure surface.
+  local root="$1" p descendants
+  for _ in 1 2 3 4 5; do
+    descendants=$(_agent_descendants "$root")
+    [ -z "$descendants" ] && break
+    for p in $descendants; do
+      kill -9 "$p" 2>/dev/null || true
+    done
+    sleep 0.2
   done
   kill -9 "$root" 2>/dev/null || true
 }

--- a/showcase/integrations/strands-typescript/entrypoint.sh
+++ b/showcase/integrations/strands-typescript/entrypoint.sh
@@ -142,7 +142,36 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # the container never restarts) but stops responding on :8000. Poll
 # /health every 30s; after 3 consecutive failures (~90s unreachable), kill
 # the agent so `wait -n` returns and Railway restarts the container.
+#
+# Startup grace: the Strands TS agent does a tsx cold-start (one-shot ESM
+# compile of server.ts + imports on first boot). On fresh Railway containers
+# this can exceed the 90s (3-strike) budget, and — now that the agent kill is
+# effective via the process-tree walk above (previously the orphan bug made it
+# cosmetic) — a slow boot would be genuinely killed and enter a restart loop.
+# Wait up to 180s for the first healthy /health probe before arming the strike
+# counter; if /health comes up sooner, fall through immediately. If 180s
+# elapses without success, arm the counter anyway — the steady-state watchdog
+# will handle a true hang. Mirrors langgraph-typescript/entrypoint.sh.
 (
+  GRACE=180
+  echo "[watchdog] Startup grace: waiting up to ${GRACE}s for first successful health probe before arming strike counter"
+  ELAPSED=0
+  while [ $ELAPSED -lt $GRACE ]; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent died during startup — wait -n in the main shell will handle it.
+      exit 0
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8000/health > /dev/null 2>&1; then
+      echo "[watchdog] Agent healthy after ${ELAPSED}s — arming strike counter"
+      break
+    fi
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+  done
+  if [ $ELAPSED -ge $GRACE ]; then
+    echo "[watchdog] Grace window elapsed without successful probe — arming strike counter anyway"
+  fi
+
   FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -166,7 +195,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 ) &
 WATCHDOG_PID=$!
 
-echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID)"
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8000/health, startup grace 180s)"
 echo "[entrypoint] All processes running. Waiting..."
 
 # Only wait on agent + next.js — NOT the watchdog.

--- a/showcase/integrations/strands-typescript/entrypoint.sh
+++ b/showcase/integrations/strands-typescript/entrypoint.sh
@@ -133,8 +133,30 @@ _kill_agent_tree() {
 _require_int() {
   local name="$1" default="$2" label="$3" value
   eval "value=\${$name}"
+  # Valid ONLY if a positive integer with no leading zero: first digit 1-9,
+  # rest digits ([1-9][0-9]*).  This rejects — and falls back to the default
+  # for — every operator-typo class that would break a guard:
+  #   • empty / non-numeric ("", "60s", "abc")
+  #   • "0" — a zero threshold/interval/limit turns a guard into an instant-fire
+  #     kill loop (SIZE_THRESHOLD_MB=0 kills on cycle 1) or a busy-spin
+  #     (SIZE_CHECK_INTERVAL=0 → `while sleep 0`)
+  #   • leading-zero / octal forms ("010", "08") — bash arithmetic reads a
+  #     leading-zero literal as OCTAL, so "010" becomes 8 (wrong value) and an
+  #     "08"/"09" digit aborts the script under `set -e` ("value too great for
+  #     base").
+  # The `[1-9]*([0-9])` extglob-free equivalent is written as two arms: a lone
+  # single digit 1-9, or a 1-9 lead followed by one-or-more digits.
   case "$value" in
-    ''|*[!0-9]*)
+    [1-9]) : ;;                # single positive digit
+    [1-9][0-9]*)               # multi-digit, must be all digits after the lead
+      case "$value" in
+        *[!0-9]*)
+          echo "[entrypoint] WARNING: ${label} (${name}) is not a positive integer (got: '${value}') — falling back to default ${default}"
+          printf -v "$name" '%s' "$default"
+          ;;
+      esac
+      ;;
+    *)
       echo "[entrypoint] WARNING: ${label} (${name}) is not a positive integer (got: '${value}') — falling back to default ${default}"
       printf -v "$name" '%s' "$default"
       ;;

--- a/showcase/integrations/strands-typescript/entrypoint.sh
+++ b/showcase/integrations/strands-typescript/entrypoint.sh
@@ -199,8 +199,18 @@ echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.
 echo "[entrypoint] All processes running. Waiting..."
 
 # Only wait on agent + next.js — NOT the watchdog.
-wait -n $AGENT_PID $NEXTJS_PID
-EXIT_CODE=$?
+#
+# `|| EXIT_CODE=$?` is LOAD-BEARING under `set -e`: the PRIMARY designed exit
+# path here is a NON-ZERO wait (137 = the watchdog SIGKILL of the agent tree,
+# or an agent crash).  Without the `||` guard, `set -e` aborts the script AT
+# this line on exactly those interesting exits, making the entire "which
+# process exited with code N" diagnostic below AND the final explicit
+# `exit $EXIT_CODE` dead code — the container still restarts (EXIT trap runs
+# cleanup, script exits non-zero) but the operator-facing diagnostic never
+# prints.  Capturing the code preserves it exactly (incl. 137) for both the
+# diagnostic and the final exit, and the container-restart path is unchanged.
+EXIT_CODE=0
+wait -n "$AGENT_PID" "$NEXTJS_PID" || EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
   echo "[entrypoint] Agent (PID: $AGENT_PID) exited with code $EXIT_CODE"
 elif ! kill -0 $NEXTJS_PID 2>/dev/null; then


### PR DESCRIPTION
## What & why

Two showcase agent containers (**langgraph-typescript**, **strands-typescript**) could enter a *running-but-dead* state: Railway showed the service `● Online` while `/api/health` returned **HTTP 502**. This took down all 36 LGT dashboard cells on staging **and** prod (prod's `.langgraph_api` had crossed the 200 MB size-watchdog threshold).

**Root cause:** the agent is launched via process substitution (`... &> >(awk …) &`), so `$AGENT_PID` (`=$!`) is the **wrapper subshell**, not the real `npm`→`node` server that holds the port. Every watchdog/cleanup did a bare `kill -9 $AGENT_PID`, which reaped only the subshell and **orphaned the real server** (reparented to PID 1, still bound to the port). The watchdog's "kill agent → container restart → boot-purge" contract therefore never fired: the frontend kept proxying to a dead agent → 502 forever.

## Fixes (each with local red-green on the real entrypoint in `node:22-slim`)

1. **cleanup() EXIT trap** → routes through `_kill_agent_tree` (was orphaning the agent on every SIGTERM/redeploy).
2. **`_kill_agent_tree`** → `/proc`-based tree-kill with a bounded re-scan (root killed last) so mid-walk forks can't escape; refuses PID ≤ 1 (fail-closed).
3. **size-watchdog** hardened against non-numeric `du` and transient errors (no silent gate-disable, no permanent loop death).
4. **strands health-watchdog** → 180 s startup-grace window (parity with langgraph); the now-effective kill would otherwise loop a slow cold start.
5. **`wait -n` under `set -e`** → capture exit code so the restart diagnostic isn't dead code on the primary (137) path.
6. **structural:** one `_require_int` validator over *every* operator-overridable numeric knob (fail-safe to default), and **every** wrapped-PID kill (incl. `NEXTJS_PID`) routed through the guarded tree-kill; dangerous `${AGENT_PID:-0}` sentinel removed.
7. **`_require_int`** requires a positive integer (rejects `0` and leading-zero/octal).

## Incident status
Staging **and** prod LGT were restored immediately via redeploy (boot-purge cleared the oversized state) — both `/api/health` → 200. This PR stops the recurrence.

## Review
Converged through a 5-round unbiased review-fix loop (1 + 4 confirmation), zero mandatory findings at close, all load-bearing guards independently re-verified. `bash -n` + shellcheck (`-S warning`) clean; 170/170 shell bats pass.

## Follow-up (tracked, separate PR — non-load-bearing)
`_require_int` upper-bound clamp (LOW arith-overflow, needs a 20+-digit value); a stale `cleanup()` comment; size-guard unarmed during the startup-grace window; SIZE_PID trap-registration micro-window; diagnostic label on near-simultaneous exit; cosmetic log nits; startup readiness `sleep 3`+`kill -0` probes the wrapper subshell; no dedicated Next.js frontend watchdog.
