### PR TITLE
feat(telemetry): emit telemetry-registry fragments for runtime + docs surfaces

### DIFF
--- a/.github/workflows/telemetry-docs-fragment.yml
+++ b/.github/workflows/telemetry-docs-fragment.yml
@@ -1,0 +1,95 @@
+# telemetry / docs fragment
+#
+# Regenerates the `CopilotKit.docs` telemetry-registry fragment (the
+# showcase/shell-docs site) and opens a path-limited PR against
+# CopilotKit/oss-path-to-production whenever the docs site's telemetry could
+# have changed. Callee-mode extraction (inline posthog.capture), content-gated:
+# if the extracted event set is unchanged the fragment is left untouched and no
+# PR is opened, so routine docs code changes don't churn the registry.
+name: telemetry / docs fragment
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "showcase/shell-docs/**"
+      - "scripts/telemetry/**"
+      - ".github/workflows/telemetry-docs-fragment.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: telemetry-docs-fragment
+  cancel-in-progress: false
+
+jobs:
+  fragment:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    # GitHub rejects secrets.* in `if:`; surface the gate as an env var.
+    env:
+      HAS_BOT_KEY: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY != '' }}
+    steps:
+      - name: Checkout CopilotKit
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.x
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Cross-repo token, least privilege: NO explicit owner + bare
+      # `repositories`; contents+pull-requests write only.
+      - name: Mint token for oss-path-to-production
+        if: env.HAS_BOT_KEY == 'true'
+        id: token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: 1108748
+          private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
+          repositories: oss-path-to-production
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout oss-path-to-production
+        if: steps.token.outputs.token != ''
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: CopilotKit/oss-path-to-production
+          token: ${{ steps.token.outputs.token }}
+          path: p2p
+          persist-credentials: false
+
+      - name: Generate docs fragment
+        if: steps.token.outputs.token != ''
+        run: pnpm tsx scripts/telemetry/emit-fragment.ts --surface docs --out p2p/telemetry-registry/fragments/CopilotKit.docs.json
+
+      - name: Open fragment PR
+        if: steps.token.outputs.token != ''
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        with:
+          token: ${{ steps.token.outputs.token }}
+          path: p2p
+          add-paths: telemetry-registry/fragments/CopilotKit.docs.json
+          base: main
+          branch: telemetry/copilotkit-docs
+          delete-branch: true
+          commit-message: "chore(telemetry): update CopilotKit.docs fragment"
+          title: "chore(telemetry): update CopilotKit.docs fragment"
+          body: |
+            Automated update of the `CopilotKit.docs` telemetry-registry fragment
+            (showcase/shell-docs), extracted from inline posthog.capture call sites.
+
+            Reconcile (telemetry-reconcile) will fold this into `telemetry-events.json`.

--- a/.github/workflows/telemetry-docs-fragment.yml
+++ b/.github/workflows/telemetry-docs-fragment.yml
@@ -30,9 +30,10 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-    # GitHub rejects secrets.* in `if:`; surface the gate as an env var.
+    # GitHub rejects secrets.* in `if:`; surface the registry App ID as an env
+    # var to gate on — the workflow self-skips when the App isn't configured.
     env:
-      HAS_BOT_KEY: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY != '' }}
+      REGISTRY_APP_ID: ${{ secrets.TELEMETRY_REGISTRY_APP_ID }}
     steps:
       - name: Checkout CopilotKit
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -53,12 +54,12 @@ jobs:
       # Cross-repo token, least privilege: NO explicit owner + bare
       # `repositories`; contents+pull-requests write only.
       - name: Mint token for oss-path-to-production
-        if: env.HAS_BOT_KEY == 'true'
+        if: env.REGISTRY_APP_ID != ''
         id: token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: 1108748
-          private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.TELEMETRY_REGISTRY_APP_ID }}
+          private-key: ${{ secrets.TELEMETRY_REGISTRY_APP_PRIVATE_KEY }}
           repositories: oss-path-to-production
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/telemetry-docs-fragment.yml
+++ b/.github/workflows/telemetry-docs-fragment.yml
@@ -77,6 +77,22 @@ jobs:
         if: steps.token.outputs.token != ''
         run: pnpm tsx scripts/telemetry/emit-fragment.ts --surface docs --out p2p/telemetry-registry/fragments/CopilotKit.docs.json
 
+      # Regenerate the canonical alongside the fragment — the registry's reconcile
+      # CI rejects a stale telemetry-events.json, so a fragment-only PR fails.
+      # Use the registry's own pnpm (its packageManager field).
+      - name: Setup pnpm for registry
+        if: steps.token.outputs.token != ''
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          package_json_file: p2p/package.json
+
+      - name: Reconcile registry
+        if: steps.token.outputs.token != ''
+        working-directory: p2p
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm reconcile
+
       - name: Open fragment PR
         if: steps.token.outputs.token != ''
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8

--- a/.github/workflows/telemetry-docs-fragment.yml
+++ b/.github/workflows/telemetry-docs-fragment.yml
@@ -12,7 +12,11 @@ on:
   push:
     branches: [main]
     paths:
-      - "showcase/shell-docs/**"
+      # Only the code under `src/**`: the emitter walks showcase/shell-docs/src
+      # for .ts/.tsx, and src/content is pure MDX/JSON prose (1000+ files, the
+      # bulk of docs traffic) that cannot contain a posthog.capture call site.
+      - "showcase/shell-docs/src/**"
+      - "!showcase/shell-docs/src/content/**"
       - "scripts/telemetry/**"
       - ".github/workflows/telemetry-docs-fragment.yml"
   workflow_dispatch: {}
