### PR TITLE
fix(channels): surface run_error on HTTP-fallback path and isolate ack failures (closes OSS-491)

### DIFF
--- a/packages/channels-intelligence/src/intelligence-adapter.test.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.test.ts
@@ -439,6 +439,52 @@ describe("intelligenceAdapter — HTTP-fallback run_error (OSS-491)", () => {
     // …and the fallback error-post path never runs on the realtime path.
     expect(egress.ops).toEqual([]);
   });
+
+  it("propagates a failure (drain rejects) when the fallback error post itself can't be emitted", async () => {
+    const source = new InMemoryDeliverySource();
+    // Egress that rejects every op — a transient/egress failure of the error
+    // post, distinct from the deterministic agent error that triggered it.
+    const failingEgress: EgressSink = {
+      emit: async () => ({ ok: false, code: "provider_rejected" }),
+    };
+    const adapter = intelligenceAdapter({ source, egress: failingEgress });
+    const renderer = adapter.createRunRenderer(target);
+    const sub = renderer.subscriber as unknown as Sub;
+
+    sub.onRunErrorEvent?.({ event: { message: "boom" } });
+
+    // The error post can't be delivered → the push chain records the error and
+    // drain() rejects, so dispatch() nacks (redelivers/retries) rather than
+    // acking a dropped error as success. This is the transient-failure escape
+    // hatch that keeps post-on-run_error from masking a real egress outage.
+    await expect(renderer.finish?.()).rejects.toThrow(/egress post failed/i);
+  });
+
+  it("flushes buffered partial text before the error post on a fallback run_error", async () => {
+    const source = new InMemoryDeliverySource();
+    const egress = new InMemoryEgressSink();
+    const adapter = intelligenceAdapter({ source, egress });
+    const renderer = adapter.createRunRenderer(target);
+    const sub = renderer.subscriber as unknown as Sub;
+
+    // Partial text that never received a text_end, then an error mid-stream.
+    sub.onTextMessageContentEvent?.({
+      event: { messageId: "m1", delta: "partial answer" },
+    });
+    sub.onRunErrorEvent?.({ event: { message: "died mid-stream" } });
+    await renderer.finish?.();
+
+    // Buffered partial output reaches the channel first, then the error post —
+    // natural reading order, no lost output, no duplicate.
+    const texts = egress.ops.map(
+      (o) =>
+        (o.op as unknown as { ir: { props: { value: string } }[] }).ir[0]!.props
+          .value,
+    );
+    expect(texts).toHaveLength(2);
+    expect(texts[0]).toBe("partial answer");
+    expect(texts[1]).toMatch(/error/i);
+  });
 });
 
 describe("intelligenceAdapter — ack failure isolation (OSS-491)", () => {

--- a/packages/channels-intelligence/src/intelligence-adapter.test.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.test.ts
@@ -11,6 +11,7 @@ import { intelligenceAdapter } from "./intelligence-adapter.js";
 import {
   InMemoryDeliverySource,
   InMemoryEgressSink,
+  InMemoryRenderEventSink,
 } from "./in-memory-transports.js";
 import { IntelligenceStateStore } from "./intelligence-state-store.js";
 import type { FetchLike } from "./http-transports.js";
@@ -339,6 +340,142 @@ describe("intelligenceAdapter — run renderer", () => {
 
     expect(egress.ops).toHaveLength(1);
     expect(egress.ops[0]!.op.kind).toBe("post");
+  });
+});
+
+describe("intelligenceAdapter — HTTP-fallback run_error (OSS-491)", () => {
+  const target = {
+    route: { r: 1 },
+    turnId: "t1",
+    deliveryId: "d1",
+  } as unknown as ReplyTarget;
+
+  type Sub = Record<string, (p: { event: Record<string, unknown> }) => unknown>;
+
+  it("surfaces a text-less run_error as a user-visible error post and logs it (fallback path)", async () => {
+    const source = new InMemoryDeliverySource();
+    const egress = new InMemoryEgressSink();
+    const logs: { msg: string; meta?: unknown }[] = [];
+    // Fallback path: no renderSink wired, so the ad-hoc plain-text sink runs and
+    // (before the fix) drops run_error — the run resolves and dispatch() acks a
+    // text-less turn as success (bot goes silent, nothing logged).
+    const adapter = intelligenceAdapter({
+      source,
+      egress,
+      config: { log: (msg, meta) => logs.push({ msg, meta }) },
+    });
+    const renderer = adapter.createRunRenderer(target);
+    const sub = renderer.subscriber as unknown as Sub;
+
+    // An agent-side failure (model error / tool crash) with no accompanying text.
+    sub.onRunErrorEvent?.({ event: { message: "model exploded" } });
+    await renderer.finish?.();
+
+    // (b) A user-visible error post is emitted rather than the turn completing
+    // silently. We post + log + ack (not nack): a run_error is frequently a
+    // deterministic agent failure and the Channel path reprocesses redeliveries
+    // (skipIngressDedup), so nacking would livelock.
+    expect(egress.ops).toHaveLength(1);
+    expect(egress.ops[0]!.op.kind).toBe("post");
+    const op = egress.ops[0]!.op as unknown as {
+      kind: string;
+      ir: { props: { value: string } }[];
+    };
+    expect(op.ir[0]!.props.value).toMatch(/error/i);
+    // (a) And the underlying error is logged so a dropped error is never invisible.
+    expect(logs.some((l) => /run_error/i.test(l.msg))).toBe(true);
+    expect(logs.some((l) => l.meta === "model exploded")).toBe(true);
+  });
+
+  it("emits run_started before a run_error that precedes any text or tool event", async () => {
+    const source = new InMemoryDeliverySource();
+    const renderSink = new InMemoryRenderEventSink();
+    // Realtime path: render frames are observable directly on the sink.
+    const adapter = intelligenceAdapter({
+      source,
+      egress: new InMemoryEgressSink(),
+      renderSink,
+    });
+    const renderer = adapter.createRunRenderer(target);
+    const sub = renderer.subscriber as unknown as Sub;
+
+    // Error before any text/tool event: it must still be preceded by run_started
+    // so the frame stream is a well-formed run lifecycle.
+    sub.onRunErrorEvent?.({ event: { message: "boom" } });
+    await renderer.finish?.();
+
+    const kinds = renderSink.frames.map((f) => f.event.kind);
+    expect(kinds[0]).toBe("run_started");
+    expect(kinds).toContain("run_error");
+    expect(kinds.indexOf("run_started")).toBeLessThan(
+      kinds.indexOf("run_error"),
+    );
+  });
+
+  it("renders run_error live on the realtime path (no user-visible error post) — unchanged", async () => {
+    const source = new InMemoryDeliverySource();
+    const egress = new InMemoryEgressSink();
+    const renderSink = new InMemoryRenderEventSink();
+    const adapter = intelligenceAdapter({ source, egress, renderSink });
+    const renderer = adapter.createRunRenderer(target);
+    const sub = renderer.subscriber as unknown as Sub;
+
+    sub.onTextMessageContentEvent?.({
+      event: { messageId: "m1", delta: "partial" },
+    });
+    await sub.onTextMessageEndEvent?.({ event: { messageId: "m1" } });
+    sub.onRunErrorEvent?.({ event: { message: "later boom" } });
+    await renderer.finish?.();
+
+    // The realtime path forwards run_error to the render sink (the Connector
+    // Outbox renders it live) — it is NOT converted into an egress error post…
+    expect(renderSink.frames.map((f) => f.event.kind)).toEqual([
+      "run_started",
+      "text_delta",
+      "text_end",
+      "run_error",
+      "finalize",
+    ]);
+    // …and the fallback error-post path never runs on the realtime path.
+    expect(egress.ops).toEqual([]);
+  });
+});
+
+describe("intelligenceAdapter — ack failure isolation (OSS-491)", () => {
+  it("does not nack or rerun a completed turn when ack() throws; logs the ack failure", async () => {
+    // A source whose ack() network call fails but whose turn processed fine.
+    class AckFailingSource extends InMemoryDeliverySource {
+      override async ack(): Promise<void> {
+        throw new Error("ack network down");
+      }
+    }
+    const source = new AckFailingSource();
+    const egress = new InMemoryEgressSink();
+    const logs: { msg: string; meta?: unknown }[] = [];
+    const bot = createChannel({
+      adapters: [
+        intelligenceAdapter({
+          source,
+          egress,
+          config: { log: (msg, meta) => logs.push({ msg, meta }) },
+        }),
+      ],
+      agent: () => new FakeAgent(),
+    });
+    let dispatchCount = 0;
+    bot.onMessage(async () => {
+      dispatchCount++;
+    });
+    await bot.ɵruntime.start();
+    await source.deliver(envelope({ deliveryId: "d9" }));
+
+    // The turn processed exactly once…
+    expect(dispatchCount).toBe(1);
+    // …and a failed ack must NOT be conflated with a turn failure: no nack
+    // (which, with skipIngressDedup, would redeliver and rerun the whole turn).
+    expect(source.nacked).toEqual([]);
+    // The ack failure is logged, not silently swallowed.
+    expect(logs.some((l) => /ack/i.test(l.msg))).toBe(true);
   });
 });
 

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -81,6 +81,16 @@ const textNode = (value: string): ChannelNode[] => [
 const INTERRUPTED_SUFFIX = "\n_(interrupted)_";
 
 /**
+ * User-visible reply posted when a run terminates with a `run_error` on the
+ * HTTP-fallback render path (no Connector Outbox). Intentionally generic: the
+ * raw error message may carry internal detail (stack fragments, upstream URLs),
+ * so it is logged via `config.log` for operators rather than shown to the end
+ * user in the channel.
+ */
+const RUN_ERROR_POST_TEXT =
+  "⚠️ The agent ran into an error and couldn't finish responding. Please try again.";
+
+/**
  * Supported configuration for the Intelligence-delivered Channels adapter.
  * Exposed to consumers through `@copilotkit/channels/intelligence`.
  */
@@ -354,6 +364,15 @@ export class IntelligenceAdapter implements PlatformAdapter {
     await this.source?.stop();
   }
 
+  /**
+   * Process one inbound delivery: run the turn, then ack/nack it. The turn and
+   * the ack are two DISTINCT phases with distinct failure semantics — a failed
+   * turn nacks (so the transport redelivers), but a failed ack must NOT, because
+   * the Channel path reprocesses redeliveries (`skipIngressDedup = true`), so
+   * nacking an already-processed turn would rerun it end to end (duplicate agent
+   * run / duplicate posts). Conflating the two (ack inside the turn's `try`) is
+   * the OSS-491 Finding-2 bug this split fixes.
+   */
   private async dispatch(env: ChannelIngressEnvelope): Promise<void> {
     // Reset the per-turn sequence so egress ids are deterministic across
     // redelivery (same turn id -> same op id sequence). Assumes the
@@ -364,10 +383,11 @@ export class IntelligenceAdapter implements PlatformAdapter {
       nextSeq: 0,
       needsFinalize: this.renderSink !== undefined,
     });
+    let turnProcessed = false;
     try {
       await this.dispatchTo(env);
       await this.finalizeRenderedTurn(env);
-      await this.requireSource().ack(env.deliveryId);
+      turnProcessed = true;
     } catch (err) {
       await this.requireSource().nack(
         env.deliveryId,
@@ -378,6 +398,19 @@ export class IntelligenceAdapter implements PlatformAdapter {
       // chain drained inside dispatchTo) so the Map can't grow unbounded over a
       // long-running Channel Bot. A redelivery re-seeds it at the top.
       this.renderState.delete(env.turnId);
+    }
+    if (!turnProcessed) return;
+    // Ack is its own phase: the turn already succeeded, so a failed ack is NOT a
+    // turn failure and must never nack (that would redeliver and rerun the whole
+    // turn). Log it and move on — the lease simply lapses and the transport may
+    // redeliver, but we never actively re-enqueue a completed turn.
+    try {
+      await this.requireSource().ack(env.deliveryId);
+    } catch (ackErr) {
+      this.opts.config?.log?.(
+        `intelligence ack failed for delivery ${env.deliveryId} after a successful turn; not nacking (turn already processed)`,
+        ackErr,
+      );
     }
   }
 
@@ -780,6 +813,22 @@ export class IntelligenceAdapter implements PlatformAdapter {
     const acc = new Map<string, string>();
     const order: string[] = [];
     let interrupted = false;
+    // Flush any message that never received a text_end (interrupt / run_error
+    // path) so buffered partial output still reaches the channel, then reset the
+    // buffers. Shared by `finalize` and `run_error`.
+    const flushPending = async (): Promise<void> => {
+      for (const id of order) {
+        const txt = acc.get(id) ?? "";
+        if (txt.length > 0) {
+          await emit({
+            kind: "post",
+            ir: textNode(interrupted ? txt + INTERRUPTED_SUFFIX : txt),
+          });
+        }
+      }
+      acc.clear();
+      order.length = 0;
+    };
     return {
       push: async (frame: RenderFrame): Promise<RenderAccepted> => {
         const e = frame.event;
@@ -798,22 +847,34 @@ export class IntelligenceAdapter implements PlatformAdapter {
           await emit({ kind: "post", ir: e.content });
         } else if (e.kind === "update") {
           await emit({ kind: "update", ref: e.ref, ir: e.content });
+        } else if (e.kind === "run_error") {
+          // On the realtime path this branch never runs (renderSinkFor returns
+          // the injected renderSink, and the Connector Outbox renders run_error
+          // live). Here, on the HTTP-fallback path, there is no Outbox: without
+          // this branch the error would be dropped, the run would resolve, and
+          // dispatch() would ack a text-less turn as success — the bot goes
+          // silent on every error with nothing logged (OSS-491 Finding 1).
+          //
+          // Surface it loudly: log the raw error for operators, flush any
+          // buffered partial text, then post a generic user-visible error. We
+          // post + log + ack (NOT nack): a run_error is frequently a
+          // deterministic agent failure (model error, tool crash), and the
+          // Channel path reprocesses redeliveries (skipIngressDedup), so nacking
+          // would livelock (redeliver → same failure → nack, forever). A genuine
+          // transient failure of the error POST itself still nacks, because
+          // `emit` throws on egress failure → the push chain rejects → drain()
+          // rejects → the delivery is nacked and retried.
+          this.opts.config?.log?.(
+            "intelligence run_error on HTTP-fallback render path",
+            e.message,
+          );
+          await flushPending();
+          await emit({ kind: "post", ir: textNode(RUN_ERROR_POST_TEXT) });
         } else if (e.kind === "finalize") {
-          // Flush any message that never received a text_end (interrupt path).
-          for (const id of order) {
-            const txt = acc.get(id) ?? "";
-            if (txt.length > 0) {
-              await emit({
-                kind: "post",
-                ir: textNode(interrupted ? txt + INTERRUPTED_SUFFIX : txt),
-              });
-            }
-          }
-          acc.clear();
-          order.length = 0;
+          await flushPending();
         }
-        // run_started / tool_start / tool_end / run_error: no provider-visible
-        // effect in the plain-text fallback (the Outbox renders those live).
+        // run_started / tool_start / tool_end: no provider-visible effect in the
+        // plain-text fallback (the realtime Outbox renders those live).
         return {
           idempotencyKey: `${frame.turnId}:${frame.slot}:${frame.seq}`,
           acceptance: "accepted",
@@ -941,6 +1002,10 @@ export class IntelligenceAdapter implements PlatformAdapter {
       },
       onRunErrorEvent({ event }) {
         if (aborted) return;
+        // Ensure a run_started precedes the error frame even when the run fails
+        // before any text/tool event — parity with the text/tool handlers, so
+        // the frame stream is always a well-formed run lifecycle (OSS-491).
+        ensureRunStarted();
         enqueue({
           kind: "run_error",
           message: event.message ?? "unknown error",


### PR DESCRIPTION
## What

Two SDK-side delivery / terminal-signal hardening fixes in the managed channels
adapter (`packages/channels-intelligence/src/intelligence-adapter.ts`), from the
pre-merge adversarial CR of #5972. Closes OSS-491.

## Scope correction (verified end-to-end during review)

The ticket originally framed Finding 1 as a live "self-hosted / no-Outbox"
silent-failure. That premise is **wrong**, and I traced the full render path to
confirm it:

- Every real deployment wires a render sink: the realtime gateway launcher passes
  one, and the config-free `intelligenceAdapter()` auto-wires `HttpRenderEventSink`
  in `start()`. On that path a `run_error` is POSTed to app-api's
  `/api/channels/deliveries/:id/render-events/accept` route, durably persisted,
  projected into canonical history as a `RUN_ERROR` terminal, **and** the Connector
  Outbox posts a user-visible `:warning: Agent error: …` to Slack.
- The Connector Outbox is the **same app-api binary** and runs in
  **self-hosted / composite** deployments too (gated only by the channels feature
  flag, not deployment mode). Self-hosted handles `run_error` identically — there
  is no server-side gap.
- The ad-hoc fallback sink in `renderSinkFor` — the code Finding 1 patches — is
  reached **only** when a consumer injects both `source` and `egress` but no
  `renderSink` (in-memory tests, and hypothetical BYO custom-transport
  integrations). It is not on any default or self-hosted path.

So Finding 1 is **defensive hardening of a fallback plus a lifecycle fix**, not a
HIGH-severity production silent-failure (severity retriaged to Low on the ticket).
Finding 2 is on the shared `dispatch()` path and does affect real deployments.

## Finding 1 — `run_error` on the ad-hoc HTTP-fallback sink

`renderSinkFor`'s ad-hoc plain-text sink (used only when no `renderSink` is wired)
had no `run_error` branch, so on that path a `run_error` was dropped, the run
resolved, and `dispatch()` acked a text-less turn as success — silent, nothing
logged. Now that sink logs the raw error via `config.log`, flushes any buffered
partial text, and posts a generic user-visible error. Posted + logged +
**acked, not nacked**: a `run_error` is frequently a deterministic agent failure
and the Channel path reprocesses redeliveries (`skipIngressDedup`), so nacking
would livelock. A genuine egress failure of the error post itself still nacks
(`emit` throws → `drain()` rejects).

Also — and this part **does** apply to the realtime path — `onRunErrorEvent` now
calls `ensureRunStarted()`, so a `run_error` that precedes any text/tool event
emits a preceding `run_started` (parity with the text/tool handlers; a well-formed
run lifecycle on both paths). This is the one intentional realtime-path change: a
text-less error now yields `[run_started, run_error, finalize]` instead of
`[run_error, finalize]`. `run_error` **rendering** is unchanged — still a frame to
the sink, never converted to an egress error post.

## Finding 2 — a failed `ack()` no longer nacks a completed turn

`ack()` sat inside the same `try` as `dispatchTo`, so an `ack()` network failure
fell into the catch and nacked an already-processed turn with a misleading reason;
with `skipIngressDedup`, the whole turn reran (duplicate agent run — re-calls the
model, re-runs tools — even though egress op-id dedupe catches duplicate posts).
Ack is now a distinct phase: a failed ack is logged, never nacked. This kills the
**spurious** rerun — notably the common "ack landed server-side but the response
was lost" case. A genuinely-failed ack still redelivers via lease expiry (inherent
to at-least-once, unavoidable); the turn already posted its reply, so only
delivery bookkeeping is delayed.

## Tests

TDD; the behavior tests were written failing first.

- Fallback text-less `run_error` ⇒ emits a user-visible error post **and** logs it.
- `run_error` before any text/tool event ⇒ `run_started` precedes it.
- Realtime path ⇒ `run_error` still forwarded to the render sink, **not** converted
  to an egress post (regression guard).
- Failed `ack()` on a successful turn ⇒ not nacked, no rerun, ack failure logged.
- Failed error-post emit on the fallback path ⇒ `drain()` rejects (nacks/retries).
- Buffered partial text flushed before the error post (order preserved).

## Verification

- `nx run @copilotkit/channels-intelligence:check-types` ✅
- `nx run @copilotkit/channels-intelligence:test` ✅ (all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
