### PR TITLE
feat(showcase): D0-gone monitor staging-enable levers (ALLOW_ENV, SLUGS, DRY_RUN)

### DIFF
--- a/showcase/harness/src/fleet/control-plane/d0-gone-monitor.gate.test.ts
+++ b/showcase/harness/src/fleet/control-plane/d0-gone-monitor.gate.test.ts
@@ -122,6 +122,78 @@ describe("B-env — env resolution normalizes and treats empty as unset", () => 
   });
 });
 
+describe("PROD_D0_MONITOR_ALLOW_ENV — staging-enable env override (§10.8)", () => {
+  it("unset → prod-only (byte-identical to prior behavior)", () => {
+    // No override: registers ONLY on production, never on staging.
+    expect(shouldRegister({ SHOWCASE_ENV: "production" })).toBe(true);
+    expect(shouldRegister({ SHOWCASE_ENV: "staging" })).toBe(false);
+    expect(
+      shouldRegister({ RAILWAY_ENVIRONMENT_NAME: "staging" }),
+    ).toBe(false);
+  });
+
+  it("ALLOW_ENV=staging ALSO registers when the resolved env is staging", () => {
+    expect(
+      shouldRegister({
+        SHOWCASE_ENV: "staging",
+        PROD_D0_MONITOR_ALLOW_ENV: "staging",
+      }),
+    ).toBe(true);
+    expect(
+      shouldRegister({
+        RAILWAY_ENVIRONMENT_NAME: "staging",
+        PROD_D0_MONITOR_ALLOW_ENV: "staging",
+      }),
+    ).toBe(true);
+    // Production still registers with the override present.
+    expect(
+      shouldRegister({
+        SHOWCASE_ENV: "production",
+        PROD_D0_MONITOR_ALLOW_ENV: "staging",
+      }),
+    ).toBe(true);
+  });
+
+  it("ALLOW_ENV mismatch stays off (override does not blanket-enable)", () => {
+    // Override names staging but the env is dev → does NOT register.
+    expect(
+      shouldRegister({
+        SHOWCASE_ENV: "dev",
+        PROD_D0_MONITOR_ALLOW_ENV: "staging",
+      }),
+    ).toBe(false);
+  });
+
+  it("ALLOW_ENV is normalized (trim + lowercase) like the env vars", () => {
+    expect(
+      shouldRegister({
+        SHOWCASE_ENV: "staging",
+        PROD_D0_MONITOR_ALLOW_ENV: " Staging ",
+      }),
+    ).toBe(true);
+  });
+
+  it("kill-switch still applies with ALLOW_ENV set (both legs preserved)", () => {
+    // ALLOW_ENV enables the env leg, but ENABLED=false still disables.
+    expect(
+      shouldRegister({
+        SHOWCASE_ENV: "staging",
+        PROD_D0_MONITOR_ALLOW_ENV: "staging",
+        PROD_D0_MONITOR_ENABLED: "false",
+      }),
+    ).toBe(false);
+  });
+
+  it("empty/whitespace ALLOW_ENV is treated as unset (prod-only)", () => {
+    expect(
+      shouldRegister({
+        SHOWCASE_ENV: "staging",
+        PROD_D0_MONITOR_ALLOW_ENV: "   ",
+      }),
+    ).toBe(false);
+  });
+});
+
 describe("resolveConfig — negative / NaN / empty parse falls back (§8, slot3 F3)", () => {
   it("defaults when env vars are absent", () => {
     const c = resolveConfig({});

--- a/showcase/harness/src/fleet/control-plane/d0-gone-monitor.gate.test.ts
+++ b/showcase/harness/src/fleet/control-plane/d0-gone-monitor.gate.test.ts
@@ -127,9 +127,7 @@ describe("PROD_D0_MONITOR_ALLOW_ENV — staging-enable env override (§10.8)", (
     // No override: registers ONLY on production, never on staging.
     expect(shouldRegister({ SHOWCASE_ENV: "production" })).toBe(true);
     expect(shouldRegister({ SHOWCASE_ENV: "staging" })).toBe(false);
-    expect(
-      shouldRegister({ RAILWAY_ENVIRONMENT_NAME: "staging" }),
-    ).toBe(false);
+    expect(shouldRegister({ RAILWAY_ENVIRONMENT_NAME: "staging" })).toBe(false);
   });
 
   it("ALLOW_ENV=staging ALSO registers when the resolved env is staging", () => {

--- a/showcase/harness/src/fleet/control-plane/d0-gone-monitor.test.ts
+++ b/showcase/harness/src/fleet/control-plane/d0-gone-monitor.test.ts
@@ -1397,3 +1397,157 @@ describe("D0-gone monitor — A6 no state advance when Slack target throws (veri
     expect(JSON.parse(f.getState().hash!).alpha).toBeUndefined();
   });
 });
+
+describe("D0-gone monitor — PROD_D0_MONITOR_SLUGS per-slug allowlist (§10.8)", () => {
+  it("unset → ALL wired+supported slugs evaluated (prod-INERT baseline)", async () => {
+    // Both alpha and beta are fully gone; with no allowlist BOTH are named.
+    const f = makeFakes();
+    f.setSummary(f.liveProducer());
+    f.setStatusRows([...goneRows("alpha", T0), ...goneRows("beta", T0)]);
+    const m = createD0GoneMonitor(f.deps); // no env → no allowlist
+    await m.tick();
+    expect(f.posted).toHaveLength(1);
+    expect(f.posted[0]).toContain("`alpha`");
+    expect(f.posted[0]).toContain("`beta`");
+  });
+
+  it("allowlist scopes evaluation to exactly the listed slugs — other gone columns are NOT alerted", async () => {
+    // alpha AND beta are both fully gone, but the allowlist names only alpha →
+    // ONLY alpha is evaluated + alerted; beta (also gone) is never mentioned and
+    // never opens an outage entry.
+    const f = makeFakes();
+    f.setSummary(f.liveProducer());
+    f.setStatusRows([...goneRows("alpha", T0), ...goneRows("beta", T0)]);
+    const m = createD0GoneMonitor({
+      ...f.deps,
+      env: { PROD_D0_MONITOR_SLUGS: "alpha" },
+    });
+    await m.tick();
+    expect(f.posted).toHaveLength(1);
+    expect(f.posted[0]).toContain("`alpha`");
+    expect(f.posted[0]).not.toContain("`beta`");
+    const map = JSON.parse(f.getState().hash!);
+    expect(map.alpha).toBeDefined();
+    expect(map.beta).toBeUndefined(); // beta filtered out of the monitored set
+  });
+
+  it("allowlist intersects with wired+supported — a non-wired allowlisted slug fabricates nothing", async () => {
+    // The allowlist names alpha (wired) + a bogus slug not in the registry. Only
+    // alpha is evaluated; the bogus slug has no cells to fold, so no column is
+    // fabricated for it.
+    const f = makeFakes();
+    f.setSummary(f.liveProducer());
+    f.setStatusRows([...goneRows("alpha", T0), ...goneRows("beta", T0)]);
+    const m = createD0GoneMonitor({
+      ...f.deps,
+      env: { PROD_D0_MONITOR_SLUGS: "alpha,does-not-exist" },
+    });
+    await m.tick();
+    expect(f.posted).toHaveLength(1);
+    expect(f.posted[0]).toContain("`alpha`");
+    expect(f.posted[0]).not.toContain("`beta`");
+    expect(f.posted[0]).not.toContain("does-not-exist");
+  });
+});
+
+describe("D0-gone monitor — PROD_D0_MONITOR_DRY_RUN log-capture mode (§10.8)", () => {
+  function makeCapturingLogger() {
+    const info: Array<{ msg: string; meta: unknown }> = [];
+    return {
+      records: info,
+      logger: {
+        info(msg: string, meta: unknown) {
+          info.push({ msg, meta });
+        },
+        warn() {},
+        error() {},
+        debug() {},
+      },
+    };
+  }
+
+  it("dry-run: LOGS the composed outage payload, does NOT POST, still advances lastAlertAt", async () => {
+    const f = makeFakes();
+    const { records, logger } = makeCapturingLogger();
+    f.setSummary(f.liveProducer());
+    f.setStatusRows(goneRows("alpha", T0));
+    const m = createD0GoneMonitor({
+      ...f.deps,
+      logger,
+      env: { PROD_D0_MONITOR_DRY_RUN: "true" },
+    });
+    await m.tick();
+
+    // NO real Slack post.
+    expect(f.posted).toHaveLength(0);
+    // The fully-composed outage payload is logged with the dry-run tag.
+    const dryRun = records.filter((r) => r.msg === "d0-monitor.dry-run-alert");
+    expect(dryRun).toHaveLength(1);
+    const meta = dryRun[0].meta as { kind?: string; text?: string };
+    expect(meta.kind).toBe("outage");
+    expect(meta.text).toContain("completely gone");
+    expect(meta.text).toContain("`alpha`");
+    // State machine STILL advances exactly as if sent (lastAlertAt set, open).
+    const map = JSON.parse(f.getState().hash!);
+    expect(map.alpha).toBeDefined();
+    expect(map.alpha.lastAlertAt).not.toBe("");
+  });
+
+  it("dry-run: cadence + recovery exercise normally in logs with no real send", async () => {
+    const f = makeFakes();
+    const { records, logger } = makeCapturingLogger();
+    f.setSummary(f.liveProducer());
+    f.setStatusRows(goneRows("alpha", T0));
+    const m = createD0GoneMonitor({
+      ...f.deps,
+      logger,
+      env: { PROD_D0_MONITOR_DRY_RUN: "1" },
+    });
+    await m.tick(); // OPEN (logged, not posted)
+
+    // 15/30/45m ticks silent (hourly dedup still honored in dry-run).
+    for (const mins of [15, 30, 45]) {
+      f.setClock(T0 + mins * MIN);
+      f.setSummary(f.liveProducer(T0 + mins * MIN));
+      f.setStatusRows(goneRows("alpha", T0));
+      await m.tick();
+    }
+    const outageLogs = records.filter(
+      (r) =>
+        r.msg === "d0-monitor.dry-run-alert" &&
+        (r.meta as { kind?: string }).kind === "outage",
+    );
+    expect(outageLogs).toHaveLength(1); // no re-log before 60m (cadence intact)
+
+    // Recovery still exercises: fresh-healthy → a recovery payload is logged and
+    // the state entry is cleared (advanced exactly as if sent).
+    f.setClock(T0 + 20 * MIN); // within the open outage, before the 60m repost
+    f.setSummary(f.liveProducer(T0 + 20 * MIN));
+    f.setStatusRows(healthyRows("alpha", T0 + 20 * MIN));
+    await m.tick();
+    const recoveryLogs = records.filter(
+      (r) =>
+        r.msg === "d0-monitor.dry-run-alert" &&
+        (r.meta as { kind?: string }).kind === "recovery",
+    );
+    expect(recoveryLogs).toHaveLength(1);
+    expect((recoveryLogs[0].meta as { text?: string }).text).toContain(
+      "recovered",
+    );
+    expect(f.posted).toHaveLength(0); // never a real send
+    expect(JSON.parse(f.getState().hash ?? "{}").alpha).toBeUndefined(); // cleared
+  });
+
+  it("unset DRY_RUN → real send path (prod-INERT baseline)", async () => {
+    const f = makeFakes();
+    const { records, logger } = makeCapturingLogger();
+    f.setSummary(f.liveProducer());
+    f.setStatusRows(goneRows("alpha", T0));
+    const m = createD0GoneMonitor({ ...f.deps, logger }); // no DRY_RUN env
+    await m.tick();
+    expect(f.posted).toHaveLength(1); // real post
+    expect(
+      records.filter((r) => r.msg === "d0-monitor.dry-run-alert"),
+    ).toHaveLength(0); // no dry-run log
+  });
+});

--- a/showcase/harness/src/fleet/control-plane/d0-gone-monitor.ts
+++ b/showcase/harness/src/fleet/control-plane/d0-gone-monitor.ts
@@ -147,6 +147,41 @@ export function isEnabled(
 }
 
 /**
+ * §10.8 staging-enable per-slug allowlist. `PROD_D0_MONITOR_SLUGS` is a
+ * comma-separated slug list that SCOPES the monitored cell set to exactly those
+ * slugs (intersected with the wired+supported universe in the constructor).
+ * Unset / empty → `undefined` → watch ALL wired+supported slugs (prod-INERT,
+ * IDENTICAL to prior behavior). Blank list entries are ignored. Returns a Set
+ * for O(1) membership at the intersection site.
+ */
+export function resolveSlugAllowlist(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): Set<string> | undefined {
+  const raw = env.PROD_D0_MONITOR_SLUGS;
+  if (raw === undefined || raw.trim() === "") return undefined;
+  const slugs = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return slugs.length > 0 ? new Set(slugs) : undefined;
+}
+
+/**
+ * §10.8 dry-run (log-capture) mode. When `PROD_D0_MONITOR_DRY_RUN` is truthy
+ * (any value other than unset / empty / `false` / `0`), the monitor LOGS the
+ * fully-composed alert payload instead of POSTing to Slack, while still
+ * advancing the state machine exactly as if sent — so the live proof can
+ * observe detection + exact alert content + recovery in logs with NO real
+ * Slack post. Unset → real send (prod-INERT, IDENTICAL to prior behavior).
+ */
+export function isDryRun(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): boolean {
+  const v = norm(env.PROD_D0_MONITOR_DRY_RUN);
+  return v !== undefined && v !== "false" && v !== "0";
+}
+
+/**
  * B-env: resolve the deploy environment for the prod gate. The raw
  * `SHOWCASE_ENV ?? RAILWAY_ENVIRONMENT_NAME` had two silent-disable bugs:
  *   1. `SHOWCASE_ENV=""` (empty but SET) SHADOWS Railway via `??` (nullish
@@ -163,11 +198,19 @@ export function isEnabled(
 export function resolveMonitorEnv(
   env: Readonly<Record<string, string | undefined>> = process.env,
 ): string | undefined {
-  const norm = (raw: string | undefined): string | undefined => {
-    const v = raw?.trim().toLowerCase();
-    return v ? v : undefined; // empty/whitespace → unset (falls through)
-  };
   return norm(env.SHOWCASE_ENV) ?? norm(env.RAILWAY_ENVIRONMENT_NAME);
+}
+
+/**
+ * Trim + lowercase a raw env value; an empty/whitespace value normalizes to
+ * `undefined` (treated as UNSET). Shared by the env gate, the kill-switch's
+ * mirror parse, and the staging-enable overrides so all env normalization is
+ * one function (no drift between `SHOWCASE_ENV`, `RAILWAY_ENVIRONMENT_NAME`,
+ * and `PROD_D0_MONITOR_ALLOW_ENV`).
+ */
+function norm(raw: string | undefined): string | undefined {
+  const v = raw?.trim().toLowerCase();
+  return v ? v : undefined; // empty/whitespace → unset
 }
 
 /**
@@ -175,13 +218,26 @@ export function resolveMonitorEnv(
  * truth `orchestrator.ts` calls AND the gate test exercises (B-gatetest), so an
  * env-precedence / kill-switch / normalization regression fails a test instead
  * of shipping the monitor to the wrong environment (or silently disabling it in
- * prod). Registers iff the resolved env normalizes to `"production"` AND the
+ * prod). Registers iff the resolved env is prod (or matches the
+ * `PROD_D0_MONITOR_ALLOW_ENV` override — §10.8 staging-enable) AND the
  * kill-switch is not `false`.
+ *
+ * STAGING-ENABLE (§10.8): `PROD_D0_MONITOR_ALLOW_ENV` is a prod-INERT override
+ * (unset → prod-only, IDENTICAL to prior behavior). When it is set to a
+ * normalized env name (e.g. `staging`), the monitor ALSO registers when the
+ * resolved env equals that name — so the live §10.8 proof can run the merged
+ * monitor on staging. The kill-switch still applies (the `&& isEnabled(env)`
+ * leg is preserved), so `PROD_D0_MONITOR_ENABLED=false` disables it everywhere.
  */
 export function shouldRegister(
   env: Readonly<Record<string, string | undefined>> = process.env,
 ): boolean {
-  return resolveMonitorEnv(env) === "production" && isEnabled(env);
+  const resolved = resolveMonitorEnv(env);
+  const allowEnv = norm(env.PROD_D0_MONITOR_ALLOW_ENV);
+  const envOk =
+    resolved === "production" ||
+    (allowEnv !== undefined && resolved === allowEnv);
+  return envOk && isEnabled(env);
 }
 
 /**
@@ -249,6 +305,13 @@ export interface D0GoneMonitorDeps {
   /** Injected confirm-scan delay (test seam; defaults to a real setTimeout). */
   sleep?: (ms: number) => Promise<void>;
   config?: Partial<D0GoneMonitorConfig>;
+  /**
+   * Env source for the staging-enable overrides (`PROD_D0_MONITOR_SLUGS`,
+   * `PROD_D0_MONITOR_DRY_RUN`). Defaults to `process.env`; injected in tests.
+   * Kept separate from `config` (numeric cadence params) — these are the §10.8
+   * scope/dry-run levers, all prod-INERT when unset.
+   */
+  env?: Readonly<Record<string, string | undefined>>;
 }
 
 export interface D0GoneMonitor {
@@ -367,9 +430,19 @@ export function isProducerLive(
 
 export function createD0GoneMonitor(deps: D0GoneMonitorDeps): D0GoneMonitor {
   const { logger } = deps;
-  const config: D0GoneMonitorConfig = { ...resolveConfig(), ...deps.config };
+  const env = deps.env ?? process.env;
+  const config: D0GoneMonitorConfig = { ...resolveConfig(env), ...deps.config };
   const sleep =
     deps.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+
+  // §10.8 staging-enable levers (all prod-INERT when unset):
+  //   - `slugAllowlist` SCOPES the monitored cell set to specific slugs (unset →
+  //     all wired+supported, IDENTICAL to prior behavior). Applied in
+  //     `wiredSupportedCells` (below) by intersecting the resolved map.
+  //   - `dryRun` swaps the send path to a log-capture (no real Slack post) while
+  //     still advancing the state machine — see the send sites in `runTick`.
+  const slugAllowlist = resolveSlugAllowlist(env);
+  const dryRun = isDryRun(env);
 
   // The idle window is 3× the LONGEST resolved producer period (§2.5), resolved
   // from the injected schedules — never a hand-picked constant. Computed once
@@ -404,7 +477,22 @@ export function createD0GoneMonitor(deps: D0GoneMonitorDeps): D0GoneMonitor {
     registryIsLoader
       ? (deps.registry as () => RegistryDoc)()
       : (deps.registry as RegistryDoc);
-  let cellsBySlug = wiredSupportedCells(loadRegistry());
+  // §10.8: enumerate the wired+supported cell universe, then (if a slug
+  // allowlist is set) INTERSECT it down to exactly the allowlisted slugs. The
+  // intersection keeps only slugs that are BOTH wired+supported AND allowlisted
+  // — an allowlisted slug that is not wired+supported is silently dropped (it
+  // has no cells to fold), so a stray/typo'd slug can never fabricate a column.
+  // Unset allowlist → the full wired+supported map (prod-INERT, unchanged).
+  const enumerateCells = (): Map<string, WiredCell[]> => {
+    const all = wiredSupportedCells(loadRegistry());
+    if (slugAllowlist === undefined) return all;
+    const scoped = new Map<string, WiredCell[]>();
+    for (const [slug, cells] of all) {
+      if (slugAllowlist.has(slug)) scoped.set(slug, cells);
+    }
+    return scoped;
+  };
+  let cellsBySlug = enumerateCells();
 
   /**
    * B-A5gap: "no wired cell anywhere". `wiredSupportedCells` keys EVERY
@@ -437,7 +525,7 @@ export function createD0GoneMonitor(deps: D0GoneMonitorDeps): D0GoneMonitor {
    */
   function resolveCells(): Map<string, WiredCell[]> {
     if (hasNoWiredCell(cellsBySlug) && registryIsLoader) {
-      cellsBySlug = wiredSupportedCells(loadRegistry());
+      cellsBySlug = enumerateCells();
     }
     return cellsBySlug;
   }
@@ -723,6 +811,27 @@ export function createD0GoneMonitor(deps: D0GoneMonitorDeps): D0GoneMonitor {
     );
   }
 
+  /**
+   * §10.8 send-or-log. In DRY_RUN mode LOG the fully-composed payload at INFO
+   * with the `kind` tag ("outage" / "recovery") and return WITHOUT POSTing to
+   * Slack or throwing — the caller then advances the state machine (lastAlertAt
+   * / recovery clear) exactly as if the send had succeeded, so cadence +
+   * recovery logic exercises normally with no real Slack post. In normal mode
+   * this is a thin pass-through to `deps.postAlert` (which throws on send
+   * failure, preserving the §7 unadvanced-clock retry discipline). Prod-INERT
+   * when `PROD_D0_MONITOR_DRY_RUN` is unset (`dryRun === false`).
+   */
+  async function postOrLog(
+    text: string,
+    kind: "outage" | "recovery",
+  ): Promise<void> {
+    if (dryRun) {
+      logger.info("d0-monitor.dry-run-alert", { kind, text });
+      return; // skip the real send; caller still advances state (as if sent)
+    }
+    await deps.postAlert(text);
+  }
+
   // ── The tick ─────────────────────────────────────────────────────────
   async function runTick(): Promise<void> {
     const nowMs = deps.now();
@@ -945,7 +1054,7 @@ export function createD0GoneMonitor(deps: D0GoneMonitorDeps): D0GoneMonitor {
       // message and the `lastAlertAt` stamp, which both use `evidenceMs`.
       const text = outageMessage(shownSlugs, overflowCount, map, evidenceMs);
       try {
-        await deps.postAlert(text);
+        await postOrLog(text, "outage");
         for (const slug of shownDue) {
           // Advance ONLY the DUE slugs that were NAMED in this message — one
           // successful send drives one shared re-post gate for the slugs it
@@ -988,7 +1097,7 @@ export function createD0GoneMonitor(deps: D0GoneMonitorDeps): D0GoneMonitor {
       // observed), not the tick-start — the two differ by the confirm delay.
       const text = recoveryMessage(recovered, evidenceMs);
       try {
-        await deps.postAlert(text);
+        await postOrLog(text, "recovery");
         for (const r of recovered) delete map[r.slug]; // clear AFTER send (§5.2)
         logger.warn("d0-monitor.recovery-alerted", {
           slugs: recovered.map((r) => r.slug),


### PR DESCRIPTION
Three **prod-INERT** config levers so the already-merged prod D0-gone monitor (#5943) can run in **STAGING**, scoped to specific slugs, in **DRY-RUN** (log-capture) mode — for the §10.8 live proof. All default to current prod behavior when unset; prod behavior is byte-identical with none set. No detection/predicate/cadence logic touched (that is converged) — this is additive config + a send-path branch + a slug filter only.

## Levers

**1. `PROD_D0_MONITOR_ALLOW_ENV`** — env-gate override. `shouldRegister` now registers when `resolvedEnv === "production"` **OR** (`ALLOW_ENV` is set and `resolvedEnv === norm(ALLOW_ENV)`). Unset → prod-only (identical). `PROD_D0_MONITOR_ALLOW_ENV=staging` → also registers on staging. Kill-switch (`isEnabled`) leg preserved. `norm` (trim+lowercase, empty→undefined) extracted to module scope and reused.

**2. `PROD_D0_MONITOR_SLUGS`** — per-slug allowlist. When set (comma-separated), the monitored cell set is intersected down to exactly those slugs (∩ wired+supported); a non-wired allowlisted slug fabricates nothing. Unset → all wired+supported (current behavior). Applied at construction and on the self-heal registry re-load.

**3. `PROD_D0_MONITOR_DRY_RUN`** — log-capture mode. When truthy, the composed alert payload (exact #oss-alerts outage message + recovery message) is logged at INFO with tag `d0-monitor.dry-run-alert` and the real Slack send is skipped **without throwing**, while the state machine still advances (`lastAlertAt` / recovery clear) exactly as if sent. Unset → real send.

## Red-green

Each lever proven RED (source reverted, new tests fail) → GREEN (source restored, pass). The `unset` baseline sub-tests pass on old code, confirming prod-inertness. Full verbatim RED→GREEN in the local CR detail note.

- harness `tsc --noEmit` = 0; shell-dashboard `tsc --noEmit` = 0
- Required suite: 87/87 pass (d0-gone-predicate, d0-gone-monitor, d0-gone-monitor.gate, cell-model.equivalence)
- Wider control-plane + cell-model: 441/441 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)