### PR TITLE
fix(showcase): aimock-wiring probe now covers starter-* services

### DIFF
--- a/showcase/harness/src/probes/aimock-wiring.test.ts
+++ b/showcase/harness/src/probes/aimock-wiring.test.ts
@@ -327,11 +327,11 @@ describe("aimock-wiring probe", () => {
   it("matches the PRIVATE Railway networking host (egress fix): internal aimockUrl vs :4010/v1 base URLs go green", async () => {
     // Egress fix: demo backends route LLM traffic at aimock over free private
     // networking (http://showcase-aimock.railway.internal:4010) instead of the
-    // billed public *.up.railway.app host. The probe matches on HOSTNAME only,
-    // so the harness AIMOCK_URL (bare internal origin) and the demo backends'
-    // OPENAI_BASE_URL (internal host + :4010 port + /v1 suffix) resolve to the
-    // same hostname `showcase-aimock.railway.internal` and the probe stays
-    // green. Locks in that the private-host migration keeps wiring green.
+    // billed public *.up.railway.app host. The probe matches on host+port, so
+    // the harness AIMOCK_URL (internal host + :4010 port) and the demo backends'
+    // OPENAI_BASE_URL (same internal host + :4010 port + /v1 suffix) resolve to
+    // the same host+port `showcase-aimock.railway.internal:4010` and the probe
+    // stays green. Locks in that the private-host migration keeps wiring green.
     const INTERNAL_AIMOCK = "http://showcase-aimock.railway.internal:4010";
     const r = await aimockWiringProbe.run(
       {
@@ -547,7 +547,7 @@ describe("aimock-wiring probe", () => {
 
   it("HF13-C1: malformed aimockUrl emits probeErrored + config-error entry in errored (no per-service iteration)", async () => {
     // Regression: when AIMOCK_BASE_URL is unparseable, the probe used to fall
-    // through `normalizeUrl -> null` and mark every service as mismatch,
+    // through `extractHostPort -> null` and mark every service as mismatch,
     // firing a spurious "all services drifted" alert. The correct behavior is
     // to short-circuit with a config-error sentinel in `errored` so
     // `deriveSignalFlags` emits `set_errored` and the aimock-wiring-drift rule
@@ -589,11 +589,9 @@ describe("aimock-wiring probe", () => {
     expect(r.signal.wired).toEqual([]);
     expect(r.signal.sealed).toEqual([]);
     expect(getServiceEnvCalls).toBe(0);
-    // listServices is allowed to run (needed for excluded filtering would add
-    // noise); assert it didn't iterate services either by checking env wasn't
-    // fetched. We don't constrain listServices itself because the contract is
-    // "no per-service env lookups", not "skip listServices".
-    expect(listServicesCalls).toBeLessThanOrEqual(1);
+    // The config-error short-circuit returns BEFORE `listServices` is called,
+    // so neither the service listing nor any per-service env lookup runs.
+    expect(listServicesCalls).toBe(0);
   });
 
   it("HF13-C1: well-formed probe runs carry probeErrored=false + configError=false", async () => {
@@ -633,7 +631,7 @@ describe("aimock-wiring probe", () => {
   it("wired when OPENAI_BASE_URL has /v1 path suffix and aimockUrl does not", async () => {
     // Most services set OPENAI_BASE_URL=<aimock>/v1 (OpenAI SDK convention)
     // while AIMOCK_URL is just the bare origin. The probe must match by
-    // hostname so the /v1 path difference does not cause a false mismatch.
+    // host+port so the /v1 path difference does not cause a false mismatch.
     const r = await aimockWiringProbe.run(
       {
         aimockUrl: AIMOCK_URL,
@@ -933,6 +931,128 @@ describe("aimock-wiring probe", () => {
     expect(r.state).toBe("green");
     expect(r.signal.sealed).toEqual(["svc-only-sealed"]);
     expect(r.signal.unwired).toEqual([]);
+    expect(r.signal.wired).toEqual([]);
+  });
+
+  it("precedence rule 1: a confirmed MATCH beats a confirmed MISMATCH on a sibling candidate → wired (green)", async () => {
+    // A service with OPENAI_BASE_URL pointing at the real API (confirmed
+    // mismatch) but ANTHROPIC_BASE_URL pointing at aimock (confirmed match)
+    // is unambiguously wired: any confirmed match wins over everything else,
+    // including a confirmed-mismatch sibling. Locks precedence rule (1).
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: AIMOCK_URL,
+        listServices: async () => [{ name: "svc-mixed-match" }],
+        getServiceEnv: async () => ({
+          OPENAI_BASE_URL: "https://api.openai.com/v1", // confirmed non-aimock
+          ANTHROPIC_BASE_URL: AIMOCK_URL, // confirmed aimock match
+        }),
+      },
+      ctx,
+    );
+    expect(r.state).toBe("green");
+    expect(r.signal.wired).toEqual(["svc-mixed-match"]);
+    expect(r.signal.unwired).toEqual([]);
+    expect(r.signal.sealed).toEqual([]);
+  });
+
+  it("unparseable candidate value (no matching sibling) → confirmed mismatch → unwired (red)", async () => {
+    // A candidate that is SET but does not parse as a URL ("not a url") is
+    // confirmed non-aimock, not "no signal": with no matching sibling the
+    // service is unwired and trips red. Locks the `cand === null` branch that
+    // still falls through to `anyConfirmedMismatch = true`.
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: AIMOCK_URL,
+        listServices: async () => [{ name: "svc-garbage-url" }],
+        getServiceEnv: async () => ({
+          OPENAI_BASE_URL: "not a url",
+        }),
+      },
+      ctx,
+    );
+    expect(r.state).toBe("red");
+    expect(r.signal.unwired).toEqual(["svc-garbage-url"]);
+    expect(r.signal.wired).toEqual([]);
+    expect(r.signal.sealed).toEqual([]);
+  });
+
+  it("empty-string candidate is treated as MISSING (no signal), not a confirmed mismatch", async () => {
+    // "" contributes no signal, exactly like an absent var. So:
+    //   - empty OPENAI + matching ANTHROPIC → the match still wins → wired.
+    const wired = await aimockWiringProbe.run(
+      {
+        aimockUrl: AIMOCK_URL,
+        listServices: async () => [{ name: "svc-empty-plus-match" }],
+        getServiceEnv: async () => ({
+          OPENAI_BASE_URL: "",
+          ANTHROPIC_BASE_URL: AIMOCK_URL,
+        }),
+      },
+      ctx,
+    );
+    expect(wired.state).toBe("green");
+    expect(wired.signal.wired).toEqual(["svc-empty-plus-match"]);
+
+    //   - empty everywhere → all-missing → unwired (red), NOT a mismatch that
+    //     would still be red for the wrong reason.
+    const unwired = await aimockWiringProbe.run(
+      {
+        aimockUrl: AIMOCK_URL,
+        listServices: async () => [{ name: "svc-all-empty" }],
+        getServiceEnv: async () => ({
+          OPENAI_BASE_URL: "",
+          ANTHROPIC_BASE_URL: "",
+          GOOGLE_GEMINI_BASE_URL: "",
+        }),
+      },
+      ctx,
+    );
+    expect(unwired.state).toBe("red");
+    expect(unwired.signal.unwired).toEqual(["svc-all-empty"]);
+
+    //   - empty OPENAI + sealed ANTHROPIC → the only real signal is sealed, so
+    //     the service lands in `sealed` (green). If "" were mistakenly treated
+    //     as a confirmed mismatch, rule (2) would demote this to unwired/red —
+    //     this assertion is what discriminates "empty == missing" from
+    //     "empty == confirmed mismatch".
+    const sealed = await aimockWiringProbe.run(
+      {
+        aimockUrl: AIMOCK_URL,
+        listServices: async () => [{ name: "svc-empty-plus-sealed" }],
+        getServiceEnv: async () => ({
+          OPENAI_BASE_URL: "",
+          ANTHROPIC_BASE_URL: SEALED_SENTINEL,
+        }),
+      },
+      ctx,
+    );
+    expect(sealed.state).toBe("green");
+    expect(sealed.signal.sealed).toEqual(["svc-empty-plus-sealed"]);
+    expect(sealed.signal.unwired).toEqual([]);
+  });
+
+  it("sealed and unwired coexist in one run: sealed is surfaced, unwired trips red", async () => {
+    // A run with one genuinely-sealed service and one genuinely-unwired service
+    // must populate BOTH buckets independently: the sealed service does NOT get
+    // swept into `unwired` (which would over-report drift), and the unwired
+    // service still trips the probe red.
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: AIMOCK_URL,
+        listServices: async () => [
+          { name: "svc-sealed" },
+          { name: "svc-unwired" },
+        ],
+        getServiceEnv: async (name) =>
+          name === "svc-sealed" ? { OPENAI_BASE_URL: SEALED_SENTINEL } : {},
+      },
+      ctx,
+    );
+    expect(r.state).toBe("red");
+    expect(r.signal.sealed).toEqual(["svc-sealed"]);
+    expect(r.signal.unwired).toEqual(["svc-unwired"]);
+    expect(r.signal.hasSealed).toBe(true);
     expect(r.signal.wired).toEqual([]);
   });
 });

--- a/showcase/harness/src/probes/aimock-wiring.test.ts
+++ b/showcase/harness/src/probes/aimock-wiring.test.ts
@@ -275,8 +275,12 @@ describe("aimock-wiring probe", () => {
   });
 
   it("normalizes URL: default http :80 and https :443 ports collapse to implicit form", async () => {
-    // Declare two services so both default-port variants are exercised in
-    // one run without crossing protocols on the aimock URL itself.
+    // Port-aware matching (c2) still treats a default port and its implicit
+    // form as equivalent: `https://h` ≡ `https://h:443`, `http://h` ≡
+    // `http://h:80`. This would FAIL a naive exact-string port compare
+    // (candidate `URL.port` "443"/"80" vs target `URL.port` "") — the probe
+    // must derive the effective port from the protocol default on BOTH sides.
+    // Implicit target vs explicit candidate (:443):
     const r = await aimockWiringProbe.run(
       {
         aimockUrl: "https://aimock.example",
@@ -290,6 +294,7 @@ describe("aimock-wiring probe", () => {
     expect(r.state).toBe("green");
     expect(r.signal.wiredCount).toBe(1);
 
+    // Implicit target vs explicit candidate (:80):
     const r2 = await aimockWiringProbe.run(
       {
         aimockUrl: "http://aimock.example",
@@ -302,6 +307,21 @@ describe("aimock-wiring probe", () => {
     );
     expect(r2.state).toBe("green");
     expect(r2.signal.wiredCount).toBe(1);
+
+    // Reverse direction — explicit target port vs implicit candidate — must
+    // also collapse (locks both sides of the comparison, not just one).
+    const r3 = await aimockWiringProbe.run(
+      {
+        aimockUrl: "https://aimock.example:443",
+        listServices: async () => [{ name: "s-implicit-443" }],
+        getServiceEnv: async () => ({
+          OPENAI_BASE_URL: "https://aimock.example",
+        }),
+      },
+      ctx,
+    );
+    expect(r3.state).toBe("green");
+    expect(r3.signal.wiredCount).toBe(1);
   });
 
   it("matches the PRIVATE Railway networking host (egress fix): internal aimockUrl vs :4010/v1 base URLs go green", async () => {
@@ -816,5 +836,103 @@ describe("aimock-wiring probe", () => {
     expect(r.state).toBe("red");
     expect(r.signal.unwired).toEqual([...backends, ...starters].sort());
     expect(r.signal.unwiredCount).toBe(32);
+  });
+
+  it("c2 wrong-port: correct aimock host but a DIFFERENT port than aimock target → unwired (red)", async () => {
+    // Internal aimock serves ONLY on :4010. A service on the correct host but
+    // the wrong port is NOT actually routed through aimock — it must read as
+    // unwired. Under naive hostname-only matching this false-passes as wired.
+    const INTERNAL_AIMOCK = "http://showcase-aimock.railway.internal:4010";
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: INTERNAL_AIMOCK,
+        listServices: async () => [{ name: "showcase-ag2" }],
+        getServiceEnv: async () => ({
+          // Same host, WRONG port (8080 instead of 4010).
+          OPENAI_BASE_URL: "http://showcase-aimock.railway.internal:8080/v1",
+        }),
+      },
+      ctx,
+    );
+    expect(r.state).toBe("red");
+    expect(r.signal.unwired).toEqual(["showcase-ag2"]);
+    expect(r.signal.wired).toEqual([]);
+  });
+
+  it("c2 missing-port: correct aimock host but NO port (default :80) when target is :4010 → unwired (red)", async () => {
+    // A bare host with no explicit port resolves to the protocol default
+    // (:80 for http), which is NOT :4010 — so it must not read as wired.
+    const INTERNAL_AIMOCK = "http://showcase-aimock.railway.internal:4010";
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: INTERNAL_AIMOCK,
+        listServices: async () => [{ name: "showcase-ag2" }],
+        getServiceEnv: async () => ({
+          OPENAI_BASE_URL: "http://showcase-aimock.railway.internal/v1",
+        }),
+      },
+      ctx,
+    );
+    expect(r.state).toBe("red");
+    expect(r.signal.unwired).toEqual(["showcase-ag2"]);
+  });
+
+  it("c2 correct-port: correct aimock host AND :4010 port (with /v1) → wired (green)", async () => {
+    // The happy path the live prod roster uses: internal host + :4010 + /v1.
+    // Port matches the target's :4010, path is irrelevant → wired.
+    const INTERNAL_AIMOCK = "http://showcase-aimock.railway.internal:4010";
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: INTERNAL_AIMOCK,
+        listServices: async () => [{ name: "showcase-ag2" }],
+        getServiceEnv: async () => ({
+          OPENAI_BASE_URL: "http://showcase-aimock.railway.internal:4010/v1",
+        }),
+      },
+      ctx,
+    );
+    expect(r.state).toBe("green");
+    expect(r.signal.wired).toEqual(["showcase-ag2"]);
+    expect(r.signal.unwired).toEqual([]);
+  });
+
+  it("c1 confirmed-mismatch beats sealed: a real non-aimock host + a sealed sibling → unwired (red), NOT sealed", async () => {
+    // A candidate that is SET to a confirmed non-aimock host (api.openai.com)
+    // is provable drift and must win over a sealed sibling. Bucketing this as
+    // `sealed` would hide real drift (a service escaping to the real API).
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: AIMOCK_URL,
+        listServices: async () => [{ name: "svc-drifted" }],
+        getServiceEnv: async () => ({
+          OPENAI_BASE_URL: "https://api.openai.com/v1", // confirmed non-aimock
+          ANTHROPIC_BASE_URL: SEALED_SENTINEL, // sealed sibling
+        }),
+      },
+      ctx,
+    );
+    expect(r.state).toBe("red");
+    expect(r.signal.unwired).toEqual(["svc-drifted"]);
+    expect(r.signal.sealed).toEqual([]);
+    expect(r.signal.wired).toEqual([]);
+  });
+
+  it("c1 purely-sealed still sealed: only signal is a sealed candidate (no confirmed mismatch) → sealed (green)", async () => {
+    // Preserve the sealed bucket for services whose ONLY signal is opaque:
+    // no confirmed mismatch and no confirmed match → sealed, does NOT trip red.
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: AIMOCK_URL,
+        listServices: async () => [{ name: "svc-only-sealed" }],
+        getServiceEnv: async () => ({
+          OPENAI_BASE_URL: SEALED_SENTINEL,
+        }),
+      },
+      ctx,
+    );
+    expect(r.state).toBe("green");
+    expect(r.signal.sealed).toEqual(["svc-only-sealed"]);
+    expect(r.signal.unwired).toEqual([]);
+    expect(r.signal.wired).toEqual([]);
   });
 });

--- a/showcase/harness/src/probes/aimock-wiring.test.ts
+++ b/showcase/harness/src/probes/aimock-wiring.test.ts
@@ -668,43 +668,75 @@ describe("aimock-wiring probe", () => {
     expect(r.signal.unwired).toEqual([]);
   });
 
-  it("excludes harness-workers and bare starter-* services by live name (drift regression)", async () => {
-    // Regression for the EXCLUDE drift: after the egress/private-networking
-    // migration the live Railway roster carries `harness-workers` (harness
-    // background workers — pure infra, no LLM callers) plus starters named
-    // `starter-<framework>[-lang]` (e.g. `starter-strands-python`,
-    // `starter-langgraph-js`). The stale EXCLUDE literals were keyed
-    // `showcase-starter-<framework>` (matching `starter-<framework>` only),
-    // and there was no `harness-workers` entry at all — so these six fell
-    // through to being checked, landed in `unwired`, and kept the probe red.
-    // Starters are intentionally not wired through aimock.
+  it("checks starters like any LLM backend (NOT excluded); infra stays excluded", async () => {
+    // Starters route through aimock identically to showcase-* backends
+    // (OPENAI_BASE_URL / ANTHROPIC_BASE_URL / GOOGLE_GEMINI_BASE_URL point at
+    // aimock), so the probe MUST verify their wiring — `starter-*` services are
+    // no longer excluded. Infra services (aimock/shell/…) remain excluded.
     const r = await aimockWiringProbe.run(
       {
         aimockUrl: AIMOCK_URL,
         listServices: async () => [
-          { name: "harness-workers" },
+          { name: "starter-langgraph-python" }, // checked → wired
+          { name: "starter-mastra" }, // checked → unwired
+          { name: "aimock" }, // infra → still excluded
+          { name: "shell" }, // infra → still excluded
+        ],
+        getServiceEnv: async (name) =>
+          name === "starter-langgraph-python"
+            ? { OPENAI_BASE_URL: AIMOCK_URL }
+            : {},
+      },
+      ctx,
+    );
+    // Infra excluded, so it appears in neither bucket. The wired starter lands
+    // in `wired`; the unwired one surfaces (and trips red) like any backend.
+    expect(r.signal.wired).toEqual(["starter-langgraph-python"]);
+    expect(r.signal.unwired).toEqual(["starter-mastra"]);
+    expect(r.state).toBe("red");
+  });
+
+  it("excludes harness-workers (infra) but checks bare starter-* services", async () => {
+    // Regression for the EXCLUDE drift: the live Railway roster carries
+    // `harness-workers` (harness background workers — pure infra, no LLM
+    // callers) which stays excluded, alongside starters named
+    // `starter-<framework>[-lang]` (e.g. `starter-strands-python`,
+    // `starter-langgraph-js`). Starters ARE checked now — a wired starter must
+    // land in `wired`, not be silently skipped.
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: AIMOCK_URL,
+        listServices: async () => [
+          { name: "harness-workers" }, // infra → excluded
           { name: "starter-adk" },
           { name: "starter-langgraph-js" },
           { name: "starter-ms-agent-framework-dotnet" },
           { name: "starter-ms-agent-framework-python" },
           { name: "starter-strands-python" },
-          { name: "showcase-ag2" }, // real backend, wired
+          { name: "showcase-ag2" }, // real backend
         ],
         getServiceEnv: async (name) =>
-          name === "showcase-ag2" ? { OPENAI_BASE_URL: AIMOCK_URL } : {},
+          name === "harness-workers" ? {} : { OPENAI_BASE_URL: AIMOCK_URL },
       },
       ctx,
     );
     expect(r.state).toBe("green");
     expect(r.signal.unwired).toEqual([]);
-    expect(r.signal.wired).toEqual(["showcase-ag2"]);
-    expect(r.signal.wiredCount).toBe(1);
+    expect(r.signal.wired).toEqual([
+      "showcase-ag2",
+      "starter-adk",
+      "starter-langgraph-js",
+      "starter-ms-agent-framework-dotnet",
+      "starter-ms-agent-framework-python",
+      "starter-strands-python",
+    ]);
+    expect(r.signal.wiredCount).toBe(6);
   });
 
-  it("starter- prefix excludes starters but never showcase-* backends", async () => {
-    // Guard: the `starter-` prefix rule must exclude the starter scaffold
-    // while leaving the real `showcase-*` backend in the checked universe.
-    // Neither is wired here, so only the backend may surface as unwired.
+  it("checks starters alongside showcase-* backends (both in the checked universe)", async () => {
+    // The old behavior excluded starters by prefix; now starters route through
+    // aimock exactly like showcase-* backends and are checked identically.
+    // Neither is wired here, so BOTH must surface as unwired.
     const r = await aimockWiringProbe.run(
       {
         aimockUrl: AIMOCK_URL,
@@ -717,14 +749,14 @@ describe("aimock-wiring probe", () => {
       ctx,
     );
     expect(r.state).toBe("red");
-    expect(r.signal.unwired).toEqual(["showcase-mastra"]); // starter excluded
+    expect(r.signal.unwired).toEqual(["showcase-mastra", "starter-mastra"]);
   });
 
-  it("full live roster: exactly the 20 showcase-* backends are checked, 21 excluded", async () => {
-    // Locks the "checked universe == the 20 showcase-* LLM backends" contract
-    // against the full 41-service production roster (9 infra + 20 backends +
-    // 12 starters). Backends are all unwired here, so `unwired` must equal
-    // exactly the 20 backends — infra and starters must all be excluded.
+  it("full live roster: the 20 showcase-* backends AND 12 starters are checked, 9 infra excluded", async () => {
+    // Locks the "checked universe == 20 showcase-* backends + 12 starters"
+    // contract against the full 41-service production roster (9 infra + 20
+    // backends + 12 starters). Backends and starters are all unwired here, so
+    // `unwired` must equal exactly those 32 — only the 9 infra are excluded.
     const infra = [
       "aimock",
       "dashboard",
@@ -782,7 +814,7 @@ describe("aimock-wiring probe", () => {
       ctx,
     );
     expect(r.state).toBe("red");
-    expect(r.signal.unwired).toEqual([...backends].sort());
-    expect(r.signal.unwiredCount).toBe(20);
+    expect(r.signal.unwired).toEqual([...backends, ...starters].sort());
+    expect(r.signal.unwiredCount).toBe(32);
   });
 });

--- a/showcase/harness/src/probes/aimock-wiring.ts
+++ b/showcase/harness/src/probes/aimock-wiring.ts
@@ -86,7 +86,7 @@ const EXCLUDE_SERVICES: ReadonlySet<string> = new Set([
 ]);
 
 export interface AimockWiringInput {
-  /** Base URL of the aimock service (must match per-service BASE_URL exactly). */
+  /** Base URL of the aimock service (matched against each per-service BASE_URL by host+port). */
   aimockUrl: string;
   /** Callback returning the list of services in the Railway project. */
   listServices: () => Promise<{ name: string }[]>;
@@ -153,7 +153,7 @@ export interface AimockWiringSignal {
    * a single config-error sentinel populates `errored` / `erroredPreview`
    * so `deriveSignalFlags` emits `set_errored` and the aimock-wiring-drift
    * rule renders the errored branch (NOT the drift branch). Without this,
-   * `normalizeUrl(aimockUrl)` returned null and every service tripped
+   * `extractHostPort(aimockUrl)` returned null and every service tripped
    * `mismatch`, firing a spurious "all services drifted" page.
    */
   probeErrored: boolean;
@@ -238,7 +238,7 @@ function extractHostPort(
 
 /**
  * Candidate env var names that may point a service at aimock. A service is
- * "wired" if ANY of these resolves to the aimock hostname.
+ * "wired" if ANY of these resolves to the aimock host+port.
  *
  *   - `OPENAI_BASE_URL`: used by the vast majority of services (OpenAI SDK
  *     convention, typically set to `<aimock>/v1`).
@@ -346,15 +346,15 @@ export const aimockWiringProbe: Probe<AimockWiringInput, AimockWiringSignal> = {
     ctx: ProbeContext,
   ): Promise<ProbeResult<AimockWiringSignal>> {
     // HF13-C1: parse the config URL ONCE at probe start. If it fails,
-    // `extractHostname` returns null → `pointsAtAimock` returns "mismatch"
+    // `extractHostPort` returns null → `pointsAtAimock` returns "mismatch"
     // → every service lands in `unwired` → probe goes red with "all
     // services drifted". That paged operators when the actual failure was
     // a config typo in AIMOCK_BASE_URL. Short-circuit here with a
     // dedicated probeErrored signal and skip per-service iteration so
     // Slack renders the errored branch, not the drift branch.
     //
-    // We validate with `new URL` rather than relying on `extractHostname`
-    // alone because a null return from hostname extraction is also a
+    // We validate with `new URL` rather than relying on `extractHostPort`
+    // alone because a null return from host+port extraction is also a
     // legitimate value for per-service env vars (a service without the
     // var set). Parse+throw gives us a clean boot-time guard.
     let aimockUrlValid = true;

--- a/showcase/harness/src/probes/aimock-wiring.ts
+++ b/showcase/harness/src/probes/aimock-wiring.ts
@@ -50,20 +50,21 @@ export const SEALED_SENTINEL = "__SEALED__";
  * counted as unwired).
  *
  * Most entries are stored in their `showcase-`-prefixed form. The exclusion
- * check (`isExcluded`) normalizes inputs by stripping a leading `showcase-`
- * so a bare deployed name (e.g. `harness`, `shell`, `aimock`) matches the
- * same canonical entry as the prefixed form (`showcase-harness`, …). This is
- * load-bearing: actual deployed Railway service names in the production
- * project are BARE — without the strip, every bare infra service would have
- * been counted as unwired and the probe would have stayed red forever.
- * `harness-workers` has no `showcase-` legacy form, so it is stored bare —
- * `isExcluded` checks the literal name first, so this matches correctly.
+ * check (`isExcluded`) matches a bare deployed name (e.g. `harness`, `shell`,
+ * `aimock`) by PREPENDING `showcase-` to it and testing that prefixed form
+ * against the set — so the bare name resolves to the same canonical entry as
+ * the prefixed form (`showcase-harness`, …). This is load-bearing: actual
+ * deployed Railway service names in the production project are BARE — without
+ * the prepend, every bare infra service would have been counted as unwired
+ * and the probe would have stayed red forever. `harness-workers` has no
+ * `showcase-` legacy form, so it is stored bare — `isExcluded` checks the
+ * literal name first, so this matches correctly.
  *
- * Match is still effectively EXACT post-strip (not prefix): a hypothetical
- * `showcase-aimock-pinger-mock-for-test` strips to `aimock-pinger-mock-for-test`,
- * which is NOT in the set, so it would correctly surface as unwired. Keep
- * this list in sync with the Railway service roster whenever new infra
- * services are added.
+ * Match is still effectively EXACT (not a prefix match): a hypothetical
+ * `showcase-aimock-pinger-mock-for-test` is tested literally and, prepended,
+ * as `showcase-showcase-aimock-pinger-mock-for-test` — neither is in the set,
+ * so it would correctly surface as unwired. Keep this list in sync with the
+ * Railway service roster whenever new infra services are added.
  *
  * NOTE: starters (`starter-*`) are NOT excluded — they route through aimock
  * exactly like the `showcase-*` backends and are checked as ordinary
@@ -190,15 +191,46 @@ function isExcluded(name: string): boolean {
 }
 
 /**
- * Extract the lowercased hostname from a URL string. Returns null if the
- * URL is unparseable. Used by `pointsAtAimock` for hostname-based matching
- * so path differences (`/v1` suffix on `OPENAI_BASE_URL` vs bare origin on
- * `AIMOCK_URL`) don't cause false mismatches.
+ * Default TCP port for a URL protocol, so an implicit URL (`http://h`) and its
+ * explicit form (`http://h:80`) compare equal. Returns the empty string for
+ * protocols we don't special-case; two such URLs still compare equal to each
+ * other by their (also-empty) `URL.port`.
  */
-function extractHostname(raw: string | undefined): string | null {
+function defaultPortForProtocol(protocol: string): string {
+  switch (protocol) {
+    case "https:":
+      return "443";
+    case "http:":
+      return "80";
+    default:
+      return "";
+  }
+}
+
+/**
+ * Extract the lowercased hostname AND effective port from a URL string.
+ * Returns null if the URL is unparseable. Used by `pointsAtAimock` for
+ * host+port matching so path differences (`/v1` suffix on `OPENAI_BASE_URL`
+ * vs bare origin on `AIMOCK_URL`), query strings, and fragments don't cause
+ * false mismatches — but a wrong/missing port DOES (internal aimock serves
+ * only on :4010, so a service on the right host but the wrong port is not
+ * actually routed through aimock).
+ *
+ * The "effective port" collapses default ports: an empty `URL.port` (implicit
+ * default) is replaced with the protocol's default (`:80` for http, `:443`
+ * for https), so `http://h` ≡ `http://h:80` on both sides of the comparison.
+ * The expected port is derived from the probe's configured `aimockUrl` — the
+ * matcher hardcodes no port (the live cron passes
+ * `http://showcase-aimock.railway.internal:4010`).
+ */
+function extractHostPort(
+  raw: string | undefined,
+): { host: string; port: string } | null {
   if (!raw) return null;
   try {
-    return new URL(raw).hostname.toLowerCase();
+    const u = new URL(raw);
+    const port = u.port !== "" ? u.port : defaultPortForProtocol(u.protocol);
+    return { host: u.hostname.toLowerCase(), port };
   } catch {
     return null;
   }
@@ -223,45 +255,71 @@ const CANDIDATE_ENV_VARS = [
 /**
  * Tri-state match against the aimock base URL.
  *   - `"match"`: env var definitely points at aimock.
- *   - `"mismatch"`: env var is set to something else, or is missing entirely.
- *   - `"sealed"`: at least one of the candidate env vars is the sealed
- *     sentinel and none of the others is a confirmed match — we can't decide,
- *     so the service goes to the `sealed` bucket rather than being flagged
- *     as drift.
+ *   - `"mismatch"`: at least one candidate is a CONFIRMED non-aimock value
+ *     (set, non-sentinel, non-empty, and does not match the aimock target),
+ *     OR every candidate is missing/unset (missing == not wired).
+ *   - `"sealed"`: the only signal is a sealed sentinel — no confirmed match
+ *     and no confirmed mismatch, so we can't decide and route the service to
+ *     the `sealed` bucket rather than flagging drift.
  *
- * Matching is **hostname-based**: a candidate value matches aimock if its
- * parsed hostname equals the aimock URL's hostname (case-insensitive). This
- * tolerates the `/v1` path suffix that `OPENAI_BASE_URL` carries by
- * convention — the path is irrelevant for determining whether traffic routes
- * through the aimock proxy. Query strings, fragments, and default ports are
- * also ignored since hostname extraction discards them.
+ * Matching is **host+port based**: a candidate value matches aimock if its
+ * parsed hostname AND effective port both equal the aimock URL's. Host compare
+ * is case-insensitive. This tolerates the `/v1` path suffix that
+ * `OPENAI_BASE_URL` carries by convention, plus query strings and fragments —
+ * those are irrelevant to whether traffic routes through the aimock proxy. But
+ * the port is NOT ignored: internal aimock serves only on :4010, so a service
+ * on the right host but a wrong/missing port is genuine drift. Default ports
+ * collapse (`http://h` ≡ `http://h:80`, `https://h` ≡ `https://h:443`); the
+ * expected port is derived from the configured `aimockUrl` (no port hardcoded).
  *
- * Ordering rationale: a confirmed match on ANY candidate env var wins, even
- * if another candidate is sealed. This mirrors the original "OR" semantics —
- * a service that exposes `ANTHROPIC_BASE_URL=aimock` and has a sealed
- * `OPENAI_BASE_URL` is unambiguously wired.
+ * Precedence: match > mismatch(confirmed) > sealed > mismatch(all-missing).
+ *   1. A confirmed match on ANY candidate wins over everything — a service
+ *      exposing `ANTHROPIC_BASE_URL=aimock` with a sealed `OPENAI_BASE_URL`
+ *      is unambiguously wired.
+ *   2. A CONFIRMED mismatch (a set, non-sentinel candidate pointing elsewhere)
+ *      beats a sealed sibling: provable drift (e.g. a var on real
+ *      api.openai.com) must NOT be masked as "can't decide". Bucketing that as
+ *      sealed would hide a service escaping aimock.
+ *   3. If the only signal is sealed (no confirmed match/mismatch) → sealed.
+ *   4. All-missing/unset → mismatch (nothing wires the service to aimock).
  */
 function pointsAtAimock(
   env: Record<string, string | undefined>,
   aimockUrl: string,
 ): "match" | "mismatch" | "sealed" {
-  const targetHost = extractHostname(aimockUrl);
+  const target = extractHostPort(aimockUrl);
   // Defense-in-depth: the probe's `run` has already validated `aimockUrl`
-  // with `new URL` and short-circuited on failure, so `targetHost` should
-  // never be null here. If it somehow is (e.g. a future caller invokes
+  // with `new URL` and short-circuited on failure, so `target` should never
+  // be null here. If it somehow is (e.g. a future caller invokes
   // `pointsAtAimock` directly), return "mismatch" rather than silently
   // matching — but this path is unreachable via the probe pipeline today.
-  if (targetHost === null) return "mismatch";
+  if (target === null) return "mismatch";
   let anySealed = false;
+  let anyConfirmedMismatch = false;
   for (const varName of CANDIDATE_ENV_VARS) {
     const raw = env[varName];
+    // Missing / empty contributes no signal — treated like the var being
+    // absent (which, if nothing else fires, lands in mismatch(all-missing)).
+    if (raw === undefined || raw === "") continue;
     if (raw === SEALED_SENTINEL) {
       anySealed = true;
       continue;
     }
-    if (extractHostname(raw) === targetHost) return "match";
+    const cand = extractHostPort(raw);
+    if (
+      cand !== null &&
+      cand.host === target.host &&
+      cand.port === target.port
+    ) {
+      return "match"; // (1) confirmed match wins over everything
+    }
+    // Set, non-sentinel, non-empty, and does not match → confirmed drift.
+    // (An unparseable value is also confirmed non-aimock.)
+    anyConfirmedMismatch = true;
   }
-  return anySealed ? "sealed" : "mismatch";
+  if (anyConfirmedMismatch) return "mismatch"; // (2) confirmed drift beats sealed
+  if (anySealed) return "sealed"; // (3) only signal is opaque
+  return "mismatch"; // (4) all-missing / unset
 }
 
 /**

--- a/showcase/harness/src/probes/aimock-wiring.ts
+++ b/showcase/harness/src/probes/aimock-wiring.ts
@@ -65,10 +65,9 @@ export const SEALED_SENTINEL = "__SEALED__";
  * this list in sync with the Railway service roster whenever new infra
  * services are added.
  *
- * NOTE: starter (`starter-*`) exclusion is handled by the prefix rule in
- * `isExcluded`, NOT by literals here — starters are a whole family and were
- * previously listed as `showcase-starter-*` literals that drifted against the
- * live bare `starter-<framework>[-lang]` names. See `isExcluded`.
+ * NOTE: starters (`starter-*`) are NOT excluded — they route through aimock
+ * exactly like the `showcase-*` backends and are checked as ordinary
+ * LLM-calling services. See `isExcluded`.
  */
 const EXCLUDE_SERVICES: ReadonlySet<string> = new Set([
   "showcase-aimock",
@@ -174,19 +173,10 @@ export interface AimockWiringSignal {
 const ERRORED_PREVIEW_MAX = 5;
 
 function isExcluded(name: string): boolean {
-  // Starters are contributor scaffolds, not showcase backends — they are
-  // categorically NOT wired through aimock (per product decision), so exclude
-  // the whole `starter-*` family by PREFIX rather than by per-framework
-  // literal. Matching starters by literal is what drifted: live Railway names
-  // are bare `starter-<framework>[-lang]` (e.g. `starter-strands-python`,
-  // `starter-langgraph-js`) while the stale EXCLUDE entries were keyed
-  // `showcase-starter-<framework>` (matching only `starter-<framework>`), so
-  // renamed/added starters fell through to being checked → unwired → red. A
-  // prefix rule can't re-drift on rename. This is SAFE: the probe's "checked"
-  // universe is intentionally the `showcase-*` LLM backends, and no
-  // `showcase-*` name begins with `starter-`, so this never over-excludes a
-  // real backend.
-  if (name.startsWith("starter-")) return true;
+  // Starters route through aimock identically to the showcase-* backends
+  // (OPENAI_BASE_URL / ANTHROPIC_BASE_URL / GOOGLE_GEMINI_BASE_URL point at
+  // aimock), so they are checked like any other LLM-calling service — NOT
+  // excluded here. Only the pure-infra services in EXCLUDE_SERVICES are skipped.
 
   // Match either the literal name or its `showcase-`-prefixed form. Railway
   // service names in the production project are BARE (`harness`, `shell`,

--- a/showcase/harness/src/probes/aimock-wiring.ts
+++ b/showcase/harness/src/probes/aimock-wiring.ts
@@ -98,7 +98,13 @@ export interface AimockWiringInput {
 }
 
 export interface AimockWiringSignal {
-  /** Services missing an aimock BASE_URL override (sorted, deduped). */
+  /**
+   * Services that are NOT routed through aimock (sorted, deduped). Covers two
+   * cases, both of which `pointsAtAimock` collapses to the `mismatch` verdict:
+   * a service with no aimock BASE_URL override at all (missing/unset), AND a
+   * service whose candidate vars point at a confirmed non-aimock host (a
+   * confirmed mismatch, e.g. a real `api.openai.com`).
+   */
   unwired: string[];
   /** Services correctly routing through aimock (sorted, deduped). */
   wired: string[];
@@ -209,7 +215,8 @@ function defaultPortForProtocol(protocol: string): string {
 
 /**
  * Extract the lowercased hostname AND effective port from a URL string.
- * Returns null if the URL is unparseable. Used by `pointsAtAimock` for
+ * Returns null for empty/undefined input as well as when the URL is
+ * unparseable. Used by `pointsAtAimock` for
  * host+port matching so path differences (`/v1` suffix on `OPENAI_BASE_URL`
  * vs bare origin on `AIMOCK_URL`), query strings, and fragments don't cause
  * false mismatches — but a wrong/missing port DOES (internal aimock serves


### PR DESCRIPTION
## What this fixes

The aimock-wiring probe (`showcase/harness/src/probes/aimock-wiring.ts`) has an `isExcluded()` helper that short-circuited every `starter-*` service out of the checked universe:

```ts
if (name.startsWith("starter-")) return true;
```

The comment justified it by claiming starters are "categorically NOT wired through aimock (per product decision)." That comment is stale and wrong. All 12 `starter-*` services route `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL` / `GOOGLE_GEMINI_BASE_URL` / `AIMOCK_URL` through aimock exactly like the `showcase-*` backends. So the probe was silently skipping wiring verification for a third of the roster.

This PR removes the `starter-` prefix skip so the probe checks starters like any other LLM-calling service, and corrects the two stale comments (the `isExcluded` body and the `EXCLUDE_SERVICES` NOTE block). The `EXCLUDE_SERVICES` set itself is untouched — it lists only pure infra (aimock/shell/dashboard/docs/dojo/pocketbase/harness/harness-workers/webhooks), and starters were never in it.

## Why now / ordering

We're flipping the 12 starters' live base-URL vars from aimock's public URL to its internal URL (a companion live-ops change, not in this PR). Once that flip lands, the probe should be watching those services. This PR makes it do so.

**This must land AFTER the live starter vars are flipped to the internal URL.** If it merges first, the probe will immediately flag the 12 starters as drifted against their pre-existing public-URL values (a real mismatch until the flip happens). Sequence: flip vars → merge this.

## The probe is read-only

Including 12 more services adds only read-only Railway variable reads. The verification path is pure string comparison:

- `aimockWiringProbe.run` calls `listServices()` then, per service, `getServiceEnv(name)` (a Railway GraphQL `variables(...)` query).
- `pointsAtAimock` compares the parsed hostname of each candidate env var (`CANDIDATE_ENV_VARS`) against the aimock URL's hostname.
- No HTTP request is made to the service itself; no LLM traffic is generated. Adding starters just means 12 more variable lookups.

## Red → Green proof

Ran the probe's unit tests (`showcase/harness/src/probes/aimock-wiring.test.ts`), which exercise the real `isExcluded` logic through the exported `aimockWiringProbe.run` surface. Added one focused test and updated three that asserted the old (wrong) starters-excluded behavior.

**RED** — with the `starter-` short-circuit still in place, the tests asserting starters are checked fail:

```
$ npx vitest run src/probes/aimock-wiring.test.ts

 FAIL  ... > checks starters like any LLM backend (NOT excluded); infra stays excluded
 FAIL  ... > excludes harness-workers (infra) but checks bare starter-* services
 FAIL  ... > checks starters alongside showcase-* backends (both in the checked universe)
 FAIL  ... > full live roster: the 20 showcase-* backends AND 12 starters are checked, 9 infra excluded

 Test Files  1 failed (1)
      Tests  4 failed | 29 passed (33)
```

Example assertion diff (roster test): expected 32 unwired (20 backends + 12 starters), received only 19 — the 12 `starter-*` entries were being excluded.

**GREEN** — after removing the short-circuit, the same test file passes:

```
$ npx vitest run src/probes/aimock-wiring.test.ts

 Test Files  1 passed (1)
      Tests  33 passed (33)
```

## Follow-up: probe-correctness fixes (c1 / c2 / c5)

Now that the probe covers all 32 services (20 `showcase-*` + 12 `starter-*`), a cr-loop audit surfaced two coupled correctness holes that let real drift go undetected, plus a stale comment. All three are in `aimock-wiring.ts` / `aimock-wiring.test.ts`.

- **c1 — confirmed mismatch beats sealed.** Old `pointsAtAimock` returned `sealed` whenever any candidate was the sealed sentinel and none was a confirmed match — even if a *sibling* candidate was set to a confirmed non-aimock host (e.g. real `api.openai.com`). That masked provable drift. The precedence is now explicit: **match > mismatch(confirmed) > sealed > mismatch(all-missing)**. A candidate that is set, non-sentinel, non-empty and does not match the aimock target is confirmed drift and wins over a sealed sibling. Purely-sealed (no confirmed match/mismatch) still → `sealed`; all-missing still → `mismatch`.
- **c2 — host + port matching (was host-only).** Internal aimock serves **only on `:4010`**, so a service on the right host but the wrong/missing port is drift, not "wired". Matching now compares host **and** effective port. Default ports collapse (`http://h` ≡ `http://h:80`, `https://h` ≡ `https://h:443`) via the protocol default on both sides. The expected port is **derived from the configured `aimockUrl`** (no port hardcoded) — see `extractHostPort`.
- **c5 — comment fix (no logic change).** The `isExcluded`/`EXCLUDE_SERVICES` doc block said the matcher "strips" a leading `showcase-`; it actually **prepends** `showcase-` to the bare name and tests that form. Corrected to describe the prepend.

### Blast-radius check (host+port change hits all 32 live services)

Confirmed the probe's expected `aimockUrl` carries `:4010` before making matching port-aware. The live cron reads it from `env.AIMOCK_URL` (`orchestrator.ts` `buildCronProbeResolver` / `probes/drivers/aimock-wiring.ts`). Live production value: `AIMOCK_URL = http://showcase-aimock.railway.internal:4010` — carries `:4010`, matching the 32 services' `:4010` base URLs. Port-aware matching therefore keeps prod green.

Note (out of scope): the **staging** harness `AIMOCK_URL` is still the public host `https://aimock-staging.up.railway.app`, while staging services point at the internal `:4010` host. That is already a hostname mismatch under the *current* (host-only) code, so staging is unaffected by this change — but it is a live staging config drift worth flipping to the internal host separately.

### Red → Green proof (c1 / c2)

New/adjusted tests exercise the real `pointsAtAimock` through `aimockWiringProbe.run`.

**RED** — against the pre-fix (host-only, sealed-wins) code:

```
$ npx vitest run src/probes/aimock-wiring.test.ts -t "c2 wrong-port|c2 missing-port|c1 confirmed-mismatch"

 FAIL  ... > c2 wrong-port: correct aimock host but a DIFFERENT port ...  expected 'green' to be 'red'
 FAIL  ... > c2 missing-port: correct aimock host but NO port (:80) ...   expected 'green' to be 'red'
 FAIL  ... > c1 confirmed-mismatch beats sealed ...                       expected 'green' to be 'red'

 Tests  3 failed | 1 passed | 34 skipped (38)
```

**GREEN** — after the c1/c2 fixes, the same tests (plus correct-port, purely-sealed, and the strengthened default-port collapse test) pass, and the full file is green:

```
$ npx vitest run src/probes/aimock-wiring.test.ts
 Test Files  1 passed (1)
      Tests  38 passed (38)
```

### LIVE value-test (shared-mechanism change)

Dumped all 32 non-infra services' base-URL vars from **live production** Railway (read-only `railway variables --json`), then ran the real `aimockWiringProbe.run` with the new code and the production `aimockUrl` (`http://showcase-aimock.railway.internal:4010`):

```
state: green
RESULT: 32/32 wired   (unwired: 0, sealed: 0, errored: 0)
```

No false reds — the port-aware + mismatch-beats-sealed verdict classifies every live production service as wired.

## Local quality (CI-relevant, this path)

- `npm run typecheck` (tsc --noEmit) — clean, exit 0
- `npm run build` (tsc -p tsconfig.build.json) — clean, exit 0
- `oxlint` / `oxfmt --check` on both changed files — clean
- `npm test` (full harness vitest) — **3308 passed**, 18 skipped. Two pre-existing failures unrelated to this change, both reproducible on `origin/main` (neither references aimock-wiring; a transient timing-only flake in `probe-invoker.test.ts` under full-suite parallel load passes 67/67 in isolation):
  - `d0-gone-predicate.test.ts` — reads the gitignored generated `showcase/shell/src/data/registry.json`, which isn't present in a fresh worktree (needs the shell generate step; present in CI/dev).
  - `d5-mapping-drift.test.ts` — parses `shell-dashboard/src/lib/live-status.ts` for `CATALOG_TO_D5_KEY`, but that file is now a re-export barrel (the symbol moved to `harness/src/shared/cell-model/live-status.ts`); the test's hardcoded path is stale on `origin/main`. Not touched by this PR.

Neither failing file is related to the aimock-wiring probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCLub2Vb5Y56cPttSzkip1

