### PR TITLE
fix(showcase): flip mastra gen-ui-declarative D6 cell green

### DIFF
--- a/showcase/aimock/d6/mastra/gen-ui-declarative.json
+++ b/showcase/aimock/d6/mastra/gen-ui-declarative.json
@@ -1,186 +1,185 @@
 {
   "_meta": {
-    "description": "D6 fixtures for mastra / gen-ui-declarative (declarative-gen-ui demo)",
-    "sourceFile": "harness/fixtures/d5/gen-ui-declarative.json",
-    "created": "2026-05-22",
-    "note": "ported from gen-ui-declarative (langgraph-python); context rewritten to mastra"
+    "description": "D6 fixtures for mastra / gen-ui-declarative (A2UI Dynamic Schema)",
+    "_note": "Agent plays a sales analyst for the fictional Vantage Threads company. Two-stage A2UI pattern mirrors the green google-adk peer: (1) the outer weatherAgent owns a single `generate_a2ui` tool (no args); (2) `generate-a2ui` internally invokes a secondary LLM (gpt-4.1) with tool_choice forced on `render_a2ui`, which emits the flat A2UI components payload; (3) after the tool returns, the outer agent emits a one-sentence narration. Fixtures cover three LLM calls per pill: (a) outer turn 1 -> generate_a2ui toolcall; (b) inner secondary call -> render_a2ui toolcall (discriminated by toolName because the user prompt is identical across outer+inner calls); (c) outer turn 2 (matched by toolCallId) -> narration. Pill prompts MUST stay in sync with the D5 driver (harness/src/probes/scripts/d5-gen-ui-declarative.ts) and declarative-gen-ui/suggestions.ts. Inner tool is `render_a2ui` (integrations/mastra/src/mastra/tools/index.ts generate-a2ui, toolChoice forced), NOT the stale `_design_a2ui_surface`.",
+    "created": "2026-07-18"
   },
   "fixtures": [
     {
-      "_comment": "pill 1 KPI \u2014 inner secondary LLM (tools=[_design_a2ui_surface], tool_choice forced) emits the flat A2UI components. Discriminated by toolName so it wins over the outer generate_a2ui fixture whose userMessage matches the same prompt.",
+      "_comment": "pill sales-dashboard hero — inner secondary LLM (tool_choice forced on render_a2ui) emits the flat A2UI components. Discriminated by toolName so it wins over the outer generate_a2ui fixture whose userMessage matches the same prompt. Hero surface: bare 4-tile KPI Metric row + PieChart + BarChart (no surrounding Card), satisfying the driver's minCounts metric:4 pie:1 bar:1.",
       "match": {
-        "userMessage": "Show me a quick KPI dashboard",
-        "toolName": "_design_a2ui_surface"
+        "userMessage": "Show me my sales dashboard for this quarter.",
+        "toolName": "render_a2ui"
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_d6_decl_kpi_design_001",
-            "name": "_design_a2ui_surface",
-            "arguments": "{\"surfaceId\":\"kpi-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Card\",\"title\":\"KPI Dashboard\",\"subtitle\":\"Last 30 days\",\"child\":\"metrics-col\"},{\"id\":\"metrics-col\",\"component\":\"Column\",\"children\":[\"m-rev\",\"m-sign\",\"m-churn\",\"m-mrr\"],\"gap\":12},{\"id\":\"m-rev\",\"component\":\"Metric\",\"label\":\"Revenue\",\"value\":\"$1.2M\",\"trend\":\"up\"},{\"id\":\"m-sign\",\"component\":\"Metric\",\"label\":\"Signups\",\"value\":\"8,420\",\"trend\":\"up\"},{\"id\":\"m-churn\",\"component\":\"Metric\",\"label\":\"Churn\",\"value\":\"2.1%\",\"trend\":\"down\"},{\"id\":\"m-mrr\",\"component\":\"Metric\",\"label\":\"MRR\",\"value\":\"$98K\",\"trend\":\"up\"}]}"
+            "id": "call_d6_decl_dash_design_001",
+            "name": "render_a2ui",
+            "arguments": "{\"surfaceId\":\"sales-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"kpi-row\",\"charts-row\"]},{\"id\":\"kpi-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-revenue\",\"metric-new-customers\",\"metric-win-rate\",\"metric-deal-size\"]},{\"id\":\"metric-revenue\",\"component\":\"Metric\",\"label\":\"Quarterly Revenue\",\"value\":\"$4.2M\",\"trend\":\"up\"},{\"id\":\"metric-new-customers\",\"component\":\"Metric\",\"label\":\"New Customers\",\"value\":\"186\",\"trend\":\"up\"},{\"id\":\"metric-win-rate\",\"component\":\"Metric\",\"label\":\"Win Rate\",\"value\":\"31%\",\"trend\":\"down\"},{\"id\":\"metric-deal-size\",\"component\":\"Metric\",\"label\":\"Avg Deal Size\",\"value\":\"$22.6k\",\"trend\":\"up\"},{\"id\":\"charts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"region-pie\",\"monthly-bar\"]},{\"id\":\"region-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by Region\",\"description\":\"Quarter revenue split across North America, EMEA, APAC, and LATAM.\",\"data\":[{\"label\":\"North America\",\"value\":1900000},{\"label\":\"EMEA\",\"value\":1300000},{\"label\":\"APAC\",\"value\":720000},{\"label\":\"LATAM\",\"value\":280000}]},{\"id\":\"monthly-bar\",\"component\":\"BarChart\",\"title\":\"Monthly Revenue\",\"description\":\"Revenue trend from Jan through Jun.\",\"data\":[{\"label\":\"Jan\",\"value\":1210000},{\"label\":\"Feb\",\"value\":1340000},{\"label\":\"Mar\",\"value\":1650000},{\"label\":\"Apr\",\"value\":1380000},{\"label\":\"May\",\"value\":1420000},{\"label\":\"Jun\",\"value\":1400000}]}]}"
           }
         ]
       },
       "chunkSize": 9999
     },
     {
-      "_comment": "pill 1 KPI \u2014 outer agent narration after generate_a2ui returns.",
+      "_comment": "pill sales-dashboard hero — outer agent narration after generate_a2ui returns.",
       "match": {
         "context": "mastra",
-        "toolCallId": "call_d6_decl_kpi_outer_001"
+        "toolCallId": "call_d6_decl_dash_outer_001"
       },
       "response": {
-        "content": "KPI dashboard rendered."
+        "content": "Here's your Q2 sales dashboard."
       },
       "chunkSize": 9999
     },
     {
-      "_comment": "pill 1 KPI \u2014 outer agent emits generate_a2ui (no args).",
+      "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args).",
       "match": {
-        "userMessage": "Show me a quick KPI dashboard",
+        "userMessage": "Show me my sales dashboard for this quarter.",
         "context": "mastra"
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_d6_decl_kpi_outer_001",
+            "id": "call_d6_decl_dash_outer_001",
             "name": "generate_a2ui",
-            "arguments": "{}"
+            "arguments": "{\"messages\": [{\"role\": \"user\", \"content\": \"Show me my sales dashboard for this quarter.\"}]}"
           }
         ]
       },
       "chunkSize": 9999
     },
     {
-      "_comment": "pill 2 pie chart \u2014 inner secondary LLM emits PieChart catalog component.",
+      "_comment": "pill team-performance — inner secondary LLM emits a DataTable + BarChart (driver minCounts data-table:1 bar:1).",
       "match": {
-        "userMessage": "pie chart of sales by region",
-        "toolName": "_design_a2ui_surface"
+        "userMessage": "How are our sales reps performing against quota?",
+        "toolName": "render_a2ui"
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_d6_decl_pie_design_001",
-            "name": "_design_a2ui_surface",
-            "arguments": "{\"surfaceId\":\"sales-pie\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"PieChart\",\"title\":\"Sales by Region\",\"data\":[{\"label\":\"North America\",\"value\":45},{\"label\":\"Europe\",\"value\":28},{\"label\":\"Asia-Pacific\",\"value\":18},{\"label\":\"Other\",\"value\":9}]}]}"
+            "id": "call_d6_decl_team_design_001",
+            "name": "render_a2ui",
+            "arguments": "{\"surfaceId\":\"rep-quota-performance\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"title\",\"summary\",\"content\"]},{\"id\":\"title\",\"component\":\"Text\",\"text\":\"Sales rep performance vs quota\"},{\"id\":\"summary\",\"component\":\"Text\",\"text\":\"2 of 5 reps are above quota, 1 is near plan, and 2 are below target in Q2.\"},{\"id\":\"content\",\"component\":\"Row\",\"gap\":16,\"children\":[\"table-card\",\"attainment-chart\"]},{\"id\":\"table-card\",\"component\":\"Card\",\"title\":\"Rep attainment table\",\"child\":\"rep-table\"},{\"id\":\"rep-table\",\"component\":\"DataTable\",\"columns\":[{\"key\":\"rep\",\"label\":\"Rep\"},{\"key\":\"attainment\",\"label\":\"Attainment\"},{\"key\":\"pipeline\",\"label\":\"Pipeline\"}],\"rows\":[{\"rep\":\"Dana Whitfield\",\"attainment\":\"124%\",\"pipeline\":\"Leading team; biggest account Meridian Apparel Group has 4 open opps worth $210k\"},{\"rep\":\"Marcus Lee\",\"attainment\":\"108%\",\"pipeline\":\"Above plan\"},{\"rep\":\"Priya Sharma\",\"attainment\":\"97%\",\"pipeline\":\"Near quota\"},{\"rep\":\"Tom Okafor\",\"attainment\":\"88%\",\"pipeline\":\"Below plan\"},{\"rep\":\"Elena Vasquez\",\"attainment\":\"71%\",\"pipeline\":\"Furthest from quota\"}]},{\"id\":\"attainment-chart\",\"component\":\"BarChart\",\"title\":\"Quota attainment by rep\",\"description\":\"Q2 quota attainment percentages for all sales reps.\",\"data\":[{\"label\":\"Dana Whitfield\",\"value\":124},{\"label\":\"Marcus Lee\",\"value\":108},{\"label\":\"Priya Sharma\",\"value\":97},{\"label\":\"Tom Okafor\",\"value\":88},{\"label\":\"Elena Vasquez\",\"value\":71}]}]}"
           }
         ]
       },
       "chunkSize": 9999
     },
     {
-      "_comment": "pill 2 pie chart \u2014 outer agent narration.",
+      "_comment": "pill team-performance — outer agent narration after generate_a2ui returns.",
       "match": {
         "context": "mastra",
-        "toolCallId": "call_d6_decl_pie_outer_001"
+        "toolCallId": "call_d6_decl_team_outer_001"
       },
       "response": {
-        "content": "Pie chart rendered."
+        "content": "Here's how the team is tracking against quota."
       },
       "chunkSize": 9999
     },
     {
-      "_comment": "pill 2 pie chart \u2014 outer agent emits generate_a2ui.",
+      "_comment": "pill team-performance — outer agent emits generate_a2ui (no args).",
       "match": {
-        "userMessage": "pie chart of sales by region",
+        "userMessage": "How are our sales reps performing against quota?",
         "context": "mastra"
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_d6_decl_pie_outer_001",
+            "id": "call_d6_decl_team_outer_001",
             "name": "generate_a2ui",
-            "arguments": "{}"
+            "arguments": "{\"messages\": [{\"role\": \"user\", \"content\": \"How are our sales reps performing against quota?\"}]}"
           }
         ]
       },
       "chunkSize": 9999
     },
     {
-      "_comment": "pill 3 bar chart \u2014 inner secondary LLM emits BarChart catalog component.",
+      "_comment": "pill at-risk — inner secondary LLM emits a 3-tile KPI Metric strip + 3 severity Cards each carrying a StatusBadge (driver minCounts status-badge:3 metric:3).",
       "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "toolName": "_design_a2ui_surface"
+        "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
+        "toolName": "render_a2ui"
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_d6_decl_bar_design_001",
-            "name": "_design_a2ui_surface",
-            "arguments": "{\"surfaceId\":\"quarterly-rev\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"BarChart\",\"title\":\"Quarterly Revenue\",\"data\":[{\"label\":\"Q1\",\"value\":280000},{\"label\":\"Q2\",\"value\":310000},{\"label\":\"Q3\",\"value\":295000},{\"label\":\"Q4\",\"value\":340000}]}]}"
+            "id": "call_d6_decl_risk_design_001",
+            "name": "render_a2ui",
+            "arguments": "{\"surfaceId\":\"risk-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"metrics-row\",\"accounts-row\"]},{\"id\":\"metrics-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-arr\",\"metric-accounts\",\"metric-biggest\"]},{\"id\":\"metric-arr\",\"component\":\"Metric\",\"label\":\"ARR at risk\",\"value\":\"$615k\",\"trend\":\"down\"},{\"id\":\"metric-accounts\",\"component\":\"Metric\",\"label\":\"Accounts at risk\",\"value\":\"3\",\"trend\":\"neutral\"},{\"id\":\"metric-biggest\",\"component\":\"Metric\",\"label\":\"Biggest exposure\",\"value\":\"Northwind Retail\",\"trend\":\"down\"},{\"id\":\"accounts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"card-northwind\",\"card-cascadia\",\"card-atlas\"]},{\"id\":\"card-northwind\",\"component\":\"Card\",\"title\":\"Northwind Retail\",\"subtitle\":\"$340k ARR at stake\",\"child\":\"northwind-content\"},{\"id\":\"northwind-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"northwind-badge\",\"northwind-text\"]},{\"id\":\"northwind-badge\",\"component\":\"StatusBadge\",\"text\":\"High severity\",\"variant\":\"error\"},{\"id\":\"northwind-text\",\"component\":\"Text\",\"text\":\"No contact in 6 weeks; next action: exec outreach this week to protect the renewal.\"},{\"id\":\"card-cascadia\",\"component\":\"Card\",\"title\":\"Cascadia Outfitters\",\"subtitle\":\"$180k ARR at stake\",\"child\":\"cascadia-content\"},{\"id\":\"cascadia-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"cascadia-badge\",\"cascadia-text\"]},{\"id\":\"cascadia-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"cascadia-text\",\"component\":\"Text\",\"text\":\"Champion left; next action: rebuild stakeholder map and secure a new sponsor.\"},{\"id\":\"card-atlas\",\"component\":\"Card\",\"title\":\"Atlas Goods\",\"subtitle\":\"$95k ARR at stake\",\"child\":\"atlas-content\"},{\"id\":\"atlas-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"atlas-badge\",\"atlas-text\"]},{\"id\":\"atlas-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"atlas-text\",\"component\":\"Text\",\"text\":\"Legal review is stalled; next action: align procurement and legal on open terms.\"}]}"
           }
         ]
       },
       "chunkSize": 9999
     },
     {
-      "_comment": "pill 3 bar chart \u2014 outer agent narration.",
+      "_comment": "pill at-risk — outer agent narration after generate_a2ui returns.",
       "match": {
         "context": "mastra",
-        "toolCallId": "call_d6_decl_bar_outer_001"
+        "toolCallId": "call_d6_decl_risk_outer_001"
       },
       "response": {
-        "content": "Bar chart rendered."
+        "content": "Three accounts need attention this quarter."
       },
       "chunkSize": 9999
     },
     {
-      "_comment": "pill 3 bar chart \u2014 outer agent emits generate_a2ui.",
+      "_comment": "pill at-risk — outer agent emits generate_a2ui (no args).",
       "match": {
-        "userMessage": "bar chart of quarterly revenue",
+        "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
         "context": "mastra"
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_d6_decl_bar_outer_001",
+            "id": "call_d6_decl_risk_outer_001",
             "name": "generate_a2ui",
-            "arguments": "{}"
+            "arguments": "{\"messages\": [{\"role\": \"user\", \"content\": \"Are any accounts or pipeline deals at risk this quarter?\"}]}"
           }
         ]
       },
       "chunkSize": 9999
     },
     {
-      "_comment": "pill 4 status report \u2014 inner secondary LLM emits StatusBadges grouped in a root Column.",
+      "_comment": "pill top-account — inner secondary LLM emits a Card of InfoRow facts + a PieChart of revenue by product line (driver minCounts info-row:1 pie:1).",
       "match": {
-        "userMessage": "status report on system health",
-        "toolName": "_design_a2ui_surface"
+        "userMessage": "Pull up the details on our biggest account.",
+        "toolName": "render_a2ui"
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_d6_decl_status_design_001",
-            "name": "_design_a2ui_surface",
-            "arguments": "{\"surfaceId\":\"sys-status\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Card\",\"title\":\"System health\",\"subtitle\":\"All services\",\"child\":\"badges-col\"},{\"id\":\"badges-col\",\"component\":\"Column\",\"children\":[\"sb-api\",\"sb-db\",\"sb-bg\"],\"gap\":8},{\"id\":\"sb-api\",\"component\":\"StatusBadge\",\"text\":\"API: healthy (p99 42ms)\",\"variant\":\"success\"},{\"id\":\"sb-db\",\"component\":\"StatusBadge\",\"text\":\"Database: healthy (replication lag 0.2s)\",\"variant\":\"success\"},{\"id\":\"sb-bg\",\"component\":\"StatusBadge\",\"text\":\"Background Workers: degraded (queue depth 1247)\",\"variant\":\"warning\"}]}"
+            "id": "call_d6_decl_acct_design_001",
+            "name": "render_a2ui",
+            "arguments": "{\"surfaceId\":\"biggest-account-details\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Row\",\"gap\":16,\"children\":[\"account-card\",\"revenue-pie\"]},{\"id\":\"account-card\",\"component\":\"Card\",\"title\":\"Meridian Apparel Group\",\"subtitle\":\"Biggest account\",\"child\":\"account-facts\"},{\"id\":\"account-facts\",\"component\":\"Column\",\"gap\":8,\"children\":[\"fact1\",\"fact2\",\"fact3\",\"fact4\",\"fact5\",\"fact6\",\"fact7\"]},{\"id\":\"fact1\",\"component\":\"InfoRow\",\"label\":\"Owner\",\"value\":\"Dana Whitfield\"},{\"id\":\"fact2\",\"component\":\"InfoRow\",\"label\":\"Region\",\"value\":\"North America\"},{\"id\":\"fact3\",\"component\":\"InfoRow\",\"label\":\"ARR\",\"value\":\"$612k\"},{\"id\":\"fact4\",\"component\":\"InfoRow\",\"label\":\"Renewal date\",\"value\":\"Sep 30\"},{\"id\":\"fact5\",\"component\":\"InfoRow\",\"label\":\"Last contact\",\"value\":\"3 days ago\"},{\"id\":\"fact6\",\"component\":\"InfoRow\",\"label\":\"Health\",\"value\":\"Green\"},{\"id\":\"fact7\",\"component\":\"InfoRow\",\"label\":\"Open opportunities\",\"value\":\"4 opportunities worth $210k\"},{\"id\":\"revenue-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by product line\",\"description\":\"Meridian Apparel Group revenue mix across product lines.\",\"data\":[{\"label\":\"Outerwear\",\"value\":260000},{\"label\":\"Footwear\",\"value\":180000},{\"label\":\"Accessories\",\"value\":112000},{\"label\":\"Custom\",\"value\":60000}]}]}"
           }
         ]
       },
       "chunkSize": 9999
     },
     {
-      "_comment": "pill 4 status report \u2014 outer agent narration.",
+      "_comment": "pill top-account — outer agent narration after generate_a2ui returns.",
       "match": {
         "context": "mastra",
-        "toolCallId": "call_d6_decl_status_outer_001"
+        "toolCallId": "call_d6_decl_acct_outer_001"
       },
       "response": {
-        "content": "System health status rendered."
+        "content": "Here's the rundown on Meridian Apparel Group."
       },
       "chunkSize": 9999
     },
     {
-      "_comment": "pill 4 status report \u2014 outer agent emits generate_a2ui.",
+      "_comment": "pill top-account — outer agent emits generate_a2ui (no args).",
       "match": {
-        "userMessage": "status report on system health",
+        "userMessage": "Pull up the details on our biggest account.",
         "context": "mastra"
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_d6_decl_status_outer_001",
+            "id": "call_d6_decl_acct_outer_001",
             "name": "generate_a2ui",
-            "arguments": "{}"
+            "arguments": "{\"messages\": [{\"role\": \"user\", \"content\": \"Pull up the details on our biggest account.\"}]}"
           }
         ]
       },

