### PR TITLE
fix(showcase): harness crash-loops at boot on extensionless ESM imports

### DIFF
--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -377,8 +377,12 @@ jobs:
         # pnpm-lock.yaml-pinned version is used (no registry-cache-miss drift).
         run: pnpm exec vitest bench src/cvdiag/emit-perf.bench.ts --run
 
-      - name: Harness ESM boot-smoke (no ERR_MODULE_NOT_FOUND)
+      - name: Harness ESM boot-smoke (no module-resolution errors)
         working-directory: showcase/harness
+        # Bound the whole step so a hung boot can never run away to the job's
+        # 25-minute timeout (see the `timeout 120s` wrapper below for the same
+        # guarantee at the node level).
+        timeout-minutes: 5
         # The harness ships as pure Node ESM: package.json `"type":"module"`,
         # build is `tsc` with `moduleResolution:"bundler"` (which PRESERVES
         # extensionless import specifiers at emit), and it runs via
@@ -388,27 +392,48 @@ jobs:
         # NONE of the other CI steps exercise the real `node dist` module graph.
         # A single extensionless relative import (as happened in the relocated
         # shared/cell-model fold) therefore builds green, passes every test, and
-        # only crash-loops the orchestrator at container boot with
-        # ERR_MODULE_NOT_FOUND. This step is the missing gate: build the dist and
-        # actually load the orchestrator module graph, failing hard on a module-
-        # resolution error. A later runtime error from missing env/PocketBase is
-        # expected and NOT a failure — only ERR_MODULE_NOT_FOUND reddens the build.
+        # only crash-loops the orchestrator at container boot with a module-
+        # resolution error. This step is the missing gate: build the dist and
+        # actually load the orchestrator module graph, failing hard on ANY
+        # module-resolution error class (not just ERR_MODULE_NOT_FOUND — a
+        # directory import, unexported package subpath, unknown extension, or
+        # invalid specifier is the same regression wearing a different code).
+        # A later runtime error from missing env/PocketBase (e.g. the
+        # `HARNESS_ROLE must be set` guard, which carries no such code) is
+        # expected and NOT a failure — only a module-resolution error reddens
+        # the build.
         run: |
           set -euo pipefail
           pnpm build
-          node -e "
+          # `timeout` (coreutils) yields a non-zero exit on timeout, so a hang
+          # FAILS the step rather than silently passing.
+          timeout 120s node -e "
+            // Any of these codes means a relative/package import failed to
+            // resolve under pure Node ESM — the exact regression this guards.
+            const MODULE_RESOLUTION_CODES = new Set([
+              'ERR_MODULE_NOT_FOUND',
+              'ERR_UNSUPPORTED_DIR_IMPORT',
+              'ERR_PACKAGE_PATH_NOT_EXPORTED',
+              'ERR_UNKNOWN_FILE_EXTENSION',
+              'ERR_INVALID_MODULE_SPECIFIER',
+            ]);
             import('./dist/orchestrator.js')
