### PR TITLE
fix(build): add types condition to package.json exports maps (#3324)

### DIFF
--- a/.github/workflows/validate_package-exports.yml
+++ b/.github/workflows/validate_package-exports.yml
@@ -13,7 +13,8 @@ on:
     paths:
       - "packages/*/package.json"
       - "packages/*/tsdown.config.ts"
-      - "scripts/tsdown-exports.ts"
+      - "scripts/tsdown-exports.mjs"
+      - "scripts/tsdown-exports.d.mts"
       - "scripts/validate-package-exports-types.ts"
       - "scripts/__tests__/validate-package-exports-types.test.ts"
       - ".github/workflows/validate_package-exports.yml"
@@ -21,7 +22,8 @@ on:
     paths:
       - "packages/*/package.json"
       - "packages/*/tsdown.config.ts"
-      - "scripts/tsdown-exports.ts"
+      - "scripts/tsdown-exports.mjs"
+      - "scripts/tsdown-exports.d.mts"
       - "scripts/validate-package-exports-types.ts"
       - "scripts/__tests__/validate-package-exports-types.test.ts"
       - ".github/workflows/validate_package-exports.yml"

--- a/.github/workflows/validate_package-exports.yml
+++ b/.github/workflows/validate_package-exports.yml
@@ -17,6 +17,7 @@ on:
       - "scripts/tsdown-exports.d.mts"
       - "scripts/validate-package-exports-types.ts"
       - "scripts/__tests__/validate-package-exports-types.test.ts"
+      - "scripts/__tests__/tsdown-exports.test.ts"
       - ".github/workflows/validate_package-exports.yml"
   pull_request:
     paths:
@@ -26,6 +27,7 @@ on:
       - "scripts/tsdown-exports.d.mts"
       - "scripts/validate-package-exports-types.ts"
       - "scripts/__tests__/validate-package-exports-types.test.ts"
+      - "scripts/__tests__/tsdown-exports.test.ts"
       - ".github/workflows/validate_package-exports.yml"
 
 permissions:
@@ -53,11 +55,14 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Unit tests for the checker + a regression assertion over every real
-      # publishable package's exports map.
+      # Unit tests for BOTH the validator (checker) and the withTypesConditions
+      # build helper — the helper is the mechanism that actually injects the
+      # types conditions, so it must be exercised here — plus a regression
+      # assertion over every real publishable package's exports map.
       - name: Run exports-types validation tests
-        run: pnpm exec vitest run scripts/__tests__/validate-package-exports-types.test.ts
+        run: pnpm exec vitest run scripts/__tests__/validate-package-exports-types.test.ts scripts/__tests__/tsdown-exports.test.ts
 
-      # Standalone gate with a human-readable report of any offending package.
+      # Standalone gate over the COMMITTED package.json maps (it does not
+      # rebuild), with a human-readable report of any offending package.
       - name: Validate package exports declare types conditions
         run: pnpm validate:exports

--- a/.github/workflows/validate_package-exports.yml
+++ b/.github/workflows/validate_package-exports.yml
@@ -1,0 +1,61 @@
+name: validate / package-exports
+
+# Guards CopilotKit issue #3324: every publishable package's package.json
+# `exports` map must carry a `types` condition for each JS entry, or strict
+# exports resolvers (bundler/node16/nodenext, e.g. the Backstage CLI) resolve
+# no type declarations. tsdown does not emit it automatically, so a stale build
+# or a hand-edited map can silently regress it — publint and attw do NOT catch
+# this (TypeScript's adjacent-file fallback masks it).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/*/package.json"
+      - "packages/*/tsdown.config.ts"
+      - "scripts/tsdown-exports.ts"
+      - "scripts/validate-package-exports-types.ts"
+      - "scripts/__tests__/validate-package-exports-types.test.ts"
+      - ".github/workflows/validate_package-exports.yml"
+  pull_request:
+    paths:
+      - "packages/*/package.json"
+      - "packages/*/tsdown.config.ts"
+      - "scripts/tsdown-exports.ts"
+      - "scripts/validate-package-exports-types.ts"
+      - "scripts/__tests__/validate-package-exports-types.test.ts"
+      - ".github/workflows/validate_package-exports.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Unit tests for the checker + a regression assertion over every real
+      # publishable package's exports map.
+      - name: Run exports-types validation tests
+        run: pnpm exec vitest run scripts/__tests__/validate-package-exports-types.test.ts
+
+      # Standalone gate with a human-readable report of any offending package.
+      - name: Validate package exports declare types conditions
+        run: pnpm validate:exports

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "attw": "nx run-many -t attw --projects=packages/**",
     "check:packages": "nx run-many -t publint,attw --projects=packages/**",
     "validate:model-names": "tsx scripts/validate-doc-model-names.ts",
+    "validate:exports": "tsx scripts/validate-package-exports-types.ts",
     "check:plugin-skills": "tsx scripts/sync-plugin-skills.ts --check",
     "sync:plugin-skills": "tsx scripts/sync-plugin-skills.ts",
     "parity:sync": "tsx examples/integrations/_parity/sync.ts",

--- a/packages/agentcore-runner/package.json
+++ b/packages/agentcore-runner/package.json
@@ -12,8 +12,14 @@
   "types": "./dist/index.d.cts",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/agentcore-runner/tsdown.config.ts
+++ b/packages/agentcore-runner/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsdown";
+import { withTypesConditions } from "../../scripts/tsdown-exports";
 
 export default defineConfig({
   entry: ["src/index.ts"],
@@ -8,5 +9,5 @@ export default defineConfig({
   target: "es2022",
   outDir: "dist",
   unbundle: true,
-  exports: true,
+  exports: { customExports: withTypesConditions },
 });

--- a/packages/agentcore-runner/tsdown.config.ts
+++ b/packages/agentcore-runner/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "tsdown";
-import { withTypesConditions } from "../../scripts/tsdown-exports";
+import { withTypesConditions } from "../../scripts/tsdown-exports.mjs";
 
 export default defineConfig({
   entry: ["src/index.ts"],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,8 +14,14 @@
   "jsdelivr": "./dist/index.umd.js",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "tsdown";
-import { withTypesConditions } from "../../scripts/tsdown-exports";
+import { withTypesConditions } from "../../scripts/tsdown-exports.mjs";
 
 export default defineConfig([
   {

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsdown";
+import { withTypesConditions } from "../../scripts/tsdown-exports";
 
 export default defineConfig([
   {
@@ -10,7 +11,7 @@ export default defineConfig([
     outDir: "dist",
     external: ["rxjs"],
     checks: { pluginTimings: false },
-    exports: true,
+    exports: { customExports: withTypesConditions },
   },
   {
     entry: ["src/index.ts"],

--- a/packages/demo-agents/package.json
+++ b/packages/demo-agents/package.json
@@ -11,8 +11,14 @@
   "types": "./dist/index.d.cts",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/demo-agents/tsdown.config.ts
+++ b/packages/demo-agents/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsdown";
+import { withTypesConditions } from "../../scripts/tsdown-exports";
 
 export default defineConfig({
   entry: ["src/index.ts"],
@@ -8,5 +9,5 @@ export default defineConfig({
   target: "es2022",
   outDir: "dist",
   unbundle: true,
-  exports: true,
+  exports: { customExports: withTypesConditions },
 });

--- a/packages/demo-agents/tsdown.config.ts
+++ b/packages/demo-agents/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "tsdown";
-import { withTypesConditions } from "../../scripts/tsdown-exports";
+import { withTypesConditions } from "../../scripts/tsdown-exports.mjs";
 
 export default defineConfig({
   entry: ["src/index.ts"],

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -36,21 +36,45 @@
   "jsdelivr": "./dist/index.umd.js",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./v2": {
-      "import": "./dist/v2/index.mjs",
-      "require": "./dist/v2/index.cjs"
+      "import": {
+        "types": "./dist/v2/index.d.mts",
+        "default": "./dist/v2/index.mjs"
+      },
+      "require": {
+        "types": "./dist/v2/index.d.cts",
+        "default": "./dist/v2/index.cjs"
+      }
     },
     "./package.json": "./package.json",
     "./v2/context": {
-      "import": "./dist/v2/context.mjs",
-      "require": "./dist/v2/context.cjs"
+      "import": {
+        "types": "./dist/v2/context.d.mts",
+        "default": "./dist/v2/context.mjs"
+      },
+      "require": {
+        "types": "./dist/v2/context.d.cts",
+        "default": "./dist/v2/context.cjs"
+      }
     },
     "./v2/headless": {
-      "import": "./dist/v2/headless.mjs",
-      "require": "./dist/v2/headless.cjs"
+      "import": {
+        "types": "./dist/v2/headless.d.mts",
+        "default": "./dist/v2/headless.mjs"
+      },
+      "require": {
+        "types": "./dist/v2/headless.d.cts",
+        "default": "./dist/v2/headless.cjs"
+      }
     },
     "./v2/styles.css": "./dist/v2/index.css"
   },

--- a/packages/react-core/tsdown.config.ts
+++ b/packages/react-core/tsdown.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "tsdown";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { withTypesConditions } from "../../scripts/tsdown-exports";
 
 // Resolved path to src/v2/context.ts — used to redirect the headless build's
 // relative ../context imports to the external @copilotkit/react-core/v2/context
@@ -73,18 +74,22 @@ export default defineConfig([
       /\.css$/,
     ],
     exports: {
-      customExports: (exports) => ({
-        ...exports,
-        "./v2/context": {
-          import: "./dist/v2/context.mjs",
-          require: "./dist/v2/context.cjs",
-        },
-        "./v2/headless": {
-          import: "./dist/v2/headless.mjs",
-          require: "./dist/v2/headless.cjs",
-        },
-        "./v2/styles.css": "./dist/v2/index.css",
-      }),
+      customExports: (exports, ctx) =>
+        withTypesConditions(
+          {
+            ...exports,
+            "./v2/context": {
+              import: "./dist/v2/context.mjs",
+              require: "./dist/v2/context.cjs",
+            },
+            "./v2/headless": {
+              import: "./dist/v2/headless.mjs",
+              require: "./dist/v2/headless.cjs",
+            },
+            "./v2/styles.css": "./dist/v2/index.css",
+          },
+          ctx,
+        ),
     },
   },
   // v2/context is built separately into dist/v2/ so it produces a standalone

--- a/packages/react-core/tsdown.config.ts
+++ b/packages/react-core/tsdown.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "tsdown";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
-import { withTypesConditions } from "../../scripts/tsdown-exports";
+import { withTypesConditions } from "../../scripts/tsdown-exports.mjs";
 
 // Resolved path to src/v2/context.ts — used to redirect the headless build's
 // relative ../context imports to the external @copilotkit/react-core/v2/context

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -27,36 +27,84 @@
   "types": "./dist/index.d.cts",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./polyfills": {
-      "import": "./dist/polyfills.mjs",
-      "require": "./dist/polyfills.cjs"
+      "import": {
+        "types": "./dist/polyfills.d.mts",
+        "default": "./dist/polyfills.mjs"
+      },
+      "require": {
+        "types": "./dist/polyfills.d.cts",
+        "default": "./dist/polyfills.cjs"
+      }
     },
     "./polyfills/streams": {
-      "import": "./dist/polyfills/streams.mjs",
-      "require": "./dist/polyfills/streams.cjs"
+      "import": {
+        "types": "./dist/polyfills/streams.d.mts",
+        "default": "./dist/polyfills/streams.mjs"
+      },
+      "require": {
+        "types": "./dist/polyfills/streams.d.cts",
+        "default": "./dist/polyfills/streams.cjs"
+      }
     },
     "./polyfills/encoding": {
-      "import": "./dist/polyfills/encoding.mjs",
-      "require": "./dist/polyfills/encoding.cjs"
+      "import": {
+        "types": "./dist/polyfills/encoding.d.mts",
+        "default": "./dist/polyfills/encoding.mjs"
+      },
+      "require": {
+        "types": "./dist/polyfills/encoding.d.cts",
+        "default": "./dist/polyfills/encoding.cjs"
+      }
     },
     "./polyfills/crypto": {
-      "import": "./dist/polyfills/crypto.mjs",
-      "require": "./dist/polyfills/crypto.cjs"
+      "import": {
+        "types": "./dist/polyfills/crypto.d.mts",
+        "default": "./dist/polyfills/crypto.mjs"
+      },
+      "require": {
+        "types": "./dist/polyfills/crypto.d.cts",
+        "default": "./dist/polyfills/crypto.cjs"
+      }
     },
     "./polyfills/dom": {
-      "import": "./dist/polyfills/dom.mjs",
-      "require": "./dist/polyfills/dom.cjs"
+      "import": {
+        "types": "./dist/polyfills/dom.d.mts",
+        "default": "./dist/polyfills/dom.mjs"
+      },
+      "require": {
+        "types": "./dist/polyfills/dom.d.cts",
+        "default": "./dist/polyfills/dom.cjs"
+      }
     },
     "./polyfills/location": {
-      "import": "./dist/polyfills/location.mjs",
-      "require": "./dist/polyfills/location.cjs"
+      "import": {
+        "types": "./dist/polyfills/location.d.mts",
+        "default": "./dist/polyfills/location.mjs"
+      },
+      "require": {
+        "types": "./dist/polyfills/location.d.cts",
+        "default": "./dist/polyfills/location.cjs"
+      }
     },
     "./components": {
-      "import": "./dist/components/index.mjs",
-      "require": "./dist/components/index.cjs"
+      "import": {
+        "types": "./dist/components/index.d.mts",
+        "default": "./dist/components/index.mjs"
+      },
+      "require": {
+        "types": "./dist/components/index.d.cts",
+        "default": "./dist/components/index.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/react-native/tsdown.config.ts
+++ b/packages/react-native/tsdown.config.ts
@@ -1,5 +1,11 @@
 import { defineConfig } from "tsdown";
 
+// NOTE: unlike the other tsdown-built packages, this config sets no `exports`
+// option, so tsdown does NOT generate/overwrite package.json `exports` — the
+// map (including the per-entry `types` conditions required by issue #3324) is
+// hand-maintained in package.json. The `pnpm validate:exports` CI gate guards
+// it against a missing `types` condition. If entry points change here, update
+// the `exports` map in package.json by hand to match.
 export default defineConfig({
   entry: [
     "src/index.ts",

--- a/packages/react-native/tsdown.config.ts
+++ b/packages/react-native/tsdown.config.ts
@@ -29,7 +29,6 @@ export default defineConfig({
     "@copilotkit/react-core",
     "@copilotkit/core",
     "@copilotkit/shared",
-    "@ag-ui/client",
     "@gorhom/bottom-sheet",
     "react-native-streamdown",
     "react-native-gesture-handler",

--- a/packages/react-textarea/package.json
+++ b/packages/react-textarea/package.json
@@ -31,8 +31,14 @@
   "jsdelivr": "./dist/index.umd.js",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./package.json": "./package.json",
     "./styles.css": "./dist/index.css"

--- a/packages/react-textarea/tsdown.config.ts
+++ b/packages/react-textarea/tsdown.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig } from "tsdown";
 import fs from "fs";
 import path from "path";
+import { withTypesConditions } from "../../scripts/tsdown-exports";
 
 // Side-effect CSS imports are kept in the JS output so styles auto-load for
 // bundler consumers, but rolldown-plugin-dts also leaves them in the emitted
@@ -38,10 +39,14 @@ export default defineConfig([
     },
     external: ["react", "react-dom"],
     exports: {
-      customExports: (exports) => ({
-        ...exports,
-        "./styles.css": "./dist/index.css",
-      }),
+      customExports: (exports, ctx) =>
+        withTypesConditions(
+          {
+            ...exports,
+            "./styles.css": "./dist/index.css",
+          },
+          ctx,
+        ),
     },
   },
   {

--- a/packages/react-textarea/tsdown.config.ts
+++ b/packages/react-textarea/tsdown.config.ts
@@ -2,7 +2,7 @@
 import { defineConfig } from "tsdown";
 import fs from "fs";
 import path from "path";
-import { withTypesConditions } from "../../scripts/tsdown-exports";
+import { withTypesConditions } from "../../scripts/tsdown-exports.mjs";
 
 // Side-effect CSS imports are kept in the JS output so styles auto-load for
 // bundler consumers, but rolldown-plugin-dts also leaves them in the emitted

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -31,8 +31,14 @@
   "jsdelivr": "./dist/index.umd.js",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./package.json": "./package.json",
     "./styles.css": "./dist/index.css",

--- a/packages/react-ui/tsdown.config.ts
+++ b/packages/react-ui/tsdown.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig } from "tsdown";
 import fs from "fs";
 import path from "path";
+import { withTypesConditions } from "../../scripts/tsdown-exports";
 
 // Side-effect CSS imports are kept in the JS output so styles auto-load for
 // bundler consumers, but rolldown-plugin-dts also leaves them in the emitted
@@ -43,11 +44,15 @@ export default defineConfig([
       "@copilotkit/react-core/v2",
     ],
     exports: {
-      customExports: (exports) => ({
-        ...exports,
-        "./styles.css": "./dist/index.css",
-        "./v2/styles.css": "./dist/v2/index.css",
-      }),
+      customExports: (exports, ctx) =>
+        withTypesConditions(
+          {
+            ...exports,
+            "./styles.css": "./dist/index.css",
+            "./v2/styles.css": "./dist/v2/index.css",
+          },
+          ctx,
+        ),
     },
   },
   {

--- a/packages/react-ui/tsdown.config.ts
+++ b/packages/react-ui/tsdown.config.ts
@@ -2,7 +2,7 @@
 import { defineConfig } from "tsdown";
 import fs from "fs";
 import path from "path";
-import { withTypesConditions } from "../../scripts/tsdown-exports";
+import { withTypesConditions } from "../../scripts/tsdown-exports.mjs";
 
 // Side-effect CSS imports are kept in the JS output so styles auto-load for
 // bundler consumers, but rolldown-plugin-dts also leaves them in the emitted

--- a/packages/runtime-client-gql/package.json
+++ b/packages/runtime-client-gql/package.json
@@ -28,8 +28,14 @@
   "jsdelivr": "./dist/index.umd.js",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/runtime-client-gql/tsdown.config.ts
+++ b/packages/runtime-client-gql/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsdown";
+import { withTypesConditions } from "../../scripts/tsdown-exports";
 
 export default defineConfig([
   {
@@ -10,7 +11,7 @@ export default defineConfig([
     outDir: "dist",
     unbundle: true,
     external: ["react", "@graphql-typed-document-node/core"],
-    exports: true,
+    exports: { customExports: withTypesConditions },
   },
   {
     entry: ["src/index.ts"],

--- a/packages/runtime-client-gql/tsdown.config.ts
+++ b/packages/runtime-client-gql/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "tsdown";
-import { withTypesConditions } from "../../scripts/tsdown-exports";
+import { withTypesConditions } from "../../scripts/tsdown-exports.mjs";
 
 export default defineConfig([
   {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -36,28 +36,64 @@
   "types": "./dist/index.d.cts",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./langgraph": {
-      "import": "./dist/langgraph.mjs",
-      "require": "./dist/langgraph.cjs"
+      "import": {
+        "types": "./dist/langgraph.d.mts",
+        "default": "./dist/langgraph.mjs"
+      },
+      "require": {
+        "types": "./dist/langgraph.d.cts",
+        "default": "./dist/langgraph.cjs"
+      }
     },
     "./v2": {
-      "import": "./dist/v2/index.mjs",
-      "require": "./dist/v2/index.cjs"
+      "import": {
+        "types": "./dist/v2/index.d.mts",
+        "default": "./dist/v2/index.mjs"
+      },
+      "require": {
+        "types": "./dist/v2/index.d.cts",
+        "default": "./dist/v2/index.cjs"
+      }
     },
     "./v2/express": {
-      "import": "./dist/v2/express.mjs",
-      "require": "./dist/v2/express.cjs"
+      "import": {
+        "types": "./dist/v2/express.d.mts",
+        "default": "./dist/v2/express.mjs"
+      },
+      "require": {
+        "types": "./dist/v2/express.d.cts",
+        "default": "./dist/v2/express.cjs"
+      }
     },
     "./v2/hono": {
-      "import": "./dist/v2/hono.mjs",
-      "require": "./dist/v2/hono.cjs"
+      "import": {
+        "types": "./dist/v2/hono.d.mts",
+        "default": "./dist/v2/hono.mjs"
+      },
+      "require": {
+        "types": "./dist/v2/hono.d.cts",
+        "default": "./dist/v2/hono.cjs"
+      }
     },
     "./v2/node": {
-      "import": "./dist/v2/node.mjs",
-      "require": "./dist/v2/node.cjs"
+      "import": {
+        "types": "./dist/v2/node.d.mts",
+        "default": "./dist/v2/node.mjs"
+      },
+      "require": {
+        "types": "./dist/v2/node.d.cts",
+        "default": "./dist/v2/node.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/runtime/tsdown.config.ts
+++ b/packages/runtime/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "tsdown";
-import { withTypesConditions } from "../../scripts/tsdown-exports";
+import { withTypesConditions } from "../../scripts/tsdown-exports.mjs";
 
 export default defineConfig({
   entry: [

--- a/packages/runtime/tsdown.config.ts
+++ b/packages/runtime/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsdown";
+import { withTypesConditions } from "../../scripts/tsdown-exports";
 
 export default defineConfig({
   entry: [
@@ -41,5 +42,5 @@ export default defineConfig({
     "@whatwg-node/server",
     "rxjs",
   ],
-  exports: true,
+  exports: { customExports: withTypesConditions },
 });

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -27,20 +27,44 @@
   "types": "./dist/index.d.cts",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./langchain": {
-      "import": "./dist/langchain.mjs",
-      "require": "./dist/langchain.cjs"
+      "import": {
+        "types": "./dist/langchain.d.mts",
+        "default": "./dist/langchain.mjs"
+      },
+      "require": {
+        "types": "./dist/langchain.d.cts",
+        "default": "./dist/langchain.cjs"
+      }
     },
     "./langgraph": {
-      "import": "./dist/langgraph.mjs",
-      "require": "./dist/langgraph.cjs"
+      "import": {
+        "types": "./dist/langgraph.d.mts",
+        "default": "./dist/langgraph.mjs"
+      },
+      "require": {
+        "types": "./dist/langgraph.d.cts",
+        "default": "./dist/langgraph.cjs"
+      }
     },
     "./langgraph-middlewares": {
-      "import": "./dist/langgraph-middlewares.mjs",
-      "require": "./dist/langgraph-middlewares.cjs"
+      "import": {
+        "types": "./dist/langgraph-middlewares.d.mts",
+        "default": "./dist/langgraph-middlewares.mjs"
+      },
+      "require": {
+        "types": "./dist/langgraph-middlewares.d.cts",
+        "default": "./dist/langgraph-middlewares.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/sdk-js/tsdown.config.ts
+++ b/packages/sdk-js/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "tsdown";
-import { withTypesConditions } from "../../scripts/tsdown-exports";
+import { withTypesConditions } from "../../scripts/tsdown-exports.mjs";
 
 export default defineConfig({
   entry: {

--- a/packages/sdk-js/tsdown.config.ts
+++ b/packages/sdk-js/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsdown";
+import { withTypesConditions } from "../../scripts/tsdown-exports";
 
 export default defineConfig({
   entry: {
@@ -14,5 +15,5 @@ export default defineConfig({
   outDir: "dist",
   unbundle: true,
   exclude: ["**/*.test.ts", "**/*.test.tsx", "**/__tests__/*"],
-  exports: true,
+  exports: { customExports: withTypesConditions },
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -29,8 +29,14 @@
   "jsdelivr": "./dist/index.umd.js",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/shared/tsdown.config.ts
+++ b/packages/shared/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsdown";
+import { withTypesConditions } from "../../scripts/tsdown-exports";
 
 export default defineConfig([
   {
@@ -9,7 +10,7 @@ export default defineConfig([
     target: "es2022",
     outDir: "dist",
     unbundle: true,
-    exports: true,
+    exports: { customExports: withTypesConditions },
   },
   {
     entry: ["src/index.ts"],

--- a/packages/shared/tsdown.config.ts
+++ b/packages/shared/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "tsdown";
-import { withTypesConditions } from "../../scripts/tsdown-exports";
+import { withTypesConditions } from "../../scripts/tsdown-exports.mjs";
 
 export default defineConfig([
   {

--- a/packages/sqlite-runner/package.json
+++ b/packages/sqlite-runner/package.json
@@ -12,8 +12,14 @@
   "types": "./dist/index.d.cts",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/sqlite-runner/tsdown.config.ts
+++ b/packages/sqlite-runner/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsdown";
+import { withTypesConditions } from "../../scripts/tsdown-exports";
 
 export default defineConfig({
   entry: ["src/index.ts"],
@@ -8,5 +9,5 @@ export default defineConfig({
   target: "es2022",
   outDir: "dist",
   unbundle: true,
-  exports: true,
+  exports: { customExports: withTypesConditions },
 });

--- a/packages/sqlite-runner/tsdown.config.ts
+++ b/packages/sqlite-runner/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "tsdown";
-import { withTypesConditions } from "../../scripts/tsdown-exports";
+import { withTypesConditions } from "../../scripts/tsdown-exports.mjs";
 
 export default defineConfig({
   entry: ["src/index.ts"],

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -14,8 +14,14 @@
   "jsdelivr": "./dist/index.umd.js",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/voice/tsdown.config.ts
+++ b/packages/voice/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsdown";
+import { withTypesConditions } from "../../scripts/tsdown-exports";
 
 const isWatch = process.argv.includes("--watch");
 
@@ -12,7 +13,7 @@ export default defineConfig([
     target: "es2022",
     outDir: "dist",
     unbundle: true,
-    exports: true,
+    exports: { customExports: withTypesConditions },
   },
   {
     entry: ["src/index.ts"],

--- a/packages/voice/tsdown.config.ts
+++ b/packages/voice/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "tsdown";
-import { withTypesConditions } from "../../scripts/tsdown-exports";
+import { withTypesConditions } from "../../scripts/tsdown-exports.mjs";
 
 const isWatch = process.argv.includes("--watch");
 

--- a/packages/web-inspector/package.json
+++ b/packages/web-inspector/package.json
@@ -14,8 +14,14 @@
   "jsdelivr": "./dist/index.umd.js",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/web-inspector/tsdown.config.ts
+++ b/packages/web-inspector/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "tsdown";
-import { withTypesConditions } from "../../scripts/tsdown-exports";
+import { withTypesConditions } from "../../scripts/tsdown-exports.mjs";
 
 export default defineConfig([
   {

--- a/packages/web-inspector/tsdown.config.ts
+++ b/packages/web-inspector/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsdown";
+import { withTypesConditions } from "../../scripts/tsdown-exports";
 
 export default defineConfig([
   {
@@ -13,7 +14,7 @@ export default defineConfig([
       ".css": "text",
       ".svg": "dataurl",
     },
-    exports: true,
+    exports: { customExports: withTypesConditions },
   },
   {
     entry: ["src/index.ts"],

--- a/scripts/__tests__/tsdown-exports.test.ts
+++ b/scripts/__tests__/tsdown-exports.test.ts
@@ -56,6 +56,31 @@ describe("withTypesConditions", () => {
     });
   });
 
+  it("normalizes a hand-authored types-last entry (idempotency keys on first key)", () => {
+    withPackage(["dist/index.d.mts", "dist/index.d.cts"], (ctx) => {
+      const result = withTypesConditions(
+        {
+          ".": {
+            import: "./dist/index.mjs",
+            require: "./dist/index.cjs",
+            types: "./dist/index.d.cts",
+          },
+        },
+        ctx,
+      );
+      // A leading `types` means "already processed" and is skipped, but a
+      // trailing `types` must NOT short-circuit — import/require still get
+      // nested types conditions (leaving the shadowed top-level `types` as-is).
+      expect(result).toEqual({
+        ".": {
+          import: { types: "./dist/index.d.mts", default: "./dist/index.mjs" },
+          require: { types: "./dist/index.d.cts", default: "./dist/index.cjs" },
+          types: "./dist/index.d.cts",
+        },
+      });
+    });
+  });
+
   it("leaves targets without a sibling declaration untouched", () => {
     withPackage([], (ctx) => {
       const input = {

--- a/scripts/__tests__/tsdown-exports.test.ts
+++ b/scripts/__tests__/tsdown-exports.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { withTypesConditions } from "../tsdown-exports.mjs";
+import { findExportsTypeViolations } from "../validate-package-exports-types";
 
 // Build a temp package dir whose dist/ contains the given declaration files
 // and hand the callback the `ctx` tsdown's `customExports` hook would pass.
@@ -21,6 +22,19 @@ function withPackage(
     run({ pkg: { packageJsonPath: path.join(root, "package.json") } });
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+// Capture `console.warn` output for the duration of `run`, then restore it.
+function withWarnSpy(run: (warnings: string[]) => void): void {
+  const warnings: string[] = [];
+  const spy = vi
+    .spyOn(console, "warn")
+    .mockImplementation((message) => warnings.push(String(message)));
+  try {
+    run(warnings);
+  } finally {
+    spy.mockRestore();
   }
 }
 
@@ -81,15 +95,76 @@ describe("withTypesConditions", () => {
     });
   });
 
-  it("leaves targets without a sibling declaration untouched", () => {
-    withPackage([], (ctx) => {
-      const input = {
-        ".": { import: "./dist/index.mjs" },
-        "./styles.css": "./dist/index.css",
-        "./package.json": "./package.json",
-      };
-      expect(withTypesConditions(input, ctx)).toEqual(input);
+  it("leaves non-JS targets (css, package.json) untouched, silently", () => {
+    withWarnSpy((warnings) => {
+      withPackage([], (ctx) => {
+        const input = {
+          "./styles.css": "./dist/index.css",
+          "./package.json": "./package.json",
+        };
+        expect(withTypesConditions(input, ctx)).toEqual(input);
+      });
+      expect(warnings).toEqual([]);
     });
+  });
+
+  it("warns and leaves a JS target with no adjacent declaration untouched", () => {
+    withWarnSpy((warnings) => {
+      withPackage([], (ctx) => {
+        const input = { ".": { import: "./dist/index.mjs" } };
+        expect(withTypesConditions(input, ctx)).toEqual(input);
+      });
+      expect(
+        warnings.some((w) => w.includes("has no adjacent declaration")),
+      ).toBe(true);
+    });
+  });
+
+  it("normalizes a types-first PARTIAL object so the uncovered mode gets typed", () => {
+    // `types` (import-only) covers import; require has no types, so the helper
+    // must still add one to the bare `require` rather than skipping the entry.
+    withPackage(["dist/index.d.mts", "dist/index.d.cts"], (ctx) => {
+      const result = withTypesConditions(
+        {
+          ".": {
+            types: { import: "./dist/index.d.mts" },
+            require: "./dist/index.cjs",
+          },
+        },
+        ctx,
+      );
+      expect(result).toEqual({
+        ".": {
+          types: { import: "./dist/index.d.mts" },
+          require: { types: "./dist/index.d.cts", default: "./dist/index.cjs" },
+        },
+      });
+    });
+  });
+
+  it("produces output the validator accepts (round-trip)", () => {
+    withPackage(
+      [
+        "dist/index.d.mts",
+        "dist/index.d.cts",
+        "dist/v2/index.d.mts",
+        "dist/v2/index.d.cts",
+      ],
+      (ctx) => {
+        const result = withTypesConditions(
+          {
+            ".": { import: "./dist/index.mjs", require: "./dist/index.cjs" },
+            "./v2": {
+              import: "./dist/v2/index.mjs",
+              require: "./dist/v2/index.cjs",
+            },
+            "./package.json": "./package.json",
+          },
+          ctx,
+        );
+        expect(findExportsTypeViolations("pkg", result)).toEqual([]);
+      },
+    );
   });
 
   it("preserves a null target (blocked subpath) without crashing", () => {

--- a/scripts/__tests__/tsdown-exports.test.ts
+++ b/scripts/__tests__/tsdown-exports.test.ts
@@ -177,20 +177,26 @@ describe("withTypesConditions", () => {
 
   it("maps over fallback-array targets instead of corrupting them", () => {
     withPackage(["dist/a.d.mts"], (ctx) => {
-      const result = withTypesConditions(
-        { ".": { import: ["./dist/a.mjs", "./dist/b.mjs"] } },
-        ctx,
-      );
-      expect(result).toEqual({
-        ".": {
-          import: [
-            { types: "./dist/a.d.mts", default: "./dist/a.mjs" },
-            "./dist/b.mjs",
-          ],
-        },
+      withWarnSpy((warnings) => {
+        const result = withTypesConditions(
+          { ".": { import: ["./dist/a.mjs", "./dist/b.mjs"] } },
+          ctx,
+        );
+        // a.mjs has a sibling declaration → typed entry; b.mjs has none → left
+        // untouched (and warned about, asserted below — not silently dropped).
+        expect(result).toEqual({
+          ".": {
+            import: [
+              { types: "./dist/a.d.mts", default: "./dist/a.mjs" },
+              "./dist/b.mjs",
+            ],
+          },
+        });
+        // The typed array element must also keep `types` first.
+        expect(JSON.stringify(result)).toContain('[{"types":');
+        // The declaration-less element is reported loudly, not swallowed.
+        expect(warnings.some((w) => w.includes("b.mjs"))).toBe(true);
       });
-      // The typed array element must also keep `types` first.
-      expect(JSON.stringify(result)).toContain('[{"types":');
     });
   });
 

--- a/scripts/__tests__/tsdown-exports.test.ts
+++ b/scripts/__tests__/tsdown-exports.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { withTypesConditions } from "../tsdown-exports.mjs";
+
+// Build a temp package dir whose dist/ contains the given declaration files
+// and hand the callback the `ctx` tsdown's `customExports` hook would pass.
+function withPackage(
+  declarations: string[],
+  run: (ctx: { pkg: { packageJsonPath: string } }) => void,
+): void {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "cpk-tsdown-"));
+  try {
+    fs.writeFileSync(path.join(root, "package.json"), "{}", "utf-8");
+    for (const rel of declarations) {
+      const abs = path.join(root, rel);
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, "export {};", "utf-8");
+    }
+    run({ pkg: { packageJsonPath: path.join(root, "package.json") } });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe("withTypesConditions", () => {
+  it("nests a types condition first for each import/require with a sibling declaration", () => {
+    withPackage(["dist/index.d.mts", "dist/index.d.cts"], (ctx) => {
+      const result = withTypesConditions(
+        { ".": { import: "./dist/index.mjs", require: "./dist/index.cjs" } },
+        ctx,
+      );
+      expect(result).toEqual({
+        ".": {
+          import: { types: "./dist/index.d.mts", default: "./dist/index.mjs" },
+          require: { types: "./dist/index.d.cts", default: "./dist/index.cjs" },
+        },
+      });
+    });
+  });
+
+  it("leaves targets without a sibling declaration untouched", () => {
+    withPackage([], (ctx) => {
+      const input = {
+        ".": { import: "./dist/index.mjs" },
+        "./styles.css": "./dist/index.css",
+        "./package.json": "./package.json",
+      };
+      expect(withTypesConditions(input, ctx)).toEqual(input);
+    });
+  });
+
+  it("preserves a null target (blocked subpath) without crashing", () => {
+    withPackage([], (ctx) => {
+      expect(withTypesConditions({ "./internal": null }, ctx)).toEqual({
+        "./internal": null,
+      });
+    });
+  });
+
+  it("maps over fallback-array targets instead of corrupting them", () => {
+    withPackage(["dist/a.d.mts"], (ctx) => {
+      const result = withTypesConditions(
+        { ".": { import: ["./dist/a.mjs", "./dist/b.mjs"] } },
+        ctx,
+      );
+      expect(result).toEqual({
+        ".": {
+          import: [
+            { types: "./dist/a.d.mts", default: "./dist/a.mjs" },
+            "./dist/b.mjs",
+          ],
+        },
+      });
+    });
+  });
+
+  it("throws when packageJsonPath is missing rather than silently dropping types", () => {
+    expect(() =>
+      withTypesConditions({ ".": { import: "./dist/index.mjs" } }, { pkg: {} }),
+    ).toThrow(/packageJsonPath/);
+  });
+});

--- a/scripts/__tests__/tsdown-exports.test.ts
+++ b/scripts/__tests__/tsdown-exports.test.ts
@@ -37,6 +37,22 @@ describe("withTypesConditions", () => {
           require: { types: "./dist/index.d.cts", default: "./dist/index.cjs" },
         },
       });
+      // `types` must be emitted FIRST — that is the whole point (attw flags a
+      // types-last condition). toEqual is key-order-insensitive, so assert
+      // order via serialization, which preserves insertion order.
+      const json = JSON.stringify(result);
+      expect(json).toContain('"import":{"types":');
+      expect(json).toContain('"require":{"types":');
+    });
+  });
+
+  it("is idempotent — re-applying does not re-nest the default target", () => {
+    withPackage(["dist/index.d.mts", "dist/index.d.cts"], (ctx) => {
+      const once = withTypesConditions(
+        { ".": { import: "./dist/index.mjs", require: "./dist/index.cjs" } },
+        ctx,
+      );
+      expect(withTypesConditions(once, ctx)).toEqual(once);
     });
   });
 
@@ -73,6 +89,8 @@ describe("withTypesConditions", () => {
           ],
         },
       });
+      // The typed array element must also keep `types` first.
+      expect(JSON.stringify(result)).toContain('[{"types":');
     });
   });
 

--- a/scripts/__tests__/validate-package-exports-types.test.ts
+++ b/scripts/__tests__/validate-package-exports-types.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import {
+  findExportsTypeViolations,
+  getPublishablePackagesWithExports,
+  validateAllPackages,
+} from "../validate-package-exports-types";
+
+// Slim wrapper so each case is one readable line (package name is irrelevant
+// to the checker logic).
+const check = (exportsMap: unknown) =>
+  findExportsTypeViolations("pkg", exportsMap);
+
+describe("findExportsTypeViolations", () => {
+  it("flags a JS export with no types condition (the #3324 bug shape)", () => {
+    const violations = check({
+      ".": { import: "./dist/index.mjs", require: "./dist/index.cjs" },
+    });
+    expect(violations.map((v) => v.subpath)).toEqual([
+      ". > import",
+      ". > require",
+    ]);
+  });
+
+  it("accepts nested per-condition types (the fix shape)", () => {
+    expect(
+      check({
+        ".": {
+          import: { types: "./dist/index.d.mts", default: "./dist/index.mjs" },
+          require: { types: "./dist/index.d.cts", default: "./dist/index.cjs" },
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("accepts a flat top-level types condition", () => {
+    expect(
+      check({
+        ".": {
+          types: "./dist/index.d.cts",
+          import: "./dist/index.mjs",
+          require: "./dist/index.cjs",
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("ignores non-JS string targets (css, package.json)", () => {
+    expect(
+      check({
+        "./styles.css": "./dist/index.css",
+        "./package.json": "./package.json",
+      }),
+    ).toEqual([]);
+  });
+
+  it("flags a types condition that is not a declaration file", () => {
+    const violations = check({
+      ".": { types: "./dist/index.js", default: "./dist/index.mjs" },
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0].reason).toMatch(/not a declaration file/);
+  });
+
+  it("flags a single-format bare default JS target", () => {
+    expect(check({ ".": { default: "./dist/index.mjs" } })).toHaveLength(1);
+  });
+
+  it("flags only the offending subpath when a sibling is correct", () => {
+    const violations = check({
+      ".": {
+        import: { types: "./dist/index.d.mts", default: "./dist/index.mjs" },
+        require: { types: "./dist/index.d.cts", default: "./dist/index.cjs" },
+      },
+      "./v2": { import: "./dist/v2/index.mjs", require: "./dist/v2/index.cjs" },
+    });
+    expect(violations).toHaveLength(2);
+    expect(violations.every((v) => v.subpath.startsWith("./v2"))).toBe(true);
+  });
+
+  it("returns nothing for packages without an exports map", () => {
+    expect(check(undefined)).toEqual([]);
+  });
+});
+
+describe("all publishable packages (regression guard for #3324)", () => {
+  it("discovers the publishable packages that declare exports", () => {
+    const names = getPublishablePackagesWithExports().map((p) => p.name);
+    // Sanity check the scanner actually found the workspace packages.
+    expect(names).toContain("@copilotkit/react-core");
+    expect(names.length).toBeGreaterThan(5);
+  });
+
+  it("declare a types condition for every JS export", () => {
+    const violations = validateAllPackages();
+    // Show the offending package + subpath in the failure message.
+    expect(
+      violations,
+      violations
+        .map((v) => `${v.package} ${v.subpath}: ${v.reason}`)
+        .join("\n"),
+    ).toEqual([]);
+  });
+});

--- a/scripts/__tests__/validate-package-exports-types.test.ts
+++ b/scripts/__tests__/validate-package-exports-types.test.ts
@@ -234,6 +234,22 @@ describe("findExportsTypeViolations", () => {
       }),
     ).toEqual([]);
   });
+
+  it("flags a partial node/default object that leaves a mode falling through to JS", () => {
+    // `node` is active in both modes but only has an `import` branch: import
+    // resolves `node`'s bare-JS leaf; require falls through to the untyped
+    // `default`. Both must be flagged (not just the first).
+    const violations = check({
+      ".": {
+        node: { import: "./dist/index.mjs" },
+        default: "./dist/fallback.js",
+      },
+    });
+    expect(violations.map((v) => v.subpath).sort()).toEqual([
+      ". > default",
+      ". > node > import",
+    ]);
+  });
 });
 
 describe("all publishable packages (regression guard for #3324)", () => {

--- a/scripts/__tests__/validate-package-exports-types.test.ts
+++ b/scripts/__tests__/validate-package-exports-types.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
   findExportsTypeViolations,
   getPublishablePackagesWithExports,
@@ -80,6 +83,95 @@ describe("findExportsTypeViolations", () => {
   it("returns nothing for packages without an exports map", () => {
     expect(check(undefined)).toEqual([]);
   });
+
+  it("flags a `types` condition listed after a JS condition (order matters)", () => {
+    // A strict resolver matches import/require before reaching a trailing
+    // `types`, landing on JS with no declarations — the #3324 failure.
+    const violations = check({
+      ".": {
+        import: "./dist/index.mjs",
+        require: "./dist/index.cjs",
+        types: "./dist/index.d.cts",
+      },
+    });
+    expect(violations.map((v) => v.subpath)).toEqual([
+      ". > import",
+      ". > require",
+    ]);
+  });
+
+  it("accepts `types` listed first ahead of JS conditions", () => {
+    expect(
+      check({
+        ".": {
+          types: "./dist/index.d.mts",
+          import: "./dist/index.mjs",
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("flags a bare-string `exports` value (sugar for '.')", () => {
+    const violations = check("./dist/index.mjs");
+    expect(violations).toHaveLength(1);
+    expect(violations[0].subpath).toBe(".");
+  });
+
+  it("flags conditions-only sugar with no `types`", () => {
+    // No `.`/`./…` keys → whole object is the `.` target's conditions.
+    const violations = check({
+      import: "./dist/index.mjs",
+      require: "./dist/index.cjs",
+    });
+    expect(violations.map((v) => v.subpath)).toEqual([
+      ". > import",
+      ". > require",
+    ]);
+  });
+
+  it("accepts conditions-only sugar with a leading `types`", () => {
+    expect(
+      check({
+        types: "./dist/index.d.ts",
+        import: "./dist/index.mjs",
+        require: "./dist/index.cjs",
+      }),
+    ).toEqual([]);
+  });
+
+  it("ignores runtime-only conditions TypeScript never resolves types through", () => {
+    // `browser` returns JS but TS ignores it for types, so a typed
+    // import/require sibling is sufficient — no false positive.
+    expect(
+      check({
+        ".": {
+          import: { types: "./dist/index.d.mts", default: "./dist/index.mjs" },
+          require: { types: "./dist/index.d.cts", default: "./dist/index.cjs" },
+          browser: "./dist/index.browser.mjs",
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("flags an object-valued `types` whose leaf is not a declaration", () => {
+    const violations = check({
+      ".": {
+        types: { import: "./dist/index.mjs" },
+        default: "./dist/index.mjs",
+      },
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0].subpath).toBe(". > types > import");
+  });
+
+  it("treats a `null` target (blocked subpath) as no violation", () => {
+    expect(check({ "./internal": null })).toEqual([]);
+  });
+
+  it("walks fallback-array targets", () => {
+    const violations = check({ ".": ["./dist/a.mjs", "./dist/b.mjs"] });
+    expect(violations.map((v) => v.subpath)).toEqual([".[0]", ".[1]"]);
+  });
 });
 
 describe("all publishable packages (regression guard for #3324)", () => {
@@ -99,5 +191,61 @@ describe("all publishable packages (regression guard for #3324)", () => {
         .map((v) => `${v.package} ${v.subpath}: ${v.reason}`)
         .join("\n"),
     ).toEqual([]);
+  });
+});
+
+describe("getPublishablePackagesWithExports (fixture-based discovery)", () => {
+  function writePackage(root: string, dir: string, pkg: object): void {
+    const pkgDir = path.join(root, dir);
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pkgDir, "package.json"),
+      JSON.stringify(pkg),
+      "utf-8",
+    );
+  }
+
+  function withFixtureRoot(run: (root: string) => void): void {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "cpk-exports-"));
+    try {
+      run(root);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+
+  it("includes only non-private packages that declare exports", () => {
+    withFixtureRoot((root) => {
+      writePackage(root, "published", {
+        name: "@x/published",
+        exports: { ".": "./index.mjs" },
+      });
+      writePackage(root, "private-pkg", {
+        name: "@x/private",
+        private: true,
+        exports: { ".": "./index.mjs" },
+      });
+      writePackage(root, "no-exports", { name: "@x/no-exports" });
+      // A directory without a package.json is skipped, not an error.
+      fs.mkdirSync(path.join(root, "not-a-package"), { recursive: true });
+
+      const names = getPublishablePackagesWithExports(root).map((p) => p.name);
+      expect(names).toEqual(["@x/published"]);
+    });
+  });
+
+  it("throws with the file path on a malformed package.json", () => {
+    withFixtureRoot((root) => {
+      const pkgDir = path.join(root, "broken");
+      fs.mkdirSync(pkgDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(pkgDir, "package.json"),
+        "{ not json",
+        "utf-8",
+      );
+      expect(() => getPublishablePackagesWithExports(root)).toThrow(
+        /broken[\\/]package\.json/,
+      );
+    });
   });
 });

--- a/scripts/__tests__/validate-package-exports-types.test.ts
+++ b/scripts/__tests__/validate-package-exports-types.test.ts
@@ -172,6 +172,20 @@ describe("findExportsTypeViolations", () => {
     const violations = check({ ".": ["./dist/a.mjs", "./dist/b.mjs"] });
     expect(violations.map((v) => v.subpath)).toEqual([".[0]", ".[1]"]);
   });
+
+  it("does not flag a trailing default/node shadowed by typed import + require", () => {
+    // import-mode resolves `import`, require-mode resolves `require`; the
+    // trailing `default` is never reached for types, so it must not be flagged.
+    expect(
+      check({
+        ".": {
+          import: { types: "./dist/index.d.mts", default: "./dist/index.mjs" },
+          require: { types: "./dist/index.d.cts", default: "./dist/index.cjs" },
+          default: "./dist/index.mjs",
+        },
+      }),
+    ).toEqual([]);
+  });
 });
 
 describe("all publishable packages (regression guard for #3324)", () => {

--- a/scripts/__tests__/validate-package-exports-types.test.ts
+++ b/scripts/__tests__/validate-package-exports-types.test.ts
@@ -140,8 +140,12 @@ describe("findExportsTypeViolations", () => {
   });
 
   it("ignores runtime-only conditions TypeScript never resolves types through", () => {
-    // `browser` returns JS but TS ignores it for types, so a typed
-    // import/require sibling is sufficient — no false positive.
+    // A bare `browser`-only JS target must NOT be flagged — TypeScript resolves
+    // no types through `browser`. This is the discriminating case: if
+    // `isActiveCondition` wrongly treated `browser` as active, `browser` would
+    // win and be flagged.
+    expect(check({ ".": { browser: "./dist/index.browser.mjs" } })).toEqual([]);
+    // ...and a runtime-only sibling alongside typed import/require is fine too.
     expect(
       check({
         ".": {
@@ -153,15 +157,53 @@ describe("findExportsTypeViolations", () => {
     ).toEqual([]);
   });
 
-  it("flags an object-valued `types` whose leaf is not a declaration", () => {
+  it("flags an object-valued `types` per resolution mode", () => {
+    // `types` covers only import (its leaf is JS, flagged); require falls
+    // through the partial `types` object to the untyped `default`.
     const violations = check({
       ".": {
         types: { import: "./dist/index.mjs" },
         default: "./dist/index.mjs",
       },
     });
-    expect(violations).toHaveLength(1);
-    expect(violations[0].subpath).toBe(". > types > import");
+    expect(violations.map((v) => v.subpath)).toEqual([
+      ". > types > import",
+      ". > default",
+    ]);
+  });
+
+  it("accepts a well-formed object-valued `types` covering both modes", () => {
+    expect(
+      check({
+        ".": {
+          types: {
+            import: "./dist/index.d.mts",
+            require: "./dist/index.d.cts",
+          },
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("flags a partial object `types` that leaves a mode falling through to JS", () => {
+    // import-only `types` → require falls through to the bare-JS `require`.
+    expect(
+      check({
+        ".": {
+          types: { import: "./dist/index.d.mts" },
+          require: "./dist/index.cjs",
+        },
+      }).map((v) => v.subpath),
+    ).toEqual([". > require"]);
+    // require-only `types` → import falls through to the bare-JS `import`.
+    expect(
+      check({
+        ".": {
+          types: { require: "./dist/index.d.cts" },
+          import: "./dist/index.mjs",
+        },
+      }).map((v) => v.subpath),
+    ).toEqual([". > import"]);
   });
 
   it("treats a `null` target (blocked subpath) as no violation", () => {
@@ -173,14 +215,20 @@ describe("findExportsTypeViolations", () => {
     expect(violations.map((v) => v.subpath)).toEqual([".[0]", ".[1]"]);
   });
 
-  it("does not flag a trailing default/node shadowed by typed import + require", () => {
+  it("flags a top-level fallback array (sugar for '.')", () => {
+    expect(check(["./dist/a.mjs"]).map((v) => v.subpath)).toEqual([".[0]"]);
+  });
+
+  it("does not flag trailing default/node shadowed by typed import + require", () => {
     // import-mode resolves `import`, require-mode resolves `require`; the
-    // trailing `default` is never reached for types, so it must not be flagged.
+    // trailing `default`/`node` are never reached for types, so neither is
+    // flagged.
     expect(
       check({
         ".": {
           import: { types: "./dist/index.d.mts", default: "./dist/index.mjs" },
           require: { types: "./dist/index.d.cts", default: "./dist/index.cjs" },
+          node: "./dist/index.mjs",
           default: "./dist/index.mjs",
         },
       }),

--- a/scripts/tsdown-exports.d.mts
+++ b/scripts/tsdown-exports.d.mts
@@ -9,9 +9,16 @@ export type ExportsEntry =
   | { [condition: string]: ExportsEntry };
 
 /**
- * Post-process tsdown's generated `exports` map so every `import`/`require`
- * target that points at emitted JavaScript gains a matching `types` condition.
- * See `tsdown-exports.mjs` and CopilotKit issue #3324.
+ * Post-process tsdown's generated `exports` map so every condition target
+ * (`import`/`require`/…) and bare-string target that points at emitted
+ * JavaScript gains a matching `types` condition. See `tsdown-exports.mjs` and
+ * CopilotKit issue #3324.
+ *
+ * `ctx.pkg` is intentionally `unknown` (the runtime reads `pkg.packageJsonPath`):
+ * tsdown's public `PackageJson` type omits `packageJsonPath`, and a
+ * `{ packageJsonPath?: string }` shape is an all-optional "weak type" that
+ * `PackageJson` cannot satisfy — so tightening it breaks `customExports`
+ * assignability (check-types) at the call sites. Do not narrow it.
  */
 export declare function withTypesConditions(
   exports: Record<string, ExportsEntry>,

--- a/scripts/tsdown-exports.d.mts
+++ b/scripts/tsdown-exports.d.mts
@@ -1,0 +1,12 @@
+/** A value in a package.json `exports` map: a target path or a nested conditions object. */
+export type ExportEntry = string | { [condition: string]: ExportEntry };
+
+/**
+ * Post-process tsdown's generated `exports` map so every `import`/`require`
+ * target that points at emitted JavaScript gains a matching `types` condition.
+ * See `tsdown-exports.mjs` and CopilotKit issue #3324.
+ */
+export declare function withTypesConditions(
+  exports: Record<string, ExportEntry>,
+  ctx: { pkg: unknown },
+): Record<string, ExportEntry>;

--- a/scripts/tsdown-exports.d.mts
+++ b/scripts/tsdown-exports.d.mts
@@ -1,5 +1,12 @@
-/** A value in a package.json `exports` map: a target path or a nested conditions object. */
-export type ExportEntry = string | { [condition: string]: ExportEntry };
+/**
+ * A value in a package.json `exports` map: a target path, `null` (blocks a
+ * subpath), a fallback array, or a nested conditions object.
+ */
+export type ExportsEntry =
+  | string
+  | null
+  | ExportsEntry[]
+  | { [condition: string]: ExportsEntry };
 
 /**
  * Post-process tsdown's generated `exports` map so every `import`/`require`
@@ -7,6 +14,6 @@ export type ExportEntry = string | { [condition: string]: ExportEntry };
  * See `tsdown-exports.mjs` and CopilotKit issue #3324.
  */
 export declare function withTypesConditions(
-  exports: Record<string, ExportEntry>,
+  exports: Record<string, ExportsEntry>,
   ctx: { pkg: unknown },
-): Record<string, ExportEntry>;
+): Record<string, ExportsEntry>;

--- a/scripts/tsdown-exports.d.mts
+++ b/scripts/tsdown-exports.d.mts
@@ -1,6 +1,10 @@
 /**
  * A value in a package.json `exports` map: a target path, `null` (blocks a
  * subpath), a fallback array, or a nested conditions object.
+ *
+ * Mirror of `ExportsEntry` in `scripts/validate-package-exports-types.ts`;
+ * the two are hand-kept in sync (a `.d.mts` declaration and a `.ts` script
+ * cannot share one source without coupling the build helper to the validator).
  */
 export type ExportsEntry =
   | string

--- a/scripts/tsdown-exports.mjs
+++ b/scripts/tsdown-exports.mjs
@@ -27,10 +27,10 @@ import path from "node:path";
  * `types` condition (`.d.mts`/`.d.cts`/`.d.ts`) FIRST so ESM consumers get
  * ESM-flavored declarations and CJS consumers get CJS-flavored ones (keeping
  * `are-the-types-wrong` green — a single top-level `.d.cts` on an ESM `import`
- * would report as False CJS). Targets without an adjacent declaration file
- * (CSS, `package.json`, UMD) are left untouched. It only ADDS a missing
- * `types`; it does not split an existing shared `types` into per-flavor
- * declarations (attw guards that).
+ * would report as False CJS). Non-JS targets (`.css`, `package.json`) are left
+ * untouched, as is any JS target with no adjacent declaration on disk (which
+ * the helper warns about). It only ADDS a missing `types`; it does not split
+ * an existing shared `types` into per-flavor declarations (attw guards that).
  *
  * Wire it into `tsdown.config.ts` via the `exports.customExports` hook:
  *   exports: { customExports: (exports, ctx) => withTypesConditions(exports, ctx) }
@@ -44,6 +44,14 @@ export function withTypesConditions(exports, ctx) {
   if (typeof packageJsonPath !== "string") {
     throw new Error(
       "withTypesConditions: ctx.pkg.packageJsonPath is required to resolve declaration files",
+    );
+  }
+  // tsdown always hands us a `subpath -> target` object; guard so a bare-string
+  // or array `exports` fails loud instead of being iterated character-/index-
+  // wise into a corrupt map.
+  if (!exports || typeof exports !== "object" || Array.isArray(exports)) {
+    throw new Error(
+      "withTypesConditions: expected a subpath -> target `exports` object",
     );
   }
   const pkgDir = path.dirname(packageJsonPath);
@@ -63,13 +71,15 @@ function withTypes(entry, pkgDir) {
   // Fallback arrays (`"import": ["./a.mjs", "./b.mjs"]`) are legal: transform
   // each element and keep the array rather than corrupting it into an object.
   if (Array.isArray(entry)) return entry.map((item) => withTypes(item, pkgDir));
-  // Idempotent: an object whose FIRST condition is already `types` is this
-  // helper's own output (types-first), so leave it untouched rather than
-  // re-nesting its `default`. Keying on first-key (not mere presence) means a
-  // hand-authored `types`-last entry is still normalized instead of passed
-  // through — keeping the helper's output consistent with what the validator
-  // (`validate-package-exports-types.ts`) accepts.
-  if (Object.keys(entry)[0] === "types") return entry;
+  // Idempotent: skip only this helper's OWN output shape — a `{ types: <string>,
+  // default, ... }` object (a string `types` listed first). Keying this
+  // narrowly (not "any first `types`") means a hand-authored `types`-last OR
+  // `types`-first-but-partial-object entry is still normalized (so its untyped
+  // siblings get a `types` condition) instead of passed through, keeping the
+  // helper's output consistent with what the validator accepts.
+  if (Object.keys(entry)[0] === "types" && typeof entry.types === "string") {
+    return entry;
+  }
   const next = {};
   for (const [condition, target] of Object.entries(entry)) {
     next[condition] =
@@ -82,7 +92,9 @@ function withTypes(entry, pkgDir) {
 
 /**
  * Map a JS output path to a `{ types, default }` pair when a sibling
- * declaration file exists; return `null` to leave the target unchanged.
+ * declaration file exists. Returns `null` (caller leaves the target as-is) for
+ * a non-JS target, or — with a loud warning — for a JS target whose declaration
+ * is missing, since emitting it untyped reintroduces #3324 for that subpath.
  */
 function typedTarget(jsPath, pkgDir) {
   const typesPath = jsPath.endsWith(".mjs")
@@ -92,6 +104,13 @@ function typedTarget(jsPath, pkgDir) {
       : jsPath.endsWith(".js")
         ? `${jsPath.slice(0, -".js".length)}.d.ts`
         : null;
-  if (!typesPath || !existsSync(path.resolve(pkgDir, typesPath))) return null;
+  if (!typesPath) return null; // non-JS (css/json): genuinely untyped, no warning
+  if (!existsSync(path.resolve(pkgDir, typesPath))) {
+    console.warn(
+      `[tsdown-exports] "${jsPath}" has no adjacent declaration (${typesPath}); ` +
+        `leaving it without a types condition (reintroduces #3324 for this subpath).`,
+    );
+    return null;
+  }
   return { types: typesPath, default: jsPath };
 }

--- a/scripts/tsdown-exports.mjs
+++ b/scripts/tsdown-exports.mjs
@@ -37,7 +37,7 @@ export function withTypesConditions(exports, ctx) {
   // from tsdown's public `PackageJson` type). Fail loud rather than silently
   // resolving against the wrong directory and emitting a types-less map — that
   // would reintroduce exactly the #3324 bug this helper prevents.
-  const packageJsonPath = ctx.pkg?.packageJsonPath;
+  const packageJsonPath = ctx?.pkg?.packageJsonPath;
   if (typeof packageJsonPath !== "string") {
     throw new Error(
       "withTypesConditions: ctx.pkg.packageJsonPath is required to resolve declaration files",
@@ -60,6 +60,10 @@ function withTypes(entry, pkgDir) {
   // Fallback arrays (`"import": ["./a.mjs", "./b.mjs"]`) are legal: transform
   // each element and keep the array rather than corrupting it into an object.
   if (Array.isArray(entry)) return entry.map((item) => withTypes(item, pkgDir));
+  // Idempotent: an object that already carries a `types` condition has been
+  // processed (or is already type-first), so leave it untouched rather than
+  // re-nesting its `default`.
+  if ("types" in entry) return entry;
   const next = {};
   for (const [condition, target] of Object.entries(entry)) {
     next[condition] =

--- a/scripts/tsdown-exports.mjs
+++ b/scripts/tsdown-exports.mjs
@@ -33,14 +33,17 @@ import path from "node:path";
  *   exports: { customExports: (exports, ctx) => withTypesConditions(exports, ctx) }
  */
 export function withTypesConditions(exports, ctx) {
-  // `packageJsonPath` is present at runtime but absent from tsdown's public
-  // `PackageJson` type; fall back to cwd (nx runs each build from the package
-  // directory) if it is ever missing.
+  // tsdown always supplies `packageJsonPath` at runtime (it is merely absent
+  // from tsdown's public `PackageJson` type). Fail loud rather than silently
+  // resolving against the wrong directory and emitting a types-less map — that
+  // would reintroduce exactly the #3324 bug this helper prevents.
   const packageJsonPath = ctx.pkg?.packageJsonPath;
-  const pkgDir =
-    typeof packageJsonPath === "string"
-      ? path.dirname(packageJsonPath)
-      : process.cwd();
+  if (typeof packageJsonPath !== "string") {
+    throw new Error(
+      "withTypesConditions: ctx.pkg.packageJsonPath is required to resolve declaration files",
+    );
+  }
+  const pkgDir = path.dirname(packageJsonPath);
   const result = {};
   for (const [subpath, entry] of Object.entries(exports)) {
     result[subpath] = withTypes(entry, pkgDir);
@@ -52,6 +55,11 @@ function withTypes(entry, pkgDir) {
   if (typeof entry === "string") {
     return typedTarget(entry, pkgDir) ?? entry;
   }
+  // `null` blocks a subpath; leave it (and any non-object) untouched.
+  if (entry === null || typeof entry !== "object") return entry;
+  // Fallback arrays (`"import": ["./a.mjs", "./b.mjs"]`) are legal: transform
+  // each element and keep the array rather than corrupting it into an object.
+  if (Array.isArray(entry)) return entry.map((item) => withTypes(item, pkgDir));
   const next = {};
   for (const [condition, target] of Object.entries(entry)) {
     next[condition] =

--- a/scripts/tsdown-exports.mjs
+++ b/scripts/tsdown-exports.mjs
@@ -21,13 +21,16 @@ import path from "node:path";
  * type declarations and report every named export as "has no exported member"
  * (CopilotKit issue #3324).
  *
- * This post-processes tsdown's generated exports: for each `import`/`require`
- * (or bare string) target pointing at an emitted `.mjs`/`.cjs`/`.js`, it nests
- * a matching `types` condition (`.d.mts`/`.d.cts`/`.d.ts`) FIRST so ESM
- * consumers get ESM-flavored declarations and CJS consumers get CJS-flavored
- * ones (keeping `are-the-types-wrong` green — a single top-level `.d.cts` on an
- * ESM `import` would report as False CJS). Targets without an adjacent
- * declaration file (CSS, `package.json`, UMD) are left untouched.
+ * This post-processes tsdown's generated exports (a `subpath -> target` map):
+ * for each condition target (typically `import`/`require`) — and bare-string
+ * targets — pointing at an emitted `.mjs`/`.cjs`/`.js`, it nests a matching
+ * `types` condition (`.d.mts`/`.d.cts`/`.d.ts`) FIRST so ESM consumers get
+ * ESM-flavored declarations and CJS consumers get CJS-flavored ones (keeping
+ * `are-the-types-wrong` green — a single top-level `.d.cts` on an ESM `import`
+ * would report as False CJS). Targets without an adjacent declaration file
+ * (CSS, `package.json`, UMD) are left untouched. It only ADDS a missing
+ * `types`; it does not split an existing shared `types` into per-flavor
+ * declarations (attw guards that).
  *
  * Wire it into `tsdown.config.ts` via the `exports.customExports` hook:
  *   exports: { customExports: (exports, ctx) => withTypesConditions(exports, ctx) }
@@ -60,10 +63,13 @@ function withTypes(entry, pkgDir) {
   // Fallback arrays (`"import": ["./a.mjs", "./b.mjs"]`) are legal: transform
   // each element and keep the array rather than corrupting it into an object.
   if (Array.isArray(entry)) return entry.map((item) => withTypes(item, pkgDir));
-  // Idempotent: an object that already carries a `types` condition has been
-  // processed (or is already type-first), so leave it untouched rather than
-  // re-nesting its `default`.
-  if ("types" in entry) return entry;
+  // Idempotent: an object whose FIRST condition is already `types` is this
+  // helper's own output (types-first), so leave it untouched rather than
+  // re-nesting its `default`. Keying on first-key (not mere presence) means a
+  // hand-authored `types`-last entry is still normalized instead of passed
+  // through — keeping the helper's output consistent with what the validator
+  // (`validate-package-exports-types.ts`) accepts.
+  if (Object.keys(entry)[0] === "types") return entry;
   const next = {};
   for (const [condition, target] of Object.entries(entry)) {
     next[condition] =

--- a/scripts/tsdown-exports.mjs
+++ b/scripts/tsdown-exports.mjs
@@ -1,23 +1,14 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 
-/**
- * A single value in a package.json `exports` map: either a target path or a
- * nested conditions object (`import`/`require`/`types`/`default`/...).
- */
-export type ExportEntry = string | { [condition: string]: ExportEntry };
-
-/**
- * Minimal shape of tsdown's `customExports` context. `pkg` is typed `unknown`
- * so this stays structurally assignable from tsdown's own
- * `{ pkg, chunks, isPublish }` context: tsdown's public `PackageJson` type does
- * not declare the `packageJsonPath` field that is present at runtime, and a
- * `{ packageJsonPath?: string }` shape would be an all-optional "weak type"
- * that `PackageJson` cannot satisfy.
- */
-interface CustomExportsContext {
-  pkg: unknown;
-}
+// Authored as plain ESM (`.mjs`) with a sibling `.d.mts`, NOT `.ts`: each
+// package's `tsdown.config.ts` imports this helper, and tsdown loads those
+// configs with Node's native ESM loader when `process.features.typescript` is
+// on (Node >= 22.18 / 24 in CI). Native ESM does not resolve extensionless or
+// `.ts`-mapped relative imports, so a `.ts` helper imported without an
+// extension fails in CI with "Cannot find module". A real `.mjs` imported with
+// its explicit extension resolves under the native loader, tsdown's bundler
+// loader, and `tsc` (via the adjacent `.d.mts`) alike.
 
 /**
  * Ensure every generated `exports` entry carries a `types` condition.
@@ -41,31 +32,27 @@ interface CustomExportsContext {
  * Wire it into `tsdown.config.ts` via the `exports.customExports` hook:
  *   exports: { customExports: (exports, ctx) => withTypesConditions(exports, ctx) }
  */
-export function withTypesConditions(
-  exports: Record<string, ExportEntry>,
-  ctx: CustomExportsContext,
-): Record<string, ExportEntry> {
+export function withTypesConditions(exports, ctx) {
   // `packageJsonPath` is present at runtime but absent from tsdown's public
   // `PackageJson` type; fall back to cwd (nx runs each build from the package
   // directory) if it is ever missing.
-  const packageJsonPath = (ctx.pkg as { packageJsonPath?: unknown })
-    .packageJsonPath;
+  const packageJsonPath = ctx.pkg?.packageJsonPath;
   const pkgDir =
     typeof packageJsonPath === "string"
       ? path.dirname(packageJsonPath)
       : process.cwd();
-  const result: Record<string, ExportEntry> = {};
+  const result = {};
   for (const [subpath, entry] of Object.entries(exports)) {
     result[subpath] = withTypes(entry, pkgDir);
   }
   return result;
 }
 
-function withTypes(entry: ExportEntry, pkgDir: string): ExportEntry {
+function withTypes(entry, pkgDir) {
   if (typeof entry === "string") {
     return typedTarget(entry, pkgDir) ?? entry;
   }
-  const next: Record<string, ExportEntry> = {};
+  const next = {};
   for (const [condition, target] of Object.entries(entry)) {
     next[condition] =
       typeof target === "string"
@@ -79,10 +66,7 @@ function withTypes(entry: ExportEntry, pkgDir: string): ExportEntry {
  * Map a JS output path to a `{ types, default }` pair when a sibling
  * declaration file exists; return `null` to leave the target unchanged.
  */
-function typedTarget(
-  jsPath: string,
-  pkgDir: string,
-): { types: string; default: string } | null {
+function typedTarget(jsPath, pkgDir) {
   const typesPath = jsPath.endsWith(".mjs")
     ? `${jsPath.slice(0, -".mjs".length)}.d.mts`
     : jsPath.endsWith(".cjs")

--- a/scripts/tsdown-exports.ts
+++ b/scripts/tsdown-exports.ts
@@ -1,0 +1,95 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * A single value in a package.json `exports` map: either a target path or a
+ * nested conditions object (`import`/`require`/`types`/`default`/...).
+ */
+export type ExportEntry = string | { [condition: string]: ExportEntry };
+
+/**
+ * Minimal shape of tsdown's `customExports` context. `pkg` is typed `unknown`
+ * so this stays structurally assignable from tsdown's own
+ * `{ pkg, chunks, isPublish }` context: tsdown's public `PackageJson` type does
+ * not declare the `packageJsonPath` field that is present at runtime, and a
+ * `{ packageJsonPath?: string }` shape would be an all-optional "weak type"
+ * that `PackageJson` cannot satisfy.
+ */
+interface CustomExportsContext {
+  pkg: unknown;
+}
+
+/**
+ * Ensure every generated `exports` entry carries a `types` condition.
+ *
+ * tsdown (0.20.x) auto-generates the package.json `exports` map from build
+ * output but never writes a `types` condition into it — it only sets the
+ * top-level `types` field, which TypeScript ignores under `moduleResolution`
+ * `bundler`/`node16`/`nodenext` once an `exports` map is present. Tools that
+ * strictly follow the exports map (e.g. the Backstage CLI) then resolve no
+ * type declarations and report every named export as "has no exported member"
+ * (CopilotKit issue #3324).
+ *
+ * This post-processes tsdown's generated exports: for each `import`/`require`
+ * (or bare string) target pointing at an emitted `.mjs`/`.cjs`/`.js`, it nests
+ * a matching `types` condition (`.d.mts`/`.d.cts`/`.d.ts`) FIRST so ESM
+ * consumers get ESM-flavored declarations and CJS consumers get CJS-flavored
+ * ones (keeping `are-the-types-wrong` green — a single top-level `.d.cts` on an
+ * ESM `import` would report as False CJS). Targets without an adjacent
+ * declaration file (CSS, `package.json`, UMD) are left untouched.
+ *
+ * Wire it into `tsdown.config.ts` via the `exports.customExports` hook:
+ *   exports: { customExports: (exports, ctx) => withTypesConditions(exports, ctx) }
+ */
+export function withTypesConditions(
+  exports: Record<string, ExportEntry>,
+  ctx: CustomExportsContext,
+): Record<string, ExportEntry> {
+  // `packageJsonPath` is present at runtime but absent from tsdown's public
+  // `PackageJson` type; fall back to cwd (nx runs each build from the package
+  // directory) if it is ever missing.
+  const packageJsonPath = (ctx.pkg as { packageJsonPath?: unknown })
+    .packageJsonPath;
+  const pkgDir =
+    typeof packageJsonPath === "string"
+      ? path.dirname(packageJsonPath)
+      : process.cwd();
+  const result: Record<string, ExportEntry> = {};
+  for (const [subpath, entry] of Object.entries(exports)) {
+    result[subpath] = withTypes(entry, pkgDir);
+  }
+  return result;
+}
+
+function withTypes(entry: ExportEntry, pkgDir: string): ExportEntry {
+  if (typeof entry === "string") {
+    return typedTarget(entry, pkgDir) ?? entry;
+  }
+  const next: Record<string, ExportEntry> = {};
+  for (const [condition, target] of Object.entries(entry)) {
+    next[condition] =
+      typeof target === "string"
+        ? (typedTarget(target, pkgDir) ?? target)
+        : withTypes(target, pkgDir);
+  }
+  return next;
+}
+
+/**
+ * Map a JS output path to a `{ types, default }` pair when a sibling
+ * declaration file exists; return `null` to leave the target unchanged.
+ */
+function typedTarget(
+  jsPath: string,
+  pkgDir: string,
+): { types: string; default: string } | null {
+  const typesPath = jsPath.endsWith(".mjs")
+    ? `${jsPath.slice(0, -".mjs".length)}.d.mts`
+    : jsPath.endsWith(".cjs")
+      ? `${jsPath.slice(0, -".cjs".length)}.d.cts`
+      : jsPath.endsWith(".js")
+        ? `${jsPath.slice(0, -".js".length)}.d.ts`
+        : null;
+  if (!typesPath || !existsSync(path.resolve(pkgDir, typesPath))) return null;
+  return { types: typesPath, default: jsPath };
+}

--- a/scripts/validate-package-exports-types.ts
+++ b/scripts/validate-package-exports-types.ts
@@ -7,7 +7,7 @@ import * as path from "node:path";
 // TypeScript ignores the top-level `types` field once a package.json `exports`
 // map exists, so under `moduleResolution` bundler/node16/nodenext every export
 // subpath that resolves to runtime JavaScript needs its OWN `types` condition.
-// tsdown does not emit one automatically (scripts/tsdown-exports.ts adds it),
+// tsdown does not emit one automatically (scripts/tsdown-exports.mjs adds it),
 // and hand-maintained maps can forget it — either way strict-exports tooling
 // (e.g. the Backstage CLI) then reports "has no exported member" for every
 // named import. This script scans every publishable package and fails if any
@@ -156,7 +156,7 @@ function main(): void {
   }
   console.error(
     "\nEvery JS entry in a package.json `exports` map needs a `types` condition.\n" +
-      "tsdown-managed packages get it from scripts/tsdown-exports.ts (withTypesConditions) —\n" +
+      "tsdown-managed packages get it from scripts/tsdown-exports.mjs (withTypesConditions) —\n" +
       "rebuild the package after editing its tsdown config. Hand-maintained maps must add it directly.",
   );
   process.exit(1);

--- a/scripts/validate-package-exports-types.ts
+++ b/scripts/validate-package-exports-types.ts
@@ -17,6 +17,10 @@ import * as path from "node:path";
 /**
  * A value in a package.json `exports` map: a target path, `null` (blocks a
  * subpath), a fallback array, or a nested conditions object.
+ *
+ * Mirror of `ExportsEntry` in `scripts/tsdown-exports.d.mts`; the two are
+ * hand-kept in sync (a `.ts` script and a `.d.mts` declaration cannot share
+ * one source without coupling the validator to the build helper).
  */
 export type ExportsEntry =
   | string

--- a/scripts/validate-package-exports-types.ts
+++ b/scripts/validate-package-exports-types.ts
@@ -1,0 +1,169 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Regression guard for CopilotKit issue #3324.
+//
+// TypeScript ignores the top-level `types` field once a package.json `exports`
+// map exists, so under `moduleResolution` bundler/node16/nodenext every export
+// subpath that resolves to runtime JavaScript needs its OWN `types` condition.
+// tsdown does not emit one automatically (scripts/tsdown-exports.ts adds it),
+// and hand-maintained maps can forget it — either way strict-exports tooling
+// (e.g. the Backstage CLI) then reports "has no exported member" for every
+// named import. This script scans every publishable package and fails if any
+// JS export is missing a valid `types` condition.
+// ---------------------------------------------------------------------------
+
+/** A value in a package.json `exports` map. */
+export type ExportsEntry = string | { [condition: string]: ExportsEntry };
+
+export interface Violation {
+  package: string;
+  /** Subpath plus the condition trail, e.g. `". > import"`. */
+  subpath: string;
+  reason: string;
+}
+
+const PACKAGES_DIR = path.resolve(__dirname, "../packages");
+
+const JS_TARGET = /\.(mjs|cjs|js)$/;
+const DECLARATION_TARGET = /\.d\.(mts|cts|ts)$/;
+
+// ---------------------------------------------------------------------------
+// Core check
+// ---------------------------------------------------------------------------
+
+/**
+ * Return every entry in one package's `exports` map that resolves to runtime
+ * JavaScript without a reachable `types` condition, or whose `types` condition
+ * does not point at a declaration file.
+ */
+export function findExportsTypeViolations(
+  packageName: string,
+  exportsMap: unknown,
+): Violation[] {
+  const violations: Violation[] = [];
+  if (exportsMap && typeof exportsMap === "object") {
+    for (const [subpath, entry] of Object.entries(exportsMap)) {
+      walk(entry, subpath, packageName, violations);
+    }
+  }
+  return violations;
+}
+
+function walk(
+  entry: unknown,
+  trail: string,
+  packageName: string,
+  out: Violation[],
+): void {
+  if (typeof entry === "string") {
+    if (JS_TARGET.test(entry)) {
+      out.push({
+        package: packageName,
+        subpath: trail,
+        reason: `JS target "${entry}" has no "types" condition`,
+      });
+    }
+    return;
+  }
+  if (!entry || typeof entry !== "object") return;
+
+  const conditions = Object.entries(entry);
+
+  // An explicit `types` condition at this level covers this branch; just check
+  // that it points at a declaration file (`are-the-types-wrong` validates the
+  // ESM/CJS flavor separately).
+  const typesEntry = conditions.find(([condition]) => condition === "types");
+  if (typesEntry) {
+    const typesTarget = typesEntry[1];
+    if (
+      typeof typesTarget === "string" &&
+      !DECLARATION_TARGET.test(typesTarget)
+    ) {
+      out.push({
+        package: packageName,
+        subpath: `${trail} > types`,
+        reason: `"types" target "${typesTarget}" is not a declaration file`,
+      });
+    }
+    return;
+  }
+
+  // No `types` here — every condition that leads to JS must carry its own.
+  for (const [condition, value] of conditions) {
+    walk(value, `${trail} > ${condition}`, packageName, out);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Package discovery
+// ---------------------------------------------------------------------------
+
+export interface PublishablePackage {
+  name: string;
+  exports: unknown;
+}
+
+/**
+ * Every publishable package (`private !== true`) under `packages/*` that
+ * declares an `exports` map. New packages are covered automatically.
+ */
+export function getPublishablePackagesWithExports(
+  packagesDir: string = PACKAGES_DIR,
+): PublishablePackage[] {
+  const packages: PublishablePackage[] = [];
+  for (const name of fs.readdirSync(packagesDir).sort()) {
+    const pkgJsonPath = path.join(packagesDir, name, "package.json");
+    if (!fs.existsSync(pkgJsonPath)) continue;
+    const pkg: { name?: string; private?: boolean; exports?: unknown } =
+      JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
+    if (pkg.private === true || !pkg.exports) continue;
+    packages.push({ name: pkg.name ?? name, exports: pkg.exports });
+  }
+  return packages;
+}
+
+export function validateAllPackages(
+  packagesDir: string = PACKAGES_DIR,
+): Violation[] {
+  const violations: Violation[] = [];
+  for (const pkg of getPublishablePackagesWithExports(packagesDir)) {
+    violations.push(...findExportsTypeViolations(pkg.name, pkg.exports));
+  }
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const violations = validateAllPackages();
+
+  if (violations.length === 0) {
+    console.log(
+      "All publishable packages declare a `types` condition for every JS export.",
+    );
+    process.exit(0);
+  }
+
+  console.error(
+    `Found ${violations.length} export${violations.length === 1 ? "" : "s"} missing a valid "types" condition (issue #3324):\n`,
+  );
+  for (const v of violations) {
+    console.error(`  ${v.package}  ${v.subpath}\n    ${v.reason}`);
+  }
+  console.error(
+    "\nEvery JS entry in a package.json `exports` map needs a `types` condition.\n" +
+      "tsdown-managed packages get it from scripts/tsdown-exports.ts (withTypesConditions) —\n" +
+      "rebuild the package after editing its tsdown config. Hand-maintained maps must add it directly.",
+  );
+  process.exit(1);
+}
+
+// Only run main when executed directly (not when imported for tests).
+const isDirectRun = typeof require !== "undefined" && require.main === module;
+if (isDirectRun) {
+  main();
+}

--- a/scripts/validate-package-exports-types.ts
+++ b/scripts/validate-package-exports-types.ts
@@ -36,23 +36,35 @@ const PACKAGES_DIR = path.resolve(__dirname, "../packages");
 const JS_TARGET = /\.(mjs|cjs|js)$/;
 const DECLARATION_TARGET = /\.d\.(mts|cts|ts)$/;
 
-// The JS-returning conditions TypeScript resolves types through. Conditions
-// match in object order (first match wins), so a `types` condition must appear
-// BEFORE these or a strict resolver reaches the JS target first and finds no
-// declarations. Runtime-only conditions (browser/deno/worker/development/
-// production/…) are absent on purpose: TypeScript ignores them for types, so a
-// JS target under one needs no declaration.
-const JS_CONDITIONS = new Set(["import", "require", "node", "default"]);
+// import- and require-mode resolve types INDEPENDENTLY. In each mode TypeScript
+// matches the first condition present (in object order) from
+// {types, <mode>, node, default} — so `import` and `require` never shadow each
+// other, and a trailing `default`/`node` after both is unreachable in every
+// mode. Runtime-only conditions (browser/deno/worker/development/production/…)
+// are ignored for types, so a JS target under one needs no declaration.
+const RESOLUTION_MODES = ["import", "require"] as const;
+
+function isActiveCondition(
+  condition: string,
+  mode: (typeof RESOLUTION_MODES)[number],
+): boolean {
+  return (
+    condition === "types" ||
+    condition === mode ||
+    condition === "node" ||
+    condition === "default"
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Core check
 // ---------------------------------------------------------------------------
 
 /**
- * Return every entry in one package's `exports` map whose first type-relevant
- * condition resolves to runtime JavaScript instead of a declaration file —
- * i.e. TypeScript (and strict `exports` resolvers such as the Backstage CLI)
- * would find no `.d.ts` for that subpath.
+ * Return every entry in one package's `exports` map where TypeScript's import-
+ * or require-mode resolution lands on runtime JavaScript instead of a
+ * declaration file — i.e. TypeScript (and strict `exports` resolvers such as
+ * the Backstage CLI) would find no `.d.ts` for that subpath.
  */
 export function findExportsTypeViolations(
   packageName: string,
@@ -109,39 +121,39 @@ function walk(
     return;
   }
 
-  // Conditions match in object order (first match wins), and import- and
-  // require-mode resolve independently. Validate each `types` target, and flag
-  // every JS-returning condition that is NOT preceded by a `types` (a strict
-  // resolver reaches that JS target before any later `types`). Runtime-only
-  // conditions are ignored — TypeScript resolves no types through them.
   const conditions = Object.entries(entry);
-  const typesIndex = conditions.findIndex(
-    ([condition]) => condition === "types",
-  );
-  conditions.forEach(([condition, value], index) => {
-    if (condition === "types") {
-      if (typeof value === "string") {
-        if (!DECLARATION_TARGET.test(value)) {
-          out.push({
-            package: packageName,
-            subpath: `${trail} > types`,
-            reason: `"types" target "${value}" is not a declaration file`,
-          });
-        }
-      } else {
-        // Nested/object `types` — recurse so each resolved leaf is validated.
-        walk(value, `${trail} > types`, packageName, out);
+
+  // 1. Every `types` target must be a declaration file (or, if nested, resolve
+  //    to declarations).
+  for (const [condition, value] of conditions) {
+    if (condition !== "types") continue;
+    if (typeof value === "string") {
+      if (!DECLARATION_TARGET.test(value)) {
+        out.push({
+          package: packageName,
+          subpath: `${trail} > types`,
+          reason: `"types" target "${value}" is not a declaration file`,
+        });
       }
-      return;
+    } else {
+      // Nested/object `types` — recurse so each resolved leaf is validated.
+      walk(value, `${trail} > types`, packageName, out);
     }
-    if (!JS_CONDITIONS.has(condition)) return; // runtime-only → no types needed
-    // A `types` condition earlier in object order covers this JS condition for
-    // its resolution mode.
-    if (typesIndex !== -1 && typesIndex < index) return;
-    // Otherwise the JS target must itself carry types (a nested `types`) or be
-    // a declaration file.
-    walk(value, `${trail} > ${condition}`, packageName, out);
-  });
+  }
+
+  // 2. For each resolution mode the first active condition wins. When that
+  //    winner is a JS-returning condition (not `types`), its value must itself
+  //    carry types. Dedupe so a shared winner (e.g. a trailing `default`) is
+  //    reported once, and skip winners already covered by a `types`.
+  const walked = new Set<string>();
+  for (const mode of RESOLUTION_MODES) {
+    const winner = conditions.find(([condition]) =>
+      isActiveCondition(condition, mode),
+    );
+    if (!winner || winner[0] === "types" || walked.has(winner[0])) continue;
+    walked.add(winner[0]);
+    walk(winner[1], `${trail} > ${winner[0]}`, packageName, out);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/validate-package-exports-types.ts
+++ b/scripts/validate-package-exports-types.ts
@@ -57,24 +57,26 @@ function isActiveCondition(
 }
 
 /**
- * Whether a `types` condition's value actually resolves for `mode`. A string
- * `types` covers every mode; an object `types` covers a mode only if it has a
- * branch active for that mode (recursively). A partial object (e.g. only
- * `import`) does NOT cover `require`, so a strict resolver falls through to the
- * next sibling condition — which is where an untyped JS target can hide.
+ * Whether a condition's value resolves to SOMETHING for `mode`. A string always
+ * resolves; an object resolves only if it has a branch active for that mode
+ * (recursively). A partial object (e.g. only `import`) does NOT resolve for
+ * `require`, so a strict resolver falls through to the next sibling condition —
+ * which is where an untyped JS target can hide. Applies to every condition,
+ * not just `types` (a partial `node`/`default`/`import` object falls through
+ * the same way).
  */
-function typesCoversMode(
+function resolvesForMode(
   value: ExportsEntry,
   mode: (typeof RESOLUTION_MODES)[number],
 ): boolean {
   if (typeof value === "string") return true;
   if (!value || typeof value !== "object") return false;
   if (Array.isArray(value)) {
-    return value.some((item) => typesCoversMode(item, mode));
+    return value.some((item) => resolvesForMode(item, mode));
   }
   return Object.entries(value).some(
     ([condition, sub]) =>
-      isActiveCondition(condition, mode) && typesCoversMode(sub, mode),
+      isActiveCondition(condition, mode) && resolvesForMode(sub, mode),
   );
 }
 
@@ -163,18 +165,20 @@ function walk(
     }
   }
 
-  // 2. For each resolution mode the first RESOLVING condition wins. A `types`
-  //    condition wins only if it actually covers the mode (a partial object
-  //    `types` does not); otherwise resolution falls through to the next
-  //    sibling. When the winner is a JS-returning condition its value must
-  //    itself carry types. Dedupe so a shared winner (e.g. a trailing
-  //    `default`) is reported once; a `types` winner is covered by step 1.
+  // 2. For each resolution mode the first RESOLVING condition wins. A condition
+  //    only wins if it is active for the mode AND its value actually resolves
+  //    for that mode (a partial object — `types`, `node`, `default`, … that
+  //    lacks the mode's branch — does not, so resolution falls through to the
+  //    next sibling, which is where an untyped JS target hides). When the winner
+  //    is a JS-returning condition its value must itself carry types. Dedupe so
+  //    a shared winner (e.g. a trailing `default`) is reported once; a `types`
+  //    winner is covered by step 1.
   const walked = new Set<string>();
   for (const mode of RESOLUTION_MODES) {
     const winner = conditions.find(([condition, value]) =>
       condition === "types"
-        ? typesCoversMode(value, mode)
-        : isActiveCondition(condition, mode),
+        ? resolvesForMode(value, mode)
+        : isActiveCondition(condition, mode) && resolvesForMode(value, mode),
     );
     if (!winner || winner[0] === "types" || walked.has(winner[0])) continue;
     walked.add(winner[0]);

--- a/scripts/validate-package-exports-types.ts
+++ b/scripts/validate-package-exports-types.ts
@@ -56,6 +56,28 @@ function isActiveCondition(
   );
 }
 
+/**
+ * Whether a `types` condition's value actually resolves for `mode`. A string
+ * `types` covers every mode; an object `types` covers a mode only if it has a
+ * branch active for that mode (recursively). A partial object (e.g. only
+ * `import`) does NOT cover `require`, so a strict resolver falls through to the
+ * next sibling condition — which is where an untyped JS target can hide.
+ */
+function typesCoversMode(
+  value: ExportsEntry,
+  mode: (typeof RESOLUTION_MODES)[number],
+): boolean {
+  if (typeof value === "string") return true;
+  if (!value || typeof value !== "object") return false;
+  if (Array.isArray(value)) {
+    return value.some((item) => typesCoversMode(item, mode));
+  }
+  return Object.entries(value).some(
+    ([condition, sub]) =>
+      isActiveCondition(condition, mode) && typesCoversMode(sub, mode),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Core check
 // ---------------------------------------------------------------------------
@@ -79,9 +101,9 @@ export function findExportsTypeViolations(
 
 /**
  * Normalize Node's `exports` sugar into a `subpath -> target` map. A bare
- * string (`"exports": "./index.mjs"`) and a conditions-only object
- * (`{ import, require }` with no `.`/`./…` keys) are both sugar for the `.`
- * subpath; a real subpath map is returned unchanged.
+ * string (`"exports": "./index.mjs"`), a top-level fallback array, and a
+ * conditions-only object (`{ import, require }` with no `.`/`./…` keys) are all
+ * sugar for the `.` subpath; a real subpath map is returned unchanged.
  */
 function normalizeExports(exportsMap: unknown): Record<string, ExportsEntry> {
   if (typeof exportsMap === "string" || Array.isArray(exportsMap)) {
@@ -141,14 +163,18 @@ function walk(
     }
   }
 
-  // 2. For each resolution mode the first active condition wins. When that
-  //    winner is a JS-returning condition (not `types`), its value must itself
-  //    carry types. Dedupe so a shared winner (e.g. a trailing `default`) is
-  //    reported once, and skip winners already covered by a `types`.
+  // 2. For each resolution mode the first RESOLVING condition wins. A `types`
+  //    condition wins only if it actually covers the mode (a partial object
+  //    `types` does not); otherwise resolution falls through to the next
+  //    sibling. When the winner is a JS-returning condition its value must
+  //    itself carry types. Dedupe so a shared winner (e.g. a trailing
+  //    `default`) is reported once; a `types` winner is covered by step 1.
   const walked = new Set<string>();
   for (const mode of RESOLUTION_MODES) {
-    const winner = conditions.find(([condition]) =>
-      isActiveCondition(condition, mode),
+    const winner = conditions.find(([condition, value]) =>
+      condition === "types"
+        ? typesCoversMode(value, mode)
+        : isActiveCondition(condition, mode),
     );
     if (!winner || winner[0] === "types" || walked.has(winner[0])) continue;
     walked.add(winner[0]);
@@ -180,7 +206,9 @@ export function getPublishablePackagesWithExports(
     try {
       pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
     } catch (error) {
-      throw new Error(`Failed to parse ${pkgJsonPath}`, { cause: error });
+      throw new Error(`Failed to read or parse ${pkgJsonPath}`, {
+        cause: error,
+      });
     }
     if (pkg.private === true || !pkg.exports) continue;
     packages.push({ name: pkg.name ?? name, exports: pkg.exports });

--- a/scripts/validate-package-exports-types.ts
+++ b/scripts/validate-package-exports-types.ts
@@ -14,8 +14,15 @@ import * as path from "node:path";
 // JS export is missing a valid `types` condition.
 // ---------------------------------------------------------------------------
 
-/** A value in a package.json `exports` map. */
-export type ExportsEntry = string | { [condition: string]: ExportsEntry };
+/**
+ * A value in a package.json `exports` map: a target path, `null` (blocks a
+ * subpath), a fallback array, or a nested conditions object.
+ */
+export type ExportsEntry =
+  | string
+  | null
+  | ExportsEntry[]
+  | { [condition: string]: ExportsEntry };
 
 export interface Violation {
   package: string;
@@ -29,30 +36,55 @@ const PACKAGES_DIR = path.resolve(__dirname, "../packages");
 const JS_TARGET = /\.(mjs|cjs|js)$/;
 const DECLARATION_TARGET = /\.d\.(mts|cts|ts)$/;
 
+// The JS-returning conditions TypeScript resolves types through. Conditions
+// match in object order (first match wins), so a `types` condition must appear
+// BEFORE these or a strict resolver reaches the JS target first and finds no
+// declarations. Runtime-only conditions (browser/deno/worker/development/
+// production/…) are absent on purpose: TypeScript ignores them for types, so a
+// JS target under one needs no declaration.
+const JS_CONDITIONS = new Set(["import", "require", "node", "default"]);
+
 // ---------------------------------------------------------------------------
 // Core check
 // ---------------------------------------------------------------------------
 
 /**
- * Return every entry in one package's `exports` map that resolves to runtime
- * JavaScript without a reachable `types` condition, or whose `types` condition
- * does not point at a declaration file.
+ * Return every entry in one package's `exports` map whose first type-relevant
+ * condition resolves to runtime JavaScript instead of a declaration file —
+ * i.e. TypeScript (and strict `exports` resolvers such as the Backstage CLI)
+ * would find no `.d.ts` for that subpath.
  */
 export function findExportsTypeViolations(
   packageName: string,
   exportsMap: unknown,
 ): Violation[] {
   const violations: Violation[] = [];
-  if (exportsMap && typeof exportsMap === "object") {
-    for (const [subpath, entry] of Object.entries(exportsMap)) {
-      walk(entry, subpath, packageName, violations);
-    }
+  for (const [subpath, entry] of Object.entries(normalizeExports(exportsMap))) {
+    walk(entry, subpath, packageName, violations);
   }
   return violations;
 }
 
+/**
+ * Normalize Node's `exports` sugar into a `subpath -> target` map. A bare
+ * string (`"exports": "./index.mjs"`) and a conditions-only object
+ * (`{ import, require }` with no `.`/`./…` keys) are both sugar for the `.`
+ * subpath; a real subpath map is returned unchanged.
+ */
+function normalizeExports(exportsMap: unknown): Record<string, ExportsEntry> {
+  if (typeof exportsMap === "string" || Array.isArray(exportsMap)) {
+    return { ".": exportsMap as ExportsEntry };
+  }
+  if (!exportsMap || typeof exportsMap !== "object") return {};
+  const entries = exportsMap as Record<string, ExportsEntry>;
+  const isSubpathMap = Object.keys(entries).some(
+    (key) => key === "." || key.startsWith("./"),
+  );
+  return isSubpathMap ? entries : { ".": entries };
+}
+
 function walk(
-  entry: unknown,
+  entry: ExportsEntry,
   trail: string,
   packageName: string,
   out: Violation[],
@@ -67,33 +99,49 @@ function walk(
     }
     return;
   }
+  // `null` blocks a subpath; primitives are not resolvable targets.
   if (!entry || typeof entry !== "object") return;
 
-  const conditions = Object.entries(entry);
-
-  // An explicit `types` condition at this level covers this branch; just check
-  // that it points at a declaration file (`are-the-types-wrong` validates the
-  // ESM/CJS flavor separately).
-  const typesEntry = conditions.find(([condition]) => condition === "types");
-  if (typesEntry) {
-    const typesTarget = typesEntry[1];
-    if (
-      typeof typesTarget === "string" &&
-      !DECLARATION_TARGET.test(typesTarget)
-    ) {
-      out.push({
-        package: packageName,
-        subpath: `${trail} > types`,
-        reason: `"types" target "${typesTarget}" is not a declaration file`,
-      });
-    }
+  // Fallback array: TypeScript resolves the first entry that exists, so every
+  // candidate must itself be typed.
+  if (Array.isArray(entry)) {
+    entry.forEach((item, i) => walk(item, `${trail}[${i}]`, packageName, out));
     return;
   }
 
-  // No `types` here — every condition that leads to JS must carry its own.
-  for (const [condition, value] of conditions) {
+  // Conditions match in object order (first match wins), and import- and
+  // require-mode resolve independently. Validate each `types` target, and flag
+  // every JS-returning condition that is NOT preceded by a `types` (a strict
+  // resolver reaches that JS target before any later `types`). Runtime-only
+  // conditions are ignored — TypeScript resolves no types through them.
+  const conditions = Object.entries(entry);
+  const typesIndex = conditions.findIndex(
+    ([condition]) => condition === "types",
+  );
+  conditions.forEach(([condition, value], index) => {
+    if (condition === "types") {
+      if (typeof value === "string") {
+        if (!DECLARATION_TARGET.test(value)) {
+          out.push({
+            package: packageName,
+            subpath: `${trail} > types`,
+            reason: `"types" target "${value}" is not a declaration file`,
+          });
+        }
+      } else {
+        // Nested/object `types` — recurse so each resolved leaf is validated.
+        walk(value, `${trail} > types`, packageName, out);
+      }
+      return;
+    }
+    if (!JS_CONDITIONS.has(condition)) return; // runtime-only → no types needed
+    // A `types` condition earlier in object order covers this JS condition for
+    // its resolution mode.
+    if (typesIndex !== -1 && typesIndex < index) return;
+    // Otherwise the JS target must itself carry types (a nested `types`) or be
+    // a declaration file.
     walk(value, `${trail} > ${condition}`, packageName, out);
-  }
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -116,8 +164,12 @@ export function getPublishablePackagesWithExports(
   for (const name of fs.readdirSync(packagesDir).sort()) {
     const pkgJsonPath = path.join(packagesDir, name, "package.json");
     if (!fs.existsSync(pkgJsonPath)) continue;
-    const pkg: { name?: string; private?: boolean; exports?: unknown } =
-      JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
+    let pkg: { name?: string; private?: boolean; exports?: unknown };
+    try {
+      pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
+    } catch (error) {
+      throw new Error(`Failed to parse ${pkgJsonPath}`, { cause: error });
+    }
     if (pkg.private === true || !pkg.exports) continue;
     packages.push({ name: pkg.name ?? name, exports: pkg.exports });
   }


### PR DESCRIPTION
## What does this PR do?

Fixes #3324: every publishable package's `package.json` `exports` map was missing a `types` condition, so under `moduleResolution` `bundler`/`node16`/`nodenext` strict-exports tooling (e.g. the Backstage CLI) resolved no type declarations and reported every named export as "has no exported member". This adds a `types` condition first inside each `import`/`require` (ESM→`.d.mts`, CJS→`.d.cts`) — via a shared `withTypesConditions` helper wired into every tsdown config (tsdown does not emit one), and directly in the hand-maintained `react-native` map. It also adds a regression guard, because `attw` and `publint` do NOT catch this (TypeScript's adjacent-file fallback masks it locally): a validator script, unit + all-package tests, a `validate:exports` npm script, and a CI workflow that fail if any publishable package's exports map lacks a `types` condition. There are no runtime code changes — only `package.json` exports maps, tsdown build config, and the new tooling.

## Related PRs and Issues

- Fixes https://github.com/CopilotKit/CopilotKit/issues/3324

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
- [ ] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
