### PR TITLE
Add the unified Intelligence learning platform

### DIFF
--- a/packages/intelligence/README.md
+++ b/packages/intelligence/README.md
@@ -1,0 +1,25 @@
+# @copilotkit/intelligence
+
+Canonical public contracts and SDK surface for the CopilotKit Intelligence
+Learning Platform.
+
+The exported Zod 4 schemas are the source of truth for the versioned V1 DTOs
+shared by CopilotKit runtimes, Intelligence services, and language SDKs. The
+package also exports generated JSON Schema objects for language-neutral
+conformance tooling.
+
+```ts
+import {
+  learningContainerV1Schema,
+  runSnapshotV1Schema,
+  skillSetProjectionV1Schema,
+} from "@copilotkit/intelligence";
+
+const container = learningContainerV1Schema.parse(response);
+const snapshot = runSnapshotV1Schema.parse(snapshotPayload);
+const projection = skillSetProjectionV1Schema.parse(registryResponse);
+```
+
+The contracts intentionally model one nullable learning-container assignment
+per thread. Runtime/browser code must not infer a default container or treat a
+browser-provided value as assignment authority.

--- a/packages/intelligence/package.json
+++ b/packages/intelligence/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@copilotkit/intelligence",
+  "version": "0.1.0",
+  "description": "Canonical contracts and SDK for the CopilotKit Intelligence Learning Platform.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CopilotKit/CopilotKit.git",
+    "directory": "packages/intelligence"
+  },
+  "homepage": "https://github.com/CopilotKit/CopilotKit",
+  "keywords": ["ai", "agent", "copilotkit", "intelligence", "learning"],
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": ["dist"],
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "check-types": "tsc --noEmit -p tsconfig.check.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "publint": "publint .",
+    "attw": "attw --pack . --profile esm-only"
+  },
+  "dependencies": {
+    "zod": "^4.3.5"
+  },
+  "devDependencies": {
+    "@copilotkit/typescript-config": "workspace:^",
+    "@types/node": "^22.10.0",
+    "typescript": "^5.6.3",
+    "vitest": "^4.1.3"
+  }
+}

--- a/packages/intelligence/src/commands.test.ts
+++ b/packages/intelligence/src/commands.test.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "vitest";
+import {
+  commitLearningRunResultV1Schema,
+  evaluateCandidateGatesV1Schema,
+  publishCandidateV1Schema,
+  requestThreadSnapshotBackfillV1Schema,
+  startLearningContainerRunV1Schema,
+} from "./commands.js";
+
+const containerId = "11111111-1111-4111-8111-111111111111";
+const runId = "22222222-2222-4222-8222-222222222222";
+const attemptId = "33333333-3333-4333-8333-333333333333";
+const candidateRevisionId = "44444444-4444-4444-8444-444444444444";
+const sha256 = "a".repeat(64);
+
+test("StartLearningContainerRunV1 requires a scoped idempotent trigger", () => {
+  expect(
+    startLearningContainerRunV1Schema.safeParse({
+      schemaVersion: 1,
+      organizationId: "org_1",
+      projectId: "42",
+      learningContainerId: containerId,
+      trigger: "manual",
+      idempotencyKey: "request_1",
+      requestId: "req_1",
+      traceId: "trace_1",
+    }).success,
+  ).toBe(true);
+  expect(
+    startLearningContainerRunV1Schema.safeParse({
+      schemaVersion: 1,
+      organizationId: "org_1",
+      projectId: "42",
+      learningContainerId: containerId,
+      trigger: "manual",
+      idempotencyKey: "",
+      requestId: "req_1",
+      traceId: "trace_1",
+    }).success,
+  ).toBe(false);
+});
+
+test("CommitLearningRunResultV1 binds output to the active attempt fence", () => {
+  const command = {
+    schemaVersion: 1,
+    learningRunId: runId,
+    attemptId,
+    fenceGeneration: 3,
+    outputSha256: sha256,
+    workflowOutput: {
+      schemaVersion: 1,
+      insights: [],
+      skillCandidates: [],
+      coverage: {},
+      rejections: [],
+      usage: {},
+    },
+    requestId: "req_1",
+    traceId: "trace_1",
+  } as const;
+
+  expect(commitLearningRunResultV1Schema.safeParse(command).success).toBe(true);
+  expect(
+    commitLearningRunResultV1Schema.safeParse({
+      ...command,
+      fenceGeneration: -1,
+    }).success,
+  ).toBe(false);
+});
+
+test("EvaluateCandidateGatesV1 and PublishCandidateV1 bind the same subject hash", () => {
+  expect(
+    evaluateCandidateGatesV1Schema.safeParse({
+      schemaVersion: 1,
+      candidateRevisionId,
+      subjectSha256: sha256,
+      evaluatorProfileRef: "evaluator:v1",
+      requestId: "req_1",
+      traceId: "trace_1",
+    }).success,
+  ).toBe(true);
+  expect(
+    publishCandidateV1Schema.safeParse({
+      schemaVersion: 1,
+      candidateRevisionId,
+      subjectSha256: sha256,
+      publicationIdempotencyKey: "publish_1",
+      expectedParentVersionId: null,
+      expectedArchiveFence: 0,
+      requestId: "req_1",
+      traceId: "trace_1",
+    }).success,
+  ).toBe(true);
+  expect(
+    publishCandidateV1Schema.safeParse({
+      schemaVersion: 1,
+      candidateRevisionId,
+      subjectSha256: "short",
+      publicationIdempotencyKey: "publish_1",
+      expectedParentVersionId: null,
+      expectedArchiveFence: 0,
+      requestId: "req_1",
+      traceId: "trace_1",
+    }).success,
+  ).toBe(false);
+});
+
+test("RequestThreadSnapshotBackfillV1 remains assignment-revision scoped and nullable", () => {
+  expect(
+    requestThreadSnapshotBackfillV1Schema.parse({
+      schemaVersion: 1,
+      organizationId: "org_1",
+      projectId: "42",
+      threadId: "thread_1",
+      learningContainerId: null,
+      assignmentRevision: 4,
+      requestId: "req_1",
+      traceId: "trace_1",
+    }),
+  ).toMatchObject({ learningContainerId: null, assignmentRevision: 4 });
+});

