### PR TITLE
fix(channels): SDK realtime-transport reliability & parity hardening (closes OSS-482)

### DIFF
--- a/examples/slack/.env.example
+++ b/examples/slack/.env.example
@@ -1,5 +1,6 @@
-# Set SLACK_*, DISCORD_*, and/or TELEGRAM_BOT_TOKEN — the bot starts an adapter
-# for each platform whose secrets are present (any one, or several at once).
+# Set SLACK_*, DISCORD_*, TELEGRAM_BOT_TOKEN, and/or WHATSAPP_* — the bot starts
+# an adapter for each platform whose secrets are present (any one, or several at
+# once).
 
 # ── Slack credentials (from api.slack.com/apps → your app) ──────────────
 # Set both to run on Slack; leave blank to skip Slack.
@@ -32,12 +33,12 @@ AGENT_URL=http://localhost:8200/api/copilotkit/agent/triage/run
 # Optional auth header forwarded to the agent (for a deployed runtime).
 # AGENT_AUTH_HEADER=Bearer ...
 
-# Model for the BuiltInAgent. provider/model — the runtime resolves the
-# provider and reads the matching API key below. Defaults to openai/gpt-5.5.
-# AGENT_MODEL=anthropic/claude-sonnet-4.5
+# Model for the agent. This runtime is OpenAI-only (its web search is an OpenAI
+# hosted provider tool), so AGENT_MODEL must be an OpenAI model id — either bare
+# ("gpt-5.5-mini") or "openai/<id>" (the "openai/" prefix is stripped). Defaults
+# to openai/gpt-5.5. OPENAI_API_KEY is required.
+# AGENT_MODEL=openai/gpt-5.5-mini
 OPENAI_API_KEY=sk-...
-# ANTHROPIC_API_KEY=sk-ant-...
-# GOOGLE_API_KEY=...
 
 # ── Intelligence (managed Channel) mode — app/managed.ts (`pnpm channel`) ─
 # The managed variant runs the SAME bot over Intelligence instead of a native
@@ -57,8 +58,9 @@ OPENAI_API_KEY=sk-...
 # ── Linear MCP ──────────────────────────────────────────────────────────
 # The hosted Linear MCP accepts a raw API key as a bearer token (no OAuth
 # dance). Create one at linear.app → Settings → API → Personal API keys.
-# Leave LINEAR_API_KEY blank to run without Linear.
-LINEAR_API_KEY=lin_api_...
+# Leave LINEAR_API_KEY blank to run without Linear — a non-blank value turns the
+# Linear MCP ON, so keep it empty unless you have a real key.
+LINEAR_API_KEY=
 # Override only if you front the MCP yourself; default is the hosted server.
 # LINEAR_MCP_URL=https://mcp.linear.app/mcp
 # Default Linear team the bot files/queries against.
@@ -72,8 +74,13 @@ LINEAR_TEAM_KEY=CPK
 # transport; the agent sends it. Pick any strong string and use it in both
 # `pnpm notion-mcp` and here. Leave NOTION_MCP_AUTH_TOKEN blank to run
 # without Notion.
-NOTION_TOKEN=ntn_...
-NOTION_MCP_AUTH_TOKEN=choose-a-strong-shared-secret
+# Both are blank by default — a non-blank NOTION_MCP_AUTH_TOKEN turns the Notion
+# MCP ON. NOTION_TOKEN is only needed when you actually run `pnpm notion-mcp`.
+NOTION_TOKEN=
+NOTION_MCP_AUTH_TOKEN=
+# Port the `pnpm notion-mcp` sidecar listens on (default 3001). If you change
+# it, update the port in NOTION_MCP_URL below to match.
+# NOTION_MCP_PORT=3001
 # Override only if the sidecar runs elsewhere; default is the local sidecar.
 # NOTION_MCP_URL=http://127.0.0.1:3001/mcp
 

--- a/packages/channels-intelligence/src/intelligence-adapter.test.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./in-memory-transports.js";
 import { IntelligenceStateStore } from "./intelligence-state-store.js";
 import type { FetchLike } from "./http-transports.js";
