### PR TITLE
fix: route showcase demos to aimock over private Railway networking (egress fix)

### DIFF
--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -2240,11 +2240,22 @@ module Railway
             end.uniq
         end
 
-        # The env-LOCAL host the target service serves in `env` (the `domains`
-        # value from the SSOT). `env` is "prod" or "staging".
+        # The env-LOCAL host a serviceRef must point at for `env`.
+        #
+        # PREFERS the PRIVATE Railway networking host (`internalDomains[env]`,
+        # e.g. `showcase-aimock.railway.internal`) when the SSOT declares one:
+        # public `*.up.railway.app` traffic is billed egress even intra-project,
+        # while `*.railway.internal` is free and env-scoped, so demo backends
+        # must resolve their aimock serviceRefs at the private host. Falls back
+        # to the public `domains[env]` host for any target that declares no
+        # internal domain (every non-aimock target today). `env` is "prod" or
+        # "staging". The comparison in `check_service_refs` is HOST-substring,
+        # so returning the bare host (no scheme/port) matches both the bare
+        # origin and the `/v1`-suffixed `http://<host>:4010/v1` forms.
         def ssot_target_host(target_name, env)
             entry = ssot_service(target_name)
-            entry && entry.dig("domains", env)
+            return nil unless entry
+            entry.dig("internalDomains", env) || entry.dig("domains", env)
         end
 
         # Read a single (service,env) variable VALUE transiently (never

--- a/showcase/bin/spec/test_promote_u5_env_serviceref.rb
+++ b/showcase/bin/spec/test_promote_u5_env_serviceref.rb
@@ -72,37 +72,66 @@ class PromoteU5EnvServiceRefTest < Minitest::Test
 
     # ── §5.2 service-ref assertion (REFUSE) ─────────────────────────────────
 
-    def test_serviceref_prod_pointing_at_staging_aimock_refuses
+    def test_serviceref_prod_pointing_at_public_aimock_host_refuses
         # showcase-ag2 carries serviceRefs:[{key:OPENAI_BASE_URL,target:aimock}].
-        # aimock prod host = showcase-aimock-production.up.railway.app.
+        # aimock now declares an env-scoped PRIVATE host
+        # (showcase-aimock.railway.internal), so `ssot_target_host` expects the
+        # INTERNAL host. A prod ref still pointing at the PUBLIC (billed-egress)
+        # aimock host is drift => REFUSE — this is the egress-leak class the
+        # private-networking migration closes.
         c = cmd
         c.instance_variable_set(:@gql, FakeGql.new(values: {
             ["ag2-prod", PROD_ENV] => {
-                # WRONG: prod points at the STAGING aimock host.
-                "OPENAI_BASE_URL" => "https://aimock-staging.up.railway.app",
+                # WRONG: prod points at the PUBLIC aimock host (billed egress).
+                "OPENAI_BASE_URL" => "https://showcase-aimock-production.up.railway.app/v1",
             },
         }))
         staging = { "services" => [{ "name" => "showcase-ag2", "service_id" => "ag2-stg" }] }
         prod    = { "services" => [{ "name" => "showcase-ag2", "service_id" => "ag2-prod" }] }
         findings = c.check_service_refs(staging, prod)
         assert(findings.any? { |f| f.start_with?("REFUSE") && f =~ /OPENAI_BASE_URL/ },
-               "expected REFUSE for prod serviceRef pointing at staging host, got #{findings.inspect}")
+               "expected REFUSE for prod serviceRef on the public egress host, got #{findings.inspect}")
         assert(c.instance_variable_get(:@gql).mutations.none? { |m| m[:kind] == :upsert },
                "service-ref check must ASSERT, never upsert")
     end
 
-    def test_serviceref_prod_pointing_at_prod_aimock_passes
+    def test_serviceref_prod_pointing_at_private_aimock_passes
+        # The private-networking target: prod OPENAI_BASE_URL points at the
+        # free env-scoped internal host with the /v1 suffix and port 4010.
+        # `ssot_target_host` prefers internalDomains, and check_service_refs
+        # compares on HOST substring, so the /v1 + :4010 form must PASS.
         c = cmd
         c.instance_variable_set(:@gql, FakeGql.new(values: {
             ["ag2-prod", PROD_ENV] => {
-                "OPENAI_BASE_URL" => "https://showcase-aimock-production.up.railway.app",
+                "OPENAI_BASE_URL" => "http://showcase-aimock.railway.internal:4010/v1",
             },
         }))
         staging = { "services" => [{ "name" => "showcase-ag2", "service_id" => "ag2-stg" }] }
         prod    = { "services" => [{ "name" => "showcase-ag2", "service_id" => "ag2-prod" }] }
         findings = c.check_service_refs(staging, prod)
         assert_empty findings.select { |f| f.start_with?("REFUSE") },
