### PR TITLE
ci(zizmor): suppress adhoc-packages for intentional global CLI installs

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -77,3 +77,20 @@ rules:
       # pkg-pr-new posts snapshot comments on the PR using the repo token
       # — credentials must remain persisted for the action to authenticate.
       - publish-commit.yml
+
+  # `adhoc-packages` flags `npm install -g <pkg>` style ad-hoc installs of
+  # tools that aren't declared in a lockfile. The installs below are
+  # intentional global CLI tools fetched in CI-only jobs — they are dev
+  # tooling invoked by the workflow itself, not application dependencies,
+  # so there is no lockfile to pin them against. Each is scoped to its
+  # exact file:line so a new, unrelated ad-hoc install still gets flagged.
+  adhoc-packages:
+    ignore:
+      # @anthropic-ai/claude-code CLI, used by the social-copy generator job.
+      - social_copy-generator.yml:209
+      # oxfmt formatter CLI, used by the static-quality format check.
+      - static_quality.yml:54
+      # @copilotkit/aimock CLI, used by the on-demand showcase e2e job.
+      - test_e2e-showcase-on-demand.yml:276
+      # @copilotkit/aimock CLI, used by the docs integration test job.
+      - test_integration-docs.yml:67


### PR DESCRIPTION
## Problem

zizmor v1.26.1 at `min-severity: low` emits 4 `adhoc-packages` (LOW) findings on intentional `npm install -g …` global CLI installs in CI-only jobs. This fails the required **Static analysis (zizmor)** check on *every* workflow-touching PR (e.g. the Renovate github-actions PRs), even though these installs are correct.

The flagged lines:
- `social_copy-generator.yml:209` — `@anthropic-ai/claude-code`
- `static_quality.yml:54` — `oxfmt@0.36`
- `test_e2e-showcase-on-demand.yml:276` — `@copilotkit/aimock`
- `test_integration-docs.yml:67` — `@copilotkit/aimock`

These are dev tooling invoked by the workflows themselves, not application dependencies, so there is no lockfile to pin them against.

## Fix

Add a scoped, `file:line`-precise `adhoc-packages` ignore block to `.github/zizmor.yml`, matching the existing per-rule suppression style with a per-entry justification. New, unrelated ad-hoc installs still get flagged.

## Red → Green proof

Exact CI invocation (`zizmor v1.26.1`, `--min-severity low`, `--config .github/zizmor.yml`, over `.github/workflows/`).

**RED (before fix, on this branch's base):**
```
$ zizmor --min-severity low --config .github/zizmor.yml .github/workflows/
help[adhoc-packages]: ad-hoc installation of packages
  209 | run: npm install -g @anthropic-ai/claude-code
   54 | run: npm install -g oxfmt@0.36
  276 | npm install -g "@copilotkit/aimock@^1.16.4" --ignore-scripts
   67 | npm install -g @copilotkit/aimock@1.24.1
250 findings (30 ignored, 216 suppressed): 0 informational, 4 low, 0 medium, 0 high
EXIT=12
```

**GREEN (after fix, identical invocation):**
```
$ zizmor --min-severity low --config .github/zizmor.yml .github/workflows/
No findings to report. Good job! (34 ignored, 216 suppressed)
EXIT=0
```

Zero `adhoc-packages` findings remain; exit 0.