--- a/packages/intelligence/src/commands.ts
+++ b/packages/intelligence/src/commands.ts
@@ -1,0 +1,119 @@
+import { z } from "zod/v4";
+import {
+  generatedSkillCandidateV1Schema,
+  jsonValueSchema,
+  learningWorkflowOutputV1Schema,
+} from "./contracts.js";
+
+const nonEmptyStringSchema = z.string().min(1);
+const idSchema = nonEmptyStringSchema;
+const uuidSchema = z.uuid();
+const nonNegativeIntegerSchema = z.int().nonnegative();
+const sha256Schema = z
+  .string()
+  .regex(/^[a-f0-9]{64}$/u, "Expected lowercase SHA-256");
+
+const commandEnvelopeShape = {
+  schemaVersion: z.literal(1),
+  requestId: nonEmptyStringSchema,
+  traceId: nonEmptyStringSchema,
+} as const;
+
+/** Starts an idempotent scheduled or manual run for one scoped container. */
+export const startLearningContainerRunV1Schema = z.looseObject({
+  ...commandEnvelopeShape,
+  organizationId: idSchema,
+  projectId: idSchema,
+  learningContainerId: uuidSchema,
+  trigger: z.enum(["nightly", "manual"]),
+  idempotencyKey: nonEmptyStringSchema,
+});
+export type StartLearningContainerRunV1 = z.infer<
+  typeof startLearningContainerRunV1Schema
+>;
+
+/** Claims and prepares one fenced attempt over the run's frozen manifest. */
+export const prepareLearningRunV1Schema = z.looseObject({
+  ...commandEnvelopeShape,
+  learningRunId: uuidSchema,
+  attemptId: uuidSchema,
+  fenceGeneration: nonNegativeIntegerSchema,
+  queueJobId: nonEmptyStringSchema,
+});
+export type PrepareLearningRunV1 = z.infer<typeof prepareLearningRunV1Schema>;
+
+/** Commits a validated aggregate output under the active attempt fence. */
+export const commitLearningRunResultV1Schema = z.looseObject({
+  ...commandEnvelopeShape,
+  learningRunId: uuidSchema,
+  attemptId: uuidSchema,
+  fenceGeneration: nonNegativeIntegerSchema,
+  outputSha256: sha256Schema,
+  workflowOutput: learningWorkflowOutputV1Schema,
+});
+export type CommitLearningRunResultV1 = z.infer<
+  typeof commitLearningRunResultV1Schema
+>;
+
+/** Converts one generated output alias into an immutable candidate revision. */
+export const prepareRegistryCandidateV1Schema = z.looseObject({
+  ...commandEnvelopeShape,
+  learningRunId: uuidSchema,
+  outputAlias: nonEmptyStringSchema,
+  idempotencyKey: nonEmptyStringSchema,
+  generatedCandidate: generatedSkillCandidateV1Schema,
+});
+export type PrepareRegistryCandidateV1 = z.infer<
+  typeof prepareRegistryCandidateV1Schema
+>;
+
+/** Evaluates every required gate against one exact candidate subject. */
+export const evaluateCandidateGatesV1Schema = z.looseObject({
+  ...commandEnvelopeShape,
+  candidateRevisionId: uuidSchema,
+  subjectSha256: sha256Schema,
+  evaluatorProfileRef: nonEmptyStringSchema,
+});
+export type EvaluateCandidateGatesV1 = z.infer<
+  typeof evaluateCandidateGatesV1Schema
+>;
+
+/** Publishes one candidate independently under parent and archive fences. */
+export const publishCandidateV1Schema = z.looseObject({
+  ...commandEnvelopeShape,
+  candidateRevisionId: uuidSchema,
+  subjectSha256: sha256Schema,
+  publicationIdempotencyKey: nonEmptyStringSchema,
+  expectedParentVersionId: uuidSchema.nullable(),
+  expectedArchiveFence: nonNegativeIntegerSchema,
+});
+export type PublishCandidateV1 = z.infer<typeof publishCandidateV1Schema>;
+
+/** Creates one forward-only complete registry revision. */
+export const createRegistryRevisionV1Schema = z.looseObject({
+  ...commandEnvelopeShape,
+  organizationId: idSchema,
+  projectId: idSchema,
+  learningContainerId: uuidSchema,
+  expectedRegistryRevision: nonEmptyStringSchema,
+  expectedArchiveFence: nonNegativeIntegerSchema,
+  idempotencyKey: nonEmptyStringSchema,
+  reasonCode: nonEmptyStringSchema,
+  mutation: jsonValueSchema,
+});
+export type CreateRegistryRevisionV1 = z.infer<
+  typeof createRegistryRevisionV1Schema
+>;
+
+/** Best-effort, non-durable request to snapshot already-finished assigned runs. */
+export const requestThreadSnapshotBackfillV1Schema = z.looseObject({
+  ...commandEnvelopeShape,
+  organizationId: idSchema,
+  projectId: idSchema,
+  threadId: idSchema,
+  learningContainerId: uuidSchema.nullable(),
+  assignmentRevision: nonNegativeIntegerSchema,
+});
+export type RequestThreadSnapshotBackfillV1 = z.infer<
+  typeof requestThreadSnapshotBackfillV1Schema
+>;

