### PR TITLE
feat(angular): typed custom-catalog helpers + agent metadata derivation for A2UI + Angular-native A2UI Renderer

### DIFF
--- a/packages/angular/a2ui/ng-package.json
+++ b/packages/angular/a2ui/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "../src/a2ui/index.ts"
+  }
+}

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -19,6 +19,12 @@
         "default": "./dist/fesm2022/copilotkit-angular.mjs"
       }
     },
+    "./a2ui": {
+      "import": {
+        "types": "./dist/types/copilotkit-angular-a2ui.d.ts",
+        "default": "./dist/fesm2022/copilotkit-angular-a2ui.mjs"
+      }
+    },
     "./styles.css": "./dist/styles.css"
   },
   "publishConfig": {
@@ -51,9 +57,12 @@
     "rxjs": "^7.8.1",
     "tailwind-merge": "^2.6.0",
     "tslib": "^2.6.0",
+    "zod": "^3.25.76",
     "zod-to-json-schema": "^3.24.5"
   },
   "devDependencies": {
+    "@a2ui/angular": "^0.9.1",
+    "@a2ui/web_core": "^0.9.2",
     "@analogjs/vite-plugin-angular": "^1.20.2",
     "@analogjs/vitest-angular": "^1.20.2",
     "@angular/cdk": "^21.2.13",
@@ -84,13 +93,22 @@
     "tw-animate-css": "^1.3.5",
     "typescript": "5.9.3",
     "vite": "^7.1.4",
-    "vitest": "^3.2.4",
-    "zod": "^3.22.4"
+    "vitest": "^3.2.4"
   },
   "peerDependencies": {
+    "@a2ui/angular": "^0.9.1",
+    "@a2ui/web_core": "^0.9.2",
     "@angular/cdk": "^19.0.0 || ^20.0.0 || ^21.0.0",
     "@angular/common": "^19.0.0 || ^20.0.0 || ^21.0.0",
     "@angular/core": "^19.0.0 || ^20.0.0 || ^21.0.0",
     "rxjs": "^7.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@a2ui/angular": {
+      "optional": true
+    },
+    "@a2ui/web_core": {
+      "optional": true
+    }
   }
 }

--- a/packages/angular/src/a2ui/index.ts
+++ b/packages/angular/src/a2ui/index.ts
@@ -1,0 +1,4 @@
+export * from "./lib/a2ui-angular-catalog";
+export * from "./lib/a2ui-angular-activity-renderer";
+export * from "./lib/a2ui-angular-action-handlers";
+export * from "./lib/provide-a2ui-angular-renderer";

--- a/packages/angular/src/a2ui/index.ts
+++ b/packages/angular/src/a2ui/index.ts
@@ -1,4 +1,6 @@
 export * from "./lib/a2ui-angular-catalog";
 export * from "./lib/a2ui-angular-activity-renderer";
 export * from "./lib/a2ui-angular-action-handlers";
+export * from "./lib/a2ui-angular-catalog-context";
+export * from "./lib/a2ui-angular-schema";
 export * from "./lib/provide-a2ui-angular-renderer";

--- a/packages/angular/src/a2ui/lib/__tests__/a2ui-angular-action-handlers.spec.ts
+++ b/packages/angular/src/a2ui/lib/__tests__/a2ui-angular-action-handlers.spec.ts
@@ -1,0 +1,122 @@
+import { A2uiRendererService } from "@a2ui/angular/v0_9";
+import { EnvironmentInjector, InjectionToken, inject } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { describe, expect, it, vi } from "vitest";
+import { registerA2UIActionHandlers } from "../a2ui-angular-action-handlers";
+import { provideA2UIAngularRenderer } from "../provide-a2ui-angular-renderer";
+
+const BASIC_CATALOG_ID =
+  "https://a2ui.org/specification/v0_9/basic_catalog.json";
+
+const GREETING = new InjectionToken<string>("GREETING", {
+  factory: () => "hello",
+});
+
+function createSurface(renderer: A2uiRendererService, surfaceId: string) {
+  renderer.processMessages([
+    {
+      version: "v0.9",
+      createSurface: { surfaceId, catalogId: BASIC_CATALOG_ID },
+    },
+  ]);
+  const surface = renderer.surfaceGroup.getSurface(surfaceId);
+  if (!surface) {
+    throw new Error(`Surface '${surfaceId}' was not created.`);
+  }
+  return surface;
+}
+
+describe("registerA2UIActionHandlers", () => {
+  it("routes dispatched actions to the handler registered under the action name", async () => {
+    TestBed.configureTestingModule({
+      providers: [provideA2UIAngularRenderer()],
+    });
+    const renderer = TestBed.inject(A2uiRendererService);
+    const bookFlight = vi.fn();
+
+    TestBed.runInInjectionContext(() =>
+      registerA2UIActionHandlers({ bookFlight }),
+    );
+
+    const surface = createSurface(renderer, "surf-a");
+    await surface.dispatchAction(
+      { event: { name: "bookFlight", context: { flightId: 42 } } },
+      "btn-1",
+    );
+
+    expect(bookFlight).toHaveBeenCalledTimes(1);
+    expect(bookFlight).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "bookFlight",
+        surfaceId: "surf-a",
+        sourceComponentId: "btn-1",
+        context: { flightId: 42 },
+      }),
+    );
+  });
+
+  it("ignores actions without a registered handler", async () => {
+    TestBed.configureTestingModule({
+      providers: [provideA2UIAngularRenderer()],
+    });
+    const renderer = TestBed.inject(A2uiRendererService);
+    const bookFlight = vi.fn();
+
+    TestBed.runInInjectionContext(() =>
+      registerA2UIActionHandlers({ bookFlight }),
+    );
+
+    const surface = createSurface(renderer, "surf-b");
+    await surface.dispatchAction(
+      { event: { name: "unknownAction", context: {} } },
+      "btn-1",
+    );
+
+    expect(bookFlight).not.toHaveBeenCalled();
+  });
+
+  it("runs handlers in the environment injection context", async () => {
+    TestBed.configureTestingModule({
+      providers: [provideA2UIAngularRenderer()],
+    });
+    const renderer = TestBed.inject(A2uiRendererService);
+    let injected: string | undefined;
+
+    TestBed.runInInjectionContext(() =>
+      registerA2UIActionHandlers({
+        greet: () => {
+          injected = inject(GREETING);
+        },
+      }),
+    );
+
+    const surface = createSurface(renderer, "surf-c");
+    await surface.dispatchAction(
+      { event: { name: "greet", context: {} } },
+      "btn-1",
+    );
+
+    expect(injected).toBe("hello");
+  });
+
+  it("stops handling actions when the injection context is destroyed", async () => {
+    TestBed.configureTestingModule({
+      providers: [provideA2UIAngularRenderer()],
+    });
+    const renderer = TestBed.inject(A2uiRendererService);
+    const bookFlight = vi.fn();
+
+    TestBed.runInInjectionContext(() =>
+      registerA2UIActionHandlers({ bookFlight }),
+    );
+    const surface = createSurface(renderer, "surf-d");
+
+    TestBed.inject(EnvironmentInjector).destroy();
+    await surface.dispatchAction(
+      { event: { name: "bookFlight", context: {} } },
+      "btn-1",
+    );
+
+    expect(bookFlight).not.toHaveBeenCalled();
+  });
+});

