### PR TITLE
Stabilize virtualized chat scrolling

### DIFF
--- a/examples/v2/react/storybook/stories/CopilotChatView.stories.tsx
+++ b/examples/v2/react/storybook/stories/CopilotChatView.stories.tsx
@@ -4,7 +4,7 @@ import {
   CopilotChatView,
   CopilotKitProvider,
 } from "@copilotkit/react-core/v2";
-import { Suggestion } from "@copilotkit/core";
+import type { Suggestion } from "@copilotkit/core";
 
 const meta = {
   title: "UI/CopilotChatView",
@@ -123,6 +123,26 @@ export const WithSuggestions: Story = {
   ),
 };
 
+export const VirtualizedMessages: Story = {
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: Default.decorators,
+  render: () => (
+    <CopilotKitProvider runtimeUrl="https://copilotkit.ai">
+      <CopilotChatConfigurationProvider threadId="storybook-virtualized">
+        <div style={{ height: "100%" }}>
+          <CopilotChatView
+            autoScroll="none"
+            messages={virtualizedMessages}
+            scrollView={{ "data-testid": "virtual-scroll" }}
+          />
+        </div>
+      </CopilotChatConfigurationProvider>
+    </CopilotKitProvider>
+  ),
+};
+
 const suggestionSamples: Suggestion[] = [
   {
     title: "Summarize conversation",
@@ -198,6 +218,12 @@ In this example:
     role: "assistant" as const,
   },
 ];
+
+const virtualizedMessages = Array.from({ length: 240 }, (_, index) => ({
+  id: `virtual-message-${index}`,
+  role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+  content: `Message ${index}. ${"Variable-height content for scroll measurement. ".repeat((index % 6) + 1)}`,
+}));
 
 // Enough back-and-forth to force scrolling so the feather region above the
 // input is clearly visible in pin-to-send mode.

