### PR TITLE
fix(showcase): spring-ai declarative-gen-ui — nested A2UI ops, DataTable/InfoRow catalog, fresh fixtures

### DIFF
--- a/showcase/aimock/d6/spring-ai/gen-ui-declarative.json
+++ b/showcase/aimock/d6/spring-ai/gen-ui-declarative.json
@@ -1,120 +1,153 @@
 {
   "_meta": {
-    "description": "D6 fixtures for spring-ai / gen-ui-declarative",
+    "description": "D6 fixtures for spring-ai / gen-ui-declarative (A2UI Dynamic Schema)",
     "sourceScript": "d5-gen-ui-declarative.ts",
-    "created": "2026-05-22"
+    "_note": "spring-ai owns generate_a2ui on the backend (a2ui.injectA2UITool:false). Per pill, 3 fixtures following the langgraph-python two-stage pattern, adapted for spring-ai's backend-owned secondary designer LLM: (1) outer StreamingToolAgent call matched by {userMessage,context} emits a generate_a2ui tool call whose userRequest is a UNIQUE surface token; (2) GenerateA2uiTool's secondary chatModel.call, matched on that unique token, returns the A2UI surface JSON ({surfaceId,catalogId,components,data}) which the tool wraps into nested v0.9 a2ui_operations (createSurface/updateComponents/updateDataModel); (3) the outer-agent narration, matched by the tool call's toolCallId (the most-specific match, so it wins over the outer {userMessage,context} on the follow-up call and is turn-independent across the 4-pill conversation). Surface component payloads mirror langgraph-python's canonical catalog 1:1 so the probe minCounts are satisfied (4 metrics/pie/bar; DataTable+bar; 3 status-badge+3 metric; info-row+pie).",
+    "created": "2026-07-17"
   },
   "fixtures": [
     {
-      "_comment": "gen-ui-declarative pill 1: KPI dashboard — emits render_a2ui with Card + Metric components. hasToolResult:false on toolCalls.",
+      "_comment": "gen-ui-declarative pill (dash): outer agent emits generate_a2ui",
       "match": {
-        "userMessage": "KPI dashboard",
-        "hasToolResult": false,
+        "userMessage": "Show me my sales dashboard for this quarter.",
         "context": "spring-ai"
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_d6_decl_kpi_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"Card\",\"props\":{\"title\":\"Q4 KPI Dashboard\"}},{\"type\":\"Metric\",\"props\":{\"label\":\"Revenue\",\"value\":\"$2.4M\",\"change\":\"+12%\"}},{\"type\":\"Metric\",\"props\":{\"label\":\"Signups\",\"value\":\"8,421\",\"change\":\"+23%\"}},{\"type\":\"Metric\",\"props\":{\"label\":\"Churn\",\"value\":\"2.1%\",\"change\":\"-0.3%\"}}]}"
+            "id": "call_d6_decl_dash_outer_spring_001",
+            "name": "generate_a2ui",
+            "arguments": "{\"userRequest\": \"sales-dashboard-surface\"}"
           }
         ]
       }
     },
     {
-      "_comment": "gen-ui-declarative pill 1: KPI dashboard — follow-up after tool result.",
+      "_comment": "gen-ui-declarative pill (dash): secondary designer LLM emits the A2UI surface JSON",
       "match": {
-        "userMessage": "KPI dashboard",
-        "hasToolResult": true,
+        "userMessage": "sales-dashboard-surface",
         "context": "spring-ai"
       },
       "response": {
-        "content": "KPI dashboard rendered above with revenue, signups, and churn metrics."
+        "content": "{\"surfaceId\": \"sales-dashboard\", \"catalogId\": \"declarative-gen-ui-catalog\", \"components\": [{\"id\": \"root\", \"component\": \"Column\", \"gap\": 16, \"children\": [\"kpi-row\", \"charts-row\"]}, {\"id\": \"kpi-row\", \"component\": \"Row\", \"gap\": 16, \"children\": [\"metric-revenue\", \"metric-new-customers\", \"metric-win-rate\", \"metric-deal-size\"]}, {\"id\": \"metric-revenue\", \"component\": \"Metric\", \"label\": \"Quarterly Revenue\", \"value\": \"$4.2M\", \"trend\": \"up\", \"trendValue\": \"+12% QoQ\"}, {\"id\": \"metric-new-customers\", \"component\": \"Metric\", \"label\": \"New Customers\", \"value\": \"186\", \"trend\": \"up\", \"trendValue\": \"+8%\"}, {\"id\": \"metric-win-rate\", \"component\": \"Metric\", \"label\": \"Win Rate\", \"value\": \"31%\", \"trend\": \"down\", \"trendValue\": \"-2 pts\"}, {\"id\": \"metric-deal-size\", \"component\": \"Metric\", \"label\": \"Avg Deal Size\", \"value\": \"$22.6k\", \"trend\": \"up\", \"trendValue\": \"+5%\"}, {\"id\": \"charts-row\", \"component\": \"Row\", \"gap\": 16, \"children\": [\"region-pie\", \"monthly-bar\"]}, {\"id\": \"region-pie\", \"component\": \"PieChart\", \"title\": \"Revenue by Region\", \"description\": \"Quarter revenue split across North America, EMEA, APAC, and LATAM.\", \"data\": [{\"label\": \"North America\", \"value\": 1900000}, {\"label\": \"EMEA\", \"value\": 1300000}, {\"label\": \"APAC\", \"value\": 720000}, {\"label\": \"LATAM\", \"value\": 280000}]}, {\"id\": \"monthly-bar\", \"component\": \"BarChart\", \"title\": \"Monthly Revenue\", \"description\": \"Revenue trend from Jan through Jun.\", \"data\": [{\"label\": \"Jan\", \"value\": 1210000}, {\"label\": \"Feb\", \"value\": 1340000}, {\"label\": \"Mar\", \"value\": 1650000}, {\"label\": \"Apr\", \"value\": 1380000}, {\"label\": \"May\", \"value\": 1420000}, {\"label\": \"Jun\", \"value\": 1400000}]}]}"
       }
     },
     {
-      "_comment": "gen-ui-declarative pill 2: pie chart — emits render_a2ui with PieChart component.",
+      "_comment": "gen-ui-declarative pill (dash): outer agent narration (matched by toolCallId)",
       "match": {
-        "userMessage": "pie chart of sales by region",
-        "hasToolResult": false,
+        "context": "spring-ai",
+        "toolCallId": "call_d6_decl_dash_outer_spring_001"
+      },
+      "response": {
+        "content": "Here's your Q2 sales dashboard."
+      }
+    },
+    {
+      "_comment": "gen-ui-declarative pill (team): outer agent emits generate_a2ui",
+      "match": {
+        "userMessage": "How are our sales reps performing against quota?",
         "context": "spring-ai"
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_d6_decl_pie_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"PieChart\",\"props\":{\"title\":\"Sales by Region\",\"data\":[{\"label\":\"North America\",\"value\":45},{\"label\":\"Europe\",\"value\":30},{\"label\":\"Asia\",\"value\":20},{\"label\":\"Other\",\"value\":5}]}}]}"
+            "id": "call_d6_decl_team_outer_spring_001",
+            "name": "generate_a2ui",
+            "arguments": "{\"userRequest\": \"rep-quota-surface\"}"
           }
         ]
       }
     },
     {
-      "_comment": "gen-ui-declarative pill 2: pie chart — follow-up.",
+      "_comment": "gen-ui-declarative pill (team): secondary designer LLM emits the A2UI surface JSON",
       "match": {
-        "userMessage": "pie chart of sales by region",
-        "hasToolResult": true,
+        "userMessage": "rep-quota-surface",
         "context": "spring-ai"
       },
       "response": {
-        "content": "Pie chart rendered above showing sales breakdown by region."
+        "content": "{\"surfaceId\": \"rep-quota-performance\", \"catalogId\": \"declarative-gen-ui-catalog\", \"components\": [{\"id\": \"root\", \"component\": \"Column\", \"gap\": 16, \"children\": [\"title\", \"summary\", \"content\"]}, {\"id\": \"title\", \"component\": \"Text\", \"text\": \"Sales rep performance vs quota\"}, {\"id\": \"summary\", \"component\": \"Text\", \"text\": \"2 of 5 reps are above quota, 1 is near plan, and 2 are below target in Q2.\"}, {\"id\": \"content\", \"component\": \"Row\", \"gap\": 16, \"children\": [\"table-card\", \"attainment-chart\"]}, {\"id\": \"table-card\", \"component\": \"Card\", \"title\": \"Rep attainment table\", \"child\": \"rep-table\"}, {\"id\": \"rep-table\", \"component\": \"DataTable\", \"columns\": [{\"key\": \"rep\", \"label\": \"Rep\"}, {\"key\": \"attainment\", \"label\": \"Attainment\"}, {\"key\": \"pipeline\", \"label\": \"Pipeline\"}], \"rows\": [{\"rep\": \"Dana Whitfield\", \"attainment\": \"124%\", \"pipeline\": \"Leading team; biggest account Meridian Apparel Group has 4 open opps worth $210k\"}, {\"rep\": \"Marcus Lee\", \"attainment\": \"108%\", \"pipeline\": \"Above plan\"}, {\"rep\": \"Priya Sharma\", \"attainment\": \"97%\", \"pipeline\": \"Near quota\"}, {\"rep\": \"Tom Okafor\", \"attainment\": \"88%\", \"pipeline\": \"Below plan\"}, {\"rep\": \"Elena Vasquez\", \"attainment\": \"71%\", \"pipeline\": \"Furthest from quota\"}]}, {\"id\": \"attainment-chart\", \"component\": \"BarChart\", \"title\": \"Quota attainment by rep\", \"description\": \"Q2 quota attainment percentages for all sales reps.\", \"data\": [{\"label\": \"Dana Whitfield\", \"value\": 124}, {\"label\": \"Marcus Lee\", \"value\": 108}, {\"label\": \"Priya Sharma\", \"value\": 97}, {\"label\": \"Tom Okafor\", \"value\": 88}, {\"label\": \"Elena Vasquez\", \"value\": 71}]}]}"
       }
     },
     {
-      "_comment": "gen-ui-declarative pill 3: bar chart — emits render_a2ui with BarChart component.",
+      "_comment": "gen-ui-declarative pill (team): outer agent narration (matched by toolCallId)",
       "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "hasToolResult": false,
+        "context": "spring-ai",
+        "toolCallId": "call_d6_decl_team_outer_spring_001"
+      },
+      "response": {
+        "content": "Here's how the team is tracking against quota."
+      }
+    },
+    {
+      "_comment": "gen-ui-declarative pill (risk): outer agent emits generate_a2ui",
+      "match": {
+        "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
         "context": "spring-ai"
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_d6_decl_bar_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"BarChart\",\"props\":{\"title\":\"Quarterly Revenue\",\"data\":[{\"label\":\"Q1\",\"value\":1800000},{\"label\":\"Q2\",\"value\":2100000},{\"label\":\"Q3\",\"value\":2300000},{\"label\":\"Q4\",\"value\":2400000}]}}]}"
+            "id": "call_d6_decl_risk_outer_spring_001",
+            "name": "generate_a2ui",
+            "arguments": "{\"userRequest\": \"at-risk-surface\"}"
           }
         ]
       }
     },
     {
-      "_comment": "gen-ui-declarative pill 3: bar chart — follow-up.",
+      "_comment": "gen-ui-declarative pill (risk): secondary designer LLM emits the A2UI surface JSON",
       "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "hasToolResult": true,
+        "userMessage": "at-risk-surface",
         "context": "spring-ai"
       },
       "response": {
-        "content": "Bar chart rendered above showing quarterly revenue growth."
+        "content": "{\"surfaceId\": \"risk-dashboard\", \"catalogId\": \"declarative-gen-ui-catalog\", \"components\": [{\"id\": \"root\", \"component\": \"Column\", \"gap\": 16, \"children\": [\"metrics-row\", \"accounts-row\"]}, {\"id\": \"metrics-row\", \"component\": \"Row\", \"gap\": 16, \"children\": [\"metric-arr\", \"metric-accounts\", \"metric-biggest\"]}, {\"id\": \"metric-arr\", \"component\": \"Metric\", \"label\": \"ARR at risk\", \"value\": \"$615k\", \"trend\": \"down\", \"trendValue\": \"3 accounts\"}, {\"id\": \"metric-accounts\", \"component\": \"Metric\", \"label\": \"Accounts at risk\", \"value\": \"3\", \"trend\": \"neutral\", \"trendValue\": \"This quarter\"}, {\"id\": \"metric-biggest\", \"component\": \"Metric\", \"label\": \"Biggest exposure\", \"value\": \"Northwind Retail\", \"trend\": \"down\", \"trendValue\": \"$340k renewal\"}, {\"id\": \"accounts-row\", \"component\": \"Row\", \"gap\": 16, \"children\": [\"card-northwind\", \"card-cascadia\", \"card-atlas\"]}, {\"id\": \"card-northwind\", \"component\": \"Card\", \"title\": \"Northwind Retail\", \"subtitle\": \"$340k ARR at stake\", \"child\": \"northwind-content\"}, {\"id\": \"northwind-content\", \"component\": \"Column\", \"gap\": 8, \"children\": [\"northwind-badge\", \"northwind-text\"]}, {\"id\": \"northwind-badge\", \"component\": \"StatusBadge\", \"text\": \"High severity\", \"variant\": \"error\"}, {\"id\": \"northwind-text\", \"component\": \"Text\", \"text\": \"No contact in 6 weeks; next action: exec outreach this week to protect the renewal.\"}, {\"id\": \"card-cascadia\", \"component\": \"Card\", \"title\": \"Cascadia Outfitters\", \"subtitle\": \"$180k ARR at stake\", \"child\": \"cascadia-content\"}, {\"id\": \"cascadia-content\", \"component\": \"Column\", \"gap\": 8, \"children\": [\"cascadia-badge\", \"cascadia-text\"]}, {\"id\": \"cascadia-badge\", \"component\": \"StatusBadge\", \"text\": \"Medium severity\", \"variant\": \"warning\"}, {\"id\": \"cascadia-text\", \"component\": \"Text\", \"text\": \"Champion left; next action: rebuild stakeholder map and secure a new sponsor.\"}, {\"id\": \"card-atlas\", \"component\": \"Card\", \"title\": \"Atlas Goods\", \"subtitle\": \"$95k ARR at stake\", \"child\": \"atlas-content\"}, {\"id\": \"atlas-content\", \"component\": \"Column\", \"gap\": 8, \"children\": [\"atlas-badge\", \"atlas-text\"]}, {\"id\": \"atlas-badge\", \"component\": \"StatusBadge\", \"text\": \"Medium severity\", \"variant\": \"warning\"}, {\"id\": \"atlas-text\", \"component\": \"Text\", \"text\": \"Legal review is stalled; next action: align procurement and legal on open terms.\"}]}"
       }
     },
     {
-      "_comment": "gen-ui-declarative pill 4: status report — emits render_a2ui with StatusBadge component.",
+      "_comment": "gen-ui-declarative pill (risk): outer agent narration (matched by toolCallId)",
       "match": {
-        "userMessage": "status report on system health",
-        "hasToolResult": false,
+        "context": "spring-ai",
+        "toolCallId": "call_d6_decl_risk_outer_spring_001"
+      },
+      "response": {
+        "content": "Three accounts need attention this quarter."
+      }
+    },
+    {
+      "_comment": "gen-ui-declarative pill (acct): outer agent emits generate_a2ui",
+      "match": {
+        "userMessage": "Pull up the details on our biggest account.",
         "context": "spring-ai"
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_d6_decl_status_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"StatusBadge\",\"props\":{\"service\":\"API\",\"status\":\"healthy\",\"uptime\":\"99.97%\"}},{\"type\":\"StatusBadge\",\"props\":{\"service\":\"Database\",\"status\":\"healthy\",\"uptime\":\"99.99%\"}},{\"type\":\"StatusBadge\",\"props\":{\"service\":\"Background Workers\",\"status\":\"degraded\",\"uptime\":\"98.2%\"}}]}"
+            "id": "call_d6_decl_acct_outer_spring_001",
+            "name": "generate_a2ui",
+            "arguments": "{\"userRequest\": \"top-account-surface\"}"
           }
         ]
       }
     },
     {
-      "_comment": "gen-ui-declarative pill 4: status report — follow-up.",
+      "_comment": "gen-ui-declarative pill (acct): secondary designer LLM emits the A2UI surface JSON",
       "match": {
-        "userMessage": "status report on system health",
-        "hasToolResult": true,
+        "userMessage": "top-account-surface",
         "context": "spring-ai"
       },
       "response": {
-        "content": "System health report rendered above. API and database are healthy; background workers show slight degradation."
+        "content": "{\"surfaceId\": \"biggest-account-details\", \"catalogId\": \"declarative-gen-ui-catalog\", \"components\": [{\"id\": \"root\", \"component\": \"Row\", \"gap\": 16, \"children\": [\"account-card\", \"revenue-pie\"]}, {\"id\": \"account-card\", \"component\": \"Card\", \"title\": \"Meridian Apparel Group\", \"subtitle\": \"Biggest account\", \"child\": \"account-facts\"}, {\"id\": \"account-facts\", \"component\": \"Column\", \"gap\": 8, \"children\": [\"fact1\", \"fact2\", \"fact3\", \"fact4\", \"fact5\", \"fact6\", \"fact7\"]}, {\"id\": \"fact1\", \"component\": \"InfoRow\", \"label\": \"Owner\", \"value\": \"Dana Whitfield\"}, {\"id\": \"fact2\", \"component\": \"InfoRow\", \"label\": \"Region\", \"value\": \"North America\"}, {\"id\": \"fact3\", \"component\": \"InfoRow\", \"label\": \"ARR\", \"value\": \"$612k\"}, {\"id\": \"fact4\", \"component\": \"InfoRow\", \"label\": \"Renewal date\", \"value\": \"Sep 30\"}, {\"id\": \"fact5\", \"component\": \"InfoRow\", \"label\": \"Last contact\", \"value\": \"3 days ago\"}, {\"id\": \"fact6\", \"component\": \"InfoRow\", \"label\": \"Health\", \"value\": \"Green\"}, {\"id\": \"fact7\", \"component\": \"InfoRow\", \"label\": \"Open opportunities\", \"value\": \"4 opportunities worth $210k\"}, {\"id\": \"revenue-pie\", \"component\": \"PieChart\", \"title\": \"Revenue by product line\", \"description\": \"Meridian Apparel Group revenue mix across product lines.\", \"data\": [{\"label\": \"Outerwear\", \"value\": 260000}, {\"label\": \"Footwear\", \"value\": 180000}, {\"label\": \"Accessories\", \"value\": 112000}, {\"label\": \"Custom\", \"value\": 60000}]}]}"
+      }
+    },
+    {
+      "_comment": "gen-ui-declarative pill (acct): outer agent narration (matched by toolCallId)",
+      "match": {
+        "context": "spring-ai",
+        "toolCallId": "call_d6_decl_acct_outer_spring_001"
+      },
+      "response": {
+        "content": "Here's the rundown on Meridian Apparel Group."
       }
     }
   ]

