### PR TITLE
fix(showcase): complete claude-sdk-python declarative gen-ui D6 (4-turn sales flow + DataTable/InfoRow parity)

### DIFF
--- a/showcase/aimock/d6/claude-sdk-python/gen-ui-declarative.json
+++ b/showcase/aimock/d6/claude-sdk-python/gen-ui-declarative.json
@@ -1,133 +1,201 @@
 {
   "_meta": {
-    "description": "D6 fixtures for claude-sdk-python / gen-ui-declarative",
-    "sourceScript": "d5-gen-ui-declarative.ts",
+    "description": "D6 fixtures for claude-sdk-python / gen-ui-declarative (A2UI Dynamic Schema)",
+    "sourceFile": "d5-gen-ui-declarative.ts",
     "created": "2026-05-22",
-    "_note": "Components MUST use the flat A2UI catalog shape: {id, component, ...catalog-props-at-top-level}. The sanitize_a2ui_components contract (showcase/integrations/langgraph-python/src/agents/_a2ui_utils.py) drops any entry missing top-level `id` or `component`. The renderer (showcase/integrations/claude-sdk-python/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx) receives the non-id/component fields as `props.*`. Each pill emits render_a2ui with a flat catalog payload mirroring the langgraph-python D6 fixture."
+    "updated": "2026-07-18",
+    "_note": "Agent plays a sales analyst for the fictional Vantage Threads company (OSS-136). Two-stage A2UI pattern mirrors the langgraph-python / google-adk references but on the Anthropic /v1/messages transport (see src/agents/a2ui_dynamic.py): (1) the OUTER Claude call has only one tool, `generate_a2ui`, and emits it with a `context` string arg; (2) `generate_a2ui` internally invokes a SECONDARY Claude call bound to `render_a2ui` (tool_choice forced) which emits the flat A2UI components payload; (3) after the tool_result returns, the outer agent emits a one-sentence narration. Fixtures cover three LLM calls per pill: (a) outer emit -> generate_a2ui toolcall (matched by userMessage + toolName generate_a2ui + hasToolResult:false); (b) inner design -> render_a2ui toolcall (matched by userMessage + toolName render_a2ui, since the user prompt is identical across the outer and inner calls); (c) outer narration -> text (matched by toolCallId, because the follow-up's last user message is a tool_result block with no text so userMessage matchers skip it). Pill prompts are natural business questions; chart steering lives in the system prompt + sales-context.ts composition rules. Keep userMessage matchers in sync with the harness d5-gen-ui-declarative.ts pill prompts. Components MUST use the flat A2UI catalog shape: {id, component, ...catalog-props-at-top-level}. The renderer (declarative-gen-ui/a2ui/renderers.tsx) mounts each catalog component's stable declarative-* testid. chunkSize 9999 keeps each args payload in a single SSE chunk."
   },
   "fixtures": [
     {
-      "_comment": "gen-ui-declarative kpi-dashboard pill — emits render_a2ui with Card root + Column + Metric children. D5 asserts declarative-card and declarative-metric testids mount.",
-      "match": {
-        "userMessage": "KPI dashboard with 3-4 metrics",
-        "hasToolResult": false,
-        "context": "claude-sdk-python"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_kpi_001",
-            "name": "render_a2ui",
-            "arguments": "{\"surfaceId\":\"kpi-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Card\",\"title\":\"Q4 KPI Dashboard\",\"subtitle\":\"Last 30 days\",\"child\":\"metrics-col\"},{\"id\":\"metrics-col\",\"component\":\"Column\",\"children\":[\"m-rev\",\"m-sign\",\"m-churn\"],\"gap\":12},{\"id\":\"m-rev\",\"component\":\"Metric\",\"label\":\"Revenue\",\"value\":\"$1.2M\",\"trend\":\"up\"},{\"id\":\"m-sign\",\"component\":\"Metric\",\"label\":\"Signups\",\"value\":\"4,231\",\"trend\":\"up\"},{\"id\":\"m-churn\",\"component\":\"Metric\",\"label\":\"Churn\",\"value\":\"2.1%\",\"trend\":\"down\"}]}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "KPI dashboard with 3-4 metrics",
-        "hasToolResult": true,
-        "context": "claude-sdk-python"
-      },
-      "response": {
-        "content": "KPI dashboard rendered with revenue, signups, and churn metrics."
-      }
-    },
-    {
-      "_comment": "gen-ui-declarative pie-chart pill — emits render_a2ui with PieChart root. D5 asserts declarative-pie-chart testid mounts.",
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "hasToolResult": false,
-        "context": "claude-sdk-python"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_pie_001",
-            "name": "render_a2ui",
-            "arguments": "{\"surfaceId\":\"sales-pie\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"PieChart\",\"title\":\"Sales by Region\",\"data\":[{\"label\":\"North America\",\"value\":45},{\"label\":\"Europe\",\"value\":30},{\"label\":\"Asia Pacific\",\"value\":25}]}]}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "hasToolResult": true,
-        "context": "claude-sdk-python"
-      },
-      "response": {
-        "content": "Pie chart rendered showing sales distribution across North America (45%), Europe (30%), and Asia Pacific (25%)."
-      }
-    },
-    {
-      "_comment": "gen-ui-declarative bar-chart pill — emits render_a2ui with BarChart root. D5 asserts declarative-bar-chart testid mounts.",
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "hasToolResult": false,
-        "context": "claude-sdk-python"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_bar_001",
-            "name": "render_a2ui",
-            "arguments": "{\"surfaceId\":\"quarterly-rev\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"BarChart\",\"title\":\"Quarterly Revenue\",\"data\":[{\"label\":\"Q1\",\"value\":280000},{\"label\":\"Q2\",\"value\":320000},{\"label\":\"Q3\",\"value\":350000},{\"label\":\"Q4\",\"value\":410000}]}]}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "hasToolResult": true,
-        "context": "claude-sdk-python"
-      },
-      "response": {
-        "content": "Bar chart rendered showing quarterly revenue trending upward from Q1 ($280K) to Q4 ($410K)."
-      }
-    },
-    {
-      "_comment": "gen-ui-declarative status-report pill — emits render_a2ui with Card root + Column + StatusBadge children. D5 asserts declarative-status-badge testid mounts (the distinguishing signal).",
-      "match": {
-        "userMessage": "status report on system health",
-        "hasToolResult": false,
-        "context": "claude-sdk-python"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_status_001",
-            "name": "render_a2ui",
-            "arguments": "{\"surfaceId\":\"sys-status\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Card\",\"title\":\"System health\",\"subtitle\":\"All services\",\"child\":\"badges-col\"},{\"id\":\"badges-col\",\"component\":\"Column\",\"children\":[\"sb-api\",\"sb-db\",\"sb-bg\"],\"gap\":8},{\"id\":\"sb-api\",\"component\":\"StatusBadge\",\"text\":\"API: healthy (99.97% uptime)\",\"variant\":\"success\"},{\"id\":\"sb-db\",\"component\":\"StatusBadge\",\"text\":\"Database: healthy (99.99% uptime)\",\"variant\":\"success\"},{\"id\":\"sb-bg\",\"component\":\"StatusBadge\",\"text\":\"Background Workers: degraded (98.2% uptime)\",\"variant\":\"warning\"}]}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "status report on system health",
-        "hasToolResult": true,
-        "context": "claude-sdk-python"
-      },
-      "response": {
-        "content": "System health report: API and Database are healthy (99.97% and 99.99% uptime). Background Workers are slightly degraded at 98.2% uptime."
-      }
-    },
-    {
-      "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args). Mirrors LGP gen-ui-declarative.json sales-dashboard outer entry. Closes the production 503 gap where backend hits aimock with tools=[generate_a2ui] for this userMessage (see /tmp/staging-journal-diff.md shape-B).",
+      "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui with a context summary.",
       "match": {
         "userMessage": "Show me my sales dashboard for this quarter.",
-        "context": "claude-sdk-python"
+        "context": "claude-sdk-python",
+        "toolName": "generate_a2ui",
+        "hasToolResult": false
       },
       "response": {
         "toolCalls": [
           {
             "id": "call_d6_decl_dash_outer_cspy_001",
             "name": "generate_a2ui",
-            "arguments": "{}"
+            "arguments": "{\"context\":\"Show me my sales dashboard for this quarter.\"}"
           }
         ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill sales-dashboard hero — inner secondary Claude call (tool_choice forced) emits the flat A2UI components. Discriminated by toolName render_a2ui so it wins over the outer generate_a2ui fixture whose userMessage matches the same prompt. Composition rule 1: bare 4-Metric KPI row (no wrapping Card) + PieChart (revenue by region) next to BarChart (monthly revenue). Mounts declarative-metric (x4) + declarative-pie-chart + declarative-bar-chart.",
+      "match": {
+        "userMessage": "Show me my sales dashboard for this quarter.",
+        "context": "claude-sdk-python",
+        "toolName": "render_a2ui"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_dash_design_cspy_001",
+            "name": "render_a2ui",
+            "arguments": "{\"surfaceId\":\"sales-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"kpi-row\",\"charts-row\"]},{\"id\":\"kpi-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-revenue\",\"metric-new-customers\",\"metric-win-rate\",\"metric-deal-size\"]},{\"id\":\"metric-revenue\",\"component\":\"Metric\",\"label\":\"Quarterly Revenue\",\"value\":\"$4.2M\",\"trend\":\"up\"},{\"id\":\"metric-new-customers\",\"component\":\"Metric\",\"label\":\"New Customers\",\"value\":\"186\",\"trend\":\"up\"},{\"id\":\"metric-win-rate\",\"component\":\"Metric\",\"label\":\"Win Rate\",\"value\":\"31%\",\"trend\":\"down\"},{\"id\":\"metric-deal-size\",\"component\":\"Metric\",\"label\":\"Avg Deal Size\",\"value\":\"$22.6k\",\"trend\":\"up\"},{\"id\":\"charts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"region-pie\",\"monthly-bar\"]},{\"id\":\"region-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by Region\",\"description\":\"Quarter revenue split across North America, EMEA, APAC, and LATAM.\",\"data\":[{\"label\":\"North America\",\"value\":1900000},{\"label\":\"EMEA\",\"value\":1300000},{\"label\":\"APAC\",\"value\":720000},{\"label\":\"LATAM\",\"value\":280000}]},{\"id\":\"monthly-bar\",\"component\":\"BarChart\",\"title\":\"Monthly Revenue\",\"description\":\"Revenue trend from Jan through Jun.\",\"data\":[{\"label\":\"Jan\",\"value\":1210000},{\"label\":\"Feb\",\"value\":1340000},{\"label\":\"Mar\",\"value\":1650000},{\"label\":\"Apr\",\"value\":1380000},{\"label\":\"May\",\"value\":1420000},{\"label\":\"Jun\",\"value\":1400000}]}]}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill sales-dashboard hero — outer agent narration after generate_a2ui returns.",
+      "match": {
+        "toolCallId": "call_d6_decl_dash_outer_cspy_001",
+        "context": "claude-sdk-python"
+      },
+      "response": {
+        "content": "Here's your Q2 sales dashboard."
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill team-performance — outer agent emits generate_a2ui with a context summary.",
+      "match": {
+        "userMessage": "How are our sales reps performing against quota?",
+        "context": "claude-sdk-python",
+        "toolName": "generate_a2ui",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_team_outer_cspy_001",
+            "name": "generate_a2ui",
+            "arguments": "{\"context\":\"How are our sales reps performing against quota?\"}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill team-performance — inner secondary Claude call emits the flat A2UI components. Composition rule 2: a Card containing a DataTable (rep/attainment/pipeline) next to a BarChart of quota attainment % per rep. Mounts declarative-data-table + declarative-bar-chart.",
+      "match": {
+        "userMessage": "How are our sales reps performing against quota?",
+        "context": "claude-sdk-python",
+        "toolName": "render_a2ui"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_team_design_cspy_001",
+            "name": "render_a2ui",
+            "arguments": "{\"surfaceId\":\"rep-quota-performance\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"title\",\"summary\",\"content\"]},{\"id\":\"title\",\"component\":\"Text\",\"text\":\"Sales rep performance vs quota\"},{\"id\":\"summary\",\"component\":\"Text\",\"text\":\"2 of 5 reps are above quota, 1 is near plan, and 2 are below target in Q2.\"},{\"id\":\"content\",\"component\":\"Row\",\"gap\":16,\"children\":[\"table-card\",\"attainment-chart\"]},{\"id\":\"table-card\",\"component\":\"Card\",\"title\":\"Rep attainment table\",\"child\":\"rep-table\"},{\"id\":\"rep-table\",\"component\":\"DataTable\",\"columns\":[{\"key\":\"rep\",\"label\":\"Rep\"},{\"key\":\"attainment\",\"label\":\"Attainment\"},{\"key\":\"pipeline\",\"label\":\"Pipeline\"}],\"rows\":[{\"rep\":\"Dana Whitfield\",\"attainment\":\"124%\",\"pipeline\":\"Leading team; biggest account Meridian Apparel Group has 4 open opps worth $210k\"},{\"rep\":\"Marcus Lee\",\"attainment\":\"108%\",\"pipeline\":\"Above plan\"},{\"rep\":\"Priya Sharma\",\"attainment\":\"97%\",\"pipeline\":\"Near quota\"},{\"rep\":\"Tom Okafor\",\"attainment\":\"88%\",\"pipeline\":\"Below plan\"},{\"rep\":\"Elena Vasquez\",\"attainment\":\"71%\",\"pipeline\":\"Furthest from quota\"}]},{\"id\":\"attainment-chart\",\"component\":\"BarChart\",\"title\":\"Quota attainment by rep\",\"description\":\"Q2 quota attainment percentages for all sales reps.\",\"data\":[{\"label\":\"Dana Whitfield\",\"value\":124},{\"label\":\"Marcus Lee\",\"value\":108},{\"label\":\"Priya Sharma\",\"value\":97},{\"label\":\"Tom Okafor\",\"value\":88},{\"label\":\"Elena Vasquez\",\"value\":71}]}]}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill team-performance — outer agent narration after generate_a2ui returns.",
+      "match": {
+        "toolCallId": "call_d6_decl_team_outer_cspy_001",
+        "context": "claude-sdk-python"
+      },
+      "response": {
+        "content": "Here's how the team is tracking against quota."
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill at-risk — outer agent emits generate_a2ui with a context summary.",
+      "match": {
+        "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
+        "context": "claude-sdk-python",
+        "toolName": "generate_a2ui",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_risk_outer_cspy_001",
+            "name": "generate_a2ui",
+            "arguments": "{\"context\":\"Are any accounts or pipeline deals at risk this quarter?\"}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill at-risk — inner secondary Claude call emits the flat A2UI components. Composition rule 3: a 3-Metric KPI row + a Row of 3 compact Cards (one per at-risk account), each with a StatusBadge above a one-line Text. Mounts declarative-status-badge (x3) + declarative-metric (x3).",
+      "match": {
+        "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
+        "context": "claude-sdk-python",
+        "toolName": "render_a2ui"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_risk_design_cspy_001",
+            "name": "render_a2ui",
+            "arguments": "{\"surfaceId\":\"risk-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"metrics-row\",\"accounts-row\"]},{\"id\":\"metrics-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-arr\",\"metric-accounts\",\"metric-biggest\"]},{\"id\":\"metric-arr\",\"component\":\"Metric\",\"label\":\"ARR at risk\",\"value\":\"$615k\",\"trend\":\"down\"},{\"id\":\"metric-accounts\",\"component\":\"Metric\",\"label\":\"Accounts at risk\",\"value\":\"3\",\"trend\":\"neutral\"},{\"id\":\"metric-biggest\",\"component\":\"Metric\",\"label\":\"Biggest exposure\",\"value\":\"Northwind Retail\",\"trend\":\"down\"},{\"id\":\"accounts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"card-northwind\",\"card-cascadia\",\"card-atlas\"]},{\"id\":\"card-northwind\",\"component\":\"Card\",\"title\":\"Northwind Retail\",\"subtitle\":\"$340k ARR at stake\",\"child\":\"northwind-content\"},{\"id\":\"northwind-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"northwind-badge\",\"northwind-text\"]},{\"id\":\"northwind-badge\",\"component\":\"StatusBadge\",\"text\":\"High severity\",\"variant\":\"error\"},{\"id\":\"northwind-text\",\"component\":\"Text\",\"text\":\"No contact in 6 weeks; next action: exec outreach this week to protect the renewal.\"},{\"id\":\"card-cascadia\",\"component\":\"Card\",\"title\":\"Cascadia Outfitters\",\"subtitle\":\"$180k ARR at stake\",\"child\":\"cascadia-content\"},{\"id\":\"cascadia-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"cascadia-badge\",\"cascadia-text\"]},{\"id\":\"cascadia-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"cascadia-text\",\"component\":\"Text\",\"text\":\"Champion left; next action: rebuild stakeholder map and secure a new sponsor.\"},{\"id\":\"card-atlas\",\"component\":\"Card\",\"title\":\"Atlas Goods\",\"subtitle\":\"$95k ARR at stake\",\"child\":\"atlas-content\"},{\"id\":\"atlas-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"atlas-badge\",\"atlas-text\"]},{\"id\":\"atlas-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"atlas-text\",\"component\":\"Text\",\"text\":\"Legal review is stalled; next action: align procurement and legal on open terms.\"}]}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill at-risk — outer agent narration after generate_a2ui returns.",
+      "match": {
+        "toolCallId": "call_d6_decl_risk_outer_cspy_001",
+        "context": "claude-sdk-python"
+      },
+      "response": {
+        "content": "Three accounts need attention this quarter."
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill top-account — outer agent emits generate_a2ui with a context summary.",
+      "match": {
+        "userMessage": "Pull up the details on our biggest account.",
+        "context": "claude-sdk-python",
+        "toolName": "generate_a2ui",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_acct_outer_cspy_001",
+            "name": "generate_a2ui",
+            "arguments": "{\"context\":\"Pull up the details on our biggest account.\"}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill top-account — inner secondary Claude call emits the flat A2UI components. Composition rule 4: a Card of InfoRow facts next to a PieChart of the account's revenue by product line. Mounts declarative-info-row + declarative-pie-chart.",
+      "match": {
+        "userMessage": "Pull up the details on our biggest account.",
+        "context": "claude-sdk-python",
+        "toolName": "render_a2ui"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_acct_design_cspy_001",
+            "name": "render_a2ui",
+            "arguments": "{\"surfaceId\":\"biggest-account-details\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Row\",\"gap\":16,\"children\":[\"account-card\",\"revenue-pie\"]},{\"id\":\"account-card\",\"component\":\"Card\",\"title\":\"Meridian Apparel Group\",\"subtitle\":\"Biggest account\",\"child\":\"account-facts\"},{\"id\":\"account-facts\",\"component\":\"Column\",\"gap\":8,\"children\":[\"fact1\",\"fact2\",\"fact3\",\"fact4\",\"fact5\",\"fact6\",\"fact7\"]},{\"id\":\"fact1\",\"component\":\"InfoRow\",\"label\":\"Owner\",\"value\":\"Dana Whitfield\"},{\"id\":\"fact2\",\"component\":\"InfoRow\",\"label\":\"Region\",\"value\":\"North America\"},{\"id\":\"fact3\",\"component\":\"InfoRow\",\"label\":\"ARR\",\"value\":\"$612k\"},{\"id\":\"fact4\",\"component\":\"InfoRow\",\"label\":\"Renewal date\",\"value\":\"Sep 30\"},{\"id\":\"fact5\",\"component\":\"InfoRow\",\"label\":\"Last contact\",\"value\":\"3 days ago\"},{\"id\":\"fact6\",\"component\":\"InfoRow\",\"label\":\"Health\",\"value\":\"Green\"},{\"id\":\"fact7\",\"component\":\"InfoRow\",\"label\":\"Open opportunities\",\"value\":\"4 opportunities worth $210k\"},{\"id\":\"revenue-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by product line\",\"description\":\"Meridian Apparel Group revenue mix across product lines.\",\"data\":[{\"label\":\"Outerwear\",\"value\":260000},{\"label\":\"Footwear\",\"value\":180000},{\"label\":\"Accessories\",\"value\":112000},{\"label\":\"Custom\",\"value\":60000}]}]}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill top-account — outer agent narration after generate_a2ui returns.",
+      "match": {
+        "toolCallId": "call_d6_decl_acct_outer_cspy_001",
+        "context": "claude-sdk-python"
+      },
+      "response": {
+        "content": "Here's the rundown on Meridian Apparel Group."
       },
       "chunkSize": 9999
     }

--- a/showcase/integrations/claude-sdk-python/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
@@ -54,6 +54,18 @@ export const myDefinitions = {
     }),
   },
 
+  DataTable: {
+    description:
+      "A data table with column headers and rows. Ideal for rankings and per-person/per-item breakdowns (rep performance vs quota, deal lists). Each row's keys MUST appear in `columns[].key`; unknown row keys render as blank cells and indicate model/schema drift.",
+    props: z.object({
+      columns: z.array(z.object({ key: z.string(), label: z.string() })),
+      // Cells may be strings or numbers — the renderer stringifies at
+      // render time, but accepting both lets the LLM emit raw numerics
+      // (e.g. attainment 124) instead of being forced to stringify.
+      rows: z.array(z.record(z.union([z.string(), z.number()]))),
+    }),
+  },
+
   PrimaryButton: {
     description:
       "A styled primary call-to-action button. Attach an optional `action` that will be dispatched back to the agent when the user clicks it.",

--- a/showcase/integrations/claude-sdk-python/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -221,7 +221,10 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     // Divider via `border-b last:border-b-0` so the final row doesn't dangle
     // a trailing line, regardless of whether the agent wraps these in a
     // Column or drops them directly into a Card's child slot.
-    <div className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0">
+    <div
+      data-testid="declarative-info-row"
+      className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0"
+    >
       <span className="text-sm text-[var(--muted-foreground)]">
         {props.label}
       </span>
@@ -230,6 +233,59 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
       </span>
     </div>
   ),
+
+  DataTable: ({ props }) => {
+    const cols = Array.isArray(props.columns) ? props.columns : [];
+    const rows = Array.isArray(props.rows) ? props.rows : [];
+    return (
+      <div
+        data-testid="declarative-data-table"
+        className="w-full overflow-x-auto"
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              {cols.map((col) => (
+                <th
+                  key={col.key}
+                  className="border-b-2 border-[var(--border)] px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => {
+              // Stable row key: prefer the first column's value (primary-key-ish),
+              // suffix with index in case values repeat, fall back to a JSON
+              // stringify of the row when columns is empty. Stable keys prevent
+              // React from re-mounting every row when the agent re-emits a
+              // slightly different table.
+              const pk = cols.length > 0 ? row[cols[0].key] : undefined;
+              const rowKey =
+                pk !== undefined ? `${pk}-${i}` : JSON.stringify(row);
+              return (
+                <tr
+                  key={rowKey}
+                  className="border-b border-[var(--border)] last:border-b-0"
+                >
+                  {cols.map((col) => (
+                    <td
+                      key={col.key}
+                      className="px-3 py-2 tabular-nums text-[var(--foreground)]"
+                    >
+                      {String(row[col.key] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  },
 
   PrimaryButton: ({ props, dispatch }) => (
     <Button


### PR DESCRIPTION
## What

Fixes the `claude-sdk-python` **gen-ui-declarative** D6 showcase cell, which was red with `reason=done-signal-missing`.

## Root cause

The aimock fixture (`showcase/aimock/d6/claude-sdk-python/gen-ui-declarative.json`) still carried the **legacy D5 pills** (KPI dashboard / pie / bar / status report) plus a single stray hero `generate_a2ui` entry. The current D6 driver uses the **4-prompt sales-analyst flow**:

1. "Show me my sales dashboard for this quarter."
2. "How are our sales reps performing against quota?"
3. "Are any accounts or pipeline deals at risk this quarter?"
4. "Pull up the details on our biggest account."

None of those turns had matching fixtures. The backend (`src/agents/a2ui_dynamic.py`) runs a two-stage flow — an outer `generate_a2ui` call, then a secondary `render_a2ui` call — and both hit aimock's `/v1/messages` in STRICT mode, which 404'd (`No fixture matched`). An unmatched turn never emits the expected render, so the run never produced the done signal for that turn.

Two additional **renderer/definition parity gaps** on claude-sdk-python (present on google-adk, absent here) blocked full green:
- Turn 2 asserts `declarative-data-table` — the `DataTable` catalog component (definition + renderer) did not exist.
- Turn 4 asserts `declarative-info-row` — the `InfoRow` renderer was missing that testid.

## Fix

- **Fixture** re-authored into the two-stage Anthropic-transport shape (mirrors the `claude-sdk-typescript` sibling for match discriminators + google-adk for the A2UI payload data). Per turn: (a) outer `generate_a2ui` emit matched by `userMessage`+`toolName`+`hasToolResult:false`, (b) inner `render_a2ui` design matched by `toolName`, (c) outer narration matched by `toolCallId`. Covers all 4 prompts.
- **DataTable** catalog component added (`definitions.ts` + `renderers.tsx`, testid `declarative-data-table`).
- **InfoRow** renderer given the missing `declarative-info-row` testid.

## Local red→green proof

Control-plane, isolation slot 12, `--isolate --rebuild` (real failure surface, not `--direct`):

**RED** (pristine code + pristine fixture):
```
✗ d6:claude-sdk-python/gen-ui-declarative  red  (state=red)  0 passed, 1 failed
aimock: STRICT: No fixture matched for POST /v1/messages  (x6)
```

**GREEN** (fix applied, same slot, rebuilt):
```
✓ d6:claude-sdk-python/gen-ui-declarative  green  1 passed
aimock: 0 no-match
```

## Visual verification

Playwright drive with the harness `X-AIMock-Context: claude-sdk-python` header, all 4 turns painted with the exact per-testid deltas the probe asserts:

| Turn | Newly-mounted testids |
|------|----------------------|
| 1 sales-dashboard | metric ×4, pie-chart ×1, bar-chart ×1 |
| 2 team-performance | data-table ×1, bar-chart ×1 |
| 3 at-risk | status-badge ×3, metric ×3 |
| 4 top-account | info-row ×7, pie-chart ×1 |

Screenshots confirm the DataTable (rep attainment table) and InfoRow (Meridian Apparel Group facts) render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