--- a/packages/angular/src/a2ui/lib/__tests__/a2ui-angular-activity-renderer.spec.ts
+++ b/packages/angular/src/a2ui/lib/__tests__/a2ui-angular-activity-renderer.spec.ts
@@ -1,0 +1,138 @@
+import { provideMarkdownRenderer } from "@a2ui/angular/v0_9";
+import { NgComponentOutlet } from "@angular/common";
+import { Component, signal } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { describe, expect, it } from "vitest";
+import {
+  CopilotA2UIAngularActivityRenderer,
+  a2uiAngularActivityRendererConfig,
+  a2uiSurfaceContentSchema,
+} from "../a2ui-angular-activity-renderer";
+import { provideA2UIAngularRenderer } from "../provide-a2ui-angular-renderer";
+import { installConstructableStyleSheetSupport } from "./constructable-stylesheet-support";
+
+installConstructableStyleSheetSupport();
+
+const BASIC_CATALOG_ID =
+  "https://a2ui.org/specification/v0_9/basic_catalog.json";
+
+function inputsFor(id: string): Record<string, unknown> {
+  const content = {
+    operations: [
+      {
+        version: "v0.9",
+        createSurface: { surfaceId: id, catalogId: BASIC_CATALOG_ID },
+      },
+      {
+        version: "v0.9",
+        updateComponents: {
+          surfaceId: id,
+          components: [
+            { id: "root", component: "Column", children: ["t"] },
+            { id: "t", component: "Text", text: `hi ${id}` },
+          ],
+        },
+      },
+    ],
+  };
+  return {
+    activityType: "a2ui-surface",
+    content,
+    message: { id, role: "activity", activityType: "a2ui-surface", content },
+    agent: undefined,
+  };
+}
+
+@Component({
+  imports: [NgComponentOutlet],
+  template: `
+    @for (item of items(); track item.id) {
+      <ng-container *ngComponentOutlet="renderer; inputs: item.inputs" />
+    }
+  `,
+})
+class HostComponent {
+  readonly renderer = CopilotA2UIAngularActivityRenderer;
+  readonly items = signal<{ id: string; inputs: Record<string, unknown> }[]>(
+    [],
+  );
+}
+
+async function settle(fixture: {
+  whenStable: () => Promise<unknown>;
+  detectChanges: () => void;
+}) {
+  await fixture.whenStable();
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  fixture.detectChanges();
+  await fixture.whenStable();
+}
+
+describe("CopilotA2UIAngularActivityRenderer", () => {
+  it("renders an A2UI surface from an a2ui-surface activity message", async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideA2UIAngularRenderer(),
+        provideMarkdownRenderer(async (markdown) => markdown),
+      ],
+    });
+
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.componentInstance.items.set([
+      { id: "surf-1", inputs: inputsFor("surf-1") },
+    ]);
+    fixture.detectChanges();
+    await settle(fixture);
+
+    expect(fixture.nativeElement.textContent).toContain("hi surf-1");
+  });
+
+  it("renders a second surface appended after the first in the shared renderer", async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideA2UIAngularRenderer(),
+        provideMarkdownRenderer(async (markdown) => markdown),
+      ],
+    });
+
+    const fixture = TestBed.createComponent(HostComponent);
+    const host = fixture.componentInstance;
+
+    host.items.set([{ id: "surf-1", inputs: inputsFor("surf-1") }]);
+    fixture.detectChanges();
+    await settle(fixture);
+    expect(fixture.nativeElement.textContent).toContain("hi surf-1");
+
+    host.items.update((current) => [
+      ...current,
+      { id: "surf-2", inputs: inputsFor("surf-2") },
+    ]);
+    fixture.detectChanges();
+    await settle(fixture);
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain("hi surf-1");
+    expect(text).toContain("hi surf-2");
+  });
+
+  it("accepts a2ui-surface content with an operations array", () => {
+    const parsed = a2uiSurfaceContentSchema.safeParse({
+      operations: [{ version: "v0.9", createSurface: { surfaceId: "s" } }],
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects a2ui-surface content without operations", () => {
+    const parsed = a2uiSurfaceContentSchema.safeParse({ wrong: true });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("is preconfigured for the a2ui-surface activity type", () => {
+    expect(a2uiAngularActivityRendererConfig.activityType).toBe("a2ui-surface");
+    expect(a2uiAngularActivityRendererConfig.component).toBe(
+      CopilotA2UIAngularActivityRenderer,
+    );
+  });
+});

--- a/packages/angular/src/a2ui/lib/__tests__/a2ui-angular-catalog-context.spec.ts
+++ b/packages/angular/src/a2ui/lib/__tests__/a2ui-angular-catalog-context.spec.ts
@@ -1,0 +1,71 @@
+import { Component, input } from "@angular/core";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  A2UI_CATALOG_CONTEXT_DESCRIPTION,
+  catalogIdToContextEntry,
+  catalogToContextEntry,
+} from "../a2ui-angular-catalog-context";
+import {
+  binding,
+  createCustomComponent,
+  type ContextFromSchema,
+} from "../a2ui-angular-schema";
+
+const CATALOG_ID = "https://example.com/catalogs/test-catalog";
+
+const cardSchema = z
+  .object({
+    title: binding(z.string()),
+  })
+  .strict();
+
+@Component({ template: `` })
+class CardComponent {
+  readonly props = input.required<ContextFromSchema<typeof cardSchema>>();
+}
+
+describe("catalogIdToContextEntry", () => {
+  it("carries only the catalog id", () => {
+    const entry = catalogIdToContextEntry(CATALOG_ID);
+
+    expect(entry.description).toBe(A2UI_CATALOG_CONTEXT_DESCRIPTION);
+    expect(JSON.parse(entry.value)).toEqual({
+      catalogId: CATALOG_ID,
+      components: {},
+    });
+  });
+});
+
+describe("catalogToContextEntry", () => {
+  it("serializes component metadata with inline JSON schemas", () => {
+    const entry = catalogToContextEntry({
+      id: CATALOG_ID,
+      components: [
+        createCustomComponent({
+          name: "Card",
+          description: "A card with a title.",
+          schema: cardSchema,
+          component: CardComponent,
+        }),
+      ],
+    });
+
+    expect(entry.description).toBe(A2UI_CATALOG_CONTEXT_DESCRIPTION);
+
+    const value = JSON.parse(entry.value);
+    expect(value.catalogId).toBe(CATALOG_ID);
+    expect(value.components.Card.description).toBe("A card with a title.");
+    expect(value.components.Card.schema.properties.title.anyOf).toHaveLength(2);
+    expect(entry.value).not.toContain('"$ref"');
+  });
+
+  it("still emits an entry for a catalog without components", () => {
+    const entry = catalogToContextEntry({ id: CATALOG_ID, components: [] });
+
+    expect(JSON.parse(entry.value)).toEqual({
+      catalogId: CATALOG_ID,
+      components: {},
+    });
+  });
+});

--- a/packages/angular/src/a2ui/lib/__tests__/a2ui-angular-schema.spec.ts
+++ b/packages/angular/src/a2ui/lib/__tests__/a2ui-angular-schema.spec.ts
@@ -1,0 +1,99 @@
+import { Component, input } from "@angular/core";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  binding,
+  createCustomCatalog,
+  createCustomComponent,
+  createCustomFunction,
+  type ContextFromSchema,
+} from "../a2ui-angular-schema";
+
+const cardSchema = z
+  .object({
+    title: binding(z.string()),
+    delay: binding(z.number()).optional(),
+  })
+  .strict();
+
+@Component({
+  template: `
+    <span>{{ props().title.value() }}</span>
+  `,
+})
+class CardComponent {
+  readonly props = input.required<ContextFromSchema<typeof cardSchema>>();
+}
+
+describe("binding", () => {
+  it("accepts a literal value", () => {
+    expect(binding(z.string()).safeParse("Paris").success).toBe(true);
+  });
+
+  it("accepts a path binding", () => {
+    expect(binding(z.string()).safeParse({ path: "/flight/to" }).success).toBe(
+      true,
+    );
+  });
+
+  it("rejects a path binding with extra keys", () => {
+    const parsed = binding(z.string()).safeParse({
+      path: "/flight/to",
+      extra: true,
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects values outside the wrapped schema", () => {
+    expect(binding(z.string()).safeParse(42).success).toBe(false);
+  });
+});
+
+describe("createCustomComponent", () => {
+  it("returns the entry unchanged with full type inference", () => {
+    const entry = createCustomComponent({
+      name: "Card",
+      description: "A card with a title.",
+      schema: cardSchema,
+      component: CardComponent,
+    });
+
+    expect(entry.name).toBe("Card");
+    expect(entry.component).toBe(CardComponent);
+    expect(entry.schema).toBe(cardSchema);
+  });
+});
+
+describe("createCustomFunction", () => {
+  it("returns the function unchanged and types execute from the schema", () => {
+    const fn = createCustomFunction({
+      name: "formatPrice",
+      description: "Formats a price in euro.",
+      returnType: "string",
+      schema: z.object({ amount: z.number() }),
+      execute: ({ amount }) => `${amount.toFixed(2)} EUR`,
+    });
+
+    expect(fn.name).toBe("formatPrice");
+    expect(fn.execute({ amount: 12 })).toBe("12.00 EUR");
+  });
+});
+
+describe("createCustomCatalog", () => {
+  it("returns the catalog unchanged", () => {
+    const entry = createCustomComponent({
+      name: "Card",
+      description: "A card with a title.",
+      schema: cardSchema,
+      component: CardComponent,
+    });
+    const catalog = createCustomCatalog({
+      id: "https://example.com/catalogs/cards",
+      components: [entry],
+    });
+
+    expect(catalog.id).toBe("https://example.com/catalogs/cards");
+    expect(catalog.components).toEqual([entry]);
+  });
+});

--- a/packages/angular/src/a2ui/lib/__tests__/constructable-stylesheet-support.ts
+++ b/packages/angular/src/a2ui/lib/__tests__/constructable-stylesheet-support.ts
@@ -1,0 +1,21 @@
+/**
+ * jsdom does not implement constructable stylesheets, which the A2UI basic
+ * catalog uses to inject its default styles. Installs the minimal surface the
+ * catalog needs so basic-catalog components can be instantiated in tests.
+ */
+export function installConstructableStyleSheetSupport(): void {
+  const prototype = globalThis.CSSStyleSheet?.prototype as
+    | (CSSStyleSheet & { replaceSync?: (text: string) => void })
+    | undefined;
+  if (prototype && typeof prototype.replaceSync !== "function") {
+    prototype.replaceSync = () => undefined;
+  }
+
+  if (!Array.isArray(document.adoptedStyleSheets)) {
+    Object.defineProperty(document, "adoptedStyleSheets", {
+      value: [],
+      writable: true,
+      configurable: true,
+    });
+  }
+}

--- a/packages/angular/src/a2ui/lib/__tests__/provide-a2ui-angular-renderer.spec.ts
+++ b/packages/angular/src/a2ui/lib/__tests__/provide-a2ui-angular-renderer.spec.ts
@@ -5,11 +5,13 @@ import {
   provideMarkdownRenderer,
   type BoundProperty,
 } from "@a2ui/angular/v0_9";
-import { Component, input } from "@angular/core";
+import { Component, EnvironmentInjector, input } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
+import { CopilotKit, provideCopilotKit } from "@copilotkit/angular";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import type { A2UIAngularCatalog } from "../a2ui-angular-catalog";
+import { A2UI_CATALOG_CONTEXT_DESCRIPTION } from "../a2ui-angular-catalog-context";
 import { CopilotA2UIAngularActivityRenderer } from "../a2ui-angular-activity-renderer";
 import { provideA2UIAngularRenderer } from "../provide-a2ui-angular-renderer";
 import { installConstructableStyleSheetSupport } from "./constructable-stylesheet-support";
@@ -74,7 +76,10 @@ describe("provideA2UIAngularRenderer", () => {
 
   it("extends the basic catalog with custom components and functions", () => {
     TestBed.configureTestingModule({
-      providers: [provideA2UIAngularRenderer(customCatalog())],
+      providers: [
+        provideCopilotKit({}),
+        provideA2UIAngularRenderer(customCatalog()),
+      ],
     });
 
     const config = TestBed.inject(A2UI_RENDERER_CONFIG);
@@ -90,7 +95,10 @@ describe("provideA2UIAngularRenderer", () => {
 
   it("validates function arguments before executing them", () => {
     TestBed.configureTestingModule({
-      providers: [provideA2UIAngularRenderer(customCatalog())],
+      providers: [
+        provideCopilotKit({}),
+        provideA2UIAngularRenderer(customCatalog()),
+      ],
     });
 
     const config = TestBed.inject(A2UI_RENDERER_CONFIG);
@@ -111,6 +119,7 @@ describe("provideA2UIAngularRenderer", () => {
   it("renders a custom Angular component emitted by the agent", async () => {
     TestBed.configureTestingModule({
       providers: [
+        provideCopilotKit({}),
         provideA2UIAngularRenderer(customCatalog()),
         provideMarkdownRenderer(async (markdown) => markdown),
       ],
@@ -156,5 +165,75 @@ describe("provideA2UIAngularRenderer", () => {
     );
     expect(card).not.toBeNull();
     expect(card?.textContent).toContain("Hello Custom");
+  });
+
+  function findCatalogContextEntry(copilotKit: CopilotKit) {
+    return Object.values(copilotKit.core.context).find(
+      (candidate) => candidate.description === A2UI_CATALOG_CONTEXT_DESCRIPTION,
+    );
+  }
+
+  it("registers the catalog descriptor as agent context", () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideCopilotKit({}),
+        provideA2UIAngularRenderer(customCatalog()),
+      ],
+    });
+
+    const copilotKit = TestBed.inject(CopilotKit);
+    const entry = findCatalogContextEntry(copilotKit);
+
+    expect(entry).toBeDefined();
+    const value = JSON.parse(entry!.value);
+    expect(value.catalogId).toBe(CUSTOM_CATALOG_ID);
+    expect(Object.keys(value.components)).toEqual(["TestCard"]);
+    expect(value.components.TestCard.schema.properties.title).toBeDefined();
+  });
+
+  it("forwards only the catalog id when sendCatalogDescription is false", () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideCopilotKit({}),
+        provideA2UIAngularRenderer(customCatalog(), {
+          sendCatalogDescription: false,
+        }),
+      ],
+    });
+
+    const copilotKit = TestBed.inject(CopilotKit);
+    const entry = findCatalogContextEntry(copilotKit);
+
+    expect(entry).toBeDefined();
+    expect(JSON.parse(entry!.value)).toEqual({
+      catalogId: CUSTOM_CATALOG_ID,
+      components: {},
+    });
+  });
+
+  it("does not register catalog context when no catalog is given", () => {
+    TestBed.configureTestingModule({
+      providers: [provideCopilotKit({}), provideA2UIAngularRenderer()],
+    });
+
+    const copilotKit = TestBed.inject(CopilotKit);
+
+    expect(findCatalogContextEntry(copilotKit)).toBeUndefined();
+  });
+
+  it("removes the catalog context when the injector is destroyed", () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideCopilotKit({}),
+        provideA2UIAngularRenderer(customCatalog()),
+      ],
+    });
+
+    const copilotKit = TestBed.inject(CopilotKit);
+    expect(findCatalogContextEntry(copilotKit)).toBeDefined();
+
+    TestBed.inject(EnvironmentInjector).destroy();
+
+    expect(findCatalogContextEntry(copilotKit)).toBeUndefined();
   });
 });

--- a/packages/angular/src/a2ui/lib/__tests__/provide-a2ui-angular-renderer.spec.ts
+++ b/packages/angular/src/a2ui/lib/__tests__/provide-a2ui-angular-renderer.spec.ts
@@ -1,0 +1,160 @@
+import {
+  A2UI_RENDERER_CONFIG,
+  A2uiRendererService,
+  BasicCatalog,
+  provideMarkdownRenderer,
+  type BoundProperty,
+} from "@a2ui/angular/v0_9";
+import { Component, input } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import type { A2UIAngularCatalog } from "../a2ui-angular-catalog";
+import { CopilotA2UIAngularActivityRenderer } from "../a2ui-angular-activity-renderer";
+import { provideA2UIAngularRenderer } from "../provide-a2ui-angular-renderer";
+import { installConstructableStyleSheetSupport } from "./constructable-stylesheet-support";
+
+installConstructableStyleSheetSupport();
+
+const CUSTOM_CATALOG_ID = "https://example.com/catalogs/test-catalog";
+
+interface TestCardProps {
+  title?: BoundProperty<string>;
+}
+
+@Component({
+  template: `
+    <span data-testid="test-card">{{ props().title?.value() ?? "" }}</span>
+  `,
+})
+class TestCardComponent {
+  readonly props = input<TestCardProps>({});
+  readonly surfaceId = input<string>("");
+  readonly componentId = input<string>("");
+  readonly dataContextPath = input("/");
+}
+
+function customCatalog(): A2UIAngularCatalog {
+  return {
+    id: CUSTOM_CATALOG_ID,
+    components: [
+      {
+        name: "TestCard",
+        description: "A test card showing a title.",
+        component: TestCardComponent,
+        schema: z.object({
+          title: z.union([z.string(), z.object({ path: z.string() }).strict()]),
+        }),
+      },
+    ],
+    functions: [
+      {
+        name: "double",
+        description: "Doubles a number.",
+        returnType: "number",
+        schema: z.object({ value: z.number() }),
+        execute: ({ value }) => value * 2,
+      },
+    ],
+  };
+}
+
+describe("provideA2UIAngularRenderer", () => {
+  it("registers the standard basic catalog when no catalog is given", () => {
+    TestBed.configureTestingModule({
+      providers: [provideA2UIAngularRenderer()],
+    });
+
+    const config = TestBed.inject(A2UI_RENDERER_CONFIG);
+
+    expect(config.catalogs).toHaveLength(1);
+    expect(config.catalogs[0]).toBeInstanceOf(BasicCatalog);
+    expect(TestBed.inject(A2uiRendererService)).toBeTruthy();
+  });
+
+  it("extends the basic catalog with custom components and functions", () => {
+    TestBed.configureTestingModule({
+      providers: [provideA2UIAngularRenderer(customCatalog())],
+    });
+
+    const config = TestBed.inject(A2UI_RENDERER_CONFIG);
+    const catalog = config.catalogs[0];
+
+    expect(catalog.id).toBe(CUSTOM_CATALOG_ID);
+    expect(catalog.components.get("TestCard")?.component).toBe(
+      TestCardComponent,
+    );
+    expect(catalog.components.has("Text")).toBe(true);
+    expect(catalog.functions.has("double")).toBe(true);
+  });
+
+  it("validates function arguments before executing them", () => {
+    TestBed.configureTestingModule({
+      providers: [provideA2UIAngularRenderer(customCatalog())],
+    });
+
+    const config = TestBed.inject(A2UI_RENDERER_CONFIG);
+    const double = config.catalogs[0].functions.get("double");
+
+    expect(
+      double?.execute({ value: 21 }, undefined as never, undefined as never),
+    ).toBe(42);
+    expect(() =>
+      double?.execute(
+        { value: "not a number" },
+        undefined as never,
+        undefined as never,
+      ),
+    ).toThrow();
+  });
+
+  it("renders a custom Angular component emitted by the agent", async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideA2UIAngularRenderer(customCatalog()),
+        provideMarkdownRenderer(async (markdown) => markdown),
+      ],
+    });
+
+    const fixture = TestBed.createComponent(CopilotA2UIAngularActivityRenderer);
+    const content = {
+      operations: [
+        {
+          version: "v0.9",
+          createSurface: {
+            surfaceId: "surf-custom",
+            catalogId: CUSTOM_CATALOG_ID,
+          },
+        },
+        {
+          version: "v0.9",
+          updateComponents: {
+            surfaceId: "surf-custom",
+            components: [
+              { id: "root", component: "Column", children: ["card"] },
+              { id: "card", component: "TestCard", title: "Hello Custom" },
+            ],
+          },
+        },
+      ],
+    };
+    fixture.componentRef.setInput("activityType", "a2ui-surface");
+    fixture.componentRef.setInput("content", content);
+    fixture.componentRef.setInput("message", {
+      id: "activity-1",
+      role: "activity",
+      activityType: "a2ui-surface",
+      content,
+    });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    fixture.detectChanges();
+
+    const card = fixture.nativeElement.querySelector(
+      '[data-testid="test-card"]',
+    );
+    expect(card).not.toBeNull();
+    expect(card?.textContent).toContain("Hello Custom");
+  });
+});

