### PR TITLE
fix(channels-intelligence): Teams thread history (getHistory + getMessages)

### DIFF
--- a/packages/channels-intelligence/src/http-transports.test.ts
+++ b/packages/channels-intelligence/src/http-transports.test.ts
@@ -592,6 +592,37 @@ describe("HttpDeliverySource.getHistory", () => {
     expect(calls).toHaveLength(1);
   });
 
+  it("sends the Teams-shaped query (adapter/tenantId/conversationId) for a teams route", async () => {
+    const { calls } = stubGlobalFetch((url) => {
+      expect(url).toBe(
+        "http://x/api/channels/history?adapter=teams&tenantId=tenant-1&conversationId=19%3Ac%40thread.tacv2%3Bmessageid%3D1&limit=5",
+      );
+      return { json: { messages: [{ id: "m1", role: "user", text: "hi" }] } };
+    });
+    const src = new HttpDeliverySource(cfg({}));
+    const history = await src.getHistory(
+      {
+        adapter: "teams",
+        tenantId: "tenant-1",
+        conversationId: "19:c@thread.tacv2;messageid=1",
+      } as unknown as Parameters<typeof src.getHistory>[0],
+      5,
+    );
+    expect(history).toEqual([{ id: "m1", role: "user", content: "hi" }]);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("returns [] for a teams route missing tenantId/conversationId (no request)", async () => {
+    const { calls } = stubGlobalFetch(() => ({ json: { messages: [] } }));
+    const src = new HttpDeliverySource(cfg({}));
+    const history = await src.getHistory(
+      { adapter: "teams" } as unknown as Parameters<typeof src.getHistory>[0],
+      5,
+    );
+    expect(history).toEqual([]);
+    expect(calls).toHaveLength(0);
+  });
+
   it("hydrates a historical file ref into content parts (text inline + image data part)", async () => {
     const png = new Uint8Array([1, 2, 3, 4]);
     stubGlobalFetch((url) => {

--- a/packages/channels-intelligence/src/http-transports.ts
+++ b/packages/channels-intelligence/src/http-transports.ts
@@ -627,24 +627,46 @@ export class HttpDeliverySource implements DeliverySource {
     replyTarget: EgressRoute,
     limit: number,
   ): Promise<AgentMessage[]> {
-    // Slack-shaped for the V1 slice; `EgressRoute` is opaque, so a second
-    // adapter would need its own route→query mapping here.
+    // Provider-specific history query. `EgressRoute` is opaque, so each adapter
+    // maps its route → app-api's `/api/channels/history` query here, mirroring
+    // `conversationKeyFromReplyTarget`'s per-adapter switch. Slack keys off
+    // `threadTs`; Teams off `tenantId`+`conversationId` (matching app-api's
+    // `teams:{tenantId}:{conversationId}` thread_key). A turn with no thread
+    // anchor has no prior history to look up, so return `[]`.
     const rt = replyTarget as
-      | { teamId?: string; channel?: string; threadTs?: string }
+      | {
+          adapter?: string;
+          teamId?: string;
+          channel?: string;
+          threadTs?: string;
+          tenantId?: string;
+          conversationId?: string;
+        }
       | undefined;
-    if (!rt?.threadTs) return [];
+    let qs: URLSearchParams;
+    if (rt?.adapter === "teams") {
+      if (!rt.tenantId || !rt.conversationId) return [];
+      qs = new URLSearchParams({
+        adapter: "teams",
+        tenantId: rt.tenantId,
+        conversationId: rt.conversationId,
+        limit: String(limit),
+      });
+    } else {
+      if (!rt?.threadTs) return [];
+      qs = new URLSearchParams({
+        teamId: rt.teamId ?? "",
+        channel: rt.channel ?? "",
+        threadTs: rt.threadTs,
+        limit: String(limit),
+      });
+    }
     try {
       const gfetch = (globalThis as unknown as { fetch?: typeof fetch }).fetch;
       if (!gfetch) {
         this.cfg.log?.("intelligence history fetch: no global fetch available");
         return [];
       }
-      const qs = new URLSearchParams({
-        teamId: rt.teamId ?? "",
-        channel: rt.channel ?? "",
-        threadTs: rt.threadTs,
-        limit: String(limit),
-      });
       const url = `${this.cfg.baseUrl}/api/channels/history?${qs.toString()}`;
       const res = await gfetch(url, {
         method: "GET",

--- a/packages/channels-intelligence/src/intelligence-adapter.test.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.test.ts
@@ -474,6 +474,53 @@ describe("intelligenceAdapter — conversation-history seeding", () => {
     expect(agent.messages).toEqual(source.history);
   });
 
+  it("getMessages maps history (string + content-part array) to ThreadMessage[]", async () => {
+    const source = new InMemoryDeliverySource();
+    source.history = [
+      { id: "h1", role: "user", content: "hi there" },
+      {
+        id: "h2",
+        role: "assistant",
+        content: [
+          { type: "text", text: "part one" },
+          {
+            type: "image",
+            source: { type: "data", value: "x", mimeType: "image/png" },
+          },
+          { type: "text", text: "part two" },
+        ],
+      },
+    ] as unknown as typeof source.history;
+    const adapter = intelligenceAdapter({
+      source,
+      egress: new InMemoryEgressSink(),
+    });
+
+    const messages = await adapter.getMessages(target);
+
+    expect(messages).toEqual([
+      // string content → text; role 'user' → isBot false, user 'user'.
+      { text: "hi there", isBot: false, user: { id: "user", name: "user" } },
+      // content-part array → text parts joined; the non-text (image) part
+      // contributes an empty string (hence the double space); assistant → bot.
+      {
+        text: "part one  part two",
+        isBot: true,
+        user: { id: "bot", name: "bot" },
+      },
+    ]);
+  });
+
+  it("getMessages returns [] when the transport has no getHistory", async () => {
+    const source = new InMemoryDeliverySource();
+    delete (source as { getHistory?: unknown }).getHistory;
+    const adapter = intelligenceAdapter({
+      source,
+      egress: new InMemoryEgressSink(),
+    });
+    expect(await adapter.getMessages(target)).toEqual([]);
+  });
+
   it("unwraps the ChannelReplyTarget to the raw route and defaults historyLimit to 20", async () => {
     const source = new InMemoryDeliverySource();
     const adapter = intelligenceAdapter({

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -3,6 +3,7 @@ import type {
   BotNode,
   MessageRef,
   PlatformUser,
+  ThreadMessage,
 } from "@copilotkit/channels-ui";
 import type {
   StateStore,
@@ -190,6 +191,47 @@ export class IntelligenceAdapter implements PlatformAdapter {
       (agent as unknown as { messages: AgentMessage[] }).messages = history;
       return { agent };
     },
+  };
+
+  /**
+   * Backs `thread.getMessages()` — e.g. the `read_thread` tool — on the managed
+   * path by reading the reconstructed thread history via the transport's
+   * `getHistory` and mapping it to the {@link ThreadMessage} shape. Without it
+   * the base `Thread.getMessages()` returns `[]`, so tools that inspect the
+   * thread (summaries, "what was in the image") see no messages even though
+   * history exists. Mirrors {@link conversationStore}'s seeding read; the
+   * `route` is the opaque {@link EgressRoute} threaded through {@link ReplyTarget}.
+   * Best-effort: a `getHistory` failure degrades to `[]` (no thrown error).
+   */
+  getMessages = async (target: ReplyTarget): Promise<ThreadMessage[]> => {
+    const route = (target as ChannelReplyTarget).route;
+    let history: AgentMessage[] = [];
+    try {
+      history =
+        ((await this.source?.getHistory?.(
+          route,
+          this.opts.historyLimit ?? 20,
+        )) as AgentMessage[] | undefined) ?? [];
+    } catch {
+      history = [];
+    }
+    return history.map((m) => {
+      const content = m.content as unknown;
+      const text =
+        typeof content === "string"
+          ? content
+          : Array.isArray(content)
+            ? content
+                .map((part) =>
+                  typeof part === "string"
+                    ? part
+                    : ((part as { text?: string } | null)?.text ?? ""),
+                )
+                .join(" ")
+            : "";
+      const who = m.role === "user" ? "user" : "bot";
+      return { text, isBot: m.role !== "user", user: { id: who, name: who } };
+    });
   };
 
   /** Persistence supplied by the Channel transport (Intelligence-backed); picked

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -212,7 +212,15 @@ export class IntelligenceAdapter implements PlatformAdapter {
           route,
           this.opts.historyLimit ?? 20,
         )) as AgentMessage[] | undefined) ?? [];
-    } catch {
+    } catch (err) {
+      // HttpDeliverySource.getHistory already swallows its own fetch failures,
+      // so this outer catch only fires on an UNEXPECTED throw — log it (matching
+      // conversationStore.getOrCreate's seeding path) rather than degrading to
+      // [] silently.
+      this.opts.config?.log?.(
+        "intelligence getMessages failed; returning no history",
+        err,
+      );
       history = [];
     }
     return history.map((m) => {
@@ -229,8 +237,9 @@ export class IntelligenceAdapter implements PlatformAdapter {
                 )
                 .join(" ")
             : "";
-      const who = m.role === "user" ? "user" : "bot";
-      return { text, isBot: m.role !== "user", user: { id: who, name: who } };
+      const isBot = m.role !== "user";
+      const who = isBot ? "bot" : "user";
+      return { text, isBot, user: { id: who, name: who } };
     });
   };
 


### PR DESCRIPTION
## Problem
On the managed Teams path the agent always reported "no earlier messages" / "I don't see the image in this thread." `HttpDeliverySource.getHistory` was **Slack-only**: it keyed off `threadTs` and returned `[]` for any route without one. A Teams route is `{ adapter: 'teams', tenantId, conversationId }` (no `threadTs`), so it short-circuited *before making any request* — starving **both** history mechanisms on Teams:
- `agent.messages` seeding (`conversationStore.getOrCreate`), and
- the `read_thread` tool (via `thread.getMessages()`).

## Fix
- **`getHistory` is now adapter-aware** (mirrors `conversationKeyFromReplyTarget`'s per-adapter switch): Slack keys off `teamId`/`channel`/`threadTs`; Teams sends `adapter=teams` + `tenantId` + `conversationId`, matching app-api's `teams:{tenantId}:{conversationId}` thread_key. app-api's `/api/channels/history` route already accepts this shape. **Slack query and order are unchanged.**
- **Add `getMessages` to the adapter** so `thread.getMessages()` (the `read_thread` tool) reads reconstructed history via the transport and maps it to `ThreadMessage[]`. Without it `Thread.getMessages()` returns `[]` and thread-reading tools (summaries, "what was in the image") see nothing even when history exists.

## Tests
- New: Teams-shaped `getHistory` query, and the missing-`tenantId`/`conversationId` short-circuit (no request).
- All 115 `channels-intelligence` tests pass; `check-types` clean.

## Notes
Verified end-to-end against a live managed Teams bot as a dist patch before porting to source (history seeding + `read_thread` both start returning the thread's messages). The app-api counterpart (Teams ingress: reactions, inline-media/Graph file ingest, slash commands) is a separate PR in the Intelligence repo.