### PR TITLE
Feat/height measurement cleanup

### DIFF
--- a/examples/v2/runtime/node/src/index.ts
+++ b/examples/v2/runtime/node/src/index.ts
@@ -8,9 +8,7 @@ import { createCopilotNodeHandler } from "@copilotkit/runtime/v2/node";
 
 const runtime = new CopilotRuntime({
   agents: {
-    default: new BuiltInAgent({
-      model: process.env.MODEL ?? "openai/gpt-5-mini",
-    }),
+    default: new BuiltInAgent({ model: "openai/gpt-5-mini" }),
   },
 });
 

--- a/examples/v2/runtime/node/src/index.ts
+++ b/examples/v2/runtime/node/src/index.ts
@@ -8,7 +8,9 @@ import { createCopilotNodeHandler } from "@copilotkit/runtime/v2/node";
 
 const runtime = new CopilotRuntime({
   agents: {
-    default: new BuiltInAgent({ model: "openai/gpt-5-mini" }),
+    default: new BuiltInAgent({
+      model: process.env.MODEL ?? "openai/gpt-5-mini",
+    }),
   },
 });
 

--- a/packages/angular/API.md
+++ b/packages/angular/API.md
@@ -116,6 +116,7 @@ Import these symbols from `@copilotkit/angular`.
 - `CopilotChatViewFeather`
 - `CopilotChatViewHandlers`
 - `CopilotChatViewInputContainer`
+- `CopilotChatViewInputMeasure`
 - `CopilotChatViewLayoutContext`
 - `CopilotChatViewProps`
 - `CopilotChatViewScrollToBottomButton`

--- a/packages/angular/src/lib/components/chat/__tests__/copilot-chat-view.component.spec.ts
+++ b/packages/angular/src/lib/components/chat/__tests__/copilot-chat-view.component.spec.ts
@@ -64,7 +64,7 @@ describe("CopilotChatView", () => {
     ).toBeNull();
   });
 