--- a/packages/intelligence/src/contracts.test.ts
+++ b/packages/intelligence/src/contracts.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, test } from "vitest";
+import {
+  blobLocatorV1Schema,
+  candidateGateResultV1Schema,
+  insightV1Schema,
+  learningContainerV1Schema,
+  learningContractJsonSchemas,
+  runSnapshotV1Schema,
+  skillCandidateV1Schema,
+  skillSetProjectionV1Schema,
+  threadAssignmentPatchV1Schema,
+} from "./contracts.js";
+
+const UUIDS = {
+  container: "11111111-1111-4111-8111-111111111111",
+  snapshot: "22222222-2222-4222-8222-222222222222",
+  insight: "33333333-3333-4333-8333-333333333333",
+  run: "44444444-4444-4444-8444-444444444444",
+  candidate: "55555555-5555-4555-8555-555555555555",
+  candidateRevision: "66666666-6666-4666-8666-666666666666",
+  skill: "77777777-7777-4777-8777-777777777777",
+  version: "88888888-8888-4888-8888-888888888888",
+  gate: "99999999-9999-4999-8999-999999999999",
+} as const;
+
+const SHA_A = "a".repeat(64);
+const SHA_B = "b".repeat(64);
+const NOW = "2026-07-16T18:00:00.000Z";
+
+const learningContainer = {
+  schemaVersion: 1,
+  id: UUIDS.container,
+  organizationId: "org_1",
+  projectId: "42",
+  name: "Support agent",
+  description: null,
+  learningEnabled: true,
+  autoApproveSkillChanges: false,
+  modelProfileRef: "model:v1",
+  promptProfileRef: "prompt:v1",
+  evaluatorProfileRef: "evaluator:v1",
+  watermarkSequence: 0,
+  configRevision: 1,
+  archiveFence: 0,
+  archivedAt: null,
+  consumptionRevokedAt: null,
+  createdAt: NOW,
+  updatedAt: NOW,
+} as const;
+
+const snapshot = {
+  schemaVersion: 1,
+  snapshotId: UUIDS.snapshot,
+  organizationId: "org_1",
+  projectId: "42",
+  learningContainerId: UUIDS.container,
+  threadId: "thread_1",
+  agentRunId: "9007199254740993",
+  externalRunId: "run_external_1",
+  terminalEventId: "event_terminal",
+  terminalType: "RUN_FINISHED",
+  terminalStatus: null,
+  startedAt: NOW,
+  terminalAt: NOW,
+  capturedAt: NOW,
+  assignmentRevision: 2,
+  sourceEvents: [
+    {
+      eventId: "event_1",
+      sequence: 1,
+      type: "TEXT_MESSAGE_END",
+      sha256: SHA_A,
+    },
+  ],
+  messages: [
+    {
+      messageId: "message_1",
+      role: "assistant",
+      content: "done",
+      toolCalls: [{ id: "call_1", name: "search", argsText: "{}" }],
+      toolResults: [
+        { toolCallId: "call_1", status: "unknown", output: { hits: 2 } },
+      ],
+      eventIds: ["event_1"],
+      timestamp: NOW,
+    },
+  ],
+  stateChanges: [],
+  annotations: [],
+  attachments: [],
+  normalizerVersion: "normalizer:v1",
+  sanitizerVersion: "sanitizer:v1",
+  contentSha256: SHA_A,
+  byteLength: 100,
+  tokenEstimate: 25,
+  containerSequence: 1,
+} as const;
+
+describe("parent V1 contract schemas", () => {
+  test("parses a complete LearningContainerV1 without inventing a default assignment", () => {
+    expect(learningContainerV1Schema.parse(learningContainer)).toEqual(
+      learningContainer,
+    );
+    expect(
+      threadAssignmentPatchV1Schema.parse({
+        learningContainerId: null,
+        expectedLearningContainerId: null,
+      }),
+    ).toEqual({
+      learningContainerId: null,
+      expectedLearningContainerId: null,
+    });
+  });
+
+  test("rejects invalid assignment identifiers and missing compare values", () => {
+    expect(
+      threadAssignmentPatchV1Schema.safeParse({
+        learningContainerId: "project",
+      }).success,
+    ).toBe(false);
+    expect(
+      threadAssignmentPatchV1Schema.safeParse({
+        learningContainerId: UUIDS.container,
+      }).success,
+    ).toBe(false);
+  });
+
+  test("preserves plural tool calls/results without inventing optional names", () => {
+    const parsed = runSnapshotV1Schema.parse(snapshot);
+
+    expect(parsed.messages[0]?.toolCalls).toHaveLength(1);
+    expect(parsed.messages[0]?.toolResults[0]).toEqual({
+      toolCallId: "call_1",
+      status: "unknown",
+      output: { hits: 2 },
+    });
+  });
+
+  test("rejects snapshots whose hashes or integer planning bounds are invalid", () => {
+    expect(
+      runSnapshotV1Schema.safeParse({ ...snapshot, contentSha256: "short" })
+        .success,
+    ).toBe(false);
+    expect(
+      runSnapshotV1Schema.safeParse({ ...snapshot, byteLength: -1 }).success,
+    ).toBe(false);
+  });
+
+  test("requires immutable insights to have finite confidence and evidence", () => {
+    const insight = {
+      schemaVersion: 1,
+      id: UUIDS.insight,
+      organizationId: "org_1",
+      projectId: "42",
+      learningContainerId: UUIDS.container,
+      learningRunId: UUIDS.run,
+      workflowOutputAlias: "insight_1",
+      kind: "agent_behavior",
+      statement: "The agent retries a completed action.",
+      impact: "The duplicate action can charge the user twice.",
+      confidence: 0.9,
+      skillEligible: true,
+      evidenceRefs: [
+        {
+          evidenceType: "run_snapshot",
+          snapshotId: UUIDS.snapshot,
+          snapshotSha256: SHA_A,
+          threadId: "thread_1",
+          externalRunId: "run_external_1",
+          messageIds: ["message_1"],
+          eventIds: ["event_1"],
+          excerpt: null,
+          excerptSha256: null,
+          truncated: false,
+        },
+      ],
+      createdAt: NOW,
+    } as const;
+
+    expect(insightV1Schema.parse(insight)).toEqual(insight);
+    expect(
+      insightV1Schema.safeParse({ ...insight, confidence: Number.NaN }).success,
+    ).toBe(false);
+    expect(
+      insightV1Schema.safeParse({ ...insight, confidence: 1.01 }).success,
+    ).toBe(false);
+    expect(
+      insightV1Schema.safeParse({ ...insight, evidenceRefs: [] }).success,
+    ).toBe(false);
+  });
+
+  test("enforces bundle subjects for add/update and removal intents for remove", () => {
+    const base = {
+      candidateId: UUIDS.candidate,
+      candidateRevisionId: UUIDS.candidateRevision,
+      organizationId: "org_1",
+      projectId: "42",
+      learningContainerId: UUIDS.container,
+      learningRunId: UUIDS.run,
+      skillId: UUIDS.skill,
+      insightIds: [UUIDS.insight],
+      evidenceRefs: [],
+      reason: "Teach an idempotent retry guard.",
+      risk: "low",
+      approvalModeSnapshot: "manual",
+      evaluatorProfileRef: "evaluator:v1",
+      status: "pending_review",
+      createdByType: "learning",
+      createdAt: NOW,
+    } as const;
+    const bundleLocator = {
+      schemaVersion: 1,
+      backendId: "primary",
+      provider: "awsS3",
+      resource: "skill-bundles",
+      key: "objects/aa/bundle.zip",
+      providerVersion: null,
+      etag: null,
+      applicationSha256: SHA_A,
+      providerChecksum: null,
+      byteLength: 12,
+      contentType: "application/zip",
+    } as const;
+
+    expect(
+      skillCandidateV1Schema.safeParse({
+        ...base,
+        action: "add",
+        proposedVersionId: UUIDS.version,
+        parentVersionId: null,
+        bundleLocator,
+        bundleSha256: SHA_A,
+        removalIntent: null,
+        removalIntentSha256: null,
+        subjectSha256: SHA_A,
+      }).success,
+    ).toBe(true);
+    expect(
+      skillCandidateV1Schema.safeParse({
+        ...base,
+        action: "add",
+        proposedVersionId: UUIDS.version,
+        parentVersionId: null,
+        bundleLocator: null,
+        bundleSha256: null,
+        removalIntent: null,
+        removalIntentSha256: null,
+        subjectSha256: SHA_A,
+      }).success,
+    ).toBe(false);
+    expect(
+      skillCandidateV1Schema.safeParse({
+        ...base,
+        action: "remove",
+        proposedVersionId: null,
+        parentVersionId: UUIDS.version,
+        bundleLocator: null,
+        bundleSha256: null,
+        removalIntent: { reasonCode: "unsafe_behavior" },
+        removalIntentSha256: SHA_B,
+        subjectSha256: SHA_B,
+      }).success,
+    ).toBe(true);
+  });
+
+  test("binds every gate result to the exact candidate subject hash", () => {
+    const gate = {
+      gateResultId: UUIDS.gate,
+      candidateRevisionId: UUIDS.candidateRevision,
+      subjectSha256: SHA_A,
+      gate: "behavioral_evaluation",
+      profileVersion: "eval:v1",
+      fixtureVersion: "fixture:v1",
+      baselineVersion: null,
+      status: "passed",
+      reasonCode: "improved",
+      detailsRef: null,
+      evaluatedAt: NOW,
+    } as const;
+
+    expect(candidateGateResultV1Schema.parse(gate)).toEqual(gate);
+    expect(
+      candidateGateResultV1Schema.safeParse({ ...gate, subjectSha256: "" })
+        .success,
+    ).toBe(false);
+  });
+
+  test("accepts an empty complete skill projection and rejects partial entries", () => {
+    const projection = {
+      schemaVersion: 1,
+      learningContainerId: UUIDS.container,
+      registryRevision: "0",
+      skillSetHash: SHA_A,
+      etag: '"registry-0"',
+      entries: [],
+      publishedAt: NOW,
+      revoked: true,
+    } as const;
+
+    expect(skillSetProjectionV1Schema.parse(projection)).toEqual(projection);
+    expect(
+      skillSetProjectionV1Schema.safeParse({
+        ...projection,
+        entries: [{ skillId: UUIDS.skill }],
+      }).success,
+    ).toBe(false);
+  });
+
+  test("supports only the four normative object-storage providers", () => {
+    const locator = {
+      schemaVersion: 1,
+      backendId: "primary",
+      provider: "googleCloudStorage",
+      resource: "skill-bundles",
+      key: "objects/aa/bundle.zip",
+      providerVersion: null,
+      etag: null,
+      applicationSha256: SHA_A,
+      providerChecksum: null,
+      byteLength: 12,
+      contentType: "application/zip",
+    } as const;
+
+    expect(blobLocatorV1Schema.parse(locator)).toEqual(locator);
+    expect(
+      blobLocatorV1Schema.safeParse({ ...locator, provider: "filesystem" })
+        .success,
+    ).toBe(false);
+  });
+
+  test("exports named JSON Schemas for language-neutral consumers", () => {
+    expect(Object.keys(learningContractJsonSchemas).sort()).toEqual(
+      expect.arrayContaining([
+        "BlobLocatorV1",
+        "InsightV1",
+        "LearningContainerV1",
+        "RunSnapshotV1",
+        "SkillCandidateV1",
+        "SkillSetProjectionV1",
+      ]),
+    );
+    expect(learningContractJsonSchemas.LearningContainerV1).toMatchObject({
+      type: "object",
+    });
+  });
+});

