### PR TITLE
docs: add Strands auth troubleshooting

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
@@ -436,6 +436,20 @@ Before you begin, you'll need the following:
                 - Make sure your agent is running on port 8000
                 - Check that your OpenAI API key is correctly set
                 - Verify that the `@ag-ui/client` package is installed in your frontend
+                - If you see `HTTP 401` with `Missing Authentication Token`, check which endpoint is rejecting the request:
+                  - For the local quickstart, keep the frontend on `<CopilotKit runtimeUrl="/api/copilotkit" agent="strands_agent">` and point `new HttpAgent({ url: "http://localhost:8000" })` at the local AG-UI server.
+                  - If your Strands AG-UI endpoint is remote and requires a static bearer token or custom header, set it on the server-side `HttpAgent` using environment variables:
+
+                    ```tsx
+                    new HttpAgent({
+                      url: process.env.STRANDS_URL!,
+                      headers: {
+                        Authorization: `Bearer ${process.env.STRANDS_TOKEN!}`,
+                      },
+                    })
+                    ```
+
+                  - Do not put agent endpoint secrets in browser code or `NEXT_PUBLIC_*` variables. For IAM SigV4 or per-request signing, put a small server-side proxy in front of the Strands endpoint and point `HttpAgent` at that proxy.
             </Accordion>
         </Accordions>
 


### PR DESCRIPTION
## Summary
- add AWS Strands quickstart troubleshooting for HTTP 401 / Missing Authentication Token
- clarify the local runtime proxy setup versus a remote protected AG-UI endpoint
- show how to set server-side HttpAgent headers from environment variables
- warn against putting endpoint secrets in browser code or NEXT_PUBLIC variables, with a server-side proxy note for SigV4/per-request signing

Fixes #2912

## Verification
- custom AWS Strands 401 troubleshooting docs check
- git diff --check
- npm run typecheck (from showcase/shell-docs)
- npm run build (from showcase/shell-docs)