### PR TITLE
fix(release): unblock Channels umbrella publish

### DIFF
--- a/scripts/release/lib/channels-umbrella.test.ts
+++ b/scripts/release/lib/channels-umbrella.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   ADAPTERS,
+  createConsumerWorkspaceYaml,
   createConsumerManifest,
+  FAMILY,
   validatePackedManifests,
 } from "./channels-umbrella.js";
 import type { PackedManifest } from "./channels-umbrella.js";
@@ -123,5 +125,15 @@ describe("createConsumerManifest", () => {
         },
       },
     });
+  });
+});
+
+describe("createConsumerWorkspaceYaml", () => {
+  it("exempts every Channels package from the release-age gate", () => {
+    const workspace = createConsumerWorkspaceYaml();
+
+    for (const name of FAMILY) {
+      expect(workspace).toContain(`  - ${JSON.stringify(name)}\n`);
+    }
   });
 });

--- a/scripts/release/lib/channels-umbrella.ts
+++ b/scripts/release/lib/channels-umbrella.ts
@@ -34,6 +34,14 @@ export const FAMILY = [
   "@copilotkit/channels",
 ] as const;
 
+export function createConsumerWorkspaceYaml(): string {
+  return [
+    "minimumReleaseAgeExclude:",
+    ...FAMILY.map((name) => `  - ${JSON.stringify(name)}`),
+    "",
+  ].join("\n");
+}
+
 export function createConsumerManifest({
   umbrellaTarball,
   packageManager,

--- a/scripts/release/verify-channels-umbrella.ts
+++ b/scripts/release/verify-channels-umbrella.ts
@@ -11,6 +11,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   createConsumerManifest,
+  createConsumerWorkspaceYaml,
   FAMILY,
   validatePackedManifests,
 } from "./lib/channels-umbrella.js";
@@ -196,6 +197,10 @@ function writeConsumer(
     );
   }
 
+  writeFileSync(
+    join(consumerDir, "pnpm-workspace.yaml"),
+    createConsumerWorkspaceYaml(),
+  );
   writeFileSync(
     join(consumerDir, "package.json"),
     `${JSON.stringify(


### PR DESCRIPTION
## Problem

The Channels v0.2.0 release publishes its dependency packages, then fails before publishing the umbrella package because pnpm rejects the freshly published dependencies under the 24-hour minimum release age policy.

## Why

The registry-backed verifier installs the packed umbrella in an isolated temporary consumer without carrying a Channels-family release-age exemption into that consumer.

## Fix

Generate a pnpm workspace config for the isolated consumer that exempts every Channels package while retaining the maturity gate for unrelated dependencies. Add regression coverage for the complete family. Verified with all 109 release-script tests, the registry-backed Channels verifier, explicit lint/typecheck/format checks, and the full Nx package build.