### PR TITLE
refactor(channels-intelligence): migrate to Channels API

### DIFF
--- a/examples/slack/.env.example
+++ b/examples/slack/.env.example
@@ -39,10 +39,10 @@ OPENAI_API_KEY=sk-...
 # ANTHROPIC_API_KEY=sk-ant-...
 # GOOGLE_API_KEY=...
 
-# ── Managed (Intelligence-hosted) mode — app/managed.ts (`pnpm managed`) ──
-# The managed variant runs the SAME bot over the Intelligence realtime-gateway
+# ── Intelligence Channel mode — app/managed.ts (`pnpm channel`) ──────────
+# The Channel variant runs the SAME bot over the Intelligence realtime gateway
 # instead of a native adapter — it holds NO Slack tokens (Intelligence owns the
-# Slack edge). Set these to run `pnpm managed`; the native `pnpm dev` ignores
+# Slack edge). Set these to run `pnpm channel`; the native `pnpm dev` ignores
 # them. The agent brain reuses AGENT_URL / AGENT_AUTH_HEADER above.
 # Gateway runner WebSocket URL (the /runner socket hosting the bot-IO channel).
 # INTELLIGENCE_GATEWAY_WS_URL=wss://gateway.intelligence.example/runner
@@ -50,11 +50,11 @@ OPENAI_API_KEY=sk-...
 # INTELLIGENCE_API_KEY=cpk-...
 # Product organization id (as issued by Intelligence).
 # INTELLIGENCE_ORG_ID=org_...
-# Numeric project id (the channel topic is hosted_bots:project:<id>).
+# Numeric project id (the channel topic is channels:project:<id>).
 # INTELLIGENCE_PROJECT_ID=123
-# Bot id + immutable project-unique bot name (from Intelligence bot setup).
-# INTELLIGENCE_BOT_ID=bot_...
-# INTELLIGENCE_BOT_NAME=triage
+# Channel id + immutable project-unique channel name (from Intelligence Channel setup).
+# INTELLIGENCE_CHANNEL_ID=channel_...
+# INTELLIGENCE_CHANNEL_NAME=triage
 # Optional: stable runtime instance id; a random rti_… is generated if unset.
 # INTELLIGENCE_RUNTIME_INSTANCE_ID=rti_...
 