-                     "prod->prod aimock ref must not REFUSE, got #{findings.inspect}"
+                     "prod private aimock ref must not REFUSE, got #{findings.inspect}"
+    end
+
+    def test_ssot_target_host_prefers_internal_over_public
+        # Direct unit assertion on the resolver: aimock declares BOTH a public
+        # `domains` host and a private `internalDomains` host; the resolver must
+        # return the PRIVATE one for both envs so serviceRefs assert against the
+        # free path. A non-aimock target with no internalDomains falls back to
+        # its public host (unchanged behaviour).
+        c = cmd
+        assert_equal "showcase-aimock.railway.internal",
+                     c.ssot_target_host("aimock", "prod"),
+                     "aimock prod host must resolve to the private internal domain"
+        assert_equal "showcase-aimock.railway.internal",
+                     c.ssot_target_host("aimock", "staging"),
+                     "aimock staging host must resolve to the private internal domain"
+        # A target that declares no internalDomains keeps its public host.
+        refute_nil c.ssot_target_host("showcase-ag2", "prod"),
+                   "non-aimock target must still resolve to its public host"
+        refute_includes c.ssot_target_host("showcase-ag2", "prod").to_s,
+                        "railway.internal",
+                        "non-aimock target must NOT resolve to an internal host"
     end
 
     # ── §5.3.1 replicate-class env-write (NEW capability) ───────────────────

