### PR TITLE
fix(showcase): pin ANTHROPIC_BASE_URL aimock serviceRef for claude-sdk-python (watchdog-restart investigation)

### DIFF
--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -341,6 +341,10 @@
         {
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
+        },
+        {
+          "key": "ANTHROPIC_BASE_URL",
+          "target": "aimock"
         }
       ],
       "healthcheckPath": {

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -932,10 +932,20 @@ export const SERVICES: Record<
     probeDriver: "agent",
     // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
     // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
-    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
-    // by the Stage-2 Ruby preflight (never copied).
+    // into the closure. The service-refs are ASSERTED prod→prod by the Stage-2
+    // Ruby preflight (never copied). The claude-sdk agent SDK reads
+    // ANTHROPIC_BASE_URL (see src/agents/claude_agent_sdk_adapter.py and the
+    // aimock-wiring probe's claude-sdk pattern), so it must be pinned at aimock
+    // alongside OPENAI_BASE_URL — otherwise a drifted ANTHROPIC_BASE_URL would
+    // silently bypass aimock and hit the real Anthropic API (non-deterministic
+    // results that look like flapping). This is SSOT hygiene: the var is
+    // already set correctly on the live service; declaring the ref makes the
+    // preflight assert it and refuse a cross-env leak.
     runtimeDeps: ["aimock"],
-    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    serviceRefs: [
+      { key: "OPENAI_BASE_URL", target: "aimock" },
+      { key: "ANTHROPIC_BASE_URL", target: "aimock" },
+    ],
     environments: {
       prod: {
         instanceId: "bb18caaf-9a3e-4fdd-85ec-562fd82a3a89",


### PR DESCRIPTION
> **DRAFT — combined python promote with #6042, gated on Jordan's explicit authorization; do not merge/promote.**

## Summary

Investigated the claude-sdk-python showcase 502 wedge and its prescribed durable fix. Two prescribed changes were on the table: (1) an `entrypoint.sh` watchdog-restart fix and (2) an `ANTHROPIC_BASE_URL` aimock SSOT serviceRef. **This PR ships only (2)** — the SSOT hygiene change. Empirical Docker red-green testing shows the prescribed entrypoint change was **not the right fix** (details below), so it is deliberately omitted rather than shipped as a kernel no-op.

## Root cause (as briefed)

Prod image `sha256:64889ca5` wedged to 502: agent `/health` blocked on a synchronous un-timeouted PocketBase write (`CVDIAG pb-write-failed error=timed out`) → in-container watchdog SIGKILLed uvicorn after ~90s → the container failed to restart, so Railway `ON_FAILURE` never fired → dead-in-place. The briefed remaining defect at HEAD was "the entrypoint watchdog restart kills the uvicorn child, not PID 1 (bash isn't PID 1 under shell-form ENTRYPOINT)".

## Ground-truth finding (contradicts the entrypoint premise)

HEAD's writer + `/health` fixes are confirmed present (threaded/non-blocking writer with 5s timeout in `_shared/cvdiag_pb_writer.py`; bare liveness `/health` returning `{"status":"ok"}` in `src/agent_server.py`). But the entrypoint claim did not hold up under real Docker testing:

1. **HEAD's Dockerfile already uses exec-form** `CMD ["./entrypoint.sh"]` — so the entrypoint bash **IS PID 1** in the real Railway invocation (verified `cat /proc/1/cmdline` → `/bin/bash /app/entrypoint.sh`). The prod wedge described was the *pre-HEAD* image's shell-form; HEAD's Dockerfile already resolves it.

2. **In the real exec-form invocation, HEAD's watchdog restart already works.** Tripping the watchdog (agent `/health` hangs) → watchdog `kill -9 $AGENT_PID` → main shell `wait -n` returns → `exit 137` → container exits **non-zero** → Railway `ON_FAILURE` would restart. Verified: container exits 137, and under `--restart on-failure` it re-execs (RestartCount=1, fresh boot banner, `/api/health` → 200).

3. **The prescribed mechanism `kill -s TERM 1` / `kill -s KILL 1` from the watchdog subshell is a kernel no-op.** The Linux PID-namespace init-protection drops unhandled signals sent to PID 1 from within its own namespace. Verified: a child running `kill -s KILL 1` returns 0 but PID 1 bash keeps running — the container does not exit. So the briefed fix would not have changed behavior.

4. The only scenario where a child-only kill wedges (container exits **0**, `ON_FAILURE` never fires) is when PID 1 is a wait-all supervisor/shell that discards child exit status — i.e. the *shell-form / init-wrapper* condition, which HEAD's exec-form Dockerfile already avoids. No entrypoint code change can force a non-zero container exit through such a wrapper.

**Conclusion:** the entrypoint watchdog restart is not defective at HEAD in the real exec-form invocation, and the prescribed kill-PID-1 mechanism does not work. Shipping it would be a no-op that misleads. It is omitted; the ground truth is documented here for the follow-up decision.

### RED → GREEN Docker proof (verbatim)

Built the full claude-sdk-python image locally (`docker build`, exit 0, 3.75GB). Ran the **real `entrypoint.sh`** (RED = origin/main, GREEN = prescribed `kill PID 1` variant) against a controllable stub agent whose `/health` hangs (`HANG_HEALTH=1`), under `--restart on-failure` (simulating Railway `ON_FAILURE`).

**Real exec-form (PID 1 = entrypoint bash — the actual prod invocation):**
```
# RED (origin/main entrypoint), no restart policy, capture first exit code:
PID1 = /bin/bash /app/entrypoint.sh
[watchdog] Agent unresponsive for ~90s — killing PID 8 to trigger container restart
Status=exited ExitCode=137        <-- NON-ZERO: Railway ON_FAILURE WOULD restart

# RED under --restart on-failure:
boot banners = 2 ; RestartCount=1 ; Running=true ; curl /api/health = 200
=> HEAD already restarts correctly in exec-form. No wedge.
```

**Kernel PID-1 signal-drop proof (why kill-PID-1 is a no-op):**
```
PID1 bash up, self-pid=1
child sending SIGKILL to PID1
child: kill returned 0
Status=running ExitCode=0         <-- PID 1 survived SIGKILL from its own namespace
```

**Wait-all wrapper (artificial non-PID-1 / shell-form condition):**
```
# RED: watchdog kills child; wrapper `wait` returns 0
Status=exited ExitCode=0 RestartCount=0 ; curl = 000 (connection refused)
=> the only wedge repro — but this is the pre-HEAD shell-form condition, not HEAD.

# GREEN (kill -s KILL 1): still exit 0 (kernel drops the PID-1 signal + reap race)
Status=exited ExitCode=0 RestartCount=0
=> prescribed fix does NOT fix even this case.
```

### Value-tests (≥3, against the real code surface in the built image)

Ran inside the built image (`/app` PYTHONPATH, real `_shared/cvdiag_pb_writer.py` + `agent_server.py`):
```
[PASS] VT1b enqueue x50 non-blocking (<0.5s) under unreachable PB — elapsed=0.0006s
[PASS] VT1c enqueue still non-blocking (<0.5s) after daemon hit unreachable PB — elapsed=0.0000s
[PASS] VT2b disabled enqueue is an instant no-op (<0.1s), no worker started — worker=None
[PASS] VT3 /health returns {'status':'ok'} in <1s with PB unreachable — status=200 elapsed=0.0045s
=== VALUE-TEST RESULT: ALL PASS ===
```
These confirm HEAD's writer + `/health` fixes hold (non-blocking enqueue under PB-hang, no-op when disabled, sub-second liveness with PB unreachable).

## What this PR ships

`showcase/scripts/railway-envs.ts` + regenerated `railway-envs.generated.json`: add `{ key: "ANTHROPIC_BASE_URL", target: "aimock" }` to the claude-sdk-python `serviceRefs`, mirroring the existing `OPENAI_BASE_URL` ref. The agent reads `ANTHROPIC_BASE_URL` (`src/agents/claude_agent_sdk_adapter.py`; aimock-wiring probe's claude-sdk pattern), so the Stage-2 Ruby preflight now asserts it prod→prod and refuses a cross-env leak. SSOT hygiene — the var is already set correctly on the live service; this makes the pin drift-proof.

### Pre-push quality (touched files)
- `emit-railway-envs-json.ts --check` → exit 0 ("up to date")
- `oxfmt --check railway-envs.generated.json` → "All matched files use the correct format"
- emit-railway-envs vitest: 14/14 pass
- resolve-verify-matrix vitest: 18/18 pass
- Ruby promote/SSOT specs (single_service_fleet_invariants, expected_domains_parity, lint_prod_covers_starters, fleet_target_invariant): 0 failures
- `tsc --noEmit` (project lib): clean

## Follow-up decision needed
If a durable in-container self-heal is still wanted for the wait-all/shell-form condition, the only mechanisms that actually work are: keep the exec-form Dockerfile (already done) and/or add a real init (tini via `--init` / `ENTRYPOINT ["tini","--"]`) that propagates the child's non-zero exit. That is a Dockerfile/design change, not an entrypoint one-liner — surfaced here for the design owner.
