### PR TITLE
docs: fix stale quickstart/link references and add MCP Codex setup

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
@@ -48,6 +48,10 @@ Before you begin, you'll need the following:
         npx create-next-app@latest my-copilot-app
         cd my-copilot-app
         ```
+
+        <Callout type="info" title="Already have an app?">
+          Skip this step and install CopilotKit into your existing React or Next.js project. The CopilotKit CLI (`npx copilotkit@latest create`, aliased as `init`) scaffolds a brand-new project in its own directory — it does not add CopilotKit to an app you already have.
+        </Callout>
     </Step>
     <Step>
         ### Install CopilotKit packages

--- a/showcase/shell-docs/src/content/snippets/shared/cli/cli.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/cli/cli.mdx
@@ -20,6 +20,10 @@ Use the CLI when you want to start a new app, connect an existing app to a cloud
 
 ## Start a new app
 
+<Callout type="info" title="Creating vs. adding to an existing app">
+  `create` (aliased as `init`) scaffolds a brand-new project in its own directory — it prompts for an app name and does not detect or bootstrap an app you already have. To add CopilotKit to an existing app, follow the manual installation in the [Quickstart](/quickstart) instead.
+</Callout>
+
 <Steps>
   <Step>
     ### Run create

--- a/showcase/shell-docs/src/content/snippets/shared/generative-ui-specs-overview.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/generative-ui-specs-overview.mdx
@@ -38,11 +38,29 @@ AG-UI natively supports all of the above generative UI specs and allows develope
 
 Explore each specification in detail:
 
-- [A2UI](/generative-ui/specs/a2ui) - Google's declarative Generative UI spec
-- [Open-JSON-UI](/generative-ui/specs/open-json-ui) - OpenAI's open Generative UI standard
-- [MCP Apps](/generative-ui/specs/mcp-apps) - Iframe-based Generative UI extending MCP
+- [A2UI](/generative-ui/a2ui) - Google's declarative Generative UI spec
+- [Open-JSON-UI](/generative-ui/open-json-ui) - OpenAI's open Generative UI standard
+- [MCP Apps](/generative-ui/mcp-apps) - Iframe-based Generative UI extending MCP
+- [Open Generative UI](/generative-ui/open-generative-ui) - Let agents generate fully interactive HTML/CSS/JS UIs that stream live into the chat
 
 Or learn about related protocols:
 
 - [AG-UI Protocol](/ag-ui-protocol) - The user interaction protocol that supports all these specs
 - [Generative UI Guide](/generative-ui) - Build with Generative UI in CopilotKit
+
+## **Supported Frameworks**
+
+Generative UI works with every agent framework CopilotKit integrates with — pick yours to get started:
+
+- [LangGraph (Python)](/langgraph-python/quickstart) · [LangGraph (TypeScript)](/langgraph-typescript/quickstart)
+- [Google ADK](/google-adk/quickstart)
+- [Microsoft Agent Framework](/ms-agent-python/quickstart)
+- [AWS Strands](/strands/quickstart)
+- [Mastra](/mastra/quickstart)
+- [PydanticAI](/pydantic-ai/quickstart)
+- [CrewAI](/crewai-crews/quickstart)
+- [Agno](/agno/quickstart)
+- [AG2](/ag2/quickstart)
+- [LlamaIndex](/llamaindex/quickstart)
+- [Claude Agent SDK](/claude-sdk-python/quickstart)
+- [Deep Agents](/deepagents/quickstart)

--- a/showcase/shell-docs/src/content/snippets/shared/generative-ui-specs-overview.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/generative-ui-specs-overview.mdx
@@ -39,12 +39,11 @@ AG-UI natively supports all of the above generative UI specs and allows develope
 Explore each specification in detail:
 
 - [A2UI](/generative-ui/a2ui) - Google's declarative Generative UI spec
-- [Open-JSON-UI](/generative-ui/open-json-ui) - OpenAI's open Generative UI standard
 - [MCP Apps](/generative-ui/mcp-apps) - Iframe-based Generative UI extending MCP
+
+Or learn about related Generative UI capabilities:
+
 - [Open Generative UI](/generative-ui/open-generative-ui) - Let agents generate fully interactive HTML/CSS/JS UIs that stream live into the chat
-
-Or learn about related protocols:
-
 - [AG-UI Protocol](/ag-ui-protocol) - The user interaction protocol that supports all these specs
 - [Generative UI Guide](/generative-ui) - Build with Generative UI in CopilotKit
 

--- a/showcase/shell-docs/src/content/snippets/shared/guides/mcp-server-setup.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/guides/mcp-server-setup.mdx
@@ -416,6 +416,39 @@ development environment, it enables AI assistants to:
   </Step>
 </Steps>
 
+### Codex
+
+[Codex](https://developers.openai.com/codex) is OpenAI's coding agent. Its CLI reads MCP servers from `~/.codex/config.toml`, where each server is defined under an `[mcp_servers.<name>]` table.
+
+<Steps>
+  <Step>
+    ### Add MCP Server to Codex
+    Add CopilotKit MCP to `~/.codex/config.toml`. Codex launches command-based (stdio) servers, so bridge the remote server with `mcp-remote`:
+
+    ```toml title="~/.codex/config.toml"
+    [mcp_servers.copilotkit]
+    command = "npx"
+    args = ["mcp-remote", "https://mcp.copilotkit.ai"]
+    ```
+
+    Or add it from the terminal with the Codex CLI:
+
+    ```bash
+    codex mcp add copilotkit -- npx mcp-remote https://mcp.copilotkit.ai
+    ```
+  </Step>
+  <Step>
+    ### Verify Connection
+    List the configured MCP servers to confirm CopilotKit is registered:
+
+    ```bash
+    codex mcp list
+    ```
+
+    Once configured, the CopilotKit MCP tools are available to Codex and are used automatically when relevant to your CopilotKit development tasks.
+  </Step>
+</Steps>
+
 ### Other
 
 For MCP-compatible applications not listed above, use these universal integration patterns. MCP (Model Context Protocol) is an open standard that allows AI applications to connect with external tools and data sources.


### PR DESCRIPTION
## What & why

Three independent documentation-accuracy fixes, batched into one PR.

### 1. Dead spec links + gen-ui page gaps (Closes #3975)
`generative-ui-specs-overview.mdx` (rendered at `/whats-new/generative-ui-spec-support`) linked to the retired `/generative-ui/specs/<spec>` subgroup. Repointed to canonical destinations and added the frameworks list the issue asked for.

**Verified live (HTTP status against docs.copilotkit.ai):**

| Link | Before | After |
| --- | --- | --- |
| A2UI | `/generative-ui/specs/a2ui` (301 hop) | `/generative-ui/a2ui` → **200** |
| MCP Apps | `/generative-ui/specs/mcp-apps` (301 hop) | `/generative-ui/mcp-apps` → **200** |
| Open Generative UI (new) | — | `/generative-ui/open-generative-ui` → **200** |

- **Supported Frameworks** list added — all 12 `/<slug>/quickstart` targets return **200** live (LangGraph Py/TS, Google ADK, MS Agent, AWS Strands, Mastra, PydanticAI, CrewAI, Agno, AG2, LlamaIndex, Claude Agent SDK, Deep Agents).
- **Open-JSON-UI is intentionally NOT linked:** `/generative-ui/open-json-ui` is a placeholder pulled from the nav and redirected to `/generative-ui` on purpose (`next.config.ts` — `// AI-slop placeholder pulled from nav until properly authored`). Linking only the two specs that have live detail pages avoids sending readers to a redirect. Open-JSON-UI is still described in the comparison table on the page.
- Open Generative UI is a CopilotKit capability (not an external spec), so it sits under "related capabilities."

