### PR TITLE
fix(ci): stop canary dispatches from false-paging the release notifier

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -733,9 +733,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # npm intent: a manual dispatch, or a merged release/publish/* PR.
-          # Computed purely from event-context expressions (no API needed).
-          NPM_INTENDED="${{ (github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/publish/'))) && 'true' || 'false' }}"
+          # npm intent: a STABLE manual dispatch (mode != prerelease — the default
+          # and the retry escape hatch both publish to npm), or a merged
+          # release/publish/* PR. A prerelease dispatch is a canary: it never pushes
+          # a tag, cuts a GH Release, or posts to Slack (the builder returns
+          # should_post=false, mirroring the `mode != 'prerelease'` guards on the
+          # publish/tag steps), so it is NOT stable-release intent and must never
+          # self-page on failure. Computed purely from event-context expressions
+          # (no API needed). Guarding on mode here is what stops a failed canary
+          # build (e.g. a stale lockfile on a canary/* branch) from tripping the
+          # notifier self-watchdog's best-effort Slack post below.
+          NPM_INTENDED="${{ ((github.event_name == 'workflow_dispatch' && inputs.mode != 'prerelease') || (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/publish/'))) && 'true' || 'false' }}"
           echo "npm_intended=$NPM_INTENDED" >> "$GITHUB_OUTPUT"
 
           # Python intent: a python_publish dispatch, OR a merged PR that changed


### PR DESCRIPTION
## What broke

Run [29605894890](https://github.com/CopilotKit/CopilotKit/actions/runs/29605894890) — a `workflow_dispatch` canary on branch `canary/mme-subagents-29605883024-1` — fired a red `🔴 CopilotKit release notifier failed — a release alert may have been swallowed` page to #engr. No release was actually missed (`npm latest` was `1.63.1`, published fine). It was a false page.

## Why it false-paged

The canary build died at `pnpm install --frozen-lockfile` (`ERR_PNPM_OUTDATED_LOCKFILE` — `@ag-ui/client` lockfile `0.0.57` vs manifest `0.0.58` on the source branch). That flipped the `notify` job to `failure()`, which triggered its self-watchdog "best-effort Slack" post.

That self-alert is gated on release intent (`npm_intended || py_intended`), and the `npm_intended` computation treated **any** `workflow_dispatch` as stable-release intent:

```
NPM_INTENDED="${{ (github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/publish/'))) && 'true' || 'false' }}"
```

But `canary.yml` orchestrates `publish-release.yml` with `-f mode=prerelease` on a short-lived `canary/*` ref (see `canary.yml` line ~196). A prerelease/canary is explicitly *not* a stable release: it pushes no tag, cuts no GH Release, and posts nothing to Slack (the notification builder returns `should_post=false` for it). So a failed canary build had no business self-paging.

## The fix

**Fix 1 (this PR):** Narrow the `npm_intended` dispatch arm with `inputs.mode != 'prerelease'`, so a canary dispatch yields `npm_intended=false` and never self-pages, while a stable dispatch (default mode + the main-only retry escape hatch) and a merged `release/publish/*` PR still page correctly on genuine failure. Using `!= 'prerelease'` (rather than `== 'stable'`) matches the existing `mode != 'prerelease'` guards on the publish/tag steps and correctly treats an empty/default mode as stable.

before:
```
NPM_INTENDED="${{ (github.event_name == 'workflow_dispatch' || (...)) && 'true' || 'false' }}"
```
after:
```
NPM_INTENDED="${{ ((github.event_name == 'workflow_dispatch' && inputs.mode != 'prerelease') || (...)) && 'true' || 'false' }}"
```

**Fix 2 (follow-up, not in this PR — deliberately):** The stale-lockfile source. `pnpm install --frozen-lockfile` *already is* the lockfile-consistency check and it failed loudly and correctly — adding another pre-check to this workflow would be redundant. The lockfile drift lives on the `canary/mme-subagents-*` source branch, produced by the `mme-subagents` agent-orchestration automation (it bumped a manifest without regenerating `pnpm-lock.yaml`). The right place to fix that is that generator, which is out of scope for this workflow file. Filing as a follow-up rather than over-engineering a guard here.

## Red-green proof

The failure surface is the intent-gate bash expression. Extracted the exact `npm_intended` boolean (pre- and post-fix) into isolated scripts and ran the real canary inputs.

**RED (pre-fix logic):**
```
$ EVENT_NAME=workflow_dispatch INPUT_MODE=prerelease PR_HEAD_REF="canary/mme-subagents-29605883024-1" bash gate_pre.sh
npm_intended=true      # BUG: canary treated as stable-release intent → self-pages
```

**GREEN (post-fix logic):**
```
$ EVENT_NAME=workflow_dispatch INPUT_MODE=prerelease PR_HEAD_REF="canary/mme-subagents-29605883024-1" bash gate_post.sh
npm_intended=false     # canary no longer self-pages

# no regression on genuine-release paths:
$ EVENT_NAME=workflow_dispatch INPUT_MODE=stable                       # stable dispatch (retry hatch)
npm_intended=true
$ EVENT_NAME=workflow_dispatch INPUT_MODE=""                           # stable dispatch, default mode
npm_intended=true
$ EVENT_NAME=pull_request PR_MERGED=true PR_HEAD_REF="release/publish/monorepo/v1.63.1"
npm_intended=true
$ EVENT_NAME=pull_request PR_MERGED=true PR_HEAD_REF="feature/some-branch"   # non-release merge
npm_intended=false
```

## Lint

`actionlint .github/workflows/publish-release.yml` → exit 0 (clean). This matches the repo's `Lint Release Workflows` CI job (actionlint, `level=error`, same file in scope).