--- a/showcase/integrations/mastra/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
+++ b/showcase/integrations/mastra/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
@@ -54,6 +54,18 @@ export const myDefinitions = {
     }),
   },
 
+  DataTable: {
+    description:
+      "A data table with column headers and rows. Ideal for rankings and per-person/per-item breakdowns (rep performance vs quota, deal lists). Each row's keys MUST appear in `columns[].key`; unknown row keys render as blank cells and indicate model/schema drift.",
+    props: z.object({
+      columns: z.array(z.object({ key: z.string(), label: z.string() })),
+      // Cells may be strings or numbers — the renderer stringifies at render
+      // time, but accepting both lets the LLM emit raw numerics (e.g.
+      // attainment 124) instead of being forced to stringify.
+      rows: z.array(z.record(z.union([z.string(), z.number()]))),
+    }),
+  },
+
   PrimaryButton: {
     description:
       "A styled primary call-to-action button. Attach an optional `action` that will be dispatched back to the agent when the user clicks it.",

--- a/showcase/integrations/mastra/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/mastra/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -221,7 +221,10 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     // Divider via `border-b last:border-b-0` so the final row doesn't dangle
     // a trailing line, regardless of whether the agent wraps these in a
     // Column or drops them directly into a Card's child slot.
-    <div className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0">
+    <div
+      data-testid="declarative-info-row"
+      className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0"
+    >
       <span className="text-sm text-[var(--muted-foreground)]">
         {props.label}
       </span>
@@ -230,6 +233,59 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
       </span>
     </div>
   ),