--- a/packages/angular/src/a2ui/lib/a2ui-angular-action-handlers.ts
+++ b/packages/angular/src/a2ui/lib/a2ui-angular-action-handlers.ts
@@ -1,0 +1,47 @@
+import { A2uiRendererService } from "@a2ui/angular/v0_9";
+import type { A2uiClientAction } from "@a2ui/web_core/v0_9";
+import {
+  DestroyRef,
+  EnvironmentInjector,
+  assertInInjectionContext,
+  inject,
+  runInInjectionContext,
+} from "@angular/core";
+
+/** Maps an A2UI action name to the handler invoked when it is dispatched. */
+export type A2UIActionHandlers = Record<
+  string,
+  (action: A2uiClientAction) => void
+>;
+
+/**
+ * Subscribes to actions dispatched from any rendered A2UI surface and routes
+ * each action to the handler registered under the action's name. Actions
+ * without a registered handler are ignored.
+ *
+ * Handlers run in the environment injection context, so they can use
+ * `inject()` to access application services. Must be called in an injection
+ * context; the subscription is released when that context is destroyed.
+ */
+export function registerA2UIActionHandlers(handlers: A2UIActionHandlers): void {
+  assertInInjectionContext(registerA2UIActionHandlers);
+
+  const renderer = inject(A2uiRendererService);
+  const destroyRef = inject(DestroyRef);
+  const environmentInjector = inject(EnvironmentInjector);
+
+  const subscription = renderer.surfaceGroup.onAction.subscribe((action) => {
+    const handler = handlers[action.name];
+    if (!handler) {
+      return;
+    }
+
+    runInInjectionContext(environmentInjector, () => {
+      handler(action);
+    });
+  });
+
+  destroyRef.onDestroy(() => {
+    subscription.unsubscribe();
+  });
+}

