### PR TITLE
Add Inspector Threads empty-state onboarding

### DIFF
--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -1906,7 +1906,7 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
       ".cpk-threads-overview-video",
     );
     expect(video?.src).toBe(
-      "https://www.copilotkit.ai/videos/copilotkit-generative-ui-agentic-frontend-demo.webm",
+      "https://cdn.copilotkit.ai/corp-site/videos/copilotkit-generative-ui-agentic-frontend-demo.webm",
     );
   });
 

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -1542,10 +1542,10 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
   const threadListText = (inspector: WebInspectorElement) =>
     inspector.shadowRoot?.querySelector("cpk-thread-list")?.shadowRoot
       ?.textContent ?? "";
-  const expectThreadsOnboardingUtmParams = (url: URL) => {
-    expect(url.searchParams.get("utm_source")).toBe("copilotkit_inspector");
-    expect(url.searchParams.get("utm_medium")).toBe("in_product");
-    expect(url.searchParams.get("utm_campaign")).toBe("threads_onboarding");
+  const expectNoUtmParams = (url: URL) => {
+    expect(url.searchParams.has("utm_source")).toBe(false);
+    expect(url.searchParams.has("utm_medium")).toBe(false);
+    expect(url.searchParams.has("utm_campaign")).toBe(false);
   };
 
   beforeEach(() => {
@@ -1762,7 +1762,7 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     expect(signupUrl.origin).toBe("https://dashboard.operations.copilotkit.ai");
     expect(signupUrl.pathname).toBe("/sign-in");
     expect(signupUrl.searchParams.get("ref")).toBe("cpk-inspector");
-    expectThreadsOnboardingUtmParams(signupUrl);
+    expectNoUtmParams(signupUrl);
     const distinctId = signupUrl.searchParams.get("posthog_distinct_id");
     expect(distinctId).toMatch(/^[0-9a-f-]{36}$/);
 
@@ -1770,7 +1770,7 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     expect(engineerUrl.origin).toBe("https://www.copilotkit.ai");
     expect(engineerUrl.pathname).toBe("/talk-to-an-engineer");
     expect(engineerUrl.searchParams.get("ref")).toBe("cpk-inspector-threads");
-    expectThreadsOnboardingUtmParams(engineerUrl);
+    expectNoUtmParams(engineerUrl);
     expect(engineerUrl.searchParams.get("posthog_distinct_id")).toBe(
       distinctId,
     );
@@ -1860,7 +1860,7 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     expect(threadsDocsUrl.searchParams.get("ref")).toBe(
       "cpk-inspector-threads",
     );
-    expectThreadsOnboardingUtmParams(threadsDocsUrl);
+    expectNoUtmParams(threadsDocsUrl);
     const selfHosted = inspector.shadowRoot?.querySelector<HTMLAnchorElement>(
       'a[href^="https://docs.copilotkit.ai/premium/self-hosting"]',
     );
@@ -1871,7 +1871,7 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     expect(selfHostedUrl.origin).toBe("https://docs.copilotkit.ai");
     expect(selfHostedUrl.pathname).toBe("/premium/self-hosting");
     expect(selfHostedUrl.searchParams.get("ref")).toBe("cpk-inspector-threads");
-    expectThreadsOnboardingUtmParams(selfHostedUrl);
+    expectNoUtmParams(selfHostedUrl);
     expect(threadListText(inspector)).toContain("Example");
     expect(text).not.toContain("No threads yet");
     expect(
@@ -1888,7 +1888,7 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     expect(engineerUrl.origin).toBe("https://www.copilotkit.ai");
     expect(engineerUrl.pathname).toBe("/talk-to-an-engineer");
     expect(engineerUrl.searchParams.get("ref")).toBe("cpk-inspector-threads");
-    expectThreadsOnboardingUtmParams(engineerUrl);
+    expectNoUtmParams(engineerUrl);
     expect(engineer?.closest("#cpk-main-scroll")).toBeNull();
   });
 

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -32,6 +32,15 @@ type InspectorThreadViewInternals = {
     agentId: string;
     updatedAt?: string | null;
   }>;
+  _threadsByAgent: Map<
+    string,
+    Array<{
+      id: string;
+      name?: string | null;
+      agentId: string;
+      updatedAt?: string | null;
+    }>
+  >;
 };
 
 type InspectorContextInternals = {
@@ -1530,6 +1539,9 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
           properties: Record<string, unknown>;
         };
       });
+  const threadListText = (inspector: WebInspectorElement) =>
+    inspector.shadowRoot?.querySelector("cpk-thread-list")?.shadowRoot
+      ?.textContent ?? "";
 
   beforeEach(() => {
     document.body.innerHTML = "";
@@ -1698,6 +1710,10 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
       "Talk to an Engineer",
       "Sign up for Intelligence",
     ]);
+    const engineer = inspector.shadowRoot?.querySelector<HTMLAnchorElement>(
+      'a[href^="https://www.copilotkit.ai/talk-to-an-engineer"]',
+    );
+    expect(engineer?.closest("#cpk-main-scroll")).toBeNull();
     expect(text).not.toContain("No threads yet");
     expect(
       fetchMock.mock.calls.some((call) => String(call[0]).includes("/threads")),
@@ -1795,7 +1811,7 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     }
   });
 
-  it("keeps the enabled empty Threads state when thread listing is available", async () => {
+  it("renders example threads and the deselected overview when enabled thread history is empty", async () => {
     const { agent } = createMockAgent("alpha");
     const harness = createHeaderMockCore({ alpha: agent }, {}, {}, true);
 
@@ -1812,13 +1828,294 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     internals.handleMenuSelect("threads");
     await inspector.updateComplete;
 
-    expect(inspector.shadowRoot?.textContent ?? "").toContain("No threads yet");
+    await vi.waitFor(() => {
+      const text = threadListText(inspector);
+      expect(text).toContain("Realtime thread sync");
+      expect(text).toContain("Manage saved conversations");
+      expect(text).toContain("Inspect durable run history");
+    });
+
+    const text = inspector.shadowRoot?.textContent ?? "";
+    expect(text).toContain("Threads are persistent, inspectable conversations");
+    expect(text).toContain(
+      "Take a tour with the example threads in the sidebar.",
+    );
+    const threadsDocs = inspector.shadowRoot?.querySelector<HTMLAnchorElement>(
+      'a[href="https://docs.copilotkit.ai/threads"]',
+    );
+    expect(threadsDocs?.textContent?.trim()).toBe("Learn how Threads work");
+    const selfHosted =
+      inspector.shadowRoot?.querySelector<HTMLAnchorElement>(
+        'a[href="https://docs.copilotkit.ai/premium/self-hosting"]',
+      );
+    expect(selfHosted?.textContent?.trim()).toBe(
+      "Explore self-hosted Intelligence",
+    );
+    expect(threadListText(inspector)).toContain("Example");
+    expect(text).not.toContain("No threads yet");
+    expect(
+      inspector.shadowRoot?.querySelector("cpk-thread-details"),
+    ).toBeNull();
+    expect(
+      (inspector as unknown as InspectorThreadViewInternals).selectedThreadId,
+    ).toBeNull();
+
     const engineer = inspector.shadowRoot?.querySelector<HTMLAnchorElement>(
       'a[href^="https://www.copilotkit.ai/talk-to-an-engineer"]',
     );
     expect(engineer?.href).toBe(
       "https://www.copilotkit.ai/talk-to-an-engineer?ref=cpk-inspector-threads",
     );
+    expect(engineer?.closest("#cpk-main-scroll")).toBeNull();
+  });
+
+  it("does not render example threads once real threads are present", async () => {
+    const inspector = new WebInspectorElement();
+    document.body.appendChild(inspector);
+    inspector.core = createHeaderMockCore({}, {}, {}, true)
+      .core as unknown as WebInspectorElement["core"];
+
+    const internals = inspector as unknown as InspectorThreadViewInternals;
+    internals.isOpen = true;
+    internals.selectedMenu = "threads";
+    internals._threads = [
+      {
+        id: "real-thread",
+        name: "Real customer thread",
+        agentId: "alpha",
+        updatedAt: "2026-06-25T10:00:00.000Z",
+      },
+    ];
+    internals._threadsByAgent = new Map([["alpha", internals._threads]]);
+    inspector.requestUpdate();
+    await inspector.updateComplete;
+
+    const text = threadListText(inspector);
+    expect(text).toContain("Real customer thread");
+    expect(text).not.toContain("Realtime thread sync");
+    expect(text).not.toContain("Example");
+  });
+
+  it("selects an example thread, shows the tour, and toggles back to the overview on second click", async () => {
+    const { agent } = createMockAgent("alpha");
+    const harness = createHeaderMockCore({ alpha: agent }, {}, {}, true);
+
+    const inspector = new WebInspectorElement();
+    document.body.appendChild(inspector);
+    inspector.core = harness.core as unknown as WebInspectorElement["core"];
+    harness.emitAgentsChanged();
+
+    const internals = inspector as unknown as {
+      isOpen: boolean;
+      handleMenuSelect: (key: "threads") => void;
+      selectedThreadId: string | null;
+    };
+    internals.isOpen = true;
+    internals.handleMenuSelect("threads");
+    await inspector.updateComplete;
+
+    await vi.waitFor(() => {
+      expect(threadListText(inspector)).toContain("Realtime thread sync");
+    });
+
+    const threadList = inspector.shadowRoot?.querySelector("cpk-thread-list");
+    const firstRow =
+      threadList?.shadowRoot?.querySelector<HTMLElement>(".cpk-tl__item");
+    expect(firstRow).toBeDefined();
+
+    firstRow!.click();
+    await inspector.updateComplete;
+    await vi.waitFor(() => {
+      expect(internals.selectedThreadId).toBe("example-realtime-sync");
+      expect(inspector.shadowRoot?.querySelector("cpk-thread-details")).not.toBe(
+        null,
+      );
+      expect(inspector.shadowRoot?.textContent ?? "").toContain(
+        "Read the run as a story",
+      );
+    });
+
+    firstRow!.click();
+    await inspector.updateComplete;
+
+    await vi.waitFor(() => {
+      expect(internals.selectedThreadId).toBeNull();
+      expect(inspector.shadowRoot?.querySelector("cpk-thread-details")).toBeNull();
+      expect(inspector.shadowRoot?.textContent ?? "").toContain(
+        "Threads are persistent, inspectable conversations",
+      );
+    });
+  });
+
+  it("persists example tour dismissal so it does not auto-open again", async () => {
+    const stored = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => stored.get(key) ?? null,
+      setItem: (key: string, value: string) => stored.set(key, value),
+      removeItem: (key: string) => stored.delete(key),
+      clear: () => stored.clear(),
+      get length() {
+        return stored.size;
+      },
+      key: (index: number) => Array.from(stored.keys())[index] ?? null,
+    });
+
+    const { agent } = createMockAgent("alpha");
+    const harness = createHeaderMockCore({ alpha: agent }, {}, {}, false);
+
+    const inspector = new WebInspectorElement();
+    document.body.appendChild(inspector);
+    inspector.core = harness.core as unknown as WebInspectorElement["core"];
+    harness.emitAgentsChanged();
+
+    const internals = inspector as unknown as {
+      isOpen: boolean;
+      handleMenuSelect: (key: "threads") => void;
+    };
+    internals.isOpen = true;
+    internals.handleMenuSelect("threads");
+    await inspector.updateComplete;
+
+    await vi.waitFor(() => {
+      expect(threadListText(inspector)).toContain("Realtime thread sync");
+    });
+
+    const firstRow = inspector.shadowRoot
+      ?.querySelector("cpk-thread-list")
+      ?.shadowRoot?.querySelector<HTMLElement>(".cpk-tl__item");
+    firstRow!.click();
+    await inspector.updateComplete;
+
+    await vi.waitFor(() => {
+      expect(inspector.shadowRoot?.textContent ?? "").toContain(
+        "Read the run as a story",
+      );
+    });
+
+    const skip = Array.from(
+      inspector.shadowRoot?.querySelectorAll<HTMLButtonElement>("button") ?? [],
+    ).find((button) => button.textContent?.trim() === "Skip");
+    expect(skip).toBeDefined();
+    skip!.click();
+    await inspector.updateComplete;
+
+    expect(
+      stored.get("cpk:inspector:threads-example-tour:v1"),
+    ).toContain('"dismissed":true');
+
+    const secondInspector = new WebInspectorElement();
+    document.body.appendChild(secondInspector);
+    secondInspector.core = harness.core as unknown as WebInspectorElement["core"];
+    harness.emitAgentsChanged();
+    const secondInternals = secondInspector as unknown as {
+      isOpen: boolean;
+      handleMenuSelect: (key: "threads") => void;
+    };
+    secondInternals.isOpen = true;
+    secondInternals.handleMenuSelect("threads");
+    await secondInspector.updateComplete;
+
+    await vi.waitFor(() => {
+      expect(threadListText(secondInspector)).toContain(
+        "Realtime thread sync",
+      );
+    });
+
+    const secondRow = secondInspector.shadowRoot
+      ?.querySelector("cpk-thread-list")
+      ?.shadowRoot?.querySelector<HTMLElement>(".cpk-tl__item");
+    secondRow!.click();
+    await secondInspector.updateComplete;
+
+    await vi.waitFor(() => {
+      expect(secondInspector.shadowRoot?.querySelector("cpk-thread-details")).not
+        .toBeNull();
+    });
+    expect(secondInspector.shadowRoot?.textContent ?? "").not.toContain(
+      "Read the run as a story",
+    );
+    expect(secondInspector.shadowRoot?.textContent ?? "").toContain("Show tour");
+
+    const showTour = Array.from(
+      secondInspector.shadowRoot?.querySelectorAll<HTMLButtonElement>(
+        "button",
+      ) ?? [],
+    ).find((button) => button.textContent?.trim() === "Show tour");
+    expect(showTour).toBeDefined();
+    showTour!.click();
+    await secondInspector.updateComplete;
+
+    await vi.waitFor(() => {
+      expect(secondInspector.shadowRoot?.textContent ?? "").toContain(
+        "Read the run as a story",
+      );
+    });
+  });
+
+  it("tracks example thread selection and tour dismissal telemetry", async () => {
+    const { agent } = createMockAgent("alpha");
+    const harness = createHeaderMockCore({ alpha: agent }, {}, {}, false);
+
+    const inspector = new WebInspectorElement();
+    document.body.appendChild(inspector);
+    inspector.core = harness.core as unknown as WebInspectorElement["core"];
+    harness.emitAgentsChanged();
+
+    const internals = inspector as unknown as {
+      isOpen: boolean;
+      handleMenuSelect: (key: "threads") => void;
+    };
+    internals.isOpen = true;
+    internals.handleMenuSelect("threads");
+    await inspector.updateComplete;
+
+    await vi.waitFor(() => {
+      expect(threadListText(inspector)).toContain("Realtime thread sync");
+    });
+
+    const firstRow = inspector.shadowRoot
+      ?.querySelector("cpk-thread-list")
+      ?.shadowRoot?.querySelector<HTMLElement>(".cpk-tl__item");
+    firstRow!.click();
+    await inspector.updateComplete;
+
+    await vi.waitFor(() => {
+      expect(inspector.shadowRoot?.textContent ?? "").toContain(
+        "Read the run as a story",
+      );
+    });
+
+    const skip = Array.from(
+      inspector.shadowRoot?.querySelectorAll<HTMLButtonElement>("button") ?? [],
+    ).find((button) => button.textContent?.trim() === "Skip");
+    skip!.click();
+    await inspector.updateComplete;
+
+    const posts = telemetryPosts();
+    expect(
+      posts.some(
+        (post) => post.event === "oss.inspector.threads_example_selected",
+      ),
+    ).toBe(true);
+    expect(
+      posts.some(
+        (post) => post.event === "oss.inspector.threads_example_tour_started",
+      ),
+    ).toBe(true);
+    const stepViewed = posts.find(
+      (post) => post.event === "oss.inspector.threads_example_tour_step_viewed",
+    );
+    expect(stepViewed?.properties).toMatchObject({
+      example_thread_id: "example-realtime-sync",
+      tour_step: 1,
+    });
+    const dismissed = posts.find(
+      (post) => post.event === "oss.inspector.threads_example_tour_dismissed",
+    );
+    expect(dismissed?.properties).toMatchObject({
+      example_thread_id: "example-realtime-sync",
+      dismiss_method: "skip",
+    });
   });
 });
 

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -1868,9 +1868,7 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     const selfHostedUrl = new URL(selfHosted!.href);
     expect(selfHostedUrl.origin).toBe("https://docs.copilotkit.ai");
     expect(selfHostedUrl.pathname).toBe("/premium/self-hosting");
