### PR TITLE
fix(showcase): offload sync LLM calls off showcase agent event loops (claude-sdk-python, ag2, llamaindex)

### DIFF
--- a/showcase/integrations/ag2/src/agents/beautiful_chat.py
+++ b/showcase/integrations/ag2/src/agents/beautiful_chat.py
@@ -26,6 +26,7 @@ runtime injects `generateSandboxedUi` on the frontend.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 from typing import Annotated
@@ -82,17 +83,13 @@ short sentence — let the visual do the talking.
 """
 
 
-async def generate_a2ui(
-    context: Annotated[
-        str, "Conversation context summary the secondary LLM should design UI from"
-    ],
-) -> str:
-    """Generate dynamic A2UI components based on the conversation.
+def _generate_a2ui(context: str) -> str:
+    """Blocking secondary-LLM round-trip for `generate_a2ui`.
 
-    Mirrors `a2ui_dynamic.py`: a secondary LLM is bound to the
-    `render_a2ui` tool with `tool_choice` forced, and the resulting
-    arguments are wrapped into an `a2ui_operations` container the
-    runtime A2UI middleware detects and forwards to the frontend.
+    Kept synchronous and offloaded via ``asyncio.to_thread`` from the async
+    tool wrapper below: the synchronous ``openai.OpenAI().chat.completions``
+    call would otherwise block the uvicorn asyncio event loop for the full
+    LLM round-trip, wedging the ``:8000`` ``/health`` endpoint under load.
     """
     client = openai.OpenAI()
     response = client.chat.completions.create(
@@ -123,6 +120,24 @@ async def generate_a2ui(
         return json.dumps(result)
 
     return json.dumps({"error": "LLM did not call render_a2ui"})
+
+
+async def generate_a2ui(
+    context: Annotated[
+        str, "Conversation context summary the secondary LLM should design UI from"
+    ],
+) -> str:
+    """Generate dynamic A2UI components based on the conversation.
+
+    Mirrors `a2ui_dynamic.py`: a secondary LLM is bound to the
+    `render_a2ui` tool with `tool_choice` forced, and the resulting
+    arguments are wrapped into an `a2ui_operations` container the
+    runtime A2UI middleware detects and forwards to the frontend.
+
+    The blocking LLM round-trip runs in ``_generate_a2ui`` and is offloaded
+    via ``asyncio.to_thread`` so it never blocks the event loop.
+    """
+    return await asyncio.to_thread(_generate_a2ui, context)
 
 
 agent = ConversableAgent(

--- a/showcase/integrations/claude-sdk-python/entrypoint.sh
+++ b/showcase/integrations/claude-sdk-python/entrypoint.sh
@@ -102,15 +102,13 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
       FAILS=$((FAILS + 1))
       echo "[watchdog] Agent health probe failed (count=$FAILS)"
       if [ $FAILS -ge 3 ]; then
-        WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
         echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
-        # LOUD alert before we kill. Never let a failed/absent webhook crash
-        # the watchdog — only attempt if the var is set, and swallow errors.
-        if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
-          curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
-            --data "{\"text\":\"[claude-sdk-python] env=${WEDGE_ENV} agent :8000 unresponsive ~90s — restarting (agent PID $AGENT_PID)\"}" \
-            "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
-        fi
+        # NOTE: no Slack alert on the :8000 agent branch. The agent event-loop
+        # wedge is self-healed silently by this kill-restart (the sync-LLM-on-
+        # the-loop root cause is fixed in src/agents/*, so a rare residual hiccup
+        # here should not page). The LOUD #oss-alerts page is kept ONLY on the
+        # public $PORT /api/health branch below, which is the surface real users
+        # and the Railway healthcheck hit.
         kill -9 $AGENT_PID 2>/dev/null || true
         break
       fi

--- a/showcase/integrations/claude-sdk-python/src/agents/a2ui_dynamic.py
+++ b/showcase/integrations/claude-sdk-python/src/agents/a2ui_dynamic.py
@@ -16,6 +16,7 @@ Mirrors the langgraph-python and ag2 references.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import traceback
@@ -284,7 +285,13 @@ async def run_a2ui_dynamic_agent(input_data: RunAgentInput) -> AsyncIterator[str
             if tc["name"] == "generate_a2ui":
                 ctx = tc["input"].get("context", "")
                 try:
-                    result_obj = _generate_a2ui(ctx, conversation_messages=messages)
+                    # Offload to a worker thread: _generate_a2ui runs a
+                    # synchronous anthropic.Anthropic() LLM round-trip, which
+                    # would otherwise block the uvicorn event loop and wedge the
+                    # :8000 /health endpoint under load.
+                    result_obj = await asyncio.to_thread(
+                        _generate_a2ui, ctx, conversation_messages=messages
+                    )
                     result_text = json.dumps(result_obj)
                 except Exception as exc:  # noqa: BLE001 - surface as tool result
                     result_text = json.dumps(

--- a/showcase/integrations/claude-sdk-python/src/agents/agent.py
+++ b/showcase/integrations/claude-sdk-python/src/agents/agent.py
@@ -7,6 +7,7 @@ All demo routes share this single agent instance served by agent_server.py.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import random
@@ -1352,8 +1353,17 @@ async def run_agent(
             if tc["name"] in frontend_tool_names:
                 has_frontend_tool = True
                 continue
-            result_text, new_state = _execute_tool(
-                tc["name"], tc["input"], state, conversation_messages=messages
+            # Offload to a worker thread: _execute_tool may run a synchronous
+            # anthropic.Anthropic() LLM round-trip (the generate_a2ui branch),
+            # which would otherwise block the uvicorn event loop and wedge the
+            # :8000 /health endpoint under load. asyncio.to_thread keeps the
+            # loop free to serve health probes and other concurrent requests.
+            result_text, new_state = await asyncio.to_thread(
+                _execute_tool,
+                tc["name"],
+                tc["input"],
+                state,
+                conversation_messages=messages,
             )
             if new_state is not None:
                 state = new_state

--- a/showcase/integrations/claude-sdk-python/src/agents/claude_agent_sdk_adapter.py
+++ b/showcase/integrations/claude-sdk-python/src/agents/claude_agent_sdk_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from collections.abc import AsyncIterator, Callable
 from typing import Any
@@ -149,7 +150,12 @@ def _make_sdk_tool(
     @sdk_tool(name, description, input_schema)
     async def sdk_tool_handler(args: dict[str, Any]):
         try:
-            result_text, next_state = execute_tool(
+            # Offload to a worker thread: execute_tool may run a synchronous
+            # anthropic.Anthropic() LLM round-trip (the generate_a2ui branch),
+            # which would otherwise block the uvicorn event loop and wedge the
+            # :8000 /health endpoint under load.
+            result_text, next_state = await asyncio.to_thread(
+                execute_tool,
                 name,
                 dict(args or {}),
                 get_state(),

--- a/showcase/integrations/llamaindex/src/agents/a2ui_dynamic.py
+++ b/showcase/integrations/llamaindex/src/agents/a2ui_dynamic.py
@@ -58,6 +58,7 @@ Both changes live entirely in this integration; no shared/`@ag-ui` package is
 touched.
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -312,21 +313,13 @@ def _make_a2ui_router(
     return router
 
 
-async def generate_a2ui(
-    context: Annotated[
-        str,
-        "Short description of what the UI should show; mirrors the last user "
-        "message so the secondary LLM has full context.",
-    ],
-) -> str:
-    """Generate dynamic A2UI components based on the conversation.
+def _generate_a2ui(context: str) -> str:
+    """Blocking secondary-LLM round-trip for `generate_a2ui`.
 
-    Invokes a secondary LLM bound to `_design_a2ui_surface` (tool_choice
-    forced) and returns the planner's `render_a2ui` args (surfaceId, catalogId,
-    components, data) as JSON. The workflow override
-    (`_A2UIRenderToolCallWorkflow.aggregate_tool_calls`) parses this result and
-    RE-EMITS it as a streamed `render_a2ui` tool-CALL that the A2UI middleware
-    watches and mounts the surface from.
+    Kept synchronous and offloaded via ``asyncio.to_thread`` from the async
+    tool wrapper below: the synchronous ``OpenAI().chat.completions`` call
+    would otherwise block the uvicorn asyncio event loop for the full LLM
+    round-trip, wedging the ``:8000`` ``/health`` endpoint under load.
     """
     from openai import OpenAI as OpenAIClient
 
@@ -391,6 +384,28 @@ async def generate_a2ui(
     # as a streamed `render_a2ui` tool-CALL (the middleware parses `components`
     # from the streamed args to mount the surface).
     return json.dumps(args)
+
+
+async def generate_a2ui(
+    context: Annotated[
+        str,
+        "Short description of what the UI should show; mirrors the last user "
+        "message so the secondary LLM has full context.",
+    ],
+) -> str:
+    """Generate dynamic A2UI components based on the conversation.
+
+    Invokes a secondary LLM bound to `_design_a2ui_surface` (tool_choice
+    forced) and returns the planner's `render_a2ui` args (surfaceId, catalogId,
+    components, data) as JSON. The workflow override
+    (`_A2UIRenderToolCallWorkflow.aggregate_tool_calls`) parses this result and
+    RE-EMITS it as a streamed `render_a2ui` tool-CALL that the A2UI middleware
+    watches and mounts the surface from.
+
+    The blocking LLM round-trip runs in ``_generate_a2ui`` and is offloaded
+    via ``asyncio.to_thread`` so it never blocks the event loop.
+    """
+    return await asyncio.to_thread(_generate_a2ui, context)
 
 
 SYSTEM_PROMPT = (

--- a/showcase/integrations/llamaindex/src/agents/agent.py
+++ b/showcase/integrations/llamaindex/src/agents/agent.py
@@ -14,6 +14,7 @@ hitl_in_chat_agent.py module docstring for details.
 """
 
 # @region[weather-tool-backend]
+import asyncio
 import json
 import os
 from typing import Annotated
@@ -140,13 +141,13 @@ async def search_flights(
     return json.dumps(result)
 
 
-async def generate_a2ui(
-    context: Annotated[str, "Conversation context to generate UI from."],
-) -> str:
-    """Generate dynamic A2UI components based on the conversation.
+def _generate_a2ui(context: str) -> str:
+    """Blocking secondary-LLM round-trip for `generate_a2ui`.
 
-    A secondary LLM designs the UI schema and data. The result is
-    returned as an a2ui_operations container for the middleware to detect.
+    Kept synchronous and offloaded via ``asyncio.to_thread`` from the async
+    tool wrapper below: the synchronous ``openai.OpenAI().chat.completions``
+    call would otherwise block the uvicorn asyncio event loop for the full
+    LLM round-trip, wedging the ``:8000`` ``/health`` endpoint under load.
     """
     from openai import OpenAI
 
@@ -189,6 +190,20 @@ async def generate_a2ui(
     args = json.loads(tool_call.function.arguments)
     result = build_a2ui_operations_from_tool_call(args)
     return json.dumps(result)
+
+
+async def generate_a2ui(
+    context: Annotated[str, "Conversation context to generate UI from."],
+) -> str:
+    """Generate dynamic A2UI components based on the conversation.
+
+    A secondary LLM designs the UI schema and data. The result is
+    returned as an a2ui_operations container for the middleware to detect.
+
+    The blocking LLM round-trip runs in ``_generate_a2ui`` and is offloaded
+    via ``asyncio.to_thread`` so it never blocks the event loop.
+    """
+    return await asyncio.to_thread(_generate_a2ui, context)
 
 
 _openai_kwargs = {}

--- a/showcase/tests/repro/async-wedge/README.md
+++ b/showcase/tests/repro/async-wedge/README.md
@@ -1,0 +1,87 @@
+# async-wedge — claude-sdk-python `:8000` event-loop wedge repro
+
+Faithful RED→GREEN reproduction of the pre-existing `claude-sdk-python` agent
+`:8000` wedge: a **synchronous** `anthropic.Anthropic()` LLM call invoked from
+inside an `async def` handler blocks the single uvicorn event loop for the full
+LLM round-trip, so `/health` cannot answer. Under load the watchdog counts 3
+consecutive `/health` failures (~90s) and kill-restarts the container.
+
+## The bug (production sites, all in `integrations/claude-sdk-python/`)
+
+- `src/agents/agent.py` — `_execute_tool` (`generate_a2ui` branch) builds
+  `anthropic.Anthropic()` and calls `client.messages.create()` synchronously.
+  `_execute_tool` is a sync callback invoked on the loop from two async callers:
+  `run_agent` (agentic loop) and the Claude-Agent-SDK MCP tool handler in
+  `claude_agent_sdk_adapter.py`.
+- `src/agents/a2ui_dynamic.py` — `_generate_a2ui` (same sync pattern), invoked
+  on the loop from the `run_a2ui_dynamic_agent` generator.
+
+## The fix
+
+`await asyncio.to_thread(...)` at every async call site (keeps the sync
+functions unchanged and fixes the whole tool-dispatch path uniformly):
+`agent.py` (run_agent call site), `claude_agent_sdk_adapter.py` (MCP handler),
+and `a2ui_dynamic.py` (secondary call site).
+
+## Topology
+
+```
+slow_anthropic.py  (separate process/loop)   <- REAL HTTP, SLOW_SECONDS latency,
+      ^ ANTHROPIC_BASE_URL / base_url            Anthropic-compatible responses
+      |
+server.py / prod_server.py  (single uvicorn event loop = the SUT)
+      RED   : sync anthropic.Anthropic().messages.create() ON the loop -> wedge
+      GREEN : await asyncio.to_thread(...)                             -> live
+```
+
+The LLM latency is a real HTTP round-trip to a local slow endpoint, so the
+**real** `anthropic` SDK `httpx` transport is exercised — not a bare
+`time.sleep` stand-in. (aimock is the mandated LLM mock, but it is a Docker
+fleet service; a hermetic local slow endpoint is the faithful equivalent for
+exercising the sync-client-on-the-loop blocking path.)
+
+## Files
+
+| File | Role |
+|------|------|
+| `slow_anthropic.py` | Anthropic-compatible mock; every response sleeps `SLOW_SECONDS`. Serves both `messages.create` (JSON) and `messages.stream` (SSE). |
+| `server.py` | Minimal replica. `FIXED=0` sync-on-loop (RED), `FIXED=1` `to_thread` (GREEN). |
+| `prod_server.py` | Drives the **real** production code. `MODE=generator` runs the whole `run_a2ui_dynamic_agent` generator; `MODE=direct` isolates the real `_generate_a2ui` (`FIXED` toggles the call shape). |
+| `run.sh` | Driver for `server.py`. `FIXED=0` asserts wedge≥1; `FIXED=1` asserts wedge==0. |
+| `run_prod.sh` | Driver for `prod_server.py`. `EXPECT=green` asserts wedge==0; `EXPECT=red` asserts wedge≥1. In `MODE=direct` the harness owns RED/GREEN via `FIXED` (deterministic mutation guard). |
+| `load.sh` | Fires `CONCURRENCY` concurrent `POST /generate`. |
+
+## Prerequisites
+
+A Python env with `anthropic==0.111.0`, `fastapi`, `uvicorn` (plus the full
+integration `requirements.txt` for `run_prod.sh`). The drivers auto-detect
+`integrations/claude-sdk-python/.venv-repro/bin/python`; override with `PY=`.
+
+```bash
+cd integrations/claude-sdk-python
+uv venv .venv-repro --python 3.12
+VIRTUAL_ENV="$PWD/.venv-repro" uv pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+cd showcase/tests/repro/async-wedge
+
+# Minimal replica
+FIXED=0 ./run.sh          # RED   — expect wedge≥1
+FIXED=1 ./run.sh          # GREEN — expect wedge==0
+
+# Real production code
+EXPECT=green MODE=generator ./run_prod.sh          # real generator, fix in source
+EXPECT=red   MODE=direct    ./run_prod.sh          # mutation guard: real fn sync-on-loop MUST wedge
+EXPECT=green MODE=direct    ./run_prod.sh          # real fn via to_thread MUST NOT wedge
+```
+
+Each driver exits non-zero if the observed outcome contradicts the expectation,
+so a false-GREEN cannot pass silently.
+
+## Tunables
+
+`SLOW_SECONDS` (default 3), `CONCURRENCY` (default 5), `PORT` (default 8000),
+`MOCK_PORT` (default 8099), `PY`.

--- a/showcase/tests/repro/async-wedge/README.md
+++ b/showcase/tests/repro/async-wedge/README.md
@@ -42,17 +42,17 @@ exercising the sync-client-on-the-loop blocking path.)
 
 ## Files
 
-| File                | Role                                                                                                                                                                                        |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `slow_anthropic.py` | Anthropic-compatible mock; every response sleeps `SLOW_SECONDS`. Serves both `messages.create` (JSON) and `messages.stream` (SSE).                                                          |
-| `server.py`         | Minimal replica. `FIXED=0` sync-on-loop (RED), `FIXED=1` `to_thread` (GREEN).                                                                                                               |
-| `prod_server.py`    | Drives the **real** production code. `MODE=generator` runs the whole `run_a2ui_dynamic_agent` generator; `MODE=direct` isolates the real `_generate_a2ui` (`FIXED` toggles the call shape). |
-| `run.sh`            | Driver for `server.py`. `FIXED=0` asserts wedge≥1; `FIXED=1` asserts wedge==0.                                                                                                              |
-| `run_prod.sh`       | Driver for `prod_server.py`. `EXPECT=green` asserts wedge==0; `EXPECT=red` asserts wedge≥1. In `MODE=direct` the harness owns RED/GREEN via `FIXED` (deterministic mutation guard).         |
-| `load.sh`           | Fires `CONCURRENCY` concurrent `POST /generate`.                                                                                                                                            |
-| `slow_openai.py`    | OpenAI-compatible mock; every `POST /v1/chat/completions` sleeps `SLOW_SECONDS` and returns a forced `render_a2ui` tool call. Sibling of `slow_anthropic.py` for the OpenAI-SDK wedge sites. |
+| File                    | Role                                                                                                                                                                                                      |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `slow_anthropic.py`     | Anthropic-compatible mock; every response sleeps `SLOW_SECONDS`. Serves both `messages.create` (JSON) and `messages.stream` (SSE).                                                                        |
+| `server.py`             | Minimal replica. `FIXED=0` sync-on-loop (RED), `FIXED=1` `to_thread` (GREEN).                                                                                                                             |
+| `prod_server.py`        | Drives the **real** production code. `MODE=generator` runs the whole `run_a2ui_dynamic_agent` generator; `MODE=direct` isolates the real `_generate_a2ui` (`FIXED` toggles the call shape).               |
+| `run.sh`                | Driver for `server.py`. `FIXED=0` asserts wedge≥1; `FIXED=1` asserts wedge==0.                                                                                                                            |
+| `run_prod.sh`           | Driver for `prod_server.py`. `EXPECT=green` asserts wedge==0; `EXPECT=red` asserts wedge≥1. In `MODE=direct` the harness owns RED/GREEN via `FIXED` (deterministic mutation guard).                       |
+| `load.sh`               | Fires `CONCURRENCY` concurrent `POST /generate`.                                                                                                                                                          |
+| `slow_openai.py`        | OpenAI-compatible mock; every `POST /v1/chat/completions` sleeps `SLOW_SECONDS` and returns a forced `render_a2ui` tool call. Sibling of `slow_anthropic.py` for the OpenAI-SDK wedge sites.              |
 | `prod_server_openai.py` | Drives the **real** production OpenAI-SDK `_generate_a2ui` sync fn selected by `TARGET` (`ag2-beautiful-chat` \| `llamaindex-agent` \| `llamaindex-a2ui`). `MODE=direct`; `FIXED` toggles the call shape. |
-| `run_prod_openai.sh` | Driver for `prod_server_openai.py`. `EXPECT=green` asserts wedge==0 AND `tool_dispatch_fired>=1`; `EXPECT=red` asserts wedge≥1. `FIXED` (aligned to `EXPECT`) owns the deterministic mutation guard. |
+| `run_prod_openai.sh`    | Driver for `prod_server_openai.py`. `EXPECT=green` asserts wedge==0 AND `tool_dispatch_fired>=1`; `EXPECT=red` asserts wedge≥1. `FIXED` (aligned to `EXPECT`) owns the deterministic mutation guard.      |
 
 ### OpenAI-SDK wedge sites (ag2 + llamaindex fold-in)
 

--- a/showcase/tests/repro/async-wedge/README.md
+++ b/showcase/tests/repro/async-wedge/README.md
@@ -42,14 +42,14 @@ exercising the sync-client-on-the-loop blocking path.)
 
 ## Files
 
-| File | Role |
-|------|------|
-| `slow_anthropic.py` | Anthropic-compatible mock; every response sleeps `SLOW_SECONDS`. Serves both `messages.create` (JSON) and `messages.stream` (SSE). |
-| `server.py` | Minimal replica. `FIXED=0` sync-on-loop (RED), `FIXED=1` `to_thread` (GREEN). |
-| `prod_server.py` | Drives the **real** production code. `MODE=generator` runs the whole `run_a2ui_dynamic_agent` generator; `MODE=direct` isolates the real `_generate_a2ui` (`FIXED` toggles the call shape). |
-| `run.sh` | Driver for `server.py`. `FIXED=0` asserts wedge≥1; `FIXED=1` asserts wedge==0. |
-| `run_prod.sh` | Driver for `prod_server.py`. `EXPECT=green` asserts wedge==0; `EXPECT=red` asserts wedge≥1. In `MODE=direct` the harness owns RED/GREEN via `FIXED` (deterministic mutation guard). |
-| `load.sh` | Fires `CONCURRENCY` concurrent `POST /generate`. |
+| File                | Role                                                                                                                                                                                        |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `slow_anthropic.py` | Anthropic-compatible mock; every response sleeps `SLOW_SECONDS`. Serves both `messages.create` (JSON) and `messages.stream` (SSE).                                                          |
+| `server.py`         | Minimal replica. `FIXED=0` sync-on-loop (RED), `FIXED=1` `to_thread` (GREEN).                                                                                                               |
+| `prod_server.py`    | Drives the **real** production code. `MODE=generator` runs the whole `run_a2ui_dynamic_agent` generator; `MODE=direct` isolates the real `_generate_a2ui` (`FIXED` toggles the call shape). |
+| `run.sh`            | Driver for `server.py`. `FIXED=0` asserts wedge≥1; `FIXED=1` asserts wedge==0.                                                                                                              |
+| `run_prod.sh`       | Driver for `prod_server.py`. `EXPECT=green` asserts wedge==0; `EXPECT=red` asserts wedge≥1. In `MODE=direct` the harness owns RED/GREEN via `FIXED` (deterministic mutation guard).         |
+| `load.sh`           | Fires `CONCURRENCY` concurrent `POST /generate`.                                                                                                                                            |
 
 ## Prerequisites
 

--- a/showcase/tests/repro/async-wedge/README.md
+++ b/showcase/tests/repro/async-wedge/README.md
@@ -50,6 +50,25 @@ exercising the sync-client-on-the-loop blocking path.)
 | `run.sh`            | Driver for `server.py`. `FIXED=0` asserts wedge≥1; `FIXED=1` asserts wedge==0.                                                                                                              |
 | `run_prod.sh`       | Driver for `prod_server.py`. `EXPECT=green` asserts wedge==0; `EXPECT=red` asserts wedge≥1. In `MODE=direct` the harness owns RED/GREEN via `FIXED` (deterministic mutation guard).         |
 | `load.sh`           | Fires `CONCURRENCY` concurrent `POST /generate`.                                                                                                                                            |
+| `slow_openai.py`    | OpenAI-compatible mock; every `POST /v1/chat/completions` sleeps `SLOW_SECONDS` and returns a forced `render_a2ui` tool call. Sibling of `slow_anthropic.py` for the OpenAI-SDK wedge sites. |
+| `prod_server_openai.py` | Drives the **real** production OpenAI-SDK `_generate_a2ui` sync fn selected by `TARGET` (`ag2-beautiful-chat` \| `llamaindex-agent` \| `llamaindex-a2ui`). `MODE=direct`; `FIXED` toggles the call shape. |
+| `run_prod_openai.sh` | Driver for `prod_server_openai.py`. `EXPECT=green` asserts wedge==0 AND `tool_dispatch_fired>=1`; `EXPECT=red` asserts wedge≥1. `FIXED` (aligned to `EXPECT`) owns the deterministic mutation guard. |
+
+### OpenAI-SDK wedge sites (ag2 + llamaindex fold-in)
+
+The same class of bug — a synchronous OpenAI SDK `.chat.completions.create()`
+inside an `async def generate_a2ui` running on the uvicorn loop — was found and
+fixed in three more integrations:
+
+- `integrations/ag2/src/agents/beautiful_chat.py`
+- `integrations/llamaindex/src/agents/agent.py`
+- `integrations/llamaindex/src/agents/a2ui_dynamic.py`
+
+Each now extracts the blocking round-trip into a sync `_generate_a2ui` and the
+async `generate_a2ui` wrapper offloads it with `await asyncio.to_thread(...)`.
+The `run_prod_openai.sh` driver exercises the REAL production `_generate_a2ui`
+(via `OPENAI_BASE_URL` → `slow_openai.py`) for each `TARGET`, RED (sync-on-loop)
+→ GREEN (to_thread), with the `tool_dispatch_fired>=1` anti-false-green guard.
 
 ## Prerequisites
 
@@ -72,10 +91,23 @@ cd showcase/tests/repro/async-wedge
 FIXED=0 ./run.sh          # RED   — expect wedge≥1
 FIXED=1 ./run.sh          # GREEN — expect wedge==0
 
-# Real production code
+# Real production code (claude-sdk-python)
 EXPECT=green MODE=generator ./run_prod.sh          # real generator, fix in source
 EXPECT=red   MODE=direct    ./run_prod.sh          # mutation guard: real fn sync-on-loop MUST wedge
 EXPECT=green MODE=direct    ./run_prod.sh          # real fn via to_thread MUST NOT wedge
+
+# Real production code (OpenAI-SDK sites: ag2 + llamaindex)
+# Build a shared venv once (union of both integrations' requirements):
+#   uv venv --python 3.12 .venv-repro-openai
+#   uv pip install --python .venv-repro-openai/bin/python \
+#     -r ../../../integrations/ag2/requirements.txt \
+#     -r ../../../integrations/llamaindex/requirements.txt
+TARGET=ag2-beautiful-chat EXPECT=red   ./run_prod_openai.sh   # MUST wedge
+TARGET=ag2-beautiful-chat EXPECT=green ./run_prod_openai.sh   # MUST NOT wedge
+TARGET=llamaindex-agent   EXPECT=red   ./run_prod_openai.sh
+TARGET=llamaindex-agent   EXPECT=green ./run_prod_openai.sh
+TARGET=llamaindex-a2ui    EXPECT=red   ./run_prod_openai.sh
+TARGET=llamaindex-a2ui    EXPECT=green ./run_prod_openai.sh
 ```
 
 Each driver exits non-zero if the observed outcome contradicts the expectation,

--- a/showcase/tests/repro/async-wedge/load.sh
+++ b/showcase/tests/repro/async-wedge/load.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Fire N concurrent POST /generate requests to saturate the single uvicorn
+# event loop. Each request drives a multi-second sync anthropic call; under the
+# RED topology the first one parks the loop and /health goes unresponsive.
+set -u
+PORT="${PORT:-8000}"
+CONCURRENCY="${CONCURRENCY:-5}"
+for _ in $(seq 1 "$CONCURRENCY"); do
+  curl -s -o /dev/null --max-time 30 -X POST "http://127.0.0.1:${PORT}/generate" &
+done
+wait

--- a/showcase/tests/repro/async-wedge/prod_server.py
+++ b/showcase/tests/repro/async-wedge/prod_server.py
@@ -1,0 +1,114 @@
+"""Repro server that drives the REAL production a2ui_dynamic generator.
+
+This is the source-level RED->GREEN discriminator: it runs the ACTUAL
+``run_a2ui_dynamic_agent`` async generator from
+``src/agents/a2ui_dynamic.py`` end-to-end. Whether the uvicorn event loop stays
+responsive under load depends ENTIRELY on the production source — specifically
+whether the ``_generate_a2ui`` call at a2ui_dynamic.py:287 is offloaded with
+``asyncio.to_thread`` (the fix) or invoked synchronously on the loop (the bug).
+
+The real ``anthropic`` clients inside the generator are pointed at the slow mock
+endpoint via ``ANTHROPIC_BASE_URL``, so both the primary streaming call and the
+secondary ``_generate_a2ui`` sync call exercise the true httpx transport with
+multi-second latency.
+
+Driving the generator to actually invoke ``generate_a2ui`` requires the primary
+streaming LLM to emit a tool_use for it; the companion ``slow_anthropic.py``
+serves a fixed streaming response that does exactly that when TARGET drives it.
+To keep the harness robust and framework-version-independent, ``/generate``
+consumes the generator fully (draining all SSE chunks); the secondary sync call
+fires whenever the model requests the tool.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from fastapi import FastAPI
+
+# Mirror tests/python/conftest.py path setup: package root (for the `tools`
+# symlink) + src/ (for `agents.*`).
+_PKG_ROOT = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "integrations",
+        "claude-sdk-python",
+    )
+)
+_INTEG_SRC = os.path.join(_PKG_ROOT, "src")
+for _p in (_PKG_ROOT, _INTEG_SRC):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import asyncio  # noqa: E402
+
+from ag_ui.core import RunAgentInput, UserMessage  # noqa: E402
+
+from agents.a2ui_dynamic import run_a2ui_dynamic_agent  # noqa: E402
+from agents import a2ui_dynamic  # noqa: E402
+
+app = FastAPI()
+
+# MODE controls which production surface is exercised:
+#   MODE=generator (default) -- drive the full run_a2ui_dynamic_agent generator
+#                               end-to-end (integration-level GREEN proof).
+#   MODE=direct              -- call the REAL production _generate_a2ui sync
+#                               function the way a2ui_dynamic.py:~287 calls it.
+#                               FIXED toggles the call shape so the harness owns
+#                               RED vs GREEN on the real function (mutation
+#                               guard): FIXED=1 => await asyncio.to_thread(...)
+#                               (the fix), else sync-on-loop (the pre-fix bug).
+MODE = os.getenv("MODE", "generator").strip().lower()
+_FIXED_RAW = os.getenv("FIXED", "0").strip().lower()
+FIXED = _FIXED_RAW in ("1", "true")
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+def _build_input() -> RunAgentInput:
+    return RunAgentInput(
+        thread_id="repro-thread",
+        run_id="repro-run",
+        messages=[
+            UserMessage(
+                id="m1",
+                role="user",
+                content="Show me a dashboard of Q1 sales.",
+            )
+        ],
+        tools=[],
+        context=[],
+        state=None,
+        forwarded_props={},
+    )
+
+
+@app.post("/generate")
+async def generate() -> dict[str, object]:
+    if MODE == "direct":
+        # Exercise the REAL production _generate_a2ui sync function. FIXED
+        # selects the exact call shape used by a2ui_dynamic.py at the offload
+        # site, isolating the blocking construct from the async-stream phase so
+        # the mutation guard is deterministic.
+        if FIXED:
+            result = await asyncio.to_thread(
+                a2ui_dynamic._generate_a2ui, "repro context", None
+            )
+        else:
+            result = a2ui_dynamic._generate_a2ui("repro context", None)
+        return {"ok": bool(result)}
+
+    # MODE=generator: drive the REAL production generator end-to-end. With the
+    # source fix present, the secondary sync _generate_a2ui is offloaded via
+    # asyncio.to_thread so the loop stays free.
+    chunks = 0
+    async for _chunk in run_a2ui_dynamic_agent(_build_input()):
+        chunks += 1
+    return {"chunks": chunks}

--- a/showcase/tests/repro/async-wedge/prod_server.py
+++ b/showcase/tests/repro/async-wedge/prod_server.py
@@ -66,10 +66,36 @@ MODE = os.getenv("MODE", "generator").strip().lower()
 _FIXED_RAW = os.getenv("FIXED", "0").strip().lower()
 FIXED = _FIXED_RAW in ("1", "true")
 
+# Count how many times the REAL production _generate_a2ui function actually
+# executes. Wrapping the module attribute (rather than a shell-side chunk-count
+# heuristic) means the counter fires only when the bug site is genuinely
+# reached, regardless of call shape (asyncio.to_thread offload OR sync-on-loop).
+# This closes the MODE=generator false-green hole (M1): if the mock's SSE is
+# mis-parsed, the generate_a2ui tool_use is dropped, or the generator early-exits
+# the dispatch branch, _generate_a2ui is never invoked, this counter stays 0,
+# and the shell GREEN assertion (tool_dispatch_fired >= 1) FAILS instead of
+# trivially passing on WEDGE==0.
+TOOL_DISPATCH_FIRED = 0
+_real_generate_a2ui = a2ui_dynamic._generate_a2ui
+
+
+def _counting_generate_a2ui(*args: object, **kwargs: object) -> object:
+    global TOOL_DISPATCH_FIRED
+    TOOL_DISPATCH_FIRED += 1
+    return _real_generate_a2ui(*args, **kwargs)
+
+
+a2ui_dynamic._generate_a2ui = _counting_generate_a2ui
+
 
 @app.get("/health")
 async def health() -> dict[str, str]:
     return {"status": "ok"}
+
+
+@app.get("/stats")
+async def stats() -> dict[str, int]:
+    return {"tool_dispatch_fired": TOOL_DISPATCH_FIRED}
 
 
 def _build_input() -> RunAgentInput:
@@ -103,7 +129,7 @@ async def generate() -> dict[str, object]:
             )
         else:
             result = a2ui_dynamic._generate_a2ui("repro context", None)
-        return {"ok": bool(result)}
+        return {"ok": bool(result), "tool_dispatch_fired": TOOL_DISPATCH_FIRED}
 
     # MODE=generator: drive the REAL production generator end-to-end. With the
     # source fix present, the secondary sync _generate_a2ui is offloaded via
@@ -111,4 +137,4 @@ async def generate() -> dict[str, object]:
     chunks = 0
     async for _chunk in run_a2ui_dynamic_agent(_build_input()):
         chunks += 1
-    return {"chunks": chunks}
+    return {"chunks": chunks, "tool_dispatch_fired": TOOL_DISPATCH_FIRED}

--- a/showcase/tests/repro/async-wedge/prod_server_openai.py
+++ b/showcase/tests/repro/async-wedge/prod_server_openai.py
@@ -1,0 +1,105 @@
+"""Repro server that drives the REAL production OpenAI-SDK a2ui generators.
+
+Sibling of ``prod_server.py`` for the OpenAI-SDK wedge sites. It runs the ACTUAL
+production ``_generate_a2ui`` sync function from a selected integration module
+(ag2 ``beautiful_chat`` or llamaindex ``agent`` / ``a2ui_dynamic``). Whether the
+uvicorn event loop stays responsive under load depends ENTIRELY on the
+production source — specifically whether the async ``generate_a2ui`` wrapper
+offloads ``_generate_a2ui`` with ``asyncio.to_thread`` (the fix) or the blocking
+``.chat.completions.create()`` runs synchronously on the loop (the bug).
+
+The real ``openai`` client inside ``_generate_a2ui`` is pointed at the slow mock
+endpoint via ``OPENAI_BASE_URL``, so the secondary sync call exercises the true
+httpx transport with multi-second latency.
+
+TARGET selects the production module under test:
+    TARGET=ag2-beautiful-chat  -> integrations/ag2/src/agents/beautiful_chat.py
+    TARGET=llamaindex-agent     -> integrations/llamaindex/src/agents/agent.py
+    TARGET=llamaindex-a2ui      -> integrations/llamaindex/src/agents/a2ui_dynamic.py
+
+MODE controls which production surface is exercised:
+    MODE=direct (only mode supported here) -- call the REAL production
+        _generate_a2ui sync function the way the async generate_a2ui wrapper
+        calls it. FIXED toggles the call shape so the harness owns RED vs GREEN
+        on the real function (mutation guard): FIXED=1 => await
+        asyncio.to_thread(...) (the fix), else sync-on-loop (the pre-fix bug).
+"""
+
+from __future__ import annotations
+
+import asyncio  # noqa: E402
+import importlib
+import os
+import sys
+
+from fastapi import FastAPI
+
+_HERE = os.path.dirname(__file__)
+_INTEGRATIONS = os.path.abspath(os.path.join(_HERE, "..", "..", "..", "integrations"))
+
+# TARGET -> (integration dir name, dotted module under agents.*)
+_TARGETS = {
+    "ag2-beautiful-chat": ("ag2", "agents.beautiful_chat"),
+    "llamaindex-agent": ("llamaindex", "agents.agent"),
+    "llamaindex-a2ui": ("llamaindex", "agents.a2ui_dynamic"),
+}
+
+TARGET = os.getenv("TARGET", "ag2-beautiful-chat").strip().lower()
+if TARGET not in _TARGETS:
+    raise SystemExit(
+        f"TARGET={TARGET!r} not recognised; choose one of {sorted(_TARGETS)}"
+    )
+
+_integ_name, _module_path = _TARGETS[TARGET]
+_pkg_root = os.path.join(_INTEGRATIONS, _integ_name)
+_integ_src = os.path.join(_pkg_root, "src")
+for _p in (_pkg_root, _integ_src):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+_module = importlib.import_module(_module_path)
+
+_FIXED_RAW = os.getenv("FIXED", "0").strip().lower()
+FIXED = _FIXED_RAW in ("1", "true")
+
+# Count how many times the REAL production _generate_a2ui function actually
+# executes. Wrapping the module attribute means the counter fires only when the
+# bug site is genuinely reached, regardless of call shape. Closes the false-green
+# hole: if _generate_a2ui never runs, this stays 0 and the shell GREEN assertion
+# (tool_dispatch_fired >= 1) FAILS instead of trivially passing on WEDGE==0.
+TOOL_DISPATCH_FIRED = 0
+_real_generate_a2ui = _module._generate_a2ui
+
+
+def _counting_generate_a2ui(*args: object, **kwargs: object) -> object:
+    global TOOL_DISPATCH_FIRED
+    TOOL_DISPATCH_FIRED += 1
+    return _real_generate_a2ui(*args, **kwargs)
+
+
+_module._generate_a2ui = _counting_generate_a2ui
+
+app = FastAPI()
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/stats")
+async def stats() -> dict[str, int]:
+    return {"tool_dispatch_fired": TOOL_DISPATCH_FIRED}
+
+
+@app.post("/generate")
+async def generate() -> dict[str, object]:
+    # Exercise the REAL production _generate_a2ui sync function. FIXED selects
+    # the exact call shape used by the async generate_a2ui wrapper at the offload
+    # site, isolating the blocking construct so the mutation guard is
+    # deterministic.
+    if FIXED:
+        result = await asyncio.to_thread(_module._generate_a2ui, "repro context")
+    else:
+        result = _module._generate_a2ui("repro context")
+    return {"ok": bool(result), "tool_dispatch_fired": TOOL_DISPATCH_FIRED}

--- a/showcase/tests/repro/async-wedge/run.sh
+++ b/showcase/tests/repro/async-wedge/run.sh
@@ -103,6 +103,11 @@ echo "[async-wedge] both servers up; /health fast-200 confirmed pre-load"
 PORT="$PORT" CONCURRENCY="$CONCURRENCY" bash "$HERE/load.sh" &
 LOAD_PID=$!
 
+# Brief gap so at least one /generate reaches the SUT and begins blocking its
+# loop before the first /health poll fires; otherwise poll 1 can be a legitimate
+# fast-200 even in the RED case (wasted poll).
+sleep 0.5
+
 # 4) Poll /health once/sec for 10s while load is in flight.
 WEDGE=0; OK=0
 for i in $(seq 1 10); do

--- a/showcase/tests/repro/async-wedge/run.sh
+++ b/showcase/tests/repro/async-wedge/run.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# RED/GREEN repro driver for the claude-sdk-python :8000 async event-loop wedge.
+#
+# Faithful topology:
+#   slow_anthropic.py  (separate process, own loop)  <- real HTTP, SLOW_SECONDS latency
+#         ^ base_url
+#   server.py          (single uvicorn event loop)   <- real anthropic.Anthropic sync client
+#     FIXED=0 RED:   sync client.messages.create() ON the loop -> loop parks -> /health wedges
+#     FIXED=1 GREEN: await asyncio.to_thread(...)          -> loop stays live -> /health fast-200
+#
+# While 5x concurrent POST /generate saturate the loop, we poll GET /health
+# once/sec for 10s and count how many polls fail/timeout (WEDGE) vs 200 (OK).
+#
+# Asserts and exits non-zero on a false result, so a false-GREEN cannot pass:
+#   RED   (FIXED=0): require WEDGE >= 1   (exit 4 if it did NOT wedge)
+#   GREEN (FIXED=1): require WEDGE == 0   (exit 5 if any wedge observed)
+#
+# Usage:
+#   FIXED=0 ./run.sh    # RED lane  — expect wedge
+#   FIXED=1 ./run.sh    # GREEN lane — expect no wedge
+#
+# Env:
+#   PY           python interpreter with anthropic+fastapi+uvicorn installed
+#                (default: ./.venv-repro python resolved relative to the
+#                 claude-sdk-python integration)
+#   SLOW_SECONDS latency of the mock LLM endpoint (default 3)
+#   PORT         SUT port (default 8000); mock endpoint is PORT+99-ish (8099)
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INTEG_DIR="$(cd "$HERE/../../../integrations/claude-sdk-python" && pwd)"
+
+# CANONICAL FIXED PREDICATE — byte-identical with server.py.
+FIXED="${FIXED:-0}"
+FIXED_LC="$(printf '%s' "$FIXED" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+if [ "$FIXED_LC" = "1" ] || [ "$FIXED_LC" = "true" ]; then
+  IS_FIXED=1
+  LANE="GREEN (asyncio.to_thread offload)"
+else
+  IS_FIXED=0
+  LANE="RED (sync client on event loop)"
+fi
+
+PORT="${PORT:-8000}"
+MOCK_PORT="${MOCK_PORT:-8099}"
+SLOW_SECONDS="${SLOW_SECONDS:-3}"
+CONCURRENCY="${CONCURRENCY:-5}"
+
+# Resolve a python that has the deps. Prefer the repro venv created next to the
+# integration; fall back to $PY, then `python3`.
+if [ -x "$INTEG_DIR/.venv-repro/bin/python" ]; then
+  PY="${PY:-$INTEG_DIR/.venv-repro/bin/python}"
+else
+  PY="${PY:-python3}"
+fi
+
+echo "========================================================"
+echo "[async-wedge] LANE: $LANE"
+echo "[async-wedge] FIXED=$FIXED (IS_FIXED=$IS_FIXED)  PORT=$PORT  MOCK_PORT=$MOCK_PORT  SLOW_SECONDS=$SLOW_SECONDS  CONCURRENCY=$CONCURRENCY"
+echo "[async-wedge] PY=$PY"
+echo "========================================================"
+
+MOCK_PID=""
+SERVER_PID=""
+cleanup() {
+  [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+  [ -n "$MOCK_PID" ] && kill "$MOCK_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# 1) Start the slow Anthropic-compatible mock endpoint (own process/loop).
+SLOW_SECONDS="$SLOW_SECONDS" "$PY" -m uvicorn slow_anthropic:app \
+  --host 127.0.0.1 --port "$MOCK_PORT" --log-level warning \
+  >/tmp/async-wedge-mock.log 2>&1 &
+MOCK_PID=$!
+
+# 2) Start the system-under-test (single event loop, matching prod uvicorn).
+FIXED="$FIXED" SLOW_BASE_URL="http://127.0.0.1:${MOCK_PORT}" \
+  "$PY" -m uvicorn server:app --host 127.0.0.1 --port "$PORT" --log-level warning \
+  >/tmp/async-wedge-server.log 2>&1 &
+SERVER_PID=$!
+
+# Wait for both to accept connections (health must be fast-200 BEFORE load).
+echo "[async-wedge] waiting for servers to come up..."
+UP=0
+for _ in $(seq 1 30); do
+  if curl -fsS --max-time 2 "http://127.0.0.1:${MOCK_PORT}/openapi.json" >/dev/null 2>&1 \
+     && curl -fsS --max-time 2 "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+    UP=1; break
+  fi
+  sleep 0.5
+done
+if [ "$UP" -ne 1 ]; then
+  echo "[async-wedge] FAIL: servers did not come up"
+  echo "----- mock log -----";   tail -20 /tmp/async-wedge-mock.log 2>/dev/null
+  echo "----- server log -----"; tail -20 /tmp/async-wedge-server.log 2>/dev/null
+  exit 3
+fi
+echo "[async-wedge] both servers up; /health fast-200 confirmed pre-load"
+
+# 3) Fire concurrent load in the background.
+PORT="$PORT" CONCURRENCY="$CONCURRENCY" bash "$HERE/load.sh" &
+LOAD_PID=$!
+
+# 4) Poll /health once/sec for 10s while load is in flight.
+WEDGE=0; OK=0
+for i in $(seq 1 10); do
+  CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "http://127.0.0.1:${PORT}/health" 2>/dev/null || echo TIMEOUT)"
+  if [ "$CODE" = "200" ]; then
+    OK=$((OK+1))
+    echo "[async-wedge] health poll $i: 200 OK"
+  else
+    WEDGE=$((WEDGE+1))
+    echo "[async-wedge] health poll $i: WEDGE ($CODE)"
+  fi
+  sleep 1
+done
+
+wait "$LOAD_PID" 2>/dev/null || true
+
+echo "========================================================"
+echo "ASSERT_SUMMARY is_fixed=$IS_FIXED ok=$OK wedge=$WEDGE"
+echo "========================================================"
+
+if [ "$IS_FIXED" = "1" ]; then
+  if [ "$WEDGE" -ne 0 ]; then
+    echo "FAIL GREEN: expected 0 wedges, observed $WEDGE — event loop still blocked"
+    exit 5
+  fi
+  echo "PASS GREEN: 0 wedges — /health stayed fast-200 under identical load"
+  exit 0
+else
+  if [ "$WEDGE" -lt 1 ]; then
+    echo "FAIL RED: expected >=1 wedge, observed 0 — harness did not reproduce the bug"
+    exit 4
+  fi
+  echo "PASS RED: $WEDGE wedge(s) — /health went unresponsive while the sync call blocked the loop"
+  exit 0
+fi

--- a/showcase/tests/repro/async-wedge/run_prod.sh
+++ b/showcase/tests/repro/async-wedge/run_prod.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Source-level RED/GREEN driver: exercises the REAL production
+# run_a2ui_dynamic_agent generator (src/agents/a2ui_dynamic.py) so that whether
+# /health wedges under load is determined by the production SOURCE (the
+# asyncio.to_thread offload at line ~287), not by the harness.
+#
+# GREEN expectation: with the fix present, /health stays fast-200 (WEDGE==0).
+# Mutation guard: revert the source offload -> re-run -> /health MUST wedge
+#                 (WEDGE>=1), proving the harness fails on the bug.
+#
+# EXPECT=green (default): require WEDGE==0, exit 5 on any wedge.
+# EXPECT=red             : require WEDGE>=1, exit 4 if no wedge.
+#
+# MODE=generator (default): drive the full run_a2ui_dynamic_agent generator
+#                           end-to-end (integration-level GREEN proof).
+# MODE=direct             : exercise the REAL _generate_a2ui sync function in
+#                           isolation; FIXED toggles the call shape so the
+#                           mutation guard is deterministic:
+#                             EXPECT=green -> FIXED=1 (asyncio.to_thread offload)
+#                             EXPECT=red   -> FIXED=0 (sync-on-loop, the bug)
+#
+# Mutation guard invocation:
+#   MODE=direct EXPECT=red   ./run_prod.sh   (must wedge)
+#   MODE=direct EXPECT=green ./run_prod.sh   (must NOT wedge)
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INTEG_DIR="$(cd "$HERE/../../../integrations/claude-sdk-python" && pwd)"
+
+EXPECT="${EXPECT:-green}"
+MODE="${MODE:-generator}"
+# In MODE=direct the harness owns RED/GREEN via FIXED, aligned with EXPECT.
+if [ "$MODE" = "direct" ]; then
+  if [ "$EXPECT" = "red" ]; then FIXED_ENV=0; else FIXED_ENV=1; fi
+else
+  FIXED_ENV="${FIXED:-1}"
+fi
+PORT="${PORT:-8000}"
+MOCK_PORT="${MOCK_PORT:-8099}"
+SLOW_SECONDS="${SLOW_SECONDS:-3}"
+CONCURRENCY="${CONCURRENCY:-5}"
+
+if [ -x "$INTEG_DIR/.venv-repro/bin/python" ]; then
+  PY="${PY:-$INTEG_DIR/.venv-repro/bin/python}"
+else
+  PY="${PY:-python3}"
+fi
+
+echo "========================================================"
+echo "[async-wedge:PROD] EXPECT=$EXPECT  MODE=$MODE  FIXED=$FIXED_ENV  PORT=$PORT  MOCK_PORT=$MOCK_PORT  SLOW_SECONDS=$SLOW_SECONDS  CONCURRENCY=$CONCURRENCY"
+echo "[async-wedge:PROD] driving REAL production a2ui_dynamic code (MODE=$MODE)"
+echo "[async-wedge:PROD] PY=$PY"
+echo "========================================================"
+
+MOCK_PID=""; SERVER_PID=""
+cleanup() {
+  [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+  [ -n "$MOCK_PID" ] && kill "$MOCK_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+SLOW_SECONDS="$SLOW_SECONDS" "$PY" -m uvicorn slow_anthropic:app \
+  --host 127.0.0.1 --port "$MOCK_PORT" --log-level warning \
+  >/tmp/async-wedge-prod-mock.log 2>&1 &
+MOCK_PID=$!
+
+# Point the real anthropic clients (in production code) at the slow mock.
+MODE="$MODE" FIXED="$FIXED_ENV" \
+  ANTHROPIC_BASE_URL="http://127.0.0.1:${MOCK_PORT}" \
+  ANTHROPIC_API_KEY="sk-repro-not-a-real-key" \
+  "$PY" -m uvicorn prod_server:app --host 127.0.0.1 --port "$PORT" --log-level warning \
+  >/tmp/async-wedge-prod-server.log 2>&1 &
+SERVER_PID=$!
+
+echo "[async-wedge:PROD] waiting for servers..."
+UP=0
+for _ in $(seq 1 40); do
+  if curl -fsS --max-time 2 "http://127.0.0.1:${MOCK_PORT}/openapi.json" >/dev/null 2>&1 \
+     && curl -fsS --max-time 2 "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+    UP=1; break
+  fi
+  sleep 0.5
+done
+if [ "$UP" -ne 1 ]; then
+  echo "[async-wedge:PROD] FAIL: servers did not come up"
+  echo "----- mock log -----";   tail -30 /tmp/async-wedge-prod-mock.log 2>/dev/null
+  echo "----- server log -----"; tail -30 /tmp/async-wedge-prod-server.log 2>/dev/null
+  exit 3
+fi
+echo "[async-wedge:PROD] servers up; /health fast-200 confirmed pre-load"
+
+# Concurrent load against the REAL generator endpoint.
+for _ in $(seq 1 "$CONCURRENCY"); do
+  curl -s -o /dev/null --max-time 40 -X POST "http://127.0.0.1:${PORT}/generate" &
+done
+
+WEDGE=0; OK=0
+for i in $(seq 1 10); do
+  CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "http://127.0.0.1:${PORT}/health" 2>/dev/null || echo TIMEOUT)"
+  if [ "$CODE" = "200" ]; then OK=$((OK+1)); echo "[async-wedge:PROD] health poll $i: 200 OK";
+  else WEDGE=$((WEDGE+1)); echo "[async-wedge:PROD] health poll $i: WEDGE ($CODE)"; fi
+  sleep 1
+done
+wait 2>/dev/null || true
+
+echo "========================================================"
+echo "ASSERT_SUMMARY expect=$EXPECT ok=$OK wedge=$WEDGE"
+echo "----- generator output sample -----"
+grep -c chunks /tmp/async-wedge-prod-server.log 2>/dev/null || true
+echo "========================================================"
+
+if [ "$EXPECT" = "green" ]; then
+  if [ "$WEDGE" -ne 0 ]; then
+    echo "FAIL GREEN: expected 0 wedges, observed $WEDGE — production loop still blocked"
+    exit 5
+  fi
+  echo "PASS GREEN: 0 wedges — real production code kept /health fast-200 under load"
+  exit 0
+else
+  if [ "$WEDGE" -lt 1 ]; then
+    echo "FAIL RED: expected >=1 wedge, observed 0 — did not reproduce the bug"
+    exit 4
+  fi
+  echo "PASS RED: $WEDGE wedge(s) — sync-on-loop wedged the loop (bug reproduced)"
+  exit 0
+fi

--- a/showcase/tests/repro/async-wedge/run_prod.sh
+++ b/showcase/tests/repro/async-wedge/run_prod.sh
@@ -90,9 +90,16 @@ if [ "$UP" -ne 1 ]; then
 fi
 echo "[async-wedge:PROD] servers up; /health fast-200 confirmed pre-load"
 
-# Concurrent load against the REAL generator endpoint.
+# Concurrent load against the REAL generator endpoint. The slow mock keeps
+# returning a generate_a2ui tool_use, so the agent loop drives repeated
+# secondary dispatches for the whole poll window (this is what keeps the loop
+# under sustained load); cap each request at 12s so it outlives the 10s poll
+# window without lingering. Track only these load PIDs so the join below does
+# NOT wait on the long-lived uvicorn server jobs (which never exit).
+LOAD_PIDS=()
 for _ in $(seq 1 "$CONCURRENCY"); do
-  curl -s -o /dev/null --max-time 40 -X POST "http://127.0.0.1:${PORT}/generate" &
+  curl -s -o /dev/null --max-time 12 -X POST "http://127.0.0.1:${PORT}/generate" &
+  LOAD_PIDS+=($!)
 done
 
 WEDGE=0; OK=0
@@ -102,12 +109,27 @@ for i in $(seq 1 10); do
   else WEDGE=$((WEDGE+1)); echo "[async-wedge:PROD] health poll $i: WEDGE ($CODE)"; fi
   sleep 1
 done
-wait 2>/dev/null || true
+# Read the cumulative tool-dispatch counter from the server BEFORE reaping the
+# load PIDs (the loopy generator can otherwise keep the load curls alive past
+# the poll window). This counts how many times the REAL production
+# _generate_a2ui actually executed across all /generate requests (see
+# prod_server.py). It is the anti-false-green guard: WEDGE==0 is only meaningful
+# if the bug site was genuinely reached.
+DISPATCH="$(curl -s --max-time 2 "http://127.0.0.1:${PORT}/stats" 2>/dev/null \
+  | sed -n 's/.*"tool_dispatch_fired"[: ]*\([0-9]*\).*/\1/p')"
+DISPATCH="${DISPATCH:-0}"
+
+# Reap the load curls (bounded — never `wait` bare, which would block on the
+# long-lived uvicorn server jobs). cleanup() tears the servers down on EXIT.
+# Guard the array expansion for bash 3.2 under set -u (empty-array expansion is
+# an unbound-variable error there).
+if [ "${#LOAD_PIDS[@]}" -gt 0 ]; then
+  for _pid in "${LOAD_PIDS[@]}"; do kill "$_pid" 2>/dev/null || true; done
+  wait "${LOAD_PIDS[@]}" 2>/dev/null || true
+fi
 
 echo "========================================================"
-echo "ASSERT_SUMMARY expect=$EXPECT ok=$OK wedge=$WEDGE"
-echo "----- generator output sample -----"
-grep -c chunks /tmp/async-wedge-prod-server.log 2>/dev/null || true
+echo "ASSERT_SUMMARY expect=$EXPECT ok=$OK wedge=$WEDGE tool_dispatch_fired=$DISPATCH"
 echo "========================================================"
 
 if [ "$EXPECT" = "green" ]; then
@@ -115,7 +137,15 @@ if [ "$EXPECT" = "green" ]; then
     echo "FAIL GREEN: expected 0 wedges, observed $WEDGE — production loop still blocked"
     exit 5
   fi
-  echo "PASS GREEN: 0 wedges — real production code kept /health fast-200 under load"
+  # Anti-false-green (M1): a GREEN with 0 wedges proves nothing unless the bug
+  # site was actually exercised. If the tool_use was dropped / SSE mis-parsed /
+  # the generator early-exited the dispatch branch, _generate_a2ui never ran and
+  # WEDGE==0 is trivial. Require the real dispatch to have fired.
+  if [ "$DISPATCH" -lt 1 ]; then
+    echo "FAIL GREEN: 0 wedges but tool_dispatch_fired=$DISPATCH — _generate_a2ui never ran; WEDGE==0 is a false green (bug site never exercised)"
+    exit 6
+  fi
+  echo "PASS GREEN: 0 wedges AND tool_dispatch_fired=$DISPATCH (>=1) — real production code exercised the bug site and kept /health fast-200 under load"
   exit 0
 else
   if [ "$WEDGE" -lt 1 ]; then

--- a/showcase/tests/repro/async-wedge/run_prod_openai.sh
+++ b/showcase/tests/repro/async-wedge/run_prod_openai.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Source-level RED/GREEN driver for the OpenAI-SDK wedge sites, sibling of
+# run_prod.sh. Exercises the REAL production _generate_a2ui sync function
+# (selected by TARGET) so that whether /health wedges under load is determined
+# by the production SOURCE (the asyncio.to_thread offload in the async
+# generate_a2ui wrapper), not by the harness.
+#
+# GREEN expectation: with the fix present, /health stays fast-200 (WEDGE==0)
+#                    AND the real _generate_a2ui actually fired (>=1).
+# Mutation guard   : FIXED toggles the harness call shape:
+#                      EXPECT=green -> FIXED=1 (asyncio.to_thread offload)
+#                      EXPECT=red   -> FIXED=0 (sync-on-loop, the bug)
+#
+# TARGET selects the production module under test:
+#   ag2-beautiful-chat | llamaindex-agent | llamaindex-a2ui
+#
+# Invocation:
+#   TARGET=llamaindex-agent EXPECT=red   ./run_prod_openai.sh   (must wedge)
+#   TARGET=llamaindex-agent EXPECT=green ./run_prod_openai.sh   (must NOT wedge)
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TARGET="${TARGET:-ag2-beautiful-chat}"
+EXPECT="${EXPECT:-green}"
+# The harness owns RED/GREEN via FIXED, aligned with EXPECT.
+if [ "$EXPECT" = "red" ]; then FIXED_ENV=0; else FIXED_ENV=1; fi
+PORT="${PORT:-8000}"
+MOCK_PORT="${MOCK_PORT:-8098}"
+SLOW_SECONDS="${SLOW_SECONDS:-3}"
+CONCURRENCY="${CONCURRENCY:-5}"
+
+PY="${PY:-$HERE/.venv-repro-openai/bin/python}"
+if [ ! -x "$PY" ]; then PY="python3"; fi
+
+echo "========================================================"
+echo "[async-wedge:OPENAI] TARGET=$TARGET EXPECT=$EXPECT FIXED=$FIXED_ENV PORT=$PORT MOCK_PORT=$MOCK_PORT SLOW_SECONDS=$SLOW_SECONDS CONCURRENCY=$CONCURRENCY"
+echo "[async-wedge:OPENAI] driving REAL production _generate_a2ui (MODE=direct)"
+echo "[async-wedge:OPENAI] PY=$PY"
+echo "========================================================"
+
+MOCK_PID=""; SERVER_PID=""
+cleanup() {
+  [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+  [ -n "$MOCK_PID" ] && kill "$MOCK_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+cd "$HERE" || exit 3
+
+# Pre-flight: reap any lingering uvicorn bound to our ports from a prior lane.
+# Without this, sequential RED->GREEN runs on the same ports can reuse a wedged
+# server from the previous lane (the RED lane's slow blocking requests keep the
+# socket alive), producing a spurious GREEN wedge with tool_dispatch_fired=0.
+if command -v lsof >/dev/null 2>&1; then
+  for _port in "$PORT" "$MOCK_PORT"; do
+    _pids="$(lsof -ti ":${_port}" 2>/dev/null || true)"
+    # shellcheck disable=SC2086 # intentional word-split: multiple PIDs -> kill args
+    [ -n "$_pids" ] && kill -9 $_pids 2>/dev/null || true
+  done
+  sleep 1
+fi
+
+SLOW_SECONDS="$SLOW_SECONDS" "$PY" -m uvicorn slow_openai:app \
+  --host 127.0.0.1 --port "$MOCK_PORT" --log-level warning \
+  >/tmp/async-wedge-openai-mock.log 2>&1 &
+MOCK_PID=$!
+
+# Point the real openai client (in production code) at the slow mock. The OpenAI
+# SDK honors OPENAI_BASE_URL; llamaindex's raw `from openai import OpenAI`
+# client honors it too. (The llama_index framework LLM object honors OPENAI_API_BASE,
+# but the wedge site uses the raw SDK client, which reads OPENAI_BASE_URL.)
+TARGET="$TARGET" FIXED="$FIXED_ENV" \
+  OPENAI_BASE_URL="http://127.0.0.1:${MOCK_PORT}/v1" \
+  OPENAI_API_KEY="sk-repro-not-a-real-key" \
+  "$PY" -m uvicorn prod_server_openai:app --host 127.0.0.1 --port "$PORT" --log-level warning \
+  >/tmp/async-wedge-openai-server.log 2>&1 &
+SERVER_PID=$!
+
+echo "[async-wedge:OPENAI] waiting for servers..."
+UP=0
+for _ in $(seq 1 40); do
+  if curl -fsS --max-time 2 "http://127.0.0.1:${MOCK_PORT}/openapi.json" >/dev/null 2>&1 \
+     && curl -fsS --max-time 2 "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+    UP=1; break
+  fi
+  sleep 0.5
+done
+if [ "$UP" -ne 1 ]; then
+  echo "[async-wedge:OPENAI] FAIL: servers did not come up"
+  echo "----- mock log -----";   tail -30 /tmp/async-wedge-openai-mock.log 2>/dev/null
+  echo "----- server log -----"; tail -40 /tmp/async-wedge-openai-server.log 2>/dev/null
+  exit 3
+fi
+echo "[async-wedge:OPENAI] servers up; /health fast-200 confirmed pre-load"
+
+# Concurrent load against the real _generate_a2ui endpoint. Cap each request at
+# 12s so it outlives the 10s poll window without lingering.
+LOAD_PIDS=()
+for _ in $(seq 1 "$CONCURRENCY"); do
+  curl -s -o /dev/null --max-time 12 -X POST "http://127.0.0.1:${PORT}/generate" &
+  LOAD_PIDS+=($!)
+done
+
+WEDGE=0; OK=0
+for i in $(seq 1 10); do
+  CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "http://127.0.0.1:${PORT}/health" 2>/dev/null || echo TIMEOUT)"
+  if [ "$CODE" = "200" ]; then OK=$((OK+1)); echo "[async-wedge:OPENAI] health poll $i: 200 OK";
+  else WEDGE=$((WEDGE+1)); echo "[async-wedge:OPENAI] health poll $i: WEDGE ($CODE)"; fi
+  sleep 1
+done
+
+DISPATCH="$(curl -s --max-time 2 "http://127.0.0.1:${PORT}/stats" 2>/dev/null \
+  | sed -n 's/.*"tool_dispatch_fired"[: ]*\([0-9]*\).*/\1/p')"
+DISPATCH="${DISPATCH:-0}"
+
+if [ "${#LOAD_PIDS[@]}" -gt 0 ]; then
+  for _pid in "${LOAD_PIDS[@]}"; do kill "$_pid" 2>/dev/null || true; done
+  wait "${LOAD_PIDS[@]}" 2>/dev/null || true
+fi
+
+echo "========================================================"
+echo "ASSERT_SUMMARY target=$TARGET expect=$EXPECT ok=$OK wedge=$WEDGE tool_dispatch_fired=$DISPATCH"
+echo "========================================================"
+
+if [ "$EXPECT" = "green" ]; then
+  if [ "$WEDGE" -ne 0 ]; then
+    echo "FAIL GREEN: expected 0 wedges, observed $WEDGE — production loop still blocked"
+    exit 5
+  fi
+  if [ "$DISPATCH" -lt 1 ]; then
+    echo "FAIL GREEN: 0 wedges but tool_dispatch_fired=$DISPATCH — _generate_a2ui never ran; WEDGE==0 is a false green (bug site never exercised)"
+    exit 6
+  fi
+  echo "PASS GREEN: 0 wedges AND tool_dispatch_fired=$DISPATCH (>=1) — real production code exercised the bug site and kept /health fast-200 under load"
+  exit 0
+else
+  if [ "$WEDGE" -lt 1 ]; then
+    echo "FAIL RED: expected >=1 wedge, observed 0 — did not reproduce the bug"
+    exit 4
+  fi
+  echo "PASS RED: $WEDGE wedge(s) — sync-on-loop wedged the loop (bug reproduced)"
+  exit 0
+fi

--- a/showcase/tests/repro/async-wedge/server.py
+++ b/showcase/tests/repro/async-wedge/server.py
@@ -1,0 +1,83 @@
+"""Minimal FastAPI replica of the claude-sdk-python :8000 event-loop wedge.
+
+Faithfully reproduces the production topology from
+``src/agents/agent.py`` (``_execute_tool`` -> ``anthropic.Anthropic()`` ->
+``client.messages.create()``) and ``src/agents/a2ui_dynamic.py``
+(``_generate_a2ui`` same pattern): a *real* synchronous ``anthropic.Anthropic``
+client whose blocking ``messages.create()`` call is invoked from within an
+``async def`` request handler.
+
+Controlled by env var:
+  FIXED=0 (default) -- sync blocking call directly on the event loop (RED):
+                       exactly the bug — the uvicorn loop parks in the sync
+                       httpx call for the full LLM round-trip.
+  FIXED=1           -- ``await asyncio.to_thread(...)`` offload (GREEN):
+                       the fix — the blocking call runs on a worker thread so
+                       the event loop stays live and ``/health`` keeps
+                       answering.
+
+The LLM latency is provided by a real HTTP round-trip to the companion
+``slow_anthropic.py`` endpoint (base_url override), so the sync
+``httpx.Client`` transport inside the anthropic SDK is exercised for real —
+not a bare ``time.sleep`` stand-in.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import anthropic
+from fastapi import FastAPI
+
+app = FastAPI()
+
+# CANONICAL FIXED PREDICATE — must be byte-identical with run.sh. FIXED is true
+# IFF the lowercased value is exactly "1" or "true". Any other value is RED.
+# This closes the false-GREEN hole where run.sh labels a run GREEN while the
+# server actually ran the RED (blocking) topology.
+_FIXED_RAW = os.getenv("FIXED", "0").strip().lower()
+FIXED = _FIXED_RAW in ("1", "true")
+
+# Point the REAL anthropic client at the local slow endpoint. This is the exact
+# production construct: anthropic.Anthropic() with a sync httpx transport.
+_SLOW_BASE_URL = os.getenv("SLOW_BASE_URL", "http://127.0.0.1:8099")
+
+
+def _blocking_llm_call() -> str:
+    """The load-bearing production construct: a SYNC anthropic client call.
+
+    Mirrors ``src/agents/agent.py:793,814`` and
+    ``src/agents/a2ui_dynamic.py:90,106`` — build ``anthropic.Anthropic()`` and
+    call ``client.messages.create()`` synchronously. Blocks the calling OS
+    thread for the full LLM round-trip.
+    """
+    client = anthropic.Anthropic(
+        api_key=os.getenv("ANTHROPIC_API_KEY", "sk-repro-not-a-real-key"),
+        base_url=_SLOW_BASE_URL,
+        max_retries=0,
+    )
+    response = client.messages.create(
+        model="claude-sonnet-4-6",
+        max_tokens=16,
+        messages=[{"role": "user", "content": "generate a dashboard"}],
+    )
+    return response.content[0].text
+
+
+@app.post("/generate")
+async def generate() -> dict[str, str]:
+    if FIXED:
+        # GREEN: offload the blocking sync call to a worker thread so the
+        # event loop stays free to serve /health.
+        result = await asyncio.to_thread(_blocking_llm_call)
+    else:
+        # RED: blocking sync call directly on the event loop thread — the bug.
+        # The uvicorn loop freezes for the LLM round-trip; /health cannot answer.
+        result = _blocking_llm_call()
+    return {"result": result}
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}

--- a/showcase/tests/repro/async-wedge/slow_anthropic.py
+++ b/showcase/tests/repro/async-wedge/slow_anthropic.py
@@ -28,9 +28,9 @@ with the system-under-test's event loop:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
-import time
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -38,6 +38,14 @@ from fastapi.responses import JSONResponse, StreamingResponse
 app = FastAPI()
 
 SLOW_SECONDS = float(os.getenv("SLOW_SECONDS", "3"))
+
+# False-green fault injection (test-of-the-test only): when set, the streaming
+# response omits the generate_a2ui tool_use and emits a text block instead, so
+# the production generator drains chunks but NEVER reaches _generate_a2ui. Used
+# by the red-green proof to confirm the hardened GREEN assertion
+# (tool_dispatch_fired >= 1) FAILS on a dropped-tool-use false green rather than
+# trivially passing on WEDGE==0. Unset in normal operation.
+DROP_TOOL_USE = os.getenv("REPRO_DROP_TOOL_USE", "0").strip().lower() in ("1", "true")
 
 
 def _nonstreaming_response() -> JSONResponse:
@@ -124,6 +132,57 @@ def _streaming_body() -> str:
     return "".join(parts)
 
 
+def _streaming_body_text_only() -> str:
+    # Fault-injection body (DROP_TOOL_USE): a valid streaming response with a
+    # text block and NO generate_a2ui tool_use, so the generator finishes but
+    # never dispatches the tool. Reproduces the M1 false-green scenario.
+    parts = [
+        _sse(
+            "message_start",
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_slowmock_stream",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-6",
+                    "content": [],
+                    "stop_reason": None,
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": 1, "output_tokens": 0},
+                },
+            },
+        ),
+        _sse(
+            "content_block_start",
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+        ),
+        _sse(
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "No tool for you."},
+            },
+        ),
+        _sse("content_block_stop", {"type": "content_block_stop", "index": 0}),
+        _sse(
+            "message_delta",
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                "usage": {"output_tokens": 1},
+            },
+        ),
+        _sse("message_stop", {"type": "message_stop"}),
+    ]
+    return "".join(parts)
+
+
 @app.post("/v1/messages")
 async def messages(request: Request) -> object:
     body = await request.body()
@@ -134,15 +193,18 @@ async def messages(request: Request) -> object:
     except json.JSONDecodeError:
         pass
 
-    # Block for SLOW_SECONDS to emulate a multi-second LLM round-trip. This
-    # handler runs in its own process so it never steals cycles from the
-    # system-under-test; the SUT's sync client blocks its calling thread for the
-    # full duration of this call.
-    time.sleep(SLOW_SECONDS)
+    # Delay for SLOW_SECONDS to emulate a multi-second LLM round-trip. Use the
+    # async sleep so this mock's own uvicorn loop stays free and can service
+    # concurrent SUT client threads in parallel (a blocking time.sleep here
+    # serialises them and needlessly extends the test under CONCURRENCY>1). The
+    # SUT's sync client still blocks its own calling thread for the full round
+    # trip, which is what the repro exercises.
+    await asyncio.sleep(SLOW_SECONDS)
 
     if is_stream:
+        body = _streaming_body_text_only() if DROP_TOOL_USE else _streaming_body()
         return StreamingResponse(
-            iter([_streaming_body()]),
+            iter([body]),
             media_type="text/event-stream",
         )
     return _nonstreaming_response()

--- a/showcase/tests/repro/async-wedge/slow_anthropic.py
+++ b/showcase/tests/repro/async-wedge/slow_anthropic.py
@@ -1,0 +1,148 @@
+"""Controllable slow Anthropic-compatible mock endpoint.
+
+Faithfully stands in for the real Anthropic Messages API so the repro can drive
+the *real* ``anthropic`` SDK clients (their ``httpx`` transports) without
+network access or an API key. The only thing we control is latency: every
+handler sleeps ``SLOW_SECONDS`` before responding, reproducing the load-bearing
+failure construct — a multi-second LLM round-trip — while keeping the HTTP
+round-trip, JSON (de)serialisation, and httpx transport all real.
+
+This is the "controllable slow endpoint" the repro spec permits in lieu of
+aimock (aimock is a Docker fleet service; a hermetic local endpoint is the
+faithful equivalent for exercising the sync-client-on-the-loop blocking path).
+
+Serves both request shapes used by the production code:
+  * non-streaming ``messages.create()`` (server.py replica + secondary
+    ``_generate_a2ui`` call) -> a single JSON Messages response whose content
+    is a ``render_a2ui`` tool_use (so build_a2ui_operations_from_tool_call has
+    something to parse).
+  * streaming ``messages.stream()`` (primary a2ui_dynamic loop) -> an SSE event
+    sequence emitting a ``generate_a2ui`` tool_use, so the generator proceeds to
+    the secondary call.
+
+Run standalone (own event loop / own process) so its latency never competes
+with the system-under-test's event loop:
+
+    uvicorn slow_anthropic:app --host 127.0.0.1 --port 8099
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+app = FastAPI()
+
+SLOW_SECONDS = float(os.getenv("SLOW_SECONDS", "3"))
+
+
+def _nonstreaming_response() -> JSONResponse:
+    # A render_a2ui tool_use so the secondary _generate_a2ui call can parse it.
+    return JSONResponse(
+        {
+            "id": "msg_slowmock",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-6",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_render",
+                    "name": "render_a2ui",
+                    "input": {"components": []},
+                }
+            ],
+            "stop_reason": "tool_use",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        }
+    )
+
+
+def _sse(event: str, data: dict) -> str:
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+
+
+def _streaming_body() -> str:
+    # Minimal Anthropic SSE sequence emitting a generate_a2ui tool_use.
+    parts = [
+        _sse(
+            "message_start",
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_slowmock_stream",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-6",
+                    "content": [],
+                    "stop_reason": None,
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": 1, "output_tokens": 0},
+                },
+            },
+        ),
+        _sse(
+            "content_block_start",
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "toolu_gen",
+                    "name": "generate_a2ui",
+                    "input": {},
+                },
+            },
+        ),
+        _sse(
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {
+                    "type": "input_json_delta",
+                    "partial_json": '{"context": "Q1 sales dashboard"}',
+                },
+            },
+        ),
+        _sse("content_block_stop", {"type": "content_block_stop", "index": 0}),
+        _sse(
+            "message_delta",
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "tool_use", "stop_sequence": None},
+                "usage": {"output_tokens": 1},
+            },
+        ),
+        _sse("message_stop", {"type": "message_stop"}),
+    ]
+    return "".join(parts)
+
+
+@app.post("/v1/messages")
+async def messages(request: Request) -> object:
+    body = await request.body()
+    is_stream = False
+    try:
+        payload = json.loads(body or b"{}")
+        is_stream = bool(payload.get("stream"))
+    except json.JSONDecodeError:
+        pass
+
+    # Block for SLOW_SECONDS to emulate a multi-second LLM round-trip. This
+    # handler runs in its own process so it never steals cycles from the
+    # system-under-test; the SUT's sync client blocks its calling thread for the
+    # full duration of this call.
+    time.sleep(SLOW_SECONDS)
+
+    if is_stream:
+        return StreamingResponse(
+            iter([_streaming_body()]),
+            media_type="text/event-stream",
+        )
+    return _nonstreaming_response()

