### PR TITLE
feat(channels-intelligence): managed-over-Phoenix launcher + slack managed entrypoint (OSS-406 Phase 1)

### DIFF
--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -557,7 +557,10 @@ jobs:
     # These tests gate the promote-fleet.sh best-effort loop + succeeded_csv
     # export that the promote → verify-prod handoff depends on.
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # The bats suite runs ~4.5min and keeps growing; at the old 5min job cap it
+    # raced the deadline and intermittently got cancelled mid-suite (all steps
+    # passing) rather than reported. Give headroom so a green suite reports green.
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/examples/slack/.env.example
+++ b/examples/slack/.env.example
@@ -39,6 +39,25 @@ OPENAI_API_KEY=sk-...
 # ANTHROPIC_API_KEY=sk-ant-...
 # GOOGLE_API_KEY=...
 
+# ── Managed (Intelligence-hosted) mode — app/managed.ts (`pnpm managed`) ──
+# The managed variant runs the SAME bot over the Intelligence realtime-gateway
+# instead of a native adapter — it holds NO Slack tokens (Intelligence owns the
+# Slack edge). Set these to run `pnpm managed`; the native `pnpm dev` ignores
+# them. The agent brain reuses AGENT_URL / AGENT_AUTH_HEADER above.
+# Gateway runner WebSocket URL (the /runner socket hosting the bot-IO channel).
+# INTELLIGENCE_GATEWAY_WS_URL=wss://gateway.intelligence.example/runner
+# Project runtime API key (cpk-…) — presented as the socket authToken.
+# INTELLIGENCE_API_KEY=cpk-...
+# Product organization id (as issued by Intelligence).
+# INTELLIGENCE_ORG_ID=org_...
+# Numeric project id (the channel topic is hosted_bots:project:<id>).
+# INTELLIGENCE_PROJECT_ID=123
+# Bot id + immutable project-unique bot name (from Intelligence bot setup).
+# INTELLIGENCE_BOT_ID=bot_...
+# INTELLIGENCE_BOT_NAME=triage
+# Optional: stable runtime instance id; a random rti_… is generated if unset.
+# INTELLIGENCE_RUNTIME_INSTANCE_ID=rti_...
+
 # ── Linear MCP ──────────────────────────────────────────────────────────
 # The hosted Linear MCP accepts a raw API key as a bearer token (no OAuth
 # dance). Create one at linear.app → Settings → API → Personal API keys.

