### PR TITLE
feat(showcase): add outcome reaction to promote-notify init Slack message

### DIFF
--- a/.github/workflows/showcase_promote_notify.dry-run.sh
+++ b/.github/workflows/showcase_promote_notify.dry-run.sh
@@ -282,6 +282,22 @@ emit() {
 emit "#team-showcase" "$init_text"
 emit "#team-showcase (thread_ts=<init_ts>)" "$thread_text"
 
+# Mirror the workflow's outcome REACTION on the init message. The live .yml
+# calls reactions.add on the ORIGINAL init post (referencing it by `timestamp`,
+# not `ts`) so operators see the net outcome at a glance. No real Slack call
+# happens here, so EMIT what reaction the workflow WOULD add. Keep this
+# outcome→reaction-name case mapping BYTE-IDENTICAL to the .yml's — an
+# anti-drift bats guard enforces it.
+case "$outcome" in
+  success) reaction_name="white_check_mark" ;;
+  partial) reaction_name="warning" ;;
+  total)   reaction_name="x" ;;
+esac
+echo "--- reactions.add ---"
+echo "channel: #team-showcase (ts=<init_ts>)"
+echo "name: ${reaction_name}"
+echo
+
 # Mirror the workflow's post-and-verify exit semantics so the dry-run exercises
 # the SAME fail-loud/warn-only distinction the live .yml does (see the matching
 # slack_alert_posted_ok calls there). No real Slack call happens here, so we

--- a/.github/workflows/showcase_promote_notify.yml
+++ b/.github/workflows/showcase_promote_notify.yml
@@ -398,6 +398,35 @@ jobs:
           # ::warning:: visible without aborting the cross-post below.
           slack_alert_posted_ok "thread reply" "$thread_resp" || true
 
+          # ---------- add outcome reaction to the init message ----------
+          # Add an emoji REACTION to the ORIGINAL init post reflecting the net
+          # run outcome, so operators see success/failure at a glance without
+          # opening the thread. reactions.add references the message by
+          # `timestamp` (NOT `ts`, unlike chat.postMessage's thread_ts). Keep
+          # this outcome→reaction-name case mapping BYTE-IDENTICAL to the
+          # dry-run mirror's — an anti-drift bats guard enforces it.
+          case "$outcome" in
+            success) reaction_name="white_check_mark" ;;
+            partial) reaction_name="warning" ;;
+            total)   reaction_name="x" ;;
+          esac
+          # Guard: the init post may have failed (init_ts/init_channel_id
+          # empty), in which case there is no message to react to — skip with a
+          # ::warning:: rather than error. This reaction is informational, so a
+          # failed add is WARN-ONLY (`|| true`, mirroring the thread reply) —
+          # NOT fail-loud like the #oss-alerts page below.
+          if [ -n "$init_ts" ] && [ -n "$init_channel_id" ]; then
+            reaction_body=$(jq -nc \
+              --arg channel "$init_channel_id" \
+              --arg timestamp "$init_ts" \
+              --arg name "$reaction_name" \
+              '{channel:$channel, timestamp:$timestamp, name:$name}')
+            reaction_resp=$(slack_api reactions.add "$reaction_body")
+            slack_alert_posted_ok "reactions.add (${reaction_name})" "$reaction_resp" || true
+          else
+            echo "::warning::init post ts/channel unavailable; skipping outcome reaction"
+          fi
+
           # ---------- cross-post to #oss-alerts on partial/total failure ----------
           if [ "$outcome" != "success" ]; then
             # Build the trailing link suffix once so both branches share it

--- a/showcase/scripts/__tests__/promote-notify.bats
+++ b/showcase/scripts/__tests__/promote-notify.bats
@@ -168,3 +168,74 @@ PARTIAL_FIXTURE() {
   [[ "$output" != *"::warning::"* ]] || fail "expected NO warning when both posts succeed, got: $output"
   [[ "$output" == *"outcome=partial"* ]] || fail "expected the trailing outcome line (proves the OSS post ran), got: $output"
 }
