### PR TITLE
fix(showcase-harness): wait on SSE turn-complete signal for D4 first token

### DIFF
--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -1923,3 +1923,143 @@ describe("d4 CVDIAG cross-layer join: probe adopts the forwarded X-Test-Id", () 
     expect(session.resolvedTestId).toBe(backendAdopted);
   });
 });
+
+// --- First-token wait hardening (client-side race) -----------------------
+//
+// REGRESSION SURFACE: D4's L4 "tools" probe reads the assistant-message
+// container's textContent by polling for up to `textPollTimeoutMs`. On a run
+// where the FIRST token renders into the DOM slightly LATER than that poll
+// budget — but the agent turn genuinely produces content (SSE RUN_STARTED →
+// RUN_FINISHED) — the pre-fix poll loop exhausted its fixed budget and read
+// the container as empty, yielding a spurious "L4: empty assistant response"
+// red. The turn was NOT empty; the assertion just fired before the first
+// token had a chance to arrive. The hardening waits on the SSE turn-complete
+// signal (RUN_FINISHED / RUN_ERROR) plus a bounded first-token grace window,
+// so a late-but-present first token is captured, while a turn that genuinely
+// completes with NO content still fails.
+
+/**
+ * A CVDIAG-instrumented fake page that models the late-first-token race with
+ * REAL wall-clock timing (no fake timers): the assistant-message `evaluate`
+ * read returns empty until `firstTokenDelayMs` has actually elapsed since
+ * `goto`, then returns `assistantText`. SSE lifecycle events are delivered on
+ * `goto` (RUN_STARTED + a terminal event) so the driver can observe that the
+ * turn completed. Setting `textPollTimeoutMs` BELOW `firstTokenDelayMs`
+ * reproduces the pre-fix race deterministically.
+ */
+function makeLateTokenBrowser(opts: {
+  assistantText: string;
+  firstTokenDelayMs: number;
+  /** Terminal SSE event type for the turn. */
+  terminalSse: "RUN_FINISHED" | "RUN_ERROR";
+  /** Omit RUN_STARTED/terminal to model "turn never started/finished". */
+  sseEvents?: CvdiagSseEvent[];
+}): CvE2eBrowser {
+  let sseHandler: ((e: CvdiagSseEvent) => void) | undefined;
+  let gotoAtMs = 0;
+  let assistantReadStarted = false;
+  const defaultSse: CvdiagSseEvent[] = [
+    { eventType: "RUN_STARTED", payloadSizeBytes: 20 },
+    { eventType: opts.terminalSse, payloadSizeBytes: 10 },
+  ];
+  const page: CvE2ePage = {
+    async goto() {
+      gotoAtMs = Date.now();
+      for (const e of opts.sseEvents ?? defaultSse) sseHandler?.(e);
+      return null;
+    },
+    async type() {},
+    async press() {},
+    async waitForSelector() {},
+    async textContent() {
+      return "";
+    },
+    async evaluate<R>(): Promise<R> {
+      // The assistant-text poll and the alternate-content histogram read both
+      // route through evaluate(). Distinguish them by whether the first token
+      // has "arrived": before firstTokenDelayMs → empty (poll still waiting);
+      // after → the assistant text. The histogram read (post-empty-exit) also
+      // lands here and returns {} harmlessly.
+      const elapsed = Date.now() - gotoAtMs;
+      if (!assistantReadStarted) assistantReadStarted = true;
+      if (opts.assistantText.length > 0 && elapsed >= opts.firstTokenDelayMs) {
+        return opts.assistantText as unknown as R;
+      }
+      return "" as unknown as R;
+    },
+    async close() {},
+    onSseEvent(h) {
+      sseHandler = h;
+    },
+  };
+  const ctx: CvE2eBrowserContext = {
+    async newPage() {
+      return page;
+    },
+    async close() {},
+  };
+  return {
+    async newContext() {
+      return ctx;
+    },
+    async close() {},
+  };
+}
+
+/** Run the driver against a late-token browser and return the L4 result. */
+async function runLateToken(browser: CvE2eBrowser): Promise<{
+  l4State: string;
+  failureSummary: string;
+}> {
+  const writer = new CapturingWriter();
+  const driver = createE2eSmokeDriver({
+    launcher: async () => browser as unknown as E2eBrowser,
+    // Below the 300ms first-token delay in the tests → pre-fix poll exhausts.
+    textPollTimeoutMs: 120,
+    // Bounded ceiling for the signal-based wait — plenty above the delay.
+    pageTimeoutMs: 4000,
+  });
+  await driver.run(baseCtx({ writer }), {
+    key: "e2e-smoke:foo",
+    backendUrl: "https://x.example.com",
+    demos: ["tool-rendering"],
+  });
+  const l4 = writer.results.find((r) => r.key === "tools:foo");
+  const signal = (l4?.signal ?? {}) as { failureSummary?: string };
+  return {
+    l4State: String(l4?.state ?? "missing"),
+    failureSummary: signal.failureSummary ?? "",
+  };
+}
+
+describe("d4 L4 first-token wait hardening", () => {
+  it("late-but-present first token (turn RUN_FINISHED, token renders after textPollTimeoutMs) PASSES", async () => {
+    // The turn genuinely produces content — SSE RUN_STARTED → RUN_FINISHED —
+    // but the first DOM token renders at 300ms, AFTER the 120ms poll budget.
+    // Pre-fix: RED ("empty assistant response"). Post-fix: GREEN.
+    const { l4State, failureSummary } = await runLateToken(
+      makeLateTokenBrowser({
+        assistantText: "The weather in San Francisco is sunny, 72 degrees.",
+        firstTokenDelayMs: 300,
+        terminalSse: "RUN_FINISHED",
+      }),
+    );
+    expect(l4State).toBe("green");
+    expect(failureSummary).toBe("");
+  });
+
+  it("genuinely-empty completed turn (RUN_FINISHED, no content ever) still FAILS", async () => {
+    // Guard against over-correcting into a false-PASS: a turn that completes
+    // (RUN_FINISHED) but never renders any assistant content must still be a
+    // red "empty assistant response", even after the grace window.
+    const { l4State, failureSummary } = await runLateToken(
+      makeLateTokenBrowser({
+        assistantText: "",
+        firstTokenDelayMs: 300,
+        terminalSse: "RUN_FINISHED",
+      }),
+    );
+    expect(l4State).toBe("red");
+    expect(failureSummary).toContain("empty assistant response");
+  });
+});

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -1968,10 +1968,30 @@ function makeLateTokenBrowser(opts: {
   neverComplete?: boolean;
   /** With neverComplete: a resend (2nd attempt) rescues the turn. */
   retrySucceeds?: boolean;
+  /**
+   * Count of PRIOR finished runs already latched on the page BEFORE the user's
+   * turn starts (auto-greeting / initial-mount run). The page-side globals are
+   * MONOTONIC, so `runsFinished` and `runStartCount` both start at this value
+   * and the current turn only bumps them PAST it. This reproduces the a1
+   * attempt-scoping bug: keying completion off the page-global `runsFinished
+   * >= 1` false-reds the in-flight user turn because a prior run already
+   * satisfied `>= 1`.
+   */
+  priorFinishedRuns?: number;
+  /** Report the interceptor as having failed to attach (finding-3 surface). */
+  sseAttachFailed?: boolean;
+  /** Callback invoked with the sendCount on each send (retry-count assertions). */
+  onSend?: (sendCount: number) => void;
 }): CvE2eBrowser {
   let lastSendAtMs = 0;
   let sendCount = 0;
   const completeAt = opts.completeAtDelayMs ?? 0;
+  const prior = opts.priorFinishedRuns ?? 0;
+  // Realistic wall-clock ms for the PRIOR run's stop edge (captured at browser
+  // construction — before any user turn). Used as `lastStoppedAtMs` while the
+  // current turn is still in-flight so the pre-fix false-completion stamps its
+  // grace window from a REAL (past) timestamp, reproducing the a1 false-red.
+  const priorStoppedAtMs = Date.now();
   const page: CvE2ePage = {
     async goto() {
       return null;
@@ -1982,6 +2002,7 @@ function makeLateTokenBrowser(opts: {
       // send so a resend restarts the first-token / completion clocks.
       lastSendAtMs = Date.now();
       sendCount += 1;
+      opts.onSend?.(sendCount);
     },
     async waitForSelector() {},
     async textContent() {
@@ -2009,11 +2030,30 @@ function makeLateTokenBrowser(opts: {
       const rescued = opts.retrySucceeds === true && sendCount >= 2;
       const complete =
         (!opts.neverComplete || rescued) && elapsed >= completeAt;
+      // MONOTONIC page-global counters (they only ever grow, exactly like the
+      // real `attachSseInterceptor` globals). `prior` runs already latched
+      // before the user's FIRST turn. Every send starts one run
+      // (`runStartCount = prior + sendCount`). All PRIOR sends' turns are done;
+      // the CURRENT (latest) turn is done once `complete`
+      // (`runsFinished = prior + (sendCount - 1) + (complete ? 1 : 0)`). This is
+      // what lets a shared page survive L3→L4 (two sequential sends) with the
+      // per-attempt baseline correctly scoping completion to each turn.
+      const started = sendCount > 0;
+      const priorSendsDone = Math.max(0, sendCount - 1);
       return {
-        runsFinished: complete ? 1 : 0,
+        runsFinished: prior + priorSendsDone + (complete ? 1 : 0),
         attrPresent: true,
-        sawRunningTrue: true,
-        runningNow: !complete,
+        sawRunningTrue: prior > 0 || started,
+        runningNow: started ? !complete : prior > 0 ? false : null,
+        runStartCount: prior + sendCount,
+        // Current turn complete → stamp NOW; else the most-recent stop is a
+        // prior run's (a real past timestamp) when any prior run has finished.
+        lastStoppedAtMs: complete
+          ? Date.now()
+          : prior > 0 || priorSendsDone > 0
+            ? priorStoppedAtMs
+            : 0,
+        sseAttachFailed: opts.sseAttachFailed === true,
       };
     },
     async close() {},
@@ -2057,6 +2097,40 @@ async function runLateToken(
   const signal = (l4?.signal ?? {}) as { failureSummary?: string };
   return {
     l4State: String(l4?.state ?? "missing"),
+    failureSummary: signal.failureSummary ?? "",
+  };
+}
+
+/**
+ * Run the driver against a late-token browser and return the L3 (chat) result.
+ * L3 uses the `agentic-chat` demo (no `tool-rendering`), so the aggregate green
+ * requires only the chat round-trip. Exercises the SAME first-token poll /
+ * grace / fast-fail / retry path as L4 but on the L3 level (which was
+ * previously test-covered only at L4).
+ */
+async function runLateTokenL3(
+  browser: CvE2eBrowser,
+  overrides: { pageTimeoutMs?: number } = {},
+): Promise<{
+  l3State: string;
+  failureSummary: string;
+}> {
+  const writer = new CapturingWriter();
+  const driver = createE2eSmokeDriver({
+    launcher: async () => browser as unknown as E2eBrowser,
+    textPollTimeoutMs: 120,
+    pageTimeoutMs: overrides.pageTimeoutMs ?? 4000,
+  });
+  await driver.run(baseCtx({ writer }), {
+    key: "e2e-smoke:foo",
+    backendUrl: "https://x.example.com",
+    // No tool-rendering demo → L4 skipped, aggregate green iff L3 green.
+    demos: [],
+  });
+  const l3 = writer.results.find((r) => r.key === "chat:foo");
+  const signal = (l3?.signal ?? {}) as { failureSummary?: string };
+  return {
+    l3State: String(l3?.state ?? "missing"),
     failureSummary: signal.failureSummary ?? "",
   };
 }
@@ -2128,4 +2202,190 @@ describe("d4 L4 first-token wait hardening (readTurnState-driven)", () => {
     expect(l4State).toBe("red");
     expect(failureSummary).toContain("empty assistant response");
   }, 10000);
+
+  it("a1 REGRESSION: a PRIOR finished run + still-in-flight user turn does NOT false-red", async () => {
+    // The dominant a1 bug: the page already has a PRIOR finished run
+    // (auto-greeting / initial-mount run) so the page-GLOBAL monotonic
+    // `runsFinished` is already >= 1 when the user's turn starts. The pre-fix
+    // poll keyed completion off `runsFinished >= 1`, so it thought THIS turn had
+    // already completed the instant it began, saw the still-empty container, and
+    // FAST-FAILED red — even though the user's turn was healthily in-flight and
+    // renders its token shortly after.
+    //
+    // With attempt-scoped completion (baseline captured at send time; complete
+    // only on a NEW edge past the baseline), the prior run's latched counter no
+    // longer satisfies THIS turn, the poll correctly waits for the real
+    // first-token, and the turn is GREEN.
+    //
+    // The token renders at 2400ms — PAST the ~2000ms grace window the pre-fix
+    // code stamps from its (false) turn-start "completion". Pre-fix: the prior
+    // run makes `runsFinished >= 1` true immediately, completion is stamped at
+    // ~send time, the grace window elapses at ~2000ms with the DOM still empty,
+    // and the poll REDS ("empty assistant response") before the real 2400ms
+    // token. Post-fix: baseline scoping means the prior run does NOT count, the
+    // turn is correctly treated as in-flight, the poll waits to its ceiling, and
+    // the 2400ms token is captured → GREEN. The turn genuinely completes at
+    // 2300ms (just before the token) so no retry-stall.
+    const { l4State, failureSummary } = await runLateToken(
+      makeLateTokenBrowser({
+        assistantText: "The weather in San Francisco is sunny, 72 degrees.",
+        firstTokenDelayMs: 2400,
+        completeAtDelayMs: 2300,
+        priorFinishedRuns: 1,
+      }),
+      { pageTimeoutMs: 8000 },
+    );
+    expect(l4State).toBe("green");
+    expect(failureSummary).toBe("");
+  }, 15000);
+
+  it("a1 REGRESSION (L3): prior finished run + in-flight chat turn does NOT false-red", async () => {
+    // Same a1 regression proven on the L3 (chat) level — the level that runs on
+    // EVERY service (L4 is tool-rendering-only). Prior run latches the global
+    // counter; the in-flight chat turn must still resolve GREEN once its token
+    // renders.
+    const { l3State, failureSummary } = await runLateTokenL3(
+      makeLateTokenBrowser({
+        assistantText: "Hi there! How can I help you today?",
+        firstTokenDelayMs: 2400,
+        completeAtDelayMs: 2300,
+        priorFinishedRuns: 2,
+      }),
+      { pageTimeoutMs: 8000 },
+    );
+    expect(l3State).toBe("green");
+    expect(failureSummary).toBe("");
+  }, 15000);
+
+  it("L3 (chat) late-but-present token: same grace path as L4 → GREEN", async () => {
+    // L3 coverage for the grace/fast-fail path (was L4-tools-only). A chat turn
+    // whose first token renders after the base poll floor still passes via the
+    // completion+grace window.
+    const { l3State, failureSummary } = await runLateTokenL3(
+      makeLateTokenBrowser({
+        assistantText: "A brief and friendly greeting.",
+        firstTokenDelayMs: 300,
+        completeAtDelayMs: 250,
+      }),
+    );
+    expect(l3State).toBe("green");
+    expect(failureSummary).toBe("");
+  });
+
+  it("completed-empty does exactly ONE send — fast-fail RED, retry does NOT fire (L3)", async () => {
+    // A turn that COMPLETES with empty assistant text is a real red and is NOT
+    // transient — the non-completion retry must not fire. L3 runs a SINGLE level
+    // (no tool-rendering demo), so `sendCount` is unconfounded: assert exactly
+    // one send, proving completed-empty short-circuits without a resend.
+    let sends = 0;
+    const { l3State, failureSummary } = await runLateTokenL3(
+      makeLateTokenBrowser({
+        assistantText: "",
+        firstTokenDelayMs: 300,
+        completeAtDelayMs: 50,
+        onSend: (n) => {
+          sends = n;
+        },
+      }),
+    );
+    expect(l3State).toBe("red");
+    expect(failureSummary).toContain("empty assistant response");
+    expect(sends).toBe(1);
+  });
+
+  it("L3 (chat) recoverable stall: rescued by non-completion retry → GREEN", async () => {
+    // L3 coverage for the retry path — attempt 1 stalls (never completes),
+    // resend rescues, second attempt renders content.
+    const { l3State, failureSummary } = await runLateTokenL3(
+      makeLateTokenBrowser({
+        assistantText: "Recovered greeting after a retry.",
+        firstTokenDelayMs: 100,
+        neverComplete: true,
+        retrySucceeds: true,
+      }),
+    );
+    expect(l3State).toBe("green");
+    expect(failureSummary).toBe("");
+  });
+});
+
+describe("wirePlaywrightPage attach-fault telemetry (finding 3)", () => {
+  it("surfaces an interceptor-attach fault via onAttachFault AND readTurnState.sseAttachFailed (not silently swallowed)", async () => {
+    // A failed `attachSseInterceptor` must degrade safely (navigation still
+    // proceeds) BUT leave a distinguishable, observable signal — not the pre-fix
+    // silent fall-back to the inert base-floor path. Assert both surfaces: the
+    // injected `onAttachFault` callback fires with the error, AND
+    // `readTurnState().sseAttachFailed` reads true.
+    const faults: unknown[] = [];
+    let gotoCalled = false;
+    const rawPage = {
+      goto: async () => {
+        gotoCalled = true;
+        return null;
+      },
+      type: async () => {},
+      press: async () => {},
+      waitForSelector: async () => {},
+      textContent: async () => "",
+      // The turn-lifecycle globals were never seeded (attach threw), so the
+      // page-side read returns the zeroed defaults; sseAttachFailed rides on top.
+      evaluate: async () => ({
+        runsFinished: 0,
+        attrPresent: false,
+        sawRunningTrue: false,
+        runningNow: null,
+        runStartCount: 0,
+        lastStoppedAtMs: 0,
+      }),
+      close: async () => {},
+      on: () => {},
+    };
+    const wired = wirePlaywrightPage(
+      rawPage as unknown as Parameters<typeof wirePlaywrightPage>[0],
+      // attachInterceptor throws — the fault path under test.
+      async () => {
+        throw new Error("CDP session unavailable");
+      },
+      (err) => faults.push(err),
+    );
+    // Navigation must still proceed despite the attach fault (degrade safely).
+    await wired.goto("https://x.example.com/demos/agentic-chat", {});
+    expect(gotoCalled).toBe(true);
+    // Fault surfaced through the telemetry callback.
+    expect(faults).toHaveLength(1);
+    expect((faults[0] as Error).message).toContain("CDP session unavailable");
+    // AND observable programmatically via readTurnState.
+    const st = await wired.readTurnState!();
+    expect(st.sseAttachFailed).toBe(true);
+  });
+
+  it("does NOT flag sseAttachFailed when the interceptor attaches cleanly", async () => {
+    const rawPage = {
+      goto: async () => null,
+      type: async () => {},
+      press: async () => {},
+      waitForSelector: async () => {},
+      textContent: async () => "",
+      evaluate: async () => ({
+        runsFinished: 0,
+        attrPresent: false,
+        sawRunningTrue: false,
+        runningNow: null,
+        runStartCount: 0,
+        lastStoppedAtMs: 0,
+      }),
+      close: async () => {},
+      on: () => {},
+    };
+    const wired = wirePlaywrightPage(
+      rawPage as unknown as Parameters<typeof wirePlaywrightPage>[0],
+      async () => ({ stop: async () => ({}) }),
+      () => {
+        throw new Error("onAttachFault must not fire on clean attach");
+      },
+    );
+    await wired.goto("https://x.example.com/demos/agentic-chat", {});
+    const st = await wired.readTurnState!();
+    expect(st.sseAttachFailed).toBe(false);
+  });
 });

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -2046,10 +2046,6 @@ function makeLateTokenBrowser(opts: {
       return "" as unknown as R;
     },
     async readTurnState() {
-      const elapsed = Date.now() - lastSendAtMs;
-      const rescued = opts.retrySucceeds === true && sendCount >= 2;
-      const complete =
-        (!opts.neverComplete || rescued) && elapsed >= completeAt;
       // MONOTONIC page-global counters (they only ever grow, exactly like the
       // real `attachSseInterceptor` globals). `prior` runs already latched
       // before the user's FIRST turn. Every send starts one run
@@ -2060,6 +2056,22 @@ function makeLateTokenBrowser(opts: {
       // per-attempt baseline correctly scoping completion to each turn.
       const started = sendCount > 0;
       const priorSendsDone = Math.max(0, sendCount - 1);
+      const elapsed = Date.now() - lastSendAtMs;
+      const rescued = opts.retrySucceeds === true && sendCount >= 2;
+      // Completion is a property of the CURRENT (in-flight) turn — it can only be
+      // true once a turn has actually been sent (`started`). Before the first
+      // send, `lastSendAtMs === 0` makes `elapsed` (≈ epoch ms) spuriously exceed
+      // `completeAt`, which used to flip `complete` true at the pre-send BASELINE
+      // read the driver takes before `sendTurn()`. That inflated the baseline
+      // `runsFinished` to `prior + 1`, so the current turn's real finished edge
+      // (`prior + priorSendsDone + 1`) never rose PAST the baseline and the
+      // driver's `sseDone = runsFinished > baseline.runsFinished` could never
+      // fire — leaving the SSE-only-stale-grace path (which depends on `sseDone`)
+      // untested. Gating on `started` makes the baseline read a true baseline
+      // (`runsFinished = prior + priorSendsDone`, no current-turn finish) so the
+      // finished edge is a genuine THIS-turn transition the driver observes.
+      const complete =
+        started && (!opts.neverComplete || rescued) && elapsed >= completeAt;
       // SSE-only completion: the transport `runsFinished` counter bumps but the
       // DOM run-lifecycle attribute never registers a fresh `true→false` stop
       // edge for THIS turn, so `runningNow` stays `true` and `lastStoppedAtMs`

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -1939,58 +1939,84 @@ describe("d4 CVDIAG cross-layer join: probe adopts the forwarded X-Test-Id", () 
 // completes with NO content still fails.
 
 /**
- * A CVDIAG-instrumented fake page that models the late-first-token race with
- * REAL wall-clock timing (no fake timers): the assistant-message `evaluate`
- * read returns empty until `firstTokenDelayMs` has actually elapsed since
- * `goto`, then returns `assistantText`. SSE lifecycle events are delivered on
- * `goto` (RUN_STARTED + a terminal event) so the driver can observe that the
- * turn completed. Setting `textPollTimeoutMs` BELOW `firstTokenDelayMs`
- * reproduces the pre-fix race deterministically.
+ * A fake page modelling the late-first-token race with REAL wall-clock timing
+ * (no fake timers), driven off the PRODUCTION signal — `readTurnState()`, the
+ * `attachSseInterceptor` page-side turn-lifecycle globals — NOT the never-wired
+ * `onSseEvent` Node seam the prior (inert) fix used.
+ *
+ * Timeline modelled relative to the most-recent send (`press`):
+ *   - the DOM assistant-text read (`evaluate`) returns "" until
+ *     `firstTokenDelayMs` has elapsed since the send, then `assistantText`.
+ *   - `readTurnState()` reports the turn COMPLETE at `completeAtDelayMs` after
+ *     the send (DOM run-stop edge + `runsFinished` bump), UNLESS
+ *     `neverComplete` is set (models a stalled/dropped stream that never
+ *     signals completion — the retry surface).
+ *   - `retrySucceeds`: when set with `neverComplete`, the FIRST attempt never
+ *     completes and stays empty; after a resend (`press` fires again) the turn
+ *     completes and `assistantText` renders — modelling a recoverable stall
+ *     that the non-completion retry rescues.
+ *
+ * Setting `textPollTimeoutMs` BELOW `firstTokenDelayMs` reproduces the pre-fix
+ * race deterministically.
  */
 function makeLateTokenBrowser(opts: {
   assistantText: string;
   firstTokenDelayMs: number;
-  /** Terminal SSE event type for the turn. */
-  terminalSse: "RUN_FINISHED" | "RUN_ERROR";
-  /** Omit RUN_STARTED/terminal to model "turn never started/finished". */
-  sseEvents?: CvdiagSseEvent[];
+  /** Delay (ms after send) at which readTurnState reports turn-complete. */
+  completeAtDelayMs?: number;
+  /** Model a stall: the turn NEVER signals completion (retry surface). */
+  neverComplete?: boolean;
+  /** With neverComplete: a resend (2nd attempt) rescues the turn. */
+  retrySucceeds?: boolean;
 }): CvE2eBrowser {
-  let sseHandler: ((e: CvdiagSseEvent) => void) | undefined;
-  let gotoAtMs = 0;
-  let assistantReadStarted = false;
-  const defaultSse: CvdiagSseEvent[] = [
-    { eventType: "RUN_STARTED", payloadSizeBytes: 20 },
-    { eventType: opts.terminalSse, payloadSizeBytes: 10 },
-  ];
+  let lastSendAtMs = 0;
+  let sendCount = 0;
+  const completeAt = opts.completeAtDelayMs ?? 0;
   const page: CvE2ePage = {
     async goto() {
-      gotoAtMs = Date.now();
-      for (const e of opts.sseEvents ?? defaultSse) sseHandler?.(e);
       return null;
     },
     async type() {},
-    async press() {},
+    async press() {
+      // Each Enter is one turn send; the timeline is relative to the LATEST
+      // send so a resend restarts the first-token / completion clocks.
+      lastSendAtMs = Date.now();
+      sendCount += 1;
+    },
     async waitForSelector() {},
     async textContent() {
       return "";
     },
     async evaluate<R>(): Promise<R> {
       // The assistant-text poll and the alternate-content histogram read both
-      // route through evaluate(). Distinguish them by whether the first token
-      // has "arrived": before firstTokenDelayMs → empty (poll still waiting);
-      // after → the assistant text. The histogram read (post-empty-exit) also
-      // lands here and returns {} harmlessly.
-      const elapsed = Date.now() - gotoAtMs;
-      if (!assistantReadStarted) assistantReadStarted = true;
-      if (opts.assistantText.length > 0 && elapsed >= opts.firstTokenDelayMs) {
+      // route through evaluate(). A record return is the histogram read
+      // (post-empty-exit) — return {} harmlessly. A string return is the
+      // assistant-text poll.
+      const elapsed = Date.now() - lastSendAtMs;
+      const rescued = opts.retrySucceeds === true && sendCount >= 2;
+      const tokenVisible =
+        opts.assistantText.length > 0 &&
+        elapsed >= opts.firstTokenDelayMs &&
+        // A never-completing (unrescued) turn also never renders its token.
+        (!opts.neverComplete || rescued);
+      if (tokenVisible) {
         return opts.assistantText as unknown as R;
       }
       return "" as unknown as R;
     },
-    async close() {},
-    onSseEvent(h) {
-      sseHandler = h;
+    async readTurnState() {
+      const elapsed = Date.now() - lastSendAtMs;
+      const rescued = opts.retrySucceeds === true && sendCount >= 2;
+      const complete =
+        (!opts.neverComplete || rescued) && elapsed >= completeAt;
+      return {
+        runsFinished: complete ? 1 : 0,
+        attrPresent: true,
+        sawRunningTrue: true,
+        runningNow: !complete,
+      };
     },
+    async close() {},
   };
   const ctx: CvE2eBrowserContext = {
     async newPage() {
@@ -2007,7 +2033,10 @@ function makeLateTokenBrowser(opts: {
 }
 
 /** Run the driver against a late-token browser and return the L4 result. */
-async function runLateToken(browser: CvE2eBrowser): Promise<{
+async function runLateToken(
+  browser: CvE2eBrowser,
+  overrides: { pageTimeoutMs?: number } = {},
+): Promise<{
   l4State: string;
   failureSummary: string;
 }> {
@@ -2017,7 +2046,7 @@ async function runLateToken(browser: CvE2eBrowser): Promise<{
     // Below the 300ms first-token delay in the tests → pre-fix poll exhausts.
     textPollTimeoutMs: 120,
     // Bounded ceiling for the signal-based wait — plenty above the delay.
-    pageTimeoutMs: 4000,
+    pageTimeoutMs: overrides.pageTimeoutMs ?? 4000,
   });
   await driver.run(baseCtx({ writer }), {
     key: "e2e-smoke:foo",
@@ -2032,34 +2061,71 @@ async function runLateToken(browser: CvE2eBrowser): Promise<{
   };
 }
 
-describe("d4 L4 first-token wait hardening", () => {
-  it("late-but-present first token (turn RUN_FINISHED, token renders after textPollTimeoutMs) PASSES", async () => {
-    // The turn genuinely produces content — SSE RUN_STARTED → RUN_FINISHED —
+describe("d4 L4 first-token wait hardening (readTurnState-driven)", () => {
+  it("late-but-present first token (turn completes, token renders after textPollTimeoutMs) PASSES", async () => {
+    // The turn genuinely produces content — readTurnState reports complete —
     // but the first DOM token renders at 300ms, AFTER the 120ms poll budget.
-    // Pre-fix: RED ("empty assistant response"). Post-fix: GREEN.
+    // Pre-fix: RED ("empty assistant response"). Post-fix: GREEN. Exercises the
+    // REAL production signal (readTurnState), not the dead onSseEvent seam.
     const { l4State, failureSummary } = await runLateToken(
       makeLateTokenBrowser({
         assistantText: "The weather in San Francisco is sunny, 72 degrees.",
         firstTokenDelayMs: 300,
-        terminalSse: "RUN_FINISHED",
+        completeAtDelayMs: 250,
       }),
     );
     expect(l4State).toBe("green");
     expect(failureSummary).toBe("");
   });
 
-  it("genuinely-empty completed turn (RUN_FINISHED, no content ever) still FAILS", async () => {
+  it("genuinely-empty completed turn (completes, no content ever) still FAILS", async () => {
     // Guard against over-correcting into a false-PASS: a turn that completes
-    // (RUN_FINISHED) but never renders any assistant content must still be a
-    // red "empty assistant response", even after the grace window.
+    // but never renders any assistant content must still be a red "empty
+    // assistant response", even after the grace window. NOT retried (completed
+    // ≠ transient).
     const { l4State, failureSummary } = await runLateToken(
       makeLateTokenBrowser({
         assistantText: "",
         firstTokenDelayMs: 300,
-        terminalSse: "RUN_FINISHED",
+        completeAtDelayMs: 50,
       }),
     );
     expect(l4State).toBe("red");
     expect(failureSummary).toContain("empty assistant response");
   });
+
+  it("recoverable stall (never completes on attempt 1, rescued on retry) PASSES", async () => {
+    // The real 20:16:52Z failure shape: the first turn stalls — never signals
+    // completion, never renders — so the poll exhausts its attempt ceiling
+    // WITHOUT a completed edge. The non-completion retry resends, and the
+    // second turn renders content → GREEN. Distinguishes "never-completed"
+    // (transient, retry) from "completed-empty" (real red, no retry).
+    const { l4State, failureSummary } = await runLateToken(
+      makeLateTokenBrowser({
+        assistantText: "The weather in San Francisco is sunny, 72 degrees.",
+        firstTokenDelayMs: 100,
+        neverComplete: true,
+        retrySucceeds: true,
+      }),
+    );
+    expect(l4State).toBe("green");
+    expect(failureSummary).toBe("");
+  });
+
+  it("permanent stall (never completes, retry also stalls) FAILS", async () => {
+    // A turn that never completes and never renders even after the retry is a
+    // red — but the retry was attempted (transient hypothesis exhausted). Two
+    // attempts × the per-attempt ceiling → keep pageTimeoutMs small so the
+    // whole envelope stays well under the vitest per-test timeout.
+    const { l4State, failureSummary } = await runLateToken(
+      makeLateTokenBrowser({
+        assistantText: "",
+        firstTokenDelayMs: 100,
+        neverComplete: true,
+      }),
+      { pageTimeoutMs: 1500 },
+    );
+    expect(l4State).toBe("red");
+    expect(failureSummary).toContain("empty assistant response");
+  }, 10000);
 });

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -1980,6 +1980,24 @@ function makeLateTokenBrowser(opts: {
   priorFinishedRuns?: number;
   /** Report the interceptor as having failed to attach (finding-3 surface). */
   sseAttachFailed?: boolean;
+  /**
+   * Model an SSE-ONLY completion: the turn completes via the `runsFinished`
+   * transport counter bumping past baseline, but NO fresh DOM `true→false`
+   * stop-edge fires for THIS turn, so `lastStoppedAtMs` keeps holding a STALE
+   * PRIOR-run page-clock value (never re-stamped for the current turn). This
+   * reproduces the grace-window-collapse bug: the pre-fix poll stamps
+   * `completeAtMs` from that stale past `lastStoppedAtMs`, so `graceEnd` lands
+   * in the past and the grace window collapses to the base floor → a
+   * late-but-present first token false-reds. Requires `priorFinishedRuns >= 1`
+   * so a genuinely-stale prior stamp exists.
+   */
+  sseOnlyStaleStop?: boolean;
+  /**
+   * Age the prior-run stop stamp (`lastStoppedAtMs`) this many ms into the past.
+   * With `sseOnlyStaleStop`, makes the stale stamp genuinely old so a pre-fix
+   * `graceEnd = staleStop + FIRST_TOKEN_GRACE_MS` lands in the past.
+   */
+  priorStoppedAgoMs?: number;
   /** Callback invoked with the sendCount on each send (retry-count assertions). */
   onSend?: (sendCount: number) => void;
 }): CvE2eBrowser {
@@ -1987,11 +2005,13 @@ function makeLateTokenBrowser(opts: {
   let sendCount = 0;
   const completeAt = opts.completeAtDelayMs ?? 0;
   const prior = opts.priorFinishedRuns ?? 0;
-  // Realistic wall-clock ms for the PRIOR run's stop edge (captured at browser
-  // construction — before any user turn). Used as `lastStoppedAtMs` while the
-  // current turn is still in-flight so the pre-fix false-completion stamps its
-  // grace window from a REAL (past) timestamp, reproducing the a1 false-red.
-  const priorStoppedAtMs = Date.now();
+  // Realistic wall-clock ms for the PRIOR run's stop edge. Normally captured at
+  // browser construction (just before the user turn); `priorStoppedAgoMs` ages
+  // it further into the past to model a prior run that finished well before the
+  // current turn — so a pre-fix poll that (wrongly) stamps the grace window from
+  // this STALE value computes a `graceEnd` that has already elapsed, collapsing
+  // the grace window to the base floor.
+  const priorStoppedAtMs = Date.now() - (opts.priorStoppedAgoMs ?? 0);
   const page: CvE2ePage = {
     async goto() {
       return null;
@@ -2040,19 +2060,33 @@ function makeLateTokenBrowser(opts: {
       // per-attempt baseline correctly scoping completion to each turn.
       const started = sendCount > 0;
       const priorSendsDone = Math.max(0, sendCount - 1);
+      // SSE-only completion: the transport `runsFinished` counter bumps but the
+      // DOM run-lifecycle attribute never registers a fresh `true→false` stop
+      // edge for THIS turn, so `runningNow` stays `true` and `lastStoppedAtMs`
+      // is NEVER re-stamped — it keeps holding the STALE prior-run value.
+      const sseOnly = opts.sseOnlyStaleStop === true;
+      const runningNow = started
+        ? sseOnly
+          ? true
+          : !complete
+        : prior > 0
+          ? false
+          : null;
       return {
         runsFinished: prior + priorSendsDone + (complete ? 1 : 0),
         attrPresent: true,
         sawRunningTrue: prior > 0 || started,
-        runningNow: started ? !complete : prior > 0 ? false : null,
+        runningNow,
         runStartCount: prior + sendCount,
         // Current turn complete → stamp NOW; else the most-recent stop is a
         // prior run's (a real past timestamp) when any prior run has finished.
-        lastStoppedAtMs: complete
-          ? Date.now()
-          : prior > 0 || priorSendsDone > 0
-            ? priorStoppedAtMs
-            : 0,
+        // SSE-only: no fresh DOM stop edge fires, so the stamp STAYS stale.
+        lastStoppedAtMs:
+          complete && !sseOnly
+            ? Date.now()
+            : prior > 0 || priorSendsDone > 0
+              ? priorStoppedAtMs
+              : 0,
         sseAttachFailed: opts.sseAttachFailed === true,
       };
     },
@@ -2232,6 +2266,34 @@ describe("d4 L4 first-token wait hardening (readTurnState-driven)", () => {
         firstTokenDelayMs: 2400,
         completeAtDelayMs: 2300,
         priorFinishedRuns: 1,
+      }),
+      { pageTimeoutMs: 8000 },
+    );
+    expect(l4State).toBe("green");
+    expect(failureSummary).toBe("");
+  }, 15000);
+
+  it("SSE-only completion with a STALE lastStoppedAtMs does NOT collapse the grace window (late-but-present token) → GREEN", async () => {
+    // Grace-window-collapse bug: the turn completes via the transport
+    // `runsFinished` counter (SSE-only) but NO fresh DOM stop-edge fires for
+    // THIS turn, so the page-side `lastStoppedAtMs` still holds a STALE prior-run
+    // timestamp (here aged 5s into the past). The pre-fix poll stamped
+    // `completeAtMs` from that stale `lastStoppedAtMs`, so
+    // `graceEnd = staleStop + FIRST_TOKEN_GRACE_MS` landed ~3s in the PAST — the
+    // ~2s grace window collapsed to the base poll floor, and the poll declared
+    // the turn completed-empty BEFORE the real first token (1000ms after send,
+    // 700ms after completion, comfortably inside a healthy grace window) → a
+    // false RED. Post-fix stamps `completeAtMs` from the Node clock at the first
+    // poll that observes completion, so the grace window measures forward from
+    // real completion time and the late-but-present token is captured → GREEN.
+    const { l4State, failureSummary } = await runLateToken(
+      makeLateTokenBrowser({
+        assistantText: "The weather in San Francisco is sunny, 72 degrees.",
+        firstTokenDelayMs: 1000,
+        completeAtDelayMs: 300,
+        priorFinishedRuns: 1,
+        sseOnlyStaleStop: true,
+        priorStoppedAgoMs: 5000,
       }),
       { pageTimeoutMs: 8000 },
     );

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -10,6 +10,7 @@ import type { BrowserPool } from "../helpers/browser-pool.js";
 import type { ProbeDriver } from "../types.js";
 import type { ProbeContext, ProbeResult } from "../../types/index.js";
 import { mintRunId } from "../helpers/cv-diag.js";
+import { attachSseInterceptor } from "../helpers/sse-interceptor.js";
 import { CvdiagEmitter, filterEdgeHeaders } from "../../cvdiag/index.js";
 import type {
   CvdiagFailureClassifier,
@@ -164,6 +165,36 @@ export interface E2eSmokeLevelSignal {
 }
 
 /**
+ * A snapshot of the page-side AG-UI turn lifecycle, read from the window
+ * globals that `attachSseInterceptor` installs at `document_start` (see
+ * `helpers/sse-interceptor.ts`). This is the SAME production-wired signal the
+ * d6 probe path (`waitForTurnComplete`) trusts — NOT the never-attached
+ * `onSseEvent` Node-side seam the prior fix keyed off (which left the whole
+ * mechanism inert in production).
+ *
+ *   - `runsFinished`   `window.__hk_runsFinished` — count of `RUN_FINISHED`
+ *                      SSE events the page-side fetch-wrap has observed. `>= 1`
+ *                      once the current turn has terminated. This is the
+ *                      transport-level turn-complete signal.
+ *   - `attrPresent`    true once the `[data-testid="copilot-chat"]`
+ *                      `data-copilot-running` attribute has been seen at all —
+ *                      i.e. the DOM run-lifecycle observer has something real to
+ *                      report. The DOM edge (`runningNow` false after a
+ *                      `sawRunningTrue`) is the transport-INDEPENDENT done-signal
+ *                      d6 prefers.
+ *   - `sawRunningTrue` true once `data-copilot-running` was ever `true` — i.e. a
+ *                      run actually started on this page.
+ *   - `runningNow`     current `data-copilot-running` state (null before first
+ *                      observation).
+ */
+export interface TurnState {
+  runsFinished: number;
+  attrPresent: boolean;
+  sawRunningTrue: boolean;
+  runningNow: boolean | null;
+}
+
+/**
  * Minimal Page surface the driver relies on. Captured here rather than
  * imported from `playwright` so unit tests can hand in a stub without
  * pulling the full runtime type tree (which carries ESM/CJS conditionals
@@ -217,10 +248,29 @@ export interface E2ePage {
   onRequestFailed?(handler: (req: CvdiagRequestFailedEvent) => void): void;
   /** Register a handler invoked for every browser console message. */
   onConsole?(handler: (msg: CvdiagConsoleEvent) => void): void;
-  /** Register a handler invoked for every observed SSE event. */
+  /**
+   * Register a handler invoked for every observed SSE event.
+   *
+   * NOTE: production SSE capture does NOT flow through this Node-side seam —
+   * the real launchers never wire it (Playwright's `page.on` has no per-SSE
+   * signal), so it fires ONLY when a test fake invokes the handler
+   * synthetically. It feeds the `probe.sse.event` CVDIAG telemetry stream and
+   * nothing that gates red/green. The authoritative production turn-complete
+   * signal is `readTurnState()` (the `attachSseInterceptor` page-side globals),
+   * which the first-token poll actually keys off.
+   */
   onSseEvent?(handler: (evt: CvdiagSseEvent) => void): void;
   /** Register a handler invoked when an SSE stream aborts abnormally. */
   onSseAborted?(handler: (evt: CvdiagSseAbortedEvent) => void): void;
+  /**
+   * Read the page-side AG-UI turn lifecycle snapshot (see `TurnState`). The
+   * real launchers back this with a `page.evaluate` of the `__hk_runsFinished`
+   * / `__hk_copilotRunning` window globals that `attachSseInterceptor` installs
+   * at `document_start`. OPTIONAL: a fake page that doesn't model the turn
+   * lifecycle simply omits it, and the driver's first-token poll then falls
+   * back to the base budget floor (no in-flight-turn signal to wait on).
+   */
+  readTurnState?(): Promise<TurnState>;
 }
 
 // The normalized CVDIAG event-source shapes (`CvdiagResponseEvent`,
@@ -402,29 +452,42 @@ const WEATHER_VOCAB = [
 ];
 
 /**
- * AG-UI SSE lifecycle events that mark a turn as COMPLETE (the agent run
- * lifecycle: `RUN_STARTED` → … → `RUN_FINISHED`/`RUN_ERROR`). The DOM
- * first-token poll (see `runLevel`) uses these — not a fixed short timeout —
- * to decide when a turn has genuinely finished, so it never asserts
- * "empty assistant response" before the turn has had a chance to render its
- * first token. Matched via the normalized `CvdiagSseEvent.eventType` the SSE
- * interceptor already surfaces (see helpers/sse-interceptor.ts).
- */
-const TURN_COMPLETE_SSE_EVENTS: ReadonlySet<string> = new Set([
-  "RUN_FINISHED",
-  "RUN_ERROR",
-]);
-
-/**
- * After a turn-complete SSE event (`RUN_FINISHED`/`RUN_ERROR`) is observed but
- * the assistant-message container is still empty, keep polling the DOM for
- * this long before declaring the turn genuinely empty. The first token often
- * renders a beat AFTER the SSE finish (React commit + markdown render), so a
- * small grace window converts a "completed but DOM not yet painted" read into
- * a captured first token, while a truly-empty completed turn still fails once
- * the grace elapses. Bounded and small so a genuinely-empty turn fails fast.
+ * After the turn has COMPLETED (a real turn-complete edge from
+ * `readTurnState()`) but the assistant-message container is still empty, keep
+ * polling the DOM for this long before declaring the turn genuinely empty. The
+ * first token often renders a beat AFTER the transport finish (React commit +
+ * markdown render), so a small grace window converts a "completed but DOM not
+ * yet painted" read into a captured first token, while a truly-empty completed
+ * turn still fails once the grace elapses. Bounded and small so a
+ * genuinely-empty completed turn fails fast.
  */
 const FIRST_TOKEN_GRACE_MS = 2000;
+
+/**
+ * Fast-fail budget for a turn that COMPLETES with empty assistant text. With a
+ * real turn-complete signal available (`readTurnState()`), we no longer burn
+ * the flat `pageTimeoutMs` (~60s) on a genuinely-empty completed turn: once the
+ * turn reports complete AND the short `FIRST_TOKEN_GRACE_MS` window has elapsed
+ * with still-empty DOM, the poll gives up here. The overall first-token budget
+ * for a COMPLETED turn is thus bounded by roughly this value (whichever is
+ * later: the base floor, or completion + grace, capped at the hard ceiling) —
+ * ~15-20s in practice rather than the flat 60s. A genuinely-completed-empty
+ * turn still reds (no masking): completion is observed, grace elapses, DOM is
+ * empty → red.
+ */
+const FIRST_TOKEN_FAST_FAIL_MS = 15_000;
+
+/**
+ * Max number of times the first-token wait retries the turn when it NEVER
+ * signals completion within budget (a stalled / dropped stream — the real
+ * 20:16:52Z failure where aimock served content but the page never rendered
+ * it). A never-completing turn is transient, so we resend once before red
+ * rather than immediate red. A turn that DID complete-empty is NOT transient
+ * and is never retried (it reds immediately per the fast-fail path). Bounded to
+ * 1 so total wall-clock stays within the `pageTimeoutMs` ceiling budgeted for
+ * the retry envelope (see `runLevel`'s per-attempt ceiling arithmetic).
+ */
+const NON_COMPLETION_RETRY_LIMIT = 1;
 
 /**
  * The slice of Playwright's `Page` the launcher adapter consumes. Declared
@@ -432,8 +495,9 @@ const FIRST_TOKEN_GRACE_MS = 2000;
  * `playwright` type tree at module scope — mirroring the existing `E2ePage`
  * decoupling rationale. The CVDIAG seams (`page.on(...)`) read response /
  * requestfailed / console events; the CDP-backed SSE interceptor
- * (`helpers/sse-interceptor.ts`) is the production source for SSE events and
- * is wired by a higher layer when present.
+ * (`helpers/sse-interceptor.ts`) is attached by `wirePlaywrightPage`'s `goto`
+ * (before navigation) and its page-side turn-lifecycle globals are read via
+ * `readTurnState()` — the production turn-complete signal for the poll.
  */
 interface PlaywrightPageLike {
   goto(url: string, opts?: unknown): Promise<unknown>;
@@ -450,14 +514,29 @@ interface PlaywrightPageLike {
  * Adapt a concrete Playwright `Page` onto our `E2ePage`, wiring the CVDIAG
  * event-source seams to Playwright's `page.on("response" | "requestfailed" |
  * "console")`. Shared by both the default and pooled launchers so the seam
- * wiring lives in exactly one place. The SSE seams (`onSseEvent` /
- * `onSseAborted`) are intentionally NOT wired here: production SSE capture
- * runs through the CDP-backed interceptor (`helpers/sse-interceptor.ts`),
- * which a higher layer attaches; leaving them unwired here means the driver
- * simply emits no `probe.sse.event` rows from the network listener (correct —
- * Playwright's `page.on` has no per-SSE-event signal).
+ * wiring lives in exactly one place.
+ *
+ * SSE turn-complete signal: the per-event `onSseEvent`/`onSseAborted` seams
+ * stay unwired (Playwright's `page.on` has no per-SSE-event signal). What IS
+ * wired — the fix for the prior inert attempt — is `attachSseInterceptor`,
+ * installed on the raw page inside `goto` BEFORE navigation (mirrors
+ * `d6-all-pills.ts`) so its `document_start` init scripts seed the page-side
+ * `__hk_runsFinished` / `__hk_copilotRunning` turn-lifecycle globals on the
+ * REAL production path. `readTurnState()` then reads those globals so the
+ * first-token poll keys off a real turn-complete edge, not a never-firing
+ * Node-side seam.
+ *
+ * `attachInterceptor` is injectable (defaults to the real
+ * `attachSseInterceptor`) so unit tests can adapt a fake Playwright page
+ * without a live chromium / CDP session.
  */
-export function wirePlaywrightPage(page: PlaywrightPageLike): E2ePage {
+export function wirePlaywrightPage(
+  page: PlaywrightPageLike,
+  attachInterceptor: (page: PlaywrightPageLike) => Promise<unknown> = (p) =>
+    attachSseInterceptor(
+      p as unknown as Parameters<typeof attachSseInterceptor>[0],
+    ),
+): E2ePage {
   // Per-request issue-time tracking so `probe.network.response.duration_ms`
   // reflects the request→response wall-clock, not just the response event.
   //
@@ -473,13 +552,63 @@ export function wirePlaywrightPage(page: PlaywrightPageLike): E2ePage {
   // non-zero rather than colliding to 0.)
   const requestStartsByUrl = new Map<string, number[]>();
   return {
-    goto: (url, opts) => page.goto(url, opts),
+    goto: async (url, opts) => {
+      // Install the SSE interceptor's `document_start` init scripts BEFORE
+      // navigation (mirrors d6-all-pills.ts). This is the LINCHPIN of the fix:
+      // it seeds the page-side `__hk_runsFinished` / `__hk_copilotRunning`
+      // turn-lifecycle globals that `readTurnState()` reads, so the first-token
+      // poll observes a REAL turn-complete edge on the production path. Wrapped
+      // best-effort: an interceptor-attach fault must never break navigation —
+      // the poll then falls back to the base budget floor (`readTurnState`
+      // reports no in-flight turn).
+      try {
+        await attachInterceptor(page);
+      } catch {
+        /* interceptor attach is best-effort; poll falls back to base budget */
+      }
+      return page.goto(url, opts);
+    },
     type: (sel, text, opts) => page.type(sel, text, opts),
     press: (sel, key, opts) => page.press(sel, key, opts),
     waitForSelector: (sel, opts) => page.waitForSelector(sel, opts),
     textContent: (sel) => page.textContent(sel),
     evaluate: <R>(fn: () => R) => page.evaluate(fn),
     close: () => page.close(),
+    async readTurnState(): Promise<TurnState> {
+      // Read the page-side globals `attachSseInterceptor` seeds at
+      // document_start. `__hk_runsFinished` is the transport-level turn-complete
+      // count; `__hk_copilotRunning` is the DOM run-lifecycle observer. Read
+      // both in one `evaluate` so the snapshot is coherent. Any read fault (page
+      // navigating, globals not yet seeded) degrades to a "nothing observed"
+      // snapshot — the poll then treats it as no-in-flight-turn, never a hang.
+      try {
+        return await page.evaluate(() => {
+          const g = globalThis as unknown as {
+            __hk_runsFinished?: number;
+            __hk_copilotRunning?: {
+              attrPresent?: boolean;
+              sawRunningTrue?: boolean;
+              runningNow?: boolean | null;
+            };
+          };
+          const run = g.__hk_copilotRunning;
+          return {
+            runsFinished:
+              typeof g.__hk_runsFinished === "number" ? g.__hk_runsFinished : 0,
+            attrPresent: run?.attrPresent === true,
+            sawRunningTrue: run?.sawRunningTrue === true,
+            runningNow: run?.runningNow ?? null,
+          };
+        });
+      } catch {
+        return {
+          runsFinished: 0,
+          attrPresent: false,
+          sawRunningTrue: false,
+          runningNow: null,
+        };
+      }
+    },
     onResponse(handler) {
       page.on("response", (arg) => {
         const resp = arg as {
@@ -1381,26 +1510,6 @@ async function runLevel(opts: {
   const cvdiagStartMs = nowMonoMs();
   let cvdiagExited = false;
   let cvdiagResponseEmpty = true;
-  /**
-   * Set the moment a turn-complete SSE event (`RUN_FINISHED`/`RUN_ERROR`) is
-   * observed on the `onSseEvent` seam. The first-token poll below uses this to
-   * distinguish "still streaming / not started" (keep waiting, within budget)
-   * from "turn completed" (do a bounded grace poll, then a completed-empty turn
-   * genuinely fails). Undefined until the turn completes. Wall-clock ms so it
-   * composes with the poll loop's `Date.now()` budget arithmetic.
-   */
-  let turnCompleteAtMs: number | undefined;
-  /**
-   * True once ANY SSE event has been observed on the `onSseEvent` seam. This
-   * gates the signal-based wait extension: we only wait PAST the base
-   * `textPollTimeoutMs` floor when we have positive evidence of an in-flight
-   * turn (an SSE stream exists and is producing events). When no SSE stream is
-   * observed at all — either the seam is not wired (fakes / non-Playwright
-   * paths) or the agent genuinely never streamed — there is no turn to wait
-   * for, so the poll falls back to the base budget floor and declares emptiness
-   * there (unchanged pre-fix behavior; no false hangs).
-   */
-  let sseObserved = false;
   /** Capture the agent-message POST edge headers for `probe.message.send`. */
   let messageSendEdge: ReturnType<typeof filterEdgeHeaders> | undefined;
   /**
@@ -1463,24 +1572,13 @@ async function runLevel(opts: {
       p.onRequestFailed?.((req) => cvdiag.networkError(req));
       p.onConsole?.((c) => cvdiag.consoleError(c));
       p.onSseEvent?.((e) => {
-        // First non-empty SSE event also marks first-token timing when the DOM
-        // first-token has not yet been observed — but DOM first-token is the
-        // authoritative class-(d/e) discriminator, so SSE only feeds the
-        // `probe.sse.event` stream here. firsttoken is emitted from the DOM
-        // poll below.
+        // TELEMETRY-ONLY: feeds the `probe.sse.event` CVDIAG stream. This
+        // Node-side seam fires exclusively when a TEST FAKE invokes it — the
+        // real launchers never wire it (Playwright has no per-SSE-event
+        // signal). It does NOT gate red/green or the first-token wait; the
+        // production turn-complete signal is `page.readTurnState()` (the
+        // `attachSseInterceptor` page-side globals), read inside the poll.
         cvdiag.sseEvent(e, nowMonoMs());
-        // Positive evidence that an SSE turn is in-flight — gates the
-        // signal-based wait extension in the first-token poll.
-        sseObserved = true;
-        // Turn-complete signal: record when the agent run lifecycle reaches a
-        // terminal event so the first-token poll can wait on it instead of a
-        // fixed short budget (see runLevel's DOM poll and TURN_COMPLETE_SSE_EVENTS).
-        if (
-          turnCompleteAtMs === undefined &&
-          TURN_COMPLETE_SSE_EVENTS.has(e.eventType)
-        ) {
-          turnCompleteAtMs = Date.now();
-        }
       });
       p.onSseAborted?.((e) => cvdiag.sseAborted(e));
     }
@@ -1510,15 +1608,25 @@ async function runLevel(opts: {
       navStatus,
     );
 
-    // Wait for the chat textarea, type, and submit. Selector mirrors the
-    // reference helper (showcase/tests/e2e/helpers.ts) — CopilotKit
-    // renders a single <textarea> for the chat input.
+    // Wait for the chat textarea to become interactive. Selector mirrors the
+    // reference helper (showcase/tests/e2e/helpers.ts) — CopilotKit renders a
+    // single <textarea> for the chat input. The type+press SEND itself is
+    // issued per-attempt inside `sendTurn` below so the non-completion retry
+    // can resend cleanly.
     await page.waitForSelector("textarea", {
       state: "visible",
       timeout: pageTimeoutMs,
     });
-    await page.type("textarea", message, { timeout: pageTimeoutMs });
-    await page.press("textarea", "Enter", { timeout: pageTimeoutMs });
+    // Issue one agent-message turn: type the message and submit. Extracted so
+    // the non-completion retry (a stalled/dropped stream that never signals
+    // turn-complete) can resend the SAME message without re-running navigation
+    // or the textarea wait. `pg` is the try-scoped non-null page handle.
+    const pg = page;
+    const sendTurn = async (): Promise<void> => {
+      await pg.type("textarea", message, { timeout: pageTimeoutMs });
+      await pg.press("textarea", "Enter", { timeout: pageTimeoutMs });
+    };
+    await sendTurn();
 
     // probe.message.send is NOT emitted here: at press time the agent-message
     // POST has only just been ISSUED — its response (and thus its edge headers)
@@ -1577,73 +1685,180 @@ async function runLevel(opts: {
       // returns immediately with whatever the DOM currently holds, and
       // uses `querySelectorAll` to find the last matching element by
       // index rather than by CSS pseudo-selector.
-      let raw = "";
-      // Signal-based first-token wait (hardening for the client-side render
-      // race). The pre-fix loop stopped at a FIXED `textPollTimeoutMs`, so a
-      // first token that rendered a beat later than that budget — on a turn
-      // that genuinely produced content — was read as empty → a spurious
-      // "empty assistant response" red. We instead keep polling until one of:
-      //
-      //   (a) non-empty text appears (the real success — break immediately), or
-      //   (b) the turn has COMPLETED (SSE `RUN_FINISHED`/`RUN_ERROR`, tracked
-      //       via `turnCompleteAtMs`) AND a short `FIRST_TOKEN_GRACE_MS` window
-      //       past that completion has elapsed with still-empty DOM — a
-      //       genuinely-empty completed turn, which must still fail, or
-      //   (c) the hard `pageTimeoutMs` ceiling is hit (defensive upper bound so
-      //       a turn that never completes and never renders can't hang).
-      //
-      // `textPollTimeoutMs` remains the MINIMUM budget floor (we always poll at
-      // least that long) — but we no longer DECLARE emptiness at that floor
-      // while the turn is still in-flight or just completed. This distinguishes
-      // "still streaming / not started" from "completed empty".
-      const pollStart = Date.now();
-      const baseBudgetEnd = pollStart + textPollTimeoutMs;
-      const hardCeiling = pollStart + pageTimeoutMs;
-      const pollDeadline = (): number => {
-        // No SSE turn observed at all → no in-flight turn to wait for; use the
-        // base budget floor (unchanged pre-fix behavior). This is the path when
-        // the SSE seam is unwired OR the agent genuinely never streamed, and it
-        // keeps a truly-dead run from hanging to the hard ceiling.
-        if (!sseObserved) return baseBudgetEnd;
-        if (turnCompleteAtMs !== undefined) {
-          // Turn finished: wait the base floor OR a short grace past the finish
-          // (whichever is later) for the first token to paint, capped at the
-          // hard ceiling. A completed-empty turn stops here → still fails.
-          const graceEnd = turnCompleteAtMs + FIRST_TOKEN_GRACE_MS;
-          return Math.min(Math.max(baseBudgetEnd, graceEnd), hardCeiling);
-        }
-        // Turn in-flight (SSE observed, not yet terminal): keep waiting up to
-        // the hard `pageTimeoutMs` ceiling so a slow first token is not cut off
-        // by the short base budget — this is the actual race being fixed.
-        return hardCeiling;
-      };
-      while (Date.now() < pollDeadline()) {
-        // The callback executes in the browser where `document` exists.
-        // TypeScript's Node-only `lib` doesn't include DOM types, so we
-        // access `document` via `globalThis` to avoid a compile error
-        // without polluting the project-wide tsconfig with `"dom"`.
-        raw =
-          (await page.evaluate(() => {
-            // `document` lives in the browser context where this callback
-            // runs. The server-side tsconfig intentionally excludes DOM
-            // types, so we reach it via a type-erased indirection.
-            const win = globalThis as unknown as {
-              document: {
-                querySelectorAll(
-                  sel: string,
-                ): ArrayLike<{ textContent: string | null }>;
-              };
+
+      // Read the current assistant-message text from the DOM (last matching
+      // container). Returns "" when the container is empty or absent.
+      const readAssistantText = async (): Promise<string> =>
+        (await pg.evaluate(() => {
+          // `document` lives in the browser context where this callback runs.
+          // The server-side tsconfig intentionally excludes DOM types, so we
+          // reach it via a type-erased indirection.
+          const win = globalThis as unknown as {
+            document: {
+              querySelectorAll(
+                sel: string,
+              ): ArrayLike<{ textContent: string | null }>;
             };
-            const msgs = win.document.querySelectorAll(
-              '[data-testid="copilot-assistant-message"]',
+          };
+          const msgs = win.document.querySelectorAll(
+            '[data-testid="copilot-assistant-message"]',
+          );
+          if (msgs.length === 0) return "";
+          return msgs[msgs.length - 1]!.textContent ?? "";
+        })) ?? "";
+
+      // Is the current turn COMPLETE? Keys off the REAL production signal —
+      // `page.readTurnState()`, backed by the `attachSseInterceptor` page-side
+      // globals — NOT the never-wired Node-side `onSseEvent` seam the prior
+      // (inert) fix used. A turn is complete when the DOM run-lifecycle
+      // observer saw a run start and then stop (`sawRunningTrue && runningNow
+      // === false` — the transport-INDEPENDENT edge d6 prefers) OR the
+      // transport-level `RUN_FINISHED` counter incremented (`runsFinished >=
+      // 1`). Absent a `readTurnState` seam (fakes that don't model the turn
+      // lifecycle) this reports "not observed", and the poll falls back to the
+      // base budget floor — no hang.
+      const readTurnComplete = async (): Promise<{
+        observed: boolean;
+        complete: boolean;
+      }> => {
+        if (page?.readTurnState === undefined) {
+          return { observed: false, complete: false };
+        }
+        const st = await page.readTurnState();
+        const domDone =
+          st.attrPresent && st.sawRunningTrue && st.runningNow === false;
+        const sseDone = st.runsFinished >= 1;
+        const observed = st.attrPresent || st.runsFinished > 0;
+        return { observed, complete: domDone || sseDone };
+      };
+
+      // First-token wait with fast-fail + non-completion retry. One attempt
+      // returns as soon as one of these holds:
+      //
+      //   (a) non-empty assistant text appears → the real success, return it, or
+      //   (b) the turn COMPLETES (real turn-complete edge from `readTurnState`)
+      //       AND a short `FIRST_TOKEN_GRACE_MS` window past completion has
+      //       elapsed with still-empty DOM → a genuinely-empty COMPLETED turn.
+      //       This FAST-FAILS (bounded by `FIRST_TOKEN_FAST_FAIL_MS`, ~15s)
+      //       instead of burning the flat `pageTimeoutMs`. It is a real red (no
+      //       masking) — the turn finished with no content — and is NOT retried.
+      //   (c) an OBSERVED-but-in-flight turn hits the per-attempt ceiling
+      //       without ever completing (stalled / dropped stream — the real
+      //       20:16:52Z failure where aimock served content but the page never
+      //       rendered it). This is TRANSIENT → the outer loop RETRIES once.
+      //   (d) NOTHING was ever observed (no `readTurnState` seam, or the page
+      //       never seeded any turn lifecycle) and the base budget floor
+      //       elapsed → a dead/never-streaming run. Stop at the base floor
+      //       (pre-fix behavior — no long wait, no retry, no hang).
+      //
+      // `textPollTimeoutMs` stays the MINIMUM budget floor (we always poll at
+      // least that long). We no longer DECLARE emptiness at that floor while a
+      // turn is still in-flight or just completed — distinguishing
+      // "still streaming" / "completed empty" / "never completed" / "no turn".
+      const runAttempt = async (
+        attemptCeiling: number,
+      ): Promise<{ text: string; completed: boolean; observed: boolean }> => {
+        const attemptStart = Date.now();
+        const baseBudgetEnd = attemptStart + textPollTimeoutMs;
+        let completeAtMs: number | undefined;
+        let everObserved = false;
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          // Abort inside the loop (not just at level entry) so an aborted level
+          // tears down promptly rather than polling out the whole budget.
+          if (abortSignal.aborted) {
+            return {
+              text: "",
+              completed: completeAtMs !== undefined,
+              observed: everObserved,
+            };
+          }
+          const raw = await readAssistantText();
+          if (raw.trim().length > 0) {
+            return {
+              text: raw.trim(),
+              completed: completeAtMs !== undefined,
+              observed: everObserved,
+            };
+          }
+          const { observed, complete } = await readTurnComplete();
+          if (observed) everObserved = true;
+          if (complete && completeAtMs === undefined) {
+            completeAtMs = Date.now();
+          }
+          const now2 = Date.now();
+          // Deadline for THIS poll iteration:
+          //   - completed-but-empty → completion+grace, capped by fast-fail and
+          //     the per-attempt ceiling (base floor always respected).
+          //   - observed in-flight (not yet complete) → poll to the per-attempt
+          //     ceiling (the slow-first-token race being fixed).
+          //   - never observed → stop at the base floor (dead/no-turn run).
+          let deadline: number;
+          if (completeAtMs !== undefined) {
+            const graceEnd = completeAtMs + FIRST_TOKEN_GRACE_MS;
+            const fastFailEnd = attemptStart + FIRST_TOKEN_FAST_FAIL_MS;
+            deadline = Math.min(
+              Math.max(baseBudgetEnd, graceEnd),
+              fastFailEnd,
+              attemptCeiling,
             );
-            if (msgs.length === 0) return "";
-            return msgs[msgs.length - 1]!.textContent ?? "";
-          })) ?? "";
-        if (raw.trim().length > 0) break;
-        await new Promise((r) => setTimeout(r, 500));
+          } else if (everObserved) {
+            deadline = attemptCeiling;
+          } else {
+            // No turn observed → base budget floor, but NEVER past the
+            // per-attempt ceiling (which is itself bounded by `pageTimeoutMs`).
+            // When `textPollTimeoutMs` defaults to `pageTimeoutMs`, the base
+            // floor would otherwise exceed the retry-split ceiling; cap it so a
+            // no-SSE run can't blow past the hard budget.
+            deadline = Math.min(baseBudgetEnd, attemptCeiling);
+          }
+          if (now2 >= deadline) {
+            return {
+              text: "",
+              completed: completeAtMs !== undefined,
+              observed: everObserved,
+            };
+          }
+          await new Promise((r) => setTimeout(r, 500));
+        }
+      };
+
+      // Retry envelope. Total wall-clock across all attempts is bounded by the
+      // hard `pageTimeoutMs` ceiling (never blown past it): each attempt gets an
+      // equal slice of the remaining budget, so `1 + NON_COMPLETION_RETRY_LIMIT`
+      // attempts fit within `pageTimeoutMs`. Retry fires ONLY when a turn was
+      // OBSERVED in-flight but never completed (transient stall). A
+      // completed-empty turn (real red) and a never-observed turn (dead run)
+      // both short-circuit without retry.
+      const pollStart = Date.now();
+      const hardCeiling = pollStart + pageTimeoutMs;
+      const maxAttempts = 1 + NON_COMPLETION_RETRY_LIMIT;
+      let attemptText = "";
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        if (abortSignal.aborted) break;
+        if (attempt > 0) {
+          // Non-completion retry: the prior attempt's turn was observed
+          // in-flight but never signalled completion (stalled/dropped stream).
+          // Resend the same message.
+          await sendTurn();
+        }
+        // Split the REMAINING budget evenly across the remaining attempts so the
+        // retry can never push total wall-clock past `pageTimeoutMs`.
+        const remainingAttempts = maxAttempts - attempt;
+        const remainingBudget = Math.max(0, hardCeiling - Date.now());
+        const attemptCeiling =
+          Date.now() + Math.floor(remainingBudget / remainingAttempts);
+        const { text, completed, observed } = await runAttempt(attemptCeiling);
+        if (text.length > 0) {
+          attemptText = text;
+          break;
+        }
+        // Retry ONLY a turn that was OBSERVED in-flight but never completed
+        // (transient stall). Completed-empty (real red) and never-observed
+        // (dead / no-turn run — nothing to retry) both stop here.
+        if (completed || !observed) break;
       }
-      responseText = raw.trim();
+      responseText = attemptText;
       if (responseText.length > 0) {
         // Real content read from the assistant-message container → a genuine
         // assistant turn (the gate's required provenance).
@@ -1653,8 +1868,19 @@ async function runLevel(opts: {
         cvdiag?.firstToken(nowMonoMs(), responseText.length);
       }
     } catch {
-      // Fallback: pull <body> text and slice off everything up to and
-      // including our sent message. Mirrors helpers.ts's fallback.
+      // Fallback: the assistant-message container never mounted (some showcases
+      // don't set the testid), so salvage substantive text from <body> after
+      // our sent message. Mirrors helpers.ts's fallback.
+      //
+      // CRITICAL PROVENANCE: `fromAssistantContainer` stays FALSE for fallback
+      // text — the tightened L3/L4 gate (see `assertResponse`) requires
+      // container provenance, so a dead agent whose static page text leaks
+      // through this scrape does NOT false-PASS. And because `cvdiagResponseEmpty`
+      // is left TRUE here (only a genuine container read clears it above), a
+      // fallback-salvaged run that the gate reds cannot emit `terminal_outcome=ok`
+      // — the exit gate keys `ok` off a genuine assistant turn, not off any
+      // non-empty text (prior bug: fallback text flipped `cvdiagResponseEmpty`
+      // and so mislabeled a red as `ok`).
       const body = (await page.textContent("body")) ?? "";
       const idx = body.lastIndexOf(message);
       if (idx >= 0) {
@@ -1666,12 +1892,20 @@ async function runLevel(opts: {
           .replace(/Powered by CopilotKit/g, "")
           .replace(/Type a message\.\.\./g, "")
           .trim();
-        if (tail.length > 20) {
-          responseText = tail.split("\n")[0]!.trim();
+        // No `tail.length > 20` floor and no `split("\n")[0]` first-line
+        // truncation: the old gate false-red'd a short valid answer (e.g. a
+        // one-word reply under 20 chars) and clipped a genuine MULTILINE answer
+        // to its first line (dropping content the vocab assertion needs). Take
+        // the whole salvaged tail (already whitespace-collapsed by `.trim()`);
+        // `assertResponse` decides green/red on the content.
+        if (tail.length > 0) {
+          responseText = tail;
         }
       }
       if (responseText.length > 0) {
-        cvdiagResponseEmpty = false;
+        // firstToken is telemetry only — record that SOME text was seen. We do
+        // NOT clear `cvdiagResponseEmpty` (fallback text is not a genuine
+        // container turn) so the exit gate cannot mislabel a red as `ok`.
         cvdiag?.firstToken(nowMonoMs(), responseText.length);
       }
     }

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -490,12 +490,15 @@ const FIRST_TOKEN_GRACE_MS = 2000;
  * real turn-complete signal available (`readTurnState()`), we no longer burn
  * the flat `pageTimeoutMs` (~60s) on a genuinely-empty completed turn: once the
  * turn reports complete AND the short `FIRST_TOKEN_GRACE_MS` window has elapsed
- * with still-empty DOM, the poll gives up here. The overall first-token budget
- * for a COMPLETED turn is thus bounded by roughly this value (whichever is
- * later: the base floor, or completion + grace, capped at the hard ceiling) —
- * ~15-20s in practice rather than the flat 60s. A genuinely-completed-empty
- * turn still reds (no masking): completion is observed, grace elapses, DOM is
- * empty → red.
+ * with still-empty DOM, the poll gives up here. The deadline for a COMPLETED
+ * turn is `Math.min(Math.max(baseBudgetEnd, graceEnd), fastFailEnd,
+ * attemptCeiling)`: completion+grace is raised to at least the base floor, then
+ * this value CLAMPS it from above (as does the per-attempt ceiling). The clamp
+ * can land BEFORE the base floor — the floor is not a hard minimum for a
+ * completed turn — so the overall first-token budget is ~15s (this value)
+ * rather than the flat 60s `pageTimeoutMs`. A genuinely-completed-empty turn
+ * still reds (no masking): completion is observed, grace elapses, DOM is empty
+ * → red.
  */
 const FIRST_TOKEN_FAST_FAIL_MS = 15_000;
 
@@ -1935,8 +1938,14 @@ async function runLevel(opts: {
           }
           const now2 = Date.now();
           // Deadline for THIS poll iteration:
-          //   - completed-but-empty → completion+grace, capped by fast-fail and
-          //     the per-attempt ceiling (base floor always respected).
+          //   - completed-but-empty → completion+grace raised to at least the
+          //     base floor (`Math.max(baseBudgetEnd, graceEnd)`), then CLAMPED by
+          //     `Math.min(fastFailEnd, attemptCeiling)`. The clamp intentionally
+          //     wins: a completed-empty turn fast-fails at `fastFailEnd`
+          //     (`attemptStart + FIRST_TOKEN_FAST_FAIL_MS`) or the per-attempt
+          //     ceiling even when that lands BEFORE the base floor — the floor is
+          //     NOT a hard minimum here (a genuinely-completed-empty turn must
+          //     red fast, not burn the full base budget).
           //   - observed in-flight (not yet complete) → poll to the per-attempt
           //     ceiling (the slow-first-token race being fixed).
           //   - never observed → stop at the base floor (dead/no-turn run).

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -186,12 +186,30 @@ export interface E2eSmokeLevelSignal {
  *                      run actually started on this page.
  *   - `runningNow`     current `data-copilot-running` state (null before first
  *                      observation).
+ *   - `runStartCount`  count of `false→true` DOM edges (RUN_STARTED). A prior
+ *                      turn (auto-greeting / initial mount run) increments this
+ *                      before the user's turn ever starts, so the poll captures
+ *                      a per-attempt BASELINE at send time and treats the turn
+ *                      as complete only on a NEW finished edge for THIS turn
+ *                      (`runsFinished`/`runStartCount` moved past the baseline),
+ *                      never on the page-GLOBAL `>= 1`.
+ *   - `lastStoppedAtMs` wall-clock ms of the most recent `true→false` DOM edge
+ *                      (RUN_FINISHED). `0` when never stopped. Lets the poll
+ *                      stamp the grace window from the REAL finished edge.
+ *   - `sseAttachFailed` true iff `attachSseInterceptor` THREW during `goto`, so
+ *                      the page-side turn-lifecycle globals were never seeded
+ *                      and the poll silently degraded to the base-floor
+ *                      (pre-fix inert / false-red) path. Surfaced so a silent
+ *                      regression to inert is DETECTABLE rather than invisible.
  */
 export interface TurnState {
   runsFinished: number;
   attrPresent: boolean;
   sawRunningTrue: boolean;
   runningNow: boolean | null;
+  runStartCount: number;
+  lastStoppedAtMs: number;
+  sseAttachFailed: boolean;
 }
 
 /**
@@ -536,7 +554,23 @@ export function wirePlaywrightPage(
     attachSseInterceptor(
       p as unknown as Parameters<typeof attachSseInterceptor>[0],
     ),
+  // Invoked when `attachInterceptor` THROWS during `goto`. Defaults to a
+  // greppable `console.warn` marker (matching the sse-interceptor's own
+  // low-volume diagnostic style) so a silent regression to the inert
+  // base-floor path leaves an operator-visible breadcrumb. Injectable so unit
+  // tests can assert the fault is surfaced without a live chromium.
+  onAttachFault: (err: unknown) => void = (err) => {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[d4-chat-roundtrip] attachSseInterceptor failed — first-token poll degrading to base-floor (inert) path",
+      { err: err instanceof Error ? err.message : String(err) },
+    );
+  },
 ): E2ePage {
+  // Latched true iff `attachInterceptor` threw during `goto`. Surfaced via
+  // `readTurnState().sseAttachFailed` so a silent regression to the base-floor
+  // (pre-fix inert / false-red) path is DETECTABLE, not invisible.
+  let sseAttachFailed = false;
   // Per-request issue-time tracking so `probe.network.response.duration_ms`
   // reflects the request→response wall-clock, not just the response event.
   //
@@ -563,8 +597,14 @@ export function wirePlaywrightPage(
       // reports no in-flight turn).
       try {
         await attachInterceptor(page);
-      } catch {
-        /* interceptor attach is best-effort; poll falls back to base budget */
+      } catch (err) {
+        // Best-effort: an interceptor-attach fault must never break navigation.
+        // But do NOT swallow it silently — the poll then falls back to the
+        // base-floor (pre-fix inert / false-red) path, and without a signal that
+        // regression is invisible. Latch a distinguishable flag (surfaced via
+        // `readTurnState().sseAttachFailed`) AND emit the telemetry marker.
+        sseAttachFailed = true;
+        onAttachFault(err);
       }
       return page.goto(url, opts);
     },
@@ -582,13 +622,15 @@ export function wirePlaywrightPage(
       // navigating, globals not yet seeded) degrades to a "nothing observed"
       // snapshot — the poll then treats it as no-in-flight-turn, never a hang.
       try {
-        return await page.evaluate(() => {
+        const snapshot = await page.evaluate(() => {
           const g = globalThis as unknown as {
             __hk_runsFinished?: number;
             __hk_copilotRunning?: {
               attrPresent?: boolean;
               sawRunningTrue?: boolean;
               runningNow?: boolean | null;
+              runStartCount?: number;
+              lastStoppedAtMs?: number;
             };
           };
           const run = g.__hk_copilotRunning;
@@ -598,14 +640,24 @@ export function wirePlaywrightPage(
             attrPresent: run?.attrPresent === true,
             sawRunningTrue: run?.sawRunningTrue === true,
             runningNow: run?.runningNow ?? null,
+            runStartCount:
+              typeof run?.runStartCount === "number" ? run.runStartCount : 0,
+            lastStoppedAtMs:
+              typeof run?.lastStoppedAtMs === "number"
+                ? run.lastStoppedAtMs
+                : 0,
           };
         });
+        return { ...snapshot, sseAttachFailed };
       } catch {
         return {
           runsFinished: 0,
           attrPresent: false,
           sawRunningTrue: false,
           runningNow: null,
+          runStartCount: 0,
+          lastStoppedAtMs: 0,
+          sseAttachFailed,
         };
       }
     },
@@ -1338,7 +1390,16 @@ export function createE2eSmokeDriver(
           };
         }
         const msg = err instanceof Error ? err.message : String(err);
-        ctx.logger.warn("probe.e2e-smoke.driver-error", { slug, err: msg });
+        // Distinguish an EXTERNAL abort (invoker-provided `ctx.abortSignal`, not
+        // the driver's own hard-timeout which `timedOut` already caught above)
+        // from a genuine driver fault. Label it `"abort"` in the aggregate,
+        // matching the per-level classification (`errorDesc: abortSignal.aborted
+        // ? "abort" : "level-error"`) so a probe-invoker abort doesn't masquerade
+        // as `driver-error` on the dashboard.
+        const externallyAborted =
+          abort.signal.aborted && externalAbort?.aborted === true;
+        const errorDesc = externallyAborted ? "abort" : "driver-error";
+        ctx.logger.warn(`probe.e2e-smoke.${errorDesc}`, { slug, err: msg });
         return {
           key: input.key,
           state: "red",
@@ -1349,7 +1410,7 @@ export function createE2eSmokeDriver(
             l3: "red",
             l4: hasToolRendering ? "red" : "skipped",
             failureSummary: truncateUtf8(msg, 1200),
-            errorDesc: "driver-error",
+            errorDesc,
           },
           observedAt,
         };
@@ -1622,10 +1683,37 @@ async function runLevel(opts: {
     // turn-complete) can resend the SAME message without re-running navigation
     // or the textarea wait. `pg` is the try-scoped non-null page handle.
     const pg = page;
+    // Hard wall-clock ceiling for the whole first-token envelope (nav + first
+    // send already happened; this bounds the poll + any retry resend). Captured
+    // BEFORE the first send so a stalled resend cannot push level wall-clock
+    // past `pageTimeoutMs`.
+    const pollStart = Date.now();
+    const hardCeiling = pollStart + pageTimeoutMs;
+    // Send one agent-message turn. Action timeouts are CAPPED by the remaining
+    // budget to `hardCeiling` (never a flat `pageTimeoutMs` per call): the retry
+    // resend runs LATE in the envelope, so passing `pageTimeoutMs` unbounded let
+    // a stalled type/press push total level wall-clock to ~2× `pageTimeoutMs`
+    // past the hard ceiling. `Math.max(0, …)` keeps the timeout non-negative;
+    // Playwright treats 0 as "no timeout", so we floor at 1ms once the budget is
+    // spent to fail fast rather than block indefinitely.
     const sendTurn = async (): Promise<void> => {
-      await pg.type("textarea", message, { timeout: pageTimeoutMs });
-      await pg.press("textarea", "Enter", { timeout: pageTimeoutMs });
+      const budget = () => Math.max(1, hardCeiling - Date.now());
+      await pg.type("textarea", message, { timeout: budget() });
+      await pg.press("textarea", "Enter", { timeout: budget() });
     };
+    // Baseline snapshot for attempt 0, taken BEFORE the send so the agent
+    // provably cannot have fired RUN_STARTED / RUN_FINISHED for THIS turn yet —
+    // the completion gate then tests strictly-new edges past this baseline.
+    // `readTurnState` reference works here (the seam is a method on `page`), but
+    // `readBaseline` is defined below inside the try block, so read the raw
+    // state directly for the pre-loop baseline.
+    let attemptBaseline = await (async () => {
+      if (page?.readTurnState === undefined) {
+        return { runsFinished: 0, runStartCount: 0 };
+      }
+      const st = await page.readTurnState();
+      return { runsFinished: st.runsFinished, runStartCount: st.runStartCount };
+    })();
     await sendTurn();
 
     // probe.message.send is NOT emitted here: at press time the agent-message
@@ -1707,29 +1795,81 @@ async function runLevel(opts: {
           return msgs[msgs.length - 1]!.textContent ?? "";
         })) ?? "";
 
-      // Is the current turn COMPLETE? Keys off the REAL production signal —
-      // `page.readTurnState()`, backed by the `attachSseInterceptor` page-side
-      // globals — NOT the never-wired Node-side `onSseEvent` seam the prior
-      // (inert) fix used. A turn is complete when the DOM run-lifecycle
-      // observer saw a run start and then stop (`sawRunningTrue && runningNow
-      // === false` — the transport-INDEPENDENT edge d6 prefers) OR the
-      // transport-level `RUN_FINISHED` counter incremented (`runsFinished >=
-      // 1`). Absent a `readTurnState` seam (fakes that don't model the turn
-      // lifecycle) this reports "not observed", and the poll falls back to the
-      // base budget floor — no hang.
-      const readTurnComplete = async (): Promise<{
-        observed: boolean;
-        complete: boolean;
+      // Per-attempt turn-lifecycle BASELINE. Snapshot the page-GLOBAL,
+      // monotonic edge counters (`runsFinished`, `runStartCount`) BEFORE a turn
+      // is sent so completion is scoped to THIS turn, not the whole page. A
+      // PRIOR run on the page (auto-greeting / initial run fired on mount)
+      // leaves `runsFinished >= 1` and `runStartCount >= 1` already latched when
+      // the user's turn starts; keying "complete" off the page-global `>= 1`
+      // (the prior bug) made the poll think THIS turn had finished the moment it
+      // began, see the still-empty container, and spuriously FAST-FAIL RED.
+      // Baselining converts the gate to a NEW-edge test (`> baseline`) so only a
+      // finish that happened AFTER the send counts. Read via `readTurnState()`
+      // (undefined seam → all-zero baseline, harmless: `> 0` still works for the
+      // first ever run). A fresh baseline is taken per attempt (each retry
+      // resends), so a stale prior edge can never satisfy a retried attempt.
+      const readBaseline = async (): Promise<{
+        runsFinished: number;
+        runStartCount: number;
       }> => {
         if (page?.readTurnState === undefined) {
-          return { observed: false, complete: false };
+          return { runsFinished: 0, runStartCount: 0 };
         }
         const st = await page.readTurnState();
+        return {
+          runsFinished: st.runsFinished,
+          runStartCount: st.runStartCount,
+        };
+      };
+
+      // Is THIS turn COMPLETE (relative to the per-attempt `baseline`)? Keys off
+      // the REAL production signal — `page.readTurnState()`, backed by the
+      // `attachSseInterceptor` page-side globals — NOT the never-wired Node-side
+      // `onSseEvent` seam the prior (inert) fix used. Attempt-scoped:
+      //   - `sseDone`  the transport-level `RUN_FINISHED` counter advanced PAST
+      //                the baseline (`runsFinished > baseline.runsFinished`) — a
+      //                NEW finished edge for THIS turn, not the page-global
+      //                `>= 1` that a prior run already satisfied.
+      //   - `domDone`  the DOM run-lifecycle observer saw a run start and then
+      //                stop (`sawRunningTrue && runningNow === false`, the
+      //                transport-INDEPENDENT edge d6 prefers) AND that start was
+      //                new for THIS turn (`runStartCount > baseline`), so a page
+      //                that was already at rest (a prior turn left runningNow
+      //                false) can't be mistaken for THIS turn completing.
+      // `stoppedAtMs` surfaces the REAL finished edge so the grace window is
+      // stamped from completion rather than the poll's local clock. Absent a
+      // `readTurnState` seam (fakes that don't model the turn lifecycle) this
+      // reports "not observed", and the poll falls back to the base budget floor
+      // — no hang.
+      const readTurnComplete = async (baseline: {
+        runsFinished: number;
+        runStartCount: number;
+      }): Promise<{
+        observed: boolean;
+        complete: boolean;
+        stoppedAtMs: number;
+      }> => {
+        if (page?.readTurnState === undefined) {
+          return { observed: false, complete: false, stoppedAtMs: 0 };
+        }
+        const st = await page.readTurnState();
+        const newRunStarted = st.runStartCount > baseline.runStartCount;
         const domDone =
-          st.attrPresent && st.sawRunningTrue && st.runningNow === false;
-        const sseDone = st.runsFinished >= 1;
-        const observed = st.attrPresent || st.runsFinished > 0;
-        return { observed, complete: domDone || sseDone };
+          st.attrPresent &&
+          st.sawRunningTrue &&
+          st.runningNow === false &&
+          newRunStarted;
+        const sseDone = st.runsFinished > baseline.runsFinished;
+        // "Observed for THIS turn": a NEW run started (DOM edge) or a NEW
+        // finished edge landed. A stale prior-run attribute alone does not count
+        // as observing THIS turn in-flight (else a page at rest from a prior run
+        // would be treated as an in-flight turn and burn the full ceiling).
+        const observed = newRunStarted || sseDone;
+        return {
+          observed,
+          complete: domDone || sseDone,
+          stoppedAtMs: st.lastStoppedAtMs,
+        };
       };
 
       // First-token wait with fast-fail + non-completion retry. One attempt
@@ -1752,11 +1892,15 @@ async function runLevel(opts: {
       //       (pre-fix behavior — no long wait, no retry, no hang).
       //
       // `textPollTimeoutMs` stays the MINIMUM budget floor (we always poll at
-      // least that long). We no longer DECLARE emptiness at that floor while a
-      // turn is still in-flight or just completed — distinguishing
-      // "still streaming" / "completed empty" / "never completed" / "no turn".
+      // least that long, unless the per-attempt `attemptCeiling` — itself
+      // bounded by `pageTimeoutMs` — is tighter, in which case the ceiling
+      // wins). We no longer DECLARE emptiness at that floor while a turn is
+      // still in-flight or just completed — distinguishing "still streaming" /
+      // "completed empty" / "never completed" / "no turn". `baseline` scopes the
+      // completion test to THIS turn (see `readTurnComplete`).
       const runAttempt = async (
         attemptCeiling: number,
+        baseline: { runsFinished: number; runStartCount: number },
       ): Promise<{ text: string; completed: boolean; observed: boolean }> => {
         const attemptStart = Date.now();
         const baseBudgetEnd = attemptStart + textPollTimeoutMs;
@@ -1781,10 +1925,17 @@ async function runLevel(opts: {
               observed: everObserved,
             };
           }
-          const { observed, complete } = await readTurnComplete();
+          const { observed, complete, stoppedAtMs } =
+            await readTurnComplete(baseline);
           if (observed) everObserved = true;
           if (complete && completeAtMs === undefined) {
-            completeAtMs = Date.now();
+            // Stamp completion from the REAL finished edge (`lastStoppedAtMs`)
+            // when the page reported one, so the grace window measures from when
+            // the turn actually finished — not from this poll iteration, which
+            // could lag the edge by up to a full 500ms poll interval and cut the
+            // grace ~500ms short. Fall back to the local clock when no DOM stop
+            // edge was recorded (SSE-only completion path).
+            completeAtMs = stoppedAtMs > 0 ? stoppedAtMs : Date.now();
           }
           const now2 = Date.now();
           // Deadline for THIS poll iteration:
@@ -1823,15 +1974,20 @@ async function runLevel(opts: {
         }
       };
 
-      // Retry envelope. Total wall-clock across all attempts is bounded by the
-      // hard `pageTimeoutMs` ceiling (never blown past it): each attempt gets an
-      // equal slice of the remaining budget, so `1 + NON_COMPLETION_RETRY_LIMIT`
-      // attempts fit within `pageTimeoutMs`. Retry fires ONLY when a turn was
-      // OBSERVED in-flight but never completed (transient stall). A
-      // completed-empty turn (real red) and a never-observed turn (dead run)
-      // both short-circuit without retry.
-      const pollStart = Date.now();
-      const hardCeiling = pollStart + pageTimeoutMs;
+      // Retry envelope. The POLL-PHASE wall-clock (all poll attempts + the
+      // retry resend, i.e. everything from `hardCeiling`'s stamp onward) is
+      // bounded by `pageTimeoutMs`: `hardCeiling` was stamped just before the
+      // first send, each attempt gets an equal slice of the REMAINING budget, so
+      // `1 + NON_COMPLETION_RETRY_LIMIT` attempts fit within it, and the resend's
+      // own type/press action timeouts are capped to `hardCeiling` (see
+      // `sendTurn`). NOTE: navigation and the FIRST send happen BEFORE
+      // `hardCeiling` is stamped and each carry their own `pageTimeoutMs`
+      // budget — so end-to-end level wall-clock (`goto` + first send + poll) can
+      // exceed a single `pageTimeoutMs`; the driver-level `timeoutMs` hard cap is
+      // the true overall bound. Retry fires ONLY when a turn was OBSERVED
+      // in-flight but never completed (transient stall). A completed-empty turn
+      // (real red) and a never-observed turn (dead run) both short-circuit
+      // without retry.
       const maxAttempts = 1 + NON_COMPLETION_RETRY_LIMIT;
       let attemptText = "";
       for (let attempt = 0; attempt < maxAttempts; attempt++) {
@@ -1839,7 +1995,11 @@ async function runLevel(opts: {
         if (attempt > 0) {
           // Non-completion retry: the prior attempt's turn was observed
           // in-flight but never signalled completion (stalled/dropped stream).
-          // Resend the same message.
+          // Re-baseline BEFORE the resend (SAME ordering rationale as attempt 0)
+          // so the retried attempt's completion gate tests strictly-new edges
+          // past the STALL's already-latched counters — a stale prior edge can
+          // never satisfy the retry.
+          attemptBaseline = await readBaseline();
           await sendTurn();
         }
         // Split the REMAINING budget evenly across the remaining attempts so the
@@ -1848,7 +2008,10 @@ async function runLevel(opts: {
         const remainingBudget = Math.max(0, hardCeiling - Date.now());
         const attemptCeiling =
           Date.now() + Math.floor(remainingBudget / remainingAttempts);
-        const { text, completed, observed } = await runAttempt(attemptCeiling);
+        const { text, completed, observed } = await runAttempt(
+          attemptCeiling,
+          attemptBaseline,
+        );
         if (text.length > 0) {
           attemptText = text;
           break;
@@ -1910,13 +2073,9 @@ async function runLevel(opts: {
       }
     }
 
-    // Fallback `probe.message.send`: the `onResponse` seam emits this the
-    // moment the message-POST response lands (real edge headers). If no
-    // message-POST response was ever observed (e.g. the page never issued one,
-    // or it errored before responding), emit here so the boundary is still
-    // recorded — idempotent via `emitMessageSend`, so a normal run that already
-    // emitted from the seam is unaffected.
-    emitMessageSend();
+    // Fallback `probe.message.send` runs in the `finally` (not here) so the
+    // boundary is recorded even on a nav/send throw path that skips this clean
+    // exit — see the `finally` block. Idempotent via `emitMessageSend`.
 
     // probe.dom.alternate_content — on a clean exit whose assistant text is
     // still empty (the d4 flap surface, class (d)): snapshot the child-element
@@ -2054,6 +2213,15 @@ async function runLevel(opts: {
       edgeHeaders: messageSendEdge,
     };
   } finally {
+    // Fallback `probe.message.send`: the `onResponse` seam emits this the
+    // moment the message-POST response lands (real edge headers). If no
+    // message-POST response was ever observed — including nav/send THROW paths
+    // that skip the clean exit entirely — emit here so the boundary is still
+    // recorded (null edge headers). Idempotent via `emitMessageSend`, so a
+    // normal run that already emitted from the seam is unaffected. In the
+    // `finally` (not the try body) so a throw before the old inline call site
+    // can no longer drop the boundary.
+    emitMessageSend();
     // Defense in depth: if neither the ok nor the error path emitted exit (an
     // unexpected control-flow gap), emit it here so `probe.exit` fires exactly
     // once on every path.

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -402,6 +402,31 @@ const WEATHER_VOCAB = [
 ];
 
 /**
+ * AG-UI SSE lifecycle events that mark a turn as COMPLETE (the agent run
+ * lifecycle: `RUN_STARTED` → … → `RUN_FINISHED`/`RUN_ERROR`). The DOM
+ * first-token poll (see `runLevel`) uses these — not a fixed short timeout —
+ * to decide when a turn has genuinely finished, so it never asserts
+ * "empty assistant response" before the turn has had a chance to render its
+ * first token. Matched via the normalized `CvdiagSseEvent.eventType` the SSE
+ * interceptor already surfaces (see helpers/sse-interceptor.ts).
+ */
+const TURN_COMPLETE_SSE_EVENTS: ReadonlySet<string> = new Set([
+  "RUN_FINISHED",
+  "RUN_ERROR",
+]);
+
+/**
+ * After a turn-complete SSE event (`RUN_FINISHED`/`RUN_ERROR`) is observed but
+ * the assistant-message container is still empty, keep polling the DOM for
+ * this long before declaring the turn genuinely empty. The first token often
+ * renders a beat AFTER the SSE finish (React commit + markdown render), so a
+ * small grace window converts a "completed but DOM not yet painted" read into
+ * a captured first token, while a truly-empty completed turn still fails once
+ * the grace elapses. Bounded and small so a genuinely-empty turn fails fast.
+ */
+const FIRST_TOKEN_GRACE_MS = 2000;
+
+/**
  * The slice of Playwright's `Page` the launcher adapter consumes. Declared
  * structurally (not imported) so the module stays loadable without the
  * `playwright` type tree at module scope — mirroring the existing `E2ePage`
@@ -1356,6 +1381,26 @@ async function runLevel(opts: {
   const cvdiagStartMs = nowMonoMs();
   let cvdiagExited = false;
   let cvdiagResponseEmpty = true;
+  /**
+   * Set the moment a turn-complete SSE event (`RUN_FINISHED`/`RUN_ERROR`) is
+   * observed on the `onSseEvent` seam. The first-token poll below uses this to
+   * distinguish "still streaming / not started" (keep waiting, within budget)
+   * from "turn completed" (do a bounded grace poll, then a completed-empty turn
+   * genuinely fails). Undefined until the turn completes. Wall-clock ms so it
+   * composes with the poll loop's `Date.now()` budget arithmetic.
+   */
+  let turnCompleteAtMs: number | undefined;
+  /**
+   * True once ANY SSE event has been observed on the `onSseEvent` seam. This
+   * gates the signal-based wait extension: we only wait PAST the base
+   * `textPollTimeoutMs` floor when we have positive evidence of an in-flight
+   * turn (an SSE stream exists and is producing events). When no SSE stream is
+   * observed at all — either the seam is not wired (fakes / non-Playwright
+   * paths) or the agent genuinely never streamed — there is no turn to wait
+   * for, so the poll falls back to the base budget floor and declares emptiness
+   * there (unchanged pre-fix behavior; no false hangs).
+   */
+  let sseObserved = false;
   /** Capture the agent-message POST edge headers for `probe.message.send`. */
   let messageSendEdge: ReturnType<typeof filterEdgeHeaders> | undefined;
   /**
@@ -1424,6 +1469,18 @@ async function runLevel(opts: {
         // `probe.sse.event` stream here. firsttoken is emitted from the DOM
         // poll below.
         cvdiag.sseEvent(e, nowMonoMs());
+        // Positive evidence that an SSE turn is in-flight — gates the
+        // signal-based wait extension in the first-token poll.
+        sseObserved = true;
+        // Turn-complete signal: record when the agent run lifecycle reaches a
+        // terminal event so the first-token poll can wait on it instead of a
+        // fixed short budget (see runLevel's DOM poll and TURN_COMPLETE_SSE_EVENTS).
+        if (
+          turnCompleteAtMs === undefined &&
+          TURN_COMPLETE_SSE_EVENTS.has(e.eventType)
+        ) {
+          turnCompleteAtMs = Date.now();
+        }
       });
       p.onSseAborted?.((e) => cvdiag.sseAborted(e));
     }
@@ -1521,8 +1578,46 @@ async function runLevel(opts: {
       // uses `querySelectorAll` to find the last matching element by
       // index rather than by CSS pseudo-selector.
       let raw = "";
-      const pollEnd = Date.now() + textPollTimeoutMs;
-      while (Date.now() < pollEnd) {
+      // Signal-based first-token wait (hardening for the client-side render
+      // race). The pre-fix loop stopped at a FIXED `textPollTimeoutMs`, so a
+      // first token that rendered a beat later than that budget — on a turn
+      // that genuinely produced content — was read as empty → a spurious
+      // "empty assistant response" red. We instead keep polling until one of:
+      //
+      //   (a) non-empty text appears (the real success — break immediately), or
+      //   (b) the turn has COMPLETED (SSE `RUN_FINISHED`/`RUN_ERROR`, tracked
+      //       via `turnCompleteAtMs`) AND a short `FIRST_TOKEN_GRACE_MS` window
+      //       past that completion has elapsed with still-empty DOM — a
+      //       genuinely-empty completed turn, which must still fail, or
+      //   (c) the hard `pageTimeoutMs` ceiling is hit (defensive upper bound so
+      //       a turn that never completes and never renders can't hang).
+      //
+      // `textPollTimeoutMs` remains the MINIMUM budget floor (we always poll at
+      // least that long) — but we no longer DECLARE emptiness at that floor
+      // while the turn is still in-flight or just completed. This distinguishes
+      // "still streaming / not started" from "completed empty".
+      const pollStart = Date.now();
+      const baseBudgetEnd = pollStart + textPollTimeoutMs;
+      const hardCeiling = pollStart + pageTimeoutMs;
+      const pollDeadline = (): number => {
+        // No SSE turn observed at all → no in-flight turn to wait for; use the
+        // base budget floor (unchanged pre-fix behavior). This is the path when
+        // the SSE seam is unwired OR the agent genuinely never streamed, and it
+        // keeps a truly-dead run from hanging to the hard ceiling.
+        if (!sseObserved) return baseBudgetEnd;
+        if (turnCompleteAtMs !== undefined) {
+          // Turn finished: wait the base floor OR a short grace past the finish
+          // (whichever is later) for the first token to paint, capped at the
+          // hard ceiling. A completed-empty turn stops here → still fails.
+          const graceEnd = turnCompleteAtMs + FIRST_TOKEN_GRACE_MS;
+          return Math.min(Math.max(baseBudgetEnd, graceEnd), hardCeiling);
+        }
+        // Turn in-flight (SSE observed, not yet terminal): keep waiting up to
+        // the hard `pageTimeoutMs` ceiling so a slow first token is not cut off
+        // by the short base budget — this is the actual race being fixed.
+        return hardCeiling;
+      };
+      while (Date.now() < pollDeadline()) {
         // The callback executes in the browser where `document` exists.
         // TypeScript's Node-only `lib` doesn't include DOM types, so we
         // access `document` via `globalThis` to avoid a compile error

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -193,9 +193,13 @@ export interface E2eSmokeLevelSignal {
  *                      as complete only on a NEW finished edge for THIS turn
  *                      (`runsFinished`/`runStartCount` moved past the baseline),
  *                      never on the page-GLOBAL `>= 1`.
- *   - `lastStoppedAtMs` wall-clock ms of the most recent `true→false` DOM edge
- *                      (RUN_FINISHED). `0` when never stopped. Lets the poll
- *                      stamp the grace window from the REAL finished edge.
+ *   - `lastStoppedAtMs` page-clock wall-clock ms of the most recent `true→false`
+ *                      DOM edge (RUN_FINISHED). `0` when never stopped. NOTE: the
+ *                      d4 first-token grace window is stamped from the Node-side
+ *                      completion instant, NOT this field — it is a page-clock
+ *                      stamp and can hold a stale prior-run value on an SSE-only
+ *                      completion; feeding it into Node-clock math collapses the
+ *                      grace window. Retained for other TurnState consumers.
  *   - `sseAttachFailed` true iff `attachSseInterceptor` THREW during `goto`, so
  *                      the page-side turn-lifecycle globals were never seeded
  *                      and the poll silently degraded to the base-floor
@@ -746,11 +750,11 @@ export function wirePlaywrightPage(
       // navigation-cancelled, etc.). Without this, an aborted same-URL request
       // leaks its start in the FIFO queue AND a LATER same-URL response shifts
       // that STALE start, mis-pairing the duration (inflated `duration_ms`).
-      // Co-located with the `request` population listener (NOT in the
-      // `onRequestFailed` block, which the caller may not wire) so eviction is
-      // always active whenever timing is tracked. Drop the OLDEST outstanding
-      // start for the URL — the failed request is, by FIFO ordering, the oldest
-      // un-responded one for that URL.
+      // Co-located with the `onResponse` timing seam (NOT the separate
+      // `onRequestFailed` block, which the caller may not wire) so eviction
+      // rides the same wiring that populates the FIFO queue. Drop the OLDEST
+      // outstanding start for the URL — the failed request is, by FIFO
+      // ordering, the oldest un-responded one for that URL.
       page.on("requestfailed", (arg) => {
         try {
           const req = arg as { url(): string };
@@ -1701,19 +1705,33 @@ async function runLevel(opts: {
       await pg.type("textarea", message, { timeout: budget() });
       await pg.press("textarea", "Enter", { timeout: budget() });
     };
-    // Baseline snapshot for attempt 0, taken BEFORE the send so the agent
-    // provably cannot have fired RUN_STARTED / RUN_FINISHED for THIS turn yet —
-    // the completion gate then tests strictly-new edges past this baseline.
-    // `readTurnState` reference works here (the seam is a method on `page`), but
-    // `readBaseline` is defined below inside the try block, so read the raw
-    // state directly for the pre-loop baseline.
-    let attemptBaseline = await (async () => {
+    // Per-attempt turn-lifecycle BASELINE. Snapshot the page-GLOBAL, monotonic
+    // edge counters (`runsFinished`, `runStartCount`) BEFORE a turn is sent so
+    // completion is scoped to THIS turn, not the whole page. A PRIOR run on the
+    // page (auto-greeting / initial run fired on mount) leaves `runsFinished >=
+    // 1` and `runStartCount >= 1` already latched when the user's turn starts;
+    // keying "complete" off the page-global `>= 1` (the prior bug) made the poll
+    // think THIS turn had finished the moment it began, see the still-empty
+    // container, and spuriously FAST-FAIL RED. Baselining converts the gate to a
+    // NEW-edge test (`> baseline`) so only a finish that happened AFTER the send
+    // counts. Read via `readTurnState()` (undefined seam → all-zero baseline,
+    // harmless: `> 0` still works for the first ever run). A fresh baseline is
+    // taken per attempt (each retry resends), so a stale prior edge can never
+    // satisfy a retried attempt.
+    const readBaseline = async (): Promise<{
+      runsFinished: number;
+      runStartCount: number;
+    }> => {
       if (page?.readTurnState === undefined) {
         return { runsFinished: 0, runStartCount: 0 };
       }
       const st = await page.readTurnState();
       return { runsFinished: st.runsFinished, runStartCount: st.runStartCount };
-    })();
+    };
+    // Baseline snapshot for attempt 0, taken BEFORE the send so the agent
+    // provably cannot have fired RUN_STARTED / RUN_FINISHED for THIS turn yet —
+    // the completion gate then tests strictly-new edges past this baseline.
+    let attemptBaseline = await readBaseline();
     await sendTurn();
 
     // probe.message.send is NOT emitted here: at press time the agent-message
@@ -1721,7 +1739,7 @@ async function runLevel(opts: {
     // has not arrived yet, so emitting now would always record empty
     // `edge_headers`. The emit is driven from the `onResponse` seam above the
     // moment the message-POST response lands (real edge headers), with a
-    // fallback `emitMessageSend()` after the response-wait below so a run where
+    // fallback `emitMessageSend()` in the `finally` block so a run where
     // no message-POST response is ever observed still records the boundary
     // (null edge headers). `char_count` (a USER-FACING Unicode code-point
     // count, computed once as `messageCharCount`) is timing-independent.
@@ -1795,33 +1813,6 @@ async function runLevel(opts: {
           return msgs[msgs.length - 1]!.textContent ?? "";
         })) ?? "";
 
-      // Per-attempt turn-lifecycle BASELINE. Snapshot the page-GLOBAL,
-      // monotonic edge counters (`runsFinished`, `runStartCount`) BEFORE a turn
-      // is sent so completion is scoped to THIS turn, not the whole page. A
-      // PRIOR run on the page (auto-greeting / initial run fired on mount)
-      // leaves `runsFinished >= 1` and `runStartCount >= 1` already latched when
-      // the user's turn starts; keying "complete" off the page-global `>= 1`
-      // (the prior bug) made the poll think THIS turn had finished the moment it
-      // began, see the still-empty container, and spuriously FAST-FAIL RED.
-      // Baselining converts the gate to a NEW-edge test (`> baseline`) so only a
-      // finish that happened AFTER the send counts. Read via `readTurnState()`
-      // (undefined seam → all-zero baseline, harmless: `> 0` still works for the
-      // first ever run). A fresh baseline is taken per attempt (each retry
-      // resends), so a stale prior edge can never satisfy a retried attempt.
-      const readBaseline = async (): Promise<{
-        runsFinished: number;
-        runStartCount: number;
-      }> => {
-        if (page?.readTurnState === undefined) {
-          return { runsFinished: 0, runStartCount: 0 };
-        }
-        const st = await page.readTurnState();
-        return {
-          runsFinished: st.runsFinished,
-          runStartCount: st.runStartCount,
-        };
-      };
-
       // Is THIS turn COMPLETE (relative to the per-attempt `baseline`)? Keys off
       // the REAL production signal — `page.readTurnState()`, backed by the
       // `attachSseInterceptor` page-side globals — NOT the never-wired Node-side
@@ -1836,8 +1827,12 @@ async function runLevel(opts: {
       //                new for THIS turn (`runStartCount > baseline`), so a page
       //                that was already at rest (a prior turn left runningNow
       //                false) can't be mistaken for THIS turn completing.
-      // `stoppedAtMs` surfaces the REAL finished edge so the grace window is
-      // stamped from completion rather than the poll's local clock. Absent a
+      // The grace window is stamped from the NODE-side instant the poll FIRST
+      // observes completion (see `runAttempt`), NOT from the page-side
+      // `lastStoppedAtMs`: that field is stamped on the BROWSER-PAGE clock and
+      // on an SSE-only completion (no fresh DOM stop-edge for THIS turn) still
+      // holds a STALE prior-run value — feeding either into the Node-clock
+      // deadline math mis-sizes (or collapses) the grace window. Absent a
       // `readTurnState` seam (fakes that don't model the turn lifecycle) this
       // reports "not observed", and the poll falls back to the base budget floor
       // — no hang.
@@ -1847,10 +1842,9 @@ async function runLevel(opts: {
       }): Promise<{
         observed: boolean;
         complete: boolean;
-        stoppedAtMs: number;
       }> => {
         if (page?.readTurnState === undefined) {
-          return { observed: false, complete: false, stoppedAtMs: 0 };
+          return { observed: false, complete: false };
         }
         const st = await page.readTurnState();
         const newRunStarted = st.runStartCount > baseline.runStartCount;
@@ -1868,7 +1862,6 @@ async function runLevel(opts: {
         return {
           observed,
           complete: domDone || sseDone,
-          stoppedAtMs: st.lastStoppedAtMs,
         };
       };
 
@@ -1925,17 +1918,20 @@ async function runLevel(opts: {
               observed: everObserved,
             };
           }
-          const { observed, complete, stoppedAtMs } =
-            await readTurnComplete(baseline);
+          const { observed, complete } = await readTurnComplete(baseline);
           if (observed) everObserved = true;
           if (complete && completeAtMs === undefined) {
-            // Stamp completion from the REAL finished edge (`lastStoppedAtMs`)
-            // when the page reported one, so the grace window measures from when
-            // the turn actually finished — not from this poll iteration, which
-            // could lag the edge by up to a full 500ms poll interval and cut the
-            // grace ~500ms short. Fall back to the local clock when no DOM stop
-            // edge was recorded (SSE-only completion path).
-            completeAtMs = stoppedAtMs > 0 ? stoppedAtMs : Date.now();
+            // Stamp completion from the NODE clock at the first poll iteration
+            // that observes THIS turn complete. The grace-window deadline math
+            // below runs on the Node clock, so the completion instant must too:
+            // the page-side `lastStoppedAtMs` is a BROWSER-PAGE-clock stamp (page
+            // ↔ Node skew mis-sizes the window) and on an SSE-only completion it
+            // still holds a STALE prior-run value (which would push `graceEnd`
+            // into the past and collapse the grace to the base floor). Stamping
+            // Node-side here keeps both clocks consistent and the window intact;
+            // it can lag the true finished edge by at most one 500ms poll
+            // interval, well inside `FIRST_TOKEN_GRACE_MS`.
+            completeAtMs = Date.now();
           }
           const now2 = Date.now();
           // Deadline for THIS poll iteration:


### PR DESCRIPTION
## Root cause

D4's L4 flap was a **stalled turn, not a client render race**: aimock served content but the page never rendered it (the real 20:16:52Z failure). The turn stream never delivered a first token to the DOM within the fixed `textPollTimeoutMs`, so the poll read the container empty → spurious "empty assistant response" red.

The **prior fix (`ceae0c2c9`) was inert in production**. It keyed the turn-complete decision off the `onSseEvent` Node-side seam, which the real launchers never wire (Playwright has no per-SSE-event signal). `sseObserved` therefore stayed `false` on the real path and the whole extension collapsed to the pre-fix base budget floor. Its red-green used a fake page that invoked the seam synthetically, so the deadness was never caught.

## The fix (3 parts, mirrors `d6-all-pills.ts`)

1. **Wire the real completion signal.** `wirePlaywrightPage.goto` now calls `attachSseInterceptor(page)` before navigation (injectable for tests), seeding the page-side `__hk_runsFinished` / `__hk_copilotRunning` turn-lifecycle globals at `document_start`. A new `readTurnState()` `E2ePage` seam reads them via `page.evaluate`; the first-token poll keys off **that** — the same transport-level `RUN_FINISHED` + DOM run-stop edge d6 trusts — not the dead `onSseEvent` seam.

2. **Fast-fail genuinely-empty turns.** With a real turn-complete edge, a turn that completes with empty assistant text reds in ~`completion + FIRST_TOKEN_GRACE_MS` (bounded by `FIRST_TOKEN_FAST_FAIL_MS` ≈ 15s) instead of burning the flat 60s. A completed-empty turn still reds (no masking) and is never retried.

3. **Retry-on-non-completion.** A turn **observed in-flight** that never signals completion within budget (stalled/dropped stream) retries once before red. **Never-observed** (dead/no-turn) runs stop at the base floor with no retry. Total wall-clock is bounded by `pageTimeoutMs` (per-attempt budget split), so the retry can't blow past the ceiling.

## CR findings resolved

- `abortSignal.aborted` checked **inside** the poll loop (was only at level entry).
- Body-scrape fallback keeps `fromAssistantContainer=false` **and** no longer clears `cvdiagResponseEmpty` — so a fallback-salvaged red can no longer emit `terminal_outcome=ok`.
- Red/green never gated on `cvdiag` (telemetry-only); the `onSseEvent` seam is documented telemetry-only.
- No-turn fallback budget capped by the per-attempt ceiling (bounded by `pageTimeoutMs`).
- Fallback `tail.length > 20` floor and `split("\n")[0]` truncation **removed** (they false-red'd short/multiline valid answers).
- Corrected stale "not started" / dead-seam comments.

## Real-surface red-green (NO fake page)

Real chromium + real `attachSseInterceptor` + real D4 driver against a local fixture serving an SSE `/api/copilotkit` with an injected first-token/stream delay (aimock-style). `sseObserved-on-real-path = (runsFinished>0 || attrPresent)` is read from the actual page-side globals.

**RED — pre-fix (interceptor UNWIRED), late-token (token@3s):**
```
MODE: unwired  scenario: late-token
L3(chat).state: red  summary: "empty assistant response"
elapsed_ms: 1444
sseObserved-on-real-path: false      <-- dead seam proven
```

**GREEN — post-fix (interceptor WIRED), same late-token:**
```
MODE: wired  scenario: late-token
L3(chat).state: green  summary: ""
elapsed_ms: 6333
LAST readTurnState on REAL path: {"runsFinished":0,"attrPresent":true,"sawRunningTrue":true,"runningNow":true}
sseObserved-on-real-path: true       <-- interceptor fires on real path
```

**completed-empty (WIRED) — still RED, fast-fail:**
```
L3(chat).state: red  summary: "empty assistant response"
elapsed_ms: 5340 (~2.5s/level, not the 60s ceiling)
LAST readTurnState on REAL path: {"runsFinished":1,"attrPresent":true,"sawRunningTrue":true,"runningNow":false}
sseObserved-on-real-path: true
```

**recoverable-stall (WIRED) — attempt 1 never completes → retry → GREEN:**
```
L3(chat).state: green  summary: ""
elapsed_ms: 13423   (attempt 1 polls to per-attempt ceiling observed=true/complete=false, then resends; attempt 2 renders)
sseObserved-on-real-path: true
```

## Checks

- `tsc --noEmit`: clean
- `tsc -p tsconfig.build.json` (build): clean
- vitest `d4-chat-roundtrip.test.ts`: 56/56 pass (suite rewritten to exercise the real `readTurnState` path + retry/fast-fail; late-token→green, completed-empty→red, recoverable-stall→green via retry, permanent-stall→red)
- oxlint: 0 errors (pre-existing warnings only)

Kept as a **draft**; do not merge.

---

## Follow-up (b572697ab): attempt-scoped completion — the dominant a1 false-red

CR flagged that the poll's `sseDone = runsFinished >= 1` read the page-GLOBAL monotonic counter. A **prior run on the page** (auto-greeting / initial-mount run) leaves `runsFinished >= 1` and `sawRunningTrue` already latched **before the user's turn starts**, so the poll thought THIS turn had already completed, saw the still-empty container, and spuriously **fast-failed RED**. It only passed the old tests because the fake reset per send.

### Fixes in this commit

1. **Completion is now ATTEMPT-SCOPED.** A per-attempt BASELINE (`runsFinished` + `runStartCount`) is captured at send time; the turn is complete only on a **new edge past the baseline** (`runsFinished > baseline`, or a new `runStartCount` DOM run-start), never the page-global `>= 1`. A fresh baseline is taken before each retry resend, so a stale prior edge can't defeat the retry. `TurnState`/`readTurnState` now surface `runStartCount` + `lastStoppedAtMs` (the sse-interceptor already latches them), and the grace window is stamped from the **real finished edge** rather than the poll's local clock (fixes the ~500ms-short grace).
2. **Retry resend bounded by remaining budget.** The retry `sendTurn()` type/press timeouts are capped to `hardCeiling` (were flat `pageTimeoutMs`, which let a stalled resend push poll-phase wall-clock ~2x past the ceiling).
3. **Attach-fault is observable.** A failed `attachSseInterceptor` now emits an `onAttachFault` marker + sets `TurnState.sseAttachFailed`, so a silent regression to the inert base-floor path is detectable.

Folded (cheap): `probe.message.send` fallback moved into `finally` (fires on nav/send throw); external `ctx.abortSignal` aborts labeled `"abort"` (not `driver-error`) in the aggregate; corrected fast-fail-floor / hardCeiling / poll-deadline doc comments.

### Real-surface RED→GREEN (real Chromium + real `attachSseInterceptor` + local SSE fixture)

The fixture fires a PRIOR run on mount (bumps the page-global counters), then the user turn renders a first token at 2800ms — PAST the 2s grace window. Driven through the REAL `createE2eSmokeDriver` + `wirePlaywrightPage` (L3/chat, the every-service level).

**PRE-FIX (`sseDone = runsFinished >= 1`):**
```
a1-priorrun      L3.state: red   "empty assistant response"  elapsed 2141ms   <-- FALSE-RED (the bug)
recoverable      L3.state: red   "empty assistant response"  elapsed 2171ms   <-- retry defeated by stale prior edge
wired-late       L3.state: green                             elapsed 3136ms   (no prior run → no false completion)
completed-empty  L3.state: red   "empty assistant response"  elapsed 2156ms
```

**POST-FIX (attempt-scoped baseline):**
```
a1-priorrun      L3.state: green                             elapsed 3285ms   <-- fixed: prior run no longer false-reds
recoverable      L3.state: green                             elapsed 5192ms   <-- retry rescues (fresh baseline per resend)
wired-late       L3.state: green                             elapsed 3150ms
completed-empty  L3.state: red   "empty assistant response"  elapsed 2707ms   <-- fast-fail (~completion+grace, not the 9s ceiling)
sseObserved-on-real-path: true (all)   sseAttachFailed: false
```

### Checks
- `tsc --noEmit`: clean · `tsc -p tsconfig.build.json` (build): clean
- vitest `d4-chat-roundtrip.test.ts`: **63/63** (added: a1-regression L3+L4, completed-empty-one-send, L3 grace/fast-fail/retry, attach-fault telemetry)
- oxlint: **0 errors** (4 pre-existing warnings only)

Still a **draft**; do not merge.


---

## Follow-up (a): grace-window timestamp — Node-stamp completion instant

Four reviewers flagged the same line in `runAttempt`:

```ts
completeAtMs = stoppedAtMs > 0 ? stoppedAtMs : Date.now();
```

where `stoppedAtMs` came from the page-side `readTurnState().lastStoppedAtMs`. Two defects in one line:

1. **Stale on SSE-only completion.** When the turn is detected complete via `sseDone = runsFinished > baseline` but no fresh DOM stop-edge fires for THIS turn, `lastStoppedAtMs` still holds a **stale prior-run** value → `graceEnd = staleStop + FIRST_TOKEN_GRACE_MS` lands in the past → the ~2s grace window collapses to the base floor → a late-but-present first token **false-REDs**.
2. **Cross-clock skew.** `lastStoppedAtMs` is stamped on the **browser-page** `Date.now()`, but `graceEnd`/deadline math runs on the **Node** clock → page↔Node skew mis-sizes the window.

### Fix (single-point, simplifying)
Stamp `completeAtMs = Date.now()` (**Node**) at the first poll iteration that observes THIS turn complete; `readTurnComplete` no longer threads `stoppedAtMs`. Both clocks are now consistent; the stamp lags the true finished edge by at most one 500ms poll interval, well inside `FIRST_TOKEN_GRACE_MS`. Preserved: completed-empty still fast-reds; base-floor and `hardCeiling` caps intact; no masking. `lastStoppedAtMs` is retained on `TurnState` (still consumed by conversation-runner / sse-interceptor / d6).

### Tightenings (net-negative source LOC: +54/−58 = **−4**)
- Extracted the attempt-0 baseline IIFE onto the existing `readBaseline` helper (DRY; removes a drift hazard on the completion-scoping path).
- Fixed stale comments: fallback `emitMessageSend()` now runs in the `finally`; eviction comment (rides the `onResponse` wiring, not "always active"); `lastStoppedAtMs` doc.

### Red-green (mandatory)

**Unit — stale-`lastStoppedAtMs` grace collapse** (`SSE-only completion with a STALE lastStoppedAtMs …`): prior finished run + `sseOnlyStaleStop` + prior stop aged 5s + token 700ms after completion (inside a healthy grace window).
```
RED   (pre-fix stamping: completeAtMs = staleStop):  expected 'red' to be 'green'   → RED
GREEN (Node-stamp fix):                              64/64 pass                      → GREEN
```

**Real-surface no-regression** (real chromium + `wirePlaywrightPage` → real `attachSseInterceptor` + local SSE fixture, `repro_d4_a1_realsurface.mts`):
```
a1-priorrun      aggregate green · L3 green                            elapsed 3292ms   (SSE-only-late, lastStoppedAtMs stale at completion)
completed-empty  aggregate red   · L3 "empty assistant response"      elapsed 2618ms   (fast-fail, not the 9s ceiling)
recoverable      aggregate green · L3 green                            elapsed 5161ms
wired-late       aggregate green · L3 green                            elapsed 3131ms
sseObserved-on-real-path: true (all)   sseAttachFailed: false
```

### Checks (this commit)
- `tsc --noEmit`: clean · build (`tsc -p tsconfig.build.json`): clean
- vitest `d4-chat-roundtrip.test.ts`: **64/64**
- oxlint: **0 errors** (4 pre-existing warnings only)
- commit: `7bb47e64d`

Still a **draft**; do not merge.


---

## Follow-up (commit `5047f7ba9`): make the SSE-only-stale grace guard actually bite

Three reviewers noted that the `sseOnlyStaleStop` guard above did not, in fact, guard the Node-stamp fix. Root cause in the fake (`makeLateTokenBrowser.readTurnState()`): the driver takes the per-attempt baseline via `readTurnState()` **before** the first send, and at that point `lastSendAtMs===0` made `elapsed` (~epoch ms) exceed `completeAt`, spuriously flipping `complete=true` at the **baseline** read. That inflated the baseline `runsFinished` to `prior+1`, so the current turn's real finished edge never rose **past** the baseline and the driver's `sseDone = runsFinished > baseline.runsFinished` could never fire. The SSE-only-stale-grace path was therefore never entered — the test passed only because the token rendered directly (path (a)), so it did **not** guard the Node-stamp fix.

**Test-only fix:** gate the fake's `complete` on `started` (a turn has actually been sent). The pre-send baseline read is now a **true** baseline (`runsFinished = prior + priorSendsDone`, no current-turn finish); the finished edge is a genuine THIS-turn transition the driver observes via `sseDone`; and the SSE-only completion path with a stale `lastStoppedAtMs` is genuinely exercised.

### RED-on-revert proof (the guard bites)

Temporarily reverted the production stamp back to the pre-fix form (`completeAtMs = stoppedAtMs > 0 ? stoppedAtMs : Date.now()`, re-threading `stoppedAtMs` through `readTurnComplete`), ran the reworked test, then restored the Node-stamp:

```
RED  (pre-fix revert: completeAtMs = stoppedAtMs):
  × SSE-only completion with a STALE lastStoppedAtMs … → GREEN
    AssertionError: expected 'red' to be 'green'
  Test Files  1 failed (1)

GREEN (Node-stamp restored: completeAtMs = Date.now()):
  ✓ SSE-only completion with a STALE lastStoppedAtMs … → GREEN
  Test Files  1 passed (1)
```

The production revert was **not committed** — final state has the correct Node-stamp; the production diff in this commit is **comment-only** (no logic change).

### Comment corrections (this commit)
- Completed-empty deadline comment: previously claimed "base floor always respected"; corrected to state that `Math.min(Math.max(baseBudgetEnd, graceEnd), fastFailEnd, attemptCeiling)` intentionally clamps **below** the floor (fast-fail — a completed-empty turn must red fast, not burn the base budget).
- `FIRST_TOKEN_FAST_FAIL_MS` doc: now spells out the full `Math.min` term rather than only the `Math.max(base, grace)` cap.

### Checks (this commit)
- `tsc --noEmit`: clean · build (`tsc -p tsconfig.build.json`): clean
- vitest `d4-chat-roundtrip.test.ts`: **64/64**
- oxlint: **0 errors** (4 pre-existing warnings only)
- diff: driver (comments) + test file only; no `repro_*`/`baseline` staged
- commit: `5047f7ba9`

Still a **draft**; do not merge.