--- a/packages/intelligence/src/contracts.ts
+++ b/packages/intelligence/src/contracts.ts
@@ -1,0 +1,672 @@
+import { z } from "zod/v4";
+
+const nonEmptyStringSchema = z.string().min(1);
+const idSchema = nonEmptyStringSchema;
+const uuidSchema = z.uuid();
+const nonNegativeIntegerSchema = z.int().nonnegative();
+const positiveIntegerSchema = z.int().positive();
+const timestampSchema = z.iso.datetime({ offset: true });
+const nullableTimestampSchema = timestampSchema.nullable();
+const sha256Schema = z
+  .string()
+  .regex(/^[a-f0-9]{64}$/u, "Expected lowercase SHA-256");
+
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { readonly [key: string]: JsonValue };
+
+/** JSON-compatible value that rejects non-finite numbers and class instances. */
+export const jsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number().finite(),
+    z.boolean(),
+    z.null(),
+    z.array(jsonValueSchema),
+    z.record(z.string(), jsonValueSchema),
+  ]),
+);
+
+const jsonObjectSchema = z.record(z.string(), jsonValueSchema);
+
+/** Canonical project-scoped learning container read model. */
+export const learningContainerV1Schema = z.looseObject({
+  schemaVersion: z.literal(1),
+  id: uuidSchema,
+  organizationId: idSchema,
+  projectId: idSchema,
+  name: nonEmptyStringSchema,
+  description: z.string().nullable(),
+  learningEnabled: z.boolean(),
+  autoApproveSkillChanges: z.boolean(),
+  modelProfileRef: nonEmptyStringSchema,
+  promptProfileRef: nonEmptyStringSchema,
+  evaluatorProfileRef: nonEmptyStringSchema,
+  watermarkSequence: nonNegativeIntegerSchema,
+  configRevision: nonNegativeIntegerSchema,
+  archiveFence: nonNegativeIntegerSchema,
+  archivedAt: nullableTimestampSchema,
+  consumptionRevokedAt: nullableTimestampSchema,
+  createdAt: timestampSchema,
+  updatedAt: timestampSchema,
+});
+export type LearningContainerV1 = z.infer<typeof learningContainerV1Schema>;
+
+/** Thread assignment fields returned by runtime/control-plane APIs. */
+export const threadAssignmentV1Schema = z.looseObject({
+  learningContainerId: uuidSchema.nullable(),
+  assignmentRevision: nonNegativeIntegerSchema,
+});
+export type ThreadAssignmentV1 = z.infer<typeof threadAssignmentV1Schema>;
+
+/** Optimistic control-plane assignment mutation. */
+export const threadAssignmentPatchV1Schema = z.looseObject({
+  learningContainerId: uuidSchema.nullable(),
+  expectedLearningContainerId: uuidSchema.nullable(),
+});
+export type ThreadAssignmentPatchV1 = z.infer<
+  typeof threadAssignmentPatchV1Schema
+>;
+
+export const normalizedToolCallV1Schema = z.looseObject({
+  id: nonEmptyStringSchema,
+  name: nonEmptyStringSchema,
+  argsText: z.string(),
+});
+export type NormalizedToolCallV1 = z.infer<typeof normalizedToolCallV1Schema>;
+
+export const normalizedToolResultV1Schema = z.looseObject({
+  toolCallId: nonEmptyStringSchema,
+  name: nonEmptyStringSchema.optional(),
+  status: z.enum(["ok", "error", "unknown"]),
+  output: jsonValueSchema,
+});
+export type NormalizedToolResultV1 = z.infer<
+  typeof normalizedToolResultV1Schema
+>;
+
+/** Lossless normalized message used by snapshots and workflow inputs. */
+export const normalizedMessageV1Schema = z.looseObject({
+  messageId: nonEmptyStringSchema,
+  role: nonEmptyStringSchema,
+  content: jsonValueSchema,
+  toolCalls: z.array(normalizedToolCallV1Schema),
+  toolResults: z.array(normalizedToolResultV1Schema),
+  eventIds: z.array(nonEmptyStringSchema),
+  timestamp: nullableTimestampSchema,
+});
+export type NormalizedMessageV1 = z.infer<typeof normalizedMessageV1Schema>;
+
+export const sourceEventManifestEntryV1Schema = z.looseObject({
+  eventId: nonEmptyStringSchema,
+  sequence: z.union([nonNegativeIntegerSchema, nonEmptyStringSchema]),
+  cursor: nonEmptyStringSchema.optional(),
+  type: nonEmptyStringSchema,
+  sha256: sha256Schema,
+});
+export type SourceEventManifestEntryV1 = z.infer<
+  typeof sourceEventManifestEntryV1Schema
+>;
+
+/** Complete immutable first-terminal-event snapshot. */
+export const runSnapshotV1Schema = z.looseObject({
+  schemaVersion: z.literal(1),
+  snapshotId: uuidSchema,
+  organizationId: idSchema,
+  projectId: idSchema,
+  learningContainerId: uuidSchema,
+  threadId: idSchema,
+  agentRunId: nonEmptyStringSchema,
+  externalRunId: nonEmptyStringSchema,
+  terminalEventId: nonEmptyStringSchema,
+  terminalType: z.enum(["RUN_FINISHED", "RUN_ERROR"]),
+  terminalStatus: z.string().nullable(),
+  startedAt: timestampSchema,
+  terminalAt: timestampSchema,
+  capturedAt: timestampSchema,
+  assignmentRevision: nonNegativeIntegerSchema,
+  sourceEvents: z.array(sourceEventManifestEntryV1Schema),
+  messages: z.array(normalizedMessageV1Schema),
+  stateChanges: z.array(jsonObjectSchema),
+  annotations: z.array(jsonObjectSchema),
+  attachments: z.array(jsonObjectSchema),
+  normalizerVersion: nonEmptyStringSchema,
+  sanitizerVersion: nonEmptyStringSchema,
+  contentSha256: sha256Schema,
+  byteLength: nonNegativeIntegerSchema,
+  tokenEstimate: nonNegativeIntegerSchema,
+  containerSequence: positiveIntegerSchema,
+});
+export type RunSnapshotV1 = z.infer<typeof runSnapshotV1Schema>;
+
+export const evidenceLocatorV1Schema = z.looseObject({
+  messageIds: z.array(nonEmptyStringSchema),
+  eventIds: z.array(nonEmptyStringSchema),
+});
+export type EvidenceLocatorV1 = z.infer<typeof evidenceLocatorV1Schema>;
+
+/** Frozen evidence-attached human annotation selected for a run. */
+export const selectedHumanAnnotationV1Schema = z.looseObject({
+  schemaVersion: z.literal(1),
+  annotationId: uuidSchema,
+  targetSnapshotId: uuidSchema,
+  targetEvidenceLocator: evidenceLocatorV1Schema.nullable(),
+  text: nonEmptyStringSchema,
+  contentSha256: sha256Schema,
+  annotationRevision: nonNegativeIntegerSchema,
+  authoredAt: timestampSchema,
+  capturedAt: timestampSchema,
+});
+export type SelectedHumanAnnotationV1 = z.infer<
+  typeof selectedHumanAnnotationV1Schema
+>;
+
+export const snapshotIdentityV1Schema = z.looseObject({
+  snapshotId: uuidSchema,
+  contentSha256: sha256Schema,
+  containerSequence: positiveIntegerSchema,
+});
+
+export const learningRunStatusV1Schema = z.enum([
+  "created",
+  "job_requested",
+  "queued",
+  "running",
+  "finalizing",
+  "succeeded",
+  "retry_wait",
+  "dead_lettered",
+  "cancelled",
+]);
+
+/** Durable learning run and its immutable frozen manifest. */
+export const learningRunV1Schema = z.looseObject({
+  learningRunId: uuidSchema,
+  organizationId: idSchema,
+  projectId: idSchema,
+  learningContainerId: uuidSchema,
+  trigger: z.enum(["nightly", "manual"]),
+  idempotencyKey: nonEmptyStringSchema,
+  selectedAfterSequence: nonNegativeIntegerSchema,
+  selectedThroughSequence: nonNegativeIntegerSchema,
+  snapshotIdsAndHashes: z.array(snapshotIdentityV1Schema),
+  selectedAnnotations: z.array(selectedHumanAnnotationV1Schema),
+  registryRevision: nonEmptyStringSchema,
+  skillSetHash: sha256Schema,
+  containerConfigRevision: nonNegativeIntegerSchema,
+  modelProfileRef: nonEmptyStringSchema,
+  promptProfileRef: nonEmptyStringSchema,
+  evaluatorProfileRef: nonEmptyStringSchema,
+  workflowVersion: nonEmptyStringSchema,
+  normalizerVersion: nonEmptyStringSchema,
+  sanitizerVersion: nonEmptyStringSchema,
+  manifestSha256: sha256Schema,
+  status: learningRunStatusV1Schema,
+  createdAt: timestampSchema,
+  startedAt: nullableTimestampSchema,
+  completedAt: nullableTimestampSchema,
+});
+export type LearningRunV1 = z.infer<typeof learningRunV1Schema>;
+
+export const learningChunkV1Schema = z.looseObject({
+  learningRunId: uuidSchema,
+  attemptId: uuidSchema,
+  chunkIndex: nonNegativeIntegerSchema,
+  snapshotRange: z.looseObject({
+    firstSnapshotId: uuidSchema,
+    lastSnapshotId: uuidSchema,
+    firstSequence: positiveIntegerSchema,
+    lastSequence: positiveIntegerSchema,
+  }),
+  inputSha256: sha256Schema,
+  outputSha256: sha256Schema.nullable(),
+  status: z.enum([
+    "planned",
+    "running",
+    "staged",
+    "failed",
+    "discarded",
+    "promoted",
+  ]),
+  privatePayloadRef: jsonValueSchema,
+  createdAt: timestampSchema,
+  updatedAt: timestampSchema,
+});
+export type LearningChunkV1 = z.infer<typeof learningChunkV1Schema>;
+
+export const evidenceRefV1Schema = z.discriminatedUnion("evidenceType", [
+  z.looseObject({
+    evidenceType: z.literal("run_snapshot"),
+    snapshotId: uuidSchema,
+    snapshotSha256: sha256Schema,
+    annotationId: z.null().optional(),
+    annotationSha256: z.null().optional(),
+    threadId: idSchema,
+    externalRunId: nonEmptyStringSchema,
+    messageIds: z.array(nonEmptyStringSchema),
+    eventIds: z.array(nonEmptyStringSchema),
+    excerpt: z.string().nullable(),
+    excerptSha256: sha256Schema.nullable(),
+    truncated: z.boolean(),
+  }),
+  z.looseObject({
+    evidenceType: z.literal("human_annotation"),
+    snapshotId: uuidSchema,
+    snapshotSha256: sha256Schema,
+    annotationId: uuidSchema,
+    annotationSha256: sha256Schema,
+    threadId: idSchema,
+    externalRunId: nonEmptyStringSchema,
+    messageIds: z.array(nonEmptyStringSchema),
+    eventIds: z.array(nonEmptyStringSchema),
+    excerpt: z.string().nullable(),
+    excerptSha256: sha256Schema.nullable(),
+    truncated: z.boolean(),
+  }),
+]);
+export type EvidenceRefV1 = z.infer<typeof evidenceRefV1Schema>;
+
+export const insightKindV1Schema = z.enum([
+  "agent_behavior",
+  "user_product",
+  "workflow",
+  "system_quality",
+]);
+
+/** Immutable evidence-backed product insight. */
+export const insightV1Schema = z.looseObject({
+  schemaVersion: z.literal(1),
+  id: uuidSchema,
+  organizationId: idSchema,
+  projectId: idSchema,
+  learningContainerId: uuidSchema,
+  learningRunId: uuidSchema,
+  workflowOutputAlias: nonEmptyStringSchema,
+  kind: insightKindV1Schema,
+  statement: nonEmptyStringSchema,
+  impact: nonEmptyStringSchema,
+  confidence: z.number().finite().min(0).max(1),
+  skillEligible: z.boolean(),
+  evidenceRefs: z.array(evidenceRefV1Schema).min(1),
+  createdAt: timestampSchema,
+});
+export type InsightV1 = z.infer<typeof insightV1Schema>;
+
+export const insightFeedbackV1Schema = z.looseObject({
+  schemaVersion: z.literal(1),
+  id: uuidSchema,
+  insightId: uuidSchema,
+  actor: nonEmptyStringSchema,
+  rating: nonEmptyStringSchema,
+  note: z.string().nullable().optional(),
+  createdAt: timestampSchema,
+});
+export type InsightFeedbackV1 = z.infer<typeof insightFeedbackV1Schema>;
+
+export const insightAnnotationV1Schema = z.looseObject({
+  schemaVersion: z.literal(1),
+  id: uuidSchema,
+  insightId: uuidSchema,
+  evidenceTarget: evidenceLocatorV1Schema.nullable().optional(),
+  actor: nonEmptyStringSchema,
+  text: nonEmptyStringSchema,
+  revision: positiveIntegerSchema,
+  createdAt: timestampSchema,
+});
+export type InsightAnnotationV1 = z.infer<typeof insightAnnotationV1Schema>;
+
+export const insightArchiveEventV1Schema = z.looseObject({
+  schemaVersion: z.literal(1),
+  id: uuidSchema,
+  insightId: uuidSchema,
+  archived: z.boolean(),
+  actor: nonEmptyStringSchema,
+  createdAt: timestampSchema,
+});
+export type InsightArchiveEventV1 = z.infer<typeof insightArchiveEventV1Schema>;
+
+export const skillArtifactFileV1Schema = z.looseObject({
+  path: nonEmptyStringSchema,
+  role: nonEmptyStringSchema,
+  mediaType: nonEmptyStringSchema,
+  byteLength: nonNegativeIntegerSchema,
+  rawSha256: sha256Schema,
+});
+export type SkillArtifactFileV1 = z.infer<typeof skillArtifactFileV1Schema>;
+
+export const skillArtifactManifestV1Schema = z.looseObject({
+  manifestVersion: z.literal(1),
+  agentSkillsProfile: nonEmptyStringSchema,
+  files: z.array(skillArtifactFileV1Schema).min(1),
+  manifestSha256: sha256Schema,
+  bundleSha256: sha256Schema,
+  bundleByteLength: positiveIntegerSchema,
+  provenance: jsonObjectSchema,
+});
+export type SkillArtifactManifestV1 = z.infer<
+  typeof skillArtifactManifestV1Schema
+>;
+
+/** Provider-neutral immutable object locator; canonical bytes never use local storage. */
+export const blobLocatorV1Schema = z.looseObject({
+  schemaVersion: z.literal(1),
+  backendId: nonEmptyStringSchema,
+  provider: z.enum([
+    "awsS3",
+    "googleCloudStorage",
+    "azureBlob",
+    "s3Compatible",
+  ]),
+  resource: nonEmptyStringSchema,
+  key: nonEmptyStringSchema,
+  providerVersion: z.string().nullable(),
+  etag: z.string().nullable(),
+  applicationSha256: sha256Schema,
+  providerChecksum: jsonObjectSchema.nullable(),
+  byteLength: nonNegativeIntegerSchema,
+  contentType: nonEmptyStringSchema,
+});
+export type BlobLocatorV1 = z.infer<typeof blobLocatorV1Schema>;
+
+export const skillBundleV1Schema = z.looseObject({
+  schemaVersion: z.literal(1),
+  manifest: skillArtifactManifestV1Schema,
+  locator: blobLocatorV1Schema,
+});
+export type SkillBundleV1 = z.infer<typeof skillBundleV1Schema>;
+
+export const candidateStatusV1Schema = z.enum([
+  "created",
+  "pending_gates",
+  "blocked",
+  "gates_passed",
+  "pending_review",
+  "publishing",
+  "published",
+  "publish_retry_wait",
+  "stale_parent",
+  "rejected",
+  "superseded_by_edit",
+]);
+
+const skillCandidateBaseShape = {
+  candidateId: uuidSchema,
+  candidateRevisionId: uuidSchema,
+  organizationId: idSchema,
+  projectId: idSchema,
+  learningContainerId: uuidSchema,
+  learningRunId: uuidSchema.nullable(),
+  action: z.enum(["add", "update", "remove"]),
+  skillId: uuidSchema,
+  proposedVersionId: uuidSchema.nullable(),
+  parentVersionId: uuidSchema.nullable(),
+  bundleLocator: blobLocatorV1Schema.nullable(),
+  bundleSha256: sha256Schema.nullable(),
+  removalIntent: jsonObjectSchema.nullable(),
+  removalIntentSha256: sha256Schema.nullable(),
+  subjectSha256: sha256Schema,
+  insightIds: z.array(uuidSchema),
+  evidenceRefs: z.array(evidenceRefV1Schema),
+  reason: nonEmptyStringSchema,
+  risk: nonEmptyStringSchema,
+  approvalModeSnapshot: z.enum(["manual", "automatic"]),
+  evaluatorProfileRef: nonEmptyStringSchema,
+  status: candidateStatusV1Schema,
+  createdByType: z.enum(["learning", "human"]),
+  createdAt: timestampSchema,
+} as const;
+
+/** Immutable candidate revision with action-specific full-bundle/removal coherence. */
+export const skillCandidateV1Schema = z
+  .looseObject(skillCandidateBaseShape)
+  .superRefine((candidate, context) => {
+    if (candidate.action === "add") {
+      if (candidate.parentVersionId !== null) {
+        context.addIssue({
+          code: "custom",
+          path: ["parentVersionId"],
+          message: "A first add cannot have a parent version",
+        });
+      }
+      if (
+        candidate.proposedVersionId === null ||
+        candidate.bundleLocator === null ||
+        candidate.bundleSha256 === null
+      ) {
+        context.addIssue({
+          code: "custom",
+          path: ["bundleLocator"],
+          message: "Add candidates require a proposed version and full bundle",
+        });
+      }
+    }
+
+    if (candidate.action === "update") {
+      if (
+        candidate.parentVersionId === null ||
+        candidate.proposedVersionId === null ||
+        candidate.bundleLocator === null ||
+        candidate.bundleSha256 === null
+      ) {
+        context.addIssue({
+          code: "custom",
+          path: ["parentVersionId"],
+          message:
+            "Update candidates require a parent, proposed version, and full bundle",
+        });
+      }
+    }
+
+    if (candidate.action === "remove") {
+      if (
+        candidate.parentVersionId === null ||
+        candidate.proposedVersionId !== null ||
+        candidate.bundleLocator !== null ||
+        candidate.bundleSha256 !== null ||
+        candidate.removalIntent === null ||
+        candidate.removalIntentSha256 === null
+      ) {
+        context.addIssue({
+          code: "custom",
+          path: ["removalIntent"],
+          message: "Remove candidates require a parent and removal intent only",
+        });
+      }
+    }
+
+    const actionHash =
+      candidate.action === "remove"
+        ? candidate.removalIntentSha256
+        : candidate.bundleSha256;
+    if (actionHash !== null && actionHash !== candidate.subjectSha256) {
+      context.addIssue({
+        code: "custom",
+        path: ["subjectSha256"],
+        message:
+          "Candidate subject hash must equal its bundle or removal-intent hash",
+      });
+    }
+  });
+export type SkillCandidateV1 = z.infer<typeof skillCandidateV1Schema>;
+
+export const candidateGateResultV1Schema = z.looseObject({
+  gateResultId: uuidSchema,
+  candidateRevisionId: uuidSchema,
+  subjectSha256: sha256Schema,
+  gate: z.enum([
+    "artifact",
+    "privacy",
+    "provenance",
+    "parent_concurrency",
+    "behavioral_evaluation",
+  ]),
+  profileVersion: nonEmptyStringSchema,
+  fixtureVersion: z.string().nullable(),
+  baselineVersion: z.string().nullable(),
+  status: z.enum(["passed", "failed", "inconclusive", "missing"]),
+  reasonCode: nonEmptyStringSchema,
+  detailsRef: jsonValueSchema.nullable(),
+  evaluatedAt: timestampSchema,
+});
+export type CandidateGateResultV1 = z.infer<typeof candidateGateResultV1Schema>;
+
+export const skillSetProjectionEntryV1Schema = z.looseObject({
+  skillId: uuidSchema,
+  versionId: uuidSchema,
+  position: nonNegativeIntegerSchema,
+  name: nonEmptyStringSchema,
+  description: z.string().nullable(),
+  bundleLocator: blobLocatorV1Schema,
+  bundleSha256: sha256Schema,
+  manifestSha256: sha256Schema,
+  bundleByteLength: positiveIntegerSchema,
+  approvalMethod: z.enum(["manual", "automatic"]),
+});
+export type SkillSetProjectionEntryV1 = z.infer<
+  typeof skillSetProjectionEntryV1Schema
+>;
+
+/** Complete ordered runtime projection; an empty projection is valid. */
+export const skillSetProjectionV1Schema = z.looseObject({
+  schemaVersion: z.literal(1),
+  learningContainerId: uuidSchema,
+  registryRevision: nonEmptyStringSchema,
+  skillSetHash: sha256Schema,
+  etag: nonEmptyStringSchema,
+  entries: z.array(skillSetProjectionEntryV1Schema),
+  publishedAt: timestampSchema,
+  revoked: z.boolean(),
+});
+export type SkillSetProjectionV1 = z.infer<typeof skillSetProjectionV1Schema>;
+
+export const workflowThreadV1Schema = z.looseObject({
+  snapshotId: uuidSchema,
+  snapshotSha256: sha256Schema,
+  threadId: idSchema,
+  externalRunId: nonEmptyStringSchema,
+  messages: z.array(normalizedMessageV1Schema),
+});
+
+export const frozenAvailableSkillV1Schema = z.looseObject({
+  skillId: uuidSchema,
+  versionId: uuidSchema,
+  alias: nonEmptyStringSchema,
+  name: nonEmptyStringSchema,
+  description: z.string(),
+  bundle: skillBundleV1Schema,
+  registryState: nonEmptyStringSchema,
+});
+
+export const learningWorkflowInputV1Schema = z.looseObject({
+  schemaVersion: z.literal(1),
+  threads: z.array(workflowThreadV1Schema),
+  selectedAnnotations: z.array(selectedHumanAnnotationV1Schema),
+  availableSkills: z.array(frozenAvailableSkillV1Schema),
+  promptContext: jsonObjectSchema.nullable(),
+  limits: jsonObjectSchema,
+});
+export type LearningWorkflowInputV1 = z.infer<
+  typeof learningWorkflowInputV1Schema
+>;
+
+export const generatedInsightV1Schema = z.looseObject({
+  outputAlias: nonEmptyStringSchema,
+  kind: insightKindV1Schema,
+  statement: nonEmptyStringSchema,
+  impact: nonEmptyStringSchema,
+  confidence: z.number().finite().min(0).max(1),
+  skillEligible: z.boolean(),
+  evidenceRefs: z.array(evidenceRefV1Schema).min(1),
+});
+
+const generatedSkillBundleV1Schema = z.looseObject({
+  rootDirectoryName: nonEmptyStringSchema,
+  files: z
+    .array(
+      z.looseObject({
+        path: nonEmptyStringSchema,
+        contentBase64: nonEmptyStringSchema,
+      }),
+    )
+    .min(1),
+});
+
+export const generatedSkillCandidateV1Schema = z
+  .looseObject({
+    outputAlias: nonEmptyStringSchema,
+    action: z.enum(["add", "update", "remove"]),
+    skillId: uuidSchema.nullable(),
+    parentVersionId: uuidSchema.nullable(),
+    bundle: generatedSkillBundleV1Schema.nullable(),
+    removalIntent: jsonObjectSchema.nullable(),
+    insightAliases: z.array(nonEmptyStringSchema).min(1),
+    evidenceRefs: z.array(evidenceRefV1Schema),
+    reason: nonEmptyStringSchema,
+    risk: nonEmptyStringSchema,
+  })
+  .superRefine((candidate, context) => {
+    const requiresBundle =
+      candidate.action === "add" || candidate.action === "update";
+    if (requiresBundle !== (candidate.bundle !== null)) {
+      context.addIssue({
+        code: "custom",
+        path: ["bundle"],
+        message: "Add/update require a full bundle; remove forbids one",
+      });
+    }
+    if (
+      (candidate.action === "remove") !==
+      (candidate.removalIntent !== null)
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["removalIntent"],
+        message: "Remove requires a removal intent; add/update forbid one",
+      });
+    }
+    if (
+      (candidate.action === "update" || candidate.action === "remove") &&
+      (candidate.skillId === null || candidate.parentVersionId === null)
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["parentVersionId"],
+        message: "Update/remove require exact target and parent version",
+      });
+    }
+  });
+
+export const learningWorkflowOutputV1Schema = z.looseObject({
+  schemaVersion: z.literal(1),
+  insights: z.array(generatedInsightV1Schema),
+  skillCandidates: z.array(generatedSkillCandidateV1Schema),
+  coverage: jsonObjectSchema,
+  rejections: z.array(jsonObjectSchema),
+  usage: jsonObjectSchema,
+});
+export type LearningWorkflowOutputV1 = z.infer<
+  typeof learningWorkflowOutputV1Schema
+>;
+
+/** Named language-neutral JSON Schemas generated from the canonical Zod 4 source. */
+export const learningContractJsonSchemas = {
+  BlobLocatorV1: z.toJSONSchema(blobLocatorV1Schema),
+  CandidateGateResultV1: z.toJSONSchema(candidateGateResultV1Schema),
+  EvidenceRefV1: z.toJSONSchema(evidenceRefV1Schema),
+  InsightV1: z.toJSONSchema(insightV1Schema),
+  LearningChunkV1: z.toJSONSchema(learningChunkV1Schema),
+  LearningContainerV1: z.toJSONSchema(learningContainerV1Schema),
+  LearningRunV1: z.toJSONSchema(learningRunV1Schema),
+  LearningWorkflowInputV1: z.toJSONSchema(learningWorkflowInputV1Schema),
+  LearningWorkflowOutputV1: z.toJSONSchema(learningWorkflowOutputV1Schema),
+  NormalizedMessageV1: z.toJSONSchema(normalizedMessageV1Schema),
+  RunSnapshotV1: z.toJSONSchema(runSnapshotV1Schema),
+  SelectedHumanAnnotationV1: z.toJSONSchema(selectedHumanAnnotationV1Schema),
+  SkillArtifactManifestV1: z.toJSONSchema(skillArtifactManifestV1Schema),
+  SkillCandidateV1: z.toJSONSchema(skillCandidateV1Schema),
+  SkillSetProjectionV1: z.toJSONSchema(skillSetProjectionV1Schema),
+} as const;