+
+# ---------- outcome reaction on the init message ----------
+# The workflow adds an emoji REACTION to the ORIGINAL init post reflecting the
+# net run outcome (success ✅ white_check_mark / partial ⚠️ warning / total ❌
+# x) so operators see the result at a glance without opening the thread. No
+# real Slack call happens in the dry-run, so it EMITS the reaction it WOULD add
+# as a `--- reactions.add ---` block. These tests run the dry-run as a
+# subprocess per fixture and assert the emitted reaction name.
+
+FIXTURE() {
+  echo "$BATS_TEST_DIRNAME/../../test-fixtures/promote-notify/$1"
+}
+
+@test "reaction: success outcome adds white_check_mark to the init message" {
+  local fixture
+  fixture="$(FIXTURE success.json)"
+  [ -f "$fixture" ] || fail "fixture not found: $fixture"
+  run bash "$HELPER" --file "$fixture"
+  [ "$status" -eq 0 ] || fail "expected zero exit, got $status; output: $output"
+  [[ "$output" == *"--- reactions.add ---"* ]] || fail "expected a reactions.add block, got: $output"
+  [[ "$output" == *"name: white_check_mark"* ]] || fail "expected name: white_check_mark, got: $output"
+}
+
+@test "reaction: partial outcome adds warning to the init message" {
+  local fixture
+  fixture="$(FIXTURE partial.json)"
+  [ -f "$fixture" ] || fail "fixture not found: $fixture"
+  run bash "$HELPER" --file "$fixture"
+  [ "$status" -eq 0 ] || fail "expected zero exit, got $status; output: $output"
+  [[ "$output" == *"--- reactions.add ---"* ]] || fail "expected a reactions.add block, got: $output"
+  [[ "$output" == *"name: warning"* ]] || fail "expected name: warning, got: $output"
+}
+
+@test "reaction: total-failure outcome adds x to the init message" {
+  local fixture
+  fixture="$(FIXTURE total-failure.json)"
+  [ -f "$fixture" ] || fail "fixture not found: $fixture"
+  run bash "$HELPER" --file "$fixture"
+  [ "$status" -eq 0 ] || fail "expected zero exit, got $status; output: $output"
+  [[ "$output" == *"--- reactions.add ---"* ]] || fail "expected a reactions.add block, got: $output"
+  [[ "$output" == *"name: x"* ]] || fail "expected name: x, got: $output"
+}
+
+# ---------- anti-drift parity guard for the reaction mapping ----------
+# The dry-run inlines the SAME outcome→reaction-name case mapping the .yml uses.
+# The suite sources only the .sh mirror, so a yml-only edit to the mapping would
+# drift undetected. Extract the three mapping arms from BOTH files (modulo
+# leading indent) and assert they are identical — mirroring the
+# slack_alert_posted_ok anti-drift guard above. Drift => CI failure.
+
+@test "reaction: yml and sh reaction-name mapping is identical (anti-drift)" {
+  local root yml sh
+  root="$BATS_TEST_DIRNAME/../../../.github/workflows"
+  yml="$root/showcase_promote_notify.yml"
+  sh="$root/showcase_promote_notify.dry-run.sh"
+  [ -f "$yml" ] || fail "yml not found: $yml"
+  [ -f "$sh" ]  || fail "sh mirror not found: $sh"
+
+  extract_map() {
+    grep -E 'reaction_name="(white_check_mark|warning|x)"' "$1" | sed 's/^[[:space:]]*//'
+  }
+  local yml_map sh_map
+  yml_map=$(extract_map "$yml")
+  sh_map=$(extract_map "$sh")
+
+  [ -n "$yml_map" ] || fail "could not extract reaction-name mapping from $yml"
+  [ -n "$sh_map" ]  || fail "could not extract reaction-name mapping from $sh"
+
+  [ "$yml_map" = "$sh_map" ] || fail "reaction-name mapping drifted between yml and sh mirror:
+$(diff <(printf '%s\n' "$sh_map") <(printf '%s\n' "$yml_map"))"
+}


