### PR TITLE
docs(channels): clarify managed connection paths

### DIFF
--- a/examples/slack/app/managed-quickstart.ts
+++ b/examples/slack/app/managed-quickstart.ts
@@ -27,9 +27,7 @@ const channel = createBot({
 
 channel.onMention(async ({ thread, message }) => {
   await thread.runAgent({
-    prompt: message.contentParts?.length
-      ? message.contentParts
-      : message.text,
+    prompt: message.contentParts?.length ? message.contentParts : message.text,
   });
 });
 

--- a/examples/slack/app/managed-quickstart.ts
+++ b/examples/slack/app/managed-quickstart.ts
@@ -1,0 +1,65 @@
+import "dotenv/config";
+import { randomUUID } from "node:crypto";
+import { createBot } from "@copilotkit/channels";
+import { SanitizingHttpAgent } from "@copilotkit/channels-slack";
+import { startChannelsOverRealtimeGateway } from "@copilotkit/channels-intelligence";
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+const projectId = Number(required("INTELLIGENCE_PROJECT_ID"));
+if (!Number.isInteger(projectId) || projectId <= 0) {
+  throw new Error("INTELLIGENCE_PROJECT_ID must be a positive integer");
+}
+
+const channelName = required("INTELLIGENCE_CHANNEL_NAME");
+const channel = createBot({
+  name: channelName,
+  agent: (threadId) => {
+    const agent = new SanitizingHttpAgent({ url: required("AGENT_URL") });
+    agent.threadId = threadId;
+    return agent;
+  },
+});
+
+channel.onMention(async ({ thread, message }) => {
+  await thread.runAgent({
+    prompt: message.contentParts?.length
+      ? message.contentParts
+      : message.text,
+  });
+});
+
+const handle = await startChannelsOverRealtimeGateway([channel], {
+  wsUrl: required("INTELLIGENCE_GATEWAY_WS_URL"),
+  apiKey: required("INTELLIGENCE_API_KEY"),
+  scope: {
+    organizationId: required("INTELLIGENCE_ORG_ID"),
+    projectId,
+    channelId: required("INTELLIGENCE_CHANNEL_ID"),
+    channelName,
+  },
+  runtimeInstanceId: `rti_${randomUUID().replaceAll("-", "")}`,
+  adapter: "slack",
+});
+
+async function shutdown(): Promise<void> {
+  await handle.stop();
+  process.exit(0);
+}
+
+process.once("SIGINT", () => {
+  shutdown().catch((error: unknown) => {
+    console.error("Failed to stop Managed Channel", error);
+    process.exit(1);
+  });
+});
+process.once("SIGTERM", () => {
+  shutdown().catch((error: unknown) => {
+    console.error("Failed to stop Managed Channel", error);
+    process.exit(1);
+  });
+});

--- a/packages/channels-intelligence/README.md
+++ b/packages/channels-intelligence/README.md
@@ -52,9 +52,7 @@ const channel = createBot({
 
 channel.onMention(async ({ thread, message }) => {
   await thread.runAgent({
-    prompt: message.contentParts?.length
-      ? message.contentParts
-      : message.text,
+    prompt: message.contentParts?.length ? message.contentParts : message.text,
   });
 });
 
@@ -94,15 +92,15 @@ Run the process with `npx tsx channel.ts`, mention the app in Slack, and verify 
 
 ## Configuration
 
-| Environment variable | Description |
-|---|---|
-| `AGENT_URL` | AG-UI endpoint that runs your agent. |
-| `INTELLIGENCE_GATEWAY_WS_URL` | Outbound Realtime Gateway WebSocket URL from the Channel handoff. |
-| `INTELLIGENCE_API_KEY` | Project runtime API key. |
-| `INTELLIGENCE_ORG_ID` | Intelligence organization ID, prefixed with `org_`. |
-| `INTELLIGENCE_PROJECT_ID` | Positive integer project ID. |
-| `INTELLIGENCE_CHANNEL_ID` | Intelligence Channel ID, prefixed with `channel_`. |
-| `INTELLIGENCE_CHANNEL_NAME` | Lowercase kebab-case Channel name. It must match the bot name and handoff exactly. |
+| Environment variable          | Description                                                                        |
+| ----------------------------- | ---------------------------------------------------------------------------------- |
+| `AGENT_URL`                   | AG-UI endpoint that runs your agent.                                               |
+| `INTELLIGENCE_GATEWAY_WS_URL` | Outbound Realtime Gateway WebSocket URL from the Channel handoff.                  |
+| `INTELLIGENCE_API_KEY`        | Project runtime API key.                                                           |
+| `INTELLIGENCE_ORG_ID`         | Intelligence organization ID, prefixed with `org_`.                                |
+| `INTELLIGENCE_PROJECT_ID`     | Positive integer project ID.                                                       |
+| `INTELLIGENCE_CHANNEL_ID`     | Intelligence Channel ID, prefixed with `channel_`.                                 |
+| `INTELLIGENCE_CHANNEL_NAME`   | Lowercase kebab-case Channel name. It must match the bot name and handoff exactly. |
 
 ## Lifecycle and reconnect behavior
 

--- a/packages/channels-intelligence/README.md
+++ b/packages/channels-intelligence/README.md
@@ -1,0 +1,128 @@
+# @copilotkit/channels-intelligence
+
+`@copilotkit/channels-intelligence` is the early-access transport between a named CopilotKit Channels bot and Managed Channels. Intelligence owns durable channel delivery and provider egress; your infrastructure runs the agent, tools, and application behavior.
+
+## Prerequisites
+
+- Node.js 22 or newer for the built-in WebSocket implementation
+- An AG-UI agent endpoint
+- An Intelligence project, project runtime API key, and configured Slack Channel
+- The runtime handoff values copied from that Channel
+
+Intelligence stores the Slack `xapp-` and `xoxb-` credentials. Do not put Slack tokens in the runtime environment.
+
+## Install
+
+```bash
+npm install @copilotkit/channels@0.1.1 \
+  @copilotkit/channels-slack@0.1.2 \
+  @copilotkit/channels-intelligence@0.1.1 dotenv
+npm install -D typescript tsx @types/node
+```
+
+## Quickstart
+
+```ts
+import "dotenv/config";
+import { randomUUID } from "node:crypto";
+import { createBot } from "@copilotkit/channels";
+import { SanitizingHttpAgent } from "@copilotkit/channels-slack";
+import { startChannelsOverRealtimeGateway } from "@copilotkit/channels-intelligence";
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+const projectId = Number(required("INTELLIGENCE_PROJECT_ID"));
+if (!Number.isInteger(projectId) || projectId <= 0) {
+  throw new Error("INTELLIGENCE_PROJECT_ID must be a positive integer");
+}
+
+const channelName = required("INTELLIGENCE_CHANNEL_NAME");
+const channel = createBot({
+  name: channelName,
+  agent: (threadId) => {
+    const agent = new SanitizingHttpAgent({ url: required("AGENT_URL") });
+    agent.threadId = threadId;
+    return agent;
+  },
+});
+
+channel.onMention(async ({ thread, message }) => {
+  await thread.runAgent({
+    prompt: message.contentParts?.length
+      ? message.contentParts
+      : message.text,
+  });
+});
+
+const handle = await startChannelsOverRealtimeGateway([channel], {
+  wsUrl: required("INTELLIGENCE_GATEWAY_WS_URL"),
+  apiKey: required("INTELLIGENCE_API_KEY"),
+  scope: {
+    organizationId: required("INTELLIGENCE_ORG_ID"),
+    projectId,
+    channelId: required("INTELLIGENCE_CHANNEL_ID"),
+    channelName,
+  },
+  runtimeInstanceId: `rti_${randomUUID().replaceAll("-", "")}`,
+  adapter: "slack",
+});
+
+async function shutdown(): Promise<void> {
+  await handle.stop();
+  process.exit(0);
+}
+
+process.once("SIGINT", () => {
+  shutdown().catch((error: unknown) => {
+    console.error("Failed to stop Managed Channel", error);
+    process.exit(1);
+  });
+});
+process.once("SIGTERM", () => {
+  shutdown().catch((error: unknown) => {
+    console.error("Failed to stop Managed Channel", error);
+    process.exit(1);
+  });
+});
+```
+
+Run the process with `npx tsx channel.ts`, mention the app in Slack, and verify the reply in Slack and the Intelligence Channel timeline.
+
+## Configuration
+
+| Environment variable | Description |
+|---|---|
+| `AGENT_URL` | AG-UI endpoint that runs your agent. |
+| `INTELLIGENCE_GATEWAY_WS_URL` | Outbound Realtime Gateway WebSocket URL from the Channel handoff. |
+| `INTELLIGENCE_API_KEY` | Project runtime API key. |
+| `INTELLIGENCE_ORG_ID` | Intelligence organization ID, prefixed with `org_`. |
+| `INTELLIGENCE_PROJECT_ID` | Positive integer project ID. |
+| `INTELLIGENCE_CHANNEL_ID` | Intelligence Channel ID, prefixed with `channel_`. |
+| `INTELLIGENCE_CHANNEL_NAME` | Lowercase kebab-case Channel name. It must match the bot name and handoff exactly. |
+
+## Lifecycle and reconnect behavior
+
+`startChannelsOverRealtimeGateway` resolves after the gateway connection is authenticated and joined and the bot is running. The gateway client reconnects and rejoins after transient connection loss while the handle remains active. Call `handle.stop()` during shutdown to stop the bot and disconnect the session; the quickstart handles `SIGINT` and `SIGTERM` for you.
+
+Startup rejects invalid Channel names and scopes before opening a socket. Authentication, join, or timeout failures disconnect the startup session. If bot startup fails after joining, the launcher also disconnects before rethrowing.
+
+## Troubleshooting
+
+- **Slack credentials are rejected:** confirm the app and bot tokens belong to the same Slack app and workspace, then re-enter them in Intelligence.
+- **Authentication or join fails:** create a current project runtime API key and verify the project ID.
+- **Channel name mismatch:** copy the Channel name from the handoff exactly.
+- **No active runtime:** keep the runtime process running and verify every Intelligence value came from the same handoff.
+- **Reconnect loop:** check WebSocket reachability and proxy support, then stop duplicate processes declaring the same Channel.
+
+## Early-access limitations
+
+- Managed Slack is the current early-access provider path; Managed Teams is not included.
+- Run one named bot per gateway session.
+- Intelligence operates the provider edge but does not host or execute your agent.
+- OAuth and Slack Marketplace installation are outside this package's current setup path.
+
+Follow the [Managed Slack early-access guide](https://docs.copilotkit.ai/channels/managed/slack) for the full journey. See the [`startChannelsOverRealtimeGateway` reference](https://docs.copilotkit.ai/reference/channels/intelligence) for configuration and failure behavior.

--- a/packages/channels-intelligence/src/index.ts
+++ b/packages/channels-intelligence/src/index.ts
@@ -1,8 +1,6 @@
-// @copilotkit/channels-intelligence — Intelligence-delivered Channel adapter for
-// @copilotkit/channels. Bridges Intelligence-delivered ingress to bot core and emits
-// generic egress operations over injectable transports. Not a publicly
-// documented API; consumed by the runtime/Channel-listener bootstrap and the
-// Intelligence side.
+// @copilotkit/channels-intelligence — early-access Intelligence transport for
+// @copilotkit/channels. Applications keep running their agent behavior while
+// Intelligence owns durable channel delivery and provider egress.
 
 export {
   intelligenceAdapter,

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -1,40 +1,44 @@
 ---
 title: Channels
-description: Build durable, cross-platform AI bots with CopilotKit — a platform adapter, an AG-UI agent, and optional persistence wired together in a single createBot call.
-icon: "lucide/Bot"
+description: Build AI agents for Slack, Microsoft Teams, Discord, Telegram, and WhatsApp with the CopilotKit Channels SDK, or let Managed Channels operate the provider connection and durable delivery.
+icon: "lucide/MessagesSquare"
 hideTOC: true
+doc_type: explanation
 ---
 
-The channel stack is three pieces: **`@copilotkit/channels`** (core runtime), a **platform adapter** (e.g. `@copilotkit/channels-slack`), and an **AG-UI agent** — any CopilotKit runtime or compatible backend. Plug them together with `createBot` and you get a bot that streams agent replies into the platform, handles interactive buttons, and — once you add a store — survives restarts and spans multiple instances.
+Channels brings the same CopilotKit agent behavior into workplace and messaging platforms. You keep your agent, tools, and application logic; choose whether your application owns the provider connection or CopilotKit Intelligence manages that edge for you.
 
-<OpsPlatformCTA
-  variant="inline"
-  title="Join the waitlist for managed Slack and Teams agents"
-  body="Start here when you want to own the adapter, runtime, and store. Join the waitlist if you want CopilotKit Intelligence to manage Slack and Teams setup, identity, durable state, approvals, and production operations."
-  ctaLabel="Join the waitlist"
-  surface="docs_bots_managed_agents_waitlist"
-  href="https://www.copilotkit.ai/opentag-managed"
-/>
+## Choose how your Channel runs
 
 <Cards>
   <Card
-    title="Slack quickstart"
+    title="Run Channels in your stack"
     href="/slack"
-    description="From zero to a working Slack bot in minutes — Socket Mode, streaming replies, and interactive Block Kit buttons."
+    description="Use the open-source Channels SDK and own the platform adapter, provider credentials, runtime, and persistence."
   />
   <Card
-    title="Persistence"
-    href="/channels/persistence"
-    description="Persist actions, locks, and per-thread state across restarts by backing the store with a durable StateStore implementation."
+    title="Use Managed Channels"
+    href="/channels/managed"
+    description="Let Intelligence manage Slack setup, credentials, durable delivery, retries, and egress while your infrastructure runs the agent."
   />
-  <Card
-    title="Transcripts"
-    href="/channels/transcripts"
-    description="Give the agent a cross-platform memory that follows users from Slack to any other channel — with GDPR-ready delete support."
-  />
-  <Card
-    title="Channels reference"
-    href="/reference/channels"
-    description="Full API reference — createBot, Thread, StateStore, ActionStore, and the Slack adapter."
-  />
+</Cards>
+
+## Same agent, different edge
+
+| | OSS Channels | Managed Channels |
+|---|---|---|
+| Agent and tools | Your infrastructure | Your infrastructure |
+| Provider credentials and connection | Your application | Intelligence |
+| Durable inbound delivery and retries | You provide it | Intelligence |
+| Provider replies and operational timeline | You provide it | Intelligence |
+
+The public SDK still uses API names such as `createBot`, `Bot`, and `BotTool` where “bot” describes the framework object. The product and documentation call the capability Channels.
+
+## Keep building
+
+<Cards>
+  <Card title="Managed Channels" href="/channels/managed" description="Understand the ownership boundary and connect Managed Slack." />
+  <Card title="Persistence" href="/channels/persistence" description="Persist actions, locks, and per-thread state for OSS Channels." />
+  <Card title="Transcripts" href="/channels/transcripts" description="Build cross-platform history for OSS Channels." />
+  <Card title="API reference" href="/reference/channels" description="Look up the Channels SDK, UI vocabulary, and adapters." />
 </Cards>

--- a/showcase/shell-docs/src/content/docs/channels/managed/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/managed/index.mdx
@@ -1,0 +1,49 @@
+---
+title: Managed Channels
+description: Understand how Managed Channels connects CopilotKit agents to Slack through Intelligence-managed credentials, durable delivery, realtime transport, retries, and provider egress.
+icon: "lucide/Radio"
+doc_type: explanation
+premium: true
+---
+
+Managed Channels lets you connect your existing CopilotKit agent behavior to Slack without operating the Slack-facing integration layer. Intelligence stores the Slack credentials, receives channel events, delivers work durably to your runtime, and sends rendered replies back to Slack, while your infrastructure runs the agent, tools, and application code.
+
+<Callout type="info" title="Early access">
+  Managed Slack is in controlled early access. Microsoft Teams is not part of this launch scope.
+</Callout>
+
+## What Intelligence manages
+
+- Slack app setup and encrypted provider credentials
+- The provider connection and inbound event normalization
+- Durable delivery, retries, and reconnect/replay through the Realtime Gateway
+- Provider egress and the operational event timeline
+
+## What you manage
+
+- Your agent and model-provider credentials
+- Your tools, context, prompts, and business logic
+- The application process that connects outbound to the Realtime Gateway
+- Access controls and end-user behavior inside your application
+
+## How a turn moves
+
+1. Slack sends an event to Intelligence.
+2. Intelligence stores the event and makes a durable delivery available.
+3. Your runtime receives the turn over an outbound realtime connection and runs your agent.
+4. Rendered output returns through Intelligence and is delivered to Slack.
+
+Intelligence does not host or execute your agent.
+
+## Choose Managed Channels when
+
+- you want Slack setup and credentials out of your application deployment;
+- you need durable retries and an operational timeline for channel work;
+- you want the same agent behavior to work with a managed provider edge.
+
+Choose the [OSS Slack quickstart](/slack) when your application should own the Slack adapter and credentials directly.
+
+## Next steps
+
+- **Run Slack yourself:** [Slack quickstart](/slack) — own the Slack adapter and credentials in your application
+- **Understand the platform:** [Enterprise Intelligence Platform](/premium/overview) — projects, hosting options, and operational capabilities

--- a/showcase/shell-docs/src/content/docs/channels/managed/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/managed/index.mdx
@@ -45,5 +45,6 @@ Choose the [OSS Slack quickstart](/slack) when your application should own the S
 
 ## Next steps
 
+- **Connect Managed Slack:** [Managed Slack early access](/channels/managed/slack) — create a Channel, connect your runtime, and verify the first reply
 - **Run Slack yourself:** [Slack quickstart](/slack) — own the Slack adapter and credentials in your application
 - **Understand the platform:** [Enterprise Intelligence Platform](/premium/overview) — projects, hosting options, and operational capabilities

--- a/showcase/shell-docs/src/content/docs/channels/managed/meta.json
+++ b/showcase/shell-docs/src/content/docs/channels/managed/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Managed Channels",
   "icon": "lucide/Radio",
-  "pages": ["index"]
+  "pages": ["index", "slack"]
 }

--- a/showcase/shell-docs/src/content/docs/channels/managed/meta.json
+++ b/showcase/shell-docs/src/content/docs/channels/managed/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Managed Channels",
+  "icon": "lucide/Radio",
+  "pages": ["index"]
+}

--- a/showcase/shell-docs/src/content/docs/channels/managed/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/managed/slack.mdx
@@ -1,0 +1,174 @@
+---
+title: Managed Slack early access
+description: Connect an existing CopilotKit or AG-UI agent to Slack with Managed Channels, Intelligence-managed credentials, durable delivery, realtime transport, and provider egress.
+icon: "lucide/Slack"
+doc_type: tutorial
+premium: true
+---
+
+**Where you are starting:** you have an AG-UI agent endpoint and an Intelligence project.
+
+**Where you are headed:** a Slack mention is delivered durably to your runtime, your infrastructure runs the agent, and the reply appears in Slack and the Intelligence timeline.
+
+<Callout type="info" title="Early access">
+  This guide covers Managed Slack. It does not host your agent, and it does not describe Managed Teams.
+</Callout>
+
+<Steps>
+  <Step>
+    ### Select an Intelligence project
+
+    Open CopilotKit Intelligence, create or select the project that will own the Channel, and create a project runtime API key. Keep the key available for your runtime environment; it authenticates the outbound Realtime Gateway connection.
+  </Step>
+
+  <Step>
+    ### Create the Channel and connect Slack
+
+    In the project, create a Slack Channel and complete the four-step Socket Mode wizard:
+
+    1. Copy the generated Slack app manifest into a new Slack app.
+    2. Create an app-level token with `connections:write`, then paste the `xapp-` token into Intelligence.
+    3. Install the app to the workspace, then paste the `xoxb-` bot token into Intelligence.
+    4. Invite the app to the Slack channel shown by the wizard.
+
+    Intelligence stores the Slack credentials. Do not copy either Slack token into the runtime you create below.
+  </Step>
+
+  <Step>
+    ### Install the early-access packages
+
+    Create an ESM TypeScript project and install the published Channels packages:
+
+    ```bash
+    mkdir managed-slack-runtime && cd managed-slack-runtime
+    npm init -y
+    npm pkg set type=module
+    npm install @copilotkit/channels@0.1.1 \
+      @copilotkit/channels-slack@0.1.2 \
+      @copilotkit/channels-intelligence@0.1.1 dotenv
+    npm install -D typescript tsx @types/node
+    ```
+  </Step>
+
+  <Step>
+    ### Create the Channel runtime
+
+    Create `channel.ts`. This process connects outbound to Intelligence and runs the agent in your infrastructure:
+
+    ```ts title="channel.ts"
+    import "dotenv/config";
+    import { randomUUID } from "node:crypto";
+    import { createBot } from "@copilotkit/channels";
+    import { SanitizingHttpAgent } from "@copilotkit/channels-slack";
+    import { startChannelsOverRealtimeGateway } from "@copilotkit/channels-intelligence";
+
+    function required(name: string): string {
+      const value = process.env[name];
+      if (!value) throw new Error(`Missing required environment variable: ${name}`);
+      return value;
+    }
+
+    const projectId = Number(required("INTELLIGENCE_PROJECT_ID"));
+    if (!Number.isInteger(projectId) || projectId <= 0) {
+      throw new Error("INTELLIGENCE_PROJECT_ID must be a positive integer");
+    }
+
+    const channelName = required("INTELLIGENCE_CHANNEL_NAME");
+    const channel = createBot({
+      name: channelName,
+      agent: (threadId) => {
+        const agent = new SanitizingHttpAgent({ url: required("AGENT_URL") });
+        agent.threadId = threadId;
+        return agent;
+      },
+    });
+
+    channel.onMention(async ({ thread, message }) => {
+      await thread.runAgent({
+        prompt: message.contentParts?.length
+          ? message.contentParts
+          : message.text,
+      });
+    });
+
+    const handle = await startChannelsOverRealtimeGateway([channel], {
+      wsUrl: required("INTELLIGENCE_GATEWAY_WS_URL"),
+      apiKey: required("INTELLIGENCE_API_KEY"),
+      scope: {
+        organizationId: required("INTELLIGENCE_ORG_ID"),
+        projectId,
+        channelId: required("INTELLIGENCE_CHANNEL_ID"),
+        channelName,
+      },
+      runtimeInstanceId: `rti_${randomUUID().replaceAll("-", "")}`,
+      adapter: "slack",
+    });
+
+    async function shutdown(): Promise<void> {
+      await handle.stop();
+      process.exit(0);
+    }
+
+    process.once("SIGINT", () => {
+      shutdown().catch((error: unknown) => {
+        console.error("Failed to stop Managed Channel", error);
+        process.exit(1);
+      });
+    });
+    process.once("SIGTERM", () => {
+      shutdown().catch((error: unknown) => {
+        console.error("Failed to stop Managed Channel", error);
+        process.exit(1);
+      });
+    });
+    ```
+  </Step>
+
+  <Step>
+    ### Configure the runtime
+
+    Copy the corrected handoff values from Intelligence into `.env`:
+
+    ```dotenv title=".env"
+    AGENT_URL=https://your-agent.example.com/api/copilotkit/agent/assistant/run
+    INTELLIGENCE_GATEWAY_WS_URL=wss://your-intelligence-gateway.example.com/socket
+    INTELLIGENCE_API_KEY=cpk-...
+    INTELLIGENCE_ORG_ID=org_...
+    INTELLIGENCE_PROJECT_ID=123
+    INTELLIGENCE_CHANNEL_ID=channel_...
+    INTELLIGENCE_CHANNEL_NAME=support-assistant
+    ```
+
+    `INTELLIGENCE_CHANNEL_NAME` must exactly match the Channel name in Intelligence. Do not add `SLACK_BOT_TOKEN` or `SLACK_APP_TOKEN`; Intelligence owns those credentials.
+  </Step>
+
+  <Step>
+    ### Run and verify the first reply
+
+    Start the outbound runtime process:
+
+    ```bash
+    npx tsx channel.ts
+    ```
+
+    Mention the app in the Slack channel you invited it to. Verify that the agent reply appears in the Slack thread, then open the Channel timeline in Intelligence and confirm the delivered turn and reply are visible.
+  </Step>
+
+  <Step>
+    ### Troubleshoot the connection
+
+    | Symptom | Check |
+    |---|---|
+    | Intelligence rejects the Slack credentials | Confirm the `xapp-` app token and `xoxb-` bot token belong to the same Slack app and workspace. Re-enter them in Intelligence, not in the runtime `.env`. |
+    | Authentication or join fails | Create a current project runtime API key and confirm `INTELLIGENCE_API_KEY` belongs to `INTELLIGENCE_PROJECT_ID`. |
+    | Runtime reports a channel-name mismatch | Copy `INTELLIGENCE_CHANNEL_NAME` from the handoff exactly; it must match the name passed to `createBot`. |
+    | Slack shows no active runtime | Keep `npx tsx channel.ts` running and confirm the gateway URL, organization, project, and Channel IDs came from the same handoff. |
+    | The connection repeatedly reconnects | Check gateway reachability and proxy WebSocket support. Stop duplicate runtime processes that declare the same Channel, then restart one instance. |
+  </Step>
+</Steps>
+
+**You have reached point B:** Slack work is delivered durably through Intelligence, your infrastructure runs the agent, and replies appear in both Slack and the operational timeline.
+
+<Callout type="info" title="Run Slack in your own stack instead">
+  Use the [OSS Slack quickstart](/slack) when your application should own the Slack adapter and provider credentials directly.
+</Callout>

--- a/showcase/shell-docs/src/content/docs/channels/managed/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/managed/slack.mdx
@@ -85,9 +85,7 @@ premium: true
 
     channel.onMention(async ({ thread, message }) => {
       await thread.runAgent({
-        prompt: message.contentParts?.length
-          ? message.contentParts
-          : message.text,
+        prompt: message.contentParts?.length ? message.contentParts : message.text,
       });
     });
 

--- a/showcase/shell-docs/src/content/docs/channels/meta.json
+++ b/showcase/shell-docs/src/content/docs/channels/meta.json
@@ -1,5 +1,5 @@
 {
-  "title": "Bots",
-  "icon": "lucide/Bot",
-  "pages": ["index", "persistence", "transcripts"]
+  "title": "Channels",
+  "icon": "lucide/MessagesSquare",
+  "pages": ["index", "managed", "persistence", "transcripts"]
 }

--- a/showcase/shell-docs/src/content/docs/channels/persistence.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/persistence.mdx
@@ -2,20 +2,16 @@
 title: Persistence
 description: Make bot state, interactive actions, and per-thread data survive restarts and scale across multiple instances with a durable store backend.
 icon: "lucide/Database"
+doc_type: how-to
 ---
 
 **Where you're starting from:** a dev bot where every restart wipes button handlers, resets thread state, and drops duplicate-detection memory. A user clicks a button five minutes after a deploy and nothing happens.
 
 **Where you're headed:** the same bot, wired to a durable store, where actions survive restarts, concurrent turns are serialised with a turn lock, and each thread carries typed state that persists across runs.
 
-<OpsPlatformCTA
-  variant="inline"
-  title="Join the waitlist for managed Slack and Teams agents"
-  body="This page shows how to bring your own Redis or PostgreSQL store. Join the waitlist if you want CopilotKit Intelligence to manage durable state, runtime handoff, approvals, analytics, and release operations for Slack and Teams."
-  ctaLabel="Join the waitlist"
-  surface="docs_bots_persistence_managed_agents_waitlist"
-  href="https://www.copilotkit.ai/opentag-managed"
-/>
+<Callout type="info" title="Using Managed Channels?">
+  These pages cover persistence that you own for OSS Channels. With [Managed Channels](/channels/managed), Intelligence provides the durable channel delivery path while your infrastructure continues to run the agent.
+</Callout>
 
 <Steps>
   <Step>

--- a/showcase/shell-docs/src/content/docs/channels/transcripts.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/transcripts.mdx
@@ -2,20 +2,16 @@
 title: Transcripts
 description: Give your bot a cross-platform memory that follows users across Slack, Teams, and any other channel — with automatic context injection and GDPR-ready delete.
 icon: "lucide/MessageSquare"
+doc_type: how-to
 ---
 
 **Where you're starting from:** a bot that forgets the user entirely between messages. The agent has no awareness that this Slack user is the same person who asked a related question on Teams yesterday, or what they said there.
 
 **Where you're headed:** one cross-platform memory indexed by user identity, automatically injected into every agent run, and deletable on request.
 
-<OpsPlatformCTA
-  variant="inline"
-  title="Join the waitlist for managed Slack and Teams agents"
-  body="This page shows how to map users and store transcripts yourself. Join the waitlist if you want CopilotKit Intelligence to manage identity, permissions, durable state, and Slack and Teams setup around the same agent runtime."
-  ctaLabel="Join the waitlist"
-  surface="docs_bots_transcripts_managed_agents_waitlist"
-  href="https://www.copilotkit.ai/opentag-managed"
-/>
+<Callout type="info" title="Using Managed Channels?">
+  These pages cover persistence that you own for OSS Channels. With [Managed Channels](/channels/managed), Intelligence provides the durable channel delivery path while your infrastructure continues to run the agent.
+</Callout>
 
 <Steps>
   <Step>

--- a/showcase/shell-docs/src/content/docs/concepts/oss-vs-enterprise.mdx
+++ b/showcase/shell-docs/src/content/docs/concepts/oss-vs-enterprise.mdx
@@ -18,6 +18,8 @@ CopilotKit ships in two layers: an **open-source frontend stack** (npm packages,
 |---|---|---|
 | Agent chat, frontend tools, agent state, gen-UI | Yes | |
 | Any AG-UI integration (LangGraph, Mastra, Built-in, custom) | Yes | |
+| Run a Slack adapter and credentials in your own application | Yes | |
+| Intelligence-managed Slack connection and durable channel delivery | | Yes |
 | Conversation history that survives reloads / devices | | Yes |
 | `useThreads` + realtime sync across tabs / devices | | Yes |
 | Hosted inspector, admin console, multi-tenancy | | Yes |
@@ -41,6 +43,7 @@ Apache 2.0 licensed. Run it on any host, in any cloud, with any LLM provider.
 A separate **backend service** that sits beside your runtime and unlocks the capabilities that need durable, multi-tenant infrastructure to be honest about:
 
 - **Threads & Persistence** — durable, resumable conversations that survive page reloads, span devices, and sync in realtime via WebSocket. Backed by Postgres + Redis with single-writer locks on active runs.
+- **[Managed Channels](/channels/managed)** — Intelligence manages Slack setup, encrypted credentials, durable delivery, retries, realtime transport, and egress while your infrastructure runs the agent.
 - **Inspection & history** — project-scoped thread history, event timelines, admin views, and API key management in the hosted web app.
 - **Inspector & Admin Console** — a hosted web UI for browsing thread history, inspecting agent traces, rotating API keys, and managing projects and organizations.
 - **Multi-tenancy** — three-level isolation (organizations, projects, users) so a single deployment can host production and staging side by side without one reading the other's data.

--- a/showcase/shell-docs/src/content/docs/frontends/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/slack.mdx
@@ -9,7 +9,7 @@ doc_type: tutorial
 This tutorial covers the OSS Channels path, where your application owns the Slack adapter, provider credentials, runtime, and persistence. Slack can be the frontend for agents built on any harness or framework, with TypeScript handlers and JSX-authored Block Kit messages for the conversations, approvals, and handoffs your team already uses.
 
 <Callout type="info" title="Want Intelligence to manage the Slack connection?">
-  Learn about [Managed Channels](/channels/managed). Intelligence stores the Slack credentials and operates durable delivery; your infrastructure still runs the agent.
+  Follow the [Managed Slack early-access guide](/channels/managed/slack). Intelligence stores the Slack credentials and operates durable delivery; your infrastructure still runs the agent.
 </Callout>
 
 ## Prerequisites

--- a/showcase/shell-docs/src/content/docs/frontends/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/slack.mdx
@@ -1,20 +1,16 @@
 ---
 title: Slack
-description: Bring custom agents into Slack with native cards, streaming replies, approvals, and durable thread context.
+description: Run the open-source Channels Slack adapter in your application with native cards, streaming replies, approvals, and durable thread context.
 icon: "lucide/Slack"
 hideTOC: true
+doc_type: tutorial
 ---
 
-Slack can be the frontend for agents built on any harness or framework, so your team can get work done in the conversations, approvals, and handoffs they already use. The open source Bot SDK gives you the adapter path for TypeScript handlers and JSX-authored Block Kit messages. CopilotKit Enterprise Intelligence adds the self-hosted or cloud-hosted production layer for thread mapping, durable agent state, approvals, observability, and release operations when Slack becomes a critical workflow.
+This tutorial covers the OSS Channels path, where your application owns the Slack adapter, provider credentials, runtime, and persistence. Slack can be the frontend for agents built on any harness or framework, with TypeScript handlers and JSX-authored Block Kit messages for the conversations, approvals, and handoffs your team already uses.
 
-<OpsPlatformCTA
-  variant="inline"
-  title="Get early access to Slack and Teams agents in CopilotKit Enterprise Intelligence"
-  body="Use the open source Bot SDK to run the adapter, runtime, platform credentials, tools, and storage inside your stack. CopilotKit Enterprise Intelligence adds the self-hosted or cloud-hosted production layer around that SDK: durable agent threads, platform conversation mapping, approvals, observability, and release operations for Slack and Teams."
-  ctaLabel="Get early access"
-  surface="docs_slack_agents_early_access"
-  href="https://www.copilotkit.ai/opentag-managed"
-/>
+<Callout type="info" title="Want Intelligence to manage the Slack connection?">
+  Learn about [Managed Channels](/channels/managed). Intelligence stores the Slack credentials and operates durable delivery; your infrastructure still runs the agent.
+</Callout>
 
 ## Prerequisites
 
@@ -240,7 +236,7 @@ Slack can be the frontend for agents built on any harness or framework, so your 
         Mention the bot with "deploy" in the message and click the buttons. Your handler code never leaves your process — Slack only sees an opaque action id.
 
         <Callout type="warn" title="Buttons expire on restart">
-          The default action store is **in-memory**: after a process restart, clicks on old buttons are acknowledged but ignored. For buttons that survive restarts, plug a durable store (Redis, a database) into `createBot({ actionStore })` — see the [ActionStore contract](/reference/channels/types/ActionStore).
+          The default store is **in-memory**: after a process restart, clicks on old buttons are acknowledged but ignored. For buttons that survive restarts, plug a durable store (Redis or a database) into `createBot({ store: { adapter } })`. See [Persistence](/channels/persistence) for the complete setup and the [ActionStore contract](/reference/channels/types/ActionStore) for the action interface.
         </Callout>
     </Step>
     <Step>

--- a/showcase/shell-docs/src/content/docs/frontends/teams.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/teams.mdx
@@ -1,19 +1,15 @@
 ---
 title: Microsoft Teams
-description: Bring custom agents into Microsoft Teams with Adaptive Cards, streaming updates, approvals, and durable conversation context.
+description: Run the open-source Channels Teams adapter in your application with Adaptive Cards, streaming updates, approvals, and durable conversation context.
 hideTOC: true
+doc_type: tutorial
 ---
 
-Microsoft Teams can be the frontend for agents built on any harness or framework, so your organization can get work done where conversations, decisions, and approvals already happen. The open source Bot SDK gives you the adapter path for TypeScript handlers and JSX-authored Adaptive Cards. CopilotKit Enterprise Intelligence adds the self-hosted or cloud-hosted production layer for conversation mapping, durable agent state, approvals, observability, and release operations when Teams becomes a critical workflow.
+This tutorial covers the OSS Channels path, where your application owns the Microsoft Teams adapter, credentials, runtime, and persistence. Teams can be the frontend for agents built on any harness or framework, with TypeScript handlers and JSX-authored Adaptive Cards where conversations, decisions, and approvals already happen.
 
-<OpsPlatformCTA
-  variant="inline"
-  title="Get early access to Slack and Teams agents in CopilotKit Enterprise Intelligence"
-  body="Use the open source Bot SDK to run the adapter, runtime, platform credentials, tools, and storage inside your stack. CopilotKit Enterprise Intelligence adds the self-hosted or cloud-hosted production layer around that SDK: durable agent threads, platform conversation mapping, approvals, observability, and release operations for Slack and Teams."
-  ctaLabel="Get early access"
-  surface="docs_teams_agents_early_access"
-  href="https://www.copilotkit.ai/opentag-managed"
-/>
+<Callout type="info" title="Managed Teams status">
+  This page covers the open-source Teams adapter. Managed Slack is the current Managed Channels early-access path; Managed Teams is not part of this launch scope.
+</Callout>
 
 ## Prerequisites
 

--- a/showcase/shell-docs/src/content/reference/channels/index.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Channels"
 description: "API reference for the CopilotKit channel stack — @copilotkit/channels, @copilotkit/channels-ui, @copilotkit/channels-slack, and @copilotkit/channels-discord."
+doc_type: reference
 ---
 
 The channel stack turns any [AG-UI](https://docs.ag-ui.com) agent into a chat-platform bot. Three packages, three jobs:
@@ -22,14 +23,9 @@ pnpm add @copilotkit/channels @copilotkit/channels-ui @copilotkit/channels-disco
   New to the stack? Start with the [Slack quickstart](/slack) — zero to a working bot, then come back here for the API surface.
 </Callout>
 
-<OpsPlatformCTA
-  variant="inline"
-  title="Join the waitlist for managed Slack and Teams agents"
-  body="The APIs below let you own the adapter, runtime, platform credentials, tools, and storage. Join the waitlist if you want CopilotKit Intelligence to manage Slack and Teams rollout, identity, durable state, approvals, observability, and release workflows."
-  ctaLabel="Join the waitlist"
-  surface="reference_bot_managed_agents_waitlist"
-  href="https://www.copilotkit.ai/opentag-managed"
-/>
+<Callout type="info" title="Looking for Managed Channels?">
+  Start with the [Managed Channels ownership model](/channels/managed). Intelligence manages Slack setup, credentials, durable delivery, retries, realtime transport, and egress while your infrastructure runs the agent.
+</Callout>
 
 ## Setup
 
@@ -81,5 +77,6 @@ A turn flows through three stages. The adapter normalizes a platform event into 
 
 ## Related
 
+- [Managed Channels](/channels/managed) — understand the Intelligence-managed provider edge and customer-owned agent boundary
 - [Slack quickstart](/slack) — create the Slack app, install, and run your first bot
 - [On-call triage example](https://github.com/CopilotKit/CopilotKit/tree/main/examples/slack) — a full bot over Linear + Notion MCP with HITL and slash commands

--- a/showcase/shell-docs/src/content/reference/channels/index.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/index.mdx
@@ -78,5 +78,6 @@ A turn flows through three stages. The adapter normalizes a platform event into 
 ## Related
 
 - [Managed Channels](/channels/managed) — understand the Intelligence-managed provider edge and customer-owned agent boundary
+- [`startChannelsOverRealtimeGateway`](/reference/channels/intelligence) — connect a named Channels SDK bot to the managed transport
 - [Slack quickstart](/slack) — create the Slack app, install, and run your first bot
 - [On-call triage example](https://github.com/CopilotKit/CopilotKit/tree/main/examples/slack) — a full bot over Linear + Notion MCP with HITL and slash commands

--- a/showcase/shell-docs/src/content/reference/channels/intelligence/index.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/intelligence/index.mdx
@@ -1,0 +1,52 @@
+---
+title: "startChannelsOverRealtimeGateway"
+description: "Connect named @copilotkit/channels bots to Managed Channels over the Intelligence Realtime Gateway while your infrastructure runs the agent."
+doc_type: reference
+---
+
+`startChannelsOverRealtimeGateway` starts one named Channels SDK bot over an outbound Intelligence Realtime Gateway connection. Start with the [Managed Channels ownership model](/channels/managed).
+
+## Signature
+
+```ts title="channel.ts"
+function startChannelsOverRealtimeGateway(
+  bots: Bot[],
+  config: StartChannelsOverRealtimeGatewayOptions,
+): Promise<ChannelsHandle>;
+```
+
+The early-access transport accepts exactly one bot per gateway session. Create that bot with a lowercase kebab-case `name` and pass the same value as `scope.channelName`.
+
+## Configuration
+
+| Field | Required | Description |
+|---|---|---|
+| `wsUrl` | Yes | Realtime Gateway runner WebSocket URL. The connection is outbound from your application process. |
+| `apiKey` | Yes | Intelligence project runtime API key used to authenticate the socket. |
+| `scope.organizationId` | Yes | Intelligence organization ID. It must start with `org_`. |
+| `scope.projectId` | Yes | Positive integer Intelligence project ID. |
+| `scope.channelId` | Yes | Intelligence Channel ID. It must start with `channel_`. |
+| `scope.channelName` | Yes | Lowercase kebab-case Channel name, 3–64 characters. It must match the name passed to `createBot`. |
+| `runtimeInstanceId` | Yes | Stable identifier for this running process, conventionally prefixed with `rti_`. |
+| `adapter` | No | Provider kind declared when joining the gateway. Defaults to `"slack"`. |
+| `timeoutMs` | No | Join and push timeout in milliseconds. Defaults to `10_000`. |
+| `log` | No | Diagnostic callback for transport events and dropped deliveries. Treat metadata as sensitive and do not log raw message content. |
+
+## Return value
+
+The promise resolves to a `ChannelsHandle` after the gateway connection is authenticated, joined, and the bot has started:
+
+- `metadata` contains the runtime environment, runtime instance ID, and declared Channel names and commands sent during activation.
+- `stop()` stops the bot and disconnects the gateway session. The connection is disconnected even if bot shutdown throws.
+
+## Failure behavior
+
+- Invalid or duplicate bot names, an invalid scope, more than one bot, or a mismatch between the bot name and `scope.channelName` reject before a socket is opened.
+- Authentication and join failures reject startup and disconnect the socket.
+- A connection timeout rejects startup and disconnects the socket. Set `timeoutMs` only when the default 10-second window is inappropriate for your network.
+- While the handle remains active, the underlying gateway client reconnects and rejoins after transient connection loss.
+- If bot startup fails after the gateway has joined, startup cleanup disconnects the session before rethrowing the error.
+
+## Next steps
+
+- Review the [Managed Channels ownership model](/channels/managed) before connecting a production runtime.

--- a/showcase/shell-docs/src/content/reference/channels/intelligence/index.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/intelligence/index.mdx
@@ -49,4 +49,5 @@ The promise resolves to a `ChannelsHandle` after the gateway connection is authe
 
 ## Next steps
 
+- Follow the [Managed Slack early-access guide](/channels/managed/slack) to create a Channel, connect your runtime, and verify the first reply.
 - Review the [Managed Channels ownership model](/channels/managed) before connecting a production runtime.

--- a/showcase/shell-docs/src/content/snippets/shared/premium/overview.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/premium/overview.mdx
@@ -9,6 +9,7 @@ Start here when you are deciding what the platform gives you and where it should
 | Capability | What it gives you | Deeper dive |
 |---|---|---|
 | Durable threads and persistence | Resumable conversations that survive reloads, devices, and browser sessions. | [Threads](/threads) and [Threads & Persistence Architecture](/premium/threads-explained) |
+| Managed Channels | Intelligence-managed Slack setup, encrypted credentials, durable delivery, retries, realtime transport, egress, and an operational timeline. Your infrastructure still runs the agent. | [Managed Channels](/channels/managed) |
 | Cloud-hosted Intelligence features | Projects, project API keys, conversation history, thread inspection, and plan management. | [Cloud-Hosted Enterprise Intelligence](/premium/managed-intelligence-platform) |
 | Premium UI capabilities | Platform-gated UI surfaces such as Fully Headless Chat UI. | [Fully Headless Chat UI](/premium/headless-ui) |
 | Self-hosting | The same platform running inside your own Kubernetes cluster, VPC, or data boundary. | [Self-Hosting Enterprise Intelligence](/premium/self-hosting) |

--- a/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
@@ -257,6 +257,29 @@ describe("Managed Channels docs", () => {
 
     expect(loadDoc("frontends/slack")?.source).toContain("/channels/managed");
   });
+
+  it("discovers the channels-intelligence reference", () => {
+    const reference = path.join(
+      CONTENT_DIR,
+      "..",
+      "reference/channels/intelligence/index.mdx",
+    );
+    const source = fs.readFileSync(reference, "utf8");
+    const tree = buildReferencePageTree("channels");
+    const pageUrls: string[] = [];
+
+    const visit = (nodes: typeof tree.children): void => {
+      for (const node of nodes) {
+        if (node.type === "page") pageUrls.push(node.url);
+        if (node.type === "folder") visit(node.children);
+      }
+    };
+    visit(tree.children);
+
+    expect(source).toContain("doc_type: reference");
+    expect(source).toContain("startChannelsOverRealtimeGateway");
+    expect(pageUrls).toContain("/reference/channels/intelligence");
+  });
 });
 
 describe("migration docs", () => {

--- a/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
@@ -280,6 +280,17 @@ describe("Managed Channels docs", () => {
     expect(source).toContain("startChannelsOverRealtimeGateway");
     expect(pageUrls).toContain("/reference/channels/intelligence");
   });
+
+  it("publishes the Managed Slack tutorial with the supported API", () => {
+    const tutorial = loadDoc("channels/managed/slack")?.source ?? "";
+
+    expect(tutorial).toContain("doc_type: tutorial");
+    expect(tutorial).toContain("startChannelsOverRealtimeGateway");
+    expect(tutorial).toContain("message.contentParts");
+    expect(tutorial).toContain("your infrastructure runs the agent");
+    expect(tutorial).not.toContain('@copilotkit/channel"');
+    expect(tutorial).not.toContain("createChannel(");
+  });
 });
 
 describe("migration docs", () => {

--- a/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
@@ -215,6 +215,30 @@ describe("reference nav", () => {
   });
 });
 
+describe("Managed Channels docs", () => {
+  it("publishes Channels navigation and the managed overview", () => {
+    const channelsMeta = JSON.parse(
+      fs.readFileSync(path.join(CONTENT_DIR, "channels/meta.json"), "utf8"),
+    ) as { title: string; pages: string[] };
+
+    expect(channelsMeta.title).toBe("Channels");
+    expect(channelsMeta.pages).toEqual([
+      "index",
+      "managed",
+      "persistence",
+      "transcripts",
+    ]);
+
+    const landing = loadDoc("channels");
+    const managed = loadDoc("channels/managed");
+
+    expect(landing?.source).toContain("doc_type: explanation");
+    expect(landing?.source).toContain("/channels/managed");
+    expect(managed?.source).toContain("doc_type: explanation");
+    expect(managed?.source).toContain("your infrastructure runs the agent");
+  });
+});
+
 describe("migration docs", () => {
   it("recommends CopilotKit from the v2 entrypoint instead of CopilotKitProvider", () => {
     const snippet = fs.readFileSync(

--- a/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
@@ -237,6 +237,28 @@ describe("Managed Channels docs", () => {
     expect(managed?.source).toContain("doc_type: explanation");
     expect(managed?.source).toContain("your infrastructure runs the agent");
   });
+
+  it("links existing Channels pages to Managed Slack without the old waitlist promise", () => {
+    const slugs = [
+      "channels",
+      "channels/persistence",
+      "channels/transcripts",
+      "frontends/slack",
+      "frontends/teams",
+    ];
+
+    for (const slug of slugs) {
+      const source = loadDoc(slug)?.source ?? "";
+      expect(source).not.toContain(
+        "Join the waitlist for managed Slack and Teams agents",
+      );
+      expect(source).not.toContain("open source Bot SDK");
+    }
+
+    expect(loadDoc("frontends/slack")?.source).toContain(
+      "/channels/managed",
+    );
+  });
 });
 
 describe("migration docs", () => {

--- a/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
@@ -255,9 +255,7 @@ describe("Managed Channels docs", () => {
       expect(source).not.toContain("open source Bot SDK");
     }
 
-    expect(loadDoc("frontends/slack")?.source).toContain(
-      "/channels/managed",
-    );
+    expect(loadDoc("frontends/slack")?.source).toContain("/channels/managed");
   });
 });
 

--- a/showcase/shell-docs/src/lib/reference-items.ts
+++ b/showcase/shell-docs/src/lib/reference-items.ts
@@ -52,6 +52,7 @@ export const REFERENCE_CATEGORIES = [
   "SDKs",
   "Slack",
   "Discord",
+  "Intelligence",
 ] as const;
 export type ReferenceCategory = (typeof REFERENCE_CATEGORIES)[number];
 
@@ -66,7 +67,8 @@ type ReferenceSubdir =
   | "enums"
   | "sdk"
   | "slack"
-  | "discord";
+  | "discord"
+  | "intelligence";
 
 const VERSION_SUBDIRS: Record<ReferenceVersion, ReferenceSubdir[]> = {
   v2: ["components", "hooks"],
@@ -75,7 +77,15 @@ const VERSION_SUBDIRS: Record<ReferenceVersion, ReferenceSubdir[]> = {
   vue: ["components", "hooks"],
   angular: ["components", "functions", "services", "directives"],
   core: ["classes", "types", "enums"],
-  channels: ["components", "functions", "classes", "types", "slack", "discord"],
+  channels: [
+    "components",
+    "functions",
+    "classes",
+    "types",
+    "slack",
+    "discord",
+    "intelligence",
+  ],
 };
 
 const CATEGORY_BY_SUBDIR: Record<ReferenceSubdir, ReferenceCategory> = {
@@ -90,6 +100,7 @@ const CATEGORY_BY_SUBDIR: Record<ReferenceSubdir, ReferenceCategory> = {
   sdk: "SDKs",
   slack: "Slack",
   discord: "Discord",
+  intelligence: "Intelligence",
 };
 
 export type ReferenceItem = {
@@ -400,6 +411,19 @@ function buildChannelsPageTree(): PageTree.Root {
           },
         ];
 
+  const intelligenceItems = loadReferenceItems("channels", "intelligence");
+  const intelligenceCoreFolder: PageTree.Folder[] =
+    intelligenceItems.length === 0
+      ? []
+      : [
+          {
+            type: "folder",
+            name: "Core",
+            defaultOpen: false,
+            children: intelligenceItems.map(itemToPage),
+          },
+        ];
+
   return {
     name: referenceRootName(),
     children: [
@@ -421,6 +445,11 @@ function buildChannelsPageTree(): PageTree.Root {
         "@copilotkit/channels-discord",
       ),
       ...discordCoreFolder,
+      packageSeparator(
+        React.createElement(CopilotKitMark),
+        "@copilotkit/channels-intelligence",
+      ),
+      ...intelligenceCoreFolder,
     ],
   };
 }


### PR DESCRIPTION
## Summary

- clarifies the available paths for operating Channels
- adds ownership and setup guidance for managed connections
- refreshes related terminology and entry points

## Why

The current docs do not clearly explain where provider operations end and application-owned agent behavior begins.

## How

- makes `/channels` the decision page
- adds conceptual and guided managed paths
- aligns adjacent Slack, Intelligence, and Channels reference material
- validates the shell-docs build and leaves a local preview running

A small generated-handoff follow-up is tracked in [#5926](https://github.com/CopilotKit/CopilotKit/issues/5926). This PR will remain draft until that alignment lands.
