### PR TITLE
fix(channels-teams): fail-loud egress + document HITL button envelope (0.1.2)

### DIFF
--- a/packages/channels-teams/docs/button-action-envelope.md
+++ b/packages/channels-teams/docs/button-action-envelope.md
@@ -21,10 +21,10 @@ the action's `data`:
   "type": "Action.Submit",
   "title": "Approve",
   "data": {
-    "ckActionId": "ck:approve",      // opaque id; present only when the Button had an onClick handler
-    "value": { "decision": "yes" }    // present only when the Button had a `value` prop
+    "ckActionId": "ck:approve", // opaque id; present only when the Button had an onClick handler
+    "value": { "decision": "yes" }, // present only when the Button had a `value` prop
   },
-  "style": "positive"                 // optional: "positive" (primary) | "destructive" (danger)
+  "style": "positive", // optional: "positive" (primary) | "destructive" (danger)
 }
 ```
 
@@ -41,12 +41,13 @@ The action's `data` becomes `activity.value`, and the message `text` is empty:
 ```jsonc
 {
   "type": "message",
-  "text": "",                          // empty — the payload is in `value`, not text
-  "value": {                           // === the emitted action `data` (merged with any card inputs)
+  "text": "", // empty — the payload is in `value`, not text
+  "value": {
+    // === the emitted action `data` (merged with any card inputs)
     "ckActionId": "ck:approve",
-    "value": { "decision": "yes" }
+    "value": { "decision": "yes" },
   },
-  "conversation": { "id": "<stable conversation id>" }
+  "conversation": { "id": "<stable conversation id>" },
 }
 ```
 

--- a/packages/channels-teams/docs/button-action-envelope.md
+++ b/packages/channels-teams/docs/button-action-envelope.md
@@ -1,0 +1,65 @@
+# HITL button action envelope
+
+Authoritative wire shape for buttons rendered by `@copilotkit/channels-teams` and
+the click Teams delivers back. A consumer that decodes clicks out-of-band (e.g.
+the Intelligence managed-Teams ingress, which deep-imports this package's renderer
+but runs its own inbound decode) must match this exactly.
+
+Contract test: [`src/button-action-envelope.contract.test.ts`](../src/button-action-envelope.contract.test.ts).
+Emitter: `renderButton` in [`src/render/adaptive-card.ts`](../src/render/adaptive-card.ts).
+Decoder: `parseCardAction` in [`src/interaction.ts`](../src/interaction.ts).
+
+## Outbound — what the renderer emits
+
+A `<Button>` (with an `onClick` handler, i.e. not a link button) renders as a
+**top-level Adaptive Card `Action.Submit`** — deliberately `Action.Submit`, **not
+`Action.Execute`** (no `verb`). The opaque action id and optional value ride in
+the action's `data`:
+
+```jsonc
+{
+  "type": "Action.Submit",
+  "title": "Approve",
+  "data": {
+    "ckActionId": "ck:approve",      // opaque id; present only when the Button had an onClick handler
+    "value": { "decision": "yes" }    // present only when the Button had a `value` prop
+  },
+  "style": "positive"                 // optional: "positive" (primary) | "destructive" (danger)
+}
+```
+
+- A **link** `<Button>` (has a `url` prop) renders as `Action.OpenUrl` instead and
+  carries **no** `data` — it is not an interactive submit and never round-trips.
+- `data` is omitted entirely if the button has neither an `onClick` id nor a `value`.
+
+## Inbound — what Teams delivers on click
+
+Clicking an `Action.Submit` arrives as a **Message activity** (`activity.type ===
+"message"`), NOT an `invoke` / `adaptiveCard/action` / `Action.Execute` activity.
+The action's `data` becomes `activity.value`, and the message `text` is empty:
+
+```jsonc
+{
+  "type": "message",
+  "text": "",                          // empty — the payload is in `value`, not text
+  "value": {                           // === the emitted action `data` (merged with any card inputs)
+    "ckActionId": "ck:approve",
+    "value": { "decision": "yes" }
+  },
+  "conversation": { "id": "<stable conversation id>" }
+}
+```
+
+### Decode rules
+
+- **Is it a card action?** `typeof activity.value.ckActionId === "string"`. If not,
+  it's an ordinary chat message.
+- **Fields:** `id = activity.value.ckActionId`, `value = activity.value.value`.
+  Carry only these two — no resume-data smuggling; durability rides on the
+  consumer's action store keyed by `id`.
+- **Card inputs:** if the card also had `<Input>`/`<Select>` fields, Teams merges
+  their values into `activity.value` alongside `ckActionId`/`value`. Read the
+  named input keys directly from `activity.value` if needed.
+- **Conversation key:** derive it from `activity.conversation.id` (see
+  `conversationKeyOf`). Ingress and interaction decode MUST use the same key or the
+  waiter is stranded.

--- a/packages/channels-teams/src/button-action-envelope.contract.test.ts
+++ b/packages/channels-teams/src/button-action-envelope.contract.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Contract test for the HITL button action envelope — the wire shape a consumer
+ * (e.g. Intelligence managed-Teams ingress) must decode. Locks the shape in BOTH
+ * directions: what {@link renderAdaptiveCard} emits for a `<Button>`, and how
+ * {@link parseCardAction} decodes the click Teams delivers back. See
+ * `docs/button-action-envelope.md`.
+ */
+import { describe, it, expect } from "vitest";
+import type { BotNode } from "@copilotkit/channels-ui";
+import { renderAdaptiveCard } from "./render/adaptive-card.js";
+import {
+  parseCardAction,
+  conversationKeyOf,
+  type TeamsActivityLike,
+} from "./interaction.js";
+
+const text = (value: string): BotNode => ({ type: "text", props: { value } });
+const el = (type: string, children: BotNode[], props = {}): BotNode => ({
+  type,
+  props: { ...props, children },
+});
+
+const buttonAction = () => {
+  const action = renderAdaptiveCard([
+    el("actions", [
+      el("button", [text("Approve")], {
+        onClick: { id: "ck:approve" },
+        value: { decision: "yes" },
+      }),
+    ]),
+  ]).actions?.[0];
+  if (!action) throw new Error("expected one action");
+  return action;
+};
+
+describe("HITL button action envelope (contract)", () => {
+  it("emits a <Button> as Action.Submit carrying { ckActionId, value } in `data` — NOT Action.Execute", () => {
+    const action = buttonAction();
+
+    expect(action.type).toBe("Action.Submit");
+    // It is a Submit, not an Execute: no `verb`, and the payload rides in `data`.
+    expect(action).not.toHaveProperty("verb");
+    expect(action.data).toEqual({
+      ckActionId: "ck:approve",
+      value: { decision: "yes" },
+    });
+  });
+
+  it("round-trips: the emitted `data` is exactly Teams' inbound activity.value, decoding to { id, value }", () => {
+    const action = buttonAction();
+
+    // Teams delivers a Button click as a *Message* activity whose `value` IS the
+    // action's `data` object (merged with any card inputs) and whose `text` is
+    // empty — there is no invoke/adaptiveCard/action envelope.
+    const inboundActivity: TeamsActivityLike = {
+      value: action.data,
+      conversation: { id: "conv-1" },
+    };
+
+    expect(parseCardAction(inboundActivity)).toEqual({
+      id: "ck:approve",
+      value: { decision: "yes" },
+    });
+    expect(conversationKeyOf(inboundActivity)).toBe("conv-1");
+  });
+
+  it("treats an ordinary chat message (no ckActionId) as not-a-card-action", () => {
+    const ordinary: TeamsActivityLike = { value: undefined };
+
+    expect(parseCardAction(ordinary)).toBeUndefined();
+  });
+});

--- a/packages/channels-teams/src/message-stream.test.ts
+++ b/packages/channels-teams/src/message-stream.test.ts
@@ -50,4 +50,61 @@ describe("TeamsMessageStream", () => {
       vi.useRealTimers();
     }
   });
+
+  it("rejects finish() when the final post fails (no silent 'sent')", async () => {
+    const post = vi.fn(async () => {
+      throw new Error("provider_down");
+    });
+    const update = vi.fn(async () => {});
+    const s = new TeamsMessageStream({ post, update });
+
+    s.append("Hello");
+
+    await expect(s.finish()).rejects.toThrow(/provider_down/);
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects finish() when the final edit fails after a successful post", async () => {
+    vi.useFakeTimers();
+    try {
+      const post = vi.fn(async () => "act-1");
+      const update = vi.fn(async () => {
+        throw new Error("update_failed");
+      });
+      const s = new TeamsMessageStream({ post, update, minIntervalMs: 100 });
+
+      s.append("A");
+      await vi.advanceTimersByTimeAsync(150); // first flush posts "A"
+      s.append("AB");
+
+      await expect(s.finish()).rejects.toThrow(/update_failed/);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("tolerates a dropped mid-stream edit, then delivers on the final flush", async () => {
+    vi.useFakeTimers();
+    try {
+      const post = vi.fn(async () => "act-1");
+      let editCalls = 0;
+      const update = vi.fn(async () => {
+        editCalls += 1;
+        if (editCalls === 1) throw new Error("transient");
+      });
+      const s = new TeamsMessageStream({ post, update, minIntervalMs: 100 });
+
+      s.append("A");
+      await vi.advanceTimersByTimeAsync(150); // posts "A"
+      s.append("AB");
+      await vi.advanceTimersByTimeAsync(150); // throttled edit -> fails, tolerated
+      s.append("ABC");
+      const id = await s.finish(); // final edit succeeds
+
+      expect(id).toBe("act-1");
+      expect(update).toHaveBeenLastCalledWith("act-1", "ABC");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/channels-teams/src/message-stream.ts
+++ b/packages/channels-teams/src/message-stream.ts
@@ -52,18 +52,28 @@ export class TeamsMessageStream {
   }
 
   /**
-   * Mark the stream done: cancel any pending throttled flush, enqueue a final
-   * flush, and resolve once the whole queue has drained. The posted activity
-   * then reflects the final buffer. Returns the activity id (or `undefined` if
-   * nothing was ever posted, e.g. an empty stream).
+   * Mark the stream done: cancel any pending throttled flush, drain the in-flight
+   * queue, then perform the FINAL send fail-loud. The posted activity then
+   * reflects the final buffer. Returns the activity id (or `undefined` if nothing
+   * was ever posted, e.g. an empty stream).
+   *
+   * Unlike the throttled mid-stream flushes (which tolerate a dropped edit and
+   * retry on the next append), the final send **rejects** if the transport call
+   * fails: the buffer was never delivered, so the caller must be able to
+   * fail/retry the turn rather than silently mark it "sent".
    */
   async finish(): Promise<string | undefined> {
     if (this.flushTimer) {
       clearTimeout(this.flushTimer);
       this.flushTimer = undefined;
     }
-    this.enqueueFlush();
+    // Drain any in-flight throttled flushes first — their failures stay tolerated
+    // (a dropped mid-stream edit shouldn't sink the reply). `flushNow` swallows,
+    // so the queue never rejects and awaiting it is safe.
     await this.queue;
+    // Then send the final buffer fail-loud: a throw here propagates so the
+    // consumer never marks the turn delivered when the last send didn't land.
+    await this.flushFinal();
     return this.id;
   }
 
@@ -81,24 +91,44 @@ export class TeamsMessageStream {
     this.queue = this.queue.then(() => this.flushNow());
   }
 
-  private async flushNow(): Promise<void> {
+  /**
+   * Send the latest buffer: first send via `post` (capturing the activity id),
+   * subsequent sends via `update`. `posted` is advanced only AFTER the transport
+   * call succeeds, so a throw leaves it unchanged and the next (or final) flush
+   * retries the same buffer. Throws on transport failure — callers decide whether
+   * to tolerate (mid-stream) or propagate (final).
+   */
+  private async doSend(): Promise<void> {
     const text = this.buffer;
     if (text === this.posted) return;
     // Don't post an empty first message; wait for real content.
     if (this.id === undefined && text.trim().length === 0) return;
+    if (this.id === undefined) {
+      if (this.config.typing) await this.config.typing();
+      this.id = await this.config.post(text);
+    } else {
+      await this.config.update(this.id, text);
+    }
     this.posted = text;
+  }
+
+  /** Throttled mid-stream flush: tolerate a dropped edit (log + retry later). */
+  private async flushNow(): Promise<void> {
     try {
-      if (this.id === undefined) {
-        if (this.config.typing) await this.config.typing();
-        this.id = await this.config.post(text);
-      } else {
-        await this.config.update(this.id, text);
-      }
+      await this.doSend();
     } catch (err) {
-      // A single failed edit shouldn't sink the stream; reset `posted` so the
-      // next flush retries with the latest buffer.
-      this.posted = "";
+      // A single failed edit shouldn't sink the stream; `doSend` leaves `posted`
+      // unchanged on failure, so the next flush retries with the latest buffer.
       console.error("[teams-message-stream] flush failed:", err);
+    } finally {
+      this.lastFlushedAt = Date.now();
+    }
+  }
+
+  /** Final flush at {@link finish}: propagate a transport failure fail-loud. */
+  private async flushFinal(): Promise<void> {
+    try {
+      await this.doSend();
     } finally {
       this.lastFlushedAt = Date.now();
     }


### PR DESCRIPTION
## Summary

Two fixes to `@copilotkit/channels-teams` found while Intelligence PR #511 (managed Microsoft Teams, **OSS-450**) deep-imports this package's run renderer for managed egress. Ships as **0.1.2** so Intelligence can bump the pin.

## 1. Fail-loud final send (silent egress failure)

`TeamsMessageStream.flushNow()` caught every POST/PUT failure and resolved, so `finish()` resolved **after a failed final send** — a consumer then marks the turn "sent" though nothing was delivered (reproduced: a `post` throwing `provider_down` logged to console but the end handler resolved successfully).

- `finish()` now drains the throttled queue, then performs the **final send fail-loud**: a transport failure **rejects** so the caller can fail/retry.
- Mid-stream throttled edits stay **tolerant** (log + retry on the next flush) — a dropped edit shouldn't sink a streaming reply.
- Refactor: a shared `doSend()` advances `posted` only *after* the transport call succeeds (a throw leaves it for retry); `flushNow` swallows, `flushFinal` propagates.
- **Tests:** final `post` failure → `finish()` rejects; final `update` failure → rejects; a mid-stream edit failure is tolerated and the final flush still delivers.

## 2. HITL button action envelope (documented + contract-tested)

Confirmed the actual emitted/inbound shape and published an authoritative note (`docs/button-action-envelope.md`) + a round-trip contract test (`src/button-action-envelope.contract.test.ts`) so the Intelligence ingress can decode clicks out-of-band.

**Outbound** — a `<Button>` renders as a top-level **`Action.Submit`** (deliberately *not* `Action.Execute` — no `verb`); the opaque id + value ride in `data`:

```jsonc
{ "type": "Action.Submit", "title": "Approve",
  "data": { "ckActionId": "ck:approve", "value": { "decision": "yes" } },
  "style": "positive" }
```
(`data.ckActionId` only when the Button has an `onClick`; `data.value` only when it has a `value` prop. A link Button → `Action.OpenUrl`, no `data`.)

**Inbound** — Teams delivers the click as a **Message activity** (`type: "message"`), *not* an invoke/`Action.Execute`. The action `data` becomes `activity.value`; `text` is empty:

```jsonc
{ "type": "message", "text": "",
  "value": { "ckActionId": "ck:approve", "value": { "decision": "yes" } },
  "conversation": { "id": "<stable conversation id>" } }
```
**Decode:** it's a card action iff `typeof activity.value.ckActionId === "string"`; then `id = activity.value.ckActionId`, `value = activity.value.value`. Any `<Input>`/`<Select>` values are merged into `activity.value` alongside these. Derive the conversation key from `activity.conversation.id`.

## Verification

`@copilotkit/channels-teams`: **88 tests pass** (incl. the 3 new fail-loud stream tests + the new envelope contract test), `tsc` build clean.

Refs Intelligence **OSS-450** / PR #511 (cross-repo consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
