### PR TITLE
docs(mastra): clarify that interrupts are not supported, redirect to tool-based HITL

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/mastra/human-in-the-loop/index.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/human-in-the-loop/index.mdx
@@ -29,24 +29,24 @@ HITL combines the efficiency of AI with human judgment, creating a system that's
 
 ## How can I use this?
 
-Mastra supports two approaches to HITL, each suited for different use cases.
+Mastra supports HITL through frontend tools that render UI and collect user input.
 
 <CTACards
   columns={2}
   cards={[
     {
-      iconKey: "circlePause",
-      title: "Interrupt-based",
+      iconKey: "share2",
+      title: "Tool-based (Supported)",
       description:
-        "Use Mastra's native suspend/resume to pause tool execution and collect user input via useInterrupt.",
-      href: "/mastra/human-in-the-loop/interrupt-flow",
+        "Register frontend tools with useHumanInTheLoop that render UI and wait for user responses. This is the working approach for Mastra.",
+      href: "/mastra/human-in-the-loop/tool-based",
     },
     {
-      iconKey: "share2",
-      title: "Tool-based",
+      iconKey: "circlePause",
+      title: "Interrupt-based (Not Supported)",
       description:
-        "Register frontend tools with useHumanInTheLoop that render UI and wait for user responses.",
-      href: "/mastra/human-in-the-loop/tool-based",
+        "Mastra does not support native interrupt flow. See this page to understand why and learn about the tool-based alternative.",
+      href: "/mastra/human-in-the-loop/interrupt-flow",
     },
   ]}
 />

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/human-in-the-loop/interrupt-flow.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/human-in-the-loop/interrupt-flow.mdx
@@ -1,117 +1,54 @@
 ---
-title: Interrupts
+title: Interrupts (Not Supported)
 icon: "lucide/CirclePause"
-description: Learn how to implement Human-in-the-Loop (HITL) using Mastra's native tool suspension.
+description: Mastra does not support native interrupt flow. Use the tool-based HITL approach instead.
 ---
 
-import RunAndConnect from "@/snippets/integrations/mastra/run-and-connect.mdx"
+<Callout type="warning">
+  **Mastra does not support native interrupt flow.** The framework lacks LangGraph-style `interrupt()` primitives that pause execution mid-tool and emit AG-UI interrupt events. This page documents the interrupt pattern for reference, but it **will not work** with Mastra.
 
-## What is this?
-
-Mastra's [tool suspension](https://mastra.ai/docs/agents/agent-approval) provides a native way to implement Human-in-the-Loop workflows.
-Tools can call `suspend()` to pause execution mid-tool and send a payload to the frontend. CopilotKit's `useInterrupt` hook
-captures the suspension, renders custom UI, and sends the user's response back to resume the tool.
-
-## When should I use this?
-
-Interrupt-based HITL is ideal when a tool needs to pause its own execution to collect user input before continuing. Common use cases include:
-
-- **Approvals** — confirm before performing destructive or irreversible actions
-- **Disambiguation** — ask the user to clarify ambiguous inputs
-- **Progressive disclosure** — collect additional details only when needed at runtime
-
-<Callout type="info">
-  If you want to render a standalone frontend tool that collects user input without suspending tool execution, see the [tool-based approach](/mastra/human-in-the-loop/tool-based).
+  For working Human-in-the-Loop functionality with Mastra, use the [tool-based approach](/mastra/human-in-the-loop/tool-based) with `useHumanInTheLoop` instead.
 </Callout>
 
-## Implementation
+## What are interrupts?
+
+Some frameworks (like LangGraph) provide native interrupt capabilities where tools can pause their own execution mid-stream via an `interrupt()` or `suspend()` call, emit an AG-UI interrupt event to the frontend, and wait for the user's response before resuming. CopilotKit's `useInterrupt` hook captures these events and renders custom UI.
+
+## Why doesn't Mastra support this?
+
+Mastra does not emit AG-UI interrupt events. While Mastra has a `suspend()` API for tool approval workflows, it operates within Mastra's own execution model and does not integrate with CopilotKit's interrupt handling via the AG-UI protocol. Any `useInterrupt` hook in a Mastra application will listen for events that never arrive, leaving the UI stuck on tool-call placeholders.
+
+## What should I use instead?
+
+**Use the tool-based approach with `useHumanInTheLoop`.** This is the supported and working pattern for Mastra:
 
 <Steps>
 <Step>
