### PR TITLE
fix(showcase): repair ms-agent-harness-dotnet D6 gen-ui-declarative (surface-missing)

### DIFF
--- a/showcase/aimock/d6/ms-agent-harness-dotnet/gen-ui-declarative.json
+++ b/showcase/aimock/d6/ms-agent-harness-dotnet/gen-ui-declarative.json
@@ -1,192 +1,25 @@
 {
   "_meta": {
-    "description": "D6 fixtures for ms-agent-harness-dotnet / gen-ui-declarative (mirrored from langgraph-python canonical)",
-    "_note": "Agent uses a two-stage A2UI pattern (src/agents/a2ui_dynamic.py): (1) outer agent has only one tool, `generate_a2ui` (no args). (2) `generate_a2ui` internally invokes a secondary LLM bound to `_design_a2ui_surface` with `tool_choice` forced; that secondary call has tools=[_design_a2ui_surface] and emits the A2UI components payload. (3) After the tool returns, the outer agent emits a one-sentence narration. Fixtures must therefore cover three LLM calls per pill: (a) outer turn 1 \u2192 emit generate_a2ui toolcall; (b) inner secondary call \u2192 emit _design_a2ui_surface toolcall with the flat catalog components; (c) outer turn 2 (post tool result) \u2192 narration. The inner secondary call is discriminated by `toolName: '_design_a2ui_surface'` because the user prompt is identical across both outer+inner calls in the same pill (the inner secondary LLM is invoked with the same conversation messages minus the last assistant message).",
-    "created": "2026-05-28"
+    "description": "D6 fixtures for ms-agent-harness-dotnet / gen-ui-declarative (A2UI Dynamic Schema)",
+    "sourceScript": "d5-gen-ui-declarative.ts",
+    "_note": "Agent uses a two-stage A2UI pattern (agent/DeclarativeGenUiAgent.cs + A2uiSecondaryToolCaller.cs): outer agent has one tool `generate_a2ui(context)` whose context arg becomes the inner secondary LLM's user_content; inner is forced `_design_a2ui_surface`. The ms-agent-harness (.NET) backend threads the FULL interleaved conversation, so `hasToolResult` (a thread-global predicate) leaks prior pills' tool results and misfires the narration on later pills' outer calls (GOTCHAS.md). Interleaved-safe discrimination: narration keyed on this pill's outer toolCallId (ordered BEFORE the outer), outer keyed on userMessage only. Mirrors llamaindex/LGP surfaces (VantageThreads).",
+    "created": "2026-07-18",
+    "copiedFrom": "llamaindex"
   },
   "fixtures": [
     {
-      "_comment": "pill 1 KPI \u2014 inner secondary LLM (tools=[_design_a2ui_surface], tool_choice forced) emits the flat A2UI components. Discriminated by toolName so it wins over the outer generate_a2ui fixture whose userMessage matches the same prompt.",
+      "_comment": "pill sales-dashboard hero — narration keyed on toolCallId (interleaved-safe; hasToolResult is thread-global and breaks multi-pill).",
       "match": {
-        "userMessage": "Show me a quick KPI dashboard",
-        "toolName": "_design_a2ui_surface"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_kpi_design_001",
-            "name": "_design_a2ui_surface",
-            "arguments": "{\"surfaceId\":\"kpi-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Card\",\"title\":\"KPI Dashboard\",\"subtitle\":\"Last 30 days\",\"child\":\"metrics-col\"},{\"id\":\"metrics-col\",\"component\":\"Column\",\"children\":[\"m-rev\",\"m-sign\",\"m-churn\",\"m-mrr\"],\"gap\":12},{\"id\":\"m-rev\",\"component\":\"Metric\",\"label\":\"Revenue\",\"value\":\"$1.2M\",\"trend\":\"up\"},{\"id\":\"m-sign\",\"component\":\"Metric\",\"label\":\"Signups\",\"value\":\"8,420\",\"trend\":\"up\"},{\"id\":\"m-churn\",\"component\":\"Metric\",\"label\":\"Churn\",\"value\":\"2.1%\",\"trend\":\"down\"},{\"id\":\"m-mrr\",\"component\":\"Metric\",\"label\":\"MRR\",\"value\":\"$98K\",\"trend\":\"up\"}]}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 1 KPI \u2014 outer agent narration after generate_a2ui returns.",
-      "match": {
-        "context": "ms-agent-harness-dotnet",
-        "toolCallId": "call_d6_decl_kpi_outer_001"
-      },
-      "response": {
-        "content": "KPI dashboard rendered."
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 1 KPI \u2014 outer agent emits generate_a2ui (no args).",
-      "match": {
-        "userMessage": "Show me a quick KPI dashboard",
+        "toolCallId": "call_d6_decl_dash_outer_msnet_001",
         "context": "ms-agent-harness-dotnet"
       },
       "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_kpi_outer_001",
-            "name": "generate_a2ui",
-            "arguments": "{\"context\": \"KPI dashboard with 3-4 metrics (revenue, signups, churn)\"}"
-          }
-        ]
+        "content": "Here's your Q2 sales dashboard."
       },
       "chunkSize": 9999
     },
     {
-      "_comment": "pill 2 pie chart \u2014 inner secondary LLM emits PieChart catalog component.",
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "toolName": "_design_a2ui_surface"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_pie_design_001",
-            "name": "_design_a2ui_surface",
-            "arguments": "{\"surfaceId\":\"sales-pie\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"PieChart\",\"title\":\"Sales by Region\",\"data\":[{\"label\":\"North America\",\"value\":45},{\"label\":\"Europe\",\"value\":28},{\"label\":\"Asia-Pacific\",\"value\":18},{\"label\":\"Other\",\"value\":9}]}]}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 2 pie chart \u2014 outer agent narration.",
-      "match": {
-        "context": "ms-agent-harness-dotnet",
-        "toolCallId": "call_d6_decl_pie_outer_001"
-      },
-      "response": {
-        "content": "Pie chart rendered."
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 2 pie chart \u2014 outer agent emits generate_a2ui.",
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "context": "ms-agent-harness-dotnet"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_pie_outer_001",
-            "name": "generate_a2ui",
-            "arguments": "{\"context\": \"pie chart of sales by region\"}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 3 bar chart \u2014 inner secondary LLM emits BarChart catalog component.",
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "toolName": "_design_a2ui_surface"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_bar_design_001",
-            "name": "_design_a2ui_surface",
-            "arguments": "{\"surfaceId\":\"quarterly-rev\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"BarChart\",\"title\":\"Quarterly Revenue\",\"data\":[{\"label\":\"Q1\",\"value\":280000},{\"label\":\"Q2\",\"value\":310000},{\"label\":\"Q3\",\"value\":295000},{\"label\":\"Q4\",\"value\":340000}]}]}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 3 bar chart \u2014 outer agent narration.",
-      "match": {
-        "context": "ms-agent-harness-dotnet",
-        "toolCallId": "call_d6_decl_bar_outer_001"
-      },
-      "response": {
-        "content": "Bar chart rendered."
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 3 bar chart \u2014 outer agent emits generate_a2ui.",
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "context": "ms-agent-harness-dotnet"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_bar_outer_001",
-            "name": "generate_a2ui",
-            "arguments": "{\"context\": \"bar chart of quarterly revenue\"}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 4 status report \u2014 inner secondary LLM emits StatusBadges grouped in a root Column.",
-      "match": {
-        "userMessage": "status report on system health",
-        "toolName": "_design_a2ui_surface"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_status_design_001",
-            "name": "_design_a2ui_surface",
-            "arguments": "{\"surfaceId\":\"sys-status\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Card\",\"title\":\"System health\",\"subtitle\":\"All services\",\"child\":\"badges-col\"},{\"id\":\"badges-col\",\"component\":\"Column\",\"children\":[\"sb-api\",\"sb-db\",\"sb-bg\"],\"gap\":8},{\"id\":\"sb-api\",\"component\":\"StatusBadge\",\"text\":\"API: healthy (p99 42ms)\",\"variant\":\"success\"},{\"id\":\"sb-db\",\"component\":\"StatusBadge\",\"text\":\"Database: healthy (replication lag 0.2s)\",\"variant\":\"success\"},{\"id\":\"sb-bg\",\"component\":\"StatusBadge\",\"text\":\"Background Workers: degraded (queue depth 1247)\",\"variant\":\"warning\"}]}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 4 status report \u2014 outer agent narration.",
-      "match": {
-        "context": "ms-agent-harness-dotnet",
-        "toolCallId": "call_d6_decl_status_outer_001"
-      },
-      "response": {
-        "content": "System health status rendered."
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 4 status report \u2014 outer agent emits generate_a2ui.",
-      "match": {
-        "userMessage": "status report on system health",
-        "context": "ms-agent-harness-dotnet"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_status_outer_001",
-            "name": "generate_a2ui",
-            "arguments": "{\"context\": \"status report on system health\"}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args). Mirrors LGP gen-ui-declarative.json sales-dashboard outer entry. Closes the production 503 gap where backend hits aimock with tools=[generate_a2ui] for this userMessage (see /tmp/staging-journal-diff.md shape-B).",
+      "_comment": "pill sales-dashboard hero — outer generate_a2ui keyed on userMessage only (no hasToolResult; interleaved thread carries prior tool results).",
       "match": {
         "userMessage": "Show me my sales dashboard for this quarter.",
         "context": "ms-agent-harness-dotnet"
@@ -196,7 +29,163 @@
           {
             "id": "call_d6_decl_dash_outer_msnet_001",
             "name": "generate_a2ui",
-            "arguments": "{}"
+            "arguments": "{\"context\":\"sales dashboard for this quarter\"}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill sales-dashboard hero — INNER secondary planner (forced _design_a2ui_surface via OpenAIClient against aimock). Inner user message = the outer's context arg. Args copied verbatim from LGP sales-dashboard render entry. Asserts declarative-metric (>=4) + declarative-pie-chart + declarative-bar-chart. Keyed userMessage(=outer context arg) + toolName:_design_a2ui_surface + context:ms-agent-harness-dotnet — the harness/HttpAgent forwards X-AIMock-Context to the secondary OpenAIClient() call (verified live: inner request carried ctxHdr=ms-agent-harness-dotnet, status 200), so context-scoping is both correct AND prevents cross-slug _design_a2ui_surface collisions (e.g. built-in-agent reuses the same context-arg userMessage strings).",
+      "match": {
+        "userMessage": "sales dashboard for this quarter",
+        "toolName": "_design_a2ui_surface",
+        "context": "ms-agent-harness-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_dash_design_msnet_001_design",
+            "name": "_design_a2ui_surface",
+            "arguments": "{\"surfaceId\":\"sales-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"kpi-row\",\"charts-row\"]},{\"id\":\"kpi-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-revenue\",\"metric-new-customers\",\"metric-win-rate\",\"metric-deal-size\"]},{\"id\":\"metric-revenue\",\"component\":\"Metric\",\"label\":\"Quarterly Revenue\",\"value\":\"$4.2M\",\"trend\":\"up\"},{\"id\":\"metric-new-customers\",\"component\":\"Metric\",\"label\":\"New Customers\",\"value\":\"186\",\"trend\":\"up\"},{\"id\":\"metric-win-rate\",\"component\":\"Metric\",\"label\":\"Win Rate\",\"value\":\"31%\",\"trend\":\"down\"},{\"id\":\"metric-deal-size\",\"component\":\"Metric\",\"label\":\"Avg Deal Size\",\"value\":\"$22.6k\",\"trend\":\"up\"},{\"id\":\"charts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"region-pie\",\"monthly-bar\"]},{\"id\":\"region-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by Region\",\"description\":\"Quarter revenue split across North America, EMEA, APAC, and LATAM.\",\"data\":[{\"label\":\"North America\",\"value\":1900000},{\"label\":\"EMEA\",\"value\":1300000},{\"label\":\"APAC\",\"value\":720000},{\"label\":\"LATAM\",\"value\":280000}]},{\"id\":\"monthly-bar\",\"component\":\"BarChart\",\"title\":\"Monthly Revenue\",\"description\":\"Revenue trend from Jan through Jun.\",\"data\":[{\"label\":\"Jan\",\"value\":1210000},{\"label\":\"Feb\",\"value\":1340000},{\"label\":\"Mar\",\"value\":1650000},{\"label\":\"Apr\",\"value\":1380000},{\"label\":\"May\",\"value\":1420000},{\"label\":\"Jun\",\"value\":1400000}]}]}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill team-performance — narration keyed on toolCallId (interleaved-safe; hasToolResult is thread-global and breaks multi-pill).",
+      "match": {
+        "toolCallId": "call_d6_decl_team_outer_msnet_001",
+        "context": "ms-agent-harness-dotnet"
+      },
+      "response": {
+        "content": "Here's how the team is tracking against quota."
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill team-performance — outer generate_a2ui keyed on userMessage only (no hasToolResult; interleaved thread carries prior tool results).",
+      "match": {
+        "userMessage": "How are our sales reps performing against quota?",
+        "context": "ms-agent-harness-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_team_outer_msnet_001",
+            "name": "generate_a2ui",
+            "arguments": "{\"context\":\"sales rep performance against quota\"}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill team-performance — INNER forced _design_a2ui_surface. Inner user message = the outer's context arg. Args copied verbatim from LGP team-performance render entry. Asserts declarative-data-table + declarative-bar-chart. Keyed userMessage(=outer context arg) + toolName:_design_a2ui_surface + context:ms-agent-harness-dotnet — the harness/HttpAgent forwards X-AIMock-Context to the secondary OpenAIClient() call (verified live: inner request carried ctxHdr=ms-agent-harness-dotnet, status 200), so context-scoping is both correct AND prevents cross-slug _design_a2ui_surface collisions (e.g. built-in-agent reuses the same context-arg userMessage strings).",
+      "match": {
+        "userMessage": "sales rep performance against quota",
+        "toolName": "_design_a2ui_surface",
+        "context": "ms-agent-harness-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_team_design_msnet_001_design",
+            "name": "_design_a2ui_surface",
+            "arguments": "{\"surfaceId\":\"rep-quota-performance\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"title\",\"summary\",\"content\"]},{\"id\":\"title\",\"component\":\"Text\",\"text\":\"Sales rep performance vs quota\"},{\"id\":\"summary\",\"component\":\"Text\",\"text\":\"2 of 5 reps are above quota, 1 is near plan, and 2 are below target in Q2.\"},{\"id\":\"content\",\"component\":\"Row\",\"gap\":16,\"children\":[\"table-card\",\"attainment-chart\"]},{\"id\":\"table-card\",\"component\":\"Card\",\"title\":\"Rep attainment table\",\"child\":\"rep-table\"},{\"id\":\"rep-table\",\"component\":\"DataTable\",\"columns\":[{\"key\":\"rep\",\"label\":\"Rep\"},{\"key\":\"attainment\",\"label\":\"Attainment\"},{\"key\":\"pipeline\",\"label\":\"Pipeline\"}],\"rows\":[{\"rep\":\"Dana Whitfield\",\"attainment\":\"124%\",\"pipeline\":\"Leading team; biggest account Meridian Apparel Group has 4 open opps worth $210k\"},{\"rep\":\"Marcus Lee\",\"attainment\":\"108%\",\"pipeline\":\"Above plan\"},{\"rep\":\"Priya Sharma\",\"attainment\":\"97%\",\"pipeline\":\"Near quota\"},{\"rep\":\"Tom Okafor\",\"attainment\":\"88%\",\"pipeline\":\"Below plan\"},{\"rep\":\"Elena Vasquez\",\"attainment\":\"71%\",\"pipeline\":\"Furthest from quota\"}]},{\"id\":\"attainment-chart\",\"component\":\"BarChart\",\"title\":\"Quota attainment by rep\",\"description\":\"Q2 quota attainment percentages for all sales reps.\",\"data\":[{\"label\":\"Dana Whitfield\",\"value\":124},{\"label\":\"Marcus Lee\",\"value\":108},{\"label\":\"Priya Sharma\",\"value\":97},{\"label\":\"Tom Okafor\",\"value\":88},{\"label\":\"Elena Vasquez\",\"value\":71}]}]}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill at-risk — narration keyed on toolCallId (interleaved-safe; hasToolResult is thread-global and breaks multi-pill).",
+      "match": {
+        "toolCallId": "call_d6_decl_risk_outer_msnet_001",
+        "context": "ms-agent-harness-dotnet"
+      },
+      "response": {
+        "content": "Three accounts need attention this quarter."
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill at-risk — outer generate_a2ui keyed on userMessage only (no hasToolResult; interleaved thread carries prior tool results).",
+      "match": {
+        "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
+        "context": "ms-agent-harness-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_risk_outer_msnet_001",
+            "name": "generate_a2ui",
+            "arguments": "{\"context\":\"accounts and pipeline deals at risk this quarter\"}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill at-risk — INNER forced _design_a2ui_surface. Inner user message = the outer's context arg. Args copied verbatim from LGP at-risk render entry. Asserts declarative-status-badge (>=3) + declarative-metric (>=3). Keyed userMessage(=outer context arg) + toolName:_design_a2ui_surface + context:ms-agent-harness-dotnet — the harness/HttpAgent forwards X-AIMock-Context to the secondary OpenAIClient() call (verified live: inner request carried ctxHdr=ms-agent-harness-dotnet, status 200), so context-scoping is both correct AND prevents cross-slug _design_a2ui_surface collisions (e.g. built-in-agent reuses the same context-arg userMessage strings).",
+      "match": {
+        "userMessage": "accounts and pipeline deals at risk this quarter",
+        "toolName": "_design_a2ui_surface",
+        "context": "ms-agent-harness-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_risk_design_msnet_001_design",
+            "name": "_design_a2ui_surface",
+            "arguments": "{\"surfaceId\":\"risk-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"metrics-row\",\"accounts-row\"]},{\"id\":\"metrics-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-arr\",\"metric-accounts\",\"metric-biggest\"]},{\"id\":\"metric-arr\",\"component\":\"Metric\",\"label\":\"ARR at risk\",\"value\":\"$615k\",\"trend\":\"down\"},{\"id\":\"metric-accounts\",\"component\":\"Metric\",\"label\":\"Accounts at risk\",\"value\":\"3\",\"trend\":\"neutral\"},{\"id\":\"metric-biggest\",\"component\":\"Metric\",\"label\":\"Biggest exposure\",\"value\":\"Northwind Retail\",\"trend\":\"down\"},{\"id\":\"accounts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"card-northwind\",\"card-cascadia\",\"card-atlas\"]},{\"id\":\"card-northwind\",\"component\":\"Card\",\"title\":\"Northwind Retail\",\"subtitle\":\"$340k ARR at stake\",\"child\":\"northwind-content\"},{\"id\":\"northwind-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"northwind-badge\",\"northwind-text\"]},{\"id\":\"northwind-badge\",\"component\":\"StatusBadge\",\"text\":\"High severity\",\"variant\":\"error\"},{\"id\":\"northwind-text\",\"component\":\"Text\",\"text\":\"No contact in 6 weeks; next action: exec outreach this week to protect the renewal.\"},{\"id\":\"card-cascadia\",\"component\":\"Card\",\"title\":\"Cascadia Outfitters\",\"subtitle\":\"$180k ARR at stake\",\"child\":\"cascadia-content\"},{\"id\":\"cascadia-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"cascadia-badge\",\"cascadia-text\"]},{\"id\":\"cascadia-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"cascadia-text\",\"component\":\"Text\",\"text\":\"Champion left; next action: rebuild stakeholder map and secure a new sponsor.\"},{\"id\":\"card-atlas\",\"component\":\"Card\",\"title\":\"Atlas Goods\",\"subtitle\":\"$95k ARR at stake\",\"child\":\"atlas-content\"},{\"id\":\"atlas-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"atlas-badge\",\"atlas-text\"]},{\"id\":\"atlas-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"atlas-text\",\"component\":\"Text\",\"text\":\"Legal review is stalled; next action: align procurement and legal on open terms.\"}]}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill top-account — narration keyed on toolCallId (interleaved-safe; hasToolResult is thread-global and breaks multi-pill).",
+      "match": {
+        "toolCallId": "call_d6_decl_acct_outer_msnet_001",
+        "context": "ms-agent-harness-dotnet"
+      },
+      "response": {
+        "content": "Here's the rundown on Meridian Apparel Group."
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill top-account — outer generate_a2ui keyed on userMessage only (no hasToolResult; interleaved thread carries prior tool results).",
+      "match": {
+        "userMessage": "Pull up the details on our biggest account.",
+        "context": "ms-agent-harness-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_acct_outer_msnet_001",
+            "name": "generate_a2ui",
+            "arguments": "{\"context\":\"details on our biggest account\"}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill top-account — INNER forced _design_a2ui_surface. Inner user message = the outer's context arg. Args copied verbatim from LGP top-account render entry. Asserts declarative-info-row + declarative-pie-chart. Keyed userMessage(=outer context arg) + toolName:_design_a2ui_surface + context:ms-agent-harness-dotnet — the harness/HttpAgent forwards X-AIMock-Context to the secondary OpenAIClient() call (verified live: inner request carried ctxHdr=ms-agent-harness-dotnet, status 200), so context-scoping is both correct AND prevents cross-slug _design_a2ui_surface collisions (e.g. built-in-agent reuses the same context-arg userMessage strings).",
+      "match": {
+        "userMessage": "details on our biggest account",
+        "toolName": "_design_a2ui_surface",
+        "context": "ms-agent-harness-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_acct_design_msnet_001_design",
+            "name": "_design_a2ui_surface",
+            "arguments": "{\"surfaceId\":\"biggest-account-details\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Row\",\"gap\":16,\"children\":[\"account-card\",\"revenue-pie\"]},{\"id\":\"account-card\",\"component\":\"Card\",\"title\":\"Meridian Apparel Group\",\"subtitle\":\"Biggest account\",\"child\":\"account-facts\"},{\"id\":\"account-facts\",\"component\":\"Column\",\"gap\":8,\"children\":[\"fact1\",\"fact2\",\"fact3\",\"fact4\",\"fact5\",\"fact6\",\"fact7\"]},{\"id\":\"fact1\",\"component\":\"InfoRow\",\"label\":\"Owner\",\"value\":\"Dana Whitfield\"},{\"id\":\"fact2\",\"component\":\"InfoRow\",\"label\":\"Region\",\"value\":\"North America\"},{\"id\":\"fact3\",\"component\":\"InfoRow\",\"label\":\"ARR\",\"value\":\"$612k\"},{\"id\":\"fact4\",\"component\":\"InfoRow\",\"label\":\"Renewal date\",\"value\":\"Sep 30\"},{\"id\":\"fact5\",\"component\":\"InfoRow\",\"label\":\"Last contact\",\"value\":\"3 days ago\"},{\"id\":\"fact6\",\"component\":\"InfoRow\",\"label\":\"Health\",\"value\":\"Green\"},{\"id\":\"fact7\",\"component\":\"InfoRow\",\"label\":\"Open opportunities\",\"value\":\"4 opportunities worth $210k\"},{\"id\":\"revenue-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by product line\",\"description\":\"Meridian Apparel Group revenue mix across product lines.\",\"data\":[{\"label\":\"Outerwear\",\"value\":260000},{\"label\":\"Footwear\",\"value\":180000},{\"label\":\"Accessories\",\"value\":112000},{\"label\":\"Custom\",\"value\":60000}]}]}"
           }
         ]
       },

--- a/showcase/integrations/ms-agent-harness-dotnet/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
+++ b/showcase/integrations/ms-agent-harness-dotnet/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
@@ -16,6 +16,45 @@ import { z } from "zod";
 import type { CatalogDefinitions } from "@copilotkit/a2ui-renderer";
 
 export const myDefinitions = {
+  // Override the basic catalog's Row/Column so `gap` is honoured — the
+  // built-in versions ignore it, which makes composed dashboards cramped.
+  Row: {
+    description:
+      "Horizontal layout container. Children share the width evenly. Use `gap` (px) to space dashboard tiles.",
+    props: z.object({
+      gap: z.number().optional(),
+      // Enum mirrors the keys the renderer actually maps to CSS. Anything
+      // outside this set silently falls back at render time, so we reject
+      // it at schema-parse time to surface LLM typos early.
+      align: z
+        .enum(["start", "center", "end", "stretch", "baseline"])
+        .optional(),
+      justify: z.enum(["start", "center", "end", "spaceBetween"]).optional(),
+      children: z.array(z.string()),
+    }),
+  },
+
+  Column: {
+    description:
+      "Vertical layout container. Use `gap` (px) to space stacked sections.",
+    props: z.object({
+      gap: z.number().optional(),
+      align: z
+        .enum(["start", "center", "end", "stretch", "baseline"])
+        .optional(),
+      children: z.array(z.string()),
+    }),
+  },
+
+  // Override the basic catalog's Text so it aligns flush with sibling
+  // components (the built-in version carries an 8px outer margin).
+  Text: {
+    description: "A plain text line. Use for short explanations inside cards.",
+    props: z.object({
+      text: z.string(),
+    }),
+  },
+
   Card: {
     description:
       "A titled card container with an optional subtitle and a single child slot. Use it to group related content (metrics, rows, buttons).",
@@ -28,7 +67,7 @@ export const myDefinitions = {
 
   StatusBadge: {
     description:
-      "A small coloured pill communicating the state of something (healthy/degraded/down, online/offline, open/closed). Choose `variant` to match the intent.",
+      "A small coloured pill communicating the state of something (healthy/degraded/at-risk, on-track/behind). Choose `variant` to match the intent.",
     props: z.object({
       text: z.string(),
       variant: z.enum(["success", "warning", "error", "info"]).optional(),
@@ -37,20 +76,43 @@ export const myDefinitions = {
 
   Metric: {
     description:
-      "A key/value KPI display with an optional trend indicator. Ideal for dashboards (e.g. 'Revenue • $12.4k • up').",
+      "A key/value KPI tile with an optional trend indicator and trend delta. Ideal for dashboard KPI rows (e.g. 'Revenue • $4.2M • up 12%').",
     props: z.object({
       label: z.string(),
       value: z.string(),
       trend: z.enum(["up", "down", "neutral"]).optional(),
+      trendValue: z.string().optional(),
     }),
   },
 
   InfoRow: {
     description:
-      "A compact two-column 'label: value' row. Good for stacks of facts inside a Card (owner, region, last updated, etc.).",
+      "A compact two-column 'label: value' row. Good for stacks of facts inside a Card (owner, region, ARR, renewal date, etc.).",
     props: z.object({
       label: z.string(),
       value: z.string(),
+    }),
+  },
+
+  DataTable: {
+    description:
+      "A data table with column headers and rows. Ideal for rankings and per-person/per-item breakdowns (rep performance vs quota, deal lists). Each row's keys MUST appear in `columns[].key`; unknown row keys render as blank cells and indicate model/schema drift.",
+    // NOTE on B12 (row-keys ⊆ columns[].key): we'd normally enforce this
+    // with `z.object(...).refine(...)`, but the host catalog package's
+    // `CatalogComponentDefinition` type requires `props: ZodObject<…>`
+    // (it inspects `.shape` at runtime), and `.refine` returns a
+    // `ZodEffects` that breaks both the `satisfies CatalogDefinitions`
+    // type assertion and the runtime `.shape` access. Until the host
+    // type is broadened, we encode the constraint in the description
+    // above so the LLM sees the rule, and leave hard enforcement to
+    // the rendering pipeline (which already shows the empty cell —
+    // detection is the gap, not behaviour).
+    props: z.object({
+      columns: z.array(z.object({ key: z.string(), label: z.string() })),
+      // Cells may be strings or numbers — the renderer stringifies at
+      // render time, but accepting both lets the LLM emit raw numerics
+      // (e.g. attainment 124) instead of being forced to stringify.
+      rows: z.array(z.record(z.union([z.string(), z.number()]))),
     }),
   },
 
@@ -59,13 +121,18 @@ export const myDefinitions = {
       "A styled primary call-to-action button. Attach an optional `action` that will be dispatched back to the agent when the user clicks it.",
     props: z.object({
       label: z.string(),
-      action: z.any().optional(),
+      // The renderer hands `action` opaquely to the A2UI `dispatch` helper,
+      // which forwards it back to the agent. We don't constrain the shape
+      // (different demos use different action payloads), but `z.unknown()`
+      // is strictly better than `z.any()` here because it forces any
+      // consumer that touches the value to narrow it explicitly.
+      action: z.unknown().optional(),
     }),
   },
 
   PieChart: {
     description:
-      "A pie/donut chart with a brand-coloured legend. Provide `title`, `description`, and `data` as an array of `{ label, value }` objects. Great for part-of-whole breakdowns (sales by region, traffic sources, portfolio allocation).",
+      "A pie/donut chart with a brand-coloured legend. Provide `title`, `description`, and `data` as an array of `{ label, value }` objects. Great for part-of-whole breakdowns (revenue by region, pipeline by stage).",
     props: z.object({
       title: z.string(),
       description: z.string(),
@@ -80,7 +147,7 @@ export const myDefinitions = {
 
   BarChart: {
     description:
-      "A vertical bar chart built on Recharts. Provide `title`, `description`, and `data` as an array of `{ label, value }` objects. Great for comparing series across categories (quarterly revenue, headcount by team, signups per month).",
+      "A vertical bar chart built on Recharts. Provide `title`, `description`, and `data` as an array of `{ label, value }` objects. Great for comparing series across categories or time (monthly revenue, signups per month).",
     props: z.object({
       title: z.string(),
       description: z.string(),

--- a/showcase/integrations/ms-agent-harness-dotnet/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/ms-agent-harness-dotnet/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -3,215 +3,252 @@
 /**
  * A2UI catalog RENDERERS.
  *
- * React implementations for each definition in `./definitions.ts`,
- * styled with the demo's local ShadCN-flavoured primitives in
- * `../_components/`. The assembled catalog (definitions × renderers via
- * `createCatalog`) lives in `./catalog.ts`.
+ * React implementations for each definition in `./definitions.ts`. Visuals
+ * mirror beautiful-chat's sales dashboard renderers
+ * (../../beautiful-chat/declarative-generative-ui/renderers.tsx) so the two
+ * demos read as the same product family — same card chrome, metric
+ * typography, recharts donut/bar styling, and palette. The assembled catalog
+ * (definitions × renderers via `createCatalog`) lives in `./catalog.ts`.
  *
  * Reference:
  *   https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui
  */
-import React, { useRef } from "react";
+import React from "react";
 import {
+  PieChart as RechartsPieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
   BarChart as RechartsBarChart,
   Bar,
   XAxis,
   YAxis,
   Tooltip,
   CartesianGrid,
-  Cell,
-  ResponsiveContainer,
-  Rectangle,
 } from "recharts";
 import type { CatalogRenderers } from "@copilotkit/a2ui-renderer";
+import { TriangleAlert, CircleAlert, CircleCheck, Info } from "lucide-react";
 
 import type { MyDefinitions } from "./definitions";
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardContent,
-} from "../_components/card";
 import { Badge } from "../_components/badge";
 import { Button } from "../_components/button";
 
-// ─── ShadCN-friendly chart palette ─────────────────────────────────────────
-// Neutral, slightly muted hues that pair with `bg-card` / `--border`
-// (zinc/slate-leaning, akin to ShadCN's chart-{1..5} palette).
-const CHART_COLORS = [
-  "#3F3F46", // zinc-700
-  "#71717A", // zinc-500
-  "#A1A1AA", // zinc-400
-  "#18181B", // zinc-900
-  "#52525B", // zinc-600
-  "#D4D4D8", // zinc-300
-  "#27272A", // zinc-800
-] as const;
-
-const CHART_TOOLTIP_STYLE: React.CSSProperties = {
-  backgroundColor: "var(--card)",
-  border: "1px solid var(--border)",
-  borderRadius: 8,
-  padding: "8px 12px",
-  color: "var(--foreground)",
-  fontSize: 12,
-  boxShadow: "0 4px 12px rgba(0,0,0,0.06)",
+// ─── Theme tokens + palette (mirrors beautiful-chat) ────────────────────────
+const c = {
+  card: "var(--card)",
+  cardFg: "var(--card-foreground)",
+  border: "var(--border)",
+  muted: "var(--muted-foreground)",
+  divider: "color-mix(in srgb, var(--border) 50%, var(--card))",
+  shadow: "0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.04)",
 };
 
-/** Custom SVG donut chart built with <circle> + stroke-dasharray. */
-function DonutChart({
-  data,
-  size = 220,
-  strokeWidth = 36,
+const CHART_COLORS = [
+  "#3b82f6", // blue-500
+  "#8b5cf6", // violet-500
+  "#ec4899", // pink-500
+  "#f59e0b", // amber-500
+  "#10b981", // emerald-500
+  "#6366f1", // indigo-500
+] as const;
+
+/** DashboardCard-style chrome shared by Card and the chart wrappers. */
+function CardShell({
+  title,
+  subtitle,
+  testid,
+  cardId,
+  children,
 }: {
-  data: { label: string; value: number }[];
-  size?: number;
-  strokeWidth?: number;
+  title: string;
+  subtitle?: string;
+  testid?: string;
+  cardId?: string;
+  children?: React.ReactNode;
 }) {
-  const radius = (size - strokeWidth) / 2;
-  const circumference = 2 * Math.PI * radius;
-  const center = size / 2;
-
-  const total = data.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
-
-  let accumulated = 0;
-  const slices = data.map((item, index) => {
-    const val = Number(item.value) || 0;
-    const ratio = total > 0 ? val / total : 0;
-    const arc = ratio * circumference;
-    const startAt = accumulated;
-    accumulated += arc;
-    return {
-      ...item,
-      arc,
-      gap: circumference - arc,
-      dashoffset: -startAt,
-      color: CHART_COLORS[index % CHART_COLORS.length],
-    };
-  });
-
   return (
-    <svg
-      width="100%"
-      viewBox={`0 0 ${size} ${size}`}
+    <div
+      data-testid={testid}
+      data-card-id={cardId}
       style={{
-        display: "block",
-        margin: "0 auto",
-        maxWidth: size,
-        transform: "scaleX(-1)",
+        background: c.card,
+        borderRadius: "12px",
+        border: `1px solid ${c.border}`,
+        padding: "20px",
+        boxShadow: c.shadow,
+        display: "flex",
+        flexDirection: "column",
+        gap: "12px",
+        width: "100%",
+        minWidth: 0,
+        overflow: "hidden",
       }}
     >
-      <circle
-        cx={center}
-        cy={center}
-        r={radius}
-        fill="none"
-        stroke="var(--muted)"
-        strokeWidth={strokeWidth}
-      />
-      {slices.map((slice, i) => (
-        <circle
-          key={i}
-          cx={center}
-          cy={center}
-          r={radius}
-          fill="none"
-          stroke={slice.color}
-          strokeWidth={strokeWidth}
-          strokeDasharray={`${slice.arc} ${slice.gap}`}
-          strokeDashoffset={slice.dashoffset}
-          strokeLinecap="butt"
-          transform={`rotate(-90 ${center} ${center})`}
-        />
-      ))}
-    </svg>
-  );
-}
-
-/** Tracks seen indices so only NEW bars get the fade-in animation. */
-function useSeenIndices() {
-  const seen = useRef(new Set<number>());
-  return {
-    isNew(index: number) {
-      if (seen.current.has(index)) return false;
-      seen.current.add(index);
-      return true;
-    },
-  };
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function AnimatedBar(props: any) {
-  const { isNew, ...rest } = props;
-  return (
-    <g
-      style={
-        isNew
-          ? {
-              animation: "barSlideIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) both",
-            }
-          : undefined
-      }
-    >
-      <Rectangle {...rest} />
-    </g>
+      <div>
+        <div style={{ fontWeight: 600, fontSize: "0.9rem", color: c.cardFg }}>
+          {title}
+        </div>
+        {subtitle && (
+          <div
+            style={{ fontSize: "0.75rem", color: c.muted, marginTop: "2px" }}
+          >
+            {subtitle}
+          </div>
+        )}
+      </div>
+      {children}
+    </div>
   );
 }
 
 // @region[renderers-react]
 export const myRenderers: CatalogRenderers<MyDefinitions> = {
-  Card: ({ props, children }) => (
-    <Card
-      className="w-full min-w-0 overflow-hidden"
-      data-testid="declarative-card"
-    >
-      <CardHeader>
-        <CardTitle>{props.title}</CardTitle>
-        {props.subtitle && <CardDescription>{props.subtitle}</CardDescription>}
-      </CardHeader>
-      {props.child && (
-        <CardContent className="flex flex-col gap-4">
-          {children(props.child)}
-        </CardContent>
-      )}
-    </Card>
+  Row: ({ props, children }) => {
+    const justifyMap: Record<string, string> = {
+      start: "flex-start",
+      center: "center",
+      end: "flex-end",
+      spaceBetween: "space-between",
+    };
+    const items = Array.isArray(props.children) ? props.children : [];
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          gap: `${props.gap ?? 16}px`,
+          alignItems: props.align ?? "stretch",
+          justifyContent: justifyMap[props.justify ?? "start"] ?? "flex-start",
+          flexWrap: "wrap",
+          width: "100%",
+        }}
+      >
+        {items.map((id, i) => (
+          <div key={`${id}-${i}`} style={{ flex: "1 1 0", minWidth: 0 }}>
+            {children(id)}
+          </div>
+        ))}
+      </div>
+    );
+  },
+
+  Column: ({ props, children }) => {
+    const items = Array.isArray(props.children) ? props.children : [];
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: `${props.gap ?? 12}px`,
+          width: "100%",
+        }}
+      >
+        {items.map((id, i) => (
+          <React.Fragment key={`${id}-${i}`}>{children(id)}</React.Fragment>
+        ))}
+      </div>
+    );
+  },
+
+  Text: ({ props }) => (
+    <span style={{ fontSize: "0.85rem", color: c.cardFg, lineHeight: 1.5 }}>
+      {props.text}
+    </span>
   ),
 
-  StatusBadge: ({ props }) => (
-    <Badge
-      variant={props.variant ?? "info"}
-      data-testid="declarative-status-badge"
+  Card: ({ props, children }) => (
+    // `data-testid="declarative-card"` stays shared so existing e2e selectors
+    // still find every card; `data-card-id={props.title}` disambiguates
+    // sibling cards (e.g. the at-risk pill's 3 severity cards) so test
+    // assertions can target a specific card by title.
+    <CardShell
+      title={props.title}
+      subtitle={props.subtitle}
+      testid="declarative-card"
+      cardId={props.title}
     >
-      {props.text}
-    </Badge>
+      {props.child && children(props.child)}
+    </CardShell>
   ),
+
+  StatusBadge: ({ props }) => {
+    const variant = props.variant ?? "info";
+    const Icon = {
+      error: TriangleAlert,
+      warning: CircleAlert,
+      success: CircleCheck,
+      info: Info,
+    }[variant];
+    return (
+      // `alignSelf: flex-start` keeps the pill content-sized — flex parents
+      // (our Column override) default to stretch, which inflates it into a
+      // full-width banner.
+      <Badge
+        variant={variant}
+        style={{ alignSelf: "flex-start" }}
+        data-testid="declarative-status-badge"
+      >
+        <Icon size={12} strokeWidth={2.5} style={{ marginRight: 4 }} />
+        {props.text}
+      </Badge>
+    );
+  },
 
   Metric: ({ props }) => {
-    const trend = props.trend ?? "neutral";
-    const arrow = trend === "up" ? "↑" : trend === "down" ? "↓" : "";
-    const trendClass =
-      trend === "up"
-        ? "text-emerald-600"
-        : trend === "down"
-          ? "text-rose-600"
-          : "text-[var(--foreground)]";
+    const trendColors: Record<string, string> = {
+      up: "#059669",
+      down: "#dc2626",
+      neutral: c.muted,
+    };
+    const trendIcons: Record<string, string> = {
+      up: "↑",
+      down: "↓",
+      neutral: "→",
+    };
     return (
-      // `flex-1 min-w-[120px]` lets a row of Metrics distribute evenly
-      // inside the basic catalog's gap-less Row — 3 metrics in a 600px
-      // card column get ~200px each instead of squishing to content width.
       <div
         data-testid="declarative-metric"
-        className="flex flex-1 min-w-[120px] flex-col gap-1"
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "4px",
+          minWidth: "120px",
+        }}
       >
-        <div className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]">
-          {props.label}
-        </div>
-        <div
-          className={`flex items-baseline gap-1.5 text-2xl font-semibold tabular-nums ${trendClass}`}
+        <span
+          style={{
+            fontSize: "0.75rem",
+            color: c.muted,
+            fontWeight: 500,
+            textTransform: "uppercase",
+            letterSpacing: "0.05em",
+          }}
         >
-          <span>{props.value}</span>
-          {arrow && <span className="text-base">{arrow}</span>}
+          {props.label}
+        </span>
+        <div style={{ display: "flex", alignItems: "baseline", gap: "8px" }}>
+          <span
+            style={{
+              fontSize: "1.5rem",
+              fontWeight: 700,
+              color: c.cardFg,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            {props.value}
+          </span>
+          {props.trend && (
+            <span
+              style={{
+                fontSize: "0.8rem",
+                fontWeight: 500,
+                color: trendColors[props.trend] ?? c.muted,
+              }}
+            >
+              {trendIcons[props.trend]}
+              {props.trendValue ? ` ${props.trendValue}` : ""}
+            </span>
+          )}
         </div>
       </div>
     );
@@ -221,7 +258,10 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     // Divider via `border-b last:border-b-0` so the final row doesn't dangle
     // a trailing line, regardless of whether the agent wraps these in a
     // Column or drops them directly into a Card's child slot.
-    <div className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0">
+    <div
+      data-testid="declarative-info-row"
+      className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0"
+    >
       <span className="text-sm text-[var(--muted-foreground)]">
         {props.label}
       </span>
@@ -230,6 +270,59 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
       </span>
     </div>
   ),
+
+  DataTable: ({ props }) => {
+    const cols = Array.isArray(props.columns) ? props.columns : [];
+    const rows = Array.isArray(props.rows) ? props.rows : [];
+    return (
+      <div
+        data-testid="declarative-data-table"
+        className="w-full overflow-x-auto"
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              {cols.map((col) => (
+                <th
+                  key={col.key}
+                  className="border-b-2 border-[var(--border)] px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => {
+              // Stable row key: prefer the first column's value (primary-key-ish),
+              // suffix with index in case values repeat, fall back to a JSON
+              // stringify of the row when columns is empty. Stable keys prevent
+              // React from re-mounting every row when the agent re-emits a
+              // slightly different table.
+              const pk = cols.length > 0 ? row[cols[0].key] : undefined;
+              const rowKey =
+                pk !== undefined ? `${pk}-${i}` : JSON.stringify(row);
+              return (
+                <tr
+                  key={rowKey}
+                  className="border-b border-[var(--border)] last:border-b-0"
+                >
+                  {cols.map((col) => (
+                    <td
+                      key={col.key}
+                      className="px-3 py-2 tabular-nums text-[var(--foreground)]"
+                    >
+                      {String(row[col.key] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  },
 
   PrimaryButton: ({ props, dispatch }) => (
     <Button
@@ -242,150 +335,114 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
   ),
 
   PieChart: ({ props }) => {
-    const data = props.data ?? [];
-    const safeData = Array.isArray(data) ? data : [];
-    const total = safeData.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
-
+    // Coerce values to numbers — the LLM sometimes emits them as strings.
+    // Use a strict finite check so null/undefined/NaN/non-numeric strings are
+    // surfaced via console.warn rather than silently collapsed to 0 (which
+    // masks schema/data drift). Recharts requires a numeric value to render,
+    // so we fall back to 0 only after logging.
+    const data = (Array.isArray(props.data) ? props.data : []).map((d) => {
+      const raw = (d as { value?: unknown }).value;
+      const n = typeof raw === "number" ? raw : parseFloat(raw as string);
+      let value: number;
+      if (Number.isFinite(n)) {
+        value = n;
+      } else {
+        console.warn("Invalid chart value", {
+          component: "PieChart",
+          key: "value",
+          raw,
+        });
+        value = 0;
+      }
+      return { ...d, value };
+    });
     return (
-      // `flex-1 min-w-0` so multiple charts in a basic-catalog Row
-      // distribute the available width evenly instead of each insisting
-      // on its content size and overflowing.
-      <Card
-        className="w-full flex-1 min-w-0 overflow-hidden"
-        data-testid="declarative-pie-chart"
+      <CardShell
+        title={props.title}
+        subtitle={props.description}
+        testid="declarative-pie-chart"
       >
-        <CardHeader>
-          <CardTitle>{props.title}</CardTitle>
-          <CardDescription>{props.description}</CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          {safeData.length === 0 ? (
-            <div className="py-8 text-center text-sm text-[var(--muted-foreground)]">
-              No data available
-            </div>
-          ) : (
-            <>
-              <DonutChart data={safeData} />
-              <div className="flex flex-col gap-2 pt-2">
-                {safeData.map((item, index) => {
-                  const val = Number(item.value) || 0;
-                  const pct =
-                    total > 0 ? ((val / total) * 100).toFixed(0) : "0";
-                  return (
-                    <div
-                      key={index}
-                      className="flex items-center gap-3 text-sm"
-                    >
-                      <span
-                        className="inline-block h-2.5 w-2.5 shrink-0 rounded-sm"
-                        style={{
-                          backgroundColor:
-                            CHART_COLORS[index % CHART_COLORS.length],
-                        }}
-                      />
-                      <span className="flex-1 truncate text-[var(--foreground)]">
-                        {item.label}
-                      </span>
-                      <span className="tabular-nums text-[var(--muted-foreground)]">
-                        {val.toLocaleString()}
-                      </span>
-                      <span className="w-10 text-right tabular-nums text-[var(--muted-foreground)]">
-                        {pct}%
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-            </>
-          )}
-        </CardContent>
-      </Card>
+        {data.length === 0 ? (
+          <div className="py-8 text-center text-sm text-[var(--muted-foreground)]">
+            No data available
+          </div>
+        ) : (
+          <div style={{ width: "100%", height: 200 }}>
+            <ResponsiveContainer>
+              <RechartsPieChart>
+                <Pie
+                  data={data}
+                  dataKey="value"
+                  nameKey="label"
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={40}
+                  outerRadius={80}
+                  paddingAngle={2}
+                >
+                  {data.map((_, i) => (
+                    <Cell
+                      key={i}
+                      fill={CHART_COLORS[i % CHART_COLORS.length]}
+                    />
+                  ))}
+                </Pie>
+                <Tooltip />
+              </RechartsPieChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardShell>
     );
   },
 
   BarChart: ({ props }) => {
-    const { isNew } = useSeenIndices();
-    const data = props.data ?? [];
-    const safeData = Array.isArray(data) ? data : [];
-
+    // Coerce values to numbers — the LLM sometimes emits them as strings,
+    // which recharts treats as categorical (unordered Y-axis ticks). Use a
+    // strict finite check so null/undefined/NaN/non-numeric strings are
+    // surfaced via console.warn rather than silently collapsed to 0 (which
+    // masks schema/data drift). Recharts requires a numeric value to render,
+    // so we fall back to 0 only after logging.
+    const data = (Array.isArray(props.data) ? props.data : []).map((d) => {
+      const raw = (d as { value?: unknown }).value;
+      const n = typeof raw === "number" ? raw : parseFloat(raw as string);
+      let value: number;
+      if (Number.isFinite(n)) {
+        value = n;
+      } else {
+        console.warn("Invalid chart value", {
+          component: "BarChart",
+          key: "value",
+          raw,
+        });
+        value = 0;
+      }
+      return { ...d, value };
+    });
     return (
-      <Card
-        className="w-full flex-1 min-w-0 overflow-hidden"
-        data-testid="declarative-bar-chart"
+      <CardShell
+        title={props.title}
+        subtitle={props.description}
+        testid="declarative-bar-chart"
       >
-        {/* Scoped keyframe — no globals.css needed */}
-        <style>{`
-          @keyframes barSlideIn {
-            from { transform: translateY(40px); opacity: 0; }
-            20% { opacity: 1; }
-            to { transform: translateY(0); opacity: 1; }
-          }
-        `}</style>
-        <CardHeader>
-          <CardTitle>{props.title}</CardTitle>
-          <CardDescription>{props.description}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          {safeData.length === 0 ? (
-            <div className="py-8 text-center text-sm text-[var(--muted-foreground)]">
-              No data available
-            </div>
-          ) : (
-            <ResponsiveContainer width="100%" height={260}>
-              <RechartsBarChart
-                data={safeData}
-                margin={{ top: 12, right: 12, bottom: 4, left: -8 }}
-              >
-                <CartesianGrid
-                  strokeDasharray="3 3"
-                  stroke="var(--border)"
-                  vertical={false}
-                />
-                <XAxis
-                  dataKey="label"
-                  tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
-                  stroke="var(--border)"
-                  tickLine={false}
-                  axisLine={false}
-                />
-                <YAxis
-                  tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
-                  stroke="var(--border)"
-                  tickLine={false}
-                  axisLine={false}
-                />
-                <Tooltip
-                  contentStyle={CHART_TOOLTIP_STYLE}
-                  cursor={{ fill: "var(--muted)", opacity: 0.5 }}
-                />
-                <Bar
-                  isAnimationActive={false}
-                  dataKey="value"
-                  radius={[6, 6, 0, 0]}
-                  maxBarSize={48}
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  shape={
-                    ((barProps: any) => (
-                      <AnimatedBar
-                        {...barProps}
-                        isNew={isNew(barProps.index as number)}
-                      />
-                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    )) as any
-                  }
-                >
-                  {safeData.map((_, index) => (
-                    <Cell
-                      key={index}
-                      fill={CHART_COLORS[index % CHART_COLORS.length]}
-                    />
-                  ))}
-                </Bar>
+        {data.length === 0 ? (
+          <div className="py-8 text-center text-sm text-[var(--muted-foreground)]">
+            No data available
+          </div>
+        ) : (
+          <div style={{ width: "100%", height: 200 }}>
+            <ResponsiveContainer>
+              <RechartsBarChart data={data}>
+                <CartesianGrid strokeDasharray="3 3" stroke={c.divider} />
+                <XAxis dataKey="label" tick={{ fontSize: 11, fill: c.muted }} />
+                <YAxis tick={{ fontSize: 11, fill: c.muted }} />
+                <Tooltip />
+                <Bar dataKey="value" fill="#3b82f6" radius={[4, 4, 0, 0]} />
               </RechartsBarChart>
             </ResponsiveContainer>
-          )}
-        </CardContent>
-      </Card>
+          </div>
+        )}
+      </CardShell>
     );
   },
 };


### PR DESCRIPTION
## Summary

The D6 e2e-full probe `d6:ms-agent-harness-dotnet/gen-ui-declarative` was failing at turn 1 with `reason=surface-missing`. Three layers, each fixed at the layer the real captured request revealed. Part of the second-wave declarative fan-out (siblings #6051–#6055 / #6053 ms-agent-python).

### Root cause 1 — stale aimock fixture
`showcase/aimock/d6/ms-agent-harness-dotnet/gen-ui-declarative.json` still carried the old D5 pill set (KPI / pie / bar / status prompts) with inner `_design_a2ui_surface` entries keyed on those stale prompts. The current driver sends four VantageThreads sales prompts, so turn 1 ("Show me my sales dashboard for this quarter.") had **no matching inner surface** — the backend looped `generate_a2ui` to its invocation limit and the frontend painted the stale KPI catch-all instead of the sales dashboard. Re-authored to the four current prompts, mirroring the **llamaindex green north-star** for this `_design_a2ui_surface` two-stage backend family (ms-agent-harness-dotnet's inner tool is `_design_a2ui_surface`, per `agent/DeclarativeGenUiAgent.cs` + `agent/A2uiSecondaryToolCaller.cs`).

### Root cause 2 — `hasToolResult` breaks the interleaved thread
This is where the dotnet family diverges from the #6053 ms-agent-python template. ms-agent-python starts a fresh session per turn; the **.NET harness backend threads the FULL interleaved conversation**. `hasToolResult` is a thread-global predicate (see `showcase/GOTCHAS.md`), so once turn 1 leaves a `role:"tool"` message in the thread, every later pill's outer `generate_a2ui` call sees `hasToolResult:true` and matches the **narration** fixture instead of emitting the tool call → surface-missing on turns 2–4. (Reproduced live: turn 2's outer call, replayed with turn-1 history, returned the narration string instead of `generate_a2ui`.) Switched to the sanctioned interleaved-safe pattern: **narration keyed on this pill's outer `toolCallId`** (ordered before the outer), **outer keyed on `userMessage` only**. Verified all four pills resolve correctly through the full interleaved thread against live aimock.

### Root cause 3 — renderer / catalog drift
`renderers.tsx` and `definitions.ts` lagged the green cluster — missing the `DataTable` and `InfoRow` components (the `declarative-data-table` / `declarative-info-row` testids that turns 2 and 4 assert), plus `Metric.trendValue` and the Row/Column/Text gap overrides. Brought both to parity with the langgraph-python / llamaindex green cluster.

## Red → Green proof (real control-plane surface)

`SHOWCASE_ISO_SLOT=18 ./bin/showcase test ms-agent-harness-dotnet:declarative-gen-ui --d6 --isolate --rebuild`

| | result |
|---|---|
| **RED** (pristine stale fixture + drifted renderers) | `state=red`, exit 1 — turn 1 `waitForTurnComplete: turn 1 did not complete within 90000ms (reason=surface-missing, runsFinished=1, count=41)`; body showed the stale "Quarterly KPIs / $1.24M / SIGNUPS 8,420" surface + `generate_a2ui` looping |
| **GREEN** (fix applied) | `state=green`, exit 0 — `1 passed` |

## Visual verification

Drove all 4 turns via Playwright with network-level route injection of `x-aimock-context: ms-agent-harness-dotnet` (replicating the harness/production proxy). Confirmed real painted surfaces:
- **turn 1 sales-dashboard**: 4 KPI metrics ($4.2M revenue, 186 customers, 31% win rate, $22.6k deal) + Revenue-by-Region donut + Monthly-Revenue bar
- **turn 2 rep-quota**: rep-attainment `DataTable` (Dana Whitfield 124% … Elena Vasquez 71%) + quota-attainment `BarChart`
- **turn 3 at-risk**: 3 severity `StatusBadge` cards (Northwind / Cascadia / Atlas) + KPI metric strip
- **turn 4 top-account**: 7 `InfoRow` account facts (Meridian Apparel Group) + product-line `PieChart`

Screenshots under `~/.local/share/copilotkit/cr/2ndwave-shots/msharness-turn{1..4}-*.png`.