--- a/showcase/integrations/spring-ai/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
+++ b/showcase/integrations/spring-ai/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
@@ -92,6 +92,18 @@ export const myDefinitions = {
       ),
     }),
   },
+
+  DataTable: {
+    description:
+      "A data table with column headers and rows. Ideal for rankings and per-person/per-item breakdowns (rep performance vs quota, deal lists). Each row's keys MUST appear in `columns[].key`; unknown row keys render as blank cells and indicate model/schema drift.",
+    props: z.object({
+      columns: z.array(z.object({ key: z.string(), label: z.string() })),
+      // Cells may be strings or numbers — the renderer stringifies at
+      // render time, but accepting both lets the LLM emit raw numerics
+      // (e.g. attainment 124) instead of being forced to stringify.
+      rows: z.array(z.record(z.union([z.string(), z.number()]))),
+    }),
+  },
 } satisfies CatalogDefinitions;
 // @endregion[definitions-zod]
 

--- a/showcase/integrations/spring-ai/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -221,7 +221,10 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     // Divider via `border-b last:border-b-0` so the final row doesn't dangle
     // a trailing line, regardless of whether the agent wraps these in a
     // Column or drops them directly into a Card's child slot.
-    <div className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0">
+    <div
+      data-testid="declarative-info-row"
+      className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0"
+    >
       <span className="text-sm text-[var(--muted-foreground)]">
         {props.label}
       </span>
