### PR TITLE
fix(showcase): close ms-agent-python A2UI outer tool call before RUN_FINISHED

### DIFF
--- a/showcase/aimock/d6/ms-agent-python/gen-ui-declarative.json
+++ b/showcase/aimock/d6/ms-agent-python/gen-ui-declarative.json
@@ -187,6 +187,34 @@
       "chunkSize": 9999
     },
     {
+      "_comment": "pill sales-dashboard hero — inner secondary LLM (tools=[_design_a2ui_surface], tool_choice forced) emits the flat A2UI components. Discriminated by toolName so it wins over the outer generate_a2ui fixture whose userMessage matches the same prompt. Mirrors LGP gen-ui-declarative.json sales-dashboard render_a2ui entry.",
+      "match": {
+        "userMessage": "Show me my sales dashboard for this quarter.",
+        "toolName": "_design_a2ui_surface"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_dash_design_mspy_001",
+            "name": "_design_a2ui_surface",
+            "arguments": "{\"surfaceId\":\"sales-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"kpi-row\",\"charts-row\"]},{\"id\":\"kpi-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-revenue\",\"metric-new-customers\",\"metric-win-rate\",\"metric-deal-size\"]},{\"id\":\"metric-revenue\",\"component\":\"Metric\",\"label\":\"Quarterly Revenue\",\"value\":\"$4.2M\",\"trend\":\"up\",\"trendValue\":\"+12% QoQ\"},{\"id\":\"metric-new-customers\",\"component\":\"Metric\",\"label\":\"New Customers\",\"value\":\"186\",\"trend\":\"up\",\"trendValue\":\"+8%\"},{\"id\":\"metric-win-rate\",\"component\":\"Metric\",\"label\":\"Win Rate\",\"value\":\"31%\",\"trend\":\"down\",\"trendValue\":\"-2 pts\"},{\"id\":\"metric-deal-size\",\"component\":\"Metric\",\"label\":\"Avg Deal Size\",\"value\":\"$22.6k\",\"trend\":\"up\",\"trendValue\":\"+5%\"},{\"id\":\"charts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"region-pie\",\"monthly-bar\"]},{\"id\":\"region-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by Region\",\"description\":\"Quarter revenue split across North America, EMEA, APAC, and LATAM.\",\"data\":[{\"label\":\"North America\",\"value\":1900000},{\"label\":\"EMEA\",\"value\":1300000},{\"label\":\"APAC\",\"value\":720000},{\"label\":\"LATAM\",\"value\":280000}]},{\"id\":\"monthly-bar\",\"component\":\"BarChart\",\"title\":\"Monthly Revenue\",\"description\":\"Revenue trend from Jan through Jun.\",\"data\":[{\"label\":\"Jan\",\"value\":1210000},{\"label\":\"Feb\",\"value\":1340000},{\"label\":\"Mar\",\"value\":1650000},{\"label\":\"Apr\",\"value\":1380000},{\"label\":\"May\",\"value\":1420000},{\"label\":\"Jun\",\"value\":1400000}]}]}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill sales-dashboard hero — outer agent narration after generate_a2ui returns. Matched by toolCallId so the outer agent's post-tool turn resolves; without this the outer generate_a2ui tool call never closes and the run hits 'Cannot send RUN_FINISHED while tool calls are still active'. Mirrors LGP gen-ui-declarative.json sales-dashboard narration entry.",
+      "match": {
+        "context": "ms-agent-python",
+        "toolCallId": "call_d6_decl_dash_outer_mspy_001"
+      },
+      "response": {
+        "content": "Here's your Q2 sales dashboard."
+      },
+      "chunkSize": 9999
+    },
+    {
       "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args). Mirrors LGP gen-ui-declarative.json sales-dashboard outer entry. Closes the production 503 gap where backend hits aimock with tools=[generate_a2ui] for this userMessage (see /tmp/staging-journal-diff.md shape-B).",
       "match": {
         "userMessage": "Show me my sales dashboard for this quarter.",


### PR DESCRIPTION
## Problem (RCA Class D)

The `ms-agent-python:declarative-gen-ui` cell reds with the AG-UI protocol violation:

```
Cannot send 'RUN_FINISHED' while tool calls are still active: call_d6_decl_dash_outer_mspy_001
```

The sales-dashboard hero pill (turn 1) was missing two aimock fixtures for the two-stage `generate_a2ui` flow:

1. the inner `_design_a2ui_surface` secondary-LLM fixture, and
2. the outer-agent narration fixture keyed by `toolCallId: call_d6_decl_dash_outer_mspy_001`.

Without the narration fixture, after `generate_a2ui` returned there was no matching outer turn to close the tool call. The run looped re-emitting `generate_a2ui` (visible as `generate_a2ui / Done` x7 in the DOM) and tripped the RUN_FINISHED guard; the run errored and never completed.

## Fix

Added both fixtures to `showcase/aimock/d6/ms-agent-python/gen-ui-declarative.json`, mirroring the canonical `langgraph-python` sales-dashboard entries (inner keyed by `toolName: _design_a2ui_surface`, narration keyed by the outer `toolCallId`).

## Red -> Green (real surface, `bin/showcase test ms-agent-python:declarative-gen-ui --d6 --direct --rebuild --isolate`)

**RED (before, buggy fixture):**
```
chat errored: copilot-error-banner visible — Cannot send 'RUN_FINISHED' while tool calls are still active: call_d6_decl_dash_outer_mspy_001
[CopilotKit] Error (agent_run_error_event): Cannot send 'RUN_FINISHED' while tool calls are still active: call_d6_decl_dash_outer_mspy_001
reason=done-signal-missing, runsFinished=0, runningNow=true
bodyText: ... generate_a2ui / Done x7 ... (run looping, never terminates)
0 passed, 1 failed
```

**GREEN (after — the assigned RUN_FINISHED violation is eliminated):**
```
runsFinished=1, runningNow=false        <- RUN_FINISHED now fires cleanly
hasErrorBoundary: false                 <- no error banner, no agent_run_error_event
bodyText: ... "Here's your Q2 sales dashboard." ... generate_a2ui / Done (x1, no loop)
```
The outer tool call now closes, RUN_FINISHED fires, and the narration fixture renders. The exact assigned bug (RUN_FINISHED-while-active) is gone.

## Remaining blocker (separate defect — NOT Class D, out of this PR's scope)

The cell still reds, now for a **different** reason: `reason=surface-missing`. The rendered surface is the stale KPI dashboard ($1.24M / 8,420 / 2.3%, 3 metrics, no pie/bar) instead of the sales dashboard (metric x4 + pie + bar) the probe asserts.

Root cause: the inner `generate_a2ui` secondary call falls back to the catch-all `user_content` (`"KPI dashboard with 3-4 metrics, pie chart sales by region..."`) in `src/agents/a2ui_dynamic.py` because `latest_user_message` extraction from `session.input_messages` returns empty (the `getattr`-based extraction reads a different message shape than `beautiful_chat.py`'s dict-based extraction, and the `except: pass` swallows it). The catch-all then matches the stale `aimock/d6/ms-agent-python/render-a2ui.json` fixture #11 (`_design_a2ui_surface` + `"KPI dashboard"`).

This is RCA Class A/C (stale mspy fixture pillset — KPI/pie/bar/status vs the new sales-analyst pills — plus broken session-message extraction), a distinct bug with a different owner. It needs its own fix + red-green and is intentionally not folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)