### PR TITLE
fix(channels): realtime-transport reliability hardening + residual bot-naming scrub (closes OSS-485, OSS-482)

### DIFF
--- a/examples/slack/.env.example
+++ b/examples/slack/.env.example
@@ -1,5 +1,6 @@
-# Set SLACK_*, DISCORD_*, and/or TELEGRAM_BOT_TOKEN — the bot starts an adapter
-# for each platform whose secrets are present (any one, or several at once).
+# Set SLACK_*, DISCORD_*, TELEGRAM_BOT_TOKEN, and/or WHATSAPP_* — the bot starts
+# an adapter for each platform whose secrets are present (any one, or several at
+# once).
 
 # ── Slack credentials (from api.slack.com/apps → your app) ──────────────
 # Set both to run on Slack; leave blank to skip Slack.
@@ -32,12 +33,12 @@ AGENT_URL=http://localhost:8200/api/copilotkit/agent/triage/run
 # Optional auth header forwarded to the agent (for a deployed runtime).
 # AGENT_AUTH_HEADER=Bearer ...
 
-# Model for the BuiltInAgent. provider/model — the runtime resolves the
-# provider and reads the matching API key below. Defaults to openai/gpt-5.5.
-# AGENT_MODEL=anthropic/claude-sonnet-4.5
+# Model for the agent. This runtime is OpenAI-only (its web search is an OpenAI
+# hosted provider tool), so AGENT_MODEL must be an OpenAI model id — either bare
+# ("gpt-5.5-mini") or "openai/<id>" (the "openai/" prefix is stripped). Defaults
+# to openai/gpt-5.5. OPENAI_API_KEY is required.
+# AGENT_MODEL=openai/gpt-5.5-mini
 OPENAI_API_KEY=sk-...
-# ANTHROPIC_API_KEY=sk-ant-...
-# GOOGLE_API_KEY=...
 
 # ── Intelligence (managed Channel) mode — app/managed.ts (`pnpm channel`) ─
 # The managed variant runs the SAME bot over Intelligence instead of a native
@@ -57,8 +58,9 @@ OPENAI_API_KEY=sk-...
 # ── Linear MCP ──────────────────────────────────────────────────────────
 # The hosted Linear MCP accepts a raw API key as a bearer token (no OAuth
 # dance). Create one at linear.app → Settings → API → Personal API keys.
-# Leave LINEAR_API_KEY blank to run without Linear.
-LINEAR_API_KEY=lin_api_...
+# Leave LINEAR_API_KEY blank to run without Linear — a non-blank value turns the
+# Linear MCP ON, so keep it empty unless you have a real key.
+LINEAR_API_KEY=
 # Override only if you front the MCP yourself; default is the hosted server.
 # LINEAR_MCP_URL=https://mcp.linear.app/mcp
 # Default Linear team the bot files/queries against.
@@ -72,8 +74,13 @@ LINEAR_TEAM_KEY=CPK
 # transport; the agent sends it. Pick any strong string and use it in both
 # `pnpm notion-mcp` and here. Leave NOTION_MCP_AUTH_TOKEN blank to run
 # without Notion.
-NOTION_TOKEN=ntn_...
-NOTION_MCP_AUTH_TOKEN=choose-a-strong-shared-secret
+# Both are blank by default — a non-blank NOTION_MCP_AUTH_TOKEN turns the Notion
+# MCP ON. NOTION_TOKEN is only needed when you actually run `pnpm notion-mcp`.
+NOTION_TOKEN=
+NOTION_MCP_AUTH_TOKEN=
+# Port the `pnpm notion-mcp` sidecar listens on (default 3001). If you change
+# it, update the port in NOTION_MCP_URL below to match.
+# NOTION_MCP_PORT=3001
 # Override only if the sidecar runs elsewhere; default is the local sidecar.
 # NOTION_MCP_URL=http://127.0.0.1:3001/mcp
 

--- a/examples/slack/.env.example
+++ b/examples/slack/.env.example
@@ -51,9 +51,10 @@ OPENAI_API_KEY=sk-...
 # COPILOTKIT_INTELLIGENCE_URL=http://localhost:4201
 # Project runtime API key (cpk-…).
 # COPILOTKIT_API_KEY=cpk-...
-# Optional: websocket base URL. Derived from COPILOTKIT_INTELLIGENCE_URL
-# (http→ws) when unset.
-# COPILOTKIT_INTELLIGENCE_WS_URL=ws://localhost:4401
+# Optional: websocket base URL. Derived from COPILOTKIT_INTELLIGENCE_URL by a
+# scheme-only swap (http→ws, same host+port) when unset — so the default here is
+# ws://localhost:4201, matching the API URL above.
+# COPILOTKIT_INTELLIGENCE_WS_URL=ws://localhost:4201
 
 # ── Linear MCP ──────────────────────────────────────────────────────────
 # The hosted Linear MCP accepts a raw API key as a bearer token (no OAuth

--- a/examples/slack/app/commands/__tests__/commands.test.ts
+++ b/examples/slack/app/commands/__tests__/commands.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi } from "vitest";
 import { renderToIR } from "@copilotkit/channels-ui";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import { appCommands } from "../index.js";
 import type { CommandContext } from "@copilotkit/channels";
 