+import type { EgressSink } from "./transports.js";
 import type {
   ChannelIngressEnvelope,
   ChannelIngressBase,
@@ -247,6 +248,38 @@ describe("intelligenceAdapter — deterministic egress ids", () => {
     egress.ops.length = 0;
     await source.deliver(envelope({ turnId: "t1", deliveryId: "d2" }));
     expect(egress.ops.map((o) => o.operationId)).toEqual(["t1:0", "t1:1"]);
+  });
+});
+
+describe("intelligenceAdapter — egress fail-loud", () => {
+  it("throws (does not silently ack) when egress reports { ok: false }", async () => {
+    const source = new InMemoryDeliverySource();
+    // Egress that always rejects the op — the HTTP-fallback failure the adapter
+    // used to swallow by minting a synthetic MessageRef and acking as success.
+    const failingEgress: EgressSink = {
+      emit: async () => ({ ok: false, code: "provider_rejected" }),
+    };
+    const channel = createChannel({
+      adapters: [intelligenceAdapter({ source, egress: failingEgress })],
+      agent: () => new FakeAgent(),
+    });
+    let postError: unknown;
+    channel.onMessage(async ({ thread }) => {
+      try {
+        await thread.post(Section({ children: "reply" }));
+      } catch (err) {
+        postError = err;
+      }
+    });
+    await channel.start();
+    await source.deliver(envelope());
+
+    // Before the fix, thread.post resolved with a synthetic ref and postError
+    // stayed undefined (the drop was acked as success). Now it throws so the
+    // failure propagates up the render path and the delivery is nacked.
+    expect(postError).toBeInstanceOf(Error);
+    expect((postError as Error).message).toMatch(/egress post failed/i);
+    expect((postError as Error).message).toContain("provider_rejected");
   });
 });
 

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -485,10 +485,20 @@ export class IntelligenceAdapter implements PlatformAdapter {
   ): Promise<MessageRef> {
     const operation = this.mintOp(target, op);
     const res = await this.requireEgress().emit(operation);
+    // Fail loud on egress failure. Returning a synthetic MessageRef here would
+    // ack a dropped post/update/delete as success — silent data loss on the
+    // HTTP-fallback egress path. Throwing instead propagates the failure up the
+    // render/run path so the delivery is nacked (and retried) rather than
+    // silently completed.
+    if (!res.ok) {
+      throw new Error(
+        `IntelligenceAdapter: egress ${op.kind} failed (code: ${res.code}) for operation ${operation.operationId}`,
+      );
+    }
     // The minted ref carries routing so a later update/delete can re-address
     // the same operation; the Outbox maps operationId -> real platform message.
     return {
-      id: res.ok ? res.ref : operation.operationId,
+      id: res.ref,
       __route: target.route,
       __turnId: target.turnId,
       __deliveryId: target.deliveryId,

--- a/packages/channels-intelligence/src/realtime-gateway-transport.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-transport.ts
@@ -88,6 +88,43 @@ export interface RealtimeGatewayTransportOptions {
    * wire this to surface them. Absent → drops stay silent (fail-closed).
    */
   log?: (message: string, meta?: unknown) => void;
+  /**
+   * Per-turn deadline (ms) for the `onDelivery` handler. A turn that throws or
+   * hangs past this is nacked (released for redelivery) and logged, so a wedged
+   * handler can't silently pin a delivery forever. Mirrors the HTTP transport's
+   * `turnTimeoutMs`. Default {@link DEFAULT_DELIVERY_TIMEOUT_MS}.
+   */
+  deliveryTimeoutMs?: number;
+}
+
+/** Default per-turn deadline before a hung realtime turn is nacked and skipped. */
+const DEFAULT_DELIVERY_TIMEOUT_MS = 120_000;
+
+/**
+ * Reject after `ms` if `p` hasn't settled, so a hung turn can't wedge a
+ * delivery. The underlying promise keeps running in the background (a rejection
+ * handler is attached, so it never surfaces as unhandled); the transport nacks
+ * and moves on. Mirrors the HTTP transport's per-turn timeout.
+ */
+function withDeliveryTimeout<T>(
+  p: Promise<T>,
+  ms: number,
+  message: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms);
+    (timer as unknown as { unref?: () => void }).unref?.();
+    p.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
 }
 
 const RENDER_EVENT = "channel.render_event.v1";
@@ -121,6 +158,7 @@ export class RealtimeGatewayTransport
   private readonly session: RealtimeGatewaySession;
   private readonly now: () => string;
   private readonly log?: (message: string, meta?: unknown) => void;
+  private readonly deliveryTimeoutMs: number;
   private readonly deliveries = new Map<string, DeliveryState>();
   private onDelivery?: (env: ChannelIngressEnvelope) => Promise<void>;
 
@@ -131,6 +169,8 @@ export class RealtimeGatewayTransport
     this.session = config.session;
     this.now = config.now ?? (() => new Date().toISOString());
     this.log = config.log;
+    this.deliveryTimeoutMs =
+      config.deliveryTimeoutMs ?? DEFAULT_DELIVERY_TIMEOUT_MS;
   }
 
   async start(
@@ -138,7 +178,17 @@ export class RealtimeGatewayTransport
   ): Promise<void> {
     this.onDelivery = onDelivery;
     this.session.on(DELIVERY_AVAILABLE, (payload) => {
-      void this.handleDeliveryAvailable(payload);
+      // Error-boundary the dispatch: without a `.catch` an onDelivery rejection
+      // (or a parse/setup throw before the delivery is registered) becomes an
+      // unhandled promise rejection and the delivery is silently dropped. The
+      // per-turn failure/timeout path inside handleDeliveryAvailable nacks;
+      // this outer catch is the safety net for anything it can't (parse/setup
+      // errors that happen before a delivery id exists to nack).
+      this.handleDeliveryAvailable(payload).catch((err: unknown) => {
+        this.log?.("realtime gateway delivery dispatch failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
     });
   }
 
@@ -152,7 +202,31 @@ export class RealtimeGatewayTransport
       scope,
       accepted: new Map(),
     });
-    await this.onDelivery?.(env);
+    // Bound the turn (parity with the HTTP runLoop): a handler that throws or
+    // hangs past deliveryTimeoutMs must not wedge the delivery or leave the
+    // render stream half-open. On failure, nack so app-api releases the lease
+    // and redelivers rather than the turn silently pinning the delivery.
+    try {
+      await withDeliveryTimeout(
+        Promise.resolve(this.onDelivery?.(env)),
+        this.deliveryTimeoutMs,
+        `realtime gateway turn ${env.turnId} exceeded ${this.deliveryTimeoutMs}ms`,
+      );
+    } catch (err) {
+      this.log?.("realtime gateway turn failed/timed out; nacking", {
+        deliveryId: env.deliveryId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      await this.nack(
+        env.deliveryId,
+        err instanceof Error ? err.message : String(err),
+      ).catch((nackErr: unknown) =>
+        this.log?.("realtime gateway nack after turn failure failed", {
+          deliveryId: env.deliveryId,
+          error: nackErr instanceof Error ? nackErr.message : String(nackErr),
+        }),
+      );
+    }
   }
 
   /**

--- a/packages/channels-intelligence/src/render-events.test.ts
+++ b/packages/channels-intelligence/src/render-events.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import type { ReplyTarget } from "@copilotkit/channels";
 import { intelligenceAdapter } from "./intelligence-adapter.js";
 import {
@@ -300,6 +300,83 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
       (fail?.payload as { payload?: { leaseToken?: string } }).payload
         ?.leaseToken,
     ).toBe("lease_l1");
+  });
+
+  it("nacks and logs when the onDelivery handler throws (dispatch error-boundary)", async () => {
+    const fake = makeFakeSession();
+    const logs: string[] = [];
+    const t = new RealtimeGatewayTransport({
+      ...cfg(fake.session),
+      log: (m) => logs.push(m),
+    });
+    // A handler that rejects. Before the fix this dispatched via `void`, so the
+    // rejection became an unhandled promise rejection and the delivery was
+    // silently dropped (never nacked, so app-api could not release it promptly).
+    await t.start(async () => {
+      throw new Error("handler boom");
+    });
+    fake.handlers.get("channel.delivery.available.v1")?.({
+      payload: {
+        delivery: {
+          id: "dlv_d1",
+          leaseToken: "lease_l1",
+          adapter: "slack",
+          channel: { id: "channel_1", name: "support" },
+          turn: {
+            id: "turn_t1",
+            eventId: "evt_1",
+            input: { kind: "text", text: "hi" },
+          },
+        },
+      },
+    });
+
+    await vi.waitFor(() =>
+      expect(fake.pushes.map((p) => p.event)).toContain(
+        "channel.delivery.fail.v1",
+      ),
+    );
+    expect(logs.some((m) => m.includes("turn failed/timed out"))).toBe(true);
+    expect(fake.pushes.map((p) => p.event)).not.toContain(
+      "channel.delivery.ack.v1",
+    );
+  });
+
+  it("nacks and logs when the onDelivery handler exceeds deliveryTimeoutMs (per-turn timeout)", async () => {
+    const fake = makeFakeSession();
+    const logs: string[] = [];
+    const t = new RealtimeGatewayTransport({
+      ...cfg(fake.session),
+      log: (m) => logs.push(m),
+      // Tiny per-turn deadline so a hung handler is bounded quickly in the test.
+      deliveryTimeoutMs: 10,
+    });
+    // A handler that never settles — the wedged-turn case the timeout guards.
+    await t.start(() => new Promise<void>(() => {}));
+    fake.handlers.get("channel.delivery.available.v1")?.({
+      payload: {
+        delivery: {
+          id: "dlv_d1",
+          leaseToken: "lease_l1",
+          adapter: "slack",
+          channel: { id: "channel_1", name: "support" },
+          turn: {
+            id: "turn_t1",
+            eventId: "evt_1",
+            input: { kind: "text", text: "hi" },
+          },
+        },
+      },
+    });
+
+    await vi.waitFor(
+      () =>
+        expect(fake.pushes.map((p) => p.event)).toContain(
+          "channel.delivery.fail.v1",
+        ),
+      { timeout: 1000 },
+    );
+    expect(logs.some((m) => m.includes("turn failed/timed out"))).toBe(true);
   });
 
   it("drops a delivery with no leaseToken (never fires onDelivery) and logs it", async () => {

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
@@ -196,6 +196,38 @@ describe("ChannelManager", () => {
     expect(mgr.status().overall).toBe("connecting");
   });
 
+  it("ready() surfaces the erroring channel's real reason even when a sibling hangs", async () => {
+    const boom = new Error("activation exploded");
+    const engine: ActivateChannelEngine = (_config, channel) =>
+      channel.name === "support"
+        ? Promise.reject(boom) // errors immediately
+        : new Promise<ChannelsHandle>(() => {}); // sibling hangs forever
+    const mgr = new ChannelManager({
+      intelligence: fakeIntelligence(),
+      channels: [
+        createChannel({ name: "support" }),
+        createChannel({ name: "sales" }),
+      ],
+      activateChannel: engine,
+    });
+    mgr.activate();
+
+    const err = await mgr.ready({ timeoutMs: 25 }).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+    // A set-wide timeout would have rejected with only a generic timeout and
+    // DISCARDED `boom`. The per-channel timeout aggregate carries BOTH.
+    expect(err).toBeInstanceOf(AggregateError);
+    const agg = err as AggregateError;
+    expect(agg.errors).toContain(boom);
+    expect(
+      agg.errors.some(
+        (e) => e instanceof Error && /"sales" did not settle/.test(e.message),
+      ),
+    ).toBe(true);
+  });
+
   it("activate() throws on duplicate channel names before any engine call (no leak)", () => {
     const engine: ActivateChannelEngine = vi.fn(async () => fakeHandle());
     const mgr = new ChannelManager({
@@ -242,6 +274,44 @@ describe("ChannelManager", () => {
     resolveActivation(handle);
     await vi.waitFor(() => expect(handle.stop).toHaveBeenCalledTimes(1));
     expect(mgr.status().channels.support).toBe("stopped");
+  });
+
+  it("stop() bounds a wedged handle.stop() so teardown can't hang (per-handle timeout)", async () => {
+    const logs: unknown[][] = [];
+    // A handle whose stop() never settles — the SIGTERM-hang risk.
+    const wedged: ChannelsHandle & { stop: ReturnType<typeof vi.fn> } = {
+      metadata: {},
+      stop: vi.fn(() => new Promise<void>(() => {})),
+    };
+    const mgr = new ChannelManager({
+      intelligence: fakeIntelligence(),
+      channels: [createChannel({ name: "support" })],
+      activateChannel: async () => wedged,
+      stopHandleTimeoutMs: 20,
+      log: (...args) => logs.push(args),
+    });
+    await mgr.ready();
+
+    let hangTimer: ReturnType<typeof setTimeout>;
+    await expect(
+      Promise.race([
+        mgr.stop(),
+        new Promise((_resolve, reject) => {
+          hangTimer = setTimeout(() => reject(new Error("stop() hung")), 1000);
+        }),
+      ]),
+    ).resolves.toBeUndefined();
+    clearTimeout(hangTimer!);
+
+    expect(mgr.status().channels.support).toBe("stopped");
+    expect(wedged.stop).toHaveBeenCalledTimes(1);
+    const timeoutLog = logs.find(
+      ([msg]) =>
+        typeof msg === "string" &&
+        msg.includes("channel handle stop() failed during teardown"),
+    );
+    expect(timeoutLog).toBeDefined();
+    expect((timeoutLog![1] as Error).message).toMatch(/timed out after 20ms/);
   });
 
   it("stop() completes and marks every channel stopped even when a handle.stop() rejects", async () => {
@@ -676,6 +746,23 @@ describe("defaultActivateChannel", () => {
     // The scope carries ONLY projectId + channelName — never org/channelId.
     expect(opts.scope).not.toHaveProperty("organizationId");
     expect(opts.scope).not.toHaveProperty("channelId");
+  });
+
+  it("forwards the log sink to the launcher opts so transport-level drops surface", async () => {
+    const handle: ChannelsHandle = { metadata: {}, stop: async () => {} };
+    const start = vi.fn<
+      ChannelsIntelligenceModule["startChannelsOverRealtimeGateway"]
+    >(async () => handle);
+    const channel = createChannel({ name: "support" });
+    const importer = async (): Promise<ChannelsIntelligenceModule> => ({
+      startChannelsOverRealtimeGateway: start,
+    });
+    const log = vi.fn();
+
+    await defaultActivateChannel(config, channel, importer, log);
+
+    const [, opts] = start.mock.calls[0]!;
+    expect(opts.log).toBe(log);
   });
 
   it("throws a friendly install hint when the module is not found", async () => {

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -131,8 +131,13 @@ export interface ChannelManagerArgs {
   activateChannel?: ActivateChannelEngine;
   /** Mint a runtime instance id per Channel. Defaults to `rti_{uuid-no-dashes}`. */
   mintRuntimeInstanceId?: () => string;
-  /** Diagnostic sink. */
+  /** Diagnostic sink. Forwarded to the launcher/transport when the default
+   * activation engine is used, so transport-level drops surface in the managed
+   * path (not just activation-level events). */
   log?: (msg: string, meta?: unknown) => void;
+  /** Per-handle deadline (ms) for `handle.stop()` during {@link ChannelManager.stop}
+   * so a wedged stop can't hang SIGTERM shutdown. Default 5000. */
+  stopHandleTimeoutMs?: number;
 }
 
 /** Per-Channel mutable activation entry tracked by the manager. */
@@ -169,6 +174,10 @@ export interface ChannelsIntelligenceModule {
       scope: { projectId: number; channelName: string };
       runtimeInstanceId: string;
       adapter?: string;
+      /** Diagnostic sink forwarded to the launcher/transport so transport-level
+       * drop diagnostics (e.g. a version-skew missing-leaseToken outage) are not
+       * silent in the managed path. */
+      log?: (msg: string, meta?: unknown) => void;
     },
   ) => Promise<ChannelsHandle>;
 }
