### PR TITLE
fix(showcase): aimock-wiring probe now covers the harness fleet (harness/harness-workers)

### DIFF
--- a/showcase/harness/src/probes/aimock-wiring.test.ts
+++ b/showcase/harness/src/probes/aimock-wiring.test.ts
@@ -92,6 +92,9 @@ describe("aimock-wiring probe", () => {
   });
 
   it("excludes aimock / shell / pocketbase services from the check (exact name match)", async () => {
+    // NOTE: `showcase-harness` is intentionally absent — the harness fleet is
+    // no longer excluded (it's an aimock consumer, see the harness-fleet tests
+    // below). Only the pure-infra services remain excluded.
     const r = await aimockWiringProbe.run(
       {
         aimockUrl: AIMOCK_URL,
@@ -101,7 +104,6 @@ describe("aimock-wiring probe", () => {
           { name: "showcase-shell-dashboard" },
           { name: "showcase-shell-docs" },
           { name: "showcase-pocketbase" },
-          { name: "showcase-harness" },
         ],
         // None of these have aimock base URLs — but all should be excluded.
         getServiceEnv: async () => ({}),
@@ -115,17 +117,17 @@ describe("aimock-wiring probe", () => {
 
   it("excludes BARE-named Railway infra services (no `showcase-` prefix)", async () => {
     // Regression: actual deployed Railway service names are bare
-    // (`harness`, `shell`, `dashboard`, `docs`, `dojo`, `pocketbase`,
-    // `webhooks`, `aimock`) but EXCLUDE_SERVICES only listed the
-    // `showcase-`-prefixed form, so the probe counted all infra services
-    // as unwired and went red on staging/prod despite aimock being
-    // correctly wired. Both forms must be treated as excluded.
+    // (`shell`, `dashboard`, `docs`, `dojo`, `pocketbase`, `webhooks`,
+    // `aimock`) but EXCLUDE_SERVICES only listed the `showcase-`-prefixed
+    // form, so the probe counted all infra services as unwired and went red
+    // on staging/prod despite aimock being correctly wired. Both forms must
+    // be treated as excluded. (`harness`/`harness-workers` are NOT here — they
+    // are aimock consumers now, verified separately below.)
     const r = await aimockWiringProbe.run(
       {
         aimockUrl: AIMOCK_URL,
         listServices: async () => [
           { name: "aimock" },
-          { name: "harness" },
           { name: "shell" },
           { name: "dashboard" },
           { name: "docs" },
@@ -714,18 +716,17 @@ describe("aimock-wiring probe", () => {
     expect(r.state).toBe("red");
   });
 
-  it("excludes harness-workers (infra) but checks bare starter-* services", async () => {
-    // Regression for the EXCLUDE drift: the live Railway roster carries
-    // `harness-workers` (harness background workers — pure infra, no LLM
-    // callers) which stays excluded, alongside starters named
-    // `starter-<framework>[-lang]` (e.g. `starter-strands-python`,
-    // `starter-langgraph-js`). Starters ARE checked now — a wired starter must
-    // land in `wired`, not be silently skipped.
+  it("checks harness-workers as an aimock consumer alongside bare starter-* services", async () => {
+    // The live Railway roster carries `harness-workers` (harness background
+    // probe fleet) which IS an aimock consumer — verified via AIMOCK_URL, no
+    // longer excluded — alongside starters named `starter-<framework>[-lang]`
+    // (e.g. `starter-strands-python`, `starter-langgraph-js`). A wired
+    // harness-worker must land in `wired`, exactly like the starters/backend.
     const r = await aimockWiringProbe.run(
       {
         aimockUrl: AIMOCK_URL,
         listServices: async () => [
-          { name: "harness-workers" }, // infra → excluded
+          { name: "harness-workers" }, // consumer → checked via AIMOCK_URL
           { name: "starter-adk" },
           { name: "starter-langgraph-js" },
           { name: "starter-ms-agent-framework-dotnet" },
@@ -734,13 +735,16 @@ describe("aimock-wiring probe", () => {
           { name: "showcase-ag2" }, // real backend
         ],
         getServiceEnv: async (name) =>
-          name === "harness-workers" ? {} : { OPENAI_BASE_URL: AIMOCK_URL },
+          name === "harness-workers"
+            ? { AIMOCK_URL }
+            : { OPENAI_BASE_URL: AIMOCK_URL },
       },
       ctx,
     );
     expect(r.state).toBe("green");
     expect(r.signal.unwired).toEqual([]);
     expect(r.signal.wired).toEqual([
+      "harness-workers",
       "showcase-ag2",
       "starter-adk",
       "starter-langgraph-js",
@@ -748,7 +752,7 @@ describe("aimock-wiring probe", () => {
       "starter-ms-agent-framework-python",
       "starter-strands-python",
     ]);
-    expect(r.signal.wiredCount).toBe(6);
+    expect(r.signal.wiredCount).toBe(7);
   });
 
   it("checks starters alongside showcase-* backends (both in the checked universe)", async () => {
@@ -770,22 +774,22 @@ describe("aimock-wiring probe", () => {
     expect(r.signal.unwired).toEqual(["showcase-mastra", "starter-mastra"]);
   });
 
-  it("full live roster: the 20 showcase-* backends AND 12 starters are checked, 9 infra excluded", async () => {
-    // Locks the "checked universe == 20 showcase-* backends + 12 starters"
-    // contract against the full 41-service production roster (9 infra + 20
-    // backends + 12 starters). Backends and starters are all unwired here, so
-    // `unwired` must equal exactly those 32 — only the 9 infra are excluded.
+  it("full live roster: 20 showcase-* backends + 12 starters + 2 harness-fleet consumers checked, 7 pure-infra excluded", async () => {
+    // Locks the checked universe against the full 41-service production roster
+    // (7 pure-infra excluded + 2 harness-fleet consumers + 20 backends + 12
+    // starters). The harness fleet is wired via AIMOCK_URL (→ `wired`); the 32
+    // backends+starters are all unwired here; only the 7 pure-infra are excluded.
     const infra = [
       "aimock",
       "dashboard",
       "docs",
       "dojo",
-      "harness",
-      "harness-workers",
       "pocketbase",
       "shell",
       "webhooks",
     ];
+    // Harness fleet: infra that ARE aimock consumers, verified via AIMOCK_URL.
+    const consumers = ["harness", "harness-workers"];
     const backends = [
       "showcase-ag2",
       "showcase-agno",
@@ -826,12 +830,18 @@ describe("aimock-wiring probe", () => {
       {
         aimockUrl: AIMOCK_URL,
         listServices: async () =>
-          [...infra, ...backends, ...starters].map((name) => ({ name })),
-        getServiceEnv: async () => ({}),
+          [...infra, ...consumers, ...backends, ...starters].map((name) => ({
+            name,
+          })),
+        // Harness fleet wired via AIMOCK_URL; everything else unwired.
+        getServiceEnv: async (name) =>
+          consumers.includes(name) ? { AIMOCK_URL } : {},
       },
       ctx,
     );
     expect(r.state).toBe("red");
+    // Pure-infra excluded; harness fleet wired; backends+starters unwired.
+    expect(r.signal.wired).toEqual([...consumers].sort());
     expect(r.signal.unwired).toEqual([...backends, ...starters].sort());
     expect(r.signal.unwiredCount).toBe(32);
   });
@@ -1053,6 +1063,147 @@ describe("aimock-wiring probe", () => {
     expect(r.signal.sealed).toEqual(["svc-sealed"]);
     expect(r.signal.unwired).toEqual(["svc-unwired"]);
     expect(r.signal.hasSealed).toBe(true);
+    expect(r.signal.wired).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Harness-fleet coverage (egress incident). `harness` and `harness-workers`
+  // reach aimock too and MUST be verified — previously they were in
+  // EXCLUDE_SERVICES, so the probe never flagged them when their aimock
+  // pointers went to the billed PUBLIC host (~$657/mo egress on staging).
+  // `harness-workers` is checked via OPENAI/ANTHROPIC/AIMOCK_URL; `harness`
+  // via its ONLY aimock pointer, AIMOCK_URL. See EXCLUDE_SERVICES /
+  // AIMOCK_CONSUMER_SERVICES / HARNESS_FLEET_CANDIDATE_ENV_VARS in
+  // aimock-wiring.ts.
+  // ---------------------------------------------------------------------------
+
+  it("flags the harness fleet when its aimock pointers are on the PUBLIC host (egress drift)", async () => {
+    // The exact incident: harness-workers had OPENAI/ANTHROPIC/AIMOCK_URL and
+    // harness had AIMOCK_URL pointing at the billed PUBLIC *.up.railway.app
+    // aimock host while the target is the free internal host. Both must surface
+    // as unwired/red. Pre-fix they were excluded and this never fired.
+    const INTERNAL_AIMOCK = "http://showcase-aimock.railway.internal:4010";
+    const PUBLIC_AIMOCK = "https://showcase-aimock-production.up.railway.app";
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: INTERNAL_AIMOCK,
+        listServices: async () => [
+          { name: "harness" },
+          { name: "harness-workers" },
+        ],
+        getServiceEnv: async (name) =>
+          name === "harness"
+            ? { AIMOCK_URL: PUBLIC_AIMOCK }
+            : {
+                OPENAI_BASE_URL: `${PUBLIC_AIMOCK}/v1`,
+                ANTHROPIC_BASE_URL: PUBLIC_AIMOCK,
+                AIMOCK_URL: PUBLIC_AIMOCK,
+              },
+      },
+      ctx,
+    );
+    expect(r.state).toBe("red");
+    expect(r.signal.unwired).toEqual(["harness", "harness-workers"]);
+    expect(r.signal.unwiredCount).toBe(2);
+  });
+
+  it("greens the harness fleet when its aimock pointers are on the PRIVATE internal host", async () => {
+    const INTERNAL_AIMOCK = "http://showcase-aimock.railway.internal:4010";
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: INTERNAL_AIMOCK,
+        listServices: async () => [
+          { name: "harness" },
+          { name: "harness-workers" },
+        ],
+        getServiceEnv: async (name) =>
+          name === "harness"
+            ? { AIMOCK_URL: INTERNAL_AIMOCK }
+            : {
+                OPENAI_BASE_URL: `${INTERNAL_AIMOCK}/v1`,
+                ANTHROPIC_BASE_URL: INTERNAL_AIMOCK,
+                AIMOCK_URL: INTERNAL_AIMOCK,
+              },
+      },
+      ctx,
+    );
+    expect(r.state).toBe("green");
+    expect(r.signal.unwired).toEqual([]);
+    expect(r.signal.wired).toEqual(["harness", "harness-workers"]);
+    expect(r.signal.wiredCount).toBe(2);
+  });
+
+  it("verifies `harness` via its only aimock pointer, AIMOCK_URL", async () => {
+    // harness exposes ONLY AIMOCK_URL (no OPENAI/ANTHROPIC/GEMINI). That var is
+    // NOT in the global candidate set, so harness is checked via the harness-
+    // fleet candidate path that adds AIMOCK_URL. Public → unwired, internal →
+    // wired. Locks that harness is caught at all: without AIMOCK_URL in its
+    // candidate set it would be all-missing/unwired forever, even when wired.
+    const INTERNAL_AIMOCK = "http://showcase-aimock.railway.internal:4010";
+    const PUBLIC_AIMOCK = "https://showcase-aimock-production.up.railway.app";
+    const drift = await aimockWiringProbe.run(
+      {
+        aimockUrl: INTERNAL_AIMOCK,
+        listServices: async () => [{ name: "harness" }],
+        getServiceEnv: async () => ({ AIMOCK_URL: PUBLIC_AIMOCK }),
+      },
+      ctx,
+    );
+    expect(drift.state).toBe("red");
+    expect(drift.signal.unwired).toEqual(["harness"]);
+
+    const wired = await aimockWiringProbe.run(
+      {
+        aimockUrl: INTERNAL_AIMOCK,
+        listServices: async () => [{ name: "harness" }],
+        getServiceEnv: async () => ({ AIMOCK_URL: INTERNAL_AIMOCK }),
+      },
+      ctx,
+    );
+    expect(wired.state).toBe("green");
+    expect(wired.signal.wired).toEqual(["harness"]);
+  });
+
+  it("does NOT flag pure-infra services with no aimock pointer (shell/dashboard/etc stay excluded)", async () => {
+    // Un-excluding the harness fleet must NOT start flagging the genuinely-infra
+    // services: they have no aimock caller, so an empty env is correct, not
+    // drift. aimock itself also stays excluded — it IS aimock, not a consumer.
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: AIMOCK_URL,
+        listServices: async () => [
+          { name: "aimock" },
+          { name: "shell" },
+          { name: "dashboard" },
+          { name: "docs" },
+          { name: "dojo" },
+          { name: "pocketbase" },
+          { name: "webhooks" },
+        ],
+        getServiceEnv: async () => ({}),
+      },
+      ctx,
+    );
+    expect(r.state).toBe("green");
+    expect(r.signal.unwired).toEqual([]);
+    expect(r.signal.wiredCount).toBe(0);
+  });
+
+  it("does NOT consult AIMOCK_URL for non-harness services (scoping guard)", async () => {
+    // AIMOCK_URL is a candidate ONLY for the harness fleet. A regular showcase-*
+    // backend that sets AIMOCK_URL but not OPENAI/ANTHROPIC/GEMINI is still
+    // unwired — its real pointer is missing. Locks that AIMOCK_URL was NOT added
+    // to the global candidate set (which could otherwise mask real drift).
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: AIMOCK_URL,
+        listServices: async () => [{ name: "showcase-ag2" }],
+        getServiceEnv: async () => ({ AIMOCK_URL }),
+      },
+      ctx,
+    );
+    expect(r.state).toBe("red");
+    expect(r.signal.unwired).toEqual(["showcase-ag2"]);
     expect(r.signal.wired).toEqual([]);
   });
 });

--- a/showcase/harness/src/probes/aimock-wiring.ts
+++ b/showcase/harness/src/probes/aimock-wiring.ts
@@ -43,22 +43,26 @@ export const SEALED_SENTINEL = "__SEALED__";
  */
 
 /**
- * Infra service names we do NOT check for aimock wiring. The aimock service
- * itself has no upstream to route through, and shell/pocketbase/harness/
- * harness-workers/dashboard/docs/dojo/webhooks are pure infra with no LLM
- * callers (so they have no `*_BASE_URL` overrides and could only ever be
- * counted as unwired).
+ * Pure-infra service names we do NOT check for aimock wiring. The aimock
+ * service itself has no upstream to route through, and shell/pocketbase/
+ * dashboard/docs/dojo/webhooks are pure infra with no LLM callers (so they
+ * have no aimock pointer and could only ever be counted as unwired).
+ *
+ * NOTE: `harness` and `harness-workers` are NOT here — they DO reach aimock
+ * (the probe fleet and its background workers call aimock), so they are
+ * checked as aimock consumers. See `AIMOCK_CONSUMER_SERVICES`. They were
+ * excluded historically, which let the harness fleet's aimock pointers drift
+ * to the billed PUBLIC `*.up.railway.app` host without the probe ever flagging
+ * it (~$657/mo egress on staging).
  *
  * Most entries are stored in their `showcase-`-prefixed form. The exclusion
- * check (`isExcluded`) matches a bare deployed name (e.g. `harness`, `shell`,
- * `aimock`) by PREPENDING `showcase-` to it and testing that prefixed form
- * against the set — so the bare name resolves to the same canonical entry as
- * the prefixed form (`showcase-harness`, …). This is load-bearing: actual
- * deployed Railway service names in the production project are BARE — without
- * the prepend, every bare infra service would have been counted as unwired
- * and the probe would have stayed red forever. `harness-workers` has no
- * `showcase-` legacy form, so it is stored bare — `isExcluded` checks the
- * literal name first, so this matches correctly.
+ * check (`isExcluded`) matches a bare deployed name (e.g. `shell`, `aimock`)
+ * by PREPENDING `showcase-` to it and testing that prefixed form against the
+ * set — so the bare name resolves to the same canonical entry as the prefixed
+ * form (`showcase-shell`, …). This is load-bearing: actual deployed Railway
+ * service names in the production project are BARE — without the prepend, every
+ * bare infra service would have been counted as unwired and the probe would
+ * have stayed red forever.
  *
  * Match is still effectively EXACT (not a prefix match): a hypothetical
  * `showcase-aimock-pinger-mock-for-test` is tested literally and, prepended,
@@ -80,9 +84,29 @@ const EXCLUDE_SERVICES: ReadonlySet<string> = new Set([
   "showcase-shell-dojo",
   "showcase-dojo",
   "showcase-pocketbase",
-  "showcase-harness",
-  "harness-workers",
   "showcase-webhooks",
+]);
+
+/**
+ * Infra services that are ALSO aimock consumers, so they must be verified even
+ * though they are not `showcase-*`/`starter-*` demo backends. The harness fleet
+ * (`harness` — the probe orchestrator; `harness-workers` — its background probe
+ * fleet) reaches aimock and must route over the free internal host, not the
+ * billed public one.
+ *
+ * Consumers are checked via `HARNESS_FLEET_CANDIDATE_ENV_VARS`, which extends
+ * the standard candidate set with `AIMOCK_URL` — `harness` exposes ONLY
+ * `AIMOCK_URL` as its aimock pointer (no OPENAI/ANTHROPIC/GEMINI base URL), so
+ * without that extra candidate it would read as all-missing/unwired forever.
+ * `AIMOCK_URL` is added for THIS path only (not the global candidate set) so a
+ * regular backend's stray `AIMOCK_URL` can't mask a missing real pointer.
+ *
+ * Stored bare (live Railway names are bare); `isAimockConsumer` also tolerates
+ * a legacy `showcase-` prefix, mirroring `isExcluded`.
+ */
+const AIMOCK_CONSUMER_SERVICES: ReadonlySet<string> = new Set([
+  "harness",
+  "harness-workers",
 ]);
 
 export interface AimockWiringInput {
@@ -186,14 +210,29 @@ function isExcluded(name: string): boolean {
   // excluded here. Only the pure-infra services in EXCLUDE_SERVICES are skipped.
 
   // Match either the literal name or its `showcase-`-prefixed form. Railway
-  // service names in the production project are BARE (`harness`, `shell`,
-  // `aimock`, `harness-workers`, …) while some EXCLUDE_SERVICES entries are
-  // keyed by the `showcase-`-prefixed form for historical reasons (the legacy
-  // local-dev project named services with that prefix). Comparing both forms
-  // keeps the set robust to either naming convention without forcing operators
-  // to maintain two parallel sets that can drift.
+  // service names in the production project are BARE (`shell`, `aimock`,
+  // `dashboard`, …) while some EXCLUDE_SERVICES entries are keyed by the
+  // `showcase-`-prefixed form for historical reasons (the legacy local-dev
+  // project named services with that prefix). Comparing both forms keeps the
+  // set robust to either naming convention without forcing operators to
+  // maintain two parallel sets that can drift.
   if (EXCLUDE_SERVICES.has(name)) return true;
   return EXCLUDE_SERVICES.has(`showcase-${name}`);
+}
+
+/**
+ * True for services in `AIMOCK_CONSUMER_SERVICES` — infra that nonetheless
+ * calls aimock and must be verified with the extended
+ * `HARNESS_FLEET_CANDIDATE_ENV_VARS` candidate set. Tolerates both the bare
+ * deployed name (`harness`) and a legacy `showcase-`-prefixed form, mirroring
+ * `isExcluded`.
+ */
+function isAimockConsumer(name: string): boolean {
+  if (AIMOCK_CONSUMER_SERVICES.has(name)) return true;
+  const bare = name.startsWith("showcase-")
+    ? name.slice("showcase-".length)
+    : name;
+  return AIMOCK_CONSUMER_SERVICES.has(bare);
 }
 
 /**
@@ -244,8 +283,9 @@ function extractHostPort(
 }
 
 /**
- * Candidate env var names that may point a service at aimock. A service is
- * "wired" if ANY of these resolves to the aimock host+port.
+ * Default candidate env var names that may point a service at aimock. A service
+ * is "wired" if ANY of these resolves to the aimock host+port. The harness
+ * fleet uses an extended set (`HARNESS_FLEET_CANDIDATE_ENV_VARS`).
  *
  *   - `OPENAI_BASE_URL`: used by the vast majority of services (OpenAI SDK
  *     convention, typically set to `<aimock>/v1`).
@@ -257,6 +297,19 @@ const CANDIDATE_ENV_VARS = [
   "OPENAI_BASE_URL",
   "ANTHROPIC_BASE_URL",
   "GOOGLE_GEMINI_BASE_URL",
+] as const;
+
+/**
+ * Candidate env vars for the harness fleet (`AIMOCK_CONSUMER_SERVICES`). Extends
+ * the standard set with `AIMOCK_URL`, the harness fleet's own aimock pointer:
+ * `harness` exposes ONLY `AIMOCK_URL`, and `harness-workers` exposes
+ * OPENAI/ANTHROPIC/AIMOCK_URL. `AIMOCK_URL` is intentionally scoped to this
+ * path — adding it to the global `CANDIDATE_ENV_VARS` would let a demo backend's
+ * stray `AIMOCK_URL` count as wired and mask a missing real base-URL pointer.
+ */
+const HARNESS_FLEET_CANDIDATE_ENV_VARS = [
+  ...CANDIDATE_ENV_VARS,
+  "AIMOCK_URL",
 ] as const;
 
 /**
@@ -279,6 +332,10 @@ const CANDIDATE_ENV_VARS = [
  * collapse (`http://h` ≡ `http://h:80`, `https://h` ≡ `https://h:443`); the
  * expected port is derived from the configured `aimockUrl` (no port hardcoded).
  *
+ * `candidateVars` selects which env vars are consulted (defaults to
+ * `CANDIDATE_ENV_VARS`; the harness fleet passes
+ * `HARNESS_FLEET_CANDIDATE_ENV_VARS`, which adds `AIMOCK_URL`).
+ *
  * Precedence: match > mismatch(confirmed) > sealed > mismatch(all-missing).
  *   1. A confirmed match on ANY candidate wins over everything — a service
  *      exposing `ANTHROPIC_BASE_URL=aimock` with a sealed `OPENAI_BASE_URL`
@@ -293,6 +350,7 @@ const CANDIDATE_ENV_VARS = [
 function pointsAtAimock(
   env: Record<string, string | undefined>,
   aimockUrl: string,
+  candidateVars: readonly string[] = CANDIDATE_ENV_VARS,
 ): "match" | "mismatch" | "sealed" {
   const target = extractHostPort(aimockUrl);
   // Defense-in-depth: the probe's `run` has already validated `aimockUrl`
@@ -303,7 +361,7 @@ function pointsAtAimock(
   if (target === null) return "mismatch";
   let anySealed = false;
   let anyConfirmedMismatch = false;
-  for (const varName of CANDIDATE_ENV_VARS) {
+  for (const varName of candidateVars) {
     const raw = env[varName];
     // Missing / empty contributes no signal — treated like the var being
     // absent (which, if nothing else fires, lands in mismatch(all-missing)).
@@ -425,7 +483,13 @@ export const aimockWiringProbe: Probe<AimockWiringInput, AimockWiringSignal> = {
         errored.push({ name, errorDesc });
         continue;
       }
-      const verdict = pointsAtAimock(env, input.aimockUrl);
+      // Harness-fleet consumers are verified with the extended candidate set
+      // (adds AIMOCK_URL) since `harness` exposes only that pointer; all other
+      // services use the standard OPENAI/ANTHROPIC/GEMINI candidates.
+      const candidateVars = isAimockConsumer(name)
+        ? HARNESS_FLEET_CANDIDATE_ENV_VARS
+        : CANDIDATE_ENV_VARS;
+      const verdict = pointsAtAimock(env, input.aimockUrl, candidateVars);
       if (verdict === "match") {
         wired.push(name);
       } else if (verdict === "sealed") {


### PR DESCRIPTION
## The incident this prevents

The showcase pays egress whenever a service reaches aimock over the PUBLIC `*.up.railway.app` host instead of the free `showcase-aimock.railway.internal:4010`. On STAGING, `harness-workers` (the 6-replica probe fleet) had `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL` / `AIMOCK_URL` pointing at PUBLIC aimock, and `harness` had a public `AIMOCK_URL` — together ~$657/mo of egress. The aimock-wiring drift probe **never flagged this** because both services were in `EXCLUDE_SERVICES`. The live vars are already fixed; this makes the probe cover the class so it can't silently regress.

## Design choice + justification

Two facts constrained the fix:

1. `harness` / `harness-workers` were excluded (`EXCLUDE_SERVICES`) → skipped entirely, so a naive fix must un-exclude them.
2. `harness` exposes its aimock pointer **only** as `AIMOCK_URL`, which is **not** in `CANDIDATE_ENV_VARS` (`OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL` / `GOOGLE_GEMINI_BASE_URL`). So merely un-excluding `harness` would leave it all-missing → unwired forever, even when correctly wired.

Chosen approach — a dedicated **aimock-consumer** class:

- Remove `harness` / `harness-workers` from `EXCLUDE_SERVICES`.
- Add `AIMOCK_CONSUMER_SERVICES = { harness, harness-workers }` + `isAimockConsumer(name)` (mirrors `isExcluded`: matches bare and legacy `showcase-`-prefixed forms).
- Add `HARNESS_FLEET_CANDIDATE_ENV_VARS = [...CANDIDATE_ENV_VARS, "AIMOCK_URL"]`; `pointsAtAimock` takes a `candidateVars` param (defaults to the standard set). In the run loop, consumers use the extended set, everything else the standard set.

This is the minimal correct surface: it catches `harness` via `AIMOCK_URL`, catches `harness-workers` via any of OPENAI/ANTHROPIC/AIMOCK_URL, and leaves the verdict precedence (match > confirmed-mismatch > sealed > missing) untouched.

### Why `AIMOCK_URL` is scoped to the harness-fleet path (and safe)

Adding `AIMOCK_URL` to the **global** candidate set is not safe: a regular demo backend that happens to expose `AIMOCK_URL` (pointed anywhere) could then count as "wired" and **mask a missing real `OPENAI_BASE_URL`/etc pointer**, hiding genuine drift. Scoping `AIMOCK_URL` to `HARNESS_FLEET_CANDIDATE_ENV_VARS` means only the two harness-fleet services consult it. A regression guard test (`does NOT consult AIMOCK_URL for non-harness services`) locks this in. Pure-infra services with no aimock pointer (aimock/shell/dashboard/docs/dojo/pocketbase/webhooks) stay excluded and never go red.

## Red → Green proof

Tests added in `aimock-wiring.test.ts`. RED was captured against the **unchanged** probe (new tests only, source untouched); GREEN after the fix + updating the 4 existing tests that asserted the old harness-excluded behavior.

**RED** (new behavior tests fail on current code — harness fleet excluded, so the incident is not flagged):

```
 FAIL  aimock-wiring.test.ts > flags the harness fleet when its aimock pointers are on the PUBLIC host (egress drift)
   AssertionError: expected 'green' to be 'red'
 FAIL  aimock-wiring.test.ts > greens the harness fleet when its aimock pointers are on the PRIVATE internal host
   AssertionError: expected [] to deeply equal [ 'harness', 'harness-workers' ]
 FAIL  aimock-wiring.test.ts > verifies `harness` via its only aimock pointer, AIMOCK_URL
   AssertionError: expected 'green' to be 'red'

 Test Files  1 failed (1)
      Tests  3 failed | 44 passed (47)
```

**GREEN** (after the fix):

```
 Test Files  1 passed (1)
      Tests  47 passed (47)
```

Test coverage added:
- `flags the harness fleet when its aimock pointers are on the PUBLIC host (egress drift)` — the exact incident → red.
- `greens the harness fleet when its aimock pointers are on the PRIVATE internal host` — positive path → wired/green.
- `verifies harness via its only aimock pointer, AIMOCK_URL` — public→red, internal→green (locks the `AIMOCK_URL`-candidate path).
- `does NOT flag pure-infra services with no aimock pointer` — guard: shell/dashboard/etc stay excluded.
- `does NOT consult AIMOCK_URL for non-harness services` — guard: `AIMOCK_URL` is not global.

## Local quality

- oxfmt (formatter) — clean on both files
- oxlint — 0 warnings, 0 errors
- `tsc --noEmit` (typecheck) — clean
- `tsc -p tsconfig.build.json` (build) — clean
- Full harness suite: only the pre-existing unrelated failures remain (`d0-gone-predicate.test.ts`, `d5-mapping-drift.test.ts`, and `cvdiag/staged-ts-scrub-parity.test.ts`) — all confirmed failing identically on the untouched baseline (verified via `git stash`). This PR adds **no** new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCLub2Vb5Y56cPttSzkip1
