### PR TITLE
feat(angular): MCP Apps activity renderer

### DIFF
--- a/packages/angular/mcp-apps/ng-package.json
+++ b/packages/angular/mcp-apps/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "../src/mcp-apps/index.ts"
+  }
+}

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -19,6 +19,12 @@
         "default": "./dist/fesm2022/copilotkit-angular.mjs"
       }
     },
+    "./mcp-apps": {
+      "import": {
+        "types": "./dist/types/copilotkit-angular-mcp-apps.d.ts",
+        "default": "./dist/fesm2022/copilotkit-angular-mcp-apps.mjs"
+      }
+    },
     "./styles.css": "./dist/styles.css"
   },
   "publishConfig": {
@@ -51,6 +57,7 @@
     "rxjs": "^7.8.1",
     "tailwind-merge": "^2.6.0",
     "tslib": "^2.6.0",
+    "zod": "^3.25.76",
     "zod-to-json-schema": "^3.24.5"
   },
   "devDependencies": {
@@ -65,6 +72,8 @@
     "@angular/platform-browser-dynamic": "^21.2.15",
     "@copilotkit/typescript-config": "workspace:*",
     "@lucide/build-icons": "^1.1.0",
+    "@modelcontextprotocol/ext-apps": "^1.5.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@tailwindcss/cli": "^4.1.11",
     "@tailwindcss/postcss": "^4.1.11",
     "@tailwindcss/typography": "^0.5.16",
@@ -84,13 +93,22 @@
     "tw-animate-css": "^1.3.5",
     "typescript": "5.9.3",
     "vite": "^7.1.4",
-    "vitest": "^3.2.4",
-    "zod": "^3.22.4"
+    "vitest": "^3.2.4"
   },
   "peerDependencies": {
     "@angular/cdk": "^19.0.0 || ^20.0.0 || ^21.0.0",
     "@angular/common": "^19.0.0 || ^20.0.0 || ^21.0.0",
     "@angular/core": "^19.0.0 || ^20.0.0 || ^21.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.5.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "rxjs": "^7.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@modelcontextprotocol/ext-apps": {
+      "optional": true
+    },
+    "@modelcontextprotocol/sdk": {
+      "optional": true
+    }
   }
 }

--- a/packages/angular/src/mcp-apps/index.ts
+++ b/packages/angular/src/mcp-apps/index.ts
@@ -1,0 +1,4 @@
+export * from "./lib/mcp-apps-content";
+export * from "./lib/mcp-apps-widget";
+export * from "./lib/mcp-apps-activity-renderer";
+export * from "./lib/provide-mcp-apps";

