### PR TITLE
fix(showcase): run dashboard dev on webpack so it resolves the shared cell-model fold

### DIFF
--- a/showcase/shell-dashboard/next.config.ts
+++ b/showcase/shell-dashboard/next.config.ts
@@ -34,6 +34,13 @@ import type { NextConfig } from "next";
  * specifier is requested — the standard bundler complement to TS's
  * NodeNext `.js`-import convention. This covers the `next build` (webpack)
  * path that CI uses.
+ *
+ * NOTE ON DEV: the `dev` script runs plain `next dev` (WEBPACK), not
+ * `next dev --turbopack`. Turbopack has no `resolve.extensionAlias` parity
+ * (Next #82945), so it can't resolve the shared cell-model fold's `.js`→`.ts`
+ * specifiers and dev fails with `Can't resolve './live-status.js'`. Webpack
+ * dev honours the alias above, so `pnpm dev` resolves the fold and serves.
+ * Switch dev back to Turbopack once it ships extensionAlias parity.
  */
 const nextConfig: NextConfig = {
   webpack: (config) => {

--- a/showcase/shell-dashboard/package.json
+++ b/showcase/shell-dashboard/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "postinstall": "cd ../scripts && npm install --no-audit --no-fund --silent",
     "predev": "tsx ../scripts/generate-registry.ts && tsx ../scripts/probe-docs.ts",
-    "dev": "next dev --turbopack --port 3002",
+    "dev": "next dev --port 3002",
     "prebuild": "tsx ../scripts/generate-registry.ts && tsx ../scripts/probe-docs.ts",
     "build": "next build",
     "start": "next start --port 3002",


### PR DESCRIPTION
## Problem

`pnpm dev` on the shell-dashboard fails to start the fold-importing routes:

```
Module not found: Can't resolve './live-status.js'
Module not found: Can't resolve './format-ts.js'
Module not found: Can't resolve './staleness.js'
GET / 500
```

The dashboard re-exports the shared **cell-model fold** from the harness (`showcase/harness/src/shared/cell-model/*.ts`). Those fold files are authored for the harness's pure-Node-ESM runtime, so their internal relative imports carry explicit `.js` extensions (e.g. `import { formatTs } from "./format-ts.js"`) even though they exist on disk as `.ts`. `export *` does not rewrite those internal edges.

`next build` (webpack) already resolves this via the `resolve.extensionAlias` in `next.config.ts` (added in #5955), which tells webpack to try the TS sources for a `.js` specifier. But the `dev` script forced Turbopack (`next dev --turbopack`), and **Turbopack has no `resolve.extensionAlias` parity** ([Next #82945](https://github.com/vercel/next.js/issues/82945)) — so dev couldn't resolve the fold.

## Fix

Drop `--turbopack` from the `dev` script. On Next 15.5.x, `--turbopack` is an explicit opt-in flag (there is no `--webpack` opt-out); plain `next dev` runs **webpack**, which honours the existing `extensionAlias`.

```diff
- "dev": "next dev --turbopack --port 3002",
+ "dev": "next dev --port 3002",
```

`build` is unchanged (`next build` = webpack). A note in `next.config.ts` explains why dev uses webpack.

**Tradeoff:** dev loses Turbopack's faster HMR and falls back to webpack-speed dev until Turbopack ships `extensionAlias` parity (#82945), at which point dev can switch back.

## Red / Green (empirical, this branch)

**Empirical proof of which bundler each command runs** (Next 15.5.15 startup banner):
- `next dev --turbopack` → `▲ Next.js 15.5.15 (Turbopack)`
- `next dev` → `▲ Next.js 15.5.15` (no "(Turbopack)" = webpack)

**RED** — `next dev --turbopack`, `GET /`:
```
▲ Next.js 15.5.15 (Turbopack)
Module not found: Can't resolve './format-ts.js'
Module not found: Can't resolve './live-status.js'
Module not found: Can't resolve './staleness.js'
GET / 500 in 3691ms
```

**GREEN** — `next dev` (webpack), `GET /`:
```
▲ Next.js 15.5.15
✓ Ready in 1124ms
✓ Compiled / in 1948ms (704 modules)
GET / 200 in 2844ms
```
No `Can't resolve`.

**No regression** — `next build` (webpack) still resolves the fold:
```
Creating an optimized production build ...
✓ Compiled successfully in 3.1s
```
(The fold compiles clean under webpack via the unchanged `extensionAlias`.)

## Deploy path is UNAFFECTED

The `dev` script is never in the build or runtime path. `showcase/shell-dashboard/Dockerfile` builds with `npx next build` (webpack) and serves with `npx next start`. This change touches only local `pnpm dev` — the built/deployed dashboard image is byte-for-byte identical.
