### PR TITLE
chore: release channels-slack v0.1.1

### DIFF
--- a/packages/channels-slack/package.json
+++ b/packages/channels-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/channels-slack",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Slack platform adapter for CopilotKit JSX channels (@copilotkit/channels).",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Bumps `@copilotkit/channels-slack` `0.1.0` → `0.1.1` to publish a version that actually exposes the **`./render`** subpath export.

## Why

`channels-slack`'s source already ships the Bolt-free render surface (`src/render.ts` barrel + the `./render` export, from the OSS-403 refactor), but the **published `@copilotkit/channels-slack@0.1.0`** does not expose `./render` at install time — a fresh CI install of `0.1.0` fails at runtime with:

```
ERR_PACKAGE_PATH_NOT_EXPORTED: Package subpath './render' is not defined by "exports" in .../@copilotkit/channels-slack/package.json
```

`channels-teams` had the identical problem and was fixed by the `v0.1.1` release (`0653031fa2`). This does the same for `channels-slack` — a pure version bump so the release pipeline publishes a `0.1.1` built from current `main` (which includes `dist/render.js` + the `./render` export).

## Impact

Unblocks the Intelligence managed-Slack egress migration (Intelligence #519), which consumes `@copilotkit/channels-slack/render` for 1:1 UX parity with the native adapter via the Connector Outbox. Once `0.1.1` is published, Intelligence pins it in place of `0.1.0`.

No source changes — version bump only.