### PR TITLE
ci(showcase): fail loud on empty redeploy set + alert on starter build failures

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -668,6 +668,45 @@ jobs:
             ghcr.io/copilotkit/${{ matrix.starter.image }}:latest
             ghcr.io/copilotkit/${{ matrix.starter.image }}:${{ github.sha }}
 
+      - name: Write per-slot starter build result
+        if: always()
+        env:
+          SERVICE: ${{ matrix.starter.slug }}
+          BUILD_STATUS: ${{ job.status }}
+        run: |
+          # Mirror of the main `build` matrix's per-slot result write
+          # (see "Write per-slot build result" above). job.status is one of
+          # success, failure, cancelled; normalize cancelled→skipped to match
+          # the same {service,status} shape. We publish per-slot via artifact
+          # because matrix-slot outputs aren't aggregable across slots.
+          #
+          # IMPORTANT: starter artifacts use the `starter-build-result-*`
+          # prefix, NOT `build-result-*`. The aggregate-build-results job
+          # downloads every `build-result-*` and feeds it to the showcase
+          # redeploy set (keyed by showcase dispatch_name). Starters are a
+          # separate namespace and must NOT pollute that intersection, so
+          # they get their own prefix. This artifact exists to give the
+          # `notify` job a durable per-starter failure surface.
+          case "$BUILD_STATUS" in
+            success) STATUS=success ;;
+            failure) STATUS=failure ;;
+            *)       STATUS=skipped ;;
+          esac
+          mkdir -p "$RUNNER_TEMP/starter-build-result"
+          printf '{"service":"%s","status":"%s"}\n' "$SERVICE" "$STATUS" \
+            > "$RUNNER_TEMP/starter-build-result/result.json"
+
+      - name: Upload per-slot starter build-result artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          # Distinct `starter-build-result-*` prefix so this never matches the
+          # aggregator's `build-result-*` download pattern.
+          name: starter-build-result-${{ matrix.starter.slug }}
+          path: ${{ runner.temp }}/starter-build-result/result.json
+          if-no-files-found: error
+          retention-days: 7
+
   aggregate-build-results:
     name: Aggregate build results
     needs: [detect-changes, build]
@@ -785,11 +824,23 @@ jobs:
           csv="$(jq -rn --argjson m "$matrix_names" --argjson s "$success_names" \
             '($m | map(select(. as $n | $s | index($n)))) | join(",")')"
           if [ -z "$csv" ]; then
-            echo "No services in matrix ∩ success-set — skipping redeploy."
-            echo "services=" >> "$GITHUB_OUTPUT"
-          else
-            echo "services=$csv" >> "$GITHUB_OUTPUT"
+            # This job only runs when aggregate-build-results.any_success == 'true'
+            # (see the job-level `if:` guard). So reaching an EMPTY intersection
+            # here does NOT mean "nothing to deploy" — it means at least one slot
+            # BUILT successfully yet none of those successes maps back into the
+            # scheduled build matrix. That is a dispatch_name↔service contract
+            # skew: the aggregator's `service` values and the matrix's
+            # `dispatch_name` values have drifted out of sync. Emitting an empty
+            # `services=` here would let the build go GREEN while redeploying
+            # NOTHING — a silent "we thought we shipped but didn't" hole. Fail
+            # LOUD instead, naming both sides of the skew so it can be diagnosed.
+            echo "::error::Build succeeded (any_success=true) but matrix ∩ success-set is EMPTY — dispatch_name/service contract skew; nothing would be redeployed."
+            echo "Successful build service values (from aggregate-build-results): $success_names"
+            echo "Scheduled matrix dispatch_name values (from detect-changes):    $matrix_names"
+            echo "These two sets share no members — a successful build maps to no matrix entry. Reconcile showcase/scripts/lib/build-outputs.ts (service field) with the build matrix dispatch_name values."
+            exit 1
           fi
+          echo "services=$csv" >> "$GITHUB_OUTPUT"
           echo "Computed services CSV (matrix ∩ build-success): $csv"
       - name: Redeploy changed services in staging
         if: steps.changed.outputs.services != ''
@@ -916,12 +967,22 @@ jobs:
     # skipped != failure. If `notify-all-builds-failed` also fires
     # (genuine all-failed case), both alerts firing for the same event is
     # acceptable per the alert SOP.
