### PR TITLE
fix(showcase): resolve dashboard cell-model fold under Turbopack (next dev)

### DIFF
--- a/showcase/shell-dashboard/next.config.ts
+++ b/showcase/shell-dashboard/next.config.ts
@@ -22,18 +22,34 @@ import type { NextConfig } from "next";
  *   2. The ops base URL stays out of the client bundle (no `NEXT_PUBLIC_*`
  *      exposure).
  *
- * `webpack.resolve.extensionAlias`: the dashboard re-exports the shared
- * cell-model fold from the harness (`src/lib/{cell-model,live-status,
- * staleness,format-ts}.ts` → `../../../harness/src/shared/cell-model/*`).
- * Those fold files are authored for the harness's pure-Node-ESM runtime, so
- * their INTERNAL relative imports carry explicit `.js` extensions (e.g.
- * `import { formatTs } from "./format-ts.js"`). `export *` does NOT rewrite
- * those internal edges, so `next build`'s webpack sees a literal `./x.js`
- * specifier that only exists on disk as `./x.ts` and fails to resolve. The
- * extensionAlias tells webpack to try the TypeScript sources when a `.js`
- * specifier is requested — the standard bundler complement to TS's
- * NodeNext `.js`-import convention. This covers the `next build` (webpack)
- * path that CI uses.
+ * === Resolving the shared cell-model fold's internal `.js` specifiers ===
+ *
+ * The dashboard re-exports the shared cell-model fold from the harness
+ * (`src/lib/{cell-model,live-status,staleness,format-ts}.ts` →
+ * `../../../harness/src/shared/cell-model/*`). Those fold files are authored
+ * for the harness's pure-Node-ESM runtime, so their INTERNAL relative imports
+ * carry explicit `.js` extensions (e.g. `import { formatTs } from
+ * "./format-ts.js"`). `export *` does NOT rewrite those internal edges, so a
+ * bundler sees a literal `./x.js` specifier that only exists on disk as
+ * `./x.ts` and fails to resolve. Both bundler paths must be handled:
+ *
+ * `webpack.resolve.extensionAlias` — covers the `next build` (webpack) path
+ * that CI uses. It tells webpack to try the TypeScript sources when a `.js`
+ * specifier is requested — the standard bundler complement to TS's NodeNext
+ * `.js`-import convention.
+ *
+ * `turbopack.rules` loader — covers the `next dev --turbopack` path (Turbopack
+ * is this package's dev server; see the `dev` script). Turbopack IGNORES the
+ * webpack callback AND has NO `extensionAlias` equivalent: mapping a relative
+ * `.js` specifier to its `.ts` source is an open, unimplemented feature
+ * request (vercel/next.js#82945), and neither `turbopack.resolveAlias` nor
+ * `turbopack.resolveExtensions` matches relative specifiers (verified
+ * empirically — both leave `Can't resolve './live-status.js'`). The documented
+ * community workaround is a transform loader that strips the trailing `.js`
+ * from relative specifiers so Turbopack's normal `.ts`/`.tsx`/`.js` extension
+ * resolution takes over. The glob scopes the loader to the fold sources ONLY;
+ * the fold's on-disk `.js` specifiers are left untouched (they stay correct
+ * for the harness's Node-ESM runtime). Remove once #82945 ships parity.
  */
 const nextConfig: NextConfig = {
   webpack: (config) => {
@@ -43,6 +59,13 @@ const nextConfig: NextConfig = {
       ".mjs": [".mts", ".mjs"],
     };
     return config;
+  },
+  turbopack: {
+    rules: {
+      "**/harness/src/shared/cell-model/*.ts": {
+        loaders: ["./turbopack-strip-js-ext-loader.cjs"],
+      },
+    },
   },
 };
 

--- a/showcase/shell-dashboard/next.config.ts
+++ b/showcase/shell-dashboard/next.config.ts
@@ -62,9 +62,14 @@ const nextConfig: NextConfig = {
   },
   turbopack: {
     rules: {
-      "**/harness/src/shared/cell-model/*.ts": {
-        loaders: ["./turbopack-strip-js-ext-loader.cjs"],
-      },
+      // Scope the loader to ONLY the 4 fold module files the dashboard
+      // re-exports — NOT the `*.test.ts` / `*.equivalence-fixtures.ts`
+      // siblings in the same dir, whose `.js`-bearing string data would be
+      // the likeliest corruption target under a source-rewriting loader.
+      "**/harness/src/shared/cell-model/{cell-model,live-status,staleness,format-ts}.ts":
+        {
+          loaders: ["./turbopack-strip-js-ext-loader.cjs"],
+        },
     },
   },
 };

--- a/showcase/shell-dashboard/src/lib/turbopack-strip-js-ext-loader.test.ts
+++ b/showcase/shell-dashboard/src/lib/turbopack-strip-js-ext-loader.test.ts
@@ -130,6 +130,37 @@ describe("turbopack-strip-js-ext-loader", () => {
     expect(run(src).code).toBe(expected);
   });
 
+  // CR round-2 regression guards: the earlier line-anchored-regex loader
+  // corrupted these because a line-leading `from` inside a multi-line template,
+  // and an `import("…")` call shape inside any literal/comment, both matched.
+  // The mask-then-match loader must leave all of them untouched.
+  it("does NOT mutate a line-leading `from` inside a multi-line template", () => {
+    const src = 'const t = `\n} from "./inside.js"`;';
+    expect(run(src).code).toBe(src);
+    const src2 = 'const t = `\nfrom "./inside.js"`;';
+    expect(run(src2).code).toBe(src2);
+  });
+
+  it("does NOT mutate a dynamic `import(...)` inside a string/template/comment", () => {
+    const tpl = 'const s = `await import("./tpl.js")`;';
+    expect(run(tpl).code).toBe(tpl);
+    const str = `const s = 'import("./str.js")';`;
+    expect(run(str).code).toBe(str);
+    const cmt = `// example: import("./doc.js")`;
+    expect(run(cmt).code).toBe(cmt);
+  });
+
+  it("does NOT mutate a `.js` specifier shape inside a block comment", () => {
+    const src = `/* import z from "./c.js"; */`;
+    expect(run(src).code).toBe(src);
+  });
+
+  it("preserves a directory segment literally named `foo.js`", () => {
+    expect(run(`import q from "./foo.js/index.js";`).code).toBe(
+      `import q from "./foo.js/index";`,
+    );
+  });
+
   it("forwards the incoming sourcemap", () => {
     const map = { version: 3, sources: ["x.ts"], mappings: "AAAA" };
     const result = run(`import { a } from "./x.js";`, map);

--- a/showcase/shell-dashboard/src/lib/turbopack-strip-js-ext-loader.test.ts
+++ b/showcase/shell-dashboard/src/lib/turbopack-strip-js-ext-loader.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for the Turbopack transform loader that strips explicit `.js`
+ * extensions off RELATIVE import/export specifiers so the harness cell-model
+ * fold resolves to its `.ts` sources under Turbopack.
+ *
+ * These tests pin the HARDENED behavior: the loader must strip `.js`/`.mjs`/
+ * `.cjs` off real relative import/export specifiers (static, bare side-effect,
+ * and dynamic forms) while NEVER mutating a `.js` occurrence that lives inside
+ * ordinary string data or a comment.
+ */
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+
+// The loader is a CommonJS `.cjs` module in the package root; load it via
+// createRequire so this ESM test can `require` it without a build step.
+const require = createRequire(import.meta.url);
+const stripRelativeJsExtensions =
+  require("../../turbopack-strip-js-ext-loader.cjs") as (
+    source: string,
+    map?: unknown,
+  ) => string;
+
+/**
+ * Invoke the loader with a fake webpack-loader `this` so `this.callback` /
+ * `this.async` (used to forward sourcemaps) resolve. Returns the emitted
+ * `{ code, map }` regardless of whether the loader returns a string or calls
+ * `this.callback`.
+ */
+function run(source: string, map?: unknown): { code: string; map: unknown } {
+  let out: { code: string; map: unknown } | undefined;
+  const ctx = {
+    callback(_err: unknown, code: string, forwardedMap?: unknown) {
+      out = { code, map: forwardedMap };
+    },
+    // Some loaders call `this.async()` and use the returned callback instead.
+    async() {
+      return (_err: unknown, code: string, forwardedMap?: unknown) => {
+        out = { code, map: forwardedMap };
+      };
+    },
+  };
+  const returned = stripRelativeJsExtensions.call(ctx, source, map);
+  if (out) return out;
+  return { code: returned, map: undefined };
+}
+
+describe("turbopack-strip-js-ext-loader", () => {
+  it("strips .js off a real static relative import/re-export specifier", () => {
+    expect(run(`import { formatTs } from "./format-ts.js";`).code).toBe(
+      `import { formatTs } from "./format-ts";`,
+    );
+    expect(run(`export { x } from "../a/b.js";`).code).toBe(
+      `export { x } from "../a/b";`,
+    );
+    expect(run(`export * from "./staleness.js";`).code).toBe(
+      `export * from "./staleness";`,
+    );
+  });
+
+  it("strips .js off a multi-line import whose `from` clause is line-anchored", () => {
+    const src = [
+      "import {",
+      "  keyFor,",
+      "  STARTER_LEVELS,",
+      '} from "./live-status.js";',
+    ].join("\n");
+    const expected = [
+      "import {",
+      "  keyFor,",
+      "  STARTER_LEVELS,",
+      '} from "./live-status";',
+    ].join("\n");
+    expect(run(src).code).toBe(expected);
+  });
+
+  it("strips .js off a bare side-effect relative import", () => {
+    expect(run(`import "./polyfill.js";`).code).toBe(`import "./polyfill";`);
+  });
+
+  it("strips .js off a dynamic relative import", () => {
+    expect(run(`const m = await import("./lazy.js");`).code).toBe(
+      `const m = await import("./lazy");`,
+    );
+  });
+
+  it("strips .mjs and .cjs off relative specifiers (webpack extensionAlias parity)", () => {
+    expect(run(`import { a } from "./x.mjs";`).code).toBe(
+      `import { a } from "./x";`,
+    );
+    expect(run(`export { b } from "./y.cjs";`).code).toBe(
+      `export { b } from "./y";`,
+    );
+  });
+
+  it("does NOT touch bare/package specifiers", () => {
+    expect(run(`import x from "react.js";`).code).toBe(
+      `import x from "react.js";`,
+    );
+    expect(run(`import y from "pkg/entry.js";`).code).toBe(
+      `import y from "pkg/entry.js";`,
+    );
+  });
+
+  it("does NOT mutate a `.js` occurrence inside string data", () => {
+    const src = `const s = 'see ./foo.js';`;
+    expect(run(src).code).toBe(src);
+  });
+
+  it("does NOT mutate a `.js` occurrence inside a line comment", () => {
+    const src = `// ./bar.js is the old path`;
+    expect(run(src).code).toBe(src);
+  });
+
+  it('does NOT mutate `from "./x.js"`-shaped text inside a template literal', () => {
+    const src = 'const t = `import a from "./tpl.js";`;';
+    expect(run(src).code).toBe(src);
+  });
+
+  it("strips only the real specifier when real + string-data coexist", () => {
+    const src = [
+      `import { formatTs } from "./format-ts.js";`,
+      `const doc = 'the module lives at ./format-ts.js';`,
+      `// re-export from "./format-ts.js" historically`,
+    ].join("\n");
+    const expected = [
+      `import { formatTs } from "./format-ts";`,
+      `const doc = 'the module lives at ./format-ts.js';`,
+      `// re-export from "./format-ts.js" historically`,
+    ].join("\n");
+    expect(run(src).code).toBe(expected);
+  });
+
+  it("forwards the incoming sourcemap", () => {
+    const map = { version: 3, sources: ["x.ts"], mappings: "AAAA" };
+    const result = run(`import { a } from "./x.js";`, map);
+    expect(result.code).toBe(`import { a } from "./x";`);
+    expect(result.map).toEqual(map);
+  });
+});

--- a/showcase/shell-dashboard/turbopack-strip-js-ext-loader.cjs
+++ b/showcase/shell-dashboard/turbopack-strip-js-ext-loader.cjs
@@ -21,53 +21,59 @@
  * relative specifiers, letting Turbopack's normal extension resolution
  * (`.ts`/`.tsx`/`.js`) take over.
  *
- * SAFE MATCHING (why this is not a blanket text replace)
- * A naive `from "…".js` text replace mutates ANY occurrence of that shape,
- * including inside string literals, comments, and template literals — e.g. a
- * template `` `import a from "./tpl.js"` `` would be corrupted. To avoid that
- * without shipping a full parser, matching is anchored to real import/export
- * STATEMENT context:
- *   - static/re-export forms are matched only when the `from` clause (or a
- *     leading `import`/`export` keyword, for single-line forms) begins a line
- *     — a `from "…"` at statement position, never `from` embedded mid-line in
- *     string data. This also covers multi-line `import { … } from "./x.js"`
- *     blocks, whose `from` clause sits on its own line.
- *   - bare side-effect imports `import "./x.js";` are matched line-anchored.
- *   - dynamic `import("./x.js")` is matched by its distinctive call syntax.
- * Only RELATIVE specifiers (starting with `.`) are ever rewritten; bare/package
- * specifiers (`"react.js"`, `"pkg/e.js"`) are left untouched.
+ * SAFE MATCHING — MASK THEN MATCH (not a blanket text replace)
+ * A naive `from "…".js` / `import("…").js` text replace mutates ANY occurrence
+ * of that shape, INCLUDING ones that appear inside string literals, template
+ * literals, and comments — e.g. a template `` `await import("./x.js")` `` or a
+ * doc comment `// see ./x.js`. Line-anchoring alone is NOT enough: a multi-line
+ * template literal can contain a physical line that begins with `from "./x.js"`,
+ * and a dynamic-`import("…")` call shape occurs freely inside string data.
+ *
+ * To rewrite ONLY real code, this loader first builds a length-preserving
+ * "masked" view of the source in which the interior of every comment
+ * (`// …`, `/* … *\/`) and every string/template literal (`'…'`, `"…"`,
+ * `` `…` ``) is blanked to spaces (newlines preserved so line/column offsets
+ * are identical to the original). The specifier regexes run against the MASKED
+ * view — so they can never match text that lived inside a comment or literal —
+ * and the resulting match RANGES are applied back to the ORIGINAL source. Real
+ * import/export specifiers are never inside a literal, so they survive masking
+ * and are the only things rewritten. Only RELATIVE specifiers (starting with
+ * `.`) are rewritten; bare/package specifiers (`"react.js"`, `"pkg/e.js"`) are
+ * left untouched.
  *
  * The `next.config.ts` rule scopes this loader to the 4 fold module files ONLY
  * (cell-model / live-status / staleness / format-ts), excluding test and
  * equivalence-fixture siblings. The fold's on-disk `.js` specifiers are left
  * untouched on disk — they remain correct for the harness's Node-ESM runtime.
- * The incoming sourcemap is forwarded so fold debugging keeps working.
+ *
+ * SOURCEMAP: every edit is a pure deletion of the 2–3-char extension suffix
+ * (`js`/`mjs`/`cjs`) from a single specifier token. The incoming map is
+ * forwarded unchanged: line mappings stay exact, and only columns AFTER the
+ * edited specifier on that one line shift left by the removed length — a
+ * cosmetic offset limited to the tail of rewritten import lines. Forwarding the
+ * map keeps whole-file line-level fold debugging intact (far better than
+ * dropping it); we do not regenerate per-column mappings for the specifier tail.
  */
 
-// A relative specifier + strippable extension, captured so the extension can
-// be dropped while quotes/relative path are preserved. `EXT` lists the
-// extensions webpack's extensionAlias maps (.js, .mjs, .cjs).
-const REL = `(\\.[^"'\\n]*?)`; // relative path body (starts with `.`)
+// A relative specifier + strippable extension. `EXT` lists the extensions
+// webpack's extensionAlias maps (.js, .mjs, .cjs). `REL` is the relative path
+// body (must start with `.`), non-greedy up to the closing quote.
+const REL = `(\\.[^"'\\n]*?)`;
 const EXT = `(?:js|mjs|cjs)`;
 
-// Static import/export whose `from` clause is line-anchored. Covers the
-// multi-line form whose closing `} from "./a.js"` (or a bare `from "./a.js"`)
-// sits on its own line — the `from` keyword begins the trimmed line, optionally
-// after a `}`. A `from "…"` embedded mid-line (e.g. inside a template literal)
-// is NOT matched.
-const STATIC_FROM_LINE = new RegExp(
-  `(^[ \\t]*(?:\\}[ \\t]*)?from[ \\t]+["'])${REL}\\.${EXT}(["'])`,
-  "gm",
-);
-
-// Single-line static import/export beginning with the keyword and carrying its
-// `from "./x.js"` clause on the same line (`import { a } from "./a.js";`,
-// `export * from "./a.js";`). Anchored to a leading `import`/`export` keyword so
-// the `from` must belong to a real statement, not string/comment data. The
-// `[^"'\n]*` gate keeps the match on a single logical line and prevents it from
-// spanning an intervening string that could contain its own quotes.
+// Static import/export whose `from` clause is line-anchored — covers both the
+// single-line form (`import { a } from "./a.js";`, `export * from "./a.js";`)
+// and the multi-line form whose closing `} from "./a.js"` (or bare
+// `from "./a.js"`) sits on its own line. Two variants: one keyed on a leading
+// `import`/`export` keyword (single-line), one keyed on a line-leading `from` /
+// `} from` (multi-line continuation). Both run against the MASKED view, so a
+// line-leading `from` INSIDE a template literal is blanked and cannot match.
 const STATIC_FROM_INLINE = new RegExp(
   `(^[ \\t]*(?:import|export)\\b[^"'\\n]*?\\bfrom[ \\t]+["'])${REL}\\.${EXT}(["'])`,
+  "gm",
+);
+const STATIC_FROM_LINE = new RegExp(
+  `(^[ \\t]*(?:\\}[ \\t]*)?from[ \\t]+["'])${REL}\\.${EXT}(["'])`,
   "gm",
 );
 
@@ -77,23 +83,140 @@ const BARE_IMPORT = new RegExp(
   "gm",
 );
 
-// Dynamic `import("./x.js")` — matched by its call syntax, which cannot occur
-// as incidental string data the way a bare `from "…"` shape can.
+// Dynamic `import("./x.js")`. Matched against the MASKED view, so an
+// `import("…")` shape sitting inside a string/template/comment is blanked and
+// cannot match — only a real dynamic import in code is rewritten.
 const DYNAMIC_IMPORT = new RegExp(
   `(import\\([ \\t]*["'])${REL}\\.${EXT}(["'][ \\t]*\\))`,
   "g",
 );
 
-function stripRelativeJsExtensions(source, map) {
-  const out = source
-    .replace(STATIC_FROM_INLINE, "$1$2$3")
-    .replace(STATIC_FROM_LINE, "$1$2$3")
-    .replace(BARE_IMPORT, "$1$2$3")
-    .replace(DYNAMIC_IMPORT, "$1$2$3");
+const PATTERNS = [
+  STATIC_FROM_INLINE,
+  STATIC_FROM_LINE,
+  BARE_IMPORT,
+  DYNAMIC_IMPORT,
+];
 
-  // Forward the incoming sourcemap so fold debugging keeps working. Prefer the
-  // webpack-style `this.callback(err, code, map)`; fall back to a plain return
-  // when invoked without a loader context (e.g. unit tests calling directly).
+/**
+ * Build a length-preserving copy of `source` where the INTERIOR of every
+ * comment and string/template literal is replaced with spaces (newlines kept,
+ * so every index in the mask corresponds to the same index in `source`).
+ * Quote/backtick/comment delimiters themselves are preserved so the specifier
+ * regexes still see the surrounding `from "…"` / `import("…")` structure of
+ * REAL code, while any `from "…"`/`import("…")`-shaped text that lived inside a
+ * literal is destroyed. A simple single-pass scanner over the standard JS
+ * lexical states — enough to protect the scoped fold files without a full
+ * parser.
+ */
+function maskLiteralsAndComments(source) {
+  const out = source.split("");
+  const n = source.length;
+  let i = 0;
+  // States: code | line-comment | block-comment | sq (') | dq (") | tpl (`)
+  while (i < n) {
+    const c = source[i];
+    const c2 = i + 1 < n ? source[i + 1] : "";
+    if (c === "/" && c2 === "/") {
+      i += 2;
+      while (i < n && source[i] !== "\n") {
+        out[i] = " ";
+        i++;
+      }
+      continue;
+    }
+    if (c === "/" && c2 === "*") {
+      i += 2;
+      while (i < n && !(source[i] === "*" && source[i + 1] === "/")) {
+        if (source[i] !== "\n") out[i] = " ";
+        i++;
+      }
+      i += 2; // skip closing */
+      continue;
+    }
+    if (c === "'" || c === '"' || c === "`") {
+      const quote = c;
+      i++; // past opening delimiter (kept)
+      while (i < n) {
+        const ch = source[i];
+        if (ch === "\\") {
+          // escaped char inside the literal — blank both, skip.
+          if (source[i] !== "\n") out[i] = " ";
+          if (i + 1 < n && source[i + 1] !== "\n") out[i + 1] = " ";
+          i += 2;
+          continue;
+        }
+        if (ch === quote) {
+          i++; // past closing delimiter (kept)
+          break;
+        }
+        // Note: template `${…}` interpolations are blanked wholesale here. That
+        // is safe for this loader — a real import/export can never live inside
+        // an interpolation, so blanking it only removes potential false matches.
+        if (ch !== "\n") out[i] = " ";
+        i++;
+      }
+      continue;
+    }
+    i++;
+  }
+  return out.join("");
+}
+
+function stripRelativeJsExtensions(source, map) {
+  // The mask is used ONLY as a code-vs-literal oracle: it blanks the interior
+  // of every comment and string/template literal (delimiters kept). We match
+  // the specifier regexes against the ORIGINAL source (so the specifier text
+  // survives to be matched) and then keep a match only if its leading keyword
+  // (`import`/`export`/`from`/`import(`) survived masking unchanged — i.e. it
+  // is real code, not text that happened to sit inside a literal or comment.
+  const masked = maskLiteralsAndComments(source);
+
+  // Collect edits (index ranges of the `.<ext>` suffix to delete). Dedupe
+  // overlapping matches (a specifier can match more than one pattern) by
+  // keeping the first edit that covers each extension position.
+  const edits = [];
+  const seen = new Set();
+  for (const re of PATTERNS) {
+    re.lastIndex = 0;
+    let m;
+    while ((m = re.exec(source)) !== null) {
+      // Reject the match unless the keyword prefix (m[1] up to the opening
+      // quote) is byte-for-byte identical in the mask — a real code statement.
+      // If any prefix char was blanked, the `from`/`import(` shape lived inside
+      // a comment or literal and must NOT be rewritten.
+      const prefixInMask = masked.slice(m.index, m.index + m[1].length);
+      if (prefixInMask !== m[1]) continue;
+
+      // Layout: m[1]=prefix (…opening quote), m[2]=relative path body, then a
+      // literal `.<ext>`, then m[3]=suffix (closing quote [+ `)` for dynamic]).
+      // Delete exactly the `.<ext>` run.
+      const extStart = m.index + m[1].length + m[2].length; // at the `.`
+      const extEnd = m.index + m[0].length - m[3].length; // end of `.<ext>`
+      const key = extStart + ":" + extEnd;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      edits.push([extStart, extEnd]);
+    }
+  }
+
+  let out = source;
+  if (edits.length > 0) {
+    edits.sort((a, b) => a[0] - b[0]);
+    let result = "";
+    let cursor = 0;
+    for (const [start, end] of edits) {
+      if (start < cursor) continue; // skip any overlap
+      result += source.slice(cursor, start);
+      cursor = end; // drop [start,end) — the `.<ext>` suffix
+    }
+    result += source.slice(cursor);
+    out = result;
+  }
+
+  // Forward the incoming sourcemap (see header note on the cosmetic column
+  // offset). Prefer the webpack-style `this.callback(err, code, map)`; fall
+  // back to a plain return when invoked without a loader context (unit tests).
   if (this && typeof this.callback === "function") {
     this.callback(null, out, map);
     return;
@@ -102,3 +225,4 @@ function stripRelativeJsExtensions(source, map) {
 }
 
 module.exports = stripRelativeJsExtensions;
+module.exports.maskLiteralsAndComments = maskLiteralsAndComments;

--- a/showcase/shell-dashboard/turbopack-strip-js-ext-loader.cjs
+++ b/showcase/shell-dashboard/turbopack-strip-js-ext-loader.cjs
@@ -1,6 +1,6 @@
 /**
- * Turbopack loader: strip explicit `.js` extensions off RELATIVE import/export
- * specifiers so they resolve to their `.ts`/`.tsx` sources.
+ * Turbopack loader: strip explicit `.js`/`.mjs`/`.cjs` extensions off RELATIVE
+ * import/export specifiers so they resolve to their `.ts`/`.tsx` sources.
  *
  * WHY THIS EXISTS
  * The dashboard re-exports the shared cell-model fold from the harness
@@ -12,23 +12,93 @@
  * does not rewrite those internal edges.
  *
  * The webpack build fixes this with `resolve.extensionAlias` (see
- * next.config.ts). Turbopack has NO equivalent — mapping a relative `.js`
- * specifier to its `.ts` source is an open, unimplemented feature request
- * (vercel/next.js#82945; `turbopack.resolveAlias`/`resolveExtensions` do not
- * match relative specifiers). Until Turbopack ships parity, the documented
- * community workaround is a transform loader that drops the trailing `.js`
- * from relative specifiers, letting Turbopack's normal extension resolution
+ * next.config.ts), which maps `.js`→`.ts`/`.tsx`/`.js` AND `.mjs`→`.mts`/`.mjs`.
+ * Turbopack has NO equivalent — mapping a relative `.js` specifier to its `.ts`
+ * source is an open, unimplemented feature request (vercel/next.js#82945;
+ * `turbopack.resolveAlias`/`resolveExtensions` do not match relative
+ * specifiers). Until Turbopack ships parity, the documented community
+ * workaround is a transform loader that drops the trailing extension from
+ * relative specifiers, letting Turbopack's normal extension resolution
  * (`.ts`/`.tsx`/`.js`) take over.
  *
- * The `next.config.ts` rule scopes this loader to the fold sources ONLY, so
- * no other dashboard module is rewritten. The fold's on-disk `.js` specifiers
- * are left untouched — they remain correct for the harness's Node-ESM runtime.
+ * SAFE MATCHING (why this is not a blanket text replace)
+ * A naive `from "…".js` text replace mutates ANY occurrence of that shape,
+ * including inside string literals, comments, and template literals — e.g. a
+ * template `` `import a from "./tpl.js"` `` would be corrupted. To avoid that
+ * without shipping a full parser, matching is anchored to real import/export
+ * STATEMENT context:
+ *   - static/re-export forms are matched only when the `from` clause (or a
+ *     leading `import`/`export` keyword, for single-line forms) begins a line
+ *     — a `from "…"` at statement position, never `from` embedded mid-line in
+ *     string data. This also covers multi-line `import { … } from "./x.js"`
+ *     blocks, whose `from` clause sits on its own line.
+ *   - bare side-effect imports `import "./x.js";` are matched line-anchored.
+ *   - dynamic `import("./x.js")` is matched by its distinctive call syntax.
+ * Only RELATIVE specifiers (starting with `.`) are ever rewritten; bare/package
+ * specifiers (`"react.js"`, `"pkg/e.js"`) are left untouched.
+ *
+ * The `next.config.ts` rule scopes this loader to the 4 fold module files ONLY
+ * (cell-model / live-status / staleness / format-ts), excluding test and
+ * equivalence-fixture siblings. The fold's on-disk `.js` specifiers are left
+ * untouched on disk — they remain correct for the harness's Node-ESM runtime.
+ * The incoming sourcemap is forwarded so fold debugging keeps working.
  */
-module.exports = function stripRelativeJsExtensions(source) {
-  // Match `from "./x.js"` / `from '../y/z.js'` (import + re-export forms) and
-  // `import("./x.js")` dynamic imports, but only RELATIVE specifiers
-  // (starting with `.`), never bare/package specifiers.
-  return source
-    .replace(/(from\s+["'])(\.[^"']*?)\.js(["'])/g, "$1$2$3")
-    .replace(/(import\(\s*["'])(\.[^"']*?)\.js(["']\s*\))/g, "$1$2$3");
-};
+
+// A relative specifier + strippable extension, captured so the extension can
+// be dropped while quotes/relative path are preserved. `EXT` lists the
+// extensions webpack's extensionAlias maps (.js, .mjs, .cjs).
+const REL = `(\\.[^"'\\n]*?)`; // relative path body (starts with `.`)
+const EXT = `(?:js|mjs|cjs)`;
+
+// Static import/export whose `from` clause is line-anchored. Covers the
+// multi-line form whose closing `} from "./a.js"` (or a bare `from "./a.js"`)
+// sits on its own line — the `from` keyword begins the trimmed line, optionally
+// after a `}`. A `from "…"` embedded mid-line (e.g. inside a template literal)
+// is NOT matched.
+const STATIC_FROM_LINE = new RegExp(
+  `(^[ \\t]*(?:\\}[ \\t]*)?from[ \\t]+["'])${REL}\\.${EXT}(["'])`,
+  "gm",
+);
+
+// Single-line static import/export beginning with the keyword and carrying its
+// `from "./x.js"` clause on the same line (`import { a } from "./a.js";`,
+// `export * from "./a.js";`). Anchored to a leading `import`/`export` keyword so
+// the `from` must belong to a real statement, not string/comment data. The
+// `[^"'\n]*` gate keeps the match on a single logical line and prevents it from
+// spanning an intervening string that could contain its own quotes.
+const STATIC_FROM_INLINE = new RegExp(
+  `(^[ \\t]*(?:import|export)\\b[^"'\\n]*?\\bfrom[ \\t]+["'])${REL}\\.${EXT}(["'])`,
+  "gm",
+);
+
+// Bare side-effect import `import "./x.js";` (no `from` clause), line-anchored.
+const BARE_IMPORT = new RegExp(
+  `(^[ \\t]*import[ \\t]+["'])${REL}\\.${EXT}(["'])`,
+  "gm",
+);
+
+// Dynamic `import("./x.js")` — matched by its call syntax, which cannot occur
+// as incidental string data the way a bare `from "…"` shape can.
+const DYNAMIC_IMPORT = new RegExp(
+  `(import\\([ \\t]*["'])${REL}\\.${EXT}(["'][ \\t]*\\))`,
+  "g",
+);
+
+function stripRelativeJsExtensions(source, map) {
+  const out = source
+    .replace(STATIC_FROM_INLINE, "$1$2$3")
+    .replace(STATIC_FROM_LINE, "$1$2$3")
+    .replace(BARE_IMPORT, "$1$2$3")
+    .replace(DYNAMIC_IMPORT, "$1$2$3");
+
+  // Forward the incoming sourcemap so fold debugging keeps working. Prefer the
+  // webpack-style `this.callback(err, code, map)`; fall back to a plain return
+  // when invoked without a loader context (e.g. unit tests calling directly).
+  if (this && typeof this.callback === "function") {
+    this.callback(null, out, map);
+    return;
+  }
+  return out;
+}
+
+module.exports = stripRelativeJsExtensions;

--- a/showcase/shell-dashboard/turbopack-strip-js-ext-loader.cjs
+++ b/showcase/shell-dashboard/turbopack-strip-js-ext-loader.cjs
@@ -1,0 +1,34 @@
+/**
+ * Turbopack loader: strip explicit `.js` extensions off RELATIVE import/export
+ * specifiers so they resolve to their `.ts`/`.tsx` sources.
+ *
+ * WHY THIS EXISTS
+ * The dashboard re-exports the shared cell-model fold from the harness
+ * (`src/lib/{cell-model,live-status,staleness,format-ts}.ts` →
+ * `../../../harness/src/shared/cell-model/*`). Those fold files are authored
+ * for the harness's pure-Node-ESM runtime, so their INTERNAL relative imports
+ * carry explicit `.js` extensions (e.g. `import { formatTs } from
+ * "./format-ts.js"`) while only `./format-ts.ts` exists on disk. `export *`
+ * does not rewrite those internal edges.
+ *
+ * The webpack build fixes this with `resolve.extensionAlias` (see
+ * next.config.ts). Turbopack has NO equivalent — mapping a relative `.js`
+ * specifier to its `.ts` source is an open, unimplemented feature request
+ * (vercel/next.js#82945; `turbopack.resolveAlias`/`resolveExtensions` do not
+ * match relative specifiers). Until Turbopack ships parity, the documented
+ * community workaround is a transform loader that drops the trailing `.js`
+ * from relative specifiers, letting Turbopack's normal extension resolution
+ * (`.ts`/`.tsx`/`.js`) take over.
+ *
+ * The `next.config.ts` rule scopes this loader to the fold sources ONLY, so
+ * no other dashboard module is rewritten. The fold's on-disk `.js` specifiers
+ * are left untouched — they remain correct for the harness's Node-ESM runtime.
+ */
+module.exports = function stripRelativeJsExtensions(source) {
+  // Match `from "./x.js"` / `from '../y/z.js'` (import + re-export forms) and
+  // `import("./x.js")` dynamic imports, but only RELATIVE specifiers
+  // (starting with `.`), never bare/package specifiers.
+  return source
+    .replace(/(from\s+["'])(\.[^"']*?)\.js(["'])/g, "$1$2$3")
+    .replace(/(import\(\s*["'])(\.[^"']*?)\.js(["']\s*\))/g, "$1$2$3");
+};


### PR DESCRIPTION
## The webpack-only gap

PR #5955 fixed the dashboard's `next build` (webpack) resolution of the shared cell-model fold's internal `.js` specifiers by adding `webpack.resolve.extensionAlias` to `next.config.ts`. That fix is **webpack-only**.

This package's `dev` script is `next dev --turbopack --port 3002` — so **local `next dev` runs under Turbopack**, which ignores the webpack callback entirely. The fold files (`harness/src/shared/cell-model/{cell-model,live-status,staleness,format-ts}.ts`) carry explicit `.js` extensions on their internal relative imports (correct for the harness's pure-Node-ESM runtime); `export *` in the dashboard's `src/lib/*` shims pulls those internal `.js` edges into the dashboard graph. Under Turbopack they failed to resolve.

## Empirical RED (Turbopack, current main tip)

`next build --turbopack` (deterministic repro of the dev resolver), with #5955's webpack `extensionAlias` present but ignored:

```
Module not found: Can't resolve './live-status.js'
Module not found: Can't resolve './staleness.js'
Module not found: Can't resolve './format-ts.js'
  at .../harness/src/shared/cell-model/cell-model.ts:17:1
  at .../harness/src/shared/cell-model/live-status.ts:17:1
> Build error occurred
```

## Why the obvious Turbopack knobs don't work

Turbopack has **no `extensionAlias` equivalent** — mapping a relative explicit `.js` specifier to its `.ts` source is an open, unimplemented feature request: [vercel/next.js#82945](https://github.com/vercel/next.js/issues/82945). Verified empirically that all of these leave the identical 3 RED lines:

- `turbopack.resolveAlias { "./x.js": "./x.ts" }` (and absolute-path / extensionless variants) — resolveAlias does not match relative specifiers
- `turbopack.resolveExtensions` with the full default list — only affects **extensionless** imports, not a `.js`→`.ts` remap

## The fix

The documented workaround from #82945: a `turbopack.rules` transform loader (`turbopack-strip-js-ext-loader.cjs`) that strips the trailing `.js` off **relative** import/re-export/dynamic-import specifiers, so Turbopack's normal `.ts`/`.tsx`/`.js` extension resolution takes over. The rule glob scopes the loader to the fold sources **only** (`**/harness/src/shared/cell-model/*.ts`); no other dashboard module is rewritten. The webpack `extensionAlias` from #5955 is retained unchanged. The fold's on-disk `.js` specifiers are untouched (still correct for the harness Node-ESM runtime).

## GREEN

- `next build --turbopack` → `✓ Compiled successfully in 2.5s` (fold errors gone)
- `next dev --turbopack` → route `/` returns HTTP 200, `✓ Compiled / in 2.3s`, zero `Module not found` (the real reviewer-flagged surface: `dashboard-page.tsx` → `src/lib` shims → harness fold compiles cleanly)

## No regressions

- **Webpack path** (`next build`) still `✓ Compiled successfully` — #5955's fix is not disturbed.
- **Harness fold untouched** — `git diff` on the fold is empty; the `.js` internal imports remain.
- The only error remaining on **both** bundlers is a pre-existing, orthogonal `Cannot find module 'croner'` in test/CI type-check (present on the #5955 baseline with these changes stashed — 2 test files fail identically before and after). Not caused or fixed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)