--- a/packages/intelligence/src/errors.test.ts
+++ b/packages/intelligence/src/errors.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "vitest";
+import {
+  LEARNING_PLATFORM_ERROR_CODES,
+  learningPlatformErrorResponseV1Schema,
+} from "./errors.js";
+
+test("learning assignment mismatch has a stable typed error code", () => {
+  expect(LEARNING_PLATFORM_ERROR_CODES).toContain(
+    "LEARNING_CONTAINER_ASSIGNMENT_MISMATCH",
+  );
+});
+
+test("LearningPlatformErrorResponseV1 carries registry metadata and correlation IDs", () => {
+  const response = {
+    error: {
+      code: "LEARNING_CONTAINER_ASSIGNMENT_MISMATCH",
+      message:
+        "Existing thread assignment does not match the asserted container.",
+      category: "conflict",
+      retryable: false,
+    },
+    requestId: "req_1",
+    traceId: "trace_1",
+  } as const;
+
+  expect(learningPlatformErrorResponseV1Schema.parse(response)).toEqual(
+    response,
+  );
+  expect(
+    learningPlatformErrorResponseV1Schema.safeParse({
+      ...response,
+      error: { ...response.error, code: "UNKNOWN" },
+    }).success,
+  ).toBe(false);
+});

--- a/packages/intelligence/src/errors.ts
+++ b/packages/intelligence/src/errors.ts
@@ -1,0 +1,55 @@
+import { z } from "zod/v4";
+
+/** Stable error identifiers shared by control-plane, runtime, workers, and SDKs. */
+export const LEARNING_PLATFORM_ERROR_CODES = [
+  "LEARNING_CONTAINER_NOT_FOUND",
+  "LEARNING_CONTAINER_ARCHIVED",
+  "LEARNING_CONTAINER_PROJECT_MISMATCH",
+  "LEARNING_CONTAINER_CONFIG_CONFLICT",
+  "LEARNING_CONTAINER_ASSIGNMENT_MISMATCH",
+  "LEARNING_CONTAINER_ASSIGNMENT_CONFLICT",
+  "LEARNING_RUN_ACTIVE_CONFLICT",
+  "LEARNING_RUN_IDEMPOTENCY_CONFLICT",
+  "LEARNING_ATTEMPT_FENCE_REJECTED",
+  "LEARNING_SNAPSHOT_INVARIANT_VIOLATION",
+  "LEARNING_CANDIDATE_STALE_PARENT",
+  "LEARNING_CANDIDATE_SUBJECT_MISMATCH",
+  "LEARNING_CANDIDATE_GATES_INCOMPLETE",
+  "LEARNING_REGISTRY_CONFLICT",
+  "LEARNING_REGISTRY_UNRECOVERABLE",
+  "LEARNING_BLOB_INTEGRITY_FAILURE",
+  "LEARNING_SDK_CACHE_CORRUPT",
+] as const;
+
+export const learningPlatformErrorCodeSchema = z.enum(
+  LEARNING_PLATFORM_ERROR_CODES,
+);
+export type LearningPlatformErrorCode = z.infer<
+  typeof learningPlatformErrorCodeSchema
+>;
+
+export const learningPlatformErrorCategorySchema = z.enum([
+  "validation",
+  "auth",
+  "permission",
+  "not_found",
+  "conflict",
+  "rate_limit",
+  "internal",
+  "dependency",
+]);
+
+/** Correlated REST error envelope used uniformly by Learning Platform APIs. */
+export const learningPlatformErrorResponseV1Schema = z.looseObject({
+  error: z.looseObject({
+    code: learningPlatformErrorCodeSchema,
+    message: z.string().min(1),
+    category: learningPlatformErrorCategorySchema,
+    retryable: z.boolean(),
+  }),
+  requestId: z.string().min(1),
+  traceId: z.string().min(1),
+});
+export type LearningPlatformErrorResponseV1 = z.infer<
+  typeof learningPlatformErrorResponseV1Schema
+>;

