### PR TITLE
fix(showcase): consolidate upstream provider keys to Railway shared vars (credential hygiene)

### DIFF
--- a/showcase/aimock/RAILWAY.md
+++ b/showcase/aimock/RAILWAY.md
@@ -208,6 +208,47 @@ None are required for the default configuration. Notes:
   network.
 - `PORT` is injected by Railway but not read by the current startCommand
   (port is hardcoded to `4010`). Harmless.
+- **No provider API keys.** aimock holds NO `OPENAI_API_KEY` /
+  `ANTHROPIC_API_KEY` / `GOOGLE_API_KEY`. On the proxy-fallthrough path it does
+  NOT authenticate with its own key — it **forwards the client-supplied
+  `Authorization` / `x-api-key` header verbatim** to the real provider (see
+  §6.1). The real key therefore lives on the CLIENT services, not here.
+
+### 6.1 Upstream auth model + provider-key credential hygiene
+
+aimock cannot own upstream provider auth. In `@copilotkit/aimock`, the
+proxy-fallthrough recorder copies every non-hop-by-hop client header straight
+to the upstream provider; the header strip-list does NOT include
+`authorization` / `x-api-key`, and there is no CLI flag or env var to inject an
+aimock-owned provider key (`--provider-openai/anthropic/gemini` set upstream
+**URLs** only). So a fixture-miss request reaches the real provider using
+**whatever key the calling service sent**.
+
+Because every showcase agent/starter (and the `shell`/`docs`/`dashboard`
+frontends) routes provider traffic through aimock, each one must carry a
+provider key for those fallthrough requests. To avoid duplicating the SAME real
+secret across ~34 services (one scraped env = the real key; rotation = ~34
+edits), each provider key is defined **once** as a Railway
+**environment-level SHARED variable** and referenced from the services that
+need it:
+
+- Create `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY` as
+  environment-shared variables in each env (staging + prod), sourced from
+  1Password — never committed to this repo.
+- Each consuming service references `${{shared.<NAME>}}` instead of holding its
+  own literal copy. The SSOT (`showcase/scripts/railway-envs.ts`) models this
+  per-service via the additive `sharedRefs` field (the provider-key NAMES a
+  service resolves from the shared variable), and the Ruby promote preflight
+  asserts each listed key resolves to the shared variable rather than a
+  distinct per-service literal.
+
+Net: the real secret lives in ONE place per env, rotation is a single edit, and
+a scraped service env yields only a `${{shared.*}}` reference token. `aimock`
+itself declares no `sharedRefs` — it holds no provider key at all.
+
+> **Rotation.** Rotate the real key in the provider dashboard (e.g. the OpenAI
+> account), store the new value in 1Password, and update the single
+> environment-shared variable. Never commit a provider key to this repo.
 
 ## 7. How to reconstruct
 

--- a/showcase/scripts/emit-railway-envs-json.ts
+++ b/showcase/scripts/emit-railway-envs-json.ts
@@ -105,6 +105,14 @@ interface Emitted {
       prod: WorkerProvisioning;
       staging: WorkerProvisioning;
     };
+    // Upstream provider-key env-var NAMES this service sources from a Railway
+    // environment-shared variable (${{shared.<NAME>}}) rather than holding its
+    // own copy of the real secret (the credential-hygiene single-source model).
+    // The Ruby preflight asserts each listed key resolves to the shared
+    // variable, never a distinct per-service literal. Appended LAST (additive)
+    // and OMITTED when the SSOT entry declares none, so services that source no
+    // shared provider key (e.g. aimock) keep the frozen shape.
+    sharedRefs?: string[];
   }>;
   // --- Top-level promote-closure plan (ADDITIVE, U2). The tier-ordered
   // closure for the FULL fleet (`all`), computed via `computePromoteClosure`.