-  ### Run and connect your agent
-  <RunAndConnect components={props.components} />
-</Step>
+  ### Register a frontend tool
 
-<Step>
-  ### Define a tool with `suspend()`
-
-  Create a Mastra tool that uses `suspend()` to pause execution and ask for user confirmation.
-  The `suspendSchema` defines what gets sent to the frontend, and the `resumeSchema` defines what the frontend sends back.
-
-  ```typescript title="src/mastra/tools/index.ts"
-  import { createTool } from "@mastra/core/tools";
-  import { z } from "zod";
-
-  export const confirmActionTool = createTool({
-    id: "confirm-action",
-    description: "Ask the user to confirm before performing a critical action",
-    inputSchema: z.object({
-      action: z.string().describe("Description of the action to confirm"),
-    }),
-    outputSchema: z.object({ confirmed: z.boolean() }),
-    suspendSchema: z.object({ action: z.string() }), // [!code highlight]
-    resumeSchema: z.object({ confirmed: z.boolean() }), // [!code highlight]
-    execute: async (inputData, context) => {
-      const { resumeData, suspend } = context?.agent ?? {};
-
-      // [!code highlight:4]
-      // First execution: pause and ask for confirmation
-      if (!resumeData) {
-        return suspend?.({ action: inputData.action });
-      }
-
-      // Resumed: the user has responded
-      return { confirmed: resumeData.confirmed };
-    },
-  });
-  ```
-</Step>
-
-<Step>
-  ### Add the tool to your agent
-
-  ```typescript title="src/mastra/agents/index.ts"
-  import { Agent } from "@mastra/core/agent";
-  import { openai } from "@ai-sdk/openai";
-  import { confirmActionTool } from "@/mastra/tools"; // [!code highlight]
-
-  export const myAgent = new Agent({
-    id: "my-agent",
-    name: "My Agent",
-    tools: { confirmActionTool }, // [!code highlight]
-    model: openai("gpt-4o"),
-    instructions:
-      "You are a helpful assistant. When performing critical actions, " +
-      "always use the confirm-action tool to get user approval first.",
-  });
-  ```
-</Step>
-
-<Step>
-  ### Handle the interrupt in your frontend
-
-  Use the `useInterrupt` hook to render UI when the agent suspends a tool.
-  The `event.value.suspendPayload` contains the data from the tool's `suspend()` call.
-  Call `resolve()` with the user's response to resume execution.
+  Define a frontend tool that renders UI and waits for the user's response:
 
   ```tsx title="ui/app/page.tsx"
-  import { useInterrupt } from "@copilotkit/react-core/v2"; // [!code highlight]
-  // ...
+  import { useHumanInTheLoop } from "@copilotkit/react-core/v2";
+  import { z } from "zod";
 
   function YourMainContent() {
-    // ...
-
-    // [!code highlight:16]
-    useInterrupt({
-      render: ({ event, resolve }) => {
-        const { action } = event.value.suspendPayload;
+    useHumanInTheLoop({
+      agentId: "my-agent",
+      name: "confirm_action",
+      description: "Ask the user to confirm before performing a critical action",
+      parameters: z.object({
+        action: z.string().describe("Description of the action to confirm"),
+      }),
+      render: ({ args, respond }) => {
+        if (!respond) return null;
         return (
           <div>
-            <p>{action}</p>
-            <button onClick={() => resolve({ confirmed: true })}>
+            <p>{args.action}</p>
+            <button onClick={() => respond({ confirmed: true })}>
               Approve
             </button>
-            <button onClick={() => resolve({ confirmed: false })}>
+            <button onClick={() => respond({ confirmed: false })}>
               Reject
             </button>
           </div>
@@ -119,149 +56,51 @@ Interrupt-based HITL is ideal when a tool needs to pause its own execution to co
       },
     });
 
-    // ...
-    return <div>{/* ... */}</div>;
+    return <div>{/* Your UI */}</div>;
   }
   ```
 </Step>
 
 <Step>
