### PR TITLE
showcase: consolidate deploy onto CI-explicit path (guard fix, autoUpdates SSOT, drift gate, reconcile)

### DIFF
--- a/.github/workflows/showcase_autoupdate_drift.yml
+++ b/.github/workflows/showcase_autoupdate_drift.yml
@@ -1,0 +1,64 @@
+name: "Showcase: autoUpdates Drift Gate"
+
+# Fails when any showcase service's LIVE Railway `source.autoUpdates` diverges
+# from the SSOT expectation (every service must be "disabled"). Railway's own
+# auto-update feature, if left enabled, silently re-pulls upstream image
+# changes out-of-band — the same class of unmanaged mutation that produced the
+# April→June image drift. The sibling `verify-image-refs` gate catches the
+# drifted *ref*; this gate catches the *cause* (auto-updates enabled).
+#
+# Reads the live value from the `Environment.config` JSON scalar (autoUpdates
+# is not on the typed ServiceSource output) — see
+# showcase/scripts/verify-autoupdates.ts. Uses the same RAILWAY_TOKEN secret
+# and tsx invocation as the verify-image-refs job in showcase_build.yml.
+#
+# Triggers: PRs that touch the Railway SSOT/tooling (catch drift at review
+# time), a daily schedule (catch out-of-band mutations regardless of PR
+# activity), and manual dispatch.
+
+on:
+  pull_request:
+    paths:
+      - "showcase/scripts/railway-envs.ts"
+      - "showcase/scripts/railway-envs.generated.json"
+      - "showcase/scripts/verify-autoupdates.ts"
+      - "showcase/scripts/verify-autoupdates.test.ts"
+      - ".github/workflows/showcase_autoupdate_drift.yml"
+  schedule:
+    # Daily at 08:23 UTC (offset from other showcase crons to avoid pile-up).
+    - cron: "23 8 * * *"
+  workflow_dispatch:
+
+jobs:
+  verify-autoupdates:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.x
+      # Fork PRs do not receive repository secrets, so RAILWAY_TOKEN is absent
+      # and the live gate cannot run. Detect that and skip cleanly (neutral,
+      # with a clear message) rather than fail an external contributor's PR with
+      # an unfixable red check. Same-repo PRs, the daily schedule, and manual
+      # dispatch all have the secret and run the gate normally.
+      - name: Check for Railway token (fork PRs lack it)
+        id: guard
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "RAILWAY_TOKEN not available (likely a fork PR) — skipping the live autoUpdates drift gate."
+            echo "It runs on same-repo PRs, the daily schedule, and manual dispatch."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Verify Railway autoUpdates disabled
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: npx tsx showcase/scripts/verify-autoupdates.ts

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -780,22 +780,31 @@ jobs:
   redeploy-staging:
     name: Trigger Railway staging redeploy
     needs: [detect-changes, build, aggregate-build-results]
-    # Run if at least one service was in the matrix AND the build job
-    # was not outright cancelled or skipped AND at least one slot
-    # succeeded (per aggregate-build-results.outputs.any_success). The
-    # any_success guard is the explicit "do not redeploy when nothing
-    # was pushed" check — without it, an all-failed build run would
-    # still kick a redeploy that just re-pulls the stale :latest and
-    # silently looks healthy. The skipped/cancelled checks on the build
-    # job still cover the "verify-image-refs gate blocked the build job
-    # entirely" path. Partial build failures (fail-fast: false) still
-    # surface as needs.build.result == 'failure' with any_success ==
-    # 'true', so redeploying what did get pushed is preserved.
+    # Run if the WORKFLOW RUN was not cancelled, at least one service was
+    # scheduled, AND at least one slot actually built
+    # (aggregate-build-results.outputs.any_success). any_success is the
+    # single source of truth for "should we redeploy?": it is derived from
+    # the real per-slot build-result artifacts (see aggregate-build-results),
+    # so it is 'true' on a PARTIAL build (fail-fast: false) and 'false' on a
+    # genuinely dead / entirely-skipped build — subsuming the old
+    # needs.build.result != 'skipped' check. It is the explicit "do not
+    # redeploy when nothing was pushed" guard: without it an all-failed run
+    # would still kick a redeploy that re-pulls the stale :latest and
+    # silently looks healthy.
+    #
+    # We deliberately do NOT gate on needs.build.result (the matrix rollup).
+    # GitHub Actions rolls a matrix job up to 'cancelled' when ANY single leg
+    # is cancelled (e.g. the LFS shell build under runner contention), so
+    # `needs.build.result != 'cancelled'` skipped the redeploy for the WHOLE
+    # fleet even when 27/28 legs succeeded. Mirror the sibling
+    # aggregate-build-results job instead: gate on !cancelled() + has_changes
+    # and let the artifact-derived any_success decide. !cancelled() (a status
+    # function) still overrides GH's default "skip when a needed job did not
+    # succeed", so this job runs even when the build rollup is cancelled/
+    # failure — as long as the RUN itself was not cancelled.
     if: >-
       ${{ !cancelled()
           && needs.detect-changes.outputs.has_changes == 'true'
-          && needs.build.result != 'skipped'
-          && needs.build.result != 'cancelled'
           && needs.aggregate-build-results.outputs.any_success == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -934,31 +943,35 @@ jobs:
     # gap by redeploying — in STAGING only — exactly the starters that built
     # successfully.
     #
-    # Gate mirrors redeploy-staging's skipped/cancelled handling:
-    #   - !cancelled()                               → don't fire on a cancel.
+    # Gate mirrors redeploy-staging:
+    #   - !cancelled()                               → don't fire when the
+    #                                                   whole RUN was cancelled.
     #   - detect-starter-changes.has_changes=='true' → at least one starter in
     #                                                   the build matrix.
-    #   - build-starters.result != 'skipped'         → the starter build job
-    #     && build-starters.result != 'cancelled'       actually ran (a skipped
-    #                                                   build means no starter
-    #                                                   image was pushed —
-    #                                                   nothing to redeploy).
     #
-    # build-starters.result == 'failure' STILL enters this job (fail-fast is
-    # false, so some slots may have succeeded while others failed). The
-    # "deploy on build failure" footgun is closed NOT by the job `if:` but by
-    # the per-slot success intersection in the compute step below: only
-    # starters whose OWN build slot reported status:success are redeployed,
-    # and an all-failed run yields an EMPTY CSV → the redeploy step is
-    # skipped. So a wholesale starter build failure never redeploys anything
-    # — the same net guarantee redeploy-staging gets from its
-    # aggregate-build-results.any_success guard, computed inline here to avoid
-    # standing up a second aggregator job for the starter lane.
+    # We deliberately do NOT gate on needs.build-starters.result (the matrix
+    # rollup). GitHub Actions rolls a matrix job up to 'cancelled' when ANY
+    # single leg is cancelled (e.g. under runner contention), so the old
+    # `build-starters.result != 'cancelled'` clause skipped the redeploy for
+    # the WHOLE starter fleet even when every other starter built fine — the
+    # same P0 defect that hit redeploy-staging.
+    #
+    # This is safe WITHOUT an any_success job guard: the "deploy on a dead
+    # build" footgun is closed NOT by the job `if:` but by the per-slot
+    # success intersection in the compute step below (only starters whose OWN
+    # build slot reported status:success are redeployed) plus the
+    # `if: steps.changed.outputs.services != ''` guard on the redeploy step.
+    # A partial success (fail-fast:false) redeploys exactly what built; a
+    # zero-success run (all failed / all cancelled / build hard-crashed before
+    # writing any result artifact) yields an EMPTY CSV → the redeploy step is
+    # skipped → nothing is deployed. The compute step's fail-loud checks only
+    # fire when build-starters.result == 'success', so a cancelled/failure
+    # rollup does not misfire them. This is the same net guarantee
+    # redeploy-staging gets from aggregate-build-results.any_success, enforced
+    # one level down to avoid standing up a second aggregator job.
     if: >-
       ${{ !cancelled()
-          && needs.detect-starter-changes.outputs.has_changes == 'true'
-          && needs.build-starters.result != 'skipped'
-          && needs.build-starters.result != 'cancelled' }}
+          && needs.detect-starter-changes.outputs.has_changes == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/showcase_reconcile_staging.yml
+++ b/.github/workflows/showcase_reconcile_staging.yml
@@ -1,0 +1,76 @@
+name: "Showcase: Reconcile staging (scheduled self-heal)"
+
+# CI-owned scheduled self-heal for the showcase STAGING fleet. Replaces
+# Railway's registry auto-watch (which we are disabling) with a deterministic,
+# CI-controlled reconcile: every 15 minutes it compares each staging service's
+# ACTUALLY-DEPLOYED image digest (Railway's latest SUCCESS deployment
+# `meta.imageDigest`) against the GHCR `:latest` digest, and re-runs the
+# existing staging redeploy (`redeploy-env.ts`) scoped to any lagging service,
+# posting a Slack alert naming them. Alert-AND-remediate, not alert-only.
+#
+# This is distinct from `showcase_reconcile.yml`, which is the MANUAL,
+# read-only PROD-vs-STAGING drift check (no schedule, no remediation). This
+# workflow reconciles STAGING against GHCR `:latest` and DOES remediate.
+#
+# See showcase/scripts/reconcile-staging.ts for the decision rule + threshold.
+
+on:
+  schedule:
+    # Every 15 minutes — one reconcile cycle. A service mid-redeploy simply
+    # matches on the next cycle (see the threshold note in reconcile-staging.ts).
+    - cron: "*/15 * * * *"
+  workflow_dispatch: {}
+
+concurrency:
+  # Serialize reconcile runs so two overlapping cycles never double-trigger a
+  # redeploy for the same lagging service.
+  group: showcase-reconcile-staging
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  # GHCR :latest manifest reads. reconcile-staging.ts resolves the digest via
+  # resolveGhcrDigest → ghcrPat() = GHCR_TOKEN || GITHUB_TOKEN. When GHCR_TOKEN
+  # is not set, the automatic GITHUB_TOKEN is used and needs packages:read to
+  # read the private showcase-* image manifests (otherwise the /token exchange
+  # 401s and every service reads as an unresolvable :latest — a false alert).
+  packages: read
+
+jobs:
+  reconcile:
+    name: Reconcile staging vs GHCR :latest
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # `railway` scopes the Railway/GHCR/Slack secrets to this job. It carries NO
+    # protection rules (no required reviewers, no wait timer, no branch policy),
+    # so it does NOT gate or stall the */15 cron self-heal — it is purely secret
+    # scoping. If protection rules are ever added to this environment, move the
+    # secrets to a plain job-level source instead, or the self-heal will stall
+    # awaiting approval every cycle.
+    environment: railway
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.x
+
+      - name: Install scripts deps
+        working-directory: showcase/scripts
+        run: npm ci
+
+      - name: Reconcile staging (compare + self-heal + alert)
+        working-directory: showcase/scripts
+        env:
+          # Railway reads (deployments query) + the staging redeploy mutation.
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          # GHCR manifest reads for the `:latest` digest. GITHUB_TOKEN
+          # (packages:read) is the CI default; GHCR_TOKEN overrides locally.
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Incoming webhook for the reconcile alert — the SAME secret
+          # showcase_build.yml posts its #oss-alerts failure alerts through.
+          SLACK_WEBHOOK_OSS_ALERTS: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+        run: npx tsx reconcile-staging.ts

--- a/showcase/scripts/emit-railway-envs-json.ts
+++ b/showcase/scripts/emit-railway-envs-json.ts
@@ -49,7 +49,11 @@ import {
   STAGING_ENV_ID,
   computePromoteClosure,
 } from "./railway-envs";
-import type { ClosurePlan, WorkerProvisioning } from "./railway-envs";
+import type {
+  AutoUpdatesPolicy,
+  ClosurePlan,
+  WorkerProvisioning,
+} from "./railway-envs";
 
 const DEFAULT_OUTPUT_PATH = resolve(
   new URL(".", import.meta.url).pathname,
@@ -113,6 +117,10 @@ interface Emitted {
       prod: WorkerProvisioning;
       staging: WorkerProvisioning;
     };
+    // Railway auto-updates policy (ADDITIVE, env-independent). ALWAYS emitted
+    // ("disabled" fleet-wide) so a sibling drift gate can positively assert the
+    // CI-explicit-only deploy path against live Railway config in both envs.
+    autoUpdates: AutoUpdatesPolicy;
   }>;
   // --- Top-level promote-closure plan (ADDITIVE, U2). The tier-ordered
   // closure for the FULL fleet (`all`), computed via `computePromoteClosure`.
@@ -252,6 +260,10 @@ function projectServiceToLegacyJson(
     ...(entry.workerProvisioning !== undefined
       ? { workerProvisioning: entry.workerProvisioning }
       : {}),
+    // Railway auto-updates policy, appended LAST (additive). ALWAYS present
+    // ("disabled" fleet-wide) — the golden test projects only LEGACY_KEYS, so
+    // this stays byte-safe there, and the drift gate reads it positively.
+    autoUpdates: entry.autoUpdates,
   };
 }
 

--- a/showcase/scripts/emit-railway-envs-json.ts
+++ b/showcase/scripts/emit-railway-envs-json.ts
@@ -117,10 +117,11 @@ interface Emitted {
       prod: WorkerProvisioning;
       staging: WorkerProvisioning;
     };
-    // Railway auto-updates policy (ADDITIVE, env-independent). ALWAYS emitted
-    // ("disabled" fleet-wide) so a sibling drift gate can positively assert the
-    // CI-explicit-only deploy path against live Railway config in both envs.
-    autoUpdates: AutoUpdatesPolicy;
+    // Railway auto-updates policy (ADDITIVE, PER-ENV). ALWAYS emitted with both
+    // env keys so the sibling drift gate can enforce the managed (concrete-
+    // "disabled") envs and skip the "unmanaged" ones. Today: staging "disabled"
+    // (enforced), prod "unmanaged" (skipped) for the staging-first rollout.
+    autoUpdates: { staging: AutoUpdatesPolicy; prod: AutoUpdatesPolicy };
   }>;
   // --- Top-level promote-closure plan (ADDITIVE, U2). The tier-ordered
   // closure for the FULL fleet (`all`), computed via `computePromoteClosure`.
@@ -260,10 +261,14 @@ function projectServiceToLegacyJson(
     ...(entry.workerProvisioning !== undefined
       ? { workerProvisioning: entry.workerProvisioning }
       : {}),
-    // Railway auto-updates policy, appended LAST (additive). ALWAYS present
-    // ("disabled" fleet-wide) — the golden test projects only LEGACY_KEYS, so
-    // this stays byte-safe there, and the drift gate reads it positively.
-    autoUpdates: entry.autoUpdates,
+    // Railway auto-updates policy, appended LAST (additive) — PER-ENV. ALWAYS
+    // present with both env keys — the golden test projects only LEGACY_KEYS,
+    // so this stays byte-safe there, and the drift gate reads the per-env
+    // policy (enforces "disabled" envs, skips "unmanaged" ones).
+    autoUpdates: {
+      staging: entry.autoUpdates.staging,
+      prod: entry.autoUpdates.prod,
+    },
   };
 }
 

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -35,7 +35,10 @@
         "prod": "/health",
         "staging": "/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "dashboard",
@@ -60,7 +63,10 @@
       },
       "promoteTier": 1,
       "runtimeDeps": ["pocketbase", "harness"],
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "docs",
@@ -85,7 +91,10 @@
       },
       "promoteTier": 2,
       "standalone": true,
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "dojo",
@@ -109,7 +118,10 @@
         "driver": "dojo"
       },
       "promoteTier": 2,
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "harness",
@@ -137,7 +149,10 @@
         "prod": "/health",
         "staging": "/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "harness-workers",
@@ -182,7 +197,10 @@
           "drainingSeconds": 180
         }
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "pocketbase",
@@ -206,7 +224,10 @@
         "driver": "pocketbase"
       },
       "promoteTier": 0,
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "shell",
@@ -234,7 +255,10 @@
         "prod": "/",
         "staging": "/"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-ag2",
@@ -265,7 +289,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-agno",
@@ -296,7 +323,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-built-in-agent",
@@ -327,7 +357,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-claude-sdk-python",
@@ -362,7 +395,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-claude-sdk-typescript",
@@ -393,7 +429,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-crewai-crews",
@@ -424,7 +463,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-google-adk",
@@ -455,7 +497,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-langgraph-fastapi",
@@ -486,7 +531,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-langgraph-python",
@@ -517,7 +565,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-langgraph-typescript",
@@ -548,7 +599,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-langroid",
@@ -579,7 +633,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-llamaindex",
@@ -610,7 +667,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-mastra",
@@ -641,7 +701,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-ms-agent-dotnet",
@@ -672,7 +735,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-ms-agent-harness-dotnet",
@@ -703,7 +769,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-ms-agent-python",
@@ -734,7 +803,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-pydantic-ai",
@@ -765,7 +837,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-spring-ai",
@@ -796,7 +871,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-strands",
@@ -827,7 +905,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "showcase-strands-typescript",
@@ -858,7 +939,10 @@
         "prod": "/api/health",
         "staging": "/api/health"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "starter-adk",
@@ -889,7 +973,10 @@
         "prod": "/",
         "staging": "/"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "starter-agno",
@@ -920,7 +1007,10 @@
         "prod": "/",
         "staging": "/"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "starter-crewai-crews",
@@ -951,7 +1041,10 @@
         "prod": "/",
         "staging": "/"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "starter-langgraph-fastapi",
@@ -982,7 +1075,10 @@
         "prod": "/",
         "staging": "/"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "starter-langgraph-js",
@@ -1013,7 +1109,10 @@
         "prod": "/",
         "staging": "/"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "starter-langgraph-python",
@@ -1044,7 +1143,10 @@
         "prod": "/",
         "staging": "/"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "starter-llamaindex",
@@ -1075,7 +1177,10 @@
         "prod": "/",
         "staging": "/"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "starter-mastra",
@@ -1106,7 +1211,10 @@
         "prod": "/",
         "staging": "/"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "starter-ms-agent-framework-dotnet",
@@ -1137,7 +1245,10 @@
         "prod": "/",
         "staging": "/"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "starter-ms-agent-framework-python",
@@ -1168,7 +1279,10 @@
         "prod": "/",
         "staging": "/"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "starter-pydantic-ai",
@@ -1199,7 +1313,10 @@
         "prod": "/",
         "staging": "/"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "starter-strands-python",
@@ -1230,7 +1347,10 @@
         "prod": "/",
         "staging": "/"
       },
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     },
     {
       "name": "webhooks",
@@ -1254,7 +1374,10 @@
         "driver": "webhooks"
       },
       "promoteTier": 0,
-      "autoUpdates": "disabled"
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "unmanaged"
+      }
     }
   ],
   "closure": {

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -34,7 +34,8 @@
       "healthcheckPath": {
         "prod": "/health",
         "staging": "/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "dashboard",
@@ -58,7 +59,8 @@
         "driver": "dashboard"
       },
       "promoteTier": 1,
-      "runtimeDeps": ["pocketbase", "harness"]
+      "runtimeDeps": ["pocketbase", "harness"],
+      "autoUpdates": "disabled"
     },
     {
       "name": "docs",
@@ -82,7 +84,8 @@
         "driver": "docs"
       },
       "promoteTier": 2,
-      "standalone": true
+      "standalone": true,
+      "autoUpdates": "disabled"
     },
     {
       "name": "dojo",
@@ -105,7 +108,8 @@
         "prod": true,
         "driver": "dojo"
       },
-      "promoteTier": 2
+      "promoteTier": 2,
+      "autoUpdates": "disabled"
     },
     {
       "name": "harness",
@@ -132,7 +136,8 @@
       "healthcheckPath": {
         "prod": "/health",
         "staging": "/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "harness-workers",
@@ -176,7 +181,8 @@
           "overlapSeconds": 45,
           "drainingSeconds": 180
         }
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "pocketbase",
@@ -199,7 +205,8 @@
         "prod": true,
         "driver": "pocketbase"
       },
-      "promoteTier": 0
+      "promoteTier": 0,
+      "autoUpdates": "disabled"
     },
     {
       "name": "shell",
@@ -226,7 +233,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-ag2",
@@ -256,7 +264,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-agno",
@@ -286,7 +295,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-built-in-agent",
@@ -316,7 +326,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-claude-sdk-python",
@@ -350,7 +361,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-claude-sdk-typescript",
@@ -380,7 +392,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-crewai-crews",
@@ -410,7 +423,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-google-adk",
@@ -440,7 +454,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-langgraph-fastapi",
@@ -470,7 +485,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-langgraph-python",
@@ -500,7 +516,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-langgraph-typescript",
@@ -530,7 +547,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-langroid",
@@ -560,7 +578,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-llamaindex",
@@ -590,7 +609,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-mastra",
@@ -620,7 +640,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-ms-agent-dotnet",
@@ -650,7 +671,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-ms-agent-harness-dotnet",
@@ -680,7 +702,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-ms-agent-python",
@@ -710,7 +733,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-pydantic-ai",
@@ -740,7 +764,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-spring-ai",
@@ -770,7 +795,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-strands",
@@ -800,7 +826,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "showcase-strands-typescript",
@@ -830,7 +857,8 @@
       "healthcheckPath": {
         "prod": "/api/health",
         "staging": "/api/health"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "starter-adk",
@@ -860,7 +888,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "starter-agno",
@@ -890,7 +919,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "starter-crewai-crews",
@@ -920,7 +950,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "starter-langgraph-fastapi",
@@ -950,7 +981,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "starter-langgraph-js",
@@ -980,7 +1012,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "starter-langgraph-python",
@@ -1010,7 +1043,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "starter-llamaindex",
@@ -1040,7 +1074,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "starter-mastra",
@@ -1070,7 +1105,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "starter-ms-agent-framework-dotnet",
@@ -1100,7 +1136,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "starter-ms-agent-framework-python",
@@ -1130,7 +1167,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "starter-pydantic-ai",
@@ -1160,7 +1198,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "starter-strands-python",
@@ -1190,7 +1229,8 @@
       "healthcheckPath": {
         "prod": "/",
         "staging": "/"
-      }
+      },
+      "autoUpdates": "disabled"
     },
     {
       "name": "webhooks",
@@ -1213,7 +1253,8 @@
         "prod": true,
         "driver": "webhooks"
       },
-      "promoteTier": 0
+      "promoteTier": 0,
+      "autoUpdates": "disabled"
     }
   ],
   "closure": {

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -1367,3 +1367,35 @@ describe("assertClosureValid", () => {
     );
   });
 });