--- a/packages/intelligence/src/index.ts
+++ b/packages/intelligence/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./contracts.js";

--- a/packages/intelligence/src/index.ts
+++ b/packages/intelligence/src/index.ts
@@ -1,1 +1,3 @@
 export * from "./contracts.js";
+export * from "./commands.js";
+export * from "./errors.js";

--- a/packages/intelligence/tsconfig.check.json
+++ b/packages/intelligence/tsconfig.check.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@copilotkit/typescript-config/base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["es2023"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/intelligence/tsconfig.json
+++ b/packages/intelligence/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@copilotkit/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["es2023"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/intelligence/vitest.config.ts
+++ b/packages/intelligence/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2753,6 +2753,25 @@ importers:
         specifier: ^4.1.3
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@22.19.11)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/intelligence:
+    dependencies:
+      zod:
+        specifier: '>=3.22.3'
+        version: 3.25.76
+    devDependencies:
+      '@copilotkit/typescript-config':
+        specifier: workspace:^
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.11
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.3
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@22.19.11)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/react-core:
     dependencies:
       '@ag-ui/client':


### PR DESCRIPTION
## Summary\n\nImplements the Unified Parent PRD for the CopilotKit Intelligence Learning Platform across dependency-ordered slices. The parent PRD remains normative over linked component documents.\n\nCurrent slice:\n- canonical public V1 learning contracts\n- language-neutral JSON Schema export\n- validation for assignment, snapshots, insights, candidates, registry projections, and blob locators\n\nNext slices will add server-first assignment compatibility and the TypeScript/Python/C# registry clients.\n\n## Verification\n\n- package tests\n- typecheck\n- build\n- publint\n- repository pre-commit package gate\n\nDraft: implementation is in progress.