### PR TITLE
fix(runtime): stop finalizeRunEvents emitting events after a terminal (#5812)

### DIFF
--- a/packages/runtime/src/v2/runtime/runner/__tests__/finalize-events.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/finalize-events.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
-import {
+import type {
   BaseEvent,
-  EventType,
   ToolCallResultEvent,
   RunErrorEvent,
 } from "@ag-ui/client";
+import { EventType } from "@ag-ui/client";
 import { finalizeRunEvents } from "@copilotkit/shared";
 
 const createTextStart = (messageId: string): BaseEvent =>
@@ -82,28 +82,54 @@ describe("finalizeRunEvents", () => {
     expect(errorEvent?.message).toContain("terminal event");
   });
 
-  it("only appends structural fixes when a terminal event already exists", () => {
+  // #5812: once a run has emitted a terminal event, the AG-UI verifier rejects
+  // any sub-event streamed after it ("the run has already errored/finished …").
+  // Because finalization events are streamed after everything the agent already
+  // emitted, finalize must append NOTHING when a terminal already exists — even
+  // for messages / tool calls that are still open (the terminal closes them on
+  // the client). Regression: it previously appended a trailing TEXT_MESSAGE_END.
+  it.each([EventType.RUN_FINISHED, EventType.RUN_ERROR])(
+    "appends nothing after an existing %s terminal, even with open sub-events",
+    (terminal) => {
+      const events: BaseEvent[] = [
+        createTextStart("msg-1"),
+        createToolStart("tool-1"),
+        { type: terminal, message: "boom" } as BaseEvent,
+      ];
+
+      const appended = finalizeRunEvents(events, { stopRequested: true });
+
+      expect(appended).toEqual([]);
+      // The terminal stays the final event — nothing was pushed after it.
+      expect(events.at(-1)?.type).toBe(terminal);
+    },
+  );
+
+  it("does not append TEXT_MESSAGE_END after a RUN_ERROR emitted on mid-stream stop (#5812)", () => {
+    // Mirrors the issue: an HttpAgent proxy is aborted mid-stream, so a live
+    // RUN_ERROR arrives while a text message is still open.
+    const messageId = "225f30a2-c662-4d0d-a05e-789cb51e17cc";
     const events: BaseEvent[] = [
-      createTextStart("msg-1"),
-      createToolStart("tool-1"),
-      { type: EventType.RUN_FINISHED } as BaseEvent,
+      createTextStart(messageId),
+      {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId,
+        delta: " frames",
+      } as BaseEvent,
+      {
+        type: EventType.RUN_ERROR,
+        message: "This operation was aborted",
+        code: "abort",
+      } as BaseEvent,
     ];
 
-    const appended = finalizeRunEvents(events);
+    const appended = finalizeRunEvents(events, { stopRequested: true });
 
-    expect(appended.map((event) => event.type)).toEqual([
-      EventType.TEXT_MESSAGE_END,
-      EventType.TOOL_CALL_END,
-    ]);
-
-    expect(
-      appended.some((event) => event.type === EventType.TOOL_CALL_RESULT),
-    ).toBe(false);
-    expect(appended.some((event) => event.type === EventType.RUN_ERROR)).toBe(
-      false,
+    expect(appended).toEqual([]);
+    const runErrorIdx = events.findIndex(
+      (event) => event.type === EventType.RUN_ERROR,
     );
-    expect(
-      appended.some((event) => event.type === EventType.RUN_FINISHED),
-    ).toBe(false);
+    // No events at all follow the terminal RUN_ERROR.
+    expect(events.slice(runErrorIdx + 1)).toEqual([]);
   });
 });

--- a/packages/runtime/src/v2/runtime/runner/__tests__/in-memory-runner.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/in-memory-runner.test.ts
@@ -13,8 +13,8 @@ import type {
   TextMessageStartEvent,
   ToolCallResultEvent,
 } from "@ag-ui/client";
-import { AbstractAgent, EventType } from "@ag-ui/client";
-import { EMPTY, firstValueFrom } from "rxjs";
+import { AbstractAgent, EventType, verifyEvents } from "@ag-ui/client";
+import { EMPTY, Observable, firstValueFrom } from "rxjs";
 import { toArray } from "rxjs/operators";
 
 const stripTerminalEvents = (events: BaseEvent[]) =>
@@ -951,5 +951,114 @@ describe("InMemoryAgentRunner onConcurrentRun", () => {
           (e as { runId?: string }).runId === "run-2",
       ),
     ).toBe(true);
+  });
+});
+
+describe("InMemoryAgentRunner stop mid-stream (#5812)", () => {
+  // Models an HttpAgent proxy (e.g. pydantic-ai's AGUIAdapter): it opens a text
+  // message and streams a chunk, then on abort emits a live RUN_ERROR WITHOUT
+  // closing the message and lets runAgent resolve. Before the fix, finalize
+  // appended a trailing TEXT_MESSAGE_END after that RUN_ERROR, which the AG-UI
+  // verifier the browser runs rejected with "the run has already errored".
+  class MidStreamAbortAgent extends AbstractAgent {
+    readonly messageId = "225f30a2-c662-4d0d-a05e-789cb51e17cc";
+    private emit?: (event: BaseEvent) => void;
+    private finishRun?: () => void;
+
+    async runAgent(
+      input: RunAgentInput,
+      options: {
+        onEvent: (e: { event: BaseEvent }) => void;
+        onRunStartedEvent?: () => void;
+      },
+    ): Promise<RunAgentResult> {
+      const emit = (event: BaseEvent) => options.onEvent({ event });
+      this.emit = emit;
+      emit({
+        type: EventType.RUN_STARTED,
+        threadId: input.threadId,
+        runId: input.runId,
+      } as RunStartedEvent);
+      options.onRunStartedEvent?.();
+      emit({
+        type: EventType.TEXT_MESSAGE_START,
+        messageId: this.messageId,
+        role: "assistant",
+      } as TextMessageStartEvent);
+      emit({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: this.messageId,
+        delta: " frames",
+      } as TextMessageContentEvent);
+      return new Promise<RunAgentResult>((resolve) => {
+        this.finishRun = () => resolve({ result: undefined, newMessages: [] });
+      });
+    }
+
+    abortRun(): void {
+      this.emit?.({
+        type: EventType.RUN_ERROR,
+        message: "This operation was aborted",
+        code: "abort",
+      } as RunErrorEvent);
+      this.finishRun?.();
+    }
+
+    clone(): AbstractAgent {
+      return new MidStreamAbortAgent();
+    }
+
+    run(): ReturnType<AbstractAgent["run"]> {
+      return EMPTY;
+    }
+
+    protected connect(): ReturnType<AbstractAgent["connect"]> {
+      return EMPTY;
+    }
+  }
+
+  it("emits no events after RUN_ERROR and the stream passes the AG-UI verifier", async () => {
+    const runner = new InMemoryAgentRunner();
+    runner.clearThreads();
+    const threadId = "in-memory-stop-mid-stream";
+    const agent = new MidStreamAbortAgent();
+    const input: RunAgentInput = {
+      threadId,
+      runId: "run-1",
+      messages: [],
+      state: {},
+      tools: [],
+      context: [],
+    };
+
+    const collected: BaseEvent[] = [];
+    const done = new Promise<void>((resolve) => {
+      runner.run({ threadId, agent, input }).subscribe({
+        next: (event) => collected.push(event),
+        complete: () => resolve(),
+      });
+    });
+
+    // START + CONTENT are emitted synchronously; press Stop mid-stream (between
+    // TEXT_MESSAGE_START and TEXT_MESSAGE_END).
+    await runner.stop({ threadId });
+    await done;
+
+    const types = collected.map((event) => event.type);
+    const runErrorIdx = types.indexOf(EventType.RUN_ERROR);
+    expect(runErrorIdx).toBeGreaterThanOrEqual(0);
+    // Nothing may follow the terminal RUN_ERROR — no trailing TEXT_MESSAGE_END.
+    expect(types.slice(runErrorIdx + 1)).toEqual([]);
+
+    // The stream the client receives must pass the SAME verifier the browser
+    // runs (verifyEvents). Before the fix this rejected the trailing
+    // TEXT_MESSAGE_END with "the run has already errored with 'RUN_ERROR'".
+    const verified = await firstValueFrom(
+      new Observable<BaseEvent>((subscriber) => {
+        for (const event of collected) subscriber.next(event);
+        subscriber.complete();
+      }).pipe(verifyEvents(false), toArray()),
+    );
+    expect(verified.at(-1)?.type).toBe(EventType.RUN_ERROR);
   });
 });

