### PR TITLE
fix(showcase): restore 3 suggestion pills on built-in-agent prebuilt demos

### DIFF
--- a/showcase/integrations/built-in-agent/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/prebuilt-popup/page.tsx
@@ -1,11 +1,8 @@
 "use client";
 
 import React from "react";
-import {
-  CopilotKitProvider,
-  CopilotPopup,
-  useConfigureSuggestions,
-} from "@copilotkit/react-core/v2";
+import { CopilotKitProvider, CopilotPopup } from "@copilotkit/react-core/v2";
+import { usePrebuiltPopupSuggestions } from "./suggestions";
 
 // Outer layer — provider + main content + floating popup launcher.
 export default function PrebuiltPopupDemo() {
@@ -43,9 +40,6 @@ function MainContent() {
 }
 
 function Suggestions() {
-  useConfigureSuggestions({
-    suggestions: [{ title: "Say hi", message: "Say hi from the popup!" }],
-    available: "always",
-  });
+  usePrebuiltPopupSuggestions();
   return null;
 }

--- a/showcase/integrations/built-in-agent/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/prebuilt-sidebar/page.tsx
@@ -1,11 +1,8 @@
 "use client";
 
 import React from "react";
-import {
-  CopilotKitProvider,
-  CopilotSidebar,
-  useConfigureSuggestions,
-} from "@copilotkit/react-core/v2";
+import { CopilotKitProvider, CopilotSidebar } from "@copilotkit/react-core/v2";
+import { usePrebuiltSidebarSuggestions } from "./suggestions";
 
 // Outer layer — provider + main content + sidebar.
 export default function PrebuiltSidebarDemo() {
@@ -39,9 +36,6 @@ function MainContent() {
 }
 
 function Suggestions() {
-  useConfigureSuggestions({
-    suggestions: [{ title: "Say hi", message: "Say hi!" }],
-    available: "always",
-  });
+  usePrebuiltSidebarSuggestions();
   return null;
 }


### PR DESCRIPTION
## What

The built-in-agent **prebuilt-sidebar** and **prebuilt-popup** demos each rendered a single hard-coded "Say hi" suggestion pill, even though a correct 3-pill hook (`usePrebuiltSidebarSuggestions` / `usePrebuiltPopupSuggestions`, byte-identical to `langgraph-python`) already lived in each demo's own `suggestions.ts` — just never imported. This wires the existing hooks so the pills match canonical:

- **prebuilt-sidebar**: Say hi · Fun fact · Is 17 prime?
- **prebuilt-popup**: Say hi · Limerick · Is 17 prime?

## Why

Classic scaffold-then-drift: the flavor was copied from canonical (bringing the `suggestions.ts` hook along) but each `page.tsx` was hand-written with a degraded inline single-pill version and never wired back. Part of the **OSS-594** P1a "orphaned suggestions" cleanup.

## How

Call the existing hook from each `page.tsx` and drop the now-unused `useConfigureSuggestions` import. No new files; the only behavior change is the suggestion set.

## Verification

- lefthook (`oxlint` + `oxfmt`) clean on commit.
- Leans on CI `build-check (built-in-agent…)` + `check-types` — both green on the sibling P0 PR #6100 for the same app.
- 6 insertions / 18 deletions across 2 files.

Refs OSS-594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
