### PR TITLE
fix(showcase): add declarative-info-row testid to 3 lagging integrations for turn-4 parity

### DIFF
--- a/showcase/integrations/langgraph-fastapi/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/langgraph-fastapi/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -221,7 +221,10 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     // Divider via `border-b last:border-b-0` so the final row doesn't dangle
     // a trailing line, regardless of whether the agent wraps these in a
     // Column or drops them directly into a Card's child slot.
-    <div className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0">
+    <div
+      data-testid="declarative-info-row"
+      className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0"
+    >
       <span className="text-sm text-[var(--muted-foreground)]">
         {props.label}
       </span>

--- a/showcase/integrations/langgraph-typescript/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -221,7 +221,10 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     // Divider via `border-b last:border-b-0` so the final row doesn't dangle
     // a trailing line, regardless of whether the agent wraps these in a
     // Column or drops them directly into a Card's child slot.
-    <div className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0">
+    <div
+      data-testid="declarative-info-row"
+      className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0"
+    >
       <span className="text-sm text-[var(--muted-foreground)]">
         {props.label}
       </span>

--- a/showcase/integrations/pydantic-ai/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -221,7 +221,10 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     // Divider via `border-b last:border-b-0` so the final row doesn't dangle
     // a trailing line, regardless of whether the agent wraps these in a
     // Column or drops them directly into a Card's child slot.
-    <div className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0">
+    <div
+      data-testid="declarative-info-row"
+      className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0"
+    >
       <span className="text-sm text-[var(--muted-foreground)]">
         {props.label}
       </span>


### PR DESCRIPTION
## What

The `gen-ui-declarative` D6 probe drives a 4-turn conversation. Turn 4 (the **top-account** pill — "Pull up the details on our biggest account.") asserts a `declarative-info-row` surface (a Card of InfoRow facts beside a PieChart). Three integrations — **pydantic-ai**, **langgraph-fastapi**, **langgraph-typescript** — rendered the `InfoRow` component but never carried the `data-testid="declarative-info-row"` attribute the probe uses to detect the surface (the green peers, e.g. langgraph-python, already have it). Turn 4 therefore timed out with `reason=surface-missing` and the cell failed at `turns_completed=3`.

## Fix

Add the missing `data-testid="declarative-info-row"` to the `InfoRow` renderer in the 3 lagging integrations, matching the green peers. 12 insertions, 3 deletions across 3 files — purely a renderer-parity gap for the turn-4 pill.

**ButtonProps note:** No `onClick`/TS2322 change was needed. `PrimaryButton` already dispatches actions via `dispatch(props.action)`, and the local `_components/button.tsx` `ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>`, so `onClick` is valid. Both GREEN Docker builds (`next build`, which runs `tsc`) compiled with zero type errors.

## Local RED → GREEN proof (real surface, D6 control-plane, isolated slots)

Base: `origin/main` (3fae3296d — already has `declarative-data-table`; only `declarative-info-row` was missing). Run via `bin/showcase test <slug>:declarative-gen-ui --d6 --isolate --rebuild` (fleet control-plane, NOT `--direct`).

### pydantic-ai
- **RED** (pristine, no testid): turns 1–3 assertions passed; turn 4 failed —
  `waitForTurnComplete: turn 4 did not complete within 90000ms (reason=surface-missing, runsFinished=4, count=8)`. CLI exit 1.
- **GREEN** (with fix): `turn 1/4 … 4/4 — assertions passed`; `✓ Tests passed`. CLI exit 0.

### langgraph-typescript
- **RED** (pristine, no testid): turns 1–3 assertions passed; turn 4 failed —
  `waitForTurnComplete: turn 4 did not complete within 90000ms (reason=surface-missing, runsFinished=4, count=4)`. CLI exit 1.
- **GREEN** (with fix): `turn 1/4 … 4/4 — assertions passed`; `✓ Tests passed`. CLI exit 0.

(langgraph-fastapi carries the byte-identical change on the same base; the two proven cells cover ≥2 as required.)

## Visual verify (painted pixels, not just DOM counts)

Drove the live GREEN pydantic-ai cell through all 4 turns in a real browser with the harness's `X-AIMock-Context: pydantic-ai` header. Turn 4 painted a fully-rendered InfoRow surface — a "Meridian Apparel Group / Biggest account" card with InfoRow facts (Owner: Dana Whitfield, Region: North America, ARR: $612k, Renewal date: Sep 30, Last contact: 3 days ago, Health: Green, Open opportunities: 4 opportunities worth $210k). DOM confirmed `declarative-info-row` count=7, `declarative-pie-chart` count=2. Screenshot: `~/.local/share/copilotkit/cr/turn4-shots/pydantic-turn4-GREEN.png`.

## Root cause

Renderer-parity gap: the turn-4 InfoRow surface was rendered but untestable because 3 integrations dropped the shared `declarative-info-row` testid that the probe and green peers depend on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
