### PR TITLE
fix(showcase): flip agno gen-ui-declarative D6 cell green (4-turn sales flow + DataTable/InfoRow parity)

### DIFF
--- a/showcase/aimock/d6/agno/gen-ui-declarative.json
+++ b/showcase/aimock/d6/agno/gen-ui-declarative.json
@@ -1,116 +1,201 @@
 {
   "_meta": {
-    "description": "D6 fixtures for agno / gen-ui-declarative",
+    "description": "D6 fixtures for agno / gen-ui-declarative (A2UI Dynamic Schema)",
     "sourceFile": "d5-gen-ui-declarative.ts",
-    "created": "2026-05-22"
+    "_note": "Agent plays a sales analyst for the fictional Vantage Threads company (OSS-136). agno uses a two-stage A2UI pattern (src/agents/a2ui_dynamic_agent.py): (1) the OUTER agent (OpenAIChat gpt-4o) owns a single `generate_a2ui(context: str)` tool; on a pill it emits a generate_a2ui toolcall carrying a per-pill `context` phrase. (2) `generate_a2ui` then makes a SECONDARY OpenAI call bound to `render_a2ui` (tool_choice forced) whose messages are [system=<catalog schema + \"Conversation context:\\n<context arg>\">, user=\"Generate a dynamic A2UI dashboard based on the conversation.\"] — note the inner user message is HARDCODED and identical across all four pills, so the inner render_a2ui fixture CANNOT key on userMessage; it discriminates on toolName:render_a2ui + context:agno + a systemMessage substring equal to the per-pill context phrase the outer injected. (3) after the tool returns, the OUTER agent emits a one-sentence narration (hasToolResult:true). So each pill needs three fixtures: outer emitter (userMessage=pill + hasToolResult:false), inner render (toolName:render_a2ui + systemMessage=context phrase), and narration (userMessage=pill + hasToolResult:true). render_a2ui args mirror the google-adk green north-star (same VantageThreads surfaces + declarative-gen-ui-catalog); agno's RENDER_A2UI_TOOL_SCHEMA (tools/generate_a2ui.py) takes the same surfaceId/catalogId/components nested tree. Runs strict (x-aimock-strict:true) so userMessage matches are exact. Keep pill prompts in sync with declarative-gen-ui/suggestions.ts + harness d5-gen-ui-declarative.ts.",
+    "created": "2026-07-18",
+    "copiedFrom": "google-adk"
   },
   "fixtures": [
     {
-      "_comment": "kpi-dashboard pill — must trigger render_a2ui with Metric + Card catalog components. The probe asserts declarative-card and declarative-metric testids mount.",
+      "_comment": "pill sales-dashboard hero — OUTER agent emits generate_a2ui with a per-pill context arg. Guarded hasToolResult:false so it fires on the outer decision call, not the post-tool narration.",
       "match": {
-        "userMessage": "KPI dashboard with 3-4 metrics",
+        "userMessage": "Show me my sales dashboard for this quarter.",
         "hasToolResult": false,
         "context": "agno"
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_d6_agno_render_a2ui_kpi_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"Card\",\"props\":{\"title\":\"KPI Dashboard\"}},{\"type\":\"Metric\",\"props\":{\"label\":\"Revenue\",\"value\":\"$4.2M\",\"change\":\"+12%\"}},{\"type\":\"Metric\",\"props\":{\"label\":\"Signups\",\"value\":\"1,847\",\"change\":\"+8%\"}},{\"type\":\"Metric\",\"props\":{\"label\":\"Churn\",\"value\":\"2.3%\",\"change\":\"-0.5%\"}}]}"
+            "id": "call_d6_decl_dash_outer_agno_001",
+            "name": "generate_a2ui",
+            "arguments": "{\"context\":\"sales dashboard for this quarter\"}"
           }
         ]
-      }
+      },
+      "chunkSize": 9999
     },
     {
+      "_comment": "pill sales-dashboard hero — INNER secondary planner (forced render_a2ui). The inner user message is the hardcoded 'Generate a dynamic A2UI dashboard...' string for every pill, so we key on toolName:render_a2ui + context:agno + a systemMessage substring equal to the outer's per-pill context phrase (injected as 'Conversation context:\\n<context>'). Args copied verbatim from the google-adk sales-dashboard render entry. Asserts declarative-metric (>=4) + declarative-pie-chart + declarative-bar-chart.",
       "match": {
-        "userMessage": "KPI dashboard with 3-4 metrics",
+        "toolName": "render_a2ui",
+        "systemMessage": "sales dashboard for this quarter",
+        "context": "agno"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_dash_design_agno_001",
+            "name": "render_a2ui",
+            "arguments": "{\"surfaceId\":\"sales-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"kpi-row\",\"charts-row\"]},{\"id\":\"kpi-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-revenue\",\"metric-new-customers\",\"metric-win-rate\",\"metric-deal-size\"]},{\"id\":\"metric-revenue\",\"component\":\"Metric\",\"label\":\"Quarterly Revenue\",\"value\":\"$4.2M\",\"trend\":\"up\",\"trendValue\":\"+12% QoQ\"},{\"id\":\"metric-new-customers\",\"component\":\"Metric\",\"label\":\"New Customers\",\"value\":\"186\",\"trend\":\"up\",\"trendValue\":\"+8%\"},{\"id\":\"metric-win-rate\",\"component\":\"Metric\",\"label\":\"Win Rate\",\"value\":\"31%\",\"trend\":\"down\",\"trendValue\":\"-2 pts\"},{\"id\":\"metric-deal-size\",\"component\":\"Metric\",\"label\":\"Avg Deal Size\",\"value\":\"$22.6k\",\"trend\":\"up\",\"trendValue\":\"+5%\"},{\"id\":\"charts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"region-pie\",\"monthly-bar\"]},{\"id\":\"region-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by Region\",\"description\":\"Quarter revenue split across North America, EMEA, APAC, and LATAM.\",\"data\":[{\"label\":\"North America\",\"value\":1900000},{\"label\":\"EMEA\",\"value\":1300000},{\"label\":\"APAC\",\"value\":720000},{\"label\":\"LATAM\",\"value\":280000}]},{\"id\":\"monthly-bar\",\"component\":\"BarChart\",\"title\":\"Monthly Revenue\",\"description\":\"Revenue trend from Jan through Jun.\",\"data\":[{\"label\":\"Jan\",\"value\":1210000},{\"label\":\"Feb\",\"value\":1340000},{\"label\":\"Mar\",\"value\":1650000},{\"label\":\"Apr\",\"value\":1380000},{\"label\":\"May\",\"value\":1420000},{\"label\":\"Jun\",\"value\":1400000}]}]}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill sales-dashboard hero — TERMINAL narration after generate_a2ui returns (hasToolResult:true) so the run emits RUN_FINISHED.",
+      "match": {
+        "userMessage": "Show me my sales dashboard for this quarter.",
         "hasToolResult": true,
         "context": "agno"
       },
       "response": {
-        "content": "KPI dashboard rendered above with revenue, signups, and churn metrics."
-      }
+        "content": "Here's your Q2 sales dashboard."
+      },
+      "chunkSize": 9999
     },
     {
-      "_comment": "pie-chart pill — must trigger render_a2ui with PieChart catalog component. The probe asserts declarative-pie-chart testid mounts.",
+      "_comment": "pill team-performance — OUTER agent emits generate_a2ui with a per-pill context arg, guarded hasToolResult:false.",
       "match": {
-        "userMessage": "pie chart of sales by region",
+        "userMessage": "How are our sales reps performing against quota?",
         "hasToolResult": false,
         "context": "agno"
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_d6_agno_render_a2ui_pie_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"PieChart\",\"props\":{\"title\":\"Sales by Region\",\"data\":[{\"label\":\"North America\",\"value\":42},{\"label\":\"Europe\",\"value\":28},{\"label\":\"Asia-Pacific\",\"value\":20},{\"label\":\"Other\",\"value\":10}]}}]}"
+            "id": "call_d6_decl_team_outer_agno_001",
+            "name": "generate_a2ui",
+            "arguments": "{\"context\":\"sales rep performance against quota\"}"
           }
         ]
