### PR TITLE
fix(research-canvas): terminate Python graph

### DIFF
--- a/examples/v1/research-canvas/agents/python/src/agent.py
+++ b/examples/v1/research-canvas/agents/python/src/agent.py
@@ -5,7 +5,7 @@ It defines the workflow graph and the entry point for the agent.
 
 import os
 
-from langgraph.graph import StateGraph
+from langgraph.graph import END, StateGraph
 
 from src.lib.chat import chat_node
 from src.lib.delete import delete_node, perform_delete_node
@@ -27,6 +27,7 @@ workflow.add_edge("download", "chat_node")
 workflow.add_edge("delete_node", "perform_delete_node")
 workflow.add_edge("perform_delete_node", "chat_node")
 workflow.add_edge("search_node", "download")
+workflow.add_edge("chat_node", END)
 
 # Conditionally use a checkpointer based on the environment
 # This allows compatibility with both LangGraph API and CopilotKit

--- a/examples/v1/research-canvas/agents/python/tests/test_graph_topology.py
+++ b/examples/v1/research-canvas/agents/python/tests/test_graph_topology.py
@@ -1,0 +1,37 @@
+import ast
+import unittest
+from pathlib import Path
+from typing import Optional
+
+
+AGENT_SOURCE = Path(__file__).resolve().parents[1] / "src" / "agent.py"
+
+
+def _literal_or_name(node: ast.AST) -> Optional[str]:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name):
+        return node.id
+    return None
+
+
+class GraphTopologyTest(unittest.TestCase):
+    def test_chat_node_has_declared_termination_edge(self) -> None:
+        tree = ast.parse(AGENT_SOURCE.read_text())
+        edges: set[tuple[Optional[str], Optional[str]]] = set()
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr != "add_edge" or len(node.args) < 2:
+                continue
+
+            edges.add((_literal_or_name(node.args[0]), _literal_or_name(node.args[1])))
+
+        self.assertIn(("chat_node", "END"), edges)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an explicit chat_node -> END edge to the research-canvas Python LangGraph workflow
- add a stdlib unittest topology regression that checks the termination edge is declared

## Verification
- python3 -m unittest discover examples/v1/research-canvas/agents/python/tests
- python3 -m py_compile examples/v1/research-canvas/agents/python/src/agent.py examples/v1/research-canvas/agents/python/tests/test_graph_topology.py