### PR TITLE
fix(harness): exclude starter-* and harness-workers from aimock-wiring probe

### DIFF
--- a/showcase/harness/src/probes/aimock-wiring.test.ts
+++ b/showcase/harness/src/probes/aimock-wiring.test.ts
@@ -667,4 +667,122 @@ describe("aimock-wiring probe", () => {
     expect(r.signal.sealed).toEqual(["showcase-google-adk"]);
     expect(r.signal.unwired).toEqual([]);
   });
+
+  it("excludes harness-workers and bare starter-* services by live name (drift regression)", async () => {
+    // Regression for the EXCLUDE drift: after the egress/private-networking
+    // migration the live Railway roster carries `harness-workers` (harness
+    // background workers — pure infra, no LLM callers) plus starters named
+    // `starter-<framework>[-lang]` (e.g. `starter-strands-python`,
+    // `starter-langgraph-js`). The stale EXCLUDE literals were keyed
+    // `showcase-starter-<framework>` (matching `starter-<framework>` only),
+    // and there was no `harness-workers` entry at all — so these six fell
+    // through to being checked, landed in `unwired`, and kept the probe red.
+    // Starters are intentionally not wired through aimock.
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: AIMOCK_URL,
+        listServices: async () => [
+          { name: "harness-workers" },
+          { name: "starter-adk" },
+          { name: "starter-langgraph-js" },
+          { name: "starter-ms-agent-framework-dotnet" },
+          { name: "starter-ms-agent-framework-python" },
+          { name: "starter-strands-python" },
+          { name: "showcase-ag2" }, // real backend, wired
+        ],
+        getServiceEnv: async (name) =>
+          name === "showcase-ag2" ? { OPENAI_BASE_URL: AIMOCK_URL } : {},
+      },
+      ctx,
+    );
+    expect(r.state).toBe("green");
+    expect(r.signal.unwired).toEqual([]);
+    expect(r.signal.wired).toEqual(["showcase-ag2"]);
+    expect(r.signal.wiredCount).toBe(1);
+  });
+
+  it("starter- prefix excludes starters but never showcase-* backends", async () => {
+    // Guard: the `starter-` prefix rule must exclude the starter scaffold
+    // while leaving the real `showcase-*` backend in the checked universe.
+    // Neither is wired here, so only the backend may surface as unwired.
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: AIMOCK_URL,
+        listServices: async () => [
+          { name: "starter-mastra" },
+          { name: "showcase-mastra" }, // must still be checked
+        ],
+        getServiceEnv: async () => ({}), // neither wired
+      },
+      ctx,
+    );
+    expect(r.state).toBe("red");
+    expect(r.signal.unwired).toEqual(["showcase-mastra"]); // starter excluded
+  });
+
+  it("full live roster: exactly the 20 showcase-* backends are checked, 21 excluded", async () => {
+    // Locks the "checked universe == the 20 showcase-* LLM backends" contract
+    // against the full 41-service production roster (9 infra + 20 backends +
+    // 12 starters). Backends are all unwired here, so `unwired` must equal
+    // exactly the 20 backends — infra and starters must all be excluded.
+    const infra = [
+      "aimock",
+      "dashboard",
+      "docs",
+      "dojo",
+      "harness",
+      "harness-workers",
+      "pocketbase",
+      "shell",
+      "webhooks",
+    ];
+    const backends = [
+      "showcase-ag2",
+      "showcase-agno",
+      "showcase-built-in-agent",
+      "showcase-claude-sdk-python",
+      "showcase-claude-sdk-typescript",
+      "showcase-crewai-crews",
+      "showcase-google-adk",
+      "showcase-langgraph-fastapi",
+      "showcase-langgraph-python",
+      "showcase-langgraph-typescript",
+      "showcase-langroid",
+      "showcase-llamaindex",
+      "showcase-mastra",
+      "showcase-ms-agent-dotnet",
+      "showcase-ms-agent-harness-dotnet",
+      "showcase-ms-agent-python",
+      "showcase-pydantic-ai",
+      "showcase-spring-ai",
+      "showcase-strands",
+      "showcase-strands-typescript",
+    ];
+    const starters = [
+      "starter-adk",
+      "starter-agno",
+      "starter-crewai-crews",
+      "starter-langgraph-fastapi",
+      "starter-langgraph-js",
+      "starter-langgraph-python",
+      "starter-llamaindex",
+      "starter-mastra",
+      "starter-ms-agent-framework-dotnet",
+      "starter-ms-agent-framework-python",
+      "starter-pydantic-ai",
+      "starter-strands-python",
+    ];
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: AIMOCK_URL,
+        listServices: async () =>
+          [...infra, ...backends, ...starters].map((name) => ({ name })),
+        getServiceEnv: async () => ({}),
+      },
+      ctx,
+    );
+    expect(r.state).toBe("red");
+    expect(r.signal.unwired).toEqual([...backends].sort());
+    expect(r.signal.unwiredCount).toBe(20);
+  });
 });

