### PR TITLE
fix(shell-docs): preserve trusted MDX expressions

### DIFF
--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -51,6 +51,7 @@ import {
   parseFrontendRoutePath,
 } from "@/lib/frontend-options";
 import { transformerMeta } from "@/lib/rehype-code-meta";
+import { createTrustedMdxRemoteOptions } from "@/lib/trusted-mdx-options";
 import {
   CONTENT_DIR,
   buildFrameworkNav,
@@ -890,7 +891,7 @@ async function FrameworkRootPage({
                 />
               ),
             },
-            options: {
+            options: createTrustedMdxRemoteOptions({
               mdxOptions: {
                 remarkPlugins: [remarkGfm],
                 // Fumadocs's Shiki-based `rehypeCode`; our
@@ -911,7 +912,7 @@ async function FrameworkRootPage({
                   ],
                 ],
               },
-            },
+            }),
           });
         } catch (err) {
           // Logged + swallowed: FrameworkOverview falls back to the

--- a/showcase/shell-docs/src/app/ag-ui/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/ag-ui/[[...slug]]/page.tsx
@@ -18,6 +18,7 @@ import { MdxCodeBlock } from "@/components/mdx-code-block";
 import { docsComponents } from "@/lib/mdx-registry";
 import { stripLeadingImports } from "@/lib/docs-render";
 import { transformerMeta } from "@/lib/rehype-code-meta";
+import { createTrustedMdxRemoteOptions } from "@/lib/trusted-mdx-options";
 import { resolveWithinDir, safeReadFileSync } from "@/lib/safe-fs";
 import { buildDocMetadata } from "@/lib/seo-metadata";
 
@@ -564,7 +565,7 @@ export default async function AgUiDocPage({
             <MDXRemote
               source={content}
               components={components}
-              options={{
+              options={createTrustedMdxRemoteOptions({
                 mdxOptions: {
                   remarkPlugins: [remarkGfm],
                   rehypePlugins: [
@@ -580,7 +581,7 @@ export default async function AgUiDocPage({
                     ],
                   ],
                 },
-              }}
+              })}
             />
           </DocsBody>
         </div>

--- a/showcase/shell-docs/src/app/reference/[...slug]/page.tsx
+++ b/showcase/shell-docs/src/app/reference/[...slug]/page.tsx
@@ -14,6 +14,7 @@ import {
 import { PropertyReference } from "@/components/property-reference";
 import { MdxCodeBlock } from "@/components/mdx-code-block";
 import { transformerMeta } from "@/lib/rehype-code-meta";
+import { createTrustedMdxRemoteOptions } from "@/lib/trusted-mdx-options";
 import {
   Callout,
   Cards,
@@ -239,7 +240,7 @@ export default async function ReferenceSlugPage({
             <MDXRemote
               source={cleanedContent}
               components={mdxComponents}
-              options={{
+              options={createTrustedMdxRemoteOptions({
                 mdxOptions: {
                   remarkPlugins: [remarkGfm],
                   rehypePlugins: [
@@ -255,7 +256,7 @@ export default async function ReferenceSlugPage({
                     ],
                   ],
                 },
-              }}
+              })}
             />
           </DocsBody>
         </div>

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -40,6 +40,7 @@ import { FrameworkSetup } from "@/lib/setup-concept";
 import { docsComponents } from "@/lib/mdx-registry";
 import { resolveDocsHref } from "@/lib/docs-link-rewrite";
 import { transformerMeta } from "@/lib/rehype-code-meta";
+import { createTrustedMdxRemoteOptions } from "@/lib/trusted-mdx-options";
 import { getIntegration, getTabDefault } from "@/lib/registry";
 import type { NavNode } from "@/lib/docs-render";
 import { navTreeToPageTree } from "@/lib/page-tree-bridge";
@@ -476,7 +477,7 @@ export async function DocsPageView({
                           </Link>
                         ),
                       }}
-                      options={{
+                      options={createTrustedMdxRemoteOptions({
                         mdxOptions: {
                           remarkPlugins: [remarkGfm],
                           // Use Fumadocs's Shiki-based `rehypeCode` for
@@ -500,7 +501,7 @@ export async function DocsPageView({
                             ],
                           ],
                         },
-                      }}
+                      })}
                     />
                   </DocsBody>
                 );

--- a/showcase/shell-docs/src/lib/__tests__/trusted-mdx-options.test.tsx
+++ b/showcase/shell-docs/src/lib/__tests__/trusted-mdx-options.test.tsx
@@ -1,0 +1,45 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MDXRemote } from "next-mdx-remote/rsc";
+import { describe, expect, it } from "vitest";
+import { createTrustedMdxRemoteOptions } from "../trusted-mdx-options";
+
+describe("createTrustedMdxRemoteOptions", () => {
+  it("preserves trusted MDX expression props for IframeSwitcher snippets", async () => {
+    const element = await MDXRemote({
+      source: `
+<IframeSwitcher
+  exampleUrl={\`https://feature-viewer.copilotkit.ai/\${props.framework || "langgraph"}/generative-ui/tool-rendering\`}
+  codeUrl={\`https://github.com/CopilotKit/CopilotKit/tree/main/examples/\${props.framework || "langgraph"}\`}
+/>
+`,
+      components: {
+        IframeSwitcher: ({
+          exampleUrl,
+          codeUrl,
+        }: {
+          exampleUrl?: string;
+          codeUrl?: string;
+        }) => <div data-example-url={exampleUrl} data-code-url={codeUrl} />,
+      },
+      options: createTrustedMdxRemoteOptions({
+        mdxOptions: {},
+      }),
+    });
+
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain(
+      'data-example-url="https://feature-viewer.copilotkit.ai/langgraph/generative-ui/tool-rendering"',
+    );
+    expect(html).toContain(
+      'data-code-url="https://github.com/CopilotKit/CopilotKit/tree/main/examples/langgraph"',
+    );
+  });
+
+  it("keeps dangerous expression filtering enabled", () => {
+    expect(createTrustedMdxRemoteOptions({ mdxOptions: {} })).toMatchObject({
+      blockJS: false,
+      blockDangerousJS: true,
+    });
+  });
+});

--- a/showcase/shell-docs/src/lib/mdx-registry-loader.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry-loader.tsx
@@ -30,6 +30,7 @@ import {
   rehypeCodeDefaultOptions,
 } from "fumadocs-core/mdx-plugins";
 import { transformerMeta } from "./rehype-code-meta";
+import { createTrustedMdxRemoteOptions } from "./trusted-mdx-options";
 import { inlineSnippets, convertTablesInJSX } from "./docs-render";
 import { resolveWithinDir } from "./safe-fs";
 
@@ -130,7 +131,7 @@ export async function PartialLoader({
       components={
         components as React.ComponentProps<typeof MDXRemote>["components"]
       }
-      options={{
+      options={createTrustedMdxRemoteOptions({
         scope,
         mdxOptions: {
           remarkPlugins: [remarkGfm],
@@ -147,7 +148,7 @@ export async function PartialLoader({
             ],
           ],
         },
-      }}
+      })}
     />
   );
 }

--- a/showcase/shell-docs/src/lib/setup-concept.tsx
+++ b/showcase/shell-docs/src/lib/setup-concept.tsx
@@ -15,6 +15,7 @@ import {
 } from "fumadocs-core/mdx-plugins";
 import { docsComponents } from "@/lib/mdx-registry";
 import { transformerMeta } from "@/lib/rehype-code-meta";
+import { createTrustedMdxRemoteOptions } from "@/lib/trusted-mdx-options";
 import { MdxCodeBlock } from "@/components/mdx-code-block";
 import { resolveBundledSetupConcept } from "@/lib/setup-content";
 import type { SetupContentBundle } from "@/lib/setup-content";
@@ -56,7 +57,7 @@ export async function FrameworkSetup({
         ...docsComponents,
         pre: MdxCodeBlock,
       },
-      options: {
+      options: createTrustedMdxRemoteOptions({
         mdxOptions: {
           remarkPlugins: [remarkGfm],
           rehypePlugins: [
@@ -72,7 +73,7 @@ export async function FrameworkSetup({
             ],
           ],
         },
-      },
+      }),
     });
   } catch (err) {
     console.error(

--- a/showcase/shell-docs/src/lib/trusted-mdx-options.ts
+++ b/showcase/shell-docs/src/lib/trusted-mdx-options.ts
@@ -1,0 +1,13 @@
+import type { MDXRemoteProps } from "next-mdx-remote/rsc";
+
+type MdxRemoteOptions = NonNullable<MDXRemoteProps["options"]>;
+
+export function createTrustedMdxRemoteOptions(
+  options: MdxRemoteOptions,
+): MdxRemoteOptions {
+  return {
+    ...options,
+    blockJS: false,
+    blockDangerousJS: true,
+  };
+}


### PR DESCRIPTION
## Summary
- allow trusted shell-docs MDX renders to preserve JSX expression props while keeping dangerous-expression filtering enabled
- share the trusted MDX options across docs, framework, reference, AG-UI, setup, and partial render paths
- add a regression test covering IframeSwitcher template-literal props

## Verification
- npm run test -- src/lib/__tests__/trusted-mdx-options.test.tsx
- npm run test -- src/lib/__tests__/docs-render.test.ts
- npm run typecheck