### PR TITLE
feat(react-ui): expose CopilotChat send handle

### DIFF
--- a/packages/react-ui/src/components/chat/Chat.ref.test.tsx
+++ b/packages/react-ui/src/components/chat/Chat.ref.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React, { act, createRef } from "react";
+import { createRoot } from "react-dom/client";
+import type { Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  sendMessage: vi.fn(async (message: unknown) => message),
+  setChatInstructions: vi.fn(),
+  setInternalErrorHandler: vi.fn(),
+  removeInternalErrorHandler: vi.fn(),
+}));
+
+vi.mock("@copilotkit/react-core", () => ({
+  useCopilotContext: () => ({
+    additionalInstructions: [],
+    setChatInstructions: mocks.setChatInstructions,
+    copilotApiConfig: {
+      publicApiKey: undefined,
+      chatApiEndpoint: "/api/copilotkit",
+    },
+    setBannerError: vi.fn(),
+    setInternalErrorHandler: mocks.setInternalErrorHandler,
+    removeInternalErrorHandler: mocks.removeInternalErrorHandler,
+  }),
+  useCopilotChatInternal: () => ({
+    messages: [],
+    isLoading: false,
+    sendMessage: mocks.sendMessage,
+    stopGeneration: vi.fn(),
+    reloadMessages: vi.fn(),
+    suggestions: [],
+    isLoadingSuggestions: false,
+    agent: {},
+  }),
+}));
+
+import { CopilotChat } from "./index";
+import type { CopilotChatRef } from "./index";
+
+describe("CopilotChat ref", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("sends text through the existing message pipeline", async () => {
+    const ref = createRef<CopilotChatRef>();
+
+    await act(async () => {
+      root.render(
+        <CopilotChat
+          ref={ref}
+          Messages={({ children }) => <>{children}</>}
+          Input={() => null}
+        />,
+      );
+    });
+
+    expect(ref.current).not.toBeNull();
+
+    await act(async () => {
+      await ref.current!.sendMessage("evaluate my traces");
+    });
+
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.sendMessage).toHaveBeenCalledWith({
+      id: expect.any(String),
+      content: "evaluate my traces",
+      role: "user",
+    });
+  });
+
+  it("does not send whitespace-only text", async () => {
+    const ref = createRef<CopilotChatRef>();
+
+    await act(async () => {
+      root.render(
+        <CopilotChat
+          ref={ref}
+          Messages={({ children }) => <>{children}</>}
+          Input={() => null}
+        />,
+      );
+    });
+
+    await act(async () => {
+      await ref.current!.sendMessage("   ");
+    });
+
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-ui/src/components/chat/Chat.tsx
+++ b/packages/react-ui/src/components/chat/Chat.tsx
@@ -27,6 +27,28 @@
  * />
  * ```
  *
+ * ### Send a message programmatically
+ *
+ * ```tsx
+ * import { useRef } from "react";
+ * import { CopilotChat, type CopilotChatRef } from "@copilotkit/react-ui";
+ *
+ * export function ChatWithRef() {
+ *   const chatRef = useRef<CopilotChatRef>(null);
+ *
+ *   const sendExample = async () => {
+ *     await chatRef.current?.sendMessage("Evaluate my traces");
+ *   };
+ *
+ *   return (
+ *     <>
+ *       <button onClick={sendExample}>Send example</button>
+ *       <CopilotChat ref={chatRef} />
+ *     </>
+ *   );
+ * }
+ * ```
+ *
  * ### With Observability Hooks
  *
  * To monitor user interactions, provide the `observabilityHooks` prop.
@@ -377,6 +399,13 @@ export interface CopilotChatProps {
   onError?: CopilotErrorHandler;
 }
 
+export interface CopilotChatRef {
+  /**
+   * Sends a text message through the same pipeline as the default chat input.
+   */
+  sendMessage: (text: string) => Promise<void>;
+}
+
 /**
  * @deprecated Use the `Attachment` type from `@copilotkit/react-ui` instead.
  * `ImageUpload` only described image payloads. `Attachment` supports images,
@@ -389,45 +418,48 @@ export type ImageUpload = {
   bytes: string;
 };
 
-export function CopilotChat({
-  instructions,
-  suggestions = "auto",
-  onSubmitMessage,
-  makeSystemMessage,
-  disableSystemMessage,
-  onInProgress,
-  onStopGeneration,
-  onReloadMessages,
-  onRegenerate,
-  onCopy,
-  onThumbsUp,
-  onThumbsDown,
-  markdownTagRenderers,
-  Messages = DefaultMessages,
-  RenderMessage = DefaultRenderMessage,
-  RenderSuggestionsList = DefaultRenderSuggestionsList,
-  Input = DefaultInput,
-  className,
-  icons,
-  labels,
-  AssistantMessage = DefaultAssistantMessage,
-  UserMessage = DefaultUserMessage,
-  ImageRenderer = DefaultImageRenderer,
-  ErrorMessage,
-  imageUploadsEnabled,
-  inputFileAccept = "image/*",
-  attachments,
-  hideStopButton,
-  observabilityHooks,
-  renderError,
-  onError,
-  // Legacy props - deprecated
-  RenderTextMessage,
-  RenderActionExecutionMessage,
-  RenderAgentStateMessage,
-  RenderResultMessage,
-  RenderImageMessage,
-}: CopilotChatProps) {
+function CopilotChatComponent(
+  {
+    instructions,
+    suggestions = "auto",
+    onSubmitMessage,
+    makeSystemMessage,
+    disableSystemMessage,
+    onInProgress,
+    onStopGeneration,
+    onReloadMessages,
+    onRegenerate,
+    onCopy,
+    onThumbsUp,
+    onThumbsDown,
+    markdownTagRenderers,
+    Messages = DefaultMessages,
+    RenderMessage = DefaultRenderMessage,
+    RenderSuggestionsList = DefaultRenderSuggestionsList,
+    Input = DefaultInput,
+    className,
+    icons,
+    labels,
+    AssistantMessage = DefaultAssistantMessage,
+    UserMessage = DefaultUserMessage,
+    ImageRenderer = DefaultImageRenderer,
+    ErrorMessage,
+    imageUploadsEnabled,
+    inputFileAccept = "image/*",
+    attachments,
+    hideStopButton,
+    observabilityHooks,
+    renderError,
+    onError,
+    // Legacy props - deprecated
+    RenderTextMessage,
+    RenderActionExecutionMessage,
+    RenderAgentStateMessage,
+    RenderResultMessage,
+    RenderImageMessage,
+  }: CopilotChatProps,
+  ref: React.ForwardedRef<CopilotChatRef>,
+) {
   const {
     additionalInstructions,
     setChatInstructions,
@@ -732,6 +764,13 @@ export function CopilotChat({
     });
   };
 
+  React.useImperativeHandle(ref, () => ({
+    sendMessage: async (text) => {
+      if (!text.trim()) return;
+      await handleSendMessage(text);
+    },
+  }));
+
   const chatContext = React.useContext(ChatContext);
   const isVisible = chatContext ? chatContext.open : true;
 
@@ -774,7 +813,9 @@ export function CopilotChat({
 
     for (const file of validFiles) {
       if (exceedsMaxSize(file, attachmentsMaxSize)) {
-        const message = `File "${file.name}" exceeds the maximum size of ${formatFileSize(attachmentsMaxSize)}`;
+        const message = `File "${
+          file.name
+        }" exceeds the maximum size of ${formatFileSize(attachmentsMaxSize)}`;
         triggerChatError(new Error(message), "fileUpload");
         resolvedAttachments?.onUploadFailed?.({
           reason: "file-too-large",
@@ -1012,6 +1053,9 @@ export function CopilotChat({
     </WrappedCopilotChat>
   );
 }
+
+export const CopilotChat = React.forwardRef(CopilotChatComponent);
+CopilotChat.displayName = "CopilotChat";
 
 export function WrappedCopilotChat({
   children,

--- a/packages/react-ui/src/components/chat/index.tsx
+++ b/packages/react-ui/src/components/chat/index.tsx
@@ -1,7 +1,11 @@
 export * from "./props";
 export { CopilotPopup } from "./Popup";
 export { CopilotSidebar } from "./Sidebar";
-export { CopilotChat } from "./Chat";
+export {
+  CopilotChat,
+  type CopilotChatProps,
+  type CopilotChatRef,
+} from "./Chat";
 export { CopilotModal } from "./Modal";
 export type { CopilotModalProps } from "./Modal";
 export { Markdown } from "./Markdown";

--- a/packages/react-ui/vitest.config.mjs
+++ b/packages/react-ui/vitest.config.mjs
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: true,
-    include: ["src/**/*.{test,spec}.ts"],
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
     reporters: [["default", { summary: false }]],
     silent: true,
   },


### PR DESCRIPTION
## Summary

- expose a public `CopilotChatRef` with an async `sendMessage(text)` method
- route imperative sends through the existing message pipeline while rejecting whitespace-only input
- add jsdom regression coverage and enable TSX test discovery

Refs #4215

## Testing

- `pnpm nx run @copilotkit/react-ui:test --excludeTaskDependencies --skip-nx-cache`
- `pnpm nx run @copilotkit/react-ui:check-types --excludeTaskDependencies --skip-nx-cache`
- `pnpm nx run @copilotkit/react-ui:build --excludeTaskDependencies --skip-nx-cache`
- `pnpm nx format:check --files=packages/react-ui/src/components/chat/Chat.tsx,packages/react-ui/src/components/chat/Chat.ref.test.tsx,packages/react-ui/src/components/chat/index.tsx,packages/react-ui/vitest.config.mjs`
- `pnpm nx run @copilotkit/react-ui:compat-check --excludeTaskDependencies --skip-nx-cache`
- `pnpm nx run @copilotkit/react-ui:publint --excludeTaskDependencies --skip-nx-cache`
- `pnpm nx run @copilotkit/react-ui:attw --excludeTaskDependencies --skip-nx-cache`
