### PR TITLE
fix(docs): align tool parameter names with state keys in state streaming examples

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx
@@ -522,7 +522,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                 {
                     name: "step_progress_tool",
                     description: "Reports the current steps being executed",
-                    schema: z.object({ steps: z.array(z.string()) }),
+                    schema: z.object({ observed_steps: z.array(z.string()) }),
                 }
             );
 

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx
@@ -246,7 +246,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                                     goto=END,
                                     update={
                                         "messages": response,
-                                        "observed_steps": response.tool_calls[0].get("args", None).get('observed_steps')
+                                        "observed_steps": response.tool_calls[0].get("args", {}).get('observed_steps')
                                     }
                                 )
 

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx
@@ -205,6 +205,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                         @tool
                         def step_progress_tool(observed_steps: list[str]):
                             """Reads and reports steps"""
+                            pass
 
                         async def frontend_actions_node(state: AgentState, config: RunnableConfig):
                             # Configure CopilotKit to treat step progress tool calls as predictive of the final state
@@ -214,7 +215,8 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                                     {
                                         "state_key": "observed_steps",
                                         "tool": "step_progress_tool",
-                                        "tool_argument": "steps"
+                                        # The tool_argument must match the tool parameter name for streaming to work
+                                        "tool_argument": "observed_steps"
                                     },
                                 ]
                             )
@@ -336,7 +338,8 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                               {
                                 stateKey: "observed_steps",
                                 tool: "step_progress_tool",
-                                toolArgument: "steps",
+                                // The toolArgument must match the tool parameter name for streaming to work
+                                toolArgument: "observed_steps",
                               },
                             ],
                           });
@@ -488,8 +491,9 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
             from langchain.tools import tool
 
             @tool
-            def step_progress_tool(steps: list[str]):
+            def step_progress_tool(observed_steps: list[str]):
                 """Reports the current steps being executed"""
+                pass
 
             agent = create_deep_agent(
                 model="openai:gpt-5.4",
@@ -497,7 +501,8 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                 middleware=[
                     CopilotKitMiddleware(),
                     StateStreamingMiddleware(  # [!code highlight]
-                        StateItem(state_key="observed_steps", tool="step_progress_tool", tool_argument="steps")  # [!code highlight]
+                        # The tool_argument must match the tool parameter name for streaming to work
+                        StateItem(state_key="observed_steps", tool="step_progress_tool", tool_argument="observed_steps")  # [!code highlight]
                     ),  # [!code highlight]
                 ],
                 system_prompt="You are a task performer. Report your steps using step_progress_tool.",
@@ -528,8 +533,8 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                     observedStepsMiddleware,
                     copilotkitMiddleware,
                     stateStreamingMiddleware(  // [!code highlight]
-                        // Map the tool's `steps` argument into the `observed_steps` state field.
-                        stateItem({ stateKey: "observed_steps", tool: "step_progress_tool", toolArgument: "steps" })  // [!code highlight]
+                        // The toolArgument must match the tool parameter name for streaming to work
+                        stateItem({ stateKey: "observed_steps", tool: "step_progress_tool", toolArgument: "observed_steps" })  // [!code highlight]
                     ),  // [!code highlight]
                 ],
                 systemPrompt: "You are a task performer. Report your steps using step_progress_tool.",

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx
@@ -203,7 +203,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
 
                         # Define a step progress tool for the llm to report the steps
                         @tool
-                        def step_progress_tool(steps: list[str]):
+                        def step_progress_tool(observed_steps: list[str]):
                             """Reads and reports steps"""
 
                         async def frontend_actions_node(state: AgentState, config: RunnableConfig):
@@ -244,7 +244,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                                     goto=END,
                                     update={
                                         "messages": response,
-                                        "observed_steps": response.tool_calls[0].get("args", None).get('steps')
+                                        "observed_steps": response.tool_calls[0].get("args", None).get('observed_steps')
                                     }
                                 )
 
