### PR TITLE
docs: remove stale Turborepo references

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -21,7 +21,7 @@ Framework integration starters demonstrating CopilotKit with various agent frame
 | Example                                                                | Description                                                                          |
 | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | [langgraph-python](./integrations/langgraph-python/)                   | Starter template for building AI agents using LangGraph (Python) and CopilotKit      |
-| [langgraph-js](./integrations/langgraph-js/)                           | Starter template for building AI agents using LangGraph (JS) with Turborepo monorepo |
+| [langgraph-js](./integrations/langgraph-js/)                           | Starter template for building AI agents using LangGraph (JS) and CopilotKit          |
 | [langgraph-fastapi](./integrations/langgraph-fastapi/)                 | Starter template for building AI agents using LangGraph with FastAPI and Poetry      |
 | [mastra](./integrations/mastra/)                                       | Starter template for building AI agents using Mastra and CopilotKit                  |
 | [crewai-flows](./integrations/crewai-flows/)                           | Starter template for building AI agents using CrewAI Flows (uv-based)                |

--- a/skills/copilotkit-integrations/references/integrations/langgraph.md
+++ b/skills/copilotkit-integrations/references/integrations/langgraph.md
@@ -290,16 +290,15 @@ Run it with `langgraphjs dev --port 8123` (the agent app's `dev` script). The `g
 
 The catch-all `src/app/api/copilotkit/[[...slug]]/route.ts` uses `LangGraphAgent` (from `@copilotkit/runtime/langgraph`) with `deploymentUrl` (the `langgraphjs dev` URL, e.g. `http://localhost:8123`) and `graphId` (`"sample_agent"`), mounted via `createCopilotHonoHandler`.
 
-## Monorepo Structure (JS)
+## Project Structure (JS)
 
-The JS variant uses a Turborepo monorepo:
+The JS variant uses a Next.js app with a nested LangGraph agent app:
 
 ```
-apps/
-  web/          # Next.js frontend
-  agent/        # LangGraph agent, served via `langgraphjs dev` (langgraph.json)
-pnpm-workspace.yaml
-turbo.json
+src/            # Next.js frontend and CopilotKit API route
+agent/          # LangGraph agent, served via `langgraphjs dev` (langgraph.json)
+scripts/        # Cross-platform agent run scripts
+package.json
 ```
 
-Run `pnpm dev` to start both apps via Turborepo (the agent app runs `langgraphjs dev --port 8123`).
+Run `pnpm dev` to start both the UI and agent servers concurrently. The agent app runs `langgraphjs dev --port 8123`.

--- a/skills/copilotkit-integrations/sources.md
+++ b/skills/copilotkit-integrations/sources.md
@@ -26,7 +26,7 @@ Generated: 2026-03-28
 
 - examples/integrations/langgraph-fastapi/ (LangGraph Python self-hosted with LangGraphAGUIAgent, FastAPI, LangGraphHttpAgent)
 - examples/integrations/langgraph-python/ (LangGraph Platform with LangGraphAgent, deploymentUrl, graphId)
-- examples/integrations/langgraph-js/ (LangGraph JS with CopilotKitStateAnnotation, convertActionsToDynamicStructuredTools, Turborepo monorepo)
+- examples/integrations/langgraph-js/ (LangGraph JS with CopilotKitStateAnnotation, convertActionsToDynamicStructuredTools, Next.js UI, and nested LangGraph agent app)
 
 ## integrations/llamaindex.md
 


### PR DESCRIPTION
## Summary
- update the LangGraph JS starter listing so it no longer describes the example as a Turborepo monorepo
- align the CopilotKit integration skill references with the current LangGraph JS starter structure
- keep existing example-level Turbo references untouched where those standalone examples still use Turbo directly

Fixes #3508

## Verification
- custom stale Turborepo docs check for contributing docs and changed LangGraph JS references
- `git diff --check`
