### PR TITLE
fix(showcase): built-in-agent OGUI + MCP-Apps drop injected tools

### DIFF
--- a/showcase/integrations/built-in-agent/src/lib/factory/mcp-apps-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/mcp-apps-factory.ts
@@ -1,11 +1,12 @@
 import { BuiltInAgent, convertInputToTanStackAI } from "@copilotkit/runtime/v2";
-import { chat } from "@tanstack/ai";
+import { chat, toolDefinition } from "@tanstack/ai";
 import { openaiText } from "@tanstack/ai-openai";
 // Custom fetch that injects ALS-bound inbound x-* headers (e.g.
 // x-aimock-context) onto every outbound OpenAI call. Required so aimock
 // can match fixtures by integration context. See ../header-forwarding.ts
 // for the full rationale; mirrors the Mastra precedent.
 import { forwardingFetch } from "../header-forwarding";
+import { jsonSchemaToZod } from "./tanstack-factory";
 
 const MCP_APPS_SYSTEM_PROMPT = `\
 You draw simple diagrams in Excalidraw via the MCP \`create_view\` tool.
@@ -30,20 +31,34 @@ make multiple \`create_view\` calls, do NOT iterate or refine.`;
 /**
  * Built-in agent for the MCP Apps demo.
  *
- * No bespoke tools — the runtime's `mcpApps.servers` config auto-applies the
- * MCP Apps middleware which exposes the remote MCP server's tools at
- * request time.
+ * The runtime's `mcpApps.servers` config makes `MCPAppsMiddleware` fetch the
+ * remote MCP server's tools and merge them into `input.tools` at request
+ * time. We MUST declare those tools to `chat()`, or the model never sees
+ * `create_view` and replies with plain text instead of rendering the
+ * Excalidraw view.
+ *
+ * Tools are declared via `toolDefinition()` (same pattern as
+ * `tanstack-factory.ts`) rather than reusing `convertInputToTanStackAI`'s
+ * `tools`, because that field only exists in @copilotkit/runtime >= 1.61.0
+ * and this app pins 1.60.2.
  */
 export function createMcpAppsAgent() {
   return new BuiltInAgent({
     type: "tanstack",
     factory: ({ input, abortController }) => {
       const { messages, systemPrompts } = convertInputToTanStackAI(input);
+      const tools = (input.tools ?? []).map((t) =>
+        toolDefinition({
+          name: t.name,
+          description: t.description ?? "",
+          inputSchema: jsonSchemaToZod(t.parameters),
+        }),
+      );
       return chat({
         adapter: openaiText("gpt-4o-mini", { fetch: forwardingFetch }),
         messages,
         systemPrompts: [MCP_APPS_SYSTEM_PROMPT, ...systemPrompts],
-        tools: [],
+        tools,
         abortController,
       });
     },

--- a/showcase/integrations/built-in-agent/src/lib/factory/ogui-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/ogui-factory.ts
@@ -1,30 +1,48 @@
 import { BuiltInAgent, convertInputToTanStackAI } from "@copilotkit/runtime/v2";
-import { chat } from "@tanstack/ai";
+import { chat, toolDefinition } from "@tanstack/ai";
 import { openaiText } from "@tanstack/ai-openai";
 // Custom fetch that injects ALS-bound inbound x-* headers (e.g.
 // x-aimock-context) onto every outbound OpenAI call. Required so aimock
 // can match fixtures by integration context. See ../header-forwarding.ts
 // for the full rationale; mirrors the Mastra precedent.
 import { forwardingFetch } from "../header-forwarding";
+import { jsonSchemaToZod } from "./tanstack-factory";
 
 /**
  * Built-in agent for the Open Generative UI demo.
  *
- * No bespoke tools — the runtime's `openGenerativeUI` flag (see
- * `src/app/api/copilotkit-ogui/route.ts`) injects the
- * `generateSandboxedUi` tool and wires the activity middleware. The agent
- * just needs an LLM that knows when to call it.
+ * The runtime's `openGenerativeUI` flag (see
+ * `src/app/api/copilotkit-ogui/route.ts`) makes `OpenGenerativeUIMiddleware`
+ * inject the `generateSandboxedUi` tool into `input.tools` at request time.
+ * We MUST declare those tools to `chat()`, or the model never sees
+ * `generateSandboxedUi` and emits the UI as a raw HTML code block instead of
+ * a tool call — so the sandboxed iframe never renders.
+ *
+ * Tools are declared via `toolDefinition()` (same pattern as
+ * `tanstack-factory.ts`) rather than reusing `convertInputToTanStackAI`'s
+ * `tools`, because that field only exists in @copilotkit/runtime >= 1.61.0
+ * and this app pins 1.60.2.
  */
 export function createOguiAgent() {
   return new BuiltInAgent({
     type: "tanstack",
     factory: ({ input, abortController }) => {
       const { messages, systemPrompts } = convertInputToTanStackAI(input);
+      // Declaration-only (no executor): the model calls the tool and the
+      // OpenGenerativeUIMiddleware turns the tool-call stream into the
+      // sandboxed-iframe activity.
+      const tools = (input.tools ?? []).map((t) =>
+        toolDefinition({
+          name: t.name,
+          description: t.description ?? "",
+          inputSchema: jsonSchemaToZod(t.parameters),
+        }),
+      );
       return chat({
         adapter: openaiText("gpt-4o", { fetch: forwardingFetch }),
         messages,
         systemPrompts,
-        tools: [],
+        tools,
         abortController,
       });
     },

--- a/showcase/integrations/built-in-agent/src/lib/factory/tanstack-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/tanstack-factory.ts
@@ -20,8 +20,11 @@ import { forwardingFetch } from "../header-forwarding";
  * schema is only used for LLM tool-call declaration, not runtime
  * validation.
  */
+// Exported so the OGUI and MCP-Apps factories can declare the tools that
+// their runtime middleware injects into `input.tools` (see ogui-factory.ts /
+// mcp-apps-factory.ts) without duplicating this conversion.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function jsonSchemaToZod(schema: any): z.ZodTypeAny {
+export function jsonSchemaToZod(schema: any): z.ZodTypeAny {
   if (!schema || typeof schema !== "object") return z.object({});
   if (schema.type === "object" && schema.properties) {
     const shape: Record<string, z.ZodTypeAny> = {};


### PR DESCRIPTION
## What

Fixes three broken **Built-in Agent** showcase demos by forwarding the tools that runtime middleware injects into `input.tools`. The in-process TanStack factories were dropping them with `tools: []`.

- **open-gen-ui** — agent now calls `generateSandboxedUi` (was emitting the UI as a raw HTML code block)
- **open-gen-ui-advanced** — same factory/route; the sandbox → host callbacks can now engage
- **mcp-apps** — agent now sees `create_view` and can render the Excalidraw view (was replying with plain text)

## Why

`OpenGenerativeUIMiddleware` / `MCPAppsMiddleware` inject their tool into `input.tools` at request time. The working main `tanstack-factory.ts` forwards `input.tools` into `chat({ tools })`, but `ogui-factory.ts` and `mcp-apps-factory.ts` hard-coded `tools: []` — so the model never received the tool and fell back to prose/HTML. This is exactly why the demos look broken on the **live Railway deploy** (real LLM): given no tool, a real model just prints the UI as text.

## How

Declare the injected tools via `toolDefinition()` — the same pattern the main factory already uses — and `export` its `jsonSchemaToZod` helper for reuse (no duplication).

Note: `convertInputToTanStackAI(input).tools` would be simpler, but that return field only exists in `@copilotkit/runtime >= 1.61.0`. This app pins **1.60.2**, so the `toolDefinition()` route is the version-safe fix.

## Verification

- ✅ `tsc --noEmit` against the pinned `@copilotkit/runtime@1.60.2` — the three changed files are type-clean. (The app has pre-existing, unrelated zod-version-skew tsc errors in the A2UI catalog files; those are on `main` and untouched here.)
- ⚠️ **D5/D6 aimock replay was NOT run** — no Docker in my environment. Needs a CI / Docker-capable run to confirm the demos render.
- ⚠️ **Fixtures may need re-recording.** The aimock fixtures for `gen-ui-open`, `gen-ui-open-advanced`, and `mcp-apps` (built-in-agent) may have been captured in the broken (no-tool-call) state; if so, replay won't demonstrate the fix until they're re-recorded against a real LLM (showcase Procedure 3). Please confirm the D5/D6 run and re-record if needed.

## Follow-ups

- After merge, **redeploy the built-in-agent Railway service** so the live showcase reflects the fix.
- P0 slice of the broader **OSS-594** parity effort; structural drift + runtime-capability gaps are tracked in that ticket.

Refs OSS-594.
