### PR TITLE
fix: preserve mobile chat input cursor

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
@@ -770,7 +770,6 @@ export function CopilotChatInput({
     ) {
       const isMobileViewport = window.matchMedia("(max-width: 767px)").matches;
       if (isMobileViewport) {
-        ensureMeasurements();
         adjustTextareaHeight();
         updateLayout("expanded");
         return;

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatInput.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatInput.test.tsx
@@ -1566,6 +1566,70 @@ describe("CopilotChatInput", () => {
       // Cache was NOT invalidated — no getBoundingClientRect needed
       expect(addRectSpy).not.toHaveBeenCalled();
     });
+
+    it("does not clear textarea.value on mobile keystrokes after measurements are cached", async () => {
+      const { textarea } = await renderAndWarmCache();
+      const textareaElement = textarea as HTMLTextAreaElement;
+      const originalMatchMedia = window.matchMedia;
+      const valueDescriptor = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value",
+      );
+      let blankValueAssignments = 0;
+
+      Object.defineProperty(textareaElement, "value", {
+        configurable: true,
+        get() {
+          return valueDescriptor?.get?.call(this) ?? "";
+        },
+        set(nextValue: string) {
+          if (nextValue === "") {
+            blankValueAssignments += 1;
+          }
+          valueDescriptor?.set?.call(this, nextValue);
+        },
+      });
+
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: query === "(max-width: 767px)",
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        })),
+      });
+
+      try {
+        blankValueAssignments = 0;
+        textareaElement.setSelectionRange(0, 0);
+
+        fireEvent.change(textareaElement, {
+          target: { value: "ba" },
+        });
+        triggerResizeForTargets(textareaElement);
+
+        await waitFor(() => {
+          expect(
+            getLayoutGrid(textareaElement).getAttribute("data-layout"),
+          ).toBe("expanded");
+        });
+
+        expect(blankValueAssignments).toBe(0);
+      } finally {
+        delete (textareaElement as { value?: string }).value;
+        Object.defineProperty(window, "matchMedia", {
+          configurable: true,
+          writable: true,
+          value: originalMatchMedia,
+        });
+      }
+    });
   });
 
   describe("Scroll behavior", () => {


### PR DESCRIPTION
## Summary
- avoid re-running destructive textarea measurement on every mobile layout evaluation once measurements are cached
- add a regression test that fails if mobile typing clears the textarea value after the measurement cache is warm

Fixes #4150

## Verification
- pnpm --filter @copilotkit/react-core exec vitest run src/v2/components/chat/__tests__/CopilotChatInput.test.tsx -t "does not clear textarea.value"
- pnpm --filter @copilotkit/react-core exec vitest run src/v2/components/chat/__tests__/CopilotChatInput.test.tsx
- pnpm nx run @copilotkit/react-core:test --excludeTaskDependencies --skip-nx-cache
- pnpm nx run @copilotkit/react-core:check-types --excludeTaskDependencies --skip-nx-cache
- pnpm nx format:check --files=packages/react-core/src/v2/components/chat/CopilotChatInput.tsx,packages/react-core/src/v2/components/chat/__tests__/CopilotChatInput.test.tsx
- git diff --check

Note: local pre-commit also triggered broader channels package builds that fail in this dependency tree because channel package dependencies are not installed; the scoped react-core validation above passes.