-  ### Give it a try!
+  ### Agent automatically uses the tool
 
-  Try asking your agent to do something that requires confirmation.
+  Mastra natively supports the AG-UI protocol. When your agent calls the `confirm_action` tool (defined on the frontend), CopilotKit automatically routes the call to your `useHumanInTheLoop` handler, renders the UI, and waits for the user's response.
+
+  No backend tool definition is needed—the frontend tool registration is sufficient.
+</Step>
+
+<Step>
+  ### Give it a try
+
+  Ask your agent something that requires confirmation:
 
   ```
   Can you delete all inactive user accounts?
   ```
 
-  The agent will call the `confirm-action` tool, which suspends execution and shows an approval UI.
-  After you approve or reject, the tool resumes with your response and the agent continues.
+  The agent will call the `confirm_action` tool, render your approval UI, and wait for the user's response before continuing.
 </Step>
 </Steps>
 
-## Advanced usage
+## Full working example
 
-### Handle multiple interrupt types
+For a complete implementation, see the [tool-based Human-in-the-Loop guide](/mastra/human-in-the-loop/tool-based), which includes:
 
-When your agent has multiple tools that use `suspend()`, use the `enabled` property to route each
-interrupt to the correct handler. The `eventValue.toolName` field identifies which tool triggered the suspension.
+- Multiple frontend tools with different UI patterns
+- Parameter validation with Zod schemas
+- Error handling and loading states
+- Production-ready examples
 
-<Steps>
-<Step>
-  ### Define multiple suspending tools
+## Comparison: Interrupts vs. Tool-based
 
-  ```typescript title="src/mastra/tools/index.ts"
-  import { createTool } from "@mastra/core/tools";
-  import { z } from "zod";
+| Feature | Interrupts (LangGraph) | Tool-based (Mastra) |
+|---------|------------------------|---------------------|
+| **Backend support** | ✅ Native `interrupt()` | ❌ No interrupt events |
+| **Frontend hook** | `useInterrupt` | `useHumanInTheLoop` |
+| **Execution model** | Tool pauses mid-execution | Agent calls frontend tool |
+| **When to use** | LangGraph, frameworks with native interrupt support | Mastra, frameworks without interrupt primitives |
+| **Works with Mastra?** | ❌ No | ✅ Yes |
 
-  export const confirmActionTool = createTool({
-    id: "confirm-action",
-    description: "Ask the user to confirm an action",
-    inputSchema: z.object({ action: z.string() }),
-    outputSchema: z.object({ confirmed: z.boolean() }),
-    suspendSchema: z.object({ action: z.string() }),
-    resumeSchema: z.object({ confirmed: z.boolean() }),
-    execute: async (inputData, context) => {
-      const { resumeData, suspend } = context?.agent ?? {};
-      if (!resumeData) return suspend?.({ action: inputData.action });
-      return { confirmed: resumeData.confirmed };
-    },
-  });
+---
 
-  export const askQuestionTool = createTool({
-    id: "ask-question",
-    description: "Ask the user a free-form question",
-    inputSchema: z.object({ question: z.string() }),
-    outputSchema: z.object({ answer: z.string() }),
-    suspendSchema: z.object({ question: z.string() }),
-    resumeSchema: z.object({ answer: z.string() }),
-    execute: async (inputData, context) => {
-      const { resumeData, suspend } = context?.agent ?? {};
-      if (!resumeData) return suspend?.({ question: inputData.question });
-      return { answer: resumeData.answer };
-    },
-  });
-  ```
-</Step>
-
-<Step>
-  ### Route interrupts with `enabled`
-
-  ```tsx title="ui/app/page.tsx"
-  import { useInterrupt } from "@copilotkit/react-core/v2";
-
-  function YourMainContent() {
-    // ...
-
-    // [!code highlight:10]
-    useInterrupt({
-      enabled: ({ eventValue }) => eventValue.toolName === "confirm-action",
-      render: ({ event, resolve }) => (
-        <div>
-          <p>{event.value.suspendPayload.action}</p>
-          <button onClick={() => resolve({ confirmed: true })}>Approve</button>
-          <button onClick={() => resolve({ confirmed: false })}>Reject</button>
-        </div>
-      ),
-    });
-
-    // [!code highlight:14]
-    useInterrupt({
-      enabled: ({ eventValue }) => eventValue.toolName === "ask-question",
-      render: ({ event, resolve }) => (
-        <div>
-          <p>{event.value.suspendPayload.question}</p>
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              resolve({ answer: (e.target as HTMLFormElement).response.value });
-            }}
-          >
-            <input type="text" name="response" placeholder="Your answer" />
-            <button type="submit">Submit</button>
-          </form>
-        </div>
-      ),
-    });
-
-    // ...
-    return <div>{/* ... */}</div>;
-  }
-  ```
-</Step>
-</Steps>
-
-### Preprocessing with `handler`
-
-Use the `handler` property to transform interrupt data or resolve interrupts programmatically before rendering UI.
-The return value of `handler` is passed to `render` as the `result` argument.
-
-```tsx title="ui/app/page.tsx"
-import { useInterrupt } from "@copilotkit/react-core/v2";
-
-function YourMainContent() {
-  const [user] = useState({ role: "admin" });
-
-  useInterrupt({
-    // [!code highlight:10]
-    handler: async ({ event, resolve }) => {
-      // Auto-approve for admins
-      if (user.role === "admin") {
-        resolve({ confirmed: true });
-        return;
-      }
-      return { action: event.value.suspendPayload.action };
-    },
-    render: ({ result, resolve }) => (
-      <div>
-        <p>{result.action}</p>
-        <button onClick={() => resolve({ confirmed: true })}>Approve</button>
-        <button onClick={() => resolve({ confirmed: false })}>Reject</button>
-      </div>
-    ),
-  });
-
-  // ...
-  return <div>{/* ... */}</div>;
-}
-```
+**Ready to implement HITL with Mastra?** Head to the [tool-based approach guide](/mastra/human-in-the-loop/tool-based) for working examples and best practices.