--- a/showcase/harness/config/alerts/aimock-wiring-drift.yml
+++ b/showcase/harness/config/alerts/aimock-wiring-drift.yml
@@ -40,7 +40,7 @@ template:
     {{#trigger.set_drifted}}:warning: *aimock wiring drift — {{signal.unwiredCount}} {{signal.unwiredNoun}} bypassing showcase-aimock:*
     {{#signal.unwired}}• `{{.}}`
     {{/signal.unwired}}
-    Fix: set `OPENAI_BASE_URL` (or `ANTHROPIC_BASE_URL` for claude-sdk) on each service to the aimock production URL.
+    Fix: set `OPENAI_BASE_URL` (or `ANTHROPIC_BASE_URL` for claude-sdk, `GOOGLE_GEMINI_BASE_URL` for google-adk) on each service to the aimock PRIVATE networking URL `http://showcase-aimock.railway.internal:4010` (append `/v1` for `OPENAI_BASE_URL`) — free intra-env networking, NOT the billed public `*.up.railway.app` host.
     <{{{env.dashboardUrl}}}|Dashboard>{{#event.runUrl}} | <{{{event.runUrl}}}|Run>{{/event.runUrl}}{{/trigger.set_drifted}}
     {{#trigger.set_errored}}:rotating_light: *aimock wiring probe errored — {{signal.erroredCount}} service(s) unreadable:*
     {{#signal.erroredPreview}}• `{{.}}`

--- a/showcase/harness/src/probes/aimock-wiring.test.ts
+++ b/showcase/harness/src/probes/aimock-wiring.test.ts
@@ -304,6 +304,67 @@ describe("aimock-wiring probe", () => {
     expect(r2.signal.wiredCount).toBe(1);
   });
 
+  it("matches the PRIVATE Railway networking host (egress fix): internal aimockUrl vs :4010/v1 base URLs go green", async () => {
+    // Egress fix: demo backends route LLM traffic at aimock over free private
+    // networking (http://showcase-aimock.railway.internal:4010) instead of the
+    // billed public *.up.railway.app host. The probe matches on HOSTNAME only,
+    // so the harness AIMOCK_URL (bare internal origin) and the demo backends'
+    // OPENAI_BASE_URL (internal host + :4010 port + /v1 suffix) resolve to the
+    // same hostname `showcase-aimock.railway.internal` and the probe stays
+    // green. Locks in that the private-host migration keeps wiring green.
+    const INTERNAL_AIMOCK = "http://showcase-aimock.railway.internal:4010";
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: INTERNAL_AIMOCK,
+        listServices: async () => [
+          { name: "showcase-ag2" },
+          { name: "showcase-claude-sdk-python" },
+          { name: "showcase-google-adk" },
+        ],
+        getServiceEnv: async (name) => {
+          if (name === "showcase-ag2")
+            return {
+              OPENAI_BASE_URL:
+                "http://showcase-aimock.railway.internal:4010/v1",
+            };
+          if (name === "showcase-claude-sdk-python")
+            return {
+              ANTHROPIC_BASE_URL: "http://showcase-aimock.railway.internal:4010",
+            };
+          return {
+            GOOGLE_GEMINI_BASE_URL:
+              "http://showcase-aimock.railway.internal:4010",
+          };
+        },
+      },
+      ctx,
+    );
+    expect(r.state).toBe("green");
+    expect(r.signal.unwired).toEqual([]);
+    expect(r.signal.wiredCount).toBe(3);
+    expect(r.signal.erroredCount).toBe(0);
+  });
+
+  it("flags a demo still on the PUBLIC aimock host when the harness is on the PRIVATE host (egress drift)", async () => {
+    // With the harness AIMOCK_URL migrated to the private host, a demo backend
+    // still pointing at the public *.up.railway.app aimock host is egress
+    // drift — different hostname → unwired → red. This is the signal that a
+    // backend missed the private-networking flip.
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: "http://showcase-aimock.railway.internal:4010",
+        listServices: async () => [{ name: "showcase-ag2" }],
+        getServiceEnv: async () => ({
+          OPENAI_BASE_URL:
+            "https://showcase-aimock-production.up.railway.app/v1",
+        }),
+      },
+      ctx,
+    );
+    expect(r.state).toBe("red");
+    expect(r.signal.unwired).toEqual(["showcase-ag2"]);
+  });
+
   it("isolates per-service env-fetch failures to the errored bucket", async () => {
     const r = await aimockWiringProbe.run(
       {

--- a/showcase/harness/src/probes/aimock-wiring.test.ts
+++ b/showcase/harness/src/probes/aimock-wiring.test.ts
@@ -329,7 +329,8 @@ describe("aimock-wiring probe", () => {
             };
           if (name === "showcase-claude-sdk-python")
             return {
-              ANTHROPIC_BASE_URL: "http://showcase-aimock.railway.internal:4010",
+              ANTHROPIC_BASE_URL:
+                "http://showcase-aimock.railway.internal:4010",
             };
           return {
             GOOGLE_GEMINI_BASE_URL:

--- a/showcase/scripts/emit-railway-envs-json.ts
+++ b/showcase/scripts/emit-railway-envs-json.ts
@@ -178,7 +178,9 @@ function projectServiceToLegacyJson(
   const internalDomains =
     prodInternal !== undefined || stagingInternal !== undefined
       ? {
-          ...(stagingInternal !== undefined ? { staging: stagingInternal } : {}),
+          ...(stagingInternal !== undefined
+            ? { staging: stagingInternal }
+            : {}),
           ...(prodInternal !== undefined ? { prod: prodInternal } : {}),
         }
       : undefined;

--- a/showcase/scripts/emit-railway-envs-json.ts
+++ b/showcase/scripts/emit-railway-envs-json.ts
@@ -69,6 +69,14 @@ interface Emitted {
     dispatchName?: string;
     repoNameOverride?: { prod?: string; staging?: string };
     domains: { staging: string; prod: string };
+    // Env-scoped PRIVATE Railway networking hosts (`*.railway.internal`).
+    // Emitted ONLY for services that declare an `internalDomain` in the SSOT
+    // (today: aimock). The Ruby serviceRef assertion (`ssot_target_host`)
+    // PREFERS this over the public `domains` host so demo backends route LLM
+    // traffic over free intra-env networking instead of billed public egress.
+    // Omitted (whole object absent) when neither env declares one — the frozen
+    // per-service shape is preserved for every other service.
+    internalDomains?: { staging?: string; prod?: string };
     probe: { staging: boolean; prod: boolean; driver: string };
     // --- Promote-closure fields (ADDITIVE, U2). Appended AFTER the frozen
     // legacy keys above so the Ruby/jq legacy shape stays byte-identical. ---
@@ -161,6 +169,20 @@ function projectServiceToLegacyJson(
   const prodDomain = prodEnv?.domain ?? compatDomains?.prod ?? "";
   const stagingDomain = stagingEnv?.domain ?? compatDomains?.staging ?? "";
 
+  // Private env-scoped networking hosts. Additive: emitted only when at least
+  // one env declares an `internalDomain` (today: aimock), and each env key is
+  // conditionally spread so a single-env internal host stays minimal. Every
+  // other service omits the whole object, preserving its frozen shape.
+  const prodInternal = prodEnv?.internalDomain;
+  const stagingInternal = stagingEnv?.internalDomain;
+  const internalDomains =
+    prodInternal !== undefined || stagingInternal !== undefined
+      ? {
+          ...(stagingInternal !== undefined ? { staging: stagingInternal } : {}),
+          ...(prodInternal !== undefined ? { prod: prodInternal } : {}),
+        }
+      : undefined;
+
   // Per-env healthcheckPath: mirror the per-env-flat ({prod, staging}) legacy
   // shape used by domains/repoNameOverride. Each env key is conditionally
   // spread (omitted when the EnvironmentConfig omits it), and the whole object
@@ -192,6 +214,11 @@ function projectServiceToLegacyJson(
     dispatchName: entry.dispatchName,
     repoNameOverride,
     domains: { staging: stagingDomain, prod: prodDomain },
+    // Private networking hosts, appended AFTER `domains` (additive). Emitted
+    // only when the SSOT declares an `internalDomain`; omitted otherwise so
+    // every non-aimock service keeps its frozen shape and the golden test
+    // (which projects only LEGACY_KEYS) is unaffected.
+    ...(internalDomains !== undefined ? { internalDomains } : {}),
     probe: {
       staging: stagingEnv ? (stagingEnv.probe ?? true) : false,
       prod: prodEnv ? (prodEnv.probe ?? true) : false,

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -21,6 +21,10 @@
         "staging": "aimock-staging.up.railway.app",
         "prod": "showcase-aimock-production.up.railway.app"
       },
+      "internalDomains": {
+        "staging": "showcase-aimock.railway.internal",
+        "prod": "showcase-aimock.railway.internal"
+      },
       "probe": {
         "staging": true,
         "prod": true,

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -274,6 +274,20 @@ export interface EnvironmentConfig {
   instanceId: string;
   /** Public host (no scheme). Omitted for domainless workers. */
   domain?: string;
+  /**
+   * Env-scoped PRIVATE Railway networking host (no scheme), e.g.
+   * `showcase-aimock.railway.internal`. Railway bills traffic to the public
+   * `*.up.railway.app` `domain` as egress even intra-project, but private
+   * `*.railway.internal` networking is FREE and env-scoped (staging resolves
+   * to the staging instance, prod to prod). When present, cross-service
+   * serviceRefs resolve to THIS host (via `ssot_target_host` preferring it)
+   * so the ~20 demo backends reach aimock over free private networking
+   * instead of billed public egress. The public `domain` is KEPT for health
+   * probes / external reachability. Same private DNS name in BOTH envs —
+   * env-scoping (not the name) provides the staging/prod isolation.
+   * OPTIONAL; omitted ⇒ serviceRefs fall back to the public `domain`.
+   */
+  internalDomain?: string;
   /** Probe this env in verify-deploy? Defaults to true when omitted. */
   probe?: boolean;
   /** Per-env GHCR repo-name override. Defaults to the service name. */
@@ -519,6 +533,11 @@ export const SERVICES: Record<
         instanceId: "5801d8be-5ad9-4eff-9c9c-7be61d9a023e",
         healthcheckPath: "/health",
         domain: "showcase-aimock-production.up.railway.app",
+        // Private env-scoped host the ~20 demo backends route LLM traffic
+        // at (FREE intra-env networking; the public `domain` above is
+        // billed egress and kept only for health probes). aimock binds
+        // 0.0.0.0:4010; serviceRefs resolve to `http://<this>:4010`.
+        internalDomain: "showcase-aimock.railway.internal",
         probe: true,
         repoName: "showcase-aimock",
       },
@@ -526,6 +545,10 @@ export const SERVICES: Record<
         instanceId: "9f260dfd-d9d4-43e9-98fe-49696f87fe50",
         healthcheckPath: "/health",
         domain: "aimock-staging.up.railway.app",
+        // Same private DNS name as prod — Railway env-scopes the resolution
+        // (staging → staging aimock instance), so demo backends stay
+        // env-local without a per-env host string.
+        internalDomain: "showcase-aimock.railway.internal",
         probe: true,
         repoName: "showcase-aimock",
       },


### PR DESCRIPTION
## Summary

Routes the ~20 showcase demo backends to **aimock** (the record/replay LLM proxy) over Railway **private networking** (`*.railway.internal`) instead of aimock's **public** `*.up.railway.app` host.

Railway bills traffic to a public domain as **egress even intra-project**, while `*.railway.internal` private networking is **free** and **env-scoped**. The 240-concurrent-browser harness fleet drives every demo continuously, so every LLM SSE stream from aimock back to a demo backend is currently billed egress.

- aimock ≈ **89% of showcase egress**, ≈ **92% of the 13TB→78TB/mo increase**.
- Estimated impact: avoids the ≈ **$602/mo → $3,856/mo** growth on the aimock path.

## Change (config-only, reversible; SSOT-driven)

1. **SSOT** (`showcase/scripts/railway-envs.ts`): add an env-scoped `internalDomain: "showcase-aimock.railway.internal"` to the aimock entry in **both** envs. The public `domain` is **kept** (health probes / external reachability).
2. **Emitter** (`showcase/scripts/emit-railway-envs-json.ts`): emit `internalDomains` (additive, after `domains`) into the generated JSON. Every non-aimock service keeps its frozen shape.
3. **Generated JSON** regenerated (oxfmt-canonical; 4-line additive diff, only the aimock entry).
4. **Promote preflight** (`showcase/bin/railway`): `ssot_target_host` now **prefers** the private `internalDomains[env]` over the public `domains[env]`, so the Stage-2 (U5) serviceRef assertion requires demo backends' `OPENAI_BASE_URL`/etc. to point at the private host. Non-aimock targets (no `internalDomains`) fall back to their public host unchanged.
5. **Harness** wiring probe needs **no code change** (it matches on hostname); added a discriminating test pair + updated the drift-alert Fix text to the private host.

**Target:** aimock binds `0.0.0.0:4010` (per `showcase/aimock/RAILWAY.md`); demo backends resolve to `http://showcase-aimock.railway.internal:4010`.

Deployed env vars, both envs (before → after):

| key | before (public, billed egress) | after (private, free) |
|---|---|---|
| `OPENAI_BASE_URL` | `https://<aimock>.up.railway.app/v1` | `http://showcase-aimock.railway.internal:4010/v1` |
| `ANTHROPIC_BASE_URL` | `https://<aimock>.up.railway.app` | `http://showcase-aimock.railway.internal:4010` |
| `GOOGLE_GEMINI_BASE_URL` | `https://<aimock>.up.railway.app` | `http://showcase-aimock.railway.internal:4010` |
| `AIMOCK_URL` | `https://<aimock>.up.railway.app` | `http://showcase-aimock.railway.internal:4010` |

`<aimock>` = `aimock-staging` (staging) / `showcase-aimock-production` (prod). `railway.internal` is env-scoped, so staging demos reach the staging aimock and prod demos reach prod aimock automatically — the same private DNS name in both envs.

---

## Red-green proof (verbatim)

### RED — live staging today (billed public egress)

Deployed `showcase-langgraph-fastapi` (staging, service `06cccb5c-…`) via Railway `variables(...)` GraphQL:

```
OPENAI_BASE_URL        = https://aimock-staging.up.railway.app/v1
ANTHROPIC_BASE_URL     = https://aimock-staging.up.railway.app
GOOGLE_GEMINI_BASE_URL = https://aimock-staging.up.railway.app
AIMOCK_URL             = https://aimock-staging.up.railway.app
```

Pre-fix generated JSON aimock entry — **no** `internalDomains`:

```json
{ "domains": { "staging": "aimock-staging.up.railway.app",
               "prod": "showcase-aimock-production.up.railway.app" },
  "internalDomains": "ABSENT" }
```

### RED — Ruby U5 serviceref resolver, with the resolver reverted to public-only

The three new U5 tests FAIL when `ssot_target_host` returns the public host:

```
7 runs, 15 assertions, 3 failures
1) test_serviceref_prod_pointing_at_public_aimock_host_refuses:
   expected REFUSE for prod serviceRef on the public egress host, got []
2) test_serviceref_prod_pointing_at_private_aimock_passes:
   prod private aimock ref must not REFUSE, got ["REFUSE: §5.2 (showcase-ag2): prod
   OPENAI_BASE_URL="http://showcase-aimock.railway.internal:4010/v1" does NOT point at
   aimock's env-LOCAL prod host "showcase-aimock-production.up.railway.app" ..."]
3) test_ssot_target_host_prefers_internal_over_public:
   expected "showcase-aimock.railway.internal",
   actual "showcase-aimock-production.up.railway.app"
```

### GREEN — after the fix

Post-fix generated JSON aimock entry:

```json
{ "domains": { "staging": "aimock-staging.up.railway.app",
               "prod": "showcase-aimock-production.up.railway.app" },
  "internalDomains": { "staging": "showcase-aimock.railway.internal",
                       "prod": "showcase-aimock.railway.internal" } }
```

Ruby U5 serviceref tests (fixed resolver — prefers `internalDomains`):

```
7 runs, 20 assertions, 0 failures, 0 errors, 0 skips
```

Full Ruby spec suite:

```
184 runs, 715 assertions, 0 failures, 0 errors, 0 skips
```

Harness aimock-wiring probe (hostname-match; internal host with `:4010` + `/v1` → green, demo still on public host while harness on private → red):

```
src/probes/aimock-wiring.test.ts        29 passed  (was 27; +2 new: internal-host green, public-host drift red)
src/probes/drivers/aimock-wiring.test.ts 16 passed
src/rules/rule-loader.test.ts           61 passed  (aimock-wiring-drift.yml parses after Fix-text update)
renderer + render-red-tick + orchestrator 157 passed  (no alert-text snapshot broke)
```

Scripts test suite (emitter golden + everything): `2147 passed, 7 skipped` (one pre-existing `/tmp` lockfile flake in `integration-smoke-registry.test.ts`, green on rerun after clearing the stale lock). `emit --check` idempotent + oxfmt-canonical. Harness `tsc --noEmit`: clean.

### GREEN — live infra confirmation

- aimock **staging** deployment status = `SUCCESS` (running), binds `0.0.0.0:4010` — so `showcase-aimock.railway.internal:4010` resolves to a live listener for any peer in the staging env.
- aimock serving LLM-shaped responses on `:4010`: `GET /health` → `200`; `GET /v1/models` → `200` `{gpt-4o, gpt-4o-mini}`.

## What was vs wasn't live-validated

**Validated live:** the RED (deployed staging vars still on the public egress host); aimock staging is deployed/running and serving on `:4010`; the full unit/wiring/promote-preflight test surface passes with the new internal-host values.

**NOT live-validated in-session:** the in-Railway-network DNS resolution of `showcase-aimock.railway.internal:4010` from a peer service, and a full staging deploy that flips the four keys + redeploys a demo backend. Reason: the in-network vantage needs `railway ssh` (requires registering a persistent account SSH key — a stateful, human-gated change I declined to make unsupervised) or a staging deploy (the local Railway access token was expired; the CLI refreshed it for read/GraphQL but a deploy is a separate gated action). Railway private networking (`*.railway.internal`) is a standard platform feature; the local `docker-compose.local.yml` already runs the identical `http://aimock:4010` internal-host pattern, and the wiring probe's hostname match is exercised by the new tests. The staging deploy + in-network curl is the first step of the rollout plan below and must be run before prod.

## Irreducible egress remains

This does **not** zero showcase egress. Still billed: real browse users hitting the public demo/shell domains; and aimock in **record mode** proxying to real providers (the outbound prompt to OpenAI/Anthropic/Google still bills).

## Rollout plan (reversible config change, staging-first, user-gated)

1. Land this branch (SSOT + generated JSON + assertions).
2. **Staging first:** set the four keys on staging demo backends + `AIMOCK_URL` on the harness to `http://showcase-aimock.railway.internal:4010` (`/v1` on `OPENAI_BASE_URL`); redeploy one demo backend + aimock; from inside a staging service curl `http://showcase-aimock.railway.internal:4010/health` (expect 200) and run a real demo LLM turn / aimock-wiring probe (expect green); confirm the aimock egress path stops accruing (`usage(measurements:[NETWORK_TX_GB])`).
3. **User-gated** promote to prod (staging→prod), same key flip.
4. **Rollback** = flip the keys back to the public host (no code revert needed).

## Follow-ups (out of scope — do NOT bundle)

- Fleet right-sizing (240-concurrent-browser harness).
- `OPENAI_API_KEY` consolidation.

---

Draft — do not merge. Do not deploy to prod.
