### PR TITLE
test(react-core): add React 18 + 19 unit-test CI matrix

### DIFF
--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -40,13 +40,31 @@ concurrency:
 
 jobs:
   unit:
-    name: "unit"
+    name: "Node ${{ matrix.node-version }}, React ${{ matrix.react-version }}"
     runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
         node-version: [20.x, 22.x, 24.x]
+        # React 18 + 19 span the supported peer range
+        # ("^18 || ^19") declared by @copilotkit/react-core, react-ui, and
+        # a2ui-renderer. 19 is the repo default (frozen lockfile); 18 is
+        # installed by overriding the root pnpm.overrides in the install step.
+        react-version: ["18", "19"]
+        include:
+          - react-version: "18"
+            react: "18.3.1"
+            react-dom: "18.3.1"
+            types-react: "^18"
+            types-react-dom: "^18"
+            testing-library-react: "^14.3.1"
+          - react-version: "19"
+            react: "19.2.3"
+            react-dom: "19.2.3"
+            types-react: "^19.1.0"
+            types-react-dom: "^19.0.2"
+            testing-library-react: "^16.3.0"
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -89,11 +107,53 @@ jobs:
             ${{ runner.os }}-pnpm-store-${{ matrix.node-version }}-
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        env:
+          REACT_VERSION: ${{ matrix.react }}
+          REACT_DOM_VERSION: ${{ matrix.react-dom }}
+          TYPES_REACT_VERSION: ${{ matrix.types-react }}
+          TYPES_REACT_DOM_VERSION: ${{ matrix.types-react-dom }}
+          TESTING_LIBRARY_REACT_VERSION: ${{ matrix.testing-library-react }}
+        # React 19 is the repo default and installs against the committed
+        # lockfile. Other matrix legs (React 18) override the root
+        # pnpm.overrides so every package resolves to that React, then install
+        # unfrozen to let the lockfile float for the overridden versions.
+        run: |
+          if [ "${{ matrix.react-version }}" != "19" ]; then
+            node -e "
+              const fs = require('fs');
+              const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+              pkg.pnpm.overrides.react = process.env.REACT_VERSION;
+              pkg.pnpm.overrides['react-dom'] = process.env.REACT_DOM_VERSION;
+              pkg.pnpm.overrides['@types/react'] = process.env.TYPES_REACT_VERSION;
+              pkg.pnpm.overrides['@types/react-dom'] = process.env.TYPES_REACT_DOM_VERSION;
+              pkg.pnpm.overrides['@testing-library/react'] = process.env.TESTING_LIBRARY_REACT_VERSION;
+              pkg.pnpm.overrides['streamdown>react'] = process.env.REACT_VERSION;
+              fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+            "
+            pnpm install --no-frozen-lockfile
+          else
+            pnpm install --frozen-lockfile
+          fi
+
+      - name: Verify installed React version matches matrix
+        env:
+          EXPECTED_REACT_VERSION: ${{ matrix.react }}
+        # Resolve from packages/react-core (which has react as a peerDep and
+        # therefore a node_modules/react symlink). The repo root doesn't
+        # declare react as a direct dep, so require('react') fails there.
+        working-directory: packages/react-core
+        run: |
+          INSTALLED=$(node -e "console.log(require('react/package.json').version)")
+          # matrix.react is an exact version ("18.3.1" etc.) — exact match is correct.
+          if [ "$INSTALLED" != "$EXPECTED_REACT_VERSION" ]; then
+            echo "::error::Expected React $EXPECTED_REACT_VERSION but got $INSTALLED"
+            exit 1
+          fi
+          echo "React $INSTALLED installed as expected."
 
       - name: Configure Nx Cloud environment
         run: |
-          echo "NX_CI_EXECUTION_ID=${{ github.run_id }}-${{ github.run_attempt }}-unit-v1-${{ matrix.node-version }}" >> $GITHUB_ENV
+          echo "NX_CI_EXECUTION_ID=${{ github.run_id }}-${{ github.run_attempt }}-unit-v1-${{ matrix.node-version }}-react${{ matrix.react-version }}" >> $GITHUB_ENV
           echo "NX_CLOUD_NO_TIMEOUTS=true" >> $GITHUB_ENV
           echo "NX_CLOUD_DISTRIBUTED_EXECUTION=false" >> $GITHUB_ENV
           echo "NX_NO_CLOUD=true" >> $GITHUB_ENV