--- a/examples/slack/app/managed.test.ts
+++ b/examples/slack/app/managed.test.ts
@@ -7,7 +7,7 @@ const fakes = vi.hoisted(() => {
   return {
     stop,
     closeBrowser: vi.fn(async () => {}),
-    startManagedBotsOverPhoenix: vi.fn(async () => ({ stop })),
+    startChannelsOverRealtimeGateway: vi.fn(async () => ({ stop })),
     bot: {
       onMention: vi.fn(),
       onModalSubmit: vi.fn(),
@@ -22,10 +22,10 @@ vi.mock("@copilotkit/channels", () => ({
 vi.mock("@copilotkit/channels-slack", () => ({
   defaultSlackTools: [],
   defaultSlackContext: [],
-  SanitizingHttpAgent: class {},
+  SanitizingHttpAgent: function SanitizingHttpAgent() {},
 }));
 vi.mock("@copilotkit/channels-intelligence", () => ({
-  startManagedBotsOverPhoenix: fakes.startManagedBotsOverPhoenix,
+  startChannelsOverRealtimeGateway: fakes.startChannelsOverRealtimeGateway,
 }));
 vi.mock("./tools/index.js", () => ({ appTools: [] }));
 vi.mock("./context/app-context.js", () => ({ appContext: [] }));
@@ -40,14 +40,14 @@ vi.mock("./render/browser.js", () => ({ closeBrowser: fakes.closeBrowser }));
 const envKeys = [
   "AGENT_URL",
   "INTELLIGENCE_PROJECT_ID",
-  "INTELLIGENCE_BOT_NAME",
+  "INTELLIGENCE_CHANNEL_NAME",
   "INTELLIGENCE_GATEWAY_WS_URL",
   "INTELLIGENCE_API_KEY",
   "INTELLIGENCE_ORG_ID",
-  "INTELLIGENCE_BOT_ID",
+  "INTELLIGENCE_CHANNEL_ID",
 ] as const;
 
-describe("managed entrypoint shutdown", () => {
+describe("channel entrypoint shutdown", () => {
   const previousEnv = new Map<string, string | undefined>();
 
   afterEach(() => {
@@ -60,15 +60,15 @@ describe("managed entrypoint shutdown", () => {
     previousEnv.clear();
   });
 
-  it("exits nonzero when stopping the managed runtime fails", async () => {
+  it("exits nonzero when stopping the channel runtime fails", async () => {
     for (const key of envKeys) previousEnv.set(key, process.env[key]);
     process.env.AGENT_URL = "http://agent.test/run";
     process.env.INTELLIGENCE_PROJECT_ID = "7";
-    process.env.INTELLIGENCE_BOT_NAME = "opentag";
+    process.env.INTELLIGENCE_CHANNEL_NAME = "opentag";
     process.env.INTELLIGENCE_GATEWAY_WS_URL = "wss://gateway.test/runner";
     process.env.INTELLIGENCE_API_KEY = "cpk-test";
     process.env.INTELLIGENCE_ORG_ID = "org_1";
-    process.env.INTELLIGENCE_BOT_ID = "bot_1";
+    process.env.INTELLIGENCE_CHANNEL_ID = "channel_1";
 
     let sigterm: (() => void) | undefined;
     vi.spyOn(process, "on").mockImplementation(((event, listener) => {
@@ -83,6 +83,15 @@ describe("managed entrypoint shutdown", () => {
 
     await import("./managed.js");
     await vi.waitFor(() => expect(sigterm).toBeTypeOf("function"));
+    expect(fakes.startChannelsOverRealtimeGateway).toHaveBeenCalledWith(
+      [fakes.bot],
+      expect.objectContaining({
+        scope: expect.objectContaining({
+          channelId: "channel_1",
+          channelName: "opentag",
+        }),
+      }),
+    );
     sigterm!();
     await vi.waitFor(() => expect(exit).toHaveBeenCalled());
 

--- a/examples/slack/app/managed.ts
+++ b/examples/slack/app/managed.ts
@@ -1,23 +1,23 @@
 /**
- * Managed (Intelligence-hosted) entrypoint for the same Slack bot as
+ * Intelligence Channel entrypoint for the same Slack bot as
  * `app/index.ts`.
  *
  * `index.ts` is the SELF-HOSTED variant: it holds the Slack bot/app tokens and
  * talks to Slack directly via the native `slack()` adapter. This file is the
- * MANAGED variant: it holds no Slack credentials and no public endpoint — it
- * connects to the Intelligence realtime-gateway over Phoenix, receives leased
+ * Channel variant: it holds no Slack credentials and no public endpoint — it
+ * connects to the Intelligence Realtime Gateway, receives leased
  * deliveries, and streams render frames back. Intelligence owns the Slack edge
  * (signed ingress → app-api, egress via the Connector Outbox).
  *
  * The bot itself — the agent, tools, context, commands, and turn handlers — is
  * IDENTICAL to the native bot; only the transport changes. `intelligenceAdapter`
- * is exclusive, so the managed bot is created WITHOUT a native adapter and
- * {@link startManagedBotsOverPhoenix} attaches the managed transport.
+ * is exclusive, so the Channel Bot is created WITHOUT a native adapter and
+ * {@link startChannelsOverRealtimeGateway} attaches the Channel transport.
  *
  *   native:   createBot({ adapters: [slack({ botToken, appToken }) ] })  // index.ts
- *   managed:  startManagedBotsOverPhoenix([ createBot({ … }) ], { … })   // this file
+ *   channel:  startChannelsOverRealtimeGateway([ createBot({ … }) ], { … })   // this file
  *
- * Run: `pnpm --filter slack-example managed` with the INTELLIGENCE_* env set
+ * Run: `pnpm --filter slack-example channel` with the INTELLIGENCE_* env set
  * (see `.env.example`).
  */
 import "dotenv/config";
@@ -28,7 +28,7 @@ import {
   defaultSlackContext,
   SanitizingHttpAgent,
 } from "@copilotkit/channels-slack";
-import { startManagedBotsOverPhoenix } from "@copilotkit/channels-intelligence";
+import { startChannelsOverRealtimeGateway } from "@copilotkit/channels-intelligence";
 import { appTools } from "./tools/index.js";
 import { appContext } from "./context/app-context.js";
 import { appCommands } from "./commands/index.js";
@@ -52,20 +52,20 @@ async function main() {
     : undefined;
 
   const projectId = Number(required("INTELLIGENCE_PROJECT_ID"));
-  if (!Number.isInteger(projectId) || projectId < 0) {
+  if (!Number.isInteger(projectId) || projectId <= 0) {
     console.error(
       `Invalid INTELLIGENCE_PROJECT_ID: "${process.env.INTELLIGENCE_PROJECT_ID}"`,
     );
     process.exit(1);
   }
-  const botName = required("INTELLIGENCE_BOT_NAME");
+  const channelName = required("INTELLIGENCE_CHANNEL_NAME");
 
-  // Same bot as the native example, minus the adapter: the managed transport is
-  // attached by startManagedBotsOverPhoenix. Slack is the only managed provider
+  // Same Slack Bot as the native example, minus the adapter: the Channel transport is
+  // attached by startChannelsOverRealtimeGateway. Slack is the only Channel provider
   // here, so it always ships the Slack tools/context (the native example adds
   // these conditionally per active adapter).
   const bot = createBot({
-    name: botName,
+    name: channelName,
     agent: (threadId) => {
       const a = new SanitizingHttpAgent({
         url: agentUrl,
@@ -82,7 +82,7 @@ async function main() {
   // Turn + feature handlers — identical to the native example (app/index.ts).
   bot.onMention(async ({ thread, message }) => {
     try {
-      // Managed history (app-api /api/bots/history) does NOT include the
+      // Channel history (app-api /api/channels/history) does NOT include the
       // in-flight turn (unlike native adapters whose getHistory rebuilds the
       // live thread), so pass the current message explicitly as `prompt` —
       // otherwise runAgent runs with zero messages. Prefer multimodal parts.
@@ -93,10 +93,12 @@ async function main() {
         context: senderContext(message.user, thread.platform),
       });
     } catch (err) {
-      console.error("[bot] agent run failed", err);
+      console.error("[channel] agent run failed", err);
       await thread
         .post("Sorry — I hit an error handling that. Please try again.")
-        .catch(() => {});
+        .catch((postErr: unknown) =>
+          console.error("[channel] failed to post agent error", postErr),
+        );
     }
   });
   bot.onModalSubmit(FILE_ISSUE_CALLBACK, fileIssueSubmit);
@@ -114,14 +116,14 @@ async function main() {
     ]);
   });
 
-  const handle = await startManagedBotsOverPhoenix([bot], {
+  const handle = await startChannelsOverRealtimeGateway([bot], {
     wsUrl: required("INTELLIGENCE_GATEWAY_WS_URL"),
     apiKey: required("INTELLIGENCE_API_KEY"),
     scope: {
       organizationId: required("INTELLIGENCE_ORG_ID"),
       projectId,
-      botId: required("INTELLIGENCE_BOT_ID"),
-      botName,
+      channelId: required("INTELLIGENCE_CHANNEL_ID"),
+      channelName,
     },
     runtimeInstanceId:
       process.env.INTELLIGENCE_RUNTIME_INSTANCE_ID ??
@@ -131,32 +133,35 @@ async function main() {
     // above) can contain message content/payloads — the design says telemetry
     // must not include raw message text. In production, drop this `log` or trim
     // `meta` to safe fields (ids, counts) before emitting.
-    log: (msg, meta) => console.log(`[managed] ${msg}`, meta ?? ""),
+    log: (msg, meta) => console.log(`[channel] ${msg}`, meta ?? ""),
   });
   console.log(
-    `[bot] started managed (Phoenix) as "${botName}" on project ${projectId}`,
+    `[channel] started over Realtime Gateway as "${channelName}" on project ${projectId}`,
   );
 
   const shutdown = async (signal: string) => {
-    console.log(`\n[bot] received ${signal}, stopping…`);
+    console.log(`\n[channel] received ${signal}, stopping…`);
     let exitCode = 0;
     try {
       await handle.stop();
     } catch (err) {
-      console.error("[bot] error stopping managed runtime", err);
+      console.error("[channel] error stopping Channel runtime", err);
       exitCode = 1;
     }
     // Browser teardown is best-effort, but still surface a failure rather than
     // swallow it silently.
     await closeBrowser().catch((err: unknown) =>
-      console.error("[bot] browser cleanup failed (continuing shutdown)", err),
+      console.error(
+        "[channel] browser cleanup failed (continuing shutdown)",
+        err,
+      ),
     );
     process.exit(exitCode);
   };
   // A failed shutdown must not vanish — log it and exit nonzero.
   const runShutdown = (signal: string): void => {
     shutdown(signal).catch((err: unknown) => {
-      console.error(`[bot] fatal during ${signal} shutdown`, err);
+      console.error(`[channel] fatal during ${signal} shutdown`, err);
       process.exit(1);
     });
   };
@@ -167,13 +172,13 @@ async function main() {
 // Fail loud, not silent: surface any stray async error instead of letting it
 // kill the process with no log (mirrors the native entrypoint).
 process.on("unhandledRejection", (reason) => {
-  console.error("[bot] unhandledRejection:", reason);
+  console.error("[channel] unhandledRejection:", reason);
 });
 process.on("uncaughtException", (err) => {
-  console.error("[bot] uncaughtException:", err);
+  console.error("[channel] uncaughtException:", err);
 });
 
 main().catch((err: unknown) => {
-  console.error("[bot] fatal: failed to start managed runtime", err);
+  console.error("[channel] fatal: failed to start Channel runtime", err);
   process.exit(1);
 });

--- a/examples/slack/package.json
+++ b/examples/slack/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "tsx watch app/index.ts",
     "start": "tsx app/index.ts",
-    "managed": "tsx app/managed.ts",
+    "channel": "tsx app/managed.ts",
     "build": "pnpm exec nx run-many -t build -p \"@copilotkit/channels*\" @copilotkit/runtime",
     "runtime": "tsx runtime.ts",
     "notion-mcp": "tsx scripts/start-notion-mcp.ts",

--- a/packages/channels-intelligence/package.json
+++ b/packages/channels-intelligence/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@copilotkit/channels-intelligence",
   "version": "0.1.0",
-  "description": "Intelligence-delivered managed-bot adapter for CopilotKit JSX channels (@copilotkit/channels).",
+  "description": "Intelligence-delivered Channel adapter for CopilotKit JSX channels (@copilotkit/channels).",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -14,7 +14,7 @@
     "agent",
     "bot",
     "intelligence",
-    "managed-bots",
+    "channels",
     "copilotkit",
     "ag-ui"
   ],

--- a/packages/channels-intelligence/package.json
+++ b/packages/channels-intelligence/package.json
@@ -12,7 +12,6 @@
   "keywords": [
     "ai",
     "agent",
-    "bot",
     "intelligence",
     "channels",
     "copilotkit",

--- a/packages/channels-intelligence/src/content-parts.ts
+++ b/packages/channels-intelligence/src/content-parts.ts
@@ -1,5 +1,5 @@
 import type { AgentContentPart } from "@copilotkit/channels-ui";
-import type { ManagedFileRef } from "./contracts.js";
+import type { ChannelFileRef } from "./contracts.js";
 
 /** Map a MIME type to its `AgentContentPart` media kind, or null for non-media. */
 export function mediaKindForMime(
@@ -27,7 +27,7 @@ export function mediaKindForMime(
  * historical image attachment and a live one produce the same content part.
  */
 export async function buildContentParts(
-  files: ManagedFileRef[] | undefined,
+  files: ChannelFileRef[] | undefined,
   fetchFile:
     | ((handle: string) => Promise<{ bytes: Uint8Array; mimeType?: string }>)
     | undefined,

--- a/packages/channels-intelligence/src/contracts.ts
+++ b/packages/channels-intelligence/src/contracts.ts
@@ -119,7 +119,7 @@ export type EgressResult =
   | { ok: false; code: string };
 
 // ── Realtime render events (OSS-402) ──────────────────────────────────────
-// Mirrors the frozen `hosted_bot.render_event.v1` contract on the Intelligence
+// Mirrors the frozen `channel.render_event.v1` contract on the Intelligence
 // side (libs/app-api-contracts/src/hosted-bots.ts). The SDK streams these
 // semantic frames to the realtime-gateway; the gateway-side Connector Outbox
 // (OSS-404) renders them to the provider (Slack Block Kit, etc.).

--- a/packages/channels-intelligence/src/contracts.ts
+++ b/packages/channels-intelligence/src/contracts.ts
@@ -1,5 +1,5 @@
 // TODO(OSS-377): replace this module with the shared
-// `@copilotkit/managed-bot-contracts` package once it lands. This is a minimal,
+// `@copilotkit/channel-contracts` package once it lands. This is a minimal,
 // self-owned placeholder: ONLY the fields the bridge adapter actually reads or
 // writes are typed. The rest of the OSS-377 surface — Zod schemas, the full
 // event-kind set, bounded failure codes, health/read models — is intentionally
@@ -13,16 +13,24 @@ import type { BotNode, MessageRef } from "@copilotkit/channels-ui";
  */
 export type EgressRoute = unknown;
 
-/** Fields common to every managed ingress envelope. */
-export interface ManagedIngressBase {
+/** Authoritative org/project/channel scope that arrived with a delivery. */
+export interface ChannelDeliveryScope {
+  organizationId: string;
+  projectId: number;
+  channelId: string;
+  channelName: string;
+}
+
+/** Fields common to every Intelligence Channel ingress envelope. */
+export interface ChannelIngressBase {
   /** Unique per delivery attempt (lease). At-least-once: may be redelivered. */
   deliveryId: string;
   /** Stable platform event id (idempotency / dedup). */
   eventId: string;
   /** Stable per-logical-turn id. Egress operation ids derive from it. */
   turnId: string;
-  /** Project-unique bot identifier (matches `createBot({ name })`). */
-  botName: string;
+  /** Channel name, which routes to the framework `Bot` named by `createBot({ name })`. */
+  channelName: string;
   /** Originating platform (e.g. "slack"). Stamped onto the handler-facing message. */
   platform: string;
   conversationKey: string;
@@ -43,21 +51,21 @@ export interface ManagedIngressBase {
  * bytes). The adapter fetches the bytes lazily via
  * {@link DeliverySource.fetchFile} and builds `AgentContentPart`s from them.
  */
-export interface ManagedFileRef {
+export interface ChannelFileRef {
   handle: string;
   filename: string;
   mimeType?: string;
   byteSize?: number;
 }
 
-export type ManagedIngressEnvelope =
-  | (ManagedIngressBase & {
+export type ChannelIngressEnvelope =
+  | (ChannelIngressBase & {
       kind: "turn";
       text?: string;
       /** Inbound files attached to this turn (images, docs, …), in order. */
-      files?: ManagedFileRef[];
+      files?: ChannelFileRef[];
     })
-  | (ManagedIngressBase & {
+  | (ChannelIngressBase & {
       kind: "command";
       /** Command name as invoked (leading slash / case normalized by core). */
       command: string;
@@ -68,7 +76,7 @@ export type ManagedIngressEnvelope =
       /** Structured, pre-parsed options when the surface delivers them. */
       rawOptions?: Record<string, unknown>;
     })
-  | (ManagedIngressBase & {
+  | (ChannelIngressBase & {
       kind: "interaction";
       /** Minted action id (ck:...) the rendered control carries. */
       actionId: string;
@@ -77,8 +85,8 @@ export type ManagedIngressEnvelope =
       messageRef?: MessageRef;
       triggerId?: string;
     })
-  | (ManagedIngressBase & { kind: "thread_started" })
-  | (ManagedIngressBase & {
+  | (ChannelIngressBase & { kind: "thread_started" })
+  | (ChannelIngressBase & {
       kind: "reaction";
       /** Platform-native emoji token. */
       rawEmoji: string;
@@ -120,15 +128,15 @@ export type EgressResult =
 
 // ── Realtime render events (OSS-402) ──────────────────────────────────────
 // Mirrors the frozen `channel.render_event.v1` contract on the Intelligence
-// side (libs/app-api-contracts/src/hosted-bots.ts). The SDK streams these
+// side (libs/app-api-contracts/src/channels.ts). The SDK streams these
 // semantic frames to the realtime-gateway; the gateway-side Connector Outbox
 // (OSS-404) renders them to the provider (Slack Block Kit, etc.).
-// TODO(OSS-377): replace with the shared `@copilotkit/managed-bot-contracts`
+// TODO(OSS-377): replace with the shared `@copilotkit/channel-contracts`
 // package; `post`/`update` content is `BotNode[]` (SDK IR) here — the frozen
-// contract types it as opaque `HostedBotRenderContent`.
+// contract types it as opaque `ChannelRenderContent`.
 
 /** One semantic render frame the agent run emits. Matches the frozen kinds. */
-export type HostedBotRenderEvent =
+export type ChannelRenderEvent =
   | { kind: "run_started" }
   | { kind: "text_delta"; messageId: string; delta: string }
   | { kind: "text_end"; messageId: string }
@@ -153,11 +161,11 @@ export type HostedBotRenderEvent =
   | { kind: "finalize" };
 
 /** All render-event kinds, for exhaustive/ordering checks. */
-export type HostedBotRenderEventKind = HostedBotRenderEvent["kind"];
+export type ChannelRenderEventKind = ChannelRenderEvent["kind"];
 
 /**
  * The adapter-facing render frame. The {@link RenderEventSink} fills in the
- * org/project/bot scope, the `idempotencyKey` (`turnId:slot:seq`), the
+ * org/project/channel scope, the `idempotencyKey` (`turnId:slot:seq`), the
  * `runtimeInstanceId`, and `sentAt` before it hits the wire — the adapter only
  * supplies the delivery/turn identity, the render lane (`slot`), the monotonic
  * per-`(turn, slot)` `seq`, and the semantic `event`.
@@ -169,7 +177,7 @@ export interface RenderFrame {
   slot: string;
   /** Zero-based, monotonic within `(turnId, slot)`. */
   seq: number;
-  event: HostedBotRenderEvent;
+  event: ChannelRenderEvent;
 }
 
 /** Durable-acceptance receipt echoed back for each pushed {@link RenderFrame}. */

--- a/packages/channels-intelligence/src/http-transports.test.ts
+++ b/packages/channels-intelligence/src/http-transports.test.ts
@@ -252,7 +252,6 @@ describe("HttpDeliverySource", () => {
     expect(calls[0]!.url).toBe("http://x/api/channels/listener/claim");
     expect(calls[0]!.body).toEqual({
       runtimeInstanceId: "rti_test",
-      adapters: ["slack"],
     });
     expect(r.env).toMatchObject({
       kind: "turn",

--- a/packages/channels-intelligence/src/http-transports.test.ts
+++ b/packages/channels-intelligence/src/http-transports.test.ts
@@ -52,18 +52,23 @@ function fakeFetch(
  * `uploadFile` methods — so history tests stub `globalThis.fetch` instead.
  */
 function stubGlobalFetch(
-  handler: (url: string) => {
+  handler: (
+    url: string,
+    init?: RequestInit,
+  ) => {
     ok?: boolean;
     status?: number;
     json?: unknown;
     arrayBuffer?: ArrayBuffer;
     contentType?: string;
   },
-): { calls: string[] } {
+): { calls: string[]; requests: Array<{ url: string; init?: RequestInit }> } {
   const calls: string[] = [];
-  vi.stubGlobal("fetch", async (url: string) => {
+  const requests: Array<{ url: string; init?: RequestInit }> = [];
+  vi.stubGlobal("fetch", async (url: string, init?: RequestInit) => {
     calls.push(url);
-    const r = handler(url);
+    requests.push({ url, init });
+    const r = handler(url, init);
     const status = r.status ?? (r.ok === false ? 500 : 200);
     return {
       ok: r.ok ?? status < 400,
@@ -77,7 +82,7 @@ function stubGlobalFetch(
       },
     };
   });
-  return { calls };
+  return { calls, requests };
 }
 
 function cfg(
@@ -86,7 +91,7 @@ function cfg(
   return resolveTransportConfig({
     baseUrl: "http://x",
     apiKey: "cpk-test",
-    botName: "opentagbot",
+    channelName: "opentagbot",
     runtimeInstanceId: "rti_test",
     adapter: "slack",
     sleep: async () => {},
@@ -102,7 +107,7 @@ const claimedDelivery = (over?: Record<string, unknown>) => ({
   attempt: 1,
   organizationId: "org_1",
   projectId: 7,
-  bot: { id: "bot_1", name: "opentagbot" },
+  channel: { id: "channel_1", name: "opentagbot" },
   adapter: "slack",
   leaseToken: "lease_z",
   leaseExpiresAt: "2026-06-30T00:00:00.000Z",
@@ -125,8 +130,23 @@ describe("resolveTransportConfig", () => {
   it("throws loudly when required fields are missing", () => {
     // No overrides + (assumed) no COPILOTKIT_* env in the test runner.
     expect(() =>
-      resolveTransportConfig({ baseUrl: "", apiKey: "", botName: "" }),
+      resolveTransportConfig({ baseUrl: "", apiKey: "", channelName: "" }),
     ).toThrow(/missing required transport config/);
+  });
+
+  it("uses COPILOTKIT_CHANNEL_NAME and rejects the legacy bot-name environment variable", () => {
+    vi.stubEnv("COPILOTKIT_INTELLIGENCE_URL", "http://x");
+    vi.stubEnv("COPILOTKIT_API_KEY", "cpk-test");
+    vi.stubEnv("COPILOTKIT_CHANNEL_NAME", "");
+    vi.stubEnv("COPILOTKIT_BOT_NAME", "legacy-bot");
+
+    try {
+      expect(() => resolveTransportConfig()).toThrow(
+        /channelName.*COPILOTKIT_CHANNEL_NAME/,
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });
 
@@ -145,10 +165,10 @@ describe("HttpEgressSink", () => {
     };
     const res = await sink.emit(op);
     expect(res).toEqual({ ok: true, ref: "eop_1" });
-    expect(calls[0]!.url).toBe("http://x/api/bots/egress/messages");
+    expect(calls[0]!.url).toBe("http://x/api/channels/egress/messages");
     expect(calls[0]!.headers["authorization"]).toBe("Bearer cpk-test");
     expect(calls[0]!.body).toMatchObject({
-      botName: "opentagbot",
+      channelName: "opentagbot",
       adapter: "slack",
       deliveryId: "dlv_9",
       idempotencyKey: "turn_9:0",
@@ -203,32 +223,37 @@ describe("HttpEgressSink", () => {
 });
 
 describe("HttpDeliverySource", () => {
-  it("heartbeat declares the bot + adapter", async () => {
+  it("heartbeat declares the channel + adapter", async () => {
     const { fetch, calls } = fakeFetch(() => ({
       body: {
         runtimeInstanceId: "rti_test",
         receivedAt: "t",
         leaseExpiresAt: "t",
-        bots: [],
+        channels: [],
       },
     }));
     const src = new HttpDeliverySource(cfg({ fetch }));
     await src.heartbeat();
-    expect(calls[0]!.url).toBe("http://x/api/bots/listener/heartbeat");
+    expect(calls[0]!.url).toBe("http://x/api/channels/listener/heartbeat");
     expect(calls[0]!.body).toMatchObject({
       runtimeInstanceId: "rti_test",
-      declaredBots: [{ botName: "opentagbot", adapter: "slack" }],
+      declaredChannels: [{ channelName: "opentagbot", adapter: "slack" }],
     });
   });
 
-  it("claimOnce maps a claimed delivery to a turn envelope with a stable conversationKey", async () => {
-    const { fetch } = fakeFetch(() => ({
+  it("claims from the channels listener and maps a delivery to a turn envelope", async () => {
+    const { fetch, calls } = fakeFetch(() => ({
       body: { claimed: true, delivery: claimedDelivery() },
     }));
     const src = new HttpDeliverySource(cfg({ fetch }));
     const r = await src.claimOnce();
     expect("env" in r).toBe(true);
     if (!("env" in r)) throw new Error("expected env");
+    expect(calls[0]!.url).toBe("http://x/api/channels/listener/claim");
+    expect(calls[0]!.body).toEqual({
+      runtimeInstanceId: "rti_test",
+      adapters: ["slack"],
+    });
     expect(r.env).toMatchObject({
       kind: "turn",
       deliveryId: "dlv_9",
@@ -394,7 +419,9 @@ describe("HttpDeliverySource", () => {
     const src = new HttpDeliverySource(cfg({ fetch }));
     await src.claimOnce();
     await src.ack("dlv_9");
-    const ack = calls.find((c) => c.url.includes("/deliveries/dlv_9/ack"))!;
+    const ack = calls.find((c) =>
+      c.url.endsWith("/api/channels/deliveries/dlv_9/ack"),
+    )!;
     expect(ack.body).toMatchObject({
       turnId: "turn_9",
       leaseToken: "lease_z",
@@ -413,7 +440,9 @@ describe("HttpDeliverySource", () => {
     const src = new HttpDeliverySource(cfg({ fetch }));
     await src.claimOnce();
     await src.nack("dlv_9", "boom");
-    const fail = calls.find((c) => c.url.includes("/deliveries/dlv_9/fail"))!;
+    const fail = calls.find((c) =>
+      c.url.endsWith("/api/channels/deliveries/dlv_9/fail"),
+    )!;
     expect(fail.body["error"]).toMatchObject({
       code: "runtime_error",
       message: "boom",
@@ -499,7 +528,7 @@ describe("HttpDeliverySource.getHistory", () => {
   it("maps role/text and sends teamId/channel/threadTs/limit in the query", async () => {
     const { calls } = stubGlobalFetch((url) => {
       expect(url).toBe(
-        "http://x/api/bots/history?teamId=T1&channel=C1&threadTs=1.2&limit=5",
+        "http://x/api/channels/history?teamId=T1&channel=C1&threadTs=1.2&limit=5",
       );
       return {
         json: {
@@ -525,7 +554,7 @@ describe("HttpDeliverySource.getHistory", () => {
   it("hydrates a historical file ref into content parts (text inline + image data part)", async () => {
     const png = new Uint8Array([1, 2, 3, 4]);
     stubGlobalFetch((url) => {
-      if (url.includes("/api/bots/history")) {
+      if (url.includes("/api/channels/history")) {
         return {
           json: {
             messages: [
@@ -545,7 +574,7 @@ describe("HttpDeliverySource.getHistory", () => {
           },
         };
       }
-      if (url.includes("/api/bots/files/fileref_abc")) {
+      if (url.includes("/api/channels/files/fileref_abc")) {
         return { arrayBuffer: png.buffer, contentType: "image/png" };
       }
       throw new Error(`unexpected url in test: ${url}`);
@@ -636,6 +665,50 @@ describe("HttpDeliverySource.getHistory", () => {
     );
     expect(history).toEqual([]);
   });
+
+  it("downloads inbound files from the channels file route", async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    const { calls } = stubGlobalFetch((url) => {
+      expect(url).toBe("http://x/api/channels/files/fileref_abc");
+      return { arrayBuffer: bytes.buffer, contentType: "application/pdf" };
+    });
+    const src = new HttpDeliverySource(cfg({}));
+
+    await expect(src.fetchFile("fileref_abc")).resolves.toEqual({
+      bytes,
+      mimeType: "application/pdf",
+    });
+    expect(calls).toEqual(["http://x/api/channels/files/fileref_abc"]);
+  });
+
+  it("uploads outbound files to the channels delivery route", async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    const { requests } = stubGlobalFetch(() => ({
+      json: { handle: "fileref_uploaded" },
+    }));
+    const src = new HttpDeliverySource(cfg({}));
+
+    await expect(
+      src.uploadFile("dlv_9", {
+        bytes,
+        filename: "report.pdf",
+        title: "Report",
+        altText: "Quarterly report",
+      }),
+    ).resolves.toEqual({ handle: "fileref_uploaded" });
+
+    expect(requests[0]).toMatchObject({
+      url: "http://x/api/channels/deliveries/dlv_9/files?filename=report.pdf&title=Report&altText=Quarterly+report",
+      init: {
+        method: "POST",
+        headers: {
+          authorization: "Bearer cpk-test",
+          "content-type": "application/octet-stream",
+        },
+        body: bytes,
+      },
+    });
+  });
 });
 
 describe("HttpRenderEventSink", () => {
@@ -668,13 +741,13 @@ describe("HttpRenderEventSink", () => {
       acceptance: "accepted",
     });
     const accept = calls.find((c) =>
-      c.url.endsWith("/deliveries/dlv_9/render-events/accept"),
+      c.url.endsWith("/api/channels/deliveries/dlv_9/render-events/accept"),
     )!;
     expect(accept.body).toMatchObject({
       organizationId: "org_1",
       projectId: 7,
-      botId: "bot_1",
-      botName: "opentagbot",
+      channelId: "channel_1",
+      channelName: "opentagbot",
       turnId: "turn_9",
       runtimeInstanceId: "rti_test",
       slot: "main",
@@ -712,7 +785,7 @@ describe("intelligenceAdapter() — config-free default transports", () => {
     expect(adapter.platform).toBe("intelligence");
   });
 
-  it("builds HTTP transports and takes botName from createBot({ name })", async () => {
+  it("builds HTTP transports and uses the bot name as the declared channel name", async () => {
     const { fetch, calls } = fakeFetch((c) =>
       c.url.endsWith("/heartbeat")
         ? {
@@ -720,7 +793,7 @@ describe("intelligenceAdapter() — config-free default transports", () => {
               runtimeInstanceId: "rti_test",
               receivedAt: "t",
               leaseExpiresAt: "t",
-              bots: [],
+              channels: [],
             },
           }
         : { body: { claimed: false, pollAfterMs: 60000 } },
@@ -728,8 +801,8 @@ describe("intelligenceAdapter() — config-free default transports", () => {
     const bot = createBot({
       name: "opentagbot",
       agent: () => new FakeAgent(),
-      // No source/egress injected -> default HTTP transports; no botName in
-      // config -> must come from createBot({ name }) via the start() context.
+      // No source/egress injected -> default HTTP transports; no channelName in
+      // config -> it comes from createBot({ name }) via the start() context.
       adapters: [
         intelligenceAdapter({
           config: {
@@ -755,7 +828,7 @@ describe("intelligenceAdapter() — config-free default transports", () => {
 
     const hb = calls.find((c) => c.url.endsWith("/heartbeat"))!;
     expect(hb.body).toMatchObject({
-      declaredBots: [{ botName: "opentagbot", adapter: "slack" }],
+      declaredChannels: [{ channelName: "opentagbot", adapter: "slack" }],
     });
     expect(calls.some((c) => c.url.endsWith("/claim"))).toBe(true);
   });

--- a/packages/channels-intelligence/src/http-transports.test.ts
+++ b/packages/channels-intelligence/src/http-transports.test.ts
@@ -134,11 +134,10 @@ describe("resolveTransportConfig", () => {
     ).toThrow(/missing required transport config/);
   });
 
-  it("uses COPILOTKIT_CHANNEL_NAME and rejects the legacy bot-name environment variable", () => {
+  it("requires COPILOTKIT_CHANNEL_NAME when no channel name is configured", () => {
     vi.stubEnv("COPILOTKIT_INTELLIGENCE_URL", "http://x");
     vi.stubEnv("COPILOTKIT_API_KEY", "cpk-test");
     vi.stubEnv("COPILOTKIT_CHANNEL_NAME", "");
-    vi.stubEnv("COPILOTKIT_BOT_NAME", "legacy-bot");
 
     try {
       expect(() => resolveTransportConfig()).toThrow(
@@ -258,7 +257,7 @@ describe("HttpDeliverySource", () => {
       deliveryId: "dlv_9",
       turnId: "turn_9",
       eventId: "evt_9",
-      botName: "opentagbot",
+      channelName: "opentagbot",
       platform: "slack",
       text: "hello",
       route: { teamId: "T1" },
@@ -342,7 +341,7 @@ describe("HttpDeliverySource", () => {
       deliveryId: "dlv_9",
       turnId: "turn_9",
       eventId: "evt_command",
-      botName: "opentagbot",
+      channelName: "opentagbot",
       platform: "slack",
       command: "/opentagbot",
       text: "summarize this channel",
@@ -387,7 +386,7 @@ describe("HttpDeliverySource", () => {
       deliveryId: "dlv_9",
       turnId: "turn_9",
       eventId: "evt_reaction",
-      botName: "opentagbot",
+      channelName: "opentagbot",
       platform: "slack",
       rawEmoji: "thumbsup",
       added: true,
@@ -433,7 +432,7 @@ describe("HttpDeliverySource", () => {
       deliveryId: "dlv_9",
       turnId: "turn_9",
       eventId: "evt_interaction",
-      botName: "opentagbot",
+      channelName: "opentagbot",
       platform: "slack",
       actionId: "ck:confirm_write:approve",
       value: { confirmed: true },

--- a/packages/channels-intelligence/src/http-transports.ts
+++ b/packages/channels-intelligence/src/http-transports.ts
@@ -823,7 +823,7 @@ interface RenderAcceptedResponse {
  * @internal {@link RenderEventSink} that streams semantic render frames to
  * Intelligence's durable render-acceptance route
  * (`/api/channels/deliveries/:id/render-events/accept`). This is the HTTP-path
- * equivalent of the realtime {@link PhoenixRealtimeTransport}: each frame is
+ * equivalent of the realtime {@link RealtimeGatewayTransport}: each frame is
  * POSTed and the durable acceptance receipt is awaited before the next. The
  * gateway-side Connector Outbox then renders the accepted frames to Slack, so
  * this path reaches full reply-UX parity without a running realtime gateway.

--- a/packages/channels-intelligence/src/http-transports.ts
+++ b/packages/channels-intelligence/src/http-transports.ts
@@ -44,8 +44,8 @@ export interface IntelligenceTransportConfig {
   baseUrl: string;
   /** Project runtime API key (`cpk-…`), sent as `Authorization: Bearer`. */
   apiKey: string;
-  /** Project-unique bot name; matches `createBot({ name })`. */
-  botName: string;
+  /** Project-unique channel name; defaults from `createBot({ name })`. */
+  channelName: string;
   /** Stable runtime instance id (`rti_…`); generated when omitted. */
   runtimeInstanceId: string;
   /** Adapter kind. First slice is `"slack"`. */
@@ -70,7 +70,8 @@ export interface IntelligenceTransportConfig {
 /**
  * Resolve transport config from explicit overrides then environment, failing
  * loudly if a required field is missing. Env: `COPILOTKIT_INTELLIGENCE_URL`,
- * `COPILOTKIT_API_KEY`, `COPILOTKIT_BOT_NAME`, `COPILOTKIT_RUNTIME_INSTANCE_ID`.
+ * `COPILOTKIT_API_KEY`, `COPILOTKIT_CHANNEL_NAME`,
+ * `COPILOTKIT_RUNTIME_INSTANCE_ID`.
  */
 export function resolveTransportConfig(
   overrides: Partial<IntelligenceTransportConfig> = {},
@@ -83,7 +84,7 @@ export function resolveTransportConfig(
     overrides.baseUrl ?? env["COPILOTKIT_INTELLIGENCE_URL"]
   )?.replace(/\/+$/, "");
   const apiKey = overrides.apiKey ?? env["COPILOTKIT_API_KEY"];
-  const botName = overrides.botName ?? env["COPILOTKIT_BOT_NAME"];
+  const channelName = overrides.channelName ?? env["COPILOTKIT_CHANNEL_NAME"];
   const runtimeInstanceId =
     overrides.runtimeInstanceId ??
     env["COPILOTKIT_RUNTIME_INSTANCE_ID"] ??
@@ -93,8 +94,8 @@ export function resolveTransportConfig(
   const missing: string[] = [];
   if (!baseUrl) missing.push("baseUrl (COPILOTKIT_INTELLIGENCE_URL)");
   if (!apiKey) missing.push("apiKey (COPILOTKIT_API_KEY)");
-  if (!botName)
-    missing.push("botName (createBot({ name }) / COPILOTKIT_BOT_NAME)");
+  if (!channelName)
+    missing.push("channelName (createBot({ name }) / COPILOTKIT_CHANNEL_NAME)");
   if (missing.length > 0) {
     throw new Error(
       `intelligenceAdapter: missing required transport config: ${missing.join(", ")}`,
@@ -104,7 +105,7 @@ export function resolveTransportConfig(
   return {
     baseUrl: baseUrl!,
     apiKey: apiKey!,
-    botName: botName!,
+    channelName: channelName!,
     runtimeInstanceId,
     adapter,
     fetch: overrides.fetch,
@@ -167,7 +168,7 @@ interface ClaimedDelivery {
   id: string;
   organizationId: string;
   projectId: number;
-  bot: { id: string; name: string };
+  channel: { id: string; name: string };
   adapter: string;
   leaseToken: string;
   turn: {
@@ -211,12 +212,12 @@ interface ClaimedDelivery {
   };
 }
 
-/** Per-delivery org/project/bot scope, echoed onto render frames. */
+/** Per-delivery org/project/channel scope, echoed onto render frames. */
 export interface DeliveryScope {
   organizationId: string;
   projectId: number;
-  botId: string;
-  botName: string;
+  channelId: string;
+  channelName: string;
 }
 
 type ClaimResponse =
@@ -273,7 +274,9 @@ function mapDeliveryToEnvelope(d: ClaimedDelivery): ManagedIngressEnvelope {
     deliveryId: d.id,
     eventId: d.turn.eventId,
     turnId: d.turn.id,
-    botName: d.bot.name,
+    // `ManagedIngressEnvelope` remains aligned with the channels framework's
+    // Bot object; only the Intelligence HTTP wire contract calls this a channel.
+    botName: d.channel.name,
     platform: d.adapter,
     conversationKey: conversationKeyFromReplyTarget(d.turn.replyTarget),
     route: d.turn.replyTarget,
@@ -359,11 +362,13 @@ export class HttpDeliverySource implements DeliverySource {
     return (this.cfg.sleep ?? defaultSleep)(ms);
   }
 
-  /** Declare this runtime + bot to Intelligence and keep the activation fresh. */
+  /** Declare this runtime + channel to Intelligence and keep the activation fresh. */
   async heartbeat(): Promise<void> {
-    await this.http.post("/api/bots/listener/heartbeat", {
+    await this.http.post("/api/channels/listener/heartbeat", {
       runtimeInstanceId: this.cfg.runtimeInstanceId,
-      declaredBots: [{ botName: this.cfg.botName, adapter: this.cfg.adapter }],
+      declaredChannels: [
+        { channelName: this.cfg.channelName, adapter: this.cfg.adapter },
+      ],
       observedAt: new Date().toISOString(),
     });
     this.lastHeartbeatAt = Date.now();
@@ -374,7 +379,7 @@ export class HttpDeliverySource implements DeliverySource {
     { env: ManagedIngressEnvelope } | { pollAfterMs: number }
   > {
     const res = await this.http.post<ClaimResponse>(
-      "/api/bots/listener/claim",
+      "/api/channels/listener/claim",
       {
         runtimeInstanceId: this.cfg.runtimeInstanceId,
         adapters: [this.cfg.adapter],
@@ -387,8 +392,8 @@ export class HttpDeliverySource implements DeliverySource {
       scope: {
         organizationId: res.delivery.organizationId,
         projectId: res.delivery.projectId,
-        botId: res.delivery.bot.id,
-        botName: res.delivery.bot.name,
+        channelId: res.delivery.channel.id,
+        channelName: res.delivery.channel.name,
       },
     });
     try {
@@ -416,7 +421,7 @@ export class HttpDeliverySource implements DeliverySource {
     }
   }
 
-  /** The org/project/bot scope for a leased delivery, for render-frame egress. */
+  /** The org/project/channel scope for a leased delivery, for render-frame egress. */
   scopeFor(deliveryId: string): DeliveryScope | undefined {
     return this.leases.get(deliveryId)?.scope;
   }
@@ -492,7 +497,7 @@ export class HttpDeliverySource implements DeliverySource {
     // other sees none and no-ops — exactly one of ack XOR fail reaches app-api.
     this.leases.delete(deliveryId);
     await this.http.post(
-      `/api/bots/deliveries/${encodeURIComponent(deliveryId)}/ack`,
+      `/api/channels/deliveries/${encodeURIComponent(deliveryId)}/ack`,
       {
         turnId: lease.turnId,
         runtimeInstanceId: this.cfg.runtimeInstanceId,
@@ -515,7 +520,7 @@ export class HttpDeliverySource implements DeliverySource {
     // Delete-before-POST for the same reason as `ack`: single terminal signal.
     this.leases.delete(deliveryId);
     await this.http.post(
-      `/api/bots/deliveries/${encodeURIComponent(deliveryId)}/fail`,
+      `/api/channels/deliveries/${encodeURIComponent(deliveryId)}/fail`,
       {
         turnId: lease.turnId,
         runtimeInstanceId: this.cfg.runtimeInstanceId,
@@ -545,7 +550,7 @@ export class HttpDeliverySource implements DeliverySource {
         "intelligenceAdapter: no global fetch available for file download",
       );
     }
-    const url = `${this.cfg.baseUrl}/api/bots/files/${encodeURIComponent(handle)}`;
+    const url = `${this.cfg.baseUrl}/api/channels/files/${encodeURIComponent(handle)}`;
     const res = await gfetch(url, {
       method: "GET",
       headers: { authorization: `Bearer ${this.cfg.apiKey}` },
@@ -567,7 +572,7 @@ export class HttpDeliverySource implements DeliverySource {
   }
 
   /**
-   * Fetch prior thread turns from app-api's bot history route for
+   * Fetch prior thread turns from app-api's channel history route for
    * conversation-history seeding (parity with bot-slack/bot-discord/
    * bot-whatsapp's reconstructed-history conversation stores). A root-level
    * turn (no `threadTs`) has no prior thread to look up, so this returns `[]`
@@ -601,7 +606,7 @@ export class HttpDeliverySource implements DeliverySource {
         threadTs: rt.threadTs,
         limit: String(limit),
       });
-      const url = `${this.cfg.baseUrl}/api/bots/history?${qs.toString()}`;
+      const url = `${this.cfg.baseUrl}/api/channels/history?${qs.toString()}`;
       const res = await gfetch(url, {
         method: "GET",
         headers: { authorization: `Bearer ${this.cfg.apiKey}` },
@@ -684,7 +689,7 @@ export class HttpDeliverySource implements DeliverySource {
     const qs = new URLSearchParams({ filename: args.filename });
     if (args.title) qs.set("title", args.title);
     if (args.altText) qs.set("altText", args.altText);
-    const url = `${this.cfg.baseUrl}/api/bots/deliveries/${encodeURIComponent(
+    const url = `${this.cfg.baseUrl}/api/channels/deliveries/${encodeURIComponent(
       deliveryId,
     )}/files?${qs.toString()}`;
     const res = await gfetch(url, {
@@ -739,9 +744,9 @@ export class HttpEgressSink implements EgressSink {
 
     try {
       const res = await this.http.post<EgressResponse>(
-        "/api/bots/egress/messages",
+        "/api/channels/egress/messages",
         {
-          botName: this.cfg.botName,
+          channelName: this.cfg.channelName,
           adapter: this.cfg.adapter,
           deliveryId: op.deliveryId,
           idempotencyKey: op.operationId,
@@ -772,13 +777,13 @@ interface RenderAcceptedResponse {
 /**
  * @internal {@link RenderEventSink} that streams semantic render frames to
  * Intelligence's durable render-acceptance route
- * (`/api/bots/deliveries/:id/render-events/accept`). This is the HTTP-path
+ * (`/api/channels/deliveries/:id/render-events/accept`). This is the HTTP-path
  * equivalent of the realtime {@link PhoenixRealtimeTransport}: each frame is
  * POSTed and the durable acceptance receipt is awaited before the next. The
  * gateway-side Connector Outbox then renders the accepted frames to Slack, so
  * this path reaches full reply-UX parity without a running realtime gateway.
  *
- * Per-delivery org/project/bot scope is read from the {@link HttpDeliverySource}
+ * Per-delivery org/project/channel scope is read from the {@link HttpDeliverySource}
  * that leased the delivery (populated at claim). The `deliveryId` travels in the
  * URL only — the accept route rejects a body that also carries it.
  */
@@ -809,12 +814,12 @@ export class HttpRenderEventSink implements RenderEventSink {
     const leaseToken = this.scopeSource.leaseTokenFor(frame.deliveryId);
     const idempotencyKey = `${frame.turnId}:${frame.slot}:${frame.seq}`;
     const res = await this.http.post<RenderAcceptedResponse>(
-      `/api/bots/deliveries/${encodeURIComponent(frame.deliveryId)}/render-events/accept`,
+      `/api/channels/deliveries/${encodeURIComponent(frame.deliveryId)}/render-events/accept`,
       {
         organizationId: scope.organizationId,
         projectId: scope.projectId,
-        botId: scope.botId,
-        botName: scope.botName,
+        channelId: scope.channelId,
+        channelName: scope.channelName,
         turnId: frame.turnId,
         runtimeInstanceId: this.cfg.runtimeInstanceId,
         slot: frame.slot,

--- a/packages/channels-intelligence/src/http-transports.ts
+++ b/packages/channels-intelligence/src/http-transports.ts
@@ -6,8 +6,9 @@ import type {
   AgentMessage,
 } from "./transports.js";
 import type {
-  ManagedIngressEnvelope,
-  ManagedFileRef,
+  ChannelIngressEnvelope,
+  ChannelDeliveryScope,
+  ChannelFileRef,
   EgressRoute,
   EgressOperation,
   EgressResult,
@@ -177,7 +178,7 @@ interface TeamsReplyTarget {
 
 /**
  * The claim's reply target is provider-tagged (Intelligence app-api mints a
- * discriminated union — one managed runtime serves every channel its bot has
+ * discriminated union — one Channel runtime serves every channel its framework Bot has
  * attached now that claims are provider-agnostic).
  */
 type ReplyTarget = SlackReplyTarget | TeamsReplyTarget;
@@ -196,10 +197,10 @@ interface ClaimedDelivery {
     replyTarget: ReplyTarget;
     // NB: there is intentionally no `thread_started` variant here — the claim
     // path only carries turn/command/reaction/interaction. `thread_started`
-    // envelopes originate on the realtime/Phoenix path, not from `claim`, so a
+    // envelopes originate on the realtime gateway path, not from `claim`, so a
     // claimed delivery never maps to `kind:"thread_started"`.
     input?:
-      | { kind: "text"; text?: string; files?: ManagedFileRef[] }
+      | { kind: "text"; text?: string; files?: ChannelFileRef[] }
       | {
           kind: "command";
           command: string;
@@ -232,13 +233,6 @@ interface ClaimedDelivery {
 }
 
 /** Per-delivery org/project/channel scope, echoed onto render frames. */
-export interface DeliveryScope {
-  organizationId: string;
-  projectId: number;
-  channelId: string;
-  channelName: string;
-}
-
 type ClaimResponse =
   | { claimed: false; pollAfterMs: number }
   | { claimed: true; delivery: ClaimedDelivery };
@@ -309,14 +303,14 @@ function conversationKeyFromReplyTarget(rt: ReplyTarget): string {
   }
 }
 
-function mapDeliveryToEnvelope(d: ClaimedDelivery): ManagedIngressEnvelope {
+function mapDeliveryToEnvelope(d: ClaimedDelivery): ChannelIngressEnvelope {
   const base = {
     deliveryId: d.id,
     eventId: d.turn.eventId,
     turnId: d.turn.id,
-    // `ManagedIngressEnvelope` remains aligned with the channels framework's
+    // `ChannelIngressEnvelope` remains aligned with the channels framework's
     // Bot object; only the Intelligence HTTP wire contract calls this a channel.
-    botName: d.channel.name,
+    channelName: d.channel.name,
     platform: d.adapter,
     conversationKey: conversationKeyFromReplyTarget(d.turn.replyTarget),
     route: d.turn.replyTarget,
@@ -378,7 +372,7 @@ function mapDeliveryToEnvelope(d: ClaimedDelivery): ManagedIngressEnvelope {
 interface LeaseRecord {
   turnId: string;
   leaseToken: string;
-  scope: DeliveryScope;
+  scope: ChannelDeliveryScope;
 }
 
 /**
@@ -416,12 +410,12 @@ export class HttpDeliverySource implements DeliverySource {
 
   /** Claim a single delivery; returns the mapped envelope, or the idle backoff. */
   async claimOnce(): Promise<
-    { env: ManagedIngressEnvelope } | { pollAfterMs: number }
+    { env: ChannelIngressEnvelope } | { pollAfterMs: number }
   > {
     const res = await this.http.post<ClaimResponse>(
       "/api/channels/listener/claim",
       {
-        // Claim provider-agnostically: the managed runtime emits abstract render
+        // Claim provider-agnostically: the Channel runtime emits abstract render
         // frames and Intelligence renders per the delivery's own reply target, so
         // a single runtime serves every channel its bot has attached (Slack,
         // Teams, ...). Declaring a single adapter here made Intelligence withhold
@@ -467,7 +461,7 @@ export class HttpDeliverySource implements DeliverySource {
   }
 
   /** The org/project/channel scope for a leased delivery, for render-frame egress. */
-  scopeFor(deliveryId: string): DeliveryScope | undefined {
+  scopeFor(deliveryId: string): ChannelDeliveryScope | undefined {
     return this.leases.get(deliveryId)?.scope;
   }
 
@@ -478,7 +472,7 @@ export class HttpDeliverySource implements DeliverySource {
   }
 
   async start(
-    onDelivery: (env: ManagedIngressEnvelope) => Promise<void>,
+    onDelivery: (env: ChannelIngressEnvelope) => Promise<void>,
   ): Promise<void> {
     this.running = true;
     await this.heartbeat();
@@ -486,7 +480,7 @@ export class HttpDeliverySource implements DeliverySource {
   }
 
   private async runLoop(
-    onDelivery: (env: ManagedIngressEnvelope) => Promise<void>,
+    onDelivery: (env: ChannelIngressEnvelope) => Promise<void>,
   ): Promise<void> {
     const cadence = this.cfg.heartbeatIntervalMs ?? 15000;
     while (this.running) {
@@ -663,7 +657,7 @@ export class HttpDeliverySource implements DeliverySource {
           // called out distinctly — surface it loudly so it doesn't hide
           // forever behind the best-effort degrade-to-`[]` below.
           this.cfg.log?.(
-            `[intelligence] getHistory ${res.status} for thread history — likely a misconfigured/unauthorized history endpoint (baseUrl/route/apiKey); managed bot will run WITHOUT prior-turn history`,
+            `[intelligence] getHistory ${res.status} for thread history — likely a misconfigured/unauthorized history endpoint (baseUrl/route/apiKey); Channel Bot will run WITHOUT prior-turn history`,
           );
         } else {
           // Transient (5xx/429) — quiet best-effort degradation, history is
@@ -677,7 +671,7 @@ export class HttpDeliverySource implements DeliverySource {
           id: string;
           role: "user" | "assistant";
           text: string;
-          files?: ManagedFileRef[];
+          files?: ChannelFileRef[];
         }>;
       };
       const out: AgentMessage[] = [];
@@ -838,7 +832,7 @@ export class HttpRenderEventSink implements RenderEventSink {
   constructor(
     private readonly cfg: IntelligenceTransportConfig,
     private readonly scopeSource: {
-      scopeFor(deliveryId: string): DeliveryScope | undefined;
+      scopeFor(deliveryId: string): ChannelDeliveryScope | undefined;
       leaseTokenFor(deliveryId: string): string | undefined;
     },
   ) {

--- a/packages/channels-intelligence/src/in-memory-transports.ts
+++ b/packages/channels-intelligence/src/in-memory-transports.ts
@@ -5,7 +5,7 @@ import type {
   AgentMessage,
 } from "./transports.js";
 import type {
-  ManagedIngressEnvelope,
+  ChannelIngressEnvelope,
   EgressRoute,
   EgressOperation,
   EgressResult,
@@ -65,13 +65,13 @@ export class InMemoryDeliverySource implements DeliverySource {
    */
   history: AgentMessage[] = [];
   /** Every `getHistory` call, in order — asserts the adapter unwraps the
-   * `ManagedReplyTarget` to the raw route and threads `historyLimit` through. */
+   * `ChannelReplyTarget` to the raw route and threads `historyLimit` through. */
   readonly historyRequests: Array<{ replyTarget: EgressRoute; limit: number }> =
     [];
-  private onDelivery?: (env: ManagedIngressEnvelope) => Promise<void>;
+  private onDelivery?: (env: ChannelIngressEnvelope) => Promise<void>;
 
   async start(
-    onDelivery: (env: ManagedIngressEnvelope) => Promise<void>,
+    onDelivery: (env: ChannelIngressEnvelope) => Promise<void>,
   ): Promise<void> {
     this.onDelivery = onDelivery;
   }
@@ -80,7 +80,7 @@ export class InMemoryDeliverySource implements DeliverySource {
    * Push an envelope through the bound adapter. Resolves after the full
    * dispatch (handler + ack/nack) completes, so tests can assert synchronously.
    */
-  async deliver(env: ManagedIngressEnvelope): Promise<void> {
+  async deliver(env: ChannelIngressEnvelope): Promise<void> {
     if (!this.onDelivery) {
       throw new Error(
         "InMemoryDeliverySource: not started — call bot.start() first",

--- a/packages/channels-intelligence/src/index.ts
+++ b/packages/channels-intelligence/src/index.ts
@@ -1,7 +1,7 @@
-// @copilotkit/channels-intelligence — Intelligence-delivered managed-bot adapter for
+// @copilotkit/channels-intelligence — Intelligence-delivered Channel adapter for
 // @copilotkit/channels. Bridges Intelligence-delivered ingress to bot core and emits
 // generic egress operations over injectable transports. Not a publicly
-// documented API; consumed by the runtime/managed-listener bootstrap and the
+// documented API; consumed by the runtime/Channel-listener bootstrap and the
 // Intelligence side.
 
 export {
@@ -20,14 +20,15 @@ export type {
 } from "./transports.js";
 
 export type {
-  ManagedIngressBase,
-  ManagedIngressEnvelope,
+  ChannelIngressBase,
+  ChannelIngressEnvelope,
+  ChannelDeliveryScope,
   EgressOperation,
   EgressOp,
   EgressResult,
   EgressRoute,
-  HostedBotRenderEvent,
-  HostedBotRenderEventKind,
+  ChannelRenderEvent,
+  ChannelRenderEventKind,
   RenderFrame,
   RenderAccepted,
 } from "./contracts.js";
@@ -40,11 +41,11 @@ export {
 
 // Realtime Gateway transport — the production render/delivery path
 // (OSS-402). Undocumented like the rest of the package; exported for the
-// managed-listener bootstrap and tests.
+// Channel-listener bootstrap and tests.
 export { RealtimeGatewayTransport } from "./realtime-gateway-transport.js";
 export type {
   RealtimeGatewayTransportOptions,
-  HostedBotRealtimeScope,
+  ChannelRealtimeScope,
 } from "./realtime-gateway-transport.js";
 export { connectRealtimeGateway } from "./realtime-gateway.js";
 export type {
@@ -52,8 +53,8 @@ export type {
   RealtimeGatewaySession,
   ConnectedRealtimeGatewaySession,
 } from "./realtime-gateway.js";
-// The managed-over-Realtime-Gateway launcher (OSS-406): the composition that
-// runs a managed channel over the realtime path.
+// The Channel-over-Realtime-Gateway launcher (OSS-406): the composition that
+// runs a Channel over the realtime path.
 export {
   startChannelsOverRealtimeGateway,
   startChannelsWithGatewaySession,
@@ -79,14 +80,14 @@ export type {
 export { irToText } from "./ir-to-text.js";
 
 export {
-  startManagedBots,
-  assertValidBotNames,
-  buildActivationMetadata,
+  startChannels,
+  assertValidChannelNames,
+  buildChannelActivationMetadata,
 } from "./runtime.js";
 export type {
-  ManagedTransport,
-  ManagedBotsHandle,
-  StartManagedBotsOptions,
-  ActivationEnv,
-  ActivationMetadata,
+  ChannelTransport,
+  ChannelsHandle,
+  StartChannelsOptions,
+  ChannelActivationEnv,
+  ChannelActivationMetadata,
 } from "./runtime.js";

--- a/packages/channels-intelligence/src/index.ts
+++ b/packages/channels-intelligence/src/index.ts
@@ -38,30 +38,30 @@ export {
   InMemoryRenderEventSink,
 } from "./in-memory-transports.js";
 
-// Realtime-gateway (Phoenix) transport — the production render/delivery path
+// Realtime Gateway transport — the production render/delivery path
 // (OSS-402). Undocumented like the rest of the package; exported for the
 // managed-listener bootstrap and tests.
-export { PhoenixRealtimeTransport } from "./phoenix-transport.js";
+export { RealtimeGatewayTransport } from "./realtime-gateway-transport.js";
 export type {
-  PhoenixTransportConfig,
-  HostedBotChannel,
+  RealtimeGatewayTransportOptions,
   HostedBotRealtimeScope,
-} from "./phoenix-transport.js";
-export { connectPhoenixHostedBotChannel } from "./phoenix-channel.js";
+} from "./realtime-gateway-transport.js";
+export { connectRealtimeGateway } from "./realtime-gateway.js";
 export type {
-  PhoenixConnectConfig,
-  ConnectedHostedBotChannel,
-} from "./phoenix-channel.js";
-// The managed-over-Phoenix launcher (OSS-406): the composition that runs a
-// managed bot over the realtime path (connect → transport → startManagedBots).
+  ConnectRealtimeGatewayOptions,
+  RealtimeGatewaySession,
+  ConnectedRealtimeGatewaySession,
+} from "./realtime-gateway.js";
+// The managed-over-Realtime-Gateway launcher (OSS-406): the composition that
+// runs a managed channel over the realtime path.
 export {
-  startManagedBotsOverPhoenix,
-  startManagedBotsOnChannel,
-} from "./phoenix-launcher.js";
+  startChannelsOverRealtimeGateway,
+  startChannelsWithGatewaySession,
+} from "./realtime-gateway-launcher.js";
 export type {
-  ManagedPhoenixConfig,
-  ManagedBotsOnChannelOptions,
-} from "./phoenix-launcher.js";
+  StartChannelsOverRealtimeGatewayOptions,
+  StartChannelsWithGatewaySessionOptions,
+} from "./realtime-gateway-launcher.js";
 
 // Undocumented fallbacks: the default HTTP transports + config resolver that
 // `intelligenceAdapter()` builds when no transports are injected. Not a public

--- a/packages/channels-intelligence/src/intelligence-adapter.test.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.test.ts
@@ -544,7 +544,7 @@ describe("intelligenceAdapter — default store resolution", () => {
 
     expect(adapter.stateStore).toBeInstanceOf(IntelligenceStateStore);
     await adapter.stateStore!.kv.get("k");
-    expect(calls[0]).toBe("http://intel.test/api/bots/kv/get");
+    expect(calls[0]).toBe("http://intel.test/api/channels/kv/get");
   });
 
   it("skips the default store when in-memory transports are injected", () => {

--- a/packages/channels-intelligence/src/intelligence-adapter.test.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.test.ts
@@ -11,17 +11,17 @@ import {
 import { IntelligenceStateStore } from "./intelligence-state-store.js";
 import type { FetchLike } from "./http-transports.js";
 import type {
-  ManagedIngressEnvelope,
-  ManagedIngressBase,
+  ChannelIngressEnvelope,
+  ChannelIngressBase,
 } from "./contracts.js";
 
-type TurnEnvelope = Extract<ManagedIngressEnvelope, { kind: "turn" }>;
-function envelope(partial?: Partial<TurnEnvelope>): ManagedIngressEnvelope {
+type TurnEnvelope = Extract<ChannelIngressEnvelope, { kind: "turn" }>;
+function envelope(partial?: Partial<TurnEnvelope>): ChannelIngressEnvelope {
   return {
     deliveryId: "d1",
     eventId: "e1",
     turnId: "t1",
-    botName: "support",
+    channelName: "support",
     platform: "slack",
     conversationKey: "c1",
     kind: "turn",
@@ -32,7 +32,7 @@ function envelope(partial?: Partial<TurnEnvelope>): ManagedIngressEnvelope {
 }
 
 describe("intelligenceAdapter — ingress dispatch", () => {
-  it("dispatches a managed turn to the handler and emits a post egress op", async () => {
+  it("dispatches a channel turn to the handler and emits a post egress op", async () => {
     const source = new InMemoryDeliverySource();
     const egress = new InMemoryEgressSink();
     const bot = createBot({
@@ -242,7 +242,7 @@ describe("intelligenceAdapter — deterministic egress ids", () => {
     expect(egress.ops.map((o) => o.operationId)).toEqual(["t1:0", "t1:1"]);
 
     // Crash-before-ack redelivery: same turn id (and event id), new delivery id.
-    // The handler re-runs (no ingress dedup on the managed path) and re-emits
+    // The handler re-runs (no ingress dedup on the Channel path) and re-emits
     // the SAME op ids, so the Connector Outbox can dedupe the Slack output.
     egress.ops.length = 0;
     await source.deliver(envelope({ turnId: "t1", deliveryId: "d2" }));
@@ -281,11 +281,11 @@ describe("intelligenceAdapter — run renderer", () => {
 });
 
 describe("intelligenceAdapter — all ingress kinds route to bot core", () => {
-  const base: ManagedIngressBase = {
+  const base: ChannelIngressBase = {
     deliveryId: "d1",
     eventId: "e1",
     turnId: "t1",
-    botName: "support",
+    channelName: "support",
     platform: "slack",
     conversationKey: "c1",
     route: { r: 1 },
@@ -429,7 +429,7 @@ describe("intelligenceAdapter — exclusivity (V1)", () => {
     ).toThrow(/only adapter|alternative modes/i);
   });
 
-  it("rejects adding a second adapter to a managed bot", () => {
+  it("rejects adding a second adapter to a Channel Bot", () => {
     const bot = createBot({ adapters: [ia()], agent: () => new FakeAgent() });
     expect(() => bot.addAdapter(new FakeAdapter())).toThrow(
       /only adapter|alternative modes/i,
@@ -474,7 +474,7 @@ describe("intelligenceAdapter — conversation-history seeding", () => {
     expect(agent.messages).toEqual(source.history);
   });
 
-  it("unwraps the ManagedReplyTarget to the raw route and defaults historyLimit to 20", async () => {
+  it("unwraps the ChannelReplyTarget to the raw route and defaults historyLimit to 20", async () => {
     const source = new InMemoryDeliverySource();
     const adapter = intelligenceAdapter({
       source,

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -25,10 +25,10 @@ import type {
   AgentMessage,
 } from "./transports.js";
 import type {
-  ManagedIngressEnvelope,
+  ChannelIngressEnvelope,
   EgressOp,
   EgressOperation,
-  HostedBotRenderEvent,
+  ChannelRenderEvent,
   RenderFrame,
   RenderAccepted,
 } from "./contracts.js";
@@ -43,14 +43,14 @@ import { IntelligenceStateStore } from "./intelligence-state-store.js";
 import { buildContentParts } from "./content-parts.js";
 
 /** Reply target the adapter mints during ingress and threads back to egress. */
-interface ManagedReplyTarget {
+interface ChannelReplyTarget {
   route: unknown;
   turnId: string;
   deliveryId: string;
 }
 
 /** Recover the routing a minted {@link MessageRef} carries (for update/delete). */
-function targetFromRef(ref: MessageRef): ManagedReplyTarget {
+function targetFromRef(ref: MessageRef): ChannelReplyTarget {
   if (ref.__deliveryId === undefined || ref.__turnId === undefined) {
     // A ref without stamped routing can't address an update/delete egress op.
     // This happens when a handler updates a ref that carries no delivery routing
@@ -119,18 +119,18 @@ export interface IntelligenceAdapterOptions {
 /**
  * @internal Not a publicly documented API.
  *
- * Bridges Intelligence-delivered managed ingress to bot core and emits generic
+ * Bridges Intelligence-delivered Channel ingress to the framework Bot core and emits generic
  * egress operations — pure plumbing over the injected {@link DeliverySource} /
  * {@link EgressSink}, with no Slack/Intelligence credentials. Production wires
  * the Realtime Gateway + Connector Outbox transports; tests/headless runs wire
- * in-memory ones. Must be the only adapter on a bot (V1).
+ * in-memory ones. Must be the only adapter on a framework Bot (V1).
  */
 export class IntelligenceAdapter implements PlatformAdapter {
   readonly platform = "intelligence";
-  /** Marks this as the managed adapter (exclusivity guard + dedup opt-out). */
-  readonly __managed = true;
+  /** Marks this as the Intelligence Channel adapter (exclusivity guard + dedup opt-out). */
+  readonly __intelligenceChannel = true;
   /**
-   * Managed delivery is at-least-once and idempotency is enforced at egress
+   * Channel delivery is at-least-once and idempotency is enforced at egress
    * (deterministic operation ids → Connector Outbox dedupe), so bot core must
    * NOT drop redeliveries at ingress — that would lose a legitimate retry.
    */
@@ -151,12 +151,12 @@ export class IntelligenceAdapter implements PlatformAdapter {
   };
 
   /**
-   * Seeds a fresh agent's `messages` from the managed transport's conversation
+   * Seeds a fresh agent's `messages` from the Channel transport's conversation
    * history (parity with bot-slack/bot-discord/bot-whatsapp, whose stores
    * rebuild `agent.messages` from platform history every turn) — an arrow
    * function property so `this` resolves to the adapter instance (not this
    * object literal) when bot core calls `adapter.conversationStore.getOrCreate(…)`.
-   * `replyTarget` here is the {@link ManagedReplyTarget} bot core threads
+   * `replyTarget` here is the {@link ChannelReplyTarget} framework core threads
    * through from `dispatchTo`; `.route` is the opaque {@link EgressRoute} the
    * transport actually needs. Best-effort: `getHistory` degrading to `[]` (no
    * transport support, or a fetch failure) just means the turn starts fresh.
@@ -164,7 +164,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
   readonly conversationStore: ConversationStore = {
     getOrCreate: async (conversationKey, replyTarget, makeAgent) => {
       const agent = makeAgent(conversationKey);
-      const route = (replyTarget as ManagedReplyTarget).route;
+      const route = (replyTarget as ChannelReplyTarget).route;
       let history: AgentMessage[] = [];
       try {
         history =
@@ -192,7 +192,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
     },
   };
 
-  /** Persistence supplied by the managed transport (Intelligence-backed); picked
+  /** Persistence supplied by the Channel transport (Intelligence-backed); picked
    * up by createBot's `resolveBackend` when no explicit `store.adapter` is set. */
   readonly stateStore?: StateStore;
 
@@ -212,7 +212,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
     this.source = opts.source;
     this.egress = opts.egress;
     this.renderSink = opts.renderSink;
-    // Default to the Intelligence-backed durable KV store so managed bots
+    // Default to the Intelligence-backed durable KV store so Channel Bots
     // persist action-registry snapshots + thread state across restarts (HITL
     // cards survive). Skipped when a store is passed explicitly or when
     // in-memory transports are injected (tests) — a durable store hitting HTTP
@@ -284,7 +284,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
     await this.source?.stop();
   }
 
-  private async dispatch(env: ManagedIngressEnvelope): Promise<void> {
+  private async dispatch(env: ChannelIngressEnvelope): Promise<void> {
     // Reset the per-turn sequence so egress ids are deterministic across
     // redelivery (same turn id -> same op id sequence). Assumes the
     // DeliverySource delivers (and awaits) one envelope per turnId at a time —
@@ -302,15 +302,15 @@ export class IntelligenceAdapter implements PlatformAdapter {
     } finally {
       // Drop the per-turn counter once the turn is fully processed (renderer
       // chain drained inside dispatchTo) so the Map can't grow unbounded over a
-      // long-running managed bot. A redelivery re-seeds it at the top.
+      // long-running Channel Bot. A redelivery re-seeds it at the top.
       this.seq.delete(env.turnId);
     }
   }
 
-  private async dispatchTo(env: ManagedIngressEnvelope): Promise<void> {
+  private async dispatchTo(env: ChannelIngressEnvelope): Promise<void> {
     const sink = this.sink;
     if (!sink) throw new Error("IntelligenceAdapter: not started");
-    const replyTarget: ManagedReplyTarget = {
+    const replyTarget: ChannelReplyTarget = {
       route: env.route,
       turnId: env.turnId,
       deliveryId: env.deliveryId,
@@ -439,7 +439,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
     return seq;
   }
 
-  private mintOp(target: ManagedReplyTarget, op: EgressOp): EgressOperation {
+  private mintOp(target: ChannelReplyTarget, op: EgressOp): EgressOperation {
     const seq = this.nextFrameSeq(target.turnId);
     return {
       operationId: `${target.turnId}:${seq}`,
@@ -457,8 +457,8 @@ export class IntelligenceAdapter implements PlatformAdapter {
    * frame so a later update/delete can re-address it.
    */
   private async postRenderFrame(
-    target: ManagedReplyTarget,
-    event: HostedBotRenderEvent,
+    target: ChannelReplyTarget,
+    event: ChannelRenderEvent,
   ): Promise<MessageRef> {
     const seq = this.nextFrameSeq(target.turnId);
     const receipt = await this.requireRenderSink().push({
@@ -477,7 +477,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
   }
 
   private async emit(
-    target: ManagedReplyTarget,
+    target: ChannelReplyTarget,
     op: EgressOp,
   ): Promise<MessageRef> {
     const operation = this.mintOp(target, op);
@@ -503,12 +503,12 @@ export class IntelligenceAdapter implements PlatformAdapter {
     // Connector Outbox renders full Block Kit (rich JSX preserved). Fallback
     // (no render sink wired — e.g. in-memory tests): the egress op path.
     if (this.renderSink) {
-      return this.postRenderFrame(target as ManagedReplyTarget, {
+      return this.postRenderFrame(target as ChannelReplyTarget, {
         kind: "post",
         content: ir,
       });
     }
-    return this.emit(target as ManagedReplyTarget, { kind: "post", ir });
+    return this.emit(target as ChannelReplyTarget, { kind: "post", ir });
   }
 
   async update(ref: MessageRef, ir: BotNode[]): Promise<void> {
@@ -532,19 +532,19 @@ export class IntelligenceAdapter implements PlatformAdapter {
       altText?: string;
     },
   ): Promise<{ ok: boolean; fileId?: string; error?: string }> {
-    const mt = target as ManagedReplyTarget;
+    const channelTarget = target as ChannelReplyTarget;
     const uploadFile = this.source?.uploadFile?.bind(this.source);
     if (!uploadFile || !this.renderSink) {
       return {
         ok: false,
-        error: "managed adapter: outbound file upload is not available",
+        error: "Channel adapter: outbound file upload is not available",
       };
     }
     try {
       // Stream bytes to app-api first (durable in S3), then emit a `file` frame
       // referencing the handle; the Connector Outbox does the Slack uploadV2.
-      const { handle } = await uploadFile(mt.deliveryId, args);
-      await this.postRenderFrame(mt, {
+      const { handle } = await uploadFile(channelTarget.deliveryId, args);
+      await this.postRenderFrame(channelTarget, {
         kind: "file",
         handle,
         filename: args.filename,
@@ -567,7 +567,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
     // Non-streaming surface: accumulate the full reply and emit one post.
     let acc = "";
     for await (const c of chunks) acc += c;
-    const target = _target as ManagedReplyTarget;
+    const target = _target as ChannelReplyTarget;
     if (this.renderSink) {
       return this.postRenderFrame(target, {
         kind: "post",
@@ -582,7 +582,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
   }
 
   decodeInteraction(_raw: unknown): InteractionEvent | undefined {
-    // TODO(OSS-377): managed interaction decoding.
+    // TODO(OSS-377): Channel interaction decoding.
     return undefined;
   }
 
@@ -599,7 +599,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
    * any un-ended text on `finalize` (the interrupt path) with the interrupted
    * marker.
    */
-  private renderSinkFor(t: ManagedReplyTarget): RenderEventSink {
+  private renderSinkFor(t: ChannelReplyTarget): RenderEventSink {
     if (this.renderSink) return this.renderSink;
     const emit = (op: EgressOp) => this.emit(t, op);
     const acc = new Map<string, string>();
@@ -648,7 +648,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
   }
 
   createRunRenderer(target: ReplyTarget): RunRenderer {
-    const t = target as ManagedReplyTarget;
+    const t = target as ChannelReplyTarget;
     const sink = this.renderSinkFor(t);
     const interruptEventNames = new Set<string>(["on_interrupt"]);
     const capturedToolCalls: CapturedToolCall[] = [];
@@ -666,7 +666,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
     let chain: Promise<void> = Promise.resolve();
     let pushError: unknown;
 
-    const enqueue = (event: HostedBotRenderEvent): void => {
+    const enqueue = (event: ChannelRenderEvent): void => {
       const frame: RenderFrame = {
         deliveryId: t.deliveryId,
         turnId: t.turnId,
@@ -810,7 +810,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
 }
 
 /**
- * @internal Construct the managed bridge adapter. Production callers (the
+ * @internal Construct the Channel bridge adapter. Production callers (the
  * runtime) inject the Realtime Gateway + Connector Outbox transports; tests and
  * standalone runs inject in-memory ones. Must be the only adapter on a bot (V1).
  */

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -101,7 +101,7 @@ export interface IntelligenceAdapterOptions {
   /** Optional Intelligence-backed persistence the adapter exposes as `stateStore`. */
   store?: StateStore;
   /**
-   * Overrides for the default-transport config (baseUrl/apiKey/botName/…).
+   * Overrides for the default-transport config (baseUrl/apiKey/channelName/…).
    * Anything omitted is resolved from env. Ignored when both `source` and
    * `egress` are injected.
    */
@@ -265,7 +265,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
     if (!this.source || !this.egress) {
       const cfg = resolveTransportConfig({
         ...this.opts.config,
-        botName: this.opts.config?.botName ?? ctx?.botName,
+        channelName: this.opts.config?.channelName ?? ctx?.botName,
       });
       const source = (this.source ??= new HttpDeliverySource(cfg));
       this.egress ??= new HttpEgressSink(cfg);

--- a/packages/channels-intelligence/src/intelligence-state-store.test.ts
+++ b/packages/channels-intelligence/src/intelligence-state-store.test.ts
@@ -4,7 +4,7 @@ import { IntelligenceStateStore } from "./intelligence-state-store.js";
 import type { FetchLike } from "./http-transports.js";
 
 /**
- * A fake `/api/bots/kv/*` server over an in-memory Map, honoring TTL the same
+ * A fake `/api/channels/kv/*` server over an in-memory Map, honoring TTL the same
  * way app-api does (lazy expiry on read). Lets the full StateStore conformance
  * suite run against IntelligenceStateStore: `kv` exercises this HTTP layer;
  * list/lock/dedup/queue exercise the delegated in-memory MemoryStore.
@@ -20,7 +20,7 @@ function fakeKvFetch(): FetchLike {
       ttlMs?: number;
     };
     let payload: unknown = { ok: true };
-    if (url.endsWith("/api/bots/kv/get")) {
+    if (url.endsWith("/api/channels/kv/get")) {
       const e = map.get(body.key);
       if (!live(e)) {
         map.delete(body.key);
@@ -28,13 +28,15 @@ function fakeKvFetch(): FetchLike {
       } else {
         payload = { value: e!.value };
       }
-    } else if (url.endsWith("/api/bots/kv/set")) {
+    } else if (url.endsWith("/api/channels/kv/set")) {
       map.set(body.key, {
         value: body.value,
         expiresAt: body.ttlMs ? Date.now() + body.ttlMs : undefined,
       });
-    } else if (url.endsWith("/api/bots/kv/delete")) {
+    } else if (url.endsWith("/api/channels/kv/delete")) {
       map.delete(body.key);
+    } else {
+      throw new Error(`unexpected KV route: ${url}`);
     }
     const text = JSON.stringify(payload);
     return { ok: true, status: 200, text: async () => text };

--- a/packages/channels-intelligence/src/intelligence-state-store.ts
+++ b/packages/channels-intelligence/src/intelligence-state-store.ts
@@ -13,19 +13,19 @@ export interface IntelligenceStateStoreConfig {
 }
 
 /**
- * Durable {@link StateStore} for managed bots, backed by Intelligence app-api's
+ * Durable {@link StateStore} for Channel Bots, backed by Intelligence app-api's
  * runtime-authed KV routes (`/api/channels/kv/*`). Only the `kv` facet is durable —
  * that is what the action registry (button/`ck:` snapshots) and thread state
- * use, so a HITL card posted before a managed-loop restart still re-renders on
+ * use, so a HITL card posted before a Channel-loop restart still re-renders on
  * cold-cache dispatch and can be flipped in place.
  *
  * `list` / `lock` / `dedup` / `queue` delegate to an in-memory
- * {@link MemoryStore}. On the managed Slack path these are not durability
+ * {@link MemoryStore}. On the Channel Slack path these are not durability
  * critical: dedup is skipped at ingress (`adapter.skipIngressDedup`), the
- * per-conversation turn lock is process-local (a single managed runtime; the
+ * per-conversation turn lock is process-local (a single Channel runtime; the
  * app-api delivery lease already fences work cross-instance), and list/queue
  * (transcripts/proactive) are unused. // ponytail: promote these to durable KV
- * only if the managed runtime is ever horizontally scaled.
+ * only if the Channel runtime is ever horizontally scaled.
  */
 export class IntelligenceStateStore implements StateStore {
   private readonly local = new MemoryStore();

--- a/packages/channels-intelligence/src/intelligence-state-store.ts
+++ b/packages/channels-intelligence/src/intelligence-state-store.ts
@@ -14,7 +14,7 @@ export interface IntelligenceStateStoreConfig {
 
 /**
  * Durable {@link StateStore} for managed bots, backed by Intelligence app-api's
- * runtime-authed KV routes (`/api/bots/kv/*`). Only the `kv` facet is durable —
+ * runtime-authed KV routes (`/api/channels/kv/*`). Only the `kv` facet is durable —
  * that is what the action registry (button/`ck:` snapshots) and thread state
  * use, so a HITL card posted before a managed-loop restart still re-renders on
  * cold-cache dispatch and can be flipped in place.
@@ -71,7 +71,7 @@ export class IntelligenceStateStore implements StateStore {
      * the StateStore contract's `undefined`. */
     get: async <T>(key: string): Promise<T | undefined> => {
       const { value } = await this.post<{ value: T | null }>(
-        "/api/bots/kv/get",
+        "/api/channels/kv/get",
         { key },
       );
       // app-api returns `null` for a missing/expired key; normalize to the
@@ -82,7 +82,7 @@ export class IntelligenceStateStore implements StateStore {
     },
     /** Write a durable key, optionally with a TTL in ms (omitted → no expiry). */
     set: async <T>(key: string, value: T, ttlMs?: number): Promise<void> => {
-      await this.post("/api/bots/kv/set", {
+      await this.post("/api/channels/kv/set", {
         key,
         value,
         // `!== undefined` (not truthiness) so an explicit `ttlMs: 0` is still
@@ -92,7 +92,7 @@ export class IntelligenceStateStore implements StateStore {
     },
     /** Delete a durable key (no-op if absent). */
     delete: async (key: string): Promise<void> => {
-      await this.post("/api/bots/kv/delete", { key });
+      await this.post("/api/channels/kv/delete", { key });
     },
   };
 

--- a/packages/channels-intelligence/src/ir-to-text.ts
+++ b/packages/channels-intelligence/src/ir-to-text.ts
@@ -5,7 +5,7 @@ import type { BotNode } from "@copilotkit/channels-ui";
  * first slice, which accepts a plain `text` field only (Intelligence owns the
  * native platform rendering later via per-platform codecs — OSS-363/OSS-377).
  *
- * The dominant managed path — streamed agent text — is already a single
+ * The dominant Channel path — streamed agent text — is already a single
  * `{ type: "text", props: { value } }` node (see {@link IntelligenceAdapter}'s
  * run renderer), so this is usually a no-op concat. Richer IR (sections, lists)
  * is best-effort flattened by concatenating descendant text; formatting is lost

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.test.ts
@@ -2,30 +2,30 @@ import { describe, it, expect } from "vitest";
 import { createBot, FakeAgent } from "@copilotkit/channels";
 import { Section } from "@copilotkit/channels-ui";
 import {
-  startManagedBotsOnChannel,
-  startManagedBotsOverPhoenix,
-} from "./phoenix-launcher.js";
-import type { HostedBotChannel } from "./phoenix-transport.js";
+  startChannelsWithGatewaySession,
+  startChannelsOverRealtimeGateway,
+} from "./realtime-gateway-launcher.js";
+import type { RealtimeGatewaySession } from "./realtime-gateway.js";
 
 const scope = {
   organizationId: "org_1",
   projectId: 7,
-  botId: "bot_1",
-  botName: "opentag",
+  channelId: "channel_1",
+  channelName: "opentag",
 };
 
-/** Fake gateway channel: records pushes, replies `render_accepted`, and exposes
+/** Fake gateway session: records pushes, replies `render_accepted`, and exposes
  * the server-push handlers so a test can simulate `delivery.available`. */
-function makeFakeChannel() {
+function makeFakeSession() {
   const pushes: { event: string; payload: unknown }[] = [];
   const handlers = new Map<string, (payload: unknown) => void>();
-  const channel: HostedBotChannel = {
+  const session: RealtimeGatewaySession = {
     push: async (event, payload) => {
       pushes.push({ event, payload });
-      if (event === "hosted_bot.render_event.v1") {
+      if (event === "channel.render_event.v1") {
         const p = (payload as { payload: Record<string, unknown> }).payload;
         return {
-          type: "hosted_bot.render_accepted.v1",
+          type: "channel.render_accepted.v1",
           occurredAt: "2026-07-09T00:00:00.000Z",
           payload: {
             idempotencyKey: p.idempotencyKey,
@@ -42,18 +42,18 @@ function makeFakeChannel() {
       handlers.set(event, handler);
     },
   };
-  return { channel, pushes, handlers };
+  return { session, pushes, handlers };
 }
 
-/** Simulate one leased text-turn delivery arriving over the channel. */
+/** Simulate one leased text-turn delivery arriving over the gateway session. */
 function deliverText(handlers: Map<string, (p: unknown) => void>) {
-  handlers.get("hosted_bot.delivery.available.v1")?.({
+  handlers.get("channel.delivery.available.v1")?.({
     payload: {
       delivery: {
         id: "dlv_1",
         leaseToken: "lease_1",
         adapter: "slack",
-        bot: { id: "bot_1", name: "opentag" },
+        channel: { id: "channel_1", name: "opentag" },
         turn: {
           id: "turn_1",
           eventId: "evt_1",
@@ -65,7 +65,7 @@ function deliverText(handlers: Map<string, (p: unknown) => void>) {
   });
 }
 
-/** The channel `delivery.available` handler is fire-and-forget, so poll until
+/** The gateway session `delivery.available` handler is fire-and-forget, so poll until
  * the async dispatch→render→ack chain has produced the terminal event. */
 async function waitFor(pred: () => boolean, tries = 50): Promise<void> {
   for (let i = 0; i < tries; i++) {
@@ -75,9 +75,9 @@ async function waitFor(pred: () => boolean, tries = 50): Promise<void> {
   throw new Error("waitFor: condition not met within the poll window");
 }
 
-describe("startManagedBotsOnChannel — managed runtime over Phoenix (OSS-406)", () => {
+describe("startChannelsWithGatewaySession — managed runtime over Realtime Gateway (OSS-406)", () => {
   it("runs a delivered turn end-to-end: handler → render frame → completion intent, never self-ack", async () => {
-    const fake = makeFakeChannel();
+    const fake = makeFakeSession();
     let ran = false;
     const bot = createBot({ name: "opentag", agent: () => new FakeAgent() });
     bot.onMessage(async ({ thread }) => {
@@ -85,8 +85,8 @@ describe("startManagedBotsOnChannel — managed runtime over Phoenix (OSS-406)",
       await thread.post(Section({ children: "reply" }));
     });
 
-    const handle = await startManagedBotsOnChannel([bot], {
-      channel: fake.channel,
+    const handle = await startChannelsWithGatewaySession([bot], {
+      session: fake.session,
       scope,
       runtimeInstanceId: "rti_1",
     });
@@ -94,54 +94,54 @@ describe("startManagedBotsOnChannel — managed runtime over Phoenix (OSS-406)",
     deliverText(fake.handlers);
     await waitFor(() =>
       fake.pushes.some(
-        (p) => p.event === "hosted_bot.delivery.complete_requested.v1",
+        (p) => p.event === "channel.delivery.complete_requested.v1",
       ),
     );
 
     const events = fake.pushes.map((p) => p.event);
-    expect(ran).toBe(true); // the bot's handler ran off a Phoenix-delivered turn
-    expect(events).toContain("hosted_bot.render_event.v1"); // rendered over the channel
-    expect(events).toContain("hosted_bot.delivery.complete_requested.v1"); // completion INTENT
-    expect(events).not.toContain("hosted_bot.delivery.ack.v1"); // SDK never commits the ack
+    expect(ran).toBe(true); // the Bot handler ran off a gateway-delivered turn
+    expect(events).toContain("channel.render_event.v1"); // rendered over the gateway session
+    expect(events).toContain("channel.delivery.complete_requested.v1"); // completion INTENT
+    expect(events).not.toContain("channel.delivery.ack.v1"); // SDK never commits the ack
 
     await handle.stop();
   });
 
   it("nacks (fail intent) when the handler throws — no completion intent, no self-ack", async () => {
-    const fake = makeFakeChannel();
+    const fake = makeFakeSession();
     const bot = createBot({ name: "opentag", agent: () => new FakeAgent() });
     bot.onMessage(async () => {
       throw new Error("boom");
     });
 
-    const handle = await startManagedBotsOnChannel([bot], {
-      channel: fake.channel,
+    const handle = await startChannelsWithGatewaySession([bot], {
+      session: fake.session,
       scope,
       runtimeInstanceId: "rti_1",
     });
 
     deliverText(fake.handlers);
     await waitFor(() =>
-      fake.pushes.some((p) => p.event === "hosted_bot.delivery.fail.v1"),
+      fake.pushes.some((p) => p.event === "channel.delivery.fail.v1"),
     );
 
     const events = fake.pushes.map((p) => p.event);
-    expect(events).toContain("hosted_bot.delivery.fail.v1");
-    expect(events).not.toContain("hosted_bot.delivery.complete_requested.v1");
-    expect(events).not.toContain("hosted_bot.delivery.ack.v1");
+    expect(events).toContain("channel.delivery.fail.v1");
+    expect(events).not.toContain("channel.delivery.complete_requested.v1");
+    expect(events).not.toContain("channel.delivery.ack.v1");
 
     await handle.stop();
   });
 });
 
-describe("startManagedBotsOverPhoenix — fail-fast validation (OSS-406)", () => {
+describe("startChannelsOverRealtimeGateway — fail-fast validation (OSS-406)", () => {
   it("rejects a bad bot name before opening a socket (no leaked connection)", async () => {
     let socketConstructed = false;
     class NeverWebSocket {
       constructor() {
         socketConstructed = true;
         throw new Error(
-          "startManagedBotsOverPhoenix should not have connected",
+          "startChannelsOverRealtimeGateway should not have connected",
         );
       }
     }
@@ -149,7 +149,7 @@ describe("startManagedBotsOverPhoenix — fail-fast validation (OSS-406)", () =>
     const b = createBot({ name: "dupe", agent: () => new FakeAgent() });
 
     await expect(
-      startManagedBotsOverPhoenix([a, b], {
+      startChannelsOverRealtimeGateway([a, b], {
         wsUrl: "wss://gateway.example/socket",
         apiKey: "cpk-test",
         scope,
@@ -161,13 +161,13 @@ describe("startManagedBotsOverPhoenix — fail-fast validation (OSS-406)", () =>
     expect(socketConstructed).toBe(false);
   });
 
-  it("rejects >1 bot before opening a socket (Phase 1 is single-bot per channel)", async () => {
+  it("rejects >1 Bot before opening a socket (Phase 1 is single-Bot per gateway session)", async () => {
     let socketConstructed = false;
     class NeverWebSocket {
       constructor() {
         socketConstructed = true;
         throw new Error(
-          "startManagedBotsOverPhoenix should not have connected",
+          "startChannelsOverRealtimeGateway should not have connected",
         );
       }
     }
@@ -175,40 +175,40 @@ describe("startManagedBotsOverPhoenix — fail-fast validation (OSS-406)", () =>
     const b = createBot({ name: "two", agent: () => new FakeAgent() });
 
     await expect(
-      startManagedBotsOverPhoenix([a, b], {
+      startChannelsOverRealtimeGateway([a, b], {
         wsUrl: "wss://gateway.example/socket",
         apiKey: "cpk-test",
         scope,
         runtimeInstanceId: "rti_1",
         webSocket: NeverWebSocket,
       }),
-    ).rejects.toThrow(/exactly one bot per channel/i);
+    ).rejects.toThrow(/exactly one Bot per gateway session/i);
 
     expect(socketConstructed).toBe(false);
   });
 
-  it("startManagedBotsOnChannel also rejects >1 bot (shared-transport misrouting guard)", async () => {
-    const fake = makeFakeChannel();
+  it("startChannelsWithGatewaySession also rejects >1 Bot (shared-transport misrouting guard)", async () => {
+    const fake = makeFakeSession();
     const a = createBot({ name: "one", agent: () => new FakeAgent() });
     const b = createBot({ name: "two", agent: () => new FakeAgent() });
 
     await expect(
-      startManagedBotsOnChannel([a, b], {
-        channel: fake.channel,
+      startChannelsWithGatewaySession([a, b], {
+        session: fake.session,
         scope,
         runtimeInstanceId: "rti_1",
       }),
-    ).rejects.toThrow(/exactly one bot per channel/i);
+    ).rejects.toThrow(/exactly one Bot per gateway session/i);
   });
 });
 
-describe("startManagedBotsOnChannel — activation metadata (OSS-406)", () => {
+describe("startChannelsWithGatewaySession — activation metadata (OSS-406)", () => {
   it("forwards env overrides into handle.metadata (keeps join ↔ metadata in sync)", async () => {
-    const fake = makeFakeChannel();
+    const fake = makeFakeSession();
     const bot = createBot({ name: "opentag", agent: () => new FakeAgent() });
 
-    const handle = await startManagedBotsOnChannel([bot], {
-      channel: fake.channel,
+    const handle = await startChannelsWithGatewaySession([bot], {
+      session: fake.session,
       scope,
       runtimeInstanceId: "rti_1",
       env: { runtimeEnv: "production", runtimePackageVersion: "9.9.9" },
@@ -222,11 +222,11 @@ describe("startManagedBotsOnChannel — activation metadata (OSS-406)", () => {
   });
 
   it("keeps the required runtimeInstanceId authoritative in handle.metadata", async () => {
-    const fake = makeFakeChannel();
+    const fake = makeFakeSession();
     const bot = createBot({ name: "opentag", agent: () => new FakeAgent() });
 
-    const handle = await startManagedBotsOnChannel([bot], {
-      channel: fake.channel,
+    const handle = await startChannelsWithGatewaySession([bot], {
+      session: fake.session,
       scope,
       runtimeInstanceId: "rti_authoritative",
       env: { runtimeEnv: "staging" },
@@ -239,7 +239,7 @@ describe("startManagedBotsOnChannel — activation metadata (OSS-406)", () => {
 });
 
 /**
- * Minimal Phoenix-compatible fake WebSocket that drives the v2-serializer join
+ * Minimal gateway-compatible fake WebSocket that drives the v2-serializer join
  * handshake so the connector's error/timeout cleanup can be exercised without a
  * real gateway. `mode` controls the phx_join reply: "ok" → joined, "error" →
  * rejected, "never" → no reply (the channel join times out). Records `close()`
@@ -302,13 +302,13 @@ function makeFakeWebSocket(mode: JoinMode) {
   return { FakeWebSocket, instances };
 }
 
-describe("startManagedBotsOverPhoenix — socket lifecycle cleanup (OSS-406)", () => {
+describe("startChannelsOverRealtimeGateway — socket lifecycle cleanup (OSS-406)", () => {
   it("disconnects the socket when the channel join times out", async () => {
     const { FakeWebSocket, instances } = makeFakeWebSocket("never");
     const bot = createBot({ name: "opentag", agent: () => new FakeAgent() });
 
     await expect(
-      startManagedBotsOverPhoenix([bot], {
+      startChannelsOverRealtimeGateway([bot], {
         wsUrl: "wss://gateway.example/socket",
         apiKey: "cpk-test",
         scope,
@@ -327,7 +327,7 @@ describe("startManagedBotsOverPhoenix — socket lifecycle cleanup (OSS-406)", (
     const bot = createBot({ name: "opentag", agent: () => new FakeAgent() });
 
     await expect(
-      startManagedBotsOverPhoenix([bot], {
+      startChannelsOverRealtimeGateway([bot], {
         wsUrl: "wss://gateway.example/socket",
         apiKey: "cpk-test",
         scope,
@@ -343,19 +343,19 @@ describe("startManagedBotsOverPhoenix — socket lifecycle cleanup (OSS-406)", (
 
   it("disconnects the socket when bot startup fails after the channel joined", async () => {
     const { FakeWebSocket, instances } = makeFakeWebSocket("ok");
-    // Pre-start the bot so startManagedBots' addAdapter() throws ("adapter added
+    // Pre-start the Bot so startManagedBots' addAdapter() throws ("adapter added
     // after start") during the post-join startup — the exact failure the
     // launcher's try/catch must clean up after.
-    const started = makeFakeChannel();
+    const started = makeFakeSession();
     const bot = createBot({ name: "opentag", agent: () => new FakeAgent() });
-    const first = await startManagedBotsOnChannel([bot], {
-      channel: started.channel,
+    const first = await startChannelsWithGatewaySession([bot], {
+      session: started.session,
       scope,
       runtimeInstanceId: "rti_pre",
     });
 
     await expect(
-      startManagedBotsOverPhoenix([bot], {
+      startChannelsOverRealtimeGateway([bot], {
         wsUrl: "wss://gateway.example/socket",
         apiKey: "cpk-test",
         scope,

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.test.ts
@@ -75,7 +75,7 @@ async function waitFor(pred: () => boolean, tries = 50): Promise<void> {
   throw new Error("waitFor: condition not met within the poll window");
 }
 
-describe("startChannelsWithGatewaySession — managed runtime over Realtime Gateway (OSS-406)", () => {
+describe("startChannelsWithGatewaySession — Channel runtime over Realtime Gateway (OSS-406)", () => {
   it("runs a delivered turn end-to-end: handler → render frame → completion intent, never self-ack", async () => {
     const fake = makeFakeSession();
     let ran = false;
@@ -135,6 +135,31 @@ describe("startChannelsWithGatewaySession — managed runtime over Realtime Gate
 });
 
 describe("startChannelsOverRealtimeGateway — fail-fast validation (OSS-406)", () => {
+  it("rejects an invalid Channel scope before opening a socket", async () => {
+    let socketConstructed = false;
+    class NeverWebSocket {
+      constructor() {
+        socketConstructed = true;
+        throw new Error(
+          "startChannelsOverRealtimeGateway should not have connected",
+        );
+      }
+    }
+    const bot = createBot({ name: "opentag", agent: () => new FakeAgent() });
+
+    await expect(
+      startChannelsOverRealtimeGateway([bot], {
+        wsUrl: "wss://gateway.example/socket",
+        apiKey: "cpk-test",
+        scope: { ...scope, channelId: "bot_1" },
+        runtimeInstanceId: "rti_1",
+        webSocket: NeverWebSocket,
+      }),
+    ).rejects.toThrow(/channel_\* channelId/i);
+
+    expect(socketConstructed).toBe(false);
+  });
+
   it("rejects a bad bot name before opening a socket (no leaked connection)", async () => {
     let socketConstructed = false;
     class NeverWebSocket {
@@ -156,7 +181,7 @@ describe("startChannelsOverRealtimeGateway — fail-fast validation (OSS-406)", 
         runtimeInstanceId: "rti_1",
         webSocket: NeverWebSocket,
       }),
-    ).rejects.toThrow(/duplicate managed bot name/i);
+    ).rejects.toThrow(/duplicate channel name/i);
 
     expect(socketConstructed).toBe(false);
   });
@@ -216,7 +241,7 @@ describe("startChannelsWithGatewaySession — activation metadata (OSS-406)", ()
 
     expect(handle.metadata.runtimeEnv).toBe("production");
     expect(handle.metadata.runtimePackageVersion).toBe("9.9.9");
-    expect(handle.metadata.declaredBotNames).toEqual(["opentag"]);
+    expect(handle.metadata.declaredChannelNames).toEqual(["opentag"]);
 
     await handle.stop();
   });
@@ -343,7 +368,7 @@ describe("startChannelsOverRealtimeGateway — socket lifecycle cleanup (OSS-406
 
   it("disconnects the socket when bot startup fails after the channel joined", async () => {
     const { FakeWebSocket, instances } = makeFakeWebSocket("ok");
-    // Pre-start the Bot so startManagedBots' addAdapter() throws ("adapter added
+    // Pre-start the Bot so startChannels' addAdapter() throws ("adapter added
     // after start") during the post-join startup — the exact failure the
     // launcher's try/catch must clean up after.
     const started = makeFakeSession();

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.ts
@@ -6,24 +6,22 @@ import {
   resolveActivationEnv,
 } from "./runtime.js";
 import type { ManagedBotsHandle, ActivationEnv } from "./runtime.js";
-import { connectPhoenixHostedBotChannel } from "./phoenix-channel.js";
-import { PhoenixRealtimeTransport } from "./phoenix-transport.js";
-import type {
-  HostedBotChannel,
-  HostedBotRealtimeScope,
-} from "./phoenix-transport.js";
+import { connectRealtimeGateway } from "./realtime-gateway.js";
+import { RealtimeGatewayTransport } from "./realtime-gateway-transport.js";
+import type { HostedBotRealtimeScope } from "./realtime-gateway-transport.js";
+import type { RealtimeGatewaySession } from "./realtime-gateway.js";
 import type { EgressSink } from "./transports.js";
 
 /**
- * Phoenix-path egress is vestigial: with a render sink wired (the transport
+ * Realtime Gateway egress is vestigial: with a render sink wired (the transport
  * itself), the adapter routes every `post`/`update` and the run-render stream
  * through the render sink and never through the generic {@link EgressSink}. Fail
  * loud if that invariant is ever broken, rather than silently dropping an op.
  */
-const phoenixEgress: EgressSink = {
+const realtimeGatewayEgress: EgressSink = {
   emit: async () => {
     throw new Error(
-      "startManagedBotsOverPhoenix: EgressSink.emit was called, but the Phoenix " +
+      "startChannelsOverRealtimeGateway: EgressSink.emit was called, but the Realtime Gateway " +
         "path routes all egress through the render sink — this indicates a " +
         "wiring bug (the render sink was not set on the adapter).",
     );
@@ -31,35 +29,36 @@ const phoenixEgress: EgressSink = {
 };
 
 /**
- * Phase 1 runs exactly one bot per channel. {@link PhoenixRealtimeTransport} is
- * a single-delivery-callback object bound to one channel; attaching more than
- * one bot's `intelligenceAdapter` to the same transport would make every
- * delivery dispatch through the last bot's callback (and earlier bots receive
- * nothing). Multi-bot routing over a shared channel is Phase 2 (OSS-459) — until
- * then, run one bot per channel/runner and fail loudly on more.
+ * Phase 1 runs exactly one framework {@link Bot} per gateway session.
+ * {@link RealtimeGatewayTransport} is a single-delivery-callback object bound
+ * to one session; attaching more than one Bot's `intelligenceAdapter` to the
+ * same transport would make every delivery dispatch through the last Bot's
+ * callback (and earlier Bots receive
+ * nothing). Multi-Bot routing over a shared session is not implemented yet —
+ * until then, run one Bot per gateway session/runner and fail loudly on more.
  */
 function assertSingleBotForPhase1(bots: readonly Bot[]): void {
   if (bots.length !== 1) {
     throw new Error(
-      `managed Phoenix runtime supports exactly one bot per channel, got ${bots.length} — ` +
-        "multi-bot routing over a shared PhoenixRealtimeTransport is not implemented yet (OSS-459); " +
-        "run one bot per channel/runner",
+      `managed Realtime Gateway runtime supports exactly one Bot per gateway session, got ${bots.length} — ` +
+        "multi-Bot routing over a shared RealtimeGatewayTransport is not implemented yet (OSS-459); " +
+        "run one Bot per gateway session/runner",
     );
   }
 }
 
-/** Options for {@link startManagedBotsOnChannel} — an already-connected channel. */
-export interface ManagedBotsOnChannelOptions {
-  /** The joined realtime-gateway bot-IO channel (`hosted_bots:project:<id>`). */
-  channel: HostedBotChannel;
-  /** Authoritative org/project/bot scope echoed on every SDK→gateway envelope. */
+/** Options for {@link startChannelsWithGatewaySession}. */
+export interface StartChannelsWithGatewaySessionOptions {
+  /** The joined Realtime Gateway session. */
+  session: RealtimeGatewaySession;
+  /** Authoritative org/project/channel scope echoed on every SDK→gateway envelope. */
   scope: HostedBotRealtimeScope;
   /** Stable runtime instance id (`rti_…`), echoed on every envelope. */
   runtimeInstanceId: string;
   /** Activation env overrides forwarded to the runtime (so `handle.metadata`
    * matches what the caller declared on join); omitted fields are gathered from
    * the process. `runtimeInstanceId` is excluded — the required
-   * {@link ManagedBotsOnChannelOptions.runtimeInstanceId} above is authoritative
+   * {@link StartChannelsWithGatewaySessionOptions.runtimeInstanceId} above is authoritative
    * and is merged in, so the transport (which stamps it on every envelope) and
    * `handle.metadata` always report the same id. */
   env?: Partial<Omit<ActivationEnv, "runtimeInstanceId">>;
@@ -68,25 +67,25 @@ export interface ManagedBotsOnChannelOptions {
 }
 
 /**
- * Compose the managed runtime over an already-connected Phoenix channel: wrap
- * the channel in a {@link PhoenixRealtimeTransport} (delivery source + render
- * sink) and start the declared bots against it via {@link startManagedBots}.
+ * Compose the managed runtime over an already-connected gateway session: wrap
+ * the session in a {@link RealtimeGatewayTransport} (delivery source + render
+ * sink) and start the declared Bots against it via {@link startManagedBots}.
  *
- * Split out from {@link startManagedBotsOverPhoenix} so the composition — the
- * part with behavior — is unit-testable against a fake channel, leaving the
- * socket connect as thin glue. `intelligenceAdapter` is exclusive, so the
- * Phoenix transport is each bot's ONLY adapter; egress is served by the render
- * sink, not the generic {@link EgressSink} (see {@link phoenixEgress}).
+ * Split out from {@link startChannelsOverRealtimeGateway} so the composition —
+ * the part with behavior — is unit-testable against a fake session, leaving the
+ * connector as thin glue. `intelligenceAdapter` is exclusive, so the gateway
+ * transport is each Bot's ONLY adapter; egress is served by the render sink,
+ * not the generic {@link EgressSink} (see {@link realtimeGatewayEgress}).
  */
-export async function startManagedBotsOnChannel(
+export async function startChannelsWithGatewaySession(
   bots: Bot[],
-  opts: ManagedBotsOnChannelOptions,
+  opts: StartChannelsWithGatewaySessionOptions,
 ): Promise<ManagedBotsHandle> {
   assertSingleBotForPhase1(bots);
-  const transport = new PhoenixRealtimeTransport({
+  const transport = new RealtimeGatewayTransport({
     scope: opts.scope,
     runtimeInstanceId: opts.runtimeInstanceId,
-    channel: opts.channel,
+    session: opts.session,
     ...(opts.log ? { log: opts.log } : {}),
   });
   return startManagedBots({
@@ -94,23 +93,23 @@ export async function startManagedBotsOnChannel(
     resolveTransport: () => ({
       source: transport,
       renderSink: transport,
-      egress: phoenixEgress,
+      egress: realtimeGatewayEgress,
     }),
     // The required runtimeInstanceId is authoritative: merge it in LAST so
     // `handle.metadata` reports the same id the transport stamps on every
     // envelope, regardless of any `env` overrides (which cannot carry it).
-    env: { ...(opts.env ?? {}), runtimeInstanceId: opts.runtimeInstanceId },
+    env: { ...opts.env, runtimeInstanceId: opts.runtimeInstanceId },
   });
 }
 
-/** Config for {@link startManagedBotsOverPhoenix}. */
-export interface ManagedPhoenixConfig {
-  /** Gateway runner WebSocket URL — the `/runner` socket hosting the
-   * `hosted_bots:project:<id>` channel. */
+/** Config for {@link startChannelsOverRealtimeGateway}. */
+export interface StartChannelsOverRealtimeGatewayOptions {
+  /** Gateway runner WebSocket URL — the `/runner` endpoint hosting the
+   * `channels:project:<id>` session. */
   wsUrl: string;
   /** Project runtime API key (`cpk-…`), presented as the socket `authToken`. */
   apiKey: string;
-  /** Authoritative org/project/bot scope echoed on every SDK→gateway envelope. */
+  /** Authoritative org/project/channel scope echoed on every SDK→gateway envelope. */
   scope: HostedBotRealtimeScope;
   /** Stable runtime instance id (`rti_…`). */
   runtimeInstanceId: string;
@@ -119,7 +118,7 @@ export interface ManagedPhoenixConfig {
   /** Activation env overrides (package versions, runtimeEnv); omitted fields
    * are gathered from the process. Included in the join's `runtimeMetadata` and
    * in `handle.metadata`. `runtimeInstanceId` is intentionally excluded — the
-   * required top-level {@link ManagedPhoenixConfig.runtimeInstanceId} is
+   * required top-level {@link StartChannelsOverRealtimeGatewayOptions.runtimeInstanceId} is
    * authoritative for both the join and `handle.metadata` (they must agree). */
   env?: Partial<Omit<ActivationEnv, "runtimeInstanceId">>;
   /** Join timeout in ms. */
@@ -131,21 +130,19 @@ export interface ManagedPhoenixConfig {
 }
 
 /**
- * The managed-over-Phoenix launcher (OSS-406): connect the realtime-gateway
- * bot-IO channel, then run the declared bots against it via
- * {@link startManagedBotsOnChannel}. This is the composition that runs a
- * managed bot over the realtime path — the transport primitives are unit-tested;
- * this wires them for a live run. The returned handle's `stop()` stops the bots
- * and then disconnects the socket.
+ * Connect a Realtime Gateway session, then run the declared framework Bots
+ * against it via {@link startChannelsWithGatewaySession}. This is the
+ * composition that runs a managed channel over the realtime path. The returned
+ * handle's `stop()` stops the Bots and then disconnects the session.
  */
-export async function startManagedBotsOverPhoenix(
+export async function startChannelsOverRealtimeGateway(
   bots: Bot[],
-  config: ManagedPhoenixConfig,
+  config: StartChannelsOverRealtimeGatewayOptions,
 ): Promise<ManagedBotsHandle> {
   const adapter = config.adapter ?? "slack";
 
   // Fail fast BEFORE opening the socket: a missing/duplicate name would
-  // otherwise send a broken join (`botName: undefined`) and — because the same
+  // otherwise send a broken channel declaration and — because the same
   // check inside startManagedBots runs only after we've connected — throw with
   // the socket already open and never closed (a leak). Validating here means a
   // bad declaration never opens a connection at all.
@@ -161,7 +158,7 @@ export async function startManagedBotsOverPhoenix(
   // spread LAST so it stays authoritative even though `config.env` cannot carry
   // it (type-excluded) — belt and suspenders for the join↔metadata invariant.
   const envOverrides: Partial<ActivationEnv> = {
-    ...(config.env ?? {}),
+    ...config.env,
     runtimeInstanceId: config.runtimeInstanceId,
   };
   const activation = buildActivationMetadata(
@@ -169,14 +166,14 @@ export async function startManagedBotsOverPhoenix(
     resolveActivationEnv(envOverrides),
   );
 
-  const channel = await connectPhoenixHostedBotChannel({
+  const session = await connectRealtimeGateway({
     wsUrl: config.wsUrl,
     apiKey: config.apiKey,
     projectId: config.scope.projectId,
     join: {
       runtimeInstanceId: config.runtimeInstanceId,
-      declaredBots: activation.declaredBots.map((b) => ({
-        botName: b.name,
+      declaredChannels: activation.declaredBots.map((b) => ({
+        channelName: b.name,
         adapter,
         // renderCapabilities: reserved — bots don't expose capabilities yet
         // (tracked with the richer per-bot metadata in OSS-377).
@@ -201,34 +198,34 @@ export async function startManagedBotsOverPhoenix(
     ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
     ...(config.webSocket !== undefined ? { webSocket: config.webSocket } : {}),
   });
-  // The channel is now joined. If starting the bots throws (e.g. a bot was
+  // The session is now joined. If starting the Bots throws (e.g. a Bot was
   // already started, or a conflicting adapter), the caller never receives a
   // handle — so disconnect the socket here rather than leak it, then rethrow.
   let handle: ManagedBotsHandle;
   try {
-    handle = await startManagedBotsOnChannel(bots, {
-      channel,
+    handle = await startChannelsWithGatewaySession(bots, {
+      session,
       scope: config.scope,
       runtimeInstanceId: config.runtimeInstanceId,
-      // startManagedBotsOnChannel re-merges the authoritative runtimeInstanceId,
+      // The session-start helper re-merges the authoritative runtimeInstanceId,
       // so forward only the caller's overrides here (they cannot carry the id).
       ...(config.env ? { env: config.env } : {}),
       ...(config.log ? { log: config.log } : {}),
     });
   } catch (err) {
-    channel.disconnect();
+    session.disconnect();
     throw err;
   }
   return {
     ...handle,
     stop: async () => {
       // Always close the connection even if stopping the bots throws — the
-      // launcher owns the socket (the transport is handed the channel and does
+      // launcher owns the socket (the transport is handed the session and does
       // not disconnect it itself).
       try {
         await handle.stop();
       } finally {
-        channel.disconnect();
+        session.disconnect();
       }
     },
   };

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.ts
@@ -1,14 +1,17 @@
 import type { Bot } from "@copilotkit/channels";
 import {
-  startManagedBots,
-  assertValidBotNames,
-  buildActivationMetadata,
-  resolveActivationEnv,
+  startChannels,
+  assertValidChannelNames,
+  buildChannelActivationMetadata,
+  resolveChannelActivationEnv,
 } from "./runtime.js";
-import type { ManagedBotsHandle, ActivationEnv } from "./runtime.js";
+import type { ChannelsHandle, ChannelActivationEnv } from "./runtime.js";
 import { connectRealtimeGateway } from "./realtime-gateway.js";
-import { RealtimeGatewayTransport } from "./realtime-gateway-transport.js";
-import type { HostedBotRealtimeScope } from "./realtime-gateway-transport.js";
+import {
+  RealtimeGatewayTransport,
+  assertValidChannelRealtimeScope,
+} from "./realtime-gateway-transport.js";
+import type { ChannelRealtimeScope } from "./realtime-gateway-transport.js";
 import type { RealtimeGatewaySession } from "./realtime-gateway.js";
 import type { EgressSink } from "./transports.js";
 
@@ -40,9 +43,23 @@ const realtimeGatewayEgress: EgressSink = {
 function assertSingleBotForPhase1(bots: readonly Bot[]): void {
   if (bots.length !== 1) {
     throw new Error(
-      `managed Realtime Gateway runtime supports exactly one Bot per gateway session, got ${bots.length} — ` +
+      `Channel Realtime Gateway runtime supports exactly one Bot per gateway session, got ${bots.length} — ` +
         "multi-Bot routing over a shared RealtimeGatewayTransport is not implemented yet (OSS-459); " +
         "run one Bot per gateway session/runner",
+    );
+  }
+}
+
+function assertScopeMatchesChannel(
+  bots: readonly Bot[],
+  scope: ChannelRealtimeScope,
+): void {
+  assertValidChannelRealtimeScope(scope);
+  assertValidChannelNames(bots);
+  assertSingleBotForPhase1(bots);
+  if (bots[0]!.name !== scope.channelName) {
+    throw new Error(
+      `Channel Realtime Gateway scope channelName ${JSON.stringify(scope.channelName)} must match Bot name ${JSON.stringify(bots[0]!.name)}`,
     );
   }
 }
@@ -52,7 +69,7 @@ export interface StartChannelsWithGatewaySessionOptions {
   /** The joined Realtime Gateway session. */
   session: RealtimeGatewaySession;
   /** Authoritative org/project/channel scope echoed on every SDK→gateway envelope. */
-  scope: HostedBotRealtimeScope;
+  scope: ChannelRealtimeScope;
   /** Stable runtime instance id (`rti_…`), echoed on every envelope. */
   runtimeInstanceId: string;
   /** Activation env overrides forwarded to the runtime (so `handle.metadata`
@@ -61,15 +78,15 @@ export interface StartChannelsWithGatewaySessionOptions {
    * {@link StartChannelsWithGatewaySessionOptions.runtimeInstanceId} above is authoritative
    * and is merged in, so the transport (which stamps it on every envelope) and
    * `handle.metadata` always report the same id. */
-  env?: Partial<Omit<ActivationEnv, "runtimeInstanceId">>;
+  env?: Partial<Omit<ChannelActivationEnv, "runtimeInstanceId">>;
   /** Diagnostic sink for dropped deliveries / transport events. */
   log?: (message: string, meta?: unknown) => void;
 }
 
 /**
- * Compose the managed runtime over an already-connected gateway session: wrap
+ * Compose the Channel runtime over an already-connected gateway session: wrap
  * the session in a {@link RealtimeGatewayTransport} (delivery source + render
- * sink) and start the declared Bots against it via {@link startManagedBots}.
+ * sink) and start the declared Bots against it via {@link startChannels}.
  *
  * Split out from {@link startChannelsOverRealtimeGateway} so the composition —
  * the part with behavior — is unit-testable against a fake session, leaving the
@@ -80,15 +97,15 @@ export interface StartChannelsWithGatewaySessionOptions {
 export async function startChannelsWithGatewaySession(
   bots: Bot[],
   opts: StartChannelsWithGatewaySessionOptions,
-): Promise<ManagedBotsHandle> {
-  assertSingleBotForPhase1(bots);
+): Promise<ChannelsHandle> {
+  assertScopeMatchesChannel(bots, opts.scope);
   const transport = new RealtimeGatewayTransport({
     scope: opts.scope,
     runtimeInstanceId: opts.runtimeInstanceId,
     session: opts.session,
     ...(opts.log ? { log: opts.log } : {}),
   });
-  return startManagedBots({
+  return startChannels({
     bots,
     resolveTransport: () => ({
       source: transport,
@@ -110,7 +127,7 @@ export interface StartChannelsOverRealtimeGatewayOptions {
   /** Project runtime API key (`cpk-…`), presented as the socket `authToken`. */
   apiKey: string;
   /** Authoritative org/project/channel scope echoed on every SDK→gateway envelope. */
-  scope: HostedBotRealtimeScope;
+  scope: ChannelRealtimeScope;
   /** Stable runtime instance id (`rti_…`). */
   runtimeInstanceId: string;
   /** Adapter kind declared to the gateway on join (default `"slack"`). */
@@ -120,7 +137,7 @@ export interface StartChannelsOverRealtimeGatewayOptions {
    * in `handle.metadata`. `runtimeInstanceId` is intentionally excluded — the
    * required top-level {@link StartChannelsOverRealtimeGatewayOptions.runtimeInstanceId} is
    * authoritative for both the join and `handle.metadata` (they must agree). */
-  env?: Partial<Omit<ActivationEnv, "runtimeInstanceId">>;
+  env?: Partial<Omit<ChannelActivationEnv, "runtimeInstanceId">>;
   /** Join timeout in ms. */
   timeoutMs?: number;
   /** Injectable `WebSocket` ctor (non-global hosts / tests). */
@@ -132,38 +149,36 @@ export interface StartChannelsOverRealtimeGatewayOptions {
 /**
  * Connect a Realtime Gateway session, then run the declared framework Bots
  * against it via {@link startChannelsWithGatewaySession}. This is the
- * composition that runs a managed channel over the realtime path. The returned
+ * composition that runs a Channel over the realtime path. The returned
  * handle's `stop()` stops the Bots and then disconnects the session.
  */
 export async function startChannelsOverRealtimeGateway(
   bots: Bot[],
   config: StartChannelsOverRealtimeGatewayOptions,
-): Promise<ManagedBotsHandle> {
+): Promise<ChannelsHandle> {
   const adapter = config.adapter ?? "slack";
 
   // Fail fast BEFORE opening the socket: a missing/duplicate name would
   // otherwise send a broken channel declaration and — because the same
-  // check inside startManagedBots runs only after we've connected — throw with
+  // check inside startChannels runs only after we've connected — throw with
   // the socket already open and never closed (a leak). Validating here means a
   // bad declaration never opens a connection at all.
-  assertValidBotNames(bots);
-  // Fail fast before opening a socket for an unsupported multi-bot call.
-  assertSingleBotForPhase1(bots);
+  assertScopeMatchesChannel(bots, config.scope);
 
   // Build activation metadata up front so the join carries the Runtime
   // Activation data Intelligence's health view expects (runtime env, node
   // version, per-bot commands) rather than just name+adapter. The same
-  // `envOverrides` is forwarded to startManagedBots so `handle.metadata` agrees
+  // `envOverrides` is forwarded to startChannels so `handle.metadata` agrees
   // with what we declared on join. The required `config.runtimeInstanceId` is
   // spread LAST so it stays authoritative even though `config.env` cannot carry
   // it (type-excluded) — belt and suspenders for the join↔metadata invariant.
-  const envOverrides: Partial<ActivationEnv> = {
+  const envOverrides: Partial<ChannelActivationEnv> = {
     ...config.env,
     runtimeInstanceId: config.runtimeInstanceId,
   };
-  const activation = buildActivationMetadata(
+  const activation = buildChannelActivationMetadata(
     bots,
-    resolveActivationEnv(envOverrides),
+    resolveChannelActivationEnv(envOverrides),
   );
 
   const session = await connectRealtimeGateway({
@@ -172,8 +187,8 @@ export async function startChannelsOverRealtimeGateway(
     projectId: config.scope.projectId,
     join: {
       runtimeInstanceId: config.runtimeInstanceId,
-      declaredChannels: activation.declaredBots.map((b) => ({
-        channelName: b.name,
+      declaredChannels: activation.declaredChannels.map((channel) => ({
+        channelName: channel.channelName,
         adapter,
         // renderCapabilities: reserved — bots don't expose capabilities yet
         // (tracked with the richer per-bot metadata in OSS-377).
@@ -186,11 +201,14 @@ export async function startChannelsOverRealtimeGateway(
         ...(activation.runtimePackageVersion
           ? { runtimePackageVersion: activation.runtimePackageVersion }
           : {}),
-        ...(activation.botPackageVersion
-          ? { botPackageVersion: activation.botPackageVersion }
+        ...(activation.channelsPackageVersion
+          ? { channelsPackageVersion: activation.channelsPackageVersion }
           : {}),
         commands: Object.fromEntries(
-          activation.declaredBots.map((b) => [b.name, b.commands]),
+          activation.declaredChannels.map((channel) => [
+            channel.channelName,
+            channel.commands,
+          ]),
         ),
       },
       observedAt: new Date().toISOString(),
@@ -201,7 +219,7 @@ export async function startChannelsOverRealtimeGateway(
   // The session is now joined. If starting the Bots throws (e.g. a Bot was
   // already started, or a conflicting adapter), the caller never receives a
   // handle — so disconnect the socket here rather than leak it, then rethrow.
-  let handle: ManagedBotsHandle;
+  let handle: ChannelsHandle;
   try {
     handle = await startChannelsWithGatewaySession(bots, {
       session,

--- a/packages/channels-intelligence/src/realtime-gateway-transport.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-transport.ts
@@ -1,21 +1,18 @@
-// Realtime-gateway (Phoenix) transport for the managed-bot SDK (OSS-402).
+// Realtime Gateway transport for the managed Bot SDK (OSS-402).
 //
 // This is the production render/delivery path: the SDK joins the gateway's
-// per-project bot-IO channel, receives leased deliveries, streams semantic
-// `hosted_bot.render_event.v1` frames, waits for durable
-// `hosted_bot.render_accepted.v1` receipts, and — only after frames are
-// accepted — sends a `hosted_bot.delivery.complete_requested.v1` COMPLETION
-// INTENT (never a committed `hosted_bot.delivery.ack.v1`; app-api owns ack).
-// On failure it sends `hosted_bot.delivery.fail.v1`. The SDK never receives
+// per-project session, receives leased deliveries, streams semantic
+// `channel.render_event.v1` frames, waits for durable
+// `channel.render_accepted.v1` receipts, and — only after frames are
+// accepted — sends a `channel.delivery.complete_requested.v1` COMPLETION
+// INTENT (never a committed `channel.delivery.ack.v1`; app-api owns ack).
+// On failure it sends `channel.delivery.fail.v1`. The SDK never receives
 // Slack/provider credentials — rendering to the provider happens on the
 // gateway-side Connector Outbox.
 //
-// The Phoenix `Socket`/`Channel` boilerplate is intentionally NOT imported
-// here: the protocol (the risky part) is expressed against a minimal injected
-// {@link HostedBotChannel}, so it is fully unit-testable with a fake channel.
-// A deployment adapts its live Phoenix channel to this interface in a few
-// lines (`push` wraps `channel.push(...).receive("ok"/"error")`; `on` wraps
-// `channel.on(...)`).
+// The connector implementation is intentionally not imported here: the
+// protocol is expressed against an injected {@link RealtimeGatewaySession}, so
+// it is fully unit-testable with a fake gateway session.
 //
 // Scope (out of this checkpoint): discrete `EgressSink` posts from
 // command/interaction handlers are not yet streamed as `post`/`update` render
@@ -29,32 +26,22 @@ import type {
   RenderFrame,
   RenderAccepted,
 } from "./contracts.js";
+import type { RealtimeGatewaySession } from "./realtime-gateway.js";
 
-/** The org/project/bot scope every realtime envelope carries. */
+/** The org/project/channel scope every realtime envelope carries. */
 export interface HostedBotRealtimeScope {
   organizationId: string;
   projectId: number;
-  botId: string;
-  botName: string;
+  channelId: string;
+  channelName: string;
 }
 
-/**
- * Minimal Phoenix channel surface this transport needs. A deployment adapts a
- * live `phoenix` `Channel` to this: `push` resolves with the server's "ok"
- * reply payload (and rejects on "error"/"timeout"); `on` subscribes to a
- * server-pushed event.
- */
-export interface HostedBotChannel {
-  push(event: string, payload: unknown): Promise<unknown>;
-  on(event: string, handler: (payload: unknown) => void): void;
-}
-
-export interface PhoenixTransportConfig {
+export interface RealtimeGatewayTransportOptions {
   scope: HostedBotRealtimeScope;
   /** Unique per runtime instance (rti_…), echoed on every SDK->gateway event. */
   runtimeInstanceId: string;
-  /** The joined bot-IO channel (topic `hosted_bots:project:{projectId}`). */
-  channel: HostedBotChannel;
+  /** The joined Realtime Gateway session. */
+  session: RealtimeGatewaySession;
   /** ISO timestamp source; injectable for deterministic tests. */
   now?: () => string;
   /**
@@ -65,44 +52,44 @@ export interface PhoenixTransportConfig {
   log?: (message: string, meta?: unknown) => void;
 }
 
-const RENDER_EVENT = "hosted_bot.render_event.v1";
-const RENDER_ACCEPTED = "hosted_bot.render_accepted.v1";
-const DELIVERY_AVAILABLE = "hosted_bot.delivery.available.v1";
-const COMPLETE_REQUESTED = "hosted_bot.delivery.complete_requested.v1";
-const DELIVERY_FAIL = "hosted_bot.delivery.fail.v1";
+const RENDER_EVENT = "channel.render_event.v1";
+const RENDER_ACCEPTED = "channel.render_accepted.v1";
+const DELIVERY_AVAILABLE = "channel.delivery.available.v1";
+const COMPLETE_REQUESTED = "channel.delivery.complete_requested.v1";
+const DELIVERY_FAIL = "channel.delivery.fail.v1";
 
 /** Per-delivery state the transport needs to build completion/fail intents. */
 interface DeliveryState {
   turnId: string;
   /** app-api's per-delivery lease token, fences the complete/fail intent. */
   leaseToken: string;
-  /** Authoritative org/project/bot scope from the delivery (not the transport default). */
+  /** Authoritative org/project/channel scope from the delivery (not the transport default). */
   scope: HostedBotRealtimeScope;
   /** Highest accepted `seq` per render slot (the completion high-water mark). */
   accepted: Map<string, number>;
 }
 
 /**
- * Realtime-gateway transport implementing both the inbound {@link DeliverySource}
+ * Realtime Gateway transport implementing both the inbound {@link DeliverySource}
  * and the streaming {@link RenderEventSink}. `ack` maps to the completion
  * INTENT (`complete_requested`) and `nack` to `fail` — the SDK is never the
  * committed-ack authority.
  */
-export class PhoenixRealtimeTransport
+export class RealtimeGatewayTransport
   implements DeliverySource, RenderEventSink
 {
   private readonly scope: HostedBotRealtimeScope;
   private readonly runtimeInstanceId: string;
-  private readonly channel: HostedBotChannel;
+  private readonly session: RealtimeGatewaySession;
   private readonly now: () => string;
   private readonly log?: (message: string, meta?: unknown) => void;
   private readonly deliveries = new Map<string, DeliveryState>();
   private onDelivery?: (env: ManagedIngressEnvelope) => Promise<void>;
 
-  constructor(config: PhoenixTransportConfig) {
+  constructor(config: RealtimeGatewayTransportOptions) {
     this.scope = config.scope;
     this.runtimeInstanceId = config.runtimeInstanceId;
-    this.channel = config.channel;
+    this.session = config.session;
     this.now = config.now ?? (() => new Date().toISOString());
     this.log = config.log;
   }
@@ -111,7 +98,7 @@ export class PhoenixRealtimeTransport
     onDelivery: (env: ManagedIngressEnvelope) => Promise<void>,
   ): Promise<void> {
     this.onDelivery = onDelivery;
-    this.channel.on(DELIVERY_AVAILABLE, (payload) => {
+    this.session.on(DELIVERY_AVAILABLE, (payload) => {
       void this.handleDeliveryAvailable(payload);
     });
   }
@@ -133,7 +120,7 @@ export class PhoenixRealtimeTransport
    * Map a `delivery.available.v1`'s claimed delivery to the adapter's ingress
    * envelope plus the authoritative `scope` and `leaseToken` the transport
    * stashes for later complete/fail intents. Returns `undefined` (delivery
-   * dropped, logged via {@link PhoenixTransportConfig.log}) when the turn
+   * dropped, logged via {@link RealtimeGatewayTransportOptions.log}) when the turn
    * identity is missing/unmodeled or the delivery carries no `leaseToken` (a
    * fenced intent can't be built without it). Only the text-turn shape is
    * handled in V1; other input kinds are ignored until modeled.
@@ -163,7 +150,7 @@ export class PhoenixRealtimeTransport
       | undefined;
     if (!turn?.id || !turn.eventId) {
       // Malformed / unmodeled delivery shape — no turn identity to route on.
-      this.log?.("phoenix delivery dropped: missing turn id/eventId", {
+      this.log?.("realtime gateway delivery dropped: missing turn id/eventId", {
         deliveryId: delivery.id,
       });
       return undefined;
@@ -175,12 +162,14 @@ export class PhoenixRealtimeTransport
       // version-skew failure mode (gateway not yet emitting leaseToken); log it
       // loudly so it isn't an invisible, indefinitely re-looping outage.
       this.log?.(
-        "phoenix delivery dropped: no leaseToken on delivery.available (gateway/SDK version skew?) — will be re-leased",
+        "realtime gateway delivery dropped: no leaseToken on delivery.available (gateway/SDK version skew?) — will be re-leased",
         { deliveryId: delivery.id },
       );
       return undefined;
     }
-    const bot = delivery.bot as { id?: string; name?: string } | undefined;
+    const channel = delivery.channel as
+      | { id?: string; name?: string }
+      | undefined;
     const scope = {
       organizationId: String(
         delivery.organizationId ?? this.scope.organizationId,
@@ -189,8 +178,8 @@ export class PhoenixRealtimeTransport
         typeof delivery.projectId === "number"
           ? delivery.projectId
           : this.scope.projectId,
-      botId: String(bot?.id ?? this.scope.botId),
-      botName: String(bot?.name ?? this.scope.botName),
+      channelId: String(channel?.id ?? this.scope.channelId),
+      channelName: String(channel?.name ?? this.scope.channelName),
     };
     return {
       scope,
@@ -200,7 +189,9 @@ export class PhoenixRealtimeTransport
         deliveryId: String(delivery.id),
         eventId: String(turn.eventId),
         turnId: String(turn.id),
-        botName: scope.botName,
+        // The framework's ingress envelope still routes to a Bot by name;
+        // Intelligence's wire contract calls that delivery entity a channel.
+        botName: scope.channelName,
         platform: String(delivery.adapter ?? "slack"),
         conversationKey: String(turn.id),
         route: turn.replyTarget,
@@ -231,7 +222,7 @@ export class PhoenixRealtimeTransport
         sentAt: this.now(),
       },
     };
-    const reply = await this.channel.push(RENDER_EVENT, envelope);
+    const reply = await this.session.push(RENDER_EVENT, envelope);
     const receipt = this.parseAccepted(reply, idempotencyKey);
     // Record the completion high-water mark for this delivery/slot.
     if (state) {
@@ -260,7 +251,7 @@ export class PhoenixRealtimeTransport
     const payload = r?.payload;
     if (r?.type !== RENDER_ACCEPTED || !payload?.acceptance) {
       throw new Error(
-        `PhoenixRealtimeTransport: expected ${RENDER_ACCEPTED} for ${idempotencyKey}, got ${r?.type ?? "no reply"}`,
+        `RealtimeGatewayTransport: expected ${RENDER_ACCEPTED} for ${idempotencyKey}, got ${r?.type ?? "no reply"}`,
       );
     }
     return {
@@ -290,7 +281,7 @@ export class PhoenixRealtimeTransport
       this.deliveries.delete(deliveryId);
       return;
     }
-    await this.channel.push(COMPLETE_REQUESTED, {
+    await this.session.push(COMPLETE_REQUESTED, {
       type: COMPLETE_REQUESTED,
       occurredAt: this.now(),
       payload: {
@@ -315,7 +306,7 @@ export class PhoenixRealtimeTransport
       // be sent; app-api releases the delivery on lease lapse. Reachable only
       // for an already-terminal/evicted delivery today; log rather than drop
       // silently so an unexpected hit is diagnosable.
-      this.log?.("phoenix nack: no delivery state; dropping fail", {
+      this.log?.("realtime gateway nack: no delivery state; dropping fail", {
         deliveryId,
         reason,
       });
@@ -329,7 +320,7 @@ export class PhoenixRealtimeTransport
       }),
     );
     const lastAccepted = accepted[accepted.length - 1];
-    await this.channel.push(DELIVERY_FAIL, {
+    await this.session.push(DELIVERY_FAIL, {
       type: DELIVERY_FAIL,
       occurredAt: this.now(),
       payload: {

--- a/packages/channels-intelligence/src/realtime-gateway-transport.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-transport.ts
@@ -1,4 +1,4 @@
-// Realtime Gateway transport for the managed Bot SDK (OSS-402).
+// Realtime Gateway transport for the Channels SDK (OSS-402).
 //
 // This is the production render/delivery path: the SDK joins the gateway's
 // per-project session, receives leased deliveries, streams semantic
@@ -22,22 +22,52 @@
 
 import type { DeliverySource, RenderEventSink } from "./transports.js";
 import type {
-  ManagedIngressEnvelope,
+  ChannelIngressEnvelope,
+  ChannelDeliveryScope,
   RenderFrame,
   RenderAccepted,
 } from "./contracts.js";
 import type { RealtimeGatewaySession } from "./realtime-gateway.js";
 
 /** The org/project/channel scope every realtime envelope carries. */
-export interface HostedBotRealtimeScope {
-  organizationId: string;
-  projectId: number;
-  channelId: string;
-  channelName: string;
+export interface ChannelRealtimeScope extends ChannelDeliveryScope {}
+
+const CHANNEL_ID_RE = /^channel_[A-Za-z0-9_-]+$/;
+const ORGANIZATION_ID_RE = /^org_[A-Za-z0-9_-]+$/;
+const CHANNEL_NAME_RE = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+
+/** @internal Validate the product scope before a realtime connection is opened. */
+export function assertValidChannelRealtimeScope(
+  scope: ChannelRealtimeScope,
+): void {
+  if (!Number.isInteger(scope.projectId) || scope.projectId <= 0) {
+    throw new Error(
+      "Realtime Gateway Channel scope requires a positive projectId",
+    );
+  }
+  if (!ORGANIZATION_ID_RE.test(scope.organizationId)) {
+    throw new Error(
+      `Realtime Gateway Channel scope requires an org_* organizationId, got ${JSON.stringify(scope.organizationId)}`,
+    );
+  }
+  if (!CHANNEL_ID_RE.test(scope.channelId)) {
+    throw new Error(
+      `Realtime Gateway Channel scope requires a channel_* channelId, got ${JSON.stringify(scope.channelId)}`,
+    );
+  }
+  if (
+    scope.channelName.length < 3 ||
+    scope.channelName.length > 64 ||
+    !CHANNEL_NAME_RE.test(scope.channelName)
+  ) {
+    throw new Error(
+      `Realtime Gateway Channel scope requires a lowercase kebab-case channelName, got ${JSON.stringify(scope.channelName)}`,
+    );
+  }
 }
 
 export interface RealtimeGatewayTransportOptions {
-  scope: HostedBotRealtimeScope;
+  scope: ChannelRealtimeScope;
   /** Unique per runtime instance (rti_…), echoed on every SDK->gateway event. */
   runtimeInstanceId: string;
   /** The joined Realtime Gateway session. */
@@ -64,7 +94,7 @@ interface DeliveryState {
   /** app-api's per-delivery lease token, fences the complete/fail intent. */
   leaseToken: string;
   /** Authoritative org/project/channel scope from the delivery (not the transport default). */
-  scope: HostedBotRealtimeScope;
+  scope: ChannelDeliveryScope;
   /** Highest accepted `seq` per render slot (the completion high-water mark). */
   accepted: Map<string, number>;
 }
@@ -78,15 +108,16 @@ interface DeliveryState {
 export class RealtimeGatewayTransport
   implements DeliverySource, RenderEventSink
 {
-  private readonly scope: HostedBotRealtimeScope;
+  private readonly scope: ChannelRealtimeScope;
   private readonly runtimeInstanceId: string;
   private readonly session: RealtimeGatewaySession;
   private readonly now: () => string;
   private readonly log?: (message: string, meta?: unknown) => void;
   private readonly deliveries = new Map<string, DeliveryState>();
-  private onDelivery?: (env: ManagedIngressEnvelope) => Promise<void>;
+  private onDelivery?: (env: ChannelIngressEnvelope) => Promise<void>;
 
   constructor(config: RealtimeGatewayTransportOptions) {
+    assertValidChannelRealtimeScope(config.scope);
     this.scope = config.scope;
     this.runtimeInstanceId = config.runtimeInstanceId;
     this.session = config.session;
@@ -95,7 +126,7 @@ export class RealtimeGatewayTransport
   }
 
   async start(
-    onDelivery: (env: ManagedIngressEnvelope) => Promise<void>,
+    onDelivery: (env: ChannelIngressEnvelope) => Promise<void>,
   ): Promise<void> {
     this.onDelivery = onDelivery;
     this.session.on(DELIVERY_AVAILABLE, (payload) => {
@@ -127,8 +158,8 @@ export class RealtimeGatewayTransport
    */
   private toIngressEnvelope(payload: unknown):
     | {
-        env: ManagedIngressEnvelope;
-        scope: HostedBotRealtimeScope;
+        env: ChannelIngressEnvelope;
+        scope: ChannelDeliveryScope;
         leaseToken: string;
       }
     | undefined {
@@ -189,9 +220,9 @@ export class RealtimeGatewayTransport
         deliveryId: String(delivery.id),
         eventId: String(turn.eventId),
         turnId: String(turn.id),
-        // The framework's ingress envelope still routes to a Bot by name;
-        // Intelligence's wire contract calls that delivery entity a channel.
-        botName: scope.channelName,
+        // This product-level field names the Channel; bot core attaches the
+        // adapter directly to the framework Bot named by `createBot({ name })`.
+        channelName: scope.channelName,
         platform: String(delivery.adapter ?? "slack"),
         conversationKey: String(turn.id),
         route: turn.replyTarget,

--- a/packages/channels-intelligence/src/realtime-gateway.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.test.ts
@@ -68,6 +68,30 @@ function makeFakeWebSocket(mode: JoinMode) {
 }
 
 describe("connectRealtimeGateway", () => {
+  it("rejects a non-positive project id before constructing a WebSocket", async () => {
+    let socketConstructed = false;
+    class NeverWebSocket {
+      constructor() {
+        socketConstructed = true;
+      }
+    }
+
+    await expect(
+      connectRealtimeGateway({
+        wsUrl: "wss://gateway.example/socket",
+        apiKey: "cpk-test",
+        projectId: 0,
+        join: {
+          runtimeInstanceId: "rti_1",
+          declaredChannels: [],
+          observedAt: "2026-07-10T00:00:00.000Z",
+        },
+        webSocket: NeverWebSocket,
+      }),
+    ).rejects.toThrow(/projectId must be a positive integer/i);
+    expect(socketConstructed).toBe(false);
+  });
+
   it("joins the channel topic with declared channels and disconnects the gateway session", async () => {
     const { FakeWebSocket, instances } = makeFakeWebSocket("ok");
     const join = {

--- a/packages/channels-intelligence/src/realtime-gateway.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { connectRealtimeGateway } from "./realtime-gateway.js";
+
+type JoinMode = "ok" | "error" | "never";
+
+function makeFakeWebSocket(mode: JoinMode) {
+  const instances: FakeWebSocket[] = [];
+  class FakeWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+    readyState = 0;
+    onopen: ((ev?: unknown) => void) | null = null;
+    onmessage: ((ev: { data: string }) => void) | null = null;
+    onerror: ((ev?: unknown) => void) | null = null;
+    onclose: ((ev?: unknown) => void) | null = null;
+    closed = false;
+    readonly frames: unknown[] = [];
+
+    constructor(public readonly url: string) {
+      instances.push(this);
+      queueMicrotask(() => {
+        this.readyState = 1;
+        this.onopen?.();
+      });
+    }
+
+    send(data: string): void {
+      if (mode === "never") return;
+      let frame: unknown;
+      try {
+        frame = JSON.parse(data);
+      } catch {
+        return;
+      }
+      this.frames.push(frame);
+      if (!Array.isArray(frame)) return;
+      const [joinRef, ref, topic, event] = frame as [
+        string,
+        string,
+        string,
+        string,
+      ];
+      if (event !== "phx_join") return;
+      const status = mode === "ok" ? "ok" : "error";
+      const response = mode === "ok" ? {} : { reason: "unauthorized" };
+      queueMicrotask(() =>
+        this.onmessage?.({
+          data: JSON.stringify([
+            joinRef,
+            ref,
+            topic,
+            "phx_reply",
+            { status, response },
+          ]),
+        }),
+      );
+    }
+
+    close(): void {
+      this.closed = true;
+      this.readyState = 3;
+      this.onclose?.();
+    }
+  }
+  return { FakeWebSocket, instances };
+}
+
+describe("connectRealtimeGateway", () => {
+  it("joins the channel topic with declared channels and disconnects the gateway session", async () => {
+    const { FakeWebSocket, instances } = makeFakeWebSocket("ok");
+    const join = {
+      runtimeInstanceId: "rti_1",
+      declaredChannels: [{ channelName: "opentag", adapter: "slack" }],
+      observedAt: "2026-07-10T00:00:00.000Z",
+    };
+
+    const session = await connectRealtimeGateway({
+      wsUrl: "wss://gateway.example/socket",
+      apiKey: "cpk-test",
+      projectId: 7,
+      join,
+      webSocket: FakeWebSocket,
+    });
+
+    expect(instances).toHaveLength(1);
+    const joinFrame = instances[0]!.frames.find(
+      (frame) => Array.isArray(frame) && frame[3] === "phx_join",
+    ) as [string, string, string, string, unknown];
+    expect(joinFrame[2]).toBe("channels:project:7");
+    expect(joinFrame[4]).toEqual(join);
+
+    session.disconnect();
+    expect(instances[0]!.closed).toBe(true);
+  });
+});

--- a/packages/channels-intelligence/src/realtime-gateway.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.ts
@@ -53,6 +53,11 @@ export interface ConnectedRealtimeGatewaySession extends RealtimeGatewaySession 
 export async function connectRealtimeGateway(
   config: ConnectRealtimeGatewayOptions,
 ): Promise<ConnectedRealtimeGatewaySession> {
+  if (!Number.isInteger(config.projectId) || config.projectId <= 0) {
+    throw new Error(
+      "connectRealtimeGateway: projectId must be a positive integer",
+    );
+  }
   const timeout = config.timeoutMs ?? 10_000;
   const transport =
     config.webSocket ??

--- a/packages/channels-intelligence/src/realtime-gateway.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.ts
@@ -1,22 +1,28 @@
 import { Socket } from "phoenix";
-import type { HostedBotChannel } from "./phoenix-transport.js";
 
 /**
- * @internal Config for {@link connectPhoenixHostedBotChannel} — the live
- * realtime-gateway connection behind {@link PhoenixRealtimeTransport}.
+ * Minimal Realtime Gateway session surface used by the delivery/render
+ * transport. The connector adapts its private socket implementation to this
+ * contract so callers never depend on a protocol client.
  */
-export interface PhoenixConnectConfig {
+export interface RealtimeGatewaySession {
+  push(event: string, payload: unknown): Promise<unknown>;
+  on(event: string, handler: (payload: unknown) => void): void;
+}
+
+/** @internal Options for {@link connectRealtimeGateway}. */
+export interface ConnectRealtimeGatewayOptions {
   /** Gateway socket URL, e.g. `wss://gateway.example/socket`. */
   wsUrl: string;
   /** Runtime API key (`cpk-…`) authenticating the socket. */
   apiKey: string;
-  /** Numeric project id — the channel topic is `hosted_bots:project:{id}`. */
+  /** Numeric project id — the session topic is `channels:project:{id}`. */
   projectId: number;
   /** Listener declaration sent as the channel join payload. */
   join: {
     runtimeInstanceId: string;
-    declaredBots: ReadonlyArray<{
-      botName: string;
+    declaredChannels: ReadonlyArray<{
+      channelName: string;
       adapter: string;
       renderCapabilities?: readonly string[];
     }>;
@@ -29,33 +35,31 @@ export interface PhoenixConnectConfig {
   webSocket?: unknown;
 }
 
-/** A connected {@link HostedBotChannel} plus a `disconnect()` for shutdown. */
-export interface ConnectedHostedBotChannel extends HostedBotChannel {
+/** A connected {@link RealtimeGatewaySession} plus a shutdown operation. */
+export interface ConnectedRealtimeGatewaySession extends RealtimeGatewaySession {
   disconnect(): void;
 }
 
 /**
- * @internal Connect the SDK to the realtime-gateway hosted-bot IO channel and
- * adapt the Phoenix `Channel` to the minimal {@link HostedBotChannel} contract
- * {@link PhoenixRealtimeTransport} consumes: `push` resolves with the server's
- * "ok" reply (rejects on "error"/"timeout"); `on` subscribes to a pushed event.
+ * @internal Connect the SDK to a Realtime Gateway session. Socket/client
+ * values stay private here; callers receive only {@link RealtimeGatewaySession}.
  *
- * The channel is joined (declaring the runtime's bots) before the promise
+ * The session is joined (declaring the runtime's channels) before the promise
  * resolves, so the caller can immediately stream render frames.
  *
  * @param config - Gateway URL, auth, project scope, and join declaration.
  * @returns The connected channel with a `disconnect()` teardown.
  */
-export async function connectPhoenixHostedBotChannel(
-  config: PhoenixConnectConfig,
-): Promise<ConnectedHostedBotChannel> {
+export async function connectRealtimeGateway(
+  config: ConnectRealtimeGatewayOptions,
+): Promise<ConnectedRealtimeGatewaySession> {
   const timeout = config.timeoutMs ?? 10_000;
   const transport =
     config.webSocket ??
     (globalThis as unknown as { WebSocket?: unknown }).WebSocket;
   if (!transport) {
     throw new Error(
-      "connectPhoenixHostedBotChannel: no WebSocket available — pass config.webSocket or run on Node 22+",
+      "connectRealtimeGateway: no WebSocket available — pass config.webSocket or run on Node 22+",
     );
   }
 
@@ -70,7 +74,7 @@ export async function connectPhoenixHostedBotChannel(
   socket.connect();
 
   const channel = socket.channel(
-    `hosted_bots:project:${config.projectId}`,
+    `channels:project:${config.projectId}`,
     config.join as object,
   );
 
@@ -79,16 +83,18 @@ export async function connectPhoenixHostedBotChannel(
       .join(timeout)
       .receive("ok", () => resolve())
       .receive("error", (reason: unknown) => {
-        // The join failed, so the caller never gets a channel it could
+        // The join failed, so the caller never gets a session it could
         // disconnect — tear the socket down here rather than leak it.
         socket.disconnect();
         reject(
-          new Error(`hosted-bot channel join failed: ${safeReason(reason)}`),
+          new Error(
+            `realtime gateway session join failed: ${safeReason(reason)}`,
+          ),
         );
       })
       .receive("timeout", () => {
         socket.disconnect();
-        reject(new Error("hosted-bot channel join timed out"));
+        reject(new Error("realtime gateway session join timed out"));
       });
   });
 
@@ -99,10 +105,16 @@ export async function connectPhoenixHostedBotChannel(
           .push(event, payload as object, timeout)
           .receive("ok", (reply: unknown) => resolve(reply))
           .receive("error", (reason: unknown) =>
-            reject(new Error(`push ${event} failed: ${safeReason(reason)}`)),
+            reject(
+              new Error(
+                `realtime gateway session push ${event} failed: ${safeReason(reason)}`,
+              ),
+            ),
           )
           .receive("timeout", () =>
-            reject(new Error(`push ${event} timed out`)),
+            reject(
+              new Error(`realtime gateway session push ${event} timed out`),
+            ),
           );
       }),
     on: (event, handler) => {

--- a/packages/channels-intelligence/src/render-events.test.ts
+++ b/packages/channels-intelligence/src/render-events.test.ts
@@ -6,8 +6,8 @@ import {
   InMemoryEgressSink,
   InMemoryRenderEventSink,
 } from "./in-memory-transports.js";
-import { PhoenixRealtimeTransport } from "./phoenix-transport.js";
-import type { HostedBotChannel } from "./phoenix-transport.js";
+import { RealtimeGatewayTransport } from "./realtime-gateway-transport.js";
+import type { RealtimeGatewaySession } from "./realtime-gateway.js";
 
 const target = {
   route: { channel: "C1", threadTs: "100.0" },
@@ -128,17 +128,17 @@ describe("run renderer — render-event streaming (OSS-402)", () => {
   });
 });
 
-/** A fake Phoenix channel that records pushes and replies with render_accepted. */
-function makeFakeChannel() {
+/** A fake Realtime Gateway session that records pushes and replies with render_accepted. */
+function makeFakeSession() {
   const pushes: { event: string; payload: unknown }[] = [];
   const handlers = new Map<string, (payload: unknown) => void>();
-  const channel: HostedBotChannel = {
+  const session: RealtimeGatewaySession = {
     push: async (event, payload) => {
       pushes.push({ event, payload });
-      if (event === "hosted_bot.render_event.v1") {
+      if (event === "channel.render_event.v1") {
         const p = (payload as { payload: Record<string, unknown> }).payload;
         return {
-          type: "hosted_bot.render_accepted.v1",
+          type: "channel.render_accepted.v1",
           occurredAt: "2026-07-01T00:00:00.000Z",
           payload: {
             idempotencyKey: p.idempotencyKey,
@@ -155,38 +155,38 @@ function makeFakeChannel() {
       handlers.set(event, handler);
     },
   };
-  return { channel, pushes, handlers };
+  return { session, pushes, handlers };
 }
 
-describe("PhoenixRealtimeTransport — completion intent, never self-ack", () => {
-  const cfg = (channel: HostedBotChannel) => ({
+describe("RealtimeGatewayTransport — completion intent, never self-ack", () => {
+  const cfg = (session: RealtimeGatewaySession) => ({
     scope: {
       organizationId: "org_1",
       projectId: 7,
-      botId: "bot_1",
-      botName: "support",
+      channelId: "channel_1",
+      channelName: "support",
     },
     runtimeInstanceId: "rti_1",
-    channel,
+    session,
     now: () => "2026-07-01T00:00:00.000Z",
   });
 
   it("streams render frames, awaits receipts, then sends complete_requested (not ack)", async () => {
-    const fake = makeFakeChannel();
-    const t = new PhoenixRealtimeTransport(cfg(fake.channel));
+    const fake = makeFakeSession();
+    const t = new RealtimeGatewayTransport(cfg(fake.session));
 
-    // Simulate a leased delivery arriving over the channel.
+    // Simulate a leased delivery arriving over the gateway session.
     let delivered = false;
     await t.start(async () => {
       delivered = true;
     });
-    fake.handlers.get("hosted_bot.delivery.available.v1")?.({
+    fake.handlers.get("channel.delivery.available.v1")?.({
       payload: {
         delivery: {
           id: "dlv_d1",
           leaseToken: "lease_l1",
           adapter: "slack",
-          bot: { id: "bot_1", name: "support" },
+          channel: { id: "channel_1", name: "support" },
           turn: {
             id: "turn_t1",
             eventId: "evt_1",
@@ -224,12 +224,12 @@ describe("PhoenixRealtimeTransport — completion intent, never self-ack", () =>
     const events = fake.pushes.map((p) => p.event);
     // render frames first, then the completion INTENT.
     expect(events).toEqual([
-      "hosted_bot.render_event.v1",
-      "hosted_bot.render_event.v1",
-      "hosted_bot.delivery.complete_requested.v1",
+      "channel.render_event.v1",
+      "channel.render_event.v1",
+      "channel.delivery.complete_requested.v1",
     ]);
     // The SDK must NEVER emit a committed delivery ack.
-    expect(events).not.toContain("hosted_bot.delivery.ack.v1");
+    expect(events).not.toContain("channel.delivery.ack.v1");
 
     const completion = fake.pushes.at(-1)!.payload as {
       payload: {
@@ -244,20 +244,20 @@ describe("PhoenixRealtimeTransport — completion intent, never self-ack", () =>
     expect(completion.payload.runtimeInstanceId).toBe("rti_1");
     // OSS-446: render-accept + completion intent are both fenced on the lease.
     const render = fake.pushes.find(
-      (p) => p.event === "hosted_bot.render_event.v1",
+      (p) => p.event === "channel.render_event.v1",
     )!.payload as { payload: { leaseToken?: string } };
     expect(render.payload.leaseToken).toBe("lease_l1");
     expect(completion.payload.leaseToken).toBe("lease_l1");
   });
 
   it("throws if a render frame is not accepted (no silent success)", async () => {
-    const fake = makeFakeChannel();
+    const fake = makeFakeSession();
     // Override push to reply with a non-accepted envelope.
-    const channel: HostedBotChannel = {
-      push: async () => ({ type: "hosted_bot.something_else.v1" }),
-      on: fake.channel.on,
+    const session: RealtimeGatewaySession = {
+      push: async () => ({ type: "channel.something_else.v1" }),
+      on: fake.session.on,
     };
-    const t = new PhoenixRealtimeTransport(cfg(channel));
+    const t = new RealtimeGatewayTransport(cfg(session));
     await expect(
       t.push({
         deliveryId: "dlv_d1",
@@ -270,16 +270,16 @@ describe("PhoenixRealtimeTransport — completion intent, never self-ack", () =>
   });
 
   it("nack sends a fail event, never an ack", async () => {
-    const fake = makeFakeChannel();
-    const t = new PhoenixRealtimeTransport(cfg(fake.channel));
+    const fake = makeFakeSession();
+    const t = new RealtimeGatewayTransport(cfg(fake.session));
     await t.start(async () => {});
-    fake.handlers.get("hosted_bot.delivery.available.v1")?.({
+    fake.handlers.get("channel.delivery.available.v1")?.({
       payload: {
         delivery: {
           id: "dlv_d1",
           leaseToken: "lease_l1",
           adapter: "slack",
-          bot: { id: "bot_1", name: "support" },
+          channel: { id: "channel_1", name: "support" },
           turn: {
             id: "turn_t1",
             eventId: "evt_1",
@@ -291,10 +291,10 @@ describe("PhoenixRealtimeTransport — completion intent, never self-ack", () =>
     await Promise.resolve();
     await t.nack("dlv_d1", "boom");
     const events = fake.pushes.map((p) => p.event);
-    expect(events).toContain("hosted_bot.delivery.fail.v1");
-    expect(events).not.toContain("hosted_bot.delivery.ack.v1");
+    expect(events).toContain("channel.delivery.fail.v1");
+    expect(events).not.toContain("channel.delivery.ack.v1");
     const fail = fake.pushes.find(
-      (p) => p.event === "hosted_bot.delivery.fail.v1",
+      (p) => p.event === "channel.delivery.fail.v1",
     );
     expect(
       (fail?.payload as { payload?: { leaseToken?: string } }).payload
@@ -303,23 +303,23 @@ describe("PhoenixRealtimeTransport — completion intent, never self-ack", () =>
   });
 
   it("drops a delivery with no leaseToken (never fires onDelivery) and logs it", async () => {
-    const fake = makeFakeChannel();
+    const fake = makeFakeSession();
     const logs: string[] = [];
-    const t = new PhoenixRealtimeTransport({
-      ...cfg(fake.channel),
+    const t = new RealtimeGatewayTransport({
+      ...cfg(fake.session),
       log: (m) => logs.push(m),
     });
     let delivered = false;
     await t.start(async () => {
       delivered = true;
     });
-    fake.handlers.get("hosted_bot.delivery.available.v1")?.({
+    fake.handlers.get("channel.delivery.available.v1")?.({
       payload: {
         delivery: {
           id: "dlv_d1",
           // no leaseToken → the SDK can't build a fenced complete/fail intent
           adapter: "slack",
-          bot: { id: "bot_1", name: "support" },
+          channel: { id: "channel_1", name: "support" },
           turn: {
             id: "turn_t1",
             eventId: "evt_1",
@@ -335,10 +335,10 @@ describe("PhoenixRealtimeTransport — completion intent, never self-ack", () =>
   });
 
   it("nack with no delivery state sends nothing and logs it", async () => {
-    const fake = makeFakeChannel();
+    const fake = makeFakeSession();
     const logs: string[] = [];
-    const t = new PhoenixRealtimeTransport({
-      ...cfg(fake.channel),
+    const t = new RealtimeGatewayTransport({
+      ...cfg(fake.session),
       log: (m) => logs.push(m),
     });
     await t.start(async () => {});
@@ -350,12 +350,12 @@ describe("PhoenixRealtimeTransport — completion intent, never self-ack", () =>
   });
 
   it("stamps the delivery's authoritative scope (not the transport default) on render + fail", async () => {
-    const fake = makeFakeChannel();
-    // Transport default scope is org_1 / 7 / bot_1; the delivery carries a
+    const fake = makeFakeSession();
+    // Transport default scope is org_1 / 7 / channel_1; the delivery carries a
     // DIFFERENT authoritative scope, so this proves DeliveryState.scope is used.
-    const t = new PhoenixRealtimeTransport(cfg(fake.channel));
+    const t = new RealtimeGatewayTransport(cfg(fake.session));
     await t.start(async () => {});
-    fake.handlers.get("hosted_bot.delivery.available.v1")?.({
+    fake.handlers.get("channel.delivery.available.v1")?.({
       payload: {
         delivery: {
           id: "dlv_d1",
@@ -363,7 +363,7 @@ describe("PhoenixRealtimeTransport — completion intent, never self-ack", () =>
           organizationId: "org_OTHER",
           projectId: 99,
           adapter: "slack",
-          bot: { id: "bot_OTHER", name: "other-bot" },
+          channel: { id: "channel_OTHER", name: "other-channel" },
           turn: {
             id: "turn_t1",
             eventId: "evt_1",
@@ -390,13 +390,13 @@ describe("PhoenixRealtimeTransport — completion intent, never self-ack", () =>
         }
       ).payload;
     for (const p of [
-      inner("hosted_bot.render_event.v1"),
-      inner("hosted_bot.delivery.fail.v1"),
+      inner("channel.render_event.v1"),
+      inner("channel.delivery.fail.v1"),
     ]) {
       expect(p.organizationId).toBe("org_OTHER");
       expect(p.projectId).toBe(99);
-      expect(p.botId).toBe("bot_OTHER");
-      expect(p.botName).toBe("other-bot");
+      expect(p.channelId).toBe("channel_OTHER");
+      expect(p.channelName).toBe("other-channel");
     }
   });
 });

--- a/packages/channels-intelligence/src/runtime.test.ts
+++ b/packages/channels-intelligence/src/runtime.test.ts
@@ -7,73 +7,81 @@ import {
   InMemoryRenderEventSink,
 } from "./in-memory-transports.js";
 import {
-  assertValidBotNames,
-  buildActivationMetadata,
-  resolveActivationEnv,
-  startManagedBots,
+  assertValidChannelNames,
+  buildChannelActivationMetadata,
+  resolveChannelActivationEnv,
+  startChannels,
 } from "./runtime.js";
 
-describe("assertValidBotNames", () => {
+describe("assertValidChannelNames", () => {
   it("throws when a bot has no name", () => {
     const bot = createBot({ agent: () => new FakeAgent() });
-    expect(() => assertValidBotNames([bot])).toThrow(/name/i);
+    expect(() => assertValidChannelNames([bot])).toThrow(/name/i);
   });
 
-  it("throws on a non-identifier name", () => {
+  it("throws on a non-channel name", () => {
     const bot = createBot({ name: "Bad Name!", agent: () => new FakeAgent() });
-    expect(() => assertValidBotNames([bot])).toThrow(/identifier|invalid/i);
+    expect(() => assertValidChannelNames([bot])).toThrow(
+      /channel name|invalid/i,
+    );
   });
 
   it("throws on duplicate names", () => {
     const a = createBot({ name: "support", agent: () => new FakeAgent() });
     const b = createBot({ name: "support", agent: () => new FakeAgent() });
-    expect(() => assertValidBotNames([a, b])).toThrow(/duplicate/i);
+    expect(() => assertValidChannelNames([a, b])).toThrow(/duplicate/i);
   });
 
-  it("treats duplicate names case-insensitively", () => {
-    const a = createBot({ name: "Support", agent: () => new FakeAgent() });
-    const b = createBot({ name: "support", agent: () => new FakeAgent() });
-    expect(() => assertValidBotNames([a, b])).toThrow(/duplicate/i);
+  it("rejects uppercase channel names", () => {
+    const bot = createBot({ name: "Support", agent: () => new FakeAgent() });
+    expect(() => assertValidChannelNames([bot])).toThrow(
+      /lowercase kebab-case/i,
+    );
   });
 
-  it("accepts valid unique identifier-style names", () => {
-    const a = createBot({ name: "support_bot", agent: () => new FakeAgent() });
-    const b = createBot({ name: "triage2", agent: () => new FakeAgent() });
-    expect(() => assertValidBotNames([a, b])).not.toThrow();
+  it("rejects the reserved channels name", () => {
+    const bot = createBot({ name: "channels", agent: () => new FakeAgent() });
+    expect(() => assertValidChannelNames([bot])).toThrow(/reserved/i);
+  });
+
+  it("accepts valid unique channel names", () => {
+    const a = createBot({ name: "support-bot", agent: () => new FakeAgent() });
+    const b = createBot({ name: "triage-2", agent: () => new FakeAgent() });
+    expect(() => assertValidChannelNames([a, b])).not.toThrow();
   });
 });
 
-describe("buildActivationMetadata", () => {
-  it("includes declared bot names and the provided env", () => {
+describe("buildChannelActivationMetadata", () => {
+  it("includes declared channel names and the provided env", () => {
     const a = createBot({ name: "support", agent: () => new FakeAgent() });
     const b = createBot({ name: "triage", agent: () => new FakeAgent() });
-    const meta = buildActivationMetadata([a, b], {
+    const meta = buildChannelActivationMetadata([a, b], {
       runtimeEnv: "production",
       nodeVersion: "v20",
       runtimePackageVersion: "1.2.3",
     });
-    expect(meta.declaredBotNames).toEqual(["support", "triage"]);
+    expect(meta.declaredChannelNames).toEqual(["support", "triage"]);
     expect(meta.runtimeEnv).toBe("production");
     expect(meta.nodeVersion).toBe("v20");
     expect(meta.runtimePackageVersion).toBe("1.2.3");
   });
 
-  it("includes each bot's declared command names", () => {
+  it("includes each channel's declared command names", () => {
     const a = createBot({ name: "support", agent: () => new FakeAgent() });
     a.onCommand("triage", async () => {});
-    const meta = buildActivationMetadata([a], { runtimeEnv: "test" });
-    expect(meta.declaredBots).toEqual([
-      { name: "support", commands: ["triage"] },
+    const meta = buildChannelActivationMetadata([a], { runtimeEnv: "test" });
+    expect(meta.declaredChannels).toEqual([
+      { channelName: "support", commands: ["triage"] },
     ]);
   });
 });
 
-describe("resolveActivationEnv", () => {
+describe("resolveChannelActivationEnv", () => {
   it("prefers COPILOTKIT_RUNTIME_ENV, includes the node version, and lets overrides win", () => {
     const prev = process.env.COPILOTKIT_RUNTIME_ENV;
     process.env.COPILOTKIT_RUNTIME_ENV = "staging";
     try {
-      const env = resolveActivationEnv({
+      const env = resolveChannelActivationEnv({
         runtimePackageVersion: "9.9.9",
         runtimeInstanceId: "inst-1",
       });
@@ -91,7 +99,7 @@ describe("resolveActivationEnv", () => {
     const prev = process.env.COPILOTKIT_RUNTIME_ENV;
     delete process.env.COPILOTKIT_RUNTIME_ENV;
     try {
-      expect(resolveActivationEnv().runtimeEnv).toBe(
+      expect(resolveChannelActivationEnv().runtimeEnv).toBe(
         process.env.NODE_ENV ?? "development",
       );
     } finally {
@@ -100,8 +108,8 @@ describe("resolveActivationEnv", () => {
   });
 });
 
-describe("startManagedBots", () => {
-  it("validates, wires each bot with a managed adapter, and routes delivery per bot", async () => {
+describe("startChannels", () => {
+  it("validates, wires each Bot with a channel adapter, and routes delivery per channel", async () => {
     const a = createBot({ name: "support", agent: () => new FakeAgent() });
     const b = createBot({ name: "triage", agent: () => new FakeAgent() });
     const aPosted: string[] = [];
@@ -117,7 +125,7 @@ describe("startManagedBots", () => {
 
     const sources = new Map<string, InMemoryDeliverySource>();
     const sinks = new Map<string, InMemoryEgressSink>();
-    const handle = await startManagedBots({
+    const handle = await startChannels({
       bots: [a, b],
       resolveTransport: (botName) => {
         const source = new InMemoryDeliverySource();
@@ -129,7 +137,7 @@ describe("startManagedBots", () => {
       env: { runtimeEnv: "test" },
     });
 
-    expect([...handle.metadata.declaredBotNames].sort()).toEqual([
+    expect([...handle.metadata.declaredChannelNames].sort()).toEqual([
       "support",
       "triage",
     ]);
@@ -138,7 +146,7 @@ describe("startManagedBots", () => {
       deliveryId: "d1",
       eventId: "e1",
       turnId: "t1",
-      botName: "support",
+      channelName: "support",
       platform: "slack",
       conversationKey: "c1",
       route: {},
@@ -153,7 +161,7 @@ describe("startManagedBots", () => {
     await handle.stop();
   });
 
-  it("forwards renderSink so managed runtime streams rich render frames", async () => {
+  it("forwards renderSink so channel runtime streams rich render frames", async () => {
     const bot = createBot({ name: "support", agent: () => new FakeAgent() });
     bot.onMessage(async ({ thread }) => {
       await thread.post(Section({ children: "A" }));
@@ -162,7 +170,7 @@ describe("startManagedBots", () => {
     const source = new InMemoryDeliverySource();
     const egress = new InMemoryEgressSink();
     const renderSink = new InMemoryRenderEventSink();
-    const handle = await startManagedBots({
+    const handle = await startChannels({
       bots: [bot],
       resolveTransport: () => ({ source, egress, renderSink }),
       env: { runtimeEnv: "test" },
@@ -172,7 +180,7 @@ describe("startManagedBots", () => {
       deliveryId: "d1",
       eventId: "e1",
       turnId: "t1",
-      botName: "support",
+      channelName: "support",
       platform: "slack",
       conversationKey: "c1",
       route: {},
@@ -189,7 +197,7 @@ describe("startManagedBots", () => {
   it("throws on invalid names before wiring anything", async () => {
     const a = createBot({ agent: () => new FakeAgent() }); // no name
     await expect(
-      startManagedBots({
+      startChannels({
         bots: [a],
         resolveTransport: () => ({
           source: new InMemoryDeliverySource(),
@@ -205,7 +213,7 @@ describe("startManagedBots", () => {
     const b = createBot({ name: "triage", agent: () => new FakeAgent() });
     const stopA = vi.spyOn(a, "stop");
     await expect(
-      startManagedBots({
+      startChannels({
         bots: [a, b],
         // First bot wires fine; second bot's transport resolution throws
         // AFTER `a` is already live.
@@ -225,7 +233,7 @@ describe("startManagedBots", () => {
   it("warns (but does not throw) when called with no bots", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
-      const handle = await startManagedBots({
+      const handle = await startChannels({
         bots: [],
         resolveTransport: () => ({
           source: new InMemoryDeliverySource(),
@@ -233,8 +241,8 @@ describe("startManagedBots", () => {
         }),
         env: { runtimeEnv: "test" },
       });
-      expect(handle.metadata.declaredBotNames).toEqual([]);
-      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/no bots/i));
+      expect(handle.metadata.declaredChannelNames).toEqual([]);
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/no channels/i));
       await handle.stop();
     } finally {
       warn.mockRestore();

--- a/packages/channels-intelligence/src/runtime.test.ts
+++ b/packages/channels-intelligence/src/runtime.test.ts
@@ -127,11 +127,11 @@ describe("startChannels", () => {
     const sinks = new Map<string, InMemoryEgressSink>();
     const handle = await startChannels({
       bots: [a, b],
-      resolveTransport: (botName) => {
+      resolveTransport: (channelName) => {
         const source = new InMemoryDeliverySource();
         const egress = new InMemoryEgressSink();
-        sources.set(botName, source);
-        sinks.set(botName, egress);
+        sources.set(channelName, source);
+        sinks.set(channelName, egress);
         return { source, egress };
       },
       env: { runtimeEnv: "test" },
@@ -217,8 +217,8 @@ describe("startChannels", () => {
         bots: [a, b],
         // First bot wires fine; second bot's transport resolution throws
         // AFTER `a` is already live.
-        resolveTransport: (botName) => {
-          if (botName === "triage") throw new Error("boom");
+        resolveTransport: (channelName) => {
+          if (channelName === "triage") throw new Error("boom");
           return {
             source: new InMemoryDeliverySource(),
             egress: new InMemoryEgressSink(),

--- a/packages/channels-intelligence/src/runtime.ts
+++ b/packages/channels-intelligence/src/runtime.ts
@@ -6,68 +6,68 @@ import type {
 } from "./transports.js";
 import { intelligenceAdapter } from "./intelligence-adapter.js";
 
-/** Project/code identifier: starts with a letter, then letters/digits/underscore. */
-const BOT_NAME_RE = /^[A-Za-z][A-Za-z0-9_]*$/;
+/** Lowercase kebab-case Channel name, 3–64 characters. */
+const CHANNEL_NAME_RE = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+const RESERVED_CHANNEL_NAME = "channels";
 
 /**
- * Validate the bots declared to a managed runtime: each needs a `name`, names
- * must be identifier-style, and they must be unique within the runtime. Fails
+ * Validate the framework Bots declared to a Channel runtime: each needs a
+ * `name`, names must be lowercase kebab-case Channel names, and they must be
+ * unique within the runtime. Fails
  * loudly — a misconfigured declaration should never start silently.
  */
-export function assertValidBotNames(bots: readonly Bot[]): void {
+export function assertValidChannelNames(bots: readonly Bot[]): void {
   const seen = new Set<string>();
   for (const bot of bots) {
     const name = bot.name;
     if (!name) {
       throw new Error(
-        "managed bot is missing a `name` — pass createBot({ name }) for Intelligence-delivered bots",
+        "Channel runtime Bot is missing a `name` — pass createBot({ name }) for an Intelligence Channel",
       );
     }
-    if (!BOT_NAME_RE.test(name)) {
+    if (name.length < 3 || name.length > 64 || !CHANNEL_NAME_RE.test(name)) {
       throw new Error(
-        `managed bot name "${name}" is invalid — use a project/code identifier ` +
-          "(letters, digits, underscore; starting with a letter)",
+        `Channel name "${name}" is invalid — use lowercase kebab-case, 3–64 characters`,
       );
     }
-    // Case-insensitive uniqueness: "Support" and "support" would resolve to the
-    // same delivery routing, so reject the collision rather than let both bots
-    // receive every delivery.
-    const key = name.toLowerCase();
-    if (seen.has(key)) {
+    if (name === RESERVED_CHANNEL_NAME) {
+      throw new Error(`Channel name "${name}" is reserved`);
+    }
+    if (seen.has(name)) {
       throw new Error(
-        `duplicate managed bot name "${name}" — each bot in a runtime must be unique (case-insensitive)`,
+        `duplicate Channel name "${name}" — each Channel runtime Bot must be unique`,
       );
     }
-    seen.add(key);
+    seen.add(name);
   }
 }
 
 /** Runtime environment + version metadata sent to Intelligence on activation. */
-export interface ActivationEnv {
+export interface ChannelActivationEnv {
   runtimeInstanceId?: string;
   /** COPILOTKIT_RUNTIME_ENV override, else NODE_ENV, else "development". */
   runtimeEnv: string;
   nodeEnv?: string;
   nodeVersion?: string;
   runtimePackageVersion?: string;
-  botPackageVersion?: string;
+  channelsPackageVersion?: string;
 }
 
-export interface ActivationMetadata extends ActivationEnv {
-  declaredBotNames: string[];
-  /** Per-bot declarations: name + declared slash-command names. */
-  declaredBots: Array<{ name: string; commands: string[] }>;
+export interface ChannelActivationMetadata extends ChannelActivationEnv {
+  declaredChannelNames: string[];
+  /** Per-Channel declarations: name + declared slash-command names. */
+  declaredChannels: Array<{ channelName: string; commands: string[] }>;
 }
 
 /**
  * Gather the process-level runtime activation env — `COPILOTKIT_RUNTIME_ENV`
  * (override) → `NODE_ENV` → "development", and the Node version. Caller
  * `overrides` win and supply what only the runtime knows: package versions
- * (`runtimePackageVersion`/`botPackageVersion`) and a stable `runtimeInstanceId`.
+ * (`runtimePackageVersion`/`channelsPackageVersion`) and a stable `runtimeInstanceId`.
  */
-export function resolveActivationEnv(
-  overrides: Partial<ActivationEnv> = {},
-): ActivationEnv {
+export function resolveChannelActivationEnv(
+  overrides: Partial<ChannelActivationEnv> = {},
+): ChannelActivationEnv {
   // Guard against non-Node hosts (browser/edge) where `process` is absent.
   const env = typeof process !== "undefined" ? process.env : undefined;
   const nodeEnv = env?.NODE_ENV;
@@ -81,85 +81,85 @@ export function resolveActivationEnv(
 
 /**
  * Build the activation metadata declared to Intelligence: the resolved
- * env/versions plus per-bot declarations (name + declared command names). Pure.
+ * env/versions plus per-Channel declarations (name + declared command names). Pure.
  *
- * Assumes every bot has a name — call {@link assertValidBotNames} first
- * (`startManagedBots` does). A nameless bot is a programming error and throws
+ * Assumes every Bot has a name — call {@link assertValidChannelNames} first
+ * (`startChannels` does). A nameless Bot is a programming error and throws
  * rather than being silently filtered out of the activation set.
  *
- * TODO(OSS-377): add richer per-bot capabilities once the bot exposes them.
+ * TODO(OSS-377): add richer per-Channel capabilities once the framework Bot exposes them.
  */
-export function buildActivationMetadata(
+export function buildChannelActivationMetadata(
   bots: readonly Bot[],
-  env: ActivationEnv,
-): ActivationMetadata {
+  env: ChannelActivationEnv,
+): ChannelActivationMetadata {
   const names = bots.map((b) => {
     if (!b.name) {
       throw new Error(
-        "buildActivationMetadata: bot is missing a `name` — validate with assertValidBotNames first",
+        "buildChannelActivationMetadata: Bot is missing a `name` — validate with assertValidChannelNames first",
       );
     }
     return b.name;
   });
   return {
     ...env,
-    declaredBotNames: names,
-    declaredBots: bots.map((b, i) => ({
-      name: names[i]!,
+    declaredChannelNames: names,
+    declaredChannels: bots.map((b, i) => ({
+      channelName: names[i]!,
       commands: b.commandNames,
     })),
   };
 }
 
-/** Per-bot managed transport, resolved by the runtime (closed Gateway/Outbox). */
-export interface ManagedTransport {
+/** Per-Channel transport, resolved by the runtime (closed Gateway/Outbox). */
+export interface ChannelTransport {
   source: DeliverySource;
   egress: EgressSink;
   renderSink?: RenderEventSink;
   store?: StateStore;
 }
 
-export interface StartManagedBotsOptions {
+export interface StartChannelsOptions {
   bots: Bot[];
-  /** Resolve the inbound/outbound transport for a declared bot name. */
-  resolveTransport: (botName: string) => ManagedTransport;
+  /** Resolve the inbound/outbound transport for a declared Channel name. */
+  resolveTransport: (channelName: string) => ChannelTransport;
   /** Activation env overrides; omitted fields are gathered from the process. */
-  env?: Partial<ActivationEnv>;
+  env?: Partial<ChannelActivationEnv>;
 }
 
-export interface ManagedBotsHandle {
-  metadata: ActivationMetadata;
+export interface ChannelsHandle {
+  metadata: ChannelActivationMetadata;
   stop(): Promise<void>;
 }
 
 /**
- * Start the managed listener lifecycle: validate the declared bots, build the
- * activation metadata, then attach an `intelligenceAdapter` to each bot (wired
+ * Start the Channel listener lifecycle: validate the declared framework Bots,
+ * build the activation metadata, then attach an `intelligenceAdapter` to each Bot (wired
  * to its resolved transport) and start it. Returns the metadata and a `stop`.
  *
  * The transports come from the caller (production: the Realtime Gateway +
  * Connector Outbox clients; tests: in-memory). This module owns no Slack
  * credentials, webhook ingress, or outbox persistence.
  */
-export async function startManagedBots(
-  opts: StartManagedBotsOptions,
-): Promise<ManagedBotsHandle> {
-  assertValidBotNames(opts.bots);
+export async function startChannels(
+  opts: StartChannelsOptions,
+): Promise<ChannelsHandle> {
+  assertValidChannelNames(opts.bots);
   if (opts.bots.length === 0) {
     console.warn(
-      "[bot-intelligence] startManagedBots called with no bots — nothing to start. " +
+      "[channels-intelligence] startChannels called with no channels — nothing to start. " +
         "Pass `bots: [createBot({ name })]` on the Intelligence runtime.",
     );
   }
-  const metadata = buildActivationMetadata(
+  const metadata = buildChannelActivationMetadata(
     opts.bots,
-    resolveActivationEnv(opts.env),
+    resolveChannelActivationEnv(opts.env),
   );
   // Partial-start rollback: addAdapter/resolveTransport/start for bot N can
-  // throw AFTER bots 0..N-1 are already live. Without unwinding, those started
-  // bots leak (open listeners/connections) with no handle to stop them. Track
+  // throw AFTER Bots 0..N-1 are already live. Without unwinding, those started
+  // Bots leak (open listeners/connections) with no handle to stop them. Track
   // what started and stop it before rethrowing.
-  const startedBots: Bot[] = [];
+  const startedChannels: Bot[] = [];
   try {
     for (const bot of opts.bots) {
       const { source, egress, renderSink, store } = opts.resolveTransport(
@@ -169,10 +169,10 @@ export async function startManagedBots(
         intelligenceAdapter({ source, egress, renderSink, store }),
       );
       await bot.start();
-      startedBots.push(bot);
+      startedChannels.push(bot);
     }
   } catch (err) {
-    await Promise.allSettled(startedBots.map((b) => b.stop()));
+    await Promise.allSettled(startedChannels.map((b) => b.stop()));
     throw err;
   }
   return {

--- a/packages/channels-intelligence/src/transports.ts
+++ b/packages/channels-intelligence/src/transports.ts
@@ -89,7 +89,7 @@ export interface EgressSink {
  * {@link RenderAccepted} receipt for each before proceeding — the SDK never
  * assumes acceptance and never commits the delivery ack (app-api owns that;
  * the {@link DeliverySource} completion signal is the SDK's only terminal
- * intent). Implemented by the Realtime Gateway (Phoenix) client in production;
+ * intent). Implemented by the Realtime Gateway client in production;
  * headless/HTTP-fallback runs translate frames back to {@link EgressSink}
  * `post` operations so a Connector Outbox isn't required to see plain-text
  * replies.

--- a/packages/channels-intelligence/src/transports.ts
+++ b/packages/channels-intelligence/src/transports.ts
@@ -1,6 +1,6 @@
 import type { AgentContentPart } from "@copilotkit/channels-ui";
 import type {
-  ManagedIngressEnvelope,
+  ChannelIngressEnvelope,
   EgressRoute,
   EgressOperation,
   EgressResult,
@@ -10,7 +10,7 @@ import type {
 
 /**
  * A conversation-history message the adapter seeds onto a fresh agent's
- * `messages` before a turn runs, giving the managed bot visibility into prior
+ * `messages` before a turn runs, giving the Channel runtime visibility into prior
  * thread turns (parity with bot-slack/bot-discord/bot-whatsapp's
  * reconstructed-history conversation stores). Structurally compatible with —
  * but intentionally looser than — the AG-UI `Message` union (which types an
@@ -25,7 +25,7 @@ export interface AgentMessage {
 }
 
 /**
- * Inbound transport for managed delivery. Implemented by the Intelligence
+ * Inbound transport for Intelligence Channel delivery. Implemented by the Intelligence
  * Realtime Gateway client in production, and by {@link InMemoryDeliverySource}
  * for headless/standalone runs and tests. The bridge adapter is the only
  * consumer — it never knows which implementation is wired.
@@ -33,14 +33,14 @@ export interface AgentMessage {
 export interface DeliverySource {
   /** Begin delivering. `onDelivery` is invoked once per leased envelope. */
   start(
-    onDelivery: (env: ManagedIngressEnvelope) => Promise<void>,
+    onDelivery: (env: ChannelIngressEnvelope) => Promise<void>,
   ): Promise<void>;
   /** Acknowledge successful processing of a delivery (lease release). */
   ack(deliveryId: string): Promise<void>;
   /** Negatively acknowledge — the work will be redelivered (at-least-once). */
   nack(deliveryId: string, reason: string): Promise<void>;
   /**
-   * Fetch an inbound file's bytes by handle (managed multimodal content).
+   * Fetch an inbound file's bytes by handle (Channel multimodal content).
    * Optional: sources without a file-serve backing omit it and the adapter
    * skips content-part hydration (text-only turn).
    */
@@ -74,7 +74,7 @@ export interface DeliverySource {
 }
 
 /**
- * Outbound transport for managed replies. Implemented by the Intelligence
+ * Outbound transport for Channel replies. Implemented by the Intelligence
  * Connector Outbox client in production, and by {@link InMemoryEgressSink} for
  * tests. Receives generic egress operations with deterministic ids; the real
  * platform render + credentialed send happen on the Intelligence side.

--- a/packages/channels/src/create-bot.ts
+++ b/packages/channels/src/create-bot.ts
@@ -175,15 +175,15 @@ export interface CreateBotOptions<
   TStateSchema extends StandardSchemaV1 | undefined = undefined,
 > {
   /**
-   * Project-unique bot identifier. Required for managed (Intelligence-delivered)
-   * bots — it ties the runtime declaration to the Intelligence setup — and
-   * optional for local/custom adapters. Validated by the managed runtime
-   * (`startManagedBots`), not here.
+   * Project-unique Intelligence Channel name. Required for Intelligence Channel
+   * Bots — it ties the runtime declaration to the Intelligence setup — and
+   * optional for local/custom adapters. Validated by the Channel runtime
+   * (`startChannels`), not here.
    */
   name?: string;
   /**
    * Adapters supplied at construction. Optional — adapters can also be attached
-   * before `start()` via {@link Bot.addAdapter} (the managed runtime uses this).
+   * before `start()` via {@link Bot.addAdapter} (the Channel runtime uses this).
    */
   adapters?: PlatformAdapter[];
   agent?: AbstractAgent | ((threadId: string) => AbstractAgent);
@@ -205,9 +205,9 @@ export interface CreateBotOptions<
 }
 
 export interface Bot<TState = unknown> {
-  /** Project-unique identifier from `createBot({ name })`; used by the managed runtime. */
+  /** Project-unique identifier from `createBot({ name })`; used by the Channel runtime. */
   readonly name?: string;
-  /** Declared slash-command names (normalized). Surfaced for managed activation metadata. */
+  /** Declared slash-command names (normalized). Surfaced for Channel activation metadata. */
   readonly commandNames: string[];
   onMention(h: BotHandler<TState>): void;
   onMessage(h: BotHandler<TState>): void;
@@ -272,15 +272,15 @@ function msgFromTurn(turn: IncomingTurn): IncomingMessage {
 }
 
 /**
- * Enforce V1 managed exclusivity: a managed adapter (`intelligenceAdapter`)
- * must be the only adapter on a bot. Managed and direct delivery are
+ * Enforce V1 Intelligence Channel exclusivity: an Intelligence Channel adapter
+ * (`intelligenceAdapter`) must be the only adapter on a bot. Channel and direct delivery are
  * alternative modes per platform — Intelligence holds the platform creds, or
  * the runtime does, never both.
  */
 function assertExclusive(adapters: PlatformAdapter[]): void {
-  if (adapters.some((a) => a.__managed) && adapters.length > 1) {
+  if (adapters.some((a) => a.__intelligenceChannel) && adapters.length > 1) {
     throw new Error(
-      "intelligenceAdapter() must be the only adapter on a bot — managed and " +
+      "intelligenceAdapter() must be the only adapter on a bot — Channel and " +
         "direct delivery are alternative modes. Use intelligenceAdapter() OR " +
         "direct adapters (slack/discord/...), not both.",
     );
@@ -324,7 +324,7 @@ export function createBot<
   }
 
   // Adapters can be supplied up front or added later via `bot.addAdapter`
-  // (before `start()`). The runtime uses the latter to attach managed delivery.
+  // (before `start()`). The runtime uses the latter to attach Channel delivery.
   const adapters: PlatformAdapter[] = [...(opts.adapters ?? [])];
   assertExclusive(adapters);
   let started = false;
@@ -664,7 +664,7 @@ export function createBot<
         // Per-message handler set via `<Message onReaction>` on the posted
         // message — hot cache, falling back to the durable snapshot after a
         // restart. Resolve by `postedMessageId` when the adapter supplies it
-        // (managed: the reaction arrives keyed by the provider ts, not the SDK
+        // (Intelligence Channel: the reaction arrives keyed by the provider ts, not the SDK
         // post ref the handler was persisted under); else by `messageId`.
         const perMessage = await registry!.resolveMessageReaction(
           evt.postedMessageId ?? evt.messageId,

--- a/packages/channels/src/index.ts
+++ b/packages/channels/src/index.ts
@@ -103,8 +103,8 @@ export { mintId, stableStringify } from "./mint-id.js";
 export { runAgentLoop } from "./run-loop.js";
 export type { RunLoopArgs } from "./run-loop.js";
 
-// Pure, per-platform codec seam (shared with the managed/Connector-Outbox path).
-// The Intelligence-delivered managed adapter itself lives in
+// Pure, per-platform codec seam (shared with the Channel/Connector-Outbox path).
+// The Intelligence Channel adapter itself lives in
 // `@copilotkit/channels-intelligence`.
 export type { PlatformCodec } from "./codec.js";
 

--- a/packages/channels/src/platform-adapter.ts
+++ b/packages/channels/src/platform-adapter.ts
@@ -31,7 +31,7 @@ export interface SurfaceCapabilities {
   /**
    * Whether `Thread.awaitChoice` can block synchronously for a user's click
    * within a single run. `true`/undefined on interactive surfaces (Slack Socket
-   * Mode, Discord, …). Set `false` on ack-first surfaces like the managed
+   * Mode, Discord, …). Set `false` on ack-first surfaces like the Intelligence
    * Intelligence HTTP loop, where a run must end after posting the picker and
    * resume on the click's separate inbound delivery (a blocking wait would
    * deadlock the one-delivery-at-a-time claim loop). The HITL resume flow will
@@ -83,14 +83,14 @@ export interface IngressEventBase {
 
 /**
  * Idempotency ids carried by turn/command/interaction ingress. Set on the
- * managed (Intelligence-delivered) path; local adapters omit them.
+ * Intelligence Channel path; local adapters omit them.
  */
 export interface IngressIds {
   /** Stable platform event id for idempotency; omit if the platform provides none. */
   eventId?: string;
-  /** Stable per-turn id (managed/Intelligence path); local adapters omit it. */
+  /** Stable per-turn id (Intelligence Channel path); local adapters omit it. */
   turnId?: string;
-  /** Lease/delivery id (managed/Intelligence path); local adapters omit it. */
+  /** Lease/delivery id (Intelligence Channel path); local adapters omit it. */
   deliveryId?: string;
 }
 
@@ -235,7 +235,7 @@ export interface ConversationStore {
 /**
  * Optional context bot core passes to {@link PlatformAdapter.start}. Carries
  * the bot's declared identity so a transport that must announce itself (e.g.
- * the managed Intelligence adapter's heartbeat) can do so without separate
+ * the Intelligence Channel adapter's heartbeat) can do so without separate
  * config. Local adapters ignore it.
  */
 export interface AdapterStartContext {
@@ -268,11 +268,11 @@ export interface PlatformAdapter {
    * {@link conversationStore}.
    */
   readonly stateStore?: StateStore;
-  /** @internal Marks the managed adapter; bot core uses it for the V1 exclusivity guard. */
-  readonly __managed?: boolean;
+  /** @internal Marks the Intelligence Channel adapter for the V1 exclusivity guard. */
+  readonly __intelligenceChannel?: boolean;
   /**
    * When true, bot core skips its ingress dedup for events from this adapter.
-   * Set by at-least-once transports (managed delivery) that enforce
+   * Set by at-least-once transports (Channel delivery) that enforce
    * idempotency at egress instead — dropping a redelivery at ingress would lose
    * a legitimate retry.
    */

--- a/packages/channels/src/reactions.test.ts
+++ b/packages/channels/src/reactions.test.ts
@@ -126,7 +126,7 @@ describe("bot.onReaction", () => {
     await bot.start();
     fake.emitTurn({});
     await tick();
-    // Managed delivery: the reaction arrives keyed by the provider ts (NOT the
+    // Channel delivery: the reaction arrives keyed by the provider ts (NOT the
     // post ref the handler was registered under), and the adapter supplies the
     // reverse-mapped post ref as `postedMessageId`. Resolution must prefer it.
     fake.emitReaction({

--- a/packages/channels/src/reactions.test.ts
+++ b/packages/channels/src/reactions.test.ts
@@ -109,7 +109,7 @@ describe("bot.onReaction", () => {
     ]);
   });
 
-  it("resolves <Message onReaction> by postedMessageId when the reaction id differs (managed path)", async () => {
+  it("resolves <Message onReaction> by postedMessageId when the reaction id differs (Channel path)", async () => {
     const fake = new FakeAdapter();
     const bot = createBot({ adapters: [fake] });
     const seen: string[] = [];

--- a/packages/runtime/src/v2/runtime/core/runtime.ts
+++ b/packages/runtime/src/v2/runtime/core/runtime.ts
@@ -35,8 +35,8 @@ import { IntelligenceAgentRunner } from "../runner/intelligence";
 import type { CopilotKitIntelligence } from "../intelligence-platform";
 // Type-only: @copilotkit/channels is pure-ESM, so a value import would break this
 // package's CJS output. The bots are validated + activated (wired to delivery
-// transports) by `startManagedBots` from @copilotkit/channels, called by the
-// managed-listener bootstrap — not here.
+// transports) by `startChannels` from @copilotkit/channels-intelligence, called
+// by the Channel-listener bootstrap — not here.
 import type { Bot } from "@copilotkit/channels";
 import telemetry from "../telemetry/telemetry-client";
 
@@ -203,11 +203,11 @@ export interface CopilotIntelligenceRuntimeOptions extends BaseCopilotRuntimeOpt
   /** Interval in seconds at which the runtime renews the thread lock. Clamped to a maximum of 3000 (50 minutes). @default 15 */
   lockHeartbeatIntervalSeconds?: number;
   /**
-   * Managed bots (Intelligence-delivered) declared by this runtime. Each is a
+   * Intelligence Channels declared by this runtime. Each is a
    * `createBot({ name })` instance. Only available on the Intelligence runtime
-   * path. Names are validated (required, identifier-style, unique) and wired to
-   * delivery/egress transports when activated via `startManagedBots` from
-   * `@copilotkit/channels` — not at construction.
+   * path. Names are validated (required, lowercase kebab-case, unique) and wired
+   * to delivery/egress transports when activated via `startChannels` from
+   * `@copilotkit/channels-intelligence` — not at construction.
    */
   bots?: Bot[];
 }
@@ -409,8 +409,8 @@ export class CopilotIntelligenceRuntime
       options.lockHeartbeatIntervalSeconds ?? 15,
       CopilotIntelligenceRuntime.MAX_HEARTBEAT_INTERVAL_SECONDS,
     );
-    // Declared managed bots. Full name validation (identifier shape +
-    // uniqueness) lives in `startManagedBots` (`assertValidBotNames`) at
+    // Declared Intelligence Channels. Full name validation (lowercase kebab-case +
+    // uniqueness) lives in `startChannels` (`assertValidChannelNames`) at
     // activation — it can't run here because it's a value import from the
     // pure-ESM `@copilotkit/channels-intelligence`, which this CJS package must not
     // pull in. Fail fast on the most common misconfiguration (a missing name)

--- a/packages/runtime/src/v2/runtime/core/runtime.ts
+++ b/packages/runtime/src/v2/runtime/core/runtime.ts
@@ -181,7 +181,7 @@ export interface CopilotSseRuntimeOptions extends BaseCopilotRuntimeOptions {
   runner?: AgentRunner;
   intelligence?: undefined;
   generateThreadNames?: undefined;
-  /** Managed bots require the Intelligence runtime; not available in SSE mode. */
+  /** Intelligence Channels require the Intelligence runtime; not available in SSE mode. */
   bots?: undefined;
 }
 
@@ -358,7 +358,7 @@ export class CopilotSseRuntime
     if (Array.isArray(bots) && bots.length > 0) {
       throw new Error(
         "`bots` requires the Intelligence runtime (pass `intelligence`); " +
-          "managed bots are not available in SSE mode.",
+          "Intelligence Channels are not available in SSE mode.",
       );
     }
     super(options, options.runner ?? new InMemoryAgentRunner());
@@ -419,7 +419,7 @@ export class CopilotIntelligenceRuntime
     for (const b of this.bots) {
       if (!b.name) {
         throw new Error(
-          "managed bot is missing a `name` — pass createBot({ name }) for each bot in `bots`",
+          "Intelligence Channel Bot is missing a `name` — pass createBot({ name }) for each Bot in `bots`",
         );
       }
     }


### PR DESCRIPTION
## Problem

`@copilotkit/channels-intelligence` still used the retired Bot HTTP/realtime contract and exposed Phoenix implementation details. The managed Slack entrypoint used the same legacy API.

## Why

Intelligence now exposes a clean-break Channels contract. The SDK must use it consistently, while keeping the Phoenix-backed transport private behind a product-neutral Realtime Gateway API. Compatibility aliases would hide integration mismatches.

## Fix

- Migrated HTTP paths, payloads, config, and KV state to Channel terminology.
- Added the Realtime Gateway abstraction and Channel realtime wire contract.
- Renamed remaining APIs/types, updated the managed Slack example, and added forbidden-term coverage.
- Preserved framework and vendor `Bot` terminology only where it remains semantically correct.
