### PR TITLE
docs: clarify React Native A2UI support

### DIFF
--- a/showcase/shell-docs/src/content/reference/react-native/hooks/useRenderTool.mdx
+++ b/showcase/shell-docs/src/content/reference/react-native/hooks/useRenderTool.mdx
@@ -13,6 +13,12 @@ description: "Register a React Native component to render inline when an agent c
   React Native, because they depend on DOM elements. Use `useRenderTool` instead.
 </Callout>
 
+<Callout type="warning" title="A2UI surfaces are not native renderers">
+  A2UI activity messages are currently rendered by the web SDK's activity
+  pipeline and component catalog. React Native apps should model native
+  generative UI as tool calls and render those calls with `useRenderTool`.
+</Callout>
+
 ## Signature
 
 ```tsx

--- a/showcase/shell-docs/src/content/reference/react-native/index.mdx
+++ b/showcase/shell-docs/src/content/reference/react-native/index.mdx
@@ -70,6 +70,17 @@ The root also exports two prebuilt chrome components: [`CopilotSidebar`](/refere
   UI. Each component page documents both, disambiguated by import path.
 </Callout>
 
+## Generative UI support
+
+React Native supports inline native UI for tool calls through [`useRenderTool`](/reference/react-native/hooks/useRenderTool), [`useFrontendTool`](/reference/react-native/hooks/useFrontendTool), and [`useHumanInTheLoop`](/reference/react-native/hooks/useHumanInTheLoop). These render functions return React Native elements such as `View`, `Text`, and `TouchableOpacity`.
+
+<Callout type="warning" title="A2UI activity rendering is web-only today">
+  Declarative A2UI activity messages and the web activity-message renderer rely
+  on DOM/CSS-based component catalogs. They are not available from
+  `@copilotkit/react-native`. For React Native apps, register explicit native
+  tool renderers with `useRenderTool` instead.
+</Callout>
+
 ## API Reference
 
 <Cards>


### PR DESCRIPTION
## Summary
- Clarify that A2UI activity rendering is currently web-only.
- Point React Native users to native tool rendering paths such as useRenderTool, useFrontendTool, and useHumanInTheLoop.
- Add warning callouts on the React Native reference index and useRenderTool hook page.

Fixes #5785

## Verification
- node MDX structure/content check
- git diff --check
- npm run typecheck (showcase/shell-docs)
- npm run build (showcase/shell-docs)