> Note: the issue/support-bot suggested a `/learn/...` path — there is no `/learn/` tree in shell-docs; the canonical homes are the flat `/generative-ui/<spec>` pages.

### 2. CLI `init` vs. existing app (Closes #2525)
Maintainer resolution was "fix the docs." The original "`init` bootstraps your existing Next.js app" claim was already removed in the shell-docs migration (the reported `/direct-to-llm/guides/quickstart` now resolves to the Built-in Agent quickstart, which is fully manual). To remove the remaining ambiguity:
- **Built-in Agent quickstart:** added an "Already have an app?" callout — existing apps skip `create-next-app`.
- **CLI guide (`cli.mdx`):** clarified that `create` (aliased `init`) scaffolds a brand-new project in its own directory and does not detect/bootstrap an existing app; points to the manual install in the Quickstart.

Verified against `copilotkit@latest` (4.3.0): `init --help` → *"Initialize a **new** CopilotKit project … before scaffolding"*, `-n, --name` *"names the local app **and its directory**"*, and `init`/`create` are aliases.

### 3. Codex setup for the MCP guide (Closes #2526)
Added a **Codex** section to `mcp-server-setup.mdx` using the stdio `mcp-remote` bridge in `~/.codex/config.toml`, matching the page's existing command-based pattern (Cursor / Windsurf / Claude Desktop), plus the `codex mcp add` shortcut.

Verified against the installed Codex CLI: `codex mcp --help` lists `add`/`list`/`get`/`remove`, and the `[mcp_servers.<name>]` table with `command`/`args` matches OpenAI's Codex config reference. Per the issue thread, the macOS `mcp-remote` port-blocking concern is **not** claimed to be solved — only the Codex config is documented.

## Testing
- **#3975 (links):** curled every added/changed URL against the live docs — A2UI, MCP Apps, Open Generative UI, and all 12 framework quickstarts return **200**; confirmed `/generative-ui/open-json-ui` is a deliberate redirect (hence unlinked). Pre-existing `/ag-ui-protocol` and `/generative-ui` links are stable 301→200 and left as-is.
- **#2525 (CLI):** ran `npx copilotkit@latest init --help` on the published `latest` (4.3.0) — confirmed new-directory scaffolding, no existing-app detection; verified `[Quickstart](/quickstart)` serves the manual-install page live (`create-next-app` + "Install CopilotKit packages").
- **#2526 (Codex):** ran `codex mcp --help` to confirm subcommands; new section reuses the file's existing `<Steps>`/fenced-code structure. `<Callout>` is a registered global MDX component (`src/lib/mdx-registry.tsx`), already used unimported on the Built-in Agent quickstart.
- Docs-only; no code paths affected.

Closes #3975
Closes #2525
Closes #2526

🤖 Generated with [Claude Code](https://claude.com/claude-code)