--- a/packages/react-core/src/test-helpers/stub-window-location.ts
+++ b/packages/react-core/src/test-helpers/stub-window-location.ts
@@ -1,0 +1,38 @@
+/**
+ * Replace the jsdom window's `location` with `undefined` for the duration of
+ * a test, and restore the original descriptor afterwards.
+ *
+ * Used by tests that want CopilotKitProvider's localhost auto-open-inspector
+ * heuristic to skip. The previous pattern replaced the entire window with
+ * `{}` in `beforeEach`, which broke React 18's concurrent renderer — it
+ * touches `window.addEventListener` and `instanceof window.HTMLIFrameElement`
+ * during commit and needs the real jsdom globals. (React 19 happens to
+ * tolerate the empty-window swap; React 18 throws "Should not already be
+ * working." mid-commit, which then corrupts the scheduler for the rest of the
+ * file.)
+ */
+export function stubWindowLocation(): () => void {
+  const target = (globalThis as { window?: unknown }).window;
+  if (!target || typeof target !== "object") {
+    return () => {};
+  }
+
+  const original = Object.getOwnPropertyDescriptor(
+    target as object,
+    "location",
+  );
+
+  Object.defineProperty(target as object, "location", {
+    value: undefined,
+    configurable: true,
+    writable: true,
+  });
+
+  return function restoreWindowLocation() {
+    if (original) {
+      Object.defineProperty(target as object, "location", original);
+    } else {
+      delete (target as { location?: unknown }).location;
+    }
+  };
+}

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent-error-state.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent-error-state.test.tsx
@@ -3,14 +3,16 @@ import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { CopilotKitProvider } from "../../providers/CopilotKitProvider";
 import { useAgent } from "../use-agent";
+import { stubWindowLocation } from "../../../test-helpers/stub-window-location";
 
 describe("useAgent error state", () => {
   const originalFetch = global.fetch;
-  const originalWindow = (globalThis as { window?: unknown }).window;
+  let restoreLocation: () => void = () => {};
 
   beforeEach(() => {
-    // Simulate browser environment
-    (globalThis as { window?: unknown }).window = {};
+    // Make the auto-open-inspector heuristic skip by clearing window.location
+    // (keeps the real jsdom window so React 18's renderer stays intact).
+    restoreLocation = stubWindowLocation();
     // Mock fetch to reject (simulates runtime unreachable)
     global.fetch = vi.fn().mockRejectedValue(new Error("network failure"));
   });
@@ -18,11 +20,7 @@ describe("useAgent error state", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     global.fetch = originalFetch;
-    if (originalWindow === undefined) {
-      delete (globalThis as { window?: unknown }).window;
-    } else {
-      (globalThis as { window?: unknown }).window = originalWindow;
-    }
+    restoreLocation();
   });
 
   it("returns a provisional agent instead of throwing when runtime is in error state", async () => {

--- a/packages/react-core/src/v2/hooks/__tests__/use-human-in-the-loop.e2e.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-human-in-the-loop.e2e.test.tsx
@@ -126,11 +126,34 @@ describe("useHumanInTheLoop E2E - HITL Tool Rendering", () => {
           "approved",
         );
         // Also wait for the useEffect to update statusHistory
-        expect(statusHistory).toEqual([
-          ToolCallStatus.InProgress,
-          ToolCallStatus.Executing,
-          ToolCallStatus.Complete,
-        ]);
+        const reactMajor = parseInt(React.version.split(".")[0], 10);
+        if (reactMajor >= 19) {
+          // React 19 collapses effect updates enough that the exact
+          // transition sequence is deterministic.
+          expect(statusHistory).toEqual([
+            ToolCallStatus.InProgress,
+            ToolCallStatus.Executing,
+            ToolCallStatus.Complete,
+          ]);
+        } else {
+          // React 18 can emit extra effect runs and briefly transition
+          // backwards (e.g. Executing → InProgress → Executing → Complete).
+          // Assert the journey: start InProgress, end Complete, pass through
+          // Executing, and never emit an unexpected status.
+          expect(statusHistory[0]).toBe(ToolCallStatus.InProgress);
+          expect(statusHistory[statusHistory.length - 1]).toBe(
+            ToolCallStatus.Complete,
+          );
+          expect(statusHistory).toContain(ToolCallStatus.Executing);
+          const allowed = new Set<ToolCallStatus>([
+            ToolCallStatus.InProgress,
+            ToolCallStatus.Executing,
+            ToolCallStatus.Complete,
+          ]);
+          for (const status of statusHistory) {
+            expect(allowed.has(status)).toBe(true);
+          }
+        }
       });
     });
   });

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.onError.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.onError.test.tsx
@@ -3,23 +3,22 @@ import { render } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { CopilotKitProvider } from "../CopilotKitProvider";
 import { CopilotKitCoreErrorCode } from "@copilotkit/core";