-      }
+      },
+      "chunkSize": 9999
     },
     {
+      "_comment": "pill team-performance — INNER forced render_a2ui, keyed by toolName + systemMessage(=outer context phrase) + context:agno. Args copied verbatim from the google-adk team-performance render entry. Asserts declarative-data-table + declarative-bar-chart.",
       "match": {
-        "userMessage": "pie chart of sales by region",
+        "toolName": "render_a2ui",
+        "systemMessage": "sales rep performance against quota",
+        "context": "agno"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_team_design_agno_001",
+            "name": "render_a2ui",
+            "arguments": "{\"surfaceId\":\"rep-quota-performance\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"title\",\"summary\",\"content\"]},{\"id\":\"title\",\"component\":\"Text\",\"text\":\"Sales rep performance vs quota\"},{\"id\":\"summary\",\"component\":\"Text\",\"text\":\"2 of 5 reps are above quota, 1 is near plan, and 2 are below target in Q2.\"},{\"id\":\"content\",\"component\":\"Row\",\"gap\":16,\"children\":[\"table-card\",\"attainment-chart\"]},{\"id\":\"table-card\",\"component\":\"Card\",\"title\":\"Rep attainment table\",\"child\":\"rep-table\"},{\"id\":\"rep-table\",\"component\":\"DataTable\",\"columns\":[{\"key\":\"rep\",\"label\":\"Rep\"},{\"key\":\"attainment\",\"label\":\"Attainment\"},{\"key\":\"pipeline\",\"label\":\"Pipeline\"}],\"rows\":[{\"rep\":\"Dana Whitfield\",\"attainment\":\"124%\",\"pipeline\":\"Leading team; biggest account Meridian Apparel Group has 4 open opps worth $210k\"},{\"rep\":\"Marcus Lee\",\"attainment\":\"108%\",\"pipeline\":\"Above plan\"},{\"rep\":\"Priya Sharma\",\"attainment\":\"97%\",\"pipeline\":\"Near quota\"},{\"rep\":\"Tom Okafor\",\"attainment\":\"88%\",\"pipeline\":\"Below plan\"},{\"rep\":\"Elena Vasquez\",\"attainment\":\"71%\",\"pipeline\":\"Furthest from quota\"}]},{\"id\":\"attainment-chart\",\"component\":\"BarChart\",\"title\":\"Quota attainment by rep\",\"description\":\"Q2 quota attainment percentages for all sales reps.\",\"data\":[{\"label\":\"Dana Whitfield\",\"value\":124},{\"label\":\"Marcus Lee\",\"value\":108},{\"label\":\"Priya Sharma\",\"value\":97},{\"label\":\"Tom Okafor\",\"value\":88},{\"label\":\"Elena Vasquez\",\"value\":71}]}]}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill team-performance — TERMINAL narration after generate_a2ui returns.",
+      "match": {
+        "userMessage": "How are our sales reps performing against quota?",
         "hasToolResult": true,
         "context": "agno"
       },
       "response": {
-        "content": "Pie chart rendered above showing sales distribution across regions."
-      }
+        "content": "Here's how the team is tracking against quota."
+      },
+      "chunkSize": 9999
     },
     {
-      "_comment": "bar-chart pill — must trigger render_a2ui with BarChart catalog component. The probe asserts declarative-bar-chart testid mounts.",
+      "_comment": "pill at-risk — OUTER agent emits generate_a2ui with a per-pill context arg, guarded hasToolResult:false.",
       "match": {
-        "userMessage": "bar chart of quarterly revenue",
+        "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
         "hasToolResult": false,
         "context": "agno"
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_d6_agno_render_a2ui_bar_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"BarChart\",\"props\":{\"title\":\"Quarterly Revenue\",\"data\":[{\"label\":\"Q1\",\"value\":800000},{\"label\":\"Q2\",\"value\":950000},{\"label\":\"Q3\",\"value\":1100000},{\"label\":\"Q4\",\"value\":1250000}]}}]}"
+            "id": "call_d6_decl_risk_outer_agno_001",
+            "name": "generate_a2ui",
+            "arguments": "{\"context\":\"accounts and pipeline deals at risk this quarter\"}"
           }
         ]
