### PR TITLE
fix(core,react-core): defer runtime /info out of the core constructor (#5801)

### DIFF
--- a/packages/core/src/__tests__/core-defer-runtime-connection.test.ts
+++ b/packages/core/src/__tests__/core-defer-runtime-connection.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Deferred runtime connection (#5801).
+ *
+ * `CopilotKitProvider` constructs the core during React's render phase, and
+ * React can start-and-discard renders (concurrent rendering, Suspense,
+ * StrictMode). When the constructor fires the `/info` request synchronously,
+ * every discarded-and-recreated core issues its own request — a single page
+ * load was observed firing 70-80 `/info` requests.
+ *
+ * The fix separates construction (pure) from connection (network I/O):
+ * `deferInitialConnection` lets the constructor set the runtime config WITHOUT
+ * fetching, and `connect()` — driven from a commit-phase effect — starts the
+ * single connection for the surviving instance. `connect()` is idempotent so
+ * StrictMode's double-invoked effect collapses to one request.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { CopilotKitCore } from "../core";
+
+const RUNTIME_URL = "https://runtime.example/rest";
+const infoResponse = { version: "1.0.0", agents: {} };
+
+describe("CopilotKitCore — deferred runtime connection (#5801)", () => {
+  const originalWindow = (globalThis as { window?: unknown }).window;
+  const originalFetch = global.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    (globalThis as { window?: unknown }).window = {};
+    fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(infoResponse), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+    if (originalWindow === undefined) {
+      delete (globalThis as { window?: unknown }).window;
+    } else {
+      (globalThis as { window?: unknown }).window = originalWindow;
+    }
+  });
+
+  const infoCalls = () =>
+    fetchMock.mock.calls.filter(([u]) => String(u).includes("/info"));
+
+  it("does not fetch /info from the constructor when deferInitialConnection is set", async () => {
+    const core = new CopilotKitCore({
+      runtimeUrl: RUNTIME_URL,
+      runtimeTransport: "rest",
+      deferInitialConnection: true,
+    });
+    expect(core.runtimeUrl).toBe(RUNTIME_URL);
+    // Wait a macrotask — a constructor-initiated fetch fires after an internal
+    // await, so a microtask wait would miss it and pass falsely.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(infoCalls().length).toBe(0);
+  });
+
+  it("still exposes runtimeUrl synchronously when deferred", () => {
+    const core = new CopilotKitCore({
+      runtimeUrl: RUNTIME_URL,
+      runtimeTransport: "rest",
+      deferInitialConnection: true,
+    });
+    expect(core.runtimeUrl).toBe(RUNTIME_URL);
+  });
+
+  it("connect() triggers exactly one /info fetch after a deferred construct", async () => {
+    const core = new CopilotKitCore({
+      runtimeUrl: RUNTIME_URL,
+      runtimeTransport: "rest",
+      deferInitialConnection: true,
+    });
+    core.connect();
+    await vi.waitFor(() => expect(infoCalls().length).toBe(1));
+    expect(infoCalls()[0]?.[0]).toBe(`${RUNTIME_URL}/info`);
+  });
+
+  it("connect() is idempotent — repeated calls collapse to one /info fetch (StrictMode double-invoke)", async () => {
+    const core = new CopilotKitCore({
+      runtimeUrl: RUNTIME_URL,
+      runtimeTransport: "rest",
+      deferInitialConnection: true,
+    });
+    core.connect();
+    core.connect();
+    core.connect();
+    await vi.waitFor(() => expect(infoCalls().length).toBe(1));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(infoCalls().length).toBe(1);
+  });
+
+  it("without deferInitialConnection the constructor still connects (backward compatible)", async () => {
+    const core = new CopilotKitCore({
+      runtimeUrl: RUNTIME_URL,
+      runtimeTransport: "rest",
+    });
+    expect(core.runtimeUrl).toBe(RUNTIME_URL);
+    await vi.waitFor(() => expect(infoCalls().length).toBe(1));
+  });
+
+  it("orphaned cores that never connect() fire zero /info; only the committed one fetches", async () => {
+    // Models React discarding in-progress renders: each attempt constructs a
+    // core, but only the committed instance reaches the connect() effect.
+    const orphans: CopilotKitCore[] = [];
+    for (let i = 0; i < 5; i++) {
+      orphans.push(
+        new CopilotKitCore({
+          runtimeUrl: RUNTIME_URL,
+          runtimeTransport: "rest",
+          deferInitialConnection: true,
+        }),
+      );
+    }
+    expect(orphans).toHaveLength(5);
+    const committed = new CopilotKitCore({
+      runtimeUrl: RUNTIME_URL,
+      runtimeTransport: "rest",
+      deferInitialConnection: true,
+    });
+    committed.connect();
+
+    await vi.waitFor(() => expect(infoCalls().length).toBe(1));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(infoCalls().length).toBe(1);
+  });
+
+  it("de-dupes concurrent same-target updateRuntimeConnection calls into one /info (in-flight guard)", async () => {
+    // A url + transport change arriving together must not fire two /info.
+    const core = new CopilotKitCore({
+      runtimeUrl: RUNTIME_URL,
+      runtimeTransport: "rest",
+      deferInitialConnection: true,
+    });
+    core.setRuntimeTransport("rest");
+    core.connect();
+    core.connect();
+    await vi.waitFor(() => expect(infoCalls().length).toBe(1));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(infoCalls().length).toBe(1);
+  });
+});

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -59,6 +59,10 @@ export class AgentRegistry {
   private remoteAgents: Record<string, AbstractAgent> = {};
 
   private _runtimeUrl?: string;
+  // Tracks an in-flight `/info` connection so concurrent calls targeting the
+  // same runtime (url + requested transport) collapse to a single request
+  // instead of each firing their own. See #5801.
+  private _connectionInFlight?: { key: string; promise: Promise<void> };
   private _runtimeVersion?: string;
   private _runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus =
     CopilotKitCoreRuntimeConnectionStatus.Disconnected;
@@ -174,7 +178,10 @@ export class AgentRegistry {
   /**
    * Set the runtime URL and update connection
    */
-  setRuntimeUrl(runtimeUrl: string | undefined): void {
+  setRuntimeUrl(
+    runtimeUrl: string | undefined,
+    options?: { deferConnection?: boolean },
+  ): void {
     const normalizedRuntimeUrl = runtimeUrl
       ? runtimeUrl.replace(/\/$/, "")
       : undefined;
@@ -184,6 +191,42 @@ export class AgentRegistry {
     }
 
     this._runtimeUrl = normalizedRuntimeUrl;
+
+    // Deferred construction (see CopilotKitCore.connect / #5801): record the URL
+    // so getters/hooks see it synchronously, but do NOT start the `/info` fetch
+    // here. The host starts it from a commit-phase effect via `connect()`, so
+    // renders discarded before commit never issue a request.
+    if (options?.deferConnection) {
+      return;
+    }
+
+    void this.updateRuntimeConnection();
+  }
+
+  /**
+   * Start the initial runtime connection if it has not been started yet.
+   *
+   * Backs {@link CopilotKitCore.connect}. Idempotent: it only kicks off a fetch
+   * when a `runtimeUrl` is set and the connection is still `Disconnected` (its
+   * state before any connect attempt). `updateRuntimeConnection` flips the
+   * status to `Connecting` synchronously, so a second call — e.g. React
+   * StrictMode double-invoking the mount effect — bails here. A genuine config
+   * change still reconnects through `setRuntimeUrl`/`setRuntimeTransport`. See
+   * #5801.
+   */
+  connectRuntime(): void {
+    if (typeof window === "undefined") {
+      return;
+    }
+    if (!this._runtimeUrl) {
+      return;
+    }
+    if (
+      this._runtimeConnectionStatus !==
+      CopilotKitCoreRuntimeConnectionStatus.Disconnected
+    ) {
+      return;
+    }
     void this.updateRuntimeConnection();
   }
 
@@ -387,6 +430,28 @@ export class AgentRegistry {
     if (typeof window === "undefined") {
       return;
     }
+
+    // In-flight guard: if a connection to the same target (runtime url +
+    // requested transport) is already running, reuse it instead of starting a
+    // second `/info` request. A change to a different target supersedes it. See
+    // #5801.
+    const key = `${this._runtimeUrl ?? ""}::${this._requestedTransport}`;
+    const inFlight = this._connectionInFlight;
+    if (inFlight && inFlight.key === key) {
+      return inFlight.promise;
+    }
+
+    const promise = this.performRuntimeConnection();
+    this._connectionInFlight = { key, promise };
+    void promise.finally(() => {
+      if (this._connectionInFlight?.promise === promise) {
+        this._connectionInFlight = undefined;
+      }
+    });
+    return promise;
+  }
+
+  private async performRuntimeConnection(): Promise<void> {
 
     if (!this.runtimeUrl) {
       this._runtimeConnectionStatus =

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -452,7 +452,6 @@ export class AgentRegistry {
   }
 
   private async performRuntimeConnection(): Promise<void> {
-
     if (!this.runtimeUrl) {
       this._runtimeConnectionStatus =
         CopilotKitCoreRuntimeConnectionStatus.Disconnected;

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -41,6 +41,15 @@ export interface CopilotKitCoreConfig {
   runtimeUrl?: string;
   /** Transport style for CopilotRuntime endpoints. Defaults to REST. */
   runtimeTransport?: CopilotRuntimeTransport;
+  /**
+   * When true, the constructor sets the runtime config but does NOT start the
+   * `/info` connection. Call {@link CopilotKitCore.connect} to start it —
+   * typically from a host's commit-phase effect. This prevents a burst of
+   * duplicate `/info` requests when a host constructs (and discards) the core
+   * during render, e.g. React concurrent rendering / Suspense / StrictMode.
+   * See https://github.com/CopilotKit/CopilotKit/issues/5801.
+   */
+  deferInitialConnection?: boolean;
   /** Mapping from agent name to its `AbstractAgent` instance. For development only - production requires CopilotRuntime. */
   agents__unsafe_dev_only?: Record<string, AbstractAgent>;
   /**
@@ -397,6 +406,7 @@ export class CopilotKitCore {
   constructor({
     runtimeUrl,
     runtimeTransport = "auto",
+    deferInitialConnection = false,
     headers = {},
     credentials,
     properties = {},
@@ -425,7 +435,9 @@ export class CopilotKitCore {
     this.stateManager.initialize();
 
     this.agentRegistry.setRuntimeTransport(runtimeTransport);
-    this.agentRegistry.setRuntimeUrl(runtimeUrl);
+    this.agentRegistry.setRuntimeUrl(runtimeUrl, {
+      deferConnection: deferInitialConnection,
+    });
 
     // Seed the previous-agents snapshot from the constructor-supplied agents.
     // `agentRegistry.initialize` does not emit `onAgentsChanged`, so the
@@ -589,6 +601,19 @@ export class CopilotKitCore {
 
   setRuntimeUrl(runtimeUrl: string | undefined): void {
     this.agentRegistry.setRuntimeUrl(runtimeUrl);
+  }
+
+  /**
+   * Start the runtime `/info` connection if it has not been started yet.
+   *
+   * Intended to be driven from a host's commit-phase effect when the core was
+   * constructed with {@link CopilotKitCoreConfig.deferInitialConnection}. Safe
+   * to call repeatedly — it is a no-op once a connection is in progress or
+   * settled, so a double-invoked mount effect (React StrictMode) collapses to a
+   * single request. See #5801.
+   */
+  connect(): void {
+    this.agentRegistry.connectRuntime();
   }
 
   get runtimeTransport(): CopilotRuntimeTransport {

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -575,6 +575,12 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   if (copilotkitRef.current === null) {
     copilotkitRef.current = new CopilotKitCoreReact({
       runtimeUrl: chatApiEndpoint,
+      // Defer the `/info` fetch out of construction. The core is constructed
+      // during render, and React can start-and-discard renders (concurrent
+      // rendering / Suspense / StrictMode) — a network request in the ctor
+      // would fire once per discarded attempt (issue #5801). `connect()` below
+      // starts the single request from a commit-phase effect.
+      deferInitialConnection: true,
       runtimeTransport:
         useSingleEndpoint === true
           ? "single"
@@ -724,6 +730,13 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
     );
     copilotkit.setAgents__unsafe_dev_only(mergedAgents);
     copilotkit.setDebug(debug);
+    // Start the runtime `/info` connection now that we're in the commit phase.
+    // The ctor deferred it (see `deferInitialConnection` above) so discarded
+    // renders never fetch; `connect()` is idempotent, so StrictMode's
+    // double-invoked effect and re-runs on unrelated prop changes collapse to a
+    // single request (a real runtimeUrl/transport change reconnects via the
+    // setters above). See #5801.
+    copilotkit.connect();
   }, [
     copilotkit,
     chatApiEndpoint,

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.deferConnection.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.deferConnection.test.tsx
@@ -1,12 +1,18 @@
 /**
- * Regression test for #5801: the provider must issue exactly one runtime
- * `/info` request per mount, driven from a commit-phase effect rather than the
- * core constructor.
+ * Regression coverage for #5801: a normal provider mount issues exactly one
+ * runtime `/info` request (real core + mocked fetch), and `connect()` stays
+ * idempotent under StrictMode's double-invoked mount effect.
  *
- * Uses the REAL `CopilotKitCoreReact` with a mocked `fetch` so we count actual
- * `/info` requests. Under React StrictMode the mount effect is double-invoked
- * (mount → cleanup → remount); `connect()` is idempotent, so the count must
- * stay at one.
+ * NOTE on scope: the actual bug (dozens of `/info`) only manifests when React
+ * *discards* in-progress renders and constructs multiple orphaned cores — which
+ * Testing Library cannot reproduce (a committed single mount yields exactly one
+ * `/info` whether the ctor or an effect fires it, and the ctor's fetch is
+ * several microtasks deep so ordering doesn't distinguish it either). The
+ * mechanism that fixes the multi-instance case is proven in `packages/core` by
+ * `core-defer-runtime-connection.test.ts` ("orphaned cores that never connect()
+ * fire zero /info"); the deferral WIRING is asserted in
+ * `CopilotKitProvider.deferWiring.test.tsx`. These two tests guard against the
+ * connection regressing to zero or duplicating on a normal mount.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, waitFor } from "@testing-library/react";
@@ -16,7 +22,7 @@ import { CopilotKitProvider } from "../CopilotKitProvider";
 const RUNTIME_URL = "https://runtime.example/rest";
 const infoResponse = { version: "1.0.0", agents: {} };
 
-describe("CopilotKitProvider — deferred runtime connection (#5801)", () => {
+describe("CopilotKitProvider — runtime connection (real core, #5801)", () => {
   const originalFetch = global.fetch;
   let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -50,7 +56,7 @@ describe("CopilotKitProvider — deferred runtime connection (#5801)", () => {
     expect(infoCalls().length).toBe(1);
   });
 
-  it("fetches /info exactly once under StrictMode (double-invoked mount effect)", async () => {
+  it("fetches /info exactly once under StrictMode (double-invoked mount effect stays idempotent)", async () => {
     render(
       <React.StrictMode>
         <CopilotKitProvider runtimeUrl={RUNTIME_URL}>

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.deferConnection.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.deferConnection.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Regression test for #5801: the provider must issue exactly one runtime
+ * `/info` request per mount, driven from a commit-phase effect rather than the
+ * core constructor.
+ *
+ * Uses the REAL `CopilotKitCoreReact` with a mocked `fetch` so we count actual
+ * `/info` requests. Under React StrictMode the mount effect is double-invoked
+ * (mount → cleanup → remount); `connect()` is idempotent, so the count must
+ * stay at one.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import React from "react";
+import { CopilotKitProvider } from "../CopilotKitProvider";
+
+const RUNTIME_URL = "https://runtime.example/rest";
+const infoResponse = { version: "1.0.0", agents: {} };
+
+describe("CopilotKitProvider — deferred runtime connection (#5801)", () => {
+  const originalFetch = global.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(infoResponse), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  const infoCalls = () =>
+    fetchMock.mock.calls.filter(([u]) => String(u).includes("/info"));
+
+  it("fetches /info exactly once on mount", async () => {
+    render(
+      <CopilotKitProvider runtimeUrl={RUNTIME_URL}>
+        <div>child</div>
+      </CopilotKitProvider>,
+    );
+
+    await waitFor(() => expect(infoCalls().length).toBe(1));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(infoCalls().length).toBe(1);
+  });
+
+  it("fetches /info exactly once under StrictMode (double-invoked mount effect)", async () => {
+    render(
+      <React.StrictMode>
+        <CopilotKitProvider runtimeUrl={RUNTIME_URL}>
+          <div>child</div>
+        </CopilotKitProvider>
+      </React.StrictMode>,
+    );
+
+    await waitFor(() => expect(infoCalls().length).toBe(1));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(infoCalls().length).toBe(1);
+  });
+});

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.deferWiring.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.deferWiring.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * #5801 deferral wiring: the provider must construct the core WITHOUT starting
+ * the `/info` connection during render (`deferInitialConnection: true`) and
+ * start the single connection from a commit-phase effect via `connect()`.
+ *
+ * This is the provider-level assertion that actually distinguishes the fix from
+ * the bug: it fails if the provider drops `deferInitialConnection` (reverting to
+ * a constructor-fired `/info`) or stops calling `connect()`. It mocks the core
+ * to capture how the provider constructs and drives it — a normal render can't
+ * observe the multi-instance duplication (see the note in
+ * `CopilotKitProvider.deferConnection.test.tsx`).
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import React from "react";
+
+const ctorConfigs: Array<Record<string, unknown>> = [];
+const connectCalls: string[] = [];
+
+vi.mock("../../lib/react-core", () => {
+  class FakeCore {
+    constructor(config: Record<string, unknown>) {
+      ctorConfigs.push(config);
+    }
+    connect() {
+      connectCalls.push("connect");
+    }
+    subscribe() {
+      return { unsubscribe: () => {} };
+    }
+    get a2uiEnabled() {
+      return false;
+    }
+    get openGenerativeUIEnabled() {
+      return false;
+    }
+    get licenseStatus() {
+      return undefined;
+    }
+    get a2uiAgents() {
+      return undefined;
+    }
+    setDefaultThrottleMs() {}
+    setRuntimeUrl() {}
+    setRuntimeTransport() {}
+    setHeaders() {}
+    setCredentials() {}
+    setProperties() {}
+    setTools() {}
+    setRenderToolCalls() {}
+    setRenderActivityMessages() {}
+    setRenderCustomMessages() {}
+    setAgents__unsafe_dev_only() {}
+    setDebug() {}
+    addContext() {}
+    removeContext() {}
+  }
+  return { CopilotKitCoreReact: FakeCore };
+});
+
+import { CopilotKitProvider } from "../CopilotKitProvider";
+
+describe("CopilotKitProvider — deferral wiring (mocked core, #5801)", () => {
+  beforeEach(() => {
+    ctorConfigs.length = 0;
+    connectCalls.length = 0;
+  });
+
+  it("constructs the core with deferInitialConnection and connects from an effect", async () => {
+    render(
+      <CopilotKitProvider runtimeUrl="https://runtime.example/rest">
+        <div>child</div>
+      </CopilotKitProvider>,
+    );
+
+    // The core was told NOT to connect from its constructor...
+    expect(ctorConfigs.length).toBeGreaterThanOrEqual(1);
+    expect(ctorConfigs[0]?.deferInitialConnection).toBe(true);
+    // ...and the provider started the connection from a commit-phase effect.
+    await waitFor(() => expect(connectCalls.length).toBeGreaterThanOrEqual(1));
+  });
+});

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.licenseRace.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.licenseRace.test.tsx
@@ -51,6 +51,7 @@ vi.mock("../../lib/react-core", () => {
     setDefaultThrottleMs() {}
     setRuntimeUrl() {}
     setRuntimeTransport() {}
+    connect() {}
     setHeaders() {}
     setCredentials() {}
     setProperties() {}


### PR DESCRIPTION
Fixes #5801.

## Problem

`CopilotKitProvider` constructs the core **during render** (the `useRef` init pattern), and the `CopilotKitCore` constructor synchronously starts the `/info` network request. React can start-and-discard renders (concurrent rendering / Suspense / StrictMode), and for a *mounting* fiber `copilotkitRef.current` is `null` again on each discarded attempt — so a brand-new core is constructed, and fires its own `/info`, per discarded render. The reporter observed **70–80 `/info` requests on a single page load** (production build, self-hosted runtime with real latency).

Root causes (all confirmed on current `main`):
1. Core constructed during render — `CopilotKitProvider.tsx`.
2. Constructor kicks off network I/O — ctor → `setRuntimeUrl` → `updateRuntimeConnection()` → `fetch(/info)`.
3. `updateRuntimeConnection()` had no in-flight guard.

The dominant multiplier is **cross-instance** (N discarded renders → N cores → N fetches), so an in-flight guard alone can't fix it — the fetch must not fire during construction.

## Fix

Separate **construction** (pure) from **connection** (network I/O), as the issue recommends:

- **core** — new `deferInitialConnection` option: the constructor records the runtime config (so `copilotkit.runtimeUrl` stays available *synchronously* to hooks like `use-threads` / the CopilotChat context — no first-render regression) but does **not** start the `/info` fetch. A new `connect()` method starts the single connection; it's idempotent (no-op unless status is `Disconnected`, which `updateRuntimeConnection` flips to `Connecting` synchronously), so a StrictMode double-invoked mount effect collapses to one request. `updateRuntimeConnection` also gains an in-flight guard keyed by `url + requested transport` so concurrent same-target calls de-dupe (a change to a different target supersedes).
- **react-core** — the provider constructs with `deferInitialConnection: true` and calls `copilotkit.connect()` from its existing commit-phase mount effect. Renders discarded before commit never reach the effect, so they never fetch. The subscribe effect runs before `connect()`, so the status-change event is caught (no reliance on the catch-up read for the common path).

**Backward compatible:** without `deferInitialConnection`, the constructor still connects — Vue/Angular/vanilla consumers are unaffected.

## Testing

- **TDD.** New core tests fail on the pre-fix code (constructor fetches) and pass after.
- **core** (`core-defer-runtime-connection.test.ts`, 7 tests) — the authoritative proof of the mechanism: deferred construct fires **zero** `/info`; `runtimeUrl` still exposed synchronously; `connect()` → exactly one `/info`; `connect()` idempotent across repeated calls; **N orphaned cores that never `connect()` → 0 fetches, only the committed one fetches** (directly models the discarded-render bug); in-flight de-dupe; backward-compat.
- **react-core** (`CopilotKitProvider.deferWiring.test.tsx`) — asserts the provider constructs with `deferInitialConnection: true` and drives `connect()` from an effect; **this is the provider-level test that distinguishes the fix from the bug** (it fails if the deferral wiring is dropped — verified by reverting).
- **react-core** (`CopilotKitProvider.deferConnection.test.tsx`, 2 tests) — normal-mount regression guards: exactly one `/info` on mount, and one under `React.StrictMode`.

  *Scope note (found via adversarial review):* the raw dozens-of-`/info` symptom only manifests with React *discarding* in-progress renders and constructing multiple orphaned cores — Testing Library can't reproduce that (a single committed mount yields one `/info` either way, and the ctor's fetch is several microtasks deep so ordering can't distinguish it). Hence the multi-instance proof lives in the core test above, and the provider is guarded by the wiring assertion.

- Full suites green: **core 576/576**, **react-core provider 141/141** (updated one fake-core mock to implement `connect()`). `tsc` 0 errors (core + react-core); `oxlint` 0 errors; `oxfmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
