### PR TITLE
fix(showcase-harness): D4 probe hardening follow-ups (budget-exhaustion, degraded-path, telemetry, coverage)

### DIFF
--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -1202,6 +1202,216 @@ describe("d4 CVDIAG probe instrumentation (L1-A)", () => {
   });
 });
 
+// ── Follow-up item 4: additional coverage (no production change) ─────────────
+//
+// These tests widen coverage over paths the #5882 CR deferred as bucket-(b):
+//   - the FIFO-cap `CVDIAG_MAX_OUTSTANDING_STARTS_PER_URL` eviction backstop,
+//   - the DEBUG-auto-disarm fail-closed guard on the raw-byte capture,
+//   - the alternate-content / raw-byte block being SKIPPED on a container
+//     success (non-empty assistant text) path.
+describe("d4 follow-up coverage (item 4)", () => {
+  function bufDir(): string {
+    return mkdtempSync(join(tmpdir(), "cvdiag-cov-"));
+  }
+
+  it("FIFO-cap: a URL that accumulates > CVDIAG_MAX_OUTSTANDING_STARTS_PER_URL un-responded starts evicts the OLDEST so a later response pairs with a RECENT start", () => {
+    // A persistent SSE stream issues many same-URL requests that NEVER respond
+    // (no `response`, no `requestfailed`) — the exact leak the cap backstops.
+    // Without the cap the per-URL FIFO grows unbounded AND a much-later response
+    // shifts an ANCIENT stale start → inflated duration_ms. The cap (64) drops
+    // the oldest starts so the queue stays bounded and the eventual response
+    // pairs with a recent start (small duration).
+    const handlers = new Map<string, (arg: unknown) => void>();
+    const fakePage = {
+      goto: async () => null,
+      type: async () => {},
+      press: async () => {},
+      waitForSelector: async () => {},
+      textContent: async () => null,
+      evaluate: async <R>() => "" as unknown as R,
+      close: async () => {},
+      on(event: string, handler: (arg: unknown) => void) {
+        handlers.set(event, handler);
+      },
+    };
+    const adapted = wirePlaywrightPage(fakePage);
+    const durations: number[] = [];
+    adapted.onResponse?.((r) => durations.push(r.durationMs));
+    const reqHandler = handlers.get("request")!;
+    const respHandler = handlers.get("response")!;
+    const URL = "https://x.example.com/api/copilotkit";
+    const mkReq = () => ({ url: () => URL });
+    const mkResp = () => ({
+      url: () => URL,
+      status: () => 200,
+      headers: () => ({}),
+      request: () => ({ method: () => "POST" }),
+    });
+
+    const CAP = 64;
+    // Issue exactly CAP ANCIENT un-responded starts (a persistent SSE stream
+    // that never responds/fails).
+    for (let i = 0; i < CAP; i++) reqHandler(mkReq());
+    // Age those ancient starts with a measurable gap.
+    const gapUntil = performance.now() + 15;
+    while (performance.now() < gapUntil) {
+      /* spin */
+    }
+    // Now issue ANOTHER CAP fresh starts. Each push beyond the cap evicts the
+    // OLDEST outstanding start, so after CAP fresh pushes EVERY ancient start
+    // has been evicted and the queue holds only the fresh (recent) starts —
+    // the whole point of the backstop for requests that neither respond nor fail.
+    for (let i = 0; i < CAP; i++) reqHandler(mkReq());
+    // A response now pairs (FIFO) with the OLDEST REMAINING start — which, after
+    // the cap evicted all ancient starts, is a fresh (recent) one.
+    respHandler(mkResp());
+
+    expect(durations.length).toBe(1);
+    // The cap evicted every ancient start, so the response paired with a RECENT
+    // start → a small duration, NOT the ~15ms+ ancient gap. Without the cap the
+    // unbounded FIFO would still hold all CAP ancient starts and shift the
+    // oldest (~15ms+) here.
+    expect(durations[0]).toBeLessThan(10);
+  });
+
+  it("DEBUG auto-disarm is fail-closed: once DEBUG has disarmed, NO raw-byte sample is captured even on the class-(d) empty-response trigger", async () => {
+    // The raw-byte body capture is the most PII-sensitive path CVDIAG has; it
+    // MUST stop the instant DEBUG auto-disarms (10min / 10k-event bounds), NOT
+    // merely when `tier` flips (it never does). The driver gates capture on the
+    // LIVE `shouldEmit("aimock.sse.chunk")` (a debug-exclusive boundary), which
+    // returns false once DEBUG expires. This negative test drives a DISARMED
+    // debug emitter down the exact empty-response path that WOULD capture while
+    // armed and asserts fail-closed: zero samples.
+    const rawByteSamples: unknown[] = [];
+    const combinedWriter = {
+      async writeBatch(): Promise<void> {},
+      async writeRawByteSample(record: unknown): Promise<void> {
+        rawByteSamples.push(record);
+      },
+    };
+    const emitter = new CvdiagEmitter({
+      debug: true,
+      env: {
+        NODE_ENV: "test",
+        SHOWCASE_ENV: "test",
+        CVDIAG_DEBUG: "1",
+        CVDIAG_DEBUG_ALLOW_LIST: "foo",
+      },
+      layer: "probe",
+      pbWriter: combinedWriter as unknown as CvdiagPbWriter,
+    });
+    // Force DEBUG past its wall-clock deadline → auto-disarmed. This models
+    // "DEBUG was armed >10 minutes ago"; `shouldEmit("aimock.sse.chunk")` now
+    // returns false (fall-through to default-tier inclusion, which excludes it).
+    (emitter as unknown as { debugDeadlineMs: number }).debugDeadlineMs =
+      Date.now() - 1;
+    expect(emitter.shouldEmit("aimock.sse.chunk")).toBe(false);
+
+    const browser = makeCvBrowser({
+      // Empty assistant text → class-(d) trigger that WOULD capture while armed.
+      assistantText: "",
+      responses: [
+        {
+          url: "https://x.example.com/api/copilotkit",
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+          contentLength: 0,
+          durationMs: 4,
+          isMessagePost: true,
+          body: async () => Buffer.from("data: {}\n\n", "utf8"),
+        },
+      ],
+    });
+    const driver = createE2eSmokeDriver({
+      launcher: async () => browser as unknown as E2eBrowser,
+      textPollTimeoutMs: 50,
+      cvdiagEmitter: emitter,
+      cvdiagBufferDir: bufDir(),
+      cvdiagPbWriter: combinedWriter as unknown as CvdiagPbWriter,
+    });
+    await driver.run(baseCtx({ env: { CVDIAG_DEBUG_ALLOW_LIST: "foo" } }), {
+      key: "e2e-smoke:foo",
+      backendUrl: "https://x.example.com",
+      demos: ["agentic-chat"],
+    });
+    await emitter.flush();
+
+    // Fail-closed: DEBUG disarmed → NO raw-byte sample written.
+    expect(rawByteSamples.length).toBe(0);
+  });
+
+  it("container-success path (non-empty assistant text): the alternate-content / raw-byte capture block is SKIPPED entirely", async () => {
+    // The alternate-content histogram + raw-byte capture block is gated on
+    // `cvdiagResponseEmpty` — it exists ONLY to characterize an EMPTY-response
+    // flap (class (d)). On a genuine container success (non-empty assistant
+    // text) `cvdiagResponseEmpty` is cleared, so the whole block must be
+    // skipped: no `probe.dom.alternate_content` boundary AND no raw-byte sample,
+    // even under a DEBUG emitter that would otherwise arm capture.
+    const rawByteSamples: unknown[] = [];
+    const captured: CvdiagEnvelope[] = [];
+    const combinedWriter = {
+      async writeBatch(events: CvdiagEnvelope[]): Promise<void> {
+        captured.push(...events);
+      },
+      async writeRawByteSample(record: unknown): Promise<void> {
+        rawByteSamples.push(record);
+      },
+    };
+    const emitter = new CvdiagEmitter({
+      debug: true,
+      env: {
+        NODE_ENV: "test",
+        SHOWCASE_ENV: "test",
+        CVDIAG_DEBUG: "1",
+        CVDIAG_DEBUG_ALLOW_LIST: "foo",
+      },
+      layer: "probe",
+      pbWriter: combinedWriter as unknown as CvdiagPbWriter,
+    });
+    const browser = makeCvBrowser({
+      // Non-empty assistant text → container SUCCESS → block skipped.
+      assistantText: "Hello there, happy to help!",
+      responses: [
+        {
+          url: "https://x.example.com/api/copilotkit",
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+          contentLength: 10,
+          durationMs: 4,
+          isMessagePost: true,
+          body: async () => Buffer.from("data: {}\n\n", "utf8"),
+        },
+      ],
+    });
+    const driver = createE2eSmokeDriver({
+      launcher: async () => browser as unknown as E2eBrowser,
+      textPollTimeoutMs: 50,
+      cvdiagEmitter: emitter,
+      cvdiagBufferDir: bufDir(),
+      cvdiagPbWriter: combinedWriter as unknown as CvdiagPbWriter,
+    });
+    const result = await driver.run(
+      baseCtx({ env: { CVDIAG_DEBUG_ALLOW_LIST: "foo" } }),
+      {
+        key: "e2e-smoke:foo",
+        backendUrl: "https://x.example.com",
+        demos: ["agentic-chat"],
+      },
+    );
+    await emitter.flush();
+
+    // The turn genuinely succeeded (container had content).
+    expect(result.state).toBe("green");
+    // The empty-response-only block was skipped: no alternate-content boundary
+    // and no raw-byte capture on the success path.
+    expect(
+      captured.filter((e) => e.boundary === "probe.dom.alternate_content")
+        .length,
+    ).toBe(0);
+    expect(rawByteSamples.length).toBe(0);
+  });
+});
+
 // ── M3 CR R1: d4 probe data-correctness fixes ───────────────────────────────
 
 describe("d4 CVDIAG data-correctness (M3 CR R1)", () => {
@@ -1981,6 +2191,29 @@ function makeLateTokenBrowser(opts: {
   /** Report the interceptor as having failed to attach (finding-3 surface). */
   sseAttachFailed?: boolean;
   /**
+   * Model the DEGRADED path (item-2 follow-up): the interceptor silently
+   * no-op'd, so `readTurnState` reports `sseAttachFailed: true` AND — because the
+   * page-side turn-lifecycle globals were NEVER seeded — every counter stays at
+   * its zero/absent baseline (`runsFinished: 0`, `runStartCount: 0`,
+   * `attrPresent: false`, `sawRunningTrue: false`, `runningNow: null`). No
+   * completion signal will ever arrive, so the driver's poll can only ever fall
+   * into the never-observed branch. The DOM token still renders late (via
+   * `evaluate`, gated on `firstTokenDelayMs`), reproducing a slow-first-token
+   * turn on a page whose interceptor failed to attach — the exact false-red
+   * surface the degraded-path widening fixes.
+   */
+  degradedNoSignal?: boolean;
+  /**
+   * Model item-1 (budget-exhaustion retry guard): when set, `type`/`press`
+   * THROW if their `timeout` option is at or below this many ms — mirroring
+   * Playwright, which rejects a ~1ms action timeout. Combined with
+   * `neverComplete` (attempt 1 stalls, forcing a retry) and a `pageTimeoutMs`
+   * tuned so the retry resend fires with the budget all but drained, this
+   * reproduces the pre-fix 1ms-timeout `level-error` flap: the guarded driver
+   * must SKIP the doomed resend rather than emit a misleading level-error.
+   */
+  throwWhenTimeoutAtMost?: number;
+  /**
    * Model an SSE-ONLY completion: the turn completes via the `runsFinished`
    * transport counter bumping past baseline, but NO fresh DOM `true→false`
    * stop-edge fires for THIS turn, so `lastStoppedAtMs` keeps holding a STALE
@@ -2000,118 +2233,198 @@ function makeLateTokenBrowser(opts: {
   priorStoppedAgoMs?: number;
   /** Callback invoked with the sendCount on each send (retry-count assertions). */
   onSend?: (sendCount: number) => void;
+  /**
+   * Callback invoked at the START of every `type` action (before it may throw),
+   * with the running count of type ATTEMPTS. Counts resend ATTEMPTS even when
+   * the action then throws on a floored timeout — the discriminator for the
+   * budget-exhaustion guard (a skipped resend never attempts `type` a 2nd time).
+   */
+  onTypeAttempt?: (typeCount: number) => void;
+  /**
+   * Item-3 (telemetry re-capture): per-send agent-message-POST responses driven
+   * into the wired `onResponse` seam. Index N is delivered when the Nth `press`
+   * (send) fires, modelling each attempt's OWN message-POST response landing
+   * after its submit. Lets a retry-rescued run give attempt 0 (stalled) and
+   * attempt 1 (winning) DISTINCT edge headers so a test can assert
+   * `probe.message.send` re-captures the WINNING attempt's headers rather than
+   * staying latched to the stalled first attempt.
+   */
+  responsesPerSend?: CvdiagResponseEvent[];
 }): CvE2eBrowser {
-  let lastSendAtMs = 0;
-  let sendCount = 0;
   const completeAt = opts.completeAtDelayMs ?? 0;
   const prior = opts.priorFinishedRuns ?? 0;
-  // Realistic wall-clock ms for the PRIOR run's stop edge. Normally captured at
-  // browser construction (just before the user turn); `priorStoppedAgoMs` ages
-  // it further into the past to model a prior run that finished well before the
-  // current turn — so a pre-fix poll that (wrongly) stamps the grace window from
-  // this STALE value computes a `graceEnd` that has already elapsed, collapsing
-  // the grace window to the base floor.
-  const priorStoppedAtMs = Date.now() - (opts.priorStoppedAgoMs ?? 0);
-  const page: CvE2ePage = {
-    async goto() {
-      return null;
-    },
-    async type() {},
-    async press() {
-      // Each Enter is one turn send; the timeline is relative to the LATEST
-      // send so a resend restarts the first-token / completion clocks.
-      lastSendAtMs = Date.now();
-      sendCount += 1;
-      opts.onSend?.(sendCount);
-    },
-    async waitForSelector() {},
-    async textContent() {
-      return "";
-    },
-    async evaluate<R>(): Promise<R> {
-      // The assistant-text poll and the alternate-content histogram read both
-      // route through evaluate(). A record return is the histogram read
-      // (post-empty-exit) — return {} harmlessly. A string return is the
-      // assistant-text poll.
-      const elapsed = Date.now() - lastSendAtMs;
-      const rescued = opts.retrySucceeds === true && sendCount >= 2;
-      const tokenVisible =
-        opts.assistantText.length > 0 &&
-        elapsed >= opts.firstTokenDelayMs &&
-        // A never-completing (unrescued) turn also never renders its token.
-        (!opts.neverComplete || rescued);
-      if (tokenVisible) {
-        return opts.assistantText as unknown as R;
-      }
-      return "" as unknown as R;
-    },
-    async readTurnState() {
-      // MONOTONIC page-global counters (they only ever grow, exactly like the
-      // real `attachSseInterceptor` globals). `prior` runs already latched
-      // before the user's FIRST turn. Every send starts one run
-      // (`runStartCount = prior + sendCount`). All PRIOR sends' turns are done;
-      // the CURRENT (latest) turn is done once `complete`
-      // (`runsFinished = prior + (sendCount - 1) + (complete ? 1 : 0)`). This is
-      // what lets a shared page survive L3→L4 (two sequential sends) with the
-      // per-attempt baseline correctly scoping completion to each turn.
-      const started = sendCount > 0;
-      const priorSendsDone = Math.max(0, sendCount - 1);
-      const elapsed = Date.now() - lastSendAtMs;
-      const rescued = opts.retrySucceeds === true && sendCount >= 2;
-      // Completion is a property of the CURRENT (in-flight) turn — it can only be
-      // true once a turn has actually been sent (`started`). Before the first
-      // send, `lastSendAtMs === 0` makes `elapsed` (≈ epoch ms) spuriously exceed
-      // `completeAt`, which used to flip `complete` true at the pre-send BASELINE
-      // read the driver takes before `sendTurn()`. That inflated the baseline
-      // `runsFinished` to `prior + 1`, so the current turn's real finished edge
-      // (`prior + priorSendsDone + 1`) never rose PAST the baseline and the
-      // driver's `sseDone = runsFinished > baseline.runsFinished` could never
-      // fire — leaving the SSE-only-stale-grace path (which depends on `sseDone`)
-      // untested. Gating on `started` makes the baseline read a true baseline
-      // (`runsFinished = prior + priorSendsDone`, no current-turn finish) so the
-      // finished edge is a genuine THIS-turn transition the driver observes.
-      const complete =
-        started && (!opts.neverComplete || rescued) && elapsed >= completeAt;
-      // SSE-only completion: the transport `runsFinished` counter bumps but the
-      // DOM run-lifecycle attribute never registers a fresh `true→false` stop
-      // edge for THIS turn, so `runningNow` stays `true` and `lastStoppedAtMs`
-      // is NEVER re-stamped — it keeps holding the STALE prior-run value.
-      const sseOnly = opts.sseOnlyStaleStop === true;
-      const runningNow = started
-        ? sseOnly
-          ? true
-          : !complete
-        : prior > 0
-          ? false
-          : null;
-      return {
-        runsFinished: prior + priorSendsDone + (complete ? 1 : 0),
-        attrPresent: true,
-        sawRunningTrue: prior > 0 || started,
-        runningNow,
-        runStartCount: prior + sendCount,
-        // Current turn complete → stamp NOW; else the most-recent stop is a
-        // prior run's (a real past timestamp) when any prior run has finished.
-        // SSE-only: no fresh DOM stop edge fires, so the stamp STAYS stale.
-        lastStoppedAtMs:
-          complete && !sseOnly
-            ? Date.now()
-            : prior > 0 || priorSendsDone > 0
-              ? priorStoppedAtMs
-              : 0,
-        sseAttachFailed: opts.sseAttachFailed === true,
-      };
-    },
-    async close() {},
-  };
-  const ctx: CvE2eBrowserContext = {
-    async newPage() {
-      return page;
-    },
-    async close() {},
+  // PER-PAGE state factory. Real Playwright hands each `newContext().newPage()`
+  // an INDEPENDENT page; the driver opens a FRESH context+page per level (L3
+  // then L4). A single shared `page` singleton leaked `sendCount` /
+  // `lastSendAtMs` / `respHandler` from L3 into L4, so L4's per-attempt baseline
+  // was polluted by L3's send and the L4 retry/completion path was never
+  // genuinely exercised in isolation. Minting fresh state per `newPage()` keeps
+  // each level's turn-lifecycle clean, faithful to production.
+  const makeLateTokenPage = (): CvE2ePage => {
+    let lastSendAtMs = 0;
+    let sendCount = 0;
+    let typeCount = 0;
+    let respHandler: ((r: CvdiagResponseEvent) => void) | undefined;
+    // Realistic wall-clock ms for the PRIOR run's stop edge. Normally captured
+    // at page construction (just before the user turn); `priorStoppedAgoMs` ages
+    // it further into the past to model a prior run that finished well before the
+    // current turn — so a pre-fix poll that (wrongly) stamps the grace window
+    // from this STALE value computes a `graceEnd` that has already elapsed,
+    // collapsing the grace window to the base floor.
+    const priorStoppedAtMs = Date.now() - (opts.priorStoppedAgoMs ?? 0);
+    const page: CvE2ePage = {
+      async goto() {
+        return null;
+      },
+      async type(_sel: string, _text: string, o?: { timeout?: number }) {
+        typeCount += 1;
+        opts.onTypeAttempt?.(typeCount);
+        // Item-1 surface: Playwright rejects a near-zero action timeout. Model it
+        // so a retry resend that runs with a drained budget (floored to ~1ms)
+        // throws — the pre-fix path that mis-classified as `level-error`.
+        if (
+          opts.throwWhenTimeoutAtMost !== undefined &&
+          o?.timeout !== undefined &&
+          o.timeout <= opts.throwWhenTimeoutAtMost
+        ) {
+          throw new Error(
+            `page.type: Timeout ${o.timeout}ms exceeded waiting for selector "textarea"`,
+          );
+        }
+      },
+      async press(_sel: string, _key: string, o?: { timeout?: number }) {
+        if (
+          opts.throwWhenTimeoutAtMost !== undefined &&
+          o?.timeout !== undefined &&
+          o.timeout <= opts.throwWhenTimeoutAtMost
+        ) {
+          throw new Error(
+            `page.press: Timeout ${o.timeout}ms exceeded waiting for selector "textarea"`,
+          );
+        }
+        // Each Enter is one turn send; the timeline is relative to the LATEST
+        // send so a resend restarts the first-token / completion clocks.
+        lastSendAtMs = Date.now();
+        sendCount += 1;
+        opts.onSend?.(sendCount);
+        // Item-3: deliver THIS send's own agent-message-POST response into the
+        // wired onResponse seam (models each attempt's response landing after its
+        // submit) so a retry-rescued run can re-capture the winning attempt's
+        // edge headers.
+        const perSend = opts.responsesPerSend?.[sendCount - 1];
+        if (perSend !== undefined) respHandler?.(perSend);
+      },
+      async waitForSelector() {},
+      async textContent() {
+        return "";
+      },
+      async evaluate<R>(): Promise<R> {
+        // The assistant-text poll and the alternate-content histogram read both
+        // route through evaluate(). A record return is the histogram read
+        // (post-empty-exit) — return {} harmlessly. A string return is the
+        // assistant-text poll.
+        const elapsed = Date.now() - lastSendAtMs;
+        const rescued = opts.retrySucceeds === true && sendCount >= 2;
+        const tokenVisible =
+          opts.assistantText.length > 0 &&
+          elapsed >= opts.firstTokenDelayMs &&
+          // A never-completing (unrescued) turn also never renders its token.
+          (!opts.neverComplete || rescued);
+        if (tokenVisible) {
+          return opts.assistantText as unknown as R;
+        }
+        return "" as unknown as R;
+      },
+      async readTurnState() {
+        // DEGRADED path (item-2): the interceptor no-op'd, so the page-side
+        // globals were NEVER seeded — every counter stays at its zero/absent
+        // baseline and `sseAttachFailed` rides true. No completion signal ever
+        // arrives; only the DOM token (via `evaluate`) eventually renders.
+        if (opts.degradedNoSignal === true) {
+          return {
+            runsFinished: 0,
+            attrPresent: false,
+            sawRunningTrue: false,
+            runningNow: null,
+            runStartCount: 0,
+            lastStoppedAtMs: 0,
+            sseAttachFailed: true,
+          };
+        }
+        // MONOTONIC page-global counters (they only ever grow, exactly like the
+        // real `attachSseInterceptor` globals). `prior` runs already latched
+        // before the user's FIRST turn. Every send starts one run
+        // (`runStartCount = prior + sendCount`). All PRIOR sends' turns are done;
+        // the CURRENT (latest) turn is done once `complete`
+        // (`runsFinished = prior + (sendCount - 1) + (complete ? 1 : 0)`). This is
+        // what lets a shared page survive L3→L4 (two sequential sends) with the
+        // per-attempt baseline correctly scoping completion to each turn.
+        const started = sendCount > 0;
+        const priorSendsDone = Math.max(0, sendCount - 1);
+        const elapsed = Date.now() - lastSendAtMs;
+        const rescued = opts.retrySucceeds === true && sendCount >= 2;
+        // Completion is a property of the CURRENT (in-flight) turn — it can only be
+        // true once a turn has actually been sent (`started`). Before the first
+        // send, `lastSendAtMs === 0` makes `elapsed` (≈ epoch ms) spuriously exceed
+        // `completeAt`, which used to flip `complete` true at the pre-send BASELINE
+        // read the driver takes before `sendTurn()`. That inflated the baseline
+        // `runsFinished` to `prior + 1`, so the current turn's real finished edge
+        // (`prior + priorSendsDone + 1`) never rose PAST the baseline and the
+        // driver's `sseDone = runsFinished > baseline.runsFinished` could never
+        // fire — leaving the SSE-only-stale-grace path (which depends on `sseDone`)
+        // untested. Gating on `started` makes the baseline read a true baseline
+        // (`runsFinished = prior + priorSendsDone`, no current-turn finish) so the
+        // finished edge is a genuine THIS-turn transition the driver observes.
+        const complete =
+          started && (!opts.neverComplete || rescued) && elapsed >= completeAt;
+        // SSE-only completion: the transport `runsFinished` counter bumps but the
+        // DOM run-lifecycle attribute never registers a fresh `true→false` stop
+        // edge for THIS turn, so `runningNow` stays `true` and `lastStoppedAtMs`
+        // is NEVER re-stamped — it keeps holding the STALE prior-run value.
+        const sseOnly = opts.sseOnlyStaleStop === true;
+        const runningNow = started
+          ? sseOnly
+            ? true
+            : !complete
+          : prior > 0
+            ? false
+            : null;
+        return {
+          runsFinished: prior + priorSendsDone + (complete ? 1 : 0),
+          attrPresent: true,
+          sawRunningTrue: prior > 0 || started,
+          runningNow,
+          runStartCount: prior + sendCount,
+          // Current turn complete → stamp NOW; else the most-recent stop is a
+          // prior run's (a real past timestamp) when any prior run has finished.
+          // SSE-only: no fresh DOM stop edge fires, so the stamp STAYS stale.
+          lastStoppedAtMs:
+            complete && !sseOnly
+              ? Date.now()
+              : prior > 0 || priorSendsDone > 0
+                ? priorStoppedAtMs
+                : 0,
+          sseAttachFailed: opts.sseAttachFailed === true,
+        };
+      },
+      async close() {},
+      onResponse(h) {
+        respHandler = h;
+      },
+    };
+    return page;
   };
   return {
     async newContext() {
+      // Fresh, independent page per context (mirrors Playwright) — no
+      // cross-level state leak.
+      const page = makeLateTokenPage();
+      const ctx: CvE2eBrowserContext = {
+        async newPage() {
+          return page;
+        },
+        async close() {},
+      };
       return ctx;
     },
     async close() {},
@@ -2220,6 +2533,14 @@ describe("d4 L4 first-token wait hardening (readTurnState-driven)", () => {
     // WITHOUT a completed edge. The non-completion retry resends, and the
     // second turn renders content → GREEN. Distinguishes "never-completed"
     // (transient, retry) from "completed-empty" (real red, no retry).
+    // With the per-page state fix, L3 (agentic-chat) AND L4 (tool-rendering) each
+    // run their OWN independent stall+retry cycle on a FRESH page, so the whole
+    // run exercises both levels' retry paths genuinely (no shared sendCount
+    // short-circuit). `pageTimeoutMs` must be generous enough that a legitimate
+    // retry still clears the budget-exhaustion guard (item-1,
+    // `RETRY_MIN_BUDGET_MS` = 750ms) after attempt 0 burns roughly half the
+    // envelope — a too-tight budget would make the guard (correctly) skip the
+    // resend and the rescue would never fire.
     const { l4State, failureSummary } = await runLateToken(
       makeLateTokenBrowser({
         assistantText: "The weather in San Francisco is sunny, 72 degrees.",
@@ -2227,10 +2548,11 @@ describe("d4 L4 first-token wait hardening (readTurnState-driven)", () => {
         neverComplete: true,
         retrySucceeds: true,
       }),
+      { pageTimeoutMs: 4000 },
     );
     expect(l4State).toBe("green");
     expect(failureSummary).toBe("");
-  });
+  }, 20000);
 
   it("permanent stall (never completes, retry also stalls) FAILS", async () => {
     // A turn that never completes and never renders even after the retry is a
@@ -2381,6 +2703,225 @@ describe("d4 L4 first-token wait hardening (readTurnState-driven)", () => {
     expect(l3State).toBe("green");
     expect(failureSummary).toBe("");
   });
+
+  // ── ITEM 2 (follow-up): degraded-path floor when interceptor no-ops ─────────
+  it("degraded path (sseAttachFailed, no completion signal) with a late-but-present token → GREEN, not a base-floor false-red", async () => {
+    // The interceptor silently no-op'd: `readTurnState` reports
+    // `sseAttachFailed: true` and every turn-lifecycle counter stays at its
+    // never-seeded baseline, so the poll can only ever fall into the
+    // never-observed branch. The DOM token renders at 800ms — AFTER the base
+    // poll floor's effective fast-fail (the ~500ms poll iteration at which
+    // `now >= baseBudgetEnd(120ms)` first fires) but WELL WITHIN the 4000ms hard
+    // ceiling. The 800ms delay is chosen so the base-floor deadline bites on a
+    // poll iteration BEFORE the token is visible (the 500ms poll interval means a
+    // 300ms token would be read at the 500ms poll regardless, masking the bug).
+    //
+    // RED (pre-fix): the never-observed branch pinned the deadline to the base
+    // floor (`min(baseBudgetEnd=120ms, attemptCeiling)`), so the poll declared
+    // the container empty at the ~500ms iteration and false-red'd —
+    // reintroducing the exact slow-first-token false-red the main #5882 fix
+    // targets, just gated behind a failed interceptor attach.
+    // GREEN (post-fix): the degraded flag widens the never-observed wait to the
+    // per-attempt ceiling, so the 800ms token is captured → GREEN.
+    const { l4State, failureSummary } = await runLateToken(
+      makeLateTokenBrowser({
+        assistantText: "The weather in San Francisco is sunny, 72 degrees.",
+        firstTokenDelayMs: 800,
+        degradedNoSignal: true,
+      }),
+    );
+    expect(l4State).toBe("green");
+    expect(failureSummary).toBe("");
+  });
+
+  it("degraded path (sseAttachFailed) that produces NO content still FAILS (widening does not mask a genuine empty)", async () => {
+    // Guard against over-correction: widening the degraded wait to the ceiling
+    // must NOT convert a genuinely-empty degraded run into a false-pass. A page
+    // whose interceptor no-op'd AND which never renders any token is a real red
+    // — it just reds at the ceiling (no signal to fast-fail on) rather than the
+    // base floor.
+    const { l4State, failureSummary } = await runLateToken(
+      makeLateTokenBrowser({
+        assistantText: "",
+        firstTokenDelayMs: 300,
+        degradedNoSignal: true,
+      }),
+      { pageTimeoutMs: 800 },
+    );
+    expect(l4State).toBe("red");
+    expect(failureSummary).toContain("empty assistant response");
+  }, 10000);
+
+  // ── ITEM 4 (#4): per-page state isolation exercises L4 retry independently ──
+  it("L3 and L4 each run their OWN independent stall+retry on a fresh page (no shared-state leak)", async () => {
+    // With the pre-fix SHARED page singleton, L3's sends leaked into L4:
+    // `retrySucceeds` gates on `sendCount >= 2`, so after L3 stalled (send 1) and
+    // retried (send 2), L4 reused the same page with `sendCount` already at 2 and
+    // was rescued on its VERY FIRST send — L4's retry path was never genuinely
+    // exercised (only 3 total sends). With per-page state, each level starts at
+    // `sendCount = 0`, stalls on its own attempt 0, and rescues on its own retry
+    // → 4 total sends (2 per level). The send count is the discriminator.
+    let totalSends = 0;
+    const writer = new CapturingWriter();
+    const driver = createE2eSmokeDriver({
+      launcher: async () =>
+        makeLateTokenBrowser({
+          assistantText: "The weather in San Francisco is sunny, 72 degrees.",
+          firstTokenDelayMs: 100,
+          neverComplete: true,
+          retrySucceeds: true,
+          onSend: () => {
+            totalSends += 1;
+          },
+        }) as unknown as E2eBrowser,
+      textPollTimeoutMs: 120,
+      pageTimeoutMs: 4000,
+    });
+    const result = await driver.run(baseCtx({ writer }), {
+      key: "e2e-smoke:foo",
+      backendUrl: "https://x.example.com",
+      // Runs BOTH L3 (agentic-chat, always) and L4 (tool-rendering).
+      demos: ["tool-rendering"],
+    });
+    expect(result.state).toBe("green");
+    // Each level independently: attempt-0 stall (1 send) + retry rescue (1 send).
+    // Pre-fix leak → 3 (L4 rescued on first send from L3's carried-over count).
+    expect(totalSends).toBe(4);
+  }, 20000);
+
+  // ── ITEM 1 (follow-up): budget-exhaustion retry guard ───────────────────────
+  it("near-exhausted-budget retry is SKIPPED — no doomed ~1ms-floored resend attempt", async () => {
+    // Attempt 0 stalls (observed in-flight, never completes → the retry
+    // surface). `textPollTimeoutMs == pageTimeoutMs == 500` (one poll interval):
+    // attempt 0 polls to its per-attempt ceiling and the single 500ms poll
+    // overrun drains essentially the whole envelope, so the retry (attempt 1)
+    // would fire with the budget gone. The fake rejects any `type` whose action
+    // timeout is <= 5ms — modelling Playwright's rejection of the ~1ms timeout
+    // `sendTurn`'s `Math.max(1, hardCeiling - now)` produces once budget drains.
+    //
+    // RED (pre-fix): the retry loop unconditionally re-sent, so `sendTurn`
+    // ATTEMPTED a second `type` with a ~1ms floored timeout — a doomed action
+    // that throws a page-fault-shaped "Timeout 1ms exceeded…" error (swallowed
+    // by the fallback into a misleading empty-red, a spurious-red flap source).
+    // The discriminator is the resend ATTEMPT itself: pre-fix `type` is invoked
+    // TWICE (attempt 0 + the doomed resend).
+    // GREEN (post-fix): the budget-exhaustion guard skips the doomed resend
+    // entirely, so `type` is invoked exactly ONCE and the stall reds cleanly on
+    // its own terms ("empty assistant response") with no 1ms-timeout artifact.
+    let typeAttempts = 0;
+    const writer = new CapturingWriter();
+    const driver = createE2eSmokeDriver({
+      launcher: async () =>
+        makeLateTokenBrowser({
+          assistantText: "",
+          firstTokenDelayMs: 100,
+          neverComplete: true,
+          throwWhenTimeoutAtMost: 5,
+          onTypeAttempt: (n) => {
+            typeAttempts = n;
+          },
+        }) as unknown as E2eBrowser,
+      textPollTimeoutMs: 500,
+      pageTimeoutMs: 500,
+    });
+    const result = await driver.run(baseCtx({ writer }), {
+      key: "e2e-smoke:foo",
+      backendUrl: "https://x.example.com",
+      demos: [],
+    });
+    expect(result.state).toBe("red");
+    const chat = writer.results.find((r) => r.key === "chat:foo");
+    expect(chat?.state).toBe("red");
+    // The discriminator: the doomed ~1ms resend was NEVER attempted → `type`
+    // fired exactly once (attempt 0). Pre-fix this is 2 (the doomed resend
+    // attempts a second `type` before throwing on its floored timeout).
+    expect(typeAttempts).toBe(1);
+  }, 10000);
+});
+
+describe("d4 retry telemetry re-attribution (follow-up item 3)", () => {
+  function bufDirLt(): string {
+    return mkdtempSync(join(tmpdir(), "cvdiag-lt-"));
+  }
+
+  it("retry-rescued GREEN turn re-captures the WINNING attempt's edge headers for probe.message.send (not the stalled first attempt's)", async () => {
+    // A stall on attempt 0 (never completes → retry), rescued by attempt 1. Each
+    // attempt lands its OWN agent-message-POST response with DISTINCT edge
+    // headers. The stalled attempt's response is the CopilotKit runtime POST
+    // (isMessagePost) carrying `cf-mitigated: stalled`; the winning resend's
+    // carries `cf-mitigated: winning`.
+    //
+    // RED (pre-fix): `messageSendEdge` / `lastMessagePostResp` latched to the
+    // FIRST (stalled) attempt's response, and `emitMessageSend`'s idempotency
+    // meant the winning resend's response never re-captured them — so
+    // `probe.message.send` reported the STALLED attempt's `cf-mitigated:stalled`
+    // header, mis-attributing edge_interference to the wrong turn.
+    // GREEN (post-fix): the retry clears the latches before the resend, so the
+    // winning attempt's response re-captures them → `probe.message.send` carries
+    // `cf-mitigated: winning`.
+    const writer = new CaptureWriter();
+    const emitter = new CvdiagEmitter({
+      verbose: true,
+      env: {},
+      layer: "probe",
+      pbWriter: writer,
+    });
+    const browser = makeLateTokenBrowser({
+      assistantText: "Recovered greeting after a retry.",
+      firstTokenDelayMs: 100,
+      neverComplete: true,
+      retrySucceeds: true,
+      responsesPerSend: [
+        {
+          url: "https://x.example.com/api/copilotkit",
+          status: 200,
+          headers: { "cf-mitigated": "stalled", "content-length": "5" },
+          contentLength: 5,
+          durationMs: 3,
+          isMessagePost: true,
+        },
+        {
+          url: "https://x.example.com/api/copilotkit",
+          status: 200,
+          headers: { "cf-mitigated": "winning", "content-length": "9" },
+          contentLength: 9,
+          durationMs: 4,
+          isMessagePost: true,
+        },
+      ],
+    });
+    const driver = createE2eSmokeDriver({
+      launcher: async () => browser as unknown as E2eBrowser,
+      textPollTimeoutMs: 120,
+      pageTimeoutMs: 4000,
+      cvdiagEmitter: emitter,
+      cvdiagBufferDir: bufDirLt(),
+    });
+    const writerP = new CapturingWriter();
+    const result = await driver.run(baseCtx({ writer: writerP }), {
+      key: "e2e-smoke:foo",
+      backendUrl: "https://x.example.com",
+      // L3-only (agentic-chat) so the retry telemetry is unconfounded by an L4 level.
+      demos: [],
+    });
+    await emitter.flush();
+    expect(result.state).toBe("green");
+
+    const send = byBoundary(writer, "probe.message.send");
+    // Two real sends (stall + winning resend) → one message.send boundary per
+    // send. Pre-fix the retry never re-armed the emit latch, so only the FIRST
+    // (stalled) boundary was ever recorded (and the winning attempt's real edge
+    // headers were lost). The re-capture fix re-arms the latch on retry, so the
+    // winning resend records its OWN boundary.
+    expect(send.length).toBe(2);
+    // The FINAL (winning) boundary carries the winning attempt's edge headers,
+    // NOT the stalled first attempt's — telemetry now attributed to the turn
+    // that actually rendered content.
+    expect(send[send.length - 1]!.edge_headers["cf-mitigated"]).toBe("winning");
+    // And the stalled first attempt is still recorded on its own boundary
+    // (nothing is silently dropped).
+    expect(send[0]!.edge_headers["cf-mitigated"]).toBe("stalled");
+  }, 15000);
 });
 
 describe("wirePlaywrightPage attach-fault telemetry (finding 3)", () => {

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -2976,6 +2976,114 @@ describe("d4 L4 first-token wait hardening (readTurnState-driven)", () => {
   }, 10000);
 });
 
+describe("d4 mid-poll abort/timeout classification (follow-up)", () => {
+  function bufDirAbort(): string {
+    return mkdtempSync(join(tmpdir(), "cvdiag-abort-"));
+  }
+
+  it("mid-poll EXTERNAL abort with empty container → abort classification (errorDesc=abort, probe.exit=timeout), NOT content-red", async () => {
+    // RED (pre-fix): the external `ctx.abortSignal` fires DURING the first-token
+    // poll while the assistant container is still empty. `runAttempt` returns
+    // empty text WITHOUT throwing, the retry loop breaks, and control falls to
+    // the clean-exit path — where the level is misclassified as a generic
+    // content red `failureSummary: "empty assistant response"` with `probe.exit`
+    // outcome `err` and NO `errorDesc: "abort"`. That masquerades a teardown/
+    // abort as a CONTENT failure on the dashboard + CVDIAG.
+    //
+    // GREEN (post-fix): the aborted-AND-empty run is short-circuited to the SAME
+    // abort classification every other abort path uses — `errorDesc: "abort"`,
+    // `probe.exit` outcome `timeout` — and is NOT the content-red "empty
+    // assistant response".
+    const { emitter, writer: cvWriter } = makeCvdiagEmitter();
+    // neverComplete + a first-token delay well past the abort instant keeps the
+    // poll spinning on an OBSERVED-but-incomplete empty turn, so the abort lands
+    // mid-poll (the exact production gap). Generous pageTimeoutMs so the EXTERNAL
+    // abort — not the driver hard-timeout — is what fires first.
+    const browser = makeLateTokenBrowser({
+      assistantText: "The weather in San Francisco is sunny, 72 degrees.",
+      firstTokenDelayMs: 5000,
+      neverComplete: true,
+    });
+    const driver = createE2eSmokeDriver({
+      launcher: async () => browser as unknown as E2eBrowser,
+      textPollTimeoutMs: 4000,
+      pageTimeoutMs: 8000,
+      cvdiagEmitter: emitter,
+      cvdiagBufferDir: bufDirAbort(),
+    });
+    const resultWriter = new CapturingWriter();
+    const ac = new AbortController();
+    // Fire the external abort mid-poll (first poll iteration is ~500ms; abort at
+    // 150ms lands squarely inside `runAttempt`'s loop while the container is
+    // still empty).
+    setTimeout(() => ac.abort(), 150);
+    await driver.run(
+      baseCtx({ writer: resultWriter, abortSignal: ac.signal }),
+      {
+        key: "e2e-smoke:foo",
+        backendUrl: "https://x.example.com",
+        demos: [],
+      },
+    );
+    await emitter.flush();
+
+    const chat = resultWriter.results.find((r) => r.key === "chat:foo");
+    expect(chat?.state).toBe("red");
+    const sig = chat?.signal as
+      | { failureSummary?: string; errorDesc?: string }
+      | undefined;
+    // Classified as an abort, NOT the generic content red.
+    expect(sig?.errorDesc).toBe("abort");
+    expect(sig?.failureSummary).not.toContain("empty assistant response");
+    // probe.exit outcome is `timeout` (the abort/teardown classification every
+    // other abort path uses), NOT `err` (the content-red classification).
+    const exits = byBoundary(cvWriter, "probe.exit");
+    expect(exits.length).toBeGreaterThan(0);
+    expect(exits[0]!.metadata.terminal_outcome).toBe("timeout");
+  }, 15000);
+
+  it("OVER-CORRECTION GUARD: a genuinely-completed-EMPTY turn (NOT aborted) STAYS content-red 'empty assistant response'", async () => {
+    // The discriminator is `abortSignal.aborted`, NOT emptiness alone. A turn
+    // that actually FINISHES with no content — nothing aborted — is a real
+    // content failure and must remain the content-red "empty assistant
+    // response" with `probe.exit` outcome `err`. This proves the abort guard
+    // does not over-correct genuine content reds into abort/timeout.
+    const { emitter, writer: cvWriter } = makeCvdiagEmitter();
+    const browser = makeLateTokenBrowser({
+      assistantText: "",
+      firstTokenDelayMs: 300,
+      completeAtDelayMs: 50,
+    });
+    const driver = createE2eSmokeDriver({
+      launcher: async () => browser as unknown as E2eBrowser,
+      textPollTimeoutMs: 120,
+      pageTimeoutMs: 4000,
+      cvdiagEmitter: emitter,
+      cvdiagBufferDir: bufDirAbort(),
+    });
+    const resultWriter = new CapturingWriter();
+    // No abort signal fired — the turn completes empty on its own.
+    await driver.run(baseCtx({ writer: resultWriter }), {
+      key: "e2e-smoke:foo",
+      backendUrl: "https://x.example.com",
+      demos: [],
+    });
+    await emitter.flush();
+
+    const chat = resultWriter.results.find((r) => r.key === "chat:foo");
+    expect(chat?.state).toBe("red");
+    const sig = chat?.signal as
+      | { failureSummary?: string; errorDesc?: string }
+      | undefined;
+    // Stays the genuine content red — NOT reclassified as an abort.
+    expect(sig?.failureSummary).toContain("empty assistant response");
+    expect(sig?.errorDesc).not.toBe("abort");
+    const exits = byBoundary(cvWriter, "probe.exit");
+    expect(exits.length).toBeGreaterThan(0);
+    expect(exits[0]!.metadata.terminal_outcome).toBe("err");
+  }, 10000);
+});
+
 describe("d4 retry telemetry re-attribution (follow-up item 3)", () => {
   function bufDirLt(): string {
     return mkdtempSync(join(tmpdir(), "cvdiag-lt-"));

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -2204,6 +2204,19 @@ function makeLateTokenBrowser(opts: {
    */
   degradedNoSignal?: boolean;
   /**
+   * Model a mid-poll `readTurnState()` REJECTION (harmonization surface): every
+   * `readTurnState()` call THROWS instead of returning a snapshot. Distinct from
+   * `degradedNoSignal` (which returns a well-formed degraded snapshot) — this is
+   * the page/launcher whose read itself rejects (a transient read fault, a page
+   * mid-navigation). Pre-fix, `readBaseline`/`readTurnComplete` called it
+   * UNGUARDED (the throw escaped → spurious `level-error`) while `readDegraded`
+   * swallowed it to `false` (silent base-floor fast-fail). The `safeReadTurnState`
+   * wrapper harmonizes all three: a throw → degraded WIDEN + observable telemetry,
+   * never a spurious red. The DOM token still renders late (via `evaluate`) so a
+   * late-but-present token on a read-throwing page can be exercised.
+   */
+  throwFromReadTurnState?: boolean;
+  /**
    * Model item-1 (budget-exhaustion retry guard): when set, `type`/`press`
    * THROW if their `timeout` option is at or below this many ms — mirroring
    * Playwright, which rejects a ~1ms action timeout. Combined with
@@ -2213,6 +2226,19 @@ function makeLateTokenBrowser(opts: {
    * must SKIP the doomed resend rather than emit a misleading level-error.
    */
   throwWhenTimeoutAtMost?: number;
+  /**
+   * Model item-1 FIRST-SEND cap: the FIRST `type` action AWAITS this many ms
+   * before returning (a near-hang first-send `type`), draining the first-token
+   * envelope so the following `press`'s remaining budget drops below
+   * `RETRY_MIN_BUDGET_MS`. Pre-fix `sendTurn` then floored `press`'s timeout to
+   * ~1ms — which (with `throwWhenTimeoutAtMost`) Playwright rejects, caught as a
+   * generic `level-error` spurious red. Post-fix the first-send min-budget guard
+   * throws a DISTINCTLY-classified `SendBudgetExhaustedError`
+   * (`errorDesc: send-budget-exhausted`) instead of issuing the doomed ~1ms
+   * `press`. Applies to the first `type` only (subsequent resends are covered by
+   * the existing `RETRY_MIN_BUDGET_MS` retry guard).
+   */
+  firstTypeDelayMs?: number;
   /**
    * Model an SSE-ONLY completion: the turn completes via the `runsFinished`
    * transport counter bumping past baseline, but NO fresh DOM `true→false`
@@ -2279,6 +2305,17 @@ function makeLateTokenBrowser(opts: {
       async type(_sel: string, _text: string, o?: { timeout?: number }) {
         typeCount += 1;
         opts.onTypeAttempt?.(typeCount);
+        // Item-1 FIRST-SEND cap: the first `type` near-hangs, consuming
+        // wall-clock so the following `press`'s remaining budget drains below
+        // the min-budget floor. Only the FIRST type (attempt 0) — resends are
+        // covered by the retry budget guard.
+        if (
+          opts.firstTypeDelayMs !== undefined &&
+          typeCount === 1 &&
+          opts.firstTypeDelayMs > 0
+        ) {
+          await new Promise((r) => setTimeout(r, opts.firstTypeDelayMs));
+        }
         // Item-1 surface: Playwright rejects a near-zero action timeout. Model it
         // so a retry resend that runs with a drained budget (floored to ~1ms)
         // throws — the pre-fix path that mis-classified as `level-error`.
@@ -2336,6 +2373,14 @@ function makeLateTokenBrowser(opts: {
         return "" as unknown as R;
       },
       async readTurnState() {
+        // HARMONIZATION surface: the read itself REJECTS mid-poll (transient
+        // read fault / page mid-navigation). Every consumer must route through
+        // `safeReadTurnState` so this throw becomes a degraded-widen, never a
+        // spurious `level-error` (unguarded escape) or a silent base-floor
+        // fast-fail (swallowed to `false`).
+        if (opts.throwFromReadTurnState === true) {
+          throw new Error("readTurnState: page evaluate rejected mid-poll");
+        }
         // DEGRADED path (item-2): the interceptor no-op'd, so the page-side
         // globals were NEVER seeded — every counter stays at its zero/absent
         // baseline and `sseAttachFailed` rides true. No completion signal ever
@@ -2752,6 +2797,51 @@ describe("d4 L4 first-token wait hardening (readTurnState-driven)", () => {
     expect(failureSummary).toContain("empty assistant response");
   }, 10000);
 
+  // ── (a) HARMONIZED readTurnState() error handling ───────────────────────────
+  it("readTurnState() THROW mid-poll with a late-but-present token → GREEN (degraded widen), not a spurious level-error / base-floor false-red", async () => {
+    // The page's `readTurnState()` REJECTS on every call (a transient read fault
+    // / page mid-navigation). The DOM token still renders at 800ms — past the
+    // 120ms base poll floor but well within the 4000ms hard ceiling.
+    //
+    // RED (pre-fix): `readBaseline` (unguarded) awaited `page.readTurnState()`
+    // BEFORE the send; the rejection escaped, the driver's outer catch caught it,
+    // and the level red'd as a generic `level-error` (a spurious red) — the token
+    // was never even polled for. (Had baseline somehow survived, `readDegraded`
+    // swallowed the throw to `false`, base-floor fast-failing at ~500ms before
+    // the 800ms token — a silent false-red either way.)
+    // GREEN (post-fix): `safeReadTurnState` turns the throw into a degraded
+    // sentinel → `readDegraded` true → the never-observed wait WIDENS to the
+    // ceiling, the 800ms token is captured → GREEN, and the fault is observable
+    // (one-shot console.warn), never a silent/spurious red.
+    const { l4State, failureSummary } = await runLateToken(
+      makeLateTokenBrowser({
+        assistantText: "The weather in San Francisco is sunny, 72 degrees.",
+        firstTokenDelayMs: 800,
+        throwFromReadTurnState: true,
+      }),
+    );
+    expect(l4State).toBe("green");
+    expect(failureSummary).toBe("");
+  });
+
+  it("readTurnState() THROW mid-poll that produces NO content still FAILS (degraded widen does not mask a genuine empty)", async () => {
+    // Over-correction guard for the harmonization: a read-throwing page that
+    // ALSO never renders any token is a real red. The throw routes onto the
+    // degraded widen path (no base-floor fast-fail, no spurious level-error), so
+    // it reds at the ceiling with the genuine "empty assistant response" — the
+    // throw must not be masked into a false-PASS.
+    const { l4State, failureSummary } = await runLateToken(
+      makeLateTokenBrowser({
+        assistantText: "",
+        firstTokenDelayMs: 300,
+        throwFromReadTurnState: true,
+      }),
+      { pageTimeoutMs: 800 },
+    );
+    expect(l4State).toBe("red");
+    expect(failureSummary).toContain("empty assistant response");
+  }, 10000);
+
   // ── ITEM 4 (#4): per-page state isolation exercises L4 retry independently ──
   it("L3 and L4 each run their OWN independent stall+retry on a fresh page (no shared-state leak)", async () => {
     // With the pre-fix SHARED page singleton, L3's sends leaked into L4:
@@ -2837,6 +2927,53 @@ describe("d4 L4 first-token wait hardening (readTurnState-driven)", () => {
     // attempts a second `type` before throwing on its floored timeout).
     expect(typeAttempts).toBe(1);
   }, 10000);
+
+  it("FIRST-SEND cap: a near-hang first `type` does NOT floor `press` to ~1ms → classified send-budget-exhausted, not a generic level-error", async () => {
+    // Item-1 first-send fold: the FIRST `type` near-hangs (awaits past the whole
+    // 2000ms envelope), so by the time `press` is reached the remaining budget
+    // has fully drained — below `RETRY_MIN_BUDGET_MS` (750ms) AND to the ~1ms
+    // pre-fix floor. `pageTimeoutMs` (2000ms) exceeds `RETRY_MIN_BUDGET_MS` so the
+    // FIRST `type` itself clears the guard (a fresh envelope) — only `press`,
+    // reached after the hang, trips it. The fake rejects any `type`/`press` whose
+    // action timeout is <= 5ms (Playwright's ~1ms rejection).
+    //
+    // RED (pre-fix): `sendTurn` floored `press`'s timeout to `Math.max(1,
+    // hardCeiling - now)` ≈ 1ms; the fake threw a page-fault-shaped "Timeout 1ms
+    // exceeded…", the driver's outer catch red-classified it as a GENERIC
+    // `level-error` — a self-inflicted 1ms floor masquerading as a real page
+    // fault (spurious-red flap).
+    // GREEN (post-fix): the first-send min-budget guard throws a distinctly
+    // classified `SendBudgetExhaustedError` BEFORE issuing the doomed `press`, so
+    // the red carries `errorDesc: send-budget-exhausted` (observable + specific),
+    // never the catch-all `level-error`.
+    const writer = new CapturingWriter();
+    const driver = createE2eSmokeDriver({
+      launcher: async () =>
+        makeLateTokenBrowser({
+          assistantText: "",
+          firstTokenDelayMs: 100,
+          // First `type` eats the whole envelope so `press` drains below
+          // RETRY_MIN_BUDGET_MS (750ms) and to the ~1ms pre-fix floor.
+          firstTypeDelayMs: 2100,
+          throwWhenTimeoutAtMost: 5,
+        }) as unknown as E2eBrowser,
+      textPollTimeoutMs: 2000,
+      pageTimeoutMs: 2000,
+    });
+    const result = await driver.run(baseCtx({ writer }), {
+      key: "e2e-smoke:foo",
+      backendUrl: "https://x.example.com",
+      demos: [],
+    });
+    expect(result.state).toBe("red");
+    const chat = writer.results.find((r) => r.key === "chat:foo");
+    expect(chat?.state).toBe("red");
+    const errorDesc = (chat?.signal as { errorDesc?: string } | undefined)
+      ?.errorDesc;
+    // The discriminator: a distinct, observable classification — NOT the generic
+    // `level-error` a floored-1ms `press` throw produced pre-fix.
+    expect(errorDesc).toBe("send-budget-exhausted");
+  }, 10000);
 });
 
 describe("d4 retry telemetry re-attribution (follow-up item 3)", () => {
@@ -2921,6 +3058,66 @@ describe("d4 retry telemetry re-attribution (follow-up item 3)", () => {
     // And the stalled first attempt is still recorded on its own boundary
     // (nothing is silently dropped).
     expect(send[0]!.edge_headers["cf-mitigated"]).toBe("stalled");
+  }, 15000);
+
+  it("retry whose WINNING resend lands NO POST does NOT emit a second NULL-header probe.message.send (single correct attribution)", async () => {
+    // Item-3 null-header double-boundary fold. Attempt 0 stalls (never completes
+    // → retry) and lands a REAL agent-message POST (`cf-mitigated: real`). The
+    // winning resend rescues (renders content → GREEN) but lands NO POST at all
+    // (`responsesPerSend[1]` is absent).
+    //
+    // RED (pre-fix): the retry reset `messageSendEmitted = false` AND cleared
+    // `messageSendEdge`, so the `finally`-block fallback `emitMessageSend()` fired
+    // a SECOND `probe.message.send` boundary with NULL edge headers — a phantom
+    // null-header turn that mis-attributes `edge_interference_signal`.
+    // GREEN (post-fix): `messageSendRealPostEmitted` (set when the attempt-0 real
+    // POST emitted) SUPPRESSES the null-header fallback, so exactly ONE boundary
+    // survives — the real attempt-0 capture. No second null-header emit.
+    const writer = new CaptureWriter();
+    const emitter = new CvdiagEmitter({
+      verbose: true,
+      env: {},
+      layer: "probe",
+      pbWriter: writer,
+    });
+    const browser = makeLateTokenBrowser({
+      assistantText: "Recovered greeting after a retry.",
+      firstTokenDelayMs: 100,
+      neverComplete: true,
+      retrySucceeds: true,
+      // Attempt 0 lands a real POST; the winning resend (index 1) lands NONE.
+      responsesPerSend: [
+        {
+          url: "https://x.example.com/api/copilotkit",
+          status: 200,
+          headers: { "cf-mitigated": "real", "content-length": "5" },
+          contentLength: 5,
+          durationMs: 3,
+          isMessagePost: true,
+        },
+      ],
+    });
+    const driver = createE2eSmokeDriver({
+      launcher: async () => browser as unknown as E2eBrowser,
+      textPollTimeoutMs: 120,
+      pageTimeoutMs: 4000,
+      cvdiagEmitter: emitter,
+      cvdiagBufferDir: bufDirLt(),
+    });
+    const writerP = new CapturingWriter();
+    const result = await driver.run(baseCtx({ writer: writerP }), {
+      key: "e2e-smoke:foo",
+      backendUrl: "https://x.example.com",
+      demos: [],
+    });
+    await emitter.flush();
+    expect(result.state).toBe("green");
+
+    const send = byBoundary(writer, "probe.message.send");
+    // Exactly ONE boundary — the real attempt-0 capture. Pre-fix: 2 (the second a
+    // spurious NULL-header emit from the finally fallback after the retry re-arm).
+    expect(send.length).toBe(1);
+    expect(send[0]!.edge_headers["cf-mitigated"]).toBe("real");
   }, 15000);
 });
 

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -472,6 +472,140 @@ describe("e2eChatToolsDriver error paths", () => {
   });
 });
 
+// --- Aggregate errorDesc propagation (follow-up hardening) --------------
+//
+// The PRIMARY dashboard tick `e2e-smoke:<slug>` returns from the aggregate
+// normal path. `runLevel` RETURNS (not throws) reds that carry an
+// `errorDesc` — the abort-before-start / mid-poll-abort guards ("abort"), the
+// hard-timeout poll exit ("timeout"), and the `SendBudgetExhaustedError`
+// classification ("send-budget-exhausted"). Those classifiers were preserved
+// on the side `chat:`/`tools:` rows but DROPPED on the aggregate, so an
+// aborted/timed-out/budget red showed on the primary tick as an unclassified
+// content-shaped red. These pin the classifier being carried through.
+describe("e2eChatToolsDriver aggregate errorDesc propagation", () => {
+  it("aborted L3 → aggregate carries errorDesc:'abort' (matching the side chat: row), NOT an unclassified content red", async () => {
+    // A pre-aborted `ctx.abortSignal` makes L3's runLevel RETURN a red whose
+    // level signal already carries `errorDesc:"abort"`. Pre-fix the aggregate
+    // dropped it (unclassified content-shaped red on the primary tick); the
+    // fix threads the failing level's classifier through.
+    const ac = new AbortController();
+    ac.abort();
+    const { browser } = makeBrowser([{ assistantText: "" }]);
+    const driver = createE2eSmokeDriver({
+      launcher: async () => browser,
+      textPollTimeoutMs: 50,
+    });
+    const writer = new CapturingWriter();
+    const result = await driver.run(
+      baseCtx({ writer, abortSignal: ac.signal }),
+      {
+        key: "e2e-smoke:foo",
+        backendUrl: "https://x.example.com",
+      },
+    );
+    expect(result.state).toBe("red");
+    const sig = result.signal as E2eSmokePackageSignal;
+    expect(sig.shape).toBe("package");
+    expect(sig.l3).toBe("red");
+    // The PRIMARY tick now carries the classifier…
+    expect(sig.errorDesc).toBe("abort");
+    // …matching the side chat: row (which always kept it).
+    const chat = writer.results.find((r) => r.key === "chat:foo");
+    const chatSig = chat?.signal as E2eSmokeLevelSignal;
+    expect(chatSig.errorDesc).toBe("abort");
+  });
+
+  it("over-correction guard: a genuinely-completed-EMPTY (non-aborted) L3 red stays a content red on the aggregate — NO spurious errorDesc", async () => {
+    // A turn that finished and produced no assistant content is a REAL content
+    // failure; its level signal carries no `errorDesc`. The aggregate must NOT
+    // invent one — only carry a classifier the failing level actually set.
+    const { browser } = makeBrowser([{ assistantText: "" }]);
+    const driver = createE2eSmokeDriver({
+      launcher: async () => browser,
+      textPollTimeoutMs: 50,
+    });
+    const result = await driver.run(baseCtx(), {
+      key: "e2e-smoke:foo",
+      backendUrl: "https://x.example.com",
+    });
+    expect(result.state).toBe("red");
+    const sig = result.signal as E2eSmokePackageSignal;
+    expect(sig.l3).toBe("red");
+    expect(sig.failureSummary).toMatch(/L3:/);
+    // Content red — no classifier fabricated.
+    expect(sig.errorDesc).toBeUndefined();
+  });
+});
+
+// --- Aborted-empty short-circuit ordering vs alternate-content reads ----
+//
+// The aborted-and-empty short-circuit runs BEFORE the alternate-content /
+// raw-byte `evaluate` reads: an aborted run's page is tearing down, so those
+// reads would be swallowed against a dead page and emit an ambiguous empty
+// histogram. A non-aborted empty run still performs the alternate-content
+// salvage.
+describe("e2eChatToolsDriver aborted-empty short-circuit ordering", () => {
+  function bufDir(): string {
+    return mkdtempSync(join(tmpdir(), "cvdiag-reorder-"));
+  }
+
+  it("aborted-and-empty run bails at the short-circuit BEFORE the alternate-content read (no probe.dom.alternate_content)", async () => {
+    const { emitter, writer } = makeCvdiagEmitter();
+    const ac = new AbortController();
+    const browser = makeCvBrowser({
+      assistantText: "",
+      alternateHistogram: { pre: 1, code: 2 },
+      // Fire the external abort on the first assistant-text read so the run is
+      // aborted-AND-empty when it reaches the short-circuit.
+      abortOnFirstEvaluate: ac,
+    });
+    const driver = createE2eSmokeDriver({
+      launcher: async () => browser as unknown as E2eBrowser,
+      textPollTimeoutMs: 50,
+      cvdiagEmitter: emitter,
+      cvdiagBufferDir: bufDir(),
+    });
+    const result = await driver.run(baseCtx({ abortSignal: ac.signal }), {
+      key: "e2e-smoke:foo",
+      backendUrl: "https://x.example.com",
+      demos: ["agentic-chat"],
+    });
+    await emitter.flush();
+
+    // The aborted level is classified as abort, not a content red.
+    const sig = result.signal as E2eSmokePackageSignal;
+    expect(sig.l3).toBe("red");
+    expect(sig.errorDesc).toBe("abort");
+    // The alternate-content read was SKIPPED — the short-circuit bailed first.
+    expect(byBoundary(writer, "probe.dom.alternate_content").length).toBe(0);
+  });
+
+  it("non-aborted empty run still performs the alternate-content salvage (reorder preserves it)", async () => {
+    const { emitter, writer } = makeCvdiagEmitter();
+    const browser = makeCvBrowser({
+      assistantText: "",
+      alternateHistogram: { pre: 1, code: 2 },
+      // No abort → falls through the short-circuit to the salvage block.
+    });
+    const driver = createE2eSmokeDriver({
+      launcher: async () => browser as unknown as E2eBrowser,
+      textPollTimeoutMs: 50,
+      cvdiagEmitter: emitter,
+      cvdiagBufferDir: bufDir(),
+    });
+    await driver.run(baseCtx(), {
+      key: "e2e-smoke:foo",
+      backendUrl: "https://x.example.com",
+      demos: ["agentic-chat"],
+    });
+    await emitter.flush();
+
+    const alt = byBoundary(writer, "probe.dom.alternate_content");
+    expect(alt.length).toBeGreaterThan(0);
+    expect(alt[0]!.metadata.child_type_histogram).toEqual({ pre: 1, code: 2 });
+  });
+});
+
 // --- Side-emit / writer plumbing ----------------------------------------
 
 describe("e2eChatToolsDriver side-emits", () => {
@@ -824,6 +958,14 @@ interface CvPageScript {
   consoleMessages?: CvdiagConsoleEvent[];
   /** SSE events delivered to the onSseEvent seam after goto. */
   sseEvents?: CvdiagSseEvent[];
+  /**
+   * When set, fire this controller's abort on the FIRST assistant-text
+   * `evaluate` read — models a mid-poll external abort (`ctx.abortSignal`
+   * firing) that leaves the response empty. The retry loop then breaks on
+   * `abortSignal.aborted` and control reaches the aborted-and-empty
+   * short-circuit before the alternate-content reads.
+   */
+  abortOnFirstEvaluate?: AbortController;
 }
 
 /**
@@ -858,6 +1000,9 @@ function makeCvBrowser(script: CvPageScript): CvE2eBrowser {
       // assistant-text read (which the driver runs post-submit).
       if (evaluateCall === 1) {
         for (const r of script.responsesAfterSubmit ?? []) respHandler?.(r);
+        // Mid-poll external abort: fire on the first assistant-text read so the
+        // response stays empty and the retry loop breaks on the aborted signal.
+        script.abortOnFirstEvaluate?.abort();
       }
       // First evaluate call(s): assistant-message text read. The
       // alternate-content read happens AFTER the poll loop, on empty exit.

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -2415,6 +2415,46 @@ async function runLevel(opts: {
       }
     }
 
+    // Aborted/timed-out-EMPTY guard. A mid-poll abort — the external
+    // `ctx.abortSignal` firing, OR the driver's own hard-timeout landing —
+    // makes `runAttempt` return with empty text WITHOUT throwing: the retry
+    // loop breaks (`abortSignal.aborted`) and control falls here to the clean
+    // exit. Classifying that as the generic content-red "empty assistant
+    // response" (`probe.exit` outcome `err`, no `errorDesc`) masquerades a
+    // teardown/abort/timeout as a CONTENT failure on the dashboard + CVDIAG.
+    // Every OTHER abort/timeout path (the abort-before-start early return, the
+    // outer catch, the aggregate) classifies it as `errorDesc: "abort"` with a
+    // `timeout` outcome; this poll-exit path was the gap. Short-circuit to the
+    // SAME classification BEFORE the content-red gate.
+    //
+    // Discriminator is `abortSignal.aborted`, NOT emptiness alone: a
+    // genuinely-completed-EMPTY turn (the turn finished, nothing was aborted)
+    // is a real content failure and MUST stay the content-red "empty assistant
+    // response" below. Only an aborted-AND-empty run is re-classified here.
+    // (Inside `runLevel` the single `abortSignal` conflates external abort and
+    // the driver hard-timeout — the same conflation the two other in-module
+    // abort paths carry — so this mirrors their `errorDesc: "abort"` / `timeout`
+    // outcome exactly rather than inventing a new classifier.)
+    if (abortSignal.aborted && responseText.length === 0) {
+      cvdiagExit(cvdiag, "timeout");
+      cvdiagExited = true;
+      return {
+        result: {
+          key: `${level}:${slug}`,
+          state: "red",
+          signal: {
+            slug,
+            backendUrl,
+            level,
+            failureSummary: "aborted during response poll",
+            errorDesc: "abort",
+          },
+          observedAt: now().toISOString(),
+        },
+        edgeHeaders: messageSendEdge,
+      };
+    }
+
     const assertion = assertResponse({
       text: responseText,
       fromAssistantContainer,

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -1379,6 +1379,7 @@ export function createE2eSmokeDriver(
 
         let l4State: "green" | "red" | "skipped" = "skipped";
         let l4Summary = "";
+        let l4ErrorDesc: string | undefined;
         if (hasToolRendering) {
           const l4 = await runLevel({
             browser,
@@ -1422,6 +1423,7 @@ export function createE2eSmokeDriver(
           });
           l4State = l4.result.state === "green" ? "green" : "red";
           l4Summary = l4.result.signal.failureSummary;
+          l4ErrorDesc = l4.result.signal.errorDesc;
           if (ctx.writer) {
             try {
               await ctx.writer.write({
@@ -1456,6 +1458,26 @@ export function createE2eSmokeDriver(
               1200,
             );
 
+        // Carry the failing level's classifier (`errorDesc`) onto the PRIMARY
+        // aggregate tick. `runLevel` RETURNS (not throws) reds that already
+        // carry an `errorDesc` — the mid-poll abort guard (`"abort"`), the
+        // hard-timeout poll exit (`"timeout"`), the `SendBudgetExhaustedError`
+        // classification (`"send-budget-exhausted"`). Those classifiers were
+        // preserved on the side `chat:`/`tools:` rows (which side-emit the raw
+        // per-level signal) but DROPPED here, so an abort/timeout/budget red
+        // showed on `e2e-smoke:<slug>` as an unclassified content-shaped red.
+        // Thread the classifier through so the primary tick matches the side
+        // row and the launcher-phase abort path. L3 (the primary chat level)
+        // takes precedence; fall back to L4 when only tools went red. This does
+        // NOT change what counts as red/green — it only carries the classifier.
+        const aggregateErrorDesc = aggregateGreen
+          ? undefined
+          : l3State === "red"
+            ? l3.result.signal.errorDesc
+            : l4State === "red"
+              ? l4ErrorDesc
+              : undefined;
+
         return {
           key: input.key,
           state: aggregateGreen ? "green" : "red",
@@ -1466,6 +1488,9 @@ export function createE2eSmokeDriver(
             l3: l3State,
             l4: l4State,
             failureSummary,
+            ...(aggregateErrorDesc !== undefined
+              ? { errorDesc: aggregateErrorDesc }
+              : {}),
           },
           observedAt,
         };
@@ -2346,6 +2371,52 @@ async function runLevel(opts: {
     // boundary is recorded even on a nav/send throw path that skips this clean
     // exit — see the `finally` block. Idempotent via `emitMessageSend`.
 
+    // Aborted/timed-out-EMPTY guard. A mid-poll abort — the external
+    // `ctx.abortSignal` firing, OR the driver's own hard-timeout landing —
+    // makes `runAttempt` return with empty text WITHOUT throwing: the retry
+    // loop breaks (`abortSignal.aborted`) and control falls here to the clean
+    // exit. Classifying that as the generic content-red "empty assistant
+    // response" (`probe.exit` outcome `err`, no `errorDesc`) masquerades a
+    // teardown/abort/timeout as a CONTENT failure on the dashboard + CVDIAG.
+    // Every OTHER abort/timeout path (the abort-before-start early return, the
+    // outer catch, the aggregate) classifies it as `errorDesc: "abort"` with a
+    // `timeout` outcome; this poll-exit path was the gap. Short-circuit to the
+    // SAME classification BEFORE the content-red gate.
+    //
+    // Discriminator is `abortSignal.aborted`, NOT emptiness alone: a
+    // genuinely-completed-EMPTY turn (the turn finished, nothing was aborted)
+    // is a real content failure and MUST stay the content-red "empty assistant
+    // response" below. Only an aborted-AND-empty run is re-classified here.
+    // (Inside `runLevel` the single `abortSignal` conflates external abort and
+    // the driver hard-timeout — the same conflation the two other in-module
+    // abort paths carry — so this mirrors their `errorDesc: "abort"` / `timeout`
+    // outcome exactly rather than inventing a new classifier.)
+    //
+    // Ordered BEFORE the alternate-content / raw-byte reads below: an aborted
+    // run's page is tearing down, so those `evaluate` reads would be swallowed
+    // against a dead page and emit an ambiguous empty histogram. Bailing here
+    // first skips them. Non-aborted runs fall through and still perform the
+    // alternate-content salvage.
+    if (abortSignal.aborted && responseText.length === 0) {
+      cvdiagExit(cvdiag, "timeout");
+      cvdiagExited = true;
+      return {
+        result: {
+          key: `${level}:${slug}`,
+          state: "red",
+          signal: {
+            slug,
+            backendUrl,
+            level,
+            failureSummary: "aborted during response poll",
+            errorDesc: "abort",
+          },
+          observedAt: now().toISOString(),
+        },
+        edgeHeaders: messageSendEdge,
+      };
+    }
+
     // probe.dom.alternate_content — on a clean exit whose assistant text is
     // still empty (the d4 flap surface, class (d)): snapshot the child-element
     // type histogram of the assistant-message container so a markdown widget /
@@ -2413,46 +2484,6 @@ async function runLevel(opts: {
           // throw into the probe it observes (spec §7 R5-F8).
         }
       }
-    }
-
-    // Aborted/timed-out-EMPTY guard. A mid-poll abort — the external
-    // `ctx.abortSignal` firing, OR the driver's own hard-timeout landing —
-    // makes `runAttempt` return with empty text WITHOUT throwing: the retry
-    // loop breaks (`abortSignal.aborted`) and control falls here to the clean
-    // exit. Classifying that as the generic content-red "empty assistant
-    // response" (`probe.exit` outcome `err`, no `errorDesc`) masquerades a
-    // teardown/abort/timeout as a CONTENT failure on the dashboard + CVDIAG.
-    // Every OTHER abort/timeout path (the abort-before-start early return, the
-    // outer catch, the aggregate) classifies it as `errorDesc: "abort"` with a
-    // `timeout` outcome; this poll-exit path was the gap. Short-circuit to the
-    // SAME classification BEFORE the content-red gate.
-    //
-    // Discriminator is `abortSignal.aborted`, NOT emptiness alone: a
-    // genuinely-completed-EMPTY turn (the turn finished, nothing was aborted)
-    // is a real content failure and MUST stay the content-red "empty assistant
-    // response" below. Only an aborted-AND-empty run is re-classified here.
-    // (Inside `runLevel` the single `abortSignal` conflates external abort and
-    // the driver hard-timeout — the same conflation the two other in-module
-    // abort paths carry — so this mirrors their `errorDesc: "abort"` / `timeout`
-    // outcome exactly rather than inventing a new classifier.)
-    if (abortSignal.aborted && responseText.length === 0) {
-      cvdiagExit(cvdiag, "timeout");
-      cvdiagExited = true;
-      return {
-        result: {
-          key: `${level}:${slug}`,
-          state: "red",
-          signal: {
-            slug,
-            backendUrl,
-            level,
-            failureSummary: "aborted during response poll",
-            errorDesc: "abort",
-          },
-          observedAt: now().toISOString(),
-        },
-        edgeHeaders: messageSendEdge,
-      };
     }
 
     const assertion = assertResponse({

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -199,7 +199,15 @@ export interface E2eSmokeLevelSignal {
  *                      completion instant, NOT this field — it is a page-clock
  *                      stamp and can hold a stale prior-run value on an SSE-only
  *                      completion; feeding it into Node-clock math collapses the
- *                      grace window. Retained for other TurnState consumers.
+ *                      grace window. RETAINED (not dead code) even though d4 only
+ *                      ever WRITES it: this field mirrors the SHARED
+ *                      `attachSseInterceptor` page-side global (`sse-interceptor.ts`
+ *                      stamps `__hk_copilotRunning.lastStoppedAtMs` on every DOM
+ *                      stop edge) that the d6 run-signal snapshot
+ *                      (`conversation-runner.ts` `CopilotRunningState`) also reads.
+ *                      Dropping it from d4's `TurnState` would diverge d4's
+ *                      snapshot shape from that shared interceptor contract; it
+ *                      stays for shared-global parity, not for d4's own use.
  *   - `sseAttachFailed` true iff `attachSseInterceptor` THREW during `goto`, so
  *                      the page-side turn-lifecycle globals were never seeded
  *                      and the poll silently degraded to the base-floor
@@ -513,6 +521,20 @@ const FIRST_TOKEN_FAST_FAIL_MS = 15_000;
  * the retry envelope (see `runLevel`'s per-attempt ceiling arithmetic).
  */
 const NON_COMPLETION_RETRY_LIMIT = 1;
+
+/**
+ * Minimum remaining wall-clock budget (ms) required to ATTEMPT a non-completion
+ * retry resend. A resend runs late in the first-token envelope; once
+ * `hardCeiling - now` drops below this floor, `sendTurn`'s
+ * `Math.max(1, hardCeiling - Date.now())` would clamp the type/press action
+ * timeout to ~1ms — which Playwright throws on, and the driver's outer catch
+ * red-classifies as a generic `level-error`, indistinguishable from a real page
+ * fault (a spurious-red flap source). Below this floor the retry is skipped and
+ * the prior attempt's stall reds on its own terms instead. Set to one poll
+ * interval (500ms) plus headroom so a resend only fires when there is real
+ * budget left to observe its result.
+ */
+const RETRY_MIN_BUDGET_MS = 750;
 
 /**
  * The slice of Playwright's `Page` the launcher adapter consumes. Declared
@@ -1894,12 +1916,39 @@ async function runLevel(opts: {
       // still in-flight or just completed — distinguishing "still streaming" /
       // "completed empty" / "never completed" / "no turn". `baseline` scopes the
       // completion test to THIS turn (see `readTurnComplete`).
+      // Is the SSE interceptor known to have failed to attach for THIS page?
+      // When true, `attachSseInterceptor` threw during `goto`, so the page-side
+      // turn-lifecycle globals were never seeded and `readTurnComplete` can
+      // NEVER report `observed`/`complete` — every poll falls into the
+      // never-observed branch. That would pin the deadline to the base floor
+      // (`textPollTimeoutMs`), reintroducing exactly the slow-first-token
+      // false-red the main fix targets: a late-but-present token that arrives
+      // after the base floor but before the hard ceiling would be missed.
+      // `undefined` seam → treated as NOT degraded (a fake that doesn't model
+      // the turn lifecycle is a legitimate no-signal case, not an attach
+      // failure). Read once per attempt (the flag is latched at `goto` time and
+      // never changes within a level).
+      const readDegraded = async (): Promise<boolean> => {
+        if (page?.readTurnState === undefined) return false;
+        try {
+          return (await page.readTurnState()).sseAttachFailed === true;
+        } catch {
+          return false;
+        }
+      };
       const runAttempt = async (
         attemptCeiling: number,
         baseline: { runsFinished: number; runStartCount: number },
       ): Promise<{ text: string; completed: boolean; observed: boolean }> => {
         const attemptStart = Date.now();
         const baseBudgetEnd = attemptStart + textPollTimeoutMs;
+        // Degraded path: the interceptor silently no-op'd (attach failed), so no
+        // completion signal will EVER arrive. Widen the never-observed wait to
+        // the per-attempt ceiling (the hard budget) instead of the base floor so
+        // a missing interceptor doesn't cause a false-red on a late-but-present
+        // token. On a healthy page (`degraded === false`) the never-observed
+        // branch keeps its base-floor semantics (dead/no-turn run fails fast).
+        const degraded = await readDegraded();
         let completeAtMs: number | undefined;
         let everObserved = false;
         // eslint-disable-next-line no-constant-condition
@@ -1960,6 +2009,14 @@ async function runLevel(opts: {
             );
           } else if (everObserved) {
             deadline = attemptCeiling;
+          } else if (degraded) {
+            // Degraded path: the interceptor never seeded the turn-lifecycle
+            // globals, so NO completion signal will ever arrive and `everObserved`
+            // can never flip. Widen the wait to the per-attempt ceiling (the hard
+            // budget) so a late-but-present first token still lands inside the
+            // window — instead of pinning to the base floor and false-redding a
+            // slow-first-token turn just because the interceptor no-op'd.
+            deadline = attemptCeiling;
           } else {
             // No turn observed → base budget floor, but NEVER past the
             // per-attempt ceiling (which is itself bounded by `pageTimeoutMs`).
@@ -1998,6 +2055,16 @@ async function runLevel(opts: {
       for (let attempt = 0; attempt < maxAttempts; attempt++) {
         if (abortSignal.aborted) break;
         if (attempt > 0) {
+          // Budget-exhaustion guard. A retry resend runs LATE in the envelope;
+          // if the remaining budget has all but drained, `sendTurn`'s
+          // `Math.max(1, hardCeiling - Date.now())` would floor the type/press
+          // action timeout to ~1ms, which Playwright throws on — and that throw
+          // is caught below as a generic `level-error`, indistinguishable from a
+          // real page fault (a spurious-red flap source). When too little budget
+          // remains to run a meaningful resend, SKIP the retry and fall through
+          // to the normal red path (the prior attempt's stall is reported on its
+          // own terms) rather than emitting a misleading 1ms-timeout error.
+          if (hardCeiling - Date.now() < RETRY_MIN_BUDGET_MS) break;
           // Non-completion retry: the prior attempt's turn was observed
           // in-flight but never signalled completion (stalled/dropped stream).
           // Re-baseline BEFORE the resend (SAME ordering rationale as attempt 0)
@@ -2005,6 +2072,18 @@ async function runLevel(opts: {
           // past the STALL's already-latched counters — a stale prior edge can
           // never satisfy the retry.
           attemptBaseline = await readBaseline();
+          // Re-arm the message-POST edge-header capture for THIS (winning)
+          // attempt: `messageSendEdge` / `lastMessagePostResp` were latched to
+          // the FIRST (stalled) attempt's POST response, so a retry-rescued GREEN
+          // turn would otherwise mis-attribute `probe.message.send` /
+          // `edge_interference_signal` / the DEBUG raw-byte sample to the stalled
+          // attempt. Clearing them (and the `emitMessageSend` idempotency latch)
+          // lets the resend's own POST response re-capture the real winning-turn
+          // edge headers. `emitMessageSend` still fires at most once PER LEVEL
+          // (the finally-block fallback covers a retry whose POST never lands).
+          messageSendEdge = undefined;
+          lastMessagePostResp = undefined;
+          messageSendEmitted = false;
           await sendTurn();
         }
         // Split the REMAINING budget evenly across the remaining attempts so the

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -133,8 +133,8 @@ type E2eSmokeDriverInput = z.infer<typeof inputSchema>;
  * against `/demos/*`. `l3` is `green` or `red`; `l4` can also be
  * `skipped` when the registry entry has no `tool-rendering` demo. A
  * red row may carry an `errorDesc` keyed to the failure class
- * (`launcher-error`, `timeout`, `driver-error`, or absent when the
- * failure lives in `failureSummary`).
+ * (`launcher-error`, `timeout`, `driver-error`, `abort`, or absent when
+ * the failure lives in `failureSummary`).
  */
 export type E2eSmokeSignal = E2eSmokePackageSignal;
 
@@ -535,6 +535,75 @@ const NON_COMPLETION_RETRY_LIMIT = 1;
  * budget left to observe its result.
  */
 const RETRY_MIN_BUDGET_MS = 750;
+
+/**
+ * Minimum wall-clock budget (ms) required to issue the `press` that FOLLOWS
+ * `type` within a single send. This is the in-send analogue of
+ * `RETRY_MIN_BUDGET_MS` (which gates whole resends BETWEEN attempts): item-1's
+ * first-send cap. A near-hang `type` drains the envelope, so the following
+ * `press`'s `Math.max(1, hardCeiling - now)` floors to ~1ms — a doomed action
+ * Playwright rejects, which the outer catch then mis-classifies as a generic
+ * `level-error`. Below this floor `sendTurn` throws a distinctly-classified
+ * `SendBudgetExhaustedError` instead of issuing the doomed `press`.
+ *
+ * Deliberately MUCH smaller than `RETRY_MIN_BUDGET_MS`: this gates a single
+ * already-in-progress action (only the ~1ms-floor danger zone matters), NOT
+ * whether a fresh resend is worth attempting — so a legitimately-small envelope
+ * (`pageTimeoutMs` well under `RETRY_MIN_BUDGET_MS`) still issues a healthy
+ * first `press`. Set to a handful of poll intervals so a press with real
+ * remaining budget is never refused, while a hang-drained (~0ms) press is.
+ */
+const SEND_PRESS_MIN_BUDGET_MS = 50;
+
+/**
+ * Thrown by `sendTurn` when too little wall-clock budget remains to issue a
+ * `type`/`press` action with a MEANINGFUL timeout — i.e. the remaining budget
+ * to `hardCeiling` has dropped below `RETRY_MIN_BUDGET_MS`, so
+ * `Math.max(1, hardCeiling - now)` would floor the Playwright action timeout to
+ * ~1ms. A ~1ms `type`/`press` timeout is a doomed action Playwright rejects
+ * with a page-fault-shaped "Timeout 1ms exceeded…" message; the driver's outer
+ * catch would then red-classify it as a GENERIC `level-error`,
+ * indistinguishable from a real page fault — a spurious-red flap source. The
+ * retry path guards whole resends with `RETRY_MIN_BUDGET_MS` BEFORE resending;
+ * `sendTurn` guards the in-send `press` with `SEND_PRESS_MIN_BUDGET_MS` (a
+ * near-hang `type` can drain the budget so the following `press` would floor to
+ * ~1ms). Carrying a distinct
+ * `errorDesc` (duck-typed in the outer catch, mirroring the
+ * `TurnNotCompleteError.reason` decoupling) classifies the failure as
+ * `send-budget-exhausted` — an OBSERVABLE, non-`level-error` red — rather than
+ * masquerading a self-inflicted 1ms floor as a generic page fault.
+ */
+class SendBudgetExhaustedError extends Error {
+  readonly errorDesc = "send-budget-exhausted" as const;
+  constructor(action: "type" | "press", remainingMs: number, minMs: number) {
+    super(
+      `send-turn ${action} skipped: ${remainingMs}ms budget remaining ` +
+        `(< ${minMs}ms min) would floor the action timeout to ~1ms`,
+    );
+    this.name = "SendBudgetExhaustedError";
+  }
+}
+
+/**
+ * Duck-typed extractor for a `SendBudgetExhaustedError`'s distinct `errorDesc`
+ * (`send-budget-exhausted`), returning `undefined` for any other throw. Kept
+ * structural (a `readonly errorDesc` field check) rather than an `instanceof`
+ * so the outer catch stays decoupled from the concrete class — the SAME
+ * decoupling rationale as `turnCompleteReason`'s `reason`-field duck-type.
+ */
+function sendBudgetErrorDesc(
+  err: unknown,
+): "send-budget-exhausted" | undefined {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    "errorDesc" in err &&
+    (err as { errorDesc?: unknown }).errorDesc === "send-budget-exhausted"
+  ) {
+    return "send-budget-exhausted";
+  }
+  return undefined;
+}
 
 /**
  * The slice of Playwright's `Page` the launcher adapter consumes. Declared
@@ -1619,9 +1688,22 @@ async function runLevel(opts: {
    * edge headers). `emitted` makes the two call sites idempotent.
    */
   let messageSendEmitted = false;
+  // True once a `probe.message.send` boundary has been emitted carrying REAL
+  // edge headers from an observed agent-message POST (i.e. `messageSendEdge` was
+  // defined at emit time). Item-3 double-boundary guard: the retry re-arms
+  // `messageSendEmitted` so the WINNING resend's real POST can re-capture and
+  // re-emit — but if the resend lands NO POST, the `finally`-block fallback
+  // would otherwise emit a SECOND boundary with NULL edge headers
+  // (`messageSendEdge` was cleared on retry), mis-attributing
+  // `edge_interference_signal` to a phantom null-header turn. The fallback is
+  // therefore SUPPRESSED once a real-header boundary already fired — a
+  // null-header boundary is only ever the SINGLE boundary for a level that never
+  // observed any message POST, never a second boundary after a real one.
+  let messageSendRealPostEmitted = false;
   const emitMessageSend = (): void => {
     if (messageSendEmitted) return;
     messageSendEmitted = true;
+    if (messageSendEdge !== undefined) messageSendRealPostEmitted = true;
     cvdiag?.messageSend(0, messageCharCount, messageSendEdge);
   };
   /**
@@ -1722,13 +1804,104 @@ async function runLevel(opts: {
     // budget to `hardCeiling` (never a flat `pageTimeoutMs` per call): the retry
     // resend runs LATE in the envelope, so passing `pageTimeoutMs` unbounded let
     // a stalled type/press push total level wall-clock to ~2× `pageTimeoutMs`
-    // past the hard ceiling. `Math.max(0, …)` keeps the timeout non-negative;
-    // Playwright treats 0 as "no timeout", so we floor at 1ms once the budget is
-    // spent to fail fast rather than block indefinitely.
+    // past the hard ceiling.
+    //
+    // MIN-BUDGET GUARD (item-1, first-send cap): the `press` that FOLLOWS `type`
+    // within one send is guarded against `SEND_PRESS_MIN_BUDGET_MS` BEFORE it
+    // issues.
+    // Without this, a near-hang `type` (it eats most of the envelope) leaves the
+    // following `press` with a sub-1ms `Math.max(1, hardCeiling - now)` timeout —
+    // a doomed ~1ms action Playwright rejects with a page-fault-shaped
+    // "Timeout 1ms exceeded…" message, which the outer catch then red-classifies
+    // as a GENERIC `level-error` (a spurious-red flap, indistinguishable from a
+    // real page fault). Instead, once the budget remaining for `press` has
+    // drained below the floor we throw a DISTINCTLY-classified
+    // `SendBudgetExhaustedError` (`errorDesc: send-budget-exhausted`) so the red
+    // is observable-and-specific, not a self-inflicted 1ms floor masquerading as
+    // a page fault. This mirrors — for the type↔press pair WITHIN a send — the
+    // retry path's own `RETRY_MIN_BUDGET_MS` guard between sends (but with a much
+    // smaller floor; see `SEND_PRESS_MIN_BUDGET_MS`).
+    //
+    // Only `press` is guarded, NOT `type`: `type` is the OPENING action of the
+    // send, so guarding it would (wrongly) refuse to even start a send on a
+    // legitimately-small envelope. The BETWEEN-send resend budget is already
+    // gated by the retry loop's own `RETRY_MIN_BUDGET_MS` check before `sendTurn`
+    // is called; this in-send guard covers the type→press drain the retry check
+    // can't see. `type` keeps the plain `Math.max(1, remaining)` floor
+    // (Playwright treats 0 as "no timeout").
     const sendTurn = async (): Promise<void> => {
-      const budget = () => Math.max(1, hardCeiling - Date.now());
-      await pg.type("textarea", message, { timeout: budget() });
-      await pg.press("textarea", "Enter", { timeout: budget() });
+      const typeBudget = Math.max(1, hardCeiling - Date.now());
+      await pg.type("textarea", message, { timeout: typeBudget });
+      const pressRemaining = hardCeiling - Date.now();
+      if (pressRemaining < SEND_PRESS_MIN_BUDGET_MS) {
+        throw new SendBudgetExhaustedError(
+          "press",
+          Math.max(0, pressRemaining),
+          SEND_PRESS_MIN_BUDGET_MS,
+        );
+      }
+      await pg.press("textarea", "Enter", {
+        timeout: Math.max(1, pressRemaining),
+      });
+    };
+    // ── ONE guarded `readTurnState()` wrapper (harmonized error handling) ─────
+    // ALL three turn-state consumers below (`readBaseline`, `readTurnComplete`,
+    // `readDegraded`) route through this. `page.readTurnState()` can REJECT
+    // mid-poll (a fake that models a transient read fault, a page mid-navigation,
+    // or any launcher whose implementation throws). Before harmonization those
+    // consumers handled a throw INCONSISTENTLY:
+    //   - `readBaseline` / `readTurnComplete` called it UNGUARDED → a mid-poll
+    //     rejection escaped, was caught by the driver's outer catch, and
+    //     red-classified as a generic `level-error` = a SPURIOUS red.
+    //   - `readDegraded` swallowed the throw into "not degraded" (`false`) → the
+    //     poll silently routed a genuinely-broken page to the base-floor
+    //     fast-fail = a SILENT false-red with NO telemetry.
+    // Both are the exact false-red/flap class this effort fights. This wrapper
+    // makes a throw mean ONE thing everywhere: "no reliable signal" → return a
+    // well-defined DEGRADED sentinel (all-zero counters + `sseAttachFailed:
+    // true`) so `readDegraded` reports degraded (WIDEN the wait to the ceiling,
+    // NOT base-floor fast-fail, NOT a spurious `level-error`), while
+    // `readBaseline`/`readTurnComplete` see a benign all-zero snapshot (never a
+    // throw). The fault is OBSERVABLE — a greppable one-shot marker (mirroring
+    // `onAttachFault`'s low-volume diagnostic style) fires the first time it is
+    // seen for this level — never a silent false-red. A genuinely-empty degraded
+    // turn still eventually reds (the widened ceiling elapses with empty DOM).
+    // `undefined` return = NO SEAM (a fake that omits `readTurnState`): a
+    // legitimate no-signal case, distinct from a throw, so callers fall back to
+    // their all-zero/not-degraded defaults WITHOUT emitting the fault marker.
+    let readTurnStateFaultReported = false;
+    const safeReadTurnState = async (): Promise<TurnState | undefined> => {
+      if (page?.readTurnState === undefined) return undefined;
+      try {
+        return await page.readTurnState();
+      } catch (err) {
+        if (!readTurnStateFaultReported) {
+          readTurnStateFaultReported = true;
+          // eslint-disable-next-line no-console
+          console.warn(
+            "[d4-chat-roundtrip] readTurnState() threw mid-poll — treating as " +
+              "degraded/unobserved (widening the first-token wait, not fast-failing)",
+            {
+              slug,
+              level,
+              err: err instanceof Error ? err.message : String(err),
+            },
+          );
+        }
+        // Well-defined DEGRADED sentinel: no reliable turn signal, so counters
+        // stay at their zero/absent baseline and `sseAttachFailed` rides true —
+        // routing the poll onto the degraded WIDEN path, never a base-floor
+        // fast-fail or a spurious `level-error`.
+        return {
+          runsFinished: 0,
+          attrPresent: false,
+          sawRunningTrue: false,
+          runningNow: null,
+          runStartCount: 0,
+          lastStoppedAtMs: 0,
+          sseAttachFailed: true,
+        };
+      }
     };
     // Per-attempt turn-lifecycle BASELINE. Snapshot the page-GLOBAL, monotonic
     // edge counters (`runsFinished`, `runStartCount`) BEFORE a turn is sent so
@@ -1739,18 +1912,18 @@ async function runLevel(opts: {
     // think THIS turn had finished the moment it began, see the still-empty
     // container, and spuriously FAST-FAIL RED. Baselining converts the gate to a
     // NEW-edge test (`> baseline`) so only a finish that happened AFTER the send
-    // counts. Read via `readTurnState()` (undefined seam → all-zero baseline,
-    // harmless: `> 0` still works for the first ever run). A fresh baseline is
-    // taken per attempt (each retry resends), so a stale prior edge can never
-    // satisfy a retried attempt.
+    // counts. Read via `safeReadTurnState()` (undefined seam OR read-throw →
+    // all-zero baseline, harmless: `> 0` still works for the first ever run). A
+    // fresh baseline is taken per attempt (each retry resends), so a stale prior
+    // edge can never satisfy a retried attempt.
     const readBaseline = async (): Promise<{
       runsFinished: number;
       runStartCount: number;
     }> => {
-      if (page?.readTurnState === undefined) {
+      const st = await safeReadTurnState();
+      if (st === undefined) {
         return { runsFinished: 0, runStartCount: 0 };
       }
-      const st = await page.readTurnState();
       return { runsFinished: st.runsFinished, runStartCount: st.runStartCount };
     };
     // Baseline snapshot for attempt 0, taken BEFORE the send so the agent
@@ -1868,10 +2041,17 @@ async function runLevel(opts: {
         observed: boolean;
         complete: boolean;
       }> => {
-        if (page?.readTurnState === undefined) {
+        // Route through `safeReadTurnState`: no seam OR a mid-poll read-throw
+        // both yield "not observed / not complete" here (the throw returns the
+        // degraded sentinel whose all-zero counters can't rise past the
+        // baseline, so `observed`/`complete` stay false). A throw is thus handled
+        // CONSISTENTLY with `readDegraded` — the poll treats it as "no reliable
+        // signal → degraded", widening the wait rather than escaping as a
+        // spurious `level-error`.
+        const st = await safeReadTurnState();
+        if (st === undefined) {
           return { observed: false, complete: false };
         }
-        const st = await page.readTurnState();
         const newRunStarted = st.runStartCount > baseline.runStartCount;
         const domDone =
           st.attrPresent &&
@@ -1928,13 +2108,18 @@ async function runLevel(opts: {
       // the turn lifecycle is a legitimate no-signal case, not an attach
       // failure). Read once per attempt (the flag is latched at `goto` time and
       // never changes within a level).
+      //
+      // Routed through `safeReadTurnState` so a mid-poll read-THROW is handled
+      // CONSISTENTLY with the two consumers above: the throw returns the degraded
+      // sentinel (`sseAttachFailed: true`), so this reports `true` and the poll
+      // WIDENS the wait — instead of the prior code, which swallowed the throw
+      // into `false` and silently base-floor fast-failed a genuinely-broken page
+      // (a SILENT false-red with no telemetry). The observable one-shot fault
+      // marker fires inside `safeReadTurnState` on that throw.
       const readDegraded = async (): Promise<boolean> => {
-        if (page?.readTurnState === undefined) return false;
-        try {
-          return (await page.readTurnState()).sseAttachFailed === true;
-        } catch {
-          return false;
-        }
+        const st = await safeReadTurnState();
+        if (st === undefined) return false;
+        return st.sseAttachFailed === true;
       };
       const runAttempt = async (
         attemptCeiling: number,
@@ -2288,7 +2473,14 @@ async function runLevel(opts: {
           backendUrl,
           level,
           failureSummary: truncateUtf8(msg, 1200),
-          errorDesc: abortSignal.aborted ? "abort" : "level-error",
+          // Duck-type a distinct `errorDesc` off the thrown error (mirroring the
+          // `TurnNotCompleteError.reason` decoupling): a `SendBudgetExhaustedError`
+          // is a self-inflicted min-budget skip (item-1), NOT a generic page
+          // fault, so it reports `send-budget-exhausted` rather than the catch-all
+          // `level-error`. An external abort still wins (the driver's hard-timeout).
+          errorDesc: abortSignal.aborted
+            ? "abort"
+            : (sendBudgetErrorDesc(err) ?? "level-error"),
         },
         observedAt: now().toISOString(),
       },
@@ -2305,7 +2497,15 @@ async function runLevel(opts: {
     // normal run that already emitted from the seam is unaffected. In the
     // `finally` (not the try body) so a throw before the old inline call site
     // can no longer drop the boundary.
-    emitMessageSend();
+    //
+    // Item-3 double-boundary guard: SUPPRESS this fallback once a REAL-header
+    // boundary already fired (`messageSendRealPostEmitted`). The retry re-arms
+    // `messageSendEmitted` so the winning resend can re-capture, but a resend
+    // that lands NO POST would otherwise let this fallback emit a SECOND,
+    // NULL-header boundary (mis-attributing `edge_interference_signal`). The
+    // null-header fallback is only ever the SINGLE boundary for a level that
+    // observed no message POST at all — never a second one after a real capture.
+    if (!messageSendRealPostEmitted) emitMessageSend();
     // Defense in depth: if neither the ok nor the error path emitted exit (an
     // unexpected control-flow gap), emit it here so `probe.exit` fires exactly
     // once on every path.


### PR DESCRIPTION
Tracked follow-up to #5882 (D4 first-token SSE turn-complete fix). These are the deferred **bucket-(b)** items from that PR's CR — non-load-bearing polish/hardening on the D4 probe driver (`showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts` + `.test.ts`). No re-architecture; each change is tight and scoped.

## Items

### 1. Budget-exhaustion retry guard (behavioral)
A late non-completion retry resend could floor its `type`/`press` action timeout to ~1ms (when the remaining budget ≈ 0), throwing a page-fault-shaped error. That throw was red-classified indistinguishably from a real page fault — a spurious-red flap source. Fix: skip the resend when the remaining budget is below `RETRY_MIN_BUDGET_MS` (750ms); the stall then reds on its own terms.

**Red-green:** with the guard disabled, the doomed resend attempts a second `type` (typeAttempts=2); with the guard, `type` fires exactly once (typeAttempts=1). RED observed (2), GREEN observed (1).

### 2. Degraded-path floor when interceptor silently no-ops (behavioral)
When `sseAttachFailed` is true, the page-side turn-lifecycle globals were never seeded, so the poll could only fall into the never-observed branch and pin the deadline to the base `textPollTimeoutMs` floor — reintroducing the slow-first-token false-red #5882 targets. Fix: consult `sseAttachFailed` to widen the never-observed wait to the per-attempt ceiling.

**Red-green:** degraded page + late-but-present token (800ms, base floor bites at the ~500ms poll before the token) → RED (pre-fix, base-floor fast-fail) vs GREEN (post-fix, widened to ceiling captures the token). RED observed (`red`), GREEN observed (`green`). A genuinely-empty degraded run still reds (over-correction guard).

### 3. Retry edge-header re-attribution (telemetry)
On a retry-rescued GREEN turn, `messageSendEdge` / `messageSendEdge` / `lastMessagePostResp` stayed latched to the first (stalled) attempt, mis-attributing `edge_interference_signal` / the DEBUG raw-byte sample. Fix: re-arm the capture latches before the resend so the winning attempt's response re-captures them.

**Focused test:** stalled attempt carries `cf-mitigated: stalled`, winning resend `cf-mitigated: winning`; the final `probe.message.send` boundary now carries `winning` (pre-fix it reported `stalled`).

### 4. Coverage (tests only, no prod change)
- FIFO-cap `CVDIAG_MAX_OUTSTANDING_STARTS_PER_URL` eviction backstop (guard-verified: fails if the cap is removed).
- DEBUG-auto-disarm fail-closed negative test (disarmed → no raw-byte capture).
- Alternate-content / raw-byte block SKIPPED on the container-success (non-empty) path.
- Fixed the `makeLateTokenBrowser` shared-page state leak: each `newContext().newPage()` now mints its own state, so L3 and L4 each run an independent stall+retry cycle (was a singleton that leaked `sendCount` from L3 into L4, so the L4 retry path was never genuinely exercised).

### 5. `lastStoppedAtMs` documentation (cleanup)
Write-only in d4; documented that it is retained for shared-global parity with the `attachSseInterceptor` global shape the d6 run-signal snapshot mirrors, so it does not read as dead code.

## Verification
- `tsc --noEmit`: clean
- `tsc -p tsconfig.build.json` (build): clean
- Full harness vitest: **3213 passed, 0 failing** (72 in the d4 file, all green)
- oxlint: **0 errors** (only pre-existing warnings, none new)
- Diff hygiene: only the driver + test file (no `repro_*` / `baseline`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## CR follow-up round (commit 13a636b67)

CR found the follow-up left `readTurnState()` error handling **inconsistent** — the exact false-red/flap class this effort fights. Addressed, plus completed two of the PR's own items.

### (a) Harmonized `readTurnState()` error handling
One guarded `safeReadTurnState()` wrapper now backs all three consumers (`readBaseline`, `readTurnComplete`, `readDegraded`). A mid-poll `readTurnState()` throw now means ONE thing everywhere: "no reliable signal" → return a well-defined degraded sentinel (`sseAttachFailed: true`, zeroed counters) → route onto the degraded **widen** path (not base-floor fast-fail, not a spurious `level-error`), and it is **observable** via a one-shot greppable marker. Previously: `readDegraded` swallowed the throw into `false` (silent base-floor false-red, no telemetry) while `readBaseline`/`readTurnComplete` let it escape → generic `level-error` (spurious red). A genuinely-empty degraded turn still reds at the widened ceiling (no masking).

### Folds
- **item-1 first-send cap:** guard the in-send `press` against `SEND_PRESS_MIN_BUDGET_MS` so a near-hang `type` can't floor `press` to ~1ms and yield a generic `level-error`; classify distinctly as `send-budget-exhausted`. Only `press` is guarded (`type` opens the envelope) so a legitimately-small `pageTimeoutMs` still issues a healthy first send.
- **item-3 null-header:** suppress the `finally`-block fallback `probe.message.send` once a real-header boundary already fired, so a retry whose winning resend lands no POST no longer emits a second NULL-header boundary (mis-attributed `edge_interference_signal`).
- errorDesc JSDoc: added `abort` to the enumeration (zero-risk).

### Red-green (verbatim, against the real runLevel/readTurnComplete path)
- **readTurnState throw:** RED `expected 'red' to be 'green'` (pre-fix spurious red on a late-but-present token) → GREEN (degraded widen; late token passes; genuinely-empty degraded still reds).
- **first-send cap:** RED `expected 'level-error' to be 'send-budget-exhausted'` → GREEN (distinct classification, no 1ms-floored `press`).
- **item-3 null-header:** RED `expected 2 to be 1` (second null-header emit) → GREEN (single correct attribution).

### Gates
`tsc --noEmit` clean · `npm run build` clean · full d4 vitest **76/76 pass** · oxlint **0 errors** (warnings pre-existing). Diff: driver + test only (no repro_*/baseline).
