### PR TITLE
fix(examples): adk-angular a11y (closed chat inert) + dev inspector out of prod bundle

### DIFF
--- a/examples/integrations/adk-angular/src/app/app.ts
+++ b/examples/integrations/adk-angular/src/app/app.ts
@@ -1,4 +1,4 @@
-import { Component, signal } from "@angular/core";
+import { Component, isDevMode, signal } from "@angular/core";
 import {
   CopilotChat,
   CopilotThreadsDrawer,
@@ -49,7 +49,14 @@ const DOCK_BREAKPOINT_PX = 1200;
       on narrower screens it OVERLAYS instead so the content isn't smushed.
       Closeable via the header X.
     -->
-    <aside class="chat" [class.chat--open]="chatOpen()" aria-label="Assistant">
+    <!-- inert while closed: the panel is only translated off-screen, so without
+         this its inputs/buttons stay in the tab order and screen-reader tree. -->
+    <aside
+      class="chat"
+      [class.chat--open]="chatOpen()"
+      [attr.inert]="chatOpen() ? null : ''"
+      aria-label="Assistant"
+    >
       <header class="chat__bar">
         <span>Assistant</span>
         <button
@@ -77,8 +84,12 @@ const DOCK_BREAKPOINT_PX = 1200;
       <lucide-angular [img]="ChatIcon" [size]="24" />
     </button>
 
-    <!-- Dev-only floating inspector (mounts into <body>). Remove for production. -->
-    <app-web-inspector />
+    <!-- Dev-only floating inspector (mounts into <body>). @defer keeps it — and
+         its @copilotkit/web-inspector dependency — out of the production initial
+         bundle: in a prod build isDev is false, so the deferred chunk never loads. -->
+    @defer (when isDev) {
+      <app-web-inspector />
+    }
   `,
   styles: [
     `
@@ -212,6 +223,8 @@ export class App {
   /** lucide icons matching React's sidebar (X for close, MessageCircle to open). */
   protected readonly CloseIcon = X;
   protected readonly ChatIcon = MessageCircle;
+  /** Dev-only: gates the @defer'd web inspector so it stays out of prod builds. */
+  protected readonly isDev = isDevMode();
 
   constructor() {
     // 🪁 Frontend tool: recolor the center panel (and, via --app-theme-color on


### PR DESCRIPTION
Two issues found in review after `examples/integrations/adk-angular` merged (#6097).

## 1. Closed chat stayed keyboard-accessible off-screen
The collapsible chat panel is only translated off-screen (`transform: translateX(100%)`), so its `copilot-chat` inputs/buttons remained in the tab order and the accessibility tree while "closed."

**Fix:** mark the `<aside>` `inert` while closed (`[attr.inert]="chatOpen() ? null : ''"`); removed when open.

## 2. Dev inspector shipped in the production bundle
The `cpk-web-inspector` dev aid (and its `@copilotkit/web-inspector` dependency, ~660 kB) was statically imported, so it landed in the **4.59 MB** production initial bundle.

**Fix:** gate it behind `@defer (when isDev)` (`isDev = isDevMode()`), splitting it into a lazy chunk that a production build (`isDev` = false) never loads.

## Testing (live)

- **Prod build** (`ng build`): initial bundle **4.59 MB → 3.93 MB**; `@copilotkit/web-inspector` is now a separate lazy chunk (660 kB) that prod never loads.
- **Dev serve**: the inspector still mounts (`@defer` triggers when `isDev`).
- **a11y**: with the chat closed, focusing a control inside the panel is blocked (`document.activeElement` falls back to `body`); open panel unaffected; the toggle FAB still reopens it.
- `oxlint` 0/0.

Follow-up to OSS-561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)