--- a/showcase/harness/src/probes/aimock-wiring.ts
+++ b/showcase/harness/src/probes/aimock-wiring.ts
@@ -43,24 +43,32 @@ export const SEALED_SENTINEL = "__SEALED__";
  */
 
 /**
- * Service names we do NOT check for aimock wiring. The aimock service
- * itself has no upstream to route through, and shell/pocketbase/harness are pure
- * infra with no LLM callers.
+ * Infra service names we do NOT check for aimock wiring. The aimock service
+ * itself has no upstream to route through, and shell/pocketbase/harness/
+ * harness-workers/dashboard/docs/dojo/webhooks are pure infra with no LLM
+ * callers (so they have no `*_BASE_URL` overrides and could only ever be
+ * counted as unwired).
  *
- * Entries are stored in their `showcase-`-prefixed form. The exclusion check
- * (`isExcluded`) normalizes inputs by stripping a leading `showcase-` so a
- * bare deployed name (e.g. `harness`, `shell`, `aimock`) matches the same
- * canonical entry as the prefixed form (`showcase-harness`, …). This is
+ * Most entries are stored in their `showcase-`-prefixed form. The exclusion
+ * check (`isExcluded`) normalizes inputs by stripping a leading `showcase-`
+ * so a bare deployed name (e.g. `harness`, `shell`, `aimock`) matches the
+ * same canonical entry as the prefixed form (`showcase-harness`, …). This is
  * load-bearing: actual deployed Railway service names in the production
  * project are BARE — without the strip, every bare infra service would have
- * been counted as unwired (no `*_BASE_URL` overrides because they are not
- * LLM callers) and the probe would have stayed red forever.
+ * been counted as unwired and the probe would have stayed red forever.
+ * `harness-workers` has no `showcase-` legacy form, so it is stored bare —
+ * `isExcluded` checks the literal name first, so this matches correctly.
  *
  * Match is still effectively EXACT post-strip (not prefix): a hypothetical
  * `showcase-aimock-pinger-mock-for-test` strips to `aimock-pinger-mock-for-test`,
  * which is NOT in the set, so it would correctly surface as unwired. Keep
  * this list in sync with the Railway service roster whenever new infra
  * services are added.
+ *
+ * NOTE: starter (`starter-*`) exclusion is handled by the prefix rule in
+ * `isExcluded`, NOT by literals here — starters are a whole family and were
+ * previously listed as `showcase-starter-*` literals that drifted against the
+ * live bare `starter-<framework>[-lang]` names. See `isExcluded`.
  */
 const EXCLUDE_SERVICES: ReadonlySet<string> = new Set([
   "showcase-aimock",
@@ -73,24 +81,8 @@ const EXCLUDE_SERVICES: ReadonlySet<string> = new Set([
   "showcase-dojo",
   "showcase-pocketbase",
   "showcase-harness",
+  "harness-workers",
   "showcase-webhooks",
-  "showcase-starter-ag2",
-  "showcase-starter-agno",
-  "showcase-starter-claude-sdk-python",
-  "showcase-starter-claude-sdk-typescript",
-  "showcase-starter-crewai-crews",
-  "showcase-starter-google-adk",
-  "showcase-starter-langgraph-fastapi",
-  "showcase-starter-langgraph-python",
-  "showcase-starter-langgraph-typescript",
-  "showcase-starter-langroid",
-  "showcase-starter-llamaindex",
-  "showcase-starter-mastra",
-  "showcase-starter-ms-agent-dotnet",
-  "showcase-starter-ms-agent-python",
-  "showcase-starter-pydantic-ai",
-  "showcase-starter-spring-ai",
-  "showcase-starter-strands",
 ]);
 
 export interface AimockWiringInput {
@@ -182,13 +174,27 @@ export interface AimockWiringSignal {
 const ERRORED_PREVIEW_MAX = 5;
 
 function isExcluded(name: string): boolean {
+  // Starters are contributor scaffolds, not showcase backends — they are
+  // categorically NOT wired through aimock (per product decision), so exclude
+  // the whole `starter-*` family by PREFIX rather than by per-framework
+  // literal. Matching starters by literal is what drifted: live Railway names
+  // are bare `starter-<framework>[-lang]` (e.g. `starter-strands-python`,
+  // `starter-langgraph-js`) while the stale EXCLUDE entries were keyed
+  // `showcase-starter-<framework>` (matching only `starter-<framework>`), so
+  // renamed/added starters fell through to being checked → unwired → red. A
+  // prefix rule can't re-drift on rename. This is SAFE: the probe's "checked"
+  // universe is intentionally the `showcase-*` LLM backends, and no
+  // `showcase-*` name begins with `starter-`, so this never over-excludes a
+  // real backend.
+  if (name.startsWith("starter-")) return true;
+
   // Match either the literal name or its `showcase-`-prefixed form. Railway
   // service names in the production project are BARE (`harness`, `shell`,
-  // `aimock`, …) while EXCLUDE_SERVICES is keyed by the `showcase-`-prefixed
-  // form for historical reasons (the legacy local-dev project named services
-  // with that prefix). Comparing both forms keeps the set robust to either
-  // naming convention without forcing operators to maintain two parallel
-  // sets that can drift.
+  // `aimock`, `harness-workers`, …) while some EXCLUDE_SERVICES entries are
+  // keyed by the `showcase-`-prefixed form for historical reasons (the legacy
+  // local-dev project named services with that prefix). Comparing both forms
+  // keeps the set robust to either naming convention without forcing operators
+  // to maintain two parallel sets that can drift.
   if (EXCLUDE_SERVICES.has(name)) return true;
   return EXCLUDE_SERVICES.has(`showcase-${name}`);
 }


### PR DESCRIPTION
## Root cause

The `aimock_wiring:global` probe (`showcase/harness/src/probes/aimock-wiring.ts`) was red on six live Railway services — the "residual-6": `harness-workers` plus `starter-adk`, `starter-langgraph-js`, `starter-ms-agent-framework-dotnet`, `starter-ms-agent-framework-python`, `starter-strands-python`.

This is EXCLUDE naming drift introduced after the egress / private-networking migration:

- `EXCLUDE_SERVICES` keyed starters as `showcase-starter-<framework>`, which (via the `showcase-` strip in `isExcluded`) only matches a live name of `starter-<framework>`. But live Railway starter names are bare `starter-<framework>[-lang]` — e.g. `starter-strands-python`, `starter-langgraph-js`, `starter-ms-agent-framework-python`. **No match** → the starter fell through to being checked → it has no `*_BASE_URL` aimock override (starters are intentionally not wired) → it landed in `unwired` → probe red.
- `harness-workers` (the harness background-worker service — pure infra, no LLM callers) had **no exclude entry at all**, so it was always counted unwired.

Seven starters coincidentally matched a stale literal and were excluded; the other five, plus `harness-workers`, kept the probe permanently red.

## Fix

Two changes, both in `aimock-wiring.ts`:

1. **Exclude the whole `starter-*` family by prefix** in `isExcluded`, instead of per-framework literals. Starters are contributor scaffolds, categorically not routed through aimock (per product decision), so matching them by literal name is exactly what drifted on rename. A prefix rule can't re-drift. This is **safe**: the probe's "checked" universe is intentionally the `showcase-*` LLM backends, and no `showcase-*` name begins with `starter-`, so the rule never over-excludes a real backend (guard test proves `starter-mastra` excluded while `showcase-mastra` still checked).
2. **Add bare `harness-workers`** to the infra exclude set (`isExcluded` checks the literal name first, so bare form matches).

The now-superseded `showcase-starter-*` literals are removed; the inert `showcase-shell-*` legacy literals are retained to keep the diff minimal and preserve an existing exclusion test. No starter is repointed — this is a naming/exclusion fix only.

## Context

The 20 `showcase-*` LLM backends were already re-wired via Railway `AIMOCK_URL` during the egress migration; they are green. This PR fixes only the exclusion-set drift on the residual-6.

## Red-green (vitest, fakes, no network)

Added to `aimock-wiring.test.ts`:
- a drift-regression test feeding the exact live residual-6 + one wired backend (`showcase-ag2`), asserting the residual-6 are excluded and only the backend is checked-and-wired;
- a guard test (`starter-mastra` excluded WHILE `showcase-mastra` still checked — proves the prefix rule doesn't over-exclude real backends);
- a full-roster test locking "checked universe == exactly the 20 `showcase-*` backends" against the full 41-service production roster.

RED (before fix) — 2 of the new tests fail; residual-6 land in `unwired`:
```
AssertionError: expected [ 'harness-workers', …(25) ] to deeply equal [ 'showcase-ag2', …(19) ]
+   "harness-workers",
+   "starter-adk",
+   "starter-langgraph-js",
+   "starter-ms-agent-framework-dotnet",
+   "starter-ms-agent-framework-python",
+   "starter-strands-python",
 Test Files  1 failed (1)
      Tests  2 failed | 30 passed (32)
```

GREEN (after fix):
```
 ✓ src/probes/aimock-wiring.test.ts (32 tests)
 Test Files  1 passed (1)
      Tests  32 passed (32)
```

## Quality gates (harness)

- `vitest run` aimock-wiring: 32/32 pass
- `tsc --noEmit`: clean
- `tsc -p tsconfig.build.json` (build): clean
- `oxfmt --check` + `oxlint`: clean (0 warnings/errors)

Two unrelated harness tests (`d5-mapping-drift`, `d0-gone-predicate`) fail locally because they parse `shell-dashboard` source / a generated `registry.json` that aren't present in a workspace-scoped install; both fail identically on clean `origin/main` and are unaffected by this change. They resolve in CI's full checkout.