### PR TITLE
feat(banking): data-bridged Open Generative UI

### DIFF
--- a/examples/showcases/banking/e2e/aimock-server.mjs
+++ b/examples/showcases/banking/e2e/aimock-server.mjs
@@ -1,13 +1,16 @@
 #!/usr/bin/env node
 /**
- * aimock launcher for the deterministic memory E2E (Task 7).
+ * aimock launcher for the deterministic banking E2Es.
  *
- * Starts an aimock server on $AIMOCK_PORT (default 7099) loading the fixtures in
- * fixtures/memory-learning.fixtures.json, so the banking dev server can point
- * OPENAI_BASE_URL at it and get deterministic agent tool calls.
+ * Starts an aimock server on $AIMOCK_PORT (default 7099) so the banking dev server
+ * can point OPENAI_BASE_URL at it and get deterministic agent tool calls. The
+ * fixture file is $AIMOCK_FIXTURES (a path relative to cwd, or absolute); when
+ * unset it defaults to fixtures/memory-learning.fixtures.json. The OGUI routing
+ * suite (playwright.ogui.config.ts) sets AIMOCK_FIXTURES=fixtures/ogui-routing...
+ * on its own aimock instance (port 7098).
  *
- * Used as Playwright webServer[0] (see playwright.config.ts) — Playwright waits on
- * the readiness URL before starting the dev server.
+ * Used as a Playwright webServer entry — Playwright waits on the readiness URL
+ * before starting the dev server.
  *
  * VERIFY ON FIRST GREEN RUN (unverified API assumptions):
  * - The exact @copilotkit/aimock programmatic API. This uses the documented
@@ -22,11 +25,15 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
 const PORT = Number(process.env.AIMOCK_PORT ?? 7099);
-const FIXTURES = join(
-  dirname(fileURLToPath(import.meta.url)),
-  "fixtures",
-  "memory-learning.fixtures.json",
-);
+const FIXTURES = process.env.AIMOCK_FIXTURES
+  ? (process.env.AIMOCK_FIXTURES.startsWith("/")
+      ? process.env.AIMOCK_FIXTURES
+      : join(process.cwd(), process.env.AIMOCK_FIXTURES))
+  : join(
+      dirname(fileURLToPath(import.meta.url)),
+      "fixtures",
+      "memory-learning.fixtures.json",
+    );
 
 const mod = await import("@copilotkit/aimock");
 

--- a/examples/showcases/banking/e2e/fixtures/ogui-routing.fixtures.json
+++ b/examples/showcases/banking/e2e/fixtures/ogui-routing.fixtures.json
@@ -1,0 +1,79 @@
+{
+  "_comment": [
+    "aimock fixtures for the deterministic OGUI routing test.",
+    "Single-turn: each pill message maps to the tool the agent must pick.",
+    "Guards BOTH boundary sides — curated pills must NOT route to generateSandboxedUi,",
+    "OGUI pills MUST. userMessage values are copied byte-for-byte from wrapper.tsx pill messages."
+  ],
+  "fixtures": [
+    {
+      "match": { "userMessage": "Show me the spending trend over time." },
+      "response": { "toolCalls": [{ "name": "showSpendingTrend", "arguments": {} }] }
+    },
+    {
+      "match": {
+        "userMessage": "Show me budget usage by policy — which ones are close to or over their limit?"
+      },
+      "response": { "toolCalls": [{ "name": "showBudgetUsage", "arguments": {} }] }
+    },
+    {
+      "match": { "userMessage": "Where is the money going? Break down spend by team." },
+      "response": { "toolCalls": [{ "name": "showSpendBreakdown", "arguments": {} }] }
+    },
+    {
+      "match": { "userMessage": "Compare our income vs expenses — how is our cash flow?" },
+      "response": { "toolCalls": [{ "name": "showIncomeVsExpenses", "arguments": {} }] }
+    },
+    {
+      "match": {
+        "userMessage": "Build a full spend report on the canvas: KPIs, the spending trend, budget usage, and a spend breakdown by team."
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "render_report",
+            "arguments": {
+              "title": "Spend report",
+              "kpis": ["totalSpend"],
+              "charts": ["spendingTrend"]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Build an interactive spend explorer I can filter and play with — pull the real transactions and policies."
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "generateSandboxedUi",
+            "arguments": {
+              "initialHeight": 320,
+              "html": "<div id=\"root\">Spend explorer</div>",
+              "jsFunctions": "async function load(){ const t = await window.Websandbox.connection.remote.getTransactions(); document.getElementById('root').textContent = 'txns: ' + t.length; } load();"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Prototype an interactive what-if calculator for our cash flow using our real income and expense figures."
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "generateSandboxedUi",
+            "arguments": {
+              "initialHeight": 320,
+              "html": "<div id=\"calc\">What-if calculator</div>",
+              "jsFunctions": "async function load(){ const k = await window.Websandbox.connection.remote.getKpis(); document.getElementById('calc').textContent = 'spend: ' + k.totalSpend; } load();"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/showcases/banking/e2e/ogui-routing.spec.ts
+++ b/examples/showcases/banking/e2e/ogui-routing.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Deterministic (aimock-backed) routing guard for the adjacency set — the pills
+// OGUI could plausibly steal. Curated pills must NOT open an OGUI iframe; OGUI
+// pills must. Runs in OSS mode via playwright.ogui.config.ts (isolated ports).
+//
+// NUANCE: clicking a pill sends its `message` (not its `title`); aimock matches
+// on userMessage = that message (see e2e/fixtures/ogui-routing.fixtures.json).
+// Here we click by the pill TITLE (what the user sees). Keep these straight.
+
+async function openChatAndClick(page: Page, pillText: string) {
+  await page.goto("/");
+  // The docked chat starts closed; CopilotSidebar's launcher is "Open chat".
+  const launcher = page.getByRole("button", { name: /open chat/i });
+  if (await launcher.count()) await launcher.first().click();
+  // Wait for the chat to hydrate (input present) before clicking a pill, else
+  // the click can land before React wires the pill's onClick and is dropped.
+  await expect(page.getByPlaceholder(/type a message/i)).toBeVisible({
+    timeout: 15_000,
+  });
+  const pill = page
+    .getByTestId("copilot-suggestion")
+    .filter({ hasText: pillText })
+    .first();
+  // The docked chat panel is pinned to the right edge, so its suggestion pills
+  // land outside the viewport where Playwright's click (even force:true)
+  // refuses to fire. Call the element's native click() — this drives React's
+  // onClick (which sends the pill's `message` to the agent) regardless of
+  // viewport position. Retry until the send registers (a user message bubble
+  // appears), covering the race where an early click is dropped before
+  // hydration completes.
+  await expect(async () => {
+    await pill.evaluate((el) => (el as HTMLElement).click());
+    await expect(
+      page.getByTestId("copilot-user-message").first(),
+    ).toBeVisible({ timeout: 2_000 });
+  }).toPass({ timeout: 20_000 });
+}
+
+const CURATED = [
+  { pill: "Show the spending trend", heading: /spending trend/i },
+  { pill: "Budgets near their limit?", heading: /budget usage/i },
+  { pill: "Where is the money going?", heading: /spend breakdown/i },
+  { pill: "How's our cash flow?", heading: /income vs expenses/i },
+];
+
+test.describe("OGUI routing — adjacency set", () => {
+  for (const { pill, heading } of CURATED) {
+    test(`curated pill "${pill}" renders its chart, not an OGUI iframe`, async ({
+      page,
+    }) => {
+      await openChatAndClick(page, pill);
+      // The curated chart renders inside an assistant message as an <h3> card
+      // title. Scope to the transcript's assistant messages (not the pill row,
+      // whose titles also contain these words). Match on the <h3> text rather
+      // than role="heading": CopilotKit paints rendered tool output with
+      // pointer-events/aria affordances that can drop the heading from the
+      // accessibility tree, so getByRole("heading") is unreliable here.
+      await expect(
+        page
+          .getByTestId("copilot-assistant-message")
+          .locator("h3")
+          .filter({ hasText: heading })
+          .first(),
+      ).toBeVisible({ timeout: 30_000 });
+      await expect(page.locator("iframe")).toHaveCount(0);
+    });
+  }
+
+  test('boundary: "Build a spend report on the canvas" routes to render_report, not OGUI', async ({
+    page,
+  }) => {
+    await openChatAndClick(page, "Build a spend report on the canvas");
+    await expect(page.getByText(/rendered on the canvas/i)).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.locator("iframe")).toHaveCount(0);
+  });
+
+  const OGUI = [
+    "Build an interactive spend explorer",
+    "Prototype a cash-flow what-if calculator",
+  ];
+  for (const pill of OGUI) {
+    test(`OGUI pill "${pill}" opens a sandboxed iframe`, async ({ page }) => {
+      await openChatAndClick(page, pill);
+      await expect(page.locator("iframe").first()).toBeVisible({
+        timeout: 30_000,
+      });
+    });
+  }
+});

--- a/examples/showcases/banking/e2e/smoke.spec.ts
+++ b/examples/showcases/banking/e2e/smoke.spec.ts
@@ -7,7 +7,7 @@ import type { ConsoleMessage, Page } from "@playwright/test";
  * What this covers:
  *   1. App boots and the dashboard renders credible content (brand + cards UI).
  *   2. The CopilotKit v2 popup launcher opens the modal.
- *   3. The three configured suggestion pills are visible.
+ *   3. The arc-leading suggestion pills (incl. the OGUI pill) are visible.
  *
  * What this intentionally does NOT do:
  *   - Send any chat message
@@ -86,17 +86,20 @@ test.describe("banking showcase smoke", () => {
       page.getByRole("dialog", { name: /Northwind Copilot/i }),
     ).toBeVisible();
 
-    // The three suggestion pills configured by BankingSuggestions render as
-    // buttons with data-testid="copilot-suggestion" (see
-    // CopilotChatSuggestionPill.tsx). Their labels are the suggestion titles.
+    // Pills configured by BankingSuggestions render as buttons with
+    // data-testid="copilot-suggestion" (CopilotChatSuggestionPill.tsx). Assert
+    // the arc-leading pills are present rather than a brittle exact count —
+    // the pill catalog grows over time (curated charts, OGUI, cross-page ops).
     const suggestions = page.getByTestId("copilot-suggestion");
-    await expect(suggestions).toHaveCount(3);
+    await expect(suggestions.first()).toBeVisible();
     await expect(
-      suggestions.filter({ hasText: "View transactions" }),
+      suggestions.filter({ hasText: "Approve the $5,000 Google Ads charge" }),
     ).toBeVisible();
-    await expect(suggestions.filter({ hasText: "Add a card" })).toBeVisible();
     await expect(
-      suggestions.filter({ hasText: "Assign a policy" }),
+      suggestions.filter({ hasText: "Review my pending transactions" }),
+    ).toBeVisible();
+    await expect(
+      suggestions.filter({ hasText: "Build an interactive spend explorer" }),
     ).toBeVisible();
 
     // Make sure nothing genuinely broken showed up in the console while the

--- a/examples/showcases/banking/package.json
+++ b/examples/showcases/banking/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint .",
     "test:e2e": "playwright test",
+    "test:e2e:ogui": "playwright test -c playwright.ogui.config.ts",
     "test:self-learning": "playwright test e2e/memory-learning.spec.ts",
     "test:unit": "vitest run",
     "mint-dev-license": "node scripts/mint-dev-license.mjs"

--- a/examples/showcases/banking/playwright.config.ts
+++ b/examples/showcases/banking/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./e2e",
+  testIgnore: /ogui-routing\.spec\.ts/,
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/examples/showcases/banking/playwright.ogui.config.ts
+++ b/examples/showcases/banking/playwright.ogui.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig } from "@playwright/test";
+
+// Dedicated config for the OGUI routing test. Isolated ports (dev :3002, aimock
+// :7098) and OSS mode (no INTELLIGENCE_* env) so it never collides with the
+// Intelligence-mode suite in playwright.config.ts and needs no docker stack.
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: /ogui-routing\.spec\.ts/,
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: "list",
+  use: {
+    baseURL: "http://localhost:3002",
+    trace: "on-first-retry",
+    // Wide enough that the full suggestion-pill row stays on-screen — the pills
+    // overflow a default 1280px viewport, landing off-screen where clicks fail.
+    viewport: { width: 1680, height: 900 },
+  },
+  webServer: [
+    {
+      command:
+        "AIMOCK_FIXTURES=e2e/fixtures/ogui-routing.fixtures.json AIMOCK_PORT=7098 node e2e/aimock-server.mjs",
+      url: "http://localhost:7098/health",
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+    },
+    {
+      command: "pnpm dev",
+      url: "http://localhost:3002",
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: {
+        PORT: "3002",
+        OPENAI_API_KEY: "test",
+        OPENAI_BASE_URL: "http://localhost:7098/v1",
+        // OSS mode: deliberately NO INTELLIGENCE_* vars → the runtime uses the
+        // InMemoryAgentRunner path (no docker, no gateway).
+        GLASS_ENGINE_AVAILABLE: "false",
+        NEXT_TELEMETRY_DISABLED: "1",
+      },
+    },
+  ],
+});

--- a/examples/showcases/banking/src/a2ui/catalog/renderers.tsx
+++ b/examples/showcases/banking/src/a2ui/catalog/renderers.tsx
@@ -8,6 +8,7 @@ import {
   IncomeExpenseChart,
 } from "@/components/analytics-charts";
 import { TransactionsList } from "@/components/transactions-list";
+import { isOverLimit } from "@/lib/over-limit";
 import { cn, formatCurrency } from "@/lib/utils";
 import { useReportData } from "../report-data";
 
@@ -110,17 +111,6 @@ const StatCard = ({
 }>) => {
   const { transactions, policies } = useReportData();
   const pending = transactions.filter((t) => t.status === "pending");
-  // A pending charge is "over limit" when approving it would push its policy
-  // past the limit and it has no clearing exception yet — mirrors `statusOf`
-  // in transactions-list.tsx (Transaction has no `overLimit` field).
-  const isOverLimit = (t: (typeof pending)[number]) => {
-    const policy = policies.find((p) => p.id === t.policyId);
-    return (
-      !!policy &&
-      policy.spent + Math.abs(t.amount) > policy.limit &&
-      !t.activeExceptionId
-    );
-  };
   let value = "";
   switch (props.metric) {
     case "totalSpend":
@@ -134,7 +124,7 @@ const StatCard = ({
       value = String(pending.length);
       break;
     case "overLimitCount":
-      value = String(pending.filter(isOverLimit).length);
+      value = String(pending.filter((t) => isOverLimit(t, policies)).length);
       break;
     case "policyCount":
       value = String(policies.length);

--- a/examples/showcases/banking/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/showcases/banking/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -222,7 +222,23 @@ Examples:
 - "build me a spend report" / "give me an overview of our spending" / "show it on the canvas" -> render_report (canvas).
 - "show the spending trend" / "what's our budget usage?" -> in-chat chart tool (inline).
 
-render_report inputs: kpis is any of totalSpend | pendingCount | overLimitCount | policyCount; charts is any of spendingTrend | budgetUsage | spendBreakdown | incomeVsExpenses; transactions (optional) is one of all | pending | approved | denied. title and summary are LABELS ONLY — never put figures, amounts, percentages, or trend claims in them; every number comes from the selected KPIs/charts, which bind live data on the client.`,
+render_report inputs: kpis is any of totalSpend | pendingCount | overLimitCount | policyCount; charts is any of spendingTrend | budgetUsage | spendBreakdown | incomeVsExpenses; transactions (optional) is one of all | pending | approved | denied. title and summary are LABELS ONLY — never put figures, amounts, percentages, or trend claims in them; every number comes from the selected KPIs/charts, which bind live data on the client.
+
+OPEN GENERATIVE UI (generateSandboxedUi): You can also author a custom, sandboxed
+interactive UI on demand with the built-in generateSandboxedUi tool. Use it ONLY
+for something the standard charts and the render_report canvas cannot express: an
+interactive tool, calculator, explorer, what-if/scenario simulator, playground,
+prototype, or a custom/novel visualization (e.g. a treemap, heatmap, sankey, 3D
+view, or a specific chart library like Chart.js / D3 / Three.js).
+- NOT for a report, overview, dashboard, or a standard chart — those ALWAYS use
+  render_report or the in-chat chart tools, EVEN WHEN the user says "build" or
+  "make" (e.g. "build a spend report on the canvas" -> render_report, never
+  generateSandboxedUi).
+- When you build such a UI you MUST obtain every figure by calling the exposed
+  sandbox functions (getTransactions, getPolicies, getCards, getKpis) from inside
+  the generated JavaScript. NEVER invent, inline, or hardcode numbers.
+- generateSandboxedUi is NEVER part of the over-limit approval / teach-recall arc,
+  the approvals queue, or the standard chart/report responses.`,
   tools: [renderReportTool],
   // Temperature 0 for consistent tool routing — the teach-flow sequencing
   // (recall_memory → offerWorkflowRecording on an over-limit approve) needs the
@@ -322,6 +338,7 @@ function createRuntime(): CopilotRuntime {
       lockHeartbeatIntervalSeconds: 12,
       generateThreadNames: true,
       a2ui: { injectA2UITool: false },
+      openGenerativeUI: { agents: ["default"] },
     });
   }
 
@@ -330,6 +347,7 @@ function createRuntime(): CopilotRuntime {
     agents: { default: bankingAgent },
     runner: new InMemoryAgentRunner(),
     a2ui: { injectA2UITool: false },
+    openGenerativeUI: { agents: ["default"] },
   });
 }
 

--- a/examples/showcases/banking/src/app/wrapper.tsx
+++ b/examples/showcases/banking/src/app/wrapper.tsx
@@ -21,6 +21,8 @@ import { ReportCopilotTools } from "@/components/wow/report-tool";
 import { GlassEngineProvider } from "@/components/glass-engine-context";
 import { InspectorStoreProvider } from "@/lib/inspector/store";
 import { InspectorPane } from "@/components/inspector/inspector-pane";
+import { sandboxFunctions } from "@/opengen/sandbox-functions";
+import { SandboxDataSync } from "@/opengen/sandbox-data-sync";
 
 // The agent's render_report tool result becomes an `a2ui-surface` activity that
 // <ReportCanvas/> renders full-screen (it reads the ops from the agent message
@@ -74,6 +76,22 @@ const A2UI_RENDERERS: ReactActivityMessageRenderer<unknown>[] = [
 // Page-scoped fire-and-forget tools (spend alert, card replacement, flag for
 // review) are deliberately NOT pilled: they only exist on the home route, so
 // a global pill for them would be a broken promise on every other page.
+
+// Design brief handed to generateSandboxedUi so generated UIs match the demo's
+// look instead of the generic DEFAULT_DESIGN_SKILL. Dark-mode aware, brand accent,
+// glass surfaces, Geist type — the same language as the curated cards.
+const NORTHWIND_DESIGN_SKILL = `You are designing UI for Northwind Finance, a
+corporate banking dashboard. Match its aesthetic:
+- Surfaces: rounded-2xl cards, subtle hairline borders, soft shadow, a translucent
+  "glass" surface over the page background. Generous padding.
+- Type: the Geist sans-serif family; clear hierarchy (semibold headings, muted
+  secondary text). Currency in USD with thousands separators.
+- Color: a restrained neutral base with a single indigo/violet brand accent for
+  emphasis, positive = green, negative/over-limit = red. Never rainbow palettes.
+- Dark-mode aware: read colors from CSS variables / prefers-color-scheme; never
+  hardcode white backgrounds.
+- Keep it calm, precise, and enterprise-appropriate — this is a finance tool.`;
+
 function BankingSuggestions() {
   useConfigureSuggestions({
     available: "always",
@@ -135,6 +153,20 @@ function BankingSuggestions() {
         title: "How's our cash flow?",
         message: "Compare our income vs expenses — how is our cash flow?",
       },
+      // ── Open Generative UI (custom interactive surfaces) ─────────────────
+      {
+        // OGUI-only: an interactive explorer the fixed catalog can't express.
+        // "interactive"/"explorer" (not "build") is what routes this to
+        // generateSandboxedUi; figures come from the sandbox functions.
+        title: "Build an interactive spend explorer",
+        message:
+          "Build an interactive spend explorer I can filter and play with — pull the real transactions and policies.",
+      },
+      {
+        title: "Prototype a cash-flow what-if calculator",
+        message:
+          "Prototype an interactive what-if calculator for our cash flow using our real income and expense figures.",
+      },
       {
         title: "How do approvals work?",
         message: "Explain how an over-limit charge gets cleared and approved.",
@@ -190,6 +222,7 @@ export function CopilotKitWrapper({
       // the surface itself renders full-screen in <ReportCanvas/>.
       a2ui={{ catalog }}
       renderActivityMessages={A2UI_RENDERERS}
+      openGenerativeUI={{ sandboxFunctions, designSkill: NORTHWIND_DESIGN_SKILL }}
       // Use the v2-native CopilotKitProvider, NOT the v1 `CopilotKit`
       // compatibility bridge. The bridge wraps the chat in a heavier stack (its
       // own ThreadsProvider + a second CopilotChatConfigurationProvider +
@@ -215,6 +248,7 @@ export function CopilotKitWrapper({
       */}
       <CopilotChatConfigurationProvider agentId="default" threadId={threadId}>
         <BankingSuggestions />
