### PR TITLE
feat(angular): initAgentStore — one-call setup for self-managed agents

### DIFF
--- a/packages/angular/API.md
+++ b/packages/angular/API.md
@@ -8,7 +8,7 @@ symbol requires the package's normal breaking-change process.
 For task-oriented examples, start with the [package README](./README.md) and the
 [Angular documentation](https://docs.copilotkit.ai/frontends/angular). The high-level
 APIs most applications need are `provideCopilotKit`, `CopilotChat`,
-`CopilotPopup`, `CopilotSidebar`, `injectAgentStore`, `injectCapabilities`, the
+`CopilotPopup`, `CopilotSidebar`, `injectAgentStore`, `initAgentStore`, `injectCapabilities`, the
 `register*` helpers, and the `inject*` controllers. The remaining components
 and context types are supported customization primitives for replacing
 individual chat slots.
@@ -153,6 +153,7 @@ Import these symbols from `@copilotkit/angular`.
 - `HumanInTheLoopConfig`
 - `HumanInTheLoopToolCall`
 - `HumanInTheLoopToolRenderer`
+- `InitAgentStoreConfig`
 - `InjectInterruptOptions`
 - `InjectThreadsInput`
 - `InjectThreadsResult`
@@ -225,6 +226,7 @@ Import these symbols from `@copilotkit/angular`.
 - `createSlotConfig`
 - `createSlotRenderer`
 - `getSlotConfig`
+- `initAgentStore`
 - `injectAgentStore`
 - `injectCapabilities`
 - `injectChatConfiguration`

--- a/packages/angular/src/lib/init-agent-store.spec.ts
+++ b/packages/angular/src/lib/init-agent-store.spec.ts
@@ -1,0 +1,164 @@
+import { HttpAgent, type HttpAgentConfig } from "@ag-ui/client";
+import { Component, EnvironmentInjector, input } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { provideCopilotKit } from "./config";
+import { CopilotKit } from "./copilotkit";
+import { initAgentStore } from "./init-agent-store";
+import type { AngularToolCall, HumanInTheLoopToolCall } from "./tools";
+
+@Component({ template: `` })
+class FlightCardComponent {
+  readonly toolCall = input.required<AngularToolCall>();
+}
+
+@Component({ template: `` })
+class ApprovalComponent {
+  readonly toolCall = input.required<HumanInTheLoopToolCall>();
+}
+
+class TestHttpAgent extends HttpAgent {}
+
+describe("initAgentStore", () => {
+  let copilotKit: CopilotKit;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [provideCopilotKit({})],
+    });
+    copilotKit = TestBed.inject(CopilotKit);
+  });
+
+  function init(config: Partial<Parameters<typeof initAgentStore>[0]> = {}) {
+    TestBed.runInInjectionContext(() =>
+      initAgentStore({
+        agentId: "pilot",
+        url: "http://localhost:9000/agent",
+        ...config,
+      }),
+    );
+  }
+
+  it("registers a self-managed HttpAgent with a fresh threadId", () => {
+    init();
+
+    const agent = copilotKit.getAgent("pilot");
+
+    expect(agent).toBeInstanceOf(HttpAgent);
+    expect((agent as HttpAgent).url).toBe("http://localhost:9000/agent");
+    expect(agent?.threadId).toBeTruthy();
+  });
+
+  it("uses the createAgent factory to map the config onto an agent", () => {
+    const createAgent = vi.fn(
+      (agentConfig: HttpAgentConfig) => new TestHttpAgent(agentConfig),
+    );
+
+    init({ createAgent });
+
+    expect(createAgent).toHaveBeenCalledWith({
+      agentId: "pilot",
+      url: "http://localhost:9000/agent",
+      threadId: expect.any(String),
+    });
+    expect(copilotKit.getAgent("pilot")).toBeInstanceOf(TestHttpAgent);
+  });
+
+  it("keeps previously registered agents when called again", () => {
+    init();
+    init({ agentId: "copilot", url: "http://localhost:9001/agent" });
+
+    expect(copilotKit.getAgent("pilot")).toBeInstanceOf(HttpAgent);
+    expect(copilotKit.getAgent("copilot")).toBeInstanceOf(HttpAgent);
+  });
+
+  it("registers tool-call renderers scoped to the agent", () => {
+    init({
+      renderToolCalls: [
+        {
+          name: "show_flight",
+          args: z.object({ flightId: z.string() }),
+          component: FlightCardComponent,
+        },
+      ],
+    });
+
+    const config = copilotKit
+      .toolCallRenderConfigs()
+      .find((candidate) => candidate.name === "show_flight");
+
+    expect(config?.agentId).toBe("pilot");
+    expect(config?.component).toBe(FlightCardComponent);
+  });
+
+  it("registers frontend tools scoped to the agent", () => {
+    const handler = vi.fn(async () => "ok");
+
+    init({
+      frontendTools: [
+        {
+          name: "load_flights",
+          description: "Loads flights.",
+          parameters: z.object({ from: z.string() }),
+          handler,
+        },
+      ],
+    });
+
+    const config = copilotKit
+      .clientToolCallRenderConfigs()
+      .find((candidate) => candidate.name === "load_flights");
+
+    expect(config?.agentId).toBe("pilot");
+    expect(
+      copilotKit.core.getTool({ toolName: "load_flights", agentId: "pilot" }),
+    ).toBeTruthy();
+  });
+
+  it("registers human-in-the-loop tools scoped to the agent", () => {
+    init({
+      humanInTheLoop: [
+        {
+          name: "confirm_booking",
+          description: "Asks the user to confirm a booking.",
+          parameters: z.object({ flightId: z.string() }),
+          component: ApprovalComponent,
+        },
+      ],
+    });
+
+    const config = copilotKit
+      .humanInTheLoopToolRenderConfigs()
+      .find((candidate) => candidate.name === "confirm_booking");
+
+    expect(config?.agentId).toBe("pilot");
+    expect(
+      copilotKit.core.getTool({
+        toolName: "confirm_booking",
+        agentId: "pilot",
+      }),
+    ).toBeTruthy();
+  });
+
+  it("removes registered tools when the injection context is destroyed", () => {
+    init({
+      renderToolCalls: [
+        {
+          name: "show_flight",
+          args: z.object({}),
+          component: FlightCardComponent,
+        },
+      ],
+    });
+
+    TestBed.inject(EnvironmentInjector).destroy();
+
+    expect(
+      copilotKit
+        .toolCallRenderConfigs()
+        .find((candidate) => candidate.name === "show_flight"),
+    ).toBeUndefined();
+  });
+});