--- a/examples/slack/app/managed.test.ts
+++ b/examples/slack/app/managed.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fakes = vi.hoisted(() => {
+  const stop = vi.fn(async () => {
+    throw new Error("stop failed");
+  });
+  return {
+    stop,
+    closeBrowser: vi.fn(async () => {}),
+    startManagedBotsOverPhoenix: vi.fn(async () => ({ stop })),
+    bot: {
+      onMention: vi.fn(),
+      onModalSubmit: vi.fn(),
+      onThreadStarted: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@copilotkit/channels", () => ({
+  createBot: vi.fn(() => fakes.bot),
+}));
+vi.mock("@copilotkit/channels-slack", () => ({
+  defaultSlackTools: [],
+  defaultSlackContext: [],
+  SanitizingHttpAgent: class {},
+}));
+vi.mock("@copilotkit/channels-intelligence", () => ({
+  startManagedBotsOverPhoenix: fakes.startManagedBotsOverPhoenix,
+}));
+vi.mock("./tools/index.js", () => ({ appTools: [] }));
+vi.mock("./context/app-context.js", () => ({ appContext: [] }));
+vi.mock("./commands/index.js", () => ({ appCommands: [] }));
+vi.mock("./sender-context.js", () => ({ senderContext: vi.fn() }));
+vi.mock("./modals/file-issue.js", () => ({
+  fileIssueSubmit: vi.fn(),
+  FILE_ISSUE_CALLBACK: "file-issue",
+}));
+vi.mock("./render/browser.js", () => ({ closeBrowser: fakes.closeBrowser }));
+
+const envKeys = [
+  "AGENT_URL",
+  "INTELLIGENCE_PROJECT_ID",
+  "INTELLIGENCE_BOT_NAME",
+  "INTELLIGENCE_GATEWAY_WS_URL",
+  "INTELLIGENCE_API_KEY",
+  "INTELLIGENCE_ORG_ID",
+  "INTELLIGENCE_BOT_ID",
+] as const;
+
+describe("managed entrypoint shutdown", () => {
+  const previousEnv = new Map<string, string | undefined>();
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const key of envKeys) {
+      const value = previousEnv.get(key);
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    previousEnv.clear();
+  });
+
+  it("exits nonzero when stopping the managed runtime fails", async () => {
+    for (const key of envKeys) previousEnv.set(key, process.env[key]);
+    process.env.AGENT_URL = "http://agent.test/run";
+    process.env.INTELLIGENCE_PROJECT_ID = "7";
+    process.env.INTELLIGENCE_BOT_NAME = "opentag";
+    process.env.INTELLIGENCE_GATEWAY_WS_URL = "wss://gateway.test/runner";
+    process.env.INTELLIGENCE_API_KEY = "cpk-test";
+    process.env.INTELLIGENCE_ORG_ID = "org_1";
+    process.env.INTELLIGENCE_BOT_ID = "bot_1";
+
+    let sigterm: (() => void) | undefined;
+    vi.spyOn(process, "on").mockImplementation(((event, listener) => {
+      if (event === "SIGTERM") sigterm = listener as () => void;
+      return process;
+    }) as typeof process.on);
+    const exit = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined as never) as typeof process.exit);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await import("./managed.js");
+    await vi.waitFor(() => expect(sigterm).toBeTypeOf("function"));
+    sigterm!();
+    await vi.waitFor(() => expect(exit).toHaveBeenCalled());
+
+    expect(fakes.stop).toHaveBeenCalledOnce();
+    expect(fakes.closeBrowser).toHaveBeenCalledOnce();
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/examples/slack/app/managed.ts
+++ b/examples/slack/app/managed.ts
@@ -1,0 +1,128 @@
+/**
+ * Managed (Intelligence-hosted) entrypoint for the same Slack bot as
+ * `app/index.ts`.
+ *
+ * `index.ts` is the SELF-HOSTED variant: it holds the Slack bot/app tokens and
+ * talks to Slack directly via the native `slack()` adapter. This file is the
+ * MANAGED variant: it holds no Slack credentials and no public endpoint — it
+ * connects to the Intelligence realtime-gateway over Phoenix, receives leased
+ * deliveries, and streams render frames back. Intelligence owns the Slack edge
+ * (signed ingress → app-api, egress via the Connector Outbox).
+ *
+ * The bot itself — the agent, tools, context, commands, and turn handlers — is
+ * IDENTICAL to the native bot; only the transport changes. `intelligenceAdapter`
+ * is exclusive, so the managed bot is created WITHOUT a native adapter and
+ * {@link startManagedBotsOverPhoenix} attaches the managed transport.
+ *
+ *   native:   createBot({ adapters: [slack({ botToken, appToken }) ] })  // index.ts
+ *   managed:  startManagedBotsOverPhoenix([ createBot({ … }) ], { … })   // this file
+ *
+ * Run: `pnpm --filter slack-example managed` with the INTELLIGENCE_* env set
+ * (see `.env.example`).
+ */
+import "dotenv/config";
+import { randomUUID } from "node:crypto";
+import { createBot } from "@copilotkit/channels";
+import {
+  defaultSlackTools,
+  defaultSlackContext,
+  SanitizingHttpAgent,
+} from "@copilotkit/channels-slack";
+import { startManagedBotsOverPhoenix } from "@copilotkit/channels-intelligence";
+import { appTools } from "./tools/index.js";
+import { appContext } from "./context/app-context.js";
+import { appCommands } from "./commands/index.js";
+import { senderContext } from "./sender-context.js";
+import { fileIssueSubmit, FILE_ISSUE_CALLBACK } from "./modals/file-issue.js";
+import { closeBrowser } from "./render/browser.js";
+
+const required = (name: string): string => {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return v;
+};
+
+async function main() {
+  const agentUrl = required("AGENT_URL");
+  const agentHeaders = process.env.AGENT_AUTH_HEADER
+    ? { Authorization: process.env.AGENT_AUTH_HEADER }
+    : undefined;
+
+  const projectId = Number(required("INTELLIGENCE_PROJECT_ID"));
+  if (!Number.isInteger(projectId) || projectId < 0) {
+    console.error(
+      `Invalid INTELLIGENCE_PROJECT_ID: "${process.env.INTELLIGENCE_PROJECT_ID}"`,
+    );
+    process.exit(1);
+  }
+  const botName = required("INTELLIGENCE_BOT_NAME");
+
+  // Same bot as the native example, minus the adapter: the managed transport is
+  // attached by startManagedBotsOverPhoenix. Slack is the only managed provider
+  // here, so it always ships the Slack tools/context (the native example adds
+  // these conditionally per active adapter).
+  const bot = createBot({
+    name: botName,
+    agent: (threadId) => {
+      const a = new SanitizingHttpAgent({ url: agentUrl, headers: agentHeaders });
+      a.threadId = threadId;
+      return a;
+    },
+    tools: [...appTools, ...defaultSlackTools],
+    context: [...appContext, ...defaultSlackContext],
+    commands: appCommands,
+  });
+
+  // Turn + feature handlers — identical to the native example (app/index.ts).
+  bot.onMention(async ({ thread, message }) => {
+    try {
+      await thread.runAgent({
+        context: senderContext(message.user, thread.platform),
+      });
+    } catch (err) {
+      console.error("[bot] agent run failed", err);
+      await thread
+        .post("Sorry — I hit an error handling that. Please try again.")
+        .catch(() => {});
+    }
+  });
+  bot.onModalSubmit(FILE_ISSUE_CALLBACK, fileIssueSubmit);
+  bot.onThreadStarted(async ({ thread, user }) => {
+    if (!user?.name) return;
+    await thread.setSuggestedPrompts([
+      { title: `Triage ${user.name}'s issues`, message: "Triage my open issues" },
+      { title: "What shipped this week?", message: "Summarize what shipped this week" },
+    ]);
+  });
+
+  const handle = await startManagedBotsOverPhoenix([bot], {
+    wsUrl: required("INTELLIGENCE_GATEWAY_WS_URL"),
+    apiKey: required("INTELLIGENCE_API_KEY"),
+    scope: {
+      organizationId: required("INTELLIGENCE_ORG_ID"),
+      projectId,
+      botId: required("INTELLIGENCE_BOT_ID"),
+      botName,
+    },
+    runtimeInstanceId:
+      process.env.INTELLIGENCE_RUNTIME_INSTANCE_ID ??
+      `rti_${randomUUID().replace(/-/g, "")}`,
+    adapter: "slack",
+    log: (msg, meta) => console.log(`[managed] ${msg}`, meta ?? ""),
+  });
+  console.log(`[bot] started managed (Phoenix) as "${botName}" on project ${projectId}`);
+
+  const shutdown = async (signal: string) => {
+    console.log(`\n[bot] received ${signal}, stopping…`);
+    await handle.stop();
+    await closeBrowser().catch(() => {});
+    process.exit(0);
+  };
+  process.on("SIGINT", () => void shutdown("SIGINT"));
+  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+}
+
+void main();

--- a/examples/slack/app/managed.ts
+++ b/examples/slack/app/managed.ts
@@ -67,7 +67,10 @@ async function main() {
   const bot = createBot({
     name: botName,
     agent: (threadId) => {
-      const a = new SanitizingHttpAgent({ url: agentUrl, headers: agentHeaders });
+      const a = new SanitizingHttpAgent({
+        url: agentUrl,
+        headers: agentHeaders,
+      });
       a.threadId = threadId;
       return a;
     },
@@ -93,8 +96,14 @@ async function main() {
   bot.onThreadStarted(async ({ thread, user }) => {
     if (!user?.name) return;
     await thread.setSuggestedPrompts([
-      { title: `Triage ${user.name}'s issues`, message: "Triage my open issues" },
-      { title: "What shipped this week?", message: "Summarize what shipped this week" },
+      {
+        title: `Triage ${user.name}'s issues`,
+        message: "Triage my open issues",
+      },
+      {
+        title: "What shipped this week?",
+        message: "Summarize what shipped this week",
+      },
     ]);
   });
 
@@ -113,7 +122,9 @@ async function main() {
     adapter: "slack",
     log: (msg, meta) => console.log(`[managed] ${msg}`, meta ?? ""),
   });
-  console.log(`[bot] started managed (Phoenix) as "${botName}" on project ${projectId}`);
+  console.log(
+    `[bot] started managed (Phoenix) as "${botName}" on project ${projectId}`,
+  );
 
   const shutdown = async (signal: string) => {
     console.log(`\n[bot] received ${signal}, stopping…`);

--- a/examples/slack/app/managed.ts
+++ b/examples/slack/app/managed.ts
@@ -82,7 +82,14 @@ async function main() {
   // Turn + feature handlers — identical to the native example (app/index.ts).
   bot.onMention(async ({ thread, message }) => {
     try {
+      // Managed history (app-api /api/bots/history) does NOT include the
+      // in-flight turn (unlike native adapters whose getHistory rebuilds the
+      // live thread), so pass the current message explicitly as `prompt` —
+      // otherwise runAgent runs with zero messages. Prefer multimodal parts.
       await thread.runAgent({
+        prompt: message.contentParts?.length
+          ? message.contentParts
+          : message.text,
         context: senderContext(message.user, thread.platform),
       });
     } catch (err) {

--- a/examples/slack/app/managed.ts
+++ b/examples/slack/app/managed.ts
@@ -139,17 +139,19 @@ async function main() {
 
   const shutdown = async (signal: string) => {
     console.log(`\n[bot] received ${signal}, stopping…`);
+    let exitCode = 0;
     try {
       await handle.stop();
     } catch (err) {
       console.error("[bot] error stopping managed runtime", err);
+      exitCode = 1;
     }
     // Browser teardown is best-effort, but still surface a failure rather than
     // swallow it silently.
     await closeBrowser().catch((err: unknown) =>
       console.error("[bot] browser cleanup failed (continuing shutdown)", err),
     );
-    process.exit(0);
+    process.exit(exitCode);
   };
   // A failed shutdown must not vanish — log it and exit nonzero.
   const runShutdown = (signal: string): void => {

--- a/examples/slack/app/managed.ts
+++ b/examples/slack/app/managed.ts
@@ -127,6 +127,10 @@ async function main() {
       process.env.INTELLIGENCE_RUNTIME_INSTANCE_ID ??
       `rti_${randomUUID().replace(/-/g, "")}`,
     adapter: "slack",
+    // DEBUG-ONLY logging. `meta` (and the raw `err` in the onMention catch
+    // above) can contain message content/payloads — the design says telemetry
+    // must not include raw message text. In production, drop this `log` or trim
+    // `meta` to safe fields (ids, counts) before emitting.
     log: (msg, meta) => console.log(`[managed] ${msg}`, meta ?? ""),
   });
   console.log(

--- a/examples/slack/app/managed.ts
+++ b/examples/slack/app/managed.ts
@@ -139,12 +139,39 @@ async function main() {
 
   const shutdown = async (signal: string) => {
     console.log(`\n[bot] received ${signal}, stopping…`);
-    await handle.stop();
-    await closeBrowser().catch(() => {});
+    try {
+      await handle.stop();
+    } catch (err) {
+      console.error("[bot] error stopping managed runtime", err);
+    }
+    // Browser teardown is best-effort, but still surface a failure rather than
+    // swallow it silently.
+    await closeBrowser().catch((err: unknown) =>
+      console.error("[bot] browser cleanup failed (continuing shutdown)", err),
+    );
     process.exit(0);
   };
-  process.on("SIGINT", () => void shutdown("SIGINT"));
-  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+  // A failed shutdown must not vanish — log it and exit nonzero.
+  const runShutdown = (signal: string): void => {
+    shutdown(signal).catch((err: unknown) => {
+      console.error(`[bot] fatal during ${signal} shutdown`, err);
+      process.exit(1);
+    });
+  };
+  process.on("SIGINT", () => runShutdown("SIGINT"));
+  process.on("SIGTERM", () => runShutdown("SIGTERM"));
 }
 
-void main();
+// Fail loud, not silent: surface any stray async error instead of letting it
+// kill the process with no log (mirrors the native entrypoint).
+process.on("unhandledRejection", (reason) => {
+  console.error("[bot] unhandledRejection:", reason);
+});
+process.on("uncaughtException", (err) => {
+  console.error("[bot] uncaughtException:", err);
+});
+
+main().catch((err: unknown) => {
+  console.error("[bot] fatal: failed to start managed runtime", err);
+  process.exit(1);
+});

--- a/examples/slack/package.json
+++ b/examples/slack/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "tsx watch app/index.ts",
     "start": "tsx app/index.ts",
+    "managed": "tsx app/managed.ts",
     "build": "pnpm exec nx run-many -t build -p \"@copilotkit/channels*\" @copilotkit/runtime",
     "runtime": "tsx runtime.ts",
     "notion-mcp": "tsx scripts/start-notion-mcp.ts",
@@ -20,6 +21,7 @@
   "dependencies": {
     "@copilotkit/channels": "workspace:*",
     "@copilotkit/channels-discord": "workspace:*",
+    "@copilotkit/channels-intelligence": "workspace:*",
     "@copilotkit/channels-slack": "workspace:*",
     "@copilotkit/channels-telegram": "workspace:*",
     "@copilotkit/channels-ui": "workspace:*",

--- a/packages/channels-intelligence/src/index.ts
+++ b/packages/channels-intelligence/src/index.ts
@@ -53,7 +53,7 @@ export type {
   ConnectedHostedBotChannel,
 } from "./phoenix-channel.js";
 // The managed-over-Phoenix launcher (OSS-406): the composition that runs a
-// coworker over the realtime path (connect → transport → startManagedBots).
+// managed bot over the realtime path (connect → transport → startManagedBots).
 export {
   startManagedBotsOverPhoenix,
   startManagedBotsOnChannel,

--- a/packages/channels-intelligence/src/index.ts
+++ b/packages/channels-intelligence/src/index.ts
@@ -52,6 +52,16 @@ export type {
   PhoenixConnectConfig,
   ConnectedHostedBotChannel,
 } from "./phoenix-channel.js";
+// The managed-over-Phoenix launcher (OSS-406): the composition that runs a
+// coworker over the realtime path (connect → transport → startManagedBots).
+export {
+  startManagedBotsOverPhoenix,
+  startManagedBotsOnChannel,
+} from "./phoenix-launcher.js";
+export type {
+  ManagedPhoenixConfig,
+  ManagedBotsOnChannelOptions,
+} from "./phoenix-launcher.js";
 
 // Undocumented fallbacks: the default HTTP transports + config resolver that
 // `intelligenceAdapter()` builds when no transports are injected. Not a public

--- a/packages/channels-intelligence/src/phoenix-channel.ts
+++ b/packages/channels-intelligence/src/phoenix-channel.ts
@@ -78,14 +78,18 @@ export async function connectPhoenixHostedBotChannel(
     channel
       .join(timeout)
       .receive("ok", () => resolve())
-      .receive("error", (reason: unknown) =>
+      .receive("error", (reason: unknown) => {
+        // The join failed, so the caller never gets a channel it could
+        // disconnect — tear the socket down here rather than leak it.
+        socket.disconnect();
         reject(
           new Error(`hosted-bot channel join failed: ${safeReason(reason)}`),
-        ),
-      )
-      .receive("timeout", () =>
-        reject(new Error("hosted-bot channel join timed out")),
-      );
+        );
+      })
+      .receive("timeout", () => {
+        socket.disconnect();
+        reject(new Error("hosted-bot channel join timed out"));
+      });
   });
 
   return {

--- a/packages/channels-intelligence/src/phoenix-launcher.test.ts
+++ b/packages/channels-intelligence/src/phoenix-launcher.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { createBot, FakeAgent } from "@copilotkit/channels";
+import { Section } from "@copilotkit/channels-ui";
+import { startManagedBotsOnChannel } from "./phoenix-launcher.js";
+import type { HostedBotChannel } from "./phoenix-transport.js";
+
+const scope = {
+  organizationId: "org_1",
+  projectId: 7,
+  botId: "bot_1",
+  botName: "opentag",
+};
+
+/** Fake gateway channel: records pushes, replies `render_accepted`, and exposes
+ * the server-push handlers so a test can simulate `delivery.available`. */
+function makeFakeChannel() {
+  const pushes: { event: string; payload: unknown }[] = [];
+  const handlers = new Map<string, (payload: unknown) => void>();
+  const channel: HostedBotChannel = {
+    push: async (event, payload) => {
+      pushes.push({ event, payload });
+      if (event === "hosted_bot.render_event.v1") {
+        const p = (payload as { payload: Record<string, unknown> }).payload;
+        return {
+          type: "hosted_bot.render_accepted.v1",
+          occurredAt: "2026-07-09T00:00:00.000Z",
+          payload: {
+            idempotencyKey: p.idempotencyKey,
+            acceptance: "accepted",
+            ...(p.event && (p.event as { kind: string }).kind === "finalize"
+              ? { egressOperationId: "eop_1" }
+              : {}),
+          },
+        };
+      }
+      return { status: "ok" };
+    },
+    on: (event, handler) => {
+      handlers.set(event, handler);
+    },
+  };
+  return { channel, pushes, handlers };
+}
+
+/** Simulate one leased text-turn delivery arriving over the channel. */
+function deliverText(handlers: Map<string, (p: unknown) => void>) {
+  handlers.get("hosted_bot.delivery.available.v1")?.({
+    payload: {
+      delivery: {
+        id: "dlv_1",
+        leaseToken: "lease_1",
+        adapter: "slack",
+        bot: { id: "bot_1", name: "opentag" },
+        turn: {
+          id: "turn_1",
+          eventId: "evt_1",
+          replyTarget: { adapter: "slack", teamId: "T1", channel: "C1" },
+          input: { kind: "text", text: "hi" },
+        },
+      },
+    },
+  });
+}
+
+/** The channel `delivery.available` handler is fire-and-forget, so poll until
+ * the async dispatch→render→ack chain has produced the terminal event. */
+async function waitFor(pred: () => boolean, tries = 50): Promise<void> {
+  for (let i = 0; i < tries; i++) {
+    if (pred()) return;
+    await new Promise((r) => setTimeout(r, 0));
+  }
+  throw new Error("waitFor: condition not met within the poll window");
+}
+
+describe("startManagedBotsOnChannel — managed runtime over Phoenix (OSS-406)", () => {
+  it("runs a delivered turn end-to-end: handler → render frame → completion intent, never self-ack", async () => {
+    const fake = makeFakeChannel();
+    let ran = false;
+    const bot = createBot({ name: "opentag", agent: () => new FakeAgent() });
+    bot.onMessage(async ({ thread }) => {
+      ran = true;
+      await thread.post(Section({ children: "reply" }));
+    });
+
+    const handle = await startManagedBotsOnChannel([bot], {
+      channel: fake.channel,
+      scope,
+      runtimeInstanceId: "rti_1",
+    });
+
+    deliverText(fake.handlers);
+    await waitFor(() =>
+      fake.pushes.some(
+        (p) => p.event === "hosted_bot.delivery.complete_requested.v1",
+      ),
+    );
+
+    const events = fake.pushes.map((p) => p.event);
+    expect(ran).toBe(true); // the bot's handler ran off a Phoenix-delivered turn
+    expect(events).toContain("hosted_bot.render_event.v1"); // rendered over the channel
+    expect(events).toContain("hosted_bot.delivery.complete_requested.v1"); // completion INTENT
+    expect(events).not.toContain("hosted_bot.delivery.ack.v1"); // SDK never commits the ack
+
+    await handle.stop();
+  });
+
+  it("nacks (fail intent) when the handler throws — no completion intent, no self-ack", async () => {
+    const fake = makeFakeChannel();
+    const bot = createBot({ name: "opentag", agent: () => new FakeAgent() });
+    bot.onMessage(async () => {
+      throw new Error("boom");
+    });
+
+    const handle = await startManagedBotsOnChannel([bot], {
+      channel: fake.channel,
+      scope,
+      runtimeInstanceId: "rti_1",
+    });
+
+    deliverText(fake.handlers);
+    await waitFor(() =>
+      fake.pushes.some((p) => p.event === "hosted_bot.delivery.fail.v1"),
+    );
+
+    const events = fake.pushes.map((p) => p.event);
+    expect(events).toContain("hosted_bot.delivery.fail.v1");
+    expect(events).not.toContain("hosted_bot.delivery.complete_requested.v1");
+    expect(events).not.toContain("hosted_bot.delivery.ack.v1");
+
+    await handle.stop();
+  });
+});

--- a/packages/channels-intelligence/src/phoenix-launcher.test.ts
+++ b/packages/channels-intelligence/src/phoenix-launcher.test.ts
@@ -220,4 +220,154 @@ describe("startManagedBotsOnChannel — activation metadata (OSS-406)", () => {
 
     await handle.stop();
   });
+
+  it("keeps the required runtimeInstanceId authoritative in handle.metadata", async () => {
+    const fake = makeFakeChannel();
+    const bot = createBot({ name: "opentag", agent: () => new FakeAgent() });
+
+    const handle = await startManagedBotsOnChannel([bot], {
+      channel: fake.channel,
+      scope,
+      runtimeInstanceId: "rti_authoritative",
+      env: { runtimeEnv: "staging" },
+    });
+
+    expect(handle.metadata.runtimeInstanceId).toBe("rti_authoritative");
+
+    await handle.stop();
+  });
+});
+
+/**
+ * Minimal Phoenix-compatible fake WebSocket that drives the v2-serializer join
+ * handshake so the connector's error/timeout cleanup can be exercised without a
+ * real gateway. `mode` controls the phx_join reply: "ok" → joined, "error" →
+ * rejected, "never" → no reply (the channel join times out). Records `close()`
+ * so a test can assert the socket was torn down.
+ */
+type JoinMode = "ok" | "error" | "never";
+function makeFakeWebSocket(mode: JoinMode) {
+  const instances: FakeWebSocket[] = [];
+  class FakeWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+    readyState = 0;
+    onopen: ((ev?: unknown) => void) | null = null;
+    onmessage: ((ev: { data: string }) => void) | null = null;
+    onerror: ((ev?: unknown) => void) | null = null;
+    onclose: ((ev?: unknown) => void) | null = null;
+    closed = false;
+    constructor(public readonly url: string) {
+      instances.push(this);
+      queueMicrotask(() => {
+        this.readyState = 1;
+        this.onopen?.();
+      });
+    }
+    send(data: string): void {
+      if (mode === "never") return;
+      let frame: unknown;
+      try {
+        frame = JSON.parse(data);
+      } catch {
+        return;
+      }
+      if (!Array.isArray(frame)) return;
+      const [joinRef, ref, topic, event] = frame as [
+        string,
+        string,
+        string,
+        string,
+      ];
+      if (event !== "phx_join") return;
+      const status = mode === "ok" ? "ok" : "error";
+      const response = mode === "ok" ? {} : { reason: "unauthorized" };
+      const reply = JSON.stringify([
+        joinRef,
+        ref,
+        topic,
+        "phx_reply",
+        { status, response },
+      ]);
+      queueMicrotask(() => this.onmessage?.({ data: reply }));
+    }
+    close(): void {
+      this.closed = true;
+      this.readyState = 3;
+      this.onclose?.();
+    }
+  }
+  return { FakeWebSocket, instances };
+}
+
+describe("startManagedBotsOverPhoenix — socket lifecycle cleanup (OSS-406)", () => {
+  it("disconnects the socket when the channel join times out", async () => {
+    const { FakeWebSocket, instances } = makeFakeWebSocket("never");
+    const bot = createBot({ name: "opentag", agent: () => new FakeAgent() });
+
+    await expect(
+      startManagedBotsOverPhoenix([bot], {
+        wsUrl: "wss://gateway.example/socket",
+        apiKey: "cpk-test",
+        scope,
+        runtimeInstanceId: "rti_1",
+        webSocket: FakeWebSocket,
+        timeoutMs: 20,
+      }),
+    ).rejects.toThrow(/timed out/i);
+
+    expect(instances.length).toBe(1);
+    expect(instances[0]!.closed).toBe(true);
+  });
+
+  it("disconnects the socket when the channel join is rejected", async () => {
+    const { FakeWebSocket, instances } = makeFakeWebSocket("error");
+    const bot = createBot({ name: "opentag", agent: () => new FakeAgent() });
+
+    await expect(
+      startManagedBotsOverPhoenix([bot], {
+        wsUrl: "wss://gateway.example/socket",
+        apiKey: "cpk-test",
+        scope,
+        runtimeInstanceId: "rti_1",
+        webSocket: FakeWebSocket,
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow(/join failed/i);
+
+    expect(instances.length).toBe(1);
+    expect(instances[0]!.closed).toBe(true);
+  });
+
+  it("disconnects the socket when bot startup fails after the channel joined", async () => {
+    const { FakeWebSocket, instances } = makeFakeWebSocket("ok");
+    // Pre-start the bot so startManagedBots' addAdapter() throws ("adapter added
+    // after start") during the post-join startup — the exact failure the
+    // launcher's try/catch must clean up after.
+    const started = makeFakeChannel();
+    const bot = createBot({ name: "opentag", agent: () => new FakeAgent() });
+    const first = await startManagedBotsOnChannel([bot], {
+      channel: started.channel,
+      scope,
+      runtimeInstanceId: "rti_pre",
+    });
+
+    await expect(
+      startManagedBotsOverPhoenix([bot], {
+        wsUrl: "wss://gateway.example/socket",
+        apiKey: "cpk-test",
+        scope,
+        runtimeInstanceId: "rti_1",
+        webSocket: FakeWebSocket,
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow();
+
+    expect(instances.length).toBe(1);
+    expect(instances[0]!.closed).toBe(true);
+
+    await first.stop();
+  });
 });

--- a/packages/channels-intelligence/src/phoenix-launcher.test.ts
+++ b/packages/channels-intelligence/src/phoenix-launcher.test.ts
@@ -166,7 +166,9 @@ describe("startManagedBotsOverPhoenix — fail-fast validation (OSS-406)", () =>
     class NeverWebSocket {
       constructor() {
         socketConstructed = true;
-        throw new Error("startManagedBotsOverPhoenix should not have connected");
+        throw new Error(
+          "startManagedBotsOverPhoenix should not have connected",
+        );
       }
     }
     const a = createBot({ name: "one", agent: () => new FakeAgent() });

--- a/packages/channels-intelligence/src/phoenix-launcher.test.ts
+++ b/packages/channels-intelligence/src/phoenix-launcher.test.ts
@@ -140,7 +140,9 @@ describe("startManagedBotsOverPhoenix — fail-fast validation (OSS-406)", () =>
     class NeverWebSocket {
       constructor() {
         socketConstructed = true;
-        throw new Error("startManagedBotsOverPhoenix should not have connected");
+        throw new Error(
+          "startManagedBotsOverPhoenix should not have connected",
+        );
       }
     }
     const a = createBot({ name: "dupe", agent: () => new FakeAgent() });

--- a/packages/channels-intelligence/src/phoenix-launcher.test.ts
+++ b/packages/channels-intelligence/src/phoenix-launcher.test.ts
@@ -160,4 +160,62 @@ describe("startManagedBotsOverPhoenix — fail-fast validation (OSS-406)", () =>
 
     expect(socketConstructed).toBe(false);
   });
+
+  it("rejects >1 bot before opening a socket (Phase 1 is single-bot per channel)", async () => {
+    let socketConstructed = false;
+    class NeverWebSocket {
+      constructor() {
+        socketConstructed = true;
+        throw new Error("startManagedBotsOverPhoenix should not have connected");
+      }
+    }
+    const a = createBot({ name: "one", agent: () => new FakeAgent() });
+    const b = createBot({ name: "two", agent: () => new FakeAgent() });
+
+    await expect(
+      startManagedBotsOverPhoenix([a, b], {
+        wsUrl: "wss://gateway.example/socket",
+        apiKey: "cpk-test",
+        scope,
+        runtimeInstanceId: "rti_1",
+        webSocket: NeverWebSocket,
+      }),
+    ).rejects.toThrow(/exactly one bot per channel/i);
+
+    expect(socketConstructed).toBe(false);
+  });
+
+  it("startManagedBotsOnChannel also rejects >1 bot (shared-transport misrouting guard)", async () => {
+    const fake = makeFakeChannel();
+    const a = createBot({ name: "one", agent: () => new FakeAgent() });
+    const b = createBot({ name: "two", agent: () => new FakeAgent() });
+
+    await expect(
+      startManagedBotsOnChannel([a, b], {
+        channel: fake.channel,
+        scope,
+        runtimeInstanceId: "rti_1",
+      }),
+    ).rejects.toThrow(/exactly one bot per channel/i);
+  });
+});
+
+describe("startManagedBotsOnChannel — activation metadata (OSS-406)", () => {
+  it("forwards env overrides into handle.metadata (keeps join ↔ metadata in sync)", async () => {
+    const fake = makeFakeChannel();
+    const bot = createBot({ name: "opentag", agent: () => new FakeAgent() });
+
+    const handle = await startManagedBotsOnChannel([bot], {
+      channel: fake.channel,
+      scope,
+      runtimeInstanceId: "rti_1",
+      env: { runtimeEnv: "production", runtimePackageVersion: "9.9.9" },
+    });
+
+    expect(handle.metadata.runtimeEnv).toBe("production");
+    expect(handle.metadata.runtimePackageVersion).toBe("9.9.9");
+    expect(handle.metadata.declaredBotNames).toEqual(["opentag"]);
+
+    await handle.stop();
+  });
 });

--- a/packages/channels-intelligence/src/phoenix-launcher.test.ts
+++ b/packages/channels-intelligence/src/phoenix-launcher.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { createBot, FakeAgent } from "@copilotkit/channels";
 import { Section } from "@copilotkit/channels-ui";
-import { startManagedBotsOnChannel } from "./phoenix-launcher.js";
+import {
+  startManagedBotsOnChannel,
+  startManagedBotsOverPhoenix,
+} from "./phoenix-launcher.js";
 import type { HostedBotChannel } from "./phoenix-transport.js";
 
 const scope = {
@@ -128,5 +131,31 @@ describe("startManagedBotsOnChannel — managed runtime over Phoenix (OSS-406)",
     expect(events).not.toContain("hosted_bot.delivery.ack.v1");
 
     await handle.stop();
+  });
+});
+
+describe("startManagedBotsOverPhoenix — fail-fast validation (OSS-406)", () => {
+  it("rejects a bad bot name before opening a socket (no leaked connection)", async () => {
+    let socketConstructed = false;
+    class NeverWebSocket {
+      constructor() {
+        socketConstructed = true;
+        throw new Error("startManagedBotsOverPhoenix should not have connected");
+      }
+    }
+    const a = createBot({ name: "dupe", agent: () => new FakeAgent() });
+    const b = createBot({ name: "dupe", agent: () => new FakeAgent() });
+
+    await expect(
+      startManagedBotsOverPhoenix([a, b], {
+        wsUrl: "wss://gateway.example/socket",
+        apiKey: "cpk-test",
+        scope,
+        runtimeInstanceId: "rti_1",
+        webSocket: NeverWebSocket,
+      }),
+    ).rejects.toThrow(/duplicate managed bot name/i);
+
+    expect(socketConstructed).toBe(false);
   });
 });

--- a/packages/channels-intelligence/src/phoenix-launcher.ts
+++ b/packages/channels-intelligence/src/phoenix-launcher.ts
@@ -1,0 +1,132 @@
+import type { Bot } from "@copilotkit/channels";
+import { startManagedBots } from "./runtime.js";
+import type { ManagedBotsHandle } from "./runtime.js";
+import { connectPhoenixHostedBotChannel } from "./phoenix-channel.js";
+import { PhoenixRealtimeTransport } from "./phoenix-transport.js";
+import type {
+  HostedBotChannel,
+  HostedBotRealtimeScope,
+} from "./phoenix-transport.js";
+import type { EgressSink } from "./transports.js";
+
+/**
+ * Phoenix-path egress is vestigial: with a render sink wired (the transport
+ * itself), the adapter routes every `post`/`update` and the run-render stream
+ * through the render sink and never through the generic {@link EgressSink}. Fail
+ * loud if that invariant is ever broken, rather than silently dropping an op.
+ */
+const phoenixEgress: EgressSink = {
+  emit: async () => {
+    throw new Error(
+      "startManagedBotsOverPhoenix: EgressSink.emit was called, but the Phoenix " +
+        "path routes all egress through the render sink — this indicates a " +
+        "wiring bug (the render sink was not set on the adapter).",
+    );
+  },
+};
+
+/** Options for {@link startManagedBotsOnChannel} — an already-connected channel. */
+export interface ManagedBotsOnChannelOptions {
+  /** The joined realtime-gateway bot-IO channel (`hosted_bots:project:<id>`). */
+  channel: HostedBotChannel;
+  /** Authoritative org/project/bot scope echoed on every SDK→gateway envelope. */
+  scope: HostedBotRealtimeScope;
+  /** Stable runtime instance id (`rti_…`), echoed on every envelope. */
+  runtimeInstanceId: string;
+  /** Diagnostic sink for dropped deliveries / transport events. */
+  log?: (message: string, meta?: unknown) => void;
+}
+
+/**
+ * Compose the managed runtime over an already-connected Phoenix channel: wrap
+ * the channel in a {@link PhoenixRealtimeTransport} (delivery source + render
+ * sink) and start the declared bots against it via {@link startManagedBots}.
+ *
+ * Split out from {@link startManagedBotsOverPhoenix} so the composition — the
+ * part with behavior — is unit-testable against a fake channel, leaving the
+ * socket connect as thin glue. `intelligenceAdapter` is exclusive, so the
+ * Phoenix transport is each bot's ONLY adapter; egress is served by the render
+ * sink, not the generic {@link EgressSink} (see {@link phoenixEgress}).
+ */
+export async function startManagedBotsOnChannel(
+  bots: Bot[],
+  opts: ManagedBotsOnChannelOptions,
+): Promise<ManagedBotsHandle> {
+  const transport = new PhoenixRealtimeTransport({
+    scope: opts.scope,
+    runtimeInstanceId: opts.runtimeInstanceId,
+    channel: opts.channel,
+    ...(opts.log ? { log: opts.log } : {}),
+  });
+  return startManagedBots({
+    bots,
+    resolveTransport: () => ({
+      source: transport,
+      renderSink: transport,
+      egress: phoenixEgress,
+    }),
+  });
+}
+
+/** Config for {@link startManagedBotsOverPhoenix}. */
+export interface ManagedPhoenixConfig {
+  /** Gateway runner WebSocket URL — the `/runner` socket hosting the
+   * `hosted_bots:project:<id>` channel. */
+  wsUrl: string;
+  /** Project runtime API key (`cpk-…`), presented as the socket `authToken`. */
+  apiKey: string;
+  /** Authoritative org/project/bot scope echoed on every SDK→gateway envelope. */
+  scope: HostedBotRealtimeScope;
+  /** Stable runtime instance id (`rti_…`). */
+  runtimeInstanceId: string;
+  /** Adapter kind declared to the gateway on join (default `"slack"`). */
+  adapter?: string;
+  /** Join timeout in ms. */
+  timeoutMs?: number;
+  /** Injectable `WebSocket` ctor (non-global hosts / tests). */
+  webSocket?: unknown;
+  /** Diagnostic sink for dropped deliveries / transport events. */
+  log?: (message: string, meta?: unknown) => void;
+}
+
+/**
+ * The managed-over-Phoenix launcher (OSS-406): connect the realtime-gateway
+ * bot-IO channel, then run the declared bots against it via
+ * {@link startManagedBotsOnChannel}. This is the composition that runs a
+ * managed bot over the realtime path — the transport primitives are unit-tested;
+ * this wires them for a live run. The returned handle's `stop()` stops the bots
+ * and then disconnects the socket.
+ */
+export async function startManagedBotsOverPhoenix(
+  bots: Bot[],
+  config: ManagedPhoenixConfig,
+): Promise<ManagedBotsHandle> {
+  const adapter = config.adapter ?? "slack";
+  const channel = await connectPhoenixHostedBotChannel({
+    wsUrl: config.wsUrl,
+    apiKey: config.apiKey,
+    projectId: config.scope.projectId,
+    join: {
+      runtimeInstanceId: config.runtimeInstanceId,
+      declaredBots: bots.map((bot) => ({ botName: bot.name!, adapter })),
+      observedAt: new Date().toISOString(),
+    },
+    ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
+    ...(config.webSocket !== undefined ? { webSocket: config.webSocket } : {}),
+  });
+  const handle = await startManagedBotsOnChannel(bots, {
+    channel,
+    scope: config.scope,
+    runtimeInstanceId: config.runtimeInstanceId,
+    ...(config.log ? { log: config.log } : {}),
+  });
+  return {
+    ...handle,
+    stop: async () => {
+      await handle.stop();
+      // The launcher owns the connection, so it closes it — the transport is
+      // handed the channel and doesn't disconnect it itself.
+      channel.disconnect();
+    },
+  };
+}

--- a/packages/channels-intelligence/src/phoenix-launcher.ts
+++ b/packages/channels-intelligence/src/phoenix-launcher.ts
@@ -133,7 +133,10 @@ export async function startManagedBotsOverPhoenix(
     runtimeInstanceId: config.runtimeInstanceId,
     ...(config.env ?? {}),
   };
-  const activation = buildActivationMetadata(bots, resolveActivationEnv(envOverrides));
+  const activation = buildActivationMetadata(
+    bots,
+    resolveActivationEnv(envOverrides),
+  );
 
   const channel = await connectPhoenixHostedBotChannel({
     wsUrl: config.wsUrl,
@@ -149,7 +152,9 @@ export async function startManagedBotsOverPhoenix(
       })),
       runtimeMetadata: {
         runtimeEnv: activation.runtimeEnv,
-        ...(activation.nodeVersion ? { nodeVersion: activation.nodeVersion } : {}),
+        ...(activation.nodeVersion
+          ? { nodeVersion: activation.nodeVersion }
+          : {}),
         ...(activation.runtimePackageVersion
           ? { runtimePackageVersion: activation.runtimePackageVersion }
           : {}),

--- a/packages/channels-intelligence/src/phoenix-launcher.ts
+++ b/packages/channels-intelligence/src/phoenix-launcher.ts
@@ -1,6 +1,11 @@
 import type { Bot } from "@copilotkit/channels";
-import { startManagedBots } from "./runtime.js";
-import type { ManagedBotsHandle } from "./runtime.js";
+import {
+  startManagedBots,
+  assertValidBotNames,
+  buildActivationMetadata,
+  resolveActivationEnv,
+} from "./runtime.js";
+import type { ManagedBotsHandle, ActivationEnv } from "./runtime.js";
 import { connectPhoenixHostedBotChannel } from "./phoenix-channel.js";
 import { PhoenixRealtimeTransport } from "./phoenix-transport.js";
 import type {
@@ -33,6 +38,10 @@ export interface ManagedBotsOnChannelOptions {
   scope: HostedBotRealtimeScope;
   /** Stable runtime instance id (`rti_…`), echoed on every envelope. */
   runtimeInstanceId: string;
+  /** Activation env overrides forwarded to the runtime (so `handle.metadata`
+   * matches what the caller declared on join); omitted fields are gathered from
+   * the process. */
+  env?: Partial<ActivationEnv>;
   /** Diagnostic sink for dropped deliveries / transport events. */
   log?: (message: string, meta?: unknown) => void;
 }
@@ -65,6 +74,7 @@ export async function startManagedBotsOnChannel(
       renderSink: transport,
       egress: phoenixEgress,
     }),
+    ...(opts.env ? { env: opts.env } : {}),
   });
 }
 
@@ -81,6 +91,10 @@ export interface ManagedPhoenixConfig {
   runtimeInstanceId: string;
   /** Adapter kind declared to the gateway on join (default `"slack"`). */
   adapter?: string;
+  /** Activation env overrides (package versions, runtimeEnv); omitted fields
+   * are gathered from the process. Included in the join's `runtimeMetadata` and
+   * in `handle.metadata`. */
+  env?: Partial<ActivationEnv>;
   /** Join timeout in ms. */
   timeoutMs?: number;
   /** Injectable `WebSocket` ctor (non-global hosts / tests). */
@@ -102,13 +116,50 @@ export async function startManagedBotsOverPhoenix(
   config: ManagedPhoenixConfig,
 ): Promise<ManagedBotsHandle> {
   const adapter = config.adapter ?? "slack";
+
+  // Fail fast BEFORE opening the socket: a missing/duplicate name would
+  // otherwise send a broken join (`botName: undefined`) and — because the same
+  // check inside startManagedBots runs only after we've connected — throw with
+  // the socket already open and never closed (a leak). Validating here means a
+  // bad declaration never opens a connection at all.
+  assertValidBotNames(bots);
+
+  // Build activation metadata up front so the join carries the Runtime
+  // Activation data Intelligence's health view expects (runtime env, node
+  // version, per-bot commands) rather than just name+adapter. The same
+  // `envOverrides` is forwarded to startManagedBots so `handle.metadata` agrees
+  // with what we declared on join.
+  const envOverrides: Partial<ActivationEnv> = {
+    runtimeInstanceId: config.runtimeInstanceId,
+    ...(config.env ?? {}),
+  };
+  const activation = buildActivationMetadata(bots, resolveActivationEnv(envOverrides));
+
   const channel = await connectPhoenixHostedBotChannel({
     wsUrl: config.wsUrl,
     apiKey: config.apiKey,
     projectId: config.scope.projectId,
     join: {
       runtimeInstanceId: config.runtimeInstanceId,
-      declaredBots: bots.map((bot) => ({ botName: bot.name!, adapter })),
+      declaredBots: activation.declaredBots.map((b) => ({
+        botName: b.name,
+        adapter,
+        // renderCapabilities: reserved — bots don't expose capabilities yet
+        // (tracked with the richer per-bot metadata in OSS-377).
+      })),
+      runtimeMetadata: {
+        runtimeEnv: activation.runtimeEnv,
+        ...(activation.nodeVersion ? { nodeVersion: activation.nodeVersion } : {}),
+        ...(activation.runtimePackageVersion
+          ? { runtimePackageVersion: activation.runtimePackageVersion }
+          : {}),
+        ...(activation.botPackageVersion
+          ? { botPackageVersion: activation.botPackageVersion }
+          : {}),
+        commands: Object.fromEntries(
+          activation.declaredBots.map((b) => [b.name, b.commands]),
+        ),
+      },
       observedAt: new Date().toISOString(),
     },
     ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
@@ -118,15 +169,20 @@ export async function startManagedBotsOverPhoenix(
     channel,
     scope: config.scope,
     runtimeInstanceId: config.runtimeInstanceId,
+    env: envOverrides,
     ...(config.log ? { log: config.log } : {}),
   });
   return {
     ...handle,
     stop: async () => {
-      await handle.stop();
-      // The launcher owns the connection, so it closes it — the transport is
-      // handed the channel and doesn't disconnect it itself.
-      channel.disconnect();
+      // Always close the connection even if stopping the bots throws — the
+      // launcher owns the socket (the transport is handed the channel and does
+      // not disconnect it itself).
+      try {
+        await handle.stop();
+      } finally {
+        channel.disconnect();
+      }
     },
   };
 }

--- a/packages/channels-intelligence/src/phoenix-launcher.ts
+++ b/packages/channels-intelligence/src/phoenix-launcher.ts
@@ -30,6 +30,24 @@ const phoenixEgress: EgressSink = {
   },
 };
 
+/**
+ * Phase 1 runs exactly one bot per channel. {@link PhoenixRealtimeTransport} is
+ * a single-delivery-callback object bound to one channel; attaching more than
+ * one bot's `intelligenceAdapter` to the same transport would make every
+ * delivery dispatch through the last bot's callback (and earlier bots receive
+ * nothing). Multi-bot routing over a shared channel is Phase 2 (OSS-459) — until
+ * then, run one bot per channel/runner and fail loudly on more.
+ */
+function assertSingleBotForPhase1(bots: readonly Bot[]): void {
+  if (bots.length !== 1) {
+    throw new Error(
+      `managed Phoenix runtime supports exactly one bot per channel, got ${bots.length} — ` +
+        "multi-bot routing over a shared PhoenixRealtimeTransport is not implemented yet (OSS-459); " +
+        "run one bot per channel/runner",
+    );
+  }
+}
+
 /** Options for {@link startManagedBotsOnChannel} — an already-connected channel. */
 export interface ManagedBotsOnChannelOptions {
   /** The joined realtime-gateway bot-IO channel (`hosted_bots:project:<id>`). */
@@ -61,6 +79,7 @@ export async function startManagedBotsOnChannel(
   bots: Bot[],
   opts: ManagedBotsOnChannelOptions,
 ): Promise<ManagedBotsHandle> {
+  assertSingleBotForPhase1(bots);
   const transport = new PhoenixRealtimeTransport({
     scope: opts.scope,
     runtimeInstanceId: opts.runtimeInstanceId,
@@ -93,8 +112,10 @@ export interface ManagedPhoenixConfig {
   adapter?: string;
   /** Activation env overrides (package versions, runtimeEnv); omitted fields
    * are gathered from the process. Included in the join's `runtimeMetadata` and
-   * in `handle.metadata`. */
-  env?: Partial<ActivationEnv>;
+   * in `handle.metadata`. `runtimeInstanceId` is intentionally excluded — the
+   * required top-level {@link ManagedPhoenixConfig.runtimeInstanceId} is
+   * authoritative for both the join and `handle.metadata` (they must agree). */
+  env?: Partial<Omit<ActivationEnv, "runtimeInstanceId">>;
   /** Join timeout in ms. */
   timeoutMs?: number;
   /** Injectable `WebSocket` ctor (non-global hosts / tests). */
@@ -123,15 +144,19 @@ export async function startManagedBotsOverPhoenix(
   // the socket already open and never closed (a leak). Validating here means a
   // bad declaration never opens a connection at all.
   assertValidBotNames(bots);
+  // Fail fast before opening a socket for an unsupported multi-bot call.
+  assertSingleBotForPhase1(bots);
 
   // Build activation metadata up front so the join carries the Runtime
   // Activation data Intelligence's health view expects (runtime env, node
   // version, per-bot commands) rather than just name+adapter. The same
   // `envOverrides` is forwarded to startManagedBots so `handle.metadata` agrees
-  // with what we declared on join.
+  // with what we declared on join. The required `config.runtimeInstanceId` is
+  // spread LAST so it stays authoritative even though `config.env` cannot carry
+  // it (type-excluded) — belt and suspenders for the join↔metadata invariant.
   const envOverrides: Partial<ActivationEnv> = {
-    runtimeInstanceId: config.runtimeInstanceId,
     ...(config.env ?? {}),
+    runtimeInstanceId: config.runtimeInstanceId,
   };
   const activation = buildActivationMetadata(
     bots,
@@ -170,13 +195,22 @@ export async function startManagedBotsOverPhoenix(
     ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
     ...(config.webSocket !== undefined ? { webSocket: config.webSocket } : {}),
   });
-  const handle = await startManagedBotsOnChannel(bots, {
-    channel,
-    scope: config.scope,
-    runtimeInstanceId: config.runtimeInstanceId,
-    env: envOverrides,
-    ...(config.log ? { log: config.log } : {}),
-  });
+  // The channel is now joined. If starting the bots throws (e.g. a bot was
+  // already started, or a conflicting adapter), the caller never receives a
+  // handle — so disconnect the socket here rather than leak it, then rethrow.
+  let handle: ManagedBotsHandle;
+  try {
+    handle = await startManagedBotsOnChannel(bots, {
+      channel,
+      scope: config.scope,
+      runtimeInstanceId: config.runtimeInstanceId,
+      env: envOverrides,
+      ...(config.log ? { log: config.log } : {}),
+    });
+  } catch (err) {
+    channel.disconnect();
+    throw err;
+  }
   return {
     ...handle,
     stop: async () => {

--- a/packages/channels-intelligence/src/phoenix-launcher.ts
+++ b/packages/channels-intelligence/src/phoenix-launcher.ts
@@ -58,8 +58,11 @@ export interface ManagedBotsOnChannelOptions {
   runtimeInstanceId: string;
   /** Activation env overrides forwarded to the runtime (so `handle.metadata`
    * matches what the caller declared on join); omitted fields are gathered from
-   * the process. */
-  env?: Partial<ActivationEnv>;
+   * the process. `runtimeInstanceId` is excluded — the required
+   * {@link ManagedBotsOnChannelOptions.runtimeInstanceId} above is authoritative
+   * and is merged in, so the transport (which stamps it on every envelope) and
+   * `handle.metadata` always report the same id. */
+  env?: Partial<Omit<ActivationEnv, "runtimeInstanceId">>;
   /** Diagnostic sink for dropped deliveries / transport events. */
   log?: (message: string, meta?: unknown) => void;
 }
@@ -93,7 +96,10 @@ export async function startManagedBotsOnChannel(
       renderSink: transport,
       egress: phoenixEgress,
     }),
-    ...(opts.env ? { env: opts.env } : {}),
+    // The required runtimeInstanceId is authoritative: merge it in LAST so
+    // `handle.metadata` reports the same id the transport stamps on every
+    // envelope, regardless of any `env` overrides (which cannot carry it).
+    env: { ...(opts.env ?? {}), runtimeInstanceId: opts.runtimeInstanceId },
   });
 }
 
@@ -204,7 +210,9 @@ export async function startManagedBotsOverPhoenix(
       channel,
       scope: config.scope,
       runtimeInstanceId: config.runtimeInstanceId,
-      env: envOverrides,
+      // startManagedBotsOnChannel re-merges the authoritative runtimeInstanceId,
+      // so forward only the caller's overrides here (they cannot carry the id).
+      ...(config.env ? { env: config.env } : {}),
       ...(config.log ? { log: config.log } : {}),
     });
   } catch (err) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,6 +414,9 @@ importers:
       '@copilotkit/channels-discord':
         specifier: workspace:*
         version: link:../../packages/channels-discord
+      '@copilotkit/channels-intelligence':
+        specifier: workspace:*
+        version: link:../../packages/channels-intelligence
       '@copilotkit/channels-slack':
         specifier: workspace:*
         version: link:../../packages/channels-slack
@@ -25036,8 +25039,8 @@ packages:
   vue-component-type-helpers@3.3.1:
     resolution: {integrity: sha512-pu58kqxmVyEH6VfNYW1UyEfR3XAnJ27ZXT3yzXxxpjLxVzAbyC35Zk/nm/RMs7ijWnJNSd9fWkeex2OhUsx3MA==}
 
-  vue-component-type-helpers@3.3.6:
-    resolution: {integrity: sha512-FkljacAwJ9BUoSUdpFe3VDy0sGigNlTH9+2zcXUWmZOjN8swiCkl3t48wOJun0OsUd2cEIda1l04tsxMiKIIrQ==}
+  vue-component-type-helpers@3.3.7:
+    resolution: {integrity: sha512-Skkhw9agYSgsWqv7bxSOGJZa9SaiJbZVGdXuFWnrzKaQYHnw9qbjD630rw6RyMqDbp54nfLCLw5SZA55if7JLg==}
 
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
@@ -38075,7 +38078,7 @@ snapshots:
       storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.34(typescript@5.8.2)
-      vue-component-type-helpers: 3.3.6
+      vue-component-type-helpers: 3.3.7
 
   '@swc/core-darwin-arm64@1.15.8':
     optional: true
@@ -55797,7 +55800,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.1: {}
 
-  vue-component-type-helpers@3.3.6: {}
+  vue-component-type-helpers@3.3.7: {}
 
   vue-devtools-stub@0.1.0: {}
 


### PR DESCRIPTION
## Summary

**OSS-406 Phase 1** — the missing composition that runs a managed bot over the **Phoenix realtime path**, plus a real consumer of it.

The realtime foundation is live on main (gateway `hosted_bots:project:<id>` channel, Redis fan-out, app-api durable authority + lease fencing), and the SDK primitives — `startManagedBots`, `connectPhoenixHostedBotChannel`, `PhoenixRealtimeTransport` — exist and are unit-tested. But **nothing composed them**, so the managed adapter fell back to its HTTP default and Phoenix was never exercised end-to-end. This adds the launcher **and wires an example to it** so it isn't an unused export.

## Launcher (`channels-intelligence/phoenix-launcher.ts`)

- **`startManagedBotsOnChannel(bots, { channel, scope, runtimeInstanceId, log? })`** — wraps an already-connected channel in a `PhoenixRealtimeTransport` (delivery source + render sink) and starts the bots via `startManagedBots`. Split out so the *behavior* is unit-testable against a fake channel.
- **`startManagedBotsOverPhoenix(bots, config)`** — thin glue: `connectPhoenixHostedBotChannel` → delegate → `disconnect()` on `stop()`.
- **`phoenixEgress`** — fail-loud `EgressSink`. `intelligenceAdapter` is exclusive and, with a render sink wired, routes every `post`/`update`/run-render through it — the generic `EgressSink` must never be hit.

## Consumer (`examples/slack/app/managed.ts`)

A **real caller** of the launcher: the *same* Slack bot as `examples/slack/app/index.ts` — identical agent, tools, context, commands, and turn handlers — run in **managed mode over Phoenix** instead of the native `slack()` adapter. `index.ts` (native/self-hosted) is left untouched; `managed.ts` holds no Slack creds and no public endpoint, just a runtime key + a Phoenix connection. Demonstrates the "same bot, swap the transport" thesis concretely:

```
native:   createBot({ adapters: [ slack({ botToken, appToken }) ] })   // index.ts
managed:  startManagedBotsOverPhoenix([ createBot({ … }) ], { … })     // managed.ts
```

The managed `onMention` handler passes the current message as `prompt` to `runAgent` — see the validation note below for why this is required on the managed path (and not on native).

## Tests

Drive a **real `createBot`** through the **full managed path** over a fake channel:
- a Phoenix-delivered turn → handler runs → `render_event` frame → `complete_requested` (completion **intent**, never a self-ack);
- a throwing handler → `fail` intent (no completion, no ack).

Build + 97 package tests green; `examples/slack` `managed.ts` type-clean.

## Validation — live E2E over the real Phoenix path

This didn't just pass unit tests against a fake channel; the whole loop was driven end-to-end on a real local stack with a **real OpenAI backend**, and I verified the message actually traveled the websocket path (not the HTTP fallback).

**Stack:** Intelligence `main` via docker-compose (postgres, postgres-ops, redis, keycloak, minio, tei, realtime-gateway on `:4401`) + app-api on `:7050` (graphile migrations applied). Managed-bots entitlement was granted via the managed-service path (a stub ops entitlement endpoint + `FF_MANAGED_BOTS=true` on both app-api and the gateway; gateway join otherwise rejects with `disabled_by_feature_flag`).

**Provisioning:** created a managed Slack bot + attached a Slack adapter (fixture workspace/creds) against app-api, then triggered a real `app-mention` event through a fake-Slack provider into app-api's signed ingress.

**What was proven:**
- app-api ingress → Redis publish → gateway leases the delivery and pushes `delivery.available` over Phoenix → `managed.ts` (via the launcher) receives it, runs the **real OpenAI** agent, and streams `render_event` frames back → durable render acceptances written (`run_started`, `text_delta`, `text_end`, `finalize`) → `complete_requested` intent → app-api commits the ack. Delivery ended `succeeded`.
- **It genuinely used the websocket path.** With gateway debug logging bumped, frames showed `HANDLED hosted_bot.render_event.v1 INCOMING ON hosted_bots:project:<id> (SdkChannel)`. All app-api delivery-side calls originated from the gateway's HTTP client (`hackney`), with **zero launcher-originated HTTP delivery calls**, and the launcher contains no HTTP delivery code at all. The render frames went bot → gateway over the Phoenix socket.

**Bug found and fixed during validation (the reason `managed.ts` passes `prompt`):**
The first real run failed with an OpenAI `400 input.messages=0` — the agent received **zero messages**. Root cause: `runAgent` (packages/channels `thread.ts`) only injects a user message when `extra.prompt` is set; otherwise it relies on the adapter's reconstructed history. The **native** path gets away with omitting `prompt` because the native adapter's `getHistory` rebuilds the live thread *including* the triggering message. The **managed** path does not: app-api's `GET /api/bots/history` (`reconstructManagedThreadHistory`) rebuilds only *prior committed* deliveries and structurally excludes the in-flight turn (the current delivery is handed to the SDK as the delivery envelope, not via history). So a managed handler that omits `prompt` drops the newest user message — turn 1 → 0 messages → 400; turn 2+ → the agent answers a *stale* prompt. FakeAgent unit tests never caught it because they don't exercise the history round-trip.

Fixed here by having the managed `onMention` pass `message.contentParts ?? message.text` as `prompt`. This is a **systemic** footgun for every managed entrypoint; it's tracked with a durable-fix recommendation (adapter auto-injects the current message so managed handlers match native) in **OSS-459**.

## Scope

- **This PR:** the launcher composition + its first consumer + unit/contract coverage, **plus the live-stack E2E above** which closes OSS-406's "realtime path is unproven" gap and surfaced/fixed the managed `prompt` bug.
- **Deferred (OSS-459):** Teams managed entrypoint, multi-tenant multiplexing, BYO, promote to a deployable Intelligence managed-bot runtime app, HTTP-path deprecation, shared bot-def extraction, and the durable managed-`prompt` fix.

Refs OSS-406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