@@ -285,7 +285,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
 
                         // 2. Define the tool with proper ToolMessage handling
                         const stepProgressTool = tool(
-                          async ({ steps }, config: ToolRunnableConfig) => {
+                          async ({ observed_steps }, config: ToolRunnableConfig) => {
                             const toolCallId = config.toolCall?.id;
                             if (typeof toolCallId !== "string" || toolCallId.length === 0) {
                               throw new Error(
@@ -297,7 +297,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
 
                             return new Command({
                               update: {
-                                observed_steps: steps,
+                                observed_steps,
                                 messages: [
                                   new ToolMessage({
                                     content: "Steps recorded to shared state.",
@@ -312,7 +312,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                           {
                             name: "step_progress_tool",
                             description: "Reports the current steps being executed",
-                            schema: z.object({ steps: z.array(z.string()) }),
+                            schema: z.object({ observed_steps: z.array(z.string()) }),
                           }
                         );
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/shared-state/predictive-state-updates.mdx
@@ -214,7 +214,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                                     goto=END,
                                     update={
                                         "messages": response,
-                                        "observed_steps": response.tool_calls[0].get("args", None).get('observed_steps')
+                                        "observed_steps": response.tool_calls[0].get("args", {}).get('observed_steps')
                                     }
                                 )
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/shared-state/predictive-state-updates.mdx
@@ -173,6 +173,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                         @tool
                         def step_progress_tool(observed_steps: list[str]):
                             """Reads and reports steps"""
+                            pass
 
                         async def frontend_actions_node(state: AgentState, config: RunnableConfig):
                             # Configure CopilotKit to treat step progress tool calls as predictive of the final state
@@ -182,7 +183,8 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                                     {
                                         "state_key": "observed_steps",
                                         "tool": "step_progress_tool",
-                                        "tool_argument": "steps"
+                                        # The tool_argument must match the tool parameter name for streaming to work
+                                        "tool_argument": "observed_steps"
                                     },
                                 ]
                             )
@@ -306,7 +308,8 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                               {
                                 stateKey: "observed_steps",
                                 tool: "StepProgressTool",
-                                toolArgument: "steps",
+                                // The toolArgument must match the tool parameter name for streaming to work
+                                toolArgument: "observed_steps",
                               },
                             ],
                           });
@@ -459,6 +462,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
             @tool
             def step_progress_tool(observed_steps: list[str]):
                 """Reports the current steps being executed"""
+                pass
 
             graph = create_agent(
                 model="openai:gpt-5.4",
@@ -466,7 +470,8 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                 middleware=[
                     CopilotKitMiddleware(),
                     StateStreamingMiddleware(  # [!code highlight]
-                        StateItem(state_key="observed_steps", tool="step_progress_tool", tool_argument="steps")  # [!code highlight]
+                        # The tool_argument must match the tool parameter name for streaming to work
+                        StateItem(state_key="observed_steps", tool="step_progress_tool", tool_argument="observed_steps")  # [!code highlight]
                     ),  # [!code highlight]
                 ],
                 system_prompt="You are a task performer. Report your steps using step_progress_tool.",
@@ -497,7 +502,8 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                 middleware: [
                     copilotkitMiddleware,
                     stateStreamingMiddleware(  // [!code highlight]
-                        stateItem({ stateKey: "observed_steps", tool: "step_progress_tool", toolArgument: "steps" })  // [!code highlight]
+                        // The toolArgument must match the tool parameter name for streaming to work
+                        stateItem({ stateKey: "observed_steps", tool: "step_progress_tool", toolArgument: "observed_steps" })  // [!code highlight]
                     ),  // [!code highlight]
                 ],
                 stateSchema: AgentStateSchema,

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/shared-state/predictive-state-updates.mdx
@@ -171,7 +171,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
 
                         # Define a step progress tool for the llm to report the steps
                         @tool
-                        def step_progress_tool(steps: list[str]):
+                        def step_progress_tool(observed_steps: list[str]):
                             """Reads and reports steps"""
 
                         async def frontend_actions_node(state: AgentState, config: RunnableConfig):
@@ -212,7 +212,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                                     goto=END,
                                     update={
                                         "messages": response,
-                                        "observed_steps": response.tool_calls[0].get("args", None).get('steps')
+                                        "observed_steps": response.tool_calls[0].get("args", None).get('observed_steps')
                                     }
                                 )
 
@@ -253,7 +253,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
 
                         // 2. Define the tool with proper ToolMessage handling
                         const stepProgressTool = tool(
-                          async ({ steps }, config: ToolRunnableConfig) => {
+                          async ({ observed_steps }, config: ToolRunnableConfig) => {
                             const toolCallId = config.toolCall?.id;
                             if (typeof toolCallId !== "string" || toolCallId.length === 0) {
                               throw new Error(
@@ -265,7 +265,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
 
                             return new Command({
                               update: {
-                                observed_steps: steps,
+                                observed_steps,
                                 messages: [
                                   new ToolMessage({
                                     content: "Steps recorded to shared state.",
@@ -281,7 +281,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                             name: "StepProgressTool",
                             description: "Records progress by updating the steps array",
                             schema: z.object({
-                              steps: z.array(z.string()),
+                              observed_steps: z.array(z.string()),
                             }),
                           }
                         );
@@ -457,7 +457,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
             from langchain.tools import tool
 
             @tool
-            def step_progress_tool(steps: list[str]):
+            def step_progress_tool(observed_steps: list[str]):
                 """Reports the current steps being executed"""
 
             graph = create_agent(
@@ -487,7 +487,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                 {
                     name: "step_progress_tool",
                     description: "Reports the current steps being executed",
-                    schema: z.object({ steps: z.array(z.string()) }),
+                    schema: z.object({ observed_steps: z.array(z.string()) }),
                 }
             );
 


### PR DESCRIPTION
## Summary
Fixes the state streaming parameter naming mismatch in LangGraph and DeepAgents predictive state updates documentation examples.

## Problem
The docs examples had **three related issues**:

1. **Parameter name mismatch**: Tool parameter name (`steps`) didn't match state key (`observed_steps`)
2. **Configuration mismatch**: The `tool_argument` configuration fields still referenced `steps` even after the tool parameter was renamed to `observed_steps`
3. **Tool schema mismatch**: DeepAgents prebuilt agent TypeScript example had `schema: z.object({ steps: ... })` while `toolArgument` was `observed_steps`

According to the working example in `showcase/integrations/langgraph-python/src/agents/shared_state_streaming.py`, the tool parameter name MUST match the state_key for per-token state streaming to work correctly:

> the frontend `usePredictStateSubscription` hook indexes the (partial-JSON-parsed) tool args by `state_key`, so the tool's argument name MUST match `state_key` for per-token deltas to land in state.

## State Streaming Invariant

For each state-streaming example, this invariant must hold:
**state_key == frontend_read_key == middleware_tool_argument == tool_parameter**

All 8 code sections now pass this invariant:
- ✅ LangGraph custom graph (Python + TypeScript)
- ✅ LangGraph prebuilt agent (Python + TypeScript)
- ✅ DeepAgents custom graph (Python + TypeScript)
- ✅ DeepAgents prebuilt agent (Python + TypeScript)

## Changes

### Initial Commits
- Renamed tool parameter from `steps` to `observed_steps` in Python and TypeScript examples
- Updated all `tool_argument`/`toolArgument` configuration fields to use `observed_steps`
- Added clarifying comments explaining the parameter name constraint
- Added `pass` statements to Python tool function bodies (required syntax)
- Used safe dictionary chaining (`.get('args', {})`)

### Final Fix (this commit)
- **Fixed DeepAgents prebuilt agent TypeScript schema**: Changed `schema: z.object({ steps: ... })` to `schema: z.object({ observed_steps: ... })` on line 525
- This was the last remaining state streaming invariant violation

## Affected Files
- `showcase/shell-docs/src/content/docs/integrations/langgraph/shared-state/predictive-state-updates.mdx`
  - Custom graph Python example (line ~186): `tool_argument` → `observed_steps`
  - Custom graph TypeScript example (line ~311): `toolArgument` → `observed_steps`
  - Prebuilt agent Python example (line ~473): `tool_argument` → `observed_steps`
  - Prebuilt agent TypeScript example (line ~505): `toolArgument` → `observed_steps`
  
- `showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx`
  - Custom graph Python example (line ~218): `tool_argument` → `observed_steps`
  - Custom graph TypeScript example (line ~341): `toolArgument` → `observed_steps`
  - Prebuilt agent Python example (line ~504): `tool_argument` → `observed_steps`
  - Prebuilt agent TypeScript example (line ~525, 537): `schema` field + `toolArgument` → `observed_steps`

## Verification
- [x] All tool parameter names match state keys throughout
- [x] All `tool_argument`/`toolArgument` config fields match tool parameter names
- [x] All tool schemas (TypeScript) match tool parameter names
- [x] Python tool functions have `pass` statements
- [x] Both custom graph and prebuilt agent sections updated
- [x] Consistent across Python and TypeScript examples
- [x] Applied to both LangGraph and DeepAgents docs
- [x] Full data-path invariant verified for all 8 code sections

## Relationship to Other PRs
- Supersedes/folds in fixes from PR #5857 (FAC-90) which was closed without merging
- Addresses all review feedback from initial implementation

Closes FAC-122