### PR DESCRIPTION
## Summary

Fixes FAC-64: Mastra Interrupts docs example fails on missing agentId and suspendPayload guard

This PR rewrites the Mastra interrupt documentation to correctly reflect that **Mastra does not support native interrupt flow**. The framework lacks LangGraph-style `interrupt()` primitives and does not emit AG-UI interrupt events.

## Changes

### 📝 Documentation Updates

1. **`interrupt-flow.mdx`**: Completely rewritten to:
   - Add prominent warning callout that Mastra doesn't support interrupts
   - Explain why the interrupt pattern doesn't work with Mastra
   - Provide working alternative using `useHumanInTheLoop`
   - Include comparison table between interrupt-based and tool-based approaches
   - Redirect users to the tool-based HITL guide

2. **`index.mdx`**: Updated to:
   - Mark interrupt-based approach as "Not Supported"
   - Mark tool-based approach as "Supported" (the working pattern)
   - Reorder cards to prioritize the working approach

## Rationale

The original docs documented `useInterrupt` with examples that would:
- Fail with "Agent 'default' not found" (missing `agentId` parameter)
- Fail with "Cannot destructure property 'action'" (incorrect payload access)
- Silently fail (hook listens for events Mastra never emits)

Research revealed:
- `showcase/integrations/mastra/manifest.yaml` explicitly lists `gen-ui-interrupt` under `not_supported_features`
- The actual working demo uses `useHumanInTheLoop`, not `useInterrupt`
- Comments in the code confirm: "This framework has no LangGraph-style `interrupt()` primitive"

## Migration Path

Users following the old docs can now:
1. See clear warning that interrupts aren't supported
2. Learn the correct `useHumanInTheLoop` pattern
3. Follow link to complete tool-based HITL guide with working examples

## Testing

- ✅ Documentation changes only (no runtime code affected)
- ✅ Verified redirect links work correctly
- ✅ Checked against actual working implementation in `showcase/integrations/mastra/src/app/demos/gen-ui-interrupt/page.tsx`

## Related

- Linear: FAC-64
- QA Report: Documented three specific runtime errors from the broken examples
- Research: Identified Option B (rewrite for useHumanInTheLoop) as the correct approach
