### PR TITLE
fix(research-canvas): route TypeScript tool calls

### DIFF
--- a/examples/v1/research-canvas/agents/typescript/package.json
+++ b/examples/v1/research-canvas/agents/typescript/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test tests/*.test.mjs"
   },
   "dependencies": {
     "@copilotkit/sdk-js": "workspace:*",

--- a/examples/v1/research-canvas/agents/typescript/src/agent.ts
+++ b/examples/v1/research-canvas/agents/typescript/src/agent.ts
@@ -36,31 +36,21 @@ export const graph = workflow.compile({
 
 function route(state: AgentState) {
   const messages = state.messages || [];
+  const lastMessage = messages[messages.length - 1];
 
-  if (
-    messages.length > 0 &&
-    messages[messages.length - 1].constructor.name === "AIMessageChunk"
-  ) {
-    const aiMessage = messages[messages.length - 1] as AIMessage;
+  if (lastMessage) {
+    const aiMessage = lastMessage as AIMessage;
+    const toolName = aiMessage.tool_calls?.[0]?.name;
 
-    if (
-      aiMessage.tool_calls &&
-      aiMessage.tool_calls.length > 0 &&
-      aiMessage.tool_calls[0].name === "Search"
-    ) {
+    if (toolName === "Search") {
       return "search_node";
-    } else if (
-      aiMessage.tool_calls &&
-      aiMessage.tool_calls.length > 0 &&
-      aiMessage.tool_calls[0].name === "DeleteResources"
-    ) {
+    } else if (toolName === "DeleteResources") {
       return "delete_node";
+    } else if (toolName) {
+      return "chat_node";
     }
   }
-  if (
-    messages.length > 0 &&
-    messages[messages.length - 1].constructor.name === "ToolMessage"
-  ) {
+  if (lastMessage?.constructor.name === "ToolMessage") {
     return "chat_node";
   }
   return END;

--- a/examples/v1/research-canvas/agents/typescript/tests/route.test.mjs
+++ b/examples/v1/research-canvas/agents/typescript/tests/route.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const agentSource = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "../src/agent.ts"),
+  "utf8",
+);
+
+test("route handles non-specialized tool calls without ending the graph", () => {
+  assert.match(agentSource, /const toolName = aiMessage\.tool_calls\?\.\[0\]\?\.name;/);
+  assert.match(agentSource, /if \(toolName === "Search"\)/);
+  assert.match(agentSource, /else if \(toolName === "DeleteResources"\)/);
+  assert.match(agentSource, /else if \(toolName\) \{\s*return "chat_node";\s*\}/);
+});
+
+test("route no longer depends on streamed AIMessageChunk constructor names", () => {
+  assert.doesNotMatch(agentSource, /AIMessageChunk/);
+});


### PR DESCRIPTION
## Summary
- route TypeScript research-canvas tool calls based on tool_calls instead of AIMessageChunk constructor names
- send non-specialized tool calls back to chat_node instead of ending the graph
- replace the placeholder test script with a Node static regression test for route behavior

## Verification
- npm test