### PR TITLE
fix(react-core): forward refs through DropdownMenuTrigger and TooltipTrigger

### DIFF
--- a/packages/react-core/src/v2/components/ui/dropdown-menu.tsx
+++ b/packages/react-core/src/v2/components/ui/dropdown-menu.tsx
@@ -20,16 +20,18 @@ function DropdownMenuPortal({
   );
 }
 
-function DropdownMenuTrigger({
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+const DropdownMenuTrigger = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>
+>(function DropdownMenuTrigger({ ...props }, ref) {
   return (
     <DropdownMenuPrimitive.Trigger
+      ref={ref}
       data-slot="dropdown-menu-trigger"
       {...props}
     />
   );
-}
+});
 
 function DropdownMenuContent({
   className,

--- a/packages/react-core/src/v2/components/ui/tooltip.tsx
+++ b/packages/react-core/src/v2/components/ui/tooltip.tsx
@@ -26,11 +26,18 @@ function Tooltip({
   );
 }
 
-function TooltipTrigger({
-  ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
-}
+const TooltipTrigger = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof TooltipPrimitive.Trigger>
+>(function TooltipTrigger({ ...props }, ref) {
+  return (
+    <TooltipPrimitive.Trigger
+      ref={ref}
+      data-slot="tooltip-trigger"
+      {...props}
+    />
+  );
+});
 
 function TooltipContent({
   className,


### PR DESCRIPTION
## Summary

`CopilotChatInput`'s `AddMenuButton` renders its trigger as nested Radix `asChild` slots:

```tsx
<TooltipTrigger asChild>
  <DropdownMenuTrigger asChild>{button}</DropdownMenuTrigger>
</TooltipTrigger>
```

Radix `asChild` slots forward a ref to their child. `DropdownMenuTrigger` and `TooltipTrigger` were plain function components, so under React 18.3 the forwarded ref triggers this warning on every render (reported in #5744):

```
Warning: Function components cannot be given refs. Attempts to access this ref will fail.
Did you mean to use React.forwardRef()?
```

## Change

Wrap `DropdownMenuTrigger` and `TooltipTrigger` in `React.forwardRef`, forwarding the ref to the underlying Radix primitive — mirroring `forwardRef` usage already present in this package (e.g. `Button`, `CopilotChatInput.TextArea`). No behavior change; the ref now reaches a DOM node and the warning is gone.

## Scope

Limited to the two primitives in the reported warning path. The other shadcn/ui primitives in `react-core` follow the same React-19 (no-`forwardRef`) style and would warn identically when used as `asChild` children under React 18.3 — happy to extend this to the rest if you'd prefer full React 18.3 coverage.

## Verification

- `nx build @copilotkit/react-core` succeeds (compiles source + generates type declarations).
- Pre-commit `test-and-check-packages` passes.

Fixes #5744
