### PR TITLE
fix: use per-request model in Anthropic adapter and preserve buffered text prefix

### DIFF
--- a/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
+++ b/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
@@ -358,7 +358,7 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
     try {
       const createParams = {
         system: cachedSystemPrompt,
-        model: this.model,
+        model: model,
         messages: cachedMessages,
         max_tokens: forwardedParameters?.maxTokens || 4096,
         ...(forwardedParameters?.temperature
@@ -522,7 +522,9 @@ class FilterThinkingTextBuffer {
         return "";
       }
     }
-    return text;
+    const result = this.buffer;
+    this.buffer = "";
+    return result;
   }
 
   reset() {


### PR DESCRIPTION
## Summary

Two bugs fixed in `AnthropicAdapter`:

1. **Per-request model override ignored** — `process()` destructures a local `model` variable from the request (with fallback to `this.model`), but the API call at line 361 was using `this.model` instead of the local `model`. This meant any per-request model override was silently ignored. Changed to use `model` to match the pattern used by OpenAI and Groq adapters.

2. **FilterThinkingTextBuffer drops leading characters** — When the buffer accumulates a prefix that turns out *not* to be a `<thinking>` tag, the fallthrough path returned only the current chunk (`text`) instead of the full accumulated buffer. This caused all previously buffered characters to be silently dropped. Fixed to return `this.buffer` (the complete accumulated text) and clear the buffer afterward.

## Test plan

- Verify that passing a model override in a chat completion request uses the overridden model for the Anthropic API call
- Verify that text chunks arriving character-by-character that happen to share a prefix with `<thinking>` (e.g., `<th` followed by `is is normal text`) are fully preserved in output
- Verify that actual `<thinking>...</thinking>` blocks are still correctly filtered out