+    #
+    # `detect-starter-changes` + `build-starters` are included so a FAILED
+    # starter image build (examples/integrations/*) also triggers the Slack
+    # alert + PR comment. Previously the starter lane had NO alert surface:
+    # its jobs were absent from `needs`, so `if: failure()` could never see a
+    # starter build failure and it shipped silently. `if: failure()` still
+    # no-ops when starters are skipped (no starter changes) — skipped !=
+    # failure — so this only fires on a genuine starter build failure.
     needs:
       [
         detect-changes,
+        detect-starter-changes,
         check-lockfile,
         verify-image-refs,
         build,
+        build-starters,
         aggregate-build-results,
         redeploy-staging,
       ]


### PR DESCRIPTION
## Two silent-failure gaps in the showcase build/deploy/notify pipeline

These are **pre-existing** silent-failure holes surfaced in code review (not
caused by any recent PR). This PR fixes the two load-bearing ones.

### 1. Green-but-zero-redeploy (silent "we thought we shipped but didn't")

The `redeploy-staging` job computes the redeploy set as the intersection of the
build matrix and the build-success set. This job **only runs when
`aggregate-build-results.outputs.any_success == 'true'`** (job-level `if:`
guard). So if that intersection comes back **EMPTY**, it does NOT mean "nothing
to deploy" — it means at least one slot built successfully yet none of those
successes maps back to a matrix `dispatch_name`. That's a `dispatch_name`↔
`service` contract skew (the aggregator's `service` values and the matrix's
`dispatch_name` values drifted apart).

The old code emitted `services=` (empty) and exited 0 → the build went **GREEN
while redeploying NOTHING**, silently.

**Fix:** on an empty intersection in this any_success-guaranteed step, fail loud
(`::error::` + `exit 1`) with a diagnostic naming both sides of the skew.
The legitimate "nothing changed / nothing succeeded" no-op paths are guarded at
the **job level** (`has_changes=='true' && any_success=='true'`), so the fixed
step never runs there — no false-red.

### 2. Starter build failures had no alert surface (invisible failures)

The `notify` job's `needs` (and its `if: failure()`) omitted
`detect-starter-changes` and `build-starters`, and `build-starters` wrote no
per-slot build-result artifact. So a **failed starter image build produced NO
Slack alert and NO PR comment** — it shipped silently.

**Fix:**
- Added `detect-starter-changes` + `build-starters` to `notify.needs` so
  `if: failure()` sees a starter build failure → Slack alert + PR comment.
- Gave `build-starters` a per-slot build-result artifact **mirroring the main
  `build` matrix** (same `{service,status}` shape, `cancelled→skipped`
  normalization, `if: always()`, `if-no-files-found: error`), using a
  **distinct `starter-build-result-*` prefix** so it never matches the
  aggregator's `build-result-*` download pattern (starters must not pollute the
  showcase redeploy set keyed by `dispatch_name`).

### Red / Green

**Finding #1** — extracted the step's shell/jq logic and drove it with synthetic
inputs:

RED (pre-fix), any_success=true + empty intersection:
```
No services in matrix ∩ success-set — skipping redeploy.
Computed services CSV (matrix ∩ build-success):
EXIT=0        # $GITHUB_OUTPUT: services=   -> silent pass, redeploys NOTHING
```
GREEN (post-fix), same inputs:
```
::error::Build succeeded (any_success=true) but matrix ∩ success-set is EMPTY — dispatch_name/service contract skew; nothing would be redeployed.
Successful build service values: ["shell-RENAMED","mastra-RENAMED"]
Scheduled matrix dispatch_name values: ["shell","mastra"]
EXIT=1        # fails loud
```
No-regression: non-empty intersection → `EXIT=0 ; services=shell`. The
nothing-changed/nothing-succeeded paths are skipped at the job level (never
reach the step) → no false-red.

**Finding #2** — modeled `if: failure()` (fires iff any `needs` job result is
`failure`):
```
BEFORE (starters NOT in needs), starter=failure -> notify fires = False  (INVISIBLE, the bug)
AFTER  (starters IN needs),     starter=failure -> notify fires = True   (FIXED)
AFTER no-regression, starters=skipped, all green -> notify fires = False (quiet)
```

### Validation
- `python3 yaml.safe_load` parses OK.
- `actionlint`: only pre-existing findings remain (matrix jq SC2086 + the known
  `depot-ubuntu-24.04-4` runner-label warning); no new errors in edited regions.
- `yamllint`: only pre-existing line-length/document-start/truthy warnings.

### Scope
Touches **only** `.github/workflows/showcase_build.yml`, and only these two
concerns. Does NOT touch the `shell_dashboard` paths-filter region (PR #5955's
domain), nor the other backlog debt (false-root-cause comment, double-alert,
check-lockfile guard). Self-contained; not stacked on #5955.
