### PR TITLE
feat(channels-intelligence): realtime transport parity — kinds, identity, history/files, delete

### DIFF
--- a/packages/channels-intelligence/src/claim-mapping.test.ts
+++ b/packages/channels-intelligence/src/claim-mapping.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import {
+  conversationKeyFromReplyTarget,
+  mapDeliveryToEnvelope,
+} from "./claim-mapping.js";
+import type { ClaimedDelivery } from "./claim-mapping.js";
+
+const baseDelivery = (
+  overrides: Partial<ClaimedDelivery["turn"]> = {},
+): ClaimedDelivery => ({
+  id: "dlv_1",
+  organizationId: "org_1",
+  projectId: 7,
+  channel: { id: "channel_1", name: "support" },
+  adapter: "slack",
+  leaseToken: "lease_1",
+  turn: {
+    id: "turn_1",
+    eventId: "evt_1",
+    replyTarget: {
+      adapter: "slack",
+      teamId: "T1",
+      channel: "C1",
+      threadTs: "9.9",
+    },
+    ...overrides,
+  },
+});
+
+describe("conversationKeyFromReplyTarget", () => {
+  it("keys Slack by team+channel+thread (thread-stable, not per-turn)", () => {
+    expect(
+      conversationKeyFromReplyTarget({
+        adapter: "slack",
+        teamId: "T1",
+        channel: "C1",
+        threadTs: "1700.1",
+      }),
+    ).toBe("slack:T1:C1:thread:1700.1");
+  });
+
+  it("keys a root-level Slack message under `root`", () => {
+    expect(
+      conversationKeyFromReplyTarget({
+        adapter: "slack",
+        teamId: "T1",
+        channel: "C1",
+      }),
+    ).toBe("slack:T1:C1:thread:root");
+  });
+
+  it("keys Teams by tenant+conversation (matching app-api thread_key)", () => {
+    expect(
+      conversationKeyFromReplyTarget({
+        adapter: "teams",
+        serviceUrl: "https://smba",
+        conversationId: "conv1",
+        tenantId: "tenantA",
+      }),
+    ).toBe("teams:tenantA:conv1");
+  });
+
+  it("fails loud on an unmodeled adapter rather than colliding conversations", () => {
+    expect(() =>
+      conversationKeyFromReplyTarget({
+        adapter: "discord",
+      } as unknown as Parameters<typeof conversationKeyFromReplyTarget>[0]),
+    ).toThrow(/unsupported reply-target adapter/);
+  });
+});
+
+describe("mapDeliveryToEnvelope — identity (OSS-476)", () => {
+  it("maps the provider actor to env.user (id + displayName)", () => {
+    const env = mapDeliveryToEnvelope(
+      baseDelivery({
+        actor: { externalUserId: "U123", displayName: "Ada" },
+        input: { kind: "text", text: "hi" },
+      }),
+    );
+    expect(env.user).toEqual({ id: "U123", displayName: "Ada" });
+  });
+
+  it("omits displayName when the actor has none", () => {
+    const env = mapDeliveryToEnvelope(
+      baseDelivery({ actor: { externalUserId: "U123" } }),
+    );
+    expect(env.user).toEqual({ id: "U123" });
+  });
+
+  it("omits user entirely when the claim carries no actor", () => {
+    const env = mapDeliveryToEnvelope(baseDelivery());
+    expect(env.user).toBeUndefined();
+  });
+
+  it("derives a thread-stable conversationKey from the reply target", () => {
+    const env = mapDeliveryToEnvelope(baseDelivery());
+    expect(env.conversationKey).toBe("slack:T1:C1:thread:9.9");
+  });
+});
+
+describe("mapDeliveryToEnvelope — kind discrimination (OSS-476)", () => {
+  it("preserves a command turn instead of coercing it to text", () => {
+    const env = mapDeliveryToEnvelope(
+      baseDelivery({
+        input: {
+          kind: "command",
+          command: "/deploy",
+          text: "prod",
+          triggerId: "tr1",
+        },
+      }),
+    );
+    expect(env.kind).toBe("command");
+    expect(env).toMatchObject({
+      command: "/deploy",
+      text: "prod",
+      triggerId: "tr1",
+    });
+  });
+
+  it("preserves a reaction turn", () => {
+    const env = mapDeliveryToEnvelope(
+      baseDelivery({
+        input: {
+          kind: "reaction",
+          rawEmoji: "eyes",
+          added: true,
+          messageId: "m1",
+        },
+      }),
+    );
+    expect(env.kind).toBe("reaction");
+    expect(env).toMatchObject({
+      rawEmoji: "eyes",
+      added: true,
+      messageId: "m1",
+    });
+  });
+
+  it("preserves an interaction turn", () => {
+    const env = mapDeliveryToEnvelope(
+      baseDelivery({
+        input: { kind: "interaction", actionId: "ck:approve", value: "yes" },
+      }),
+    );
+    expect(env.kind).toBe("interaction");
+    expect(env).toMatchObject({ actionId: "ck:approve", value: "yes" });
+  });
+
+  it("maps a text (or absent) input to a turn", () => {
+    expect(mapDeliveryToEnvelope(baseDelivery({ input: undefined })).kind).toBe(
+      "turn",
+    );
+    const env = mapDeliveryToEnvelope(
+      baseDelivery({ input: { kind: "text", text: "hello" } }),
+    );
+    expect(env.kind).toBe("turn");
+    expect(env).toMatchObject({ text: "hello" });
+  });
+});

