### PR TITLE
fix(useAgent): add isReady flag and defensive subscribe() initialization

### DIFF
--- a/packages/react-core/src/v2/hooks/use-agent.tsx
+++ b/packages/react-core/src/v2/hooks/use-agent.tsx
@@ -251,7 +251,22 @@ export function useAgent({ agentId, updates, throttleMs }: UseAgentProps = {}) {
     agent.threadId = configThreadId;
   }, [agent, configThreadId, configHasExplicitThreadId]);
 
+  // Determine if the agent is fully initialized and safe for direct operations
+  // like agent.subscribe(). When the runtime is still connecting, the returned
+  // agent is a provisional ProxiedCopilotRuntimeAgent whose internal state may
+  // not be fully set up yet. Consumers can guard subscribe() calls with this flag.
+  // Defensive: ensure subscribers array exists so direct agent.subscribe() calls
+  // don't throw "Cannot read properties of undefined (reading 'subscribers')" (#5000).
+  if (!agent.subscribers) {
+    agent.subscribers = [];
+  }
+
+  const isReady =
+    !copilotkit.runtimeUrl ||
+    copilotkit.runtimeConnectionStatus === CopilotKitCoreRuntimeConnectionStatus.Connected;
+
   return {
     agent,
+    isReady,
   };
 }


### PR DESCRIPTION
## Summary

Fixes #5000

When `useAgent()` returns a provisional `ProxiedCopilotRuntimeAgent` (runtime still connecting), calling `agent.subscribe()` immediately throws:

```
TypeError: Cannot read properties of undefined (reading 'subscribers')
    at AbstractAgent.subscribe
```

The hook always returns an `AbstractAgent` instance (never null), so there is no signal to know when the agent is fully initialized and safe to call `subscribe()` on.

## Changes

**`packages/react-core/src/v2/hooks/use-agent.tsx`**:

1. **Defensive initialization**: Before returning, ensure `agent.subscribers` is an array. This prevents the `undefined` reference error when `AbstractAgent.subscribe()` tries to push to `this.subscribers`.

2. **Expose `isReady` flag**: Consumers can now guard `subscribe()` and other operations with the `isReady` boolean:

```tsx
const { agent, isReady } = useAgent({ agentId });

useEffect(() => {
  if (!isReady) return;
  const sub = agent.subscribe({
    onRunFinalized: (params) => console.log(params),
  });
  return () => sub.unsubscribe();
}, [agent, isReady]);
```

`isReady` is `true` when:
- No runtime URL is configured (agent is directly registered), OR
- `runtimeConnectionStatus === Connected`

## Root Cause Analysis

The `useAgent` hook returns a `ProxiedCopilotRuntimeAgent` with `runtimeMode: "pending"` while the runtime is still syncing. This provisional agent extends `HttpAgent` → `AbstractAgent`, but the internal `subscribers` array (a class field initialized in `AbstractAgent`) may not be properly set up when the agent is created through the provisional path. The `subscribe()` method then throws when accessing `this.subscribers.push()`.

## Testing

- The fix is purely defensive — it does not change any existing behavior when `subscribers` is already initialized
- The `isReady` flag is a new additive API that doesn't break existing consumers
- Existing `useAgent` tests should continue to pass (the return object now has an additional `isReady` property)

## Notes

- This is a minimal, non-breaking fix in CopilotKit's codebase. The underlying `AbstractAgent.subscribe()` lives in `@ag-ui/client` (external package) and was not modified.
- The `isReady` pattern follows the same convention used by other async hooks in the React ecosystem (e.g., `useAuth()`, `useConnection()`).