-  it("sizes the default scroll view as the flex child that owns vertical scrolling", () => {
+  it("sizes the default scroll view as the flex child that owns vertical scrolling", async () => {
     const fixture = TestBed.createComponent(CopilotChatView);
     const messages: Message[] = [
       {
@@ -76,12 +76,17 @@ describe("CopilotChatView", () => {
 
     fixture.componentRef.setInput("messages", messages);
     fixture.detectChanges();
+    // Flush the scroll view's mount hook so the interactive branch renders
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    fixture.detectChanges();
 
     const element = fixture.nativeElement as HTMLElement;
     const scrollViewHost = element.querySelector(
       "copilot-chat-view-scroll-view",
     );
-    const scrollContainer = scrollViewHost?.querySelector("div");
+    const scrollContainer = scrollViewHost?.querySelector("[cdkScrollable]");
 
     expect(scrollViewHost?.classList.contains("cpk:flex-1")).toBe(true);
     expect(scrollViewHost?.classList.contains("cpk:min-h-0")).toBe(true);
@@ -115,5 +120,121 @@ describe("CopilotChatView", () => {
     ).find((node) => node.style.paddingBottom !== "");
 
     expect(scrollContent?.style.paddingBottom).toBe("32px");
+  });
+
+  it("sizes the mounted scroll wrapper to its container, not the viewport", async () => {
+    const fixture = TestBed.createComponent(CopilotChatView);
+    const messages: Message[] = [
+      {
+        id: "user-1",
+        role: "user",
+        content: "Hello",
+      },
+    ];
+
+    fixture.componentRef.setInput("messages", messages);
+    fixture.detectChanges();
+    // Flush the scroll view's hasMounted timer so the mounted branch renders
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    const wrapper = element.querySelector(
+      "copilot-chat-view-scroll-view > div",
+    );
+
+    // A viewport-based height (calc(100vh - 9rem)) overshoots any embedded
+    // container; the wrapper must track the panel it is placed in instead.
+    expect(wrapper?.className).toContain("cpk:h-full");
+    expect(wrapper?.className).toContain("cpk:max-h-full");
+    expect(wrapper?.className).not.toContain("100vh");
+  });
+
+  it("measures the floating input after transitioning from welcome screen to chat", async () => {
+    // Regression: measurement used to run once in ngAfterViewInit. When the
+    // chat mounted on the welcome screen (no input overlay in the DOM), all
+    // retries expired and inputContainerHeight stayed 0 forever — messages
+    // hid under the floating input and the scroll-to-bottom button sat on
+    // top of it.
+    const fixture = TestBed.createComponent(CopilotChatView);
+    fixture.componentRef.setInput("messages", []);
+    fixture.componentRef.setInput("hasExplicitThreadId", false);
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    expect(
+      element.querySelector('[data-testid="copilot-welcome-screen"]'),
+    ).not.toBeNull();
+
+    // jsdom reports offsetHeight as 0; give elements a real footprint so the
+    // measurement can succeed once the overlay exists.
+    const originalOffsetHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "offsetHeight",
+    );
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      configurable: true,
+      get() {
+        return 132;
+      },
+    });
+
+    try {
+      const messages: Message[] = [
+        {
+          id: "user-1",
+          role: "user",
+          content: "Hello",
+        },
+      ];
+      fixture.componentRef.setInput("messages", messages);
+      fixture.detectChanges();
+
+      // Flush the deferred measurement (scheduled at 0ms when the overlay
+      // branch mounts) plus the scroll view's hasMounted timer.
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+      fixture.detectChanges();
+
+      const scrollContent = Array.from(
+        element.querySelectorAll<HTMLElement>(
+          "copilot-chat-view-scroll-view div",
+        ),
+      ).find((node) => node.style.paddingBottom !== "");
+
+      // measured input height (132) + default reserve (32)
+      expect(scrollContent?.style.paddingBottom).toBe("164px");
+
+      // Returning to the welcome screen and starting a new chat re-measures
+      // when the overlay mounts again.
+      fixture.componentRef.setInput("messages", []);
+      fixture.detectChanges();
+      fixture.componentRef.setInput("messages", messages);
+      fixture.detectChanges();
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+      fixture.detectChanges();
+
+      const remeasured = Array.from(
+        element.querySelectorAll<HTMLElement>(
+          "copilot-chat-view-scroll-view div",
+        ),
+      ).find((node) => node.style.paddingBottom !== "");
+      expect(remeasured?.style.paddingBottom).toBe("164px");
+    } finally {
+      if (originalOffsetHeight) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "offsetHeight",
+          originalOffsetHeight,
+        );
+      } else {
+        delete (HTMLElement.prototype as any).offsetHeight;
+      }
+    }
   });
 });

