### PR TITLE
fix(sdk-js): preserve AIMessage metadata in middleware

### DIFF
--- a/packages/sdk-js/src/langgraph/__tests__/middleware.test.ts
+++ b/packages/sdk-js/src/langgraph/__tests__/middleware.test.ts
@@ -497,24 +497,30 @@ describe("afterAgent", () => {
     expect(result!.copilotkit.originalAIMessageId).toBeUndefined();
   });
 
-  it("preserves AIMessage metadata through interception and restoration", () => {
+  it("preserves v1 metadata and content blocks through interception and restoration", () => {
+    const backendToolCall = {
+      id: "backend-1",
+      name: "search",
+      args: { query: "CopilotKit" },
+    };
+    const frontendToolCall = {
+      id: "frontend-1",
+      name: "navigate",
+      args: { path: "/results" },
+    };
     const original = new AIMessage({
       content: [
-        { type: "reasoning", reasoning: "Navigate to the details page." },
+        { type: "reasoning", reasoning: "Search, then open the result." },
+        { type: "tool_call", ...backendToolCall },
+        { type: "tool_call", ...frontendToolCall },
         {
-          type: "tool_call",
-          id: "frontend-1",
-          name: "navigate",
-          args: { path: "/details" },
+          type: "tool_call_chunk",
+          id: "stale-1",
+          name: "stale",
+          args: "{}",
         },
       ],
-      tool_calls: [
-        {
-          id: "frontend-1",
-          name: "navigate",
-          args: { path: "/details" },
-        },
-      ],
+      tool_calls: [backendToolCall, frontendToolCall],
       additional_kwargs: { provider_request_id: "request-1" },
       response_metadata: {
         output_version: "v1",
@@ -534,77 +540,27 @@ describe("afterAgent", () => {
           type: "invalid_tool_call",
         },
       ],
-      id: "ai-metadata",
+      id: "ai-v1",
       name: "assistant-with-tools",
     });
     const state = {
-      messages: [new HumanMessage("open details"), original],
-      copilotkit: { actions: [{ function: { name: "navigate" } }] },
-    };
-
-    const intercepted = copilotkitMiddleware.afterModel(state, {} as any)!;
-    const restored = copilotkitMiddleware.afterAgent(intercepted, {} as any)!;
-    const restoredMessage = restored.messages.at(-1) as AIMessage;
-
-    expect(restoredMessage.additional_kwargs).toEqual(
-      original.additional_kwargs,
-    );
-    expect(restoredMessage.response_metadata).toEqual(
-      original.response_metadata,
-    );
-    expect(restoredMessage.usage_metadata).toEqual(original.usage_metadata);
-    expect(restoredMessage.invalid_tool_calls).toEqual(
-      original.invalid_tool_calls,
-    );
-    expect(restoredMessage.name).toBe(original.name);
-  });
-
-  it("keeps v1 content blocks aligned with intercepted tool calls", () => {
-    const original = new AIMessage({
-      content: [
-        { type: "reasoning", reasoning: "Search, then open the result." },
-        {
-          type: "tool_call",
-          id: "backend-1",
-          name: "search",
-          args: { query: "CopilotKit" },
-        },
-        {
-          type: "tool_call",
-          id: "frontend-1",
-          name: "navigate",
-          args: { path: "/results" },
-        },
-        {
-          type: "tool_call_chunk",
-          id: "stale-1",
-          name: "stale",
-          args: "{}",
-        },
-      ],
-      tool_calls: [
-        {
-          id: "backend-1",
-          name: "search",
-          args: { query: "CopilotKit" },
-        },
-        {
-          id: "frontend-1",
-          name: "navigate",
-          args: { path: "/results" },
-        },
-      ],
-      response_metadata: { output_version: "v1" },
-      id: "ai-v1",
-    });
-    const state = {
-      messages: [original],
+      messages: [new HumanMessage("open the search result"), original],
       copilotkit: { actions: [{ name: "navigate" }] },
     };
 
     const intercepted = copilotkitMiddleware.afterModel(state, {} as any)!;
-    const interceptedContent = intercepted.messages.at(-1)!.content as any[];
+    const interceptedMessage = intercepted.messages.at(-1) as AIMessage;
+    const interceptedContent = interceptedMessage.content as any[];
 
+    expect(interceptedMessage).toMatchObject({
+      additional_kwargs: original.additional_kwargs,
+      response_metadata: original.response_metadata,
+      usage_metadata: original.usage_metadata,
+      invalid_tool_calls: original.invalid_tool_calls,
+      id: original.id,
+      name: original.name,
+      tool_calls: [backendToolCall],
+    });
     expect(
       interceptedContent
         .filter((block) => block.type === "tool_call")
@@ -615,8 +571,18 @@ describe("afterAgent", () => {
     ).toBe(false);
 
     const restored = copilotkitMiddleware.afterAgent(intercepted, {} as any)!;
-    const restoredContent = restored.messages.at(-1)!.content as any[];
+    const restoredMessage = restored.messages.at(-1) as AIMessage;
+    const restoredContent = restoredMessage.content as any[];
 
+    expect(restoredMessage).toMatchObject({
+      additional_kwargs: original.additional_kwargs,
+      response_metadata: original.response_metadata,
+      usage_metadata: original.usage_metadata,
+      invalid_tool_calls: original.invalid_tool_calls,
+      id: original.id,
+      name: original.name,
+      tool_calls: [backendToolCall, frontendToolCall],
+    });
     expect(
       restoredContent
         .filter((block) => block.type === "tool_call")

--- a/packages/sdk-js/src/langgraph/__tests__/middleware.test.ts
+++ b/packages/sdk-js/src/langgraph/__tests__/middleware.test.ts
@@ -496,6 +496,137 @@ describe("afterAgent", () => {
     expect(result!.copilotkit.interceptedToolCalls).toBeUndefined();
     expect(result!.copilotkit.originalAIMessageId).toBeUndefined();
   });
+
+  it("preserves AIMessage metadata through interception and restoration", () => {
+    const original = new AIMessage({
+      content: [
+        { type: "reasoning", reasoning: "Navigate to the details page." },
+        {
+          type: "tool_call",
+          id: "frontend-1",
+          name: "navigate",
+          args: { path: "/details" },
+        },
+      ],
+      tool_calls: [
+        {
+          id: "frontend-1",
+          name: "navigate",
+          args: { path: "/details" },
+        },
+      ],
+      additional_kwargs: { provider_request_id: "request-1" },
+      response_metadata: {
+        output_version: "v1",
+        status: "completed",
+      },
+      usage_metadata: {
+        input_tokens: 10,
+        output_tokens: 5,
+        total_tokens: 15,
+      },
+      invalid_tool_calls: [
+        {
+          id: "invalid-1",
+          name: "broken_tool",
+          args: "{",
+          error: "Invalid JSON",
+          type: "invalid_tool_call",
+        },
+      ],
+      id: "ai-metadata",
+      name: "assistant-with-tools",
+    });
+    const state = {
+      messages: [new HumanMessage("open details"), original],
+      copilotkit: { actions: [{ function: { name: "navigate" } }] },
+    };
+
+    const intercepted = copilotkitMiddleware.afterModel(state, {} as any)!;
+    const restored = copilotkitMiddleware.afterAgent(intercepted, {} as any)!;
+    const restoredMessage = restored.messages.at(-1) as AIMessage;
+
+    expect(restoredMessage.additional_kwargs).toEqual(
+      original.additional_kwargs,
+    );
+    expect(restoredMessage.response_metadata).toEqual(
+      original.response_metadata,
+    );
+    expect(restoredMessage.usage_metadata).toEqual(original.usage_metadata);
+    expect(restoredMessage.invalid_tool_calls).toEqual(
+      original.invalid_tool_calls,
+    );
+    expect(restoredMessage.name).toBe(original.name);
+  });
+
+  it("keeps v1 content blocks aligned with intercepted tool calls", () => {
+    const original = new AIMessage({
+      content: [
+        { type: "reasoning", reasoning: "Search, then open the result." },
+        {
+          type: "tool_call",
+          id: "backend-1",
+          name: "search",
+          args: { query: "CopilotKit" },
+        },
+        {
+          type: "tool_call",
+          id: "frontend-1",
+          name: "navigate",
+          args: { path: "/results" },
+        },
+        {
+          type: "tool_call_chunk",
+          id: "stale-1",
+          name: "stale",
+          args: "{}",
+        },
+      ],
+      tool_calls: [
+        {
+          id: "backend-1",
+          name: "search",
+          args: { query: "CopilotKit" },
+        },
+        {
+          id: "frontend-1",
+          name: "navigate",
+          args: { path: "/results" },
+        },
+      ],
+      response_metadata: { output_version: "v1" },
+      id: "ai-v1",
+    });
+    const state = {
+      messages: [original],
+      copilotkit: { actions: [{ name: "navigate" }] },
+    };
+
+    const intercepted = copilotkitMiddleware.afterModel(state, {} as any)!;
+    const interceptedContent = intercepted.messages.at(-1)!.content as any[];
+
+    expect(
+      interceptedContent
+        .filter((block) => block.type === "tool_call")
+        .map((block) => block.name),
+    ).toEqual(["search"]);
+    expect(
+      interceptedContent.some((block) => block.type === "tool_call_chunk"),
+    ).toBe(false);
+
+    const restored = copilotkitMiddleware.afterAgent(intercepted, {} as any)!;
+    const restoredContent = restored.messages.at(-1)!.content as any[];
+
+    expect(
+      restoredContent
+        .filter((block) => block.type === "tool_call")
+        .map((block) => block.name),
+    ).toEqual(["search", "navigate"]);
+    expect(restoredContent[0]).toEqual({
+      type: "reasoning",
+      reasoning: "Search, then open the result.",
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/sdk-js/src/langgraph/middleware.ts
+++ b/packages/sdk-js/src/langgraph/middleware.ts
@@ -360,6 +360,40 @@ const copilotKitStateSchema = z.object({
   ),
 });
 
+const isToolCallContentBlock = (block: unknown) =>
+  typeof block === "object" &&
+  block !== null &&
+  "type" in block &&
+  (block.type === "tool_call" || block.type === "tool_call_chunk");
+
+const usesV1ContentBlocks = (responseMetadata: unknown) =>
+  typeof responseMetadata === "object" &&
+  responseMetadata !== null &&
+  "output_version" in responseMetadata &&
+  responseMetadata.output_version === "v1";
+
+const rebuildAIMessageWithToolCalls = (
+  message: AIMessage,
+  toolCalls: AIMessage["tool_calls"],
+) => {
+  const content =
+    usesV1ContentBlocks(message.response_metadata) &&
+    Array.isArray(message.content)
+      ? message.content.filter((block) => !isToolCallContentBlock(block))
+      : message.content;
+
+  return new AIMessage({
+    content,
+    additional_kwargs: message.additional_kwargs,
+    response_metadata: message.response_metadata,
+    tool_calls: toolCalls,
+    invalid_tool_calls: message.invalid_tool_calls,
+    usage_metadata: message.usage_metadata,
+    id: message.id,
+    name: message.name,
+  });
+};
+
 const buildMiddlewareInput = (
   exposeState: ExposeStateOption,
   a2uiParams?: Omit<A2UIToolParams, "model">,
@@ -487,11 +521,10 @@ const buildMiddlewareInput = (
       if (AIMessage.isInstance(msg) && msg.id === originalMessageId) {
         messageFound = true;
         const existingToolCalls = msg.tool_calls || [];
-        return new AIMessage({
-          content: msg.content,
-          tool_calls: [...existingToolCalls, ...interceptedToolCalls],
-          id: msg.id,
-        });
+        return rebuildAIMessageWithToolCalls(msg, [
+          ...existingToolCalls,
+          ...interceptedToolCalls,
+        ]);
       }
       return msg;
     });
@@ -541,11 +574,10 @@ const buildMiddlewareInput = (
 
     if (frontendToolCalls.length === 0) return;
 
-    const updatedAIMessage = new AIMessage({
-      content: lastMessage.content,
-      tool_calls: backendToolCalls,
-      id: lastMessage.id,
-    });
+    const updatedAIMessage = rebuildAIMessageWithToolCalls(
+      lastMessage,
+      backendToolCalls,
+    );
 
     return {
       messages: [...state.messages.slice(0, -1), updatedAIMessage],

--- a/packages/sdk-js/src/langgraph/middleware.ts
+++ b/packages/sdk-js/src/langgraph/middleware.ts
@@ -376,11 +376,13 @@ const rebuildAIMessageWithToolCalls = (
   message: AIMessage,
   toolCalls: AIMessage["tool_calls"],
 ) => {
-  const content =
+  let content = message.content;
+  if (
     usesV1ContentBlocks(message.response_metadata) &&
-    Array.isArray(message.content)
-      ? message.content.filter((block) => !isToolCallContentBlock(block))
-      : message.content;
+    Array.isArray(content)
+  ) {
+    content = content.filter((block) => !isToolCallContentBlock(block));
+  }
 
   return new AIMessage({
     content,

--- a/packages/sdk-js/src/langgraph/middleware.ts
+++ b/packages/sdk-js/src/langgraph/middleware.ts
@@ -372,6 +372,12 @@ const usesV1ContentBlocks = (responseMetadata: unknown) =>
   "output_version" in responseMetadata &&
   responseMetadata.output_version === "v1";
 
+/**
+ * Rebuilds an AIMessage with `toolCalls` as the source of truth while
+ * preserving its non-tool content and metadata. For v1 content blocks, old
+ * tool blocks must be removed before construction so they cannot duplicate or
+ * override the supplied tool calls when AIMessage synchronizes both fields.
+ */
 const rebuildAIMessageWithToolCalls = (
   message: AIMessage,
   toolCalls: AIMessage["tool_calls"],


### PR DESCRIPTION
## What does this PR do?

- Preserve non-tool `AIMessage` fields when frontend tool calls are intercepted in `afterModel` and restored in `afterAgent`, including `additional_kwargs`, `response_metadata`, `usage_metadata`, `invalid_tool_calls`, `id`, and `name`.
- Use a shared rebuild helper with `tool_calls` as the source of truth. For LangChain v1 content blocks, remove stale `tool_call` and `tool_call_chunk` blocks before reconstructing the message.
- Add regression coverage for the `reasoning + backend/frontend tool calls -> afterModel -> afterAgent` flow, including metadata preservation and v1 content block synchronization.

## Related PRs and Issues

- Closes #6087
- Related to #4759 and #5308

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] Documentation is not required because this is an internal middleware bug fix with no public API changes
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)