-              .then(() => { console.log('BOOT_OK: orchestrator module graph loaded'); })
+              .then(() => {
+                console.log('BOOT_OK: orchestrator module graph loaded');
+                // Explicit exit so a lingering open handle can't hang the run.
+                process.exit(0);
+              })
               .catch((e) => {
-                if (e && e.code === 'ERR_MODULE_NOT_FOUND') {
+                if (e && MODULE_RESOLUTION_CODES.has(e.code)) {
                   console.error('BOOT_FAIL:', e.code, e.message);
-                  console.error('An extensionless relative import broke the pure-ESM module graph. Add the .js extension to the offending relative import specifier.');
+                  console.error('A relative/package import failed to resolve in the pure-ESM module graph (e.g. a missing .js extension). Fix the offending import specifier.');
                   process.exit(1);
                 }
                 // Any non-module-resolution error (e.g. missing env/PocketBase
                 // at boot) means the module graph loaded fine — that is a PASS
                 // for this smoke.
                 console.log('BOOT_OK: module graph loaded (non-module-resolution runtime error is expected here):', e && e.code);
+                process.exit(0);
               });
           "
 

--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -377,6 +377,41 @@ jobs:
         # pnpm-lock.yaml-pinned version is used (no registry-cache-miss drift).
         run: pnpm exec vitest bench src/cvdiag/emit-perf.bench.ts --run
 
+      - name: Harness ESM boot-smoke (no ERR_MODULE_NOT_FOUND)
+        working-directory: showcase/harness
+        # The harness ships as pure Node ESM: package.json `"type":"module"`,
+        # build is `tsc` with `moduleResolution:"bundler"` (which PRESERVES
+        # extensionless import specifiers at emit), and it runs via
+        # `node dist/orchestrator.js` (Docker CMD + `start` script). Under pure
+        # Node ESM, relative import specifiers MUST carry the `.js` extension —
+        # `tsc`, vitest, and tsx all resolve extensionless specifiers fine, so
+        # NONE of the other CI steps exercise the real `node dist` module graph.
+        # A single extensionless relative import (as happened in the relocated
+        # shared/cell-model fold) therefore builds green, passes every test, and
+        # only crash-loops the orchestrator at container boot with
+        # ERR_MODULE_NOT_FOUND. This step is the missing gate: build the dist and
+        # actually load the orchestrator module graph, failing hard on a module-
+        # resolution error. A later runtime error from missing env/PocketBase is
+        # expected and NOT a failure — only ERR_MODULE_NOT_FOUND reddens the build.
+        run: |
+          set -euo pipefail
+          pnpm build
+          node -e "
+            import('./dist/orchestrator.js')
+              .then(() => { console.log('BOOT_OK: orchestrator module graph loaded'); })
+              .catch((e) => {
+                if (e && e.code === 'ERR_MODULE_NOT_FOUND') {
+                  console.error('BOOT_FAIL:', e.code, e.message);
+                  console.error('An extensionless relative import broke the pure-ESM module graph. Add the .js extension to the offending relative import specifier.');
+                  process.exit(1);
+                }
+                // Any non-module-resolution error (e.g. missing env/PocketBase
+                // at boot) means the module graph loaded fine — that is a PASS
+                // for this smoke.
+                console.log('BOOT_OK: module graph loaded (non-module-resolution runtime error is expected here):', e && e.code);
+              });
+          "
+
       - name: Validate manifests & generate registry
         working-directory: showcase/scripts
         run: pnpm exec tsx generate-registry.ts

--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -377,7 +377,7 @@ jobs:
         # pnpm-lock.yaml-pinned version is used (no registry-cache-miss drift).
         run: pnpm exec vitest bench src/cvdiag/emit-perf.bench.ts --run
 
-      - name: Harness ESM boot-smoke (no module-resolution errors)
+      - name: Harness ESM boot-smoke (module graph must load without throwing)
         working-directory: showcase/harness
         # Bound the whole step so a hung boot can never run away to the job's
         # 25-minute timeout (see the `timeout 120s` wrapper below for the same
@@ -394,22 +394,35 @@ jobs:
         # shared/cell-model fold) therefore builds green, passes every test, and
         # only crash-loops the orchestrator at container boot with a module-
         # resolution error. This step is the missing gate: build the dist and
-        # actually load the orchestrator module graph, failing hard on ANY
-        # module-resolution error class (not just ERR_MODULE_NOT_FOUND — a
-        # directory import, unexported package subpath, unknown extension, or
-        # invalid specifier is the same regression wearing a different code).
-        # A later runtime error from missing env/PocketBase (e.g. the
-        # `HARNESS_ROLE must be set` guard, which carries no such code) is
-        # expected and NOT a failure — only a module-resolution error reddens
-        # the build.
+        # actually load the orchestrator module graph via `import()`.
+        #
+        # STRICT semantics: we run under `node -e`, so `process.argv[1]` is
+        # UNSET. `bootFleet()` — which does the env/PocketBase validation that
+        # legitimately throws (e.g. the `HARNESS_ROLE must be set` guard) — only
+        # runs when the orchestrator is the entry module (argv[1] === its own
+        # path), which never happens here. So this smoke ONLY links + evaluates
+        # the module graph; it never boots the fleet. A CLEAN build therefore
+        # loads with NO thrown error (proven: the real dist/orchestrator.js →
+        # BOOT_OK, exit 0). It follows that ANY error thrown by `import()` here
+        # is a boot regression and MUST fail the gate — not just module-
+        # resolution failures (missing .js extension, directory import,
+        # unexported subpath, unknown extension, invalid specifier), but ALSO
+        # evaluation/link failures with no resolution code: a top-level throw,
+        # an await-rejection, a bad named binding, or a SyntaxError. We still
+        # walk the cause chain / AggregateError members for a module-resolution
+        # code, but now ONLY to LABEL the failure ("module-resolution failure"
+        # vs "boot/evaluation failure") — both exit 1.
         run: |
           set -euo pipefail
           pnpm build
           # `timeout` (coreutils) yields a non-zero exit on timeout, so a hang
           # FAILS the step rather than silently passing.
           timeout 120s node -e "
-            // Any of these codes means a relative/package import failed to
-            // resolve under pure Node ESM — the exact regression this guards.
+            // Codes that mean a relative/package import failed to RESOLVE
+            // under pure Node ESM. Under strict semantics these no longer
+            // gate pass/fail (ANY thrown error fails) — they only LABEL the
+            // failure so the log distinguishes a resolution failure from an
+            // evaluation/link failure.
             const MODULE_RESOLUTION_CODES = new Set([
               'ERR_MODULE_NOT_FOUND',
               'ERR_UNSUPPORTED_DIR_IMPORT',
@@ -421,10 +434,10 @@ jobs:
             // level: Node (or an intermediate loader) may rethrow it WRAPPED
             // in \`e.cause\` (possibly a chain) or bundled inside an
             // AggregateError (\`e.errors\`), where a bare \`e.code\` check sees
-            // no code and would wave the regression through. So collect every
-            // code reachable from the thrown error — itself, its cause chain,
-            // and any AggregateError members (recursively, with a depth cap to
-            // bound cause cycles) — and fail if ANY is a resolution code.
+            // no code. We collect every code reachable from the thrown error —
+            // itself, its cause chain, and any AggregateError members
+            // (recursively, with a depth cap to bound cause cycles) — purely
+            // to CLASSIFY the failure message; the exit code is 1 regardless.
             const collectErrorCodes = (e, depth = 0, codes = new Set()) => {
               if (!e || typeof e !== 'object' || depth > 10) return codes;
               if (e.code) codes.add(e.code);
@@ -441,17 +454,18 @@ jobs:
                 process.exit(0);
               })
               .catch((e) => {
-                const hit = [...collectErrorCodes(e)].find((c) => MODULE_RESOLUTION_CODES.has(c));
-                if (hit) {
-                  console.error('BOOT_FAIL:', hit, e && e.message);
+                // STRICT: any rejection is a boot regression. bootFleet() does
+                // not run here (argv[1] is unset), so a clean graph loads
+                // without throwing — there is no legitimate error to swallow.
+                const resolutionHit = [...collectErrorCodes(e)].find((c) => MODULE_RESOLUTION_CODES.has(c));
+                if (resolutionHit) {
+                  console.error('BOOT_FAIL (module-resolution failure):', resolutionHit, e && e.message);
                   console.error('A relative/package import failed to resolve in the pure-ESM module graph (e.g. a missing .js extension). Fix the offending import specifier.');
-                  process.exit(1);
+                } else {
+                  console.error('BOOT_FAIL (boot/evaluation failure):', (e && e.code) || (e && e.name) || 'Error', e && e.message);
+                  console.error('The orchestrator module graph threw while loading (top-level throw, await rejection, bad named binding, or syntax error). bootFleet() does NOT run in this smoke, so a clean graph must load without throwing. Fix the boot-time regression.');
                 }
-                // Any non-module-resolution error (e.g. missing env/PocketBase
-                // at boot) means the module graph loaded fine — that is a PASS
-                // for this smoke.
-                console.log('BOOT_OK: module graph loaded (non-module-resolution runtime error is expected here):', e && e.code);
-                process.exit(0);
+                process.exit(1);
               });
           "
 

--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -417,6 +417,23 @@ jobs:
               'ERR_UNKNOWN_FILE_EXTENSION',
               'ERR_INVALID_MODULE_SPECIFIER',
             ]);
+            // A module-resolution error does not always arrive at the top
+            // level: Node (or an intermediate loader) may rethrow it WRAPPED
+            // in \`e.cause\` (possibly a chain) or bundled inside an
+            // AggregateError (\`e.errors\`), where a bare \`e.code\` check sees
+            // no code and would wave the regression through. So collect every
+            // code reachable from the thrown error — itself, its cause chain,
+            // and any AggregateError members (recursively, with a depth cap to
+            // bound cause cycles) — and fail if ANY is a resolution code.
+            const collectErrorCodes = (e, depth = 0, codes = new Set()) => {
+              if (!e || typeof e !== 'object' || depth > 10) return codes;
+              if (e.code) codes.add(e.code);
+              if (e.cause) collectErrorCodes(e.cause, depth + 1, codes);
+              if (Array.isArray(e.errors)) {
+                for (const inner of e.errors) collectErrorCodes(inner, depth + 1, codes);
+              }
+              return codes;
+            };
             import('./dist/orchestrator.js')
               .then(() => {
                 console.log('BOOT_OK: orchestrator module graph loaded');
@@ -424,8 +441,9 @@ jobs:
                 process.exit(0);
               })
               .catch((e) => {
-                if (e && MODULE_RESOLUTION_CODES.has(e.code)) {
-                  console.error('BOOT_FAIL:', e.code, e.message);
+                const hit = [...collectErrorCodes(e)].find((c) => MODULE_RESOLUTION_CODES.has(c));
+                if (hit) {
+                  console.error('BOOT_FAIL:', hit, e && e.message);
                   console.error('A relative/package import failed to resolve in the pure-ESM module graph (e.g. a missing .js extension). Fix the offending import specifier.');
                   process.exit(1);
                 }

--- a/showcase/harness/src/shared/cell-model/cell-model.equivalence-fixtures.ts
+++ b/showcase/harness/src/shared/cell-model/cell-model.equivalence-fixtures.ts
@@ -14,10 +14,10 @@
  * `row(key, state, {observedAt})` builder and `mergeRowsToMap(...groups)` to
  * assemble the `LiveStatusMap`.
  */
-import type { StatusRow, State } from "./live-status";
-import { keyFor, mergeRowsToMap, CATALOG_TO_D5_KEY } from "./live-status";
-import type { CellModelInput } from "./cell-model";
-import { E2E_STALE_AFTER_MS } from "./staleness";
+import type { StatusRow, State } from "./live-status.js";
+import { keyFor, mergeRowsToMap, CATALOG_TO_D5_KEY } from "./live-status.js";
+import type { CellModelInput } from "./cell-model.js";
+import { E2E_STALE_AFTER_MS } from "./staleness.js";
 
 /**
  * FIXED reference clock. Every fixture is built relative to this instant so the

--- a/showcase/harness/src/shared/cell-model/cell-model.equivalence.test.ts
+++ b/showcase/harness/src/shared/cell-model/cell-model.equivalence.test.ts
@@ -15,12 +15,12 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { buildCellModel } from "./cell-model";
+import { buildCellModel } from "./cell-model.js";
 import {
   FIXTURES,
   NOW,
   serializeModel,
-} from "./cell-model.equivalence-fixtures";
+} from "./cell-model.equivalence-fixtures.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const BASELINE: Record<string, unknown> = JSON.parse(

--- a/showcase/harness/src/shared/cell-model/cell-model.ts
+++ b/showcase/harness/src/shared/cell-model/cell-model.ts
@@ -13,22 +13,22 @@ import type {
   State,
   PoolCommError,
   FleetSurfaceState,
-} from "./live-status";
+} from "./live-status.js";
 import {
   keyFor,
   CATALOG_TO_D5_KEY,
   commErrorFromStatusSignal,
   FLEET_COMM_AGGREGATE_DIMENSIONS,
   STARTER_LEVELS,
-} from "./live-status";
-import type { StarterLevel } from "./live-status";
+} from "./live-status.js";
+import type { StarterLevel } from "./live-status.js";
 import {
   E2E_STALE_AFTER_MS,
   D4_STALE_AFTER_MS,
   LIVENESS_STALE_AFTER_MS,
   STARTER_STALE_AFTER_MS,
   isStale,
-} from "./staleness";
+} from "./staleness.js";
 
 // Re-export the staleness windows so existing consumers that import them from
 // this module (e.g. `__tests__/cell-model.test.ts`) keep resolving — the
@@ -37,7 +37,7 @@ export {
   E2E_STALE_AFTER_MS,
   D4_STALE_AFTER_MS,
   LIVENESS_STALE_AFTER_MS,
-} from "./staleness";
+} from "./staleness.js";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/showcase/harness/src/shared/cell-model/live-status.ts
+++ b/showcase/harness/src/shared/cell-model/live-status.ts
@@ -14,14 +14,14 @@
  * per-cell (the aggregate is red whenever any cell fails).
  */
 
-import { formatTs } from "./format-ts";
+import { formatTs } from "./format-ts.js";
 import {
   D4_STALE_AFTER_MS,
   E2E_STALE_AFTER_MS,
   LIVENESS_STALE_AFTER_MS,
   STARTER_STALE_AFTER_MS,
   isStale,
-} from "./staleness";
+} from "./staleness.js";
 
 export type State = "green" | "red" | "degraded";
 

--- a/showcase/harness/src/shared/cell-model/staleness.ts
+++ b/showcase/harness/src/shared/cell-model/staleness.ts
@@ -10,7 +10,7 @@
  * type from `live-status.ts`, so there is no runtime dependency edge.
  */
 
-import type { StatusRow } from "./live-status";
+import type { StatusRow } from "./live-status.js";
 
 /**
  * Staleness window for the `e2e:` dimension. The e2e-demos driver writes


### PR DESCRIPTION
## What broke

The showcase control-plane harness crash-looped at boot on `origin/main` HEAD, breaking the staging auto-deploy:

```
BOOT_ERR ERR_MODULE_NOT_FOUND Cannot find module '.../dist/shared/cell-model/live-status' imported from .../dist/shared/cell-model/cell-model.js
```

## Root cause

The harness ships as **pure Node ESM**:
- `showcase/harness/package.json` has `"type": "module"`
- build is `tsc -p tsconfig.build.json` with `moduleResolution: "bundler"`, which **preserves extensionless import specifiers at emit** (it does not rewrite `./live-status` → `./live-status.js`)
- the Docker `CMD` and the `start` script both run `node dist/orchestrator.js`

Under pure Node ESM, relative import specifiers **must** carry the `.js` extension. The harness already honors this convention everywhere — `orchestrator.ts` has 79 relative imports, 79/79 ending in `.js`.

The relocated `showcase/harness/src/shared/cell-model/` fold broke the convention: `cell-model.ts`, `live-status.ts`, `staleness.ts`, and the equivalence fixtures/test imported their siblings extensionless (`"./live-status"`, `"./staleness"`, etc). `tsc`, `vitest`, and `tsx` all resolve extensionless specifiers fine, so it built green and passed every test — then `node dist/orchestrator.js` threw `ERR_MODULE_NOT_FOUND` at boot and crash-looped.

## The fix

Add the `.js` extension to every offending relative import in the cell-model fold, matching the harness convention. **No tsconfig change** (deliberately not switching to `nodenext`) — the minimal, convention-matching fix is the extensions.

Files fixed (7 relative import specifiers across 5 files):
- `cell-model.ts` — 4 specifiers (`./live-status` ×3, `./staleness` ×2 counting the re-export)
- `live-status.ts` — `./format-ts`, `./staleness`
- `staleness.ts` — `./live-status`
- `cell-model.equivalence-fixtures.ts` — `./live-status` ×2, `./cell-model`, `./staleness`
- `cell-model.equivalence.test.ts` — `./cell-model`, `./cell-model.equivalence-fixtures`

The shell-dashboard re-export shims (`showcase/shell-dashboard/src/lib/{cell-model,live-status,staleness,format-ts}.ts`) were intentionally **left unchanged**: that package is a Next.js build (not `node dist`) and uses extensionless relative imports as its own convention, including reaching into harness `src`. Adding `.js` there would break it.

## Local RED / GREEN proof

Same `node dist/orchestrator.js` boot probe, before and after the fix.

**RED** (unmodified branch code, after `pnpm --filter @copilotkit/showcase-harness build`):
```
BOOT_ERR ERR_MODULE_NOT_FOUND Cannot find module '/…/showcase/harness/dist/shared/cell-model/live-status' imported from /…/showcase/harness/dist/shared/cell-model/cell-model.js
```

**GREEN** (after the fix, rebuilt):
```
BOOT_OK
```
The orchestrator module graph now loads fully — `ERR_MODULE_NOT_FOUND` is gone.

## Docker boot result

Built the harness image locally from repo root (`docker build -f showcase/harness/Dockerfile -t harness-esm-test .`) — build succeeded (exit 0). Ran the container (`docker run harness-esm-test`, no env supplied). It did **not** crash-loop on module resolution: the full ESM module graph loaded and boot reached `bootFleet` in `orchestrator.js`, then exited cleanly on the expected missing-env application error — **no `ERR_MODULE_NOT_FOUND`**:

```
{"level":"error","msg":"showcase-harness.boot-failed","err":"HARNESS_ROLE must be set to one of: control-plane, worker (got: <unset>). ...","stack":"Error: HARNESS_ROLE must be set ...
    at resolveFleetRoleConfig (file:///app/dist/fleet/role-config.js:72:15)
    at bootFleet (file:///app/dist/orchestrator.js:3680:20)
    at file:///app/dist/orchestrator.js:3762:5
    at ModuleJob.run (node:internal/modules/esm/module_job:343:25)"}
```

Every `dist/` module resolved (note `file:///app/dist/fleet/role-config.js` and `file:///app/dist/orchestrator.js`); the crash was the intended env-validation guard, exactly the "later runtime error is acceptable" case. On pre-fix code this same container would have thrown `ERR_MODULE_NOT_FOUND` at import time and crash-looped.

## CI regression guard

CI missed this because `tsc` (bundler resolution), `vitest`, and `tsx` all resolve extensionless specifiers — **no existing CI step ever ran the real `node dist` module graph** that the container boots.

Added a **harness ESM boot-smoke** step to the `Showcase: Validate` job (already gated on `showcase/harness/**`, a required PR check): after building the harness dist, it loads `dist/orchestrator.js` via `node import()` and fails hard on `ERR_MODULE_NOT_FOUND`. A later runtime error from missing env/PocketBase is expected and passes — only a module-resolution failure reddens the build.

**Guard red-green** (the guard's own proof, run locally against both code states):
- **pre-fix** (extensionless imports): `BOOT_FAIL: ERR_MODULE_NOT_FOUND …/dist/shared/cell-model/live-status` → exit **1** ✅ caught
- **post-fix** (with `.js`): `BOOT_OK: orchestrator module graph loaded` → exit **0** ✅ passes

## Verification

- `pnpm typecheck` / `tsc --noEmit`: clean
- `cell-model.equivalence.test.ts`: 7/7 pass
- lefthook lint + commitlint: pass on both commits

Do not merge — merge is user-gated after code review.