@@ -36,15 +40,15 @@ jobs:
       REGISTRY_APP_ID: ${{ secrets.TELEMETRY_REGISTRY_APP_ID }}
     steps:
       - name: Checkout CopilotKit
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.x
 
@@ -66,7 +70,7 @@ jobs:
 
       - name: Checkout oss-path-to-production
         if: steps.token.outputs.token != ''
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: CopilotKit/oss-path-to-production
           token: ${{ steps.token.outputs.token }}
@@ -82,7 +86,7 @@ jobs:
       # Use the registry's own pnpm (its packageManager field).
       - name: Setup pnpm for registry
         if: steps.token.outputs.token != ''
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           package_json_file: p2p/package.json
 
@@ -99,7 +103,9 @@ jobs:
         with:
           token: ${{ steps.token.outputs.token }}
           path: p2p
-          add-paths: telemetry-registry/fragments/CopilotKit.docs.json
+          add-paths: |
+            telemetry-registry/fragments/CopilotKit.docs.json
+            telemetry-registry/telemetry-events.json
           base: main
           branch: telemetry/copilotkit-docs
           delete-branch: true
@@ -109,4 +115,5 @@ jobs:
             Automated update of the `CopilotKit.docs` telemetry-registry fragment
             (showcase/shell-docs), extracted from inline posthog.capture call sites.
 
-            Reconcile (telemetry-reconcile) will fold this into `telemetry-events.json`.
+            `telemetry-events.json` is regenerated alongside it (`pnpm reconcile`) so the
+            registry's reconcile check sees a fresh canonical; curated fields are preserved.

--- a/.github/workflows/telemetry-runtime-fragment.yml
+++ b/.github/workflows/telemetry-runtime-fragment.yml
@@ -33,10 +33,11 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-    # Surface the secret-derived gate as an env var: GitHub rejects secrets.* in
-    # an `if:` expression, so the mint step gates on env.* instead.
+    # GitHub rejects secrets.* in an `if:`, so surface the registry App ID as an
+    # env var and gate the mint step on it — the workflow self-skips when the
+    # registry App secrets aren't configured on this repo.
     env:
-      HAS_BOT_KEY: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY != '' }}
+      REGISTRY_APP_ID: ${{ secrets.TELEMETRY_REGISTRY_APP_ID }}
     steps:
       - name: Checkout CopilotKit
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -58,12 +59,12 @@ jobs:
       # app installation's owner) + bare `repositories` scopes the token to this
       # one repo; contents+pull-requests write and nothing else.
       - name: Mint token for oss-path-to-production
-        if: env.HAS_BOT_KEY == 'true'
+        if: env.REGISTRY_APP_ID != ''
         id: token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: 1108748
-          private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.TELEMETRY_REGISTRY_APP_ID }}
+          private-key: ${{ secrets.TELEMETRY_REGISTRY_APP_PRIVATE_KEY }}
           repositories: oss-path-to-production
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/telemetry-runtime-fragment.yml
+++ b/.github/workflows/telemetry-runtime-fragment.yml
@@ -82,13 +82,31 @@ jobs:
         if: steps.token.outputs.token != ''
         run: pnpm tsx scripts/telemetry/emit-fragment.ts --surface runtime --out p2p/telemetry-registry/fragments/CopilotKit.runtime.json
 
+      # Regenerate the canonical alongside the fragment — the registry's reconcile
+      # CI rejects a stale telemetry-events.json, so a fragment-only PR fails.
+      # Use the registry's own pnpm (its packageManager field).
+      - name: Setup pnpm for registry
+        if: steps.token.outputs.token != ''
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          package_json_file: p2p/package.json
+
+      - name: Reconcile registry
+        if: steps.token.outputs.token != ''
+        working-directory: p2p
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm reconcile
+
       - name: Open fragment PR
         if: steps.token.outputs.token != ''
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ steps.token.outputs.token }}
           path: p2p
-          add-paths: telemetry-registry/fragments/CopilotKit.runtime.json
+          add-paths: |
+            telemetry-registry/fragments/CopilotKit.runtime.json
+            telemetry-registry/telemetry-events.json
           base: main
           branch: telemetry/copilotkit-runtime
           delete-branch: true

