### PR TITLE
fix(react-core): expose lean hooks from /v2/headless to cut bundle bloat (#4893)

### DIFF
--- a/packages/react-core/src/v2/__tests__/headless-exports.test.ts
+++ b/packages/react-core/src/v2/__tests__/headless-exports.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import * as headless from "../headless";
+
+// Guards the two regressions issue #4893 fixed that neither the bundle guard nor
+// `tsc` catches: (1) a documented hook silently dropped from the entry, and
+// (2) UseAgentUpdate — a runtime enum — re-exported via `export type`, which
+// type-checks clean but strips the runtime binding under isolatedModules, leaving
+// useAgent's `updates` option undefined at runtime.
+//
+// Typing the name lists as `(keyof typeof headless)[]` also fails `tsc` if a
+// listed export is removed, so the surface is guarded at build time too.
+describe("@copilotkit/react-core/v2/headless runtime exports", () => {
+  it("exports the documented hooks as runtime functions", () => {
+    const hooks: (keyof typeof headless)[] = [
+      "useCopilotKit",
+      "useAgent",
+      "useFrontendTool",
+      "useComponent",
+      "useHumanInTheLoop",
+      "useInterrupt",
+      "useSuggestions",
+      "useConfigureSuggestions",
+      "useAgentContext",
+      "useThreads",
+      "useRenderTool",
+      "useRenderToolCall",
+      "useCapabilities",
+      "useCopilotChatConfiguration",
+    ];
+    for (const name of hooks) {
+      expect(
+        typeof headless[name],
+        `${name} should be a runtime function`,
+      ).toBe("function");
+    }
+  });
+
+  it("exports the provider, core class, and helpers as runtime values", () => {
+    const values: (keyof typeof headless)[] = [
+      "CopilotKitCoreReact",
+      "CopilotChatConfigurationProvider",
+      "CopilotChatDefaultLabels",
+      "defineToolCallRenderer",
+    ];
+    for (const name of values) {
+      expect(headless[name], `${name} should be a runtime value`).toBeDefined();
+    }
+  });
+
+  it("exports UseAgentUpdate as a runtime enum value (not stripped by `export type`)", () => {
+    expect(headless.UseAgentUpdate).toBeDefined();
+    expect(headless.UseAgentUpdate.OnMessagesChanged).toBe("OnMessagesChanged");
+  });
+});

--- a/packages/react-core/src/v2/headless.ts
+++ b/packages/react-core/src/v2/headless.ts
@@ -1,8 +1,19 @@
 /**
  * Headless (platform-agnostic) exports from @copilotkit/react-core/v2.
  *
- * No CSS, no web UI components, no DOM dependencies.
- * Used by @copilotkit/react-native.
+ * No CSS and no built-in chat UI components — and, crucially, none of the
+ * built-in chat-message rendering stack (Markdown / syntax highlighting via
+ * `streamdown` → shiki, plus mermaid, cytoscape and katex). The few browser
+ * APIs it touches (e.g. `window.matchMedia`) are feature-detected, so it stays
+ * SSR- and React-Native-safe. Because this is a separate build entry, it ships
+ * as its own small chunk instead of the monolithic shared chunk the main
+ * `@copilotkit/react-core/v2` entry re-exports from — importing any symbol from
+ * that entry drags the whole rendering stack into the consumer's bundle with no
+ * way to tree-shake it out (issue #4893), adding several MB to a build.
+ *
+ * Import hooks from here when you build a fully custom chat UI and don't use any
+ * of the prebuilt `CopilotChat*` components. Also used by
+ * `@copilotkit/react-native`.
  */
 
 // Re-export from context (which is external in this build) so the .d.ts
@@ -11,7 +22,7 @@
 // The relative "./context" specifier is rewritten to the external package path
 // in the emitted declarations by the tsdown `build:done` hook (a relative
 // extensionless import is invalid in ESM declarations).
-export { CopilotKitCoreReact } from "./context";
+export { CopilotKitCoreReact, useCopilotKit } from "./context";
 export type { CopilotKitCoreReactConfig } from "./context";
 
 // Chat configuration provider (no UI, just context)
@@ -24,8 +35,11 @@ export {
   type CopilotChatConfigurationProviderProps,
 } from "./providers/CopilotChatConfigurationProvider";
 
-// Platform-agnostic hooks
-export { useAgent, type UseAgentUpdate } from "./hooks/use-agent";
+// Platform-agnostic hooks.
+// UseAgentUpdate is a runtime enum (passed as a value to useAgent's `updates`
+// option), so it must be a value export — `export type` would strip its runtime
+// binding from this entry under isolatedModules, breaking consumers.
+export { useAgent, UseAgentUpdate } from "./hooks/use-agent";
 export { useFrontendTool } from "./hooks/use-frontend-tool";
 export { useComponent } from "./hooks/use-component";
 export { useHumanInTheLoop } from "./hooks/use-human-in-the-loop";
@@ -57,6 +71,13 @@ export {
   type RenderToolExecutingProps,
   type RenderToolCompleteProps,
 } from "./hooks/use-render-tool";
+// Consumption counterpart to useRenderTool: renders a tool call using the app's
+// registered renderers. Like useRenderTool it introduces no host DOM of its own
+// (the app-supplied renderers do) and pulls no chat-UI rendering stack — unlike
+// useDefaultRenderTool (renders web-only <div>/<svg>) or useRenderCustomMessages
+// / useRenderActivityMessage (link @copilotkit/a2ui-renderer), which stay in the
+// main /v2 entry.
+export { useRenderToolCall } from "./hooks/use-render-tool-call";
 export { defineToolCallRenderer } from "./types/defineToolCallRenderer";
 
 // Platform-agnostic types

--- a/packages/react-core/src/v2/lib/shallow-stable-ref.ts
+++ b/packages/react-core/src/v2/lib/shallow-stable-ref.ts
@@ -1,0 +1,67 @@
+import { useRef } from "react";
+
+// Tailwind-free reference-stability helpers. Kept in their own leaf module (not
+// in ./slots, which imports `tailwind-merge`) so that DOM/CSS-free consumers —
+// e.g. CopilotChatConfigurationProvider, which is re-exported from the lean
+// `@copilotkit/react-core/v2/headless` entry — can reach them without pulling
+// `tailwind-merge` into the bundle (issue #4893).
+
+/**
+ * Shallow equality comparison for objects.
+ */
+export function shallowEqual<T extends Record<string, unknown>>(
+  obj1: T,
+  obj2: T,
+): boolean {
+  const keys1 = Object.keys(obj1);
+  const keys2 = Object.keys(obj2);
+
+  if (keys1.length !== keys2.length) return false;
+
+  for (const key of keys1) {
+    if (obj1[key] !== obj2[key]) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Returns true only for plain JS objects (`{}`), excluding arrays, Dates,
+ * class instances, and other exotic objects that happen to have typeof "object".
+ */
+function isPlainObject(obj: unknown): obj is Record<string, unknown> {
+  return (
+    obj !== null &&
+    typeof obj === "object" &&
+    Object.prototype.toString.call(obj) === "[object Object]"
+  );
+}
+
+/**
+ * Returns the same reference as long as the value is shallowly equal to the
+ * previous render's value.
+ *
+ * - Identical references bail out immediately (O(1)).
+ * - Plain objects ({}) are shallow-compared key-by-key.
+ * - Arrays, Dates, class instances, functions, and primitives are compared by
+ *   reference only — shallowEqual is never called on non-plain objects, which
+ *   avoids incorrect equality for e.g. [1,2] vs [1,2] (different arrays).
+ *
+ * Typical use: stabilize inline slot props so MemoizedSlotWrapper's shallow
+ * equality check isn't defeated by a new object reference on every render.
+ */
+export function useShallowStableRef<T>(value: T): T {
+  const ref = useRef(value);
+
+  // 1. Identical reference — bail early, no comparison needed.
+  if (ref.current === value) return ref.current;
+
+  // 2. Both are plain objects — shallow-compare to detect structural equality.
+  if (isPlainObject(ref.current) && isPlainObject(value)) {
+    if (shallowEqual(ref.current, value)) return ref.current;
+  }
+
+  // 3. Different values (or non-comparable types) — update the ref.
+  ref.current = value;
+  return ref.current;
+}

--- a/packages/react-core/src/v2/lib/slots.tsx
+++ b/packages/react-core/src/v2/lib/slots.tsx
@@ -1,71 +1,18 @@
-import React, { useRef } from "react";
+import React from "react";
 import { twMerge } from "tailwind-merge";
+import { shallowEqual, useShallowStableRef } from "./shallow-stable-ref";
+
+// Reference-stability helpers moved to ./shallow-stable-ref (a tailwind-free leaf
+// module) so the lean @copilotkit/react-core/v2/headless entry can reach them
+// without pulling tailwind-merge (issue #4893). Re-exported here to preserve this
+// module's public surface for existing importers (e.g. CopilotChat).
+export { shallowEqual, useShallowStableRef };
 
 /** Existing union (unchanged) */
 export type SlotValue<C extends React.ComponentType<any>> =
   | C
   | string
   | Partial<React.ComponentProps<C>>;
-
-/**
- * Shallow equality comparison for objects.
- */
-export function shallowEqual<T extends Record<string, unknown>>(
-  obj1: T,
-  obj2: T,
-): boolean {
-  const keys1 = Object.keys(obj1);
-  const keys2 = Object.keys(obj2);
-
-  if (keys1.length !== keys2.length) return false;
-
-  for (const key of keys1) {
-    if (obj1[key] !== obj2[key]) return false;
-  }
-
-  return true;
-}
-
-/**
- * Returns true only for plain JS objects (`{}`), excluding arrays, Dates,
- * class instances, and other exotic objects that happen to have typeof "object".
- */
-function isPlainObject(obj: unknown): obj is Record<string, unknown> {
-  return (
-    obj !== null &&
-    typeof obj === "object" &&
-    Object.prototype.toString.call(obj) === "[object Object]"
-  );
-}
-
-/**
- * Returns the same reference as long as the value is shallowly equal to the
- * previous render's value.
- *
- * - Identical references bail out immediately (O(1)).
- * - Plain objects ({}) are shallow-compared key-by-key.
- * - Arrays, Dates, class instances, functions, and primitives are compared by
- *   reference only — shallowEqual is never called on non-plain objects, which
- *   avoids incorrect equality for e.g. [1,2] vs [1,2] (different arrays).
- *
- * Typical use: stabilize inline slot props so MemoizedSlotWrapper's shallow
- * equality check isn't defeated by a new object reference on every render.
- */
-export function useShallowStableRef<T>(value: T): T {
-  const ref = useRef(value);
-
-  // 1. Identical reference — bail early, no comparison needed.
-  if (ref.current === value) return ref.current;
-
-  // 2. Both are plain objects — shallow-compare to detect structural equality.
-  if (isPlainObject(ref.current) && isPlainObject(value)) {
-    if (shallowEqual(ref.current, value)) return ref.current;
-  }
-
-  // 3. Different values (or non-comparable types) — update the ref.
-  ref.current = value;
-  return ref.current;
-}
 
 /** Utility: concrete React elements for every slot */
 type SlotElements<S> = { [K in keyof S]: React.ReactElement };

--- a/packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx
@@ -9,7 +9,9 @@ import React, {
   useState,
 } from "react";
 import { DEFAULT_AGENT_ID, randomUUID } from "@copilotkit/shared";
-import { useShallowStableRef } from "../lib/slots";
+// Import from the tailwind-free leaf module (not ../lib/slots, which pulls
+// tailwind-merge) so this provider stays lean in the headless entry (issue #4893).
+import { useShallowStableRef } from "../lib/shallow-stable-ref";
 
 // Default labels
 export const CopilotChatDefaultLabels = {


### PR DESCRIPTION
## What & why

`@copilotkit/react-core`'s `/v2` entry (and the root entry) re-exports from a
single **monolithic shared chunk**, so importing *any* symbol — even one hook —
pulls the built-in chat-message rendering stack (`streamdown` → shiki, `mermaid`,
`cytoscape`, `katex`) into the consumer's bundle: **~3 MB gzip / ~15 MB raw**,
with no way to tree-shake it. Consumers who build a fully custom chat UI and only
use hooks pay the full cost. (Issue #4893.)

A separate lean build entry — `@copilotkit/react-core/v2/headless` — already
ships those hooks in their own small chunk **without** that stack (it's how
`@copilotkit/react-native` mounts CopilotKit). This PR makes it usable for a
custom web UI.

Measured with esbuild (react/react-dom external):

| import | bundled JS |
|---|---|
| hooks from `@copilotkit/react-core/v2` | **~2.96 MB** gzip (≈ importing full `CopilotChat`) |
| same hooks from `@copilotkit/react-core/v2/headless` | **~0.03 MB** gzip |

> Note on the report: `@copilotkit/a2ui-renderer` doesn't bundle the rich-text
> stack (its deps are `@a2ui/web_core`, `lit`, `clsx`, `zod`). The weight is
> entirely `streamdown` (shiki/mermaid/cytoscape) + `katex`, pulled by the
> built-in `CopilotChat*` message components.

## Changes

- **`headless.ts`** — export `useCopilotKit` + `useRenderToolCall` (both DOM-free
  and rendering-stack-free); fix `UseAgentUpdate` (a runtime `enum`) being
  re-exported via `export type`, which stripped its runtime value under
  `isolatedModules` (so `useAgent`'s `updates` option was unusable from headless
  — a bug `tsc` can't catch). `useDefaultRenderTool` / `useRenderCustomMessages`
  / `useRenderActivityMessage` stay in `/v2` (web-only markup or `a2ui-renderer`).
- **Remove a `tailwind-merge` leak** — extract the tailwind-free ref helpers
  (`shallowEqual` / `useShallowStableRef`) into `lib/shallow-stable-ref.ts` so the
  headless graph no longer pulls `tailwind-merge` via
  `CopilotChatConfigurationProvider`.
- **Test** — a small vitest export-surface test guarding the hook surface and the
  `UseAgentUpdate` runtime value.

## Verification

`react-core` typecheck + vitest (1427) and `react-native` typecheck pass. Shipped
`dist/v2/headless.mjs` imports only `react`, `@ag-ui/client`, `@copilotkit/core`,
`@copilotkit/shared`, `@copilotkit/react-core/v2/context`, `zod` — no rendering
stack.

## Notes / follow-ups

- Headless hooks read a **different React context** than the prebuilt `/v2`
  `<CopilotKitProvider>`, so the two can't be mixed — mount a lean provider over
  `/v2/context` (as `@copilotkit/react-native` does). Making the `/v2` provider
  reuse the standalone `/v2/context` singleton would remove that sharp edge and
  is the natural follow-up.
- Existing bundle-size CI (`compressed-size-action`) already tracks `headless.mjs`,
  so no new size tooling is added here.

Addresses #4893.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
