### PR TITLE
Fix stale activity content after deltas

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -42,6 +42,16 @@ import {
 import { LastUserMessageContext } from "./last-user-message-context";
 import type { LastUserMessageState } from "./last-user-message-context";
 
+function getActivityContentMemoKey(content: unknown): string | number {
+  if (content === null || typeof content !== "object") return 0;
+
+  try {
+    return JSON.stringify(content);
+  } catch {
+    return Object.prototype.toString.call(content);
+  }
+}
+
 export type CopilotChatProps = Omit<
   CopilotChatViewProps,
   | "messages"
@@ -979,15 +989,20 @@ export function CopilotChat({
   // serializing large base64 attachment data on every render. The key captures:
   //   - message id, role, content length (text streaming)
   //   - content part count (multimodal additions)
+  //   - activity object content (custom/A2UI activity deltas)
   //   - tool call ids + argument lengths (tool call streaming)
   const messagesMemoKey = agent.messages
     .map((m) => {
       const contentKey =
-        typeof m.content === "string"
-          ? m.content.length
-          : Array.isArray(m.content)
+        m.role === "activity" &&
+        m.content !== null &&
+        typeof m.content === "object"
+          ? getActivityContentMemoKey(m.content)
+          : typeof m.content === "string"
             ? m.content.length
-            : 0;
+            : Array.isArray(m.content)
+              ? m.content.length
+              : 0;
       const toolCallsKey =
         "toolCalls" in m && Array.isArray(m.toolCalls)
           ? m.toolCalls

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.tsx
@@ -220,6 +220,72 @@ describe("CopilotChat activity message rendering", () => {
     });
   });
 
+  it("rerenders activity content when an activity delta updates object content", async () => {
+    const agent = new MockStepwiseAgent();
+    const activityMessageId = testId("activity-delta");
+
+    const activityRenderer: ReactActivityMessageRenderer<{
+      title: string;
+      data: number[];
+    }> = {
+      activityType: "chart-activity",
+      content: z.object({
+        title: z.string(),
+        data: z.array(z.number()),
+      }),
+      render: ({ content }) => (
+        <div data-testid="activity-card">
+          {content.title}: {content.data.join(",")}
+        </div>
+      ),
+    };
+
+    renderWithCopilotKit({
+      agent,
+      renderActivityMessages: [activityRenderer],
+    });
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, { target: { value: "show chart" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("show chart")).toBeDefined();
+    });
+
+    agent.emit(runStartedEvent());
+    agent.emit(
+      activitySnapshotEvent({
+        messageId: activityMessageId,
+        activityType: "chart-activity",
+        content: { title: "Initial", data: [1, 2, 3] },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("activity-card").textContent).toContain(
+        "Initial: 1,2,3",
+      );
+    });
+
+    agent.emit({
+      type: EventType.ACTIVITY_DELTA,
+      messageId: activityMessageId,
+      activityType: "chart-activity",
+      patch: [
+        { op: "replace", path: "/title", value: "Updated" },
+        { op: "replace", path: "/data/1", value: 42 },
+      ],
+    } as never);
+    agent.emit(runFinishedEvent());
+
+    await waitFor(() => {
+      expect(screen.getByTestId("activity-card").textContent).toContain(
+        "Updated: 1,42,3",
+      );
+    });
+  });
+
   it("skips unmatched activity types when no renderer exists", async () => {
     const agent = new MockStepwiseAgent();
 


### PR DESCRIPTION
## Summary
- Add regression coverage for object-backed activity messages updated by `ACTIVITY_DELTA`.
- Include activity object content in the chat message memo key so activity renderers receive updated message content.
- Keep non-activity memo behavior scoped to existing lightweight fingerprints.

## Verification
- `pnpm --filter @copilotkit/react-core exec vitest run src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.tsx -t "rerenders activity content"`
- `pnpm nx run @copilotkit/react-core:test --excludeTaskDependencies --skip-nx-cache`
- `pnpm nx run @copilotkit/react-core:check-types --excludeTaskDependencies --skip-nx-cache`
- `pnpm nx run @copilotkit/react-core:build --excludeTaskDependencies --skip-nx-cache`
- `pnpm nx format:check --files=packages/react-core/src/v2/components/chat/CopilotChat.tsx,packages/react-core/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.tsx`
- `git diff --check`

Closes #6001