### PR TITLE
docs(channels): add Channels SDK documentation

### DIFF
--- a/showcase/shell-docs/src/content/docs/channels/commands-and-reactions.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/commands-and-reactions.mdx
@@ -1,0 +1,113 @@
+---
+title: Commands and Reactions
+icon: "lucide/SlashSquare"
+description: Slash commands and react-to-any-message handlers at the channel level.
+---
+
+Two channel-level shortcuts that are not tied to a message you rendered: slash
+commands the user types, and reactions on any message in the channel.
+
+## Slash commands
+
+A command runs when the user types `/name`. Define it with
+`defineChannelCommand` and wire it into the channel.
+
+```ts
+import { defineChannelCommand } from "@copilotkit/channels";
+
+export const commands = [
+  defineChannelCommand({
+    name: "ask", // no leading slash, matched case-insensitively
+    description: "Ask the agent anything, no mention needed.",
+    async handler({ thread, text, user }) {
+      if (!text) {
+        await thread.post("Usage: `/ask <your question>`");
+        return;
+      }
+      await thread.runAgent({ prompt: text });
+    },
+  }),
+];
+```
+
+```ts
+import { createChannel } from "@copilotkit/channels";
+import { intelligenceAdapter } from "@copilotkit/channels/intelligence";
+import { agent } from "./agent";
+import { commands } from "./commands";
+
+const channel = createChannel({
+  name: "support-bot",
+  agent,
+  adapters: [intelligenceAdapter()],
+  commands,
+});
+```
+
+The user's words after the command arrive as `text`:
+
+```
+/ask how do I reset my password
+        -> text = "how do I reset my password"
+```
+
+<Callout type="info" title="Slack needs the command declared too">
+On Slack, register the same command in your Slack app manifest so Slack sends
+it to your bot. The name in the manifest must match the `name` here.
+</Callout>
+
+### Typed arguments
+
+Platforms with native structured arguments (Discord) can parse args for you.
+Add an `options` schema, and read `options` in the handler:
+
+```ts
+import { z } from "zod";
+
+defineChannelCommand({
+  name: "weather",
+  description: "Get the weather for a city.",
+  options: z.object({ city: z.string() }),
+  async handler({ thread, options }) {
+    await thread.runAgent({ prompt: `What's the weather in ${options.city}?` });
+  },
+});
+```
+
+On text-only surfaces `options` is empty and the raw string is in `text`, so
+handle both if a command targets several platforms.
+
+The command handler also has `thread.postEphemeral(...)` for a reply only the
+caller sees, and `openModal(...)` on platforms that support dialogs.
+
+## Global reactions
+
+`channel.onReaction` fires when a user reacts to any message in the channel,
+not just a card you rendered. Use it for channel-wide shortcuts, like a
+refresh emoji that re-runs the last request.
+
+```ts
+channel.onReaction(async ({ added, emoji, thread, user }) => {
+  if (!added) return; // ignore un-reactions
+  if (emoji !== "refresh") return; // 🔄
+  await thread.post(`On it, ${user?.name ?? "there"}.`);
+});
+```
+
+Scope it to one emoji so you skip the check:
+
+```ts
+channel.onReaction("fire", async ({ thread }) => {
+  await thread.post("🔥");
+});
+```
+
+The event carries `emoji` (the canonical name), `rawEmoji` (the platform
+token), `added`, `user`, `thread`, and `messageRef` for
+`thread.update(messageRef, ...)`.
+
+<Callout type="info">
+Want to handle a reaction on one specific card instead of the whole channel?
+Use the per-message [`<Message onReaction>`](/channels/interactive/reactions)
+handler.
+</Callout>

--- a/showcase/shell-docs/src/content/docs/channels/commands-and-reactions.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/commands-and-reactions.mdx
@@ -32,14 +32,12 @@ export const commands = [
 
 ```ts
 import { createChannel } from "@copilotkit/channels";
-import { intelligenceAdapter } from "@copilotkit/channels/intelligence";
 import { agent } from "./agent";
 import { commands } from "./commands";
 
 const channel = createChannel({
   name: "support-bot",
   agent,
-  adapters: [intelligenceAdapter()],
   commands,
 });
 ```

--- a/showcase/shell-docs/src/content/docs/channels/configuration.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/configuration.mdx
@@ -1,0 +1,60 @@
+---
+title: Channel Configuration
+icon: "lucide/Settings"
+description: The createChannel options that shape a channel: identity, connection, and per-thread state.
+---
+
+`createChannel(options)` takes more than an agent and adapters. This page
+covers the configuration you reach for most. For the full option list, see the
+[Channel API](/channels/reference/channel).
+
+## Identity and connection
+
+| Option | What it does |
+| --- | --- |
+| `name` | Project-unique name. Required for a managed (Intelligence) channel, ties the runtime to the dashboard setup. |
+| `agent` | The agent, or a `(threadId) => agent` factory. See the [Quickstart](/channels/quickstart). |
+| `adapters` | Direct platform adapters. Attach several to run one bot on many platforms. |
+| `provider` | For a no-adapter managed channel: the platform to declare to Intelligence. Defaults to `"slack"`; `"teams"` is gated. |
+
+```ts
+const channel = createChannel({
+  name: "support-bot",
+  agent,
+  adapters: [intelligenceAdapter()],
+});
+```
+
+## Per-thread state
+
+Give `store.state` a schema and `thread.state()` / `thread.setState()` become
+typed to it and validated on write. Good for tracking where a conversation is
+in a flow.
+
+```ts
+import { z } from "zod";
+
+const channel = createChannel({
+  name: "support-bot",
+  agent,
+  adapters: [intelligenceAdapter()],
+  store: {
+    state: z.object({ step: z.enum(["idle", "awaiting_approval"]) }),
+  },
+});
+
+channel.onMessage(async ({ thread }) => {
+  await thread.setState({ step: "awaiting_approval" }); // validated
+  const state = await thread.state(); // { step: "idle" | "awaiting_approval" } | undefined
+});
+```
+
+## The rest
+
+| Option | See |
+| --- | --- |
+| `tools`, `context` | [Tools and context](/channels/tools) |
+| `components` | [UI library](/channels/ui-library#register-components) |
+| `commands` | [Commands and reactions](/channels/commands-and-reactions) |
+| `store.adapter` (durable backend) | [Persistence](/channels/persistence) |
+| `store.identity` + `store.transcripts` | [Transcripts](/channels/transcripts) |

--- a/showcase/shell-docs/src/content/docs/channels/configuration.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/configuration.mdx
@@ -8,20 +8,26 @@ description: The createChannel options that shape a channel: identity, connectio
 covers the configuration you reach for most. For the full option list, see the
 [Channel API](/channels/reference/channel).
 
+<Callout type="info">
+Every channel runs through the Intelligence runtime, so running one requires a
+CopilotKit Intelligence key (free tier available) — for both managed and direct
+channels. See the [Quickstart](/channels/quickstart) for the run pattern.
+</Callout>
+
 ## Identity and connection
 
 | Option | What it does |
 | --- | --- |
-| `name` | Project-unique name. Required for a managed (Intelligence) channel, ties the runtime to the dashboard setup. |
+| `name` | Project-unique name. Required — the runtime keys the channel's lifecycle by it (and, for a managed channel, ties it to the dashboard setup). |
 | `agent` | The agent, or a `(threadId) => agent` factory. See the [Quickstart](/channels/quickstart). |
 | `adapters` | Direct platform adapters. Attach several to run one bot on many platforms. |
 | `provider` | For a no-adapter managed channel: the platform to declare to Intelligence. Defaults to `"slack"`; `"teams"` is gated. |
 
 ```ts
+// A managed channel: Intelligence hosts the transport, so no adapter.
 const channel = createChannel({
   name: "support-bot",
   agent,
-  adapters: [intelligenceAdapter()],
 });
 ```
 
@@ -37,7 +43,6 @@ import { z } from "zod";
 const channel = createChannel({
   name: "support-bot",
   agent,
-  adapters: [intelligenceAdapter()],
   store: {
     state: z.object({ step: z.enum(["idle", "awaiting_approval"]) }),
   },

--- a/showcase/shell-docs/src/content/docs/channels/files-and-multimodality.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/files-and-multimodality.mdx
@@ -1,0 +1,88 @@
+---
+title: Files and Multimodality
+icon: "lucide/Paperclip"
+description: Let users send images and files for the agent to read, and send files back.
+---
+
+When a user drops an image, PDF, or other file into the chat, it arrives on
+the message as `contentParts`. Merge those parts into the agent's prompt and
+the agent can read them.
+
+## Read an uploaded file
+
+```ts
+channel.onMessage(async ({ thread, message }) => {
+  await thread.runAgent({
+    prompt: message.contentParts?.length
+      ? [
+          // the user's instruction, if any
+          ...(message.text ? [{ type: "text" as const, text: message.text }] : []),
+          // the uploaded files
+          ...message.contentParts,
+        ]
+      : message.text,
+  });
+});
+```
+
+<Callout type="warn" title="Merge the text and the files">
+The adapter builds `contentParts` from the **files only**, not the message
+text. If you pass `message.contentParts` alone, you drop the instruction and
+hand the model a bare file with no ask. Always merge the text back in, as
+above.
+</Callout>
+
+## What a part looks like
+
+`message.contentParts` is an array of typed parts. File bytes come base64
+encoded on `source.value`.
+
+```ts
+type AgentContentPart =
+  | { type: "text"; text: string }
+  | { type: "image"; source: { type: "data"; value: string; mimeType: string } }
+  | { type: "audio"; source: { type: "data"; value: string; mimeType: string } }
+  | { type: "video"; source: { type: "data"; value: string; mimeType: string } }
+  | { type: "document"; source: { type: "data"; value: string; mimeType: string } };
+```
+
+So "summarize this PDF" with an attached file arrives as a `text` part plus a
+`document` part. An image the agent should look at arrives as an `image` part.
+
+<Callout type="info" title="The model has to support it">
+Reading images or documents needs a multimodal model. Use one in your agent's
+`chat()` adapter, for example `openaiText("gpt-5.5")`.
+</Callout>
+
+## Send a file back
+
+Post a file to the thread with `thread.postFile`:
+
+```ts
+await thread.postFile({
+  bytes: pngBuffer, // Buffer or Uint8Array
+  filename: "chart.png",
+  title: "Revenue by month",
+  altText: "A bar chart of revenue for the last 12 months",
+});
+```
+
+This is how a bot returns a generated chart or report.
+
+## Limit what comes in
+
+Each direct adapter takes a `files` option (`FileDeliveryConfig`) to cap
+incoming files. The Intelligence adapter applies the platform's own limits.
+Pass `files` on the adapter when you connect a platform directly, and let your
+editor's types show the available caps:
+
+```ts
+import { whatsapp } from "@copilotkit/channels/whatsapp";
+
+whatsapp({
+  // ...credentials
+  files: {
+    /* caps for incoming files, see FileDeliveryConfig */
+  },
+});
+```

--- a/showcase/shell-docs/src/content/docs/channels/files-and-multimodality.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/files-and-multimodality.mdx
@@ -72,7 +72,7 @@ This is how a bot returns a generated chart or report.
 ## Limit what comes in
 
 Each direct adapter takes a `files` option (`FileDeliveryConfig`) to cap
-incoming files. The Intelligence adapter applies the platform's own limits.
+incoming files. A managed channel applies the platform's own limits.
 Pass `files` on the adapter when you connect a platform directly, and let your
 editor's types show the available caps:
 

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -1,40 +1,143 @@
 ---
-title: Channels SDK
-description: Build durable, cross-platform AI bots with CopilotKit — a platform adapter, an AG-UI agent, and optional persistence wired together in a single createBot call.
-icon: "lucide/Bot"
-hideTOC: true
+title: Channels Overview
+icon: "lucide/MessagesSquare"
+description: Run your CopilotKit agent as a bot inside Slack, Teams, WhatsApp, Telegram, and Discord.
 ---
 
-The Channels SDK is three pieces: **`@copilotkit/channels`** (core runtime), a **platform adapter** (e.g. `@copilotkit/channels-slack`), and an **AG-UI agent** — any CopilotKit runtime or compatible backend. Plug them together with `createBot` and you get a bot that streams agent replies into the platform, handles interactive buttons, and — once you add a store — survives restarts and spans multiple instances.
+Channels let you take a CopilotKit agent and run it as a bot inside a chat
+app. The user talks to your agent in Slack, Teams, WhatsApp, Telegram, or
+Discord, and your agent answers right there in the thread.
 
-<OpsPlatformCTA
-  variant="inline"
-  title="Join the waitlist for managed Slack and Teams agents"
-  body="Start here when you want to own the adapter, runtime, and store. Join the waitlist if you want CopilotKit Intelligence to manage Slack and Teams setup, identity, durable state, approvals, and production operations."
-  ctaLabel="Join the waitlist"
-  surface="docs_bots_managed_agents_waitlist"
-  href="https://www.copilotkit.ai/opentag-managed"
-/>
+You write the bot once. The same agent, tools, commands, and interactive
+cards run on every platform you attach.
+
+## A channel, end to end
+
+Three pieces: a TanStack AI agent, JSX turned on, and a channel that plugs the
+agent into a platform and replies with clickable UI.
+
+```bash
+npm install @copilotkit/channels @copilotkit/runtime @tanstack/ai @tanstack/ai-openai
+```
+
+<Steps>
+<Step>
+### The agent
+
+A [Built-in Agent](/built-in-agent) in TanStack factory mode. You own the
+model call with [TanStack AI](https://tanstack.com/ai); the agent turns its
+stream into the events the channel renders.
+
+```ts title="agent.ts"
+import { BuiltInAgent, convertInputToTanStackAI } from "@copilotkit/runtime/v2";
+import { chat } from "@tanstack/ai";
+import { openaiText } from "@tanstack/ai-openai";
+
+export const agent = new BuiltInAgent({
+  type: "tanstack",
+  factory: (ctx) => {
+    const { messages, systemPrompts, tools } = convertInputToTanStackAI(ctx.input);
+    return chat({
+      adapter: openaiText("gpt-5.5"),
+      messages,
+      systemPrompts: ["You are a helpful support assistant.", ...systemPrompts],
+      tools,
+      abortController: ctx.abortController,
+    });
+  },
+});
+```
+</Step>
+
+<Step>
+### Turn on JSX
+
+Replies render as native UI. Point the JSX runtime at the channels package.
+
+```jsonc title="tsconfig.json"
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "@copilotkit/channels"
+  }
+}
+```
+</Step>
+
+<Step>
+### The channel
+
+Plug the agent into a channel through the Intelligence adapter, then answer
+messages. A reply can be the agent's own words, or a card whose button you
+handle right where you wrote it.
+
+```tsx title="bot.ts"
+import { createChannel } from "@copilotkit/channels";
+import { intelligenceAdapter } from "@copilotkit/channels/intelligence";
+import { Message, Section, Actions, Button } from "@copilotkit/channels/ui";
+import { agent } from "./agent";
+
+const channel = createChannel({
+  name: "support-bot",
+  agent,
+  adapters: [intelligenceAdapter()],
+});
+
+channel.onMessage(async ({ thread, message }) => {
+  // let the agent answer
+  await thread.runAgent({ prompt: message.text });
+
+  // then post a card, and handle the click right here
+  await thread.post(
+    <Message>
+      <Section>{"Did that answer your question?"}</Section>
+      <Actions>
+        <Button 
+          onClick={async ({ thread }) => {
+            await thread.post("Glad I could help!");
+          }}
+        >
+          Yes, thanks
+        </Button>
+      </Actions>
+    </Message>,
+  );
+});
+
+await channel.start();
+```
+</Step>
+</Steps>
+
+That is a working bot: a TanStack AI agent, answering across platforms,
+replying with clickable UI. The [Quickstart](/channels/quickstart) adds the
+dashboard setup and environment, and [the UI library](/channels/ui-library) shows how to register that card so
+its button still works after a restart.
+
+## Two ways to connect a platform
+
+| | Managed (Intelligence adapter) | Direct (platform adapter) |
+| --- | --- | --- |
+| Who holds the platform tokens | CopilotKit Intelligence | You |
+| What your process does | Runs the agent, nothing else | Connects straight to the platform |
+| Add a platform | Attach it in the Intelligence dashboard | Add another adapter in code |
+| Best for | Shipping fast, many platforms, no secrets in your app | Full control, self-hosting one platform |
+
+With the managed path your process holds no Slack or Teams tokens. CopilotKit
+receives the platform event, delivers it to your bot over HTTP, runs the same
+handlers, and does the credentialed send back. Start there. See
+[Platforms](/channels/platforms) for what Intelligence handles for you and the
+per-platform setup.
+
+## What you can build
 
 <Cards>
-  <Card
-    title="Slack quickstart"
-    href="/slack"
-    description="From zero to a working Slack bot in minutes — Socket Mode, streaming replies, and interactive Block Kit buttons."
-  />
-  <Card
-    title="Persistence"
-    href="/channels/persistence"
-    description="Persist actions, locks, and per-thread state across restarts by backing the store with a durable StateStore implementation."
-  />
-  <Card
-    title="Transcripts"
-    href="/channels/transcripts"
-    description="Give the agent a cross-platform memory that follows users from Slack to any other channel — with GDPR-ready delete support."
-  />
-  <Card
-    title="Channels SDK reference"
-    href="/reference/channels"
-    description="Full API reference — createBot, Thread, StateStore, ActionStore, and the Slack adapter."
-  />
+  <Card title="Quickstart" href="/channels/quickstart" description="A working bot that answers messages, end to end." />
+  <Card title="UI library" href="/channels/ui-library" description="Reply with cards, buttons, and inputs using JSX." />
+  <Card title="Interactive flows" href="/channels/interactive" description="Approval gates and reaction handlers built on components." />
+  <Card title="Commands and reactions" href="/channels/commands-and-reactions" description="Slash commands and react-to-any-message handlers." />
+  <Card title="Files and multimodality" href="/channels/files-and-multimodality" description="Let users drop in images and files for the agent to read." />
+  <Card title="MCP servers" href="/channels/mcp" description="Give the bot external tools through MCP." />
+  <Card title="Platforms" href="/channels/platforms" description="Teams, WhatsApp, Slack, Telegram, and Discord, and what Intelligence handles for you." />
+  <Card title="API reference" href="/channels/reference/channel" description="Every method on the channel, the thread, and JSX callbacks." />
 </Cards>

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -67,20 +67,20 @@ Replies render as native UI. Point the JSX runtime at the channels package.
 <Step>
 ### The channel
 
-Plug the agent into a channel through the Intelligence adapter, then answer
-messages. A reply can be the agent's own words, or a card whose button you
-handle right where you wrote it.
+Declare a channel, then answer messages. A reply can be the agent's own words,
+or a card whose button you handle right where you wrote it.
 
 ```tsx title="bot.ts"
 import { createChannel } from "@copilotkit/channels";