-    expect(selfHostedUrl.searchParams.get("ref")).toBe(
-      "cpk-inspector-threads",
-    );
+    expect(selfHostedUrl.searchParams.get("ref")).toBe("cpk-inspector-threads");
     expectThreadsOnboardingUtmParams(selfHostedUrl);
     expect(threadListText(inspector)).toContain("Example");
     expect(text).not.toContain("No threads yet");
@@ -1887,9 +1885,7 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     const engineerUrl = new URL(engineer!.href);
     expect(engineerUrl.origin).toBe("https://www.copilotkit.ai");
     expect(engineerUrl.pathname).toBe("/talk-to-an-engineer");
-    expect(engineerUrl.searchParams.get("ref")).toBe(
-      "cpk-inspector-threads",
-    );
+    expect(engineerUrl.searchParams.get("ref")).toBe("cpk-inspector-threads");
     expectThreadsOnboardingUtmParams(engineerUrl);
     expect(engineer?.closest("#cpk-main-scroll")).toBeNull();
   });

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -1844,10 +1844,9 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
       'a[href="https://docs.copilotkit.ai/threads"]',
     );
     expect(threadsDocs?.textContent?.trim()).toBe("Learn how Threads work");
-    const selfHosted =
-      inspector.shadowRoot?.querySelector<HTMLAnchorElement>(
-        'a[href="https://docs.copilotkit.ai/premium/self-hosting"]',
-      );
+    const selfHosted = inspector.shadowRoot?.querySelector<HTMLAnchorElement>(
+      'a[href="https://docs.copilotkit.ai/premium/self-hosting"]',
+    );
     expect(selfHosted?.textContent?.trim()).toBe(
       "Explore self-hosted Intelligence",
     );