--- a/showcase/tests/repro/async-wedge/slow_openai.py
+++ b/showcase/tests/repro/async-wedge/slow_openai.py
@@ -1,0 +1,93 @@
+"""Controllable slow OpenAI-compatible mock endpoint.
+
+Sibling of ``slow_anthropic.py`` for the OpenAI-SDK wedge sites (ag2
+``beautiful_chat.py`` and llamaindex ``agent.py`` / ``a2ui_dynamic.py``). It
+faithfully stands in for the real OpenAI Chat Completions API so the repro can
+drive the *real* ``openai`` SDK client (its ``httpx`` transport) without network
+access or an API key. The only thing we control is latency: every handler sleeps
+``SLOW_SECONDS`` before responding, reproducing the load-bearing failure
+construct — a multi-second LLM round-trip — while keeping the HTTP round-trip,
+JSON (de)serialisation, and httpx transport all real.
+
+The production ``generate_a2ui`` sites force a single ``render_a2ui`` tool call
+via ``tool_choice``, so the mock returns a Chat Completions response whose
+``choices[0].message.tool_calls[0]`` is a ``render_a2ui`` call with empty
+``components`` — enough for ``build_a2ui_operations_from_tool_call`` (or the
+llamaindex JSON passthrough) to parse.
+
+Run standalone (own event loop / own process) so its latency never competes with
+the system-under-test's event loop:
+
+    uvicorn slow_openai:app --host 127.0.0.1 --port 8098
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+app = FastAPI()
+
+SLOW_SECONDS = float(os.getenv("SLOW_SECONDS", "3"))
+
+
+def _chat_completion_response() -> JSONResponse:
+    # A forced render_a2ui tool call with valid JSON arguments so both the ag2
+    # (build_a2ui_operations_from_tool_call) and llamaindex (JSON passthrough)
+    # generators parse a real tool call.
+    tool_args = json.dumps(
+        {
+            "surfaceId": "repro-surface",
+            "catalogId": "repro-catalog",
+            "components": [],
+            "data": {},
+        }
+    )
+    return JSONResponse(
+        {
+            "id": "chatcmpl-slowmock",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": "gpt-4.1",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_render",
+                                "type": "function",
+                                "function": {
+                                    "name": "render_a2ui",
+                                    "arguments": tool_args,
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 1,
+                "completion_tokens": 1,
+                "total_tokens": 2,
+            },
+        }
+    )
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions() -> object:
+    # Async sleep so the mock's own uvicorn loop stays free and services
+    # concurrent SUT client threads in parallel. The SUT's sync client still
+    # blocks its own calling thread for the full round trip, which is what the
+    # repro exercises.
+    await asyncio.sleep(SLOW_SECONDS)
+    return _chat_completion_response()


### PR DESCRIPTION
## What

The `claude-sdk-python` showcase agent `:8000` wedges under D6/LLM load: two **synchronous** `anthropic.Anthropic().messages.create()` calls run directly on the uvicorn asyncio event loop, freezing it for the full LLM round-trip so `/health` stops answering. The watchdog counts 3 consecutive failures (~90s) and kill-restarts the container, dropping active sessions. This is the pre-existing root cause behind the #oss-alerts restart noise that #5987's alerting surfaced (it was never a #5987 regression).

## Root cause (sync-in-async)

All in `integrations/claude-sdk-python/`:

- **`src/agents/agent.py`** — `_execute_tool`'s `generate_a2ui` branch builds a sync `anthropic.Anthropic()` and calls `client.messages.create()` synchronously. `_execute_tool` is a sync callback invoked on the loop from **two** async callers: `run_agent`'s agentic loop, and the Claude-Agent-SDK MCP tool handler in `claude_agent_sdk_adapter.py`.
- **`src/agents/a2ui_dynamic.py`** — `_generate_a2ui`, same sync pattern, invoked on the loop from the `run_a2ui_dynamic_agent` generator.

## Fix — approach (a): `await asyncio.to_thread(...)` at the call sites

Chosen over approach (b) (`AsyncAnthropic` + `async def`) because it is the **lowest blast radius**: the sync functions and the shared `ExecuteTool` callback type stay unchanged, and wrapping at the call sites fixes the **whole** tool-dispatch path uniformly (any current or future sync tool in the dispatcher), not just `generate_a2ui`. Approach (b) would only fix `generate_a2ui` unless `_execute_tool` were made fully async — which ripples into the `ExecuteTool` type and both call sites anyway.

Every occurrence fixed (file:line):
- `src/agents/agent.py:~1355` — `run_agent` call site → `await asyncio.to_thread(_execute_tool, ...)`
- `src/agents/claude_agent_sdk_adapter.py:~152` — MCP `sdk_tool_handler` → `await asyncio.to_thread(execute_tool, ...)`
- `src/agents/a2ui_dynamic.py:~287` — secondary call site → `await asyncio.to_thread(_generate_a2ui, ...)`

Whole-integration grep for the pattern (`anthropic.Anthropic(`, sync `.messages.create`, `OpenAI(`, `time.sleep`, blocking I/O): only these two sites existed. Every other agent in the integration already uses `AsyncAnthropic`.

## Showcase parity verdict

`a2ui_dynamic.py` is **per-integration**, not shared. Each framework (langgraph-python, llamaindex, ms-agent-python, pydantic-ai, ag2, strands, agno, …) ships its own copy that "mirrors" langgraph-python but uses that framework's own client. Only claude-sdk-python's copy used the sync `anthropic.Anthropic()` pattern, so **blast radius is claude-sdk-python only** — no other integration has this wedge. The `tools` symlink (→ `showcase/shared/python/tools`) was **not** touched (iron-rule: edit shared source only, never symlink copies; here no shared change was needed).

## entrypoint.sh alert scoping

- `:8000` agent watchdog branch: **removed** the Slack POST, **kept** the `kill -9 $AGENT_PID` self-heal. It now self-heals silently (root cause fixed).
- Public `$PORT` `/api/health` branch: Slack POST to `$SLACK_WEBHOOK_OSS_ALERTS` **intact** — the public Next.js wedge still pages.

## Red → green proof

Faithful harness at `showcase/tests/repro/async-wedge/`: a real `anthropic.Anthropic` sync client (real httpx transport) pointed via `ANTHROPIC_BASE_URL`/`base_url` at a controllable slow local Anthropic-compatible endpoint (`slow_anthropic.py`, `SLOW_SECONDS` latency, serves both `messages.create` JSON and `messages.stream` SSE). 5× concurrent `POST /generate`; poll `/health` 1/s for 10s; assert & exit non-zero on a false result.

**Minimal replica (`server.py`) — the load-bearing construct:**
```
REPLICA RED (FIXED=0, sync client on loop):   ASSERT_SUMMARY is_fixed=0 ok=6  wedge=4  → PASS RED
REPLICA GREEN (FIXED=1, asyncio.to_thread):   ASSERT_SUMMARY is_fixed=1 ok=10 wedge=0  → PASS GREEN
```

**Real production code (`prod_server.py`):**
```
PROD GENERATOR GREEN (real run_a2ui_dynamic_agent, fix in source):
    ASSERT_SUMMARY expect=green ok=10 wedge=0  → PASS GREEN
    (secondary sync _generate_a2ui fired 5x via to_thread; /health stayed 200)

MUTATION GUARD RED (real _generate_a2ui, sync-on-loop):
    ASSERT_SUMMARY expect=red   ok=5  wedge=5  → PASS RED  (proves the harness fails on the bug)

PROD DIRECT GREEN (real _generate_a2ui via to_thread):
    ASSERT_SUMMARY expect=green ok=10 wedge=0  → PASS GREEN
```

The mutation guard exercises the **real** production `_generate_a2ui` sync-on-loop and confirms it wedges (`wedge=5`), while the `to_thread` path stays fast-200 (`wedge=0`) — the harness is not vacuously green.

## Regression check

`pytest tests/python/` → **6 passed**. `ruff format --check` clean on all 3 edited files (no new lint; the pre-existing origin/main ruff findings are untouched, out of scope). `bash -n` clean on entrypoint.sh and all repro scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## CR round 2 — repro hardening

Addressed the one mandatory CR finding (M1) plus two optional items on the `showcase/tests/repro/async-wedge/` harness. **Repro-harness only — no production source touched** (`src/agents/a2ui_dynamic.py` unchanged).

**M1 (mandatory) — MODE=generator false-green closed.** The GREEN lane previously asserted only `WEDGE==0`. If the mock's SSE were mis-parsed, the `generate_a2ui` tool_use dropped, or the generator early-exited, `_generate_a2ui` (the bug site) would never run, the loop would never park, and `WEDGE==0` would pass trivially — proving nothing. Fix: `prod_server.py` now wraps the real `a2ui_dynamic._generate_a2ui` with a counter (`tool_dispatch_fired`), exposed via `/stats` and the `/generate` response. `run_prod.sh` reads it after the poll window and the GREEN lane now **fails (exit 6)** unless `tool_dispatch_fired >= 1`. The counter tracks genuine execution regardless of call shape (`asyncio.to_thread` offload or sync-on-loop).

**O1** — `slow_anthropic.py` now uses `await asyncio.sleep(SLOW_SECONDS)` instead of blocking `time.sleep`, so the mock's own loop stays free under concurrency.

**O2** — `run.sh` adds a 0.5s gap after firing load, before the first `/health` poll, so poll 1 isn't wasted on a pre-block fast-200.

Also fixed a latent hang: `run_prod.sh` ended with a bare `wait` that blocked forever on the long-lived uvicorn server jobs, so the summary/assertion never printed. It now tracks and reaps only the load-curl PIDs (bash-3.2 / `set -u` safe).

### Red-green proof (harness assertion)

RED (false-green injected via `REPRO_DROP_TOOL_USE=1` — tool_use dropped, generator drains but never dispatches; env-only, no source mutation):
```
ASSERT_SUMMARY expect=green ok=10 wedge=0 tool_dispatch_fired=0
FAIL GREEN: 0 wedges but tool_dispatch_fired=0 — _generate_a2ui never ran; WEDGE==0 is a false green (bug site never exercised)
EXIT=6
```
Old assertion (`WEDGE==0` only) would have PASSED here; hardened assertion correctly FAILS.

GREEN (normal operation — tool dispatch fires):
```
ASSERT_SUMMARY expect=green ok=10 wedge=0 tool_dispatch_fired=9
PASS GREEN: 0 wedges AND tool_dispatch_fired=9 (>=1) — real production code exercised the bug site and kept /health fast-200 under load
EXIT=0
```

### No regression — deterministic MODE=direct mutation guard
```
MODE=direct EXPECT=red   -> ASSERT_SUMMARY expect=red   ok=8  wedge=2 tool_dispatch_fired=3 -> PASS RED   (exit 0)
MODE=direct EXPECT=green -> ASSERT_SUMMARY expect=green ok=10 wedge=0 tool_dispatch_fired=3 -> PASS GREEN (exit 0)
```


---

## Fold-in: ag2 + llamaindex (fleet-wide sweep)

A CR flagged the same sync-LLM-on-the-event-loop wedge in two more integrations,
and a fleet-wide sweep of every `integrations/*/src/**` Python file for a sync
LLM `.create()` running **directly inside an `async def`** on the uvicorn loop
found a THIRD previously-missed site. All three are now fixed with the same
lowest-blast-radius approach (extract the blocking round-trip into a sync
`_generate_a2ui`, and `await asyncio.to_thread(...)` from the async wrapper):

- `integrations/ag2/src/agents/beautiful_chat.py` — `async def generate_a2ui` (sync `openai.OpenAI().chat.completions.create`)
- `integrations/llamaindex/src/agents/a2ui_dynamic.py` — `async def generate_a2ui` (sync `OpenAI().chat.completions.create`)
- `integrations/llamaindex/src/agents/agent.py` — `async def generate_a2ui` (sync `OpenAI().chat.completions.create`) — **found by the sweep, not in the original report**

### Fleet-sweep result (what was NOT touched, and why)

- **ag2 `agent.py` + `a2ui_dynamic.py`**: already non-blocking (`await _async_openai_client.chat.completions.create`, i.e. `AsyncOpenAI`). Confirmed, not re-touched.
- **agno, ms-agent-python, pydantic-ai, strands, crewai** sync `.create` sites: all inside plain `def` framework tools (`@tool`-style), which the frameworks dispatch in their own worker/executor context — never bare-`await`ed on the loop. No wedge.
- **`.ts` voice routes / `agent_server.ts`**: TypeScript/Node, not the uvicorn asyncio loop.
- **`llama_index.llms.openai.OpenAI(model=…)`** objects: framework-managed async LLMs, distinct from the raw `openai` SDK client at the wedge sites.

So the wedge exists at exactly these three `async def generate_a2ui` sites (plus the two claude-sdk-python sites fixed above). All three edited files are per-integration REAL files (not symlinks to `showcase/shared/`) — verified per the iron rule.

`ag2`/`llamaindex` `entrypoint.sh` were intentionally **not** touched — the Slack-alert scoping was specific to the claude-sdk-python incident.

### Red → green proof (real production code, deterministic)

New OpenAI-SDK repro harness (dev-only, under `showcase/tests/repro/async-wedge/`, sibling of the anthropic one): a real `openai` SDK client (real httpx transport) pointed via `OPENAI_BASE_URL` at a controllable slow local OpenAI-compatible endpoint (`slow_openai.py`). `run_prod_openai.sh` drives the **real production `_generate_a2ui`** for each `TARGET`, 5× concurrent `POST /generate`, poll `/health` 1/s ×10, with the `tool_dispatch_fired >= 1` anti-false-green guard.

```
ag2-beautiful-chat  RED:   ASSERT_SUMMARY expect=red   ok=5  wedge=5 tool_dispatch_fired=5  -> PASS RED
ag2-beautiful-chat  GREEN: ASSERT_SUMMARY expect=green ok=10 wedge=0 tool_dispatch_fired=5  -> PASS GREEN
llamaindex-agent    RED:   ASSERT_SUMMARY expect=red   ok=5  wedge=5 tool_dispatch_fired=5  -> PASS RED
llamaindex-agent    GREEN: ASSERT_SUMMARY expect=green ok=10 wedge=0 tool_dispatch_fired=5  -> PASS GREEN
llamaindex-a2ui     RED:   ASSERT_SUMMARY expect=red   ok=5  wedge=5 tool_dispatch_fired=5  -> PASS RED
llamaindex-a2ui     GREEN: ASSERT_SUMMARY expect=green ok=10 wedge=0 tool_dispatch_fired=5  -> PASS GREEN
```

Source-level cross-check driving the **real on-disk `async generate_a2ui` wrapper** directly: 5 concurrent 3s calls complete in ~3.1s (parallel offload threads, not serialized ~15s) while a bare asyncio heartbeat keeps ticking (64 ticks through the load window) — loop stays free. Negative control (ag2 wrapper temporarily reverted to sync-on-loop): 15.11s serialized, heartbeat starved to 4 ticks — wedge reproduced; source restored.

Existing claude-sdk-python lanes re-run green (no regression).
