### PR TITLE
fix(showcase): gateIgnore showcase-angular-preview to unblock fleet deploys

### DIFF
--- a/showcase/scripts/__tests__/emit-railway-envs-json.test.ts
+++ b/showcase/scripts/__tests__/emit-railway-envs-json.test.ts
@@ -25,7 +25,7 @@ describe("emit-railway-envs-json", () => {
     expect(json.projectId).toBe("6f8c6bff-a80d-4f8f-b78d-50b32bcf4479");
     expect(json.envIds.staging).toBe("8edfef02-ea09-4a20-8689-261f21cc2849");
     expect(json.envIds.prod).toBe("b14919f4-6417-429f-848d-c6ae2201e04f");
-    expect(json.services.length).toBe(41);
+    expect(json.services.length).toBe(42);
     const docs = json.services.find((s: { name: string }) => s.name === "docs");
     expect(docs.domains.staging).toBe("docs.staging.copilotkit.ai");
     expect(docs.domains.prod).toBe("docs.copilotkit.ai");

--- a/showcase/scripts/__tests__/fixtures/railway-envs.golden.json
+++ b/showcase/scripts/__tests__/fixtures/railway-envs.golden.json
@@ -159,6 +159,15 @@
       "repoName": "showcase-agno"
     }
   },
+  "showcase-angular-preview": {
+    "staging": {
+      "instanceId": "a86a647a-32ac-4f9a-a71c-351b81bf878c",
+      "domain": null,
+      "probe": false,
+      "driver": "shell",
+      "repoName": "showcase-angular"
+    }
+  },
   "showcase-built-in-agent": {
     "prod": {
       "instanceId": "40018ef7-1ed1-4979-b80c-9c2d957b6d88",

--- a/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
+++ b/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
@@ -33,7 +33,7 @@ describe("ServiceEntry gateIgnore field", () => {
     // branch below. S2: the 12 starter-<slug> services are likewise NO LONGER
     // gate-ignored — they are fully gate-managed (gateValidated, no
     // gateIgnore), exactly like every showcase-* agent.
-    const GATE_IGNORED = new Set<string>([]);
+    const GATE_IGNORED = new Set<string>(["showcase-angular-preview"]);
     const isGateIgnored = (name: string): boolean => GATE_IGNORED.has(name);
     for (const [name, entry] of Object.entries(SERVICES)) {
       const gi = (entry as ServiceEntry).gateIgnore;
@@ -260,18 +260,17 @@ describe("WS-C: all gate-managed services gateValidated, with correct overrides"
     ["harness", "showcase-harness"],
   ] as const;
 
-  it("has 41 services in the SSOT (29 showcase/infra + 12 starter-*)", () => {
-    expect(Object.keys(SERVICES)).toHaveLength(41);
+  it("has 42 services in the SSOT (30 showcase/infra + 12 starter-*)", () => {
+    expect(Object.keys(SERVICES)).toHaveLength(42);
   });
 
   it("marks every gate-managed service gateValidated (no Phase-2 holdouts)", () => {
-    // There is no longer ANY gateIgnore:true / gateValidated:false holdout: the
-    // `harness-workers` worker, formerly the sole exception, has been
-    // backfilled as a dual-env gateValidated:true service. S2 brought the 12
-    // starter-<slug> services UNDER the gate (gateValidated:true);
-    // `showcase-strands-typescript` is provisioned in prod and gateValidated
-    // too — so EVERY service must now be gateValidated:true.
-    const GATE_IGNORED = new Set<string>([]);
+    // Every gate-managed service must be gateValidated:true. The sole current
+    // exception is `showcase-angular-preview` — a TEMPORARY gateIgnore holdout
+    // (staging-only Angular preview running an out-of-band image) added to
+    // unblock the fleet build gate; remove it once that preview is promoted to
+    // a gate-validated service or torn down on Railway (see CPK-7709).
+    const GATE_IGNORED = new Set<string>(["showcase-angular-preview"]);
     const isGateIgnored = (name: string): boolean => GATE_IGNORED.has(name);
     const unvalidated = Object.entries(SERVICES)
       .filter(([name, entry]) => !entry.gateValidated && !isGateIgnored(name))

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -329,6 +329,31 @@
       }
     },
     {
+      "name": "showcase-angular-preview",
+      "serviceId": "935f7db0-7b50-4e3d-8105-345425aaebf3",
+      "prodInstanceId": "935f7db0-7b50-4e3d-8105-345425aaebf3",
+      "stagingInstanceId": "a86a647a-32ac-4f9a-a71c-351b81bf878c",
+      "ciBuilt": false,
+      "gateValidated": false,
+      "repoNameOverride": {
+        "staging": "showcase-angular"
+      },
+      "domains": {
+        "staging": "",
+        "prod": ""
+      },
+      "probe": {
+        "staging": false,
+        "prod": false,
+        "driver": "shell"
+      },
+      "promoteTier": 2,
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "disabled"
+      }
+    },
+    {
       "name": "showcase-built-in-agent",
       "serviceId": "f4f8371a-bc46-45b2-b6d4-9c9af608bdbf",
       "prodInstanceId": "40018ef7-1ed1-4979-b80c-9c2d957b6d88",
@@ -1548,6 +1573,11 @@
         "tier": 2
       }
     ],
-    "skipped": []
+    "skipped": [
+      {
+        "name": "showcase-angular-preview",
+        "reason": "no \"prod\" environment in the SSOT — cannot be promoted (it exists in: staging)."
+      }
+    ]
   }
 }

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -107,9 +107,9 @@ describe("railway-envs SSOT", () => {
     expect(ENV_IDS.staging).toBe(STAGING_ENV_ID);
   });
 
-  it("contains exactly 41 services (29 showcase/infra + 12 starter-*)", () => {
+  it("contains exactly 42 services (30 showcase/infra + 12 starter-*)", () => {
     const names = listServiceNames();
-    expect(names.length).toBe(41);
+    expect(names.length).toBe(42);
   });
 
   it("contains the expected canonical services", () => {

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -841,6 +841,39 @@ export const SERVICES: Record<
       },
     },
   },
+  // TEMPORARY — remove me (see CPK-7709). Tracked here ONLY to clear the
+  // Railway->SSOT "untracked service" check in verify-railway-image-refs.ts,
+  // which is currently failing every `Showcase: Build & Push` run on main and
+  // skipping the build + Railway staging redeploy fleet-wide.
+  //
+  // `showcase-angular-preview` is a STAGING-ONLY Angular preview service that
+  // runs the out-of-band `ghcr.io/copilotkit/showcase-angular` image (NOT built
+  // by showcase_build.yml), stood up for the Angular-in-Showcase work
+  // (ENT-1164). It is deliberately UNMANAGED by WS4:
+  //   - gateIgnore:true     -> image-ref gate ignores it in BOTH directions
+  //   - ciBuilt:false        -> excluded from the CI redeploy scope
+  //   - gateValidated:false  -> not shape-checked by the image-ref gate
+  //   - probe:false          -> verify-deploy does not probe it
+  // Remove this entry once the preview is either promoted to a real,
+  // gate-validated fleet service or torn down on Railway.
+  "showcase-angular-preview": {
+    serviceId: "935f7db0-7b50-4e3d-8105-345425aaebf3",
+    autoUpdates: { staging: "disabled", prod: "disabled" },
+    ciBuilt: false,
+    gateValidated: false,
+    gateIgnore: true,
+    // probe:false + gateIgnore, so the driver is inert; "shell" (a frontend
+    // surface) avoids the `agent`-driver contract that mandates
+    // runtimeDeps:["aimock"] (this preview is not an aimock-routing agent).
+    probeDriver: "shell",
+    environments: {
+      staging: {
+        instanceId: "a86a647a-32ac-4f9a-a71c-351b81bf878c",
+        probe: false,
+        repoName: "showcase-angular",
+      },
+    },
+  },
   pocketbase: {
     serviceId: "ba11e854-d695-4738-9a45-2b0776788824",
     autoUpdates: { staging: "disabled", prod: "disabled" },


### PR DESCRIPTION
## What

Adds a **temporary** `gateIgnore` SSOT entry for the live `showcase-angular-preview` Railway service so `verify-railway-image-refs.ts` stops failing the fleet build gate. The running service is **not** touched (no image deleted).

## Why

Every `Showcase: Build & Push` on `main` was failing at the `verify-image-refs` pre-flight: Railway has a live `showcase-angular-preview` service (staging-only Angular preview, out-of-band `ghcr.io/copilotkit/showcase-angular` image, from the Angular-in-Showcase work) with **no SSOT entry** → flagged "untracked". Because `build` needs `verify-image-refs`, that failure **skipped the build + Railway staging redeploy fleet-wide** — so recently-merged fixes never reached staging. See **CPK-7709**.

## How

Register it as a deliberately-unmanaged entry — `gateIgnore: true`, `ciBuilt: false`, `gateValidated: false`, `probe: false`, staging-only — mirroring the former `harness-legacy`/`harness-workers` gateIgnore pattern. Regenerated `railway-envs.generated.json` and the golden fixture, and updated the gate-holdout allowlists + service-count assertions to include it.

## Verification

- Full `showcase/scripts` suite: **2254 tests pass** (66 files).
- The real gate, run against Railway: `✓ 82 env-scoped instances verified (1 skipped)` — the `showcase-angular-preview` untracked-service failure is gone (the "1 skipped" is this gateIgnore entry).
- Module-load SSOT assertions pass (emit succeeds); the promote dropdown regenerates with no change (this service is correctly non-promotable).

## Temporary

Marked TEMPORARY in code + tests. **Remove this entry** once `showcase-angular-preview` is promoted to a real gate-validated fleet service or torn down on Railway. The systemic hardening (make the gate warn — not hard-fail — on a single untracked service) is tracked separately in CPK-7709.

Refs CPK-7709. Unblocks the merged OSS-594 fixes (#6100, #6102) from reaching staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
