### PR TITLE
fix(react-native): render user messages as markdown

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -83,6 +83,8 @@
     "@copilotkit/core": "workspace:*",
     "@copilotkit/react-core": "workspace:*",
     "@copilotkit/shared": "workspace:*",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "text-encoding": "^0.7.0",
     "web-streams-polyfill": "^4.2.0"
   },

--- a/packages/react-native/src/components/Markdown.tsx
+++ b/packages/react-native/src/components/Markdown.tsx
@@ -1,5 +1,10 @@
+import type { CSSProperties } from "react";
 import React, { useMemo } from "react";
+import type { Components } from "react-markdown";
+import ReactMarkdown from "react-markdown";
+import { Platform } from "react-native";
 import { StreamdownText } from "react-native-streamdown";
+import remarkGfm from "remark-gfm";
 
 /**
  * Style object accepted by `react-native-enriched-markdown` (and therefore
@@ -93,6 +98,24 @@ export const defaultMarkdownStyles: MarkdownStyle = {
   },
 };
 
+function toWebStyle(
+  style: Record<string, unknown> | undefined,
+): CSSProperties | undefined {
+  if (!style) return undefined;
+  const {
+    underline,
+    bulletColor: _bulletColor,
+    markerColor: _markerColor,
+    gapWidth,
+    ...cssStyle
+  } = style;
+  return {
+    ...cssStyle,
+    ...(underline ? { textDecorationLine: "underline" } : {}),
+    ...(gapWidth !== undefined ? { paddingLeft: gapWidth } : {}),
+  } as CSSProperties;
+}
+
 /**
  * Renders markdown content using `react-native-streamdown` with
  * pre-configured styles suited for CopilotKit chat bubbles.
@@ -113,6 +136,73 @@ export function CopilotMarkdown({
     if (!style) return defaultMarkdownStyles;
     return { ...defaultMarkdownStyles, ...style };
   }, [style]);
+
+  const webComponents = useMemo<Components>(
+    () => ({
+      p: ({ node: _node, ...props }) => (
+        <p {...props} style={toWebStyle(mergedStyles.paragraph)} />
+      ),
+      h1: ({ node: _node, ...props }) => (
+        <h1 {...props} style={toWebStyle(mergedStyles.h1)} />
+      ),
+      h2: ({ node: _node, ...props }) => (
+        <h2 {...props} style={toWebStyle(mergedStyles.h2)} />
+      ),
+      h3: ({ node: _node, ...props }) => (
+        <h3 {...props} style={toWebStyle(mergedStyles.h3)} />
+      ),
+      h4: ({ node: _node, ...props }) => (
+        <h4 {...props} style={toWebStyle(mergedStyles.h4)} />
+      ),
+      h5: ({ node: _node, ...props }) => (
+        <h5 {...props} style={toWebStyle(mergedStyles.h5)} />
+      ),
+      h6: ({ node: _node, ...props }) => (
+        <h6 {...props} style={toWebStyle(mergedStyles.h6)} />
+      ),
+      a: ({ node: _node, ...props }) => (
+        <a
+          {...props}
+          style={toWebStyle(mergedStyles.link)}
+          target="_blank"
+          rel="noopener noreferrer"
+        />
+      ),
+      blockquote: ({ node: _node, ...props }) => (
+        <blockquote {...props} style={toWebStyle(mergedStyles.blockquote)} />
+      ),
+      ul: ({ node: _node, ...props }) => (
+        <ul {...props} style={toWebStyle(mergedStyles.list)} />
+      ),
+      ol: ({ node: _node, ...props }) => (
+        <ol {...props} style={toWebStyle(mergedStyles.list)} />
+      ),
+      li: ({ node: _node, ...props }) => (
+        <li {...props} style={toWebStyle(mergedStyles.list)} />
+      ),
+      strong: ({ node: _node, ...props }) => (
+        <strong {...props} style={toWebStyle(mergedStyles.strong)} />
+      ),
+      em: ({ node: _node, ...props }) => (
+        <em {...props} style={toWebStyle(mergedStyles.em)} />
+      ),
+      code: ({ node: _node, ...props }) => (
+        <code {...props} style={toWebStyle(mergedStyles.code)} />
+      ),
+      pre: ({ node: _node, ...props }) => (
+        <pre {...props} style={toWebStyle(mergedStyles.codeBlock)} />
+      ),
+    }),
+    [mergedStyles],
+  );
+
+  if (Platform.OS === "web") {
+    return (
+      <ReactMarkdown components={webComponents} remarkPlugins={[remarkGfm]}>
+        {content}
+      </ReactMarkdown>
+    );
+  }
 
   return (
     <StreamdownText

--- a/packages/react-native/src/components/Markdown.tsx
+++ b/packages/react-native/src/components/Markdown.tsx
@@ -1,10 +1,8 @@
 import type { CSSProperties } from "react";
-import React, { useMemo } from "react";
+import React, { lazy, Suspense, useMemo } from "react";
 import type { Components } from "react-markdown";
-import ReactMarkdown from "react-markdown";
 import { Platform } from "react-native";
 import { StreamdownText } from "react-native-streamdown";
-import remarkGfm from "remark-gfm";
 
 /**
  * Style object accepted by `react-native-enriched-markdown` (and therefore
@@ -98,6 +96,24 @@ export const defaultMarkdownStyles: MarkdownStyle = {
   },
 };
 
+interface WebMarkdownProps {
+  components: Components;
+  content: string;
+}
+
+const WebMarkdown = lazy(async () => {
+  const [{ default: ReactMarkdown }, { default: remarkGfm }] =
+    await Promise.all([import("react-markdown"), import("remark-gfm")]);
+
+  return {
+    default: ({ components, content }: WebMarkdownProps) => (
+      <ReactMarkdown components={components} remarkPlugins={[remarkGfm]}>
+        {content}
+      </ReactMarkdown>
+    ),
+  };
+});
+
 function toWebStyle(
   style: Record<string, unknown> | undefined,
 ): CSSProperties | undefined {
@@ -107,10 +123,12 @@ function toWebStyle(
     bulletColor: _bulletColor,
     markerColor: _markerColor,
     gapWidth,
+    borderWidth,
     ...cssStyle
   } = style;
   return {
     ...cssStyle,
+    ...(borderWidth !== undefined ? { borderStyle: "solid", borderWidth } : {}),
     ...(underline ? { textDecorationLine: "underline" } : {}),
     ...(gapWidth !== undefined ? { paddingLeft: gapWidth } : {}),
   } as CSSProperties;
@@ -140,7 +158,14 @@ export function CopilotMarkdown({
   const webComponents = useMemo<Components>(
     () => ({
       p: ({ node: _node, ...props }) => (
-        <p {...props} style={toWebStyle(mergedStyles.paragraph)} />
+        <p
+          {...props}
+          style={{
+            ...toWebStyle(mergedStyles.paragraph),
+            overflowWrap: "anywhere",
+            whiteSpace: "pre-wrap",
+          }}
+        />
       ),
       h1: ({ node: _node, ...props }) => (
         <h1 {...props} style={toWebStyle(mergedStyles.h1)} />
@@ -190,7 +215,57 @@ export function CopilotMarkdown({
         <code {...props} style={toWebStyle(mergedStyles.code)} />
       ),
       pre: ({ node: _node, ...props }) => (
-        <pre {...props} style={toWebStyle(mergedStyles.codeBlock)} />
+        <pre
+          {...props}
+          style={{
+            ...toWebStyle(mergedStyles.codeBlock),
+            boxSizing: "border-box",
+            maxWidth: "100%",
+            overflowX: "auto",
+          }}
+        />
+      ),
+      table: ({ node: _node, ...props }) => (
+        <div style={{ maxWidth: "100%", overflowX: "auto" }}>
+          <table
+            {...props}
+            style={{
+              ...toWebStyle(mergedStyles.paragraph),
+              borderCollapse: "collapse",
+              width: "100%",
+            }}
+          />
+        </div>
+      ),
+      th: ({ node: _node, ...props }) => (
+        <th
+          {...props}
+          style={{
+            border: "1px solid currentColor",
+            padding: "4px 8px",
+            textAlign: "left",
+          }}
+        />
+      ),
+      td: ({ node: _node, ...props }) => (
+        <td
+          {...props}
+          style={{
+            border: "1px solid currentColor",
+            padding: "4px 8px",
+          }}
+        />
+      ),
+      img: ({ node: _node, ...props }) => (
+        // oxlint-disable-next-line next/no-img-element -- React Native Web needs a DOM image renderer.
+        <img
+          {...props}
+          style={{
+            display: "block",
+            height: "auto",
+            maxWidth: "100%",
+          }}
+        />
       ),
     }),
     [mergedStyles],
@@ -198,9 +273,21 @@ export function CopilotMarkdown({
 
   if (Platform.OS === "web") {
     return (
-      <ReactMarkdown components={webComponents} remarkPlugins={[remarkGfm]}>
-        {content}
-      </ReactMarkdown>
+      <Suspense
+        fallback={
+          <span
+            style={{
+              ...toWebStyle(mergedStyles.paragraph),
+              overflowWrap: "anywhere",
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            {content}
+          </span>
+        }
+      >
+        <WebMarkdown components={webComponents} content={content} />
+      </Suspense>
     );
   }
 

--- a/packages/react-native/src/components/Markdown.tsx
+++ b/packages/react-native/src/components/Markdown.tsx
@@ -124,10 +124,18 @@ function toWebStyle(
     markerColor: _markerColor,
     gapWidth,
     borderWidth,
+    lineHeight,
     ...cssStyle
   } = style;
+  const webLineHeight =
+    typeof lineHeight === "number"
+      ? Number.isFinite(lineHeight)
+        ? `${lineHeight}px`
+        : undefined
+      : lineHeight;
   return {
     ...cssStyle,
+    ...(webLineHeight !== undefined ? { lineHeight: webLineHeight } : {}),
     ...(borderWidth !== undefined ? { borderStyle: "solid", borderWidth } : {}),
     ...(underline ? { textDecorationLine: "underline" } : {}),
     ...(gapWidth !== undefined ? { paddingLeft: gapWidth } : {}),

--- a/packages/react-native/src/components/__tests__/Markdown.test.tsx
+++ b/packages/react-native/src/components/__tests__/Markdown.test.tsx
@@ -10,6 +10,9 @@ vi.mock("react-native", () => ({
     create: <T extends Record<string, any>>(styles: T): T => styles,
     flatten: (style: any) => style,
   },
+  Platform: {
+    OS: "ios",
+  },
   View: "View",
   Text: "Text",
 }));
@@ -29,6 +32,7 @@ vi.mock("react-native-streamdown", () => ({
 }));
 
 // Import after mocks
+import { Platform } from "react-native";
 import { CopilotMarkdown, defaultMarkdownStyles } from "../Markdown";
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -36,6 +40,7 @@ import { CopilotMarkdown, defaultMarkdownStyles } from "../Markdown";
 describe("CopilotMarkdown", () => {
   beforeEach(() => {
     lastStreamdownProps = null;
+    (Platform as { OS: string }).OS = "ios";
   });
 
   it("renders without crashing", () => {
@@ -86,6 +91,21 @@ describe("CopilotMarkdown", () => {
   it("allows disabling streamingAnimation", () => {
     render(<CopilotMarkdown content="test" streamingAnimation={false} />);
     expect(lastStreamdownProps.streamingAnimation).toBe(false);
+  });
+
+  it("uses a DOM markdown renderer on web", () => {
+    (Platform as { OS: string }).OS = "web";
+
+    const { container } = render(
+      <CopilotMarkdown content="**Bold** and [link](https://example.com)" />,
+    );
+
+    expect(container.querySelector("strong")?.textContent).toBe("Bold");
+    expect(container.querySelector("a")?.textContent).toBe("link");
+    expect(container.querySelector("a")?.getAttribute("href")).toBe(
+      "https://example.com",
+    );
+    expect(lastStreamdownProps).toBeNull();
   });
 });
 

--- a/packages/react-native/src/components/__tests__/Markdown.test.tsx
+++ b/packages/react-native/src/components/__tests__/Markdown.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
@@ -93,19 +93,56 @@ describe("CopilotMarkdown", () => {
     expect(lastStreamdownProps.streamingAnimation).toBe(false);
   });
 
-  it("uses a DOM markdown renderer on web", () => {
+  it("uses a DOM markdown renderer on web", async () => {
     (Platform as { OS: string }).OS = "web";
 
     const { container } = render(
       <CopilotMarkdown content="**Bold** and [link](https://example.com)" />,
     );
 
-    expect(container.querySelector("strong")?.textContent).toBe("Bold");
+    await waitFor(() => {
+      expect(container.querySelector("strong")?.textContent).toBe("Bold");
+    });
     expect(container.querySelector("a")?.textContent).toBe("link");
     expect(container.querySelector("a")?.getAttribute("href")).toBe(
       "https://example.com",
     );
     expect(lastStreamdownProps).toBeNull();
+  });
+
+  it("preserves multiline text and constrains rich content on web", async () => {
+    (Platform as { OS: string }).OS = "web";
+
+    const { container } = render(
+      <CopilotMarkdown
+        content={[
+          "first line",
+          "second line",
+          "",
+          "| Key | Value |",
+          "| --- | --- |",
+          "| A | B |",
+          "",
+          "```text",
+          "a-very-long-line",
+          "```",
+          "",
+          "![preview](https://example.com/preview.png)",
+        ].join("\n")}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("table")).not.toBeNull();
+    });
+    expect(container.querySelector("p")?.style.whiteSpace).toBe("pre-wrap");
+    expect(
+      container.querySelector("table")?.parentElement?.style.overflowX,
+    ).toBe("auto");
+    expect(container.querySelector("pre")?.style.maxWidth).toBe("100%");
+    expect(container.querySelector("pre")?.style.overflowX).toBe("auto");
+    expect(container.querySelector("img")?.style.maxWidth).toBe("100%");
+    expect(container.querySelector("img")?.getAttribute("alt")).toBe("preview");
   });
 });
 

--- a/packages/react-native/src/components/__tests__/Markdown.test.tsx
+++ b/packages/react-native/src/components/__tests__/Markdown.test.tsx
@@ -100,13 +100,17 @@ describe("CopilotMarkdown", () => {
       <CopilotMarkdown content="**Bold** and [link](https://example.com)" />,
     );
 
-    await waitFor(() => {
-      expect(container.querySelector("strong")?.textContent).toBe("Bold");
-    });
+    await waitFor(
+      () => {
+        expect(container.querySelector("strong")?.textContent).toBe("Bold");
+      },
+      { timeout: 5_000 },
+    );
     expect(container.querySelector("a")?.textContent).toBe("link");
     expect(container.querySelector("a")?.getAttribute("href")).toBe(
       "https://example.com",
     );
+    expect(container.querySelector("p")?.style.lineHeight).toBe("24px");
     expect(lastStreamdownProps).toBeNull();
   });
 
@@ -132,9 +136,12 @@ describe("CopilotMarkdown", () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(container.querySelector("table")).not.toBeNull();
-    });
+    await waitFor(
+      () => {
+        expect(container.querySelector("table")).not.toBeNull();
+      },
+      { timeout: 5_000 },
+    );
     expect(container.querySelector("p")?.style.whiteSpace).toBe("pre-wrap");
     expect(
       container.querySelector("table")?.parentElement?.style.overflowX,

--- a/packages/react-native/src/components/messages/UserMessage.tsx
+++ b/packages/react-native/src/components/messages/UserMessage.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { View, Text, StyleSheet, type ViewStyle } from "react-native";
+import { View, Text, StyleSheet } from "react-native";
+import type { ViewStyle } from "react-native";
+import { CopilotMarkdown } from "../Markdown";
+import type { MarkdownStyle } from "../Markdown";
 import { formatTimestamp } from "./utils";
 
 // ─── Colors ──────────────────────────────────────────────────────────────────
@@ -7,11 +10,39 @@ const USER_BUBBLE_BG = "#0066CC";
 const USER_TEXT_COLOR = "#FFFFFF";
 const TIMESTAMP_COLOR = "#999999";
 
+const userMarkdownStyles: MarkdownStyle = {
+  paragraph: {
+    color: USER_TEXT_COLOR,
+    fontSize: 16,
+    lineHeight: 22,
+    marginTop: 0,
+    marginBottom: 0,
+  },
+  h1: {
+    color: USER_TEXT_COLOR,
+  },
+  h2: {
+    color: USER_TEXT_COLOR,
+  },
+  h3: {
+    color: USER_TEXT_COLOR,
+  },
+  link: {
+    color: USER_TEXT_COLOR,
+    underline: true,
+  },
+  list: {
+    color: USER_TEXT_COLOR,
+    marginTop: 4,
+    marginBottom: 4,
+  },
+};
+
 /**
  * Props for the UserMessage component.
  */
 export interface UserMessageProps {
-  /** Plain text content to display */
+  /** Markdown content to display */
   content: string;
   /** Optional timestamp displayed below the bubble */
   timestamp?: Date;
@@ -22,14 +53,18 @@ export interface UserMessageProps {
 /**
  * Right-aligned chat bubble for user messages.
  *
- * Renders plain text (no markdown) with a primary-color background
- * and white text. Optionally displays a subtle timestamp below.
+ * Renders markdown with a primary-color background and white text.
+ * Optionally displays a subtle timestamp below.
  */
 export function UserMessage({ content, timestamp, style }: UserMessageProps) {
   return (
     <View style={[styles.container, style]}>
       <View style={styles.bubble}>
-        <Text style={styles.text}>{content}</Text>
+        <CopilotMarkdown
+          content={content}
+          style={userMarkdownStyles}
+          streamingAnimation={false}
+        />
       </View>
       {timestamp && (
         <Text style={styles.timestamp}>{formatTimestamp(timestamp)}</Text>
@@ -53,11 +88,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 8,
     maxWidth: "80%",
-  },
-  text: {
-    color: USER_TEXT_COLOR,
-    fontSize: 16,
-    lineHeight: 22,
   },
   timestamp: {
     color: TIMESTAMP_COLOR,

--- a/packages/react-native/src/components/messages/UserMessage.tsx
+++ b/packages/react-native/src/components/messages/UserMessage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { View, Text, StyleSheet } from "react-native";
 import type { ViewStyle } from "react-native";
-import { CopilotMarkdown } from "../Markdown";
+import { CopilotMarkdown, defaultMarkdownStyles } from "../Markdown";
 import type { MarkdownStyle } from "../Markdown";
 import { formatTimestamp } from "./utils";
 
@@ -19,12 +19,24 @@ const userMarkdownStyles: MarkdownStyle = {
     marginBottom: 0,
   },
   h1: {
+    ...defaultMarkdownStyles.h1,
     color: USER_TEXT_COLOR,
   },
   h2: {
+    ...defaultMarkdownStyles.h2,
     color: USER_TEXT_COLOR,
   },
   h3: {
+    ...defaultMarkdownStyles.h3,
+    color: USER_TEXT_COLOR,
+  },
+  h4: {
+    color: USER_TEXT_COLOR,
+  },
+  h5: {
+    color: USER_TEXT_COLOR,
+  },
+  h6: {
     color: USER_TEXT_COLOR,
   },
   link: {
@@ -33,8 +45,15 @@ const userMarkdownStyles: MarkdownStyle = {
   },
   list: {
     color: USER_TEXT_COLOR,
+    bulletColor: USER_TEXT_COLOR,
+    markerColor: USER_TEXT_COLOR,
     marginTop: 4,
     marginBottom: 4,
+  },
+  code: {
+    ...defaultMarkdownStyles.code,
+    color: USER_TEXT_COLOR,
+    backgroundColor: "#004C99",
   },
 };
 

--- a/packages/react-native/src/components/messages/UserMessage.tsx
+++ b/packages/react-native/src/components/messages/UserMessage.tsx
@@ -55,6 +55,17 @@ const userMarkdownStyles: MarkdownStyle = {
     color: USER_TEXT_COLOR,
     backgroundColor: "#004C99",
   },
+  codeBlock: {
+    ...defaultMarkdownStyles.codeBlock,
+    color: USER_TEXT_COLOR,
+    backgroundColor: "#004C99",
+  },
+  blockquote: {
+    ...defaultMarkdownStyles.blockquote,
+    color: USER_TEXT_COLOR,
+    backgroundColor: "#004C99",
+    borderColor: "#80BFFF",
+  },
 };
 
 /**

--- a/packages/react-native/src/components/messages/__tests__/UserMessage.web.test.tsx
+++ b/packages/react-native/src/components/messages/__tests__/UserMessage.web.test.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("react-native", () => {
+  const ReactRuntime = require("react");
+  return {
+    Platform: { OS: "web" },
+    StyleSheet: {
+      create: <T extends Record<string, unknown>>(styles: T): T => styles,
+    },
+    View: ({ children, style }: any) =>
+      ReactRuntime.createElement(
+        "div",
+        {
+          style: Object.assign(
+            {},
+            ...(Array.isArray(style) ? style : [style]).filter(Boolean),
+          ),
+        },
+        children,
+      ),
+    Text: ({ children, style }: any) =>
+      ReactRuntime.createElement(
+        "span",
+        {
+          style: Object.assign(
+            {},
+            ...(Array.isArray(style) ? style : [style]).filter(Boolean),
+          ),
+        },
+        children,
+      ),
+  };
+});
+
+import { UserMessage } from "../UserMessage";
+
+describe("UserMessage on React Native Web", () => {
+  it("renders markdown through the real web renderer", () => {
+    const { container } = render(
+      <UserMessage content="Hello **web** — [docs](https://example.com)" />,
+    );
+
+    expect(container.querySelector("strong")?.textContent).toBe("web");
+    expect(container.querySelector("a")?.textContent).toBe("docs");
+    expect(container.querySelector("a")?.getAttribute("href")).toBe(
+      "https://example.com",
+    );
+  });
+});

--- a/packages/react-native/src/components/messages/__tests__/UserMessage.web.test.tsx
+++ b/packages/react-native/src/components/messages/__tests__/UserMessage.web.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("react-native", () => {
@@ -37,15 +37,33 @@ vi.mock("react-native", () => {
 import { UserMessage } from "../UserMessage";
 
 describe("UserMessage on React Native Web", () => {
-  it("renders markdown through the real web renderer", () => {
+  it("renders markdown through the real web renderer", async () => {
     const { container } = render(
-      <UserMessage content="Hello **web** — [docs](https://example.com)" />,
+      <UserMessage
+        content={[
+          "Hello **web** — [docs](https://example.com)",
+          "",
+          "> quoted text",
+          "",
+          "| Key | Value |",
+          "| --- | --- |",
+          "| A | B |",
+        ].join("\n")}
+      />,
     );
 
-    expect(container.querySelector("strong")?.textContent).toBe("web");
+    await waitFor(() => {
+      expect(container.querySelector("strong")?.textContent).toBe("web");
+    });
     expect(container.querySelector("a")?.textContent).toBe("docs");
     expect(container.querySelector("a")?.getAttribute("href")).toBe(
       "https://example.com",
+    );
+    expect(container.querySelector("blockquote")?.style.backgroundColor).toBe(
+      "rgb(0, 76, 153)",
+    );
+    expect(container.querySelector("table")?.style.color).toBe(
+      "rgb(255, 255, 255)",
     );
   });
 });

--- a/packages/react-native/src/components/messages/__tests__/UserMessage.web.test.tsx
+++ b/packages/react-native/src/components/messages/__tests__/UserMessage.web.test.tsx
@@ -52,9 +52,12 @@ describe("UserMessage on React Native Web", () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(container.querySelector("strong")?.textContent).toBe("web");
-    });
+    await waitFor(
+      () => {
+        expect(container.querySelector("strong")?.textContent).toBe("web");
+      },
+      { timeout: 5_000 },
+    );
     expect(container.querySelector("a")?.textContent).toBe("docs");
     expect(container.querySelector("a")?.getAttribute("href")).toBe(
       "https://example.com",
@@ -65,5 +68,6 @@ describe("UserMessage on React Native Web", () => {
     expect(container.querySelector("table")?.style.color).toBe(
       "rgb(255, 255, 255)",
     );
+    expect(container.querySelector("p")?.style.lineHeight).toBe("22px");
   });
 });

--- a/packages/react-native/src/components/messages/__tests__/messages-edge-cases.test.tsx
+++ b/packages/react-native/src/components/messages/__tests__/messages-edge-cases.test.tsx
@@ -82,6 +82,12 @@ vi.mock("react-native", () => {
 
 // ─── Mock Markdown ────────────────────────────────────────────────────────────
 vi.mock("../../Markdown", () => ({
+  defaultMarkdownStyles: {
+    h1: {},
+    h2: {},
+    h3: {},
+    code: {},
+  },
   CopilotMarkdown: ({ content }: { content: string }) => {
     const React = require("react");
     return React.createElement(

--- a/packages/react-native/src/components/messages/__tests__/messages.test.tsx
+++ b/packages/react-native/src/components/messages/__tests__/messages.test.tsx
@@ -108,6 +108,34 @@ vi.mock("react-native", () => {
 const markdownProps = vi.hoisted(() => ({ current: null as any }));
 
 vi.mock("../../Markdown", () => ({
+  defaultMarkdownStyles: {
+    h1: {
+      fontSize: 24,
+      fontWeight: "bold",
+      marginTop: 12,
+      marginBottom: 8,
+      color: "#111111",
+    },
+    h2: {
+      fontSize: 20,
+      fontWeight: "bold",
+      marginTop: 10,
+      marginBottom: 6,
+      color: "#111111",
+    },
+    h3: {
+      fontSize: 18,
+      fontWeight: "600",
+      marginTop: 8,
+      marginBottom: 4,
+      color: "#222222",
+    },
+    code: {
+      backgroundColor: "#f0f0f0",
+      fontFamily: "monospace",
+      fontSize: 14,
+    },
+  },
   CopilotMarkdown: (props: {
     content: string;
     style?: Record<string, Record<string, unknown>>;
@@ -189,14 +217,43 @@ describe("UserMessage", () => {
           marginTop: 0,
           marginBottom: 0,
         },
-        h1: { color: "#FFFFFF" },
-        h2: { color: "#FFFFFF" },
-        h3: { color: "#FFFFFF" },
+        h1: {
+          fontSize: 24,
+          fontWeight: "bold",
+          marginTop: 12,
+          marginBottom: 8,
+          color: "#FFFFFF",
+        },
+        h2: {
+          fontSize: 20,
+          fontWeight: "bold",
+          marginTop: 10,
+          marginBottom: 6,
+          color: "#FFFFFF",
+        },
+        h3: {
+          fontSize: 18,
+          fontWeight: "600",
+          marginTop: 8,
+          marginBottom: 4,
+          color: "#FFFFFF",
+        },
+        h4: { color: "#FFFFFF" },
+        h5: { color: "#FFFFFF" },
+        h6: { color: "#FFFFFF" },
         link: { color: "#FFFFFF", underline: true },
         list: {
           color: "#FFFFFF",
+          bulletColor: "#FFFFFF",
+          markerColor: "#FFFFFF",
           marginTop: 4,
           marginBottom: 4,
+        },
+        code: {
+          backgroundColor: "#004C99",
+          color: "#FFFFFF",
+          fontFamily: "monospace",
+          fontSize: 14,
         },
       },
     });

--- a/packages/react-native/src/components/messages/__tests__/messages.test.tsx
+++ b/packages/react-native/src/components/messages/__tests__/messages.test.tsx
@@ -135,6 +135,19 @@ vi.mock("../../Markdown", () => ({
       fontFamily: "monospace",
       fontSize: 14,
     },
+    codeBlock: {
+      backgroundColor: "#f0f0f0",
+      borderRadius: 8,
+      padding: 12,
+      fontFamily: "monospace",
+      fontSize: 14,
+    },
+    blockquote: {
+      backgroundColor: "#f5f5f5",
+      borderWidth: 4,
+      borderColor: "#cccccc",
+      gapWidth: 12,
+    },
   },
   CopilotMarkdown: (props: {
     content: string;
@@ -254,6 +267,21 @@ describe("UserMessage", () => {
           color: "#FFFFFF",
           fontFamily: "monospace",
           fontSize: 14,
+        },
+        codeBlock: {
+          backgroundColor: "#004C99",
+          borderRadius: 8,
+          color: "#FFFFFF",
+          fontFamily: "monospace",
+          fontSize: 14,
+          padding: 12,
+        },
+        blockquote: {
+          backgroundColor: "#004C99",
+          borderColor: "#80BFFF",
+          borderWidth: 4,
+          color: "#FFFFFF",
+          gapWidth: 12,
         },
       },
     });

--- a/packages/react-native/src/components/messages/__tests__/messages.test.tsx
+++ b/packages/react-native/src/components/messages/__tests__/messages.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 
 // ─── Mock react-native ───────────────────────────────────────────────────────
 // jsdom doesn't have react-native, so we provide lightweight stand-ins.
@@ -105,13 +105,20 @@ vi.mock("react-native", () => {
 });
 
 // ─── Mock the Markdown component (B1 owns it, may not exist yet) ─────────────
+const markdownProps = vi.hoisted(() => ({ current: null as any }));
+
 vi.mock("../../Markdown", () => ({
-  CopilotMarkdown: ({ content }: { content: string }) => {
+  CopilotMarkdown: (props: {
+    content: string;
+    style?: Record<string, Record<string, unknown>>;
+    streamingAnimation?: boolean;
+  }) => {
     const React = require("react");
+    markdownProps.current = props;
     return React.createElement(
       "div",
       { "data-testid": "copilot-markdown" },
-      content,
+      props.content,
     );
   },
 }));
@@ -159,9 +166,40 @@ describe("AssistantMessage", () => {
 });
 
 describe("UserMessage", () => {
-  it("renders plain text content", () => {
-    const { container } = render(<UserMessage content="Hello from the user" />);
-    expect(container.textContent).toContain("Hello from the user");
+  beforeEach(() => {
+    markdownProps.current = null;
+  });
+
+  it("renders content via CopilotMarkdown", () => {
+    const { getByTestId } = render(
+      <UserMessage content="Hello **from the user**" />,
+    );
+
+    expect(getByTestId("copilot-markdown").textContent).toBe(
+      "Hello **from the user**",
+    );
+    expect(markdownProps.current).toMatchObject({
+      content: "Hello **from the user**",
+      streamingAnimation: false,
+      style: {
+        paragraph: {
+          color: "#FFFFFF",
+          fontSize: 16,
+          lineHeight: 22,
+          marginTop: 0,
+          marginBottom: 0,
+        },
+        h1: { color: "#FFFFFF" },
+        h2: { color: "#FFFFFF" },
+        h3: { color: "#FFFFFF" },
+        link: { color: "#FFFFFF", underline: true },
+        list: {
+          color: "#FFFFFF",
+          marginTop: 4,
+          marginBottom: 4,
+        },
+      },
+    });
   });
 
   it("displays a timestamp when provided", () => {

--- a/packages/react-native/tsdown.config.ts
+++ b/packages/react-native/tsdown.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
   outDir: "dist",
   external: [
     "react",
+    "react-markdown",
     "react-native",
     "@ag-ui/client",
     "@copilotkit/react-core",
@@ -32,5 +33,6 @@ export default defineConfig({
     "react-native-enriched-markdown",
     "react-native-worklets",
     "remend",
+    "remark-gfm",
   ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3107,6 +3107,9 @@ importers:
       expo-file-system:
         specifier: '>=17.0.0'
         version: 56.0.7(expo@56.0.3)(react-native@0.85.2(@babel/core@7.29.7)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@react-native/jest-preset@0.85.2(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.1.8)(react@19.2.3))
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.1.8)(react@19.2.3)
       react-native:
         specifier: '>=0.70'
         version: 0.85.2(@babel/core@7.29.7)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@react-native/jest-preset@0.85.2(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.1.8)(react@19.2.3)
@@ -3119,6 +3122,9 @@ importers:
       react-native-streamdown:
         specifier: '>=0.1.0'
         version: 0.1.1(react-native-enriched-markdown@0.4.0(react-native@0.85.2(@babel/core@7.29.7)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@react-native/jest-preset@0.85.2(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.1.8)(react@19.2.3))(react@19.2.3))(react-native@0.85.2(@babel/core@7.29.7)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@react-native/jest-preset@0.85.2(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.1.8)(react@19.2.3))(react@19.2.3)(remend@1.2.2)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       text-encoding:
         specifier: ^0.7.0
         version: 0.7.0


### PR DESCRIPTION
## What does this PR do?

- Render React Native `UserMessage` content through the existing `CopilotMarkdown` component.
- Preserve readable white Markdown text, headings, list markers, links, and inline code inside the blue user bubble.
- Add a React Native Web path that renders Markdown with `react-markdown` and `remark-gfm` instead of the native-only `react-native-streamdown` component.
- Keep the existing `StreamdownText` renderer and streaming behavior unchanged on iOS and Android.
- Add regression coverage that imports the real `UserMessage` and `CopilotMarkdown` stack on the web path and verifies rendered DOM Markdown.

## Related PRs and Issues

Fixes #5781

## Testing

- `pnpm exec vitest run src/components/__tests__/Markdown.test.tsx src/components/messages/__tests__/UserMessage.web.test.tsx src/components/messages/__tests__/messages.test.tsx` (18 tests passed)
- `pnpm --filter @copilotkit/react-native build`
- `pnpm --filter @copilotkit/react-native publint`
- `pnpm exec oxlint packages/react-native/src/components/Markdown.tsx packages/react-native/src/components/__tests__/Markdown.test.tsx packages/react-native/src/components/messages/__tests__/UserMessage.web.test.tsx packages/react-native/tsdown.config.ts`
- `pnpm exec oxfmt --check packages/react-native/package.json packages/react-native/src/components/Markdown.tsx packages/react-native/src/components/__tests__/Markdown.test.tsx packages/react-native/src/components/messages/__tests__/UserMessage.web.test.tsx packages/react-native/tsdown.config.ts pnpm-lock.yaml`
- Verified both generated CJS and ESM builds can load the web Markdown dependencies.

## Checklist

- [x] I have read the Contribution Guide
- [x] Documentation is not required because this fixes the documented Markdown behavior without changing the public API
- [x] Allow edits by maintainers is enabled
