### PR TITLE
docs(channels): use Channels SDK naming

### DIFF
--- a/showcase/shell-docs/src/app/reference/page.tsx
+++ b/showcase/shell-docs/src/app/reference/page.tsx
@@ -67,9 +67,9 @@ const SDK_CHOICES: { name: string; description: string; href: string }[] = [
     href: referenceVersionHref("core"),
   },
   {
-    name: "Channels",
+    name: "Channels SDK",
     description:
-      "The bot stack — createBot, JSX message components, and the Slack adapter.",
+      "Build chat-platform agents with createBot, JSX message components, and platform adapters.",
     href: referenceVersionHref("channels"),
   },
 ];

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: Channels
+title: Channels SDK
 description: Build durable, cross-platform AI bots with CopilotKit — a platform adapter, an AG-UI agent, and optional persistence wired together in a single createBot call.
 icon: "lucide/Bot"
 hideTOC: true
 ---
 
-The channel stack is three pieces: **`@copilotkit/channels`** (core runtime), a **platform adapter** (e.g. `@copilotkit/channels-slack`), and an **AG-UI agent** — any CopilotKit runtime or compatible backend. Plug them together with `createBot` and you get a bot that streams agent replies into the platform, handles interactive buttons, and — once you add a store — survives restarts and spans multiple instances.
+The Channels SDK is three pieces: **`@copilotkit/channels`** (core runtime), a **platform adapter** (e.g. `@copilotkit/channels-slack`), and an **AG-UI agent** — any CopilotKit runtime or compatible backend. Plug them together with `createBot` and you get a bot that streams agent replies into the platform, handles interactive buttons, and — once you add a store — survives restarts and spans multiple instances.
 
 <OpsPlatformCTA
   variant="inline"
@@ -33,7 +33,7 @@ The channel stack is three pieces: **`@copilotkit/channels`** (core runtime), a 
     description="Give the agent a cross-platform memory that follows users from Slack to any other channel — with GDPR-ready delete support."
   />
   <Card
-    title="Channels reference"
+    title="Channels SDK reference"
     href="/reference/channels"
     description="Full API reference — createBot, Thread, StateStore, ActionStore, and the Slack adapter."
   />

--- a/showcase/shell-docs/src/content/docs/channels/meta.json
+++ b/showcase/shell-docs/src/content/docs/channels/meta.json
@@ -1,5 +1,5 @@
 {
-  "title": "Bots",
+  "title": "Channels SDK",
   "icon": "lucide/Bot",
   "pages": ["index", "persistence", "transcripts"]
 }

--- a/showcase/shell-docs/src/content/docs/frontends/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/slack.mdx
@@ -5,12 +5,12 @@ icon: "lucide/Slack"
 hideTOC: true
 ---
 
-Slack can be the frontend for agents built on any harness or framework, so your team can get work done in the conversations, approvals, and handoffs they already use. The open source Bot SDK gives you the adapter path for TypeScript handlers and JSX-authored Block Kit messages. CopilotKit Enterprise Intelligence adds the self-hosted or cloud-hosted production layer for thread mapping, durable agent state, approvals, observability, and release operations when Slack becomes a critical workflow.
+Slack can be the frontend for agents built on any harness or framework, so your team can get work done in the conversations, approvals, and handoffs they already use. The open source Channels SDK gives you the adapter path for TypeScript handlers and JSX-authored Block Kit messages. CopilotKit Enterprise Intelligence adds the self-hosted or cloud-hosted production layer for thread mapping, durable agent state, approvals, observability, and release operations when Slack becomes a critical workflow.
 
 <OpsPlatformCTA
   variant="inline"
   title="Get early access to Slack and Teams agents in CopilotKit Enterprise Intelligence"
-  body="Use the open source Bot SDK to run the adapter, runtime, platform credentials, tools, and storage inside your stack. CopilotKit Enterprise Intelligence adds the self-hosted or cloud-hosted production layer around that SDK: durable agent threads, platform conversation mapping, approvals, observability, and release operations for Slack and Teams."
+  body="Use the open source Channels SDK to run the adapter, runtime, platform credentials, tools, and storage inside your stack. CopilotKit Enterprise Intelligence adds the self-hosted or cloud-hosted production layer around that SDK: durable agent threads, platform conversation mapping, approvals, observability, and release operations for Slack and Teams."
   ctaLabel="Get early access"
   surface="docs_slack_agents_early_access"
   href="https://www.copilotkit.ai/opentag-managed"
