### PR TITLE
docs: clarify CLI initialization guidance

### DIFF
--- a/showcase/shell-docs/src/content/docs/agentic-protocols/mcp.mdx
+++ b/showcase/shell-docs/src/content/docs/agentic-protocols/mcp.mdx
@@ -67,21 +67,15 @@ For further reading, check out the [Model Context Protocol](https://modelcontext
     <TailoredContentOption
       id="use-cli"
       title="Use the CopilotKit CLI"
-      description="I have a Next.js application and want to get started quickly."
+      description="Scaffold a fresh Next.js starter with MCP configured."
       icon={<SquareTerminal />}
     >
       <Step>
         ### Run the CLI
-        Just run this following command in your Next.js application to get started!
 
-        <Accordions>
-            <Accordion title="Don't have a Next.js application?">
-                No problem! Just use `create-next-app` to make one quickly.
-                ```bash
-                npx create-next-app@latest
-                ```
-            </Accordion>
-        </Accordions>
+        Use this path when you want the CLI to generate a new CopilotKit starter project with MCP configured.
+
+        If you're adding MCP to an existing Next.js application, choose **Code along** below and add the provider, MCP server manager, and chat UI manually.
 
         ```bash
         npx copilotkit@latest init -m MCP
@@ -91,7 +85,7 @@ For further reading, check out the [Model Context Protocol](https://modelcontext
     <TailoredContentOption
         id="do-it-manually"
         title="Code along"
-        description="I want to deeply understand what's happening under the hood or don't have a Next.js application."
+        description="Add MCP to an existing app or learn each setup step."
         icon={<SquareChartGantt />}
     >
       <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/quickstart.mdx
@@ -37,22 +37,16 @@ Before you begin, you must have a [CrewAI Flow](https://docs.crewai.com/guides/f
     >
     <TailoredContentOption
         id="cli"
-        title="Use the CopilotKit CLI (NextJS only)"
-        description="I have a Next.js application and want to get started quickly."
+        title="Use the CopilotKit CLI"
+        description="Scaffold a fresh Next.js starter for CrewAI Flows."
         icon={<SquareTerminal />}
     >
         <Step>
             ### Run the CLI
-            Just run this following command in your Next.js application to get started!
 
-            <Accordions>
-                <Accordion title="Don't have a Next.js application?">
-                    No problem! Just use `create-next-app` to make one quickly.
-                    ```bash
-                    npx create-next-app@latest
-                    ```
-                </Accordion>
-            </Accordions>
+            Use this path when you want the CLI to generate a new CopilotKit starter project for CrewAI Flows.
+
+            If you're adding CopilotKit to an existing Next.js application, choose **Code along** below and install the packages manually.
 
             ```bash
             npx copilotkit@latest init --framework flows
@@ -80,7 +74,7 @@ Before you begin, you must have a [CrewAI Flow](https://docs.crewai.com/guides/f
     <TailoredContentOption
         id="code-along"
         title="Code along"
-        description="I want to deeply understand what's happening under the hood or don't have a Next.js application."
+        description="Add CopilotKit to an existing app or learn each setup step."
         icon={<SquareChartGantt />}
     >
         <Step>


### PR DESCRIPTION
## Summary
- Clarifies that the CLI path scaffolds a fresh starter project.
- Directs existing Next.js app users to the manual/code-along setup path.
- Removes copy that suggested running `init` inside an existing Next.js app.

Fixes #2525

## Verification
- `node` docs guidance check for stale phrasing, frontmatter, and fenced code blocks
- `git diff --check`
- `npm run typecheck` from `showcase/shell-docs`

## Note
- `npm run build` reaches the Next.js production build step but fails locally while `next/font` fetches Plus Jakarta Sans from Google Fonts.