--- a/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
@@ -496,11 +496,11 @@ describe("IntelligenceAgentRunner", () => {
       });
     });
 
-    it("finalizes open message streams before completing", async () => {
+    it("does not push a TEXT_MESSAGE_END after an agent-emitted terminal (#5812)", async () => {
       const threadId = "t-finalize";
       const input = createRunInput({ threadId, runId: "r-fin" });
 
-      // Emit an unclosed text message, then RUN_FINISHED.
+      // Agent leaves a text message open, then emits its own RUN_FINISHED.
       const agentEvents: BaseEvent[] = [
         {
           type: EventType.TEXT_MESSAGE_START,
@@ -519,14 +519,18 @@ describe("IntelligenceAgentRunner", () => {
 
       await eventsPromise;
 
-      // finalizeRunEvents appends TEXT_MESSAGE_END for the unclosed message.
-      // Verify the channel received both agent and finalization events.
+      // Once the agent emits a terminal, finalizeRunEvents must append nothing:
+      // the AG-UI verifier rejects any TEXT_MESSAGE_END streamed after the
+      // terminal ("the run has already finished"). RUN_FINISHED stays the last
+      // channel push — the open message is closed by the terminal on the client.
       const chPayloadTypes = ch.pushLog.map((p) => p.payload.type);
-      expect(chPayloadTypes).toContain(EventType.RUN_STARTED);
-      expect(chPayloadTypes).toContain(EventType.TEXT_MESSAGE_START);
-      expect(chPayloadTypes).toContain(EventType.TEXT_MESSAGE_END);
+      expect(chPayloadTypes).toEqual([
+        EventType.RUN_STARTED,
+        EventType.TEXT_MESSAGE_START,
+        EventType.RUN_FINISHED,
+      ]);
       expect(ch.pushLog.map((p) => p.payload.metadata.cpki_event_seq)).toEqual([
-        1, 2, 3, 4,
+        1, 2, 3,
       ]);
     });
 

--- a/packages/shared/src/finalize-events.ts
+++ b/packages/shared/src/finalize-events.ts
@@ -1,4 +1,5 @@
-import { BaseEvent, EventType, RunErrorEvent } from "@ag-ui/client";
+import type { BaseEvent, RunErrorEvent } from "@ag-ui/client";
+import { EventType } from "@ag-ui/client";
 import { randomUUID } from "./utils";
 
 interface FinalizeRunOptions {
@@ -79,14 +80,25 @@ export function finalizeRunEvents(
     }
   }
 
-  const hasRunFinished = events.some(
-    (event) => event.type === EventType.RUN_FINISHED,
+  const hasTerminalEvent = events.some(
+    (event) =>
+      event.type === EventType.RUN_FINISHED ||
+      event.type === EventType.RUN_ERROR,
   );
-  const hasRunError = events.some(
-    (event) => event.type === EventType.RUN_ERROR,
-  );
-  const hasTerminalEvent = hasRunFinished || hasRunError;
-  const terminalEventMissing = !hasTerminalEvent;
+
+  // Once a run has emitted a terminal event (RUN_FINISHED or RUN_ERROR), the
+  // AG-UI spec forbids any further events for that run — the verifier rejects a
+  // trailing TEXT_MESSAGE_END / TOOL_CALL_END with "the run has already
+  // errored/finished with '…'. No further events can be sent." (issue #5812).
+  // These finalization events are streamed *after* everything the agent already
+  // emitted, so appending closers here would place them after that terminal.
+  // When a terminal already exists we therefore append nothing: any message or
+  // tool call still open when the terminal arrived is implicitly closed by the
+  // terminal on the client. We only synthesize closers + a terminal for a
+  // stream that ended abruptly without a terminal of its own (below).
+  if (hasTerminalEvent) {
+    return appended;
+  }
 
   for (const messageId of openMessageIds) {
     const endEvent = {
@@ -107,7 +119,7 @@ export function finalizeRunEvents(
       appended.push(endEvent);
     }
 
-    if (terminalEventMissing && !info.hasResult) {
+    if (!info.hasResult) {
       const resultEvent = {
         type: EventType.TOOL_CALL_RESULT,
         toolCallId,
@@ -132,22 +144,20 @@ export function finalizeRunEvents(
     }
   }
 
-  if (terminalEventMissing) {
-    if (stopRequested) {
-      const finishedEvent = {
-        type: EventType.RUN_FINISHED,
-      } as BaseEvent;
-      events.push(finishedEvent);
-      appended.push(finishedEvent);
-    } else {
-      const errorEvent: RunErrorEvent = {
-        type: EventType.RUN_ERROR,
-        message: resolvedAbruptMessage,
-        code: "INCOMPLETE_STREAM",
-      };
-      events.push(errorEvent);
-      appended.push(errorEvent);
-    }
+  if (stopRequested) {
+    const finishedEvent = {
+      type: EventType.RUN_FINISHED,
+    } as BaseEvent;
+    events.push(finishedEvent);
+    appended.push(finishedEvent);
+  } else {
+    const errorEvent: RunErrorEvent = {
+      type: EventType.RUN_ERROR,
+      message: resolvedAbruptMessage,
+      code: "INCOMPLETE_STREAM",
+    };
+    events.push(errorEvent);
+    appended.push(errorEvent);
   }
 
   return appended;


### PR DESCRIPTION
## Summary

Pressing **Stop** while an assistant message is streaming (CopilotRuntime + `HttpAgent` proxy) crashed the chat with:

```
Cannot send event type 'TEXT_MESSAGE_END': The run has already errored with 'RUN_ERROR'. No further events can be sent.
```

Root cause: `finalizeRunEvents` appended a trailing `TEXT_MESSAGE_END` **after** the `RUN_ERROR` that the aborted agent had already emitted.

Fixes #5812.

## Root cause

When the upstream agent (e.g. pydantic-ai's `AGUIAdapter`) is aborted mid-stream it emits a live `RUN_ERROR` while a text message is still open — it does **not** close the message first. All runners (`in-memory`, `intelligence`, `sqlite`) stream `finalizeRunEvents`' output *after* everything the agent already emitted, so the appended closer landed past the terminal:

| | outgoing event order |
|---|---|
| **Before** | `… TEXT_MESSAGE_CONTENT → RUN_ERROR → TEXT_MESSAGE_END` ❌ verifier throws |
| **After** | `… TEXT_MESSAGE_CONTENT → RUN_ERROR` ✅ terminal closes the message client-side |

Per the AG-UI invariant: at most one terminal event per run, and no sub-events after it. I confirmed against the real `@ag-ui/client` `verifyEvents` (the verifier the browser runs) that a terminal arriving with a message still open is valid — the terminal implicitly closes it.

## Fix

`finalizeRunEvents` (in `@copilotkit/shared`) now returns early and appends **nothing** when the stream already contains a terminal event (`RUN_FINISHED` or `RUN_ERROR`). The abrupt-end path (no terminal → close open streams + synthesize a terminal, in the correct order) is unchanged. No API/signature change; the in-memory, intelligence, and sqlite runners all inherit the fix.

## Testing

RED→GREEN verified — each new/updated assertion was confirmed to fail against the pre-fix code:

- **`finalize-events.test.ts`** — terminal-present appends nothing (parametrized over `RUN_FINISHED` and `RUN_ERROR`) + a named #5812 case.
- **`in-memory-runner.test.ts`** — end-to-end mid-stream-stop regression: a fake `HttpAgent`-style agent is stopped between `TEXT_MESSAGE_START` and `TEXT_MESSAGE_END`; asserts no events follow `RUN_ERROR` **and** that the collected stream passes `verifyEvents` (before the fix this threw the exact browser error).
- **`intelligence-runner.test.ts`** — corrected a pre-existing assertion that had encoded the buggy post-terminal `TEXT_MESSAGE_END`.

Green: full `@copilotkit/runtime` suite, `@copilotkit/sqlite-runner`, `@copilotkit/shared`, `check-types`, `oxlint` (0 errors), and build.

## Reviewer notes

- The behavior change is a single early-return in `finalize-events.ts`; the `terminalEventMissing` guards simplify away because they're only reachable when no terminal exists.
- Diff is +204/−55 across 4 files, the bulk of it tests.