-      }
+      },
+      "chunkSize": 9999
     },
     {
+      "_comment": "pill at-risk — INNER forced render_a2ui, keyed by toolName + systemMessage(=outer context phrase) + context:agno. Args copied verbatim from the google-adk at-risk render entry. Asserts declarative-status-badge (>=3) + declarative-metric (>=3).",
       "match": {
-        "userMessage": "bar chart of quarterly revenue",
+        "toolName": "render_a2ui",
+        "systemMessage": "accounts and pipeline deals at risk this quarter",
+        "context": "agno"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_risk_design_agno_001",
+            "name": "render_a2ui",
+            "arguments": "{\"surfaceId\":\"risk-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"metrics-row\",\"accounts-row\"]},{\"id\":\"metrics-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-arr\",\"metric-accounts\",\"metric-biggest\"]},{\"id\":\"metric-arr\",\"component\":\"Metric\",\"label\":\"ARR at risk\",\"value\":\"$615k\",\"trend\":\"down\",\"trendValue\":\"3 accounts\"},{\"id\":\"metric-accounts\",\"component\":\"Metric\",\"label\":\"Accounts at risk\",\"value\":\"3\",\"trend\":\"neutral\",\"trendValue\":\"This quarter\"},{\"id\":\"metric-biggest\",\"component\":\"Metric\",\"label\":\"Biggest exposure\",\"value\":\"Northwind Retail\",\"trend\":\"down\",\"trendValue\":\"$340k renewal\"},{\"id\":\"accounts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"card-northwind\",\"card-cascadia\",\"card-atlas\"]},{\"id\":\"card-northwind\",\"component\":\"Card\",\"title\":\"Northwind Retail\",\"subtitle\":\"$340k ARR at stake\",\"child\":\"northwind-content\"},{\"id\":\"northwind-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"northwind-badge\",\"northwind-text\"]},{\"id\":\"northwind-badge\",\"component\":\"StatusBadge\",\"text\":\"High severity\",\"variant\":\"error\"},{\"id\":\"northwind-text\",\"component\":\"Text\",\"text\":\"No contact in 6 weeks; next action: exec outreach this week to protect the renewal.\"},{\"id\":\"card-cascadia\",\"component\":\"Card\",\"title\":\"Cascadia Outfitters\",\"subtitle\":\"$180k ARR at stake\",\"child\":\"cascadia-content\"},{\"id\":\"cascadia-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"cascadia-badge\",\"cascadia-text\"]},{\"id\":\"cascadia-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"cascadia-text\",\"component\":\"Text\",\"text\":\"Champion left; next action: rebuild stakeholder map and secure a new sponsor.\"},{\"id\":\"card-atlas\",\"component\":\"Card\",\"title\":\"Atlas Goods\",\"subtitle\":\"$95k ARR at stake\",\"child\":\"atlas-content\"},{\"id\":\"atlas-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"atlas-badge\",\"atlas-text\"]},{\"id\":\"atlas-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"atlas-text\",\"component\":\"Text\",\"text\":\"Legal review is stalled; next action: align procurement and legal on open terms.\"}]}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill at-risk — TERMINAL narration after generate_a2ui returns.",
+      "match": {
+        "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
         "hasToolResult": true,
         "context": "agno"
       },
       "response": {
-        "content": "Bar chart rendered above showing quarterly revenue trend."
-      }
+        "content": "Three accounts need attention this quarter."
+      },
+      "chunkSize": 9999
     },
     {
-      "_comment": "status-report pill — must trigger render_a2ui with StatusBadge catalog component. The probe asserts declarative-status-badge testid mounts (this is the distinguishing signal).",
+      "_comment": "pill top-account — OUTER agent emits generate_a2ui with a per-pill context arg, guarded hasToolResult:false.",
       "match": {
-        "userMessage": "status report on system health",
+        "userMessage": "Pull up the details on our biggest account.",
         "hasToolResult": false,
         "context": "agno"
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_d6_agno_render_a2ui_status_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"StatusBadge\",\"props\":{\"label\":\"API\",\"status\":\"healthy\"}},{\"type\":\"StatusBadge\",\"props\":{\"label\":\"Database\",\"status\":\"healthy\"}},{\"type\":\"StatusBadge\",\"props\":{\"label\":\"Background Workers\",\"status\":\"degraded\"}}]}"
+            "id": "call_d6_decl_acct_outer_agno_001",
+            "name": "generate_a2ui",
+            "arguments": "{\"context\":\"details on our biggest account\"}"
           }
         ]
