### PR TITLE
showcase: harden notify jobs + bring prod autoUpdates under drift-gate management

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -1108,13 +1108,21 @@ jobs:
     if: >-
       ${{ !cancelled()
           && needs.detect-changes.outputs.has_changes == 'true'
-          && needs.build.result == 'failure'
+          && needs.build.result != 'skipped'
           && needs.aggregate-build-results.outputs.any_success == 'false' }}
-    # The `needs.build.result == 'failure'` clause guards against the case
-    # where the build job itself was SKIPPED (e.g. verify-image-refs failed
-    # upstream, so the matrix never executed). Without it, the aggregator
-    # would still report `any_success=false` and we'd Slack-spam "all
-    # builds failed" even though builds never ran — a misleading alert.
+    # Previously this keyed off `needs.build.result == 'failure'`, which shared
+    # the redeploy job's cancelled-rollup blind spot: GitHub rolls the build
+    # matrix up to 'cancelled' when ANY leg is cancelled (e.g. the LFS shell
+    # leg under runner contention), so an all-failed build with one cancelled
+    # leg rolled up to 'cancelled', the `== 'failure'` clause went false, and
+    # NO alert fired. `any_success == 'false'` (the artifact-derived signal the
+    # redeploy fix uses) is the authoritative "nothing built" check, so we fire
+    # on it directly. The `!= 'skipped'` clause still guards the case where the
+    # build job was SKIPPED (e.g. verify-image-refs failed upstream, so the
+    # matrix never executed) — the aggregator would report `any_success=false`
+    # for an empty run, and the sibling `notify` job already covers that
+    # upstream red, so firing here too would be a misleading "all builds
+    # failed" alert. `!cancelled()` keeps a user-cancelled RUN silent.
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
@@ -1150,11 +1158,21 @@ jobs:
     # also missed those pre-build red paths. Adding the early-stage jobs
     # to `needs` extends the alert surface to the full workflow, matching
     # the workflow-level notify pattern in showcase_promote.yml.
-    # `if: failure()` already skips when none of the needs failed — so
-    # this still no-ops for the "no changes → build skipped" path, since
-    # skipped != failure. If `notify-all-builds-failed` also fires
-    # (genuine all-failed case), both alerts firing for the same event is
-    # acceptable per the alert SOP.
+    # The guard is `!cancelled() && (failure() || any_success == 'false')`
+    # rather than a bare `failure()`. Bare `failure()` shared the redeploy
+    # job's cancelled-rollup blind spot: when every real build leg failed but
+    # one leg was CANCELLED (runner contention), the matrix rolled up to
+    # 'cancelled' — which is NOT a `failure()` — so no needs job "failed" and
+    # the alert stayed silent on a genuinely dead build. The extra
+    # `any_success == 'false'` clause (the artifact-derived signal the redeploy
+    # fix uses) fires on "nothing built" regardless of the rollup. `failure()`
+    # is retained so a failure DOWNSTREAM of a successful build (e.g.
+    # redeploy-staging, on which any_success == 'true') still alerts. `!cancelled()`
+    # keeps a user-cancelled RUN silent, and the "no changes → build skipped"
+    # path stays a no-op (aggregate is skipped, so any_success is '' not 'false',
+    # and nothing failed). If `notify-all-builds-failed` also fires (genuine
+    # all-failed case), both alerts firing for the same event is acceptable per
+    # the alert SOP.
     #
     # `detect-starter-changes` + `build-starters` + `redeploy-staging-starters`
     # are included so a FAILED starter image build OR a failed starter staging
@@ -1176,7 +1194,10 @@ jobs:
         redeploy-staging,
         redeploy-staging-starters,
       ]
