### PR TITLE
fix(release): make packed Channels umbrella verify hermetic

### DIFF
--- a/scripts/release/verify-channels-umbrella.ts
+++ b/scripts/release/verify-channels-umbrella.ts
@@ -77,6 +77,46 @@ function packPackage(
   return { manifest, tarball };
 }
 
+interface SourceManifest {
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+}
+
+/**
+ * The Channels family depends on monorepo-versioned packages (e.g.
+ * `@copilotkit/core`, `@copilotkit/shared`) via the `workspace:` protocol.
+ * `pnpm pack` rewrites those ranges to the workspace's current version — which,
+ * on a release PR, is the freshly-bumped version that is not on the registry
+ * until this very release publishes. Packing them locally too keeps the
+ * consumer install hermetic instead of racing the registry against our own
+ * in-flight release. Discovered transitively via `workspace:` so the list never
+ * drifts as the family's internal dependencies change.
+ */
+function workspaceSiblings(): string[] {
+  const seen = new Set<string>(FAMILY);
+  const siblings: string[] = [];
+  const queue: string[] = [...FAMILY];
+
+  while (queue.length) {
+    const name = queue.shift() as string;
+    const source = readJson<SourceManifest>(
+      join(packageDirectory(name), "package.json"),
+    );
+    for (const deps of [source.dependencies, source.peerDependencies]) {
+      for (const [dep, range] of Object.entries(deps ?? {})) {
+        if (!dep.startsWith("@copilotkit/")) continue;
+        if (!range.startsWith("workspace:")) continue;
+        if (seen.has(dep)) continue;
+        seen.add(dep);
+        siblings.push(dep);
+        queue.push(dep);
+      }
+    }
+  }
+
+  return siblings;
+}
+
 function packLocalFamily(tarballDir: string): {
   manifests: Map<string, PackedManifest>;
   tarballs: Map<string, string>;
@@ -87,6 +127,13 @@ function packLocalFamily(tarballDir: string): {
   for (const name of FAMILY) {
     const { manifest, tarball } = packPackage(name, tarballDir);
     manifests.set(name, manifest);
+    tarballs.set(name, tarball);
+  }
+
+  // Pin monorepo siblings to local tarballs too (overrides only — they are not
+  // part of the packed-manifest contract that `validatePackedManifests` checks).
+  for (const name of workspaceSiblings()) {
+    const { tarball } = packPackage(name, tarballDir);
     tarballs.set(name, tarball);
   }
 


### PR DESCRIPTION
## Problem

Every **monorepo** release PR is blocked by its own not-yet-published version. The `test / unit` → **`unit (20.x)` → "Verify packed Channels umbrella contract"** step (`pnpm run verify:channels-umbrella`, local mode) fails with:

```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @copilotkit/core@^1.63.1
  This error happened while installing the dependencies of @copilotkit/channels@0.2.0
```

### Root cause

`verify:channels-umbrella` (local mode) packs the Channels family into tarballs and installs a throwaway consumer, pinning **only the family** to those local tarballs via `pnpm.overrides`. But the family depends on monorepo-versioned packages — `@copilotkit/core`, `@copilotkit/shared` — via the `workspace:` protocol. `pnpm pack` rewrites `workspace:^` to the workspace's *current* version (e.g. `^1.63.1`). On a release PR that's the freshly-bumped version, which isn't on npm until the release publishes. Since those packages aren't in the override set, the consumer install falls through to the public registry and can't find them → deadlock: the gate can't go green until the very version it's bumping to is published, and publishing only happens after merge.

This is why `unit (20.x)` was red on **#5992 (v1.63.0)** and **#6019 (v1.63.1)** — both merged through the red manually.

## Fix

In local mode, also `pnpm pack` the family's `workspace:` monorepo siblings and pin them as consumer overrides, so the install is fully hermetic and never races the registry against our own in-flight release. Siblings are discovered **transitively via the `workspace:` protocol**, so the list never drifts as the family's internal dependencies change (today it resolves to exactly `@copilotkit/core` + `@copilotkit/shared`; `@copilotkit/shared`'s `license-verifier ~0.5.0` is correctly excluded since it's a normal published range, not `workspace:`).

The registry-backed mode (`--registry`, used at publish time in `publish-release.yml`) is unchanged.

## Testing

- Bumped `packages/shared` + `packages/core` to an unpublished `1.63.99` to simulate a release PR:
  - **Unmodified script** → `ERR_PNPM_NO_MATCHING_VERSION` for `@copilotkit/core@^1.63.99` (reproduces the CI failure).
  - **Fixed script** → `OK: local Channels snapshot is exact, compatible, singly resolved, and TSX-consumable.`
- `npx vitest run --config scripts/release/vitest.config.mts` → **109/109 pass**.
- Sibling discovery verified to return exactly `[@copilotkit/core, @copilotkit/shared]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)