### PR TITLE
fix(showcase): self-heal shared D6 browser on crash + right-size BROWSER_POOL_MAX_CONTEXTS

### DIFF
--- a/showcase/harness/src/cli/runner.ts
+++ b/showcase/harness/src/cli/runner.ts
@@ -42,9 +42,9 @@ import { livenessDriver } from "../probes/drivers/d2-liveness.js";
 import { e2eChatToolsDriver } from "../probes/drivers/d4-chat-roundtrip.js";
 import {
   createE2eFullDriver,
-  openGuardedContext,
+  createSelfHealingE2eFullLauncher,
 } from "../probes/drivers/d6-all-pills.js";
-import type { E2eFullBrowser } from "../probes/drivers/d6-all-pills.js";
+import type playwrightModule from "playwright";
 import type { StatusWriter } from "../writers/status-writer.js";
 import { runViaControlPlane } from "./control-plane-run.js";
 import type { ControlPlaneLevel } from "./control-plane-run.js";
@@ -316,77 +316,19 @@ export async function run(
 
   const fullDriver = options.headed
     ? createE2eFullDriver({
-        launcher: async (): Promise<E2eFullBrowser> => {
-          const mod =
-            (await import("playwright")) as typeof import("playwright");
-          const browser = await mod.chromium.launch({
+        // Headed launcher: same self-healing shared-browser model as the
+        // headless defaultLauncher (crash → bounded relaunch + retry instead of
+        // cascading every remaining feature into a raw "has been closed"),
+        // differing ONLY in headless:false. Relaunch events flow to the CLI
+        // logger. The shared factory also gives headed mode the full E2eFullPage
+        // wrapper the driver expects.
+        launcher: createSelfHealingE2eFullLauncher(async () => {
+          const mod = (await import("playwright")) as typeof playwrightModule;
+          return mod.chromium.launch({
             headless: false,
             args: ["--no-sandbox", "--disable-dev-shm-usage"],
           });
-          return {
-            async newContext(contextOpts?: {
-              extraHTTPHeaders?: Record<string, string>;
-            }) {
-              // GUARD: same shared-browser disconnect guard as defaultLauncher
-              // — refuse to open on a dead browser and convert a mid-open
-              // disconnect into a clean BrowserDisconnectedError rather than
-              // leaking Playwright's raw "has been closed" string.
-              const bCtx = await openGuardedContext<
-                Awaited<ReturnType<typeof browser.newContext>>
-              >(browser, {
-                extraHTTPHeaders: {
-                  "X-AIMock-Strict": "true",
-                  ...contextOpts?.extraHTTPHeaders,
-                },
-              });
-              return {
-                async newPage() {
-                  const page = await bCtx.newPage();
-                  const consoleLogs: string[] = [];
-                  const requestFailures: string[] = [];
-                  page.on(
-                    "console",
-                    (msg: { type(): string; text(): string }) => {
-                      const t = msg.type();
-                      if (t === "error" || t === "warning") {
-                        consoleLogs.push(`[${t}] ${msg.text().slice(0, 200)}`);
-                      }
-                    },
-                  );
-                  page.on(
-                    "requestfailed",
-                    (request: {
-                      method(): string;
-                      url(): string;
-                      failure(): { errorText: string } | null;
-                    }) => {
-                      requestFailures.push(
-                        `${request.method()} ${request.url().slice(0, 200)} => ${
-                          request.failure()?.errorText || "unknown"
-                        }`,
-                      );
-                    },
-                  );
-                  return Object.assign(page, {
-                    getDiagnostics: () => ({
-                      consoleLogs: consoleLogs.slice(-20),
-                      requestFailures: requestFailures.slice(-10),
-                    }),
-                    isClosed: () => page.isClosed(),
-                    locator: (s: string) => page.locator(s),
-                    route: (
-                      u: string | RegExp,
-                      handler: Parameters<typeof page.route>[1],
-                    ) => page.route(u, handler),
-                    unroute: (u: string | RegExp) => page.unroute(u),
-                  }) as unknown as import("../probes/drivers/d6-all-pills.js").E2eFullPage;
-                },
-                close: () => bCtx.close(),
-              };
-            },
-            close: () => browser.close(),
-          };
-        },
+        }, logger),
         // CVDIAG persistence for the local d5/d6 path (headed).
         cvdiagPbWriter: cvdiagWriter,
       })

--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -6,10 +6,13 @@ import {
   DEPLOY_CHURN_GRACE_MS,
   e2eFullDriver,
   FEATURE_CONCURRENCY_D6,
+  MAX_BROWSER_RELAUNCHES_D6,
   openGuardedContext,
+  openSelfHealingContext,
   parseFailureClassifier,
   Semaphore,
 } from "./d6-all-pills.js";
+import type { SelfHealDeps } from "./d6-all-pills.js";
 import { CVDIAG_FAILURE_CLASSIFIERS } from "../../cvdiag/index.js";
 import type { GuardableBrowser } from "./d6-all-pills.js";
 import type {
@@ -924,6 +927,277 @@ describe("e2e-full driver", () => {
       );
 
       // And no per-feature side row leaked the raw string either.
+      for (const emit of sideEmits) {
+        const desc = emit.signal?.errorDesc ?? "";
+        expect(desc).not.toContain(
+          "Target page, context or browser has been closed",
+        );
+      }
+    });
+  });
+
+  // --------------------------------------------------------------------
+  // SELF-HEAL: openGuardedContext (above) makes a shared-browser crash
+  // CLASSIFIABLE but does NOT recover — once the single shared Chromium
+  // crashes mid-fanout, every remaining feature open hits a dead browser
+  // and the whole run cascades red/abort (claude-sdk-python collapses
+  // 0/40). openSelfHealingContext RELAUNCHES the shared browser (bounded)
+  // and retries the open, so one crash no longer wipes the run.
+  // --------------------------------------------------------------------
+  describe("openSelfHealingContext (shared-browser crash recovery)", () => {
+    // A relaunchable fake: `live[i]` toggles the i-th browser's connectivity.
+    // newContext throws the raw "has been closed" once its browser is dead.
+    function makeRelaunchable(opts: {
+      // How many contexts the CURRENT browser opens before it "crashes".
+      opensBeforeCrash: number;
+    }) {
+      let generation = 0;
+      let opensOnCurrent = 0;
+      let connected = true;
+      const relaunchLog: number[] = [];
+      const build = (): GuardableBrowser => ({
+        isConnected: () => connected,
+        newContext: async () => {
+          if (!connected) {
+            throw new Error(
+              "browser.newContext: Target page, context or browser has been closed",
+            );
+          }
+          opensOnCurrent += 1;
+          if (opensOnCurrent >= opts.opensBeforeCrash) {
+            // This open is the last before the crash: succeed, then die.
+            connected = false;
+          }
+          return { id: `ctx-gen${generation}-open${opensOnCurrent}` };
+        },
+      });
+      let current = build();
+      return {
+        deps(warnLogger?: {
+          warn(e: string, m?: Record<string, unknown>): void;
+        }): SelfHealDeps<GuardableBrowser> {
+          return {
+            get: () => current,
+            set: (b) => {
+              current = b;
+            },
+            relaunch: async () => {
+              generation += 1;
+              opensOnCurrent = 0;
+              connected = true;
+              relaunchLog.push(generation);
+              current = build();
+              return current;
+            },
+            maxRelaunches: MAX_BROWSER_RELAUNCHES_D6,
+            counter: { relaunches: 0 },
+            logger: warnLogger,
+          };
+        },
+        relaunchLog,
+      };
+    }
+
+    it("relaunches the shared browser and retries the open after a crash", async () => {
+      const warns: string[] = [];
+      const rel = makeRelaunchable({ opensBeforeCrash: 1 });
+      const deps = rel.deps({ warn: (e) => warns.push(e) });
+
+      // First open succeeds (and crashes the browser). Second open would hit a
+      // dead browser under the plain guard; self-heal relaunches + retries.
+      const ctx1 = await openSelfHealingContext<
+        { id: string },
+        GuardableBrowser
+      >(deps);
+      expect(ctx1.id).toContain("gen0");
+      const ctx2 = await openSelfHealingContext<
+        { id: string },
+        GuardableBrowser
+      >(deps);
+      // The second context comes from a RELAUNCHED browser (gen1), proving the
+      // shared ref was swapped and the open retried — no cascade.
+      expect(ctx2.id).toContain("gen1");
+      expect(rel.relaunchLog).toEqual([1]);
+      expect(warns).toContain("probe.e2e-full.browser-relaunch");
+    });
+
+    it("bounds relaunches: a browser that will not stay up degrades to a clean BrowserDisconnectedError", async () => {
+      const warns: string[] = [];
+      // Every launched browser is born already-dead: its start-check refuses to
+      // open (BrowserDisconnectedError), so every attempt triggers a relaunch,
+      // exhausting the bounded budget. `gen` counts relaunches.
+      let gen = 0;
+      const deadBrowser: GuardableBrowser = {
+        isConnected: () => false,
+        newContext: async () => ({}),
+      };
+      const deps: SelfHealDeps<GuardableBrowser> = {
+        get: () => deadBrowser,
+        set: () => {},
+        relaunch: async () => {
+          gen += 1;
+          return deadBrowser;
+        },
+        maxRelaunches: MAX_BROWSER_RELAUNCHES_D6,
+        counter: { relaunches: 0 },
+        logger: { warn: (e) => warns.push(e) },
+      };
+      await expect(openSelfHealingContext(deps)).rejects.toBeInstanceOf(
+        BrowserDisconnectedError,
+      );
+      // Exactly the bounded number of relaunch attempts were made.
+      expect(gen).toBe(MAX_BROWSER_RELAUNCHES_D6);
+      expect(warns).toContain("probe.e2e-full.browser-relaunch-exhausted");
+    });
+
+    it("does NOT relaunch on a transient open error while the browser stays live (no cascade masking)", async () => {
+      let relaunched = false;
+      const deps: SelfHealDeps<never> = {
+        get: () =>
+          ({
+            isConnected: () => true,
+            newContext: async () => {
+              throw new Error("transient open hiccup");
+            },
+          }) as unknown as never,
+        set: () => {},
+        relaunch: async () => {
+          relaunched = true;
+          return undefined as unknown as never;
+        },
+        maxRelaunches: MAX_BROWSER_RELAUNCHES_D6,
+        counter: { relaunches: 0 },
+      };
+      await expect(openSelfHealingContext(deps)).rejects.toThrow(
+        "transient open hiccup",
+      );
+      // A live-browser open error is that feature's own failure — never a
+      // relaunch. The clean error taxonomy for genuine failures is preserved.
+      expect(relaunched).toBe(false);
+    });
+  });
+
+  // --------------------------------------------------------------------
+  // The DRIVER-LEVEL cascade proof. Runs the real multi-feature loop
+  // (createE2eFullDriver) with a launcher that routes every open through the
+  // REAL openSelfHealingContext over a relaunchable raw-browser fake that
+  // crashes after its first context open. This is the same repro surface the
+  // pre-fix integration test above exercises — the ONLY difference is the open
+  // path (openGuardedContext → cascade-red vs openSelfHealingContext →
+  // recover). RED (pre-fix, plain guard): the second feature + aggregate go red
+  // with "shared browser disconnected". GREEN (self-heal): the launcher
+  // relaunches a fresh browser and both features complete.
+  // --------------------------------------------------------------------
+  describe("shared-browser crash self-heal (driver integration)", () => {
+    // A relaunchable raw-browser fake: each browser crashes after
+    // `opensBeforeCrash` context opens; relaunch yields a fresh live browser
+    // that returns already-wrapped E2eFull pages (mirrors the pre-fix
+    // integration test's launcher shape). `launchCount` counts initial +
+    // relaunches so we can assert a relaunch actually happened.
+    function makeRelaunchableRawBrowser(opts: { opensBeforeCrash: number }) {
+      type RawCtx = {
+        newPage: () => Promise<E2eFullPage>;
+        close: () => Promise<void>;
+      };
+      type RawBrowser = GuardableBrowser & { close(): Promise<void> };
+      let launchCount = 0;
+      const build = (): RawBrowser => {
+        let connected = true;
+        let opens = 0;
+        return {
+          isConnected: () => connected,
+          newContext: async (): Promise<RawCtx> => {
+            if (!connected) {
+              throw new Error(
+                "browser.newContext: Target page, context or browser has been closed",
+              );
+            }
+            opens += 1;
+            if (opens >= opts.opensBeforeCrash) connected = false;
+            return {
+              newPage: async () => makePage(),
+              close: async () => {},
+            };
+          },
+          close: async () => {},
+        };
+      };
+      let current = build();
+      launchCount = 1;
+      const counter = { relaunches: 0 };
+      const warns: string[] = [];
+      // A launcher whose newContext routes through the REAL self-heal helper.
+      const launcher = async (): Promise<E2eFullBrowser> => ({
+        async newContext(contextOpts?: {
+          extraHTTPHeaders?: Record<string, string>;
+        }): Promise<E2eFullBrowserContext> {
+          const ctx = await openSelfHealingContext<RawCtx, RawBrowser>(
+            {
+              get: () => current,
+              set: (b) => {
+                current = b;
+              },
+              relaunch: async () => {
+                launchCount += 1;
+                current = build();
+                return current;
+              },
+              maxRelaunches: MAX_BROWSER_RELAUNCHES_D6,
+              counter,
+              logger: { warn: (e) => warns.push(e) },
+            },
+            contextOpts,
+          );
+          return ctx as unknown as E2eFullBrowserContext;
+        },
+        close: () => current.close(),
+      });
+      return {
+        launcher,
+        warns,
+        get launchCount() {
+          return launchCount;
+        },
+      };
+    }
+
+    it("recovers remaining features after the shared browser crashes mid-fanout (cascade stopped)", async () => {
+      registerD5Script(makeScript(["agentic-chat"]));
+      registerD5Script(makeScript(["tool-rendering"]));
+
+      const sideEmits: ProbeResult<E2eFullFeatureSignal>[] = [];
+      const writer: ProbeResultWriter = {
+        write: async (r) => {
+          sideEmits.push(r as ProbeResult<E2eFullFeatureSignal>);
+        },
+      };
+
+      // Crash after the first context open — exactly the byoc burst scenario.
+      const fake = makeRelaunchableRawBrowser({ opensBeforeCrash: 1 });
+
+      const driver = createE2eFullDriver({
+        launcher: fake.launcher,
+        scriptLoader: noopScriptLoader(),
+      });
+
+      const result = await driver.run(makeCtx({ writer }), {
+        key: "e2e_d6:byoc",
+        backendUrl: "https://byoc.example.com",
+        features: ["agentic-chat", "tool-rendering"],
+      });
+
+      // GREEN: with self-heal, the crash is recovered and BOTH features pass —
+      // no cascade. (Pre-fix, the second feature and the aggregate went red
+      // with "shared browser disconnected".)
+      const signal = result.signal as E2eFullAggregateSignal;
+      expect(result.state).toBe("green");
+      expect(signal.passed).toBe(2);
+      expect(signal.failed).toEqual([]);
+      // The browser was relaunched at least once (initial launch + relaunch).
+      expect(fake.launchCount).toBeGreaterThanOrEqual(2);
+      expect(fake.warns).toContain("probe.e2e-full.browser-relaunch");
+
+      // No side row leaked the raw Playwright string.
       for (const emit of sideEmits) {
         const desc = emit.signal?.errorDesc ?? "";
         expect(desc).not.toContain(

--- a/showcase/harness/src/probes/drivers/d6-all-pills.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.ts
@@ -460,35 +460,180 @@ export async function openGuardedContext<C>(
 }
 
 /**
- * Default Playwright-backed launcher. Sets X-AIMock-Strict header at the
- * browser level. Per-context headers (X-AIMock-Context, X-Test-Id) are
- * set per-feature in newContext calls from the feature loop.
+ * Minimal logger shape the self-healing open needs. Structural so the launcher
+ * can pass the probe logger and a unit test can pass a spy.
  */
-const defaultLauncher: E2eFullBrowserLauncher =
-  async (): Promise<E2eFullBrowser> => {
-    const mod = (await import("playwright")) as typeof playwright;
-    const browser = await mod.chromium.launch({
-      headless: true,
-      args: ["--no-sandbox", "--disable-dev-shm-usage"],
-    });
+export interface RelaunchLogger {
+  warn(event: string, meta?: Record<string, unknown>): void;
+}
+
+/**
+ * State/plumbing for the self-healing shared-browser open. The launcher owns a
+ * MUTABLE reference to the single shared browser plus a `relaunch` factory that
+ * opens a fresh Chromium. `get`/`set` read and swap the closed-over reference so
+ * a relaunch is visible to every subsequent feature open (not just the one that
+ * triggered it). `maxRelaunches` bounds the recovery so a browser that will not
+ * stay up can never spin an unbounded relaunch loop.
+ */
+export interface SelfHealDeps<B extends GuardableBrowser> {
+  /** Read the current shared browser handle. */
+  get(): B;
+  /** Swap the shared browser handle to a freshly-launched one. */
+  set(browser: B): void;
+  /** Launch a fresh browser (re-establish the shared ref). */
+  relaunch(): Promise<B>;
+  /** Bound on how many times the shared browser may be relaunched per run. */
+  maxRelaunches: number;
+  /** Shared mutable relaunch counter across all concurrent feature opens. */
+  counter: { relaunches: number };
+  logger?: RelaunchLogger;
+}
+
+/**
+ * Open a context on the shared browser, SELF-HEALING across a crash of that
+ * shared browser.
+ *
+ * `openGuardedContext` (above) makes a single crash CLASSIFIABLE — the failing
+ * feature goes red with a clean `BrowserDisconnectedError` instead of leaking
+ * Playwright's raw "has been closed" string. But it does NOT recover: once the
+ * single shared Chromium crashes mid-fanout (the byoc memory/PID-burst case),
+ * EVERY remaining feature's open hits a dead browser and the whole run cascades
+ * to red/abort (claude-sdk-python collapses 0/40 this way).
+ *
+ * This wrapper closes that gap: when the shared browser is detected
+ * disconnected — either the guard's start-check refuses to open on a dead
+ * process, or a mid-open disconnect surfaces as `BrowserDisconnectedError` —
+ * it RELAUNCHES a fresh Chromium (via `deps.relaunch`), swaps the shared ref
+ * (`deps.set`) so siblings pick up the healthy browser, and RETRIES the open.
+ * The relaunch is bounded by `deps.maxRelaunches` (shared counter across all
+ * concurrent opens) so a browser that refuses to stay up degrades to the
+ * classifiable `BrowserDisconnectedError` rather than an unbounded relaunch
+ * loop. Every relaunch is logged.
+ *
+ * A genuinely-transient open error on a STILL-LIVE browser is surfaced
+ * unchanged by the inner guard — only that one feature fails; no relaunch and
+ * no cascade. So the clean error taxonomy for legitimately-failing features is
+ * preserved.
+ */
+export async function openSelfHealingContext<C, B extends GuardableBrowser>(
+  deps: SelfHealDeps<B>,
+  opts?: { extraHTTPHeaders?: Record<string, string> },
+): Promise<C> {
+  // Loop bound = one initial attempt + up to maxRelaunches recovery attempts.
+  // The shared `counter` is the authoritative budget (so concurrent opens can't
+  // collectively exceed maxRelaunches); `attempt` is a per-call safety stop.
+  for (let attempt = 0; attempt <= deps.maxRelaunches; attempt++) {
+    try {
+      return await openGuardedContext<C>(deps.get(), opts);
+    } catch (err) {
+      // Only a disconnect is self-healable. A transient open error on a live
+      // browser (openGuardedContext re-throws it unchanged) is NOT a disconnect
+      // and must propagate so that one feature fails cleanly without a relaunch.
+      if (!(err instanceof BrowserDisconnectedError)) {
+        throw err;
+      }
+      // Budget check: bail to the classifiable disconnect error once the shared
+      // relaunch budget is exhausted. Concurrent opens share `counter` so the
+      // fleet-wide relaunch count is bounded even under FEATURE_CONCURRENCY_D6
+      // parallel opens.
+      if (deps.counter.relaunches >= deps.maxRelaunches) {
+        deps.logger?.warn("probe.e2e-full.browser-relaunch-exhausted", {
+          relaunches: deps.counter.relaunches,
+          maxRelaunches: deps.maxRelaunches,
+        });
+        throw err;
+      }
+      deps.counter.relaunches += 1;
+      const relaunchSeq = deps.counter.relaunches;
+      deps.logger?.warn("probe.e2e-full.browser-relaunch", {
+        relaunchSeq,
+        maxRelaunches: deps.maxRelaunches,
+        reason: err.message,
+      });
+      let fresh: B;
+      try {
+        fresh = await deps.relaunch();
+      } catch (relaunchErr) {
+        // Relaunch itself failed — nothing recoverable; surface the ORIGINAL
+        // classifiable disconnect (not the relaunch error) so the feature's
+        // red reason stays the clean "shared browser disconnected" sentinel.
+        deps.logger?.warn("probe.e2e-full.browser-relaunch-failed", {
+          relaunchSeq,
+          relaunchErr:
+            relaunchErr instanceof Error
+              ? relaunchErr.message
+              : String(relaunchErr),
+        });
+        throw err;
+      }
+      deps.set(fresh);
+      // Loop retries the open on the freshly-launched browser.
+    }
+  }
+  // maxRelaunches exhausted via the per-call loop bound without a live open.
+  throw new BrowserDisconnectedError(
+    "shared browser disconnected: relaunch budget exhausted",
+  );
+}
+
+/**
+ * Max times the single shared Chromium may be relaunched within one D6 run.
+ * Bounds the self-heal so a browser that will not stay up degrades to a clean
+ * BrowserDisconnectedError rather than an unbounded relaunch loop. Sized to
+ * absorb a small number of independent crashes across a ~40-feature fanout
+ * without masking a systemically-broken browser.
+ */
+export const MAX_BROWSER_RELAUNCHES_D6 = 3;
+
+/**
+ * Build a self-healing single-shared-browser launcher over a `launch` factory
+ * that opens a fresh raw Playwright Browser. Both the driver's `defaultLauncher`
+ * (headless) and the CLI's headed launcher use this so the crash-recovery lives
+ * in ONE place: they differ only in the `launch` factory (headless flag).
+ *
+ * The returned launcher holds a MUTABLE shared browser reference plus a shared
+ * relaunch counter. `newContext` routes every open through
+ * `openSelfHealingContext`, so when the single shared Chromium crashes mid-run
+ * it is relaunched (bounded by MAX_BROWSER_RELAUNCHES_D6) and the open retried,
+ * instead of failing every remaining feature. `close()` closes whatever browser
+ * is CURRENTLY referenced (post-relaunch, this is the healthy one).
+ */
+export function createSelfHealingE2eFullLauncher(
+  launch: () => Promise<playwright.Browser>,
+  logger?: RelaunchLogger,
+  maxRelaunches: number = MAX_BROWSER_RELAUNCHES_D6,
+): E2eFullBrowserLauncher {
+  return async (): Promise<E2eFullBrowser> => {
+    let browser = await launch();
+    const counter = { relaunches: 0 };
+    const selfHeal: SelfHealDeps<playwright.Browser> = {
+      get: () => browser,
+      set: (b) => {
+        browser = b;
+      },
+      relaunch: () => launch(),
+      maxRelaunches,
+      counter,
+      logger,
+    };
     return {
       async newContext(contextOpts?: {
         extraHTTPHeaders?: Record<string, string>;
       }): Promise<E2eFullBrowserContext> {
-        // GUARD: open the context on the shared browser only while it is LIVE,
-        // and convert a mid-open disconnect into a clean BrowserDisconnectedError
-        // instead of leaking Playwright's raw "has been closed" string (which
-        // the feature loop would surface as an opaque driver-error on every
-        // remaining byoc cell). See openGuardedContext for the full rationale.
-        const ctx = await openGuardedContext<playwright.BrowserContext>(
-          browser,
-          {
-            extraHTTPHeaders: {
-              "X-AIMock-Strict": "true",
-              ...contextOpts?.extraHTTPHeaders,
-            },
+        // SELF-HEAL: open the context on the shared browser; if that browser
+        // crashed mid-fanout, relaunch a fresh Chromium (bounded) and retry so
+        // one crash no longer cascades into every remaining feature failing with
+        // a raw "has been closed". A transient open error on a still-live browser
+        // fails only that feature. See openSelfHealingContext for the full model.
+        const ctx = await openSelfHealingContext<
+          playwright.BrowserContext,
+          playwright.Browser
+        >(selfHeal, {
+          extraHTTPHeaders: {
+            "X-AIMock-Strict": "true",
+            ...contextOpts?.extraHTTPHeaders,
           },
-        );
+        });
         return {
           async newPage(): Promise<E2eFullPage> {
             const page = await ctx.newPage();
@@ -558,6 +703,28 @@ const defaultLauncher: E2eFullBrowserLauncher =
       close: () => browser.close(),
     };
   };
+}
+
+/**
+ * Default Playwright-backed launcher (headless). Sets X-AIMock-Strict at the
+ * browser level; per-context headers (X-AIMock-Context, X-Test-Id) are set
+ * per-feature in the feature loop. Self-heals the shared browser on crash via
+ * createSelfHealingE2eFullLauncher. A logger can be threaded so relaunch events
+ * land in the probe log stream; the module-level fallback passes none.
+ */
+export function createDefaultE2eFullLauncher(
+  logger?: RelaunchLogger,
+): E2eFullBrowserLauncher {
+  return createSelfHealingE2eFullLauncher(async () => {
+    const mod = (await import("playwright")) as typeof playwright;
+    return mod.chromium.launch({
+      headless: true,
+      args: ["--no-sandbox", "--disable-dev-shm-usage"],
+    });
+  }, logger);
+}
+
+const defaultLauncher: E2eFullBrowserLauncher = createDefaultE2eFullLauncher();
 
 export function createPooledE2eFullLauncher(
   pool: BrowserPool,

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -163,7 +163,7 @@
         "prod": {
           "effectiveReplicas": 6,
           "numReplicas": 6,
-          "BROWSER_POOL_MAX_CONTEXTS": 40,
+          "BROWSER_POOL_MAX_CONTEXTS": 24,
           "HARNESS_POOL_COUNT": 3,
           "overlapSeconds": 45,
           "drainingSeconds": 180
@@ -171,7 +171,7 @@
         "staging": {
           "effectiveReplicas": 6,
           "numReplicas": 6,
-          "BROWSER_POOL_MAX_CONTEXTS": 40,
+          "BROWSER_POOL_MAX_CONTEXTS": 24,
           "HARNESS_POOL_COUNT": 2,
           "overlapSeconds": 45,
           "drainingSeconds": 180

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -471,8 +471,12 @@ export interface ServiceEntry {
    * These values match CURRENT LIVE REALITY as of 2026-06-26, VERIFIED via the
    * Railway GraphQL `environment.config` staged-config read (both envs carry
    * `deploy.multiRegionConfig = {"us-west2":{"numReplicas":6}}`):
-   *   prod:    effectiveReplicas=6, numReplicas(mirror)=6, BROWSER_POOL_MAX_CONTEXTS=40
-   *   staging: effectiveReplicas=6, numReplicas(mirror)=6, BROWSER_POOL_MAX_CONTEXTS=40
+   *   prod:    effectiveReplicas=6, numReplicas(mirror)=6, BROWSER_POOL_MAX_CONTEXTS=24
+   *   staging: effectiveReplicas=6, numReplicas(mirror)=6, BROWSER_POOL_MAX_CONTEXTS=24
+   *
+   * NOTE: BROWSER_POOL_MAX_CONTEXTS was right-sized 40 → 24 to match the runtime
+   * code default (browser-pool.ts). This is a SOURCE/SSOT change; the runtime
+   * value in Railway is rolled out by a SEPARATE gated deploy.
    *
    * EFFECTIVE FIELD: `effectiveReplicas` models `multiRegionConfig.us-west2.
    * numReplicas` — the field Railway actually honors for this single-region
@@ -757,7 +761,13 @@ export const SERVICES: Record<
         effectiveReplicas: 6,
         // Top-level mirror (equal, single-region).
         numReplicas: 6,
-        BROWSER_POOL_MAX_CONTEXTS: 40,
+        // Right-sized to the code default (browser-pool.ts) of 24, LOWERED from
+        // 40. The SSOT previously over-provisioned at 40 while the runtime code
+        // default fell to 24, so the intended fleet-wide budget (6×40=240) was
+        // ~66% higher than the runtime honors (6×24=144). Aligning the SSOT to
+        // the code default removes that drift. Runtime rollout of this value is
+        // a SEPARATE gated deploy (no variableUpsert here).
+        BROWSER_POOL_MAX_CONTEXTS: 24,
         // INFORMATIONAL ONLY — not a fork factor.
         HARNESS_POOL_COUNT: 3,
         // DEPLOY ROLLOVER (layer c) — pure Railway config, no rolling-restart code.
@@ -773,7 +783,10 @@ export const SERVICES: Record<
         effectiveReplicas: 6,
         // Top-level mirror (equal, single-region).
         numReplicas: 6,
-        BROWSER_POOL_MAX_CONTEXTS: 40,
+        // Right-sized to the code default (browser-pool.ts) of 24, LOWERED from
+        // 40 — see the prod entry above for the drift rationale. Runtime rollout
+        // is a SEPARATE gated deploy (no variableUpsert here).
+        BROWSER_POOL_MAX_CONTEXTS: 24,
         // INFORMATIONAL ONLY — not a fork factor. Live staging value is 2
         // (verified via the variables read); it does not gate the worker count.
         HARNESS_POOL_COUNT: 2,


### PR DESCRIPTION
## Root cause

The D6/D5 e2e run for a showcase integration shares ONE Chromium per service, opening a context per feature concurrently (`FEATURE_CONCURRENCY_D6=4`) on that single shared browser (`defaultLauncher` + the CLI headed launcher — the `--direct`/dev path). Under the fanout's Chromium-spawn / memory-PID burst (heaviest for `byoc`), the shared browser can crash mid-run.

`openGuardedContext` already made that crash **classifiable** — the feature that hits the dead browser gets a clean `BrowserDisconnectedError` instead of Playwright's raw `Target page, context or browser has been closed`. But it did **not recover**: once the shared Chromium was gone, every *remaining* feature open hit a dead browser and the whole run cascaded to red/abort (up to the 600s cap). `claude-sdk-python` collapses to 0/40 this way.

Separately, the fleet was over-provisioned: the SSOT (`railway-envs.ts`) shipped `BROWSER_POOL_MAX_CONTEXTS=40` while the runtime code default had fallen to 24 (`browser-pool.ts`, lowered to cap thread demand under the platform-fixed limit). Intended fleet-wide budget 6×40=240 vs the 6×24=144 the runtime actually honors.

## Fix 1 — self-heal the shared browser on disconnect (the cascade fix)

`showcase/harness/src/probes/drivers/d6-all-pills.ts`

- New `openSelfHealingContext<C, B>` (d6-all-pills.ts:518) wraps `openGuardedContext`. On a detected disconnect (start-check dead **or** mid-open `BrowserDisconnectedError`) it **relaunches** a fresh Chromium, swaps the shared browser ref so sibling features pick up the healthy browser, and **retries** the open. Bounded by `MAX_BROWSER_RELAUNCHES_D6=3` via a **shared counter** across concurrent opens, so a browser that refuses to stay up degrades to a clean `BrowserDisconnectedError` instead of an unbounded relaunch loop. Every relaunch is logged (`probe.e2e-full.browser-relaunch{,-exhausted,-failed}`).
- A transient open error on a **still-live** browser is surfaced unchanged — that one feature fails, no relaunch — so the clean error taxonomy for genuinely-failing features is preserved.
- Crash-recovery now lives in ONE place: `createSelfHealingE2eFullLauncher` (d6-all-pills.ts:601), shared by the headless `defaultLauncher` and the CLI **headed** launcher (`showcase/harness/src/cli/runner.ts`), which previously carried a near-duplicate guarded-open path.

## Fix 2 — right-size the fleet (SSOT only)

`showcase/scripts/railway-envs.ts` — `BROWSER_POOL_MAX_CONTEXTS` 40 → 24 for prod and staging harness-workers (matches the `browser-pool.ts` code default). Regenerated `showcase/scripts/railway-envs.generated.json` via `emit-railway-envs-json.ts` (not by hand).

> **Runtime rollout of the 40 → 24 config is a SEPARATE gated deploy.** This PR is a source/SSOT change ONLY — no `variableUpsert` against Railway, no redeploy.

## Red-green proof (real driver surface)

Driver-level integration test in `d6-all-pills.test.ts` runs the real multi-feature loop (`createE2eFullDriver`) against a relaunchable raw-browser fake that crashes after its first context open (the byoc-burst repro), routing opens through the **real** `openSelfHealingContext`. Same repro surface as the pre-existing pre-fix integration test; the only variable is the open path.

**RED** (pre-fix path — swap the open to plain `openGuardedContext`), same repro:
```
probe.e2e-full.feature-complete ... featureType:"tool-rendering" pass:false
  errorDesc:"shared browser disconnected before context open"
probe.e2e-full.service-complete ... passed:1 failed:1 state:"red"
AssertionError: expected 'red' to be 'green'
```

**GREEN** (self-heal), same repro:
```
probe.e2e-full.feature-complete ... featureType:"agentic-chat"   pass:true
probe.e2e-full.feature-complete ... featureType:"tool-rendering" pass:true
probe.e2e-full.service-complete ... passed:2 failed:0 state:"green"
✓ recovers remaining features after the shared browser crashes mid-fanout (cascade stopped)
```

Plus unit tests on `openSelfHealingContext`: relaunch+retry after a crash; **bounded** relaunch → clean `BrowserDisconnectedError` when the browser won't stay up; **no** relaunch on a transient live-browser error (taxonomy preserved).

### Local gates (all green)
- `vitest run d6-all-pills.test.ts` — **57 passed**
- `vitest run` (scripts: railway-envs + emit-railway-envs) — **119 passed**
- `tsc --noEmit` (harness) — clean
- `tsc -p tsconfig.build.json` (harness) — clean; ESM boot-smoke `import('./dist/orchestrator.js')` — OK
- oxlint + oxfmt — clean on changed files

Two harness test files fail on this branch **and on clean origin/main** (`orchestrator.test.ts` boot/serve mocking, `d5-mapping-drift.test.ts` dashboard-catalog drift) — pre-existing, unrelated to this change.

## Not done here (out of scope / gated)
- No Railway mutation, no redeploy, no issues created. Runtime rollout of the config value is a separate gated deploy the reviewer/owner initiates.