--- a/packages/channels-intelligence/src/claim-mapping.ts
+++ b/packages/channels-intelligence/src/claim-mapping.ts
@@ -63,9 +63,14 @@ export interface ClaimedDelivery {
     /** Provider identity of the turn's author (OSS-476). */
     actor?: ClaimedDeliveryActor;
     // NB: there is intentionally no `thread_started` variant here — the claim
-    // path only carries turn/command/reaction/interaction. `thread_started`
-    // envelopes originate on the realtime gateway path, not from `claim`, so a
-    // claimed delivery never maps to `kind:"thread_started"`.
+    // path only carries turn/command/reaction/interaction. Neither wire mapper
+    // produces `kind:"thread_started"`: BOTH the HTTP and realtime transports
+    // build their envelope through this same `mapDeliveryToEnvelope`, so a real
+    // `thread_started` delivery over either transport would fall through to the
+    // empty-`turn` default below, not the `onThreadStarted` dispatch branch.
+    // Today `kind:"thread_started"` is only produced by an injected in-memory
+    // source (tests); wiring it over a real transport needs a dedicated mapper
+    // path (follow-up), not this claim shape.
     input?:
       | { kind: "text"; text?: string; files?: ChannelFileRef[] }
       | {

--- a/packages/channels-intelligence/src/claim-mapping.ts
+++ b/packages/channels-intelligence/src/claim-mapping.ts
@@ -1,0 +1,213 @@
+import type { MessageRef } from "@copilotkit/channels-ui";
+import type { ChannelFileRef, ChannelIngressEnvelope } from "./contracts.js";
+
+/**
+ * Shared claim → ingress-envelope mapping used by BOTH transports (the HTTP
+ * polling {@link ../http-transports} and the realtime gateway
+ * {@link ../realtime-gateway-transport}). Extracted so the two paths cannot
+ * drift — divergence here is exactly what OSS-476 fixes: the realtime path had
+ * a text-only mapping that coerced commands/reactions/interactions into empty
+ * turns, keyed conversations per-turn (breaking threaded follow-ups), and
+ * dropped the provider actor identity.
+ */
+
+/** Slack reply target Intelligence mints at ingress. */
+export interface SlackReplyTarget {
+  adapter: "slack";
+  teamId: string;
+  channel: string;
+  threadTs?: string;
+}
+
+/**
+ * Teams reply target Intelligence mints at ingress (Bot Connector coordinates).
+ * Distinct shape from Slack — no teamId/channel/threadTs — so conversation
+ * identity must be derived per-provider (see {@link conversationKeyFromReplyTarget}).
+ */
+export interface TeamsReplyTarget {
+  adapter: "teams";
+  serviceUrl: string;
+  conversationId: string;
+  tenantId: string;
+}
+
+/**
+ * The claim's reply target is provider-tagged (Intelligence app-api mints a
+ * discriminated union — one Channel runtime serves every channel its framework
+ * Bot has attached now that claims are provider-agnostic).
+ */
+export type ReplyTarget = SlackReplyTarget | TeamsReplyTarget;
+
+/**
+ * The provider user who authored the turn, carried on the claim (OSS-476). It
+ * is opaque runtime identity — NOT a control-plane user — and maps to the
+ * ingress envelope's {@link ChannelIngressBase.user}.
+ */
+export interface ClaimedDeliveryActor {
+  externalUserId: string;
+  displayName?: string;
+}
+
+/** Successful `claim` delivery envelope (the subset the bridge reads). */
+export interface ClaimedDelivery {
+  id: string;
+  organizationId: string;
+  projectId: number;
+  channel: { id: string; name: string };
+  adapter: string;
+  leaseToken: string;
+  turn: {
+    id: string;
+    eventId: string;
+    replyTarget: ReplyTarget;
+    /** Provider identity of the turn's author (OSS-476). */
+    actor?: ClaimedDeliveryActor;
+    // NB: there is intentionally no `thread_started` variant here — the claim
+    // path only carries turn/command/reaction/interaction. `thread_started`
+    // envelopes originate on the realtime gateway path, not from `claim`, so a
+    // claimed delivery never maps to `kind:"thread_started"`.
+    input?:
+      | { kind: "text"; text?: string; files?: ChannelFileRef[] }
+      | {
+          kind: "command";
+          command: string;
+          text?: string;
+          triggerId?: string;
+          rawOptions?: Record<string, unknown>;
+        }
+      | {
+          kind: "reaction";
+          rawEmoji: string;
+          added: boolean;
+          messageId: string;
+          threadId?: string;
+          /** SDK post-time ref the reacted message maps to (reverse-resolved by
+           * app-api), so a `<Message onReaction>` handler can be found. */
+          postedRef?: string;
+        }
+      | {
+          kind: "interaction";
+          /** Minted action id (ck:...) the clicked control carried. */
+          actionId: string;
+          /** The clicked control's value (block_actions value / selected options). */
+          value?: unknown;
+          /** The message the interaction occurred on (so a handler can update it). */
+          messageRef?: MessageRef;
+          /** Slack trigger id (for opening a modal off the interaction). */
+          triggerId?: string;
+        };
+  };
+}
+
+/**
+ * Stable per-conversation key, derived per provider — it keys the agent/session
+ * (`getOrCreate(conversationKey)`), so distinct conversations MUST get distinct
+ * keys or their state bleeds together. Slack: `slack:teamId:channel:thread:threadTs`.
+ * Teams: `teams:tenantId:conversationId`, matching app-api's `thread_key`
+ * (`teams:{tenantId}:{conversationId}`) so client and server agree on identity.
+ * Deriving from Slack-only fields would collapse every Teams conversation to one
+ * key — the bug this switch prevents now that claims are provider-agnostic.
+ */
+export function conversationKeyFromReplyTarget(rt: ReplyTarget): string {
+  switch (rt.adapter) {
+    case "slack":
+      return `slack:${rt.teamId}:${rt.channel}:thread:${rt.threadTs ?? "root"}`;
+    case "teams":
+      return `teams:${rt.tenantId}:${rt.conversationId}`;
+    default: {
+      // A provider we don't model yet: fail loud rather than silently collide
+      // distinct conversations onto a shared agent/session.
+      const unknown = rt as { adapter?: string };
+      throw new Error(
+        `conversationKeyFromReplyTarget: unsupported reply-target adapter ${JSON.stringify(unknown.adapter)}`,
+      );
+    }
+  }
+}
+
+/**
+ * Map a claimed delivery to the discriminated {@link ChannelIngressEnvelope} the
+ * bridge adapter routes on. Threads the provider `actor` through as
+ * `env.user`, derives a thread-stable `conversationKey`, and discriminates on
+ * `input.kind` — an unknown kind fails loud rather than being silently coerced
+ * into an empty turn (which would then ack as a processed no-op).
+ */
+export function mapDeliveryToEnvelope(
+  d: ClaimedDelivery,
+): ChannelIngressEnvelope {
+  const base = {
+    deliveryId: d.id,
+    eventId: d.turn.eventId,
+    turnId: d.turn.id,
+    // `ChannelIngressEnvelope` remains aligned with the channels framework's
+    // Bot object; only the Intelligence HTTP wire contract calls this a channel.
+    channelName: d.channel.name,
+    platform: d.adapter,
+    conversationKey: conversationKeyFromReplyTarget(d.turn.replyTarget),
+    route: d.turn.replyTarget,
+    // Provider identity → opaque runtime app user (OSS-476). Omitted when the
+    // claim carries no actor (older gateway/app-api, or an actor-less event).
+    ...(d.turn.actor
+      ? {
+          user: {
+            id: d.turn.actor.externalUserId,
+            ...(d.turn.actor.displayName
+              ? { displayName: d.turn.actor.displayName }
+              : {}),
+          },
+        }
+      : {}),
+  };
+  const input = d.turn.input;
+
+  if (input?.kind === "command") {
+    return {
+      ...base,
+      kind: "command",
+      command: input.command,
+      text: input.text ?? "",
+      ...(input.triggerId ? { triggerId: input.triggerId } : {}),
+      ...(input.rawOptions ? { rawOptions: input.rawOptions } : {}),
+    };
+  }
+
+  if (input?.kind === "reaction") {
+    return {
+      ...base,
+      kind: "reaction",
+      rawEmoji: input.rawEmoji,
+      added: input.added,
+      messageId: input.messageId,
+      ...(input.threadId ? { threadId: input.threadId } : {}),
+      ...(input.postedRef ? { postedRef: input.postedRef } : {}),
+    };
+  }
+
+  if (input?.kind === "interaction") {
+    return {
+      ...base,
+      kind: "interaction",
+      actionId: input.actionId,
+      ...(input.value !== undefined ? { value: input.value } : {}),
+      ...(input.messageRef ? { messageRef: input.messageRef } : {}),
+      ...(input.triggerId ? { triggerId: input.triggerId } : {}),
+    };
+  }
+
+  if (input === undefined || input.kind === "text") {
+    return {
+      ...base,
+      kind: "turn",
+      text: input?.text ?? "",
+      ...(input?.files?.length ? { files: input.files } : {}),
+    };
+  }
+
+  // Exhaustiveness guard: mirror the adapter's dispatch switch — an unknown wire
+  // kind must fail loud rather than be silently coerced into an empty turn (which
+  // would then ack as a processed no-op).
+  const unhandled: never = input;
+  throw new Error(
+    `intelligenceAdapter: unknown delivery input kind ${JSON.stringify(unhandled)}`,
+  );
+}

--- a/packages/channels-intelligence/src/contracts.ts
+++ b/packages/channels-intelligence/src/contracts.ts
@@ -155,6 +155,16 @@ export type ChannelRenderEvent =
   | { kind: "update"; ref: string; content: ChannelNode[] }
   | {
       /**
+       * Delete a previously-posted message (`thread.delete`). Carries only the
+       * post ref; the gateway-side Connector Outbox resolves it to the provider
+       * message ts and calls `chat.delete`. Mirrors the frozen `delete` render
+       * kind on the Intelligence side (OSS-420).
+       */
+      kind: "delete";
+      ref: string;
+    }
+  | {
+      /**
        * Outbound file post (`thread.postFile`). Bytes were streamed to app-api
        * ahead of this frame and stored in object storage under `handle`; the
        * Connector Outbox fetches them and calls Slack `files.uploadV2`.

--- a/packages/channels-intelligence/src/http-transports.ts
+++ b/packages/channels-intelligence/src/http-transports.ts
@@ -123,7 +123,12 @@ export function resolveTransportConfig(
 }
 
 const defaultSleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
+  new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    // Don't let a pending poll-sleep hold the event loop open (parity with the
+    // realtime transport's timers) so the process can exit after stop().
+    (timer as unknown as { unref?: () => void }).unref?.();
+  });
 
 /** Default per-turn deadline before a hung turn is nacked and skipped. */
 const DEFAULT_TURN_TIMEOUT_MS = 120_000;
@@ -140,6 +145,9 @@ function withTimeout<T>(
 ): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error(message)), ms);
+    // Don't let a pending per-turn deadline hold the event loop open (parity
+    // with the realtime transport's withDeliveryTimeout).
+    (timer as unknown as { unref?: () => void }).unref?.();
     p.then(
       (value) => {
         clearTimeout(timer);

--- a/packages/channels-intelligence/src/http-transports.ts
+++ b/packages/channels-intelligence/src/http-transports.ts
@@ -15,9 +15,12 @@ import type {
   RenderFrame,
   RenderAccepted,
 } from "./contracts.js";
-import type { MessageRef, AgentContentPart } from "@copilotkit/channels-ui";
+import type { AgentContentPart } from "@copilotkit/channels-ui";
 import { irToText } from "./ir-to-text.js";
 import { buildContentParts } from "./content-parts.js";
+import { mapDeliveryToEnvelope } from "./claim-mapping.js";
+import type { ClaimedDelivery } from "./claim-mapping.js";
+import { IntelligenceFileHistoryClient } from "./intelligence-file-history.js";
 
 /**
  * @internal Default HTTP transports for {@link intelligenceAdapter}.
@@ -126,14 +129,6 @@ const defaultSleep = (ms: number): Promise<void> =>
 const DEFAULT_TURN_TIMEOUT_MS = 120_000;
 
 /**
- * Safety backstop on an inbound file download. app-api caps inbound files at
- * 25 MiB, so this generous ceiling never rejects legitimate traffic — it just
- * prevents an unbounded `arrayBuffer()` read if a served body is pathologically
- * large (anomaly / misrouted endpoint) and advertises its size.
- */
-const MAX_INBOUND_FILE_BYTES = 64 * 1024 * 1024;
-
-/**
  * Reject after `ms` if `p` hasn't settled, so a hung turn can't wedge the
  * single-delivery loop. The underlying promise keeps running in the background
  * (harmless — a rejection handler is attached), but the loop moves on.
@@ -159,81 +154,6 @@ function withTimeout<T>(
 }
 
 /** Slack reply target Intelligence mints at ingress and the sink echoes back. */
-interface SlackReplyTarget {
-  adapter: "slack";
-  teamId: string;
-  channel: string;
-  threadTs?: string;
-}
-
-/**
- * Teams reply target Intelligence mints at ingress (Bot Connector coordinates).
- * Distinct shape from Slack — no teamId/channel/threadTs — so conversation
- * identity must be derived per-provider (see {@link conversationKeyFromReplyTarget}).
- */
-interface TeamsReplyTarget {
-  adapter: "teams";
-  serviceUrl: string;
-  conversationId: string;
-  tenantId: string;
-}
-
-/**
- * The claim's reply target is provider-tagged (Intelligence app-api mints a
- * discriminated union — one Channel runtime serves every channel its framework Bot has
- * attached now that claims are provider-agnostic).
- */
-type ReplyTarget = SlackReplyTarget | TeamsReplyTarget;
-
-/** Successful `claim` delivery envelope (subset the bridge reads). */
-interface ClaimedDelivery {
-  id: string;
-  organizationId: string;
-  projectId: number;
-  channel: { id: string; name: string };
-  adapter: string;
-  leaseToken: string;
-  turn: {
-    id: string;
-    eventId: string;
-    replyTarget: ReplyTarget;
-    // NB: there is intentionally no `thread_started` variant here — the claim
-    // path only carries turn/command/reaction/interaction. `thread_started`
-    // envelopes originate on the realtime gateway path, not from `claim`, so a
-    // claimed delivery never maps to `kind:"thread_started"`.
-    input?:
-      | { kind: "text"; text?: string; files?: ChannelFileRef[] }
-      | {
-          kind: "command";
-          command: string;
-          text?: string;
-          triggerId?: string;
-          rawOptions?: Record<string, unknown>;
-        }
-      | {
-          kind: "reaction";
-          rawEmoji: string;
-          added: boolean;
-          messageId: string;
-          threadId?: string;
-          /** SDK post-time ref the reacted message maps to (reverse-resolved by
-           * app-api), so a `<Message onReaction>` handler can be found. */
-          postedRef?: string;
-        }
-      | {
-          kind: "interaction";
-          /** Minted action id (ck:...) the clicked control carried. */
-          actionId: string;
-          /** The clicked control's value (block_actions value / selected options). */
-          value?: unknown;
-          /** The message the interaction occurred on (so a handler can update it). */
-          messageRef?: MessageRef;
-          /** Slack trigger id (for opening a modal off the interaction). */
-          triggerId?: string;
-        };
-  };
-}
-
 /** Per-delivery org/project/channel scope, echoed onto render frames. */
 type ClaimResponse =
   | { claimed: false; pollAfterMs: number }
@@ -279,98 +199,6 @@ class IntelligenceHttp {
   }
 }
 
-/**
- * Stable per-conversation key, derived per provider — it keys the agent/session
- * (`getOrCreate(conversationKey)`), so distinct conversations MUST get distinct
- * keys or their state bleeds together. Slack: `slack:teamId:channel:thread:threadTs`.
- * Teams: `teams:tenantId:conversationId`, matching app-api's `thread_key`
- * (`teams:{tenantId}:{conversationId}`) so client and server agree on identity.
- * Deriving from Slack-only fields would collapse every Teams conversation to one
- * key — the bug this switch prevents now that claims are provider-agnostic.
- */
-function conversationKeyFromReplyTarget(rt: ReplyTarget): string {
-  switch (rt.adapter) {
-    case "slack":
-      return `slack:${rt.teamId}:${rt.channel}:thread:${rt.threadTs ?? "root"}`;
-    case "teams":
-      return `teams:${rt.tenantId}:${rt.conversationId}`;
-    default: {
-      // A provider we don't model yet: fail loud rather than silently collide
-      // distinct conversations onto a shared agent/session.
-      const unknown = rt as { adapter?: string };
-      throw new Error(
-        `conversationKeyFromReplyTarget: unsupported reply-target adapter ${JSON.stringify(unknown.adapter)}`,
-      );
-    }
-  }
-}
-
-function mapDeliveryToEnvelope(d: ClaimedDelivery): ChannelIngressEnvelope {
-  const base = {
-    deliveryId: d.id,
-    eventId: d.turn.eventId,
-    turnId: d.turn.id,
-    // `ChannelIngressEnvelope` remains aligned with the channels framework's
-    // Bot object; only the Intelligence HTTP wire contract calls this a channel.
-    channelName: d.channel.name,
-    platform: d.adapter,
-    conversationKey: conversationKeyFromReplyTarget(d.turn.replyTarget),
-    route: d.turn.replyTarget,
-  };
-  const input = d.turn.input;
-
-  if (input?.kind === "command") {
-    return {
-      ...base,
-      kind: "command",
-      command: input.command,
-      text: input.text ?? "",
-      ...(input.triggerId ? { triggerId: input.triggerId } : {}),
-      ...(input.rawOptions ? { rawOptions: input.rawOptions } : {}),
-    };
-  }
-
-  if (input?.kind === "reaction") {
-    return {
-      ...base,
-      kind: "reaction",
-      rawEmoji: input.rawEmoji,
-      added: input.added,
-      messageId: input.messageId,
-      ...(input.threadId ? { threadId: input.threadId } : {}),
-      ...(input.postedRef ? { postedRef: input.postedRef } : {}),
-    };
-  }
-
-  if (input?.kind === "interaction") {
-    return {
-      ...base,
-      kind: "interaction",
-      actionId: input.actionId,
-      ...(input.value !== undefined ? { value: input.value } : {}),
-      ...(input.messageRef ? { messageRef: input.messageRef } : {}),
-      ...(input.triggerId ? { triggerId: input.triggerId } : {}),
-    };
-  }
-
-  if (input === undefined || input.kind === "text") {
-    return {
-      ...base,
-      kind: "turn",
-      text: input?.text ?? "",
-      ...(input?.files?.length ? { files: input.files } : {}),
-    };
-  }
-
-  // Exhaustiveness guard: mirror the adapter's dispatch switch — an unknown wire
-  // kind must fail loud rather than be silently coerced into an empty turn (which
-  // would then ack as a processed no-op).
-  const unhandled: never = input;
-  throw new Error(
-    `intelligenceAdapter: unknown delivery input kind ${JSON.stringify(unhandled)}`,
-  );
-}
-
 interface LeaseRecord {
   turnId: string;
   leaseToken: string;
@@ -385,6 +213,7 @@ interface LeaseRecord {
  */
 export class HttpDeliverySource implements DeliverySource {
   private readonly http: IntelligenceHttp;
+  private readonly fileHistory: IntelligenceFileHistoryClient;
   private readonly leases = new Map<string, LeaseRecord>();
   private running = false;
   private loop?: Promise<void>;
@@ -392,6 +221,11 @@ export class HttpDeliverySource implements DeliverySource {
 
   constructor(private readonly cfg: IntelligenceTransportConfig) {
     this.http = new IntelligenceHttp(cfg);
+    this.fileHistory = new IntelligenceFileHistoryClient({
+      baseUrl: cfg.baseUrl,
+      apiKey: cfg.apiKey,
+      log: cfg.log,
+    });
   }
 
   private sleep(ms: number): Promise<void> {
@@ -576,165 +410,18 @@ export class HttpDeliverySource implements DeliverySource {
     );
   }
 
-  /**
-   * Download an inbound file's raw bytes by handle from app-api's file-serve
-   * route. Bypasses {@link IntelligenceHttp} on purpose — that helper is
-   * JSON/POST-only and decodes bodies as text, which corrupts binary; the
-   * global `fetch` gives us `arrayBuffer()`. Auth is the same runtime bearer.
-   */
-  async fetchFile(
-    handle: string,
-  ): Promise<{ bytes: Uint8Array; mimeType?: string }> {
-    const gfetch = (globalThis as unknown as { fetch?: typeof fetch }).fetch;
-    if (!gfetch) {
-      throw new Error(
-        "intelligenceAdapter: no global fetch available for file download",
-      );
-    }
-    const url = `${this.cfg.baseUrl}/api/channels/files/${encodeURIComponent(handle)}`;
-    const res = await gfetch(url, {
-      method: "GET",
-      headers: { authorization: `Bearer ${this.cfg.apiKey}` },
-    });
-    if (!res.ok) {
-      throw new Error(`intelligence file ${handle} -> ${res.status}`);
-    }
-    // Bound the body read when the server advertises an oversize length, before
-    // pulling the whole thing into memory as an arrayBuffer.
-    const declaredLen = Number(res.headers.get("content-length") ?? "");
-    if (Number.isFinite(declaredLen) && declaredLen > MAX_INBOUND_FILE_BYTES) {
-      throw new Error(
-        `intelligence file ${handle} too large: ${declaredLen} bytes > ${MAX_INBOUND_FILE_BYTES} cap`,
-      );
-    }
-    const bytes = new Uint8Array(await res.arrayBuffer());
-    const mimeType = res.headers.get("content-type") ?? undefined;
-    return { bytes, mimeType };
+  // fetchFile / getHistory / uploadFile delegate to the shared
+  // IntelligenceFileHistoryClient so the HTTP and realtime transports stay in
+  // lockstep (OSS-476). See {@link IntelligenceFileHistoryClient}.
+  fetchFile(handle: string): Promise<{ bytes: Uint8Array; mimeType?: string }> {
+    return this.fileHistory.fetchFile(handle);
   }
 
-  /**
-   * Fetch prior thread turns from app-api's channel history route for
-   * conversation-history seeding (parity with bot-slack/bot-discord/
-   * bot-whatsapp's reconstructed-history conversation stores). A root-level
-   * turn (no `threadTs`) has no prior thread to look up, so this returns `[]`
-   * without a request. Best-effort like {@link fetchFile}'s sibling paths — any
-   * non-2xx response or thrown error degrades to `[]`; missing history must
-   * never fail the turn. Logging is split by failure class: a 4xx (except
-   * 429) is a permanent misconfiguration (route not mounted / wrong baseUrl /
-   * bad runtime key) and is logged loudly and distinctly so it doesn't hide
-   * forever; a 5xx, 429, or thrown network error is a transient blip and gets
-   * the existing quiet degradation log.
-   */
-  async getHistory(
-    replyTarget: EgressRoute,
-    limit: number,
-  ): Promise<AgentMessage[]> {
-    // Provider-specific history query. `EgressRoute` is opaque, so each adapter
-    // maps its route → app-api's `/api/channels/history` query here, mirroring
-    // `conversationKeyFromReplyTarget`'s per-adapter switch. Slack keys off
-    // `threadTs`; Teams off `tenantId`+`conversationId` (matching app-api's
-    // `teams:{tenantId}:{conversationId}` thread_key). A turn with no thread
-    // anchor has no prior history to look up, so return `[]`.
-    const rt = replyTarget as
-      | {
-          adapter?: string;
-          teamId?: string;
-          channel?: string;
-          threadTs?: string;
-          tenantId?: string;
-          conversationId?: string;
-        }
-      | undefined;
-    let qs: URLSearchParams;
-    if (rt?.adapter === "teams") {
-      if (!rt.tenantId || !rt.conversationId) return [];
-      qs = new URLSearchParams({
-        adapter: "teams",
-        tenantId: rt.tenantId,
-        conversationId: rt.conversationId,
-        limit: String(limit),
-      });
-    } else {
-      if (!rt?.threadTs) return [];
-      qs = new URLSearchParams({
-        teamId: rt.teamId ?? "",
-        channel: rt.channel ?? "",
-        threadTs: rt.threadTs,
-        limit: String(limit),
-      });
-    }
-    try {
-      const gfetch = (globalThis as unknown as { fetch?: typeof fetch }).fetch;
-      if (!gfetch) {
-        this.cfg.log?.("intelligence history fetch: no global fetch available");
-        return [];
-      }
-      const url = `${this.cfg.baseUrl}/api/channels/history?${qs.toString()}`;
-      const res = await gfetch(url, {
-        method: "GET",
-        headers: { authorization: `Bearer ${this.cfg.apiKey}` },
-      });
-      if (!res.ok) {
-        if (res.status >= 400 && res.status < 500 && res.status !== 429) {
-          // A permanent misconfiguration (missing route, wrong baseUrl, bad
-          // runtime key) looks identical to a transient blip unless it's
-          // called out distinctly — surface it loudly so it doesn't hide
-          // forever behind the best-effort degrade-to-`[]` below.
-          this.cfg.log?.(
-            `[intelligence] getHistory ${res.status} for thread history — likely a misconfigured/unauthorized history endpoint (baseUrl/route/apiKey); Channel Bot will run WITHOUT prior-turn history`,
-          );
-        } else {
-          // Transient (5xx/429) — quiet best-effort degradation, history is
-          // just skipped for this turn.
-          this.cfg.log?.(`intelligence history fetch -> ${res.status}`);
-        }
-        return [];
-      }
-      const json = (await res.json()) as {
-        messages?: Array<{
-          id: string;
-          role: "user" | "assistant";
-          text: string;
-          files?: ChannelFileRef[];
-        }>;
-      };
-      const out: AgentMessage[] = [];
-      for (const m of json.messages ?? []) {
-        if (!m.files?.length) {
-          out.push({ id: m.id, role: m.role, content: m.text ?? "" });
-          continue;
-        }
-        // Hydrate historical file refs with the SAME logic as the live inbound
-        // turn path, so a past image attachment and a live one produce
-        // identical content parts (e.g. "what was the image I sent?" works).
-        const fileParts = await buildContentParts(
-          m.files,
-          this.fetchFile.bind(this),
-          this.cfg.log,
-        );
-        const content: AgentContentPart[] = [];
-        if (m.text) content.push({ type: "text", text: m.text });
-        content.push(...fileParts);
-        out.push({ id: m.id, role: m.role, content });
-      }
-      // Defensive parity with InMemoryDeliverySource.getHistory (`slice(-limit)`):
-      // the route contract is oldest→newest capped at `limit`, but don't trust
-      // the server to honor it — keep the most recent `limit` so an over-
-      // returning route can't seed more than `historyLimit` onto agent.messages.
-      return out.length > limit ? out.slice(-limit) : out;
-    } catch (err) {
-      this.cfg.log?.("intelligence history fetch failed", err);
-      return [];
-    }
+  getHistory(replyTarget: EgressRoute, limit: number): Promise<AgentMessage[]> {
+    return this.fileHistory.getHistory(replyTarget, limit);
   }
 
-  /**
-   * Stream an outbound file's bytes to app-api's per-delivery upload route
-   * (lease-scoped) ahead of a `file` render frame. Returns the storage handle
-   * the frame references. Bytes go as the raw request body; display metadata
-   * rides query params.
-   */
-  async uploadFile(
+  uploadFile(
     deliveryId: string,
     args: {
       bytes: Uint8Array;
@@ -743,38 +430,7 @@ export class HttpDeliverySource implements DeliverySource {
       altText?: string;
     },
   ): Promise<{ handle: string }> {
-    const gfetch = (globalThis as unknown as { fetch?: typeof fetch }).fetch;
-    if (!gfetch) {
-      throw new Error(
-        "intelligenceAdapter: no global fetch available for file upload",
-      );
-    }
-    const qs = new URLSearchParams({ filename: args.filename });
-    if (args.title) qs.set("title", args.title);
-    if (args.altText) qs.set("altText", args.altText);
-    const url = `${this.cfg.baseUrl}/api/channels/deliveries/${encodeURIComponent(
-      deliveryId,
-    )}/files?${qs.toString()}`;
-    const res = await gfetch(url, {
-      method: "POST",
-      headers: {
-        authorization: `Bearer ${this.cfg.apiKey}`,
-        "content-type": "application/octet-stream",
-      },
-      // The runtime (undici) sends the Uint8Array bytes verbatim; the static
-      // `fetch` body type differs across this package's dom vs node-only lib
-      // configs, so bridge with a portable cast (`string` is a valid body in
-      // both). The value is never actually a string at runtime.
-      body: args.bytes as unknown as string,
-    });
-    if (!res.ok) {
-      throw new Error(`intelligence file upload -> ${res.status}`);
-    }
-    const json = (await res.json()) as { handle?: string };
-    if (!json.handle) {
-      throw new Error("intelligence file upload: response missing handle");
-    }
-    return { handle: json.handle };
+    return this.fileHistory.uploadFile(deliveryId, args);
   }
 
   async stop(): Promise<void> {

--- a/packages/channels-intelligence/src/http-transports.ts
+++ b/packages/channels-intelligence/src/http-transports.ts
@@ -8,16 +8,13 @@ import type {
 import type {
   ChannelIngressEnvelope,
   ChannelDeliveryScope,
-  ChannelFileRef,
   EgressRoute,
   EgressOperation,
   EgressResult,
   RenderFrame,
   RenderAccepted,
 } from "./contracts.js";
-import type { AgentContentPart } from "@copilotkit/channels-ui";
 import { irToText } from "./ir-to-text.js";
-import { buildContentParts } from "./content-parts.js";
 import { mapDeliveryToEnvelope } from "./claim-mapping.js";
 import type { ClaimedDelivery } from "./claim-mapping.js";
 import { IntelligenceFileHistoryClient } from "./intelligence-file-history.js";

--- a/packages/channels-intelligence/src/http-transports.ts
+++ b/packages/channels-intelligence/src/http-transports.ts
@@ -158,8 +158,7 @@ function withTimeout<T>(
   });
 }
 
-/** Slack reply target Intelligence mints at ingress and the sink echoes back. */
-/** Per-delivery org/project/channel scope, echoed onto render frames. */
+/** The claim route's response: an idle-backoff, or a leased delivery to run. */
 type ClaimResponse =
   | { claimed: false; pollAfterMs: number }
   | { claimed: true; delivery: ClaimedDelivery };

--- a/packages/channels-intelligence/src/in-memory-transports.ts
+++ b/packages/channels-intelligence/src/in-memory-transports.ts
@@ -107,7 +107,9 @@ export class InMemoryDeliverySource implements DeliverySource {
     limit: number,
   ): Promise<AgentMessage[]> {
     this.historyRequests.push({ replyTarget, limit });
-    return this.history.slice(-limit);
+    // `limit <= 0` → no history (a raw `slice(-0)` returns the WHOLE array);
+    // mirrors IntelligenceFileHistoryClient.getHistory's guard.
+    return limit <= 0 ? [] : this.history.slice(-limit);
   }
   async stop(): Promise<void> {}
 }

--- a/packages/channels-intelligence/src/intelligence-adapter.test.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.test.ts
@@ -57,6 +57,28 @@ describe("intelligenceAdapter — ingress dispatch", () => {
     expect(seen?.platform).toBe("slack");
   });
 
+  it("forwards the provider actor displayName to handlers, not just the id", async () => {
+    const source = new InMemoryDeliverySource();
+    const egress = new InMemoryEgressSink();
+    const channel = createChannel({
+      adapters: [intelligenceAdapter({ source, egress })],
+      agent: () => new FakeAgent(),
+    });
+    let seenUser: { id: string; displayName?: string } | undefined;
+    channel.onMessage(async ({ message }) => {
+      seenUser = message.user;
+    });
+    await channel.start();
+    // Before the fix, dispatchTo narrowed env.user to `{ id }`, dropping the
+    // displayName the claim mapper resolved.
+    await source.deliver(
+      envelope({ user: { id: "u1", displayName: "Ada Lovelace" } }),
+    );
+
+    expect(seenUser?.id).toBe("u1");
+    expect(seenUser?.displayName).toBe("Ada Lovelace");
+  });
+
   it("acks the delivery after the handler completes", async () => {
     const source = new InMemoryDeliverySource();
     const egress = new InMemoryEgressSink();

--- a/packages/channels-intelligence/src/intelligence-adapter.test.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.test.ts
@@ -297,8 +297,10 @@ describe("intelligenceAdapter — egress fail-loud", () => {
     await source.deliver(envelope());
 
     // Before the fix, thread.post resolved with a synthetic ref and postError
-    // stayed undefined (the drop was acked as success). Now it throws so the
-    // failure propagates up the render path and the delivery is nacked.
+    // stayed undefined (the drop was acked as success). Now it throws. (This
+    // test asserts the throw at the post() boundary; the handler catches it
+    // here, so no nack is exercised — the run-loop's nack-on-throw is covered
+    // by the render-events dispatch tests.)
     expect(postError).toBeInstanceOf(Error);
     expect((postError as Error).message).toMatch(/egress post failed/i);
     expect((postError as Error).message).toContain("provider_rejected");
@@ -560,9 +562,10 @@ describe("intelligenceAdapter — conversation-history seeding", () => {
       // string content → text; role 'user' → isBot false, user 'user'.
       { text: "hi there", isBot: false, user: { id: "user", name: "user" } },
       // content-part array → text parts joined; the non-text (image) part
-      // contributes an empty string (hence the double space); assistant → bot.
+      // contributes no text and is dropped before the join, so there is no
+      // stray doubled space; assistant → bot.
       {
-        text: "part one  part two",
+        text: "part one part two",
         isBot: true,
         user: { id: "bot", name: "bot" },
       },

--- a/packages/channels-intelligence/src/intelligence-adapter.test.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.test.ts
@@ -57,26 +57,27 @@ describe("intelligenceAdapter — ingress dispatch", () => {
     expect(seen?.platform).toBe("slack");
   });
 
-  it("forwards the provider actor displayName to handlers, not just the id", async () => {
+  it("maps the provider actor display name onto PlatformUser.name for handlers", async () => {
     const source = new InMemoryDeliverySource();
     const egress = new InMemoryEgressSink();
     const channel = createChannel({
       adapters: [intelligenceAdapter({ source, egress })],
       agent: () => new FakeAgent(),
     });
-    let seenUser: { id: string; displayName?: string } | undefined;
+    let seenUser: { id: string; name?: string } | undefined;
     channel.onMessage(async ({ message }) => {
       seenUser = message.user;
     });
     await channel.start();
-    // Before the fix, dispatchTo narrowed env.user to `{ id }`, dropping the
-    // displayName the claim mapper resolved.
+    // The wire field is `displayName`; it must surface as PlatformUser.name so
+    // `message.user.name` is observable through the typed API (parity with the
+    // direct Slack adapter, which populates `name`).
     await source.deliver(
       envelope({ user: { id: "u1", displayName: "Ada Lovelace" } }),
     );
 
     expect(seenUser?.id).toBe("u1");
-    expect(seenUser?.displayName).toBe("Ada Lovelace");
+    expect(seenUser?.name).toBe("Ada Lovelace");
   });
 
   it("acks the delivery after the handler completes", async () => {

--- a/packages/channels-intelligence/src/intelligence-adapter.test.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.test.ts
@@ -574,7 +574,10 @@ describe("intelligenceAdapter — conversation-history seeding", () => {
 
   it("getMessages returns [] when the transport has no getHistory", async () => {
     const source = new InMemoryDeliverySource();
-    delete (source as { getHistory?: unknown }).getHistory;
+    // Shadow the prototype method with an own `undefined` — `delete` wouldn't
+    // remove a prototype method, so the `source?.getHistory?.()` short-circuit
+    // (the branch under test) would never actually be exercised.
+    (source as { getHistory?: unknown }).getHistory = undefined;
     const adapter = intelligenceAdapter({
       source,
       egress: new InMemoryEgressSink(),
@@ -619,7 +622,10 @@ describe("intelligenceAdapter — conversation-history seeding", () => {
 
   it("starts fresh (empty messages) when the transport has no getHistory", async () => {
     const source = new InMemoryDeliverySource();
-    delete (source as { getHistory?: unknown }).getHistory;
+    // Shadow the prototype method with an own `undefined` — `delete` wouldn't
+    // remove a prototype method, so the `source?.getHistory?.()` short-circuit
+    // (the branch under test) would never actually be exercised.
+    (source as { getHistory?: unknown }).getHistory = undefined;
     const adapter = intelligenceAdapter({
       source,
       egress: new InMemoryEgressSink(),

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -369,7 +369,17 @@ export class IntelligenceAdapter implements PlatformAdapter {
       turnId: env.turnId,
       deliveryId: env.deliveryId,
     };
-    const user = env.user ? { id: env.user.id } : undefined;
+    // Forward the full provider identity the claim mapper resolved (OSS-476),
+    // not just the id — otherwise `displayName` is plumbed through the mapper
+    // only to be dropped one layer before it reaches handlers.
+    const user = env.user
+      ? {
+          id: env.user.id,
+          ...(env.user.displayName !== undefined
+            ? { displayName: env.user.displayName }
+            : {}),
+        }
+      : undefined;
 
     switch (env.kind) {
       case "turn": {
@@ -632,6 +642,19 @@ export class IntelligenceAdapter implements PlatformAdapter {
     let acc = "";
     for await (const c of chunks) acc += c;
     const target = _target as ChannelReplyTarget;
+    if (acc.length === 0) {
+      // An empty stream (no chunks, or only empty strings) has nothing to post.
+      // Posting textNode("") violates the render contract's min-1-text
+      // constraint (the frame is rejected → the whole turn nacks), and the HTTP
+      // egress fallback guards the same case. Skip the post and return a
+      // synthetic ref keyed to the turn — there is nothing to update/delete.
+      return {
+        id: `${target.turnId}:empty`,
+        __route: target.route,
+        __turnId: target.turnId,
+        __deliveryId: target.deliveryId,
+      };
+    }
     if (this.renderSink) {
       return this.postRenderFrame(target, {
         kind: "post",

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -373,14 +373,16 @@ export class IntelligenceAdapter implements PlatformAdapter {
       turnId: env.turnId,
       deliveryId: env.deliveryId,
     };
-    // Forward the full provider identity the claim mapper resolved (OSS-476),
-    // not just the id — otherwise `displayName` is plumbed through the mapper
-    // only to be dropped one layer before it reaches handlers.
+    // Forward the provider identity the claim mapper resolved (OSS-476), not
+    // just the id. The wire field is `displayName`; the public `PlatformUser`
+    // exposes it as `name` (the direct Slack adapter populates `name` too), so
+    // map onto `name` — otherwise `message.user.name` is undefined on managed
+    // turns and callers can't read the profile through the typed API.
     const user = env.user
       ? {
           id: env.user.id,
           ...(env.user.displayName !== undefined
-            ? { displayName: env.user.displayName }
+            ? { name: env.user.displayName }
             : {}),
         }
       : undefined;

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -642,6 +642,16 @@ export class IntelligenceAdapter implements PlatformAdapter {
   }
 
   async delete(ref: MessageRef): Promise<void> {
+    // Realtime path: stream a `delete` render frame so the Connector Outbox
+    // resolves the ref and calls chat.delete (OSS-420) — mirroring post/update.
+    // Fallback (no render sink — in-memory tests): the egress op path.
+    if (this.renderSink) {
+      await this.postRenderFrame(targetFromRef(ref), {
+        kind: "delete",
+        ref: ref.id,
+      });
+      return;
+    }
     await this.emit(targetFromRef(ref), { kind: "delete", ref: ref.id });
   }
 

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -235,6 +235,10 @@ export class IntelligenceAdapter implements PlatformAdapter {
                     ? part
                     : ((part as { text?: string } | null)?.text ?? ""),
                 )
+                // Drop empty parts (non-text content contributes "") BEFORE
+                // joining, so a `read_thread` transcript isn't corrupted with
+                // doubled/leading/trailing spaces around image/file parts.
+                .filter(Boolean)
                 .join(" ")
             : "";
       const isBot = m.role !== "user";

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -434,7 +434,8 @@ export class IntelligenceAdapter implements PlatformAdapter {
         //
         // CONTRACT (app-api side): the interaction delivery MUST carry a turnId
         // distinct from the turn that originally posted the card. Egress op ids
-        // are `${turnId}:${seq}` (see mintOp/postRenderFrame) and seq resets to
+        // are `${turnId}:${seq}` (see mintOp; the render path keys on the
+        // 3-part `${turnId}:${slot}:${seq}`) and seq resets to
         // 0 per delivery, so a reused turnId makes the update's op id collide
         // with the original post's — the Connector Outbox dedupes on op id and
         // SILENTLY DROPS the update, so the card never flips. This layer can't

--- a/packages/channels-intelligence/src/intelligence-file-history.test.ts
+++ b/packages/channels-intelligence/src/intelligence-file-history.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { IntelligenceFileHistoryClient } from "./intelligence-file-history.js";
+import type { EgressRoute } from "./contracts.js";
+
+/** A slack reply target with a thread anchor so getHistory issues the fetch. */
+const slackRoute = {
+  adapter: "slack",
+  teamId: "T1",
+  channel: "C1",
+  threadTs: "1700.5",
+} as unknown as EgressRoute;
+
+function stubFetchReturning(messages: unknown[]): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ messages }),
+    })),
+  );
+}
+
+describe("IntelligenceFileHistoryClient.getHistory", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  const client = new IntelligenceFileHistoryClient({
+    baseUrl: "http://app-api.test",
+    apiKey: "cpk-test",
+  });
+
+  it("returns [] for limit <= 0 instead of the full history (slice(-0) guard)", async () => {
+    // The server over-returns; a raw `slice(-0)` would hand back ALL of it.
+    stubFetchReturning([
+      { id: "m1", role: "user", text: "one" },
+      { id: "m2", role: "assistant", text: "two" },
+      { id: "m3", role: "user", text: "three" },
+    ]);
+
+    const out = await client.getHistory(slackRoute, 0);
+    expect(out).toEqual([]);
+  });
+
+  it("caps to the most recent `limit` messages", async () => {
+    stubFetchReturning(
+      Array.from({ length: 5 }, (_, i) => ({
+        id: `m${i}`,
+        role: "user",
+        text: `t${i}`,
+      })),
+    );
+
+    const out = await client.getHistory(slackRoute, 2);
+    expect(out.map((m) => m.id)).toEqual(["m3", "m4"]);
+  });
+});

--- a/packages/channels-intelligence/src/intelligence-file-history.ts
+++ b/packages/channels-intelligence/src/intelligence-file-history.ts
@@ -17,6 +17,53 @@ import { buildContentParts } from "./content-parts.js";
 /** Hard cap on an inbound file download (mirrors the app-api serve route). */
 const MAX_INBOUND_FILE_BYTES = 64 * 1024 * 1024;
 
+/**
+ * Read a response body into memory, aborting once `cap` bytes are exceeded — so
+ * a response with no or understated `content-length` (chunked transfer, or a
+ * misbehaving/anomalous server) cannot pull an unbounded body into memory. Falls
+ * back to a buffered `arrayBuffer()` read with a post-read size check when the
+ * response exposes no readable stream (e.g. a mocked Response in tests).
+ */
+async function readCapped(
+  res: Response,
+  cap: number,
+  handle: string,
+): Promise<Uint8Array> {
+  const body = res.body;
+  if (!body) {
+    const buf = new Uint8Array(await res.arrayBuffer());
+    if (buf.byteLength > cap) {
+      throw new Error(
+        `intelligence file ${handle} too large: ${buf.byteLength} bytes > ${cap} cap`,
+      );
+    }
+    return buf;
+  }
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > cap) {
+      await reader.cancel();
+      throw new Error(
+        `intelligence file ${handle} too large: exceeded ${cap} byte cap`,
+      );
+    }
+    chunks.push(value);
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
 /** The minimal app-api HTTP coordinates the file/history calls need. */
 export interface IntelligenceFileHistoryConfig {
   /** Intelligence app-api base URL, e.g. `http://localhost:7050`. */
@@ -56,15 +103,18 @@ export class IntelligenceFileHistoryClient {
     if (!res.ok) {
       throw new Error(`intelligence file ${handle} -> ${res.status}`);
     }
-    // Bound the body read when the server advertises an oversize length, before
-    // pulling the whole thing into memory as an arrayBuffer.
+    // Fast reject on an advertised oversize length…
     const declaredLen = Number(res.headers.get("content-length") ?? "");
     if (Number.isFinite(declaredLen) && declaredLen > MAX_INBOUND_FILE_BYTES) {
       throw new Error(
         `intelligence file ${handle} too large: ${declaredLen} bytes > ${MAX_INBOUND_FILE_BYTES} cap`,
       );
     }
-    const bytes = new Uint8Array(await res.arrayBuffer());
+    // …but the declared length is not trustworthy (absent on chunked transfer,
+    // or understated by a misbehaving/anomalous server), so bound the ACTUAL
+    // read: stream the body and abort once the cap is exceeded rather than
+    // pulling an unbounded response into memory via arrayBuffer().
+    const bytes = await readCapped(res, MAX_INBOUND_FILE_BYTES, handle);
     const mimeType = res.headers.get("content-type") ?? undefined;
     return { bytes, mimeType };
   }
@@ -153,8 +203,13 @@ export class IntelligenceFileHistoryClient {
           files?: ChannelFileRef[];
         }>;
       };
+      // Cap to the most recent `limit` BEFORE hydrating file bytes: an
+      // over-returning route must not make us download attachments for messages
+      // we'd immediately discard, and `limit <= 0` means "no history" (a raw
+      // `slice(-0)` would otherwise return the ENTIRE array).
+      const capped = limit <= 0 ? [] : (json.messages ?? []).slice(-limit);
       const out: AgentMessage[] = [];
-      for (const m of json.messages ?? []) {
+      for (const m of capped) {
         if (!m.files?.length) {
           out.push({ id: m.id, role: m.role, content: m.text ?? "" });
           continue;
@@ -172,11 +227,8 @@ export class IntelligenceFileHistoryClient {
         content.push(...fileParts);
         out.push({ id: m.id, role: m.role, content });
       }
-      // Defensive parity with InMemoryDeliverySource.getHistory (`slice(-limit)`):
-      // the route contract is oldest→newest capped at `limit`, but don't trust
-      // the server to honor it — keep the most recent `limit` so an over-
-      // returning route can't seed more than `historyLimit` onto agent.messages.
-      return out.length > limit ? out.slice(-limit) : out;
+      // Already capped to the most recent `limit` above (before hydration).
+      return out;
     } catch (err) {
       this.cfg.log?.("intelligence history fetch failed", err);
       return [];

--- a/packages/channels-intelligence/src/intelligence-file-history.ts
+++ b/packages/channels-intelligence/src/intelligence-file-history.ts
@@ -1,0 +1,234 @@
+import type { AgentContentPart } from "@copilotkit/channels-ui";
+import type { AgentMessage } from "./transports.js";
+import type { ChannelFileRef, EgressRoute } from "./contracts.js";
+import { buildContentParts } from "./content-parts.js";
+
+/**
+ * Shared file/history client used by BOTH transports — the HTTP polling
+ * {@link ../http-transports} and the realtime gateway
+ * {@link ../realtime-gateway-transport}. These three operations are HTTP-only:
+ * the gateway relays the render-event STREAM but never file bytes or history
+ * (bytes don't belong on the control socket), so a realtime deployment reaches
+ * the same app-api REST endpoints directly. Extracting them here keeps the two
+ * paths byte-identical — the OSS-476 parity guarantee — instead of the realtime
+ * path silently degrading (no history, no inbound file bytes, no upload).
+ */
+
+/** Hard cap on an inbound file download (mirrors the app-api serve route). */
+const MAX_INBOUND_FILE_BYTES = 64 * 1024 * 1024;
+
+/** The minimal app-api HTTP coordinates the file/history calls need. */
+export interface IntelligenceFileHistoryConfig {
+  /** Intelligence app-api base URL, e.g. `http://localhost:7050`. */
+  baseUrl: string;
+  /** Project runtime API key (`cpk-…`), sent as `Authorization: Bearer`. */
+  apiKey: string;
+  /** Optional diagnostic sink for best-effort degradation. */
+  log?: (msg: string, meta?: unknown) => void;
+}
+
+/**
+ * Credentialed client for app-api's file-serve, history, and file-upload
+ * routes. Instantiated by each transport from its own app-api coordinates.
+ */
+export class IntelligenceFileHistoryClient {
+  constructor(private readonly cfg: IntelligenceFileHistoryConfig) {}
+
+  /**
+   * Download an inbound file's raw bytes by handle from app-api's file-serve
+   * route. Uses the global `fetch` directly (not a JSON helper) so the binary
+   * body survives via `arrayBuffer()`. Auth is the same runtime bearer.
+   */
+  async fetchFile(
+    handle: string,
+  ): Promise<{ bytes: Uint8Array; mimeType?: string }> {
+    const gfetch = (globalThis as unknown as { fetch?: typeof fetch }).fetch;
+    if (!gfetch) {
+      throw new Error(
+        "intelligenceAdapter: no global fetch available for file download",
+      );
+    }
+    const url = `${this.cfg.baseUrl}/api/channels/files/${encodeURIComponent(handle)}`;
+    const res = await gfetch(url, {
+      method: "GET",
+      headers: { authorization: `Bearer ${this.cfg.apiKey}` },
+    });
+    if (!res.ok) {
+      throw new Error(`intelligence file ${handle} -> ${res.status}`);
+    }
+    // Bound the body read when the server advertises an oversize length, before
+    // pulling the whole thing into memory as an arrayBuffer.
+    const declaredLen = Number(res.headers.get("content-length") ?? "");
+    if (Number.isFinite(declaredLen) && declaredLen > MAX_INBOUND_FILE_BYTES) {
+      throw new Error(
+        `intelligence file ${handle} too large: ${declaredLen} bytes > ${MAX_INBOUND_FILE_BYTES} cap`,
+      );
+    }
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    const mimeType = res.headers.get("content-type") ?? undefined;
+    return { bytes, mimeType };
+  }
+
+  /**
+   * Fetch prior thread turns from app-api's channel history route for
+   * conversation-history seeding. A root-level turn (no thread anchor) has no
+   * prior thread to look up, so this returns `[]` without a request.
+   * Best-effort like {@link fetchFile}'s sibling paths — any non-2xx response
+   * or thrown error degrades to `[]`; missing history must never fail the turn.
+   * Logging is split by failure class: a 4xx (except 429) is a permanent
+   * misconfiguration (route not mounted / wrong baseUrl / bad runtime key) and
+   * is logged loudly and distinctly so it doesn't hide forever; a 5xx, 429, or
+   * thrown network error is a transient blip and gets the quiet degradation log.
+   */
+  async getHistory(
+    replyTarget: EgressRoute,
+    limit: number,
+  ): Promise<AgentMessage[]> {
+    // Provider-specific history query. `EgressRoute` is opaque, so each adapter
+    // maps its route → app-api's `/api/channels/history` query here, mirroring
+    // `conversationKeyFromReplyTarget`'s per-adapter switch. Slack keys off
+    // `threadTs`; Teams off `tenantId`+`conversationId` (matching app-api's
+    // `teams:{tenantId}:{conversationId}` thread_key). A turn with no thread
+    // anchor has no prior history to look up, so return `[]`.
+    const rt = replyTarget as
+      | {
+          adapter?: string;
+          teamId?: string;
+          channel?: string;
+          threadTs?: string;
+          tenantId?: string;
+          conversationId?: string;
+        }
+      | undefined;
+    let qs: URLSearchParams;
+    if (rt?.adapter === "teams") {
+      if (!rt.tenantId || !rt.conversationId) return [];
+      qs = new URLSearchParams({
+        adapter: "teams",
+        tenantId: rt.tenantId,
+        conversationId: rt.conversationId,
+        limit: String(limit),
+      });
+    } else {
+      if (!rt?.threadTs) return [];
+      qs = new URLSearchParams({
+        teamId: rt.teamId ?? "",
+        channel: rt.channel ?? "",
+        threadTs: rt.threadTs,
+        limit: String(limit),
+      });
+    }
+    try {
+      const gfetch = (globalThis as unknown as { fetch?: typeof fetch }).fetch;
+      if (!gfetch) {
+        this.cfg.log?.("intelligence history fetch: no global fetch available");
+        return [];
+      }
+      const url = `${this.cfg.baseUrl}/api/channels/history?${qs.toString()}`;
+      const res = await gfetch(url, {
+        method: "GET",
+        headers: { authorization: `Bearer ${this.cfg.apiKey}` },
+      });
+      if (!res.ok) {
+        if (res.status >= 400 && res.status < 500 && res.status !== 429) {
+          // A permanent misconfiguration (missing route, wrong baseUrl, bad
+          // runtime key) looks identical to a transient blip unless it's
+          // called out distinctly — surface it loudly so it doesn't hide
+          // forever behind the best-effort degrade-to-`[]` below.
+          this.cfg.log?.(
+            `[intelligence] getHistory ${res.status} for thread history — likely a misconfigured/unauthorized history endpoint (baseUrl/route/apiKey); Channel Bot will run WITHOUT prior-turn history`,
+          );
+        } else {
+          // Transient (5xx/429) — quiet best-effort degradation, history is
+          // just skipped for this turn.
+          this.cfg.log?.(`intelligence history fetch -> ${res.status}`);
+        }
+        return [];
+      }
+      const json = (await res.json()) as {
+        messages?: Array<{
+          id: string;
+          role: "user" | "assistant";
+          text: string;
+          files?: ChannelFileRef[];
+        }>;
+      };
+      const out: AgentMessage[] = [];
+      for (const m of json.messages ?? []) {
+        if (!m.files?.length) {
+          out.push({ id: m.id, role: m.role, content: m.text ?? "" });
+          continue;
+        }
+        // Hydrate historical file refs with the SAME logic as the live inbound
+        // turn path, so a past image attachment and a live one produce
+        // identical content parts (e.g. "what was the image I sent?" works).
+        const fileParts = await buildContentParts(
+          m.files,
+          this.fetchFile.bind(this),
+          this.cfg.log,
+        );
+        const content: AgentContentPart[] = [];
+        if (m.text) content.push({ type: "text", text: m.text });
+        content.push(...fileParts);
+        out.push({ id: m.id, role: m.role, content });
+      }
+      // Defensive parity with InMemoryDeliverySource.getHistory (`slice(-limit)`):
+      // the route contract is oldest→newest capped at `limit`, but don't trust
+      // the server to honor it — keep the most recent `limit` so an over-
+      // returning route can't seed more than `historyLimit` onto agent.messages.
+      return out.length > limit ? out.slice(-limit) : out;
+    } catch (err) {
+      this.cfg.log?.("intelligence history fetch failed", err);
+      return [];
+    }
+  }
+
+  /**
+   * Stream an outbound file's bytes to app-api's per-delivery upload route
+   * (lease-scoped) ahead of a `file` render frame. Returns the storage handle
+   * the frame references. Bytes go as the raw request body; display metadata
+   * rides query params.
+   */
+  async uploadFile(
+    deliveryId: string,
+    args: {
+      bytes: Uint8Array;
+      filename: string;
+      title?: string;
+      altText?: string;
+    },
+  ): Promise<{ handle: string }> {
+    const gfetch = (globalThis as unknown as { fetch?: typeof fetch }).fetch;
+    if (!gfetch) {
+      throw new Error(
+        "intelligenceAdapter: no global fetch available for file upload",
+      );
+    }
+    const qs = new URLSearchParams({ filename: args.filename });
+    if (args.title) qs.set("title", args.title);
+    if (args.altText) qs.set("altText", args.altText);
+    const url = `${this.cfg.baseUrl}/api/channels/deliveries/${encodeURIComponent(
+      deliveryId,
+    )}/files?${qs.toString()}`;
+    const res = await gfetch(url, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${this.cfg.apiKey}`,
+        "content-type": "application/octet-stream",
+      },
+      // The runtime (undici) sends the Uint8Array bytes verbatim; the static
+      // `fetch` body type differs across this package's dom vs node-only lib
+      // configs, so bridge with a portable cast (`string` is a valid body in
+      // both). The value is never actually a string at runtime.
+      body: args.bytes as unknown as string,
+    });
+    if (!res.ok) {
+      throw new Error(`intelligence file upload -> ${res.status}`);
+    }
+    const json = (await res.json()) as { handle?: string };
+    if (!json.handle) {
+      throw new Error("intelligence file upload: response missing handle");
+    }
+    return { handle: json.handle };
+  }
+}

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.ts
@@ -72,6 +72,11 @@ export interface StartChannelsWithGatewaySessionOptions {
   scope: ChannelRealtimeScope;
   /** Stable runtime instance id (`rti_…`), echoed on every envelope. */
   runtimeInstanceId: string;
+  /** Intelligence app-api HTTP base URL — enables file/history parity on the
+   * realtime path (OSS-476), which are HTTP-only. With {@link apiKey}. */
+  appApiBaseUrl?: string;
+  /** Project runtime API key (`cpk-…`) for the app-api file/history calls. */
+  apiKey?: string;
   /** Activation env overrides forwarded to the runtime (so `handle.metadata`
    * matches what the caller declared on join); omitted fields are gathered from
    * the process. `runtimeInstanceId` is excluded — the required
@@ -103,6 +108,8 @@ export async function startChannelsWithGatewaySession(
     scope: opts.scope,
     runtimeInstanceId: opts.runtimeInstanceId,
     session: opts.session,
+    ...(opts.appApiBaseUrl ? { appApiBaseUrl: opts.appApiBaseUrl } : {}),
+    ...(opts.apiKey ? { apiKey: opts.apiKey } : {}),
     ...(opts.log ? { log: opts.log } : {}),
   });
   const handle = await startChannels({
@@ -164,6 +171,11 @@ export interface StartChannelsOverRealtimeGatewayOptions {
   runtimeInstanceId: string;
   /** Adapter kind declared to the gateway on join (default `"slack"`). */
   adapter?: string;
+  /** Intelligence app-api HTTP base URL. Enables file/history parity on the
+   * realtime path (OSS-476) — these are HTTP-only (the gateway relays the
+   * render-event stream, not bytes/history), reached with the {@link apiKey}
+   * above. Omit and file/history stay unavailable (graceful degradation). */
+  appApiBaseUrl?: string;
   /** Activation env overrides (package versions, runtimeEnv); omitted fields
    * are gathered from the process. Included in the join's `runtimeMetadata` and
    * in `handle.metadata`. `runtimeInstanceId` is intentionally excluded — the
@@ -257,6 +269,11 @@ export async function startChannelsOverRealtimeGateway(
       session,
       scope: config.scope,
       runtimeInstanceId: config.runtimeInstanceId,
+      // File/history parity is HTTP-only; forward the app-api coordinates (the
+      // apiKey is the same one used as the socket authToken) so the transport
+      // can reach the file/history REST endpoints directly.
+      ...(config.appApiBaseUrl ? { appApiBaseUrl: config.appApiBaseUrl } : {}),
+      apiKey: config.apiKey,
       // The session-start helper re-merges the authoritative runtimeInstanceId,
       // so forward only the caller's overrides here (they cannot carry the id).
       ...(config.env ? { env: config.env } : {}),

--- a/packages/channels-intelligence/src/realtime-gateway-transport.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-transport.ts
@@ -20,14 +20,22 @@
 // renderer and is a follow-up. This transport covers the agent-run render
 // stream + delivery lifecycle.
 
-import type { DeliverySource, RenderEventSink } from "./transports.js";
+import type {
+  DeliverySource,
+  RenderEventSink,
+  AgentMessage,
+} from "./transports.js";
 import type {
   ChannelIngressEnvelope,
   ChannelDeliveryScope,
+  EgressRoute,
   RenderFrame,
   RenderAccepted,
 } from "./contracts.js";
 import type { RealtimeGatewaySession } from "./realtime-gateway.js";
+import { mapDeliveryToEnvelope } from "./claim-mapping.js";
+import type { ClaimedDelivery } from "./claim-mapping.js";
+import { IntelligenceFileHistoryClient } from "./intelligence-file-history.js";
 
 /** The org/project/channel scope every realtime envelope carries. */
 export interface ChannelRealtimeScope extends ChannelDeliveryScope {}
@@ -80,6 +88,19 @@ export interface RealtimeGatewayTransportOptions {
   runtimeInstanceId: string;
   /** The joined Realtime Gateway session. */
   session: RealtimeGatewaySession;
+  /**
+   * Intelligence app-api HTTP base URL (e.g. `https://…/`). File bytes and
+   * thread history are HTTP-only — the gateway relays the render-event stream
+   * but never bytes/history — so the realtime path reaches these app-api REST
+   * endpoints directly. Provide it (with {@link apiKey}) to enable
+   * fetchFile/getHistory/uploadFile parity with the HTTP transport (OSS-476);
+   * omit it and those capabilities stay absent (each turn starts fresh, inbound
+   * files aren't fetched, outbound file posts are unavailable) exactly as before.
+   */
+  appApiBaseUrl?: string;
+  /** Project runtime API key (`cpk-…`) for the app-api file/history calls.
+   * Required alongside {@link appApiBaseUrl} to enable file/history. */
+  apiKey?: string;
   /** ISO timestamp source; injectable for deterministic tests. */
   now?: () => string;
   /**
@@ -162,6 +183,30 @@ export class RealtimeGatewayTransport
   private readonly deliveries = new Map<string, DeliveryState>();
   private onDelivery?: (env: ChannelIngressEnvelope) => Promise<void>;
 
+  /**
+   * File/history capabilities (OSS-476). Assigned only when the transport is
+   * configured with an app-api HTTP client (`appApiBaseUrl` + `apiKey`); left
+   * `undefined` otherwise so the adapter's optional-chaining degrades exactly
+   * as before (no history, no inbound file bytes, no outbound file post). These
+   * are HTTP-only — they never touch the gateway session.
+   */
+  readonly fetchFile?: (
+    handle: string,
+  ) => Promise<{ bytes: Uint8Array; mimeType?: string }>;
+  readonly getHistory?: (
+    replyTarget: EgressRoute,
+    limit: number,
+  ) => Promise<AgentMessage[]>;
+  readonly uploadFile?: (
+    deliveryId: string,
+    args: {
+      bytes: Uint8Array;
+      filename: string;
+      title?: string;
+      altText?: string;
+    },
+  ) => Promise<{ handle: string }>;
+
   constructor(config: RealtimeGatewayTransportOptions) {
     assertValidChannelRealtimeScope(config.scope);
     this.scope = config.scope;
@@ -171,6 +216,20 @@ export class RealtimeGatewayTransport
     this.log = config.log;
     this.deliveryTimeoutMs =
       config.deliveryTimeoutMs ?? DEFAULT_DELIVERY_TIMEOUT_MS;
+    // File/history parity is HTTP-only; wire the shared client (identical to
+    // the HTTP transport's) when app-api coordinates are supplied.
+    if (config.appApiBaseUrl && config.apiKey) {
+      const fileHistory = new IntelligenceFileHistoryClient({
+        baseUrl: config.appApiBaseUrl,
+        apiKey: config.apiKey,
+        log: config.log,
+      });
+      this.fetchFile = (handle) => fileHistory.fetchFile(handle);
+      this.getHistory = (replyTarget, limit) =>
+        fileHistory.getHistory(replyTarget, limit);
+      this.uploadFile = (deliveryId, args) =>
+        fileHistory.uploadFile(deliveryId, args);
+    }
   }
 
   async start(
@@ -235,11 +294,14 @@ export class RealtimeGatewayTransport
    * stashes for later complete/fail intents. Returns `undefined` (delivery
    * dropped, logged via {@link RealtimeGatewayTransportOptions.log}) when the turn
    * identity is missing/unmodeled or the delivery carries no `leaseToken` (a
-   * fenced intent can't be built without it). V1 assumes every leased delivery
-   * is a text turn and does not discriminate on `input.kind` — non-text kinds
-   * (command/interaction/reaction) are not yet modeled on the realtime path
-   * and will be mis-handled (coerced into a text turn) until they are
-   * (tracked for the event-parity follow-up).
+   * fenced intent can't be built without it). The envelope itself is built by
+   * the shared {@link mapDeliveryToEnvelope} — the SAME mapper the HTTP
+   * transport uses — so the realtime path has full parity (OSS-476): it
+   * discriminates on `input.kind` (turn/command/reaction/interaction), derives
+   * a thread-stable `conversationKey`, and threads the provider `actor` through
+   * as `env.user`. A malformed/unmodeled delivery (bad reply-target adapter,
+   * unknown input kind) throws in the mapper and is dropped+logged here rather
+   * than crashing the delivery handler (fail-closed).
    */
   private toIngressEnvelope(payload: unknown):
     | {
@@ -304,23 +366,28 @@ export class RealtimeGatewayTransport
       ...(channelId !== undefined ? { channelId } : {}),
       channelName: String(channel?.name ?? this.scope.channelName),
     };
-    return {
-      scope,
-      leaseToken,
-      env: {
-        kind: "turn",
-        deliveryId: String(delivery.id),
-        eventId: String(turn.eventId),
-        turnId: String(turn.id),
-        // This product-level field names the Channel; bot core attaches the
-        // adapter directly to the framework Channel named by `createChannel({ name })`.
-        channelName: scope.channelName,
-        platform: String(delivery.adapter ?? "slack"),
-        conversationKey: String(turn.id),
-        route: turn.replyTarget,
-        text: turn.input?.text ?? "",
-      },
-    };
+    // Build the ingress envelope via the shared claim mapper (parity with the
+    // HTTP transport). The scope's channel name/adapter fallbacks are folded in
+    // so the mapper sees a fully-resolved delivery; the mapper throws on an
+    // unmodeled reply-target adapter or input kind, so drop+log on failure.
+    try {
+      const claimed: ClaimedDelivery = {
+        id: String(delivery.id),
+        organizationId: organizationId ?? "",
+        projectId: scope.projectId,
+        channel: { id: channelId ?? "", name: scope.channelName },
+        adapter: String(delivery.adapter ?? "slack"),
+        leaseToken,
+        turn: delivery.turn as ClaimedDelivery["turn"],
+      };
+      return { scope, leaseToken, env: mapDeliveryToEnvelope(claimed) };
+    } catch (err) {
+      this.log?.(
+        "realtime gateway delivery dropped: could not map claim to ingress envelope (unmodeled reply-target adapter or input kind?)",
+        { deliveryId: delivery.id, err },
+      );
+      return undefined;
+    }
   }
 
   async push(frame: RenderFrame): Promise<RenderAccepted> {

--- a/packages/channels-intelligence/src/realtime-gateway-transport.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-transport.ts
@@ -206,6 +206,10 @@ export class RealtimeGatewayTransport
   private onDelivery?: (env: ChannelIngressEnvelope) => Promise<void>;
   /** Tail of the serial delivery-processing chain — see {@link start}. */
   private processing: Promise<void> = Promise.resolve();
+  /** Set by {@link stop}; gates {@link handleDeliveryAvailable} so no new
+   * delivery is processed after teardown (the session exposes no `off`, so the
+   * DELIVERY_AVAILABLE listener cannot be detached). */
+  private stopped = false;
 
   /**
    * File/history capabilities (OSS-476). Assigned only when the transport is
@@ -285,6 +289,12 @@ export class RealtimeGatewayTransport
   }
 
   private async handleDeliveryAvailable(payload: unknown): Promise<void> {
+    // Stop consuming once torn down. The DELIVERY_AVAILABLE listener can't be
+    // detached (the session has no `off`), so this guard is how stop() halts
+    // intake — otherwise a delivery arriving after stop() (the caller-owned
+    // session in `startChannelsWithGatewaySession` stays connected) would spin
+    // up a fresh turn on a dead adapter.
+    if (this.stopped) return;
     let claimed:
       | {
           env: ChannelIngressEnvelope;
@@ -626,12 +636,25 @@ export class RealtimeGatewayTransport
         ...(retryable ? { deliveryStatus: "retry_wait" } : {}),
         ...(lastAccepted ? { lastAccepted } : {}),
         failedAt: this.now(),
-        error: { code: "runtime_error", message: reason, retryable },
+        // Bound the reason (parity with HttpDeliverySource.nack) so a long
+        // error/stack isn't sent verbatim over the gateway socket.
+        error: {
+          code: "runtime_error",
+          message: (reason || "runtime error").slice(0, 500),
+          retryable,
+        },
       },
     });
   }
 
   async stop(): Promise<void> {
+    // Halt new intake (the guard in handleDeliveryAvailable), then DRAIN the
+    // in-flight delivery before clearing state. Without the drain, a turn that
+    // settles after `deliveries.clear()` finds no DeliveryState and its
+    // ack/nack silently no-ops — the terminal signal is lost and the delivery
+    // redelivers. Mirrors HttpDeliverySource.stop() (running=false + await loop).
+    this.stopped = true;
+    await this.processing.catch(() => {});
     this.deliveries.clear();
   }
 }

--- a/packages/channels-intelligence/src/realtime-gateway-transport.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-transport.ts
@@ -567,7 +567,13 @@ export class RealtimeGatewayTransport
       // that posts nothing) has no valid completion signal under the frozen
       // contract (acceptedThrough requires >=1), so it redelivers until
       // max_attempts. A terminal "completed-empty" signal needs app-api
-      // coordination — tracked in OSS-491, not fixable SDK-side here.
+      // coordination — tracked in OSS-491, not fixable SDK-side here. Log it so
+      // the resulting redelivery pile-up is diagnosable (every other drop path
+      // in this transport logs).
+      this.log?.(
+        "realtime gateway ack: empty turn (no accepted frames) — no completion sent; will redeliver until max_attempts (OSS-491)",
+        { deliveryId },
+      );
       return;
     }
     await this.session.push(COMPLETE_REQUESTED, {

--- a/packages/channels-intelligence/src/realtime-gateway-transport.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-transport.ts
@@ -286,7 +286,11 @@ export class RealtimeGatewayTransport
 
   private async handleDeliveryAvailable(payload: unknown): Promise<void> {
     let claimed:
-      | { env: ChannelIngressEnvelope; scope: ChannelDeliveryScope; leaseToken: string }
+      | {
+          env: ChannelIngressEnvelope;
+          scope: ChannelDeliveryScope;
+          leaseToken: string;
+        }
       | undefined;
     try {
       claimed = this.toIngressEnvelope(payload);
@@ -307,11 +311,14 @@ export class RealtimeGatewayTransport
         );
         await this.nack(err.deliveryId, err.message, false).catch(
           (nackErr: unknown) =>
-            this.log?.("realtime gateway nack after unmappable delivery failed", {
-              deliveryId: err.deliveryId,
-              error:
-                nackErr instanceof Error ? nackErr.message : String(nackErr),
-            }),
+            this.log?.(
+              "realtime gateway nack after unmappable delivery failed",
+              {
+                deliveryId: err.deliveryId,
+                error:
+                  nackErr instanceof Error ? nackErr.message : String(nackErr),
+              },
+            ),
         );
         return;
       }

--- a/packages/channels-intelligence/src/realtime-gateway-transport.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-transport.ts
@@ -166,6 +166,28 @@ interface DeliveryState {
 }
 
 /**
+ * Thrown internally when a delivery has a valid lease + turn identity but its
+ * claim cannot be mapped to an ingress envelope (unmodeled reply-target adapter
+ * / unknown input kind). Carries the fencing fields so the delivery can be
+ * failed NON-retryably (dead-lettered) instead of dropped into an indefinite
+ * re-lease loop — the exact poison-payload failure mode the HTTP transport
+ * guards against with a non-retryable nack.
+ */
+class PoisonDeliveryError extends Error {
+  constructor(
+    readonly deliveryId: string,
+    readonly leaseToken: string,
+    readonly turnId: string,
+    readonly scope: ChannelDeliveryScope,
+    reason: string,
+    options?: { cause?: unknown },
+  ) {
+    super(reason, options);
+    this.name = "PoisonDeliveryError";
+  }
+}
+
+/**
  * Realtime Gateway transport implementing both the inbound {@link DeliverySource}
  * and the streaming {@link RenderEventSink}. `ack` maps to the completion
  * INTENT (`complete_requested`) and `nack` to `fail` — the SDK is never the
@@ -182,6 +204,8 @@ export class RealtimeGatewayTransport
   private readonly deliveryTimeoutMs: number;
   private readonly deliveries = new Map<string, DeliveryState>();
   private onDelivery?: (env: ChannelIngressEnvelope) => Promise<void>;
+  /** Tail of the serial delivery-processing chain — see {@link start}. */
+  private processing: Promise<void> = Promise.resolve();
 
   /**
    * File/history capabilities (OSS-476). Assigned only when the transport is
@@ -237,22 +261,62 @@ export class RealtimeGatewayTransport
   ): Promise<void> {
     this.onDelivery = onDelivery;
     this.session.on(DELIVERY_AVAILABLE, (payload) => {
-      // Error-boundary the dispatch: without a `.catch` an onDelivery rejection
-      // (or a parse/setup throw before the delivery is registered) becomes an
-      // unhandled promise rejection and the delivery is silently dropped. The
-      // per-turn failure/timeout path inside handleDeliveryAvailable nacks;
-      // this outer catch is the safety net for anything it can't (parse/setup
-      // errors that happen before a delivery id exists to nack).
-      this.handleDeliveryAvailable(payload).catch((err: unknown) => {
-        this.log?.("realtime gateway delivery dispatch failed", {
-          error: err instanceof Error ? err.message : String(err),
+      // Process deliveries SERIALLY (one at a time), matching the HTTP
+      // transport's single-delivery runLoop. Concurrent handling would let an
+      // at-least-once redelivery of an in-flight turnId reset the shared
+      // per-turn `seq` counter mid-run — corrupting egress operation ids /
+      // render idempotency keys (`${turnId}:${slot}:${seq}`) — and run two turns
+      // of the same conversation against one agent/session simultaneously.
+      //
+      // Each link is error-boundaried so one failed delivery never poisons the
+      // chain (the `.catch` keeps `this.processing` resolved for the next
+      // delivery): without it, an onDelivery rejection or a pre-registration
+      // parse/setup throw would surface as an unhandled rejection and stall the
+      // queue. The per-turn failure/timeout and poison paths inside
+      // handleDeliveryAvailable nack; this outer catch is the last-resort net.
+      this.processing = this.processing
+        .then(() => this.handleDeliveryAvailable(payload))
+        .catch((err: unknown) => {
+          this.log?.("realtime gateway delivery dispatch failed", {
+            error: err instanceof Error ? err.message : String(err),
+          });
         });
-      });
     });
   }
 
   private async handleDeliveryAvailable(payload: unknown): Promise<void> {
-    const claimed = this.toIngressEnvelope(payload);
+    let claimed:
+      | { env: ChannelIngressEnvelope; scope: ChannelDeliveryScope; leaseToken: string }
+      | undefined;
+    try {
+      claimed = this.toIngressEnvelope(payload);
+    } catch (err) {
+      if (err instanceof PoisonDeliveryError) {
+        // Unmappable delivery with a valid lease: register minimal state and
+        // fail it NON-retryably so app-api dead-letters it instead of re-leasing
+        // the identical poison payload forever (parity with the HTTP path).
+        this.deliveries.set(err.deliveryId, {
+          turnId: err.turnId,
+          leaseToken: err.leaseToken,
+          scope: err.scope,
+          accepted: new Map(),
+        });
+        this.log?.(
+          "realtime gateway delivery unmappable; failing non-retryable (dead-letter)",
+          { deliveryId: err.deliveryId, error: err.message },
+        );
+        await this.nack(err.deliveryId, err.message, false).catch(
+          (nackErr: unknown) =>
+            this.log?.("realtime gateway nack after unmappable delivery failed", {
+              deliveryId: err.deliveryId,
+              error:
+                nackErr instanceof Error ? nackErr.message : String(nackErr),
+            }),
+        );
+        return;
+      }
+      throw err;
+    }
     if (!claimed) return;
     const { env, scope, leaseToken } = claimed;
     this.deliveries.set(env.deliveryId, {
@@ -382,11 +446,18 @@ export class RealtimeGatewayTransport
       };
       return { scope, leaseToken, env: mapDeliveryToEnvelope(claimed) };
     } catch (err) {
-      this.log?.(
-        "realtime gateway delivery dropped: could not map claim to ingress envelope (unmodeled reply-target adapter or input kind?)",
-        { deliveryId: delivery.id, err },
+      // A valid lease + turn identity but an unmappable claim (unmodeled
+      // reply-target adapter / unknown input kind) is a POISON payload: dropping
+      // it (return undefined) would leak the lease and re-lease the identical
+      // payload forever. Surface it so the caller fails it non-retryably.
+      throw new PoisonDeliveryError(
+        String(delivery.id),
+        leaseToken,
+        String(turn.id),
+        scope,
+        `could not map claim to ingress envelope (unmodeled reply-target adapter or input kind?): ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
       );
-      return undefined;
     }
   }
 
@@ -461,14 +532,25 @@ export class RealtimeGatewayTransport
   async ack(deliveryId: string): Promise<void> {
     const state = this.deliveries.get(deliveryId);
     if (!state) return;
+    // Claim the terminal signal BEFORE the wire call, mirroring the HTTP
+    // transport's delete-before-POST. A turn that times out (handleDeliveryAvailable
+    // nacks) while its dispatch keeps running in the background will call ack()
+    // here; deleting first guarantees whichever of ack/nack runs first wins and
+    // the loser no-ops on missing state — exactly one of complete_requested XOR
+    // fail reaches app-api for a given delivery.
     const acceptedThrough = Array.from(state.accepted.entries()).map(
       ([slot, seq]) => ({ turnId: state.turnId, slot, seq }),
     );
+    this.deliveries.delete(deliveryId);
     if (acceptedThrough.length === 0) {
       // Nothing was accepted (e.g. an empty turn). Without an accepted frame
       // there is nothing to complete; let the lease lapse / redeliver instead
       // of sending an invalid (empty acceptedThrough) intent.
-      this.deliveries.delete(deliveryId);
+      // NOTE (OSS-491): a legitimately empty turn (a reaction/command handler
+      // that posts nothing) has no valid completion signal under the frozen
+      // contract (acceptedThrough requires >=1), so it redelivers until
+      // max_attempts. A terminal "completed-empty" signal needs app-api
+      // coordination — tracked in OSS-491, not fixable SDK-side here.
       return;
     }
     await this.session.push(COMPLETE_REQUESTED, {
@@ -486,10 +568,23 @@ export class RealtimeGatewayTransport
         requestedAt: this.now(),
       },
     });
-    this.deliveries.delete(deliveryId);
   }
 
-  async nack(deliveryId: string, reason: string): Promise<void> {
+  /**
+   * Send a `fail` intent for a delivery. `retryable` (default `true`) controls
+   * whether app-api re-leases: a transient turn failure is retryable; an
+   * unmappable/poison delivery is NOT (`retryable: false`) so app-api
+   * dead-letters it instead of redelivering the identical payload forever
+   * (mirrors {@link http-transports} `HttpDeliverySource.nack`). `error.retryable`
+   * is the authoritative signal (the HTTP path drives dead-lettering off it);
+   * the realtime-only `deliveryStatus: "retry_wait"` decoration is sent only on
+   * the retryable path so it never contradicts a non-retryable fail.
+   */
+  async nack(
+    deliveryId: string,
+    reason: string,
+    retryable = true,
+  ): Promise<void> {
     const state = this.deliveries.get(deliveryId);
     if (!state) {
       // No state → no leaseToken to build a fenced fail intent, so nothing can
@@ -510,6 +605,8 @@ export class RealtimeGatewayTransport
       }),
     );
     const lastAccepted = accepted[accepted.length - 1];
+    // Claim the terminal signal BEFORE the wire call (XOR with ack) — see ack().
+    this.deliveries.delete(deliveryId);
     await this.session.push(DELIVERY_FAIL, {
       type: DELIVERY_FAIL,
       occurredAt: this.now(),
@@ -519,13 +616,12 @@ export class RealtimeGatewayTransport
         turnId: state.turnId,
         runtimeInstanceId: this.runtimeInstanceId,
         leaseToken: state.leaseToken,
-        deliveryStatus: "retry_wait",
+        ...(retryable ? { deliveryStatus: "retry_wait" } : {}),
         ...(lastAccepted ? { lastAccepted } : {}),
         failedAt: this.now(),
-        error: { code: "runtime_error", message: reason, retryable: true },
+        error: { code: "runtime_error", message: reason, retryable },
       },
     });
-    this.deliveries.delete(deliveryId);
   }
 
   async stop(): Promise<void> {

--- a/packages/channels-intelligence/src/render-events.test.ts
+++ b/packages/channels-intelligence/src/render-events.test.ts
@@ -406,6 +406,135 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     expect(logs.some((m) => m.includes("turn failed/timed out"))).toBe(true);
   });
 
+  it("fails an UNMAPPABLE (poison) delivery non-retryable instead of dropping it into a re-lease loop", async () => {
+    const fake = makeFakeSession();
+    const logs: string[] = [];
+    const t = new RealtimeGatewayTransport({
+      ...cfg(fake.session),
+      log: (m) => logs.push(m),
+    });
+    let delivered = false;
+    await t.start(async () => {
+      delivered = true;
+    });
+    // Valid turn id/eventId/leaseToken, but an unmodeled reply-target adapter →
+    // mapDeliveryToEnvelope throws. Before the fix this logged + dropped (no
+    // fail intent), so app-api re-leased the identical poison payload forever.
+    fake.handlers.get("channel.delivery.available.v1")?.({
+      payload: {
+        delivery: {
+          id: "dlv_poison",
+          leaseToken: "lease_l1",
+          adapter: "slack",
+          channel: { id: "channel_1", name: "support" },
+          turn: {
+            id: "turn_t1",
+            eventId: "evt_1",
+            replyTarget: { adapter: "discord", guildId: "G1", channel: "C1" },
+            input: { kind: "text", text: "hi" },
+          },
+        },
+      },
+    });
+
+    await vi.waitFor(() =>
+      expect(fake.pushes.map((p) => p.event)).toContain(
+        "channel.delivery.fail.v1",
+      ),
+    );
+    expect(delivered).toBe(false); // never reached the handler
+    const fail = fake.pushes.find((p) => p.event === "channel.delivery.fail.v1")!
+      .payload as {
+      payload: { leaseToken?: string; error: { retryable: boolean } };
+    };
+    // Non-retryable → app-api dead-letters instead of re-leasing.
+    expect(fail.payload.error.retryable).toBe(false);
+    expect(fail.payload.leaseToken).toBe("lease_l1");
+  });
+
+  it("sends exactly one terminal signal per delivery (delete-before-push): a late ack after nack no-ops", async () => {
+    const fake = makeFakeSession();
+    const t = new RealtimeGatewayTransport(cfg(fake.session));
+    let delivered = false;
+    await t.start(async () => {
+      delivered = true;
+    });
+    fake.handlers.get("channel.delivery.available.v1")?.({
+      payload: {
+        delivery: {
+          id: "dlv_d1",
+          leaseToken: "lease_l1",
+          adapter: "slack",
+          channel: { id: "channel_1", name: "support" },
+          turn: {
+            id: "turn_t1",
+            eventId: "evt_1",
+            replyTarget: { adapter: "slack", teamId: "T1", channel: "C1" },
+            input: { kind: "text", text: "hi" },
+          },
+        },
+      },
+    });
+    await vi.waitFor(() => expect(delivered).toBe(true));
+
+    // Simulate the timeout race: the per-turn timeout nacks while the still-
+    // running dispatch later acks. delete-before-push guarantees the first wins
+    // and the second no-ops — exactly one terminal signal reaches app-api.
+    await t.nack("dlv_d1", "timed out", true);
+    await t.ack("dlv_d1"); // late ack — state already gone, must send nothing
+
+    const terminals = fake.pushes
+      .map((p) => p.event)
+      .filter(
+        (e) =>
+          e === "channel.delivery.fail.v1" ||
+          e === "channel.delivery.complete_requested.v1",
+      );
+    expect(terminals).toEqual(["channel.delivery.fail.v1"]);
+  });
+
+  it("processes deliveries serially — a second delivery waits for the first to finish", async () => {
+    const fake = makeFakeSession();
+    const t = new RealtimeGatewayTransport(cfg(fake.session));
+    const order: string[] = [];
+    let release1!: () => void;
+    const gate1 = new Promise<void>((r) => {
+      release1 = r;
+    });
+    await t.start(async (env) => {
+      order.push(`start:${env.deliveryId}`);
+      if (env.deliveryId === "d1") await gate1; // first hangs until released
+      order.push(`end:${env.deliveryId}`);
+    });
+    const fire = (id: string) =>
+      fake.handlers.get("channel.delivery.available.v1")?.({
+        payload: {
+          delivery: {
+            id,
+            leaseToken: "l",
+            adapter: "slack",
+            channel: { id: "channel_1", name: "support" },
+            turn: {
+              id: `turn_${id}`,
+              eventId: `e_${id}`,
+              replyTarget: { adapter: "slack", teamId: "T1", channel: "C1" },
+              input: { kind: "text", text: "hi" },
+            },
+          },
+        },
+      });
+    fire("d1");
+    fire("d2");
+
+    await vi.waitFor(() => expect(order).toContain("start:d1"));
+    // d2 must NOT have started while d1 is gated (serial, not concurrent).
+    expect(order).toEqual(["start:d1"]);
+    release1();
+    await vi.waitFor(() =>
+      expect(order).toEqual(["start:d1", "end:d1", "start:d2", "end:d2"]),
+    );
+  });
+
   it("drops a delivery with no leaseToken (never fires onDelivery) and logs it", async () => {
     const fake = makeFakeSession();
     const logs: string[] = [];

--- a/packages/channels-intelligence/src/render-events.test.ts
+++ b/packages/channels-intelligence/src/render-events.test.ts
@@ -536,6 +536,57 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     );
   });
 
+  it("stop() drains the in-flight turn before resolving and ignores deliveries after stop", async () => {
+    const fake = makeFakeSession();
+    const t = new RealtimeGatewayTransport(cfg(fake.session));
+    let started = false;
+    let calls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    await t.start(async () => {
+      calls++;
+      started = true;
+      await gate; // in-flight turn hangs until released
+    });
+    const fire = (id: string) =>
+      fake.handlers.get("channel.delivery.available.v1")?.({
+        payload: {
+          delivery: {
+            id,
+            leaseToken: `lease_${id}`,
+            adapter: "slack",
+            channel: { id: "channel_1", name: "support" },
+            turn: {
+              id: `turn_${id}`,
+              eventId: `e_${id}`,
+              replyTarget: { adapter: "slack", teamId: "T1", channel: "C1" },
+              input: { kind: "text", text: "hi" },
+            },
+          },
+        },
+      });
+    fire("d1");
+    await vi.waitFor(() => expect(started).toBe(true));
+
+    // stop() must not resolve until the gated in-flight turn drains.
+    let stopResolved = false;
+    const stopP = t.stop().then(() => {
+      stopResolved = true;
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(stopResolved).toBe(false);
+    release();
+    await stopP;
+    expect(stopResolved).toBe(true);
+
+    // A delivery arriving AFTER stop() is ignored by the guard, never processed.
+    fire("d2");
+    await new Promise((r) => setTimeout(r, 20));
+    expect(calls).toBe(1);
+  });
+
   it("drops a delivery with no leaseToken (never fires onDelivery) and logs it", async () => {
     const fake = makeFakeSession();
     const logs: string[] = [];

--- a/packages/channels-intelligence/src/render-events.test.ts
+++ b/packages/channels-intelligence/src/render-events.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./in-memory-transports.js";
 import { RealtimeGatewayTransport } from "./realtime-gateway-transport.js";
 import type { RealtimeGatewaySession } from "./realtime-gateway.js";
+import type { ChannelIngressEnvelope } from "./contracts.js";
 
 const target = {
   route: { channel: "C1", threadTs: "100.0" },
@@ -104,6 +105,29 @@ describe("run renderer — render-event streaming (OSS-402)", () => {
     expect(
       (postFrame?.event as { kind: "post"; content: unknown }).content,
     ).toEqual(card);
+  });
+
+  it("routes a delete through a delete render frame when a renderSink is wired (OSS-420)", async () => {
+    const renderSink = new InMemoryRenderEventSink();
+    const adapter = intelligenceAdapter({
+      source: new InMemoryDeliverySource(),
+      egress: new InMemoryEgressSink(),
+      renderSink,
+    });
+    const card = [
+      { type: "section", props: { children: "card" } },
+    ] as unknown as Parameters<typeof adapter.post>[1];
+
+    const ref = await adapter.post(target, card);
+    await adapter.delete(ref);
+
+    const deleteFrame = renderSink.frames.find(
+      (f) => f.event.kind === "delete",
+    );
+    expect(deleteFrame).toBeDefined();
+    expect((deleteFrame?.event as { kind: "delete"; ref: string }).ref).toBe(
+      ref.id,
+    );
   });
 
   it("falls back to a single post op on the EgressSink when no renderSink is wired", async () => {
@@ -283,6 +307,7 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
           turn: {
             id: "turn_t1",
             eventId: "evt_1",
+            replyTarget: { adapter: "slack", teamId: "T1", channel: "C1" },
             input: { kind: "text", text: "hi" },
           },
         },
@@ -325,6 +350,7 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
           turn: {
             id: "turn_t1",
             eventId: "evt_1",
+            replyTarget: { adapter: "slack", teamId: "T1", channel: "C1" },
             input: { kind: "text", text: "hi" },
           },
         },
@@ -363,6 +389,7 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
           turn: {
             id: "turn_t1",
             eventId: "evt_1",
+            replyTarget: { adapter: "slack", teamId: "T1", channel: "C1" },
             input: { kind: "text", text: "hi" },
           },
         },
@@ -400,6 +427,7 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
           turn: {
             id: "turn_t1",
             eventId: "evt_1",
+            replyTarget: { adapter: "slack", teamId: "T1", channel: "C1" },
             input: { kind: "text", text: "hi" },
           },
         },
@@ -444,6 +472,7 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
           turn: {
             id: "turn_t1",
             eventId: "evt_1",
+            replyTarget: { adapter: "slack", teamId: "T1", channel: "C1" },
             input: { kind: "text", text: "hi" },
           },
         },
@@ -475,5 +504,62 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
       expect(p.channelId).toBe("channel_OTHER");
       expect(p.channelName).toBe("other-channel");
     }
+  });
+
+  it("maps a non-text turn to its real kind, with actor→user and a thread-stable key (OSS-476)", async () => {
+    const fake = makeFakeSession();
+    const t = new RealtimeGatewayTransport(cfg(fake.session));
+    let env: ChannelIngressEnvelope | undefined;
+    await t.start(async (e) => {
+      env = e;
+    });
+    fake.handlers.get("channel.delivery.available.v1")?.({
+      payload: {
+        delivery: {
+          id: "dlv_d1",
+          leaseToken: "lease_l1",
+          adapter: "slack",
+          channel: { id: "channel_1", name: "support" },
+          turn: {
+            id: "turn_t1",
+            eventId: "evt_1",
+            replyTarget: {
+              adapter: "slack",
+              teamId: "T1",
+              channel: "C1",
+              threadTs: "1700.5",
+            },
+            actor: { externalUserId: "U42", displayName: "Grace" },
+            input: { kind: "command", command: "/deploy", text: "prod" },
+          },
+        },
+      },
+    });
+    await Promise.resolve();
+
+    expect(env?.kind).toBe("command");
+    expect(env).toMatchObject({ command: "/deploy", text: "prod" });
+    // Provider identity survived the realtime claim (previously dropped).
+    expect(env?.user).toEqual({ id: "U42", displayName: "Grace" });
+    // Thread-stable, not the per-turn id it used to be.
+    expect(env?.conversationKey).toBe("slack:T1:C1:thread:1700.5");
+  });
+
+  it("exposes file/history only when app-api HTTP coordinates are configured (OSS-476)", () => {
+    const fake = makeFakeSession();
+
+    const without = new RealtimeGatewayTransport(cfg(fake.session));
+    expect(without.fetchFile).toBeUndefined();
+    expect(without.getHistory).toBeUndefined();
+    expect(without.uploadFile).toBeUndefined();
+
+    const withHttp = new RealtimeGatewayTransport({
+      ...cfg(fake.session),
+      appApiBaseUrl: "https://app-api.example",
+      apiKey: "cpk-test",
+    });
+    expect(typeof withHttp.fetchFile).toBe("function");
+    expect(typeof withHttp.getHistory).toBe("function");
+    expect(typeof withHttp.uploadFile).toBe("function");
   });
 });

--- a/packages/channels-intelligence/src/render-events.test.ts
+++ b/packages/channels-intelligence/src/render-events.test.ts
@@ -443,8 +443,9 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
       ),
     );
     expect(delivered).toBe(false); // never reached the handler
-    const fail = fake.pushes.find((p) => p.event === "channel.delivery.fail.v1")!
-      .payload as {
+    const fail = fake.pushes.find(
+      (p) => p.event === "channel.delivery.fail.v1",
+    )!.payload as {
       payload: { leaseToken?: string; error: { retryable: boolean } };
     };
     // Non-retryable → app-api dead-letters instead of re-leasing.

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-activation-config.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-activation-config.test.ts
@@ -116,6 +116,7 @@ describe("deriveChannelActivationConfig", () => {
 
     expect(config).toEqual({
       wsUrl: intelligence.ɵgetRunnerWsUrl(),
+      apiUrl: intelligence.ɵgetApiUrl(),
       apiKey: intelligence.ɵgetRunnerAuthToken(),
       projectId: 42,
       channelName: "support",

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
@@ -726,6 +726,7 @@ describe("ChannelManager", () => {
 describe("defaultActivateChannel", () => {
   const config: ChannelActivationConfig = {
     wsUrl: "wss://runtime.example",
+    apiUrl: "https://runtime.example",
     apiKey: "cpk-42_short_long",
     projectId: 42,
     channelName: "support",
@@ -755,6 +756,10 @@ describe("defaultActivateChannel", () => {
       scope: { projectId: 42, channelName: "support" },
       runtimeInstanceId: "rti_x",
       adapter: "slack",
+      // The app-api HTTP base URL must reach the launcher so the transport wires
+      // file/history on the NORMAL managed path (OSS-476) — not only manual
+      // low-level callers.
+      appApiBaseUrl: "https://runtime.example",
     });
     // The scope carries ONLY projectId + channelName — never org/channelId.
     expect(opts.scope).not.toHaveProperty("organizationId");

--- a/packages/runtime/src/v2/runtime/core/channel-activation-config.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-activation-config.ts
@@ -24,6 +24,11 @@ export interface ChannelActivationConfig {
   wsUrl: string;
   /** Intelligence API key used to authenticate the runner connection. */
   apiKey: string;
+  /** Intelligence app-api HTTP base URL (`intelligence.ɵgetApiUrl()`), forwarded
+   * to the transport so the managed realtime path enables file/history parity
+   * (those are HTTP-only). Without it, Channels started by the normal runtime
+   * handler run with no history and no file support (OSS-476). */
+  apiUrl: string;
   /** Project id parsed from {@link apiKey}. */
   projectId: number;
   /** The Channel's declared name (`createChannel({ name })`). */
@@ -138,6 +143,7 @@ export function deriveChannelActivationConfig(args: {
   const channelName = channel.name;
 
   const wsUrl = intelligence.ɵgetRunnerWsUrl();
+  const apiUrl = intelligence.ɵgetApiUrl();
   const apiKey = intelligence.ɵgetRunnerAuthToken();
   const projectId = parseProjectIdFromApiKey(apiKey);
 
@@ -153,6 +159,7 @@ export function deriveChannelActivationConfig(args: {
 
   return {
     wsUrl,
+    apiUrl,
     apiKey,
     projectId,
     channelName,

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -174,6 +174,9 @@ export interface ChannelsIntelligenceModule {
       scope: { projectId: number; channelName: string };
       runtimeInstanceId: string;
       adapter?: string;
+      /** Intelligence app-api HTTP base URL, forwarded to the transport so the
+       * managed realtime path enables file/history parity (HTTP-only) — OSS-476. */
+      appApiBaseUrl?: string;
       /** Diagnostic sink forwarded to the launcher/transport so transport-level
        * drop diagnostics (e.g. a version-skew missing-leaseToken outage) are not
        * silent in the managed path. */
@@ -231,6 +234,10 @@ export async function defaultActivateChannel(
     scope: { projectId: config.projectId, channelName: config.channelName },
     runtimeInstanceId: config.runtimeInstanceId,
     adapter: config.adapter,
+    // Forward the app-api HTTP base URL so the transport wires file/history
+    // (HTTP-only) on the NORMAL managed path — without this, Channels started by
+    // the CopilotRuntime handler run with no history/file support (OSS-476).
+    appApiBaseUrl: config.apiUrl,
     // Forward the manager's diagnostic sink down to the launcher/transport so a
     // transport-level drop (e.g. a version-skew missing-leaseToken outage) is
     // observable in the managed path, not just activation-level events.


### PR DESCRIPTION
## What & why

The Realtime Gateway transport had drifted from the HTTP polling transport, so managed channels running over the gateway behaved differently from direct. This brings the realtime path to full parity.

Before, the realtime transport:
- built a **text-only** ingress envelope — commands/reactions/interactions were coerced into empty turns;
- keyed conversations **per-turn** (`conversationKey = turn.id`), so threaded follow-ups didn't share agent/session state;
- **dropped the provider actor** — `env.user` was never populated (on *both* transports, in fact);
- implemented **none** of `fetchFile`/`getHistory`/`uploadFile`, so the realtime path silently ran with no history and no file support;
- had **no `delete` render kind**, so `thread.delete` couldn't render over the gateway.

## Changes

- **`claim-mapping.ts` (new, shared):** extract the claim→ingress mapping — `ClaimedDelivery`, `conversationKeyFromReplyTarget`, `mapDeliveryToEnvelope` — into one module both transports import, so they can't drift again (drift *was* the bug). Adds the provider `actor` to the claim turn and maps it to `env.user` — fixing identity on **both** paths.
- **realtime transport:** builds the envelope via the shared mapper (real kind discrimination, thread-stable `conversationKey`, actor→user) instead of the inline text-only build. Fail-closed: an unmodeled reply-target/kind is dropped+logged, not crashed.
- **`intelligence-file-history.ts` (new, shared):** extract `fetchFile`/`getHistory`/`uploadFile` into `IntelligenceFileHistoryClient`. These are **HTTP-only** — the gateway relays the render-event stream but never file bytes or history. The realtime transport gains them when configured with `appApiBaseUrl` + `apiKey` (threaded through the launcher); without those, the methods stay `undefined` and the adapter degrades exactly as before.
- **`delete` render kind:** add `{ kind: "delete"; ref }` to `ChannelRenderEvent` (mirrors the frozen Intelligence contract) and route `thread.delete` through a render frame when a render sink is wired, like post/update/file.

## Tests

- `claim-mapping.test.ts`: actor→user, kind discrimination (command/reaction/interaction/text), thread-stable conversationKey (slack/teams), unmodeled-adapter throw.
- `render-events.test.ts`: realtime non-text kind + identity + thread-stable key; file/history capability toggling on config; a delete-render-frame test.
- Full suite (160) + `check-types` + `build` green.

## Companion

This is the CopilotKit SDK half of the managed-transport parity work; the Intelligence-side half (gateway `render_event/1` validator for file/delete, DB CHECK, Connector Outbox `chat.delete`, actor on the claim) landed separately. Together they close the direct-vs-managed parity matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)