-      }
+      },
+      "chunkSize": 9999
     },
     {
+      "_comment": "pill top-account — INNER forced render_a2ui, keyed by toolName + systemMessage(=outer context phrase) + context:agno. Args copied verbatim from the google-adk top-account render entry. Asserts declarative-info-row + declarative-pie-chart.",
       "match": {
-        "userMessage": "status report on system health",
+        "toolName": "render_a2ui",
+        "systemMessage": "details on our biggest account",
+        "context": "agno"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_acct_design_agno_001",
+            "name": "render_a2ui",
+            "arguments": "{\"surfaceId\":\"biggest-account-details\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Row\",\"gap\":16,\"children\":[\"account-card\",\"revenue-pie\"]},{\"id\":\"account-card\",\"component\":\"Card\",\"title\":\"Meridian Apparel Group\",\"subtitle\":\"Biggest account\",\"child\":\"account-facts\"},{\"id\":\"account-facts\",\"component\":\"Column\",\"gap\":8,\"children\":[\"fact1\",\"fact2\",\"fact3\",\"fact4\",\"fact5\",\"fact6\",\"fact7\"]},{\"id\":\"fact1\",\"component\":\"InfoRow\",\"label\":\"Owner\",\"value\":\"Dana Whitfield\"},{\"id\":\"fact2\",\"component\":\"InfoRow\",\"label\":\"Region\",\"value\":\"North America\"},{\"id\":\"fact3\",\"component\":\"InfoRow\",\"label\":\"ARR\",\"value\":\"$612k\"},{\"id\":\"fact4\",\"component\":\"InfoRow\",\"label\":\"Renewal date\",\"value\":\"Sep 30\"},{\"id\":\"fact5\",\"component\":\"InfoRow\",\"label\":\"Last contact\",\"value\":\"3 days ago\"},{\"id\":\"fact6\",\"component\":\"InfoRow\",\"label\":\"Health\",\"value\":\"Green\"},{\"id\":\"fact7\",\"component\":\"InfoRow\",\"label\":\"Open opportunities\",\"value\":\"4 opportunities worth $210k\"},{\"id\":\"revenue-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by product line\",\"description\":\"Meridian Apparel Group revenue mix across product lines.\",\"data\":[{\"label\":\"Outerwear\",\"value\":260000},{\"label\":\"Footwear\",\"value\":180000},{\"label\":\"Accessories\",\"value\":112000},{\"label\":\"Custom\",\"value\":60000}]}]}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill top-account — TERMINAL narration after generate_a2ui returns.",
+      "match": {
+        "userMessage": "Pull up the details on our biggest account.",
         "hasToolResult": true,
         "context": "agno"
       },
       "response": {
-        "content": "System health report rendered above. API and database are healthy; background workers are degraded."
+        "content": "Here's the rundown on Meridian Apparel Group."
       }
     }
   ]

