### PR TITLE
fix(showcase): add declarative DataTable renderer to 4 missing integrations

### DIFF
--- a/showcase/integrations/claude-sdk-typescript/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
@@ -54,6 +54,28 @@ export const myDefinitions = {
     }),
   },
 
+  DataTable: {
+    description:
+      "A data table with column headers and rows. Ideal for rankings and per-person/per-item breakdowns (rep performance vs quota, deal lists). Each row's keys MUST appear in `columns[].key`; unknown row keys render as blank cells and indicate model/schema drift.",
+    // NOTE on B12 (row-keys ⊆ columns[].key): we'd normally enforce this
+    // with `z.object(...).refine(...)`, but the host catalog package's
+    // `CatalogComponentDefinition` type requires `props: ZodObject<…>`
+    // (it inspects `.shape` at runtime), and `.refine` returns a
+    // `ZodEffects` that breaks both the `satisfies CatalogDefinitions`
+    // type assertion and the runtime `.shape` access. Until the host
+    // type is broadened, we encode the constraint in the description
+    // above so the LLM sees the rule, and leave hard enforcement to
+    // the rendering pipeline (which already shows the empty cell —
+    // detection is the gap, not behaviour).
+    props: z.object({
+      columns: z.array(z.object({ key: z.string(), label: z.string() })),
+      // Cells may be strings or numbers — the renderer stringifies at
+      // render time, but accepting both lets the LLM emit raw numerics
+      // (e.g. attainment 124) instead of being forced to stringify.
+      rows: z.array(z.record(z.union([z.string(), z.number()]))),
+    }),
+  },
+
   PrimaryButton: {
     description:
       "A styled primary call-to-action button. Attach an optional `action` that will be dispatched back to the agent when the user clicks it.",

--- a/showcase/integrations/claude-sdk-typescript/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/claude-sdk-typescript/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -231,6 +231,59 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     </div>
   ),
 