-function tags(node: BotNode | unknown, acc: string[] = []): string[] {
+function tags(node: ChannelNode | unknown, acc: string[] = []): string[] {
   if (!node || typeof node !== "object") return acc;
-  const n = node as BotNode;
+  const n = node as ChannelNode;
   if (typeof n.type === "string") acc.push(n.type);
-  for (const c of (n.props?.children as BotNode[] | undefined) ?? []) {
+  for (const c of (n.props?.children as ChannelNode[] | undefined) ?? []) {
     tags(c, acc);
   }
   return acc;

--- a/examples/slack/app/components/issue-card.tsx
+++ b/examples/slack/app/components/issue-card.tsx
@@ -20,7 +20,7 @@ import {
   Message,
   Section,
 } from "@copilotkit/channels-ui";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import { accentForIssue, priorityGlyph, stateGlyph } from "./_status.js";
 
 export const issueCardSchema = z.object({
@@ -51,7 +51,7 @@ export const issueCardSchema = z.object({
 export type IssueCardProps = z.infer<typeof issueCardSchema>;
 
 /** Render ONE Linear issue as a rich Block Kit card. */
-export function IssueCard(issue: IssueCardProps): BotNode {
+export function IssueCard(issue: IssueCardProps): ChannelNode {
   const titleText = issue.url
     ? `[**${issue.title}**](${issue.url})`
     : `**${issue.title}**`;

--- a/examples/slack/app/components/issue-list.tsx
+++ b/examples/slack/app/components/issue-list.tsx
@@ -17,7 +17,7 @@
  */
 import { z } from "zod";
 import { Context, Header, Message, Section } from "@copilotkit/channels-ui";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import { accentForIssues, stateGlyph } from "./_status.js";
 
 const issueSchema = z.object({
@@ -59,7 +59,7 @@ const MAX = 15;
 const TITLE_MAX = 70;
 
 /** Render a list of Linear issues as a compact, fixed-size Block Kit card. */
-export function IssueList({ heading, issues }: IssueListProps): BotNode {
+export function IssueList({ heading, issues }: IssueListProps): ChannelNode {
   const lines = issues.slice(0, MAX).map((issue: Issue) => {
     const idLink = issue.url
       ? `[**${issue.identifier}**](${issue.url})`

--- a/examples/slack/app/components/page-list.tsx
+++ b/examples/slack/app/components/page-list.tsx
@@ -16,7 +16,7 @@ import {
   Message,
   Section,
 } from "@copilotkit/channels-ui";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import { ACCENT } from "./_status.js";
 
 const pageSchema = z.object({
@@ -45,8 +45,8 @@ export type PageListProps = z.infer<typeof pageListSchema>;
 type Page = z.infer<typeof pageSchema>;
 
 /** Render a list of Notion pages as a Block Kit card. */
-export function PageList({ heading, pages }: PageListProps): BotNode {
-  const rows: BotNode[] = [];
+export function PageList({ heading, pages }: PageListProps): ChannelNode {
+  const rows: ChannelNode[] = [];
   pages.forEach((page: Page, i: number) => {
     const titleLink = page.url
       ? `[**${page.title}**](${page.url})`

--- a/examples/slack/app/human-in-the-loop/__tests__/confirm-write-tool.test.tsx
+++ b/examples/slack/app/human-in-the-loop/__tests__/confirm-write-tool.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { renderToIR, type BotNode } from "@copilotkit/channels-ui";
+import { renderToIR } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import { renderSlackMessage } from "@copilotkit/channels-slack";
 import { confirmWriteTool } from "../confirm-write-tool.js";
 
@@ -32,7 +33,7 @@ describe("confirm_write tool", () => {
     // The posted UI is a ConfirmWrite picker: amber accent + header carrying the action.
     expect(awaited).toHaveLength(1);
     const { blocks, accent } = renderSlackMessage(
-      renderToIR(awaited[0] as BotNode),
+      renderToIR(awaited[0] as ChannelNode),
     );
     expect(accent).toBe("#E2B340");
     const header = blocks.find((b) => b.type === "header") as

--- a/examples/slack/app/human-in-the-loop/__tests__/confirm-write.test.tsx
+++ b/examples/slack/app/human-in-the-loop/__tests__/confirm-write.test.tsx
@@ -1,35 +1,38 @@
 import { describe, it, expect, vi } from "vitest";
-import {
-  renderToIR,
-  type BotNode,
-  type InteractionContext,
-  type ClickHandler,
+import { renderToIR } from "@copilotkit/channels-ui";
+import type {
+  ChannelNode,
+  InteractionContext,
+  ClickHandler,
 } from "@copilotkit/channels-ui";
 import { renderSlackMessage } from "@copilotkit/channels-slack";
 import { ConfirmWrite } from "../confirm-write.js";
 
 /** Children of an IR node as an array (empty if none). */
-function childNodes(node: BotNode): BotNode[] {
+function childNodes(node: ChannelNode): ChannelNode[] {
   const children = node.props?.children;
-  if (Array.isArray(children)) return children as BotNode[];
+  if (Array.isArray(children)) return children as ChannelNode[];
   if (
     children &&
     typeof children === "object" &&
     "type" in (children as object)
   ) {
-    return [children as BotNode];
+    return [children as ChannelNode];
   }
   return [];
 }
 
 /** Concatenate the text of all descendant `text` nodes (depth-first). */
-function collectText(node: BotNode): string {
+function collectText(node: ChannelNode): string {
   if (node.type === "text") return String(node.props?.value ?? "");
   return childNodes(node).map(collectText).join("");
 }
 
 /** Walk the whole tree to find the first node of a given intrinsic type. */
-function findByType(nodes: BotNode[], type: string): BotNode | undefined {
+function findByType(
+  nodes: ChannelNode[],
+  type: string,
+): ChannelNode | undefined {
   for (const n of nodes) {
     if (n.type === type) return n;
     const hit = findByType(childNodes(n), type);
@@ -39,8 +42,8 @@ function findByType(nodes: BotNode[], type: string): BotNode | undefined {
 }
 
 /** All button nodes in the tree. */
-function findButtons(nodes: BotNode[]): BotNode[] {
-  const out: BotNode[] = [];
+function findButtons(nodes: ChannelNode[]): ChannelNode[] {
+  const out: ChannelNode[] = [];
   for (const n of nodes) {
     if (n.type === "button") out.push(n);
     out.push(...findButtons(childNodes(n)));
@@ -48,7 +51,7 @@ function findButtons(nodes: BotNode[]): BotNode[] {
   return out;
 }
 
-function buttonByText(ir: BotNode[], text: string): BotNode {
+function buttonByText(ir: ChannelNode[], text: string): ChannelNode {
   const btn = findButtons(ir).find((b) => collectText(b) === text);
   if (!btn) throw new Error(`button "${text}" not found`);
   return btn;

--- a/examples/slack/app/modals/__tests__/file-issue.test.tsx
+++ b/examples/slack/app/modals/__tests__/file-issue.test.tsx
@@ -6,13 +6,13 @@ import {
   issueFromValues,
   FILE_ISSUE_CALLBACK,
 } from "../file-issue.js";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 
-function tags(node: BotNode | unknown, acc: string[] = []): string[] {
+function tags(node: ChannelNode | unknown, acc: string[] = []): string[] {
   if (!node || typeof node !== "object") return acc;
-  const n = node as BotNode;
+  const n = node as ChannelNode;
   if (typeof n.type === "string") acc.push(n.type);
-  for (const c of (n.props?.children as BotNode[] | undefined) ?? []) {
+  for (const c of (n.props?.children as ChannelNode[] | undefined) ?? []) {
     tags(c, acc);
   }
   return acc;

--- a/examples/slack/app/tools/__tests__/showcase-tools.test.tsx
+++ b/examples/slack/app/tools/__tests__/showcase-tools.test.tsx
@@ -9,7 +9,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { renderToIR } from "@copilotkit/channels-ui";
 import type {
-  BotNode,
+  ChannelNode,
   InteractionContext,
   ClickHandler,
 } from "@copilotkit/channels-ui";
@@ -43,17 +43,17 @@ function fakeThread() {
 
 /** Depth-first: find the first IR node whose `type` matches and that has the named prop. */
 function findWithProp(
-  nodes: BotNode[],
+  nodes: ChannelNode[],
   type: string,
   prop: string,
-): BotNode | undefined {
+): ChannelNode | undefined {
   for (const node of nodes) {
     if (node.type === type && node.props && prop in node.props) return node;
     const children = node.props?.children;
     const childArr = Array.isArray(children)
-      ? (children as BotNode[])
+      ? (children as ChannelNode[])
       : children && typeof children === "object"
-        ? [children as BotNode]
+        ? [children as ChannelNode]
         : [];
     const found = findWithProp(childArr, type, prop);
     if (found) return found;

--- a/examples/teams/app/human-in-the-loop/__tests__/confirm-action.test.tsx
+++ b/examples/teams/app/human-in-the-loop/__tests__/confirm-action.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { renderToIR } from "@copilotkit/channels-ui";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import { renderAdaptiveCard } from "@copilotkit/channels-teams";
 import { confirmWriteTool } from "../index.js";
 
@@ -29,7 +29,7 @@ describe("confirm_write tool (Teams)", () => {
 
     // The posted UI renders to an Adaptive Card whose header carries the action.
     expect(awaited).toHaveLength(1);
-    const card = renderAdaptiveCard(renderToIR(awaited[0] as BotNode));
+    const card = renderAdaptiveCard(renderToIR(awaited[0] as ChannelNode));
     expect(card.type).toBe("AdaptiveCard");
     const header = card.body[0] as { type: string; text: string } | undefined;
     expect(header?.type).toBe("TextBlock");

--- a/packages/channels-discord/src/adapter.ts
+++ b/packages/channels-discord/src/adapter.ts
@@ -20,7 +20,7 @@ import type {
   NativePayload,
 } from "@copilotkit/channels";
 import type {
-  BotNode,
+  ChannelNode,
   ThreadMessage,
   EmojiValue,
   EphemeralResult,
@@ -314,11 +314,11 @@ export class DiscordAdapter implements PlatformAdapter {
     await this.client.destroy();
   }
 
-  render(ir: BotNode[]) {
+  render(ir: ChannelNode[]) {
     return renderComponents(ir);
   }
 
-  async post(target: BotReplyTarget, ir: BotNode[]): Promise<MessageRef> {
+  async post(target: BotReplyTarget, ir: ChannelNode[]): Promise<MessageRef> {
     const t = target as ReplyTarget;
     const channel = await this.fetchSendable(t.channelId);
     const { components, flags } = renderDiscordMessage(ir);
@@ -326,7 +326,7 @@ export class DiscordAdapter implements PlatformAdapter {
     return { id: msg.id, channelId: t.channelId };
   }
 
-  async update(ref: MessageRef, ir: BotNode[]): Promise<void> {
+  async update(ref: MessageRef, ir: ChannelNode[]): Promise<void> {
     // An empty stream returns a ref with id "" (no message was ever posted);
     // a fetch on "" would throw, so treat update/delete on it as a no-op.
     if (!ref.id) return;
@@ -548,7 +548,7 @@ export class DiscordAdapter implements PlatformAdapter {
   async postEphemeral(
     _target: BotReplyTarget,
     user: PlatformUser | string,
-    ir: BotNode[],
+    ir: ChannelNode[],
     opts: { fallbackToDM: boolean },
   ): Promise<EphemeralResult | null> {
     // Native interaction-ephemeral is only reachable from within a live,
@@ -571,14 +571,14 @@ export class DiscordAdapter implements PlatformAdapter {
     }
   }
 
-  renderModal(ir: BotNode[]): NativePayload {
+  renderModal(ir: ChannelNode[]): NativePayload {
     return renderDiscordModal(ir);
   }
 
   async openModal(
     _target: BotReplyTarget,
     triggerId: string,
-    ir: BotNode[],
+    ir: ChannelNode[],
   ): Promise<{ ok: boolean; error?: string }> {
     let modal: ReturnType<typeof renderDiscordModal>;
     try {

--- a/packages/channels-discord/src/render/components-v2.test.ts
+++ b/packages/channels-discord/src/render/components-v2.test.ts
@@ -1,17 +1,23 @@
 import { describe, it, expect, vi } from "vitest";
 import { ComponentType, ButtonStyle } from "discord.js";
 import { renderComponents } from "./components-v2.js";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 
-const text = (value: string): BotNode => ({ type: "text", props: { value } });
-const node = (type: string, props: Record<string, unknown> = {}): BotNode => ({
+const text = (value: string): ChannelNode => ({
+  type: "text",
+  props: { value },
+});
+const node = (
+  type: string,
+  props: Record<string, unknown> = {},
+): ChannelNode => ({
   type,
   props,
 });
 
 describe("renderComponents", () => {
   it("wraps a header + section in a container with text displays", () => {
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", {
         children: [
           node("header", { children: text("Hello") }),
@@ -30,7 +36,7 @@ describe("renderComponents", () => {
   });
 
   it("maps accent to the container accent color (#5865F2 → int)", () => {
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", { accent: "#5865F2", children: text("hi") }),
     ];
     const json = renderComponents(ir).toJSON();
@@ -38,7 +44,7 @@ describe("renderComponents", () => {
   });
 
   it("renders a button with its minted custom_id and style", () => {
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", {
         children: node("actions", {
           children: node("button", {
@@ -61,7 +67,7 @@ describe("renderComponents", () => {
   });
 
   it("renders a url button as a Link-style button with no custom_id", () => {
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", {
         children: node("actions", {
           children: node("button", {
@@ -82,7 +88,7 @@ describe("renderComponents", () => {
   });
 
   it("sets max_values on a multi-select so the decoder reads an array", () => {
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", {
         children: node("actions", {
           children: node("select", {
@@ -110,7 +116,7 @@ describe("renderComponents", () => {
     const buttons = Array.from({ length: 7 }, (_, i) =>
       node("button", { children: text(`b${i}`), onClick: { id: `ck:${i}` } }),
     );
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", { children: node("actions", { children: buttons }) }),
     ];
     const json = renderComponents(ir).toJSON();
@@ -123,7 +129,7 @@ describe("renderComponents", () => {
   });
 
   it("renders a divider as a separator", () => {
-    const ir: BotNode[] = [node("message", { children: node("divider") })];
+    const ir: ChannelNode[] = [node("message", { children: node("divider") })];
     const json = renderComponents(ir).toJSON();
     expect(
       json.components.some((c: any) => c.type === ComponentType.Separator),
@@ -133,7 +139,7 @@ describe("renderComponents", () => {
   it("clamps an IR with > componentsPerMessage components and appends one overflow marker", () => {
     // 60 dividers each cost one component; the message caps at 40 total.
     const dividers = Array.from({ length: 60 }, () => node("divider"));
-    const ir: BotNode[] = [node("message", { children: dividers })];
+    const ir: ChannelNode[] = [node("message", { children: dividers })];
     const json = renderComponents(ir).toJSON();
     expect(json.components.length).toBeLessThanOrEqual(40);
     const overflow = json.components.filter(
@@ -150,7 +156,7 @@ describe("renderComponents", () => {
     const sections = Array.from({ length: 3 }, () =>
       node("section", { children: text(chunk) }),
     );
-    const ir: BotNode[] = [node("message", { children: sections })];
+    const ir: ChannelNode[] = [node("message", { children: sections })];
     const json = renderComponents(ir).toJSON();
     const totalText = json.components
       .filter((c: any) => c.type === ComponentType.TextDisplay)
@@ -165,7 +171,7 @@ describe("renderComponents", () => {
       label: `opt${i}`,
       value: `v${i}`,
     }));
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", {
         children: node("actions", {
           children: node("select", { onSelect: { id: "ck:sel" }, options }),
@@ -192,7 +198,7 @@ describe("renderComponents", () => {
 
   it("truncates a select placeholder over 150 chars", () => {
     const long = "p".repeat(300);
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", {
         children: node("actions", {
           children: node("select", {
@@ -231,7 +237,7 @@ describe("renderComponents", () => {
   it("drops an over-large button value but still renders the button via its handler id", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const bigValue = { blob: "z".repeat(200) }; // v:<json> exceeds 100 chars
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", {
         children: node("actions", {
           children: node("button", {
@@ -255,7 +261,7 @@ describe("renderComponents", () => {
   it("warns and renders no button when an over-large value is the only id source", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const bigValue = { blob: "z".repeat(200) };
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", {
         children: node("actions", {
           children: node("button", { children: text("Go"), value: bigValue }),
@@ -278,7 +284,7 @@ describe("renderComponents", () => {
         ],
       }),
     );
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", { children: node("table", { columns, children: rows }) }),
     ];
     const json = renderComponents(ir).toJSON();
@@ -297,7 +303,7 @@ describe("renderComponents", () => {
     const buttons = Array.from({ length: 25 }, (_, i) =>
       node("button", { children: text(`b${i}`), onClick: { id: `ck:${i}` } }),
     );
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", {
         children: [
           node("section", { children: text("header text") }),
@@ -326,7 +332,7 @@ describe("renderComponents", () => {
     const buttons = Array.from({ length: 25 }, (_, i) =>
       node("button", { children: text(`b${i}`), onClick: { id: `ck:${i}` } }),
     );
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", {
         children: [...dividers, node("actions", { children: buttons })],
       }),
@@ -352,7 +358,7 @@ describe("renderComponents", () => {
     // Two 4000-char sections: the first fills totalTextChars, the second clamps
     // to "" — which must NOT become an empty TextDisplay (Discord rejects it).
     const chunk = "x".repeat(4000);
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", {
         children: [
           node("section", { children: text(chunk) }),
@@ -368,7 +374,7 @@ describe("renderComponents", () => {
   });
 
   it("emits no 'content truncated' marker for genuinely-empty input (empty Fields / empty Text)", () => {
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", {
         children: [
           node("fields", { children: [] }),
@@ -410,7 +416,7 @@ describe("renderComponents", () => {
         ],
       }),
     );
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", {
         children: [...fillers, node("table", { columns, children: rows })],
       }),
@@ -429,7 +435,7 @@ describe("renderComponents", () => {
   });
 
   it("does not emit a Select with zero options", () => {
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", {
         children: node("actions", {
           children: node("select", { onSelect: { id: "ck:sel" }, options: [] }),
@@ -445,7 +451,7 @@ describe("renderComponents", () => {
   });
 
   it("falls back to ' ' for an explicitly-empty select placeholder", () => {
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", {
         children: node("actions", {
           children: node("select", {
@@ -471,7 +477,7 @@ describe("renderComponents", () => {
     const sections = Array.from({ length: 4 }, () =>
       node("section", { children: text(chunk) }),
     );
-    const ir: BotNode[] = [node("message", { children: sections })];
+    const ir: ChannelNode[] = [node("message", { children: sections })];
     const json = renderComponents(ir).toJSON();
     const totalText = json.components
       .filter((c: any) => c.type === ComponentType.TextDisplay)

--- a/packages/channels-discord/src/render/components-v2.ts
+++ b/packages/channels-discord/src/render/components-v2.ts
@@ -13,7 +13,7 @@ import {
   MessageFlags,
 } from "discord.js";
 import type { MessageActionRowComponentBuilder } from "discord.js";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import {
   DISCORD_LIMITS,
   truncateText,
@@ -108,7 +108,7 @@ function addText(
  * Total renderer: unknown intrinsics are skipped, never thrown. Per-element
  * limits apply via truncate/clamp; nothing is silently dropped.
  */
-export function renderComponents(ir: BotNode[]): ContainerBuilder {
+export function renderComponents(ir: ChannelNode[]): ContainerBuilder {
   const container = new ContainerBuilder();
 
   // <Message accent="#hex"> → container accent color.
@@ -128,7 +128,7 @@ export function renderComponents(ir: BotNode[]): ContainerBuilder {
 }
 
 /** Ready-to-send payload for channel.send / message.edit. */
-export function renderDiscordMessage(ir: BotNode[]): {
+export function renderDiscordMessage(ir: ChannelNode[]): {
   components: ContainerBuilder[];
   flags: number;
 } {
@@ -139,7 +139,7 @@ export function renderDiscordMessage(ir: BotNode[]): {
 }
 
 function addNode(
-  node: BotNode,
+  node: ChannelNode,
   container: ContainerBuilder,
   budget: RenderBudget,
 ): void {
@@ -296,7 +296,7 @@ function addNode(
 
 /** Build action rows from a flat list of button/select children, chunking buttons ≤5/row. */
 function buildActionRows(
-  children: BotNode[],
+  children: ChannelNode[],
 ): ActionRowBuilder<MessageActionRowComponentBuilder>[] {
   const rows: ActionRowBuilder<MessageActionRowComponentBuilder>[] = [];
   let current: ButtonBuilder[] = [];
@@ -334,7 +334,7 @@ function buildActionRows(
   return rows.slice(0, DISCORD_LIMITS.actionRows);
 }
 
-function buildButton(node: BotNode): ButtonBuilder | undefined {
+function buildButton(node: ChannelNode): ButtonBuilder | undefined {
   const props = node.props ?? {};
   const label = truncateText(
     collectText(node) || " ",
@@ -356,7 +356,7 @@ function buildButton(node: BotNode): ButtonBuilder | undefined {
   return btn;
 }
 
-function buildSelect(node: BotNode): StringSelectMenuBuilder | undefined {
+function buildSelect(node: ChannelNode): StringSelectMenuBuilder | undefined {
   const props = node.props ?? {};
   const id = idFromHandler(props.onSelect);
   if (!id) return undefined;
@@ -477,20 +477,20 @@ function parseAccent(accent: unknown): number | undefined {
 }
 
 // ── helpers copied verbatim from bot-slack/src/render/block-kit.ts ──
-function childNodes(node: BotNode): BotNode[] {
+function childNodes(node: ChannelNode): ChannelNode[] {
   const children = node.props?.children;
-  if (Array.isArray(children)) return children as BotNode[];
+  if (Array.isArray(children)) return children as ChannelNode[];
   if (
     children &&
     typeof children === "object" &&
     "type" in (children as object)
   ) {
-    return [children as BotNode];
+    return [children as ChannelNode];
   }
   return [];
 }
 
-function collectText(node: BotNode): string {
+function collectText(node: ChannelNode): string {
   if (typeof node.type === "string" && node.type === "text") {
     return String(node.props?.value ?? "");
   }
@@ -502,17 +502,17 @@ function collectText(node: BotNode): string {
 }
 
 // Field label/value: a <Field label="..">value</Field> or text-only field.
-function collectFieldLabel(node: BotNode): string {
+function collectFieldLabel(node: ChannelNode): string {
   const label = node.props?.label;
   return typeof label === "string" ? label : "";
 }
-function collectFieldValue(node: BotNode): string {
+function collectFieldValue(node: ChannelNode): string {
   return collectText(node);
 }
 
 // Reconstruct a GFM pipe table from a <Table columns rows> node so
 // discordMarkdown can fence it. Columns from props.columns; rows from row/cell.
-function tableToMarkdown(node: BotNode): string {
+function tableToMarkdown(node: ChannelNode): string {
   const columns =
     (node.props?.columns as { header: string }[] | undefined)?.map(
       (c) => c.header,

--- a/packages/channels-discord/src/render/modal.ts
+++ b/packages/channels-discord/src/render/modal.ts
@@ -1,4 +1,4 @@
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import { ModalRenderError } from "@copilotkit/channels-ui";
 import {
   ActionRowBuilder,
@@ -15,12 +15,12 @@ import {
  * a {@link ModalRenderError}, which `adapter.openModal` translates to
  * `{ ok: false, error }` (degrade-never-throw at the boundary).
  */
-export function renderDiscordModal(ir: BotNode[]): ModalBuilder {
+export function renderDiscordModal(ir: ChannelNode[]): ModalBuilder {
   const root = ir.find((n) => n.type === "modal");
   if (!root)
     throw new ModalRenderError("renderDiscordModal: no <Modal> root in IR");
   const p = root.props as Record<string, unknown>;
-  const kids = Array.isArray(p.children) ? (p.children as BotNode[]) : [];
+  const kids = Array.isArray(p.children) ? (p.children as ChannelNode[]) : [];
   const inputs = kids.filter((k) => k.type === "modal_text_input");
   const unsupported = kids.find((k) => k.type !== "modal_text_input");
   if (unsupported) {

--- a/packages/channels-intelligence/src/contracts.ts
+++ b/packages/channels-intelligence/src/contracts.ts
@@ -5,7 +5,7 @@
 // event-kind set, bounded failure codes, health/read models — is intentionally
 // left out and noted inline so the swap later is a pure import change.
 
-import type { BotNode, MessageRef } from "@copilotkit/channels-ui";
+import type { ChannelNode, MessageRef } from "@copilotkit/channels-ui";
 
 /**
  * Opaque return address minted by Intelligence and echoed back on egress. The
@@ -112,8 +112,8 @@ export type ChannelIngressEnvelope =
 
 /** A generic, platform-agnostic reply operation emitted by the bridge adapter. */
 export type EgressOp =
-  | { kind: "post"; ir: BotNode[] }
-  | { kind: "update"; ref: string; ir: BotNode[] }
+  | { kind: "post"; ir: ChannelNode[] }
+  | { kind: "update"; ref: string; ir: ChannelNode[] }
   | { kind: "delete"; ref: string };
 // TODO(OSS-377): a "stream" op for incremental updates, once the streaming
 // capability is honored end-to-end.
@@ -139,7 +139,7 @@ export type EgressResult =
 // semantic frames to the realtime-gateway; the gateway-side Connector Outbox
 // (OSS-404) renders them to the provider (Slack Block Kit, etc.).
 // TODO(OSS-377): replace with the shared `@copilotkit/channel-contracts`
-// package; `post`/`update` content is `BotNode[]` (SDK IR) here — the frozen
+// package; `post`/`update` content is `ChannelNode[]` (SDK IR) here — the frozen
 // contract types it as opaque `ChannelRenderContent`.
 
 /** One semantic render frame the agent run emits. Matches the frozen kinds. */
@@ -151,8 +151,8 @@ export type ChannelRenderEvent =
   | { kind: "tool_end"; toolCallId: string; toolName: string }
   | { kind: "interrupt" }
   | { kind: "run_error"; message: string }
-  | { kind: "post"; content: BotNode[] }
-  | { kind: "update"; ref: string; content: BotNode[] }
+  | { kind: "post"; content: ChannelNode[] }
+  | { kind: "update"; ref: string; content: ChannelNode[] }
   | {
       /**
        * Outbound file post (`thread.postFile`). Bytes were streamed to app-api

--- a/packages/channels-intelligence/src/http-transports.test.ts
+++ b/packages/channels-intelligence/src/http-transports.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { createChannel, FakeAgent } from "@copilotkit/channels";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import {
   HttpDeliverySource,
   HttpEgressSink,
@@ -99,8 +99,8 @@ function cfg(
   });
 }
 
-const text = (value: string): BotNode =>
-  ({ type: "text", props: { value } }) as unknown as BotNode;
+const text = (value: string): ChannelNode =>
+  ({ type: "text", props: { value } }) as unknown as ChannelNode;
 
 const claimedDelivery = (over?: Record<string, unknown>) => ({
   id: "dlv_9",

--- a/packages/channels-intelligence/src/intelligence-adapter.test.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./in-memory-transports.js";
 import { IntelligenceStateStore } from "./intelligence-state-store.js";
 import type { FetchLike } from "./http-transports.js";
+import type { EgressSink } from "./transports.js";
 import type {
   ChannelIngressEnvelope,
   ChannelIngressBase,
@@ -247,6 +248,38 @@ describe("intelligenceAdapter — deterministic egress ids", () => {
     egress.ops.length = 0;
     await source.deliver(envelope({ turnId: "t1", deliveryId: "d2" }));
     expect(egress.ops.map((o) => o.operationId)).toEqual(["t1:0", "t1:1"]);
+  });
+});
+
+describe("intelligenceAdapter — egress fail-loud", () => {
+  it("throws (does not silently ack) when egress reports { ok: false }", async () => {
+    const source = new InMemoryDeliverySource();
+    // Egress that always rejects the op — the HTTP-fallback failure the adapter
+    // used to swallow by minting a synthetic MessageRef and acking as success.
+    const failingEgress: EgressSink = {
+      emit: async () => ({ ok: false, code: "provider_rejected" }),
+    };
+    const channel = createChannel({
+      adapters: [intelligenceAdapter({ source, egress: failingEgress })],
+      agent: () => new FakeAgent(),
+    });
+    let postError: unknown;
+    channel.onMessage(async ({ thread }) => {
+      try {
+        await thread.post(Section({ children: "reply" }));
+      } catch (err) {
+        postError = err;
+      }
+    });
+    await channel.start();
+    await source.deliver(envelope());
+
+    // Before the fix, thread.post resolved with a synthetic ref and postError
+    // stayed undefined (the drop was acked as success). Now it throws so the
+    // failure propagates up the render path and the delivery is nacked.
+    expect(postError).toBeInstanceOf(Error);
+    expect((postError as Error).message).toMatch(/egress post failed/i);
+    expect((postError as Error).message).toContain("provider_rejected");
   });
 });
 

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -1,6 +1,6 @@
 import type { AgentSubscriber } from "@ag-ui/client";
 import type {
-  BotNode,
+  ChannelNode,
   MessageRef,
   PlatformUser,
 } from "@copilotkit/channels-ui";
@@ -73,7 +73,7 @@ function targetFromRef(ref: MessageRef): ChannelReplyTarget {
   };
 }
 
-const textNode = (value: string): BotNode[] => [
+const textNode = (value: string): ChannelNode[] => [
   { type: "text", props: { value } },
 ];
 
@@ -258,14 +258,17 @@ export class IntelligenceAdapter implements PlatformAdapter {
     return this.renderSink;
   }
 
-  async start(sink: IngressSink, ctx?: { botName?: string }): Promise<void> {
+  async start(
+    sink: IngressSink,
+    ctx?: { channelName?: string },
+  ): Promise<void> {
     this.sink = sink;
-    // Config-free default: build the HTTP transports from env (+ the bot's
-    // name from createChannel, passed by bot core) when none were injected.
+    // Config-free default: build the HTTP transports from env (+ the channel's
+    // name from createChannel, passed by channel core) when none were injected.
     if (!this.source || !this.egress) {
       const cfg = resolveTransportConfig({
         ...this.opts.config,
-        channelName: this.opts.config?.channelName ?? ctx?.botName,
+        channelName: this.opts.config?.channelName ?? ctx?.channelName,
       });
       const source = (this.source ??= new HttpDeliverySource(cfg));
       this.egress ??= new HttpEgressSink(cfg);
@@ -492,13 +495,13 @@ export class IntelligenceAdapter implements PlatformAdapter {
     };
   }
 
-  render(ir: BotNode[]): NativePayload {
+  render(ir: ChannelNode[]): NativePayload {
     // Passthrough: platform rendering (IR -> Slack/Discord/...) happens in the
     // Connector Outbox via the per-platform codec (OSS-363).
     return ir;
   }
 
-  async post(target: ReplyTarget, ir: BotNode[]): Promise<MessageRef> {
+  async post(target: ReplyTarget, ir: ChannelNode[]): Promise<MessageRef> {
     // Realtime path: stream a `post` render frame carrying the IR so the
     // Connector Outbox renders full Block Kit (rich JSX preserved). Fallback
     // (no render sink wired — e.g. in-memory tests): the egress op path.
@@ -511,7 +514,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
     return this.emit(target as ChannelReplyTarget, { kind: "post", ir });
   }
 
-  async update(ref: MessageRef, ir: BotNode[]): Promise<void> {
+  async update(ref: MessageRef, ir: ChannelNode[]): Promise<void> {
     if (this.renderSink) {
       await this.postRenderFrame(targetFromRef(ref), {
         kind: "update",

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -485,10 +485,20 @@ export class IntelligenceAdapter implements PlatformAdapter {
   ): Promise<MessageRef> {
     const operation = this.mintOp(target, op);
     const res = await this.requireEgress().emit(operation);
+    // Fail loud on egress failure. Returning a synthetic MessageRef here would
+    // ack a dropped post/update/delete as success — silent data loss on the
+    // HTTP-fallback egress path. Throwing instead propagates the failure up the
+    // render/run path so the delivery is nacked (and retried) rather than
+    // silently completed.
+    if (!res.ok) {
+      throw new Error(
+        `IntelligenceAdapter: egress ${op.kind} failed (code: ${res.code}) for operation ${operation.operationId}`,
+      );
+    }
     // The minted ref carries routing so a later update/delete can re-address
     // the same operation; the Outbox maps operationId -> real platform message.
     return {
-      id: res.ok ? res.ref : operation.operationId,
+      id: res.ref,
       __route: target.route,
       __turnId: target.turnId,
       __deliveryId: target.deliveryId,

--- a/packages/channels-intelligence/src/ir-to-text.test.ts
+++ b/packages/channels-intelligence/src/ir-to-text.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { Section } from "@copilotkit/channels-ui";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import { irToText } from "./ir-to-text.js";
 
-const text = (value: string): BotNode =>
-  ({ type: "text", props: { value } }) as unknown as BotNode;
+const text = (value: string): ChannelNode =>
+  ({ type: "text", props: { value } }) as unknown as ChannelNode;
 
 describe("irToText", () => {
   it("returns the value of a single text node (the streamed-agent path)", () => {
@@ -12,7 +12,9 @@ describe("irToText", () => {
   });
 
   it("flattens nested children to text", () => {
-    expect(irToText([Section({ children: "reply" }) as BotNode])).toBe("reply");
+    expect(irToText([Section({ children: "reply" }) as ChannelNode])).toBe(
+      "reply",
+    );
   });
 
   it("joins multiple top-level nodes with newlines", () => {

--- a/packages/channels-intelligence/src/ir-to-text.ts
+++ b/packages/channels-intelligence/src/ir-to-text.ts
@@ -1,7 +1,7 @@
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 
 /**
- * Flatten Bot UI IR (`BotNode[]`) to plain text for the Intelligence egress
+ * Flatten Bot UI IR (`ChannelNode[]`) to plain text for the Intelligence egress
  * first slice, which accepts a plain `text` field only (Intelligence owns the
  * native platform rendering later via per-platform codecs — OSS-363/OSS-377).
  *
@@ -13,7 +13,7 @@ import type { BotNode } from "@copilotkit/channels-ui";
  *
  * TODO(OSS-377): drop once Intelligence renders IR via the shared codecs.
  */
-export function irToText(ir: BotNode[]): string {
+export function irToText(ir: ChannelNode[]): string {
   return ir
     .map((node) => nodeToText(node))
     .filter((s) => s.length > 0)

--- a/packages/channels-intelligence/src/realtime-gateway-transport.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-transport.ts
@@ -88,6 +88,43 @@ export interface RealtimeGatewayTransportOptions {
    * wire this to surface them. Absent → drops stay silent (fail-closed).
    */
   log?: (message: string, meta?: unknown) => void;
+  /**
+   * Per-turn deadline (ms) for the `onDelivery` handler. A turn that throws or
+   * hangs past this is nacked (released for redelivery) and logged, so a wedged
+   * handler can't silently pin a delivery forever. Mirrors the HTTP transport's
+   * `turnTimeoutMs`. Default {@link DEFAULT_DELIVERY_TIMEOUT_MS}.
+   */
+  deliveryTimeoutMs?: number;
+}
+
+/** Default per-turn deadline before a hung realtime turn is nacked and skipped. */
+const DEFAULT_DELIVERY_TIMEOUT_MS = 120_000;
+
+/**
+ * Reject after `ms` if `p` hasn't settled, so a hung turn can't wedge a
+ * delivery. The underlying promise keeps running in the background (a rejection
+ * handler is attached, so it never surfaces as unhandled); the transport nacks
+ * and moves on. Mirrors the HTTP transport's per-turn timeout.
+ */
+function withDeliveryTimeout<T>(
+  p: Promise<T>,
+  ms: number,
+  message: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms);
+    (timer as unknown as { unref?: () => void }).unref?.();
+    p.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
 }
 
 const RENDER_EVENT = "channel.render_event.v1";
@@ -121,6 +158,7 @@ export class RealtimeGatewayTransport
   private readonly session: RealtimeGatewaySession;
   private readonly now: () => string;
   private readonly log?: (message: string, meta?: unknown) => void;
+  private readonly deliveryTimeoutMs: number;
   private readonly deliveries = new Map<string, DeliveryState>();
   private onDelivery?: (env: ChannelIngressEnvelope) => Promise<void>;
 
@@ -131,6 +169,8 @@ export class RealtimeGatewayTransport
     this.session = config.session;
     this.now = config.now ?? (() => new Date().toISOString());
     this.log = config.log;
+    this.deliveryTimeoutMs =
+      config.deliveryTimeoutMs ?? DEFAULT_DELIVERY_TIMEOUT_MS;
   }
 
   async start(
@@ -138,7 +178,17 @@ export class RealtimeGatewayTransport
   ): Promise<void> {
     this.onDelivery = onDelivery;
     this.session.on(DELIVERY_AVAILABLE, (payload) => {
-      void this.handleDeliveryAvailable(payload);
+      // Error-boundary the dispatch: without a `.catch` an onDelivery rejection
+      // (or a parse/setup throw before the delivery is registered) becomes an
+      // unhandled promise rejection and the delivery is silently dropped. The
+      // per-turn failure/timeout path inside handleDeliveryAvailable nacks;
+      // this outer catch is the safety net for anything it can't (parse/setup
+      // errors that happen before a delivery id exists to nack).
+      this.handleDeliveryAvailable(payload).catch((err: unknown) => {
+        this.log?.("realtime gateway delivery dispatch failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
     });
   }
 
@@ -152,7 +202,31 @@ export class RealtimeGatewayTransport
       scope,
       accepted: new Map(),
     });
-    await this.onDelivery?.(env);
+    // Bound the turn (parity with the HTTP runLoop): a handler that throws or
+    // hangs past deliveryTimeoutMs must not wedge the delivery or leave the
+    // render stream half-open. On failure, nack so app-api releases the lease
+    // and redelivers rather than the turn silently pinning the delivery.
+    try {
+      await withDeliveryTimeout(
+        Promise.resolve(this.onDelivery?.(env)),
+        this.deliveryTimeoutMs,
+        `realtime gateway turn ${env.turnId} exceeded ${this.deliveryTimeoutMs}ms`,
+      );
+    } catch (err) {
+      this.log?.("realtime gateway turn failed/timed out; nacking", {
+        deliveryId: env.deliveryId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      await this.nack(
+        env.deliveryId,
+        err instanceof Error ? err.message : String(err),
+      ).catch((nackErr: unknown) =>
+        this.log?.("realtime gateway nack after turn failure failed", {
+          deliveryId: env.deliveryId,
+          error: nackErr instanceof Error ? nackErr.message : String(nackErr),
+        }),
+      );
+    }
   }
 
   /**

--- a/packages/channels-intelligence/src/render-events.test.ts
+++ b/packages/channels-intelligence/src/render-events.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import type { ReplyTarget } from "@copilotkit/channels";
 import { intelligenceAdapter } from "./intelligence-adapter.js";
 import {
@@ -300,6 +300,83 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
       (fail?.payload as { payload?: { leaseToken?: string } }).payload
         ?.leaseToken,
     ).toBe("lease_l1");
+  });
+
+  it("nacks and logs when the onDelivery handler throws (dispatch error-boundary)", async () => {
+    const fake = makeFakeSession();
+    const logs: string[] = [];
+    const t = new RealtimeGatewayTransport({
+      ...cfg(fake.session),
+      log: (m) => logs.push(m),
+    });
+    // A handler that rejects. Before the fix this dispatched via `void`, so the
+    // rejection became an unhandled promise rejection and the delivery was
+    // silently dropped (never nacked, so app-api could not release it promptly).
+    await t.start(async () => {
+      throw new Error("handler boom");
+    });
+    fake.handlers.get("channel.delivery.available.v1")?.({
+      payload: {
+        delivery: {
+          id: "dlv_d1",
+          leaseToken: "lease_l1",
+          adapter: "slack",
+          channel: { id: "channel_1", name: "support" },
+          turn: {
+            id: "turn_t1",
+            eventId: "evt_1",
+            input: { kind: "text", text: "hi" },
+          },
+        },
+      },
+    });
+
+    await vi.waitFor(() =>
+      expect(fake.pushes.map((p) => p.event)).toContain(
+        "channel.delivery.fail.v1",
+      ),
+    );
+    expect(logs.some((m) => m.includes("turn failed/timed out"))).toBe(true);
+    expect(fake.pushes.map((p) => p.event)).not.toContain(
+      "channel.delivery.ack.v1",
+    );
+  });
+
+  it("nacks and logs when the onDelivery handler exceeds deliveryTimeoutMs (per-turn timeout)", async () => {
+    const fake = makeFakeSession();
+    const logs: string[] = [];
+    const t = new RealtimeGatewayTransport({
+      ...cfg(fake.session),
+      log: (m) => logs.push(m),
+      // Tiny per-turn deadline so a hung handler is bounded quickly in the test.
+      deliveryTimeoutMs: 10,
+    });
+    // A handler that never settles — the wedged-turn case the timeout guards.
+    await t.start(() => new Promise<void>(() => {}));
+    fake.handlers.get("channel.delivery.available.v1")?.({
+      payload: {
+        delivery: {
+          id: "dlv_d1",
+          leaseToken: "lease_l1",
+          adapter: "slack",
+          channel: { id: "channel_1", name: "support" },
+          turn: {
+            id: "turn_t1",
+            eventId: "evt_1",
+            input: { kind: "text", text: "hi" },
+          },
+        },
+      },
+    });
+
+    await vi.waitFor(
+      () =>
+        expect(fake.pushes.map((p) => p.event)).toContain(
+          "channel.delivery.fail.v1",
+        ),
+      { timeout: 1000 },
+    );
+    expect(logs.some((m) => m.includes("turn failed/timed out"))).toBe(true);
   });
 
   it("drops a delivery with no leaseToken (never fires onDelivery) and logs it", async () => {

--- a/packages/channels-slack/src/__tests__/views.test.ts
+++ b/packages/channels-slack/src/__tests__/views.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { decodeViewSubmission, decodeViewClosed } from "../interaction.js";
 import { SlackAdapter } from "../adapter.js";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 
 describe("decodeViewSubmission", () => {
   it("parses field values from a view_submission payload", () => {
@@ -118,7 +118,7 @@ describe("decodeViewClosed", () => {
 });
 
 describe("SlackAdapter.openModal", () => {
-  const modalIr: BotNode[] = [
+  const modalIr: ChannelNode[] = [
     {
       type: "modal",
       props: {
@@ -126,7 +126,7 @@ describe("SlackAdapter.openModal", () => {
         title: "File issue",
         children: [],
       },
-    } as unknown as BotNode,
+    } as unknown as ChannelNode,
   ];
 
   function makeAdapter() {
@@ -160,7 +160,7 @@ describe("SlackAdapter.openModal", () => {
 
   it("preserves an author-set private_metadata under pm", async () => {
     const { adapter, open } = makeAdapter();
-    const irWithMeta: BotNode[] = [
+    const irWithMeta: ChannelNode[] = [
       {
         type: "modal",
         props: {
@@ -169,7 +169,7 @@ describe("SlackAdapter.openModal", () => {
           privateMetadata: "authorMeta",
           children: [],
         },
-      } as unknown as BotNode,
+      } as unknown as ChannelNode,
     ];
     await adapter.openModal(
       { channel: "C123" } as never,

--- a/packages/channels-slack/src/adapter.test.ts
+++ b/packages/channels-slack/src/adapter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { SlackAdapter } from "./adapter.js";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import type { InteractionEvent, IngressSink } from "@copilotkit/channels";
 
 /**
@@ -24,7 +24,7 @@ function makeAdapter() {
   return { adapter, chat };
 }
 
-const section = (text: string): BotNode => ({
+const section = (text: string): ChannelNode => ({
   type: "section",
   props: { children: [{ type: "text", props: { value: text } }] },
 });
@@ -56,7 +56,7 @@ describe("SlackAdapter.post", () => {
 
   it("renders a <Message accent> as a colored attachment with a short top-level text and NO fallback on the attachment", async () => {
     const { adapter, chat } = makeAdapter();
-    const header = (text: string): BotNode => ({
+    const header = (text: string): ChannelNode => ({
       type: "header",
       props: { children: [{ type: "text", props: { value: text } }] },
     });
@@ -104,7 +104,7 @@ describe("SlackAdapter.post", () => {
 
   it("uses the header as the short fallback summary — not a dump of the whole card", async () => {
     const { adapter, chat } = makeAdapter();
-    const header = (text: string): BotNode => ({
+    const header = (text: string): ChannelNode => ({
       type: "header",
       props: { children: [{ type: "text", props: { value: text } }] },
     });
@@ -144,7 +144,7 @@ describe("SlackAdapter.update / delete use the stashed channel", () => {
 
   it("update of an accent card sets a short top-level text and attachments with NO fallback", async () => {
     const { adapter, chat } = makeAdapter();
-    const header = (text: string): BotNode => ({
+    const header = (text: string): ChannelNode => ({
       type: "header",
       props: { children: [{ type: "text", props: { value: text } }] },
     });

--- a/packages/channels-slack/src/adapter.ts
+++ b/packages/channels-slack/src/adapter.ts
@@ -25,7 +25,7 @@ import type {
 } from "@copilotkit/channels";
 import type { AbstractAgent } from "@ag-ui/client";
 import type {
-  BotNode,
+  ChannelNode,
   ThreadMessage,
   EmojiValue,
 } from "@copilotkit/channels-ui";
@@ -311,11 +311,11 @@ export class SlackAdapter implements PlatformAdapter {
     await this.app.stop();
   }
 
-  render(ir: BotNode[]) {
+  render(ir: ChannelNode[]) {
     return renderBlockKit(ir);
   }
 
-  async post(target: BotReplyTarget, ir: BotNode[]): Promise<MessageRef> {
+  async post(target: BotReplyTarget, ir: ChannelNode[]): Promise<MessageRef> {
     const t = target as ReplyTarget;
     const { blocks, accent } = renderSlackMessage(ir);
     const summary = fallbackText(ir);
@@ -342,7 +342,7 @@ export class SlackAdapter implements PlatformAdapter {
     return { id: res.ts as string, channel: t.channel, ts: res.ts };
   }
 
-  async update(ref: MessageRef, ir: BotNode[]): Promise<void> {
+  async update(ref: MessageRef, ir: ChannelNode[]): Promise<void> {
     const channel = channelOf(ref);
     const { blocks, accent } = renderSlackMessage(ir);
     const summary = fallbackText(ir);
@@ -944,7 +944,7 @@ export class SlackAdapter implements PlatformAdapter {
   async postEphemeral(
     target: BotReplyTarget,
     user: PlatformUser | string,
-    ir: BotNode[],
+    ir: ChannelNode[],
     _opts: { fallbackToDM: boolean },
   ): Promise<EphemeralResult | null> {
     const t = target as ReplyTarget;
@@ -973,7 +973,7 @@ export class SlackAdapter implements PlatformAdapter {
   }
 
   /** Render a modal IR tree to a Slack `views.open` `View` (pure; backs `openModal`). */
-  renderModal(ir: BotNode[]): NativePayload {
+  renderModal(ir: ChannelNode[]): NativePayload {
     return renderSlackModal(ir);
   }
 
@@ -985,7 +985,7 @@ export class SlackAdapter implements PlatformAdapter {
   async openModal(
     target: BotReplyTarget,
     triggerId: string,
-    ir: BotNode[],
+    ir: ChannelNode[],
   ): Promise<{ ok: boolean; error?: string }> {
     try {
       const t = target as ReplyTarget;
@@ -1026,9 +1026,9 @@ function channelOf(ref: MessageRef): string {
 }
 
 /** Collect a node's descendant text into a single whitespace-joined string. */
-function collectNodeText(node: BotNode): string {
+function collectNodeText(node: ChannelNode): string {
   const acc: string[] = [];
-  const visit = (n: BotNode): void => {
+  const visit = (n: ChannelNode): void => {
     if (typeof n.type === "string" && n.type === "text") {
       const value = n.props?.value;
       if (value != null) acc.push(String(value));
@@ -1040,14 +1040,14 @@ function collectNodeText(node: BotNode): string {
       : children && typeof children === "object" && "type" in children
         ? [children]
         : [];
-    for (const child of list as BotNode[]) visit(child);
+    for (const child of list as ChannelNode[]) visit(child);
   };
   visit(node);
   return acc.join(" ");
 }
 
 /** Depth-first search for the first node of `type` in the IR tree. */
-function findFirst(ir: BotNode[], type: string): BotNode | undefined {
+function findFirst(ir: ChannelNode[], type: string): ChannelNode | undefined {
   for (const node of ir) {
     if (typeof node.type === "string" && node.type === type) return node;
     const children = node.props?.children;
@@ -1056,7 +1056,7 @@ function findFirst(ir: BotNode[], type: string): BotNode | undefined {
       : children && typeof children === "object" && "type" in children
         ? [children]
         : [];
-    const found = findFirst(list as BotNode[], type);
+    const found = findFirst(list as ChannelNode[], type);
     if (found) return found;
   }
   return undefined;
@@ -1070,7 +1070,7 @@ function findFirst(ir: BotNode[], type: string): BotNode | undefined {
  * MUST stay short: it is the notification text, never a dump of the whole tree
  * (which Slack would render as a duplicate "text wall" above the card).
  */
-function fallbackText(ir: BotNode[]): string {
+function fallbackText(ir: ChannelNode[]): string {
   const header = findFirst(ir, "header");
   const source = header ? collectNodeText(header) : firstText(ir);
   const text = source.replace(/\s+/g, " ").trim();
@@ -1079,7 +1079,7 @@ function fallbackText(ir: BotNode[]): string {
 }
 
 /** First descendant text node's value across the whole IR, or "". */
-function firstText(ir: BotNode[]): string {
+function firstText(ir: ChannelNode[]): string {
   for (const node of ir) {
     const t = collectNodeText(node);
     if (t.trim()) return t;

--- a/packages/channels-slack/src/codec.test.ts
+++ b/packages/channels-slack/src/codec.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import { slackCodec } from "./codec.js";
 
 describe("slackCodec", () => {
@@ -8,7 +8,7 @@ describe("slackCodec", () => {
   });
 
   it("renders IR to Slack Block Kit via the shared pure renderer", () => {
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       {
         type: "section",
         props: { children: [{ type: "text", props: { value: "hi" } }] },

--- a/packages/channels-slack/src/render/block-kit.test.ts
+++ b/packages/channels-slack/src/render/block-kit.test.ts
@@ -1,5 +1,5 @@
 import { Header, Message, Section, renderToIR } from "@copilotkit/channels-ui";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import { describe, expect, it } from "vitest";
 import { renderBlockKit, renderSlackMessage } from "./block-kit.js";
 
@@ -20,7 +20,7 @@ describe("renderBlockKit", () => {
   });
 
   it("renders a pre-bound button inside actions with its stamped action_id", () => {
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       {
         type: "actions",
         props: {
@@ -116,7 +116,7 @@ describe("renderBlockKit", () => {
   });
 
   it("renders a Table IR into a native Slack table block", () => {
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       {
         type: "table",
         props: {

--- a/packages/channels-slack/src/render/block-kit.ts
+++ b/packages/channels-slack/src/render/block-kit.ts
@@ -1,4 +1,4 @@
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import type { ContextActionsBlock, KnownBlock } from "@slack/types";
 import { markdownToMrkdwn } from "../markdown-to-mrkdwn.js";
 import { SLACK_LIMITS, clampArray, truncateText } from "./budget.js";
@@ -62,7 +62,7 @@ export function buildFeedbackBlocks(opts?: {
  * {@link clampArray}; nothing is silently dropped — overflowing collections
  * clamp and, at the top level, append an explicit overflow signal block.
  */
-export function renderBlockKit(ir: BotNode[]): KnownBlock[] {
+export function renderBlockKit(ir: ChannelNode[]): KnownBlock[] {
   const blocks: KnownBlock[] = [];
   for (const node of ir) {
     renderNode(node, blocks);
@@ -82,7 +82,7 @@ export function renderBlockKit(ir: BotNode[]): KnownBlock[] {
 }
 
 /** Render IR to Slack blocks, extracting a top-level <Message accent="#hex"> color for an attachment wrapper. */
-export function renderSlackMessage(ir: BotNode[]): {
+export function renderSlackMessage(ir: ChannelNode[]): {
   blocks: KnownBlock[];
   accent?: string;
 } {
@@ -104,7 +104,7 @@ function overflowSignal(count: number): KnownBlock {
 }
 
 /** Render a single IR node, pushing zero or more blocks onto `out`. */
-function renderNode(node: BotNode, out: KnownBlock[]): void {
+function renderNode(node: ChannelNode, out: KnownBlock[]): void {
   if (typeof node.type !== "string") return; // non-intrinsic — already expanded away
   const props = node.props ?? {};
   switch (node.type) {
@@ -307,7 +307,7 @@ function renderNode(node: BotNode, out: KnownBlock[]): void {
  * Render one interactive element inside an `actions` block. Returns `null` for
  * children that aren't renderable as action elements (so callers can filter).
  */
-function renderActionElement(node: BotNode): object | null {
+function renderActionElement(node: ChannelNode): object | null {
   if (typeof node.type !== "string") return null;
   const props = node.props ?? {};
   switch (node.type) {
@@ -373,7 +373,7 @@ function renderActionElement(node: BotNode): object | null {
  * `multi_static_select` (which Slack forbids inside an `actions` block). The
  * block_actions payload carries `selected_options`, decoded to a `string[]`.
  */
-function multiSelectInput(node: BotNode): KnownBlock {
+function multiSelectInput(node: ChannelNode): KnownBlock {
   const props = node.props ?? {};
   const action_id = truncateText(
     idFromHandler(props.onSelect) ?? "select",
@@ -420,22 +420,22 @@ function idFromHandler(handler: unknown): string | undefined {
   return undefined;
 }
 
-/** The expanded `children` of an IR node as an `BotNode[]` (empty if none). */
-function childNodes(node: BotNode): BotNode[] {
+/** The expanded `children` of an IR node as an `ChannelNode[]` (empty if none). */
+function childNodes(node: ChannelNode): ChannelNode[] {
   const children = node.props?.children;
-  if (Array.isArray(children)) return children as BotNode[];
+  if (Array.isArray(children)) return children as ChannelNode[];
   if (
     children &&
     typeof children === "object" &&
     "type" in (children as object)
   ) {
-    return [children as BotNode];
+    return [children as ChannelNode];
   }
   return [];
 }
 
 /** A field's mrkdwn text: a bold `label` line (when set) above the value. */
-function fieldMrkdwn(node: BotNode): string {
+function fieldMrkdwn(node: ChannelNode): string {
   const value = markdownToMrkdwn(collectText(node));
   const label = (node.props as { label?: unknown }).label;
   return typeof label === "string" && label.length > 0
@@ -444,7 +444,7 @@ function fieldMrkdwn(node: BotNode): string {
 }
 
 /** Concatenate the `value` of all descendant `text` nodes (depth-first). */
-function collectText(node: BotNode): string {
+function collectText(node: ChannelNode): string {
   if (typeof node.type === "string" && node.type === "text") {
     return String(node.props?.value ?? "");
   }

--- a/packages/channels-slack/src/render/modal.ts
+++ b/packages/channels-slack/src/render/modal.ts
@@ -1,20 +1,20 @@
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import { ModalRenderError } from "@copilotkit/channels-ui";
 import type { View } from "@slack/web-api";
 
 const plain = (text: string) => ({ type: "plain_text" as const, text });
 
-function optionFrom(node: BotNode) {
+function optionFrom(node: ChannelNode) {
   return {
     text: plain(String(node.props.label ?? "")),
     value: String(node.props.value ?? ""),
   };
 }
 
-function childOptions(node: BotNode): BotNode[] {
+function childOptions(node: ChannelNode): ChannelNode[] {
   const kids = node.props.children;
   return Array.isArray(kids)
-    ? (kids as BotNode[]).filter((k) => k.type === "modal_select_option")
+    ? (kids as ChannelNode[]).filter((k) => k.type === "modal_select_option")
     : [];
 }
 
@@ -27,12 +27,12 @@ function childOptions(node: BotNode): BotNode[] {
  * back to the field. Throws {@link ModalRenderError} when there is no modal
  * root or a child uses an unsupported element type.
  */
-export function renderSlackModal(ir: BotNode[]): View {
+export function renderSlackModal(ir: ChannelNode[]): View {
   const root = ir.find((n) => n.type === "modal");
   if (!root)
     throw new ModalRenderError("renderSlackModal: no <Modal> root in IR");
   const p = root.props as Record<string, unknown>;
-  const kids = Array.isArray(p.children) ? (p.children as BotNode[]) : [];
+  const kids = Array.isArray(p.children) ? (p.children as ChannelNode[]) : [];
   const blocks = kids.map((node): unknown => {
     const fp = node.props as Record<string, unknown>;
     const id = String(fp.id ?? "");

--- a/packages/channels-teams/src/adapter.ts
+++ b/packages/channels-teams/src/adapter.ts
@@ -18,7 +18,7 @@ import type {
   UserQuery,
 } from "@copilotkit/channels";
 import type {
-  BotNode,
+  ChannelNode,
   ThreadMessage,
   AgentContentPart,
 } from "@copilotkit/channels-ui";
@@ -386,13 +386,13 @@ export class TeamsAdapter implements PlatformAdapter {
    * otherwise an Adaptive Card. (A bare `Echo: hi` is a text bubble; structured
    * or interactive UI becomes a card.)
    */
-  render(ir: BotNode[]): TeamsActivityPayload {
+  render(ir: ChannelNode[]): TeamsActivityPayload {
     return isPlainText(ir)
       ? { text: renderTeamsMarkdown(ir) }
       : { card: renderAdaptiveCard(ir) };
   }
 
-  async post(target: ReplyTarget, ir: BotNode[]): Promise<MessageRef> {
+  async post(target: ReplyTarget, ir: ChannelNode[]): Promise<MessageRef> {
     const t = target as TeamsReplyTarget;
     const payload = this.render(ir);
     const id =
@@ -402,7 +402,7 @@ export class TeamsAdapter implements PlatformAdapter {
     return { id, conversationKey: t.conversationKey, context: t.context };
   }
 
-  async update(ref: MessageRef, ir: BotNode[]): Promise<void> {
+  async update(ref: MessageRef, ir: ChannelNode[]): Promise<void> {
     const r = ref as TeamsMessageRef;
     if (!r.id) return;
     const payload = this.render(ir);

--- a/packages/channels-teams/src/button-action-envelope.contract.test.ts
+++ b/packages/channels-teams/src/button-action-envelope.contract.test.ts
@@ -6,16 +6,20 @@
  * `docs/button-action-envelope.md`.
  */
 import { describe, it, expect } from "vitest";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import { renderAdaptiveCard } from "./render/adaptive-card.js";
-import {
-  parseCardAction,
-  conversationKeyOf,
-  type TeamsActivityLike,
-} from "./interaction.js";
+import { parseCardAction, conversationKeyOf } from "./interaction.js";
+import type { TeamsActivityLike } from "./interaction.js";
 
-const text = (value: string): BotNode => ({ type: "text", props: { value } });
-const el = (type: string, children: BotNode[], props = {}): BotNode => ({
+const text = (value: string): ChannelNode => ({
+  type: "text",
+  props: { value },
+});
+const el = (
+  type: string,
+  children: ChannelNode[],
+  props = {},
+): ChannelNode => ({
   type,
   props: { ...props, children },
 });

--- a/packages/channels-teams/src/render/adaptive-card.test.ts
+++ b/packages/channels-teams/src/render/adaptive-card.test.ts
@@ -1,17 +1,24 @@
 import { describe, it, expect } from "vitest";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import {
   renderAdaptiveCard,
   isPlainText,
   collectPlainText,
 } from "./adaptive-card.js";
 
-const text = (value: string): BotNode => ({ type: "text", props: { value } });
-const el = (type: string, children: BotNode[], props = {}): BotNode => ({
+const text = (value: string): ChannelNode => ({
+  type: "text",
+  props: { value },
+});
+const el = (
+  type: string,
+  children: ChannelNode[],
+  props = {},
+): ChannelNode => ({
   type,
   props: { ...props, children },
 });
-const chart = (props: Record<string, unknown>): BotNode => ({
+const chart = (props: Record<string, unknown>): ChannelNode => ({
   type: "chart",
   props,
 });

--- a/packages/channels-teams/src/render/adaptive-card.ts
+++ b/packages/channels-teams/src/render/adaptive-card.ts
@@ -1,4 +1,4 @@
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import { TEAMS_LIMITS, truncateText, clampArray } from "./budget.js";
 
 /** Teams attachment content type for an Adaptive Card. */
@@ -38,7 +38,7 @@ const VERSION = "1.5";
  * text truncates to {@link TEAMS_LIMITS} so the card stays within Teams' payload
  * ceiling.
  */
-export function renderAdaptiveCard(ir: BotNode[]): AdaptiveCard {
+export function renderAdaptiveCard(ir: ChannelNode[]): AdaptiveCard {
   const body: CardElement[] = [];
   const actions: CardAction[] = [];
   for (const node of ir) renderNode(node, body, actions);
@@ -56,7 +56,7 @@ export function renderAdaptiveCard(ir: BotNode[]): AdaptiveCard {
 
 /** Render a single IR node, pushing body elements and/or top-level actions. */
 function renderNode(
-  node: BotNode,
+  node: ChannelNode,
   body: CardElement[],
   actions: CardAction[],
 ): void {
@@ -151,7 +151,7 @@ function textBlock(text: string): CardElement {
 
 /** A `<Fields>`/`<Field>` group → a `FactSet`. Each field's text is split on
  *  its first colon into title/value (falling back to a value-only fact). */
-function factSet(fieldNodes: BotNode[]): CardElement {
+function factSet(fieldNodes: ChannelNode[]): CardElement {
   const { items } = clampArray(fieldNodes, TEAMS_LIMITS.factsPerSet);
   const facts = items.map((f) => {
     const text = collectText(f);
@@ -167,7 +167,7 @@ function factSet(fieldNodes: BotNode[]): CardElement {
   return { type: "FactSet", facts };
 }
 
-function renderButton(node: BotNode): CardAction {
+function renderButton(node: ChannelNode): CardAction {
   const props = node.props ?? {};
   // Link button → Action.OpenUrl (opens the URL; carries no submit data).
   if (typeof props.url === "string" && props.url.length > 0) {
@@ -196,7 +196,7 @@ function renderButton(node: BotNode): CardAction {
   return action;
 }
 
-function renderSelect(node: BotNode): CardElement {
+function renderSelect(node: ChannelNode): CardElement {
   const props = node.props ?? {};
   const options =
     (props.options as { label: string; value: unknown }[] | undefined) ?? [];
@@ -215,7 +215,7 @@ function renderSelect(node: BotNode): CardElement {
   return el;
 }
 
-function renderInput(node: BotNode): CardElement {
+function renderInput(node: ChannelNode): CardElement {
   const props = node.props ?? {};
   const el: CardElement = {
     type: "Input.Text",
@@ -227,7 +227,7 @@ function renderInput(node: BotNode): CardElement {
 }
 
 /** A `<Table>` → a native Adaptive Cards `Table` (1.5). */
-function renderTable(node: BotNode): CardElement {
+function renderTable(node: ChannelNode): CardElement {
   const props = node.props ?? {};
   const cell = (text: string, header = false): Record<string, unknown> => ({
     type: "TableCell",
@@ -287,7 +287,7 @@ function renderTable(node: BotNode): CardElement {
  * opts into chart support; other Adaptive Card hosts ignore the unknown
  * element. Data points clamp and labels/title truncate to the budget.
  */
-function renderChart(node: BotNode): CardElement {
+function renderChart(node: ChannelNode): CardElement {
   const props = node.props ?? {};
   const type = String(props.type ?? "verticalBar");
   const title =
@@ -345,7 +345,7 @@ function renderChart(node: BotNode): CardElement {
 }
 
 /** When no explicit `columns` are given, size the grid to the widest row. */
-function inferColumns(rowNodes: BotNode[]): { align?: undefined }[] {
+function inferColumns(rowNodes: ChannelNode[]): { align?: undefined }[] {
   let widest = 0;
   for (const r of rowNodes) {
     const n = childNodes(r).filter((c) => c.type === "cell").length;
@@ -370,22 +370,22 @@ function idFromHandler(handler: unknown): string | undefined {
   return undefined;
 }
 
-/** The expanded `children` of an IR node as a `BotNode[]` (empty if none). */
-function childNodes(node: BotNode): BotNode[] {
+/** The expanded `children` of an IR node as a `ChannelNode[]` (empty if none). */
+function childNodes(node: ChannelNode): ChannelNode[] {
   const children = node.props?.children;
-  if (Array.isArray(children)) return children as BotNode[];
+  if (Array.isArray(children)) return children as ChannelNode[];
   if (
     children &&
     typeof children === "object" &&
     "type" in (children as object)
   ) {
-    return [children as BotNode];
+    return [children as ChannelNode];
   }
   return [];
 }
 
 /** Concatenate the `value` of all descendant `text` nodes (depth-first). */
-function collectText(node: BotNode): string {
+function collectText(node: ChannelNode): string {
   if (typeof node.type === "string" && node.type === "text") {
     return String(node.props?.value ?? "");
   }
@@ -399,7 +399,7 @@ function collectText(node: BotNode): string {
  * Such replies are sent as a normal Teams text activity rather than wrapped in
  * an Adaptive Card. A bare `Echo: hi` shouldn't render as a card.
  */
-export function isPlainText(ir: BotNode[]): boolean {
+export function isPlainText(ir: ChannelNode[]): boolean {
   const RICH = new Set([
     "header",
     "fields",
@@ -416,7 +416,7 @@ export function isPlainText(ir: BotNode[]): boolean {
     "divider",
     "context",
   ]);
-  const visit = (node: BotNode): boolean => {
+  const visit = (node: ChannelNode): boolean => {
     if (typeof node.type === "string" && RICH.has(node.type)) return false;
     return childNodes(node).every(visit);
   };
@@ -424,7 +424,7 @@ export function isPlainText(ir: BotNode[]): boolean {
 }
 
 /** Plain-text projection of an IR tree (depth-first text, blocks joined). */
-export function collectPlainText(ir: BotNode[]): string {
+export function collectPlainText(ir: ChannelNode[]): string {
   return ir
     .map((n) => collectText(n))
     .filter((s) => s.length > 0)

--- a/packages/channels-teams/src/render/markdown.test.ts
+++ b/packages/channels-teams/src/render/markdown.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from "vitest";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import { renderTeamsMarkdown } from "./markdown.js";
 
-const text = (value: string): BotNode => ({ type: "text", props: { value } });
+const text = (value: string): ChannelNode => ({
+  type: "text",
+  props: { value },
+});
 
 describe("renderTeamsMarkdown", () => {
   it("renders a bare text node", () => {
@@ -10,7 +13,7 @@ describe("renderTeamsMarkdown", () => {
   });
 
   it("renders a header as bold", () => {
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       { type: "header", props: { children: [text("Title")] } },
     ];
     expect(renderTeamsMarkdown(ir)).toBe("**Title**");
@@ -21,7 +24,7 @@ describe("renderTeamsMarkdown", () => {
   });
 
   it("joins a message container's children with blank lines", () => {
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       {
         type: "message",
         props: {
@@ -36,7 +39,7 @@ describe("renderTeamsMarkdown", () => {
   });
 
   it("renders context children as emphasized lines", () => {
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       { type: "context", props: { children: [text("fyi")] } },
     ];
     expect(renderTeamsMarkdown(ir)).toBe("_fyi_");
@@ -47,11 +50,11 @@ describe("renderTeamsMarkdown", () => {
   });
 
   it("renders a <Table> as a GFM pipe-table fallback", () => {
-    const cell = (v: string): BotNode => ({
+    const cell = (v: string): ChannelNode => ({
       type: "cell",
       props: { children: [text(v)] },
     });
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       {
         type: "table",
         props: {

--- a/packages/channels-teams/src/render/markdown.ts
+++ b/packages/channels-teams/src/render/markdown.ts
@@ -1,4 +1,4 @@
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 
 /**
  * Render the bot-ui IR tree to a Teams message string.
@@ -10,7 +10,7 @@ import type { BotNode } from "@copilotkit/channels-ui";
  * shapes; richer interactive surfaces (buttons, inputs) will render to
  * Adaptive Cards in a follow-up (see the package README).
  */
-export function renderTeamsMarkdown(ir: BotNode[]): string {
+export function renderTeamsMarkdown(ir: ChannelNode[]): string {
   return ir
     .map((node) => renderNode(node))
     .filter((s) => s.length > 0)
@@ -18,7 +18,7 @@ export function renderTeamsMarkdown(ir: BotNode[]): string {
     .trim();
 }
 
-function renderNode(node: BotNode): string {
+function renderNode(node: ChannelNode): string {
   if (typeof node.type !== "string") {
     // Components are expanded to intrinsic nodes before render(); a stray
     // function/symbol node carries no renderable text.
@@ -66,7 +66,7 @@ function renderNode(node: BotNode): string {
  * native Table; this is the text-surface fallback). Teams renders GFM pipe
  * tables in message text.
  */
-function renderTable(node: BotNode): string {
+function renderTable(node: ChannelNode): string {
   const columns = node.props?.columns as
     | { header: string; align?: "left" | "center" | "right" }[]
     | undefined;
@@ -99,7 +99,7 @@ function renderTable(node: BotNode): string {
   );
 }
 
-function renderChildren(node: BotNode): string {
+function renderChildren(node: ChannelNode): string {
   const kids = childNodes(node);
   if (kids.length === 0) return "";
   return kids
@@ -109,19 +109,19 @@ function renderChildren(node: BotNode): string {
 }
 
 /** Normalize a node's `children` prop to an array of child nodes. */
-function childNodes(node: BotNode): BotNode[] {
+function childNodes(node: ChannelNode): ChannelNode[] {
   const children = node.props?.children;
-  if (Array.isArray(children)) return children as BotNode[];
+  if (Array.isArray(children)) return children as ChannelNode[];
   if (children && typeof children === "object" && "type" in children) {
-    return [children as BotNode];
+    return [children as ChannelNode];
   }
   return [];
 }
 
 /** Depth-first collection of a node's descendant text. */
-function collectText(node: BotNode): string {
+function collectText(node: ChannelNode): string {
   const out: string[] = [];
-  const visit = (n: BotNode): void => {
+  const visit = (n: ChannelNode): void => {
     if (typeof n.type === "string" && n.type === "text") {
       const value = n.props?.value;
       if (value != null) out.push(String(value));

--- a/packages/channels-telegram/src/adapter.ts
+++ b/packages/channels-telegram/src/adapter.ts
@@ -14,7 +14,7 @@ import type {
   CommandSpec,
 } from "@copilotkit/channels";
 import type {
-  BotNode,
+  ChannelNode,
   ThreadMessage,
   EmojiValue,
   EphemeralResult,
@@ -251,11 +251,11 @@ export class TelegramAdapter implements PlatformAdapter {
     await this.bot.stop();
   }
 
-  render(ir: BotNode[]): TelegramPayload {
+  render(ir: ChannelNode[]): TelegramPayload {
     return renderTelegram(ir);
   }
 
-  async post(target: BotReplyTarget, ir: BotNode[]): Promise<MessageRef> {
+  async post(target: BotReplyTarget, ir: ChannelNode[]): Promise<MessageRef> {
     const t = target as ReplyTarget;
     const p = renderTelegram(ir);
     const replyMarkup = this.toReplyMarkup(p.inlineKeyboard);
@@ -349,7 +349,7 @@ export class TelegramAdapter implements PlatformAdapter {
     return ref;
   }
 
-  async update(ref: MessageRef, ir: BotNode[]): Promise<void> {
+  async update(ref: MessageRef, ir: ChannelNode[]): Promise<void> {
     const r = ref as TelegramMessageRef;
     // Guard against a bogus ref (e.g. the empty ref returned by stream() when
     // no chunk was posted): a message id of 0/undefined can never be edited.
@@ -656,7 +656,7 @@ export class TelegramAdapter implements PlatformAdapter {
   async postEphemeral(
     _target: BotReplyTarget,
     user: PlatformUser | string,
-    ir: BotNode[],
+    ir: ChannelNode[],
     opts: { fallbackToDM: boolean },
   ): Promise<EphemeralResult | null> {
     if (!opts.fallbackToDM) return null; // no native ephemeral on Telegram

--- a/packages/channels-telegram/src/render/telegram.ts
+++ b/packages/channels-telegram/src/render/telegram.ts
@@ -1,4 +1,4 @@
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import type { TelegramInlineButton, TelegramPayload } from "../types.js";
 import { telegramHtml, escapeHtml } from "../telegram-html.js";
 import {
@@ -35,7 +35,7 @@ interface LineEntry {
  * throwing. Telegram limits are enforced via {@link truncateText},
  * {@link clampArray}, and {@link byteLen}.
  */
-export function renderTelegram(ir: BotNode[]): TelegramPayload {
+export function renderTelegram(ir: ChannelNode[]): TelegramPayload {
   // Each entry holds the pre-HTML (raw) text and the corresponding HTML for a
   // line. Separating them lets us apply the character budget to SOURCE text
   // before HTML conversion, so the emitted HTML is always well-formed.
@@ -206,7 +206,7 @@ function sliceHtmlSafely(html: string, limit: number): string {
 
 /** Render a single IR node, appending to lineEntries/inlineKeyboard/photos. */
 function renderNode(
-  node: BotNode,
+  node: ChannelNode,
   lineEntries: LineEntry[],
   inlineKeyboard: TelegramInlineButton[][],
   photos: { url: string; caption?: string }[],
@@ -442,7 +442,7 @@ function appendButtons(
 }
 
 /** Render one button node for an inline keyboard. Returns null for non-renderable nodes. */
-function renderActionButton(node: BotNode): TelegramInlineButton | null {
+function renderActionButton(node: ChannelNode): TelegramInlineButton | null {
   if (typeof node.type !== "string") return null;
   if (node.type !== "button") return null;
 
@@ -478,22 +478,22 @@ function actionIdOf(props: Record<string, unknown>): string {
   return "action";
 }
 
-/** The expanded `children` of an IR node as a `BotNode[]` (empty if none). */
-function childNodes(node: BotNode): BotNode[] {
+/** The expanded `children` of an IR node as a `ChannelNode[]` (empty if none). */
+function childNodes(node: ChannelNode): ChannelNode[] {
   const children = node.props?.children;
-  if (Array.isArray(children)) return children as BotNode[];
+  if (Array.isArray(children)) return children as ChannelNode[];
   if (
     children &&
     typeof children === "object" &&
     "type" in (children as object)
   ) {
-    return [children as BotNode];
+    return [children as ChannelNode];
   }
   return [];
 }
 
 /** Concatenate the `value` of all descendant `text` nodes (depth-first). */
-function collectText(node: BotNode): string {
+function collectText(node: ChannelNode): string {
   if (typeof node.type === "string" && node.type === "text") {
     return String(node.props?.value ?? "");
   }

--- a/packages/channels-ui/src/bind.ts
+++ b/packages/channels-ui/src/bind.ts
@@ -1,5 +1,5 @@
 import type { ClickHandler, InteractionContext } from "./types.js";
-const BOUND = Symbol.for("copilotkit.bot-ui.bound");
+const BOUND = Symbol.for("copilotkit.channels-ui.bound");
 interface BoundHandler {
   (...a: unknown[]): unknown;
   [BOUND]?: { handler: ClickHandler; args: unknown };

--- a/packages/channels-ui/src/components.test.tsx
+++ b/packages/channels-ui/src/components.test.tsx
@@ -1,4 +1,4 @@
-import type { BotNode } from "./ir.js";
+import type { ChannelNode } from "./ir.js";
 import { describe, it, expect } from "vitest";
 import { renderToIR } from "./render.js";
 import {
@@ -92,7 +92,7 @@ describe("component vocabulary", () => {
       </Actions>,
     );
     const actions = out[0]!;
-    const button = (actions.props.children as BotNode[])[0] as BotNode;
+    const button = (actions.props.children as ChannelNode[])[0] as ChannelNode;
     expect(button.type).toBe("button");
     expect(button.props.onClick).toBe(fn);
     expect(button.props.style).toBe("primary");
@@ -115,13 +115,13 @@ describe("component vocabulary", () => {
     const table = out[0]!;
     expect(table.type).toBe("table");
     expect((table.props.columns as unknown[]).length).toBe(2);
-    const rows = table.props.children as BotNode[];
+    const rows = table.props.children as ChannelNode[];
     const row = rows[0]!;
     expect(row.type).toBe("row");
-    const cells = row.props.children as BotNode[];
+    const cells = row.props.children as ChannelNode[];
     expect(cells.length).toBe(2);
     expect(cells[0]!.type).toBe("cell");
-    const cellText = (cells[0]!.props.children as BotNode[])[0]!;
+    const cellText = (cells[0]!.props.children as ChannelNode[])[0]!;
     expect(cellText).toMatchObject({ type: "text", props: { value: "Ana" } });
   });
   it("Chart carries type, title, axis titles, and data in props", () => {

--- a/packages/channels-ui/src/components.tsx
+++ b/packages/channels-ui/src/components.tsx
@@ -1,4 +1,4 @@
-import type { BotNode } from "./ir.js";
+import type { ChannelNode } from "./ir.js";
 import type { ClickHandler, MessageReactionHandler } from "./types.js";
 
 /**
@@ -7,7 +7,7 @@ import type { ClickHandler, MessageReactionHandler } from "./types.js";
  * nothing), plus arrays thereof.
  */
 export type BotChildren =
-  | BotNode
+  | ChannelNode
   | string
   | number
   | boolean
@@ -157,7 +157,7 @@ export interface ChartProps {
 
 export const intrinsic =
   <P,>(type: string) =>
-  (props: P): BotNode => ({
+  (props: P): ChannelNode => ({
     type,
     props: (props ?? {}) as Record<string, unknown>,
   });
@@ -176,15 +176,17 @@ export const Chart = intrinsic<ChartProps>("chart");
 export const Row = intrinsic<RowProps>("row");
 export const Cell = intrinsic<CellProps>("cell");
 
-export function Button<TValue = unknown>(props: ButtonProps<TValue>): BotNode {
+export function Button<TValue = unknown>(
+  props: ButtonProps<TValue>,
+): ChannelNode {
   return { type: "button", props: props as unknown as Record<string, unknown> };
 }
-export function Select(props: SelectProps): BotNode {
+export function Select(props: SelectProps): ChannelNode {
   return { type: "select", props: props as unknown as Record<string, unknown> };
 }
-export function Input(props: InputProps): BotNode {
+export function Input(props: InputProps): ChannelNode {
   return { type: "input", props: props as unknown as Record<string, unknown> };
 }
-export function Table(props: TableProps): BotNode {
+export function Table(props: TableProps): ChannelNode {
   return { type: "table", props: props as unknown as Record<string, unknown> };
 }

--- a/packages/channels-ui/src/ir.ts
+++ b/packages/channels-ui/src/ir.ts
@@ -1,10 +1,16 @@
 export type ComponentFn = (
   props: Record<string, unknown>,
-) => BotNode | BotNode[] | string | null;
-export interface BotNode {
+) => ChannelNode | ChannelNode[] | string | null;
+export interface ChannelNode {
   type: string | ComponentFn | symbol;
   props: Record<string, unknown>;
   key?: string | number;
 }
-export type Renderable = string | BotNode | BotNode[] | { raw: unknown };
-export const Fragment: unique symbol = Symbol.for("copilotkit.bot-ui.Fragment");
+export type Renderable =
+  | string
+  | ChannelNode
+  | ChannelNode[]
+  | { raw: unknown };
+export const Fragment: unique symbol = Symbol.for(
+  "copilotkit.channels-ui.Fragment",
+);

--- a/packages/channels-ui/src/jsx-runtime.test.ts
+++ b/packages/channels-ui/src/jsx-runtime.test.ts
@@ -1,19 +1,19 @@
 import { describe, it, expect } from "vitest";
 import { jsx, jsxs, Fragment } from "./jsx-runtime.js";
-import type { BotNode } from "./ir.js";
+import type { ChannelNode } from "./ir.js";
 
 describe("jsx factory", () => {
-  it("builds an BotNode with type and props", () => {
-    const node = jsx("section", { children: "hi" }) as BotNode;
+  it("builds an ChannelNode with type and props", () => {
+    const node = jsx("section", { children: "hi" }) as ChannelNode;
     expect(node.type).toBe("section");
     expect(node.props.children).toBe("hi");
   });
   it("jsxs keeps array children", () => {
-    const node = jsxs("actions", { children: ["a", "b"] }) as BotNode;
+    const node = jsxs("actions", { children: ["a", "b"] }) as ChannelNode;
     expect(Array.isArray(node.props.children)).toBe(true);
   });
   it("Fragment is a stable sentinel", () => {
-    const node = jsx(Fragment, { children: ["a", "b"] }) as BotNode;
+    const node = jsx(Fragment, { children: ["a", "b"] }) as ChannelNode;
     expect(node.type).toBe(Fragment);
   });
 });

--- a/packages/channels-ui/src/jsx-runtime.ts
+++ b/packages/channels-ui/src/jsx-runtime.ts
@@ -1,12 +1,13 @@
-import { Fragment, type BotNode } from "./ir.js";
+import { Fragment } from "./ir.js";
+import type { ChannelNode } from "./ir.js";
 export { Fragment };
 
 export function jsx(
   type: string | ((props: never) => unknown) | symbol,
   props: Record<string, unknown> | null,
   key?: string | number,
-): BotNode {
-  return { type: type as BotNode["type"], props: props ?? {}, key };
+): ChannelNode {
+  return { type: type as ChannelNode["type"], props: props ?? {}, key };
 }
 export const jsxs = jsx;
 
@@ -14,7 +15,7 @@ export const jsxs = jsx;
  * The JSX type contract for this runtime. Declaring it here (rather than
  * relying on a global `JSX` namespace) is what makes the compiler actually
  * check element props: unknown attributes and bad children are errors, and
- * every element returns an {@link BotNode}.
+ * every element returns an {@link ChannelNode}.
  *
  * Resolved by TypeScript because `jsxImportSource` points at this package, so
  * `<Section foo={1} />` is checked against `SectionProps` with excess-property
@@ -22,7 +23,7 @@ export const jsxs = jsx;
  */
 export namespace JSX {
   /** The result of evaluating a JSX expression. */
-  export type Element = BotNode;
+  export type Element = ChannelNode;
   /** Tells TypeScript which prop receives nested children. */
   export interface ElementChildrenAttribute {
     children: {};

--- a/packages/channels-ui/src/modal.tsx
+++ b/packages/channels-ui/src/modal.tsx
@@ -1,4 +1,4 @@
-import type { BotNode } from "./ir.js";
+import type { ChannelNode } from "./ir.js";
 import type { BotChildren } from "./components.js";
 import { intrinsic } from "./components.js";
 
@@ -7,7 +7,7 @@ interface WithModalChildren {
 }
 
 export interface ModalProps extends WithModalChildren {
-  /** Stable id routed to `bot.onModalSubmit` / `bot.onModalClose`. */
+  /** Stable id routed to `channel.onModalSubmit` / `channel.onModalClose`. */
   callbackId: string;
   title: string;
   submitLabel?: string;
@@ -48,7 +48,7 @@ export interface RadioButtonsProps extends WithModalChildren {
 }
 
 /** A modal view IR root. Distinct from message IR; rendered via `renderModal`. */
-export type ModalView = BotNode & { type: "modal" };
+export type ModalView = ChannelNode & { type: "modal" };
 
 /** Thrown by an adapter's `renderModal` when a view uses an unsupported element. */
 export class ModalRenderError extends Error {

--- a/packages/channels-ui/src/render.test.tsx
+++ b/packages/channels-ui/src/render.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { renderToIR } from "./render.js";
-import type { BotNode } from "./ir.js";
+import type { ChannelNode } from "./ir.js";
 
-function Card(props: { title: string }): BotNode {
+function Card(props: { title: string }): ChannelNode {
   return { type: "section", props: { children: props.title } };
 }
 
@@ -28,12 +28,15 @@ describe("renderToIR", () => {
         <Card title="B" />
       </>,
     );
-    expect(out.map((n) => (n as BotNode).type)).toEqual(["section", "section"]);
+    expect(out.map((n) => (n as ChannelNode).type)).toEqual([
+      "section",
+      "section",
+    ]);
   });
   it("wraps string children inside intrinsic nodes recursively", () => {
     const out = renderToIR({ type: "actions", props: { children: ["x"] } });
-    const actions = out[0] as BotNode;
-    expect((actions.props.children as BotNode[])[0]).toEqual({
+    const actions = out[0] as ChannelNode;
+    expect((actions.props.children as ChannelNode[])[0]).toEqual({
       type: "text",
       props: { value: "x" },
     });

--- a/packages/channels-ui/src/render.ts
+++ b/packages/channels-ui/src/render.ts
@@ -1,16 +1,17 @@
-import { Fragment, type BotNode, type Renderable } from "./ir.js";
+import { Fragment } from "./ir.js";
+import type { ChannelNode, Renderable } from "./ir.js";
 
-function isBotNode(v: unknown): v is BotNode {
+function isChannelNode(v: unknown): v is ChannelNode {
   return typeof v === "object" && v !== null && "type" in v && "props" in v;
 }
 
-function expand(node: unknown): BotNode[] {
+function expand(node: unknown): ChannelNode[] {
   if (node == null || node === false || node === true) return [];
   if (typeof node === "string" || typeof node === "number") {
     return [{ type: "text", props: { value: String(node) } }];
   }
   if (Array.isArray(node)) return node.flatMap(expand);
-  if (!isBotNode(node)) return [];
+  if (!isChannelNode(node)) return [];
   if (node.type === Fragment) return expand(node.props.children);
   if (typeof node.type === "function") {
     return expand(
@@ -32,7 +33,7 @@ function expand(node: unknown): BotNode[] {
   ];
 }
 
-export function renderToIR(ui: Renderable): BotNode[] {
+export function renderToIR(ui: Renderable): ChannelNode[] {
   if (typeof ui === "object" && ui !== null && "raw" in ui) {
     return [{ type: "raw", props: { value: (ui as { raw: unknown }).raw } }];
   }

--- a/packages/channels-ui/src/types.ts
+++ b/packages/channels-ui/src/types.ts
@@ -28,7 +28,7 @@ export type MediaDataSource = { type: "data"; value: string; mimeType: string };
  * AG-UI multimodal content parts. Defined here (the lowest shared layer) so
  * platform adapters can carry built multimodal content through the framework
  * to the agent without a circular dependency — `@copilotkit/channels` depends on
- * `@copilotkit/channels-ui`, not the reverse. Identical in shape to bot-slack's so
+ * `@copilotkit/channels-ui`, not the reverse. Identical in shape to channels-slack's so
  * the agent sees the same multimodal input across every adapter.
  *
  * Binary media (image/audio/video/document) is passed straight through as a
@@ -53,7 +53,7 @@ export interface IncomingMessage {
    */
   contentParts?: AgentContentPart[];
   /**
-   * Cross-platform identity key resolved by the bot's `identity` resolver, if
+   * Cross-platform identity key resolved by the channel's `identity` resolver, if
    * any. Stable across platforms for the same human (e.g. an email address).
    */
   userKey?: string;
@@ -117,7 +117,7 @@ export interface Thread {
     messageRef: MessageRef,
     emoji: EmojiValue,
   ): Promise<{ ok: boolean; error?: string }>;
-  /** Remove the bot's emoji reaction from a message (capability-gated). */
+  /** Remove the channel's emoji reaction from a message (capability-gated). */
   unreact(
     messageRef: MessageRef,
     emoji: EmojiValue,

--- a/packages/channels-whatsapp/src/adapter.ts
+++ b/packages/channels-whatsapp/src/adapter.ts
@@ -8,7 +8,7 @@ import type {
   UserQuery,
 } from "@copilotkit/channels";
 import type {
-  BotNode,
+  ChannelNode,
   MessageRef,
   PlatformUser,
   ThreadMessage,
@@ -107,11 +107,11 @@ export class WhatsAppAdapter implements PlatformAdapter {
     }
   }
 
-  render(ir: BotNode[]): WhatsAppOutbound[] {
+  render(ir: ChannelNode[]): WhatsAppOutbound[] {
     return renderWhatsAppMessage(ir);
   }
 
-  async post(target: ReplyTarget, ir: BotNode[]): Promise<MessageRef> {
+  async post(target: ReplyTarget, ir: ChannelNode[]): Promise<MessageRef> {
     const payloads = this.render(ir);
     let last: WhatsAppMessageRef = {
       id: "",
@@ -125,7 +125,7 @@ export class WhatsAppAdapter implements PlatformAdapter {
     return last;
   }
 
-  async update(ref: MessageRef, ir: BotNode[]): Promise<void> {
+  async update(ref: MessageRef, ir: ChannelNode[]): Promise<void> {
     // WhatsApp can't edit messages; "update" posts a fresh message instead.
     const r = ref as unknown as WhatsAppMessageRef;
     await this.post({ to: r.to, phoneNumberId: r.phoneNumberId }, ir);

--- a/packages/channels-whatsapp/src/render/message.test.ts
+++ b/packages/channels-whatsapp/src/render/message.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from "vitest";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import { renderWhatsAppMessage } from "./message.js";
 
-const node = (type: string, props: Record<string, unknown> = {}): BotNode => ({
+const node = (
+  type: string,
+  props: Record<string, unknown> = {},
+): ChannelNode => ({
   type,
   props,
 });
@@ -149,10 +152,13 @@ describe("renderWhatsAppMessage", () => {
   // renderToIR lowers text into `{ type: "text", props: { value } }` leaves and
   // nests controls inside containers (message > actions > button). These guard
   // against the shape the flat hand-built fixtures above don't exercise.
-  const text = (value: string): BotNode => ({ type: "text", props: { value } });
+  const text = (value: string): ChannelNode => ({
+    type: "text",
+    props: { value },
+  });
 
   it("renders a message>header>section tree with text-value leaves (issue_list regression)", () => {
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", {
         children: [
           node("header", { children: [text("Open CPK issues")] }),
@@ -170,7 +176,7 @@ describe("renderWhatsAppMessage", () => {
   });
 
   it("finds buttons nested in message>actions with text-value titles (show_incident regression)", () => {
-    const ir: BotNode[] = [
+    const ir: ChannelNode[] = [
       node("message", {
         children: [
           node("section", { children: [text("An incident needs attention")] }),

--- a/packages/channels-whatsapp/src/render/message.ts
+++ b/packages/channels-whatsapp/src/render/message.ts
@@ -1,4 +1,4 @@
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import { markdownToWhatsApp } from "../markdown-to-wa.js";
 import { WA_LIMITS, truncateText, clampArray } from "./budget.js";
 
@@ -51,7 +51,7 @@ interface Action {
 const VALUE_ONLY_ID = "wa:choice";
 
 /**
- * Lower `BotNode[]` IR to Cloud API payload(s).
+ * Lower `ChannelNode[]` IR to Cloud API payload(s).
  *
  * Strategy: collect (a) the prose text from text/section/header/markdown/
  * fields/table/context/divider nodes, and (b) actionable controls from
@@ -62,7 +62,7 @@ const VALUE_ONLY_ID = "wa:choice";
  *   - >10 actions           → numbered text menu (degraded).
  * Image nodes always emit their own image payload.
  */
-export function renderWhatsAppMessage(ir: BotNode[]): WhatsAppOutbound[] {
+export function renderWhatsAppMessage(ir: ChannelNode[]): WhatsAppOutbound[] {
   const out: WhatsAppOutbound[] = [];
   const prose: string[] = [];
   const actions: Action[] = [];
@@ -88,11 +88,11 @@ export function renderWhatsAppMessage(ir: BotNode[]): WhatsAppOutbound[] {
       return;
     }
     if (typeof children === "object" && "type" in (children as object)) {
-      visitNode(children as BotNode);
+      visitNode(children as ChannelNode);
     }
   };
 
-  const visitNode = (n: BotNode): void => {
+  const visitNode = (n: ChannelNode): void => {
     const t = typeof n.type === "string" ? n.type : "";
     switch (t) {
       case "text": {
@@ -284,7 +284,7 @@ function textOf(children: unknown): string {
   if (typeof children === "string") return children;
   if (typeof children === "number") return String(children);
   if (Array.isArray(children)) return children.map(textOf).join("");
-  const node = children as BotNode;
+  const node = children as ChannelNode;
   if (node && typeof node === "object" && "props" in node) {
     const props = node.props as Record<string, unknown>;
     if (

--- a/packages/channels/src/action-registry.test.ts
+++ b/packages/channels/src/action-registry.test.ts
@@ -3,14 +3,14 @@ import { ActionRegistry, ActionExpiredError } from "./action-registry.js";
 import { InMemoryActionStore } from "./action-store.js";
 import { MemoryStore } from "./state/memory-store.js";
 import { kvActionStore } from "./state/kv-action-store.js";
-import type { BotNode, InteractionContext } from "@copilotkit/channels-ui";
+import type { ChannelNode, InteractionContext } from "@copilotkit/channels-ui";
 
 // Records each click so a test can assert the handler ran — dispatch() now
 // returns the clicked element's `value` (needed to resolve HITL waiters on
 // platforms whose callback payload can't carry it), not the handler's return.
 const clicks: string[] = [];
 
-function Confirm(props: { action: string }): BotNode {
+function Confirm(props: { action: string }): ChannelNode {
   return {
     type: "actions",
     props: {
@@ -41,7 +41,7 @@ describe("ActionRegistry", () => {
     const reg = new ActionRegistry({ store: new InMemoryActionStore() });
     reg.registerComponent("Confirm", Confirm as never);
     const ir = await reg.bindTree("Confirm", { action: "write" }, "conv1");
-    const button = (ir[0]!.props.children as BotNode[])[0]!;
+    const button = (ir[0]!.props.children as ChannelNode[])[0]!;
     const id = (button.props.onClick as { id: string }).id;
     expect(typeof id).toBe("string");
     const value = await reg.dispatch(id, ctx);
@@ -54,7 +54,9 @@ describe("ActionRegistry", () => {
     reg.registerComponent("Confirm", Confirm as never);
     const ir = await reg.bindTree("Confirm", { action: "write" }, "conv1");
     const id = (
-      (ir[0]!.props.children as BotNode[])[0]!.props.onClick as { id: string }
+      (ir[0]!.props.children as ChannelNode[])[0]!.props.onClick as {
+        id: string;
+      }
     ).id;
     reg.clearHotCache();
     const value = await reg.dispatch(id, ctx);
@@ -80,7 +82,9 @@ describe("ActionRegistry", () => {
       "conv-cold",
     );
     const id = (
-      (ir[0]!.props.children as BotNode[])[0]!.props.onClick as { id: string }
+      (ir[0]!.props.children as ChannelNode[])[0]!.props.onClick as {
+        id: string;
+      }
     ).id;
 
     // registryB: fresh registry with no hot cache but sharing the same store
@@ -115,7 +119,7 @@ describe("ActionRegistry", () => {
         "conv-restart",
       );
       const id = (
-        (ir[0]!.props.children as BotNode[])[0]!.props.onClick as {
+        (ir[0]!.props.children as ChannelNode[])[0]!.props.onClick as {
           id: string;
         }
       ).id;
@@ -146,7 +150,7 @@ describe("ActionRegistry", () => {
         "conv-no-reg",
       );
       const id = (
-        (ir[0]!.props.children as BotNode[])[0]!.props.onClick as {
+        (ir[0]!.props.children as ChannelNode[])[0]!.props.onClick as {
           id: string;
         }
       ).id;

--- a/packages/channels/src/action-registry.ts
+++ b/packages/channels/src/action-registry.ts
@@ -1,5 +1,5 @@
 import type {
-  BotNode,
+  ChannelNode,
   ClickHandler,
   InteractionContext,
   ComponentFn,
@@ -111,7 +111,7 @@ export class ActionRegistry {
     componentName: string,
     props: Record<string, unknown>,
     conversationKey: string,
-  ): Promise<BotNode[]> {
+  ): Promise<ChannelNode[]> {
     const fn = this.components.get(componentName);
     const root = renderToIR((fn ? fn(props) : props) as Renderable);
     await this.walk(root, [], componentName, props, conversationKey);
@@ -129,7 +129,7 @@ export class ActionRegistry {
     ui: Renderable,
     conversationKey: string,
   ): Promise<{
-    root: BotNode[];
+    root: ChannelNode[];
     onReaction?: MessageReactionHandler;
     /**
      * The component + props to persist for durable reaction routing, present
@@ -138,7 +138,7 @@ export class ActionRegistry {
      */
     reactionComponent?: { component: string; props: Record<string, unknown> };
   }> {
-    let root: BotNode[];
+    let root: ChannelNode[];
     let component: string | undefined;
     let props: Record<string, unknown> | undefined;
     if (isComponentElement(ui)) {
@@ -161,7 +161,7 @@ export class ActionRegistry {
   }
 
   private async walk(
-    nodes: BotNode[],
+    nodes: ChannelNode[],
     base: (string | number)[],
     comp: string,
     props: unknown,
@@ -192,7 +192,7 @@ export class ActionRegistry {
       const children = node.props.children;
       if (Array.isArray(children)) {
         await this.walk(
-          children as BotNode[],
+          children as ChannelNode[],
           [...path, "children"],
           comp,
           props,
@@ -243,7 +243,7 @@ function reactionKey(messageId: string): string {
  * payload). Returns the handler when the single root node is a `message`.
  */
 function takeMessageReaction(
-  root: BotNode[],
+  root: ChannelNode[],
 ): MessageReactionHandler | undefined {
   const node = root.length === 1 ? root[0] : undefined;
   if (!node || node.type !== "message" || !("onReaction" in node.props)) {
@@ -257,30 +257,30 @@ function takeMessageReaction(
 }
 
 /** Navigate to the node owning the event-prop at `path` and read its `value`. */
-function pluckValue(tree: BotNode[], path: (string | number)[]): unknown {
+function pluckValue(tree: ChannelNode[], path: (string | number)[]): unknown {
   let cur: unknown = tree;
   for (const seg of path.slice(0, -1)) {
     if (Array.isArray(cur)) cur = cur[seg as number];
     else if (cur && typeof cur === "object")
-      cur = (cur as BotNode).props?.[seg as string];
+      cur = (cur as ChannelNode).props?.[seg as string];
     else return undefined;
   }
-  return (cur as BotNode | undefined)?.props?.value;
+  return (cur as ChannelNode | undefined)?.props?.value;
 }
 
 function pluck(
-  tree: BotNode[],
+  tree: ChannelNode[],
   path: (string | number)[],
 ): ClickHandler | undefined {
   let cur: unknown = tree;
   for (const seg of path.slice(0, -1)) {
     if (Array.isArray(cur)) cur = cur[seg as number];
     else if (cur && typeof cur === "object")
-      cur = (cur as BotNode).props?.[seg as string];
+      cur = (cur as ChannelNode).props?.[seg as string];
     else return undefined;
   }
   const ep = path[path.length - 1] as string;
-  const node = cur as BotNode | undefined;
+  const node = cur as ChannelNode | undefined;
   const h = node?.props?.[ep];
   return typeof h === "function" ? (h as ClickHandler) : undefined;
 }

--- a/packages/channels/src/codec.ts
+++ b/packages/channels/src/codec.ts
@@ -1,4 +1,4 @@
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 
 /**
  * A pure, dependency-free, per-platform codec shared by the local adapter and
@@ -20,6 +20,6 @@ import type { BotNode } from "@copilotkit/channels-ui";
  */
 export interface PlatformCodec {
   readonly platform: string;
-  /** IR → native payload. Pure; opaque to bot core. */
-  renderEgress(ir: BotNode[]): unknown;
+  /** IR → native payload. Pure; opaque to channel core. */
+  renderEgress(ir: ChannelNode[]): unknown;
 }

--- a/packages/channels/src/create-channel.foundations.test.ts
+++ b/packages/channels/src/create-channel.foundations.test.ts
@@ -9,53 +9,53 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
 describe("createChannel — optional adapters + addAdapter", () => {
   it("starts with no adapters and runs one added before start()", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ agent: () => new FakeAgent() });
-    bot.addAdapter(fake);
-    await bot.start();
+    const channel = createChannel({ agent: () => new FakeAgent() });
+    channel.addAdapter(fake);
+    await channel.start();
     expect(fake.started).toBe(true);
   });
 
   it("throws when addAdapter is called after start()", async () => {
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [new FakeAdapter()],
       agent: () => new FakeAgent(),
     });
-    await bot.start();
-    expect(() => bot.addAdapter(new FakeAdapter())).toThrow(/start/i);
+    await channel.start();
+    expect(() => channel.addAdapter(new FakeAdapter())).toThrow(/start/i);
   });
 
   it("is idempotent: a second start() does not re-start adapters or rebuild state", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       agent: () => new FakeAgent(),
     });
     const startSpy = vi.spyOn(fake, "start");
-    await bot.start();
-    const transcriptsAfterFirst = bot.transcripts;
-    await bot.start(); // second call must be a no-op
+    await channel.start();
+    const transcriptsAfterFirst = channel.transcripts;
+    await channel.start(); // second call must be a no-op
     expect(startSpy).toHaveBeenCalledTimes(1);
     // Same transcript-store instance → state (locks/dedup/actions) not wiped.
-    expect(bot.transcripts).toBe(transcriptsAfterFirst);
+    expect(channel.transcripts).toBe(transcriptsAfterFirst);
   });
 
   it("allows a real restart after stop() (start → stop → start re-inits)", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       agent: () => new FakeAgent(),
     });
     const startSpy = vi.spyOn(fake, "start");
-    await bot.start();
-    await bot.stop();
-    await bot.start(); // stop() cleared `started`, so this is a real restart
+    await channel.start();
+    await channel.stop();
+    await channel.start(); // stop() cleared `started`, so this is a real restart
     expect(startSpy).toHaveBeenCalledTimes(2);
   });
 });
 
 describe("createChannel — transcripts deferred to start()", () => {
-  it("throws if bot.transcripts is accessed before start()", () => {
-    const bot = createChannel({
+  it("throws if channel.transcripts is accessed before start()", () => {
+    const channel = createChannel({
       adapters: [new FakeAdapter()],
       agent: () => new FakeAgent(),
       store: {
@@ -64,7 +64,7 @@ describe("createChannel — transcripts deferred to start()", () => {
         transcripts: {},
       },
     });
-    expect(() => bot.transcripts).toThrow(/start/i);
+    expect(() => channel.transcripts).toThrow(/start/i);
   });
 });
 
@@ -72,8 +72,8 @@ describe("createChannel — store resolution", () => {
   it("uses an adapter-provided stateStore when no explicit store.adapter", async () => {
     const adapterStore = new MemoryStore();
 
-    // Seed the adapter's store via a throwaway bot so we can prove the real
-    // bot reads from that exact instance.
+    // Seed the adapter's store via a throwaway channel so we can prove the real
+    // channel reads from that exact instance.
     const seeder = createChannel({
       adapters: [new FakeAdapter()],
       agent: () => new FakeAgent(),
@@ -92,14 +92,14 @@ describe("createChannel — store resolution", () => {
 
     const fake = new FakeAdapter();
     fake.stateStore = adapterStore;
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       agent: () => new FakeAgent(),
       store: { identity: () => "u@x.com", transcripts: {} },
     });
-    await bot.start();
+    await channel.start();
 
-    const entries = await bot.transcripts.list({ userKey: "u@x.com" });
+    const entries = await channel.transcripts.list({ userKey: "u@x.com" });
     expect(entries.map((e) => e.text)).toContain("seeded");
   });
 
@@ -108,7 +108,7 @@ describe("createChannel — store resolution", () => {
     const fake = new FakeAdapter();
     fake.stateStore = new MemoryStore();
     const explicit = new MemoryStore();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       agent: () => new FakeAgent(),
       store: {
@@ -117,7 +117,7 @@ describe("createChannel — store resolution", () => {
         transcripts: {},
       },
     });
-    await bot.start();
+    await channel.start();
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
   });
@@ -128,11 +128,11 @@ describe("createChannel — store resolution", () => {
     a.stateStore = new MemoryStore();
     const b = new FakeAdapter({ platform: "b" });
     b.stateStore = new MemoryStore();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [a, b],
       agent: () => new FakeAgent(),
     });
-    await bot.start();
+    await channel.start();
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("state store"));
     warn.mockRestore();
   });
@@ -141,19 +141,19 @@ describe("createChannel — store resolution", () => {
 describe("createChannel — id propagation to handler context", () => {
   it("threads turnId/deliveryId from IncomingTurn onto message", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       agent: () => new FakeAgent(),
     });
     let seen: { turnId?: string; deliveryId?: string; eventId?: string } = {};
-    bot.onMessage(async ({ message }) => {
+    channel.onMessage(async ({ message }) => {
       seen = {
         turnId: message.turnId,
         deliveryId: message.deliveryId,
         eventId: message.eventId,
       };
     });
-    await bot.start();
+    await channel.start();
     fake.emitTurn({
       userText: "hi",
       conversationKey: "c1",

--- a/packages/channels/src/create-channel.test.ts
+++ b/packages/channels/src/create-channel.test.ts
@@ -6,7 +6,7 @@ import { FakeAdapter } from "./testing/fake-adapter.js";
 import { FakeAgent } from "./testing/fake-agent.js";
 import { MemoryStore } from "./state/memory-store.js";
 import { Section, Actions, Button } from "@copilotkit/channels-ui";
-import type { BotNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
 import type { PlatformAdapter } from "./platform-adapter.js";
 
 const tick = () => new Promise((r) => setTimeout(r, 0));
@@ -17,13 +17,13 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
  * `ctx.action.value`.
  */
 const __handlerTypeGuards = () => {
-  const bot = createChannel({ adapters: [new FakeAdapter()] });
-  bot.onInterrupt<{ question: string }>("ask", ({ payload }) => {
+  const channel = createChannel({ adapters: [new FakeAdapter()] });
+  channel.onInterrupt<{ question: string }>("ask", ({ payload }) => {
     payload.question.toUpperCase();
     // @ts-expect-error 'missing' is not on the payload type
     payload.missing;
   });
-  bot.onInteraction<{ page: number }>("next", (ctx) => {
+  channel.onInteraction<{ page: number }>("next", (ctx) => {
     ctx.action.value?.page.toFixed(0);
     // @ts-expect-error 'nope' is not on the action value type
     ctx.action.value?.nope;
@@ -32,12 +32,12 @@ const __handlerTypeGuards = () => {
 void __handlerTypeGuards;
 
 /** Recursively find the first node of a given type in an IR tree. */
-function findNode(nodes: BotNode[], type: string): BotNode | undefined {
+function findNode(nodes: ChannelNode[], type: string): ChannelNode | undefined {
   for (const n of nodes) {
     if (n.type === type) return n;
     const children = n.props.children;
     if (Array.isArray(children)) {
-      const found = findNode(children as BotNode[], type);
+      const found = findNode(children as ChannelNode[], type);
       if (found) return found;
     }
   }
@@ -45,13 +45,13 @@ function findNode(nodes: BotNode[], type: string): BotNode | undefined {
 }
 
 /** Concatenate all text node values in an IR tree. */
-function collectText(nodes: BotNode[]): string {
+function collectText(nodes: ChannelNode[]): string {
   let out = "";
   for (const n of nodes) {
     if (n.type === "text" && typeof n.props.value === "string")
       out += n.props.value;
     const children = n.props.children;
-    if (Array.isArray(children)) out += collectText(children as BotNode[]);
+    if (Array.isArray(children)) out += collectText(children as ChannelNode[]);
   }
   return out;
 }
@@ -60,13 +60,13 @@ describe("createChannel", () => {
   it("routes a mention to a handler that posts UI", async () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    const bot = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({ adapters: [fake], agent: () => agent });
 
-    bot.onMention(async ({ thread }) => {
+    channel.onMention(async ({ thread }) => {
       await thread.post(Section({ children: "hi" }));
     });
 
-    await bot.start();
+    await channel.start();
     fake.emitTurn({ userText: "yo", conversationKey: "c1" });
     await tick();
 
@@ -79,13 +79,13 @@ describe("createChannel", () => {
   it("calls renderer.finish() once after a turn's run-loop resolves", async () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    const bot = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({ adapters: [fake], agent: () => agent });
 
-    bot.onMention(async ({ thread }) => {
+    channel.onMention(async ({ thread }) => {
       await thread.runAgent();
     });
 
-    await bot.start();
+    await channel.start();
     fake.emitTurn({ userText: "yo", conversationKey: "c1" });
     await tick();
 
@@ -105,7 +105,7 @@ describe("createChannel", () => {
       added.push(m);
       return origAddMessage(m);
     };
-    const bot = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({ adapters: [fake], agent: () => agent });
 
     const parts = [
       { type: "text" as const, text: "look" },
@@ -114,7 +114,7 @@ describe("createChannel", () => {
         source: { type: "data" as const, value: "QUJD", mimeType: "image/png" },
       },
     ];
-    bot.onMention(async ({ thread, message }) => {
+    channel.onMention(async ({ thread, message }) => {
       // The example mirrors this: prefer multimodal parts over plain text.
       await thread.runAgent({
         prompt:
@@ -124,7 +124,7 @@ describe("createChannel", () => {
       });
     });
 
-    await bot.start();
+    await channel.start();
     fake.emitTurn({
       userText: "look",
       conversationKey: "c1",
@@ -142,10 +142,10 @@ describe("createChannel", () => {
   it("dispatches a bound onClick handler on interaction", async () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    const bot = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({ adapters: [fake], agent: () => agent });
 
     let clicked = false;
-    bot.onMention(async ({ thread }) => {
+    channel.onMention(async ({ thread }) => {
       await thread.post(
         Actions({
           children: [
@@ -161,7 +161,7 @@ describe("createChannel", () => {
       );
     });
 
-    await bot.start();
+    await channel.start();
     fake.emitTurn({ userText: "yo", conversationKey: "c1" });
     await tick();
 
@@ -178,10 +178,10 @@ describe("createChannel", () => {
   it("resolves a HITL awaitChoice with the element value when the event carries none (Telegram)", async () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    const bot = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({ adapters: [fake], agent: () => agent });
 
     let chosen: unknown;
-    bot.onMention(async ({ thread }) => {
+    channel.onMention(async ({ thread }) => {
       chosen = await thread.awaitChoice(
         Actions({
           children: [
@@ -195,7 +195,7 @@ describe("createChannel", () => {
       );
     });
 
-    await bot.start();
+    await channel.start();
     fake.emitTurn({ userText: "create a thing", conversationKey: "c1" });
     await tick();
 
@@ -211,7 +211,7 @@ describe("createChannel", () => {
     expect(chosen).toEqual({ confirmed: true });
   });
 
-  it("merges per-turn runAgent context with the bot-level context", async () => {
+  it("merges per-turn runAgent context with the channel-level context", async () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
     // Capture the context/tools passed to the agent's first runAgent call.
@@ -227,24 +227,24 @@ describe("createChannel", () => {
       return origRunAgent(parameters, subscriber);
     };
 
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       agent: () => agent,
-      context: [{ description: "bot-level", value: "always here" }],
+      context: [{ description: "channel-level", value: "always here" }],
     });
 
-    bot.onMention(async ({ thread }) => {
+    channel.onMention(async ({ thread }) => {
       await thread.runAgent({
         context: [{ description: "who", value: "user U1" }],
       });
     });
 
-    await bot.start();
+    await channel.start();
     fake.emitTurn({ userText: "go", conversationKey: "c1" });
     await tick();
 
     expect(seenContext).toEqual([
-      { description: "bot-level", value: "always here" },
+      { description: "channel-level", value: "always here" },
       { description: "who", value: "user U1" },
     ]);
     expect(seenTools).toEqual([]);
@@ -253,17 +253,17 @@ describe("createChannel", () => {
   it("thread.postFile returns a capability-gated error when the adapter can't upload", async () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    const bot = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({ adapters: [fake], agent: () => agent });
 
     let result: { ok: boolean; error?: string } | undefined;
-    bot.onMention(async ({ thread }) => {
+    channel.onMention(async ({ thread }) => {
       result = await thread.postFile({
         bytes: new Uint8Array([1, 2, 3]),
         filename: "x.png",
       });
     });
 
-    await bot.start();
+    await channel.start();
     fake.emitTurn({ userText: "hi", conversationKey: "c1" });
     await tick();
 
@@ -280,16 +280,16 @@ describe("createChannel", () => {
     ];
     fake.user = { id: "u1", name: "Ada" };
     const agent = new FakeAgent();
-    const bot = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({ adapters: [fake], agent: () => agent });
 
     let history: unknown;
     let resolved: unknown;
-    bot.onMention(async ({ thread }) => {
+    channel.onMention(async ({ thread }) => {
       history = await thread.getMessages();
       resolved = await thread.lookupUser("Ada");
     });
 
-    await bot.start();
+    await channel.start();
     fake.emitTurn({ userText: "hi", conversationKey: "c1" });
     await tick();
 
@@ -302,10 +302,10 @@ describe("createChannel", () => {
   it("resolves awaitChoice when a matching interaction arrives", async () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    const bot = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({ adapters: [fake], agent: () => agent });
 
     let choicePromise: Promise<unknown> | undefined;
-    bot.onMention(async ({ thread }) => {
+    channel.onMention(async ({ thread }) => {
       choicePromise = thread.awaitChoice(
         Actions({
           children: [
@@ -319,7 +319,7 @@ describe("createChannel", () => {
       );
     });
 
-    await bot.start();
+    await channel.start();
     fake.emitTurn({ userText: "decide", conversationKey: "c1" });
     await tick();
 
@@ -345,17 +345,17 @@ describe("createChannel", () => {
 
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       agent: () => agent,
       store: { adapter: state, onLockConflict: "drop" },
     });
-    bot.onMention(async () => {
+    channel.onMention(async () => {
       runs++;
       await gate;
     });
 
-    await bot.start();
+    await channel.start();
     const sink = fake.getSink();
     const turn = {
       conversationKey: "c1",
@@ -382,17 +382,17 @@ describe("createChannel", () => {
 
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       agent: () => agent,
       store: { adapter: state, onLockConflict: "force" },
     });
-    bot.onMention(async () => {
+    channel.onMention(async () => {
       runs++;
       await gate;
     });
 
-    await bot.start();
+    await channel.start();
     const sink = fake.getSink();
     const turn = {
       conversationKey: "c1",
@@ -417,16 +417,16 @@ describe("createChannel", () => {
 
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       agent: () => agent,
       store: { adapter: state },
     });
-    bot.onMention(async () => {
+    channel.onMention(async () => {
       runs++;
     });
 
-    await bot.start();
+    await channel.start();
     const sink = fake.getSink();
     const base = {
       conversationKey: "c",
@@ -474,7 +474,7 @@ describe("createChannel", () => {
     const state = new MemoryStore();
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       agent: () => agent,
       store: {
@@ -485,11 +485,11 @@ describe("createChannel", () => {
     });
 
     let capturedKey: string | undefined;
-    bot.onMention(async ({ message }) => {
+    channel.onMention(async ({ message }) => {
       capturedKey = message.userKey;
     });
 
-    await bot.start();
+    await channel.start();
     const sink = fake.getSink();
     await sink.onTurn({
       conversationKey: "c1",
@@ -502,11 +502,11 @@ describe("createChannel", () => {
     expect(capturedKey).toBe("user@example.com");
   });
 
-  it("bot.transcripts.append/list round-trips with MemoryStore", async () => {
+  it("channel.transcripts.append/list round-trips with MemoryStore", async () => {
     const state = new MemoryStore();
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       agent: () => agent,
       store: {
@@ -516,29 +516,29 @@ describe("createChannel", () => {
       },
     });
 
-    await bot.start();
+    await channel.start();
     const sink = fake.getSink();
 
     // Drive a turn so identity is resolved and we can verify transcripts exist
     const thread = { platform: "fake", conversationKey: "c1" } as Parameters<
-      typeof bot.transcripts.append
+      typeof channel.transcripts.append
     >[0];
 
-    // Directly append via bot.transcripts
-    await bot.transcripts.append(
+    // Directly append via channel.transcripts
+    await channel.transcripts.append(
       thread,
       { role: "user", text: "hi there" },
       {
         userKey: "alice@example.com",
       },
     );
-    await bot.transcripts.append(
+    await channel.transcripts.append(
       thread,
       { role: "assistant", text: "hello!" },
       { userKey: "alice@example.com" },
     );
 
-    const entries = await bot.transcripts.list({
+    const entries = await channel.transcripts.list({
       userKey: "alice@example.com",
     });
     expect(entries).toHaveLength(2);
@@ -553,7 +553,7 @@ describe("createChannel", () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
 
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       agent: () => agent,
       store: {
@@ -581,15 +581,15 @@ describe("createChannel", () => {
       return origRunAgent(parameters, subscriber);
     };
 
-    bot.onMention(async ({ thread }) => {
+    channel.onMention(async ({ thread }) => {
       await thread.runAgent({ transcript: true });
     });
 
-    await bot.start();
+    await channel.start();
     // Seed one prior cross-platform entry (different platform label) so we can
     // assert it shows up in the injected context. Seeded post-start: transcripts
     // are only available once the backend is resolved in start().
-    await bot.transcripts.append(
+    await channel.transcripts.append(
       { platform: "discord", conversationKey: "other" },
       { role: "user", text: "remembered from discord" },
       { userKey: "u@x.com" },
@@ -605,7 +605,7 @@ describe("createChannel", () => {
 
     // Append side: both the user turn and the assistant reply are recorded,
     // oldest-first (after the seeded discord entry).
-    const entries = await bot.transcripts.list({ userKey: "u@x.com" });
+    const entries = await channel.transcripts.list({ userKey: "u@x.com" });
     const fakeEntries = entries.filter((e) => e.platform === "fake");
     expect(fakeEntries).toHaveLength(2);
     expect(fakeEntries[0]!.role).toBe("user");
@@ -628,7 +628,7 @@ describe("createChannel", () => {
   it("typesafe state: setState validates against store.state schema and round-trips", async () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       agent: () => agent,
       store: {
@@ -639,7 +639,7 @@ describe("createChannel", () => {
 
     let roundTripped: { step: string } | undefined;
     let rejected = false;
-    bot.onMention(async ({ thread }) => {
+    channel.onMention(async ({ thread }) => {
       // Typed to { step: string } via the configured schema.
       await thread.setState({ step: "x" });
       roundTripped = await thread.state();
@@ -651,7 +651,7 @@ describe("createChannel", () => {
       }
     });
 
-    await bot.start();
+    await channel.start();
     fake.emitTurn({ userText: "go", conversationKey: "c1" });
     await tick();
 
@@ -667,7 +667,7 @@ describe("createChannel lock and dedup edge cases", () => {
     const gate = new Promise<void>((r) => (release = r));
 
     const fake = new FakeAdapter();
-    // Use a separate bot so the throwing handler is isolated.
+    // Use a separate channel so the throwing handler is isolated.
     const bot1 = createChannel({
       adapters: [fake],
       store: { adapter: state, onLockConflict: "drop", lockTtl: 5000 },
@@ -711,7 +711,7 @@ describe("createChannel lock and dedup edge cases", () => {
     let callbackMessageText: string | undefined;
 
     const fake = new FakeAdapter();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       store: {
         adapter: state,
@@ -722,12 +722,12 @@ describe("createChannel lock and dedup edge cases", () => {
         },
       },
     });
-    bot.onMention(async () => {
+    channel.onMention(async () => {
       runs++;
       await gate;
     });
 
-    await bot.start();
+    await channel.start();
     const sink = fake.getSink();
     const turn = {
       conversationKey: "c1",
@@ -753,19 +753,19 @@ describe("createChannel lock and dedup edge cases", () => {
     const gate = new Promise<void>((r) => (release = r));
 
     const fake = new FakeAdapter();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       store: {
         adapter: state,
         onLockConflict: () => Promise.resolve("force" as const),
       },
     });
-    bot.onMention(async () => {
+    channel.onMention(async () => {
       runs++;
       await gate;
     });
 
-    await bot.start();
+    await channel.start();
     const sink = fake.getSink();
     const turn = {
       conversationKey: "c1",
@@ -785,7 +785,7 @@ describe("createChannel lock and dedup edge cases", () => {
   it("identity throws: handler still runs and userKey is undefined", async () => {
     const state = new MemoryStore();
     const fake = new FakeAdapter();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       store: {
         adapter: state,
@@ -797,11 +797,11 @@ describe("createChannel lock and dedup edge cases", () => {
     });
 
     let capturedUserKey: string | undefined = "SENTINEL";
-    bot.onMention(async ({ message }) => {
+    channel.onMention(async ({ message }) => {
       capturedUserKey = message.userKey;
     });
 
-    await bot.start();
+    await channel.start();
     const sink = fake.getSink();
     await sink.onTurn({
       conversationKey: "c1",
@@ -816,17 +816,17 @@ describe("createChannel lock and dedup edge cases", () => {
   it("identity returns null: userKey is undefined", async () => {
     const state = new MemoryStore();
     const fake = new FakeAdapter();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       store: { adapter: state, identity: () => null, transcripts: {} },
     });
 
     let capturedUserKey: string | undefined = "SENTINEL";
-    bot.onMention(async ({ message }) => {
+    channel.onMention(async ({ message }) => {
       capturedUserKey = message.userKey;
     });
 
-    await bot.start();
+    await channel.start();
     const sink = fake.getSink();
     await sink.onTurn({
       conversationKey: "c1",
@@ -843,15 +843,15 @@ describe("createChannel lock and dedup edge cases", () => {
     let runs = 0;
 
     const fake = new FakeAdapter();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       store: { adapter: state, onLockConflict: "drop" },
     });
-    bot.onMention(async () => {
+    channel.onMention(async () => {
       runs++;
     });
 
-    await bot.start();
+    await channel.start();
     const sink = fake.getSink();
     const base = {
       conversationKey: "c1",
@@ -887,12 +887,15 @@ describe("createChannel lock and dedup edge cases", () => {
 
     let runs = 0;
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake], store: { adapter: state } });
-    bot.onMention(async () => {
+    const channel = createChannel({
+      adapters: [fake],
+      store: { adapter: state },
+    });
+    channel.onMention(async () => {
       runs++;
     });
 
-    await bot.start();
+    await channel.start();
     const sink = fake.getSink();
     await sink.onTurn({
       conversationKey: "c1",
@@ -913,16 +916,16 @@ describe("createChannel lock and dedup edge cases", () => {
     const gate = new Promise<void>((r) => (releaseGate = r));
 
     const fake = new FakeAdapter();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       store: { adapter: state, onLockConflict: "drop" },
     });
-    bot.onMention(async () => {
+    channel.onMention(async () => {
       runs++;
       await gate;
     });
 
-    await bot.start();
+    await channel.start();
     const sink = fake.getSink();
     const turnA = {
       conversationKey: "c1",
@@ -962,15 +965,15 @@ describe("createChannel lock and dedup edge cases", () => {
     let runs = 0;
 
     const fake = new FakeAdapter();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       store: { adapter: state },
     });
-    bot.onMention(async () => {
+    channel.onMention(async () => {
       runs++;
     });
 
-    await bot.start();
+    await channel.start();
     const sink = fake.getSink();
     const turn = {
       conversationKey: "c2",
@@ -993,24 +996,24 @@ describe("createChannel lock and dedup edge cases", () => {
 describe("createChannel slash commands", () => {
   it("routes a command to its handler with the raw text", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     let seen: { command: string; text: string } | undefined;
-    bot.onCommand("triage", ({ command, text }) => {
+    channel.onCommand("triage", ({ command, text }) => {
       seen = { command, text };
     });
-    await bot.start();
+    await channel.start();
     await fake.emitCommand({ command: "/Triage", text: "db is down" });
     expect(seen).toEqual({ command: "triage", text: "db is down" });
   });
 
   it("ignores a command with no registered handler", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     let fired = false;
-    bot.onCommand("triage", () => {
+    channel.onCommand("triage", () => {
       fired = true;
     });
-    await bot.start();
+    await channel.start();
     await fake.emitCommand({ command: "unknown", text: "x" });
     expect(fired).toBe(false);
   });
@@ -1018,7 +1021,7 @@ describe("createChannel slash commands", () => {
   it("parses rawOptions through the command's schema into ctx.options", async () => {
     let captured: { seat: string } | undefined;
     const fake = new FakeAdapter();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       commands: [
         defineChannelCommand({
@@ -1030,7 +1033,7 @@ describe("createChannel slash commands", () => {
         }),
       ],
     });
-    await bot.start();
+    await channel.start();
     await fake.emitCommand({
       command: "book",
       text: "raw",
@@ -1041,10 +1044,10 @@ describe("createChannel slash commands", () => {
 
   it("hands declared commands to adapters that implement registerCommands", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
-    bot.onCommand("triage", () => {});
-    bot.onCommand("status", () => {});
-    await bot.start();
+    const channel = createChannel({ adapters: [fake] });
+    channel.onCommand("triage", () => {});
+    channel.onCommand("status", () => {});
+    await channel.start();
     expect(fake.registeredCommands?.map((c) => c.name).sort()).toEqual([
       "status",
       "triage",
@@ -1056,8 +1059,8 @@ describe("createChannel slash commands", () => {
     try {
       const bad = new FakeAdapter({ platform: "telegram", failStart: true });
       const good = new FakeAdapter({ platform: "slack" });
-      const bot = createChannel({ adapters: [bad, good] });
-      await expect(bot.start()).resolves.toBeUndefined();
+      const channel = createChannel({ adapters: [bad, good] });
+      await expect(channel.start()).resolves.toBeUndefined();
       expect(good.started).toBe(true);
       expect(
         errSpy.mock.calls.some((c) => String(c[0]).includes("telegram")),
@@ -1075,9 +1078,9 @@ describe("createChannel slash commands", () => {
         failRegisterCommands: true,
       });
       const good = new FakeAdapter({ platform: "slack" });
-      const bot = createChannel({ adapters: [bad, good] });
-      bot.onCommand("triage", () => {});
-      await expect(bot.start()).resolves.toBeUndefined();
+      const channel = createChannel({ adapters: [bad, good] });
+      channel.onCommand("triage", () => {});
+      await expect(channel.start()).resolves.toBeUndefined();
       expect(good.started).toBe(true);
       expect(good.registeredCommands?.map((c) => c.name)).toEqual(["triage"]);
       expect(
@@ -1094,9 +1097,9 @@ describe("createChannel slash commands", () => {
       const bad = new FakeAdapter({ platform: "telegram", failStop: true });
       const good = new FakeAdapter({ platform: "slack" });
       const stopSpy = vi.spyOn(good, "stop");
-      const bot = createChannel({ adapters: [bad, good] });
-      await bot.start();
-      await expect(bot.stop()).resolves.toBeUndefined();
+      const channel = createChannel({ adapters: [bad, good] });
+      await channel.start();
+      await expect(channel.stop()).resolves.toBeUndefined();
       expect(stopSpy).toHaveBeenCalled();
       expect(
         errSpy.mock.calls.some((c) => String(c[0]).includes("telegram")),
@@ -1108,22 +1111,22 @@ describe("createChannel slash commands", () => {
 
   it("exposes attached adapters through a read-only, non-mutable-through accessor", () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
 
-    expect(bot.adapters).toContain(fake);
-    expect(bot.adapters).toHaveLength(1);
+    expect(channel.adapters).toContain(fake);
+    expect(channel.adapters).toHaveLength(1);
 
     // The returned snapshot is a copy: mutating it must not affect the channel.
-    (bot.adapters as PlatformAdapter[]).push(new FakeAdapter());
-    expect(bot.adapters).toHaveLength(1);
+    (channel.adapters as PlatformAdapter[]).push(new FakeAdapter());
+    expect(channel.adapters).toHaveLength(1);
   });
 
   it("reflects an adapter attached via addAdapter in the adapters accessor", () => {
-    const bot = createChannel({});
-    expect(bot.adapters).toHaveLength(0);
+    const channel = createChannel({});
+    expect(channel.adapters).toHaveLength(0);
 
     const fake = new FakeAdapter();
-    bot.addAdapter(fake);
-    expect(bot.adapters).toEqual([fake]);
+    channel.addAdapter(fake);
+    expect(channel.adapters).toEqual([fake]);
   });
 });

--- a/packages/channels/src/create-channel.ts
+++ b/packages/channels/src/create-channel.ts
@@ -231,7 +231,7 @@ export interface CreateChannelOptions<
   context?: ContextEntry[];
   /**
    * Named JSX components used in interactive messages. Registering them here
-   * lets the bot re-render and re-fire their handlers after a restart (durable
+   * lets the channel re-render and re-fire their handlers after a restart (durable
    * actions); without registration, a click on a message posted before the
    * restart degrades to "action expired".
    */
@@ -296,7 +296,7 @@ export interface Channel<TState = unknown> {
   /** Handle a modal dismissal for `callbackId` (Slack `view_closed`). */
   onModalClose(callbackId: string, handler: ModalCloseHandler): void;
   tool(t: ChannelTool): void;
-  /** Attach an adapter before `start()`. Throws if called after the bot has started. */
+  /** Attach an adapter before `start()`. Throws if called after the channel has started. */
   addAdapter(adapter: PlatformAdapter): void;
   start(): Promise<void>;
   stop(): Promise<void>;
@@ -372,7 +372,7 @@ export function createChannel<
     );
   }
 
-  // Adapters can be supplied up front or added later via `bot.addAdapter`
+  // Adapters can be supplied up front or added later via `channel.addAdapter`
   // (before `start()`). The runtime uses the latter to attach Channel delivery.
   const adapters: PlatformAdapter[] = [...(opts.adapters ?? [])];
   assertExclusive(adapters);
@@ -426,7 +426,7 @@ export function createChannel<
   const modalCloseHandlers = new Map<string, ModalCloseHandler>();
   const waiters = new Map<string, (value: unknown) => void>();
 
-  // Recomputed on start() so tools added via bot.tool() before start are picked up.
+  // Recomputed on start() so tools added via channel.tool() before start are picked up.
   let toolDescriptors = toAgentToolDescriptors([...toolMap.values()]);
 
   function makeThread(
@@ -760,7 +760,7 @@ export function createChannel<
     };
   }
 
-  const bot: Channel<ThreadStateOf<TStateSchema>> = {
+  const channel: Channel<ThreadStateOf<TStateSchema>> = {
     name: opts.name,
     ...(opts.provider !== undefined ? { provider: opts.provider } : {}),
     get adapters() {
@@ -913,10 +913,10 @@ export function createChannel<
       });
       // Isolate per-adapter startup failures: one adapter rejecting (e.g.
       // Telegram's setMyCommands rejecting a hyphenated command name, a revoked
-      // token, a port already in use) must NOT crash the bot or prevent the
+      // token, a port already in use) must NOT crash the channel or prevent the
       // other adapters from starting. Log + degrade, never throw.
       const startResults = await Promise.allSettled(
-        adapters.map((a) => a.start(makeSink(a), { botName: opts.name })),
+        adapters.map((a) => a.start(makeSink(a), { channelName: opts.name })),
       );
       const startedPlatforms: string[] = [];
       const failedPlatforms: string[] = [];
@@ -989,5 +989,5 @@ export function createChannel<
       });
     },
   };
-  return bot;
+  return channel;
 }

--- a/packages/channels/src/index.ts
+++ b/packages/channels/src/index.ts
@@ -117,5 +117,5 @@ export type { PlatformCodec } from "./codec.js";
 export { FakeAdapter, makeFakeRunRenderer } from "./testing/fake-adapter.js";
 export { FakeAgent } from "./testing/fake-agent.js";
 
-// Re-export the bot-ui component vocabulary + types for convenience.
+// Re-export the channels-ui component vocabulary + types for convenience.
 export * from "@copilotkit/channels-ui";

--- a/packages/channels/src/modal-submit.test.ts
+++ b/packages/channels/src/modal-submit.test.ts
@@ -3,17 +3,17 @@ import { describe, it, expect } from "vitest";
 import { createChannel } from "./create-channel.js";
 import { FakeAdapter } from "./testing/fake-adapter.js";
 
-describe("bot.onModalSubmit / onModalClose", () => {
+describe("channel.onModalSubmit / onModalClose", () => {
   it("routes a submission by callbackId and parses values; thread present when conversation context exists", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     const seen: {
       values: Record<string, unknown>;
       user?: string;
       cb: string;
       hasThread: boolean;
     }[] = [];
-    bot.onModalSubmit("triage", (evt) => {
+    channel.onModalSubmit("triage", (evt) => {
       seen.push({
         values: evt.values,
         user: evt.user?.id,
@@ -21,7 +21,7 @@ describe("bot.onModalSubmit / onModalClose", () => {
         hasThread: !!evt.thread,
       });
     });
-    await bot.start();
+    await channel.start();
     const res = await fake.emitModalSubmit({
       callbackId: "triage",
       values: { summary: "boom", prio: "high" },
@@ -42,11 +42,11 @@ describe("bot.onModalSubmit / onModalClose", () => {
 
   it("returns the handler's field errors so the adapter can keep the modal open", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
-    bot.onModalSubmit("triage", (evt) =>
+    const channel = createChannel({ adapters: [fake] });
+    channel.onModalSubmit("triage", (evt) =>
       evt.values.summary ? undefined : { errors: { summary: "Required" } },
     );
-    await bot.start();
+    await channel.start();
     const res = await fake.emitModalSubmit({
       callbackId: "triage",
       values: {},
@@ -56,8 +56,8 @@ describe("bot.onModalSubmit / onModalClose", () => {
 
   it("ignores submissions with no registered handler", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
-    await bot.start();
+    const channel = createChannel({ adapters: [fake] });
+    await channel.start();
     const res = await fake.emitModalSubmit({
       callbackId: "unknown",
       values: {},
@@ -67,12 +67,12 @@ describe("bot.onModalSubmit / onModalClose", () => {
 
   it("routes a close by callbackId", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     const closed: string[] = [];
-    bot.onModalClose("triage", (evt) => {
+    channel.onModalClose("triage", (evt) => {
       closed.push(evt.callbackId);
     });
-    await bot.start();
+    await channel.start();
     await fake.emitModalClose({ callbackId: "triage", user: { id: "U2" } });
     expect(closed).toEqual(["triage"]);
   });

--- a/packages/channels/src/open-modal.test.tsx
+++ b/packages/channels/src/open-modal.test.tsx
@@ -14,12 +14,12 @@ const view = (
 describe("ctx.openModal", () => {
   it("opens a modal from an interaction when a triggerId is present", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     let res: unknown;
-    bot.onInteraction("ck:open", async (ctx) => {
+    channel.onInteraction("ck:open", async (ctx) => {
       res = await ctx.openModal!(view);
     });
-    await bot.start();
+    await channel.start();
     fake.emitInteraction({ id: "ck:open", triggerId: "T123" });
     await tick();
     expect(res).toEqual({ ok: true });
@@ -30,12 +30,12 @@ describe("ctx.openModal", () => {
 
   it("opens a modal from a command", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     let res: unknown;
-    bot.onCommand("triage", async (ctx) => {
+    channel.onCommand("triage", async (ctx) => {
       res = await ctx.openModal!(view);
     });
-    await bot.start();
+    await channel.start();
     await fake.emitCommand({ command: "triage", triggerId: "T999" });
     expect(res).toEqual({ ok: true });
     expect(fake.openedModals[0]!.triggerId).toBe("T999");
@@ -43,12 +43,12 @@ describe("ctx.openModal", () => {
 
   it("omits openModal when no triggerId is present", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     let hasOpen = true;
-    bot.onInteraction("ck:noop", (ctx) => {
+    channel.onInteraction("ck:noop", (ctx) => {
       hasOpen = typeof ctx.openModal === "function";
     });
-    await bot.start();
+    await channel.start();
     fake.emitInteraction({ id: "ck:noop" });
     await tick();
     expect(hasOpen).toBe(false);
@@ -56,12 +56,12 @@ describe("ctx.openModal", () => {
 
   it("omits openModal when the adapter has no modal support", async () => {
     const fake = new FakeAdapter({ modals: false });
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     let hasOpen = true;
-    bot.onInteraction("ck:x", (ctx) => {
+    channel.onInteraction("ck:x", (ctx) => {
       hasOpen = typeof ctx.openModal === "function";
     });
-    await bot.start();
+    await channel.start();
     fake.emitInteraction({ id: "ck:x", triggerId: "T1" });
     await tick();
     expect(hasOpen).toBe(false);

--- a/packages/channels/src/platform-adapter.ts
+++ b/packages/channels/src/platform-adapter.ts
@@ -1,7 +1,7 @@
 import type { AgentSubscriber, AbstractAgent } from "@ag-ui/client";
 import type {
   AgentContentPart,
-  BotNode,
+  ChannelNode,
   EmojiValue,
   EphemeralResult,
   MessageRef,
@@ -11,7 +11,7 @@ import type {
 import type { CommandSpec } from "./commands.js";
 import type { StateStore } from "./state/state-store.js";
 
-/** Opaque to the bot core — created by an adapter during ingress and passed back to post/createRunRenderer. */
+/** Opaque to the channel core — created by an adapter during ingress and passed back to post/createRunRenderer. */
 export type ReplyTarget = unknown;
 /** Opaque native payload produced by an adapter's render(). */
 export type NativePayload = unknown;
@@ -198,7 +198,7 @@ export interface ModalSubmitResult {
 export interface IngressSink {
   onTurn(turn: IncomingTurn): void | Promise<void>;
   onInteraction(evt: InteractionEvent): void | Promise<void>;
-  /** A slash command fired. Routed to the matching `bot.onCommand` handler (ignored if none). */
+  /** A slash command fired. Routed to the matching `channel.onCommand` handler (ignored if none). */
   onCommand(cmd: IncomingCommand): void | Promise<void>;
   /** A conversation surface opened. Adapters without the concept never call it. */
   onThreadStarted(evt: IncomingThreadStart): void | Promise<void>;
@@ -233,14 +233,14 @@ export interface ConversationStore {
 }
 
 /**
- * Optional context bot core passes to {@link PlatformAdapter.start}. Carries
- * the bot's declared identity so a transport that must announce itself (e.g.
+ * Optional context channel core passes to {@link PlatformAdapter.start}. Carries
+ * the channel's declared identity so a transport that must announce itself (e.g.
  * the Intelligence Channel adapter's heartbeat) can do so without separate
  * config. Local adapters ignore it.
  */
 export interface AdapterStartContext {
-  /** The bot's declared name (`createChannel({ name })`), when set. */
-  botName?: string;
+  /** The channel's declared name (`createChannel({ name })`), when set. */
+  channelName?: string;
 }
 
 export interface PlatformAdapter {
@@ -249,9 +249,9 @@ export interface PlatformAdapter {
   readonly ackDeadlineMs: number;
   start(sink: IngressSink, ctx?: AdapterStartContext): Promise<void>;
   stop(): Promise<void>;
-  render(ir: BotNode[]): NativePayload;
-  post(target: ReplyTarget, ir: BotNode[]): Promise<MessageRef>;
-  update(ref: MessageRef, ir: BotNode[]): Promise<void>;
+  render(ir: ChannelNode[]): NativePayload;
+  post(target: ReplyTarget, ir: ChannelNode[]): Promise<MessageRef>;
+  update(ref: MessageRef, ir: ChannelNode[]): Promise<void>;
   stream(
     target: ReplyTarget,
     chunks: AsyncIterable<string>,
@@ -271,7 +271,7 @@ export interface PlatformAdapter {
   /** @internal Marks the Intelligence Channel adapter for the V1 exclusivity guard. */
   readonly __intelligenceChannel?: boolean;
   /**
-   * When true, bot core skips its ingress dedup for events from this adapter.
+   * When true, channel core skips its ingress dedup for events from this adapter.
    * Set by at-least-once transports (Channel delivery) that enforce
    * idempotency at egress instead — dropping a redelivery at ingress would lose
    * a legitimate retry.
@@ -298,7 +298,7 @@ export interface PlatformAdapter {
     },
   ): Promise<{ ok: boolean; fileId?: string; error?: string }>;
   /**
-   * Optional slash-command support. Called once on `start()` with the bot's
+   * Optional slash-command support. Called once on `start()` with the channel's
    * declared commands, so a surface that registers commands up front (e.g.
    * Discord's application-command API) can publish them. Surfaces that match
    * commands dynamically (e.g. Slack, which forwards every `/command` to
@@ -348,11 +348,11 @@ export interface PlatformAdapter {
   postEphemeral?(
     target: ReplyTarget,
     user: PlatformUser | string,
-    ir: BotNode[],
+    ir: ChannelNode[],
     opts: { fallbackToDM: boolean },
   ): Promise<EphemeralResult | null>;
   /** Optional modal render (pure; backs `openModal`). Throws `ModalRenderError` on unsupported elements. */
-  renderModal?(ir: BotNode[]): NativePayload;
+  renderModal?(ir: ChannelNode[]): NativePayload;
   /**
    * Optional modal open (backs context `openModal`). Renders `ir` and opens it
    * against the platform `triggerId`. Returns `{ ok: false }` on failure
@@ -361,6 +361,6 @@ export interface PlatformAdapter {
   openModal?(
     target: ReplyTarget,
     triggerId: string,
-    ir: BotNode[],
+    ir: ChannelNode[],
   ): Promise<{ ok: boolean; error?: string }>;
 }

--- a/packages/channels/src/reactions.test.ts
+++ b/packages/channels/src/reactions.test.ts
@@ -7,15 +7,15 @@ import { MemoryStore } from "./state/memory-store.js";
 
 const tick = () => new Promise((r) => setTimeout(r, 0));
 
-describe("bot.onReaction", () => {
+describe("channel.onReaction", () => {
   it("routes a specific reaction, normalizing the platform token", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     const seen: { emoji: string; raw: string; added: boolean }[] = [];
-    bot.onReaction([emoji.thumbs_up], (evt) => {
+    channel.onReaction([emoji.thumbs_up], (evt) => {
       seen.push({ emoji: evt.emoji, raw: evt.rawEmoji, added: evt.added });
     });
-    await bot.start();
+    await channel.start();
     // FakeAdapter.platform === "fake": normalizeEmoji falls through, but engine
     // normalizes by adapter.platform. Use a Slack-style token via a fake whose
     // platform normalizes — here we assert passthrough + catch-all instead.
@@ -27,7 +27,7 @@ describe("bot.onReaction", () => {
 
   it("fires a catch-all for any reaction and reports added/removed", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     const seen: {
       raw: string;
       added: boolean;
@@ -35,7 +35,7 @@ describe("bot.onReaction", () => {
       messageId: string;
       platform: string;
     }[] = [];
-    bot.onReaction((evt) => {
+    channel.onReaction((evt) => {
       seen.push({
         raw: evt.rawEmoji,
         added: evt.added,
@@ -44,7 +44,7 @@ describe("bot.onReaction", () => {
         platform: evt.thread.platform,
       });
     });
-    await bot.start();
+    await channel.start();
     fake.emitReaction({
       rawEmoji: "🎉",
       added: true,
@@ -69,12 +69,12 @@ describe("bot.onReaction", () => {
     // A fake whose platform === "slack" so normalizeEmoji maps the shortcode.
     const fake = new FakeAdapter();
     Object.defineProperty(fake, "platform", { value: "slack" });
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     const hits: string[] = [];
-    bot.onReaction(["thumbs_up"], (evt) => {
+    channel.onReaction(["thumbs_up"], (evt) => {
       hits.push(evt.emoji);
     });
-    await bot.start();
+    await channel.start();
     fake.emitReaction({ rawEmoji: "thumbsup", added: true }); // Slack alias
     await tick();
     expect(hits).toEqual(["thumbs_up"]);
@@ -82,9 +82,9 @@ describe("bot.onReaction", () => {
 
   it("routes a reaction on a posted message to its <Message onReaction>", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     const seen: { emoji: string; added: boolean }[] = [];
-    bot.onMessage(async ({ thread }) => {
+    channel.onMessage(async ({ thread }) => {
       await thread.post(
         Message({
           onReaction: (e, r) => {
@@ -94,7 +94,7 @@ describe("bot.onReaction", () => {
         }),
       );
     });
-    await bot.start();
+    await channel.start();
     fake.emitTurn({});
     await tick();
     // The handler is a closure, never serialized into the native payload.
@@ -111,9 +111,9 @@ describe("bot.onReaction", () => {
 
   it("resolves <Message onReaction> by postedMessageId when the reaction id differs (Channel path)", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     const seen: string[] = [];
-    bot.onMessage(async ({ thread }) => {
+    channel.onMessage(async ({ thread }) => {
       await thread.post(
         Message({
           onReaction: (e, r) => {
@@ -123,7 +123,7 @@ describe("bot.onReaction", () => {
         }),
       );
     });
-    await bot.start();
+    await channel.start();
     fake.emitTurn({});
     await tick();
     // Channel delivery: the reaction arrives keyed by the provider ts (NOT the
@@ -167,7 +167,7 @@ describe("bot.onReaction", () => {
     fake1.emitTurn({});
     await tick();
 
-    // "Restart": a fresh bot + registry sharing the same store, Card re-registered.
+    // "Restart": a fresh channel + registry sharing the same store, Card re-registered.
     // Its reaction hot cache is empty, so it must resolve via the durable snapshot.
     const fake2 = new FakeAdapter();
     const bot2 = createChannel({
@@ -183,9 +183,9 @@ describe("bot.onReaction", () => {
 
   it("gives the handler a thread to post new UI and the reacted message's ref", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     let seenRefId: string | undefined;
-    bot.onMessage(async ({ thread }) => {
+    channel.onMessage(async ({ thread }) => {
       await thread.post(
         Message({
           onReaction: async (_e, r) => {
@@ -196,7 +196,7 @@ describe("bot.onReaction", () => {
         }),
       );
     });
-    await bot.start();
+    await channel.start();
     fake.emitTurn({});
     await tick();
     const before = fake.posted.length;
@@ -210,9 +210,9 @@ describe("bot.onReaction", () => {
 
   it("does not fire a message handler for a reaction on a different message", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     let fired = false;
-    bot.onMessage(async ({ thread }) => {
+    channel.onMessage(async ({ thread }) => {
       await thread.post(
         Message({
           onReaction: () => {
@@ -222,7 +222,7 @@ describe("bot.onReaction", () => {
         }),
       );
     });
-    await bot.start();
+    await channel.start();
     fake.emitTurn({});
     await tick();
     fake.emitReaction({ rawEmoji: "🎉", added: true, messageId: "other" });
@@ -235,15 +235,15 @@ describe("bot.onReaction", () => {
     // Slack alias to the canonical "thumbs_up", so the filter must too.
     const fake = new FakeAdapter();
     Object.defineProperty(fake, "platform", { value: "slack" });
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     const hits: string[] = [];
-    bot.onReaction(["👍"], (evt) => {
+    channel.onReaction(["👍"], (evt) => {
       hits.push(evt.emoji);
     });
-    bot.onReaction(["thumbsup"], (evt) => {
+    channel.onReaction(["thumbsup"], (evt) => {
       hits.push(`alias:${evt.emoji}`);
     });
-    await bot.start();
+    await channel.start();
     fake.emitReaction({ rawEmoji: "thumbsup", added: true }); // Slack alias
     await tick();
     expect(hits).toEqual(["thumbs_up", "alias:thumbs_up"]);

--- a/packages/channels/src/state/state-store.ts
+++ b/packages/channels/src/state/state-store.ts
@@ -1,5 +1,5 @@
 /**
- * Pluggable persistence interface for the bot runtime.
+ * Pluggable persistence interface for the channel runtime.
  *
  * **JSON-serialization contract**: all values round-trip through
  * `JSON.stringify` / `JSON.parse` on remote backends (Redis, Postgres), so `T`

--- a/packages/channels/src/telemetry/create-channel-telemetry.test.ts
+++ b/packages/channels/src/telemetry/create-channel-telemetry.test.ts
@@ -25,7 +25,7 @@ describe("createChannel telemetry wiring", () => {
     // The config snapshot is captured at start() — the backend (and therefore
     // telemetry) is resolved there, not at construction, so an adapter attached
     // via addAdapter can still provide the persistence backend.
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [new FakeAdapter()],
       components: [
         function Card() {
@@ -33,7 +33,7 @@ describe("createChannel telemetry wiring", () => {
         },
       ],
     });
-    await bot.start();
+    await channel.start();
     const call = capture.mock.calls.find(
       (c) => c[0] === "oss.channel.configured",
     );
@@ -45,8 +45,8 @@ describe("createChannel telemetry wiring", () => {
 
   it("emits oss.channel.started on start, start_failed (category only) on a throwing adapter", async () => {
     const ok = new FakeAdapter();
-    const bot = createChannel({ adapters: [ok] });
-    await bot.start();
+    const channel = createChannel({ adapters: [ok] });
+    await channel.start();
     expect(
       capture.mock.calls.find((c) => c[0] === "oss.channel.started")?.[1]
         .startedCount,
@@ -70,14 +70,14 @@ describe("createChannel telemetry wiring", () => {
 
   it("emits oss.channel.agent_run on a successful run", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       agent: () => new FakeAgent(),
     });
-    bot.onMention(async ({ thread }) => {
+    channel.onMention(async ({ thread }) => {
       await thread.runAgent();
     });
-    await bot.start();
+    await channel.start();
     capture.mockClear();
     fake.emitTurn({ userText: "hi", conversationKey: "c1" });
     await tick();

--- a/packages/channels/src/telemetry/e2e-telemetry.test.ts
+++ b/packages/channels/src/telemetry/e2e-telemetry.test.ts
@@ -38,14 +38,14 @@ describe("oss.channel.* end-to-end (real ChannelTelemetry, only network boundary
 
   it("flows configured -> started -> agent_run with anonymous_id + channel_session_id and no env config", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({
+    const channel = createChannel({
       adapters: [fake],
       agent: () => new FakeAgent(),
     });
-    bot.onMention(async ({ thread }) => {
+    channel.onMention(async ({ thread }) => {
       await thread.runAgent();
     });
-    await bot.start();
+    await channel.start();
     fake.emitTurn({ userText: "hi", conversationKey: "c1" });
 
     await waitFor(() =>

--- a/packages/channels/src/testing/fake-adapter.ts
+++ b/packages/channels/src/testing/fake-adapter.ts
@@ -1,6 +1,6 @@
 import type { AgentSubscriber } from "@ag-ui/client";
 import type {
-  BotNode,
+  ChannelNode,
   MessageRef,
   PlatformUser,
   ThreadMessage,
@@ -174,8 +174,8 @@ export class FakeAdapter implements PlatformAdapter {
     },
   };
 
-  posted: BotNode[][] = [];
-  updated: { ref: MessageRef; ir: BotNode[] }[] = [];
+  posted: ChannelNode[][] = [];
+  updated: { ref: MessageRef; ir: ChannelNode[] }[] = [];
   interactionsSeen: InteractionEvent[] = [];
   lastRunRenderer?: RunRenderer;
   /** History returned by getMessages(); override in tests. */
@@ -203,14 +203,14 @@ export class FakeAdapter implements PlatformAdapter {
     if (this.failStop) throw new Error("fake-adapter: stop failed");
   }
 
-  render(ir: BotNode[]): NativePayload {
+  render(ir: ChannelNode[]): NativePayload {
     return ir;
   }
-  async post(_target: ReplyTarget, ir: BotNode[]): Promise<MessageRef> {
+  async post(_target: ReplyTarget, ir: ChannelNode[]): Promise<MessageRef> {
     this.posted.push(ir);
     return { id: `msg-${++this.counter}` };
   }
-  async update(ref: MessageRef, ir: BotNode[]): Promise<void> {
+  async update(ref: MessageRef, ir: ChannelNode[]): Promise<void> {
     this.updated.push({ ref, ir });
   }
   async stream(
@@ -260,13 +260,13 @@ export class FakeAdapter implements PlatformAdapter {
   // --- ephemeral ---
   ephemeralPosts: {
     user: unknown;
-    ir: BotNode[];
+    ir: ChannelNode[];
     opts: { fallbackToDM: boolean };
   }[] = [];
   postEphemeral?: PlatformAdapter["postEphemeral"];
 
   // --- modals ---
-  openedModals: { triggerId: string; ir: BotNode[] }[] = [];
+  openedModals: { triggerId: string; ir: ChannelNode[] }[] = [];
   renderModal?: PlatformAdapter["renderModal"];
   openModal?: PlatformAdapter["openModal"];
 

--- a/packages/channels/src/thread-capabilities.test.ts
+++ b/packages/channels/src/thread-capabilities.test.ts
@@ -5,12 +5,12 @@ import { FakeAdapter } from "./testing/fake-adapter.js";
 describe("onThreadStarted routing", () => {
   it("invokes registered handlers with the thread and user", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     const seen: { user?: string; platform: string }[] = [];
-    bot.onThreadStarted(({ thread, user }) => {
+    channel.onThreadStarted(({ thread, user }) => {
       seen.push({ user: user?.id, platform: thread.platform });
     });
-    await bot.start();
+    await channel.start();
 
     await fake.emitThreadStarted({ user: { id: "U1", name: "Ada" } });
     expect(seen).toEqual([{ user: "U1", platform: "fake" }]);
@@ -18,23 +18,23 @@ describe("onThreadStarted routing", () => {
 
   it("invokes every registered handler in order", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     const order: number[] = [];
-    bot.onThreadStarted(() => {
+    channel.onThreadStarted(() => {
       order.push(1);
     });
-    bot.onThreadStarted(() => {
+    channel.onThreadStarted(() => {
       order.push(2);
     });
-    await bot.start();
+    await channel.start();
     await fake.emitThreadStarted();
     expect(order).toEqual([1, 2]);
   });
 
   it("is a no-op when no handler is registered", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
-    await bot.start();
+    const channel = createChannel({ adapters: [fake] });
+    await channel.start();
     // Should not throw.
     await expect(
       Promise.resolve(fake.emitThreadStarted()),
@@ -45,9 +45,9 @@ describe("onThreadStarted routing", () => {
 describe("Thread.setSuggestedPrompts / setTitle capability gating", () => {
   it("delegates to the adapter when supported", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     const results: { ok: boolean; error?: string }[] = [];
-    bot.onThreadStarted(async ({ thread }) => {
+    channel.onThreadStarted(async ({ thread }) => {
       results.push(
         await thread.setSuggestedPrompts(
           [{ title: "Triage", message: "Triage my issues" }],
@@ -56,7 +56,7 @@ describe("Thread.setSuggestedPrompts / setTitle capability gating", () => {
       );
       results.push(await thread.setTitle("My conversation"));
     });
-    await bot.start();
+    await channel.start();
     await fake.emitThreadStarted({ replyTarget: { channel: "D1" } });
 
     expect(results).toEqual([{ ok: true }, { ok: true }]);
@@ -73,13 +73,13 @@ describe("Thread.setSuggestedPrompts / setTitle capability gating", () => {
 
   it("returns { ok: false } without throwing when unsupported", async () => {
     const fake = new FakeAdapter({ paneMethods: false });
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     const results: { ok: boolean; error?: string }[] = [];
-    bot.onThreadStarted(async ({ thread }) => {
+    channel.onThreadStarted(async ({ thread }) => {
       results.push(await thread.setSuggestedPrompts([]));
       results.push(await thread.setTitle("nope"));
     });
-    await bot.start();
+    await channel.start();
     await fake.emitThreadStarted();
 
     expect(results[0]!.ok).toBe(false);

--- a/packages/channels/src/thread-ephemeral.test.ts
+++ b/packages/channels/src/thread-ephemeral.test.ts
@@ -6,9 +6,9 @@ async function runOnMessage(
   fake: FakeAdapter,
   fn: Parameters<ReturnType<typeof createChannel>["onMessage"]>[0],
 ) {
-  const bot = createChannel({ adapters: [fake] });
-  bot.onMessage(fn);
-  await bot.start();
+  const channel = createChannel({ adapters: [fake] });
+  channel.onMessage(fn);
+  await channel.start();
   fake.emitTurn({ userText: "hi", user: { id: "U1" } });
   await new Promise((r) => setTimeout(r, 0));
 }

--- a/packages/channels/src/thread-reactions.test.ts
+++ b/packages/channels/src/thread-reactions.test.ts
@@ -6,13 +6,13 @@ import { FakeAdapter } from "./testing/fake-adapter.js";
 describe("Thread.react / unreact", () => {
   it("delegates to the adapter when supported", async () => {
     const fake = new FakeAdapter();
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     const results: { ok: boolean }[] = [];
-    bot.onMessage(async ({ thread, message }) => {
+    channel.onMessage(async ({ thread, message }) => {
       results.push(await thread.react(message.ref, emoji.thumbs_up));
       results.push(await thread.unreact(message.ref, emoji.thumbs_up));
     });
-    await bot.start();
+    await channel.start();
     fake.emitTurn({ userText: "hi" });
     await new Promise((r) => setTimeout(r, 0));
 
@@ -27,12 +27,12 @@ describe("Thread.react / unreact", () => {
 
   it("returns { ok: false } without throwing when unsupported", async () => {
     const fake = new FakeAdapter({ reactions: false });
-    const bot = createChannel({ adapters: [fake] });
+    const channel = createChannel({ adapters: [fake] });
     let res: { ok: boolean; error?: string } | undefined;
-    bot.onMessage(async ({ thread, message }) => {
+    channel.onMessage(async ({ thread, message }) => {
       res = await thread.react(message.ref, emoji.heart);
     });
-    await bot.start();
+    await channel.start();
     fake.emitTurn({ userText: "hi" });
     await new Promise((r) => setTimeout(r, 0));
 

--- a/packages/channels/src/thread.ts
+++ b/packages/channels/src/thread.ts
@@ -192,7 +192,7 @@ export class Thread implements ThreadInterface {
     return adapter.addReaction(this.deps.replyTarget, messageRef, emoji);
   }
 
-  /** Remove the bot's emoji reaction from a message (capability-gated). */
+  /** Remove the channel's emoji reaction from a message (capability-gated). */
   async unreact(
     messageRef: MessageRef,
     emoji: EmojiValue,
@@ -308,7 +308,7 @@ export class Thread implements ThreadInterface {
      *   3. runs the agent,
      *   4. captures the assistant reply and appends it.
      * This flag OWNS the bridge — callers using it should NOT also manually
-     * append the same user/assistant turn via `bot.transcripts.append`.
+     * append the same user/assistant turn via `channel.transcripts.append`.
      * No-ops with a one-time warning when identity/transcripts aren't configured.
      */
     transcript?: boolean | { limit?: number };
@@ -345,7 +345,7 @@ export class Thread implements ThreadInterface {
         // AG-UI types `content` as `string`, but multimodal works at runtime by
         // setting it to an `AgentContentPart[]` — the runtime's LLM adapter
         // converts the parts to the provider's multimodal format. We cast to
-        // satisfy the string-typed field (bot-slack parity — it does the same
+        // satisfy the string-typed field (channels-slack parity — it does the same
         // when assigning multimodal `content` to its reconstructed messages).
         content: extra.prompt as unknown as string,
       });
@@ -384,7 +384,7 @@ export class Thread implements ThreadInterface {
       }
     }
 
-    // Merge per-run context/tools (this run only) on top of the bot-level deps.
+    // Merge per-run context/tools (this run only) on top of the channel-level deps.
     const extraTools = extra?.tools ?? [];
     let tools = this.deps.tools;
     let toolDescriptors = this.deps.toolDescriptors;

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
@@ -196,6 +196,38 @@ describe("ChannelManager", () => {
     expect(mgr.status().overall).toBe("connecting");
   });
 
+  it("ready() surfaces the erroring channel's real reason even when a sibling hangs", async () => {
+    const boom = new Error("activation exploded");
+    const engine: ActivateChannelEngine = (_config, channel) =>
+      channel.name === "support"
+        ? Promise.reject(boom) // errors immediately
+        : new Promise<ChannelsHandle>(() => {}); // sibling hangs forever
+    const mgr = new ChannelManager({
+      intelligence: fakeIntelligence(),
+      channels: [
+        createChannel({ name: "support" }),
+        createChannel({ name: "sales" }),
+      ],
+      activateChannel: engine,
+    });
+    mgr.activate();
+
+    const err = await mgr.ready({ timeoutMs: 25 }).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+    // A set-wide timeout would have rejected with only a generic timeout and
+    // DISCARDED `boom`. The per-channel timeout aggregate carries BOTH.
+    expect(err).toBeInstanceOf(AggregateError);
+    const agg = err as AggregateError;
+    expect(agg.errors).toContain(boom);
+    expect(
+      agg.errors.some(
+        (e) => e instanceof Error && /"sales" did not settle/.test(e.message),
+      ),
+    ).toBe(true);
+  });
+
   it("activate() throws on duplicate channel names before any engine call (no leak)", () => {
     const engine: ActivateChannelEngine = vi.fn(async () => fakeHandle());
     const mgr = new ChannelManager({
@@ -242,6 +274,44 @@ describe("ChannelManager", () => {
     resolveActivation(handle);
     await vi.waitFor(() => expect(handle.stop).toHaveBeenCalledTimes(1));
     expect(mgr.status().channels.support).toBe("stopped");
+  });
+
+  it("stop() bounds a wedged handle.stop() so teardown can't hang (per-handle timeout)", async () => {
+    const logs: unknown[][] = [];
+    // A handle whose stop() never settles — the SIGTERM-hang risk.
+    const wedged: ChannelsHandle & { stop: ReturnType<typeof vi.fn> } = {
+      metadata: {},
+      stop: vi.fn(() => new Promise<void>(() => {})),
+    };
+    const mgr = new ChannelManager({
+      intelligence: fakeIntelligence(),
+      channels: [createChannel({ name: "support" })],
+      activateChannel: async () => wedged,
+      stopHandleTimeoutMs: 20,
+      log: (...args) => logs.push(args),
+    });
+    await mgr.ready();
+
+    let hangTimer: ReturnType<typeof setTimeout>;
+    await expect(
+      Promise.race([
+        mgr.stop(),
+        new Promise((_resolve, reject) => {
+          hangTimer = setTimeout(() => reject(new Error("stop() hung")), 1000);
+        }),
+      ]),
+    ).resolves.toBeUndefined();
+    clearTimeout(hangTimer!);
+
+    expect(mgr.status().channels.support).toBe("stopped");
+    expect(wedged.stop).toHaveBeenCalledTimes(1);
+    const timeoutLog = logs.find(
+      ([msg]) =>
+        typeof msg === "string" &&
+        msg.includes("channel handle stop() failed during teardown"),
+    );
+    expect(timeoutLog).toBeDefined();
+    expect((timeoutLog![1] as Error).message).toMatch(/timed out after 20ms/);
   });
 
   it("stop() completes and marks every channel stopped even when a handle.stop() rejects", async () => {
@@ -676,6 +746,23 @@ describe("defaultActivateChannel", () => {
     // The scope carries ONLY projectId + channelName — never org/channelId.
     expect(opts.scope).not.toHaveProperty("organizationId");
     expect(opts.scope).not.toHaveProperty("channelId");
+  });
+
+  it("forwards the log sink to the launcher opts so transport-level drops surface", async () => {
+    const handle: ChannelsHandle = { metadata: {}, stop: async () => {} };
+    const start = vi.fn<
+      ChannelsIntelligenceModule["startChannelsOverRealtimeGateway"]
+    >(async () => handle);
+    const channel = createChannel({ name: "support" });
+    const importer = async (): Promise<ChannelsIntelligenceModule> => ({
+      startChannelsOverRealtimeGateway: start,
+    });
+    const log = vi.fn();
+
+    await defaultActivateChannel(config, channel, importer, log);
+
+    const [, opts] = start.mock.calls[0]!;
+    expect(opts.log).toBe(log);
   });
 
   it("throws a friendly install hint when the module is not found", async () => {

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
@@ -182,6 +182,19 @@ describe("ChannelManager", () => {
     expect(mgr.status().overall).toBe("error");
   });
 
+  it("status() reports overall 'stopped' when stop() runs before activate() (SIGTERM during startup)", async () => {
+    const mgr = new ChannelManager({
+      intelligence: fakeIntelligence(),
+      channels: [createChannel({ name: "support" })],
+      activateChannel: async () => fakeHandle(),
+    });
+    // stop() before activate() — no entries were ever created, so the empty-set
+    // fold would report "online" (a torn-down manager reading healthy) without
+    // the stopped short-circuit in status().
+    await mgr.stop();
+    expect(mgr.status().overall).toBe("stopped");
+  });
+
   it("ready() rejects when a channel does not settle within timeoutMs", async () => {
     const engine: ActivateChannelEngine = () =>
       new Promise<ChannelsHandle>(() => {});

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -131,8 +131,13 @@ export interface ChannelManagerArgs {
   activateChannel?: ActivateChannelEngine;
   /** Mint a runtime instance id per Channel. Defaults to `rti_{uuid-no-dashes}`. */
   mintRuntimeInstanceId?: () => string;
-  /** Diagnostic sink. */
+  /** Diagnostic sink. Forwarded to the launcher/transport when the default
+   * activation engine is used, so transport-level drops surface in the managed
+   * path (not just activation-level events). */
   log?: (msg: string, meta?: unknown) => void;
+  /** Per-handle deadline (ms) for `handle.stop()` during {@link ChannelManager.stop}
+   * so a wedged stop can't hang SIGTERM shutdown. Default 5000. */
+  stopHandleTimeoutMs?: number;
 }
 
 /** Per-Channel mutable activation entry tracked by the manager. */
@@ -169,6 +174,10 @@ export interface ChannelsIntelligenceModule {
       scope: { projectId: number; channelName: string };
       runtimeInstanceId: string;
       adapter?: string;
+      /** Diagnostic sink forwarded to the launcher/transport so transport-level
+       * drop diagnostics (e.g. a version-skew missing-leaseToken outage) are not
+       * silent in the managed path. */
+      log?: (msg: string, meta?: unknown) => void;
     },
   ) => Promise<ChannelsHandle>;
 }
@@ -191,6 +200,8 @@ export interface ChannelsIntelligenceModule {
  * @param channel - The Channel to activate.
  * @param importChannelsIntelligence - Test seam; loads the channels-intelligence
  *   module. Defaults to a dynamic import of the real package.
+ * @param log - Optional diagnostic sink forwarded to the launcher/transport so
+ *   transport-level drop diagnostics are not silent in the managed path.
  * @returns The launcher's {@link ChannelsHandle}.
  */
 export async function defaultActivateChannel(
@@ -200,6 +211,7 @@ export async function defaultActivateChannel(
     import(
       CHANNELS_INTELLIGENCE_SPECIFIER
     ) as Promise<ChannelsIntelligenceModule>,
+  log?: (msg: string, meta?: unknown) => void,
 ): Promise<ChannelsHandle> {
   let mod: ChannelsIntelligenceModule;
   try {
@@ -219,6 +231,10 @@ export async function defaultActivateChannel(
     scope: { projectId: config.projectId, channelName: config.channelName },
     runtimeInstanceId: config.runtimeInstanceId,
     adapter: config.adapter,
+    // Forward the manager's diagnostic sink down to the launcher/transport so a
+    // transport-level drop (e.g. a version-skew missing-leaseToken outage) is
+    // observable in the managed path, not just activation-level events.
+    ...(log ? { log } : {}),
   });
 }
 
@@ -246,22 +262,30 @@ export function isModuleNotFound(err: unknown): boolean {
   return code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND";
 }
 
+/** Default deadline (ms) for a single `handle.stop()` during teardown. */
+const DEFAULT_STOP_HANDLE_TIMEOUT_MS = 5_000;
+
 /**
- * Reject after `timeoutMs` if `inner` has not settled, otherwise pass `inner`
- * through. When `timeoutMs` is undefined, `inner` is returned unchanged.
+ * Reject with `timeoutMessage` after `timeoutMs` if `inner` has not settled,
+ * otherwise pass `inner` through. When `timeoutMs` is undefined, `inner` is
+ * returned unchanged. The timer is `unref`'d so a pending deadline never keeps
+ * the process alive, and `inner` always has a settle handler attached, so a
+ * timed-out promise that later settles never surfaces as unhandled.
  */
-function withTimeout<T>(inner: Promise<T>, timeoutMs?: number): Promise<T> {
+function withTimeout<T>(
+  inner: Promise<T>,
+  timeoutMs: number | undefined,
+  timeoutMessage: string,
+): Promise<T> {
   if (timeoutMs === undefined) {
     return inner;
   }
   return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      reject(
-        new Error(
-          `ChannelManager.ready timed out after ${timeoutMs}ms waiting for all channels to settle`,
-        ),
-      );
-    }, timeoutMs);
+    const timer = setTimeout(
+      () => reject(new Error(timeoutMessage)),
+      timeoutMs,
+    );
+    (timer as unknown as { unref?: () => void }).unref?.();
     inner.then(
       (value) => {
         clearTimeout(timer);
@@ -311,6 +335,7 @@ export class ChannelManager implements ChannelsControl {
   private readonly activateChannel: ActivateChannelEngine;
   private readonly mintRuntimeInstanceId: () => string;
   private readonly log?: (msg: string, meta?: unknown) => void;
+  private readonly stopHandleTimeoutMs: number;
 
   private readonly entries = new Map<string, ChannelEntry>();
   private activated = false;
@@ -320,11 +345,20 @@ export class ChannelManager implements ChannelsControl {
   constructor(args: ChannelManagerArgs) {
     this.intelligence = args.intelligence;
     this.channels = args.channels;
-    this.activateChannel = args.activateChannel ?? defaultActivateChannel;
+    this.log = args.log;
+    // When using the default engine, forward the manager's log DOWN to the
+    // launcher/transport (via defaultActivateChannel's log param) so a
+    // transport-level drop is observable in the managed path. `this.log` is read
+    // lazily at activation time, so this closure always sees the assigned sink.
+    this.activateChannel =
+      args.activateChannel ??
+      ((config, channel) =>
+        defaultActivateChannel(config, channel, undefined, this.log));
     this.mintRuntimeInstanceId =
       args.mintRuntimeInstanceId ??
       (() => `rti_${randomUUID().replace(/-/g, "")}`);
-    this.log = args.log;
+    this.stopHandleTimeoutMs =
+      args.stopHandleTimeoutMs ?? DEFAULT_STOP_HANDLE_TIMEOUT_MS;
   }
 
   /**
@@ -518,9 +552,12 @@ export class ChannelManager implements ChannelsControl {
    * same {@link ChannelConfigError} as the synchronous throw from
    * {@link activate} for an up-front misconfiguration (duplicate/missing Channel
    * names). Once activation has been kicked off, all OTHER failures are surfaced
-   * here instead: this rejects with an `AggregateError` of the reasons if any
-   * Channel settled to `error`, or with a timeout error if `timeoutMs` elapses
-   * before all Channels settle.
+   * here instead: this rejects with an `AggregateError` if any Channel settled
+   * to `error` OR — when `timeoutMs` is given — did not settle in time. The
+   * `timeoutMs` deadline is applied PER CHANNEL, so the aggregate carries each
+   * failed Channel's real reason AND a named timeout for each Channel still
+   * hanging: a genuine activation error is never masked by a sibling that hangs
+   * (a pre-fix set-wide timeout discarded the real reason in that case).
    *
    * A STOPPED manager short-circuits and resolves: a Channel that settled to
    * `error` BEFORE {@link stop} already rejected its `settled` promise, so
@@ -540,16 +577,29 @@ export class ChannelManager implements ChannelsControl {
       return;
     }
     this.activate();
-    const entries = [...this.entries.values()];
-    const all = Promise.allSettled(entries.map((e) => e.settled));
-    const results = await withTimeout(all, opts?.timeoutMs);
+    const entries = [...this.entries.entries()];
+    // Apply `timeoutMs` PER CHANNEL rather than to the whole set. A single
+    // set-wide timeout wrapping `allSettled` would, when one channel settles to
+    // `error` while a sibling hangs, reject with only a generic timeout and
+    // DISCARD the erroring channel's real reason. Timing out each channel's
+    // `settled` independently lets `allSettled` collect BOTH a hung channel's
+    // named timeout AND a failed channel's real error into one AggregateError.
+    const results = await Promise.allSettled(
+      entries.map(([name, e]) =>
+        withTimeout(
+          e.settled,
+          opts?.timeoutMs,
+          `channel "${name}" did not settle within ${opts?.timeoutMs}ms`,
+        ),
+      ),
+    );
     const errors = results
       .filter((r): r is PromiseRejectedResult => r.status === "rejected")
       .map((r) => r.reason);
     if (errors.length > 0) {
       throw new AggregateError(
         errors,
-        `ChannelManager.ready: ${errors.length} channel(s) failed to activate`,
+        `ChannelManager.ready: ${errors.length} channel(s) failed to activate or settle in time`,
       );
     }
   }
@@ -699,6 +749,11 @@ export class ChannelManager implements ChannelsControl {
    * The developer's `channel.start()`/stop path is unaffected by manager
    * teardown.
    *
+   * A WEDGED `handle.stop()` (one that never settles) is bounded by
+   * {@link ChannelManagerArgs.stopHandleTimeoutMs}: after the deadline the call
+   * is logged and abandoned so it can't hang `stop()` — and thus SIGTERM
+   * shutdown — forever.
+   *
    * @param entry - The Channel entry to stop.
    */
   private async stopEntry(entry: ChannelEntry): Promise<void> {
@@ -709,11 +764,20 @@ export class ChannelManager implements ChannelsControl {
     if (entry.handle && !entry.handleStopped) {
       entry.handleStopped = true;
       const handle = entry.handle;
-      await Promise.resolve()
-        .then(() => handle.stop())
-        .catch((err: unknown) =>
-          this.log?.("channel handle stop() failed during teardown", err),
-        );
+      // Bound handle.stop(): a wedged stop() (e.g. a socket.disconnect that
+      // never returns) must not hang teardown — and thus SIGTERM shutdown —
+      // forever. On timeout, log and abandon it (the call keeps running with a
+      // settle handler attached inside withTimeout, so it never surfaces as an
+      // unhandled rejection) so every OTHER entry still reaches `stopped`. The
+      // `Promise.resolve().then(...)` wrap also routes a SYNCHRONOUS throw from
+      // a foreign handle through the same timeout+catch.
+      await withTimeout(
+        Promise.resolve().then(() => handle.stop()),
+        this.stopHandleTimeoutMs,
+        `channel handle stop() timed out after ${this.stopHandleTimeoutMs}ms during teardown`,
+      ).catch((err: unknown) =>
+        this.log?.("channel handle stop() failed during teardown", err),
+      );
     }
   }
 
@@ -732,6 +796,9 @@ export class ChannelManager implements ChannelsControl {
    * Teardown is resilient to a throwing `handle.stop()`: `Promise.allSettled`
    * over the per-entry `stopEntry` calls guarantees one rejection can't abort
    * the rest, so every entry reaches `stopped` and `stop()` always resolves.
+   * It is equally resilient to a WEDGED `handle.stop()` that never settles: each
+   * is bounded by {@link ChannelManagerArgs.stopHandleTimeoutMs} inside
+   * {@link stopEntry}, so a single hung handle can't hang SIGTERM shutdown.
    */
   async stop(): Promise<void> {
     if (this.stopped) {

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -630,14 +630,23 @@ export class ChannelManager implements ChannelsControl {
     for (const [name, entry] of this.entries) {
       channels[name] = entry.status;
     }
+    // A stopped manager is `stopped` regardless of whether it was ever activated.
+    // stop() before activate() (e.g. SIGTERM during startup) leaves `entries`
+    // empty, and the empty-set fold below returns `online` — a torn-down manager
+    // must never read healthy. Short-circuit before that fold. (After a normal
+    // activate→stop, every entry is already `stopped` and the fold agrees, so
+    // this is also consistent with the populated case.)
+    if (this.stopped) {
+      return { overall: "stopped", channels };
+    }
     // Before activate() has run, `entries` is empty. Folding an empty set gives
     // `online` — correct for a manager that declares NO channels (nothing is
     // degraded), but a LIE for one that declares channels and simply has not
     // opened its socket yet: activation is lazy (deferred to the first
     // `ready()`), so a not-yet-activated manager must never read `online`.
     // Report `connecting` ("not started") for that case so `status()` is honest
-    // before any `ready()`. A stopped manager falls through to the fold below.
-    if (!this.activated && !this.stopped && this.channels.length > 0) {
+    // before any `ready()`.
+    if (!this.activated && this.channels.length > 0) {
       return { overall: "connecting", channels };
     }
     return { overall: this.computeOverall(Object.values(channels)), channels };


### PR DESCRIPTION
Combines the two OSS-473 follow-ups (originally #5972 + #5973, now folded here) into one PR for a single review/merge. Base is `main` (OSS-473/#5963 has merged). Reviewable **commit-by-commit** — the mechanical rename is isolated in commit 1; the behavior changes are commits 2–4.

## Commit 1 — `refactor(channels)`: scrub residual internal "bot" naming (closes OSS-485)

Mechanical, naming-only, **no behavior change** — the last internal "bot" vestiges left out of 473's atomic telemetry-surface commit.

- `bot` local variable → `channel` in `create-channel.ts` internals + the ~15 tests that exercise it.
- `BotNode` type → `ChannelNode` in `@copilotkit/channels-ui` and **every** importer (channels, slack/teams/discord/telegram/whatsapp/intelligence adapters, slack/teams examples — 256 refs).
- `botName` adapter-SPI option → `channelName` on `AdapterStartContext` + its `create-channel` caller + the one consumer (`IntelligenceAdapter.start` ctx), in one change so the SPI can't drift. (Phoenix wire contract was already `channelName` as of 473.)
- Stale `bot-ui`/`bot-slack` comment refs → `channels-ui`/`channels-slack`; `Symbol.for("copilotkit.bot-ui.*")` → `"copilotkit.channels-ui.*"`.
- **Kept** (out of scope): the platform `isBot?` author flag (unrelated semantic) and example `bot` instance vars / "demo bot" prose (user-facing).

## Commits 2–4 — `fix`: realtime-transport reliability & parity hardening (closes OSS-482)

The self-contained observability/robustness subset of the OSS-473 CR follow-ups (`packages/channels-intelligence` transport + `packages/runtime` manager). Each hardening ships with a test that fails without the fix.

- **`emit()` fail-loud** (`intelligence-adapter.ts`) — returned a synthetic `MessageRef` on `{ ok: false }`, acking a failed post/update/delete as success (silent egress drop). Now throws → the delivery is nacked/retried.
- **Realtime delivery dispatch** (`realtime-gateway-transport.ts`) — the `void handleDeliveryAvailable(...)` fire-and-forget had no error boundary and no deadline. Replaced with a `.catch` + a bounded per-turn timeout that nacks + logs on failure/timeout (parity with the HTTP `runLoop`).
- **`ChannelManager.stop()` per-handle timeout** — a wedged `handle.stop()` hung teardown/SIGTERM forever. Each is now bounded by `stopHandleTimeoutMs` (default 5000); on timeout it's logged and abandoned so other entries still stop.
- **`ChannelManager.ready({ timeoutMs })`** — a set-wide timeout discarded an erroring channel's reason when a sibling hung. The deadline is now **per channel**, so the `AggregateError` carries both the real activation error **and** a named timeout for each hanging channel.
- **Forward `ChannelManager` `log` down** to the launcher/transport so transport-level drop diagnostics (e.g. a version-skew missing-`leaseToken` outage) aren't silent in the managed path.
- **`examples/slack/.env.example`** — OpenAI-only `AGENT_MODEL` guidance; removed never-read `ANTHROPIC_API_KEY`/`GOOGLE_API_KEY`; blanked the presence-gated `LINEAR_API_KEY`/`NOTION_*` placeholders (a non-blank value wires a broken MCP); documented `NOTION_MCP_PORT`; added WhatsApp to the adapter list.

### Already landed in OSS-473 (not re-done here)
The reconnect **"gave-up → error" escalation** is fully implemented on `main`: `realtime-gateway.ts` bounds the reconnect window (`reconnectGiveUpMs`, default 60s) and emits a terminal `gave_up`; the launcher exposes `onStateChange`; `ChannelManager.registerConnectionObserver` maps `gave_up → error` (covered by `realtime-gateway.test.ts` + `channel-manager-reconnect.test.ts`).

### Explicitly EXCLUDED — owned by OSS-474 / OSS-476
Left untouched (overlap in-flight work): no cross-turn history on the realtime path (per-turn `conversationKey`) → OSS-474/476; empty-turn `ack()` redelivery livelock → OSS-474/475/476; non-text parity (command/interaction/reaction) → OSS-476; `thread.delete()` render frame → OSS-476 (PR #554); durable StateStore on the managed realtime path → OSS-474/476.

## Testing
- **DoD grep** — `grep -rn "\bbot\b\|botName\|BotNode" packages/channels packages/channels-ui` (`.ts`/`.tsx`, excl. `dist/`) → **0**; `BotNode` gone repo-wide.
- **check-types** green across all 8 channels packages + `@copilotkit/runtime`.
- **tests** green: channels 155, channels-ui 23, slack 277, teams 88, discord 193, telegram 149, whatsapp 73, channels-intelligence 144, runtime `channel-manager` 40; slack-example 63, teams-example 2. Full CI matrix (incl. `unit` 20.x/22.x/24.x) green on this branch.
- Each 482 hardening has a test that fails pre-fix (no silent ack; dispatch nacks on throw/timeout; `stop()` resolves + logs on a wedged handle; `ready()` aggregate preserves the real reason; `defaultActivateChannel` forwards `log`).

Closes OSS-485. Closes OSS-482.
