### PR TITLE
fix(examples): expose frontend tools to the ADK agent via AGUIToolset [OSS-561]

### DIFF
--- a/examples/integrations/adk/agent/main.py
+++ b/examples/integrations/adk/agent/main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Dict, Optional
 
-from ag_ui_adk import ADKAgent, add_adk_fastapi_endpoint
+from ag_ui_adk import ADKAgent, add_adk_fastapi_endpoint, AGUIToolset
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from google.adk.agents import LlmAgent
@@ -166,7 +166,11 @@ proverbs_agent = LlmAgent(
         - "Whats the weather right now" → Use the location "Everywhere ever in the whole wide world"
         - Is it raining in London? → Use the tool with the location "London"
         """,
-    tools=[set_proverbs, get_weather],
+    # AGUIToolset exposes the frontend-registered tools (e.g. setThemeColor) to
+    # the LLM: ag_ui_adk swaps it for a ClientProxyToolset wired to the run's
+    # forwarded client tools. Without it, only the server tools below are visible
+    # and the agent can't call frontend tools.
+    tools=[set_proverbs, get_weather, AGUIToolset()],
     before_agent_callback=on_before_agent,
     before_model_callback=before_model_modifier,
     after_model_callback=simple_after_model_modifier,


### PR DESCRIPTION
## What & why

The **"Frontend Tools"** demo (`setThemeColor`) silently fails in `examples/integrations/adk`: asking "set the theme to green" makes the agent reply *"I can only help with proverbs or the weather"* and nothing recolors.

**Root cause:** the ADK agent's tools are static `[set_proverbs, get_weather]`. `ag_ui_adk` only injects a run's forwarded client tools (the frontend-registered `setThemeColor`) into the LLM's tool set when the agent's `tools` include an **`AGUIToolset`** placeholder — it swaps that for a `ClientProxyToolset` wired to `input.tools`. Without it, `gemini-2.5-flash` never sees `setThemeColor` and declines. (No CopilotKit ADK example currently includes `AGUIToolset`, and the docs don't mention it.)

## Change

```python
from ag_ui_adk import ADKAgent, add_adk_fastapi_endpoint, AGUIToolset
...
tools=[set_proverbs, get_weather, AGUIToolset()],
```

Agent-side only; no prompt change needed.

## Testing

Verified **live** (real Gemini key) via the identical change in `examples/integrations/adk-angular` (same `agent/main.py` + `ag_ui_adk` adapter): "Set the theme to green" now recolors the panel; before the fix the agent refused. Because the fix is agent-side and framework-agnostic, and `setThemeColor` was already confirmed forwarded in the run body, the React `adk` frontend + this agent behaves identically.

## Related

- Companion to CopilotKit/CopilotKit#6097 (the new `adk-angular` example carries the same fix).
- Discovered while validating #6097 by live-comparing Angular vs React ADK behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)