### PR TITLE
test(showcase): derive D4 guard probed-route set from probe SSOT + align D4 probe naming

### DIFF
--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -458,6 +458,30 @@ function isAgentMessagePost(method: string, url: string): boolean {
 const DEFAULT_TIMEOUT_MS = 3 * 60 * 1000;
 const DEFAULT_PAGE_TIMEOUT_MS = 60 * 1000;
 
+/**
+ * L3 demo route (`/demos/agentic-chat`) — driven on EVERY discovered slug.
+ */
+export const D4_DEMO_ROUTE_AGENTIC_CHAT = "agentic-chat" as const;
+/**
+ * L4 demo route (`/demos/tool-rendering`) — driven only where the slug's
+ * registry exposes the `tool-rendering` demo.
+ */
+export const D4_DEMO_ROUTE_TOOL_RENDERING = "tool-rendering" as const;
+
+/**
+ * SOURCE OF TRUTH for the set of `/demos/<route>` routes this probe navigates:
+ * L3 (`agentic-chat`) always, L4 (`tool-rendering`) conditionally. The
+ * `runLevel` call sites below derive their `demo`/`demoPath` from these same
+ * constants, and the `d4-probe-domdone-guard` test derives its probed-route
+ * scan from this array (instead of a parallel hardcoded literal that could
+ * silently drift) so a future D4 route is covered automatically.
+ */
+export const D4_PROBED_DEMO_ROUTES = [
+  D4_DEMO_ROUTE_AGENTIC_CHAT,
+  D4_DEMO_ROUTE_TOOL_RENDERING,
+] as const;
+export type D4ProbedDemoRoute = (typeof D4_PROBED_DEMO_ROUTES)[number];
+
 // `PendingSseEvent`, `CvdiagProbeSession`, `defaultCvdiagBufferDir`, and
 // `nowMonoMs` were extracted to `../../cvdiag/probe-session.js` so the d5/d6
 // probe path can reuse the SAME probe-layer session. They are imported at the
@@ -1185,7 +1209,7 @@ export function createE2eSmokeDriver(
           demos = [];
         }
       }
-      const hasToolRendering = demos.includes("tool-rendering");
+      const hasToolRendering = demos.includes(D4_DEMO_ROUTE_TOOL_RENDERING);
 
       // Arm an AbortController that combines:
       //   1. The driver's own `timeoutMs` hard cap (triggers teardown).