@@ -223,6 +231,13 @@ function projectServiceToLegacyJson(
     ...(entry.workerProvisioning !== undefined
       ? { workerProvisioning: entry.workerProvisioning }
       : {}),
+    // Shared provider-key references (ADDITIVE, credential-hygiene model).
+    // Emitted only when the SSOT declares `sharedRefs`, so services that hold
+    // no shared provider key (aimock, harness, pocketbase, …) keep the frozen
+    // per-service shape. Read by the Ruby preflight to assert each listed key
+    // resolves to the Railway environment-shared variable, never a distinct
+    // per-service literal.
+    ...(entry.sharedRefs !== undefined ? { sharedRefs: entry.sharedRefs } : {}),
   };
 }
 

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -54,7 +54,8 @@
         "driver": "dashboard"
       },
       "promoteTier": 1,
-      "runtimeDeps": ["pocketbase", "harness"]
+      "runtimeDeps": ["pocketbase", "harness"],
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]
     },
     {
       "name": "docs",
@@ -78,7 +79,8 @@
         "driver": "docs"
       },
       "promoteTier": 2,
-      "standalone": true
+      "standalone": true,
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "dojo",
@@ -222,7 +224,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "showcase-ag2",
@@ -252,7 +255,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]
     },
     {
       "name": "showcase-agno",
@@ -282,7 +286,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "showcase-built-in-agent",
@@ -312,7 +317,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "showcase-claude-sdk-python",
@@ -342,7 +348,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]
     },
     {
       "name": "showcase-claude-sdk-typescript",
@@ -372,7 +379,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]
     },
     {
       "name": "showcase-crewai-crews",
@@ -402,7 +410,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "showcase-google-adk",
@@ -432,7 +441,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "showcase-langgraph-fastapi",
@@ -462,7 +472,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "showcase-langgraph-python",
@@ -492,7 +503,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "showcase-langgraph-typescript",
@@ -522,7 +534,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "showcase-langroid",
@@ -552,7 +565,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]
     },
     {
       "name": "showcase-llamaindex",
@@ -582,7 +596,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "showcase-mastra",
@@ -612,7 +627,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "showcase-ms-agent-dotnet",
@@ -642,7 +658,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "showcase-ms-agent-harness-dotnet",
@@ -672,7 +689,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "showcase-ms-agent-python",
@@ -702,7 +720,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "showcase-pydantic-ai",
@@ -732,7 +751,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "showcase-spring-ai",
@@ -762,7 +782,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]
     },
     {
       "name": "showcase-strands",
@@ -792,7 +813,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "showcase-strands-typescript",
@@ -822,7 +844,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY"]
     },
     {
       "name": "starter-adk",
@@ -852,7 +875,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "starter-agno",
@@ -882,7 +906,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "starter-crewai-crews",
@@ -912,7 +937,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "starter-langgraph-fastapi",
@@ -942,7 +968,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "starter-langgraph-js",
@@ -972,7 +999,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "starter-langgraph-python",
@@ -1002,7 +1030,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "starter-llamaindex",
@@ -1032,7 +1061,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "starter-mastra",
@@ -1062,7 +1092,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "starter-ms-agent-framework-dotnet",
@@ -1092,7 +1123,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "starter-ms-agent-framework-python",
@@ -1122,7 +1154,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "starter-pydantic-ai",
@@ -1152,7 +1185,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "starter-strands-python",
@@ -1182,7 +1216,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "sharedRefs": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"]
     },
     {
       "name": "webhooks",

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -7,6 +7,7 @@ import {
   ENV_ID_BY_NAME,
   PRODUCTION_ENV_ID,
   PROJECT_ID,
+  PROVIDER_KEY_SHARED_VARS,
   SERVICES,
   STAGING_ENV_ID,
   assertClosureValid,
@@ -14,6 +15,8 @@ import {
   assertEnvRegistryConsistent,
   assertImageConsumersValid,
   assertServiceAndInstanceIdsUnique,
+  assertSharedRefsValid,
+  sharedRefsFor,
   computePromoteClosure,
   domainFor,
   envsFor,
@@ -1365,5 +1368,67 @@ describe("assertClosureValid", () => {
     expect(() => assertClosureValid(["harness"], allProdless)).toThrow(
       /empty|promote nothing/i,
     );
+  });
+});
+
+describe("sharedRefs — upstream provider-key single-source model", () => {
+  // Every showcase service that routes LLM traffic at aimock (agents,
+  // starters, and the shell/docs/dashboard frontends) MUST declare its
+  // provider keys as shared references, NOT hold its own copy of the real
+  // secret. A service that declares a runtime dep on aimock is exactly the
+  // set that sends provider-keyed requests through the proxy.
+  const AGENT_LIKE = Object.entries(SERVICES).filter(([, e]) =>
+    (e.runtimeDeps ?? []).includes("aimock"),
+  );
+
+  it("has agent/starter services that route through aimock", () => {
+    // Guard the guard: if this ever hits zero, the assertions below become
+    // vacuous, so fail loud instead.
+    expect(AGENT_LIKE.length).toBeGreaterThan(20);
+  });
+
+  it("every aimock-routed service declares OPENAI_API_KEY as a shared ref", () => {
+    const offenders = AGENT_LIKE.filter(
+      ([name]) => !sharedRefsFor(name).includes("OPENAI_API_KEY"),
+    ).map(([name]) => name);
+    expect(offenders).toEqual([]);
+  });
+
+  it("aimock itself declares NO sharedRefs (it holds no provider key)", () => {
+    expect(sharedRefsFor("aimock")).toEqual([]);
+  });
+
+  it("every sharedRefs entry is a recognized provider-key var", () => {
+    const bad: string[] = [];
+    for (const name of Object.keys(SERVICES)) {
+      for (const ref of sharedRefsFor(name)) {
+        if (!PROVIDER_KEY_SHARED_VARS.has(ref)) bad.push(`${name}:${ref}`);
+      }
+    }
+    expect(bad).toEqual([]);
+  });
+
+  it("sharedRefsFor returns a sorted copy and throws on unknown service", () => {
+    const refs = sharedRefsFor("showcase-langgraph-python");
+    expect(refs).toEqual([...refs].sort());
+    expect(() => sharedRefsFor("no-such-service")).toThrow(/Unknown/i);
+  });
+
+  it("the production SSOT passes assertSharedRefsValid", () => {
+    expect(() => assertSharedRefsValid()).not.toThrow();
+  });
+
+  it("throws on an unrecognized sharedRefs var name", () => {
+    const synthetic = { svc: { sharedRefs: ["OPENAPI_API_KEY"] } };
+    expect(() => assertSharedRefsValid(synthetic)).toThrow(
+      /not a recognized provider-key var/i,
+    );
+  });
+
+  it("throws on a duplicate sharedRefs var within a service", () => {
+    const synthetic = {
+      svc: { sharedRefs: ["OPENAI_API_KEY", "OPENAI_API_KEY"] },
+    };
+    expect(() => assertSharedRefsValid(synthetic)).toThrow(/duplicate/i);
   });
 });

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -413,6 +413,36 @@ export interface ServiceEntry {
    */
   serviceRefs?: { key: string; target: string }[];
   /**
+   * UPSTREAM PROVIDER-KEY references sourced from a Railway ENVIRONMENT-LEVEL
+   * SHARED variable — the env-var NAMES (e.g. `OPENAI_API_KEY`,
+   * `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`) this service resolves via
+   * `${{shared.<NAME>}}` instead of holding its own per-service copy of the
+   * real secret.
+   *
+   * WHY THIS EXISTS. Every showcase agent/starter (and the shell/docs/dashboard
+   * frontends) points its provider BASE URLs at the env-local aimock
+   * record/replay proxy, but on a fixture-miss aimock proxies the request to
+   * the REAL provider and FORWARDS THE CLIENT-SUPPLIED `Authorization` /
+   * `x-api-key` header verbatim (see `@copilotkit/aimock` recorder — the proxy
+   * strips hop-by-hop headers but NOT the auth header, and has no CLI flag or
+   * env var to inject its own provider key). aimock therefore cannot own
+   * upstream auth; the real key must live on the CLIENT. To avoid duplicating
+   * the SAME real secret across ~34 services (one scraped demo env = the real
+   * key; rotation = ~34 edits), each provider key is defined ONCE as a Railway
+   * environment-shared variable and referenced here. Net: real secret in ONE
+   * place per env, one-edit rotation, a scraped service env yields only a
+   * `${{shared.*}}` reference token.
+   *
+   * This field MODELS the arrangement so it is machine-checkable (the Ruby
+   * preflight asserts each listed key resolves to the shared variable, never a
+   * distinct per-service literal). Each name must be a recognized provider-key
+   * env var and unique within the array (enforced at module load by
+   * `assertSharedRefsValid`). OPTIONAL; omitted = this service sources no
+   * provider key from a shared variable (e.g. `aimock` itself, which holds no
+   * provider key at all). The values live ONLY in Railway — NEVER in this repo.
+   */
+  sharedRefs?: string[];
+  /**
    * Ruby/jq-BOUNDARY COMPATIBILITY SHIM — read ONLY by
    * `emit-railway-envs-json.ts`, never by any TS accessor.
    *
@@ -545,6 +575,7 @@ export const SERVICES: Record<
     // Railway service name is `dashboard`; GHCR repo is
     // `showcase-shell-dashboard`. Same override for both envs:
     // staging :latest, prod @sha256 — uniform across all services.
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"],
     environments: {
       prod: {
         instanceId: "e68f98fa-b2ef-41cc-82f6-2ed6f9533bf3",
@@ -573,6 +604,7 @@ export const SERVICES: Record<
     // env-divergence WARN-refusal must not block docs).
     standalone: true,
     // Railway service name is `docs`; GHCR repo is `showcase-shell-docs`.
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "b15564fc-f832-49b3-82df-fd36f298fe96",
@@ -803,6 +835,7 @@ export const SERVICES: Record<
     dispatchName: "shell",
     probeDriver: "shell",
     // Railway service name is `shell`; GHCR repo is `showcase-shell`.
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "01614ccf-e109-4b30-b41b-7c5551c0a34c",
@@ -832,6 +865,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"],
     environments: {
       prod: {
         instanceId: "de571c97-03fd-486b-8a54-9767a4a53f95",
@@ -859,6 +893,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "026d12fb-2844-42af-8f92-b47bc8a06bc8",
@@ -886,6 +921,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "40018ef7-1ed1-4979-b80c-9c2d957b6d88",
@@ -913,6 +949,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"],
     environments: {
       prod: {
         instanceId: "bb18caaf-9a3e-4fdd-85ec-562fd82a3a89",
@@ -940,6 +977,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"],
     environments: {
       prod: {
         instanceId: "bee425e4-9661-4a88-8888-922b8cd4b61d",
@@ -967,6 +1005,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "3dab0cc3-cab1-4579-b772-947268088514",
@@ -994,6 +1033,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "7b2da5db-87d2-40ad-a3d9-b2d7a5485a22",
@@ -1021,6 +1061,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "105b7e01-acd0-48e2-9a09-541e2103e8d2",
@@ -1048,6 +1089,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "aec504f7-63d7-4ea6-9d50-601b00d2ae80",
@@ -1075,6 +1117,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "f53e9fdc-7c3e-4dfd-9fa8-d7241fd55bb8",
@@ -1102,6 +1145,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"],
     environments: {
       prod: {
         instanceId: "6b5e20b5-8f8e-4ec3-9288-7a41122e42e5",
@@ -1129,6 +1173,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "b778856e-9f90-4136-9415-fb2b41173f8d",
@@ -1156,6 +1201,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "eaeddd9c-8b75-426f-b033-0fd935cbf6ef",
@@ -1183,6 +1229,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "93ca0edf-7b59-4de4-b1fd-3412bb07bc6a",
@@ -1210,6 +1257,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "8f91ebc6-95c0-4433-b1f7-657ff49c2d59",
@@ -1237,6 +1285,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "323ed911-4d28-45ab-8fc0-7d151828b938",
@@ -1264,6 +1313,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "192cd647-6824-4f01-937a-1da675d83805",
@@ -1291,6 +1341,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"],
     environments: {
       prod: {
         instanceId: "2fbf1db2-5e51-44c9-983c-3f2242d95c61",
@@ -1318,6 +1369,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "2123c71b-9385-443c-a1c3-bcf4b1669eeb",
@@ -1351,6 +1403,7 @@ export const SERVICES: Record<
     // by the Stage-2 Ruby preflight (never copied).
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY"],
     environments: {
       prod: {
         instanceId: "8a50728e-6119-43c4-b59c-d9535b6717a4",
@@ -1422,6 +1475,7 @@ export const SERVICES: Record<
     promoteTier: 2,
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "cb23cae4-9555-4ddd-8a62-f1aa1ff72c67",
@@ -1446,6 +1500,7 @@ export const SERVICES: Record<
     promoteTier: 2,
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "2f58513b-5fe4-4b09-a28f-93d4caa277b5",
@@ -1470,6 +1525,7 @@ export const SERVICES: Record<
     promoteTier: 2,
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "1a3e24cb-0752-45c8-b4a2-0c6096899875",
@@ -1494,6 +1550,7 @@ export const SERVICES: Record<
     promoteTier: 2,
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "0679bc18-e9af-40c6-bc17-0b5eb2cd7bec",
@@ -1518,6 +1575,7 @@ export const SERVICES: Record<
     promoteTier: 2,
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "50a2205b-8768-4765-b7a1-21941c105051",
@@ -1542,6 +1600,7 @@ export const SERVICES: Record<
     promoteTier: 2,
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "24dad599-576a-4154-a621-c3af40629a8f",
@@ -1566,6 +1625,7 @@ export const SERVICES: Record<
     promoteTier: 2,
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "c119f40b-dc71-4734-9716-c1085754b085",
@@ -1590,6 +1650,7 @@ export const SERVICES: Record<
     promoteTier: 2,
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "c6fba6d8-8dde-442b-948f-560bf25fa2f1",
@@ -1614,6 +1675,7 @@ export const SERVICES: Record<
     promoteTier: 2,
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "993237a4-9ee7-47b2-a5be-267e247c1409",
@@ -1638,6 +1700,7 @@ export const SERVICES: Record<
     promoteTier: 2,
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "aa934881-340a-4fb7-8b39-9cb0a6f372b2",
@@ -1662,6 +1725,7 @@ export const SERVICES: Record<
     promoteTier: 2,
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "74ce36fe-0b8f-446e-8e06-0b6496b6e829",
@@ -1686,6 +1750,7 @@ export const SERVICES: Record<
     promoteTier: 2,
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    sharedRefs: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
     environments: {
       prod: {
         instanceId: "4af440e0-ba05-48a5-b922-5b96a033891a",
@@ -2558,12 +2623,83 @@ export function assertServiceAndInstanceIdsUnique(
   }
 }
 
+/**
+ * The recognized upstream provider-key env-var names a service may source
+ * from a Railway environment-shared variable via `sharedRefs`. Kept as a
+ * closed allow-list so a typo (`OPENAPI_API_KEY`) or a non-secret config var
+ * cannot slip into `sharedRefs` and silently defeat the single-source
+ * assertion. `GOOGLE_API_KEY` is the name the showcase Gemini integrations
+ * actually use (NOT `GEMINI_API_KEY`, which appears on no live service).
+ */
+export const PROVIDER_KEY_SHARED_VARS: ReadonlySet<string> = new Set([
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "GOOGLE_API_KEY",
+]);
+
+/**
+ * The provider-key env-var names `serviceName` sources from a Railway
+ * environment-shared variable (`${{shared.<NAME>}}`). Returns a sorted copy
+ * (deterministic order regardless of literal order); empty for a service that
+ * declares no `sharedRefs` (e.g. `aimock`, which holds no provider key).
+ * Throws on unknown service (fail loud, consistent with the other accessors).
+ */
+export function sharedRefsFor(serviceName: string): string[] {
+  return [...(getEntry(serviceName).sharedRefs ?? [])].sort();
+}
+
+/**
+ * Throw on SSOT load if any `sharedRefs` entry is malformed: a name that is
+ * not a recognized provider-key var (see `PROVIDER_KEY_SHARED_VARS`) or a
+ * duplicate within a single service's array. A stray/typo'd name would model
+ * a shared reference the Ruby preflight then cannot assert, silently letting a
+ * real per-service secret survive — so fail loud at module load, in the same
+ * style as `assertDispatchNamesUnique` / `assertImageConsumersValid`.
+ *
+ * Accepts an injected map for testing; defaults to the real SERVICES map.
+ */
+export function assertSharedRefsValid(
+  services: Record<string, { sharedRefs?: string[] }> = SERVICES,
+): void {
+  const problems: string[] = [];
+  for (const [key, entry] of Object.entries(services)) {
+    const refs = entry.sharedRefs;
+    if (refs === undefined) continue;
+    const seen = new Set<string>();
+    for (const name of refs) {
+      if (!PROVIDER_KEY_SHARED_VARS.has(name)) {
+        problems.push(
+          `  - sharedRefs "${name}" on "${key}" is not a recognized provider-key var (allowed: ${[
+            ...PROVIDER_KEY_SHARED_VARS,
+          ]
+            .sort()
+            .join(", ")})`,
+        );
+      }
+      if (seen.has(name)) {
+        problems.push(`  - duplicate sharedRefs "${name}" on "${key}"`);
+      }
+      seen.add(name);
+    }
+  }
+  if (problems.length > 0) {
+    throw new Error(
+      `railway-envs sharedRefs invariant violated:\n${problems.join("\n")}\n` +
+        `Fix: every sharedRefs entry must be a recognized provider-key env ` +
+        `var name (defined ONCE as a Railway environment-shared variable and ` +
+        `referenced via \${{shared.<NAME>}}), unique within the service.`,
+    );
+  }
+}
+
 // Module-load assertions: fail any importer if the SSOT drifts into a
-// collision, a mis-wired image consumer, an inconsistent env registry, or
-// a duplicated Railway ID. Tests that exercise the invariants with
-// synthetic input call the assert functions directly.
+// collision, a mis-wired image consumer, an inconsistent env registry, a
+// duplicated Railway ID, or a malformed shared provider-key reference. Tests
+// that exercise the invariants with synthetic input call the assert functions
+// directly.
 assertDispatchNamesUnique();
 assertImageConsumersValid();
 assertEnvRegistryConsistent();
 assertServiceAndInstanceIdsUnique();
 assertClosureValid();
+assertSharedRefsValid();


### PR DESCRIPTION
## Problem

The **same real upstream OpenAI/Anthropic/Google key** is duplicated in plaintext across ~34 showcase services' Railway env, while **aimock** — the only service that ever reaches real providers — holds none.

Empirically verified on live staging (values never printed; compared by sha256 prefix):

| Key | Distinct values | # services holding it |
|---|---|---|
| `OPENAI_API_KEY` | 2 (one value on 34, one outlier) | 35 |
| `ANTHROPIC_API_KEY` | 1 | 34 |
| `GOOGLE_API_KEY` | 1 | 28 |

aimock staging carries **zero** provider keys. Even the `shell`/`docs`/`dashboard` frontends carry the real keys. Net: one scraped demo env = the real key; rotation = ~34 edits.

## STEP 1 — Feasibility finding: aimock own-key = **NO**

Can aimock authenticate upstream with its OWN key instead of forwarding the client's? **No.** In `@copilotkit/aimock@1.26.1`:

- The proxy passthrough (`dist/recorder.js`) copies every non-stripped client header to upstream. `STRIP_HEADERS` strips hop-by-hop headers but **not** `authorization` / `x-api-key` — the client key is forwarded verbatim.
- No `process.env.OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` is read anywhere on the proxy path.
- The CLI `--provider-openai/anthropic/gemini` flags set upstream **URLs only**; there is no key flag.

So aimock cannot own upstream auth. Per the task's fallback instruction, this PR implements the **lighter design**: define each provider key **once** as a Railway **environment-shared variable** and reference it (`${{shared.OPENAI_API_KEY}}`) from the services that need it — single source, one-edit rotation, a scraped service env yields only a reference token.

## What this PR changes (repo side — modeling + guardrail)

The real key *values* live only in Railway, so the durable repo-side change is to **model and enforce** the single-source arrangement:

- **`railway-envs.ts`** — additive `sharedRefs?: string[]` on each service (the provider-key env-var NAMES it sources from a shared variable), a `PROVIDER_KEY_SHARED_VARS` allow-list, a `sharedRefsFor` accessor, and an `assertSharedRefsValid` module-load invariant. Populated from live staging reality (OPENAI everywhere; ANTHROPIC/GOOGLE where present; `strands-typescript` = OPENAI only).
- **`emit-railway-envs-json.ts`** — emit `sharedRefs` additively (frozen legacy shape preserved; byte-stability golden still passes).
- **`railway-envs.generated.json`** — regenerated deterministically via the generator.
- **Tests** — red-green coverage: every aimock-routed service must declare a shared `OPENAI_API_KEY` ref; aimock declares none; malformed/duplicate refs fail loud.

Values live **only in Railway, never in this repo.**

## Red / Green

Exercised at the SSOT/wiring level (a live provider passthrough was not run in-session; see note below).

- **RED** — with the `sharedRefs` data stripped (the pre-fix state where each service still models its own per-service key), the test *"every aimock-routed service declares OPENAI_API_KEY as a shared ref"* fails, listing all 30+ agent/starter services as offenders.
- **GREEN** — with `sharedRefs` populated, all 8 new tests pass; the full `railway-envs` + `emit` suites pass (127/127), including the byte-stability golden and `emit --check`.

**Not live-validated in-session:** an end-to-end passthrough (demo backend → aimock → real provider using the shared key) requires creating the Railway shared variable and switching a service to `${{shared.*}}`, which is a prod/staging mutation intentionally left as the manual ops step below. The wiring/assertion level is proven here.

## Manual follow-up (ops — not done in this PR)

- [ ] Create environment-shared variables `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY` in each Railway env (staging + prod), sourced from 1Password.
- [ ] Switch every service listed in `sharedRefs` to reference `${{shared.<NAME>}}` and delete its per-service copy.
- [ ] Live-validate one demo backend passthrough (fixture-miss → real completion) with only the shared reference present.
- [ ] **MANUAL: rotate the exposed key.** The real `OPENAI_API_KEY` surfaced in plaintext across ~34 services in a debugging session — rotate it in the OpenAI dashboard, store the new value in 1Password, and reference it via the shared variable (never commit it).

## Coordination

Independent of and mergeable in **any order** with `fix/aimock-private-egress`. This PR touches only the `*_API_KEY` modeling (`sharedRefs`) — it does **not** modify base-URL host resolution. The one shared artifact, `railway-envs.generated.json`, is deterministically regenerable via the generator on the merged SSOT (never hand-merge).