--- a/packages/angular/src/lib/components/chat/copilot-chat-view-input-measure.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat-view-input-measure.ts
@@ -1,0 +1,74 @@
+import {
+  DestroyRef,
+  Directive,
+  ElementRef,
+  afterNextRender,
+  computed,
+  inject,
+  signal,
+} from "@angular/core";
+import { toObservable, toSignal } from "@angular/core/rxjs-interop";
+import { EMPTY } from "rxjs";
+import { switchMap } from "rxjs/operators";
+import { ResizeObserverService } from "../../resize-observer";
+
+/**
+ * Measures the chat view's floating input container and exposes its height
+ * as a signal.
+ *
+ * Applied to the copilot-slot hosting the input container. Because the slot
+ * only exists on the chat-view branch of the template (the welcome-screen
+ * branch omits it), the directive's lifecycle mirrors the overlay's: it is
+ * created when the overlay mounts — including after the user sends their
+ * first message from the welcome screen — and torn down with it.
+ *
+ * Measurement is platform-driven: afterNextRender fires once the slot's
+ * dynamically created content is in the DOM (and never during SSR), and the
+ * ResizeObserver keeps the height current from there, including the initial
+ * 0 → laid-out transition.
+ */
+@Directive({
+  selector: "[copilotChatViewInputMeasure]",
+})
+export class CopilotChatViewInputMeasure {
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly resizeObserverService = inject(ResizeObserverService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  /**
+   * Root element of the input container component — its absolutely
+   * positioned overlay wrapper — once it has been rendered into the slot.
+   * Custom input containers without that element are left unmeasured.
+   */
+  private readonly target = signal<HTMLElement | null>(null);
+
+  private readonly state = toSignal(
+    toObservable(this.target).pipe(
+      switchMap((el) =>
+        el
+          ? this.resizeObserverService.observeElement(new ElementRef(el))
+          : EMPTY,
+      ),
+    ),
+  );
+
+  /** Measured height of the input container in px; 0 until first laid out. */
+  readonly height = computed(() => this.state()?.height ?? 0);
+
+  /** True while the input container is resizing, false once it has settled. */
+  readonly resizing = computed(() => this.state()?.isResizing ?? false);
+
+  constructor() {
+    afterNextRender(() => {
+      const el = this.host.nativeElement.querySelector(
+        "copilot-chat-view-input-container",
+      )?.firstElementChild;
+      if (el instanceof HTMLElement) {
+        this.destroyRef.onDestroy(() =>
+          this.resizeObserverService.unobserve(el),
+        );
+        this.target.set(el);
+      }
+    });
+  }
+}

--- a/packages/angular/src/lib/components/chat/copilot-chat-view-scroll-view.html
+++ b/packages/angular/src/lib/components/chat/copilot-chat-view-scroll-view.html
@@ -58,7 +58,7 @@
 </div>
 } @else {
 <div
-  class="cpk:h-[calc(100vh-9rem)] cpk:flex cpk:flex-col cpk:min-h-0 cpk:relative"
+  class="cpk:h-full cpk:max-h-full cpk:flex cpk:flex-col cpk:min-h-0 cpk:relative"
 >
   @if (autoScroll()) {
   <!-- Auto-scroll mode with StickToBottom directive -->

--- a/packages/angular/src/lib/components/chat/copilot-chat-view.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat-view.ts
@@ -3,21 +3,15 @@ import {
   ContentChild,
   TemplateRef,
   Type,
-  ViewChild,
-  ElementRef,
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   ViewEncapsulation,
   computed,
-  signal,
   OnInit,
   OnChanges,
-  OnDestroy,
-  AfterViewInit,
   input,
   output,
   inject,
-  NgZone,
+  viewChild,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { CopilotSlot } from "../../slots/copilot-slot";
@@ -25,6 +19,7 @@ import { CopilotChatViewScrollView } from "./copilot-chat-view-scroll-view";
 import { CopilotChatViewScrollToBottomButton } from "./copilot-chat-view-scroll-to-bottom-button";
 import { CopilotChatViewFeather } from "./copilot-chat-view-feather";
 import { CopilotChatViewInputContainer } from "./copilot-chat-view-input-container";
+import { CopilotChatViewInputMeasure } from "./copilot-chat-view-input-measure";
 import { CopilotChatViewDisclaimer } from "./copilot-chat-view-disclaimer";
 import { CopilotChatInput } from "./copilot-chat-input";
 import { CopilotChatAttachmentQueue } from "./copilot-chat-attachment-queue";
@@ -33,8 +28,6 @@ import { Message } from "@ag-ui/client";
 import { cn } from "../../utils";
 import { ResizeObserverService } from "../../resize-observer";
 import { CopilotChatViewHandlers } from "./copilot-chat-view-handlers";
-import { Subject } from "rxjs";
-import { takeUntil } from "rxjs/operators";
 import { ChatState } from "../../chat-state";
 import { CopilotIcon, Upload } from "../icons/copilot-icon";
 import { injectChatLabels } from "../../chat-config";
@@ -58,6 +51,7 @@ import { injectChatLabels } from "../../chat-config";
     CommonModule,
     CopilotSlot,
     CopilotChatViewScrollView,
+    CopilotChatViewInputMeasure,
     CopilotChatAttachmentQueue,
     CopilotChatSuggestionView,
     CopilotIcon,
@@ -206,7 +200,7 @@ import { injectChatLabels } from "../../chat-config";
 
         <!-- Input container -->
         <copilot-slot
-          #inputContainerSlotRef
+          copilotChatViewInputMeasure
           [slot]="inputContainerSlot()"
           [context]="inputContainerContext()"
           [defaultComponent]="defaultInputContainerComponent"
@@ -216,9 +210,7 @@ import { injectChatLabels } from "../../chat-config";
     }
   `,
 })
-export class CopilotChatView
-  implements OnInit, OnChanges, AfterViewInit, OnDestroy
-{
+export class CopilotChatView implements OnInit, OnChanges {
   // Core inputs matching React props
   protected readonly chatState = inject(ChatState, { optional: true });
   protected readonly UploadIcon = Upload;
@@ -305,10 +297,6 @@ export class CopilotChatView
   userMessageCopy = output<{ message: Message }>();
   userMessageEdit = output<{ message: Message }>();
 
-  // ViewChild references
-  @ViewChild("inputContainerSlotRef", { read: ElementRef })
-  inputContainerSlotRef?: ElementRef;
-
   // Default components for slots
   protected readonly defaultScrollViewComponent = CopilotChatViewScrollView;
   protected readonly defaultScrollToBottomButtonComponent =
@@ -326,8 +314,13 @@ export class CopilotChatView
   protected showCursorSignal = computed(() => this.showCursor());
   protected disclaimerTextSignal = computed(() => this.disclaimerText());
   protected disclaimerClassSignal = computed(() => this.disclaimerClass());
-  protected inputContainerHeight = signal<number>(0);
-  protected isResizing = signal<boolean>(false);
+  private readonly inputMeasure = viewChild(CopilotChatViewInputMeasure);
+  protected readonly inputContainerHeight = computed(
+    () => this.inputMeasure()?.height() ?? 0,
+  );
+  protected readonly isResizing = computed(
+    () => this.inputMeasure()?.resizing() ?? false,
+  );
   protected shouldShowWelcomeScreen = computed(
     () => this.messagesValue().length === 0 && !this.hasExplicitThreadId(),
   );
@@ -424,19 +417,7 @@ export class CopilotChatView
     disclaimer: this.disclaimerSlot(),
   }));
 
-  private destroy$ = new Subject<void>();
-  private resizeTimeoutRef?: number;
-  private measurementRetryTimeoutRef?: number;
-  private readonly ngZone = inject(NgZone);
-  private destroyed = false;
-
-  constructor(
-    private resizeObserverService: ResizeObserverService,
-    private cdr: ChangeDetectorRef,
-    private handlers: CopilotChatViewHandlers,
-  ) {
-    // Clear any pending resize timeout when toggling isResizing, without signal writes here
-  }
+  constructor(private handlers: CopilotChatViewHandlers) {}
 
   ngOnInit(): void {
     // Initialize handler availability in the view-scoped service
@@ -457,132 +438,5 @@ export class CopilotChatView
     this.handlers.hasAssistantRegenerateHandler.set(true);
     this.handlers.hasUserCopyHandler.set(true);
     this.handlers.hasUserEditHandler.set(true);
-  }
-
-  ngAfterViewInit(): void {
-    // Don't set a default height - measure it dynamically
-
-    // Set up input container height monitoring
-    const measureAndObserve = () => {
-      if (
-        !this.inputContainerSlotRef ||
-        !this.inputContainerSlotRef.nativeElement
-      ) {
-        return false;
-      }
-
-      // The slot ref points to the copilot-slot element
-      // We need to find the actual input container component inside it
-      const slotElement = this.inputContainerSlotRef.nativeElement;
-      const componentElement = slotElement.querySelector(
-        "copilot-chat-view-input-container",
-      );
-
-      if (!componentElement) {
-        return false;
-      }
-
-      // Look for the absolute positioned div that contains the input
-      let innerDiv = componentElement.querySelector(
-        "div.absolute",
-      ) as HTMLElement;
-
-      // If not found by class, try first child
-      if (!innerDiv) {
-        innerDiv = componentElement.firstElementChild as HTMLElement;
-      }
-
-      if (!innerDiv) {
-        return false;
-      }
-
-      // Measure the actual height
-      const measuredHeight = innerDiv.offsetHeight;
-
-      if (measuredHeight === 0) {
-        return false;
-      }
-
-      // Success! Set the initial height
-      this.inputContainerHeight.set(measuredHeight);
-      this.cdr.detectChanges();
-
-      // Create an ElementRef wrapper for ResizeObserver
-      const innerDivRef = new ElementRef(innerDiv);
-
-      // Set up ResizeObserver to track changes
-      this.resizeObserverService
-        .observeElement(innerDivRef, 0, 250)
-        .pipe(takeUntil(this.destroy$))
-        .subscribe((state) => {
-          const newHeight = state.height;
-
-          if (newHeight !== this.inputContainerHeight() && newHeight > 0) {
-            this.inputContainerHeight.set(newHeight);
-            this.isResizing.set(true);
-            this.cdr.detectChanges();
-
-            // Clear existing timeout
-            if (this.resizeTimeoutRef) {
-              clearTimeout(this.resizeTimeoutRef);
-            }
-
-            // Set isResizing to false after a short delay
-            this.resizeTimeoutRef = window.setTimeout(() => {
-              this.isResizing.set(false);
-              this.resizeTimeoutRef = undefined;
-              this.cdr.detectChanges();
-            }, 250);
-          }
-        });
-
-      return true;
-    };
-
-    // Try to measure immediately
-    if (!measureAndObserve()) {
-      // If failed, retry with increasing delays
-      let attempts = 0;
-      const maxAttempts = 10;
-
-      const retry = () => {
-        if (this.destroyed) return;
-        attempts++;
-        if (measureAndObserve()) {
-          // Successfully measured
-        } else if (attempts < maxAttempts) {
-          // Exponential backoff: 50ms, 100ms, 200ms, 400ms, etc.
-          const delay = 50 * Math.pow(2, Math.min(attempts - 1, 4));
-          this.scheduleMeasurementRetry(retry, delay);
-        } else {
-          // Failed to measure after max attempts
-        }
-      };
-
-      // Start retry with first delay
-      this.scheduleMeasurementRetry(retry, 50);
-    }
-  }
-
-  /** Schedules a cancellable layout retry without triggering zone-wide ticks. */
-  private scheduleMeasurementRetry(callback: () => void, delay: number): void {
-    this.ngZone.runOutsideAngular(() => {
-      this.measurementRetryTimeoutRef = window.setTimeout(() => {
-        this.measurementRetryTimeoutRef = undefined;
-        callback();
-      }, delay);
-    });
-  }
-
-  ngOnDestroy(): void {
-    this.destroyed = true;
-    if (this.resizeTimeoutRef) {
-      clearTimeout(this.resizeTimeoutRef);
-    }
-    if (this.measurementRetryTimeoutRef) {
-      clearTimeout(this.measurementRetryTimeoutRef);
-    }
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -65,6 +65,7 @@ export * from "./lib/components/chat/copilot-chat-view-disclaimer";
 export * from "./lib/components/chat/copilot-chat-view-feather";
 export * from "./lib/components/chat/copilot-chat-view-handlers";
 export * from "./lib/components/chat/copilot-chat-view-input-container";
+export * from "./lib/components/chat/copilot-chat-view-input-measure";
 export * from "./lib/components/chat/copilot-chat-view-scroll-to-bottom-button";
 export * from "./lib/components/chat/copilot-chat-view-scroll-view";
 export * from "./lib/components/chat/copilot-chat-view.types";


### PR DESCRIPTION
Fixes two layout bugs in the Angular chat view:

1. **Floating-input height stuck at `0`.** Measurement ran once in `ngAfterViewInit`,
   but on the welcome screen the input overlay isn't in the DOM yet — retries
   expired and the height never recovered. After the first message, the list
   rendered under the floating input and the scroll-to-bottom button overlapped it.
2. **Scroll wrapper sized to the viewport** (`h-[calc(100vh-9rem)]`), which
   overshoots when the chat is embedded in a smaller panel.

Changes:
- New **`CopilotChatViewInputMeasure`** directive on the input slot — its lifecycle
  mirrors the overlay, so it re-measures on the welcome → chat transition.
  `afterNextRender` + `ResizeObserver`, SSR-safe, height exposed as a signal.
- Scroll wrapper → `h-full max-h-full` so it tracks its container.

Regression tests cover both fixes.

## Checklist

- [ X ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ X ] If the PR changes or adds functionality, I have updated the relevant documentation
- [ X ] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)