--- a/packages/angular/src/a2ui/lib/a2ui-angular-activity-renderer.ts
+++ b/packages/angular/src/a2ui/lib/a2ui-angular-activity-renderer.ts
@@ -1,0 +1,100 @@
+import { A2uiRendererService, SurfaceComponent } from "@a2ui/angular/v0_9";
+import type { A2uiMessage } from "@a2ui/web_core/v0_9";
+import type { AbstractAgent, ActivityMessage } from "@ag-ui/client";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+} from "@angular/core";
+import type {
+  ActivityRenderer,
+  RenderActivityMessageConfig,
+} from "@copilotkit/angular";
+import { z } from "zod";
+
+/**
+ * Content schema for `activityType: "a2ui-surface"` activity messages: the
+ * batch of A2UI protocol operations that describe the rendered surface.
+ */
+export const a2uiSurfaceContentSchema = z.object({
+  operations: z.array(z.custom<A2uiMessage>()),
+});
+
+/** Parsed content of an `a2ui-surface` activity message. */
+export type A2UISurfaceContent = z.infer<typeof a2uiSurfaceContentSchema>;
+
+/**
+ * Activity renderer for `a2ui-surface` snapshots based on the official A2UI
+ * Angular renderer (`@a2ui/angular`).
+ *
+ * The emitted operations are fed into the shared {@link A2uiRendererService},
+ * so all surfaces of a conversation share one surface group and one catalog
+ * configuration. Because the official Angular renderer resolves catalog
+ * entries to Angular component classes, custom components for custom catalogs
+ * can be written as plain Angular components and registered via
+ * `provideA2UIAngularRenderer`.
+ */
+@Component({
+  selector: "copilot-a2ui-angular-activity-renderer",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [SurfaceComponent],
+  template: `
+    @let surface = surfaceId();
+    @if (surface) {
+      <a2ui-v09-surface [surfaceId]="surface" />
+    }
+  `,
+})
+export class CopilotA2UIAngularActivityRenderer implements ActivityRenderer<A2UISurfaceContent> {
+  readonly activityType = input.required<string>();
+  readonly content = input.required<A2UISurfaceContent>();
+  readonly message = input.required<ActivityMessage>();
+  readonly agent = input<AbstractAgent | undefined>();
+
+  private readonly renderer = inject(A2uiRendererService);
+
+  protected readonly surfaceId = computed(() =>
+    getRenderedSurfaceId(this.content().operations),
+  );
+
+  constructor() {
+    effect(() => {
+      this.renderer.processMessages(this.content().operations);
+    });
+  }
+}
+
+/**
+ * Ready-to-register render config for `a2ui-surface` activity messages. Pass
+ * it to `provideCopilotKit({ renderActivityMessages: [...] })` to render A2UI
+ * surfaces with the official Angular renderer.
+ */
+export const a2uiAngularActivityRendererConfig: RenderActivityMessageConfig<A2UISurfaceContent> =
+  {
+    activityType: "a2ui-surface",
+    content: a2uiSurfaceContentSchema,
+    component: CopilotA2UIAngularActivityRenderer,
+  };
+
+function getRenderedSurfaceId(operations: A2uiMessage[]): string | null {
+  for (const operation of operations) {
+    if ("createSurface" in operation && operation.createSurface.surfaceId) {
+      return operation.createSurface.surfaceId;
+    }
+
+    if (
+      "updateComponents" in operation &&
+      operation.updateComponents.surfaceId
+    ) {
+      return operation.updateComponents.surfaceId;
+    }
+
+    if ("updateDataModel" in operation && operation.updateDataModel.surfaceId) {
+      return operation.updateDataModel.surfaceId;
+    }
+  }
+  return null;
+}

