### PR TITLE
fix(showcase): wire ag2 declarative-gen-ui via Option A (JS-injected A2UI)

### DIFF
--- a/showcase/aimock/d6/ag2/gen-ui-declarative.json
+++ b/showcase/aimock/d6/ag2/gen-ui-declarative.json
@@ -1,12 +1,13 @@
 {
  "_meta": {
   "description": "D6 fixtures for ag2 / gen-ui-declarative (A2UI Dynamic Schema)",
-  "_note": "Mirrors langgraph-python gen-ui-declarative.json 1:1 (same 4 sales-context pills, same render_a2ui component trees). ag2 backend is the dedicated a2ui_dynamic.py agent mounted at /declarative-gen-ui (the route points HttpAgent at ${AGENT_URL}/declarative-gen-ui/, injectA2UITool:false). Two-stage pattern: (1) outer agent emits no-arg generate_a2ui toolcall (matched by userMessage+context=ag2); (2) the agent body runs its own secondary render_a2ui LLM call (matched by userMessage+toolName=render_a2ui) and wraps the result in an a2ui_operations container; (3) outer agent emits a one-sentence narration (matched by toolCallId). The outer generate_a2ui handler takes NO arguments — a required context param caused empty-args {} pydantic rejection + a retry hot loop.",
-  "created": "2026-06-23"
+  "_note": "Option A (JS-runtime-injected A2UI). Mirrors langgraph-python gen-ui-declarative.json 1:1 (same 4 sales-context pills, same render_a2ui component trees). ag2 backend is the dedicated a2ui_dynamic.py agent mounted at /declarative-gen-ui (the route points HttpAgent at ${AGENT_URL}/declarative-gen-ui/, injectA2UITool:true default). Two-stage fixture pattern: (1) outer agent emits no-arg generate_a2ui toolcall (matched by userMessage+context=ag2); (2) CopilotKit JS middleware intercepts, drives secondary render_a2ui LLM pass (matched by userMessage+toolName=render_a2ui) and synthesizes the tool result + fires RUN_FINISHED. The outer generate_a2ui handler takes NO arguments.",
+  "created": "2026-06-23",
+  "updated": "2026-07-20"
  },
  "fixtures": [
   {
-   "_comment": "pill sales-dashboard hero — inner secondary LLM (middleware-injected render_a2ui) emits the flat A2UI components.",
+   "_comment": "pill sales-dashboard hero — JS middleware drives secondary render_a2ui LLM pass; emits flat A2UI component tree.",
    "match": {
     "userMessage": "Show me my sales dashboard for this quarter.",
     "toolName": "render_a2ui"
@@ -51,7 +52,7 @@
    "chunkSize": 9999
   },
   {
-   "_comment": "pill team-performance — inner secondary LLM (middleware-injected render_a2ui) emits the flat A2UI components.",
+   "_comment": "pill team-performance — JS middleware drives secondary render_a2ui LLM pass; emits flat A2UI component tree.",
    "match": {
     "userMessage": "How are our sales reps performing against quota?",
     "toolName": "render_a2ui"
@@ -96,7 +97,7 @@
    "chunkSize": 9999
   },
   {
-   "_comment": "pill at-risk — inner secondary LLM (middleware-injected render_a2ui) emits the flat A2UI components.",
+   "_comment": "pill at-risk — JS middleware drives secondary render_a2ui LLM pass; emits flat A2UI component tree.",
    "match": {
     "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
     "toolName": "render_a2ui"
@@ -141,7 +142,7 @@
    "chunkSize": 9999
   },
   {
-   "_comment": "pill top-account — inner secondary LLM (middleware-injected render_a2ui) emits the flat A2UI components.",
+   "_comment": "pill top-account — JS middleware drives secondary render_a2ui LLM pass; emits flat A2UI component tree.",
    "match": {
     "userMessage": "Pull up the details on our biggest account.",
     "toolName": "render_a2ui"

--- a/showcase/integrations/ag2/src/agents/a2ui_dynamic.py
+++ b/showcase/integrations/ag2/src/agents/a2ui_dynamic.py
@@ -1,45 +1,24 @@
 """AG2 agent for the Declarative Generative UI (A2UI Dynamic Schema) demo.
 
-Mirrors the langgraph-python `a2ui_dynamic.py` pattern: the agent owns the
-`generate_a2ui` tool explicitly. When called, it invokes a secondary LLM
-bound to `render_a2ui` (tool_choice forced) using the registered client
-catalog injected via the runtime's `copilotkit.context`. The tool result
-returns an `a2ui_operations` container which the runtime's A2UI middleware
-detects and forwards to the frontend renderer.
+Option A (JS-runtime-injected A2UI): the agent wires a no-arg
+``generate_a2ui`` tool stub whose body raises loudly if called — the
+CopilotKit runtime middleware (``a2ui.injectA2UITool: true``, enabled by
+default in route.ts) intercepts the toolcall before it reaches Python and
+drives the secondary ``render_a2ui`` LLM pass itself.  The frontend renderer
+paints the emitted ``a2ui_operations``.
 
-The dedicated runtime route (`api/copilotkit-declarative-gen-ui/route.ts`)
-sets `injectA2UITool: false` so the runtime does not double-bind a second
-A2UI tool on top of this one.
+Reference: langgraph-python/src/agents/a2ui_dynamic.py (same pattern).
 """
 
 from __future__ import annotations
 
-import json
 import logging
-from typing import cast
 
-import openai
 from autogen import ConversableAgent, LLMConfig
 from autogen.ag_ui import AGUIStream  # type: ignore[import-not-found]  # runtime-only submodule (ag2[ag-ui] extra); not present in static type stubs
 from fastapi import FastAPI
-from openai.types.chat import ChatCompletionFunctionToolParam
-from openai.types.shared_params import FunctionDefinition
-
-from tools import (
-    build_a2ui_operations_from_tool_call,
-    RENDER_A2UI_TOOL_SCHEMA,
-)
-
-from ._header_forwarding import get_forwarded_headers
-from ._request_context import get_latest_user_message
 
 logger = logging.getLogger(__name__)
-
-# Module-level async client: re-used across requests (httpx connection pool is
-# thread-safe). Using AsyncOpenAI inside an `async def` avoids blocking the
-# ASGI event loop on the secondary LLM call.
-_async_openai_client = openai.AsyncOpenAI()
-
 
 SYSTEM_PROMPT = (
     "You are a demo assistant for Declarative Generative UI (A2UI — Dynamic "
@@ -59,119 +38,21 @@ SYSTEM_PROMPT = (
 )
 
 
-async def generate_a2ui() -> str:
+def generate_a2ui() -> str:
     """Generate dynamic A2UI components based on the conversation.
 
-    Takes NO arguments. The outer agent calls this tool with empty
-    arguments (``{}``); the per-request user prompt is read from the
-    ``RequestUserMessageMiddleware`` ContextVar (see ``_request_context``)
-    rather than threaded through a tool parameter. This mirrors the
-    langgraph-python sibling, whose ``generate_a2ui`` also takes no args
-    (``a2ui_dynamic.py``), and keeps the tool schema aligned with the D6
-    fixtures, which emit ``generate_a2ui`` with ``arguments="{}"``. A
-    required ``context`` parameter here would make pydantic reject every
-    empty-args call and drive the outer agent into a retry hot loop.
-
-    A secondary LLM designs the UI schema and data using the `render_a2ui`
-    tool schema. The result is returned as an `a2ui_operations` container
-    for the runtime A2UI middleware to detect and forward to the frontend.
+    Takes NO arguments. The CopilotKit runtime middleware
+    (``a2ui.injectA2UITool: true``) intercepts this toolcall before it
+    reaches the Python body and drives the secondary ``render_a2ui`` LLM
+    pass itself. If this body actually executes, the middleware is
+    misconfigured — raise loudly so the failure is visible.
     """
-    # A4 / R2-A3: thread the latest user prompt from the outer conversation
-    # into the inner call so each pill's request body is byte-distinct
-    # (without this, all 4 declarative pills produce IDENTICAL wire payloads
-    # because the outer agent calls generate_a2ui with arguments="{}" →
-    # context defaults → system message is constant, and the user message
-    # below is hardcoded).
-    #
-    # The prompt is read from a per-request ContextVar populated by
-    # ``RequestUserMessageMiddleware`` at the inbound HTTP boundary — NOT
-    # from ``agent.chat_messages`` (which is shared module-level mutable
-    # state racing across concurrent requests). If the middleware did not
-    # capture anything (non-AG-UI request, parse failure already logged at
-    # WARNING) we fall back to the original hardcoded prompt so the inner
-    # LLM call still produces a sensible default.
-    user_prompt = get_latest_user_message() or (
-        "Generate a dynamic A2UI dashboard based on the conversation."
+    raise RuntimeError(
+        "generate_a2ui called directly — the CopilotKit a2ui middleware "
+        "should intercept this call before it reaches the agent. "
+        "Check the route configuration at "
+        "app/api/copilotkit-declarative-gen-ui/route.ts."
     )
-    # The inner-call system message is constant; per-pill distinctness comes
-    # from ``user_prompt`` above (the outer conversation's latest user
-    # message, captured per-request). Previously this was the outer agent's
-    # ``context`` tool argument, but the outer agent calls ``generate_a2ui``
-    # with empty args ``{}`` (see the no-arg signature + the D6 fixtures),
-    # so a required ``context`` param only produced a pydantic hot loop.
-    inner_system_prompt = "Generate a useful dashboard UI."
-    # A13: forward inbound x-* headers via extra_headers as a defense in depth
-    # alongside the global httpx hook (see _header_forwarding.py). The hook
-    # patches httpx at module load, but extra_headers makes the intent
-    # explicit at the call site and is robust to alternative HTTP transports.
-    forwarded = get_forwarded_headers()
-    try:
-        response = await _async_openai_client.chat.completions.create(
-            model="gpt-4.1",
-            messages=[
-                {
-                    "role": "system",
-                    "content": inner_system_prompt,
-                },
-                {"role": "user", "content": user_prompt},
-            ],
-            tools=[
-                ChatCompletionFunctionToolParam(
-                    type="function",
-                    # RENDER_A2UI_TOOL_SCHEMA is an untyped dict literal that
-                    # conforms to the OpenAI FunctionDefinition TypedDict shape;
-                    # cast so the type checker accepts it (no runtime change).
-                    function=cast(FunctionDefinition, RENDER_A2UI_TOOL_SCHEMA),
-                )
-            ],
-            tool_choice={"type": "function", "function": {"name": "render_a2ui"}},
-            extra_headers=forwarded or None,
-        )
-    except Exception as exc:
-        logger.error(
-            "generate_a2ui: inner LLM call failed type=%s err=%s",
-            type(exc).__name__,
-            exc,
-            exc_info=True,
-        )
-        return json.dumps({"error": f"inner LLM call failed: {type(exc).__name__}"})
-
-    if not response.choices:
-        logger.warning("generate_a2ui: LLM returned no choices")
-        return json.dumps({"error": "LLM returned no choices"})
-
-    choice = response.choices[0]
-    if not choice.message.tool_calls:
-        logger.warning("generate_a2ui: secondary LLM produced no render_a2ui tool call")
-        return json.dumps({"error": "LLM did not call render_a2ui"})
-
-    # tool_calls is a union of function- and custom-tool calls; only the
-    # function variant carries `.function`. `tool_choice` above forces the
-    # `render_a2ui` FUNCTION tool, so the first call is always the function
-    # variant at runtime — narrow on `.type` to make that explicit to the type
-    # checker (and degrade gracefully to the same error shape if it ever isn't).
-    first_call = choice.message.tool_calls[0]
-    if first_call.type != "function":
-        logger.warning(
-            "generate_a2ui: secondary LLM returned non-function tool call type=%s",
-            first_call.type,
-        )
-        return json.dumps({"error": "LLM did not call render_a2ui"})
-
-    try:
-        args = json.loads(first_call.function.arguments)
-        result = build_a2ui_operations_from_tool_call(args)
-        return json.dumps(result)
-    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
-        logger.error(
-            "generate_a2ui: failed to parse render_a2ui args type=%s err=%s",
-            type(exc).__name__,
-            exc,
-            exc_info=True,
-        )
-        return json.dumps(
-            {"error": f"failed to parse render_a2ui args: {type(exc).__name__}"}
-        )
 
 
 agent = ConversableAgent(

--- a/showcase/integrations/ag2/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/ag2/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -1,14 +1,16 @@
 // Dedicated runtime for the Declarative Generative UI (A2UI — Dynamic Schema)
 // cell. The backend is the dedicated `a2ui_dynamic.py` agent mounted at
-// `/declarative-gen-ui` (NOT the root catch-all `agent.py`): it owns the
-// `generate_a2ui` tool explicitly and runs its own secondary `render_a2ui`
-// LLM pass, returning an `a2ui_operations` container that the A2UI
-// middleware detects and streams to the frontend. This mirrors the sibling
-// dedicated routes (`/a2ui-fixed-schema/`, `/beautiful-chat/`, etc.) which
-// all point at their named mount, and matches the D6 fixtures + PARITY_NOTES.
+// `/declarative-gen-ui` (NOT the root catch-all `agent.py`): it wires a
+// no-arg `generate_a2ui` tool stub. The CopilotKit runtime middleware
+// (`a2ui.injectA2UITool: true`, enabled by default) intercepts the agent's
+// `generate_a2ui` toolcall before it reaches Python and drives the secondary
+// `render_a2ui` LLM pass itself, emitting `a2ui_operations` that the frontend
+// renderer paints. This is Option A (JS-runtime-injected A2UI) — same
+// pattern as the langgraph-python and crewai-crews siblings.
 //
-// `injectA2UITool: false` — the agent already owns `generate_a2ui`, so the
-// runtime must NOT double-bind a second injected A2UI tool over it.
+// `defaultCatalogId` pins the catalog the page registers so the middleware's
+// secondary-LLM pass uses the correct component set (omitting `catalogId`
+// falls back to the unregistered basic catalog → "Catalog not found" error).
 
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
@@ -29,14 +31,10 @@ const runtime = new CopilotRuntime({
     }),
   },
   a2ui: {
-    // The dedicated agent owns `generate_a2ui` and produces the
-    // `a2ui_operations` container itself; do not inject a second A2UI tool.
-    injectA2UITool: false,
-    // Pin the catalog the page registers (mirrors the sibling
-    // `/copilotkit-beautiful-chat` and `/copilotkit-a2ui-fixed-schema`
-    // routes). The agent's emitted ops already carry this catalogId, but
-    // pinning it guards against any op that omits it falling back to the
-    // unregistered basic catalog ("Catalog not found" → surface never mounts).
+    // Pin the catalog the page registers so the middleware's secondary-LLM
+    // pass uses the correct component set. Models that follow the tool-usage
+    // guide and omit `catalogId` would otherwise fall back to the unregistered
+    // basic catalog ("Catalog not found" render error).
     defaultCatalogId: "declarative-gen-ui-catalog",
   },
 });


### PR DESCRIPTION
## Summary

- **Route**: Drop `injectA2UITool: false` from `copilotkit-declarative-gen-ui/route.ts` — default `true` enables JS middleware injection
- **Backend**: Replace the complex inner-LLM two-stage body in `a2ui_dynamic.py` with a fail-loud stub matching the crewai-crews Option A pattern (no more openai/AsyncOpenAI, no `_request_context`, no `tools/RENDER_A2UI_TOOL_SCHEMA`)
- **Fixture**: Update `_meta` note and `_comment` fields to reflect Option A; fixture structure was already correct for aimock two-stage matching (outer `generate_a2ui` matched by `context:ag2`; inner `render_a2ui` matched by `toolName:render_a2ui`)

## Why Option A works

AG2's AG-UI adapter has no Python-side A2UI injection. Option A routes the secondary LLM pass through the JS CopilotKit runtime middleware, which intercepts the agent's `generate_a2ui` toolcall, drives `render_a2ui` itself, synthesises the tool result, and fires `RUN_FINISHED`. This is the same pattern as the merged crewai-crews fix (#6067) and mirrors the green langgraph-python sibling.

The previous two-stage backend approach failed under aimock because the backend's inner `AsyncOpenAI` call to `render_a2ui` bypassed aimock entirely (aimock only intercepts the frontend→backend path).

## Red → Green evidence

**RED** (pristine, before changes):
```
▸ Testing ag2:declarative-gen-ui (--d6)...
▸ Isolation active: project=showcase-iso19 slot=19
✗ d6:ag2/gen-ui-declarative  red (0.0s)
  state=red
0 passed, 1 failed
⚠ Tests failed for ag2:declarative-gen-ui (exit 1)
```

**GREEN** (after Option A changes):
```
▸ Testing ag2:declarative-gen-ui (--d6)...
▸ Isolation active: project=showcase-iso20 slot=20
✓ d6:ag2/gen-ui-declarative  green (0.0s)
1 passed
✓ Tests passed for ag2:declarative-gen-ui
```

## Files changed

- `showcase/integrations/ag2/src/app/api/copilotkit-declarative-gen-ui/route.ts` — drop `injectA2UITool: false`, update header comment
- `showcase/integrations/ag2/src/agents/a2ui_dynamic.py` — replace inner-LLM body with fail-loud stub
- `showcase/aimock/d6/ag2/gen-ui-declarative.json` — update `_meta`/`_comment` for Option A

🤖 Generated with [Claude Code](https://claude.com/claude-code)