### PR DESCRIPTION
## What & why

The `showcase_promote_notify` workflow posts an init message to `#team-showcase`, then a threaded reply summarizing the run outcome. Operators wanted the *net* result visible at a glance on the original init message without clicking into the thread.

This adds an emoji **reaction** to the original init message reflecting the run outcome via Slack's `reactions.add` API.

### Outcome → emoji mapping

| `outcome` | reaction name | emoji |
|-----------|---------------|-------|
| `success` | `white_check_mark` | ✅ |
| `partial` | `warning` | ⚠️ |
| `total`   | `x` | ❌ |

### Implementation notes

- **`showcase_promote_notify.yml`** — after the thread reply, maps `outcome` → reaction name with a `case` and calls the existing `slack_api` helper with `reactions.add` (body `{channel, timestamp, name}` — note `timestamp`, not `ts`, for `reactions.add`). Guarded: only attempts when both `init_ts` and `init_channel_id` are non-empty (init post may have failed → skip with a `::warning::`). The reaction is informational, so a failed add is **warn-only** (`|| true`), mirroring the thread-reply idiom — NOT the fail-loud `#oss-alerts` page.
- **`showcase_promote_notify.dry-run.sh`** — makes no real Slack calls, so it emits the reaction it *would* add as a `--- reactions.add ---` block. The `outcome`→reaction-name `case` is byte-identical to the `.yml`.
- **`promote-notify.bats`** — new tests assert the emitted reaction name per fixture, plus a new anti-drift parity guard that the reaction mapping matches between the `.yml` and the `.sh` mirror (mirroring the existing `slack_alert_posted_ok` parity test).

## Red-Green Proof

The real failure surface is the dry-run harness + bats suite.

### RED — before the change

Dry-run on all three fixtures emits **no** `reactions.add` line (`grep -c` = 0 each):

```
########## RED dry-run: success.json ##########  -> grep reactions.add: 0
########## RED dry-run: partial.json ##########  -> grep reactions.add: 0
########## RED dry-run: total-failure.json #####  -> grep reactions.add: 0
```

New bats tests fail (existing 1–11 pass):

```
ok 11 call-site: both posts ok → zero exit, no warning
not ok 12 reaction: success outcome adds white_check_mark to the init message
not ok 13 reaction: partial outcome adds warning to the init message
not ok 14 reaction: total-failure outcome adds x to the init message
not ok 15 reaction: yml and sh reaction-name mapping is identical (anti-drift)
```

### GREEN — after the change

Dry-run emits the correct reaction per outcome:

```
########## GREEN dry-run: success.json ##########
--- reactions.add ---
channel: #team-showcase (ts=<init_ts>)
name: white_check_mark
########## GREEN dry-run: partial.json ##########
--- reactions.add ---
channel: #team-showcase (ts=<init_ts>)
name: warning
########## GREEN dry-run: total-failure.json ##########
--- reactions.add ---
channel: #team-showcase (ts=<init_ts>)
name: x
```

Full bats suite passes (15/15):

```
ok 1  slack_alert_posted_ok: ok:true response returns 0 and emits no warning
...
ok 11 call-site: both posts ok → zero exit, no warning
ok 12 reaction: success outcome adds white_check_mark to the init message
ok 13 reaction: partial outcome adds warning to the init message
ok 14 reaction: total-failure outcome adds x to the init message
ok 15 reaction: yml and sh reaction-name mapping is identical (anti-drift)
```

`shellcheck .github/workflows/showcase_promote_notify.dry-run.sh` → clean (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6rwtyRSUFtgiAY2dYuyU2