--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -511,6 +511,19 @@ export function CopilotChatMessageView({
     !children &&
     deduplicatedMessages.length > VIRTUALIZE_THRESHOLD;
 
+  // TanStack Virtual corrects scrollTop as dynamic rows are measured. Disable
+  // the browser's competing scroll anchoring while virtualized so those two
+  // correction systems cannot move the viewport independently.
+  useLayoutEffect(() => {
+    if (!shouldVirtualize || !scrollElement) return;
+
+    const previousOverflowAnchor = scrollElement.style.overflowAnchor;
+    scrollElement.style.overflowAnchor = "none";
+    return () => {
+      scrollElement.style.overflowAnchor = previousOverflowAnchor;
+    };
+  }, [scrollElement, shouldVirtualize]);
+
   const virtualizer = useVirtualizer({
     // count=0 disables the virtualizer without changing hook call order.
     count: shouldVirtualize ? deduplicatedMessages.length : 0,
@@ -519,7 +532,7 @@ export function CopilotChatMessageView({
     // first render so the estimate only affects the initial total height.
     estimateSize: () => 100,
     overscan: 5,
-    measureElement: (el: Element) => el?.getBoundingClientRect().height ?? 0,
+    getItemKey: (index) => deduplicatedMessages[index]?.id ?? index,
     // Assume a 600 px viewport before the real element is measured so that
     // the first virtual render shows ~6 items rather than 0.
     initialRect: { width: 0, height: 600 },
@@ -685,7 +698,7 @@ export function CopilotChatMessageView({
             const message = deduplicatedMessages[virtualItem.index]!;
             return (
               <div
-                key={message.id}
+                key={virtualItem.key}
                 data-index={virtualItem.index}
                 ref={virtualizer.measureElement}
                 style={{

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatMessageView.virtualization.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatMessageView.virtualization.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import type { Message } from "@ag-ui/core";
+import { vi } from "vitest";
+import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
+import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
+import CopilotChatMessageView from "../CopilotChatMessageView";
+import { ScrollElementContext } from "../scroll-element-context";
+
+const virtualizerMocks = vi.hoisted(() => ({
+  useVirtualizer: vi.fn(),
+  measureElement: vi.fn(),
+  scrollToIndex: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: virtualizerMocks.useVirtualizer,
+}));
+
+function createScrollElement() {
+  const element = document.createElement("div");
+  Object.defineProperty(element, "clientHeight", {
+    configurable: true,
+    value: 600,
+  });
+  return element;
+}
+
+function createMessages(count: number): Message[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `message-${index}`,
+    role: "assistant" as const,
+    content: `Message ${index}`,
+  }));
+}
+
+function renderVirtualizedMessages(scrollElement: HTMLElement) {
+  return render(
+    <CopilotKitProvider>
+      <CopilotChatConfigurationProvider agentId="default" threadId="thread">
+        <ScrollElementContext.Provider value={scrollElement}>
+          <CopilotChatMessageView messages={createMessages(60)} />
+        </ScrollElementContext.Provider>
+      </CopilotChatConfigurationProvider>
+    </CopilotKitProvider>,
+  );
+}
+
+describe("CopilotChatMessageView virtualization stability", () => {
+  beforeEach(() => {
+    virtualizerMocks.measureElement.mockReset();
+    virtualizerMocks.scrollToIndex.mockReset();
+    virtualizerMocks.useVirtualizer.mockReset();
+    virtualizerMocks.useVirtualizer.mockReturnValue({
+      getTotalSize: () => 6_000,
+      getVirtualItems: () => [
+        { index: 0, key: "message-0", start: 0, end: 100, size: 100 },
+      ],
+      measureElement: virtualizerMocks.measureElement,
+      scrollToIndex: virtualizerMocks.scrollToIndex,
+    });
+  });
+
+  it("disables native scroll anchoring only while virtualized", async () => {
+    const scrollElement = createScrollElement();
+    scrollElement.style.overflowAnchor = "auto";
+
+    const { unmount } = renderVirtualizedMessages(scrollElement);
+
+    await waitFor(() => {
+      expect(scrollElement.style.overflowAnchor).toBe("none");
+    });
+
+    unmount();
+    expect(scrollElement.style.overflowAnchor).toBe("auto");
+  });
+
+  it("uses stable message keys and the ResizeObserver-aware default measurement", () => {
+    const scrollElement = createScrollElement();
+
+    renderVirtualizedMessages(scrollElement);
+
+    const options = virtualizerMocks.useVirtualizer.mock.calls.at(-1)?.[0];
+    expect(options).toBeDefined();
+    expect(options.measureElement).toBeUndefined();
+    expect(options.getItemKey(0)).toBe("message-0");
+    expect(options.getItemKey(100)).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary
- Disable native scroll anchoring while CopilotChat message virtualization is active so browser anchoring does not compete with TanStack Virtual scroll corrections.
- Let TanStack Virtual use its default ResizeObserver-aware item measurement instead of a synchronous `getBoundingClientRect()` override.
- Add stable virtual item keys from message IDs and a Storybook stress story for long, variable-height message lists.

Closes #5979

## Verification
- `pnpm nx run @copilotkit/react-core:test --excludeTaskDependencies --skip-nx-cache`
- `pnpm nx run @copilotkit/react-core:check-types --excludeTaskDependencies --skip-nx-cache`
- `pnpm nx run @copilotkit/react-core:build --excludeTaskDependencies --skip-nx-cache`
- `pnpm nx format:check --files=packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx,packages/react-core/src/v2/components/chat/__tests__/CopilotChatMessageView.virtualization.test.tsx,examples/v2/react/storybook/stories/CopilotChatView.stories.tsx`
- `git diff --check`

## Local Environment Notes
- `pnpm nx run @copilotkit-storybook/react:build --excludeTaskDependencies --skip-nx-cache` could not complete locally because the shared dependency tree is missing `@storybook/nextjs` and `@storybook/addon-themes`.
- A browser retest could not be relaunched locally because the Playwright package was present but the required Chromium executable was not available in the local browser cache.