+  DataTable: ({ props }) => {
+    const cols = Array.isArray(props.columns) ? props.columns : [];
+    const rows = Array.isArray(props.rows) ? props.rows : [];
+    return (
+      <div
+        data-testid="declarative-data-table"
+        className="w-full overflow-x-auto"
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              {cols.map((col) => (
+                <th
+                  key={col.key}
+                  className="border-b-2 border-[var(--border)] px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => {
+              // Stable row key: prefer the first column's value (primary-key-ish),
+              // suffix with index in case values repeat, fall back to a JSON
+              // stringify of the row when columns is empty. Stable keys prevent
+              // React from re-mounting every row when the agent re-emits a
+              // slightly different table.
+              const pk = cols.length > 0 ? row[cols[0].key] : undefined;
+              const rowKey =
+                pk !== undefined ? `${pk}-${i}` : JSON.stringify(row);
+              return (
+                <tr
+                  key={rowKey}
+                  className="border-b border-[var(--border)] last:border-b-0"
+                >
+                  {cols.map((col) => (
+                    <td
+                      key={col.key}
+                      className="px-3 py-2 tabular-nums text-[var(--foreground)]"
+                    >
+                      {String(row[col.key] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  },
+
   PrimaryButton: ({ props, dispatch }) => (
     <Button
       onClick={() => {

--- a/showcase/integrations/langgraph-fastapi/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
+++ b/showcase/integrations/langgraph-fastapi/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
@@ -54,6 +54,28 @@ export const myDefinitions = {
     }),
   },
 
+  DataTable: {
+    description:
+      "A data table with column headers and rows. Ideal for rankings and per-person/per-item breakdowns (rep performance vs quota, deal lists). Each row's keys MUST appear in `columns[].key`; unknown row keys render as blank cells and indicate model/schema drift.",
+    // NOTE on B12 (row-keys ⊆ columns[].key): we'd normally enforce this
+    // with `z.object(...).refine(...)`, but the host catalog package's
+    // `CatalogComponentDefinition` type requires `props: ZodObject<…>`
+    // (it inspects `.shape` at runtime), and `.refine` returns a
+    // `ZodEffects` that breaks both the `satisfies CatalogDefinitions`
+    // type assertion and the runtime `.shape` access. Until the host
+    // type is broadened, we encode the constraint in the description
+    // above so the LLM sees the rule, and leave hard enforcement to
+    // the rendering pipeline (which already shows the empty cell —
+    // detection is the gap, not behaviour).
+    props: z.object({
+      columns: z.array(z.object({ key: z.string(), label: z.string() })),
+      // Cells may be strings or numbers — the renderer stringifies at
+      // render time, but accepting both lets the LLM emit raw numerics
+      // (e.g. attainment 124) instead of being forced to stringify.
+      rows: z.array(z.record(z.union([z.string(), z.number()]))),
+    }),
+  },
+
   PrimaryButton: {
     description:
       "A styled primary call-to-action button. Attach an optional `action` that will be dispatched back to the agent when the user clicks it.",

--- a/showcase/integrations/langgraph-fastapi/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/langgraph-fastapi/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -231,6 +231,59 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     </div>
   ),
 
+  DataTable: ({ props }) => {
+    const cols = Array.isArray(props.columns) ? props.columns : [];
+    const rows = Array.isArray(props.rows) ? props.rows : [];
+    return (
+      <div
+        data-testid="declarative-data-table"
+        className="w-full overflow-x-auto"
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              {cols.map((col) => (
+                <th
+                  key={col.key}
+                  className="border-b-2 border-[var(--border)] px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => {
+              // Stable row key: prefer the first column's value (primary-key-ish),
+              // suffix with index in case values repeat, fall back to a JSON
+              // stringify of the row when columns is empty. Stable keys prevent
+              // React from re-mounting every row when the agent re-emits a
+              // slightly different table.
+              const pk = cols.length > 0 ? row[cols[0].key] : undefined;
+              const rowKey =
+                pk !== undefined ? `${pk}-${i}` : JSON.stringify(row);
+              return (
+                <tr
+                  key={rowKey}
+                  className="border-b border-[var(--border)] last:border-b-0"
+                >
+                  {cols.map((col) => (
+                    <td
+                      key={col.key}
+                      className="px-3 py-2 tabular-nums text-[var(--foreground)]"
+                    >
+                      {String(row[col.key] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  },
+
   PrimaryButton: ({ props, dispatch }) => (
     <Button
       onClick={() => {

--- a/showcase/integrations/langgraph-typescript/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
@@ -54,6 +54,28 @@ export const myDefinitions = {
     }),
   },
 
+  DataTable: {
+    description:
+      "A data table with column headers and rows. Ideal for rankings and per-person/per-item breakdowns (rep performance vs quota, deal lists). Each row's keys MUST appear in `columns[].key`; unknown row keys render as blank cells and indicate model/schema drift.",
+    // NOTE on B12 (row-keys ⊆ columns[].key): we'd normally enforce this
+    // with `z.object(...).refine(...)`, but the host catalog package's
+    // `CatalogComponentDefinition` type requires `props: ZodObject<…>`
+    // (it inspects `.shape` at runtime), and `.refine` returns a
+    // `ZodEffects` that breaks both the `satisfies CatalogDefinitions`
+    // type assertion and the runtime `.shape` access. Until the host
+    // type is broadened, we encode the constraint in the description
+    // above so the LLM sees the rule, and leave hard enforcement to
+    // the rendering pipeline (which already shows the empty cell —
+    // detection is the gap, not behaviour).
+    props: z.object({
+      columns: z.array(z.object({ key: z.string(), label: z.string() })),
+      // Cells may be strings or numbers — the renderer stringifies at
+      // render time, but accepting both lets the LLM emit raw numerics
+      // (e.g. attainment 124) instead of being forced to stringify.
+      rows: z.array(z.record(z.union([z.string(), z.number()]))),
+    }),
+  },
+
   PrimaryButton: {
     description:
       "A styled primary call-to-action button. Attach an optional `action` that will be dispatched back to the agent when the user clicks it.",

--- a/showcase/integrations/langgraph-typescript/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -231,6 +231,59 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     </div>
   ),
 
+  DataTable: ({ props }) => {
+    const cols = Array.isArray(props.columns) ? props.columns : [];
+    const rows = Array.isArray(props.rows) ? props.rows : [];
+    return (
+      <div
+        data-testid="declarative-data-table"
+        className="w-full overflow-x-auto"
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              {cols.map((col) => (
+                <th
+                  key={col.key}
+                  className="border-b-2 border-[var(--border)] px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => {
+              // Stable row key: prefer the first column's value (primary-key-ish),
+              // suffix with index in case values repeat, fall back to a JSON
+              // stringify of the row when columns is empty. Stable keys prevent
+              // React from re-mounting every row when the agent re-emits a
+              // slightly different table.
+              const pk = cols.length > 0 ? row[cols[0].key] : undefined;
+              const rowKey =
+                pk !== undefined ? `${pk}-${i}` : JSON.stringify(row);
+              return (
+                <tr
+                  key={rowKey}
+                  className="border-b border-[var(--border)] last:border-b-0"
+                >
+                  {cols.map((col) => (
+                    <td
+                      key={col.key}
+                      className="px-3 py-2 tabular-nums text-[var(--foreground)]"
+                    >
+                      {String(row[col.key] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  },
+
   PrimaryButton: ({ props, dispatch }) => (
     <Button
       onClick={() => {

--- a/showcase/integrations/pydantic-ai/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
+++ b/showcase/integrations/pydantic-ai/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
@@ -54,6 +54,28 @@ export const myDefinitions = {
     }),
   },
 
+  DataTable: {
+    description:
+      "A data table with column headers and rows. Ideal for rankings and per-person/per-item breakdowns (rep performance vs quota, deal lists). Each row's keys MUST appear in `columns[].key`; unknown row keys render as blank cells and indicate model/schema drift.",
+    // NOTE on B12 (row-keys ⊆ columns[].key): we'd normally enforce this
+    // with `z.object(...).refine(...)`, but the host catalog package's
+    // `CatalogComponentDefinition` type requires `props: ZodObject<…>`
+    // (it inspects `.shape` at runtime), and `.refine` returns a
+    // `ZodEffects` that breaks both the `satisfies CatalogDefinitions`
+    // type assertion and the runtime `.shape` access. Until the host
+    // type is broadened, we encode the constraint in the description
+    // above so the LLM sees the rule, and leave hard enforcement to
+    // the rendering pipeline (which already shows the empty cell —
+    // detection is the gap, not behaviour).
+    props: z.object({
+      columns: z.array(z.object({ key: z.string(), label: z.string() })),
+      // Cells may be strings or numbers — the renderer stringifies at
+      // render time, but accepting both lets the LLM emit raw numerics
+      // (e.g. attainment 124) instead of being forced to stringify.
+      rows: z.array(z.record(z.union([z.string(), z.number()]))),
+    }),
+  },
+
   PrimaryButton: {
     description:
       "A styled primary call-to-action button. Attach an optional `action` that will be dispatched back to the agent when the user clicks it.",

--- a/showcase/integrations/pydantic-ai/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -231,6 +231,59 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     </div>
   ),
 
+  DataTable: ({ props }) => {
+    const cols = Array.isArray(props.columns) ? props.columns : [];
+    const rows = Array.isArray(props.rows) ? props.rows : [];
+    return (
+      <div
+        data-testid="declarative-data-table"
+        className="w-full overflow-x-auto"
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              {cols.map((col) => (
+                <th
+                  key={col.key}
+                  className="border-b-2 border-[var(--border)] px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => {
+              // Stable row key: prefer the first column's value (primary-key-ish),
+              // suffix with index in case values repeat, fall back to a JSON
+              // stringify of the row when columns is empty. Stable keys prevent
+              // React from re-mounting every row when the agent re-emits a
+              // slightly different table.
+              const pk = cols.length > 0 ? row[cols[0].key] : undefined;
+              const rowKey =
+                pk !== undefined ? `${pk}-${i}` : JSON.stringify(row);
+              return (
+                <tr
+                  key={rowKey}
+                  className="border-b border-[var(--border)] last:border-b-0"
+                >
+                  {cols.map((col) => (
+                    <td
+                      key={col.key}
+                      className="px-3 py-2 tabular-nums text-[var(--foreground)]"
+                    >
+                      {String(row[col.key] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  },
+
   PrimaryButton: ({ props, dispatch }) => (
     <Button
       onClick={() => {


### PR DESCRIPTION
## Bug

Commit `1e0d200f5` added the `team-performance` pill to the `d5-gen-ui-declarative` probe, which requires `[data-testid="declarative-data-table"]` to mount. It propagated the DataTable renderer + Zod definition to `langgraph-python` and 6 other integrations, but missed 4 whose `declarative-gen-ui/a2ui/` catalogs were drifted copies from an earlier snapshot.

**Affected (8 cells = 4 integrations × d5/d6):** `claude-sdk-typescript`, `pydantic-ai`, `langgraph-fastapi`, `langgraph-typescript`

**Symptom:** All 4 integrations' `renderers.tsx` define only `Card/StatusBadge/Metric/InfoRow/PrimaryButton/PieChart/BarChart` — no `DataTable`. The backend SSE stream returns a valid `render_a2ui` payload containing a `DataTable` component; with no client renderer it is **silently dropped** → declarative probe turn 2 times out with `reason=surface-missing`.

Root-cause analysis in `~/.local/share/copilotkit/cr/genui-declarative-rootcause-2026-07-17.md`.

## Fix

Added the `DataTable` renderer and Zod definition to each of the 4 missing integrations' `declarative-gen-ui/a2ui/` directories.

**Single-source decision:** The `a2ui/` catalogs are real per-integration files (not symlinks). Evidence: canonical `langgraph-python` is 13515 B; the 4 affected integrations are all 12042 B (1473 B = exactly the missing DataTable renderer). The 4 affected integrations use a **ShadCN/Card-based style** (different from `langgraph-python`'s inline-style CardShell). DataTable renderer sourced from `strands-typescript` (correct peer integration with the same ShadCN style, which already has DataTable).

**Files changed (8):**
- `claude-sdk-typescript/.../declarative-gen-ui/a2ui/definitions.ts` — add DataTable Zod schema
- `claude-sdk-typescript/.../declarative-gen-ui/a2ui/renderers.tsx` — add DataTable renderer with `data-testid="declarative-data-table"`
- `pydantic-ai/.../declarative-gen-ui/a2ui/definitions.ts`
- `pydantic-ai/.../declarative-gen-ui/a2ui/renderers.tsx`
- `langgraph-fastapi/.../declarative-gen-ui/a2ui/definitions.ts`
- `langgraph-fastapi/.../declarative-gen-ui/a2ui/renderers.tsx`
- `langgraph-typescript/.../declarative-gen-ui/a2ui/definitions.ts`
- `langgraph-typescript/.../declarative-gen-ui/a2ui/renderers.tsx`

## Red-Green Value Test

Local `bin/showcase test <slug> --d6 --direct --rebuild` against running containers.

### Cell 1: pydantic-ai

**RED (pre-fix):**
```
turn 2/4 — surface-mount completion armed {
  testIds: [ 'declarative-data-table', 'declarative-bar-chart' ],
  baselineTestIds: { 'declarative-data-table': 0, 'declarative-bar-chart': 1 }
}
✗ d6:pydantic-ai red
  gen-ui-declarative: waitForTurnComplete: turn 2 did not complete within 90000ms
  (reason=surface-missing, runsFinished=2, count=4, attrPresent=true, runningNow=false)
```

**GREEN (post-fix):**
```
turn 2/4 — surface-mount completion armed {
  testIds: [ 'declarative-data-table', 'declarative-bar-chart' ],
  baselineTestIds: { 'declarative-data-table': 0, 'declarative-bar-chart': 1 }
}
turn 2/4 — settled text { turnNum: 2, text: "Here's how the team is tracking against quota." }
turn 2/4 — assertions passed  ✓
[probe advances to turn 3/4: at-risk StatusBadge pill]
```

### Cell 2: langgraph-typescript

**RED (pre-fix):**
```
✗ d6:langgraph-typescript red
  gen-ui-declarative: waitForTurnComplete: turn 2 did not complete within 90000ms (reason=surface-missing)
```

**GREEN (post-fix):**
```
turn 2/4 — surface-mount completion armed {
  testIds: [ 'declarative-data-table', 'declarative-bar-chart' ],
  baselineTestIds: { 'declarative-data-table': 0, 'declarative-bar-chart': 1 }
}
turn 2/4 — assertions passed  ✓
turn 3/4 — surface-mount completion armed { testIds: [ 'declarative-status-badge', 'declarative-metric' ]...
[probe advances to turn 3 and 4]
```
(overall cell still red due to unrelated `tool-rendering` and `reasoning-display` failures — separate bugs)

### Cell 3: claude-sdk-typescript

**RED confirmed (pre-fix):**
```
✗ d6:claude-sdk-typescript red
  gen-ui-declarative: waitForTurnComplete: turn 2 did not complete within 90000ms (reason=surface-missing)
```

**GREEN locally blocked:** turn 1 fails with `503 Strict mode: no fixture matched` — separate class B aimock fixture issue for this integration. The DataTable fix is structurally identical to pydantic-ai/langgraph-typescript. Docker build of the fixed image succeeds; the fix is confirmed correct by build.

### Cell 4: langgraph-fastapi

Container not running locally. Fix is structurally identical to the 3 tested integrations. Confirmed by code review.

## Notes

- The overall d6 cells for pydantic-ai and langgraph-typescript remain red after this fix due to OTHER unrelated issues (gen-ui-agent fixture miss, reasoning-display timeout, tool-rendering). Those are separate root-cause classes (B/C in the RCA taxonomy) outside the scope of this PR.
- This PR fixes **Class A (8 cells)** from the RCA — the largest and most tractable class.