### PR TITLE
fix(runtime): pass agent id to connect requests

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/handle-connect.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handle-connect.test.ts
@@ -136,6 +136,56 @@ describe("handleConnectAgent", () => {
     expect(recordedRequests[0].headers).not.toHaveProperty("user-agent");
   });
 
+  it("forwards the route agentId to runner.connect()", async () => {
+    const recordedRequests: AgentRunnerConnectRequest[] = [];
+    let resolveConnect: (() => void) | undefined;
+    const connectInvoked = new Promise<void>((resolve) => {
+      resolveConnect = resolve;
+    });
+
+    const runtime = createMockRuntime(
+      { "test-agent": { clone: () => ({}) } },
+      (request: AgentRunnerConnectRequest) =>
+        new Observable<BaseEvent>((subscriber) => {
+          recordedRequests.push(request);
+          resolveConnect?.();
+          subscriber.complete();
+        }),
+    );
+
+    const request = new Request(
+      "https://example.com/agent/test-agent/connect",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          threadId: "thread-1",
+          runId: "run-1",
+          state: {},
+          messages: [],
+          tools: [],
+          context: [],
+          forwardedProps: {},
+        }),
+      },
+    );
+
+    const response = await handleConnectAgent({
+      runtime,
+      request,
+      agentId: "test-agent",
+    });
+
+    expect(response.status).toBe(200);
+    await connectInvoked;
+
+    expect(recordedRequests).toHaveLength(1);
+    expect(recordedRequests[0]).toMatchObject({
+      threadId: "thread-1",
+      agentId: "test-agent",
+    });
+  });
+
   it("passes empty headers object when no forwardable headers present", async () => {
     const recordedRequests: AgentRunnerConnectRequest[] = [];
     let resolveConnect: (() => void) | undefined;

--- a/packages/runtime/src/v2/runtime/handlers/sse/connect.ts
+++ b/packages/runtime/src/v2/runtime/handlers/sse/connect.ts
@@ -46,6 +46,7 @@ export function handleSseConnect({
     observableFactory: () =>
       runtime.runner.connect({
         threadId,
+        agentId,
         // Forward-looking plumbing: we compute the merged header set (server
         // `agent.headers` win on collision, case-insensitively; non-colliding
         // inbound headers still forward — see `mergeForwardableHeaders`, #5712)

--- a/packages/runtime/src/v2/runtime/runner/agent-runner.ts
+++ b/packages/runtime/src/v2/runtime/runner/agent-runner.ts
@@ -15,6 +15,7 @@ export interface AgentRunnerRunRequest {
 
 export interface AgentRunnerConnectRequest {
   threadId: string;
+  agentId?: string;
   headers?: Record<string, string>;
   joinCode?: string;
 }


### PR DESCRIPTION
Fixes #5911.

## Summary
- Add optional `agentId` to `AgentRunnerConnectRequest`.
- Pass the route-resolved agent id through the SSE connect handler into `runner.connect()`.
- Add a regression test that verifies `handleConnectAgent` forwards the agent id to the runner connect request.

## Verification
- `pnpm nx run @copilotkit/runtime:test --excludeTaskDependencies --skip-nx-cache -- src/v2/runtime/__tests__/handle-connect.test.ts src/v2/runtime/handlers/sse/__tests__/sse-connect-agent-id.test.ts`
- `pnpm nx run @copilotkit/runtime:check-types --excludeTaskDependencies --skip-nx-cache`