+
+describe("autoUpdates deploy-consolidation policy (fleet-wide disabled)", () => {
+  // Railway `source.autoUpdates.type = "minor"` is the ENABLED form (Railway
+  // watches the GHCR registry and auto-redeploys on a new push); the SSOT
+  // target is "disabled" so the ONLY deploy path is the CI-explicit redeploy.
+  // autoUpdates was previously tracked NOWHERE, which is how the live fleet
+  // drifted (24 services "minor" / 17 none, incoherently). Tracking it as a
+  // required SSOT field + this positive assertion make the fleet-wide policy
+  // explicit; a sibling drift gate enforces the SAME value against live
+  // Railway config in both envs.
+  it("every service in the SSOT declares autoUpdates 'disabled'", () => {
+    for (const [name, entry] of Object.entries(SERVICES)) {
+      expect(
+        (entry as { autoUpdates?: string }).autoUpdates,
+        `${name}.autoUpdates must be "disabled" (no Railway registry auto-watch; CI-explicit redeploy only)`,
+      ).toBe("disabled");
+    }
+  });
+
+  it("every service in the generated JSON carries autoUpdates 'disabled'", () => {
+    const generated = JSON.parse(
+      readFileSync(resolve(__dirname, "./railway-envs.generated.json"), "utf8"),
+    ) as { services: Array<{ name: string; autoUpdates?: string }> };
+    expect(generated.services.length).toBeGreaterThan(0);
+    for (const svc of generated.services) {
+      expect(
+        svc.autoUpdates,
+        `generated ${svc.name}.autoUpdates must be "disabled"`,
+      ).toBe("disabled");
+    }
+  });
+});

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -1368,34 +1368,50 @@ describe("assertClosureValid", () => {
   });
 });
 
