### PR TITLE
Add optional timestamps to default chat UI

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -33,6 +33,7 @@ import { useCopilotKit, useLicenseContext } from "../../context";
 import { InlineFeatureWarning } from "../../components/license-warning-banner";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
+import type { Message } from "@ag-ui/core";
 import type { SlotValue } from "../../lib/slots";
 import { renderSlot, useShallowStableRef } from "../../lib/slots";
 import {
@@ -41,6 +42,31 @@ import {
 } from "../../lib/transcription-client";
 import { LastUserMessageContext } from "./last-user-message-context";
 import type { LastUserMessageState } from "./last-user-message-context";
+import { getMessageTimestampValue } from "./message-timestamps";
+
+export function getMessagesMemoKey(messages: readonly Message[]): string {
+  return messages
+    .map((message) => {
+      const contentKey =
+        typeof message.content === "string"
+          ? message.content.length
+          : Array.isArray(message.content)
+            ? message.content.length
+            : 0;
+      const toolCallsKey =
+        "toolCalls" in message && Array.isArray(message.toolCalls)
+          ? message.toolCalls
+              .map(
+                (toolCall) =>
+                  `${toolCall.id}:${toolCall.function?.arguments?.length ?? 0}`,
+              )
+              .join(";")
+          : "";
+      const timestampKey = getMessageTimestampValue(message) ?? "";
+      return `${message.id}:${message.role}:${contentKey}:${toolCallsKey}:${timestampKey}`;
+    })
+    .join(",");
+}
 
 export type CopilotChatProps = Omit<
   CopilotChatViewProps,
@@ -980,25 +1006,7 @@ export function CopilotChat({
   //   - message id, role, content length (text streaming)
   //   - content part count (multimodal additions)
   //   - tool call ids + argument lengths (tool call streaming)
-  const messagesMemoKey = agent.messages
-    .map((m) => {
-      const contentKey =
-        typeof m.content === "string"
-          ? m.content.length
-          : Array.isArray(m.content)
-            ? m.content.length
-            : 0;
-      const toolCallsKey =
-        "toolCalls" in m && Array.isArray(m.toolCalls)
-          ? m.toolCalls
-              .map(
-                (tc: any) => `${tc.id}:${tc.function?.arguments?.length ?? 0}`,
-              )
-              .join(";")
-          : "";
-      return `${m.id}:${m.role}:${contentKey}:${toolCallsKey}`;
-    })
-    .join(",");
+  const messagesMemoKey = getMessagesMemoKey(agent.messages);
   const messages = useMemo(
     () => [...agent.messages],
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/react-core/src/v2/components/chat/CopilotChatAssistantMessage.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatAssistantMessage.tsx
@@ -25,6 +25,8 @@ import { renderSlot } from "../../lib/slots";
 import { Streamdown } from "streamdown";
 import { copyToClipboard } from "@copilotkit/shared";
 import CopilotChatToolCallsView from "./CopilotChatToolCallsView";
+import { useMessageTimestamp } from "./message-timestamps";
+import type { CopilotChatTimestampFormatter } from "./message-timestamps";
 
 export type CopilotChatAssistantMessageProps = WithSlots<
   {
@@ -45,6 +47,8 @@ export type CopilotChatAssistantMessageProps = WithSlots<
     message: AssistantMessage;
     messages?: Message[];
     isRunning?: boolean;
+    showTimestamp?: boolean;
+    formatTimestamp?: CopilotChatTimestampFormatter;
     additionalToolbarItems?: React.ReactNode;
     toolbarVisible?: boolean;
   } & React.HTMLAttributes<HTMLDivElement>
@@ -54,6 +58,8 @@ export function CopilotChatAssistantMessage({
   message,
   messages,
   isRunning,
+  showTimestamp,
+  formatTimestamp,
   onThumbsUp,
   onThumbsDown,
   onReadAloud,
@@ -155,6 +161,11 @@ export function CopilotChatAssistantMessage({
 
   // Don't show toolbar if message has no content (only tool calls)
   const hasContent = !!(message.content && message.content.trim().length > 0);
+  const { timestamp, timestampText } = useMessageTimestamp(
+    message,
+    showTimestamp,
+    formatTimestamp,
+  );
   const isLatestAssistantMessage =
     message.role === "assistant" &&
     messages?.[messages.length - 1]?.id === message.id;
@@ -176,6 +187,8 @@ export function CopilotChatAssistantMessage({
           message,
           messages,
           isRunning,
+          showTimestamp,
+          formatTimestamp,
           onThumbsUp,
           onThumbsDown,
           onReadAloud,
@@ -202,6 +215,15 @@ export function CopilotChatAssistantMessage({
         {boundMarkdownRenderer}
       </div>
       {boundToolCallsView}
+      {timestamp && timestampText ? (
+        <time
+          data-testid="copilot-message-timestamp"
+          dateTime={timestamp.toISOString()}
+          className="cpk:block cpk:mt-1 cpk:text-xs cpk:leading-4 cpk:text-muted-foreground"
+        >
+          {timestampText}
+        </time>
+      ) : null}
       {shouldShowToolbar && boundToolbar}
     </div>
   );

--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -31,6 +31,8 @@ import {
 } from "../intelligence-indicator";
 import type { IntelligenceIndicatorView } from "../intelligence-indicator";
 import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
+import type { CopilotChatTimestampFormatter } from "./message-timestamps";
+import { getMessageTimestampValue } from "./message-timestamps";
 
 /**
  * Resolves a slot value into a { Component, slotProps } pair, handling the three
@@ -68,12 +70,16 @@ const MemoizedAssistantMessage = React.memo(
     message,
     messages,
     isRunning,
+    showTimestamps,
+    formatTimestamp,
     AssistantMessageComponent,
     slotProps,
   }: {
     message: AssistantMessage;
     messages: Message[];
     isRunning: boolean;
+    showTimestamps?: boolean;
+    formatTimestamp?: CopilotChatTimestampFormatter;
     AssistantMessageComponent: typeof CopilotChatAssistantMessage;
     slotProps?: Partial<
       React.ComponentProps<typeof CopilotChatAssistantMessage>
@@ -84,6 +90,8 @@ const MemoizedAssistantMessage = React.memo(
         message={message}
         messages={messages}
         isRunning={isRunning}
+        showTimestamp={showTimestamps}
+        formatTimestamp={formatTimestamp}
         {...slotProps}
       />
     );
@@ -92,6 +100,11 @@ const MemoizedAssistantMessage = React.memo(
     // Only re-render if this specific message changed
     if (prevProps.message.id !== nextProps.message.id) return false;
     if (prevProps.message.content !== nextProps.message.content) return false;
+    if (
+      getMessageTimestampValue(prevProps.message) !==
+      getMessageTimestampValue(nextProps.message)
+    )
+      return false;
 
     // Compare tool calls if present
     const prevToolCalls = prevProps.message.toolCalls;
@@ -136,6 +149,8 @@ const MemoizedAssistantMessage = React.memo(
       nextProps.message.id;
     if (nextIsLatest && prevProps.isRunning !== nextProps.isRunning)
       return false;
+    if (prevProps.showTimestamps !== nextProps.showTimestamps) return false;
+    if (prevProps.formatTimestamp !== nextProps.formatTimestamp) return false;
 
     // Check if component reference changed
     if (
@@ -157,21 +172,39 @@ const MemoizedAssistantMessage = React.memo(
 const MemoizedUserMessage = React.memo(
   function MemoizedUserMessage({
     message,
+    showTimestamps,
+    formatTimestamp,
     UserMessageComponent,
     slotProps,
   }: {
     message: UserMessage;
+    showTimestamps?: boolean;
+    formatTimestamp?: CopilotChatTimestampFormatter;
     UserMessageComponent: typeof CopilotChatUserMessage;
     slotProps?: Partial<React.ComponentProps<typeof CopilotChatUserMessage>>;
   }) {
-    return <UserMessageComponent message={message} {...slotProps} />;
+    return (
+      <UserMessageComponent
+        message={message}
+        showTimestamp={showTimestamps}
+        formatTimestamp={formatTimestamp}
+        {...slotProps}
+      />
+    );
   },
   (prevProps, nextProps) => {
     // Only re-render if this specific message changed
     if (prevProps.message.id !== nextProps.message.id) return false;
     if (prevProps.message.content !== nextProps.message.content) return false;
+    if (
+      getMessageTimestampValue(prevProps.message) !==
+      getMessageTimestampValue(nextProps.message)
+    )
+      return false;
     if (prevProps.UserMessageComponent !== nextProps.UserMessageComponent)
       return false;
+    if (prevProps.showTimestamps !== nextProps.showTimestamps) return false;
+    if (prevProps.formatTimestamp !== nextProps.formatTimestamp) return false;
     // Check if slot props changed
     if (prevProps.slotProps !== nextProps.slotProps) return false;
     return true;
@@ -362,6 +395,8 @@ export type CopilotChatMessageViewProps = Omit<
     {
       isRunning?: boolean;
       messages?: Message[];
+      showTimestamps?: boolean;
+      formatTimestamp?: CopilotChatTimestampFormatter;
     } & React.HTMLAttributes<HTMLDivElement>
   >,
   "children"
@@ -387,6 +422,8 @@ export function CopilotChatMessageView({
   cursor,
   intelligenceIndicator,
   isRunning = false,
+  showTimestamps = false,
+  formatTimestamp,
   children,
   className,
   ...props
@@ -577,6 +614,8 @@ export function CopilotChatMessageView({
           message={message as AssistantMessage}
           messages={messages}
           isRunning={isRunning}
+          showTimestamps={showTimestamps}
+          formatTimestamp={formatTimestamp}
           AssistantMessageComponent={AssistantComponent}
           slotProps={assistantSlotProps}
         />,
@@ -586,6 +625,8 @@ export function CopilotChatMessageView({
         <MemoizedUserMessage
           key={message.id}
           message={message as UserMessage}
+          showTimestamps={showTimestamps}
+          formatTimestamp={formatTimestamp}
           UserMessageComponent={UserComponent}
           slotProps={userSlotProps}
         />,

--- a/packages/react-core/src/v2/components/chat/CopilotChatUserMessage.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatUserMessage.tsx
@@ -22,6 +22,8 @@ import type {
   DocumentInputPart,
 } from "@copilotkit/shared";
 import { CopilotChatAttachmentRenderer } from "./CopilotChatAttachmentRenderer";
+import { useMessageTimestamp } from "./message-timestamps";
+import type { CopilotChatTimestampFormatter } from "./message-timestamps";
 
 function flattenUserMessageContent(content?: UserMessage["content"]): string {
   if (!content) {
@@ -105,6 +107,8 @@ export type CopilotChatUserMessageProps = WithSlots<
     message: UserMessage;
     branchIndex?: number;
     numberOfBranches?: number;
+    showTimestamp?: boolean;
+    formatTimestamp?: CopilotChatTimestampFormatter;
     additionalToolbarItems?: React.ReactNode;
   } & React.HTMLAttributes<HTMLDivElement>
 >;
@@ -116,6 +120,8 @@ export function CopilotChatUserMessage({
   numberOfBranches,
   onSwitchToBranch,
   additionalToolbarItems,
+  showTimestamp,
+  formatTimestamp,
   messageRenderer,
   toolbar,
   copyButton,
@@ -177,6 +183,11 @@ export function CopilotChatUserMessage({
 
   const showBranchNavigation =
     numberOfBranches && numberOfBranches > 1 && onSwitchToBranch;
+  const { timestamp, timestampText } = useMessageTimestamp(
+    message,
+    showTimestamp,
+    formatTimestamp,
+  );
 
   const BoundToolbar = renderSlot(toolbar, CopilotChatUserMessage.Toolbar, {
     children: (
@@ -201,6 +212,8 @@ export function CopilotChatUserMessage({
           message,
           branchIndex,
           numberOfBranches,
+          showTimestamp,
+          formatTimestamp,
           additionalToolbarItems,
         })}
       </div>
@@ -231,6 +244,15 @@ export function CopilotChatUserMessage({
         </div>
       )}
       {BoundMessageRenderer}
+      {timestamp && timestampText ? (
+        <time
+          data-testid="copilot-message-timestamp"
+          dateTime={timestamp.toISOString()}
+          className="cpk:block cpk:mt-1 cpk:text-xs cpk:leading-4 cpk:text-muted-foreground"
+        >
+          {timestampText}
+        </time>
+      ) : null}
       {BoundToolbar}
     </div>
   );

--- a/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
@@ -39,6 +39,7 @@ import { useKeyboardHeight } from "../../hooks/use-keyboard-height";
 import { normalizeAutoScroll } from "./normalize-auto-scroll";
 import type { AutoScrollMode } from "./normalize-auto-scroll";
 import { usePinToSend } from "../../hooks/use-pin-to-send";
+import type { CopilotChatTimestampFormatter } from "./message-timestamps";
 
 // Vertical gap between the scroll-to-bottom button and the input container.
 const SCROLL_BUTTON_OFFSET = 16;
@@ -64,6 +65,8 @@ export type CopilotChatViewProps = WithSlots<
   {
     messages?: Message[];
     autoScroll?: AutoScrollMode | boolean;
+    showTimestamps?: boolean;
+    formatTimestamp?: CopilotChatTimestampFormatter;
     isRunning?: boolean;
     suggestions?: Suggestion[];
     suggestionLoadingIndexes?: ReadonlyArray<number>;
@@ -144,6 +147,8 @@ export function CopilotChatView({
   welcomeScreen,
   messages = [],
   autoScroll = true,
+  showTimestamps = false,
+  formatTimestamp,
   isRunning = false,
   suggestions,
   suggestionLoadingIndexes,
@@ -248,6 +253,8 @@ export function CopilotChatView({
   const BoundMessageView = renderSlot(messageView, CopilotChatMessageView, {
     messages,
     isRunning,
+    showTimestamps,
+    formatTimestamp,
     intelligenceIndicator,
   });
 

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.memo-key.test.ts
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.memo-key.test.ts
@@ -1,0 +1,27 @@
+import type { Message } from "@ag-ui/core";
+import { getMessagesMemoKey } from "../CopilotChat";
+
+describe("getMessagesMemoKey", () => {
+  const baseMessage = {
+    id: "message-1",
+    role: "user",
+    content: "Hello",
+  } as Message;
+
+  it("changes when only the message timestamp changes", () => {
+    const withoutTimestamp = getMessagesMemoKey([baseMessage]);
+    const withCreatedAt = getMessagesMemoKey([
+      {
+        ...baseMessage,
+        createdAt: "2026-07-16T09:30:00.000Z",
+      } as unknown as Message,
+    ]);
+    const withTimestamp = getMessagesMemoKey([
+      { ...baseMessage, timestamp: 1_700_000_000 } as unknown as Message,
+    ]);
+
+    expect(withCreatedAt).not.toBe(withoutTimestamp);
+    expect(withTimestamp).not.toBe(withoutTimestamp);
+    expect(withCreatedAt).not.toBe(withTimestamp);
+  });
+});

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatMessageView.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatMessageView.test.tsx
@@ -1,4 +1,7 @@
 import React from "react";
+import { act } from "react";
+import { hydrateRoot } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
 import { render, screen } from "@testing-library/react";
 import { z } from "zod";
 import { vi } from "vitest";
@@ -15,6 +18,12 @@ import type {
   UserMessage,
 } from "@ag-ui/core";
 import type { ReactActivityMessageRenderer } from "../../../types";
+import type { CopilotChatTimestampFormatter } from "../message-timestamps";
+import {
+  getMessageTimestamp,
+  useMessageTimestamp,
+} from "../message-timestamps";
+import { CopilotChatUserMessage } from "../CopilotChatUserMessage";
 
 // ---------------------------------------------------------------------------
 // Shared constants & helpers
@@ -58,18 +67,116 @@ function toolCall(id: string, name: string, args = "{}") {
 function renderMessageView({
   messages,
   renderActivityMessages,
+  showTimestamps,
+  formatTimestamp,
 }: {
   messages: Message[];
   renderActivityMessages?: ReactActivityMessageRenderer<{ percent: number }>[];
+  showTimestamps?: boolean;
+  formatTimestamp?: CopilotChatTimestampFormatter;
 }) {
   return render(
     <CopilotKitProvider renderActivityMessages={renderActivityMessages}>
       <CopilotChatConfigurationProvider agentId={AGENT_ID} threadId={THREAD_ID}>
-        <CopilotChatMessageView messages={messages} />
+        <CopilotChatMessageView
+          messages={messages}
+          showTimestamps={showTimestamps}
+          formatTimestamp={formatTimestamp}
+        />
       </CopilotChatConfigurationProvider>
     </CopilotKitProvider>,
   );
 }
+
+describe("CopilotChatMessageView timestamps", () => {
+  const createdAt = "2026-07-16T09:30:00.000Z";
+
+  it("keeps timestamps hidden by default", () => {
+    const message = { ...userMsg("user-1", "Hello"), createdAt } as Message;
+
+    renderMessageView({ messages: [message] });
+
+    expect(screen.queryByTestId("copilot-message-timestamp")).toBeNull();
+  });
+
+  it("does not render locale-dependent timestamp text during SSR", () => {
+    const message = { ...userMsg("user-1", "Hello"), createdAt } as Message;
+
+    const html = renderToStaticMarkup(
+      <CopilotChatUserMessage message={message as UserMessage} showTimestamp />,
+    );
+
+    expect(html).not.toContain("copilot-message-timestamp");
+  });
+
+  it("does not schedule a hydration update when timestamps are hidden", async () => {
+    const message = { ...userMsg("user-1", "Hello"), createdAt } as Message;
+    const container = document.createElement("div");
+    let renderCount = 0;
+
+    function TimestampProbe() {
+      renderCount += 1;
+      useMessageTimestamp(message, false);
+      return <span>Hello</span>;
+    }
+
+    container.innerHTML = renderToStaticMarkup(<TimestampProbe />);
+    renderCount = 0;
+    const root = hydrateRoot(container, <TimestampProbe />);
+
+    await act(async () => {});
+
+    expect(renderCount).toBe(1);
+    await act(async () => root.unmount());
+  });
+
+  it("falls back to a numeric-string timestamp when createdAt is invalid", () => {
+    const message = {
+      ...userMsg("user-1", "Hello"),
+      createdAt: "not-a-date",
+      timestamp: "1700000000",
+    } as Message;
+
+    expect(getMessageTimestamp(message)?.toISOString()).toBe(
+      "2023-11-14T22:13:20.000Z",
+    );
+  });
+
+  it("renders available timestamps with a custom formatter", () => {
+    const userMessage = {
+      ...userMsg("user-1", "Hello"),
+      createdAt,
+      timestamp: 1_700_000_000,
+    } as Message;
+    const assistantMessage = {
+      ...assistantMsg("assistant-1", "Hi"),
+      timestamp: 1_700_000_000,
+    } as Message;
+    const formatTimestamp = vi.fn(
+      (timestamp: Date, message: Message) =>
+        `${message.role}:${timestamp.toISOString()}`,
+    );
+
+    renderMessageView({
+      messages: [
+        userMessage,
+        assistantMessage,
+        userMsg("user-2", "No timestamp"),
+      ],
+      showTimestamps: true,
+      formatTimestamp,
+    });
+
+    const timestamps = screen.getAllByTestId("copilot-message-timestamp");
+    expect(timestamps).toHaveLength(2);
+    expect(timestamps[0].getAttribute("datetime")).toBe(createdAt);
+    expect(timestamps[0].textContent).toBe(`user:${createdAt}`);
+    expect(timestamps[1].textContent).toBe(
+      "assistant:2023-11-14T22:13:20.000Z",
+    );
+    expect(formatTimestamp).toHaveBeenCalledTimes(2);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/packages/react-core/src/v2/components/chat/index.ts
+++ b/packages/react-core/src/v2/components/chat/index.ts
@@ -39,6 +39,7 @@ export {
   default as CopilotChatMessageView,
   type CopilotChatMessageViewProps,
 } from "./CopilotChatMessageView";
+export type { CopilotChatTimestampFormatter } from "./message-timestamps";
 
 export {
   default as CopilotChatToolCallsView,

--- a/packages/react-core/src/v2/components/chat/message-timestamps.ts
+++ b/packages/react-core/src/v2/components/chat/message-timestamps.ts
@@ -1,0 +1,93 @@
+import type { Message } from "@ag-ui/core";
+import { useSyncExternalStore } from "react";
+
+type TimestampValue = Date | number | string;
+
+type TimestampedMessage = Message & {
+  createdAt?: TimestampValue;
+  timestamp?: TimestampValue;
+};
+
+export type CopilotChatTimestampFormatter = (
+  timestamp: Date,
+  message: Message,
+) => string;
+
+// Keep locale-dependent text out of the server snapshot, then reveal it after hydration.
+const subscribeToClient = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+function parseTimestamp(value: TimestampValue | undefined): Date | null {
+  if (value === undefined || value === null || value === "") return null;
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return null;
+    const date = new Date(
+      Math.abs(value) < 1_000_000_000_000 ? value * 1000 : value,
+    );
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  const normalized = value.trim();
+  if (!normalized) return null;
+
+  const numericValue = Number(normalized);
+  const date =
+    Number.isFinite(numericValue) && /^[+-]?\d+(?:\.\d+)?$/.test(normalized)
+      ? parseTimestamp(numericValue)
+      : new Date(normalized);
+
+  return date && !Number.isNaN(date.getTime()) ? date : null;
+}
+
+export function getMessageTimestampValue(message: Message): number | undefined {
+  return getMessageTimestamp(message)?.getTime();
+}
+
+export function getMessageTimestamp(message: Message): Date | null {
+  const timestamped = message as TimestampedMessage;
+  for (const candidate of [timestamped.createdAt, timestamped.timestamp]) {
+    const timestamp = parseTimestamp(candidate);
+    if (timestamp) return timestamp;
+  }
+  return null;
+}
+
+export function formatMessageTimestamp(
+  timestamp: Date,
+  message: Message,
+  formatTimestamp?: CopilotChatTimestampFormatter,
+): string {
+  if (formatTimestamp) {
+    return formatTimestamp(timestamp, message);
+  }
+
+  return timestamp.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export function useMessageTimestamp(
+  message: Message,
+  showTimestamp: boolean | undefined,
+  formatTimestamp?: CopilotChatTimestampFormatter,
+): { timestamp: Date | null; timestampText: string | null } {
+  const timestamp = showTimestamp ? getMessageTimestamp(message) : null;
+  const isClient = useSyncExternalStore(
+    subscribeToClient,
+    getClientSnapshot,
+    timestamp ? getServerSnapshot : getClientSnapshot,
+  );
+  const timestampText =
+    isClient && timestamp
+      ? formatMessageTimestamp(timestamp, message, formatTimestamp)
+      : null;
+
+  return { timestamp, timestampText };
+}

--- a/packages/react-ui/src/components/chat/Chat.tsx
+++ b/packages/react-ui/src/components/chat/Chat.tsx
@@ -69,6 +69,7 @@ import { RenderMessage as DefaultRenderMessage } from "./messages/RenderMessage"
 import { AssistantMessage as DefaultAssistantMessage } from "./messages/AssistantMessage";
 import { UserMessage as DefaultUserMessage } from "./messages/UserMessage";
 import { ImageRenderer as DefaultImageRenderer } from "./messages/ImageRenderer";
+import type { CopilotChatTimestampFormatter } from "./message-timestamps";
 import React, { useEffect, useRef, useState, useCallback } from "react";
 import type { SystemMessageFunction } from "@copilotkit/react-core";
 import {
@@ -375,6 +376,21 @@ export interface CopilotChatProps {
    * Optional handler for comprehensive debugging and observability.
    */
   onError?: CopilotErrorHandler;
+
+  /**
+   * Shows message timestamps when timestamp data is present on a message.
+   *
+   * The default renderer reads `createdAt` first and then `timestamp`, so
+   * persisted thread history can display server-provided message times without
+   * inventing client-side timestamps for messages that do not have one.
+   */
+  showTimestamps?: boolean;
+
+  /**
+   * Formats message timestamps for display. Defaults to the user's locale time
+   * with hour and minute precision.
+   */
+  formatTimestamp?: CopilotChatTimestampFormatter;
 }
 
 /**
@@ -421,6 +437,8 @@ export function CopilotChat({
   observabilityHooks,
   renderError,
   onError,
+  showTimestamps,
+  formatTimestamp,
   // Legacy props - deprecated
   RenderTextMessage,
   RenderActionExecutionMessage,
@@ -956,6 +974,8 @@ export function CopilotChat({
           onThumbsUp={handleThumbsUp}
           onThumbsDown={handleThumbsDown}
           messageFeedback={messageFeedback}
+          showTimestamps={showTimestamps}
+          formatTimestamp={formatTimestamp}
           markdownTagRenderers={markdownTagRenderers}
           ImageRenderer={ImageRenderer}
           ErrorMessage={ErrorMessage}

--- a/packages/react-ui/src/components/chat/Messages.tsx
+++ b/packages/react-ui/src/components/chat/Messages.tsx
@@ -19,6 +19,8 @@ export const Messages = ({
   onThumbsUp,
   onThumbsDown,
   messageFeedback,
+  showTimestamps,
+  formatTimestamp,
   markdownTagRenderers,
   chatError,
 
@@ -108,6 +110,8 @@ export const Messages = ({
               onThumbsUp={onThumbsUp}
               onThumbsDown={onThumbsDown}
               messageFeedback={messageFeedback}
+              showTimestamps={showTimestamps}
+              formatTimestamp={formatTimestamp}
               markdownTagRenderers={markdownTagRenderers}
             />
           );

--- a/packages/react-ui/src/components/chat/index.tsx
+++ b/packages/react-ui/src/components/chat/index.tsx
@@ -12,3 +12,4 @@ export { useChatContext } from "./ChatContext";
 export { Suggestions as RenderSuggestionsList } from "./Suggestions";
 export { Suggestion as RenderSuggestion } from "./Suggestion";
 export { suppressDeprecationWarnings } from "./attachment-utils";
+export type { CopilotChatTimestampFormatter } from "./message-timestamps";

--- a/packages/react-ui/src/components/chat/message-timestamps.ts
+++ b/packages/react-ui/src/components/chat/message-timestamps.ts
@@ -1,0 +1,91 @@
+import type { Message } from "@copilotkit/shared";
+import { useSyncExternalStore } from "react";
+
+type TimestampValue = Date | number | string;
+
+type TimestampedMessage = Message & {
+  createdAt?: TimestampValue;
+  timestamp?: TimestampValue;
+};
+
+export type CopilotChatTimestampFormatter = (
+  timestamp: Date,
+  message: Message,
+) => string;
+
+// Keep locale-dependent text out of the server snapshot, then reveal it after hydration.
+const subscribeToClient = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+function parseTimestamp(value: TimestampValue | undefined): Date | null {
+  if (value === undefined || value === null || value === "") return null;
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return null;
+    const date = new Date(
+      Math.abs(value) < 1_000_000_000_000 ? value * 1000 : value,
+    );
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  const normalized = value.trim();
+  if (!normalized) return null;
+
+  const numericValue = Number(normalized);
+  const date =
+    Number.isFinite(numericValue) && /^[+-]?\d+(?:\.\d+)?$/.test(normalized)
+      ? parseTimestamp(numericValue)
+      : new Date(normalized);
+
+  return date && !Number.isNaN(date.getTime()) ? date : null;
+}
+
+export function getMessageTimestamp(message: Message | undefined): Date | null {
+  if (!message) return null;
+
+  const timestamped = message as TimestampedMessage;
+  for (const candidate of [timestamped.createdAt, timestamped.timestamp]) {
+    const timestamp = parseTimestamp(candidate);
+    if (timestamp) return timestamp;
+  }
+  return null;
+}
+
+export function formatMessageTimestamp(
+  timestamp: Date,
+  message: Message,
+  formatTimestamp?: CopilotChatTimestampFormatter,
+): string {
+  if (formatTimestamp) {
+    return formatTimestamp(timestamp, message);
+  }
+
+  return timestamp.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export function useMessageTimestamp(
+  message: Message | undefined,
+  showTimestamp: boolean | undefined,
+  formatTimestamp?: CopilotChatTimestampFormatter,
+): { timestamp: Date | null; timestampText: string | null } {
+  const timestamp = showTimestamp ? getMessageTimestamp(message) : null;
+  const isClient = useSyncExternalStore(
+    subscribeToClient,
+    getClientSnapshot,
+    timestamp ? getServerSnapshot : getClientSnapshot,
+  );
+  const timestampText =
+    isClient && timestamp && message
+      ? formatMessageTimestamp(timestamp, message, formatTimestamp)
+      : null;
+
+  return { timestamp, timestampText };
+}

--- a/packages/react-ui/src/components/chat/messages/AssistantMessage.tsx
+++ b/packages/react-ui/src/components/chat/messages/AssistantMessage.tsx
@@ -4,6 +4,7 @@ import { Markdown } from "../Markdown";
 import { useState } from "react";
 import React from "react";
 import { copyToClipboard } from "@copilotkit/shared";
+import { useMessageTimestamp } from "../message-timestamps";
 
 export const AssistantMessage = (props: AssistantMessageProps) => {
   const { icons, labels } = useChatContext();
@@ -16,6 +17,8 @@ export const AssistantMessage = (props: AssistantMessageProps) => {
     onThumbsDown,
     isCurrentMessage,
     feedback,
+    showTimestamp,
+    formatTimestamp,
     markdownTagRenderers,
   } = props;
   const [copied, setCopied] = useState(false);
@@ -56,6 +59,11 @@ export const AssistantMessage = (props: AssistantMessageProps) => {
   const subComponentPosition = message?.generativeUIPosition ?? "after";
   const renderBefore = subComponent && subComponentPosition === "before";
   const renderAfter = subComponent && subComponentPosition !== "before";
+  const { timestamp, timestampText } = useMessageTimestamp(
+    message,
+    showTimestamp,
+    formatTimestamp,
+  );
 
   return (
     <>
@@ -67,6 +75,15 @@ export const AssistantMessage = (props: AssistantMessageProps) => {
           {content && (
             <Markdown content={content} components={markdownTagRenderers} />
           )}
+          {timestamp && timestampText ? (
+            <time
+              className="copilotKitMessageTimestamp"
+              data-testid="copilot-message-timestamp"
+              dateTime={timestamp.toISOString()}
+            >
+              {timestampText}
+            </time>
+          ) : null}
 
           {content && !isLoading && (
             <div

--- a/packages/react-ui/src/components/chat/messages/LegacyRenderMessage.test.ts
+++ b/packages/react-ui/src/components/chat/messages/LegacyRenderMessage.test.ts
@@ -1,0 +1,47 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { RenderMessageProps, UserMessageProps } from "../props";
+import { LegacyRenderMessage } from "./LegacyRenderMessage";
+
+const h = React.createElement;
+const message = { id: "user-1", role: "user", content: "Hello" } as const;
+const baseProps = {
+  message,
+  messages: [message],
+  inProgress: false,
+  index: 0,
+  isCurrentMessage: true,
+  showTimestamps: true,
+  formatTimestamp: () => "formatted",
+};
+
+describe("LegacyRenderMessage timestamp props", () => {
+  it("forwards timestamp options to a configured legacy renderer", () => {
+    const RenderTextMessage = (props: RenderMessageProps) =>
+      h("span", null, String(props.showTimestamps));
+
+    const html = renderToStaticMarkup(
+      h(LegacyRenderMessage, {
+        ...baseProps,
+        legacyProps: { RenderTextMessage },
+      }),
+    );
+
+    expect(html).toContain(">true<");
+  });
+
+  it("forwards timestamp options through the default fallback", () => {
+    const UserMessage = (props: UserMessageProps) =>
+      h("span", null, String(props.showTimestamp));
+
+    const html = renderToStaticMarkup(
+      h(LegacyRenderMessage, {
+        ...baseProps,
+        UserMessage,
+        legacyProps: { RenderImageMessage: () => null },
+      }),
+    );
+
+    expect(html).toContain(">true<");
+  });
+});

--- a/packages/react-ui/src/components/chat/messages/LegacyRenderMessage.tsx
+++ b/packages/react-ui/src/components/chat/messages/LegacyRenderMessage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { RenderMessageProps } from "../props";
+import type { RenderMessageProps } from "../props";
 import { RenderMessage as DefaultRenderMessage } from "./RenderMessage";
 import { aguiToGQL } from "@copilotkit/runtime-client-gql";
 
@@ -39,6 +39,8 @@ export const LegacyRenderMessage: React.FC<LegacyRenderMessageProps> = ({
   onCopy,
   onThumbsUp,
   onThumbsDown,
+  showTimestamps,
+  formatTimestamp,
   markdownTagRenderers,
   legacyProps,
 }) => {
@@ -67,6 +69,8 @@ export const LegacyRenderMessage: React.FC<LegacyRenderMessageProps> = ({
         onCopy={onCopy}
         onThumbsUp={onThumbsUp}
         onThumbsDown={onThumbsDown}
+        showTimestamps={showTimestamps}
+        formatTimestamp={formatTimestamp}
         markdownTagRenderers={markdownTagRenderers}
       />
     );
@@ -86,6 +90,8 @@ export const LegacyRenderMessage: React.FC<LegacyRenderMessageProps> = ({
         actionResult={actionResult}
         AssistantMessage={AssistantMessage}
         UserMessage={UserMessage}
+        showTimestamps={showTimestamps}
+        formatTimestamp={formatTimestamp}
       />
     );
   }
@@ -100,6 +106,8 @@ export const LegacyRenderMessage: React.FC<LegacyRenderMessageProps> = ({
         isCurrentMessage={isCurrentMessage}
         AssistantMessage={AssistantMessage}
         UserMessage={UserMessage}
+        showTimestamps={showTimestamps}
+        formatTimestamp={formatTimestamp}
       />
     );
   }
@@ -114,6 +122,8 @@ export const LegacyRenderMessage: React.FC<LegacyRenderMessageProps> = ({
         isCurrentMessage={isCurrentMessage}
         AssistantMessage={AssistantMessage}
         UserMessage={UserMessage}
+        showTimestamps={showTimestamps}
+        formatTimestamp={formatTimestamp}
       />
     );
   }
@@ -128,6 +138,8 @@ export const LegacyRenderMessage: React.FC<LegacyRenderMessageProps> = ({
         isCurrentMessage={isCurrentMessage}
         AssistantMessage={AssistantMessage}
         UserMessage={UserMessage}
+        showTimestamps={showTimestamps}
+        formatTimestamp={formatTimestamp}
       />
     );
   }
@@ -147,6 +159,8 @@ export const LegacyRenderMessage: React.FC<LegacyRenderMessageProps> = ({
       onCopy={onCopy}
       onThumbsUp={onThumbsUp}
       onThumbsDown={onThumbsDown}
+      showTimestamps={showTimestamps}
+      formatTimestamp={formatTimestamp}
       markdownTagRenderers={markdownTagRenderers}
     />
   );

--- a/packages/react-ui/src/components/chat/messages/RenderMessage.tsx
+++ b/packages/react-ui/src/components/chat/messages/RenderMessage.tsx
@@ -1,4 +1,4 @@
-import { RenderMessageProps } from "../props";
+import type { RenderMessageProps } from "../props";
 import { UserMessage as DefaultUserMessage } from "./UserMessage";
 import { AssistantMessage as DefaultAssistantMessage } from "./AssistantMessage";
 import { ImageRenderer as DefaultImageRenderer } from "./ImageRenderer";
@@ -20,6 +20,8 @@ export function RenderMessage({
     onThumbsUp,
     onThumbsDown,
     messageFeedback,
+    showTimestamps,
+    formatTimestamp,
     markdownTagRenderers,
   } = props;
 
@@ -32,6 +34,8 @@ export function RenderMessage({
           data-message-role="user"
           message={message}
           ImageRenderer={ImageRenderer}
+          showTimestamp={showTimestamps}
+          formatTimestamp={formatTimestamp}
         />
       );
     case "assistant":
@@ -51,6 +55,8 @@ export function RenderMessage({
           onThumbsUp={onThumbsUp}
           onThumbsDown={onThumbsDown}
           feedback={messageFeedback?.[message.id] || null}
+          showTimestamp={showTimestamps}
+          formatTimestamp={formatTimestamp}
           markdownTagRenderers={markdownTagRenderers}
           ImageRenderer={ImageRenderer}
         />

--- a/packages/react-ui/src/components/chat/messages/UserMessage.tsx
+++ b/packages/react-ui/src/components/chat/messages/UserMessage.tsx
@@ -1,5 +1,6 @@
-import { UserMessageProps } from "../props";
+import type { UserMessageProps } from "../props";
 import { AttachmentRenderer } from "../AttachmentRenderer";
+import { useMessageTimestamp } from "../message-timestamps";
 
 type UserMessageContent = NonNullable<UserMessageProps["message"]>["content"];
 
@@ -49,8 +50,23 @@ const getMediaParts = (content: UserMessageContent | undefined) => {
 };
 
 export const UserMessage = (props: UserMessageProps) => {
-  const { message, ImageRenderer } = props;
+  const { message, ImageRenderer, showTimestamp, formatTimestamp } = props;
   const content = message?.content;
+  const { timestamp, timestampText } = useMessageTimestamp(
+    message,
+    showTimestamp,
+    formatTimestamp,
+  );
+  const timestampElement =
+    timestamp && timestampText ? (
+      <time
+        className="copilotKitMessageTimestamp"
+        data-testid="copilot-message-timestamp"
+        dateTime={timestamp.toISOString()}
+      >
+        {timestampText}
+      </time>
+    ) : null;
 
   // Legacy path: old-style image field on message
   const isLegacyImageMessage =
@@ -62,6 +78,7 @@ export const UserMessage = (props: UserMessageProps) => {
     return (
       <div className="copilotKitMessage copilotKitUserMessage">
         <ImageRenderer image={legacyImage} content={textContent} />
+        {timestampElement}
       </div>
     );
   }
@@ -73,6 +90,7 @@ export const UserMessage = (props: UserMessageProps) => {
     return (
       <div className="copilotKitMessage copilotKitUserMessage">
         {textContent}
+        {timestampElement}
       </div>
     );
   }
@@ -83,6 +101,7 @@ export const UserMessage = (props: UserMessageProps) => {
       {mediaParts.map((part, index) => (
         <AttachmentRenderer key={index} type={part.type} source={part.source} />
       ))}
+      {timestampElement}
     </div>
   );
 };

--- a/packages/react-ui/src/components/chat/messages/message-timestamps.test.ts
+++ b/packages/react-ui/src/components/chat/messages/message-timestamps.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot, hydrateRoot } from "react-dom/client";
+import type { Root } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { vi } from "vitest";
+import type {
+  AIMessage,
+  Message,
+  UserMessage as UserMessageType,
+} from "@copilotkit/shared";
+import { ChatContextProvider } from "../ChatContext";
+import {
+  getMessageTimestamp,
+  useMessageTimestamp,
+} from "../message-timestamps";
+import { AssistantMessage } from "./AssistantMessage";
+import { UserMessage } from "./UserMessage";
+
+const h = React.createElement;
+const ImageRenderer = () => null;
+
+describe("default chat message timestamps", () => {
+  const createdAt = "2026-07-16T09:30:00.000Z";
+  const originalTimezone = process.env.TZ;
+  let container: HTMLDivElement;
+  let root: Root | undefined;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => root?.unmount());
+      root = undefined;
+    }
+    container.remove();
+    process.env.TZ = originalTimezone;
+  });
+
+  it("keeps timestamps hidden by default", () => {
+    const message = {
+      id: "user-1",
+      role: "user",
+      content: "Hello",
+      createdAt,
+    } as UserMessageType;
+
+    const html = renderToStaticMarkup(
+      h(UserMessage, { message, ImageRenderer, rawData: message }),
+    );
+
+    expect(html).not.toContain("copilotKitMessageTimestamp");
+  });
+
+  it("renders local time only after hydration", async () => {
+    const message = {
+      id: "user-1",
+      role: "user",
+      content: "Hello",
+      createdAt,
+    } as UserMessageType;
+    const element = h(UserMessage, {
+      message,
+      ImageRenderer,
+      rawData: message,
+      showTimestamp: true,
+    });
+
+    process.env.TZ = "UTC";
+    const serverHtml = renderToStaticMarkup(element);
+    expect(serverHtml).not.toContain("copilotKitMessageTimestamp");
+
+    process.env.TZ = "Asia/Shanghai";
+    container.innerHTML = serverHtml;
+    await act(async () => {
+      root = hydrateRoot(container, element);
+    });
+
+    const expected = new Date(createdAt).toLocaleTimeString([], {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+    expect(
+      container.querySelector("[data-testid='copilot-message-timestamp']")
+        ?.textContent,
+    ).toBe(expected);
+  });
+
+  it("does not schedule a hydration update when timestamps are hidden", async () => {
+    const message = {
+      id: "user-1",
+      role: "user",
+      content: "Hello",
+      createdAt,
+    } as UserMessageType;
+    let renderCount = 0;
+
+    function TimestampProbe() {
+      renderCount += 1;
+      useMessageTimestamp(message, false);
+      return h("span", null, "Hello");
+    }
+
+    const element = h(TimestampProbe);
+    container.innerHTML = renderToStaticMarkup(element);
+    renderCount = 0;
+    root = hydrateRoot(container, element);
+
+    await act(async () => {});
+
+    expect(renderCount).toBe(1);
+  });
+
+  it("renders an assistant timestamp with the message-aware formatter", async () => {
+    const message = {
+      id: "assistant-1",
+      role: "assistant",
+      content: "Hi",
+      createdAt,
+    } as AIMessage;
+    const formatTimestamp = vi.fn(
+      (timestamp: Date, value: Message) =>
+        `${value.id}:${timestamp.toISOString()}`,
+    );
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        h(
+          ChatContextProvider,
+          { open: false, setOpen: vi.fn() },
+          h(AssistantMessage, {
+            message,
+            rawData: message,
+            isLoading: false,
+            isGenerating: false,
+            showTimestamp: true,
+            formatTimestamp,
+          }),
+        ),
+      );
+    });
+
+    expect(
+      container.querySelector("[data-testid='copilot-message-timestamp']")
+        ?.textContent,
+    ).toBe(`assistant-1:${createdAt}`);
+    expect(formatTimestamp).toHaveBeenCalledWith(new Date(createdAt), message);
+  });
+
+  it("falls back to a numeric-string timestamp when createdAt is invalid", () => {
+    const message = {
+      id: "user-1",
+      role: "user",
+      content: "Hello",
+      createdAt: "not-a-date",
+      timestamp: "1700000000",
+    } as UserMessageType;
+
+    expect(getMessageTimestamp(message)?.toISOString()).toBe(
+      "2023-11-14T22:13:20.000Z",
+    );
+  });
+});

--- a/packages/react-ui/src/components/chat/props.ts
+++ b/packages/react-ui/src/components/chat/props.ts
@@ -13,6 +13,7 @@ import type {
   Attachment,
   AttachmentModality,
 } from "@copilotkit/shared";
+import type { CopilotChatTimestampFormatter } from "./message-timestamps";
 
 // Re-export for backward compat
 export type { AttachmentsConfig, Attachment, AttachmentModality };
@@ -131,6 +132,8 @@ export interface MessagesProps {
    * Map of message IDs to their feedback state
    */
   messageFeedback?: Record<string, "thumbsUp" | "thumbsDown">;
+  showTimestamps?: boolean;
+  formatTimestamp?: CopilotChatTimestampFormatter;
 
   /**
    * A list of markdown components to render in assistant message.
@@ -171,6 +174,8 @@ export interface Renderer {
 export interface UserMessageProps {
   message?: UserMessage;
   ImageRenderer: React.ComponentType<ImageRendererProps>;
+  showTimestamp?: boolean;
+  formatTimestamp?: CopilotChatTimestampFormatter;
 
   /**
    * @deprecated use message instead
@@ -202,6 +207,8 @@ export interface AssistantMessageProps {
    * Whether a response is generating, this is when the LLM is actively generating and streaming content.
    */
   isGenerating: boolean;
+  showTimestamp?: boolean;
+  formatTimestamp?: CopilotChatTimestampFormatter;
 
   /**
    * Callback function to regenerate the assistant's response
@@ -323,6 +330,8 @@ export interface RenderMessageProps {
    * Map of message IDs to their feedback state
    */
   messageFeedback?: Record<string, "thumbsUp" | "thumbsDown">;
+  showTimestamps?: boolean;
+  formatTimestamp?: CopilotChatTimestampFormatter;
 
   /**
    * A list of markdown components to render in assistant message.

--- a/packages/react-ui/src/css/messages.css
+++ b/packages/react-ui/src/css/messages.css
@@ -159,6 +159,14 @@
   opacity: 0.7;
 }
 
+.copilotKitMessageTimestamp {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  opacity: 0.7;
+}
+
 @keyframes copilotKitSpinAnimation {
   0% {
     transform: rotate(0deg);

--- a/packages/runtime-client-gql/src/message-conversion/gql-to-agui.test.ts
+++ b/packages/runtime-client-gql/src/message-conversion/gql-to-agui.test.ts
@@ -8,7 +8,17 @@ import {
   gqlImageMessageToAGUIMessage,
   gqlActionExecutionMessageToAGUIMessage,
 } from "./gql-to-agui";
-import { AIMessage } from "@copilotkit/shared";
+import type { AIMessage } from "@copilotkit/shared";
+
+function expectConvertedMessage(
+  actual: unknown,
+  expected: Record<string, unknown>,
+) {
+  expect(actual).toEqual({
+    ...expected,
+    createdAt: expect.any(Date),
+  });
+}
 
 describe("message-conversion", () => {
   describe("gqlTextMessageToAGUIMessage", () => {
@@ -95,6 +105,22 @@ describe("message-conversion", () => {
   });
 
   describe("gqlToAGUI", () => {
+    test("should preserve persisted message creation time", () => {
+      const createdAt = new Date("2026-07-16T09:30:00.000Z");
+      const gqlMessage = new gql.TextMessage({
+        id: "user-1",
+        content: "Hello",
+        role: gql.Role.User,
+        createdAt,
+      });
+
+      const [result] = gqlToAGUI(gqlMessage);
+
+      expect((result as typeof result & { createdAt?: Date }).createdAt).toBe(
+        createdAt,
+      );
+    });
+
     test("should convert an array of text messages", () => {
       const gqlMessages = [
         new gql.TextMessage({
@@ -112,12 +138,12 @@ describe("message-conversion", () => {
       const result = gqlToAGUI(gqlMessages);
 
       expect(result).toHaveLength(2);
-      expect(result[0]).toEqual({
+      expectConvertedMessage(result[0], {
         id: "dev-1",
         role: "developer",
         content: "Hello",
       });
-      expect(result[1]).toEqual({
+      expectConvertedMessage(result[1], {
         id: "assistant-1",
         role: "assistant",
         content: "Hi there",
@@ -130,7 +156,7 @@ describe("message-conversion", () => {
       const result = gqlToAGUI(gqlMessages);
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toEqual({
+      expectConvertedMessage(result[0], {
         id: "agent-state-1",
         role: "assistant",
       });
@@ -172,17 +198,17 @@ describe("message-conversion", () => {
       const result = gqlToAGUI(gqlMessages);
 
       expect(result).toHaveLength(3);
-      expect(result[0]).toEqual({
+      expectConvertedMessage(result[0], {
         id: "dev-1",
         role: "developer",
         content: "Run action",
       });
-      expect(result[1]).toEqual({
+      expectConvertedMessage(result[1], {
         id: "assistant-1",
         role: "assistant",
         content: "I'll run the action",
       });
-      expect(result[2]).toEqual({
+      expectConvertedMessage(result[2], {
         id: "result-1",
         role: "tool",
         content: "Action result",
@@ -209,12 +235,12 @@ describe("message-conversion", () => {
 
       // Now we expect 2 messages: the original assistant message and the action execution message
       expect(result).toHaveLength(2);
-      expect(result[0]).toEqual({
+      expectConvertedMessage(result[0], {
         id: "assistant-1",
         role: "assistant",
         content: "I'll execute an action",
       });
-      expect(result[1]).toEqual({
+      expectConvertedMessage(result[1], {
         id: "action-1",
         role: "assistant",
         name: "testAction",
@@ -256,12 +282,12 @@ describe("message-conversion", () => {
 
       // Now we expect 3 messages: the original assistant message and 2 separate action execution messages
       expect(result).toHaveLength(3);
-      expect(result[0]).toEqual({
+      expectConvertedMessage(result[0], {
         id: "assistant-1",
         role: "assistant",
         content: "I'll execute multiple actions",
       });
-      expect(result[1]).toEqual({
+      expectConvertedMessage(result[1], {
         id: "action-1",
         role: "assistant",
         name: "firstAction",
@@ -276,7 +302,7 @@ describe("message-conversion", () => {
           },
         ],
       });
-      expect(result[2]).toEqual({
+      expectConvertedMessage(result[2], {
         id: "action-2",
         role: "assistant",
         name: "secondAction",
@@ -311,13 +337,13 @@ describe("message-conversion", () => {
 
       // Now we expect 2 messages: the developer message and the action execution as assistant message
       expect(result).toHaveLength(2);
-      expect(result[0]).toEqual({
+      expectConvertedMessage(result[0], {
         id: "dev-1",
         role: "developer",
         content: "Developer message",
       });
       // The action execution becomes its own assistant message regardless of parent
-      expect(result[1]).toEqual({
+      expectConvertedMessage(result[1], {
         id: "action-1",
         role: "assistant",
         name: "testAction",
@@ -344,7 +370,7 @@ describe("message-conversion", () => {
       const result = gqlToAGUI([actionExecMsg]);
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toEqual({
+      expectConvertedMessage(result[0], {
         id: "action-1",
         role: "assistant",
         name: "testAction",
@@ -604,7 +630,7 @@ describe("message-conversion", () => {
       const result = gqlToAGUI([actionExecMsg], actions);
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toEqual({
+      expectConvertedMessage(result[0], {
         id: "action-1",
         role: "assistant",
         name: "unknownAction",
@@ -643,7 +669,7 @@ describe("message-conversion", () => {
       const result = gqlToAGUI([agentStateMsg], undefined, coAgentStateRenders);
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toEqual({
+      expectConvertedMessage(result[0], {
         id: "agent-state-1",
         role: "assistant",
         agentName: "testAgent",
@@ -674,7 +700,7 @@ describe("message-conversion", () => {
       const result = gqlToAGUI([agentStateMsg]);
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toEqual({
+      expectConvertedMessage(result[0], {
         id: "agent-state-1",
         role: "assistant",
         agentName: "testAgent",
@@ -703,7 +729,7 @@ describe("message-conversion", () => {
       const result = gqlToAGUI([agentStateMsg], undefined, coAgentStateRenders);
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toEqual({
+      expectConvertedMessage(result[0], {
         id: "agent-state-1",
         role: "assistant",
         agentName: "unknownAgent",
@@ -724,7 +750,7 @@ describe("message-conversion", () => {
       const result = gqlToAGUI([userMsg]);
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toEqual({
+      expectConvertedMessage(result[0], {
         id: "user-1",
         role: "user",
         content: "Hello from user",
@@ -760,7 +786,7 @@ describe("message-conversion", () => {
       );
 
       expect(result).toHaveLength(2);
-      expect(result[0]).toEqual({
+      expectConvertedMessage(result[0], {
         id: "text-1",
         role: "assistant",
         content: "Hello",

--- a/packages/runtime-client-gql/src/message-conversion/gql-to-agui.ts
+++ b/packages/runtime-client-gql/src/message-conversion/gql-to-agui.ts
@@ -1,10 +1,21 @@
 import * as gql from "../client";
-import * as agui from "@copilotkit/shared";
+import type * as agui from "@copilotkit/shared";
 import { MessageStatusCode } from "../graphql/@generated/graphql";
 
 // Define valid image formats based on the supported formats in the codebase
 const VALID_IMAGE_FORMATS = ["jpeg", "png", "webp", "gif"] as const;
 type ValidImageFormat = (typeof VALID_IMAGE_FORMATS)[number];
+
+type TimestampedMessage = agui.Message & {
+  createdAt: gql.Message["createdAt"];
+};
+
+function preserveCreatedAt(
+  message: gql.Message,
+  converted: agui.Message,
+): TimestampedMessage {
+  return { ...converted, createdAt: message.createdAt } as TimestampedMessage;
+}
 
 // Validation function for image format
 function validateImageFormat(format: string): format is ValidImageFormat {
@@ -33,23 +44,28 @@ export function gqlToAGUI(
   }
 
   for (const message of messages) {
+    let converted: agui.Message;
     if (message.isTextMessage()) {
-      aguiMessages.push(gqlTextMessageToAGUIMessage(message));
+      converted = gqlTextMessageToAGUIMessage(message);
     } else if (message.isResultMessage()) {
-      aguiMessages.push(gqlResultMessageToAGUIMessage(message));
+      converted = gqlResultMessageToAGUIMessage(message);
     } else if (message.isActionExecutionMessage()) {
-      aguiMessages.push(
-        gqlActionExecutionMessageToAGUIMessage(message, actions, actionResults),
+      converted = gqlActionExecutionMessageToAGUIMessage(
+        message,
+        actions,
+        actionResults,
       );
     } else if (message.isAgentStateMessage()) {
-      aguiMessages.push(
-        gqlAgentStateMessageToAGUIMessage(message, coAgentStateRenders),
+      converted = gqlAgentStateMessageToAGUIMessage(
+        message,
+        coAgentStateRenders,
       );
     } else if (message.isImageMessage()) {
-      aguiMessages.push(gqlImageMessageToAGUIMessage(message));
+      converted = gqlImageMessageToAGUIMessage(message);
     } else {
       throw new Error("Unknown message type");
     }
+    aguiMessages.push(preserveCreatedAt(message, converted));
   }
 
   return aguiMessages;
@@ -102,7 +118,7 @@ export function gqlActionExecutionMessageToAGUIMessage(
       if (typeof props?.result === "string") {
         try {
           props.result = JSON.parse(props.result);
-        } catch (e) {
+        } catch {
           /* do nothing */
         }
       }
@@ -111,7 +127,7 @@ export function gqlActionExecutionMessageToAGUIMessage(
       if (typeof actionResult === "string") {
         try {
           actionResult = JSON.parse(actionResult);
-        } catch (e) {
+        } catch {
           /* do nothing */
         }
       }

--- a/showcase/shell-docs/src/content/reference/components/CopilotChat.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotChat.mdx
@@ -21,9 +21,8 @@ import "@copilotkit/react-core/v2/styles.css";
 ### Own Props
 
 <PropertyReference name="agentId" type="string">
-  ID of the agent to use. Must match an agent configured in
-  `CopilotKit`. Defaults to the provider-level default agent when
-  omitted.
+  ID of the agent to use. Must match an agent configured in `CopilotKit`.
+  Defaults to the provider-level default agent when omitted.
 </PropertyReference>
 
 <PropertyReference name="threadId" type="string">
@@ -73,6 +72,16 @@ This means you can pass slot overrides such as `messageView`, `input`, `scrollVi
 
 <PropertyReference name="autoScroll" type="boolean" default="true">
   Whether the chat scrolls to the bottom automatically when new messages arrive.
+</PropertyReference>
+
+<PropertyReference name="showTimestamps" type="boolean" default="false">
+  Displays timestamps for user and assistant messages that include `createdAt`
+  or `timestamp` data.
+</PropertyReference>
+
+<PropertyReference name="formatTimestamp" type="CopilotChatTimestampFormatter">
+  Formats each parsed timestamp. The default uses the browser's local hour and
+  minute format.
 </PropertyReference>
 
 <PropertyReference
@@ -134,6 +143,25 @@ function App() {
           {input}
         </div>
       )}
+    />
+  );
+}
+```
+
+### Showing Message Timestamps
+
+```tsx
+function App() {
+  return (
+    <CopilotChat
+      agentId="my-agent"
+      showTimestamps
+      formatTimestamp={(timestamp) =>
+        timestamp.toLocaleTimeString([], {
+          hour: "2-digit",
+          minute: "2-digit",
+        })
+      }
     />
   );
 }

--- a/showcase/shell-docs/src/content/reference/components/CopilotChatAssistantMessage.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotChatAssistantMessage.mdx
@@ -31,6 +31,15 @@ import "@copilotkit/react-core/v2/styles.css";
   adjust their behavior during streaming.
 </PropertyReference>
 
+<PropertyReference name="showTimestamp" type="boolean" default="false">
+  Displays the message's `createdAt` or `timestamp` value below its content.
+</PropertyReference>
+
+<PropertyReference name="formatTimestamp" type="CopilotChatTimestampFormatter">
+  Formats the parsed timestamp and receives the assistant message as its second
+  argument.
+</PropertyReference>
+
 <PropertyReference name="onThumbsUp" type="(message: AssistantMessage) => void">
   Callback invoked when the user clicks the thumbs-up button. When not provided,
   the thumbs-up button is hidden from the toolbar.

--- a/showcase/shell-docs/src/content/reference/components/CopilotChatMessageView.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotChatMessageView.mdx
@@ -26,8 +26,26 @@ import "@copilotkit/react-core/v2/styles.css";
   an `id`, `role` (`"user"` or `"assistant"`), and `content`.
 </PropertyReference>
 
-<PropertyReference name="children" type="(props: { isRunning: boolean; messages: Message[]; messageElements: React.ReactElement[] }) => React.ReactElement">
-Optional render-prop function that receives the resolved state and pre-built message elements. When provided, the component calls this function instead of rendering the default message list layout. The callback receives `isRunning` (current running state), `messages` (the raw message array), and `messageElements` (an array of React elements built from the `assistantMessage` and `userMessage` slots).
+<PropertyReference name="showTimestamps" type="boolean" default="false">
+  Displays timestamps for user and assistant messages with valid `createdAt` or
+  `timestamp` data.
+</PropertyReference>
+
+<PropertyReference name="formatTimestamp" type="CopilotChatTimestampFormatter">
+  Formats the parsed timestamp and receives the source message as its second
+  argument. The default uses the browser's local hour and minute format.
+</PropertyReference>
+
+<PropertyReference
+  name="children"
+  type="(props: { isRunning: boolean; messages: Message[]; messageElements: React.ReactElement[] }) => React.ReactElement"
+>
+  Optional render-prop function that receives the resolved state and pre-built
+  message elements. When provided, the component calls this function instead of
+  rendering the default message list layout. The callback receives `isRunning`
+  (current running state), `messages` (the raw message array), and
+  `messageElements` (an array of React elements built from the
+  `assistantMessage` and `userMessage` slots).
 </PropertyReference>
 
 ## Slots

--- a/showcase/shell-docs/src/content/reference/components/CopilotChatUserMessage.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotChatUserMessage.mdx
@@ -21,6 +21,15 @@ import "@copilotkit/react-core/v2/styles.css";
   `role`.
 </PropertyReference>
 
+<PropertyReference name="showTimestamp" type="boolean" default="false">
+  Displays the message's `createdAt` or `timestamp` value below its content.
+</PropertyReference>
+
+<PropertyReference name="formatTimestamp" type="CopilotChatTimestampFormatter">
+  Formats the parsed timestamp and receives the user message as its second
+  argument.
+</PropertyReference>
+
 <PropertyReference
   name="onEditMessage"
   type="(props: { message: UserMessage }) => void"

--- a/showcase/shell-docs/src/content/reference/components/CopilotChatView.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotChatView.mdx
@@ -114,6 +114,18 @@ Passing a `children` render-prop gives you access to all composed slot elements 
   arrive. Set to `false` if you want manual scroll control.
 </PropertyReference>
 
+<PropertyReference name="showTimestamps" type="boolean" default="false">
+  Displays a timestamp below each user and assistant message that contains a
+  valid `createdAt` or `timestamp` value. Messages without timestamp data are
+  left unchanged.
+</PropertyReference>
+
+<PropertyReference name="formatTimestamp" type="CopilotChatTimestampFormatter">
+  Formats a message timestamp for display. The callback receives the parsed
+  `Date` and the source message. By default, timestamps use the browser's local
+  time with hour and minute precision.
+</PropertyReference>
+
 <PropertyReference
   name="inputProps"
   type="Partial<Omit<CopilotChatInputProps, 'children'>>"

--- a/showcase/shell-docs/src/content/reference/components/CopilotPopup.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotPopup.mdx
@@ -49,8 +49,7 @@ import "@copilotkit/react-core/v2/styles.css";
 `CopilotPopup` accepts all props from [`CopilotChatProps`](/reference/components/CopilotChat) **except** `chatView`, which is set internally to `CopilotPopupView`. This includes:
 
 <PropertyReference name="agentId" type="string">
-  ID of the agent to use. Must match an agent configured in
-  `CopilotKit`.
+  ID of the agent to use. Must match an agent configured in `CopilotKit`.
 </PropertyReference>
 
 <PropertyReference name="threadId" type="string">
@@ -63,6 +62,14 @@ import "@copilotkit/react-core/v2/styles.css";
 
 <PropertyReference name="autoScroll" type="boolean" default="true">
   Whether the chat scrolls to the bottom automatically when new messages arrive.
+</PropertyReference>
+
+<PropertyReference name="showTimestamps" type="boolean" default="false">
+  Displays timestamps for messages with valid `createdAt` or `timestamp` data.
+</PropertyReference>
+
+<PropertyReference name="formatTimestamp" type="CopilotChatTimestampFormatter">
+  Formats each parsed timestamp before it is displayed.
 </PropertyReference>
 
 <PropertyReference

--- a/showcase/shell-docs/src/content/reference/components/CopilotSidebar.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotSidebar.mdx
@@ -40,8 +40,7 @@ import "@copilotkit/react-core/v2/styles.css";
 `CopilotSidebar` accepts all props from [`CopilotChatProps`](/reference/components/CopilotChat) **except** `chatView`, which is set internally to `CopilotSidebarView`. This includes:
 
 <PropertyReference name="agentId" type="string">
-  ID of the agent to use. Must match an agent configured in
-  `CopilotKit`.
+  ID of the agent to use. Must match an agent configured in `CopilotKit`.
 </PropertyReference>
 
 <PropertyReference name="threadId" type="string">
@@ -54,6 +53,14 @@ import "@copilotkit/react-core/v2/styles.css";
 
 <PropertyReference name="autoScroll" type="boolean" default="true">
   Whether the chat scrolls to the bottom automatically when new messages arrive.
+</PropertyReference>
+
+<PropertyReference name="showTimestamps" type="boolean" default="false">
+  Displays timestamps for messages with valid `createdAt` or `timestamp` data.
+</PropertyReference>
+
+<PropertyReference name="formatTimestamp" type="CopilotChatTimestampFormatter">
+  Formats each parsed timestamp before it is displayed.
 </PropertyReference>
 
 <PropertyReference

--- a/showcase/shell-docs/src/content/reference/v1/components/chat/CopilotChat.mdx
+++ b/showcase/shell-docs/src/content/reference/v1/components/chat/CopilotChat.mdx
@@ -236,3 +236,15 @@ Custom error renderer for chat-specific errors.
 Optional handler for comprehensive debugging and observability.
 </PropertyReference>
 
+<PropertyReference name="showTimestamps" type="boolean">
+Shows message timestamps when timestamp data is present on a message.
+
+The default renderer reads `createdAt` first and then `timestamp`, so persisted
+thread history can display server-provided message times without inventing
+client-side timestamps for messages that do not have one.
+</PropertyReference>
+
+<PropertyReference name="formatTimestamp" type="CopilotChatTimestampFormatter">
+Formats message timestamps for display. Defaults to the user's locale time with
+hour and minute precision.
+</PropertyReference>

--- a/showcase/shell-docs/src/content/reference/v1/components/chat/CopilotPopup.mdx
+++ b/showcase/shell-docs/src/content/reference/v1/components/chat/CopilotPopup.mdx
@@ -240,6 +240,19 @@ Custom error renderer for chat-specific errors.
 Optional handler for comprehensive debugging and observability.
 </PropertyReference>
 
+<PropertyReference name="showTimestamps" type="boolean">
+Shows message timestamps when timestamp data is present on a message.
+
+The default renderer reads `createdAt` first and then `timestamp`, so persisted
+thread history can display server-provided message times without inventing
+client-side timestamps for messages that do not have one.
+</PropertyReference>
+
+<PropertyReference name="formatTimestamp" type="CopilotChatTimestampFormatter">
+Formats message timestamps for display. Defaults to the user's locale time with
+hour and minute precision.
+</PropertyReference>
+
 <PropertyReference name="defaultOpen" type="boolean"  default="false"> 
 Whether the chat window should be open by default.
 </PropertyReference>
@@ -272,4 +285,3 @@ A custom Button component to use instead of the default.
 <PropertyReference name="Header" type="React.ComponentType<HeaderProps>"  > 
 A custom Header component to use instead of the default.
 </PropertyReference>
-

--- a/showcase/shell-docs/src/content/reference/v1/components/chat/CopilotSidebar.mdx
+++ b/showcase/shell-docs/src/content/reference/v1/components/chat/CopilotSidebar.mdx
@@ -244,6 +244,19 @@ Custom error renderer for chat-specific errors.
 Optional handler for comprehensive debugging and observability.
 </PropertyReference>
 
+<PropertyReference name="showTimestamps" type="boolean">
+Shows message timestamps when timestamp data is present on a message.
+
+The default renderer reads `createdAt` first and then `timestamp`, so persisted
+thread history can display server-provided message times without inventing
+client-side timestamps for messages that do not have one.
+</PropertyReference>
+
+<PropertyReference name="formatTimestamp" type="CopilotChatTimestampFormatter">
+Formats message timestamps for display. Defaults to the user's locale time with
+hour and minute precision.
+</PropertyReference>
+
 <PropertyReference name="defaultOpen" type="boolean"  default="false"> 
 Whether the chat window should be open by default.
 </PropertyReference>
@@ -276,4 +289,3 @@ A custom Button component to use instead of the default.
 <PropertyReference name="Header" type="React.ComponentType<HeaderProps>"  > 
 A custom Header component to use instead of the default.
 </PropertyReference>
-


### PR DESCRIPTION
## What does this PR do?

Adds opt-in message timestamps to the default v1 and v2 chat UIs.

- Adds `showTimestamps` and `formatTimestamp` APIs while keeping timestamps off by default.
- Reads persisted `createdAt` values first, with `timestamp` as a fallback, and supports dates, ISO strings, and Unix seconds or milliseconds.
- Preserves GraphQL message creation times during AG-UI conversion and includes timestamps in v2 memoization.
- Defers locale-sensitive formatting until hydration and avoids hydration updates when timestamps are disabled.
- Forwards the options through legacy renderers and documents the public APIs.

## Related PRs and Issues

- Closes https://github.com/CopilotKit/CopilotKit/issues/5892
- Related persistence work: https://github.com/CopilotKit/CopilotKit/issues/2750

## Verification

- React core Nx tests: 118 files, 1439 tests passed.
- React UI Nx tests: 9 files, 60 tests passed.
- Runtime GraphQL conversion tests: 50 tests passed.
- Nx type checks and builds passed for `@copilotkit/runtime-client-gql`, `@copilotkit/react-core`, and `@copilotkit/react-ui`.
- Changed MDX pages passed structural checks; `git diff --check` passed.
- Full shell-docs build was not run because its separate dependencies are not installed in this worktree.

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)