--- a/packages/angular/src/mcp-apps/lib/__tests__/mcp-apps-content.spec.ts
+++ b/packages/angular/src/mcp-apps/lib/__tests__/mcp-apps-content.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { mcpAppsSnapshotContentSchema } from "../mcp-apps-content";
+
+const validContent = {
+  serverId: "demo",
+  resourceUri: "ui://demo/widget.html",
+  result: { content: [{ type: "text", text: "done" }] },
+  toolInput: { city: "Paris" },
+};
+
+describe("mcpAppsSnapshotContentSchema", () => {
+  it("accepts a complete mcp-apps snapshot", () => {
+    const parsed = mcpAppsSnapshotContentSchema.safeParse(validContent);
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("keeps unknown keys so future snapshot fields survive parsing", () => {
+    const parsed = mcpAppsSnapshotContentSchema.safeParse({
+      ...validContent,
+      sessionId: "s-1",
+    });
+
+    expect(parsed.success).toBe(true);
+    expect((parsed as { data: Record<string, unknown> }).data.sessionId).toBe(
+      "s-1",
+    );
+  });
+
+  it("rejects a snapshot without a server id", () => {
+    const { serverId, ...rest } = validContent;
+
+    expect(mcpAppsSnapshotContentSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it("rejects a snapshot with an invalid tool result", () => {
+    const parsed = mcpAppsSnapshotContentSchema.safeParse({
+      ...validContent,
+      result: { content: "not an array" },
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/packages/angular/src/mcp-apps/lib/__tests__/mcp-apps-widget.spec.ts
+++ b/packages/angular/src/mcp-apps/lib/__tests__/mcp-apps-widget.spec.ts
@@ -1,0 +1,216 @@
+import { TestBed } from "@angular/core/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MCPAppsSnapshotContent } from "../mcp-apps-content";
+import { CopilotMCPAppsWidget } from "../mcp-apps-widget";
+import {
+  CopilotMCPAppsActivityRenderer,
+  mcpAppsActivityRendererConfig,
+} from "../mcp-apps-activity-renderer";
+import { provideMCPApps } from "../provide-mcp-apps";
+
+const mocks = vi.hoisted(() => ({
+  clientCtor: vi.fn(),
+  clientConnect: vi.fn(async () => undefined),
+  clientClose: vi.fn(async () => undefined),
+  readResource: vi.fn(),
+  transportCtor: vi.fn(),
+  bridgeCtor: vi.fn(),
+  bridgeConnect: vi.fn(async () => undefined),
+  sendToolInput: vi.fn(),
+  sendToolResult: vi.fn(),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => {
+  class Client {
+    connect = mocks.clientConnect;
+    readResource = mocks.readResource;
+    close = mocks.clientClose;
+
+    constructor(info: unknown) {
+      mocks.clientCtor(info);
+    }
+  }
+  return { Client };
+});
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => {
+  class StreamableHTTPClientTransport {
+    constructor(url: URL) {
+      mocks.transportCtor(url);
+    }
+  }
+  return { StreamableHTTPClientTransport };
+});
+
+vi.mock("@modelcontextprotocol/ext-apps/app-bridge", () => {
+  class AppBridge {
+    onopenlink: unknown;
+    onloggingmessage: unknown;
+    onsizechange: unknown;
+    onrequestdisplaymode: unknown;
+    connect = mocks.bridgeConnect;
+    sendToolInput = mocks.sendToolInput;
+    sendToolResult = mocks.sendToolResult;
+    teardownResource = vi.fn(async () => ({}));
+    close = vi.fn(async () => undefined);
+
+    constructor(...args: unknown[]) {
+      mocks.bridgeCtor(...args);
+    }
+
+    set oninitialized(callback: (() => void) | undefined) {
+      callback?.();
+    }
+  }
+  class PostMessageTransport {}
+  return { AppBridge, PostMessageTransport };
+});
+
+const snapshot: MCPAppsSnapshotContent = {
+  serverId: "demo",
+  resourceUri: "ui://demo/widget.html",
+  result: { content: [{ type: "text", text: "done" }] },
+  toolInput: { city: "Paris" },
+};
+
+function configureTestingModule() {
+  TestBed.configureTestingModule({
+    providers: [
+      provideMCPApps({
+        servers: {
+          demo: "http://localhost:3999/mcp",
+          dynamic: () => "http://localhost:4999/mcp",
+        },
+        hostInfo: { name: "Test Host", version: "1.0.0" },
+      }),
+    ],
+  });
+}
+
+async function settle(fixture: {
+  whenStable: () => Promise<unknown>;
+  detectChanges: () => void;
+}) {
+  fixture.detectChanges();
+  await fixture.whenStable();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  fixture.detectChanges();
+}
+
+describe("CopilotMCPAppsWidget", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.readResource.mockResolvedValue({
+      contents: [{ uri: "ui://demo/widget.html", text: "<h1>MCP App</h1>" }],
+    });
+  });
+
+  it("loads the ui resource and boots the app bridge", async () => {
+    configureTestingModule();
+    const fixture = TestBed.createComponent(CopilotMCPAppsWidget);
+    fixture.componentRef.setInput("data", snapshot);
+
+    await settle(fixture);
+
+    const frame =
+      fixture.nativeElement.querySelector<HTMLIFrameElement>("iframe");
+    expect(mocks.transportCtor).toHaveBeenCalledWith(
+      new URL("http://localhost:3999/mcp"),
+    );
+    expect(mocks.clientConnect).toHaveBeenCalledTimes(1);
+    expect(mocks.readResource).toHaveBeenCalledWith({
+      uri: "ui://demo/widget.html",
+    });
+    expect(frame?.getAttribute("sandbox")).toBe("allow-scripts allow-forms");
+    expect(frame?.getAttribute("srcdoc")).toContain("MCP App");
+    expect(mocks.sendToolInput).toHaveBeenCalledWith({
+      arguments: snapshot.toolInput,
+    });
+    expect(mocks.sendToolResult).toHaveBeenCalledWith(snapshot.result);
+    expect(fixture.nativeElement.textContent).not.toContain("No MCP server");
+  });
+
+  it("announces the configured host identity to server and bridge", async () => {
+    configureTestingModule();
+    const fixture = TestBed.createComponent(CopilotMCPAppsWidget);
+    fixture.componentRef.setInput("data", snapshot);
+
+    await settle(fixture);
+
+    expect(mocks.clientCtor).toHaveBeenCalledWith({
+      name: "Test Host",
+      version: "1.0.0",
+    });
+    expect(mocks.bridgeCtor.mock.calls[0][1]).toEqual({
+      name: "Test Host",
+      version: "1.0.0",
+    });
+  });
+
+  it("resolves function-valued server urls at connect time", async () => {
+    configureTestingModule();
+    const fixture = TestBed.createComponent(CopilotMCPAppsWidget);
+    fixture.componentRef.setInput("data", { ...snapshot, serverId: "dynamic" });
+
+    await settle(fixture);
+
+    expect(mocks.transportCtor).toHaveBeenCalledWith(
+      new URL("http://localhost:4999/mcp"),
+    );
+  });
+
+  it("shows an error when no server url is configured for the snapshot", async () => {
+    configureTestingModule();
+    const fixture = TestBed.createComponent(CopilotMCPAppsWidget);
+    fixture.componentRef.setInput("data", { ...snapshot, serverId: "unknown" });
+
+    await settle(fixture);
+
+    expect(fixture.nativeElement.textContent).toContain(
+      'No MCP server URL configured for server "unknown".',
+    );
+    const frame =
+      fixture.nativeElement.querySelector<HTMLIFrameElement>("iframe");
+    expect(frame?.hasAttribute("srcdoc")).toBe(false);
+    expect(mocks.sendToolResult).not.toHaveBeenCalled();
+  });
+});
+
+describe("CopilotMCPAppsActivityRenderer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.readResource.mockResolvedValue({
+      contents: [{ uri: "ui://demo/widget.html", text: "<h1>MCP App</h1>" }],
+    });
+  });
+
+  it("renders the widget for the activity message content", async () => {
+    configureTestingModule();
+    const fixture = TestBed.createComponent(CopilotMCPAppsActivityRenderer);
+    fixture.componentRef.setInput("activityType", "mcp-apps");
+    fixture.componentRef.setInput("content", snapshot);
+    fixture.componentRef.setInput("message", {
+      id: "activity-1",
+      role: "activity",
+      activityType: "mcp-apps",
+      content: snapshot,
+    });
+
+    await settle(fixture);
+
+    const widget = fixture.nativeElement.querySelector(
+      "copilot-mcp-apps-widget",
+    );
+    expect(widget).not.toBeNull();
+    expect(widget?.querySelector("iframe")?.getAttribute("srcdoc")).toContain(
+      "MCP App",
+    );
+  });
+
+  it("is preconfigured for the mcp-apps activity type", () => {
+    expect(mcpAppsActivityRendererConfig.activityType).toBe("mcp-apps");
+    expect(mcpAppsActivityRendererConfig.component).toBe(
+      CopilotMCPAppsActivityRenderer,
+    );
+  });
+});

--- a/packages/angular/src/mcp-apps/lib/mcp-apps-activity-renderer.ts
+++ b/packages/angular/src/mcp-apps/lib/mcp-apps-activity-renderer.ts
@@ -1,0 +1,42 @@
+import type { AbstractAgent, ActivityMessage } from "@ag-ui/client";
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import type {
+  ActivityRenderer,
+  RenderActivityMessageConfig,
+} from "@copilotkit/angular";
+import {
+  mcpAppsSnapshotContentSchema,
+  type MCPAppsSnapshotContent,
+} from "./mcp-apps-content";
+import { CopilotMCPAppsWidget } from "./mcp-apps-widget";
+
+/**
+ * Activity renderer for `mcp-apps` snapshots. Renders the referenced MCP App
+ * inline via {@link CopilotMCPAppsWidget}. Requires `provideMCPApps` to be
+ * set up with the MCP servers the host may connect to.
+ */
+@Component({
+  selector: "copilot-mcp-apps-activity-renderer",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CopilotMCPAppsWidget],
+  template: `
+    <copilot-mcp-apps-widget [data]="content()" />
+  `,
+})
+export class CopilotMCPAppsActivityRenderer implements ActivityRenderer<MCPAppsSnapshotContent> {
+  readonly activityType = input.required<string>();
+  readonly content = input.required<MCPAppsSnapshotContent>();
+  readonly message = input.required<ActivityMessage>();
+  readonly agent = input<AbstractAgent | undefined>();
+}
+
+/**
+ * Ready-to-register render config for `mcp-apps` activity messages. Pass it
+ * to `provideCopilotKit({ renderActivityMessages: [...] })`.
+ */
+export const mcpAppsActivityRendererConfig: RenderActivityMessageConfig<MCPAppsSnapshotContent> =
+  {
+    activityType: "mcp-apps",
+    content: mcpAppsSnapshotContentSchema,
+    component: CopilotMCPAppsActivityRenderer,
+  };

--- a/packages/angular/src/mcp-apps/lib/mcp-apps-content.ts
+++ b/packages/angular/src/mcp-apps/lib/mcp-apps-content.ts
@@ -1,0 +1,22 @@
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod/v4";
+
+/**
+ * Content schema for `activityType: "mcp-apps"` activity messages: a snapshot
+ * of an MCP Apps tool call, carrying the server id, the ui:// resource to
+ * render, the tool result, and the tool input the app receives.
+ *
+ * Declared with the `zod/v4` API because the MCP SDK's `CallToolResultSchema`
+ * is a zod/v4 schema and must not be nested inside a classic zod v3 object.
+ */
+export const mcpAppsSnapshotContentSchema = z.looseObject({
+  serverId: z.string(),
+  resourceUri: z.string(),
+  result: CallToolResultSchema,
+  toolInput: z.record(z.string(), z.unknown()),
+});
+
+/** Parsed content of an `mcp-apps` activity message. */
+export type MCPAppsSnapshotContent = z.infer<
+  typeof mcpAppsSnapshotContentSchema
+>;

--- a/packages/angular/src/mcp-apps/lib/mcp-apps-widget.ts
+++ b/packages/angular/src/mcp-apps/lib/mcp-apps-widget.ts
@@ -1,0 +1,213 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  ElementRef,
+  afterNextRender,
+  inject,
+  input,
+  signal,
+  viewChild,
+} from "@angular/core";
+import {
+  AppBridge,
+  PostMessageTransport,
+  type McpUiHostCapabilities,
+} from "@modelcontextprotocol/ext-apps/app-bridge";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { type MCPAppsSnapshotContent } from "./mcp-apps-content";
+import { MCP_APPS_CONFIG, type MCPAppsServerUrls } from "./provide-mcp-apps";
+
+const defaultHostCapabilities: McpUiHostCapabilities = {
+  openLinks: {},
+  serverTools: {},
+  logging: {},
+};
+
+function resolveServerUrls(
+  serverUrls: MCPAppsServerUrls,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(serverUrls).map(([serverId, url]) => [
+      serverId,
+      typeof url === "function" ? url() : url,
+    ]),
+  );
+}
+
+/**
+ * Renders one MCP App snapshot: loads the app's ui:// resource from the
+ * configured MCP server, embeds its HTML in a sandboxed iframe, and connects
+ * an `AppBridge` that relays tool input and result, size changes, links, and
+ * log messages. The MCP client and bridge are torn down with the component.
+ */
+@Component({
+  selector: "copilot-mcp-apps-widget",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (error()) {
+      <p class="copilot-mcp-apps-error">{{ error() }}</p>
+    }
+
+    <iframe #appFrame class="copilot-mcp-apps-frame"></iframe>
+  `,
+  styles: `
+    .copilot-mcp-apps-frame {
+      display: block;
+      width: 100%;
+      min-height: 260px;
+      border: 0;
+      background: transparent;
+    }
+
+    .copilot-mcp-apps-error {
+      margin: 20px 0;
+      padding: 16px 0;
+      color: darkred;
+    }
+  `,
+})
+export class CopilotMCPAppsWidget {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly mcpAppsConfig = inject(MCP_APPS_CONFIG);
+  private readonly mcpAppsServerUrls = resolveServerUrls(
+    this.mcpAppsConfig.servers,
+  );
+
+  readonly data = input.required<MCPAppsSnapshotContent>();
+
+  private readonly appFrame =
+    viewChild.required<ElementRef<HTMLIFrameElement>>("appFrame");
+
+  private bridge: AppBridge | null = null;
+  private client: Client | null = null;
+  protected readonly error = signal("");
+
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      void this.dispose();
+    });
+
+    afterNextRender(() => {
+      const frame = this.appFrame().nativeElement;
+      const data = this.data();
+      void this.renderApp(frame, data);
+    });
+  }
+
+  private async renderApp(
+    frame: HTMLIFrameElement,
+    data: MCPAppsSnapshotContent,
+  ): Promise<void> {
+    this.error.set("");
+
+    try {
+      const client = await this.getClient(data.serverId);
+      const resource = await client.readResource({ uri: data.resourceUri });
+      const content = resource.contents[0] as { text: string };
+      const html = content.text;
+
+      frame.setAttribute("sandbox", "allow-scripts allow-forms");
+
+      const bridge = new AppBridge(
+        client,
+        this.mcpAppsConfig.hostInfo,
+        this.mcpAppsConfig.hostCapabilities ?? defaultHostCapabilities,
+        {
+          hostContext: {
+            ...this.mcpAppsConfig.hostContext,
+            containerDimensions: {
+              width: Math.round(frame.clientWidth || 640),
+              maxHeight: 5000,
+            },
+          },
+        },
+      );
+
+      bridge.onopenlink = async ({ url }) => {
+        window.open(url, "_blank", "noopener,noreferrer");
+        return {};
+      };
+      bridge.onloggingmessage = ({ level, data: logData }) => {
+        console.info("[MCP App]", level, logData);
+      };
+      bridge.onsizechange = async ({ height }) => {
+        if (typeof height === "number" && height > 0) {
+          frame.style.height = `${Math.ceil(height)}px`;
+        }
+      };
+      bridge.onrequestdisplaymode = async () => ({ mode: "inline" });
+
+      frame.srcdoc = html;
+      await bridge.connect(
+        new PostMessageTransport(frame.contentWindow!, frame.contentWindow!),
+      );
+
+      await whenInitialized(bridge);
+
+      bridge.sendToolInput({ arguments: data.toolInput });
+      bridge.sendToolResult(data.result);
+
+      this.bridge = bridge;
+    } catch (error) {
+      this.error.set(
+        error instanceof Error ? error.message : "Unable to render MCP App.",
+      );
+      frame.removeAttribute("srcdoc");
+    }
+  }
+
+  private async getClient(serverId: string): Promise<Client> {
+    if (!this.client) {
+      this.client = await this.createClient(serverId);
+    }
+
+    return this.client;
+  }
+
+  private async createClient(serverId: string): Promise<Client> {
+    const serverUrl = this.mcpAppsServerUrls[serverId];
+
+    if (!serverUrl) {
+      throw new Error(`No MCP server URL configured for server "${serverId}".`);
+    }
+
+    const client = new Client(this.mcpAppsConfig.hostInfo);
+    const transport = new StreamableHTTPClientTransport(new URL(serverUrl));
+
+    await client.connect(transport);
+    return client;
+  }
+
+  private async disposeBridge(): Promise<void> {
+    if (this.bridge) {
+      await this.bridge.teardownResource({}).catch(() => undefined);
+      await this.bridge.close().catch(() => undefined);
+      this.bridge = null;
+    }
+  }
+
+  private async disposeClient(): Promise<void> {
+    const client = this.client;
+
+    this.client = null;
+
+    if (client) {
+      await client.close().catch(() => undefined);
+    }
+  }
+
+  private async dispose(): Promise<void> {
+    await this.disposeBridge();
+    await this.disposeClient();
+  }
+}
+
+function whenInitialized(bridge: AppBridge): Promise<void> {
+  return new Promise((resolve) => {
+    bridge.oninitialized = () => {
+      resolve();
+    };
+  });
+}

--- a/packages/angular/src/mcp-apps/lib/provide-mcp-apps.ts
+++ b/packages/angular/src/mcp-apps/lib/provide-mcp-apps.ts
@@ -1,0 +1,44 @@
+import {
+  InjectionToken,
+  makeEnvironmentProviders,
+  type EnvironmentProviders,
+} from "@angular/core";
+import type {
+  McpUiHostCapabilities,
+  McpUiHostContext,
+} from "@modelcontextprotocol/ext-apps/app-bridge";
+import type { Implementation } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * Maps the server id referenced by `mcp-apps` snapshots to the URL of the
+ * MCP server's streamable HTTP endpoint. A function value is resolved once
+ * per widget, so URLs can depend on runtime configuration.
+ */
+export type MCPAppsServerUrls = Record<string, string | (() => string)>;
+
+/** Configuration for rendering MCP Apps. */
+export interface MCPAppsConfig {
+  servers: MCPAppsServerUrls;
+  hostInfo: Implementation;
+  hostCapabilities?: McpUiHostCapabilities;
+  hostContext?: McpUiHostContext;
+}
+
+/** Holds the MCP Apps configuration registered via `provideMCPApps`. */
+export const MCP_APPS_CONFIG = new InjectionToken<MCPAppsConfig>(
+  "MCP_APPS_CONFIG",
+);
+
+/**
+ * Registers the MCP Apps configuration: the MCP servers the host may connect
+ * to and the host identity, capabilities, and context announced to embedded
+ * apps. Required by `CopilotMCPAppsActivityRenderer`.
+ */
+export function provideMCPApps(config: MCPAppsConfig): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    {
+      provide: MCP_APPS_CONFIG,
+      useValue: config,
+    },
+  ]);
+}

--- a/packages/angular/tsconfig.json
+++ b/packages/angular/tsconfig.json
@@ -18,6 +18,7 @@
     "importHelpers": true,
     "types": ["node"],
     "paths": {
+      "@copilotkit/angular": ["./src/public-api.ts"],
       "@copilotkit/a2ui-renderer/web-components": [
         "../a2ui-renderer/src/web-components/index.ts"
       ],

--- a/packages/angular/vitest.config.mts
+++ b/packages/angular/vitest.config.mts
@@ -10,6 +10,9 @@ const r = (...p: string[]) => resolve(__dirname, ...p);
 export default defineConfig(({ mode }) => ({
   plugins: [angular()],
   resolve: {
+    alias: {
+      "@copilotkit/angular": r("src/public-api.ts"),
+    },
     dedupe: [
       "@angular/core",
       "@angular/common",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2251,6 +2251,9 @@ importers:
       tslib:
         specifier: ^2.6.0
         version: 2.8.1
+      zod:
+        specifier: '>=3.22.3'
+        version: 3.25.76
       zod-to-json-schema:
         specifier: ^3.24.5
         version: 3.25.1(zod@3.25.76)
@@ -2288,6 +2291,12 @@ importers:
       '@lucide/build-icons':
         specifier: ^1.1.0
         version: 1.1.0
+      '@modelcontextprotocol/ext-apps':
+        specifier: ^1.5.0
+        version: 1.7.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76)
+      '@modelcontextprotocol/sdk':
+        specifier: '>=1.26.0'
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@tailwindcss/cli':
         specifier: ^4.1.11
         version: 4.1.18
@@ -2342,9 +2351,6 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(@vitest/ui@3.2.4)(jiti@2.7.0)(jsdom@24.1.3)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
-      zod:
-        specifier: '>=3.22.3'
-        version: 3.25.76
 
   packages/channels:
     dependencies:
@@ -8745,6 +8751,20 @@ packages:
 
   '@mjackson/node-fetch-server@0.2.0':
     resolution: {integrity: sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==}
+
+  '@modelcontextprotocol/ext-apps@1.7.4':
+    resolution: {integrity: sha512-QQqysE549cf/Y0VabBmAACXhj92EhB3t8yVct2BHbkWiPTFA1S91EqTVjYXXcZEefXU0pmHcdObhsNMcomJIOQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': '>=1.26.0'
+      react: 19.2.3
+      react-dom: 19.2.3
+      zod: '>=3.22.3'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -16717,10 +16737,6 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
-
-  eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
-    engines: {node: '>=18.0.0'}
 
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
@@ -33939,6 +33955,15 @@ snapshots:
 
   '@mjackson/node-fetch-server@0.2.0': {}
 
+  '@modelcontextprotocol/ext-apps@1.7.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@standard-schema/spec': 1.1.0
+      zod: 3.25.76
+    optionalDependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 2.0.0(hono@4.12.15)
@@ -33948,7 +33973,7 @@ snapshots:
       cors: 2.8.5
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.4.1(express@5.2.1)
       hono: 4.12.15
@@ -43962,8 +43987,6 @@ snapshots:
       - bare-abort-controller
 
   events@3.3.0: {}
-
-  eventsource-parser@3.0.6: {}
 
   eventsource-parser@3.0.8: {}
 


### PR DESCRIPTION
## What

Adds an opt-in secondary entry point `@copilotkit/angular/mcp-apps` that renders [MCP Apps](https://github.com/modelcontextprotocol/ext-apps) inline in the chat from `activityType: "mcp-apps"` activity messages:

- `CopilotMCPAppsActivityRenderer` plus a ready-to-register `mcpAppsActivityRendererConfig`
- `CopilotMCPAppsWidget` — connects an MCP client to the configured server, loads the app's `ui://` resource, embeds its HTML in a sandboxed iframe (`allow-scripts allow-forms`), and wires an `AppBridge` that relays tool input and result into the app and handles size changes, link opening, display-mode requests, and log messages; client and bridge are torn down with the component
- `provideMCPApps({ servers, hostInfo, hostCapabilities?, hostContext? })` — one provider for the server URLs (static or lazily resolved via functions) and the host identity/capabilities/context announced to embedded apps
- content validated against the MCP SDK's own `CallToolResultSchema`

```ts
provideCopilotKit({ renderActivityMessages: [mcpAppsActivityRendererConfig] }),
provideMCPApps({
  servers: { threejs: "http://localhost:3999/mcp" },
  hostInfo: { name: "My App", version: "1.0.0" },
}),
```

## Why

MCP Apps are becoming the interoperable way for MCP servers to ship rich interactive UI with their tools. Agents that surface such tool calls need a host that can actually render them; today Angular users have to hand-roll the client + iframe + AppBridge dance themselves. This PR turns that into a registered activity renderer plus one provider call, with the security-relevant parts (iframe sandboxing, host-capability gating) handled by the package.

## Design notes

- Ships as a **secondary entry point**, so the main entry stays free of MCP imports (verified against the built FESM). `@modelcontextprotocol/sdk` and `@modelcontextprotocol/ext-apps` are **optional peer dependencies** — only apps importing `@copilotkit/angular/mcp-apps` install them.
- The content schema is declared with the `zod/v4` API because the MCP SDK's `CallToolResultSchema` is a zod/v4 schema; nesting it inside a classic zod v3 object fails at parse time.
- `zod` moves from devDependencies to dependencies (it was already an implicit runtime requirement via `zod-to-json-schema`).

## Testing

- 10 new specs with a mocked MCP client/bridge: resource loading and bridge boot (sandbox attribute, srcdoc, tool input/result relay), host identity propagation to client and bridge, function-valued server URL resolution, error state for unknown server ids, activity-type wiring, and content-schema validation (loose parsing, missing fields, invalid tool results).
- `vitest run` (28 files, 188 tests), `tsc --noEmit`, two-entry-point `ng-packagr` build, and `publint` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)