### PR TITLE
fix(showcase): emit A2UI v0.9 nested operations from TS builders (Python/TS parity)

### DIFF
--- a/showcase/aimock/d6/ag2/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/ag2/gen-ui-a2ui-fixed.json
@@ -1,0 +1,37 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for ag2 / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-14"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill — 'Find me a flight from SFO to JFK on United for $289.' The ag2 backend calls OpenAI with the `display_flight` tool; the tool emits an a2ui_operations container (v0.9 shape) via TOOL_CALL_RESULT which the runtime A2UI middleware detects and forwards to the frontend renderer (Card renderer with data-testid='a2ui-fixed-card'). Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "ag2"
+      },
+      "response": {
+        "content": "Here is the SFO to JFK flight on United.",
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_ag2_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing, preventing a tool-invocation loop.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "ag2"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/agno/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/agno/gen-ui-a2ui-fixed.json
@@ -1,0 +1,37 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for agno / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-14"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill — 'Find me a flight from SFO to JFK on United for $289.' The agno backend calls OpenAI with the `display_flight` tool; the tool emits an a2ui_operations container (v0.9 shape) via TOOL_CALL_RESULT which the runtime A2UI middleware detects and forwards to the frontend renderer (Card renderer with data-testid='a2ui-fixed-card'). Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "agno"
+      },
+      "response": {
+        "content": "Here is the SFO to JFK flight on United.",
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_agno_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing, preventing a tool-invocation loop.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "agno"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/claude-sdk-typescript/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/claude-sdk-typescript/gen-ui-a2ui-fixed.json
@@ -1,0 +1,37 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for claude-sdk-typescript / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-14"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill — 'Find me a flight from SFO to JFK on United for $289.' The claude-sdk-typescript backend calls the LLM with the `display_flight` tool; the tool emits an a2ui_operations container (v0.9 shape) via TOOL_CALL_RESULT which the runtime A2UI middleware detects and forwards to the frontend renderer (Card renderer with data-testid='a2ui-fixed-card'). Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "claude-sdk-typescript"
+      },
+      "response": {
+        "content": "Here is the SFO to JFK flight on United.",
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_claude_sdk_typescript_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing, preventing a tool-invocation loop.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "claude-sdk-typescript"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/langgraph-fastapi/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/langgraph-fastapi/gen-ui-a2ui-fixed.json
@@ -1,0 +1,37 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for langgraph-fastapi / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-14"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill — 'Find me a flight from SFO to JFK on United for $289.' The langgraph-fastapi backend calls OpenAI with the `display_flight` tool; the tool emits an a2ui_operations container (v0.9 shape) via TOOL_CALL_RESULT which the runtime A2UI middleware detects and forwards to the frontend renderer (Card renderer with data-testid='a2ui-fixed-card'). Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "langgraph-fastapi"
+      },
+      "response": {
+        "content": "Here is the SFO to JFK flight on United.",
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_langgraph_fastapi_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing, preventing a tool-invocation loop.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "langgraph-fastapi"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/langgraph-python/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/langgraph-python/gen-ui-a2ui-fixed.json
@@ -1,0 +1,37 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for langgraph-python / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-14"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill — 'Find me a flight from SFO to JFK on United for $289.' The langgraph-python backend calls OpenAI with the `display_flight` tool; the tool emits an a2ui_operations container (v0.9 shape) via TOOL_CALL_RESULT which the runtime A2UI middleware detects and forwards to the frontend renderer (Card renderer with data-testid='a2ui-fixed-card'). Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "langgraph-python"
+      },
+      "response": {
+        "content": "Here is the SFO to JFK flight on United.",
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_langgraph_python_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing, preventing a tool-invocation loop.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "langgraph-python"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/langgraph-typescript/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/langgraph-typescript/gen-ui-a2ui-fixed.json
@@ -1,0 +1,37 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for langgraph-typescript / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-14"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill — 'Find me a flight from SFO to JFK on United for $289.' The langgraph-typescript backend calls OpenAI with the `display_flight` tool; the tool emits an a2ui_operations container (v0.9 shape) via TOOL_CALL_RESULT which the runtime A2UI middleware detects and forwards to the frontend renderer (Card renderer with data-testid='a2ui-fixed-card'). Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "langgraph-typescript"
+      },
+      "response": {
+        "content": "Here is the SFO to JFK flight on United.",
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_langgraph_typescript_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing, preventing a tool-invocation loop.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "langgraph-typescript"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/llamaindex/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/llamaindex/gen-ui-a2ui-fixed.json
@@ -1,0 +1,37 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for llamaindex / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-14"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill — 'Find me a flight from SFO to JFK on United for $289.' The llamaindex backend calls OpenAI with the `display_flight` tool; the tool emits an a2ui_operations container (v0.9 shape) via TOOL_CALL_RESULT which the runtime A2UI middleware detects and forwards to the frontend renderer (Card renderer with data-testid='a2ui-fixed-card'). Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "llamaindex"
+      },
+      "response": {
+        "content": "Here is the SFO to JFK flight on United.",
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_llamaindex_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing, preventing a tool-invocation loop.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "llamaindex"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/mastra/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/mastra/gen-ui-a2ui-fixed.json
@@ -1,0 +1,123 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for mastra / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill via weatherAgent/generate_a2ui)",
+    "created": "2026-07-14",
+    "note": "mastra a2ui_pattern is llm-driven — weatherAgent calls generate_a2ui (llm-driven pattern). generate_a2ui internally forces render_a2ui and returns a2ui_operations. Three legs: leg-1 (weatherAgent outer call, hasToolResult:false) returns generate_a2ui with valid messages arg; leg-2 (inner forced render_a2ui call, toolName:render_a2ui) returns the full flight-card component tree; leg-3 (weatherAgent follow-up, hasToolResult:true) returns narration text."
+  },
+  "fixtures": [
+    {
+      "_comment": "Leg-1: weatherAgent outer call (first turn, no tool results yet) — 'Find me a flight from SFO to JFK on United for $289.' The agent calls generate_a2ui with the conversation messages. messages must be non-empty so generateA2uiTool.execute() does not throw on .map(). toolName:generate_a2ui + hasToolResult:false together discriminate from (a) the secondary render_a2ui call (leg-2) which has render_a2ui in tools, and (b) the follow-up narration call (leg-3, hasToolResult:true).",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "toolName": "generate_a2ui",
+        "hasToolResult": false,
+        "context": "mastra"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_mastra_sfo_jfk_001",
+            "name": "generate_a2ui",
+            "arguments": "{\"messages\":[{\"role\":\"user\",\"content\":\"Find me a flight from SFO to JFK on United for $289.\"}],\"contextEntries\":[]}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Leg-2: secondary LLM call inside generateA2uiTool — toolChoice forces render_a2ui. aimock intercepts via toolName:render_a2ui. Returns the 12-node fixed flight-card component tree: Card > Column > [Title, Row[Airport,Arrow,Airport], Row[AirlineBadge,PriceTag], Button > Text]. catalogId must match the registered catalog (copilotkit://flight-fixed-catalog). Literal text fields ('Flight Details', 'SFO', 'JFK', 'Book flight') are what the spec asserts.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "toolName": "render_a2ui",
+        "context": "mastra"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_mastra_render_001",
+            "name": "render_a2ui",
+            "arguments": {
+              "surfaceId": "flight-fixed-surface",
+              "catalogId": "copilotkit://flight-fixed-catalog",
+              "components": [
+                {
+                  "id": "root",
+                  "component": "Card",
+                  "child": "content"
+                },
+                {
+                  "id": "content",
+                  "component": "Column",
+                  "children": ["title", "route", "meta", "bookButton"],
+                  "gap": 12
+                },
+                {
+                  "id": "title",
+                  "component": "Title",
+                  "text": "Flight Details"
+                },
+                {
+                  "id": "route",
+                  "component": "Row",
+                  "children": ["from", "arrow", "to"],
+                  "gap": 0
+                },
+                {
+                  "id": "from",
+                  "component": "Airport",
+                  "code": "SFO"
+                },
+                {
+                  "id": "arrow",
+                  "component": "Arrow"
+                },
+                {
+                  "id": "to",
+                  "component": "Airport",
+                  "code": "JFK"
+                },
+                {
+                  "id": "meta",
+                  "component": "Row",
+                  "children": ["airline", "price"],
+                  "gap": 8
+                },
+                {
+                  "id": "airline",
+                  "component": "AirlineBadge",
+                  "name": "United"
+                },
+                {
+                  "id": "price",
+                  "component": "PriceTag",
+                  "amount": "$289"
+                },
+                {
+                  "id": "bookButton",
+                  "component": "Button",
+                  "child": "bookButtonLabel"
+                },
+                {
+                  "id": "bookButtonLabel",
+                  "component": "Text",
+                  "text": "Book flight"
+                }
+              ],
+              "data": {}
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Leg-3: weatherAgent follow-up after generate_a2ui has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing, preventing a tool-invocation loop.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "mastra"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/ms-agent-python/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/ms-agent-python/gen-ui-a2ui-fixed.json
@@ -1,0 +1,37 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for ms-agent-python / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-14"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill — 'Find me a flight from SFO to JFK on United for $289.' The ms-agent-python backend calls OpenAI with the `display_flight` tool; the tool emits an a2ui_operations container (v0.9 shape) via TOOL_CALL_RESULT which the runtime A2UI middleware detects and forwards to the frontend renderer (Card renderer with data-testid='a2ui-fixed-card'). Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "ms-agent-python"
+      },
+      "response": {
+        "content": "Here is the SFO to JFK flight on United.",
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_ms_agent_python_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing, preventing a tool-invocation loop.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "ms-agent-python"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/pydantic-ai/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/pydantic-ai/gen-ui-a2ui-fixed.json
@@ -1,0 +1,37 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for pydantic-ai / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-14"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill — 'Find me a flight from SFO to JFK on United for $289.' The pydantic-ai backend calls OpenAI with the `display_flight` tool; the tool emits an a2ui_operations container (v0.9 shape) via TOOL_CALL_RESULT which the runtime A2UI middleware detects and forwards to the frontend renderer (Card renderer with data-testid='a2ui-fixed-card'). Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "pydantic-ai"
+      },
+      "response": {
+        "content": "Here is the SFO to JFK flight on United.",
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_pydantic_ai_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing, preventing a tool-invocation loop.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "pydantic-ai"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/strands-typescript/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/strands-typescript/gen-ui-a2ui-fixed.json
@@ -1,0 +1,37 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for strands-typescript / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-14"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill — 'Find me a flight from SFO to JFK on United for $289.' The strands-typescript backend calls the LLM with the `display_flight` tool; the tool emits an a2ui_operations container (v0.9 shape) via TOOL_CALL_RESULT which the runtime A2UI middleware detects and forwards to the frontend renderer (Card renderer with data-testid='a2ui-fixed-card'). Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "strands-typescript"
+      },
+      "response": {
+        "content": "Here is the SFO to JFK flight on United.",
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_strands_typescript_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing, preventing a tool-invocation loop.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "strands-typescript"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d6/strands/gen-ui-a2ui-fixed.json
+++ b/showcase/aimock/d6/strands/gen-ui-a2ui-fixed.json
@@ -1,0 +1,37 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for strands / gen-ui-a2ui-fixed (a2ui-fixed-schema flight card pill)",
+    "created": "2026-07-14"
+  },
+  "fixtures": [
+    {
+      "_comment": "a2ui-fixed-schema pill — 'Find me a flight from SFO to JFK on United for $289.' The strands backend calls the LLM with the `display_flight` tool; the tool emits an a2ui_operations container (v0.9 shape) via TOOL_CALL_RESULT which the runtime A2UI middleware detects and forwards to the frontend renderer (Card renderer with data-testid='a2ui-fixed-card'). Anchored on hasToolResult:false so it fires on the initial routing turn before any tool result is observed.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": false,
+        "context": "strands"
+      },
+      "response": {
+        "content": "Here is the SFO to JFK flight on United.",
+        "toolCalls": [
+          {
+            "id": "call_a2ui_fixed_strands_sfo_jfk_001",
+            "name": "display_flight",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\",\"airline\":\"United\",\"price\":\"$289\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "a2ui-fixed-schema pill — follow-up content after display_flight has returned its a2ui_operations container (flight card already rendered). Anchored on hasToolResult:true so it fires AFTER the tool result instead of re-routing, preventing a tool-invocation loop.",
+      "match": {
+        "userMessage": "Find me a flight from SFO to JFK on United for $289",
+        "hasToolResult": true,
+        "context": "strands"
+      },
+      "response": {
+        "content": "Here's your flight: United Airlines, SFO → JFK, $289 — rendered in the card above. Tap \"Book flight\" to confirm."
+      }
+    }
+  ]
+}

--- a/showcase/integrations/claude-sdk-typescript/shared-tools/__tests__/generate-a2ui.test.ts
+++ b/showcase/integrations/claude-sdk-typescript/shared-tools/__tests__/generate-a2ui.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi } from "vitest";
 import {
   generateA2uiImpl,
   buildA2uiOperationsFromToolCall,
-  RENDER_A2UI_TOOL_SCHEMA,
   CUSTOM_CATALOG_ID,
 } from "../generate-a2ui";
 
@@ -46,18 +45,24 @@ describe("generateA2uiImpl", () => {
 });
 
 describe("buildA2uiOperationsFromToolCall", () => {
-  it("builds create_surface + update_components", () => {
+  it("builds createSurface + updateComponents in v0.9 nested format", () => {
     const result = buildA2uiOperationsFromToolCall({
       surfaceId: "s1",
       catalogId: "cat1",
       components: [{ id: "root", component: "Title" }],
     });
     expect(result.a2ui_operations).toHaveLength(2);
-    expect(result.a2ui_operations[0].type).toBe("create_surface");
-    expect(result.a2ui_operations[1].type).toBe("update_components");
+    expect(result.a2ui_operations[0]).toMatchObject({
+      version: "v0.9",
+      createSurface: { surfaceId: "s1", catalogId: "cat1" },
+    });
+    expect(result.a2ui_operations[1]).toMatchObject({
+      version: "v0.9",
+      updateComponents: { surfaceId: "s1" },
+    });
   });
 
-  it("includes update_data_model when data provided", () => {
+  it("includes updateDataModel when data provided", () => {
     const result = buildA2uiOperationsFromToolCall({
       surfaceId: "s1",
       catalogId: "cat1",
@@ -65,13 +70,20 @@ describe("buildA2uiOperationsFromToolCall", () => {
       data: { key: "value" },
     });
     expect(result.a2ui_operations).toHaveLength(3);
-    expect(result.a2ui_operations[2].type).toBe("update_data_model");
+    expect(result.a2ui_operations[2]).toMatchObject({
+      version: "v0.9",
+      updateDataModel: { surfaceId: "s1", path: "/", value: { key: "value" } },
+    });
   });
 
   it("defaults surfaceId and catalogId", () => {
     const result = buildA2uiOperationsFromToolCall({ components: [] });
-    expect(result.a2ui_operations[0].surfaceId).toBe("dynamic-surface");
-    expect(result.a2ui_operations[0].catalogId).toBe(CUSTOM_CATALOG_ID);
+    const op0 = result.a2ui_operations[0] as {
+      version: string;
+      createSurface: { surfaceId: string; catalogId: string };
+    };
+    expect(op0.createSurface.surfaceId).toBe("dynamic-surface");
+    expect(op0.createSurface.catalogId).toBe(CUSTOM_CATALOG_ID);
   });
 
   it("warns on empty components", () => {
@@ -86,5 +98,109 @@ describe("buildA2uiOperationsFromToolCall", () => {
       "s1",
     );
     spy.mockRestore();
+  });
+});
+
+// Anti-drift parity guard. The TS builder MUST emit the same v0.9 NESTED
+// operation shape as the Python source of truth in
+// showcase/shared/python/tools/generate_a2ui.py
+// (build_a2ui_operations_from_tool_call). A2UI consumers process operations
+// by their nested createSurface/updateComponents/updateDataModel keys; the
+// legacy FLAT shape (`{ type: "create_surface", surfaceId }`) is not
+// processed as a valid nested operation, so the surface's schema and
+// components are never applied. This test would have caught the Python/TS
+// drift: it FAILS against the flat builder and PASSES against the nested one.
+describe("buildA2uiOperationsFromToolCall v0.9 nested-shape parity guard", () => {
+  it("emits the nested v0.9 shape and NEVER the legacy flat `type` shape", () => {
+    const { a2ui_operations: ops } = buildA2uiOperationsFromToolCall({
+      surfaceId: "s1",
+      catalogId: "cat1",
+      components: [{ id: "root", component: "Title" }],
+      data: { key: "value" },
+    });
+
+    // Every op carries the version tag and one nested operation key —
+    // and NONE of them carry the flat `type` discriminator.
+    for (const op of ops) {
+      const record = op as Record<string, unknown>;
+      expect(record.version).toBe("v0.9");
+      expect(record.type).toBeUndefined();
+      expect(record).not.toHaveProperty("type");
+    }
+
+    // Exact nested keys, mirroring generate_a2ui.py's op list.
+    expect(ops[0]).toMatchObject({
+      version: "v0.9",
+      createSurface: { surfaceId: "s1", catalogId: "cat1" },
+    });
+    expect(ops[1]).toMatchObject({
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "s1",
+        components: [{ id: "root", component: "Title" }],
+      },
+    });
+    expect(ops[2]).toMatchObject({
+      version: "v0.9",
+      updateDataModel: { surfaceId: "s1", path: "/", value: { key: "value" } },
+    });
+
+    // Explicit negative assertions on the exact legacy flat literals so a
+    // regression to the old shape fails loudly rather than silently.
+    expect(JSON.stringify(ops)).not.toContain('"type":"create_surface"');
+    expect(JSON.stringify(ops)).not.toContain('"type":"update_components"');
+    expect(JSON.stringify(ops)).not.toContain('"type":"update_data_model"');
+  });
+});
+
+// Empty-data parity guard. Python uses `if data:`, so an empty dict `{}`
+// (falsy in Python) emits NO updateDataModel op. TS previously used a bare
+// `if (data)`, and `{}` is truthy in JS — that emitted a spurious
+// updateDataModel with `value: {}`, diverging from Python on our own mastra
+// fixture (showcase/aimock/d6/mastra/gen-ui-a2ui-fixed.json records
+// `"data": {}`). The builder now only emits updateDataModel for a non-empty
+// object, matching Python.
+describe("buildA2uiOperationsFromToolCall empty-data parity guard", () => {
+  it("omits updateDataModel when data is an empty object `{}`", () => {
+    const { a2ui_operations: ops } = buildA2uiOperationsFromToolCall({
+      surfaceId: "s1",
+      catalogId: "cat1",
+      components: [{ id: "root", component: "Title" }],
+      data: {},
+    });
+
+    expect(ops).toHaveLength(2);
+    expect(
+      ops.some((op) => "updateDataModel" in (op as Record<string, unknown>)),
+    ).toBe(false);
+    expect(ops[0]).toMatchObject({
+      version: "v0.9",
+      createSurface: { surfaceId: "s1" },
+    });
+    expect(ops[1]).toMatchObject({
+      version: "v0.9",
+      updateComponents: { surfaceId: "s1" },
+    });
+  });
+
+  it("omits updateDataModel when data is absent", () => {
+    const { a2ui_operations: ops } = buildA2uiOperationsFromToolCall({
+      surfaceId: "s1",
+      catalogId: "cat1",
+      components: [{ id: "root", component: "Title" }],
+    });
+
+    // A builder that wrongly emitted updateDataModel for absent data would
+    // produce 3 ops; asserting exactly 2 nested ops (and their keys) makes
+    // this a meaningful count guard rather than a vacuous membership check.
+    expect(ops).toHaveLength(2);
+    expect(ops[0]).toMatchObject({
+      version: "v0.9",
+      createSurface: { surfaceId: "s1" },
+    });
+    expect(ops[1]).toMatchObject({
+      version: "v0.9",
+      updateComponents: { surfaceId: "s1" },
+    });
   });
 });

--- a/showcase/integrations/claude-sdk-typescript/shared-tools/generate-a2ui.ts
+++ b/showcase/integrations/claude-sdk-typescript/shared-tools/generate-a2ui.ts
@@ -60,13 +60,33 @@ export function generateA2uiImpl(input: GenerateA2UIInput): GenerateA2UIResult {
   };
 }
 
-export interface A2UIOperation {
-  type: "create_surface" | "update_components" | "update_data_model";
-  surfaceId: string;
-  catalogId?: string;
-  components?: Array<Record<string, unknown>>;
-  data?: Record<string, unknown>;
-}
+/**
+ * A2UI v0.9 nested operation shape. A2UI consumers process operations by
+ * their nested `createSurface` / `updateComponents` / `updateDataModel`
+ * keys; the legacy flat shape (`{ type: "create_surface", surfaceId }`) is
+ * not processed as a valid nested operation, so the surface's schema and
+ * components are never applied. The operation ENVELOPE shape here mirrors
+ * Python's `build_a2ui_operations_from_tool_call` in
+ * showcase/shared/python/tools/generate_a2ui.py (TS does NOT yet replicate
+ * Python's component sanitization — that's a separate follow-up).
+ */
+export type A2UIOperation =
+  | { version: "v0.9"; createSurface: { surfaceId: string; catalogId: string } }
+  | {
+      version: "v0.9";
+      updateComponents: {
+        surfaceId: string;
+        components: Array<Record<string, unknown>>;
+      };
+    }
+  | {
+      version: "v0.9";
+      updateDataModel: {
+        surfaceId: string;
+        path: string;
+        value: Record<string, unknown>;
+      };
+    };
 
 export function buildA2uiOperationsFromToolCall(
   args: Record<string, unknown>,
@@ -77,6 +97,11 @@ export function buildA2uiOperationsFromToolCall(
   const catalogId = (args.catalogId as string) ?? CUSTOM_CATALOG_ID;
   const components = (args.components as Array<Record<string, unknown>>) ?? [];
   const data = args.data as Record<string, unknown> | undefined;
+  // Python uses `if data:` — an empty dict `{}` is falsy and emits no
+  // updateDataModel op. `{}` is truthy in JS, so guard on a non-empty object
+  // to keep parity with generate_a2ui.py.
+  const hasData =
+    data != null && typeof data === "object" && Object.keys(data).length > 0;
 
   if (components.length === 0) {
     console.warn(
@@ -86,12 +111,15 @@ export function buildA2uiOperationsFromToolCall(
   }
 
   const ops: A2UIOperation[] = [
-    { type: "create_surface", surfaceId, catalogId },
-    { type: "update_components", surfaceId, components },
+    { version: "v0.9", createSurface: { surfaceId, catalogId } },
+    { version: "v0.9", updateComponents: { surfaceId, components } },
   ];
 
-  if (data) {
-    ops.push({ type: "update_data_model", surfaceId, data });
+  if (hasData) {
+    ops.push({
+      version: "v0.9",
+      updateDataModel: { surfaceId, path: "/", value: data },
+    });
   }
 
   return { a2ui_operations: ops };

--- a/showcase/integrations/langgraph-typescript/shared-tools/__tests__/generate-a2ui.test.ts
+++ b/showcase/integrations/langgraph-typescript/shared-tools/__tests__/generate-a2ui.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi } from "vitest";
 import {
   generateA2uiImpl,
   buildA2uiOperationsFromToolCall,
-  RENDER_A2UI_TOOL_SCHEMA,
   CUSTOM_CATALOG_ID,
 } from "../generate-a2ui";
 
@@ -46,18 +45,24 @@ describe("generateA2uiImpl", () => {
 });
 
 describe("buildA2uiOperationsFromToolCall", () => {
-  it("builds create_surface + update_components", () => {
+  it("builds createSurface + updateComponents in v0.9 nested format", () => {
     const result = buildA2uiOperationsFromToolCall({
       surfaceId: "s1",
       catalogId: "cat1",
       components: [{ id: "root", component: "Title" }],
     });
     expect(result.a2ui_operations).toHaveLength(2);
-    expect(result.a2ui_operations[0].type).toBe("create_surface");
-    expect(result.a2ui_operations[1].type).toBe("update_components");
+    expect(result.a2ui_operations[0]).toMatchObject({
+      version: "v0.9",
+      createSurface: { surfaceId: "s1", catalogId: "cat1" },
+    });
+    expect(result.a2ui_operations[1]).toMatchObject({
+      version: "v0.9",
+      updateComponents: { surfaceId: "s1" },
+    });
   });
 
-  it("includes update_data_model when data provided", () => {
+  it("includes updateDataModel when data provided", () => {
     const result = buildA2uiOperationsFromToolCall({
       surfaceId: "s1",
       catalogId: "cat1",
@@ -65,13 +70,20 @@ describe("buildA2uiOperationsFromToolCall", () => {
       data: { key: "value" },
     });
     expect(result.a2ui_operations).toHaveLength(3);
-    expect(result.a2ui_operations[2].type).toBe("update_data_model");
+    expect(result.a2ui_operations[2]).toMatchObject({
+      version: "v0.9",
+      updateDataModel: { surfaceId: "s1", path: "/", value: { key: "value" } },
+    });
   });
 
   it("defaults surfaceId and catalogId", () => {
     const result = buildA2uiOperationsFromToolCall({ components: [] });
-    expect(result.a2ui_operations[0].surfaceId).toBe("dynamic-surface");
-    expect(result.a2ui_operations[0].catalogId).toBe(CUSTOM_CATALOG_ID);
+    const op0 = result.a2ui_operations[0] as {
+      version: string;
+      createSurface: { surfaceId: string; catalogId: string };
+    };
+    expect(op0.createSurface.surfaceId).toBe("dynamic-surface");
+    expect(op0.createSurface.catalogId).toBe(CUSTOM_CATALOG_ID);
   });
 
   it("warns on empty components", () => {
@@ -86,5 +98,109 @@ describe("buildA2uiOperationsFromToolCall", () => {
       "s1",
     );
     spy.mockRestore();
+  });
+});
+
+// Anti-drift parity guard. The TS builder MUST emit the same v0.9 NESTED
+// operation shape as the Python source of truth in
+// showcase/shared/python/tools/generate_a2ui.py
+// (build_a2ui_operations_from_tool_call). A2UI consumers process operations
+// by their nested createSurface/updateComponents/updateDataModel keys; the
+// legacy FLAT shape (`{ type: "create_surface", surfaceId }`) is not
+// processed as a valid nested operation, so the surface's schema and
+// components are never applied. This test would have caught the Python/TS
+// drift: it FAILS against the flat builder and PASSES against the nested one.
+describe("buildA2uiOperationsFromToolCall v0.9 nested-shape parity guard", () => {
+  it("emits the nested v0.9 shape and NEVER the legacy flat `type` shape", () => {
+    const { a2ui_operations: ops } = buildA2uiOperationsFromToolCall({
+      surfaceId: "s1",
+      catalogId: "cat1",
+      components: [{ id: "root", component: "Title" }],
+      data: { key: "value" },
+    });
+
+    // Every op carries the version tag and one nested operation key —
+    // and NONE of them carry the flat `type` discriminator.
+    for (const op of ops) {
+      const record = op as Record<string, unknown>;
+      expect(record.version).toBe("v0.9");
+      expect(record.type).toBeUndefined();
+      expect(record).not.toHaveProperty("type");
+    }
+
+    // Exact nested keys, mirroring generate_a2ui.py's op list.
+    expect(ops[0]).toMatchObject({
+      version: "v0.9",
+      createSurface: { surfaceId: "s1", catalogId: "cat1" },
+    });
+    expect(ops[1]).toMatchObject({
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "s1",
+        components: [{ id: "root", component: "Title" }],
+      },
+    });
+    expect(ops[2]).toMatchObject({
+      version: "v0.9",
+      updateDataModel: { surfaceId: "s1", path: "/", value: { key: "value" } },
+    });
+
+    // Explicit negative assertions on the exact legacy flat literals so a
+    // regression to the old shape fails loudly rather than silently.
+    expect(JSON.stringify(ops)).not.toContain('"type":"create_surface"');
+    expect(JSON.stringify(ops)).not.toContain('"type":"update_components"');
+    expect(JSON.stringify(ops)).not.toContain('"type":"update_data_model"');
+  });
+});
+
+// Empty-data parity guard. Python uses `if data:`, so an empty dict `{}`
+// (falsy in Python) emits NO updateDataModel op. TS previously used a bare
+// `if (data)`, and `{}` is truthy in JS — that emitted a spurious
+// updateDataModel with `value: {}`, diverging from Python on our own mastra
+// fixture (showcase/aimock/d6/mastra/gen-ui-a2ui-fixed.json records
+// `"data": {}`). The builder now only emits updateDataModel for a non-empty
+// object, matching Python.
+describe("buildA2uiOperationsFromToolCall empty-data parity guard", () => {
+  it("omits updateDataModel when data is an empty object `{}`", () => {
+    const { a2ui_operations: ops } = buildA2uiOperationsFromToolCall({
+      surfaceId: "s1",
+      catalogId: "cat1",
+      components: [{ id: "root", component: "Title" }],
+      data: {},
+    });
+
+    expect(ops).toHaveLength(2);
+    expect(
+      ops.some((op) => "updateDataModel" in (op as Record<string, unknown>)),
+    ).toBe(false);
+    expect(ops[0]).toMatchObject({
+      version: "v0.9",
+      createSurface: { surfaceId: "s1" },
+    });
+    expect(ops[1]).toMatchObject({
+      version: "v0.9",
+      updateComponents: { surfaceId: "s1" },
+    });
+  });
+
+  it("omits updateDataModel when data is absent", () => {
+    const { a2ui_operations: ops } = buildA2uiOperationsFromToolCall({
+      surfaceId: "s1",
+      catalogId: "cat1",
+      components: [{ id: "root", component: "Title" }],
+    });
+
+    // A builder that wrongly emitted updateDataModel for absent data would
+    // produce 3 ops; asserting exactly 2 nested ops (and their keys) makes
+    // this a meaningful count guard rather than a vacuous membership check.
+    expect(ops).toHaveLength(2);
+    expect(ops[0]).toMatchObject({
+      version: "v0.9",
+      createSurface: { surfaceId: "s1" },
+    });
+    expect(ops[1]).toMatchObject({
+      version: "v0.9",
+      updateComponents: { surfaceId: "s1" },
+    });
   });
 });

--- a/showcase/integrations/langgraph-typescript/shared-tools/generate-a2ui.ts
+++ b/showcase/integrations/langgraph-typescript/shared-tools/generate-a2ui.ts
@@ -60,13 +60,33 @@ export function generateA2uiImpl(input: GenerateA2UIInput): GenerateA2UIResult {
   };
 }
 
-export interface A2UIOperation {
-  type: "create_surface" | "update_components" | "update_data_model";
-  surfaceId: string;
-  catalogId?: string;
-  components?: Array<Record<string, unknown>>;
-  data?: Record<string, unknown>;
-}
+/**
+ * A2UI v0.9 nested operation shape. A2UI consumers process operations by
+ * their nested `createSurface` / `updateComponents` / `updateDataModel`
+ * keys; the legacy flat shape (`{ type: "create_surface", surfaceId }`) is
+ * not processed as a valid nested operation, so the surface's schema and
+ * components are never applied. The operation ENVELOPE shape here mirrors
+ * Python's `build_a2ui_operations_from_tool_call` in
+ * showcase/shared/python/tools/generate_a2ui.py (TS does NOT yet replicate
+ * Python's component sanitization — that's a separate follow-up).
+ */
+export type A2UIOperation =
+  | { version: "v0.9"; createSurface: { surfaceId: string; catalogId: string } }
+  | {
+      version: "v0.9";
+      updateComponents: {
+        surfaceId: string;
+        components: Array<Record<string, unknown>>;
+      };
+    }
+  | {
+      version: "v0.9";
+      updateDataModel: {
+        surfaceId: string;
+        path: string;
+        value: Record<string, unknown>;
+      };
+    };
 
 export function buildA2uiOperationsFromToolCall(
   args: Record<string, unknown>,
@@ -77,6 +97,11 @@ export function buildA2uiOperationsFromToolCall(
   const catalogId = (args.catalogId as string) ?? CUSTOM_CATALOG_ID;
   const components = (args.components as Array<Record<string, unknown>>) ?? [];
   const data = args.data as Record<string, unknown> | undefined;
+  // Python uses `if data:` — an empty dict `{}` is falsy and emits no
+  // updateDataModel op. `{}` is truthy in JS, so guard on a non-empty object
+  // to keep parity with generate_a2ui.py.
+  const hasData =
+    data != null && typeof data === "object" && Object.keys(data).length > 0;
 
   if (components.length === 0) {
     console.warn(
@@ -86,12 +111,15 @@ export function buildA2uiOperationsFromToolCall(
   }
 
   const ops: A2UIOperation[] = [
-    { type: "create_surface", surfaceId, catalogId },
-    { type: "update_components", surfaceId, components },
+    { version: "v0.9", createSurface: { surfaceId, catalogId } },
+    { version: "v0.9", updateComponents: { surfaceId, components } },
   ];
 
-  if (data) {
-    ops.push({ type: "update_data_model", surfaceId, data });
+  if (hasData) {
+    ops.push({
+      version: "v0.9",
+      updateDataModel: { surfaceId, path: "/", value: data },
+    });
   }
 
   return { a2ui_operations: ops };

--- a/showcase/integrations/mastra/shared-tools/__tests__/generate-a2ui.test.ts
+++ b/showcase/integrations/mastra/shared-tools/__tests__/generate-a2ui.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi } from "vitest";
 import {
   generateA2uiImpl,
   buildA2uiOperationsFromToolCall,
-  RENDER_A2UI_TOOL_SCHEMA,
   CUSTOM_CATALOG_ID,
 } from "../generate-a2ui";
 
@@ -46,18 +45,24 @@ describe("generateA2uiImpl", () => {
 });
 
 describe("buildA2uiOperationsFromToolCall", () => {
-  it("builds create_surface + update_components", () => {
+  it("builds createSurface + updateComponents in v0.9 nested format", () => {
     const result = buildA2uiOperationsFromToolCall({
       surfaceId: "s1",
       catalogId: "cat1",
       components: [{ id: "root", component: "Title" }],
     });
     expect(result.a2ui_operations).toHaveLength(2);
-    expect(result.a2ui_operations[0].type).toBe("create_surface");
-    expect(result.a2ui_operations[1].type).toBe("update_components");
+    expect(result.a2ui_operations[0]).toMatchObject({
+      version: "v0.9",
+      createSurface: { surfaceId: "s1", catalogId: "cat1" },
+    });
+    expect(result.a2ui_operations[1]).toMatchObject({
+      version: "v0.9",
+      updateComponents: { surfaceId: "s1" },
+    });
   });
 
-  it("includes update_data_model when data provided", () => {
+  it("includes updateDataModel when data provided", () => {
     const result = buildA2uiOperationsFromToolCall({
       surfaceId: "s1",
       catalogId: "cat1",
@@ -65,13 +70,20 @@ describe("buildA2uiOperationsFromToolCall", () => {
       data: { key: "value" },
     });
     expect(result.a2ui_operations).toHaveLength(3);
-    expect(result.a2ui_operations[2].type).toBe("update_data_model");
+    expect(result.a2ui_operations[2]).toMatchObject({
+      version: "v0.9",
+      updateDataModel: { surfaceId: "s1", path: "/", value: { key: "value" } },
+    });
   });
 
   it("defaults surfaceId and catalogId", () => {
     const result = buildA2uiOperationsFromToolCall({ components: [] });
-    expect(result.a2ui_operations[0].surfaceId).toBe("dynamic-surface");
-    expect(result.a2ui_operations[0].catalogId).toBe(CUSTOM_CATALOG_ID);
+    const op0 = result.a2ui_operations[0] as {
+      version: string;
+      createSurface: { surfaceId: string; catalogId: string };
+    };
+    expect(op0.createSurface.surfaceId).toBe("dynamic-surface");
+    expect(op0.createSurface.catalogId).toBe(CUSTOM_CATALOG_ID);
   });
 
   it("warns on empty components", () => {
@@ -86,5 +98,109 @@ describe("buildA2uiOperationsFromToolCall", () => {
       "s1",
     );
     spy.mockRestore();
+  });
+});
+
+// Anti-drift parity guard. The TS builder MUST emit the same v0.9 NESTED
+// operation shape as the Python source of truth in
+// showcase/shared/python/tools/generate_a2ui.py
+// (build_a2ui_operations_from_tool_call). A2UI consumers process operations
+// by their nested createSurface/updateComponents/updateDataModel keys; the
+// legacy FLAT shape (`{ type: "create_surface", surfaceId }`) is not
+// processed as a valid nested operation, so the surface's schema and
+// components are never applied. This test would have caught the Python/TS
+// drift: it FAILS against the flat builder and PASSES against the nested one.
+describe("buildA2uiOperationsFromToolCall v0.9 nested-shape parity guard", () => {
+  it("emits the nested v0.9 shape and NEVER the legacy flat `type` shape", () => {
+    const { a2ui_operations: ops } = buildA2uiOperationsFromToolCall({
+      surfaceId: "s1",
+      catalogId: "cat1",
+      components: [{ id: "root", component: "Title" }],
+      data: { key: "value" },
+    });
+
+    // Every op carries the version tag and one nested operation key —
+    // and NONE of them carry the flat `type` discriminator.
+    for (const op of ops) {
+      const record = op as Record<string, unknown>;
+      expect(record.version).toBe("v0.9");
+      expect(record.type).toBeUndefined();
+      expect(record).not.toHaveProperty("type");
+    }
+
+    // Exact nested keys, mirroring generate_a2ui.py's op list.
+    expect(ops[0]).toMatchObject({
+      version: "v0.9",
+      createSurface: { surfaceId: "s1", catalogId: "cat1" },
+    });
+    expect(ops[1]).toMatchObject({
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "s1",
+        components: [{ id: "root", component: "Title" }],
+      },
+    });
+    expect(ops[2]).toMatchObject({
+      version: "v0.9",
+      updateDataModel: { surfaceId: "s1", path: "/", value: { key: "value" } },
+    });
+
+    // Explicit negative assertions on the exact legacy flat literals so a
+    // regression to the old shape fails loudly rather than silently.
+    expect(JSON.stringify(ops)).not.toContain('"type":"create_surface"');
+    expect(JSON.stringify(ops)).not.toContain('"type":"update_components"');
+    expect(JSON.stringify(ops)).not.toContain('"type":"update_data_model"');
+  });
+});
+
+// Empty-data parity guard. Python uses `if data:`, so an empty dict `{}`
+// (falsy in Python) emits NO updateDataModel op. TS previously used a bare
+// `if (data)`, and `{}` is truthy in JS — that emitted a spurious
+// updateDataModel with `value: {}`, diverging from Python on our own mastra
+// fixture (showcase/aimock/d6/mastra/gen-ui-a2ui-fixed.json records
+// `"data": {}`). The builder now only emits updateDataModel for a non-empty
+// object, matching Python.
+describe("buildA2uiOperationsFromToolCall empty-data parity guard", () => {
+  it("omits updateDataModel when data is an empty object `{}`", () => {
+    const { a2ui_operations: ops } = buildA2uiOperationsFromToolCall({
+      surfaceId: "s1",
+      catalogId: "cat1",
+      components: [{ id: "root", component: "Title" }],
+      data: {},
+    });
+
+    expect(ops).toHaveLength(2);
+    expect(
+      ops.some((op) => "updateDataModel" in (op as Record<string, unknown>)),
+    ).toBe(false);
+    expect(ops[0]).toMatchObject({
+      version: "v0.9",
+      createSurface: { surfaceId: "s1" },
+    });
+    expect(ops[1]).toMatchObject({
+      version: "v0.9",
+      updateComponents: { surfaceId: "s1" },
+    });
+  });
+
+  it("omits updateDataModel when data is absent", () => {
+    const { a2ui_operations: ops } = buildA2uiOperationsFromToolCall({
+      surfaceId: "s1",
+      catalogId: "cat1",
+      components: [{ id: "root", component: "Title" }],
+    });
+
+    // A builder that wrongly emitted updateDataModel for absent data would
+    // produce 3 ops; asserting exactly 2 nested ops (and their keys) makes
+    // this a meaningful count guard rather than a vacuous membership check.
+    expect(ops).toHaveLength(2);
+    expect(ops[0]).toMatchObject({
+      version: "v0.9",
+      createSurface: { surfaceId: "s1" },
+    });
+    expect(ops[1]).toMatchObject({
+      version: "v0.9",
+      updateComponents: { surfaceId: "s1" },
+    });
   });
 });

--- a/showcase/integrations/mastra/shared-tools/generate-a2ui.ts
+++ b/showcase/integrations/mastra/shared-tools/generate-a2ui.ts
@@ -60,13 +60,33 @@ export function generateA2uiImpl(input: GenerateA2UIInput): GenerateA2UIResult {
   };
 }
 
-export interface A2UIOperation {
-  type: "create_surface" | "update_components" | "update_data_model";
-  surfaceId: string;
-  catalogId?: string;
-  components?: Array<Record<string, unknown>>;
-  data?: Record<string, unknown>;
-}
+/**
+ * A2UI v0.9 nested operation shape. A2UI consumers process operations by
+ * their nested `createSurface` / `updateComponents` / `updateDataModel`
+ * keys; the legacy flat shape (`{ type: "create_surface", surfaceId }`) is
+ * not processed as a valid nested operation, so the surface's schema and
+ * components are never applied. The operation ENVELOPE shape here mirrors
+ * Python's `build_a2ui_operations_from_tool_call` in
+ * showcase/shared/python/tools/generate_a2ui.py (TS does NOT yet replicate
+ * Python's component sanitization — that's a separate follow-up).
+ */
+export type A2UIOperation =
+  | { version: "v0.9"; createSurface: { surfaceId: string; catalogId: string } }
+  | {
+      version: "v0.9";
+      updateComponents: {
+        surfaceId: string;
+        components: Array<Record<string, unknown>>;
+      };
+    }
+  | {
+      version: "v0.9";
+      updateDataModel: {
+        surfaceId: string;
+        path: string;
+        value: Record<string, unknown>;
+      };
+    };
 
 export function buildA2uiOperationsFromToolCall(
   args: Record<string, unknown>,
@@ -77,6 +97,11 @@ export function buildA2uiOperationsFromToolCall(
   const catalogId = (args.catalogId as string) ?? CUSTOM_CATALOG_ID;
   const components = (args.components as Array<Record<string, unknown>>) ?? [];
   const data = args.data as Record<string, unknown> | undefined;
+  // Python uses `if data:` — an empty dict `{}` is falsy and emits no
+  // updateDataModel op. `{}` is truthy in JS, so guard on a non-empty object
+  // to keep parity with generate_a2ui.py.
+  const hasData =
+    data != null && typeof data === "object" && Object.keys(data).length > 0;
 
   if (components.length === 0) {
     console.warn(
@@ -86,12 +111,15 @@ export function buildA2uiOperationsFromToolCall(
   }
 
   const ops: A2UIOperation[] = [
-    { type: "create_surface", surfaceId, catalogId },
-    { type: "update_components", surfaceId, components },
+    { version: "v0.9", createSurface: { surfaceId, catalogId } },
+    { version: "v0.9", updateComponents: { surfaceId, components } },
   ];
 
-  if (data) {
-    ops.push({ type: "update_data_model", surfaceId, data });
+  if (hasData) {
+    ops.push({
+      version: "v0.9",
+      updateDataModel: { surfaceId, path: "/", value: data },
+    });
   }
 
   return { a2ui_operations: ops };

--- a/showcase/shared/typescript/tools/__tests__/generate-a2ui.test.ts
+++ b/showcase/shared/typescript/tools/__tests__/generate-a2ui.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi } from "vitest";
 import {
   generateA2uiImpl,
   buildA2uiOperationsFromToolCall,
-  RENDER_A2UI_TOOL_SCHEMA,
   CUSTOM_CATALOG_ID,
 } from "../generate-a2ui";
 
@@ -46,18 +45,24 @@ describe("generateA2uiImpl", () => {
 });
 
 describe("buildA2uiOperationsFromToolCall", () => {
-  it("builds create_surface + update_components", () => {
+  it("builds createSurface + updateComponents in v0.9 nested format", () => {
     const result = buildA2uiOperationsFromToolCall({
       surfaceId: "s1",
       catalogId: "cat1",
       components: [{ id: "root", component: "Title" }],
     });
     expect(result.a2ui_operations).toHaveLength(2);
-    expect(result.a2ui_operations[0].type).toBe("create_surface");
-    expect(result.a2ui_operations[1].type).toBe("update_components");
+    expect(result.a2ui_operations[0]).toMatchObject({
+      version: "v0.9",
+      createSurface: { surfaceId: "s1", catalogId: "cat1" },
+    });
+    expect(result.a2ui_operations[1]).toMatchObject({
+      version: "v0.9",
+      updateComponents: { surfaceId: "s1" },
+    });
   });
 
-  it("includes update_data_model when data provided", () => {
+  it("includes updateDataModel when data provided", () => {
     const result = buildA2uiOperationsFromToolCall({
       surfaceId: "s1",
       catalogId: "cat1",
@@ -65,13 +70,20 @@ describe("buildA2uiOperationsFromToolCall", () => {
       data: { key: "value" },
     });
     expect(result.a2ui_operations).toHaveLength(3);
-    expect(result.a2ui_operations[2].type).toBe("update_data_model");
+    expect(result.a2ui_operations[2]).toMatchObject({
+      version: "v0.9",
+      updateDataModel: { surfaceId: "s1", path: "/", value: { key: "value" } },
+    });
   });
 
   it("defaults surfaceId and catalogId", () => {
     const result = buildA2uiOperationsFromToolCall({ components: [] });
-    expect(result.a2ui_operations[0].surfaceId).toBe("dynamic-surface");
-    expect(result.a2ui_operations[0].catalogId).toBe(CUSTOM_CATALOG_ID);
+    const op0 = result.a2ui_operations[0] as {
+      version: string;
+      createSurface: { surfaceId: string; catalogId: string };
+    };
+    expect(op0.createSurface.surfaceId).toBe("dynamic-surface");
+    expect(op0.createSurface.catalogId).toBe(CUSTOM_CATALOG_ID);
   });
 
   it("warns on empty components", () => {
@@ -86,5 +98,109 @@ describe("buildA2uiOperationsFromToolCall", () => {
       "s1",
     );
     spy.mockRestore();
+  });
+});
+
+// Anti-drift parity guard. The TS builder MUST emit the same v0.9 NESTED
+// operation shape as the Python source of truth in
+// showcase/shared/python/tools/generate_a2ui.py
+// (build_a2ui_operations_from_tool_call). A2UI consumers process operations
+// by their nested createSurface/updateComponents/updateDataModel keys; the
+// legacy FLAT shape (`{ type: "create_surface", surfaceId }`) is not
+// processed as a valid nested operation, so the surface's schema and
+// components are never applied. This test would have caught the Python/TS
+// drift: it FAILS against the flat builder and PASSES against the nested one.
+describe("buildA2uiOperationsFromToolCall v0.9 nested-shape parity guard", () => {
+  it("emits the nested v0.9 shape and NEVER the legacy flat `type` shape", () => {
+    const { a2ui_operations: ops } = buildA2uiOperationsFromToolCall({
+      surfaceId: "s1",
+      catalogId: "cat1",
+      components: [{ id: "root", component: "Title" }],
+      data: { key: "value" },
+    });
+
+    // Every op carries the version tag and one nested operation key —
+    // and NONE of them carry the flat `type` discriminator.
+    for (const op of ops) {
+      const record = op as Record<string, unknown>;
+      expect(record.version).toBe("v0.9");
+      expect(record.type).toBeUndefined();
+      expect(record).not.toHaveProperty("type");
+    }
+
+    // Exact nested keys, mirroring generate_a2ui.py's op list.
+    expect(ops[0]).toMatchObject({
+      version: "v0.9",
+      createSurface: { surfaceId: "s1", catalogId: "cat1" },
+    });
+    expect(ops[1]).toMatchObject({
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "s1",
+        components: [{ id: "root", component: "Title" }],
+      },
+    });
+    expect(ops[2]).toMatchObject({
+      version: "v0.9",
+      updateDataModel: { surfaceId: "s1", path: "/", value: { key: "value" } },
+    });
+
+    // Explicit negative assertions on the exact legacy flat literals so a
+    // regression to the old shape fails loudly rather than silently.
+    expect(JSON.stringify(ops)).not.toContain('"type":"create_surface"');
+    expect(JSON.stringify(ops)).not.toContain('"type":"update_components"');
+    expect(JSON.stringify(ops)).not.toContain('"type":"update_data_model"');
+  });
+});
+
+// Empty-data parity guard. Python uses `if data:`, so an empty dict `{}`
+// (falsy in Python) emits NO updateDataModel op. TS previously used a bare
+// `if (data)`, and `{}` is truthy in JS — that emitted a spurious
+// updateDataModel with `value: {}`, diverging from Python on our own mastra
+// fixture (showcase/aimock/d6/mastra/gen-ui-a2ui-fixed.json records
+// `"data": {}`). The builder now only emits updateDataModel for a non-empty
+// object, matching Python.
+describe("buildA2uiOperationsFromToolCall empty-data parity guard", () => {
+  it("omits updateDataModel when data is an empty object `{}`", () => {
+    const { a2ui_operations: ops } = buildA2uiOperationsFromToolCall({
+      surfaceId: "s1",
+      catalogId: "cat1",
+      components: [{ id: "root", component: "Title" }],
+      data: {},
+    });
+
+    expect(ops).toHaveLength(2);
+    expect(
+      ops.some((op) => "updateDataModel" in (op as Record<string, unknown>)),
+    ).toBe(false);
+    expect(ops[0]).toMatchObject({
+      version: "v0.9",
+      createSurface: { surfaceId: "s1" },
+    });
+    expect(ops[1]).toMatchObject({
+      version: "v0.9",
+      updateComponents: { surfaceId: "s1" },
+    });
+  });
+
+  it("omits updateDataModel when data is absent", () => {
+    const { a2ui_operations: ops } = buildA2uiOperationsFromToolCall({
+      surfaceId: "s1",
+      catalogId: "cat1",
+      components: [{ id: "root", component: "Title" }],
+    });
+
+    // A builder that wrongly emitted updateDataModel for absent data would
+    // produce 3 ops; asserting exactly 2 nested ops (and their keys) makes
+    // this a meaningful count guard rather than a vacuous membership check.
+    expect(ops).toHaveLength(2);
+    expect(ops[0]).toMatchObject({
+      version: "v0.9",
+      createSurface: { surfaceId: "s1" },
+    });
+    expect(ops[1]).toMatchObject({
+      version: "v0.9",
+      updateComponents: { surfaceId: "s1" },
+    });
   });
 });

--- a/showcase/shared/typescript/tools/generate-a2ui.ts
+++ b/showcase/shared/typescript/tools/generate-a2ui.ts
@@ -60,13 +60,33 @@ export function generateA2uiImpl(input: GenerateA2UIInput): GenerateA2UIResult {
   };
 }
 
-export interface A2UIOperation {
-  type: "create_surface" | "update_components" | "update_data_model";
-  surfaceId: string;
-  catalogId?: string;
-  components?: Array<Record<string, unknown>>;
-  data?: Record<string, unknown>;
-}
+/**
+ * A2UI v0.9 nested operation shape. A2UI consumers process operations by
+ * their nested `createSurface` / `updateComponents` / `updateDataModel`
+ * keys; the legacy flat shape (`{ type: "create_surface", surfaceId }`) is
+ * not processed as a valid nested operation, so the surface's schema and
+ * components are never applied. The operation ENVELOPE shape here mirrors
+ * Python's `build_a2ui_operations_from_tool_call` in
+ * showcase/shared/python/tools/generate_a2ui.py (TS does NOT yet replicate
+ * Python's component sanitization — that's a separate follow-up).
+ */
+export type A2UIOperation =
+  | { version: "v0.9"; createSurface: { surfaceId: string; catalogId: string } }
+  | {
+      version: "v0.9";
+      updateComponents: {
+        surfaceId: string;
+        components: Array<Record<string, unknown>>;
+      };
+    }
+  | {
+      version: "v0.9";
+      updateDataModel: {
+        surfaceId: string;
+        path: string;
+        value: Record<string, unknown>;
+      };
+    };
 
 export function buildA2uiOperationsFromToolCall(
   args: Record<string, unknown>,
@@ -77,6 +97,11 @@ export function buildA2uiOperationsFromToolCall(
   const catalogId = (args.catalogId as string) ?? CUSTOM_CATALOG_ID;
   const components = (args.components as Array<Record<string, unknown>>) ?? [];
   const data = args.data as Record<string, unknown> | undefined;
+  // Python uses `if data:` — an empty dict `{}` is falsy and emits no
+  // updateDataModel op. `{}` is truthy in JS, so guard on a non-empty object
+  // to keep parity with generate_a2ui.py.
+  const hasData =
+    data != null && typeof data === "object" && Object.keys(data).length > 0;
 
   if (components.length === 0) {
     console.warn(
@@ -86,12 +111,15 @@ export function buildA2uiOperationsFromToolCall(
   }
 
   const ops: A2UIOperation[] = [
-    { type: "create_surface", surfaceId, catalogId },
-    { type: "update_components", surfaceId, components },
+    { version: "v0.9", createSurface: { surfaceId, catalogId } },
+    { version: "v0.9", updateComponents: { surfaceId, components } },
   ];
 
-  if (data) {
-    ops.push({ type: "update_data_model", surfaceId, data });
+  if (hasData) {
+    ops.push({
+      version: "v0.9",
+      updateDataModel: { surfaceId, path: "/", value: data },
+    });
   }
 
   return { a2ui_operations: ops };

--- a/showcase/shared/typescript/tools/generate-a2ui.ts
+++ b/showcase/shared/typescript/tools/generate-a2ui.ts
@@ -5,8 +5,8 @@
 
 export const CUSTOM_CATALOG_ID = "copilotkit://app-dashboard-catalog";
 
-export const DESIGN_A2UI_SURFACE_TOOL_SCHEMA = {
-  name: "_design_a2ui_surface",
+export const RENDER_A2UI_TOOL_SCHEMA = {
+  name: "render_a2ui",
   description: "Render a dynamic A2UI v0.9 surface.",
   parameters: {
     type: "object",
@@ -34,7 +34,7 @@ export interface GenerateA2UIInput {
 
 export interface GenerateA2UIResult {
   systemPrompt: string;
-  toolSchema: typeof DESIGN_A2UI_SURFACE_TOOL_SCHEMA;
+  toolSchema: typeof RENDER_A2UI_TOOL_SCHEMA;
   toolChoice: string;
   messages: Array<Record<string, unknown>>;
   catalogId: string;
@@ -53,8 +53,8 @@ export function generateA2uiImpl(input: GenerateA2UIInput): GenerateA2UIResult {
 
   return {
     systemPrompt: contextText,
-    toolSchema: DESIGN_A2UI_SURFACE_TOOL_SCHEMA,
-    toolChoice: "_design_a2ui_surface",
+    toolSchema: RENDER_A2UI_TOOL_SCHEMA,
+    toolChoice: "render_a2ui",
     messages: input.messages,
     catalogId: CUSTOM_CATALOG_ID,
   };


### PR DESCRIPTION
## Summary

The TypeScript A2UI operation builders (`buildA2uiOperationsFromToolCall`) emitted the **legacy flat** operation shape (`{ type: "create_surface", surfaceId }`). A2UI consumers process operations by their **nested** `createSurface` / `updateComponents` / `updateDataModel` keys — a flat op is never processed as a valid nested operation, so the surface's schema and components are never applied and the UI renders nothing (the `generate_a2ui` / `render_a2ui` path).

Python was fixed to the v0.9 nested shape long ago (#4792, #5832); the TypeScript builders were **born flat and never fixed** — a Python/TS parity gap with no guard. This aligns the TS side and adds a guard so the two can't silently drift again.

## Changes

- **4 TS builders → v0.9 nested** (byte-identical): `shared/typescript/tools` + integrations `mastra`, `claude-sdk-typescript`, `langgraph-typescript`.
- **Empty-data parity fix**: TS `if (data)` treated `{}` as truthy and emitted a spurious `updateDataModel` op; Python `if data:` does not. Now guarded to match Python (empty object → no `updateDataModel`). Our mastra fixture records `"data": {}`, so this is exercised directly.
- **v0.9 parity guard test** in all 4 test files (asserts nested keys, no flat `type`).
- **12 `gen-ui-a2ui-fixed` aimock fixtures** for the fixed-schema a2ui demo.

## Red–green evidence

- Empty-data: pre-fix builder emits 3 ops on `data:{}` → `toHaveLength(2)` **FAILS (red)**; fixed builder emits 2 → **passes (green)**.
- Parity guard: flat shape → `.type` present / nested keys absent → **red**; nested → **green**.

## Validation (please read — what CI does and doesn't cover)

CI **does** run `check-types`, `format`/`oxlint`, `Validate Showcase`, and `build-check` on the changed integrations (mastra, langgraph-typescript, claude-sdk-typescript) — these catch TS/build breaks. But the unit-test workflow has `paths-ignore: showcase/**`, so the **showcase vitest suites where the parity guard and aimock-fixtures tests live are NOT run in CI**. Those were validated **locally**:

- `aimock-fixtures`: **837 passed** (all 12 new fixtures valid).
- Parity guard + empty-data red–green: **verified** (`showcase/shared/typescript` vitest).
- `tsc --noEmit --strict`: **clean** on all 4 builders.
- **mastra Playwright screenshot**: the `render_a2ui` flow renders the flight card (SFO→JFK, Flight Details, $289) with the nested ops.

## Real-surface confirmation (bin/showcase test --direct)

Proven on the live probe, not just unit tests:

- **RED** (old flat builder): `d6:mastra a2ui-fixed-schema` → `1 failed — [data-testid="a2ui-fixed-card"] failed to mount within 60000ms`.
- **GREEN** (this branch, rebuilt image): `d6:mastra a2ui-fixed-schema` → `✓ green, 1 passed` — the card mounts and renders (SFO→JFK, UNITED, $289, "Book flight").
- **≥3 cells `--direct` GREEN**: `mastra` ✓, `langgraph-typescript` ✓, `pydantic-ai` ✓.
- **Frontend parity**: mastra ≡ langgraph-python render the same flight card (byte-identical frontend; only expected agent-specific tool-row/ordering differences).

## Iron-rule adherence

| Rule | Evidence |
|------|----------|
| Identical tests | One shared harness probe (`d5-gen-ui-a2ui-fixed`) measures the feature across all integrations; no per-integration test copies added. |
| Near-identical frontends | mastra ≡ langgraph-python frontend (byte-identical); visual parity confirmed on the rendered card. |
| Minimal backends | Change is the minimal flat→nested + empty-data guard; 4 TS builder copies byte-identical. |
| Per-integration fixtures | 12 `gen-ui-a2ui-fixed.json`, one per slug, context-keyed. |

Note: the *single-source symlink* restoration (the `shared-tools/`/`tools/` symlinks that eroded to real files repo-wide) is handled in a **companion structural PR**, plus a `showcase/AGENTS.md` documenting the iron rules and a CI check that fails on future erosion.

## Known follow-ups (out of scope here)

1. **`render_a2ui` naming drift (pre-existing):** the *shared* builder exports `_design_a2ui_surface` while the 3 integrations + Python use `render_a2ui`; the shared test asserts `render_a2ui` and is red on `main` today. Not run by CI. A one-line rename aligns shared to the source of truth and greens the file — happy to fold it in if wanted.
2. **Integration test copies aren't executed** by their vitest `include` globs (only `shared/typescript` runs its copy) — add a cross-copy byte-identity CI check.
3. **Full `_sanitize_a2ui_components` parity** — TS forwards components raw; Python sanitizes (drops entries missing id/component, unstringifies Gemini JSON-string arrays).
4. **Showcase tests are CI-excluded** (`paths-ignore: showcase/**`) — no automated gate for showcase unit tests.