--- a/packages/angular/src/a2ui/lib/a2ui-angular-catalog-context.ts
+++ b/packages/angular/src/a2ui/lib/a2ui-angular-catalog-context.ts
@@ -1,0 +1,47 @@
+import type { Context } from "@ag-ui/core";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import type { A2UIAngularCatalog } from "./a2ui-angular-catalog";
+
+/**
+ * Description of the AG-UI context entry that carries the custom catalog
+ * metadata. Servers match on this exact string to extract the entry, so it
+ * must stay stable.
+ */
+export const A2UI_CATALOG_CONTEXT_DESCRIPTION = "A2UI Custom Catalog";
+
+/**
+ * Serializes only the catalog id into an AG-UI context entry. Use this when
+ * the server resolves the trusted catalog descriptor from its own registry
+ * and must not rely on client-supplied metadata.
+ */
+export function catalogIdToContextEntry(catalogId: string): Context {
+  return {
+    description: A2UI_CATALOG_CONTEXT_DESCRIPTION,
+    value: JSON.stringify({ catalogId, components: {} }),
+  };
+}
+
+/**
+ * Serializes a custom catalog into an AG-UI context entry so the agent can
+ * adopt the catalog id and learn the custom component names, descriptions,
+ * and prop schemas. The prop schemas are emitted as JSON Schema with
+ * `$refStrategy: "none"`, keeping them inline so consumers do not have to
+ * resolve `$ref` pointers. A catalog without components still yields an
+ * entry, so the agent always receives the id.
+ */
+export function catalogToContextEntry(catalog: A2UIAngularCatalog): Context {
+  const components = Object.fromEntries(
+    catalog.components.map((component) => [
+      component.name,
+      {
+        description: component.description,
+        schema: zodToJsonSchema(component.schema, { $refStrategy: "none" }),
+      },
+    ]),
+  );
+
+  return {
+    description: A2UI_CATALOG_CONTEXT_DESCRIPTION,
+    value: JSON.stringify({ catalogId: catalog.id, components }),
+  };
+}

