### PR TITLE
fix(vue-demo): use v2 entrypoint and BuiltInAgent

### DIFF
--- a/examples/v2/vue/demo/pages/a2ui-catalog.vue
+++ b/examples/v2/vue/demo/pages/a2ui-catalog.vue
@@ -3,7 +3,7 @@ import {
   CopilotChat,
   CopilotKitProvider,
   vueBasicCatalog,
-} from "@copilotkit/vue";
+} from "@copilotkit/vue/v2";
 
 // Catalog-on-provider path (#5774): the runtime at /api/copilotkit-catalog has
 // NO a2ui config. A2UI must switch on purely because we pass a catalog here,

--- a/examples/v2/vue/demo/pages/a2ui-demo.vue
+++ b/examples/v2/vue/demo/pages/a2ui-demo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { CopilotChat, CopilotKitProvider } from "@copilotkit/vue";
+import { CopilotChat, CopilotKitProvider } from "@copilotkit/vue/v2";
 </script>
 
 <template>

--- a/examples/v2/vue/demo/pages/index.vue
+++ b/examples/v2/vue/demo/pages/index.vue
@@ -7,8 +7,8 @@ import {
   useAgentContext,
   useConfigureSuggestions,
   useFrontendTool,
-} from "@copilotkit/vue";
-import type { ToolsMenuItem } from "@copilotkit/vue";
+} from "@copilotkit/vue/v2";
+import type { ToolsMenuItem } from "@copilotkit/vue/v2";
 
 const selectedThreadId = ref<"thread---a" | "thread---b" | "thread---c">(
   "thread---a",

--- a/examples/v2/vue/demo/pages/mcp-apps.vue
+++ b/examples/v2/vue/demo/pages/mcp-apps.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { CopilotKitProvider, CopilotSidebar } from "@copilotkit/vue";
+import { CopilotKitProvider, CopilotSidebar } from "@copilotkit/vue/v2";
 
 const demoCards = Array.from({ length: 4 }, (_unused, index) => index + 1);
 const mcpServerSetup = `git clone https://github.com/modelcontextprotocol/ext-apps

--- a/examples/v2/vue/demo/pages/popup.vue
+++ b/examples/v2/vue/demo/pages/popup.vue
@@ -6,7 +6,7 @@ import {
   CopilotPopup,
   useConfigureSuggestions,
   useFrontendTool,
-} from "@copilotkit/vue";
+} from "@copilotkit/vue/v2";
 
 const popupCards = Array.from({ length: 6 }, (_unused, index) => index + 1);
 

--- a/examples/v2/vue/demo/pages/sidebar.vue
+++ b/examples/v2/vue/demo/pages/sidebar.vue
@@ -6,7 +6,7 @@ import {
   CopilotSidebar,
   useConfigureSuggestions,
   useFrontendTool,
-} from "@copilotkit/vue";
+} from "@copilotkit/vue/v2";
 
 const projectCards = Array.from({ length: 4 }, (_unused, index) => index + 1);
 

--- a/examples/v2/vue/demo/pages/single.vue
+++ b/examples/v2/vue/demo/pages/single.vue
@@ -6,8 +6,8 @@ import {
   CopilotKitProvider,
   useConfigureSuggestions,
   useFrontendTool,
-} from "@copilotkit/vue";
-import type { ToolsMenuItem } from "@copilotkit/vue";
+} from "@copilotkit/vue/v2";
+import type { ToolsMenuItem } from "@copilotkit/vue/v2";
 
 const toolsMenu: (ToolsMenuItem | "-")[] = [
   {

--- a/examples/v2/vue/demo/server/utils/runtime.ts
+++ b/examples/v2/vue/demo/server/utils/runtime.ts
@@ -1,6 +1,6 @@
 import { MCPAppsMiddleware } from "@ag-ui/mcp-apps-middleware";
 import {
-  BasicAgent,
+  BuiltInAgent,
   CopilotRuntime,
   InMemoryAgentRunner,
 } from "@copilotkit/runtime/v2";
@@ -158,7 +158,7 @@ class DemoButtonAgent extends AbstractAgent {
 export const createDefaultRuntime = () =>
   new CopilotRuntime({
     agents: {
-      default: new BasicAgent({
+      default: new BuiltInAgent({
         model: determineModel(),
         prompt: "You are a helpful AI assistant.",
         temperature: 0.7,
@@ -185,7 +185,7 @@ export const createCatalogOnlyRuntime = () =>
   });
 
 export const createMcpRuntime = () => {
-  const agent = new BasicAgent({
+  const agent = new BuiltInAgent({
     model: determineModel(),
     prompt: "You are a helpful AI assistant with access to MCP apps and tools.",
     temperature: 0.7,


### PR DESCRIPTION
## What does this PR do?

Updates the Vue v2 demo to consistently use current v2 APIs:

- imports all Vue demo pages, including the A2UI catalog page, from `@copilotkit/vue/v2`;
- replaces the demo runtime's deprecated `BasicAgent` instances with `BuiltInAgent`.

This is the focused, still-applicable demo correction recovered from #5176. It does not change package exports, public APIs, documentation, or unrelated demo behavior.

## Related PRs and Issues

- Extracts the Vue demo portion of #5176.

## Verification

- `pnpm nx run @copilotkit/vue-demo:lint` passed.
- Manual Vue demo smoke testing passed using the branch's Nx dev server.
- `pnpm nx run @copilotkit/vue-demo:build` completed Nuxt client and server compilation locally, but did not exit during Nitro finalization and was stopped after producing no further output.
- Vue package suite: 1,069 tests passed; two unrelated existing 5-second timeout failures occurred in `CopilotChatMessageView` activity rendering and `CopilotSidebarView` measured-margin coverage.
- `git diff --check` passed.

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] Documentation is not required because this only corrects the existing v2 demo's imports and deprecated runtime construction.
- [x] "Allow edits by maintainers" is checked (lets us help iterate on the PR directly).
