### PR TITLE
fix(react-core): preserve MCP app queue thread context

### DIFF
--- a/packages/react-core/src/v2/components/MCPAppsActivityRenderer.tsx
+++ b/packages/react-core/src/v2/components/MCPAppsActivityRenderer.tsx
@@ -58,7 +58,7 @@ class MCPAppsRequestQueue {
   private queues = new Map<
     string,
     Array<{
-      execute: () => Promise<RunAgentResult>;
+      execute: (threadId: string) => Promise<RunAgentResult>;
       resolve: (result: RunAgentResult) => void;
       reject: (error: Error) => void;
     }>
@@ -71,7 +71,7 @@ class MCPAppsRequestQueue {
    */
   async enqueue(
     agent: AbstractAgent,
-    request: () => Promise<RunAgentResult>,
+    request: (threadId: string) => Promise<RunAgentResult>,
   ): Promise<RunAgentResult> {
     const threadId = agent.threadId || "default";
 
@@ -114,7 +114,7 @@ class MCPAppsRequestQueue {
           await this.waitForAgentIdle(agent);
 
           // Execute the request
-          const result = await item.execute();
+          const result = await item.execute(threadId);
           item.resolve(result);
         } catch (error) {
           item.reject(
@@ -574,9 +574,11 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
                       // frontend tools, context, tool execution, and abort support.
                       // Fire-and-forget: errors are handled by RunHandler's error emission.
                       mcpAppsRequestQueue
-                        .enqueue(currentAgent, () =>
-                          copilotkit.runAgent({ agent: currentAgent }),
-                        )
+                        .enqueue(currentAgent, (threadId) => {
+                          const scopedAgent = currentAgent.clone();
+                          scopedAgent.threadId = threadId;
+                          return copilotkit.runAgent({ agent: scopedAgent });
+                        })
                         .catch((err) =>
                           console.error(
                             "[MCPAppsRenderer] ui/message agent run failed:",

--- a/packages/react-core/src/v2/components/chat/__tests__/MCPAppsUiMessage.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/MCPAppsUiMessage.e2e.test.tsx
@@ -42,6 +42,7 @@ class MockMCPProxyAgent extends AbstractAgent {
     role: string;
     content: string;
   }> = [];
+  public runAgentThreadIds: string[] = [];
 
   private runAgentResponses: Map<string, unknown> = new Map();
 
@@ -73,6 +74,65 @@ class MockMCPProxyAgent extends AbstractAgent {
     act(() => {
       this.subject.complete();
     });
+  }
+
+  clone(): MockMCPProxyAgent {
+    const cloned = super.clone() as MockMCPProxyAgent;
+    type Internal = {
+      subject: Subject<BaseEvent>;
+      runAgentCalls: Array<{ input: Partial<RunAgentInput> }>;
+      addMessageCalls: Array<{
+        id: string;
+        role: string;
+        content: string;
+      }>;
+      runAgentThreadIds: string[];
+      runAgentResponses: Map<string, unknown>;
+    };
+    (cloned as unknown as Internal).subject = (
+      this as unknown as Internal
+    ).subject;
+    (cloned as unknown as Internal).runAgentCalls = (
+      this as unknown as Internal
+    ).runAgentCalls;
+    (cloned as unknown as Internal).addMessageCalls = (
+      this as unknown as Internal
+    ).addMessageCalls;
+    (cloned as unknown as Internal).runAgentThreadIds = (
+      this as unknown as Internal
+    ).runAgentThreadIds;
+    (cloned as unknown as Internal).runAgentResponses = (
+      this as unknown as Internal
+    ).runAgentResponses;
+
+    const registry = this;
+    Object.defineProperty(cloned, "isRunning", {
+      get() {
+        return registry.isRunning;
+      },
+      set(v: boolean) {
+        registry.isRunning = v;
+      },
+      configurable: true,
+      enumerable: true,
+    });
+
+    const proto = MockMCPProxyAgent.prototype;
+    cloned.runAgent = async function (
+      input?: Partial<RunAgentInput>,
+    ): Promise<RunAgentResult> {
+      const proxiedRequest = input?.forwardedProps?.__proxiedMCPRequest;
+      if (proxiedRequest) {
+        return registry.runAgent(input);
+      }
+      return proto.runAgent.call(cloned, input);
+    };
+
+    cloned.run = function (input: RunAgentInput): Observable<BaseEvent> {
+      return registry.run(input);
+    };
+
+    return cloned;
   }
 
   async detachActiveRun(): Promise<void> {}
@@ -117,6 +177,7 @@ class MockMCPProxyAgent extends AbstractAgent {
       return { result: {}, newMessages: [] };
     }
 
+    this.runAgentThreadIds.push(this.threadId);
     return super.runAgent(input);
   }
 }
@@ -144,6 +205,7 @@ async function setupMCPActivity(
   agent: MockMCPProxyAgent,
   agentId: string,
   userMessage: string,
+  threadId = testId("thread"),
 ): Promise<HTMLIFrameElement> {
   agent.setRunAgentResponse("resources/read", {
     contents: [
@@ -154,10 +216,6 @@ async function setupMCPActivity(
       },
     ],
   });
-
-  // Use a unique threadId per test to avoid module-level mcpAppsRequestQueue
-  // state leaking between tests (the queue keys by threadId).
-  const threadId = testId("thread");
 
   renderWithCopilotKit({
     agents: { [agentId]: agent },
@@ -358,6 +416,42 @@ describe("MCP Apps ui/message followUp behavior", () => {
 
     // run() should have been called
     expect(runSpy.mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it("keeps queued ui/message follow-up work scoped to the enqueue-time thread", async () => {
+    const agent = new MockMCPProxyAgent();
+    agent.agentId = "ui-msg-agent-thread-context";
+    const threadA = testId("thread-A");
+    const threadB = testId("thread-B");
+
+    const iframe = await setupMCPActivity(
+      agent,
+      "ui-msg-agent-thread-context",
+      "Queued thread context test",
+      threadA,
+    );
+    agent.runAgentThreadIds.length = 0;
+
+    agent.emit(runStartedEvent());
+
+    await sendUiMessage(iframe, {
+      role: "user",
+      content: [{ type: "text", text: "Queued follow-up" }],
+    });
+
+    expect(agent.runAgentThreadIds).toEqual([]);
+
+    agent.threadId = threadB;
+    agent.emit(runFinishedEvent());
+
+    await waitFor(
+      () => {
+        expect(agent.runAgentThreadIds).toEqual([threadA]);
+      },
+      { timeout: 3000 },
+    );
+
+    agent.emit(runFinishedEvent());
   });
 
   it("message with text content always adds to agent messages regardless of followUp", async () => {


### PR DESCRIPTION
## What does this PR do?

`ui/message` follow-up work from MCP apps could run on a later thread when the shared agent's `threadId` changed while the request was waiting in `MCPAppsRequestQueue`. This keeps the queue's enqueue-time thread id and runs delayed `ui/message` follow-ups through a cloned agent scoped to that captured thread, while the idle wait still watches the shared running agent and resource/tool proxying stays unchanged.

I checked the focused regression, then ran the React-core test, build, and type-check targets plus root lint. `pnpm run check-format` still reports unrelated showcase MDX formatting outside this change; the touched files pass `oxfmt --check`.

## Related PRs and Issues

- Fixes #5819
- Related: #5810, #5380

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation (not applicable; bug fix only)
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)
