### PR TITLE
fix(ci): deploy starter-only changes (showcase_build redeploy gap)

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -964,7 +964,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -919,6 +919,128 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  redeploy-staging-starters:
+    name: Trigger Railway staging redeploy (starters)
+    needs: [detect-starter-changes, build-starters]
+    # Starter analogue of `redeploy-staging`. The starter lane
+    # (detect-starter-changes → build-starters) previously ENDED at the GHCR
+    # push: a starter-only change (examples/integrations/<slug>/**) built a
+    # fresh `starter-<slug>:latest` image, but nothing ever told Railway to
+    # pull it, so the fix sat undeployed until someone manually redeployed
+    # (the PR #6061 agno incident — merged + built to GHCR, never deployed,
+    # starter-agno stayed crashed). The showcase `redeploy-staging` job only
+    # covers the showcase `build` lane (needs: [detect-changes, build, ...]),
+    # so the starter lane had NO redeploy step at all. This job closes that
+    # gap by redeploying — in STAGING only — exactly the starters that built
+    # successfully.
+    #
+    # Gate mirrors redeploy-staging's skipped/cancelled handling:
+    #   - !cancelled()                               → don't fire on a cancel.
+    #   - detect-starter-changes.has_changes=='true' → at least one starter in
+    #                                                   the build matrix.
+    #   - build-starters.result != 'skipped'         → the starter build job
+    #     && build-starters.result != 'cancelled'       actually ran (a skipped
+    #                                                   build means no starter
+    #                                                   image was pushed —
+    #                                                   nothing to redeploy).
+    #
+    # build-starters.result == 'failure' STILL enters this job (fail-fast is
+    # false, so some slots may have succeeded while others failed). The
+    # "deploy on build failure" footgun is closed NOT by the job `if:` but by
+    # the per-slot success intersection in the compute step below: only
+    # starters whose OWN build slot reported status:success are redeployed,
+    # and an all-failed run yields an EMPTY CSV → the redeploy step is
+    # skipped. So a wholesale starter build failure never redeploys anything
+    # — the same net guarantee redeploy-staging gets from its
+    # aggregate-build-results.any_success guard, computed inline here to avoid
+    # standing up a second aggregator job for the starter lane.
+    if: >-
+      ${{ !cancelled()
+          && needs.detect-starter-changes.outputs.has_changes == 'true'
+          && needs.build-starters.result != 'skipped'
+          && needs.build-starters.result != 'cancelled' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.x
+
+      - name: Download per-slot starter build-result artifacts
+        # `pattern` (not `name`) download: unlike a `name:` download, a
+        # pattern that matches ZERO artifacts logs a warning and SUCCEEDS
+        # rather than hard-failing. That is exactly the wanted behavior when
+        # build-starters hard-crashed before any slot wrote its result
+        # artifact — the compute step then sees an empty success set and the
+        # redeploy step is skipped (no deploy on a total build failure). These
+        # `starter-build-result-*` artifacts are already emitted per-slot by
+        # build-starters; before this job they were write-only.
+        # merge-multiple:false keeps each slot in its own subdirectory so the
+        # find below reads them deterministically.
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: starter-build-result-*
+          path: ${{ runner.temp }}/starter-build-results-in
+          merge-multiple: false
+
+      - name: Compute successfully-built starter services
+        id: changed
+        env:
+          MATRIX_JSON: ${{ needs.detect-starter-changes.outputs.matrix }}
+          RESULTS_DIR: ${{ runner.temp }}/starter-build-results-in
+        run: |
+          set -euo pipefail
+          # Each per-slot artifact extracts to
+          #   $RESULTS_DIR/starter-build-result-<slug>/result.json
+          # with shape {"service":"<RAW slug>","status":"success|failure|skipped"}
+          # (see build-starters' "Write per-slot starter build result" step).
+          # Collect the RAW slugs whose slot reported status:success. `find
+          # -exec cat {} +` runs cat zero times when nothing matches (empty
+          # or absent result dir) → jq -s slurps zero inputs → `[]`, so an
+          # all-failed / crashed build yields an empty success set with no
+          # xargs-on-empty hang.
+          success_slugs='[]'
+          if [ -d "$RESULTS_DIR" ]; then
+            success_slugs="$(find "$RESULTS_DIR" -name result.json -exec cat {} + 2>/dev/null \
+              | jq -sc '[.[] | select(.status == "success") | .service]')"
+          fi
+          # Map each successfully-built RAW slug → its SSOT key via the starter
+          # matrix `.image` field (image === "starter-<slug>" === the
+          # railway-envs.ts SERVICES key). redeploy-env.ts resolves that SSOT
+          # key directly. The RAW slug must NOT be passed: e.g. the raw slug
+          # "agno" collides with the SHOWCASE `agno` dispatch_name and would
+          # redeploy the wrong (showcase, not starter) Railway service.
+          csv="$(jq -rn --argjson m "$MATRIX_JSON" --argjson s "$success_slugs" \
+            '($m | map(select(.slug as $sl | $s | index($sl)) | .image)) | join(",")')"
+          echo "services=$csv" >> "$GITHUB_OUTPUT"
+          echo "Computed starter services CSV (matrix ∩ build-success): $csv"
+
+      - name: Redeploy changed starters in staging
+        # Empty CSV = no starter built successfully (or the build hard-crashed
+        # before writing any result artifact) → nothing to redeploy → skip.
+        # This is the "no deploy on failure" guard for the starter lane.
+        if: steps.changed.outputs.services != ''
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          SERVICES_CSV: ${{ steps.changed.outputs.services }}
+        run: |
+          # Staging is non-blocking by design: redeploy-env.ts always exits 0
+          # on staging and writes per-service failures to $GITHUB_STEP_SUMMARY.
+          # We deliberately do NOT set REDEPLOY_SUMMARY_JSON or upload a
+          # `redeploy-summary` artifact here: that artifact name is OWNED by
+          # the showcase `redeploy-staging` job and is downloaded by
+          # showcase_deploy.yml by EXACT name, so a second upload of the same
+          # name would collide on a combined (starter + showcase) push.
+          # Starter STAGING verification is intentionally out of scope for
+          # this deploy-gap fix — starters are already smoke-covered by
+          # test_smoke-starter.yml and the harness `starter_smoke` axis.
+          npx tsx showcase/scripts/redeploy-env.ts staging --services "$SERVICES_CSV"
+
   notify-all-builds-failed:
     name: Notify all builds failed (staging unchanged)
     needs: [detect-changes, build, aggregate-build-results]
@@ -977,13 +1099,14 @@ jobs:
     # (genuine all-failed case), both alerts firing for the same event is
     # acceptable per the alert SOP.
     #
-    # `detect-starter-changes` + `build-starters` are included so a FAILED
-    # starter image build (examples/integrations/*) also triggers the Slack
-    # alert + PR comment. Previously the starter lane had NO alert surface:
-    # its jobs were absent from `needs`, so `if: failure()` could never see a
-    # starter build failure and it shipped silently. `if: failure()` still
-    # no-ops when starters are skipped (no starter changes) — skipped !=
-    # failure — so this only fires on a genuine starter build failure.
+    # `detect-starter-changes` + `build-starters` + `redeploy-staging-starters`
+    # are included so a FAILED starter image build OR a failed starter staging
+    # redeploy (examples/integrations/*) also triggers the Slack alert + PR
+    # comment. Previously the starter lane had NO alert surface: its jobs were
+    # absent from `needs`, so `if: failure()` could never see a starter build
+    # failure and it shipped silently. `if: failure()` still no-ops when the
+    # starter jobs are skipped (no starter changes) — skipped != failure — so
+    # this only fires on a genuine starter build or starter redeploy failure.
     needs:
       [
         detect-changes,
@@ -994,6 +1117,7 @@ jobs:
         build-starters,
         aggregate-build-results,
         redeploy-staging,
+        redeploy-staging-starters,
       ]
     if: failure()
     runs-on: ubuntu-latest

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -993,22 +993,46 @@ jobs:
         env:
           MATRIX_JSON: ${{ needs.detect-starter-changes.outputs.matrix }}
           RESULTS_DIR: ${{ runner.temp }}/starter-build-results-in
+          BUILD_STARTERS_RESULT: ${{ needs.build-starters.result }}
         run: |
           set -euo pipefail
           # Each per-slot artifact extracts to
           #   $RESULTS_DIR/starter-build-result-<slug>/result.json
           # with shape {"service":"<RAW slug>","status":"success|failure|skipped"}
           # (see build-starters' "Write per-slot starter build result" step).
-          # Collect the RAW slugs whose slot reported status:success. `find
-          # -exec cat {} +` runs cat zero times when nothing matches (empty
-          # or absent result dir) → jq -s slurps zero inputs → `[]`, so an
-          # all-failed / crashed build yields an empty success set with no
-          # xargs-on-empty hang.
-          success_slugs='[]'
+          # Slurp ALL result records first. `find -exec cat {} +` runs cat zero
+          # times when nothing matches (empty or absent result dir) → jq -s
+          # slurps zero inputs → `[]`, so an all-failed / crashed build yields
+          # an empty record set with no xargs-on-empty hang.
+          #
+          # NO `2>/dev/null` on the cat (Finding 2): suppressing read errors
+          # would let a starter whose result.json exists-but-is-unreadable be
+          # silently dropped from the success set (a silent under-deploy). Let a
+          # read error surface and trip `pipefail` so the job fails loud.
+          records='[]'
           if [ -d "$RESULTS_DIR" ]; then
-            success_slugs="$(find "$RESULTS_DIR" -name result.json -exec cat {} + 2>/dev/null \
-              | jq -sc '[.[] | select(.status == "success") | .service]')"
+            records="$(find "$RESULTS_DIR" -name result.json -exec cat {} + \
+              | jq -sc '.')"
           fi
+          # Fail-loud artifact-completeness check (Finding 2): every matrix slot
+          # writes a result.json ("Write per-slot starter build result" runs
+          # `if: always()`), so when ALL slots built (build-starters.result ==
+          # 'success') the parsed record count MUST equal the matrix slot count.
+          # A shortfall means a `starter-build-result-*` artifact is missing or
+          # expired → a successfully-built starter would be silently dropped
+          # from the redeploy set. Gated on 'success' so a partial/total build
+          # FAILURE (where a crashed slot may legitimately lack its artifact) is
+          # NOT double-reported here — that failure is already surfaced by the
+          # build-starters job itself.
+          matrix_slot_count="$(echo "$MATRIX_JSON" | jq 'length')"
+          record_count="$(echo "$records" | jq 'length')"
+          if [ "$BUILD_STARTERS_RESULT" = "success" ] && [ "$record_count" -ne "$matrix_slot_count" ]; then
+            echo "::error::All starter slots built (build-starters.result=success) but parsed $record_count build-result record(s) for $matrix_slot_count matrix slot(s) — a per-slot starter-build-result-* artifact is missing or expired. A successfully-built starter could be silently dropped from the redeploy set. Check the build-starters upload step and artifact retention (retention-days)."
+            echo "Scheduled starter matrix (detect-starter-changes): $MATRIX_JSON"
+            echo "Parsed build-result records (from RESULTS_DIR):     $records"
+            exit 1
+          fi
+          success_slugs="$(echo "$records" | jq -c '[.[] | select(.status == "success") | .service]')"
           # Map each successfully-built RAW slug → its SSOT key via the starter
           # matrix `.image` field (image === "starter-<slug>" === the
           # railway-envs.ts SERVICES key). redeploy-env.ts resolves that SSOT
@@ -1017,6 +1041,26 @@ jobs:
           # redeploy the wrong (showcase, not starter) Railway service.
           csv="$(jq -rn --argjson m "$MATRIX_JSON" --argjson s "$success_slugs" \
             '($m | map(select(.slug as $sl | $s | index($sl)) | .image)) | join(",")')"
+          # Fail-loud empty-deploy-set check (Finding 1): mirror the sibling
+          # redeploy-staging job's empty-intersection guard. When ALL slots
+          # built (build-starters.result == 'success') yet the matrix ∩ success
+          # CSV is EMPTY, everything built but nothing would be redeployed — a
+          # silent "we thought we shipped but didn't" hole (a slug↔.image
+          # contract skew, or the success set maps to no matrix entry). Fail
+          # loud. Do NOT fail when build-starters merely FAILED (partial or
+          # total): an empty CSV there is the legitimate "no slot succeeded →
+          # nothing to deploy" path, and the build failure is already surfaced
+          # by build-starters itself.
+          if [ -z "$csv" ] && [ "$BUILD_STARTERS_RESULT" = "success" ]; then
+            echo "::error::All starter slots built (build-starters.result=success) but matrix ∩ success-set is EMPTY — nothing would be redeployed. Likely a slug↔.image contract skew between detect-starter-changes' matrix and the per-slot result artifacts' service values."
+            echo "Successful starter slugs (status:success records): $success_slugs"
+            echo "Scheduled starter matrix (detect-starter-changes): $MATRIX_JSON"
+            echo "Reconcile the starter matrix (.slug/.image) with build-starters' per-slot result service values so every built starter maps to a Railway service."
+            exit 1
+          fi
+          if [ -z "$csv" ]; then
+            echo "build-starters.result=$BUILD_STARTERS_RESULT with an empty deploy set — no starter built successfully, nothing to redeploy (any build failure is surfaced by the build-starters job)."
+          fi
           echo "services=$csv" >> "$GITHUB_OUTPUT"
           echo "Computed starter services CSV (matrix ∩ build-success): $csv"
 


### PR DESCRIPTION
## The incident

PR #6061 (`fix(starters): add python-multipart to agno starter`) merged, its
`starter-agno` image built to GHCR via `showcase_build.yml`'s `build-starters`
job — and then was **never deployed to Railway**. `starter-agno` stayed crashed
until someone manually redeployed. That is not a one-off: it is structural. Any
change touching **only** starter files (`examples/integrations/<slug>/**`) hits
the same hole.

## Root cause (job-graph)

`showcase_build.yml` has two independent lanes:

| Lane | Detect | Build | Aggregate | Redeploy |
| --- | --- | --- | --- | --- |
| **Showcase fleet** | `detect-changes` | `build` (matrix) | `aggregate-build-results` | `redeploy-staging` |
| **Starters** | `detect-starter-changes` | `build-starters` (matrix) | — | **(none)** |

`redeploy-staging` is scoped **entirely to the showcase fleet**:

```
redeploy-staging:
  needs: [detect-changes, build, aggregate-build-results]
  if: >-
    !cancelled()
    && needs.detect-changes.outputs.has_changes == 'true'
    && needs.build.result != 'skipped'
    && needs.build.result != 'cancelled'
    && needs.aggregate-build-results.outputs.any_success == 'true'
```
(`.github/workflows/showcase_build.yml:780-799`)

On a **starter-only** push:
- `detect-changes` filters are all `showcase/**` paths → none match
  `examples/integrations/**` → `has_changes=false` → `build` skips →
  `aggregate-build-results` skips → `redeploy-staging` skips (fails its
  `has_changes=='true'` and `build.result != 'skipped'` clauses).
- `detect-starter-changes` matches → `build-starters` builds
  `starter-<slug>:latest` to GHCR — **and stops.** There is no aggregate and
  **no redeploy job for the starter lane at all.**

Net: the starter image is built and pushed, but nothing ever calls Railway's
`serviceInstanceRedeploy`, so the running container keeps the stale image.

The `starter-build-result-*` per-slot artifacts already emitted by
`build-starters` were **write-only** — nothing consumed them.

## The fix

A new `redeploy-staging-starters` job that mirrors `redeploy-staging` for the
starter lane, reusing existing mechanisms (no new script, no new aggregator):

```
redeploy-staging-starters:
  needs: [detect-starter-changes, build-starters]
  if: >-
    !cancelled()
    && needs.detect-starter-changes.outputs.has_changes == 'true'
    && needs.build-starters.result != 'skipped'
    && needs.build-starters.result != 'cancelled'
```

Steps:
1. Download the already-emitted `starter-build-result-*` artifacts
   (`pattern` download → succeeds with zero matches if the build crashed
   before writing any).
2. Compute `matrix ∩ build-success`: read each per-slot
   `{"service":"<raw slug>","status":...}`, keep `status:success` slugs, map
   each **raw slug → `starter-<slug>` SSOT key** via the starter matrix
   `.image` field. (The raw slug must NOT be passed to `redeploy-env.ts` —
   e.g. `"agno"` collides with the **showcase** `agno` dispatch_name.)
3. If the CSV is non-empty, `npx tsx showcase/scripts/redeploy-env.ts staging
   --services <csv>` — the exact same invocation `redeploy-staging` uses.
   `redeploy-env.ts` already resolves each `starter-<slug>` as an SSOT key
   (verified: all 12 starter `.image` values exist as keys in
   `railway-envs.ts`).

**Deploy-on-failure is impossible:** the "don't deploy on build failure" guard
is the per-slot success intersection, not the job `if:`. `build-starters`
`result == 'failure'` still enters the job (fail-fast is false, so some slots
may have succeeded), but only `status:success` slots are redeployed; an
all-failed or crashed build yields an empty CSV → the redeploy step is skipped.
This is the same net guarantee `redeploy-staging` gets from its `any_success`
guard, computed inline to avoid standing up a second aggregator job.

**No `redeploy-summary` artifact is written** by this job on purpose: that
name is owned by `redeploy-staging` and downloaded by `showcase_deploy.yml` by
exact name — a second same-named upload would collide on a combined push.
Starter *staging verification* is intentionally out of scope for this
deploy-gap fix (starters are already smoke-covered by `test_smoke-starter.yml`
and the harness `starter_smoke` axis). `redeploy-staging-starters` was also
added to the `notify` job's `needs` so a starter redeploy failure alerts.

## Before / after truth table

| Scenario | `build` | `redeploy-staging` | `build-starters` | `redeploy-staging-starters` |
| --- | --- | --- | --- | --- |
| **(a) main-fleet-only change** | runs | **redeploys fleet** | skipped | skipped |
| **(b) starter-only change** | skipped | skipped | runs | **redeploys starter (NEW)** |
| **(c) both changed** | runs | **redeploys fleet** | runs | **redeploys starter (NEW)** |
| **(d) starter build failure** | (n/a) | (n/a) | failure | runs, but CSV empty → **no redeploy** |

- **(a)** unchanged — the showcase lane is untouched.
- **(b)** is the fix: the starter now auto-deploys instead of sitting on GHCR.
- **(c)** unchanged for the fleet; the starter additionally deploys. No artifact
  collision because `redeploy-staging-starters` uploads no `redeploy-summary`.
- **(d)** partial failure redeploys only the slots that succeeded; a wholesale
  failure redeploys nothing.

## Fail-loud hardening (CR follow-up)

A CR flagged that the new `redeploy-staging-starters` job could itself
**silently under-deploy** — re-opening the very hole it exists to close. Two
guards added to the `Compute successfully-built starter services` step, mirroring
the sibling `redeploy-staging` job's empty-intersection guard:

1. **Empty deploy-set → fail loud.** When `build-starters.result == 'success'`
   (all slots built) but the `matrix ∩ success` CSV is **empty**, the job now
   `exit 1`s with an actionable `::error::` instead of silently skipping the
   redeploy at green CI (a slug↔`.image` contract skew, or a success set that
   maps to no matrix entry). Gated on `'success'` so a partial/total build
   **failure** keeps the legitimate no-deploy path and is not double-reported —
   that failure is already surfaced by `build-starters` itself.
2. **Missing/unreadable result artifact → fail loud.** Dropped `2>/dev/null` on
   the `result.json` read so a read error surfaces and trips `pipefail`, and
   added a parsed-record-count vs matrix-slot-count assertion (every slot writes
   a `result.json` via `if: always()`, so on a full-success build the counts must
   match). A missing/expired `starter-build-result-*` artifact — which would
   otherwise silently drop a built starter from the redeploy set — now fails the
   job. Also gated on `'success'` so a crashed slot's legitimately-absent
   artifact isn't double-reported on a build failure.

Updated truth table with the new fail-loud row:

| Scenario | `build-starters.result` | deploy CSV | `redeploy-staging-starters` |
| --- | --- | --- | --- |
| success + non-empty CSV | success | non-empty | **redeploys** |
| success + **empty** CSV | success | empty | **exit 1 (NEW fail-loud)** |
| build failure (partial) | failure | subset | redeploys successful subset, no spurious exit |
| build failure (all/crash) | failure | empty | no deploy, failure surfaced, no spurious exit |
| skipped (no starter changes) | skipped | (n/a) | job `if:` excludes it — never runs |

Both guards were locally red→green exercised: pre-fix the empty-CSV and
missing-artifact cases went **green with nothing/partial deployed**; post-fix
they `exit 1`. actionlint still 9/9 (no new findings).

## actionlint

Clean. Baseline (`origin/main`) = 9 findings; this branch = 9 findings, all at
pre-existing lines (custom `depot-*` runner label + pre-existing SC2086 infos).
**Zero new findings** from the added job. The `matrix ∩ success` jq mapping was
locally exercised across the four scenarios above (success/partial/all-fail/
crash-before-artifacts) and produced the expected CSVs.

## Prod-promote path

**Does NOT share the gap.** `showcase_promote.yml` is `workflow_dispatch`-only
("Humans trigger. No automatic prod promotes.") and already lists all 12
`starter-*` services in its choices with `resolve-targets` handling them. There
is no push-driven prod path to fix.

## Residual verification (honest note)

Workflows can't be safely dry-run end-to-end (the redeploy path hits live
Railway). Static validation is complete (actionlint clean, jq logic exercised,
all 12 starter SSOT keys confirmed, `redeploy-env.ts` reused unchanged), but
the true end-to-end confirmation is the **next starter-only change
auto-deploying to staging**. That first real starter-only merge after this
lands should be watched to confirm `redeploy-staging-starters` fires and the
Railway service picks up the new image.

---
Draft — do not merge until reviewed.