@@ -1262,8 +1286,8 @@ export function createE2eSmokeDriver(
           slug,
           backendUrl,
           level: "chat",
-          demo: "agentic-chat",
-          demoPath: "/demos/agentic-chat",
+          demo: D4_DEMO_ROUTE_AGENTIC_CHAT,
+          demoPath: `/demos/${D4_DEMO_ROUTE_AGENTIC_CHAT}`,
           message: "Hello, please respond with a brief greeting.",
           testId: `d4-${slug}-${runId}`,
           abortSignal: abort.signal,
@@ -1386,8 +1410,8 @@ export function createE2eSmokeDriver(
             slug,
             backendUrl,
             level: "tools",
-            demo: "tool-rendering",
-            demoPath: "/demos/tool-rendering",
+            demo: D4_DEMO_ROUTE_TOOL_RENDERING,
+            demoPath: `/demos/${D4_DEMO_ROUTE_TOOL_RENDERING}`,
             message: "What's the weather in San Francisco?",
             testId: `d4-${slug}-${runId}`,
             abortSignal: abort.signal,

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -2088,18 +2088,18 @@ async function runLevel(opts: {
         runStartCount: number;
       }): Promise<{
         observed: boolean;
-        complete: boolean;
+        completed: boolean;
       }> => {
         // Route through `safeReadTurnState`: no seam OR a mid-poll read-throw
         // both yield "not observed / not complete" here (the throw returns the
         // degraded sentinel whose all-zero counters can't rise past the
-        // baseline, so `observed`/`complete` stay false). A throw is thus handled
+        // baseline, so `observed`/`completed` stay false). A throw is thus handled
         // CONSISTENTLY with `readDegraded` — the poll treats it as "no reliable
         // signal → degraded", widening the wait rather than escaping as a
         // spurious `level-error`.
         const st = await safeReadTurnState();
         if (st === undefined) {
-          return { observed: false, complete: false };
+          return { observed: false, completed: false };
         }
         const newRunStarted = st.runStartCount > baseline.runStartCount;
         const domDone =
@@ -2126,7 +2126,7 @@ async function runLevel(opts: {
           // turn that was about to render correctly ("empty assistant
           // response"). `observed` still includes `sseDone` (above) so a turn
           // whose attribute never appears still gets the wider polling window.
-          complete: domDone,
+          completed: domDone,
         };
       };
 
@@ -2215,9 +2215,9 @@ async function runLevel(opts: {
               observed: everObserved,
             };
           }
-          const { observed, complete } = await readTurnComplete(baseline);
+          const { observed, completed } = await readTurnComplete(baseline);
           if (observed) everObserved = true;
-          if (complete && completeAtMs === undefined) {
+          if (completed && completeAtMs === undefined) {
             // Stamp completion from the NODE clock at the first poll iteration
             // that observes THIS turn complete. The grace-window deadline math
             // below runs on the Node clock, so the completion instant must too:

--- a/showcase/harness/src/probes/drivers/d4-probe-domdone-guard.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-probe-domdone-guard.test.ts
@@ -3,6 +3,7 @@ import { readdirSync, existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
+import { D4_PROBED_DEMO_ROUTES } from "./d4-chat-roundtrip.js";
 
 // Regression guard for the D4 chat probe's `domDone` turn-completion gate.
 //
@@ -42,7 +43,11 @@ const INTEGRATIONS_DIR = path.resolve(WORKSPACE_ROOT, "showcase/integrations");
 // d4-chat-roundtrip.ts): `/demos/agentic-chat` ALWAYS; `/demos/tool-rendering`
 // only where the slug's registry exposes it. We scan the corresponding page
 // entrypoints for every integration that HAS them.
-const PROBED_ROUTES = ["agentic-chat", "tool-rendering"] as const;
+//
+// DERIVED from the probe's own `D4_PROBED_DEMO_ROUTES` source-of-truth (NOT a
+// parallel hardcoded literal) so a future D4 route the probe starts driving is
+// scanned by this guard automatically, with no second edit here.
+const PROBED_ROUTES = D4_PROBED_DEMO_ROUTES;
 
 const COPILOT_CHAT_TAG = "CopilotChat";
 
@@ -122,6 +127,17 @@ function classifyCopilotChatUsage(file: string): {
 
 describe("d4 probe domDone gate: probed-route pages emit data-copilot-running", () => {
   const pages = collectProbedPages();
+
+  it("derives a probed-route set that still covers {agentic-chat, tool-rendering}", () => {
+    // Coverage-floor guard for the SSOT switch: deriving PROBED_ROUTES from the
+    // probe's `D4_PROBED_DEMO_ROUTES` must never NARROW the scan below the two
+    // routes the guard has always covered. Assert the derived set is a SUPERSET
+    // of the historical hardcoded literal so a future probe edit can only ADD
+    // routes, never silently drop coverage.
+    for (const route of ["agentic-chat", "tool-rendering"] as const) {
+      expect(PROBED_ROUTES).toContain(route);
+    }
+  });
 
   it("finds the universal agentic-chat page for every integration", () => {
     // Sanity: the probe navigates to /demos/agentic-chat for EVERY slug, so


### PR DESCRIPTION
## Summary

Three laser-surgical cleanups to the showcase D4 chat-roundtrip probe and its `domDone` regression guard. Two are behavior-preserving refactors; one is a test-coverage hardening. No probe control-flow / outcome behavior changes.

## Changes

### GB2 — derive the guard's probed-route set from the probe SSOT
`d4-probe-domdone-guard.test.ts` hardcoded its probed-route set as a literal `["agentic-chat","tool-rendering"]` parallel to the probe's own inline `demo`/`demoPath` literals — a drift hazard if the probe ever starts driving a new D4 route. Introduced `D4_DEMO_ROUTE_AGENTIC_CHAT`, `D4_DEMO_ROUTE_TOOL_RENDERING`, and a `D4_PROBED_DEMO_ROUTES` source-of-truth array in `d4-chat-roundtrip.ts`, wired the two `runLevel` `demo`/`demoPath` call sites and `hasToolRendering` to them, and had the guard derive `PROBED_ROUTES` from that export. A future D4 route is now covered automatically. Added a superset assertion so the derived set can never narrow coverage below `{agentic-chat, tool-rendering}`. Route strings unchanged → behavior-preserving.

### T2 — consolidate the completion FSM — DEFERRED
Not surgically achievable without behavior risk. The completion state (`completeAtMs` / `everObserved` / `degraded` plus the per-poll `observed` / `completed`) is progressively mutated across poll iterations inside `runAttempt`'s loop and consumed jointly by the grace/ceiling/floor deadline clamp (`Math.min(Math.max(baseBudgetEnd, graceEnd), fastFailEnd, attemptCeiling)`) and three early-return sites. There is no single read-site to redirect into one named source of truth; a true consolidation would restructure the deadline arithmetic and risk altering the clamp outcomes on this flap-critical probe. Left as-is per proportionate-fix discipline.

### T3 — align complete/completed naming (behavior-preserving rename)
`readTurnComplete` returned `{ observed, complete }` while `runAttempt` returned `{ text, completed, observed }` for the same concept. Renamed the lower-churn side (`readTurnComplete`'s `complete` → `completed`, 5 refs vs 6) so both use `completed`. The fields are local to `runLevel`, not exported and not referenced by any test → pure rename, zero behavior change.

## Proof — behavior preserved

Baseline (origin/main state, before changes):
- `d4-chat-roundtrip.test.ts`: **84 passed**
- `d4-probe-domdone-guard.test.ts`: **41 passed**
- Total: **125 passed**

After changes:
- `d4-chat-roundtrip.test.ts`: **84 passed** (identical — behavior preserved through T3 rename + GB2 wiring)
- `d4-probe-domdone-guard.test.ts`: **42 passed** (41 original + 1 new GB2 superset test)
- Total: **126 passed**

The 125 baseline tests all still pass; the only delta is the added GB2 coverage test.

## GB2 guard red-green

On `showcase/integrations/langgraph-python/src/app/demos/agentic-chat/page.tsx`:
- Mutated `<CopilotChat … />` → `<CopilotChat …>{null}</CopilotChat>` (children/render-prop form) → guard **RED** (1 failed: `langgraph-python/agentic-chat renders <CopilotChat/> in the attribute-bearing self-closing form`).
- Reverted → guard **GREEN** (42 passed).

Mutation fully reverted; net change to the guard's scanned pages is zero.

## Quality gates
- `oxfmt --check`: clean
- `oxlint`: 0 errors (2 warnings, both pre-existing on lines 954 / 1189, untouched by this diff)
- `tsc --noEmit`: clean
- `tsc -p tsconfig.build.json` (full build): clean
