### PR TITLE
fix(showcase): gate D4 chat probe completion on domDone to close empty-response render race

### DIFF
--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -7,6 +7,7 @@ import {
   buildEdgeAbRecord,
   CvdiagProbeSession,
   wirePlaywrightPage,
+  FIRST_TOKEN_GRACE_MS,
 } from "./d4-chat-roundtrip.js";
 import { filterEdgeHeaders } from "../../cvdiag/index.js";
 import { computeAbReport } from "../../cvdiag/ab-report.js";
@@ -3181,16 +3182,30 @@ describe("d4 render-race: sseDone-leads / domDone-lags turn completion (Fix B)",
     // (`domDone` only): `complete` stays false until 2500ms (the turn is merely
     // `observed` in-flight via `sseDone`, so the poll WIDENS to the ceiling
     // instead of fast-failing), then the token renders and the poll returns it.
+    // This test only DISCRIMINATES pre-fix vs post-fix while the token lands
+    // AFTER the grace window but BEFORE the attempt-0 ceiling:
+    //   FIRST_TOKEN_GRACE_MS (2000) < firstTokenDelayMs (2500) < ceiling (~4000)
+    // Pin the lower bound against the ACTUAL source constant so that raising
+    // FIRST_TOKEN_GRACE_MS past this fixture's delay fails this test LOUDLY
+    // (the sim would otherwise silently stop discriminating — the token would
+    // land inside the grace window and both formulas would pass).
+    const firstTokenDelayMs = 2500;
+    const pageTimeoutMs = 8000;
+    // Attempt-0 ceiling ≈ pageTimeoutMs / 2. Both bounds must bracket the delay
+    // for the sim to exercise the post-fix widening.
+    const attempt0CeilingMs = pageTimeoutMs / 2;
+    expect(FIRST_TOKEN_GRACE_MS).toBeLessThan(firstTokenDelayMs);
+    expect(firstTokenDelayMs).toBeLessThan(attempt0CeilingMs);
     const { l4State, failureSummary } = await runLateToken(
       makeLateTokenBrowser({
         assistantText: "The weather in San Francisco is sunny, 72 degrees.",
         sseLeadMs: 0,
-        completeAtDelayMs: 2500,
-        firstTokenDelayMs: 2500,
+        completeAtDelayMs: firstTokenDelayMs,
+        firstTokenDelayMs,
       }),
       // Ceiling comfortably past the 2500ms lag so attempt 0 can reach the
       // token (attempt-0 ceiling ≈ pageTimeoutMs/2 ≈ 4000ms > 2500ms).
-      { pageTimeoutMs: 8000 },
+      { pageTimeoutMs },
     );
     expect(l4State).toBe("green");
     expect(failureSummary).toBe("");

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -2421,6 +2421,26 @@ function makeLateTokenBrowser(opts: {
    * staying latched to the stalled first attempt.
    */
   responsesPerSend?: CvdiagResponseEvent[];
+  /**
+   * Model the ROOT render-race Fix B closes: the transport-level RUN_FINISHED
+   * counter (`sseDone`) firing EARLY — at this many ms after the send — while
+   * the DOM run-stop edge (`domDone`, `runningNow: true→false`) AND the
+   * assistant-text commit land LATER, together, at `completeAtDelayMs` /
+   * `firstTokenDelayMs` (which a test sets EQUAL so they coalesce into one
+   * React commit, faithful to the `use-agent.tsx` batchedForceUpdate/
+   * queueMicrotask coalescing proven in `d4-race-cause.md` §2). Set to `0` to
+   * model `sseDone` firing immediately on send.
+   *
+   * DECOUPLES `runsFinished` (sseDone) from `runningNow`/`lastStoppedAtMs`
+   * (domDone): with this set, `runsFinished` bumps past baseline at
+   * `elapsed >= sseLeadMs` INDEPENDENT of the fixture's `complete` gate, which
+   * now drives ONLY the DOM stop-edge. Every OTHER fixture variant flips both
+   * signals together at the same `complete` edge, so none of them exercise the
+   * sseDone-leads / domDone-lags ordering this option models. When UNSET, the
+   * transport finished edge tracks `complete` exactly (existing coupled
+   * behavior — untouched, so all pre-existing tests are unaffected).
+   */
+  sseLeadMs?: number;
 }): CvE2eBrowser {
   const completeAt = opts.completeAtDelayMs ?? 0;
   const prior = opts.priorFinishedRuns ?? 0;
@@ -2567,6 +2587,21 @@ function makeLateTokenBrowser(opts: {
         // finished edge is a genuine THIS-turn transition the driver observes.
         const complete =
           started && (!opts.neverComplete || rescued) && elapsed >= completeAt;
+        // SSE-LEAD race (Fix B surface): the transport RUN_FINISHED counter
+        // (`sseDone`) can fire BEFORE the DOM run-stop edge (`domDone`). When
+        // `sseLeadMs` is set, `runsFinished` bumps past baseline at
+        // `elapsed >= sseLeadMs` independent of `complete` — which continues to
+        // drive ONLY `runningNow`/`lastStoppedAtMs` (the DOM edge). When unset,
+        // the finished edge tracks `complete` exactly (coupled, as before), so
+        // every existing fixture variant is byte-for-byte unchanged.
+        // NOTE: `sseFinished` is deliberately INDEPENDENT of `neverComplete` —
+        // the formula-pin test models a turn whose transport RUN_FINISHED edge
+        // fires while the DOM edge (`complete`) NEVER does, so `runsFinished`
+        // must bump even under `neverComplete`.
+        const sseFinished =
+          opts.sseLeadMs !== undefined
+            ? started && elapsed >= opts.sseLeadMs
+            : complete;
         // SSE-only completion: the transport `runsFinished` counter bumps but the
         // DOM run-lifecycle attribute never registers a fresh `true→false` stop
         // edge for THIS turn, so `runningNow` stays `true` and `lastStoppedAtMs`
@@ -2580,7 +2615,7 @@ function makeLateTokenBrowser(opts: {
             ? false
             : null;
         return {
-          runsFinished: prior + priorSendsDone + (complete ? 1 : 0),
+          runsFinished: prior + priorSendsDone + (sseFinished ? 1 : 0),
           attrPresent: true,
           sawRunningTrue: prior > 0 || started,
           runningNow,
@@ -3119,6 +3154,80 @@ describe("d4 L4 first-token wait hardening (readTurnState-driven)", () => {
     // `level-error` a floored-1ms `press` throw produced pre-fix.
     expect(errorDesc).toBe("send-budget-exhausted");
   }, 10000);
+});
+
+describe("d4 render-race: sseDone-leads / domDone-lags turn completion (Fix B)", () => {
+  // These two tests pin the fix for the rotating-full-column-red flap whose
+  // ROOT is a probe render-race: `readTurnComplete()` used to gate `complete`
+  // on `domDone || sseDone`. `sseDone` (the transport RUN_FINISHED counter) is
+  // a synchronous raw-byte parse OUTSIDE React and can fire AT-OR-BEFORE the
+  // React commit that renders the assistant text; `domDone` is coalesced into
+  // that SAME commit. Gating on `sseDone` let the fast-fail grace window elapse
+  // with the DOM still empty under contention, redding a turn that was about to
+  // render correctly ("empty assistant response"). Fix B gates on `domDone`
+  // ALONE. See SPEC "Fix B" + "Test / regression coverage".
+
+  it("TIMING SIM: sseDone fires EARLY, domDone+text land LATE together → GREEN (RED pre-fix)", async () => {
+    // The exact race Fix B closes, decoupled IN TIME (not just in kind):
+    //   - `sseDone` fires at send (`sseLeadMs: 0`) — the transport finished
+    //     edge leads.
+    //   - `domDone` (runningNow true→false) AND the assistant-text DOM commit
+    //     land TOGETHER at 2500ms (`completeAtDelayMs === firstTokenDelayMs`),
+    //     modelling the proven same-React-commit coalescing.
+    // 2500ms is PAST the ~2000ms `FIRST_TOKEN_GRACE_MS`. PRE-FIX
+    // (`domDone || sseDone`): `sseDone` stamps completion at ~send, the grace
+    // window elapses at ~2000ms with the DOM still empty, and the poll fast-
+    // fails RED before the real 2500ms token — the classic false red. POST-FIX
+    // (`domDone` only): `complete` stays false until 2500ms (the turn is merely
+    // `observed` in-flight via `sseDone`, so the poll WIDENS to the ceiling
+    // instead of fast-failing), then the token renders and the poll returns it.
+    const { l4State, failureSummary } = await runLateToken(
+      makeLateTokenBrowser({
+        assistantText: "The weather in San Francisco is sunny, 72 degrees.",
+        sseLeadMs: 0,
+        completeAtDelayMs: 2500,
+        firstTokenDelayMs: 2500,
+      }),
+      // Ceiling comfortably past the 2500ms lag so attempt 0 can reach the
+      // token (attempt-0 ceiling ≈ pageTimeoutMs/2 ≈ 4000ms > 2500ms).
+      { pageTimeoutMs: 8000 },
+    );
+    expect(l4State).toBe("green");
+    expect(failureSummary).toBe("");
+  }, 20000);
+
+  it("FORMULA PIN: sseDone alone must NOT flip `complete` — a turn that only ever fires sseDone stalls+retries (does NOT fast-fail as completed-empty)", async () => {
+    // Catches a LITERAL revert to `domDone || sseDone` via an observable that
+    // does not depend on wall-clock thresholds: the send count.
+    //   - `sseLeadMs: 0` → `sseDone` fires immediately.
+    //   - `neverComplete` → `domDone` (and the token) NEVER arrive.
+    // POST-FIX (`domDone`): `complete` stays false, so the turn reads as
+    // OBSERVED-but-in-flight (a stall) → the non-completion retry fires → the
+    // page receives a SECOND send (sends === 2), then reds.
+    // PRE-FIX (`domDone || sseDone`): `sseDone` flips `complete` true → the
+    // turn reads as COMPLETED-empty (a real red) → NO retry → sends === 1.
+    // Asserting sends === 2 therefore FAILS on the pre-fix formula and PASSES
+    // only once completion is gated on `domDone` alone.
+    let sends = 0;
+    const { l3State, failureSummary } = await runLateTokenL3(
+      makeLateTokenBrowser({
+        assistantText: "",
+        firstTokenDelayMs: 100,
+        neverComplete: true,
+        sseLeadMs: 0,
+        onSend: (n) => {
+          sends = Math.max(sends, n);
+        },
+      }),
+      { pageTimeoutMs: 4000 },
+    );
+    // Genuinely empty (no token ever) → red either way; the DISCRIMINATOR is
+    // whether the retry fired, i.e. whether `sseDone` alone was (wrongly)
+    // treated as turn-complete.
+    expect(l3State).toBe("red");
+    expect(failureSummary).toContain("empty assistant response");
+    expect(sends).toBe(2);
+  }, 20000);
 });
 
 describe("d4 mid-poll abort/timeout classification (follow-up)", () => {

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -2100,7 +2100,7 @@ async function runLevel(opts: {
           // already in the DOM. Gating on `sseDone` let the fast-fail grace
           // window elapse with the DOM still empty under contention, redding a
           // turn that was about to render correctly ("empty assistant
-          // response"). `observed` still includes `sseDone` (below) so a turn
+          // response"). `observed` still includes `sseDone` (above) so a turn
           // whose attribute never appears still gets the wider polling window.
           complete: domDone,
         };

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -2091,7 +2091,18 @@ async function runLevel(opts: {
         const observed = newRunStarted || sseDone;
         return {
           observed,
-          complete: domDone || sseDone,
+          // Gate completion on `domDone` ALONE, not `domDone || sseDone`.
+          // `sseDone` (the transport-level RUN_FINISHED counter) is a
+          // synchronous raw-byte parse OUTSIDE React and can fire at-or-before
+          // the React commit that renders the assistant text; `domDone` is
+          // coalesced into that SAME commit (use-agent.tsx batchedForceUpdate /
+          // queueMicrotask), so the moment `domDone` is true the text is
+          // already in the DOM. Gating on `sseDone` let the fast-fail grace
+          // window elapse with the DOM still empty under contention, redding a
+          // turn that was about to render correctly ("empty assistant
+          // response"). `observed` still includes `sseDone` (below) so a turn
+          // whose attribute never appears still gets the wider polling window.
+          complete: domDone,
         };
       };
 

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -491,7 +491,7 @@ const WEATHER_VOCAB = [
  * turn still fails once the grace elapses. Bounded and small so a
  * genuinely-empty completed turn fails fast.
  */
-const FIRST_TOKEN_GRACE_MS = 2000;
+export const FIRST_TOKEN_GRACE_MS = 2000;
 
 /**
  * Fast-fail budget for a turn that COMPLETES with empty assistant text. With a

--- a/showcase/harness/src/probes/drivers/d4-probe-domdone-guard.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-probe-domdone-guard.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+// Regression guard for the D4 chat probe's `domDone` turn-completion gate.
+//
+// ROOT the probe depends on: `d4-chat-roundtrip.ts` gates turn completion on
+// `domDone` — derived from the DOM `data-copilot-running` attribute on the
+// `[data-testid="copilot-chat"]` container. That attribute is emitted ONLY by
+// the attribute-bearing render branches of `CopilotChatView`, which fire when
+// `<CopilotChat/>` is used in its SELF-CLOSING form. The OTHER branch —
+// `if (children)` (the render-prop / slot form `<CopilotChat>{...}</CopilotChat>`)
+// — returns a bare `<div style="display:contents">` that emits NEITHER
+// `data-testid="copilot-chat"` NOR `data-copilot-running`. See
+// packages/react-core/src/v2/components/chat/CopilotChatView.tsx (the
+// `if (children)` early-return vs the two self-closing returns).
+//
+// If a PROBED-route page were to switch to the render-prop form (or drop
+// `<CopilotChat/>` entirely for a custom chat UI), `domDone` could never fire
+// for that cell: the probe would silently fall back to the wider ~60s /
+// double-send polling path instead of the fast DOM-coalesced completion. That
+// regression is INVISIBLE to the probe's own unit tests (they inject fakes) and
+// would only surface as a slow, flappy live cell. This test fails at CI time if
+// any probed-route page stops using the attribute-bearing self-closing form.
+//
+// We assert at the SOURCE level (AST) rather than by rendering the pages: the
+// pages are Next.js `"use client"` app-router entrypoints that mount a live
+// `<CopilotKit runtimeUrl=.../>` provider and framework agents, so a faithful
+// full render would need the whole runtime + agent stack stood up — impractical
+// and slow for a structural guard. Parsing the TSX with the TypeScript compiler
+// (not a hand-rolled regex/lexer) distinguishes the self-closing element from
+// the children form robustly, matching the exact `CopilotChatView` branch split.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// drivers → probes → src → harness → showcase → repo root
+const WORKSPACE_ROOT = path.resolve(__dirname, "../../../../..");
+const INTEGRATIONS_DIR = path.resolve(WORKSPACE_ROOT, "showcase/integrations");
+
+// The routes the D4 chat probe navigates to (see `demoPath` in
+// d4-chat-roundtrip.ts): `/demos/agentic-chat` ALWAYS; `/demos/tool-rendering`
+// only where the slug's registry exposes it. We scan the corresponding page
+// entrypoints for every integration that HAS them.
+const PROBED_ROUTES = ["agentic-chat", "tool-rendering"] as const;
+
+const COPILOT_CHAT_TAG = "CopilotChat";
+
+interface ProbedPage {
+  slug: string;
+  route: string;
+  file: string;
+}
+
+function listIntegrationSlugs(): string[] {
+  return readdirSync(INTEGRATIONS_DIR, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && !e.name.startsWith("_"))
+    .map((e) => e.name)
+    .sort();
+}
+
+function collectProbedPages(): ProbedPage[] {
+  const pages: ProbedPage[] = [];
+  for (const slug of listIntegrationSlugs()) {
+    for (const route of PROBED_ROUTES) {
+      const file = path.join(
+        INTEGRATIONS_DIR,
+        slug,
+        "src/app/demos",
+        route,
+        "page.tsx",
+      );
+      // agentic-chat is universal; tool-rendering is present only where the
+      // integration exposes it. Absent pages are simply not probed → skip.
+      if (existsSync(file)) pages.push({ slug, route, file });
+    }
+  }
+  return pages;
+}
+
+/**
+ * Classify every `<CopilotChat …>` JSX usage in a source file via the TS AST.
+ * `selfClosing` counts the attribute-BEARING self-closing form; `withChildren`
+ * counts the attribute-OMITTING render-prop/slot form.
+ */
+function classifyCopilotChatUsage(file: string): {
+  selfClosing: number;
+  withChildren: number;
+} {
+  const src = readFileSync(file, "utf8");
+  const sf = ts.createSourceFile(
+    file,
+    src,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX,
+  );
+
+  let selfClosing = 0;
+  let withChildren = 0;
+
+  const tagText = (name: ts.JsxTagNameExpression): string => name.getText(sf);
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isJsxSelfClosingElement(node) &&
+      tagText(node.tagName) === COPILOT_CHAT_TAG
+    ) {
+      selfClosing += 1;
+    } else if (
+      ts.isJsxElement(node) &&
+      tagText(node.openingElement.tagName) === COPILOT_CHAT_TAG
+    ) {
+      withChildren += 1;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+
+  return { selfClosing, withChildren };
+}
+
+describe("d4 probe domDone gate: probed-route pages emit data-copilot-running", () => {
+  const pages = collectProbedPages();
+
+  it("finds the universal agentic-chat page for every integration", () => {
+    // Sanity: the probe navigates to /demos/agentic-chat for EVERY slug, so
+    // each integration must contribute one. If this drops to zero the scan
+    // is mis-rooted and the whole guard would silently pass on nothing.
+    const agenticPages = pages.filter((p) => p.route === "agentic-chat");
+    expect(agenticPages.length).toBeGreaterThanOrEqual(
+      listIntegrationSlugs().length,
+    );
+  });
+
+  it.each(pages.map((p) => [`${p.slug}/${p.route}`, p] as const))(
+    "%s renders <CopilotChat/> in the attribute-bearing self-closing form (not the children render-prop form)",
+    (_label, page) => {
+      const { selfClosing, withChildren } = classifyCopilotChatUsage(page.file);
+      // Must render CopilotChat in the self-closing (attribute-bearing) form:
+      // this is the branch of CopilotChatView that emits
+      // data-testid="copilot-chat" + data-copilot-running, which the D4 probe's
+      // domDone gate reads. Zero → the page dropped <CopilotChat/> for a custom
+      // chat UI that won't emit the attribute.
+      expect(selfClosing).toBeGreaterThanOrEqual(1);
+      // Must NOT use the render-prop/slot children form on a probed route: that
+      // branch (`if (children)` in CopilotChatView) returns a display:contents
+      // wrapper with NO data-copilot-running, silently regressing the cell to
+      // the ~60s / double-send fallback path.
+      expect(withChildren).toBe(0);
+    },
+  );
+});


### PR DESCRIPTION
## Incident

At ~21:19Z on 2026-07-20 the prod showcase Feature Matrix showed the `claude-sdk-python` column whole-column-red (✓0/✗37). It self-recovered by ~21:30Z. Not infra, not staleness: `/api/health` was 200 throughout, `commErrorKinds` was empty, and the image was current.

## Root cause

The shared D4 chat probe (`d4-chat-roundtrip.ts`) emitted ONE transient red — `failureSummary: "empty assistant response"`, no `errorClass`/`errorDesc`. Because the dashboard's `resolveD4` is **slug-keyed**, that single `chat:<slug>` row gated all 37 feature cells for the slug → the whole column went red off one flap.

The producer-side origin is a **render race**. `readTurnComplete()` gated turn completion on `domDone || sseDone`. `sseDone` is the transport-level `RUN_FINISHED` counter — a synchronous raw-byte SSE parse that runs *outside* React and can fire at-or-before the React commit that actually renders the assistant text. `domDone` (the `data-copilot-running` true→false DOM edge) is coalesced into that *same* React commit (`use-agent.tsx` `batchedForceUpdate`/`queueMicrotask`). Under contention, gating on `sseDone` let the fast-fail grace window elapse while the DOM was still empty, redding a turn that was about to render correctly.

## The change

`complete: domDone || sseDone` → `complete: domDone`. The moment `domDone` is true, the assistant text is already in the DOM (same commit). `observed` still includes `sseDone`, so a turn whose attribute never appears still gets the wider polling window rather than fast-failing. `FIRST_TOKEN_GRACE_MS` and `NON_COMPLETION_RETRY_LIMIT` are untouched. `domDone` is not a new signal — the probe already observes that edge via `readTurnState`; this only changes which existing signal `complete` trusts.

**Throughput-neutral:** `runAttempt` returns on a non-empty `readAssistantText` *before* `readTurnComplete` is consulted, so the happy path is unchanged. Only a completed-but-empty turn's classification changes. A genuinely-empty completed turn still reds (correct) — only the race false-positive is removed.

## Red → green proof (deterministic, on the real code path)

A new deterministic timing-sim regression (`sseLeadMs` fixture) decouples `sseDone` from `domDone` *in time* and drives the real `readTurnComplete`/`runAttempt`. Two cases: a TIMING SIM (sseDone at send, text at 2500ms past the ~2000ms grace window) and a FORMULA PIN (sseDone-only, token never arrives → asserts `sends === 2`, catching a literal revert to `domDone || sseDone` via the retry-fired discriminator, not a wall-clock threshold).

**RED — test hunks applied on top of UNFIXED probe code:**

```
 FAIL  src/probes/drivers/d4-chat-roundtrip.test.ts > d4 render-race: sseDone-leads / domDone-lags turn completion (Fix B) > TIMING SIM: sseDone fires EARLY, domDone+text land LATE together → GREEN (RED pre-fix)
AssertionError: expected 'red' to be 'green' // Object.is equality
Expected: "green"
Received: "red"
 ❯ src/probes/drivers/d4-chat-roundtrip.test.ts:3195:21

 FAIL  src/probes/drivers/d4-chat-roundtrip.test.ts > d4 render-race: sseDone-leads / domDone-lags turn completion (Fix B) > FORMULA PIN: sseDone alone must NOT flip `complete` — a turn that only ever fires sseDone stalls+retries (does NOT fast-fail as completed-empty)
AssertionError: expected 1 to be 2 // Object.is equality
- Expected  2
+ Received  1
 ❯ src/probes/drivers/d4-chat-roundtrip.test.ts:3229:19

 Test Files  1 failed (1)
      Tests  2 failed | 82 skipped (84)
```

**GREEN — probe fix hunk then applied, same tests re-run:**

```
 ✓ src/probes/drivers/d4-chat-roundtrip.test.ts (84 tests | 82 skipped) 9026ms
   ✓ d4 render-race: sseDone-leads / domDone-lags turn completion (Fix B) > TIMING SIM: sseDone fires EARLY, domDone+text land LATE together → GREEN (RED pre-fix)  5017ms
   ✓ d4 render-race: sseDone-leads / domDone-lags turn completion (Fix B) > FORMULA PIN: sseDone alone must NOT flip `complete` — a turn that only ever fires sseDone stalls+retries (does NOT fast-fail as completed-empty)  4007ms

 Test Files  1 passed (1)
      Tests  2 passed | 82 skipped (84)
```

Full `d4-chat-roundtrip.test.ts` suite after the fix: **84 passed (84)** — no regression.

## Real-probe forcing (Part B) — honest disclosure

The live race is low-rate and non-deterministic. The `--direct` (direct-LLM) live-probe forcing path could **not** be stood up within reasonable effort in this environment: Docker is running, but `--direct` requires a real Anthropic API key that is not present here, and forcing a probabilistic React-commit-timing race across ~300 reps on a freshly-built `claude-sdk-python` integration stack is beyond a reasonable bound for the bonus real-surface proof. It was **not** faked. The deterministic timing-sim regression above exercises the real `readTurnComplete`/`runAttempt` code path and is the gating proof. **Recommendation:** a multi-tick staging dashboard watch post-merge to confirm the flap does not recur.

## Scope note

This PR fixes the **producer-side** root cause. The **render-layer de-amplifier** (a single transient D4 flap should degrade a slug's cells to *amber*, not whole-column-red via slug-keyed `resolveD4` fan-out) is owned separately by the dashboard-ladder redesign.


## CR follow-ups (post-review hardening)

Three small follow-ups from the 7-agent CR + adversarial verify (which found zero live bugs in the Fix B core). The `complete: domDone` core is untouched.

- **Regression-guard test (hardening).** New `d4-probe-domdone-guard.test.ts` (source-level, TS AST). It asserts every D4-probed demo page — `/demos/agentic-chat` for every integration, `/demos/tool-rendering` where present — renders `<CopilotChat/>` in the attribute-bearing **self-closing** form, not the children render-prop / slot form. Only the self-closing form hits the `CopilotChatView` branch that emits `data-testid="copilot-chat"` + `data-copilot-running`, which the probe's `domDone` gate reads; the `if (children)` branch returns a `display:contents` wrapper with neither, which would silently regress the cell to the ~60s / double-send fallback. That regression is invisible to the probe's own fake-injected unit tests, so it is guarded structurally at CI time. Chose the source/AST approach over full page render because the pages are Next.js `"use client"` app-router entrypoints mounting a live `<CopilotKit runtimeUrl=.../>` provider + framework agents (impractical to render faithfully in a harness unit test).

  **Red-green proof.** Temporarily mutated `langgraph-python/agentic-chat/page.tsx` to the children render-prop form → guard **RED** (`langgraph-python/agentic-chat … expected 0 to be greater than or equal to 1`, 1 failed | 40 passed). Reverted the mutation → **GREEN** (41 passed). Mutation fully reverted; net change is the test only.

- **Comment factual fix.** In `d4-chat-roundtrip.ts` near the `complete: domDone` gate: the comment said `observed` still includes `sseDone` "(below)", but `observed` is defined *above*. Corrected "(below)" → "(above)".

- **Timing-sim robustness pin.** The `TIMING SIM` test's discriminating power depended on `FIRST_TOKEN_GRACE_MS (2000) < firstTokenDelayMs (2500) < ceiling (~4000)`, encoded only in prose. Now imports the actual `FIRST_TOKEN_GRACE_MS` source constant (newly exported) and asserts that ordering, so raising the grace constant later fails the test loudly instead of silently ceasing to discriminate. No existing assertion weakened.

Quality: harness `d4-chat-roundtrip.test.ts` + new guard test green (125 tests); `tsc --noEmit` clean; `tsc -p tsconfig.build.json` clean; `oxfmt --check` clean; `oxlint` warnings-only (no errors).