-    if: failure()
+    if: >-
+      ${{ !cancelled()
+          && (failure()
+              || needs.aggregate-build-results.outputs.any_success == 'false') }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -37,7 +37,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -65,7 +65,7 @@
       "runtimeDeps": ["pocketbase", "harness"],
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -93,7 +93,7 @@
       "standalone": true,
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -120,7 +120,7 @@
       "promoteTier": 2,
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -151,7 +151,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -199,7 +199,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -226,7 +226,7 @@
       "promoteTier": 0,
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -257,7 +257,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -291,7 +291,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -325,7 +325,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -359,7 +359,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -397,7 +397,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -431,7 +431,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -465,7 +465,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -499,7 +499,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -533,7 +533,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -567,7 +567,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -601,7 +601,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -635,7 +635,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -669,7 +669,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -703,7 +703,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -737,7 +737,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -771,7 +771,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -805,7 +805,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -839,7 +839,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -873,7 +873,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -907,7 +907,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -941,7 +941,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -975,7 +975,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -1009,7 +1009,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -1043,7 +1043,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -1077,7 +1077,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -1111,7 +1111,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -1145,7 +1145,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -1179,7 +1179,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -1213,7 +1213,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -1247,7 +1247,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -1281,7 +1281,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -1315,7 +1315,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -1349,7 +1349,7 @@
       },
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     },
     {
@@ -1376,7 +1376,7 @@
       "promoteTier": 0,
       "autoUpdates": {
         "staging": "disabled",
-        "prod": "unmanaged"
+        "prod": "disabled"
       }
     }
   ],

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -1372,13 +1372,11 @@ describe("autoUpdates deploy-consolidation policy (per-env, staging-first)", () 
   // Railway `source.autoUpdates.type = "minor"` is the ENABLED form (Railway
   // watches the GHCR registry and auto-redeploys on a new push); the SSOT
   // target is "disabled" so the ONLY deploy path is the CI-explicit redeploy.
-  // autoUpdates is now PER-ENV to support a staging-first rollout: STAGING is
-  // enforced "disabled" (its live config is being flipped to disabled), while
-  // PROD is "unmanaged" — NOT yet under drift-gate management (its live
-  // autoUpdates are heterogeneous and must be left untouched until a later
-  // migration). The sibling drift gate ENFORCES the concrete-"disabled" envs
-  // and SKIPS the "unmanaged" ones.
-  it("every service declares staging 'disabled' and prod 'unmanaged'", () => {
+  // autoUpdates is now PER-ENV; the staging-first rollout has completed, so
+  // BOTH staging and prod are enforced "disabled" (prod was migrated off
+  // "unmanaged" once its live autoUpdates were flipped to disabled). The
+  // sibling drift gate ENFORCES the concrete-"disabled" envs for both.
+  it("every service declares staging 'disabled' and prod 'disabled'", () => {
     for (const [name, entry] of Object.entries(SERVICES)) {
       const au = (entry as { autoUpdates?: Record<string, string> })
         .autoUpdates;
@@ -1388,12 +1386,12 @@ describe("autoUpdates deploy-consolidation policy (per-env, staging-first)", () 
       ).toBe("disabled");
       expect(
         au?.prod,
-        `${name}.autoUpdates.prod must be "unmanaged" (prod not yet migrated; drift gate skips it)`,
-      ).toBe("unmanaged");
+        `${name}.autoUpdates.prod must be "disabled" (prod is now under drift-gate management; CI-explicit redeploy only)`,
+      ).toBe("disabled");
     }
   });
 
-  it("the generated JSON carries per-env autoUpdates (staging disabled, prod unmanaged)", () => {
+  it("the generated JSON carries per-env autoUpdates (staging disabled, prod disabled)", () => {
     const generated = JSON.parse(
       readFileSync(resolve(__dirname, "./railway-envs.generated.json"), "utf8"),
     ) as {
@@ -1410,8 +1408,8 @@ describe("autoUpdates deploy-consolidation policy (per-env, staging-first)", () 
       ).toBe("disabled");
       expect(
         svc.autoUpdates?.prod,
-        `generated ${svc.name}.autoUpdates.prod must be "unmanaged"`,
-      ).toBe("unmanaged");
+        `generated ${svc.name}.autoUpdates.prod must be "disabled"`,
+      ).toBe("disabled");
     }
   });
 });

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -302,8 +302,9 @@ export interface EnvironmentConfig {
 /**
  * Railway auto-updates policy for a service in ONE env — the tracked SSOT form
  * of the Railway `source.autoUpdates` setting. This is PER-ENV (see
- * {@link AutoUpdatesByEnv}) to support a staging-first rollout: staging can be
- * managed-"disabled" while prod stays "unmanaged" until a later migration.
+ * {@link AutoUpdatesByEnv}) to support a staging-first rollout. Both staging
+ * and prod are now managed-"disabled" (prod was migrated off "unmanaged" once
+ * its live autoUpdates were flipped to disabled).
  *
  * - "minor"     — Railway's ENABLED form (`source.autoUpdates.type = "minor"`):
  *                 Railway watches the GHCR registry and AUTO-redeploys the
@@ -332,9 +333,9 @@ export type AutoUpdatesPolicy = "disabled" | "minor" | "unmanaged";
 /**
  * Per-env auto-updates policy, keyed by the SAME env names as
  * `ServiceEntry.environments` ("prod" / "staging" / …). Every env a service
- * declares carries its own {@link AutoUpdatesPolicy}. Today staging is
- * managed-"disabled" (drift-gate enforced) and prod is "unmanaged" (skipped)
- * for the staging-first rollout.
+ * declares carries its own {@link AutoUpdatesPolicy}. Today both staging and
+ * prod are managed-"disabled" (drift-gate enforced); prod was migrated off
+ * "unmanaged" once its live autoUpdates were flipped to disabled.
  */
 export type AutoUpdatesByEnv = Record<EnvName, AutoUpdatesPolicy>;
 
@@ -343,10 +344,10 @@ export interface ServiceEntry {
   serviceId: string;
   /**
    * Railway auto-updates policy, PER-ENV. REQUIRED. Today every showcase
-   * service is `{ staging: "disabled", prod: "unmanaged" }` for the
-   * staging-first rollout: staging is drift-gate-enforced to "disabled" (the
-   * CI-explicit redeploy is the single deploy path), while prod is "unmanaged"
-   * (the gate skips it) until a later migration. See {@link AutoUpdatesByEnv}.
+   * service is `{ staging: "disabled", prod: "disabled" }`: both envs are
+   * drift-gate-enforced to "disabled" so the CI-explicit redeploy is the single
+   * deploy path. Prod was migrated off "unmanaged" once its live autoUpdates
+   * were flipped to disabled. See {@link AutoUpdatesByEnv}.
    */
   autoUpdates: AutoUpdatesByEnv;
   /**
@@ -561,7 +562,7 @@ export const SERVICES: Record<
 > = {
   aimock: {
     serviceId: "0fa0435d-8a66-46f0-84fd-e4250b580013",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "showcase-aimock",
@@ -604,7 +605,7 @@ export const SERVICES: Record<
   },
   dashboard: {
     serviceId: "4d5dfd74-be61-40b2-8564-b53b7dd4c15b",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "shell-dashboard",
@@ -634,7 +635,7 @@ export const SERVICES: Record<
   },
   docs: {
     serviceId: "7badfb8d-4228-414c-9145-b4026803714f",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "shell-docs",
@@ -663,7 +664,7 @@ export const SERVICES: Record<
   },
   dojo: {
     serviceId: "7ad1ece7-2228-49cd-8a78-bddf30322907",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "shell-dojo",
@@ -686,7 +687,7 @@ export const SERVICES: Record<
   },
   harness: {
     serviceId: "3a14bfed-0537-4d71-897b-7c593dca161d",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "showcase-harness",
@@ -720,7 +721,7 @@ export const SERVICES: Record<
   // not `showcase-harness-worker`.
   "harness-workers": {
     serviceId: "c2aa8a0b-350e-4b76-8541-3012dfac41d0",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     // Pool-fleet worker. Workers run in BOTH staging and prod: the prod worker
     // is live on Railway (deployed 2026-06-19, HARNESS_ROLE=worker, pool
     // count 2) and is now BACKFILLED as a `prod` env entry below (real
@@ -842,7 +843,7 @@ export const SERVICES: Record<
   },
   pocketbase: {
     serviceId: "ba11e854-d695-4738-9a45-2b0776788824",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     // pocketbase is a first-party ghcr.io/copilotkit/ image whose GHCR
     // repo name is `showcase-pocketbase` (NOT `pocketbase`). It is now
     // built+pushed by showcase_build.yml (the `pocketbase` matrix slot,
@@ -875,7 +876,7 @@ export const SERVICES: Record<
   },
   shell: {
     serviceId: "40eea0da-6071-4ea8-bdb9-39afb19225ec",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "shell",
@@ -900,7 +901,7 @@ export const SERVICES: Record<
   },
   "showcase-ag2": {
     serviceId: "4a37481b-f264-4eb7-a9cd-0a9ebb9ac05c",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "ag2",
@@ -928,7 +929,7 @@ export const SERVICES: Record<
   },
   "showcase-agno": {
     serviceId: "32cab80b-e329-45bd-9c73-c4e1ddc94305",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "agno",
@@ -956,7 +957,7 @@ export const SERVICES: Record<
   },
   "showcase-built-in-agent": {
     serviceId: "f4f8371a-bc46-45b2-b6d4-9c9af608bdbf",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "built-in-agent",
@@ -984,7 +985,7 @@ export const SERVICES: Record<
   },
   "showcase-claude-sdk-python": {
     serviceId: "b122ab65-9854-4cb2-a68e-b50ff13f7481",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "claude-sdk-python",
@@ -1022,7 +1023,7 @@ export const SERVICES: Record<
   },
   "showcase-claude-sdk-typescript": {
     serviceId: "18a98727-5700-44aa-b497-b60795dbbd6a",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "claude-sdk-typescript",
@@ -1050,7 +1051,7 @@ export const SERVICES: Record<
   },
   "showcase-crewai-crews": {
     serviceId: "0e9c284d-8d87-4fcf-9f82-6b704d7e4bd4",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "crewai-crews",
@@ -1078,7 +1079,7 @@ export const SERVICES: Record<
   },
   "showcase-google-adk": {
     serviceId: "87f60507-5a3d-4b8a-9e23-2b1de85d939c",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "google-adk",
@@ -1106,7 +1107,7 @@ export const SERVICES: Record<
   },
   "showcase-langgraph-fastapi": {
     serviceId: "06cccb5c-59f4-46b5-8adc-7113e77011a4",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "langgraph-fastapi",
@@ -1134,7 +1135,7 @@ export const SERVICES: Record<
   },
   "showcase-langgraph-python": {
     serviceId: "90d03214-4569-41b0-b4c1-6438a8a7b203",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "langgraph-python",
@@ -1162,7 +1163,7 @@ export const SERVICES: Record<
   },
   "showcase-langgraph-typescript": {
     serviceId: "66246d3b-a18e-46f0-be51-5f3ff7a36e5a",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "langgraph-typescript",
@@ -1190,7 +1191,7 @@ export const SERVICES: Record<
   },
   "showcase-langroid": {
     serviceId: "6dd9cb0a-66cc-46f1-972e-7cd74756157d",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "langroid",
@@ -1218,7 +1219,7 @@ export const SERVICES: Record<
   },
   "showcase-llamaindex": {
     serviceId: "285386e8-492d-4cb8-b632-0a7d4607378f",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "llamaindex",
@@ -1246,7 +1247,7 @@ export const SERVICES: Record<
   },
   "showcase-mastra": {
     serviceId: "d7979eb7-2405-4aab-ad21-438f4a1b08af",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "mastra",
@@ -1274,7 +1275,7 @@ export const SERVICES: Record<
   },
   "showcase-ms-agent-dotnet": {
     serviceId: "beeb2dd6-87a4-4599-aa07-0578f7bd6519",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "ms-agent-dotnet",
@@ -1302,7 +1303,7 @@ export const SERVICES: Record<
   },
   "showcase-ms-agent-harness-dotnet": {
     serviceId: "6343d7f9-6c3f-4c8d-9a6e-79f03d2f1e37",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "ms-agent-harness-dotnet",
@@ -1330,7 +1331,7 @@ export const SERVICES: Record<
   },
   "showcase-ms-agent-python": {
     serviceId: "655db75a-af8d-427d-a4f9-441570ae5003",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "ms-agent-python",
@@ -1358,7 +1359,7 @@ export const SERVICES: Record<
   },
   "showcase-pydantic-ai": {
     serviceId: "0a106173-2282-4887-a994-0ca276a99d69",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "pydantic-ai",
@@ -1386,7 +1387,7 @@ export const SERVICES: Record<
   },
   "showcase-spring-ai": {
     serviceId: "eed5d041-91be-4282-b414-beea00843401",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "spring-ai",
@@ -1414,7 +1415,7 @@ export const SERVICES: Record<
   },
   "showcase-strands": {
     serviceId: "92e1cfad-ad53-403f-ab2b-5ab380832232",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "strands",
@@ -1448,7 +1449,7 @@ export const SERVICES: Record<
   // legacyJsonCompat prod-domain placeholder removed.
   "showcase-strands-typescript": {
     serviceId: "d6f47c8c-a0a1-4dbe-991c-50f8463fd68d",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "strands-typescript",
@@ -1523,7 +1524,7 @@ export const SERVICES: Record<
   // prod→prod by the Stage-2 Ruby preflight (never copied).
   "starter-adk": {
     serviceId: "37691009-c0b2-4af7-8960-9f0b3f0a6be3",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-adk",
@@ -1548,7 +1549,7 @@ export const SERVICES: Record<
   },
   "starter-agno": {
     serviceId: "5ab3c37e-18a5-44e5-8329-26243dd98da8",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-agno",
@@ -1573,7 +1574,7 @@ export const SERVICES: Record<
   },
   "starter-crewai-crews": {
     serviceId: "2a9a4230-e6cd-4c1d-92a5-36e5c624371a",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-crewai-crews",
@@ -1598,7 +1599,7 @@ export const SERVICES: Record<
   },
   "starter-langgraph-fastapi": {
     serviceId: "6ae57213-52ea-4fea-b4a0-7bc304cbc80e",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-langgraph-fastapi",
@@ -1623,7 +1624,7 @@ export const SERVICES: Record<
   },
   "starter-langgraph-js": {
     serviceId: "d044c3e5-bb27-4d5e-a2bf-e3b382981372",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-langgraph-js",
@@ -1648,7 +1649,7 @@ export const SERVICES: Record<
   },
   "starter-langgraph-python": {
     serviceId: "10dca514-7c8f-4a32-9708-9f29a944da36",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-langgraph-python",
@@ -1673,7 +1674,7 @@ export const SERVICES: Record<
   },
   "starter-llamaindex": {
     serviceId: "3255b27f-ea84-44b7-b587-b1687b409363",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-llamaindex",
@@ -1698,7 +1699,7 @@ export const SERVICES: Record<
   },
   "starter-mastra": {
     serviceId: "6548403e-3fee-4443-9d59-d8b041a3d43a",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-mastra",
@@ -1723,7 +1724,7 @@ export const SERVICES: Record<
   },
   "starter-ms-agent-framework-dotnet": {
     serviceId: "1b4c5296-97f6-463d-90af-6e04d7919957",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-ms-agent-framework-dotnet",
@@ -1748,7 +1749,7 @@ export const SERVICES: Record<
   },
   "starter-ms-agent-framework-python": {
     serviceId: "225d0a06-d1cd-4b82-ae9c-2d1e8ecbaf86",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-ms-agent-framework-python",
@@ -1773,7 +1774,7 @@ export const SERVICES: Record<
   },
   "starter-pydantic-ai": {
     serviceId: "c01d0d24-af88-4631-8a9a-23cffef2b36a",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-pydantic-ai",
@@ -1798,7 +1799,7 @@ export const SERVICES: Record<
   },
   "starter-strands-python": {
     serviceId: "321735ab-c14d-4e45-a1c2-e47f2b29d774",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "starter-strands-python",
@@ -1823,7 +1824,7 @@ export const SERVICES: Record<
   },
   webhooks: {
     serviceId: "ba6acc13-7585-41fe-a5ee-585b34a58fcd",
-    autoUpdates: { staging: "disabled", prod: "unmanaged" },
+    autoUpdates: { staging: "disabled", prod: "disabled" },
     ciBuilt: false,
     gateValidated: true,
     dispatchName: "webhooks",

--- a/showcase/scripts/redeploy-guard.test.ts
+++ b/showcase/scripts/redeploy-guard.test.ts
@@ -62,6 +62,18 @@ interface GhContext {
   runCancelled: boolean;
 }
 
+/**
+ * Model GitHub's `failure()` status function: true when at least one job in
+ * `needs` resolved to `'failure'` (and the run itself was not cancelled). A
+ * matrix rollup of `'cancelled'` is NOT a failure — that is the exact blind
+ * spot the `notify` job's bare `failure()` guard missed.
+ */
+function anyDepFailed(ctx: GhContext): boolean {
+  return Object.values(ctx.needs).some(
+    (j) => (j as { result?: string } | undefined)?.result === "failure",
+  );
+}
+
 function resolvePath(path: string, ctx: GhContext): string {
   const segs = path.split(".");
   let cur: unknown = { needs: ctx.needs };
@@ -92,7 +104,7 @@ function evalClause(raw: string, ctx: GhContext): boolean {
         value = !ctx.runCancelled;
         break;
       case "failure":
-        value = false;
+        value = !ctx.runCancelled && anyDepFailed(ctx);
         break;
       default:
         throw new Error(`Unhandled status function '${fn[2]}'`);
@@ -110,14 +122,129 @@ function evalClause(raw: string, ctx: GhContext): boolean {
   throw new Error(`Unparseable clause: '${clause}'`);
 }
 
+// ---------------------------------------------------------------------------
+// A small recursive-descent evaluator for the boolean grammar these guards
+// use: `||` / `&&` / `!` / parentheses over atoms, where each atom is a status
+// function or a `<path> ==|!= '<literal>'` comparison (handled by evalClause).
+// `&&` binds tighter than `||`, matching GitHub Actions' operator precedence.
+// The `notify` job's guard combines `failure()` with an `any_success` check via
+// `||` inside parens, which the previous split-on-`&&` model could not parse.
+// ---------------------------------------------------------------------------
+type Token = { kind: "&&" | "||" | "!" | "(" | ")" | "atom"; text?: string };
+
+function tokenize(expr: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  const atomRe =
+    /^(?:(?:!\s*)?(?:cancelled|always|success|failure)\(\)|[A-Za-z0-9_.-]+\s*(?:==|!=)\s*'[^']*')/;
+  while (i < expr.length) {
+    const rest = expr.slice(i);
+    const ws = rest.match(/^\s+/);
+    if (ws) {
+      i += ws[0].length;
+      continue;
+    }
+    if (rest.startsWith("&&")) {
+      tokens.push({ kind: "&&" });
+      i += 2;
+      continue;
+    }
+    if (rest.startsWith("||")) {
+      tokens.push({ kind: "||" });
+      i += 2;
+      continue;
+    }
+    if (rest[0] === "(") {
+      tokens.push({ kind: "(" });
+      i += 1;
+      continue;
+    }
+    if (rest[0] === ")") {
+      tokens.push({ kind: ")" });
+      i += 1;
+      continue;
+    }
+    const atom = rest.match(atomRe);
+    if (atom) {
+      tokens.push({ kind: "atom", text: atom[0] });
+      i += atom[0].length;
+      continue;
+    }
+    if (rest[0] === "!") {
+      // A bare `!` here can only be negation of a parenthesized group; a `!`
+      // that prefixes a status function is already consumed by the atom regex.
+      tokens.push({ kind: "!" });
+      i += 1;
+      continue;
+    }
+    throw new Error(`Unexpected token at: '${rest}'`);
+  }
+  return tokens;
+}
+
 function evalGuard(expr: string, ctx: GhContext): boolean {
   const inner = expr
     .replace(/^\s*\$\{\{/, "")
     .replace(/\}\}\s*$/, "")
     .trim();
-  // No `||` and no `&&` nested inside parens in this grammar, so a top-level
-  // split on `&&` is sound.
-  return inner.split("&&").every((c) => evalClause(c, ctx));
+  const tokens = tokenize(inner);
+  let pos = 0;
+
+  const peek = () => tokens[pos];
+  const eat = (kind: Token["kind"]) => {
+    const t = tokens[pos];
+    if (!t || t.kind !== kind) {
+      throw new Error(`Expected '${kind}' at token ${pos}`);
+    }
+    pos += 1;
+    return t;
+  };
+
+  const parsePrimary = (): boolean => {
+    const t = peek();
+    if (!t) throw new Error("Unexpected end of guard expression");
+    if (t.kind === "!") {
+      eat("!");
+      return !parsePrimary();
+    }
+    if (t.kind === "(") {
+      eat("(");
+      const v = parseOr();
+      eat(")");
+      return v;
+    }
+    if (t.kind === "atom") {
+      eat("atom");
+      return evalClause(t.text as string, ctx);
+    }
+    throw new Error(`Unexpected token '${t.kind}' in guard expression`);
+  };
+
+  function parseAnd(): boolean {
+    let v = parsePrimary();
+    while (peek()?.kind === "&&") {
+      eat("&&");
+      const rhs = parsePrimary();
+      v = v && rhs;
+    }
+    return v;
+  }
+
+  function parseOr(): boolean {
+    let v = parseAnd();
+    while (peek()?.kind === "||") {
+      eat("||");
+      const rhs = parseAnd();
+      v = v || rhs;
+    }
+    return v;
+  }
+
+  const result = parseOr();
+  if (pos !== tokens.length) {
+    throw new Error(`Trailing tokens in guard expression at ${pos}`);
+  }
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -287,5 +414,80 @@ describe("redeploy-staging-starters guard — matrix cancellation regression", (
     expect(runStarters(starterContextFor(legs, { hasChanges: false }))).toBe(
       false,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression guard for the notification jobs (`notify-all-builds-failed` and
+// `notify`). They shared the redeploy job's cancelled-rollup blind spot: the
+// former keyed off `needs.build.result == 'failure'` and the latter off a bare
+// `failure()`, so a build where every real service FAILED but one leg was
+// CANCELLED (runner contention) rolled the matrix up to 'cancelled' and sent
+// NO alert. The authoritative "did anything build?" signal is the same one the
+// redeploy fix uses — `aggregate-build-results.outputs.any_success`.
+// ---------------------------------------------------------------------------
+describe("notify-all-builds-failed guard — cancelled-rollup blind spot", () => {
+  const guard = readJobGuard("notify-all-builds-failed");
+
+  it("(a) fires when every leg is cancelled but nothing built (any_success=false)", () => {
+    const legs = Array(28).fill("cancelled");
+    const ctx = contextFor(legs, { runCancelled: false });
+    expect(rollupBuildResult(legs)).toBe("cancelled"); // GH rolls up to cancelled
+    expect(jobRuns(guard, ctx)).toBe(true); // ...but the alert still fires
+  });
+
+  it("(a2) fires on a clean all-failure build (unchanged behavior)", () => {
+    const legs = Array(28).fill("failure");
+    expect(jobRuns(guard, contextFor(legs))).toBe(true);
+  });
+
+  it("(b) does NOT fire when all legs succeed", () => {
+    const legs = Array(28).fill("success");
+    expect(jobRuns(guard, contextFor(legs))).toBe(false);
+  });
+
+  it("does NOT fire when one leg is cancelled but the rest succeeded", () => {
+    const legs = [...Array(27).fill("success"), "cancelled"];
+    expect(jobRuns(guard, contextFor(legs, { runCancelled: false }))).toBe(
+      false,
+    );
+  });
+
+  it("(c) does NOT fire when the whole RUN is cancelled", () => {
+    const legs = Array(28).fill("cancelled");
+    const ctx = contextFor(legs, { runCancelled: true });
+    expect(jobRuns(guard, ctx)).toBe(false);
+  });
+});
+
+describe("notify guard — cancelled-rollup blind spot", () => {
+  const guard = readJobGuard("notify");
+
+  it("(a) fires when every leg is cancelled but nothing built (any_success=false)", () => {
+    const legs = Array(28).fill("cancelled");
+    const ctx = contextFor(legs, { runCancelled: false });
+    // No needs job resolved to 'failure' (matrix rolled up to 'cancelled'), so
+    // the bare `failure()` guard would stay silent — the any_success clause is
+    // what makes the alert fire.
+    expect(anyDepFailed(ctx)).toBe(false);
+    expect(jobRuns(guard, ctx)).toBe(true);
+  });
+
+  it("(a2) fires on a genuine build-job failure via failure() (unchanged behavior)", () => {
+    const legs = Array(28).fill("failure");
+    const ctx = contextFor(legs, { runCancelled: false });
+    expect(anyDepFailed(ctx)).toBe(true);
+    expect(jobRuns(guard, ctx)).toBe(true);
+  });
+
+  it("(b) does NOT fire when all legs succeed", () => {
+    const legs = Array(28).fill("success");
+    expect(jobRuns(guard, contextFor(legs))).toBe(false);
+  });
+
+  it("(c) does NOT fire when the whole RUN is cancelled", () => {
+    const legs = Array(28).fill("cancelled");
+    const ctx = contextFor(legs, { runCancelled: true });
+    expect(jobRuns(guard, ctx)).toBe(false);
   });
 });


### PR DESCRIPTION
Follow-ups to #6082 (showcase deploy consolidation), applied after the live prod `autoUpdates` flip.

1. **fix** — the `notify-all-builds-failed` / `notify` jobs had the same cancelled-rollup blind spot as the redeploy guard: an all-legs-cancelled build (one leg cancelled under contention) that really produced **no** successful service sent **no** alert. They now fire on `any_success == 'false'` (guarded by a status function so a user-cancelled run stays silent). Red-green in `redeploy-guard.test.ts` (reads the live workflow guards).
2. **feat** — prod `autoUpdates` is now `"disabled"` (was `"unmanaged"`), bringing prod under drift-gate management now that its live Railway `autoUpdates` are disabled. Both envs are migrated; the gate enforces both.

The live staging + prod Railway `autoUpdates` are already disabled, so the drift gate finds live == SSOT on both envs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)