@@ -1927,9 +1926,9 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     await inspector.updateComplete;
     await vi.waitFor(() => {
       expect(internals.selectedThreadId).toBe("example-realtime-sync");
-      expect(inspector.shadowRoot?.querySelector("cpk-thread-details")).not.toBe(
-        null,
-      );
+      expect(
+        inspector.shadowRoot?.querySelector("cpk-thread-details"),
+      ).not.toBe(null);
       expect(inspector.shadowRoot?.textContent ?? "").toContain(
         "Read the run as a story",
       );
@@ -1940,7 +1939,9 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
 
     await vi.waitFor(() => {
       expect(internals.selectedThreadId).toBeNull();
-      expect(inspector.shadowRoot?.querySelector("cpk-thread-details")).toBeNull();
+      expect(
+        inspector.shadowRoot?.querySelector("cpk-thread-details"),
+      ).toBeNull();
       expect(inspector.shadowRoot?.textContent ?? "").toContain(
         "Threads are persistent, inspectable conversations",
       );
@@ -1999,13 +2000,14 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     skip!.click();
     await inspector.updateComplete;
 
-    expect(
-      stored.get("cpk:inspector:threads-example-tour:v1"),
-    ).toContain('"dismissed":true');
+    expect(stored.get("cpk:inspector:threads-example-tour:v1")).toContain(
+      '"dismissed":true',
+    );
 
     const secondInspector = new WebInspectorElement();
     document.body.appendChild(secondInspector);
-    secondInspector.core = harness.core as unknown as WebInspectorElement["core"];
+    secondInspector.core =
+      harness.core as unknown as WebInspectorElement["core"];
     harness.emitAgentsChanged();
     const secondInternals = secondInspector as unknown as {
       isOpen: boolean;
@@ -2016,9 +2018,7 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     await secondInspector.updateComplete;
 
     await vi.waitFor(() => {
-      expect(threadListText(secondInspector)).toContain(
-        "Realtime thread sync",
-      );
+      expect(threadListText(secondInspector)).toContain("Realtime thread sync");
     });
 
     const secondRow = secondInspector.shadowRoot
@@ -2028,13 +2028,16 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     await secondInspector.updateComplete;
 
     await vi.waitFor(() => {
-      expect(secondInspector.shadowRoot?.querySelector("cpk-thread-details")).not
-        .toBeNull();
+      expect(
+        secondInspector.shadowRoot?.querySelector("cpk-thread-details"),
+      ).not.toBeNull();
     });
     expect(secondInspector.shadowRoot?.textContent ?? "").not.toContain(
       "Read the run as a story",
     );
-    expect(secondInspector.shadowRoot?.textContent ?? "").toContain("Show tour");
+    expect(secondInspector.shadowRoot?.textContent ?? "").toContain(
+      "Show tour",
+    );
 
     const showTour = Array.from(
       secondInspector.shadowRoot?.querySelectorAll<HTMLButtonElement>(

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -1933,6 +1933,108 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     );
   });
 
+  it("does not load the empty overview video when reduced motion is preferred", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("matchMedia", () => ({ matches: true }));
+
+    const { agent } = createMockAgent("alpha");
+    const harness = createHeaderMockCore({ alpha: agent }, {}, {}, false);
+
+    const inspector = new WebInspectorElement();
+    document.body.appendChild(inspector);
+    inspector.core = harness.core as unknown as WebInspectorElement["core"];
+    harness.emitAgentsChanged();
+
+    const internals = inspector as unknown as {
+      isOpen: boolean;
+      handleMenuSelect: (key: "threads") => void;
+    };
+    internals.isOpen = true;
+    internals.handleMenuSelect("threads");
+    await inspector.updateComplete;
+
+    expect(inspector.shadowRoot?.textContent ?? "").toContain(
+      "Threads are persistent, inspectable conversations",
+    );
+    expect(
+      inspector.shadowRoot?.querySelector(".cpk-threads-overview-video-frame"),
+    ).not.toBeNull();
+
+    await vi.advanceTimersByTimeAsync(1200);
+    await inspector.updateComplete;
+
+    expect(
+      inspector.shadowRoot?.querySelector(".cpk-threads-overview-video"),
+    ).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("clears the deferred video timeout when disconnected before load", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("matchMedia", () => ({ matches: false }));
+    Object.defineProperty(window, "requestIdleCallback", {
+      configurable: true,
+      value: undefined,
+    });
+    const clearTimeoutSpy = vi.spyOn(window, "clearTimeout");
+
+    const { agent } = createMockAgent("alpha");
+    const harness = createHeaderMockCore({ alpha: agent }, {}, {}, false);
+
+    const inspector = new WebInspectorElement();
+    document.body.appendChild(inspector);
+    inspector.core = harness.core as unknown as WebInspectorElement["core"];
+    harness.emitAgentsChanged();
+
+    const internals = inspector as unknown as {
+      isOpen: boolean;
+      handleMenuSelect: (key: "threads") => void;
+    };
+    internals.isOpen = true;
+    internals.handleMenuSelect("threads");
+    await inspector.updateComplete;
+
+    expect(vi.getTimerCount()).toBe(1);
+    inspector.remove();
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("cancels the deferred video idle callback when disconnected before load", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("matchMedia", () => ({ matches: false }));
+    const requestIdleCallback = vi.fn(() => 123);
+    const cancelIdleCallback = vi.fn();
+    Object.defineProperty(window, "requestIdleCallback", {
+      configurable: true,
+      value: requestIdleCallback,
+    });
+    Object.defineProperty(window, "cancelIdleCallback", {
+      configurable: true,
+      value: cancelIdleCallback,
+    });
+
+    const { agent } = createMockAgent("alpha");
+    const harness = createHeaderMockCore({ alpha: agent }, {}, {}, false);
+
+    const inspector = new WebInspectorElement();
+    document.body.appendChild(inspector);
+    inspector.core = harness.core as unknown as WebInspectorElement["core"];
+    harness.emitAgentsChanged();
+
+    const internals = inspector as unknown as {
+      isOpen: boolean;
+      handleMenuSelect: (key: "threads") => void;
+    };
+    internals.isOpen = true;
+    internals.handleMenuSelect("threads");
+    await inspector.updateComplete;
+
+    expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+    inspector.remove();
+    expect(cancelIdleCallback).toHaveBeenCalledWith(123);
+  });
+
   it("does not render example threads once real threads are present", async () => {
     const inspector = new WebInspectorElement();
     document.body.appendChild(inspector);

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -24,7 +24,7 @@ type InspectorInternals = {
 
 type InspectorThreadViewInternals = {
   isOpen: boolean;
-  selectedMenu: "threads";
+  selectedMenu: "ag-ui-events" | "threads";
   selectedThreadId: string | null;
   _threads: Array<{
     id: string;
@@ -1542,6 +1542,10 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
   const threadListText = (inspector: WebInspectorElement) =>
     inspector.shadowRoot?.querySelector("cpk-thread-list")?.shadowRoot
       ?.textContent ?? "";
+  const menuButton = (inspector: WebInspectorElement, label: string) =>
+    Array.from(
+      inspector.shadowRoot?.querySelectorAll<HTMLButtonElement>("button") ?? [],
+    ).find((button) => button.textContent?.trim() === label);
 
   beforeEach(() => {
     document.body.innerHTML = "";
@@ -1558,6 +1562,7 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -1866,6 +1871,127 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
       "https://www.copilotkit.ai/talk-to-an-engineer?ref=cpk-inspector-threads",
     );
     expect(engineer?.closest("#cpk-main-scroll")).toBeNull();
+  });
+
+  it("defers loading the empty overview video until after the overview paints", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("matchMedia", () => ({ matches: false }));
+
+    const { agent } = createMockAgent("alpha");
+    const harness = createHeaderMockCore({ alpha: agent }, {}, {}, false);
+
+    const inspector = new WebInspectorElement();
+    document.body.appendChild(inspector);
+    inspector.core = harness.core as unknown as WebInspectorElement["core"];
+    harness.emitAgentsChanged();
+
+    const internals = inspector as unknown as {
+      isOpen: boolean;
+      handleMenuSelect: (key: "threads") => void;
+    };
+    internals.isOpen = true;
+    internals.handleMenuSelect("threads");
+    await inspector.updateComplete;
+
+    expect(inspector.shadowRoot?.textContent ?? "").toContain(
+      "Threads are persistent, inspectable conversations",
+    );
+    expect(
+      inspector.shadowRoot?.querySelector(".cpk-threads-overview-video-frame"),
+    ).not.toBeNull();
+    expect(
+      inspector.shadowRoot?.querySelector(".cpk-threads-overview-video"),
+    ).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(450);
+    await inspector.updateComplete;
+
+    const video = inspector.shadowRoot?.querySelector<HTMLVideoElement>(
+      ".cpk-threads-overview-video",
+    );
+    expect(video?.src).toBe(
+      "https://www.copilotkit.ai/videos/copilotkit-generative-ui-agentic-frontend-demo.webm",
+    );
+  });
+
+  it("only shimmers the Threads nav tab as a deselected locked or empty cue", async () => {
+    const renderWith = async (
+      core: CopilotKitCore,
+      setup?: (internals: InspectorThreadViewInternals) => void,
+    ) => {
+      const inspector = new WebInspectorElement();
+      document.body.appendChild(inspector);
+      inspector.core = core;
+      const internals = inspector as unknown as InspectorThreadViewInternals;
+      internals.isOpen = true;
+      internals.selectedMenu = "ag-ui-events";
+      setup?.(internals);
+      inspector.requestUpdate();
+      await inspector.updateComplete;
+      return inspector;
+    };
+
+    const locked = await renderWith(
+      createHeaderMockCore({}, {}, { list: false }, false)
+        .core as unknown as CopilotKitCore,
+    );
+    expect(menuButton(locked, "Threads")?.className).toContain(
+      "cpk-tab-threads-glimmer",
+    );
+
+    menuButton(locked, "Threads")!.click();
+    await locked.updateComplete;
+    expect(menuButton(locked, "Threads")?.className).not.toContain(
+      "cpk-tab-threads-glimmer",
+    );
+
+    const enabledEmpty = await renderWith(
+      createHeaderMockCore({}, {}, {}, false).core as unknown as CopilotKitCore,
+    );
+    expect(menuButton(enabledEmpty, "Threads")?.className).toContain(
+      "cpk-tab-threads-glimmer",
+    );
+
+    const populated = await renderWith(
+      createHeaderMockCore({}, {}, {}, false).core as unknown as CopilotKitCore,
+      (internals) => {
+        internals._threads = [
+          {
+            id: "real-thread",
+            name: "Real customer thread",
+            agentId: "alpha",
+            updatedAt: "2026-06-25T10:00:00.000Z",
+          },
+        ];
+        internals._threadsByAgent = new Map([["alpha", internals._threads]]);
+      },
+    );
+    expect(menuButton(populated, "Threads")?.className).not.toContain(
+      "cpk-tab-threads-glimmer",
+    );
+
+    const errored = await renderWith(
+      createHeaderMockCore({}, {}, {}, false).core as unknown as CopilotKitCore,
+      (internals) => {
+        (
+          internals as unknown as {
+            _threadsErrorByAgent: Map<string, Error>;
+          }
+        )._threadsErrorByAgent = new Map([
+          ["alpha", new Error("Thread list failed")],
+        ]);
+      },
+    );
+    expect(menuButton(errored, "Threads")?.className).not.toContain(
+      "cpk-tab-threads-glimmer",
+    );
+
+    const telemetryDisabled = await renderWith(
+      createHeaderMockCore({}, {}, {}, true).core as unknown as CopilotKitCore,
+    );
+    expect(menuButton(telemetryDisabled, "Threads")?.className).not.toContain(
+      "cpk-tab-threads-glimmer",
+    );
   });
 
   it("does not render example threads once real threads are present", async () => {

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -2462,6 +2462,29 @@ describe("WebInspectorElement memories — view states", () => {
     ).toBeNull();
   });
 
+  it("does not use Threads onboarding UTM attribution for locked memory CTAs", async () => {
+    const core = makeCoreNoIntelligence();
+    const el = await mountMemories(core);
+
+    const talkToEngineer = el.shadowRoot?.querySelector<HTMLAnchorElement>(
+      'a[href^="https://www.copilotkit.ai/talk-to-an-engineer"]',
+    );
+    const signup = el.shadowRoot?.querySelector<HTMLAnchorElement>(
+      'a[href^="https://go.copilotkit.ai/intelligence-signup"]',
+    );
+
+    expect(talkToEngineer).not.toBeNull();
+    expect(signup).not.toBeNull();
+
+    for (const href of [talkToEngineer!.href, signup!.href]) {
+      const url = new URL(href);
+      expect(url.searchParams.get("ref")).toBeTruthy();
+      expect(url.searchParams.has("utm_source")).toBe(false);
+      expect(url.searchParams.has("utm_medium")).toBe(false);
+      expect(url.searchParams.has("utm_campaign")).toBe(false);
+    }
+  });
+
   it("renders the locked teaser when memories are unavailable", async () => {
     const core = makeCoreWithMemory([], { available: false });
     const el = await mountMemories(core);

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -1749,7 +1749,7 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     await inspector.updateComplete;
 
     const signup = inspector.shadowRoot?.querySelector<HTMLAnchorElement>(
-      'a[href^="https://go.copilotkit.ai/intelligence-signup"]',
+      'a[href^="https://dashboard.operations.copilotkit.ai/sign-in"]',
     );
     const engineer = inspector.shadowRoot?.querySelector<HTMLAnchorElement>(
       'a[href^="https://www.copilotkit.ai/talk-to-an-engineer"]',
@@ -1759,6 +1759,8 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     expect(engineer).not.toBeNull();
 
     const signupUrl = new URL(signup!.href);
+    expect(signupUrl.origin).toBe("https://dashboard.operations.copilotkit.ai");
+    expect(signupUrl.pathname).toBe("/sign-in");
     expect(signupUrl.searchParams.get("ref")).toBe("cpk-inspector");
     expectThreadsOnboardingUtmParams(signupUrl);
     const distinctId = signupUrl.searchParams.get("posthog_distinct_id");

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -1542,6 +1542,11 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
   const threadListText = (inspector: WebInspectorElement) =>
     inspector.shadowRoot?.querySelector("cpk-thread-list")?.shadowRoot
       ?.textContent ?? "";
+  const expectThreadsOnboardingUtmParams = (url: URL) => {
+    expect(url.searchParams.get("utm_source")).toBe("copilotkit_inspector");
+    expect(url.searchParams.get("utm_medium")).toBe("in_product");
+    expect(url.searchParams.get("utm_campaign")).toBe("threads_onboarding");
+  };
 
   beforeEach(() => {
     document.body.innerHTML = "";
@@ -1721,7 +1726,7 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     ).toBe(false);
   });
 
-  it("adds ref and posthog distinct ID attribution to locked-state CTAs", async () => {
+  it("adds inspector attribution to locked-state CTAs", async () => {
     const { agent } = createMockAgent("alpha");
     const harness = createHeaderMockCore(
       { alpha: agent },
@@ -1755,6 +1760,7 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
 
     const signupUrl = new URL(signup!.href);
     expect(signupUrl.searchParams.get("ref")).toBe("cpk-inspector");
+    expectThreadsOnboardingUtmParams(signupUrl);
     const distinctId = signupUrl.searchParams.get("posthog_distinct_id");
     expect(distinctId).toMatch(/^[0-9a-f-]{36}$/);
 
@@ -1762,6 +1768,7 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     expect(engineerUrl.origin).toBe("https://www.copilotkit.ai");
     expect(engineerUrl.pathname).toBe("/talk-to-an-engineer");
     expect(engineerUrl.searchParams.get("ref")).toBe("cpk-inspector-threads");
+    expectThreadsOnboardingUtmParams(engineerUrl);
     expect(engineerUrl.searchParams.get("posthog_distinct_id")).toBe(
       distinctId,
     );
@@ -1842,15 +1849,29 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
       "Take a tour with the example threads in the sidebar.",
     );
     const threadsDocs = inspector.shadowRoot?.querySelector<HTMLAnchorElement>(
-      'a[href="https://docs.copilotkit.ai/threads"]',
+      'a[href^="https://docs.copilotkit.ai/threads"]',
     );
     expect(threadsDocs?.textContent?.trim()).toBe("Learn how Threads work");
+    const threadsDocsUrl = new URL(threadsDocs!.href);
+    expect(threadsDocsUrl.origin).toBe("https://docs.copilotkit.ai");
+    expect(threadsDocsUrl.pathname).toBe("/threads");
+    expect(threadsDocsUrl.searchParams.get("ref")).toBe(
+      "cpk-inspector-threads",
+    );
+    expectThreadsOnboardingUtmParams(threadsDocsUrl);
     const selfHosted = inspector.shadowRoot?.querySelector<HTMLAnchorElement>(
-      'a[href="https://docs.copilotkit.ai/premium/self-hosting"]',
+      'a[href^="https://docs.copilotkit.ai/premium/self-hosting"]',
     );
     expect(selfHosted?.textContent?.trim()).toBe(
       "Explore self-hosted Intelligence",
     );
+    const selfHostedUrl = new URL(selfHosted!.href);
+    expect(selfHostedUrl.origin).toBe("https://docs.copilotkit.ai");
+    expect(selfHostedUrl.pathname).toBe("/premium/self-hosting");
+    expect(selfHostedUrl.searchParams.get("ref")).toBe(
+      "cpk-inspector-threads",
+    );
+    expectThreadsOnboardingUtmParams(selfHostedUrl);
     expect(threadListText(inspector)).toContain("Example");
     expect(text).not.toContain("No threads yet");
     expect(
@@ -1863,9 +1884,13 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     const engineer = inspector.shadowRoot?.querySelector<HTMLAnchorElement>(
       'a[href^="https://www.copilotkit.ai/talk-to-an-engineer"]',
     );
-    expect(engineer?.href).toBe(
-      "https://www.copilotkit.ai/talk-to-an-engineer?ref=cpk-inspector-threads",
+    const engineerUrl = new URL(engineer!.href);
+    expect(engineerUrl.origin).toBe("https://www.copilotkit.ai");
+    expect(engineerUrl.pathname).toBe("/talk-to-an-engineer");
+    expect(engineerUrl.searchParams.get("ref")).toBe(
+      "cpk-inspector-threads",
     );
+    expectThreadsOnboardingUtmParams(engineerUrl);
     expect(engineer?.closest("#cpk-main-scroll")).toBeNull();
   });
 

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -1542,10 +1542,6 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
   const threadListText = (inspector: WebInspectorElement) =>
     inspector.shadowRoot?.querySelector("cpk-thread-list")?.shadowRoot
       ?.textContent ?? "";
-  const menuButton = (inspector: WebInspectorElement, label: string) =>
-    Array.from(
-      inspector.shadowRoot?.querySelectorAll<HTMLButtonElement>("button") ?? [],
-    ).find((button) => button.textContent?.trim() === label);
 
   beforeEach(() => {
     document.body.innerHTML = "";
@@ -1911,86 +1907,6 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     );
     expect(video?.src).toBe(
       "https://www.copilotkit.ai/videos/copilotkit-generative-ui-agentic-frontend-demo.webm",
-    );
-  });
-
-  it("only shimmers the Threads nav tab as a deselected locked or empty cue", async () => {
-    const renderWith = async (
-      core: CopilotKitCore,
-      setup?: (internals: InspectorThreadViewInternals) => void,
-    ) => {
-      const inspector = new WebInspectorElement();
-      document.body.appendChild(inspector);
-      inspector.core = core;
-      const internals = inspector as unknown as InspectorThreadViewInternals;
-      internals.isOpen = true;
-      internals.selectedMenu = "ag-ui-events";
-      setup?.(internals);
-      inspector.requestUpdate();
-      await inspector.updateComplete;
-      return inspector;
-    };
-
-    const locked = await renderWith(
-      createHeaderMockCore({}, {}, { list: false }, false)
-        .core as unknown as CopilotKitCore,
-    );
-    expect(menuButton(locked, "Threads")?.className).toContain(
-      "cpk-tab-threads-glimmer",
-    );
-
-    menuButton(locked, "Threads")!.click();
-    await locked.updateComplete;
-    expect(menuButton(locked, "Threads")?.className).not.toContain(
-      "cpk-tab-threads-glimmer",
-    );
-
-    const enabledEmpty = await renderWith(
-      createHeaderMockCore({}, {}, {}, false).core as unknown as CopilotKitCore,
-    );
-    expect(menuButton(enabledEmpty, "Threads")?.className).toContain(
-      "cpk-tab-threads-glimmer",
-    );
-
-    const populated = await renderWith(
-      createHeaderMockCore({}, {}, {}, false).core as unknown as CopilotKitCore,
-      (internals) => {
-        internals._threads = [
-          {
-            id: "real-thread",
-            name: "Real customer thread",
-            agentId: "alpha",
-            updatedAt: "2026-06-25T10:00:00.000Z",
-          },
-        ];
-        internals._threadsByAgent = new Map([["alpha", internals._threads]]);
-      },
-    );
-    expect(menuButton(populated, "Threads")?.className).not.toContain(
-      "cpk-tab-threads-glimmer",
-    );
-
-    const errored = await renderWith(
-      createHeaderMockCore({}, {}, {}, false).core as unknown as CopilotKitCore,
-      (internals) => {
-        (
-          internals as unknown as {
-            _threadsErrorByAgent: Map<string, Error>;
-          }
-        )._threadsErrorByAgent = new Map([
-          ["alpha", new Error("Thread list failed")],
-        ]);
-      },
-    );
-    expect(menuButton(errored, "Threads")?.className).not.toContain(
-      "cpk-tab-threads-glimmer",
-    );
-
-    const telemetryDisabled = await renderWith(
-      createHeaderMockCore({}, {}, {}, true).core as unknown as CopilotKitCore,
-    );
-    expect(menuButton(telemetryDisabled, "Threads")?.className).not.toContain(
-      "cpk-tab-threads-glimmer",
     );
   });
 

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -946,9 +946,9 @@ class CpkThreadList extends LitElement {
                   <span class="cpk-tl__pill">${thread.agentId}</span>
                   ${
                     (thread as Partial<ExampleThread>).isExample
-                      ? html`<span class="cpk-tl__pill cpk-tl__pill--example"
-                          >Example</span
-                        >`
+                      ? html`
+                          <span class="cpk-tl__pill cpk-tl__pill--example">Example</span>
+                        `
                       : nothing
                   }
                 </div>
@@ -8144,7 +8144,10 @@ ${argsString}</pre
   }
 
   private renderThreadsExampleTour() {
-    if (!this.selectedThreadId || !this.isExampleThreadId(this.selectedThreadId)) {
+    if (
+      !this.selectedThreadId ||
+      !this.isExampleThreadId(this.selectedThreadId)
+    ) {
       return nothing;
     }
 
@@ -8178,7 +8181,8 @@ ${argsString}</pre
       THREADS_EXAMPLE_TOUR_STEPS[this.exampleTourStep] ??
       THREADS_EXAMPLE_TOUR_STEPS[0]!;
     const isFirst = this.exampleTourStep === 0;
-    const isLast = this.exampleTourStep === THREADS_EXAMPLE_TOUR_STEPS.length - 1;
+    const isLast =
+      this.exampleTourStep === THREADS_EXAMPLE_TOUR_STEPS.length - 1;
 
     return html`
       <div
@@ -8987,7 +8991,7 @@ ${argsString}</pre
                   ${selectedThreadIsExample ? this.renderThreadsExampleTour() : nothing}`
                 : showingExamples
                   ? this.renderThreadsExampleOverview()
-                : html`
+                  : html`
                     <div
                       style="
                         flex: 1;

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -4384,17 +4384,11 @@ export class WebInspectorElement extends LitElement {
   }
 
   private getThreadsTalkToEngineerUrl(): string {
-    return this.appendRefParam(
-      TALK_TO_ENGINEER_URL,
-      "cpk-inspector-threads",
-    );
+    return this.appendRefParam(TALK_TO_ENGINEER_URL, "cpk-inspector-threads");
   }
 
   private getThreadsDocsUrl(): string {
-    return this.appendRefParam(
-      THREADS_DOCS_URL,
-      "cpk-inspector-threads",
-    );
+    return this.appendRefParam(THREADS_DOCS_URL, "cpk-inspector-threads");
   }
 
   private getSelfHostedIntelligenceUrl(): string {

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -123,6 +123,8 @@ const TALK_TO_ENGINEER_URL = "https://www.copilotkit.ai/talk-to-an-engineer";
 const THREADS_DOCS_URL = "https://docs.copilotkit.ai/threads";
 const SELF_HOSTED_INTELLIGENCE_URL =
   "https://docs.copilotkit.ai/premium/self-hosting";
+const THREADS_EXAMPLE_OVERVIEW_VIDEO_URL =
+  "https://www.copilotkit.ai/videos/copilotkit-generative-ui-agentic-frontend-demo.webm";
 const THREADS_EXAMPLE_TOUR_STORAGE_KEY =
   "cpk:inspector:threads-example-tour:v1";
 const THREADS_EXAMPLE_AGENT_ID = "threads-feature";
@@ -4204,6 +4206,10 @@ export class WebInspectorElement extends LitElement {
   private exampleTourActive = false;
   private exampleTourStep = 0;
   private exampleTourAutoShown = false;
+  private threadsExampleOverviewVideoShouldLoad = false;
+  private threadsExampleOverviewVideoReady = false;
+  private threadsExampleOverviewVideoLoadTimer: number | null = null;
+  private threadsExampleOverviewVideoIdleCallbackId: number | null = null;
 
   get core(): CopilotKitCore | null {
     return this._core;
@@ -4296,6 +4302,51 @@ export class WebInspectorElement extends LitElement {
 
   private areThreadEndpointsAvailable(): boolean {
     return this.getThreadServiceStatus() !== "unavailable";
+  }
+
+  private getActiveThreadsState(): {
+    displayThreads: ɵThread[];
+    threadsErrorMessage: string | null;
+  } {
+    const displayThreads =
+      this.selectedContext === "all-agents"
+        ? this._threads
+        : (this._threadsByAgent.get(this.selectedContext) ?? []);
+
+    // Surface a thread-store load error inline. For "all-agents" we report
+    // the first error encountered across all agents (good enough for a
+    // debugging surface — the per-agent context filter narrows down the
+    // culprit). For a specific agent we use that agent's error directly.
+    let threadsErrorMessage: string | null = null;
+    if (this.selectedContext === "all-agents") {
+      const firstError = this._threadsErrorByAgent.values().next().value;
+      threadsErrorMessage = firstError?.message ?? null;
+    } else {
+      threadsErrorMessage =
+        this._threadsErrorByAgent.get(this.selectedContext)?.message ?? null;
+    }
+
+    return { displayThreads, threadsErrorMessage };
+  }
+
+  private shouldShowThreadsNavGlimmer(key: MenuKey): boolean {
+    if (key !== "threads" || this.selectedMenu === "threads") {
+      return false;
+    }
+    if (this.core?.telemetryDisabled) {
+      return false;
+    }
+
+    const threadServiceStatus = this.getThreadServiceStatus();
+    if (threadServiceStatus === "unavailable") {
+      return true;
+    }
+    if (threadServiceStatus !== "available") {
+      return false;
+    }
+
+    const { displayThreads, threadsErrorMessage } = this.getActiveThreadsState();
+    return !threadsErrorMessage && displayThreads.length === 0;
   }
 
   private getThreadsTelemetryProps(
@@ -5971,6 +6022,79 @@ ${argsString}</pre
       .cpk-tab-active {
         cursor: pointer;
       }
+      @keyframes cpkThreadsNavGlimmer {
+        0% {
+          background-position: 160% 50%;
+        }
+        48%,
+        100% {
+          background-position: -60% 50%;
+        }
+      }
+      @keyframes cpkThreadsNavPulse {
+        0%,
+        100% {
+          box-shadow:
+            inset 0 0 0 1px rgba(190, 194, 255, 0.28),
+            0 0 0 rgba(190, 194, 255, 0);
+        }
+        50% {
+          box-shadow:
+            inset 0 0 0 1px rgba(190, 194, 255, 0.42),
+            0 0 16px rgba(190, 194, 255, 0.22);
+        }
+      }
+      .cpk-tab-threads-glimmer {
+        overflow: hidden;
+        background-image: linear-gradient(
+          112deg,
+          rgba(190, 194, 255, 0.14) 0%,
+          rgba(190, 194, 255, 0.18) 34%,
+          rgba(255, 255, 255, 0.78) 45%,
+          rgba(133, 236, 206, 0.16) 54%,
+          rgba(190, 194, 255, 0.14) 70%
+        );
+        background-size: 240% 100%;
+        animation:
+          cpkThreadsNavGlimmer 3.2s ease-in-out infinite,
+          cpkThreadsNavPulse 4.6s ease-in-out infinite;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .cpk-tab-threads-glimmer {
+          animation: none;
+          background-position: 50% 50%;
+        }
+      }
+
+      .cpk-threads-overview-video-frame {
+        position: relative;
+        display: block;
+        width: 100%;
+        max-width: 440px;
+        aspect-ratio: 16 / 9;
+        margin: 0 0 14px;
+        overflow: hidden;
+        border: 1px solid #dbdbe5;
+        border-radius: 8px;
+        background:
+          linear-gradient(
+            135deg,
+            rgba(190, 194, 255, 0.18),
+            rgba(133, 236, 206, 0.12)
+          ),
+          #ffffff;
+        box-shadow: 0 8px 20px rgba(1, 5, 7, 0.08);
+      }
+      .cpk-threads-overview-video {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        opacity: 0;
+        transition: opacity 220ms ease;
+      }
+      .cpk-threads-overview-video[data-ready="true"] {
+        opacity: 1;
+      }
 
       /* ── Header control buttons (dock, close) — first row only ───── */
       .drag-handle > div:first-child button {
@@ -6187,6 +6311,17 @@ ${argsString}</pre
     if (this.transitionTimeoutId !== null) {
       clearTimeout(this.transitionTimeoutId);
       this.transitionTimeoutId = null;
+    }
+    if (this.threadsExampleOverviewVideoLoadTimer !== null) {
+      clearTimeout(this.threadsExampleOverviewVideoLoadTimer);
+      this.threadsExampleOverviewVideoLoadTimer = null;
+    }
+    if (
+      this.threadsExampleOverviewVideoIdleCallbackId !== null &&
+      typeof window.cancelIdleCallback === "function"
+    ) {
+      window.cancelIdleCallback(this.threadsExampleOverviewVideoIdleCallbackId);
+      this.threadsExampleOverviewVideoIdleCallbackId = null;
     }
     this.removeDockStyles(true); // Clean up any docking styles, skip transition
     this.detachFromCore();
@@ -6437,6 +6572,9 @@ ${argsString}</pre
                 const tabClasses = [
                   "inline-flex items-center gap-2 rounded-md px-3 py-2 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-300",
                   isSelected ? "cpk-tab-active" : "cpk-tab-inactive",
+                  this.shouldShowThreadsNavGlimmer(key)
+                    ? "cpk-tab-threads-glimmer"
+                    : "",
                 ].join(" ");
 
                 return html`
@@ -8057,6 +8195,70 @@ ${argsString}</pre
     }
   }
 
+  private scheduleThreadsExampleOverviewVideoLoad(): void {
+    if (
+      this.threadsExampleOverviewVideoShouldLoad ||
+      this.threadsExampleOverviewVideoLoadTimer !== null ||
+      this.threadsExampleOverviewVideoIdleCallbackId !== null ||
+      typeof window === "undefined"
+    ) {
+      return;
+    }
+
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) {
+      return;
+    }
+
+    const loadVideo = () => {
+      this.threadsExampleOverviewVideoLoadTimer = null;
+      this.threadsExampleOverviewVideoIdleCallbackId = null;
+      this.threadsExampleOverviewVideoShouldLoad = true;
+      this.requestUpdate();
+    };
+
+    if (typeof window.requestIdleCallback === "function") {
+      this.threadsExampleOverviewVideoIdleCallbackId =
+        window.requestIdleCallback(loadVideo, { timeout: 1200 });
+      return;
+    }
+
+    this.threadsExampleOverviewVideoLoadTimer = window.setTimeout(
+      loadVideo,
+      450,
+    );
+  }
+
+  private handleThreadsExampleOverviewVideoLoaded = (): void => {
+    this.threadsExampleOverviewVideoReady = true;
+    this.requestUpdate();
+  };
+
+  private renderThreadsExampleOverviewVideo() {
+    this.scheduleThreadsExampleOverviewVideoLoad();
+
+    return html`
+      <div class="cpk-threads-overview-video-frame" aria-hidden="true">
+        ${
+          this.threadsExampleOverviewVideoShouldLoad
+            ? html`
+                <video
+                  class="cpk-threads-overview-video"
+                  data-ready=${this.threadsExampleOverviewVideoReady}
+                  src=${THREADS_EXAMPLE_OVERVIEW_VIDEO_URL}
+                  autoplay
+                  loop
+                  muted
+                  playsinline
+                  preload="metadata"
+                  @loadeddata=${this.handleThreadsExampleOverviewVideoLoaded}
+                ></video>
+              `
+            : nothing
+        }
+      </div>
+    `;
+  }
+
   private renderThreadsExampleOverview() {
     return html`
       <div
@@ -8082,6 +8284,7 @@ ${argsString}</pre
           >
             Threads are persistent, inspectable conversations
           </h2>
+          ${this.renderThreadsExampleOverviewVideo()}
           <p
             style="
               margin: 0 0 16px;

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -65,6 +65,13 @@ import {
   trackTalkToEngineerClicked,
   trackThreadsEmptyEnabledViewed,
   trackThreadsEnabledViewed,
+  trackThreadsExampleSelected,
+  trackThreadsExampleTourCompleted,
+  trackThreadsExampleTourDismissed,
+  trackThreadsExampleTourReopened,
+  trackThreadsExampleTourStarted,
+  trackThreadsExampleTourStepViewed,
+  trackThreadsExampleViewed,
   trackThreadsIntelligenceSignupClicked,
   trackThreadsLockedViewed,
   trackMemoriesTabClicked,
@@ -113,6 +120,12 @@ const MAX_AGENT_EVENTS = 200;
 const MAX_TOTAL_EVENTS = 500;
 const INTELLIGENCE_SIGNUP_URL = "https://go.copilotkit.ai/intelligence-signup";
 const TALK_TO_ENGINEER_URL = "https://www.copilotkit.ai/talk-to-an-engineer";
+const THREADS_DOCS_URL = "https://docs.copilotkit.ai/threads";
+const SELF_HOSTED_INTELLIGENCE_URL =
+  "https://docs.copilotkit.ai/premium/self-hosting";
+const THREADS_EXAMPLE_TOUR_STORAGE_KEY =
+  "cpk:inspector:threads-example-tour:v1";
+const THREADS_EXAMPLE_AGENT_ID = "threads-feature";
 
 type ThreadServiceStatus = "available" | "unavailable" | "unknown" | "error";
 
@@ -376,6 +389,235 @@ type RuntimeStateFetchResult =
   | { status: "available"; state: Record<string, unknown> | null }
   | { status: "not-available" };
 
+type ExampleThread = ɵThread & { isExample: true };
+
+type ExampleThreadDetails = {
+  messages: ThreadDebuggerMessage[];
+  events: ThreadDebuggerEvent[];
+  state: Record<string, unknown>;
+};
+
+const THREADS_EXAMPLE_THREADS: ExampleThread[] = [
+  {
+    id: "example-realtime-sync",
+    name: "Realtime thread sync",
+    agentId: THREADS_EXAMPLE_AGENT_ID,
+    organizationId: "example-organization",
+    createdById: "example-user",
+    archived: false,
+    createdAt: "2026-07-08T16:00:00.000Z",
+    updatedAt: "2026-07-08T16:30:00.000Z",
+    isExample: true,
+  },
+  {
+    id: "example-manage-history",
+    name: "Manage saved conversations",
+    agentId: THREADS_EXAMPLE_AGENT_ID,
+    organizationId: "example-organization",
+    createdById: "example-user",
+    archived: false,
+    createdAt: "2026-07-07T17:45:00.000Z",
+    updatedAt: "2026-07-07T18:15:00.000Z",
+    isExample: true,
+  },
+  {
+    id: "example-inspect-runs",
+    name: "Inspect durable run history",
+    agentId: THREADS_EXAMPLE_AGENT_ID,
+    organizationId: "example-organization",
+    createdById: "example-user",
+    archived: false,
+    createdAt: "2026-07-06T20:15:00.000Z",
+    updatedAt: "2026-07-06T20:45:00.000Z",
+    isExample: true,
+  },
+];
+
+const THREADS_EXAMPLE_DETAILS: Record<string, ExampleThreadDetails> = {
+  "example-realtime-sync": {
+    messages: [
+      {
+        id: "example-sync-user",
+        role: "user",
+        content: "Resume the checkout support thread from yesterday.",
+      },
+      {
+        id: "example-sync-assistant",
+        role: "assistant",
+        content:
+          "I found the saved thread, restored the cart state, and continued from the latest user message.",
+      },
+    ],
+    events: [
+      {
+        type: "RUN_STARTED",
+        timestamp: "2026-07-08T16:30:00.000Z",
+        payload: {
+          threadId: "example-realtime-sync",
+          agentId: THREADS_EXAMPLE_AGENT_ID,
+        },
+      },
+      {
+        type: "MESSAGES_SNAPSHOT",
+        timestamp: "2026-07-08T16:30:01.000Z",
+        payload: {
+          messageCount: 6,
+          source: "thread-history",
+        },
+      },
+      {
+        type: "STATE_SNAPSHOT",
+        timestamp: "2026-07-08T16:30:02.000Z",
+        payload: {
+          cartId: "cart_demo_42",
+          checkoutStep: "shipping",
+          resumed: true,
+        },
+      },
+      {
+        type: "RUN_FINISHED",
+        timestamp: "2026-07-08T16:30:04.000Z",
+        payload: {
+          status: "completed",
+        },
+      },
+    ],
+    state: {
+      cartId: "cart_demo_42",
+      checkoutStep: "shipping",
+      userIntent: "resume_previous_checkout",
+      persistedThread: true,
+    },
+  },
+  "example-manage-history": {
+    messages: [
+      {
+        id: "example-history-user",
+        role: "user",
+        content: "Rename this saved support conversation for the handoff.",
+      },
+      {
+        id: "example-history-assistant",
+        role: "assistant",
+        content:
+          "Renamed the thread and kept the prior messages available for the next session.",
+      },
+    ],
+    events: [
+      {
+        type: "RUN_STARTED",
+        timestamp: "2026-07-07T18:15:00.000Z",
+        payload: {
+          threadId: "example-manage-history",
+          agentId: THREADS_EXAMPLE_AGENT_ID,
+        },
+      },
+      {
+        type: "CUSTOM_EVENT",
+        timestamp: "2026-07-07T18:15:01.000Z",
+        payload: {
+          action: "thread_renamed",
+          previousName: "Untitled",
+          name: "Billing escalation handoff",
+        },
+      },
+      {
+        type: "RUN_FINISHED",
+        timestamp: "2026-07-07T18:15:03.000Z",
+        payload: {
+          status: "completed",
+        },
+      },
+    ],
+    state: {
+      name: "Billing escalation handoff",
+      savedMessages: 14,
+      lastHandoff: "support-team",
+    },
+  },
+  "example-inspect-runs": {
+    messages: [
+      {
+        id: "example-inspect-user",
+        role: "user",
+        content: "Why did the assistant recommend the enterprise plan?",
+      },
+      {
+        id: "example-inspect-assistant",
+        role: "assistant",
+        content:
+          "The recommendation came from the account size, SSO requirement, and audit-log constraint in state.",
+      },
+    ],
+    events: [
+      {
+        type: "RUN_STARTED",
+        timestamp: "2026-07-06T20:45:00.000Z",
+        payload: {
+          threadId: "example-inspect-runs",
+          agentId: THREADS_EXAMPLE_AGENT_ID,
+        },
+      },
+      {
+        type: "TOOL_CALL_START",
+        timestamp: "2026-07-06T20:45:01.000Z",
+        payload: {
+          toolCallId: "call_account_lookup",
+          toolName: "lookupAccount",
+        },
+      },
+      {
+        type: "TOOL_CALL_RESULT",
+        timestamp: "2026-07-06T20:45:02.000Z",
+        payload: {
+          toolCallId: "call_account_lookup",
+          seats: 220,
+          requiresSso: true,
+        },
+      },
+      {
+        type: "RUN_FINISHED",
+        timestamp: "2026-07-06T20:45:04.000Z",
+        payload: {
+          status: "completed",
+        },
+      },
+    ],
+    state: {
+      accountTier: "growth",
+      seats: 220,
+      requiresSso: true,
+      auditLogsRequired: true,
+    },
+  },
+};
+
+const THREADS_EXAMPLE_TOUR_STEPS: ReadonlyArray<{
+  tab: ThreadDetailsTab;
+  label: string;
+  title: string;
+  body: string;
+}> = [
+  {
+    tab: "timeline",
+    label: "Timeline",
+    title: "Read the run as a story",
+    body: "The timeline turns messages, tool calls, state changes, and run markers into a scannable debugging trail.",
+  },
+  {
+    tab: "raw-events",
+    label: "Raw AG-UI Events",
+    title: "Drop into the protocol payloads",
+    body: "Raw events show the exact AG-UI stream behind the timeline when you need to verify ordering or payload shape.",
+  },
+  {
+    tab: "state",
+    label: "State",
+    title: "Check the durable state",
+    body: "The state tab shows the saved values that make a thread resumable across sessions.",
+  },
+];
+
 // ─── JSON syntax highlighter ─────────────────────────────────────────────────
 // Inline-styled so shadow DOM encapsulation preserves colors when the output
 // is injected via unsafeHTML. Only for structured data — never raw user HTML.
@@ -602,6 +844,11 @@ class CpkThreadList extends LitElement {
       color: #57575b;
     }
 
+    .cpk-tl__pill--example {
+      background: rgba(133, 236, 206, 0.22);
+      color: #189370;
+    }
+
     /* ── Empty state ── */
     .cpk-tl__empty {
       padding: 32px 16px;
@@ -697,6 +944,13 @@ class CpkThreadList extends LitElement {
                 </div>
                 <div class="cpk-tl__meta">
                   <span class="cpk-tl__pill">${thread.agentId}</span>
+                  ${
+                    (thread as Partial<ExampleThread>).isExample
+                      ? html`<span class="cpk-tl__pill cpk-tl__pill--example"
+                          >Example</span
+                        >`
+                      : nothing
+                  }
                 </div>
               </div>
             `,
@@ -971,6 +1225,10 @@ export class CpkThreadInspector extends LitElement {
       });
     }
     this.maybeFetchTabData(id);
+  }
+
+  selectTab(id: ThreadDetailsTab): void {
+    this.activateTab(id);
   }
 
   private maybeFetchTabData(id: ThreadDetailsTab): void {
@@ -3937,6 +4195,15 @@ export class WebInspectorElement extends LitElement {
   // don't inflate funnel counts beyond one signal per intent type per banner.
   private clickedBannerIds: Set<string> = new Set();
   private viewedThreadsTelemetryStates: Set<string> = new Set();
+  private viewedExampleThreadIds: Set<string> = new Set();
+  private selectedExampleThreadIds: Set<string> = new Set();
+  private viewedExampleTourSteps: Set<string> = new Set();
+  private exampleThreadProviders: Map<string, ThreadDebuggerProvider> =
+    new Map();
+  private exampleTourDismissed = false;
+  private exampleTourActive = false;
+  private exampleTourStep = 0;
+  private exampleTourAutoShown = false;
 
   get core(): CopilotKitCore | null {
     return this._core;
@@ -4114,6 +4381,7 @@ export class WebInspectorElement extends LitElement {
     if (this._threads.length === 0) return;
     const stillValid =
       this.selectedThreadId != null &&
+      !this.isExampleThreadId(this.selectedThreadId) &&
       this._threads.some((t) => t.id === this.selectedThreadId);
     if (!stillValid) {
       // Threads are sorted most-recently-updated first
@@ -5885,6 +6153,7 @@ ${argsString}</pre
 
       // Load state early (before first render) so menu selection is correct
       this.hydrateStateFromStorageEarly();
+      this.exampleTourDismissed = this.readThreadsExampleTourDismissed();
       this.tryAutoAttachCore();
       this.ensureAnnouncementLoading();
     }
@@ -6188,6 +6457,21 @@ ${argsString}</pre
                   </button>
                 `;
               })}
+              ${
+                this.selectedMenu === "threads"
+                  ? html`
+                      <a
+                        href=${this.getTalkToEngineerUrl()}
+                        target="_blank"
+                        rel="noopener"
+                        style="margin-left:auto;display:inline-flex;align-items:center;gap:6px;border-radius:6px;border:1px solid #dbdbe5;background:#ffffff;padding:7px 10px;font-size:12px;font-weight:600;color:#57575b;text-decoration:none;"
+                        @click=${this.handleTalkToEngineerClick}
+                      >
+                        Talk to an Engineer
+                      </a>
+                    `
+                  : nothing
+              }
             </div>
           </div>
           <div class="flex flex-1 flex-col overflow-hidden">
@@ -7566,6 +7850,421 @@ ${argsString}</pre
     }
   }
 
+  private shouldRenderExampleThreads(
+    displayThreads: ɵThread[],
+    threadsErrorMessage: string | null,
+  ): boolean {
+    return (
+      this.areThreadEndpointsAvailable() &&
+      !threadsErrorMessage &&
+      displayThreads.length === 0
+    );
+  }
+
+  private getVisibleThreads(
+    displayThreads: ɵThread[],
+    threadsErrorMessage: string | null,
+  ): ɵThread[] {
+    return this.shouldRenderExampleThreads(displayThreads, threadsErrorMessage)
+      ? THREADS_EXAMPLE_THREADS
+      : displayThreads;
+  }
+
+  private isExampleThreadId(threadId: string | null | undefined): boolean {
+    return THREADS_EXAMPLE_THREADS.some((thread) => thread.id === threadId);
+  }
+
+  private getExampleThreadProvider(threadId: string): ThreadDebuggerProvider {
+    const cached = this.exampleThreadProviders.get(threadId);
+    if (cached) return cached;
+    const thread = THREADS_EXAMPLE_THREADS.find((item) => item.id === threadId);
+    const details = THREADS_EXAMPLE_DETAILS[threadId];
+    const provider: ThreadDebuggerProvider = {
+      getThreadMetadata: async () =>
+        thread
+          ? {
+              id: thread.id,
+              name: thread.name,
+              agentId: thread.agentId,
+              endUserId: "example-user",
+              status: "completed",
+              updatedAt: thread.updatedAt,
+            }
+          : null,
+      getMessages: async () => details?.messages ?? [],
+      getEvents: async () => details?.events ?? [],
+      getState: async () => details?.state ?? null,
+    };
+    this.exampleThreadProviders.set(threadId, provider);
+    return provider;
+  }
+
+  private trackThreadsExampleViewedOnce(): void {
+    if (this.core?.telemetryDisabled) return;
+    for (const thread of THREADS_EXAMPLE_THREADS) {
+      if (this.viewedExampleThreadIds.has(thread.id)) continue;
+      this.viewedExampleThreadIds.add(thread.id);
+      trackThreadsExampleViewed(
+        this.getThreadsTelemetryProps({
+          example_thread_id: thread.id,
+          thread_count: 0,
+        }),
+      );
+    }
+  }
+
+  private trackThreadsExampleSelectedOnce(threadId: string): void {
+    if (this.core?.telemetryDisabled) return;
+    if (this.selectedExampleThreadIds.has(threadId)) return;
+    this.selectedExampleThreadIds.add(threadId);
+    trackThreadsExampleSelected(
+      this.getThreadsTelemetryProps({
+        example_thread_id: threadId,
+        thread_count: 0,
+      }),
+    );
+  }
+
+  private getCurrentExampleTourProps(): InspectorThreadTelemetryProps {
+    const step =
+      THREADS_EXAMPLE_TOUR_STEPS[this.exampleTourStep] ??
+      THREADS_EXAMPLE_TOUR_STEPS[0]!;
+    return this.getThreadsTelemetryProps({
+      example_thread_id: this.selectedThreadId ?? undefined,
+      thread_count: 0,
+      tour_step: this.exampleTourStep + 1,
+      tour_tab: step?.tab,
+    });
+  }
+
+  private trackThreadsExampleTourStepViewedOnce(): void {
+    if (this.core?.telemetryDisabled || !this.selectedThreadId) return;
+    const step =
+      THREADS_EXAMPLE_TOUR_STEPS[this.exampleTourStep] ??
+      THREADS_EXAMPLE_TOUR_STEPS[0]!;
+    if (!step) return;
+    const key = `${this.selectedThreadId}:${this.exampleTourStep}`;
+    if (this.viewedExampleTourSteps.has(key)) return;
+    this.viewedExampleTourSteps.add(key);
+    trackThreadsExampleTourStepViewed(this.getCurrentExampleTourProps());
+  }
+
+  private syncExampleTourTab(): void {
+    const step =
+      THREADS_EXAMPLE_TOUR_STEPS[this.exampleTourStep] ??
+      THREADS_EXAMPLE_TOUR_STEPS[0]!;
+    if (!step) return;
+    void this.updateComplete.then(() => {
+      const details = this.shadowRoot?.querySelector("cpk-thread-details") as
+        | (ɵCpkThreadDetails & { selectTab?: (id: ThreadDetailsTab) => void })
+        | null;
+      details?.selectTab?.(step.tab);
+    });
+  }
+
+  private startExampleTour(autoStarted: boolean): void {
+    if (!this.selectedThreadId) return;
+    this.exampleTourActive = true;
+    this.exampleTourStep = 0;
+    if (autoStarted) {
+      this.exampleTourAutoShown = true;
+      if (!this.core?.telemetryDisabled) {
+        trackThreadsExampleTourStarted(this.getCurrentExampleTourProps());
+      }
+    } else if (!this.core?.telemetryDisabled) {
+      trackThreadsExampleTourReopened(this.getCurrentExampleTourProps());
+    }
+    this.trackThreadsExampleTourStepViewedOnce();
+    this.syncExampleTourTab();
+    this.requestUpdate();
+  }
+
+  private setExampleTourStep(nextStep: number): void {
+    this.exampleTourStep = Math.max(
+      0,
+      Math.min(THREADS_EXAMPLE_TOUR_STEPS.length - 1, nextStep),
+    );
+    this.trackThreadsExampleTourStepViewedOnce();
+    this.syncExampleTourTab();
+    this.requestUpdate();
+  }
+
+  private dismissExampleTour(method: "skip" | "done"): void {
+    if (!this.selectedThreadId) return;
+    const props = this.getThreadsTelemetryProps({
+      ...this.getCurrentExampleTourProps(),
+      dismiss_method: method,
+    });
+    this.exampleTourActive = false;
+    this.exampleTourDismissed = true;
+    this.writeThreadsExampleTourDismissed();
+    if (!this.core?.telemetryDisabled) {
+      if (method === "done") {
+        trackThreadsExampleTourCompleted(props);
+      } else {
+        trackThreadsExampleTourDismissed(props);
+      }
+    }
+    this.requestUpdate();
+  }
+
+  private handleThreadsThreadSelected(
+    threadId: string,
+    showingExamples: boolean,
+  ): void {
+    if (showingExamples && this.selectedThreadId === threadId) {
+      this.selectedThreadId = null;
+      this.exampleTourActive = false;
+      this.requestUpdate();
+      return;
+    }
+
+    this.selectedThreadId = threadId;
+    if (showingExamples && this.isExampleThreadId(threadId)) {
+      this.trackThreadsExampleSelectedOnce(threadId);
+      if (!this.exampleTourDismissed && !this.exampleTourAutoShown) {
+        this.startExampleTour(true);
+      } else {
+        this.exampleTourActive = false;
+      }
+    } else {
+      this.exampleTourActive = false;
+    }
+    this.requestUpdate();
+  }
+
+  private readThreadsExampleTourDismissed(): boolean {
+    if (typeof window === "undefined") return false;
+    try {
+      const raw = window.localStorage.getItem(THREADS_EXAMPLE_TOUR_STORAGE_KEY);
+      if (!raw) return false;
+      const value = JSON.parse(raw) as { dismissed?: unknown };
+      return value.dismissed === true;
+    } catch {
+      return false;
+    }
+  }
+
+  private writeThreadsExampleTourDismissed(): void {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(
+        THREADS_EXAMPLE_TOUR_STORAGE_KEY,
+        JSON.stringify({ dismissed: true }),
+      );
+    } catch {
+      // Persistence is best-effort; the inspector should keep working without it.
+    }
+  }
+
+  private renderThreadsExampleOverview() {
+    return html`
+      <div
+        style="
+          flex: 1;
+          min-width: 0;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 32px;
+          background: #f7f7f9;
+        "
+      >
+        <div style="max-width: 440px; color: #57575b;">
+          <h2
+            style="
+              margin: 0 0 10px;
+              font-size: 20px;
+              line-height: 1.25;
+              font-weight: 600;
+              color: #010507;
+            "
+          >
+            Threads are persistent, inspectable conversations
+          </h2>
+          <p
+            style="
+              margin: 0 0 16px;
+              font-size: 13px;
+              line-height: 1.55;
+              color: #57575b;
+            "
+          >
+            Take a tour with the example threads in the sidebar. Then, start
+            chatting in your app to create the first real thread.
+          </p>
+          <div style="display:flex;flex-wrap:wrap;gap:8px;">
+            <a
+              href=${THREADS_DOCS_URL}
+              target="_blank"
+              rel="noopener"
+              style="
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                gap: 6px;
+                min-height: 34px;
+                border-radius: 6px;
+                background: #010507;
+                padding: 8px 12px;
+                font-size: 12px;
+                font-weight: 600;
+                color: #ffffff;
+                text-decoration: none;
+              "
+            >
+              Learn how Threads work
+            </a>
+            <a
+              href=${SELF_HOSTED_INTELLIGENCE_URL}
+              target="_blank"
+              rel="noopener"
+              style="
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                gap: 6px;
+                min-height: 34px;
+                border-radius: 6px;
+                border: 1px solid #dbdbe5;
+                background: #ffffff;
+                padding: 8px 12px;
+                font-size: 12px;
+                font-weight: 600;
+                color: #010507;
+                text-decoration: none;
+              "
+            >
+              Explore self-hosted Intelligence
+            </a>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderThreadsExampleTour() {
+    if (!this.selectedThreadId || !this.isExampleThreadId(this.selectedThreadId)) {
+      return nothing;
+    }
+
+    if (!this.exampleTourActive) {
+      return html`
+        <button
+          type="button"
+          style="
+            position: absolute;
+            right: 16px;
+            bottom: 16px;
+            z-index: 2;
+            border: 1px solid #dbdbe5;
+            border-radius: 6px;
+            background: #ffffff;
+            padding: 7px 10px;
+            color: #57575b;
+            font-size: 12px;
+            font-weight: 600;
+            cursor: pointer;
+            box-shadow: 0 8px 18px rgba(1, 5, 7, 0.08);
+          "
+          @click=${() => this.startExampleTour(false)}
+        >
+          Show tour
+        </button>
+      `;
+    }
+
+    const step =
+      THREADS_EXAMPLE_TOUR_STEPS[this.exampleTourStep] ??
+      THREADS_EXAMPLE_TOUR_STEPS[0]!;
+    const isFirst = this.exampleTourStep === 0;
+    const isLast = this.exampleTourStep === THREADS_EXAMPLE_TOUR_STEPS.length - 1;
+
+    return html`
+      <div
+        role="dialog"
+        aria-label="Example thread tour"
+        style="
+          position: absolute;
+          right: 16px;
+          bottom: 16px;
+          z-index: 3;
+          width: min(340px, calc(100% - 32px));
+          border: 1px solid #dbdbe5;
+          border-radius: 8px;
+          background: #ffffff;
+          padding: 14px;
+          box-shadow: 0 16px 36px rgba(1, 5, 7, 0.14);
+          color: #57575b;
+        "
+      >
+        <div
+          style="
+            margin-bottom: 8px;
+            font-family: 'Spline Sans Mono', monospace;
+            font-size: 10px;
+            font-weight: 600;
+            color: #189370;
+            text-transform: uppercase;
+          "
+        >
+          ${this.exampleTourStep + 1}/${THREADS_EXAMPLE_TOUR_STEPS.length}
+          ${step.label}
+        </div>
+        <div
+          style="
+            margin-bottom: 6px;
+            font-size: 14px;
+            line-height: 1.35;
+            font-weight: 600;
+            color: #010507;
+          "
+        >
+          ${step.title}
+        </div>
+        <div style="font-size: 12px; line-height: 1.5; color: #57575b;">
+          ${step.body}
+        </div>
+        <div
+          style="
+            display: flex;
+            justify-content: space-between;
+            gap: 8px;
+            margin-top: 14px;
+          "
+        >
+          <button
+            type="button"
+            style="border:0;background:transparent;color:#838389;font-size:12px;font-weight:600;cursor:pointer;padding:7px 0;"
+            @click=${() => this.dismissExampleTour("skip")}
+          >
+            Skip
+          </button>
+          <div style="display:flex;gap:8px;">
+            <button
+              type="button"
+              style="border:1px solid #dbdbe5;border-radius:6px;background:#ffffff;color:#57575b;font-size:12px;font-weight:600;cursor:pointer;padding:7px 10px;"
+              ?disabled=${isFirst}
+              @click=${() => this.setExampleTourStep(this.exampleTourStep - 1)}
+            >
+              Back
+            </button>
+            <button
+              type="button"
+              style="border:1px solid #010507;border-radius:6px;background:#010507;color:#ffffff;font-size:12px;font-weight:600;cursor:pointer;padding:7px 10px;"
+              @click=${() =>
+                isLast
+                  ? this.dismissExampleTour("done")
+                  : this.setExampleTourStep(this.exampleTourStep + 1)}
+            >
+              ${isLast ? "Done" : "Next"}
+            </button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
   private renderThreadsLockedBackgroundMockup() {
     const threadRows = [
       { width: 74, accent: true },
@@ -7812,28 +8511,6 @@ ${argsString}</pre
               gap: 8px;
             "
           >
-            <a
-              href=${this.getTalkToEngineerUrl()}
-              target="_blank"
-              rel="noopener"
-              style="
-                display: inline-flex;
-                min-height: 34px;
-                align-items: center;
-                justify-content: center;
-                gap: 6px;
-                border-radius: 6px;
-                background: #010507;
-                padding: 8px 12px;
-                font-size: 12px;
-                font-weight: 600;
-                color: #ffffff;
-                text-decoration: none;
-              "
-              @click=${this.handleThreadsTalkToEngineerClick}
-            >
-              Talk to an Engineer
-            </a>
             <a
               href=${this.getIntelligenceSignupUrl()}
               target="_blank"
@@ -8226,10 +8903,23 @@ ${argsString}</pre
         this._threadsErrorByAgent.get(this.selectedContext)?.message ?? null;
     }
 
+    const showingExamples = this.shouldRenderExampleThreads(
+      displayThreads,
+      threadsErrorMessage,
+    );
+    const visibleThreads = this.getVisibleThreads(
+      displayThreads,
+      threadsErrorMessage,
+    );
+    if (showingExamples) {
+      this.trackThreadsExampleViewedOnce();
+    }
+
     const selectedThread =
       this.selectedThreadId != null
-        ? (displayThreads.find((t) => t.id === this.selectedThreadId) ?? null)
+        ? (visibleThreads.find((t) => t.id === this.selectedThreadId) ?? null)
         : null;
+    const selectedThreadIsExample = this.isExampleThreadId(selectedThread?.id);
 
     if (!threadsErrorMessage) {
       this.trackThreadsViewStateOnce(
@@ -8240,19 +8930,6 @@ ${argsString}</pre
 
     return html`
       <div style="display:flex;height:100%;overflow:hidden;flex-direction:column;">
-        <div
-          style="display:flex;align-items:center;justify-content:flex-end;border-bottom:1px solid #DBDBE5;background:#ffffff;padding:8px 12px;flex-shrink:0;"
-        >
-          <a
-            href=${this.getTalkToEngineerUrl()}
-            target="_blank"
-            rel="noopener"
-            style="display:inline-flex;align-items:center;gap:6px;border-radius:6px;border:1px solid #dbdbe5;background:#ffffff;padding:7px 10px;font-size:12px;font-weight:600;color:#57575b;text-decoration:none;"
-            @click=${this.handleTalkToEngineerClick}
-          >
-            Talk to an Engineer
-          </a>
-        </div>
         <div style="display:flex;min-height:0;flex:1;overflow:hidden;">
           <!-- Left sidebar: thread list -->
           <div
@@ -8260,12 +8937,11 @@ ${argsString}</pre
           >
             <cpk-thread-list
               style="height:100%;"
-              .threads=${displayThreads}
+              .threads=${visibleThreads}
               .selectedThreadId=${this.selectedThreadId}
               .errorMessage=${threadsErrorMessage}
               @threadSelected=${(e: CustomEvent<string>) => {
-                this.selectedThreadId = e.detail;
-                this.requestUpdate();
+                this.handleThreadsThreadSelected(e.detail, showingExamples);
               }}
             ></cpk-thread-list>
           </div>
@@ -8280,16 +8956,22 @@ ${argsString}</pre
           ></div>
 
           <!-- Center + right: thread details or empty state -->
-          <div style="flex:1;min-width:0;overflow:hidden;display:flex;">
+          <div style="flex:1;min-width:0;overflow:hidden;display:flex;position:relative;">
             ${
               selectedThread
                 ? html`<cpk-thread-details
                     style="flex:1;min-width:0;"
                     .threadId=${selectedThread.id}
                     .thread=${selectedThread}
+                    .provider=${
+                      selectedThreadIsExample
+                        ? this.getExampleThreadProvider(selectedThread.id)
+                        : null
+                    }
                     .runtimeUrl=${this._core?.runtimeUrl ?? ""}
                     .headers=${this._core?.headers ?? {}}
                     .threadInspectionAvailable=${
+                      selectedThreadIsExample ||
                       this._core?.threadEndpoints?.inspect !== false
                     }
                     .liveMessageVersion=${
@@ -8301,7 +8983,10 @@ ${argsString}</pre
                     .agentEventsInput=${
                       this.agentEvents.get(selectedThread.agentId) ?? []
                     }
-                  ></cpk-thread-details>`
+                  ></cpk-thread-details>
+                  ${selectedThreadIsExample ? this.renderThreadsExampleTour() : nothing}`
+                : showingExamples
+                  ? this.renderThreadsExampleOverview()
                 : html`
                     <div
                       style="

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -4345,7 +4345,8 @@ export class WebInspectorElement extends LitElement {
       return false;
     }
 
-    const { displayThreads, threadsErrorMessage } = this.getActiveThreadsState();
+    const { displayThreads, threadsErrorMessage } =
+      this.getActiveThreadsState();
     return !threadsErrorMessage && displayThreads.length === 0;
   }
 

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -119,6 +119,8 @@ const DOCKED_LEFT_WIDTH = 500; // Sensible width for left dock with collapsed si
 const MAX_AGENT_EVENTS = 200;
 const MAX_TOTAL_EVENTS = 500;
 const INTELLIGENCE_SIGNUP_URL = "https://go.copilotkit.ai/intelligence-signup";
+const THREADS_INTELLIGENCE_SIGNIN_URL =
+  "https://dashboard.operations.copilotkit.ai/sign-in";
 const TALK_TO_ENGINEER_URL = "https://www.copilotkit.ai/talk-to-an-engineer";
 const THREADS_DOCS_URL = "https://docs.copilotkit.ai/threads";
 const SELF_HOSTED_INTELLIGENCE_URL =
@@ -4377,7 +4379,7 @@ export class WebInspectorElement extends LitElement {
 
   private getThreadsIntelligenceSignupUrl(): string {
     return this.appendThreadsOnboardingAttribution(
-      INTELLIGENCE_SIGNUP_URL,
+      THREADS_INTELLIGENCE_SIGNIN_URL,
       "cpk-inspector",
     );
   }

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -124,7 +124,7 @@ const THREADS_DOCS_URL = "https://docs.copilotkit.ai/threads";
 const SELF_HOSTED_INTELLIGENCE_URL =
   "https://docs.copilotkit.ai/premium/self-hosting";
 const THREADS_EXAMPLE_OVERVIEW_VIDEO_URL =
-  "https://www.copilotkit.ai/videos/copilotkit-generative-ui-agentic-frontend-demo.webm";
+  "https://cdn.copilotkit.ai/corp-site/videos/copilotkit-generative-ui-agentic-frontend-demo.webm";
 const THREADS_EXAMPLE_TOUR_STORAGE_KEY =
   "cpk:inspector:threads-example-tour:v1";
 const THREADS_EXAMPLE_AGENT_ID = "threads-feature";

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -6273,7 +6273,7 @@ ${argsString}</pre
       this.transitionTimeoutId = null;
     }
     if (this.threadsExampleOverviewVideoLoadTimer !== null) {
-      clearTimeout(this.threadsExampleOverviewVideoLoadTimer);
+      window.clearTimeout(this.threadsExampleOverviewVideoLoadTimer);
       this.threadsExampleOverviewVideoLoadTimer = null;
     }
     if (
@@ -8086,10 +8086,10 @@ ${argsString}</pre
 
   private dismissExampleTour(method: "skip" | "done"): void {
     if (!this.selectedThreadId) return;
-    const props = this.getThreadsTelemetryProps({
+    const props = {
       ...this.getCurrentExampleTourProps(),
       dismiss_method: method,
-    });
+    };
     this.exampleTourActive = false;
     this.exampleTourDismissed = true;
     this.writeThreadsExampleTourDismissed();
@@ -9049,23 +9049,8 @@ ${argsString}</pre
       return this.renderThreadsLockedView();
     }
 
-    const displayThreads =
-      this.selectedContext === "all-agents"
-        ? this._threads
-        : (this._threadsByAgent.get(this.selectedContext) ?? []);
-
-    // Surface a thread-store load error inline. For "all-agents" we report
-    // the first error encountered across all agents (good enough for a
-    // debugging surface — the per-agent context filter narrows down the
-    // culprit). For a specific agent we use that agent's error directly.
-    let threadsErrorMessage: string | null = null;
-    if (this.selectedContext === "all-agents") {
-      const firstError = this._threadsErrorByAgent.values().next().value;
-      threadsErrorMessage = firstError?.message ?? null;
-    } else {
-      threadsErrorMessage =
-        this._threadsErrorByAgent.get(this.selectedContext)?.message ?? null;
-    }
+    const { displayThreads, threadsErrorMessage } =
+      this.getActiveThreadsState();
 
     const showingExamples = this.shouldRenderExampleThreads(
       displayThreads,

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -130,11 +130,6 @@ const THREADS_EXAMPLE_OVERVIEW_VIDEO_URL =
 const THREADS_EXAMPLE_TOUR_STORAGE_KEY =
   "cpk:inspector:threads-example-tour:v1";
 const THREADS_EXAMPLE_AGENT_ID = "threads-feature";
-const INSPECTOR_UTM_PARAMS = {
-  utm_source: "copilotkit_inspector",
-  utm_medium: "in_product",
-  utm_campaign: "threads_onboarding",
-} as const;
 
 type ThreadServiceStatus = "available" | "unavailable" | "unknown" | "error";
 
@@ -4378,7 +4373,7 @@ export class WebInspectorElement extends LitElement {
   }
 
   private getThreadsIntelligenceSignupUrl(): string {
-    return this.appendThreadsOnboardingAttribution(
+    return this.appendRefParam(
       THREADS_INTELLIGENCE_SIGNIN_URL,
       "cpk-inspector",
     );
@@ -4389,21 +4384,21 @@ export class WebInspectorElement extends LitElement {
   }
 
   private getThreadsTalkToEngineerUrl(): string {
-    return this.appendThreadsOnboardingAttribution(
+    return this.appendRefParam(
       TALK_TO_ENGINEER_URL,
       "cpk-inspector-threads",
     );
   }
 
   private getThreadsDocsUrl(): string {
-    return this.appendThreadsOnboardingAttribution(
+    return this.appendRefParam(
       THREADS_DOCS_URL,
       "cpk-inspector-threads",
     );
   }
 
   private getSelfHostedIntelligenceUrl(): string {
-    return this.appendThreadsOnboardingAttribution(
+    return this.appendRefParam(
       SELF_HOSTED_INTELLIGENCE_URL,
       "cpk-inspector-threads",
     );
@@ -11040,18 +11035,7 @@ ${prettyEvent}</pre
     }
   };
 
-  private appendThreadsOnboardingAttribution(
-    href: string,
-    ref = "cpk-inspector-threads",
-  ): string {
-    return this.appendRefParam(href, ref, INSPECTOR_UTM_PARAMS);
-  }
-
-  private appendRefParam(
-    href: string,
-    ref = "cpk-inspector",
-    utmParams?: Readonly<Record<string, string>>,
-  ): string {
+  private appendRefParam(href: string, ref = "cpk-inspector"): string {
     try {
       const isRootRelative = href.startsWith("/") && !href.startsWith("//");
       const url = new URL(
@@ -11062,13 +11046,6 @@ ${prettyEvent}</pre
       );
       if (!url.searchParams.has("ref")) {
         url.searchParams.append("ref", ref);
-      }
-      if (utmParams) {
-        for (const [key, value] of Object.entries(utmParams)) {
-          if (!url.searchParams.has(key)) {
-            url.searchParams.append(key, value);
-          }
-        }
       }
       // Propagate the inspector's anonymous distinct-ID so the website /
       // Ops API can call posthog.alias(...) on signup-flow landing and

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -4329,27 +4329,6 @@ export class WebInspectorElement extends LitElement {
     return { displayThreads, threadsErrorMessage };
   }
 
-  private shouldShowThreadsNavGlimmer(key: MenuKey): boolean {
-    if (key !== "threads" || this.selectedMenu === "threads") {
-      return false;
-    }
-    if (this.core?.telemetryDisabled) {
-      return false;
-    }
-
-    const threadServiceStatus = this.getThreadServiceStatus();
-    if (threadServiceStatus === "unavailable") {
-      return true;
-    }
-    if (threadServiceStatus !== "available") {
-      return false;
-    }
-
-    const { displayThreads, threadsErrorMessage } =
-      this.getActiveThreadsState();
-    return !threadsErrorMessage && displayThreads.length === 0;
-  }
-
   private getThreadsTelemetryProps(
     extra: Partial<InspectorThreadTelemetryProps> = {},
     options: { includeUrlAttribution?: boolean } = {},
@@ -6023,50 +6002,6 @@ ${argsString}</pre
       .cpk-tab-active {
         cursor: pointer;
       }
-      @keyframes cpkThreadsNavGlimmer {
-        0% {
-          background-position: 160% 50%;
-        }
-        48%,
-        100% {
-          background-position: -60% 50%;
-        }
-      }
-      @keyframes cpkThreadsNavPulse {
-        0%,
-        100% {
-          box-shadow:
-            inset 0 0 0 1px rgba(190, 194, 255, 0.28),
-            0 0 0 rgba(190, 194, 255, 0);
-        }
-        50% {
-          box-shadow:
-            inset 0 0 0 1px rgba(190, 194, 255, 0.42),
-            0 0 16px rgba(190, 194, 255, 0.22);
-        }
-      }
-      .cpk-tab-threads-glimmer {
-        overflow: hidden;
-        background-image: linear-gradient(
-          112deg,
-          rgba(190, 194, 255, 0.14) 0%,
-          rgba(190, 194, 255, 0.18) 34%,
-          rgba(255, 255, 255, 0.78) 45%,
-          rgba(133, 236, 206, 0.16) 54%,
-          rgba(190, 194, 255, 0.14) 70%
-        );
-        background-size: 240% 100%;
-        animation:
-          cpkThreadsNavGlimmer 3.2s ease-in-out infinite,
-          cpkThreadsNavPulse 4.6s ease-in-out infinite;
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .cpk-tab-threads-glimmer {
-          animation: none;
-          background-position: 50% 50%;
-        }
-      }
-
       .cpk-threads-overview-video-frame {
         position: relative;
         display: block;
@@ -6573,9 +6508,6 @@ ${argsString}</pre
                 const tabClasses = [
                   "inline-flex items-center gap-2 rounded-md px-3 py-2 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-300",
                   isSelected ? "cpk-tab-active" : "cpk-tab-inactive",
-                  this.shouldShowThreadsNavGlimmer(key)
-                    ? "cpk-tab-threads-glimmer"
-                    : "",
                 ].join(" ");
 
                 return html`

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -128,6 +128,11 @@ const THREADS_EXAMPLE_OVERVIEW_VIDEO_URL =
 const THREADS_EXAMPLE_TOUR_STORAGE_KEY =
   "cpk:inspector:threads-example-tour:v1";
 const THREADS_EXAMPLE_AGENT_ID = "threads-feature";
+const INSPECTOR_UTM_PARAMS = {
+  utm_source: "copilotkit_inspector",
+  utm_medium: "in_product",
+  utm_campaign: "threads_onboarding",
+} as const;
 
 type ThreadServiceStatus = "available" | "unavailable" | "unknown" | "error";
 
@@ -4367,11 +4372,31 @@ export class WebInspectorElement extends LitElement {
   }
 
   private getIntelligenceSignupUrl(): string {
-    return this.appendRefParam(INTELLIGENCE_SIGNUP_URL, "cpk-inspector");
+    return this.appendThreadsOnboardingAttribution(
+      INTELLIGENCE_SIGNUP_URL,
+      "cpk-inspector",
+    );
   }
 
   private getTalkToEngineerUrl(): string {
-    return this.appendRefParam(TALK_TO_ENGINEER_URL, "cpk-inspector-threads");
+    return this.appendThreadsOnboardingAttribution(
+      TALK_TO_ENGINEER_URL,
+      "cpk-inspector-threads",
+    );
+  }
+
+  private getThreadsDocsUrl(): string {
+    return this.appendThreadsOnboardingAttribution(
+      THREADS_DOCS_URL,
+      "cpk-inspector-threads",
+    );
+  }
+
+  private getSelfHostedIntelligenceUrl(): string {
+    return this.appendThreadsOnboardingAttribution(
+      SELF_HOSTED_INTELLIGENCE_URL,
+      "cpk-inspector-threads",
+    );
   }
 
   private subscribeToThreadStore(agentId: string, store: ɵThreadStore): void {
@@ -8231,7 +8256,7 @@ ${argsString}</pre
           </p>
           <div style="display:flex;flex-wrap:wrap;gap:8px;">
             <a
-              href=${THREADS_DOCS_URL}
+              href=${this.getThreadsDocsUrl()}
               target="_blank"
               rel="noopener"
               style="
@@ -8252,7 +8277,7 @@ ${argsString}</pre
               Learn how Threads work
             </a>
             <a
-              href=${SELF_HOSTED_INTELLIGENCE_URL}
+              href=${this.getSelfHostedIntelligenceUrl()}
               target="_blank"
               rel="noopener"
               style="
@@ -11005,7 +11030,18 @@ ${prettyEvent}</pre
     }
   };
 
-  private appendRefParam(href: string, ref = "cpk-inspector"): string {
+  private appendThreadsOnboardingAttribution(
+    href: string,
+    ref = "cpk-inspector-threads",
+  ): string {
+    return this.appendRefParam(href, ref, INSPECTOR_UTM_PARAMS);
+  }
+
+  private appendRefParam(
+    href: string,
+    ref = "cpk-inspector",
+    utmParams?: Readonly<Record<string, string>>,
+  ): string {
     try {
       const isRootRelative = href.startsWith("/") && !href.startsWith("//");
       const url = new URL(
@@ -11016,6 +11052,13 @@ ${prettyEvent}</pre
       );
       if (!url.searchParams.has("ref")) {
         url.searchParams.append("ref", ref);
+      }
+      if (utmParams) {
+        for (const [key, value] of Object.entries(utmParams)) {
+          if (!url.searchParams.has(key)) {
+            url.searchParams.append(key, value);
+          }
+        }
       }
       // Propagate the inspector's anonymous distinct-ID so the website /
       // Ops API can call posthog.alias(...) on signup-flow landing and

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -4372,6 +4372,10 @@ export class WebInspectorElement extends LitElement {
   }
 
   private getIntelligenceSignupUrl(): string {
+    return this.appendRefParam(INTELLIGENCE_SIGNUP_URL, "cpk-inspector");
+  }
+
+  private getThreadsIntelligenceSignupUrl(): string {
     return this.appendThreadsOnboardingAttribution(
       INTELLIGENCE_SIGNUP_URL,
       "cpk-inspector",
@@ -4379,6 +4383,10 @@ export class WebInspectorElement extends LitElement {
   }
 
   private getTalkToEngineerUrl(): string {
+    return this.appendRefParam(TALK_TO_ENGINEER_URL, "cpk-inspector-threads");
+  }
+
+  private getThreadsTalkToEngineerUrl(): string {
     return this.appendThreadsOnboardingAttribution(
       TALK_TO_ENGINEER_URL,
       "cpk-inspector-threads",
@@ -6557,7 +6565,7 @@ ${argsString}</pre
                 this.selectedMenu === "threads"
                   ? html`
                       <a
-                        href=${this.getTalkToEngineerUrl()}
+                        href=${this.getThreadsTalkToEngineerUrl()}
                         target="_blank"
                         rel="noopener"
                         style="margin-left:auto;display:inline-flex;align-items:center;gap:6px;border-radius:6px;border:1px solid #dbdbe5;background:#ffffff;padding:7px 10px;font-size:12px;font-weight:600;color:#57575b;text-decoration:none;"
@@ -8677,7 +8685,7 @@ ${argsString}</pre
             "
           >
             <a
-              href=${this.getIntelligenceSignupUrl()}
+              href=${this.getThreadsIntelligenceSignupUrl()}
               target="_blank"
               rel="noopener"
               style="

--- a/packages/web-inspector/src/lib/telemetry.ts
+++ b/packages/web-inspector/src/lib/telemetry.ts
@@ -38,6 +38,14 @@ export const TELEMETRY_EVENTS = {
   talkToEngineerClicked: "oss.inspector.talk_to_engineer_clicked",
   threadsEmptyEnabledViewed: "oss.inspector.threads_empty_enabled_viewed",
   threadsEnabledViewed: "oss.inspector.threads_enabled_viewed",
+  threadsExampleViewed: "oss.inspector.threads_example_viewed",
+  threadsExampleSelected: "oss.inspector.threads_example_selected",
+  threadsExampleTourStarted: "oss.inspector.threads_example_tour_started",
+  threadsExampleTourStepViewed:
+    "oss.inspector.threads_example_tour_step_viewed",
+  threadsExampleTourDismissed: "oss.inspector.threads_example_tour_dismissed",
+  threadsExampleTourCompleted: "oss.inspector.threads_example_tour_completed",
+  threadsExampleTourReopened: "oss.inspector.threads_example_tour_reopened",
   memoriesTabClicked: "oss.inspector.memories_tab_clicked",
 } as const;
 
@@ -70,6 +78,13 @@ function isThreadsTelemetryEvent(event: TelemetryEvent): boolean {
     event === TELEMETRY_EVENTS.talkToEngineerClicked ||
     event === TELEMETRY_EVENTS.threadsEmptyEnabledViewed ||
     event === TELEMETRY_EVENTS.threadsEnabledViewed ||
+    event === TELEMETRY_EVENTS.threadsExampleViewed ||
+    event === TELEMETRY_EVENTS.threadsExampleSelected ||
+    event === TELEMETRY_EVENTS.threadsExampleTourStarted ||
+    event === TELEMETRY_EVENTS.threadsExampleTourStepViewed ||
+    event === TELEMETRY_EVENTS.threadsExampleTourDismissed ||
+    event === TELEMETRY_EVENTS.threadsExampleTourCompleted ||
+    event === TELEMETRY_EVENTS.threadsExampleTourReopened ||
     event === TELEMETRY_EVENTS.memoriesTabClicked
   );
 }
@@ -203,6 +218,10 @@ export type InspectorThreadTelemetryProps = {
   cta?: "signup" | "talk_to_engineer";
   telemetry_disabled?: boolean;
   thread_count?: number;
+  example_thread_id?: string;
+  tour_step?: number;
+  tour_tab?: "timeline" | "raw-events" | "state";
+  dismiss_method?: "skip" | "done";
 };
 
 export function trackThreadsTabClicked(
@@ -245,6 +264,48 @@ export function trackThreadsEnabledViewed(
   props: InspectorThreadTelemetryProps,
 ): void {
   track(TELEMETRY_EVENTS.threadsEnabledViewed, props);
+}
+
+export function trackThreadsExampleViewed(
+  props: InspectorThreadTelemetryProps,
+): void {
+  track(TELEMETRY_EVENTS.threadsExampleViewed, props);
+}
+
+export function trackThreadsExampleSelected(
+  props: InspectorThreadTelemetryProps,
+): void {
+  track(TELEMETRY_EVENTS.threadsExampleSelected, props);
+}
+
+export function trackThreadsExampleTourStarted(
+  props: InspectorThreadTelemetryProps,
+): void {
+  track(TELEMETRY_EVENTS.threadsExampleTourStarted, props);
+}
+
+export function trackThreadsExampleTourStepViewed(
+  props: InspectorThreadTelemetryProps,
+): void {
+  track(TELEMETRY_EVENTS.threadsExampleTourStepViewed, props);
+}
+
+export function trackThreadsExampleTourDismissed(
+  props: InspectorThreadTelemetryProps,
+): void {
+  track(TELEMETRY_EVENTS.threadsExampleTourDismissed, props);
+}
+
+export function trackThreadsExampleTourCompleted(
+  props: InspectorThreadTelemetryProps,
+): void {
+  track(TELEMETRY_EVENTS.threadsExampleTourCompleted, props);
+}
+
+export function trackThreadsExampleTourReopened(
+  props: InspectorThreadTelemetryProps,
+): void {
+  track(TELEMETRY_EVENTS.threadsExampleTourReopened, props);
 }
 
 export type InspectorMemoryTelemetryProps = {


### PR DESCRIPTION
## Summary

Adds production onboarding for the Inspector Threads empty state:

- Moves the Threads `Talk to an Engineer` CTA into the main inspector tab nav when Threads is active.
- Replaces the enabled-empty `No threads yet` state with example thread rows and a deselected overview.
- Lets users select an example thread to preview the real thread-details UI with Timeline, Raw AG-UI Events, and State data.
- Adds a dismissible/reopenable example tour that persists dismissal in local storage.
- Hides examples once real threads are present.
- Adds the `Learn how Threads work` and `Explore self-hosted Intelligence` CTAs.
- Adds a deferred autoplay video preview to the enabled-empty deselected overview.

## Telemetry

New/updated Threads events in this PR:

- `oss.inspector.threads_tab_clicked` — fires when the rendered Threads nav tab is clicked.
- `oss.inspector.threads_locked_viewed` — fires once per inspector instance for the locked state.
- `oss.inspector.threads_empty_enabled_viewed` — fires once per inspector instance when Threads are enabled with zero real threads.
- `oss.inspector.threads_enabled_viewed` — fires once per inspector instance when real threads are present.
- `oss.inspector.threads_intelligence_signup_clicked` — fires from locked-state Intelligence signup CTAs.
- `oss.inspector.threads_talk_to_engineer_clicked` / `oss.inspector.talk_to_engineer_clicked` — fire from Threads-specific and shared Talk to an Engineer CTAs.
- `oss.inspector.threads_example_viewed` — fires once per example thread shown in the empty state.
- `oss.inspector.threads_example_selected` — fires once per example thread selection.
- `oss.inspector.threads_example_tour_started` — fires when the tour auto-starts for the first selected example.
- `oss.inspector.threads_example_tour_step_viewed` — fires once per example thread/tour step.
- `oss.inspector.threads_example_tour_dismissed` — fires when the user skips the tour.
- `oss.inspector.threads_example_tour_completed` — fires when the user finishes the tour.
- `oss.inspector.threads_example_tour_reopened` — fires when the user clicks `Show tour` after dismissal.

Telemetry properties are limited to product metadata and funnel context: package/version, inspector distinct IDs, intelligence/thread-service/license/runtime status, runtime URL type, CTA surface/type, telemetry-disabled status, thread count, example thread ID, tour step/tab, and dismiss method. We do **not** send message content, AG-UI event payloads, agent state, prompts, completions, or thread bodies.

No telemetry was added for passive video loading; it is a visual affordance rather than a user intent signal.

## Outbound Attribution

Threads onboarding CTAs now include existing `ref` attribution plus these UTM parameters:

- `utm_source=copilotkit_inspector`
- `utm_medium=in_product`
- `utm_campaign=threads_onboarding`

Affected links are limited to Threads onboarding surfaces:

- Threads tab-nav `Talk to an Engineer`
- Threads locked-state `Sign up for Intelligence` (`https://dashboard.operations.copilotkit.ai/sign-in`)
- Empty Threads overview `Learn how Threads work`
- Empty Threads overview `Explore self-hosted Intelligence`

The UTM params are opt-in for these Threads onboarding CTAs and do not apply to generic announcement/banner links or locked Memories CTAs. The inspector spec includes a regression test to keep locked Memories CTAs free of the Threads campaign params.

## Video Asset + Performance

- The overview video uses the CDN-hosted asset at `https://cdn.copilotkit.ai/corp-site/videos/copilotkit-generative-ui-agentic-frontend-demo.webm` instead of committing a binary to `@copilotkit/web-inspector`.
- Verified the URL serves `200`, `Content-Type: video/webm`, `Content-Length: 6765736`, and a CloudFront cache hit.
- `@copilotkit/web-inspector` currently only inlines CSS and SVG assets in its package build, while larger docs/showcase media commonly lives on hosted/CDN-style URLs.
- The video `src` is not rendered on the initial overview paint. It is deferred until `requestIdleCallback` or a short timeout fallback, uses `preload="metadata"`, fades in after `loadeddata`, and does not load for `prefers-reduced-motion: reduce`.

## Validation

- `NX_TUI=false npx -y pnpm@10.33.4 nx run @copilotkit/web-inspector:test -- web-inspector.spec.ts`
- `NX_TUI=false npx -y pnpm@10.33.4 nx run @copilotkit/web-inspector:check-types`

<img width="1662" height="1382" alt="CleanShot 2026-07-10 at 12 01 03@2x" src="https://github.com/user-attachments/assets/e2031570-f602-40dc-a54c-e9c7690fc0ba" />
<img width="1680" height="1388" alt="CleanShot 2026-07-10 at 12 01 12@2x" src="https://github.com/user-attachments/assets/2c8db42f-3ab0-47e2-a235-ea54e8dd292b" />