--- a/showcase/integrations/agno/src/agents/a2ui_dynamic_agent.py
+++ b/showcase/integrations/agno/src/agents/a2ui_dynamic_agent.py
@@ -41,20 +41,22 @@ load_dotenv()
 
 
 SYSTEM_PROMPT = (
-    "You are a demo assistant for Declarative Generative UI (A2UI — Dynamic "
-    "Schema). Whenever a response would benefit from a rich visual — a "
-    "dashboard, status report, KPI summary, card layout, info grid, a "
-    "pie/donut chart of part-of-whole breakdowns, a bar chart comparing "
-    "values across categories, or anything more structured than plain text — "
-    "call `generate_a2ui` to draw it. The registered catalog includes "
-    "`Card`, `StatusBadge`, `Metric`, `InfoRow`, `PrimaryButton`, `PieChart`, "
-    "and `BarChart` (in addition to the basic A2UI primitives). Prefer "
-    "`PieChart` for part-of-whole breakdowns (sales by region, traffic "
-    "sources, portfolio allocation) and `BarChart` for comparisons across "
-    "categories (quarterly revenue, headcount by team, signups per month). "
-    "`generate_a2ui` takes a single `context` argument summarising the "
-    "conversation. Keep chat replies to one short sentence; let the UI do "
-    "the talking."
+    "You are a sales analyst for Vantage Threads, a fictional B2B apparel "
+    "company. Answer every business question by calling `generate_a2ui` to "
+    "draw a rich visual surface — a sales dashboard, a rep-performance table, "
+    "an at-risk-accounts summary, or an account detail view — rather than "
+    "replying in plain prose. The registered catalog includes `Card`, "
+    "`StatusBadge`, `Metric`, `InfoRow`, `DataTable`, `PrimaryButton`, "
+    "`PieChart`, and `BarChart` (in addition to the basic A2UI primitives "
+    "`Row`, `Column`, and `Text`). Pick the component that matches the shape "
+    "of the answer: `Metric` tiles for KPIs, `DataTable` for per-rep or "
+    "per-deal rankings, `InfoRow` for a stack of account facts, `StatusBadge` "
+    "for risk severity, `PieChart` for part-of-whole breakdowns (revenue by "
+    "region, revenue by product line), and `BarChart` for comparisons across "
+    "categories or time (monthly revenue, quota attainment by rep). Never ask "
+    "the user which chart they want. `generate_a2ui` takes a single `context` "
+    "argument summarising what to draw. Keep chat replies to one short "
+    "sentence; let the UI do the talking."
 )
 
 

