### PR TITLE
fix(showcase/mastra): D6 follow-ups to #5798 — gen-ui-agent step cap + useComponent probe path (OSS-381)

### DIFF
--- a/showcase/aimock/d6/mastra/gen-ui-custom.json
+++ b/showcase/aimock/d6/mastra/gen-ui-custom.json
@@ -1,0 +1,41 @@
+{
+  "_meta": {
+    "description": "D6 fixtures for mastra / gen-ui-custom (pie chart path). Mastra's gen-ui-tool-based page is the LGP-style useComponent chart demo (render_pie_chart / render_bar_chart), so it takes the CHART_INTEGRATIONS branch of the d5-gen-ui-custom probe. Mirrors langgraph-python/gen-ui-custom.json with context: mastra.",
+    "sourceFile": "harness/fixtures/d5/gen-ui-custom.json",
+    "copiedFrom": "langgraph-python",
+    "created": "2026-07-22"
+  },
+  "fixtures": [
+    {
+      "_comment": "gen-ui-custom pie chart — first leg: emit render_pie_chart tool call. hasToolResult:false ensures this only matches when there's no prior tool result in the conversation. Narration content (with 'pie chart' tokens) is inlined so the D5 probe's last-assistant-text assertion passes even when the runtime does not re-invoke the LLM after a frontend tool result returns. chunkSize: 9999 keeps the large render_pie_chart args in a single chunk so partial-JSON tool-call parsing can't trip RUN_ERROR.",
+      "match": {
+        "userMessage": "Show me a pie chart of revenue by category",
+        "hasToolResult": false,
+        "context": "mastra"
+      },
+      "response": {
+        "content": "Pie chart rendered above — Electronics is the largest slice, followed by Clothing, Food, and Books.",
+        "toolCalls": [
+          {
+            "id": "call_d5_render_pie_chart_001",
+            "name": "render_pie_chart",
+            "arguments": "{\"title\":\"Revenue by Category\",\"description\":\"Revenue breakdown by product category (Q4)\",\"data\":[{\"label\":\"Electronics\",\"value\":42000},{\"label\":\"Clothing\",\"value\":28000},{\"label\":\"Food\",\"value\":18000},{\"label\":\"Books\",\"value\":12000}]}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
+      "_comment": "gen-ui-custom pie chart — second leg: narration after the pie chart tool result lands. Safety net for when the runtime DOES loop back to the LLM. The follow-up text contains 'pie' and 'chart' tokens — the D5 probe asserts their presence.",
+      "match": {
+        "userMessage": "Show me a pie chart of revenue by category",
+        "hasToolResult": true,
+        "context": "mastra"
+      },
+      "response": {
+        "content": "Pie chart rendered above — Electronics is the largest slice, followed by Clothing, Food, and Books."
+      },
+      "chunkSize": 9999
+    }
+  ]
+}

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-custom.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-custom.test.ts
@@ -268,7 +268,10 @@ describe("d5-gen-ui-custom script", () => {
   it("haiku: assertion FAILS when haiku card has zero children (empty wrapper)", async () => {
     const { script } = await loadFreshRegistry();
     const turn = script.buildTurns({
-      integrationSlug: "mastra",
+      // agno is a genuine haiku integration; mastra was moved to
+      // CHART_INTEGRATIONS (it's an LGP-style useComponent chart demo), so it
+      // no longer takes the haiku path here.
+      integrationSlug: "agno",
       featureType: "gen-ui-custom",
       baseUrl: "https://example.com",
     })[0]!;

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-custom.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-custom.ts
@@ -49,6 +49,13 @@ const CHART_INTEGRATIONS = new Set([
   // `render_pie_chart` + `render_bar_chart` via `useComponent` like LGP
   // does, not the legacy `generate_haiku` shape.
   "google-adk",
+  // mastra's gen-ui-tool-based page is the same LGP-style `useComponent`
+  // chart demo (render_pie_chart / render_bar_chart), not the haiku shape.
+  // Without this entry the probe sent the haiku prompt and looked for a
+  // haiku card the demo can't produce, so the assistant bubble came back
+  // empty ("rendered but has no text content"). Surfaced once OSS-381 took
+  // the cell out of not_supported. Pairs with aimock/d6/mastra/gen-ui-custom.json.
+  "mastra",
 ]);
 
 /**

--- a/showcase/integrations/mastra/src/mastra/agents/index.ts
+++ b/showcase/integrations/mastra/src/mastra/agents/index.ts
@@ -332,6 +332,16 @@ export const genUiAgent = new Agent({
   name: "Gen UI Agent",
   tools: { setStepsTool },
   model: openai("gpt-4o-mini"),
+  // The planner scripts 3 steps × 2 set_steps transitions (in_progress →
+  // completed) + 1 initial "all pending" call + 1 closing message = ~8 model
+  // turns. The AI SDK's default stop condition halts the agentic loop before
+  // the 3rd step reaches "completed" (only 2/3 land), so raise the step cap to
+  // run the full progression. LangGraph (gold) loops until the graph ends and
+  // needs no equivalent; this is the AI-SDK step-cap analogue (cf.
+  // toolRenderingAgent's d20 sequence).
+  defaultOptions: {
+    stopWhen: stepCountIs(12),
+  },
   instructions: `You are an agentic planner. For each user request, follow this exact sequence:
 1. Plan exactly 3 concrete steps and call \`set_steps\` ONCE with all three steps at status="pending".
 2. Step 1: call \`set_steps\` with step 1 at status="in_progress", then call \`set_steps\` again with step 1 at status="completed".


### PR DESCRIPTION
## What

Two mastra showcase D6 follow-ups to #5798 (v1 bridge alpha). Both cells went red the moment #5798 took them out of `not_supported_features` — they were claimed supported before actually passing. **Neither is a v1-bridge streaming regression.**

## Commits

**1. gen-ui-agent completes all 3 steps (raise step cap)** — `57afed6dd`
"Generative UI: Agent State" (gen-ui-agent) stalled at 2/3 steps: `genUiAgent` set no stop condition, so the AI SDK default halted the agentic loop before the 3rd step completed. Adds `defaultOptions.stopWhen = stepCountIs(12)`. Verified 6/6 on the Node-22 + `next start` + aimock replay rig; tool-rendering / gen-ui-tool-based unaffected.

**2. useComponent (gen-ui-tool-based) — probe took the wrong path** — `4640d6304`
The D5 `gen-ui-custom` probe omitted `mastra` from `CHART_INTEGRATIONS`, so it sent the *haiku* prompt and hunted for a haiku card. mastra's demo is the LGP-style `useComponent` chart demo (`render_pie_chart` / `render_bar_chart`) with no haiku tool, so the assistant bubble came back empty (*"haiku card [data-testid=copilot-assistant-message] rendered but has no text content"*).
- Add `"mastra"` to `CHART_INTEGRATIONS`.
- Add `aimock/d6/mastra/gen-ui-custom.json` (mirrors langgraph-python; identical pie schema `{title, description, data:[{label,value}]}`) so the cell is deterministic under replay instead of falling through to the live upstream.
- Repoint the probe unit test's haiku-empty-card case from `"mastra"` → `"agno"` (a genuine haiku integration).

## Verification

- gen-ui-agent: 6/6 on the faithful rig.
- useComponent: logic-only harness + fixture changes; harness unit tests run in CI (sparse local checkout has no vitest).

## Refs

- Follow-on to #5798. Linear **OSS-381** (mastra refresh umbrella).
- Companion `@ag-ui/mastra` PR — multi-turn Responses-API message-id 400 fix: ag-ui-protocol/ag-ui#2227.
- Sibling from the same triage (separate, not fixed here): **PNI-100** — hitl-in-app follow-up-run gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
