### PR TITLE
fix(core): don't surface a user-initiated Stop as an agent error (#5966)

### DIFF
--- a/packages/core/src/__tests__/core-error-handling.test.ts
+++ b/packages/core/src/__tests__/core-error-handling.test.ts
@@ -73,6 +73,112 @@ describe("CopilotKitCore error handling", () => {
       sub.unsubscribe();
     });
 
+    it("suppresses AGENT_RUN_ERROR_EVENT when the agent emits RUN_ERROR with code 'abort' (user stop, #5966)", async () => {
+      const core = new CopilotKitCore({});
+      const errors: Array<{ code: CopilotKitCoreErrorCode }> = [];
+      const sub = core.subscribe({ onError: (e) => void errors.push(e) });
+
+      const agent = {
+        agentId: "agent-abort",
+        threadId: "t1",
+        messages: [] as any[],
+        state: {},
+        addMessages: (_m: any[]) => {},
+        addMessage: (_m: any) => {},
+        abortRun: () => {},
+        clone: () => agent,
+        subscribe: () => ({ unsubscribe() {} }),
+        async runAgent(_params: any, subscriber?: any) {
+          await subscriber?.onRunErrorEvent?.({
+            event: {
+              type: "RUN_ERROR",
+              threadId: this.threadId,
+              runId: "r1",
+              message: "This operation was aborted",
+              code: "abort",
+              rawEvent: {},
+            } as any,
+            agent: this,
+            messages: this.messages,
+            state: this.state,
+            input: {
+              threadId: this.threadId,
+              runId: "r1",
+              messages: this.messages,
+              state: this.state,
+            },
+          });
+          return { newMessages: [] };
+        },
+      } as any;
+
+      core.addAgent__unsafe_dev_only({ id: agent.agentId, agent });
+      await core.runAgent({ agent });
+
+      expect(
+        errors.some(
+          (e) => e.code === CopilotKitCoreErrorCode.AGENT_RUN_ERROR_EVENT,
+        ),
+      ).toBe(false);
+
+      sub.unsubscribe();
+    });
+
+    it("suppresses AGENT_RUN_ERROR_EVENT for a RUN_ERROR after the run was user-aborted, regardless of code (#5966)", async () => {
+      const core = new CopilotKitCore({});
+      const errors: Array<{ code: CopilotKitCoreErrorCode }> = [];
+      const sub = core.subscribe({ onError: (e) => void errors.push(e) });
+
+      const agent = {
+        agentId: "agent-stopped",
+        threadId: "t1",
+        messages: [] as any[],
+        state: {},
+        addMessages: (_m: any[]) => {},
+        addMessage: (_m: any) => {},
+        abortRun: () => {},
+        clone: () => agent,
+        subscribe: () => ({ unsubscribe() {} }),
+        async runAgent(_params: any, subscriber?: any) {
+          // Simulate the user pressing Stop mid-run. RunHandler intercepts
+          // agent.abortRun to abort its AbortController, so this flips
+          // _runAbortController.signal.aborted before the terminal arrives.
+          this.abortRun();
+          await subscriber?.onRunErrorEvent?.({
+            event: {
+              type: "RUN_ERROR",
+              threadId: this.threadId,
+              runId: "r1",
+              message: "aborted by user",
+              code: "server_error",
+              rawEvent: {},
+            } as any,
+            agent: this,
+            messages: this.messages,
+            state: this.state,
+            input: {
+              threadId: this.threadId,
+              runId: "r1",
+              messages: this.messages,
+              state: this.state,
+            },
+          });
+          return { newMessages: [] };
+        },
+      } as any;
+
+      core.addAgent__unsafe_dev_only({ id: agent.agentId, agent });
+      await core.runAgent({ agent });
+
+      expect(
+        errors.some(
+          (e) => e.code === CopilotKitCoreErrorCode.AGENT_RUN_ERROR_EVENT,
+        ),
+      ).toBe(false);
+
+      sub.unsubscribe();
+    });
+
     it("emits AGENT_THREAD_LOCKED when onRunFailed receives AgentThreadLockedError", async () => {
       const core = new CopilotKitCore({});
       const errors: Array<{

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -1003,6 +1003,19 @@ export class RunHandler {
         });
       },
       onRunErrorEvent: async ({ event }) => {
+        // A user-initiated stop (stopAgent / agent.abortRun) makes the agent
+        // emit a terminal RUN_ERROR — often code "abort" — as its cancellation
+        // signal. That is expected, not a failure: surfacing it would pop an
+        // error banner on Stop (#5966, follow-up to #5812). Mirror the
+        // local-abort suppression on the runAgent/connectAgent paths and skip
+        // it. Prefer the abort controller (the client's own record that it
+        // initiated the stop) over the agent-supplied `code`, which is not
+        // standardized across agents.
+        const runWasAborted = this._runAbortController?.signal.aborted === true;
+        if (runWasAborted || event?.code === "abort") {
+          return;
+        }
+
         const eventError =
           event?.rawEvent instanceof Error
             ? event.rawEvent


### PR DESCRIPTION
Fixes #5966. Follow-up to #5812 / #5885.

## Problem

After #5885 stopped the post-terminal `TEXT_MESSAGE_END` crash, pressing **Stop** no longer breaks the chat — but for an agent that emits a terminal `RUN_ERROR` (code `abort`) as its cancellation signal (e.g. pydantic-ai's `AGUIAdapter`), the client still surfaces that as an **error banner** ("This operation was aborted"). A user-initiated stop is expected cancellation, not a failure.

Traced path (no abort suppression at any hop):
`RUN_ERROR(code:"abort")` → `RunHandler.onRunErrorEvent` (`run-handler.ts`) → `emitAgentError(AGENT_RUN_ERROR_EVENT)` → `onError` → CopilotChat/react-ui `triggerChatError` → banner. The only existing abort suppression is for the *local* fetch-abort rejection (`run-handler.ts:318`), a different path.

## Fix

Suppress the error emission in `onRunErrorEvent` when the run was user-aborted — mirroring the local-abort suppression already on the `runAgent`/`connectAgent` paths:

```ts
const runWasAborted = this._runAbortController?.signal.aborted === true;
if (runWasAborted || event?.code === "abort") {
  return;
}
```

Prefers the client's own `_runAbortController.signal.aborted` (robust — the agent-supplied `code` isn't standardized across agents; the `code:"abort"` in the repro comes from the agent, not CopilotKit) with `code === "abort"` as a secondary signal. Normal `RUN_ERROR`s are unaffected.

## Testing

- **TDD** (`core-error-handling.test.ts`): two new tests fail pre-fix and pass after —
  - agent emits `RUN_ERROR` code `"abort"` → no `AGENT_RUN_ERROR_EVENT` surfaced.
  - run user-aborted mid-stream (via `agent.abortRun()`, which RunHandler intercepts to abort the controller) → a subsequent `RUN_ERROR` with a *non-abort* code is still suppressed (exercises the `signal.aborted` path).
- The pre-existing test — normal `RUN_ERROR` (code `"bad_request"`) still emits `AGENT_RUN_ERROR_EVENT` — continues to pass (control against over-suppression).
- Full `@copilotkit/core` suite green: **578/578**. `tsc` 0 errors; `oxlint` 0.

Note: this is a UX/product call (a user Stop shouldn't render as an error). Suppressing in core fixes it for both the default chat banner and app-level `onError` handlers; the run lifecycle still reflects the termination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