--- a/packages/angular/src/a2ui/lib/a2ui-angular-catalog.ts
+++ b/packages/angular/src/a2ui/lib/a2ui-angular-catalog.ts
@@ -1,0 +1,57 @@
+import type { Type } from "@angular/core";
+import type { z } from "zod";
+
+/**
+ * Return type of a custom catalog function, as declared towards the A2UI
+ * renderer's expression evaluator.
+ */
+export type A2UIAngularFunctionReturnType =
+  | "string"
+  | "number"
+  | "boolean"
+  | "array"
+  | "object"
+  | "any"
+  | "void";
+
+/**
+ * A custom component contributed to an A2UI catalog and rendered by a plain
+ * Angular component.
+ *
+ * The agent references the component by `name` in its emitted A2UI operations.
+ * The renderer instantiates `component` and binds every property declared in
+ * `schema` as a `BoundProperty` on the component's `props` input.
+ */
+export interface A2UIAngularCatalogComponent {
+  name: string;
+  description: string;
+  component: Type<unknown>;
+  schema: z.ZodTypeAny;
+}
+
+/**
+ * A custom function contributed to an A2UI catalog and callable from A2UI
+ * expressions. Arguments are validated against `schema` before `execute`
+ * is invoked.
+ */
+export interface A2UIAngularCatalogFunction<
+  TName extends string = string,
+  TSchema extends z.ZodTypeAny = z.ZodTypeAny,
+> {
+  name: TName;
+  description: string;
+  returnType: A2UIAngularFunctionReturnType;
+  schema: TSchema;
+  execute: (args: z.infer<TSchema>) => unknown;
+}
+
+/**
+ * Describes a custom A2UI catalog: a stable catalog id plus the Angular
+ * components and functions that extend the standard basic catalog under
+ * that id.
+ */
+export interface A2UIAngularCatalog {
+  id: string;
+  components: A2UIAngularCatalogComponent[];
+  functions?: A2UIAngularCatalogFunction[];
+}

--- a/packages/angular/src/a2ui/lib/a2ui-angular-schema.ts
+++ b/packages/angular/src/a2ui/lib/a2ui-angular-schema.ts
@@ -1,0 +1,85 @@
+import type { BoundProperty } from "@a2ui/angular/v0_9";
+import type { Signal, Type } from "@angular/core";
+import { z } from "zod";
+import type {
+  A2UIAngularCatalog,
+  A2UIAngularCatalogFunction,
+} from "./a2ui-angular-catalog";
+
+type StripPathBinding<T> = T extends { path: string } ? never : T;
+
+/**
+ * Derives the shape of a custom component's `props` input from its Zod
+ * schema: every declared prop is exposed as a `BoundProperty` whose value
+ * signal resolves literals as well as path bindings against the surface's
+ * data model.
+ */
+export type ContextFromSchema<TSchema extends z.ZodObject<z.ZodRawShape>> = {
+  [K in keyof z.infer<TSchema>]-?: BoundProperty<
+    StripPathBinding<NonNullable<z.infer<TSchema>[K]>>
+  >;
+};
+
+/**
+ * Wraps a value schema in a union with a path-binding schema.
+ *
+ * Use this for every prop of a custom A2UI component so the agent can either
+ * provide a literal value (e.g. `"Paris"`) or a path binding into the
+ * surface's data model (e.g. `{ path: "/flight/to" }`).
+ */
+export const binding = <T extends z.ZodTypeAny>(value: T) =>
+  z.union([value, z.object({ path: z.string() }).strict()]);
+
+/**
+ * A fully typed custom-component entry: the shape of the component's `props`
+ * input is derived from the Zod schema via {@link ContextFromSchema}, so
+ * component and schema cannot drift apart.
+ */
+export interface A2UIAngularComponentEntry<
+  TName extends string = string,
+  TSchema extends z.ZodObject<z.ZodRawShape> = z.ZodObject<z.ZodRawShape>,
+> {
+  name: TName;
+  description: string;
+  schema: TSchema;
+  component: Type<{
+    props: Signal<ContextFromSchema<TSchema>>;
+  }>;
+}
+
+/**
+ * Identity helper for defining a custom catalog component. Keeps name,
+ * description, prop schema, and Angular component together and verifies at
+ * compile time that the component's `props` input matches the schema.
+ */
+export function createCustomComponent<
+  const TName extends string,
+  const TSchema extends z.ZodObject<z.ZodRawShape>,
+>(
+  entry: A2UIAngularComponentEntry<TName, TSchema>,
+): A2UIAngularComponentEntry<TName, TSchema> {
+  return entry;
+}
+
+/**
+ * Identity helper for defining a custom catalog function. Gives `execute`
+ * full argument type inference from the Zod `schema`.
+ */
+export function createCustomFunction<
+  const TName extends string,
+  const TSchema extends z.ZodTypeAny,
+>(
+  fn: A2UIAngularCatalogFunction<TName, TSchema>,
+): A2UIAngularCatalogFunction<TName, TSchema> {
+  return fn;
+}
+
+/**
+ * Identity helper for defining a custom catalog from component and function
+ * entries while preserving their literal types.
+ */
+export function createCustomCatalog<const TCatalog extends A2UIAngularCatalog>(
+  catalog: TCatalog,
+): TCatalog {
+  return catalog;
+}

--- a/packages/angular/src/a2ui/lib/provide-a2ui-angular-renderer.ts
+++ b/packages/angular/src/a2ui/lib/provide-a2ui-angular-renderer.ts
@@ -9,15 +9,22 @@ import {
 } from "@a2ui/angular/v0_9";
 import type { FunctionImplementation } from "@a2ui/web_core/v0_9";
 import {
+  DestroyRef,
   inject,
   makeEnvironmentProviders,
+  provideEnvironmentInitializer,
   type EnvironmentProviders,
 } from "@angular/core";
+import { CopilotKit } from "@copilotkit/angular";
 import type {
   A2UIAngularCatalog,
   A2UIAngularCatalogComponent,
   A2UIAngularCatalogFunction,
 } from "./a2ui-angular-catalog";