+        <SandboxDataSync />
         {/*
           ChatInboxProvider carries the inbox open/closed state + the thread
           actions (select/create) so the panel header and the inbox rows can

--- a/examples/showcases/banking/src/components/copilot-context.tsx
+++ b/examples/showcases/banking/src/components/copilot-context.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/analytics-charts";
 import { ApprovalFlowDiagram } from "@/components/approval-flow-diagram";
 import { PERMISSIONS } from "@/app/api/v1/permissions";
+import { withOverLimit } from "@/lib/over-limit";
 import { Button } from "./ui/button";
 
 export enum Page {
@@ -113,14 +114,7 @@ const CopilotContext = ({ children }: { children: React.ReactNode }) => {
     value: JSON.stringify({
       cards,
       policies,
-      transactions: transactions.map((t) => {
-        const policy = policies.find((p) => p.id === t.policyId);
-        const overLimit =
-          !!policy &&
-          policy.spent + Math.abs(t.amount) > policy.limit &&
-          !t.activeExceptionId;
-        return { ...t, overLimit };
-      }),
+      transactions: withOverLimit(transactions, policies),
     }),
   });
 

--- a/examples/showcases/banking/src/lib/over-limit.test.ts
+++ b/examples/showcases/banking/src/lib/over-limit.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { isOverLimit, withOverLimit } from "./over-limit";
+import { ExpenseRole, type ExpensePolicy, type Transaction } from "@/app/api/v1/data";
+
+const policies: ExpensePolicy[] = [
+  { id: "pol-mkt", type: ExpenseRole.Marketing, limit: 5000, spent: 500 },
+  { id: "pol-eng", type: ExpenseRole.Engineering, limit: 15000, spent: 1500 },
+];
+
+const base: Omit<Transaction, "id" | "amount" | "policyId" | "activeExceptionId"> = {
+  title: "x",
+  date: "2026-01-01",
+  cardId: "c1",
+  status: "pending",
+};
+
+describe("isOverLimit", () => {
+  it("is true when spent + |amount| exceeds the limit and there is no active exception", () => {
+    const t: Transaction = { ...base, id: "t1", amount: -5000, policyId: "pol-mkt", activeExceptionId: null };
+    expect(isOverLimit(t, policies)).toBe(true);
+  });
+
+  it("is false once an exception is active, even if it exceeds the limit", () => {
+    const t: Transaction = { ...base, id: "t2", amount: -5000, policyId: "pol-mkt", activeExceptionId: "ex-1" };
+    expect(isOverLimit(t, policies)).toBe(false);
+  });
+
+  it("is false within the limit", () => {
+    const t: Transaction = { ...base, id: "t3", amount: -100, policyId: "pol-mkt", activeExceptionId: null };
+    expect(isOverLimit(t, policies)).toBe(false);
+  });
+
+  it("is false when no matching policy exists", () => {
+    const t: Transaction = { ...base, id: "t4", amount: -999999, policyId: "pol-missing", activeExceptionId: null };
+    expect(isOverLimit(t, policies)).toBe(false);
+  });
+});
+
+describe("withOverLimit", () => {
+  it("attaches the derived overLimit flag to every transaction", () => {
+    const txs: Transaction[] = [
+      { ...base, id: "t1", amount: -5000, policyId: "pol-mkt", activeExceptionId: null },
+      { ...base, id: "t3", amount: -100, policyId: "pol-mkt", activeExceptionId: null },
+    ];
+    const out = withOverLimit(txs, policies);
+    expect(out.map((t) => t.overLimit)).toEqual([true, false]);
+    expect(out[0]).toMatchObject({ id: "t1", overLimit: true });
+  });
+});

--- a/examples/showcases/banking/src/lib/over-limit.ts
+++ b/examples/showcases/banking/src/lib/over-limit.ts
@@ -1,0 +1,31 @@
+import type { ExpensePolicy, Transaction } from "@/app/api/v1/data";
+
+/** A transaction annotated with the derived over-limit flag. */
+export type TransactionWithOverLimit = Transaction & { overLimit: boolean };
+
+/**
+ * A pending charge is "over limit" when approving it would push its policy past
+ * the limit AND it has no clearing exception yet. Single source of truth for the
+ * over-limit derivation across the demo's data surfaces — the chat readable
+ * (copilot-context), the A2UI report renderers, and the OGUI sandbox handlers —
+ * so they can never disagree.
+ */
+export function isOverLimit(
+  transaction: Transaction,
+  policies: ExpensePolicy[],
+): boolean {
+  const policy = policies.find((p) => p.id === transaction.policyId);
+  return (
+    !!policy &&
+    policy.spent + Math.abs(transaction.amount) > policy.limit &&
+    !transaction.activeExceptionId
+  );
+}
+
+/** Map transactions to include the derived `overLimit` flag. */
+export function withOverLimit(
+  transactions: Transaction[],
+  policies: ExpensePolicy[],
+): TransactionWithOverLimit[] {
+  return transactions.map((t) => ({ ...t, overLimit: isOverLimit(t, policies) }));
+}

--- a/examples/showcases/banking/src/opengen/sandbox-data-sync.tsx
+++ b/examples/showcases/banking/src/opengen/sandbox-data-sync.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { useEffect } from "react";
+import useCreditCards from "@/app/actions";
+import { setSandboxSnapshot } from "@/opengen/sandbox-functions";
+
+/**
+ * Mirrors the app's live (role-filtered) view into the OGUI sandbox snapshot so
+ * the iframe's callbacks return the exact data the user sees. Renders nothing.
+ * `cards` from useCreditCards is already role-scoped, so the iframe inherits the
+ * same visibility rules as the dashboard.
+ */
+export function SandboxDataSync() {
+  const { cards, policies, transactions } = useCreditCards();
+  useEffect(() => {
+    setSandboxSnapshot({ cards, policies, transactions });
+  }, [cards, policies, transactions]);
+  return null;
+}

--- a/examples/showcases/banking/src/opengen/sandbox-functions.test.ts
+++ b/examples/showcases/banking/src/opengen/sandbox-functions.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { sandboxFunctions, setSandboxSnapshot } from "./sandbox-functions";
+import type { Card, ExpensePolicy, Transaction } from "@/app/api/v1/data";
+import { CardBrand, ExpenseRole } from "@/app/api/v1/data";
+
+const fn = (name: string) => {
+  const f = sandboxFunctions.find((s) => s.name === name);
+  if (!f) throw new Error(`no sandbox function named ${name}`);
+  return f;
+};
+
+const cards: Card[] = [
+  { id: "c1", last4: "4242", expiry: "12/29", type: CardBrand.Visa, color: "bg-blue-500", pin: "1234", expensePolicyId: "pol-mkt" },
+];
+const policies: ExpensePolicy[] = [
+  { id: "pol-mkt", type: ExpenseRole.Marketing, limit: 5000, spent: 500 },
+];
+const transactions: Transaction[] = [
+  { id: "t1", title: "Google Ads", amount: -5000, date: "2026-01-01", policyId: "pol-mkt", cardId: "c1", status: "pending", activeExceptionId: null },
+  { id: "t2", title: "Lunch", amount: -20, date: "2026-01-02", policyId: "pol-mkt", cardId: "c1", status: "approved", activeExceptionId: null },
+];
+
+beforeEach(() => setSandboxSnapshot({ cards, policies, transactions }));
+
+describe("getCards", () => {
+  it("never leaks pin or expiry", async () => {
+    const out = (await fn("getCards").handler({})) as Record<string, unknown>[];
+    expect(out).toHaveLength(1);
+    expect(out.every((c) => !("pin" in c))).toBe(true);
+    expect(out.every((c) => !("expiry" in c))).toBe(true);
+    expect(out[0]).toMatchObject({ id: "c1", last4: "4242", type: CardBrand.Visa, expensePolicyId: "pol-mkt" });
+  });
+});
+
+describe("getPolicies", () => {
+  it("projects policies to id/type/limit/spent", async () => {
+    const out = (await fn("getPolicies").handler({})) as Record<string, unknown>[];
+    expect(out).toEqual([
+      { id: "pol-mkt", type: ExpenseRole.Marketing, limit: 5000, spent: 500 },
+    ]);
+  });
+});
+
+describe("getTransactions", () => {
+  it("surfaces the derived overLimit flag", async () => {
+    const out = (await fn("getTransactions").handler({})) as Array<{ id: string; overLimit: boolean }>;
+    expect(out.find((t) => t.id === "t1")?.overLimit).toBe(true);
+    expect(out.find((t) => t.id === "t2")?.overLimit).toBe(false);
+  });
+
+  it("honors the status filter", async () => {
+    const out = (await fn("getTransactions").handler({ status: "approved" })) as Array<{ id: string }>;
+    expect(out.map((t) => t.id)).toEqual(["t2"]);
+  });
+});
+
+describe("getKpis", () => {
+  it("computes counts from the snapshot", async () => {
+    const kpis = (await fn("getKpis").handler({})) as {
+      totalSpend: number; pendingCount: number; overLimitCount: number; policyCount: number;
+    };
+    expect(kpis).toEqual({ totalSpend: 20, pendingCount: 1, overLimitCount: 1, policyCount: 1 });
+  });
+});

--- a/examples/showcases/banking/src/opengen/sandbox-functions.ts
+++ b/examples/showcases/banking/src/opengen/sandbox-functions.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+import type { SandboxFunction } from "@copilotkit/react-core/v2";
+import type { Card, CardBrand, ExpensePolicy, Transaction } from "@/app/api/v1/data";
+import { withOverLimit, isOverLimit } from "@/lib/over-limit";
+
+/**
+ * The single source the sandbox reads. Holds FULL domain objects (mirrors
+ * `useCreditCards`); every handler projects to a DTO at the boundary so no
+ * secret (Card.pin, etc.) ever crosses into the iframe's LLM-authored JS.
+ * <SandboxDataSync/> keeps this in sync with the app's live view.
+ */
+export type Snapshot = { transactions: Transaction[]; policies: ExpensePolicy[]; cards: Card[] };
+let snapshot: Snapshot = { transactions: [], policies: [], cards: [] };
+/**
+ * Replace the snapshot the handlers read. Takes ownership of `next` (and its
+ * arrays) by reference — it does not clone. The sole caller is <SandboxDataSync/>,
+ * which passes React state treated as immutable, so the reference is never mutated
+ * in place after handoff.
+ */
+export function setSandboxSnapshot(next: Snapshot): void {
+  snapshot = next;
+}
+
+// ── Projection DTOs (allowlist — no raw domain objects cross the boundary) ──
+type SafeCard = { id: string; last4: string; type: CardBrand; expensePolicyId?: string };
+type SafeTransaction = {
+  id: string; title: string; amount: number; date: string;
+  policyId: string; cardId: string; status: Transaction["status"]; overLimit: boolean;
+};
+type SafePolicy = { id: string; type: ExpensePolicy["type"]; limit: number; spent: number };
+type Kpis = { totalSpend: number; pendingCount: number; overLimitCount: number; policyCount: number };
+
+const toSafeCard = (c: Card): SafeCard => ({ id: c.id, last4: c.last4, type: c.type, expensePolicyId: c.expensePolicyId });
+const toSafePolicy = (p: ExpensePolicy): SafePolicy => ({ id: p.id, type: p.type, limit: p.limit, spent: p.spent });
+
+function safeTransactions(status?: Transaction["status"]): SafeTransaction[] {
+  const withFlag = withOverLimit(snapshot.transactions, snapshot.policies);
+  const filtered = status ? withFlag.filter((t) => t.status === status) : withFlag;
+  return filtered.map((t) => ({
+    id: t.id, title: t.title, amount: t.amount, date: t.date,
+    policyId: t.policyId, cardId: t.cardId, status: t.status, overLimit: t.overLimit,
+  }));
+}
+
+export function computeKpis(s: Snapshot): Kpis {
+  const pending = s.transactions.filter((t) => t.status === "pending");
+  return {
+    totalSpend: s.transactions
+      .filter((t) => t.status === "approved")
+      .reduce((sum, t) => sum + Math.abs(t.amount), 0),
+    pendingCount: pending.length,
+    overLimitCount: pending.filter((t) => isOverLimit(t, s.policies)).length,
+    policyCount: s.policies.length,
+  };
+}
+
+/**
+ * Stable module-scope array — safe to hand straight to the provider. The
+ * handlers close over the mutable module snapshot, so the array identity never
+ * changes (avoids per-render re-registration + dev-console warnings from
+ * useStableArrayProp) while the DATA stays live.
+ */
+export const sandboxFunctions: SandboxFunction[] = [
+  {
+    name: "getTransactions",
+    description:
+      "Return the current transactions (real app data). Each includes `overLimit` " +
+      "(true when the pending charge exceeds its policy limit and has no active " +
+      "exception). Optional `status` filters to pending/approved/denied.",
+    parameters: z.object({ status: z.enum(["pending", "approved", "denied"]).optional() }),
+    handler: async ({ status }: { status?: Transaction["status"] }) => safeTransactions(status),
+  },
+  {
+    name: "getPolicies",
+    description: "Return the expense policies (id, type, limit, spent) — real app data.",
+    parameters: z.object({}),
+    handler: async () => snapshot.policies.map(toSafePolicy),
+  },
+  {
+    name: "getCards",
+    description: "Return the expense cards (id, last4, type, assigned policy) — real app data. No PIN or expiry is exposed.",
+    parameters: z.object({}),
+    handler: async () => snapshot.cards.map(toSafeCard),
+  },
+  {
+    name: "getKpis",
+    description: "Return headline KPIs: totalSpend, pendingCount, overLimitCount, policyCount — real app data.",
+    parameters: z.object({}),
+    handler: async () => computeKpis(snapshot),
+  },
+];


### PR DESCRIPTION
## Summary

Adds **Open Generative UI (OGUI)** to the Northwind banking demo: the agent can author sandboxed, interactive UI (rendered in an isolated iframe) that pulls **real, read-only banking data** via sandbox-function callbacks — so every figure it shows is real app data (fetched on demand), never fabricated, and no secret ever crosses the boundary.

- **New `src/opengen/` module** — a stable, module-scope `sandboxFunctions` array (`getTransactions`/`getPolicies`/`getCards`/`getKpis`) whose handlers read a module snapshot kept fresh by a headless `<SandboxDataSync/>` mirroring the app's live (role-filtered) `useCreditCards` view. Handlers return **projection DTOs** — `getCards` drops `pin`/`expiry`, guarded by a no-leak unit test.
- **Shared over-limit derivation** — extracted to `src/lib/over-limit.ts` so the chat readable, the A2UI report renderers, and the OGUI sandbox all agree on which charges are over limit (behavior-preserving).
- **OGUI enabled on both runtime paths** (Intelligence + OSS) with an **artifact-type routing fence** in the agent prompt: `generateSandboxedUi` only for interactive/custom UI, explicitly excluded from reports/charts *even when the user says "build"* (protects the existing "Build a spend report on the canvas" pill), and never part of the teach/recall arc.
- **Provider wiring** — `openGenerativeUI={{ sandboxFunctions, designSkill: NORTHWIND_DESIGN_SKILL }}` plus two OGUI-only pills ("Build an interactive spend explorer", "Prototype a cash-flow what-if calculator").
- **Deterministic routing guard** — `e2e/ogui-routing.spec.ts` (dedicated OSS-mode config, isolated ports, no docker) pins both boundary sides: the 5 visualization pills still route to their curated tool (no iframe), and the 2 OGUI pills render an iframe. Also fixes stale pill assertions in `smoke.spec.ts`.

Additive only — no changes to existing curated charts, the A2UI report canvas, or the teach/recall arc beyond the behavior-preserving over-limit extraction.

## Test Plan

- [x] Unit suite green (65 tests) — incl. `over-limit`, `sandbox-functions` (no-`pin`/`expiry` leak + over-limit flag + KPI counts)
- [x] `tsc --noEmit` clean · eslint clean · `nx build` success
- [x] OGUI routing e2e: **7 passed** (OSS mode, no docker) — curated pills + boundary + OGUI pills
- [ ] **CI**: license-gated `smoke.spec.ts` + docker-backed `memory-learning.spec.ts` (blocked locally: no license token / Intelligence stack; must pass unchanged in CI)
- [ ] **Manual**: render "Build an interactive spend explorer", confirm iframe figures match the dashboard in light/dark, and no PIN is ever shown

## Notes

- Follow-up (out of scope): additional over-limit derivation copies remain in `proactive-notice.tsx`, `transactions-list.tsx`, `pending-approvals-chat.tsx` — candidates to migrate onto the new shared helper.
- The deterministic e2e pins the tool call (aimock), so it proves the tool-rendering plumbing and that curated surfaces still work — real LLM routing is the manual check above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)