### PR TITLE
fix(showcase): wire crewai-crews declarative-gen-ui via Option A (JS-injected A2UI)

### DIFF
--- a/showcase/aimock/d6/crewai-crews/gen-ui-declarative.json
+++ b/showcase/aimock/d6/crewai-crews/gen-ui-declarative.json
@@ -1,418 +1,81 @@
 {
-  "_meta": {
-    "description": "D6 fixtures for crewai-crews / gen-ui-declarative (A2UI dynamic schema)",
-    "sourceFile": "harness/fixtures/d5/gen-ui-declarative.json",
-    "copiedFrom": "langgraph-python",
-    "created": "2026-05-22"
+ "_meta": {
+  "description": "D6 fixtures for crewai-crews / gen-ui-declarative (A2UI Dynamic Schema)",
+  "_note": "Option A (JS-runtime-injected A2UI). The CopilotKit runtime middleware (`a2ui.injectA2UITool: true`, default) injects `render_a2ui` into the agent's available tools via copilotkit.actions. The `ChatWithCrewFlow` exposes it to the chat LLM; the LLM calls `render_a2ui` directly with full component arguments. The ag_ui_crewai adapter streams the TOOL_CALL_CHUNK events; the JS A2UIMiddleware intercepts them, builds a2ui_operations, and emits them to the frontend. The adapter ends without handling the tool result (CrewAI has no a2ui-specific result handling); the middleware's complete() handler synthesizes the tool result and fires RUN_FINISHED. Fixtures match `toolName: render_a2ui` + `context: crewai-crews` (single-stage, no outer generate_a2ui wrapper). Pill userMessage matchers are the full prompt text from declarative-gen-ui/suggestions.ts.",
+  "created": "2026-07-20"
+ },
+ "fixtures": [
+  {
+   "_comment": "pill sales-dashboard — LLM calls render_a2ui directly with full component tree (no outer generate_a2ui wrapper).",
+   "match": {
+    "userMessage": "Show me my sales dashboard for this quarter.",
+    "toolName": "render_a2ui",
+    "context": "crewai-crews"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_crewai_decl_dash_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"sales-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"kpi-row\",\"charts-row\"]},{\"id\":\"kpi-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-revenue\",\"metric-new-customers\",\"metric-win-rate\",\"metric-deal-size\"]},{\"id\":\"metric-revenue\",\"component\":\"Metric\",\"label\":\"Quarterly Revenue\",\"value\":\"$4.2M\",\"trend\":\"up\",\"trendValue\":\"+12% QoQ\"},{\"id\":\"metric-new-customers\",\"component\":\"Metric\",\"label\":\"New Customers\",\"value\":\"186\",\"trend\":\"up\",\"trendValue\":\"+8%\"},{\"id\":\"metric-win-rate\",\"component\":\"Metric\",\"label\":\"Win Rate\",\"value\":\"31%\",\"trend\":\"down\",\"trendValue\":\"-2 pts\"},{\"id\":\"metric-deal-size\",\"component\":\"Metric\",\"label\":\"Avg Deal Size\",\"value\":\"$22.6k\",\"trend\":\"up\",\"trendValue\":\"+5%\"},{\"id\":\"charts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"region-pie\",\"monthly-bar\"]},{\"id\":\"region-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by Region\",\"description\":\"Quarter revenue split across North America, EMEA, APAC, and LATAM.\",\"data\":[{\"label\":\"North America\",\"value\":1900000},{\"label\":\"EMEA\",\"value\":1300000},{\"label\":\"APAC\",\"value\":720000},{\"label\":\"LATAM\",\"value\":280000}]},{\"id\":\"monthly-bar\",\"component\":\"BarChart\",\"title\":\"Monthly Revenue\",\"description\":\"Revenue trend from Jan through Jun.\",\"data\":[{\"label\":\"Jan\",\"value\":1210000},{\"label\":\"Feb\",\"value\":1340000},{\"label\":\"Mar\",\"value\":1650000},{\"label\":\"Apr\",\"value\":1380000},{\"label\":\"May\",\"value\":1420000},{\"label\":\"Jun\",\"value\":1400000}]}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
   },
-  "fixtures": [
-    {
-      "_comment": "KPI dashboard pill — primary agent response triggers generate_a2ui tool call.",
-      "match": {
-        "userMessage": "KPI dashboard",
-        "hasToolResult": false,
-        "context": "crewai-crews"
-      },
-      "response": {
-        "content": "Here is the KPI dashboard you requested.",
-        "toolCalls": [
-          {
-            "id": "call_d6_gen_a2ui_kpi_001",
-            "name": "generate_a2ui",
-            "arguments": "{}"
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "KPI dashboard pill — secondary tool (_design_a2ui_surface) renders the component tree.",
-      "match": {
-        "userMessage": "KPI dashboard",
-        "toolName": "_design_a2ui_surface",
-        "context": "crewai-crews"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "_design_a2ui_surface",
-            "arguments": {
-              "surfaceId": "declarative-surface",
-              "catalogId": "declarative-gen-ui-catalog",
-              "components": [
-                {
-                  "id": "root",
-                  "component": "Card",
-                  "title": "KPI dashboard",
-                  "subtitle": "Last 30 days",
-                  "child": "metrics-col"
-                },
-                {
-                  "id": "metrics-col",
-                  "component": "Column",
-                  "children": ["metric-revenue", "metric-signups", "metric-churn"],
-                  "gap": 12
-                },
-                {
-                  "id": "metric-revenue",
-                  "component": "Metric",
-                  "label": "Revenue",
-                  "value": "$1.2M",
-                  "trend": "up"
-                },
-                {
-                  "id": "metric-signups",
-                  "component": "Metric",
-                  "label": "Signups",
-                  "value": "4,820",
-                  "trend": "up"
-                },
-                {
-                  "id": "metric-churn",
-                  "component": "Metric",
-                  "label": "Churn",
-                  "value": "2.1%",
-                  "trend": "down"
-                }
-              ],
-              "data": {}
-            }
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "KPI dashboard pill — render_a2ui variant (Google-ADK secondary tool name).",
-      "match": {
-        "userMessage": "KPI dashboard",
-        "toolName": "render_a2ui",
-        "context": "crewai-crews"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "render_a2ui",
-            "arguments": {
-              "surfaceId": "declarative-surface",
-              "catalogId": "declarative-gen-ui-catalog",
-              "components": [
-                {
-                  "id": "root",
-                  "component": "Card",
-                  "title": "KPI dashboard",
-                  "subtitle": "Last 30 days",
-                  "child": "metrics-col"
-                },
-                {
-                  "id": "metrics-col",
-                  "component": "Column",
-                  "children": ["metric-revenue", "metric-signups", "metric-churn"],
-                  "gap": 12
-                },
-                {
-                  "id": "metric-revenue",
-                  "component": "Metric",
-                  "label": "Revenue",
-                  "value": "$1.2M",
-                  "trend": "up"
-                },
-                {
-                  "id": "metric-signups",
-                  "component": "Metric",
-                  "label": "Signups",
-                  "value": "4,820",
-                  "trend": "up"
-                },
-                {
-                  "id": "metric-churn",
-                  "component": "Metric",
-                  "label": "Churn",
-                  "value": "2.1%",
-                  "trend": "down"
-                }
-              ],
-              "data": {}
-            }
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "Pie chart pill — primary agent response.",
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "hasToolResult": false,
-        "context": "crewai-crews"
-      },
-      "response": {
-        "content": "Here is the pie chart by region.",
-        "toolCalls": [
-          {
-            "id": "call_d6_gen_a2ui_pie_001",
-            "name": "generate_a2ui",
-            "arguments": "{}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "toolName": "_design_a2ui_surface",
-        "context": "crewai-crews"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "_design_a2ui_surface",
-            "arguments": {
-              "surfaceId": "declarative-surface",
-              "catalogId": "declarative-gen-ui-catalog",
-              "components": [
-                {
-                  "id": "root",
-                  "component": "PieChart",
-                  "title": "Sales by region",
-                  "description": "Q4 — share of total revenue",
-                  "data": [
-                    { "label": "North America", "value": 540 },
-                    { "label": "EMEA", "value": 320 },
-                    { "label": "APAC", "value": 210 },
-                    { "label": "LATAM", "value": 90 }
-                  ]
-                }
-              ],
-              "data": {}
-            }
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "toolName": "render_a2ui",
-        "context": "crewai-crews"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "render_a2ui",
-            "arguments": {
-              "surfaceId": "declarative-surface",
-              "catalogId": "declarative-gen-ui-catalog",
-              "components": [
-                {
-                  "id": "root",
-                  "component": "PieChart",
-                  "title": "Sales by region",
-                  "description": "Q4 — share of total revenue",
-                  "data": [
-                    { "label": "North America", "value": 540 },
-                    { "label": "EMEA", "value": 320 },
-                    { "label": "APAC", "value": 210 },
-                    { "label": "LATAM", "value": 90 }
-                  ]
-                }
-              ],
-              "data": {}
-            }
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "Bar chart pill — primary agent response.",
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "hasToolResult": false,
-        "context": "crewai-crews"
-      },
-      "response": {
-        "content": "Here is the bar chart of quarterly revenue.",
-        "toolCalls": [
-          {
-            "id": "call_d6_gen_a2ui_bar_001",
-            "name": "generate_a2ui",
-            "arguments": "{}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "toolName": "_design_a2ui_surface",
-        "context": "crewai-crews"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "_design_a2ui_surface",
-            "arguments": {
-              "surfaceId": "declarative-surface",
-              "catalogId": "declarative-gen-ui-catalog",
-              "components": [
-                {
-                  "id": "root",
-                  "component": "BarChart",
-                  "title": "Quarterly revenue",
-                  "description": "FY24 — USD thousands",
-                  "data": [
-                    { "label": "Q1", "value": 820 },
-                    { "label": "Q2", "value": 940 },
-                    { "label": "Q3", "value": 1080 },
-                    { "label": "Q4", "value": 1240 }
-                  ]
-                }
-              ],
-              "data": {}
-            }
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "toolName": "render_a2ui",
-        "context": "crewai-crews"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "render_a2ui",
-            "arguments": {
-              "surfaceId": "declarative-surface",
-              "catalogId": "declarative-gen-ui-catalog",
-              "components": [
-                {
-                  "id": "root",
-                  "component": "BarChart",
-                  "title": "Quarterly revenue",
-                  "description": "FY24 — USD thousands",
-                  "data": [
-                    { "label": "Q1", "value": 820 },
-                    { "label": "Q2", "value": 940 },
-                    { "label": "Q3", "value": 1080 },
-                    { "label": "Q4", "value": 1240 }
-                  ]
-                }
-              ],
-              "data": {}
-            }
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "Status report pill — primary agent response.",
-      "match": {
-        "userMessage": "status report on system health",
-        "hasToolResult": false,
-        "context": "crewai-crews"
-      },
-      "response": {
-        "content": "Here is the system health status report.",
-        "toolCalls": [
-          {
-            "id": "call_d6_gen_a2ui_status_001",
-            "name": "generate_a2ui",
-            "arguments": "{}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "status report on system health",
-        "toolName": "_design_a2ui_surface",
-        "context": "crewai-crews"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "_design_a2ui_surface",
-            "arguments": {
-              "surfaceId": "declarative-surface",
-              "catalogId": "declarative-gen-ui-catalog",
-              "components": [
-                {
-                  "id": "root",
-                  "component": "Card",
-                  "title": "System health",
-                  "subtitle": "All services",
-                  "children": ["status-api", "status-db", "status-workers"]
-                },
-                {
-                  "id": "status-api",
-                  "component": "StatusBadge",
-                  "text": "API: healthy",
-                  "variant": "success"
-                },
-                {
-                  "id": "status-db",
-                  "component": "StatusBadge",
-                  "text": "Database: healthy",
-                  "variant": "success"
-                },
-                {
-                  "id": "status-workers",
-                  "component": "StatusBadge",
-                  "text": "Workers: degraded",
-                  "variant": "warning"
-                }
-              ],
-              "data": {}
-            }
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "status report on system health",
-        "toolName": "render_a2ui",
-        "context": "crewai-crews"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "render_a2ui",
-            "arguments": {
-              "surfaceId": "declarative-surface",
-              "catalogId": "declarative-gen-ui-catalog",
-              "components": [
-                {
-                  "id": "root",
-                  "component": "Card",
-                  "title": "System health",
-                  "subtitle": "All services",
-                  "children": ["status-api", "status-db", "status-workers"]
-                },
-                {
-                  "id": "status-api",
-                  "component": "StatusBadge",
-                  "text": "API: healthy",
-                  "variant": "success"
-                },
-                {
-                  "id": "status-db",
-                  "component": "StatusBadge",
-                  "text": "Database: healthy",
-                  "variant": "success"
-                },
-                {
-                  "id": "status-workers",
-                  "component": "StatusBadge",
-                  "text": "Workers: degraded",
-                  "variant": "warning"
-                }
-              ],
-              "data": {}
-            }
-          }
-        ]
-      }
-    }
-  ]
+  {
+   "_comment": "pill team-performance — LLM calls render_a2ui directly with full component tree.",
+   "match": {
+    "userMessage": "How are our sales reps performing against quota?",
+    "toolName": "render_a2ui",
+    "context": "crewai-crews"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_crewai_decl_team_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"rep-quota-performance\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"title\",\"summary\",\"content\"]},{\"id\":\"title\",\"component\":\"Text\",\"text\":\"Sales rep performance vs quota\"},{\"id\":\"summary\",\"component\":\"Text\",\"text\":\"2 of 5 reps are above quota, 1 is near plan, and 2 are below target in Q2.\"},{\"id\":\"content\",\"component\":\"Row\",\"gap\":16,\"children\":[\"table-card\",\"attainment-chart\"]},{\"id\":\"table-card\",\"component\":\"Card\",\"title\":\"Rep attainment table\",\"child\":\"rep-table\"},{\"id\":\"rep-table\",\"component\":\"DataTable\",\"columns\":[{\"key\":\"rep\",\"label\":\"Rep\"},{\"key\":\"attainment\",\"label\":\"Attainment\"},{\"key\":\"pipeline\",\"label\":\"Pipeline\"}],\"rows\":[{\"rep\":\"Dana Whitfield\",\"attainment\":\"124%\",\"pipeline\":\"Leading team; biggest account Meridian Apparel Group has 4 open opps worth $210k\"},{\"rep\":\"Marcus Lee\",\"attainment\":\"108%\",\"pipeline\":\"Above plan\"},{\"rep\":\"Priya Sharma\",\"attainment\":\"97%\",\"pipeline\":\"Near quota\"},{\"rep\":\"Tom Okafor\",\"attainment\":\"88%\",\"pipeline\":\"Below plan\"},{\"rep\":\"Elena Vasquez\",\"attainment\":\"71%\",\"pipeline\":\"Furthest from quota\"}]},{\"id\":\"attainment-chart\",\"component\":\"BarChart\",\"title\":\"Quota attainment by rep\",\"description\":\"Q2 quota attainment percentages for all sales reps.\",\"data\":[{\"label\":\"Dana Whitfield\",\"value\":124},{\"label\":\"Marcus Lee\",\"value\":108},{\"label\":\"Priya Sharma\",\"value\":97},{\"label\":\"Tom Okafor\",\"value\":88},{\"label\":\"Elena Vasquez\",\"value\":71}]}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill at-risk — LLM calls render_a2ui directly with full component tree.",
+   "match": {
+    "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
+    "toolName": "render_a2ui",
+    "context": "crewai-crews"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_crewai_decl_risk_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"risk-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"metrics-row\",\"accounts-row\"]},{\"id\":\"metrics-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-arr\",\"metric-accounts\",\"metric-biggest\"]},{\"id\":\"metric-arr\",\"component\":\"Metric\",\"label\":\"ARR at risk\",\"value\":\"$615k\",\"trend\":\"down\",\"trendValue\":\"3 accounts\"},{\"id\":\"metric-accounts\",\"component\":\"Metric\",\"label\":\"Accounts at risk\",\"value\":\"3\",\"trend\":\"neutral\",\"trendValue\":\"This quarter\"},{\"id\":\"metric-biggest\",\"component\":\"Metric\",\"label\":\"Biggest exposure\",\"value\":\"Northwind Retail\",\"trend\":\"down\",\"trendValue\":\"$340k renewal\"},{\"id\":\"accounts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"card-northwind\",\"card-cascadia\",\"card-atlas\"]},{\"id\":\"card-northwind\",\"component\":\"Card\",\"title\":\"Northwind Retail\",\"subtitle\":\"$340k ARR at stake\",\"child\":\"northwind-content\"},{\"id\":\"northwind-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"northwind-badge\",\"northwind-text\"]},{\"id\":\"northwind-badge\",\"component\":\"StatusBadge\",\"text\":\"High severity\",\"variant\":\"error\"},{\"id\":\"northwind-text\",\"component\":\"Text\",\"text\":\"No contact in 6 weeks; next action: exec outreach this week to protect the renewal.\"},{\"id\":\"card-cascadia\",\"component\":\"Card\",\"title\":\"Cascadia Outfitters\",\"subtitle\":\"$180k ARR at stake\",\"child\":\"cascadia-content\"},{\"id\":\"cascadia-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"cascadia-badge\",\"cascadia-text\"]},{\"id\":\"cascadia-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"cascadia-text\",\"component\":\"Text\",\"text\":\"Champion left; next action: rebuild stakeholder map and secure a new sponsor.\"},{\"id\":\"card-atlas\",\"component\":\"Card\",\"title\":\"Atlas Goods\",\"subtitle\":\"$95k ARR at stake\",\"child\":\"atlas-content\"},{\"id\":\"atlas-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"atlas-badge\",\"atlas-text\"]},{\"id\":\"atlas-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"atlas-text\",\"component\":\"Text\",\"text\":\"Legal review is stalled; next action: align procurement and legal on open terms.\"}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill top-account — LLM calls render_a2ui directly with full component tree.",
+   "match": {
+    "userMessage": "Pull up the details on our biggest account.",
+    "toolName": "render_a2ui",
+    "context": "crewai-crews"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_crewai_decl_acct_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"biggest-account-details\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Row\",\"gap\":16,\"children\":[\"account-card\",\"revenue-pie\"]},{\"id\":\"account-card\",\"component\":\"Card\",\"title\":\"Meridian Apparel Group\",\"subtitle\":\"Biggest account\",\"child\":\"account-facts\"},{\"id\":\"account-facts\",\"component\":\"Column\",\"gap\":8,\"children\":[\"fact1\",\"fact2\",\"fact3\",\"fact4\",\"fact5\",\"fact6\",\"fact7\"]},{\"id\":\"fact1\",\"component\":\"InfoRow\",\"label\":\"Owner\",\"value\":\"Dana Whitfield\"},{\"id\":\"fact2\",\"component\":\"InfoRow\",\"label\":\"Region\",\"value\":\"North America\"},{\"id\":\"fact3\",\"component\":\"InfoRow\",\"label\":\"ARR\",\"value\":\"$612k\"},{\"id\":\"fact4\",\"component\":\"InfoRow\",\"label\":\"Renewal date\",\"value\":\"Sep 30\"},{\"id\":\"fact5\",\"component\":\"InfoRow\",\"label\":\"Last contact\",\"value\":\"3 days ago\"},{\"id\":\"fact6\",\"component\":\"InfoRow\",\"label\":\"Health\",\"value\":\"Green\"},{\"id\":\"fact7\",\"component\":\"InfoRow\",\"label\":\"Open opportunities\",\"value\":\"4 opportunities worth $210k\"},{\"id\":\"revenue-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by product line\",\"description\":\"Meridian Apparel Group revenue mix across product lines.\",\"data\":[{\"label\":\"Outerwear\",\"value\":260000},{\"label\":\"Footwear\",\"value\":180000},{\"label\":\"Accessories\",\"value\":112000},{\"label\":\"Custom\",\"value\":60000}]}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  }
+ ]
 }

--- a/showcase/integrations/crewai-crews/src/agents/declarative_gen_ui.py
+++ b/showcase/integrations/crewai-crews/src/agents/declarative_gen_ui.py
@@ -1,14 +1,14 @@
 """Dedicated crew for the Declarative Generative UI (A2UI Dynamic Schema) demo.
 
-Mirrors `langgraph-python/src/agents/a2ui_dynamic.py` with CrewAI plumbing:
+Option A (JS-runtime-injected A2UI): the crew wires a no-arg `generate_a2ui`
+tool whose body raises loudly if called — the CopilotKit runtime middleware
+(`a2ui.injectA2UITool: true`, enabled by default in route.ts) intercepts the
+toolcall before it reaches Python and drives the secondary `render_a2ui` LLM
+pass itself.  The frontend renderer paints the emitted `a2ui_operations`.
 
-- A single-agent crew that owns a `GenerateA2uiTool` which invokes a
-  secondary LLM bound to a `render_a2ui` function-call, producing A2UI
-  `a2ui_operations` that the runtime's A2UI middleware forwards to the
-  frontend renderer.
-- The agent is tuned via role/backstory to call `generate_a2ui` whenever a
-  response would benefit from a rich visual, matching the system prompt in
-  the langgraph reference.
+The backend crew is tuned via role/backstory to call `generate_a2ui` (no
+args) whenever a response would benefit from a rich visual, matching the
+pattern in the langgraph-python reference agent (`a2ui_dynamic.py`).
 
 CrewAI caveat: `ChatWithCrewFlow` wraps every chat turn in a CrewAI
 "platform" system prompt that encourages the LLM to introduce itself and
@@ -24,26 +24,58 @@ Reference:
 from __future__ import annotations
 
 from crewai import Agent, Crew, Process, Task
+from crewai.tools import BaseTool
+from pydantic import BaseModel
 
 from agents._chat_flow_helpers import preseed_system_prompt
-from agents.tools.custom_tool import GenerateA2uiTool
+
+
+class _NoArgInput(BaseModel):
+    """Empty input schema — generate_a2ui takes no arguments."""
+
+
+class _GenerateA2uiNoArgTool(BaseTool):
+    """No-arg generate_a2ui tool for the injected A2UI pattern.
+
+    The CopilotKit runtime middleware (`a2ui.injectA2UITool: true`) intercepts
+    this toolcall before it reaches the Python body and drives the secondary
+    `render_a2ui` LLM pass itself.  If this body actually runs, the middleware
+    is misconfigured — fail loud per fail-loud-discipline rather than silently
+    returning an empty surface.
+    """
+
+    name: str = "generate_a2ui"
+    description: str = (
+        "Generate a dynamic A2UI dashboard surface from the current conversation. "
+        "Takes no arguments. The CopilotKit runtime middleware intercepts this call "
+        "and drives the secondary render_a2ui pass automatically."
+    )
+    args_schema: type[BaseModel] = _NoArgInput
+
+    def _run(self) -> str:  # type: ignore[override]
+        raise RuntimeError(
+            "generate_a2ui called directly — the CopilotKit a2ui middleware "
+            "should intercept this call before it reaches the agent. "
+            "Check the route configuration at "
+            "app/api/copilotkit-declarative-gen-ui/route.ts."
+        )
 
 
 DECLARATIVE_GEN_UI_BACKSTORY = (
-    "You are a demo assistant for Declarative Generative UI (A2UI - Dynamic "
-    "Schema). Whenever a response would benefit from a rich visual - a "
-    "dashboard, status report, KPI summary, card layout, info grid, a "
-    "pie/donut chart of part-of-whole breakdowns, a bar chart comparing "
-    "values across categories, or anything more structured than plain text - "
-    "call the generate_a2ui tool to draw it. The registered catalog "
-    "includes Card, StatusBadge, Metric, InfoRow, PrimaryButton, PieChart, "
-    "and BarChart (in addition to the basic A2UI primitives). Prefer "
-    "PieChart for part-of-whole breakdowns (sales by region, traffic "
-    "sources, portfolio allocation) and BarChart for comparisons across "
-    "categories (quarterly revenue, headcount by team, signups per month). "
-    "generate_a2ui takes a single `context` argument; pass the user's "
-    "request as the context and it handles the rendering automatically. "
-    "Keep chat replies to one short sentence; let the UI do the talking."
+    "You are the embedded sales analyst for Vantage Threads, the fictional "
+    "B2B apparel company described in your App Context. Answer every "
+    "business question by calling `generate_a2ui` to draw a rich visual "
+    "surface, and keep the chat reply to one short sentence. "
+    "Ground every number in the sales dataset from App Context — never "
+    "invent figures that contradict it. Follow the dashboard composition "
+    "rules from App Context when choosing components: pick the component "
+    "by the shape of the question (snapshot → composed KPI dashboard with "
+    "charts; team performance → table; risk → status badges; single "
+    "account → info rows; part-of-whole → pie; trend/comparison → bar). "
+    "Never ask the user which chart they want. `generate_a2ui` takes no "
+    "arguments and handles the rendering automatically. Compose "
+    "generously — a dashboard should feel like a real analytics product, "
+    "not a single widget."
 )
 
 CREW_NAME = "DeclarativeGenUI"
@@ -54,11 +86,9 @@ CREW_NAME = "DeclarativeGenUI"
 preseed_system_prompt(
     CREW_NAME,
     (
-        "Declarative Generative UI demo. The registered catalog includes "
-        "Card, StatusBadge, Metric, InfoRow, PrimaryButton, PieChart, and "
-        "BarChart. Prefer calling generate_a2ui whenever a dashboard, chart, "
-        "or card layout would improve the answer. Keep chat replies to one "
-        "short sentence."
+        "Declarative Generative UI demo (Vantage Threads sales analyst). "
+        "Call generate_a2ui (no args) whenever a dashboard, chart, or card "
+        "layout would improve the answer. Keep chat replies to one short sentence."
     ),
 )
 
@@ -72,7 +102,7 @@ def _build_crew() -> Crew:
         ),
         backstory=DECLARATIVE_GEN_UI_BACKSTORY,
         verbose=False,
-        tools=[GenerateA2uiTool()],
+        tools=[_GenerateA2uiNoArgTool()],
     )
 
     task = Task(

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -1,10 +1,18 @@
 // Dedicated runtime for the Declarative Generative UI (A2UI - Dynamic Schema)
 // cell.
 //
-// `injectA2UITool: false` because the backend crew owns the `generate_a2ui`
-// tool itself (see src/agents/declarative_gen_ui.py). The A2UI middleware
-// still runs on the runtime side so the registered client catalog is
-// serialised into `copilotkit.context` for the secondary LLM inside the tool.
+// Option A (JS-runtime-injected A2UI): `injectA2UITool` defaults to true so
+// the CopilotKit runtime middleware intercepts the agent's no-arg
+// `generate_a2ui` toolcall and drives the secondary `render_a2ui` LLM pass
+// itself, emitting `a2ui_operations` that the frontend renderer paints.
+// The backend crew (see src/agents/declarative_gen_ui.py) wires a no-arg
+// `generate_a2ui` tool that raises loudly if called directly — the
+// middleware should always intercept before it reaches Python.
+//
+// `defaultCatalogId` pins the catalog the page registers so the middleware's
+// secondary-LLM pass uses the correct component set (models that follow the
+// tool-usage guide and omit `catalogId` would otherwise fall back to the
+// unregistered spec basic catalog, giving a "Catalog not found" render error).
 //
 // Agent URL points at the dedicated `/declarative-gen-ui` FastAPI endpoint
 // mounted by `agent_server.py`, so this demo runs against its own crew
@@ -35,7 +43,6 @@ const runtime = new CopilotRuntime({
   // @ts-ignore -- see main route.ts
   agents,
   a2ui: {
-    injectA2UITool: false,
     // Models follow the tool-usage guide and omit `catalogId`, and the
     // middleware then falls back to the unregistered spec basic catalog
     // ("Catalog not found" render error). Pin the catalog the page registers.

--- a/showcase/integrations/crewai-crews/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
+++ b/showcase/integrations/crewai-crews/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
@@ -92,6 +92,28 @@ export const myDefinitions = {
       ),
     }),
   },
+
+  DataTable: {
+    description:
+      "A data table with column headers and rows. Ideal for rankings and per-person/per-item breakdowns (rep performance vs quota, deal lists). Each row's keys MUST appear in `columns[].key`; unknown row keys render as blank cells and indicate model/schema drift.",
+    // NOTE on B12 (row-keys ⊆ columns[].key): we'd normally enforce this
+    // with `z.object(...).refine(...)`, but the host catalog package's
+    // `CatalogComponentDefinition` type requires `props: ZodObject<…>`
+    // (it inspects `.shape` at runtime), and `.refine` returns a
+    // `ZodEffects` that breaks both the `satisfies CatalogDefinitions`
+    // type assertion and the runtime `.shape` access. Until the host
+    // type is broadened, we encode the constraint in the description
+    // above so the LLM sees the rule, and leave hard enforcement to
+    // the rendering pipeline (which already shows the empty cell —
+    // detection is the gap, not behaviour).
+    props: z.object({
+      columns: z.array(z.object({ key: z.string(), label: z.string() })),
+      // Cells may be strings or numbers — the renderer stringifies at
+      // render time, but accepting both lets the LLM emit raw numerics
+      // (e.g. attainment 124) instead of being forced to stringify.
+      rows: z.array(z.record(z.union([z.string(), z.number()]))),
+    }),
+  },
 } satisfies CatalogDefinitions;
 // @endregion[definitions-zod]
 

--- a/showcase/integrations/crewai-crews/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -221,7 +221,10 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     // Divider via `border-b last:border-b-0` so the final row doesn't dangle
     // a trailing line, regardless of whether the agent wraps these in a
     // Column or drops them directly into a Card's child slot.
-    <div className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0">
+    <div
+      data-testid="declarative-info-row"
+      className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0"
+    >
       <span className="text-sm text-[var(--muted-foreground)]">
         {props.label}
       </span>
@@ -300,6 +303,59 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
           )}
         </CardContent>
       </Card>
+    );
+  },
+
+  DataTable: ({ props }) => {
+    const cols = Array.isArray(props.columns) ? props.columns : [];
+    const rows = Array.isArray(props.rows) ? props.rows : [];
+    return (
+      <div
+        data-testid="declarative-data-table"
+        className="w-full overflow-x-auto"
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              {cols.map((col) => (
+                <th
+                  key={col.key}
+                  className="border-b-2 border-[var(--border)] px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => {
+              // Stable row key: prefer the first column's value (primary-key-ish),
+              // suffix with index in case values repeat, fall back to a JSON
+              // stringify of the row when columns is empty. Stable keys prevent
+              // React from re-mounting every row when the agent re-emits a
+              // slightly different table.
+              const pk = cols.length > 0 ? row[cols[0].key] : undefined;
+              const rowKey =
+                pk !== undefined ? `${pk}-${i}` : JSON.stringify(row);
+              return (
+                <tr
+                  key={rowKey}
+                  className="border-b border-[var(--border)] last:border-b-0"
+                >
+                  {cols.map((col) => (
+                    <td
+                      key={col.key}
+                      className="px-3 py-2 tabular-nums text-[var(--foreground)]"
+                    >
+                      {String(row[col.key] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
     );
   },
 


### PR DESCRIPTION
## Summary

- **route.ts**: remove `injectA2UITool: false` (enables JS middleware injection); keep `defaultCatalogId: "declarative-gen-ui-catalog"` to prevent "Catalog not found" render errors when models omit `catalogId`.
- **declarative_gen_ui.py**: replace `GenerateA2uiTool` (Python body that would drive a secondary LLM pass — impossible in `ag_ui_crewai`, which has no `CopilotKitMiddleware`) with a no-arg `_GenerateA2uiNoArgTool` that raises loudly if called directly. The JS `A2UIMiddleware` intercepts the `generate_a2ui` toolcall before Python ever sees it and drives the secondary `render_a2ui` pass itself.
- **definitions.ts + renderers.tsx**: add `DataTable` component (columns/rows schema + `declarative-data-table` testid); add missing `declarative-info-row` testid to `InfoRow`. Both were present in the `langgraph-python` reference catalog but absent from `crewai-crews`. Required by D5 harness turns 2 and 4.
- **gen-ui-declarative.json**: rewrite D6 aimock fixtures from broken two-stage pattern (`generate_a2ui` → inner `render_a2ui`) to correct single-stage (LLM calls `render_a2ui` directly). `ag_ui_crewai` has no Python-side injection; the middleware's `complete()` synthesizes the tool result and fires `RUN_FINISHED` after streaming all `TOOL_CALL_CHUNK` events through AG-UI.

## Architecture note

`langgraph-python` uses **two-stage A2UI**: outer `generate_a2ui` → Python `CopilotKitMiddleware` drives inner `render_a2ui`. `crewai-crews` uses **single-stage**: JS `A2UIMiddleware` intercepts `generate_a2ui` (toolcall in the agent's tool list), fires a secondary LLM call itself passing `render_a2ui` in the tools list, the LLM calls `render_a2ui` directly, and `ag_ui_crewai` streams the `TOOL_CALL_CHUNK` events through AG-UI to the middleware.

## RED → GREEN proof

**RED (main, `injectA2UITool: false`):**
```
[conversation-runner] turn 1/4 — FAILED {
  error: 'waitForTurnComplete: turn 1 did not complete within 90000ms
    (reason=surface-missing, runsFinished=1, ...)'
```
Every pill: "CrewAI flow failed; see server logs" — `render_a2ui` not in the agent tool list, aimock fixture never fired, no surface painted.

**GREEN (this branch):**
```
[conversation-runner] turn 1/4 — assertions passed
[conversation-runner] turn 2/4 — assertions passed
[conversation-runner] turn 3/4 — assertions passed
[conversation-runner] turn 4/4 — assertions passed
[conversation-runner] conversation completed successfully { turnsCompleted: 4, totalDurationMs: 8524 }

✓ d6:crewai-crews/gen-ui-declarative  green  (0.0s)
1 passed
```
All 4 pills pass with full component-tree assertions (Metric×4+PieChart+BarChart / DataTable+BarChart / StatusBadge×3+Metric×3 / InfoRow×7+PieChart).

## Adapter-forwarding value-test

Turn 1 passing confirms the full Option A path end-to-end: `generate_a2ui` in tool list → JS `A2UIMiddleware` fires secondary `render_a2ui` LLM pass → aimock returns component tree → `ag_ui_crewai` streams `TOOL_CALL_CHUNK` events → middleware builds `a2ui_operations` → frontend catalog renders `declarative-metric`/`declarative-pie-chart`/`declarative-bar-chart` testids with correct counts.