+import {
+  catalogIdToContextEntry,
+  catalogToContextEntry,
+} from "./a2ui-angular-catalog-context";
 
 function toAngularComponentImplementation(
   entry: A2UIAngularCatalogComponent,
@@ -41,6 +48,19 @@ function toFunctionImplementation(
   };
 }
 
+export interface ProvideA2UIAngularRendererOptions {
+  /**
+   * If `true` (default), the agent receives the full catalog descriptor
+   * (component names, descriptions, and prop schemas as JSON Schema) as an
+   * AG-UI context entry.
+   *
+   * Set to `false` to forward only the catalog id. Use this in production
+   * setups where the server resolves the trusted catalog descriptor from its
+   * own registry instead of trusting client-supplied metadata.
+   */
+  sendCatalogDescription?: boolean;
+}
+
 /**
  * Wires the official A2UI Angular renderer (`@a2ui/angular`) into the
  * application so `CopilotA2UIAngularActivityRenderer` can render surfaces.
@@ -49,10 +69,14 @@ function toFunctionImplementation(
  * catalog descriptor, the basic components and functions are extended by the
  * given custom Angular components and functions under the catalog's id, so
  * agents can target the custom catalog while all standard components keep
- * working.
+ * working. The catalog metadata is additionally registered as an AG-UI
+ * context entry (see {@link ProvideA2UIAngularRendererOptions} to restrict
+ * it to the catalog id), so agents learn which custom components they may
+ * emit.
  */
 export function provideA2UIAngularRenderer(
   catalog?: A2UIAngularCatalog,
+  options?: ProvideA2UIAngularRendererOptions,
 ): EnvironmentProviders {
   if (!catalog) {
     return makeEnvironmentProviders([
@@ -79,8 +103,22 @@ export function provideA2UIAngularRenderer(
     catalogs: [rendererCatalog],
   };
 
+  const { sendCatalogDescription = true } = options ?? {};
+
   return makeEnvironmentProviders([
     { provide: A2UI_RENDERER_CONFIG, useValue: rendererConfig },
     A2uiRendererService,
+    provideEnvironmentInitializer(() => {
+      const copilotKit = inject(CopilotKit);
+      const destroyRef = inject(DestroyRef);
+      const entry = sendCatalogDescription
+        ? catalogToContextEntry(catalog)
+        : catalogIdToContextEntry(catalog.id);
+      const contextId = copilotKit.core.addContext(entry);
+
+      destroyRef.onDestroy(() => {
+        copilotKit.core.removeContext(contextId);
+      });
+    }),
   ]);
 }

--- a/packages/angular/src/a2ui/lib/provide-a2ui-angular-renderer.ts
+++ b/packages/angular/src/a2ui/lib/provide-a2ui-angular-renderer.ts
@@ -1,0 +1,86 @@
+import {
+  A2UI_RENDERER_CONFIG,
+  A2uiRendererService,
+  BASIC_FUNCTIONS,
+  BasicCatalog,
+  BasicCatalogBase,
+  type AngularComponentImplementation,
+  type RendererConfiguration,
+} from "@a2ui/angular/v0_9";
+import type { FunctionImplementation } from "@a2ui/web_core/v0_9";
+import {
+  inject,
+  makeEnvironmentProviders,
+  type EnvironmentProviders,
+} from "@angular/core";
+import type {
+  A2UIAngularCatalog,
+  A2UIAngularCatalogComponent,
+  A2UIAngularCatalogFunction,
+} from "./a2ui-angular-catalog";
+
+function toAngularComponentImplementation(
+  entry: A2UIAngularCatalogComponent,
+): AngularComponentImplementation {
+  return {
+    name: entry.name,
+    component: entry.component,
+    schema: entry.schema,
+  } as unknown as AngularComponentImplementation;
+}
+
+function toFunctionImplementation(
+  fn: A2UIAngularCatalogFunction,
+): FunctionImplementation {
+  return {
+    name: fn.name,
+    returnType: fn.returnType,
+    schema: fn.schema as unknown as FunctionImplementation["schema"],
+    execute: (args: Record<string, unknown>) =>
+      fn.execute(fn.schema.parse(args)),
+  };
+}
+
+/**
+ * Wires the official A2UI Angular renderer (`@a2ui/angular`) into the
+ * application so `CopilotA2UIAngularActivityRenderer` can render surfaces.
+ *
+ * Without arguments, the standard `BasicCatalog` is registered. With a
+ * catalog descriptor, the basic components and functions are extended by the
+ * given custom Angular components and functions under the catalog's id, so
+ * agents can target the custom catalog while all standard components keep
+ * working.
+ */
+export function provideA2UIAngularRenderer(
+  catalog?: A2UIAngularCatalog,
+): EnvironmentProviders {
+  if (!catalog) {
+    return makeEnvironmentProviders([
+      {
+        provide: A2UI_RENDERER_CONFIG,
+        useFactory: (): RendererConfiguration => ({
+          catalogs: [inject(BasicCatalog)],
+        }),
+      },
+      A2uiRendererService,
+    ]);
+  }
+
+  const rendererCatalog = new BasicCatalogBase({
+    id: catalog.id,
+    extraComponents: catalog.components.map(toAngularComponentImplementation),
+    functions: [
+      ...BASIC_FUNCTIONS,
+      ...(catalog.functions ?? []).map(toFunctionImplementation),
+    ],
+  });
+
+  const rendererConfig: RendererConfiguration = {
+    catalogs: [rendererCatalog],
+  };
+
+  return makeEnvironmentProviders([
+    { provide: A2UI_RENDERER_CONFIG, useValue: rendererConfig },
+    A2uiRendererService,
+  ]);
+}

--- a/packages/angular/tsconfig.json
+++ b/packages/angular/tsconfig.json
@@ -18,6 +18,7 @@
     "importHelpers": true,
     "types": ["node"],
     "paths": {
+      "@copilotkit/angular": ["./src/public-api.ts"],
       "@copilotkit/a2ui-renderer/web-components": [
         "../a2ui-renderer/src/web-components/index.ts"
       ],

--- a/packages/angular/vitest.config.mts
+++ b/packages/angular/vitest.config.mts
@@ -10,6 +10,9 @@ const r = (...p: string[]) => resolve(__dirname, ...p);
 export default defineConfig(({ mode }) => ({
   plugins: [angular()],
   resolve: {
+    alias: {
+      "@copilotkit/angular": r("src/public-api.ts"),
+    },
     dedupe: [
       "@angular/core",
       "@angular/common",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2251,10 +2251,19 @@ importers:
       tslib:
         specifier: ^2.6.0
         version: 2.8.1
+      zod:
+        specifier: '>=3.22.3'
+        version: 3.25.76
       zod-to-json-schema:
         specifier: ^3.24.5
         version: 3.25.1(zod@3.25.76)
     devDependencies:
+      '@a2ui/angular':
+        specifier: ^0.9.1
+        version: 0.9.1(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1))(rxjs@7.8.1))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1))(@angular/platform-browser@21.2.15(@angular/animations@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1)))(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1))(rxjs@7.8.1))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1)))
+      '@a2ui/web_core':
+        specifier: ^0.9.2
+        version: 0.9.2
       '@analogjs/vite-plugin-angular':
         specifier: ^1.20.2
         version: 1.22.5(@angular-devkit/build-angular@20.3.26(e74296cd50e248d850db2882907edb7f))(@angular/build@20.3.26(@angular/compiler-cli@21.2.15(@angular/compiler@21.2.15)(typescript@5.9.3))(@angular/compiler@21.2.15)(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1))(@angular/platform-browser@21.2.15(@angular/animations@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1)))(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1))(rxjs@7.8.1))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1)))(@types/node@22.19.11)(chokidar@5.0.0)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(ng-packagr@21.2.3(@angular/compiler-cli@21.2.15(@angular/compiler@21.2.15)(typescript@5.9.3))(tailwindcss@4.1.18)(tslib@2.8.1)(typescript@5.9.3))(postcss@8.5.6)(tailwindcss@4.1.18)(terser@5.46.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4)(yaml@2.9.0))