@@ -59,7 +59,7 @@ Slack can be the frontend for agents built on any harness or framework, so your 
         npm init -y && npm pkg set type=module
         ```
 
-        Install the bot packages, plus `@copilotkit/runtime` for Copilot Runtime and `tsx` to run TypeScript directly:
+        Install the Channels packages, plus `@copilotkit/runtime` for Copilot Runtime and `tsx` to run TypeScript directly:
 
         <Tabs groupId="package-manager" items={['npm', 'pnpm', 'yarn']}>
             <Tab value="npm">
@@ -102,7 +102,7 @@ Slack can be the frontend for agents built on any harness or framework, so your 
         ```
 
         <Callout type="info" title="ESM only">
-          The bot packages are ESM-only — `"type": "module"` (set above) is required.
+          The Channels packages are ESM-only — `"type": "module"` (set above) is required.
         </Callout>
     </Step>
     <Step>
@@ -321,5 +321,5 @@ Discord requires the modal to be opened **before any other response** to a butto
 
 ## Next steps
 
-- **API reference:** the [Channels reference](/reference/channels) — [createBot](/reference/channels/functions/createBot), the [Thread API](/reference/channels/classes/Thread), [tools](/reference/channels/functions/defineBotTool) & [commands](/reference/channels/functions/defineBotCommand), the [component vocabulary](/reference/channels/components/Message), and the [Slack adapter](/reference/channels/slack)
+- **API reference:** the [Channels SDK reference](/reference/channels) — [createBot](/reference/channels/functions/createBot), the [Thread API](/reference/channels/classes/Thread), [tools](/reference/channels/functions/defineBotTool) & [commands](/reference/channels/functions/defineBotCommand), the [component vocabulary](/reference/channels/components/Message), and the [Slack adapter](/reference/channels/slack)
 - **Full example:** [on-call triage bot over Linear + Notion MCP](https://github.com/CopilotKit/CopilotKit/tree/main/examples/slack) — tools, human-in-the-loop, slash commands, file uploads

--- a/showcase/shell-docs/src/content/docs/frontends/teams.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/teams.mdx
@@ -4,12 +4,12 @@ description: Bring custom agents into Microsoft Teams with Adaptive Cards, strea
 hideTOC: true
 ---
 
-Microsoft Teams can be the frontend for agents built on any harness or framework, so your organization can get work done where conversations, decisions, and approvals already happen. The open source Bot SDK gives you the adapter path for TypeScript handlers and JSX-authored Adaptive Cards. CopilotKit Enterprise Intelligence adds the self-hosted or cloud-hosted production layer for conversation mapping, durable agent state, approvals, observability, and release operations when Teams becomes a critical workflow.
+Microsoft Teams can be the frontend for agents built on any harness or framework, so your organization can get work done where conversations, decisions, and approvals already happen. The open source Channels SDK gives you the adapter path for TypeScript handlers and JSX-authored Adaptive Cards. CopilotKit Enterprise Intelligence adds the self-hosted or cloud-hosted production layer for conversation mapping, durable agent state, approvals, observability, and release operations when Teams becomes a critical workflow.
 
 <OpsPlatformCTA
   variant="inline"
   title="Get early access to Slack and Teams agents in CopilotKit Enterprise Intelligence"
-  body="Use the open source Bot SDK to run the adapter, runtime, platform credentials, tools, and storage inside your stack. CopilotKit Enterprise Intelligence adds the self-hosted or cloud-hosted production layer around that SDK: durable agent threads, platform conversation mapping, approvals, observability, and release operations for Slack and Teams."
+  body="Use the open source Channels SDK to run the adapter, runtime, platform credentials, tools, and storage inside your stack. CopilotKit Enterprise Intelligence adds the self-hosted or cloud-hosted production layer around that SDK: durable agent threads, platform conversation mapping, approvals, observability, and release operations for Slack and Teams."
   ctaLabel="Get early access"
   surface="docs_teams_agents_early_access"
   href="https://www.copilotkit.ai/opentag-managed"
@@ -33,7 +33,7 @@ Microsoft Teams can be the frontend for agents built on any harness or framework
         npm init -y && npm pkg set type=module
         ```
 
-        Install the bot packages, plus `@copilotkit/runtime` for the in-process agent and `tsx` to run TypeScript directly:
+        Install the Channels packages, plus `@copilotkit/runtime` for the in-process agent and `tsx` to run TypeScript directly:
 
         <Tabs groupId="package-manager" items={['npm', 'pnpm', 'yarn']}>
             <Tab value="npm">
@@ -76,7 +76,7 @@ Microsoft Teams can be the frontend for agents built on any harness or framework
         ```
 
         <Callout type="info" title="ESM only">
-          The bot packages are ESM-only, so `"type": "module"` (set above) is required.
+          The Channels packages are ESM-only, so `"type": "module"` (set above) is required.
         </Callout>
     </Step>
     <Step>
@@ -396,5 +396,5 @@ In Microsoft Teams: open **Apps → Manage your apps → Upload a custom app**, 
 
 ## Next steps
 
-- **API reference:** the [Channels reference](/reference/channels), covering [createBot](/reference/channels/functions/createBot), the [Thread API](/reference/channels/classes/Thread), [tools](/reference/channels/functions/defineBotTool), and the [component vocabulary](/reference/channels/components/Message)
+- **API reference:** the [Channels SDK reference](/reference/channels), covering [createBot](/reference/channels/functions/createBot), the [Thread API](/reference/channels/classes/Thread), [tools](/reference/channels/functions/defineBotTool), and the [component vocabulary](/reference/channels/components/Message)
 - **Full example:** the [Teams demo bot](https://github.com/CopilotKit/CopilotKit/tree/main/examples/teams), a `BuiltInAgent` with agent-rendered Adaptive Cards, a human-in-the-loop approval gate, and a deployable app package

--- a/showcase/shell-docs/src/content/docs/frontends/whatsapp.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/whatsapp.mdx
@@ -52,7 +52,7 @@ This guide takes you from zero to a WhatsApp bot that replies to every inbound m
         npm init -y && npm pkg set type=module
         ```
 
-        Install the bot packages, plus `@copilotkit/runtime` for the in-process agent and `tsx` to run TypeScript directly:
+        Install the Channels packages, plus `@copilotkit/runtime` for the in-process agent and `tsx` to run TypeScript directly:
 
         <Tabs groupId="package-manager" items={['npm', 'pnpm', 'yarn']}>
             <Tab value="npm">
@@ -95,7 +95,7 @@ This guide takes you from zero to a WhatsApp bot that replies to every inbound m
         ```
 
         <Callout type="info" title="ESM only">
-          The bot packages are ESM-only — `"type": "module"` (set above) is required.
+          The Channels packages are ESM-only — `"type": "module"` (set above) is required.
         </Callout>
     </Step>
     <Step>
@@ -312,5 +312,5 @@ value instead.
 
 ## Next steps
 
-- **API reference:** the [Channels reference](/reference/channels) — [createBot](/reference/channels/functions/createBot), the [Thread API](/reference/channels/classes/Thread), [tools](/reference/channels/functions/defineBotTool) & [commands](/reference/channels/functions/defineBotCommand), and the [component vocabulary](/reference/channels/components/Message)
+- **API reference:** the [Channels SDK reference](/reference/channels) — [createBot](/reference/channels/functions/createBot), the [Thread API](/reference/channels/classes/Thread), [tools](/reference/channels/functions/defineBotTool) & [commands](/reference/channels/functions/defineBotCommand), and the [component vocabulary](/reference/channels/components/Message)
 - **Full example:** [on-call triage bot over Linear + Notion MCP](https://github.com/CopilotKit/CopilotKit/tree/main/examples/slack) — tools, human-in-the-loop, commands, file uploads, persistent history

--- a/showcase/shell-docs/src/content/reference/channels/index.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Channels"
-description: "API reference for the CopilotKit channel stack — @copilotkit/channels, @copilotkit/channels-ui, @copilotkit/channels-slack, and @copilotkit/channels-discord."
+title: "Channels SDK"
+description: "API reference for the CopilotKit Channels SDK — @copilotkit/channels, @copilotkit/channels-ui, @copilotkit/channels-slack, and @copilotkit/channels-discord."
 ---
 
-The channel stack turns any [AG-UI](https://docs.ag-ui.com) agent into a chat-platform bot. Three packages, three jobs:
+The Channels SDK turns any [AG-UI](https://docs.ag-ui.com) agent into a chat-platform bot. Three packages, three jobs:
 
 | Package | Role |
 |---------|------|

--- a/showcase/shell-docs/src/lib/__tests__/frontend-options.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/frontend-options.test.ts
@@ -206,6 +206,14 @@ describe("frontend options", () => {
     expect(getFrontendReferenceSlug("teams")).toBe("reference");
   });
 
+  it("keeps the early-access guidance link iconless", () => {
+    const guidanceLink = getFrontendQuickstartNavTree("slack").find(
+      (node) => node.type === "page" && node.title === "About early access",
+    );
+
+    expect(guidanceLink).not.toHaveProperty("icon");
+  });
+
   it("keeps non-React frontend sidebars limited to quickstart and reference links", () => {
     const navTree = getFrontendQuickstartNavTree("slack");
     const flattenedNavTree = flattenNavTree(navTree);

--- a/showcase/shell-docs/src/lib/__tests__/redirects.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/redirects.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import nextConfig from "../../../next.config";
+
+describe("legacy Bots SDK redirects", () => {
+  it("permanently redirects Bots SDK routes to Channels SDK routes", async () => {
+    expect(nextConfig.redirects).toBeTypeOf("function");
+
+    const redirects = await nextConfig.redirects!();
+
+    expect(redirects).toEqual(
+      expect.arrayContaining([
+        {
+          source: "/bots",
+          destination: "/channels",
+          permanent: true,
+        },
+        {
+          source: "/bots/:path*",
+          destination: "/channels/:path*",
+          permanent: true,
+        },
+        {
+          source: "/reference/bot",
+          destination: "/reference/channels",
+          permanent: true,
+        },
+        {
+          source: "/reference/bot/:path*",
+          destination: "/reference/channels/:path*",
+          permanent: true,
+        },
+      ]),
+    );
+  });
+});

--- a/showcase/shell-docs/src/lib/frontend-page-content.ts
+++ b/showcase/shell-docs/src/lib/frontend-page-content.ts
@@ -52,7 +52,6 @@ export function getFrontendQuickstartNavTree(id: FrontendPageId): NavNode[] {
       type: "page",
       title: getFrontendGuidanceTitle(id),
       slug: "using-these-docs",
-      icon: "lucide/Wrench",
     },
     {
       type: "page",


### PR DESCRIPTION
## Problem

The package and docs routes were renamed from Bots to Channels, but the docs still presented the old “Bots” and “Bot SDK” product name in navigation and integration guides. The Channels reference page was titled only “Channels” instead of “Channels SDK.”

## Why

The stale naming makes the Channels SDK links unclear in launch communications and creates an inconsistent journey between the package names, Slack and Teams quickstarts, and API reference.

## Fix

- Title the Channels guide and `/reference/channels` page “Channels SDK.”
- Update the reference chooser and Slack, Teams, and WhatsApp guides to use the Channels SDK name.
- Remove the stale wrench icon from the Slack and Teams early-access sidebar link, with a regression test for the navigation node.
- Preserve the existing `/channels`, `/reference/channels`, `/slack`, and `/teams` routes and all existing link targets.
- Verify permanent redirects from `/bots` and `/bots/*` to `/channels`, and from `/reference/bot` and `/reference/bot/*` to `/reference/channels`, with regression coverage for both exact and nested routes.

Verification:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- Local production smoke checks returned HTTP 200 for `/channels`, `/reference/channels`, `/slack`, and `/teams`; rendered `/slack` contains no wrench markup.
