### PR TITLE
fix(showcase/langgraph-typescript): disable FileSystemPersistence disk flush (permanent LGT outage fix)

### DIFF
--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -622,6 +622,17 @@ jobs:
           cache-dependency-path: |
             showcase/integrations/*/requirements.txt
 
+      # Node is required so the langgraph-typescript behavioral proof
+      # (test_real_package_writes_are_suppressed_behavioral +
+      # test_boot_fails_if_namespace_binding_not_patched_high1) can `npm install`
+      # the agent's real @langchain/langgraph-api and drive the fs-write
+      # interception against it. Without this, that test skips and the durable
+      # LGT persistence-disable fix would ship with zero real-package coverage.
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
       - name: Install minimal test deps
         # Always need pytest + typing_extensions. pytest-asyncio is required
         # by langroid's test_agui_adapter.py (16 tests use
@@ -686,12 +697,30 @@ jobs:
                 continue
               }
             fi
+            # langgraph-typescript's persistence-disable fix has a REAL-PACKAGE
+            # behavioral proof that drives @langchain/langgraph-api's actual
+            # FileSystemPersistence writer through the preload interception (and
+            # a negative proof that the boot binding-identity guard FAILS boot if
+            # the fs/promises namespace was linked before the patch). Install the
+            # agent deps and set LGT_REQUIRE_BEHAVIORAL=1 so those tests MUST run
+            # here (a missing runtime FAILS instead of silently skipping) — this
+            # is the merge gate that proves the interception actually works.
+            pkg_extra_env=""
+            if [ "$pkg" = "langgraph-typescript" ]; then
+              echo "Installing langgraph-typescript agent deps (npm install)"
+              (cd "${pkg_dir}src/agent" && npm install --no-audit --no-fund) || {
+                echo "::error::npm install failed for langgraph-typescript agent"
+                failed=1
+                continue
+              }
+              pkg_extra_env="LGT_REQUIRE_BEHAVIORAL=1"
+            fi
             # Export PYTHONPATH so `from tools import ...` in agent modules
             # resolves via the `tools` symlink at the integration root.
             # Also include src/ so `from agents.X import ...` works even if
             # a conftest.py omits the sys.path setup. Mirrors the local dev
             # convention (`PYTHONPATH=. python ...` in package.json scripts).
-            (cd "$pkg_dir" && PYTHONPATH=".:src:${PYTHONPATH:-}" python -m pytest tests/python/ -v) || failed=1
+            (cd "$pkg_dir" && env $pkg_extra_env PYTHONPATH=".:src:${PYTHONPATH:-}" python -m pytest tests/python/ -v) || failed=1
           done
           if [ "$found" -eq 0 ]; then
             echo "::warning::No showcase/integrations/*/tests/python/ directories found"

--- a/showcase/integrations/langgraph-typescript/entrypoint.sh
+++ b/showcase/integrations/langgraph-typescript/entrypoint.sh
@@ -356,6 +356,22 @@ else
   echo "[entrypoint] No prior persistence state found — clean boot"
 fi
 
+# Disable @langchain/langgraph-api's FileSystemPersistence disk flush. Without
+# this, the inmem runtime serialises ALL accumulated thread/run/checkpoint
+# state to .langgraph_api on a 3-second timer; under D6 probe fan-out (36
+# parallel probes) the dir fills past the 200MB size-watchdog threshold in
+# ~90s, the watchdog kills the agent, and on rapid restart the D6 cron refills
+# it and re-trips — Railway crash-loop backoff then stops restarting the
+# container (the 2026-07-13 outage). Setting this env var is the TypeScript
+# equivalent of the langgraph-python fix in PR #5825 (which exported the same
+# LANGGRAPH_DISABLE_FILE_PERSISTENCE=true for its inmem runtime). Because the
+# TS package has no built-in switch, src/agent/disable-file-persistence.mjs —
+# preloaded via `node --import` in `npm start` — reads this var and no-ops the
+# .langgraph_api fs writes, leaving in-memory state (the actual runtime state)
+# intact. State is bounded by process memory and discarded on restart, so the
+# size-watchdog has nothing to fill and never trips under probe load.
+export LANGGRAPH_DISABLE_FILE_PERSISTENCE=true
+
 # Start LangGraph agent server in background.
 # `npm start` runs `node --import tsx liveness.mjs` (see src/agent/package.json).
 # liveness.mjs binds :8124/ok immediately using only node:http, then dynamic-

--- a/showcase/integrations/langgraph-typescript/src/agent/disable-file-persistence.mjs
+++ b/showcase/integrations/langgraph-typescript/src/agent/disable-file-persistence.mjs
@@ -9,73 +9,331 @@
 // has NO such switch, so we neutralise the flush ourselves at the fs layer.
 //
 // Why the fs layer (and not the class):
-//   @langchain/langgraph-api's `FileSystemPersistence` (dist/storage/persist.mjs)
-//   is the single writer. Its module singletons (checkpointer, store, ops) are
-//   constructed at import time and are NOT exported, and the package's exports
-//   map blocks a deep import of persist.mjs (ERR_PACKAGE_PATH_NOT_EXPORTED), so
-//   the class prototype cannot be patched from here. The only disk-write surface
-//   in persist.mjs is `fs.writeFile` (the flush) and `fs.mkdir` (dir create),
-//   both from `node:fs/promises`. Intercepting those two calls for the
-//   `.langgraph_api` path fully stops disk growth while leaving the in-memory
-//   store — the actual runtime state — untouched. Conversation/thread/run state
-//   still works within a container's lifetime; it just never persists to disk.
-//   This matches python's behaviour: in-memory state bounded by process memory,
-//   discarded on restart, nothing accumulating on disk to trip the size
-//   watchdog.
+//   @langchain/langgraph-api's `FileSystemPersistence`
+//   (dist/storage/persist.mjs) is the single writer for all three persist
+//   targets (.langgraphjs_ops.json, .langgraphjs_api.store.json,
+//   .langgraphjs_api.checkpointer.json — all under a `.langgraph_api/` dir).
+//   Its module singletons (checkpointer, store, ops) are constructed at import
+//   time and are NOT exported, and the package's exports map blocks a deep
+//   import of persist.mjs (ERR_PACKAGE_PATH_NOT_EXPORTED), so the class
+//   prototype cannot be patched from here. Intercepting the fs write surface
+//   for the persist dir fully stops disk growth while leaving the in-memory
+//   store — the actual runtime state — untouched. Conversation/thread/run
+//   state still works within a container's lifetime; it just never persists to
+//   disk. This matches python's behaviour: in-memory state bounded by process
+//   memory, discarded on restart, nothing accumulating on disk to trip the
+//   size watchdog.
 //
 // Why the CJS handle (and not `import * as fs from "node:fs/promises"`):
 //   An ESM namespace object is sealed — `fsPromises.writeFile = ...` throws
 //   "Cannot assign to read only property". The writable seam is the CJS
-//   `require("node:fs").promises` object; the package's ESM
-//   `import * as fs from "node:fs/promises"` named exports are backed by that
-//   same object, so patching it there IS observed by the package (verified:
-//   `esmNs.writeFile === require("node:fs").promises.writeFile`).
+//   `require("node:fs").promises` object; the package reaches fs/promises via
+//   `import * as fs from "node:fs/promises"` and calls `fs.writeFile(...)`
+//   (NAMESPACE property access — verified in persist.mjs@1.1.17), which reads
+//   through to that same live object, so patching it there IS observed. NOTE:
+//   this holds for namespace/property-access calls; it does NOT hold for NAMED
+//   imports (`import { writeFile } from "node:fs/promises"`), whose bindings
+//   Node snapshots at link time. The version guard below fails loudly if the
+//   package ever switches to a named-import form (or adds an unpatched write
+//   surface), so a silent regression on upgrade is impossible.
+//
+// Why anchor on the resolved persist-dir path (and not a bare substring):
+//   The persist dir is `path.resolve(cwd, ".langgraph_api", <name>)`. We match
+//   the `.langgraph_api` path SEGMENT (a `/.langgraph_api/` boundary or a
+//   trailing `/.langgraph_api`), not a bare `.includes(".langgraph_api")`, so
+//   an unrelated path that merely embeds the token (e.g.
+//   `/tmp/x.langgraph_api.log`, `.langgraph_api_backup`) is NOT silently
+//   dropped. String, Buffer, and URL path forms are all normalised first.
+//
+// Why patch every write surface (and not just writeFile + mkdir):
+//   persist.mjs@1.1.17 writes ONLY via `fs.writeFile` + `fs.mkdir`. But an
+//   atomic write-then-rename, appendFile, open()+handle.write, a *Sync variant,
+//   or createWriteStream would each bypass a writeFile-only patch and let the
+//   dir grow again with zero signal (the exact recurring-outage failure mode).
+//   We therefore neutralise every fs write surface — async promises, sync, and
+//   handle/stream openers — for the persist dir. Reads (readFile/readdir/stat)
+//   pass through untouched so in-lifetime read-back still works.
 //
 // Loaded via `node --import` BEFORE liveness.mjs/server.mjs, so the patch is in
 // place before any langgraph code touches the filesystem.
 
 import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 
 const PERSIST_MARKER = ".langgraph_api";
-const disabled =
-  String(process.env.LANGGRAPH_DISABLE_FILE_PERSISTENCE ?? "").toLowerCase() ===
-  "true";
 
