### PR TITLE
docs(runtime): add Docker Model Runner setup

### DIFF
--- a/packages/runtime/src/service-adapters/openai/openai-adapter.ts
+++ b/packages/runtime/src/service-adapters/openai/openai-adapter.ts
@@ -17,6 +17,26 @@
  * return new OpenAIAdapter({ openai });
  * ```
  *
+ * ## Example with Docker Model Runner
+ *
+ * ```ts
+ * import { CopilotRuntime, OpenAIAdapter } from "@copilotkit/runtime";
+ * import OpenAI from "openai";
+ *
+ * const openai = new OpenAI({
+ *   baseURL: process.env["DOCKER_MODEL_RUNNER_BASE_URL"] ?? "http://localhost:12434/engines/v1",
+ *   // Docker Model Runner ignores Authorization, but the OpenAI SDK requires a value.
+ *   apiKey: process.env["DOCKER_MODEL_RUNNER_API_KEY"] ?? "not-needed",
+ * });
+ *
+ * const copilotKit = new CopilotRuntime();
+ *
+ * return new OpenAIAdapter({
+ *   openai,
+ *   model: process.env["DOCKER_MODEL_RUNNER_MODEL"] ?? "ai/smollm2",
+ * });
+ * ```
+ *
  * ## Example with Azure OpenAI
  *
  * ```ts

--- a/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
@@ -50,6 +50,8 @@ import { CopilotKit } from "@copilotkit/react-core/v2";
 For Express, NestJS, or plain Node.js HTTP variants, see the [quickstart](/quickstart).
 For the exact HTTP routes the runtime exposes (and how to probe them with `curl`),
 see [Runtime HTTP endpoints](/backend/runtime-endpoints).
+To run the runtime against a local OpenAI-compatible Docker Model Runner LLM,
+see [Docker Model Runner](/backend/docker-model-runner).
 
 <Callout type="info" title="Legacy vs. v2 runtime endpoints">
   The `copilotRuntimeNextJSAppRouterEndpoint` / `copilotRuntimeNodeHttpEndpoint` / `copilotRuntimeNodeExpressEndpoint` / `copilotRuntimeNestEndpoint` helpers above are the **legacy** (v1) endpoint factories, imported from `@copilotkit/runtime`. The v2 runtime exposes a smaller, framework-agnostic API under `@copilotkit/runtime/v2`:

--- a/showcase/shell-docs/src/content/docs/backend/docker-model-runner.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/docker-model-runner.mdx
@@ -1,0 +1,120 @@
+---
+title: "Docker Model Runner"
+icon: "lucide/Container"
+description: "Run CopilotKit against a local Docker Model Runner LLM through the OpenAI-compatible API."
+---
+
+Docker Model Runner exposes an OpenAI-compatible chat completions API, so CopilotKit does not need a separate Docker-specific adapter. Point the OpenAI SDK at the Model Runner base URL, pass that client to `OpenAIAdapter`, and keep the rest of your Copilot Runtime wiring unchanged.
+
+## Prerequisites
+
+- Docker Model Runner is enabled and has a chat model pulled, for example `ai/smollm2`.
+- TCP host access is enabled if your runtime runs as a host process.
+- Your chosen model supports the capabilities your copilot uses. Tool calling depends on the model and inference engine.
+
+<Callout type="info" title="Base URL">
+  For a runtime running on the host, Docker's OpenAI-compatible base URL is usually `http://localhost:12434/engines/v1`. If your Copilot Runtime runs inside a container, use the container-reachable Model Runner host instead, such as `http://model-runner.docker.internal/engines/v1` on Docker Desktop.
+</Callout>
+
+## Next.js runtime route
+
+```ts title="app/api/copilotkit/route.ts"
+import {
+  CopilotRuntime,
+  OpenAIAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import OpenAI from "openai";
+import { NextRequest } from "next/server";
+
+const model = process.env.DOCKER_MODEL_RUNNER_MODEL ?? "ai/smollm2";
+
+const openai = new OpenAI({
+  baseURL:
+    process.env.DOCKER_MODEL_RUNNER_BASE_URL ??
+    "http://localhost:12434/engines/v1",
+  // Docker Model Runner ignores Authorization, but the OpenAI SDK requires a value.
+  apiKey: process.env.DOCKER_MODEL_RUNNER_API_KEY ?? "not-needed",
+});
+
+const serviceAdapter = new OpenAIAdapter({
+  openai,
+  model,
+});
+
+const runtime = new CopilotRuntime({
+  agents: {
+    // your agents go here
+  },
+});
+
+export const POST = async (req: NextRequest) => {
+  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+    runtime,
+    serviceAdapter,
+    endpoint: "/api/copilotkit",
+  });
+
+  return handleRequest(req);
+};
+```
+
+Add the matching environment variables:
+
+```bash title=".env.local"
+DOCKER_MODEL_RUNNER_BASE_URL=http://localhost:12434/engines/v1
+DOCKER_MODEL_RUNNER_MODEL=ai/smollm2
+# Optional; Docker Model Runner ignores it, but some wrappers expect one.
+DOCKER_MODEL_RUNNER_API_KEY=not-needed
+```
+
+Then point your frontend at the runtime as usual:
+
+```tsx
+import { CopilotKit } from "@copilotkit/react-core/v2";
+
+<CopilotKit runtimeUrl="/api/copilotkit">
+  <YourApp />
+</CopilotKit>;
+```
+
+## Docker Compose runtime
+
+When your application runs in Compose, the runtime container must be able to reach Model Runner. On Docker Desktop, use `model-runner.docker.internal`:
+
+```yaml title="compose.yaml"
+services:
+  web:
+    build: .
+    environment:
+      DOCKER_MODEL_RUNNER_BASE_URL: http://model-runner.docker.internal/engines/v1
+      DOCKER_MODEL_RUNNER_MODEL: ai/smollm2
+      DOCKER_MODEL_RUNNER_API_KEY: not-needed
+```
+
+On Docker Engine, add a host-gateway mapping if `model-runner.docker.internal` is not already available:
+
+```yaml title="compose.yaml"
+services:
+  web:
+    build: .
+    extra_hosts:
+      - "model-runner.docker.internal:host-gateway"
+    environment:
+      DOCKER_MODEL_RUNNER_BASE_URL: http://model-runner.docker.internal:12434/engines/v1
+      DOCKER_MODEL_RUNNER_MODEL: ai/smollm2
+      DOCKER_MODEL_RUNNER_API_KEY: not-needed
+```
+
+## Troubleshooting
+
+- **Connection refused:** confirm Model Runner is enabled, the TCP endpoint is enabled for host access, and the runtime is using the correct host/container base URL.
+- **Model not found:** use a full Docker Model Runner model name such as `ai/smollm2` or `ai/llama3.2`.
+- **Tool calls do not work:** choose a model and inference engine that support function calling, or avoid CopilotKit actions that require tool calling.
+- **401 from a wrapper or proxy:** Docker Model Runner itself does not require an API key, but the OpenAI SDK and some proxies expect a non-empty `apiKey`.
+
+## Related
+
+- [OpenAIAdapter](/reference/v1/classes/llm-adapters/OpenAIAdapter): the adapter used for OpenAI-compatible endpoints.
+- [Copilot Runtime](/backend/copilot-runtime): runtime setup and frontend wiring.
+- [Runtime HTTP endpoints](/backend/runtime-endpoints): how to probe a self-hosted runtime.

--- a/showcase/shell-docs/src/content/docs/backend/meta.json
+++ b/showcase/shell-docs/src/content/docs/backend/meta.json
@@ -2,6 +2,7 @@
   "title": "Runtime",
   "pages": [
     "copilot-runtime",
+    "docker-model-runner",
     "runtime-endpoints",
     "custom-agent",
     "agent-runner",

--- a/showcase/shell-docs/src/content/reference/v1/classes/llm-adapters/OpenAIAdapter.mdx
+++ b/showcase/shell-docs/src/content/reference/v1/classes/llm-adapters/OpenAIAdapter.mdx
@@ -11,79 +11,98 @@ description: "Copilot Runtime adapter for OpenAI."
   */
 }
 Copilot Runtime adapter for OpenAI.
- 
+
 ## Example
- 
+
 ```ts
 import { CopilotRuntime, OpenAIAdapter } from "@copilotkit/runtime";
 import OpenAI from "openai";
- 
+
 const copilotKit = new CopilotRuntime();
- 
+
 const openai = new OpenAI({
   organization: "<your-organization-id>", // optional
   apiKey: "<your-api-key>",
 });
- 
+
 return new OpenAIAdapter({ openai });
 ```
