### PR TITLE
fix(ci): handle flattened showcase build artifact

### DIFF
--- a/showcase/scripts/__tests__/aggregate-build-results.test.ts
+++ b/showcase/scripts/__tests__/aggregate-build-results.test.ts
@@ -62,6 +62,20 @@ describe("aggregate-build-results.run", () => {
     );
   });
 
+  it("reads a single artifact extracted directly into INPUT_DIR", () => {
+    writeFileSync(
+      join(inputDir, "result.json"),
+      JSON.stringify({ service: "shell-docs", status: "success" }),
+    );
+
+    run({ inputDir, outputDir, githubOutput });
+
+    const results = JSON.parse(
+      readFileSync(join(outputDir, "results.json"), "utf-8"),
+    );
+    expect(results).toEqual([{ service: "shell-docs", status: "success" }]);
+  });
+
   it("throws naming the slot when build-result-<x>/result.json is missing", () => {
     const slotDir = join(inputDir, "build-result-orphan");
     mkdirSync(slotDir, { recursive: true });

--- a/showcase/scripts/aggregate-build-results.ts
+++ b/showcase/scripts/aggregate-build-results.ts
@@ -21,6 +21,7 @@
  */
 import {
   appendFileSync,
+  existsSync,
   mkdirSync,
   readFileSync,
   readdirSync,
@@ -110,16 +111,17 @@ export function run(opts: RunOptions): void {
   const slotDirs = readdirSync(inputDir, { withFileTypes: true })
     .filter((d) => d.isDirectory() && d.name.startsWith("build-result-"))
     .map((d) => d.name);
+  const singleArtifactPath = join(inputDir, "result.json");
 
   // The aggregator job is gated upstream on `has_changes == 'true'`, so the
   // build matrix is guaranteed non-empty by the time we run. A zero-slot
-  // input dir therefore signals a BROKEN per-slot artifact download (e.g.
+  // input with neither layout therefore signals a BROKEN artifact download (e.g.
   // expired artifacts, wrong run-id, transient download error) — NOT a
   // legitimate empty build set. Silently emitting `any_success=false` with
   // `results=[]` would be indistinguishable from "all builds failed" and
   // would push deploy down the false-green path where it probes the full
   // service set against stale `:latest`. Fail loud instead.
-  if (slotDirs.length === 0) {
+  if (slotDirs.length === 0 && !existsSync(singleArtifactPath)) {
     throw new Error(
       `aggregate-build-results: found 0 build-result-* slot dirs in ${inputDir} — ` +
         `the per-slot artifact download produced nothing; this indicates a broken ` +
@@ -127,7 +129,10 @@ export function run(opts: RunOptions): void {
     );
   }
 
-  const payloads = slotDirs.map((name) => readSlotPayload(inputDir, name));
+  const payloads =
+    slotDirs.length === 0
+      ? [readFileSync(singleArtifactPath, "utf-8")]
+      : slotDirs.map((name) => readSlotPayload(inputDir, name));
 
   const merged = mergeBuildResultFiles(payloads);
   const resultsJson = JSON.stringify(merged);


### PR DESCRIPTION
## Problem

Docs-only showcase runs build successfully, but result aggregation fails with zero `build-result-*` directories. That prevents the Railway staging redeploy and posts a misleading build-failure alert.

## Why

After `actions/download-artifact` was upgraded from v4 to v8, a pattern matching exactly one artifact is extracted directly into the configured directory as `result.json`. The aggregator only accepted the multi-artifact layout with nested `build-result-*/result.json` files.

## Fix

- Read the root-level `result.json` when no nested artifact directories exist.
- Keep the existing fail-loud behavior when neither layout is present.
- Add a regression test for the single-artifact layout.