-if (disabled) {
+// Accept the common truthy bool conventions (case-insensitive) so an operator
+// setting `=1` / `=yes` / `=TRUE` is not silently ignored (which would re-enable
+// unbounded persistence and recur the outage with no diagnostic).
+const rawFlag = String(
+  process.env.LANGGRAPH_DISABLE_FILE_PERSISTENCE ?? "",
+).trim();
+const disabled = ["1", "true", "yes", "on"].includes(rawFlag.toLowerCase());
+
+if (!disabled) {
+  // Log on the NOT-disabled branch too, so a misconfiguration (typo, wrong
+  // value) is diagnosable from the boot log rather than presenting as a silent
+  // return of the disk-growth outage.
+  console.log(
+    `[persistence] LANGGRAPH_DISABLE_FILE_PERSISTENCE not enabled ` +
+      `(value=${JSON.stringify(rawFlag)}) — FileSystemPersistence disk flush ` +
+      `is ACTIVE; .langgraph_api will grow on disk`,
+  );
+} else {
   const require = createRequire(import.meta.url);
-  const fsPromises = require("node:fs").promises;
+  const fs = require("node:fs");
+  const fsPromises = fs.promises;
 
-  // Only paths under `.langgraph_api` are short-circuited; every other fs write
-  // (Next.js caches, tmp files, langgraph worker caches, etc.) is untouched.
-  const targetsPersistDir = (p) =>
-    // p may be a string, Buffer, URL, or file handle. Only the path-like string
-    // form addresses the persistence dir; anything else falls through to the
-    // real implementation unchanged.
-    typeof p === "string" && p.includes(PERSIST_MARKER);
+  // --- Version / writer-shape guard -------------------------------------
+  // The interception below is coupled to how @langchain/langgraph-api writes:
+  // namespace `fs.*` calls (not named imports) and only through the surfaces we
+  // patch. If a version bump changes the pinned version OR the persist.mjs
+  // source no longer matches the expected writer shape, FAIL LOUDLY at boot so
+  // the mismatch is caught here and not as a silent disk-growth outage in prod.
+  const EXPECTED_PKG_VERSION = "1.1.17";
+  try {
+    const pkgJsonPath =
+      require.resolve("@langchain/langgraph-api/package.json");
+    const installed = require(pkgJsonPath).version;
+    if (installed !== EXPECTED_PKG_VERSION) {
+      throw new Error(
+        `@langchain/langgraph-api is ${installed}, but the fs-write ` +
+          `interception was verified against ${EXPECTED_PKG_VERSION}. ` +
+          `Re-verify persist.mjs's write surfaces and import form (see ` +
+          `disable-file-persistence.mjs header), then bump EXPECTED_PKG_VERSION. ` +
+          `Refusing to boot with an unverified writer shape.`,
+      );
+    }
+    // Confirm the writer still uses namespace fs access (not a named import)
+    // and still writes via fs.writeFile. Reading the source is a cheap, robust
+    // shape check. persist.mjs sits at <pkgRoot>/dist/storage/persist.mjs.
+    const pkgRoot = pkgJsonPath.slice(0, -"package.json".length);
+    const persistSrc = fs.readFileSync(
+      `${pkgRoot}dist/storage/persist.mjs`,
+      "utf-8",
+    );
+    if (
+      !/import \* as fs from "node:fs\/promises"/.test(persistSrc) ||
+      !/\bfs\.writeFile\(/.test(persistSrc)
+    ) {
+      throw new Error(
+        `persist.mjs no longer uses \`import * as fs from "node:fs/promises"\` ` +
+          `+ \`fs.writeFile(...)\`. The namespace-access interception may no ` +
+          `longer be observed. Re-verify the writer shape before trusting the ` +
+          `persistence disable.`,
+      );
+    }
+  } catch (err) {
+    // A hard failure here is intentional: a wrong writer shape must NOT boot
+    // silently. Re-throw to crash the process with a clear message.
+    console.error(
+      "[persistence] version/shape guard failed:",
+      err && err.message ? err.message : err,
+    );
+    throw err;
+  }
 
+  // --- Path matching -----------------------------------------------------
+  // Normalise string | Buffer | URL path forms to a string, then match the
+  // `.langgraph_api` path SEGMENT (boundary-anchored), not a bare substring.
+  const toPathString = (p) => {
+    if (typeof p === "string") return p;
+    if (p instanceof URL) {
+      try {
+        return fileURLToPath(p);
+      } catch {
+        return null;
+      }
+    }
+    if (Buffer.isBuffer(p)) return p.toString("utf-8");
+    // Numeric fd or FileHandle — not a path we can classify; treat as non-match
+    // (a bare fd is only obtained via open(), which we already gate below).
+    return null;
+  };
+
+  // Matches `<...>/.langgraph_api` or `<...>/.langgraph_api/<...>` (POSIX or
+  // Windows separators), but NOT `.langgraph_api_backup` or `x.langgraph_api`.
+  const persistDirRe = new RegExp(
+    `(^|[\\\\/])${PERSIST_MARKER.replace(/\./g, "\\.")}([\\\\/]|$)`,
+  );
+  const targetsPersistDir = (p) => {
+    const s = toPathString(p);
+    return s != null && persistDirRe.test(s);
+  };
+
+  // One-time observable signal that an interception actually fired, so an
+  // operator can confirm the patch is live on the real write path (and, if the
+  // dir ever DOES grow, distinguish "patch never fired" from "write slipped
+  // through an unpatched surface").
+  let firstHitLogged = false;
+  const noteHit = (surface, target) => {
+    if (!firstHitLogged) {
+      firstHitLogged = true;
+      console.log(
+        `[persistence] intercepted first persist-dir write via ${surface} ` +
+          `(target=${target}); further hits silent`,
+      );
+    }
+  };
+
+  // --- Async (fs.promises) surfaces --------------------------------------
   const realWriteFile = fsPromises.writeFile;
+  const realAppendFile = fsPromises.appendFile;
   const realMkdir = fsPromises.mkdir;
+  const realRename = fsPromises.rename;
+  const realCp = fsPromises.cp;
+  const realOpen = fsPromises.open;
 
   fsPromises.writeFile = function writeFile(file, ...rest) {
     if (targetsPersistDir(file)) {
-      // No-op: the flush is skipped, matching python's disabled-persistence
-      // behaviour. Resolve so the caller's `await` completes normally.
+      noteHit("promises.writeFile", toPathString(file));
       return Promise.resolve();
     }
     return realWriteFile.call(this, file, ...rest);
   };
 
+  fsPromises.appendFile = function appendFile(file, ...rest) {
+    if (targetsPersistDir(file)) {
+      noteHit("promises.appendFile", toPathString(file));
+      return Promise.resolve();
+    }
+    return realAppendFile.call(this, file, ...rest);
+  };
+
   fsPromises.mkdir = function mkdir(dir, ...rest) {
     if (targetsPersistDir(dir)) {
-      // No-op: no persistence dir is created, so `du` finds nothing to grow.
-      // mkdir({recursive:true}) resolves to the first created path or undefined;
-      // callers of this path ignore the result, so undefined is safe.
-      return Promise.resolve(undefined);
+      noteHit("promises.mkdir", toPathString(dir));
+      // Honour the `{recursive:true}` return contract: real mkdir resolves to
+      // the first-created directory path (or undefined if it already existed).
+      // We report the requested dir as "created" so a caller that branches on
+      // the return value sees a consistent recursive-create result.
+      const opts = rest[0];
+      const recursive =
+        opts && typeof opts === "object" && opts.recursive === true;
+      return Promise.resolve(recursive ? toPathString(dir) : undefined);
     }
     return realMkdir.call(this, dir, ...rest);
   };
 
+  fsPromises.rename = function rename(src, dest, ...rest) {
+    // Drop the write if EITHER endpoint is in the persist dir (a *.tmp→final
+    // atomic-write-then-rename lands the payload IN the persist dir).
+    if (targetsPersistDir(src) || targetsPersistDir(dest)) {
+      noteHit("promises.rename", toPathString(dest) ?? toPathString(src));
+      return Promise.resolve();
+    }
+    return realRename.call(this, src, dest, ...rest);
+  };
+
+  if (typeof realCp === "function") {
+    fsPromises.cp = function cp(src, dest, ...rest) {
+      if (targetsPersistDir(dest)) {
+        noteHit("promises.cp", toPathString(dest));
+        return Promise.resolve();
+      }
+      return realCp.call(this, src, dest, ...rest);
+    };
+  }
+
+  fsPromises.open = function open(pth, ...rest) {
+    if (targetsPersistDir(pth)) {
+      noteHit("promises.open", toPathString(pth));
+      // Return a stub FileHandle whose writes are swallowed but reads/close
+      // behave. In practice the persist dir is write-only for this package, so
+      // a caller opening it to write gets a no-op handle instead of growing the
+      // dir; a caller opening to read a suppressed file would already have hit
+      // the readFile catch path (persist.mjs treats a missing file as "empty").
+      return Promise.resolve(makeNoopFileHandle());
+    }
+    return realOpen.call(this, pth, ...rest);
+  };
+
+  // --- Sync surfaces -----------------------------------------------------
+  const realWriteFileSync = fs.writeFileSync;
+  const realAppendFileSync = fs.appendFileSync;
+  const realMkdirSync = fs.mkdirSync;
+  const realRenameSync = fs.renameSync;
+  const realOpenSync = fs.openSync;
+
+  fs.writeFileSync = function writeFileSync(file, ...rest) {
+    if (targetsPersistDir(file)) {
+      noteHit("writeFileSync", toPathString(file));
+      return undefined;
+    }
+    return realWriteFileSync.call(this, file, ...rest);
+  };
+
+  fs.appendFileSync = function appendFileSync(file, ...rest) {
+    if (targetsPersistDir(file)) {
+      noteHit("appendFileSync", toPathString(file));
+      return undefined;
+    }
+    return realAppendFileSync.call(this, file, ...rest);
+  };
+
+  fs.mkdirSync = function mkdirSync(dir, ...rest) {
+    if (targetsPersistDir(dir)) {
+      noteHit("mkdirSync", toPathString(dir));
+      const opts = rest[0];
+      const recursive =
+        opts && typeof opts === "object" && opts.recursive === true;
+      return recursive ? toPathString(dir) : undefined;
+    }
+    return realMkdirSync.call(this, dir, ...rest);
+  };
+
+  fs.renameSync = function renameSync(src, dest, ...rest) {
+    if (targetsPersistDir(src) || targetsPersistDir(dest)) {
+      noteHit("renameSync", toPathString(dest) ?? toPathString(src));
+      return undefined;
+    }
+    return realRenameSync.call(this, src, dest, ...rest);
+  };
+
+  fs.openSync = function openSync(pth, ...rest) {
+    if (targetsPersistDir(pth)) {
+      noteHit("openSync", toPathString(pth));
+      // Hand back a real fd to /dev/null so subsequent fd writes are discarded
+      // but the fd is valid (closeSync etc. behave). Reads return EOF.
+      return realOpenSync.call(this, "/dev/null", "r+");
+    }
+    return realOpenSync.call(this, pth, ...rest);
+  };
+
+  // --- Stream opener -----------------------------------------------------
+  const realCreateWriteStream = fs.createWriteStream;
+  fs.createWriteStream = function createWriteStream(pth, ...rest) {
+    if (targetsPersistDir(pth)) {
+      noteHit("createWriteStream", toPathString(pth));
+      // Stream writes to /dev/null so the persist dir never grows but the
+      // stream contract (writable, 'finish'/'close' events) is preserved.
+      return realCreateWriteStream.call(this, "/dev/null", ...rest);
+    }
+    return realCreateWriteStream.call(this, pth, ...rest);
+  };
+
   console.log(
-    "[persistence] LANGGRAPH_DISABLE_FILE_PERSISTENCE=true — FileSystemPersistence disk flush disabled (in-memory only)",
+    "[persistence] LANGGRAPH_DISABLE_FILE_PERSISTENCE enabled " +
+      `(value=${JSON.stringify(rawFlag)}) — FileSystemPersistence disk flush ` +
+      "disabled across all fs write surfaces (in-memory only)",
   );
+}
+
+// A minimal FileHandle-shaped stub whose writes are swallowed. Only the members
+// a persistence writer plausibly touches are implemented; everything resolves
+// so a caller's `await` completes normally.
+function makeNoopFileHandle() {
+  return {
+    write: () => Promise.resolve({ bytesWritten: 0, buffer: Buffer.alloc(0) }),
+    writeFile: () => Promise.resolve(),
+    appendFile: () => Promise.resolve(),
+    truncate: () => Promise.resolve(),
+    sync: () => Promise.resolve(),
+    datasync: () => Promise.resolve(),
+    read: () => Promise.resolve({ bytesRead: 0, buffer: Buffer.alloc(0) }),
+    readFile: () => Promise.resolve(Buffer.alloc(0)),
+    stat: () => Promise.resolve({ size: 0 }),
+    close: () => Promise.resolve(),
+    [Symbol.asyncDispose]: () => Promise.resolve(),
+  };
 }

--- a/showcase/integrations/langgraph-typescript/src/agent/disable-file-persistence.mjs
+++ b/showcase/integrations/langgraph-typescript/src/agent/disable-file-persistence.mjs
@@ -33,9 +33,14 @@
 //   through to that same live object, so patching it there IS observed. NOTE:
 //   this holds for namespace/property-access calls; it does NOT hold for NAMED
 //   imports (`import { writeFile } from "node:fs/promises"`), whose bindings
-//   Node snapshots at link time. The version guard below fails loudly if the
-//   package ever switches to a named-import form (or adds an unpatched write
-//   surface), so a silent regression on upgrade is impossible.
+//   Node snapshots at link time. Two guards make a silent regression
+//   impossible: (1) the source-shape guard below fails loudly if the package
+//   ever switches to a named-import form (or drops the fs.writeFile call), and
+//   (2) a runtime binding-identity assertion (end of this module) imports the
+//   node:fs/promises namespace AFTER patching and throws if any patched member
+//   is not identity-equal to the function we installed — catching the case
+//   where fs/promises was LINKED before the reassignment ran and the namespace
+//   snapshotted the ORIGINAL (unpatched) reference.
 //
 // Why anchor on the resolved persist-dir path (and not a bare substring):
 //   The persist dir is `path.resolve(cwd, ".langgraph_api", <name>)`. We match
@@ -112,9 +117,25 @@ if (!disabled) {
       `${pkgRoot}dist/storage/persist.mjs`,
       "utf-8",
     );
+    // Tolerant shape check: match the namespace-import form regardless of
+    // cosmetic reformatting (whitespace runs, single/double quotes) so a benign
+    // re-spaced / re-quoted / lightly-minified dist bump that STILL uses a
+    // namespace import does NOT crash boot. We only fail loud on a genuine
+    // writer-shape change (e.g. a switch to a named import, or dropping the
+    // fs.writeFile call). Capture the namespace alias and verify the write call
+    // uses that SAME alias (`<alias>.writeFile(`), so a rename of the imported
+    // binding is still validated correctly.
+    const nsImportRe =
+      /import\s*\*\s*as\s+([A-Za-z_$][\w$]*)\s+from\s*['"]node:fs\/promises['"]/;
+    const nsMatch = nsImportRe.exec(persistSrc);
+    const writerAlias = nsMatch ? nsMatch[1] : null;
+    const writeCallRe = writerAlias
+      ? new RegExp(`\\b${writerAlias}\\.writeFile\\s*\\(`)
+      : null;
     if (
-      !/import \* as fs from "node:fs\/promises"/.test(persistSrc) ||
-      !/\bfs\.writeFile\(/.test(persistSrc)
+      writerAlias === null ||
+      writeCallRe === null ||
+      !writeCallRe.test(persistSrc)
     ) {
       throw new Error(
         `persist.mjs no longer uses \`import * as fs from "node:fs/promises"\` ` +
@@ -161,6 +182,26 @@ if (!disabled) {
     return s != null && persistDirRe.test(s);
   };
 
+  // For a suppressed `mkdir({recursive:true})`, the real fs contract returns the
+  // FIRST (topmost) directory actually created — not the requested leaf. When a
+  // fresh persist tree is created the topmost new dir is the `.langgraph_api`
+  // segment itself (its parent, the cwd, already exists), so we report the path
+  // truncated at (and including) that segment. This keeps a caller that branches
+  // on the recursive-create return value consistent with the real contract even
+  // though we create nothing on disk. Returns the requested path unchanged if the
+  // segment can't be located (defensive; targetsPersistDir already matched it).
+  const persistDirRoot = (p) => {
+    const str = toPathString(p);
+    if (str == null) return str;
+    // Split on either separator, find the `.langgraph_api` segment, rejoin up to
+    // and including it (preserving the original separator style via a regex that
+    // keeps the leading portion + the segment).
+    const m = new RegExp(
+      `^(.*?[\\\\/]?${PERSIST_MARKER.replace(/\./g, "\\.")})(?:[\\\\/]|$)`,
+    ).exec(str);
+    return m ? m[1] : str;
+  };
+
   // One-time observable signal that an interception actually fired, so an
   // operator can confirm the patch is live on the real write path (and, if the
   // dir ever DOES grow, distinguish "patch never fired" from "write slipped
@@ -174,6 +215,35 @@ if (!disabled) {
           `(target=${target}); further hits silent`,
       );
     }
+  };
+
+  // Construct an ENOENT-shaped error so a suppressed-path READ presents to the
+  // caller exactly as if the file does not exist — the caller then takes its
+  // missing-file/default branch (persist.mjs: a missing checkpoint file yields
+  // the empty-state default) rather than parsing an empty buffer as JSON.
+  const makeEnoent = (syscall, target) => {
+    const err = new Error(
+      `ENOENT: no such file or directory, ${syscall} '${target}'`,
+    );
+    err.code = "ENOENT";
+    err.errno = -2;
+    err.syscall = syscall;
+    err.path = target;
+    return err;
+  };
+
+  // A read-only open (flags "r"/"rs"/undefined default) must ENOENT for a
+  // suppressed path; a write-intent open (w/a/r+/w+/a+/...) gets a no-op handle
+  // so writes are swallowed without growing the dir.
+  const isReadOnlyFlags = (flags) => {
+    if (flags === undefined) return true; // fs default is "r"
+    const f = typeof flags === "number" ? null : String(flags);
+    // Numeric flag: cannot cheaply classify → treat as write-intent (no-op
+    // handle) to preserve the swallow-writes invariant; a numeric read-only
+    // open of a suppressed file is not a path this package exercises.
+    if (f === null) return false;
+    // Read-only iff it contains no write/append/create/truncate indicators.
+    return !/[wa+]/.test(f);
   };
 
   // --- Async (fs.promises) surfaces --------------------------------------
@@ -210,7 +280,7 @@ if (!disabled) {
       const opts = rest[0];
       const recursive =
         opts && typeof opts === "object" && opts.recursive === true;
-      return Promise.resolve(recursive ? toPathString(dir) : undefined);
+      return Promise.resolve(recursive ? persistDirRoot(dir) : undefined);
     }
     return realMkdir.call(this, dir, ...rest);
   };
@@ -235,17 +305,19 @@ if (!disabled) {
     };
   }
 
-  fsPromises.open = function open(pth, ...rest) {
+  fsPromises.open = function open(pth, flags, ...rest) {
     if (targetsPersistDir(pth)) {
       noteHit("promises.open", toPathString(pth));
-      // Return a stub FileHandle whose writes are swallowed but reads/close
-      // behave. In practice the persist dir is write-only for this package, so
-      // a caller opening it to write gets a no-op handle instead of growing the
-      // dir; a caller opening to read a suppressed file would already have hit
-      // the readFile catch path (persist.mjs treats a missing file as "empty").
+      // Read-only open of a suppressed file must reject ENOENT (as if missing)
+      // so the caller hits its missing-file default branch — NOT an empty
+      // handle whose read yields "" and mis-parses. A write-intent open gets a
+      // no-op handle so writes are swallowed without growing the dir.
+      if (isReadOnlyFlags(flags)) {
+        return Promise.reject(makeEnoent("open", toPathString(pth)));
+      }
       return Promise.resolve(makeNoopFileHandle());
     }
-    return realOpen.call(this, pth, ...rest);
+    return realOpen.call(this, pth, flags, ...rest);
   };
 
   // --- Sync surfaces -----------------------------------------------------
@@ -277,7 +349,7 @@ if (!disabled) {
       const opts = rest[0];
       const recursive =
         opts && typeof opts === "object" && opts.recursive === true;
-      return recursive ? toPathString(dir) : undefined;
+      return recursive ? persistDirRoot(dir) : undefined;
     }
     return realMkdirSync.call(this, dir, ...rest);
   };
@@ -290,14 +362,20 @@ if (!disabled) {
     return realRenameSync.call(this, src, dest, ...rest);
   };
 
-  fs.openSync = function openSync(pth, ...rest) {
+  fs.openSync = function openSync(pth, flags, ...rest) {
     if (targetsPersistDir(pth)) {
       noteHit("openSync", toPathString(pth));
-      // Hand back a real fd to /dev/null so subsequent fd writes are discarded
-      // but the fd is valid (closeSync etc. behave). Reads return EOF.
+      // Read-only openSync of a suppressed file must throw ENOENT (as if
+      // missing) so the caller takes its missing-file branch — not read EOF
+      // from a /dev/null fd and mis-handle the empty payload. A write-intent
+      // openSync hands back a real /dev/null fd so subsequent fd writes are
+      // discarded but the fd is valid (closeSync etc. behave).
+      if (isReadOnlyFlags(flags)) {
+        throw makeEnoent("open", toPathString(pth));
+      }
       return realOpenSync.call(this, "/dev/null", "r+");
     }
-    return realOpenSync.call(this, pth, ...rest);
+    return realOpenSync.call(this, pth, flags, ...rest);
   };
 
   // --- Stream opener -----------------------------------------------------
@@ -312,10 +390,65 @@ if (!disabled) {
     return realCreateWriteStream.call(this, pth, ...rest);
   };
 
+  // --- Runtime binding-identity assertion (the ordering-safety net) ------
+  // The interception above works by MUTATING properties on the live
+  // `require("node:fs").promises` object. A consumer reaches these via
+  // `import * as fs from "node:fs/promises"; fs.writeFile(...)` — a namespace
+  // property access that reads THROUGH to that same live object, so the patch
+  // is observed. BUT an ESM namespace binding snapshots the function reference
+  // at the importing module's LINK time. If anything links `node:fs/promises`
+  // BEFORE the reassignment above (an earlier-ordered `--import`, a future edit
+  // that imports fs/promises before patching, or a Node-internal pre-link), the
+  // consumer's `fs.writeFile` resolves to the ORIGINAL function and every
+  // persist write SILENTLY bypasses the patch — the dir refills and the outage
+  // recurs with zero signal. The source-string guard above cannot catch this
+  // (it checks text, not runtime identity).
+  //
+  // So: import the namespace HERE (after patching) and assert each patched
+  // member is identity-equal to the function we installed. A mismatch means the
+  // seam is not live for that member — FAIL BOOT LOUDLY naming the member rather
+  // than continue into a silent disk-growth outage. Top-level await is valid in
+  // an ESM `--import` preload and completes before any langgraph code runs.
+  const ns = await import("node:fs/promises");
+  const patchedMembers = {
+    writeFile: fsPromises.writeFile,
+    appendFile: fsPromises.appendFile,
+    mkdir: fsPromises.mkdir,
+    rename: fsPromises.rename,
+    open: fsPromises.open,
+  };
+  // `cp` is only patched when the runtime provides it (older Node lacks it).
+  if (typeof realCp === "function") {
+    patchedMembers.cp = fsPromises.cp;
+  }
+  const mismatches = [];
+  for (const [name, patchedFn] of Object.entries(patchedMembers)) {
+    // The namespace member MUST be the exact function object we installed on
+    // the live promises object. If it is not, a consumer importing the
+    // namespace will call the pre-patch original and bypass the no-op.
+    if (ns[name] !== patchedFn) {
+      mismatches.push(name);
+    }
+  }
+  if (mismatches.length > 0) {
+    const msg =
+      `[persistence] FATAL: node:fs/promises namespace binding does NOT reflect ` +
+      `the installed patch for: ${mismatches.join(", ")}. This means the ` +
+      `fs/promises namespace was LINKED BEFORE the interception was installed, ` +
+      `so @langchain/langgraph-api's \`fs.${mismatches[0]}(...)\` would call the ` +
+      `ORIGINAL function and silently refill .langgraph_api on disk — the exact ` +
+      `recurring-outage failure mode. Refusing to boot. Ensure ` +
+      `disable-file-persistence.mjs is the FIRST \`--import\` and that nothing ` +
+      `links node:fs/promises before its property reassignments run.`;
+    console.error(msg);
+    throw new Error(msg);
+  }
+
   console.log(
     "[persistence] LANGGRAPH_DISABLE_FILE_PERSISTENCE enabled " +
       `(value=${JSON.stringify(rawFlag)}) — FileSystemPersistence disk flush ` +
-      "disabled across all fs write surfaces (in-memory only)",
+      "disabled across all fs write surfaces (in-memory only); " +
+      `namespace binding-identity verified for ${Object.keys(patchedMembers).length} members`,
   );
 }
 

--- a/showcase/integrations/langgraph-typescript/src/agent/disable-file-persistence.mjs
+++ b/showcase/integrations/langgraph-typescript/src/agent/disable-file-persistence.mjs
@@ -1,0 +1,81 @@
+// Preload module — disables @langchain/langgraph-api's FileSystemPersistence
+// disk flush, gated by LANGGRAPH_DISABLE_FILE_PERSISTENCE (default: enabled).
+//
+// This is the TypeScript equivalent of the langgraph-python fix in PR #5825,
+// which set `export LANGGRAPH_DISABLE_FILE_PERSISTENCE=true` in the python
+// entrypoint so langgraph_runtime_inmem never flushes its unbounded pickle
+// state to `.langgraph_api/*.pckl`. Python reads that env var at import time
+// inside the runtime package; the TypeScript stack (`@langchain/langgraph-api`)
+// has NO such switch, so we neutralise the flush ourselves at the fs layer.
+//
+// Why the fs layer (and not the class):
+//   @langchain/langgraph-api's `FileSystemPersistence` (dist/storage/persist.mjs)
+//   is the single writer. Its module singletons (checkpointer, store, ops) are
+//   constructed at import time and are NOT exported, and the package's exports
+//   map blocks a deep import of persist.mjs (ERR_PACKAGE_PATH_NOT_EXPORTED), so
+//   the class prototype cannot be patched from here. The only disk-write surface
+//   in persist.mjs is `fs.writeFile` (the flush) and `fs.mkdir` (dir create),
+//   both from `node:fs/promises`. Intercepting those two calls for the
+//   `.langgraph_api` path fully stops disk growth while leaving the in-memory
+//   store — the actual runtime state — untouched. Conversation/thread/run state
+//   still works within a container's lifetime; it just never persists to disk.
+//   This matches python's behaviour: in-memory state bounded by process memory,
+//   discarded on restart, nothing accumulating on disk to trip the size
+//   watchdog.
+//
+// Why the CJS handle (and not `import * as fs from "node:fs/promises"`):
+//   An ESM namespace object is sealed — `fsPromises.writeFile = ...` throws
+//   "Cannot assign to read only property". The writable seam is the CJS
+//   `require("node:fs").promises` object; the package's ESM
+//   `import * as fs from "node:fs/promises"` named exports are backed by that
+//   same object, so patching it there IS observed by the package (verified:
+//   `esmNs.writeFile === require("node:fs").promises.writeFile`).
+//
+// Loaded via `node --import` BEFORE liveness.mjs/server.mjs, so the patch is in
+// place before any langgraph code touches the filesystem.
+
+import { createRequire } from "node:module";
+
+const PERSIST_MARKER = ".langgraph_api";
+const disabled =
+  String(process.env.LANGGRAPH_DISABLE_FILE_PERSISTENCE ?? "").toLowerCase() ===
+  "true";
+
+if (disabled) {
+  const require = createRequire(import.meta.url);
+  const fsPromises = require("node:fs").promises;
+
+  // Only paths under `.langgraph_api` are short-circuited; every other fs write
+  // (Next.js caches, tmp files, langgraph worker caches, etc.) is untouched.
+  const targetsPersistDir = (p) =>
+    // p may be a string, Buffer, URL, or file handle. Only the path-like string
+    // form addresses the persistence dir; anything else falls through to the
+    // real implementation unchanged.
+    typeof p === "string" && p.includes(PERSIST_MARKER);
+
+  const realWriteFile = fsPromises.writeFile;
+  const realMkdir = fsPromises.mkdir;
+
+  fsPromises.writeFile = function writeFile(file, ...rest) {
+    if (targetsPersistDir(file)) {
+      // No-op: the flush is skipped, matching python's disabled-persistence
+      // behaviour. Resolve so the caller's `await` completes normally.
+      return Promise.resolve();
+    }
+    return realWriteFile.call(this, file, ...rest);
+  };
+
+  fsPromises.mkdir = function mkdir(dir, ...rest) {
+    if (targetsPersistDir(dir)) {
+      // No-op: no persistence dir is created, so `du` finds nothing to grow.
+      // mkdir({recursive:true}) resolves to the first created path or undefined;
+      // callers of this path ignore the result, so undefined is safe.
+      return Promise.resolve(undefined);
+    }
+    return realMkdir.call(this, dir, ...rest);
+  };
+
+  console.log(
+    "[persistence] LANGGRAPH_DISABLE_FILE_PERSISTENCE=true — FileSystemPersistence disk flush disabled (in-memory only)",
+  );
+}

--- a/showcase/integrations/langgraph-typescript/src/agent/package.json
+++ b/showcase/integrations/langgraph-typescript/src/agent/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "npx @langchain/langgraph-cli@1.2.1 dev --port 8123 --no-browser",
-    "start": "node --import tsx liveness.mjs"
+    "start": "node --import ./disable-file-persistence.mjs --import tsx liveness.mjs"
   },
   "dependencies": {
     "@copilotkit/sdk-js": "1.61.2",

--- a/showcase/integrations/langgraph-typescript/tests/python/test_entrypoint_watchdog.py
+++ b/showcase/integrations/langgraph-typescript/tests/python/test_entrypoint_watchdog.py
@@ -246,6 +246,116 @@ class TestBootPurge:
 
 
 @pytest.mark.skipif(not _ENTRYPOINT.exists(), reason="entrypoint.sh not found")
+class TestFilePersistenceDisabled:
+    """FileSystemPersistence disk flush must be disabled — the durable root-cause
+    fix for the 2026-07-13 outage.
+
+    The langgraph-python integration (PR #5825) exports
+    LANGGRAPH_DISABLE_FILE_PERSISTENCE=true so its inmem runtime never flushes
+    unbounded state to disk. The TypeScript stack (@langchain/langgraph-api) has
+    no built-in switch, so this integration sets the same env var AND ships a
+    preload module (src/agent/disable-file-persistence.mjs, wired into `npm
+    start` via `node --import`) that reads it and no-ops the .langgraph_api fs
+    writes. If either half is dropped, .langgraph_api grows unbounded under
+    probe fan-out and the size-watchdog kill-loops the container again.
+    """
+
+    def test_export_runs_before_agent_start(self, tmp_path):
+        """Behavioral: the LANGGRAPH_DISABLE_FILE_PERSISTENCE export must actually
+        EXECUTE at boot, before the agent is launched.
+
+        Runs the boot sequence under `bash -x` and inspects the execution trace.
+        The export line runs before the hardcoded `cd /app/src/agent && npm start`
+        (which fails outside a container), so a source-only check is insufficient
+        — this proves the statement is on the live boot path, not dead code after
+        an early return/guard. We assert the export trace line appears AND that it
+        precedes the agent `cd /app/src/agent` trace line.
+        """
+        stub_dir = tmp_path / "stubs_trace"
+        stub_dir.mkdir(parents=True)
+        for tool in ("node", "npm", "npx", "next"):
+            t = stub_dir / tool
+            t.write_text("#!/bin/bash\nexit 0\n")
+            t.chmod(0o755)
+        curl = stub_dir / "curl"
+        curl.write_text("#!/bin/bash\nexit 0\n")
+        curl.chmod(0o755)
+
+        persist_dir = tmp_path / "langgraph_api"
+        clean_env = {
+            "PATH": f"{stub_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+            "HOME": os.environ.get("HOME", "/tmp"),
+            "PORT": "10000",
+            "LANGGRAPH_PERSIST_DIR_OVERRIDE": str(persist_dir),
+        }
+        try:
+            result = subprocess.run(
+                ["/bin/bash", "-x", str(_ENTRYPOINT)],
+                env=clean_env,
+                capture_output=True,
+                text=True,
+                timeout=8,
+            )
+            trace = result.stderr
+        except subprocess.TimeoutExpired as exc:
+            raw = exc.stderr
+            trace = raw.decode() if isinstance(raw, (bytes, bytearray)) else (raw or "")
+
+        assert "LANGGRAPH_DISABLE_FILE_PERSISTENCE=true" in trace, (
+            "Export of LANGGRAPH_DISABLE_FILE_PERSISTENCE=true must execute at "
+            f"boot (not be dead code). trace tail={trace[-1500:]!r}"
+        )
+        export_pos = trace.index("LANGGRAPH_DISABLE_FILE_PERSISTENCE=true")
+        # The agent launch (cd into the agent dir) must come AFTER the export.
+        cd_pos = trace.find("cd /app/src/agent")
+        assert cd_pos != -1, (
+            f"Expected agent-start trace line. trace tail={trace[-1500:]!r}"
+        )
+        assert export_pos < cd_pos, (
+            "The persistence-disable export must execute BEFORE the agent starts."
+        )
+
+    def test_env_var_exported_in_source(self):
+        """entrypoint.sh must export LANGGRAPH_DISABLE_FILE_PERSISTENCE=true —
+        parity with langgraph-python's PR #5825 fix."""
+        source = _ENTRYPOINT.read_text()
+        assert "export LANGGRAPH_DISABLE_FILE_PERSISTENCE=true" in source, (
+            "entrypoint.sh must export LANGGRAPH_DISABLE_FILE_PERSISTENCE=true "
+            "to disable FileSystemPersistence disk flush (root-cause fix)."
+        )
+
+    def test_preload_module_exists_and_gated(self):
+        """The preload module must exist and be gated on the env var (not
+        unconditionally patch fs, which would break non-persistence writes)."""
+        preload = _PKG_ROOT / "src" / "agent" / "disable-file-persistence.mjs"
+        assert preload.exists(), f"Preload module missing at {preload}"
+        text = preload.read_text()
+        assert "LANGGRAPH_DISABLE_FILE_PERSISTENCE" in text, (
+            "Preload must read LANGGRAPH_DISABLE_FILE_PERSISTENCE"
+        )
+        assert ".langgraph_api" in text, (
+            "Preload must scope its fs no-op to the .langgraph_api path"
+        )
+
+    def test_start_script_preloads_disable_module(self):
+        """src/agent/package.json `start` must preload the disable module via
+        `node --import` BEFORE tsx/liveness, or the patch is never installed."""
+        import json
+
+        pkg_path = _PKG_ROOT / "src" / "agent" / "package.json"
+        pkg = json.loads(pkg_path.read_text())
+        start = pkg.get("scripts", {}).get("start", "")
+        assert "disable-file-persistence.mjs" in start, (
+            f"start script must --import disable-file-persistence.mjs. start={start!r}"
+        )
+        # The disable module must load BEFORE liveness.mjs (which triggers the
+        # heavy server import that touches the filesystem).
+        assert start.index("disable-file-persistence.mjs") < start.index(
+            "liveness.mjs"
+        ), "disable-file-persistence.mjs must be preloaded BEFORE liveness.mjs"
+
+
+@pytest.mark.skipif(not _ENTRYPOINT.exists(), reason="entrypoint.sh not found")
 class TestNoFixedIntervalTruncate:
     """The fixed-interval POST /internal/truncate loop must NOT exist.
 

--- a/showcase/integrations/langgraph-typescript/tests/python/test_entrypoint_watchdog.py
+++ b/showcase/integrations/langgraph-typescript/tests/python/test_entrypoint_watchdog.py
@@ -1,18 +1,24 @@
 """Subprocess tests for entrypoint.sh watchdog / persistence-bounding mechanism.
 
-Covers:
-  C1 - Under set -e, TRUNC_RESPONSE=$(curl -fsS ...) exits the subshell on
-       first non-2xx, making the truncate loop dead code.
-  C2 - /internal/truncate exists in @langchain/langgraph-api@1.1.17 but wipes
-       ALL in-flight runs/threads (R7-C1), making a fixed-interval timer unsafe.
-  Fix verification:
-    - Boot-purge (.langgraph_api removal) still fires on every start.
-    - No fixed-interval POST to /internal/truncate in watchdog.
-    - Size-gated restart mechanism: fires restart only when dir exceeds threshold,
-      NOT on a fixed timer; watchdog kills the agent (triggering container restart
-      which re-runs boot-purge).
-    - Failure escalation: size-check errors are logged, not silently swallowed.
-    - Behavioral: the size-gate logic actually executes under test (not just grep).
+Current mechanism (permanent LGT outage fix):
+  - Persistence disable: `LANGGRAPH_DISABLE_FILE_PERSISTENCE=true` is exported
+    before the agent starts, and src/agent/disable-file-persistence.mjs (a
+    `node --import` preload) neutralises every @langchain/langgraph-api fs write
+    surface for the `.langgraph_api` persist dir, so it never grows on disk.
+  - Boot-purge: any pre-existing `.langgraph_api` is removed on every start.
+  - Size-gated restart: a defense-in-depth watchdog sub-loop kills the agent
+    (triggering a container restart + boot-purge) only if the persist dir ever
+    DOES exceed SIZE_THRESHOLD_MB — not on a fixed timer.
+  - Sub-loop reaping: the watchdog subshell arms `trap _reap_watchdog_children
+    EXIT`, which reaps the size sub-loop via a `$BASHPID` PPID-walk plus a direct
+    `kill "$SIZE_PID"` backstop, so no orphan outlives the watchdog.
+
+Historical context (guarded against regression, no longer the mechanism):
+  - An earlier design POSTed to /internal/truncate on a fixed timer. That was
+    removed: under `set -e` a bare `TRUNC_RESPONSE=$(curl -fsS ...)` exited the
+    subshell on the first non-2xx (dead code), and /internal/truncate wipes ALL
+    in-flight runs/threads. The truncate-absence tests below assert that dead
+    code stays gone.
 
 We stub node/npm/npx/curl via PATH prepend (same pattern as google-adk tests).
 The stub executables exit 0 immediately so the script can progress through the
@@ -29,12 +35,18 @@ du|awk extraction.
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from pathlib import Path
 from textwrap import dedent
 from typing import NamedTuple
 
 import pytest
+
+
+def _indent(text, spaces):
+    pad = " " * spaces
+    return "\n".join(pad + line if line else line for line in text.splitlines())
 
 
 _PKG_ROOT = Path(__file__).resolve().parents[2]
@@ -187,7 +199,21 @@ def _run_check_size_once(
         # Capture whether the gate killed the dummy BEFORE the finally reaper
         # runs — once finally calls dummy.kill(), poll() would always be non-None
         # regardless of whether the script killed it.
-        dummy_was_killed = dummy.poll() is not None
+        #
+        # The gate's kill (`kill -9` in _kill_agent_tree) is issued asynchronously
+        # right before the entrypoint exits, so `subprocess.run` can return before
+        # SIGKILL delivery + zombie reaping have completed. A single-shot poll()
+        # can therefore observe the dummy as still alive on a loaded machine (a
+        # flaky false-negative). Poll in a bounded retry loop (up to ~1s) to let
+        # the async signal land, mirroring the orphan-guard behavioral test.
+        import time
+
+        dummy_was_killed = False
+        for _ in range(20):
+            if dummy.poll() is not None:
+                dummy_was_killed = True
+                break
+            time.sleep(0.05)
         return CheckSizeResult(result=result, dummy_was_killed=dummy_was_killed)
     finally:
         # Reap the dummy process (may already be dead if kill -9 landed).
@@ -353,6 +379,110 @@ class TestFilePersistenceDisabled:
         assert start.index("disable-file-persistence.mjs") < start.index(
             "liveness.mjs"
         ), "disable-file-persistence.mjs must be preloaded BEFORE liveness.mjs"
+
+    def test_real_package_writes_are_suppressed_behavioral(self, tmp_path):
+        """BEHAVIORAL (real package): with the preload active and the flag ON, the
+        REAL @langchain/langgraph-api FileSystemPersistence flush must NOT grow
+        `.langgraph_api` on disk, AND an in-memory write/read round-trip must still
+        return the value (persistence disabled != conversation capability removed).
+
+        Skipped if the agent's node_modules is not installed (CI matrices that do
+        not `npm ci` the agent). When installed, this is the proof that closes the
+        stubbed-fs gap: it drives the real writer, not a fake.
+        """
+        import json
+        import shutil
+
+        agent_dir = _PKG_ROOT / "src" / "agent"
+        persist_pkg = (
+            agent_dir
+            / "node_modules"
+            / "@langchain"
+            / "langgraph-api"
+            / "dist"
+            / "storage"
+            / "persist.mjs"
+        )
+        if not persist_pkg.exists():
+            pytest.skip("agent node_modules not installed (@langchain/langgraph-api)")
+        node = shutil.which("node")
+        if node is None:
+            pytest.skip("node not on PATH")
+
+        run_cwd = tmp_path / "run"
+        run_cwd.mkdir()
+        driver = tmp_path / "driver.mjs"
+        driver.write_text(
+            dedent(r"""
+            import { pathToFileURL } from "node:url";
+            import * as fsSync from "node:fs";
+            import * as path from "node:path";
+            const persistAbs = process.env.PERSIST_ABS;
+            const cwd = process.env.RUN_CWD;
+            const { FileSystemPersistence } =
+              await import(pathToFileURL(persistAbs).href);
+            const conn = new FileSystemPersistence(
+              ".langgraphjs_api.checkpointer.json", () => ({ threads: {} }));
+            await conn.initialize(cwd);
+            await conn.with(async (data) => {
+              for (let i = 0; i < 500; i++)
+                data.threads["t" + i] =
+                  { messages: [{ role: "assistant", content: "reply-" + i }] };
+            });
+            let readBack;
+            await conn.with(async (data) => {
+              readBack = data.threads["t0"]?.messages?.[0]?.content;
+            });
+            await conn.flush();
+            await new Promise((r) => setTimeout(r, 3500));
+            const dir = path.join(cwd, ".langgraph_api");
+            let bytes = 0;
+            if (fsSync.existsSync(dir))
+              for (const e of fsSync.readdirSync(dir))
+                bytes += fsSync.statSync(path.join(dir, e)).size;
+            console.log(JSON.stringify({ readBack, bytes }));
+        """)
+        )
+
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": os.environ.get("HOME", "/tmp"),
+            "LANGGRAPH_DISABLE_FILE_PERSISTENCE": "true",
+            "PERSIST_ABS": str(persist_pkg),
+            "RUN_CWD": str(run_cwd),
+        }
+        preload = agent_dir / "disable-file-persistence.mjs"
+        result = subprocess.run(
+            [node, "--import", str(preload), str(driver)],
+            cwd=str(agent_dir),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0, (
+            f"driver failed rc={result.returncode}\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        # Last JSON line of stdout carries the result.
+        payload = None
+        for line in reversed(result.stdout.strip().splitlines()):
+            try:
+                payload = json.loads(line)
+                break
+            except ValueError:
+                continue
+        assert payload is not None, f"no JSON result. stdout={result.stdout!r}"
+        assert payload["bytes"] == 0, (
+            "REAL @langchain/langgraph-api persist flush grew .langgraph_api to "
+            f"{payload['bytes']} bytes despite the disable flag — the fix does not "
+            "cover the package's real write path."
+        )
+        assert payload["readBack"] == "reply-0", (
+            "In-memory round-trip broke: expected 'reply-0', got "
+            f"{payload['readBack']!r}. Persistence disable must not remove "
+            "in-lifetime conversation state."
+        )
 
 
 @pytest.mark.skipif(not _ENTRYPOINT.exists(), reason="entrypoint.sh not found")
@@ -586,25 +716,41 @@ class TestSizePidOrphanGuard:
         )
 
     def test_size_pid_reaped_by_in_subshell_trap(self):
-        """SIZE_PID must be reaped by an EXIT trap INSIDE the watchdog subshell.
+        """SIZE_PID sub-loop must be reaped by an EXIT trap INSIDE the watchdog subshell.
 
-        Source-level check: the trap must appear inside the ( ) & block,
-        after SIZE_PID=$!, not in the outer cleanup() function.
+        Source-level check of the SHIPPED mechanism: the watchdog subshell
+        registers `trap _reap_watchdog_children EXIT`, and
+        `_reap_watchdog_children` reaps the sub-loop via a `$BASHPID` PPID-walk
+        (`_agent_descendants "$BASHPID"`) plus a belt-and-suspenders direct
+        `kill "$SIZE_PID"`.  (The older `trap 'kill "$SIZE_PID"' EXIT` form is
+        NO LONGER used — it survives only in an explanatory comment describing
+        why the arm-then-spawn ordering was changed.)
         """
         source = _ENTRYPOINT.read_text()
-        # The trap must be registered inside the watchdog subshell (after SIZE_PID=$!)
-        # and must reference SIZE_PID.
-        assert (
-            'trap \'kill "$SIZE_PID"' in source or "trap 'kill \"$SIZE_PID\"'" in source
-        ), (
-            "Expected `trap 'kill \"$SIZE_PID\" ...' EXIT` inside watchdog subshell "
-            "(I1: SIZE_PID is subshell-local, outer cleanup cannot reach it)"
+        # The shipped trap installs the reaper helper (not an inline kill).
+        assert "trap _reap_watchdog_children EXIT" in source, (
+            "Expected `trap _reap_watchdog_children EXIT` inside the watchdog "
+            "subshell (the shipped reaping mechanism)"
+        )
+        # The reaper helper must exist and reap by a $BASHPID PPID-walk.
+        assert "_reap_watchdog_children()" in source, (
+            "Expected _reap_watchdog_children() helper to be defined"
+        )
+        reaper_match = re.search(
+            r"_reap_watchdog_children\(\)\s*\{(.*?)\n  \}", source, re.DOTALL
+        )
+        assert reaper_match, "Could not locate _reap_watchdog_children() body"
+        reaper_body = reaper_match.group(1)
+        assert '_agent_descendants "$BASHPID"' in reaper_body, (
+            "Reaper must PPID-walk THIS subshell ($BASHPID) to find the sub-loop"
+        )
+        # Belt-and-suspenders direct kill of the captured SIZE_PID is RETAINED.
+        assert 'kill "$SIZE_PID"' in reaper_body, (
+            'Reaper must retain the direct `kill "$SIZE_PID"` backstop'
         )
         # The outer cleanup() must NOT contain an EXECUTABLE kill for SIZE_PID
         # (it would be dead code since SIZE_PID is never set in the outer shell).
         # Comments mentioning SIZE_PID are acceptable (they explain WHY it's absent).
-        import re
-
         cleanup_match = re.search(r"cleanup\(\)\s*\{([^}]*)\}", source, re.DOTALL)
         if cleanup_match:
             cleanup_body = cleanup_match.group(1)
@@ -621,65 +767,92 @@ class TestSizePidOrphanGuard:
                 "Any kill of SIZE_PID here would be dead code."
             )
 
-    def test_size_pid_reaped_on_watchdog_exit_behavioral(self, tmp_path):
-        """BEHAVIORAL: size sub-loop is actually reaped when its parent subshell exits.
+    def test_reap_watchdog_children_reaps_real_sub_loop_behavioral(self, tmp_path):
+        """BEHAVIORAL: the SHIPPED _reap_watchdog_children reaper actually reaps a
+        forked sub-loop when its parent subshell exits.
 
-        Simulates the watchdog subshell lifecycle:
-          1. Fork a long-running "size sub-loop" process (sleep 60, stands in for the
-             real size-check loop).
-          2. Register `trap 'kill "$SIZE_PID" 2>/dev/null || true' EXIT` in a subshell,
-             exactly as the fixed entrypoint does.
-          3. Send SIGTERM to the subshell (simulating the outer cleanup() killing the
-             watchdog).
-          4. Assert the size sub-loop was reaped (poll() is not None).
-
-        This exercises the trap FIRING, not just its registration.
+        Rather than re-implementing the reaper in a mock (which would validate a
+        copy, not the shipped code), this extracts the REAL _agent_descendants +
+        _reap_watchdog_children helpers from entrypoint.sh and drives them in a
+        subshell whose lifecycle mirrors the watchdog: fork a long-lived sub-loop,
+        capture SIZE_PID, arm `trap _reap_watchdog_children EXIT`, then SIGTERM the
+        subshell and assert the sub-loop is reaped.
         """
         import time
 
-        # Spawn the "size sub-loop" process (long-lived, safe to kill).
-        size_loop = subprocess.Popen(["sleep", "60"])
-        size_pid = size_loop.pid
+        source = _ENTRYPOINT.read_text()
 
-        # Write a minimal shell that mimics the fixed watchdog subshell:
-        # register the in-subshell EXIT trap, then sleep (simulating the
-        # watchdog's health-probe loop blocked in sleep).
-        watchdog_script = dedent(f"""\
-            #!/bin/bash
-            set -e
-            SIZE_PID={size_pid}
-            trap 'kill "$SIZE_PID" 2>/dev/null || true' EXIT
-            # Simulate watchdog blocked in health-probe sleep.
-            sleep 60
-        """)
-        script_path = tmp_path / "mock_watchdog.sh"
-        script_path.write_text(watchdog_script)
+        def _extract(func_name):
+            m = re.search(
+                r"^(?:  )?" + re.escape(func_name) + r"\(\)\s*\{.*?^(?:  )?\}",
+                source,
+                re.DOTALL | re.MULTILINE,
+            )
+            assert m, "Could not extract %s() from entrypoint.sh" % func_name
+            return m.group(0)
+
+        agent_descendants = _extract("_agent_descendants")
+        reaper = _extract("_reap_watchdog_children")
+
+        driver = (
+            "#!/bin/bash\n"
+            "set -u\n"
+            + _indent(agent_descendants, 0)
+            + "\n"
+            + _indent(reaper, 0)
+            + "\n"
+            + "( while :; do sleep 30; done ) &\n"
+            + "SIZE_PID=$!\n"
+            + 'echo "$SIZE_PID" > "'
+            + str(tmp_path)
+            + '/size_pid"\n'
+            + "trap _reap_watchdog_children EXIT\n"
+            + "while :; do sleep 30; done\n"
+        )
+        script_path = tmp_path / "real_watchdog.sh"
+        script_path.write_text(driver)
         script_path.chmod(0o755)
 
+        def _alive(pid):
+            try:
+                os.kill(pid, 0)
+                return True
+            except OSError:
+                return False
+
         watchdog = subprocess.Popen(["/bin/bash", str(script_path)])
-        # Let the script register its trap.
-        time.sleep(0.1)
+        size_pid = None
+        for _ in range(40):
+            pid_file = tmp_path / "size_pid"
+            if pid_file.exists() and pid_file.read_text().strip():
+                size_pid = int(pid_file.read_text().strip())
+                break
+            time.sleep(0.05)
+        assert size_pid is not None, "watchdog driver never reported SIZE_PID"
+        assert _alive(size_pid), "sub-loop should be alive before watchdog exits"
 
-        # Simulate outer cleanup() sending SIGTERM to the watchdog.
+        # Simulate outer cleanup() SIGTERMing the watchdog subshell.
         watchdog.terminate()
-        watchdog.wait(timeout=3)
+        watchdog.wait(timeout=5)
 
-        # The EXIT trap should have reaped the size sub-loop.
-        # Give the OS a moment to deliver the kill.
-        for _ in range(20):
-            if size_loop.poll() is not None:
+        # Bounded poll for the async reap signal to land.
+        reaped = False
+        for _ in range(40):
+            if not _alive(size_pid):
+                reaped = True
                 break
             time.sleep(0.05)
 
-        size_exit = size_loop.poll()
-        assert size_exit is not None, (
-            f"Size sub-loop (PID {size_pid}) is still alive after watchdog subshell "
-            "exited — EXIT trap did NOT fire or did not kill it.  "
-            "This is the I1 orphan: the sub-loop outlives the watchdog."
+        if _alive(size_pid):
+            try:
+                os.kill(size_pid, 9)
+            except OSError:
+                pass
+
+        assert reaped, (
+            "Sub-loop (PID %d) still alive after the watchdog subshell exited — "
+            "the SHIPPED _reap_watchdog_children EXIT trap did NOT reap it." % size_pid
         )
-        # Clean up in case assertion is skipped.
-        size_loop.kill()
-        size_loop.wait()
 
 
 @pytest.mark.skipif(not _ENTRYPOINT.exists(), reason="entrypoint.sh not found")
@@ -696,8 +869,6 @@ class TestSetECorrectness:
           b) explicit rc check with || true
         But removal is the correct fix.
         """
-        import re
-
         source = _ENTRYPOINT.read_text()
         # Old broken pattern from C1 finding:
         bad_pattern = re.search(r"TRUNC_RESPONSE=\$\(curl\s+-fsS", source)
@@ -712,8 +883,6 @@ class TestSetECorrectness:
         source = _ENTRYPOINT.read_text()
         # The size-check uses du -sm ... | awk, and must guard against du failures.
         # Skip comment lines (lines whose first non-whitespace char is #).
-        import re
-
         du_lines = [
             line
             for line in source.splitlines()

--- a/showcase/integrations/langgraph-typescript/tests/python/test_entrypoint_watchdog.py
+++ b/showcase/integrations/langgraph-typescript/tests/python/test_entrypoint_watchdog.py
@@ -403,10 +403,33 @@ class TestFilePersistenceDisabled:
             / "storage"
             / "persist.mjs"
         )
+        # In CI, LGT_REQUIRE_BEHAVIORAL=1 makes a missing runtime a FAILURE, not
+        # a skip: the merge-gating job is SUPPOSED to have the package installed,
+        # so a silent skip there would let the suite go green without ever
+        # exercising the real writer — the exact false-confidence mode this fix
+        # exists to prevent. Local dev machines (flag unset) still skip
+        # gracefully when the agent deps legitimately are not installed.
+        require_behavioral = os.environ.get("LGT_REQUIRE_BEHAVIORAL") == "1"
         if not persist_pkg.exists():
-            pytest.skip("agent node_modules not installed (@langchain/langgraph-api)")
+            msg = (
+                "agent node_modules not installed (@langchain/langgraph-api) at "
+                f"{persist_pkg}"
+            )
+            if require_behavioral:
+                pytest.fail(
+                    "LGT_REQUIRE_BEHAVIORAL=1 but " + msg + " — the CI job that "
+                    "gates this fix MUST install the agent deps (npm install in "
+                    "src/agent) so the real-package interception is actually "
+                    "exercised. Refusing to skip the sole behavioral proof."
+                )
+            pytest.skip(msg)
         node = shutil.which("node")
         if node is None:
+            if require_behavioral:
+                pytest.fail(
+                    "LGT_REQUIRE_BEHAVIORAL=1 but node is not on PATH — the CI job "
+                    "must set up Node before running the behavioral proof."
+                )
             pytest.skip("node not on PATH")
 
         run_cwd = tmp_path / "run"
@@ -482,6 +505,87 @@ class TestFilePersistenceDisabled:
             "In-memory round-trip broke: expected 'reply-0', got "
             f"{payload['readBack']!r}. Persistence disable must not remove "
             "in-lifetime conversation state."
+        )
+
+    def test_boot_fails_if_namespace_binding_not_patched_high1(self, tmp_path):
+        """HIGH-1 negative proof: if node:fs/promises is LINKED before the
+        preload's property reassignments run, the ESM namespace snapshots the
+        ORIGINAL (unpatched) function reference and a consumer's fs.writeFile
+        would silently bypass the no-op. The preload's runtime binding-identity
+        assertion MUST catch this and FAIL BOOT (non-zero exit) naming the
+        affected members — never continue silently into a disk-growth outage.
+
+        We simulate the fragile ordering with an earlier `--import` module that
+        links node:fs/promises before the disable module, then assert the
+        process exits non-zero with the FATAL identity-mismatch message. A
+        control run (correct ordering) is covered by
+        test_real_package_writes_are_suppressed_behavioral above.
+        """
+        import shutil
+
+        node = shutil.which("node")
+        require_behavioral = os.environ.get("LGT_REQUIRE_BEHAVIORAL") == "1"
+        if node is None:
+            if require_behavioral:
+                pytest.fail(
+                    "LGT_REQUIRE_BEHAVIORAL=1 but node is not on PATH — cannot "
+                    "run the HIGH-1 guard-fires proof."
+                )
+            pytest.skip("node not on PATH")
+
+        agent_dir = _PKG_ROOT / "src" / "agent"
+        preload = agent_dir / "disable-file-persistence.mjs"
+        assert preload.exists(), f"preload missing at {preload}"
+
+        # Earlier-ordered --import that links node:fs/promises FIRST, forcing the
+        # namespace binding to snapshot the pre-patch original.
+        early = tmp_path / "early_link_fs_promises.mjs"
+        early.write_text(
+            dedent(
+                """
+                import * as _fsp from "node:fs/promises";
+                void _fsp.writeFile; // force the namespace binding to resolve now
+                """
+            )
+        )
+
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": os.environ.get("HOME", "/tmp"),
+            "LANGGRAPH_DISABLE_FILE_PERSISTENCE": "true",
+        }
+        result = subprocess.run(
+            [
+                node,
+                "--import",
+                str(early),
+                "--import",
+                str(preload),
+                "-e",
+                "console.log('SHOULD-NOT-REACH')",
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        combined = result.stdout + result.stderr
+        assert result.returncode != 0, (
+            "Expected boot to FAIL when node:fs/promises is linked before the "
+            "patch (namespace snapshots the original fn), but the process exited "
+            f"0. stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        assert "SHOULD-NOT-REACH" not in result.stdout, (
+            "Boot continued past the identity guard despite the namespace binding "
+            "NOT reflecting the patch — this is the silent-bypass failure mode."
+        )
+        assert "namespace binding does NOT reflect the installed patch" in combined, (
+            "Expected the FATAL binding-identity message naming the unpatched "
+            f"members. output={combined!r}"
+        )
+        assert "writeFile" in combined, (
+            "The identity-guard failure must name the writeFile member (the "
+            f"primary persist write surface). output={combined!r}"
         )
 
 


### PR DESCRIPTION
## What & why

Permanent fix for the recurring langgraph-typescript (LGT) Railway outage — most recently **2026-07-13**, when both staging and prod went dead at D0.

**Root cause.** The LGT backend uses `@langchain/langgraph-api@1.1.17`, whose `FileSystemPersistence` (`dist/storage/persist.mjs`) serialises **all** accumulated thread/run/checkpoint state to `/app/src/agent/.langgraph_api` on a 3-second timer. Under the D6 probe fan-out (36 parallel probes in ~55s) the dir filled to **201MB in ~90s**, tripping the 200MB size-watchdog in `entrypoint.sh`:

```
[watchdog:size] Size threshold exceeded (201MB >= 200MB) — killing agent PID 5 ... exit code 137
```

Each restart refilled and re-tripped; after enough rapid kill→restart cycles Railway crash-loop backoff stopped restarting the container → the whole LGT column dead on **both** staging and prod.

## How this mirrors #5825

PR #5825 fixed the **python** side (commit `b4adfc6296`) by exporting `LANGGRAPH_DISABLE_FILE_PERSISTENCE=true`, which python's `langgraph_runtime_inmem` reads at import time to skip its pickle-flush-to-disk loop. **The TS side (commit `ef103f5f58`) never disabled persistence** — it only added the boot-purge + size-gated watchdog, which is exactly the mechanism that failed on 2026-07-13 (it kills on oversize, but the dir refills faster than backoff tolerates).

This PR does for TS what #5825 did for python: **stop the unbounded disk writes.** The mechanism differs because `@langchain/langgraph-api` has **no** `LANGGRAPH_DISABLE_FILE_PERSISTENCE` switch, its persistence writers are unexported module singletons, and the package `exports` map blocks a deep import of `persist.mjs` (`ERR_PACKAGE_PATH_NOT_EXPORTED`, verified). The only disk-write surface is `fs.writeFile`/`fs.mkdir` from `node:fs/promises`, so:

- **`src/agent/disable-file-persistence.mjs`** (new) — a `node --import` preload that, gated on `LANGGRAPH_DISABLE_FILE_PERSISTENCE=true`, no-ops `node:fs/promises` `writeFile`/`mkdir` for `.langgraph_api` paths only. Uses the CJS handle `require("node:fs").promises` because an ESM namespace object is sealed (`fsPromises.writeFile = …` throws — verified); the package's `import * as fs` named exports are backed by that same object, so the patch is observed by the package. In-memory state (the actual runtime state) is untouched.
- **`src/agent/package.json`** — `start` now `node --import ./disable-file-persistence.mjs --import tsx liveness.mjs` (patch installs before any langgraph code touches the fs).
- **`entrypoint.sh`** — `export LANGGRAPH_DISABLE_FILE_PERSISTENCE=true` before launching the agent (same placement/intent as #5825's python entrypoint).

Behavior preserved: runs still execute, thread state reads back from the in-memory checkpointer within a container's lifetime (D4/D5/D6 round-trips unaffected). Only disk persistence is removed — bounded by process memory, discarded on restart, matching python.

## LOCAL RED-GREEN PROOF (real surface)

Exercised the **real** `@langchain/langgraph-api@1.1.17` `startServer` with a real compiled `StateGraph`, drove real runs via `@langchain/langgraph-sdk`, then ran the **real** `entrypoint.sh --check-size-once` watchdog seam against the produced dir.

### RED (pre-fix) — unbounded growth trips the real watchdog

40 real runs, no preload → `.langgraph_api` = **43,320 KB** (checkpointer 32MB + ops 12MB). Real `entrypoint.sh` watchdog against it (threshold 30MB):

```
[watchdog:size] Persistence dir size: 43MB (threshold: 30MB)
[watchdog:size] Size threshold exceeded (43MB >= 30MB) — killing agent PID 78845 (and its npm→node tree) to trigger container restart and boot-purge
watchdog exit code (1 = killed): 1
dummy agent was KILLED by watchdog (RED reproduced)
```

### GREEN (post-fix) — no growth, watchdog never fires, round-trip still works

Same 40 real runs, with preload + env var → `.langgraph_api` = **0 KB (no dir)**. Real watchdog, same threshold:

```
[persistence] LANGGRAPH_DISABLE_FILE_PERSISTENCE=true — FileSystemPersistence disk flush disabled (in-memory only)
===RESULT=== runs=40 persistDirSizeKB=0
[watchdog:size] Persistence dir /tmp/lgt-persist-proof/.langgraph_api does not exist — skipping size check
watchdog exit code (0 = no kill): 0
dummy agent STILL ALIVE — watchdog did NOT fire (GREEN)
```

Behavior-preserved round-trip (with fix):

```
ROUND-TRIP: messages returned = 2 | assistant content length = 200000
ROUND-TRIP OK: true
persist dir after round-trip: 0 (no dir)
```

## Tests

`tests/python/test_entrypoint_watchdog.py` gains `TestFilePersistenceDisabled` (behavioral `bash -x` export-on-boot-path check + source/wiring guards). Full suite: **22 passed** (18 pre-existing + 4 new). No watchdog-logic regressions.

## Deferred (out of scope)

The size-watchdog restart contract still has no restart cooldown / crash-loop guard. With this fix the dir never grows so the watchdog should never trip under probe load, but a restart cooldown would harden against any future writer. Left out deliberately — root cause (the unbounded write) is eliminated here.

## ⚠ Before merge

The entrypoint env-var + preload are source-verified and locally red-green-proven against the real package, but the full container has not been run on Railway from this branch. Recommend a branch deploy (boots, serves 200, `.langgraph_api` stays empty under a probe wave) before merge. Kept as a **draft** pending that validation + maintainer approval.


---

## Round-2 CR fixes (7 reviewers + pre-audit)

Seven reviewers plus a pre-audit flagged that the round-1 `disable-file-persistence.mjs` was **surface-coupled and unanchored**, and that the entrypoint watchdog tests asserted a stale mechanism. All mandatory findings resolved and re-proven against the **real** package.

### Empirical truth about the writer (verified on installed `@langchain/langgraph-api@1.1.17`)

`FileSystemPersistence` (`dist/storage/persist.mjs`) uses `import * as fs from "node:fs/promises"` and calls `fs.writeFile(...)` / `fs.mkdir(...)` via **namespace property access** — which DOES read through to the CJS `.promises` patch. So the round-1 mechanism was *not* a silent no-op on this version (the pre-audit's named-import fear does not apply here). But the patch covered **only `writeFile` + `mkdir`** with an **unanchored substring**, leaving atomic write-then-rename, `appendFile`, the `*Sync` variants, `open`+handle, and `createWriteStream` as **silent bypasses** — the exact way the outage recurs if the pinned package's writer shape changes on upgrade. There is **no** env/config knob to disable or redirect persistence (the dir is hardcoded `path.resolve(cwd, ".langgraph_api", name)`), and `persist.mjs` is not deep-importable — so a hardened monkeypatch is the only faithful option.

### What changed

- **Patch every fs write surface** for the persist dir — `promises.{writeFile,appendFile,mkdir,rename,cp,open}`, `fs.{writeFileSync,appendFileSync,mkdirSync,renameSync,openSync,createWriteStream}` — so no future writer shape silently grows `.langgraph_api`.
- **Anchor path matching to the `.langgraph_api` path segment** (not a bare substring); normalise string/Buffer/URL forms. Fixes over-match data loss (`/tmp/x.langgraph_api.log`, `.langgraph_api_backup` now write normally).
- **Version + writer-shape guard that fails loudly at boot** if `@langchain/langgraph-api` is upgraded off `1.1.17` or switches to named imports — a silent recurrence on upgrade becomes an obvious boot crash with an actionable message.
- **mkdir `{recursive:true}` return contract honoured**; **env gate accepts `1`/`true`/`TRUE`/`yes`/`on`** and **logs on both branches** (enabled AND "not enabled — persistence ACTIVE").
- **Observability**: one-time "intercepted first persist-dir write via <surface>" log.
- **Tests**: assert the SHIPPED reaper (`trap _reap_watchdog_children EXIT` + `$BASHPID` PPID-walk), not a comment-only stale trap string; replace the mock-of-old-shape behavioral reaper test with one that drives the **real** extracted `entrypoint.sh` helpers; fix a flaky single-shot `poll()` with a bounded retry loop; refresh the stale truncate-era docstring; **add a real-package behavioral test** that drives the real `FileSystemPersistence` and asserts `.langgraph_api` stays 0 bytes while an in-memory round-trip still returns an assistant response.

### Round-2 RED-GREEN — real package, bypass surface

RED — round-1 fix (from committed HEAD), flag ON, an atomic write-then-rename (`writeFileSync`+`rename`) into `.langgraph_api` still lands on disk:

```
[persistence] LANGGRAPH_DISABLE_FILE_PERSISTENCE=true — FileSystemPersistence disk flush disabled (in-memory only)
RESULT bytes=4428903 files=.langgraphjs_api.checkpointer.json
DISK_GROWS=YES
```

GREEN — corrected fix, real `FileSystemPersistence.persist()` flush of 2000 threads:

```
[persistence] LANGGRAPH_DISABLE_FILE_PERSISTENCE enabled (value="true") — FileSystemPersistence disk flush disabled across all fs write surfaces (in-memory only)
[persistence] intercepted first persist-dir write via promises.mkdir (target=.../.langgraph_api); further hits silent
RESULT bytes=0 files=(none)
DISK_GROWS=NO
```

GREEN — corrected fix, the SAME bypass surface as RED is now closed:

```
RESULT bytes=0 files=(dir-not-created)
DISK_GROWS=NO
```

GREEN — real in-memory round-trip still works (conversation capability preserved) while disk stays empty:

```
ASSISTANT_RESPONSE="Hello from LGT"
DISK bytes=0
ROUNDTRIP=OK_AND_NO_DISK
```

Version guard fails loudly on a simulated upgrade (installed 1.2.0 vs expected 1.1.17):

```
[persistence] version/shape guard failed: @langchain/langgraph-api is 1.2.0, but the fs-write interception was verified against 1.1.17 ... Refusing to boot with an unverified writer shape.
```

`pytest tests/python/test_entrypoint_watchdog.py` → **23 passed** (incl. the new real-package + real-reaper behavioral tests; they run, not skip, when the agent's `node_modules` is installed).


---

## Round-3 CR fixes

Confirmation-CR round-2 raised two HIGH findings + three LOWs; all resolved on this branch (commit `01d3fa7794`).

**HIGH-1 — ESM-namespace-snapshot fragility (silent bypass on load-order).** The patch mutates `require("node:fs").promises.*`; a consumer's `import * as fs from "node:fs/promises"` observes it only if fs/promises links *after* the reassignment. If anything links it first, the namespace snapshots the ORIGINAL fn and every persist write silently bypasses the no-op. Added a runtime binding-identity net: after patching, the preload `await import("node:fs/promises")` and asserts `ns[name] === patchedFn` for every member it installed (writeFile, appendFile, mkdir, rename, open, cp); on any mismatch it FAILS BOOT naming the members, never continues silently. The source-string guard could not catch this (it checks text, not runtime identity).

**HIGH-2 — behavioral test skipped in CI (green-but-unproven).** The sole real-package proof `pytest.skip`ped when agent `node_modules` was absent, and no CI installed them. Now the test reads `LGT_REQUIRE_BEHAVIORAL`: `=1` (CI) turns a missing runtime into a FAILURE; unset (local dev) still skips gracefully. The `python-unit-tests` job in `showcase_validate.yml` now sets up Node 22, `npm install`s the agent deps, and runs the langgraph-typescript pytest with `LGT_REQUIRE_BEHAVIORAL=1`, so a green check genuinely proves the interception fired.

**LOWs:** tolerant writer-shape guard regex (quote/whitespace/alias agnostic; still trips on a named-import switch); read-only `open`/`openSync` reject an ENOENT-shaped error for suppressed paths (write-intent still no-ops) so a reader hits its missing-file branch; `mkdir {recursive:true}` returns the topmost-created dir per the real fs contract.

### Round-3 red-green — REAL `@langchain/langgraph-api@1.1.17`

RED (no preload; the real writer's flush lands on disk):
```
REAL-PACKAGE-RESULT {"readBack":"reply-0","bytes":32302}
```

GREEN (preload + `LANGGRAPH_DISABLE_FILE_PERSISTENCE=true`; dir stays empty, round-trip intact):
```
[persistence] ... disabled across all fs write surfaces (in-memory only); namespace binding-identity verified for 6 members
REAL-PACKAGE-RESULT {"readBack":"reply-0","bytes":0}
```

HIGH-1 guard-fires (fs/promises linked before the patch → boot THROWS, exit 1):
```
[persistence] FATAL: node:fs/promises namespace binding does NOT reflect the installed patch for: writeFile, appendFile, mkdir, rename, open, cp. ... Refusing to boot. ...
EXIT=1
```

`LGT_REQUIRE_BEHAVIORAL=1 pytest tests/python/test_entrypoint_watchdog.py` → **24 passed** (adds the HIGH-1 guard-fires regression test; the real-package behavioral proof now runs, not skips, and is CI-gated).
