### PR TITLE
fix(react-core): scope streamdown table action controls in packaged CSS (#5775)

### DIFF
--- a/packages/react-core/src/v2/styles/__tests__/streamdown-styles.test.ts
+++ b/packages/react-core/src/v2/styles/__tests__/streamdown-styles.test.ts
@@ -29,4 +29,14 @@ describe("Streamdown styles", () => {
       '[data-copilotkit] [data-streamdown="superscript"]',
     );
   });
+
+  it("ships scoped fallback styles for the table action controls row (#5775)", () => {
+    // The controls row / buttons / popovers have no stable data-streamdown
+    // attribute, so they are scoped structurally under the table wrapper.
+    // Normalize whitespace so the assertion is independent of line-wrapping.
+    const normalized = globalsCss.replace(/\s+/g, " ");
+    expect(normalized).toContain(
+      '[data-streamdown="table-wrapper"] > div:first-child:not(:last-child)',
+    );
+  });
 });

--- a/packages/react-core/src/v2/styles/__tests__/streamdown-table-controls.test.tsx
+++ b/packages/react-core/src/v2/styles/__tests__/streamdown-table-controls.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * #5775: CopilotKit ships scoped fallback CSS for streamdown's table action
+ * controls (copy / download), which render with raw Tailwind utilities and no
+ * stable `data-streamdown` attribute. The CSS therefore targets them
+ * structurally: `[data-streamdown="table-wrapper"] > div:first-child:not(:last-child)`.
+ *
+ * A source-string test (streamdown-styles.test.ts) guards that the selectors
+ * exist. This DOM test guards the OTHER half: that streamdown actually renders
+ * the structure those selectors assume. If streamdown changes its table-controls
+ * markup (adds a data-streamdown attribute, reorders/renests the children), this
+ * fails — signalling the scoped CSS must be revisited.
+ */
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { Streamdown } from "streamdown";
+
+const TABLE_MARKDOWN = ["| A | B |", "| - | - |", "| 1 | 2 |", ""].join("\n");
+
+describe("Streamdown table controls DOM (#5775)", () => {
+  it("renders a controls row as table-wrapper's first (non-only) child, matching the scoped selector", () => {
+    const { container } = render(
+      <div data-copilotkit="">
+        <Streamdown>{TABLE_MARKDOWN}</Streamdown>
+      </div>,
+    );
+
+    // The outer wrapper is the first [data-streamdown="table-wrapper"] in
+    // document order (a streamdown quirk in 1.6.11 also stamps that value on the
+    // <table> element itself, so match the DIV specifically).
+    const wrapper = container.querySelector(
+      'div[data-streamdown="table-wrapper"]',
+    );
+    expect(wrapper).not.toBeNull();
+
+    // The table scroll container is the last child and holds the <table>.
+    expect(wrapper!.querySelector(":scope > div:last-child table")).not.toBeNull();
+
+    // The controls row is the first child AND distinct from the last child —
+    // exactly what `> div:first-child:not(:last-child)` scopes.
+    const controlsRow = wrapper!.querySelector(
+      ":scope > div:first-child:not(:last-child)",
+    );
+    expect(controlsRow).not.toBeNull();
+
+    // It has no data-streamdown attribute (the reason we target it structurally)
+    expect(controlsRow!.getAttribute("data-streamdown")).toBeNull();
+
+    // ...and it contains the copy/download trigger buttons the CSS styles, each
+    // wrapped in a positioned <div> (matching `> div > button`).
+    const triggerButtons = controlsRow!.querySelectorAll(":scope > div > button");
+    expect(triggerButtons.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/react-core/src/v2/styles/__tests__/streamdown-table-controls.test.tsx
+++ b/packages/react-core/src/v2/styles/__tests__/streamdown-table-controls.test.tsx
@@ -33,7 +33,9 @@ describe("Streamdown table controls DOM (#5775)", () => {
     expect(wrapper).not.toBeNull();
 
     // The table scroll container is the last child and holds the <table>.
-    expect(wrapper!.querySelector(":scope > div:last-child table")).not.toBeNull();
+    expect(
+      wrapper!.querySelector(":scope > div:last-child table"),
+    ).not.toBeNull();
 
     // The controls row is the first child AND distinct from the last child —
     // exactly what `> div:first-child:not(:last-child)` scopes.
@@ -47,7 +49,9 @@ describe("Streamdown table controls DOM (#5775)", () => {
 
     // ...and it contains the copy/download trigger buttons the CSS styles, each
     // wrapped in a positioned <div> (matching `> div > button`).
-    const triggerButtons = controlsRow!.querySelectorAll(":scope > div > button");
+    const triggerButtons = controlsRow!.querySelectorAll(
+      ":scope > div > button",
+    );
     expect(triggerButtons.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -241,6 +241,51 @@
     @apply cpk:overflow-x-auto;
   }
 
+  /* Table action controls (copy / download). streamdown renders the controls
+     row, per-button wrappers, trigger buttons, dropdown popovers and menu items
+     with raw Tailwind utilities and no stable `data-streamdown` attribute, so
+     scope them structurally under the table wrapper. The controls row is the
+     first child ONLY when controls are enabled; `:not(:last-child)` leaves a
+     control-less table (single child = the scroll container handled above)
+     untouched. #5775 */
+  [data-copilotkit]
+    [data-streamdown="table-wrapper"]
+    > div:first-child:not(:last-child) {
+    @apply cpk:flex cpk:items-center cpk:justify-end cpk:gap-1;
+  }
+
+  [data-copilotkit]
+    [data-streamdown="table-wrapper"]
+    > div:first-child:not(:last-child)
+    > div {
+    @apply cpk:relative;
+  }
+
+  [data-copilotkit]
+    [data-streamdown="table-wrapper"]
+    > div:first-child:not(:last-child)
+    > div
+    > button {
+    @apply cpk:cursor-pointer cpk:p-1 cpk:text-muted-foreground cpk:transition-all cpk:hover:text-foreground cpk:disabled:cursor-not-allowed cpk:disabled:opacity-50;
+  }
+
+  [data-copilotkit]
+    [data-streamdown="table-wrapper"]
+    > div:first-child:not(:last-child)
+    > div
+    > div {
+    @apply cpk:absolute cpk:top-full cpk:right-0 cpk:z-10 cpk:mt-1 cpk:min-w-[120px] cpk:overflow-hidden cpk:rounded-md cpk:border cpk:border-border cpk:bg-background cpk:shadow-lg;
+  }
+
+  [data-copilotkit]
+    [data-streamdown="table-wrapper"]
+    > div:first-child:not(:last-child)
+    > div
+    > div
+    > button {
+    @apply cpk:w-full cpk:px-3 cpk:py-2 cpk:text-left cpk:text-sm cpk:transition-colors cpk:hover:bg-muted;
+  }
+
   [data-copilotkit] [data-streamdown="table"] {
     @apply cpk:w-full cpk:border-collapse cpk:border cpk:border-border;
   }


### PR DESCRIPTION
Fixes #5775.

## Problem

After #5099 scoped the streamdown markdown/table styles under `[data-copilotkit] [data-streamdown="…"]`, the **table action controls** (copy / download) are still unstyled for hosts that import `@copilotkit/react-core/v2/styles.css` but don't also ship streamdown's raw Tailwind utilities. streamdown renders the controls row, per-button wrappers, trigger buttons, dropdown popovers and menu items with unprefixed utilities (`flex`, `items-center`, `justify-end`, `gap-1`, `cursor-pointer`, `p-1`, …) and **no stable `data-streamdown` attribute**, so CopilotKit's packaged CSS didn't cover them — the controls rendered as vertically stacked plain icons instead of a right-aligned row.

## Fix

Add scoped fallback selectors under `[data-copilotkit] [data-streamdown="table-wrapper"]`, targeting the controls chrome **structurally** (since it has no `data-streamdown` hook):

- controls row → `> div:first-child:not(:last-child)` (flex, right-aligned, gap)
- per-button wrapper → `… > div` (relative, positions the popover)
- trigger buttons → `… > div > button` (matches the code-block copy/download button styling)
- dropdown popover → `… > div > div`
- popover menu items → `… > div > div > button`

The controls row is `table-wrapper`'s first child **only when controls are enabled**; `:not(:last-child)` leaves a control-less table (whose single child is the scroll container, already styled by #5099) untouched.

## Verification

- **Compiles.** Built `globals.css` through the Tailwind v4 CLI — every `@apply` resolves (e.g. `bg-background` → `var(--background)`, `shadow-lg` → the shadow vars, `min-w-[120px]` → `min-width:120px`) and all five rules emit with correct values.
- **Selectors match the real DOM.** A new DOM test (`streamdown-table-controls.test.tsx`) renders a real `<Streamdown>` table and asserts the controls row is `table-wrapper`'s first-non-only child, carries no `data-streamdown` attribute, and contains the trigger buttons under `> div > button` — i.e. the scoped selectors target real elements. This also guards against streamdown markup drift.
- **Selector presence** guarded by `streamdown-styles.test.ts` (whitespace-robust).
- Full `styles/__tests__` suite green; `oxlint`/`oxfmt` clean.

## Note (out of scope, discovered while fixing)

At runtime in streamdown `1.6.11` the `<table>` element is stamped `data-streamdown="table-wrapper"` (not `"table"`): `MarkdownTable` passes `data-streamdown="table-wrapper"` as a prop that leaks through `...rest` onto the `<table>`, overriding the intended `"table"`. So #5099's `[data-streamdown="table"]` selector currently matches nothing, and the table also matches the `table-wrapper` rules. The controls fix here is unaffected (its child-combinator selectors don't match the table's `thead`/`tbody` children), but the `[data-streamdown="table"]` selector is worth a separate follow-up / upstream report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
