### PR TITLE
fix(showcase): rewrite gen-ui-agent probe to per-pill content assertion

### DIFF
--- a/showcase/harness/src/probes/scripts/d5-gen-ui-agent.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-agent.test.ts
@@ -7,15 +7,39 @@ import {
   GEN_UI_AGENT_PILLS,
 } from "./d5-gen-ui-agent.js";
 
-function makePage(state: { stepCount: number; stepText: string }): Page {
-  return {
+/**
+ * DYNAMIC fake: `evaluate()` returns a DIFFERENT set of step rows on
+ * each successive poll, driven by `frames`. This forces the probe's
+ * swap-window wait loop to actually iterate (the poll path executes)
+ * rather than being satisfied by a single static read. The last frame
+ * repeats forever so the loop settles on it.
+ *
+ * The probe reads step rows via a `querySelectorAll('[data-testid=
+ * "agent-step"]')` inside `page.evaluate`; our fake ignores the passed
+ * function and returns the current frame's rows directly, which is how
+ * the runner's structural `Page.evaluate` fake contract works.
+ */
+function makeDynamicPage(frames: string[][]): {
+  page: Page;
+  pollCount: () => number;
+} {
+  let idx = 0;
+  const page: Page = {
     async waitForSelector() {},
     async fill() {},
     async press() {},
     async evaluate<R>() {
-      return state as unknown as R;
+      const frame = frames[Math.min(idx, frames.length - 1)]!;
+      idx += 1;
+      return frame as unknown as R;
     },
   };
+  return { page, pollCount: () => idx };
+}
+
+/** Static single-frame fake (still exercises one poll iteration). */
+function makePage(rows: string[]): Page {
+  return makeDynamicPage([rows]).page;
 }
 
 describe("d5-gen-ui-agent script", () => {
@@ -25,7 +49,7 @@ describe("d5-gen-ui-agent script", () => {
     expect(script?.fixtureFile).toBe("gen-ui-agent.json");
   });
 
-  it("buildTurns produces three per-pill turns mirroring suggestions.ts", () => {
+  it("buildTurns produces three per-pill turns mirroring the demo pills", () => {
     const ctx: D5BuildContext = {
       integrationSlug: "x",
       featureType: "gen-ui-agent",
@@ -38,64 +62,196 @@ describe("d5-gen-ui-agent script", () => {
     expect(turns[2]!.input).toContain("top competitor");
   });
 
-  it("GEN_UI_AGENT_PILLS lists three tags", () => {
+  it("GEN_UI_AGENT_PILLS lists three tags with expected markers", () => {
     const tags = GEN_UI_AGENT_PILLS.map((p) => p.tag);
     expect(tags).toEqual([
       "product-launch",
       "team-offsite",
       "competitor-research",
     ]);
+    // Markers are derived from the fixture step titles.
+    expect(GEN_UI_AGENT_PILLS[0]!.expectedMarkers).toEqual([
+      "launch",
+      "marketing",
+    ]);
+    expect(GEN_UI_AGENT_PILLS[1]!.expectedMarkers).toEqual(["venue", "agenda"]);
+    expect(GEN_UI_AGENT_PILLS[2]!.expectedMarkers).toEqual([
+      "competitor",
+      "weakness",
+    ]);
   });
 
-  it("assertion succeeds when ≥ 2 step rows render with novel content", async () => {
+  it("GREEN: accepts once the correct pill content lands across the swap window (poll path runs)", async () => {
     const seen = { values: [] as string[] };
-    const assertion = buildAgentStateAssertion("product-launch", seen);
-    const page = makePage({
-      stepCount: 3,
-      stepText: "Define launch goals Coordinate marketing rollout",
-    });
-    await expect(assertion(page)).resolves.toBeUndefined();
-    expect(seen.values).toHaveLength(1);
-  });
-
-  it("assertion succeeds across pills under last-write-wins state swap", async () => {
-    // First pill establishes a fingerprint; second pill swaps state
-    // (DOM still has 3 rows, but the textContent reflects the NEW
-    // pill's steps), assertion accepts because content differs from
-    // the seen-set.
-    const seen = { values: [] as string[] };
-    const firstAssertion = buildAgentStateAssertion("product-launch", seen);
-    const firstPage = makePage({
-      stepCount: 3,
-      stepText: "launch goals marketing rollout post-launch metrics",
-    });
-    await expect(firstAssertion(firstPage)).resolves.toBeUndefined();
-
-    const secondAssertion = buildAgentStateAssertion("team-offsite", seen);
-    const secondPage = makePage({
-      stepCount: 3,
-      stepText: "venue agenda travel",
-    });
-    await expect(secondAssertion(secondPage)).resolves.toBeUndefined();
-    expect(seen.values).toHaveLength(2);
-  });
-
-  it("assertion fails when fewer than 2 rows render in 15s", async () => {
-    const seen = { values: [] as string[] };
-    const assertion = buildAgentStateAssertion("team-offsite", seen);
-    const page = makePage({ stepCount: 1, stepText: "only one step" });
-    await expect(assertion(page)).rejects.toThrow(
-      /expected ≥ 2 \[data-testid="agent-step"\] rows/,
+    const assertion = buildAgentStateAssertion(
+      "product-launch",
+      ["launch", "marketing"],
+      seen,
     );
+    // Frame 0: swap not landed — no rows yet.
+    // Frame 1: still swapping — previous (empty) placeholder.
+    // Frame 2+: product-launch content lands.
+    const { page, pollCount } = makeDynamicPage([
+      [],
+      [""],
+      [
+        "Define launch goals and audience",
+        "Coordinate marketing and PR rollout",
+        "Track post-launch metrics for week 1",
+      ],
+    ]);
+    await expect(assertion(page)).resolves.toBeUndefined();
+    // Prove the poll/wait loop actually iterated (≥ 3 reads).
+    expect(pollCount()).toBeGreaterThanOrEqual(3);
+    expect(seen.values).toHaveLength(1);
+    expect(seen.values[0]).toContain("launch");
+    expect(seen.values[0]).toContain("marketing");
   }, 20_000);
 
-  it("assertion fails when step content duplicates an earlier pill", async () => {
-    const seen = { values: ["shared steps content"] };
-    const assertion = buildAgentStateAssertion("team-offsite", seen);
-    const page = makePage({
-      stepCount: 3,
-      stepText: "shared steps content",
-    });
-    await expect(assertion(page)).rejects.toThrow(/duplicates/);
-  }, 20_000);
+  it("GREEN: distinct-per-pill content passes for all three pills in sequence", async () => {
+    const seen = { values: [] as string[] };
+    const a1 = buildAgentStateAssertion(
+      "product-launch",
+      ["launch", "marketing"],
+      seen,
+    );
+    await expect(
+      a1(
+        makePage([
+          "Define launch goals and audience",
+          "Coordinate marketing and PR rollout",
+        ]),
+      ),
+    ).resolves.toBeUndefined();
+
+    const a2 = buildAgentStateAssertion(
+      "team-offsite",
+      ["venue", "agenda"],
+      seen,
+    );
+    await expect(
+      a2(
+        makePage([
+          "Reserve venue near downtown for 30 engineers",
+          "Build day-by-day agenda with workshop slots",
+        ]),
+      ),
+    ).resolves.toBeUndefined();
+
+    const a3 = buildAgentStateAssertion(
+      "competitor-research",
+      ["competitor", "weakness"],
+      seen,
+    );
+    await expect(
+      a3(
+        makePage([
+          "Map competitor product surface and pricing tiers",
+          "Identify weaknesses our positioning can exploit",
+        ]),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(seen.values).toHaveLength(3);
+  }, 30_000);
+
+  it("RED / FALSE-GREEN GUARD: fails on same canned steps for every pill (identical content across pills)", async () => {
+    // Regression: backend returns the SAME product-launch steps for
+    // EVERY pill. Pill 1 (product-launch) passes, but pill 2
+    // (team-offsite) renders launch content → wrong markers → RED.
+    const seen = { values: [] as string[] };
+    const canned = [
+      "Define launch goals and audience",
+      "Coordinate marketing and PR rollout",
+      "Track post-launch metrics for week 1",
+    ];
+    const a1 = buildAgentStateAssertion(
+      "product-launch",
+      ["launch", "marketing"],
+      seen,
+    );
+    await expect(a1(makePage(canned))).resolves.toBeUndefined();
+
+    const a2 = buildAgentStateAssertion(
+      "team-offsite",
+      ["venue", "agenda"],
+      seen,
+    );
+    // Dynamic fake: repeatedly returns the stale canned content — poll
+    // loop runs to the deadline, then hard-fails on missing markers.
+    const { page, pollCount } = makeDynamicPage([canned]);
+    await expect(a2(page)).rejects.toThrow(
+      /missing expected marker\(s\) \[venue, agenda\]/,
+    );
+    expect(pollCount()).toBeGreaterThanOrEqual(2);
+  }, 30_000);
+
+  it("RED / FALSE-GREEN GUARD: fails on stale NON-ADJACENT content (pill 3 shows pill 1's content)", async () => {
+    const seen = { values: [] as string[] };
+    const pill1 = [
+      "Define launch goals and audience",
+      "Coordinate marketing and PR rollout",
+    ];
+    const pill2 = [
+      "Reserve venue near downtown for 30 engineers",
+      "Build day-by-day agenda with workshop slots",
+    ];
+    const a1 = buildAgentStateAssertion(
+      "product-launch",
+      ["launch", "marketing"],
+      seen,
+    );
+    await expect(a1(makePage(pill1))).resolves.toBeUndefined();
+    const a2 = buildAgentStateAssertion(
+      "team-offsite",
+      ["venue", "agenda"],
+      seen,
+    );
+    await expect(a2(makePage(pill2))).resolves.toBeUndefined();
+
+    // Pill 3 (competitor-research) stale-renders PILL 1's content
+    // (non-adjacent). Adjacency-only dedup would miss this; content
+    // markers catch it → RED.
+    const a3 = buildAgentStateAssertion(
+      "competitor-research",
+      ["competitor", "weakness"],
+      seen,
+    );
+    const { page } = makeDynamicPage([pill1]);
+    await expect(a3(page)).rejects.toThrow(
+      /missing expected marker\(s\) \[competitor, weakness\]/,
+    );
+  }, 30_000);
+
+  it("RED / FALSE-GREEN GUARD: fails on empty/whitespace step rows (stepCount ≥ 2 but rows are blank)", async () => {
+    const seen = { values: [] as string[] };
+    const assertion = buildAgentStateAssertion(
+      "product-launch",
+      ["launch", "marketing"],
+      seen,
+    );
+    // Three rows present in the DOM, but all trim to empty — a card that
+    // rendered blank placeholder rows must NOT count toward ≥ 2.
+    // (readAgentStepRows trims inside page.evaluate; the fake bypasses
+    // that, so we supply the already-trimmed values the real DOM read
+    // would return: whitespace-only rows collapse to "".)
+    const { page, pollCount } = makeDynamicPage([["", "", ""]]);
+    await expect(assertion(page)).rejects.toThrow(
+      /expected ≥ 2 non-empty \[data-testid="agent-step"\] rows/,
+    );
+    expect(pollCount()).toBeGreaterThanOrEqual(2);
+  }, 30_000);
+
+  it("RED / FALSE-GREEN GUARD: fails when fewer than 2 rows render at all", async () => {
+    const seen = { values: [] as string[] };
+    const assertion = buildAgentStateAssertion(
+      "team-offsite",
+      ["venue", "agenda"],
+      seen,
+    );
+    const { page } = makeDynamicPage([["Reserve venue near downtown"]]);
+    await expect(assertion(page)).rejects.toThrow(
+      /expected ≥ 2 non-empty \[data-testid="agent-step"\] rows/,
+    );
+  }, 30_000);
 });

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-agent.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-agent.ts
@@ -8,14 +8,21 @@
  * `[data-testid="agent-step"]` per step in `state.steps`.
  *
  * Genuine assertion: send each suggestion-pill prompt; after settle,
- * assert the state card mounted with ≥ 2 step rows. Three pills are
- * exercised sequentially in one probe; per-pill aimock fixtures
- * produce different step content so a regression that returns the
- * same canned step list for every pill (e.g. a hard-coded tool reply
- * not keyed on the user prompt) turns the probe red.
+ * assert the state card mounted with ≥ 2 NON-EMPTY step rows AND that
+ * the rendered step text contains that pill's EXPECTED CONTENT MARKERS
+ * (distinctive, stable tokens drawn from the pill's step titles).
+ * Three pills are exercised sequentially in one probe, each with a
+ * different set of markers, so a regression that returns the same
+ * canned step list for every pill (e.g. a hard-coded tool reply not
+ * keyed on the user prompt) renders the WRONG pill's content and turns
+ * the probe red — as does a stale non-adjacent render (pill 3 still
+ * showing pill 1's content) or empty/whitespace-only step rows.
  *
- * Pill prompts are read from `gen-ui-agent/suggestions.ts` so the
- * prompts in this probe stay in sync with the demo's pill set.
+ * Pill prompts and their expected markers are HARDCODED here (they are
+ * NOT read from the demo's `suggestions.ts` — that file is a separate
+ * copy in the frontend). If the demo's pill set changes, update
+ * `GEN_UI_AGENT_PILLS` here to match. The expected markers are derived
+ * from the step titles in `showcase/harness/fixtures/d5/gen-ui-agent.json`.
  */
 
 import {
@@ -25,30 +32,43 @@ import {
 import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
 import { FIRST_SIGNAL_TIMEOUT_MS, waitForTestId } from "./_genuine-shared.js";
 
-/** Pill prompts MUST mirror `gen-ui-agent/suggestions.ts`. */
+/**
+ * Pill prompts MUST mirror the demo's hardcoded suggestion pills.
+ *
+ * `expectedMarkers` are low-brittleness, case-insensitive substrings
+ * that appear robustly in that pill's step titles (see the fixture
+ * `showcase/harness/fixtures/d5/gen-ui-agent.json`):
+ *   - product-launch: titles mention "launch" and "marketing".
+ *   - team-offsite:    titles mention "venue" and "agenda".
+ *   - competitor-research: titles mention "competitor" and "weakness".
+ * These are deliberately partial tokens (not full-text match) so the
+ * assertion is robust to live-LLM (--direct) nondeterminism while still
+ * proving the RIGHT pill's content rendered.
+ */
 export const GEN_UI_AGENT_PILLS = [
   {
     tag: "product-launch",
     prompt: "Plan a product launch for a new mobile app.",
+    expectedMarkers: ["launch", "marketing"],
   },
   {
     tag: "team-offsite",
     prompt: "Organize a three-day engineering team offsite.",
+    expectedMarkers: ["venue", "agenda"],
   },
   {
     tag: "competitor-research",
     prompt:
       "Research our top competitor and summarize their strengths and weaknesses.",
+    expectedMarkers: ["competitor", "weakness"],
   },
 ] as const;
 
-/** Read the count of `[data-testid="agent-step"]` rows currently in
- *  the DOM, plus the joined step text for per-pill content
- *  fingerprinting. */
-async function readAgentStepState(page: Page): Promise<{
-  stepCount: number;
-  stepText: string;
-}> {
+/** Read the per-row text of every `[data-testid="agent-step"]` node
+ *  currently in the DOM. Returns the trimmed text of each row so the
+ *  caller can reject empty/whitespace-only rows and match content
+ *  markers. */
+async function readAgentStepRows(page: Page): Promise<string[]> {
   return (await page.evaluate(() => {
     const win = globalThis as unknown as {
       document: {
@@ -58,35 +78,43 @@ async function readAgentStepState(page: Page): Promise<{
       };
     };
     const nodes = win.document.querySelectorAll('[data-testid="agent-step"]');
-    let acc = "";
+    const rows: string[] = [];
     for (let i = 0; i < nodes.length; i++) {
-      acc += " " + (nodes[i]!.textContent ?? "");
+      rows.push((nodes[i]!.textContent ?? "").trim());
     }
-    return { stepCount: nodes.length, stepText: acc };
-  })) as { stepCount: number; stepText: string };
+    return rows;
+  })) as string[];
 }
 
-/** Build a per-pill assertion. `seenStepTextsRef` accumulates the
- *  observed step-text fingerprint across pills — a regression where
- *  every pill produces the SAME steps would fail at the second pill
- *  because `stepText` would equal a previous entry.
+/** Build a per-pill assertion driven by EXPECTED CONTENT.
  *
- *  Note on the swap-not-accumulate model: the backend's `set_steps`
- *  reducer is `last-write-wins` (see `gen_ui_agent.py`), so each pill
- *  REPLACES `state.steps` rather than appending. The DOM mirrors
- *  state, so step-row count after pill N reflects ONLY pill N's
- *  steps — earlier pills' rows unmount. An earlier "delta vs.
- *  pre-pill baseline ≥ 2" check assumed accumulation and failed at
- *  pill 2+ even when the new steps rendered correctly.
+ *  The state card is populated asynchronously: after a pill click the
+ *  `set_steps` tool streams state over a short swap window, during which
+ *  the DOM may still show the previous pill's rows before this pill's
+ *  content lands. We therefore POLL until the correct content appears
+ *  (exercising the swap-window wait loop), then assert:
  *
- *  Primary signal: ≥ 2 step rows visible after the pill settles. The
- *  fingerprint deduplication keeps catching a fixture that returns
- *  identical content regardless of prompt — that probe still works
- *  under the swap model, since the textContent of the visible rows
- *  IS the per-pill content.
+ *    1. ≥ 2 NON-EMPTY step rows (a row that trims to empty does not
+ *       count — that rejects a card that rendered blank/placeholder
+ *       rows).
+ *    2. The joined step text contains ALL of this pill's expected
+ *       markers (case-insensitive substring).
+ *
+ *  This is robust to live-LLM nondeterminism (it checks the RIGHT
+ *  content rendered, not exact text) WITHOUT false-greening:
+ *    - identical-across-pills canned steps → wrong markers → RED;
+ *    - stale non-adjacent content (pill 3 showing pill 1) → wrong
+ *      markers → RED;
+ *    - empty/whitespace rows → fewer than 2 non-empty rows → RED.
+ *
+ *  `seenStepTextsRef` is retained for diagnostic accumulation only; it
+ *  no longer gates acceptance (the earlier cross-pill-difference
+ *  heuristic was fragile and could false-fail on coincidental live-LLM
+ *  content collisions). Content-marker matching replaces it.
  */
 export function buildAgentStateAssertion(
   pillTag: string,
+  expectedMarkers: readonly string[],
   seenStepTextsRef: { values: string[] },
 ): (page: Page) => Promise<void> {
   return async (page: Page): Promise<void> => {
@@ -96,50 +124,57 @@ export function buildAgentStateAssertion(
       FIRST_SIGNAL_TIMEOUT_MS,
       `gen-ui-agent-${pillTag}`,
     );
-    // Wait briefly for the swap to settle. We need ≥ 2 step rows
-    // visible, AND we need the visible textContent to differ from
-    // any earlier pill (fingerprint dedup).
+
+    const markers = expectedMarkers.map((m) => m.toLowerCase());
     const deadline = Date.now() + 15_000;
-    let last = { stepCount: 0, stepText: "" };
+    let rows: string[] = [];
+    let nonEmpty: string[] = [];
+    let joined = "";
+    let missing: string[] = markers.slice();
+
     while (Date.now() < deadline) {
-      last = await readAgentStepState(page);
-      if (last.stepCount >= 2) {
-        const fingerprint = last.stepText.trim().toLowerCase();
-        if (
-          seenStepTextsRef.values.length > 0 &&
-          seenStepTextsRef.values.includes(fingerprint)
-        ) {
-          // Same content as earlier pill — wait for the swap to
-          // finish landing. (Brief window where the DOM still
-          // shows the previous pill's rows.)
-          await new Promise((r) => setTimeout(r, 300));
-          continue;
-        }
-        // Stable, ≥ 2 rows, content differs from earlier pills.
-        seenStepTextsRef.values.push(fingerprint);
+      rows = await readAgentStepRows(page);
+      nonEmpty = rows.filter((r) => r.length > 0);
+      joined = nonEmpty.join(" ").toLowerCase();
+      missing = markers.filter((m) => !joined.includes(m));
+      if (nonEmpty.length >= 2 && missing.length === 0) {
+        // Correct pill content has landed with ≥ 2 non-empty rows.
+        seenStepTextsRef.values.push(joined);
         return;
       }
+      // Either the swap has not landed yet (still showing the prior
+      // pill / empty rows) or content is missing markers — keep polling
+      // until this pill's expected content appears.
       await new Promise((r) => setTimeout(r, 300));
     }
-    if (last.stepCount < 2) {
+
+    if (nonEmpty.length < 2) {
       throw new Error(
-        `gen-ui-agent-${pillTag}: expected ≥ 2 [data-testid="agent-step"] rows ` +
-          `(observed=${last.stepCount}) within 15s — pill set_steps tool call may not have streamed state`,
+        `gen-ui-agent-${pillTag}: expected ≥ 2 non-empty ` +
+          `[data-testid="agent-step"] rows ` +
+          `(observed ${nonEmpty.length} non-empty of ${rows.length} total) ` +
+          `within 15s — pill set_steps tool call may not have streamed state`,
       );
     }
-    // Reached deadline with enough rows but content kept duplicating
-    // an earlier pill — fixture is not differentiating by prompt.
     throw new Error(
-      `gen-ui-agent-${pillTag}: step content duplicates an earlier pill — fixture is not differentiating by prompt`,
+      `gen-ui-agent-${pillTag}: rendered ${nonEmpty.length} step rows but ` +
+        `their content is missing expected marker(s) [${missing.join(", ")}] ` +
+        `within 15s — the card shows the wrong pill's content ` +
+        `(stale/duplicated steps) rather than this pill's steps. ` +
+        `Observed: ${JSON.stringify(nonEmpty)}`,
     );
   };
 }
 
 export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
   const seenStepTextsRef = { values: [] as string[] };
-  return GEN_UI_AGENT_PILLS.map(({ tag, prompt }) => ({
+  return GEN_UI_AGENT_PILLS.map(({ tag, prompt, expectedMarkers }) => ({
     input: prompt,
-    assertions: buildAgentStateAssertion(tag, seenStepTextsRef),
+    assertions: buildAgentStateAssertion(
+      tag,
+      expectedMarkers,
+      seenStepTextsRef,
+    ),
     responseTimeoutMs: 60_000,
   }));
 }


### PR DESCRIPTION
The old gen-ui-agent probe leaned on a cross-pill-difference heuristic — it fingerprinted the rendered step text and treated inter-pill differences as a settling signal, then accepted any render that had >=2 rows by the deadline. That let a real regression slip through green: when pill 3 stale-renders pill 1's card, the ">=2 rows present" check is still satisfied and the dedup was only ever a wait mechanism, never a hard gate.

This PR rewrites the assertion to check what each pill should actually render. Every pill carries a couple of low-brittleness content markers pulled from its step titles in the d5 fixture (product-launch -> launch/marketing, team-offsite -> venue/agenda, competitor-research -> competitor/weakness). The probe polls the swap window until the card shows >=2 non-empty step rows whose joined text contains all of that pill's markers, and hard-fails otherwise. Matching is partial and case-insensitive so it holds up under live-LLM (--direct) nondeterminism while still proving the right pill's content landed.

Red-green: a dynamic-fake red-green plus three retained false-green guards — identical-across-pills canned steps, stale non-adjacent content (pill 3 showing pill 1), and empty/whitespace-only rows all go RED; distinct-per-pill content passes. 9/9 tests green locally.

Important: this does NOT flip the affected cells green. The corrected probe EXPOSES a genuine pill-3 stale-card regression on agno, langroid, and crewai-crews — those cells are legitimately RED now and stay RED until the underlying backend/frontend bug is fixed (separate follow-up). The langgraph-python reference passes.

## Follow-ups (not this PR)

CR surfaced a handful of hardening items worth tracking, none of which block this rework:

- The marker check is present-only, not absence-of-other-pills. A canned backend reply that happened to contain every pill's tokens at once could false-green. That's unrealistic for the current regression class (which this probe does catch), but the check isn't airtight.
- Success latches on the first matching poll — there's no settle/stability re-check after the content lands.
- Dead `seenStepTextsRef` state is still threaded through but never read on the prod path; it should be removed.
- The unit-test fakes bypass the real `evaluate`/`.trim()` DOM logic. That path is covered by the `--direct` value-test, not the unit test.
- Markers are matched against a joined row string, so it doesn't strictly prove two distinct rows. There's also no drift guard against `suggestions.ts`/the fixture, and the 15s content-poll deadline is a magic number decoupled from `responseTimeoutMs`.

Also worth flagging: this PR EXPOSES a genuine pill-3 stale-state-card regression on agno/langroid/crewai-crews — it's a backend per-turn state/history handling problem, tracked separately and NOT fixed here. The langgraph-python reference passes.