@@ -2342,9 +2351,6 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(@vitest/ui@3.2.4)(jiti@2.7.0)(jsdom@24.1.3)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
-      zod:
-        specifier: '>=3.22.3'
-        version: 3.25.76
 
   packages/channels:
     dependencies:
@@ -4013,6 +4019,17 @@ packages:
     resolution: {integrity: sha512-VTDuRS5V0ATbJ/LkaQlisMnTAeYKXAK6scMguVBstf+KIBQ7HIuKhiXLv+G/hvejkV+THoXzoNifInAkU81P1g==}
     engines: {node: '>=18'}
 
+  '@a2ui/angular@0.9.1':
+    resolution: {integrity: sha512-P35j7l/1Id3VkpmNm5LNCnsuSzM/eA3RRg4knCAD0mwaAgHNxsYT0FGYiTyeFIFoWck0foxNnh6I0hiKb7QJjw==}
+    peerDependencies:
+      '@a2ui/markdown-it': ^0.0.3
+      '@angular/common': ^21.2.0
+      '@angular/core': ^21.2.0
+      '@angular/platform-browser': ^21.2.0
+    peerDependenciesMeta:
+      '@a2ui/markdown-it':
+        optional: true
+
   '@a2ui/lit@0.8.3':
     resolution: {integrity: sha512-YXJksuier3nZLFtdrXfMNd7WdEOldQEfXGDMqoBTMVIM8xU22F/SvfNeDJoKQ4Wn7hXzRMi0vnwq0HI7Lzpyow==}
 
@@ -4021,6 +4038,9 @@ packages:
 
   '@a2ui/web_core@0.9.0':
     resolution: {integrity: sha512-TsMWuEeuVDsScGIGPy/fWIZu+EOBRfhx6KwjKh3VwY1AwysRenQM8zDr8VrSk14Wck/aBgVxk2zWVrMCK2/s6A==}
+
+  '@a2ui/web_core@0.9.2':
+    resolution: {integrity: sha512-EOfhLOF7tnpPmNq4y116k3gxWdrXQW8h3dhKF0pC++21zLZnCSLSHl6zgQFG+kPeVAZb64t+sQiRXlnyS8+RBg==}
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
@@ -25750,6 +25770,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@a2ui/angular@0.9.1(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1))(rxjs@7.8.1))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1))(@angular/platform-browser@21.2.15(@angular/animations@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1)))(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1))(rxjs@7.8.1))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1)))':
+    dependencies:
+      '@a2ui/web_core': 0.9.2
+      '@angular/common': 21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1))(rxjs@7.8.1)
+      '@angular/core': 21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1)
+      '@angular/platform-browser': 21.2.15(@angular/animations@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1)))(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1))(rxjs@7.8.1))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.1)(zone.js@0.15.1))
+      '@preact/signals-core': 1.14.1
+      tslib: 2.8.1
+      zod: 3.25.76
+
   '@a2ui/lit@0.8.3(signal-polyfill@0.2.2)':
     dependencies:
       '@a2ui/web_core': 0.8.0
@@ -25766,6 +25796,13 @@ snapshots:
       zod-to-json-schema: 3.25.1(zod@3.25.76)
 
   '@a2ui/web_core@0.9.0':
+    dependencies:
+      '@preact/signals-core': 1.14.1
+      date-fns: 4.1.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+
+  '@a2ui/web_core@0.9.2':
     dependencies:
       '@preact/signals-core': 1.14.1
       date-fns: 4.1.0


### PR DESCRIPTION
> **Stacked on #6072** — please review only the last commit here until #6072 is merged; the first commit is that PR.

## What

Extends the `@copilotkit/angular/a2ui` entry point (introduced in #6072) with the authoring side of custom catalogs:

**Typed catalog definition**
- `binding(schema)` — wraps a prop schema in a union with a path-binding schema, so the agent can pass a literal (`"Paris"`) or a data-model binding (`{ path: "/flight/to" }`) for every prop
- `ContextFromSchema<Schema>` — derives the shape of a custom component's `props` input (each prop as a `BoundProperty`) from its Zod schema
- `createCustomComponent` / `createCustomFunction` / `createCustomCatalog` — identity helpers with literal type inference that keep name, description, schema, and implementation together

**Metadata / schema derivation for the agent**
- `catalogToContextEntry` / `catalogIdToContextEntry` — serialize a catalog into an AG-UI context entry (`A2UI_CATALOG_CONTEXT_DESCRIPTION`), with prop schemas emitted as inline JSON Schema (`$refStrategy: "none"`)
- `provideA2UIAngularRenderer(catalog)` now registers that context entry automatically and removes it when the providing injector is destroyed. `sendCatalogDescription: false` restricts the entry to the catalog id — for production setups where the server resolves the trusted catalog descriptor from its own registry instead of trusting client-supplied metadata.

## Why

Custom catalogs only work when two sides stay in sync: the renderer must know the Angular component behind each catalog name, and the agent must know which components exist and which props they accept. Without helpers, both halves are stringly typed and drift silently. With this PR the Zod schema is the single source of truth: it types the component's `props` input at compile time, validates at runtime, and is what the agent sees as JSON Schema:

```ts
const ticketWidget = createCustomComponent({
  name: "TicketWidget",
  description: "Boarding-pass style widget for a booked flight.",
  component: TicketWidget,
  schema: z.object({
    from: binding(z.string()),
    to: binding(z.string()),
    delay: binding(z.number()).optional(),
  }).strict(),
});

provideA2UIAngularRenderer(createCustomCatalog({
  id: "https://example.com/catalogs/flights",
  components: [ticketWidget],
}));
```

## Testing

- 14 new specs: `binding` parsing (literal / path / strict rejection), identity helpers incl. execute-arg inference, context-entry serialization (inline schemas, no `$ref`, empty-catalog case), automatic context registration, id-only mode, no-catalog case, and removal on injector destroy.
- `vitest run` (31 files, 205 tests), `tsc --noEmit`, and the two-entry-point `ng-packagr` build are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)