### PR TITLE
feat(integrations): migrate managed scaffolds to project credentials

### DIFF
--- a/.github/workflows/integrations_parity.yml
+++ b/.github/workflows/integrations_parity.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths:
       - "examples/integrations/**"
+      - "scripts/__tests__/integration-intelligence-migration.test.ts"
       - ".github/workflows/integrations_parity.yml"
   push:
     branches: [main]
     paths:
       - "examples/integrations/**"
+      - "scripts/__tests__/integration-intelligence-migration.test.ts"
       - ".github/workflows/integrations_parity.yml"
 
 permissions:
@@ -41,6 +43,9 @@ jobs:
 
       - name: Install root dev dependencies (tsx)
         run: pnpm install --frozen-lockfile --ignore-scripts --filter=.
+
+      - name: Verify managed integration credential contracts
+        run: pnpm exec vitest run scripts/__tests__/integration-intelligence-migration.test.ts
 
       - name: Verify integration-demo parity
         run: |

--- a/.github/workflows/integrations_parity.yml
+++ b/.github/workflows/integrations_parity.yml
@@ -44,12 +44,12 @@ jobs:
       - name: Install root dev dependencies (tsx)
         run: pnpm install --frozen-lockfile --ignore-scripts --filter=.
 
-      - name: Verify managed integration credential contracts
-        run: pnpm exec vitest run scripts/__tests__/integration-intelligence-migration.test.ts
-
       - name: Verify integration-demo parity
         run: |
           echo "Checking examples/integrations/* against north-star..."
           echo "If this fails, run: pnpm parity:sync --target=<instance>"
           echo "and resolve agent-surface drift manually (see _parity/README.md)."
           pnpm parity:check
+
+      - name: Verify managed integration credential contracts
+        run: pnpm exec vitest run scripts/__tests__/integration-intelligence-migration.test.ts

--- a/examples/integrations/a2a-middleware/.env.example
+++ b/examples/integrations/a2a-middleware/.env.example
@@ -41,11 +41,13 @@ RESEARCH_PORT=9001
 ANALYSIS_PORT=9002
 
 
-# ========================================
-# CopilotKit Intelligence Threads (Optional)
-# ========================================
+# Your CopilotKit Enterprise Intelligence API Key
+# Project Name: A2A Middleware
+CPK_INTELLIGENCE_API_KEY=
 
-# COPILOTKIT_LICENSE_TOKEN=
-# INTELLIGENCE_API_KEY=
-# INTELLIGENCE_API_URL=http://localhost:4201
-# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
+# CopilotKit Telemetry ID
+# Optional non-secret analytics identity.
+CPK_TELEMETRY_ID=
+
+INTELLIGENCE_API_URL=http://localhost:4201
+INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/a2a-middleware/README.md
+++ b/examples/integrations/a2a-middleware/README.md
@@ -256,6 +256,12 @@ The **A2A Middleware** (in `app/api/copilotkit/route.ts`) is the magic that conn
 - [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)
 - [CopilotKit Documentation](https://docs.copilotkit.ai)
 
+## Managed CopilotKit Intelligence
+
+`copilotkit init` writes `CPK_INTELLIGENCE_API_KEY` for the selected managed
+project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
+Keep both values in `.env`; the telemetry ID is not a credential.
+
 ## License
 
 MIT

--- a/examples/integrations/a2a-middleware/README.md
+++ b/examples/integrations/a2a-middleware/README.md
@@ -262,6 +262,12 @@ The **A2A Middleware** (in `app/api/copilotkit/route.ts`) is the magic that conn
 project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
 Keep both values in `.env`; the telemetry ID is not a credential.
 
+## Offline or self-hosted licensing
+
+For an offline or self-hosted deployment that requires a license token, set
+`COPILOTKIT_LICENSE_TOKEN` separately. It is not part of the managed project
+credential contract above.
+
 ## License
 
 MIT

--- a/examples/integrations/a2a-middleware/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/a2a-middleware/app/api/copilotkit/[[...slug]]/route.ts
@@ -2,7 +2,6 @@ import {
   CopilotRuntime,
   CopilotKitIntelligence,
   createCopilotEndpoint,
-  InMemoryAgentRunner,
 } from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import type {
@@ -133,20 +132,14 @@ const runtime = new CopilotRuntime({
     a2a_chat: a2aMiddlewareAgent,
   },
   // --- copilotkit:intelligence (remove this block to opt out) ---
-  ...(process.env.COPILOTKIT_LICENSE_TOKEN
-    ? {
-        intelligence: new CopilotKitIntelligence({
-          apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
-        }),
-        // Demo stub - replace with your own auth-derived user identity (e.g. OIDC)
-        // before any multi-user deployment, or all users share one thread history.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
-        licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
-      }
-    : { runner: new InMemoryAgentRunner() }),
+  intelligence: new CopilotKitIntelligence({
+    apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? "",
+    apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+    wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+  }),
+  // Demo stub - replace with your own auth-derived user identity (e.g. OIDC)
+  // before any multi-user deployment, or all users share one thread history.
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   // --- /copilotkit:intelligence ---
 });
 

--- a/examples/integrations/a2a-middleware/app/page.tsx
+++ b/examples/integrations/a2a-middleware/app/page.tsx
@@ -217,7 +217,7 @@ export default function Home() {
       */}
       <CopilotChatConfigurationProvider agentId="a2a_chat">
         <div className={`${styles.layout} threadsLayout`}>
-          {/* SDK threads drawer (replaces the hand-rolled fork). License-gated: the locked view's Upgrade CTA opens the Intelligence docs by default. */}
+          {/* SDK threads drawer for the selected managed Intelligence project. */}
           <CopilotThreadsDrawer agentId="a2a_chat" />
           <div className={styles.mainPanel}>
             <ResearchAssistant />

--- a/examples/integrations/a2a-middleware/next.config.ts
+++ b/examples/integrations/a2a-middleware/next.config.ts
@@ -4,7 +4,7 @@ const nextConfig: NextConfig = {
   output: "standalone",
   serverExternalPackages: ["@copilotkit/runtime"],
   env: {
-    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.COPILOTKIT_LICENSE_TOKEN
+    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.CPK_INTELLIGENCE_API_KEY
       ? "true"
       : "false",
   },

--- a/examples/integrations/adk/.env.example
+++ b/examples/integrations/adk/.env.example
@@ -1,8 +1,13 @@
 GOOGLE_API_KEY=your-api-key-here
 AGENT_URL=http://localhost:8000
 
-# --- CopilotKit Intelligence (optional; set COPILOTKIT_LICENSE_TOKEN to enable Threads — server + UI) ---
-# COPILOTKIT_LICENSE_TOKEN=
-# INTELLIGENCE_API_URL=http://localhost:4201
-# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
-# INTELLIGENCE_API_KEY=
+# Your CopilotKit Enterprise Intelligence API Key
+# Project Name: Google ADK
+CPK_INTELLIGENCE_API_KEY=
+
+# CopilotKit Telemetry ID
+# Optional non-secret analytics identity.
+CPK_TELEMETRY_ID=
+
+INTELLIGENCE_API_URL=http://localhost:4201
+INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/adk/README.md
+++ b/examples/integrations/adk/README.md
@@ -93,6 +93,12 @@ The main UI component is in `src/app/page.tsx`. You can:
 
 Feel free to submit issues and enhancement requests! This starter is designed to be easily extensible.
 
+## Managed CopilotKit Intelligence
+
+`copilotkit init` writes `CPK_INTELLIGENCE_API_KEY` for the selected managed
+project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
+Keep both values in `.env`; the telemetry ID is not a credential.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/adk/README.md
+++ b/examples/integrations/adk/README.md
@@ -99,6 +99,12 @@ Feel free to submit issues and enhancement requests! This starter is designed to
 project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
 Keep both values in `.env`; the telemetry ID is not a credential.
 
+## Offline or self-hosted licensing
+
+For an offline or self-hosted deployment that requires a license token, set
+`COPILOTKIT_LICENSE_TOKEN` separately. It is not part of the managed project
+credential contract above.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/adk/next.config.ts
+++ b/examples/integrations/adk/next.config.ts
@@ -3,15 +3,8 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   serverExternalPackages: ["@copilotkit/runtime"],
   env: {
-    // The public Threads UI flag is DERIVED from the server-side license token.
-    // Set COPILOTKIT_LICENSE_TOKEN (only) to enable Threads — do not set this flag
-    // directly. NOTE: NEXT_PUBLIC_* resolves at BUILD time while the runtime reads
-    // the token per-request, so the UI gate and runtime agree only when the token is
-    // present at build time (the standard `next dev` / host-build flow). For a
-    // standalone/Docker image built without the token and injected at runtime, set
-    // COPILOTKIT_LICENSE_TOKEN at build time too (or gate the UI at runtime) so the
-    // baked flag reflects it.
-    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.COPILOTKIT_LICENSE_TOKEN
+    // This browser-safe flag contains only key presence, never the key itself.
+    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.CPK_INTELLIGENCE_API_KEY
       ? "true"
       : "false",
   },

--- a/examples/integrations/adk/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/adk/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -2,7 +2,6 @@ import {
   CopilotRuntime,
   CopilotKitIntelligence,
   createCopilotEndpoint,
-  InMemoryAgentRunner,
 } from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import { handle } from "hono/vercel";
@@ -14,20 +13,14 @@ const runtime = new CopilotRuntime({
     }),
   },
   // --- copilotkit:intelligence (remove this block to opt out) ---
-  ...(process.env.COPILOTKIT_LICENSE_TOKEN
-    ? {
-        intelligence: new CopilotKitIntelligence({
-          apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
-        }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
-        licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
-      }
-    : { runner: new InMemoryAgentRunner() }),
+  intelligence: new CopilotKitIntelligence({
+    apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? "",
+    apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+    wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+  }),
+  // Demo stub — replace with your real auth-derived user identity before any
+  // multi-user deployment, or all users share one thread history.
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   // --- /copilotkit:intelligence ---
 });
 

--- a/examples/integrations/adk/src/app/page.tsx
+++ b/examples/integrations/adk/src/app/page.tsx
@@ -78,7 +78,7 @@ export default function CopilotKitPage() {
     */
     <CopilotChatConfigurationProvider agentId={AGENT_ID}>
       <div className={`${styles.layout} threadsLayout`}>
-        {/* SDK threads drawer (replaces the hand-rolled fork). License-gated: the locked view's Upgrade CTA opens the Intelligence docs by default. */}
+        {/* SDK threads drawer for the selected managed Intelligence project. */}
         <CopilotThreadsDrawer agentId={AGENT_ID} />
         <div className={styles.mainPanel}>
           <main

--- a/examples/integrations/agentcore/.env.example
+++ b/examples/integrations/agentcore/.env.example
@@ -1,0 +1,10 @@
+# Your CopilotKit Enterprise Intelligence API Key
+# Project Name: agentcore
+CPK_INTELLIGENCE_API_KEY=
+
+# CopilotKit Telemetry ID
+# Optional non-secret analytics identity.
+CPK_TELEMETRY_ID=
+
+INTELLIGENCE_API_URL=http://localhost:4201
+INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/agentcore/README.md
+++ b/examples/integrations/agentcore/README.md
@@ -33,17 +33,25 @@ Set `CPK_INTELLIGENCE_API_KEY` to the API key for your managed CopilotKit Intell
 
    Set `stack_name_base` and `admin_user_email` in `config.yaml`. The deploy script stores the managed key from `.env` in the configured AWS Secrets Manager secret; CDK resolves it only for the CopilotKit runtime Lambda.
 
+   Before deploying, provide managed or self-hosted Intelligence endpoints that are reachable from AWS. AWS deployments must not use `localhost` or `127.0.0.1`; the localhost defaults in `.env.example` are only for local Docker Compose.
+
 2. **Deploy:**
 
    ```bash
+   INTELLIGENCE_API_URL=https://intelligence.example.com \
+   INTELLIGENCE_GATEWAY_WS_URL=wss://gateway.example.com \
    ./deploy-langgraph.sh                    # LangGraph agent (infra + frontend)
    ./deploy-langgraph.sh --skip-frontend    # infra/agent only
    ./deploy-langgraph.sh --skip-backend     # frontend only
    # or
+   INTELLIGENCE_API_URL=https://intelligence.example.com \
+   INTELLIGENCE_GATEWAY_WS_URL=wss://gateway.example.com \
    ./deploy-strands.sh                      # AWS Strands agent
    ./deploy-strands.sh --skip-frontend
    ./deploy-strands.sh --skip-backend
    ```
+
+   The command-prefixed endpoint values override the local defaults sourced from `.env`. Use the same prefix with `--skip-frontend` or `--skip-backend` when needed.
 
 3. **Open** the Amplify URL printed at the end. Sign in with your email.
 

--- a/examples/integrations/agentcore/README.md
+++ b/examples/integrations/agentcore/README.md
@@ -73,7 +73,7 @@ See `docs/LOCAL_DEVELOPMENT.md` for full details.
 | `agents/langgraph-single-agent/` | LangGraph agent with tools + shared todo state             |
 | `agents/strands-single-agent/`   | Strands agent with tools + shared todo state               |
 | `infra-cdk/`                     | CDK: Cognito, AgentCore, CopilotKit Lambda bridge, Amplify |
-| `infra-terraform/`               | Terraform equivalent — see `infra-terraform/README.md`     |
+| `infra-terraform/`               | Base AgentCore infrastructure without managed Intelligence |
 | `docker/`                        | Local dev via Docker Compose                               |
 | `docs/`                          | LOCAL_DEVELOPMENT.md, LOCAL_DOCKER_TESTING.md              |
 

--- a/examples/integrations/agentcore/README.md
+++ b/examples/integrations/agentcore/README.md
@@ -11,14 +11,27 @@ Chat UI with generative charts, shared-state todo canvas, and inline tool render
 | Python  | 3.8+                         |
 | Docker  | running                      |
 
+## Managed Intelligence credentials
+
+Create the root environment file before deploying or running locally:
+
+```bash
+cp .env.example .env
+```
+
+Set `CPK_INTELLIGENCE_API_KEY` to the API key for your managed CopilotKit Intelligence project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity and can be left blank.
+
 ## Deploy to AWS
 
-1. **Create your config:**
+1. **Create your environment and config:**
 
    ```bash
+   cp .env.example .env
    cp config.yaml.example config.yaml
-   # Edit config.yaml — set stack_name_base and admin_user_email
+   # Edit .env and config.yaml.
    ```
+
+   Set `stack_name_base` and `admin_user_email` in `config.yaml`. The deploy script stores the managed key from `.env` in the configured AWS Secrets Manager secret; CDK resolves it only for the CopilotKit runtime Lambda.
 
 2. **Deploy:**
 
@@ -37,9 +50,10 @@ Chat UI with generative charts, shared-state todo canvas, and inline tool render
 ## Local Development
 
 ```bash
-cd docker
 cp .env.example .env
-# Fill in AWS creds — STACK_NAME, MEMORY_ID, and aws-exports.json are auto-resolved
+cp docker/.env.example docker/.env
+cd docker
+# Fill in docker/.env AWS creds — STACK_NAME, MEMORY_ID, and aws-exports.json are auto-resolved
 ./up.sh --build
 ```
 
@@ -76,6 +90,10 @@ Browser → API Gateway → CopilotKit Lambda (Node.js, AG-UI bridge)
 ```
 
 Auth: Cognito OIDC → Bearer token forwarded from browser through Lambda to AgentCore.
+
+## Offline or self-hosted license
+
+This example's managed path uses `CPK_INTELLIGENCE_API_KEY`. For an offline or self-hosted enterprise deployment that requires a license token, follow the self-hosted Intelligence licensing guide and keep that separate from the managed project credentials above.
 
 ## Tear down
 

--- a/examples/integrations/agentcore/config.yaml.example
+++ b/examples/integrations/agentcore/config.yaml.example
@@ -1,6 +1,7 @@
 # ── User-editable settings ──────────────────────────────────────────────────
 stack_name_base: my-copilotkit-agentcore-lg # max 35 chars; used as prefix for all AWS resources
 admin_user_email: # e.g. you@example.com — auto-creates a Cognito user
+copilotkit_intelligence_api_key_secret_name: copilotkit/intelligence/api-key
 
 backend:
   # Set automatically by deploy scripts — do not edit.

--- a/examples/integrations/agentcore/deploy-langgraph.sh
+++ b/examples/integrations/agentcore/deploy-langgraph.sh
@@ -94,21 +94,21 @@ stack = re.search(r"stack_name_base:\s*([\w-]+)", content).group(1)
 print(f"✓ config.yaml → pattern: {pattern}, stack: {stack}")
 PYEOF
 
-# ── Managed Intelligence secret ──────────────────────────────────────────────
-CPK_INTELLIGENCE_API_KEY_SECRET_NAME=$(python3 -c "import re; c=open('$CONFIG').read(); print(re.search(r'^copilotkit_intelligence_api_key_secret_name:\s*([^#\s]+)', c, re.MULTILINE).group(1))")
-if aws secretsmanager describe-secret --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" >/dev/null 2>&1; then
-  CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(aws secretsmanager put-secret-value --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" --query VersionId --output text)
-else
-  CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(aws secretsmanager create-secret --name "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" --query VersionId --output text)
-fi
-: "${CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID:?Secrets Manager did not return a managed key version ID}"
-export CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID
-echo "✓ Managed Intelligence key stored in Secrets Manager"
-
 # ── CDK deploy ───────────────────────────────────────────────────────────────
 if [ "$SKIP_BACKEND" = true ]; then
   echo "⚡ Skipping backend deploy (--skip-backend)"
 else
+  # Materialize the managed key only when backend resources are being deployed.
+  CPK_INTELLIGENCE_API_KEY_SECRET_NAME=$(python3 -c "import re; c=open('$CONFIG').read(); print(re.search(r'^copilotkit_intelligence_api_key_secret_name:\s*([^#\s]+)', c, re.MULTILINE).group(1))")
+  if aws secretsmanager describe-secret --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" >/dev/null 2>&1; then
+    CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(aws secretsmanager put-secret-value --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" --query VersionId --output text)
+  else
+    CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(aws secretsmanager create-secret --name "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" --query VersionId --output text)
+  fi
+  : "${CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID:?Secrets Manager did not return a managed key version ID}"
+  export CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID
+  echo "✓ Managed Intelligence key stored in Secrets Manager"
+
   echo "Deploying infrastructure (this takes ~10–15 min on first run)..."
   cd "$CDK_DIR"
   npm install --silent

--- a/examples/integrations/agentcore/deploy-langgraph.sh
+++ b/examples/integrations/agentcore/deploy-langgraph.sh
@@ -4,6 +4,9 @@
 # Stack: <stack_name_base>-lg  (isolated from deploy-strands.sh)
 # Using Terraform instead? See infra-terraform/README.md
 set -euo pipefail
+set +a
+set +x
+export -n CPK_INTELLIGENCE_API_KEY
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PATTERN="langgraph-single-agent"
@@ -29,9 +32,9 @@ if [ "${INTELLIGENCE_GATEWAY_WS_URL+x}" = x ]; then
   INTELLIGENCE_GATEWAY_WS_URL_OVERRIDE_SET=true
 fi
 
-set -a
 source "$SCRIPT_DIR/.env"
 set +a
+set +x
 if [ "$INTELLIGENCE_API_URL_OVERRIDE_SET" = true ]; then
   export INTELLIGENCE_API_URL="$INTELLIGENCE_API_URL_OVERRIDE"
 fi
@@ -39,7 +42,11 @@ if [ "$INTELLIGENCE_GATEWAY_WS_URL_OVERRIDE_SET" = true ]; then
   export INTELLIGENCE_GATEWAY_WS_URL="$INTELLIGENCE_GATEWAY_WS_URL_OVERRIDE"
 fi
 : "${CPK_INTELLIGENCE_API_KEY:?CPK_INTELLIGENCE_API_KEY is required in .env}"
+export -n CPK_INTELLIGENCE_API_KEY
+export INTELLIGENCE_API_URL="${INTELLIGENCE_API_URL:-}"
+export INTELLIGENCE_GATEWAY_WS_URL="${INTELLIGENCE_GATEWAY_WS_URL:-}"
 export CPK_TELEMETRY_ID="${CPK_TELEMETRY_ID:-}"
+export VITE_COPILOTKIT_THREADS_ENABLED=true
 
 for arg in "$@"; do
   [[ "$arg" == "--skip-frontend" ]] && SKIP_FRONTEND=true
@@ -96,15 +103,17 @@ PYEOF
 
 # ── CDK deploy ───────────────────────────────────────────────────────────────
 if [ "$SKIP_BACKEND" = true ]; then
+  unset CPK_INTELLIGENCE_API_KEY
   echo "⚡ Skipping backend deploy (--skip-backend)"
 else
   # Materialize the managed key only when backend resources are being deployed.
   CPK_INTELLIGENCE_API_KEY_SECRET_NAME=$(python3 -c "import re; c=open('$CONFIG').read(); print(re.search(r'^copilotkit_intelligence_api_key_secret_name:\s*([^#\s]+)', c, re.MULTILINE).group(1))")
   if aws secretsmanager describe-secret --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" >/dev/null 2>&1; then
-    CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(aws secretsmanager put-secret-value --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" --query VersionId --output text)
+    CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(printf '%s' "$CPK_INTELLIGENCE_API_KEY" | aws secretsmanager put-secret-value --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string file:///dev/stdin --query VersionId --output text)
   else
-    CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(aws secretsmanager create-secret --name "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" --query VersionId --output text)
+    CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(printf '%s' "$CPK_INTELLIGENCE_API_KEY" | aws secretsmanager create-secret --name "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string file:///dev/stdin --query VersionId --output text)
   fi
+  unset CPK_INTELLIGENCE_API_KEY
   : "${CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID:?Secrets Manager did not return a managed key version ID}"
   export CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID
   echo "✓ Managed Intelligence key stored in Secrets Manager"

--- a/examples/integrations/agentcore/deploy-langgraph.sh
+++ b/examples/integrations/agentcore/deploy-langgraph.sh
@@ -13,6 +13,17 @@ CDK_DIR="$SCRIPT_DIR/infra-cdk"
 SKIP_FRONTEND=false
 SKIP_BACKEND=false
 
+if [ ! -f "$SCRIPT_DIR/.env" ]; then
+  echo "ERROR: $SCRIPT_DIR/.env is required. Copy .env.example and add your managed project credentials."
+  exit 1
+fi
+
+set -a
+source "$SCRIPT_DIR/.env"
+set +a
+: "${CPK_INTELLIGENCE_API_KEY:?CPK_INTELLIGENCE_API_KEY is required in .env}"
+export CPK_TELEMETRY_ID="${CPK_TELEMETRY_ID:-}"
+
 for arg in "$@"; do
   [[ "$arg" == "--skip-frontend" ]] && SKIP_FRONTEND=true
   [[ "$arg" == "--skip-backend" ]] && SKIP_BACKEND=true
@@ -54,6 +65,15 @@ with open(config_path, "w") as f:
 stack = re.search(r"stack_name_base:\s*([\w-]+)", content).group(1)
 print(f"✓ config.yaml → pattern: {pattern}, stack: {stack}")
 PYEOF
+
+# ── Managed Intelligence secret ──────────────────────────────────────────────
+CPK_INTELLIGENCE_API_KEY_SECRET_NAME=$(python3 -c "import re; c=open('$CONFIG').read(); print(re.search(r'^copilotkit_intelligence_api_key_secret_name:\s*([^#\s]+)', c, re.MULTILINE).group(1))")
+if aws secretsmanager describe-secret --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" >/dev/null 2>&1; then
+  aws secretsmanager put-secret-value --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" >/dev/null
+else
+  aws secretsmanager create-secret --name "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" >/dev/null
+fi
+echo "✓ Managed Intelligence key stored in Secrets Manager"
 
 # ── CDK deploy ───────────────────────────────────────────────────────────────
 if [ "$SKIP_BACKEND" = true ]; then

--- a/examples/integrations/agentcore/deploy-langgraph.sh
+++ b/examples/integrations/agentcore/deploy-langgraph.sh
@@ -97,10 +97,12 @@ PYEOF
 # ── Managed Intelligence secret ──────────────────────────────────────────────
 CPK_INTELLIGENCE_API_KEY_SECRET_NAME=$(python3 -c "import re; c=open('$CONFIG').read(); print(re.search(r'^copilotkit_intelligence_api_key_secret_name:\s*([^#\s]+)', c, re.MULTILINE).group(1))")
 if aws secretsmanager describe-secret --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" >/dev/null 2>&1; then
-  aws secretsmanager put-secret-value --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" >/dev/null
+  CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(aws secretsmanager put-secret-value --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" --query VersionId --output text)
 else
-  aws secretsmanager create-secret --name "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" >/dev/null
+  CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(aws secretsmanager create-secret --name "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" --query VersionId --output text)
 fi
+: "${CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID:?Secrets Manager did not return a managed key version ID}"
+export CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID
 echo "✓ Managed Intelligence key stored in Secrets Manager"
 
 # ── CDK deploy ───────────────────────────────────────────────────────────────

--- a/examples/integrations/agentcore/deploy-langgraph.sh
+++ b/examples/integrations/agentcore/deploy-langgraph.sh
@@ -18,9 +18,26 @@ if [ ! -f "$SCRIPT_DIR/.env" ]; then
   exit 1
 fi
 
+INTELLIGENCE_API_URL_OVERRIDE_SET=false
+if [ "${INTELLIGENCE_API_URL+x}" = x ]; then
+  INTELLIGENCE_API_URL_OVERRIDE="$INTELLIGENCE_API_URL"
+  INTELLIGENCE_API_URL_OVERRIDE_SET=true
+fi
+INTELLIGENCE_GATEWAY_WS_URL_OVERRIDE_SET=false
+if [ "${INTELLIGENCE_GATEWAY_WS_URL+x}" = x ]; then
+  INTELLIGENCE_GATEWAY_WS_URL_OVERRIDE="$INTELLIGENCE_GATEWAY_WS_URL"
+  INTELLIGENCE_GATEWAY_WS_URL_OVERRIDE_SET=true
+fi
+
 set -a
 source "$SCRIPT_DIR/.env"
 set +a
+if [ "$INTELLIGENCE_API_URL_OVERRIDE_SET" = true ]; then
+  export INTELLIGENCE_API_URL="$INTELLIGENCE_API_URL_OVERRIDE"
+fi
+if [ "$INTELLIGENCE_GATEWAY_WS_URL_OVERRIDE_SET" = true ]; then
+  export INTELLIGENCE_GATEWAY_WS_URL="$INTELLIGENCE_GATEWAY_WS_URL_OVERRIDE"
+fi
 : "${CPK_INTELLIGENCE_API_KEY:?CPK_INTELLIGENCE_API_KEY is required in .env}"
 export CPK_TELEMETRY_ID="${CPK_TELEMETRY_ID:-}"
 
@@ -35,6 +52,17 @@ echo "── CopilotKit + AWS AgentCore (LangGraph) ─────────�
 check_command() {
   command -v "$1" >/dev/null 2>&1 || { echo "ERROR: $1 is required but not installed."; exit 1; }
 }
+require_remote_endpoint() {
+  local name="$1"
+  local value="$2"
+  local example="$3"
+  if [[ -z "$value" || "$value" =~ ^[a-zA-Z][a-zA-Z0-9+.-]*://(localhost|127\.0\.0\.1)([:/]|$) ]]; then
+    echo "ERROR: $name must be a non-local endpoint reachable from AWS (for example, $example). Set it in .env or prefix the deploy command."
+    exit 1
+  fi
+}
+require_remote_endpoint INTELLIGENCE_API_URL "${INTELLIGENCE_API_URL:-}" "https://intelligence.example.com"
+require_remote_endpoint INTELLIGENCE_GATEWAY_WS_URL "${INTELLIGENCE_GATEWAY_WS_URL:-}" "wss://gateway.example.com"
 check_command aws
 check_command node
 check_command python3

--- a/examples/integrations/agentcore/deploy-strands.sh
+++ b/examples/integrations/agentcore/deploy-strands.sh
@@ -18,9 +18,26 @@ if [ ! -f "$SCRIPT_DIR/.env" ]; then
   exit 1
 fi
 
+INTELLIGENCE_API_URL_OVERRIDE_SET=false
+if [ "${INTELLIGENCE_API_URL+x}" = x ]; then
+  INTELLIGENCE_API_URL_OVERRIDE="$INTELLIGENCE_API_URL"
+  INTELLIGENCE_API_URL_OVERRIDE_SET=true
+fi
+INTELLIGENCE_GATEWAY_WS_URL_OVERRIDE_SET=false
+if [ "${INTELLIGENCE_GATEWAY_WS_URL+x}" = x ]; then
+  INTELLIGENCE_GATEWAY_WS_URL_OVERRIDE="$INTELLIGENCE_GATEWAY_WS_URL"
+  INTELLIGENCE_GATEWAY_WS_URL_OVERRIDE_SET=true
+fi
+
 set -a
 source "$SCRIPT_DIR/.env"
 set +a
+if [ "$INTELLIGENCE_API_URL_OVERRIDE_SET" = true ]; then
+  export INTELLIGENCE_API_URL="$INTELLIGENCE_API_URL_OVERRIDE"
+fi
+if [ "$INTELLIGENCE_GATEWAY_WS_URL_OVERRIDE_SET" = true ]; then
+  export INTELLIGENCE_GATEWAY_WS_URL="$INTELLIGENCE_GATEWAY_WS_URL_OVERRIDE"
+fi
 : "${CPK_INTELLIGENCE_API_KEY:?CPK_INTELLIGENCE_API_KEY is required in .env}"
 export CPK_TELEMETRY_ID="${CPK_TELEMETRY_ID:-}"
 
@@ -35,6 +52,17 @@ echo "── CopilotKit + AWS AgentCore (Strands) ──────────
 check_command() {
   command -v "$1" >/dev/null 2>&1 || { echo "ERROR: $1 is required but not installed."; exit 1; }
 }
+require_remote_endpoint() {
+  local name="$1"
+  local value="$2"
+  local example="$3"
+  if [[ -z "$value" || "$value" =~ ^[a-zA-Z][a-zA-Z0-9+.-]*://(localhost|127\.0\.0\.1)([:/]|$) ]]; then
+    echo "ERROR: $name must be a non-local endpoint reachable from AWS (for example, $example). Set it in .env or prefix the deploy command."
+    exit 1
+  fi
+}
+require_remote_endpoint INTELLIGENCE_API_URL "${INTELLIGENCE_API_URL:-}" "https://intelligence.example.com"
+require_remote_endpoint INTELLIGENCE_GATEWAY_WS_URL "${INTELLIGENCE_GATEWAY_WS_URL:-}" "wss://gateway.example.com"
 check_command aws
 check_command node
 check_command python3

--- a/examples/integrations/agentcore/deploy-strands.sh
+++ b/examples/integrations/agentcore/deploy-strands.sh
@@ -4,6 +4,9 @@
 # Stack: <stack_name_base>-st  (isolated from deploy-langgraph.sh)
 # Using Terraform instead? See infra-terraform/README.md
 set -euo pipefail
+set +a
+set +x
+export -n CPK_INTELLIGENCE_API_KEY
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PATTERN="strands-single-agent"
@@ -29,9 +32,9 @@ if [ "${INTELLIGENCE_GATEWAY_WS_URL+x}" = x ]; then
   INTELLIGENCE_GATEWAY_WS_URL_OVERRIDE_SET=true
 fi
 
-set -a
 source "$SCRIPT_DIR/.env"
 set +a
+set +x
 if [ "$INTELLIGENCE_API_URL_OVERRIDE_SET" = true ]; then
   export INTELLIGENCE_API_URL="$INTELLIGENCE_API_URL_OVERRIDE"
 fi
@@ -39,7 +42,11 @@ if [ "$INTELLIGENCE_GATEWAY_WS_URL_OVERRIDE_SET" = true ]; then
   export INTELLIGENCE_GATEWAY_WS_URL="$INTELLIGENCE_GATEWAY_WS_URL_OVERRIDE"
 fi
 : "${CPK_INTELLIGENCE_API_KEY:?CPK_INTELLIGENCE_API_KEY is required in .env}"
+export -n CPK_INTELLIGENCE_API_KEY
+export INTELLIGENCE_API_URL="${INTELLIGENCE_API_URL:-}"
+export INTELLIGENCE_GATEWAY_WS_URL="${INTELLIGENCE_GATEWAY_WS_URL:-}"
 export CPK_TELEMETRY_ID="${CPK_TELEMETRY_ID:-}"
+export VITE_COPILOTKIT_THREADS_ENABLED=true
 
 for arg in "$@"; do
   [[ "$arg" == "--skip-frontend" ]] && SKIP_FRONTEND=true
@@ -95,15 +102,17 @@ PYEOF
 
 # ── CDK deploy ───────────────────────────────────────────────────────────────
 if [ "$SKIP_BACKEND" = true ]; then
+  unset CPK_INTELLIGENCE_API_KEY
   echo "⚡ Skipping backend deploy (--skip-backend)"
 else
   # Materialize the managed key only when backend resources are being deployed.
   CPK_INTELLIGENCE_API_KEY_SECRET_NAME=$(python3 -c "import re; c=open('$CONFIG').read(); print(re.search(r'^copilotkit_intelligence_api_key_secret_name:\s*([^#\s]+)', c, re.MULTILINE).group(1))")
   if aws secretsmanager describe-secret --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" >/dev/null 2>&1; then
-    CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(aws secretsmanager put-secret-value --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" --query VersionId --output text)
+    CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(printf '%s' "$CPK_INTELLIGENCE_API_KEY" | aws secretsmanager put-secret-value --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string file:///dev/stdin --query VersionId --output text)
   else
-    CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(aws secretsmanager create-secret --name "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" --query VersionId --output text)
+    CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(printf '%s' "$CPK_INTELLIGENCE_API_KEY" | aws secretsmanager create-secret --name "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string file:///dev/stdin --query VersionId --output text)
   fi
+  unset CPK_INTELLIGENCE_API_KEY
   : "${CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID:?Secrets Manager did not return a managed key version ID}"
   export CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID
   echo "✓ Managed Intelligence key stored in Secrets Manager"

--- a/examples/integrations/agentcore/deploy-strands.sh
+++ b/examples/integrations/agentcore/deploy-strands.sh
@@ -93,21 +93,21 @@ stack = re.search(r"stack_name_base:\s*([\w-]+)", content).group(1)
 print(f"✓ config.yaml → pattern: {pattern}, stack: {stack}")
 PYEOF
 
-# ── Managed Intelligence secret ──────────────────────────────────────────────
-CPK_INTELLIGENCE_API_KEY_SECRET_NAME=$(python3 -c "import re; c=open('$CONFIG').read(); print(re.search(r'^copilotkit_intelligence_api_key_secret_name:\s*([^#\s]+)', c, re.MULTILINE).group(1))")
-if aws secretsmanager describe-secret --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" >/dev/null 2>&1; then
-  CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(aws secretsmanager put-secret-value --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" --query VersionId --output text)
-else
-  CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(aws secretsmanager create-secret --name "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" --query VersionId --output text)
-fi
-: "${CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID:?Secrets Manager did not return a managed key version ID}"
-export CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID
-echo "✓ Managed Intelligence key stored in Secrets Manager"
-
 # ── CDK deploy ───────────────────────────────────────────────────────────────
 if [ "$SKIP_BACKEND" = true ]; then
   echo "⚡ Skipping backend deploy (--skip-backend)"
 else
+  # Materialize the managed key only when backend resources are being deployed.
+  CPK_INTELLIGENCE_API_KEY_SECRET_NAME=$(python3 -c "import re; c=open('$CONFIG').read(); print(re.search(r'^copilotkit_intelligence_api_key_secret_name:\s*([^#\s]+)', c, re.MULTILINE).group(1))")
+  if aws secretsmanager describe-secret --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" >/dev/null 2>&1; then
+    CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(aws secretsmanager put-secret-value --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" --query VersionId --output text)
+  else
+    CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(aws secretsmanager create-secret --name "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" --query VersionId --output text)
+  fi
+  : "${CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID:?Secrets Manager did not return a managed key version ID}"
+  export CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID
+  echo "✓ Managed Intelligence key stored in Secrets Manager"
+
   echo "Deploying infrastructure (this takes ~10–15 min on first run)..."
   cd "$CDK_DIR"
   npm install --silent

--- a/examples/integrations/agentcore/deploy-strands.sh
+++ b/examples/integrations/agentcore/deploy-strands.sh
@@ -13,6 +13,17 @@ CDK_DIR="$SCRIPT_DIR/infra-cdk"
 SKIP_FRONTEND=false
 SKIP_BACKEND=false
 
+if [ ! -f "$SCRIPT_DIR/.env" ]; then
+  echo "ERROR: $SCRIPT_DIR/.env is required. Copy .env.example and add your managed project credentials."
+  exit 1
+fi
+
+set -a
+source "$SCRIPT_DIR/.env"
+set +a
+: "${CPK_INTELLIGENCE_API_KEY:?CPK_INTELLIGENCE_API_KEY is required in .env}"
+export CPK_TELEMETRY_ID="${CPK_TELEMETRY_ID:-}"
+
 for arg in "$@"; do
   [[ "$arg" == "--skip-frontend" ]] && SKIP_FRONTEND=true
   [[ "$arg" == "--skip-backend" ]] && SKIP_BACKEND=true
@@ -53,6 +64,15 @@ with open(config_path, "w") as f:
 stack = re.search(r"stack_name_base:\s*([\w-]+)", content).group(1)
 print(f"✓ config.yaml → pattern: {pattern}, stack: {stack}")
 PYEOF
+
+# ── Managed Intelligence secret ──────────────────────────────────────────────
+CPK_INTELLIGENCE_API_KEY_SECRET_NAME=$(python3 -c "import re; c=open('$CONFIG').read(); print(re.search(r'^copilotkit_intelligence_api_key_secret_name:\s*([^#\s]+)', c, re.MULTILINE).group(1))")
+if aws secretsmanager describe-secret --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" >/dev/null 2>&1; then
+  aws secretsmanager put-secret-value --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" >/dev/null
+else
+  aws secretsmanager create-secret --name "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" >/dev/null
+fi
+echo "✓ Managed Intelligence key stored in Secrets Manager"
 
 # ── CDK deploy ───────────────────────────────────────────────────────────────
 if [ "$SKIP_BACKEND" = true ]; then

--- a/examples/integrations/agentcore/deploy-strands.sh
+++ b/examples/integrations/agentcore/deploy-strands.sh
@@ -96,10 +96,12 @@ PYEOF
 # ── Managed Intelligence secret ──────────────────────────────────────────────
 CPK_INTELLIGENCE_API_KEY_SECRET_NAME=$(python3 -c "import re; c=open('$CONFIG').read(); print(re.search(r'^copilotkit_intelligence_api_key_secret_name:\s*([^#\s]+)', c, re.MULTILINE).group(1))")
 if aws secretsmanager describe-secret --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" >/dev/null 2>&1; then
-  aws secretsmanager put-secret-value --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" >/dev/null
+  CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(aws secretsmanager put-secret-value --secret-id "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" --query VersionId --output text)
 else
-  aws secretsmanager create-secret --name "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" >/dev/null
+  CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID=$(aws secretsmanager create-secret --name "$CPK_INTELLIGENCE_API_KEY_SECRET_NAME" --secret-string "$CPK_INTELLIGENCE_API_KEY" --query VersionId --output text)
 fi
+: "${CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID:?Secrets Manager did not return a managed key version ID}"
+export CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID
 echo "✓ Managed Intelligence key stored in Secrets Manager"
 
 # ── CDK deploy ───────────────────────────────────────────────────────────────

--- a/examples/integrations/agentcore/docker/.env.example
+++ b/examples/integrations/agentcore/docker/.env.example
@@ -15,10 +15,3 @@ AWS_DEFAULT_REGION=us-east-1
 # ── Agent selection ────────────────────────────────────────────────────────────
 # Which agent to run locally: langgraph or strands (default: strands)
 AGENT=strands
-
-# ── CopilotKit Intelligence / Threads (optional) ──────────────────────────────
-# Enables persistent Threads in the CopilotKit bridge + frontend.
-COPILOTKIT_LICENSE_TOKEN=
-INTELLIGENCE_API_KEY=
-INTELLIGENCE_API_URL=http://localhost:4201
-INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/agentcore/docker/docker-compose.yml
+++ b/examples/integrations/agentcore/docker/docker-compose.yml
@@ -68,8 +68,6 @@ services:
       - AGENTCORE_AG_UI_URL=http://agent:8080/invocations
       - PORT=3001
       - OTEL_SDK_DISABLED=true
-      - INTELLIGENCE_API_URL=${INTELLIGENCE_API_URL:-http://localhost:4201}
-      - INTELLIGENCE_GATEWAY_WS_URL=${INTELLIGENCE_GATEWAY_WS_URL:-ws://localhost:4401}
     depends_on:
       agent:
         condition: service_healthy

--- a/examples/integrations/agentcore/docker/docker-compose.yml
+++ b/examples/integrations/agentcore/docker/docker-compose.yml
@@ -63,12 +63,11 @@ services:
       dockerfile: ../../../docker/Dockerfile.bridge.dev
     ports:
       - "3001:3001"
+    env_file: ../.env
     environment:
       - AGENTCORE_AG_UI_URL=http://agent:8080/invocations
       - PORT=3001
       - OTEL_SDK_DISABLED=true
-      - COPILOTKIT_LICENSE_TOKEN=${COPILOTKIT_LICENSE_TOKEN}
-      - INTELLIGENCE_API_KEY=${INTELLIGENCE_API_KEY}
       - INTELLIGENCE_API_URL=${INTELLIGENCE_API_URL:-http://localhost:4201}
       - INTELLIGENCE_GATEWAY_WS_URL=${INTELLIGENCE_GATEWAY_WS_URL:-ws://localhost:4401}
     depends_on:
@@ -86,9 +85,9 @@ services:
     volumes:
       - ../frontend:/app
       - /app/node_modules
+    env_file: ../.env
     environment:
       - NODE_ENV=development
-      - VITE_COPILOTKIT_THREADS_ENABLED=${COPILOTKIT_LICENSE_TOKEN:+true}
     depends_on:
       bridge:
         condition: service_started

--- a/examples/integrations/agentcore/frontend/src/components/chat/CopilotKit/index.tsx
+++ b/examples/integrations/agentcore/frontend/src/components/chat/CopilotKit/index.tsx
@@ -61,7 +61,7 @@ function CopilotChatContent() {
     */
     <CopilotChatConfigurationProvider agentId={COPILOTKIT_AGENT_ID}>
       <div className={styles.layout}>
-        {/* SDK threads drawer (replaces the hand-rolled fork). License-gated: the locked view's Upgrade CTA opens the Intelligence docs by default. */}
+        {/* SDK threads drawer backed by the configured managed Intelligence project. */}
         <CopilotThreadsDrawer agentId={COPILOTKIT_AGENT_ID} />
         <div className={styles.mainPanel}>
           <div className="h-full flex flex-row">

--- a/examples/integrations/agentcore/frontend/vite.config.ts
+++ b/examples/integrations/agentcore/frontend/vite.config.ts
@@ -11,8 +11,7 @@ export default defineConfig({
 
   define: {
     "import.meta.env.VITE_COPILOTKIT_THREADS_ENABLED": JSON.stringify(
-      process.env.VITE_COPILOTKIT_THREADS_ENABLED ??
-        (process.env.COPILOTKIT_LICENSE_TOKEN ? "true" : "false"),
+      process.env.CPK_INTELLIGENCE_API_KEY ? "true" : "false",
     ),
   },
 

--- a/examples/integrations/agentcore/frontend/vite.config.ts
+++ b/examples/integrations/agentcore/frontend/vite.config.ts
@@ -11,7 +11,13 @@ export default defineConfig({
 
   define: {
     "import.meta.env.VITE_COPILOTKIT_THREADS_ENABLED": JSON.stringify(
-      process.env.CPK_INTELLIGENCE_API_KEY ? "true" : "false",
+      process.env.VITE_COPILOTKIT_THREADS_ENABLED === "true"
+        ? "true"
+        : process.env.VITE_COPILOTKIT_THREADS_ENABLED === "false"
+          ? "false"
+          : process.env.CPK_INTELLIGENCE_API_KEY
+            ? "true"
+            : "false",
     ),
   },
 

--- a/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts
+++ b/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts
@@ -38,21 +38,7 @@ export function buildAgents(): Record<string, HttpAgent> {
   return { [agentName]: agent };
 }
 
-/**
- * AgentCore stores conversation history in its own memory layer (AgentCoreMemorySaver /
- * AgentCoreMemorySessionManager). When CopilotKit reconnects to an existing thread
- * (e.g. page refresh), it calls `connect()` which replays that stored history as a
- * MESSAGES_SNAPSHOT event. Two issues arise from this that this runner fixes:
- *
- * 1. Unknown threads — CopilotKit may call `connect()` for a thread it has never
- *    `run()` against (e.g. on first load). The base runner would error; instead we
- *    return an empty snapshot so the UI initialises cleanly.
- *
- * 2. Missing tool-call results — AgentCore's snapshot includes assistant messages
- *    with tool calls, but the corresponding TOOL_CALL_RESULT events are absent.
- *    CopilotKit needs those results to reconcile its internal message state. We
- *    synthesise empty results for every past tool call before emitting the snapshot.
- */
+/** Preserves AgentCore snapshot replay behavior for local and managed threads. */
 export class AgentCoreRunner extends InMemoryAgentRunner {
   private readonly knownThreadIds = new Set<string>();
 
@@ -67,7 +53,6 @@ export class AgentCoreRunner extends InMemoryAgentRunner {
     request: Parameters<InMemoryAgentRunner["connect"]>[0],
   ): ReturnType<InMemoryAgentRunner["connect"]> {
     if (!request.threadId || !this.knownThreadIds.has(request.threadId)) {
-      // Unknown thread — return an empty snapshot instead of erroring.
       const runId =
         typeof (request as { runId?: unknown }).runId === "string"
           ? ((request as { runId?: string }).runId ?? randomUUID())
@@ -88,8 +73,6 @@ export class AgentCoreRunner extends InMemoryAgentRunner {
       ) as unknown as ReturnType<InMemoryAgentRunner["connect"]>;
     }
 
-    // Known thread — replay synthetic tool-call results before the snapshot so
-    // CopilotKit can reconcile its message state correctly.
     return (super.connect(request) as any).pipe(
       concatMap((event: any) => {
         if (
@@ -128,22 +111,15 @@ export function buildApp() {
 
   const runtime = new CopilotRuntime({
     agents: { ...agents, default: defaultAgent },
-    // --- copilotkit:intelligence (remove this block to opt out) ---
-    ...(process.env.COPILOTKIT_LICENSE_TOKEN
-      ? {
-          intelligence: new CopilotKitIntelligence({
-            apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-            apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-            wsUrl:
-              process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
-          }),
-          // Demo stub — replace with your real auth-derived user identity before any
-          // multi-user deployment, or all users share one thread history.
-          identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
-          licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
-        }
-      : { runner: new AgentCoreRunner() }),
-    // --- /copilotkit:intelligence ---
+    runner: new AgentCoreRunner(),
+    intelligence: new CopilotKitIntelligence({
+      apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? "",
+      apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+      wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+    }),
+    // Demo stub — replace with your real auth-derived user identity before any
+    // multi-user deployment, or all users share one thread history.
+    identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   });
 
   return createCopilotEndpoint({ runtime, basePath: "/copilotkit" });

--- a/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts
+++ b/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts
@@ -109,18 +109,23 @@ export function buildApp() {
   if (!defaultAgent)
     throw new Error("At least one CopilotKit agent URL must be configured");
 
-  const runtime = new CopilotRuntime({
-    agents: { ...agents, default: defaultAgent },
-    runner: new AgentCoreRunner(),
-    intelligence: new CopilotKitIntelligence({
-      apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? "",
-      apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-      wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
-    }),
-    // Demo stub — replace with your real auth-derived user identity before any
-    // multi-user deployment, or all users share one thread history.
-    identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
-  });
+  const runtime = process.env.CPK_INTELLIGENCE_API_KEY
+    ? new CopilotRuntime({
+        agents: { ...agents, default: defaultAgent },
+        intelligence: new CopilotKitIntelligence({
+          apiKey: process.env.CPK_INTELLIGENCE_API_KEY,
+          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+          wsUrl:
+            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+        }),
+        // Demo stub — replace with your real auth-derived user identity before any
+        // multi-user deployment, or all users share one thread history.
+        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+      })
+    : new CopilotRuntime({
+        agents: { ...agents, default: defaultAgent },
+        runner: new AgentCoreRunner(),
+      });
 
   return createCopilotEndpoint({ runtime, basePath: "/copilotkit" });
 }

--- a/examples/integrations/agentcore/infra-cdk/lib/amplify-hosting-stack.ts
+++ b/examples/integrations/agentcore/infra-cdk/lib/amplify-hosting-stack.ts
@@ -2,8 +2,8 @@ import * as cdk from "aws-cdk-lib";
 import * as amplify from "@aws-cdk/aws-amplify-alpha";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as iam from "aws-cdk-lib/aws-iam";
-import { Construct } from "constructs";
-import { AppConfig } from "./utils/config-manager";
+import type { Construct } from "constructs";
+import type { AppConfig } from "./utils/config-manager";
 
 export interface AmplifyStackProps extends cdk.NestedStackProps {
   config: AppConfig;
@@ -87,6 +87,12 @@ export class AmplifyHostingStack extends cdk.NestedStack {
       appName: `${props.config.stack_name_base}-frontend`,
       description: `${props.config.stack_name_base} - React Frontend`,
       platform: amplify.Platform.WEB,
+      environmentVariables: {
+        VITE_COPILOTKIT_THREADS_ENABLED: props.config
+          .copilotkit_intelligence_api_key_secret_name
+          ? "true"
+          : "false",
+      },
     });
 
     // Create main branch for the Amplify app

--- a/examples/integrations/agentcore/infra-cdk/lib/backend-stack.ts
+++ b/examples/integrations/agentcore/infra-cdk/lib/backend-stack.ts
@@ -428,6 +428,9 @@ export class BackendStack extends cdk.NestedStack {
             config.backend?.pattern || "langgraph-single-agent",
           CPK_INTELLIGENCE_API_KEY: cdk.SecretValue.secretsManager(
             config.copilotkit_intelligence_api_key_secret_name,
+            {
+              versionId: process.env.CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID,
+            },
           ).unsafeUnwrap(),
           CPK_TELEMETRY_ID: process.env.CPK_TELEMETRY_ID ?? "",
           INTELLIGENCE_API_URL:

--- a/examples/integrations/agentcore/infra-cdk/lib/backend-stack.ts
+++ b/examples/integrations/agentcore/infra-cdk/lib/backend-stack.ts
@@ -11,8 +11,8 @@ import * as bedrockagentcore from "aws-cdk-lib/aws-bedrockagentcore";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as ecr_assets from "aws-cdk-lib/aws-ecr-assets";
 import * as cr from "aws-cdk-lib/custom-resources";
-import { Construct } from "constructs";
-import { AppConfig } from "./utils/config-manager";
+import type { Construct } from "constructs";
+import type { AppConfig } from "./utils/config-manager";
 import { AgentCoreRole } from "./utils/agentcore-role";
 import * as path from "path";
 import * as fs from "fs";
@@ -426,6 +426,10 @@ export class BackendStack extends cdk.NestedStack {
           AGENTCORE_AG_UI_URL: agentCoreAgUiUrl,
           COPILOTKIT_AGENT_NAME:
             config.backend?.pattern || "langgraph-single-agent",
+          CPK_INTELLIGENCE_API_KEY: cdk.SecretValue.secretsManager(
+            config.copilotkit_intelligence_api_key_secret_name,
+          ).unsafeUnwrap(),
+          CPK_TELEMETRY_ID: process.env.CPK_TELEMETRY_ID ?? "",
         },
         timeout: cdk.Duration.seconds(30),
         memorySize: 1024,

--- a/examples/integrations/agentcore/infra-cdk/lib/backend-stack.ts
+++ b/examples/integrations/agentcore/infra-cdk/lib/backend-stack.ts
@@ -430,6 +430,10 @@ export class BackendStack extends cdk.NestedStack {
             config.copilotkit_intelligence_api_key_secret_name,
           ).unsafeUnwrap(),
           CPK_TELEMETRY_ID: process.env.CPK_TELEMETRY_ID ?? "",
+          INTELLIGENCE_API_URL:
+            process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+          INTELLIGENCE_GATEWAY_WS_URL:
+            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
         },
         timeout: cdk.Duration.seconds(30),
         memorySize: 1024,

--- a/examples/integrations/agentcore/infra-cdk/lib/utils/config-manager.ts
+++ b/examples/integrations/agentcore/infra-cdk/lib/utils/config-manager.ts
@@ -29,6 +29,8 @@ export interface VpcConfig {
 export interface AppConfig {
   stack_name_base: string;
   admin_user_email?: string | null;
+  /** Secrets Manager name containing the managed CopilotKit Intelligence key. */
+  copilotkit_intelligence_api_key_secret_name: string;
   backend: {
     pattern: string;
     deployment_type: DeploymentType;
@@ -108,6 +110,8 @@ export class ConfigManager {
       return {
         stack_name_base: stackNameBase,
         admin_user_email: parsedConfig.admin_user_email || null,
+        copilotkit_intelligence_api_key_secret_name:
+          parsedConfig.copilotkit_intelligence_api_key_secret_name,
         backend: {
           pattern: parsedConfig.backend?.pattern || "langgraph-single-agent",
           deployment_type: deploymentType,

--- a/examples/integrations/agentcore/infra-terraform/README.md
+++ b/examples/integrations/agentcore/infra-terraform/README.md
@@ -1,6 +1,9 @@
 # Terraform Infrastructure
 
-Equivalent of `../infra-cdk/` using Terraform.
+Terraform support covers the base AgentCore agent, gateway, authentication, and
+frontend infrastructure. It does not project managed Intelligence credentials
+into the CopilotKit Runtime Lambda. Use the CDK deployment path documented in
+`../README.md` when the managed Threads and Intelligence path is required.
 
 ## Usage
 

--- a/examples/integrations/agno/.env.example
+++ b/examples/integrations/agno/.env.example
@@ -1,8 +1,13 @@
 OPENAI_API_KEY=your-api-key-here
 AGENT_URL=http://localhost:8000
 
-# --- CopilotKit Intelligence (optional; set COPILOTKIT_LICENSE_TOKEN to enable Threads — server + UI) ---
-# COPILOTKIT_LICENSE_TOKEN=
-# INTELLIGENCE_API_URL=http://localhost:4201
-# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
-# INTELLIGENCE_API_KEY=
+# Your CopilotKit Enterprise Intelligence API Key
+# Project Name: Agno
+CPK_INTELLIGENCE_API_KEY=
+
+# CopilotKit Telemetry ID
+# Optional non-secret analytics identity.
+CPK_TELEMETRY_ID=
+
+INTELLIGENCE_API_URL=http://localhost:4201
+INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/agno/README.md
+++ b/examples/integrations/agno/README.md
@@ -100,6 +100,12 @@ Feel free to submit issues and enhancement requests! This starter is designed to
 project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
 Keep both values in `.env`; the telemetry ID is not a credential.
 
+## Offline or self-hosted licensing
+
+For an offline or self-hosted deployment that requires a license token, set
+`COPILOTKIT_LICENSE_TOKEN` separately. It is not part of the managed project
+credential contract above.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/agno/README.md
+++ b/examples/integrations/agno/README.md
@@ -94,6 +94,12 @@ Otherwise, check out the documentation relevant to your task:
 
 Feel free to submit issues and enhancement requests! This starter is designed to be easily extensible.
 
+## Managed CopilotKit Intelligence
+
+`copilotkit init` writes `CPK_INTELLIGENCE_API_KEY` for the selected managed
+project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
+Keep both values in `.env`; the telemetry ID is not a credential.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/agno/next.config.ts
+++ b/examples/integrations/agno/next.config.ts
@@ -4,15 +4,8 @@ const nextConfig: NextConfig = {
   typescript: { ignoreBuildErrors: true },
   serverExternalPackages: ["pino", "thread-stream"],
   env: {
-    // The public Threads UI flag is DERIVED from the server-side license token.
-    // Set COPILOTKIT_LICENSE_TOKEN (only) to enable Threads — do not set this flag
-    // directly. NOTE: NEXT_PUBLIC_* resolves at BUILD time while the runtime reads
-    // the token per-request, so the UI gate and runtime agree only when the token is
-    // present at build time (the standard `next dev` / host-build flow). For a
-    // standalone/Docker image built without the token and injected at runtime, set
-    // COPILOTKIT_LICENSE_TOKEN at build time too (or gate the UI at runtime) so the
-    // baked flag reflects it.
-    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.COPILOTKIT_LICENSE_TOKEN
+    // This browser-safe flag contains only key presence, never the key itself.
+    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.CPK_INTELLIGENCE_API_KEY
       ? "true"
       : "false",
   },

--- a/examples/integrations/agno/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/agno/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -2,7 +2,6 @@ import {
   CopilotRuntime,
   CopilotKitIntelligence,
   createCopilotEndpoint,
-  InMemoryAgentRunner,
 } from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import { handle } from "hono/vercel";
@@ -16,20 +15,14 @@ const runtime = new CopilotRuntime({
     }),
   },
   // --- copilotkit:intelligence (remove this block to opt out) ---
-  ...(process.env.COPILOTKIT_LICENSE_TOKEN
-    ? {
-        intelligence: new CopilotKitIntelligence({
-          apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
-        }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
-        licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
-      }
-    : { runner: new InMemoryAgentRunner() }),
+  intelligence: new CopilotKitIntelligence({
+    apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? "",
+    apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+    wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+  }),
+  // Demo stub — replace with your real auth-derived user identity before any
+  // multi-user deployment, or all users share one thread history.
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   // --- /copilotkit:intelligence ---
 });
 

--- a/examples/integrations/agno/src/app/page.tsx
+++ b/examples/integrations/agno/src/app/page.tsx
@@ -76,7 +76,7 @@ export default function CopilotKitPage() {
     */
     <CopilotChatConfigurationProvider agentId={AGENT_ID}>
       <div className={`${styles.layout} threadsLayout`}>
-        {/* SDK threads drawer (replaces the hand-rolled fork). License-gated: the locked view's Upgrade CTA opens the Intelligence docs by default. */}
+        {/* SDK threads drawer for the selected managed Intelligence project. */}
         <CopilotThreadsDrawer agentId={AGENT_ID} />
         <div className={styles.mainPanel}>
           <main

--- a/examples/integrations/claude-sdk-python/.env.example
+++ b/examples/integrations/claude-sdk-python/.env.example
@@ -9,10 +9,13 @@ CLAUDE_MODEL=claude-sonnet-5
 # URL the Next.js runtime uses to reach the agent (optional; this is the default).
 AGENT_URL=http://localhost:8000
 
-# --- CopilotKit Intelligence (optional) ---
-# Set COPILOTKIT_LICENSE_TOKEN to activate the Threads drawer's live thread
-# history (server + UI). Without it the drawer shows a locked state.
-# COPILOTKIT_LICENSE_TOKEN=
-# INTELLIGENCE_API_URL=http://localhost:4201
-# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
-# INTELLIGENCE_API_KEY=
+# Your CopilotKit Enterprise Intelligence API Key
+# Project Name: Claude Agent SDK Python
+CPK_INTELLIGENCE_API_KEY=
+
+# CopilotKit Telemetry ID
+# Optional non-secret analytics identity.
+CPK_TELEMETRY_ID=
+
+INTELLIGENCE_API_URL=http://localhost:4201
+INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/claude-sdk-python/README.md
+++ b/examples/integrations/claude-sdk-python/README.md
@@ -70,6 +70,12 @@ agent updates through the adapter's built-in `ag_ui_update_state` tool.
 project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
 Keep both values in `.env`; the telemetry ID is not a credential.
 
+## Offline or self-hosted licensing
+
+For an offline or self-hosted deployment that requires a license token, set
+`COPILOTKIT_LICENSE_TOKEN` separately. It is not part of the managed project
+credential contract above.
+
 ## Available scripts
 
 - `npm run dev` — start the UI and agent together (dev mode)

--- a/examples/integrations/claude-sdk-python/README.md
+++ b/examples/integrations/claude-sdk-python/README.md
@@ -10,7 +10,7 @@ agent that speaks the [AG-UI protocol](https://docs.ag-ui.com), and shows Copilo
 - **flight cards** and **dynamic dashboards** via A2UI generative UI,
 - a **human-in-the-loop** meeting picker,
 - a light/dark **theme toggle**, and
-- the SDK **threads drawer** (activated with a CopilotKit Intelligence license).
+- the SDK **threads drawer** backed by the selected managed Intelligence project.
 
 The agent is powered by Claude (`claude-sonnet-5` by default) and exposes three backend tools —
 `query_data`, `search_flights`, and `generate_a2ui` — while the todo board is shared state the
@@ -61,9 +61,14 @@ agent updates through the adapter's built-in `ag_ui_update_state` tool.
 5. **Open [http://localhost:3000](http://localhost:3000)** and try the suggested prompts
    (add todos, draw a chart, search flights, build a dashboard, schedule a meeting).
 
-6. **(Optional) Enable the Threads drawer.** Thread history is gated behind a CopilotKit
-   Intelligence license. Set `COPILOTKIT_LICENSE_TOKEN` (and the `INTELLIGENCE_*` URLs) in
-   `.env` to activate live thread history; without it the drawer shows a locked state.
+6. Open the Threads drawer to inspect history from the selected managed
+   Intelligence project.
+
+## Managed CopilotKit Intelligence
+
+`copilotkit init` writes `CPK_INTELLIGENCE_API_KEY` for the selected managed
+project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
+Keep both values in `.env`; the telemetry ID is not a credential.
 
 ## Available scripts
 

--- a/examples/integrations/claude-sdk-python/next.config.ts
+++ b/examples/integrations/claude-sdk-python/next.config.ts
@@ -4,15 +4,8 @@ const nextConfig: NextConfig = {
   output: "standalone",
   serverExternalPackages: ["@copilotkit/runtime"],
   env: {
-    // The public Threads UI flag is DERIVED from the server-side license token.
-    // Set COPILOTKIT_LICENSE_TOKEN (only) to enable Threads — do not set this flag
-    // directly. NOTE: NEXT_PUBLIC_* resolves at BUILD time while the runtime reads
-    // the token per-request, so the UI gate and runtime agree only when the token is
-    // present at build time (the standard `next dev` / host-build flow). For a
-    // standalone/Docker image built without the token and injected at runtime, set
-    // COPILOTKIT_LICENSE_TOKEN at build time too (or gate the UI at runtime) so the
-    // baked flag reflects it.
-    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.COPILOTKIT_LICENSE_TOKEN
+    // This browser-safe flag contains only key presence, never the key itself.
+    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.CPK_INTELLIGENCE_API_KEY
       ? "true"
       : "false",
   },

--- a/examples/integrations/claude-sdk-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/claude-sdk-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -2,7 +2,6 @@ import {
   CopilotRuntime,
   CopilotKitIntelligence,
   createCopilotEndpoint,
-  InMemoryAgentRunner,
 } from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import { handle } from "hono/vercel";
@@ -21,20 +20,14 @@ const defaultAgent = new HttpAgent({
 const runtime = new CopilotRuntime({
   agents: { default: defaultAgent },
   // --- copilotkit:intelligence (remove this block to opt out) ---
-  ...(process.env.COPILOTKIT_LICENSE_TOKEN
-    ? {
-        intelligence: new CopilotKitIntelligence({
-          apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
-        }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
-        licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
-      }
-    : { runner: new InMemoryAgentRunner() }),
+  intelligence: new CopilotKitIntelligence({
+    apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? "",
+    apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+    wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+  }),
+  // Demo stub — replace with your real auth-derived user identity before any
+  // multi-user deployment, or all users share one thread history.
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   // --- /copilotkit:intelligence ---
   openGenerativeUI: true,
   a2ui: {

--- a/examples/integrations/claude-sdk-python/src/app/page.tsx
+++ b/examples/integrations/claude-sdk-python/src/app/page.tsx
@@ -30,7 +30,7 @@ export default function HomePage() {
     */
     <CopilotChatConfigurationProvider agentId="default">
       <div className={styles.layout}>
-        {/* SDK threads drawer (replaces the hand-rolled fork). License-gated: the locked view's Upgrade CTA opens the Intelligence docs by default. */}
+        {/* SDK threads drawer for the selected managed Intelligence project. */}
         <CopilotThreadsDrawer agentId="default" />
         <div className={styles.mainPanel}>
           <ExampleLayout

--- a/examples/integrations/claude-sdk-typescript/.env.example
+++ b/examples/integrations/claude-sdk-typescript/.env.example
@@ -9,10 +9,13 @@ CLAUDE_MODEL=claude-sonnet-5
 # URL the Next.js runtime uses to reach the agent (optional; this is the default).
 AGENT_URL=http://localhost:8000
 
-# --- CopilotKit Intelligence (optional) ---
-# Set COPILOTKIT_LICENSE_TOKEN to activate the Threads drawer's live thread
-# history (server + UI). Without it the drawer shows a locked state.
-# COPILOTKIT_LICENSE_TOKEN=
-# INTELLIGENCE_API_URL=http://localhost:4201
-# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
-# INTELLIGENCE_API_KEY=
+# Your CopilotKit Enterprise Intelligence API Key
+# Project Name: Claude Agent SDK TypeScript
+CPK_INTELLIGENCE_API_KEY=
+
+# CopilotKit Telemetry ID
+# Optional non-secret analytics identity.
+CPK_TELEMETRY_ID=
+
+INTELLIGENCE_API_URL=http://localhost:4201
+INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/claude-sdk-typescript/README.md
+++ b/examples/integrations/claude-sdk-typescript/README.md
@@ -68,6 +68,12 @@ agent updates through the adapter's built-in `ag_ui_update_state` tool.
 project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
 Keep both values in `.env`; the telemetry ID is not a credential.
 
+## Offline or self-hosted licensing
+
+For an offline or self-hosted deployment that requires a license token, set
+`COPILOTKIT_LICENSE_TOKEN` separately. It is not part of the managed project
+credential contract above.
+
 ## Available scripts
 
 - `npm run dev` — start the UI and agent together (dev mode)

--- a/examples/integrations/claude-sdk-typescript/README.md
+++ b/examples/integrations/claude-sdk-typescript/README.md
@@ -10,7 +10,7 @@ agent that speaks the [AG-UI protocol](https://docs.ag-ui.com), and shows Copilo
 - **flight cards** and **dynamic dashboards** via A2UI generative UI,
 - a **human-in-the-loop** meeting picker,
 - a light/dark **theme toggle**, and
-- the SDK **threads drawer** (activated with a CopilotKit Intelligence license).
+- the SDK **threads drawer** backed by the selected managed Intelligence project.
 
 The agent is powered by Claude (`claude-sonnet-5` by default) and exposes three backend tools —
 `query_data`, `search_flights`, and `generate_a2ui` — while the todo board is shared state the
@@ -59,9 +59,14 @@ agent updates through the adapter's built-in `ag_ui_update_state` tool.
 5. **Open [http://localhost:3000](http://localhost:3000)** and try the suggested prompts
    (add todos, draw a chart, search flights, build a dashboard, schedule a meeting).
 
-6. **(Optional) Enable the Threads drawer.** Thread history is gated behind a CopilotKit
-   Intelligence license. Set `COPILOTKIT_LICENSE_TOKEN` (and the `INTELLIGENCE_*` URLs) in
-   `.env` to activate live thread history; without it the drawer shows a locked state.
+6. Open the Threads drawer to inspect history from the selected managed
+   Intelligence project.
+
+## Managed CopilotKit Intelligence
+
+`copilotkit init` writes `CPK_INTELLIGENCE_API_KEY` for the selected managed
+project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
+Keep both values in `.env`; the telemetry ID is not a credential.
 
 ## Available scripts
 

--- a/examples/integrations/claude-sdk-typescript/next.config.ts
+++ b/examples/integrations/claude-sdk-typescript/next.config.ts
@@ -4,15 +4,8 @@ const nextConfig: NextConfig = {
   output: "standalone",
   serverExternalPackages: ["@copilotkit/runtime"],
   env: {
-    // The public Threads UI flag is DERIVED from the server-side license token.
-    // Set COPILOTKIT_LICENSE_TOKEN (only) to enable Threads — do not set this flag
-    // directly. NOTE: NEXT_PUBLIC_* resolves at BUILD time while the runtime reads
-    // the token per-request, so the UI gate and runtime agree only when the token is
-    // present at build time (the standard `next dev` / host-build flow). For a
-    // standalone/Docker image built without the token and injected at runtime, set
-    // COPILOTKIT_LICENSE_TOKEN at build time too (or gate the UI at runtime) so the
-    // baked flag reflects it.
-    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.COPILOTKIT_LICENSE_TOKEN
+    // This browser-safe flag contains only key presence, never the key itself.
+    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.CPK_INTELLIGENCE_API_KEY
       ? "true"
       : "false",
   },

--- a/examples/integrations/claude-sdk-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/claude-sdk-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -2,7 +2,6 @@ import {
   CopilotRuntime,
   CopilotKitIntelligence,
   createCopilotEndpoint,
-  InMemoryAgentRunner,
 } from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import { handle } from "hono/vercel";
@@ -21,20 +20,14 @@ const defaultAgent = new HttpAgent({
 const runtime = new CopilotRuntime({
   agents: { default: defaultAgent },
   // --- copilotkit:intelligence (remove this block to opt out) ---
-  ...(process.env.COPILOTKIT_LICENSE_TOKEN
-    ? {
-        intelligence: new CopilotKitIntelligence({
-          apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
-        }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
-        licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
-      }
-    : { runner: new InMemoryAgentRunner() }),
+  intelligence: new CopilotKitIntelligence({
+    apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? "",
+    apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+    wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+  }),
+  // Demo stub — replace with your real auth-derived user identity before any
+  // multi-user deployment, or all users share one thread history.
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   // --- /copilotkit:intelligence ---
   openGenerativeUI: true,
   a2ui: {

--- a/examples/integrations/claude-sdk-typescript/src/app/page.tsx
+++ b/examples/integrations/claude-sdk-typescript/src/app/page.tsx
@@ -30,7 +30,7 @@ export default function HomePage() {
     */
     <CopilotChatConfigurationProvider agentId="default">
       <div className={styles.layout}>
-        {/* SDK threads drawer (replaces the hand-rolled fork). License-gated: the locked view's Upgrade CTA opens the Intelligence docs by default. */}
+        {/* SDK threads drawer for the selected managed Intelligence project. */}
         <CopilotThreadsDrawer agentId="default" />
         <div className={styles.mainPanel}>
           <ExampleLayout

--- a/examples/integrations/crewai-flows/.env.example
+++ b/examples/integrations/crewai-flows/.env.example
@@ -1,7 +1,12 @@
 OPENAI_API_KEY=
 
-# --- copilotkit:intelligence (optional local threads stack) ---
-# COPILOTKIT_LICENSE_TOKEN=
-# INTELLIGENCE_API_KEY=
-# INTELLIGENCE_API_URL=http://localhost:4201
-# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
+# Your CopilotKit Enterprise Intelligence API Key
+# Project Name: CrewAI Flows
+CPK_INTELLIGENCE_API_KEY=
+
+# CopilotKit Telemetry ID
+# Optional non-secret analytics identity.
+CPK_TELEMETRY_ID=
+
+INTELLIGENCE_API_URL=http://localhost:4201
+INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/crewai-flows/README.md
+++ b/examples/integrations/crewai-flows/README.md
@@ -94,6 +94,12 @@ Feel free to submit issues and enhancement requests! This starter is designed to
 project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
 Keep both values in `.env`; the telemetry ID is not a credential.
 
+## Offline or self-hosted licensing
+
+For an offline or self-hosted deployment that requires a license token, set
+`COPILOTKIT_LICENSE_TOKEN` separately. It is not part of the managed project
+credential contract above.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/crewai-flows/README.md
+++ b/examples/integrations/crewai-flows/README.md
@@ -88,6 +88,12 @@ The main UI component is in `src/app/page.tsx`. You can:
 
 Feel free to submit issues and enhancement requests! This starter is designed to be easily extensible.
 
+## Managed CopilotKit Intelligence
+
+`copilotkit init` writes `CPK_INTELLIGENCE_API_KEY` for the selected managed
+project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
+Keep both values in `.env`; the telemetry ID is not a credential.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/crewai-flows/next.config.ts
+++ b/examples/integrations/crewai-flows/next.config.ts
@@ -4,15 +4,8 @@ const nextConfig: NextConfig = {
   output: "standalone",
   serverExternalPackages: ["@copilotkit/runtime"],
   env: {
-    // The public Threads UI flag is DERIVED from the server-side license token.
-    // Set COPILOTKIT_LICENSE_TOKEN (only) to enable Threads — do not set this flag
-    // directly. NOTE: NEXT_PUBLIC_* resolves at BUILD time while the runtime reads
-    // the token per-request, so the UI gate and runtime agree only when the token is
-    // present at build time (the standard `next dev` / host-build flow). For a
-    // standalone/Docker image built without the token and injected at runtime, set
-    // COPILOTKIT_LICENSE_TOKEN at build time too (or gate the UI at runtime) so the
-    // baked flag reflects it.
-    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.COPILOTKIT_LICENSE_TOKEN
+    // This browser-safe flag contains only key presence, never the key itself.
+    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.CPK_INTELLIGENCE_API_KEY
       ? "true"
       : "false",
   },

--- a/examples/integrations/crewai-flows/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/crewai-flows/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -2,7 +2,6 @@ import {
   CopilotRuntime,
   CopilotKitIntelligence,
   createCopilotEndpoint,
-  InMemoryAgentRunner,
 } from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import { handle } from "hono/vercel";
@@ -19,20 +18,14 @@ const runtime = new CopilotRuntime({
     }),
   },
   // --- copilotkit:intelligence (remove this block to opt out) ---
-  ...(process.env.COPILOTKIT_LICENSE_TOKEN
-    ? {
-        intelligence: new CopilotKitIntelligence({
-          apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
-        }),
-        // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
-        // before any multi-user deployment, or all users share one thread history.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
-        licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
-      }
-    : { runner: new InMemoryAgentRunner() }),
+  intelligence: new CopilotKitIntelligence({
+    apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? "",
+    apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+    wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+  }),
+  // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
+  // before any multi-user deployment, or all users share one thread history.
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   // --- /copilotkit:intelligence ---
 });
 

--- a/examples/integrations/crewai-flows/src/app/page.tsx
+++ b/examples/integrations/crewai-flows/src/app/page.tsx
@@ -48,7 +48,7 @@ export default function CopilotKitPage() {
     */
     <CopilotChatConfigurationProvider agentId={AGENT_ID}>
       <div className={`${styles.layout} threadsLayout`}>
-        {/* SDK threads drawer (replaces the hand-rolled fork). License-gated: the locked view's Upgrade CTA opens the Intelligence docs by default. */}
+        {/* SDK threads drawer for the selected managed Intelligence project. */}
         <CopilotThreadsDrawer agentId={AGENT_ID} />
         <div className={styles.mainPanel}>
           <main

--- a/examples/integrations/langgraph-fastapi/.env.example
+++ b/examples/integrations/langgraph-fastapi/.env.example
@@ -1,8 +1,13 @@
 AGENT_URL=http://localhost:8000
 OPENAI_API_KEY=
 
-# --- CopilotKit Intelligence (optional; set COPILOTKIT_LICENSE_TOKEN to enable Threads — server + UI) ---
-# COPILOTKIT_LICENSE_TOKEN=
-# INTELLIGENCE_API_URL=http://localhost:4201
-# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
-# INTELLIGENCE_API_KEY=
+# Your CopilotKit Enterprise Intelligence API Key
+# Project Name: LangGraph FastAPI
+CPK_INTELLIGENCE_API_KEY=
+
+# CopilotKit Telemetry ID
+# Optional non-secret analytics identity.
+CPK_TELEMETRY_ID=
+
+INTELLIGENCE_API_URL=http://localhost:4201
+INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/langgraph-fastapi/README.md
+++ b/examples/integrations/langgraph-fastapi/README.md
@@ -103,6 +103,18 @@ The main UI component is in `src/app/page.tsx`. You can:
 
 Feel free to submit issues and enhancement requests! This starter is designed to be easily extensible.
 
+## Managed CopilotKit Intelligence
+
+`copilotkit init` writes `CPK_INTELLIGENCE_API_KEY` for the selected managed
+project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
+Keep both values in `.env`; the telemetry ID is not a credential.
+
+## Offline or self-hosted licensing
+
+For an offline or self-hosted enterprise deployment that requires a license
+token, follow the self-hosted Intelligence licensing guide. Keep that token
+separate from the managed project credentials above.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/langgraph-fastapi/next.config.ts
+++ b/examples/integrations/langgraph-fastapi/next.config.ts
@@ -4,15 +4,8 @@ const nextConfig: NextConfig = {
   output: "standalone",
   serverExternalPackages: ["@copilotkit/runtime"],
   env: {
-    // The public Threads UI flag is DERIVED from the server-side license token.
-    // Set COPILOTKIT_LICENSE_TOKEN (only) to enable Threads — do not set this flag
-    // directly. NOTE: NEXT_PUBLIC_* resolves at BUILD time while the runtime reads
-    // the token per-request, so the UI gate and runtime agree only when the token is
-    // present at build time (the standard `next dev` / host-build flow). For a
-    // standalone/Docker image built without the token and injected at runtime, set
-    // COPILOTKIT_LICENSE_TOKEN at build time too (or gate the UI at runtime) so the
-    // baked flag reflects it.
-    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.COPILOTKIT_LICENSE_TOKEN
+    // This browser-safe flag contains only key presence, never the key itself.
+    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.CPK_INTELLIGENCE_API_KEY
       ? "true"
       : "false",
   },

--- a/examples/integrations/langgraph-fastapi/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/langgraph-fastapi/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -2,7 +2,6 @@ import {
   CopilotRuntime,
   CopilotKitIntelligence,
   createCopilotEndpoint,
-  InMemoryAgentRunner,
 } from "@copilotkit/runtime/v2";
 import { handle } from "hono/vercel";
 import { LangGraphHttpAgent } from "@copilotkit/runtime/langgraph";
@@ -20,20 +19,14 @@ const defaultAgent = new LangGraphHttpAgent({
 const runtime = new CopilotRuntime({
   agents: { default: defaultAgent },
   // --- copilotkit:intelligence (remove this block to opt out) ---
-  ...(process.env.COPILOTKIT_LICENSE_TOKEN
-    ? {
-        intelligence: new CopilotKitIntelligence({
-          apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
-        }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
-        licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
-      }
-    : { runner: new InMemoryAgentRunner() }),
+  intelligence: new CopilotKitIntelligence({
+    apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? "",
+    apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+    wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+  }),
+  // Demo stub — replace with your real auth-derived user identity before any
+  // multi-user deployment, or all users share one thread history.
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   // --- /copilotkit:intelligence ---
   openGenerativeUI: true,
   a2ui: {

--- a/examples/integrations/langgraph-fastapi/src/app/page.tsx
+++ b/examples/integrations/langgraph-fastapi/src/app/page.tsx
@@ -30,7 +30,7 @@ export default function HomePage() {
     */
     <CopilotChatConfigurationProvider agentId="default">
       <div className={styles.layout}>
-        {/* SDK threads drawer (replaces the hand-rolled fork). License-gated: the locked view's Upgrade CTA opens the Intelligence docs by default. */}
+        {/* SDK threads drawer for the selected managed Intelligence project. */}
         <CopilotThreadsDrawer agentId="default" />
         <div className={styles.mainPanel}>
           <ExampleLayout

--- a/examples/integrations/langgraph-js/.env.example
+++ b/examples/integrations/langgraph-js/.env.example
@@ -1,8 +1,13 @@
 AGENT_URL=http://localhost:8123
 OPENAI_API_KEY=
 
-# --- CopilotKit Intelligence (optional; set COPILOTKIT_LICENSE_TOKEN to enable Threads — server + UI) ---
-# COPILOTKIT_LICENSE_TOKEN=
-# INTELLIGENCE_API_URL=http://localhost:4201
-# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
-# INTELLIGENCE_API_KEY=
+# Your CopilotKit Enterprise Intelligence API Key
+# Project Name: LangGraph JavaScript
+CPK_INTELLIGENCE_API_KEY=
+
+# CopilotKit Telemetry ID
+# Optional non-secret analytics identity.
+CPK_TELEMETRY_ID=
+
+INTELLIGENCE_API_URL=http://localhost:4201
+INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/langgraph-js/README.md
+++ b/examples/integrations/langgraph-js/README.md
@@ -184,6 +184,12 @@ Both patterns use the same catalog on the frontend — the difference is where t
 
 Feel free to submit issues and enhancement requests! This starter is designed to be easily extensible.
 
+## Managed CopilotKit Intelligence
+
+`copilotkit init` writes `CPK_INTELLIGENCE_API_KEY` for the selected managed
+project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
+Keep both values in `.env`; the telemetry ID is not a credential.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/langgraph-js/README.md
+++ b/examples/integrations/langgraph-js/README.md
@@ -190,6 +190,12 @@ Feel free to submit issues and enhancement requests! This starter is designed to
 project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
 Keep both values in `.env`; the telemetry ID is not a credential.
 
+## Offline or self-hosted licensing
+
+For an offline or self-hosted deployment that requires a license token, set
+`COPILOTKIT_LICENSE_TOKEN` separately. It is not part of the managed project
+credential contract above.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/langgraph-js/next.config.ts
+++ b/examples/integrations/langgraph-js/next.config.ts
@@ -4,15 +4,8 @@ const nextConfig: NextConfig = {
   output: "standalone",
   serverExternalPackages: ["@copilotkit/runtime"],
   env: {
-    // The public Threads UI flag is DERIVED from the server-side license token.
-    // Set COPILOTKIT_LICENSE_TOKEN (only) to enable Threads — do not set this flag
-    // directly. NOTE: NEXT_PUBLIC_* resolves at BUILD time while the runtime reads
-    // the token per-request, so the UI gate and runtime agree only when the token is
-    // present at build time (the standard `next dev` / host-build flow). For a
-    // standalone/Docker image built without the token and injected at runtime, set
-    // COPILOTKIT_LICENSE_TOKEN at build time too (or gate the UI at runtime) so the
-    // baked flag reflects it.
-    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.COPILOTKIT_LICENSE_TOKEN
+    // This browser-safe flag contains only key presence, never the key itself.
+    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.CPK_INTELLIGENCE_API_KEY
       ? "true"
       : "false",
   },

--- a/examples/integrations/langgraph-js/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/langgraph-js/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -2,7 +2,6 @@ import {
   CopilotRuntime,
   CopilotKitIntelligence,
   createCopilotEndpoint,
-  InMemoryAgentRunner,
 } from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 import { handle } from "hono/vercel";
@@ -19,20 +18,14 @@ const defaultAgent = new LangGraphAgent({
 const runtime = new CopilotRuntime({
   agents: { default: defaultAgent },
   // --- copilotkit:intelligence (remove this block to opt out) ---
-  ...(process.env.COPILOTKIT_LICENSE_TOKEN
-    ? {
-        intelligence: new CopilotKitIntelligence({
-          apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
-        }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
-        licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
-      }
-    : { runner: new InMemoryAgentRunner() }),
+  intelligence: new CopilotKitIntelligence({
+    apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? "",
+    apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+    wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+  }),
+  // Demo stub — replace with your real auth-derived user identity before any
+  // multi-user deployment, or all users share one thread history.
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   // --- /copilotkit:intelligence ---
   openGenerativeUI: true,
   a2ui: {

--- a/examples/integrations/langgraph-js/src/app/page.tsx
+++ b/examples/integrations/langgraph-js/src/app/page.tsx
@@ -34,7 +34,7 @@ export default function HomePage() {
       <div className={styles.layout}>
         {/*
           SDK threads drawer (replaces the former hand-rolled fork). SSR-safe and
-          license-gated (shows its own locked view when threads aren't licensed), so it
+          managed-project-backed, so it
           needs no example-level gate.
         */}
         <CopilotThreadsDrawer agentId="default" />

--- a/examples/integrations/langgraph-python/.env.example
+++ b/examples/integrations/langgraph-python/.env.example
@@ -1,8 +1,13 @@
 AGENT_URL=http://localhost:8123
 OPENAI_API_KEY=
 
-# --- CopilotKit Intelligence (optional; set COPILOTKIT_LICENSE_TOKEN to enable Threads — server + UI) ---
-# COPILOTKIT_LICENSE_TOKEN=
-# INTELLIGENCE_API_URL=http://localhost:4201
-# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
-# INTELLIGENCE_API_KEY=
+# Your CopilotKit Enterprise Intelligence API Key
+# Project Name: LangGraph Python
+CPK_INTELLIGENCE_API_KEY=
+
+# CopilotKit Telemetry ID
+# Optional non-secret analytics identity.
+CPK_TELEMETRY_ID=
+
+INTELLIGENCE_API_URL=http://localhost:4201
+INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/langgraph-python/README.md
+++ b/examples/integrations/langgraph-python/README.md
@@ -183,6 +183,12 @@ Both patterns use the same catalog on the frontend — the difference is where t
 
 Feel free to submit issues and enhancement requests! This starter is designed to be easily extensible.
 
+## Managed CopilotKit Intelligence
+
+`copilotkit init` writes `CPK_INTELLIGENCE_API_KEY` for the selected managed
+project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
+Keep both values in `.env`; the telemetry ID is not a credential.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/langgraph-python/README.md
+++ b/examples/integrations/langgraph-python/README.md
@@ -189,6 +189,12 @@ Feel free to submit issues and enhancement requests! This starter is designed to
 project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
 Keep both values in `.env`; the telemetry ID is not a credential.
 
+## Offline or self-hosted licensing
+
+For an offline or self-hosted deployment that requires a license token, set
+`COPILOTKIT_LICENSE_TOKEN` separately. It is not part of the managed project
+credential contract above.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/langgraph-python/next.config.ts
+++ b/examples/integrations/langgraph-python/next.config.ts
@@ -4,15 +4,8 @@ const nextConfig: NextConfig = {
   output: "standalone",
   serverExternalPackages: ["@copilotkit/runtime"],
   env: {
-    // The public Threads UI flag is DERIVED from the server-side license token.
-    // Set COPILOTKIT_LICENSE_TOKEN (only) to enable Threads — do not set this flag
-    // directly. NOTE: NEXT_PUBLIC_* resolves at BUILD time while the runtime reads
-    // the token per-request, so the UI gate and runtime agree only when the token is
-    // present at build time (the standard `next dev` / host-build flow). For a
-    // standalone/Docker image built without the token and injected at runtime, set
-    // COPILOTKIT_LICENSE_TOKEN at build time too (or gate the UI at runtime) so the
-    // baked flag reflects it.
-    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.COPILOTKIT_LICENSE_TOKEN
+    // This browser-safe flag contains only key presence, never the key itself.
+    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.CPK_INTELLIGENCE_API_KEY
       ? "true"
       : "false",
   },

--- a/examples/integrations/langgraph-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/langgraph-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -2,7 +2,6 @@ import {
   CopilotRuntime,
   CopilotKitIntelligence,
   createCopilotEndpoint,
-  InMemoryAgentRunner,
 } from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 import { handle } from "hono/vercel";
@@ -19,20 +18,14 @@ const defaultAgent = new LangGraphAgent({
 const runtime = new CopilotRuntime({
   agents: { default: defaultAgent },
   // --- copilotkit:intelligence (remove this block to opt out) ---
-  ...(process.env.COPILOTKIT_LICENSE_TOKEN
-    ? {
-        intelligence: new CopilotKitIntelligence({
-          apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
-        }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
-        licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
-      }
-    : { runner: new InMemoryAgentRunner() }),
+  intelligence: new CopilotKitIntelligence({
+    apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? "",
+    apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+    wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+  }),
+  // Demo stub — replace with your real auth-derived user identity before any
+  // multi-user deployment, or all users share one thread history.
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   // --- /copilotkit:intelligence ---
   openGenerativeUI: true,
   a2ui: {

--- a/examples/integrations/langgraph-python/src/app/page.tsx
+++ b/examples/integrations/langgraph-python/src/app/page.tsx
@@ -30,7 +30,7 @@ export default function HomePage() {
     */
     <CopilotChatConfigurationProvider agentId="default">
       <div className={styles.layout}>
-        {/* SDK threads drawer (replaces the hand-rolled fork). License-gated: the locked view's Upgrade CTA opens the Intelligence docs by default. */}
+        {/* SDK threads drawer for the selected managed Intelligence project. */}
         <CopilotThreadsDrawer agentId="default" />
         <div className={styles.mainPanel}>
           <ExampleLayout

--- a/examples/integrations/llamaindex/.env.example
+++ b/examples/integrations/llamaindex/.env.example
@@ -1,8 +1,13 @@
 OPENAI_API_KEY=your-api-key-here
 AGENT_URL=http://127.0.0.1:9000
 
-# Optional: enable CopilotKit Intelligence Threads locally
-COPILOTKIT_LICENSE_TOKEN=
-INTELLIGENCE_API_KEY=
+# Your CopilotKit Enterprise Intelligence API Key
+# Project Name: LlamaIndex
+CPK_INTELLIGENCE_API_KEY=
+
+# CopilotKit Telemetry ID
+# Optional non-secret analytics identity.
+CPK_TELEMETRY_ID=
+
 INTELLIGENCE_API_URL=http://localhost:4201
 INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/llamaindex/README.md
+++ b/examples/integrations/llamaindex/README.md
@@ -90,6 +90,12 @@ The main UI component is in `src/app/page.tsx`. You can:
 
 Feel free to submit issues and enhancement requests! This starter is designed to be easily extensible.
 
+## Managed CopilotKit Intelligence
+
+`copilotkit init` writes `CPK_INTELLIGENCE_API_KEY` for the selected managed
+project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
+Keep both values in `.env`; the telemetry ID is not a credential.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/llamaindex/README.md
+++ b/examples/integrations/llamaindex/README.md
@@ -96,6 +96,12 @@ Feel free to submit issues and enhancement requests! This starter is designed to
 project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
 Keep both values in `.env`; the telemetry ID is not a credential.
 
+## Offline or self-hosted licensing
+
+For an offline or self-hosted deployment that requires a license token, set
+`COPILOTKIT_LICENSE_TOKEN` separately. It is not part of the managed project
+credential contract above.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/llamaindex/next.config.ts
+++ b/examples/integrations/llamaindex/next.config.ts
@@ -4,7 +4,7 @@ const nextConfig: NextConfig = {
   output: "standalone",
   serverExternalPackages: ["@copilotkit/runtime"],
   env: {
-    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.COPILOTKIT_LICENSE_TOKEN
+    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.CPK_INTELLIGENCE_API_KEY
       ? "true"
       : "false",
   },

--- a/examples/integrations/llamaindex/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/llamaindex/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -2,7 +2,6 @@ import {
   CopilotRuntime,
   CopilotKitIntelligence,
   createCopilotEndpoint,
-  InMemoryAgentRunner,
 } from "@copilotkit/runtime/v2";
 import { LlamaIndexAgent } from "@ag-ui/llamaindex";
 import { handle } from "hono/vercel";
@@ -16,20 +15,14 @@ const runtime = new CopilotRuntime({
     }),
   },
   // --- copilotkit:intelligence (remove this block to opt out) ---
-  ...(process.env.COPILOTKIT_LICENSE_TOKEN
-    ? {
-        intelligence: new CopilotKitIntelligence({
-          apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
-        }),
-        // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
-        // before any multi-user deployment, or all users share one thread history.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
-        licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
-      }
-    : { runner: new InMemoryAgentRunner() }),
+  intelligence: new CopilotKitIntelligence({
+    apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? "",
+    apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+    wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+  }),
+  // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
+  // before any multi-user deployment, or all users share one thread history.
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   // --- /copilotkit:intelligence ---
 });
 

--- a/examples/integrations/mastra/.env.example
+++ b/examples/integrations/mastra/.env.example
@@ -1,0 +1,12 @@
+OPENAI_API_KEY=
+
+# Your CopilotKit Enterprise Intelligence API Key
+# Project Name: Mastra
+CPK_INTELLIGENCE_API_KEY=
+
+# CopilotKit Telemetry ID
+# Optional non-secret analytics identity.
+CPK_TELEMETRY_ID=
+
+INTELLIGENCE_API_URL=http://localhost:4201
+INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/mastra/.gitignore
+++ b/examples/integrations/mastra/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel
@@ -41,4 +42,3 @@ yarn-error.log*
 next-env.d.ts
 
 .mastra/
-

--- a/examples/integrations/mastra/README.md
+++ b/examples/integrations/mastra/README.md
@@ -81,6 +81,12 @@ Feel free to submit issues and enhancement requests!
 project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
 Keep both values in `.env`; the telemetry ID is not a credential.
 
+## Offline or self-hosted licensing
+
+For an offline or self-hosted deployment that requires a license token, set
+`COPILOTKIT_LICENSE_TOKEN` separately. It is not part of the managed project
+credential contract above.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/mastra/README.md
+++ b/examples/integrations/mastra/README.md
@@ -75,6 +75,12 @@ The following scripts can also be run using your preferred package manager:
 
 Feel free to submit issues and enhancement requests!
 
+## Managed CopilotKit Intelligence
+
+`copilotkit init` writes `CPK_INTELLIGENCE_API_KEY` for the selected managed
+project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
+Keep both values in `.env`; the telemetry ID is not a credential.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/mastra/next.config.ts
+++ b/examples/integrations/mastra/next.config.ts
@@ -4,7 +4,7 @@ const nextConfig: NextConfig = {
   output: "standalone",
   serverExternalPackages: ["@copilotkit/runtime"],
   env: {
-    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.COPILOTKIT_LICENSE_TOKEN
+    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.CPK_INTELLIGENCE_API_KEY
       ? "true"
       : "false",
   },

--- a/examples/integrations/mastra/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/mastra/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -2,7 +2,6 @@ import {
   CopilotRuntime,
   CopilotKitIntelligence,
   createCopilotEndpoint,
-  InMemoryAgentRunner,
 } from "@copilotkit/runtime/v2";
 import { MastraAgent } from "@ag-ui/mastra";
 import { mastra } from "@/mastra";
@@ -12,20 +11,14 @@ const runtime = new CopilotRuntime({
   // @ts-expect-error - ignore for now, typing error
   agents: MastraAgent.getLocalAgents({ mastra }),
   // --- copilotkit:intelligence (remove this block to opt out) ---
-  ...(process.env.COPILOTKIT_LICENSE_TOKEN
-    ? {
-        intelligence: new CopilotKitIntelligence({
-          apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
-        }),
-        // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
-        // before any multi-user deployment, or all users share one thread history.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
-        licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
-      }
-    : { runner: new InMemoryAgentRunner() }),
+  intelligence: new CopilotKitIntelligence({
+    apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? "",
+    apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+    wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+  }),
+  // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
+  // before any multi-user deployment, or all users share one thread history.
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   // --- /copilotkit:intelligence ---
 });
 

--- a/examples/integrations/mastra/src/app/page.tsx
+++ b/examples/integrations/mastra/src/app/page.tsx
@@ -81,7 +81,7 @@ export default function CopilotKitPage() {
     */
     <CopilotChatConfigurationProvider agentId="default">
       <div className={`${styles.layout} threadsLayout`}>
-        {/* SDK threads drawer (replaces the hand-rolled fork). License-gated: the locked view's Upgrade CTA opens the Intelligence docs by default. */}
+        {/* SDK threads drawer for the selected managed Intelligence project. */}
         <CopilotThreadsDrawer agentId="default" />
         <div className={styles.mainPanel}>
           <main

--- a/examples/integrations/mcp-apps/.env.example
+++ b/examples/integrations/mcp-apps/.env.example
@@ -1,7 +1,12 @@
 OPENAI_API_KEY=your-openai-api-key-here
 
-# Optional: enable CopilotKit Intelligence Threads locally
-COPILOTKIT_LICENSE_TOKEN=
-INTELLIGENCE_API_KEY=
+# Your CopilotKit Enterprise Intelligence API Key
+# Project Name: MCP Apps
+CPK_INTELLIGENCE_API_KEY=
+
+# CopilotKit Telemetry ID
+# Optional non-secret analytics identity.
+CPK_TELEMETRY_ID=
+
 INTELLIGENCE_API_URL=http://localhost:4201
 INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/mcp-apps/README.md
+++ b/examples/integrations/mcp-apps/README.md
@@ -111,6 +111,12 @@ Feel free to submit issues and enhancement requests! This starter is designed to
 project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
 Keep both values in `.env`; the telemetry ID is not a credential.
 
+## Offline or self-hosted licensing
+
+For an offline or self-hosted deployment that requires a license token, set
+`COPILOTKIT_LICENSE_TOKEN` separately. It is not part of the managed project
+credential contract above.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/mcp-apps/README.md
+++ b/examples/integrations/mcp-apps/README.md
@@ -105,6 +105,12 @@ The MCP App Server code is in `threejs-server/`.
 
 Feel free to submit issues and enhancement requests! This starter is designed to be easily extensible.
 
+## Managed CopilotKit Intelligence
+
+`copilotkit init` writes `CPK_INTELLIGENCE_API_KEY` for the selected managed
+project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
+Keep both values in `.env`; the telemetry ID is not a credential.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/mcp-apps/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/mcp-apps/app/api/copilotkit/[[...slug]]/route.ts
@@ -1,7 +1,6 @@
 import {
   CopilotKitIntelligence,
   CopilotRuntime,
-  InMemoryAgentRunner,
   createCopilotEndpoint,
 } from "@copilotkit/runtime/v2";
 import { BuiltInAgent } from "@copilotkit/runtime/v2";
@@ -34,20 +33,14 @@ const runtime = new CopilotRuntime({
     default: agent,
   },
   // --- copilotkit:intelligence (remove this block to opt out) ---
-  ...(process.env.COPILOTKIT_LICENSE_TOKEN
-    ? {
-        intelligence: new CopilotKitIntelligence({
-          apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
-        }),
-        // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
-        // before any multi-user deployment, or all users share one thread history.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
-        licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
-      }
-    : { runner: new InMemoryAgentRunner() }),
+  intelligence: new CopilotKitIntelligence({
+    apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? "",
+    apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+    wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+  }),
+  // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
+  // before any multi-user deployment, or all users share one thread history.
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   // --- /copilotkit:intelligence ---
 });
 

--- a/examples/integrations/mcp-apps/app/page.tsx
+++ b/examples/integrations/mcp-apps/app/page.tsx
@@ -22,7 +22,7 @@ export default function CopilotKitPage() {
     */
     <CopilotChatConfigurationProvider agentId={agentId}>
       <div className={`${styles.layout} threadsLayout`}>
-        {/* SDK threads drawer (replaces the hand-rolled fork). License-gated: the locked view's Upgrade CTA opens the Intelligence docs by default. */}
+        {/* SDK threads drawer for the selected managed Intelligence project. */}
         <CopilotThreadsDrawer agentId={agentId} />
         <div className={styles.mainPanel}>
           <main className="h-full w-full flex justify-center items-center">

--- a/examples/integrations/mcp-apps/next.config.ts
+++ b/examples/integrations/mcp-apps/next.config.ts
@@ -3,7 +3,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   serverExternalPackages: ["@copilotkit/runtime"],
   env: {
-    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.COPILOTKIT_LICENSE_TOKEN
+    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.CPK_INTELLIGENCE_API_KEY
       ? "true"
       : "false",
   },

--- a/examples/integrations/ms-agent-framework-dotnet/.env.example
+++ b/examples/integrations/ms-agent-framework-dotnet/.env.example
@@ -1,8 +1,13 @@
 # The C# agent reads GitHubToken from .NET user-secrets; see README.md.
 AGENT_URL=http://localhost:8000
 
-# --- CopilotKit Intelligence (optional; set COPILOTKIT_LICENSE_TOKEN to enable Threads — server + UI) ---
-# COPILOTKIT_LICENSE_TOKEN=
-# INTELLIGENCE_API_URL=http://localhost:4201
-# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
-# INTELLIGENCE_API_KEY=
+# Your CopilotKit Enterprise Intelligence API Key
+# Project Name: Microsoft Agent Framework .NET
+CPK_INTELLIGENCE_API_KEY=
+
+# CopilotKit Telemetry ID
+# Optional non-secret analytics identity.
+CPK_TELEMETRY_ID=
+
+INTELLIGENCE_API_URL=http://localhost:4201
+INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/ms-agent-framework-dotnet/README.md
+++ b/examples/integrations/ms-agent-framework-dotnet/README.md
@@ -177,6 +177,12 @@ Feel free to submit issues and enhancement requests! This starter is designed to
 project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
 Keep both values in `.env`; the telemetry ID is not a credential.
 
+## Offline or self-hosted licensing
+
+For an offline or self-hosted deployment that requires a license token, set
+`COPILOTKIT_LICENSE_TOKEN` separately. It is not part of the managed project
+credential contract above.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/ms-agent-framework-dotnet/README.md
+++ b/examples/integrations/ms-agent-framework-dotnet/README.md
@@ -171,6 +171,12 @@ This starter showcases key AG-UI protocol features:
 
 Feel free to submit issues and enhancement requests! This starter is designed to be easily extensible.
 
+## Managed CopilotKit Intelligence
+
+`copilotkit init` writes `CPK_INTELLIGENCE_API_KEY` for the selected managed
+project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
+Keep both values in `.env`; the telemetry ID is not a credential.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/ms-agent-framework-dotnet/next.config.ts
+++ b/examples/integrations/ms-agent-framework-dotnet/next.config.ts
@@ -4,12 +4,8 @@ const nextConfig: NextConfig = {
   typescript: { ignoreBuildErrors: true },
   serverExternalPackages: ["@copilotkit/runtime"],
   env: {
-    // The public Threads UI flag is DERIVED from the server-side license token.
-    // Set COPILOTKIT_LICENSE_TOKEN (only) to enable Threads — do not set this flag
-    // directly. NOTE: NEXT_PUBLIC_* resolves at BUILD time while the runtime reads
-    // the token per-request, so the UI gate and runtime agree only when the token is
-    // present at build time (the standard `next dev` / host-build flow).
-    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.COPILOTKIT_LICENSE_TOKEN
+    // This browser-safe flag contains only key presence, never the key itself.
+    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.CPK_INTELLIGENCE_API_KEY
       ? "true"
       : "false",
   },

--- a/examples/integrations/ms-agent-framework-dotnet/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/ms-agent-framework-dotnet/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -2,7 +2,6 @@ import {
   CopilotRuntime,
   CopilotKitIntelligence,
   createCopilotEndpoint,
-  InMemoryAgentRunner,
 } from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import { handle } from "hono/vercel";
@@ -14,18 +13,12 @@ const runtime = new CopilotRuntime({
     }),
   },
   // --- copilotkit:intelligence (remove this block to opt out) ---
-  ...(process.env.COPILOTKIT_LICENSE_TOKEN
-    ? {
-        intelligence: new CopilotKitIntelligence({
-          apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
-        }),
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
-        licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
-      }
-    : { runner: new InMemoryAgentRunner() }),
+  intelligence: new CopilotKitIntelligence({
+    apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? "",
+    apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+    wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+  }),
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   // --- /copilotkit:intelligence ---
 });
 

--- a/examples/integrations/ms-agent-framework-dotnet/src/app/page.tsx
+++ b/examples/integrations/ms-agent-framework-dotnet/src/app/page.tsx
@@ -49,7 +49,7 @@ export default function CopilotKitPage() {
     */
     <CopilotChatConfigurationProvider agentId="default">
       <div className={`${styles.layout} threadsLayout`}>
-        {/* SDK threads drawer (replaces the hand-rolled fork). License-gated: the locked view's Upgrade CTA opens the Intelligence docs by default. */}
+        {/* SDK threads drawer for the selected managed Intelligence project. */}
         <CopilotThreadsDrawer agentId="default" />
         <div className={styles.mainPanel}>
           <main

--- a/examples/integrations/ms-agent-framework-python/.env.example
+++ b/examples/integrations/ms-agent-framework-python/.env.example
@@ -1,8 +1,13 @@
 OPENAI_API_KEY=your-api-key-here
 AGENT_URL=http://localhost:8000
 
-# --- CopilotKit Intelligence (optional; set COPILOTKIT_LICENSE_TOKEN to enable Threads — server + UI) ---
-# COPILOTKIT_LICENSE_TOKEN=
-# INTELLIGENCE_API_URL=http://localhost:4201
-# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
-# INTELLIGENCE_API_KEY=
+# Your CopilotKit Enterprise Intelligence API Key
+# Project Name: Microsoft Agent Framework Python
+CPK_INTELLIGENCE_API_KEY=
+
+# CopilotKit Telemetry ID
+# Optional non-secret analytics identity.
+CPK_TELEMETRY_ID=
+
+INTELLIGENCE_API_URL=http://localhost:4201
+INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/ms-agent-framework-python/README.md
+++ b/examples/integrations/ms-agent-framework-python/README.md
@@ -107,6 +107,12 @@ The main UI component is in `src/app/page.tsx`. You can:
 
 Feel free to submit issues and enhancement requests! This starter is designed to be easily extensible.
 
+## Managed CopilotKit Intelligence
+
+`copilotkit init` writes `CPK_INTELLIGENCE_API_KEY` for the selected managed
+project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
+Keep both values in `.env`; the telemetry ID is not a credential.
+
 ## License
 
 This project is licensed under the MIT License – see the LICENSE file for details.

--- a/examples/integrations/ms-agent-framework-python/README.md
+++ b/examples/integrations/ms-agent-framework-python/README.md
@@ -113,6 +113,12 @@ Feel free to submit issues and enhancement requests! This starter is designed to
 project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
 Keep both values in `.env`; the telemetry ID is not a credential.
 
+## Offline or self-hosted licensing
+
+For an offline or self-hosted deployment that requires a license token, set
+`COPILOTKIT_LICENSE_TOKEN` separately. It is not part of the managed project
+credential contract above.
+
 ## License
 
 This project is licensed under the MIT License – see the LICENSE file for details.

--- a/examples/integrations/ms-agent-framework-python/next.config.ts
+++ b/examples/integrations/ms-agent-framework-python/next.config.ts
@@ -3,13 +3,8 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   serverExternalPackages: ["@copilotkit/runtime"],
   env: {
-    // The public Threads UI flag is DERIVED from the server-side license token.
-    // Set COPILOTKIT_LICENSE_TOKEN (only) to enable Threads — do not set this
-    // flag directly. NOTE: NEXT_PUBLIC_* resolves at BUILD time while the
-    // runtime reads the token per-request, so the UI gate and runtime agree
-    // only when the token is present at build time (the standard `next dev` /
-    // host-build flow).
-    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.COPILOTKIT_LICENSE_TOKEN
+    // This browser-safe flag contains only key presence, never the key itself.
+    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.CPK_INTELLIGENCE_API_KEY
       ? "true"
       : "false",
   },

--- a/examples/integrations/ms-agent-framework-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/ms-agent-framework-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -1,7 +1,6 @@
 import {
   CopilotRuntime,
   CopilotKitIntelligence,
-  InMemoryAgentRunner,
   createCopilotEndpoint,
 } from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
@@ -17,18 +16,12 @@ const runtime = new CopilotRuntime({
     }),
   },
   // --- copilotkit:intelligence (remove this block to opt out) ---
-  ...(process.env.COPILOTKIT_LICENSE_TOKEN
-    ? {
-        intelligence: new CopilotKitIntelligence({
-          apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
-        }),
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
-        licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
-      }
-    : { runner: new InMemoryAgentRunner() }),
+  intelligence: new CopilotKitIntelligence({
+    apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? "",
+    apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+    wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+  }),
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   // --- /copilotkit:intelligence ---
 });
 

--- a/examples/integrations/ms-agent-framework-python/src/app/page.tsx
+++ b/examples/integrations/ms-agent-framework-python/src/app/page.tsx
@@ -85,7 +85,7 @@ export default function CopilotKitPage() {
     */
     <CopilotChatConfigurationProvider agentId="default">
       <div className={`${styles.layout} threadsLayout`}>
-        {/* SDK threads drawer (replaces the hand-rolled fork). License-gated: the locked view's Upgrade CTA opens the Intelligence docs by default. */}
+        {/* SDK threads drawer for the selected managed Intelligence project. */}
         <CopilotThreadsDrawer agentId="default" />
         <div className={styles.mainPanel}>
           <main

--- a/examples/integrations/pydantic-ai/.env.example
+++ b/examples/integrations/pydantic-ai/.env.example
@@ -1,8 +1,13 @@
 OPENAI_API_KEY=your-api-key-here
 AGENT_URL=http://localhost:8000
 
-# --- copilotkit:intelligence (optional local threads stack) ---
-# COPILOTKIT_LICENSE_TOKEN=
-# INTELLIGENCE_API_KEY=
-# INTELLIGENCE_API_URL=http://localhost:4201
-# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
+# Your CopilotKit Enterprise Intelligence API Key
+# Project Name: Pydantic AI
+CPK_INTELLIGENCE_API_KEY=
+
+# CopilotKit Telemetry ID
+# Optional non-secret analytics identity.
+CPK_TELEMETRY_ID=
+
+INTELLIGENCE_API_URL=http://localhost:4201
+INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/pydantic-ai/README.md
+++ b/examples/integrations/pydantic-ai/README.md
@@ -96,6 +96,12 @@ The main UI component is in `src/app/page.tsx`. You can:
 
 Feel free to submit issues and enhancement requests! This starter is designed to be easily extensible.
 
+## Managed CopilotKit Intelligence
+
+`copilotkit init` writes `CPK_INTELLIGENCE_API_KEY` for the selected managed
+project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
+Keep both values in `.env`; the telemetry ID is not a credential.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/pydantic-ai/README.md
+++ b/examples/integrations/pydantic-ai/README.md
@@ -102,6 +102,12 @@ Feel free to submit issues and enhancement requests! This starter is designed to
 project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
 Keep both values in `.env`; the telemetry ID is not a credential.
 
+## Offline or self-hosted licensing
+
+For an offline or self-hosted deployment that requires a license token, set
+`COPILOTKIT_LICENSE_TOKEN` separately. It is not part of the managed project
+credential contract above.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/pydantic-ai/next.config.ts
+++ b/examples/integrations/pydantic-ai/next.config.ts
@@ -4,7 +4,7 @@ const nextConfig: NextConfig = {
   output: "standalone",
   serverExternalPackages: ["@copilotkit/runtime"],
   env: {
-    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.COPILOTKIT_LICENSE_TOKEN
+    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.CPK_INTELLIGENCE_API_KEY
       ? "true"
       : "false",
   },

--- a/examples/integrations/pydantic-ai/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/pydantic-ai/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -1,7 +1,6 @@
 import {
   CopilotRuntime,
   CopilotKitIntelligence,
-  InMemoryAgentRunner,
   createCopilotEndpoint,
 } from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
@@ -17,20 +16,14 @@ const runtime = new CopilotRuntime({
     }),
   },
   // --- copilotkit:intelligence (remove this block to opt out) ---
-  ...(process.env.COPILOTKIT_LICENSE_TOKEN
-    ? {
-        intelligence: new CopilotKitIntelligence({
-          apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
-        }),
-        // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
-        // before any multi-user deployment, or all users share one thread history.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
-        licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
-      }
-    : { runner: new InMemoryAgentRunner() }),
+  intelligence: new CopilotKitIntelligence({
+    apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? "",
+    apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+    wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+  }),
+  // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
+  // before any multi-user deployment, or all users share one thread history.
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   // --- /copilotkit:intelligence ---
 });
 

--- a/examples/integrations/pydantic-ai/src/app/page.tsx
+++ b/examples/integrations/pydantic-ai/src/app/page.tsx
@@ -52,7 +52,7 @@ export default function CopilotKitPage() {
     */
     <CopilotChatConfigurationProvider agentId="default">
       <div className={`${styles.layout} threadsLayout`}>
-        {/* SDK threads drawer (replaces the hand-rolled fork). License-gated: the locked view's Upgrade CTA opens the Intelligence docs by default. */}
+        {/* SDK threads drawer for the selected managed Intelligence project. */}
         <CopilotThreadsDrawer agentId="default" />
         <div className={styles.mainPanel}>
           <main

--- a/examples/integrations/strands-python/.env.example
+++ b/examples/integrations/strands-python/.env.example
@@ -1,8 +1,13 @@
 AGENT_URL=http://localhost:8000
 OPENAI_API_KEY=
 
-# --- CopilotKit Intelligence (optional; set COPILOTKIT_LICENSE_TOKEN to enable Threads — server + UI) ---
-# COPILOTKIT_LICENSE_TOKEN=
-# INTELLIGENCE_API_URL=http://localhost:4201
-# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
-# INTELLIGENCE_API_KEY=
+# Your CopilotKit Enterprise Intelligence API Key
+# Project Name: Strands Python
+CPK_INTELLIGENCE_API_KEY=
+
+# CopilotKit Telemetry ID
+# Optional non-secret analytics identity.
+CPK_TELEMETRY_ID=
+
+INTELLIGENCE_API_URL=http://localhost:4201
+INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/strands-python/README.md
+++ b/examples/integrations/strands-python/README.md
@@ -93,6 +93,12 @@ Otherwise, check out the documentation relevant to your task:
 
 Feel free to submit issues and enhancement requests! This starter is designed to be easily extensible.
 
+## Managed CopilotKit Intelligence
+
+`copilotkit init` writes `CPK_INTELLIGENCE_API_KEY` for the selected managed
+project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
+Keep both values in `.env`; the telemetry ID is not a credential.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/strands-python/README.md
+++ b/examples/integrations/strands-python/README.md
@@ -99,6 +99,12 @@ Feel free to submit issues and enhancement requests! This starter is designed to
 project. `CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.
 Keep both values in `.env`; the telemetry ID is not a credential.
 
+## Offline or self-hosted licensing
+
+For an offline or self-hosted deployment that requires a license token, set
+`COPILOTKIT_LICENSE_TOKEN` separately. It is not part of the managed project
+credential contract above.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/examples/integrations/strands-python/next.config.ts
+++ b/examples/integrations/strands-python/next.config.ts
@@ -4,15 +4,8 @@ const nextConfig: NextConfig = {
   output: "standalone",
   serverExternalPackages: ["@copilotkit/runtime"],
   env: {
-    // The public Threads UI flag is DERIVED from the server-side license token.
-    // Set COPILOTKIT_LICENSE_TOKEN (only) to enable Threads — do not set this flag
-    // directly. NOTE: NEXT_PUBLIC_* resolves at BUILD time while the runtime reads
-    // the token per-request, so the UI gate and runtime agree only when the token is
-    // present at build time (the standard `next dev` / host-build flow). For a
-    // standalone/Docker image built without the token and injected at runtime, set
-    // COPILOTKIT_LICENSE_TOKEN at build time too (or gate the UI at runtime) so the
-    // baked flag reflects it.
-    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.COPILOTKIT_LICENSE_TOKEN
+    // This browser-safe flag contains only key presence, never the key itself.
+    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.CPK_INTELLIGENCE_API_KEY
       ? "true"
       : "false",
   },

--- a/examples/integrations/strands-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/strands-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -2,7 +2,6 @@ import {
   CopilotRuntime,
   CopilotKitIntelligence,
   createCopilotEndpoint,
-  InMemoryAgentRunner,
 } from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import { handle } from "hono/vercel";
@@ -19,20 +18,14 @@ const defaultAgent = new HttpAgent({
 const runtime = new CopilotRuntime({
   agents: { default: defaultAgent },
   // --- copilotkit:intelligence (remove this block to opt out) ---
-  ...(process.env.COPILOTKIT_LICENSE_TOKEN
-    ? {
-        intelligence: new CopilotKitIntelligence({
-          apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
-        }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
-        licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
-      }
-    : { runner: new InMemoryAgentRunner() }),
+  intelligence: new CopilotKitIntelligence({
+    apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? "",
+    apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+    wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+  }),
+  // Demo stub — replace with your real auth-derived user identity before any
+  // multi-user deployment, or all users share one thread history.
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   // --- /copilotkit:intelligence ---
   openGenerativeUI: true,
   a2ui: {

--- a/examples/integrations/strands-python/src/app/page.tsx
+++ b/examples/integrations/strands-python/src/app/page.tsx
@@ -30,7 +30,7 @@ export default function HomePage() {
     */
     <CopilotChatConfigurationProvider agentId="default">
       <div className={styles.layout}>
-        {/* SDK threads drawer (replaces the hand-rolled fork). License-gated: the locked view's Upgrade CTA opens the Intelligence docs by default. */}
+        {/* SDK threads drawer for the selected managed Intelligence project. */}
         <CopilotThreadsDrawer agentId="default" />
         <div className={styles.mainPanel}>
           <ExampleLayout

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -16,6 +16,8 @@ const MANAGED_API_KEY_SECRET_CONFIG =
   "copilotkit_intelligence_api_key_secret_name";
 const NEXT_THREADS_GATE = "NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED";
 const VITE_THREADS_GATE = "VITE_COPILOTKIT_THREADS_ENABLED";
+const MANAGED_DOCUMENTATION_LABEL = /\bmanaged\b/i;
+const SELF_HOSTED_OR_OFFLINE_LABEL = /\b(?:self[ -]?hosted|offline)\b/i;
 
 const MANAGED_CLI_FRAMEWORKS = [
   "langgraph-py",
@@ -563,16 +565,14 @@ function envAssignmentPattern(identifier: string): RegExp {
   return new RegExp(`^\\s*#?\\s*${identifier}\\s*=`, "m");
 }
 
-/**
- * Returns the blank-line-delimited text block containing a marker.
- *
- * @param contents - Environment example or other block-oriented text.
- * @param marker - Managed credential identifier used to locate the block.
- * @returns The matching block, or an empty string when the marker is absent.
- */
+/** Returns every blank-line-delimited block in block-oriented text. */
+function textBlocks(contents: string): readonly string[] {
+  return contents.split(/\r?\n\s*\r?\n/);
+}
+
+/** Returns the first blank-line-delimited text block containing a marker. */
 function textBlockContaining(contents: string, marker: string): string {
-  const blocks = contents.split(/\r?\n\s*\r?\n/);
-  return blocks.find((block) => block.includes(marker)) ?? "";
+  return textBlocks(contents).find((block) => block.includes(marker)) ?? "";
 }
 
 /** Asserts telemetry copy describes identity without prerequisite semantics. */
@@ -588,59 +588,107 @@ function expectTelemetryIdentityDocumentation(contents: string): void {
   );
 }
 
-/**
- * Returns the Markdown section containing a managed credential marker.
- *
- * This scopes license-copy checks so explicit self-hosted or offline sections
- * elsewhere in the README remain valid.
- *
- * @param markdown - README contents.
- * @param marker - Managed credential identifier used to locate the section.
- * @returns The matching heading section, or only the matching paragraph when
- * no preceding Markdown heading exists.
- */
-function markdownSectionContaining(markdown: string, marker: string): string {
+/** Returns whether an env block has an explicit comment label. */
+function envBlockHasLabel(block: string, label: RegExp): boolean {
+  return block
+    .split(/\r?\n/)
+    .some((line) => /^\s*#/.test(line) && label.test(line));
+}
+
+/** Returns the explicitly labeled managed env block containing both fields. */
+function managedEnvBlock(contents: string): string {
+  return (
+    textBlocks(contents).find(
+      (block) =>
+        envBlockHasLabel(block, MANAGED_DOCUMENTATION_LABEL) &&
+        envAssignmentPattern(MANAGED_API_KEY).test(block) &&
+        envAssignmentPattern(OPTIONAL_TELEMETRY_ID).test(block),
+    ) ?? ""
+  );
+}
+
+/** Asserts every env license occurrence has a deployment-mode label. */
+function expectEnvLicenseOccurrencesClassified(contents: string): void {
+  const licenseBlocks = textBlocks(contents).filter((block) =>
+    block.includes(MANAGED_LICENSE_TOKEN),
+  );
+
+  expect(
+    licenseBlocks.every((block) =>
+      envBlockHasLabel(block, SELF_HOSTED_OR_OFFLINE_LABEL),
+    ),
+  ).toBe(true);
+}
+
+/** Returns the managed Markdown heading section containing both fields. */
+function managedMarkdownSection(markdown: string): string {
   const lines = markdown.split(/\r?\n/);
-  const markerLine = lines.findIndex((line) => line.includes(marker));
 
-  if (markerLine < 0) {
-    return "";
-  }
-
-  let headingLine = -1;
-  let headingLevel = 0;
-
-  for (let index = markerLine; index >= 0; index -= 1) {
-    const heading = lines[index]?.match(/^(#{1,6})\s+/);
-    if (heading) {
-      headingLine = index;
-      headingLevel = heading[1]?.length ?? 0;
-      break;
+  for (let start = 0; start < lines.length; start += 1) {
+    const heading = lines[start]?.match(/^(#{1,6})\s+(.+?)\s*$/);
+    if (!heading || !MANAGED_DOCUMENTATION_LABEL.test(heading[2] ?? "")) {
+      continue;
     }
-  }
 
-  if (headingLine < 0) {
-    const paragraphs = markdown.split(/\r?\n\s*\r?\n/);
-    return paragraphs.find((paragraph) => paragraph.includes(marker)) ?? "";
-  }
+    const headingLevel = heading[1]?.length ?? 0;
+    let end = lines.length;
+    for (let index = start + 1; index < lines.length; index += 1) {
+      const subsequent = lines[index]?.match(/^(#{1,6})\s+/);
+      if (subsequent && (subsequent[1]?.length ?? 0) <= headingLevel) {
+        end = index;
+        break;
+      }
+    }
 
-  let endLine = lines.length;
-  for (let index = markerLine + 1; index < lines.length; index += 1) {
-    const heading = lines[index]?.match(/^(#{1,6})\s+(.+?)\s*$/);
-    const subsequentLevel = heading?.[1]?.length ?? 0;
-    const subsequentTitle = heading?.[2] ?? "";
-    const startsSeparateLicenseGuidance =
-      /\b(?:self[ -]?hosted|offline)\b/i.test(subsequentTitle);
+    const section = lines.slice(start, end).join("\n");
     if (
-      heading &&
-      (subsequentLevel <= headingLevel || startsSeparateLicenseGuidance)
+      exactEnvIdentifierPattern(MANAGED_API_KEY).test(section) &&
+      exactEnvIdentifierPattern(OPTIONAL_TELEMETRY_ID).test(section)
     ) {
-      endLine = index;
-      break;
+      return section;
     }
   }
 
-  return lines.slice(headingLine, endLine).join("\n");
+  return "";
+}
+
+/** Returns whether a Markdown line has a heading ancestor with the label. */
+function markdownLineHasLabeledAncestor(
+  lines: readonly string[],
+  lineIndex: number,
+  label: RegExp,
+): boolean {
+  let childLevel = 7;
+  for (let index = lineIndex; index >= 0; index -= 1) {
+    const heading = lines[index]?.match(/^(#{1,6})\s+(.+?)\s*$/);
+    const headingLevel = heading?.[1]?.length ?? 0;
+    if (heading && headingLevel < childLevel) {
+      if (label.test(heading[2] ?? "")) {
+        return true;
+      }
+      childLevel = headingLevel;
+    }
+  }
+
+  return false;
+}
+
+/** Asserts every README license mention has a deployment-mode heading. */
+function expectMarkdownLicenseOccurrencesClassified(markdown: string): void {
+  const lines = markdown.split(/\r?\n/);
+  const licenseLines = lines.flatMap((line, index) =>
+    line.includes(MANAGED_LICENSE_TOKEN) ? [index] : [],
+  );
+
+  expect(
+    licenseLines.every((index) =>
+      markdownLineHasLabeledAncestor(
+        lines,
+        index,
+        SELF_HOSTED_OR_OFFLINE_LABEL,
+      ),
+    ),
+  ).toBe(true);
 }
 
 /**
@@ -678,14 +726,13 @@ function expectManagedGateContract(contents: string): void {
  * @param contents - Managed template environment example contents.
  */
 function expectManagedEnvContract(contents: string): void {
-  expect(contents).toMatch(envAssignmentPattern(MANAGED_API_KEY));
-  expect(contents).toMatch(envAssignmentPattern(OPTIONAL_TELEMETRY_ID));
-  expectTelemetryIdentityDocumentation(contents);
+  const managedBlock = managedEnvBlock(contents);
+
+  expect(managedBlock).not.toBe("");
+  expectTelemetryIdentityDocumentation(managedBlock);
   expect(contents).not.toMatch(envAssignmentPattern(LEGACY_API_KEY));
   expect(contents).not.toMatch(envAssignmentPattern(LEGACY_TELEMETRY_ID));
-
-  const managedBlock = textBlockContaining(contents, MANAGED_API_KEY);
-  expect(managedBlock).not.toMatch(envAssignmentPattern(MANAGED_LICENSE_TOKEN));
+  expectEnvLicenseOccurrencesClassified(contents);
 }
 
 /**
@@ -694,14 +741,13 @@ function expectManagedEnvContract(contents: string): void {
  * @param contents - Managed template README contents.
  */
 function expectManagedReadmeContract(contents: string): void {
-  expect(contents).toMatch(exactEnvIdentifierPattern(MANAGED_API_KEY));
-  expect(contents).toMatch(exactEnvIdentifierPattern(OPTIONAL_TELEMETRY_ID));
-  expectTelemetryIdentityDocumentation(contents);
+  const managedSection = managedMarkdownSection(contents);
+
+  expect(managedSection).not.toBe("");
+  expectTelemetryIdentityDocumentation(managedSection);
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_API_KEY));
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_TELEMETRY_ID));
-
-  const managedSection = markdownSectionContaining(contents, MANAGED_API_KEY);
-  expect(managedSection).not.toContain(MANAGED_LICENSE_TOKEN);
+  expectMarkdownLicenseOccurrencesClassified(contents);
 }
 
 /** Assert AgentCore local services consume the CLI-managed root env safely. */
@@ -911,6 +957,7 @@ test("managed documentation helpers reject misleading telemetry semantics", () =
 
   for (const description of misleadingDescriptions) {
     const envExample = `
+      # Managed Intelligence credentials
       CPK_INTELLIGENCE_API_KEY=
       # Optional, non-secret analytics ${description}.
       CPK_TELEMETRY_ID=
@@ -930,6 +977,7 @@ test("managed documentation helpers reject misleading telemetry semantics", () =
 
 test("managed documentation helpers accept an optional non-secret analytics identity", () => {
   const envExample = `
+    # Managed Intelligence credentials
     CPK_INTELLIGENCE_API_KEY=
     # Optional, non-secret analytics identity.
     CPK_TELEMETRY_ID=
@@ -960,6 +1008,60 @@ test("managed documentation helpers reject license guidance inside the managed b
     "Set CPK_INTELLIGENCE_API_KEY for the project.",
     "CPK_TELEMETRY_ID is an optional, non-secret analytics identity.",
     "COPILOTKIT_LICENSE_TOKEN is not a managed credential.",
+  ].join("\n");
+
+  expect(() => expectManagedEnvContract(envExample)).toThrow();
+  expect(() => expectManagedReadmeContract(readme)).toThrow();
+});
+
+test("managed documentation helpers reject separated unlabeled license guidance", () => {
+  const envExample = `
+    # Managed Intelligence credentials
+    CPK_INTELLIGENCE_API_KEY=
+    # Optional, non-secret analytics identity
+    CPK_TELEMETRY_ID=
+
+    # Self-hosted / offline license
+    COPILOTKIT_LICENSE_TOKEN=
+
+    # Troubleshooting
+    COPILOTKIT_LICENSE_TOKEN=
+  `;
+  const readme = [
+    "## Managed Intelligence credentials",
+    "",
+    "Set CPK_INTELLIGENCE_API_KEY for the project.",
+    "CPK_TELEMETRY_ID is an optional, non-secret analytics identity.",
+    "",
+    "## Self-hosted / offline license",
+    "",
+    "Offline deployments may set COPILOTKIT_LICENSE_TOKEN.",
+    "",
+    "## Troubleshooting",
+    "",
+    "Set COPILOTKIT_LICENSE_TOKEN if the managed integration is unavailable.",
+  ].join("\n");
+
+  expect(() => expectManagedEnvContract(envExample)).toThrow();
+  expect(() => expectManagedReadmeContract(readme)).toThrow();
+});
+
+test("managed documentation helpers require credentials in one managed block", () => {
+  const envExample = `
+    # Managed Intelligence credentials
+    CPK_INTELLIGENCE_API_KEY=
+
+    # Optional, non-secret analytics identity
+    CPK_TELEMETRY_ID=
+  `;
+  const readme = [
+    "## Managed Intelligence credentials",
+    "",
+    "Set CPK_INTELLIGENCE_API_KEY for the project.",
+    "",
+    "## Analytics identity",
+    "",
+    "CPK_TELEMETRY_ID is an optional, non-secret analytics identity.",
   ].join("\n");
 
   expect(() => expectManagedEnvContract(envExample)).toThrow();

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -1342,15 +1342,21 @@ function markdownLicenseOccurrenceLines(lines: readonly string[]): number[] {
   return occurrences;
 }
 
-/** Returns the managed Markdown heading section containing both fields. */
-function managedMarkdownSection(markdown: string): string {
+interface MarkdownHeadingSection {
+  readonly heading: string;
+  readonly contents: string;
+}
+
+/** Returns every Markdown heading section through its next peer heading. */
+function markdownHeadingSections(
+  markdown: string,
+): readonly MarkdownHeadingSection[] {
   const lines = markdown.split(/\r?\n/);
+  const sections: MarkdownHeadingSection[] = [];
 
   for (let start = 0; start < lines.length; start += 1) {
     const heading = lines[start]?.match(/^(#{1,6})\s+(.+?)\s*$/);
-    if (!heading || !MANAGED_DOCUMENTATION_LABEL.test(heading[2] ?? "")) {
-      continue;
-    }
+    if (!heading) continue;
 
     const headingLevel = heading[1]?.length ?? 0;
     let end = lines.length;
@@ -1362,16 +1368,37 @@ function managedMarkdownSection(markdown: string): string {
       }
     }
 
-    const section = lines.slice(start, end).join("\n");
-    if (
-      exactEnvIdentifierPattern(MANAGED_API_KEY).test(section) &&
-      exactEnvIdentifierPattern(OPTIONAL_TELEMETRY_ID).test(section)
-    ) {
-      return section;
-    }
+    sections.push({
+      heading: heading[2] ?? "",
+      contents: lines.slice(start, end).join("\n"),
+    });
   }
 
-  return "";
+  return sections;
+}
+
+/** Returns the managed Markdown section containing both managed fields. */
+function managedMarkdownSection(markdown: string): string {
+  return (
+    markdownHeadingSections(markdown).find(
+      ({ heading, contents }) =>
+        MANAGED_DOCUMENTATION_LABEL.test(heading) &&
+        exactEnvIdentifierPattern(MANAGED_API_KEY).test(contents) &&
+        exactEnvIdentifierPattern(OPTIONAL_TELEMETRY_ID).test(contents),
+    )?.contents ?? ""
+  );
+}
+
+/** Returns distinct offline or self-hosted license-token guidance. */
+function offlineOrSelfHostedLicenseSection(markdown: string): string {
+  return (
+    markdownHeadingSections(markdown).find(
+      ({ heading, contents }) =>
+        SELF_HOSTED_OR_OFFLINE_LABEL.test(heading) &&
+        (exactEnvIdentifierPattern(MANAGED_LICENSE_TOKEN).test(contents) ||
+          /\blicen[cs]e\s+token\b/i.test(contents)),
+    )?.contents ?? ""
+  );
 }
 
 /** Returns whether a Markdown line has a heading ancestor with the label. */
@@ -1464,9 +1491,16 @@ function expectManagedEnvContract(contents: string): void {
  */
 function expectManagedReadmeContract(contents: string): void {
   const managedSection = managedMarkdownSection(contents);
+  const offlineOrSelfHostedSection =
+    offlineOrSelfHostedLicenseSection(contents);
 
   expect(managedSection).not.toBe("");
+  expect(managedSection).not.toContain(MANAGED_LICENSE_TOKEN);
   expectTelemetryIdentityDocumentation(managedSection);
+  expect(offlineOrSelfHostedSection).not.toBe("");
+  if (offlineOrSelfHostedSection) {
+    expect(managedSection).not.toContain(offlineOrSelfHostedSection);
+  }
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_API_KEY));
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_TELEMETRY_ID));
   expectMarkdownLicenseOccurrencesClassified(contents);
@@ -2661,10 +2695,26 @@ test("managed documentation helpers accept an optional non-secret analytics iden
     "Set `CPK_INTELLIGENCE_API_KEY` for the project.",
     "",
     "`CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.",
+    "",
+    "## Offline or self-hosted licensing",
+    "",
+    "Set `COPILOTKIT_LICENSE_TOKEN` only for an offline deployment.",
   ].join("\n");
 
   expect(() => expectManagedEnvContract(envExample)).not.toThrow();
   expect(() => expectManagedReadmeContract(readme)).not.toThrow();
+});
+
+test("managed README helper rejects missing offline or self-hosted license guidance", () => {
+  const readme = [
+    "## Managed Intelligence credentials",
+    "",
+    "Set `CPK_INTELLIGENCE_API_KEY` for the project.",
+    "",
+    "`CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.",
+  ].join("\n");
+
+  expect(() => expectManagedReadmeContract(readme)).toThrow();
 });
 
 test.each([
@@ -2763,7 +2813,7 @@ test("managed documentation helpers allow separate self-hosted and offline licen
     "Set CPK_INTELLIGENCE_API_KEY for the project.",
     "CPK_TELEMETRY_ID is an optional, non-secret analytics identity.",
     "",
-    "### Self-hosted / offline license",
+    "## Self-hosted / offline license",
     "",
     "Offline deployments may set COPILOTKIT_LICENSE_TOKEN instead.",
   ].join("\n");
@@ -2809,6 +2859,7 @@ test("managed documentation helpers allow generic license-gating copy only in se
     "",
     "## Self-hosted / offline license behavior",
     "",
+    "Set COPILOTKIT_LICENSE_TOKEN only for this deployment mode.",
     "A deployment license enables Threads and Inspector offline.",
   ].join("\n");
 

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -18,6 +18,14 @@ const NEXT_THREADS_GATE = "NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED";
 const VITE_THREADS_GATE = "VITE_COPILOTKIT_THREADS_ENABLED";
 const MANAGED_DOCUMENTATION_LABEL = /\bmanaged\b/i;
 const SELF_HOSTED_OR_OFFLINE_LABEL = /\b(?:self[ -]?hosted|offline)\b/i;
+const LICENSE_GATING_LANGUAGE =
+  /(?:\blicen[cs]e\b[\s\S]{0,160}\b(?:activat(?:e[sd]?|ing)|unlock(?:s|ed|ing)?|enabl(?:e[sd]?|ing))\b[\s\S]{0,160}\b(?:threads?|inspector)\b|\b(?:threads?|inspector)\b[\s\S]{0,160}\b(?:activat(?:e[sd]?|ing)|unlock(?:s|ed|ing)?|enabl(?:e[sd]?|ing))\b[\s\S]{0,160}\blicen[cs]e\b)/i;
+const INTEGRATION_PARITY_WORKFLOW = path.join(
+  repoRoot,
+  ".github",
+  "workflows",
+  "integrations_parity.yml",
+);
 
 const MANAGED_CLI_FRAMEWORKS = [
   "langgraph-py",
@@ -247,18 +255,6 @@ function rootManagedEnvFilePattern(): RegExp {
   return /env_file:\s*(?:\r?\n\s*-\s*)?\.\.\/\.env\b/;
 }
 
-/** Matches a deployment config key without constraining its safe reference. */
-function deploymentConfigReferencePattern(identifier: string): RegExp {
-  return new RegExp(`^\\s*${identifier}\\s*:`, "m");
-}
-
-/** Matches two required terms close enough to belong to one configuration. */
-function nearbyTermsPattern(first: string, second: string): RegExp {
-  return new RegExp(
-    `(?:${first}[\\s\\S]{0,400}${second}|${second}[\\s\\S]{0,400}${first})`,
-  );
-}
-
 /**
  * Matches an environment identifier without matching it inside a longer name.
  *
@@ -404,6 +400,41 @@ function expressionUsesManagedKeyWithoutTelemetry(
   );
 }
 
+/** Returns whether an expression is a literal boolean string projection. */
+function isBooleanStringProjection(expression: ts.Expression): boolean {
+  const unwrapped = unwrapExpression(expression);
+  if (ts.isStringLiteral(unwrapped)) {
+    return unwrapped.text === "true" || unwrapped.text === "false";
+  }
+  if (ts.isConditionalExpression(unwrapped)) {
+    return (
+      isBooleanStringProjection(unwrapped.whenTrue) &&
+      isBooleanStringProjection(unwrapped.whenFalse)
+    );
+  }
+  if (
+    ts.isCallExpression(unwrapped) &&
+    ts.isPropertyAccessExpression(unwrapped.expression) &&
+    ts.isIdentifier(unwrapped.expression.expression) &&
+    unwrapped.expression.expression.text === "JSON" &&
+    unwrapped.expression.name.text === "stringify" &&
+    unwrapped.arguments.length === 1
+  ) {
+    return isBooleanStringProjection(unwrapped.arguments[0]!);
+  }
+
+  return false;
+}
+
+/** Returns whether the public gate is boolean-only and keyed by the CPK credential. */
+function expressionUsesManagedBooleanGate(expression: ts.Expression): boolean {
+  return (
+    expressionContainsEnvRead(expression, MANAGED_API_KEY) &&
+    !expressionContainsEnvRead(expression, OPTIONAL_TELEMETRY_ID) &&
+    isBooleanStringProjection(expression)
+  );
+}
+
 /** Returns whether a CopilotKit Intelligence constructor owns the API-key read. */
 function hasRuntimeApiKeyRead(sourceFile: ts.SourceFile): boolean {
   let found = false;
@@ -500,26 +531,6 @@ function defaultExportExpression(
   return null;
 }
 
-/** Returns whether a nested object property owns the managed env read. */
-function nestedPropertyContainsEnvRead(
-  objectLiteral: ts.ObjectLiteralExpression,
-  containerName: string,
-  propertyName: string,
-): boolean {
-  const container = objectPropertyAssignment(objectLiteral, containerName);
-  if (!container) {
-    return false;
-  }
-  const containerInitializer = unwrapExpression(container.initializer);
-  if (!ts.isObjectLiteralExpression(containerInitializer)) {
-    return false;
-  }
-  const property = objectPropertyAssignment(containerInitializer, propertyName);
-  return Boolean(
-    property && expressionUsesManagedKeyWithoutTelemetry(property.initializer),
-  );
-}
-
 /** Returns whether the exported Next or Vite thread gate owns the key read. */
 function hasExportedGateApiKeyRead(sourceFile: ts.SourceFile): boolean {
   const exported = defaultExportExpression(sourceFile);
@@ -530,7 +541,12 @@ function hasExportedGateApiKeyRead(sourceFile: ts.SourceFile): boolean {
   const nextConfig = exportedObjectLiteral(exported, sourceFile);
   if (
     nextConfig &&
-    nestedPropertyContainsEnvRead(nextConfig, "env", NEXT_THREADS_GATE)
+    nestedPropertyMatches(
+      nextConfig,
+      "env",
+      NEXT_THREADS_GATE,
+      expressionUsesManagedBooleanGate,
+    )
   ) {
     return true;
   }
@@ -544,15 +560,130 @@ function hasExportedGateApiKeyRead(sourceFile: ts.SourceFile): boolean {
     const config = unwrapped.arguments[0];
     const unwrappedConfig = config ? unwrapExpression(config) : null;
     if (unwrappedConfig && ts.isObjectLiteralExpression(unwrappedConfig)) {
-      return nestedPropertyContainsEnvRead(
+      return nestedPropertyMatches(
         unwrappedConfig,
         "define",
         `import.meta.env.${VITE_THREADS_GATE}`,
+        expressionUsesManagedBooleanGate,
       );
     }
   }
 
   return false;
+}
+
+/** Returns whether a nested object property satisfies an expression predicate. */
+function nestedPropertyMatches(
+  objectLiteral: ts.ObjectLiteralExpression,
+  containerName: string,
+  propertyName: string,
+  predicate: (expression: ts.Expression) => boolean,
+): boolean {
+  const container = objectPropertyAssignment(objectLiteral, containerName);
+  if (!container) {
+    return false;
+  }
+  const containerInitializer = unwrapExpression(container.initializer);
+  if (!ts.isObjectLiteralExpression(containerInitializer)) {
+    return false;
+  }
+  const property = objectPropertyAssignment(containerInitializer, propertyName);
+  return Boolean(property && predicate(property.initializer));
+}
+
+/** Returns the exact dotted parts of a property-access expression. */
+function propertyAccessParts(expression: ts.Expression): readonly string[] {
+  const unwrapped = unwrapExpression(expression);
+  if (ts.isIdentifier(unwrapped)) {
+    return [unwrapped.text];
+  }
+  if (ts.isPropertyAccessExpression(unwrapped)) {
+    return [...propertyAccessParts(unwrapped.expression), unwrapped.name.text];
+  }
+
+  return [];
+}
+
+/** Returns whether an expression contains an exact dotted property path. */
+function expressionContainsPropertyPath(
+  expression: ts.Expression,
+  expectedPath: readonly string[],
+): boolean {
+  let found = false;
+
+  /** Visits one expression node for the exact configured path. */
+  function visit(node: ts.Node): void {
+    if (found) return;
+    if (
+      ts.isExpression(node) &&
+      propertyAccessParts(node).join(".") === expectedPath.join(".")
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(expression);
+  return found;
+}
+
+/** Returns whether an expression resolves a value through Secrets Manager. */
+function expressionContainsSecretResolution(
+  expression: ts.Expression,
+): boolean {
+  let found = false;
+
+  /** Visits one expression node for an explicit Secrets Manager call. */
+  function visit(node: ts.Node): void {
+    if (found) return;
+    if (ts.isCallExpression(node)) {
+      const callee = propertyAccessParts(node.expression);
+      if (
+        callee.at(-1) === "secretsManager" &&
+        callee.includes("SecretValue")
+      ) {
+        found = true;
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(expression);
+  return found;
+}
+
+/** Returns all new-expression option objects matching a construct name and id. */
+function constructOptions(
+  sourceFile: ts.SourceFile,
+  constructorPath: readonly string[],
+  constructId: string,
+): readonly ts.ObjectLiteralExpression[] {
+  const matches: ts.ObjectLiteralExpression[] = [];
+
+  /** Visits construct calls for exact constructor and id ownership. */
+  function visit(node: ts.Node): void {
+    if (
+      ts.isNewExpression(node) &&
+      propertyAccessParts(node.expression).join(".") ===
+        constructorPath.join(".") &&
+      node.arguments?.[1] &&
+      ts.isStringLiteral(node.arguments[1]) &&
+      node.arguments[1].text === constructId
+    ) {
+      const options = node.arguments[2]
+        ? unwrapExpression(node.arguments[2])
+        : null;
+      if (options && ts.isObjectLiteralExpression(options)) {
+        matches.push(options);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return matches;
 }
 
 /**
@@ -609,8 +740,10 @@ function managedEnvBlock(contents: string): string {
 
 /** Asserts every env license occurrence has a deployment-mode label. */
 function expectEnvLicenseOccurrencesClassified(contents: string): void {
-  const licenseBlocks = textBlocks(contents).filter((block) =>
-    block.includes(MANAGED_LICENSE_TOKEN),
+  const licenseBlocks = textBlocks(contents).filter(
+    (block) =>
+      block.includes(MANAGED_LICENSE_TOKEN) ||
+      LICENSE_GATING_LANGUAGE.test(block),
   );
 
   expect(
@@ -618,6 +751,28 @@ function expectEnvLicenseOccurrencesClassified(contents: string): void {
       envBlockHasLabel(block, SELF_HOSTED_OR_OFFLINE_LABEL),
     ),
   ).toBe(true);
+}
+
+/** Returns Markdown paragraph starts containing license literals or gating copy. */
+function markdownLicenseOccurrenceLines(lines: readonly string[]): number[] {
+  const occurrences: number[] = [];
+  let start = 0;
+  while (start < lines.length) {
+    while (start < lines.length && lines[start]?.trim() === "") start += 1;
+    if (start >= lines.length) break;
+    let end = start + 1;
+    while (end < lines.length && lines[end]?.trim() !== "") end += 1;
+    const block = lines.slice(start, end).join("\n");
+    if (
+      block.includes(MANAGED_LICENSE_TOKEN) ||
+      LICENSE_GATING_LANGUAGE.test(block)
+    ) {
+      occurrences.push(start);
+    }
+    start = end + 1;
+  }
+
+  return occurrences;
 }
 
 /** Returns the managed Markdown heading section containing both fields. */
@@ -676,9 +831,7 @@ function markdownLineHasLabeledAncestor(
 /** Asserts every README license mention has a deployment-mode heading. */
 function expectMarkdownLicenseOccurrencesClassified(markdown: string): void {
   const lines = markdown.split(/\r?\n/);
-  const licenseLines = lines.flatMap((line, index) =>
-    line.includes(MANAGED_LICENSE_TOKEN) ? [index] : [],
-  );
+  const licenseLines = markdownLicenseOccurrenceLines(lines);
 
   expect(
     licenseLines.every((index) =>
@@ -765,44 +918,230 @@ function expectAgentCoreLocalComposeContract(contents: string): void {
 
 /** Assert AgentCore deploy configuration carries only a secret reference. */
 function expectAgentCoreDeploymentConfigContract(contents: string): void {
-  expect(contents).toMatch(
-    deploymentConfigReferencePattern(MANAGED_API_KEY_SECRET_CONFIG),
-  );
+  const configuredSecretNames = contents.split(/\r?\n/).flatMap((line) => {
+    const match = line.match(
+      new RegExp(
+        `^${MANAGED_API_KEY_SECRET_CONFIG}\\s*:\\s*([^#\\s][^#]*?)\\s*(?:#.*)?$`,
+      ),
+    );
+    return match?.[1] ? [match[1].trim()] : [];
+  });
+
+  expect(configuredSecretNames).toHaveLength(1);
+  expect(configuredSecretNames[0]).not.toMatch(/^\$\{|^process\.env\b/);
   expect(contents).not.toMatch(exactEnvIdentifierPattern(MANAGED_API_KEY));
   expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
 }
 
 /** Assert AgentCore's deployed Lambda resolves the managed key from a secret. */
 function expectAgentCoreRuntimeDeploymentContract(contents: string): void {
-  expect(contents).toMatch(
-    nearbyTermsPattern(MANAGED_API_KEY, MANAGED_API_KEY_SECRET_CONFIG),
+  const sourceFile = parseManagedSource(contents);
+  const lambdaOptions = constructOptions(
+    sourceFile,
+    ["lambda", "Function"],
+    "CopilotKitRuntimeLambda",
   );
-  expect(contents).toMatch(/\b(?:SecretValue|secretsmanager|secretName)\b/i);
-  expect(contents).not.toMatch(
-    new RegExp(`${MANAGED_API_KEY}\\s*:\\s*["'\\x60]`),
-  );
+  expect(lambdaOptions).toHaveLength(1);
+  const environment = lambdaOptions[0]
+    ? objectPropertyAssignment(lambdaOptions[0], "environment")
+    : null;
+  const environmentObject = environment
+    ? unwrapExpression(environment.initializer)
+    : null;
+  expect(
+    environmentObject && ts.isObjectLiteralExpression(environmentObject),
+  ).toBe(true);
+  const managedKey =
+    environmentObject && ts.isObjectLiteralExpression(environmentObject)
+      ? objectPropertyAssignment(environmentObject, MANAGED_API_KEY)
+      : null;
+  expect(managedKey).not.toBeNull();
+  if (!managedKey) return;
+
+  expect(
+    expressionContainsPropertyPath(managedKey.initializer, [
+      "config",
+      MANAGED_API_KEY_SECRET_CONFIG,
+    ]),
+  ).toBe(true);
+  expect(expressionContainsSecretResolution(managedKey.initializer)).toBe(true);
+  expect(
+    expressionContainsEnvRead(managedKey.initializer, MANAGED_API_KEY),
+  ).toBe(false);
   expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
 }
 
 /** Assert AgentCore's frontend receives only the key-derived public gate. */
 function expectAgentCoreFrontendDeploymentContract(contents: string): void {
-  expect(contents).toMatch(
-    nearbyTermsPattern(VITE_THREADS_GATE, MANAGED_API_KEY_SECRET_CONFIG),
+  const sourceFile = parseManagedSource(contents);
+  const appOptions = constructOptions(
+    sourceFile,
+    ["amplify", "App"],
+    "AmplifyApp",
   );
+  expect(appOptions).toHaveLength(1);
+  const environmentVariables = appOptions[0]
+    ? objectPropertyAssignment(appOptions[0], "environmentVariables")
+    : null;
+  const environmentObject = environmentVariables
+    ? unwrapExpression(environmentVariables.initializer)
+    : null;
+  const managedGate =
+    environmentObject && ts.isObjectLiteralExpression(environmentObject)
+      ? objectPropertyAssignment(environmentObject, VITE_THREADS_GATE)
+      : null;
+  expect(managedGate).not.toBeNull();
+  if (!managedGate) return;
+
+  expect(isBooleanStringProjection(managedGate.initializer)).toBe(true);
+  expect(
+    expressionContainsPropertyPath(managedGate.initializer, [
+      "props",
+      "config",
+      MANAGED_API_KEY_SECRET_CONFIG,
+    ]),
+  ).toBe(true);
+  expect(
+    expressionContainsEnvRead(managedGate.initializer, MANAGED_API_KEY),
+  ).toBe(false);
   expect(contents).not.toMatch(exactEnvIdentifierPattern(MANAGED_API_KEY));
   expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
 }
 
 /** Assert an AgentCore variant deploy script safely materializes its key secret. */
 function expectAgentCoreDeployScriptContract(contents: string): void {
-  expect(contents).toContain(".env");
-  expect(contents).toMatch(exactEnvIdentifierPattern(MANAGED_API_KEY));
-  expect(contents).toContain(MANAGED_API_KEY_SECRET_CONFIG);
-  expect(contents).toMatch(
-    /aws\s+secretsmanager\s+(?:create-secret|put-secret-value)/,
+  const normalized = contents.replace(/\\\r?\n\s*/g, " ");
+  const lines = normalized.split(/\r?\n/);
+  const rootEnvLoadIndex = lines.findIndex((line) =>
+    /(?:^|\s)(?:source|\.)\s+["']?\$\{?SCRIPT_DIR\}?\/\.env["']?(?:\s|$)/.test(
+      line,
+    ),
   );
-  expect(contents).toMatch(/npx\s+cdk(?:@\S+)?\s+deploy/);
+  const secretConfigAssignment = lines
+    .map((line, index) => ({
+      index,
+      match: line.match(
+        new RegExp(`^\\s*([A-Z][A-Z0-9_]*)=.*${MANAGED_API_KEY_SECRET_CONFIG}`),
+      ),
+    }))
+    .find(({ match }) => match?.[1]);
+  const secretNameVariable = secretConfigAssignment?.match?.[1];
+  const secretCommands = lines
+    .map((line, index) => ({ index, line }))
+    .filter(({ line }) =>
+      /aws\s+secretsmanager\s+(?:create-secret|put-secret-value)\b/.test(line),
+    );
+  const cdkDeployIndex = lines.findIndex((line) =>
+    /npx\s+cdk(?:@\S+)?\s+deploy\b/.test(line),
+  );
+
+  expect(rootEnvLoadIndex).toBeGreaterThanOrEqual(0);
+  expect(secretNameVariable).toBeDefined();
+  expect(secretCommands.length).toBeGreaterThan(0);
+  expect(cdkDeployIndex).toBeGreaterThan(
+    Math.max(...secretCommands.map(({ index }) => index)),
+  );
+  for (const { line } of secretCommands) {
+    expect(line).toMatch(
+      new RegExp(
+        `--secret-string(?:=|\\s+)["']?\\$\\{?${MANAGED_API_KEY}\\}?["']?(?:\\s|$)`,
+      ),
+    );
+    expect(line).toMatch(
+      new RegExp(
+        `--(?:name|secret-id)(?:=|\\s+)["']?\\$\\{?${secretNameVariable}\\}?["']?(?:\\s|$)`,
+      ),
+    );
+  }
+  expect(rootEnvLoadIndex).toBeLessThan(secretCommands[0]!.index);
+  expect(secretConfigAssignment!.index).toBeLessThan(secretCommands[0]!.index);
   expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
+}
+
+/** Returns exact path filters for one top-level workflow event. */
+function workflowEventPaths(contents: string, eventName: string): string[] {
+  const lines = contents.split(/\r?\n/);
+  const eventStart = lines.findIndex((line) => line === `  ${eventName}:`);
+  if (eventStart < 0) return [];
+  const relativeEventEnd = lines
+    .slice(eventStart + 1)
+    .findIndex((line) => /^(?:\S| {2}\S).*:\s*$/.test(line));
+  const eventEnd =
+    relativeEventEnd < 0 ? lines.length : eventStart + relativeEventEnd + 1;
+  const eventLines = lines.slice(eventStart, eventEnd);
+  const pathsStart = eventLines.findIndex((line) => line === "    paths:");
+  if (pathsStart < 0) return [];
+
+  const paths: string[] = [];
+  for (const line of eventLines.slice(pathsStart + 1)) {
+    const match = line.match(/^      - ["']?(.+?)["']?\s*$/);
+    if (!match?.[1]) break;
+    paths.push(match[1]);
+  }
+  return paths;
+}
+
+interface WorkflowStep {
+  readonly name: string;
+  readonly run: string;
+}
+
+/** Returns named workflow steps with their complete run scripts. */
+function workflowSteps(contents: string): WorkflowStep[] {
+  const lines = contents.split(/\r?\n/);
+  const stepStarts = lines.flatMap((line, index) =>
+    /^      - name:\s*/.test(line) ? [index] : [],
+  );
+
+  return stepStarts.map((start, position) => {
+    const end = stepStarts[position + 1] ?? lines.length;
+    const stepLines = lines.slice(start, end);
+    const name = stepLines[0]!
+      .replace(/^      - name:\s*/, "")
+      .replace(/^["']|["']$/g, "");
+    const runStart = stepLines.findIndex((line) =>
+      line.startsWith("        run:"),
+    );
+    const run =
+      runStart < 0
+        ? ""
+        : stepLines
+            .slice(runStart)
+            .join("\n")
+            .replace(/^\s*run:\s*[|>-]?\s*/m, "")
+            .trim();
+    return { name, run };
+  });
+}
+
+/** Assert the parity workflow preserves filters and runs red contracts second. */
+function expectIntegrationParityWorkflowContract(contents: string): void {
+  const expectedPaths = [
+    "examples/integrations/**",
+    "scripts/__tests__/integration-intelligence-migration.test.ts",
+    ".github/workflows/integrations_parity.yml",
+  ];
+  expect(workflowEventPaths(contents, "pull_request")).toEqual(expectedPaths);
+  expect(workflowEventPaths(contents, "push")).toEqual(expectedPaths);
+
+  const steps = workflowSteps(contents);
+  const parityIndex = steps.findIndex(
+    ({ name }) => name === "Verify integration-demo parity",
+  );
+  const contractIndex = steps.findIndex(
+    ({ name }) => name === "Verify managed integration credential contracts",
+  );
+  expect(parityIndex).toBeGreaterThanOrEqual(0);
+  expect(contractIndex).toBeGreaterThan(parityIndex);
+  expect(steps[parityIndex]?.run).toContain("pnpm parity:check");
+  expect(steps[contractIndex]?.run).toContain(
+    "pnpm exec vitest run scripts/__tests__/integration-intelligence-migration.test.ts",
+  );
+}
+
+/** Renders an exact workflow path-filter list for helper self-tests. */
+function renderWorkflowPaths(values: readonly string[]): string {
+  return values.map((value) => `      - "${value}"`).join("\n");
 }
 
 test("managed TypeScript helpers reject API-key identifiers outside configured expressions", () => {
@@ -853,6 +1192,130 @@ test("managed TypeScript helpers reject decoy configured properties", () => {
   expect(() => expectManagedRuntimeContract(decoyRuntimeRead)).toThrow();
   expect(() => expectManagedGateContract(decoyNextGateRead)).toThrow();
   expect(() => expectManagedGateContract(decoyViteGateRead)).toThrow();
+});
+
+test("managed gate helpers reject direct, concatenated, comment-only, and decoy key exposure", () => {
+  const invalidGateSources = [
+    `export default { env: { ${NEXT_THREADS_GATE}: process.env.${MANAGED_API_KEY} } };`,
+    `export default { env: { ${NEXT_THREADS_GATE}: "enabled-" + process.env.${MANAGED_API_KEY} } };`,
+    `
+      // ${NEXT_THREADS_GATE}: process.env.${MANAGED_API_KEY} ? "true" : "false"
+      export default { env: { ${NEXT_THREADS_GATE}: "false" } };
+    `,
+    `
+      const decoy = process.env.${MANAGED_API_KEY} ? "true" : "false";
+      export default { env: { ${NEXT_THREADS_GATE}: "false" } };
+    `,
+  ];
+
+  for (const source of invalidGateSources) {
+    expect(() => expectManagedGateContract(source)).toThrow();
+  }
+});
+
+test("managed gate helpers accept normalized Next and Vite boolean projections", () => {
+  const nextGate = `
+    export default {
+      env: {
+        ${NEXT_THREADS_GATE}: process.env.${MANAGED_API_KEY}
+          ? "true"
+          : "false",
+      },
+    };
+  `;
+  const viteGateWithOverride = `
+    export default defineConfig({
+      define: {
+        "import.meta.env.${VITE_THREADS_GATE}": JSON.stringify(
+          process.env.${VITE_THREADS_GATE} === "true"
+            ? "true"
+            : process.env.${MANAGED_API_KEY}
+              ? "true"
+              : "false",
+        ),
+      },
+    });
+  `;
+
+  expect(() => expectManagedGateContract(nextGate)).not.toThrow();
+  expect(() => expectManagedGateContract(viteGateWithOverride)).not.toThrow();
+});
+
+test("AgentCore structural helpers accept linked root-env, secret, Lambda, and frontend wiring", () => {
+  const deploymentConfig = `${MANAGED_API_KEY_SECRET_CONFIG}: cpk-managed-key`;
+  const runtimeDeployment = `
+    new lambda.Function(this, "CopilotKitRuntimeLambda", {
+      environment: {
+        ${MANAGED_API_KEY}: cdk.SecretValue.secretsManager(
+          config.${MANAGED_API_KEY_SECRET_CONFIG},
+        ).unsafeUnwrap(),
+      },
+    });
+  `;
+  const frontendDeployment = `
+    new amplify.App(this, "AmplifyApp", {
+      environmentVariables: {
+        ${VITE_THREADS_GATE}: props.config.${MANAGED_API_KEY_SECRET_CONFIG}
+          ? "true"
+          : "false",
+      },
+    });
+  `;
+  const deployScript = `
+    source "$SCRIPT_DIR/.env"
+    CPK_SECRET_NAME=$(read_config ${MANAGED_API_KEY_SECRET_CONFIG})
+    aws secretsmanager create-secret --name "$CPK_SECRET_NAME" --secret-string "$${MANAGED_API_KEY}"
+    npx cdk deploy --all
+  `;
+
+  expect(() =>
+    expectAgentCoreDeploymentConfigContract(deploymentConfig),
+  ).not.toThrow();
+  expect(() =>
+    expectAgentCoreRuntimeDeploymentContract(runtimeDeployment),
+  ).not.toThrow();
+  expect(() =>
+    expectAgentCoreFrontendDeploymentContract(frontendDeployment),
+  ).not.toThrow();
+  expect(() => expectAgentCoreDeployScriptContract(deployScript)).not.toThrow();
+});
+
+test("AgentCore structural helpers reject comment, unrelated-secret, and disconnected-command decoys", () => {
+  const runtimeDecoy = `
+    // ${MANAGED_API_KEY} uses config.${MANAGED_API_KEY_SECRET_CONFIG}
+    const unrelated = cdk.SecretValue.secretsManager("other-secret");
+    new lambda.Function(this, "CopilotKitRuntimeLambda", {
+      environment: { ${MANAGED_API_KEY}: "literal-key" },
+    });
+  `;
+  const frontendDecoy = `
+    // ${VITE_THREADS_GATE} follows props.config.${MANAGED_API_KEY_SECRET_CONFIG}
+    new amplify.App(this, "AmplifyApp", {
+      environmentVariables: { ${VITE_THREADS_GATE}: "enabled" },
+    });
+  `;
+  const deployScriptDecoy = `
+    # source "$SCRIPT_DIR/.env"
+    CPK_SECRET_NAME=$(read_config ${MANAGED_API_KEY_SECRET_CONFIG})
+    echo "$${MANAGED_API_KEY}"
+    aws secretsmanager create-secret --name unrelated --secret-string literal
+    npx cdk deploy --all
+  `;
+
+  expect(() =>
+    expectAgentCoreRuntimeDeploymentContract(runtimeDecoy),
+  ).toThrow();
+  expect(() =>
+    expectAgentCoreFrontendDeploymentContract(frontendDecoy),
+  ).toThrow();
+  expect(() =>
+    expectAgentCoreDeployScriptContract(deployScriptDecoy),
+  ).toThrow();
+  expect(() =>
+    expectAgentCoreDeploymentConfigContract(
+      `${MANAGED_API_KEY_SECRET_CONFIG}: \${${MANAGED_API_KEY}}`,
+    ),
+  ).toThrow();
 });
 
 test("managed TypeScript helpers reject malformed source", () => {
@@ -1091,6 +1554,93 @@ test("managed documentation helpers allow separate self-hosted and offline licen
 
   expect(() => expectManagedEnvContract(envExample)).not.toThrow();
   expect(() => expectManagedReadmeContract(readme)).not.toThrow();
+});
+
+test("managed documentation helpers reject unlabeled generic license-gating copy without an env literal", () => {
+  const envExample = `
+    # Managed Intelligence credentials
+    CPK_INTELLIGENCE_API_KEY=
+    # Optional, non-secret analytics identity
+    CPK_TELEMETRY_ID=
+
+    # Product capabilities
+    # A license unlocks Threads and enables Inspector.
+  `;
+  const readme = [
+    "## Managed Intelligence credentials",
+    "",
+    "Set CPK_INTELLIGENCE_API_KEY for the project.",
+    "CPK_TELEMETRY_ID is an optional, non-secret analytics identity.",
+    "",
+    "## Product capabilities",
+    "",
+    "A license activates Threads and unlocks Inspector.",
+  ].join("\n");
+
+  expect(() => expectManagedEnvContract(envExample)).toThrow();
+  expect(() => expectManagedReadmeContract(readme)).toThrow();
+});
+
+test("managed documentation helpers allow generic license-gating copy only in self-hosted or offline sections", () => {
+  const envExample = `
+    # Managed Intelligence credentials
+    CPK_INTELLIGENCE_API_KEY=
+    # Optional, non-secret analytics identity
+    CPK_TELEMETRY_ID=
+
+    # Self-hosted / offline license behavior
+    # A deployment license enables Threads and Inspector offline.
+  `;
+  const readme = [
+    "## Managed Intelligence credentials",
+    "",
+    "Set CPK_INTELLIGENCE_API_KEY for the project.",
+    "CPK_TELEMETRY_ID is an optional, non-secret analytics identity.",
+    "",
+    "## Self-hosted / offline license behavior",
+    "",
+    "A deployment license enables Threads and Inspector offline.",
+  ].join("\n");
+
+  expect(() => expectManagedEnvContract(envExample)).not.toThrow();
+  expect(() => expectManagedReadmeContract(readme)).not.toThrow();
+});
+
+test("integration parity workflow preserves filters and runs parity before the expected-red managed contract", () => {
+  const workflow = fs.readFileSync(INTEGRATION_PARITY_WORKFLOW, "utf8");
+
+  expectIntegrationParityWorkflowContract(workflow);
+});
+
+test("integration parity workflow helper rejects missing filters and reversed contract order", () => {
+  const paths = [
+    "examples/integrations/**",
+    "scripts/__tests__/integration-intelligence-migration.test.ts",
+    ".github/workflows/integrations_parity.yml",
+  ];
+  const workflow = (eventPaths: readonly string[], reversed: boolean) => `
+on:
+  pull_request:
+    paths:
+${renderWorkflowPaths(eventPaths)}
+  push:
+    paths:
+${renderWorkflowPaths(paths)}
+jobs:
+  parity-check:
+    steps:
+      - name: ${reversed ? "Verify managed integration credential contracts" : "Verify integration-demo parity"}
+        run: ${reversed ? "pnpm exec vitest run scripts/__tests__/integration-intelligence-migration.test.ts" : "pnpm parity:check"}
+      - name: ${reversed ? "Verify integration-demo parity" : "Verify managed integration credential contracts"}
+        run: ${reversed ? "pnpm parity:check" : "pnpm exec vitest run scripts/__tests__/integration-intelligence-migration.test.ts"}
+`;
+
+  expect(() =>
+    expectIntegrationParityWorkflowContract(workflow(paths, true)),
+  ).toThrow();
+  expect(() =>
+    expectIntegrationParityWorkflowContract(workflow(paths.slice(0, 2), false)),
+  ).toThrow();
 });
 
 test("the 16 managed template directories back all 19 in-repo CLI frameworks", () => {

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -14,6 +14,8 @@ const LEGACY_TELEMETRY_ID = "COPILOTKIT_TELEMETRY_ID";
 const MANAGED_LICENSE_TOKEN = "COPILOTKIT_LICENSE_TOKEN";
 const MANAGED_API_KEY_SECRET_CONFIG =
   "copilotkit_intelligence_api_key_secret_name";
+const INTELLIGENCE_API_URL = "INTELLIGENCE_API_URL";
+const INTELLIGENCE_GATEWAY_WS_URL = "INTELLIGENCE_GATEWAY_WS_URL";
 const NEXT_THREADS_GATE = "NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED";
 const VITE_THREADS_GATE = "VITE_COPILOTKIT_THREADS_ENABLED";
 const MANAGED_DOCUMENTATION_LABEL = /\bmanaged\b/i;
@@ -82,6 +84,8 @@ interface ManagedTemplateContract {
     readonly deploymentConfigPath: string;
     readonly runtimeDeploymentPath: string;
     readonly frontendDeploymentPath: string;
+    readonly terraformRuntimeDeploymentPath: string;
+    readonly terraformReadmePath: string;
     readonly deployScriptPaths: readonly string[];
   };
 }
@@ -336,6 +340,9 @@ const MANAGED_TEMPLATE_CONTRACTS = [
       deploymentConfigPath: "config.yaml.example",
       runtimeDeploymentPath: "infra-cdk/lib/backend-stack.ts",
       frontendDeploymentPath: "infra-cdk/lib/amplify-hosting-stack.ts",
+      terraformRuntimeDeploymentPath:
+        "infra-terraform/modules/backend/copilotkit_runtime.tf",
+      terraformReadmePath: "infra-terraform/README.md",
       deployScriptPaths: ["deploy-langgraph.sh", "deploy-strands.sh"],
     },
   },
@@ -1938,6 +1945,12 @@ function expectAgentCoreLocalComposeContract(contents: string): void {
   expect(frontend).toMatch(rootManagedEnvFilePattern());
   expect(frontend).not.toContain(VITE_THREADS_GATE);
   expect(frontend).not.toContain(OPTIONAL_TELEMETRY_ID);
+  expect(bridge).not.toMatch(
+    new RegExp(`^\\s*-\\s*${INTELLIGENCE_API_URL}=`, "m"),
+  );
+  expect(bridge).not.toMatch(
+    new RegExp(`^\\s*-\\s*${INTELLIGENCE_GATEWAY_WS_URL}=`, "m"),
+  );
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_API_KEY));
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_TELEMETRY_ID));
   expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
@@ -1986,9 +1999,19 @@ function expectAgentCoreRuntimeDeploymentContract(contents: string): void {
     environmentObject && ts.isObjectLiteralExpression(environmentObject)
       ? objectPropertyAssignment(environmentObject, OPTIONAL_TELEMETRY_ID)
       : null;
+  const apiUrl =
+    environmentObject && ts.isObjectLiteralExpression(environmentObject)
+      ? objectPropertyAssignment(environmentObject, INTELLIGENCE_API_URL)
+      : null;
+  const gatewayWsUrl =
+    environmentObject && ts.isObjectLiteralExpression(environmentObject)
+      ? objectPropertyAssignment(environmentObject, INTELLIGENCE_GATEWAY_WS_URL)
+      : null;
   expect(managedKey).not.toBeNull();
   expect(telemetryId).not.toBeNull();
-  if (!managedKey || !telemetryId) return;
+  expect(apiUrl).not.toBeNull();
+  expect(gatewayWsUrl).not.toBeNull();
+  if (!managedKey || !telemetryId || !apiUrl || !gatewayWsUrl) return;
 
   expect(
     expressionContainsPropertyPath(managedKey.initializer, [
@@ -2006,7 +2029,31 @@ function expectAgentCoreRuntimeDeploymentContract(contents: string): void {
   expect(expressionContainsSecretResolution(telemetryId.initializer)).toBe(
     false,
   );
+  expect(
+    expressionContainsEnvRead(apiUrl.initializer, INTELLIGENCE_API_URL),
+  ).toBe(true);
+  expect(
+    expressionContainsEnvRead(
+      gatewayWsUrl.initializer,
+      INTELLIGENCE_GATEWAY_WS_URL,
+    ),
+  ).toBe(true);
   expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
+}
+
+/** Assert Terraform clearly excludes the managed Intelligence credential path. */
+function expectAgentCoreTerraformExclusionContract(
+  runtimeDeployment: string,
+  readme: string,
+): void {
+  expect(runtimeDeployment).not.toMatch(
+    exactEnvIdentifierPattern(MANAGED_API_KEY),
+  );
+  expect(runtimeDeployment).not.toMatch(
+    exactEnvIdentifierPattern(OPTIONAL_TELEMETRY_ID),
+  );
+  expect(readme).toMatch(/does not project managed Intelligence credentials/i);
+  expect(readme).toMatch(/use the CDK deployment path/i);
 }
 
 /** Assert AgentCore's frontend receives only the key-derived public gate. */
@@ -2336,6 +2383,8 @@ test("AgentCore structural helpers accept linked root-env, secret, Lambda, and f
           config.${MANAGED_API_KEY_SECRET_CONFIG},
         ).unsafeUnwrap(),
         ${OPTIONAL_TELEMETRY_ID}: process.env.${OPTIONAL_TELEMETRY_ID} ?? "",
+        ${INTELLIGENCE_API_URL}: process.env.${INTELLIGENCE_API_URL} ?? "http://localhost:4201",
+        ${INTELLIGENCE_GATEWAY_WS_URL}: process.env.${INTELLIGENCE_GATEWAY_WS_URL} ?? "ws://localhost:4401",
       },
     });
   `;
@@ -2448,6 +2497,25 @@ test("AgentCore structural helpers reject comment, unrelated-secret, and disconn
     expectAgentCoreDeploymentConfigContract(
       `${MANAGED_API_KEY_SECRET_CONFIG}: \${${MANAGED_API_KEY}}`,
     ),
+  ).toThrow();
+});
+
+test("AgentCore deployment helper rejects endpoint literals disconnected from the root env", () => {
+  const runtimeDeployment = `
+    new lambda.Function(this, "CopilotKitRuntimeLambda", {
+      environment: {
+        ${MANAGED_API_KEY}: cdk.SecretValue.secretsManager(
+          config.${MANAGED_API_KEY_SECRET_CONFIG},
+        ).unsafeUnwrap(),
+        ${OPTIONAL_TELEMETRY_ID}: process.env.${OPTIONAL_TELEMETRY_ID} ?? "",
+        ${INTELLIGENCE_API_URL}: "https://hard-coded.example",
+        ${INTELLIGENCE_GATEWAY_WS_URL}: "wss://hard-coded.example",
+      },
+    });
+  `;
+
+  expect(() =>
+    expectAgentCoreRuntimeDeploymentContract(runtimeDeployment),
   ).toThrow();
 });
 
@@ -3167,6 +3235,24 @@ for (const contract of MANAGED_TEMPLATE_CONTRACTS) {
       );
 
       expectAgentCoreFrontendDeploymentContract(frontendDeployment);
+    });
+
+    test(`${contract.directory} explicitly excludes managed credentials from Terraform`, () => {
+      const terraformRuntimeDeployment = readManagedSurface(
+        contract,
+        supportedPaths.terraformRuntimeDeploymentPath,
+        "Terraform runtime deployment",
+      );
+      const terraformReadme = readManagedSurface(
+        contract,
+        supportedPaths.terraformReadmePath,
+        "Terraform README",
+      );
+
+      expectAgentCoreTerraformExclusionContract(
+        terraformRuntimeDeployment,
+        terraformReadme,
+      );
     });
 
     test(`${contract.directory} deploy scripts materialize the configured managed key secret`, () => {

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -1923,11 +1923,14 @@ function expectAgentCoreRuntimeBehavior(contents: string): void {
   expect(objectPropertyExpression(localOptions, "intelligence")).toBeNull();
   const localRunner = objectPropertyExpression(localOptions, "runner");
   expect(localRunner).not.toBeNull();
+  const unwrappedLocalRunner = localRunner
+    ? unwrapExpression(localRunner)
+    : null;
   expect(
-    localRunner &&
-      ts.isNewExpression(unwrapExpression(localRunner)) &&
-      ts.isIdentifier(unwrapExpression(localRunner).expression) &&
-      unwrapExpression(localRunner).expression.text === "AgentCoreRunner",
+    unwrappedLocalRunner &&
+      ts.isNewExpression(unwrappedLocalRunner) &&
+      ts.isIdentifier(unwrappedLocalRunner.expression) &&
+      unwrappedLocalRunner.expression.text === "AgentCoreRunner",
   ).toBe(true);
   expect(endpointCalls).toHaveLength(1);
   const endpointOptions = endpointCalls[0]?.arguments[0];

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -953,6 +953,7 @@ function expectAgentCoreLocalComposeContract(contents: string): void {
   expect(bridge).toMatch(rootManagedEnvFilePattern());
   expect(frontend).toMatch(rootManagedEnvFilePattern());
   expect(frontend).not.toContain(VITE_THREADS_GATE);
+  expect(frontend).not.toContain(OPTIONAL_TELEMETRY_ID);
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_API_KEY));
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_TELEMETRY_ID));
   expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
@@ -997,8 +998,13 @@ function expectAgentCoreRuntimeDeploymentContract(contents: string): void {
     environmentObject && ts.isObjectLiteralExpression(environmentObject)
       ? objectPropertyAssignment(environmentObject, MANAGED_API_KEY)
       : null;
+  const telemetryId =
+    environmentObject && ts.isObjectLiteralExpression(environmentObject)
+      ? objectPropertyAssignment(environmentObject, OPTIONAL_TELEMETRY_ID)
+      : null;
   expect(managedKey).not.toBeNull();
-  if (!managedKey) return;
+  expect(telemetryId).not.toBeNull();
+  if (!managedKey || !telemetryId) return;
 
   expect(
     expressionContainsPropertyPath(managedKey.initializer, [
@@ -1010,6 +1016,12 @@ function expectAgentCoreRuntimeDeploymentContract(contents: string): void {
   expect(
     expressionContainsEnvRead(managedKey.initializer, MANAGED_API_KEY),
   ).toBe(false);
+  expect(
+    expressionContainsEnvRead(telemetryId.initializer, OPTIONAL_TELEMETRY_ID),
+  ).toBe(true);
+  expect(expressionContainsSecretResolution(telemetryId.initializer)).toBe(
+    false,
+  );
   expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
 }
 
@@ -1047,6 +1059,9 @@ function expectAgentCoreFrontendDeploymentContract(contents: string): void {
     expressionContainsEnvRead(managedGate.initializer, MANAGED_API_KEY),
   ).toBe(false);
   expect(contents).not.toMatch(exactEnvIdentifierPattern(MANAGED_API_KEY));
+  expect(contents).not.toMatch(
+    exactEnvIdentifierPattern(OPTIONAL_TELEMETRY_ID),
+  );
   expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
 }
 
@@ -1076,12 +1091,16 @@ function expectAgentCoreDeployScriptContract(contents: string): void {
   const cdkDeployIndex = lines.findIndex((line) =>
     /npx\s+cdk(?:@\S+)?\s+deploy\b/.test(line),
   );
+  const telemetryExportIndex = lines.findIndex((line) =>
+    new RegExp(`^\\s*export\\s+${OPTIONAL_TELEMETRY_ID}(?:=|\\s|$)`).test(line),
+  );
 
   expect(rootEnvLoadIndex).toBeGreaterThanOrEqual(0);
   expect(secretNameVariable).toBeDefined();
   expect(secretCommands.length).toBeGreaterThan(0);
+  expect(telemetryExportIndex).toBeGreaterThan(rootEnvLoadIndex);
   expect(cdkDeployIndex).toBeGreaterThan(
-    Math.max(...secretCommands.map(({ index }) => index)),
+    Math.max(telemetryExportIndex, ...secretCommands.map(({ index }) => index)),
   );
   for (const { line } of secretCommands) {
     expect(line).toMatch(
@@ -1291,6 +1310,7 @@ test("AgentCore structural helpers accept linked root-env, secret, Lambda, and f
         ${MANAGED_API_KEY}: cdk.SecretValue.secretsManager(
           config.${MANAGED_API_KEY_SECRET_CONFIG},
         ).unsafeUnwrap(),
+        ${OPTIONAL_TELEMETRY_ID}: process.env.${OPTIONAL_TELEMETRY_ID} ?? "",
       },
     });
   `;
@@ -1305,6 +1325,7 @@ test("AgentCore structural helpers accept linked root-env, secret, Lambda, and f
   `;
   const deployScript = `
     source "$SCRIPT_DIR/.env"
+    export ${OPTIONAL_TELEMETRY_ID}
     CPK_SECRET_NAME=$(read_config ${MANAGED_API_KEY_SECRET_CONFIG})
     aws secretsmanager create-secret --name "$CPK_SECRET_NAME" --secret-string "$${MANAGED_API_KEY}"
     npx cdk deploy --all
@@ -1327,13 +1348,41 @@ test("AgentCore structural helpers reject comment, unrelated-secret, and disconn
     // ${MANAGED_API_KEY} uses config.${MANAGED_API_KEY_SECRET_CONFIG}
     const unrelated = cdk.SecretValue.secretsManager("other-secret");
     new lambda.Function(this, "CopilotKitRuntimeLambda", {
-      environment: { ${MANAGED_API_KEY}: "literal-key" },
+      environment: {
+        ${MANAGED_API_KEY}: "literal-key",
+        ${OPTIONAL_TELEMETRY_ID}: "literal-telemetry-id",
+      },
     });
   `;
   const frontendDecoy = `
     // ${VITE_THREADS_GATE} follows props.config.${MANAGED_API_KEY_SECRET_CONFIG}
     new amplify.App(this, "AmplifyApp", {
-      environmentVariables: { ${VITE_THREADS_GATE}: "enabled" },
+      environmentVariables: {
+        ${VITE_THREADS_GATE}: "enabled",
+        ${OPTIONAL_TELEMETRY_ID}: process.env.${OPTIONAL_TELEMETRY_ID},
+      },
+    });
+  `;
+  const runtimeTelemetrySecretDecoy = `
+    new lambda.Function(this, "CopilotKitRuntimeLambda", {
+      environment: {
+        ${MANAGED_API_KEY}: cdk.SecretValue.secretsManager(
+          config.${MANAGED_API_KEY_SECRET_CONFIG},
+        ).unsafeUnwrap(),
+        ${OPTIONAL_TELEMETRY_ID}: cdk.SecretValue.secretsManager(
+          config.${MANAGED_API_KEY_SECRET_CONFIG},
+        ).unsafeUnwrap(),
+      },
+    });
+  `;
+  const frontendTelemetryDecoy = `
+    new amplify.App(this, "AmplifyApp", {
+      environmentVariables: {
+        ${VITE_THREADS_GATE}: props.config.${MANAGED_API_KEY_SECRET_CONFIG}
+          ? "true"
+          : "false",
+        ${OPTIONAL_TELEMETRY_ID}: process.env.${OPTIONAL_TELEMETRY_ID},
+      },
     });
   `;
   const deployScriptDecoy = `
@@ -1342,6 +1391,14 @@ test("AgentCore structural helpers reject comment, unrelated-secret, and disconn
     echo "$${MANAGED_API_KEY}"
     aws secretsmanager create-secret --name unrelated --secret-string literal
     npx cdk deploy --all
+    export ${OPTIONAL_TELEMETRY_ID}
+  `;
+  const lateTelemetryExportDecoy = `
+    source "$SCRIPT_DIR/.env"
+    CPK_SECRET_NAME=$(read_config ${MANAGED_API_KEY_SECRET_CONFIG})
+    aws secretsmanager create-secret --name "$CPK_SECRET_NAME" --secret-string "$${MANAGED_API_KEY}"
+    npx cdk deploy --all
+    export ${OPTIONAL_TELEMETRY_ID}
   `;
 
   expect(() =>
@@ -1351,7 +1408,16 @@ test("AgentCore structural helpers reject comment, unrelated-secret, and disconn
     expectAgentCoreFrontendDeploymentContract(frontendDecoy),
   ).toThrow();
   expect(() =>
+    expectAgentCoreRuntimeDeploymentContract(runtimeTelemetrySecretDecoy),
+  ).toThrow();
+  expect(() =>
+    expectAgentCoreFrontendDeploymentContract(frontendTelemetryDecoy),
+  ).toThrow();
+  expect(() =>
     expectAgentCoreDeployScriptContract(deployScriptDecoy),
+  ).toThrow();
+  expect(() =>
+    expectAgentCoreDeployScriptContract(lateTelemetryExportDecoy),
   ).toThrow();
   expect(() =>
     expectAgentCoreDeploymentConfigContract(

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import * as vm from "node:vm";
 
 import * as ts from "typescript";
 import { expect, test } from "vitest";
@@ -8,6 +9,7 @@ const repoRoot = path.resolve(__dirname, "..", "..");
 const integrationsDir = path.join(repoRoot, "examples", "integrations");
 
 const MANAGED_API_KEY = "CPK_INTELLIGENCE_API_KEY";
+const MANAGED_API_KEY_SENTINEL = "cpk_secret_must_not_reach_browser_assets";
 const OPTIONAL_TELEMETRY_ID = "CPK_TELEMETRY_ID";
 const LEGACY_API_KEY = "INTELLIGENCE_API_KEY";
 const LEGACY_TELEMETRY_ID = "COPILOTKIT_TELEMETRY_ID";
@@ -18,6 +20,7 @@ const INTELLIGENCE_API_URL = "INTELLIGENCE_API_URL";
 const INTELLIGENCE_GATEWAY_WS_URL = "INTELLIGENCE_GATEWAY_WS_URL";
 const NEXT_THREADS_GATE = "NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED";
 const VITE_THREADS_GATE = "VITE_COPILOTKIT_THREADS_ENABLED";
+const VITE_THREADS_GATE_DEFINITION = `import.meta.env.${VITE_THREADS_GATE}`;
 const MANAGED_DOCUMENTATION_LABEL = /\bmanaged\b/i;
 const SELF_HOSTED_OR_OFFLINE_LABEL = /\b(?:self[ -]?hosted|offline)\b/i;
 const LICENSE_GATING_LANGUAGE =
@@ -87,6 +90,17 @@ interface ManagedTemplateContract {
     readonly terraformRuntimeDeploymentPath: string;
     readonly terraformReadmePath: string;
     readonly deployScriptPaths: readonly string[];
+  };
+}
+
+interface AgentCoreViteEnvironment {
+  readonly [MANAGED_API_KEY]?: string;
+  readonly [VITE_THREADS_GATE]?: string;
+}
+
+interface EvaluatedAgentCoreViteConfig {
+  readonly define?: {
+    readonly [VITE_THREADS_GATE_DEFINITION]?: string;
   };
 }
 
@@ -2090,8 +2104,10 @@ function expectAgentCoreTerraformExclusionContract(
   expect(readme).toMatch(/use the CDK deployment path/i);
 }
 
-/** Assert AgentCore's frontend receives only the key-derived public gate. */
-function expectAgentCoreFrontendDeploymentContract(contents: string): void {
+/** Returns AgentCore's Amplify public-gate initializer. */
+function agentCoreFrontendGateInitializer(
+  contents: string,
+): ts.Expression | null {
   const sourceFile = parseManagedSource(contents);
   const appOptions = constructOptions(
     sourceFile,
@@ -2109,25 +2125,154 @@ function expectAgentCoreFrontendDeploymentContract(contents: string): void {
     environmentObject && ts.isObjectLiteralExpression(environmentObject)
       ? objectPropertyAssignment(environmentObject, VITE_THREADS_GATE)
       : null;
+
+  return managedGate?.initializer ?? null;
+}
+
+/** Assert AgentCore's frontend receives only the key-derived public gate. */
+function expectAgentCoreFrontendDeploymentContract(contents: string): void {
+  const managedGate = agentCoreFrontendGateInitializer(contents);
   expect(managedGate).not.toBeNull();
   if (!managedGate) return;
 
-  expect(isBooleanStringProjection(managedGate.initializer)).toBe(true);
+  expect(isBooleanStringProjection(managedGate)).toBe(true);
   expect(
-    expressionContainsPropertyPath(managedGate.initializer, [
+    expressionContainsPropertyPath(managedGate, [
       "props",
       "config",
       MANAGED_API_KEY_SECRET_CONFIG,
     ]),
   ).toBe(true);
-  expect(
-    expressionContainsEnvRead(managedGate.initializer, MANAGED_API_KEY),
-  ).toBe(false);
+  expect(expressionContainsEnvRead(managedGate, MANAGED_API_KEY)).toBe(false);
   expect(contents).not.toMatch(exactEnvIdentifierPattern(MANAGED_API_KEY));
   expect(contents).not.toMatch(
     exactEnvIdentifierPattern(OPTIONAL_TELEMETRY_ID),
   );
   expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
+}
+
+/**
+ * Resolves the public AgentCore frontend gate emitted by the Amplify stack.
+ *
+ * @param contents - Amplify stack source.
+ * @param hasManagedSecret - Whether the managed key secret reference is configured.
+ * @returns The projected boolean string, or null for an unsupported expression.
+ */
+function agentCoreFrontendGateProjection(
+  contents: string,
+  hasManagedSecret: boolean,
+): string | null {
+  const gate = agentCoreFrontendGateInitializer(contents);
+  const initializer = gate ? unwrapExpression(gate) : null;
+  if (!initializer || !ts.isConditionalExpression(initializer)) {
+    return null;
+  }
+
+  const selected = unwrapExpression(
+    hasManagedSecret ? initializer.whenTrue : initializer.whenFalse,
+  );
+  return ts.isStringLiteral(selected) ? selected.text : null;
+}
+
+/**
+ * Executes the real AgentCore Vite config with a controlled environment.
+ *
+ * @param contents - AgentCore Vite config source.
+ * @param environment - Managed environment visible to the config process.
+ * @returns The literal replacement Vite would emit for the public gate.
+ */
+function evaluateAgentCoreViteGate(
+  contents: string,
+  environment: AgentCoreViteEnvironment,
+): string {
+  const transpiled = ts.transpileModule(contents, {
+    compilerOptions: {
+      esModuleInterop: true,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+    fileName: "agentcore-vite.config.ts",
+    reportDiagnostics: true,
+  });
+  const diagnostics =
+    transpiled.diagnostics?.filter(
+      (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
+    ) ?? [];
+  expect(diagnostics, "AgentCore Vite config must transpile").toHaveLength(0);
+
+  const evaluatedModule: {
+    exports: { default?: EvaluatedAgentCoreViteConfig };
+  } = { exports: {} };
+
+  /** Supplies only the config-time modules needed by the real Vite source. */
+  function configRequire(identifier: string): unknown {
+    if (identifier === "vite") {
+      return {
+        defineConfig: (config: EvaluatedAgentCoreViteConfig) => config,
+      };
+    }
+    if (identifier === "@vitejs/plugin-react") {
+      return {
+        __esModule: true,
+        default: () => ({ name: "react" }),
+      };
+    }
+    if (identifier === "path") {
+      return path;
+    }
+    throw new Error(`Unexpected AgentCore Vite dependency: ${identifier}`);
+  }
+
+  vm.runInNewContext(transpiled.outputText, {
+    __dirname: path.join(integrationsDir, "agentcore", "frontend"),
+    exports: evaluatedModule.exports,
+    module: evaluatedModule,
+    process: { env: environment },
+    require: configRequire,
+  });
+
+  const definition =
+    evaluatedModule.exports.default?.define?.[VITE_THREADS_GATE_DEFINITION];
+  expect(
+    definition,
+    "AgentCore Vite config must define the public gate",
+  ).toBeDefined();
+  return definition ?? "";
+}
+
+/**
+ * Applies the configured Vite replacement to a representative browser asset.
+ *
+ * @param definition - Literal public-gate replacement from the Vite config.
+ * @returns Browser asset text after Vite's configured replacement.
+ */
+function emitAgentCoreBrowserGateAsset(definition: string): string {
+  return `window.__agentCoreThreadsEnabled = ${VITE_THREADS_GATE_DEFINITION};`.replaceAll(
+    VITE_THREADS_GATE_DEFINITION,
+    definition,
+  );
+}
+
+/** Reads the linked AgentCore Vite and Amplify gate surfaces. */
+function readAgentCoreFrontendGateSurfaces(): {
+  readonly deployment: string;
+  readonly vite: string;
+} {
+  const contract = MANAGED_TEMPLATE_CONTRACTS.find(
+    ({ directory }) => directory === "agentcore",
+  );
+  if (!contract || !("supportedPaths" in contract)) {
+    throw new Error("AgentCore managed template contract is missing");
+  }
+
+  return {
+    deployment: readManagedSurface(
+      contract,
+      contract.supportedPaths.frontendDeploymentPath,
+      "frontend deployment config",
+    ),
+    vite: readManagedSurface(contract, contract.gatePath, "client gate"),
+  };
 }
 
 /** Assert an AgentCore variant deploy script safely materializes its key secret. */
@@ -2406,6 +2551,55 @@ test("managed gate helpers accept normalized Next and Vite boolean projections",
 
   expect(() => expectManagedGateContract(nextGate)).not.toThrow();
   expect(() => expectManagedGateContract(viteGateWithOverride)).not.toThrow();
+});
+
+test("AgentCore Vite honors the Amplify public gate before local key presence", () => {
+  const { deployment, vite } = readAgentCoreFrontendGateSurfaces();
+
+  expectAgentCoreFrontendDeploymentContract(deployment);
+  const enabledGate = agentCoreFrontendGateProjection(deployment, true);
+  const disabledGate = agentCoreFrontendGateProjection(deployment, false);
+  expect(enabledGate).toBe("true");
+  expect(disabledGate).toBe("false");
+  if (!enabledGate || !disabledGate) {
+    throw new Error("AgentCore Amplify gate projection is incomplete");
+  }
+
+  expect(
+    evaluateAgentCoreViteGate(vite, {
+      [VITE_THREADS_GATE]: enabledGate,
+    }),
+  ).toBe(JSON.stringify("true"));
+  expect(
+    evaluateAgentCoreViteGate(vite, {
+      [MANAGED_API_KEY]: MANAGED_API_KEY_SENTINEL,
+      [VITE_THREADS_GATE]: disabledGate,
+    }),
+  ).toBe(JSON.stringify("false"));
+});
+
+test("AgentCore Vite falls back to local managed-key presence", () => {
+  const { vite } = readAgentCoreFrontendGateSurfaces();
+
+  expect(
+    evaluateAgentCoreViteGate(vite, {
+      [MANAGED_API_KEY]: MANAGED_API_KEY_SENTINEL,
+    }),
+  ).toBe(JSON.stringify("true"));
+  expect(evaluateAgentCoreViteGate(vite, {})).toBe(JSON.stringify("false"));
+});
+
+test("AgentCore emitted browser gate omits the managed key value", () => {
+  const { vite } = readAgentCoreFrontendGateSurfaces();
+
+  const definition = evaluateAgentCoreViteGate(vite, {
+    [MANAGED_API_KEY]: MANAGED_API_KEY_SENTINEL,
+  });
+  const browserAsset = emitAgentCoreBrowserGateAsset(definition);
+
+  expect(browserAsset).toContain(JSON.stringify("true"));
+  expect(browserAsset).not.toContain(MANAGED_API_KEY_SENTINEL);
+  expect(browserAsset).not.toContain(MANAGED_API_KEY);
 });
 
 test("AgentCore structural helpers accept linked root-env, secret, Lambda, and frontend wiring", () => {

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -686,6 +686,269 @@ function constructOptions(
   return matches;
 }
 
+/** Returns every object-literal options argument for one constructor. */
+function newExpressionOptions(
+  sourceFile: ts.SourceFile,
+  constructorName: string,
+): readonly ts.ObjectLiteralExpression[] {
+  const matches: ts.ObjectLiteralExpression[] = [];
+
+  /** Visits constructor calls for exact constructor ownership. */
+  function visit(node: ts.Node): void {
+    if (
+      ts.isNewExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === constructorName
+    ) {
+      const options = node.arguments?.[0]
+        ? unwrapExpression(node.arguments[0])
+        : null;
+      if (options && ts.isObjectLiteralExpression(options)) {
+        matches.push(options);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return matches;
+}
+
+/** Returns whether source constructs one exact class. */
+function sourceContainsNewExpression(
+  sourceFile: ts.SourceFile,
+  constructorName: string,
+): boolean {
+  let found = false;
+
+  /** Visits constructor calls until the required class is found. */
+  function visit(node: ts.Node): void {
+    if (found) return;
+    if (
+      ts.isNewExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === constructorName
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return found;
+}
+
+/** Returns whether a source contains a call to one exact function or method. */
+function sourceContainsCall(
+  sourceFile: ts.SourceFile,
+  calleePath: readonly string[],
+): boolean {
+  let found = false;
+
+  /** Visits call expressions until the required callee is found. */
+  function visit(node: ts.Node): void {
+    if (found) return;
+    if (
+      ts.isCallExpression(node) &&
+      propertyAccessParts(node.expression).join(".") === calleePath.join(".")
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return found;
+}
+
+/** Returns calls to one exact function or method. */
+function sourceCalls(
+  sourceFile: ts.SourceFile,
+  calleePath: readonly string[],
+): readonly ts.CallExpression[] {
+  const matches: ts.CallExpression[] = [];
+
+  /** Visits source nodes for the required callee. */
+  function visit(node: ts.Node): void {
+    if (
+      ts.isCallExpression(node) &&
+      propertyAccessParts(node.expression).join(".") === calleePath.join(".")
+    ) {
+      matches.push(node);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return matches;
+}
+
+/** Returns whether source contains an exact environment read. */
+function sourceContainsEnvRead(
+  sourceFile: ts.SourceFile,
+  identifier: string,
+): boolean {
+  let found = false;
+
+  /** Visits source nodes for the required environment read. */
+  function visit(node: ts.Node): void {
+    if (found) return;
+    if (isProcessEnvRead(node, identifier)) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return found;
+}
+
+/** Returns the exported HTTP methods assigned to `handle(app)`. */
+function exportedEndpointHandlers(
+  sourceFile: ts.SourceFile,
+): ReadonlySet<string> {
+  const methods = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isVariableStatement(statement) ||
+      !statement.modifiers?.some(
+        (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+      )
+    ) {
+      continue;
+    }
+
+    for (const declaration of statement.declarationList.declarations) {
+      const initializer = declaration.initializer
+        ? unwrapExpression(declaration.initializer)
+        : null;
+      if (
+        ts.isIdentifier(declaration.name) &&
+        initializer &&
+        ts.isCallExpression(initializer) &&
+        ts.isIdentifier(initializer.expression) &&
+        initializer.expression.text === "handle" &&
+        initializer.arguments.length === 1 &&
+        ts.isIdentifier(initializer.arguments[0]) &&
+        initializer.arguments[0].text === "app"
+      ) {
+        methods.add(declaration.name.text);
+      }
+    }
+  }
+
+  return methods;
+}
+
+/** Returns static JSX tag text when the tag is not computed. */
+function jsxTagNameText(name: ts.JsxTagNameExpression): string | null {
+  if (ts.isIdentifier(name)) {
+    return name.text;
+  }
+  if (ts.isPropertyAccessExpression(name)) {
+    return propertyAccessParts(name).join(".");
+  }
+
+  return null;
+}
+
+/** Returns all JSX elements and self-closing elements with one tag name. */
+function jsxNodesWithTag(
+  root: ts.Node,
+  tagName: string,
+): readonly (ts.JsxElement | ts.JsxSelfClosingElement)[] {
+  const matches: (ts.JsxElement | ts.JsxSelfClosingElement)[] = [];
+
+  /** Visits JSX nodes for the exact tag name. */
+  function visit(node: ts.Node): void {
+    if (
+      ts.isJsxElement(node) &&
+      jsxTagNameText(node.openingElement.tagName) === tagName
+    ) {
+      matches.push(node);
+    } else if (
+      ts.isJsxSelfClosingElement(node) &&
+      jsxTagNameText(node.tagName) === tagName
+    ) {
+      matches.push(node);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(root);
+  return matches;
+}
+
+/** Returns the opening-like node for a JSX element. */
+function jsxOpeningLikeElement(
+  node: ts.JsxElement | ts.JsxSelfClosingElement,
+): ts.JsxOpeningLikeElement {
+  return ts.isJsxElement(node) ? node.openingElement : node;
+}
+
+/** Returns one exact JSX attribute. */
+function jsxAttribute(
+  node: ts.JsxElement | ts.JsxSelfClosingElement,
+  attributeName: string,
+): ts.JsxAttribute | null {
+  const opening = jsxOpeningLikeElement(node);
+  for (const property of opening.attributes.properties) {
+    if (
+      ts.isJsxAttribute(property) &&
+      property.name.getText() === attributeName
+    ) {
+      return property;
+    }
+  }
+
+  return null;
+}
+
+/** Returns a stable structural identity for one JSX attribute value. */
+function jsxAttributeIdentity(
+  attribute: ts.JsxAttribute | null,
+): string | null {
+  if (!attribute?.initializer) {
+    return attribute ? "true" : null;
+  }
+  if (ts.isStringLiteral(attribute.initializer)) {
+    return JSON.stringify(attribute.initializer.text);
+  }
+  if (
+    ts.isJsxExpression(attribute.initializer) &&
+    attribute.initializer.expression
+  ) {
+    return attribute.initializer.expression.getText();
+  }
+
+  return null;
+}
+
+/** Returns whether a JSX attribute is the boolean literal `false`. */
+function jsxAttributeIsFalse(attribute: ts.JsxAttribute | null): boolean {
+  return Boolean(
+    attribute?.initializer &&
+    ts.isJsxExpression(attribute.initializer) &&
+    attribute.initializer.expression?.kind === ts.SyntaxKind.FalseKeyword,
+  );
+}
+
+/** Returns whether an object property is one exact string literal. */
+function objectPropertyIsString(
+  objectLiteral: ts.ObjectLiteralExpression,
+  propertyName: string,
+  expected: string,
+): boolean {
+  const property = objectPropertyAssignment(objectLiteral, propertyName);
+  if (!property) return false;
+  const initializer = unwrapExpression(property.initializer);
+  return ts.isStringLiteral(initializer) && initializer.text === expected;
+}
+
 /**
  * Matches a documented environment assignment, including commented examples.
  *
@@ -943,6 +1206,357 @@ function expectManagedReadmeContract(contents: string): void {
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_API_KEY));
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_TELEMETRY_ID));
   expectMarkdownLicenseOccurrencesClassified(contents);
+}
+
+/** Asserts a Next/Hono runtime preserves its complete REST handler surface. */
+function expectEndpointHandlerContract(contents: string): void {
+  const handlers = exportedEndpointHandlers(parseManagedSource(contents));
+
+  expect([...handlers].sort()).toEqual(["DELETE", "GET", "PATCH", "POST"]);
+}
+
+/** Asserts a frontend preserves REST transport and shared thread ownership. */
+function expectFrontendThreadContract(
+  providerContents: string,
+  threadContents: string,
+): void {
+  const providerSource = parseManagedSource(providerContents);
+  const threadSource = parseManagedSource(threadContents);
+  const providers = [
+    ...jsxNodesWithTag(providerSource, "CopilotKit"),
+    ...jsxNodesWithTag(providerSource, "CopilotKitProvider"),
+  ];
+  const configurationProviders = jsxNodesWithTag(
+    threadSource,
+    "CopilotChatConfigurationProvider",
+  );
+  const drawers = jsxNodesWithTag(threadSource, "CopilotThreadsDrawer");
+
+  expect(providers).toHaveLength(1);
+  expect(configurationProviders).toHaveLength(1);
+  expect(drawers).toHaveLength(1);
+  if (
+    providers.length !== 1 ||
+    configurationProviders.length !== 1 ||
+    drawers.length !== 1
+  ) {
+    return;
+  }
+
+  const provider = providers[0]!;
+  const configurationProvider = configurationProviders[0]!;
+  const drawer = drawers[0]!;
+  const configuredAgent = jsxAttributeIdentity(
+    jsxAttribute(configurationProvider, "agentId"),
+  );
+  const drawerAgent = jsxAttributeIdentity(jsxAttribute(drawer, "agentId"));
+
+  expect(jsxAttribute(provider, "runtimeUrl")).not.toBeNull();
+  expect(jsxAttributeIsFalse(jsxAttribute(provider, "useSingleEndpoint"))).toBe(
+    true,
+  );
+  expect(jsxAttribute(configurationProvider, "threadId")).toBeNull();
+  expect(configuredAgent).not.toBeNull();
+  expect(drawerAgent).toBe(configuredAgent);
+  expect(
+    jsxNodesWithTag(configurationProvider, "CopilotThreadsDrawer"),
+  ).toHaveLength(1);
+
+  const configuredChatCount = [
+    "CopilotChat",
+    "CopilotSidebar",
+    "Chat",
+    "ResearchAssistant",
+  ].reduce(
+    (count, tagName) =>
+      count + jsxNodesWithTag(configurationProvider, tagName).length,
+    0,
+  );
+  expect(configuredChatCount).toBeGreaterThan(0);
+}
+
+/** Asserts MCP Apps retains its client middleware configuration. */
+function expectMcpAppsRuntimeBehavior(contents: string): void {
+  const sourceFile = parseManagedSource(contents);
+  const middlewareOptions = newExpressionOptions(
+    sourceFile,
+    "MCPAppsMiddleware",
+  );
+  const agentOptions = newExpressionOptions(sourceFile, "BuiltInAgent");
+
+  expect(middlewareOptions).toHaveLength(1);
+  expect(agentOptions).toHaveLength(1);
+  expect(sourceContainsCall(sourceFile, ["agent", "use"])).toBe(true);
+  if (middlewareOptions.length !== 1) return;
+
+  const serversProperty = objectPropertyAssignment(
+    middlewareOptions[0]!,
+    "mcpServers",
+  );
+  const servers = serversProperty
+    ? unwrapExpression(serversProperty.initializer)
+    : null;
+  expect(servers && ts.isArrayLiteralExpression(servers)).toBe(true);
+  if (!servers || !ts.isArrayLiteralExpression(servers)) return;
+
+  const configuredServers = servers.elements.filter(
+    ts.isObjectLiteralExpression,
+  );
+  expect(configuredServers).toHaveLength(1);
+  if (configuredServers.length !== 1) return;
+  expect(objectPropertyIsString(configuredServers[0]!, "type", "http")).toBe(
+    true,
+  );
+  expect(
+    objectPropertyIsString(configuredServers[0]!, "serverId", "threejs"),
+  ).toBe(true);
+  expect(
+    objectPropertyIsString(
+      configuredServers[0]!,
+      "url",
+      "http://localhost:3108/mcp",
+    ),
+  ).toBe(true);
+}
+
+/** Asserts the bundled MCP server retains its tools and UI resource. */
+function expectMcpServerBehavior(
+  serverContents: string,
+  transportContents: string,
+): void {
+  const serverSource = parseManagedSource(serverContents);
+  const transportSource = parseManagedSource(transportContents);
+  const appToolCalls = sourceCalls(serverSource, ["registerAppTool"]);
+  const toolCalls = sourceCalls(serverSource, ["server", "registerTool"]);
+  const resourceCalls = sourceCalls(serverSource, ["registerAppResource"]);
+  const routeCalls = sourceCalls(transportSource, ["app", "all"]);
+
+  expect(appToolCalls).toHaveLength(1);
+  expect(toolCalls).toHaveLength(1);
+  expect(resourceCalls).toHaveLength(1);
+  expect(routeCalls).toHaveLength(1);
+  expect(appToolCalls[0]?.arguments[1]).toMatchObject({
+    text: "show_threejs_scene",
+  });
+  expect(toolCalls[0]?.arguments[0]).toMatchObject({ text: "learn_threejs" });
+  expect(sourceContainsCall(serverSource, ["startServer"])).toBe(true);
+  expect(sourceContainsCall(transportSource, ["server", "connect"])).toBe(true);
+  expect(
+    sourceContainsCall(transportSource, ["transport", "handleRequest"]),
+  ).toBe(true);
+  expect(routeCalls[0]?.arguments[0]).toMatchObject({ text: "/mcp" });
+
+  const resourceArgument = resourceCalls[0]?.arguments[1];
+  expect(resourceArgument && ts.isIdentifier(resourceArgument)).toBe(true);
+  expect(serverContents).toContain(
+    'const resourceUri = "ui://threejs/mcp-app.html"',
+  );
+}
+
+/** Returns whether source declares one class extending the expected base. */
+function sourceContainsClassExtension(
+  sourceFile: ts.SourceFile,
+  className: string,
+  baseName: string,
+): boolean {
+  let found = false;
+
+  /** Visits class declarations for the exact inheritance edge. */
+  function visit(node: ts.Node): void {
+    if (found) return;
+    if (
+      ts.isClassDeclaration(node) &&
+      node.name?.text === className &&
+      node.heritageClauses?.some(
+        (clause) =>
+          clause.token === ts.SyntaxKind.ExtendsKeyword &&
+          clause.types.some(
+            (type) =>
+              ts.isIdentifier(type.expression) &&
+              type.expression.text === baseName,
+          ),
+      )
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return found;
+}
+
+/** Asserts A2A retains isolated multi-agent routing and URL ownership. */
+function expectA2ARuntimeBehavior(contents: string): void {
+  const sourceFile = parseManagedSource(contents);
+  const runtimeOptions = newExpressionOptions(
+    sourceFile,
+    "RuntimeA2AMiddlewareAgent",
+  ).find((options) => objectPropertyAssignment(options, "agentUrls"));
+
+  expect(
+    sourceContainsClassExtension(
+      sourceFile,
+      "RuntimeA2AMiddlewareAgent",
+      "A2AMiddlewareAgent",
+    ),
+  ).toBe(true);
+  expect(newExpressionOptions(sourceFile, "A2AMiddlewareAgent")).toHaveLength(
+    1,
+  );
+  expect(
+    newExpressionOptions(sourceFile, "HttpAgent").length,
+  ).toBeGreaterThanOrEqual(2);
+  expect(sourceContainsCall(sourceFile, ["isolatedAgent", "setMessages"])).toBe(
+    true,
+  );
+  expect(sourceContainsCall(sourceFile, ["isolatedAgent", "runAgent"])).toBe(
+    true,
+  );
+  for (const identifier of [
+    "RESEARCH_AGENT_URL",
+    "ANALYSIS_AGENT_URL",
+    "ORCHESTRATOR_URL",
+  ]) {
+    expect(sourceContainsEnvRead(sourceFile, identifier)).toBe(true);
+  }
+
+  expect(runtimeOptions).toBeDefined();
+  if (!runtimeOptions) return;
+  expect(objectPropertyIsString(runtimeOptions, "agentId", "a2a_chat")).toBe(
+    true,
+  );
+  const agentUrls = objectPropertyAssignment(runtimeOptions, "agentUrls");
+  const orchestrationAgentUrl = objectPropertyAssignment(
+    runtimeOptions,
+    "orchestrationAgentUrl",
+  );
+  expect(agentUrls?.initializer.getText()).toBe(
+    "[researchAgentUrl, analysisAgentUrl]",
+  );
+  expect(orchestrationAgentUrl?.initializer.getText()).toBe("orchestratorUrl");
+}
+
+/** Asserts A2A visualization stays registered inside the configured chat. */
+function expectA2AVisualizationBehavior(contents: string): void {
+  const sourceFile = parseManagedSource(contents);
+  const toolCalls = sourceCalls(sourceFile, ["useFrontendTool"]);
+  const visualizationTool = toolCalls.find((call) => {
+    const options = call.arguments[0]
+      ? unwrapExpression(call.arguments[0])
+      : null;
+    return (
+      options &&
+      ts.isObjectLiteralExpression(options) &&
+      objectPropertyIsString(options, "name", "send_message_to_a2a_agent")
+    );
+  });
+
+  expect(visualizationTool).toBeDefined();
+  expect(jsxNodesWithTag(sourceFile, "MessageToA2A")).toHaveLength(1);
+  expect(jsxNodesWithTag(sourceFile, "MessageFromA2A")).toHaveLength(1);
+  expect(jsxNodesWithTag(sourceFile, "CopilotChat")).toHaveLength(1);
+  expect(jsxNodesWithTag(sourceFile, "CopilotKit")).toHaveLength(0);
+  expect(jsxNodesWithTag(sourceFile, "CopilotKitProvider")).toHaveLength(0);
+}
+
+/** Asserts AgentCore retains its custom runner and bridge endpoint behavior. */
+function expectAgentCoreRuntimeBehavior(contents: string): void {
+  const sourceFile = parseManagedSource(contents);
+  const endpointCalls = sourceCalls(sourceFile, ["createCopilotEndpoint"]);
+  const requiredAgentUrl = sourceCalls(sourceFile, ["requireEnv"]).some(
+    (call) =>
+      call.arguments[0] &&
+      ts.isStringLiteral(call.arguments[0]) &&
+      call.arguments[0].text === "AGENTCORE_AG_UI_URL",
+  );
+
+  expect(
+    sourceContainsClassExtension(
+      sourceFile,
+      "AgentCoreRunner",
+      "InMemoryAgentRunner",
+    ),
+  ).toBe(true);
+  expect(requiredAgentUrl).toBe(true);
+  expect(newExpressionOptions(sourceFile, "HttpAgent")).toHaveLength(1);
+  expect(newExpressionOptions(sourceFile, "MCPAppsMiddleware")).toHaveLength(1);
+  expect(sourceContainsNewExpression(sourceFile, "AgentCoreRunner")).toBe(true);
+  expect(endpointCalls).toHaveLength(1);
+  const endpointOptions = endpointCalls[0]?.arguments[0];
+  const unwrappedOptions = endpointOptions
+    ? unwrapExpression(endpointOptions)
+    : null;
+  expect(
+    unwrappedOptions && ts.isObjectLiteralExpression(unwrappedOptions),
+  ).toBe(true);
+  if (!unwrappedOptions || !ts.isObjectLiteralExpression(unwrappedOptions)) {
+    return;
+  }
+  expect(
+    objectPropertyIsString(unwrappedOptions, "basePath", "/copilotkit"),
+  ).toBe(true);
+}
+
+/** Asserts AgentCore local services retain bridge routing and one network. */
+function expectAgentCoreNetworkingBehavior(contents: string): void {
+  const agent = yamlMappingSection(contents, "agent");
+  const bridge = yamlMappingSection(contents, "bridge");
+  const frontend = yamlMappingSection(contents, "frontend");
+
+  expect(agent).toMatch(/networks:\s*\n\s*- agentcore-network/);
+  expect(bridge).toContain("AGENTCORE_AG_UI_URL=http://agent:8080/invocations");
+  expect(bridge).toMatch(
+    /depends_on:\s*\n\s*agent:\s*\n\s*condition: service_healthy/,
+  );
+  expect(bridge).toMatch(/networks:\s*\n\s*- agentcore-network/);
+  expect(frontend).toMatch(
+    /depends_on:\s*\n\s*bridge:\s*\n\s*condition: service_started/,
+  );
+  expect(frontend).toMatch(/networks:\s*\n\s*- agentcore-network/);
+  expect(contents).toMatch(
+    /^networks:\s*\n\s*agentcore-network:\s*\n\s*driver: bridge\s*$/m,
+  );
+}
+
+/** Asserts an AgentCore deploy script preserves one framework variant. */
+function expectAgentCoreVariantBehavior(
+  contents: string,
+  pattern: string,
+  suffix: string,
+): void {
+  expect(contents).toMatch(new RegExp(`^PATTERN="${pattern}"$`, "m"));
+  expect(contents).toMatch(new RegExp(`^SUFFIX="${suffix}"$`, "m"));
+  expect(contents).toMatch(/^CONFIG="\$SCRIPT_DIR\/config\.yaml"$/m);
+  expect(contents).toMatch(
+    /npx cdk@latest deploy --all --require-approval never/,
+  );
+  expect(contents).toMatch(
+    /python3 scripts\/deploy-frontend\.py "\$STACK_NAME"/,
+  );
+}
+
+/** Returns the provider and thread-owning frontend surfaces for a template. */
+function frontendBehaviorPaths(contract: ManagedTemplateContract): {
+  readonly providerPath: string;
+  readonly threadPath: string;
+} {
+  if (contract.directory === "agentcore") {
+    const chatPath = "frontend/src/components/chat/CopilotKit/index.tsx";
+    return { providerPath: chatPath, threadPath: chatPath };
+  }
+  if (contract.directory === "a2a-middleware") {
+    return { providerPath: "app/page.tsx", threadPath: "app/page.tsx" };
+  }
+  if (contract.directory === "mcp-apps") {
+    return { providerPath: "app/layout.tsx", threadPath: "app/page.tsx" };
+  }
+
+  return {
+    providerPath: "src/app/layout.tsx",
+    threadPath: "src/app/page.tsx",
+  };
 }
 
 /** Assert AgentCore local services consume the CLI-managed root env safely. */
@@ -1721,6 +2335,76 @@ test("managed documentation helpers allow generic license-gating copy only in se
   expect(() => expectManagedReadmeContract(readme)).not.toThrow();
 });
 
+test("route preservation helper rejects an incomplete handler export set", () => {
+  const route = `
+    const app = createCopilotEndpoint({ runtime, basePath: "/api/copilotkit" });
+    export const GET = handle(app);
+    export const POST = handle(app);
+    export const PATCH = handle(app);
+  `;
+
+  expect(() => expectEndpointHandlerContract(route)).toThrow();
+});
+
+test("frontend preservation helper rejects controlled thread state and single-endpoint transport", () => {
+  const frontend = `
+    export function App() {
+      return (
+        <CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={true}>
+          <CopilotChatConfigurationProvider agentId="default" threadId="thread-1">
+            <CopilotThreadsDrawer agentId="default" />
+            <CopilotChat />
+          </CopilotChatConfigurationProvider>
+        </CopilotKit>
+      );
+    }
+  `;
+
+  expect(() => expectFrontendThreadContract(frontend, frontend)).toThrow();
+});
+
+test("MCP preservation helper rejects a middleware-only scaffold without server behavior", () => {
+  const server = `
+    export function createServer() {
+      return new McpServer({ name: "Three.js Server", version: "1.0.0" });
+    }
+  `;
+  const transport = `
+    export function startServer() {
+      const app = createMcpExpressApp();
+      app.all("/mcp", () => undefined);
+    }
+  `;
+
+  expect(() => expectMcpServerBehavior(server, transport)).toThrow();
+});
+
+test("A2A preservation helper rejects collapsed single-agent routing", () => {
+  const route = `
+    const agent = new RuntimeA2AMiddlewareAgent({
+      agentId: "a2a_chat",
+      agentUrls: [],
+      orchestrationAgentUrl: "http://localhost:9000",
+    });
+  `;
+
+  expect(() => expectA2ARuntimeBehavior(route)).toThrow();
+});
+
+test("AgentCore preservation helper rejects disconnected local services", () => {
+  const compose = `
+services:
+  agent:
+    image: agent
+  bridge:
+    image: bridge
+  frontend:
+    image: frontend
+`;
+
+  expect(() => expectAgentCoreNetworkingBehavior(compose)).toThrow();
+});
+
 test("integration parity workflow preserves filters and runs parity before the expected-red managed contract", () => {
   const workflow = fs.readFileSync(INTEGRATION_PARITY_WORKFLOW, "utf8");
 
@@ -1769,6 +2453,34 @@ test("the 16 managed template directories back all 19 in-repo CLI frameworks", (
 });
 
 for (const contract of MANAGED_TEMPLATE_CONTRACTS) {
+  if (contract.directory !== "agentcore") {
+    test(`${contract.directory} runtime preserves all REST endpoint handlers`, () => {
+      const runtime = readManagedSurface(
+        contract,
+        contract.runtimePath,
+        "runtime",
+      );
+
+      expectEndpointHandlerContract(runtime);
+    });
+  }
+
+  test(`${contract.directory} frontend preserves REST transport and shared thread context`, () => {
+    const frontendPaths = frontendBehaviorPaths(contract);
+    const provider = readManagedSurface(
+      contract,
+      frontendPaths.providerPath,
+      "frontend provider",
+    );
+    const threadSurface = readManagedSurface(
+      contract,
+      frontendPaths.threadPath,
+      "thread surface",
+    );
+
+    expectFrontendThreadContract(provider, threadSurface);
+  });
+
   test(`${contract.directory} runtime uses the managed Intelligence API key`, () => {
     const runtime = readManagedSurface(
       contract,
@@ -1801,8 +2513,115 @@ for (const contract of MANAGED_TEMPLATE_CONTRACTS) {
     expectManagedReadmeContract(readme);
   });
 
+  if (contract.directory === "mcp-apps") {
+    test("mcp-apps runtime preserves its MCP Apps client middleware", () => {
+      const runtime = readManagedSurface(
+        contract,
+        contract.runtimePath,
+        "runtime",
+      );
+
+      expectMcpAppsRuntimeBehavior(runtime);
+    });
+
+    test("mcp-apps preserves its streamable HTTP tools and UI resource server", () => {
+      const server = readManagedSurface(
+        contract,
+        "threejs-server/server.ts",
+        "MCP server",
+      );
+      const transport = readManagedSurface(
+        contract,
+        "threejs-server/server-utils.ts",
+        "MCP transport",
+      );
+
+      expectMcpServerBehavior(server, transport);
+    });
+  }
+
+  if (contract.directory === "a2a-middleware") {
+    test("a2a-middleware preserves isolated multi-agent routing", () => {
+      const runtime = readManagedSurface(
+        contract,
+        contract.runtimePath,
+        "runtime",
+      );
+
+      expectA2ARuntimeBehavior(runtime);
+    });
+
+    test("a2a-middleware preserves its configured chat visualization tool", () => {
+      const chat = readManagedSurface(
+        contract,
+        "components/chat.tsx",
+        "A2A chat",
+      );
+
+      expectA2AVisualizationBehavior(chat);
+    });
+  }
+
   if ("supportedPaths" in contract) {
     const supportedPaths = contract.supportedPaths;
+    test(`${contract.directory} runtime preserves AgentCore bridge behavior`, () => {
+      const runtime = readManagedSurface(
+        contract,
+        contract.runtimePath,
+        "runtime",
+      );
+
+      expectAgentCoreRuntimeBehavior(runtime);
+    });
+
+    test(`${contract.directory} local Compose preserves service networking`, () => {
+      const compose = readManagedSurface(
+        contract,
+        supportedPaths.localComposePath,
+        "local Compose config",
+      );
+
+      expectAgentCoreNetworkingBehavior(compose);
+    });
+
+    test(`${contract.directory} deploy scripts preserve LangGraph and Strands variants`, () => {
+      const variants = [
+        {
+          path: supportedPaths.deployScriptPaths[0]!,
+          pattern: "langgraph-single-agent",
+          suffix: "-lg",
+        },
+        {
+          path: supportedPaths.deployScriptPaths[1]!,
+          pattern: "strands-single-agent",
+          suffix: "-st",
+        },
+      ];
+
+      for (const variant of variants) {
+        const deployScript = readManagedSurface(
+          contract,
+          variant.path,
+          "deploy script",
+        );
+        expectAgentCoreVariantBehavior(
+          deployScript,
+          variant.pattern,
+          variant.suffix,
+        );
+        expect(
+          fs.existsSync(
+            path.join(
+              integrationsDir,
+              contract.directory,
+              "agents",
+              variant.pattern,
+            ),
+          ),
+        ).toBe(true);
+      }
+    });
+
     test(`${contract.directory} local Compose consumes the root managed env`, () => {
       const compose = readManagedSurface(
         contract,

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -51,6 +51,24 @@ const MANAGED_CLI_FRAMEWORKS = [
 
 type ManagedCliFramework = (typeof MANAGED_CLI_FRAMEWORKS)[number];
 
+interface AgentOptionContract {
+  readonly property: string;
+  readonly environmentReads?: readonly string[];
+  readonly stringLiterals?: readonly string[];
+}
+
+type RuntimeAgentContract =
+  | {
+      readonly registration: "default";
+      readonly constructorName: string;
+      readonly options: readonly AgentOptionContract[];
+    }
+  | {
+      readonly registration: "factory";
+      readonly calleePath: readonly string[];
+      readonly argumentIdentifier: string;
+    };
+
 interface ManagedTemplateContract {
   readonly directory: string;
   readonly frameworks: readonly ManagedCliFramework[];
@@ -58,6 +76,7 @@ interface ManagedTemplateContract {
   readonly gatePath: string;
   readonly envPath: string;
   readonly readmePath: string;
+  readonly runtimeAgent?: RuntimeAgentContract;
   readonly supportedPaths?: {
     readonly localComposePath: string;
     readonly deploymentConfigPath: string;
@@ -67,6 +86,89 @@ interface ManagedTemplateContract {
   };
 }
 
+const LANGGRAPH_RUNTIME_AGENT_CONTRACT = {
+  registration: "default",
+  constructorName: "LangGraphAgent",
+  options: [
+    {
+      property: "deploymentUrl",
+      environmentReads: ["AGENT_URL", "LANGGRAPH_DEPLOYMENT_URL"],
+      stringLiterals: ["http://localhost:8123"],
+    },
+    { property: "graphId", stringLiterals: ["sample_agent"] },
+    {
+      property: "langsmithApiKey",
+      environmentReads: ["LANGSMITH_API_KEY"],
+    },
+  ],
+} as const satisfies RuntimeAgentContract;
+
+const HTTP_LOCALHOST_RUNTIME_AGENT_CONTRACT = {
+  registration: "default",
+  constructorName: "HttpAgent",
+  options: [
+    {
+      property: "url",
+      environmentReads: ["AGENT_URL"],
+      stringLiterals: ["http://localhost:8000"],
+    },
+  ],
+} as const satisfies RuntimeAgentContract;
+
+const HTTP_LOCALHOST_SLASH_RUNTIME_AGENT_CONTRACT = {
+  registration: "default",
+  constructorName: "HttpAgent",
+  options: [
+    {
+      property: "url",
+      environmentReads: ["AGENT_URL"],
+      stringLiterals: ["http://localhost:8000/"],
+    },
+  ],
+} as const satisfies RuntimeAgentContract;
+
+const MASTRA_RUNTIME_AGENT_CONTRACT = {
+  registration: "factory",
+  calleePath: ["MastraAgent", "getLocalAgents"],
+  argumentIdentifier: "mastra",
+} as const satisfies RuntimeAgentContract;
+
+const LLAMAINDEX_RUNTIME_AGENT_CONTRACT = {
+  registration: "default",
+  constructorName: "LlamaIndexAgent",
+  options: [
+    {
+      property: "url",
+      environmentReads: ["AGENT_URL"],
+      stringLiterals: ["http://127.0.0.1:9000", "/run"],
+    },
+  ],
+} as const satisfies RuntimeAgentContract;
+
+const AGNO_RUNTIME_AGENT_CONTRACT = {
+  registration: "default",
+  constructorName: "HttpAgent",
+  options: [
+    {
+      property: "url",
+      environmentReads: ["AGENT_URL"],
+      stringLiterals: ["http://localhost:8000", "/agui"],
+    },
+  ],
+} as const satisfies RuntimeAgentContract;
+
+const STRANDS_RUNTIME_AGENT_CONTRACT = {
+  registration: "default",
+  constructorName: "HttpAgent",
+  options: [
+    {
+      property: "url",
+      environmentReads: ["AGENT_URL", "STRANDS_AGENT_URL"],
+      stringLiterals: ["http://localhost:8000"],
+    },
+  ],
+} as const satisfies RuntimeAgentContract;
+
 const MANAGED_TEMPLATE_CONTRACTS = [
   {
     directory: "langgraph-python",
@@ -75,6 +177,7 @@ const MANAGED_TEMPLATE_CONTRACTS = [
     gatePath: "next.config.ts",
     envPath: ".env.example",
     readmePath: "README.md",
+    runtimeAgent: LANGGRAPH_RUNTIME_AGENT_CONTRACT,
   },
   {
     directory: "langgraph-js",
@@ -83,6 +186,7 @@ const MANAGED_TEMPLATE_CONTRACTS = [
     gatePath: "next.config.ts",
     envPath: ".env.example",
     readmePath: "README.md",
+    runtimeAgent: LANGGRAPH_RUNTIME_AGENT_CONTRACT,
   },
   {
     directory: "claude-sdk-typescript",
@@ -91,6 +195,7 @@ const MANAGED_TEMPLATE_CONTRACTS = [
     gatePath: "next.config.ts",
     envPath: ".env.example",
     readmePath: "README.md",
+    runtimeAgent: HTTP_LOCALHOST_RUNTIME_AGENT_CONTRACT,
   },
   {
     directory: "claude-sdk-python",
@@ -99,6 +204,7 @@ const MANAGED_TEMPLATE_CONTRACTS = [
     gatePath: "next.config.ts",
     envPath: ".env.example",
     readmePath: "README.md",
+    runtimeAgent: HTTP_LOCALHOST_RUNTIME_AGENT_CONTRACT,
   },
   {
     directory: "crewai-flows",
@@ -107,6 +213,7 @@ const MANAGED_TEMPLATE_CONTRACTS = [
     gatePath: "next.config.ts",
     envPath: ".env.example",
     readmePath: "README.md",
+    runtimeAgent: HTTP_LOCALHOST_RUNTIME_AGENT_CONTRACT,
   },
   {
     directory: "mastra",
@@ -115,6 +222,7 @@ const MANAGED_TEMPLATE_CONTRACTS = [
     gatePath: "next.config.ts",
     envPath: ".env.example",
     readmePath: "README.md",
+    runtimeAgent: MASTRA_RUNTIME_AGENT_CONTRACT,
   },
   {
     directory: "pydantic-ai",
@@ -123,6 +231,7 @@ const MANAGED_TEMPLATE_CONTRACTS = [
     gatePath: "next.config.ts",
     envPath: ".env.example",
     readmePath: "README.md",
+    runtimeAgent: HTTP_LOCALHOST_SLASH_RUNTIME_AGENT_CONTRACT,
   },
   {
     directory: "llamaindex",
@@ -131,6 +240,7 @@ const MANAGED_TEMPLATE_CONTRACTS = [
     gatePath: "next.config.ts",
     envPath: ".env.example",
     readmePath: "README.md",
+    runtimeAgent: LLAMAINDEX_RUNTIME_AGENT_CONTRACT,
   },
   {
     directory: "agno",
@@ -139,6 +249,7 @@ const MANAGED_TEMPLATE_CONTRACTS = [
     gatePath: "next.config.ts",
     envPath: ".env.example",
     readmePath: "README.md",
+    runtimeAgent: AGNO_RUNTIME_AGENT_CONTRACT,
   },
   {
     directory: "adk",
@@ -147,6 +258,7 @@ const MANAGED_TEMPLATE_CONTRACTS = [
     gatePath: "next.config.ts",
     envPath: ".env.example",
     readmePath: "README.md",
+    runtimeAgent: HTTP_LOCALHOST_SLASH_RUNTIME_AGENT_CONTRACT,
   },
   {
     directory: "strands-python",
@@ -155,6 +267,7 @@ const MANAGED_TEMPLATE_CONTRACTS = [
     gatePath: "next.config.ts",
     envPath: ".env.example",
     readmePath: "README.md",
+    runtimeAgent: STRANDS_RUNTIME_AGENT_CONTRACT,
   },
   {
     directory: "a2a-middleware",
@@ -171,6 +284,7 @@ const MANAGED_TEMPLATE_CONTRACTS = [
     gatePath: "next.config.ts",
     envPath: ".env.example",
     readmePath: "README.md",
+    runtimeAgent: HTTP_LOCALHOST_SLASH_RUNTIME_AGENT_CONTRACT,
   },
   {
     directory: "ms-agent-framework-python",
@@ -179,6 +293,7 @@ const MANAGED_TEMPLATE_CONTRACTS = [
     gatePath: "next.config.ts",
     envPath: ".env.example",
     readmePath: "README.md",
+    runtimeAgent: HTTP_LOCALHOST_SLASH_RUNTIME_AGENT_CONTRACT,
   },
   {
     directory: "mcp-apps",
@@ -390,6 +505,31 @@ function expressionContainsEnvRead(
   return found;
 }
 
+/** Returns whether an expression contains one exact string literal. */
+function expressionContainsStringLiteral(
+  expression: ts.Expression,
+  expected: string,
+): boolean {
+  let found = false;
+
+  /** Visits one initializer node looking for the required literal. */
+  function visit(node: ts.Node): void {
+    if (found) return;
+    if (
+      (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) &&
+      node.text === expected
+    ) {
+      found = true;
+      return;
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(expression);
+  return found;
+}
+
 /** Returns whether an expression uses the managed key without telemetry. */
 function expressionUsesManagedKeyWithoutTelemetry(
   expression: ts.Expression,
@@ -492,6 +632,43 @@ function topLevelVariableInitializer(
   }
 
   return null;
+}
+
+/** Resolves one registered agent through an optional top-level identifier. */
+function registeredAgentExpression(
+  sourceFile: ts.SourceFile,
+  expression: ts.Expression,
+): ts.Expression {
+  const unwrapped = unwrapExpression(expression);
+  if (!ts.isIdentifier(unwrapped)) return unwrapped;
+
+  const initializer = topLevelVariableInitializer(sourceFile, unwrapped.text);
+  return initializer ? unwrapExpression(initializer) : unwrapped;
+}
+
+/** Returns whether an object property carries one exact identifier. */
+function objectPropertyIsIdentifier(
+  objectLiteral: ts.ObjectLiteralExpression,
+  propertyName: string,
+  identifier: string,
+): boolean {
+  return objectLiteral.properties.some((property) => {
+    if (
+      ts.isShorthandPropertyAssignment(property) &&
+      property.name.text === propertyName
+    ) {
+      return property.name.text === identifier;
+    }
+    if (
+      ts.isPropertyAssignment(property) &&
+      propertyNameText(property.name) === propertyName
+    ) {
+      const initializer = unwrapExpression(property.initializer);
+      return ts.isIdentifier(initializer) && initializer.text === identifier;
+    }
+
+    return false;
+  });
 }
 
 /** Resolves a default-exported object literal through top-level variables. */
@@ -1206,6 +1383,79 @@ function expectManagedReadmeContract(contents: string): void {
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_API_KEY));
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_TELEMETRY_ID));
   expectMarkdownLicenseOccurrencesClassified(contents);
+}
+
+/** Asserts one ordinary template retains its framework-specific Runtime agent. */
+function expectRuntimeAgentContract(
+  contents: string,
+  contract: RuntimeAgentContract,
+): void {
+  const sourceFile = parseManagedSource(contents);
+  const runtimeOptions = newExpressionOptions(sourceFile, "CopilotRuntime");
+
+  expect(runtimeOptions).toHaveLength(1);
+  if (runtimeOptions.length !== 1) return;
+  const agents = objectPropertyAssignment(runtimeOptions[0]!, "agents");
+  expect(agents).not.toBeNull();
+  if (!agents) return;
+  const registeredAgents = unwrapExpression(agents.initializer);
+
+  if (contract.registration === "factory") {
+    expect(ts.isCallExpression(registeredAgents)).toBe(true);
+    if (!ts.isCallExpression(registeredAgents)) return;
+    expect(propertyAccessParts(registeredAgents.expression)).toEqual(
+      contract.calleePath,
+    );
+    const argument = registeredAgents.arguments[0]
+      ? unwrapExpression(registeredAgents.arguments[0])
+      : null;
+    expect(argument && ts.isObjectLiteralExpression(argument)).toBe(true);
+    if (!argument || !ts.isObjectLiteralExpression(argument)) return;
+    expect(
+      objectPropertyIsIdentifier(
+        argument,
+        contract.argumentIdentifier,
+        contract.argumentIdentifier,
+      ),
+    ).toBe(true);
+    return;
+  }
+
+  expect(ts.isObjectLiteralExpression(registeredAgents)).toBe(true);
+  if (!ts.isObjectLiteralExpression(registeredAgents)) return;
+  const defaultAgent = objectPropertyAssignment(registeredAgents, "default");
+  expect(defaultAgent).not.toBeNull();
+  if (!defaultAgent) return;
+  const agent = registeredAgentExpression(sourceFile, defaultAgent.initializer);
+  expect(ts.isNewExpression(agent)).toBe(true);
+  if (!ts.isNewExpression(agent)) return;
+  expect(propertyAccessParts(agent.expression)).toEqual([
+    contract.constructorName,
+  ]);
+  const agentOptions = agent.arguments?.[0]
+    ? unwrapExpression(agent.arguments[0])
+    : null;
+  expect(agentOptions && ts.isObjectLiteralExpression(agentOptions)).toBe(true);
+  if (!agentOptions || !ts.isObjectLiteralExpression(agentOptions)) return;
+
+  for (const optionContract of contract.options) {
+    const option = objectPropertyAssignment(
+      agentOptions,
+      optionContract.property,
+    );
+    expect(option).not.toBeNull();
+    if (!option) continue;
+    for (const identifier of optionContract.environmentReads ?? []) {
+      expect(expressionContainsEnvRead(option.initializer, identifier)).toBe(
+        true,
+      );
+    }
+    for (const literal of optionContract.stringLiterals ?? []) {
+      expect(expressionContainsStringLiteral(option.initializer, literal)).toBe(
+        true,
+      );
+    }
+  }
 }
 
 /** Asserts a Next/Hono runtime preserves its complete REST handler surface. */
@@ -2446,13 +2696,76 @@ test("the 16 managed template directories back all 19 in-repo CLI frameworks", (
   const frameworks = MANAGED_TEMPLATE_CONTRACTS.flatMap(
     (contract) => contract.frameworks,
   );
+  const ordinaryRuntimeContracts = MANAGED_TEMPLATE_CONTRACTS.filter(
+    (contract) => "runtimeAgent" in contract,
+  );
 
   expect(MANAGED_TEMPLATE_CONTRACTS).toHaveLength(16);
+  expect(ordinaryRuntimeContracts).toHaveLength(13);
   expect(new Set(frameworks).size).toBe(19);
   expect([...frameworks].sort()).toEqual([...MANAGED_CLI_FRAMEWORKS].sort());
 });
 
+test.each([
+  {
+    defect: "registered constructor changes",
+    contents: `
+      const defaultAgent = new WrongAgent({
+        url: process.env.AGENT_URL || "http://localhost:8000/",
+      });
+      new CopilotRuntime({ agents: { default: defaultAgent } });
+    `,
+    contract: HTTP_LOCALHOST_SLASH_RUNTIME_AGENT_CONTRACT,
+  },
+  {
+    defect: "required endpoint configuration disappears",
+    contents: `
+      const defaultAgent = new HttpAgent({
+        url: "http://localhost:8000/",
+      });
+      new CopilotRuntime({ agents: { default: defaultAgent } });
+    `,
+    contract: HTTP_LOCALHOST_SLASH_RUNTIME_AGENT_CONTRACT,
+  },
+  {
+    defect: "constructed agent is no longer registered",
+    contents: `
+      const defaultAgent = new HttpAgent({
+        url: process.env.AGENT_URL || "http://localhost:8000/",
+      });
+      new CopilotRuntime({ agents: { default: unregisteredAgent } });
+    `,
+    contract: HTTP_LOCALHOST_SLASH_RUNTIME_AGENT_CONTRACT,
+  },
+  {
+    defect: "framework factory changes",
+    contents: `
+      new CopilotRuntime({
+        agents: MastraAgent.getRemoteAgents({ mastra }),
+      });
+    `,
+    contract: MASTRA_RUNTIME_AGENT_CONTRACT,
+  },
+])(
+  "the ordinary Runtime agent helper rejects when $defect",
+  ({ contents, contract }) => {
+    expect(() => expectRuntimeAgentContract(contents, contract)).toThrow();
+  },
+);
+
 for (const contract of MANAGED_TEMPLATE_CONTRACTS) {
+  if ("runtimeAgent" in contract) {
+    test(`${contract.directory} runtime preserves its framework-specific agent wiring`, () => {
+      const runtime = readManagedSurface(
+        contract,
+        contract.runtimePath,
+        "runtime",
+      );
+
+      expectRuntimeAgentContract(runtime, contract.runtimeAgent);
+    });
+  }
+
   if (contract.directory !== "agentcore") {
     test(`${contract.directory} runtime preserves all REST endpoint handlers`, () => {
       const runtime = readManagedSurface(

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -123,6 +123,7 @@ interface AgentCoreDeployHarnessOptions {
   readonly callerEnvironment?: AgentCoreDeployEnvironment;
   readonly skipBackend?: boolean;
   readonly skipFrontend?: boolean;
+  readonly xtrace?: boolean;
 }
 
 interface AgentCoreDeployHarnessResult {
@@ -134,6 +135,9 @@ interface AgentCoreDeployHarnessResult {
   readonly npmCommands: readonly string[];
   readonly frontendStackName: string | null;
   readonly frontendSecretVersionId: string | null;
+  readonly frontendThreadsEnabled: string | null;
+  readonly secretExposureObservations: readonly string[];
+  readonly secretInputObservations: readonly string[];
 }
 
 const LANGGRAPH_RUNTIME_AGENT_CONTRACT = {
@@ -2354,6 +2358,22 @@ function expectAgentCoreDeployScriptContract(contents: string): void {
   const telemetryExportIndex = lines.findIndex((line) =>
     new RegExp(`^\\s*export\\s+${OPTIONAL_TELEMETRY_ID}(?:=|\\s|$)`).test(line),
   );
+  const disableAllexportIndex = lines.findIndex((line) =>
+    /^\s*set\s+\+a\s*$/.test(line),
+  );
+  const disableXtraceIndex = lines.findIndex((line) =>
+    /^\s*set\s+\+x\s*$/.test(line),
+  );
+  const managedKeyUnexportIndices = lines.flatMap((line, index) =>
+    new RegExp(`^\\s*export\\s+-n\\s+${MANAGED_API_KEY}\\s*$`).test(line)
+      ? [index]
+      : [],
+  );
+  const managedKeyUnsetIndices = lines.flatMap((line, index) =>
+    new RegExp(`^\\s*unset\\s+${MANAGED_API_KEY}\\s*$`).test(line)
+      ? [index]
+      : [],
+  );
   const secretVersionExportIndex = lines.findIndex((line) =>
     new RegExp(
       `^\\s*export\\s+${MANAGED_API_KEY_SECRET_VERSION_ID}(?:=|\\s|$)`,
@@ -2371,6 +2391,19 @@ function expectAgentCoreDeployScriptContract(contents: string): void {
     throw new Error("AgentCore secret materialization contract is incomplete");
   }
   expect(skipBackendGuardIndex).toBeGreaterThanOrEqual(0);
+  expect(disableAllexportIndex).toBeGreaterThanOrEqual(0);
+  expect(disableAllexportIndex).toBeLessThan(rootEnvLoadIndex);
+  expect(disableXtraceIndex).toBeGreaterThanOrEqual(0);
+  expect(disableXtraceIndex).toBeLessThan(rootEnvLoadIndex);
+  expect(contents).not.toMatch(/^\s*set\s+-a\s*$/m);
+  expect(
+    managedKeyUnexportIndices.some((index) => index < rootEnvLoadIndex),
+  ).toBe(true);
+  expect(
+    managedKeyUnexportIndices.some(
+      (index) => index > rootEnvLoadIndex && index < skipBackendGuardIndex,
+    ),
+  ).toBe(true);
   expect(backendDeployElseIndex).toBeGreaterThan(skipBackendGuardIndex);
   expect(secretConfigAssignment.index).toBeGreaterThan(backendDeployElseIndex);
   expect(secretVersionExportIndex).toBeGreaterThan(backendDeployElseIndex);
@@ -2381,6 +2414,14 @@ function expectAgentCoreDeployScriptContract(contents: string): void {
   );
   for (const { line } of secretCommands) {
     expect(line).toMatch(
+      new RegExp(
+        `printf\\s+['"]%s['"]\\s+["']\\$\\{?${MANAGED_API_KEY}\\}?["']\\s*\\|\\s*aws\\s+secretsmanager`,
+      ),
+    );
+    expect(line).toMatch(
+      /--secret-string(?:=|\s+)file:\/\/\/dev\/stdin(?:\s|$)/,
+    );
+    expect(line).not.toMatch(
       new RegExp(
         `--secret-string(?:=|\\s+)["']?\\$\\{?${MANAGED_API_KEY}\\}?["']?(?:\\s|$)`,
       ),
@@ -2393,6 +2434,17 @@ function expectAgentCoreDeployScriptContract(contents: string): void {
   }
   expect(rootEnvLoadIndex).toBeLessThan(secretCommands[0].index);
   expect(secretConfigAssignment.index).toBeLessThan(secretCommands[0].index);
+  expect(
+    managedKeyUnsetIndices.some(
+      (index) =>
+        index > skipBackendGuardIndex && index < backendDeployElseIndex,
+    ),
+  ).toBe(true);
+  expect(
+    managedKeyUnsetIndices.some(
+      (index) => index > secretCommands[0].index && index < cdkDeployIndex,
+    ),
+  ).toBe(true);
   for (const backendOwnedIndex of [
     secretConfigAssignment.index,
     ...secretCommands.map(({ index: commandIndex }) => commandIndex),
@@ -2703,13 +2755,20 @@ test("AgentCore structural helpers accept linked root-env, secret, Lambda, and f
     });
   `;
   const deployScript = `
+    set +a
+    set +x
+    export -n ${MANAGED_API_KEY}
     source "$SCRIPT_DIR/.env"
+    export -n ${MANAGED_API_KEY}
     export ${OPTIONAL_TELEMETRY_ID}
+    export ${VITE_THREADS_GATE}=true
     if [ "$SKIP_BACKEND" = true ]; then
+      unset ${MANAGED_API_KEY}
       echo "Skipping backend"
     else
       CPK_SECRET_NAME=$(read_config ${MANAGED_API_KEY_SECRET_CONFIG})
-      aws secretsmanager create-secret --name "$CPK_SECRET_NAME" --secret-string "$${MANAGED_API_KEY}"
+      printf '%s' "$${MANAGED_API_KEY}" | aws secretsmanager create-secret --name "$CPK_SECRET_NAME" --secret-string file:///dev/stdin
+      unset ${MANAGED_API_KEY}
       export ${MANAGED_API_KEY_SECRET_VERSION_ID}
       npx cdk deploy --all
     fi
@@ -2927,6 +2986,26 @@ for (const scriptName of [
     expect(result.output).not.toContain(MANAGED_API_KEY_SENTINEL);
   });
 
+  test(`${scriptName} delivers the managed key only through Secrets Manager stdin`, () => {
+    const result = runAgentCoreDeployHarness({
+      scriptName,
+      envFile: {
+        apiUrl: "https://intelligence.example.com/api",
+        gatewayWsUrl: "wss://gateway.example.com/runtime",
+      },
+      skipFrontend: false,
+      xtrace: true,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.secretInputObservations).toEqual(["aws:stdin-match"]);
+    expect(result.secretExposureObservations).toEqual([]);
+    expect(result.awsCommands.join("\n")).not.toContain(
+      MANAGED_API_KEY_SENTINEL,
+    );
+    expect(result.frontendThreadsEnabled).toBe("true");
+  });
+
   test(`${scriptName} --skip-backend leaves backend secret state untouched while deploying the frontend`, () => {
     const result = runAgentCoreDeployHarness({
       scriptName,
@@ -2951,6 +3030,9 @@ for (const scriptName of [
         : "agentcore-contract-st",
     );
     expect(result.frontendSecretVersionId).toBe("");
+    expect(result.frontendThreadsEnabled).toBe("true");
+    expect(result.secretExposureObservations).toEqual([]);
+    expect(result.secretInputObservations).toEqual([]);
     expect(result.output).toContain("Skipping backend deploy (--skip-backend)");
     expect(result.output).not.toContain("Managed Intelligence key stored");
     expect(result.output).not.toContain(MANAGED_API_KEY_SENTINEL);
@@ -3832,6 +3914,18 @@ function readAgentCoreHarnessLines(capturePath: string): string[] {
     .filter((line) => line.length > 0);
 }
 
+/** Emit a shell probe that records any managed-key environment or argv leak. */
+function agentCoreSecretExposureProbe(command: string): string {
+  return [
+    `if [[ -n "\${${MANAGED_API_KEY}-}" ]]; then`,
+    `  printf '%s\\n' '${command}:env' >> "\${SECRET_EXPOSURE_CAPTURE:?}"`,
+    "fi",
+    `if [[ "$*" == *'${MANAGED_API_KEY_SENTINEL}'* ]]; then`,
+    `  printf '%s\\n' '${command}:argv' >> "\${SECRET_EXPOSURE_CAPTURE:?}"`,
+    "fi",
+  ].join("\n");
+}
+
 /** Execute one real AgentCore deploy script against non-networking command stubs. */
 function runAgentCoreDeployHarness(
   options: AgentCoreDeployHarnessOptions,
@@ -3848,6 +3942,14 @@ function runAgentCoreDeployHarness(
     const frontendCapturePath = path.join(
       harnessDirectory,
       "frontend-environment.txt",
+    );
+    const secretExposureCapturePath = path.join(
+      harnessDirectory,
+      "secret-exposure.txt",
+    );
+    const secretInputCapturePath = path.join(
+      harnessDirectory,
+      "secret-input.txt",
     );
     const scriptPath = path.join(harnessDirectory, options.scriptName);
     fs.mkdirSync(fakeBin);
@@ -3891,6 +3993,7 @@ function runAgentCoreDeployHarness(
       [
         "#!/usr/bin/env bash\n",
         "set -eu\n",
+        `${agentCoreSecretExposureProbe("npm")}\n`,
         'printf \'%s\\n\' "$*" >> "${NPM_COMMAND_CAPTURE:?}"\n',
       ].join(""),
     );
@@ -3900,8 +4003,15 @@ function runAgentCoreDeployHarness(
       [
         "#!/usr/bin/env bash\n",
         "set -eu\n",
+        `${agentCoreSecretExposureProbe("aws")}\n`,
         'printf \'%s\\n\' "$*" >> "${AWS_COMMAND_CAPTURE:?}"\n',
         'if [[ "$*" == *"secretsmanager put-secret-value"* || "$*" == *"secretsmanager create-secret"* ]]; then\n',
+        "  secret_input=$(cat)\n",
+        `  if [[ "$secret_input" == '${MANAGED_API_KEY_SENTINEL}' ]]; then\n`,
+        "    printf '%s\\n' 'aws:stdin-match' >> \"${SECRET_INPUT_CAPTURE:?}\"\n",
+        "  else\n",
+        "    printf '%s\\n' 'aws:stdin-missing' >> \"${SECRET_INPUT_CAPTURE:?}\"\n",
+        "  fi\n",
         `  printf '%s\\n' '${MANAGED_API_KEY_SECRET_VERSION_SENTINEL}'\n`,
         "fi\n",
       ].join(""),
@@ -3912,6 +4022,7 @@ function runAgentCoreDeployHarness(
       [
         "#!/usr/bin/env bash\n",
         "set -eu\n",
+        `${agentCoreSecretExposureProbe("npx")}\n`,
         `printf '%s\\n%s\\n%s\\n' "\${${INTELLIGENCE_API_URL}-}" "\${${INTELLIGENCE_GATEWAY_WS_URL}-}" "\${${MANAGED_API_KEY_SECRET_VERSION_ID}-}" > "\${CDK_ENV_CAPTURE:?}"\n`,
       ].join(""),
     );
@@ -3921,13 +4032,17 @@ function runAgentCoreDeployHarness(
         "import os\n",
         "import pathlib\n",
         "import sys\n",
+        `if os.environ.get('${MANAGED_API_KEY}'):\n`,
+        '    with pathlib.Path(os.environ["SECRET_EXPOSURE_CAPTURE"]).open("a") as capture:\n',
+        '        capture.write("frontend:env\\n")\n',
         'pathlib.Path(os.environ["FRONTEND_CAPTURE"]).write_text(\n',
-        `    f"{sys.argv[1]}\\n{os.environ.get('${MANAGED_API_KEY_SECRET_VERSION_ID}', '')}\\n"\n`,
+        `    f"{sys.argv[1]}\\n{os.environ.get('${MANAGED_API_KEY_SECRET_VERSION_ID}', '')}\\n{os.environ.get('${VITE_THREADS_GATE}', '')}\\n"\n`,
         ")\n",
       ].join(""),
     );
 
     const environment = { ...process.env };
+    environment[MANAGED_API_KEY] = MANAGED_API_KEY_SENTINEL;
     delete environment[INTELLIGENCE_API_URL];
     delete environment[INTELLIGENCE_GATEWAY_WS_URL];
     delete environment[MANAGED_API_KEY_SECRET_VERSION_ID];
@@ -3936,6 +4051,8 @@ function runAgentCoreDeployHarness(
     environment.AWS_COMMAND_CAPTURE = awsCapturePath;
     environment.NPM_COMMAND_CAPTURE = npmCapturePath;
     environment.FRONTEND_CAPTURE = frontendCapturePath;
+    environment.SECRET_EXPOSURE_CAPTURE = secretExposureCapturePath;
+    environment.SECRET_INPUT_CAPTURE = secretInputCapturePath;
     if (options.callerEnvironment?.apiUrl !== undefined) {
       environment[INTELLIGENCE_API_URL] = options.callerEnvironment.apiUrl;
     }
@@ -3945,6 +4062,7 @@ function runAgentCoreDeployHarness(
     }
 
     const scriptArguments = [
+      ...(options.xtrace === true ? ["-x"] : []),
       scriptPath,
       ...(options.skipFrontend === false ? [] : ["--skip-frontend"]),
       ...(options.skipBackend === true ? ["--skip-backend"] : []),
@@ -3977,6 +4095,13 @@ function runAgentCoreDeployHarness(
       npmCommands: readAgentCoreHarnessLines(npmCapturePath),
       frontendStackName: frontendEnvironment?.[0] ?? null,
       frontendSecretVersionId: frontendEnvironment?.[1] ?? null,
+      frontendThreadsEnabled: frontendEnvironment?.[2] ?? null,
+      secretExposureObservations: readAgentCoreHarnessLines(
+        secretExposureCapturePath,
+      ),
+      secretInputObservations: readAgentCoreHarnessLines(
+        secretInputCapturePath,
+      ),
     };
   } finally {
     fs.rmSync(harnessDirectory, { force: true, recursive: true });

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -18,6 +18,10 @@ const LEGACY_TELEMETRY_ID = "COPILOTKIT_TELEMETRY_ID";
 const MANAGED_LICENSE_TOKEN = "COPILOTKIT_LICENSE_TOKEN";
 const MANAGED_API_KEY_SECRET_CONFIG =
   "copilotkit_intelligence_api_key_secret_name";
+const MANAGED_API_KEY_SECRET_VERSION_ID =
+  "CPK_INTELLIGENCE_API_KEY_SECRET_VERSION_ID";
+const MANAGED_API_KEY_SECRET_VERSION_SENTINEL =
+  "agentcore-secret-version-contract";
 const INTELLIGENCE_API_URL = "INTELLIGENCE_API_URL";
 const INTELLIGENCE_GATEWAY_WS_URL = "INTELLIGENCE_GATEWAY_WS_URL";
 const NEXT_THREADS_GATE = "NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED";
@@ -123,6 +127,7 @@ interface AgentCoreDeployHarnessResult {
   readonly status: number | null;
   readonly output: string;
   readonly cdkEnvironment: string | null;
+  readonly secretVersionId: string | null;
 }
 
 const LANGGRAPH_RUNTIME_AGENT_CONTRACT = {
@@ -2093,6 +2098,12 @@ function expectAgentCoreRuntimeDeploymentContract(contents: string): void {
   ).toBe(true);
   expect(expressionContainsSecretResolution(managedKey.initializer)).toBe(true);
   expect(
+    expressionContainsEnvRead(
+      managedKey.initializer,
+      MANAGED_API_KEY_SECRET_VERSION_ID,
+    ),
+  ).toBe(true);
+  expect(
     expressionContainsEnvRead(managedKey.initializer, MANAGED_API_KEY),
   ).toBe(false);
   expect(
@@ -2633,6 +2644,7 @@ test("AgentCore structural helpers accept linked root-env, secret, Lambda, and f
       environment: {
         ${MANAGED_API_KEY}: cdk.SecretValue.secretsManager(
           config.${MANAGED_API_KEY_SECRET_CONFIG},
+          { versionId: process.env.${MANAGED_API_KEY_SECRET_VERSION_ID} },
         ).unsafeUnwrap(),
         ${OPTIONAL_TELEMETRY_ID}: process.env.${OPTIONAL_TELEMETRY_ID} ?? "",
         ${INTELLIGENCE_API_URL}: process.env.${INTELLIGENCE_API_URL} ?? "http://localhost:4201",
@@ -2846,6 +2858,25 @@ for (const scriptName of [
     expect(result.cdkEnvironment).toBe(
       "https://intelligence.example.com/api\n" +
         "wss://gateway.example.com/runtime\n",
+    );
+    expect(result.output).not.toContain(MANAGED_API_KEY_SENTINEL);
+  });
+
+  test(`${scriptName} passes the updated secret version to CDK without logging it`, () => {
+    const result = runAgentCoreDeployHarness({
+      scriptName,
+      envFile: {
+        apiUrl: "https://intelligence.example.com/api",
+        gatewayWsUrl: "wss://gateway.example.com/runtime",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.secretVersionId).toBe(
+      MANAGED_API_KEY_SECRET_VERSION_SENTINEL,
+    );
+    expect(result.output).not.toContain(
+      MANAGED_API_KEY_SECRET_VERSION_SENTINEL,
     );
     expect(result.output).not.toContain(MANAGED_API_KEY_SENTINEL);
   });
@@ -3755,16 +3786,27 @@ function runAgentCoreDeployHarness(
       ].join(""),
     );
 
-    for (const command of ["aws", "docker", "node", "npm"]) {
+    for (const command of ["docker", "node", "npm"]) {
       writeAgentCoreCommandStub(fakeBin, command);
     }
+    writeAgentCoreCommandStub(
+      fakeBin,
+      "aws",
+      [
+        "#!/usr/bin/env bash\n",
+        "set -eu\n",
+        'if [[ "$*" == *"secretsmanager put-secret-value"* || "$*" == *"secretsmanager create-secret"* ]]; then\n',
+        `  printf '%s\\n' '${MANAGED_API_KEY_SECRET_VERSION_SENTINEL}'\n`,
+        "fi\n",
+      ].join(""),
+    );
     writeAgentCoreCommandStub(
       fakeBin,
       "npx",
       [
         "#!/usr/bin/env bash\n",
         "set -eu\n",
-        `printf '%s\\n%s\\n' "\${${INTELLIGENCE_API_URL}-}" "\${${INTELLIGENCE_GATEWAY_WS_URL}-}" > "\${CDK_ENV_CAPTURE:?}"\n`,
+        `printf '%s\\n%s\\n%s\\n' "\${${INTELLIGENCE_API_URL}-}" "\${${INTELLIGENCE_GATEWAY_WS_URL}-}" "\${${MANAGED_API_KEY_SECRET_VERSION_ID}-}" > "\${CDK_ENV_CAPTURE:?}"\n`,
       ].join(""),
     );
 
@@ -3786,10 +3828,17 @@ function runAgentCoreDeployHarness(
       env: environment,
     });
     const output = `${result.stdout}${result.stderr}`;
-    const cdkEnvironment = fs.existsSync(capturePath)
+    const capturedEnvironment = fs.existsSync(capturePath)
       ? fs.readFileSync(capturePath, "utf8")
       : null;
-    return { status: result.status, output, cdkEnvironment };
+    const capturedLines = capturedEnvironment?.split("\n") ?? [];
+    const cdkEnvironment = capturedEnvironment
+      ? `${capturedLines[0] ?? ""}\n${capturedLines[1] ?? ""}\n`
+      : null;
+    const secretVersionId = capturedEnvironment
+      ? (capturedLines[2] ?? null)
+      : null;
+    return { status: result.status, output, cdkEnvironment, secretVersionId };
   } finally {
     fs.rmSync(harnessDirectory, { force: true, recursive: true });
   }

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -726,16 +726,56 @@ function envBlockHasLabel(block: string, label: RegExp): boolean {
     .some((line) => /^\s*#/.test(line) && label.test(line));
 }
 
-/** Returns the explicitly labeled managed env block containing both fields. */
-function managedEnvBlock(contents: string): string {
-  return (
-    textBlocks(contents).find(
-      (block) =>
-        envBlockHasLabel(block, MANAGED_DOCUMENTATION_LABEL) &&
-        envAssignmentPattern(MANAGED_API_KEY).test(block) &&
-        envAssignmentPattern(OPTIONAL_TELEMETRY_ID).test(block),
-    ) ?? ""
-  );
+interface ManagedEnvSections {
+  readonly apiKey: string;
+  readonly telemetry: string;
+}
+
+/** Returns the exact ordered managed dotenv sections from the public contract. */
+function managedEnvSections(contents: string): ManagedEnvSections | null {
+  const lines = contents.replaceAll("\r\n", "\n").split("\n");
+  const apiHeader = "# Your CopilotKit Enterprise Intelligence API Key";
+  const telemetryHeader = "# CopilotKit Telemetry ID";
+  if (
+    lines.filter((line) => line === apiHeader).length !== 1 ||
+    lines.filter((line) => line === telemetryHeader).length !== 1 ||
+    lines.filter((line) => envAssignmentPattern(MANAGED_API_KEY).test(line))
+      .length !== 1 ||
+    lines.filter((line) =>
+      envAssignmentPattern(OPTIONAL_TELEMETRY_ID).test(line),
+    ).length !== 1
+  ) {
+    return null;
+  }
+  const apiHeaderIndex = lines.findIndex((line) => line === apiHeader);
+  if (apiHeaderIndex < 0) return null;
+
+  const projectName = lines[apiHeaderIndex + 1] ?? "";
+  const apiKeyAssignment = lines[apiHeaderIndex + 2] ?? "";
+  const separator = lines[apiHeaderIndex + 3];
+  const telemetryHeaderIndex = apiHeaderIndex + 4;
+  if (
+    !/^# Project Name: \S.*$/u.test(projectName) ||
+    !envAssignmentPattern(MANAGED_API_KEY).test(apiKeyAssignment) ||
+    separator !== "" ||
+    lines[telemetryHeaderIndex] !== telemetryHeader
+  ) {
+    return null;
+  }
+
+  let telemetryEnd = telemetryHeaderIndex + 1;
+  while (telemetryEnd < lines.length && lines[telemetryEnd] !== "") {
+    telemetryEnd += 1;
+  }
+  const telemetry = lines.slice(telemetryHeaderIndex, telemetryEnd).join("\n");
+  if (!envAssignmentPattern(OPTIONAL_TELEMETRY_ID).test(telemetry)) {
+    return null;
+  }
+
+  return {
+    apiKey: lines.slice(apiHeaderIndex, apiHeaderIndex + 3).join("\n"),
+    telemetry,
+  };
 }
 
 /** Asserts every env license occurrence has a deployment-mode label. */
@@ -879,10 +919,12 @@ function expectManagedGateContract(contents: string): void {
  * @param contents - Managed template environment example contents.
  */
 function expectManagedEnvContract(contents: string): void {
-  const managedBlock = managedEnvBlock(contents);
+  const managedSections = managedEnvSections(contents);
 
-  expect(managedBlock).not.toBe("");
-  expectTelemetryIdentityDocumentation(managedBlock);
+  expect(managedSections).not.toBeNull();
+  if (!managedSections) return;
+  expect(managedSections.apiKey).toMatch(envAssignmentPattern(MANAGED_API_KEY));
+  expectTelemetryIdentityDocumentation(managedSections.telemetry);
   expect(contents).not.toMatch(envAssignmentPattern(LEGACY_API_KEY));
   expect(contents).not.toMatch(envAssignmentPattern(LEGACY_TELEMETRY_ID));
   expectEnvLicenseOccurrencesClassified(contents);
@@ -1409,6 +1451,21 @@ test("managed TypeScript helpers reject telemetry prerequisites", () => {
   expect(() => expectManagedGateContract(telemetryGatedViteConfig)).toThrow();
 });
 
+/** Build the exact managed dotenv sections with telemetry semantics documented. */
+function managedEnvExample(
+  telemetryDescription = "Optional, non-secret analytics identity.",
+): string {
+  return [
+    "# Your CopilotKit Enterprise Intelligence API Key",
+    "# Project Name: xxxxxxxxxx",
+    "CPK_INTELLIGENCE_API_KEY=xxxxx",
+    "",
+    "# CopilotKit Telemetry ID",
+    `# ${telemetryDescription}`,
+    "CPK_TELEMETRY_ID=xxxxx",
+  ].join("\n");
+}
+
 test("managed documentation helpers reject misleading telemetry semantics", () => {
   const misleadingDescriptions = [
     "authentication credential",
@@ -1419,12 +1476,9 @@ test("managed documentation helpers reject misleading telemetry semantics", () =
   ];
 
   for (const description of misleadingDescriptions) {
-    const envExample = `
-      # Managed Intelligence credentials
-      CPK_INTELLIGENCE_API_KEY=
-      # Optional, non-secret analytics ${description}.
-      CPK_TELEMETRY_ID=
-    `;
+    const envExample = managedEnvExample(
+      `Optional, non-secret analytics ${description}.`,
+    );
     const readme = [
       "## Managed Intelligence credentials",
       "",
@@ -1439,12 +1493,7 @@ test("managed documentation helpers reject misleading telemetry semantics", () =
 });
 
 test("managed documentation helpers accept an optional non-secret analytics identity", () => {
-  const envExample = `
-    # Managed Intelligence credentials
-    CPK_INTELLIGENCE_API_KEY=
-    # Optional, non-secret analytics identity.
-    CPK_TELEMETRY_ID=
-  `;
+  const envExample = managedEnvExample();
   const readme = [
     "## Managed Intelligence credentials",
     "",
@@ -1457,14 +1506,24 @@ test("managed documentation helpers accept an optional non-secret analytics iden
   expect(() => expectManagedReadmeContract(readme)).not.toThrow();
 });
 
-test("managed documentation helpers reject license guidance inside the managed block", () => {
-  const envExample = `
-    # Managed Intelligence credentials
-    CPK_INTELLIGENCE_API_KEY=
-    # Optional, non-secret analytics identity
-    CPK_TELEMETRY_ID=
-    COPILOTKIT_LICENSE_TOKEN=
-  `;
+test.each([
+  {
+    invalidLayout: "two blank lines between sections",
+    envExample: managedEnvExample().replace(
+      "CPK_INTELLIGENCE_API_KEY=xxxxx\n\n# CopilotKit",
+      "CPK_INTELLIGENCE_API_KEY=xxxxx\n\n\n# CopilotKit",
+    ),
+  },
+  {
+    invalidLayout: "duplicate telemetry section",
+    envExample: `${managedEnvExample()}\n\n# CopilotKit Telemetry ID\nCPK_TELEMETRY_ID=duplicate`,
+  },
+])("managed documentation helpers reject $invalidLayout", ({ envExample }) => {
+  expect(() => expectManagedEnvContract(envExample)).toThrow();
+});
+
+test("managed documentation helpers reject license guidance inside the telemetry section", () => {
+  const envExample = `${managedEnvExample()}\nCOPILOTKIT_LICENSE_TOKEN=`;
   const readme = [
     "## Managed Intelligence credentials",
     "",
@@ -1478,18 +1537,15 @@ test("managed documentation helpers reject license guidance inside the managed b
 });
 
 test("managed documentation helpers reject separated unlabeled license guidance", () => {
-  const envExample = `
-    # Managed Intelligence credentials
-    CPK_INTELLIGENCE_API_KEY=
-    # Optional, non-secret analytics identity
-    CPK_TELEMETRY_ID=
-
-    # Self-hosted / offline license
-    COPILOTKIT_LICENSE_TOKEN=
-
-    # Troubleshooting
-    COPILOTKIT_LICENSE_TOKEN=
-  `;
+  const envExample = [
+    managedEnvExample(),
+    "",
+    "# Self-hosted / offline license",
+    "COPILOTKIT_LICENSE_TOKEN=",
+    "",
+    "# Troubleshooting",
+    "COPILOTKIT_LICENSE_TOKEN=",
+  ].join("\n");
   const readme = [
     "## Managed Intelligence credentials",
     "",
@@ -1509,14 +1565,16 @@ test("managed documentation helpers reject separated unlabeled license guidance"
   expect(() => expectManagedReadmeContract(readme)).toThrow();
 });
 
-test("managed documentation helpers require credentials in one managed block", () => {
-  const envExample = `
-    # Managed Intelligence credentials
-    CPK_INTELLIGENCE_API_KEY=
-
-    # Optional, non-secret analytics identity
-    CPK_TELEMETRY_ID=
-  `;
+test("managed documentation helpers reject reordered managed dotenv sections", () => {
+  const envExample = [
+    "# CopilotKit Telemetry ID",
+    "# Optional, non-secret analytics identity.",
+    "CPK_TELEMETRY_ID=xxxxx",
+    "",
+    "# Your CopilotKit Enterprise Intelligence API Key",
+    "# Project Name: xxxxxxxxxx",
+    "CPK_INTELLIGENCE_API_KEY=xxxxx",
+  ].join("\n");
   const readme = [
     "## Managed Intelligence credentials",
     "",
@@ -1532,15 +1590,12 @@ test("managed documentation helpers require credentials in one managed block", (
 });
 
 test("managed documentation helpers allow separate self-hosted and offline license guidance", () => {
-  const envExample = `
-    # Managed Intelligence credentials
-    CPK_INTELLIGENCE_API_KEY=
-    # Optional, non-secret analytics identity
-    CPK_TELEMETRY_ID=
-
-    # Self-hosted / offline license
-    COPILOTKIT_LICENSE_TOKEN=
-  `;
+  const envExample = [
+    managedEnvExample(),
+    "",
+    "# Self-hosted / offline license",
+    "COPILOTKIT_LICENSE_TOKEN=",
+  ].join("\n");
   const readme = [
     "## Managed Intelligence credentials",
     "",
@@ -1557,15 +1612,12 @@ test("managed documentation helpers allow separate self-hosted and offline licen
 });
 
 test("managed documentation helpers reject unlabeled generic license-gating copy without an env literal", () => {
-  const envExample = `
-    # Managed Intelligence credentials
-    CPK_INTELLIGENCE_API_KEY=
-    # Optional, non-secret analytics identity
-    CPK_TELEMETRY_ID=
-
-    # Product capabilities
-    # A license unlocks Threads and enables Inspector.
-  `;
+  const envExample = [
+    managedEnvExample(),
+    "",
+    "# Product capabilities",
+    "# A license unlocks Threads and enables Inspector.",
+  ].join("\n");
   const readme = [
     "## Managed Intelligence credentials",
     "",
@@ -1582,15 +1634,12 @@ test("managed documentation helpers reject unlabeled generic license-gating copy
 });
 
 test("managed documentation helpers allow generic license-gating copy only in self-hosted or offline sections", () => {
-  const envExample = `
-    # Managed Intelligence credentials
-    CPK_INTELLIGENCE_API_KEY=
-    # Optional, non-secret analytics identity
-    CPK_TELEMETRY_ID=
-
-    # Self-hosted / offline license behavior
-    # A deployment license enables Threads and Inspector offline.
-  `;
+  const envExample = [
+    managedEnvExample(),
+    "",
+    "# Self-hosted / offline license behavior",
+    "# A deployment license enables Threads and Inspector offline.",
+  ].join("\n");
   const readme = [
     "## Managed Intelligence credentials",
     "",

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -653,6 +653,30 @@ function topLevelVariableInitializer(
   return null;
 }
 
+/** Returns every variable initializer with one exact identifier in a source tree. */
+function variableInitializers(
+  root: ts.Node,
+  identifier: string,
+): readonly ts.Expression[] {
+  const matches: ts.Expression[] = [];
+
+  /** Visits variable declarations for the requested identifier. */
+  function visit(node: ts.Node): void {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === identifier &&
+      node.initializer
+    ) {
+      matches.push(node.initializer);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(root);
+  return matches;
+}
+
 /** Resolves transparent wrappers and top-level variable aliases. */
 function resolveTopLevelExpression(
   sourceFile: ts.SourceFile,
@@ -931,29 +955,24 @@ function newExpressionOptions(
   return matches;
 }
 
-/** Returns whether source constructs one exact class. */
-function sourceContainsNewExpression(
-  sourceFile: ts.SourceFile,
+/** Returns one constructor's object-literal options from an exact expression. */
+function constructorOptionsFromExpression(
+  expression: ts.Expression,
   constructorName: string,
-): boolean {
-  let found = false;
-
-  /** Visits constructor calls until the required class is found. */
-  function visit(node: ts.Node): void {
-    if (found) return;
-    if (
-      ts.isNewExpression(node) &&
-      ts.isIdentifier(node.expression) &&
-      node.expression.text === constructorName
-    ) {
-      found = true;
-      return;
-    }
-    ts.forEachChild(node, visit);
+): ts.ObjectLiteralExpression | null {
+  const unwrapped = unwrapExpression(expression);
+  if (
+    !ts.isNewExpression(unwrapped) ||
+    !ts.isIdentifier(unwrapped.expression) ||
+    unwrapped.expression.text !== constructorName
+  ) {
+    return null;
   }
 
-  visit(sourceFile);
-  return found;
+  const options = unwrapped.arguments?.[0]
+    ? unwrapExpression(unwrapped.arguments[0])
+    : null;
+  return options && ts.isObjectLiteralExpression(options) ? options : null;
 }
 
 /** Returns whether a source contains a call to one exact function or method. */
@@ -1751,7 +1770,7 @@ function expectA2AVisualizationBehavior(contents: string): void {
   expect(jsxNodesWithTag(sourceFile, "CopilotKitProvider")).toHaveLength(0);
 }
 
-/** Asserts AgentCore retains its custom runner and bridge endpoint behavior. */
+/** Asserts AgentCore selects managed Intelligence or its custom local runner. */
 function expectAgentCoreRuntimeBehavior(contents: string): void {
   const sourceFile = parseManagedSource(contents);
   const endpointCalls = sourceCalls(sourceFile, ["createCopilotEndpoint"]);
@@ -1772,7 +1791,47 @@ function expectAgentCoreRuntimeBehavior(contents: string): void {
   expect(requiredAgentUrl).toBe(true);
   expect(newExpressionOptions(sourceFile, "HttpAgent")).toHaveLength(1);
   expect(newExpressionOptions(sourceFile, "MCPAppsMiddleware")).toHaveLength(1);
-  expect(sourceContainsNewExpression(sourceFile, "AgentCoreRunner")).toBe(true);
+
+  const runtimeInitializers = variableInitializers(sourceFile, "runtime");
+  expect(runtimeInitializers).toHaveLength(1);
+  const runtimeSelection = runtimeInitializers[0]
+    ? unwrapExpression(runtimeInitializers[0])
+    : null;
+  expect(runtimeSelection && ts.isConditionalExpression(runtimeSelection)).toBe(
+    true,
+  );
+  if (!runtimeSelection || !ts.isConditionalExpression(runtimeSelection)) {
+    return;
+  }
+
+  expect(
+    expressionUsesManagedKeyWithoutTelemetry(runtimeSelection.condition),
+  ).toBe(true);
+  const managedOptions = constructorOptionsFromExpression(
+    runtimeSelection.whenTrue,
+    "CopilotRuntime",
+  );
+  const localOptions = constructorOptionsFromExpression(
+    runtimeSelection.whenFalse,
+    "CopilotRuntime",
+  );
+  expect(managedOptions).not.toBeNull();
+  expect(localOptions).not.toBeNull();
+  if (!managedOptions || !localOptions) return;
+
+  expect(
+    objectPropertyExpression(managedOptions, "intelligence"),
+  ).not.toBeNull();
+  expect(objectPropertyExpression(managedOptions, "runner")).toBeNull();
+  expect(objectPropertyExpression(localOptions, "intelligence")).toBeNull();
+  const localRunner = objectPropertyExpression(localOptions, "runner");
+  expect(localRunner).not.toBeNull();
+  expect(
+    localRunner &&
+      ts.isNewExpression(unwrapExpression(localRunner)) &&
+      ts.isIdentifier(unwrapExpression(localRunner).expression) &&
+      unwrapExpression(localRunner).expression.text === "AgentCoreRunner",
+  ).toBe(true);
   expect(endpointCalls).toHaveLength(1);
   const endpointOptions = endpointCalls[0]?.arguments[0];
   const unwrappedOptions = endpointOptions
@@ -2736,6 +2795,28 @@ services:
 `;
 
   expect(() => expectAgentCoreNetworkingBehavior(compose)).toThrow();
+});
+
+test("AgentCore preservation helper rejects a custom runner disconnected from Runtime selection", () => {
+  const runtime = `
+    class AgentCoreRunner extends InMemoryAgentRunner {}
+    const disconnectedRunner = new AgentCoreRunner();
+    const runtime = process.env.${MANAGED_API_KEY}
+      ? new CopilotRuntime({
+          agents: {},
+          intelligence: new CopilotKitIntelligence({
+            apiKey: process.env.${MANAGED_API_KEY},
+          }),
+          identifyUser: () => ({ id: "demo-user" }),
+        })
+      : new CopilotRuntime({
+          agents: {},
+          runner: new InMemoryAgentRunner(),
+        });
+    const app = createCopilotEndpoint({ runtime, basePath: "/copilotkit" });
+  `;
+
+  expect(() => expectAgentCoreRuntimeBehavior(runtime)).toThrow();
 });
 
 test("integration parity workflow preserves filters and runs parity before the expected-red managed contract", () => {

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -121,6 +121,8 @@ interface AgentCoreDeployHarnessOptions {
   readonly scriptName: AgentCoreDeployScriptName;
   readonly envFile: AgentCoreDeployEnvironment;
   readonly callerEnvironment?: AgentCoreDeployEnvironment;
+  readonly skipBackend?: boolean;
+  readonly skipFrontend?: boolean;
 }
 
 interface AgentCoreDeployHarnessResult {
@@ -128,6 +130,10 @@ interface AgentCoreDeployHarnessResult {
   readonly output: string;
   readonly cdkEnvironment: string | null;
   readonly secretVersionId: string | null;
+  readonly awsCommands: readonly string[];
+  readonly npmCommands: readonly string[];
+  readonly frontendStackName: string | null;
+  readonly frontendSecretVersionId: string | null;
 }
 
 const LANGGRAPH_RUNTIME_AGENT_CONTRACT = {
@@ -2336,13 +2342,39 @@ function expectAgentCoreDeployScriptContract(contents: string): void {
   const cdkDeployIndex = lines.findIndex((line) =>
     /npx\s+cdk(?:@\S+)?\s+deploy\b/.test(line),
   );
+  const skipBackendGuardIndex = lines.findIndex((line) =>
+    /if\s+\[\s+"\$SKIP_BACKEND"\s+=\s+true\s+\];\s+then/.test(line),
+  );
+  const backendDeployElseIndex = lines.findIndex(
+    (line, index) => index > skipBackendGuardIndex && line.trim() === "else",
+  );
+  const backendDeployEndIndex = lines.findIndex(
+    (line, index) => index > cdkDeployIndex && line.trim() === "fi",
+  );
   const telemetryExportIndex = lines.findIndex((line) =>
     new RegExp(`^\\s*export\\s+${OPTIONAL_TELEMETRY_ID}(?:=|\\s|$)`).test(line),
+  );
+  const secretVersionExportIndex = lines.findIndex((line) =>
+    new RegExp(
+      `^\\s*export\\s+${MANAGED_API_KEY_SECRET_VERSION_ID}(?:=|\\s|$)`,
+    ).test(line),
   );
 
   expect(rootEnvLoadIndex).toBeGreaterThanOrEqual(0);
   expect(secretNameVariable).toBeDefined();
   expect(secretCommands.length).toBeGreaterThan(0);
+  if (
+    secretConfigAssignment === undefined ||
+    secretNameVariable === undefined ||
+    secretCommands[0] === undefined
+  ) {
+    throw new Error("AgentCore secret materialization contract is incomplete");
+  }
+  expect(skipBackendGuardIndex).toBeGreaterThanOrEqual(0);
+  expect(backendDeployElseIndex).toBeGreaterThan(skipBackendGuardIndex);
+  expect(secretConfigAssignment.index).toBeGreaterThan(backendDeployElseIndex);
+  expect(secretVersionExportIndex).toBeGreaterThan(backendDeployElseIndex);
+  expect(backendDeployEndIndex).toBeGreaterThan(cdkDeployIndex);
   expect(telemetryExportIndex).toBeGreaterThan(rootEnvLoadIndex);
   expect(cdkDeployIndex).toBeGreaterThan(
     Math.max(telemetryExportIndex, ...secretCommands.map(({ index }) => index)),
@@ -2359,8 +2391,17 @@ function expectAgentCoreDeployScriptContract(contents: string): void {
       ),
     );
   }
-  expect(rootEnvLoadIndex).toBeLessThan(secretCommands[0]!.index);
-  expect(secretConfigAssignment!.index).toBeLessThan(secretCommands[0]!.index);
+  expect(rootEnvLoadIndex).toBeLessThan(secretCommands[0].index);
+  expect(secretConfigAssignment.index).toBeLessThan(secretCommands[0].index);
+  for (const backendOwnedIndex of [
+    secretConfigAssignment.index,
+    ...secretCommands.map(({ index: commandIndex }) => commandIndex),
+    secretVersionExportIndex,
+    cdkDeployIndex,
+  ]) {
+    expect(backendOwnedIndex).toBeGreaterThan(backendDeployElseIndex);
+    expect(backendOwnedIndex).toBeLessThan(backendDeployEndIndex);
+  }
   expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
 }
 
@@ -2664,9 +2705,14 @@ test("AgentCore structural helpers accept linked root-env, secret, Lambda, and f
   const deployScript = `
     source "$SCRIPT_DIR/.env"
     export ${OPTIONAL_TELEMETRY_ID}
-    CPK_SECRET_NAME=$(read_config ${MANAGED_API_KEY_SECRET_CONFIG})
-    aws secretsmanager create-secret --name "$CPK_SECRET_NAME" --secret-string "$${MANAGED_API_KEY}"
-    npx cdk deploy --all
+    if [ "$SKIP_BACKEND" = true ]; then
+      echo "Skipping backend"
+    else
+      CPK_SECRET_NAME=$(read_config ${MANAGED_API_KEY_SECRET_CONFIG})
+      aws secretsmanager create-secret --name "$CPK_SECRET_NAME" --secret-string "$${MANAGED_API_KEY}"
+      export ${MANAGED_API_KEY_SECRET_VERSION_ID}
+      npx cdk deploy --all
+    fi
   `;
 
   expect(() =>
@@ -2879,6 +2925,38 @@ for (const scriptName of [
       MANAGED_API_KEY_SECRET_VERSION_SENTINEL,
     );
     expect(result.output).not.toContain(MANAGED_API_KEY_SENTINEL);
+  });
+
+  test(`${scriptName} --skip-backend leaves backend secret state untouched while deploying the frontend`, () => {
+    const result = runAgentCoreDeployHarness({
+      scriptName,
+      envFile: {
+        apiUrl: "https://intelligence.example.com/api",
+        gatewayWsUrl: "wss://gateway.example.com/runtime",
+      },
+      skipBackend: true,
+      skipFrontend: false,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.awsCommands).toEqual([
+      "sts get-caller-identity --query Account --output text",
+    ]);
+    expect(result.npmCommands).toEqual([]);
+    expect(result.cdkEnvironment).toBeNull();
+    expect(result.secretVersionId).toBeNull();
+    expect(result.frontendStackName).toBe(
+      scriptName === "deploy-langgraph.sh"
+        ? "agentcore-contract-lg"
+        : "agentcore-contract-st",
+    );
+    expect(result.frontendSecretVersionId).toBe("");
+    expect(result.output).toContain("Skipping backend deploy (--skip-backend)");
+    expect(result.output).not.toContain("Managed Intelligence key stored");
+    expect(result.output).not.toContain(MANAGED_API_KEY_SENTINEL);
+    expect(result.output).not.toContain(
+      MANAGED_API_KEY_SECRET_VERSION_SENTINEL,
+    );
   });
 
   test(`${scriptName} preserves documented caller endpoint overrides over root localhost defaults`, () => {
@@ -3743,6 +3821,17 @@ function agentCoreEndpointAssignment(name: string, value?: string): string {
   return value === undefined ? "" : `${name}=${value}\n`;
 }
 
+/** Read one optional newline-delimited harness capture. */
+function readAgentCoreHarnessLines(capturePath: string): string[] {
+  if (!fs.existsSync(capturePath)) {
+    return [];
+  }
+  return fs
+    .readFileSync(capturePath, "utf8")
+    .split("\n")
+    .filter((line) => line.length > 0);
+}
+
 /** Execute one real AgentCore deploy script against non-networking command stubs. */
 function runAgentCoreDeployHarness(
   options: AgentCoreDeployHarnessOptions,
@@ -3754,9 +3843,16 @@ function runAgentCoreDeployHarness(
     const fakeBin = path.join(harnessDirectory, "bin");
     const cdkDirectory = path.join(harnessDirectory, "infra-cdk");
     const capturePath = path.join(harnessDirectory, "cdk-environment.txt");
+    const awsCapturePath = path.join(harnessDirectory, "aws-commands.txt");
+    const npmCapturePath = path.join(harnessDirectory, "npm-commands.txt");
+    const frontendCapturePath = path.join(
+      harnessDirectory,
+      "frontend-environment.txt",
+    );
     const scriptPath = path.join(harnessDirectory, options.scriptName);
     fs.mkdirSync(fakeBin);
     fs.mkdirSync(cdkDirectory);
+    fs.mkdirSync(path.join(harnessDirectory, "scripts"));
     fs.copyFileSync(
       path.join(integrationsDir, "agentcore", options.scriptName),
       scriptPath,
@@ -3786,15 +3882,25 @@ function runAgentCoreDeployHarness(
       ].join(""),
     );
 
-    for (const command of ["docker", "node", "npm"]) {
+    for (const command of ["docker", "node"]) {
       writeAgentCoreCommandStub(fakeBin, command);
     }
+    writeAgentCoreCommandStub(
+      fakeBin,
+      "npm",
+      [
+        "#!/usr/bin/env bash\n",
+        "set -eu\n",
+        'printf \'%s\\n\' "$*" >> "${NPM_COMMAND_CAPTURE:?}"\n',
+      ].join(""),
+    );
     writeAgentCoreCommandStub(
       fakeBin,
       "aws",
       [
         "#!/usr/bin/env bash\n",
         "set -eu\n",
+        'printf \'%s\\n\' "$*" >> "${AWS_COMMAND_CAPTURE:?}"\n',
         'if [[ "$*" == *"secretsmanager put-secret-value"* || "$*" == *"secretsmanager create-secret"* ]]; then\n',
         `  printf '%s\\n' '${MANAGED_API_KEY_SECRET_VERSION_SENTINEL}'\n`,
         "fi\n",
@@ -3809,12 +3915,27 @@ function runAgentCoreDeployHarness(
         `printf '%s\\n%s\\n%s\\n' "\${${INTELLIGENCE_API_URL}-}" "\${${INTELLIGENCE_GATEWAY_WS_URL}-}" "\${${MANAGED_API_KEY_SECRET_VERSION_ID}-}" > "\${CDK_ENV_CAPTURE:?}"\n`,
       ].join(""),
     );
+    fs.writeFileSync(
+      path.join(harnessDirectory, "scripts", "deploy-frontend.py"),
+      [
+        "import os\n",
+        "import pathlib\n",
+        "import sys\n",
+        'pathlib.Path(os.environ["FRONTEND_CAPTURE"]).write_text(\n',
+        `    f"{sys.argv[1]}\\n{os.environ.get('${MANAGED_API_KEY_SECRET_VERSION_ID}', '')}\\n"\n`,
+        ")\n",
+      ].join(""),
+    );
 
     const environment = { ...process.env };
     delete environment[INTELLIGENCE_API_URL];
     delete environment[INTELLIGENCE_GATEWAY_WS_URL];
+    delete environment[MANAGED_API_KEY_SECRET_VERSION_ID];
     environment.PATH = `${fakeBin}:${process.env.PATH ?? ""}`;
     environment.CDK_ENV_CAPTURE = capturePath;
+    environment.AWS_COMMAND_CAPTURE = awsCapturePath;
+    environment.NPM_COMMAND_CAPTURE = npmCapturePath;
+    environment.FRONTEND_CAPTURE = frontendCapturePath;
     if (options.callerEnvironment?.apiUrl !== undefined) {
       environment[INTELLIGENCE_API_URL] = options.callerEnvironment.apiUrl;
     }
@@ -3823,7 +3944,13 @@ function runAgentCoreDeployHarness(
         options.callerEnvironment.gatewayWsUrl;
     }
 
-    const result = spawnSync("/bin/bash", [scriptPath, "--skip-frontend"], {
+    const scriptArguments = [
+      scriptPath,
+      ...(options.skipFrontend === false ? [] : ["--skip-frontend"]),
+      ...(options.skipBackend === true ? ["--skip-backend"] : []),
+    ];
+    const result = spawnSync("/bin/bash", scriptArguments, {
+      cwd: harnessDirectory,
       encoding: "utf8",
       env: environment,
     });
@@ -3838,7 +3965,19 @@ function runAgentCoreDeployHarness(
     const secretVersionId = capturedEnvironment
       ? (capturedLines[2] ?? null)
       : null;
-    return { status: result.status, output, cdkEnvironment, secretVersionId };
+    const frontendEnvironment = fs.existsSync(frontendCapturePath)
+      ? fs.readFileSync(frontendCapturePath, "utf8").split("\n")
+      : null;
+    return {
+      status: result.status,
+      output,
+      cdkEnvironment,
+      secretVersionId,
+      awsCommands: readAgentCoreHarnessLines(awsCapturePath),
+      npmCommands: readAgentCoreHarnessLines(npmCapturePath),
+      frontendStackName: frontendEnvironment?.[0] ?? null,
+      frontendSecretVersionId: frontendEnvironment?.[1] ?? null,
+    };
   } finally {
     fs.rmSync(harnessDirectory, { force: true, recursive: true });
   }

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -1,4 +1,6 @@
+import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import * as vm from "node:vm";
 
@@ -102,6 +104,25 @@ interface EvaluatedAgentCoreViteConfig {
   readonly define?: {
     readonly [VITE_THREADS_GATE_DEFINITION]?: string;
   };
+}
+
+type AgentCoreDeployScriptName = "deploy-langgraph.sh" | "deploy-strands.sh";
+
+interface AgentCoreDeployEnvironment {
+  readonly apiUrl?: string;
+  readonly gatewayWsUrl?: string;
+}
+
+interface AgentCoreDeployHarnessOptions {
+  readonly scriptName: AgentCoreDeployScriptName;
+  readonly envFile: AgentCoreDeployEnvironment;
+  readonly callerEnvironment?: AgentCoreDeployEnvironment;
+}
+
+interface AgentCoreDeployHarnessResult {
+  readonly status: number | null;
+  readonly output: string;
+  readonly cdkEnvironment: string | null;
 }
 
 const LANGGRAPH_RUNTIME_AGENT_CONTRACT = {
@@ -2747,6 +2768,107 @@ test("AgentCore deployment helper rejects endpoint literals disconnected from th
   ).toThrow();
 });
 
+test("AgentCore README documents caller-overridden remote endpoints for both AWS deploy variants", () => {
+  const readme = fs.readFileSync(
+    path.join(integrationsDir, "agentcore", "README.md"),
+    "utf8",
+  );
+
+  expectAgentCoreAwsEndpointReadmeContract(readme);
+});
+
+for (const scriptName of [
+  "deploy-langgraph.sh",
+  "deploy-strands.sh",
+] as const) {
+  test(`${scriptName} validates AWS endpoint overrides before secret or CDK commands`, () => {
+    const deployScript = fs.readFileSync(
+      path.join(integrationsDir, "agentcore", scriptName),
+      "utf8",
+    );
+
+    expectAgentCoreAwsEndpointDeployContract(deployScript);
+  });
+
+  for (const invalidEndpoint of [
+    {
+      label: "localhost API URL",
+      envFile: {
+        apiUrl: "http://localhost:4201",
+        gatewayWsUrl: "wss://gateway.example.com/runtime",
+      },
+      expectedVariable: INTELLIGENCE_API_URL,
+    },
+    {
+      label: "127.0.0.1 gateway URL",
+      envFile: {
+        apiUrl: "https://intelligence.example.com/api",
+        gatewayWsUrl: "ws://127.0.0.1:4401",
+      },
+      expectedVariable: INTELLIGENCE_GATEWAY_WS_URL,
+    },
+    {
+      label: "empty gateway URL",
+      envFile: {
+        apiUrl: "https://intelligence.example.com/api",
+        gatewayWsUrl: "",
+      },
+      expectedVariable: INTELLIGENCE_GATEWAY_WS_URL,
+    },
+  ] as const) {
+    test(`${scriptName} rejects ${invalidEndpoint.label} without exposing the managed key`, () => {
+      const result = runAgentCoreDeployHarness({
+        scriptName,
+        envFile: invalidEndpoint.envFile,
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.output).toContain(invalidEndpoint.expectedVariable);
+      expect(result.output).toMatch(/reachable from AWS/i);
+      expect(result.output).not.toContain(MANAGED_API_KEY_SENTINEL);
+      expect(result.cdkEnvironment).toBeNull();
+    });
+  }
+
+  test(`${scriptName} accepts sourced HTTPS and WSS endpoints and passes them to CDK`, () => {
+    const result = runAgentCoreDeployHarness({
+      scriptName,
+      envFile: {
+        apiUrl: "https://intelligence.example.com/api",
+        gatewayWsUrl: "wss://gateway.example.com/runtime",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.cdkEnvironment).toBe(
+      "https://intelligence.example.com/api\n" +
+        "wss://gateway.example.com/runtime\n",
+    );
+    expect(result.output).not.toContain(MANAGED_API_KEY_SENTINEL);
+  });
+
+  test(`${scriptName} preserves documented caller endpoint overrides over root localhost defaults`, () => {
+    const result = runAgentCoreDeployHarness({
+      scriptName,
+      envFile: {
+        apiUrl: "http://localhost:4201",
+        gatewayWsUrl: "ws://localhost:4401",
+      },
+      callerEnvironment: {
+        apiUrl: "https://managed-intelligence.example.com/api",
+        gatewayWsUrl: "wss://managed-gateway.example.com/runtime",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.cdkEnvironment).toBe(
+      "https://managed-intelligence.example.com/api\n" +
+        "wss://managed-gateway.example.com/runtime\n",
+    );
+    expect(result.output).not.toContain(MANAGED_API_KEY_SENTINEL);
+  });
+}
+
 test("managed TypeScript helpers reject malformed source", () => {
   const malformedRuntime = `
     const intelligence = new CopilotKitIntelligence({
@@ -3510,5 +3632,162 @@ for (const contract of MANAGED_TEMPLATE_CONTRACTS) {
         expectAgentCoreDeployScriptContract(deployScript);
       }
     });
+  }
+}
+
+/** Assert AgentCore's AWS instructions require caller-provided remote endpoints. */
+function expectAgentCoreAwsEndpointReadmeContract(contents: string): void {
+  expect(contents).toMatch(/managed or self-hosted Intelligence endpoints/i);
+  expect(contents).toMatch(/reachable from AWS/i);
+  expect(contents).toMatch(
+    /must not use[\s`]*localhost[\s\S]{0,40}127\.0\.0\.1/i,
+  );
+
+  for (const scriptName of [
+    "deploy-langgraph.sh",
+    "deploy-strands.sh",
+  ] as const) {
+    expect(contents).toMatch(
+      new RegExp(
+        `INTELLIGENCE_API_URL=https://[^\\s]+[\\s\\S]{0,200}` +
+          `INTELLIGENCE_GATEWAY_WS_URL=wss://[^\\s]+[\\s\\S]{0,200}` +
+          `\\./${scriptName.replace(".", "\\.")}`,
+      ),
+    );
+  }
+}
+
+/** Assert one AgentCore deploy script validates remote endpoints before AWS writes. */
+function expectAgentCoreAwsEndpointDeployContract(contents: string): void {
+  const normalized = contents.replace(/\\\r?\n\s*/g, " ");
+  const lines = normalized.split(/\r?\n/);
+  const rootEnvLoadIndex = lines.findIndex((line) =>
+    /(?:^|\s)(?:source|\.)\s+["']?\$\{?SCRIPT_DIR\}?\/\.env["']?(?:\s|$)/.test(
+      line,
+    ),
+  );
+  const apiGuardIndex = lines.findIndex((line) =>
+    /require_remote_endpoint\s+INTELLIGENCE_API_URL\b/.test(line),
+  );
+  const gatewayGuardIndex = lines.findIndex((line) =>
+    /require_remote_endpoint\s+INTELLIGENCE_GATEWAY_WS_URL\b/.test(line),
+  );
+  const firstAwsWriteIndex = lines.findIndex((line) =>
+    /aws\s+secretsmanager\s+(?:create-secret|put-secret-value)\b/.test(line),
+  );
+  const cdkDeployIndex = lines.findIndex((line) =>
+    /npx\s+cdk(?:@\S+)?\s+deploy\b/.test(line),
+  );
+
+  expect(contents).toContain("${INTELLIGENCE_API_URL+x}");
+  expect(contents).toContain("${INTELLIGENCE_GATEWAY_WS_URL+x}");
+  expect(contents).toContain("localhost");
+  expect(contents).toContain("127\\.0\\.0\\.1");
+  expect(apiGuardIndex).toBeGreaterThan(rootEnvLoadIndex);
+  expect(gatewayGuardIndex).toBeGreaterThan(rootEnvLoadIndex);
+  expect(firstAwsWriteIndex).toBeGreaterThan(
+    Math.max(apiGuardIndex, gatewayGuardIndex),
+  );
+  expect(cdkDeployIndex).toBeGreaterThan(
+    Math.max(apiGuardIndex, gatewayGuardIndex),
+  );
+}
+
+/** Write one executable command stub into an AgentCore deploy harness. */
+function writeAgentCoreCommandStub(
+  directory: string,
+  command: string,
+  contents = "#!/usr/bin/env bash\nexit 0\n",
+): void {
+  const commandPath = path.join(directory, command);
+  fs.writeFileSync(commandPath, contents);
+  fs.chmodSync(commandPath, 0o755);
+}
+
+/** Render one optional endpoint into a shell environment assignment. */
+function agentCoreEndpointAssignment(name: string, value?: string): string {
+  return value === undefined ? "" : `${name}=${value}\n`;
+}
+
+/** Execute one real AgentCore deploy script against non-networking command stubs. */
+function runAgentCoreDeployHarness(
+  options: AgentCoreDeployHarnessOptions,
+): AgentCoreDeployHarnessResult {
+  const harnessDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "agentcore-deploy-contract-"),
+  );
+  try {
+    const fakeBin = path.join(harnessDirectory, "bin");
+    const cdkDirectory = path.join(harnessDirectory, "infra-cdk");
+    const capturePath = path.join(harnessDirectory, "cdk-environment.txt");
+    const scriptPath = path.join(harnessDirectory, options.scriptName);
+    fs.mkdirSync(fakeBin);
+    fs.mkdirSync(cdkDirectory);
+    fs.copyFileSync(
+      path.join(integrationsDir, "agentcore", options.scriptName),
+      scriptPath,
+    );
+    fs.writeFileSync(
+      path.join(harnessDirectory, ".env"),
+      [
+        `${MANAGED_API_KEY}=${MANAGED_API_KEY_SENTINEL}\n`,
+        `${OPTIONAL_TELEMETRY_ID}=agentcore-test-telemetry\n`,
+        agentCoreEndpointAssignment(
+          INTELLIGENCE_API_URL,
+          options.envFile.apiUrl,
+        ),
+        agentCoreEndpointAssignment(
+          INTELLIGENCE_GATEWAY_WS_URL,
+          options.envFile.gatewayWsUrl,
+        ),
+      ].join(""),
+    );
+    fs.writeFileSync(
+      path.join(harnessDirectory, "config.yaml"),
+      [
+        "stack_name_base: agentcore-contract\n",
+        `${MANAGED_API_KEY_SECRET_CONFIG}: agentcore/contract/key\n`,
+        "backend:\n",
+        "  pattern: placeholder\n",
+      ].join(""),
+    );
+
+    for (const command of ["aws", "docker", "node", "npm"]) {
+      writeAgentCoreCommandStub(fakeBin, command);
+    }
+    writeAgentCoreCommandStub(
+      fakeBin,
+      "npx",
+      [
+        "#!/usr/bin/env bash\n",
+        "set -eu\n",
+        `printf '%s\\n%s\\n' "\${${INTELLIGENCE_API_URL}-}" "\${${INTELLIGENCE_GATEWAY_WS_URL}-}" > "\${CDK_ENV_CAPTURE:?}"\n`,
+      ].join(""),
+    );
+
+    const environment = { ...process.env };
+    delete environment[INTELLIGENCE_API_URL];
+    delete environment[INTELLIGENCE_GATEWAY_WS_URL];
+    environment.PATH = `${fakeBin}:${process.env.PATH ?? ""}`;
+    environment.CDK_ENV_CAPTURE = capturePath;
+    if (options.callerEnvironment?.apiUrl !== undefined) {
+      environment[INTELLIGENCE_API_URL] = options.callerEnvironment.apiUrl;
+    }
+    if (options.callerEnvironment?.gatewayWsUrl !== undefined) {
+      environment[INTELLIGENCE_GATEWAY_WS_URL] =
+        options.callerEnvironment.gatewayWsUrl;
+    }
+
+    const result = spawnSync("/bin/bash", [scriptPath, "--skip-frontend"], {
+      encoding: "utf8",
+      env: environment,
+    });
+    const output = `${result.stdout}${result.stderr}`;
+    const cdkEnvironment = fs.existsSync(capturePath)
+      ? fs.readFileSync(capturePath, "utf8")
+      : null;
+    return { status: result.status, output, cdkEnvironment };
+  } finally {
+    fs.rmSync(harnessDirectory, { force: true, recursive: true });
   }
 }

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -575,40 +575,59 @@ function expressionUsesManagedBooleanGate(expression: ts.Expression): boolean {
   );
 }
 
-/** Returns whether a CopilotKit Intelligence constructor owns the API-key read. */
-function hasRuntimeApiKeyRead(sourceFile: ts.SourceFile): boolean {
-  let found = false;
-
-  /** Visits constructors until the managed Intelligence API-key option is found. */
-  function visit(node: ts.Node): void {
-    if (found) {
-      return;
-    }
-
+/** Returns the expression assigned to one exact object-literal property. */
+function objectPropertyExpression(
+  objectLiteral: ts.ObjectLiteralExpression,
+  name: string,
+): ts.Expression | null {
+  for (const property of objectLiteral.properties) {
     if (
-      ts.isNewExpression(node) &&
-      ts.isIdentifier(node.expression) &&
-      node.expression.text === "CopilotKitIntelligence"
+      ts.isPropertyAssignment(property) &&
+      propertyNameText(property.name) === name
     ) {
-      const options = node.arguments?.[0];
-      const unwrappedOptions = options ? unwrapExpression(options) : null;
-      if (unwrappedOptions && ts.isObjectLiteralExpression(unwrappedOptions)) {
-        const apiKey = objectPropertyAssignment(unwrappedOptions, "apiKey");
-        if (
-          apiKey &&
-          expressionUsesManagedKeyWithoutTelemetry(apiKey.initializer)
-        ) {
-          found = true;
-          return;
-        }
-      }
+      return property.initializer;
     }
-
-    ts.forEachChild(node, visit);
+    if (
+      ts.isShorthandPropertyAssignment(property) &&
+      property.name.text === name
+    ) {
+      return property.name;
+    }
   }
 
-  visit(sourceFile);
-  return found;
+  return null;
+}
+
+/** Returns whether the Runtime's Intelligence client owns the API-key read. */
+function hasRuntimeApiKeyRead(sourceFile: ts.SourceFile): boolean {
+  return newExpressionOptions(sourceFile, "CopilotRuntime").some(
+    (runtimeOptions) => {
+      const intelligence = objectPropertyExpression(
+        runtimeOptions,
+        "intelligence",
+      );
+      if (!intelligence) return false;
+
+      const client = resolveTopLevelExpression(sourceFile, intelligence);
+      if (
+        !ts.isNewExpression(client) ||
+        !ts.isIdentifier(client.expression) ||
+        client.expression.text !== "CopilotKitIntelligence"
+      ) {
+        return false;
+      }
+
+      const options = client.arguments?.[0]
+        ? unwrapExpression(client.arguments[0])
+        : null;
+      if (!options || !ts.isObjectLiteralExpression(options)) return false;
+
+      const apiKey = objectPropertyAssignment(options, "apiKey");
+      return Boolean(
+        apiKey && expressionUsesManagedKeyWithoutTelemetry(apiKey.initializer),
+      );
+    },
+  );
 }
 
 /** Returns the initializer for one top-level variable identifier. */
@@ -632,6 +651,27 @@ function topLevelVariableInitializer(
   }
 
   return null;
+}
+
+/** Resolves transparent wrappers and top-level variable aliases. */
+function resolveTopLevelExpression(
+  sourceFile: ts.SourceFile,
+  expression: ts.Expression,
+  seenIdentifiers: ReadonlySet<string> = new Set(),
+): ts.Expression {
+  const unwrapped = unwrapExpression(expression);
+  if (!ts.isIdentifier(unwrapped) || seenIdentifiers.has(unwrapped.text)) {
+    return unwrapped;
+  }
+
+  const initializer = topLevelVariableInitializer(sourceFile, unwrapped.text);
+  if (!initializer) return unwrapped;
+
+  return resolveTopLevelExpression(
+    sourceFile,
+    initializer,
+    new Set([...seenIdentifiers, unwrapped.text]),
+  );
 }
 
 /** Resolves one registered agent through an optional top-level identifier. */
@@ -2119,6 +2159,47 @@ test("managed TypeScript helpers reject decoy configured properties", () => {
   expect(() => expectManagedGateContract(decoyViteGateRead)).toThrow();
 });
 
+test.each([
+  {
+    name: "inline client",
+    source: `
+      const runtime = new CopilotRuntime({
+        agents: {},
+        intelligence: new CopilotKitIntelligence({
+          apiKey: process.env.CPK_INTELLIGENCE_API_KEY,
+        }),
+      });
+    `,
+  },
+  {
+    name: "bound client",
+    source: `
+      const intelligence = new CopilotKitIntelligence({
+        apiKey: process.env.CPK_INTELLIGENCE_API_KEY,
+      });
+      const runtime = new CopilotRuntime({ agents: {}, intelligence });
+    `,
+  },
+])(
+  "managed Runtime helper accepts a $name wired into the Runtime",
+  ({ source }) => {
+    expect(() => expectManagedRuntimeContract(source)).not.toThrow();
+  },
+);
+
+test("managed Runtime helper rejects a configured Intelligence client that is not wired into the Runtime", () => {
+  const unusedConfiguredClient = `
+    const intelligence = new CopilotKitIntelligence({
+      apiKey: process.env.CPK_INTELLIGENCE_API_KEY,
+    });
+    const runtime = new CopilotRuntime({
+      agents: { default: new HttpAgent({ url: "http://localhost:8000" }) },
+    });
+  `;
+
+  expect(() => expectManagedRuntimeContract(unusedConfiguredClient)).toThrow();
+});
+
 test("managed gate helpers reject direct, concatenated, comment-only, and decoy key exposure", () => {
   const invalidGateSources = [
     `export default { env: { ${NEXT_THREADS_GATE}: process.env.${MANAGED_API_KEY} } };`,
@@ -2314,6 +2395,7 @@ test("managed TypeScript helpers accept independent telemetry reads", () => {
     const intelligence = new CopilotKitIntelligence({
       apiKey: process.env["CPK_INTELLIGENCE_API_KEY"] ?? "",
     });
+    const runtime = new CopilotRuntime({ agents: {}, intelligence });
   `;
   const configuredGateRead = `
     const telemetryId = process.env["CPK_TELEMETRY_ID"];
@@ -2350,6 +2432,7 @@ test("managed TypeScript helpers reject telemetry prerequisites", () => {
         process.env.CPK_INTELLIGENCE_API_KEY &&
         process.env.CPK_TELEMETRY_ID,
     });
+    const runtime = new CopilotRuntime({ agents: {}, intelligence });
   `;
   const telemetryGatedNextConfig = `
     const nextConfig = {

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -2870,6 +2870,15 @@ test("the 16 managed template directories back all 19 in-repo CLI frameworks", (
   expect([...frameworks].sort()).toEqual([...MANAGED_CLI_FRAMEWORKS].sort());
 });
 
+test("Mastra explicitly includes its generated managed env example", () => {
+  const gitignore = fs.readFileSync(
+    path.join(integrationsDir, "mastra", ".gitignore"),
+    "utf8",
+  );
+
+  expect(gitignore).toMatch(/^!\.env\.example$/m);
+});
+
 test.each([
   {
     defect: "registered constructor changes",

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -103,6 +103,18 @@ const LANGGRAPH_RUNTIME_AGENT_CONTRACT = {
   ],
 } as const satisfies RuntimeAgentContract;
 
+const LANGGRAPH_FASTAPI_RUNTIME_AGENT_CONTRACT = {
+  registration: "default",
+  constructorName: "LangGraphHttpAgent",
+  options: [
+    {
+      property: "url",
+      environmentReads: ["AGENT_URL"],
+      stringLiterals: ["http://localhost:8123"],
+    },
+  ],
+} as const satisfies RuntimeAgentContract;
+
 const HTTP_LOCALHOST_RUNTIME_AGENT_CONTRACT = {
   registration: "default",
   constructorName: "HttpAgent",
@@ -187,6 +199,15 @@ const MANAGED_TEMPLATE_CONTRACTS = [
     envPath: ".env.example",
     readmePath: "README.md",
     runtimeAgent: LANGGRAPH_RUNTIME_AGENT_CONTRACT,
+  },
+  {
+    directory: "langgraph-fastapi",
+    frameworks: [],
+    runtimePath: "src/app/api/copilotkit/[[...slug]]/route.ts",
+    gatePath: "next.config.ts",
+    envPath: ".env.example",
+    readmePath: "README.md",
+    runtimeAgent: LANGGRAPH_FASTAPI_RUNTIME_AGENT_CONTRACT,
   },
   {
     directory: "claude-sdk-typescript",
@@ -2856,7 +2877,7 @@ jobs:
   ).toThrow();
 });
 
-test("the 16 managed template directories back all 19 in-repo CLI frameworks", () => {
+test("the 17 managed template directories back all 19 in-repo CLI frameworks", () => {
   const frameworks = MANAGED_TEMPLATE_CONTRACTS.flatMap(
     (contract) => contract.frameworks,
   );
@@ -2864,8 +2885,8 @@ test("the 16 managed template directories back all 19 in-repo CLI frameworks", (
     (contract) => "runtimeAgent" in contract,
   );
 
-  expect(MANAGED_TEMPLATE_CONTRACTS).toHaveLength(16);
-  expect(ordinaryRuntimeContracts).toHaveLength(13);
+  expect(MANAGED_TEMPLATE_CONTRACTS).toHaveLength(17);
+  expect(ordinaryRuntimeContracts).toHaveLength(14);
   expect(new Set(frameworks).size).toBe(19);
   expect([...frameworks].sort()).toEqual([...MANAGED_CLI_FRAMEWORKS].sort());
 });

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -12,6 +12,10 @@ const OPTIONAL_TELEMETRY_ID = "CPK_TELEMETRY_ID";
 const LEGACY_API_KEY = "INTELLIGENCE_API_KEY";
 const LEGACY_TELEMETRY_ID = "COPILOTKIT_TELEMETRY_ID";
 const MANAGED_LICENSE_TOKEN = "COPILOTKIT_LICENSE_TOKEN";
+const MANAGED_API_KEY_SECRET_CONFIG =
+  "copilotkit_intelligence_api_key_secret_name";
+const NEXT_THREADS_GATE = "NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED";
+const VITE_THREADS_GATE = "VITE_COPILOTKIT_THREADS_ENABLED";
 
 const MANAGED_CLI_FRAMEWORKS = [
   "langgraph-py",
@@ -44,6 +48,13 @@ interface ManagedTemplateContract {
   readonly gatePath: string;
   readonly envPath: string;
   readonly readmePath: string;
+  readonly supportedPaths?: {
+    readonly localComposePath: string;
+    readonly deploymentConfigPath: string;
+    readonly runtimeDeploymentPath: string;
+    readonly frontendDeploymentPath: string;
+    readonly deployScriptPaths: readonly string[];
+  };
 }
 
 const MANAGED_TEMPLATE_CONTRACTS = [
@@ -172,8 +183,15 @@ const MANAGED_TEMPLATE_CONTRACTS = [
     frameworks: ["agentcore-langgraph", "agentcore-strands"],
     runtimePath: "infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts",
     gatePath: "frontend/vite.config.ts",
-    envPath: "docker/.env.example",
+    envPath: ".env.example",
     readmePath: "README.md",
+    supportedPaths: {
+      localComposePath: "docker/docker-compose.yml",
+      deploymentConfigPath: "config.yaml.example",
+      runtimeDeploymentPath: "infra-cdk/lib/backend-stack.ts",
+      frontendDeploymentPath: "infra-cdk/lib/amplify-hosting-stack.ts",
+      deployScriptPaths: ["deploy-langgraph.sh", "deploy-strands.sh"],
+    },
   },
 ] as const satisfies readonly ManagedTemplateContract[];
 
@@ -199,6 +217,44 @@ function readManagedSurface(
   ).toBe(true);
 
   return exists ? fs.readFileSync(filePath, "utf8") : "";
+}
+
+/**
+ * Returns one two-space-indented YAML mapping section.
+ *
+ * @param contents - YAML source containing service-style mappings.
+ * @param name - Mapping key whose complete section should be returned.
+ * @returns The mapping section, or an empty string when it is absent.
+ */
+function yamlMappingSection(contents: string, name: string): string {
+  const lines = contents.split(/\r?\n/);
+  const start = lines.findIndex((line) => line === `  ${name}:`);
+  if (start < 0) {
+    return "";
+  }
+
+  const relativeEnd = lines
+    .slice(start + 1)
+    .findIndex((line) => /^  [^\s].*:\s*$/.test(line));
+  const end = relativeEnd < 0 ? lines.length : start + relativeEnd + 1;
+  return lines.slice(start, end).join("\n");
+}
+
+/** Matches a service-level reference to the generated project's root env. */
+function rootManagedEnvFilePattern(): RegExp {
+  return /env_file:\s*(?:\r?\n\s*-\s*)?\.\.\/\.env\b/;
+}
+
+/** Matches a deployment config key without constraining its safe reference. */
+function deploymentConfigReferencePattern(identifier: string): RegExp {
+  return new RegExp(`^\\s*${identifier}\\s*:`, "m");
+}
+
+/** Matches two required terms close enough to belong to one configuration. */
+function nearbyTermsPattern(first: string, second: string): RegExp {
+  return new RegExp(
+    `(?:${first}[\\s\\S]{0,400}${second}|${second}[\\s\\S]{0,400}${first})`,
+  );
 }
 
 /**
@@ -423,9 +479,9 @@ function expectManagedGateContract(contents: string): void {
       contents,
       MANAGED_API_KEY,
       (name) =>
-        name === "NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED" ||
-        name === "VITE_COPILOTKIT_THREADS_ENABLED" ||
-        name.endsWith(".VITE_COPILOTKIT_THREADS_ENABLED"),
+        name === NEXT_THREADS_GATE ||
+        name === VITE_THREADS_GATE ||
+        name.endsWith(`.${VITE_THREADS_GATE}`),
     ),
   ).toBe(true);
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_API_KEY));
@@ -467,6 +523,61 @@ function expectManagedReadmeContract(contents: string): void {
 
   const managedSection = markdownSectionContaining(contents, MANAGED_API_KEY);
   expect(managedSection).not.toContain(MANAGED_LICENSE_TOKEN);
+}
+
+/** Assert AgentCore local services consume the CLI-managed root env safely. */
+function expectAgentCoreLocalComposeContract(contents: string): void {
+  const bridge = yamlMappingSection(contents, "bridge");
+  const frontend = yamlMappingSection(contents, "frontend");
+
+  expect(bridge).toMatch(rootManagedEnvFilePattern());
+  expect(frontend).toMatch(rootManagedEnvFilePattern());
+  expect(frontend).not.toContain(VITE_THREADS_GATE);
+  expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_API_KEY));
+  expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_TELEMETRY_ID));
+  expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
+}
+
+/** Assert AgentCore deploy configuration carries only a secret reference. */
+function expectAgentCoreDeploymentConfigContract(contents: string): void {
+  expect(contents).toMatch(
+    deploymentConfigReferencePattern(MANAGED_API_KEY_SECRET_CONFIG),
+  );
+  expect(contents).not.toMatch(exactEnvIdentifierPattern(MANAGED_API_KEY));
+  expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
+}
+
+/** Assert AgentCore's deployed Lambda resolves the managed key from a secret. */
+function expectAgentCoreRuntimeDeploymentContract(contents: string): void {
+  expect(contents).toMatch(
+    nearbyTermsPattern(MANAGED_API_KEY, MANAGED_API_KEY_SECRET_CONFIG),
+  );
+  expect(contents).toMatch(/\b(?:SecretValue|secretsmanager|secretName)\b/i);
+  expect(contents).not.toMatch(
+    new RegExp(`${MANAGED_API_KEY}\\s*:\\s*["'\\x60]`),
+  );
+  expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
+}
+
+/** Assert AgentCore's frontend receives only the key-derived public gate. */
+function expectAgentCoreFrontendDeploymentContract(contents: string): void {
+  expect(contents).toMatch(
+    nearbyTermsPattern(VITE_THREADS_GATE, MANAGED_API_KEY_SECRET_CONFIG),
+  );
+  expect(contents).not.toMatch(exactEnvIdentifierPattern(MANAGED_API_KEY));
+  expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
+}
+
+/** Assert an AgentCore variant deploy script safely materializes its key secret. */
+function expectAgentCoreDeployScriptContract(contents: string): void {
+  expect(contents).toContain(".env");
+  expect(contents).toMatch(exactEnvIdentifierPattern(MANAGED_API_KEY));
+  expect(contents).toContain(MANAGED_API_KEY_SECRET_CONFIG);
+  expect(contents).toMatch(
+    /aws\s+secretsmanager\s+(?:create-secret|put-secret-value)/,
+  );
+  expect(contents).toMatch(/npx\s+cdk(?:@\S+)?\s+deploy/);
+  expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
 }
 
 test("managed TypeScript helpers reject API-key identifiers outside configured expressions", () => {
@@ -593,4 +704,58 @@ for (const contract of MANAGED_TEMPLATE_CONTRACTS) {
 
     expectManagedReadmeContract(readme);
   });
+
+  if ("supportedPaths" in contract) {
+    const supportedPaths = contract.supportedPaths;
+    test(`${contract.directory} local Compose consumes the root managed env`, () => {
+      const compose = readManagedSurface(
+        contract,
+        supportedPaths.localComposePath,
+        "local Compose config",
+      );
+
+      expectAgentCoreLocalComposeContract(compose);
+    });
+
+    test(`${contract.directory} deployment config stores a managed key secret reference`, () => {
+      const deploymentConfig = readManagedSurface(
+        contract,
+        supportedPaths.deploymentConfigPath,
+        "deployment config",
+      );
+
+      expectAgentCoreDeploymentConfigContract(deploymentConfig);
+    });
+
+    test(`${contract.directory} deployed Lambda resolves the managed key secret`, () => {
+      const runtimeDeployment = readManagedSurface(
+        contract,
+        supportedPaths.runtimeDeploymentPath,
+        "runtime deployment config",
+      );
+
+      expectAgentCoreRuntimeDeploymentContract(runtimeDeployment);
+    });
+
+    test(`${contract.directory} deployed frontend receives only the key-derived gate`, () => {
+      const frontendDeployment = readManagedSurface(
+        contract,
+        supportedPaths.frontendDeploymentPath,
+        "frontend deployment config",
+      );
+
+      expectAgentCoreFrontendDeploymentContract(frontendDeployment);
+    });
+
+    test(`${contract.directory} deploy scripts materialize the configured managed key secret`, () => {
+      for (const deployScriptPath of supportedPaths.deployScriptPaths) {
+        const deployScript = readManagedSurface(
+          contract,
+          deployScriptPath,
+          "deploy script",
+        );
+        expectAgentCoreDeployScriptContract(deployScript);
+      }
+    });
+  }
 }

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -1,406 +1,385 @@
-import { describe, expect, it, test } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
+
+import { expect, test } from "vitest";
 
 const repoRoot = path.resolve(__dirname, "..", "..");
 const integrationsDir = path.join(repoRoot, "examples", "integrations");
 
-const migratedIntegrations = [
-  "crewai-flows",
-  "llamaindex",
-  "langgraph-fastapi",
+const MANAGED_API_KEY = "CPK_INTELLIGENCE_API_KEY";
+const OPTIONAL_TELEMETRY_ID = "CPK_TELEMETRY_ID";
+const LEGACY_API_KEY = "INTELLIGENCE_API_KEY";
+const LEGACY_TELEMETRY_ID = "COPILOTKIT_TELEMETRY_ID";
+const MANAGED_LICENSE_TOKEN = "COPILOTKIT_LICENSE_TOKEN";
+
+const MANAGED_CLI_FRAMEWORKS = [
+  "langgraph-py",
+  "langgraph-js",
+  "claude-sdk-typescript",
+  "claude-sdk-python",
+  "flows",
+  "mastra",
   "pydantic-ai",
+  "llamaindex",
+  "agno",
+  "adk",
+  "aws-strands-py",
+  "a2a",
+  "microsoft-agent-framework-dotnet",
+  "microsoft-agent-framework-py",
   "mcp-apps",
-  "agent-spec",
-  "strands-python",
-  "crewai-crews",
+  "agentcore-langgraph",
+  "agentcore-strands",
+  "a2ui",
+  "opengenui",
 ] as const;
-const a2aMiddlewareRoot = path.join(integrationsDir, "a2a-middleware");
 
-const appRoots: Record<(typeof migratedIntegrations)[number], string> = {
-  "crewai-flows": "src/app",
-  llamaindex: "src/app",
-  "langgraph-fastapi": "src/app",
-  "pydantic-ai": "src/app",
-  "mcp-apps": "app",
-  "agent-spec": "src/app",
-  "strands-python": "src/app",
-  "crewai-crews": "src/app",
-};
+type ManagedCliFramework = (typeof MANAGED_CLI_FRAMEWORKS)[number];
 
-function readIntegrationFile(
-  integration: string,
+interface ManagedTemplateContract {
+  readonly directory: string;
+  readonly frameworks: readonly ManagedCliFramework[];
+  readonly runtimePath: string;
+  readonly gatePath: string;
+  readonly envPath: string;
+  readonly readmePath: string;
+}
+
+const MANAGED_TEMPLATE_CONTRACTS = [
+  {
+    directory: "langgraph-python",
+    frameworks: ["langgraph-py", "a2ui", "opengenui"],
+    runtimePath: "src/app/api/copilotkit/[[...slug]]/route.ts",
+    gatePath: "next.config.ts",
+    envPath: ".env.example",
+    readmePath: "README.md",
+  },
+  {
+    directory: "langgraph-js",
+    frameworks: ["langgraph-js"],
+    runtimePath: "src/app/api/copilotkit/[[...slug]]/route.ts",
+    gatePath: "next.config.ts",
+    envPath: ".env.example",
+    readmePath: "README.md",
+  },
+  {
+    directory: "claude-sdk-typescript",
+    frameworks: ["claude-sdk-typescript"],
+    runtimePath: "src/app/api/copilotkit/[[...slug]]/route.ts",
+    gatePath: "next.config.ts",
+    envPath: ".env.example",
+    readmePath: "README.md",
+  },
+  {
+    directory: "claude-sdk-python",
+    frameworks: ["claude-sdk-python"],
+    runtimePath: "src/app/api/copilotkit/[[...slug]]/route.ts",
+    gatePath: "next.config.ts",
+    envPath: ".env.example",
+    readmePath: "README.md",
+  },
+  {
+    directory: "crewai-flows",
+    frameworks: ["flows"],
+    runtimePath: "src/app/api/copilotkit/[[...slug]]/route.ts",
+    gatePath: "next.config.ts",
+    envPath: ".env.example",
+    readmePath: "README.md",
+  },
+  {
+    directory: "mastra",
+    frameworks: ["mastra"],
+    runtimePath: "src/app/api/copilotkit/[[...slug]]/route.ts",
+    gatePath: "next.config.ts",
+    envPath: ".env.example",
+    readmePath: "README.md",
+  },
+  {
+    directory: "pydantic-ai",
+    frameworks: ["pydantic-ai"],
+    runtimePath: "src/app/api/copilotkit/[[...slug]]/route.ts",
+    gatePath: "next.config.ts",
+    envPath: ".env.example",
+    readmePath: "README.md",
+  },
+  {
+    directory: "llamaindex",
+    frameworks: ["llamaindex"],
+    runtimePath: "src/app/api/copilotkit/[[...slug]]/route.ts",
+    gatePath: "next.config.ts",
+    envPath: ".env.example",
+    readmePath: "README.md",
+  },
+  {
+    directory: "agno",
+    frameworks: ["agno"],
+    runtimePath: "src/app/api/copilotkit/[[...slug]]/route.ts",
+    gatePath: "next.config.ts",
+    envPath: ".env.example",
+    readmePath: "README.md",
+  },
+  {
+    directory: "adk",
+    frameworks: ["adk"],
+    runtimePath: "src/app/api/copilotkit/[[...slug]]/route.ts",
+    gatePath: "next.config.ts",
+    envPath: ".env.example",
+    readmePath: "README.md",
+  },
+  {
+    directory: "strands-python",
+    frameworks: ["aws-strands-py"],
+    runtimePath: "src/app/api/copilotkit/[[...slug]]/route.ts",
+    gatePath: "next.config.ts",
+    envPath: ".env.example",
+    readmePath: "README.md",
+  },
+  {
+    directory: "a2a-middleware",
+    frameworks: ["a2a"],
+    runtimePath: "app/api/copilotkit/[[...slug]]/route.ts",
+    gatePath: "next.config.ts",
+    envPath: ".env.example",
+    readmePath: "README.md",
+  },
+  {
+    directory: "ms-agent-framework-dotnet",
+    frameworks: ["microsoft-agent-framework-dotnet"],
+    runtimePath: "src/app/api/copilotkit/[[...slug]]/route.ts",
+    gatePath: "next.config.ts",
+    envPath: ".env.example",
+    readmePath: "README.md",
+  },
+  {
+    directory: "ms-agent-framework-python",
+    frameworks: ["microsoft-agent-framework-py"],
+    runtimePath: "src/app/api/copilotkit/[[...slug]]/route.ts",
+    gatePath: "next.config.ts",
+    envPath: ".env.example",
+    readmePath: "README.md",
+  },
+  {
+    directory: "mcp-apps",
+    frameworks: ["mcp-apps"],
+    runtimePath: "app/api/copilotkit/[[...slug]]/route.ts",
+    gatePath: "next.config.ts",
+    envPath: ".env.example",
+    readmePath: "README.md",
+  },
+  {
+    directory: "agentcore",
+    frameworks: ["agentcore-langgraph", "agentcore-strands"],
+    runtimePath: "infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts",
+    gatePath: "frontend/vite.config.ts",
+    envPath: "docker/.env.example",
+    readmePath: "README.md",
+  },
+] as const satisfies readonly ManagedTemplateContract[];
+
+/**
+ * Reads one required managed-template surface from its authoritative path.
+ *
+ * @param contract - Managed template and its exact surface paths.
+ * @param relativePath - Surface path relative to the integration directory.
+ * @param surface - Human-readable surface name used in assertion failures.
+ * @returns The UTF-8 contents, or an empty string after a missing-file assertion.
+ */
+function readManagedSurface(
+  contract: ManagedTemplateContract,
   relativePath: string,
+  surface: string,
 ): string {
-  return fs.readFileSync(
-    path.join(integrationsDir, integration, relativePath),
-    "utf8",
+  const filePath = path.join(integrationsDir, contract.directory, relativePath);
+  const exists = fs.existsSync(filePath);
+
+  expect(
+    exists,
+    `${contract.directory} ${surface} must exist at ${relativePath}`,
+  ).toBe(true);
+
+  return exists ? fs.readFileSync(filePath, "utf8") : "";
+}
+
+/**
+ * Matches an environment identifier without matching it inside a longer name.
+ *
+ * @param identifier - Exact uppercase environment identifier to match.
+ * @returns A pattern that excludes surrounding uppercase identifier characters.
+ */
+function exactEnvIdentifierPattern(identifier: string): RegExp {
+  return new RegExp(`(^|[^A-Z0-9_])${identifier}([^A-Z0-9_]|$)`);
+}
+
+/**
+ * Matches a documented environment assignment, including commented examples.
+ *
+ * @param identifier - Exact environment identifier expected before `=`.
+ * @returns A multiline assignment pattern.
+ */
+function envAssignmentPattern(identifier: string): RegExp {
+  return new RegExp(`^\\s*#?\\s*${identifier}\\s*=`, "m");
+}
+
+/**
+ * Matches documentation that labels an environment identifier as optional.
+ *
+ * @param identifier - Environment identifier whose optionality is documented.
+ * @returns A proximity pattern allowing a short comment or paragraph.
+ */
+function optionalEnvDocumentationPattern(identifier: string): RegExp {
+  return new RegExp(
+    `(?:optional[\\s\\S]{0,240}${identifier}|${identifier}[\\s\\S]{0,240}optional)`,
+    "i",
   );
 }
 
-function readOptionalIntegrationFile(
-  integration: string,
-  relativePath: string,
-): string {
-  const filePath = path.join(integrationsDir, integration, relativePath);
-  return fs.existsSync(filePath) ? fs.readFileSync(filePath, "utf8") : "";
-}
+/**
+ * Returns the Markdown section containing a managed credential marker.
+ *
+ * This scopes license-copy checks so explicit self-hosted or offline sections
+ * elsewhere in the README remain valid.
+ *
+ * @param markdown - README contents.
+ * @param marker - Managed credential identifier used to locate the section.
+ * @returns The matching heading section, or only the matching paragraph when
+ * no preceding Markdown heading exists.
+ */
+function markdownSectionContaining(markdown: string, marker: string): string {
+  const lines = markdown.split(/\r?\n/);
+  const markerLine = lines.findIndex((line) => line.includes(marker));
 
-function readA2AMiddlewareFile(pathFromRoot: string): string {
-  return fs.readFileSync(path.join(a2aMiddlewareRoot, pathFromRoot), "utf8");
-}
-
-describe("batch-2 Intelligence integration migration", () => {
-  for (const integration of migratedIntegrations) {
-    it(`${integration} has the env-gated Intelligence runtime route`, () => {
-      const route = readIntegrationFile(
-        integration,
-        `${appRoots[integration]}/api/copilotkit/[[...slug]]/route.ts`,
-      );
-
-      expect(route).toContain("CopilotKitIntelligence");
-      expect(route).toContain("process.env.COPILOTKIT_LICENSE_TOKEN");
-      expect(route).toContain(
-        "licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN",
-      );
-      expect(route).toContain('id: "demo-user"');
-      expect(route).toContain("new InMemoryAgentRunner()");
-      expect(route).toContain("export const GET = handle(app)");
-      expect(route).toContain("export const POST = handle(app)");
-      expect(route).toContain("export const PATCH = handle(app)");
-      expect(route).toContain("export const DELETE = handle(app)");
-    });
-
-    it(`${integration} forces REST transport for thread routes`, () => {
-      const layout = readIntegrationFile(
-        integration,
-        `${appRoots[integration]}/layout.tsx`,
-      );
-      const page = readIntegrationFile(
-        integration,
-        `${appRoots[integration]}/page.tsx`,
-      );
-
-      expect(`${layout}\n${page}`).toContain("useSingleEndpoint={false}");
-    });
-
-    it(`${integration} wires the threads drawer into the chat thread context`, () => {
-      const page = readIntegrationFile(
-        integration,
-        `${appRoots[integration]}/page.tsx`,
-      );
-
-      expect(page).toContain("ThreadsDrawer");
-      expect(page).toContain("ThreadsPanelGate");
-      expect(page).toContain("CopilotChatConfigurationProvider");
-      expect(page).toContain("threadId");
-      expect(page).toContain("onThreadChange={setThreadId}");
-
-      if (integration === "mcp-apps") {
-        expect(page).toContain('key={threadId ?? "new-thread"}');
-        expect(page).toContain("threadId={threadId}");
-
-        const drawer = readIntegrationFile(
-          integration,
-          "app/components/threads-drawer/threads-drawer.tsx",
-        );
-        expect(drawer).toContain("onThreadChange(undefined)");
-        expect(drawer).not.toContain("crypto.randomUUID()");
-      }
-    });
-
-    it(`${integration} exposes the client-safe threads enabled gate`, () => {
-      const nextConfig = readIntegrationFile(integration, "next.config.ts");
-
-      expect(nextConfig).toContain("NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED");
-      expect(nextConfig).toContain("process.env.COPILOTKIT_LICENSE_TOKEN");
-    });
-
-    it(`${integration} documents the local Intelligence environment`, () => {
-      const envExample = readOptionalIntegrationFile(
-        integration,
-        ".env.example",
-      );
-
-      expect(envExample).toContain("COPILOTKIT_LICENSE_TOKEN");
-      expect(envExample).toContain("INTELLIGENCE_API_KEY");
-      expect(envExample).toContain("INTELLIGENCE_API_URL");
-      expect(envExample).toContain("INTELLIGENCE_GATEWAY_WS_URL");
-    });
-
-    it(`${integration} pins CopilotKit packages to the threads-capable release`, () => {
-      const packageJson = JSON.parse(
-        readIntegrationFile(integration, "package.json"),
-      ) as { dependencies?: Record<string, string> };
-
-      expect(packageJson.dependencies?.["@copilotkit/react-core"]).toBe(
-        "1.59.3",
-      );
-      expect(packageJson.dependencies?.["@copilotkit/runtime"]).toBe("1.59.3");
-    });
+  if (markerLine < 0) {
+    return "";
   }
-});
 
-test("a2a-middleware runtime route is gated for Intelligence threads", () => {
-  const route = readA2AMiddlewareFile(
-    "app/api/copilotkit/[[...slug]]/route.ts",
-  );
+  let headingLine = -1;
+  let headingLevel = 0;
 
-  expect(route).toContain("CopilotKitIntelligence");
-  expect(route).toContain(
-    "class RuntimeA2AMiddlewareAgent extends A2AMiddlewareAgent",
-  );
-  expect(route).toContain("const isolatedAgent = new A2AMiddlewareAgent");
-  expect(route).toContain("new HttpAgent({");
-  expect(route).toContain("isolatedAgent.setMessages(parameters.messages)");
-  expect(route).toContain("return isolatedAgent.runAgent(");
-  expect(route).toContain("process.env.COPILOTKIT_LICENSE_TOKEN");
-  expect(route).toContain("process.env.INTELLIGENCE_API_KEY");
-  expect(route).toContain("process.env.INTELLIGENCE_API_URL");
-  expect(route).toContain("process.env.INTELLIGENCE_GATEWAY_WS_URL");
-  expect(route).toContain('id: "demo-user"');
-  expect(route).toContain("licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN");
-  expect(route).toContain(": { runner: new InMemoryAgentRunner() }");
-  expect(route).toContain("export const GET = handle(app);");
-  expect(route).toContain("export const POST = handle(app);");
-  expect(route).toContain("export const PATCH = handle(app);");
-  expect(route).toContain("export const DELETE = handle(app);");
-});
-
-test("a2a-middleware preserves its three-agent URL configuration", () => {
-  const route = readA2AMiddlewareFile(
-    "app/api/copilotkit/[[...slug]]/route.ts",
-  );
-
-  expect(route).toContain("process.env.RESEARCH_AGENT_URL");
-  expect(route).toContain("process.env.ANALYSIS_AGENT_URL");
-  expect(route).toContain("process.env.ORCHESTRATOR_URL");
-  expect(route).toContain('agentId: "a2a_chat"');
-  expect(route).toContain("agentUrls: [researchAgentUrl, analysisAgentUrl]");
-  expect(route).toContain("orchestrationAgentUrl: orchestratorUrl");
-});
-
-test("a2a-middleware page uses REST transport for Threads APIs", () => {
-  const page = readA2AMiddlewareFile("app/page.tsx");
-
-  expect(page).toContain('runtimeUrl="/api/copilotkit"');
-  expect(page).toContain("useSingleEndpoint={false}");
-  expect(page).toContain('agentId="a2a_chat"');
-  expect(page).toContain("ThreadsDrawer");
-  expect(page).toContain("ThreadsPanelGate");
-  expect(page).toContain("CopilotChatConfigurationProvider");
-  expect(page).toContain("const [threadId, setThreadId]");
-  expect(page).toContain("threadId={threadId}");
-});
-
-test("a2a-middleware chat keeps A2A visualization tools inside the configured chat", () => {
-  const chat = readA2AMiddlewareFile("components/chat.tsx");
-
-  expect(chat).toContain("useFrontendTool");
-  expect(chat).toContain('name: "send_message_to_a2a_agent"');
-  expect(chat).toContain("MessageToA2A");
-  expect(chat).toContain("MessageFromA2A");
-  expect(chat).not.toContain("<CopilotKit");
-});
-
-test("a2a-middleware exposes local Intelligence env documentation", () => {
-  const envExample = readA2AMiddlewareFile(".env.example");
-
-  expect(envExample).toContain("GOOGLE_API_KEY=");
-  expect(envExample).toContain("OPENAI_API_KEY=");
-  expect(envExample).toContain("COPILOTKIT_LICENSE_TOKEN=");
-  expect(envExample).toContain("INTELLIGENCE_API_KEY=");
-  expect(envExample).toContain("INTELLIGENCE_API_URL=http://localhost:4201");
-  expect(envExample).toContain(
-    "INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401",
-  );
-});
-
-test("a2a-middleware package is pinned to the Intelligence-ready CopilotKit SDK", () => {
-  const packageJson = JSON.parse(readA2AMiddlewareFile("package.json")) as {
-    dependencies: Record<string, string>;
-  };
-
-  expect(packageJson.dependencies["@copilotkit/react-core"]).toBe("1.59.3");
-  expect(packageJson.dependencies["@copilotkit/runtime"]).toBe("1.59.3");
-  expect(packageJson.dependencies["lucide-react"]).toBeDefined();
-});
-
-test("a2a-middleware Next config enables the Threads feature flag", () => {
-  const nextConfig = readA2AMiddlewareFile("next.config.ts");
-
-  expect(nextConfig).toContain('output: "standalone"');
-  expect(nextConfig).toContain("NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED");
-  expect(nextConfig).toContain("process.env");
-  expect(nextConfig).toContain("COPILOTKIT_LICENSE_TOKEN");
-});
-
-const a2aA2uiRoot = path.join(integrationsDir, "a2a-a2ui");
-
-function readA2AA2uiFile(pathFromRoot: string): string {
-  return fs.readFileSync(path.join(a2aA2uiRoot, pathFromRoot), "utf8");
-}
-
-test("a2a-a2ui runtime route is gated for Intelligence threads", () => {
-  const route = readA2AA2uiFile("app/api/copilotkit/[[...slug]]/route.tsx");
-
-  expect(route).toContain("CopilotKitIntelligence");
-  expect(route).toContain("class RuntimeA2AAgent extends A2AAgent");
-  expect(route).toContain("const isolatedAgent = new A2AAgent");
-  expect(route).toContain("isolatedAgent.setMessages(parameters.messages)");
-  expect(route).toContain("return isolatedAgent.runAgent(");
-  expect(route).toContain("process.env.COPILOTKIT_LICENSE_TOKEN");
-  expect(route).toContain("process.env.INTELLIGENCE_API_KEY");
-  expect(route).toContain("process.env.INTELLIGENCE_API_URL");
-  expect(route).toContain("process.env.INTELLIGENCE_GATEWAY_WS_URL");
-  expect(route).toContain('id: "demo-user"');
-  expect(route).toContain("licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN");
-  expect(route).toContain(": { runner: new InMemoryAgentRunner() }");
-  expect(route).toContain("a2ui: {}");
-  expect(route).toContain("export const GET = handle(app);");
-  expect(route).toContain("export const POST = handle(app);");
-  expect(route).toContain("export const PATCH = handle(app);");
-  expect(route).toContain("export const DELETE = handle(app);");
-});
-
-test("a2a-a2ui page uses REST transport for Threads APIs", () => {
-  const page = readA2AA2uiFile("app/page.tsx");
-
-  expect(page).toContain('runtimeUrl="/api/copilotkit"');
-  expect(page).toContain('agentId="default"');
-  expect(page).toContain("useSingleEndpoint={false}");
-  expect(page).toContain("a2ui={{ theme }}");
-  expect(page).toContain("const activityRenderers = [a2uiV08Renderer];");
-  expect(page).toContain("renderActivityMessages={activityRenderers}");
-});
-
-test("a2a-a2ui page wires a threads drawer into the active chat thread", () => {
-  const page = readA2AA2uiFile("app/page.tsx");
-
-  expect(page).toContain("ThreadsDrawer");
-  expect(page).toContain("ThreadsPanelGate");
-  expect(page).toContain("CopilotChatConfigurationProvider");
-  expect(page).toContain("const [threadId, setThreadId]");
-  expect(page).toContain('agentId="default"');
-  expect(page).toContain("threadId={threadId}");
-});
-
-test("a2a-a2ui exposes local Intelligence env documentation", () => {
-  const envExample = readA2AA2uiFile(".env.example");
-  const gitignore = readA2AA2uiFile(".gitignore");
-
-  expect(envExample).toContain("OPENAI_API_KEY=");
-  expect(envExample).toContain("COPILOTKIT_LICENSE_TOKEN=");
-  expect(envExample).toContain("INTELLIGENCE_API_KEY=");
-  expect(envExample).toContain("INTELLIGENCE_API_URL=http://localhost:4201");
-  expect(envExample).toContain(
-    "INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401",
-  );
-  expect(gitignore).toContain("!.env.example");
-});
-
-test("a2a-a2ui package is pinned to the Intelligence-ready CopilotKit SDK", () => {
-  const packageJson = JSON.parse(readA2AA2uiFile("package.json")) as {
-    dependencies: Record<string, string>;
-  };
-
-  expect(packageJson.dependencies["@copilotkit/a2ui-renderer"]).toBe("1.59.3");
-  expect(packageJson.dependencies["@copilotkit/react-core"]).toBe("1.59.3");
-  expect(packageJson.dependencies["@copilotkit/runtime"]).toBe("1.59.3");
-  expect(packageJson.dependencies["lucide-react"]).toBeDefined();
-});
-
-test("a2a-a2ui Next config enables the Threads feature flag", () => {
-  const nextConfig = readA2AA2uiFile("next.config.js");
-
-  expect(nextConfig).toContain('output: "standalone"');
-  expect(nextConfig).toContain(
-    "NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.COPILOTKIT_LICENSE_TOKEN",
-  );
-});
-
-const agentcoreRoot = path.join(integrationsDir, "agentcore");
-
-function readAgentcoreFile(pathFromRoot: string): string {
-  return fs.readFileSync(path.join(agentcoreRoot, pathFromRoot), "utf8");
-}
-
-describe("agentcore Intelligence integration migration", () => {
-  it("gates the Hono runtime bridge with CopilotKit Intelligence", () => {
-    const runtime = readAgentcoreFile(
-      "infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts",
-    );
-
-    expect(runtime).toContain("CopilotKitIntelligence");
-    expect(runtime).toContain("process.env.COPILOTKIT_LICENSE_TOKEN");
-    expect(runtime).toContain("process.env.INTELLIGENCE_API_KEY");
-    expect(runtime).toContain("process.env.INTELLIGENCE_API_URL");
-    expect(runtime).toContain("process.env.INTELLIGENCE_GATEWAY_WS_URL");
-    expect(runtime).toContain(
-      "licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN",
-    );
-    expect(runtime).toContain('id: "demo-user"');
-    expect(runtime).toContain(": { runner: new AgentCoreRunner() }");
-    expect(runtime).toContain('basePath: "/copilotkit"');
-  });
-
-  it("forces REST transport and threads context in the Vite frontend", () => {
-    const chat = readAgentcoreFile(
-      "frontend/src/components/chat/CopilotKit/index.tsx",
-    );
-
-    expect(chat).toContain("useSingleEndpoint={false}");
-    expect(chat).toContain("ThreadsDrawer");
-    expect(chat).toContain("ThreadsPanelGate");
-    expect(chat).toContain("CopilotChatConfigurationProvider");
-    expect(chat).toContain("const [threadId, setThreadId]");
-    expect(chat).toContain("threadId={threadId}");
-    expect(chat).toContain("runtimeUrl={runtimeUrl}");
-    expect(chat).toContain("headers={headers}");
-  });
-
-  it("exposes the client-safe threads enabled gate for Vite", () => {
-    const viteConfig = readAgentcoreFile("frontend/vite.config.ts");
-    const lockedState = readAgentcoreFile(
-      "frontend/src/components/threads-drawer/locked-state.tsx",
-    );
-
-    expect(viteConfig).toContain("VITE_COPILOTKIT_THREADS_ENABLED");
-    expect(viteConfig).toContain("process.env.COPILOTKIT_LICENSE_TOKEN");
-    expect(lockedState).toContain(
-      "import.meta.env.VITE_COPILOTKIT_THREADS_ENABLED",
-    );
-  });
-
-  it("documents and wires local Intelligence environment variables", () => {
-    const dockerEnv = readAgentcoreFile("docker/.env.example");
-    const compose = readAgentcoreFile("docker/docker-compose.yml");
-
-    for (const envName of [
-      "COPILOTKIT_LICENSE_TOKEN",
-      "INTELLIGENCE_API_KEY",
-      "INTELLIGENCE_API_URL",
-      "INTELLIGENCE_GATEWAY_WS_URL",
-    ]) {
-      expect(dockerEnv).toContain(envName);
-      expect(compose).toContain(envName);
+  for (let index = markerLine; index >= 0; index -= 1) {
+    const heading = lines[index]?.match(/^(#{1,6})\s+/);
+    if (heading) {
+      headingLine = index;
+      headingLevel = heading[1]?.length ?? 0;
+      break;
     }
-  });
+  }
 
-  it("pins AgentCore frontend and runtime packages to threads-capable versions", () => {
-    const frontendPackageJson = JSON.parse(
-      readAgentcoreFile("frontend/package.json"),
-    ) as { dependencies?: Record<string, string> };
-    const runtimePackageJson = JSON.parse(
-      readAgentcoreFile("infra-cdk/lambdas/copilotkit-runtime/package.json"),
-    ) as { dependencies?: Record<string, string> };
+  if (headingLine < 0) {
+    const paragraphs = markdown.split(/\r?\n\s*\r?\n/);
+    return paragraphs.find((paragraph) => paragraph.includes(marker)) ?? "";
+  }
 
-    expect(frontendPackageJson.dependencies?.["@copilotkit/react-core"]).toBe(
-      "1.59.3",
-    );
-    expect(runtimePackageJson.dependencies?.["@copilotkit/runtime"]).toBe(
-      "1.59.3",
-    );
-    expect(runtimePackageJson.dependencies?.["@ag-ui/client"]).toBe("0.0.53");
-  });
+  let endLine = lines.length;
+  for (let index = markerLine + 1; index < lines.length; index += 1) {
+    const heading = lines[index]?.match(/^(#{1,6})\s+/);
+    if (heading && (heading[1]?.length ?? 0) <= headingLevel) {
+      endLine = index;
+      break;
+    }
+  }
+
+  return lines.slice(headingLine, endLine).join("\n");
+}
+
+/**
+ * Asserts the managed runtime reads only the managed project credential.
+ *
+ * @param contents - Runtime route or bridge source.
+ */
+function expectManagedRuntimeContract(contents: string): void {
+  expect(contents).toMatch(exactEnvIdentifierPattern(MANAGED_API_KEY));
+  expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_API_KEY));
+  expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_TELEMETRY_ID));
+  expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
+  expect(contents).not.toMatch(/\blicenseToken\s*:/);
+}
+
+/**
+ * Asserts the browser-safe feature gate follows the managed project credential.
+ *
+ * @param contents - Next.js or Vite gate configuration source.
+ */
+function expectManagedGateContract(contents: string): void {
+  expect(contents).toMatch(exactEnvIdentifierPattern(MANAGED_API_KEY));
+  expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_API_KEY));
+  expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_TELEMETRY_ID));
+  expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
+}
+
+/**
+ * Asserts an env example documents the managed key and optional telemetry ID.
+ *
+ * @param contents - Managed template environment example contents.
+ */
+function expectManagedEnvContract(contents: string): void {
+  expect(contents).toMatch(envAssignmentPattern(MANAGED_API_KEY));
+  expect(contents).toMatch(envAssignmentPattern(OPTIONAL_TELEMETRY_ID));
+  expect(contents).toMatch(
+    optionalEnvDocumentationPattern(OPTIONAL_TELEMETRY_ID),
+  );
+  expect(contents).not.toMatch(envAssignmentPattern(LEGACY_API_KEY));
+  expect(contents).not.toMatch(envAssignmentPattern(LEGACY_TELEMETRY_ID));
+  expect(contents).not.toMatch(envAssignmentPattern(MANAGED_LICENSE_TOKEN));
+}
+
+/**
+ * Asserts a README documents the managed key and optional telemetry identity.
+ *
+ * @param contents - Managed template README contents.
+ */
+function expectManagedReadmeContract(contents: string): void {
+  expect(contents).toMatch(exactEnvIdentifierPattern(MANAGED_API_KEY));
+  expect(contents).toMatch(exactEnvIdentifierPattern(OPTIONAL_TELEMETRY_ID));
+  expect(contents).toMatch(
+    optionalEnvDocumentationPattern(OPTIONAL_TELEMETRY_ID),
+  );
+  expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_API_KEY));
+  expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_TELEMETRY_ID));
+
+  const managedSection = markdownSectionContaining(contents, MANAGED_API_KEY);
+  expect(managedSection).not.toContain(MANAGED_LICENSE_TOKEN);
+}
+
+test("the 16 managed template directories back all 19 in-repo CLI frameworks", () => {
+  const frameworks = MANAGED_TEMPLATE_CONTRACTS.flatMap(
+    (contract) => contract.frameworks,
+  );
+
+  expect(MANAGED_TEMPLATE_CONTRACTS).toHaveLength(16);
+  expect(new Set(frameworks).size).toBe(19);
+  expect([...frameworks].sort()).toEqual([...MANAGED_CLI_FRAMEWORKS].sort());
 });
+
+for (const contract of MANAGED_TEMPLATE_CONTRACTS) {
+  test(`${contract.directory} runtime uses the managed Intelligence API key`, () => {
+    const runtime = readManagedSurface(
+      contract,
+      contract.runtimePath,
+      "runtime",
+    );
+
+    expectManagedRuntimeContract(runtime);
+  });
+
+  test(`${contract.directory} client gate uses the managed Intelligence API key`, () => {
+    const gate = readManagedSurface(contract, contract.gatePath, "client gate");
+
+    expectManagedGateContract(gate);
+  });
+
+  test(`${contract.directory} env example documents managed Intelligence credentials`, () => {
+    const envExample = readManagedSurface(
+      contract,
+      contract.envPath,
+      "env example",
+    );
+
+    expectManagedEnvContract(envExample);
+  });
+
+  test(`${contract.directory} README documents managed Intelligence credentials`, () => {
+    const readme = readManagedSurface(contract, contract.readmePath, "README");
+
+    expectManagedReadmeContract(readme);
+  });
+}

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -305,17 +305,26 @@ function propertyNameText(name: ts.PropertyName): string | null {
   return null;
 }
 
-/**
- * Returns whether a configured property initializer contains the required read.
- *
- * Parsing the source excludes comments and unused string literals by construction;
- * traversing only the matched initializer excludes unrelated executable reads.
- */
-function hasConfiguredEnvRead(
-  contents: string,
-  identifier: string,
-  matchesProperty: (name: string) => boolean,
-): boolean {
+/** Parses managed scaffold TypeScript and rejects parser-recovered source. */
+function parseManagedSource(contents: string): ts.SourceFile {
+  const transpiled = ts.transpileModule(contents, {
+    compilerOptions: {
+      jsx: ts.JsxEmit.Preserve,
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.Latest,
+    },
+    fileName: "managed-integration-contract.tsx",
+    reportDiagnostics: true,
+  });
+  const parseDiagnostics =
+    transpiled.diagnostics?.filter(
+      (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
+    ) ?? [];
+  expect(
+    parseDiagnostics,
+    "managed scaffold source must parse without diagnostics",
+  ).toHaveLength(0);
+
   const sourceFile = ts.createSourceFile(
     "managed-integration-contract.tsx",
     contents,
@@ -323,32 +332,92 @@ function hasConfiguredEnvRead(
     true,
     ts.ScriptKind.TSX,
   );
-  let found = false;
 
-  /** Visits one configured initializer looking for the required env read. */
-  function initializerContainsEnvRead(node: ts.Node): boolean {
-    if (isProcessEnvRead(node, identifier)) {
-      return true;
-    }
+  return sourceFile;
+}
 
-    return node.getChildren(sourceFile).some(initializerContainsEnvRead);
+/** Returns an expression without transparent TypeScript wrappers. */
+function unwrapExpression(expression: ts.Expression): ts.Expression {
+  if (
+    ts.isParenthesizedExpression(expression) ||
+    ts.isAsExpression(expression) ||
+    ts.isTypeAssertionExpression(expression) ||
+    ts.isSatisfiesExpression(expression) ||
+    ts.isNonNullExpression(expression)
+  ) {
+    return unwrapExpression(expression.expression);
   }
 
-  /** Visits object-literal properties until the configured read is found. */
+  return expression;
+}
+
+/** Returns one exact object-literal property assignment when present. */
+function objectPropertyAssignment(
+  objectLiteral: ts.ObjectLiteralExpression,
+  name: string,
+): ts.PropertyAssignment | null {
+  for (const property of objectLiteral.properties) {
+    if (
+      ts.isPropertyAssignment(property) &&
+      propertyNameText(property.name) === name
+    ) {
+      return property;
+    }
+  }
+
+  return null;
+}
+
+/** Returns whether one expression contains the exact managed env read. */
+function expressionContainsEnvRead(
+  expression: ts.Expression,
+  identifier: string,
+): boolean {
+  let found = false;
+
+  /** Visits one initializer node looking for the required env read. */
+  function visit(node: ts.Node): void {
+    if (found) {
+      return;
+    }
+    if (isProcessEnvRead(node, identifier)) {
+      found = true;
+      return;
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(expression);
+  return found;
+}
+
+/** Returns whether a CopilotKit Intelligence constructor owns the API-key read. */
+function hasRuntimeApiKeyRead(sourceFile: ts.SourceFile): boolean {
+  let found = false;
+
+  /** Visits constructors until the managed Intelligence API-key option is found. */
   function visit(node: ts.Node): void {
     if (found) {
       return;
     }
 
-    if (ts.isPropertyAssignment(node)) {
-      const name = propertyNameText(node.name);
-      if (
-        name !== null &&
-        matchesProperty(name) &&
-        initializerContainsEnvRead(node.initializer)
-      ) {
-        found = true;
-        return;
+    if (
+      ts.isNewExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "CopilotKitIntelligence"
+    ) {
+      const options = node.arguments?.[0];
+      const unwrappedOptions = options ? unwrapExpression(options) : null;
+      if (unwrappedOptions && ts.isObjectLiteralExpression(unwrappedOptions)) {
+        const apiKey = objectPropertyAssignment(unwrappedOptions, "apiKey");
+        if (
+          apiKey &&
+          expressionContainsEnvRead(apiKey.initializer, MANAGED_API_KEY)
+        ) {
+          found = true;
+          return;
+        }
       }
     }
 
@@ -357,6 +426,122 @@ function hasConfiguredEnvRead(
 
   visit(sourceFile);
   return found;
+}
+
+/** Returns the initializer for one top-level variable identifier. */
+function topLevelVariableInitializer(
+  sourceFile: ts.SourceFile,
+  identifier: string,
+): ts.Expression | null {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) {
+      continue;
+    }
+
+    for (const declaration of statement.declarationList.declarations) {
+      if (
+        ts.isIdentifier(declaration.name) &&
+        declaration.name.text === identifier
+      ) {
+        return declaration.initializer ?? null;
+      }
+    }
+  }
+
+  return null;
+}
+
+/** Resolves a default-exported object literal through top-level variables. */
+function exportedObjectLiteral(
+  expression: ts.Expression,
+  sourceFile: ts.SourceFile,
+  seenIdentifiers: ReadonlySet<string> = new Set(),
+): ts.ObjectLiteralExpression | null {
+  const unwrapped = unwrapExpression(expression);
+  if (ts.isObjectLiteralExpression(unwrapped)) {
+    return unwrapped;
+  }
+  if (ts.isIdentifier(unwrapped) && !seenIdentifiers.has(unwrapped.text)) {
+    const initializer = topLevelVariableInitializer(sourceFile, unwrapped.text);
+    if (initializer) {
+      return exportedObjectLiteral(
+        initializer,
+        sourceFile,
+        new Set([...seenIdentifiers, unwrapped.text]),
+      );
+    }
+  }
+
+  return null;
+}
+
+/** Returns the source's default export expression when it has one. */
+function defaultExportExpression(
+  sourceFile: ts.SourceFile,
+): ts.Expression | null {
+  for (const statement of sourceFile.statements) {
+    if (ts.isExportAssignment(statement) && !statement.isExportEquals) {
+      return statement.expression;
+    }
+  }
+
+  return null;
+}
+
+/** Returns whether a nested object property owns the managed env read. */
+function nestedPropertyContainsEnvRead(
+  objectLiteral: ts.ObjectLiteralExpression,
+  containerName: string,
+  propertyName: string,
+): boolean {
+  const container = objectPropertyAssignment(objectLiteral, containerName);
+  if (!container) {
+    return false;
+  }
+  const containerInitializer = unwrapExpression(container.initializer);
+  if (!ts.isObjectLiteralExpression(containerInitializer)) {
+    return false;
+  }
+  const property = objectPropertyAssignment(containerInitializer, propertyName);
+  return Boolean(
+    property &&
+    expressionContainsEnvRead(property.initializer, MANAGED_API_KEY),
+  );
+}
+
+/** Returns whether the exported Next or Vite thread gate owns the key read. */
+function hasExportedGateApiKeyRead(sourceFile: ts.SourceFile): boolean {
+  const exported = defaultExportExpression(sourceFile);
+  if (!exported) {
+    return false;
+  }
+
+  const nextConfig = exportedObjectLiteral(exported, sourceFile);
+  if (
+    nextConfig &&
+    nestedPropertyContainsEnvRead(nextConfig, "env", NEXT_THREADS_GATE)
+  ) {
+    return true;
+  }
+
+  const unwrapped = unwrapExpression(exported);
+  if (
+    ts.isCallExpression(unwrapped) &&
+    ts.isIdentifier(unwrapped.expression) &&
+    unwrapped.expression.text === "defineConfig"
+  ) {
+    const config = unwrapped.arguments[0];
+    const unwrappedConfig = config ? unwrapExpression(config) : null;
+    if (unwrappedConfig && ts.isObjectLiteralExpression(unwrappedConfig)) {
+      return nestedPropertyContainsEnvRead(
+        unwrappedConfig,
+        "define",
+        `import.meta.env.${VITE_THREADS_GATE}`,
+      );
+    }
+  }
+
+  return false;
 }
 
 /**
@@ -455,13 +640,9 @@ function markdownSectionContaining(markdown: string, marker: string): string {
  * @param contents - Runtime route or bridge source.
  */
 function expectManagedRuntimeContract(contents: string): void {
-  expect(
-    hasConfiguredEnvRead(
-      contents,
-      MANAGED_API_KEY,
-      (name) => name === "apiKey",
-    ),
-  ).toBe(true);
+  const sourceFile = parseManagedSource(contents);
+
+  expect(hasRuntimeApiKeyRead(sourceFile)).toBe(true);
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_API_KEY));
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_TELEMETRY_ID));
   expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
@@ -474,16 +655,9 @@ function expectManagedRuntimeContract(contents: string): void {
  * @param contents - Next.js or Vite gate configuration source.
  */
 function expectManagedGateContract(contents: string): void {
-  expect(
-    hasConfiguredEnvRead(
-      contents,
-      MANAGED_API_KEY,
-      (name) =>
-        name === NEXT_THREADS_GATE ||
-        name === VITE_THREADS_GATE ||
-        name.endsWith(`.${VITE_THREADS_GATE}`),
-    ),
-  ).toBe(true);
+  const sourceFile = parseManagedSource(contents);
+
+  expect(hasExportedGateApiKeyRead(sourceFile)).toBe(true);
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_API_KEY));
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_TELEMETRY_ID));
   expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
@@ -598,25 +772,86 @@ test("managed TypeScript helpers reject API-key identifiers outside configured e
   expect(() => expectManagedGateContract(unusedGateRead)).toThrow();
 });
 
-test("managed TypeScript helpers accept configured dot and bracket env reads", () => {
-  const configuredRuntimeRead = `
-    const intelligence = {
-      apiKey: process.env["CPK_INTELLIGENCE_API_KEY"] ?? "",
-    };
+test("managed TypeScript helpers reject decoy configured properties", () => {
+  const decoyRuntimeRead = `
+    const decoy = { apiKey: process.env.CPK_INTELLIGENCE_API_KEY };
+    const intelligence = new CopilotKitIntelligence({ apiKey: "" });
   `;
-  const configuredGateRead = `
+  const decoyNextGateRead = `
+    const decoy = {
+      NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED:
+        process.env.CPK_INTELLIGENCE_API_KEY ? "true" : "false",
+    };
+    const nextConfig = {
+      env: { NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: "false" },
+    };
+    export default nextConfig;
+  `;
+  const decoyViteGateRead = `
+    const decoy = {
+      "import.meta.env.VITE_COPILOTKIT_THREADS_ENABLED":
+        process.env.CPK_INTELLIGENCE_API_KEY ? "true" : "false",
+    };
+    export default defineConfig({
+      define: {
+        "import.meta.env.VITE_COPILOTKIT_THREADS_ENABLED": "false",
+      },
+    });
+  `;
+
+  expect(() => expectManagedRuntimeContract(decoyRuntimeRead)).toThrow();
+  expect(() => expectManagedGateContract(decoyNextGateRead)).toThrow();
+  expect(() => expectManagedGateContract(decoyViteGateRead)).toThrow();
+});
+
+test("managed TypeScript helpers reject malformed source", () => {
+  const malformedRuntime = `
+    const intelligence = new CopilotKitIntelligence({
+      apiKey: process.env.CPK_INTELLIGENCE_API_KEY,
+    });
+  }`;
+  const malformedGate = `
     export default {
       env: {
         NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED:
           process.env.CPK_INTELLIGENCE_API_KEY ? "true" : "false",
       },
+    `;
+
+  expect(() => expectManagedRuntimeContract(malformedRuntime)).toThrow();
+  expect(() => expectManagedGateContract(malformedGate)).toThrow();
+});
+
+test("managed TypeScript helpers accept configured dot and bracket env reads", () => {
+  const configuredRuntimeRead = `
+    const intelligence = new CopilotKitIntelligence({
+      apiKey: process.env["CPK_INTELLIGENCE_API_KEY"] ?? "",
+    });
+  `;
+  const configuredGateRead = `
+    const nextConfig = {
+      env: {
+        NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED:
+          process.env.CPK_INTELLIGENCE_API_KEY ? "true" : "false",
+      },
     };
+    export default nextConfig;
+  `;
+  const configuredViteGateRead = `
+    export default defineConfig({
+      define: {
+        "import.meta.env.VITE_COPILOTKIT_THREADS_ENABLED": JSON.stringify(
+          process.env["CPK_INTELLIGENCE_API_KEY"] ? "true" : "false",
+        ),
+      },
+    });
   `;
 
   expect(() =>
     expectManagedRuntimeContract(configuredRuntimeRead),
   ).not.toThrow();
   expect(() => expectManagedGateContract(configuredGateRead)).not.toThrow();
+  expect(() => expectManagedGateContract(configuredViteGateRead)).not.toThrow();
 });
 
 test("managed documentation helpers reject license guidance inside the managed block", () => {

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -392,6 +392,16 @@ function expressionContainsEnvRead(
   return found;
 }
 
+/** Returns whether an expression uses the managed key without telemetry. */
+function expressionUsesManagedKeyWithoutTelemetry(
+  expression: ts.Expression,
+): boolean {
+  return (
+    expressionContainsEnvRead(expression, MANAGED_API_KEY) &&
+    !expressionContainsEnvRead(expression, OPTIONAL_TELEMETRY_ID)
+  );
+}
+
 /** Returns whether a CopilotKit Intelligence constructor owns the API-key read. */
 function hasRuntimeApiKeyRead(sourceFile: ts.SourceFile): boolean {
   let found = false;
@@ -413,7 +423,7 @@ function hasRuntimeApiKeyRead(sourceFile: ts.SourceFile): boolean {
         const apiKey = objectPropertyAssignment(unwrappedOptions, "apiKey");
         if (
           apiKey &&
-          expressionContainsEnvRead(apiKey.initializer, MANAGED_API_KEY)
+          expressionUsesManagedKeyWithoutTelemetry(apiKey.initializer)
         ) {
           found = true;
           return;
@@ -504,8 +514,7 @@ function nestedPropertyContainsEnvRead(
   }
   const property = objectPropertyAssignment(containerInitializer, propertyName);
   return Boolean(
-    property &&
-    expressionContainsEnvRead(property.initializer, MANAGED_API_KEY),
+    property && expressionUsesManagedKeyWithoutTelemetry(property.initializer),
   );
 }
 
@@ -555,19 +564,6 @@ function envAssignmentPattern(identifier: string): RegExp {
 }
 
 /**
- * Matches documentation that labels an environment identifier as optional.
- *
- * @param identifier - Environment identifier whose optionality is documented.
- * @returns A proximity pattern allowing a short comment or paragraph.
- */
-function optionalEnvDocumentationPattern(identifier: string): RegExp {
-  return new RegExp(
-    `(?:optional[\\s\\S]{0,240}${identifier}|${identifier}[\\s\\S]{0,240}optional)`,
-    "i",
-  );
-}
-
-/**
  * Returns the blank-line-delimited text block containing a marker.
  *
  * @param contents - Environment example or other block-oriented text.
@@ -577,6 +573,19 @@ function optionalEnvDocumentationPattern(identifier: string): RegExp {
 function textBlockContaining(contents: string, marker: string): string {
   const blocks = contents.split(/\r?\n\s*\r?\n/);
   return blocks.find((block) => block.includes(marker)) ?? "";
+}
+
+/** Asserts telemetry copy describes identity without prerequisite semantics. */
+function expectTelemetryIdentityDocumentation(contents: string): void {
+  const telemetryBlock = textBlockContaining(contents, OPTIONAL_TELEMETRY_ID);
+
+  expect(telemetryBlock).toMatch(/\boptional\b/i);
+  expect(telemetryBlock).toMatch(/\bnon[- ]?secret\b/i);
+  expect(telemetryBlock).toMatch(/\banalytics\b/i);
+  expect(telemetryBlock).toMatch(/\bidentity\b/i);
+  expect(telemetryBlock).not.toMatch(
+    /\b(?:auth(?:entication|orization)?|entitlements?|enabl(?:e[sd]?|ing|ement)|consent(?:s|ed|ing)?|send(?:s|ing)?|sent|transmit(?:s|ted|ting)?)\b/i,
+  );
 }
 
 /**
@@ -671,9 +680,7 @@ function expectManagedGateContract(contents: string): void {
 function expectManagedEnvContract(contents: string): void {
   expect(contents).toMatch(envAssignmentPattern(MANAGED_API_KEY));
   expect(contents).toMatch(envAssignmentPattern(OPTIONAL_TELEMETRY_ID));
-  expect(contents).toMatch(
-    optionalEnvDocumentationPattern(OPTIONAL_TELEMETRY_ID),
-  );
+  expectTelemetryIdentityDocumentation(contents);
   expect(contents).not.toMatch(envAssignmentPattern(LEGACY_API_KEY));
   expect(contents).not.toMatch(envAssignmentPattern(LEGACY_TELEMETRY_ID));
 
@@ -689,9 +696,7 @@ function expectManagedEnvContract(contents: string): void {
 function expectManagedReadmeContract(contents: string): void {
   expect(contents).toMatch(exactEnvIdentifierPattern(MANAGED_API_KEY));
   expect(contents).toMatch(exactEnvIdentifierPattern(OPTIONAL_TELEMETRY_ID));
-  expect(contents).toMatch(
-    optionalEnvDocumentationPattern(OPTIONAL_TELEMETRY_ID),
-  );
+  expectTelemetryIdentityDocumentation(contents);
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_API_KEY));
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_TELEMETRY_ID));
 
@@ -822,13 +827,15 @@ test("managed TypeScript helpers reject malformed source", () => {
   expect(() => expectManagedGateContract(malformedGate)).toThrow();
 });
 
-test("managed TypeScript helpers accept configured dot and bracket env reads", () => {
+test("managed TypeScript helpers accept independent telemetry reads", () => {
   const configuredRuntimeRead = `
+    const telemetryId = process.env.CPK_TELEMETRY_ID;
     const intelligence = new CopilotKitIntelligence({
       apiKey: process.env["CPK_INTELLIGENCE_API_KEY"] ?? "",
     });
   `;
   const configuredGateRead = `
+    const telemetryId = process.env["CPK_TELEMETRY_ID"];
     const nextConfig = {
       env: {
         NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED:
@@ -838,6 +845,7 @@ test("managed TypeScript helpers accept configured dot and bracket env reads", (
     export default nextConfig;
   `;
   const configuredViteGateRead = `
+    const telemetryId = process.env.CPK_TELEMETRY_ID;
     export default defineConfig({
       define: {
         "import.meta.env.VITE_COPILOTKIT_THREADS_ENABLED": JSON.stringify(
@@ -854,18 +862,103 @@ test("managed TypeScript helpers accept configured dot and bracket env reads", (
   expect(() => expectManagedGateContract(configuredViteGateRead)).not.toThrow();
 });
 
+test("managed TypeScript helpers reject telemetry prerequisites", () => {
+  const telemetryGatedRuntime = `
+    const intelligence = new CopilotKitIntelligence({
+      apiKey:
+        process.env.CPK_INTELLIGENCE_API_KEY &&
+        process.env.CPK_TELEMETRY_ID,
+    });
+  `;
+  const telemetryGatedNextConfig = `
+    const nextConfig = {
+      env: {
+        NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED:
+          process.env.CPK_INTELLIGENCE_API_KEY &&
+          process.env.CPK_TELEMETRY_ID
+            ? "true"
+            : "false",
+      },
+    };
+    export default nextConfig;
+  `;
+  const telemetryGatedViteConfig = `
+    export default defineConfig({
+      define: {
+        "import.meta.env.VITE_COPILOTKIT_THREADS_ENABLED": JSON.stringify(
+          process.env.CPK_INTELLIGENCE_API_KEY &&
+            process.env.CPK_TELEMETRY_ID
+            ? "true"
+            : "false",
+        ),
+      },
+    });
+  `;
+
+  expect(() => expectManagedRuntimeContract(telemetryGatedRuntime)).toThrow();
+  expect(() => expectManagedGateContract(telemetryGatedNextConfig)).toThrow();
+  expect(() => expectManagedGateContract(telemetryGatedViteConfig)).toThrow();
+});
+
+test("managed documentation helpers reject misleading telemetry semantics", () => {
+  const misleadingDescriptions = [
+    "authentication credential",
+    "entitlement identity",
+    "feature enablement identity",
+    "analytics consent identity",
+    "telemetry send-policy identity",
+  ];
+
+  for (const description of misleadingDescriptions) {
+    const envExample = `
+      CPK_INTELLIGENCE_API_KEY=
+      # Optional, non-secret analytics ${description}.
+      CPK_TELEMETRY_ID=
+    `;
+    const readme = [
+      "## Managed Intelligence credentials",
+      "",
+      "Set `CPK_INTELLIGENCE_API_KEY` for the project.",
+      "",
+      `\`CPK_TELEMETRY_ID\` is an optional, non-secret analytics ${description}.`,
+    ].join("\n");
+
+    expect(() => expectManagedEnvContract(envExample)).toThrow();
+    expect(() => expectManagedReadmeContract(readme)).toThrow();
+  }
+});
+
+test("managed documentation helpers accept an optional non-secret analytics identity", () => {
+  const envExample = `
+    CPK_INTELLIGENCE_API_KEY=
+    # Optional, non-secret analytics identity.
+    CPK_TELEMETRY_ID=
+  `;
+  const readme = [
+    "## Managed Intelligence credentials",
+    "",
+    "Set `CPK_INTELLIGENCE_API_KEY` for the project.",
+    "",
+    "`CPK_TELEMETRY_ID` is an optional, non-secret analytics identity.",
+  ].join("\n");
+
+  expect(() => expectManagedEnvContract(envExample)).not.toThrow();
+  expect(() => expectManagedReadmeContract(readme)).not.toThrow();
+});
+
 test("managed documentation helpers reject license guidance inside the managed block", () => {
   const envExample = `
     # Managed Intelligence credentials
     CPK_INTELLIGENCE_API_KEY=
-    # Optional stable telemetry identity
+    # Optional, non-secret analytics identity
     CPK_TELEMETRY_ID=
     COPILOTKIT_LICENSE_TOKEN=
   `;
   const readme = [
     "## Managed Intelligence credentials",
     "",
-    "Set CPK_INTELLIGENCE_API_KEY for the project. CPK_TELEMETRY_ID is optional.",
+    "Set CPK_INTELLIGENCE_API_KEY for the project.",
+    "CPK_TELEMETRY_ID is an optional, non-secret analytics identity.",
     "COPILOTKIT_LICENSE_TOKEN is not a managed credential.",
   ].join("\n");
 
@@ -877,7 +970,7 @@ test("managed documentation helpers allow separate self-hosted and offline licen
   const envExample = `
     # Managed Intelligence credentials
     CPK_INTELLIGENCE_API_KEY=
-    # Optional stable telemetry identity
+    # Optional, non-secret analytics identity
     CPK_TELEMETRY_ID=
 
     # Self-hosted / offline license
@@ -886,7 +979,8 @@ test("managed documentation helpers allow separate self-hosted and offline licen
   const readme = [
     "## Managed Intelligence credentials",
     "",
-    "Set CPK_INTELLIGENCE_API_KEY for the project. CPK_TELEMETRY_ID is optional.",
+    "Set CPK_INTELLIGENCE_API_KEY for the project.",
+    "CPK_TELEMETRY_ID is an optional, non-secret analytics identity.",
     "",
     "### Self-hosted / offline license",
     "",

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+import * as ts from "typescript";
 import { expect, test } from "vitest";
 
 const repoRoot = path.resolve(__dirname, "..", "..");
@@ -210,6 +211,98 @@ function exactEnvIdentifierPattern(identifier: string): RegExp {
   return new RegExp(`(^|[^A-Z0-9_])${identifier}([^A-Z0-9_]|$)`);
 }
 
+/** Returns whether a node is the `process.env` object expression. */
+function isProcessEnvObject(node: ts.Node): boolean {
+  return (
+    ts.isPropertyAccessExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === "process" &&
+    node.name.text === "env"
+  );
+}
+
+/**
+ * Returns whether a node is a dot or bracket read from `process.env`.
+ *
+ * @param node - TypeScript syntax node under inspection.
+ * @param identifier - Exact environment identifier that must be read.
+ */
+function isProcessEnvRead(node: ts.Node, identifier: string): boolean {
+  if (ts.isPropertyAccessExpression(node)) {
+    return isProcessEnvObject(node.expression) && node.name.text === identifier;
+  }
+
+  return (
+    ts.isElementAccessExpression(node) &&
+    isProcessEnvObject(node.expression) &&
+    ts.isStringLiteral(node.argumentExpression) &&
+    node.argumentExpression.text === identifier
+  );
+}
+
+/** Returns the static text of an object-literal property name when available. */
+function propertyNameText(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) {
+    return name.text;
+  }
+
+  return null;
+}
+
+/**
+ * Returns whether a configured property initializer contains the required read.
+ *
+ * Parsing the source excludes comments and unused string literals by construction;
+ * traversing only the matched initializer excludes unrelated executable reads.
+ */
+function hasConfiguredEnvRead(
+  contents: string,
+  identifier: string,
+  matchesProperty: (name: string) => boolean,
+): boolean {
+  const sourceFile = ts.createSourceFile(
+    "managed-integration-contract.tsx",
+    contents,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  let found = false;
+
+  /** Visits one configured initializer looking for the required env read. */
+  function initializerContainsEnvRead(node: ts.Node): boolean {
+    if (isProcessEnvRead(node, identifier)) {
+      return true;
+    }
+
+    return node.getChildren(sourceFile).some(initializerContainsEnvRead);
+  }
+
+  /** Visits object-literal properties until the configured read is found. */
+  function visit(node: ts.Node): void {
+    if (found) {
+      return;
+    }
+
+    if (ts.isPropertyAssignment(node)) {
+      const name = propertyNameText(node.name);
+      if (
+        name !== null &&
+        matchesProperty(name) &&
+        initializerContainsEnvRead(node.initializer)
+      ) {
+        found = true;
+        return;
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return found;
+}
+
 /**
  * Matches a documented environment assignment, including commented examples.
  *
@@ -231,6 +324,18 @@ function optionalEnvDocumentationPattern(identifier: string): RegExp {
     `(?:optional[\\s\\S]{0,240}${identifier}|${identifier}[\\s\\S]{0,240}optional)`,
     "i",
   );
+}
+
+/**
+ * Returns the blank-line-delimited text block containing a marker.
+ *
+ * @param contents - Environment example or other block-oriented text.
+ * @param marker - Managed credential identifier used to locate the block.
+ * @returns The matching block, or an empty string when the marker is absent.
+ */
+function textBlockContaining(contents: string, marker: string): string {
+  const blocks = contents.split(/\r?\n\s*\r?\n/);
+  return blocks.find((block) => block.includes(marker)) ?? "";
 }
 
 /**
@@ -271,8 +376,15 @@ function markdownSectionContaining(markdown: string, marker: string): string {
 
   let endLine = lines.length;
   for (let index = markerLine + 1; index < lines.length; index += 1) {
-    const heading = lines[index]?.match(/^(#{1,6})\s+/);
-    if (heading && (heading[1]?.length ?? 0) <= headingLevel) {
+    const heading = lines[index]?.match(/^(#{1,6})\s+(.+?)\s*$/);
+    const subsequentLevel = heading?.[1]?.length ?? 0;
+    const subsequentTitle = heading?.[2] ?? "";
+    const startsSeparateLicenseGuidance =
+      /\b(?:self[ -]?hosted|offline)\b/i.test(subsequentTitle);
+    if (
+      heading &&
+      (subsequentLevel <= headingLevel || startsSeparateLicenseGuidance)
+    ) {
       endLine = index;
       break;
     }
@@ -287,7 +399,13 @@ function markdownSectionContaining(markdown: string, marker: string): string {
  * @param contents - Runtime route or bridge source.
  */
 function expectManagedRuntimeContract(contents: string): void {
-  expect(contents).toMatch(exactEnvIdentifierPattern(MANAGED_API_KEY));
+  expect(
+    hasConfiguredEnvRead(
+      contents,
+      MANAGED_API_KEY,
+      (name) => name === "apiKey",
+    ),
+  ).toBe(true);
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_API_KEY));
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_TELEMETRY_ID));
   expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
@@ -300,7 +418,16 @@ function expectManagedRuntimeContract(contents: string): void {
  * @param contents - Next.js or Vite gate configuration source.
  */
 function expectManagedGateContract(contents: string): void {
-  expect(contents).toMatch(exactEnvIdentifierPattern(MANAGED_API_KEY));
+  expect(
+    hasConfiguredEnvRead(
+      contents,
+      MANAGED_API_KEY,
+      (name) =>
+        name === "NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED" ||
+        name === "VITE_COPILOTKIT_THREADS_ENABLED" ||
+        name.endsWith(".VITE_COPILOTKIT_THREADS_ENABLED"),
+    ),
+  ).toBe(true);
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_API_KEY));
   expect(contents).not.toMatch(exactEnvIdentifierPattern(LEGACY_TELEMETRY_ID));
   expect(contents).not.toContain(MANAGED_LICENSE_TOKEN);
@@ -319,7 +446,9 @@ function expectManagedEnvContract(contents: string): void {
   );
   expect(contents).not.toMatch(envAssignmentPattern(LEGACY_API_KEY));
   expect(contents).not.toMatch(envAssignmentPattern(LEGACY_TELEMETRY_ID));
-  expect(contents).not.toMatch(envAssignmentPattern(MANAGED_LICENSE_TOKEN));
+
+  const managedBlock = textBlockContaining(contents, MANAGED_API_KEY);
+  expect(managedBlock).not.toMatch(envAssignmentPattern(MANAGED_LICENSE_TOKEN));
 }
 
 /**
@@ -339,6 +468,88 @@ function expectManagedReadmeContract(contents: string): void {
   const managedSection = markdownSectionContaining(contents, MANAGED_API_KEY);
   expect(managedSection).not.toContain(MANAGED_LICENSE_TOKEN);
 }
+
+test("managed TypeScript helpers reject API-key identifiers outside configured expressions", () => {
+  const unusedRuntimeRead = `
+    const unused = process.env.CPK_INTELLIGENCE_API_KEY;
+    // apiKey: process.env.CPK_INTELLIGENCE_API_KEY
+    const intelligence = { apiKey: "CPK_INTELLIGENCE_API_KEY" };
+  `;
+  const unusedGateRead = `
+    const unused = process.env["CPK_INTELLIGENCE_API_KEY"];
+    // NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: process.env.CPK_INTELLIGENCE_API_KEY
+    export default {
+      env: { NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: "false" },
+    };
+  `;
+
+  expect(() => expectManagedRuntimeContract(unusedRuntimeRead)).toThrow();
+  expect(() => expectManagedGateContract(unusedGateRead)).toThrow();
+});
+
+test("managed TypeScript helpers accept configured dot and bracket env reads", () => {
+  const configuredRuntimeRead = `
+    const intelligence = {
+      apiKey: process.env["CPK_INTELLIGENCE_API_KEY"] ?? "",
+    };
+  `;
+  const configuredGateRead = `
+    export default {
+      env: {
+        NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED:
+          process.env.CPK_INTELLIGENCE_API_KEY ? "true" : "false",
+      },
+    };
+  `;
+
+  expect(() =>
+    expectManagedRuntimeContract(configuredRuntimeRead),
+  ).not.toThrow();
+  expect(() => expectManagedGateContract(configuredGateRead)).not.toThrow();
+});
+
+test("managed documentation helpers reject license guidance inside the managed block", () => {
+  const envExample = `
+    # Managed Intelligence credentials
+    CPK_INTELLIGENCE_API_KEY=
+    # Optional stable telemetry identity
+    CPK_TELEMETRY_ID=
+    COPILOTKIT_LICENSE_TOKEN=
+  `;
+  const readme = [
+    "## Managed Intelligence credentials",
+    "",
+    "Set CPK_INTELLIGENCE_API_KEY for the project. CPK_TELEMETRY_ID is optional.",
+    "COPILOTKIT_LICENSE_TOKEN is not a managed credential.",
+  ].join("\n");
+
+  expect(() => expectManagedEnvContract(envExample)).toThrow();
+  expect(() => expectManagedReadmeContract(readme)).toThrow();
+});
+
+test("managed documentation helpers allow separate self-hosted and offline license guidance", () => {
+  const envExample = `
+    # Managed Intelligence credentials
+    CPK_INTELLIGENCE_API_KEY=
+    # Optional stable telemetry identity
+    CPK_TELEMETRY_ID=
+
+    # Self-hosted / offline license
+    COPILOTKIT_LICENSE_TOKEN=
+  `;
+  const readme = [
+    "## Managed Intelligence credentials",
+    "",
+    "Set CPK_INTELLIGENCE_API_KEY for the project. CPK_TELEMETRY_ID is optional.",
+    "",
+    "### Self-hosted / offline license",
+    "",
+    "Offline deployments may set COPILOTKIT_LICENSE_TOKEN instead.",
+  ].join("\n");
+
+  expect(() => expectManagedEnvContract(envExample)).not.toThrow();
+  expect(() => expectManagedReadmeContract(readme)).not.toThrow();
+});
 
 test("the 16 managed template directories back all 19 in-repo CLI frameworks", () => {
   const frameworks = MANAGED_TEMPLATE_CONTRACTS.flatMap(


### PR DESCRIPTION
## Summary

- Migrate the 17 managed integration templates covering all 19 CLI frameworks to `CPK_INTELLIGENCE_API_KEY`.
- Add `CPK_TELEMETRY_ID` to generated environment examples and documentation as an optional, non-secret analytics identity.
- Remove managed license-token wiring while preserving separate offline and self-hosted licensing guidance.
- Preserve framework agents, endpoints, thread behavior, and AgentCore secret isolation and deployment variants.

## SDK stable-release dependency

The templates intentionally retain currently published stable CopilotKit package pins. No preview, branch, workspace, Git, or `pkg.pr.new` dependencies are introduced.

The current stable SDK (`1.62.3`; AgentCore currently uses `1.62.2`) does not yet consume `CPK_TELEMETRY_ID` end-to-end. This PR emits and documents the identity, but telemetry attribution must not be claimed until SDK support ships in a stable release.

No package was published, no version or lockfile changed, and no tag, release, merge, or deployment was performed.

## Validation

- [x] Integration parity: 0 errors
- [x] Managed scaffold contract: 188 tests
- [x] Stable integration pin contract: 11 tests
- [x] Changed-file formatting: 74 files
- [x] Changed-code and repository lint: 0 errors
- [x] Workflow YAML, actionlint, and repository-threshold zizmor
- [x] Clean archived starter installs/builds where supported
- [x] Browser bundles exclude the API-key sentinel
- [x] AgentCore frontend and Runtime Lambda compilation
- [x] Clean live-main range-diff and worktree
- [ ] Remote CI on this exact head
- [ ] End-to-end telemetry identity consumption after a stable SDK release

## Known baseline limitations

- Repository-wide formatting currently fails on 18 untouched showcase MDX files.
- LlamaIndex has an unchanged `clickOutsideToClose` stable-SDK type failure.
- Full .NET agent installation requires a .NET SDK unavailable on this host; its JS frontend build passes with lifecycle scripts disabled.
- AgentCore's unchanged Runtime lockfile blocks `npm ci`, though the documented `npm install` path and Lambda build pass.
- AgentCore CDK compilation has unchanged undefined gateway/tool output references, so synthesis and deployment are not claimed here.

## Required before any future merge

- [ ] SDK telemetry support is available in a stable release
- [ ] Affected template pins/locks are updated to that stable release where required
- [ ] Starter install/build/smoke and telemetry attribution are revalidated
- [ ] All required GitHub checks pass

This PR remains draft and dependency-blocked; merge, release, publication, and deployment are out of scope.