### PR TITLE
fix(starters): add python-multipart to agno starter (fixes startup crash)

### DIFF
--- a/examples/integrations/agno/agent/pyproject.toml
+++ b/examples/integrations/agno/agent/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
   "openai>=1.88.0",
   "yfinance>=0.2.63",
   "fastapi>=0.115.13",
+  "python-multipart>=0.0.20",
   "uvicorn>=0.34.3",
   "ag-ui-protocol>=0.1.8",
   "packaging>=25.0.0",

--- a/examples/integrations/agno/agent/uv.lock
+++ b/examples/integrations/agno/agent/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -407,6 +407,7 @@ dependencies = [
     { name = "openai" },
     { name = "packaging" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "uvicorn" },
     { name = "yfinance" },
 ]
@@ -419,6 +420,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.88.0" },
     { name = "packaging", specifier = ">=25.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "uvicorn", specifier = ">=0.34.3" },
     { name = "yfinance", specifier = ">=0.2.63" },
 ]


### PR DESCRIPTION
## The crash

`starter-agno` (Railway service, built from `examples/integrations/agno`) was crash-looping at import time:

```
RuntimeError: Form data requires "python-multipart" to be installed.
  fastapi/dependencies/utils.py  ensure_multipart_is_installed()
  agno/os/routers/agents/router.py  get_agent_router(...)
  agno/os/app.py  _add_built_in_routes(...)
```

The app dies during startup import — before any network/LLM activity.

## Root cause

The starter's top-level `Dockerfile` installs Python deps with:

```dockerfile
RUN cd agent && uv pip install --system -e .
```

`uv pip install -e .` resolves from `pyproject.toml` and **does not consult `uv.lock`**. The pyproject pinned `agno>=1.7.8`, which now resolves to **agno 2.7.4**. agno **dropped `python-multipart` as a hard dependency** in the 2.7.x line (it was still a hard dep in the locked 2.3.3, and in 2.6.19). agno's `AgentOS` registers a FastAPI form-data route, and FastAPI's `ensure_multipart_is_installed()` raises at route-registration (import) time when the package is absent — so the agent never starts.

The pinned `uv.lock` (agno 2.3.3) *did* carry `python-multipart` transitively, which is why the lockfile looked fine while the deployed image (which bypasses the lock) broke.

## Fix

Add `python-multipart>=0.0.20` directly to the starter agent's `pyproject.toml` dependencies (and refresh `uv.lock`) so it installs regardless of agno's transitive-dependency changes.

## Red → Green proof

Reproduced against the **real deployed install path** (`uv pip install -e .` from pyproject, lock bypassed) in a clean Python 3.12 venv.

### RED (main, before fix)
```
agno resolved: 2.7.4   fastapi: 0.139.2   python-multipart: ABSENT
$ python -c "import main"
RuntimeError: Form data requires "python-multipart" to be installed.
You can install "python-multipart" with:
pip install python-multipart
```

### GREEN (after fix)
```
agno resolved: 2.7.4   fastapi: 0.139.2   python-multipart: 0.0.32  (now installed)
$ python -c "import main"
IMPORT OK - AgentOS app built, no RuntimeError

$ uvicorn main:app ...
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8123
$ curl /health  ->  {"status":"ok",...}
```

## Docker build (local, real starter image)

Built the actual starter image from the top-level `Dockerfile` (the deployed path using `uv pip install --system -e .`) with the local BuildKit builder, then ran it:

```
docker buildx build -f Dockerfile -t agno-fix-test .   ->  EXIT 0
docker run ... agno-fix-test
  agent /health -> 200 {"status":"ok",...}
  agent log: "Application startup complete." / "Uvicorn running on http://0.0.0.0:8000"
  RuntimeError count in container logs: 0
  in-image check: python-multipart present: 0.0.32
```

## Other agno variants

`showcase/integrations/agno` uses a **separate** dep file (`requirements.txt`, not this pyproject/uv.lock) and pins `agno==2.6.19`, which still carries `python-multipart` transitively — so it is **not currently broken**, but it is fragile (a bump past 2.7.x would hit the same crash). No shared dep file, so it is intentionally out of scope here; recommend a follow-up to add an explicit `python-multipart` pin there too.
