### PR TITLE
fix(showcase): pin ag2 declarative-gen-ui to its registered catalog id

### DIFF
--- a/showcase/integrations/ag2/src/agents/a2ui_dynamic.py
+++ b/showcase/integrations/ag2/src/agents/a2ui_dynamic.py
@@ -35,6 +35,23 @@ from ._request_context import get_latest_user_message
 
 logger = logging.getLogger(__name__)
 
+# Must match the catalog id the declarative-gen-ui page registers via
+# `createCatalog(..., { catalogId: "declarative-gen-ui-catalog" })`
+# (src/app/demos/declarative-gen-ui/a2ui/catalog.ts) and the route's
+# `a2ui.defaultCatalogId` (api/copilotkit-declarative-gen-ui/route.ts).
+#
+# The shared `render_a2ui` tool schema (tools/generate_a2ui.py) steers the
+# secondary planner toward `copilotkit://app-dashboard-catalog` — the catalog
+# the *beautiful-chat* demo registers, NOT this one. Under aimock the recorded
+# fixture already carries the right id, but against a real LLM the planner
+# emits `copilotkit://app-dashboard-catalog`, the middleware can't resolve it
+# ("[A2UI] processMessages error: Catalog not found:
+# copilotkit://app-dashboard-catalog"), and the surface never mounts. Stamping
+# the correct id here pins this dedicated agent to the page's catalog
+# regardless of what the planner returned. Mirrors the strands sibling's
+# `CATALOG_ID` (strands/src/agents/a2ui_dynamic.py).
+CATALOG_ID = "declarative-gen-ui-catalog"
+
 # Module-level async client: re-used across requests (httpx connection pool is
 # thread-safe). Using AsyncOpenAI inside an `async def` avoids blocking the
 # ASGI event loop on the secondary LLM call.
@@ -160,6 +177,11 @@ async def generate_a2ui() -> str:
 
     try:
         args = json.loads(first_call.function.arguments)
+        # Pin the catalog id to the one this demo's page registers. The shared
+        # render_a2ui schema nudges the planner toward beautiful-chat's
+        # `copilotkit://app-dashboard-catalog`; overriding it here keeps the
+        # emitted createSurface op aligned with `declarative-gen-ui-catalog`.
+        args["catalogId"] = CATALOG_ID
         result = build_a2ui_operations_from_tool_call(args)
         return json.dumps(result)
     except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:


### PR DESCRIPTION
Fixes RCA class E (ag2 declarative-gen-ui catalog id mismatch).

## Root cause
The dedicated ag2 declarative agent (`integrations/ag2/src/agents/a2ui_dynamic.py`) builds its `createSurface` op from the shared `render_a2ui` planner result. The shared tool (`shared/python/tools/generate_a2ui.py`) sets `CUSTOM_CATALOG_ID = "copilotkit://app-dashboard-catalog"` (the *beautiful-chat* catalog) and its schema prose tells the planner to use it. The declarative-gen-ui **page** registers `declarative-gen-ui-catalog` (`a2ui/catalog.ts`) and the route pins that via `a2ui.defaultCatalogId`.

Against a real LLM (prod), the planner emits `copilotkit://app-dashboard-catalog`, the A2UI middleware cannot resolve it (`[A2UI] processMessages error: Catalog not found: copilotkit://app-dashboard-catalog`), and the surface never mounts.

## Fix
Stamp `declarative-gen-ui-catalog` into the emitted op regardless of what the planner returned (mirrors the `strands` sibling's `CATALOG_ID` constant). Scoped to the ag2 declarative agent only — the shared beautiful-chat default is untouched.

## Red-green — HONEST status (why this is a DRAFT)

**The catalogId fix could NOT be proven red->green on the live cell**, because the local/aimock failure surface reds for a **different, orthogonal reason**:

- The shipping **aimock D6 fixture** (`aimock/d6/ag2/gen-ui-declarative.json`) already emits the correct `catalogId: "declarative-gen-ui-catalog"`. Verified on the wire: the `/api/copilotkit-declarative-gen-ui` SSE response body contains `catalogId":"declarative-gen-ui-catalog"` and **no** `app-dashboard-catalog`.
- So under aimock the catalog-not-found never occurs. Instead the cell reds with `reason=surface-missing` and the browser console shows `[CopilotKit] Error (agent_run_error_event): Run ended without emitting a terminal event` / `runtimeErrorCode: INCOMPLETE_STREAM`. The ag2 outer ConversableAgent run never emits `RUN_FINISHED` — an RCA class-D/F run-lifecycle bug, NOT the catalog (class E) bug.

`bin/showcase test ag2:declarative-gen-ui --d6 --direct --rebuild --isolate`:
- **Before fix:** RED — `surface-missing` (0 declarative-metric/pie/bar mounted); console `INCOMPLETE_STREAM`.
- **After fix:** STILL RED — identical `surface-missing` / `INCOMPLETE_STREAM`. The catalogId fix has no effect on the aimock cell because the fixture already carried the right id.

The catalog fix IS proven correct at the unit level (given planner args with the wrong `copilotkit://app-dashboard-catalog`, the emitted `createSurface.catalogId` flips to `declarative-gen-ui-catalog`), and it is the confirmed prod root cause per the RCA. But per the red-green-on-real-surface precondition, this stays a **draft**: the live cell will only go green once the orthogonal `INCOMPLETE_STREAM` (ag2 run never terminates under aimock) is also fixed. That is separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)