### PR TITLE
docs(channels): clarify read_thread getMessages is text-only (OSS-488)

### DIFF
--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -201,10 +201,13 @@ export class IntelligenceAdapter implements PlatformAdapter {
    * Backs `thread.getMessages()` — e.g. the `read_thread` tool — on the managed
    * path by reading the reconstructed thread history via the transport's
    * `getHistory` and mapping it to the {@link ThreadMessage} shape. Without it
-   * the base `Thread.getMessages()` returns `[]`, so tools that inspect the
-   * thread (summaries, "what was in the image") see no messages even though
-   * history exists. Mirrors {@link conversationStore}'s seeding read; the
-   * `route` is the opaque {@link EgressRoute} threaded through {@link ReplyTarget}.
+   * the base `Thread.getMessages()` returns `[]`, so text-inspecting tools
+   * (e.g. `read_thread` summarizing prior turns) see no messages even though
+   * history exists. The mapping is text-only: image/file parts contribute no
+   * text, so `read_thread` never sees image *content* — that reaches the model
+   * only through {@link conversationStore}'s seeding of `agent.messages`.
+   * Mirrors that seeding read; the `route` is the opaque {@link EgressRoute}
+   * threaded through {@link ReplyTarget}.
    * Best-effort: a `getHistory` failure degrades to `[]` (no thrown error).
    */
   getMessages = async (target: ReplyTarget): Promise<ThreadMessage[]> => {


### PR DESCRIPTION
## What

Follow-up nit from [PR #5969](https://github.com/CopilotKit/CopilotKit/pull/5969) review ([OSS-488](https://linear.app/copilotkit/issue/OSS-488)). Fixes the `getMessages` JSDoc in `packages/channels-intelligence/src/intelligence-adapter.ts`, which oversold image support.

The comment cited *"what was in the image"* as a `read_thread` use case, but image/file parts contribute **no text** in this mapping — `read_thread` is text-only by design. Image *content* reaches the model only via `conversationStore`'s seeding of `agent.messages`. The comment now says so explicitly instead of implying `read_thread` can see image content.

Comment-only change — no runtime/API behavior change, so no changeset.

## Scope of OSS-488

The ticket listed three nits; this PR addresses the one still actionable:

- **#1 (double-space when joining content parts)** — ✅ already resolved on `main` (the `.filter(Boolean).join(" ")` fix + updated test landed via the OSS-476 CR round). Nothing to do.
- **#2 (JSDoc oversells image support)** — ✅ **this PR**.
- **#3 (duplicate `getHistory` fetch per turn)** — intentionally **deferred**. A per-turn memo would need turn-scoped caching with a clear-on-turn-start hook; without one it risks serving stale history — a correctness regression on something the ticket itself rates "acceptable for an on-demand tool." Not worth it here.

The **known limitation** (speakers collapse to `user`/`bot` because upstream `AgentMessage` carries no names) is unchanged and not actionable at this layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)