### PR TITLE
fix(react-core): preserve code block newlines

### DIFF
--- a/packages/react-core/src/v2/styles/__tests__/streamdown-styles.test.ts
+++ b/packages/react-core/src/v2/styles/__tests__/streamdown-styles.test.ts
@@ -30,6 +30,15 @@ describe("Streamdown styles", () => {
     );
   });
 
+  it("preserves newlines in Streamdown code-block pre elements (#3330)", () => {
+    const normalized = globalsCss.replace(/\s+/g, " ");
+    const codeBlockPreRule = normalized.match(
+      /\[data-copilotkit\] div\[data-streamdown="code-block"\] > pre \{([^}]+)\}/,
+    )?.[1];
+
+    expect(codeBlockPreRule).toContain("cpk:whitespace-pre");
+  });
+
   it("ships scoped fallback styles for the table action controls row (#5775)", () => {
     // The controls row / buttons / popovers have no stable data-streamdown
     // attribute, so they are scoped structurally under the table wrapper.

--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -176,7 +176,7 @@
 }
 
 [data-copilotkit] div[data-streamdown="code-block"] > pre {
-  @apply cpk:mt-0 cpk:mb-0;
+  @apply cpk:mt-0 cpk:mb-0 cpk:whitespace-pre;
 }
 
 @layer components {


### PR DESCRIPTION
## Summary
- add cpk:whitespace-pre to Streamdown code-block pre elements
- add a source-string regression test for the scoped code-block pre rule

## Verification
- pnpm nx run @copilotkit/shared:build
- pnpm --filter @copilotkit/react-core exec vitest run src/v2/styles/__tests__/streamdown-styles.test.ts
- pnpm --filter @copilotkit/react-core run build:css