-import { intelligenceAdapter } from "@copilotkit/channels/intelligence";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 import { Message, Section, Actions, Button } from "@copilotkit/channels/ui";
 import { agent } from "./agent";
 
+// A managed channel: Intelligence hosts the transport, so no adapter.
 const channel = createChannel({
   name: "support-bot",
   agent,
-  adapters: [intelligenceAdapter()],
 });
 
 channel.onMessage(async ({ thread, message }) => {
@@ -104,7 +104,21 @@ channel.onMessage(async ({ thread, message }) => {
   );
 });
 
-await channel.start();
+// The runtime owns the channel's lifecycle. A CopilotKit Intelligence key runs
+// any channel (free tier available); `ready()` activates it.
+const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
+const runtime = new CopilotRuntime({
+  intelligence: new CopilotKitIntelligence({
+    apiUrl,
+    wsUrl: apiUrl.replace(/^http/, "ws"),
+    apiKey: process.env.COPILOTKIT_API_KEY!,
+  }),
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+  channels: [channel],
+});
+
+const listener = createCopilotNodeListener({ runtime });
+await listener.channels?.ready();
 ```
 </Step>
 </Steps>
@@ -116,18 +130,23 @@ its button still works after a restart.
 
 ## Two ways to connect a platform
 
-| | Managed (Intelligence adapter) | Direct (platform adapter) |
-| --- | --- | --- |
-| Who holds the platform tokens | CopilotKit Intelligence | You |
-| What your process does | Runs the agent, nothing else | Connects straight to the platform |
-| Add a platform | Attach it in the Intelligence dashboard | Add another adapter in code |
-| Best for | Shipping fast, many platforms, no secrets in your app | Full control, self-hosting one platform |
+Every channel runs through the Intelligence runtime, so both paths need a
+CopilotKit Intelligence key (free tier available). The difference is **who
+holds the platform bot credentials** — either way, the runtime drives the
+channel.
 
-With the managed path your process holds no Slack or Teams tokens. CopilotKit
-receives the platform event, delivers it to your bot over HTTP, runs the same
-handlers, and does the credentialed send back. Start there. See
-[Platforms](/channels/platforms) for what Intelligence handles for you and the
-per-platform setup.
+| | Managed | Direct (platform adapter) |
+| --- | --- | --- |
+| Who holds the platform tokens | CopilotKit Intelligence | You supply them to the adapter |
+| Add a platform | Attach it in the Intelligence dashboard | Add another adapter in code |
+| Best for | Shipping fast, many platforms, no platform secrets in your app | Owning one platform's connection end to end |
+
+With the managed path your process holds no Slack or Teams tokens: Intelligence
+receives the platform event, delivers the turn to your bot, runs the same
+handlers, and does the credentialed send back. With a direct adapter you supply
+the platform credentials, but the runtime still owns the channel's lifecycle.
+Start with managed. See [Platforms](/channels/platforms) for what Intelligence
+handles for you and the per-platform setup.
 
 ## What you can build
 

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -108,6 +108,7 @@ channel.onMessage(async ({ thread, message }) => {
 // any channel (free tier available); `ready()` activates it.
 const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
 const runtime = new CopilotRuntime({
+  agents: {},
   intelligence: new CopilotKitIntelligence({
     apiUrl,
     wsUrl: apiUrl.replace(/^http/, "ws"),
@@ -119,6 +120,7 @@ const runtime = new CopilotRuntime({
 
 const listener = createCopilotNodeListener({ runtime });
 await listener.channels?.ready();
+// Mount the listener on an HTTP server to keep the process running (see the Quickstart).
 ```
 </Step>
 </Steps>

--- a/showcase/shell-docs/src/content/docs/channels/interactive/human-in-the-loop.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/interactive/human-in-the-loop.mdx
@@ -100,7 +100,6 @@ Register both the tool and the component:
 const channel = createChannel({
   name: "release-bot",
   agent,
-  adapters: [intelligenceAdapter()],
   tools: [confirmWriteTool],
   components: [ConfirmWrite], // so the click resolves after a restart
 });
@@ -123,7 +122,7 @@ if (confirmed) {
 }
 ```
 
-The Intelligence adapter delivers one turn at a time and does not block, so
+A managed channel delivers one turn at a time and does not block, so
 use the post-and-resume pattern above with it.
 </Callout>
 
@@ -144,6 +143,6 @@ channel.onInterrupt<{ question: string }>("ask_human", async ({ payload, thread 
 ```
 
 `onInterrupt` is keyed by the event name (here `"ask_human"`), and the type
-argument types `payload`. On the Intelligence adapter, where `awaitChoice` does
+argument types `payload`. On a managed channel, where `awaitChoice` does
 not block, post a component whose button calls `thread.resume(answer)` instead.
 

--- a/showcase/shell-docs/src/content/docs/channels/interactive/human-in-the-loop.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/interactive/human-in-the-loop.mdx
@@ -1,0 +1,149 @@
+---
+title: Human-in-the-Loop
+icon: "lucide/UserCheck"
+description: Pause the agent for an approve or cancel decision, rendered as buttons.
+---
+
+Some actions should not happen without a human saying yes. Human-in-the-loop
+posts an approve or cancel card, waits for the click, and only then lets the
+agent continue.
+
+This builds on [the UI library](/channels/ui-library). Make sure
+JSX is turned on and your card is registered in `createChannel({ components })`.
+
+## The confirm card
+
+Two buttons. Each repaints the card in place, and the approve button resumes
+the agent with the decision.
+
+```tsx title="confirm-write.tsx"
+import {
+  Message,
+  Header,
+  Section,
+  Actions,
+  Button,
+  type ChannelNode,
+  type InteractionContext,
+} from "@copilotkit/channels/ui";
+
+export function ConfirmWrite({ action }: { action: string }): ChannelNode {
+  return (
+    <Message accent="#F59E0B">
+      <Header>{`Confirm: ${action}`}</Header>
+      <Section>{"Approve to let me continue."}</Section>
+      <Actions>
+        <Button
+          value={{ confirmed: true }}
+          style="primary"
+          onClick={async ({ thread, message }: InteractionContext) => {
+            // repaint the card so the buttons can't be clicked twice
+            await thread.update(
+              message.ref,
+              <Message accent="#27AE60">
+                <Header>{`Approved: ${action}`}</Header>
+              </Message>,
+            );
+            // resume the agent with the answer
+            await thread.runAgent({
+              prompt: `The user approved: ${action}. Go ahead.`,
+            });
+          }}
+        >
+          Approve
+        </Button>
+        <Button
+          value={{ confirmed: false }}
+          style="danger"
+          onClick={async ({ thread, message }: InteractionContext) => {
+            await thread.update(
+              message.ref,
+              <Message accent="#E74C3C">
+                <Header>{"Cancelled"}</Header>
+              </Message>,
+            );
+          }}
+        >
+          Cancel
+        </Button>
+      </Actions>
+    </Message>
+  );
+}
+```
+
+## Ask before a write
+
+Give the agent a tool that shows the card, then ends its turn. The agent
+stops there. The click resumes it.
+
+```ts
+import { defineChannelTool } from "@copilotkit/channels";
+import { z } from "zod";
+import { ConfirmWrite } from "./confirm-write";
+
+export const confirmWriteTool = defineChannelTool({
+  name: "confirm_write",
+  description: "Ask the user to approve an action before doing it.",
+  parameters: z.object({ action: z.string() }),
+  async handler({ action }, { thread }) {
+    await thread.post(<ConfirmWrite action={action} />);
+    // this string is what the model reads back, so it knows to stop
+    return "Showed an approval card. Waiting for the user to decide.";
+  },
+});
+```
+
+Register both the tool and the component:
+
+```ts
+const channel = createChannel({
+  name: "release-bot",
+  agent,
+  adapters: [intelligenceAdapter()],
+  tools: [confirmWriteTool],
+  components: [ConfirmWrite], // so the click resolves after a restart
+});
+```
+
+The flow: the agent calls `confirm_write`, the card appears, the agent's turn
+ends. When the user clicks Approve, `onClick` runs the agent again with the
+decision folded into the prompt, and it finishes the work.
+
+<Callout type="info" title="Direct platforms can block instead">
+On a platform you connect with a direct adapter, `thread.supportsBlockingChoice`
+is `true` and you can wait for the click inline with `awaitChoice`:
+
+```ts
+const { confirmed } = await thread.awaitChoice<{ confirmed?: boolean }>(
+  <ConfirmWrite action={action} />,
+);
+if (confirmed) {
+  // do the write
+}
+```
+
+The Intelligence adapter delivers one turn at a time and does not block, so
+use the post-and-resume pattern above with it.
+</Callout>
+
+## Agent-initiated interrupts
+
+The pattern above is driven by a tool the agent calls. An agent can also pause
+itself by emitting an `on_interrupt` event mid-run, for example a graph node
+that needs a human answer to continue. Handle it with `channel.onInterrupt`,
+collect the answer, and call `thread.resume` to hand it back.
+
+```tsx
+channel.onInterrupt<{ question: string }>("ask_human", async ({ payload, thread }) => {
+  const { value } = await thread.awaitChoice<{ value: string }>(
+    <AskCard question={payload.question} />,
+  );
+  await thread.resume(value); // the run continues with the answer
+});
+```
+
+`onInterrupt` is keyed by the event name (here `"ask_human"`), and the type
+argument types `payload`. On the Intelligence adapter, where `awaitChoice` does
+not block, post a component whose button calls `thread.resume(answer)` instead.
+

--- a/showcase/shell-docs/src/content/docs/channels/interactive/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/interactive/index.mdx
@@ -1,0 +1,18 @@
+---
+title: Interactive flows
+icon: "lucide/MousePointerClick"
+description: Flows where a component drives the conversation, built on the UI library.
+---
+
+These build on [the UI library](/channels/ui-library). Set up
+JSX and know how `thread.post(<Card/>)`, callbacks, and component registration
+work first, then come back here for the flows where a component drives the
+conversation.
+
+Two patterns:
+
+<Cards>
+  <Card title="Human-in-the-loop" href="/channels/interactive/human-in-the-loop" description="The agent posts an approve or cancel card and waits for the click before continuing." />
+  <Card title="Reactions" href="/channels/interactive/reactions" description="Run code when a user reacts to a specific card you posted." />
+  <Card title="Modals" href="/channels/interactive/modals" description="Open a form dialog, collect fields, and handle the submission." />
+</Cards>

--- a/showcase/shell-docs/src/content/docs/channels/interactive/meta.json
+++ b/showcase/shell-docs/src/content/docs/channels/interactive/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Interactive flows",
+  "icon": "lucide/MousePointerClick",
+  "pages": ["index", "human-in-the-loop", "reactions", "modals"]
+}

