### PR TITLE
fix: stringify array content for token counting and fix useMemo deps

### DIFF
--- a/packages/react-core/src/hooks/use-coagent.ts
+++ b/packages/react-core/src/hooks/use-coagent.ts
@@ -364,7 +364,7 @@ export function useCoAgent<T = any>(
     agent?.state,
     agent?.runAgent,
     agent?.abortRun,
-    agent?.runAgent,
+    nodeName,
     agent?.threadId,
     agent?.isRunning,
     agent?.agentId,

--- a/packages/runtime/src/service-adapters/openai/utils.ts
+++ b/packages/runtime/src/service-adapters/openai/utils.ts
@@ -221,7 +221,7 @@ function countToolsTokens(model: string, tools: any[]): number {
 }
 
 function countMessageTokens(model: string, message: any): number {
-  return countTokens(model, message.content || "");
+  return countTokens(model, JSON.stringify(message.content) || "");
 }
 
 function countTokens(model: string, text: string): number {


### PR DESCRIPTION
## Summary

Two small bug fixes:

### 1. `countMessageTokens` miscounts tokens for array content (OpenAI adapter)

In `packages/runtime/src/service-adapters/openai/utils.ts`, `countMessageTokens` passed `message.content` directly to `countTokens`, which uses `text.length / 3`. When `message.content` is an array (e.g., image messages with multiple content blocks), `.length` returns the number of array elements rather than an actual character count, producing wildly inaccurate token estimates.

**Fix:** Use `JSON.stringify(message.content)` before passing to `countTokens`, consistent with how the Anthropic adapter already handles this at line 125 of `packages/runtime/src/service-adapters/anthropic/utils.ts`.

### 2. Duplicate `useMemo` dependency in `useCoagent` hook

In `packages/react-core/src/hooks/use-coagent.ts`, the `useMemo` dependency array listed `agent?.runAgent` twice while `nodeName` — which is used in the memoized return value — was missing entirely. This could cause stale values when `nodeName` changes.

**Fix:** Replaced the duplicate `agent?.runAgent` entry with `nodeName`.

## Test plan

- [ ] Verify token counting with array-type message content (e.g., image messages) returns reasonable estimates
- [ ] Verify `useCoagent` hook properly re-computes when `nodeName` changes
- [ ] Existing tests continue to pass