@@ -230,6 +233,59 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
       </span>
     </div>
   ),
+
+  DataTable: ({ props }) => {
+    const cols = Array.isArray(props.columns) ? props.columns : [];
+    const rows = Array.isArray(props.rows) ? props.rows : [];
+    return (
+      <div
+        data-testid="declarative-data-table"
+        className="w-full overflow-x-auto"
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              {cols.map((col) => (
+                <th
+                  key={col.key}
+                  className="border-b-2 border-[var(--border)] px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => {
+              // Stable row key: prefer the first column's value
+              // (primary-key-ish), suffix with index in case values repeat,
+              // fall back to a JSON stringify of the row when columns is
+              // empty. Stable keys prevent React from re-mounting every row
+              // when the agent re-emits a slightly different table.
+              const pk = cols.length > 0 ? row[cols[0].key] : undefined;
+              const rowKey =
+                pk !== undefined ? `${pk}-${i}` : JSON.stringify(row);
+              return (
+                <tr
+                  key={rowKey}
+                  className="border-b border-[var(--border)] last:border-b-0"
+                >
+                  {cols.map((col) => (
+                    <td
+                      key={col.key}
+                      className="px-3 py-2 tabular-nums text-[var(--foreground)]"
+                    >
+                      {String(row[col.key] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  },
 
   PrimaryButton: ({ props, dispatch }) => (
     <Button

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/tools/GenerateA2uiTool.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/tools/GenerateA2uiTool.java
@@ -18,7 +18,11 @@ import java.util.function.Function;
  */
 public class GenerateA2uiTool implements Function<GenerateA2uiTool.Request, String> {
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final String CATALOG_ID = "copilotkit://app-dashboard-catalog";
+    // Must match the catalogId the frontend registers in
+    // declarative-gen-ui/a2ui/catalog.ts (`declarative-gen-ui-catalog`) and
+    // the route's `defaultCatalogId`. A mismatched id makes the renderer fail
+    // with "Catalog not found" and the surface silently drops.
+    private static final String CATALOG_ID = "declarative-gen-ui-catalog";
 
     public record Request(String userRequest) {}
 
@@ -36,7 +40,7 @@ public class GenerateA2uiTool implements Function<GenerateA2uiTool.Request, Stri
                 You MUST respond with ONLY a JSON object (no markdown, no explanation) with this exact structure:
                 {
                   "surfaceId": "dynamic-surface",
-                  "catalogId": "copilotkit://app-dashboard-catalog",
+                  "catalogId": "declarative-gen-ui-catalog",
                   "components": [<A2UI v0.9 component array>],
                   "data": {<optional initial data>}
                 }
@@ -58,15 +62,34 @@ public class GenerateA2uiTool implements Function<GenerateA2uiTool.Request, Stri
             String surfaceId = args.has("surfaceId") ? args.get("surfaceId").asText() : "dynamic-surface";
             String catalogId = args.has("catalogId") ? args.get("catalogId").asText() : CATALOG_ID;
 
+            // Emit v0.9 NESTED A2UI operations (mirrors the sibling
+            // DisplayFlightTool). The a2ui-middleware (>=0.0.10) is
+            // nested-only: it expects each op to carry `"version":"v0.9"`
+            // with a camelCase operation key (`createSurface` /
+            // `updateComponents` / `updateDataModel`) and the data-model
+            // payload nested under `value` at a `path` (NOT a flat `data`
+            // field). The legacy flat ops (`create_surface` /
+            // `update_components` / `update_data_model`) are silently dropped
+            // by the current middleware, so the surface never mounts.
             var ops = new java.util.ArrayList<>(List.of(
-                Map.of("type", "create_surface", "surfaceId", surfaceId, "catalogId", catalogId),
-                Map.of("type", "update_components", "surfaceId", surfaceId,
-                       "components", MAPPER.readValue(args.get("components").toString(), List.class))
+                Map.of("version", "v0.9",
+                       "createSurface", Map.of(
+                               "surfaceId", surfaceId,
+                               "catalogId", catalogId)),
+                Map.of("version", "v0.9",
+                       "updateComponents", Map.of(
+                               "surfaceId", surfaceId,
+                               "components", MAPPER.readValue(
+                                       args.get("components").toString(), List.class)))
             ));
 
             if (args.has("data") && !args.get("data").isNull()) {
-                ops.add(Map.of("type", "update_data_model", "surfaceId", surfaceId,
-                              "data", MAPPER.readValue(args.get("data").toString(), Map.class)));
+                ops.add(Map.of("version", "v0.9",
+                       "updateDataModel", Map.of(
+                               "surfaceId", surfaceId,
+                               "path", "/",
+                               "value", MAPPER.readValue(
+                                       args.get("data").toString(), Map.class))));
             }
 
             return MAPPER.writeValueAsString(Map.of("a2ui_operations", ops));


### PR DESCRIPTION
## Summary

Fixes the red `spring-ai / declarative-gen-ui` showcase cell. The failure was heterogeneous — a backend `RuntimeException` **and** the A2UI surface never mounting — with four distinct root causes:

1. **Legacy flat A2UI ops.** `GenerateA2uiTool` emitted `create_surface` / `update_components` / `update_data_model`, which the nested-only a2ui-middleware (>=0.0.10) silently drops. Migrated to nested v0.9 ops (`createSurface` / `updateComponents` / `updateDataModel`, data under `value` at `path: "/"`), mirroring the sibling `DisplayFlightTool`.
2. **Wrong catalogId.** `GenerateA2uiTool` pinned `copilotkit://app-dashboard-catalog`, which the frontend never registers → "Catalog not found". Fixed to `declarative-gen-ui-catalog` (the id the page + route register).
3. **Stale aimock fixture.** The spring-ai `gen-ui-declarative.json` fixture still targeted the old "KPI dashboard" pills emitting `render_a2ui`; the current 4-pill probe found no match → aimock 503 → `agent run failed: RuntimeException`. Rewrote it for spring-ai's backend-owned two-stage `generate_a2ui` flow (outer tool call matched by `{userMessage,context}`; secondary designer LLM matched by a unique surface token; narration matched by `toolCallId`), with surface payloads mirroring the canonical langgraph-python catalog 1:1.
4. **Drifted frontend catalog.** The `DataTable` renderer/definition was missing (pill 2) and the `InfoRow` renderer had lost its `data-testid="declarative-info-row"` (pill 4). Both restored from the canonical langgraph-python catalog.

`a2ui-fixed-schema` was already green on `main` (its `DisplayFlightTool` already emits nested v0.9 ops) and is unchanged.

## Red → green proof

`bin/showcase test spring-ai:declarative-gen-ui --d6 --direct --rebuild --isolate`

**RED (origin/main):**
```
turn 1/4 — FAILED  reason=surface-missing
bodyText: agent run failed: RuntimeException (see server logs)
0 passed, 1 failed
```
Backend log: `RuntimeException: Streaming failed … 503 Service Unavailable from POST http://aimock:4010/v1/chat/completions`; aimock: `STRICT: No fixture matched`.

**GREEN (this change):**
```
turn 1/4 — assertions passed
turn 2/4 — assertions passed   (DataTable + BarChart)
turn 3/4 — assertions passed   (StatusBadge + Metric)
turn 4/4 — assertions passed   (InfoRow + PieChart)
conversation completed successfully { turnsCompleted: 4 }
✓ d6:spring-ai green
```

aimock stable (deterministic fixtures; zero 503/404 across the run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)