### PR TITLE
fix(showcase): repair ms-agent-dotnet D6 gen-ui-declarative (surface-missing)

### DIFF
--- a/showcase/aimock/d6/ms-agent-dotnet/gen-ui-declarative.json
+++ b/showcase/aimock/d6/ms-agent-dotnet/gen-ui-declarative.json
@@ -1,192 +1,25 @@
 {
   "_meta": {
-    "description": "D6 fixtures for ms-agent-dotnet / gen-ui-declarative (mirrored from langgraph-python canonical)",
-    "_note": "Agent uses a two-stage A2UI pattern (src/agents/a2ui_dynamic.py): (1) outer agent has only one tool, `generate_a2ui` (no args). (2) `generate_a2ui` internally invokes a secondary LLM bound to `_design_a2ui_surface` with `tool_choice` forced; that secondary call has tools=[_design_a2ui_surface] and emits the A2UI components payload. (3) After the tool returns, the outer agent emits a one-sentence narration. Fixtures must therefore cover three LLM calls per pill: (a) outer turn 1 \u2192 emit generate_a2ui toolcall; (b) inner secondary call \u2192 emit _design_a2ui_surface toolcall with the flat catalog components; (c) outer turn 2 (post tool result) \u2192 narration. The inner secondary call is discriminated by `toolName: '_design_a2ui_surface'` because the user prompt is identical across both outer+inner calls in the same pill (the inner secondary LLM is invoked with the same conversation messages minus the last assistant message).",
-    "created": "2026-05-28"
+    "description": "D6 fixtures for ms-agent-dotnet / gen-ui-declarative (A2UI Dynamic Schema)",
+    "sourceScript": "d5-gen-ui-declarative.ts",
+    "_note": "Agent plays a sales analyst for the fictional Vantage Threads company (OSS-136). ms-agent-dotnet uses a two-stage A2UI pattern (agent/DeclarativeGenUiAgent.cs + agent/A2uiSecondaryToolCaller.cs) with inner tool `_design_a2ui_surface` (vs google-adk's render_a2ui). Because the ms-agent-framework session does not surface the latest user message to the secondary generate_a2ui LLM call, the OUTER generate_a2ui fixture returns a `context` steering phrase that becomes the inner call's user_content; the inner `_design_a2ui_surface` fixture matches that phrase (NOT the full pill prompt). Mirrors the llamaindex green north-star for this backend shape (same VantageThreads surfaces, same declarative-gen-ui-catalog). hasToolResult discriminates outer (false) vs narration (true). NOTE (ms-agent-dotnet specific): unlike llamaindex/ms-agent-python, the ms-agent-dotnet ChatClientAgent session ACCUMULATES prior-turn tool results into each subsequent turn's request, so hasToolResult is true from turn 2 onward and cannot discriminate outer vs narration. The narration is therefore keyed on the CURRENT turn's outer toolCallId (aimock only matches toolCallId when the LAST message is that tool result), and the outer drops the hasToolResult guard and matches on the full pill prompt.",
+    "created": "2026-07-18",
+    "copiedFrom": "llamaindex"
   },
   "fixtures": [
     {
-      "_comment": "pill 1 KPI \u2014 inner secondary LLM (tools=[_design_a2ui_surface], tool_choice forced) emits the flat A2UI components. Discriminated by toolName so it wins over the outer generate_a2ui fixture whose userMessage matches the same prompt.",
+      "_comment": "pill sales-dashboard hero — TERMINAL narration after generate_a2ui returns — keyed on this turn's outer toolCallId (LAST message = this tool result) so it is per-turn and unaffected by prior-turn tool results accumulated in the ms-agent-dotnet session history.",
       "match": {
-        "userMessage": "Show me a quick KPI dashboard",
-        "toolName": "_design_a2ui_surface"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_kpi_design_001",
-            "name": "_design_a2ui_surface",
-            "arguments": "{\"surfaceId\":\"kpi-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Card\",\"title\":\"KPI Dashboard\",\"subtitle\":\"Last 30 days\",\"child\":\"metrics-col\"},{\"id\":\"metrics-col\",\"component\":\"Column\",\"children\":[\"m-rev\",\"m-sign\",\"m-churn\",\"m-mrr\"],\"gap\":12},{\"id\":\"m-rev\",\"component\":\"Metric\",\"label\":\"Revenue\",\"value\":\"$1.2M\",\"trend\":\"up\"},{\"id\":\"m-sign\",\"component\":\"Metric\",\"label\":\"Signups\",\"value\":\"8,420\",\"trend\":\"up\"},{\"id\":\"m-churn\",\"component\":\"Metric\",\"label\":\"Churn\",\"value\":\"2.1%\",\"trend\":\"down\"},{\"id\":\"m-mrr\",\"component\":\"Metric\",\"label\":\"MRR\",\"value\":\"$98K\",\"trend\":\"up\"}]}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 1 KPI \u2014 outer agent narration after generate_a2ui returns.",
-      "match": {
-        "context": "ms-agent-dotnet",
-        "toolCallId": "call_d6_decl_kpi_outer_001"
-      },
-      "response": {
-        "content": "KPI dashboard rendered."
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 1 KPI \u2014 outer agent emits generate_a2ui (no args).",
-      "match": {
-        "userMessage": "Show me a quick KPI dashboard",
+        "toolCallId": "call_d6_decl_dash_outer_msdotnet_001",
         "context": "ms-agent-dotnet"
       },
       "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_kpi_outer_001",
-            "name": "generate_a2ui",
-            "arguments": "{\"context\": \"KPI dashboard with 3-4 metrics (revenue, signups, churn)\"}"
-          }
-        ]
+        "content": "Here's your Q2 sales dashboard."
       },
       "chunkSize": 9999
     },
     {
-      "_comment": "pill 2 pie chart \u2014 inner secondary LLM emits PieChart catalog component.",
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "toolName": "_design_a2ui_surface"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_pie_design_001",
-            "name": "_design_a2ui_surface",
-            "arguments": "{\"surfaceId\":\"sales-pie\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"PieChart\",\"title\":\"Sales by Region\",\"data\":[{\"label\":\"North America\",\"value\":45},{\"label\":\"Europe\",\"value\":28},{\"label\":\"Asia-Pacific\",\"value\":18},{\"label\":\"Other\",\"value\":9}]}]}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 2 pie chart \u2014 outer agent narration.",
-      "match": {
-        "context": "ms-agent-dotnet",
-        "toolCallId": "call_d6_decl_pie_outer_001"
-      },
-      "response": {
-        "content": "Pie chart rendered."
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 2 pie chart \u2014 outer agent emits generate_a2ui.",
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "context": "ms-agent-dotnet"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_pie_outer_001",
-            "name": "generate_a2ui",
-            "arguments": "{\"context\": \"pie chart of sales by region\"}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 3 bar chart \u2014 inner secondary LLM emits BarChart catalog component.",
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "toolName": "_design_a2ui_surface"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_bar_design_001",
-            "name": "_design_a2ui_surface",
-            "arguments": "{\"surfaceId\":\"quarterly-rev\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"BarChart\",\"title\":\"Quarterly Revenue\",\"data\":[{\"label\":\"Q1\",\"value\":280000},{\"label\":\"Q2\",\"value\":310000},{\"label\":\"Q3\",\"value\":295000},{\"label\":\"Q4\",\"value\":340000}]}]}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 3 bar chart \u2014 outer agent narration.",
-      "match": {
-        "context": "ms-agent-dotnet",
-        "toolCallId": "call_d6_decl_bar_outer_001"
-      },
-      "response": {
-        "content": "Bar chart rendered."
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 3 bar chart \u2014 outer agent emits generate_a2ui.",
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "context": "ms-agent-dotnet"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_bar_outer_001",
-            "name": "generate_a2ui",
-            "arguments": "{\"context\": \"bar chart of quarterly revenue\"}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 4 status report \u2014 inner secondary LLM emits StatusBadges grouped in a root Column.",
-      "match": {
-        "userMessage": "status report on system health",
-        "toolName": "_design_a2ui_surface"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_status_design_001",
-            "name": "_design_a2ui_surface",
-            "arguments": "{\"surfaceId\":\"sys-status\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Card\",\"title\":\"System health\",\"subtitle\":\"All services\",\"child\":\"badges-col\"},{\"id\":\"badges-col\",\"component\":\"Column\",\"children\":[\"sb-api\",\"sb-db\",\"sb-bg\"],\"gap\":8},{\"id\":\"sb-api\",\"component\":\"StatusBadge\",\"text\":\"API: healthy (p99 42ms)\",\"variant\":\"success\"},{\"id\":\"sb-db\",\"component\":\"StatusBadge\",\"text\":\"Database: healthy (replication lag 0.2s)\",\"variant\":\"success\"},{\"id\":\"sb-bg\",\"component\":\"StatusBadge\",\"text\":\"Background Workers: degraded (queue depth 1247)\",\"variant\":\"warning\"}]}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 4 status report \u2014 outer agent narration.",
-      "match": {
-        "context": "ms-agent-dotnet",
-        "toolCallId": "call_d6_decl_status_outer_001"
-      },
-      "response": {
-        "content": "System health status rendered."
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 4 status report \u2014 outer agent emits generate_a2ui.",
-      "match": {
-        "userMessage": "status report on system health",
-        "context": "ms-agent-dotnet"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_status_outer_001",
-            "name": "generate_a2ui",
-            "arguments": "{\"context\": \"status report on system health\"}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args). Mirrors LGP gen-ui-declarative.json sales-dashboard outer entry. Closes the production 503 gap where backend hits aimock with tools=[generate_a2ui] for this userMessage (see /tmp/staging-journal-diff.md shape-B).",
+      "_comment": "pill sales-dashboard hero — OUTER agent emits generate_a2ui with a per-pill context arg, keyed on the full pill prompt (last user msg); the per-turn narration below is keyed on this outer toolCallId so accumulated prior-turn tool results do NOT shadow this outer into the narration branch.",
       "match": {
         "userMessage": "Show me my sales dashboard for this quarter.",
         "context": "ms-agent-dotnet"
@@ -194,9 +27,165 @@
       "response": {
         "toolCalls": [
           {
-            "id": "call_d6_decl_dash_outer_msnet_001",
+            "id": "call_d6_decl_dash_outer_msdotnet_001",
             "name": "generate_a2ui",
-            "arguments": "{}"
+            "arguments": "{\"context\":\"sales dashboard for this quarter\"}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill sales-dashboard hero — INNER secondary planner (forced _design_a2ui_surface via OpenAIClient against aimock). Inner user message = the outer's context arg. Args copied verbatim from LGP sales-dashboard render entry. Asserts declarative-metric (>=4) + declarative-pie-chart + declarative-bar-chart. Keyed userMessage(=outer context arg) + toolName:_design_a2ui_surface + context:ms-agent-dotnet — the harness/HttpAgent forwards X-AIMock-Context to the secondary OpenAIClient() call (verified live: inner request carried ctxHdr=ms-agent-dotnet, status 200), so context-scoping is both correct AND prevents cross-slug _design_a2ui_surface collisions (e.g. built-in-agent reuses the same context-arg userMessage strings).",
+      "match": {
+        "userMessage": "sales dashboard for this quarter",
+        "toolName": "_design_a2ui_surface",
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_dash_design_msdotnet_001_design",
+            "name": "_design_a2ui_surface",
+            "arguments": "{\"surfaceId\":\"sales-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"kpi-row\",\"charts-row\"]},{\"id\":\"kpi-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-revenue\",\"metric-new-customers\",\"metric-win-rate\",\"metric-deal-size\"]},{\"id\":\"metric-revenue\",\"component\":\"Metric\",\"label\":\"Quarterly Revenue\",\"value\":\"$4.2M\",\"trend\":\"up\"},{\"id\":\"metric-new-customers\",\"component\":\"Metric\",\"label\":\"New Customers\",\"value\":\"186\",\"trend\":\"up\"},{\"id\":\"metric-win-rate\",\"component\":\"Metric\",\"label\":\"Win Rate\",\"value\":\"31%\",\"trend\":\"down\"},{\"id\":\"metric-deal-size\",\"component\":\"Metric\",\"label\":\"Avg Deal Size\",\"value\":\"$22.6k\",\"trend\":\"up\"},{\"id\":\"charts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"region-pie\",\"monthly-bar\"]},{\"id\":\"region-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by Region\",\"description\":\"Quarter revenue split across North America, EMEA, APAC, and LATAM.\",\"data\":[{\"label\":\"North America\",\"value\":1900000},{\"label\":\"EMEA\",\"value\":1300000},{\"label\":\"APAC\",\"value\":720000},{\"label\":\"LATAM\",\"value\":280000}]},{\"id\":\"monthly-bar\",\"component\":\"BarChart\",\"title\":\"Monthly Revenue\",\"description\":\"Revenue trend from Jan through Jun.\",\"data\":[{\"label\":\"Jan\",\"value\":1210000},{\"label\":\"Feb\",\"value\":1340000},{\"label\":\"Mar\",\"value\":1650000},{\"label\":\"Apr\",\"value\":1380000},{\"label\":\"May\",\"value\":1420000},{\"label\":\"Jun\",\"value\":1400000}]}]}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill team-performance — TERMINAL narration after generate_a2ui returns.",
+      "match": {
+        "toolCallId": "call_d6_decl_team_outer_msdotnet_001",
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "content": "Here's how the team is tracking against quota."
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill team-performance — OUTER agent emits generate_a2ui with a per-pill context arg, guarded hasToolResult:false.",
+      "match": {
+        "userMessage": "How are our sales reps performing against quota?",
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_team_outer_msdotnet_001",
+            "name": "generate_a2ui",
+            "arguments": "{\"context\":\"sales rep performance against quota\"}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill team-performance — INNER forced _design_a2ui_surface. Inner user message = the outer's context arg. Args copied verbatim from LGP team-performance render entry. Asserts declarative-data-table + declarative-bar-chart. Keyed userMessage(=outer context arg) + toolName:_design_a2ui_surface + context:ms-agent-dotnet — the harness/HttpAgent forwards X-AIMock-Context to the secondary OpenAIClient() call (verified live: inner request carried ctxHdr=ms-agent-dotnet, status 200), so context-scoping is both correct AND prevents cross-slug _design_a2ui_surface collisions (e.g. built-in-agent reuses the same context-arg userMessage strings).",
+      "match": {
+        "userMessage": "sales rep performance against quota",
+        "toolName": "_design_a2ui_surface",
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_team_design_msdotnet_001_design",
+            "name": "_design_a2ui_surface",
+            "arguments": "{\"surfaceId\":\"rep-quota-performance\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"title\",\"summary\",\"content\"]},{\"id\":\"title\",\"component\":\"Text\",\"text\":\"Sales rep performance vs quota\"},{\"id\":\"summary\",\"component\":\"Text\",\"text\":\"2 of 5 reps are above quota, 1 is near plan, and 2 are below target in Q2.\"},{\"id\":\"content\",\"component\":\"Row\",\"gap\":16,\"children\":[\"table-card\",\"attainment-chart\"]},{\"id\":\"table-card\",\"component\":\"Card\",\"title\":\"Rep attainment table\",\"child\":\"rep-table\"},{\"id\":\"rep-table\",\"component\":\"DataTable\",\"columns\":[{\"key\":\"rep\",\"label\":\"Rep\"},{\"key\":\"attainment\",\"label\":\"Attainment\"},{\"key\":\"pipeline\",\"label\":\"Pipeline\"}],\"rows\":[{\"rep\":\"Dana Whitfield\",\"attainment\":\"124%\",\"pipeline\":\"Leading team; biggest account Meridian Apparel Group has 4 open opps worth $210k\"},{\"rep\":\"Marcus Lee\",\"attainment\":\"108%\",\"pipeline\":\"Above plan\"},{\"rep\":\"Priya Sharma\",\"attainment\":\"97%\",\"pipeline\":\"Near quota\"},{\"rep\":\"Tom Okafor\",\"attainment\":\"88%\",\"pipeline\":\"Below plan\"},{\"rep\":\"Elena Vasquez\",\"attainment\":\"71%\",\"pipeline\":\"Furthest from quota\"}]},{\"id\":\"attainment-chart\",\"component\":\"BarChart\",\"title\":\"Quota attainment by rep\",\"description\":\"Q2 quota attainment percentages for all sales reps.\",\"data\":[{\"label\":\"Dana Whitfield\",\"value\":124},{\"label\":\"Marcus Lee\",\"value\":108},{\"label\":\"Priya Sharma\",\"value\":97},{\"label\":\"Tom Okafor\",\"value\":88},{\"label\":\"Elena Vasquez\",\"value\":71}]}]}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill at-risk — TERMINAL narration after generate_a2ui returns.",
+      "match": {
+        "toolCallId": "call_d6_decl_risk_outer_msdotnet_001",
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "content": "Three accounts need attention this quarter."
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill at-risk — OUTER agent emits generate_a2ui with a per-pill context arg, guarded hasToolResult:false.",
+      "match": {
+        "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_risk_outer_msdotnet_001",
+            "name": "generate_a2ui",
+            "arguments": "{\"context\":\"accounts and pipeline deals at risk this quarter\"}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill at-risk — INNER forced _design_a2ui_surface. Inner user message = the outer's context arg. Args copied verbatim from LGP at-risk render entry. Asserts declarative-status-badge (>=3) + declarative-metric (>=3). Keyed userMessage(=outer context arg) + toolName:_design_a2ui_surface + context:ms-agent-dotnet — the harness/HttpAgent forwards X-AIMock-Context to the secondary OpenAIClient() call (verified live: inner request carried ctxHdr=ms-agent-dotnet, status 200), so context-scoping is both correct AND prevents cross-slug _design_a2ui_surface collisions (e.g. built-in-agent reuses the same context-arg userMessage strings).",
+      "match": {
+        "userMessage": "accounts and pipeline deals at risk this quarter",
+        "toolName": "_design_a2ui_surface",
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_risk_design_msdotnet_001_design",
+            "name": "_design_a2ui_surface",
+            "arguments": "{\"surfaceId\":\"risk-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"metrics-row\",\"accounts-row\"]},{\"id\":\"metrics-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-arr\",\"metric-accounts\",\"metric-biggest\"]},{\"id\":\"metric-arr\",\"component\":\"Metric\",\"label\":\"ARR at risk\",\"value\":\"$615k\",\"trend\":\"down\"},{\"id\":\"metric-accounts\",\"component\":\"Metric\",\"label\":\"Accounts at risk\",\"value\":\"3\",\"trend\":\"neutral\"},{\"id\":\"metric-biggest\",\"component\":\"Metric\",\"label\":\"Biggest exposure\",\"value\":\"Northwind Retail\",\"trend\":\"down\"},{\"id\":\"accounts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"card-northwind\",\"card-cascadia\",\"card-atlas\"]},{\"id\":\"card-northwind\",\"component\":\"Card\",\"title\":\"Northwind Retail\",\"subtitle\":\"$340k ARR at stake\",\"child\":\"northwind-content\"},{\"id\":\"northwind-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"northwind-badge\",\"northwind-text\"]},{\"id\":\"northwind-badge\",\"component\":\"StatusBadge\",\"text\":\"High severity\",\"variant\":\"error\"},{\"id\":\"northwind-text\",\"component\":\"Text\",\"text\":\"No contact in 6 weeks; next action: exec outreach this week to protect the renewal.\"},{\"id\":\"card-cascadia\",\"component\":\"Card\",\"title\":\"Cascadia Outfitters\",\"subtitle\":\"$180k ARR at stake\",\"child\":\"cascadia-content\"},{\"id\":\"cascadia-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"cascadia-badge\",\"cascadia-text\"]},{\"id\":\"cascadia-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"cascadia-text\",\"component\":\"Text\",\"text\":\"Champion left; next action: rebuild stakeholder map and secure a new sponsor.\"},{\"id\":\"card-atlas\",\"component\":\"Card\",\"title\":\"Atlas Goods\",\"subtitle\":\"$95k ARR at stake\",\"child\":\"atlas-content\"},{\"id\":\"atlas-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"atlas-badge\",\"atlas-text\"]},{\"id\":\"atlas-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"atlas-text\",\"component\":\"Text\",\"text\":\"Legal review is stalled; next action: align procurement and legal on open terms.\"}]}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill top-account — TERMINAL narration after generate_a2ui returns.",
+      "match": {
+        "toolCallId": "call_d6_decl_acct_outer_msdotnet_001",
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "content": "Here's the rundown on Meridian Apparel Group."
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill top-account — OUTER agent emits generate_a2ui with a per-pill context arg, guarded hasToolResult:false.",
+      "match": {
+        "userMessage": "Pull up the details on our biggest account.",
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_acct_outer_msdotnet_001",
+            "name": "generate_a2ui",
+            "arguments": "{\"context\":\"details on our biggest account\"}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "pill top-account — INNER forced _design_a2ui_surface. Inner user message = the outer's context arg. Args copied verbatim from LGP top-account render entry. Asserts declarative-info-row + declarative-pie-chart. Keyed userMessage(=outer context arg) + toolName:_design_a2ui_surface + context:ms-agent-dotnet — the harness/HttpAgent forwards X-AIMock-Context to the secondary OpenAIClient() call (verified live: inner request carried ctxHdr=ms-agent-dotnet, status 200), so context-scoping is both correct AND prevents cross-slug _design_a2ui_surface collisions (e.g. built-in-agent reuses the same context-arg userMessage strings).",
+      "match": {
+        "userMessage": "details on our biggest account",
+        "toolName": "_design_a2ui_surface",
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_acct_design_msdotnet_001_design",
+            "name": "_design_a2ui_surface",
+            "arguments": "{\"surfaceId\":\"biggest-account-details\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Row\",\"gap\":16,\"children\":[\"account-card\",\"revenue-pie\"]},{\"id\":\"account-card\",\"component\":\"Card\",\"title\":\"Meridian Apparel Group\",\"subtitle\":\"Biggest account\",\"child\":\"account-facts\"},{\"id\":\"account-facts\",\"component\":\"Column\",\"gap\":8,\"children\":[\"fact1\",\"fact2\",\"fact3\",\"fact4\",\"fact5\",\"fact6\",\"fact7\"]},{\"id\":\"fact1\",\"component\":\"InfoRow\",\"label\":\"Owner\",\"value\":\"Dana Whitfield\"},{\"id\":\"fact2\",\"component\":\"InfoRow\",\"label\":\"Region\",\"value\":\"North America\"},{\"id\":\"fact3\",\"component\":\"InfoRow\",\"label\":\"ARR\",\"value\":\"$612k\"},{\"id\":\"fact4\",\"component\":\"InfoRow\",\"label\":\"Renewal date\",\"value\":\"Sep 30\"},{\"id\":\"fact5\",\"component\":\"InfoRow\",\"label\":\"Last contact\",\"value\":\"3 days ago\"},{\"id\":\"fact6\",\"component\":\"InfoRow\",\"label\":\"Health\",\"value\":\"Green\"},{\"id\":\"fact7\",\"component\":\"InfoRow\",\"label\":\"Open opportunities\",\"value\":\"4 opportunities worth $210k\"},{\"id\":\"revenue-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by product line\",\"description\":\"Meridian Apparel Group revenue mix across product lines.\",\"data\":[{\"label\":\"Outerwear\",\"value\":260000},{\"label\":\"Footwear\",\"value\":180000},{\"label\":\"Accessories\",\"value\":112000},{\"label\":\"Custom\",\"value\":60000}]}]}"
           }
         ]
       },

--- a/showcase/integrations/ms-agent-dotnet/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
+++ b/showcase/integrations/ms-agent-dotnet/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
@@ -54,6 +54,28 @@ export const myDefinitions = {
     }),
   },
 
+  DataTable: {
+    description:
+      "A data table with column headers and rows. Ideal for rankings and per-person/per-item breakdowns (rep performance vs quota, deal lists). Each row's keys MUST appear in `columns[].key`; unknown row keys render as blank cells and indicate model/schema drift.",
+    // NOTE on row-keys ⊆ columns[].key: we'd normally enforce this with
+    // `z.object(...).refine(...)`, but the host catalog package's
+    // `CatalogComponentDefinition` type requires `props: ZodObject<…>`
+    // (it inspects `.shape` at runtime), and `.refine` returns a
+    // `ZodEffects` that breaks both the `satisfies CatalogDefinitions`
+    // type assertion and the runtime `.shape` access. Until the host type
+    // is broadened, we encode the constraint in the description above so
+    // the LLM sees the rule, and leave hard enforcement to the rendering
+    // pipeline (which already shows the empty cell — detection is the gap,
+    // not behaviour).
+    props: z.object({
+      columns: z.array(z.object({ key: z.string(), label: z.string() })),
+      // Cells may be strings or numbers — the renderer stringifies at
+      // render time, but accepting both lets the LLM emit raw numerics
+      // (e.g. attainment 124) instead of being forced to stringify.
+      rows: z.array(z.record(z.union([z.string(), z.number()]))),
+    }),
+  },
+
   PrimaryButton: {
     description:
       "A styled primary call-to-action button. Attach an optional `action` that will be dispatched back to the agent when the user clicks it.",

--- a/showcase/integrations/ms-agent-dotnet/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/ms-agent-dotnet/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -221,7 +221,10 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     // Divider via `border-b last:border-b-0` so the final row doesn't dangle
     // a trailing line, regardless of whether the agent wraps these in a
     // Column or drops them directly into a Card's child slot.
-    <div className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0">
+    <div
+      data-testid="declarative-info-row"
+      className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0"
+    >
       <span className="text-sm text-[var(--muted-foreground)]">
         {props.label}
       </span>
@@ -230,6 +233,59 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
       </span>
     </div>
   ),
+
+  DataTable: ({ props }) => {
+    const cols = Array.isArray(props.columns) ? props.columns : [];
+    const rows = Array.isArray(props.rows) ? props.rows : [];
+    return (
+      <div
+        data-testid="declarative-data-table"
+        className="w-full overflow-x-auto"
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              {cols.map((col) => (
+                <th
+                  key={col.key}
+                  className="border-b-2 border-[var(--border)] px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => {
+              // Stable row key: prefer the first column's value (primary-key-ish),
+              // suffix with index in case values repeat, fall back to a JSON
+              // stringify of the row when columns is empty. Stable keys prevent
+              // React from re-mounting every row when the agent re-emits a
+              // slightly different table.
+              const pk = cols.length > 0 ? row[cols[0].key] : undefined;
+              const rowKey =
+                pk !== undefined ? `${pk}-${i}` : JSON.stringify(row);
+              return (
+                <tr
+                  key={rowKey}
+                  className="border-b border-[var(--border)] last:border-b-0"
+                >
+                  {cols.map((col) => (
+                    <td
+                      key={col.key}
+                      className="px-3 py-2 tabular-nums text-[var(--foreground)]"
+                    >
+                      {String(row[col.key] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  },
 
   PrimaryButton: ({ props, dispatch }) => (
     <Button


### PR DESCRIPTION
## Summary

The D6 e2e-full probe `d6:ms-agent-dotnet/gen-ui-declarative` was failing at turn 1 with `reason=surface-missing`. Two root causes, both fixed at the layer the real captured backend behaviour revealed.

### Root cause 1 — stale aimock fixture
`showcase/aimock/d6/ms-agent-dotnet/gen-ui-declarative.json` still carried the old D5 pill prompts (KPI / pie / bar / status) plus a lone outer `generate_a2ui` entry for the sales-dashboard prompt with **no** matching inner `_design_a2ui_surface`, so turn 1 never produced a surface.

Re-authored to the current 4 VantageThreads sales prompts, mirroring the **llamaindex / ms-agent-python green north-stars** for this `_design_a2ui_surface` backend family (confirmed identical two-stage pattern in `agent/DeclarativeGenUiAgent.cs` + `agent/A2uiSecondaryToolCaller.cs`): the outer `generate_a2ui` returns a per-pill `context` steering phrase that becomes the inner secondary call's `user_content`; the inner `_design_a2ui_surface` fixture matches that phrase (not the full prompt).

**ms-agent-dotnet–specific discriminator.** Unlike llamaindex / ms-agent-python, the ms-agent-dotnet `ChatClientAgent` session **accumulates prior-turn tool results** into each subsequent turn's request, so aimock's `hasToolResult` predicate is `true` from turn 2 onward and can no longer discriminate outer vs narration — turn 2+ would short-circuit straight to the narration fixture and emit no surface (verified live). The narration is therefore keyed on the **current turn's outer `toolCallId`** (aimock only matches `toolCallId` when the LAST message is that tool result) and ordered **before** the outer per pill, so a tool-result turn resolves to narration while a user-message turn resolves to the outer.

### Root cause 2 — renderer / catalog drift
The declarative catalog lagged the green cluster: `InfoRow` was missing its `declarative-info-row` testid (turn 4 assert) and `DataTable` was absent entirely (turn 2 assert). Added the testid and the `DataTable` renderer + definition, matching the green cluster.

## Red → Green proof (real control-plane surface)

`./bin/showcase test ms-agent-dotnet:declarative-gen-ui --d6 --isolate --rebuild`

| | result |
|---|---|
| **RED** (pristine stale fixture + missing DataTable/info-row testid) | `d6:ms-agent-dotnet/gen-ui-declarative = red` — exit 1, turn 1 `surface-missing`, `0 passed, 1 failed` |
| **GREEN** (fix applied) | `d6:ms-agent-dotnet/gen-ui-declarative = green` — exit 0, `1 passed` |

An intermediate rebuild flipped turn 1 green but exposed the turn-2 `surface-missing` (accumulated-history bug); the `toolCallId` narration re-keying fixed all four turns.

## Visual verification

Drove all 4 turns via Playwright (header-injected `X-AIMock-Context: ms-agent-dotnet` + `X-AIMock-Strict: true` to replicate the harness proxy). Confirmed real painted surfaces:
- **turn 1 sales-dashboard**: 4 KPI metrics ($4.2M revenue, 186 customers, 31% win rate, $22.6k deal) + Revenue-by-Region pie + Monthly-Revenue bar
- **turn 2 team-performance**: rep-quota `DataTable` (Dana Whitfield 124% … Elena Vasquez 71%) + attainment `BarChart`
- **turn 3 at-risk**: 3 `StatusBadge` severity cards + KPI metric strip
- **turn 4 top-account**: 7 `InfoRow` account facts (Meridian Apparel Group) + product-line `PieChart`

Screenshots under `~/.local/share/copilotkit/cr/2ndwave-shots/msdotnet-turn{1..4}-full.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