--- a/showcase/shell-docs/src/content/docs/channels/interactive/modals.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/interactive/modals.mdx
@@ -1,0 +1,121 @@
+---
+title: Modals
+icon: "lucide/PanelTopOpen"
+description: Open a form dialog, collect fields, and handle the submission.
+---
+
+A modal is a form dialog: a title, some inputs, a submit button. Open it from a
+button click or a slash command, collect the fields, and handle the
+submission.
+
+Modals are capability-gated. Slack and Discord support them; on a platform that
+does not, `openModal` resolves `{ ok: false }`. This builds on [component
+rendering](/channels/ui-library).
+
+## Build the view
+
+Compose a modal from `@copilotkit/channels/ui`. The `callbackId` is how the
+submission routes back to your handler.
+
+```tsx
+import {
+  Modal,
+  TextInput,
+  ModalSelect,
+  ModalSelectOption,
+  type ModalView,
+} from "@copilotkit/channels/ui";
+
+function FileIssueModal(): ModalView {
+  return (
+    <Modal callbackId="file-issue" title="File an issue" submitLabel="Create">
+      <TextInput id="title" label="Title" />
+      <TextInput id="body" label="Description" multiline optional />
+      <ModalSelect id="priority" label="Priority" initialOption="medium">
+        <ModalSelectOption label="High" value="high" />
+        <ModalSelectOption label="Medium" value="medium" />
+        <ModalSelectOption label="Low" value="low" />
+      </ModalSelect>
+    </Modal>
+  );
+}
+```
+
+### Elements
+
+| Component | Use |
+| --- | --- |
+| `Modal` | The dialog. `callbackId` (routes the submit/close), `title`, `submitLabel?`, `closeLabel?`, `notifyOnClose?`, `privateMetadata?`. |
+| `TextInput` | A text field. `id`, `label`, `placeholder?`, `multiline?`, `optional?`, `maxLength?`, `initialValue?`. |
+| `ModalSelect` + `ModalSelectOption` | A dropdown. `ModalSelect` takes `id`, `label`, `initialOption?`; each option is `{ label, value }`. |
+| `RadioButtons` | A single-choice group, same shape as `ModalSelect`. |
+
+## Open it
+
+A modal needs a fresh interaction trigger, so open it from a button click or a
+slash command, not from `onMessage`.
+
+From a button:
+
+```tsx
+<Button
+  onClick={async ({ openModal }) => {
+    await openModal?.(<FileIssueModal />);
+  }}
+>
+  File an issue
+</Button>
+```
+
+From a slash command:
+
+```ts
+defineChannelCommand({
+  name: "file-issue",
+  description: "Open the file-an-issue form.",
+  async handler({ openModal }) {
+    await openModal?.(<FileIssueModal />);
+  },
+});
+```
+
+<Callout type="warn" title="Discord expires the trigger fast">
+On Discord the interaction trigger expires about 3 seconds after the click.
+Call `openModal` first, before any slow work.
+</Callout>
+
+## Handle the submission
+
+Register a handler for the `callbackId`. Field values arrive on `evt.values`,
+keyed by each input's `id`. Return `{ errors }` to keep the modal open with
+per-field messages.
+
+```ts
+channel.onModalSubmit("file-issue", async (evt) => {
+  const { title, body, priority } = evt.values as {
+    title: string;
+    body?: string;
+    priority: string;
+  };
+
+  if (!title) {
+    return { errors: { title: "Title is required" } }; // keeps the modal open
+  }
+
+  await createIssue({ title, body, priority });
+  await evt.thread?.post(`Filed: ${title}`);
+});
+```
+
+To know when a user dismisses the modal, set `notifyOnClose` on the `Modal` and
+register `onModalClose`:
+
+```ts
+channel.onModalClose("file-issue", (evt) => {
+  // the user closed the form without submitting
+});
+```
+
+The submit event carries `values`, `user`, `thread?` (when the submission has a
+conversation context), and `privateMetadata` (the opaque string you set on the
+`Modal`).

--- a/showcase/shell-docs/src/content/docs/channels/interactive/reactions.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/interactive/reactions.mdx
@@ -38,7 +38,6 @@ Post it, and register it so a late reaction still resolves after a restart:
 const channel = createChannel({
   name: "poll-bot",
   agent,
-  adapters: [intelligenceAdapter()],
   components: [PollCard],
 });
 