--- a/showcase/integrations/agno/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
+++ b/showcase/integrations/agno/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
@@ -16,6 +16,16 @@ import { z } from "zod";
 import type { CatalogDefinitions } from "@copilotkit/a2ui-renderer";
 
 export const myDefinitions = {
+  // NOTE: `Row`, `Column`, and `Text` are intentionally NOT declared here.
+  // The catalog is assembled with `includeBasicCatalog: true` (see
+  // ./catalog.ts), which supplies the built-in `Row`/`Column`/`Text`
+  // renderers — declaring them here without a matching entry in
+  // `./renderers.tsx` would make `createCatalog` produce a catalog whose
+  // definition set is wider than its renderer set and crash the surface at
+  // render time. The custom renderers below (`Metric`, `PieChart`,
+  // `BarChart`, …) are written to lay out correctly inside the basic
+  // gap-less Row/Column via `flex-1`/`min-w-*`, so composed dashboards
+  // still read cleanly.
   Card: {
     description:
       "A titled card container with an optional subtitle and a single child slot. Use it to group related content (metrics, rows, buttons).",
@@ -28,7 +38,7 @@ export const myDefinitions = {
 
   StatusBadge: {
     description:
-      "A small coloured pill communicating the state of something (healthy/degraded/down, online/offline, open/closed). Choose `variant` to match the intent.",
+      "A small coloured pill communicating the state of something (healthy/degraded/at-risk, on-track/behind). Choose `variant` to match the intent.",
     props: z.object({
       text: z.string(),
       variant: z.enum(["success", "warning", "error", "info"]).optional(),
@@ -37,20 +47,43 @@ export const myDefinitions = {
 
   Metric: {
     description:
-      "A key/value KPI display with an optional trend indicator. Ideal for dashboards (e.g. 'Revenue • $12.4k • up').",
+      "A key/value KPI tile with an optional trend indicator and trend delta. Ideal for dashboard KPI rows (e.g. 'Revenue • $4.2M • up 12%').",
     props: z.object({
       label: z.string(),
       value: z.string(),
       trend: z.enum(["up", "down", "neutral"]).optional(),
+      trendValue: z.string().optional(),
     }),
   },
 
   InfoRow: {
     description:
-      "A compact two-column 'label: value' row. Good for stacks of facts inside a Card (owner, region, last updated, etc.).",
+      "A compact two-column 'label: value' row. Good for stacks of facts inside a Card (owner, region, ARR, renewal date, etc.).",
     props: z.object({
       label: z.string(),
       value: z.string(),
+    }),
+  },
+
+  DataTable: {
+    description:
+      "A data table with column headers and rows. Ideal for rankings and per-person/per-item breakdowns (rep performance vs quota, deal lists). Each row's keys MUST appear in `columns[].key`; unknown row keys render as blank cells and indicate model/schema drift.",
+    // NOTE on row-keys ⊆ columns[].key: we'd normally enforce this with
+    // `z.object(...).refine(...)`, but the host catalog package's
+    // `CatalogComponentDefinition` type requires `props: ZodObject<…>`
+    // (it inspects `.shape` at runtime), and `.refine` returns a
+    // `ZodEffects` that breaks both the `satisfies CatalogDefinitions`
+    // type assertion and the runtime `.shape` access. Until the host type
+    // is broadened, we encode the constraint in the description above so
+    // the LLM sees the rule, and leave hard enforcement to the rendering
+    // pipeline (which already shows the empty cell — detection is the gap,
+    // not behaviour).
+    props: z.object({
+      columns: z.array(z.object({ key: z.string(), label: z.string() })),
+      // Cells may be strings or numbers — the renderer stringifies at render
+      // time, but accepting both lets the LLM emit raw numerics (e.g.
+      // attainment 124) instead of being forced to stringify.
+      rows: z.array(z.record(z.union([z.string(), z.number()]))),
     }),
   },
 
@@ -59,7 +92,12 @@ export const myDefinitions = {
       "A styled primary call-to-action button. Attach an optional `action` that will be dispatched back to the agent when the user clicks it.",
     props: z.object({
       label: z.string(),
-      action: z.any().optional(),
+      // The renderer hands `action` opaquely to the A2UI `dispatch` helper,
+      // which forwards it back to the agent. We don't constrain the shape
+      // (different demos use different action payloads), but `z.unknown()`
+      // is strictly better than `z.any()` here because it forces any
+      // consumer that touches the value to narrow it explicitly.
+      action: z.unknown().optional(),
     }),
   },
 

--- a/showcase/integrations/agno/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/agno/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -221,7 +221,10 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     // Divider via `border-b last:border-b-0` so the final row doesn't dangle
     // a trailing line, regardless of whether the agent wraps these in a
     // Column or drops them directly into a Card's child slot.
-    <div className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0">
+    <div
+      data-testid="declarative-info-row"
+      className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0"
+    >
       <span className="text-sm text-[var(--muted-foreground)]">
         {props.label}
       </span>
@@ -230,6 +233,59 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
       </span>
     </div>
   ),
+
+  DataTable: ({ props }) => {
+    const cols = Array.isArray(props.columns) ? props.columns : [];
+    const rows = Array.isArray(props.rows) ? props.rows : [];
+    return (
+      <div
+        data-testid="declarative-data-table"
+        className="w-full overflow-x-auto"
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              {cols.map((col) => (
+                <th
+                  key={col.key}
+                  className="border-b-2 border-[var(--border)] px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => {
+              // Stable row key: prefer the first column's value (primary-key-ish),
+              // suffix with index in case values repeat, fall back to a JSON
+              // stringify of the row when columns is empty. Stable keys prevent
+              // React from re-mounting every row when the agent re-emits a
+              // slightly different table.
+              const pk = cols.length > 0 ? row[cols[0].key] : undefined;
+              const rowKey =
+                pk !== undefined ? `${pk}-${i}` : JSON.stringify(row);
+              return (
+                <tr
+                  key={rowKey}
+                  className="border-b border-[var(--border)] last:border-b-0"
+                >
+                  {cols.map((col) => (
+                    <td
+                      key={col.key}
+                      className="px-3 py-2 tabular-nums text-[var(--foreground)]"
+                    >
+                      {String(row[col.key] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  },
 
   PrimaryButton: ({ props, dispatch }) => (
     <Button

--- a/showcase/integrations/agno/src/app/demos/declarative-gen-ui/suggestions.ts
+++ b/showcase/integrations/agno/src/app/demos/declarative-gen-ui/suggestions.ts
@@ -1,25 +1,29 @@
 import { useConfigureSuggestions } from "@copilotkit/react-core/v2";
 
+// Pill prompts are natural business questions — chart-type steering lives in
+// the agent's system prompt (src/agents/a2ui_dynamic_agent.py). Each pill maps
+// to a distinct catalog component so the D5 probe
+// (showcase/harness/src/probes/scripts/d5-gen-ui-declarative.ts) can assert a
+// newly-mounted testid per pill. Keep prompts in sync with that probe and with
+// tests/e2e/declarative-gen-ui.spec.ts.
 export function useDeclarativeGenUISuggestions() {
   useConfigureSuggestions({
     suggestions: [
       {
-        title: "Show a KPI dashboard",
-        message:
-          "Show me a quick KPI dashboard with 3-4 metrics (revenue, signups, churn).",
+        title: "Show my sales dashboard",
+        message: "Show me my sales dashboard for this quarter.",
       },
       {
-        title: "Pie chart — sales by region",
-        message: "Show a pie chart of sales by region.",
+        title: "Team performance",
+        message: "How are our sales reps performing against quota?",
       },
       {
-        title: "Bar chart — quarterly revenue",
-        message: "Render a bar chart of quarterly revenue.",
+        title: "Anything at risk?",
+        message: "Are any accounts or pipeline deals at risk this quarter?",
       },
       {
-        title: "Status report",
-        message:
-          "Give me a status report on system health — API, database, and background workers.",
+        title: "Top account details",
+        message: "Pull up the details on our biggest account.",
       },
     ],
     available: "always",

--- a/showcase/scripts/__tests__/aimock-fixtures.test.ts
+++ b/showcase/scripts/__tests__/aimock-fixtures.test.ts
@@ -258,7 +258,19 @@ describe("fixture collision detection", () => {
     // (interrupt/gen-ui-interrupt, declarative/render_a2ui, and copied
     // LangGraph headless/feature-parity routes) that are disambiguated by
     // fixtureFile/demo route like the existing integration parity copies above.
-    const KNOWN_DUPLICATE_CEILING = 297;
+    // Bumped 297 → 300 (+3) porting agno/gen-ui-declarative to the OSS-136
+    // sales flow: agno's two-stage a2ui_dynamic_agent forces the INNER
+    // render_a2ui secondary call with a HARDCODED user message ("Generate a
+    // dynamic A2UI dashboard based on the conversation.") that is identical
+    // across all four pills, so the four inner fixtures cannot be keyed on
+    // userMessage — they discriminate on `systemMessage` (the per-pill
+    // context phrase the outer generate_a2ui injects as "Conversation
+    // context:\n<context>"). `matchKey` here does not encode systemMessage or
+    // context, so the four inner entries collapse to a single
+    // `toolName=render_a2ui` key → 3 exact-key collisions that aimock's router
+    // DOES disambiguate at runtime (verified live: the inner request's system
+    // text carried the pill's context phrase, matched the right surface).
+    const KNOWN_DUPLICATE_CEILING = 300;
 
     const collisions: string[] = [];
 


### PR DESCRIPTION
## What

Flips the `d6:agno/gen-ui-declarative` cell from **red (turn-1 dom-missing) → green**. Fan-out of the proven 2nd-wave declarative fix pattern (pilots #6051 claude-sdk-python, #6052 mastra, #6053 ms-agent-python).

## Root cause (verified at the request level)

agno's declarative-gen-ui shipped a **stale D5 aimock fixture** keyed on the old prompts (KPI dashboard / pie chart of sales by region / bar chart / status report), while the current D6 driver sends the OSS-136 sales prompts. Captured from the aimock journal on a RED run: agno's OUTER agent hit aimock with `tools=[generate_a2ui]`, `userMessage="Show me my sales dashboard for this quarter."`, `x-aimock-strict:true`, `context=agno` — the stale fixture matched **none**, aimock returned 503 (strict), the outer agent never emitted `generate_a2ui`, no surface rendered → turn-1 dom-missing → `state=red`.

## Backend family + north-star

agno uses the plain **`render_a2ui` two-stage** family (`src/agents/a2ui_dynamic_agent.py`): an OUTER `generate_a2ui(context: str)` tool, then a forced-`render_a2ui` secondary call, then narration. Mirrored the **google-adk** green north-star (same VantageThreads surfaces + `declarative-gen-ui-catalog`; `render_a2ui` args copied verbatim).

Key agno-specific wrinkle: the inner secondary call's **user message is hardcoded and identical across all four pills** ("Generate a dynamic A2UI dashboard based on the conversation."), so the inner `render_a2ui` fixtures cannot key on `userMessage`. They discriminate on `toolName:render_a2ui` + `context:agno` + a `systemMessage` substring equal to the per-pill context phrase the outer injects ("Conversation context:\n<context>"). aimock's CLI server uses substring matching, so this works; verified live against the journal.

## Fix layers

- **Fixture** (`aimock/d6/agno/gen-ui-declarative.json`): 4 sales prompts × 3 calls (outer/inner/narration) = 12 fixtures.
- **Renderers** (`.../a2ui/renderers.tsx`): `declarative-info-row` testid on InfoRow (turn 4) + new `DataTable` renderer with `declarative-data-table` testid (turn 2), mirroring google-adk.
- **Definitions** (`.../a2ui/definitions.ts`): `DataTable` schema, `Metric.trendValue`, `z.unknown()` PrimaryButton action, refreshed descriptions.
- **Backend** (`a2ui_dynamic_agent.py`): sales-analyst system prompt for live-mode steering.
- **Test** (`scripts/__tests__/aimock-fixtures.test.ts`): `KNOWN_DUPLICATE_CEILING` 297→300 (+3) — the 4 inner render fixtures collapse to one `toolName=render_a2ui` matchKey (matchKey omits systemMessage/context) but aimock's router disambiguates them at runtime.

### Bug caught during green

First green attempt still red with a client-side exception: adding `Row`/`Column`/`Text` to `myDefinitions` **without matching renderers** (agno relies on `includeBasicCatalog:true` for those) made `createCatalog` produce a definition set wider than its renderer set → render crash. Fixed by not declaring Row/Column/Text in definitions.

## Local RED → GREEN proof (isolated D6 slots)

**RED** (control-plane, stale fixture):
```
✗ d6:agno/gen-ui-declarative red — state=red
```

**GREEN** (control-plane, after fix):
```
✓ d6:agno/gen-ui-declarative green
1 passed
```

**GREEN** (`--direct`, per-turn DOM assertions — authoritative):
```
turn 1/4 — assertions passed   (sales-dashboard: metric×4 + pie + bar)
turn 2/4 — assertions passed   (team-performance: data-table + bar)
turn 3/4 — assertions passed   (at-risk: status-badge×3 + metric×3)
turn 4/4 — assertions passed   (top-account: info-row + pie)
state=green, 1 passed
```

GREEN aimock journal: 12 requests = 4× OUTER `generate_a2ui` + 4× INNER `render_a2ui` + 4× narration, all matched.

**Live Playwright visual** (all 4 surfaces painted, testids counted): turn1 metric×4/pie/bar, turn2 data-table×1/bar, turn3 status-badge×3/metric, turn4 info-row×7/pie.

`aimock-fixtures.test.ts`: 837 passed after the ceiling bump.