@@ -191,6 +200,8 @@ export interface ChannelsIntelligenceModule {
  * @param channel - The Channel to activate.
  * @param importChannelsIntelligence - Test seam; loads the channels-intelligence
  *   module. Defaults to a dynamic import of the real package.
+ * @param log - Optional diagnostic sink forwarded to the launcher/transport so
+ *   transport-level drop diagnostics are not silent in the managed path.
  * @returns The launcher's {@link ChannelsHandle}.
  */
 export async function defaultActivateChannel(
@@ -200,6 +211,7 @@ export async function defaultActivateChannel(
     import(
       CHANNELS_INTELLIGENCE_SPECIFIER
     ) as Promise<ChannelsIntelligenceModule>,
+  log?: (msg: string, meta?: unknown) => void,
 ): Promise<ChannelsHandle> {
   let mod: ChannelsIntelligenceModule;
   try {
@@ -219,6 +231,10 @@ export async function defaultActivateChannel(
     scope: { projectId: config.projectId, channelName: config.channelName },
     runtimeInstanceId: config.runtimeInstanceId,
     adapter: config.adapter,
+    // Forward the manager's diagnostic sink down to the launcher/transport so a
+    // transport-level drop (e.g. a version-skew missing-leaseToken outage) is
+    // observable in the managed path, not just activation-level events.
+    ...(log ? { log } : {}),
   });
 }
 
@@ -246,22 +262,30 @@ export function isModuleNotFound(err: unknown): boolean {
   return code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND";
 }
 
+/** Default deadline (ms) for a single `handle.stop()` during teardown. */
+const DEFAULT_STOP_HANDLE_TIMEOUT_MS = 5_000;
+
 /**
- * Reject after `timeoutMs` if `inner` has not settled, otherwise pass `inner`
- * through. When `timeoutMs` is undefined, `inner` is returned unchanged.
+ * Reject with `timeoutMessage` after `timeoutMs` if `inner` has not settled,
+ * otherwise pass `inner` through. When `timeoutMs` is undefined, `inner` is
+ * returned unchanged. The timer is `unref`'d so a pending deadline never keeps
+ * the process alive, and `inner` always has a settle handler attached, so a
+ * timed-out promise that later settles never surfaces as unhandled.
  */
-function withTimeout<T>(inner: Promise<T>, timeoutMs?: number): Promise<T> {
+function withTimeout<T>(
+  inner: Promise<T>,
+  timeoutMs: number | undefined,
+  timeoutMessage: string,
+): Promise<T> {
   if (timeoutMs === undefined) {
     return inner;
   }
   return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      reject(
-        new Error(
-          `ChannelManager.ready timed out after ${timeoutMs}ms waiting for all channels to settle`,
-        ),
-      );
-    }, timeoutMs);
+    const timer = setTimeout(
+      () => reject(new Error(timeoutMessage)),
+      timeoutMs,
+    );
+    (timer as unknown as { unref?: () => void }).unref?.();
     inner.then(
       (value) => {
         clearTimeout(timer);
@@ -311,6 +335,7 @@ export class ChannelManager implements ChannelsControl {
   private readonly activateChannel: ActivateChannelEngine;
   private readonly mintRuntimeInstanceId: () => string;
   private readonly log?: (msg: string, meta?: unknown) => void;
+  private readonly stopHandleTimeoutMs: number;
 
   private readonly entries = new Map<string, ChannelEntry>();
   private activated = false;
@@ -320,11 +345,20 @@ export class ChannelManager implements ChannelsControl {
   constructor(args: ChannelManagerArgs) {
     this.intelligence = args.intelligence;
     this.channels = args.channels;
-    this.activateChannel = args.activateChannel ?? defaultActivateChannel;
+    this.log = args.log;
+    // When using the default engine, forward the manager's log DOWN to the
+    // launcher/transport (via defaultActivateChannel's log param) so a
+    // transport-level drop is observable in the managed path. `this.log` is read
+    // lazily at activation time, so this closure always sees the assigned sink.
+    this.activateChannel =
+      args.activateChannel ??
+      ((config, channel) =>
+        defaultActivateChannel(config, channel, undefined, this.log));
     this.mintRuntimeInstanceId =
       args.mintRuntimeInstanceId ??
       (() => `rti_${randomUUID().replace(/-/g, "")}`);
-    this.log = args.log;
+    this.stopHandleTimeoutMs =
+      args.stopHandleTimeoutMs ?? DEFAULT_STOP_HANDLE_TIMEOUT_MS;
   }
 
   /**
@@ -518,9 +552,12 @@ export class ChannelManager implements ChannelsControl {
    * same {@link ChannelConfigError} as the synchronous throw from
    * {@link activate} for an up-front misconfiguration (duplicate/missing Channel
    * names). Once activation has been kicked off, all OTHER failures are surfaced
-   * here instead: this rejects with an `AggregateError` of the reasons if any
-   * Channel settled to `error`, or with a timeout error if `timeoutMs` elapses
-   * before all Channels settle.
+   * here instead: this rejects with an `AggregateError` if any Channel settled
+   * to `error` OR — when `timeoutMs` is given — did not settle in time. The
+   * `timeoutMs` deadline is applied PER CHANNEL, so the aggregate carries each
+   * failed Channel's real reason AND a named timeout for each Channel still
+   * hanging: a genuine activation error is never masked by a sibling that hangs
+   * (a pre-fix set-wide timeout discarded the real reason in that case).
    *
    * A STOPPED manager short-circuits and resolves: a Channel that settled to
    * `error` BEFORE {@link stop} already rejected its `settled` promise, so
@@ -540,16 +577,29 @@ export class ChannelManager implements ChannelsControl {
       return;
     }
     this.activate();
-    const entries = [...this.entries.values()];
-    const all = Promise.allSettled(entries.map((e) => e.settled));
-    const results = await withTimeout(all, opts?.timeoutMs);
+    const entries = [...this.entries.entries()];
+    // Apply `timeoutMs` PER CHANNEL rather than to the whole set. A single
+    // set-wide timeout wrapping `allSettled` would, when one channel settles to
+    // `error` while a sibling hangs, reject with only a generic timeout and
+    // DISCARD the erroring channel's real reason. Timing out each channel's
+    // `settled` independently lets `allSettled` collect BOTH a hung channel's
+    // named timeout AND a failed channel's real error into one AggregateError.
+    const results = await Promise.allSettled(
+      entries.map(([name, e]) =>
+        withTimeout(
+          e.settled,
+          opts?.timeoutMs,
+          `channel "${name}" did not settle within ${opts?.timeoutMs}ms`,
+        ),
+      ),
+    );
     const errors = results
       .filter((r): r is PromiseRejectedResult => r.status === "rejected")
       .map((r) => r.reason);
     if (errors.length > 0) {
       throw new AggregateError(
         errors,
-        `ChannelManager.ready: ${errors.length} channel(s) failed to activate`,
+        `ChannelManager.ready: ${errors.length} channel(s) failed to activate or settle in time`,
       );
     }
   }
@@ -699,6 +749,11 @@ export class ChannelManager implements ChannelsControl {
    * The developer's `channel.start()`/stop path is unaffected by manager
    * teardown.
    *
+   * A WEDGED `handle.stop()` (one that never settles) is bounded by
+   * {@link ChannelManagerArgs.stopHandleTimeoutMs}: after the deadline the call
+   * is logged and abandoned so it can't hang `stop()` — and thus SIGTERM
+   * shutdown — forever.
+   *
    * @param entry - The Channel entry to stop.
    */
   private async stopEntry(entry: ChannelEntry): Promise<void> {
@@ -709,11 +764,20 @@ export class ChannelManager implements ChannelsControl {
     if (entry.handle && !entry.handleStopped) {
       entry.handleStopped = true;
       const handle = entry.handle;
-      await Promise.resolve()
-        .then(() => handle.stop())
-        .catch((err: unknown) =>
-          this.log?.("channel handle stop() failed during teardown", err),
-        );
+      // Bound handle.stop(): a wedged stop() (e.g. a socket.disconnect that
+      // never returns) must not hang teardown — and thus SIGTERM shutdown —
+      // forever. On timeout, log and abandon it (the call keeps running with a
+      // settle handler attached inside withTimeout, so it never surfaces as an
+      // unhandled rejection) so every OTHER entry still reaches `stopped`. The
+      // `Promise.resolve().then(...)` wrap also routes a SYNCHRONOUS throw from
+      // a foreign handle through the same timeout+catch.
+      await withTimeout(
+        Promise.resolve().then(() => handle.stop()),
+        this.stopHandleTimeoutMs,
+        `channel handle stop() timed out after ${this.stopHandleTimeoutMs}ms during teardown`,
+      ).catch((err: unknown) =>
+        this.log?.("channel handle stop() failed during teardown", err),
+      );
     }
   }
 
@@ -732,6 +796,9 @@ export class ChannelManager implements ChannelsControl {
    * Teardown is resilient to a throwing `handle.stop()`: `Promise.allSettled`
    * over the per-entry `stopEntry` calls guarantees one rejection can't abort
    * the rest, so every entry reaches `stopped` and `stop()` always resolves.
+   * It is equally resilient to a WEDGED `handle.stop()` that never settles: each
+   * is bounded by {@link ChannelManagerArgs.stopHandleTimeoutMs} inside
+   * {@link stopEntry}, so a single hung handle can't hang SIGTERM shutdown.
    */
   async stop(): Promise<void> {
     if (this.stopped) {


### PR DESCRIPTION
## What

The self-contained observability/robustness subset of the OSS-473 CR follow-ups for the managed **realtime transport** (`packages/channels-intelligence`) and **manager** (`packages/runtime`). Each hardening ships with a test proving the new behavior.

### Included (this PR)
- **`emit()` fail-loud** (`intelligence-adapter.ts`) — returned a synthetic `MessageRef` on `{ ok: false }`, acking a failed post/update/delete as success (silent egress drop on the HTTP-fallback path). Now throws with the failure code → the delivery is nacked/retried.
- **Realtime delivery dispatch** (`realtime-gateway-transport.ts`) — `session.on(delivery.available)` fired `void handleDeliveryAvailable(...)` with no error boundary and no deadline. Replaced the `void` with a `.catch` and wrapped the turn in a bounded per-turn timeout that nacks + logs on failure/timeout (parity with the HTTP `runLoop`'s `turnTimeoutMs`).
- **`ChannelManager.stop()` per-handle timeout** (`channel-manager.ts`) — a wedged `handle.stop()` hung teardown (and SIGTERM) forever. Each `handle.stop()` is now bounded by `stopHandleTimeoutMs` (default 5000); on timeout it's logged and abandoned so every other entry still reaches `stopped`.
- **`ChannelManager.ready({ timeoutMs })` surfaces the real reason on hang** — a single set-wide timeout discarded an erroring channel's reason when a sibling hung. The deadline is now applied **per channel**, so the `AggregateError` carries both each failed channel's real reason **and** a named timeout for each still-hanging channel.
- **Forward `ChannelManager` `log` down to the launcher/transport** — the manager's `log` reached activation-level events only; the default engine never passed it into `startChannelsOverRealtimeGateway`, so transport-level drop diagnostics (e.g. a version-skew missing-`leaseToken` outage) were silent in the managed path. Now forwarded.
- **`examples/slack/.env.example` accuracy** — OpenAI-only `AGENT_MODEL` guidance; removed never-read `ANTHROPIC_API_KEY`/`GOOGLE_API_KEY`; blanked the presence-gated `LINEAR_API_KEY`/`NOTION_*` placeholders (a non-blank value wires a broken MCP); documented `NOTION_MCP_PORT`; added WhatsApp to the adapter list.

### Already landed in OSS-473 (not re-done here)
- **Reconnect "gave-up → error" escalation** is fully implemented end-to-end on the base branch: `realtime-gateway.ts` bounds the reconnect window (`reconnectGiveUpMs`, default 60s) and emits a terminal `gave_up`; the launcher exposes `onStateChange`; `ChannelManager.registerConnectionObserver` maps `gave_up → error`. Covered by `realtime-gateway.test.ts` + `channel-manager-reconnect.test.ts`.

### Explicitly EXCLUDED — owned by OSS-474 / OSS-476
These overlap in-flight work and are intentionally left untouched:
- No cross-turn history on the realtime path (per-turn `conversationKey`) → **OSS-474/476**.
- Empty-turn `ack()` → redelivery livelock (needs a terminal signal) → **OSS-474/475/476**.
- Non-text parity (command/interaction/reaction coerced to empty text) → **OSS-476**.
- `thread.delete()` render frame → folded into **OSS-476** (PR #554).
- No durable StateStore on the managed realtime path → **OSS-474/476**.

## Testing
Each hardening has a test that fails without the fix:
- `channels-intelligence` — **138 tests pass** (check-types green). New: egress `{ ok: false }` makes `thread.post` throw (no silent ack); an `onDelivery` throw and an `onDelivery` that exceeds `deliveryTimeoutMs` both nack (`channel.delivery.fail.v1`) and log.
- `runtime` — `channel-manager` **38 tests pass**; `nx build @copilotkit/runtime` (tsup, type-checks) green. New: `stop()` resolves + logs a timeout when `handle.stop()` never settles; `ready()` aggregate carries both a real activation error and the hung sibling's named timeout; `defaultActivateChannel` forwards its `log` sink to the launcher opts.

## Stacking
- **Base is `ben1/oss-485-scrub-residual-bot-symbols`** (which is itself based on OSS-473's `ben1/oss-473-runtime-handler-channels`). Review the 3 commits here, not the whole stack.
- **Rebase plan:** when OSS-473 (#5963) merges to `main`, the 485→482 stack rebases onto `main`; retarget 485's base to `main`, then this PR's base to `main` (or 485 if 485 lands first). Depends on 473's code, not its outcome.