--- a/packages/angular/src/lib/init-agent-store.spec.ts
+++ b/packages/angular/src/lib/init-agent-store.spec.ts
@@ -1,11 +1,11 @@
 import { HttpAgent, type HttpAgentConfig } from "@ag-ui/client";
 import { Component, EnvironmentInjector, input } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { provideCopilotKit } from "./config";
 import { CopilotKit } from "./copilotkit";
-import { initAgentStore } from "./init-agent-store";
+import { initAgentStore, type InitAgentStoreConfig } from "./init-agent-store";
 import type { AngularToolCall, HumanInTheLoopToolCall } from "./tools";
 
 @Component({ template: `` })
@@ -20,29 +20,29 @@ class ApprovalComponent {
 
 class TestHttpAgent extends HttpAgent {}
 
-describe("initAgentStore", () => {
-  let copilotKit: CopilotKit;
-
-  beforeEach(() => {
-    TestBed.resetTestingModule();
-    TestBed.configureTestingModule({
-      providers: [provideCopilotKit({})],
-    });
-    copilotKit = TestBed.inject(CopilotKit);
+function setup(config: Partial<InitAgentStoreConfig> = {}) {
+  TestBed.configureTestingModule({
+    providers: [provideCopilotKit({})],
   });
+  const copilotKit = TestBed.inject(CopilotKit);
 
-  function init(config: Partial<Parameters<typeof initAgentStore>[0]> = {}) {
+  const init = (overrides: Partial<InitAgentStoreConfig> = {}) =>
     TestBed.runInInjectionContext(() =>
       initAgentStore({
         agentId: "pilot",
         url: "http://localhost:9000/agent",
-        ...config,
+        ...overrides,
       }),
     );
-  }
 
+  init(config);
+
+  return { copilotKit, init };
+}
+
+describe("initAgentStore", () => {
   it("registers a self-managed HttpAgent with a fresh threadId", () => {
-    init();
+    const { copilotKit } = setup();
 
     const agent = copilotKit.getAgent("pilot");
 
@@ -56,7 +56,7 @@ describe("initAgentStore", () => {
       (agentConfig: HttpAgentConfig) => new TestHttpAgent(agentConfig),
     );
 
-    init({ createAgent });
+    const { copilotKit } = setup({ createAgent });
 
     expect(createAgent).toHaveBeenCalledWith({
       agentId: "pilot",
@@ -67,7 +67,7 @@ describe("initAgentStore", () => {
   });
 
   it("keeps previously registered agents when called again", () => {
-    init();
+    const { copilotKit, init } = setup();
     init({ agentId: "copilot", url: "http://localhost:9001/agent" });
 
     expect(copilotKit.getAgent("pilot")).toBeInstanceOf(HttpAgent);
@@ -75,7 +75,7 @@ describe("initAgentStore", () => {
   });
 
   it("registers tool-call renderers scoped to the agent", () => {
-    init({
+    const { copilotKit } = setup({
       renderToolCalls: [
         {
           name: "show_flight",
@@ -93,10 +93,35 @@ describe("initAgentStore", () => {
     expect(config?.component).toBe(FlightCardComponent);
   });
 
+  it("registers display-only components as agent-scoped tools", () => {
+    const { copilotKit } = setup({
+      components: [
+        {
+          name: "show_flight",
+          description: "Shows one flight.",
+          parameters: z.object({ flightId: z.string() }),
+          component: FlightCardComponent,
+        },
+      ],
+    });
+
+    const config = copilotKit
+      .clientToolCallRenderConfigs()
+      .find((candidate) => candidate.name === "show_flight");
+
+    expect(config?.agentId).toBe("pilot");
+    expect(config?.component).toBe(FlightCardComponent);
+    expect(config?.handler).toBeUndefined();
+    expect(config?.description).toContain("Shows one flight.");
+    expect(
+      copilotKit.core.getTool({ toolName: "show_flight", agentId: "pilot" }),
+    ).toBeTruthy();
+  });
+
   it("registers frontend tools scoped to the agent", () => {
     const handler = vi.fn(async () => "ok");
 
-    init({
+    const { copilotKit } = setup({
       frontendTools: [
         {
           name: "load_flights",
@@ -118,7 +143,7 @@ describe("initAgentStore", () => {
   });
 
   it("registers human-in-the-loop tools scoped to the agent", () => {
-    init({
+    const { copilotKit } = setup({
       humanInTheLoop: [
         {
           name: "confirm_booking",
@@ -143,7 +168,7 @@ describe("initAgentStore", () => {
   });
 
   it("removes registered tools when the injection context is destroyed", () => {
-    init({
+    const { copilotKit } = setup({
       renderToolCalls: [
         {
           name: "show_flight",

--- a/packages/angular/src/lib/init-agent-store.ts
+++ b/packages/angular/src/lib/init-agent-store.ts
@@ -1,0 +1,70 @@
+import { HttpAgent, randomUUID, type HttpAgentConfig } from "@ag-ui/client";
+import { inject } from "@angular/core";
+import { CopilotKit } from "./copilotkit";
+import {
+  registerFrontendTool,
+  registerHumanInTheLoop,
+  registerRenderToolCall,
+  type FrontendToolConfig,
+  type HumanInTheLoopConfig,
+  type RenderToolCallConfig,
+} from "./tools";
+
+export interface InitAgentStoreConfig {
+  agentId: string;
+  url: string;
+  frontendTools?: FrontendToolConfig[];
+  renderToolCalls?: RenderToolCallConfig[];
+  humanInTheLoop?: HumanInTheLoopConfig[];
+  /**
+   * Maps the prepared agent config onto the `HttpAgent` (or subclass) that
+   * is registered for `agentId`. Defaults to `new HttpAgent(agentConfig)`.
+   * Use this to plug in an agent with custom headers, persistent context,
+   * or incremental message history.
+   */
+  createAgent?: (agentConfig: HttpAgentConfig) => HttpAgent;
+}
+
+/**
+ * Registers a self-managed `HttpAgent` under `agentId` together with the
+ * agent-scoped frontend tools, tool-call renderers, and human-in-the-loop
+ * tools it needs, so `injectAgentStore(agentId)` resolves the agent
+ * afterwards. A fresh `threadId` is generated per registration.
+ *
+ * Must run in an injection context, but is otherwise placement-agnostic:
+ * call it from an environment initializer (e.g. in route-level `providers`),
+ * from a custom `injectXyz()` helper, or from any constructor or provider
+ * factory. Registered tools are removed when the surrounding injection
+ * context is destroyed.
+ */
+export function initAgentStore(config: InitAgentStoreConfig): void {
+  const copilotKit = inject(CopilotKit);
+
+  const agentConfig: HttpAgentConfig = {
+    agentId: config.agentId,
+    url: config.url,
+    threadId: randomUUID(),
+  };
+  const agent = config.createAgent
+    ? config.createAgent(agentConfig)
+    : new HttpAgent(agentConfig);
+
+  copilotKit.updateRuntime({
+    selfManagedAgents: {
+      ...copilotKit.agents(),
+      [config.agentId]: agent,
+    },
+  });
+
+  for (const frontendTool of config.frontendTools ?? []) {
+    registerFrontendTool({ ...frontendTool, agentId: config.agentId });
+  }
+
+  for (const renderToolCall of config.renderToolCalls ?? []) {
+    registerRenderToolCall({ ...renderToolCall, agentId: config.agentId });
+  }
+
+  for (const humanInTheLoop of config.humanInTheLoop ?? []) {
+    registerHumanInTheLoop({ ...humanInTheLoop, agentId: config.agentId });
+  }
+}

--- a/packages/angular/src/lib/init-agent-store.ts
+++ b/packages/angular/src/lib/init-agent-store.ts
@@ -2,17 +2,21 @@ import { HttpAgent, randomUUID, type HttpAgentConfig } from "@ag-ui/client";
 import { inject } from "@angular/core";
 import { CopilotKit } from "./copilotkit";
 import {
+  registerComponent,
   registerFrontendTool,
   registerHumanInTheLoop,
   registerRenderToolCall,
   type FrontendToolConfig,
   type HumanInTheLoopConfig,
+  type RegisterComponentConfig,
   type RenderToolCallConfig,
 } from "./tools";
 
 export interface InitAgentStoreConfig {
   agentId: string;
   url: string;
+  /** Display-only components the agent can call, see `registerComponent`. */
+  components?: RegisterComponentConfig[];
   frontendTools?: FrontendToolConfig[];
   renderToolCalls?: RenderToolCallConfig[];
   humanInTheLoop?: HumanInTheLoopConfig[];
@@ -27,9 +31,9 @@ export interface InitAgentStoreConfig {
 
 /**
  * Registers a self-managed `HttpAgent` under `agentId` together with the
- * agent-scoped frontend tools, tool-call renderers, and human-in-the-loop
- * tools it needs, so `injectAgentStore(agentId)` resolves the agent
- * afterwards. A fresh `threadId` is generated per registration.
+ * agent-scoped components, frontend tools, tool-call renderers, and
+ * human-in-the-loop tools it needs, so `injectAgentStore(agentId)` resolves
+ * the agent afterwards. A fresh `threadId` is generated per registration.
  *
  * Must run in an injection context, but is otherwise placement-agnostic:
  * call it from an environment initializer (e.g. in route-level `providers`),
@@ -55,6 +59,10 @@ export function initAgentStore(config: InitAgentStoreConfig): void {
       [config.agentId]: agent,
     },
   });
+
+  for (const component of config.components ?? []) {
+    registerComponent({ ...component, agentId: config.agentId });
+  }
 
   for (const frontendTool of config.frontendTools ?? []) {
     registerFrontendTool({ ...frontendTool, agentId: config.agentId });

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -5,6 +5,7 @@ export * from "./lib/render-tool-calls";
 export * from "./lib/activity-renderer";
 export * from "./lib/open-generative-ui";
 export * from "./lib/agent";
+export * from "./lib/init-agent-store";
 export * from "./lib/threads";
 export * from "./lib/chat-config";
 export * from "./lib/chat-configuration";

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -9,6 +9,7 @@ export * from "./lib/agent";
 export * from "./lib/capabilities";
 export * from "./lib/interrupt";
 export * from "./lib/inject-interrupt";
+export * from "./lib/init-agent-store";
 export * from "./lib/threads";
 export * from "./lib/chat-config";
 export * from "./lib/chat-configuration";

--- a/showcase/shell-docs/src/content/reference/angular/functions/initAgentStore.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/initAgentStore.mdx
@@ -1,0 +1,147 @@
+---
+title: "initAgentStore"
+description: "Angular function that registers a self-managed HttpAgent under an agent id together with the agent-scoped components and tools it needs, in one call."
+---
+
+## Overview
+
+`initAgentStore` registers a self-managed [`HttpAgent`](/backend/ag-ui) under an `agentId`, together with everything that agent needs on the frontend: display-only components, frontend tools, tool-call renderers, and human-in-the-loop tools. Every registration is scoped to that `agentId`, and a fresh `threadId` is generated per call. Afterwards, [`injectAgentStore`](/reference/angular/functions/injectAgentStore) resolves the agent as usual.
+
+Without it, setting up a self-managed agent means constructing the `HttpAgent`, generating a thread id, merging the agent into the runtime's `selfManagedAgents` without dropping agents registered earlier, and then registering each tool with the matching `agentId`. `initAgentStore` collapses that into one declarative call.
+
+The function only requires an injection context, so it is placement-agnostic: call it from an environment initializer (for example in route-level `providers`), from a custom `injectXyz()` helper that wraps it, or from a component constructor or provider factory. Registered tools are removed when the surrounding injector is destroyed.
+
+<Callout type="info">
+  Import from the package root, `@copilotkit/angular`. `initAgentStore` must run in an injection context that has [`provideCopilotKit`](/reference/angular/functions/provideCopilotKit) in scope. Self-managed agents are part of CopilotKit's [Enterprise Intelligence tier](/intelligence/intelligence-platform); see [Self-managed agents](/backend/self-managed-agents).
+</Callout>
+
+## Signature
+
+```ts
+import { initAgentStore } from "@copilotkit/angular";
+
+function initAgentStore(config: InitAgentStoreConfig): void;
+```
+
+## Parameters
+
+<PropertyReference name="config" type="InitAgentStoreConfig" required>
+  The agent setup object.
+
+  <PropertyReference name="agentId" type="string" required>
+    The id the agent is registered under. Chat components, `injectAgentStore`, and the registered tools use this id to address the agent.
+  </PropertyReference>
+
+  <PropertyReference name="url" type="string" required>
+    The AG-UI endpoint of the agent server the `HttpAgent` talks to.
+  </PropertyReference>
+
+  <PropertyReference name="components" type="RegisterComponentConfig[]">
+    Display-only components the agent can call to show them in the chat. Each entry is registered through [`registerComponent`](/reference/angular/functions/registerComponent) with this `agentId`.
+  </PropertyReference>
+
+  <PropertyReference name="frontendTools" type="FrontendToolConfig[]">
+    Browser-executed tools with a `handler`. Each entry is registered through [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool) with this `agentId`.
+  </PropertyReference>
+
+  <PropertyReference name="renderToolCalls" type="RenderToolCallConfig[]">
+    Renderers for tools the agent already has. Each entry is registered through [`registerRenderToolCall`](/reference/angular/functions/registerRenderToolCall) with this `agentId`.
+  </PropertyReference>
+
+  <PropertyReference name="humanInTheLoop" type="HumanInTheLoopConfig[]">
+    Tools that pause the agent until the user responds. Each entry is registered through [`registerHumanInTheLoop`](/reference/angular/functions/registerHumanInTheLoop) with this `agentId`.
+  </PropertyReference>
+
+  <PropertyReference name="createAgent" type="(agentConfig: HttpAgentConfig) => HttpAgent">
+    Maps the prepared agent config (`agentId`, `url`, and the generated `threadId`) onto the `HttpAgent` or subclass that gets registered. Defaults to `new HttpAgent(agentConfig)`. Use it to plug in an agent with custom headers, persistent context, or incremental message history.
+  </PropertyReference>
+</PropertyReference>
+
+## Return Value
+
+`initAgentStore` returns `void`. It registers the agent and its tools as a side effect. Calling it again with another `agentId` keeps the agents registered before.
+
+## Usage
+
+### Set up an agent per route
+
+```ts title="src/app/app.routes.ts"
+import { Routes } from "@angular/router";
+import { provideEnvironmentInitializer } from "@angular/core";
+import { initAgentStore } from "@copilotkit/angular";
+import { FlightsComponent } from "./flights/flights.component";
+import { FlightCardComponent } from "./flights/flight-card.component";
+import { flightCardSchema, loadFlightsTool } from "./flights/tools";
+
+export const routes: Routes = [
+  {
+    path: "flights",
+    component: FlightsComponent,
+    providers: [
+      provideEnvironmentInitializer(() =>
+        initAgentStore({
+          agentId: "flight-agent",
+          url: "http://localhost:9000/agent",
+          components: [
+            {
+              name: "show_flight",
+              description: "Show one flight from the search result.",
+              parameters: flightCardSchema,
+              component: FlightCardComponent,
+            },
+          ],
+          frontendTools: [loadFlightsTool],
+        }),
+      ),
+    ],
+  },
+];
+```
+
+Inside the route, read the agent with `injectAgentStore("flight-agent")`.
+
+### Customize the agent
+
+```ts
+import { HttpAgent, HttpAgentConfig } from "@ag-ui/client";
+
+class AuthenticatedAgent extends HttpAgent {
+  constructor(config: HttpAgentConfig) {
+    super({
+      ...config,
+      headers: { Authorization: `Bearer ${readToken()}` },
+    });
+  }
+}
+
+initAgentStore({
+  agentId: "flight-agent",
+  url: "http://localhost:9000/agent",
+  createAgent: (agentConfig) => new AuthenticatedAgent(agentConfig),
+});
+```
+
+## Related
+
+<Cards>
+  <Card
+    title="injectAgentStore"
+    description="Subscribe to the registered agent and read its messages, state, and run status as signals."
+    href="/reference/angular/functions/injectAgentStore"
+  />
+  <Card
+    title="registerComponent"
+    description="Register a component the agent can display, with nothing to add on the agent side."
+    href="/reference/angular/functions/registerComponent"
+  />
+  <Card
+    title="provideCopilotKit"
+    description="Configure the runtime connection and self-managed agents at application startup."
+    href="/reference/angular/functions/provideCopilotKit"
+  />
+  <Card
+    title="Self-managed agents"
+    description="Connect AG-UI agents that you host and secure yourself."
+    href="/backend/self-managed-agents"
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/public-api.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/public-api.mdx
@@ -18,8 +18,8 @@ requires every export to appear exactly once in that inventory.
 - **Composable chat UI:** `CopilotChatView`, message, input, textarea,
   suggestion, toolbar, button, attachment, audio, scroll, cursor, disclaimer,
   feather, tools-menu, and renderer components plus their slot/context types.
-- **Agents and application state:** `injectAgentStore`, `injectCapabilities`,
-  `AgentStore`, `connectAgentContext`, `CopilotKitAgentContext`,
+- **Agents and application state:** `injectAgentStore`, `initAgentStore`,
+  `injectCapabilities`, `AgentStore`, `connectAgentContext`, `CopilotKitAgentContext`,
   `injectChatState`, `injectThreads`, `injectMemories`, and their stores,
   controllers, and types.
 - **Tools and activities:** `registerComponent`, `registerFrontendTool`, `registerRenderToolCall`,


### PR DESCRIPTION
## What

Adds `initAgentStore(config)` to the main entry point. One call registers a self-managed `HttpAgent` under an `agentId`, with a fresh `threadId`, together with everything that agent needs on the frontend, all scoped to that agent:

- `components` (display-only components, via `registerComponent`)
- `frontendTools` (browser-executed tools)
- `renderToolCalls` (tool-call renderers)
- `humanInTheLoop` tools

Afterwards, `injectAgentStore(agentId)` resolves the agent as usual. Registered tools are removed when the surrounding injection context is destroyed.

```ts
export const routes: Routes = [{
  path: "flights",
  providers: [provideEnvironmentInitializer(() => initAgentStore({
    agentId: "flight-agent",
    url: "http://localhost:9000/agent",
    components: [flightCard],
    frontendTools: [loadFlightsTool],
  }))],
  ...
}];
```

## Why

Setting up a self-managed agent today means touching several APIs in the right order: construct the `HttpAgent`, generate a thread id, merge it into `updateRuntime({ selfManagedAgents })` without dropping previously registered agents, then register each tool with the matching `agentId`. That is boilerplate every app repeats, and forgetting the `agentId` scoping is an easy silent bug. `initAgentStore` collapses it into one declarative call.

The function only requires an injection context, so it is placement-agnostic: it works from an environment initializer (route-level `providers`, as above), from a custom `injectXyz()` helper that wraps it, or anywhere else injection-context code runs.

## Design notes

- `createAgent?: (agentConfig: HttpAgentConfig) => HttpAgent` maps the prepared config onto an `HttpAgent` subclass when the default is not enough (custom headers, persistent context, incremental history). The default stays `new HttpAgent(agentConfig)`.
- Calling it repeatedly (e.g. once per route) preserves previously registered agents.
- No new dependencies; `HttpAgent` and `randomUUID` come from the existing `@ag-ui/client` dependency.
- Documented in `API.md` and as a reference page in shell-docs.

## Testing

8 specs: agent registration incl. fresh thread id, `createAgent` factory contract, multi-agent accumulation, per-kind registration with correct `agentId` scoping (components, renderers, frontend tools, human-in-the-loop) verified against both the render configs and the core tool registry, and tool removal on injector destroy. Build, `check-types`, and the full Angular suite (55 files, 350 tests) are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Angular support for initializing self-managed agents with automatic thread IDs.
  * Added configuration for agent-scoped components, frontend tools, tool-call renderers, and human-in-the-loop tools.
  * Added support for custom agent creation and automatic cleanup when the Angular injection context is destroyed.

* **Documentation**
  * Added Angular API reference documentation and public API listings for `initAgentStore`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->