### PR TITLE
fix(showcase): resolve dashboard build of shared cell-model fold + close CI gap

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -164,6 +164,15 @@ jobs:
               - 'showcase/shared/**'
               - 'showcase/scripts/**'
               - 'showcase/integrations/*/manifest.yaml'
+              # The dashboard re-exports the harness's shared cell-model fold
+              # (src/lib/{cell-model,live-status,staleness,format-ts}.ts →
+              # ../../../harness/src/shared/cell-model/*), so those files are
+              # compiled INTO the dashboard's `next build`. A change to the
+              # fold that only touches showcase/harness/** would otherwise
+              # select `showcase_harness` but NOT this slot — exactly how
+              # #5952 shipped an unbuilt dashboard. Gate the dashboard on the
+              # fold so a fold change can never again bypass its build.
+              - 'showcase/harness/src/shared/**'
             shell_docs:
               - 'showcase/shell-docs/**'
               - 'showcase/shared/**'

--- a/showcase/shell-dashboard/next.config.ts
+++ b/showcase/shell-dashboard/next.config.ts
@@ -21,7 +21,29 @@ import type { NextConfig } from "next";
  *   1. showcase-harness has no CORS allowlist for cross-origin browser calls.
  *   2. The ops base URL stays out of the client bundle (no `NEXT_PUBLIC_*`
  *      exposure).
+ *
+ * `webpack.resolve.extensionAlias`: the dashboard re-exports the shared
+ * cell-model fold from the harness (`src/lib/{cell-model,live-status,
+ * staleness,format-ts}.ts` → `../../../harness/src/shared/cell-model/*`).
+ * Those fold files are authored for the harness's pure-Node-ESM runtime, so
+ * their INTERNAL relative imports carry explicit `.js` extensions (e.g.
+ * `import { formatTs } from "./format-ts.js"`). `export *` does NOT rewrite
+ * those internal edges, so `next build`'s webpack sees a literal `./x.js`
+ * specifier that only exists on disk as `./x.ts` and fails to resolve. The
+ * extensionAlias tells webpack to try the TypeScript sources when a `.js`
+ * specifier is requested — the standard bundler complement to TS's
+ * NodeNext `.js`-import convention. This covers the `next build` (webpack)
+ * path that CI uses.
  */
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  webpack: (config) => {
+    config.resolve.extensionAlias = {
+      ...(config.resolve.extensionAlias ?? {}),
+      ".js": [".ts", ".tsx", ".js"],
+      ".mjs": [".mts", ".mjs"],
+    };
+    return config;
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
## What broke

PR #5952 (`9a8cf615`) added explicit `.js` extensions to the relative imports inside the harness's shared cell-model fold (`showcase/harness/src/shared/cell-model/{cell-model,live-status,staleness}.ts`). Those `.js` extensions are **REQUIRED** for the harness's pure-Node-ESM runtime and are **correct** — this PR does not revert them.

The problem: the dashboard re-exports that fold via re-export shims (`showcase/shell-dashboard/src/lib/{cell-model,live-status,staleness,format-ts}.ts`, each `export * from "../../../harness/src/shared/cell-model/*"`), which pulls the fold **into the dashboard's `next build`**. `export *` does not rewrite the fold's *internal* `.js` edges, and the dashboard's `next.config.ts` was empty (no `extensionAlias`), so webpack resolved `./live-status.js` **literally**, found only the `.ts` source, and failed:

```
../harness/src/shared/cell-model/cell-model.ts
Module not found: Can't resolve './live-status.js'
Module not found: Can't resolve './staleness.js'
../harness/src/shared/cell-model/live-status.ts
Module not found: Can't resolve './format-ts.js'
> Build failed because of webpack errors
```

First-red at `9a8cf615`; reproduced in CI run `29306712559` (shell-dashboard build job).

## The fix (two parts, one coherent subject)

**1. Resolution** — `showcase/shell-dashboard/next.config.ts`: add a webpack `resolve.extensionAlias` so `.js`/`.mjs` specifiers resolve to `.ts`/`.tsx`/`.mts` sources. This is the standard bundler complement to TypeScript NodeNext's `.js`-import convention, and it applies to the `next build` (webpack) path CI uses. A shim-only fix does **not** work — `export *` doesn't intercept the fold's internal `.js` edges; the alias in the dashboard build is the correct layer. The harness fold `.js` imports are **left untouched**.

**2. CI gap** — `.github/workflows/showcase_build.yml`: the dashboard build didn't run on #5952 because the build matrix is path-filtered and #5952 only touched `showcase/harness/**`, which selects `showcase_harness` but **not** `shell_dashboard`. Added `showcase/harness/src/shared/**` to the `shell_dashboard` `dorny/paths-filter` set. Now any change to the shared fold the dashboard compiles in also selects the dashboard build — a fold change can never again ship an unbuilt dashboard. (Verified only `shell-dashboard` consumes this fold, so the gate is scoped precisely.)

## Local red-green proof

**RED** (latest main, before the `next.config.ts` fix) — from `showcase/shell-dashboard`, `next build`:
```
../harness/src/shared/cell-model/cell-model.ts
Module not found: Can't resolve './live-status.js'
Module not found: Can't resolve './staleness.js'
../harness/src/shared/cell-model/live-status.ts
Module not found: Can't resolve './format-ts.js'
Module not found: Can't resolve './staleness.js'
> Build failed because of webpack errors
```
(4 fold-resolve errors.)

**GREEN** (after the `extensionAlias` fix) — same `next build`:
```
(0 fold-resolve errors — the fold resolves)
```
The only remaining `Module not found` errors are `@/data/{catalog,registry,docs-status}.json`, which are generated by the dashboard's `prebuild` scripts (`generate-registry.ts` / `probe-docs.ts`) that were skipped in the local repro. CI's Docker build runs `prebuild` first, so those files exist there — unrelated to this fix.

## CI-gap trace

`dorny/paths-filter` emits `changes` as the JSON array of filter keys whose patterns matched. A change to `showcase/harness/src/shared/cell-model/live-status.ts` now matches both `showcase_harness` (via `showcase/harness/**`) **and** `shell_dashboard` (via the new `showcase/harness/src/shared/**`), so the matrix `select` (`$dispatch == "" and ($changes | index($fk) != null)`) includes the `shell-dashboard` slot. Gap closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)