+
+  DataTable: ({ props }) => {
+    const cols = Array.isArray(props.columns) ? props.columns : [];
+    const rows = Array.isArray(props.rows) ? props.rows : [];
+    return (
+      <div
+        data-testid="declarative-data-table"
+        className="w-full overflow-x-auto"
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              {cols.map((col) => (
+                <th
+                  key={col.key}
+                  className="border-b-2 border-[var(--border)] px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => {
+              // Stable row key: prefer the first column's value (primary-key-ish),
+              // suffix with index in case values repeat, fall back to a JSON
+              // stringify of the row when columns is empty. Stable keys prevent
+              // React from re-mounting every row when the agent re-emits a
+              // slightly different table.
+              const pk = cols.length > 0 ? row[cols[0].key] : undefined;
+              const rowKey =
+                pk !== undefined ? `${pk}-${i}` : JSON.stringify(row);
+              return (
+                <tr
+                  key={rowKey}
+                  className="border-b border-[var(--border)] last:border-b-0"
+                >
+                  {cols.map((col) => (
+                    <td
+                      key={col.key}
+                      className="px-3 py-2 tabular-nums text-[var(--foreground)]"
+                    >
+                      {String(row[col.key] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  },
 
   PrimaryButton: ({ props, dispatch }) => (
     <Button


### PR DESCRIPTION
## What

Flips the `d6:mastra/gen-ui-declarative` showcase cell from **red** to **green**.

The cell failed turn 1 with `reason=surface-missing` (the dom-missing family). Reading the real failure surface (aimock logs + mastra container logs + harness worker logs) exposed **three** distinct defects, each fixed at its own layer.

## Root cause (empirically confirmed)

1. **Stale aimock fixture.** `aimock/d6/mastra/gen-ui-declarative.json` carried the OLD D5 pill prompts (`"Show me a quick KPI dashboard"`, `"pie chart of sales by region"`, ...) and the stale inner tool name `_design_a2ui_surface`. The current D6 driver sends 4 different prompts, so aimock matched **0** fixtures:
   ```
   [aimock] STRICT: No fixture matched for POST /v1/responses   (x2 = the two-stage flow's outer + inner calls)
   ```
   Nothing emitted → no render → `surface-missing`.

2. **Mastra outer-tool arg schema (mastra-specific).** Unlike the green `google-adk` peer whose outer `generate_a2ui` takes `{}`, mastra's `generateA2uiTool` (`integrations/mastra/src/mastra/tools/index.ts`) has an `inputSchema` that **requires a `messages` array**. After re-authoring the fixture to the green shape (which emits `generate_a2ui` with `{}`), the mastra runtime rejected it:
   ```
   Tool input validation failed for generate_a2ui — messages: Required. Provided arguments: {}
   ```
   The outer tool never executed → no `a2ui_operations` container → `surface-missing` (narration bubble rendered, but no A2UI surface).

3. **Renderer testid parity.** The D6 probe DOM-asserts `declarative-data-table` (turn 2) and `declarative-info-row` (turn 4). Mastra's `renderers.tsx` had **no DataTable renderer at all** and its InfoRow renderer **lacked the `data-testid`**; `definitions.ts` had no DataTable definition. Turns 2 and 4 could never satisfy their assertions.

## Fix (3 files)

- **`aimock/d6/mastra/gen-ui-declarative.json`** — re-authored to the current 4 driver prompts + the green two-stage shape (outer `generate_a2ui` + inner forced `render_a2ui`, `context: "mastra"`, `catalogId: "declarative-gen-ui-catalog"`, per-pill narration). Each outer `generate_a2ui` call now carries a valid `messages` array (mastra schema requirement).
- **`integrations/mastra/.../a2ui/definitions.ts`** — added the `DataTable` catalog definition (mirrors the green `google-adk` peer).
- **`integrations/mastra/.../a2ui/renderers.tsx`** — added `data-testid="declarative-info-row"` to the InfoRow renderer, and added a `DataTable` renderer carrying `data-testid="declarative-data-table"`.

## Red → Green proof (real control-plane surface, slot 13, `--rebuild`)

Command: `SHOWCASE_ISO_SLOT=13 ./bin/showcase test mastra:declarative-gen-ui --d6 --isolate --rebuild`

**RED (pristine main):**
```
✗ d6:mastra/gen-ui-declarative red — state=red
turn 1 did not complete within 90000ms (reason=surface-missing)
```

**GREEN (fixed):**
```
✓ d6:mastra/gen-ui-declarative green
1 passed
[conversation-runner] turn 1/4 — assertions passed   (metric x4, pie, bar; baseline 0)
[conversation-runner] turn 2/4 — assertions passed   (data-table NEW, bar)
[conversation-runner] turn 3/4 — assertions passed   (status-badge x3, metric x3)
[conversation-runner] turn 4/4 — assertions passed   (info-row NEW, pie)
[conversation-runner] conversation completed successfully { turnsCompleted: 4 }
```

## Visual evidence

Drove the live cell through all 4 turns via Playwright (route-level `x-aimock-context` injection) and screenshotted each painted surface — all real renders, no error states:

- **turn 1** sales-dashboard: 4 KPI metric tiles + donut PieChart (Revenue by Region) + BarChart (Monthly Revenue)
- **turn 2** team-performance: DataTable (Rep attainment: Dana Whitfield 124%, ...) — the new renderer
- **turn 3** at-risk: 3 severity cards each with a StatusBadge + 3 KPI metric tiles
- **turn 4** top-account: Card of InfoRow facts (Owner/Region/ARR/...) + PieChart — the new testid

Note: `google-adk` remains the only D6 declarative fixture already on the current prompts; the other integrations (`langgraph-typescript`, etc.) still carry the same stale-fixture shape and are a follow-up wave.
