### PR TITLE
docs(ag-ui): fix broken /copilotkit route in quickstart

### DIFF
--- a/showcase/shell-docs/src/content/ag-ui/quickstart/applications.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/quickstart/applications.mdx
@@ -32,4 +32,4 @@ Once the setup is done, start the server with
 npm run dev
 ```
 
-For the copilotkit example you can head to http://localhost:3000/copilotkit to see the app in action.
+Head to http://localhost:3000 to see your app in action.


### PR DESCRIPTION
## Problem

The AG-UI quickstart documentation at `showcase/shell-docs/src/content/ag-ui/quickstart/applications.mdx` directs users to visit `http://localhost:3000/copilotkit` after running the CLI. However, this route returns 404 because the page doesn't exist in generated apps.

## Solution

Updated the documentation to point to the correct root URL (`http://localhost:3000`) where the generated app is actually served. This aligns with the pattern used in other quickstart pages (`server.mdx` and `middleware.mdx`).

## Testing

- Verified that other AG-UI quickstart pages consistently reference `http://localhost:3000`
- Confirmed no other broken `/copilotkit` page route references exist (all other references are to `/api/copilotkit` endpoints, which are correct)

## Related

Fixes [FAC-123](https://linear.app/copilotkit/issue/FAC-123/ag-ui-quickstart-docs-link-to-copilotkit-returns-404)