### PR TITLE
fix(showcase): wire langroid declarative-gen-ui via Option A (JS-injected A2UI)

### DIFF
--- a/showcase/aimock/d6/langroid/gen-ui-declarative.json
+++ b/showcase/aimock/d6/langroid/gen-ui-declarative.json
@@ -1,12 +1,12 @@
 {
  "_meta": {
   "description": "D6 fixtures for langroid / gen-ui-declarative (A2UI Dynamic Schema)",
-  "_note": "Agent plays a sales analyst for the fictional Vantage Threads company (OSS-136). Two-stage A2UI pattern: (1) outer agent has only one tool, `generate_a2ui` (no args); (2) `generate_a2ui` internally invokes a secondary LLM with tool_choice forced on the design tool, which emits the flat A2UI components payload; (3) after the tool returns, the outer agent emits a one-sentence narration. Fixtures cover three LLM calls per pill: (a) outer turn 1 -> generate_a2ui toolcall; (b) inner secondary call -> design toolcall (discriminated by toolName because the user prompt is identical across outer+inner calls); (c) outer turn 2 (matched by toolCallId) -> narration. Pill prompts are natural business questions; chart steering lives in the system prompt + sales-context.ts context entries. Keep userMessage matchers in sync with declarative-gen-ui/suggestions.ts and harness d5-gen-ui-declarative.ts.",
-  "created": "2026-06-11"
+  "_note": "Option A (JS-runtime-injected A2UI). The CopilotKit runtime middleware (`a2ui.injectA2UITool: true`, default) injects `render_a2ui` into the agent's available tools. The LLM calls `render_a2ui` directly with full component arguments (single-stage, no outer generate_a2ui wrapper, no narration turn). The JS A2UIMiddleware intercepts the TOOL_CALL_CHUNK events, builds a2ui_operations, and fires RUN_FINISHED. Fixtures match `toolName: render_a2ui` + `context: langroid`. Pill userMessage matchers are the full prompt text from declarative-gen-ui/suggestions.ts. Supersedes the two-stage approach from #6058 (which severed across the prod streaming boundary).",
+  "created": "2026-07-20"
  },
  "fixtures": [
   {
-   "_comment": "pill sales-dashboard hero — inner secondary LLM (tool_choice forced) emits the flat A2UI components. Discriminated by toolName so it wins over the outer generate_a2ui fixture whose userMessage matches the same prompt. Scoped to context=langroid (langroid forwards x-aimock-context to the inner planner call, unlike ag_ui_adk/strands) so it does not collide with the sibling shared-scope render_a2ui fixtures.",
+   "_comment": "pill sales-dashboard — LLM calls render_a2ui directly with full component tree (no outer generate_a2ui wrapper).",
    "match": {
     "userMessage": "Show me my sales dashboard for this quarter.",
     "toolName": "render_a2ui",
@@ -15,7 +15,7 @@
    "response": {
     "toolCalls": [
      {
-      "id": "call_d6_decl_dash_design_001",
+      "id": "call_d6_langroid_decl_dash_001_render",
       "name": "render_a2ui",
       "arguments": "{\"surfaceId\":\"sales-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"kpi-row\",\"charts-row\"]},{\"id\":\"kpi-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-revenue\",\"metric-new-customers\",\"metric-win-rate\",\"metric-deal-size\"]},{\"id\":\"metric-revenue\",\"component\":\"Metric\",\"label\":\"Quarterly Revenue\",\"value\":\"$4.2M\",\"trend\":\"up\",\"trendValue\":\"+12% QoQ\"},{\"id\":\"metric-new-customers\",\"component\":\"Metric\",\"label\":\"New Customers\",\"value\":\"186\",\"trend\":\"up\",\"trendValue\":\"+8%\"},{\"id\":\"metric-win-rate\",\"component\":\"Metric\",\"label\":\"Win Rate\",\"value\":\"31%\",\"trend\":\"down\",\"trendValue\":\"-2 pts\"},{\"id\":\"metric-deal-size\",\"component\":\"Metric\",\"label\":\"Avg Deal Size\",\"value\":\"$22.6k\",\"trend\":\"up\",\"trendValue\":\"+5%\"},{\"id\":\"charts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"region-pie\",\"monthly-bar\"]},{\"id\":\"region-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by Region\",\"description\":\"Quarter revenue split across North America, EMEA, APAC, and LATAM.\",\"data\":[{\"label\":\"North America\",\"value\":1900000},{\"label\":\"EMEA\",\"value\":1300000},{\"label\":\"APAC\",\"value\":720000},{\"label\":\"LATAM\",\"value\":280000}]},{\"id\":\"monthly-bar\",\"component\":\"BarChart\",\"title\":\"Monthly Revenue\",\"description\":\"Revenue trend from Jan through Jun.\",\"data\":[{\"label\":\"Jan\",\"value\":1210000},{\"label\":\"Feb\",\"value\":1340000},{\"label\":\"Mar\",\"value\":1650000},{\"label\":\"Apr\",\"value\":1380000},{\"label\":\"May\",\"value\":1420000},{\"label\":\"Jun\",\"value\":1400000}]}]}"
      }
@@ -24,35 +24,7 @@
    "chunkSize": 9999
   },
   {
-   "_comment": "pill sales-dashboard hero — outer agent narration after generate_a2ui returns.",
-   "match": {
-    "context": "langroid",
-    "toolCallId": "call_d6_decl_dash_outer_001"
-   },
-   "response": {
-    "content": "Here's your Q2 sales dashboard."
-   },
-   "chunkSize": 9999
-  },
-  {
-   "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args).",
-   "match": {
-    "userMessage": "Show me my sales dashboard for this quarter.",
-    "context": "langroid"
-   },
-   "response": {
-    "toolCalls": [
-     {
-      "id": "call_d6_decl_dash_outer_001",
-      "name": "generate_a2ui",
-      "arguments": "{}"
-     }
-    ]
-   },
-   "chunkSize": 9999
-  },
-  {
-   "_comment": "pill team-performance — inner secondary LLM (tool_choice forced) emits the flat A2UI components. Discriminated by toolName so it wins over the outer generate_a2ui fixture whose userMessage matches the same prompt. Scoped to context=langroid (langroid forwards x-aimock-context to the inner planner call, unlike ag_ui_adk/strands) so it does not collide with the sibling shared-scope render_a2ui fixtures.",
+   "_comment": "pill team-performance — LLM calls render_a2ui directly with full component tree.",
    "match": {
     "userMessage": "How are our sales reps performing against quota?",
     "toolName": "render_a2ui",
@@ -61,7 +33,7 @@
    "response": {
     "toolCalls": [
      {
-      "id": "call_d6_decl_team_design_001",
+      "id": "call_d6_langroid_decl_team_001_render",
       "name": "render_a2ui",
       "arguments": "{\"surfaceId\":\"rep-quota-performance\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"title\",\"summary\",\"content\"]},{\"id\":\"title\",\"component\":\"Text\",\"text\":\"Sales rep performance vs quota\"},{\"id\":\"summary\",\"component\":\"Text\",\"text\":\"2 of 5 reps are above quota, 1 is near plan, and 2 are below target in Q2.\"},{\"id\":\"content\",\"component\":\"Row\",\"gap\":16,\"children\":[\"table-card\",\"attainment-chart\"]},{\"id\":\"table-card\",\"component\":\"Card\",\"title\":\"Rep attainment table\",\"child\":\"rep-table\"},{\"id\":\"rep-table\",\"component\":\"DataTable\",\"columns\":[{\"key\":\"rep\",\"label\":\"Rep\"},{\"key\":\"attainment\",\"label\":\"Attainment\"},{\"key\":\"pipeline\",\"label\":\"Pipeline\"}],\"rows\":[{\"rep\":\"Dana Whitfield\",\"attainment\":\"124%\",\"pipeline\":\"Leading team; biggest account Meridian Apparel Group has 4 open opps worth $210k\"},{\"rep\":\"Marcus Lee\",\"attainment\":\"108%\",\"pipeline\":\"Above plan\"},{\"rep\":\"Priya Sharma\",\"attainment\":\"97%\",\"pipeline\":\"Near quota\"},{\"rep\":\"Tom Okafor\",\"attainment\":\"88%\",\"pipeline\":\"Below plan\"},{\"rep\":\"Elena Vasquez\",\"attainment\":\"71%\",\"pipeline\":\"Furthest from quota\"}]},{\"id\":\"attainment-chart\",\"component\":\"BarChart\",\"title\":\"Quota attainment by rep\",\"description\":\"Q2 quota attainment percentages for all sales reps.\",\"data\":[{\"label\":\"Dana Whitfield\",\"value\":124},{\"label\":\"Marcus Lee\",\"value\":108},{\"label\":\"Priya Sharma\",\"value\":97},{\"label\":\"Tom Okafor\",\"value\":88},{\"label\":\"Elena Vasquez\",\"value\":71}]}]}"
      }
@@ -70,35 +42,7 @@
    "chunkSize": 9999
   },
   {
-   "_comment": "pill team-performance — outer agent narration after generate_a2ui returns.",
-   "match": {
-    "context": "langroid",
-    "toolCallId": "call_d6_decl_team_outer_001"
-   },
-   "response": {
-    "content": "Here's how the team is tracking against quota."
-   },
-   "chunkSize": 9999
-  },
-  {
-   "_comment": "pill team-performance — outer agent emits generate_a2ui (no args).",
-   "match": {
-    "userMessage": "How are our sales reps performing against quota?",
-    "context": "langroid"
-   },
-   "response": {
-    "toolCalls": [
-     {
-      "id": "call_d6_decl_team_outer_001",
-      "name": "generate_a2ui",
-      "arguments": "{}"
-     }
-    ]
-   },
-   "chunkSize": 9999
-  },
-  {
-   "_comment": "pill at-risk — inner secondary LLM (tool_choice forced) emits the flat A2UI components. Discriminated by toolName so it wins over the outer generate_a2ui fixture whose userMessage matches the same prompt. Scoped to context=langroid (langroid forwards x-aimock-context to the inner planner call, unlike ag_ui_adk/strands) so it does not collide with the sibling shared-scope render_a2ui fixtures.",
+   "_comment": "pill at-risk — LLM calls render_a2ui directly with full component tree.",
    "match": {
     "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
     "toolName": "render_a2ui",
@@ -107,7 +51,7 @@
    "response": {
     "toolCalls": [
      {
-      "id": "call_d6_decl_risk_design_001",
+      "id": "call_d6_langroid_decl_risk_001_render",
       "name": "render_a2ui",
       "arguments": "{\"surfaceId\":\"risk-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"metrics-row\",\"accounts-row\"]},{\"id\":\"metrics-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-arr\",\"metric-accounts\",\"metric-biggest\"]},{\"id\":\"metric-arr\",\"component\":\"Metric\",\"label\":\"ARR at risk\",\"value\":\"$615k\",\"trend\":\"down\",\"trendValue\":\"3 accounts\"},{\"id\":\"metric-accounts\",\"component\":\"Metric\",\"label\":\"Accounts at risk\",\"value\":\"3\",\"trend\":\"neutral\",\"trendValue\":\"This quarter\"},{\"id\":\"metric-biggest\",\"component\":\"Metric\",\"label\":\"Biggest exposure\",\"value\":\"Northwind Retail\",\"trend\":\"down\",\"trendValue\":\"$340k renewal\"},{\"id\":\"accounts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"card-northwind\",\"card-cascadia\",\"card-atlas\"]},{\"id\":\"card-northwind\",\"component\":\"Card\",\"title\":\"Northwind Retail\",\"subtitle\":\"$340k ARR at stake\",\"child\":\"northwind-content\"},{\"id\":\"northwind-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"northwind-badge\",\"northwind-text\"]},{\"id\":\"northwind-badge\",\"component\":\"StatusBadge\",\"text\":\"High severity\",\"variant\":\"error\"},{\"id\":\"northwind-text\",\"component\":\"Text\",\"text\":\"No contact in 6 weeks; next action: exec outreach this week to protect the renewal.\"},{\"id\":\"card-cascadia\",\"component\":\"Card\",\"title\":\"Cascadia Outfitters\",\"subtitle\":\"$180k ARR at stake\",\"child\":\"cascadia-content\"},{\"id\":\"cascadia-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"cascadia-badge\",\"cascadia-text\"]},{\"id\":\"cascadia-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"cascadia-text\",\"component\":\"Text\",\"text\":\"Champion left; next action: rebuild stakeholder map and secure a new sponsor.\"},{\"id\":\"card-atlas\",\"component\":\"Card\",\"title\":\"Atlas Goods\",\"subtitle\":\"$95k ARR at stake\",\"child\":\"atlas-content\"},{\"id\":\"atlas-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"atlas-badge\",\"atlas-text\"]},{\"id\":\"atlas-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"atlas-text\",\"component\":\"Text\",\"text\":\"Legal review is stalled; next action: align procurement and legal on open terms.\"}]}"
      }
@@ -116,35 +60,7 @@
    "chunkSize": 9999
   },
   {
-   "_comment": "pill at-risk — outer agent narration after generate_a2ui returns.",
-   "match": {
-    "context": "langroid",
-    "toolCallId": "call_d6_decl_risk_outer_001"
-   },
-   "response": {
-    "content": "Three accounts need attention this quarter."
-   },
-   "chunkSize": 9999
-  },
-  {
-   "_comment": "pill at-risk — outer agent emits generate_a2ui (no args).",
-   "match": {
-    "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
-    "context": "langroid"
-   },
-   "response": {
-    "toolCalls": [
-     {
-      "id": "call_d6_decl_risk_outer_001",
-      "name": "generate_a2ui",
-      "arguments": "{}"
-     }
-    ]
-   },
-   "chunkSize": 9999
-  },
-  {
-   "_comment": "pill top-account — inner secondary LLM (tool_choice forced) emits the flat A2UI components. Discriminated by toolName so it wins over the outer generate_a2ui fixture whose userMessage matches the same prompt. Scoped to context=langroid (langroid forwards x-aimock-context to the inner planner call, unlike ag_ui_adk/strands) so it does not collide with the sibling shared-scope render_a2ui fixtures.",
+   "_comment": "pill top-account — LLM calls render_a2ui directly with full component tree.",
    "match": {
     "userMessage": "Pull up the details on our biggest account.",
     "toolName": "render_a2ui",
@@ -153,37 +69,9 @@
    "response": {
     "toolCalls": [
      {
-      "id": "call_d6_decl_acct_design_001",
+      "id": "call_d6_langroid_decl_acct_001_render",
       "name": "render_a2ui",
       "arguments": "{\"surfaceId\":\"biggest-account-details\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Row\",\"gap\":16,\"children\":[\"account-card\",\"revenue-pie\"]},{\"id\":\"account-card\",\"component\":\"Card\",\"title\":\"Meridian Apparel Group\",\"subtitle\":\"Biggest account\",\"child\":\"account-facts\"},{\"id\":\"account-facts\",\"component\":\"Column\",\"gap\":8,\"children\":[\"fact1\",\"fact2\",\"fact3\",\"fact4\",\"fact5\",\"fact6\",\"fact7\"]},{\"id\":\"fact1\",\"component\":\"InfoRow\",\"label\":\"Owner\",\"value\":\"Dana Whitfield\"},{\"id\":\"fact2\",\"component\":\"InfoRow\",\"label\":\"Region\",\"value\":\"North America\"},{\"id\":\"fact3\",\"component\":\"InfoRow\",\"label\":\"ARR\",\"value\":\"$612k\"},{\"id\":\"fact4\",\"component\":\"InfoRow\",\"label\":\"Renewal date\",\"value\":\"Sep 30\"},{\"id\":\"fact5\",\"component\":\"InfoRow\",\"label\":\"Last contact\",\"value\":\"3 days ago\"},{\"id\":\"fact6\",\"component\":\"InfoRow\",\"label\":\"Health\",\"value\":\"Green\"},{\"id\":\"fact7\",\"component\":\"InfoRow\",\"label\":\"Open opportunities\",\"value\":\"4 opportunities worth $210k\"},{\"id\":\"revenue-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by product line\",\"description\":\"Meridian Apparel Group revenue mix across product lines.\",\"data\":[{\"label\":\"Outerwear\",\"value\":260000},{\"label\":\"Footwear\",\"value\":180000},{\"label\":\"Accessories\",\"value\":112000},{\"label\":\"Custom\",\"value\":60000}]}]}"
-     }
-    ]
-   },
-   "chunkSize": 9999
-  },
-  {
-   "_comment": "pill top-account — outer agent narration after generate_a2ui returns.",
-   "match": {
-    "context": "langroid",
-    "toolCallId": "call_d6_decl_acct_outer_001"
-   },
-   "response": {
-    "content": "Here's the rundown on Meridian Apparel Group."
-   },
-   "chunkSize": 9999
-  },
-  {
-   "_comment": "pill top-account — outer agent emits generate_a2ui (no args).",
-   "match": {
-    "userMessage": "Pull up the details on our biggest account.",
-    "context": "langroid"
-   },
-   "response": {
-    "toolCalls": [
-     {
-      "id": "call_d6_decl_acct_outer_001",
-      "name": "generate_a2ui",
-      "arguments": "{}"
      }
     ]
    },

--- a/showcase/integrations/langroid/src/agents/agent.py
+++ b/showcase/integrations/langroid/src/agents/agent.py
@@ -24,13 +24,11 @@ aligned.
 # @region[weather-tool-backend]
 from __future__ import annotations
 
-import contextvars
-import functools
 import json
 import logging
 import os
 from enum import Enum
-from typing import Annotated, Any, Literal, Protocol, TypedDict, cast
+from typing import Annotated, Any, Literal
 
 # Module-local binding for json.dumps. Tests that need to inject
 # serialization failures (RecursionError / MemoryError / etc.) patch THIS
@@ -45,7 +43,6 @@ _json_dumps = json.dumps
 import langroid as lr
 import langroid.language_models as lm
 from langroid.agent.tool_message import ToolMessage
-from pydantic import ValidationError
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -62,554 +59,7 @@ from tools import (
     get_sales_todos_impl,
     schedule_meeting_impl,
     search_flights_impl,
-    build_a2ui_operations_from_tool_call,
 )
-
-
-# =====================================================================
-# A2UI planner LLM — provider-agnostic
-# =====================================================================
-#
-# The secondary LLM that emits the A2UI schema is routed through langroid's
-# own LLM abstraction (``lm.OpenAIGPT``, which despite the historical name
-# handles OpenAI / Anthropic / Gemini / any ``provider/model`` chat-model
-# string). That way this package stays provider-agnostic: whatever
-# ``LANGROID_MODEL`` the operator picks for the primary chat agent, the A2UI
-# planner inherits by default. Operators can override only the planner via
-# ``A2UI_MODEL`` without touching the primary agent.
-#
-# Sibling implementations live in
-# ``showcase/integrations/google-adk/src/agents/main.py`` (Gemini-native) and
-# ``showcase/integrations/strands/src/agents/agent.py`` (OpenAI-only). Keep the
-# error-surface shape (_A2uiError) consistent across all three so the
-# frontend renderer treats them identically.
-
-
-class _A2uiErrorKind(str, Enum):
-    """Closed set of known A2UI planner error kinds.
-
-    Using an Enum (str-valued so JSON serialization stays stable) lets us
-    catch typos at static-analysis time and gives tests a single place to
-    enumerate the valid set. Kept as ``str``-subclass so the serialized
-    JSON shape is identical to the previous bare-string contract.
-    """
-
-    LLM_ERROR = "a2ui_llm_error"
-    NO_TOOL_CALL = "a2ui_no_tool_call"
-    INVALID_ARGUMENTS = "a2ui_invalid_arguments"
-
-
-class _A2uiError(TypedDict):
-    """Shape of the structured error dict returned by generate_a2ui branches.
-
-    Every error branch MUST populate all three keys so callers (and the LLM
-    summarizing the tool result) see a consistent surface.
-
-    NOTE: Identical TypedDicts live in
-    ``showcase/integrations/google-adk/src/agents/main.py`` and
-    ``showcase/integrations/strands/src/agents/agent.py``. Keep all three in
-    sync — any key additions / removals must land in every sibling so the
-    A2UI error surface stays consistent across showcase adapters.
-    """
-
-    # Synthesized from ``_A2uiErrorKind`` (Python 3.11+ ``Literal[*tuple(...)]``
-    # unpacking) so the Literal and the enum can never drift out of sync.
-    # Add/remove a kind in the enum above and the TypedDict follows automatically.
-    error: Literal[*tuple(k.value for k in _A2uiErrorKind)]  # type: ignore[misc]
-    message: str
-    remediation: str
-
-
-class _A2uiSuccess(TypedDict):
-    """Shape of the successful generate_a2ui return value.
-
-    Mirrors what ``build_a2ui_operations_from_tool_call`` produces: a single
-    key ``a2ui_operations`` mapping to a list of operation dicts. Defining
-    the shape here (rather than ``dict[str, Any]``) lets type-checkers flag
-    accidental key renames and keeps the public contract documented next to
-    the error surface.
-    """
-
-    a2ui_operations: list[dict[str, Any]]
-
-
-def _a2ui_error(*, error: _A2uiErrorKind, message: str, remediation: str) -> _A2uiError:
-    """Construct and contract-check an ``_A2uiError``.
-
-    Centralizing construction lets us enforce at runtime that every error
-    return from the A2UI planner carries all three required keys with
-    non-empty string values. Typos ("remediaton") or accidental omissions
-    blow up here rather than silently produce a malformed error surface.
-
-    ``error`` is the ``_A2uiErrorKind`` enum (not a raw string) so call sites
-    cannot invent new error codes and bypass the closed set. The factory
-    extracts ``.value`` internally; callers pass the enum directly.
-
-    Raises ``ValueError`` (not ``assert``) so ``python -O`` can't strip the
-    validation in production. Also rejects non-string values for
-    ``message`` / ``remediation`` — the TypedDict annotation says ``str``
-    and runtime must match, otherwise callers can accidentally slip lists
-    or dicts through and break the frontend contract.
-    """
-    err: _A2uiError = {
-        "error": error.value,
-        "message": message,
-        "remediation": remediation,
-    }
-    missing = [k for k in ("error", "message", "remediation") if not err.get(k)]
-    if missing:
-        raise ValueError(
-            f"_a2ui_error missing required non-empty keys: {missing}; got {err!r}"
-        )
-    bad_types = [
-        k for k in ("error", "message", "remediation") if not isinstance(err[k], str)
-    ]
-    if bad_types:
-        raise ValueError(
-            f"_a2ui_error requires str values for keys {bad_types}; got {err!r}"
-        )
-    return err
-
-
-def _resolve_a2ui_model() -> str:
-    """Resolve the A2UI planner's chat_model string.
-
-    Resolution order:
-      1. ``A2UI_MODEL`` — planner-only override.
-      2. ``LANGROID_MODEL`` — inherits from the primary agent's model.
-      3. Default ``gpt-4.1`` (bare OpenAI name — matches ``create_agent``
-         below). NOTE: langroid does NOT strip the ``openai/`` prefix —
-         it passes the model string LITERALLY to the OpenAI SDK, which
-         rejects ``openai/gpt-4.1`` as "model not found". The canonical
-         langroid convention (and ``OpenAIChatModel.GPT4_1.value``) is
-         the bare name.
-    """
-    return os.getenv("A2UI_MODEL") or os.getenv("LANGROID_MODEL") or "gpt-4.1"
-
-
-# Memoize the A2UI planner LLM so we don't rebuild ``OpenAIGPT`` (and re-run
-# credential resolution) on every request. Keyed on the resolved model string
-# so env overrides produce distinct entries. ``maxsize=4`` is intentional: in
-# production the resolved model is effectively constant, so the cache only
-# needs to cover test churn — tests that patch across more distinct models
-# should call ``_get_a2ui_llm.cache_clear()`` rather than rely on identity.
-@functools.lru_cache(maxsize=4)
-def _get_a2ui_llm(model: str) -> lm.OpenAIGPT:
-    """Return a memoized langroid LLM bound to the given chat_model string.
-
-    Callers must resolve the model first (see ``_resolve_a2ui_model``) and
-    pass it in explicitly; the cache is keyed on ``model`` so env changes
-    produce distinct instances rather than silently returning a stale one.
-    ``maxsize=4`` — the 5th distinct model evicts the least-recently-used
-    entry (see block comment above for rationale). Call ``.cache_clear()``
-    in tests that need to reset memoization.
-    """
-    config = lm.OpenAIGPTConfig(
-        chat_model=model,
-        # Non-streaming for the planner: we need the full tool call before
-        # we can emit operations. Streaming here is wasted work.
-        stream=False,
-    )
-    return lm.OpenAIGPT(config)
-
-
-# The render_a2ui function the planner is forced to call. Kept here (not
-# imported from shared/) because the shape is OpenAI-compatible regardless
-# of which provider langroid's ``OpenAIGPT`` is talking to — langroid
-# normalizes the forced-function-call across providers.
-_RENDER_A2UI_FUNCTION_SPEC = lm.LLMFunctionSpec(
-    name="render_a2ui",
-    description="Render a dynamic A2UI v0.9 surface.",
-    parameters={
-        "type": "object",
-        "properties": {
-            "surfaceId": {"type": "string"},
-            "catalogId": {"type": "string"},
-            "components": {"type": "array", "items": {"type": "object"}},
-            "data": {"type": "object"},
-        },
-        "required": ["surfaceId", "catalogId", "components"],
-    },
-)
-
-# The same spec expressed as a MODERN tool spec (``tools=[...]`` +
-# ``tool_choice=...``) rather than the legacy ``functions=[...]`` +
-# ``function_call=...`` API. This matters for the aimock replay path: the
-# fixture router discriminates the inner planner call from the outer agent
-# call via the ``toolName`` matcher, which inspects the request's
-# ``tools[]`` array — the legacy ``functions[]`` field is invisible to it,
-# so a legacy-API inner call would fall through to the outer
-# ``generate_a2ui`` fixture (yielding an empty surface). Emitting the tool
-# via ``tools[]`` puts ``render_a2ui`` where the matcher looks. langroid's
-# response extractor already reads the modern ``oai_tool_calls`` path first
-# (see ``_extract_tool_call_arguments``), so nothing downstream changes.
-_RENDER_A2UI_TOOL_SPEC = lm.base.OpenAIToolSpec(
-    type="function",
-    function=_RENDER_A2UI_FUNCTION_SPEC,
-)
-
-
-class _LLMResponseLike(Protocol):
-    """Structural type for the subset of ``LLMResponse`` we read.
-
-    Defined as a Protocol (rather than importing langroid's concrete type)
-    so the extractor is trivially unit-testable with a fake object and the
-    signature documents exactly which attributes matter.
-    """
-
-    oai_tool_calls: Any
-    function_call: Any
-
-
-# Sentinel: distinct from ``None`` so the caller can tell "no tool call at all"
-# (returned as ``None``) from "tool-call shape present but ``arguments`` field
-# was ``None``" (returned as this sentinel). The two cases have different
-# remediations — see ``generate_a2ui_via_llm``.
-_ARGS_MISSING: object = object()
-
-
-def _extract_tool_call_arguments(
-    response: _LLMResponseLike,
-) -> dict[str, Any] | str | None | object:
-    """Pull the planner's tool-call arguments out of an ``LLMResponse``.
-
-    Handles both shapes langroid exposes:
-      - ``oai_tool_calls[0].function.arguments`` — modern tool-calling path.
-      - ``function_call.arguments`` — legacy path used by some providers.
-
-    Returns:
-      - ``dict`` or ``str`` (JSON) — the raw arguments value to parse/use.
-      - ``None`` — no tool call was produced at all (→ ``a2ui_no_tool_call``).
-      - ``_ARGS_MISSING`` — a tool-call slot was present but its ``arguments``
-        field was missing/None (→ ``a2ui_invalid_arguments``; the planner
-        DID try to call but emitted a degraded shape, so "no tool call"
-        remediation would be misleading).
-
-    Logs a WARN for every shape-drift case so operators can diagnose
-    langroid / provider-SDK regressions without strace-ing tests.
-    """
-    tool_calls = getattr(response, "oai_tool_calls", None)
-    saw_modern_call = False
-    if tool_calls:
-        # Non-empty ``tool_calls`` list always counts as "planner attempted
-        # a modern-slot call" — even when ``.function`` is None (degraded
-        # shape). Without this, ``.function is None`` + no legacy
-        # ``function_call`` returns plain ``None``, which the caller maps
-        # to ``NO_TOOL_CALL``. But the planner DID try to call in the
-        # modern slot; the correct remediation is ``INVALID_ARGUMENTS``
-        # (symmetric with the ``.function.arguments is None`` case below).
-        saw_modern_call = True
-        if len(tool_calls) > 1:
-            # Forced function-call should produce exactly one tool call;
-            # multiple is unexpected and we pick index 0 silently today.
-            # Logging it makes the truncation visible rather than mysterious.
-            logger.warning(
-                "generate_a2ui_via_llm: planner returned %d tool calls; "
-                "using index 0 only",
-                len(tool_calls),
-            )
-        first = tool_calls[0]
-        func = getattr(first, "function", None)
-        if func is not None:
-            args = getattr(func, "arguments", None)
-            if args is not None:
-                return args
-            # Degraded shape: the modern slot has no arguments. Log and
-            # fall through to the legacy function_call path — providers
-            # occasionally put the forced call in the legacy slot even
-            # when the modern slot is present but empty.
-            logger.warning(
-                "generate_a2ui_via_llm: tool_call.function present but "
-                ".arguments is None (response-shape drift?)"
-            )
-        else:
-            # Degraded shape: tool_calls[0].function is None. Log and fall
-            # through to the legacy function_call path — some providers put
-            # the forced call in the legacy slot.
-            logger.warning(
-                "generate_a2ui_via_llm: tool_call present but .function is None "
-                "(response-shape drift?)"
-            )
-
-    function_call = getattr(response, "function_call", None)
-    if function_call is not None:
-        args = getattr(function_call, "arguments", None)
-        if args is None:
-            # Legacy slot is present but its ``arguments`` field is missing.
-            # Symmetric with the modern-slot warning above, and flagged as
-            # INVALID_ARGUMENTS (not NO_TOOL_CALL) via the sentinel so the
-            # caller emits the correct remediation.
-            logger.warning(
-                "generate_a2ui_via_llm: function_call present but .arguments "
-                "is None (response-shape drift?)"
-            )
-            return _ARGS_MISSING
-        return args
-
-    # No legacy slot. If we saw a modern tool-call structure but its
-    # arguments were empty, surface that as _ARGS_MISSING so the caller
-    # emits a2ui_invalid_arguments rather than a2ui_no_tool_call.
-    if saw_modern_call:
-        return _ARGS_MISSING
-
-    return None
-
-
-# The last user turn of the current run, stashed here by the AG-UI adapter
-# (``handle_run``) so the secondary A2UI planner LLM can thread it as the
-# inner ``render_a2ui`` call's user message. The sibling google-adk /
-# strands backends get this for free because their framework middleware
-# (``ag_ui_adk`` / ``ag_ui_strands``) forwards the run's conversation into
-# the inner call — so aimock matches the inner planner call on the pill
-# prompt (the generic render guidance rides as the system prompt). Langroid
-# has no such middleware, so we thread it explicitly. A ContextVar (not a
-# module global) so concurrent requests on the shared worker don't clobber
-# each other; ``asyncio.to_thread`` copies the context into the worker
-# thread, so the value set in the request coroutine is visible inside the
-# backend tool's ``.handle()``.
-_LAST_USER_MESSAGE: contextvars.ContextVar[str] = contextvars.ContextVar(
-    "a2ui_last_user_message", default=""
-)
-
-
-def set_last_user_message(text: str) -> None:
-    """Record the current run's last user turn for the A2UI planner.
-
-    Called by the AG-UI adapter at the top of a run. Best-effort: an empty
-    or missing value simply falls back to the generic inner prompt below.
-    """
-    _LAST_USER_MESSAGE.set(text or "")
-
-
-def generate_a2ui_via_llm(*, context: str) -> _A2uiError | _A2uiSuccess:
-    """Run the A2UI planner LLM and return either operations or a structured
-    error.
-
-    Provider-agnostic: routes through ``lm.OpenAIGPT`` (langroid's universal
-    LLM abstraction) so whatever provider the operator configured via
-    ``LANGROID_MODEL`` / ``A2UI_MODEL`` is used. No direct provider-SDK
-    imports live in this module.
-
-    Error surface is the shared ``_A2uiError`` TypedDict (see sibling
-    google-adk / strands implementations).
-    """
-    system_prompt = context or "Generate a useful dashboard UI."
-    # Thread the run's last user turn (the pill prompt) as the inner call's
-    # user message so aimock's dynamic-schema fixtures can discriminate the
-    # per-pill surface by ``userMessage`` — matching the sibling backends'
-    # framework-forwarded behavior. Fall back to the generic guidance string
-    # when no user turn is available (e.g. programmatic invocation / tests).
-    user_message = (
-        _LAST_USER_MESSAGE.get()
-        or "Generate a dynamic A2UI dashboard based on the conversation."
-    )
-    messages = [
-        lm.LLMMessage(role=lm.Role.SYSTEM, content=system_prompt),
-        lm.LLMMessage(
-            role=lm.Role.USER,
-            content=user_message,
-        ),
-    ]
-
-    # Wrap the LLM call so expected transport / auth / rate-limit failures
-    # do not bubble up through langroid's tool machinery as uncaught
-    # exceptions.
-    #
-    # We explicitly re-raise the narrow class of structural / programmer
-    # bugs (AttributeError, TypeError, NameError, ImportError,
-    # ModuleNotFoundError, AssertionError, NotImplementedError,
-    # pydantic.ValidationError). Those indicate real bugs and must surface
-    # to tests and server logs rather than be reported as "verify provider
-    # credentials" — the remediation in ``a2ui_llm_error`` is wrong for
-    # those classes (e.g. a missing ``anthropic`` package is an install
-    # problem, not a credentials problem; a pydantic validation failure is
-    # a schema bug, not a transport failure).
-    #
-    # Intentionally NOT re-raised (so they flow into the transport-error
-    # path): KeyError, IndexError, LookupError, RecursionError, MemoryError.
-    # The SDK / adapter stack raises these as recoverable conditions on
-    # malformed provider payloads, and swallowing them into the structured
-    # error surface gives callers the correct "retry / check provider"
-    # remediation rather than an uncaught 500.
-    try:
-        llm = _get_a2ui_llm(_resolve_a2ui_model())
-        response = llm.chat(
-            messages=messages,
-            tools=[_RENDER_A2UI_TOOL_SPEC],
-            tool_choice={"type": "function", "function": {"name": "render_a2ui"}},
-        )
-    except (
-        AttributeError,
-        TypeError,
-        NameError,
-        ImportError,
-        ModuleNotFoundError,
-        AssertionError,
-        NotImplementedError,
-        ValidationError,
-    ):
-        # Programmer / environment bugs — propagate so tests & server logs
-        # catch them instead of producing a misleading "verify credentials"
-        # remediation.
-        raise
-    except Exception as exc:  # noqa: BLE001 — see rationale above
-        logger.exception("generate_a2ui_via_llm: LLM call failed")
-        # Include a truncated str(exc) so ConnectionError("backend unreachable")
-        # and similar transport failures surface the actionable substring.
-        # We truncate regardless of provider SDK behavior — bounds the blast
-        # radius of any future regression where an SDK embeds credentials
-        # in exception messages.
-        exc_detail = str(exc)[:200] if str(exc) else ""
-        message = f"Secondary A2UI LLM call failed: {exc.__class__.__name__}"
-        if exc_detail:
-            message = f"{message}: {exc_detail}"
-        return _a2ui_error(
-            error=_A2uiErrorKind.LLM_ERROR,
-            message=message,
-            remediation=(
-                "Verify the provider credentials required by LANGROID_MODEL / "
-                "A2UI_MODEL are set and the provider is reachable. "
-                "See server logs for the full traceback."
-            ),
-        )
-
-    raw_args = _extract_tool_call_arguments(response)
-    if raw_args is None:
-        logger.warning(
-            "generate_a2ui_via_llm: planner did not emit a render_a2ui tool call"
-        )
-        return _a2ui_error(
-            error=_A2uiErrorKind.NO_TOOL_CALL,
-            message="Secondary A2UI LLM did not call render_a2ui.",
-            remediation=(
-                "Retry the request. If this persists, verify the planner model "
-                "supports forced function-calling."
-            ),
-        )
-    if raw_args is _ARGS_MISSING:
-        # Distinct from NO_TOOL_CALL: the planner DID produce a tool-call
-        # shape but its ``arguments`` field was missing/None. "Supports
-        # forced function-calling" is the wrong remediation here — the
-        # actionable fix is to retry (transient) or investigate a
-        # response-shape regression in the provider SDK.
-        return _a2ui_error(
-            error=_A2uiErrorKind.INVALID_ARGUMENTS,
-            message=(
-                "Secondary A2UI LLM emitted a tool-call with no arguments payload."
-            ),
-            remediation=(
-                "Retry the request; if this persists, check server logs for a "
-                "response-shape drift warning from the provider SDK."
-            ),
-        )
-
-    # langroid usually pre-parses tool arguments into a dict, but some
-    # provider adapters surface them as a JSON string. Handle both shapes.
-    if isinstance(raw_args, str):
-        try:
-            args = json.loads(raw_args)
-        # MemoryError / RecursionError can fire on pathological payloads
-        # (multi-MB JSON, deeply-nested structures). Parity with
-        # ``GenerateA2UITool.handle``'s widened catch — we'd rather surface
-        # a structured INVALID_ARGUMENTS than let these bubble up as an
-        # uncaught 500.
-        except (ValueError, TypeError, MemoryError, RecursionError) as exc:
-            logger.exception(
-                "generate_a2ui_via_llm: failed to parse render_a2ui arguments as JSON"
-            )
-            # Truncate ``str(exc)`` — parity with the LLM-error path and
-            # defense against multi-KB raw LLM payloads leaking into the
-            # structured error surface.
-            return _a2ui_error(
-                error=_A2uiErrorKind.INVALID_ARGUMENTS,
-                message=f"Could not parse render_a2ui arguments: {str(exc)[:200]}",
-                remediation=(
-                    "Retry the request; the secondary LLM emitted malformed JSON."
-                ),
-            )
-    else:
-        args = raw_args
-
-    if not isinstance(args, dict):
-        logger.warning(
-            "generate_a2ui_via_llm: render_a2ui arguments parsed to %s (not dict)",
-            type(args).__name__,
-        )
-        return _a2ui_error(
-            error=_A2uiErrorKind.INVALID_ARGUMENTS,
-            message=(
-                f"render_a2ui arguments must be a JSON object, got "
-                f"{type(args).__name__}."
-            ),
-            remediation="Retry the request; the secondary LLM emitted a non-object payload.",
-        )
-
-    # ``build_a2ui_operations_from_tool_call`` can raise if required keys
-    # are missing or values aren't serializable. Without this guard, an
-    # upstream schema change (planner LLM returns a slightly-wrong shape)
-    # produces a 500 and bypasses the structured-error contract the
-    # frontend relies on.
-    try:
-        result = build_a2ui_operations_from_tool_call(args)
-    # Widened to match the ``GenerateA2UITool.handle`` transport-path wrapper
-    # and the str-arg ``json.loads`` wrapper above: IndexError / AttributeError
-    # / LookupError can fire on malformed or partial payloads (planner emits a
-    # dict missing a list slot; provider SDK returns a sparse attribute) and
-    # must NOT escape into langroid's tool-handling stack. Narrow catches here
-    # produced a 500 that bypassed the structured-error contract the frontend
-    # relies on.
-    except (
-        KeyError,
-        ValueError,
-        TypeError,
-        IndexError,
-        AttributeError,
-        LookupError,
-    ) as exc:
-        logger.exception(
-            "generate_a2ui_via_llm: build_a2ui_operations_from_tool_call failed"
-        )
-        return _a2ui_error(
-            error=_A2uiErrorKind.INVALID_ARGUMENTS,
-            message=f"Could not build A2UI operations: {exc.__class__.__name__}",
-            remediation=(
-                "Retry with a simpler A2UI design or check the LLM-emitted schema."
-            ),
-        )
-
-    # Defense-in-depth: the shared helper is contracted to return
-    # ``{"a2ui_operations": [...]}`` but a shape regression upstream
-    # (e.g. accidental ``None`` or dict without the key) would otherwise
-    # bypass ``_A2uiSuccess`` and break the frontend renderer silently.
-    if (
-        not isinstance(result, dict)
-        or "a2ui_operations" not in result
-        or not isinstance(result["a2ui_operations"], list)
-    ):
-        # Include the first-20 sorted keys when the result IS a dict so
-        # operators can tell "wrong key name" (e.g. planner emitted
-        # ``operations`` instead of ``a2ui_operations``) from "wrong type".
-        # The type name alone doesn't give enough signal to diagnose.
-        result_keys: list[str] | None = (
-            sorted(str(k) for k in result.keys())[:20]
-            if isinstance(result, dict)
-            else None
-        )
-        logger.error(
-            "build_a2ui_operations_from_tool_call returned unexpected shape: "
-            "type=%s keys=%r",
-            type(result).__name__,
-            result_keys,
-        )
-        return _a2ui_error(
-            error=_A2uiErrorKind.INVALID_ARGUMENTS,
-            message="A2UI builder returned invalid shape.",
-            remediation=(
-                "Upstream `build_a2ui_operations_from_tool_call` returned an "
-                "unexpected result; check shared/python/tools."
-            ),
-        )
-    return cast(_A2uiSuccess, result)
 
 
 # =====================================================================
@@ -625,10 +75,6 @@ class _ToolErrorKind(str, Enum):
     ``"get_wether_failed"`` that ship silently through free-form strings.
     Values match the historical bare-string codes so the serialized JSON
     shape is identical to the previous contract.
-
-    Mirrors ``_A2uiErrorKind`` — both enums live in this module for the
-    same reason: closed-set typing for the error surface the outer LLM
-    consumes.
     """
 
     GET_WEATHER_FAILED = "get_weather_failed"
@@ -821,57 +267,27 @@ class SearchFlightsTool(ToolMessage):
 class GenerateA2UITool(ToolMessage):
     request: str = "generate_a2ui"
     purpose: str = (
-        "Generate dynamic A2UI components based on the conversation. "
-        "A secondary LLM designs the UI schema and data."
+        "Generate dynamic A2UI components based on the conversation context. "
+        "Call with no arguments — the CopilotKit runtime middleware intercepts "
+        "this call and drives the render_a2ui design pass itself (Option A: "
+        "JS-injected A2UI). If handle() fires, the middleware interception "
+        "regressed."
     )
-    # Optional (default "") so a no-arg tool call — ``arguments: {}`` —
-    # validates. The two-stage A2UI pattern's outer tool takes no meaningful
-    # arguments: the surface design happens entirely inside the secondary
-    # planner LLM (see ``generate_a2ui_via_llm``), which is steered by the
-    # frontend App Context (sales-context.ts) serialized into its system
-    # prompt, not by an outer-supplied ``context`` string. Making this
-    # required forced the outer LLM (and aimock's outer fixture, which emits
-    # ``{}``) to supply a value or fail pydantic ValidationError before the
-    # tool could run — the root cause of the turn-1 surface-missing failure.
-    # Mirrors the sibling google-adk / strands outer tools, which are no-arg.
-    context: str = ""
 
     def handle(self) -> str:
-        # Delegate to the provider-agnostic planner. `generate_a2ui_via_llm`
-        # returns either the successful `a2ui_operations` dict or a
-        # structured `_A2uiError` — both shapes are JSON-serializable and
-        # are surfaced verbatim to the outer langroid agent (and thereby
-        # the frontend A2UI renderer).
-        result = generate_a2ui_via_llm(context=self.context)
-        try:
-            return _json_dumps(result)
-        except (TypeError, ValueError, OverflowError, RecursionError) as exc:
-            # Defensive: generate_a2ui_via_llm returns dicts by contract,
-            # but if an upstream change ever returns a non-serializable
-            # value we want a structured error rather than an uncaught
-            # exception bubbling through langroid's tool machinery.
-            # OverflowError covers NaN/inf floats; RecursionError covers
-            # cyclic structures — both raised by ``json.dumps`` and not
-            # subclasses of ``TypeError`` / ``ValueError``.
-            logger.exception("GenerateA2UITool.handle: json.dumps failed")
-            # Use the stdlib json.dumps directly here (not _json_dumps) so
-            # the structured-error dump still succeeds when tests patch
-            # _json_dumps to simulate a RecursionError on the success path.
-            # Tests for this branch bind their side_effect to _json_dumps
-            # only; the raw ``json.dumps`` remains callable and produces a
-            # parseable error envelope for the frontend.
-            return json.dumps(
-                _a2ui_error(
-                    error=_A2uiErrorKind.INVALID_ARGUMENTS,
-                    message=(
-                        f"Could not serialize A2UI result: {exc.__class__.__name__}"
-                    ),
-                    remediation=(
-                        "This indicates an upstream planner contract bug; "
-                        "see server logs."
-                    ),
-                )
-            )
+        # Option A: the CopilotKit runtime A2UIMiddleware should intercept
+        # generate_a2ui BEFORE it reaches the Python backend and drive the
+        # secondary render_a2ui LLM pass itself. If we are here, the
+        # middleware interception regressed. Log loudly so the regression
+        # surfaces in server logs.
+        logger.error(
+            "GenerateA2UITool.handle fired server-side — A2UIMiddleware "
+            "interception regression; generate_a2ui should be intercepted "
+            "by the JS runtime before reaching Python."
+        )
+        return _json_dumps(
+            {"error": "generate_a2ui reached Python backend (middleware regression)"}
+        )
 
 
 # Tools that execute server-side (Langroid handles them directly)
@@ -903,7 +319,7 @@ FRONTEND_TOOL_NAMES: frozenset[str] = frozenset(
 # raises at import time rather than at request time.
 #
 # Uses ``raise RuntimeError`` (not ``assert``) so ``python -O`` can't strip
-# the check in production — same reasoning as ``_a2ui_error`` above.
+# the check in production.
 _EXPECTED_FRONTEND_TOOL_NAMES = frozenset(
     {"change_background", "generate_haiku", "schedule_meeting"}
 )
@@ -942,8 +358,6 @@ def create_agent(system_message: str | None = None) -> lr.ChatAgent:
     Default model is the bare ``gpt-4.1`` (not ``openai/gpt-4.1``): langroid
     does NOT strip the ``openai/`` prefix before passing the string to the
     OpenAI SDK, and the SDK rejects ``openai/gpt-4.1`` as "model not found".
-    See ``_resolve_a2ui_model`` for the same reasoning on the planner
-    default.
 
     ``system_message`` — optional override for the agent's system prompt.
     Used by the Agent Config Object demo to steer tone / expertise /

--- a/showcase/integrations/langroid/src/agents/agui_adapter.py
+++ b/showcase/integrations/langroid/src/agents/agui_adapter.py
@@ -50,7 +50,6 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from agents.agent import (
     build_agent_config_system_prompt,
     extract_agent_config_properties,
-    set_last_user_message,
     ALL_TOOLS,
     FRONTEND_TOOL_NAMES,
     SYSTEM_PROMPT,
@@ -526,22 +525,39 @@ async def handle_run(request: Request) -> StreamingResponse:
     model = os.getenv("LANGROID_MODEL", "gpt-4.1")
     oai_tools = _get_openai_tools()
 
-    # Thread the last user turn to the A2UI planner (see
-    # ``set_last_user_message``). The ``generate_a2ui`` backend tool uses it
-    # as the inner ``render_a2ui`` call's user message so aimock's
-    # dynamic-schema fixtures can discriminate the surface per pill prompt —
-    # matching the framework-forwarded behavior of the sibling google-adk /
-    # strands backends. Best-effort: no user turn → the planner falls back to
-    # its generic prompt. Set unconditionally (including "") so a prior run's
-    # value on this worker's context cannot leak into a run with no user turn.
-    _last_user_text = ""
-    for _m in reversed(oai_messages):
-        if _m.get("role") == "user":
-            _content = _m.get("content")
-            if isinstance(_content, str) and _content:
-                _last_user_text = _content
-            break
-    set_last_user_message(_last_user_text)
+    # Merge in any tools injected by the AG-UI middleware (e.g. ``render_a2ui``
+    # added by A2UIMiddleware when injectA2UITool is enabled). The langroid
+    # adapter builds its tool list from Python-side ALL_TOOLS, which doesn't
+    # include runtime-injected tools. Without this merge, the LLM never sees
+    # ``render_a2ui`` in its tools list and can't call it directly (Option A).
+    #
+    # RunAgentInput.tools uses ag_ui.core.Tool (name/description/parameters),
+    # so we convert each injected entry to the OpenAI {"type": "function", ...}
+    # shape. Only tools NOT already in the Python-built list are appended so
+    # there are no duplicates.
+    _known_tool_names = {t["function"]["name"] for t in oai_tools}
+    for agui_tool in run_input.tools or []:
+        if agui_tool.name not in _known_tool_names:
+            params: dict[str, Any] = (
+                agui_tool.parameters if isinstance(agui_tool.parameters, dict) else {}
+            )
+            oai_tools = oai_tools + [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": agui_tool.name,
+                        "description": agui_tool.description
+                        or f"Tool: {agui_tool.name}",
+                        "parameters": params
+                        if params
+                        else {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+            _known_tool_names.add(agui_tool.name)
+            logger.debug(
+                "Merged AG-UI-injected tool into OpenAI tool list: %s", agui_tool.name
+            )
 
     # Compute the effective thread_id ONCE so every event emitted for this
     # run (RUN_STARTED, RUN_FINISHED, ...) references the same thread.

--- a/showcase/integrations/langroid/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -1,13 +1,17 @@
 // Dedicated runtime for the Declarative Generative UI (A2UI) cell (Langroid).
 //
-// The unified Langroid agent already owns a `generate_a2ui` tool (see
-// src/agents/agent.py -> GenerateA2UITool). We route this demo here so we
-// can set `a2ui.injectA2UITool: false` — the runtime must NOT auto-inject
-// its own A2UI tool on top of the agent-owned one.
+// Option A (JS-runtime-injected A2UI): `injectA2UITool` defaults to true so
+// the CopilotKit runtime middleware intercepts the agent's no-arg
+// `generate_a2ui` toolcall and drives the secondary `render_a2ui` LLM pass
+// itself, emitting `a2ui_operations` that the frontend renderer paints.
+// The backend (see src/agents/agent.py -> GenerateA2UITool) wires a no-arg
+// stub that raises loudly if called directly — the middleware should always
+// intercept before it reaches Python.
 //
-// The A2UI middleware still runs: it serialises the registered client
-// catalog into the agent's context so the secondary LLM inside
-// `generate_a2ui` knows which components to emit.
+// `defaultCatalogId` pins the catalog the page registers so the middleware's
+// secondary-LLM pass uses the correct component set (models that follow the
+// tool-usage guide and omit `catalogId` would otherwise fall back to the
+// unregistered spec basic catalog, giving a "Catalog not found" render error).
 
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
@@ -26,7 +30,6 @@ const runtime = new CopilotRuntime({
   // @ts-ignore -- see main route.ts
   agents: { "declarative-gen-ui": declarativeGenUiAgent },
   a2ui: {
-    injectA2UITool: false,
     // Models follow the tool-usage guide and omit `catalogId`, and the
     // middleware then falls back to the unregistered spec basic catalog
     // ("Catalog not found" render error). Pin the catalog the page registers.

--- a/showcase/integrations/langroid/tests/python/test_generate_a2ui.py
+++ b/showcase/integrations/langroid/tests/python/test_generate_a2ui.py
@@ -1,32 +1,22 @@
-"""Unit tests for langroid's A2UI planner.
+"""Unit tests for langroid's GenerateA2UITool and tool infrastructure.
 
-Sibling tests to ``showcase/integrations/google-adk/tests/python/test_generate_a2ui.py``
-and ``showcase/integrations/strands/tests/python/test_generate_a2ui.py``. Covers:
+After Option A (JS-injected A2UI), the two-stage server-side A2UI planner
+(``generate_a2ui_via_llm``, ``_get_a2ui_llm``, ``_resolve_a2ui_model``,
+``_A2uiError``, ``_A2uiErrorKind``, ``_RENDER_A2UI_FUNCTION_SPEC``,
+``_RENDER_A2UI_TOOL_SPEC``, ``_a2ui_error``) has been removed. The
+CopilotKit JS runtime's A2UIMiddleware now intercepts ``generate_a2ui``
+calls before they reach the Python backend and drives the render_a2ui LLM
+pass itself.
 
-- Provider-agnostic LLM routing through langroid's ``OpenAIGPT`` abstraction
-  (which despite the name handles OpenAI / Anthropic / Gemini / any
-  ``provider/model`` chat-model string).
-- ``A2UI_MODEL`` env override takes precedence over ``LANGROID_MODEL``.
-- Structured error surface (``_A2uiError``) for every failure branch:
-    - LLM call raises (transport / auth / rate-limit)
-    - response contains no tool call
-    - response tool-call arguments are malformed JSON
-- Happy path: valid tool call args → ``build_a2ui_operations_from_tool_call``
-- Programmer errors (``AttributeError``, ``TypeError``, ``ImportError``,
-  ``NameError``, ``AssertionError``, ``NotImplementedError``,
-  ``ModuleNotFoundError``, ``pydantic.ValidationError``) propagate — not
-  silently masked as LLM errors. Conversely ``KeyError`` / ``IndexError`` /
-  ``RecursionError`` / ``MemoryError`` / ``LookupError`` are NO LONGER
-  re-raised; they wrap into the structured ``a2ui_llm_error`` surface.
-- Construction must not require OpenAI-specific env when a non-OpenAI
-  ``LANGROID_MODEL`` is configured (provider-agnostic routing).
-- Memoization: the A2UI planner LLM is built once per resolved model string.
-- Structured warning / error log output on the module logger for every
-  degraded / drift path (with message substring assertions).
-
-Mocks live at the langroid-LLM layer (``lm.OpenAIGPT``) rather than at any
-provider SDK layer — the whole point of the provider-agnostic fix is that
-the A2UI planner no longer speaks to any provider SDK directly.
+This file covers:
+- ``_ToolErrorKind`` enum identity (error-code contract with outer LLM).
+- ``GenerateA2UITool.handle()`` Option A: must return a structured error
+  JSON string and log an ERROR (middleware regression guard).
+- Backend tool handle() happy + error paths (6 tools, parametrized).
+- ``create_agent`` factory wiring contract (tools, stream, model).
+- Module hygiene: no top-level openai import; clean subprocess import.
+- Tool-tuples structural contract (BACKEND_TOOLS / FRONTEND_TOOLS /
+  ALL_TOOLS).
 """
 
 from __future__ import annotations
@@ -38,24 +28,14 @@ import logging
 import os
 import subprocess
 import sys
-from dataclasses import dataclass
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from agents.agent import (
-    _A2uiError,
-    _A2uiErrorKind,
-    _RENDER_A2UI_FUNCTION_SPEC,
-    _RENDER_A2UI_TOOL_SPEC,
-    _a2ui_error,
-    _get_a2ui_llm,
-    _resolve_a2ui_model,
     _ToolErrorKind,
-    generate_a2ui_via_llm,
     create_agent,
     ALL_TOOLS,
     BACKEND_TOOLS,
@@ -74,139 +54,7 @@ from langroid.agent.tool_message import ToolMessage
 
 
 # ---------------------------------------------------------------------------
-# Fakes / helpers
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class _FakeFunction:
-    """Typo-safe stand-in for a langroid tool-call ``function`` attribute.
-
-    Dataclass (rather than ``SimpleNamespace``) so typos in field names blow
-    up at construction rather than silently producing a shape that looks
-    right but with a missing attribute.
-    """
-
-    name: str = "render_a2ui"
-    arguments: Any = None
-
-
-@dataclass
-class _FakeOaiToolCall:
-    """Typo-safe stand-in for a langroid ``OaiToolCall``."""
-
-    id: str = "call-1"
-    function: _FakeFunction | None = None
-
-
-@dataclass
-class _FakeFunctionCall:
-    """Typo-safe stand-in for a legacy ``LLMFunctionCall``."""
-
-    name: str = "render_a2ui"
-    arguments: Any = None
-
-
-@dataclass
-class _FakeLLMResponse:
-    """Typo-safe stand-in for langroid's ``LLMResponse``.
-
-    The planner only reads ``.oai_tool_calls`` and ``.function_call`` so those
-    are the only fields we model. Using a dataclass guards against silently
-    adding unused attrs via typo.
-    """
-
-    message: str = ""
-    oai_tool_calls: list | None = None
-    function_call: _FakeFunctionCall | None = None
-
-
-def _llm_response(*, tool_calls=None, function_call=None) -> _FakeLLMResponse:
-    """Build a fake langroid ``LLMResponse``-shaped object."""
-    return _FakeLLMResponse(
-        message="",
-        oai_tool_calls=tool_calls,
-        function_call=function_call,
-    )
-
-
-def _oai_tool_call(*, arguments, call_id: str = "call-1") -> _FakeOaiToolCall:
-    """Build a fake ``OpenAIToolCall``.
-
-    Helper passes the ``arguments`` value through unchanged; callers may
-    supply a dict or a JSON string — both paths are exercised by the tests
-    below.
-    """
-    return _FakeOaiToolCall(
-        id=call_id,
-        function=_FakeFunction(name="render_a2ui", arguments=arguments),
-    )
-
-
-def _function_call(*, arguments) -> _FakeFunctionCall:
-    """Build a fake legacy ``LLMFunctionCall``."""
-    return _FakeFunctionCall(name="render_a2ui", arguments=arguments)
-
-
-@pytest.fixture(autouse=True)
-def _reset_llm_cache():
-    """Clear the memoized A2UI LLM between tests so patched factories are
-    honored freshly each test."""
-    _get_a2ui_llm.cache_clear()
-    yield
-    _get_a2ui_llm.cache_clear()
-
-
-@pytest.fixture(autouse=True)
-def _clean_env(monkeypatch):
-    """Unset A2UI_MODEL / LANGROID_MODEL / OPENAI_* / every provider key
-    between tests so tests don't leak one another's env setup. The provider
-    key set matches what ``_expected_key_for_model`` handles across sibling
-    adapters — keeping them all unset here means a regression in provider
-    routing can't be silently masked by a stray key in the developer's env.
-    """
-    for var in (
-        "A2UI_MODEL",
-        "LANGROID_MODEL",
-        "OPENAI_API_KEY",
-        "OPENAI_BASE_URL",
-        "ANTHROPIC_API_KEY",
-        "GEMINI_API_KEY",
-        "OPENROUTER_API_KEY",
-        "GROQ_API_KEY",
-        "DEEPSEEK_API_KEY",
-        "CEREBRAS_API_KEY",
-        "GLHF_API_KEY",
-        "MINIMAX_API_KEY",
-        "PORTKEY_API_KEY",
-    ):
-        monkeypatch.delenv(var, raising=False)
-    yield
-
-
-# ---------------------------------------------------------------------------
-# _A2uiErrorKind enum identity — pins the error-code contract
-# ---------------------------------------------------------------------------
-
-
-def test_a2ui_error_kind_values_pinned():
-    """The enum ``.value``s are the string contract shared with the
-    frontend renderer and the sibling ``google-adk`` / ``strands`` adapters.
-    Renaming any of these is a cross-sibling breaking change; pin the set
-    here so a regression is caught at unit-test time rather than by an
-    alert from the renderer in production."""
-    assert _A2uiErrorKind.LLM_ERROR.value == "a2ui_llm_error"
-    assert _A2uiErrorKind.NO_TOOL_CALL.value == "a2ui_no_tool_call"
-    assert _A2uiErrorKind.INVALID_ARGUMENTS.value == "a2ui_invalid_arguments"
-    assert {m.value for m in _A2uiErrorKind} == {
-        "a2ui_llm_error",
-        "a2ui_no_tool_call",
-        "a2ui_invalid_arguments",
-    }
-
-
-# ---------------------------------------------------------------------------
-# _ToolErrorKind enum identity — pins the backend-tool error-code contract
+# _ToolErrorKind enum identity — pins the error-code contract
 # ---------------------------------------------------------------------------
 
 
@@ -235,1248 +83,68 @@ def test_tool_error_kind_values_pinned():
 
 
 # ---------------------------------------------------------------------------
-# _a2ui_error contract
+# GenerateA2UITool.handle — Option A contract
 # ---------------------------------------------------------------------------
 
 
-def test_a2ui_error_accepts_full_shape():
-    err = _a2ui_error(error=_A2uiErrorKind.LLM_ERROR, message="m", remediation="r")
-    assert err == {
-        "error": "a2ui_llm_error",
-        "message": "m",
-        "remediation": "r",
-    }
+def test_generate_a2ui_tool_handle_returns_middleware_regression_error(caplog):
+    """Option A: ``GenerateA2UITool.handle()`` must return a JSON-encoded
+    structured error indicating middleware regression. The CopilotKit JS
+    runtime's A2UIMiddleware should intercept ``generate_a2ui`` calls before
+    they ever reach the Python backend. If handle() fires, the interception
+    regressed.
 
-
-def test_a2ui_error_rejects_empty_values():
-    """Empty-string values for message/remediation must blow up at
-    construction time, not silently produce a malformed error surface.
-    ``error`` is the enum now, so the only way to get an empty ``error``
-    value would be to subvert the enum — not a supported use case."""
-    with pytest.raises(ValueError):
-        _a2ui_error(error=_A2uiErrorKind.LLM_ERROR, message="", remediation="r")
-    with pytest.raises(ValueError):
-        _a2ui_error(error=_A2uiErrorKind.LLM_ERROR, message="m", remediation="")
-
-
-def test_a2ui_error_rejects_non_string_message():
-    """The TypedDict annotation says ``str``; the factory must enforce that
-    at runtime. A caller accidentally slipping a list/dict/int into
-    ``message`` would break the frontend's error renderer."""
-    with pytest.raises(ValueError):
-        _a2ui_error(
-            error=_A2uiErrorKind.LLM_ERROR,
-            message=123,
-            remediation="r",  # type: ignore[arg-type]
-        )
-    with pytest.raises(ValueError):
-        _a2ui_error(
-            error=_A2uiErrorKind.LLM_ERROR,
-            message="m",
-            remediation=["r"],  # type: ignore[arg-type]
-        )
-
-
-def _assert_full_error_shape(result: dict) -> None:
-    """Every generate_a2ui error branch must include these three keys and
-    ONLY these three keys (no traceback / stderr / secret leakage)."""
-    assert isinstance(result, dict), f"expected dict, got {type(result).__name__}"
-    # Exactly the three required keys — no extras (catches regressions that
-    # leak tracebacks, stderr, or secret material into error dicts).
-    assert set(result.keys()) == {"error", "message", "remediation"}, (
-        f"unexpected keys in error result: {sorted(result.keys())}"
-    )
-    for key in ("error", "message", "remediation"):
-        assert isinstance(result[key], str) and result[key], (
-            f"'{key}' must be non-empty str; got {result.get(key)!r}"
-        )
-
-
-# ---------------------------------------------------------------------------
-# Happy path
-# ---------------------------------------------------------------------------
-
-
-def test_generate_a2ui_happy_path_returns_operations():
-    """A valid ``oai_tool_calls`` response should be routed through
-    ``build_a2ui_operations_from_tool_call`` and return the operations dict.
-
-    Pins the full op shape — surfaceId / catalogId / components / data —
-    so a regression that swaps args or drops the data-update op is caught.
-    Also asserts the LLM was called with the forced-function-call kwargs
-    so the "the planner forces render_a2ui" contract is pinned.
+    Asserts:
+    - Return value is a JSON string (langroid tool contract).
+    - Parsed dict contains ``"error"`` key with "middleware regression"
+      substring (catches a regression that returns an empty dict or drops
+      the error key).
+    - Module logger emits an ERROR record (so the regression surfaces
+      in server logs immediately).
     """
-    fake_llm = MagicMock()
-    args = {
-        "surfaceId": "dynamic-surface",
-        "catalogId": "copilotkit://app-dashboard-catalog",
-        "components": [{"id": "root", "component": "Container"}],
-        "data": {"greeting": "hi"},
-    }
-    fake_llm.chat.return_value = _llm_response(
-        tool_calls=[_oai_tool_call(arguments=args)]
-    )
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        result = generate_a2ui_via_llm(context="test context")
-
-    # LLM forced-tool-call wiring. The planner uses the MODERN
-    # tools=/tool_choice= API (not the legacy functions=/function_call=) so
-    # aimock's toolName matcher — which inspects the request's tools[] array
-    # — can discriminate the inner render_a2ui call from the outer
-    # generate_a2ui call. See ``_RENDER_A2UI_TOOL_SPEC`` in agents/agent.py.
-    fake_llm.chat.assert_called_once()
-    call_kwargs = fake_llm.chat.call_args.kwargs
-    assert call_kwargs["tools"] == [_RENDER_A2UI_TOOL_SPEC]
-    assert call_kwargs["tool_choice"] == {
-        "type": "function",
-        "function": {"name": "render_a2ui"},
-    }
-
-    # Message wiring: system prompt from caller's ``context``, plus a user
-    # message instructing the planner to emit a dashboard. Both must be
-    # present (langroid uses two-message system+user priming) — a regression
-    # that drops one would still forward kwargs but emit a broken prompt.
-    messages = call_kwargs["messages"]
-    assert len(messages) == 2, f"expected system+user messages, got {len(messages)}"
-    assert messages[0].content == "test context", (
-        f"system message must carry caller's context verbatim; got "
-        f"{messages[0].content!r}"
-    )
-
-    # Op shape
-    assert "a2ui_operations" in result, f"unexpected shape: {result!r}"
-    ops = result["a2ui_operations"]
-    assert len(ops) == 3
-
-    assert ops[0]["version"] == "v0.9"
-    assert ops[0]["createSurface"]["surfaceId"] == "dynamic-surface"
-    assert ops[0]["createSurface"]["catalogId"] == "copilotkit://app-dashboard-catalog"
-
-    assert ops[1]["version"] == "v0.9"
-    assert ops[1]["updateComponents"]["components"] == [
-        {"id": "root", "component": "Container"}
-    ]
-
-    assert ops[2]["version"] == "v0.9"
-    assert ops[2]["updateDataModel"]["value"] == {"greeting": "hi"}
-
-
-def test_generate_a2ui_happy_path_json_string_arguments_also_work():
-    """If a provider adapter returns ``arguments`` as a JSON string (not a
-    pre-parsed dict — some langroid backends do this), the function must
-    still parse and succeed. Assert the round-trip — ``surfaceId`` from the
-    JSON string makes it into ``a2ui_operations[0].surfaceId`` — so that a
-    regression where the parsed dict was dropped on the floor gets caught."""
-    fake_llm = MagicMock()
-    args_json = json.dumps(
-        {
-            "surfaceId": "s1",
-            "catalogId": "copilotkit://app-dashboard-catalog",
-            "components": [{"id": "root", "component": "Container"}],
-        }
-    )
-    fake_llm.chat.return_value = _llm_response(
-        tool_calls=[_oai_tool_call(arguments=args_json)]
-    )
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        result = generate_a2ui_via_llm(context="")
-    assert "a2ui_operations" in result
-    assert result["a2ui_operations"][0]["createSurface"]["surfaceId"] == "s1"
-    # No ``data`` in args → no update_data_model op → exactly 2 ops.
-    assert len(result["a2ui_operations"]) == 2, (
-        f"expected 2 ops when args has no 'data' key; got "
-        f"{len(result['a2ui_operations'])}"
-    )
-    # Default system prompt must kick in when context is empty.
-    call_kwargs = fake_llm.chat.call_args.kwargs
-    messages = call_kwargs["messages"]
-    assert messages[0].content == "Generate a useful dashboard UI.", (
-        f"empty context must trigger the default system prompt; got "
-        f"{messages[0].content!r}"
-    )
-
-
-def test_generate_a2ui_legacy_function_call_path():
-    """Older / alternate providers surface the forced tool call via
-    ``function_call`` rather than ``oai_tool_calls``. Both shapes must work.
-    Pin ``surfaceId`` so we know the LEGACY slot's args were consumed (a
-    regression that reads from the empty modern slot would fall through to
-    ``a2ui_no_tool_call`` — but an even subtler regression could read the
-    wrong slot's args)."""
-    fake_llm = MagicMock()
-    args = {
-        "surfaceId": "legacy-surface",
-        "catalogId": "copilotkit://app-dashboard-catalog",
-        "components": [{"id": "root", "component": "Container"}],
-    }
-    fake_llm.chat.return_value = _llm_response(
-        tool_calls=None,
-        function_call=_function_call(arguments=args),
-    )
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        result = generate_a2ui_via_llm(context="")
-    assert "a2ui_operations" in result
-    assert (
-        result["a2ui_operations"][0]["createSurface"]["surfaceId"] == "legacy-surface"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Error branches
-# ---------------------------------------------------------------------------
-
-
-def test_generate_a2ui_llm_exception_returns_full_error_shape(caplog):
-    """Runtime exception from ``llm.chat(...)`` → structured ``a2ui_llm_error``
-    with all keys populated, and an ERROR-level log on the module logger.
-
-    Also pin the remediation content — the entire point of the
-    provider-agnostic fix is that the remediation points at
-    ``LANGROID_MODEL`` / ``A2UI_MODEL`` rather than OpenAI-specific env
-    variables."""
-    fake_llm = MagicMock()
-    fake_llm.chat.side_effect = ConnectionError("backend unreachable")
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        with caplog.at_level(logging.ERROR, logger="agents.agent"):
-            result = generate_a2ui_via_llm(context="")
-    _assert_full_error_shape(result)
-    assert result["error"] == "a2ui_llm_error"
-    # Source formats the message as "...: ClassName: detail" — BOTH parts
-    # must be present. Previously used `or`; that weakened the assertion
-    # and would pass if the class name alone leaked through.
-    assert "ConnectionError" in result["message"]
-    assert "backend unreachable" in result["message"]
-    # Remediation must reference the provider-agnostic env vars — catches a
-    # regression that reintroduces "set OPENAI_API_KEY" phrasing.
-    assert "LANGROID_MODEL" in result["remediation"]
-    assert "A2UI_MODEL" in result["remediation"]
-    # And the module logger must have emitted an ERROR record whose message
-    # pins the substring from the source's ``logger.exception(...)`` call.
-    assert any(
-        rec.levelno >= logging.ERROR
-        and rec.name == "agents.agent"
-        and "LLM call failed" in rec.getMessage()
-        for rec in caplog.records
-    ), (
-        f"expected ERROR-level log mentioning 'LLM call failed'; got "
-        f"{[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
-    )
-
-
-def test_generate_a2ui_llm_exception_message_is_truncated_to_200_chars():
-    """The source truncates ``str(exc)`` to 200 chars to bound the blast
-    radius if a future provider SDK regression embeds credentials /
-    huge stack state in exception text. Regression-guard the truncation."""
-    fake_llm = MagicMock()
-    huge = "X" * 5000
-    fake_llm.chat.side_effect = ConnectionError(huge)
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        result = generate_a2ui_via_llm(context="")
-    _assert_full_error_shape(result)
-    # Message format: "Secondary A2UI LLM call failed: ConnectionError: <detail>"
-    # The <detail> portion must be at most 200 chars (truncated from 5000).
-    prefix = "Secondary A2UI LLM call failed: ConnectionError: "
-    assert result["message"].startswith(prefix)
-    detail = result["message"][len(prefix) :]
-    # Pin the exact truncation: source slices ``str(exc)[:200]`` with a huge
-    # input, so the detail must be EXACTLY the first 200 chars of the
-    # stressor string, not merely <=200 (which would accept a regression
-    # that truncated to e.g. 50 chars).
-    assert detail == "X" * 200, (
-        f"detail must be exactly 200 'X's from str(exc)[:200]; got {len(detail)} chars"
-    )
-    # And the total must not be anywhere near the original 5000.
-    assert len(result["message"]) < 500
-
-
-def test_generate_a2ui_llm_construction_failure_returns_full_error_shape():
-    """Failure inside ``_get_a2ui_llm`` (e.g. missing provider-specific API
-    key at construction time) must surface as a structured tool result
-    rather than propagate as an uncaught exception."""
-
-    def _raise(*_a, **_kw):
-        raise ValueError("no API key for provider X")
-
-    with patch("agents.agent._get_a2ui_llm", side_effect=_raise):
-        result = generate_a2ui_via_llm(context="")
-
-    _assert_full_error_shape(result)
-    assert result["error"] == "a2ui_llm_error"
-    # Message must carry both the exception class name (``ValueError``) and
-    # the original detail substring (``no API key``) — a regression that
-    # dropped ``str(exc)`` and left only the class name is caught.
-    assert "ValueError" in result["message"]
-    assert "no API key" in result["message"]
-
-
-def test_generate_a2ui_no_tool_call_returns_full_error_shape():
-    """LLM responded but emitted no tool call → a2ui_no_tool_call."""
-    fake_llm = MagicMock()
-    fake_llm.chat.return_value = _llm_response(tool_calls=None, function_call=None)
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        result = generate_a2ui_via_llm(context="")
-    _assert_full_error_shape(result)
-    assert result["error"] == "a2ui_no_tool_call"
-
-
-def test_generate_a2ui_empty_tool_calls_returns_full_error_shape():
-    """``oai_tool_calls`` was an empty list → a2ui_no_tool_call."""
-    fake_llm = MagicMock()
-    fake_llm.chat.return_value = _llm_response(tool_calls=[], function_call=None)
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        result = generate_a2ui_via_llm(context="")
-    _assert_full_error_shape(result)
-    assert result["error"] == "a2ui_no_tool_call"
-
-
-def test_generate_a2ui_invalid_arguments_returns_full_error_shape():
-    """Arguments that are a str but NOT valid JSON → a2ui_invalid_arguments."""
-    fake_llm = MagicMock()
-    fake_llm.chat.return_value = _llm_response(
-        tool_calls=[_oai_tool_call(arguments="not json {{{")]
-    )
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        result = generate_a2ui_via_llm(context="")
-    _assert_full_error_shape(result)
-    assert result["error"] == "a2ui_invalid_arguments"
-
-
-def test_generate_a2ui_non_dict_arguments_returns_full_error_shape():
-    """Arguments valid JSON but not a dict (e.g. a list) →
-    a2ui_invalid_arguments (build_a2ui_operations_from_tool_call expects
-    a dict and we must not let the TypeError escape)."""
-    fake_llm = MagicMock()
-    fake_llm.chat.return_value = _llm_response(
-        tool_calls=[_oai_tool_call(arguments=[1, 2, 3])]
-    )
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        result = generate_a2ui_via_llm(context="")
-    _assert_full_error_shape(result)
-    assert result["error"] == "a2ui_invalid_arguments"
-
-
-@pytest.mark.parametrize(
-    "exc_cls,exc_args",
-    [
-        (KeyError, ("missing surfaceId",)),
-        (TypeError, ("nope",)),
-        (ValueError, ("bad value",)),
-    ],
-)
-def test_build_a2ui_operations_wrapper_catches_expected_errors(exc_cls, exc_args):
-    """``build_a2ui_operations_from_tool_call`` raising any of the three
-    expected classes (``KeyError`` / ``TypeError`` / ``ValueError``) on
-    malformed args must wrap into ``a2ui_invalid_arguments`` rather than
-    propagate. Parametrized so the three near-identical bodies don't drift
-    (previously copy-pasted, which is exactly how one of the branches would
-    silently fall out of sync on a refactor).
-    """
-    fake_llm = MagicMock()
-    args = {
-        "surfaceId": "s",
-        "catalogId": "copilotkit://app-dashboard-catalog",
-        "components": [{"id": "root", "component": "Container"}],
-    }
-    fake_llm.chat.return_value = _llm_response(
-        tool_calls=[_oai_tool_call(arguments=args)]
-    )
-    with (
-        patch("agents.agent._get_a2ui_llm", return_value=fake_llm),
-        patch(
-            "agents.agent.build_a2ui_operations_from_tool_call",
-            side_effect=exc_cls(*exc_args),
-        ),
-    ):
-        result = generate_a2ui_via_llm(context="")
-    _assert_full_error_shape(result)
-    assert result["error"] == "a2ui_invalid_arguments"
-
-
-def test_build_a2ui_operations_boundary_validates_return_shape():
-    """Even on the happy path, ``build_a2ui_operations_from_tool_call`` can
-    theoretically drift and return a dict missing the ``a2ui_operations``
-    key (e.g. upstream schema change). The planner MUST boundary-validate
-    the return shape and surface a structured ``a2ui_invalid_arguments``
-    rather than propagate the malformed dict to the frontend."""
-    fake_llm = MagicMock()
-    args = {
-        "surfaceId": "s",
-        "catalogId": "copilotkit://app-dashboard-catalog",
-        "components": [{"id": "root", "component": "Container"}],
-    }
-    fake_llm.chat.return_value = _llm_response(
-        tool_calls=[_oai_tool_call(arguments=args)]
-    )
-    # Patch the builder to return a malformed dict lacking "a2ui_operations".
-    with (
-        patch("agents.agent._get_a2ui_llm", return_value=fake_llm),
-        patch(
-            "agents.agent.build_a2ui_operations_from_tool_call",
-            return_value={"unexpected_key": "foo"},
-        ),
-    ):
-        result = generate_a2ui_via_llm(context="")
-    _assert_full_error_shape(result)
-    assert result["error"] == "a2ui_invalid_arguments"
-
-
-# ---------------------------------------------------------------------------
-# Programmer errors MUST propagate — not be silently swallowed.
-# The narrow re-raise tuple is (AttributeError, TypeError, NameError,
-# ImportError, ModuleNotFoundError, AssertionError, NotImplementedError,
-# pydantic.ValidationError).
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "exc_cls,exc_args",
-    [
-        (AttributeError, ("typo",)),
-        (TypeError, ("bad kwargs",)),
-        (NameError, ("unknown name",)),
-        (ImportError, ("bad import",)),
-        (ModuleNotFoundError, ("no module",)),
-        (AssertionError, ("assertion",)),
-        (NotImplementedError, ("todo",)),
-    ],
-)
-def test_generate_a2ui_lets_programmer_errors_propagate(exc_cls, exc_args):
-    """Programmer-error exception classes must propagate uncaught rather
-    than being wrapped as ``a2ui_llm_error``. Keeps genuine bugs visible
-    in tests and server logs instead of silently masked."""
-    fake_llm = MagicMock()
-    fake_llm.chat.side_effect = exc_cls(*exc_args)
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        with pytest.raises(exc_cls):
-            generate_a2ui_via_llm(context="")
-
-
-def test_generate_a2ui_propagates_pydantic_validation_error():
-    """``pydantic.ValidationError`` indicates a schema bug (the planner's
-    response could not be validated against the expected model), not a
-    transport failure. It must propagate rather than be wrapped as
-    ``a2ui_llm_error`` — the remediation for a schema bug is not "verify
-    provider credentials"."""
-    from pydantic import BaseModel, ValidationError
-
-    class _Dummy(BaseModel):
-        x: int
-
-    # Trigger a real ValidationError so we have a legitimate instance to
-    # raise — constructing ValidationError directly is tricky across
-    # pydantic versions.
-    try:
-        _Dummy(x="not-an-int")  # type: ignore[arg-type]
-    except ValidationError as ve:
-        real_ve = ve
-    else:  # pragma: no cover - defensive
-        pytest.fail("expected pydantic to raise ValidationError")
-
-    fake_llm = MagicMock()
-    fake_llm.chat.side_effect = real_ve
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        with pytest.raises(ValidationError):
-            generate_a2ui_via_llm(context="")
-
-
-@pytest.mark.parametrize(
-    "exc_cls,exc_args",
-    [
-        (KeyError, ("missing",)),
-        (IndexError, ("out of range",)),
-        (RecursionError, ("too deep",)),
-        (MemoryError, ()),
-        (LookupError, ("lookup",)),
-    ],
-)
-def test_generate_a2ui_wraps_recoverable_errors_into_llm_error(exc_cls, exc_args):
-    """``KeyError`` / ``IndexError`` / ``LookupError`` / ``RecursionError`` /
-    ``MemoryError`` are raised by SDK/adapter code as recoverable conditions
-    on malformed provider payloads. They used to propagate, but the narrowed
-    re-raise tuple now lets them fall through into the transport-error path
-    so callers get the structured ``a2ui_llm_error`` surface with the
-    correct "retry / verify provider" remediation rather than an uncaught
-    500."""
-    fake_llm = MagicMock()
-    fake_llm.chat.side_effect = exc_cls(*exc_args)
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        result = generate_a2ui_via_llm(context="")
-    _assert_full_error_shape(result)
-    assert result["error"] == "a2ui_llm_error"
-
-
-def test_generate_a2ui_memory_error_without_args_produces_classname_only_message():
-    """``MemoryError()`` carries no args, so ``str(exc) == ""``. The source's
-    ``exc_detail = str(exc)[:200] if str(exc) else ""`` branch drops the
-    trailing ``: <detail>`` segment, so the message must be exactly
-    ``"Secondary A2UI LLM call failed: MemoryError"`` with no trailing
-    colon. Pinning this catches a regression that always appends ``:`` even
-    when detail is empty (which would produce ``"...: MemoryError: "`` and
-    look subtly broken in the frontend)."""
-    fake_llm = MagicMock()
-    fake_llm.chat.side_effect = MemoryError()
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        result = generate_a2ui_via_llm(context="")
-    _assert_full_error_shape(result)
-    assert result["error"] == "a2ui_llm_error"
-    assert result["message"] == "Secondary A2UI LLM call failed: MemoryError", (
-        f"empty-detail path must produce classname-only message (no trailing "
-        f"': '); got {result['message']!r}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# _get_a2ui_llm: model resolution + keyed memoization + provider-agnostic
-# ---------------------------------------------------------------------------
-
-
-def test_a2ui_model_env_overrides_langroid_model(monkeypatch):
-    """When ``A2UI_MODEL`` is set, the planner LLM must use it regardless
-    of ``LANGROID_MODEL``."""
-    monkeypatch.setenv("LANGROID_MODEL", "gpt-4.1")
-    monkeypatch.setenv("A2UI_MODEL", "anthropic/claude-opus-4")
-
-    captured_models: list[str] = []
-
-    class _FakeLLM:
-        def __init__(self, config):
-            captured_models.append(config.chat_model)
-
-        def chat(self, *_a, **_kw):
-            return _llm_response(tool_calls=None)
-
-    with patch("agents.agent.lm.OpenAIGPT", _FakeLLM):
-        # Drive through the public path so model resolution runs.
-        generate_a2ui_via_llm(context="")
-
-    assert captured_models == ["anthropic/claude-opus-4"], (
-        f"A2UI_MODEL should win; got {captured_models!r}"
-    )
-
-
-def test_langroid_model_used_when_a2ui_model_unset(monkeypatch):
-    """When only ``LANGROID_MODEL`` is set, the planner LLM should inherit
-    it — same provider as the primary chat agent."""
-    monkeypatch.setenv("LANGROID_MODEL", "anthropic/claude-opus-4")
-
-    captured_models: list[str] = []
-
-    class _FakeLLM:
-        def __init__(self, config):
-            captured_models.append(config.chat_model)
-
-        def chat(self, *_a, **_kw):
-            return _llm_response(tool_calls=None)
-
-    with patch("agents.agent.lm.OpenAIGPT", _FakeLLM):
-        generate_a2ui_via_llm(context="")
-
-    assert captured_models == ["anthropic/claude-opus-4"]
-
-
-def test_default_model_when_no_env_set(monkeypatch):
-    """With neither ``A2UI_MODEL`` nor ``LANGROID_MODEL`` set, the default
-    chat_model must match the primary agent's default (``gpt-4.1``
-    as documented in ``create_agent``). Pinning the string here catches a
-    silent drift between the planner default and the primary default.
-
-    Explicit ``monkeypatch.delenv`` on both vars (belt-and-suspenders
-    alongside the autouse ``_clean_env`` fixture) so a future refactor of
-    the fixture can't accidentally leak a stray env var into this test.
-    """
-    monkeypatch.delenv("A2UI_MODEL", raising=False)
-    monkeypatch.delenv("LANGROID_MODEL", raising=False)
-    captured_models: list[str] = []
-
-    class _FakeLLM:
-        def __init__(self, config):
-            captured_models.append(config.chat_model)
-
-        def chat(self, *_a, **_kw):
-            return _llm_response(tool_calls=None)
-
-    with patch("agents.agent.lm.OpenAIGPT", _FakeLLM):
-        generate_a2ui_via_llm(context="")
-
-    assert captured_models == ["gpt-4.1"]
-
-
-def test_llm_memoization_returns_same_instance_for_same_model():
-    """Two calls with the same resolved model must return the same LLM
-    instance — rebuilding is wasted work and re-runs credential resolution."""
-    sentinel = MagicMock()
-    with patch("agents.agent.lm.OpenAIGPT", return_value=sentinel) as mock_cls:
-        first = _get_a2ui_llm("gpt-4.1")
-        second = _get_a2ui_llm("gpt-4.1")
-    assert first is second is sentinel
-    assert mock_cls.call_count == 1
-
-
-def test_llm_memoization_is_keyed_per_model():
-    """Different model strings must produce different instances, and each
-    call must construct ``OpenAIGPT`` with the exact model string passed."""
-    instances: list[MagicMock] = []
-    captured_models: list[str] = []
-
-    class _FakeLLM:
-        def __init__(self, config):
-            captured_models.append(config.chat_model)
-            instances.append(self)  # type: ignore[arg-type]
-
-        def chat(self, *_a, **_kw):  # pragma: no cover - not used here
-            return _llm_response(tool_calls=None)
-
-    with patch("agents.agent.lm.OpenAIGPT", _FakeLLM):
-        a = _get_a2ui_llm("gpt-4.1")
-        b = _get_a2ui_llm("anthropic/claude-opus-4")
-        a2 = _get_a2ui_llm("gpt-4.1")
-
-    assert a is not b, "different models must produce different instances"
-    assert a is a2, "repeated calls for same model must hit the cache"
-    assert captured_models == ["gpt-4.1", "anthropic/claude-opus-4"]
-
-
-@pytest.mark.skipif(
-    not os.environ.get("LANGROID_INTEGRATION_TESTS"),
-    reason=(
-        "Integration test: constructs real lm.OpenAIGPT. Set "
-        "LANGROID_INTEGRATION_TESTS=1 to enable."
-    ),
-)
-def test_construction_succeeds_without_openai_env_real_openaigpt(monkeypatch):
-    """Regression guard (strong form): with ``LANGROID_MODEL=anthropic/...``
-    set and NO ``OPENAI_*`` env variables, constructing the REAL
-    ``lm.OpenAIGPT`` must not raise.
-
-    This is the whole point of the provider-agnostic fix. langroid's
-    ``OpenAIGPT`` class dispatches to the right provider based on the
-    ``provider/model`` prefix; only that provider's credentials are
-    required at construction time. Construction should be pure (config +
-    env reads, no network), so calling it against an Anthropic-prefixed
-    model with only ``ANTHROPIC_API_KEY`` set should succeed without
-    requiring any OpenAI-specific env.
-
-    Opt-in (``LANGROID_INTEGRATION_TESTS=1``) because langroid's
-    ``OpenAIGPT.__init__`` has historically flirted with network / provider
-    init; we keep the weaker model-string routing test (below) as the
-    always-on unit-level line of defense.
-    """
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
-    monkeypatch.setenv("LANGROID_MODEL", "anthropic/claude-opus-4")
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
-
-    import langroid.language_models as lm  # noqa: WPS433 — local import by design
-
-    # Construct directly — this is the regression we're actually guarding.
-    try:
-        config = lm.OpenAIGPTConfig(
-            chat_model="anthropic/claude-opus-4",
-            stream=False,
-        )
-        llm = lm.OpenAIGPT(config)
-    except Exception as exc:  # pragma: no cover - explicit failure path
-        pytest.fail(
-            f"OpenAIGPT construction must not require OpenAI env when model is "
-            f"non-OpenAI; got {type(exc).__name__}: {exc}"
-        )
-    assert llm is not None
-
-
-def test_construction_uses_correct_model_string_for_non_openai(monkeypatch):
-    """Supplementary model-string routing test: with a non-OpenAI
-    ``LANGROID_MODEL``, the planner constructs an ``OpenAIGPT`` with the
-    exact model string. This is the weaker cousin of the strong-form
-    regression guard above — it confirms the routing path even if the real
-    constructor becomes impossible to unit-test (e.g. adds network I/O)."""
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
-    monkeypatch.setenv("LANGROID_MODEL", "anthropic/claude-opus-4")
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
-
-    captured_models: list[str] = []
-
-    class _FakeLLM:
-        def __init__(self, config):
-            captured_models.append(config.chat_model)
-
-        def chat(self, *_a, **_kw):
-            return _llm_response(tool_calls=None)
-
-    with patch("agents.agent.lm.OpenAIGPT", _FakeLLM):
-        generate_a2ui_via_llm(context="")
-
-    assert captured_models == ["anthropic/claude-opus-4"]
-
-
-def test_agent_module_imports_cleanly_without_openai_env(tmp_path):
-    """Honest import-time regression guard: importing ``agents.agent`` with
-    no OpenAI-specific env must succeed. This catches any top-level
-    ``openai.OpenAI()`` / ``openai.Client()`` call that would re-introduce
-    a hard provider dependency.
-
-    Runs in a SUBPROCESS so module-level state (specifically the
-    ``_get_a2ui_llm`` ``lru_cache`` and any other module-scope singletons)
-    in the parent interpreter is not perturbed by a reload. Previously we
-    used ``importlib.reload`` which rebinds module-level function
-    identities — downstream tests patching by name would then silently see
-    a stale reference and leak state across tests. Subprocess isolation
-    makes this test order-independent.
-    """
-    # Strip any OPENAI_* / LANGROID_* / A2UI_* env vars the child would
-    # otherwise inherit, but keep everything else (PATH, HOME, etc.) so the
-    # interpreter can actually start.
-    env = {
-        k: v
-        for k, v in os.environ.items()
-        if not k.startswith(("OPENAI_", "LANGROID_", "A2UI_"))
-    }
-    # Ensure the child can import ``agents.agent`` via the package's src/
-    # directory — mirrors what conftest.py does for the parent.
-    # Also include the integration root so the ``tools`` symlink (which
-    # lives at ``langroid/tools`` → ``../../shared/python/tools``) is
-    # importable — mirrors the ``PYTHONPATH=".:src:..."`` that the CI
-    # workflow and ``package.json`` dev script both set.
-    pkg_root = Path(__file__).resolve().parents[2]
-    src_dir = pkg_root / "src"
-    existing_pp = env.get("PYTHONPATH", "")
-    new_pp = f"{pkg_root}{os.pathsep}{src_dir}"
-    env["PYTHONPATH"] = f"{new_pp}{os.pathsep}{existing_pp}" if existing_pp else new_pp
-
-    # Run the import from ``tmp_path`` so any stray ``.env`` file in the
-    # project root isn't auto-loaded by ``dotenv.load_dotenv`` (which would
-    # reintroduce OPENAI_* silently and mask a regression).
-    result = subprocess.run(
-        [sys.executable, "-c", "import agents.agent"],
-        env=env,
-        cwd=str(tmp_path),
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode == 0, (
-        f"import agents.agent failed in clean subprocess:\n"
-        f"stdout: {result.stdout}\nstderr: {result.stderr}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# GenerateA2UITool.handle delegates to generate_a2ui_via_llm
-# ---------------------------------------------------------------------------
-
-
-def test_generate_a2ui_tool_handle_returns_json_str_of_operations():
-    """``GenerateA2UITool.handle`` is what langroid invokes server-side. It
-    must return a JSON string of whatever ``generate_a2ui_via_llm`` returned
-    (a2ui_operations dict on success, or an error dict on failure)."""
-    happy_result = {"a2ui_operations": [{"type": "create_surface"}]}
-    with patch("agents.agent.generate_a2ui_via_llm", return_value=happy_result) as stub:
-        tool = GenerateA2UITool(context="whatever")
+    tool = GenerateA2UITool(context="test context")
+    with caplog.at_level(logging.ERROR, logger="agents.agent"):
         out = tool.handle()
-    stub.assert_called_once_with(context="whatever")
+
     assert isinstance(out, str), (
         f"handle() must return str for langroid's tool framework; got "
         f"{type(out).__name__}"
     )
     parsed = json.loads(out)
-    assert parsed == happy_result
-
-
-def test_generate_a2ui_tool_handle_surfaces_error_dicts_verbatim():
-    """Errors from generate_a2ui_via_llm must be serialized to JSON verbatim
-    so the frontend / outer LLM can show the structured error."""
-    err = {"error": "a2ui_llm_error", "message": "x", "remediation": "y"}
-    with patch("agents.agent.generate_a2ui_via_llm", return_value=err):
-        tool = GenerateA2UITool(context="")
-        out = tool.handle()
-    assert isinstance(out, str)
-    parsed = json.loads(out)
-    assert parsed == err
-
-
-def test_generate_a2ui_tool_handle_wraps_json_dumps_failure():
-    """If ``generate_a2ui_via_llm`` returns something with a non-JSON-serializable
-    value (e.g. a ``set`` leaked in from an upstream bug), ``handle()``
-    must NOT propagate the ``TypeError`` to the langroid tool framework.
-    Instead it emits a JSON-encoded structured error string so the outer
-    agent sees a recognizable failure shape.
-
-    Uses ``{1, 2, 3}`` (a set) because it is unambiguously non-JSON-
-    serializable and — unlike ``datetime.utcnow()`` — does not depend on a
-    deprecated stdlib API.
-    """
-    unserializable = {"a2ui_operations": [{"payload": {1, 2, 3}}]}
-    with patch("agents.agent.generate_a2ui_via_llm", return_value=unserializable):
-        tool = GenerateA2UITool(context="")
-        out = tool.handle()
-    # Must still be a str that json.loads accepts.
-    parsed = json.loads(out)
-    _assert_full_error_shape(parsed)
-
-
-# ---------------------------------------------------------------------------
-# Module hygiene: no top-level openai import (including inside top-level
-# try/except blocks, conditional imports, etc. — anywhere that runs at
-# module load time).
-# ---------------------------------------------------------------------------
-
-
-def _module_level_ancestors(tree: ast.Module) -> dict[int, bool]:
-    """Return a map ``id(node) -> is_module_level``.
-
-    A node is module-level iff the chain of containing nodes from the
-    module root never passes through a ``FunctionDef`` / ``AsyncFunctionDef``.
-    Top-level ``Try`` / ``If`` / ``With`` / ``ClassDef`` blocks DO count as
-    module-level — their bodies execute at import time. A regression that
-    drops an ``import openai`` into a class body (e.g. default-factory
-    attribute, metaclass setup) must be caught here too.
-    """
-    is_module_level: dict[int, bool] = {}
-
-    def _walk(node: ast.AST, inside_func: bool) -> None:
-        # Any import statement encountered here gets tagged. We don't need
-        # every node, just the imports — but walking uniformly keeps the
-        # logic simple.
-        if isinstance(node, (ast.Import, ast.ImportFrom)):
-            is_module_level[id(node)] = not inside_func
-        # Recurse, flipping the flag only when we enter a function body
-        # (its code runs on call, not at import time). Class bodies execute
-        # at module load, so we intentionally do NOT flip the flag for
-        # ``ClassDef``.
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            for child in ast.iter_child_nodes(node):
-                _walk(child, inside_func=True)
-        else:
-            for child in ast.iter_child_nodes(node):
-                _walk(child, inside_func=inside_func)
-
-    _walk(tree, inside_func=False)
-    return is_module_level
-
-
-def test_agent_module_does_not_import_openai_at_module_load_time():
-    """The provider-agnostic fix requires that importing ``agents.agent``
-    does not pull in the ``openai`` SDK. A module-load-time ``import openai``
-    — whether at the top of the file, inside a top-level ``try/except``, or
-    inside a top-level ``if``/``with``/etc — would reintroduce the
-    hard-coded provider dependency we just removed.
-
-    The previous walker only inspected ``tree.body``, missing imports
-    nested inside a ``try: import openai; except: pass`` pattern (which
-    still runs at module import). This version walks the full AST and
-    flags any import whose execution path is NOT guarded by a
-    ``FunctionDef`` / ``AsyncFunctionDef`` / ``ClassDef`` body.
-    """
-    import agents.agent as mod
-
-    source = inspect.getsource(mod)
-    tree = ast.parse(source)
-    is_module_level = _module_level_ancestors(tree)
-
-    for node in ast.walk(tree):
-        if not isinstance(node, (ast.Import, ast.ImportFrom)):
-            continue
-        if not is_module_level.get(id(node), False):
-            continue  # inside a function / class body → fine, lazy
-        if isinstance(node, ast.ImportFrom):
-            if node.module and node.module.startswith("openai"):
-                raise AssertionError(
-                    f"agents.agent must not `from openai ...` at module load "
-                    f"time (line {node.lineno}); found: from {node.module} import ..."
-                )
-        else:  # ast.Import
-            for alias in node.names:
-                if alias.name.startswith("openai"):
-                    raise AssertionError(
-                        f"agents.agent must not `import openai` at module load "
-                        f"time (line {node.lineno}); found: {alias.name}"
-                    )
-
-
-# ---------------------------------------------------------------------------
-# Logger assertions — every logger.exception / logger.warning call in source
-# should have a corresponding caplog assertion here. Message substrings are
-# pinned so an unrelated future WARN doesn't silently satisfy the assertion.
-# ---------------------------------------------------------------------------
-
-
-def test_multi_tool_call_picks_first_and_warns(caplog):
-    """When the planner returns more than one tool call (some providers do
-    this under certain conditions), the code must pick ``[0]`` and emit a
-    WARN log about dropping the tail. Never silently consume N>1.
-
-    Pin the message substring (``"2 tool calls"`` — source formats the
-    count via ``%d``) so an unrelated future WARN can't satisfy this
-    assertion.
-    """
-    fake_llm = MagicMock()
-    args_first = {
-        "surfaceId": "first",
-        "catalogId": "copilotkit://app-dashboard-catalog",
-        "components": [{"id": "root", "component": "Container"}],
-    }
-    args_second = {
-        "surfaceId": "second",
-        "catalogId": "copilotkit://app-dashboard-catalog",
-        "components": [{"id": "root", "component": "Container"}],
-    }
-    fake_llm.chat.return_value = _llm_response(
-        tool_calls=[
-            _oai_tool_call(arguments=args_first, call_id="c1"),
-            _oai_tool_call(arguments=args_second, call_id="c2"),
-        ]
+    assert "error" in parsed, (
+        f"handle() must return a dict with 'error' key; got {parsed!r}"
     )
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        with caplog.at_level(logging.WARNING, logger="agents.agent"):
-            result = generate_a2ui_via_llm(context="")
-
-    assert "a2ui_operations" in result
-    assert result["a2ui_operations"][0]["createSurface"]["surfaceId"] == "first", (
-        "must pick tool_calls[0] when multiple are present"
-    )
-    # The FIRST call's args lack ``data``, so the op list should be exactly
-    # 2 (surface + components) — NOT 4 (which would indicate both calls
-    # were processed and concatenated). Pinning the count catches a
-    # regression that silently processes all calls.
-    assert len(result["a2ui_operations"]) == 2, (
-        f"expected 2 ops from first tool_call's args only; got "
-        f"{len(result['a2ui_operations'])}"
-    )
-    assert any(
-        rec.levelno == logging.WARNING
-        and rec.name == "agents.agent"
-        and "2 tool calls" in rec.getMessage()
-        for rec in caplog.records
-    ), (
-        f"expected WARN mentioning '2 tool calls'; got "
-        f"{[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
-    )
-
-
-def test_tool_call_missing_function_attr_falls_through_to_legacy_path(caplog):
-    """Degraded-shape: ``tool_calls=[call]`` where ``call.function`` is
-    ``None``. The code must fall through to the legacy ``function_call``
-    path rather than raising ``AttributeError``, and emit a WARN pinpointing
-    the drift so operators see it in logs.
-
-    Pin the message substring (``".function is None"``) so the caplog
-    assertion can't silently pass on an unrelated future WARN.
-    """
-    fake_llm = MagicMock()
-    degraded = _FakeOaiToolCall(id="c1", function=None)
-    args = {
-        "surfaceId": "legacy-via-fallthrough",
-        "catalogId": "copilotkit://app-dashboard-catalog",
-        "components": [{"id": "root", "component": "Container"}],
-    }
-    fake_llm.chat.return_value = _llm_response(
-        tool_calls=[degraded],
-        function_call=_function_call(arguments=args),
-    )
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        with caplog.at_level(logging.WARNING, logger="agents.agent"):
-            result = generate_a2ui_via_llm(context="")
-    assert "a2ui_operations" in result
     assert (
-        result["a2ui_operations"][0]["createSurface"]["surfaceId"]
-        == "legacy-via-fallthrough"
-    )
+        "middleware regression" in parsed["error"] or "middleware" in parsed["error"]
+    ), f"error value must mention middleware regression; got {parsed['error']!r}"
+    # ERROR log must fire so operators see the regression immediately.
     assert any(
-        rec.levelno == logging.WARNING
-        and rec.name == "agents.agent"
-        and ".function is None" in rec.getMessage()
+        rec.levelno >= logging.ERROR and rec.name == "agents.agent"
         for rec in caplog.records
     ), (
-        f"expected WARN mentioning '.function is None'; got "
+        f"expected ERROR-level log from agents.agent; got "
+        f"{[(r.name, r.levelname) for r in caplog.records]}"
+    )
+
+
+def test_generate_a2ui_tool_handle_logs_interception_regression_message(caplog):
+    """Pin the ERROR log message substring so a future refactor that renames
+    the log message (without updating monitoring alerts) is caught at
+    unit-test time. The message must mention 'A2UIMiddleware' so operators
+    can diagnose the source of the regression from the log line alone."""
+    tool = GenerateA2UITool(context="")
+    with caplog.at_level(logging.ERROR, logger="agents.agent"):
+        tool.handle()
+
+    assert any(
+        rec.levelno >= logging.ERROR
+        and rec.name == "agents.agent"
+        and "A2UIMiddleware" in rec.getMessage()
+        for rec in caplog.records
+    ), (
+        f"expected ERROR log mentioning 'A2UIMiddleware'; got "
         f"{[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
     )
-
-
-def test_tool_call_with_function_arguments_none_falls_through_to_legacy_path(caplog):
-    """Symmetric fallthrough: ``tool_calls[0].function`` is present but its
-    ``arguments`` is ``None``. The modern slot has no args, so the code
-    must fall through to the legacy ``function_call`` path (some providers
-    put the forced call in the legacy slot even when the modern slot is
-    half-populated).
-
-    This is symmetric with the ``function is None`` fallthrough above —
-    before the source fix, the modern slot returned ``None`` eagerly and
-    this case was misclassified as ``a2ui_no_tool_call``.
-
-    Pin the WARN substring (``".arguments is None"``) so the assertion
-    doesn't silently pass on an unrelated future WARN.
-    """
-    fake_llm = MagicMock()
-    # Modern slot: function present, but arguments is None (degraded shape).
-    modern_no_args = _FakeOaiToolCall(
-        id="c1",
-        function=_FakeFunction(name="render_a2ui", arguments=None),
-    )
-    legacy_args = {
-        "surfaceId": "legacy-surface",
-        "catalogId": "copilotkit://app-dashboard-catalog",
-        "components": [{"id": "root", "component": "Container"}],
-    }
-    fake_llm.chat.return_value = _llm_response(
-        tool_calls=[modern_no_args],
-        function_call=_function_call(arguments=legacy_args),
-    )
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        with caplog.at_level(logging.WARNING, logger="agents.agent"):
-            result = generate_a2ui_via_llm(context="")
-    assert "a2ui_operations" in result
-    assert (
-        result["a2ui_operations"][0]["createSurface"]["surfaceId"] == "legacy-surface"
-    )
-    # Tight substring: pin the MODERN-slot warning specifically. The legacy-
-    # slot warning ("function_call present but .arguments is None") also
-    # contains ".arguments is None" — a regression that swaps which warning
-    # fires would pass with the looser substring.
-    assert any(
-        rec.levelno == logging.WARNING
-        and rec.name == "agents.agent"
-        and "tool_call.function present but .arguments is None" in rec.getMessage()
-        for rec in caplog.records
-    ), (
-        f"expected WARN mentioning 'tool_call.function present but .arguments is None'; got "
-        f"{[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
-    )
-
-
-def test_tool_call_with_function_missing_arguments_returns_invalid_arguments(caplog):
-    """Degraded-shape: ``tool_calls[0].function`` exists but has no
-    ``arguments`` attr AND there is no legacy ``function_call`` fallback.
-
-    The updated source distinguishes this case from "no tool call at all":
-    the planner DID produce a tool-call shape, just with no args payload,
-    so the ``_extract_tool_call_arguments`` helper surfaces ``_ARGS_MISSING``
-    and the caller emits ``a2ui_invalid_arguments`` (not
-    ``a2ui_no_tool_call``) — "supports forced function-calling" would be
-    the wrong remediation since the planner clearly did try.
-
-    Pin the full MODERN-slot WARN substring (``"tool_call.function present
-    but .arguments is None"``) instead of the loose ``".arguments is None"``
-    — the legacy-slot WARN (``"function_call present but .arguments is
-    None"``) also contains ``.arguments is None``, and a regression that
-    swaps which WARN fires would pass the loose assertion.
-    """
-    fake_llm = MagicMock()
-    # SimpleNamespace with no `arguments` attr — getattr returns None.
-    degraded_func = SimpleNamespace(name="render_a2ui")
-    degraded_call = _FakeOaiToolCall(id="c1", function=degraded_func)
-    fake_llm.chat.return_value = _llm_response(tool_calls=[degraded_call])
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        with caplog.at_level(logging.WARNING, logger="agents.agent"):
-            result = generate_a2ui_via_llm(context="")
-    _assert_full_error_shape(result)
-    assert result["error"] == "a2ui_invalid_arguments", (
-        f"modern slot present with arguments=None and no legacy fallback "
-        f"must surface a2ui_invalid_arguments (via _ARGS_MISSING sentinel); "
-        f"got {result['error']!r}"
-    )
-    assert any(
-        rec.levelno == logging.WARNING
-        and rec.name == "agents.agent"
-        and "tool_call.function present but .arguments is None" in rec.getMessage()
-        for rec in caplog.records
-    ), (
-        f"expected WARN mentioning 'tool_call.function present but .arguments is None'; got "
-        f"{[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
-    )
-
-
-def test_no_tool_call_warn_log(caplog):
-    """``a2ui_no_tool_call`` branch must log a WARNING so operators see the
-    planner drift in logs. Pin the substring ``"did not emit"`` from the
-    source's WARN message."""
-    fake_llm = MagicMock()
-    fake_llm.chat.return_value = _llm_response(tool_calls=None, function_call=None)
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        with caplog.at_level(logging.WARNING, logger="agents.agent"):
-            result = generate_a2ui_via_llm(context="")
-    assert result["error"] == "a2ui_no_tool_call"
-    assert any(
-        rec.levelno == logging.WARNING
-        and rec.name == "agents.agent"
-        and "did not emit" in rec.getMessage()
-        for rec in caplog.records
-    ), (
-        f"expected WARN mentioning 'did not emit'; got "
-        f"{[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
-    )
-
-
-def test_legacy_function_call_with_none_arguments_warns_and_returns_invalid_arguments(
-    caplog,
-):
-    """Legacy-slot fallthrough: ``function_call`` is present but its
-    ``arguments`` attr is ``None``. The updated source emits a WARN and
-    surfaces ``_ARGS_MISSING`` → ``a2ui_invalid_arguments`` (symmetric with
-    the modern slot's degraded-shape path). Distinct from
-    ``a2ui_no_tool_call``: the planner DID emit a tool-call shape, just
-    with no args payload.
-
-    Pin the WARN substring (``"function_call present but .arguments is
-    None"``) so an unrelated future WARN can't silently satisfy the
-    assertion.
-    """
-    fake_llm = MagicMock()
-    # Modern slot absent; legacy slot present with arguments=None.
-    fake_llm.chat.return_value = _llm_response(
-        tool_calls=None,
-        function_call=_function_call(arguments=None),
-    )
-    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
-        with caplog.at_level(logging.WARNING, logger="agents.agent"):
-            result = generate_a2ui_via_llm(context="")
-    _assert_full_error_shape(result)
-    assert result["error"] == "a2ui_invalid_arguments", (
-        f"legacy slot with arguments=None must surface a2ui_invalid_arguments "
-        f"(via _ARGS_MISSING sentinel); got {result['error']!r}"
-    )
-    assert any(
-        rec.levelno == logging.WARNING
-        and rec.name == "agents.agent"
-        and "function_call present but .arguments is None" in rec.getMessage()
-        for rec in caplog.records
-    ), (
-        f"expected WARN mentioning 'function_call present but .arguments is None'; "
-        f"got {[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# _resolve_a2ui_model: env-var precedence contract
-# ---------------------------------------------------------------------------
-
-
-def test_resolve_a2ui_precedence(monkeypatch):
-    """``A2UI_MODEL`` must win over ``LANGROID_MODEL`` — the planner-only
-    override is the whole point of that env var."""
-    monkeypatch.setenv("A2UI_MODEL", "anthropic/claude-opus-4")
-    monkeypatch.setenv("LANGROID_MODEL", "gpt-4.1")
-    assert _resolve_a2ui_model() == "anthropic/claude-opus-4"
-
-
-def test_resolve_a2ui_empty_a2ui_falls_through(monkeypatch):
-    """Empty-string ``A2UI_MODEL`` (e.g. operator typed ``A2UI_MODEL=``
-    without a value) must fall through to ``LANGROID_MODEL`` rather than
-    freezing the planner into the empty string. ``os.getenv`` returns ``""``
-    (not ``None``) in this case, and the source relies on ``or``'s
-    falsy-fallthrough semantics for the empty-string case.
-    """
-    monkeypatch.setenv("A2UI_MODEL", "")
-    monkeypatch.setenv("LANGROID_MODEL", "anthropic/claude-opus-4")
-    assert _resolve_a2ui_model() == "anthropic/claude-opus-4"
-
-
-def test_resolve_a2ui_default(monkeypatch):
-    """With no env vars set at all, the resolver returns the documented
-    default ``gpt-4.1``. Pinning the string here catches a silent
-    drift between the planner default and ``create_agent``'s default.
-    """
-    monkeypatch.delenv("A2UI_MODEL", raising=False)
-    monkeypatch.delenv("LANGROID_MODEL", raising=False)
-    assert _resolve_a2ui_model() == "gpt-4.1"
-
-
-# ---------------------------------------------------------------------------
-# _get_a2ui_llm LRU eviction: maxsize=4 must evict LRU entry on 5th distinct
-# model. Documented behavior in the source block comment — unpinned until now.
-# ---------------------------------------------------------------------------
-
-
-def test_llm_cache_evicts_after_maxsize():
-    """After ``maxsize=4`` was made explicit, the 5th distinct model evicts
-    the least-recently-used entry. The first-inserted model's second call
-    must reconstruct a fresh ``OpenAIGPT`` (not hit the cache), observable
-    as a second ``__init__`` invocation with the same model string.
-
-    Without this guard, a silent bump of ``maxsize`` to a larger number
-    (or to ``None`` / unbounded) wouldn't fail any existing test but would
-    change memory semantics in production.
-    """
-    instances: list[str] = []
-
-    class _FakeLLM:
-        def __init__(self, config):
-            instances.append(config.chat_model)
-
-    with patch("agents.agent.lm.OpenAIGPT", _FakeLLM):
-        # Fill the cache (4 distinct models).
-        for i in range(4):
-            _get_a2ui_llm(f"provider/m{i}")
-        # Insert a 5th — evicts provider/m0 (LRU).
-        _get_a2ui_llm("provider/m4")
-        # Re-fetching provider/m0 must reconstruct.
-        _get_a2ui_llm("provider/m0")
-
-    # provider/m0 appears twice in the construction log: once on initial
-    # insert, once after eviction + reconstruct.
-    assert instances.count("provider/m0") == 2, (
-        f"provider/m0 should have been constructed twice (initial + after "
-        f"eviction); got instances={instances!r}"
-    )
-    # Others constructed exactly once.
-    for m in ("provider/m1", "provider/m2", "provider/m3", "provider/m4"):
-        assert instances.count(m) == 1, (
-            f"{m} should have been constructed once; got instances={instances!r}"
-        )
-
-
-# ---------------------------------------------------------------------------
-# Planner LLM must construct with stream=False — load-bearing per source
-# block comment (streaming wastes work; we need the full tool call before
-# emitting operations). Previously untested.
-# ---------------------------------------------------------------------------
-
-
-def test_planner_llm_constructs_with_stream_false():
-    """Capture the ``OpenAIGPTConfig`` passed to the planner LLM and assert
-    ``stream is False``. Load-bearing per the source comment; distinct from
-    the primary chat agent's config which uses ``stream=True`` for SSE
-    streaming to the frontend.
-    """
-    captured_configs: list[Any] = []
-
-    class _FakeLLM:
-        def __init__(self, config):
-            captured_configs.append(config)
-
-        def chat(self, *_a, **_kw):
-            return _llm_response(tool_calls=None)
-
-    with patch("agents.agent.lm.OpenAIGPT", _FakeLLM):
-        generate_a2ui_via_llm(context="")
-
-    assert len(captured_configs) == 1, (
-        f"expected one OpenAIGPTConfig construction; got {len(captured_configs)}"
-    )
-    cfg = captured_configs[0]
-    assert cfg.stream is False, (
-        f"planner must construct with stream=False (full tool call before "
-        f"emitting ops); got stream={cfg.stream!r}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# _RENDER_A2UI_FUNCTION_SPEC: pin the schema shape. This is the contract
-# between the planner LLM and the frontend renderer; a silent rename of
-# required fields would break every downstream consumer.
-# ---------------------------------------------------------------------------
-
-
-def test_render_a2ui_function_spec_required_fields():
-    """Pin the forced-function-call spec's name and required-field set.
-    These are the contract the planner LLM is forced to obey — renaming
-    ``surfaceId`` / ``catalogId`` / ``components`` is a frontend-breaking
-    change and must be caught at unit-test time.
-    """
-    assert _RENDER_A2UI_FUNCTION_SPEC.name == "render_a2ui"
-    assert _RENDER_A2UI_FUNCTION_SPEC.parameters["required"] == [
-        "surfaceId",
-        "catalogId",
-        "components",
-    ]
 
 
 # ---------------------------------------------------------------------------
@@ -1605,120 +273,6 @@ def test_backend_tool_handle_error_path_returns_structured_error(
 
 
 # ---------------------------------------------------------------------------
-# GenerateA2UITool.handle: json.dumps wrapper must catch every exception
-# class raised by ``json.dumps`` on pathological inputs. Source catches
-# ``(TypeError, ValueError, OverflowError, RecursionError)`` — each branch
-# gets its own test so a regression that narrows the tuple is caught.
-# ---------------------------------------------------------------------------
-
-
-def test_tool_handle_wraps_value_error_on_circular_reference():
-    """A cyclic dict makes ``json.dumps`` raise ``ValueError("Circular
-    reference detected")`` — NOT ``RecursionError``. CPython's ``json``
-    encoder detects the cycle via its ``markers`` dict and raises
-    ``ValueError`` long before the recursion limit is hit.
-    ``GenerateA2UITool.handle`` must catch it and emit a structured-error
-    JSON string rather than propagate the exception to langroid's
-    tool-handling stack. Pins the ``ValueError`` branch of the source's
-    widened ``except (TypeError, ValueError, OverflowError,
-    RecursionError)`` tuple.
-    """
-    cyclic: dict = {}
-    cyclic["self"] = cyclic
-    with patch(
-        "agents.agent.generate_a2ui_via_llm",
-        return_value={"a2ui_operations": [cyclic]},
-    ):
-        tool = GenerateA2UITool(context="")
-        out = tool.handle()
-    assert isinstance(out, str)
-    parsed = json.loads(out)
-    _assert_full_error_shape(parsed)
-    assert parsed["error"] == "a2ui_invalid_arguments"
-
-
-def test_tool_handle_wraps_recursion_error_on_deep_nesting():
-    """The ``RecursionError`` branch of the source's widened ``json.dumps``
-    catch must actually be exercised. Patches the module-local
-    ``_json_dumps`` binding (NOT the stdlib ``json.dumps``) to raise
-    ``RecursionError`` — ``json.dumps`` on truly pathological inputs
-    (e.g. deeply-nested but acyclic structures) can hit ``RecursionError``
-    under sufficient nesting, and we also want the source to stay
-    resilient against any future regression that introduces it via a
-    different path.
-
-    NOTE on patching discipline: earlier test revisions patched
-    ``agents.agent.json.dumps`` directly, which mutates the shared stdlib
-    module object and can collide with pytest / caplog internals that
-    dispatch through ``json.dumps`` while the patch is active. The source
-    introduces a module-local ``_json_dumps = json.dumps`` binding so
-    tests can patch ONLY the agent's success-path serialization without
-    leaking into unrelated stdlib consumers. The exception-branch
-    structured-error dump uses the raw ``json.dumps`` so the error
-    envelope still serializes even when ``_json_dumps`` is patched.
-    """
-    with (
-        patch(
-            "agents.agent.generate_a2ui_via_llm",
-            return_value={"a2ui_operations": [{"deep": "stub"}]},
-        ),
-        patch("agents.agent._json_dumps", side_effect=RecursionError("max depth")),
-    ):
-        tool = GenerateA2UITool(context="")
-        out = tool.handle()
-    assert isinstance(out, str)
-    parsed = json.loads(out)
-    _assert_full_error_shape(parsed)
-    assert parsed["error"] == "a2ui_invalid_arguments"
-    # Message must mention the class name so operators can diagnose the
-    # branch that fired.
-    assert "RecursionError" in parsed["message"]
-
-
-# ---------------------------------------------------------------------------
-# Additional _A2uiSuccess boundary validation — parametrized coverage for
-# non-dict / None / wrong-shape returns from build_a2ui_operations_from_tool_call.
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "builder_return,case",
-    [
-        (None, "returns None"),
-        (["not", "a", "dict"], "returns list"),
-        ({"a2ui_operations": None}, "operations key None"),
-        ({"a2ui_operations": "not a list"}, "operations key str"),
-    ],
-)
-def test_build_a2ui_boundary_rejects_malformed_shapes(builder_return, case):
-    """The planner's boundary-validation layer must reject every shape that
-    doesn't match ``_A2uiSuccess`` contract (``{"a2ui_operations": [...]}``
-    with a list value). Parametrized so all four failure modes are exercised
-    — a regression that loosens the ``isinstance(..., list)`` check to
-    ``is not None`` would be caught by the 'operations key str' case.
-    """
-    fake_llm = MagicMock()
-    args = {
-        "surfaceId": "s",
-        "catalogId": "copilotkit://app-dashboard-catalog",
-        "components": [{"id": "root", "component": "Container"}],
-    }
-    fake_llm.chat.return_value = _llm_response(
-        tool_calls=[_oai_tool_call(arguments=args)]
-    )
-    with (
-        patch("agents.agent._get_a2ui_llm", return_value=fake_llm),
-        patch(
-            "agents.agent.build_a2ui_operations_from_tool_call",
-            return_value=builder_return,
-        ),
-    ):
-        result = generate_a2ui_via_llm(context="")
-    _assert_full_error_shape(result)
-    assert result["error"] == "a2ui_invalid_arguments", f"case: {case}"
-
-
-# ---------------------------------------------------------------------------
 # create_agent factory — wiring contract with langroid
 # ---------------------------------------------------------------------------
 
@@ -1726,8 +280,7 @@ def test_build_a2ui_boundary_rejects_malformed_shapes(builder_return, case):
 def test_create_agent_wires_all_tools_with_stream_true(monkeypatch):
     """``create_agent`` must:
       - construct ``OpenAIGPTConfig`` with ``chat_model=$LANGROID_MODEL`` and
-        ``stream=True`` (primary agent streams to SSE; distinct from the
-        planner's ``stream=False``).
+        ``stream=True`` (primary agent streams to SSE).
       - construct ``ChatAgent`` and call ``enable_message(list(ALL_TOOLS))``
         with every tool.
 
@@ -1791,9 +344,8 @@ def test_create_agent_wires_all_tools_with_stream_true(monkeypatch):
 
 def test_create_agent_default_model_when_langroid_model_unset(monkeypatch):
     """When ``LANGROID_MODEL`` is unset, ``create_agent`` falls back to the
-    documented default ``gpt-4.1``. Pins the default string in a
-    second test site (the other is ``_resolve_a2ui_model``) so a silent
-    drift between the two defaults is caught."""
+    documented default ``gpt-4.1``. Pins the default string so a silent
+    drift between the primary agent default and documentation is caught."""
     monkeypatch.delenv("LANGROID_MODEL", raising=False)
 
     captured_config_kwargs: list[dict] = []
@@ -1820,6 +372,131 @@ def test_create_agent_default_model_when_langroid_model_unset(monkeypatch):
         create_agent()
 
     assert captured_config_kwargs[0]["chat_model"] == "gpt-4.1"
+
+
+# ---------------------------------------------------------------------------
+# Module hygiene: no top-level openai import (including inside top-level
+# try/except blocks, conditional imports, etc. — anywhere that runs at
+# module load time).
+# ---------------------------------------------------------------------------
+
+
+def _module_level_ancestors(tree: ast.Module) -> dict[int, bool]:
+    """Return a map ``id(node) -> is_module_level``.
+
+    A node is module-level iff the chain of containing nodes from the
+    module root never passes through a ``FunctionDef`` / ``AsyncFunctionDef``.
+    Top-level ``Try`` / ``If`` / ``With`` / ``ClassDef`` blocks DO count as
+    module-level — their bodies execute at import time. A regression that
+    drops an ``import openai`` into a class body (e.g. default-factory
+    attribute, metaclass setup) must be caught here too.
+    """
+    is_module_level: dict[int, bool] = {}
+
+    def _walk(node: ast.AST, inside_func: bool) -> None:
+        # Any import statement encountered here gets tagged. We don't need
+        # every node, just the imports — but walking uniformly keeps the
+        # logic simple.
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            is_module_level[id(node)] = not inside_func
+        # Recurse, flipping the flag only when we enter a function body
+        # (its code runs on call, not at import time). Class bodies execute
+        # at module load, so we intentionally do NOT flip the flag for
+        # ``ClassDef``.
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for child in ast.iter_child_nodes(node):
+                _walk(child, inside_func=True)
+        else:
+            for child in ast.iter_child_nodes(node):
+                _walk(child, inside_func=inside_func)
+
+    _walk(tree, inside_func=False)
+    return is_module_level
+
+
+def test_agent_module_does_not_import_openai_at_module_load_time():
+    """The provider-agnostic fix requires that importing ``agents.agent``
+    does not pull in the ``openai`` SDK. A module-load-time ``import openai``
+    — whether at the top of the file, inside a top-level ``try/except``, or
+    inside a top-level ``if``/``with``/etc — would reintroduce the
+    hard-coded provider dependency we just removed.
+
+    The previous walker only inspected ``tree.body``, missing imports
+    nested inside a ``try: import openai; except: pass`` pattern (which
+    still runs at module import). This version walks the full AST and
+    flags any import whose execution path is NOT guarded by a
+    ``FunctionDef`` / ``AsyncFunctionDef`` / ``ClassDef`` body.
+    """
+    import agents.agent as mod
+
+    source = inspect.getsource(mod)
+    tree = ast.parse(source)
+    is_module_level = _module_level_ancestors(tree)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Import, ast.ImportFrom)):
+            continue
+        if not is_module_level.get(id(node), False):
+            continue  # inside a function / class body → fine, lazy
+        if isinstance(node, ast.ImportFrom):
+            if node.module and node.module.startswith("openai"):
+                raise AssertionError(
+                    f"agents.agent must not `from openai ...` at module load "
+                    f"time (line {node.lineno}); found: from {node.module} import ..."
+                )
+        else:  # ast.Import
+            for alias in node.names:
+                if alias.name.startswith("openai"):
+                    raise AssertionError(
+                        f"agents.agent must not `import openai` at module load "
+                        f"time (line {node.lineno}); found: {alias.name}"
+                    )
+
+
+def test_agent_module_imports_cleanly_without_openai_env(tmp_path):
+    """Honest import-time regression guard: importing ``agents.agent`` with
+    no OpenAI-specific env must succeed. This catches any top-level
+    ``openai.OpenAI()`` / ``openai.Client()`` call that would re-introduce
+    a hard provider dependency.
+
+    Runs in a SUBPROCESS so module-level state (specifically any
+    module-scope singletons) in the parent interpreter is not perturbed by
+    a reload. Subprocess isolation makes this test order-independent.
+    """
+    # Strip any OPENAI_* / LANGROID_* / A2UI_* env vars the child would
+    # otherwise inherit, but keep everything else (PATH, HOME, etc.) so the
+    # interpreter can actually start.
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith(("OPENAI_", "LANGROID_", "A2UI_"))
+    }
+    # Ensure the child can import ``agents.agent`` via the package's src/
+    # directory — mirrors what conftest.py does for the parent.
+    # Also include the integration root so the ``tools`` symlink (which
+    # lives at ``langroid/tools`` → ``../../shared/python/tools``) is
+    # importable — mirrors the ``PYTHONPATH=".:src:..."`` that the CI
+    # workflow and ``package.json`` dev script both set.
+    pkg_root = Path(__file__).resolve().parents[2]
+    src_dir = pkg_root / "src"
+    existing_pp = env.get("PYTHONPATH", "")
+    new_pp = f"{pkg_root}{os.pathsep}{src_dir}"
+    env["PYTHONPATH"] = f"{new_pp}{os.pathsep}{existing_pp}" if existing_pp else new_pp
+
+    # Run the import from ``tmp_path`` so any stray ``.env`` file in the
+    # project root isn't auto-loaded by ``dotenv.load_dotenv`` (which would
+    # reintroduce OPENAI_* silently and mask a regression).
+    result = subprocess.run(
+        [sys.executable, "-c", "import agents.agent"],
+        env=env,
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"import agents.agent failed in clean subprocess:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Supersedes #6058's two-stage approach (outer `generate_a2ui` → secondary Python LLM call → `render_a2ui`), which severed across the prod streaming boundary.

**Option A** (mirroring crewai-crews #6067): `injectA2UITool` defaults to `true`, so CopilotKit's `A2UIMiddleware` injects `render_a2ui` into `RunAgentInput.tools`. The langroid `agui_adapter.py` now merges those injected tools into its OpenAI call, so the LLM calls `render_a2ui` directly. The middleware intercepts the tool call stream, builds `a2ui_operations`, and fires `RUN_FINISHED` — no secondary Python LLM pass needed.

## Changes

- **`agent.py`**: Remove ~550 lines of two-stage A2UI infrastructure (`generate_a2ui_via_llm`, `_a2ui_error`, `_resolve_a2ui_model`, `_get_a2ui_llm`, `_RENDER_A2UI_FUNCTION_SPEC`, etc.). Replace `GenerateA2UITool.handle` with a stub that logs loudly on regression (middleware should always intercept before reaching Python).
- **`agui_adapter.py`**: Merge `run_input.tools` (AG-UI-injected) into the OpenAI tools list so `render_a2ui` is visible to the LLM. Remove `set_last_user_message` call (ContextVar no longer needed).
- **`route.ts`**: Remove `injectA2UITool: false`; keep `defaultCatalogId` pin.
- **`gen-ui-declarative.json`**: Replace 9 two-stage fixtures with 4 single-stage fixtures matching `toolName: render_a2ui` + `context: langroid`.

## Root cause of prior RED

The langroid adapter builds its OpenAI tool list from `ALL_TOOLS` (Python-side registry) via `_get_openai_tools()`, which does NOT include `render_a2ui`. The `A2UIMiddleware` injects `render_a2ui` into `RunAgentInput.tools` at the AG-UI protocol level, but `agui_adapter.py` ignored `run_input.tools` entirely — so the LLM never saw `render_a2ui` in its tool list, never called it, and the fixture never matched.

## Red-green proof

**RED** (from main, before changes):
```
✗ d6:langroid/gen-ui-declarative  red  (0.0s)
  state=red
0 passed, 1 failed
```

**GREEN** (after this PR's changes, rebuild from worktree):
```
✓ d6:langroid/gen-ui-declarative  green  (0.0s)
1 passed
✓ Tests passed for langroid:declarative-gen-ui
```

Test command: `bin/showcase test langroid:declarative-gen-ui --d6 --isolate --rebuild`

## Related

- Supersedes #6058 (two-stage approach, now reverted in this integration)
- Mirrors #6067 (crewai-crews Option A fix, same pattern)