### PR TITLE
fix(showcase): bound claude-sdk-python declarative gen-ui loop so RUN_FINISHED fires

### DIFF
--- a/showcase/integrations/claude-sdk-python/src/agents/a2ui_dynamic.py
+++ b/showcase/integrations/claude-sdk-python/src/agents/a2ui_dynamic.py
@@ -153,7 +153,15 @@ async def run_a2ui_dynamic_agent(input_data: RunAgentInput) -> AsyncIterator[str
         RunStartedEvent(type=EventType.RUN_STARTED, thread_id=thread_id, run_id=run_id)
     )
 
-    while True:
+    # Maximum tool iterations per run. `generate_a2ui` normally renders in a
+    # single turn, but a misbehaving model could keep re-calling the tool and
+    # never yield an empty `tool_calls` turn — which would wedge the run and
+    # RUN_FINISHED would never fire (done-signal-missing timeout). Cap the loop
+    # so the run always terminates. Mirrors the claude-sdk-typescript sibling's
+    # MAX_TOOL_ITERATIONS bound.
+    MAX_TOOL_ITERATIONS = 10
+
+    for _iter in range(MAX_TOOL_ITERATIONS):
         msg_id = f"msg-{run_id}-{len(messages)}"
         yield encoder.encode(
             TextMessageStartEvent(


### PR DESCRIPTION
## What

Fixes the claude-sdk-python **declarative-gen-ui** class-F failure (RCA 2026-07-17): the dashboard renders but `RUN_FINISHED` never arrives, so the harness times out with `done-signal-missing`.

The `run_a2ui_dynamic_agent` tool loop used `while True:`, breaking only when the model returned a turn with no tool calls. With a **real** LLM key the model keeps re-calling `generate_a2ui` after each tool result, so that empty-tool turn never arrives — the loop spins forever and never emits `RUN_FINISHED`. (A dummy key hits the auth-fail path, which already terminates, which is why this only reproduces with a real key.)

**Fix:** replace the unbounded loop with a bounded `for _iter in range(MAX_TOOL_ITERATIONS)` (cap 10), mirroring the proven-GREEN `claude-sdk-typescript` sibling (`agent_server.ts` `MAX_TOOL_ITERATIONS`). The loop now always falls through to `RUN_FINISHED`.

## Red / Green proof

Real surface, real OPENAI key: `bin/showcase test claude-sdk-python:declarative-gen-ui --d6 --direct --rebuild --isolate`

**RED (before — `while True:`):**
```
turn 1 did not complete within 90000ms
(reason=done-signal-missing, runsFinished=0, count=12, runningNow=true, runStartCount=1)
bodyText: generate_a2ui / Done  (x12 — infinite re-call loop, RUN_FINISHED never fires)
⚠ Tests failed for claude-sdk-python:declarative-gen-ui (exit 1)
```

**GREEN (after — bounded loop):**
```
turn 1/4 — assistant settled { text: 'generate_a2uiDone' }   (single call, run terminates)
turn 2 diagnostics: runsFinished=2, runningNow=false          (RUN_FINISHED now fires, runs complete)
bodyText: QUARTERLY REVENUE $4.2M / Revenue by Region / NA·EMEA·APAC·LATAM  (dashboard renders)
```

`runsFinished` 0 → 2 and `runningNow` true → false confirms the run now terminates. The class-F hang is fixed.

## Scope note

The remaining turn-2 `surface-missing` on this cell is a **separate** RCA class-A defect (missing `DataTable` renderer in the per-integration frontend catalog), owned by a different fix and out of scope here.