- 
-## Example with Azure OpenAI
- 
+
+## Example with Docker Model Runner
+
 ```ts
 import { CopilotRuntime, OpenAIAdapter } from "@copilotkit/runtime";
 import OpenAI from "openai";
- 
+
+const openai = new OpenAI({
+  baseURL: process.env["DOCKER_MODEL_RUNNER_BASE_URL"] ?? "http://localhost:12434/engines/v1",
+  // Docker Model Runner ignores Authorization, but the OpenAI SDK requires a value.
+  apiKey: process.env["DOCKER_MODEL_RUNNER_API_KEY"] ?? "not-needed",
+});
+
+const copilotKit = new CopilotRuntime();
+
+return new OpenAIAdapter({
+  openai,
+  model: process.env["DOCKER_MODEL_RUNNER_MODEL"] ?? "ai/smollm2",
+});
+```
+
+## Example with Azure OpenAI
+
+```ts
+import { CopilotRuntime, OpenAIAdapter } from "@copilotkit/runtime";
+import OpenAI from "openai";
+
 // The name of your Azure OpenAI Instance.
 // https://learn.microsoft.com/en-us/azure/cognitive-services/openai/how-to/create-resource?pivots=web-portal#create-a-resource
 const instance = "<your instance name>";
- 
+
 // Corresponds to your Model deployment within your OpenAI resource, e.g. my-gpt35-16k-deployment
 // Navigate to the Azure OpenAI Studio to deploy a model.
 const model = "<your model>";
- 
+
 const apiKey = process.env["AZURE_OPENAI_API_KEY"];
 if (!apiKey) {
   throw new Error("The AZURE_OPENAI_API_KEY environment variable is missing or empty.");
 }
- 
+
 const copilotKit = new CopilotRuntime();
- 
+
 const openai = new OpenAI({
   apiKey,
   baseURL: `https://${instance}.openai.azure.com/openai/deployments/${model}`,
   defaultQuery: { "api-version": "2024-04-01-preview" },
   defaultHeaders: { "api-key": apiKey },
 });
- 
+
 return new OpenAIAdapter({ openai });
 ```
 
 ## Constructor Parameters
 
-<PropertyReference name="openai" type="OpenAI"  > 
+<PropertyReference name="openai" type="OpenAI"  >
 An optional OpenAI instance to use.  If not provided, a new instance will be
   created.
 </PropertyReference>
 
-<PropertyReference name="model" type="string"  > 
+<PropertyReference name="model" type="string"  >
 The model to use.
 </PropertyReference>
 
-<PropertyReference name="disableParallelToolCalls" type="boolean"  default="false"> 
+<PropertyReference name="disableParallelToolCalls" type="boolean"  default="false">
 Whether to disable parallel tool calls.
   You can disable parallel tool calls to force the model to execute tool calls sequentially.
   This is useful if you want to execute tool calls in a specific order so that the state changes
   introduced by one tool call are visible to the next tool call. (i.e. new actions or readables)
 </PropertyReference>
 
-<PropertyReference name="keepSystemRole" type="boolean"  default="false"> 
+<PropertyReference name="keepSystemRole" type="boolean"  default="false">
 Whether to keep the role in system messages as "System".
   By default, it is converted to "developer", which is used by newer OpenAI models
 </PropertyReference>
 
-<PropertyReference name="maxInputTokens" type="number"  > 
+<PropertyReference name="maxInputTokens" type="number"  >
 Optional maximum input token limit. Overrides the default model-based limit
   used when trimming messages to fit the context window.
 </PropertyReference>
-

--- a/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
@@ -200,6 +200,16 @@ describe("loadDoc", () => {
       "Headless Threads",
     );
   });
+
+  it("publishes Docker Model Runner runtime guidance", () => {
+    const doc = loadDoc("backend/docker-model-runner");
+
+    expect(doc?.fm.title).toBe("Docker Model Runner");
+    expect(doc?.source).toContain("DOCKER_MODEL_RUNNER_BASE_URL");
+    expect(doc?.source).toContain("new OpenAIAdapter");
+    expect(doc?.source).toContain("http://localhost:12434/engines/v1");
+    expect(doc?.source).not.toContain("ExperimentalOllamaAdapter");
+  });
 });
 
 describe("readIcon", () => {


### PR DESCRIPTION
## Summary

- add a Runtime guide for using Docker Model Runner through its OpenAI-compatible API
- document `OpenAIAdapter` + OpenAI SDK `baseURL` wiring for host and Docker Compose runtimes
- add Docker Model Runner coverage to the generated OpenAIAdapter reference and docs-render regression test

Closes #2530.

## Testing

- `vitest run src/lib/__tests__/docs-render.test.ts` from `showcase/shell-docs` using temporary npx dependency symlinks
- custom Node docs contract check for the new page, backend nav, OpenAIAdapter reference, and regression test
- `git diff --check`
