### PR TITLE
fix(bot): move runStateStoreConformance to @copilotkit/bot/testing subpath

### DIFF
--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -29,6 +29,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing/state-store-conformance.d.ts",
+      "import": "./dist/testing/state-store-conformance.js"
     }
   },
   "files": [
@@ -56,5 +60,13 @@
     "typescript": "^5.6.3",
     "vitest": "^4.1.3",
     "zod": "^3.25.76"
+  },
+  "peerDependencies": {
+    "vitest": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vitest": {
+      "optional": true
+    }
   }
 }

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -64,7 +64,11 @@ export { ActionRegistry, ActionExpiredError } from "./action-registry.js";
 // State store
 export type { StateStore } from "./state/state-store.js";
 export { MemoryStore } from "./state/memory-store.js";
-export { runStateStoreConformance } from "./testing/state-store-conformance.js";
+// NOTE: `runStateStoreConformance` is intentionally NOT re-exported here. It
+// pulls in `vitest`, so re-exporting it from the package entry would drag a
+// test framework into every consumer's runtime module graph (a bare
+// `import ... from "@copilotkit/bot"` would fail unless vitest is installed).
+// It is published under the `@copilotkit/bot/testing` subpath instead.
 export { parseDuration } from "./state/duration.js";
 export { createStateBackedConversationStore } from "./state/state-conversation-store.js";
 

--- a/showcase/shell-docs/src/content/docs/bots/persistence.mdx
+++ b/showcase/shell-docs/src/content/docs/bots/persistence.mdx
@@ -67,7 +67,7 @@ icon: "lucide/Database"
     The package ships `runStateStoreConformance(name, make, teardown?)` — a Vitest describe block that verifies your implementation against the full contract (locking, dedup, state round-trips). Run it in your test suite before wiring the store into production:
 
     ```ts
-    import { runStateStoreConformance } from "@copilotkit/bot";
+    import { runStateStoreConformance } from "@copilotkit/bot/testing";
 
     runStateStoreConformance(
       "MyDurableStore",

--- a/showcase/shell-docs/src/content/reference/bot/types/StateStore.mdx
+++ b/showcase/shell-docs/src/content/reference/bot/types/StateStore.mdx
@@ -139,7 +139,7 @@ To use a durable store (Redis, Postgres, or any other persistence layer), implem
 Implement all five primitive groups of the `StateStore` interface and pass your instance as `store.adapter`. Run the conformance suite to verify correctness:
 
 ```ts
-import { runStateStoreConformance } from "@copilotkit/bot";
+import { runStateStoreConformance } from "@copilotkit/bot/testing";
 
 runStateStoreConformance(
   "MyCustomStore",


### PR DESCRIPTION
## Problem

`@copilotkit/bot`'s package entry re-exports `runStateStoreConformance` from `./testing/state-store-conformance`, which does `import { describe, it, expect, ... } from "vitest"` at module top-level. In ESM a static re-export **eagerly evaluates** the re-exported module, so a plain:

```ts
import { createBot } from "@copilotkit/bot";
```

drags `vitest` into the consumer's runtime module graph and throws `ERR_MODULE_NOT_FOUND: Cannot find package 'vitest'` for any consumer that doesn't have vitest installed (i.e. every production consumer). `vitest` is only a devDependency.

Surfaced while smoke-testing the package rename (OSS-438) — but it's a pre-existing bug on `main`, independent of that rename.

## Fix

- **Drop the re-export from `src/index.ts`** → the package entry is now vitest-free.
- **Publish the helper under a `./testing` subpath** (`@copilotkit/bot/testing`) — test tooling lives off the runtime entry, the standard pattern.
- **Declare `vitest` as an optional `peerDependency`** so consumers of `/testing` get the right signal.
- **Docs** updated to `import { runStateStoreConformance } from "@copilotkit/bot/testing"`.

Only the import path of the test-only conformance helper changes; the runtime API is untouched.

## Verification
- Static import trace: the entry graph is 12 runtime modules, **none** import vitest; every vitest importer is a `.test.js` (not in the graph) or `testing/state-store-conformance.js` (only reachable via `/testing`).
- `@copilotkit/bot` builds; **143/143** tests pass; `publint` + `attw` clean (the internal conformance test imports the helper by relative path, unaffected).

## Coordination
Touches `packages/bot` on `main`. The OSS-438 rename PR (#5849) renames this package to `@copilotkit/channels`; that PR re-derives from `main` before merge, so it will absorb this fix automatically. If #5849 merges first, this rebases onto `packages/channels` mechanically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)