### PR TITLE
feat(channels-intelligence): emit leaseToken on render-accept + complete (OSS-446)

### DIFF
--- a/packages/channels-intelligence/src/http-transports.test.ts
+++ b/packages/channels-intelligence/src/http-transports.test.ts
@@ -681,6 +681,8 @@ describe("HttpRenderEventSink", () => {
       seq: 0,
       idempotencyKey: "turn_9:main:0",
       event: { kind: "text_delta", messageId: "m1", delta: "hi" },
+      // OSS-446: the render-accept is fenced on the claim's lease token.
+      leaseToken: "lease_z",
     });
     // The accept route rejects a body that also carries deliveryId.
     expect("deliveryId" in accept.body).toBe(false);

--- a/packages/channels-intelligence/src/http-transports.ts
+++ b/packages/channels-intelligence/src/http-transports.ts
@@ -421,6 +421,12 @@ export class HttpDeliverySource implements DeliverySource {
     return this.leases.get(deliveryId)?.scope;
   }
 
+  /** The lease token for a leased delivery, so a render frame can fence its
+   * accept against `lease_token_hash` the same way ack/fail already do. */
+  leaseTokenFor(deliveryId: string): string | undefined {
+    return this.leases.get(deliveryId)?.leaseToken;
+  }
+
   async start(
     onDelivery: (env: ManagedIngressEnvelope) => Promise<void>,
   ): Promise<void> {
@@ -783,6 +789,7 @@ export class HttpRenderEventSink implements RenderEventSink {
     private readonly cfg: IntelligenceTransportConfig,
     private readonly scopeSource: {
       scopeFor(deliveryId: string): DeliveryScope | undefined;
+      leaseTokenFor(deliveryId: string): string | undefined;
     },
   ) {
     this.http = new IntelligenceHttp(cfg);
@@ -795,6 +802,11 @@ export class HttpRenderEventSink implements RenderEventSink {
         `intelligenceAdapter: no leased scope for delivery ${frame.deliveryId}`,
       );
     }
+    // Fence the render-accept on the delivery's lease token (OSS-446), the same
+    // way ack/fail already do. Optional: app-api falls back to instance-id +
+    // expiry when it's absent, so an older lease record without a token still
+    // renders — but supplying it lets app-api reject a stale/rotated lease.
+    const leaseToken = this.scopeSource.leaseTokenFor(frame.deliveryId);
     const idempotencyKey = `${frame.turnId}:${frame.slot}:${frame.seq}`;
     const res = await this.http.post<RenderAcceptedResponse>(
       `/api/bots/deliveries/${encodeURIComponent(frame.deliveryId)}/render-events/accept`,
@@ -809,6 +821,7 @@ export class HttpRenderEventSink implements RenderEventSink {
         seq: frame.seq,
         idempotencyKey,
         event: frame.event,
+        ...(leaseToken ? { leaseToken } : {}),
         sentAt: new Date().toISOString(),
       },
     );

--- a/packages/channels-intelligence/src/phoenix-transport.ts
+++ b/packages/channels-intelligence/src/phoenix-transport.ts
@@ -224,6 +224,10 @@ export class PhoenixRealtimeTransport
         seq: frame.seq,
         idempotencyKey,
         event: frame.event,
+        // Fence the render-accept on the lease token (OSS-446), matching the
+        // fail path. Optional — omitted when no state (app-api falls back to
+        // instance-id + expiry), present for a normally-leased delivery.
+        ...(state ? { leaseToken: state.leaseToken } : {}),
         sentAt: this.now(),
       },
     };
@@ -294,6 +298,9 @@ export class PhoenixRealtimeTransport
         deliveryId,
         turnId: state.turnId,
         runtimeInstanceId: this.runtimeInstanceId,
+        // Fence the completion intent on the lease token (OSS-446), matching
+        // the fail path; app-api fences when present, falls back otherwise.
+        leaseToken: state.leaseToken,
         acceptedThrough,
         requestedAt: this.now(),
       },

--- a/packages/channels-intelligence/src/render-events.test.ts
+++ b/packages/channels-intelligence/src/render-events.test.ts
@@ -232,12 +232,22 @@ describe("PhoenixRealtimeTransport — completion intent, never self-ack", () =>
     expect(events).not.toContain("hosted_bot.delivery.ack.v1");
 
     const completion = fake.pushes.at(-1)!.payload as {
-      payload: { acceptedThrough: unknown[]; runtimeInstanceId: string };
+      payload: {
+        acceptedThrough: unknown[];
+        runtimeInstanceId: string;
+        leaseToken?: string;
+      };
     };
     expect(completion.payload.acceptedThrough).toEqual([
       { turnId: "turn_t1", slot: "main", seq: 1 },
     ]);
     expect(completion.payload.runtimeInstanceId).toBe("rti_1");
+    // OSS-446: render-accept + completion intent are both fenced on the lease.
+    const render = fake.pushes.find(
+      (p) => p.event === "hosted_bot.render_event.v1",
+    )!.payload as { payload: { leaseToken?: string } };
+    expect(render.payload.leaseToken).toBe("lease_l1");
+    expect(completion.payload.leaseToken).toBe("lease_l1");
   });
 
   it("throws if a render frame is not accepted (no silent success)", async () => {


### PR DESCRIPTION
## Summary

SDK-emit half of **OSS-446** (lease-token fencing for hosted-bot render/complete). The `fail` path already sends the delivery lease token; **render-accept** and the **completion intent** did not — so app-api fell back to the weaker instance-id + expiry check on those two paths.

This makes the SDK send `leaseToken` on both, on **both transports**:

- **HTTP** — `HttpRenderEventSink.push` now includes `leaseToken`, via a new `leaseTokenFor(deliveryId)` accessor on `HttpDeliverySource` (mirrors the existing `scopeFor`). (`ack` already sent it.)
- **Phoenix** — `push` (render-accept) and `complete_requested` now carry `leaseToken` from `DeliveryState` (`fail` already did).

## Why it's safe to ship now (ahead of the app-api "require" flip)

Verified end-to-end against the live Intelligence server:

- **Gateway** `validate_render_payload` allows `leaseToken` (optional, `maybe_put_lease_token`) and forwards it via `accept_render_event`; `validate_complete_payload` merges the payload through and forwards it via `complete_delivery`.
- **app-api** fences render-accept (`$N IS NULL OR lease_token_hash = $N`) and complete (`$N IS NULL OR ...`) **optionally** today — so supplying the token starts fencing on it immediately, and omitting it still works. No breakage; strictly a security improvement on the paths that were previously unfenced.

## Scope

This is **half A** (SDK emit). **Half B** — flipping app-api's render-accept + complete fences from optional to *required* and dropping the instance-id/expiry fallback — is deferred until #511 (managed Teams) settles `managed-bots/service.ts`, and follows from OSS-446's "require *once the SDK sends it*" premise.

## Tests

- HTTP: render-accept POST asserts `leaseToken` from the claimed lease flows into the body.
- Phoenix: render-accept + `complete_requested` payloads assert `leaseToken`.
- Build + 95 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
