### PR TITLE
fix(showcase): langroid declarative gen-ui → two-stage A2UI north-star (D6 turn-1 surface-missing)

### DIFF
--- a/showcase/aimock/d6/langroid/gen-ui-declarative.json
+++ b/showcase/aimock/d6/langroid/gen-ui-declarative.json
@@ -1,138 +1,193 @@
 {
-  "_meta": {
-    "description": "D6 fixtures for langroid / gen-ui-declarative",
-    "sourceScript": "d5-gen-ui-declarative.ts",
-    "created": "2026-05-22"
+ "_meta": {
+  "description": "D6 fixtures for langroid / gen-ui-declarative (A2UI Dynamic Schema)",
+  "_note": "Agent plays a sales analyst for the fictional Vantage Threads company (OSS-136). Two-stage A2UI pattern: (1) outer agent has only one tool, `generate_a2ui` (no args); (2) `generate_a2ui` internally invokes a secondary LLM with tool_choice forced on the design tool, which emits the flat A2UI components payload; (3) after the tool returns, the outer agent emits a one-sentence narration. Fixtures cover three LLM calls per pill: (a) outer turn 1 -> generate_a2ui toolcall; (b) inner secondary call -> design toolcall (discriminated by toolName because the user prompt is identical across outer+inner calls); (c) outer turn 2 (matched by toolCallId) -> narration. Pill prompts are natural business questions; chart steering lives in the system prompt + sales-context.ts context entries. Keep userMessage matchers in sync with declarative-gen-ui/suggestions.ts and harness d5-gen-ui-declarative.ts.",
+  "created": "2026-06-11"
+ },
+ "fixtures": [
+  {
+   "_comment": "pill sales-dashboard hero — inner secondary LLM (tool_choice forced) emits the flat A2UI components. Discriminated by toolName so it wins over the outer generate_a2ui fixture whose userMessage matches the same prompt. Scoped to context=langroid (langroid forwards x-aimock-context to the inner planner call, unlike ag_ui_adk/strands) so it does not collide with the sibling shared-scope render_a2ui fixtures.",
+   "match": {
+    "userMessage": "Show me my sales dashboard for this quarter.",
+    "toolName": "render_a2ui",
+    "context": "langroid"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_dash_design_001",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"sales-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"kpi-row\",\"charts-row\"]},{\"id\":\"kpi-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-revenue\",\"metric-new-customers\",\"metric-win-rate\",\"metric-deal-size\"]},{\"id\":\"metric-revenue\",\"component\":\"Metric\",\"label\":\"Quarterly Revenue\",\"value\":\"$4.2M\",\"trend\":\"up\",\"trendValue\":\"+12% QoQ\"},{\"id\":\"metric-new-customers\",\"component\":\"Metric\",\"label\":\"New Customers\",\"value\":\"186\",\"trend\":\"up\",\"trendValue\":\"+8%\"},{\"id\":\"metric-win-rate\",\"component\":\"Metric\",\"label\":\"Win Rate\",\"value\":\"31%\",\"trend\":\"down\",\"trendValue\":\"-2 pts\"},{\"id\":\"metric-deal-size\",\"component\":\"Metric\",\"label\":\"Avg Deal Size\",\"value\":\"$22.6k\",\"trend\":\"up\",\"trendValue\":\"+5%\"},{\"id\":\"charts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"region-pie\",\"monthly-bar\"]},{\"id\":\"region-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by Region\",\"description\":\"Quarter revenue split across North America, EMEA, APAC, and LATAM.\",\"data\":[{\"label\":\"North America\",\"value\":1900000},{\"label\":\"EMEA\",\"value\":1300000},{\"label\":\"APAC\",\"value\":720000},{\"label\":\"LATAM\",\"value\":280000}]},{\"id\":\"monthly-bar\",\"component\":\"BarChart\",\"title\":\"Monthly Revenue\",\"description\":\"Revenue trend from Jan through Jun.\",\"data\":[{\"label\":\"Jan\",\"value\":1210000},{\"label\":\"Feb\",\"value\":1340000},{\"label\":\"Mar\",\"value\":1650000},{\"label\":\"Apr\",\"value\":1380000},{\"label\":\"May\",\"value\":1420000},{\"label\":\"Jun\",\"value\":1400000}]}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
   },
-  "fixtures": [
-    {
-      "_comment": "kpi-dashboard pill — emits render_a2ui tool call with Card + Metric components. hasToolResult:false prevents re-match on second leg.",
-      "match": {
-        "userMessage": "KPI dashboard with 3-4 metrics",
-        "hasToolResult": false,
-        "context": "langroid"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_kpi_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"Card\",\"props\":{\"title\":\"KPI Dashboard\"}},{\"type\":\"Metric\",\"props\":{\"label\":\"Revenue\",\"value\":\"$2.4M\",\"change\":\"+15%\"}},{\"type\":\"Metric\",\"props\":{\"label\":\"Signups\",\"value\":\"12,400\",\"change\":\"+8%\"}},{\"type\":\"Metric\",\"props\":{\"label\":\"Churn\",\"value\":\"2.1%\",\"change\":\"-0.3%\"}}]}"
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "kpi-dashboard pill — follow-up narration after tool result.",
-      "match": {
-        "userMessage": "KPI dashboard with 3-4 metrics",
-        "hasToolResult": true,
-        "context": "langroid"
-      },
-      "response": {
-        "content": "KPI dashboard rendered above with revenue, signups, and churn metrics."
-      }
-    },
-    {
-      "_comment": "pie-chart pill — emits render_a2ui with PieChart component.",
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "hasToolResult": false,
-        "context": "langroid"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_pie_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"PieChart\",\"props\":{\"title\":\"Sales by Region\",\"data\":[{\"label\":\"North America\",\"value\":45},{\"label\":\"Europe\",\"value\":30},{\"label\":\"Asia-Pacific\",\"value\":20},{\"label\":\"Other\",\"value\":5}]}}]}"
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "pie-chart pill — follow-up narration.",
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "hasToolResult": true,
-        "context": "langroid"
-      },
-      "response": {
-        "content": "Pie chart rendered above — North America leads at 45%, followed by Europe at 30%."
-      }
-    },
-    {
-      "_comment": "bar-chart pill — emits render_a2ui with BarChart component.",
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "hasToolResult": false,
-        "context": "langroid"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_bar_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"BarChart\",\"props\":{\"title\":\"Quarterly Revenue\",\"data\":[{\"label\":\"Q1\",\"value\":580000},{\"label\":\"Q2\",\"value\":620000},{\"label\":\"Q3\",\"value\":710000},{\"label\":\"Q4\",\"value\":850000}]}}]}"
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "bar-chart pill — follow-up narration.",
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "hasToolResult": true,
-        "context": "langroid"
-      },
-      "response": {
-        "content": "Bar chart rendered above showing quarterly revenue growth from Q1 through Q4."
-      }
-    },
-    {
-      "_comment": "status-report pill — emits render_a2ui with StatusBadge components. The distinguishing testid is declarative-status-badge.",
-      "match": {
-        "userMessage": "status report on system health",
-        "hasToolResult": false,
-        "context": "langroid"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_status_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"StatusBadge\",\"props\":{\"label\":\"API\",\"status\":\"healthy\"}},{\"type\":\"StatusBadge\",\"props\":{\"label\":\"Database\",\"status\":\"healthy\"}},{\"type\":\"StatusBadge\",\"props\":{\"label\":\"Background Workers\",\"status\":\"degraded\"}}]}"
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "status-report pill — follow-up narration.",
-      "match": {
-        "userMessage": "status report on system health",
-        "hasToolResult": true,
-        "context": "langroid"
-      },
-      "response": {
-        "content": "System health report rendered. API and Database are healthy; Background Workers are in a degraded state."
-      }
-    },
-    {
-      "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args). Mirrors LGP gen-ui-declarative.json sales-dashboard outer entry. Closes the production 503 gap where backend hits aimock with tools=[generate_a2ui] for this userMessage (see /tmp/staging-journal-diff.md shape-B).",
-      "match": {
-        "userMessage": "Show me my sales dashboard for this quarter.",
-        "context": "langroid"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_dash_outer_langroid_001",
-            "name": "generate_a2ui",
-            "arguments": "{}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    }
-  ]
+  {
+   "_comment": "pill sales-dashboard hero — outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "langroid",
+    "toolCallId": "call_d6_decl_dash_outer_001"
+   },
+   "response": {
+    "content": "Here's your Q2 sales dashboard."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "Show me my sales dashboard for this quarter.",
+    "context": "langroid"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_dash_outer_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill team-performance — inner secondary LLM (tool_choice forced) emits the flat A2UI components. Discriminated by toolName so it wins over the outer generate_a2ui fixture whose userMessage matches the same prompt. Scoped to context=langroid (langroid forwards x-aimock-context to the inner planner call, unlike ag_ui_adk/strands) so it does not collide with the sibling shared-scope render_a2ui fixtures.",
+   "match": {
+    "userMessage": "How are our sales reps performing against quota?",
+    "toolName": "render_a2ui",
+    "context": "langroid"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_team_design_001",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"rep-quota-performance\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"title\",\"summary\",\"content\"]},{\"id\":\"title\",\"component\":\"Text\",\"text\":\"Sales rep performance vs quota\"},{\"id\":\"summary\",\"component\":\"Text\",\"text\":\"2 of 5 reps are above quota, 1 is near plan, and 2 are below target in Q2.\"},{\"id\":\"content\",\"component\":\"Row\",\"gap\":16,\"children\":[\"table-card\",\"attainment-chart\"]},{\"id\":\"table-card\",\"component\":\"Card\",\"title\":\"Rep attainment table\",\"child\":\"rep-table\"},{\"id\":\"rep-table\",\"component\":\"DataTable\",\"columns\":[{\"key\":\"rep\",\"label\":\"Rep\"},{\"key\":\"attainment\",\"label\":\"Attainment\"},{\"key\":\"pipeline\",\"label\":\"Pipeline\"}],\"rows\":[{\"rep\":\"Dana Whitfield\",\"attainment\":\"124%\",\"pipeline\":\"Leading team; biggest account Meridian Apparel Group has 4 open opps worth $210k\"},{\"rep\":\"Marcus Lee\",\"attainment\":\"108%\",\"pipeline\":\"Above plan\"},{\"rep\":\"Priya Sharma\",\"attainment\":\"97%\",\"pipeline\":\"Near quota\"},{\"rep\":\"Tom Okafor\",\"attainment\":\"88%\",\"pipeline\":\"Below plan\"},{\"rep\":\"Elena Vasquez\",\"attainment\":\"71%\",\"pipeline\":\"Furthest from quota\"}]},{\"id\":\"attainment-chart\",\"component\":\"BarChart\",\"title\":\"Quota attainment by rep\",\"description\":\"Q2 quota attainment percentages for all sales reps.\",\"data\":[{\"label\":\"Dana Whitfield\",\"value\":124},{\"label\":\"Marcus Lee\",\"value\":108},{\"label\":\"Priya Sharma\",\"value\":97},{\"label\":\"Tom Okafor\",\"value\":88},{\"label\":\"Elena Vasquez\",\"value\":71}]}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill team-performance — outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "langroid",
+    "toolCallId": "call_d6_decl_team_outer_001"
+   },
+   "response": {
+    "content": "Here's how the team is tracking against quota."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill team-performance — outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "How are our sales reps performing against quota?",
+    "context": "langroid"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_team_outer_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill at-risk — inner secondary LLM (tool_choice forced) emits the flat A2UI components. Discriminated by toolName so it wins over the outer generate_a2ui fixture whose userMessage matches the same prompt. Scoped to context=langroid (langroid forwards x-aimock-context to the inner planner call, unlike ag_ui_adk/strands) so it does not collide with the sibling shared-scope render_a2ui fixtures.",
+   "match": {
+    "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
+    "toolName": "render_a2ui",
+    "context": "langroid"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_risk_design_001",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"risk-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"metrics-row\",\"accounts-row\"]},{\"id\":\"metrics-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-arr\",\"metric-accounts\",\"metric-biggest\"]},{\"id\":\"metric-arr\",\"component\":\"Metric\",\"label\":\"ARR at risk\",\"value\":\"$615k\",\"trend\":\"down\",\"trendValue\":\"3 accounts\"},{\"id\":\"metric-accounts\",\"component\":\"Metric\",\"label\":\"Accounts at risk\",\"value\":\"3\",\"trend\":\"neutral\",\"trendValue\":\"This quarter\"},{\"id\":\"metric-biggest\",\"component\":\"Metric\",\"label\":\"Biggest exposure\",\"value\":\"Northwind Retail\",\"trend\":\"down\",\"trendValue\":\"$340k renewal\"},{\"id\":\"accounts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"card-northwind\",\"card-cascadia\",\"card-atlas\"]},{\"id\":\"card-northwind\",\"component\":\"Card\",\"title\":\"Northwind Retail\",\"subtitle\":\"$340k ARR at stake\",\"child\":\"northwind-content\"},{\"id\":\"northwind-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"northwind-badge\",\"northwind-text\"]},{\"id\":\"northwind-badge\",\"component\":\"StatusBadge\",\"text\":\"High severity\",\"variant\":\"error\"},{\"id\":\"northwind-text\",\"component\":\"Text\",\"text\":\"No contact in 6 weeks; next action: exec outreach this week to protect the renewal.\"},{\"id\":\"card-cascadia\",\"component\":\"Card\",\"title\":\"Cascadia Outfitters\",\"subtitle\":\"$180k ARR at stake\",\"child\":\"cascadia-content\"},{\"id\":\"cascadia-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"cascadia-badge\",\"cascadia-text\"]},{\"id\":\"cascadia-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"cascadia-text\",\"component\":\"Text\",\"text\":\"Champion left; next action: rebuild stakeholder map and secure a new sponsor.\"},{\"id\":\"card-atlas\",\"component\":\"Card\",\"title\":\"Atlas Goods\",\"subtitle\":\"$95k ARR at stake\",\"child\":\"atlas-content\"},{\"id\":\"atlas-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"atlas-badge\",\"atlas-text\"]},{\"id\":\"atlas-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"atlas-text\",\"component\":\"Text\",\"text\":\"Legal review is stalled; next action: align procurement and legal on open terms.\"}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill at-risk — outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "langroid",
+    "toolCallId": "call_d6_decl_risk_outer_001"
+   },
+   "response": {
+    "content": "Three accounts need attention this quarter."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill at-risk — outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
+    "context": "langroid"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_risk_outer_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill top-account — inner secondary LLM (tool_choice forced) emits the flat A2UI components. Discriminated by toolName so it wins over the outer generate_a2ui fixture whose userMessage matches the same prompt. Scoped to context=langroid (langroid forwards x-aimock-context to the inner planner call, unlike ag_ui_adk/strands) so it does not collide with the sibling shared-scope render_a2ui fixtures.",
+   "match": {
+    "userMessage": "Pull up the details on our biggest account.",
+    "toolName": "render_a2ui",
+    "context": "langroid"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_acct_design_001",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"biggest-account-details\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Row\",\"gap\":16,\"children\":[\"account-card\",\"revenue-pie\"]},{\"id\":\"account-card\",\"component\":\"Card\",\"title\":\"Meridian Apparel Group\",\"subtitle\":\"Biggest account\",\"child\":\"account-facts\"},{\"id\":\"account-facts\",\"component\":\"Column\",\"gap\":8,\"children\":[\"fact1\",\"fact2\",\"fact3\",\"fact4\",\"fact5\",\"fact6\",\"fact7\"]},{\"id\":\"fact1\",\"component\":\"InfoRow\",\"label\":\"Owner\",\"value\":\"Dana Whitfield\"},{\"id\":\"fact2\",\"component\":\"InfoRow\",\"label\":\"Region\",\"value\":\"North America\"},{\"id\":\"fact3\",\"component\":\"InfoRow\",\"label\":\"ARR\",\"value\":\"$612k\"},{\"id\":\"fact4\",\"component\":\"InfoRow\",\"label\":\"Renewal date\",\"value\":\"Sep 30\"},{\"id\":\"fact5\",\"component\":\"InfoRow\",\"label\":\"Last contact\",\"value\":\"3 days ago\"},{\"id\":\"fact6\",\"component\":\"InfoRow\",\"label\":\"Health\",\"value\":\"Green\"},{\"id\":\"fact7\",\"component\":\"InfoRow\",\"label\":\"Open opportunities\",\"value\":\"4 opportunities worth $210k\"},{\"id\":\"revenue-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by product line\",\"description\":\"Meridian Apparel Group revenue mix across product lines.\",\"data\":[{\"label\":\"Outerwear\",\"value\":260000},{\"label\":\"Footwear\",\"value\":180000},{\"label\":\"Accessories\",\"value\":112000},{\"label\":\"Custom\",\"value\":60000}]}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill top-account — outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "langroid",
+    "toolCallId": "call_d6_decl_acct_outer_001"
+   },
+   "response": {
+    "content": "Here's the rundown on Meridian Apparel Group."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill top-account — outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "Pull up the details on our biggest account.",
+    "context": "langroid"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_acct_outer_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  }
+ ]
 }

--- a/showcase/integrations/langroid/src/agents/agent.py
+++ b/showcase/integrations/langroid/src/agents/agent.py
@@ -24,6 +24,7 @@ aligned.
 # @region[weather-tool-backend]
 from __future__ import annotations
 
+import contextvars
 import functools
 import json
 import logging
@@ -231,6 +232,22 @@ _RENDER_A2UI_FUNCTION_SPEC = lm.LLMFunctionSpec(
     },
 )
 
+# The same spec expressed as a MODERN tool spec (``tools=[...]`` +
+# ``tool_choice=...``) rather than the legacy ``functions=[...]`` +
+# ``function_call=...`` API. This matters for the aimock replay path: the
+# fixture router discriminates the inner planner call from the outer agent
+# call via the ``toolName`` matcher, which inspects the request's
+# ``tools[]`` array — the legacy ``functions[]`` field is invisible to it,
+# so a legacy-API inner call would fall through to the outer
+# ``generate_a2ui`` fixture (yielding an empty surface). Emitting the tool
+# via ``tools[]`` puts ``render_a2ui`` where the matcher looks. langroid's
+# response extractor already reads the modern ``oai_tool_calls`` path first
+# (see ``_extract_tool_call_arguments``), so nothing downstream changes.
+_RENDER_A2UI_TOOL_SPEC = lm.base.OpenAIToolSpec(
+    type="function",
+    function=_RENDER_A2UI_FUNCTION_SPEC,
+)
+
 
 class _LLMResponseLike(Protocol):
     """Structural type for the subset of ``LLMResponse`` we read.
@@ -338,6 +355,32 @@ def _extract_tool_call_arguments(
     return None
 
 
+# The last user turn of the current run, stashed here by the AG-UI adapter
+# (``handle_run``) so the secondary A2UI planner LLM can thread it as the
+# inner ``render_a2ui`` call's user message. The sibling google-adk /
+# strands backends get this for free because their framework middleware
+# (``ag_ui_adk`` / ``ag_ui_strands``) forwards the run's conversation into
+# the inner call — so aimock matches the inner planner call on the pill
+# prompt (the generic render guidance rides as the system prompt). Langroid
+# has no such middleware, so we thread it explicitly. A ContextVar (not a
+# module global) so concurrent requests on the shared worker don't clobber
+# each other; ``asyncio.to_thread`` copies the context into the worker
+# thread, so the value set in the request coroutine is visible inside the
+# backend tool's ``.handle()``.
+_LAST_USER_MESSAGE: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "a2ui_last_user_message", default=""
+)
+
+
+def set_last_user_message(text: str) -> None:
+    """Record the current run's last user turn for the A2UI planner.
+
+    Called by the AG-UI adapter at the top of a run. Best-effort: an empty
+    or missing value simply falls back to the generic inner prompt below.
+    """
+    _LAST_USER_MESSAGE.set(text or "")
+
+
 def generate_a2ui_via_llm(*, context: str) -> _A2uiError | _A2uiSuccess:
     """Run the A2UI planner LLM and return either operations or a structured
     error.
@@ -351,11 +394,20 @@ def generate_a2ui_via_llm(*, context: str) -> _A2uiError | _A2uiSuccess:
     google-adk / strands implementations).
     """
     system_prompt = context or "Generate a useful dashboard UI."
+    # Thread the run's last user turn (the pill prompt) as the inner call's
+    # user message so aimock's dynamic-schema fixtures can discriminate the
+    # per-pill surface by ``userMessage`` — matching the sibling backends'
+    # framework-forwarded behavior. Fall back to the generic guidance string
+    # when no user turn is available (e.g. programmatic invocation / tests).
+    user_message = (
+        _LAST_USER_MESSAGE.get()
+        or "Generate a dynamic A2UI dashboard based on the conversation."
+    )
     messages = [
         lm.LLMMessage(role=lm.Role.SYSTEM, content=system_prompt),
         lm.LLMMessage(
             role=lm.Role.USER,
-            content="Generate a dynamic A2UI dashboard based on the conversation.",
+            content=user_message,
         ),
     ]
 
@@ -383,8 +435,8 @@ def generate_a2ui_via_llm(*, context: str) -> _A2uiError | _A2uiSuccess:
         llm = _get_a2ui_llm(_resolve_a2ui_model())
         response = llm.chat(
             messages=messages,
-            functions=[_RENDER_A2UI_FUNCTION_SPEC],
-            function_call={"name": "render_a2ui"},
+            tools=[_RENDER_A2UI_TOOL_SPEC],
+            tool_choice={"type": "function", "function": {"name": "render_a2ui"}},
         )
     except (
         AttributeError,
@@ -772,7 +824,17 @@ class GenerateA2UITool(ToolMessage):
         "Generate dynamic A2UI components based on the conversation. "
         "A secondary LLM designs the UI schema and data."
     )
-    context: str
+    # Optional (default "") so a no-arg tool call — ``arguments: {}`` —
+    # validates. The two-stage A2UI pattern's outer tool takes no meaningful
+    # arguments: the surface design happens entirely inside the secondary
+    # planner LLM (see ``generate_a2ui_via_llm``), which is steered by the
+    # frontend App Context (sales-context.ts) serialized into its system
+    # prompt, not by an outer-supplied ``context`` string. Making this
+    # required forced the outer LLM (and aimock's outer fixture, which emits
+    # ``{}``) to supply a value or fail pydantic ValidationError before the
+    # tool could run — the root cause of the turn-1 surface-missing failure.
+    # Mirrors the sibling google-adk / strands outer tools, which are no-arg.
+    context: str = ""
 
     def handle(self) -> str:
         # Delegate to the provider-agnostic planner. `generate_a2ui_via_llm`

--- a/showcase/integrations/langroid/src/agents/agui_adapter.py
+++ b/showcase/integrations/langroid/src/agents/agui_adapter.py
@@ -50,6 +50,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from agents.agent import (
     build_agent_config_system_prompt,
     extract_agent_config_properties,
+    set_last_user_message,
     ALL_TOOLS,
     FRONTEND_TOOL_NAMES,
     SYSTEM_PROMPT,
@@ -524,6 +525,23 @@ async def handle_run(request: Request) -> StreamingResponse:
     oai_messages = _agui_messages_to_openai(run_input.messages or [], system_prompt)
     model = os.getenv("LANGROID_MODEL", "gpt-4.1")
     oai_tools = _get_openai_tools()
+
+    # Thread the last user turn to the A2UI planner (see
+    # ``set_last_user_message``). The ``generate_a2ui`` backend tool uses it
+    # as the inner ``render_a2ui`` call's user message so aimock's
+    # dynamic-schema fixtures can discriminate the surface per pill prompt —
+    # matching the framework-forwarded behavior of the sibling google-adk /
+    # strands backends. Best-effort: no user turn → the planner falls back to
+    # its generic prompt. Set unconditionally (including "") so a prior run's
+    # value on this worker's context cannot leak into a run with no user turn.
+    _last_user_text = ""
+    for _m in reversed(oai_messages):
+        if _m.get("role") == "user":
+            _content = _m.get("content")
+            if isinstance(_content, str) and _content:
+                _last_user_text = _content
+            break
+    set_last_user_message(_last_user_text)
 
     # Compute the effective thread_id ONCE so every event emitted for this
     # run (RUN_STARTED, RUN_FINISHED, ...) references the same thread.

--- a/showcase/integrations/langroid/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
+++ b/showcase/integrations/langroid/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
@@ -37,20 +37,43 @@ export const myDefinitions = {
 
   Metric: {
     description:
-      "A key/value KPI display with an optional trend indicator. Ideal for dashboards (e.g. 'Revenue • $12.4k • up').",
+      "A key/value KPI tile with an optional trend indicator and trend delta. Ideal for dashboard KPI rows (e.g. 'Revenue • $4.2M • up 12%').",
     props: z.object({
       label: z.string(),
       value: z.string(),
       trend: z.enum(["up", "down", "neutral"]).optional(),
+      trendValue: z.string().optional(),
     }),
   },
 
   InfoRow: {
     description:
-      "A compact two-column 'label: value' row. Good for stacks of facts inside a Card (owner, region, last updated, etc.).",
+      "A compact two-column 'label: value' row. Good for stacks of facts inside a Card (owner, region, ARR, renewal date, etc.).",
     props: z.object({
       label: z.string(),
       value: z.string(),
+    }),
+  },
+
+  DataTable: {
+    description:
+      "A data table with column headers and rows. Ideal for rankings and per-person/per-item breakdowns (rep performance vs quota, deal lists). Each row's keys MUST appear in `columns[].key`; unknown row keys render as blank cells and indicate model/schema drift.",
+    // NOTE on B12 (row-keys ⊆ columns[].key): we'd normally enforce this
+    // with `z.object(...).refine(...)`, but the host catalog package's
+    // `CatalogComponentDefinition` type requires `props: ZodObject<…>`
+    // (it inspects `.shape` at runtime), and `.refine` returns a
+    // `ZodEffects` that breaks both the `satisfies CatalogDefinitions`
+    // type assertion and the runtime `.shape` access. Until the host
+    // type is broadened, we encode the constraint in the description
+    // above so the LLM sees the rule, and leave hard enforcement to
+    // the rendering pipeline (which already shows the empty cell —
+    // detection is the gap, not behaviour).
+    props: z.object({
+      columns: z.array(z.object({ key: z.string(), label: z.string() })),
+      // Cells may be strings or numbers — the renderer stringifies at
+      // render time, but accepting both lets the LLM emit raw numerics
+      // (e.g. attainment 124) instead of being forced to stringify.
+      rows: z.array(z.record(z.union([z.string(), z.number()]))),
     }),
   },
 

--- a/showcase/integrations/langroid/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/langroid/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -212,6 +212,9 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
         >
           <span>{props.value}</span>
           {arrow && <span className="text-base">{arrow}</span>}
+          {props.trendValue && (
+            <span className="text-sm font-medium">{props.trendValue}</span>
+          )}
         </div>
       </div>
     );
@@ -221,7 +224,10 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     // Divider via `border-b last:border-b-0` so the final row doesn't dangle
     // a trailing line, regardless of whether the agent wraps these in a
     // Column or drops them directly into a Card's child slot.
-    <div className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0">
+    <div
+      data-testid="declarative-info-row"
+      className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0"
+    >
       <span className="text-sm text-[var(--muted-foreground)]">
         {props.label}
       </span>
@@ -230,6 +236,59 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
       </span>
     </div>
   ),
+
+  DataTable: ({ props }) => {
+    const cols = Array.isArray(props.columns) ? props.columns : [];
+    const rows = Array.isArray(props.rows) ? props.rows : [];
+    return (
+      <div
+        data-testid="declarative-data-table"
+        className="w-full overflow-x-auto"
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              {cols.map((col) => (
+                <th
+                  key={col.key}
+                  className="border-b-2 border-[var(--border)] px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => {
+              // Stable row key: prefer the first column's value (primary-key-ish),
+              // suffix with index in case values repeat, fall back to a JSON
+              // stringify of the row when columns is empty. Stable keys prevent
+              // React from re-mounting every row when the agent re-emits a
+              // slightly different table.
+              const pk = cols.length > 0 ? row[cols[0].key] : undefined;
+              const rowKey =
+                pk !== undefined ? `${pk}-${i}` : JSON.stringify(row);
+              return (
+                <tr
+                  key={rowKey}
+                  className="border-b border-[var(--border)] last:border-b-0"
+                >
+                  {cols.map((col) => (
+                    <td
+                      key={col.key}
+                      className="px-3 py-2 tabular-nums text-[var(--foreground)]"
+                    >
+                      {String(row[col.key] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  },
 
   PrimaryButton: ({ props, dispatch }) => (
     <Button

--- a/showcase/integrations/langroid/src/app/demos/declarative-gen-ui/chat.tsx
+++ b/showcase/integrations/langroid/src/app/demos/declarative-gen-ui/chat.tsx
@@ -2,9 +2,11 @@
 
 import { CopilotChat } from "@copilotkit/react-core/v2";
 import { useDeclarativeGenUISuggestions } from "./suggestions";
+import { useSalesAnalystContext } from "./sales-context";
 
 export function Chat() {
   useDeclarativeGenUISuggestions();
+  useSalesAnalystContext();
   return (
     <CopilotChat agentId="declarative-gen-ui" className="h-full rounded-2xl" />
   );

--- a/showcase/integrations/langroid/src/app/demos/declarative-gen-ui/sales-context.ts
+++ b/showcase/integrations/langroid/src/app/demos/declarative-gen-ui/sales-context.ts
@@ -1,0 +1,43 @@
+import { useAgentContext } from "@copilotkit/react-core/v2";
+
+// Grounding data + composition rules for the sales-analyst demo persona.
+// Registered as agent context so it reaches both the primary agent (App
+// Context) and the secondary A2UI planner LLM, which serialises frontend
+// context entries into its system instruction.
+//
+// DUPLICATION NOTICE: This file is intentionally byte-duplicated across
+// the langgraph-python, google-adk, strands, and langroid integrations, per
+// the showcase's per-integration parity convention (no cross-integration
+// imports). The copies MUST be kept byte-for-byte identical — verify with
+// `diff` after any edit, and update ALL copies in the same commit.
+//
+// TODO(OSS-136): Extract this dataset + composition rules into a shared
+// showcase module so both integrations import a single source of truth
+// instead of relying on manual byte-sync.
+const SALES_DATASET = `Vantage Threads (fictional B2B apparel company) — Q2 sales data. Ground every visual in these numbers; invent only plausible details consistent with them.
+- Quarterly revenue: $4.2M (up 12% QoQ). New customers: 186 (up 8%). Win rate: 31% (down 2pts). Avg deal size: $22.6k (up 5%).
+- Revenue by region: North America $1.9M, EMEA $1.3M, APAC $720k, LATAM $280k.
+- Monthly revenue: Jan $1.21M, Feb $1.34M, Mar $1.65M, Apr $1.38M, May $1.42M, Jun $1.40M.
+- Reps (vs quota): Dana Whitfield 124%, Marcus Lee 108%, Priya Sharma 97%, Tom Okafor 88%, Elena Vasquez 71%.
+- At-risk: total $615k ARR across 3 accounts — Northwind Retail ($340k renewal, no contact 6 weeks; severity high), Cascadia Outfitters ($180k, champion left; severity medium), Atlas Goods ($95k, stalled legal review; severity medium).
+- Biggest account: Meridian Apparel Group — owner Dana Whitfield, region North America, ARR $612k, renewal Sep 30, last contact 3 days ago, health green, 4 open opportunities worth $210k.
+- Meridian revenue by product line: Outerwear $260k, Footwear $180k, Accessories $112k, Custom $60k.`;
+
+const COMPOSITION_RULES = `Pick A2UI components by the shape of the question — never ask which chart the user wants:
+1. Overall snapshot / "sales dashboard" → a Column (gap 16) whose first child is a Row (gap 16) of 4 Metric tiles (each with trend + trendValue), followed by a Row with a PieChart (revenue by region) next to a BarChart (monthly revenue, all six months Jan-Jun). Do NOT wrap the dashboard in a surrounding Card — the charts carry their own card chrome. Do NOT use StatusBadge, DataTable, or InfoRow here.
+2. Rep / team performance → a Column (gap 16) with a Card containing a DataTable (columns: rep, attainment, pipeline) next to or above a BarChart of quota attainment % per rep — no StatusBadge or InfoRow.
+3. Risk / health checks → a Column (gap 16): first a Row (gap 16) of 3 Metric tiles (ARR at risk $615k trend down, accounts at risk 3, biggest exposure Northwind $340k), then a Row (gap 16) with one compact Card per at-risk account (title = account name, subtitle = ARR at stake) containing a StatusBadge (error for high severity, warning otherwise) above a one-line Text with the reason and the recommended next action — no DataTable or InfoRow.
+4. Single account/entity details → a Row (gap 16) with a Card of InfoRow facts (owner, region, ARR, renewal date, last contact) next to a PieChart of that account's revenue by product line — no DataTable or StatusBadge.
+5. Part-of-whole follow-ups → PieChart; trends or comparisons over time/categories → BarChart.
+Compose generously — a dashboard should feel like a real analytics product, not a single widget.`;
+
+export function useSalesAnalystContext() {
+  useAgentContext({
+    description: "Sales dataset for Vantage Threads (the demo company)",
+    value: SALES_DATASET,
+  });
+  useAgentContext({
+    description: "Dashboard composition rules for A2UI surfaces",
+    value: COMPOSITION_RULES,
+  });
+}

--- a/showcase/integrations/langroid/src/app/demos/declarative-gen-ui/suggestions.ts
+++ b/showcase/integrations/langroid/src/app/demos/declarative-gen-ui/suggestions.ts
@@ -1,25 +1,29 @@
 import { useConfigureSuggestions } from "@copilotkit/react-core/v2";
 
+// Pill prompts are natural business questions — chart-type steering lives in
+// the agent context (./sales-context.ts). Each pill maps to a distinct
+// catalog component so the D5/D6 probe
+// (showcase/harness/src/probes/scripts/d5-gen-ui-declarative.ts) can assert a
+// newly-mounted testid per pill. Keep prompts in sync with that probe and with
+// the sibling google-adk / strands integrations.
 export function useDeclarativeGenUISuggestions() {
   useConfigureSuggestions({
     suggestions: [
       {
-        title: "Show a KPI dashboard",
-        message:
-          "Show me a quick KPI dashboard with 3-4 metrics (revenue, signups, churn).",
+        title: "Show my sales dashboard",
+        message: "Show me my sales dashboard for this quarter.",
       },
       {
-        title: "Pie chart — sales by region",
-        message: "Show a pie chart of sales by region.",
+        title: "Team performance",
+        message: "How are our sales reps performing against quota?",
       },
       {
-        title: "Bar chart — quarterly revenue",
-        message: "Render a bar chart of quarterly revenue.",
+        title: "Anything at risk?",
+        message: "Are any accounts or pipeline deals at risk this quarter?",
       },
       {
-        title: "Status report",
-        message:
-          "Give me a status report on system health — API, database, and background workers.",
+        title: "Top account details",
+        message: "Pull up the details on our biggest account.",
       },
     ],
     available: "always",

--- a/showcase/integrations/langroid/tests/python/test_generate_a2ui.py
+++ b/showcase/integrations/langroid/tests/python/test_generate_a2ui.py
@@ -50,6 +50,7 @@ from agents.agent import (
     _A2uiError,
     _A2uiErrorKind,
     _RENDER_A2UI_FUNCTION_SPEC,
+    _RENDER_A2UI_TOOL_SPEC,
     _a2ui_error,
     _get_a2ui_llm,
     _resolve_a2ui_model,
@@ -318,11 +319,18 @@ def test_generate_a2ui_happy_path_returns_operations():
     with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
         result = generate_a2ui_via_llm(context="test context")
 
-    # LLM forced-function-call wiring
+    # LLM forced-tool-call wiring. The planner uses the MODERN
+    # tools=/tool_choice= API (not the legacy functions=/function_call=) so
+    # aimock's toolName matcher — which inspects the request's tools[] array
+    # — can discriminate the inner render_a2ui call from the outer
+    # generate_a2ui call. See ``_RENDER_A2UI_TOOL_SPEC`` in agents/agent.py.
     fake_llm.chat.assert_called_once()
     call_kwargs = fake_llm.chat.call_args.kwargs
-    assert call_kwargs["functions"] == [_RENDER_A2UI_FUNCTION_SPEC]
-    assert call_kwargs["function_call"] == {"name": "render_a2ui"}
+    assert call_kwargs["tools"] == [_RENDER_A2UI_TOOL_SPEC]
+    assert call_kwargs["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "render_a2ui"},
+    }
 
     # Message wiring: system prompt from caller's ``context``, plus a user
     # message instructing the planner to emit a dashboard. Both must be


### PR DESCRIPTION
## What

Brings the **langroid** `declarative-gen-ui` D6 cell to sibling parity with the two-stage dynamic-schema A2UI north-star (google-adk / strands). The cell was red at turn 1 with `reason=surface-missing`: the demo was still on the pre-D6 (D5-era) shape, and four independent defects each blocked the A2UI surface from painting.

Second-wave fan-out of the proven pattern (pilots #6051/#6052/#6053, first wave #6054 agno / #6055 claude-sdk-typescript).

## Root cause (four defects, each verified against a live isolated stack)

1. **Stale suggestions + fixtures.** `suggestions.ts` still offered the old D5 pills; the aimock fixture only mocked those. The D6 driver sends the four current business-question prompts. Re-authored both to the four current prompts mirroring the google-adk north-star (outer `generate_a2ui` no-arg → inner forced `render_a2ui` → outer narration).
2. **Required `context` on the outer tool.** `GenerateA2UITool.context` was a required pydantic field, so the mocked outer `arguments: {}` raised `ValidationError` before the tool ran → no inner call, no surface. Made optional (default `""`) to match the no-arg sibling tools.
3. **Legacy functions API hid the inner tool from aimock's matcher.** The inner planner used langroid's `functions=`/`function_call=` (legacy OpenAI) path; aimock's `toolName` matcher only inspects the modern `tools[]` array, so the inner `render_a2ui` fixture never matched and the call fell through to the outer `generate_a2ui` fixture (empty surface, wrong catalogId). Switched the inner call to the modern `tools=`/`tool_choice=` API. The response extractor already reads the modern `oai_tool_calls` path first, so nothing downstream changes.
4. **Inner call could not be discriminated per pill.** langroid has no framework middleware to forward the run's conversation into the inner call (unlike `ag_ui_adk` / `ag_ui_strands`), so its inner user message was a fixed generic string across all four pills. Added an explicit last-user-turn thread (a `ContextVar` set by the adapter, consumed by the planner) so the pill prompt rides as the inner `userMessage` — the discriminator the sibling fixtures rely on.

**Renderer/catalog parity:** added the missing `declarative-info-row` testid on InfoRow (turn 4) and a full `DataTable` definition + renderer (`declarative-data-table`, turn 2), plus `trendValue` on Metric. Added `sales-context.ts` (byte-identical dataset + composition rules to the strands/google-adk siblings) and wired it via `chat.tsx`.

Backend family mirrored: **google-adk / strands** — outer `generate_a2ui` (no args) + inner forced `render_a2ui`, `declarative-gen-ui-catalog`.

## Red-green proof (isolated control-plane, `--isolate --rebuild`, slot 16)

**RED (pre-fix, 3 runs):**
```
✗ d6:langroid/gen-ui-declarative red — state=red
  waitForTurnComplete: turn 1 did not complete within 90000ms (reason=surface-missing)
```
First diagnosis (direct backend SSE): outer `generate_a2ui` → `{"error": "Tool generate_a2ui failed: ValidationError"}`. After fixing that: outer succeeded but emitted `catalogId: copilotkit://app-dashboard-catalog` with `components: []` (inner never matched — legacy functions API). After the tools-API + threading fix:

**GREEN (post-fix, 2 runs):**
```
✓ d6:langroid/gen-ui-declarative green
  1 passed
```
aimock journal confirms all four pills' outer `generate_a2ui` + inner `render_a2ui` (tool_choice forced) calls return **200** and emit `declarative-gen-ui-catalog` surfaces.

Per-turn backend SSE verified:
- turn 1 (sales-dashboard): 4 × Metric + PieChart + BarChart
- turn 2 (team-performance): DataTable + BarChart
- turn 4 (top-account): 7 × InfoRow + PieChart

## Visual

`langroid-turn1-sales-dashboard.png` — live Playwright render (X-AIMock-Context: langroid): 4 metric tiles + revenue-by-region pie + monthly-revenue bar. Turns 2–4 surface renders are asserted and pass in the authoritative D6 run (conjunctive per-turn testid checks) and confirmed via backend SSE above.

## Notes

- Draft: not for merge/promote (user-gated).
- A concurrent `ms-agent-harness-dotnet` fan-out agent was hitting the shared local aimock during manual browser capture (interleaved 404s in the journal); it does not affect the isolated D6 result, which is the binding proof.

---

**CI-driven follow-ups (in this same commit):**
- Updated `integrations/langroid/tests/python/test_generate_a2ui.py` to assert the modern `tools=`/`tool_choice=` kwargs (was pinning the legacy `functions=`/`function_call=` API this fix intentionally replaced). 78 passed / 1 skipped locally.
- Scoped the four inner `render_a2ui` fixtures to `context: langroid` (langroid forwards `x-aimock-context` to the inner planner call, unlike `ag_ui_adk`/`ag_ui_strands`) so they don't collide in the shared scope with the sibling integrations' identical inner keys — keeps the `aimock-fixtures` exact-duplicate ceiling at 297 (no bump). Full `aimock-fixtures.test.ts` suite: 837 passed. D6 re-run after this change: still green 4/4.