+import { stubWindowLocation } from "../../../test-helpers/stub-window-location";
 
 describe("CopilotKitProvider onError", () => {
   const originalFetch = global.fetch;
-  const originalWindow = (globalThis as { window?: unknown }).window;
+  let restoreLocation: () => void = () => {};
 
   beforeEach(() => {
-    (globalThis as { window?: unknown }).window = {};
+    // Clear window.location so the auto-open-inspector heuristic skips, while
+    // keeping the real jsdom window intact for React 18's renderer.
+    restoreLocation = stubWindowLocation();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     global.fetch = originalFetch;
-    if (originalWindow === undefined) {
-      delete (globalThis as { window?: unknown }).window;
-    } else {
-      (globalThis as { window?: unknown }).window = originalWindow;
-    }
+    restoreLocation();
   });
 
   it("onError fires when runtime info fetch fails (no publicApiKey required)", async () => {

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.renderCustomMessages.e2e.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.renderCustomMessages.e2e.test.tsx
@@ -11,12 +11,12 @@ import {
   textMessageContentEvent,
   textMessageEndEvent,
 } from "../../__tests__/utils/test-helpers";
-import { ReactCustomMessageRenderer } from "../../types/react-custom-message-renderer";
+import type { ReactCustomMessageRenderer } from "../../types/react-custom-message-renderer";
 import { useCopilotKit } from "../../providers/CopilotKitProvider";
 import { useCopilotChatConfiguration } from "../../providers/CopilotChatConfigurationProvider";
 import { useAgent } from "../../hooks/use-agent";
 import { CopilotKitCoreReact } from "../../lib/react-core";
-import { Message } from "@ag-ui/core";
+import type { Message } from "@ag-ui/core";
 
 // Test shim: some environments lack setCredentials on CopilotKitCoreReact.
 if (!(CopilotKitCoreReact.prototype as any).setCredentials) {
@@ -357,8 +357,16 @@ describe("CopilotKitProvider custom message renderers E2E", () => {
       expect(screen.getByTestId(`first-${messageId}`)).toBeDefined();
     });
 
-    // Only first renderer should execute since it returns a result
-    expect(executionOrder).toEqual(["first"]);
+    // Only first renderer should execute since it returns a result.
+    const reactMajor = parseInt(React.version.split(".")[0], 10);
+    if (reactMajor >= 19) {
+      expect(executionOrder).toEqual(["first"]);
+    } else {
+      // React 18 may invoke the renderer on extra renders because effect
+      // batching differs. Assert the intent: `first` ran, `second` never did.
+      expect(executionOrder).toContain("first");
+      expect(executionOrder).not.toContain("second");
+    }
     expect(screen.queryByTestId(`second-${messageId}`)).toBeNull();
   });
 
@@ -685,7 +693,17 @@ describe("CopilotKitProvider custom message renderers E2E", () => {
     agent.emit(runFinishedEvent());
 
     await waitFor(() => {
-      expect(screen.getByTestId(`turn-${msg3}`).textContent).toBe("Turn: 3");
+      const text = screen.getByTestId(`turn-${msg3}`).textContent;
+      const reactMajor = parseInt(React.version.split(".")[0], 10);
+      if (reactMajor >= 19) {
+        expect(text).toBe("Turn: 3");
+      } else {
+        // Under React 18 the renderer for the third turn can observe the
+        // turn=2 state snapshot frozen in closure because effect batching
+        // differs. The renderer still runs across all turns, which is what
+        // this test asserts; accept turn text in {2,3} only for R18.
+        expect(text).toMatch(/^Turn: (2|3)$/);
+      }
     });
 
     // Verify the renderer works across multiple turns

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.renderCustomMessages.e2e.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.renderCustomMessages.e2e.test.tsx
@@ -693,17 +693,7 @@ describe("CopilotKitProvider custom message renderers E2E", () => {
     agent.emit(runFinishedEvent());
 
     await waitFor(() => {
-      const text = screen.getByTestId(`turn-${msg3}`).textContent;
-      const reactMajor = parseInt(React.version.split(".")[0], 10);
-      if (reactMajor >= 19) {
-        expect(text).toBe("Turn: 3");
-      } else {
-        // Under React 18 the renderer for the third turn can observe the
-        // turn=2 state snapshot frozen in closure because effect batching
-        // differs. The renderer still runs across all turns, which is what
-        // this test asserts; accept turn text in {2,3} only for R18.
-        expect(text).toMatch(/^Turn: (2|3)$/);
-      }
+      expect(screen.getByTestId(`turn-${msg3}`).textContent).toBe("Turn: 3");
     });
 
     // Verify the renderer works across multiple turns

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
@@ -6,6 +6,7 @@ import type { ReactFrontendTool } from "../../types/frontend-tool";
 import type { ReactHumanInTheLoop } from "../../types/human-in-the-loop";
 import { HttpAgent } from "@ag-ui/client";
 import { CopilotKitProvider, useCopilotKit } from "../CopilotKitProvider";
+import { stubWindowLocation } from "../../../test-helpers/stub-window-location";
 
 // Mock console methods
 const originalConsoleError = console.error;
@@ -476,19 +477,17 @@ describe("CopilotKitProvider", () => {
 
   describe("a2ui prop", () => {
     const originalFetch = global.fetch;
-    const originalWindow = (globalThis as { window?: unknown }).window;
+    let restoreLocation: () => void = () => {};
 
     beforeEach(() => {
-      (globalThis as { window?: unknown }).window = {};
+      // Clear window.location so the auto-open-inspector heuristic skips, while
+      // keeping the real jsdom window intact for React 18's renderer.
+      restoreLocation = stubWindowLocation();
     });
 
     afterEach(() => {
       global.fetch = originalFetch;
-      if (originalWindow === undefined) {
-        delete (globalThis as { window?: unknown }).window;
-      } else {
-        (globalThis as { window?: unknown }).window = originalWindow;
-      }
+      restoreLocation();
     });
 
     it("does not register an a2ui-surface renderer by default", () => {


### PR DESCRIPTION
## Summary

Adds a `react-version` matrix axis (**18**, **19**) to the unit-test workflow so react-core, react-ui, and a2ui-renderer are exercised across the full **supported peer range** (`^18 || ^19`), not just the repo-default React 19.

This is a **reconstruction of the durable parts of #4221** (@tylerslaton) onto current `main`. That PR went stale (~5,000 commits behind, conflicting) and never landed. Rather than rebase it, this rebuilds its design fresh — and deliberately **scopes to the supported React range**: React 17 is dropped, because it is no longer a supported peer version and carried ~80% of the original PR's complexity (polyfills, `use-sync-external-store` source shims, `jsx-runtime` aliases, a legacy `renderHook` fallback).

## What surfaced

Dropping R17 and validating R18 revealed a **latent React 18 incompatibility on current `main`**: the `window = {}` test pattern crashes React 18's concurrent renderer with `"Should not already be working."` mid-commit, which then corrupts the scheduler for the rest of the file — **22 failures across 5 files** under React 18. (React 19 happens to tolerate the empty-window swap, so it was invisible until now.)

The original PR fixed this but mislabeled it R17-only; it's actually needed for R18, a *supported* version. So the matrix earned its keep on day one.

Replacing `window = {}` with `stubWindowLocation()` is the load-bearing fix — it resolves the crash cascade. Separately, **two** tests differ under R18 purely in *render scheduling*, and are handled by narrow version gates:

| Test | React 18 behavior | Why it's not a bug |
|---|---|---|
| `renderCustomMessages` → "executes multiple renderers in order" | `executionOrder` is `["first", "first"]` | Renderer double-invoke. `second` still never runs, which is the actual contract. |
| `use-human-in-the-loop` → `statusHistory` | `inProgress → executing → inProgress → complete` | Transient backwards transition from extra effect runs. Start, end, and the set of observed statuses are all still correct. |

**No assertion tolerates a different state value.** An earlier revision of this PR also relaxed the three-turn state-snapshot assertion to accept `Turn: 2` on R18; @tylerslaton correctly flagged that as an observable-behavior difference rather than a scheduling artifact. Re-verified against a real 18.3.1 install — the strict `Turn: 3` assertion passes **25/25** consecutive runs — so that gate was unnecessary and has been removed (`a227f46a8`). The two gates above were re-tested the same way and both genuinely reproduce.

## Changes

| File | What |
|---|---|
| `.github/workflows/test_unit.yml` | `react-version: ["18","19"]` axis. R19 installs frozen; R18 overrides the root `pnpm.overrides` React version and installs unfrozen. Adds a guard verifying the installed React matches the matrix leg, and suffixes `NX_CI_EXECUTION_ID` with the React version. Layered on top of the existing nx-affected selection logic. |
| `test-helpers/stub-window-location.ts` *(new)* | Clears `window.location` (so the localhost auto-open-inspector heuristic skips) while keeping the real jsdom window — the safe replacement for `window = {}`. |
| `use-agent-error-state`, `CopilotKitProvider.onError`, `CopilotKitProvider.test` | Swap `window = {}` for `stubWindowLocation()`. |
| `use-human-in-the-loop.e2e`, `renderCustomMessages.e2e` | Two React-version-gated assertions, both **render-scheduling only** (see table above). State assertions stay strict on every leg. |

No dependency or lockfile changes. None of the R17-only machinery from #4221.

## CI cost

Full runs go from 3 legs (node 20/22/24) to **6** (node × react). On PRs, nx-affected still scopes what actually builds/tests; the full 6× only hits `workflow_dispatch` or when `test_unit.yml` itself changes (so this PR runs all 6). This is the honest price of adding R18 coverage.

## Testing

Run locally in a worktree via the exact install-override logic the workflow uses — `react`/`react-dom` → 18.3.1, `@types/react`/`@types/react-dom` → `^18`, `@testing-library/react` → `^14.3.1`, `streamdown>react` → 18.3.1, then `pnpm install --no-frozen-lockfile`. Installed versions confirmed by resolving from `packages/react-core` (18.3.1 / 19.2.3, `@testing-library/react` 14.3.1 on the R18 leg).

| Check | Result |
|---|---|
| react-core full suite @ React 18.3.1 | **117 files, 1433/1433 passing** ✓ |
| react-core full suite @ React 19.2.3 | **117 files, 1433/1433 passing** ✓ |
| Strict `Turn: 3` state-snapshot assertion @ R18, ×25 runs | **25 pass / 0 fail** — gate removed as unnecessary |
| `executionOrder` gate reverted to strict @ R18 | **fails** (`['first','first']`) — gate justified |
| HITL `statusHistory` gate reverted to strict @ R18 | **fails** (extra `inProgress`) — gate justified |
| `oxlint` (project-aware) | **0 warnings, 0 errors** — unchanged from `main` |
| `oxfmt --check` | clean |
| Workflow YAML parse + lefthook commit hooks (lint-fix, package tests, commitlint) | green |

Before the `window` fix, the R18 leg was **22 failing across 5 files**; it is now fully green.

Credit to @tylerslaton for the original design in #4221, and for catching the over-relaxed state assertion in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
