### PR TITLE
fix(channels-intelligence): claim deliveries provider-agnostically

### DIFF
--- a/packages/channels-intelligence/src/http-transports.test.ts
+++ b/packages/channels-intelligence/src/http-transports.test.ts
@@ -242,6 +242,49 @@ describe("HttpDeliverySource", () => {
     expect(r.env.conversationKey).toBe("slack:T1:C1:thread:1.2");
   });
 
+  it("claimOnce derives a Teams conversationKey from tenantId+conversationId (provider-agnostic claim)", async () => {
+    // Now that the runtime claims provider-agnostically, a Teams delivery flows
+    // through the same bridge. Its reply target is a different shape (no
+    // teamId/channel), so the conversationKey must be derived per-provider —
+    // otherwise every Teams conversation collapses onto one agent/session.
+    const { fetch } = fakeFetch(() => ({
+      body: {
+        claimed: true,
+        delivery: claimedDelivery({
+          adapter: "teams",
+          turn: {
+            id: "turn_9",
+            eventId: "evt_9",
+            receivedAt: "2026-06-30T00:00:00.000Z",
+            replyTarget: {
+              adapter: "teams",
+              serviceUrl: "https://smba.trafficmanager.net/teams",
+              conversationId: "19:abc@thread.tacv2",
+              tenantId: "tenant-1",
+            },
+            input: { kind: "text", text: "hello" },
+          },
+        }),
+      },
+    }));
+    const src = new HttpDeliverySource(cfg({ fetch }));
+    const r = await src.claimOnce();
+    expect("env" in r).toBe(true);
+    if (!("env" in r)) throw new Error("expected env");
+    expect(r.env).toMatchObject({
+      kind: "turn",
+      platform: "teams",
+      text: "hello",
+    });
+    // Matches Intelligence app-api's thread_key = teams:{tenantId}:{conversationId}.
+    expect(r.env.conversationKey).toBe("teams:tenant-1:19:abc@thread.tacv2");
+    // Reply route is passed through verbatim for provider-agnostic egress.
+    expect(r.env.route).toMatchObject({
+      adapter: "teams",
+      conversationId: "19:abc@thread.tacv2",
+    });
+  });
+
   it("claimOnce maps a claimed slash command delivery to a command envelope", async () => {
     const { fetch } = fakeFetch(() => ({
       body: {

--- a/packages/channels-intelligence/src/http-transports.ts
+++ b/packages/channels-intelligence/src/http-transports.ts
@@ -376,8 +376,13 @@ export class HttpDeliverySource implements DeliverySource {
     const res = await this.http.post<ClaimResponse>(
       "/api/bots/listener/claim",
       {
+        // Claim provider-agnostically: the managed runtime emits abstract render
+        // frames and Intelligence renders per the delivery's own reply target, so
+        // a single runtime serves every channel its bot has attached (Slack,
+        // Teams, ...). Declaring a single adapter here made Intelligence withhold
+        // deliveries for the bot's other channels (e.g. a Slack-declared runtime
+        // never received the same bot's Teams messages).
         runtimeInstanceId: this.cfg.runtimeInstanceId,
-        adapters: [this.cfg.adapter],
       },
     );
     if (!res.claimed) return { pollAfterMs: res.pollAfterMs ?? 1000 };

--- a/packages/channels-intelligence/src/http-transports.ts
+++ b/packages/channels-intelligence/src/http-transports.ts
@@ -156,11 +156,30 @@ function withTimeout<T>(
 
 /** Slack reply target Intelligence mints at ingress and the sink echoes back. */
 interface SlackReplyTarget {
-  adapter: string;
+  adapter: "slack";
   teamId: string;
   channel: string;
   threadTs?: string;
 }
+
+/**
+ * Teams reply target Intelligence mints at ingress (Bot Connector coordinates).
+ * Distinct shape from Slack — no teamId/channel/threadTs — so conversation
+ * identity must be derived per-provider (see {@link conversationKeyFromReplyTarget}).
+ */
+interface TeamsReplyTarget {
+  adapter: "teams";
+  serviceUrl: string;
+  conversationId: string;
+  tenantId: string;
+}
+
+/**
+ * The claim's reply target is provider-tagged (Intelligence app-api mints a
+ * discriminated union — one managed runtime serves every channel its bot has
+ * attached now that claims are provider-agnostic).
+ */
+type ReplyTarget = SlackReplyTarget | TeamsReplyTarget;
 
 /** Successful `claim` delivery envelope (subset the bridge reads). */
 interface ClaimedDelivery {
@@ -173,7 +192,7 @@ interface ClaimedDelivery {
   turn: {
     id: string;
     eventId: string;
-    replyTarget: SlackReplyTarget;
+    replyTarget: ReplyTarget;
     // NB: there is intentionally no `thread_started` variant here — the claim
     // path only carries turn/command/reaction/interaction. `thread_started`
     // envelopes originate on the realtime/Phoenix path, not from `claim`, so a
@@ -263,9 +282,30 @@ class IntelligenceHttp {
   }
 }
 
-/** `slack:teamId:channel:thread:threadTs` — stable per Slack thread. */
-function conversationKeyFromReplyTarget(rt: SlackReplyTarget): string {
-  return `${rt.adapter}:${rt.teamId}:${rt.channel}:thread:${rt.threadTs ?? "root"}`;
+/**
+ * Stable per-conversation key, derived per provider — it keys the agent/session
+ * (`getOrCreate(conversationKey)`), so distinct conversations MUST get distinct
+ * keys or their state bleeds together. Slack: `slack:teamId:channel:thread:threadTs`.
+ * Teams: `teams:tenantId:conversationId`, matching app-api's `thread_key`
+ * (`teams:{tenantId}:{conversationId}`) so client and server agree on identity.
+ * Deriving from Slack-only fields would collapse every Teams conversation to one
+ * key — the bug this switch prevents now that claims are provider-agnostic.
+ */
+function conversationKeyFromReplyTarget(rt: ReplyTarget): string {
+  switch (rt.adapter) {
+    case "slack":
+      return `slack:${rt.teamId}:${rt.channel}:thread:${rt.threadTs ?? "root"}`;
+    case "teams":
+      return `teams:${rt.tenantId}:${rt.conversationId}`;
+    default: {
+      // A provider we don't model yet: fail loud rather than silently collide
+      // distinct conversations onto a shared agent/session.
+      const unknown = rt as { adapter?: string };
+      throw new Error(
+        `conversationKeyFromReplyTarget: unsupported reply-target adapter ${JSON.stringify(unknown.adapter)}`,
+      );
+    }
+  }
 }
 
 function mapDeliveryToEnvelope(d: ClaimedDelivery): ManagedIngressEnvelope {


### PR DESCRIPTION
## Problem

A managed bot with **both** a Slack and a Teams adapter attached only ever received its **Slack** deliveries. Teams deliveries stayed `queued` forever — never claimed, never sent.

## Root cause

`channels-intelligence`'s runtime claim loop (`http-transports.ts` → `claimOnce()`) posted a per-provider filter to `/api/bots/listener/claim`:

```ts
{
  runtimeInstanceId: this.cfg.runtimeInstanceId,
  adapters: [this.cfg.adapter], // defaults to "slack"
}
```

app-api filters claimable deliveries by that list (`$adapters IS NULL OR bie.provider = ANY($adapters)`), so a runtime declaring only `"slack"` is never handed the same bot's Teams deliveries.

But the managed runtime is **provider-agnostic**: it emits abstract render frames and Intelligence renders each reply per the delivery's own reply target. There is no reason for the runtime to constrain claims by provider — one `intelligenceAdapter()` should serve every channel its bot has attached.

## Fix

Drop the `adapters` field from the claim body. `adapters` is already optional on the app-api side (absent → `NULL` → no provider filter → all providers), so this needs no coordinated backend change. `this.cfg.adapter` is still used for the heartbeat's declared bots and for egress, both unaffected.

## Testing

Verified end-to-end locally against a managed Teams bot: inbound Bot Framework JWT → claim → agent run → render → Bot Connector egress all `succeed` with this change. Slack continues to work unchanged.