--- a/showcase/shell-docs/src/content/docs/channels/interactive/reactions.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/interactive/reactions.mdx
@@ -1,0 +1,115 @@
+---
+title: Reactions
+icon: "lucide/SmilePlus"
+description: Run code when a user reacts to a card you posted, using JSX.
+---
+
+Attach `onReaction` to a message you post, and your handler runs when someone
+reacts to that message. Good for a thumbs-up to confirm, or a refresh emoji to
+redraw a card.
+
+This is the per-card handler. It builds on [the UI library](/channels/ui-library), so set up JSX first. To react to
+_any_ message in the channel, see [global
+reactions](/channels/commands-and-reactions#global-reactions).
+
+## A card that reacts
+
+```tsx
+import { Message, Section, type ChannelNode } from "@copilotkit/channels/ui";
+
+export function PollCard(): ChannelNode {
+  return (
+    <Message
+      onReaction={async (emoji, reaction) => {
+        if (!reaction.added) return; // ignore un-reactions
+        if (emoji !== "thumbs_up") return;
+        await reaction.thread.post(`Thanks for the vote, ${reaction.user?.name ?? "friend"}.`);
+      }}
+    >
+      <Section>{"React with a thumbs up to vote."}</Section>
+    </Message>
+  );
+}
+```
+
+Post it, and register it so a late reaction still resolves after a restart:
+
+```ts
+const channel = createChannel({
+  name: "poll-bot",
+  agent,
+  adapters: [intelligenceAdapter()],
+  components: [PollCard],
+});
+
+await thread.post(<PollCard />);
+```
+
+## What the handler gets
+
+```ts
+onReaction={(emoji, reaction) => {
+  emoji;              // canonical name: "thumbs_up", "refresh", "fire", ...
+  reaction.rawEmoji;  // the platform's native token
+  reaction.added;     // true = added, false = removed
+  reaction.user;      // who reacted
+  reaction.thread;    // post back here
+  reaction.messageRef; // pass to thread.update(...) to redraw this card
+}}
+```
+
+## Emoji names are normalized
+
+The same reaction arrives under one canonical `emoji` name on every platform.
+The counterclockwise-arrows emoji is `"refresh"` whether it came in as Slack's
+`arrows_counterclockwise`, a Teams token, or the raw unicode elsewhere. So you
+match on the name once:
+
+```ts
+if (emoji === "refresh") {
+  await reaction.thread.update(reaction.messageRef, <PollCard />);
+}
+```
+
+Reach for `reaction.rawEmoji` only when you need the exact platform token, for
+example a custom Slack emoji that has no canonical name.
+
+## Emoji helpers
+
+`@copilotkit/channels/ui` exports a few helpers for working with emoji names.
+
+Use the `emoji` accessor instead of a bare string so a typo is a compile error
+and you get autocomplete:
+
+```ts
+import { emoji } from "@copilotkit/channels/ui";
+
+if (reaction.emoji === emoji.refresh) {
+  // ...
+}
+```
+
+The known names come from `EMOJI_TABLE` (`thumbs_up`, `heart`, `fire`, `eyes`,
+`bug`, `check`, `cross`, `tada`, `rocket`, `refresh`, and more). The
+`EmojiValue` type is `KnownEmoji | (string & {})`, so a known name
+autocompletes while any custom token still passes through.
+
+| Helper | Signature | Use |
+| --- | --- | --- |
+| `toCanonicalEmoji` | `(value: EmojiValue) => EmojiValue` | Resolve a name, Slack shortcode, or unicode to the canonical name. Unknown tokens pass through. |
+| `normalizeEmoji` | `(token: string, platform) => EmojiValue \| undefined` | A platform-native token to its canonical name, or `undefined` if unknown. |
+| `toPlatformEmoji` | `(value: EmojiValue, platform) => string \| undefined` | The reverse: a canonical name to a platform's native token. |
+
+`platform` is one of `"slack" | "discord" | "telegram" | "teams" | "whatsapp"`.
+
+```ts
+import { toCanonicalEmoji, toPlatformEmoji } from "@copilotkit/channels/ui";
+
+toCanonicalEmoji("arrows_counterclockwise"); // "refresh"
+toCanonicalEmoji("🔄");                       // "refresh"
+toPlatformEmoji("refresh", "slack");          // "arrows_counterclockwise"
+```
+
+Ingress already normalizes `reaction.emoji` for you, so you mostly reach for
+these when matching a caller-supplied filter or posting a reaction with
+`thread.react` on a specific platform.

--- a/showcase/shell-docs/src/content/docs/channels/mcp.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/mcp.mdx
@@ -1,0 +1,122 @@
+---
+title: MCP Servers
+icon: "lucide/Network"
+description: Give your bot external tools by connecting MCP servers on its agent.
+---
+
+A channel runs an agent, and the agent is where tools come from. To give your
+bot tools from a Model Context Protocol server, connect the server inside the
+agent's TanStack factory. Nothing about the channel changes.
+
+The tools then work on every platform the channel is attached to.
+
+## Install
+
+```bash
+npm install @tanstack/ai-mcp
+```
+
+You already have `@copilotkit/runtime`, `@tanstack/ai`, and `@tanstack/ai-openai`
+from the [Quickstart](/channels/quickstart).
+
+## Connect an MCP server in the factory
+
+Create a client with `createMCPClient` and pass it to `chat({ mcp })`. TanStack
+AI connects it for the run and closes it when the run ends.
+
+```ts title="agent.ts"
+import { BuiltInAgent, convertInputToTanStackAI } from "@copilotkit/runtime/v2";
+import { chat } from "@tanstack/ai";
+import { openaiText } from "@tanstack/ai-openai";
+import { createMCPClient } from "@tanstack/ai-mcp";
+
+const SYSTEM_PROMPT = "You are an ops assistant. Use the connected tools to answer.";
+
+export const agent = new BuiltInAgent({
+  type: "tanstack",
+  factory: async (ctx) => {
+    const { messages, systemPrompts, tools } = convertInputToTanStackAI(ctx.input);
+
+    // Connect your MCP server for this turn.
+    const client = await createMCPClient({
+      transport: {
+        type: "http",
+        url: "https://mcp.example.com/mcp",
+        headers: { Authorization: `Bearer ${process.env.MCP_TOKEN}` },
+      },
+    });
+
+    return chat({
+      adapter: openaiText("gpt-5.5"),
+      messages,
+      systemPrompts: [SYSTEM_PROMPT, ...systemPrompts],
+      tools,
+      mcp: { clients: [client] },
+      abortController: ctx.abortController,
+    });
+  },
+});
+```
+
+Wire that agent into the channel as usual:
+
+```ts
+import { createChannel } from "@copilotkit/channels";
+import { intelligenceAdapter } from "@copilotkit/channels/intelligence";
+import { agent } from "./agent";
+
+const channel = createChannel({
+  name: "ops-bot",
+  agent,
+  adapters: [intelligenceAdapter()],
+});
+
+channel.onMessage(async ({ thread, message }) => {
+  await thread.runAgent({ prompt: message.text });
+});
+
+await channel.start();
+```
+
+Now when a user asks the bot something that needs an MCP tool, the agent calls
+it and answers with the result, in Slack, Teams, or wherever the channel is
+attached.
+
+## More than one server
+
+Connect each server and pass all the clients:
+
+```ts
+const [linear, notion] = await Promise.all([
+  createMCPClient({ transport: { type: "http", url: process.env.LINEAR_MCP_URL! } }),
+  createMCPClient({ transport: { type: "http", url: process.env.NOTION_MCP_URL! } }),
+]);
+
+return chat({
+  adapter: openaiText("gpt-5.5"),
+  messages,
+  systemPrompts,
+  tools,
+  mcp: { clients: [linear, notion] },
+  abortController: ctx.abortController,
+});
+```
+
+<Callout type="info" title="Don't let one server take down the turn">
+Connecting inside the factory means a slow or misconfigured server can stall a
+turn. Connect each client independently with `Promise.allSettled`, drop the
+ones that fail, and run with whatever connected. The agent still answers with
+the tools that are up.
+</Callout>
+
+## Lifecycle
+
+By default TanStack AI closes the clients when the run ends, so creating them
+in the factory is the simplest choice. If you want a persistent connection,
+create the client once outside the factory and reuse it, and close it yourself
+on shutdown.
+
+<Callout type="info">
+This is the channels view of MCP. For the concept and transports, see the
+[MCP guide](/agentic-protocols/mcp).
+</Callout>

--- a/showcase/shell-docs/src/content/docs/channels/mcp.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/mcp.mdx
@@ -62,20 +62,35 @@ Wire that agent into the channel as usual:
 
 ```ts
 import { createChannel } from "@copilotkit/channels";
-import { intelligenceAdapter } from "@copilotkit/channels/intelligence";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 import { agent } from "./agent";
 
+// A managed channel: Intelligence hosts the transport, so no adapter.
 const channel = createChannel({
   name: "ops-bot",
   agent,
-  adapters: [intelligenceAdapter()],
 });
 
 channel.onMessage(async ({ thread, message }) => {
   await thread.runAgent({ prompt: message.text });
 });
 
-await channel.start();
+// The runtime owns the channel; a CopilotKit Intelligence key runs it (free
+// tier available). `ready()` activates it.
+const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
+const runtime = new CopilotRuntime({
+  intelligence: new CopilotKitIntelligence({
+    apiUrl,
+    wsUrl: apiUrl.replace(/^http/, "ws"),
+    apiKey: process.env.COPILOTKIT_API_KEY!,
+  }),
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+  channels: [channel],
+});
+
+const listener = createCopilotNodeListener({ runtime });
+await listener.channels?.ready();
 ```
 
 Now when a user asks the bot something that needs an MCP tool, the agent calls

--- a/showcase/shell-docs/src/content/docs/channels/mcp.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/mcp.mdx
@@ -80,6 +80,7 @@ channel.onMessage(async ({ thread, message }) => {
 // tier available). `ready()` activates it.
 const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
 const runtime = new CopilotRuntime({
+  agents: {},
   intelligence: new CopilotKitIntelligence({
     apiUrl,
     wsUrl: apiUrl.replace(/^http/, "ws"),
@@ -91,6 +92,7 @@ const runtime = new CopilotRuntime({
 
 const listener = createCopilotNodeListener({ runtime });
 await listener.channels?.ready();
+// Mount the listener on an HTTP server to keep the process running (see the Quickstart).
 ```
 
 Now when a user asks the bot something that needs an MCP tool, the agent calls

--- a/showcase/shell-docs/src/content/docs/channels/meta.json
+++ b/showcase/shell-docs/src/content/docs/channels/meta.json
@@ -1,5 +1,19 @@
 {
-  "title": "Channels SDK",
-  "icon": "lucide/Bot",
-  "pages": ["index", "persistence", "transcripts"]
+  "title": "Channels",
+  "icon": "lucide/MessagesSquare",
+  "pages": [
+    "index",
+    "quickstart",
+    "ui-library",
+    "tools",
+    "interactive",
+    "commands-and-reactions",
+    "files-and-multimodality",
+    "mcp",
+    "configuration",
+    "persistence",
+    "transcripts",
+    "platforms",
+    "reference"
+  ]
 }

--- a/showcase/shell-docs/src/content/docs/channels/platforms/discord.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/discord.mdx
@@ -21,6 +21,11 @@ From the Discord Developer Portal (your application and bot):
 DISCORD_BOT_TOKEN=...
 DISCORD_APP_ID=...
 DISCORD_GUILD_ID=...   # optional, for faster command registration in one server
+
+# The runtime runs every channel, so a CopilotKit Intelligence key is required
+# even for a direct adapter (free tier available).
+COPILOTKIT_INTELLIGENCE_URL=https://your-intelligence-url
+COPILOTKIT_API_KEY=cpk-...
 ```
 
 ## Connect
@@ -28,9 +33,12 @@ DISCORD_GUILD_ID=...   # optional, for faster command registration in one server
 ```ts
 import { createChannel } from "@copilotkit/channels";
 import { discord } from "@copilotkit/channels/discord";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 import { agent } from "./agent"; // your TanStack AI agent, see the Quickstart
 
 const channel = createChannel({
+  name: "support-bot",
   agent,
   adapters: [
     discord({
@@ -45,7 +53,21 @@ channel.onMessage(async ({ thread, message }) => {
   await thread.runAgent({ prompt: message.text });
 });
 
-await channel.start();
+// The runtime drives the channel — it starts the Discord adapter, you don't
+// call channel.start() yourself. `ready()` activates it.
+const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
+const runtime = new CopilotRuntime({
+  intelligence: new CopilotKitIntelligence({
+    apiUrl,
+    wsUrl: apiUrl.replace(/^http/, "ws"),
+    apiKey: process.env.COPILOTKIT_API_KEY!,
+  }),
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+  channels: [channel],
+});
+
+const listener = createCopilotNodeListener({ runtime });
+await listener.channels?.ready();
 ```
 
 ## Typed slash commands

--- a/showcase/shell-docs/src/content/docs/channels/platforms/discord.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/discord.mdx
@@ -57,6 +57,7 @@ channel.onMessage(async ({ thread, message }) => {
 // call channel.start() yourself. `ready()` activates it.
 const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
 const runtime = new CopilotRuntime({
+  agents: {},
   intelligence: new CopilotKitIntelligence({
     apiUrl,
     wsUrl: apiUrl.replace(/^http/, "ws"),

--- a/showcase/shell-docs/src/content/docs/channels/platforms/discord.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/discord.mdx
@@ -1,0 +1,87 @@
+---
+title: Discord
+icon: "lucide/Hash"
+description: Connect Discord with the Discord adapter.
+---
+
+Connect Discord with the Discord adapter. Discord has native slash commands
+with typed arguments, so `/commands` feel first class.
+
+## Install
+
+```bash
+npm install @copilotkit/channels @copilotkit/runtime @tanstack/ai @tanstack/ai-openai
+```
+
+## Credentials
+
+From the Discord Developer Portal (your application and bot):
+
+```bash
+DISCORD_BOT_TOKEN=...
+DISCORD_APP_ID=...
+DISCORD_GUILD_ID=...   # optional, for faster command registration in one server
+```
+
+## Connect
+
+```ts
+import { createChannel } from "@copilotkit/channels";
+import { discord } from "@copilotkit/channels/discord";
+import { agent } from "./agent"; // your TanStack AI agent, see the Quickstart
+
+const channel = createChannel({
+  agent,
+  adapters: [
+    discord({
+      botToken: process.env.DISCORD_BOT_TOKEN!,
+      appId: process.env.DISCORD_APP_ID!,
+      guildId: process.env.DISCORD_GUILD_ID, // optional
+    }),
+  ],
+});
+
+channel.onMessage(async ({ thread, message }) => {
+  await thread.runAgent({ prompt: message.text });
+});
+
+await channel.start();
+```
+
+## Typed slash commands
+
+Discord parses command arguments for you. Add an `options` schema and read the
+parsed values from `options`:
+
+```ts
+import { defineChannelCommand } from "@copilotkit/channels";
+import { z } from "zod";
+
+defineChannelCommand({
+  name: "weather",
+  description: "Get the weather for a city.",
+  options: z.object({ city: z.string() }),
+  async handler({ thread, options }) {
+    await thread.runAgent({ prompt: `What's the weather in ${options.city}?` });
+  },
+});
+```
+
+See [commands and reactions](/channels/commands-and-reactions) for the full
+command API.
+
+## Built-in tools and context
+
+The Discord adapter ships helpers you can spread into your channel: a set of
+tools (including a Discord user-lookup tool) and Discord formatting context.
+
+```ts
+import { discord, defaultDiscordTools, defaultDiscordContext } from "@copilotkit/channels/discord";
+
+createChannel({
+  agent,
+  tools: [...defaultDiscordTools],
+  context: [...defaultDiscordContext],
+  adapters: [discord({ /* ...credentials */ })],
+});
+```

--- a/showcase/shell-docs/src/content/docs/channels/platforms/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/index.mdx
@@ -1,0 +1,63 @@
+---
+title: Platforms
+icon: "lucide/Plug"
+description: Supported chat platforms, and the platform work Intelligence handles for you.
+---
+
+A channel can run on any of these platforms. The same agent, tools, commands,
+and cards work on all of them.
+
+| Platform | Direct adapter | Connect directly |
+| --- | --- | --- |
+| Slack | `@copilotkit/channels/slack` | [Slack](/channels/platforms/slack) |
+| Microsoft Teams | `@copilotkit/channels/teams` | [Teams](/channels/platforms/teams) |
+| WhatsApp | `@copilotkit/channels/whatsapp` | [WhatsApp](/channels/platforms/whatsapp) |
+| Telegram | `@copilotkit/channels/telegram` | [Telegram](/channels/platforms/telegram) |
+| Discord | `@copilotkit/channels/discord` | [Discord](/channels/platforms/discord) |
+
+## What Intelligence handles for you
+
+Each platform has its own login, its own way of delivering events, and its own
+message format. When you connect through the [Intelligence
+adapter](/channels/quickstart), Intelligence takes care of the platform-side
+work, so your process just runs the agent. Connect a platform with its own
+adapter and that work becomes yours.
+
+| Concern | With the Intelligence adapter | With a direct adapter |
+| --- | --- | --- |
+| **Credentials** | Held by Intelligence. No platform tokens in your app. | You hold and rotate every token. |
+| **Ingress** | Intelligence receives the platform event and delivers the turn to your bot over HTTP. | You run the webhook or socket connection. |
+| **Egress** | Intelligence does the credentialed send back to the platform. | You send with your own credentials. |
+| **Files and media** | Fetched, size-checked, and handed to your agent as content parts. | You fetch and cap them on the adapter. |
+| **Delivery** | Retries, de-duplication, and per-thread ordering are managed. | You handle duplicates and retries. |
+| **Adding a platform** | Attach it in the dashboard, no code change. | Add another adapter and its setup. |
+
+Two things are the same either way, because they live in the SDK: components
+render to each platform's native format (Slack Block Kit, Teams Adaptive
+Cards, and so on), and reactions arrive under one [canonical
+name](/channels/interactive/reactions) on every platform.
+
+## Per-platform notes
+
+Some behavior is set by the platform itself and holds no matter how you
+connect:
+
+- **Slack** runs over Socket Mode, and a `/command` must be declared in your
+  Slack app manifest.
+- **Teams** accepts image attachments only for outbound files, and reactions
+  arrive as tokens like `1f504_refresh` (normalized for you).
+- **WhatsApp** and **Telegram** deliver slash commands as plain text.
+- **Discord** has native slash commands with typed arguments.
+
+## Connect a platform directly
+
+Start with the [Quickstart](/channels/quickstart) on the Intelligence adapter.
+Reach for a direct adapter when you want to own one platform end to end:
+
+<Cards>
+  <Card title="Slack" href="/channels/platforms/slack" description="Socket Mode, no public URL needed." />
+  <Card title="Microsoft Teams" href="/channels/platforms/teams" description="Bot Framework endpoint and Entra app." />
+  <Card title="WhatsApp" href="/channels/platforms/whatsapp" description="WhatsApp Cloud API webhook." />
+  <Card title="Telegram" href="/channels/platforms/telegram" description="Just a BotFather token." />
+  <Card title="Discord" href="/channels/platforms/discord" description="Native typed slash commands." />
+</Cards>

--- a/showcase/shell-docs/src/content/docs/channels/platforms/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/index.mdx
@@ -18,12 +18,12 @@ and cards work on all of them.
 ## What Intelligence handles for you
 
 Each platform has its own login, its own way of delivering events, and its own
-message format. When you connect through the [Intelligence
-adapter](/channels/quickstart), Intelligence takes care of the platform-side
-work, so your process just runs the agent. Connect a platform with its own
-adapter and that work becomes yours.
+message format. With a [managed channel](/channels/quickstart), Intelligence
+takes care of the platform-side work, so your process just runs the agent.
+Connect a platform with its own adapter and that work becomes yours (though the
+runtime still drives the channel).
 
-| Concern | With the Intelligence adapter | With a direct adapter |
+| Concern | With a managed channel | With a direct adapter |
 | --- | --- | --- |
 | **Credentials** | Held by Intelligence. No platform tokens in your app. | You hold and rotate every token. |
 | **Ingress** | Intelligence receives the platform event and delivers the turn to your bot over HTTP. | You run the webhook or socket connection. |
@@ -51,8 +51,9 @@ connect:
 
 ## Connect a platform directly
 
-Start with the [Quickstart](/channels/quickstart) on the Intelligence adapter.
-Reach for a direct adapter when you want to own one platform end to end:
+Start with the [Quickstart](/channels/quickstart) on a managed channel. Reach
+for a direct adapter when you want to own one platform's credentials end to end
+(the runtime still runs the channel, so an Intelligence key is required):
 
 <Cards>
   <Card title="Slack" href="/channels/platforms/slack" description="Socket Mode, no public URL needed." />

--- a/showcase/shell-docs/src/content/docs/channels/platforms/meta.json
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Platforms",
+  "icon": "lucide/Plug",
+  "pages": ["index", "teams", "whatsapp", "slack", "telegram", "discord"]
+}

--- a/showcase/shell-docs/src/content/docs/channels/platforms/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/slack.mdx
@@ -20,6 +20,11 @@ From your Slack app:
 ```bash
 SLACK_BOT_TOKEN=xoxb-...   # Bot User OAuth token
 SLACK_APP_TOKEN=xapp-...   # App-level token, for Socket Mode
+
+# The runtime runs every channel, so a CopilotKit Intelligence key is required
+# even for a direct adapter (free tier available).
+COPILOTKIT_INTELLIGENCE_URL=https://your-intelligence-url
+COPILOTKIT_API_KEY=cpk-...
 ```
 
 ## Connect
@@ -27,9 +32,12 @@ SLACK_APP_TOKEN=xapp-...   # App-level token, for Socket Mode
 ```ts
 import { createChannel } from "@copilotkit/channels";
 import { slack, defaultSlackContext } from "@copilotkit/channels/slack";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 import { agent } from "./agent"; // your TanStack AI agent, see the Quickstart
 
 const channel = createChannel({
+  name: "support-bot",
   agent,
   // Slack output-formatting guidance so replies render well in Slack.
   context: [...defaultSlackContext],
@@ -50,7 +58,22 @@ channel.onMessage(async ({ thread, message }) => {
   await thread.runAgent({ prompt: message.text });
 });
 
-await channel.start();
+// The runtime drives the channel — it starts the Slack adapter, you don't call
+// channel.start() yourself. A CopilotKit Intelligence key runs every channel,
+// direct adapters included (free tier available); `ready()` activates it.
+const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
+const runtime = new CopilotRuntime({
+  intelligence: new CopilotKitIntelligence({
+    apiUrl,
+    wsUrl: apiUrl.replace(/^http/, "ws"),
+    apiKey: process.env.COPILOTKIT_API_KEY!,
+  }),
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+  channels: [channel],
+});
+
+const listener = createCopilotNodeListener({ runtime });
+await listener.channels?.ready();
 ```
 
 `respondTo` controls when the bot answers: DMs, mentions, and whether it keeps

--- a/showcase/shell-docs/src/content/docs/channels/platforms/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/slack.mdx
@@ -63,6 +63,7 @@ channel.onMessage(async ({ thread, message }) => {
 // direct adapters included (free tier available); `ready()` activates it.
 const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
 const runtime = new CopilotRuntime({
+  agents: {},
   intelligence: new CopilotKitIntelligence({
     apiUrl,
     wsUrl: apiUrl.replace(/^http/, "ws"),

--- a/showcase/shell-docs/src/content/docs/channels/platforms/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/slack.mdx
@@ -1,0 +1,99 @@
+---
+title: Slack
+icon: "lucide/Slack"
+description: Connect Slack directly with the Slack adapter.
+---
+
+Connect Slack yourself with the Slack adapter. It runs over Socket Mode by
+default, so no public URL is needed for local development.
+
+## Install
+
+```bash
+npm install @copilotkit/channels @copilotkit/runtime @tanstack/ai @tanstack/ai-openai
+```
+
+## Credentials
+
+From your Slack app:
+
+```bash
+SLACK_BOT_TOKEN=xoxb-...   # Bot User OAuth token
+SLACK_APP_TOKEN=xapp-...   # App-level token, for Socket Mode
+```
+
+## Connect
+
+```ts
+import { createChannel } from "@copilotkit/channels";
+import { slack, defaultSlackContext } from "@copilotkit/channels/slack";
+import { agent } from "./agent"; // your TanStack AI agent, see the Quickstart
+
+const channel = createChannel({
+  agent,
+  // Slack output-formatting guidance so replies render well in Slack.
+  context: [...defaultSlackContext],
+  adapters: [
+    slack({
+      botToken: process.env.SLACK_BOT_TOKEN!,
+      appToken: process.env.SLACK_APP_TOKEN!,
+      respondTo: {
+        directMessages: true,
+        appMentions: { reply: "thread" },
+        threadReplies: "mentionsOnly",
+      },
+    }),
+  ],
+});
+
+channel.onMessage(async ({ thread, message }) => {
+  await thread.runAgent({ prompt: message.text });
+});
+
+await channel.start();
+```
+
+`respondTo` controls when the bot answers: DMs, mentions, and whether it keeps
+listening in a thread it is part of.
+
+## Streaming
+
+The Slack adapter streams replies as they are produced. The `streaming` option
+picks the transport:
+
+- `"native"` (default) uses Slack's `chat.startStream` in threads, and falls
+  back automatically in flat DMs or workspaces where the streaming API is not
+  available.
+- `"legacy"` edits a single message with repeated `chat.update` calls.
+
+```ts
+slack({
+  botToken: process.env.SLACK_BOT_TOKEN!,
+  appToken: process.env.SLACK_APP_TOKEN!,
+  streaming: "native",
+});
+```
+
+<Callout type="info" title="Declare slash commands in the manifest">
+A `/command` only reaches your bot if it is declared in your Slack app
+manifest with the same name you pass to `defineChannelCommand`. See [commands
+and reactions](/channels/commands-and-reactions).
+</Callout>
+
+## Built-in tools and context
+
+The Slack adapter ships helpers you can spread into your channel: a set of
+tools (including a Slack user-lookup tool) and context that guides Slack
+formatting and tagging.
+
+```ts
+import { slack, defaultSlackTools, defaultSlackContext } from "@copilotkit/channels/slack";
+
+createChannel({
+  name: "support-bot",
+  agent,
+  tools: [...defaultSlackTools],
+  context: [...defaultSlackContext],
+  adapters: [slack({ /* ...credentials */ })],
+});
+```

--- a/showcase/shell-docs/src/content/docs/channels/platforms/teams.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/teams.mdx
@@ -1,0 +1,74 @@
+---
+title: Microsoft Teams
+icon: "lucide/MessageSquare"
+description: Connect Microsoft Teams directly with the Teams adapter.
+---
+
+Connect Teams yourself with the Teams adapter when you want to hold the
+credentials and run the bot on your own infrastructure. If you would rather
+CopilotKit manage the connection, use the [Intelligence
+adapter](/channels/quickstart) instead.
+
+## Install
+
+```bash
+npm install @copilotkit/channels @copilotkit/runtime @tanstack/ai @tanstack/ai-openai
+```
+
+## Credentials
+
+The Teams adapter authenticates with an Entra (Azure AD) app. It reads
+`clientId`, `clientSecret`, and `tenantId` from the environment, or you can
+pass them directly.
+
+```bash
+clientId=...
+clientSecret=...
+tenantId=...
+```
+
+## Connect
+
+The adapter serves the Bot Framework messaging endpoint at `POST
+/api/messages`.
+
+```ts
+import { createChannel } from "@copilotkit/channels";
+import { teams } from "@copilotkit/channels/teams";
+import { agent } from "./agent"; // your TanStack AI agent, see the Quickstart
+
+const channel = createChannel({
+  agent,
+  adapters: [
+    teams({
+      port: 3978, // Bot Framework endpoint at /api/messages
+      // clientId, clientSecret, tenantId fall back to env
+    }),
+  ],
+});
+
+channel.onMessage(async ({ thread, message }) => {
+  await thread.runAgent({ prompt: message.text });
+});
+
+await channel.start();
+```
+
+## Set up the Teams side
+
+You need an Entra app, an Azure Bot resource pointing at your public
+`/api/messages` URL with the Teams channel enabled, and a sideloaded Teams app
+package. For a tunnel during local development, point the Azure Bot messaging
+endpoint at your public tunnel URL.
+
+<Callout type="info">
+Teams reactions arrive as tokens like `1f504_refresh`. The SDK normalizes
+them to canonical names, so `emoji === "refresh"` works the same as on every
+other platform. See [reactions](/channels/interactive/reactions).
+</Callout>
+
+## Send files
+
+Teams accepts image attachments. `thread.postFile` with an image mime type
+posts an inline image. See [files and
+multimodality](/channels/files-and-multimodality).

--- a/showcase/shell-docs/src/content/docs/channels/platforms/teams.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/teams.mdx
@@ -5,9 +5,9 @@ description: Connect Microsoft Teams directly with the Teams adapter.
 ---
 
 Connect Teams yourself with the Teams adapter when you want to hold the
-credentials and run the bot on your own infrastructure. If you would rather
-CopilotKit manage the connection, use the [Intelligence
-adapter](/channels/quickstart) instead.
+platform credentials. If you would rather CopilotKit hold them, use a [managed
+channel](/channels/quickstart) instead. Either way the runtime runs the
+channel, so a CopilotKit Intelligence key is required (free tier available).
 
 ## Install
 
@@ -25,6 +25,11 @@ pass them directly.
 clientId=...
 clientSecret=...
 tenantId=...
+
+# The runtime runs every channel, so a CopilotKit Intelligence key is required
+# even for a direct adapter (free tier available).
+COPILOTKIT_INTELLIGENCE_URL=https://your-intelligence-url
+COPILOTKIT_API_KEY=cpk-...
 ```
 
 ## Connect
@@ -35,9 +40,12 @@ The adapter serves the Bot Framework messaging endpoint at `POST
 ```ts
 import { createChannel } from "@copilotkit/channels";
 import { teams } from "@copilotkit/channels/teams";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 import { agent } from "./agent"; // your TanStack AI agent, see the Quickstart
 
 const channel = createChannel({
+  name: "support-bot",
   agent,
   adapters: [
     teams({
@@ -51,7 +59,21 @@ channel.onMessage(async ({ thread, message }) => {
   await thread.runAgent({ prompt: message.text });
 });
 
-await channel.start();
+// The runtime drives the channel — it starts the Teams adapter, you don't call
+// channel.start() yourself. `ready()` activates it.
+const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
+const runtime = new CopilotRuntime({
+  intelligence: new CopilotKitIntelligence({
+    apiUrl,
+    wsUrl: apiUrl.replace(/^http/, "ws"),
+    apiKey: process.env.COPILOTKIT_API_KEY!,
+  }),
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+  channels: [channel],
+});
+
+const listener = createCopilotNodeListener({ runtime });
+await listener.channels?.ready();
 ```
 
 ## Set up the Teams side

--- a/showcase/shell-docs/src/content/docs/channels/platforms/teams.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/teams.mdx
@@ -63,6 +63,7 @@ channel.onMessage(async ({ thread, message }) => {
 // channel.start() yourself. `ready()` activates it.
 const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
 const runtime = new CopilotRuntime({
+  agents: {},
   intelligence: new CopilotKitIntelligence({
     apiUrl,
     wsUrl: apiUrl.replace(/^http/, "ws"),

--- a/showcase/shell-docs/src/content/docs/channels/platforms/telegram.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/telegram.mdx
@@ -51,6 +51,7 @@ channel.onMessage(async ({ thread, message }) => {
 // call channel.start() yourself. `ready()` activates it.
 const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
 const runtime = new CopilotRuntime({
+  agents: {},
   intelligence: new CopilotKitIntelligence({
     apiUrl,
     wsUrl: apiUrl.replace(/^http/, "ws"),

--- a/showcase/shell-docs/src/content/docs/channels/platforms/telegram.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/telegram.mdx
@@ -1,0 +1,63 @@
+---
+title: Telegram
+icon: "lucide/Send"
+description: Connect Telegram with the Telegram adapter.
+---
+
+Connect Telegram with the Telegram adapter. All you need is a bot token from
+BotFather.
+
+## Install
+
+```bash
+npm install @copilotkit/channels @copilotkit/runtime @tanstack/ai @tanstack/ai-openai
+```
+
+## Credentials
+
+Create a bot with [BotFather](https://t.me/botfather) and copy its token:
+
+```bash
+TELEGRAM_BOT_TOKEN=...
+```
+
+## Connect
+
+```ts
+import { createChannel } from "@copilotkit/channels";
+import { telegram } from "@copilotkit/channels/telegram";
+import { agent } from "./agent"; // your TanStack AI agent, see the Quickstart
+
+const channel = createChannel({
+  agent,
+  adapters: [
+    telegram({ token: process.env.TELEGRAM_BOT_TOKEN! }),
+  ],
+});
+
+channel.onMessage(async ({ thread, message }) => {
+  await thread.runAgent({ prompt: message.text });
+});
+
+await channel.start();
+```
+
+That is the whole connection. Add [commands](/channels/commands-and-reactions),
+[interactive flows](/channels/interactive), and [file
+handling](/channels/files-and-multimodality) the same way as any other channel.
+
+## Built-in tools and context
+
+The Telegram adapter ships helpers you can spread into your channel: a set of
+tools (including a Telegram user-lookup tool) and Telegram formatting context.
+
+```ts
+import { telegram, defaultTelegramTools, defaultTelegramContext } from "@copilotkit/channels/telegram";
+
+createChannel({
+  agent,
+  tools: [...defaultTelegramTools],
+  context: [...defaultTelegramContext],
+  adapters: [telegram({ token: process.env.TELEGRAM_BOT_TOKEN! })],
+});
+```

--- a/showcase/shell-docs/src/content/docs/channels/platforms/telegram.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/telegram.mdx
@@ -19,6 +19,11 @@ Create a bot with [BotFather](https://t.me/botfather) and copy its token:
 
 ```bash
 TELEGRAM_BOT_TOKEN=...
+
+# The runtime runs every channel, so a CopilotKit Intelligence key is required
+# even for a direct adapter (free tier available).
+COPILOTKIT_INTELLIGENCE_URL=https://your-intelligence-url
+COPILOTKIT_API_KEY=cpk-...
 ```
 
 ## Connect
@@ -26,9 +31,12 @@ TELEGRAM_BOT_TOKEN=...
 ```ts
 import { createChannel } from "@copilotkit/channels";
 import { telegram } from "@copilotkit/channels/telegram";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 import { agent } from "./agent"; // your TanStack AI agent, see the Quickstart
 
 const channel = createChannel({
+  name: "support-bot",
   agent,
   adapters: [
     telegram({ token: process.env.TELEGRAM_BOT_TOKEN! }),
@@ -39,7 +47,21 @@ channel.onMessage(async ({ thread, message }) => {
   await thread.runAgent({ prompt: message.text });
 });
 
-await channel.start();
+// The runtime drives the channel — it starts the Telegram adapter, you don't
+// call channel.start() yourself. `ready()` activates it.
+const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
+const runtime = new CopilotRuntime({
+  intelligence: new CopilotKitIntelligence({
+    apiUrl,
+    wsUrl: apiUrl.replace(/^http/, "ws"),
+    apiKey: process.env.COPILOTKIT_API_KEY!,
+  }),
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+  channels: [channel],
+});
+
+const listener = createCopilotNodeListener({ runtime });
+await listener.channels?.ready();
 ```
 
 That is the whole connection. Add [commands](/channels/commands-and-reactions),

--- a/showcase/shell-docs/src/content/docs/channels/platforms/whatsapp.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/whatsapp.mdx
@@ -64,6 +64,7 @@ channel.onMessage(async ({ thread, message }) => {
 // call channel.start() yourself. `ready()` activates it.
 const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
 const runtime = new CopilotRuntime({
+  agents: {},
   intelligence: new CopilotKitIntelligence({
     apiUrl,
     wsUrl: apiUrl.replace(/^http/, "ws"),

--- a/showcase/shell-docs/src/content/docs/channels/platforms/whatsapp.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/whatsapp.mdx
@@ -22,6 +22,11 @@ WHATSAPP_ACCESS_TOKEN=...
 WHATSAPP_PHONE_NUMBER_ID=...
 WHATSAPP_APP_SECRET=...
 WHATSAPP_VERIFY_TOKEN=...   # a string you choose, used to verify the webhook
+
+# The runtime runs every channel, so a CopilotKit Intelligence key is required
+# even for a direct adapter (free tier available).
+COPILOTKIT_INTELLIGENCE_URL=https://your-intelligence-url
+COPILOTKIT_API_KEY=cpk-...
 ```
 
 ## Connect
@@ -32,9 +37,12 @@ webhook at that public URL and use the same `verifyToken`.
 ```ts
 import { createChannel } from "@copilotkit/channels";
 import { whatsapp } from "@copilotkit/channels/whatsapp";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 import { agent } from "./agent"; // your TanStack AI agent, see the Quickstart
 
 const channel = createChannel({
+  name: "support-bot",
   agent,
   adapters: [
     whatsapp({
@@ -52,7 +60,21 @@ channel.onMessage(async ({ thread, message }) => {
   await thread.runAgent({ prompt: message.text });
 });
 
-await channel.start();
+// The runtime drives the channel — it starts the WhatsApp adapter, you don't
+// call channel.start() yourself. `ready()` activates it.
+const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
+const runtime = new CopilotRuntime({
+  intelligence: new CopilotKitIntelligence({
+    apiUrl,
+    wsUrl: apiUrl.replace(/^http/, "ws"),
+    apiKey: process.env.COPILOTKIT_API_KEY!,
+  }),
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+  channels: [channel],
+});
+
+const listener = createCopilotNodeListener({ runtime });
+await listener.channels?.ready();
 ```
 
 <Callout type="info">

--- a/showcase/shell-docs/src/content/docs/channels/platforms/whatsapp.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/whatsapp.mdx
@@ -1,0 +1,79 @@
+---
+title: WhatsApp
+icon: "lucide/MessageCircle"
+description: Connect WhatsApp with the WhatsApp adapter.
+---
+
+Connect WhatsApp with the WhatsApp adapter, backed by the WhatsApp Cloud API.
+You hold the Meta credentials and the bot runs on your infrastructure.
+
+## Install
+
+```bash
+npm install @copilotkit/channels @copilotkit/runtime @tanstack/ai @tanstack/ai-openai
+```
+
+## Credentials
+
+From your Meta app and WhatsApp Business number:
+
+```bash
+WHATSAPP_ACCESS_TOKEN=...
+WHATSAPP_PHONE_NUMBER_ID=...
+WHATSAPP_APP_SECRET=...
+WHATSAPP_VERIFY_TOKEN=...   # a string you choose, used to verify the webhook
+```
+
+## Connect
+
+The adapter serves a webhook at `/webhook` by default. Point your Meta app's
+webhook at that public URL and use the same `verifyToken`.
+
+```ts
+import { createChannel } from "@copilotkit/channels";
+import { whatsapp } from "@copilotkit/channels/whatsapp";
+import { agent } from "./agent"; // your TanStack AI agent, see the Quickstart
+
+const channel = createChannel({
+  agent,
+  adapters: [
+    whatsapp({
+      accessToken: process.env.WHATSAPP_ACCESS_TOKEN!,
+      phoneNumberId: process.env.WHATSAPP_PHONE_NUMBER_ID!,
+      appSecret: process.env.WHATSAPP_APP_SECRET!,
+      verifyToken: process.env.WHATSAPP_VERIFY_TOKEN!,
+      port: 3000,
+      path: "/webhook",
+    }),
+  ],
+});
+
+channel.onMessage(async ({ thread, message }) => {
+  await thread.runAgent({ prompt: message.text });
+});
+
+await channel.start();
+```
+
+<Callout type="info">
+Slash commands on WhatsApp are plain text with a `/` prefix. The user's words
+after the command arrive in `text`. See [commands and
+reactions](/channels/commands-and-reactions).
+</Callout>
+
+## Built-in tools and context
+
+The WhatsApp adapter ships default tools and formatting context you can spread
+into your channel. Unlike the other adapters, it does not ship a user-lookup
+tool.
+
+```ts
+import { whatsapp, defaultWhatsAppTools, defaultWhatsAppContext } from "@copilotkit/channels/whatsapp";
+
+createChannel({
+  agent,
+  tools: [...defaultWhatsAppTools],
+  context: [...defaultWhatsAppContext],
+  adapters: [whatsapp({ /* ...credentials */ })],
+});
+```

--- a/showcase/shell-docs/src/content/docs/channels/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/quickstart.mdx
@@ -1,0 +1,172 @@
+---
+title: Quickstart
+icon: "lucide/Rocket"
+description: Build a bot that answers messages in a chat app, end to end.
+---
+
+You have a CopilotKit agent. By the end of this page it answers messages in
+a real chat thread through the Intelligence adapter.
+
+<Steps>
+<Step>
+### Install
+
+```bash
+npm install @copilotkit/channels @copilotkit/runtime @tanstack/ai @tanstack/ai-openai
+```
+</Step>
+
+<Step>
+### Turn on JSX
+
+Replies render through components, so point the JSX runtime at the UI library.
+See [the UI library](/channels/ui-library) for what this unlocks.
+
+```jsonc title="tsconfig.json"
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "@copilotkit/channels"
+  }
+}
+```
+</Step>
+
+<Step>
+### Create a channel in the dashboard
+
+In the Intelligence dashboard, create a channel and attach a platform
+(Slack, Teams, and so on). Note the channel **name**, you will pass the same
+name in code. Copy your project **runtime API key** (`cpk-...`).
+
+See [Intelligence Platform](/premium/intelligence-platform) for the dashboard
+walkthrough and per-platform install links.
+</Step>
+
+<Step>
+### Set the environment
+
+The Intelligence adapter reads the first two. No platform tokens live in your
+app. `OPENAI_API_KEY` powers the agent's model.
+
+```bash
+COPILOTKIT_INTELLIGENCE_URL=https://your-intelligence-url
+COPILOTKIT_API_KEY=cpk-...
+OPENAI_API_KEY=sk-...
+```
+</Step>
+
+<Step>
+### Define the agent
+
+The agent is the brain. Build it in TanStack factory mode: you own the LLM
+call with TanStack AI's `chat()`, and the Built-in Agent turns its stream into
+the events the channel renders.
+
+```ts title="agent.ts"
+import { BuiltInAgent, convertInputToTanStackAI } from "@copilotkit/runtime/v2";
+import { chat } from "@tanstack/ai";
+import { openaiText } from "@tanstack/ai-openai";
+
+const SYSTEM_PROMPT = "You are a helpful support assistant. Keep replies short.";
+
+export const agent = new BuiltInAgent({
+  type: "tanstack",
+  factory: (ctx) => {
+    // Turn the run input into TanStack AI messages, system prompts, and the
+    // channel tools forwarded on this turn.
+    const { messages, systemPrompts, tools } = convertInputToTanStackAI(ctx.input);
+
+    return chat({
+      adapter: openaiText("gpt-5.5"),
+      messages,
+      systemPrompts: [SYSTEM_PROMPT, ...systemPrompts],
+      tools,
+      abortController: ctx.abortController,
+    });
+  },
+});
+```
+</Step>
+
+<Step>
+### Write the bot
+
+```ts title="bot.ts"
+import { createChannel } from "@copilotkit/channels";
+import { intelligenceAdapter } from "@copilotkit/channels/intelligence";
+import { agent } from "./agent";
+
+const channel = createChannel({
+  // Must match the channel name you created in the dashboard.
+  name: "support-bot",
+  agent,
+  adapters: [intelligenceAdapter()],
+});
+
+// Intelligence only delivers turns your bot should answer (a mention or a
+// DM), so run the agent on each delivered message.
+channel.onMessage(async ({ thread, message }) => {
+  await thread.runAgent({ prompt: message.text });
+});
+
+await channel.start();
+console.log("bot listening");
+```
+</Step>
+
+<Step>
+### Run it
+
+```bash
+npx tsx bot.ts
+```
+
+Message the bot in your chat app. It replies in the thread.
+</Step>
+</Steps>
+
+<Callout type="info" title="Keep the process alive">
+The managed delivery loop polls in the background with timers that do not, on
+their own, hold the process open. If your bot exits right after
+`channel.start()`, add a keep-alive and clean up on shutdown:
+
+```ts
+const keepAlive = setInterval(() => {}, 1 << 30);
+
+const shutdown = async () => {
+  clearInterval(keepAlive);
+  await channel.stop();
+  process.exit(0);
+};
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+```
+</Callout>
+
+## What `thread` gives you
+
+`onMessage` hands you a `thread` and the incoming `message`.
+
+```ts
+channel.onMessage(async ({ thread, message }) => {
+  message.text;        // the user's text
+  message.user;        // { id, name?, handle?, email? }
+  thread.platform;     // "slack" | "teams" | ...
+
+  await thread.post("a plain text reply");
+  await thread.runAgent({ prompt: message.text });
+});
+```
+
+`thread.runAgent` runs your agent and streams its reply into the thread.
+`thread.post` sends a message yourself, without the agent.
+
+## Next steps
+
+<Cards>
+  <Card title="UI library" href="/channels/ui-library" description="Reply with cards and buttons, not just text." />
+  <Card title="Interactive flows" href="/channels/interactive" description="Approval gates and reaction handlers." />
+  <Card title="Commands and reactions" href="/channels/commands-and-reactions" description="Slash commands and reaction handlers." />
+  <Card title="Files and multimodality" href="/channels/files-and-multimodality" description="Accept images and files." />
+</Cards>

--- a/showcase/shell-docs/src/content/docs/channels/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/quickstart.mdx
@@ -5,7 +5,14 @@ description: Build a bot that answers messages in a chat app, end to end.
 ---
 
 You have a CopilotKit agent. By the end of this page it answers messages in
-a real chat thread through the Intelligence adapter.
+a real chat thread, run by the CopilotKit runtime.
+
+<Callout type="info" title="You need a CopilotKit Intelligence key">
+Every channel runs through the Intelligence runtime, so a CopilotKit
+Intelligence key is required to run one — for both managed and direct channels.
+A free tier is available. Grab a project key (`cpk-...`) from the Intelligence
+dashboard before you start.
+</Callout>
 
 <Steps>
 <Step>
@@ -46,8 +53,8 @@ walkthrough and per-platform install links.
 <Step>
 ### Set the environment
 
-The Intelligence adapter reads the first two. No platform tokens live in your
-app. `OPENAI_API_KEY` powers the agent's model.
+The Intelligence runtime reads the first two. For a managed channel no platform
+tokens live in your app. `OPENAI_API_KEY` powers the agent's model.
 
 ```bash
 COPILOTKIT_INTELLIGENCE_URL=https://your-intelligence-url
@@ -94,14 +101,15 @@ export const agent = new BuiltInAgent({
 
 ```ts title="bot.ts"
 import { createChannel } from "@copilotkit/channels";
-import { intelligenceAdapter } from "@copilotkit/channels/intelligence";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 import { agent } from "./agent";
 
+// A managed channel: Intelligence hosts the platform transport, so it takes no
+// adapter. The name must match the channel you created in the dashboard.
 const channel = createChannel({
-  // Must match the channel name you created in the dashboard.
   name: "support-bot",
   agent,
-  adapters: [intelligenceAdapter()],
 });
 
 // Intelligence only delivers turns your bot should answer (a mention or a
@@ -110,7 +118,24 @@ channel.onMessage(async ({ thread, message }) => {
   await thread.runAgent({ prompt: message.text });
 });
 
-await channel.start();
+// The runtime owns the channel. Declare it here, mount the listener, and
+// `ready()` activates it. The Intelligence key (free tier available) is what
+// lets the runtime run any channel.
+const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
+const intelligence = new CopilotKitIntelligence({
+  apiUrl,
+  wsUrl: apiUrl.replace(/^http/, "ws"), // ws base derives from the api base
+  apiKey: process.env.COPILOTKIT_API_KEY!,
+});
+
+const runtime = new CopilotRuntime({
+  intelligence,
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+  channels: [channel],
+});
+
+const listener = createCopilotNodeListener({ runtime });
+await listener.channels?.ready();
 console.log("bot listening");
 ```
 </Step>
@@ -126,17 +151,17 @@ Message the bot in your chat app. It replies in the thread.
 </Step>
 </Steps>
 
-<Callout type="info" title="Keep the process alive">
-The managed delivery loop polls in the background with timers that do not, on
-their own, hold the process open. If your bot exits right after
-`channel.start()`, add a keep-alive and clean up on shutdown:
+<Callout type="info" title="Keep the process alive and shut down cleanly">
+The listener is a request handler, so to hold the lifecycle-owning process open
+mount it on a server, and stop the channels on shutdown:
 
 ```ts
-const keepAlive = setInterval(() => {}, 1 << 30);
+import { createServer } from "node:http";
+
+createServer(listener).listen(3000);
 
 const shutdown = async () => {
-  clearInterval(keepAlive);
-  await channel.stop();
+  await listener.channels?.stop();
   process.exit(0);
 };
 process.on("SIGINT", shutdown);

--- a/showcase/shell-docs/src/content/docs/channels/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/quickstart.mdx
@@ -129,6 +129,7 @@ const intelligence = new CopilotKitIntelligence({
 });
 
 const runtime = new CopilotRuntime({
+  agents: {},
   intelligence,
   identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   channels: [channel],

--- a/showcase/shell-docs/src/content/docs/channels/reference/callbacks.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/reference/callbacks.mdx
@@ -1,0 +1,142 @@
+---
+title: JSX Callbacks
+icon: "lucide/MousePointerClick"
+description: The handlers a component can carry, what they receive, and how the click resolves.
+---
+
+Interactive components carry a callback. When the user clicks a button, picks
+from a select, submits an input, or reacts to a message, your handler runs with
+the thread and the interaction in hand.
+
+This is the reference. For the walkthrough, see [the UI library](/channels/ui-library).
+
+## Which component takes which callback
+
+| Component | Prop | Handler type | Fires when |
+| --- | --- | --- | --- |
+| `Button` | `onClick` | `ClickHandler<TValue>` | the button is clicked |
+| `Select` | `onSelect` | `ClickHandler<string \| string[]>` | an option is chosen (`multi` gives an array) |
+| `Input` | `onSubmit` | `ClickHandler<string>` | the input is submitted |
+| `Message` | `onReaction` | `MessageReactionHandler` | a user reacts to the message |
+
+## ClickHandler
+
+`onClick`, `onSelect`, and `onSubmit` are all a `ClickHandler`. It receives one
+`InteractionContext`:
+
+```ts
+type ClickHandler<TValue = unknown> = (ctx: InteractionContext<TValue>) => void | Promise<void>;
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `thread` | `Thread` | The conversation. Post, update, run the agent, block on a choice. See the [Thread API](/channels/reference/thread). |
+| `message` | `IncomingMessage` | The message the control lives on. `message.ref` updates that message in place. |
+| `action.id` | `string` | The control's opaque id. |
+| `action.value` | `TValue` | The `value` the control carried, typed by `TValue`. |
+| `values` | `Record<string, unknown>` | All input values submitted with this interaction. |
+| `user` | `PlatformUser` | Who interacted. |
+| `platform` | `string` | The platform the interaction came from. |
+| `openModal` | `(view: ModalView) => Promise<{ ok, error? }>` | Open a modal. Capability-gated. On Discord, call it before any long work (the trigger expires in ~3s). |
+
+### The value round-trip
+
+A control's `value` prop is echoed back on `action.value`, typed by `TValue`.
+That is how you tell clicks apart without separate ids:
+
+```tsx
+<Button
+  value={{ choice: "approve" }}
+  onClick={async ({ thread, message, action }) => {
+    action.value; // { choice: "approve" }
+    await thread.update(message.ref, "Approved.");
+  }}
+>
+  Approve
+</Button>
+```
+
+### Button, Select, Input
+
+```tsx
+import { Actions, Button, Select, Input } from "@copilotkit/channels/ui";
+
+<Actions>
+  <Button
+    value={{ id: 42 }}
+    style="primary"
+    onClick={async ({ thread, action }) => {
+      await thread.post(`Picked ${action.value.id}`);
+    }}
+  >
+    Choose
+  </Button>
+
+  <Select
+    placeholder="Priority"
+    options={[
+      { label: "High", value: "high" },
+      { label: "Low", value: "low" },
+    ]}
+    onSelect={async ({ thread, action }) => {
+      await thread.post(`Priority: ${action.value}`);
+    }}
+  />
+
+  <Input
+    placeholder="Add a note"
+    onSubmit={async ({ thread, action }) => {
+      await thread.post(`Note: ${action.value}`);
+    }}
+  />
+</Actions>;
+```
+
+`Button` also takes `url` (a link button, which ignores `onClick`/`value`) and
+`style: "primary" | "danger"`. `Select` takes `multi` for multi-select (where
+`action.value` is a `string[]`).
+
+## MessageReactionHandler
+
+`<Message onReaction>` is different: it takes the emoji first, then the full
+reaction.
+
+```ts
+type MessageReactionHandler = (emoji: EmojiValue, reaction: MessageReaction) => void | Promise<void>;
+```
+
+| `reaction` field | Type | Description |
+| --- | --- | --- |
+| `emoji` | `EmojiValue` | Canonical name when recognized, else the raw token. Same as the first argument. |
+| `rawEmoji` | `string` | Platform-native token. |
+| `added` | `boolean` | `true` = added, `false` = removed. |
+| `user` | `PlatformUser?` | The reacting user, when reported. |
+| `messageId` | `string` | Id of the reacted message. |
+| `thread` | `Thread` | Post back, run the agent, block on a choice, react. |
+| `messageRef` | `MessageRef` | Pass to `thread.update(messageRef, ui)` to redraw this message. |
+
+```tsx
+import { Message, Section } from "@copilotkit/channels/ui";
+
+<Message
+  onReaction={async (emoji, reaction) => {
+    if (!reaction.added || emoji !== "thumbs_up") return;
+    await reaction.thread.post(`Thanks, ${reaction.user?.name ?? "friend"}.`);
+  }}
+>
+  <Section>{"React with a thumbs up."}</Section>
+</Message>;
+```
+
+See [reactions](/channels/interactive/reactions) for more, and [global
+reactions](/channels/commands-and-reactions#global-reactions) for reacting to
+any message rather than a specific card.
+
+## Handlers must survive a restart
+
+<Callout type="warn">
+A click or reaction can arrive after your process restarts, when the in-memory
+handler is gone. Register every component that carries a callback in
+`createChannel({ components })` so the handler is rebuilt from the durable
+snapshot. See [the UI library](/channels/ui-library#register-components).
+</Callout>

--- a/showcase/shell-docs/src/content/docs/channels/reference/channel.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/reference/channel.mdx
@@ -1,0 +1,139 @@
+---
+title: Channel API
+icon: "lucide/Antenna"
+description: createChannel options, properties, event handlers, and lifecycle methods.
+---
+
+`createChannel(options)` returns a `Channel`. This page lists every option it
+takes and every method it exposes.
+
+```ts
+import { createChannel } from "@copilotkit/channels";
+
+const channel = createChannel({ name, agent, adapters });
+```
+
+## createChannel options
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | Project-unique Intelligence channel name. Required for managed channels, optional for direct adapters. |
+| `agent` | `AbstractAgent \| (threadId: string) => AbstractAgent` | The agent, or a per-thread factory. |
+| `adapters` | `PlatformAdapter[]` | Adapters attached at construction. You can also add them later with `addAdapter`. |
+| `provider` | `"slack" \| "teams"` | Managed delivery provider for a no-adapter (Intelligence) channel. Defaults to `"slack"`. `"teams"` is SDK-ready but gated. |
+| `tools` | `ChannelTool[]` | Tools exposed to the agent. See [commands](/channels/commands-and-reactions) and the agent's own tools. |
+| `context` | `ContextEntry[]` | `{ description, value }` entries forwarded to the agent each turn. |
+| `components` | `ChannelComponent[]` | Named JSX components. Register them so their handlers survive a restart. See [the UI library](/channels/ui-library). |
+| `commands` | `ChannelCommand[]` | Slash commands. Forwarded to adapters that support them. |
+| `store` | `StoreConfig` | Persistence, per-thread state, and cross-platform history (see below). |
+
+### store options
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `state` | `StandardSchema` | Schema for per-thread state. Types `thread.state()`/`setState()` and validates on write. See [configuration](/channels/configuration#per-thread-state). |
+| `adapter` | `StateStore` | Durable persistence backend. See [Persistence](/channels/persistence). |
+| `identity`, `transcripts` | | Cross-platform history keyed by a stable identity. See [Transcripts](/channels/transcripts). |
+
+## Properties
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `name` | `string \| undefined` | The name from `createChannel({ name })`. |
+| `adapters` | `readonly PlatformAdapter[]` | Attached adapters (read-only snapshot). |
+| `provider` | `"slack" \| "teams" \| undefined` | Managed provider; `undefined` means the default (`"slack"`). |
+| `commandNames` | `string[]` | Declared slash-command names, normalized. |
+
+## Event handlers
+
+Register these before `start()`.
+
+### onMessage / onMention / onThreadStarted
+
+```ts
+channel.onMessage((ctx) => {});      // every delivered message
+channel.onMention((ctx) => {});      // messages that @mention the bot
+channel.onThreadStarted((ctx) => {}); // a conversation surface opened (e.g. Slack assistant pane)
+```
+
+`onMessage` and `onMention` hand you `{ thread, message }`. `message` is an
+`IncomingMessage` (`text`, `user`, `ref`, `platform`, `contentParts?`). See the
+[Thread API](/channels/reference/thread). `onThreadStarted` gives `{ thread, user? }`.
+
+### onReaction
+
+```ts
+channel.onReaction((evt) => {});                // any reaction, any message
+channel.onReaction("refresh", (evt) => {});     // only this emoji
+channel.onReaction(["fire", "tada"], (evt) => {}); // any of these
+```
+
+The `ReactionEvent` passed in:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `emoji` | `EmojiValue` | Canonical name when recognized, else the raw token. |
+| `rawEmoji` | `string` | Platform-native token. |
+| `added` | `boolean` | `true` = added, `false` = removed. |
+| `user` | `PlatformUser?` | The reacting user, when reported. |
+| `messageId` | `string` | Id of the reacted message. |
+| `messageRef` | `MessageRef` | Pass to `thread.update(messageRef, ui)` to redraw it. |
+| `thread` | `Thread` | Post back, run the agent, and so on. |
+| `adapter` | `PlatformAdapter` | The adapter that delivered it. |
+| `raw` | `unknown` | The raw platform payload. |
+
+See [global reactions](/channels/commands-and-reactions#global-reactions).
+
+### onCommand
+
+```ts
+channel.onCommand(defineChannelCommand({ name, handler })); // full command
+channel.onCommand("ask", (ctx) => {});                      // free-text by name
+```
+
+Passing `commands` to `createChannel` does the same registration. See
+[commands](/channels/commands-and-reactions).
+
+### onInteraction
+
+```ts
+channel.onInteraction<{ id: string }>("approve", (ctx) => {
+  ctx.action.value; // typed as { id: string }
+});
+```
+
+Handle clicks on a specific action `id`. The context is the same
+`InteractionContext` a JSX `onClick` receives. Most of the time you use an
+inline `onClick` on the [component](/channels/reference/callbacks) instead.
+
+### onInterrupt
+
+```ts
+channel.onInterrupt<{ question: string }>("ask", ({ payload, thread }) => {});
+```
+
+Handle an agent interrupt (an `on_interrupt` custom event). `payload` is the
+event's value, typed by the type argument.
+
+### onModalSubmit / onModalClose
+
+```ts
+channel.onModalSubmit("file-issue", (evt) => {
+  evt.values;   // submitted field values
+  // return { errors } to keep the modal open
+});
+channel.onModalClose("file-issue", (evt) => {});
+```
+
+For platforms with modal/dialog support. Open a modal from an interaction with
+`ctx.openModal(view)`.
+
+## Registration and lifecycle
+
+| Method | Signature | Description |
+| --- | --- | --- |
+| `tool` | `tool(t: ChannelTool): void` | Register one tool (same as an entry in `tools`). |
+| `addAdapter` | `addAdapter(a: PlatformAdapter): void` | Attach an adapter. Throws if called after `start()`. |
+| `start` | `start(): Promise<void>` | Start all attached adapters and begin handling events. |
+| `stop` | `stop(): Promise<void>` | Tear everything down. |
+| `transcripts` | `Transcripts` | Cross-platform transcript store. See [Transcripts](/channels/transcripts). |

--- a/showcase/shell-docs/src/content/docs/channels/reference/channel.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/reference/channel.mdx
@@ -17,9 +17,9 @@ const channel = createChannel({ name, agent, adapters });
 
 | Option | Type | Description |
 | --- | --- | --- |
-| `name` | `string` | Project-unique Intelligence channel name. Required for managed channels, optional for direct adapters. |
+| `name` | `string` | Project-unique channel name. Required: the runtime keys the channel's lifecycle by it (and, for a managed channel, ties it to the dashboard setup). |
 | `agent` | `AbstractAgent \| (threadId: string) => AbstractAgent` | The agent, or a per-thread factory. |
-| `adapters` | `PlatformAdapter[]` | Adapters attached at construction. You can also add them later with `addAdapter`. |
+| `adapters` | `PlatformAdapter[]` | Direct platform adapters attached at construction. The runtime starts them when it activates the channel. |
 | `provider` | `"slack" \| "teams"` | Managed delivery provider for a no-adapter (Intelligence) channel. Defaults to `"slack"`. `"teams"` is SDK-ready but gated. |
 | `tools` | `ChannelTool[]` | Tools exposed to the agent. See [commands](/channels/commands-and-reactions) and the agent's own tools. |
 | `context` | `ContextEntry[]` | `{ description, value }` entries forwarded to the agent each turn. |
@@ -46,7 +46,8 @@ const channel = createChannel({ name, agent, adapters });
 
 ## Event handlers
 
-Register these before `start()`.
+Register these before the runtime activates the channel (before
+`handler.channels.ready()`).
 
 ### onMessage / onMention / onThreadStarted
 
@@ -130,10 +131,13 @@ For platforms with modal/dialog support. Open a modal from an interaction with
 
 ## Registration and lifecycle
 
+A channel has no public `start()`/`stop()`. Lifecycle is owned by the runtime:
+declare the channel on `new CopilotRuntime({ channels: [channel] })`, then drive
+it through the handler's `channels` control — `handler.channels.ready()` to
+activate and `handler.channels.stop()` to tear down. See the
+[Quickstart](/channels/quickstart) for the full run pattern.
+
 | Method | Signature | Description |
 | --- | --- | --- |
 | `tool` | `tool(t: ChannelTool): void` | Register one tool (same as an entry in `tools`). |
-| `addAdapter` | `addAdapter(a: PlatformAdapter): void` | Attach an adapter. Throws if called after `start()`. |
-| `start` | `start(): Promise<void>` | Start all attached adapters and begin handling events. |
-| `stop` | `stop(): Promise<void>` | Tear everything down. |
 | `transcripts` | `Transcripts` | Cross-platform transcript store. See [Transcripts](/channels/transcripts). |

--- a/showcase/shell-docs/src/content/docs/channels/reference/meta.json
+++ b/showcase/shell-docs/src/content/docs/channels/reference/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "API reference",
+  "icon": "lucide/Braces",
+  "pages": ["channel", "thread", "callbacks"]
+}

--- a/showcase/shell-docs/src/content/docs/channels/reference/thread.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/reference/thread.mdx
@@ -1,0 +1,180 @@
+---
+title: Thread API
+icon: "lucide/MessageSquareText"
+description: Every method on the thread your handlers receive: reply, run the agent, files, reactions, state.
+---
+
+Every handler (`onMessage`, `onReaction`, a tool, a JSX `onClick`) gets a
+`thread`. It is the conversation: post to it, run the agent, read history,
+persist state.
+
+```ts
+channel.onMessage(async ({ thread, message }) => {
+  await thread.post("hi");
+  await thread.runAgent({ prompt: message.text });
+});
+```
+
+<Callout type="info" title="Capability-gated methods">
+Not every platform supports every method (reactions, ephemeral messages,
+titles, reading history). Those methods return `{ ok: false }` or `undefined`
+on a surface that does not support them, rather than throwing. Check the
+result when it matters.
+</Callout>
+
+## Properties
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `platform` | `string` | The platform this thread is on: `"slack"`, `"teams"`, and so on. |
+| `conversationKey` | `string` | Stable key identifying this conversation. |
+| `supportsBlockingChoice` | `boolean?` | `true`/`undefined`: `awaitChoice` can block for a click. `false`: use post-and-resume (the managed path). |
+
+```ts
+if (thread.platform === "teams") {
+  // teams-specific formatting
+}
+if (thread.supportsBlockingChoice === false) {
+  // managed surface: post and resume instead of awaitChoice
+}
+```
+
+## Reply
+
+| Method | Signature | Description |
+| --- | --- | --- |
+| `post` | `post(ui: Renderable): Promise<MessageRef>` | Send a message. `ui` is a string or a JSX component. Returns a ref you can update. |
+| `update` | `update(ref: MessageRef, ui: Renderable): Promise<MessageRef>` | Replace a message you posted, in place. |
+| `delete` | `delete(ref: MessageRef): Promise<void>` | Remove a message you posted. |
+| `stream` | `stream(src: string \| AsyncIterable<string>): Promise<MessageRef>` | Post a message that fills in as the source yields. |
+| `postEphemeral` | `postEphemeral(user, ui, { fallbackToDM }): Promise<EphemeralResult \| null>` | Post a message only `user` sees. `fallbackToDM: true` DMs the user where ephemeral is unsupported; `false` resolves `null`. |
+
+```ts
+const ref = await thread.post("working on it...");
+await thread.update(ref, "done.");
+await thread.delete(ref);
+
+// stream text in as it is produced
+await thread.stream(tokenStream);
+
+// a reply only the caller sees
+await thread.postEphemeral(message.user, "psst, only you see this", {
+  fallbackToDM: true,
+});
+
+// escape hatch: a raw, platform-native payload (e.g. Slack Block Kit)
+await thread.post({ raw: [{ type: "divider" }] });
+```
+
+`post` and `update` accept a raw payload as an escape hatch when a component
+does not cover what a platform can do. See [the UI
+library](/channels/ui-library#escape-hatch-raw-payloads).
+
+## Run the agent
+
+| Method | Signature | Description |
+| --- | --- | --- |
+| `runAgent` | `runAgent(input?): Promise<MessageRef \| undefined>` | Run the agent and stream its reply into the thread. |
+| `resume` | `resume(value: unknown): Promise<MessageRef \| undefined>` | Resume a run waiting on a value (HITL). |
+
+`runAgent` input:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `prompt` | `string \| AgentContentPart[]` | A user message to inject. Use the array form for [files and images](/channels/files-and-multimodality). |
+| `context` | `ContextEntry[]` | Extra context for this run. |
+| `tools` | `ChannelTool[]` | Extra tools for this run. |
+| `transcript` | `boolean \| { limit?: number }` | Bridge cross-platform history for this run. See [Transcripts](/channels/transcripts). |
+
+```ts
+// inject a prompt plus per-turn context
+await thread.runAgent({
+  prompt: message.text,
+  context: [{ description: "Requesting user", value: message.user.name ?? "" }],
+});
+
+// resume a run that paused for a human answer
+await thread.resume({ approved: true });
+```
+
+## Files
+
+| Method | Signature | Description |
+| --- | --- | --- |
+| `postFile` | `postFile({ bytes, filename, title?, altText? }): Promise<{ ok, fileId?, error? }>` | Send a file. `bytes` is a `Uint8Array`. |
+
+```ts
+await thread.postFile({ bytes: png, filename: "chart.png", title: "Revenue" });
+```
+
+## Human-in-the-loop
+
+| Method | Signature | Description |
+| --- | --- | --- |
+| `awaitChoice` | `awaitChoice<T>(ui: Renderable): Promise<T>` | Post a picker and block until a click resolves to the button's `value`. Only on surfaces where `supportsBlockingChoice` is not `false`. |
+
+```ts
+const { confirmed } = await thread.awaitChoice<{ confirmed: boolean }>(
+  <ConfirmCard />,
+);
+if (confirmed) await doTheWrite();
+```
+
+See [human-in-the-loop](/channels/interactive/human-in-the-loop) for the
+managed post-and-resume pattern.
+
+## Reactions
+
+| Method | Signature | Description |
+| --- | --- | --- |
+| `react` | `react(ref: MessageRef, emoji: EmojiValue): Promise<{ ok, error? }>` | Add an emoji reaction to a message. |
+| `unreact` | `unreact(ref: MessageRef, emoji: EmojiValue): Promise<{ ok, error? }>` | Remove the bot's reaction. |
+
+```ts
+await thread.react(message.ref, "eyes"); // 👀 acknowledge
+// ...work...
+await thread.unreact(message.ref, "eyes");
+await thread.react(message.ref, "white_check_mark"); // ✅ done
+```
+
+## Read the conversation
+
+| Method | Signature | Description |
+| --- | --- | --- |
+| `getMessages` | `getMessages(): Promise<ThreadMessage[]>` | The conversation's messages. `[]` when the adapter can't read history. |
+| `lookupUser` | `lookupUser(query: string): Promise<PlatformUser \| undefined>` | Resolve a user by free-form query. `undefined` when unsupported. |
+
+```ts
+const history = await thread.getMessages();
+const user = await thread.lookupUser("alex@acme.com");
+```
+
+## Per-thread state
+
+| Method | Signature | Description |
+| --- | --- | --- |
+| `setState` | `setState<T>(v: T): Promise<void>` | Persist arbitrary per-thread state (e.g. a workflow step). Typed and validated when `store.state` is set. |
+| `state` | `state<T>(): Promise<T \| undefined>` | Read back what `setState` wrote. |
+
+```ts
+await thread.setState({ step: "awaiting_approval" });
+const { step } = (await thread.state<{ step: string }>()) ?? {};
+```
+
+## Conversation surface
+
+| Method | Signature | Description |
+| --- | --- | --- |
+| `setSuggestedPrompts` | `setSuggestedPrompts(prompts, opts?): Promise<{ ok, error? }>` | Pin suggested prompts (e.g. the Slack assistant pane). |
+| `setTitle` | `setTitle(title: string): Promise<{ ok, error? }>` | Name the conversation. |
+| `subscribe` / `unsubscribe` | `(): Promise<void>` | Record or drop a subscription for this conversation. |
+| `isSubscribed` | `(): Promise<boolean>` | Whether this conversation is subscribed. |
+
+```ts
+await thread.setTitle("Incident #4213");
+await thread.setSuggestedPrompts([
+  { title: "Summarize", message: "Summarize this thread" },
+  { title: "File it", message: "File a Linear issue for this" },
+]);
+await thread.subscribe();
+```

--- a/showcase/shell-docs/src/content/docs/channels/tools.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/tools.mdx
@@ -48,7 +48,6 @@ Register tools on the channel:
 const channel = createChannel({
   name: "support-bot",
   agent,
-  adapters: [intelligenceAdapter()],
   tools: [issueCard],
 });
 
@@ -110,7 +109,6 @@ rely on: app identity, policy, formatting rules, anything stable.
 const channel = createChannel({
   name: "support-bot",
   agent,
-  adapters: [intelligenceAdapter()],
   context: [
     { description: "Assistant policy", value: "Be concise. Never share secrets." },
     { description: "Product", value: "Acme Cloud, a managed hosting platform." },

--- a/showcase/shell-docs/src/content/docs/channels/tools.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/tools.mdx
@@ -1,0 +1,155 @@
+---
+title: Tools and Context
+icon: "lucide/Wrench"
+description: Give the agent channel-level tools it can call, and context it sees every turn.
+---
+
+Two things you configure on the channel shape what the agent can do:
+
+- **Tools** the agent can call, defined with `defineChannelTool`.
+- **Context** the agent sees every turn, as `{ description, value }` entries.
+
+The channel forwards both to the agent on each run, alongside the agent's own
+tools and any [MCP servers](/channels/mcp).
+
+## Define a tool
+
+A tool is a name, a description, a parameters schema (Zod or any Standard
+Schema), and a handler. The handler's `args` are typed from the schema.
+
+```tsx
+import { defineChannelTool } from "@copilotkit/channels";
+import { z } from "zod";
+import { Message, Header, Section } from "@copilotkit/channels/ui";
+
+export const issueCard = defineChannelTool({
+  name: "issue_card",
+  description: "Show a single Linear issue as a card.",
+  parameters: z.object({
+    title: z.string(),
+    status: z.string(),
+    url: z.string(),
+  }),
+  async handler({ title, status, url }, { thread }) {
+    await thread.post(
+      <Message accent="#5E6AD2">
+        <Header>{title}</Header>
+        <Section>{`Status: ${status}`}</Section>
+      </Message>,
+    );
+    return "Displayed the issue card to the user.";
+  },
+});
+```
+
+Register tools on the channel:
+
+```ts
+const channel = createChannel({
+  name: "support-bot",
+  agent,
+  adapters: [intelligenceAdapter()],
+  tools: [issueCard],
+});
+
+// or add one later
+channel.tool(issueCard);
+```
+
+## The handler context
+
+The second argument gives you the conversation and the caller.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `thread` | `Thread` | Post UI, run the agent, block on a choice. See the [Thread API](/channels/reference/thread). |
+| `message` | `IncomingMessage?` | The message that triggered this turn, when there is one. |
+| `user` | `PlatformUser?` | The requesting user, when known. |
+| `platform` | `string` | The platform the call came from. |
+| `signal` | `AbortSignal?` | Aborts if the run is superseded or cancelled. |
+
+## What to return
+
+The return value is read by the **model**, not shown to the user. The SDK
+serializes it for you.
+
+| Return | The model sees |
+| --- | --- |
+| a `string` | the string as-is |
+| `null` / `undefined` | an empty string |
+| any object or array | the value, JSON-stringified automatically |
+
+Return something meaningful:
+
+- A **render tool** (one that posts a card with `thread.post`) should return a
+  short confirmation like `"Displayed the issue card."`, so the model gives a
+  brief acknowledgement instead of restating the card as text.
+- A **data tool** should return the raw object or array. Do not hand-stringify
+  it, and do not return boilerplate like `{ ok: true }`.
+- A **failure** should return the actual error text, so the model can repair
+  and retry.
+
+```ts
+export const listOpenIssues = defineChannelTool({
+  name: "list_open_issues",
+  description: "List the open issues for a team.",
+  parameters: z.object({ team: z.string() }),
+  async handler({ team }) {
+    const issues = await api.issues({ team, state: "open" });
+    return issues; // returned raw; the SDK serializes it for the model
+  },
+});
+```
+
+## Context
+
+Context entries are forwarded to the agent every turn as background it can
+rely on: app identity, policy, formatting rules, anything stable.
+
+```ts
+const channel = createChannel({
+  name: "support-bot",
+  agent,
+  adapters: [intelligenceAdapter()],
+  context: [
+    { description: "Assistant policy", value: "Be concise. Never share secrets." },
+    { description: "Product", value: "Acme Cloud, a managed hosting platform." },
+  ],
+});
+```
+
+## Per-run tools and context
+
+Pass tools or context for a single run through `thread.runAgent`. They add to
+the channel-level ones for that turn only.
+
+```ts
+channel.onMessage(async ({ thread, message }) => {
+  await thread.runAgent({
+    prompt: message.text,
+    context: [{ description: "Requester", value: message.user.email ?? "" }],
+    tools: [oneOffTool],
+  });
+});
+```
+
+## How tools reach the agent
+
+The channel's tools and context travel in the run input. In [TanStack factory
+mode](/channels/quickstart), `convertInputToTanStackAI(ctx.input)` returns the
+tools as `tools` and folds context into `systemPrompts`, which you hand to
+`chat()`. So the model can call your channel tools next to the agent's own
+tools and MCP:
+
+```ts
+factory: (ctx) => {
+  const { messages, systemPrompts, tools } = convertInputToTanStackAI(ctx.input);
+  return chat({
+    adapter: openaiText("gpt-5.5"),
+    messages,
+    systemPrompts,
+    tools, // your channel tools, forwarded here
+    abortController: ctx.abortController,
+  });
+};
+```

--- a/showcase/shell-docs/src/content/docs/channels/ui-library.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/ui-library.mdx
@@ -1,0 +1,176 @@
+---
+title: UI Library
+icon: "lucide/LayoutTemplate"
+description: Reply with UI, not plain text. Write it as JSX; it renders natively on every platform.
+---
+
+A reply does not have to be text. With channels you write a reply as a
+component, and it renders as native UI on the platform: a Slack Block Kit
+message, a Teams Adaptive Card, and so on. You write it once, as JSX.
+
+This is the default way to build replies. Set it up in the
+[Quickstart](/channels/quickstart), reach for it here, and see [interactive
+flows](/channels/interactive) when a component needs to drive the conversation.
+
+## Why JSX
+
+A chat reply is a small UI: a card, some buttons, a table. JSX is the natural
+way to describe that, and it buys you three things:
+
+- **Callbacks live with the markup.** A button's `onClick` sits on the button.
+  There is no separate action registry to wire up by hand.
+- **One tree, every platform.** The SDK renders the same component to each
+  platform's native format. You do not write Block Kit and Adaptive Cards
+  yourself.
+- **It is typed.** Component props and the payload your handler receives are
+  checked at compile time.
+
+For anything beyond a card, drop back to a string: `thread.post("hi")` still
+works.
+
+## Turn on JSX
+
+The UI library ships inside `@copilotkit/channels`, so there is nothing extra
+to install. Point the JSX runtime at it in your `tsconfig.json`:
+
+```jsonc title="tsconfig.json"
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "@copilotkit/channels"
+  }
+}
+```
+
+## Post a component
+
+Import the pieces from `@copilotkit/channels/ui` and post the tree.
+
+```tsx
+import { Message, Section, Actions, Button } from "@copilotkit/channels/ui";
+
+await thread.post(
+  <Message accent="#4F46E5">
+    <Section>{"Deploy to production?"}</Section>
+    <Actions>
+      <Button
+        value={{ go: true }}
+        style="primary"
+        onClick={async ({ thread }) => {
+          await thread.post("Deploying now.");
+        }}
+      >
+        Deploy
+      </Button>
+    </Actions>
+  </Message>,
+);
+```
+
+## The UI library
+
+| Component | Use |
+| --- | --- |
+| `Message` | The wrapper for one posted message. Takes an `accent` color and `onReaction`. |
+| `Header`, `Section`, `Context` | Title, body text, and muted footnote text. |
+| `Actions` | A row of interactive controls. |
+| `Button` | A click target. `onClick`, `value`, `url`, `style: "primary" \| "danger"`. |
+| `Select` | A dropdown. `onSelect`, `options`, `placeholder`, `multi`. |
+| `Input` | A text input. `onSubmit`, `placeholder`, `multiline`. |
+| `Image`, `Divider`, `Table`, `Chart`, `Markdown` | Display blocks. |
+
+## Callbacks
+
+`onClick`, `onSelect`, `onSubmit`, and `onReaction` all hand your function an
+interaction context with the `thread` and the `message` that was clicked. Use
+`message.ref` to repaint the message in place. For every field and handler
+type, see the [JSX callbacks reference](/channels/reference/callbacks).
+
+```tsx
+import { type InteractionContext } from "@copilotkit/channels/ui";
+
+<Button
+  value={{ id }}
+  onClick={async ({ thread, message }: InteractionContext) => {
+    await thread.update(
+      message.ref,
+      <Message>
+        <Header>{"Saved"}</Header>
+      </Message>,
+    );
+  }}
+>
+  Save
+</Button>;
+```
+
+## Register components
+
+<Callout type="warn" title="Register anything with a handler">
+A click can arrive minutes later, after your process has restarted, and the
+in-memory `onClick` is gone by then. Register every component that carries a
+handler in `createChannel({ components })` so the handler can be rebuilt from
+the durable snapshot. An unregistered card degrades to "action expired" after
+a restart.
+</Callout>
+
+Define the component as a named function and register it:
+
+```tsx
+import { createChannel } from "@copilotkit/channels";
+import { Message, Section, Actions, Button, type ChannelNode } from "@copilotkit/channels/ui";
+import { agent } from "./agent";
+
+function DeployCard(): ChannelNode {
+  return (
+    <Message accent="#4F46E5">
+      <Section>{"Deploy to production?"}</Section>
+      <Actions>
+        <Button value={{ go: true }} style="primary" onClick={onDeploy}>
+          Deploy
+        </Button>
+      </Actions>
+    </Message>
+  );
+}
+
+const channel = createChannel({
+  name: "release-bot",
+  agent,
+  adapters: [intelligenceAdapter()],
+  components: [DeployCard], // required for the click to resolve after a restart
+});
+
+// post it anywhere
+await thread.post(<DeployCard />);
+```
+
+## Escape hatch: raw payloads
+
+When a component does not cover something a platform can do, pass a raw,
+platform-native payload. It skips the renderer and goes straight to the
+adapter, so the shape is whatever that platform's API expects: Slack Block Kit
+blocks, a Teams Adaptive Card, and so on.
+
+```ts
+// Slack: raw Block Kit blocks, straight to the adapter
+await thread.post({
+  raw: [
+    { type: "section", text: { type: "mrkdwn", text: "*Raw* Block Kit here" } },
+  ],
+});
+```
+
+`thread.update(ref, { raw })` works the same way. Because a raw payload is
+tied to one platform, a bot that targets several platforms should prefer
+components, which render natively on each. Reach for `raw` only for a platform
+feature the components do not expose.
+
+## Advanced flows
+
+When a component should pause the agent or react to the user, see:
+
+<Cards>
+  <Card title="Human-in-the-loop" href="/channels/interactive/human-in-the-loop" description="Pause the agent for an approve or cancel decision." />
+  <Card title="Reactions" href="/channels/interactive/reactions" description="Run code when a user reacts to a card." />
+</Cards>

--- a/showcase/shell-docs/src/content/docs/channels/ui-library.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/ui-library.mdx
@@ -137,7 +137,6 @@ function DeployCard(): ChannelNode {
 const channel = createChannel({
   name: "release-bot",
   agent,
-  adapters: [intelligenceAdapter()],
   components: [DeployCard], // required for the click to resolve after a restart
 });
 


### PR DESCRIPTION
## What does this PR do?

Adds documentation for the **`@copilotkit/channels` SDK** — running a CopilotKit agent as a bot inside Slack, Teams, WhatsApp, Telegram, and Discord. New `---Channels---` nav group under `showcase/shell-docs`.

**Guides**
- Overview (agent + JSX + channel, end to end), Quickstart (TanStack factory agent on the Intelligence adapter)
- UI Library (JSX component rendering, callbacks, component registration, `{ raw }` escape hatch)
- Interactive flows: Human-in-the-loop (+ agent-initiated `onInterrupt`), Reactions (+ emoji helpers), Modals
- Commands & global reactions, Files & multimodality, MCP (agent-side), Channel configuration, Tools & context
- Platforms: overview of what Intelligence handles for you, plus per-adapter pages (Teams / WhatsApp / Slack / Telegram / Discord) with built-in tools/context

**API reference** (signatures pulled from the installed `0.2.1` type definitions): Channel, Thread, JSX callbacks.

All examples use the Intelligence adapter except the platform-specific pages, which use each platform's own adapter. Every internal link resolves; MDX validated.

## Related PRs and Issues

- N/A

## Checklist

- [x] I have read the Contribution Guide
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