--- a/.github/workflows/telemetry-runtime-fragment.yml
+++ b/.github/workflows/telemetry-runtime-fragment.yml
@@ -1,0 +1,100 @@
+# telemetry / runtime fragment
+#
+# Regenerates the `CopilotKit.runtime` telemetry-registry fragment and opens a
+# path-limited PR against CopilotKit/oss-path-to-production whenever a stable
+# monorepo release publishes (that's when @copilotkit/runtime ships). The
+# emitter is content-gated: if the runtime event set is unchanged, the fragment
+# is left untouched and create-pull-request opens nothing — so this only PRs
+# when the runtime's telemetry actually changed.
+name: telemetry / runtime fragment
+
+on:
+  # A stable monorepo release. Scoped-package releases tag "<scope>/v..."; the
+  # monorepo (which carries @copilotkit/runtime) tags "vX.Y.Z" — no slash.
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: telemetry-runtime-fragment
+  cancel-in-progress: false
+
+jobs:
+  fragment:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'release' &&
+        github.event.release.prerelease == false &&
+        !contains(github.event.release.tag_name, '/'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    # Surface the secret-derived gate as an env var: GitHub rejects secrets.* in
+    # an `if:` expression, so the mint step gates on env.* instead.
+    env:
+      HAS_BOT_KEY: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY != '' }}
+    steps:
+      - name: Checkout CopilotKit
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.x
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Cross-repo token, least privilege: NO explicit owner (defaults to the
+      # app installation's owner) + bare `repositories` scopes the token to this
+      # one repo; contents+pull-requests write and nothing else.
+      - name: Mint token for oss-path-to-production
+        if: env.HAS_BOT_KEY == 'true'
+        id: token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: 1108748
+          private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
+          repositories: oss-path-to-production
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout oss-path-to-production
+        if: steps.token.outputs.token != ''
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: CopilotKit/oss-path-to-production
+          token: ${{ steps.token.outputs.token }}
+          path: p2p
+          persist-credentials: false
+
+      - name: Generate runtime fragment
+        if: steps.token.outputs.token != ''
+        run: pnpm tsx scripts/telemetry/emit-fragment.ts --surface runtime --out p2p/telemetry-registry/fragments/CopilotKit.runtime.json
+
+      - name: Open fragment PR
+        if: steps.token.outputs.token != ''
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        with:
+          token: ${{ steps.token.outputs.token }}
+          path: p2p
+          add-paths: telemetry-registry/fragments/CopilotKit.runtime.json
+          base: main
+          branch: telemetry/copilotkit-runtime
+          delete-branch: true
+          commit-message: "chore(telemetry): update CopilotKit.runtime fragment"
+          title: "chore(telemetry): update CopilotKit.runtime fragment"
+          body: |
+            Automated update of the `CopilotKit.runtime` telemetry-registry fragment,
+            emitted from the CopilotKit runtime type catalog on a stable release.
+
+            Reconcile (telemetry-reconcile) will fold this into `telemetry-events.json`.

--- a/.github/workflows/telemetry-runtime-fragment.yml
+++ b/.github/workflows/telemetry-runtime-fragment.yml
@@ -40,15 +40,15 @@ jobs:
       REGISTRY_APP_ID: ${{ secrets.TELEMETRY_REGISTRY_APP_ID }}
     steps:
       - name: Checkout CopilotKit
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.x
 
@@ -71,7 +71,7 @@ jobs:
 
       - name: Checkout oss-path-to-production
         if: steps.token.outputs.token != ''
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: CopilotKit/oss-path-to-production
           token: ${{ steps.token.outputs.token }}
@@ -87,7 +87,7 @@ jobs:
       # Use the registry's own pnpm (its packageManager field).
       - name: Setup pnpm for registry
         if: steps.token.outputs.token != ''
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           package_json_file: p2p/package.json
 
@@ -116,4 +116,5 @@ jobs:
             Automated update of the `CopilotKit.runtime` telemetry-registry fragment,
             emitted from the CopilotKit runtime type catalog on a stable release.
 
-            Reconcile (telemetry-reconcile) will fold this into `telemetry-events.json`.
+            `telemetry-events.json` is regenerated alongside it (`pnpm reconcile`) so the
+            registry's reconcile check sees a fresh canonical; curated fields are preserved.

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -77,3 +77,17 @@ rules:
       # pkg-pr-new posts snapshot comments on the PR using the repo token
       # — credentials must remain persisted for the action to authenticate.
       - publish-commit.yml
+
+  # `cache-poisoning` flags setup-* actions under a "publishing" trigger
+  # (here `on: release`) on the theory that a poisoned restored cache could
+  # taint a published artifact.
+  #
+  # telemetry-runtime-fragment.yml: reviewed, does not apply. The workflow
+  # configures NO cache (setup-node caching is opt-in via `cache:`, which this
+  # workflow does not set), and it publishes no build artifact — it reads the
+  # runtime's type catalog, emits a JSON registry fragment, and opens a PR
+  # against another repo. There is no runtime artifact a restored cache could
+  # poison.
+  cache-poisoning:
+    ignore:
+      - telemetry-runtime-fragment.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -84,7 +84,9 @@ rules:
   #
   # telemetry-runtime-fragment.yml: reviewed, does not apply. The workflow
   # configures NO cache (setup-node caching is opt-in via `cache:`, which this
-  # workflow does not set), and it publishes no build artifact — it reads the
+  # workflow does not set; setup-node v7's `package-manager-cache` auto-path
+  # only engages when package.json declares npm, and this repo declares pnpm),
+  # and it publishes no build artifact — it reads the
   # runtime's type catalog, emits a JSON registry fragment, and opens a PR
   # against another repo. There is no runtime artifact a restored cache could
   # poison.

--- a/scripts/__tests__/telemetry-fragment.test.ts
+++ b/scripts/__tests__/telemetry-fragment.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  extractCallees,
+  readCatalogFile,
+  readRuntimeCatalog,
+  buildRuntimeEvents,
+} from "../telemetry/extract";
+
+const f = (p: string, content: string) => ({ path: p, content });
+
+// ---------------------------------------------------------------------------
+// extractCallees (docs / callee mode)
+// ---------------------------------------------------------------------------
+
+describe("extractCallees", () => {
+  it("captures string-literal event names and inline object keys", () => {
+    const out = extractCallees(
+      [
+        f(
+          "a.tsx",
+          `posthog.capture("try_for_free_clicked", { location: "hero", plan });`,
+        ),
+      ],
+      { calleeNames: ["posthog.capture"], callSites: "file" },
+    );
+    expect(out).toEqual([
+      {
+        event: "try_for_free_clicked",
+        call_sites: ["a.tsx"],
+        properties_seen: ["location", "plan"],
+      },
+    ]);
+  });
+
+  it("matches the bare method name and a qualified receiver", () => {
+    const src = `posthog.capture("e1", {}); telemetry.capture("e2", {});`;
+    const qualified = extractCallees([f("q.ts", src)], {
+      calleeNames: ["posthog.capture"],
+    });
+    expect(qualified.map((e) => e.event)).toEqual(["e1"]);
+    const bare = extractCallees([f("q.ts", src)], { calleeNames: ["capture"] });
+    expect(bare.map((e) => e.event)).toEqual(["e1", "e2"]);
+  });
+
+  it("merges, dedupes and sorts across call sites; skips non-literal keys", () => {
+    const out = extractCallees(
+      [
+        f("x.ts", `capture("evt", { b: 1, ...rest, [dyn]: 2 });`),
+        f("y.ts", `capture("evt", { a: 1 });`),
+      ],
+      { calleeNames: ["capture"], callSites: "file" },
+    );
+    expect(out).toEqual([
+      {
+        event: "evt",
+        call_sites: ["x.ts", "y.ts"],
+        properties_seen: ["a", "b"],
+      },
+    ]);
+  });
+
+  it("emits line-numbered sites in line mode", () => {
+    const out = extractCallees([f("z.ts", `\ncapture("e", {});`)], {
+      calleeNames: ["capture"],
+      callSites: "line",
+    });
+    expect(out[0].call_sites).toEqual(["z.ts:2"]);
+  });
+
+  it("throws loudly on a parse error rather than silently under-reporting", () => {
+    expect(() =>
+      extractCallees([f("bad.ts", `function (`)], { calleeNames: ["capture"] }),
+    ).toThrow(/Parse error in bad\.ts/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readCatalogFile / readRuntimeCatalog (runtime / catalog mode)
+// ---------------------------------------------------------------------------
+
+const CATALOG = `
+export type AnalyticsEvents = {
+  "oss.runtime.instance_created": InstanceInfo;
+  "oss.runtime.copilot_request_created": {
+    requestType: string;
+    "cloud.api_key_provided": boolean;
+    "cloud.public_api_key"?: string;
+  };
+};
+export interface InstanceInfo {
+  actionsAmount: number;
+  hashedLgcKey?: string;
+  "cloud.api_key_provided": boolean;
+}
+`;
+
+describe("readCatalogFile", () => {
+  it("reads event names + properties from inline literals and referenced interfaces", () => {
+    const cat = readCatalogFile("events.ts", CATALOG);
+    expect(cat.get("oss.runtime.instance_created")).toEqual([
+      "actionsAmount",
+      "cloud.api_key_provided",
+      "hashedLgcKey",
+    ]);
+    expect(cat.get("oss.runtime.copilot_request_created")).toEqual([
+      "cloud.api_key_provided",
+      "cloud.public_api_key",
+      "requestType",
+    ]);
+  });
+
+  it("throws when an event references an unknown type", () => {
+    const bad = `export type AnalyticsEvents = { "x": Missing };`;
+    expect(() => readCatalogFile("e.ts", bad)).toThrow(
+      /references unknown type Missing/,
+    );
+  });
+
+  it("throws when AnalyticsEvents is absent", () => {
+    expect(() => readCatalogFile("e.ts", `export type Other = {};`)).toThrow(
+      /AnalyticsEvents type map not found/,
+    );
+  });
+});
+
+describe("readRuntimeCatalog", () => {
+  it("returns the catalog when v1 and v2 agree", () => {
+    const cat = readRuntimeCatalog(f("v1.ts", CATALOG), f("v2.ts", CATALOG));
+    expect([...cat.keys()].sort()).toEqual([
+      "oss.runtime.copilot_request_created",
+      "oss.runtime.instance_created",
+    ]);
+  });
+
+  it("fails loud when v1 and v2 diverge", () => {
+    const v2 = CATALOG.replace(
+      "actionsAmount: number;",
+      "actionsAmount: number;\n  extra?: string;",
+    );
+    expect(() =>
+      readRuntimeCatalog(f("v1.ts", CATALOG), f("v2.ts", v2)),
+    ).toThrow(/diverge/);
+  });
+});
+
+describe("buildRuntimeEvents", () => {
+  it("takes properties from the catalog and call sites from the scan; drops non-catalog scanned events", () => {
+    const catalog = new Map([
+      ["oss.runtime.instance_created", ["actionsAmount"]],
+    ]);
+    const events = buildRuntimeEvents(catalog, [
+      f(
+        "integrations/nest.ts",
+        `client.capture("oss.runtime.instance_created", getInfo(opts));`,
+      ),
+      f("other.ts", `client.capture("something.else", { a: 1 });`),
+    ]);
+    expect(events).toEqual([
+      {
+        event: "oss.runtime.instance_created",
+        call_sites: ["integrations/nest.ts"],
+        properties_seen: ["actionsAmount"],
+      },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Loose smoke test against the real runtime catalog — robust to event additions
+// (asserts shape/namespace, not an exact count that would rot on every change).
+// ---------------------------------------------------------------------------
+
+describe("real runtime catalog", () => {
+  const root = path.join(__dirname, "..", "..");
+  const v1 = path.join(root, "packages/shared/src/telemetry/events.ts");
+  const v2 = path.join(
+    root,
+    "packages/runtime/src/v2/runtime/telemetry/events.ts",
+  );
+
+  it("v1 parses to a non-empty oss.runtime.* catalog", () => {
+    const cat = readCatalogFile(v1, fs.readFileSync(v1, "utf8"));
+    expect(cat.size).toBeGreaterThan(0);
+    for (const name of cat.keys())
+      expect(name.startsWith("oss.runtime.")).toBe(true);
+  });
+
+  it("v1 and v2 catalogs agree (drift guard)", () => {
+    expect(() =>
+      readRuntimeCatalog(
+        { path: v1, content: fs.readFileSync(v1, "utf8") },
+        { path: v2, content: fs.readFileSync(v2, "utf8") },
+      ),
+    ).not.toThrow();
+  });
+});

--- a/scripts/telemetry/emit-fragment.ts
+++ b/scripts/telemetry/emit-fragment.ts
@@ -1,0 +1,185 @@
+// Emit a CopilotKit telemetry-registry fragment for one surface.
+//
+//   pnpm tsx scripts/telemetry/emit-fragment.ts --surface runtime|docs --out <path>
+//
+// Writes a fragment that validates against oss-path-to-production's
+// telemetry-registry/schema/fragment.schema.json. CONTENT-GATED: if --out
+// already holds a fragment whose `events` match what we just extracted, the
+// file is left byte-for-byte untouched (released_in/generated_at preserved) and
+// nothing is written — so the CI job opens a PR only when the event set, its
+// properties, or its call sites actually change, never once per release.
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { execFileSync } from "node:child_process";
+import {
+  buildRuntimeEvents,
+  extractCallees,
+  readRuntimeCatalog,
+} from "./extract";
+import type { FragmentEvent } from "./extract";
+
+interface Fragment {
+  repo: string;
+  surface: string;
+  released_in: string;
+  generated_at: string;
+  events: FragmentEvent[];
+}
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+const REPO = "CopilotKit";
+const REPO_ROOT = path.resolve(
+  arg("repo-root") ?? path.join(__dirname, "..", ".."),
+);
+
+function walk(dir: string, exts: string[]): string[] {
+  const out: string[] = [];
+  const skipDir = new Set([
+    "node_modules",
+    "dist",
+    ".next",
+    ".turbo",
+    ".nx",
+    "__tests__",
+  ]);
+  const rec = (d: string): void => {
+    for (const ent of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, ent.name);
+      if (ent.isDirectory()) {
+        if (!skipDir.has(ent.name)) rec(p);
+      } else if (
+        exts.some((e) => ent.name.endsWith(e)) &&
+        !/\.(test|spec)\.[tj]sx?$/.test(ent.name)
+      ) {
+        out.push(p);
+      }
+    }
+  };
+  rec(dir);
+  return out.sort();
+}
+
+// Read files as { path: <repo-relative>, content } so call_sites are portable.
+function load(absPaths: string[]): Array<{ path: string; content: string }> {
+  return absPaths.map((p) => ({
+    path: path.relative(REPO_ROOT, p),
+    content: fs.readFileSync(p, "utf8"),
+  }));
+}
+
+function shortSha(): string {
+  const env = process.env.GITHUB_SHA;
+  if (env) return env.slice(0, 7);
+  try {
+    return execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+      cwd: REPO_ROOT,
+    })
+      .toString()
+      .trim();
+  } catch {
+    return "local";
+  }
+}
+
+function runtimeFragment(): {
+  surface: string;
+  released_in: string;
+  events: FragmentEvent[];
+} {
+  const v1Rel = "packages/shared/src/telemetry/events.ts";
+  const v2Rel = "packages/runtime/src/v2/runtime/telemetry/events.ts";
+  const read = (rel: string) => ({
+    path: rel,
+    content: fs.readFileSync(path.join(REPO_ROOT, rel), "utf8"),
+  });
+  const catalog = readRuntimeCatalog(read(v1Rel), read(v2Rel));
+  const callSiteFiles = load(
+    walk(path.join(REPO_ROOT, "packages/runtime/src"), [".ts"]),
+  );
+  const events = buildRuntimeEvents(catalog, callSiteFiles);
+  const version = JSON.parse(
+    fs.readFileSync(
+      path.join(REPO_ROOT, "packages/runtime/package.json"),
+      "utf8",
+    ),
+  ).version;
+  return { surface: "runtime", released_in: `runtime@${version}`, events };
+}
+
+function docsFragment(): {
+  surface: string;
+  released_in: string;
+  events: FragmentEvent[];
+} {
+  const srcDir = path.join(REPO_ROOT, "showcase/shell-docs/src");
+  const files = load(walk(srcDir, [".ts", ".tsx"]));
+  const events = extractCallees(files, {
+    calleeNames: ["posthog.capture", "capture"],
+    callSites: "file",
+  })
+    // Drop PostHog-reserved events ($pageview et al.) — those are analytics
+    // infrastructure, not product/GTM events the registry catalogs.
+    .filter((e) => !e.event.startsWith("$"));
+  return { surface: "docs", released_in: `shell-docs@${shortSha()}`, events };
+}
+
+function main(): void {
+  const surface = arg("surface");
+  const out = arg("out");
+  if (!surface || !out) {
+    console.error(
+      "usage: emit-fragment.ts --surface runtime|docs --out <path> [--released-in X] [--generated-at ISO]",
+    );
+    process.exit(2);
+  }
+
+  const built =
+    surface === "runtime"
+      ? runtimeFragment()
+      : surface === "docs"
+        ? docsFragment()
+        : undefined;
+  if (!built) {
+    console.error(`unknown surface: ${surface} (expected runtime|docs)`);
+    process.exit(2);
+  }
+  if (built.events.length === 0) {
+    // A surface with zero events is almost always a broken extraction, not a
+    // real state — fail loud rather than emit an empty fragment.
+    console.error(
+      `::error::extracted 0 events for surface ${surface}; refusing to write an empty fragment`,
+    );
+    process.exit(1);
+  }
+
+  const fragment: Fragment = {
+    repo: REPO,
+    surface: built.surface,
+    released_in: arg("released-in") ?? built.released_in,
+    generated_at: arg("generated-at") ?? new Date().toISOString(),
+    events: built.events,
+  };
+
+  const eventsJson = JSON.stringify(fragment.events);
+  if (fs.existsSync(out)) {
+    const existing = JSON.parse(fs.readFileSync(out, "utf8")) as Fragment;
+    if (JSON.stringify(existing.events) === eventsJson) {
+      console.log(
+        `${surface}: ${fragment.events.length} events unchanged — leaving ${out} untouched`,
+      );
+      return;
+    }
+  }
+
+  fs.mkdirSync(path.dirname(out), { recursive: true });
+  fs.writeFileSync(out, JSON.stringify(fragment, null, 2) + "\n");
+  console.log(
+    `${surface}: wrote ${fragment.events.length} events → ${out} (released_in ${fragment.released_in})`,
+  );
+}
+
+if (require.main === module) main();

--- a/scripts/telemetry/extract.ts
+++ b/scripts/telemetry/extract.ts
@@ -1,0 +1,248 @@
+// Pure extraction for CopilotKit telemetry-registry fragments.
+//
+// Two surfaces, two mechanisms (see docs/telemetry-registry-publish-roadmap.md
+// in oss-path-to-production):
+//   - runtime → typed catalog. Event names + property names live in the
+//     `AnalyticsEvents` type map (packages/shared/.../events.ts, duplicated in
+//     the v2 runtime). `readRuntimeCatalog` reads that type; call sites come
+//     from a name-based scan (the emit sites pass non-literal props, so their
+//     inline keys are NOT authoritative — the catalog is).
+//   - docs (showcase/shell-docs) → inline `posthog.capture("name", { ... })`.
+//     `extractCallees` collects the string-literal name + inline object keys,
+//     same best-effort static rules as the shared registry extractor.
+//
+// Both outputs are deterministic (sorted, deduped) so the fragment is byte
+// stable and the CI content-gate can compare event sets reliably.
+import ts from "typescript";
+
+export interface FragmentEvent {
+  event: string;
+  call_sites: string[];
+  properties_seen: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Callee-mode extraction (docs) — ported from the registry's extract.ts.
+// Deliberate limits: string-literal names only; inline object-literal keys of
+// arg[1] only (no spreads/computed/variables); matches `foo` and `obj.method`.
+// ---------------------------------------------------------------------------
+
+function calleeNames(expr: ts.CallExpression): string[] {
+  const c = expr.expression;
+  if (ts.isIdentifier(c)) return [c.text];
+  if (ts.isPropertyAccessExpression(c)) {
+    const method = c.name.text;
+    if (ts.isIdentifier(c.expression))
+      return [`${c.expression.text}.${method}`, method];
+    return [method];
+  }
+  return [];
+}
+
+function objectKeys(node: ts.Node | undefined): string[] {
+  if (!node || !ts.isObjectLiteralExpression(node)) return [];
+  const keys: string[] = [];
+  for (const prop of node.properties) {
+    if (
+      (ts.isPropertyAssignment(prop) ||
+        ts.isShorthandPropertyAssignment(prop)) &&
+      prop.name
+    ) {
+      if (ts.isIdentifier(prop.name)) keys.push(prop.name.text);
+      else if (ts.isStringLiteralLike(prop.name)) keys.push(prop.name.text);
+    }
+  }
+  return keys;
+}
+
+function parse(path: string, content: string): ts.SourceFile {
+  const sf = ts.createSourceFile(path, content, ts.ScriptTarget.Latest, true);
+  // createSourceFile is error-recovering: a syntax error yields a partial AST
+  // and silently fewer events. Fail loud.
+  const diagnostics = (sf as { parseDiagnostics?: readonly ts.Diagnostic[] })
+    .parseDiagnostics;
+  if (diagnostics && diagnostics.length > 0) {
+    const first = ts.flattenDiagnosticMessageText(
+      diagnostics[0].messageText,
+      "\n",
+    );
+    throw new Error(`Parse error in ${path}: ${first}`);
+  }
+  return sf;
+}
+
+export function extractCallees(
+  files: Array<{ path: string; content: string }>,
+  config: { calleeNames: string[]; callSites?: "file" | "line" },
+): FragmentEvent[] {
+  const callSites = config.callSites ?? "file";
+  const wanted = new Set(config.calleeNames);
+  const byEvent = new Map<string, { props: Set<string>; sites: string[] }>();
+
+  for (const file of files) {
+    const sf = parse(file.path, file.content);
+    const visit = (node: ts.Node): void => {
+      if (ts.isCallExpression(node)) {
+        const names = calleeNames(node);
+        const first = node.arguments[0];
+        if (
+          names.some((n) => wanted.has(n)) &&
+          first &&
+          ts.isStringLiteralLike(first)
+        ) {
+          const event = first.text;
+          const entry = byEvent.get(event) ?? {
+            props: new Set<string>(),
+            sites: [],
+          };
+          for (const k of objectKeys(node.arguments[1])) entry.props.add(k);
+          if (callSites === "file") entry.sites.push(file.path);
+          else
+            entry.sites.push(
+              `${file.path}:${sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1}`,
+            );
+          byEvent.set(event, entry);
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
+  }
+
+  return finalize(byEvent);
+}
+
+function finalize(
+  byEvent: Map<string, { props: Set<string>; sites: string[] }>,
+): FragmentEvent[] {
+  return [...byEvent.entries()]
+    .map(([event, { props, sites }]) => ({
+      event,
+      call_sites: [...new Set(sites)].sort(),
+      properties_seen: [...props].sort(),
+    }))
+    .sort((a, b) => a.event.localeCompare(b.event));
+}
+
+// ---------------------------------------------------------------------------
+// Catalog-mode extraction (runtime) — read the `AnalyticsEvents` type map.
+// ---------------------------------------------------------------------------
+
+// Collect property-signature names (Identifier or string-literal keys, incl.
+// optional) from a type-literal or an interface body.
+function propNames(members: ts.NodeArray<ts.TypeElement>): string[] {
+  const out: string[] = [];
+  for (const m of members) {
+    if (ts.isPropertySignature(m) && m.name) {
+      if (ts.isIdentifier(m.name)) out.push(m.name.text);
+      else if (ts.isStringLiteralLike(m.name)) out.push(m.name.text);
+    }
+  }
+  return out;
+}
+
+// Parse one events.ts into { eventName -> sorted property names }. Resolves an
+// event's value type whether it is an inline type-literal or a reference to a
+// local interface (RuntimeInstanceCreatedInfo / AgentExecutionResponseInfo).
+export function readCatalogFile(
+  path: string,
+  content: string,
+): Map<string, string[]> {
+  const sf = parse(path, content);
+  const interfaces = new Map<string, string[]>();
+  let analytics: ts.TypeLiteralNode | undefined;
+
+  const collect = (node: ts.Node): void => {
+    if (ts.isInterfaceDeclaration(node))
+      interfaces.set(node.name.text, propNames(node.members));
+    if (
+      ts.isTypeAliasDeclaration(node) &&
+      node.name.text === "AnalyticsEvents" &&
+      ts.isTypeLiteralNode(node.type)
+    ) {
+      analytics = node.type;
+    }
+    ts.forEachChild(node, collect);
+  };
+  collect(sf);
+
+  if (!analytics)
+    throw new Error(`AnalyticsEvents type map not found in ${path}`);
+
+  const out = new Map<string, string[]>();
+  for (const m of analytics.members) {
+    if (!ts.isPropertySignature(m) || !m.name || !m.type) continue;
+    if (!ts.isStringLiteralLike(m.name)) {
+      throw new Error(
+        `Non-string-literal event key in AnalyticsEvents (${path}): ${m.name.getText(sf)}`,
+      );
+    }
+    const event = m.name.text;
+    let props: string[];
+    if (ts.isTypeLiteralNode(m.type)) {
+      props = propNames(m.type.members);
+    } else if (
+      ts.isTypeReferenceNode(m.type) &&
+      ts.isIdentifier(m.type.typeName)
+    ) {
+      const ref = interfaces.get(m.type.typeName.text);
+      if (!ref)
+        throw new Error(
+          `Event ${event} references unknown type ${m.type.typeName.text} in ${path}`,
+        );
+      props = ref;
+    } else {
+      throw new Error(
+        `Event ${event} has an unsupported value type in ${path}: ${m.type.getText(sf)}`,
+      );
+    }
+    out.set(event, [...new Set(props)].sort());
+  }
+  return out;
+}
+
+// Read both the v1 and v2 catalogs and fail loud if they diverge — the two are
+// duplicated byte-for-byte today, and silent drift between them is exactly the
+// risk this emitter exists to catch.
+function serializeCatalog(m: Map<string, string[]>): string {
+  return JSON.stringify(
+    [...m.entries()].sort((x, y) => x[0].localeCompare(y[0])),
+  );
+}
+
+export function readRuntimeCatalog(
+  v1: { path: string; content: string },
+  v2: { path: string; content: string },
+): Map<string, string[]> {
+  const a = readCatalogFile(v1.path, v1.content);
+  const b = readCatalogFile(v2.path, v2.content);
+  if (serializeCatalog(a) !== serializeCatalog(b)) {
+    throw new Error(
+      `Runtime v1 and v2 telemetry catalogs diverge.\n  v1 (${v1.path}): ${serializeCatalog(a)}\n  v2 (${v2.path}): ${serializeCatalog(b)}`,
+    );
+  }
+  return a;
+}
+
+// Combine catalog properties (authoritative) with call sites discovered by a
+// name-based scan of the emit sites. Only events present in the catalog are
+// emitted; call sites are matched by event name.
+export function buildRuntimeEvents(
+  catalog: Map<string, string[]>,
+  callSiteFiles: Array<{ path: string; content: string }>,
+): FragmentEvent[] {
+  const scanned = extractCallees(callSiteFiles, {
+    calleeNames: ["capture"],
+    callSites: "file",
+  });
+  const sitesByEvent = new Map(scanned.map((e) => [e.event, e.call_sites]));
+  const events: FragmentEvent[] = [];
+  for (const [event, properties_seen] of catalog) {
+    events.push({
+      event,
+      call_sites: sitesByEvent.get(event) ?? [],
+      properties_seen,
+    });
+  }
+  return events.sort((a, b) => a.event.localeCompare(b.event));
+}


### PR DESCRIPTION
## What

Adds the CopilotKit side of the [telemetry event registry](https://github.com/CopilotKit/oss-path-to-production/blob/main/docs/telemetry-registry-publish-roadmap.md): tooling + CI that generate this repo's registry **fragments** and open path-limited PRs into `CopilotKit/oss-path-to-production`, where the reconciler folds them into `telemetry-events.json`.

Two surfaces, two mechanisms (per the surface-owns-its-extractor design):

| Surface | Events | Extraction | Trigger |
|---|---|---|---|
| **runtime** | 5 `oss.runtime.*` | **bespoke catalog** — reads the `AnalyticsEvents` type map (names + properties), scans `capture()` sites for `call_sites`; **fails loud if the v1/v2 catalogs diverge** | stable **monorepo** release (`on: release`, tag `vX.Y.Z`) |
| **docs** (`showcase/shell-docs`) | 11 | **callee mode** — inline `posthog.capture("name", {…})` literals; drops `$`-reserved events | push to `main` touching `showcase/shell-docs/src/**` (excluding `src/content`) |

## Key properties

- **Content-gated.** The emitter leaves the target fragment byte-for-byte untouched when the extracted event set is unchanged, so a PR opens **only when telemetry actually changes** — no per-release / per-commit churn.
- **Reconciled canonical in every PR.** Both workflows run the registry's `pnpm reconcile` and commit `telemetry-events.json` alongside the fragment, matching the registry's shipped emitters — a fragment-only PR fails its `telemetry-reconcile` staleness gate.
- **Least-privilege cross-repo token.** No explicit `owner` (defaults to the app installation's org) + bare `repositories: oss-path-to-production` + `contents`/`pull-requests` write only; mint gated on a job-level env var (GitHub rejects `secrets.*` in `if:`).
- **zizmor clean** at CI's `--min-severity low` (one `cache-poisoning` suppression, justified in `.github/zizmor.yml`: the workflow configures no cache and publishes a PR, not build artifacts).

## Files

- `scripts/telemetry/extract.ts` — pure extraction (callee scan + catalog reader), deterministic output.
- `scripts/telemetry/emit-fragment.ts` — CLI: `--surface runtime|docs --out <path>`, assembles + content-gates the fragment.
- `scripts/__tests__/telemetry-fragment.test.ts` — 13 unit tests (fixtures) + a loose real-catalog drift smoke test.
- `.github/workflows/telemetry-{runtime,docs}-fragment.yml` — the two CI jobs.

## Testing

Rebased onto `main` (`55aaad21a6`) and revalidated end-to-end on 2026-08-05 — the branch had fallen 1345 commits behind.

**Unit / static**

- `vitest run scripts/__tests__/telemetry-fragment.test.ts` → **13/13 passed**.
- `tsc --noEmit --strict --esModuleInterop` over both scripts → **clean** (`scripts/` has no tsconfig, so this is the ad-hoc invocation).
- `oxlint scripts/telemetry` → **0 warnings, 0 errors**; `oxfmt --check` → **all files correctly formatted**.
- `zizmor --min-severity low --config .github/zizmor.yml .github/workflows` (CI's exact invocation) → **No findings to report** (32 ignored, 233 suppressed).

**Runtime surface — mechanism proven against the live rebased tree**

```
$ tsx scripts/telemetry/emit-fragment.ts --surface runtime --out /tmp/CopilotKit.runtime.json
runtime: wrote 5 events → /tmp/CopilotKit.runtime.json (released_in runtime@1.66.2)
```

Diffed event-for-event against the registry's committed `CopilotKit.runtime.json`: **semantically identical** (same 5 events, same `call_sites`, same `properties_seen`) — the only difference is ordering, since the emitter sorts alphabetically and the hand-seeded fragment is in catalog-declaration order. Confirmed the reorder is a no-op at the canonical level (see below), so the first automated run opens one reordering PR with an empty `telemetry-events.json` diff and is quiet thereafter.

Also confirmed the catalog is still complete on current `main`: the only `oss.*` event literals anywhere under `packages/runtime/src` + `packages/shared/src` are the 5 catalog entries (43/22/12/9/9 occurrences), so no untyped event is being silently dropped. Both v1 and v2 catalogs remain byte-identical, so the divergence guard passes.

**Docs surface**

```
$ tsx scripts/telemetry/emit-fragment.ts --surface docs --out /tmp/CopilotKit.docs.json
docs: wrote 11 events → /tmp/CopilotKit.docs.json (released_in shell-docs@5855496103)
```

11 events (up from 7 when this PR was authored — the docs site grew): `cli_command_copied`, `docs_conversion_clicked`, `docs_conversion_copied`, `docs.framework_selected`, `docs.frontend_selected`, `docs.journey_continued`, `hero_command_copied`, `markdown_copied`, `open_in_llm_clicked`, `talk_to_us_clicked`, `try_for_free_clicked`. `$pageview` correctly dropped.

**End-to-end against the real registry**

Dropped both emitted fragments into a clean `oss-path-to-production@main` worktree and ran its own `pnpm reconcile`:

- Both fragments **validate against `fragment.schema.json`** (ajv, via the reconciler's loader).
- Reconcile succeeded; `telemetry-events.json` grew by 216 lines with 11 new `"surface": "docs"` observations.
- **Zero `oss.runtime.*` entries changed** — confirming the runtime fragment's reordering has no canonical effect.

## Fixed during revalidation

- **`add-paths` bug in the docs workflow (would have failed on first run).** It ran `pnpm reconcile` but listed only the fragment in `add-paths`, so its PR would have landed a fresh fragment beside a stale `telemetry-events.json` and tripped the registry's `telemetry-reconcile` staleness gate — the exact failure the runtime workflow was already fixed for. Verified against the registry's shipped emitters: every automated fragment PR there (`website.corp` #232/#220, Intelligence surfaces #228) carries `telemetry-events.json` alongside its fragment.
- **Stale action pins.** Refreshed to the SHAs `main` now uses everywhere: `actions/checkout` v7, `actions/setup-node` v7.0.0, `pnpm/action-setup` v6.0.10.
- **Over-broad docs trigger.** Narrowed from `showcase/shell-docs/**` to the code under `src/**`, excluding `src/content/**` — 1012 MDX + 140 JSON prose files with zero `.ts`/`.tsx`, none of which can hold a `posthog.capture` call site. Prose edits no longer fire a full monorepo install.
- **zizmor justification accuracy.** `setup-node` v7 adds a `package-manager-cache` input defaulting to `true`; per its `action.yml` it engages only when `package.json` declares **npm**, and this repo declares pnpm — so the workflow is still cacheless and the suppression still holds. Noted inline.

## Prerequisite — now satisfied

The registry App secrets (`TELEMETRY_REGISTRY_APP_ID`, `TELEMETRY_REGISTRY_APP_PRIVATE_KEY`) are configured on this repo (added 2026-07-09), and `app/copilotkit-telemetry-bot` is demonstrably installed on `oss-path-to-production` — it has been opening fragment PRs there from other surfaces (#232, #228, #220). No further setup needed.

## Not in this PR

- The registry-side seed of the **docs** surface. The docs fragment first appears via this workflow's initial run, which now also carries the reconciled canonical, so it lands green.
- The **web-inspector** surface, hand-seeded in the registry since this PR was authored, remains manual. Automating it is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