-describe("autoUpdates deploy-consolidation policy (fleet-wide disabled)", () => {
+describe("autoUpdates deploy-consolidation policy (per-env, staging-first)", () => {
   // Railway `source.autoUpdates.type = "minor"` is the ENABLED form (Railway
   // watches the GHCR registry and auto-redeploys on a new push); the SSOT
   // target is "disabled" so the ONLY deploy path is the CI-explicit redeploy.
-  // autoUpdates was previously tracked NOWHERE, which is how the live fleet
-  // drifted (24 services "minor" / 17 none, incoherently). Tracking it as a
-  // required SSOT field + this positive assertion make the fleet-wide policy
-  // explicit; a sibling drift gate enforces the SAME value against live
-  // Railway config in both envs.
-  it("every service in the SSOT declares autoUpdates 'disabled'", () => {
+  // autoUpdates is now PER-ENV to support a staging-first rollout: STAGING is
+  // enforced "disabled" (its live config is being flipped to disabled), while
+  // PROD is "unmanaged" — NOT yet under drift-gate management (its live
+  // autoUpdates are heterogeneous and must be left untouched until a later
+  // migration). The sibling drift gate ENFORCES the concrete-"disabled" envs
+  // and SKIPS the "unmanaged" ones.
+  it("every service declares staging 'disabled' and prod 'unmanaged'", () => {
     for (const [name, entry] of Object.entries(SERVICES)) {
+      const au = (entry as { autoUpdates?: Record<string, string> })
+        .autoUpdates;
       expect(
-        (entry as { autoUpdates?: string }).autoUpdates,
-        `${name}.autoUpdates must be "disabled" (no Railway registry auto-watch; CI-explicit redeploy only)`,
+        au?.staging,
+        `${name}.autoUpdates.staging must be "disabled" (staging is under drift-gate management; CI-explicit redeploy only)`,
       ).toBe("disabled");
+      expect(
+        au?.prod,
+        `${name}.autoUpdates.prod must be "unmanaged" (prod not yet migrated; drift gate skips it)`,
+      ).toBe("unmanaged");
     }
   });
 
-  it("every service in the generated JSON carries autoUpdates 'disabled'", () => {
+  it("the generated JSON carries per-env autoUpdates (staging disabled, prod unmanaged)", () => {
     const generated = JSON.parse(
       readFileSync(resolve(__dirname, "./railway-envs.generated.json"), "utf8"),
-    ) as { services: Array<{ name: string; autoUpdates?: string }> };
+    ) as {
+      services: Array<{
+        name: string;
+        autoUpdates?: { staging?: string; prod?: string };
+      }>;
+    };
     expect(generated.services.length).toBeGreaterThan(0);
     for (const svc of generated.services) {
       expect(
-        svc.autoUpdates,
-        `generated ${svc.name}.autoUpdates must be "disabled"`,
+        svc.autoUpdates?.staging,
+        `generated ${svc.name}.autoUpdates.staging must be "disabled"`,
       ).toBe("disabled");
+      expect(
+        svc.autoUpdates?.prod,
+        `generated ${svc.name}.autoUpdates.prod must be "unmanaged"`,
+      ).toBe("unmanaged");
     }
   });
 });

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -300,36 +300,55 @@ export interface EnvironmentConfig {
 }
 
 /**
- * Railway auto-updates policy for a service — the tracked SSOT form of the
- * Railway `source.autoUpdates` setting. Env-independent in our model (the
- * fleet-wide policy is uniform across prod + staging, exactly like
- * `probeDriver`), so it is hoisted to the `ServiceEntry`.
+ * Railway auto-updates policy for a service in ONE env — the tracked SSOT form
+ * of the Railway `source.autoUpdates` setting. This is PER-ENV (see
+ * {@link AutoUpdatesByEnv}) to support a staging-first rollout: staging can be
+ * managed-"disabled" while prod stays "unmanaged" until a later migration.
  *
- * - "minor"    — Railway's ENABLED form (`source.autoUpdates.type = "minor"`):
- *                Railway watches the GHCR registry and AUTO-redeploys the
- *                service whenever a new image is pushed. This is a SECOND,
- *                implicit deploy path competing with the CI-explicit redeploy.
- * - "disabled" — no registry auto-watch. The CI-explicit redeploy
- *                (`redeploy-env.ts` / the promote path) is the SINGLE deploy
- *                path. This is the target for EVERY showcase service.
+ * - "minor"     — Railway's ENABLED form (`source.autoUpdates.type = "minor"`):
+ *                 Railway watches the GHCR registry and AUTO-redeploys the
+ *                 service whenever a new image is pushed. This is a SECOND,
+ *                 implicit deploy path competing with the CI-explicit redeploy.
+ * - "disabled"  — no registry auto-watch. The CI-explicit redeploy
+ *                 (`redeploy-env.ts` / the promote path) is the SINGLE deploy
+ *                 path. This is a MANAGED policy: the sibling drift gate
+ *                 (`verify-autoupdates.ts`) ENFORCES it against live Railway
+ *                 config (a live-enabled service in a "disabled" env fails).
+ * - "unmanaged" — NOT yet under drift-gate management. The gate SKIPS an
+ *                 "unmanaged" env entirely: it does not read, compare, or flag
+ *                 the live value, and the env is not counted toward the gate's
+ *                 zero-checked floor. Use this for an env whose live
+ *                 autoUpdates are heterogeneous and must be left completely
+ *                 alone until a deliberate migration flips it to "disabled".
  *
  * autoUpdates was previously tracked NOWHERE in the SSOT, which is how the
- * live fleet drifted incoherently (24 services "minor" / 17 none). Making it
- * a REQUIRED, explicitly-"disabled" field per service turns the fleet-wide
- * policy into a positive, drift-checkable invariant: a sibling drift gate
- * asserts this same value against live Railway config in BOTH envs.
+ * live fleet drifted incoherently (24 services "minor" / 17 none). Tracking it
+ * per-env turns the policy into a positive, drift-checkable invariant for the
+ * MANAGED (concrete-"disabled") envs while explicitly marking the not-yet-
+ * migrated envs "unmanaged" so the gate leaves them untouched.
  */
-export type AutoUpdatesPolicy = "disabled" | "minor";
+export type AutoUpdatesPolicy = "disabled" | "minor" | "unmanaged";
+
+/**
+ * Per-env auto-updates policy, keyed by the SAME env names as
+ * `ServiceEntry.environments` ("prod" / "staging" / …). Every env a service
+ * declares carries its own {@link AutoUpdatesPolicy}. Today staging is
+ * managed-"disabled" (drift-gate enforced) and prod is "unmanaged" (skipped)
+ * for the staging-first rollout.
+ */
+export type AutoUpdatesByEnv = Record<EnvName, AutoUpdatesPolicy>;
 
 export interface ServiceEntry {
   /** Railway service ID (env-independent). */
   serviceId: string;
   /**
-   * Railway auto-updates policy (env-independent). REQUIRED and "disabled"
-   * for every showcase service so the CI-explicit redeploy is the single
-   * deploy path (no Railway registry auto-watch). See {@link AutoUpdatesPolicy}.
+   * Railway auto-updates policy, PER-ENV. REQUIRED. Today every showcase
+   * service is `{ staging: "disabled", prod: "unmanaged" }` for the
+   * staging-first rollout: staging is drift-gate-enforced to "disabled" (the
+   * CI-explicit redeploy is the single deploy path), while prod is "unmanaged"
+   * (the gate skips it) until a later migration. See {@link AutoUpdatesByEnv}.
    */
-  autoUpdates: AutoUpdatesPolicy;
+  autoUpdates: AutoUpdatesByEnv;
   /**
    * Per-env configuration, keyed by env name ("prod" / "staging" / …).
    * A service present in only one env carries only that key.
@@ -542,7 +561,7 @@ export const SERVICES: Record<
 > = {
   aimock: {
     serviceId: "0fa0435d-8a66-46f0-84fd-e4250b580013",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "showcase-aimock",
@@ -585,7 +604,7 @@ export const SERVICES: Record<
   },
   dashboard: {
     serviceId: "4d5dfd74-be61-40b2-8564-b53b7dd4c15b",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "shell-dashboard",
@@ -615,7 +634,7 @@ export const SERVICES: Record<
   },
   docs: {
     serviceId: "7badfb8d-4228-414c-9145-b4026803714f",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "shell-docs",
@@ -644,7 +663,7 @@ export const SERVICES: Record<
   },
   dojo: {
     serviceId: "7ad1ece7-2228-49cd-8a78-bddf30322907",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "shell-dojo",
@@ -667,7 +686,7 @@ export const SERVICES: Record<
   },
   harness: {
     serviceId: "3a14bfed-0537-4d71-897b-7c593dca161d",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "showcase-harness",
@@ -701,7 +720,7 @@ export const SERVICES: Record<
   // not `showcase-harness-worker`.
   "harness-workers": {
     serviceId: "c2aa8a0b-350e-4b76-8541-3012dfac41d0",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     // Pool-fleet worker. Workers run in BOTH staging and prod: the prod worker
     // is live on Railway (deployed 2026-06-19, HARNESS_ROLE=worker, pool
     // count 2) and is now BACKFILLED as a `prod` env entry below (real
@@ -823,7 +842,7 @@ export const SERVICES: Record<
   },
   pocketbase: {
     serviceId: "ba11e854-d695-4738-9a45-2b0776788824",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     // pocketbase is a first-party ghcr.io/copilotkit/ image whose GHCR
     // repo name is `showcase-pocketbase` (NOT `pocketbase`). It is now
     // built+pushed by showcase_build.yml (the `pocketbase` matrix slot,
@@ -856,7 +875,7 @@ export const SERVICES: Record<
   },
   shell: {
     serviceId: "40eea0da-6071-4ea8-bdb9-39afb19225ec",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "shell",
@@ -881,7 +900,7 @@ export const SERVICES: Record<
   },
   "showcase-ag2": {
     serviceId: "4a37481b-f264-4eb7-a9cd-0a9ebb9ac05c",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "ag2",
@@ -909,7 +928,7 @@ export const SERVICES: Record<
   },
   "showcase-agno": {
     serviceId: "32cab80b-e329-45bd-9c73-c4e1ddc94305",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "agno",
@@ -937,7 +956,7 @@ export const SERVICES: Record<
   },
   "showcase-built-in-agent": {
     serviceId: "f4f8371a-bc46-45b2-b6d4-9c9af608bdbf",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "built-in-agent",
@@ -965,7 +984,7 @@ export const SERVICES: Record<
   },
   "showcase-claude-sdk-python": {
     serviceId: "b122ab65-9854-4cb2-a68e-b50ff13f7481",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "claude-sdk-python",
@@ -1003,7 +1022,7 @@ export const SERVICES: Record<
   },
   "showcase-claude-sdk-typescript": {
     serviceId: "18a98727-5700-44aa-b497-b60795dbbd6a",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "claude-sdk-typescript",
@@ -1031,7 +1050,7 @@ export const SERVICES: Record<
   },
   "showcase-crewai-crews": {
     serviceId: "0e9c284d-8d87-4fcf-9f82-6b704d7e4bd4",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "crewai-crews",
@@ -1059,7 +1078,7 @@ export const SERVICES: Record<
   },
   "showcase-google-adk": {
     serviceId: "87f60507-5a3d-4b8a-9e23-2b1de85d939c",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "google-adk",
@@ -1087,7 +1106,7 @@ export const SERVICES: Record<
   },
   "showcase-langgraph-fastapi": {
     serviceId: "06cccb5c-59f4-46b5-8adc-7113e77011a4",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "langgraph-fastapi",
@@ -1115,7 +1134,7 @@ export const SERVICES: Record<
   },
   "showcase-langgraph-python": {
     serviceId: "90d03214-4569-41b0-b4c1-6438a8a7b203",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "langgraph-python",
@@ -1143,7 +1162,7 @@ export const SERVICES: Record<
   },
   "showcase-langgraph-typescript": {
     serviceId: "66246d3b-a18e-46f0-be51-5f3ff7a36e5a",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "langgraph-typescript",
@@ -1171,7 +1190,7 @@ export const SERVICES: Record<
   },
   "showcase-langroid": {
     serviceId: "6dd9cb0a-66cc-46f1-972e-7cd74756157d",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "langroid",
@@ -1199,7 +1218,7 @@ export const SERVICES: Record<
   },
   "showcase-llamaindex": {
     serviceId: "285386e8-492d-4cb8-b632-0a7d4607378f",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "llamaindex",
@@ -1227,7 +1246,7 @@ export const SERVICES: Record<
   },
   "showcase-mastra": {
     serviceId: "d7979eb7-2405-4aab-ad21-438f4a1b08af",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "mastra",
@@ -1255,7 +1274,7 @@ export const SERVICES: Record<
   },
   "showcase-ms-agent-dotnet": {
     serviceId: "beeb2dd6-87a4-4599-aa07-0578f7bd6519",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "ms-agent-dotnet",
@@ -1283,7 +1302,7 @@ export const SERVICES: Record<
   },
   "showcase-ms-agent-harness-dotnet": {
     serviceId: "6343d7f9-6c3f-4c8d-9a6e-79f03d2f1e37",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "ms-agent-harness-dotnet",
@@ -1311,7 +1330,7 @@ export const SERVICES: Record<
   },
   "showcase-ms-agent-python": {
     serviceId: "655db75a-af8d-427d-a4f9-441570ae5003",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "ms-agent-python",
@@ -1339,7 +1358,7 @@ export const SERVICES: Record<
   },
   "showcase-pydantic-ai": {
     serviceId: "0a106173-2282-4887-a994-0ca276a99d69",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "pydantic-ai",
@@ -1367,7 +1386,7 @@ export const SERVICES: Record<
   },
   "showcase-spring-ai": {
     serviceId: "eed5d041-91be-4282-b414-beea00843401",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "spring-ai",
@@ -1395,7 +1414,7 @@ export const SERVICES: Record<
   },
   "showcase-strands": {
     serviceId: "92e1cfad-ad53-403f-ab2b-5ab380832232",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "strands",
@@ -1429,7 +1448,7 @@ export const SERVICES: Record<
   // legacyJsonCompat prod-domain placeholder removed.
   "showcase-strands-typescript": {
     serviceId: "d6f47c8c-a0a1-4dbe-991c-50f8463fd68d",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "strands-typescript",
@@ -1504,7 +1523,7 @@ export const SERVICES: Record<
   // prod→prod by the Stage-2 Ruby preflight (never copied).
   "starter-adk": {
     serviceId: "37691009-c0b2-4af7-8960-9f0b3f0a6be3",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-adk",
@@ -1529,7 +1548,7 @@ export const SERVICES: Record<
   },
   "starter-agno": {
     serviceId: "5ab3c37e-18a5-44e5-8329-26243dd98da8",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-agno",
@@ -1554,7 +1573,7 @@ export const SERVICES: Record<
   },
   "starter-crewai-crews": {
     serviceId: "2a9a4230-e6cd-4c1d-92a5-36e5c624371a",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-crewai-crews",
@@ -1579,7 +1598,7 @@ export const SERVICES: Record<
   },
   "starter-langgraph-fastapi": {
     serviceId: "6ae57213-52ea-4fea-b4a0-7bc304cbc80e",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-langgraph-fastapi",
@@ -1604,7 +1623,7 @@ export const SERVICES: Record<
   },
   "starter-langgraph-js": {
     serviceId: "d044c3e5-bb27-4d5e-a2bf-e3b382981372",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-langgraph-js",
@@ -1629,7 +1648,7 @@ export const SERVICES: Record<
   },
   "starter-langgraph-python": {
     serviceId: "10dca514-7c8f-4a32-9708-9f29a944da36",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-langgraph-python",
@@ -1654,7 +1673,7 @@ export const SERVICES: Record<
   },
   "starter-llamaindex": {
     serviceId: "3255b27f-ea84-44b7-b587-b1687b409363",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-llamaindex",
@@ -1679,7 +1698,7 @@ export const SERVICES: Record<
   },
   "starter-mastra": {
     serviceId: "6548403e-3fee-4443-9d59-d8b041a3d43a",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-mastra",
@@ -1704,7 +1723,7 @@ export const SERVICES: Record<
   },
   "starter-ms-agent-framework-dotnet": {
     serviceId: "1b4c5296-97f6-463d-90af-6e04d7919957",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-ms-agent-framework-dotnet",
@@ -1729,7 +1748,7 @@ export const SERVICES: Record<
   },
   "starter-ms-agent-framework-python": {
     serviceId: "225d0a06-d1cd-4b82-ae9c-2d1e8ecbaf86",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-ms-agent-framework-python",
@@ -1754,7 +1773,7 @@ export const SERVICES: Record<
   },
   "starter-pydantic-ai": {
     serviceId: "c01d0d24-af88-4631-8a9a-23cffef2b36a",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-pydantic-ai",
@@ -1779,7 +1798,7 @@ export const SERVICES: Record<
   },
   "starter-strands-python": {
     serviceId: "321735ab-c14d-4e45-a1c2-e47f2b29d774",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-strands-python",
@@ -1804,7 +1823,7 @@ export const SERVICES: Record<
   },
   webhooks: {
     serviceId: "ba6acc13-7585-41fe-a5ee-585b34a58fcd",
-    autoUpdates: "disabled",
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
     ciBuilt: false,
     gateValidated: true,
     dispatchName: "webhooks",

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -299,9 +299,37 @@ export interface EnvironmentConfig {
   healthcheckPath?: string;
 }
 
+/**
+ * Railway auto-updates policy for a service — the tracked SSOT form of the
+ * Railway `source.autoUpdates` setting. Env-independent in our model (the
+ * fleet-wide policy is uniform across prod + staging, exactly like
+ * `probeDriver`), so it is hoisted to the `ServiceEntry`.
+ *
+ * - "minor"    — Railway's ENABLED form (`source.autoUpdates.type = "minor"`):
+ *                Railway watches the GHCR registry and AUTO-redeploys the
+ *                service whenever a new image is pushed. This is a SECOND,
+ *                implicit deploy path competing with the CI-explicit redeploy.
+ * - "disabled" — no registry auto-watch. The CI-explicit redeploy
+ *                (`redeploy-env.ts` / the promote path) is the SINGLE deploy
+ *                path. This is the target for EVERY showcase service.
+ *
+ * autoUpdates was previously tracked NOWHERE in the SSOT, which is how the
+ * live fleet drifted incoherently (24 services "minor" / 17 none). Making it
+ * a REQUIRED, explicitly-"disabled" field per service turns the fleet-wide
+ * policy into a positive, drift-checkable invariant: a sibling drift gate
+ * asserts this same value against live Railway config in BOTH envs.
+ */
+export type AutoUpdatesPolicy = "disabled" | "minor";
+
 export interface ServiceEntry {
   /** Railway service ID (env-independent). */
   serviceId: string;
+  /**
+   * Railway auto-updates policy (env-independent). REQUIRED and "disabled"
+   * for every showcase service so the CI-explicit redeploy is the single
+   * deploy path (no Railway registry auto-watch). See {@link AutoUpdatesPolicy}.
+   */
+  autoUpdates: AutoUpdatesPolicy;
   /**
    * Per-env configuration, keyed by env name ("prod" / "staging" / …).
    * A service present in only one env carries only that key.
@@ -514,6 +542,7 @@ export const SERVICES: Record<
 > = {
   aimock: {
     serviceId: "0fa0435d-8a66-46f0-84fd-e4250b580013",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "showcase-aimock",
@@ -556,6 +585,7 @@ export const SERVICES: Record<
   },
   dashboard: {
     serviceId: "4d5dfd74-be61-40b2-8564-b53b7dd4c15b",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "shell-dashboard",
@@ -585,6 +615,7 @@ export const SERVICES: Record<
   },
   docs: {
     serviceId: "7badfb8d-4228-414c-9145-b4026803714f",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "shell-docs",
@@ -613,6 +644,7 @@ export const SERVICES: Record<
   },
   dojo: {
     serviceId: "7ad1ece7-2228-49cd-8a78-bddf30322907",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "shell-dojo",
@@ -635,6 +667,7 @@ export const SERVICES: Record<
   },
   harness: {
     serviceId: "3a14bfed-0537-4d71-897b-7c593dca161d",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "showcase-harness",
@@ -668,6 +701,7 @@ export const SERVICES: Record<
   // not `showcase-harness-worker`.
   "harness-workers": {
     serviceId: "c2aa8a0b-350e-4b76-8541-3012dfac41d0",
+    autoUpdates: "disabled",
     // Pool-fleet worker. Workers run in BOTH staging and prod: the prod worker
     // is live on Railway (deployed 2026-06-19, HARNESS_ROLE=worker, pool
     // count 2) and is now BACKFILLED as a `prod` env entry below (real
@@ -789,6 +823,7 @@ export const SERVICES: Record<
   },
   pocketbase: {
     serviceId: "ba11e854-d695-4738-9a45-2b0776788824",
+    autoUpdates: "disabled",
     // pocketbase is a first-party ghcr.io/copilotkit/ image whose GHCR
     // repo name is `showcase-pocketbase` (NOT `pocketbase`). It is now
     // built+pushed by showcase_build.yml (the `pocketbase` matrix slot,
@@ -821,6 +856,7 @@ export const SERVICES: Record<
   },
   shell: {
     serviceId: "40eea0da-6071-4ea8-bdb9-39afb19225ec",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "shell",
@@ -845,6 +881,7 @@ export const SERVICES: Record<
   },
   "showcase-ag2": {
     serviceId: "4a37481b-f264-4eb7-a9cd-0a9ebb9ac05c",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "ag2",
@@ -872,6 +909,7 @@ export const SERVICES: Record<
   },
   "showcase-agno": {
     serviceId: "32cab80b-e329-45bd-9c73-c4e1ddc94305",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "agno",
@@ -899,6 +937,7 @@ export const SERVICES: Record<
   },
   "showcase-built-in-agent": {
     serviceId: "f4f8371a-bc46-45b2-b6d4-9c9af608bdbf",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "built-in-agent",
@@ -926,6 +965,7 @@ export const SERVICES: Record<
   },
   "showcase-claude-sdk-python": {
     serviceId: "b122ab65-9854-4cb2-a68e-b50ff13f7481",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "claude-sdk-python",
@@ -963,6 +1003,7 @@ export const SERVICES: Record<
   },
   "showcase-claude-sdk-typescript": {
     serviceId: "18a98727-5700-44aa-b497-b60795dbbd6a",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "claude-sdk-typescript",
@@ -990,6 +1031,7 @@ export const SERVICES: Record<
   },
   "showcase-crewai-crews": {
     serviceId: "0e9c284d-8d87-4fcf-9f82-6b704d7e4bd4",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "crewai-crews",
@@ -1017,6 +1059,7 @@ export const SERVICES: Record<
   },
   "showcase-google-adk": {
     serviceId: "87f60507-5a3d-4b8a-9e23-2b1de85d939c",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "google-adk",
@@ -1044,6 +1087,7 @@ export const SERVICES: Record<
   },
   "showcase-langgraph-fastapi": {
     serviceId: "06cccb5c-59f4-46b5-8adc-7113e77011a4",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "langgraph-fastapi",
@@ -1071,6 +1115,7 @@ export const SERVICES: Record<
   },
   "showcase-langgraph-python": {
     serviceId: "90d03214-4569-41b0-b4c1-6438a8a7b203",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "langgraph-python",
@@ -1098,6 +1143,7 @@ export const SERVICES: Record<
   },
   "showcase-langgraph-typescript": {
     serviceId: "66246d3b-a18e-46f0-be51-5f3ff7a36e5a",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "langgraph-typescript",
@@ -1125,6 +1171,7 @@ export const SERVICES: Record<
   },
   "showcase-langroid": {
     serviceId: "6dd9cb0a-66cc-46f1-972e-7cd74756157d",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "langroid",
@@ -1152,6 +1199,7 @@ export const SERVICES: Record<
   },
   "showcase-llamaindex": {
     serviceId: "285386e8-492d-4cb8-b632-0a7d4607378f",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "llamaindex",
@@ -1179,6 +1227,7 @@ export const SERVICES: Record<
   },
   "showcase-mastra": {
     serviceId: "d7979eb7-2405-4aab-ad21-438f4a1b08af",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "mastra",
@@ -1206,6 +1255,7 @@ export const SERVICES: Record<
   },
   "showcase-ms-agent-dotnet": {
     serviceId: "beeb2dd6-87a4-4599-aa07-0578f7bd6519",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "ms-agent-dotnet",
@@ -1233,6 +1283,7 @@ export const SERVICES: Record<
   },
   "showcase-ms-agent-harness-dotnet": {
     serviceId: "6343d7f9-6c3f-4c8d-9a6e-79f03d2f1e37",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "ms-agent-harness-dotnet",
@@ -1260,6 +1311,7 @@ export const SERVICES: Record<
   },
   "showcase-ms-agent-python": {
     serviceId: "655db75a-af8d-427d-a4f9-441570ae5003",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "ms-agent-python",
@@ -1287,6 +1339,7 @@ export const SERVICES: Record<
   },
   "showcase-pydantic-ai": {
     serviceId: "0a106173-2282-4887-a994-0ca276a99d69",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "pydantic-ai",
@@ -1314,6 +1367,7 @@ export const SERVICES: Record<
   },
   "showcase-spring-ai": {
     serviceId: "eed5d041-91be-4282-b414-beea00843401",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "spring-ai",
@@ -1341,6 +1395,7 @@ export const SERVICES: Record<
   },
   "showcase-strands": {
     serviceId: "92e1cfad-ad53-403f-ab2b-5ab380832232",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "strands",
@@ -1374,6 +1429,7 @@ export const SERVICES: Record<
   // legacyJsonCompat prod-domain placeholder removed.
   "showcase-strands-typescript": {
     serviceId: "d6f47c8c-a0a1-4dbe-991c-50f8463fd68d",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "strands-typescript",
@@ -1448,6 +1504,7 @@ export const SERVICES: Record<
   // prod→prod by the Stage-2 Ruby preflight (never copied).
   "starter-adk": {
     serviceId: "37691009-c0b2-4af7-8960-9f0b3f0a6be3",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-adk",
@@ -1472,6 +1529,7 @@ export const SERVICES: Record<
   },
   "starter-agno": {
     serviceId: "5ab3c37e-18a5-44e5-8329-26243dd98da8",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-agno",
@@ -1496,6 +1554,7 @@ export const SERVICES: Record<
   },
   "starter-crewai-crews": {
     serviceId: "2a9a4230-e6cd-4c1d-92a5-36e5c624371a",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-crewai-crews",
@@ -1520,6 +1579,7 @@ export const SERVICES: Record<
   },
   "starter-langgraph-fastapi": {
     serviceId: "6ae57213-52ea-4fea-b4a0-7bc304cbc80e",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-langgraph-fastapi",
@@ -1544,6 +1604,7 @@ export const SERVICES: Record<
   },
   "starter-langgraph-js": {
     serviceId: "d044c3e5-bb27-4d5e-a2bf-e3b382981372",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-langgraph-js",
@@ -1568,6 +1629,7 @@ export const SERVICES: Record<
   },
   "starter-langgraph-python": {
     serviceId: "10dca514-7c8f-4a32-9708-9f29a944da36",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-langgraph-python",
@@ -1592,6 +1654,7 @@ export const SERVICES: Record<
   },
   "starter-llamaindex": {
     serviceId: "3255b27f-ea84-44b7-b587-b1687b409363",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-llamaindex",
@@ -1616,6 +1679,7 @@ export const SERVICES: Record<
   },
   "starter-mastra": {
     serviceId: "6548403e-3fee-4443-9d59-d8b041a3d43a",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-mastra",
@@ -1640,6 +1704,7 @@ export const SERVICES: Record<
   },
   "starter-ms-agent-framework-dotnet": {
     serviceId: "1b4c5296-97f6-463d-90af-6e04d7919957",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-ms-agent-framework-dotnet",
@@ -1664,6 +1729,7 @@ export const SERVICES: Record<
   },
   "starter-ms-agent-framework-python": {
     serviceId: "225d0a06-d1cd-4b82-ae9c-2d1e8ecbaf86",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-ms-agent-framework-python",
@@ -1688,6 +1754,7 @@ export const SERVICES: Record<
   },
   "starter-pydantic-ai": {
     serviceId: "c01d0d24-af88-4631-8a9a-23cffef2b36a",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-pydantic-ai",
@@ -1712,6 +1779,7 @@ export const SERVICES: Record<
   },
   "starter-strands-python": {
     serviceId: "321735ab-c14d-4e45-a1c2-e47f2b29d774",
+    autoUpdates: "disabled",
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-strands-python",
@@ -1736,6 +1804,7 @@ export const SERVICES: Record<
   },
   webhooks: {
     serviceId: "ba6acc13-7585-41fe-a5ee-585b34a58fcd",
+    autoUpdates: "disabled",
     ciBuilt: false,
     gateValidated: true,
     dispatchName: "webhooks",

--- a/showcase/scripts/reconcile-staging.test.ts
+++ b/showcase/scripts/reconcile-staging.test.ts
@@ -1,0 +1,745 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  pickNewestSuccessDigest,
+  reconcileExitCode,
+  reconcileStaging,
+  selectLaggingServices,
+  stagingReconcileServices,
+} from "./reconcile-staging";
+import type {
+  RedeployReport,
+  ReconcileDeps,
+  ServiceDigestPair,
+} from "./reconcile-staging";
+import { CI_BUILT_SERVICES, SERVICES } from "./railway-envs";
+import { runRedeploy } from "./redeploy-env";
+
+const DIGEST_A =
+  "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const DIGEST_B =
+  "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+describe("selectLaggingServices (pure decision logic)", () => {
+  it("returns [] when every service's deployed digest matches :latest", () => {
+    const pairs: ServiceDigestPair[] = [
+      {
+        service: "showcase-ag2",
+        repoName: "showcase-ag2",
+        deployedDigest: DIGEST_A,
+        latestDigest: DIGEST_A,
+      },
+      {
+        service: "showcase-agno",
+        repoName: "showcase-agno",
+        deployedDigest: DIGEST_B,
+        latestDigest: DIGEST_B,
+      },
+    ];
+    expect(selectLaggingServices(pairs)).toEqual([]);
+  });
+
+  it("flags a service whose deployed digest lags :latest", () => {
+    const pairs: ServiceDigestPair[] = [
+      {
+        service: "showcase-ag2",
+        repoName: "showcase-ag2",
+        deployedDigest: DIGEST_A,
+        latestDigest: DIGEST_B,
+      },
+    ];
+    expect(selectLaggingServices(pairs)).toEqual(["showcase-ag2"]);
+  });
+
+  it("does NOT flag a service whose deployed digest could not be resolved (null)", () => {
+    // A null deployed digest means we could not read a SUCCESS deployment for
+    // the service. Re-deploying on that ambiguous signal risks churn, so v1
+    // treats an unresolved deployed digest as NOT lagging (skip, record).
+    const pairs: ServiceDigestPair[] = [
+      {
+        service: "showcase-ag2",
+        repoName: "showcase-ag2",
+        deployedDigest: null,
+        latestDigest: DIGEST_B,
+      },
+    ];
+    expect(selectLaggingServices(pairs)).toEqual([]);
+  });
+
+  it("returns only the lagging subset, sorted", () => {
+    const pairs: ServiceDigestPair[] = [
+      {
+        service: "showcase-mastra",
+        repoName: "showcase-mastra",
+        deployedDigest: DIGEST_A,
+        latestDigest: DIGEST_B, // lags
+      },
+      {
+        service: "showcase-agno",
+        repoName: "showcase-agno",
+        deployedDigest: DIGEST_A,
+        latestDigest: DIGEST_A, // current
+      },
+      {
+        service: "showcase-ag2",
+        repoName: "showcase-ag2",
+        deployedDigest: DIGEST_B,
+        latestDigest: DIGEST_A, // lags
+      },
+    ];
+    expect(selectLaggingServices(pairs)).toEqual([
+      "showcase-ag2",
+      "showcase-mastra",
+    ]);
+  });
+});
+
+describe("stagingReconcileServices", () => {
+  it("returns staging services that float :latest (CI-built OR imageOf consumers), all real SSOT keys", () => {
+    const list = stagingReconcileServices();
+    expect(list.length).toBeGreaterThan(0);
+    for (const name of list) {
+      expect(Object.hasOwn(SERVICES, name)).toBe(true);
+      expect(Object.hasOwn(SERVICES[name].environments, "staging")).toBe(true);
+      // Every entry is EITHER a CI-built service OR an imageOf consumer — the
+      // two sources that float staging :latest.
+      const entry = SERVICES[name];
+      expect(CI_BUILT_SERVICES.has(name) || entry.imageOf !== undefined).toBe(
+        true,
+      );
+    }
+  });
+
+  it("INCLUDES imageOf consumers that declare staging (e.g. harness-workers) so their independent drift is detected", () => {
+    // harness-workers runs the showcase-harness image on its own
+    // serviceInstance (ciBuilt:false, imageOf:"harness") and floats staging
+    // :latest — it can drift from harness (PR #5352 regression). It MUST be in
+    // scope even though it is not CI-built.
+    const list = stagingReconcileServices();
+    expect(SERVICES["harness-workers"].imageOf).toBe("harness");
+    expect(CI_BUILT_SERVICES.has("harness-workers")).toBe(false);
+    expect(list).toContain("harness-workers");
+  });
+});
+
+/**
+ * Build a mocked ReconcileDeps over a fixed scope of services with a
+ * per-service map of { deployed, latest } digests. redeploy + Slack are
+ * vi.fn() spies so the test asserts the decision → action wiring without
+ * any live network.
+ */
+function makeDeps(
+  digests: Record<
+    string,
+    { deployed: string | null; latest: string } | { error: string }
+  >,
+  opts: { slackDelivers?: boolean; redeployReport?: RedeployReport } = {},
+): {
+  deps: ReconcileDeps;
+  redeploySpy: ReturnType<typeof vi.fn>;
+  slackSpy: ReturnType<typeof vi.fn>;
+} {
+  const services = Object.keys(digests);
+  const slackDelivers = opts.slackDelivers ?? true;
+  const redeploySpy = vi.fn(
+    async (svcs: string[]) =>
+      opts.redeployReport ?? {
+        attempted: svcs.length,
+        succeeded: svcs.length,
+        failed: 0,
+        // Default healthy path: every requested lagging service redeploys ok,
+        // so each is positively confirmed remediated (per-service, not count).
+        records: svcs.map((s) => ({ service: s, status: "ok" as const })),
+      },
+  );
+  const slackSpy = vi.fn(async (_text: string) => slackDelivers);
+  const deps: ReconcileDeps = {
+    services,
+    fetchDeployedDigest: async (serviceId: string) => {
+      const name = Object.entries(SERVICES).find(
+        ([, e]) => e.serviceId === serviceId,
+      )?.[0];
+      const d = name ? digests[name] : undefined;
+      if (!d) throw new Error(`no fixture for serviceId ${serviceId}`);
+      if ("error" in d) throw new Error(d.error);
+      return d.deployed;
+    },
+    fetchLatestDigest: async (repoName: string) => {
+      // The scope here uses agent services whose repoName === service name.
+      const d = digests[repoName];
+      if (!d) throw new Error(`no fixture for repo ${repoName}`);
+      if ("error" in d) throw new Error(d.error);
+      return d.latest;
+    },
+    redeployStaging: redeploySpy,
+    postSlackAlert: slackSpy,
+    log: () => {},
+  };
+  return { deps, redeploySpy, slackSpy };
+}
+
+describe("reconcileStaging (orchestration)", () => {
+  it("LAGGING fixture → redeploys exactly the lagging service AND posts a Slack alert naming it", async () => {
+    // showcase-ag2's deployed digest lags :latest; showcase-agno is current.
+    const { deps, redeploySpy, slackSpy } = makeDeps({
+      "showcase-ag2": { deployed: DIGEST_A, latest: DIGEST_B },
+      "showcase-agno": { deployed: DIGEST_B, latest: DIGEST_B },
+    });
+
+    const summary = await reconcileStaging(deps);
+
+    expect(summary.lagging).toEqual(["showcase-ag2"]);
+    // (a) redeploy called once, scoped to EXACTLY the lagging service.
+    expect(redeploySpy).toHaveBeenCalledTimes(1);
+    expect(redeploySpy).toHaveBeenCalledWith(["showcase-ag2"]);
+    // (b) Slack alert posted once, naming the lagging service.
+    expect(slackSpy).toHaveBeenCalledTimes(1);
+    expect(slackSpy.mock.calls[0][0]).toContain("showcase-ag2");
+    expect(summary.redeployed).toBe(true);
+    expect(summary.alerted).toBe(true);
+  });
+
+  it("MATCHED fixture → no redeploy and no Slack alert (no-op)", async () => {
+    const { deps, redeploySpy, slackSpy } = makeDeps({
+      "showcase-ag2": { deployed: DIGEST_A, latest: DIGEST_A },
+      "showcase-agno": { deployed: DIGEST_B, latest: DIGEST_B },
+    });
+
+    const summary = await reconcileStaging(deps);
+
+    expect(summary.lagging).toEqual([]);
+    expect(redeploySpy).not.toHaveBeenCalled();
+    expect(slackSpy).not.toHaveBeenCalled();
+    expect(summary.redeployed).toBe(false);
+    expect(summary.alerted).toBe(false);
+  });
+
+  it("a per-service digest-fetch error does not mask another service's real lag", async () => {
+    const { deps, redeploySpy, slackSpy } = makeDeps({
+      "showcase-ag2": { error: "GHCR 500" },
+      "showcase-agno": { deployed: DIGEST_A, latest: DIGEST_B }, // lags
+    });
+
+    const summary = await reconcileStaging(deps);
+
+    expect(summary.errors.map((e) => e.service)).toContain("showcase-ag2");
+    expect(summary.lagging).toEqual(["showcase-agno"]);
+    expect(redeploySpy).toHaveBeenCalledWith(["showcase-agno"]);
+    expect(slackSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Finding 1: an unresolvable deployed digest is an ERROR, not "current" ──
+  it("null deployed digest → recorded as an ERROR and NOT silently counted as up-to-date", async () => {
+    const { deps, redeploySpy, slackSpy } = makeDeps({
+      "showcase-ag2": { deployed: null, latest: DIGEST_B },
+    });
+
+    const summary = await reconcileStaging(deps);
+
+    // Surfaced as an error (the header contract), not hidden.
+    expect(summary.errors.map((e) => e.service)).toContain("showcase-ag2");
+    // Not counted as a checked/current service and not redeployed.
+    expect(summary.checked).toBe(0);
+    expect(summary.lagging).toEqual([]);
+    expect(redeploySpy).not.toHaveBeenCalled();
+    // The single service could not be confirmed current ⇒ unconfirmed.
+    expect(summary.unconfirmed.map((u) => u.service)).toContain("showcase-ag2");
+    expect(slackSpy).toHaveBeenCalledTimes(1);
+    expect(reconcileExitCode(summary)).not.toBe(0);
+  });
+
+  // ── Finding 2: nothing confirmed (all errored / checked===0) fails loud ────
+  it("all-services-errored (checked===0) → Slack alert fired AND non-zero exit", async () => {
+    const { deps, redeploySpy, slackSpy } = makeDeps({
+      "showcase-ag2": { error: "Railway unreachable" },
+      "showcase-agno": { error: "Railway unreachable" },
+    });
+
+    const summary = await reconcileStaging(deps);
+
+    expect(summary.checked).toBe(0);
+    // Both services are unconfirmed (neither could be checked).
+    expect(summary.unconfirmed.map((u) => u.service).sort()).toEqual([
+      "showcase-ag2",
+      "showcase-agno",
+    ]);
+    // Fail loud: alert fired even though nothing was "lagging".
+    expect(slackSpy).toHaveBeenCalledTimes(1);
+    expect(redeploySpy).not.toHaveBeenCalled();
+    // Scheduled run must go RED.
+    expect(reconcileExitCode(summary)).not.toBe(0);
+  });
+
+  it("healthy no-op (nothing lagging, everything confirmed) → exit 0, no alert", async () => {
+    const { deps, slackSpy } = makeDeps({
+      "showcase-ag2": { deployed: DIGEST_A, latest: DIGEST_A },
+      "showcase-agno": { deployed: DIGEST_B, latest: DIGEST_B },
+    });
+
+    const summary = await reconcileStaging(deps);
+
+    expect(summary.unconfirmed).toEqual([]);
+    expect(summary.emptyScope).toBe(false);
+    expect(slackSpy).not.toHaveBeenCalled();
+    expect(reconcileExitCode(summary)).toBe(0);
+  });
+
+  // ── Finding 4: alerted reflects ACTUAL delivery, not "we tried" ────────────
+  it("Slack POST fails to deliver → summary.alerted === false", async () => {
+    const { deps } = makeDeps(
+      {
+        "showcase-ag2": { deployed: DIGEST_A, latest: DIGEST_B }, // lags
+        "showcase-agno": { deployed: DIGEST_B, latest: DIGEST_B },
+      },
+      { slackDelivers: false },
+    );
+
+    const summary = await reconcileStaging(deps);
+
+    expect(summary.lagging).toEqual(["showcase-ag2"]);
+    expect(summary.alerted).toBe(false);
+    // A real lag whose alert never delivered must not report green.
+    expect(reconcileExitCode(summary)).not.toBe(0);
+  });
+
+  // ── Finding 5: a partial redeploy failure must not report green ────────────
+  it("partial redeploy failure (failed>0) → non-zero exit", async () => {
+    const { deps } = makeDeps(
+      {
+        "showcase-ag2": { deployed: DIGEST_A, latest: DIGEST_B }, // lags
+      },
+      {
+        redeployReport: {
+          attempted: 1,
+          succeeded: 0,
+          failed: 1,
+          records: [
+            { service: "showcase-ag2", status: "error", error: "HTTP 500" },
+          ],
+        },
+      },
+    );
+
+    const summary = await reconcileStaging(deps);
+
+    expect(summary.lagging).toEqual(["showcase-ag2"]);
+    expect(summary.redeployReport).toEqual({
+      attempted: 1,
+      succeeded: 0,
+      failed: 1,
+      records: [
+        { service: "showcase-ag2", status: "error", error: "HTTP 500" },
+      ],
+    });
+    // The failed lagging service is named unconfirmed (per-service).
+    expect(summary.unconfirmed.map((u) => u.service)).toContain("showcase-ag2");
+    expect(reconcileExitCode(summary)).not.toBe(0);
+  });
+});
+
+// ── R2 invariant: a run is green ONLY when EVERY in-scope staging service was
+// positively confirmed current. Any service NOT confirmed current — for ANY
+// reason — drives a Slack alert AND a non-zero exit. These cases prove the
+// holes the scattered special-cases left open. ─────────────────────────────
+describe("reconcileStaging invariant (green ⇔ every service confirmed current)", () => {
+  // The A16 + A19 cases exercise the REAL `runRedeploy`, which honors
+  // $REDEPLOY_SUMMARY_JSON (writing a real artifact file via fs.writeFileSync)
+  // and streams per-service progress to process.stdout — so under CI (where
+  // that env var is set) an unguarded call writes a real file and spams the
+  // terminal. Mirror redeploy-env.test.ts's guard: delete the artifact env
+  // vars (undefined removes them) and silence process.stdout. Restored in
+  // afterEach. (The mocked-redeploy cases in this block are unaffected.)
+  let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.stubEnv("REDEPLOY_SUMMARY_JSON", undefined);
+    vi.stubEnv("GITHUB_STEP_SUMMARY", undefined);
+    stdoutWriteSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutWriteSpy.mockRestore();
+    // mockRestore does NOT undo stubEnv — unstub explicitly so the stub never
+    // leaks into another test file under fork reuse.
+    vi.unstubAllEnvs();
+  });
+
+  it("redeploy drops a lagging service (record present for only one) → non-zero + alert names the dropped one", async () => {
+    // Two services lag, but the redeploy reported a per-service record for only
+    // ONE of them (showcase-agno was silently dropped/skipped). Per-service
+    // matching flags the missing one; the old count-compare could not.
+    const { deps, slackSpy } = makeDeps(
+      {
+        "showcase-ag2": { deployed: DIGEST_A, latest: DIGEST_B }, // lags
+        "showcase-agno": { deployed: DIGEST_A, latest: DIGEST_B }, // lags
+      },
+      {
+        redeployReport: {
+          attempted: 1,
+          succeeded: 1,
+          failed: 0,
+          records: [{ service: "showcase-ag2", status: "ok" }],
+        },
+      },
+    );
+
+    const summary = await reconcileStaging(deps);
+
+    expect(summary.lagging).toEqual(["showcase-ag2", "showcase-agno"]);
+    // Fail loud: the dropped lagging service is NOT confirmed current, by name.
+    expect(summary.unconfirmed.map((u) => u.service)).toContain(
+      "showcase-agno",
+    );
+    expect(summary.unconfirmed.map((u) => u.service)).not.toContain(
+      "showcase-ag2",
+    );
+    expect(reconcileExitCode(summary)).not.toBe(0);
+    expect(slackSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("null deployed digest on an otherwise-healthy fleet → non-zero + alert (not silent)", async () => {
+    // One service is current; one has an unresolvable deployed digest (no
+    // SUCCESS deployment / window miss). The old code recorded the null as an
+    // error but only failed loud when EVERYTHING errored (systemic) — so a
+    // single null on a healthy fleet read green.
+    const { deps, slackSpy } = makeDeps({
+      "showcase-ag2": { deployed: DIGEST_A, latest: DIGEST_A }, // current
+      "showcase-agno": { deployed: null, latest: DIGEST_B }, // unresolvable
+    });
+
+    const summary = await reconcileStaging(deps);
+
+    expect(reconcileExitCode(summary)).not.toBe(0);
+    expect(slackSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("null/empty GHCR :latest on an otherwise-healthy fleet → non-zero + alert", async () => {
+    const { deps, slackSpy } = makeDeps({
+      "showcase-ag2": { deployed: DIGEST_A, latest: DIGEST_A }, // current
+      "showcase-agno": { deployed: DIGEST_B, latest: "" }, // GHCR :latest empty
+    });
+
+    const summary = await reconcileStaging(deps);
+
+    expect(reconcileExitCode(summary)).not.toBe(0);
+    expect(slackSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("empty in-scope set (checked===0) → non-zero + alert (checked nothing is NOT green)", async () => {
+    const { deps, slackSpy } = makeDeps({});
+
+    const summary = await reconcileStaging(deps);
+
+    expect(summary.checked).toBe(0);
+    expect(reconcileExitCode(summary)).not.toBe(0);
+    expect(slackSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // ── A16: dropped-lag detection must NOT be defeated by imageOf expansion ────
+  it("A16: REAL imageOf expansion inflates `attempted`, but a dropped lagging service is still caught per-service", async () => {
+    // Two services lag: `harness` and `showcase-ag2`. The remediation redeploy
+    // actually forwards ONLY `harness` to the REAL runRedeploy — which, through
+    // REAL imageOf expansion, pulls in `harness-workers`, so `attempted` = 2.
+    // `showcase-ag2` is genuinely dropped and never remediated. Because
+    // expansion inflated `attempted` to 2 (= lagging.length), the OLD
+    // `attempted < lagging.length` count-compare (2 < 2 = false) read GREEN.
+    // Per-service matching against the real `records` catches the drop.
+    const redeployedServiceIds: string[] = [];
+    const fakeRedeploy = async (serviceId: string) => {
+      redeployedServiceIds.push(serviceId);
+      return { ok: true as const };
+    };
+
+    const deps: ReconcileDeps = {
+      services: ["harness", "showcase-ag2"],
+      // Both lag: deployed=A, latest=B.
+      fetchDeployedDigest: async () => DIGEST_A,
+      fetchLatestDigest: async () => DIGEST_B,
+      redeployStaging: async (_lagging) => {
+        // SIMULATE THE DROP: only `harness` reaches the real redeploy path
+        // (showcase-ag2 is dropped), but REAL runRedeploy still expands
+        // `harness` → `harness` + `harness-workers`, inflating `attempted`.
+        const summary = await runRedeploy({
+          env: "staging",
+          services: ["harness"],
+          redeploy: fakeRedeploy,
+          appendSummary: () => {},
+        });
+        return {
+          attempted: summary.attempted,
+          succeeded: summary.succeeded,
+          failed: summary.failed,
+          records: summary.records,
+        };
+      },
+      postSlackAlert: async () => true,
+      log: () => {},
+    };
+
+    const summary = await reconcileStaging(deps);
+
+    expect(summary.lagging).toEqual(["harness", "showcase-ag2"]);
+    // REAL expansion: only `harness` was forwarded, yet `attempted` = 2 because
+    // `harness-workers` (imageOf: harness) joined — NOT a hardcoded count.
+    expect(summary.redeployReport?.attempted).toBe(2);
+    expect(redeployedServiceIds).toHaveLength(2);
+    // `attempted` (2) is NOT < lagging.length (2): the old count-compare can't
+    // fire — yet the dropped lagging service must still be flagged.
+    expect(summary.redeployReport!.attempted).not.toBeLessThan(
+      summary.lagging.length,
+    );
+    // Per-service: the dropped lagging service is named unconfirmed.
+    expect(summary.unconfirmed.map((u) => u.service)).toContain("showcase-ag2");
+    // `harness` WAS remediated (and its consumer), so it is NOT unconfirmed.
+    expect(summary.unconfirmed.map((u) => u.service)).not.toContain("harness");
+    expect(reconcileExitCode(summary)).not.toBe(0);
+
+    // Guard proof: the REAL runRedeploy ran but wrote NO artifact file (the
+    // $REDEPLOY_SUMMARY_JSON env was deleted, so its fs.writeFileSync path is
+    // skipped) and its per-service stdout progress was intercepted by the spy
+    // instead of spamming the terminal.
+    expect(process.env.REDEPLOY_SUMMARY_JSON).toBeUndefined();
+    expect(stdoutWriteSpy).toHaveBeenCalled();
+  });
+
+  // ── A19: an already-CURRENT expansion consumer's incidental redeploy failure
+  // must NOT fail the run (only genuinely-lagging services do). ──────────────
+  it("A19: an ALREADY-CURRENT imageOf consumer whose INCIDENTAL expansion redeploy FAILS does not fail the run", async () => {
+    // `harness` lags :latest (deployed=A, latest=B). `harness-workers`
+    // (imageOf: harness) is ALREADY CURRENT (deployed=B === latest=B). The
+    // remediation forwards ONLY the lagging `harness` to the REAL runRedeploy,
+    // which through REAL imageOf expansion also redeploys `harness-workers`.
+    // That INCIDENTAL redeploy of the already-current consumer FAILS. Because
+    // `harness-workers` was positively confirmed current at check time, its
+    // failed incidental redeploy must NOT mark it unconfirmed — the run stays
+    // GREEN (the genuinely-lagging `harness` was itself remediated ok). The
+    // pre-A19 code flagged ANY failed non-lagging service and failed the run.
+    const HARNESS_ID = SERVICES["harness"].serviceId;
+    const WORKERS_ID = SERVICES["harness-workers"].serviceId;
+
+    const fakeRedeploy = async (serviceId: string) => {
+      // The already-current consumer's incidental expansion redeploy fails; the
+      // genuinely-lagging producer redeploys ok.
+      if (serviceId === WORKERS_ID) {
+        return {
+          ok: false as const,
+          error: "incidental expansion redeploy HTTP 500",
+        };
+      }
+      return { ok: true as const };
+    };
+
+    const deps: ReconcileDeps = {
+      services: ["harness", "harness-workers"],
+      fetchDeployedDigest: async (serviceId: string) => {
+        if (serviceId === HARNESS_ID) return DIGEST_A; // lags :latest
+        if (serviceId === WORKERS_ID) return DIGEST_B; // already current
+        throw new Error(`unexpected serviceId ${serviceId}`);
+      },
+      // Both track the showcase-harness image, whose :latest is DIGEST_B.
+      fetchLatestDigest: async () => DIGEST_B,
+      redeployStaging: async (lagging) => {
+        // Only the lagging `harness` reaches the real redeploy path; REAL
+        // runRedeploy expands it to also redeploy `harness-workers`.
+        const summary = await runRedeploy({
+          env: "staging",
+          services: lagging,
+          redeploy: fakeRedeploy,
+          appendSummary: () => {},
+        });
+        return {
+          attempted: summary.attempted,
+          succeeded: summary.succeeded,
+          failed: summary.failed,
+          records: summary.records,
+        };
+      },
+      postSlackAlert: async () => true,
+      log: () => {},
+    };
+
+    const summary = await reconcileStaging(deps);
+
+    // Only `harness` lagged; `harness-workers` was current at check time.
+    expect(summary.lagging).toEqual(["harness"]);
+    // REAL expansion pulled the already-current consumer into the redeploy, and
+    // its incidental redeploy FAILED (proving the failure surface is real).
+    const workersRec = summary.redeployReport?.records.find(
+      (r) => r.service === "harness-workers",
+    );
+    expect(workersRec).toEqual({
+      service: "harness-workers",
+      status: "error",
+      error: "incidental expansion redeploy HTTP 500",
+    });
+    // A19: the already-current consumer is NOT marked unconfirmed by its failed
+    // incidental redeploy, and `harness` was remediated ok — so nothing is
+    // unconfirmed and the run is GREEN.
+    expect(summary.unconfirmed.map((u) => u.service)).not.toContain(
+      "harness-workers",
+    );
+    expect(summary.unconfirmed).toEqual([]);
+    expect(reconcileExitCode(summary)).toBe(0);
+  });
+
+  // ── A17: a remediation redeploy that THROWS still alerts + exits non-zero ───
+  it("A17: remediation redeploy THROWS → Slack alert fires AND non-zero exit (every lagging service unconfirmed)", async () => {
+    const { deps, slackSpy } = makeDeps({
+      "showcase-ag2": { deployed: DIGEST_A, latest: DIGEST_B }, // lags
+      "showcase-agno": { deployed: DIGEST_B, latest: DIGEST_A }, // lags
+    });
+    // Override the redeploy to throw (e.g. token expiry, unreachable Railway).
+    deps.redeployStaging = vi.fn(async () => {
+      throw new Error("Railway redeploy exploded");
+    });
+
+    const summary = await reconcileStaging(deps);
+
+    expect(summary.lagging).toEqual(["showcase-ag2", "showcase-agno"]);
+    // Every lagging service is unconfirmed because remediation never returned.
+    expect(summary.unconfirmed.map((u) => u.service).sort()).toEqual([
+      "showcase-ag2",
+      "showcase-agno",
+    ]);
+    // The invariant: any unconfirmed ⇒ alert AND non-zero — BOTH must happen
+    // even when the redeploy itself throws.
+    expect(slackSpy).toHaveBeenCalledTimes(1);
+    expect(summary.alerted).toBe(true);
+    expect(reconcileExitCode(summary)).not.toBe(0);
+  });
+
+  it("all-current → exit 0 and NO alert (green only when truly all-confirmed)", async () => {
+    const { deps, slackSpy } = makeDeps({
+      "showcase-ag2": { deployed: DIGEST_A, latest: DIGEST_A },
+      "showcase-agno": { deployed: DIGEST_B, latest: DIGEST_B },
+    });
+
+    const summary = await reconcileStaging(deps);
+
+    expect(reconcileExitCode(summary)).toBe(0);
+    expect(slackSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ── Finding 3: newest-SUCCESS selection is deterministic (createdAt desc) ────
+describe("pickNewestSuccessDigest", () => {
+  it("chooses the newest SUCCESS by createdAt even when edges arrive out of order", () => {
+    const edges = [
+      {
+        node: {
+          id: "old",
+          status: "SUCCESS",
+          meta: { imageDigest: DIGEST_A },
+          createdAt: "2026-07-01T00:00:00.000Z",
+        },
+      },
+      {
+        node: {
+          id: "new",
+          status: "SUCCESS",
+          meta: { imageDigest: DIGEST_B },
+          createdAt: "2026-07-19T00:00:00.000Z",
+        },
+      },
+      {
+        node: {
+          id: "mid",
+          status: "SUCCESS",
+          meta: { imageDigest: DIGEST_A },
+          createdAt: "2026-07-10T00:00:00.000Z",
+        },
+      },
+    ];
+    // Newest by createdAt is the "new" edge → DIGEST_B, regardless of order.
+    expect(pickNewestSuccessDigest(edges)).toBe(DIGEST_B);
+  });
+
+  it("ignores non-SUCCESS deployments even when they are newer", () => {
+    const edges = [
+      {
+        node: {
+          id: "failed-newer",
+          status: "FAILED",
+          meta: { imageDigest: DIGEST_B },
+          createdAt: "2026-07-20T00:00:00.000Z",
+        },
+      },
+      {
+        node: {
+          id: "success-older",
+          status: "SUCCESS",
+          meta: { imageDigest: DIGEST_A },
+          createdAt: "2026-07-01T00:00:00.000Z",
+        },
+      },
+    ];
+    expect(pickNewestSuccessDigest(edges)).toBe(DIGEST_A);
+  });
+
+  // ── A18: an unparseable createdAt must never win "newest" ──────────────────
+  it("A18: an unparseable createdAt on a SUCCESS deployment never wins 'newest' — the valid newest digest is chosen", () => {
+    // The invalid-timestamp edge is listed FIRST. Under the old comparator
+    // (`new Date(b).getTime() - new Date(a).getTime()`) the subtraction yields
+    // NaN, the sort leaves order undefined, and the NaN edge can remain at
+    // index 0 → the WRONG (DIGEST_B) digest is selected. NaN-safe ordering
+    // sorts the invalid timestamp to the bottom so the valid SUCCESS wins.
+    const edges = [
+      {
+        node: {
+          id: "nan-createdAt",
+          status: "SUCCESS",
+          meta: { imageDigest: DIGEST_B },
+          createdAt: "not-a-real-date",
+        },
+      },
+      {
+        node: {
+          id: "valid",
+          status: "SUCCESS",
+          meta: { imageDigest: DIGEST_A },
+          createdAt: "2026-07-01T00:00:00.000Z",
+        },
+      },
+    ];
+    expect(pickNewestSuccessDigest(edges)).toBe(DIGEST_A);
+  });
+
+  it("prefers a valid newer SUCCESS over an unparseable one regardless of input order", () => {
+    // Same invariant with the valid edge first — the invalid one must still
+    // never be selected.
+    const edges = [
+      {
+        node: {
+          id: "valid-newer",
+          status: "SUCCESS",
+          meta: { imageDigest: DIGEST_A },
+          createdAt: "2026-07-19T00:00:00.000Z",
+        },
+      },
+      {
+        node: {
+          id: "nan-createdAt",
+          status: "SUCCESS",
+          meta: { imageDigest: DIGEST_B },
+          createdAt: "",
+        },
+      },
+    ];
+    expect(pickNewestSuccessDigest(edges)).toBe(DIGEST_A);
+  });
+
+  it("returns null when there is no SUCCESS deployment", () => {
+    const edges = [
+      {
+        node: {
+          id: "building",
+          status: "BUILDING",
+          meta: { imageDigest: DIGEST_A },
+          createdAt: "2026-07-20T00:00:00.000Z",
+        },
+      },
+    ];
+    expect(pickNewestSuccessDigest(edges)).toBeNull();
+  });
+});

--- a/showcase/scripts/reconcile-staging.ts
+++ b/showcase/scripts/reconcile-staging.ts
@@ -1,0 +1,874 @@
+#!/usr/bin/env npx tsx
+/**
+ * reconcile-staging.ts — CI-owned scheduled self-heal for the showcase
+ * STAGING fleet.
+ *
+ * Replaces Railway's registry auto-watch (which we are disabling) with a
+ * deterministic, CI-controlled reconcile. On a 15-minute cadence it compares
+ * each staging showcase service's ACTUALLY-DEPLOYED image digest against the
+ * GHCR `:latest` digest for that service's repo. When a service's deployed
+ * digest LAGS `:latest`, the reconcile re-runs the existing staging redeploy
+ * (`redeploy-env.ts`) scoped to just the lagging services and posts a Slack
+ * alert naming them — alert-AND-remediate, not alert-only.
+ *
+ * Why this exists: staging floats on the mutable `:latest` tag. Railway's
+ * registry auto-watch used to notice a new `:latest` push and redeploy the
+ * service. Disabling that watch removes the self-heal, so this workflow is the
+ * deterministic replacement — CI owns the "is staging actually running the
+ * latest image?" question and re-triggers the redeploy that already exists.
+ *
+ * ── Deployed-digest mechanism ──────────────────────────────────────────────
+ * Railway stores TAG-ONLY refs in `serviceInstance.source.image`
+ * (`ghcr.io/copilotkit/<repo>:latest`), so the running digest is NOT
+ * recoverable from that field. The real running digest lives on the latest
+ * SUCCESS deployment's `meta.imageDigest` (a `sha256:…` value). This mirrors
+ * `showcase/bin/railway`'s `staging_running_digest` and the harness
+ * `image-drift` probe.
+ *
+ * ── Threshold (v1) ─────────────────────────────────────────────────────────
+ * A service is treated as LAGGING on a plain digest MISMATCH
+ * (`deployedDigest !== latestDigest`). A precise "how long has it been
+ * lagging?" signal is not cheaply available from a single Railway read, so v1
+ * uses the mismatch alone. The 15-minute cadence itself provides the debounce:
+ * a service that is mid-redeploy (its new deployment not yet SUCCESS) simply
+ * matches on the next cycle, and re-running the staging redeploy is idempotent
+ * (it just triggers another redeploy of an image that is already `:latest`), so
+ * a transient duplicate is harmless. A deployed digest that cannot be resolved
+ * (no SUCCESS deployment / no `meta.imageDigest`) is recorded as an ERROR and
+ * SURFACED — it is NOT silently counted as up-to-date and it is NOT redeployed
+ * (re-deploying on that ambiguous signal would risk churn without a clear win),
+ * but it never masquerades as a healthy "current with :latest" service.
+ *
+ * The newest running digest is the newest SUCCESS deployment BY `createdAt`
+ * (descending) — Railway's `deployments()` connection order is not contracted,
+ * so the reconcile sorts explicitly rather than trusting API ordering.
+ *
+ * ── The invariant (the ONE organizing rule) ─────────────────────────────────
+ * A reconcile run is GREEN (exit 0) IF AND ONLY IF EVERY in-scope staging
+ * service was either POSITIVELY CONFIRMED CURRENT or was a lag whose
+ * remediation redeploy CLEANLY fixed it (no failures, no drops). A cleanly
+ * remediated lag still posts an INFORMATIONAL Slack alert (alert-AND-remediate)
+ * yet exits 0. Any service that is NOT confirmed current or cleanly remediated
+ * — for ANY reason — lands in the single `unconfirmed` set, which drives BOTH a
+ * Slack alert naming the services + the reason AND a non-zero exit. There are
+ * no scattered per-cause special-cases: the exit code and the alert are derived
+ * from that one set.
+ *
+ * A service is NOT confirmed current when:
+ *   • it is LAGGING (`deployed !== latest`) and its remediation redeploy did
+ *     not CLEARLY remediate IT — there is no `status:"ok"` per-service record
+ *     for it (it was dropped/skipped, or its own redeploy failed). This is
+ *     matched PER-SERVICE, not by comparing the post-expansion `attempted`
+ *     count against `lagging.length` (imageOf expansion inflates `attempted`
+ *     and could numerically mask a dropped lag — the A16 hole). An INCIDENTAL
+ *     expansion-redeploy failure of an ALREADY-CURRENT consumer does NOT count
+ *     — it was verified on `:latest` at check time (A19);
+ *   • its DEPLOYED digest is null/unresolvable — no SUCCESS deployment, no
+ *     parseable `meta.imageDigest`, or the newest SUCCESS was pushed out of the
+ *     `deployments(first:10)` window by >10 newer non-SUCCESS deploys;
+ *   • its GHCR `:latest` digest is null/empty;
+ *   • a per-service Railway/GHCR read threw;
+ *   • the in-scope set was EMPTY (`emptyScope`, i.e. `services.length === 0` — a
+ *     run that checked nothing is NOT green, mirroring the autoUpdates gate's
+ *     zero-checked floor). NOTE: an all-errored run (scope non-empty but every
+ *     service faulted) is NOT `emptyScope` — each faulted service contributes
+ *     its own entry to the `unconfirmed` set via `errors`.
+ *
+ * A LAGGING service whose remediation redeploy CLEARLY succeeded (no failures,
+ * no drops) is confirmed-in-progress: the run still posts an informational
+ * alert (alert-AND-remediate) but exits 0, and it will match `:latest` on the
+ * next cycle. An UNDELIVERED alert alongside a lag also fails loud (see
+ * `alerted`).
+ *
+ * `alerted` reflects ACTUAL delivery: it is true only when the Slack webhook
+ * POST returned 2xx. A missing webhook, a non-2xx response, or a thrown request
+ * all leave `alerted === false` so a swallowed alert never reads as success.
+ *
+ * ── Usage ──────────────────────────────────────────────────────────────────
+ *   npx tsx showcase/scripts/reconcile-staging.ts
+ *
+ * Auth: RAILWAY_TOKEN env var or ~/.railway/config.json (Railway reads +
+ * redeploy), GHCR_TOKEN / GITHUB_TOKEN (GHCR manifest reads), and
+ * SLACK_WEBHOOK_OSS_ALERTS (incoming webhook for the alert — the SAME secret
+ * showcase_build.yml posts its failure alerts through).
+ *
+ * Exit code: 0 on a clean reconcile (including a fully-remediated lag). A hard
+ * operator/config error (missing Railway token, unreachable Railway), a
+ * systemic failure, a partial redeploy failure, or an undelivered lag alert all
+ * fail loud with a non-zero exit (see the fail-loud contract above).
+ */
+
+import { fileURLToPath } from "url";
+import {
+  CI_BUILT_SERVICES,
+  ENV_ID_BY_NAME,
+  PROJECT_ID,
+  SERVICES,
+  repoNameFor,
+} from "./railway-envs";
+import {
+  RAILWAY_GRAPHQL_ENDPOINT,
+  sanitizeErrorBody,
+} from "./lib/railway-graphql";
+import { RailwayTokenError, resolveRailwayToken } from "./lib/railway-token";
+import { resolveGhcrDigest } from "./deploy-to-railway";
+import { makeLiveRedeploy, runRedeploy } from "./redeploy-env";
+import type { RedeployServiceRecord } from "./redeploy-env";
+
+// ── Pure decision core (unit-tested without network) ───────────────────────
+
+/**
+ * A resolved (service, deployedDigest, latestDigest) tuple for one staging
+ * service. `deployedDigest` is null when Railway had no SUCCESS deployment /
+ * no `meta.imageDigest` to read. Both digests are normalized `sha256:<hex>`
+ * strings (or null).
+ */
+export interface ServiceDigestPair {
+  service: string;
+  repoName: string;
+  deployedDigest: string | null;
+  latestDigest: string;
+}
+
+/**
+ * Redeploy outcome the orchestrator threads into the Slack alert. Mirrors the
+ * tally `redeploy-env.ts`'s `runRedeploy` returns, PLUS the per-service
+ * `records` — the reconcile confirms remediation PER-SERVICE (each lagging
+ * service must have a `status:"ok"` record) rather than comparing the
+ * post-expansion `attempted` count against the pre-expansion lagging count
+ * (imageOf expansion inflates `attempted`, which can numerically MASK a
+ * dropped lagging service — the A16 hole).
+ */
+export interface RedeployReport {
+  attempted: number;
+  succeeded: number;
+  failed: number;
+  /** Per-service outcomes (post-expansion), matched by service key. */
+  records: RedeployServiceRecord[];
+}
+
+export interface ReconcileDeps {
+  /**
+   * SSOT keys of the staging services to reconcile. Defaults to
+   * `stagingReconcileServices()` (CI-built services that declare a staging
+   * env). Injectable so the test can pin a small fixed scope.
+   */
+  services?: string[];
+  /**
+   * Resolve the digest currently DEPLOYED on the staging serviceInstance.
+   * Returns null when no running digest is resolvable.
+   */
+  fetchDeployedDigest: (
+    serviceId: string,
+    environmentId: string,
+  ) => Promise<string | null>;
+  /** Resolve the GHCR `:latest` digest for a repo name. */
+  fetchLatestDigest: (repoName: string) => Promise<string>;
+  /**
+   * Trigger a staging redeploy scoped to the given SSOT keys. Returns the
+   * per-run tally.
+   */
+  redeployStaging: (services: string[]) => Promise<RedeployReport>;
+  /**
+   * Post a Slack alert with the given text. Returns true only when the alert
+   * was ACTUALLY delivered (a 2xx POST); false on a missing webhook, a non-2xx
+   * response, or a thrown request. The caller records the returned value as
+   * `summary.alerted` so a swallowed alert never reads as a delivered one.
+   */
+  postSlackAlert: (text: string) => Promise<boolean>;
+  /** Progress logger. Defaults to console.log. */
+  log?: (line: string) => void;
+}
+
+/**
+ * One in-scope service that could NOT be positively confirmed current, with a
+ * human-readable reason. This is the atom of the invariant: the reconcile is
+ * green iff the `unconfirmed` set is empty. `service` may be a synthetic label
+ * (e.g. `(redeploy)` / `(scope)`) for a fleet-level shortfall that is not
+ * attributable to a single service.
+ */
+export interface UnconfirmedService {
+  service: string;
+  reason: string;
+}
+
+export interface ReconcileSummary {
+  /**
+   * Count of services SUCCESSFULLY COMPARED — both the deployed digest and the
+   * GHCR `:latest` digest resolved (i.e. `pairs.length`). This INCLUDES any
+   * found lagging; it is NOT a positively-current count (that is
+   * `checked - lagging.length`). Services whose digest read errored are not
+   * counted here — they land in `errors`/`unconfirmed`.
+   */
+  checked: number;
+  lagging: string[];
+  errors: { service: string; error: string }[];
+  redeployed: boolean;
+  /** True only when a Slack alert was ACTUALLY delivered (2xx POST). */
+  alerted: boolean;
+  /**
+   * The remediation redeploy tally, or null when no redeploy ran. Threaded out
+   * so a partial (`failed > 0`) or dropped (`attempted < lagging.length`)
+   * remediation flows into `unconfirmed`.
+   */
+  redeployReport: RedeployReport | null;
+  /**
+   * THE INVARIANT SET: every in-scope service NOT positively confirmed current,
+   * with its reason. A run is green iff this is empty. The exit code and the
+   * alert are both derived from it (see `reconcileExitCode` / the header
+   * contract) — there are no separate per-cause special-cases.
+   */
+  unconfirmed: UnconfirmedService[];
+  /**
+   * True when the in-scope set was empty (`services.length === 0`) — the run
+   * checked nothing, which is NOT green. Recorded as its own field for the
+   * alert text; it also contributes an entry to `unconfirmed`.
+   */
+  emptyScope: boolean;
+}
+
+/**
+ * Normalize a digest for comparison: trim + lowercase. null passes through.
+ * GHCR's Docker-Content-Digest and Railway's meta.imageDigest are both
+ * `sha256:<hex>`, but normalizing guards against stray casing/whitespace.
+ */
+function normalizeDigest(d: string | null): string | null {
+  if (d === null) return null;
+  const t = d.trim().toLowerCase();
+  return t === "" ? null : t;
+}
+
+/**
+ * The reconcile decision, pure and unit-testable. A service is LAGGING when
+ * its deployed digest resolved (non-null) AND differs from the GHCR `:latest`
+ * digest. A null deployed digest is NOT lagging (see the threshold note in the
+ * file header). Returns the lagging SSOT keys, sorted for stable output.
+ */
+export function selectLaggingServices(pairs: ServiceDigestPair[]): string[] {
+  return pairs
+    .filter(
+      (p) => p.deployedDigest !== null && p.deployedDigest !== p.latestDigest,
+    )
+    .map((p) => p.service)
+    .sort();
+}
+
+/**
+ * The default reconcile scope: every staging service that floats `:latest`.
+ * That is BOTH:
+ *   • every CI-built service that declares a staging env (it floats `:latest`
+ *     in staging and is redeployed by the build's staging redeploy), AND
+ *   • every `imageOf` consumer that declares a staging env — a service that
+ *     runs another (CI-built) service's image on its OWN serviceInstance
+ *     (e.g. `harness-workers` runs the `showcase-harness` image). A consumer
+ *     tracks the same `:latest` but has an INDEPENDENT deployment history, so
+ *     it can drift from its producer (the PR #5352 regression: `harness`
+ *     bounced, `harness-workers` left running the stale image). Excluding it
+ *     from the reconcile scope would leave that drift undetected — and it IS
+ *     remediable, since `runRedeploy`/`resolveTargetServices` honor any SSOT
+ *     key and `expandImageConsumers` redeploys consumers — so include it.
+ *
+ * Its GHCR `:latest` is checked against `repoNameFor(consumer, "staging")`,
+ * which resolves to the producer's repo via the consumer's `repoName`
+ * override; its deployed digest is read from the consumer's own
+ * serviceInstance. Sorted for stable iteration.
+ */
+export function stagingReconcileServices(): string[] {
+  const scope = new Set<string>();
+  for (const [name, entry] of Object.entries(SERVICES)) {
+    if (!Object.hasOwn(entry.environments, "staging")) continue;
+    if (CI_BUILT_SERVICES.has(name) || entry.imageOf !== undefined) {
+      scope.add(name);
+    }
+  }
+  return [...scope].sort();
+}
+
+/**
+ * Compute the ONE invariant set — every in-scope service NOT positively
+ * confirmed current, with its reason — from the raw reconcile facts. This is
+ * the single place the "not confirmed current" cases from the header contract
+ * are enumerated; the exit code and the alert both derive from its result.
+ *
+ * Sources of "unconfirmed":
+ *   • per-service digest-read faults (`errors`) — null/unresolvable deployed
+ *     digest, null/empty GHCR `:latest`, a thrown read, or a bogus SSOT key;
+ *   • a remediation redeploy that THREW before reporting (`redeployError`) —
+ *     every lagging service is unconfirmed (remediation did not run to a
+ *     result), so the invariant still alerts + exits non-zero (A17);
+ *   • a lagging service NOT positively confirmed remediated — it lacks a
+ *     `status:"ok"` per-service record in `redeployReport.records` (it was
+ *     dropped/skipped, or its own redeploy failed). This is matched
+ *     PER-SERVICE, NOT by comparing the post-expansion `attempted` count
+ *     against `lagging.length`: imageOf expansion inflates `attempted`, so a
+ *     genuinely dropped lagging service could be numerically masked (A16);
+ *   • any OTHER service the redeploy attempted and FAILED that was NOT already
+ *     confirmed current at check time — e.g. an imageOf consumer pulled in by
+ *     expansion that was itself lagging/unresolved — since it is still running
+ *     the stale image. A consumer that WAS confirmed current stays confirmed
+ *     even if its incidental expansion redeploy fails (A19): it was already
+ *     verified on `:latest`, so the failure is not evidence of a stale image;
+ *   • an EMPTY in-scope set (`emptyScope`) — a run that checked nothing.
+ */
+export function buildUnconfirmed(args: {
+  errors: { service: string; error: string }[];
+  lagging: string[];
+  redeployReport: RedeployReport | null;
+  redeployError: string | null;
+  emptyScope: boolean;
+  /**
+   * Services POSITIVELY CONFIRMED CURRENT at check time (deployed === latest).
+   * `runRedeploy` expands an explicitly-redeployed lagging service to ALSO
+   * redeploy its `imageOf` consumers; a consumer that was already current only
+   * gets an INCIDENTAL expansion redeploy. If that incidental redeploy fails,
+   * the service is STILL current (it was verified on `:latest`), so it must
+   * NOT be marked unconfirmed (A19). Passing the set lets the "other failed"
+   * loop below exclude such already-verified services.
+   */
+  confirmedCurrent: Set<string>;
+}): UnconfirmedService[] {
+  const {
+    errors,
+    lagging,
+    redeployReport,
+    redeployError,
+    emptyScope,
+    confirmedCurrent,
+  } = args;
+  const unconfirmed: UnconfirmedService[] = [];
+
+  if (emptyScope) {
+    unconfirmed.push({
+      service: "(scope)",
+      reason:
+        "no in-scope staging services — the reconcile checked nothing (a zero-checked run is not green)",
+    });
+  }
+
+  for (const e of errors) {
+    unconfirmed.push({ service: e.service, reason: e.error });
+  }
+
+  // A17: the remediation redeploy THREW before returning a report. No lagging
+  // service can be confirmed remediated, so every one is unconfirmed — the
+  // invariant still alerts AND exits non-zero even when the redeploy itself
+  // throws (a bare propagated throw would go CI-red but skip the Slack alert).
+  if (redeployError !== null) {
+    for (const svc of lagging) {
+      unconfirmed.push({
+        service: svc,
+        reason: `remediation redeploy threw before confirming this lagging service: ${redeployError}`,
+      });
+    }
+  }
+
+  if (redeployReport !== null) {
+    // A16: confirm remediation PER-SERVICE. A lagging service is confirmed only
+    // if the redeploy reported a status:"ok" record for it. Comparing the
+    // post-expansion `attempted` count against `lagging.length` is DEFEATED by
+    // imageOf expansion (which inflates `attempted`), so a dropped lagging
+    // service could read green — match the records instead.
+    const okServices = new Set(
+      redeployReport.records
+        .filter((r) => r.status === "ok")
+        .map((r) => r.service),
+    );
+    for (const svc of lagging) {
+      if (okServices.has(svc)) continue;
+      const rec = redeployReport.records.find((r) => r.service === svc);
+      const detail =
+        rec === undefined
+          ? "the remediation redeploy attempted no redeploy for it (dropped/skipped and never remediated)"
+          : `its remediation redeploy failed${rec.error ? `: ${rec.error}` : ""}`;
+      unconfirmed.push({
+        service: svc,
+        reason: `lagging service not confirmed current — ${detail}`,
+      });
+    }
+    // Any OTHER service the redeploy attempted and FAILED (e.g. an imageOf
+    // consumer added by expansion) that was NOT already confirmed current is
+    // also not current — it is still running the stale image. Lagging failures
+    // are already reported above.
+    //
+    // A19: a service CONFIRMED CURRENT at check time stays confirmed even if
+    // its INCIDENTAL expansion redeploy fails. `runRedeploy` expands a lagging
+    // service to also redeploy its imageOf consumers; a consumer that was
+    // already on `:latest` was positively verified before the redeploy ran, so
+    // a failed incidental redeploy of it is not evidence of a stale image and
+    // must NOT fail the run. (This never re-opens the A16 hole: a genuinely
+    // LAGGING dropped/failed service is NOT in `confirmedCurrent` and is still
+    // caught above via per-service record matching.)
+    for (const r of redeployReport.records) {
+      if (r.status !== "error") continue;
+      if (lagging.includes(r.service)) continue;
+      if (confirmedCurrent.has(r.service)) continue;
+      unconfirmed.push({
+        service: r.service,
+        reason: `remediation redeploy failed${r.error ? `: ${r.error}` : ""}`,
+      });
+    }
+  }
+
+  return unconfirmed;
+}
+
+/**
+ * Build the single Slack alert text for a non-green reconcile. Names the
+ * unconfirmed services + reasons (the fail-loud part) AND the lagging services
+ * + remediation outcome (the informational alert-AND-remediate part). The
+ * headline reflects the ACTUAL condition — unconfirmed services when any exist,
+ * otherwise a plain lag notice — rather than a hardcoded cause. Human-voiced,
+ * mrkdwn.
+ */
+export function buildReconcileAlert(args: {
+  lagging: string[];
+  redeployReport: RedeployReport | null;
+  unconfirmed: UnconfirmedService[];
+  scope: number;
+}): string {
+  const { lagging, redeployReport, unconfirmed, scope } = args;
+  const sections: string[] = [];
+
+  if (unconfirmed.length > 0) {
+    const n = unconfirmed.length;
+    const sample = unconfirmed
+      .slice(0, 8)
+      .map((u) => `• \`${u.service}\`: ${u.reason}`)
+      .join("\n");
+    const more = n > 8 ? `\n…and ${n - 8} more` : "";
+    sections.push(
+      `:rotating_light: *Showcase staging reconcile — ${n} service${n === 1 ? "" : "s"} NOT confirmed current* ` +
+        `(of ${scope} in scope). Staging drift is not fully self-healed until this clears:\n${sample}${more}`,
+    );
+  }
+
+  if (lagging.length > 0 && redeployReport !== null) {
+    const n = lagging.length;
+    const bullets = lagging.map((s) => `• \`${s}\``).join("\n");
+    sections.push(
+      `:arrows_counterclockwise: ${n} service${n === 1 ? "" : "s"} lagging \`:latest\`, re-triggered the staging redeploy:\n${bullets}\n` +
+        `redeploy: ${redeployReport.succeeded}/${redeployReport.attempted} triggered (${redeployReport.failed} failed)`,
+    );
+  }
+
+  return sections.join("\n\n");
+}
+
+/**
+ * The scheduled run's exit code, derived purely from the ONE invariant. Fail
+ * loud (non-zero) whenever any in-scope service is unconfirmed, or when a lag
+ * was found but its alert never delivered; 0 only when every service was
+ * confirmed current (or a lag was cleanly remediated AND its alert delivered).
+ * See the invariant in the file header.
+ */
+export function reconcileExitCode(summary: ReconcileSummary): number {
+  if (summary.unconfirmed.length > 0) return 1;
+  if (summary.lagging.length > 0 && !summary.alerted) return 1;
+  return 0;
+}
+
+/**
+ * Compare each staging service's deployed digest against GHCR `:latest`, then
+ * redeploy + alert per the ONE invariant: the run is green iff EVERY in-scope
+ * service is positively confirmed current. Per-service digest-fetch failures —
+ * including an unresolvable deployed digest or an empty GHCR `:latest` — become
+ * `unconfirmed` entries (they never mask another service's lag and never read
+ * as a healthy "current" service). A lag is remediated by a scoped redeploy; a
+ * redeploy that fails or drops a lagging service, and an empty in-scope set,
+ * also land in `unconfirmed`. A single Slack alert names the unconfirmed
+ * services + reasons and the lag/remediation outcome, and the exit code is
+ * derived from the same set. All I/O is injected via `deps` so the decision →
+ * action wiring is unit-tested offline.
+ */
+export async function reconcileStaging(
+  deps: ReconcileDeps,
+): Promise<ReconcileSummary> {
+  const log = deps.log ?? ((l: string) => console.log(l));
+  const stagingEnvId = ENV_ID_BY_NAME["staging"];
+  const services = deps.services ?? stagingReconcileServices();
+
+  const pairs: ServiceDigestPair[] = [];
+  const errors: { service: string; error: string }[] = [];
+
+  for (const name of services) {
+    // Own-property guard so an inherited prototype key can never dereference a
+    // bogus SERVICES entry.
+    const entry = Object.hasOwn(SERVICES, name) ? SERVICES[name] : undefined;
+    if (entry === undefined) {
+      errors.push({ service: name, error: "not an SSOT service key" });
+      continue;
+    }
+    try {
+      const repoName = repoNameFor(name, "staging");
+      const [deployedRaw, latestRaw] = await Promise.all([
+        deps.fetchDeployedDigest(entry.serviceId, stagingEnvId),
+        deps.fetchLatestDigest(repoName),
+      ]);
+      const deployedDigest = normalizeDigest(deployedRaw);
+      const latestDigest = normalizeDigest(latestRaw);
+      if (latestDigest === null) {
+        // A missing GHCR :latest digest is a fault, not a comparison — record
+        // and skip rather than treat the null-vs-something as a lag.
+        errors.push({
+          service: name,
+          error: `GHCR :latest digest for ${repoName} resolved empty`,
+        });
+        continue;
+      }
+      if (deployedDigest === null) {
+        // No resolvable SUCCESS deployment digest. Per the header contract this
+        // is recorded as an ERROR and surfaced — NOT silently treated as
+        // up-to-date, and NOT redeployed (the ambiguous signal would risk
+        // churn). It stays out of `pairs` so it never reads as "current".
+        errors.push({
+          service: name,
+          error: `no resolvable deployed digest (no SUCCESS deployment / meta.imageDigest) for ${repoName}`,
+        });
+        log(`  ${name.padEnd(36)} ERROR: deployed digest unresolved`);
+        continue;
+      }
+      pairs.push({ service: name, repoName, deployedDigest, latestDigest });
+      log(
+        `  ${name.padEnd(36)} deployed=${deployedDigest} latest=${latestDigest}`,
+      );
+    } catch (e) {
+      const error = sanitizeErrorBody(
+        e instanceof Error ? e.message : String(e),
+      );
+      errors.push({ service: name, error });
+      log(`  ${name.padEnd(36)} ERROR: ${error}`);
+    }
+  }
+
+  const lagging = selectLaggingServices(pairs);
+  const laggingSet = new Set(lagging);
+  // Services POSITIVELY CONFIRMED CURRENT at check time: a resolved pair whose
+  // deployed digest matched `:latest`. Threaded into buildUnconfirmed so an
+  // incidental imageOf-expansion redeploy failure of an already-current service
+  // does not falsely mark it unconfirmed (A19).
+  const confirmedCurrent = new Set(
+    pairs.filter((p) => !laggingSet.has(p.service)).map((p) => p.service),
+  );
+  const emptyScope = services.length === 0;
+
+  // Remediate any lag FIRST so the redeploy tally feeds the invariant set.
+  let redeployed = false;
+  let redeployReport: RedeployReport | null = null;
+  let redeployError: string | null = null;
+  if (lagging.length > 0) {
+    log(
+      `\n${lagging.length} staging service(s) lagging :latest: ${lagging.join(", ")}`,
+    );
+    // A17: guard the redeploy call. A thrown remediation must NOT propagate
+    // out of the reconcile before the alert fires — a bare throw would go
+    // CI-red but skip the Slack alert, half-violating the invariant. On throw
+    // we record the error, leave redeployReport null, and let buildUnconfirmed
+    // mark every lagging service unconfirmed so the run still alerts + exits
+    // non-zero.
+    try {
+      redeployReport = await deps.redeployStaging(lagging);
+      redeployed = true;
+    } catch (e) {
+      redeployError = sanitizeErrorBody(
+        e instanceof Error ? e.message : String(e),
+      );
+      log(`\nremediation redeploy threw before confirming: ${redeployError}`);
+    }
+  }
+
+  // THE ONE INVARIANT: every in-scope service not positively confirmed current.
+  const unconfirmed = buildUnconfirmed({
+    errors,
+    lagging,
+    redeployReport,
+    redeployError,
+    emptyScope,
+    confirmedCurrent,
+  });
+
+  // Alert whenever the run is not a clean silent no-op: any unconfirmed service
+  // (fail-loud) OR any lag (informational alert-AND-remediate). A single alert
+  // covers both.
+  let alerted = false;
+  if (unconfirmed.length > 0 || lagging.length > 0) {
+    if (unconfirmed.length > 0) {
+      log(
+        `\n${unconfirmed.length} staging service(s) NOT confirmed current (of ${services.length} in scope).`,
+      );
+    }
+    alerted = await deps.postSlackAlert(
+      buildReconcileAlert({
+        lagging,
+        redeployReport,
+        unconfirmed,
+        scope: services.length,
+      }),
+    );
+  } else {
+    log(
+      `\nAll ${pairs.length} checked staging service(s) current with :latest.`,
+    );
+  }
+
+  return {
+    checked: pairs.length,
+    lagging,
+    errors,
+    redeployed,
+    alerted,
+    redeployReport,
+    unconfirmed,
+    emptyScope,
+  };
+}
+
+// ── Live wiring (main) ──────────────────────────────────────────────────────
+
+const RAILWAY_API = RAILWAY_GRAPHQL_ENDPOINT;
+
+/**
+ * Resolve the Railway bearer token, mapping a RailwayTokenError onto the
+ * script's exit-1 operator/config-error contract (mirrors the other scripts).
+ */
+function getRailwayToken(): string {
+  try {
+    return resolveRailwayToken().token;
+  } catch (e) {
+    if (e instanceof RailwayTokenError) {
+      console.error(e.message);
+      process.exit(1);
+    }
+    throw e;
+  }
+}
+
+/** A single deployment edge as returned by Railway's `deployments()` query. */
+export interface DeploymentEdge {
+  node: {
+    id: string;
+    status: string;
+    meta: unknown;
+    createdAt: string;
+  };
+}
+
+interface DeploymentsResponse {
+  deployments: {
+    edges: DeploymentEdge[];
+  } | null;
+}
+
+/**
+ * Pick the imageDigest of the newest SUCCESS deployment from a batch of edges.
+ *
+ * Railway's `deployments()` connection order is NOT contracted, so we sort the
+ * SUCCESS deployments by `createdAt` descending and take the first rather than
+ * trusting the API to return newest-first. A wrong pick would either flag a
+ * false lag (churn) or miss a real one. Returns null when there is no SUCCESS
+ * deployment or no parseable `meta.imageDigest`.
+ *
+ * A18 — NaN-safe ordering: an unparseable/missing `createdAt` yields NaN from
+ * `Date.getTime()`, and a comparator that returns NaN leaves the sort order
+ * undefined — an invalid-timestamp SUCCESS could then win "newest" and select
+ * the WRONG digest (false lag or masked lag). We map an unparseable timestamp
+ * to `-Infinity` so it sorts to the BOTTOM and can never beat a valid SUCCESS.
+ * The determinism guarantee is: any valid-timestamp SUCCESS always wins "newest"
+ * over an invalid one, so a valid digest is never masked by a bogus timestamp.
+ * (The comparator is NOT NaN-free in every case — subtracting two `-Infinity`
+ * values yields NaN — but that only arises when EVERY SUCCESS has an invalid
+ * timestamp; there is no valid candidate to protect, and V8's stable sort then
+ * preserves input order, so the pick stays deterministic.)
+ */
+function successCreatedAtMs(edge: DeploymentEdge): number {
+  const t = new Date(edge.node.createdAt).getTime();
+  return Number.isNaN(t) ? -Infinity : t;
+}
+
+export function pickNewestSuccessDigest(
+  edges: DeploymentEdge[],
+): string | null {
+  const newest = edges
+    .filter((e) => e.node.status === "SUCCESS")
+    .sort((a, b) => successCreatedAtMs(b) - successCreatedAtMs(a))[0];
+  if (!newest) return null;
+  let meta = newest.node.meta;
+  if (typeof meta === "string") {
+    try {
+      meta = JSON.parse(meta);
+    } catch {
+      return null;
+    }
+  }
+  if (meta === null || typeof meta !== "object") return null;
+  const m = meta as { imageDigest?: unknown; image?: unknown };
+  let digest =
+    typeof m.imageDigest === "string" && m.imageDigest !== ""
+      ? m.imageDigest
+      : null;
+  if (
+    digest === null &&
+    typeof m.image === "string" &&
+    m.image.includes("@sha256:")
+  ) {
+    digest = m.image.split("@", 2)[1] ?? null;
+  }
+  return digest;
+}
+
+/**
+ * Read the digest the staging deployment is ACTUALLY running: the newest
+ * SUCCESS deployment's `meta.imageDigest`. Mirrors `showcase/bin/railway`'s
+ * `staging_running_digest`. Returns null when no SUCCESS deployment /
+ * imageDigest is available.
+ */
+async function liveFetchDeployedDigest(
+  token: string,
+  serviceId: string,
+  environmentId: string,
+): Promise<string | null> {
+  const res = await fetch(RAILWAY_API, {
+    method: "POST",
+    signal: AbortSignal.timeout(30_000),
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      // first:10 is a safe upper bound: a staging service's newest SUCCESS is
+      // effectively always among its 10 most-recent deployments (queued/failed
+      // attempts included). We do NOT rely on the connection's order — see
+      // pickNewestSuccessDigest, which sorts by createdAt.
+      query: `query Deployments($serviceId: String!, $environmentId: String!) {
+        deployments(first: 10, input: { serviceId: $serviceId, environmentId: $environmentId }) {
+          edges { node { id status meta createdAt } }
+        }
+      }`,
+      variables: { serviceId, environmentId },
+    }),
+  });
+  if (!res.ok) {
+    const body = sanitizeErrorBody(await res.text());
+    throw new Error(`Railway deployments query HTTP ${res.status}: ${body}`);
+  }
+  const json = (await res.json()) as {
+    data?: DeploymentsResponse;
+    errors?: Array<{ message: string }>;
+  };
+  if (json.errors?.length) {
+    throw new Error(
+      json.errors.map((e) => sanitizeErrorBody(e.message)).join("; "),
+    );
+  }
+  const edges = json.data?.deployments?.edges ?? [];
+  return pickNewestSuccessDigest(edges);
+}
+
+/**
+ * Post the reconcile alert to the shared #oss-alerts incoming webhook (the
+ * SAME `SLACK_WEBHOOK_OSS_ALERTS` secret showcase_build.yml posts through).
+ * Returns true ONLY when the alert actually delivered (a 2xx POST). A missing
+ * webhook, a non-2xx response, or a thrown request return false and are warned
+ * to stderr — the caller records this as `summary.alerted` so a swallowed
+ * alert never reads as a delivered one (and, alongside a real lag, fails the
+ * run loud per the exit-code contract).
+ */
+async function livePostSlackAlert(text: string): Promise<boolean> {
+  const webhook = (process.env.SLACK_WEBHOOK_OSS_ALERTS || "").trim();
+  if (!webhook) {
+    process.stderr.write(
+      "warning: SLACK_WEBHOOK_OSS_ALERTS is not set — skipping Slack alert\n",
+    );
+    return false;
+  }
+  try {
+    const res = await fetch(webhook, {
+      method: "POST",
+      signal: AbortSignal.timeout(15_000),
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text }),
+    });
+    if (!res.ok) {
+      process.stderr.write(
+        `warning: Slack webhook POST non-2xx (${res.status}) — alert may have been dropped\n`,
+      );
+      return false;
+    }
+    return true;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    process.stderr.write(`warning: Slack webhook POST failed (${msg})\n`);
+    return false;
+  }
+}
+
+async function main(): Promise<void> {
+  const token = getRailwayToken();
+  const redeploy = makeLiveRedeploy(token);
+
+  const deps: ReconcileDeps = {
+    fetchDeployedDigest: (serviceId, environmentId) =>
+      liveFetchDeployedDigest(token, serviceId, environmentId),
+    fetchLatestDigest: (repoName) => resolveGhcrDigest(repoName, "latest"),
+    redeployStaging: async (services) => {
+      const summary = await runRedeploy({
+        env: "staging",
+        services,
+        redeploy,
+        appendSummary: (line) => process.stderr.write(line + "\n"),
+      });
+      return {
+        attempted: summary.attempted,
+        succeeded: summary.succeeded,
+        failed: summary.failed,
+        records: summary.records,
+      };
+    },
+    postSlackAlert: livePostSlackAlert,
+  };
+
+  console.log(
+    `Reconciling staging against GHCR :latest (project ${PROJECT_ID})…`,
+  );
+  const summary = await reconcileStaging(deps);
+  console.log(
+    `\nchecked=${summary.checked} lagging=${summary.lagging.length} errors=${summary.errors.length} redeployed=${summary.redeployed} alerted=${summary.alerted} unconfirmed=${summary.unconfirmed.length} emptyScope=${summary.emptyScope}`,
+  );
+  if (summary.errors.length > 0) {
+    for (const e of summary.errors) {
+      console.error(`  digest-read error: ${e.service}: ${e.error}`);
+    }
+  }
+
+  const code = reconcileExitCode(summary);
+  if (code !== 0) {
+    // Fail loud so the scheduled run goes RED and the alert isn't the only
+    // signal (see the invariant in the file header). Every non-green cause
+    // flows through the ONE `unconfirmed` set, so report it directly.
+    if (summary.unconfirmed.length > 0) {
+      console.error(
+        `${summary.unconfirmed.length} staging service(s) NOT confirmed current (alerted=${summary.alerted}):`,
+      );
+      for (const u of summary.unconfirmed) {
+        console.error(`  unconfirmed: ${u.service}: ${u.reason}`);
+      }
+    } else if (summary.lagging.length > 0 && !summary.alerted) {
+      console.error(
+        `lag detected (${summary.lagging.join(", ")}) but the Slack alert did not deliver.`,
+      );
+    }
+  }
+  // The run is green ONLY when every in-scope service was confirmed current
+  // (or a lag was cleanly remediated AND its alert delivered). Any unconfirmed
+  // service fails the whole scheduled run — the self-heal is not allowed to
+  // read green while a staging service is unverified.
+  process.exit(code);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((e) => {
+    // Hard operator/config error (missing token, unreachable Railway, a bug in
+    // the wiring). Fail loud so the scheduled run goes red.
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/showcase/scripts/redeploy-env.ts
+++ b/showcase/scripts/redeploy-env.ts
@@ -179,11 +179,32 @@ export interface RunRedeployOpts {
   services?: string[];
 }
 
+/**
+ * A single per-service redeploy outcome. `status:"ok"` means Railway accepted
+ * the `serviceInstanceRedeploy` for that service; `status:"error"` carries the
+ * sanitized failure. Callers that must confirm a SPECIFIC service was actually
+ * redeployed (e.g. reconcile-staging's per-service remediation check) match on
+ * these records rather than the post-expansion `attempted` COUNT — imageOf
+ * expansion inflates `attempted` above the requested set, so a count alone can
+ * mask a dropped/failed service.
+ */
+export interface RedeployServiceRecord {
+  service: string;
+  status: "ok" | "error";
+  error?: string;
+}
+
 export interface RunRedeploySummary {
   exitCode: number;
   attempted: number;
   succeeded: number;
   failed: number;
+  /**
+   * Per-service outcomes for EVERY service the run attempted (post-expansion),
+   * in iteration order. Exposed so a caller can confirm remediation
+   * per-service instead of trusting the aggregate counts.
+   */
+  records: RedeployServiceRecord[];
 }
 
 /**
@@ -414,11 +435,7 @@ export async function runRedeploy(
   //   Array<{ service: string; status: "ok" | "error"; error?: string }>
   // Built in parallel with the existing `failures`/`succeeded` tallies so
   // PR #5093's exit-code computation below is untouched.
-  const records: Array<{
-    service: string;
-    status: "ok" | "error";
-    error?: string;
-  }> = [];
+  const records: RedeployServiceRecord[] = [];
   let succeeded = 0;
 
   appendSummary(`## Railway redeploy — env=${env}`);
@@ -532,7 +549,7 @@ export async function runRedeploy(
   // canary, …) inherits fatal semantics instead of silently swallowing
   // failures the way only staging is meant to.
   const exitCode = env !== "staging" && failed > 0 ? 1 : 0;
-  return { exitCode, attempted, succeeded, failed };
+  return { exitCode, attempted, succeeded, failed, records };
 }
 
 async function main(): Promise<void> {

--- a/showcase/scripts/redeploy-guard.test.ts
+++ b/showcase/scripts/redeploy-guard.test.ts
@@ -1,0 +1,291 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+
+// ---------------------------------------------------------------------------
+// Regression guard for the `redeploy-staging` job in
+// `.github/workflows/showcase_build.yml`.
+//
+// The bug: the job's `if:` guarded on `needs.build.result != 'cancelled'`.
+// GitHub Actions rolls a matrix job's aggregate `result` up to `cancelled`
+// whenever ANY single leg is cancelled — even if 27/28 legs succeeded. A
+// single leg cancelled by runner contention (NOT a run-level cancellation)
+// therefore skipped the staging redeploy for the ENTIRE fleet, even though
+// the downstream "Compute changed-service list" step correctly intersects the
+// build matrix with the actual per-slot successes.
+//
+// The correct signal for "should we redeploy?" is
+// `aggregate-build-results.outputs.any_success == 'true'` (computed from the
+// real per-slot build-result artifacts), exactly as the sibling
+// `aggregate-build-results` job already gates itself. This test encodes the
+// LIVE guard string from the workflow and evaluates it against a faithful
+// model of GitHub Actions' matrix→job result rollup.
+// ---------------------------------------------------------------------------
+
+const WORKFLOW_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  ".github",
+  "workflows",
+  "showcase_build.yml",
+);
+
+/** Read the LIVE `if:` expression of the given job from the workflow YAML. */
+function readJobGuard(jobId: string): string {
+  const doc = parseYaml(readFileSync(WORKFLOW_PATH, "utf8")) as {
+    jobs: Record<string, { if?: string }>;
+  };
+  const job = doc.jobs[jobId];
+  if (!job) throw new Error(`Job '${jobId}' not found in ${WORKFLOW_PATH}`);
+  if (typeof job.if !== "string") {
+    throw new Error(`Job '${jobId}' has no string 'if:' guard`);
+  }
+  return job.if;
+}
+
+// ---------------------------------------------------------------------------
+// A faithful (bounded-grammar) evaluator for the GitHub Actions `if:`
+// expressions this workflow uses: top-level `&&` chains of either a status
+// function (`cancelled()`/`always()`/`success()`/`failure()`, optionally
+// negated with `!`) or a `<context.path> ==|!= '<literal>'` comparison.
+// Context paths may contain hyphens (e.g. `needs.detect-changes.outputs.*`),
+// so we resolve them by splitting on `.` rather than relying on JS property
+// access.
+// ---------------------------------------------------------------------------
+
+interface GhContext {
+  needs: Record<string, unknown>;
+  /** Whether the WORKFLOW RUN was cancelled (drives `cancelled()`). */
+  runCancelled: boolean;
+}
+
+function resolvePath(path: string, ctx: GhContext): string {
+  const segs = path.split(".");
+  let cur: unknown = { needs: ctx.needs };
+  for (const seg of segs) {
+    if (cur == null || typeof cur !== "object" || !(seg in (cur as object))) {
+      throw new Error(`Unresolved context path '${path}' at segment '${seg}'`);
+    }
+    cur = (cur as Record<string, unknown>)[seg];
+  }
+  return String(cur);
+}
+
+function evalClause(raw: string, ctx: GhContext): boolean {
+  const clause = raw.trim();
+
+  const fn = clause.match(/^(!)?\s*(cancelled|always|success|failure)\(\)$/);
+  if (fn) {
+    const negated = fn[1] === "!";
+    let value: boolean;
+    switch (fn[2]) {
+      case "cancelled":
+        value = ctx.runCancelled;
+        break;
+      case "always":
+        value = true;
+        break;
+      case "success":
+        value = !ctx.runCancelled;
+        break;
+      case "failure":
+        value = false;
+        break;
+      default:
+        throw new Error(`Unhandled status function '${fn[2]}'`);
+    }
+    return negated ? !value : value;
+  }
+
+  const cmp = clause.match(/^(.+?)\s*(==|!=)\s*'([^']*)'$/);
+  if (cmp) {
+    const left = resolvePath(cmp[1].trim(), ctx);
+    const right = cmp[3];
+    return cmp[2] === "==" ? left === right : left !== right;
+  }
+
+  throw new Error(`Unparseable clause: '${clause}'`);
+}
+
+function evalGuard(expr: string, ctx: GhContext): boolean {
+  const inner = expr
+    .replace(/^\s*\$\{\{/, "")
+    .replace(/\}\}\s*$/, "")
+    .trim();
+  // No `||` and no `&&` nested inside parens in this grammar, so a top-level
+  // split on `&&` is sound.
+  return inner.split("&&").every((c) => evalClause(c, ctx));
+}
+
+// ---------------------------------------------------------------------------
+// Faithful model of GitHub Actions' matrix → job `result` rollup.
+//   - any leg cancelled              => 'cancelled'
+//   - else any leg failed            => 'failure'
+//   - else (all success/skipped)     => 'success'
+// ---------------------------------------------------------------------------
+function rollupBuildResult(legResults: readonly string[]): string {
+  if (legResults.includes("cancelled")) return "cancelled";
+  if (legResults.includes("failure")) return "failure";
+  return "success";
+}
+
+/**
+ * Build a GH context for the `redeploy-staging` guard from a set of per-leg
+ * build outcomes. `any_success` is derived from the real per-slot outcomes
+ * exactly as `aggregate-build-results` does (any leg == 'success').
+ * `runCancelled` models a RUN-level cancellation, which a single contention-
+ * cancelled leg does NOT trigger.
+ */
+function contextFor(
+  legResults: readonly string[],
+  opts: { runCancelled?: boolean; hasChanges?: boolean } = {},
+): GhContext {
+  const anySuccess = legResults.includes("success");
+  return {
+    runCancelled: opts.runCancelled ?? false,
+    needs: {
+      "detect-changes": {
+        outputs: { has_changes: String(opts.hasChanges ?? true) },
+      },
+      build: { result: rollupBuildResult(legResults) },
+      "aggregate-build-results": {
+        outputs: { any_success: String(anySuccess) },
+      },
+    },
+  };
+}
+
+/**
+ * Model the FULL GH job-dispatch decision, not just the boolean expression:
+ * a dependent job is auto-SKIPPED when a `needs` job did not succeed, UNLESS
+ * the `if:` contains a status-check function (`always`/`cancelled`/`success`/
+ * `failure`). Both the buggy and fixed guards here contain `!cancelled()`, so
+ * the expression is always evaluated — but we model the override rule anyway
+ * so the test stays honest if the guard ever drops its status function.
+ */
+function jobRuns(
+  guard: string,
+  ctx: GhContext,
+  buildJobKey = "build",
+): boolean {
+  const hasStatusFn = /\b(always|cancelled|success|failure)\(\)/.test(guard);
+  const buildResult = String(
+    (ctx.needs[buildJobKey] as { result: string }).result,
+  );
+  const depFailedOrCancelled =
+    buildResult === "failure" || buildResult === "cancelled";
+  if (depFailedOrCancelled && !hasStatusFn) return false;
+  return evalGuard(guard, ctx);
+}
+
+/**
+ * Build a GH context for the `redeploy-staging-starters` guard. Unlike the
+ * showcase job, the starter lane has NO aggregate `any_success` output: its
+ * job guard only sees `detect-starter-changes.has_changes` and
+ * `build-starters.result`. The zero-success safety lives DOWNSTREAM, at the
+ * redeploy step's `if: steps.changed.outputs.services != ''` guard (see
+ * `starterRedeployStepRuns`).
+ */
+function starterContextFor(
+  legResults: readonly string[],
+  opts: { runCancelled?: boolean; hasChanges?: boolean } = {},
+): GhContext {
+  return {
+    runCancelled: opts.runCancelled ?? false,
+    needs: {
+      "detect-starter-changes": {
+        outputs: { has_changes: String(opts.hasChanges ?? true) },
+      },
+      "build-starters": { result: rollupBuildResult(legResults) },
+    },
+  };
+}
+
+/**
+ * Model the starter redeploy STEP guard (`steps.changed.outputs.services !=
+ * ''`). The compute step intersects the starter matrix with the per-slot
+ * SUCCESS set, so the services CSV is non-empty iff at least one starter leg
+ * actually built. This is the starter lane's "no deploy on a dead build"
+ * guarantee — equivalent to the showcase lane's `any_success` job guard, just
+ * enforced one level down.
+ */
+function starterRedeployStepRuns(legResults: readonly string[]): boolean {
+  return legResults.includes("success");
+}
+
+describe("redeploy-staging guard — matrix cancellation regression", () => {
+  const guard = readJobGuard("redeploy-staging");
+
+  it("(a) redeploys when 27 legs succeed and 1 leg is cancelled (contention)", () => {
+    const legs = [...Array(27).fill("success"), "cancelled"];
+    // A single leg cancelled by runner contention does NOT cancel the run.
+    const ctx = contextFor(legs, { runCancelled: false });
+    expect(rollupBuildResult(legs)).toBe("cancelled"); // GH rolls up to cancelled
+    expect(jobRuns(guard, ctx)).toBe(true); // ...but the fleet still redeploys
+  });
+
+  it("(b) redeploys when all legs succeed", () => {
+    const legs = Array(28).fill("success");
+    expect(jobRuns(guard, contextFor(legs))).toBe(true);
+  });
+
+  it("(c) skips when the build is genuinely dead (zero successes)", () => {
+    const legs = Array(28).fill("failure");
+    expect(jobRuns(guard, contextFor(legs))).toBe(false);
+  });
+
+  it("skips a partial-success run only when the whole RUN is cancelled", () => {
+    const legs = [...Array(27).fill("success"), "cancelled"];
+    const ctx = contextFor(legs, { runCancelled: true });
+    expect(jobRuns(guard, ctx)).toBe(false);
+  });
+
+  it("skips when detect-changes reports no changes", () => {
+    const legs = Array(28).fill("success");
+    expect(jobRuns(guard, contextFor(legs, { hasChanges: false }))).toBe(false);
+  });
+});
+
+describe("redeploy-staging-starters guard — matrix cancellation regression", () => {
+  const guard = readJobGuard("redeploy-staging-starters");
+  const runStarters = (ctx: GhContext) => jobRuns(guard, ctx, "build-starters");
+
+  it("(a) runs (and redeploys) when 1 starter leg is cancelled and the rest succeed", () => {
+    const legs = [...Array(5).fill("success"), "cancelled"];
+    const ctx = starterContextFor(legs, { runCancelled: false });
+    expect(rollupBuildResult(legs)).toBe("cancelled"); // GH rolls up to cancelled
+    expect(runStarters(ctx)).toBe(true); // ...but the starter lane still runs
+    expect(starterRedeployStepRuns(legs)).toBe(true); // non-empty services CSV
+  });
+
+  it("(b) runs (and redeploys) when all starter legs succeed", () => {
+    const legs = Array(6).fill("success");
+    expect(runStarters(starterContextFor(legs))).toBe(true);
+    expect(starterRedeployStepRuns(legs)).toBe(true);
+  });
+
+  it("(c) the job may run on a zero-success build, but the redeploy step is a no-op (empty CSV)", () => {
+    for (const dead of [Array(6).fill("failure"), Array(6).fill("cancelled")]) {
+      // The zero-success safety is at the STEP level, not the job guard: the
+      // services CSV is empty, so `if: steps.changed.outputs.services != ''`
+      // skips the redeploy — nothing is deployed on a dead build.
+      expect(starterRedeployStepRuns(dead)).toBe(false);
+    }
+  });
+
+  it("skips when the whole RUN is cancelled", () => {
+    const legs = [...Array(5).fill("success"), "cancelled"];
+    const ctx = starterContextFor(legs, { runCancelled: true });
+    expect(runStarters(ctx)).toBe(false);
+  });
+
+  it("skips when detect-starter-changes reports no changes", () => {
+    const legs = Array(6).fill("success");
+    expect(runStarters(starterContextFor(legs, { hasChanges: false }))).toBe(
+      false,
+    );
+  });
+});

--- a/showcase/scripts/verify-autoupdates.test.ts
+++ b/showcase/scripts/verify-autoupdates.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkAutoUpdates,
+  expectedPolicyFor,
+  isLiveAutoUpdatesEnabled,
+  parseEnvironmentConfig,
+  runAutoUpdatesGate,
+  summarizeAutoUpdatesFailures,
+} from "./verify-autoupdates";
+import type {
+  AutoUpdatesGateEntry,
+  EnvironmentConfigJson,
+} from "./verify-autoupdates";
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+//
+// Faithful to the LIVE surface the CI gate reads at runtime: the
+// `Environment.config` JSON scalar, keyed `services.<serviceId>.source.
+// autoUpdates`, with Railway's ENABLED form `{ type: "minor" }` and the
+// DISABLED form being an absent/null autoUpdates block. The tests exercise the
+// exact comparison logic main() runs; the only substitution is the fetch
+// (fixtures instead of a live GraphQL read).
+
+const ENV_IDS = {
+  prod: "prod-env-id",
+  staging: "staging-env-id",
+} as const;
+
+// A tiny SSOT: two services, both expected "disabled" (the invariant every
+// real service satisfies).
+const SSOT: Record<string, AutoUpdatesGateEntry> = {
+  "showcase-mastra": {
+    serviceId: "svc-mastra",
+    environments: { prod: {}, staging: {} },
+    autoUpdates: "disabled",
+  },
+  "showcase-ag2": {
+    serviceId: "svc-ag2",
+    environments: { prod: {}, staging: {} },
+    autoUpdates: "disabled",
+  },
+};
+
+/** All-disabled live config for both envs → the GREEN world. */
+function allDisabledConfig(): Record<string, EnvironmentConfigJson> {
+  const cfg: EnvironmentConfigJson = {
+    services: {
+      "svc-mastra": { source: { autoUpdates: null } },
+      "svc-ag2": { source: {} },
+    },
+  };
+  return { "prod-env-id": cfg, "staging-env-id": cfg };
+}
+
+/** One service with auto-updates ENABLED in prod → the RED world. */
+function driftConfig(): Record<string, EnvironmentConfigJson> {
+  const stagingCfg: EnvironmentConfigJson = {
+    services: {
+      "svc-mastra": { source: { autoUpdates: null } },
+      "svc-ag2": { source: {} },
+    },
+  };
+  const prodCfg: EnvironmentConfigJson = {
+    services: {
+      // DRIFT: Railway auto-updates left enabled on this prod service.
+      "svc-mastra": { source: { autoUpdates: { type: "minor" } } },
+      "svc-ag2": { source: {} },
+    },
+  };
+  return { "prod-env-id": prodCfg, "staging-env-id": stagingCfg };
+}
+
+function fetcherFor(byEnvId: Record<string, EnvironmentConfigJson>) {
+  return async (envId: string): Promise<EnvironmentConfigJson> => {
+    const cfg = byEnvId[envId];
+    if (!cfg) throw new Error(`no fixture for env id ${envId}`);
+    return cfg;
+  };
+}
+
+// ── isLiveAutoUpdatesEnabled ──────────────────────────────────────────────
+
+describe("isLiveAutoUpdatesEnabled", () => {
+  it("treats absent/null/empty as disabled", () => {
+    expect(isLiveAutoUpdatesEnabled(undefined)).toBe(false);
+    expect(isLiveAutoUpdatesEnabled(null)).toBe(false);
+    expect(isLiveAutoUpdatesEnabled({})).toBe(false);
+    expect(isLiveAutoUpdatesEnabled({ type: "" })).toBe(false);
+    expect(isLiveAutoUpdatesEnabled({ type: "disabled" })).toBe(false);
+  });
+
+  it("treats a non-empty type as enabled", () => {
+    expect(isLiveAutoUpdatesEnabled({ type: "minor" })).toBe(true);
+    // A future enabled variant must still register as drift.
+    expect(isLiveAutoUpdatesEnabled({ type: "all" })).toBe(true);
+  });
+});
+
+// ── checkAutoUpdates (pure comparison) ────────────────────────────────────
+
+describe("checkAutoUpdates", () => {
+  it("passes when disabled is expected and live is disabled", () => {
+    expect(
+      checkAutoUpdates({
+        service: "s",
+        env: "prod",
+        expected: "disabled",
+        liveAutoUpdates: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("flags drift when disabled is expected but live is minor", () => {
+    const v = checkAutoUpdates({
+      service: "s",
+      env: "prod",
+      expected: "disabled",
+      liveAutoUpdates: { type: "minor" },
+    });
+    expect(v).not.toBeNull();
+    expect(v!.liveType).toBe("minor");
+    expect(v!.reason).toMatch(/ENABLED/);
+  });
+
+  it("flags drift when minor is expected but live is disabled", () => {
+    const v = checkAutoUpdates({
+      service: "s",
+      env: "staging",
+      expected: "minor",
+      liveAutoUpdates: null,
+    });
+    expect(v).not.toBeNull();
+    expect(v!.liveType).toBeNull();
+  });
+});
+
+describe("expectedPolicyFor", () => {
+  it("reads the SSOT field", () => {
+    expect(
+      expectedPolicyFor({
+        serviceId: "x",
+        environments: {},
+        autoUpdates: "minor",
+      }),
+    ).toBe("minor");
+  });
+
+  it("defaults to disabled when the SSOT field is absent", () => {
+    expect(expectedPolicyFor({ serviceId: "x", environments: {} })).toBe(
+      "disabled",
+    );
+  });
+});
+
+// ── runAutoUpdatesGate — RED / GREEN ──────────────────────────────────────
+
+describe("runAutoUpdatesGate — red/green", () => {
+  it("RED: reports drift and would exit non-zero when a live service is minor", async () => {
+    const result = await runAutoUpdatesGate({
+      services: SSOT,
+      envIds: ENV_IDS,
+      fetchEnvConfig: fetcherFor(driftConfig()),
+    });
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0]).toMatchObject({
+      service: "showcase-mastra",
+      env: "prod",
+      expected: "disabled",
+      liveType: "minor",
+    });
+    const summary = summarizeAutoUpdatesFailures(result);
+    expect(summary.shouldFail).toBe(true);
+    expect(summary.lines.join("\n")).toMatch(/autoUpdates drift detected/);
+  });
+
+  it("GREEN: no violations and would exit zero when all services are disabled", async () => {
+    const result = await runAutoUpdatesGate({
+      services: SSOT,
+      envIds: ENV_IDS,
+      fetchEnvConfig: fetcherFor(allDisabledConfig()),
+    });
+    expect(result.violations).toHaveLength(0);
+    expect(result.checked).toBe(4); // 2 services × 2 envs
+    const summary = summarizeAutoUpdatesFailures(result);
+    expect(summary.shouldFail).toBe(false);
+    expect(summary.lines).toEqual([]);
+  });
+
+  it("skips (does not fail) a service absent from an env's live config", async () => {
+    const cfg: EnvironmentConfigJson = {
+      services: { "svc-ag2": { source: {} } }, // mastra missing entirely
+    };
+    const result = await runAutoUpdatesGate({
+      services: SSOT,
+      envIds: ENV_IDS,
+      fetchEnvConfig: fetcherFor({
+        "prod-env-id": cfg,
+        "staging-env-id": cfg,
+      }),
+    });
+    expect(result.violations).toHaveLength(0);
+    expect(result.checked).toBe(2); // only ag2, both envs
+    expect(result.skipped).toBe(2); // mastra skipped in both envs
+  });
+});
+
+// ── Fail-closed floor: zero-checked must never report green ────────────────
+//
+// The gate reported "✓ verified across 0 services" (exit 0) whenever the live
+// config yielded no comparable services — empty/absent/string-form config,
+// wrong project scope, or all-skipped. A drift gate that verified NOTHING must
+// fail, not silently pass. (RED before the floor: shouldFail was false.)
+
+describe("summarizeAutoUpdatesFailures — zero-checked floor", () => {
+  it("FAILS when zero service/env pairs were checked (no false green)", () => {
+    const summary = summarizeAutoUpdatesFailures({
+      violations: [],
+      checked: 0,
+      skipped: 6,
+    });
+    expect(summary.shouldFail).toBe(true);
+    expect(summary.lines.join("\n")).toMatch(/ZERO service\/env pairs/);
+    expect(summary.lines.join("\n")).toMatch(/refusing to report success/);
+  });
+
+  it("still passes cleanly when at least one pair was checked and clean", () => {
+    const summary = summarizeAutoUpdatesFailures({
+      violations: [],
+      checked: 4,
+      skipped: 0,
+    });
+    expect(summary.shouldFail).toBe(false);
+    expect(summary.lines).toEqual([]);
+  });
+});
+
+// ── Per-env fail-closed floor: a healthy env must not mask a starved env ────
+//
+// The zero-checked floor was GLOBAL: if ONE env returned an empty/absent
+// Environment.config, all of that env's services were silently skipped while a
+// healthy OTHER env kept `checked>0` and the gate green — so drift in the
+// broken env went unverified. The floor is now PER-ENV: every queried env that
+// expected to check services must verify >0 of them, else the gate fails and
+// names the starved env. (RED before the per-env floor: shouldFail was false
+// because the healthy env kept the global checked count positive.)
+
+describe("runAutoUpdatesGate + summary — per-env fail-closed floor", () => {
+  it("FAILS naming the starved env when one env is healthy but another's config is empty", async () => {
+    const healthy: EnvironmentConfigJson = {
+      services: {
+        "svc-mastra": { source: { autoUpdates: null } },
+        "svc-ag2": { source: {} },
+      },
+    };
+    const emptyEnv: EnvironmentConfigJson = { services: {} };
+    const result = await runAutoUpdatesGate({
+      services: SSOT,
+      envIds: ENV_IDS,
+      // env A (staging) healthy, env B (prod) empty/absent config.
+      fetchEnvConfig: fetcherFor({
+        "staging-env-id": healthy,
+        "prod-env-id": emptyEnv,
+      }),
+    });
+    // The healthy env keeps the GLOBAL checked count positive, so the old
+    // global-only floor passed green here — the per-env floor must still fail.
+    expect(result.checked).toBeGreaterThan(0);
+    const summary = summarizeAutoUpdatesFailures(result);
+    expect(summary.shouldFail).toBe(true);
+    // The failure must name the starved env (prod), not the healthy one.
+    expect(summary.lines.join("\n")).toMatch(/\[prod\]/);
+    expect(summary.lines.join("\n")).not.toMatch(/\[staging\]/);
+  });
+});
+
+describe("runAutoUpdatesGate + summary — zero-checked floor end-to-end", () => {
+  it("FAILS when the live config has an empty/absent services map", async () => {
+    // Empty services map for both envs → every pair skipped → checked===0.
+    const empty: EnvironmentConfigJson = { services: {} };
+    const result = await runAutoUpdatesGate({
+      services: SSOT,
+      envIds: ENV_IDS,
+      fetchEnvConfig: fetcherFor({
+        "prod-env-id": empty,
+        "staging-env-id": empty,
+      }),
+    });
+    expect(result.checked).toBe(0);
+    // Pre-fix this reported shouldFail=false (false green); post-fix it fails.
+    expect(summarizeAutoUpdatesFailures(result).shouldFail).toBe(true);
+  });
+});
+
+// ── String-form Environment.config must be parsed, not silently skipped ─────
+//
+// Railway's `environment(id){config}` JSON scalar can arrive as a JSON STRING.
+// The old code cast it `as EnvironmentConfigJson`, so `.services` was undefined
+// and every service was skipped (checked===0) — a false green once combined
+// with the missing floor. The gate now normalizes via parseEnvironmentConfig.
+// (RED before the fix: checked===0 / skipped===4 because the string was never
+// parsed.)
+
+describe("string-form Environment.config", () => {
+  it("parses a JSON-string config so services are actually checked", async () => {
+    const cfgObj: EnvironmentConfigJson = {
+      services: {
+        "svc-mastra": { source: { autoUpdates: null } },
+        "svc-ag2": { source: {} },
+      },
+    };
+    const asString = JSON.stringify(cfgObj);
+    const result = await runAutoUpdatesGate({
+      services: SSOT,
+      envIds: ENV_IDS,
+      // Live GraphQL sometimes returns the JSON scalar as a string.
+      fetchEnvConfig: async () => asString,
+    });
+    expect(result.violations).toHaveLength(0);
+    expect(result.checked).toBe(4); // 2 services × 2 envs — parsed, not skipped
+    expect(result.skipped).toBe(0);
+    expect(summarizeAutoUpdatesFailures(result).shouldFail).toBe(false);
+  });
+
+  it("catches drift carried in a JSON-string config", async () => {
+    const prod = JSON.stringify({
+      services: {
+        "svc-mastra": { source: { autoUpdates: { type: "minor" } } },
+        "svc-ag2": { source: {} },
+      },
+    });
+    const staging = JSON.stringify({
+      services: {
+        "svc-mastra": { source: { autoUpdates: null } },
+        "svc-ag2": { source: {} },
+      },
+    });
+    const byEnv: Record<string, string> = {
+      "prod-env-id": prod,
+      "staging-env-id": staging,
+    };
+    const result = await runAutoUpdatesGate({
+      services: SSOT,
+      envIds: ENV_IDS,
+      fetchEnvConfig: async (envId: string) => byEnv[envId],
+    });
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0]).toMatchObject({
+      service: "showcase-mastra",
+      env: "prod",
+      liveType: "minor",
+    });
+  });
+});
+
+describe("parseEnvironmentConfig", () => {
+  it("passes objects through unchanged", () => {
+    const obj: EnvironmentConfigJson = { services: { a: { source: {} } } };
+    expect(parseEnvironmentConfig(obj)).toBe(obj);
+  });
+
+  it("parses JSON strings", () => {
+    expect(parseEnvironmentConfig('{"services":{"a":{"source":{}}}}')).toEqual({
+      services: { a: { source: {} } },
+    });
+  });
+
+  it("treats null/undefined as an empty config (floor then catches it)", () => {
+    expect(parseEnvironmentConfig(null)).toEqual({});
+    expect(parseEnvironmentConfig(undefined)).toEqual({});
+  });
+
+  it("fails loud on invalid JSON strings", () => {
+    expect(() => parseEnvironmentConfig("{not json")).toThrow(/not valid JSON/);
+  });
+
+  it("fails loud on a non-object JSON scalar", () => {
+    expect(() => parseEnvironmentConfig("42")).toThrow(/non-object/);
+  });
+
+  it("fails loud on an unexpected scalar type", () => {
+    expect(() => parseEnvironmentConfig(42)).toThrow(/unexpected type/);
+  });
+});

--- a/showcase/scripts/verify-autoupdates.test.ts
+++ b/showcase/scripts/verify-autoupdates.test.ts
@@ -26,18 +26,35 @@ const ENV_IDS = {
   staging: "staging-env-id",
 } as const;
 
-// A tiny SSOT: two services, both expected "disabled" (the invariant every
-// real service satisfies).
+// A tiny SSOT: two services, both MANAGED-"disabled" in BOTH envs (a
+// fully-managed fleet — exercises the general disabled-vs-minor comparison in
+// both envs). autoUpdates is per-env, keyed by the same env names as
+// `environments`.
 const SSOT: Record<string, AutoUpdatesGateEntry> = {
   "showcase-mastra": {
     serviceId: "svc-mastra",
     environments: { prod: {}, staging: {} },
-    autoUpdates: "disabled",
+    autoUpdates: { prod: "disabled", staging: "disabled" },
   },
   "showcase-ag2": {
     serviceId: "svc-ag2",
     environments: { prod: {}, staging: {} },
-    autoUpdates: "disabled",
+    autoUpdates: { prod: "disabled", staging: "disabled" },
+  },
+};
+
+// The staging-first SSOT: staging is MANAGED-"disabled" (enforced) while prod
+// is "unmanaged" (the gate skips it entirely). This is the live rollout shape.
+const SSOT_STAGING_FIRST: Record<string, AutoUpdatesGateEntry> = {
+  "showcase-mastra": {
+    serviceId: "svc-mastra",
+    environments: { prod: {}, staging: {} },
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+  },
+  "showcase-ag2": {
+    serviceId: "svc-ag2",
+    environments: { prod: {}, staging: {} },
+    autoUpdates: { staging: "disabled", prod: "unmanaged" },
   },
 };
 
@@ -135,20 +152,33 @@ describe("checkAutoUpdates", () => {
 });
 
 describe("expectedPolicyFor", () => {
-  it("reads the SSOT field", () => {
+  it("reads the per-env SSOT field for the requested env", () => {
     expect(
-      expectedPolicyFor({
-        serviceId: "x",
-        environments: {},
-        autoUpdates: "minor",
-      }),
+      expectedPolicyFor(
+        {
+          serviceId: "x",
+          environments: { prod: {}, staging: {} },
+          autoUpdates: { prod: "minor", staging: "disabled" },
+        },
+        "prod",
+      ),
     ).toBe("minor");
   });
 
+  it("resolves the 'unmanaged' sentinel for the requested env", () => {
+    const entry: AutoUpdatesGateEntry = {
+      serviceId: "x",
+      environments: { prod: {}, staging: {} },
+      autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    };
+    expect(expectedPolicyFor(entry, "staging")).toBe("disabled");
+    expect(expectedPolicyFor(entry, "prod")).toBe("unmanaged");
+  });
+
   it("defaults to disabled when the SSOT field is absent", () => {
-    expect(expectedPolicyFor({ serviceId: "x", environments: {} })).toBe(
-      "disabled",
-    );
+    expect(
+      expectedPolicyFor({ serviceId: "x", environments: {} }, "prod"),
+    ).toBe("disabled");
   });
 });
 
@@ -201,6 +231,139 @@ describe("runAutoUpdatesGate — red/green", () => {
     expect(result.violations).toHaveLength(0);
     expect(result.checked).toBe(2); // only ag2, both envs
     expect(result.skipped).toBe(2); // mastra skipped in both envs
+  });
+});
+
+// ── Staging-first per-env rollout: enforce staging, skip unmanaged prod ─────
+//
+// autoUpdates is per-env. Staging is MANAGED-"disabled" (the gate enforces it:
+// a live-minor staging service is a violation). Prod is "unmanaged" — the gate
+// does NOT check it AT ALL, so prod's heterogeneous live autoUpdates (some
+// minor, some disabled) produce ZERO violations and do not trip the per-env
+// zero-checked floor (an unmanaged env is not counted as expected).
+
+describe("runAutoUpdatesGate — staging-first per-env rollout", () => {
+  it("(a) MANAGED staging with a live-minor service ⇒ violation", async () => {
+    // staging: mastra minor (drift). prod: all disabled (but prod is unmanaged
+    // anyway). Exactly one violation, in staging.
+    const staging: EnvironmentConfigJson = {
+      services: {
+        "svc-mastra": { source: { autoUpdates: { type: "minor" } } },
+        "svc-ag2": { source: {} },
+      },
+    };
+    const prod: EnvironmentConfigJson = {
+      services: {
+        "svc-mastra": { source: { autoUpdates: null } },
+        "svc-ag2": { source: {} },
+      },
+    };
+    const result = await runAutoUpdatesGate({
+      services: SSOT_STAGING_FIRST,
+      envIds: ENV_IDS,
+      fetchEnvConfig: fetcherFor({
+        "staging-env-id": staging,
+        "prod-env-id": prod,
+      }),
+    });
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0]).toMatchObject({
+      service: "showcase-mastra",
+      env: "staging",
+      expected: "disabled",
+      liveType: "minor",
+    });
+    // Prod is unmanaged → not checked; only the 2 staging services are.
+    expect(result.checked).toBe(2);
+    const summary = summarizeAutoUpdatesFailures(result);
+    expect(summary.shouldFail).toBe(true);
+    expect(summary.lines.join("\n")).toMatch(/\[staging\]/);
+  });
+
+  it("(b) UNMANAGED prod with a live-minor service ⇒ NOT flagged (skipped)", async () => {
+    // Both envs carry a live-minor mastra. Staging (managed) ⇒ violation;
+    // prod (unmanaged) ⇒ NOT flagged, and prod is not even counted/checked.
+    const minorCfg: EnvironmentConfigJson = {
+      services: {
+        "svc-mastra": { source: { autoUpdates: { type: "minor" } } },
+        "svc-ag2": { source: { autoUpdates: { type: "minor" } } },
+      },
+    };
+    const result = await runAutoUpdatesGate({
+      services: SSOT_STAGING_FIRST,
+      envIds: ENV_IDS,
+      fetchEnvConfig: fetcherFor({
+        "staging-env-id": minorCfg,
+        "prod-env-id": minorCfg,
+      }),
+    });
+    // No prod violations despite prod being live-minor for BOTH services.
+    expect(result.violations.every((v) => v.env !== "prod")).toBe(true);
+    // Both staging services are flagged; prod produced nothing.
+    expect(result.violations).toHaveLength(2);
+    expect(result.violations.map((v) => v.env)).toEqual(["staging", "staging"]);
+    // Prod is unmanaged → not counted as expected, not checked.
+    expect(result.perEnv?.prod).toEqual({
+      expected: 0,
+      checked: 0,
+      skipped: 0,
+    });
+    // The starvation floor must NOT fire for the unmanaged prod env.
+    const summary = summarizeAutoUpdatesFailures(result);
+    expect(summary.lines.join("\n")).not.toMatch(/\[prod\]/);
+  });
+
+  it("(b') all-unmanaged prod is entirely skipped and never trips the floor", async () => {
+    // Even when prod's live config is EMPTY, an unmanaged prod produces no
+    // starvation failure (it is not expected). A clean managed staging passes.
+    const stagingClean: EnvironmentConfigJson = {
+      services: {
+        "svc-mastra": { source: { autoUpdates: null } },
+        "svc-ag2": { source: {} },
+      },
+    };
+    const prodEmpty: EnvironmentConfigJson = { services: {} };
+    const result = await runAutoUpdatesGate({
+      services: SSOT_STAGING_FIRST,
+      envIds: ENV_IDS,
+      fetchEnvConfig: fetcherFor({
+        "staging-env-id": stagingClean,
+        "prod-env-id": prodEmpty,
+      }),
+    });
+    expect(result.violations).toHaveLength(0);
+    expect(result.perEnv?.prod).toEqual({
+      expected: 0,
+      checked: 0,
+      skipped: 0,
+    });
+    expect(summarizeAutoUpdatesFailures(result).shouldFail).toBe(false);
+  });
+
+  it("(c) MANAGED staging that verifies ZERO services ⇒ floor fails (named)", async () => {
+    // Staging is managed (expected>0) but its live config is empty ⇒ checked 0
+    // for a managed env ⇒ the per-env floor fails and names [staging]. Prod is
+    // unmanaged, so it neither contributes nor masks the failure.
+    const stagingEmpty: EnvironmentConfigJson = { services: {} };
+    const prodMinor: EnvironmentConfigJson = {
+      services: {
+        "svc-mastra": { source: { autoUpdates: { type: "minor" } } },
+        "svc-ag2": { source: {} },
+      },
+    };
+    const result = await runAutoUpdatesGate({
+      services: SSOT_STAGING_FIRST,
+      envIds: ENV_IDS,
+      fetchEnvConfig: fetcherFor({
+        "staging-env-id": stagingEmpty,
+        "prod-env-id": prodMinor,
+      }),
+    });
+    const summary = summarizeAutoUpdatesFailures(result);
+    expect(summary.shouldFail).toBe(true);
+    expect(summary.lines.join("\n")).toMatch(/\[staging\]/);
+    // Prod (unmanaged) must not be named as starved.
+    expect(summary.lines.join("\n")).not.toMatch(/\[prod\]/);
   });
 });
 

--- a/showcase/scripts/verify-autoupdates.ts
+++ b/showcase/scripts/verify-autoupdates.ts
@@ -46,14 +46,17 @@ const RAILWAY_API = RAILWAY_GRAPHQL_ENDPOINT;
 /**
  * Auto-updates policy vocabulary. Mirrors the `AutoUpdatesPolicy` type the SSOT
  * (`railway-envs.ts`) exports:
- *   - "disabled" — Railway source auto-updates OFF (the target for EVERY
- *     service). Live shape: `autoUpdates` absent/null, or `type` falsy.
- *   - "minor"    — Railway's ENABLED form (`source.autoUpdates.type = "minor"`).
+ *   - "disabled"  — Railway source auto-updates OFF (the MANAGED target this
+ *     gate enforces). Live shape: `autoUpdates` absent/null, or `type` falsy.
+ *   - "minor"     — Railway's ENABLED form (`source.autoUpdates.type = "minor"`).
+ *   - "unmanaged" — NOT yet under drift-gate management. The gate SKIPS an
+ *     "unmanaged" env entirely (no read, no compare, no flag) and does not
+ *     count it toward the zero-checked floor.
  *
  * Declared locally (not imported) so this gate compiles standalone even before
  * the SSOT field lands in this worktree; the two definitions are identical.
  */
-export type AutoUpdatesPolicy = "disabled" | "minor";
+export type AutoUpdatesPolicy = "disabled" | "minor" | "unmanaged";
 
 /**
  * Shape of a single service's `source.autoUpdates` inside the
@@ -122,7 +125,13 @@ export function parseEnvironmentConfig(raw: unknown): EnvironmentConfigJson {
 export interface AutoUpdatesGateEntry {
   serviceId: string;
   environments: Record<string, unknown>;
-  autoUpdates?: AutoUpdatesPolicy;
+  /**
+   * Per-env auto-updates policy, keyed by the same env names as
+   * `environments`. Structural subset of the SSOT `AutoUpdatesByEnv`. Optional
+   * so the gate compiles/behaves whether or not the SSOT field is present;
+   * `expectedPolicyFor` defaults a missing env to "disabled".
+   */
+  autoUpdates?: Record<string, AutoUpdatesPolicy>;
 }
 
 export interface AutoUpdatesViolation {
@@ -189,16 +198,17 @@ export function checkAutoUpdates(params: {
 }
 
 /**
- * Resolve the SSOT auto-updates expectation for an entry. Reads the SSOT
- * `autoUpdates` field; defaults to "disabled" when absent (the invariant every
- * service satisfies) so the gate is correct both before and after the SSOT
- * field lands. Structural typing lets real `SERVICES` entries flow in whether
- * or not `ServiceEntry` declares the field yet.
+ * Resolve the SSOT auto-updates expectation for an entry in a SPECIFIC env.
+ * Reads the per-env SSOT `autoUpdates[env]` policy; defaults to "disabled"
+ * when absent (the managed invariant) so the gate is correct both before and
+ * after the SSOT field lands. Structural typing lets real `SERVICES` entries
+ * flow in whether or not `ServiceEntry` declares the field yet.
  */
 export function expectedPolicyFor(
   entry: AutoUpdatesGateEntry,
+  env: EnvName,
 ): AutoUpdatesPolicy {
-  return entry.autoUpdates ?? "disabled";
+  return entry.autoUpdates?.[env] ?? "disabled";
 }
 
 /**
@@ -268,6 +278,13 @@ export async function runAutoUpdatesGate(deps: {
       // (matching reconcile-staging.ts) so a declared-but-falsy env value is
       // still asserted rather than silently skipped.
       if (!Object.hasOwn(entry.environments, env)) continue;
+      const expected = expectedPolicyFor(entry, env);
+      // "unmanaged" env: NOT under drift-gate management. Skip it ENTIRELY —
+      // do not read/compare the live value, and do not count it toward the
+      // per-env floor (`expected`) or the global tallies. This is how prod
+      // stays untouched during a staging-first rollout: its heterogeneous
+      // live autoUpdates produce zero violations and never trip the floor.
+      if (expected === "unmanaged") continue;
       stats.expected++;
       const liveSvc = liveServices[entry.serviceId];
       if (!liveSvc) {
@@ -281,7 +298,7 @@ export async function runAutoUpdatesGate(deps: {
       const v = checkAutoUpdates({
         service: name,
         env,
-        expected: expectedPolicyFor(entry),
+        expected,
         liveAutoUpdates: liveSvc.source?.autoUpdates,
       });
       if (v) violations.push(v);

--- a/showcase/scripts/verify-autoupdates.ts
+++ b/showcase/scripts/verify-autoupdates.ts
@@ -1,0 +1,467 @@
+#!/usr/bin/env npx tsx
+/**
+ * verify-autoupdates.ts — Live Railway `autoUpdates` drift gate.
+ *
+ * Every showcase service in the CopilotKit Railway project must have Railway
+ * source auto-updates DISABLED: the deploy pipeline is the ONLY thing allowed
+ * to move an image (staging floats `:latest` via CI redeploy, prod is
+ * digest-pinned via `bin/railway promote`). If Railway's own auto-update
+ * feature is enabled on a service (`source.autoUpdates.type = "minor"`), the
+ * platform silently re-pulls upstream image changes out-of-band — exactly the
+ * class of unmanaged mutation that produced the April→June image drift the
+ * sibling gate (`verify-railway-image-refs.ts`) was written to catch after the
+ * fact. This gate catches the *cause* (auto-updates left enabled) rather than
+ * the *symptom* (a drifted ref).
+ *
+ * SSOT expectation: `railway-envs.ts` carries a required per-service
+ * `autoUpdates` policy field (added alongside this gate); every service is
+ * `"disabled"`. This gate does NOT hardcode the service list — it reads the
+ * expectation from the SSOT and compares it against the LIVE Railway value.
+ *
+ * Live value source: `autoUpdates` is NOT exposed on the typed `ServiceSource`
+ * GraphQL output. It lives in the `Environment.config` JSON scalar (the same
+ * staged-config blob that carries `deploy.multiRegionConfig`), under
+ * `services.<serviceId>.source.autoUpdates`. We therefore read
+ * `environment(id){ config }` once per env and index into that JSON by
+ * serviceId.
+ *
+ * Usage:
+ *   npx tsx showcase/scripts/verify-autoupdates.ts
+ *
+ * Requires: RAILWAY_TOKEN env var or ~/.railway/config.json
+ * Exit: 0 when every service matches the SSOT expectation; 1 on any drift.
+ */
+
+import { fileURLToPath } from "url";
+import { ENV_ID_BY_NAME, SERVICES } from "./railway-envs";
+import type { EnvName } from "./railway-envs";
+import {
+  RAILWAY_GRAPHQL_ENDPOINT,
+  sanitizeErrorBody,
+} from "./lib/railway-graphql";
+import { RailwayTokenError, resolveRailwayToken } from "./lib/railway-token";
+
+const RAILWAY_API = RAILWAY_GRAPHQL_ENDPOINT;
+
+/**
+ * Auto-updates policy vocabulary. Mirrors the `AutoUpdatesPolicy` type the SSOT
+ * (`railway-envs.ts`) exports:
+ *   - "disabled" — Railway source auto-updates OFF (the target for EVERY
+ *     service). Live shape: `autoUpdates` absent/null, or `type` falsy.
+ *   - "minor"    — Railway's ENABLED form (`source.autoUpdates.type = "minor"`).
+ *
+ * Declared locally (not imported) so this gate compiles standalone even before
+ * the SSOT field lands in this worktree; the two definitions are identical.
+ */
+export type AutoUpdatesPolicy = "disabled" | "minor";
+
+/**
+ * Shape of a single service's `source.autoUpdates` inside the
+ * `Environment.config` JSON scalar. Railway omits the object (or sets it null)
+ * when auto-updates are off; when on it carries `{ type: "minor" }`.
+ */
+export interface LiveAutoUpdates {
+  type?: string | null;
+}
+
+/** Per-service slice of the `Environment.config` JSON we care about. */
+export interface LiveServiceConfig {
+  source?: { autoUpdates?: LiveAutoUpdates | null } | null;
+}
+
+/** The `Environment.config` JSON scalar (only the `services` map is read). */
+export interface EnvironmentConfigJson {
+  services?: Record<string, LiveServiceConfig> | null;
+}
+
+/**
+ * Normalize the raw `Environment.config` value into the typed slice we index
+ * into. Railway's GraphQL JSON scalar is USUALLY returned already-parsed (an
+ * object), but can come back as a JSON *string* depending on client/transport.
+ * A blind `as EnvironmentConfigJson` cast on a string leaves `.services`
+ * undefined, which makes every service silently skip (checked===0) and — absent
+ * the zero-checked floor — report a false green. So parse strings, and fail
+ * loud on anything that is neither an object nor valid JSON, rather than
+ * silently degrading to an empty config.
+ */
+export function parseEnvironmentConfig(raw: unknown): EnvironmentConfigJson {
+  if (raw === null || raw === undefined) return {};
+  if (typeof raw === "string") {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (e) {
+      throw new Error(
+        `Railway Environment.config was a string but is not valid JSON: ${
+          e instanceof Error ? e.message : String(e)
+        }`,
+        { cause: e },
+      );
+    }
+    if (typeof parsed !== "object" || parsed === null) {
+      throw new Error(
+        `Railway Environment.config parsed to a non-object (${typeof parsed}); expected the staged-config JSON object.`,
+      );
+    }
+    return parsed as EnvironmentConfigJson;
+  }
+  if (typeof raw === "object") return raw as EnvironmentConfigJson;
+  throw new Error(
+    `Railway Environment.config had unexpected type "${typeof raw}"; expected an object or JSON string.`,
+  );
+}
+
+/**
+ * Minimal SSOT entry shape this gate consumes. A structural subset of
+ * `ServiceEntry` (plus the `autoUpdates` policy field the SSOT adds) so the
+ * gate can be driven by fixtures in tests WITHOUT depending on the full
+ * `ServiceEntry` interface — and so it compiles whether or not the SSOT field
+ * is present in this worktree yet (real `SERVICES` entries are assignable
+ * either way).
+ */
+export interface AutoUpdatesGateEntry {
+  serviceId: string;
+  environments: Record<string, unknown>;
+  autoUpdates?: AutoUpdatesPolicy;
+}
+
+export interface AutoUpdatesViolation {
+  service: string;
+  env: EnvName;
+  expected: AutoUpdatesPolicy;
+  /** Raw live `autoUpdates.type` (null when disabled/absent). */
+  liveType: string | null;
+  reason: string;
+}
+
+/**
+ * True iff the live `autoUpdates` block represents an ENABLED auto-update.
+ * Any present, non-empty `type` that is not the explicit "disabled" marker
+ * counts as enabled — so a future enabled variant (e.g. "all"/"patch") is
+ * still caught as drift rather than silently passing.
+ */
+export function isLiveAutoUpdatesEnabled(
+  raw: LiveAutoUpdates | null | undefined,
+): boolean {
+  const t = raw?.type;
+  return typeof t === "string" && t.length > 0 && t !== "disabled";
+}
+
+/**
+ * Pure, unit-testable comparison. Returns null when the live value matches the
+ * SSOT expectation, or an AutoUpdatesViolation describing the drift.
+ */
+export function checkAutoUpdates(params: {
+  service: string;
+  env: EnvName;
+  expected: AutoUpdatesPolicy;
+  liveAutoUpdates: LiveAutoUpdates | null | undefined;
+}): AutoUpdatesViolation | null {
+  const { service, env, expected, liveAutoUpdates } = params;
+  const enabled = isLiveAutoUpdatesEnabled(liveAutoUpdates);
+  const liveType = liveAutoUpdates?.type ? liveAutoUpdates.type : null;
+
+  if (expected === "disabled" && enabled) {
+    return {
+      service,
+      env,
+      expected,
+      liveType,
+      reason: `Railway source auto-updates are ENABLED (autoUpdates.type=${JSON.stringify(
+        liveType,
+      )}) but the SSOT requires "disabled". Disable auto-updates on this service in the Railway dashboard (Service → Settings → Source → Automatic deployments) so only the deploy pipeline moves the image.`,
+    };
+  }
+
+  if (expected === "minor" && !enabled) {
+    return {
+      service,
+      env,
+      expected,
+      liveType,
+      reason: `SSOT expects auto-updates "minor" but Railway reports them disabled (autoUpdates.type=${JSON.stringify(
+        liveType,
+      )}).`,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the SSOT auto-updates expectation for an entry. Reads the SSOT
+ * `autoUpdates` field; defaults to "disabled" when absent (the invariant every
+ * service satisfies) so the gate is correct both before and after the SSOT
+ * field lands. Structural typing lets real `SERVICES` entries flow in whether
+ * or not `ServiceEntry` declares the field yet.
+ */
+export function expectedPolicyFor(
+  entry: AutoUpdatesGateEntry,
+): AutoUpdatesPolicy {
+  return entry.autoUpdates ?? "disabled";
+}
+
+/**
+ * Per-environment check tally. `expected` = SSOT services that declare this
+ * env; `checked` = of those, how many were present in the env's live config
+ * and actually compared; `skipped` = declared-but-absent-from-live. An env with
+ * `expected > 0` but `checked === 0` means its live `Environment.config` yielded
+ * nothing comparable (empty/absent config, wrong project scope) — that env's
+ * drift went unverified and the gate must fail even if a sibling env is healthy.
+ */
+export interface EnvCheckStats {
+  expected: number;
+  checked: number;
+  skipped: number;
+}
+
+export interface GateResult {
+  violations: AutoUpdatesViolation[];
+  checked: number;
+  skipped: number;
+  /**
+   * Per-env tallies, keyed by env name — drives the per-env fail-closed floor.
+   * Optional so callers that only build the global counters (e.g. legacy
+   * fixtures) still type-check; `summarizeAutoUpdatesFailures` falls back to the
+   * global `checked===0` floor when it is absent. `runAutoUpdatesGate` always
+   * populates it.
+   */
+  perEnv?: Record<string, EnvCheckStats>;
+}
+
+/**
+ * Fetches the RAW `Environment.config` value for one env id (object, JSON
+ * string, or absent — exactly what the GraphQL scalar yields). The gate
+ * normalizes it via `parseEnvironmentConfig`. Injectable.
+ */
+export type EnvConfigFetcher = (envId: string) => Promise<unknown>;
+
+/**
+ * Core gate — fully injectable so tests drive it with fixtures (no live
+ * Railway, no dependency on the SSOT file). For every SSOT service, in every
+ * env it declares, reads the live `autoUpdates` from that env's config and
+ * compares it to the SSOT expectation. A service absent from an env's live
+ * config is skipped (cannot assert), not failed.
+ */
+export async function runAutoUpdatesGate(deps: {
+  services: Record<string, AutoUpdatesGateEntry>;
+  envIds: Record<EnvName, string>;
+  fetchEnvConfig: EnvConfigFetcher;
+}): Promise<GateResult> {
+  const { services, envIds, fetchEnvConfig } = deps;
+  const violations: AutoUpdatesViolation[] = [];
+  let checked = 0;
+  let skipped = 0;
+  const perEnv: Record<string, EnvCheckStats> = {};
+
+  // Sorted env names for stable, deterministic output ordering.
+  for (const env of Object.keys(envIds).sort()) {
+    const envId = envIds[env];
+    const config = parseEnvironmentConfig(await fetchEnvConfig(envId));
+    const liveServices = config.services ?? {};
+    const stats: EnvCheckStats = { expected: 0, checked: 0, skipped: 0 };
+
+    // Sorted service names for stable output ordering.
+    for (const name of Object.keys(services).sort()) {
+      const entry = services[name];
+      // Only assert an env the service actually declares. Use Object.hasOwn
+      // (matching reconcile-staging.ts) so a declared-but-falsy env value is
+      // still asserted rather than silently skipped.
+      if (!Object.hasOwn(entry.environments, env)) continue;
+      stats.expected++;
+      const liveSvc = liveServices[entry.serviceId];
+      if (!liveSvc) {
+        // Service not present in this env's live config — nothing to compare.
+        skipped++;
+        stats.skipped++;
+        continue;
+      }
+      checked++;
+      stats.checked++;
+      const v = checkAutoUpdates({
+        service: name,
+        env,
+        expected: expectedPolicyFor(entry),
+        liveAutoUpdates: liveSvc.source?.autoUpdates,
+      });
+      if (v) violations.push(v);
+    }
+
+    perEnv[env] = stats;
+  }
+
+  return { violations, checked, skipped, perEnv };
+}
+
+export interface FailureSummaryOutput {
+  shouldFail: boolean;
+  lines: string[];
+}
+
+/**
+ * Pure failure-summary builder. Mirrors verify-railway-image-refs's
+ * summarizeFailures reporting convention.
+ */
+export function summarizeAutoUpdatesFailures(
+  result: GateResult,
+): FailureSummaryOutput {
+  const { violations, checked, skipped, perEnv } = result;
+
+  // Per-env fail-closed floor: a drift gate must verify EVERY queried env, not
+  // just some. An env that expected to check services but verified ZERO of them
+  // (empty/absent Environment.config for that env, or wrong project scope) means
+  // that env's drift went unverified — and a HEALTHY sibling env must NOT keep
+  // the gate green while another env is unverifiable. Fail and name the starved
+  // env(s). Sorted for deterministic output.
+  const byEnv = perEnv ?? {};
+  const starvedEnvs = Object.keys(byEnv)
+    .filter((env) => byEnv[env].expected > 0 && byEnv[env].checked === 0)
+    .sort();
+
+  if (starvedEnvs.length > 0) {
+    const lines: string[] = [
+      `\n✗ autoUpdates drift gate verified ZERO expected services in ${starvedEnvs.length} environment(s) — refusing to report success.\n`,
+    ];
+    for (const env of starvedEnvs) {
+      const s = byEnv[env];
+      lines.push(
+        `  ✗ [${env}] expected ${s.expected} service(s) but checked 0 (${s.skipped} skipped) — empty/absent Environment.config for this env, or wrong Railway project scope. That env's drift went unverified.`,
+      );
+    }
+    lines.push(
+      `\nA gate that verified nothing in an environment is not green. Confirm the Railway token can read every queried environment and that each env's config carries the expected services.\n`,
+    );
+    return { shouldFail: true, lines };
+  }
+
+  // Global fail-closed floor (subset of the per-env floor for callers that do
+  // not carry a per-env breakdown, e.g. legacy fixtures): a drift gate that
+  // verified NOTHING at all must never report success. checked===0 means the
+  // live config yielded no comparable service/env pairs (empty/absent/string-
+  // form Environment.config, wrong Railway project scope, or every pair skipped).
+  if (checked === 0) {
+    return {
+      shouldFail: true,
+      lines: [
+        `\n✗ autoUpdates drift gate checked ZERO service/env pairs (${skipped} skipped) — refusing to report success.\n` +
+          `This usually means the live Environment.config had no matching services (empty/string-form config, wrong Railway project scope, or every pair skipped). A gate that verified nothing is not green.\n`,
+      ],
+    };
+  }
+
+  const shouldFail = violations.length > 0;
+  const lines: string[] = [];
+  if (!shouldFail) return { shouldFail, lines };
+
+  lines.push(
+    `\n✗ Railway autoUpdates drift detected (${violations.length} violations across ${checked} service/env checks; ${skipped} skipped)\n`,
+  );
+  for (const v of violations) {
+    lines.push(`  ✗ [${v.env}] ${v.service}`);
+    lines.push(`    expected: ${v.expected}`);
+    lines.push(`    live:     autoUpdates.type=${v.liveType ?? "<none>"}`);
+    lines.push(`    reason:   ${v.reason}`);
+  }
+  lines.push(
+    `\nFix by disabling Railway source auto-updates on the offending service(s) so only the deploy pipeline moves images.\n`,
+  );
+  return { shouldFail, lines };
+}
+
+// ── Railway GraphQL plumbing ────────────────────────────────────────────
+
+/**
+ * Resolve the Railway bearer token. Mirrors verify-railway-image-refs's
+ * getToken(): maps RailwayTokenError onto the exit-1 operator-error contract.
+ */
+function getToken(): string {
+  try {
+    return resolveRailwayToken().token;
+  } catch (e) {
+    if (e instanceof RailwayTokenError) {
+      console.error(e.message);
+      process.exit(1);
+    }
+    throw e;
+  }
+}
+
+async function railwayGql<T = unknown>(
+  query: string,
+  variables: Record<string, unknown> = {},
+): Promise<T> {
+  const token = getToken();
+  const res = await fetch(RAILWAY_API, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) {
+    const body = sanitizeErrorBody(await res.text());
+    throw new Error(`Railway API error: ${res.status} ${body}`);
+  }
+  const json = (await res.json()) as {
+    data?: T;
+    errors?: Array<{ message: string }>;
+  };
+  if (json.errors?.length) {
+    throw new Error(
+      `Railway GraphQL errors:\n${json.errors.map((e) => `  - ${e.message}`).join("\n")}`,
+    );
+  }
+  return json.data as T;
+}
+
+/**
+ * Live `Environment.config` reader. Returns the RAW JSON scalar (object or, on
+ * some transports, a JSON string); the gate normalizes it via
+ * `parseEnvironmentConfig` — so a string-form scalar is parsed rather than
+ * cast-and-silently-skipped.
+ */
+async function fetchEnvConfigLive(envId: string): Promise<unknown> {
+  const data = await railwayGql<{ environment: { config: unknown } | null }>(
+    `query envConfig($id: String!) {
+      environment(id: $id) { config }
+    }`,
+    { id: envId },
+  );
+  if (data.environment === null || data.environment === undefined) {
+    throw new Error(
+      `Railway environment ${envId} returned null — check the env id and that the Railway token has access to this project.`,
+    );
+  }
+  return data.environment.config;
+}
+
+async function main(): Promise<void> {
+  // SERVICES is `ServiceEntry & { dispatchName? }`; structurally assignable to
+  // the minimal gate-entry shape (serviceId + environments + optional
+  // autoUpdates). The cast is a widening view, not `any`.
+  const services = SERVICES as unknown as Record<string, AutoUpdatesGateEntry>;
+
+  const result = await runAutoUpdatesGate({
+    services,
+    envIds: ENV_ID_BY_NAME,
+    fetchEnvConfig: fetchEnvConfigLive,
+  });
+
+  const summary = summarizeAutoUpdatesFailures(result);
+  if (summary.shouldFail) {
+    for (const line of summary.lines) console.error(line);
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ autoUpdates verified disabled across ${result.checked} service/env checks (${result.skipped} skipped)`,
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Showcase deploy-mechanism consolidation

Consolidates the showcase Railway deploy path onto a single **CI-explicit** mechanism, so we can safely retire Railway's registry auto-watch (the source of the surprise "Service aimock upgraded to latest" emails). Design proposal: [Notion — Showcase Deploy-Mechanism Consolidation](https://app.notion.com/p/3a33aa38185281e4b64cc5bebde92d91).

### What & why
The "aimock upgraded to latest" email was never a per-service config choice — it was a **CI bug** letting Railway's watcher win a race: a Renovate PR that only touches `showcase_build.yml` forces a full-fleet rebuild; the LFS `shell` leg gets cancelled under runner contention; and the `redeploy-staging` guard (`needs.build.result != 'cancelled'`) then skipped the CI redeploy for the **whole fleet**, orphaning aimock's fresh digest for Railway's watcher to pick up. The `autoUpdates` setting itself had also silently drifted (24 services `minor` / 17 none) — tracked in no SSOT, gated by nothing.

### The four changes (one commit each)
1. **`fix(showcase)` — the P0 guard bug.** Relax the `redeploy-staging` **and** `redeploy-staging-starters` guards so a cancelled sibling leg no longer skips the fleet's staging redeploy; they now redeploy the already-computed successful-service list. A guard-evaluation test reads the live workflow `if:` strings and models GitHub's matrix rollup.
2. **`feat(showcase)` — autoUpdates SSOT (per-env, staging-first).** Add a **per-env** `autoUpdates` policy to every service in `railway-envs.ts` — **staging: `disabled`** (enforced), **prod: `unmanaged`** (left exactly as-is until a later migration). Regenerate `railway-envs.generated.json`. CI-explicit redeploy becomes the single deploy path on staging.
3. **`feat(showcase)` — drift gate.** New CI gate fails when a live Railway service's `autoUpdates` diverges from the SSOT. Reads `Environment.config` (autoUpdates isn't on the typed `ServiceSource` output), **enforces managed (`disabled`) envs and skips `unmanaged` ones** (so prod is untouched), **fails closed per-env** on zero-checked, and skips cleanly on fork PRs with no Railway token.
4. **`feat(showcase)` — scheduled reconcile.** CI-owned self-heal (every 15m) comparing each staging service's deployed digest against GHCR `:latest`, re-running the staging redeploy for lagging services and alerting Slack. Invariant: **green ⟺ every in-scope service confirmed current**; any unconfirmed service (lag, digest error, dropped redeploy, empty scope, thrown redeploy) alerts and exits non-zero.

### Verification
- Every behavior change carries red-green tests; **230 tests pass**, `tsc` clean, `oxfmt`/`oxlint` clean, generated JSON in sync, workflows parse.
- Reviewed via a full CR loop (Tier 3, 5 rounds to convergence); the reconcile's fail-loud invariant was hardened across rounds (silent-green holes, stale-digest ordering, expansion false-positives, test hygiene).

### Rollout (staging-first)
- **Staging is flipped live as part of this change** — `autoUpdates` disabled on all staging services (snapshot-first, verified only `autoUpdates` changed). The drift gate now enforces staging.
- **Prod is untouched** — its `autoUpdates` stay exactly as-is and the gate marks prod `unmanaged` (skipped). Migrating prod is a deliberate follow-up (flip prod live + change prod SSOT `unmanaged`→`disabled` together) once we're comfortable with staging on the new mechanism. No transition window where anything is unguarded.

### Follow-ups (from CR, non-blocking)
- Dedup the reconcile alert's `unconfirmed` list by service key (cosmetic double-listing; exit code already correct).
- Harden the sibling `notify-all-builds-failed`/`notify` jobs against the same all-legs-cancelled rollup (pre-existing, in a job this PR doesn't touch).
- Minor: `postSlackAlert` try/catch belt; a few added test assertions; comment/doc accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
