### PR TITLE
fix(release): align Channels umbrella handoff contract

### DIFF
--- a/scripts/release/lib/channels-umbrella.test.ts
+++ b/scripts/release/lib/channels-umbrella.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   ADAPTERS,
+  createConsumerSmokeSource,
   createConsumerWorkspaceYaml,
   createConsumerManifest,
   FAMILY,
@@ -26,7 +27,7 @@ function validManifests(): Map<string, PackedManifest> {
       "@copilotkit/channels-ui": "^0.1.2",
     },
   }));
-  const family = [core, ui, ...adapters];
+  const family = [ui, core, ...adapters];
   const umbrella: PackedManifest = {
     name: "@copilotkit/channels",
     version: "0.2.0",
@@ -126,6 +127,20 @@ describe("createConsumerManifest", () => {
       },
     });
   });
+
+  it("keeps internal packages out of install dependencies even when local overrides are present", () => {
+    const manifest = createConsumerManifest({
+      umbrellaTarball: "/tmp/channels.tgz",
+      packageManager: "pnpm@10.33.4",
+      typescript: "^5.6.3",
+      nodeTypes: "^22.10.0",
+      overrides: new Map(FAMILY.map((name) => [name, `/tmp/${name}.tgz`])),
+    });
+
+    expect(manifest.dependencies).toEqual({
+      "@copilotkit/channels": "file:/tmp/channels.tgz",
+    });
+  });
 });
 
 describe("createConsumerWorkspaceYaml", () => {
@@ -134,6 +149,29 @@ describe("createConsumerWorkspaceYaml", () => {
 
     for (const name of FAMILY) {
       expect(workspace).toContain(`  - ${JSON.stringify(name)}\n`);
+    }
+  });
+});
+
+describe("createConsumerSmokeSource", () => {
+  it("emits the public umbrella handoff contract", () => {
+    const source = createConsumerSmokeSource();
+
+    expect(source).toContain(
+      'import { Button, createChannel, Message } from "@copilotkit/channels";',
+    );
+    expect(source).toContain(
+      'import { slack } from "@copilotkit/channels/slack";',
+    );
+    expect(source).toContain(
+      'import { intelligenceAdapter } from "@copilotkit/channels/intelligence";',
+    );
+    expect(source).not.toContain("createBot");
+    expect(source).not.toContain("startChannelsOverRealtimeGateway");
+    expect(source).not.toContain("@copilotkit/channels-core");
+    expect(source).not.toContain("@copilotkit/channels-ui");
+    for (const adapter of ADAPTERS) {
+      expect(source).not.toContain(`from "${adapter}"`);
     }
   });
 });

--- a/scripts/release/lib/channels-umbrella.ts
+++ b/scripts/release/lib/channels-umbrella.ts
@@ -15,8 +15,8 @@ interface ConsumerManifestOptions {
 }
 
 export const FOUNDATION = [
-  "@copilotkit/channels-core",
   "@copilotkit/channels-ui",
+  "@copilotkit/channels-core",
 ] as const;
 
 export const ADAPTERS = [
@@ -73,6 +73,20 @@ export function createConsumerManifest({
   }
 
   return manifest;
+}
+
+export function createConsumerSmokeSource(): string {
+  return `import { Button, createChannel, Message } from "@copilotkit/channels";
+import { slack } from "@copilotkit/channels/slack";
+import { teams } from "@copilotkit/channels/teams";
+import { intelligenceAdapter } from "@copilotkit/channels/intelligence";
+import { discord } from "@copilotkit/channels/discord";
+import { telegram } from "@copilotkit/channels/telegram";
+import { whatsapp } from "@copilotkit/channels/whatsapp";
+
+const view = <Message><Button>OK</Button></Message>;
+void [createChannel, slack, teams, intelligenceAdapter, discord, telegram, whatsapp, view];
+`;
 }
 
 function requireManifest(

--- a/scripts/release/lib/config.test.ts
+++ b/scripts/release/lib/config.test.ts
@@ -1,18 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { getScopeConfig } from "./config.js";
 import { getPackagesForScope } from "./versions.js";
-
-const CHANNELS_PACKAGES = [
-  "@copilotkit/channels-ui",
-  "@copilotkit/channels-core",
-  "@copilotkit/channels-slack",
-  "@copilotkit/channels-teams",
-  "@copilotkit/channels-intelligence",
-  "@copilotkit/channels-discord",
-  "@copilotkit/channels-telegram",
-  "@copilotkit/channels-whatsapp",
-  "@copilotkit/channels",
-];
+import { FAMILY as CHANNELS_PACKAGES } from "./channels-umbrella.js";
 
 describe("Channels release scope", () => {
   it("publishes the complete Channels family from one shared scope", () => {

--- a/scripts/release/verify-channels-umbrella.ts
+++ b/scripts/release/verify-channels-umbrella.ts
@@ -11,6 +11,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   createConsumerManifest,
+  createConsumerSmokeSource,
   createConsumerWorkspaceYaml,
   FAMILY,
   validatePackedManifests,
@@ -237,17 +238,7 @@ function writeConsumer(
   );
   writeFileSync(
     join(consumerDir, "smoke.tsx"),
-    `import { Button, createChannel, Message } from "@copilotkit/channels";
-import { slack } from "@copilotkit/channels/slack";
-import { teams } from "@copilotkit/channels/teams";
-import { intelligenceAdapter } from "@copilotkit/channels/intelligence";
-import { discord } from "@copilotkit/channels/discord";
-import { telegram } from "@copilotkit/channels/telegram";
-import { whatsapp } from "@copilotkit/channels/whatsapp";
-
-const view = <Message><Button>OK</Button></Message>;
-void [createChannel, slack, teams, intelligenceAdapter, discord, telegram, whatsapp, view];
-`,
+    createConsumerSmokeSource(),
   );
 }
 


### PR DESCRIPTION
## Summary

- align the Channels release helper order with the installable package family contract
- reuse the shared Channels family contract in release config tests instead of duplicating the package list
- move the generated consumer smoke source into a tested helper so it stays on the public umbrella API (`@copilotkit/channels` + subpaths, `createChannel`) and does not regress to the legacy `createBot` / realtime launcher handoff

Closes #5926.
Related docs PR: #5925.

## Testing

- `npx --yes -p vitest@4.1.3 -p semver@7.8.1 bash -lc 'NPM_BIN="$(dirname "$(which vitest)")"; NPM_ROOT="$(dirname "$NPM_BIN")"; export PATH="$NPM_BIN:/opt/homebrew/bin:$PATH"; rm -rf node_modules; mkdir node_modules; ln -s "$NPM_ROOT/semver" node_modules/semver; trap "rm -rf node_modules" EXIT; node --version; vitest run scripts/release/lib/channels-umbrella.test.ts scripts/release/lib/config.test.ts'`
- `git diff --check`
