### PR TITLE
docs(shell-docs): add LangSmith Platform deploy guide (LangGraph + ADK)

### DIFF
--- a/.github/workflows/showcase_eval.yml
+++ b/.github/workflows/showcase_eval.yml
@@ -288,6 +288,27 @@ jobs:
       - name: Install Playwright chromium
         run: npx playwright install chromium --with-deps
 
+      # docker-compose.local.yml declares `env_file: .env` on every service, so
+      # `docker compose` hard-fails if showcase/.env is missing — and .env is
+      # gitignored (only .env.example is committed). Provision it here so the
+      # eval's self-provisioning lifecycle can bring the fleet up. Values are
+      # dummies: aimock serves the recorded fixtures and never validates tokens
+      # (see showcase/.env.example), and the aimock base URLs are already
+      # hardcoded in the compose `environment:` block — these are belt-and-braces.
+      - name: Provision showcase/.env for compose (aimock replay)
+        run: |
+          cat > showcase/.env <<'EOF'
+          OPENAI_API_KEY=sk-aimock-dev-ci-only
+          ANTHROPIC_API_KEY=sk-aimock-dev-ci-only
+          GOOGLE_API_KEY=fake-gemini-key
+          LANGSMITH_API_KEY=ls-mock-ci-only
+          GitHubToken=gh-mock-local-dev
+          OPENAI_BASE_URL=http://aimock:4010/v1
+          ANTHROPIC_BASE_URL=http://aimock:4010
+          SPRING_AI_OPENAI_BASE_URL=http://aimock:4010
+          AIMOCK_URL=http://aimock:4010
+          EOF
+
       - name: Run showcase eval
         id: run-eval
         run: |

--- a/.github/workflows/showcase_eval.yml
+++ b/.github/workflows/showcase_eval.yml
@@ -295,8 +295,18 @@ jobs:
 
           # Build the command. EVAL_SCOPE_FLAG may contain spaces (e.g. "--slug mastra,agno")
           # so we intentionally leave it unquoted for word splitting.
+          #
+          # NOTE: no `--ci`. This job runs on a bare runner with NO step that
+          # starts the showcase fleet, so the eval must self-provision. `--ci`
+          # tells the CLI to skip the Docker lifecycle and assume the fleet is
+          # already running (see showcase/harness/src/cli/eval/index.ts), which
+          # here means no healthy container → instant failure. Without it, the
+          # CLI builds + starts the in-scope slug(s) + aimock and health-checks
+          # them before running. `compose()` uses piped (captured) stdio and the
+          # eval's progress logs are all `if (!opts.json)`-guarded, so `--json`
+          # keeps stdout clean JSON for the post-result job to parse.
           # shellcheck disable=SC2086
-          CMD="showcase/bin/showcase eval --${EVAL_LEVEL} ${EVAL_SCOPE_FLAG} --parallel 8 --json --baseline compare --timeout 60000 --ci"
+          CMD="showcase/bin/showcase eval --${EVAL_LEVEL} ${EVAL_SCOPE_FLAG} --parallel 8 --json --baseline compare --timeout 60000"
           echo "::group::Running: $CMD"
 
           EXIT_CODE=0

--- a/.github/workflows/showcase_eval.yml
+++ b/.github/workflows/showcase_eval.yml
@@ -38,6 +38,10 @@ on:
         required: false
         default: "d5"
         type: string
+      slug:
+        description: "Integration slug(s) to eval, comma-separated (e.g. mastra). Empty = affected."
+        required: false
+        type: string
 
 concurrency:
   group: showcase-eval-${{ github.event.inputs.pr_number || github.event.issue.number || github.run_id }}
@@ -223,10 +227,42 @@ jobs:
       pr_sha: ${{ steps.resolve.outputs.sha }}
       pr_number: ${{ github.event.inputs.pr_number }}
       level: ${{ github.event.inputs.level || 'd5' }}
-      scope_flag: "--scope affected"
-      scope_display: "affected"
+      scope_flag: ${{ steps.scope.outputs.scope_flag }}
+      scope_display: ${{ steps.scope.outputs.scope_display }}
       check_run_id: ${{ github.event.inputs.check_run_id }}
     steps:
+      - name: Resolve scope from slug input
+        id: scope
+        # `slug` is UNTRUSTED input — read via env, never inline into the shell.
+        # Empty slug keeps the historical default (--scope affected). A provided
+        # slug lets a manual dispatch target one integration like the comment
+        # path (`/eval d5 mastra`), so the fleet bring-up stays bounded instead
+        # of building every affected image.
+        env:
+          SLUG_INPUT: ${{ github.event.inputs.slug }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SLUG_INPUT:-}" ]; then
+            echo "scope_flag=--scope affected" >> "$GITHUB_OUTPUT"
+            echo "scope_display=affected" >> "$GITHUB_OUTPUT"
+          else
+            # Validate each slug against ^[a-z0-9-]+$ (same rule as the comment
+            # gate) before it reaches the eval command unquoted.
+            IFS=',' read -ra SLUGS <<< "$SLUG_INPUT"
+            for s in "${SLUGS[@]}"; do
+              s=$(printf '%s' "$s" | xargs)  # trim whitespace
+              case "$s" in
+                ''|*[!a-z0-9-]*)
+                  echo "::error::Invalid slug '$s' — must match ^[a-z0-9-]+$"
+                  exit 1
+                  ;;
+              esac
+            done
+            CLEAN=$(printf '%s' "$SLUG_INPUT" | tr -d ' ')
+            echo "scope_flag=--slug $CLEAN" >> "$GITHUB_OUTPUT"
+            echo "scope_display=$CLEAN" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Resolve PR HEAD SHA
         id: resolve
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/showcase/harness/src/cli/eval/index.ts
+++ b/showcase/harness/src/cli/eval/index.ts
@@ -23,7 +23,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { loadConfig } from "../config.js";
-import { up, down, isRunning } from "../lifecycle.js";
+import { up, down, isRunning, healthCheck } from "../lifecycle.js";
 import { createLogger, reloadLogLevel } from "../../logger.js";
 
 // Sibling modules created by other blitz agents — imports written against
@@ -376,20 +376,26 @@ export async function runEval(opts: EvalOptions): Promise<void> {
   }
 
   // -- 6-7. Run tiered tests -------------------------------------------------
-  const healthySlugs = opts.ci
-    ? [...scopeResult.slugs]
-    : scopeResult.slugs.filter((s) => {
-        try {
-          const result = execFileSync(
-            "docker",
-            ["inspect", "--format={{.State.Health.Status}}", `showcase-${s}`],
-            { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
-          ).trim();
-          return result === "healthy";
-        } catch {
-          return false;
-        }
-      });
+  // Determine which in-scope slugs are healthy enough to test.
+  //
+  // In --ci mode the caller guarantees a running fleet, so trust every scope
+  // slug. Otherwise reuse the SAME HTTP health signal that up() already gates
+  // on (lifecycle.healthCheck) rather than `docker inspect
+  // .State.Health.Status`. The two signals disagree: up() polls the service's
+  // host-port /api/health, while the container's internal HEALTHCHECK curls
+  // localhost:10000 inside the container. On CI runners the docker-inspect
+  // status stayed non-"healthy" (still "starting", or the in-container probe
+  // never flips) even though up() had already confirmed the app serves
+  // requests — so the old gate rejected every slug up() had validated and no
+  // tier ever ran. healthCheck() covers both freshly-started and pre-existing
+  // containers and retries, keeping this gate consistent with startup.
+  let healthySlugs: string[];
+  if (opts.ci) {
+    healthySlugs = [...scopeResult.slugs];
+  } else {
+    const health = await healthCheck([...scopeResult.slugs]);
+    healthySlugs = scopeResult.slugs.filter((s) => health.get(s) === true);
+  }
 
   let tieredResult: TieredRunResult;
 

--- a/showcase/shell-docs/src/content/docs/deploy/langsmith.mdx
+++ b/showcase/shell-docs/src/content/docs/deploy/langsmith.mdx
@@ -1,0 +1,7 @@
+---
+title: LangSmith Platform
+icon: "lucide/Rocket"
+description: Deploy your LangGraph or Google ADK agent to the LangSmith Platform and connect it to CopilotKit.
+hideHeader: true
+---
+<Content partial="integrations/langsmith/index.mdx" />

--- a/showcase/shell-docs/src/content/docs/deploy/meta.json
+++ b/showcase/shell-docs/src/content/docs/deploy/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Deploy",
   "pages": [
-    "agentcore"
+    "agentcore",
+    "langsmith"
   ]
 }

--- a/showcase/shell-docs/src/content/docs/integrations/adk/deploy-langsmith.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/deploy-langsmith.mdx
@@ -1,0 +1,7 @@
+---
+title: LangSmith Platform
+icon: "lucide/Rocket"
+description: Deploy your Google ADK agent to the LangSmith Platform and connect it to CopilotKit.
+hideHeader: true
+---
+<Content framework="adk" partial="integrations/langsmith/index.mdx" />

--- a/showcase/shell-docs/src/content/docs/integrations/adk/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/meta.json
@@ -8,6 +8,8 @@
     "---App Control---",
     "frontend-tools",
     "shared-state",
+    "---Deploy---",
+    "deploy-langsmith",
     "---Intelligence Platform---",
     {
       "title": "Threads",

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/deploy-langsmith.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/deploy-langsmith.mdx
@@ -1,0 +1,7 @@
+---
+title: LangSmith Platform
+icon: "lucide/Rocket"
+description: Deploy your LangGraph agent to the LangSmith Platform and connect it to CopilotKit.
+hideHeader: true
+---
+<Content framework="langgraph" partial="integrations/langsmith/index.mdx" />

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/meta.json
@@ -28,6 +28,9 @@
     "configurable",
     "subgraphs",
     "auth",
+    "---Deploy---",
+    "deploy-agentcore",
+    "deploy-langsmith",
     "---Tutorials---",
     "...tutorials"
   ]

--- a/showcase/shell-docs/src/content/snippets/integrations/langsmith/index.mdx
+++ b/showcase/shell-docs/src/content/snippets/integrations/langsmith/index.mdx
@@ -1,0 +1,454 @@
+import { Callout } from "fumadocs-ui/components/callout";
+import { Tabs, Tab } from "fumadocs-ui/components/tabs";
+import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
+import { Cards, Card } from "fumadocs-ui/components/card";
+import { PaintbrushIcon, RepeatIcon } from "lucide-react";
+import {
+  TailoredContent,
+  TailoredContentOption,
+} from "@/components/react/tailored-content.tsx";
+
+## CopilotKit + LangSmith Platform
+
+[LangSmith Deployment](https://docs.langchain.com/langsmith/deployment) gives your LangGraph and
+Google ADK agents a managed, serverless runtime — handling scaling, persistence, and the LangGraph
+Server API. CopilotKit gives those agents a production-ready frontend.
+
+## How it works
+
+The two connect through **CopilotKit Runtime**, a lightweight server-side layer that sits between
+your browser and your LangSmith deployment. It's the same runtime you'd use with any
+CopilotKit-powered agent — it just needs to run server-side so your `LANGSMITH_API_KEY` never
+reaches the browser.
+
+```
+Browser → CopilotKit Runtime → LangSmith deployment → your agent
+```
+
+LangSmith hosts the agent only; there's no frontend-hosting offering. You host the CopilotKit
+frontend and runtime wherever you already deploy your app (Vercel, your own Node server, etc.) and
+point the runtime at the LangSmith deployment URL.
+
+## What you get
+
+- **Chat UI** — prebuilt chat interface, or headless hooks to build your own
+- **Shared state** — bidirectional sync between agent state and your React UI
+- **Generative UI** — render custom components from tool calls in real time
+- **Human-in-the-loop** — let users review, approve, or redirect agent actions
+- **Managed persistence** — thread history and checkpoints live in the LangSmith deployment
+
+## Quickstart
+
+<Callout type="info" title="LangSmith authority">
+  These steps reproduce the LangSmith deploy flow inline so you can finish here. For the
+  canonical reference — pricing, deployment types, and self-hosting — see the
+  [LangSmith deployment docs](https://docs.langchain.com/langsmith/deployment).
+</Callout>
+
+<Callout type="info" title="Prerequisites">
+  You need a [LangSmith account](https://smith.langchain.com) on the **Plus plan or above** and a
+  LangSmith API key (`lsv2_...`). Deploying uses the LangGraph CLI; Docker is optional (only needed
+  for local container builds).
+</Callout>
+
+<Steps>
+  <TailoredContent
+    className="step"
+    id="starting-point"
+    header={
+      <div>
+        <p className="text-xl font-semibold">Choose your starting point</p>
+        <p className="text-base">
+          Deploy a new agent to LangSmith from scratch, or connect CopilotKit to an agent you've
+          already deployed.
+        </p>
+      </div>
+    }
+  >
+    <TailoredContentOption
+      id="scratch"
+      title="Deploy a new agent"
+      description="Scaffold an agent, deploy it to LangSmith, then wire up CopilotKit."
+    >
+      <Step>
+        ### Install the LangGraph CLI
+
+        The CLI scaffolds a deployable project and pushes it to LangSmith:
+
+        ```bash
+        uv tool install langgraph-cli
+        ```
+      </Step>
+
+      <Step>
+        ### Create your deployable app
+
+        A LangSmith deployment is any project that exports a graph via `langgraph.json`.
+
+        <Tabs groupId="langsmith-agent-framework" items={['LangGraph', 'Google ADK']}>
+          <Tab value="LangGraph">
+            Scaffold a new project from the official template:
+
+            ```bash
+            langgraph new ./my-agent --template new-langgraph-project-python
+            ```
+
+            The template ships a `langgraph.json` that already exports a graph:
+
+            ```json title="langgraph.json"
+            {
+              "$schema": "https://langgra.ph/schema.json",
+              "dependencies": ["."],
+              "graphs": {
+                "agent": "./src/agent/graph.py:graph"
+              },
+              "env": ".env"
+            }
+            ```
+
+            The `graphs` key (`agent` here) is the **graph ID** you'll point CopilotKit at later.
+          </Tab>
+
+          <Tab value="Google ADK">
+            ADK agents don't deploy to LangSmith natively — you wrap the ADK `Runner` so it exports a
+            LangGraph-compatible graph, then deploy it exactly like a LangGraph app.
+
+            Install the wrapper SDK (published as `deployments-wrap-sdk`, imported as `saf_sdk`):
+
+            ```bash
+            pip install "deployments-wrap-sdk[google-adk]"
+            ```
+
+            Wrap your ADK `Runner` with `wrap()` and a `LangsmithSessionService`, then export the
+            result as a module-level `agent`:
+
+            ```python title="agent.py"
+            from google.adk.agents import Agent
+            from google.adk.runners import Runner
+            from saf_sdk.adk import LangsmithSessionService, wrap
+
+            agent = wrap(
+                Runner(
+                    agent=Agent(
+                        name="my_agent",
+                        model="gemini-2.5-flash",
+                        instruction="You are a helpful assistant.",
+                    ),
+                    app_name="my_adk_agent",
+                    session_service=LangsmithSessionService(),
+                )
+            )
+            ```
+
+            <Callout type="warn">
+              The `Runner.session_service` **must** be a `LangsmithSessionService`. ADK's other
+              session services (`InMemorySessionService`, `DatabaseSessionService`,
+              `VertexAiSessionService`) are rejected — session state lives in the LangGraph
+              checkpoint.
+            </Callout>
+
+            Point `langgraph.json` at the exported symbol:
+
+            ```json title="langgraph.json"
+            {
+              "$schema": "https://langgra.ph/schema.json",
+              "dependencies": ["."],
+              "graphs": {
+                "my_agent": "./agent.py:agent"
+              },
+              "env": ".env"
+            }
+            ```
+
+            The `graphs` key (`my_agent` here) is the **graph ID** you'll point CopilotKit at later.
+            See the [Deploy Google ADK agents](https://docs.langchain.com/langsmith/deploy-google-adk)
+            guide for the full walkthrough.
+          </Tab>
+        </Tabs>
+      </Step>
+
+      <Step>
+        ### Add your API key
+
+        Add your LangSmith API key to the project's `.env`. The deploy command reads it
+        automatically:
+
+        ```plaintext title=".env"
+        LANGSMITH_API_KEY=lsv2_...
+        ```
+      </Step>
+
+      <Step>
+        ### Deploy
+
+        From the project root:
+
+        ```bash
+        langgraph deploy --name my-agent
+        ```
+
+        This creates a **serverless** deployment by default. Useful flags and follow-ups:
+
+        - `--deployment-type dedicated` — provision a dedicated (non-serverless) deployment
+        - `--name <name>` — set the deployment name (re-running `langgraph deploy` with the same
+          name **updates the existing deployment in place**)
+        - `langgraph deploy list` — list your deployments
+        - `langgraph deploy logs` — tail runtime logs
+        - `langgraph deploy delete <id>` — remove a deployment
+      </Step>
+
+      <Step>
+        ### Get your deployment API URL
+
+        <Callout type="info" title="Where to find the URL">
+          In the [LangSmith UI](https://smith.langchain.com), open **Deployments** in the sidebar,
+          select your deployment, and copy the **API URL** from the details view. It looks like
+          `https://<deployment-id>.<region>.langgraph.app`.
+        </Callout>
+      </Step>
+
+      <Step>
+        ### Install CopilotKit
+
+        In your frontend app:
+
+        ```npm
+        npm install @copilotkit/react-core @copilotkit/runtime
+        ```
+      </Step>
+
+      <Step>
+        ### Set up CopilotKit Runtime
+
+        CopilotKit Runtime is the server-side layer that connects your frontend to the LangSmith
+        deployment. Create an API route:
+
+        ```typescript title="app/api/copilotkit/route.ts"
+        import {
+          CopilotRuntime,
+          ExperimentalEmptyAdapter,
+          copilotRuntimeNextJSAppRouterEndpoint,
+        } from "@copilotkit/runtime";
+        import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
+        import { NextRequest } from "next/server";
+
+        const runtime = new CopilotRuntime({
+          agents: {
+            my_agent: new LangGraphAgent({
+              deploymentUrl: process.env.LANGGRAPH_DEPLOYMENT_URL!, // your LangSmith API URL
+              graphId: "agent", // must match a key in your langgraph.json "graphs"
+              langsmithApiKey: process.env.LANGSMITH_API_KEY!,
+            }),
+          },
+        });
+
+        export const POST = async (req: NextRequest) => {
+          const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+            runtime,
+            serviceAdapter: new ExperimentalEmptyAdapter(),
+            endpoint: "/api/copilotkit",
+          });
+          return handleRequest(req);
+        };
+        ```
+
+        <Callout type="info" title="graphId must match langgraph.json">
+          `graphId` is the key from the `graphs` object in your `langgraph.json` — `agent` for the
+          LangGraph template, or whatever you named the ADK graph (e.g. `my_agent`). If it doesn't
+          match, the runtime can't find your graph.
+        </Callout>
+      </Step>
+
+      <Step>
+        ### Add the CopilotKit provider
+
+        ```tsx title="app/layout.tsx"
+        import { CopilotKit } from "@copilotkit/react-core/v2";
+        import "@copilotkit/react-core/v2/styles.css";
+
+        export default function RootLayout({ children }: { children: React.ReactNode }) {
+          return (
+            <html lang="en">
+              <body>
+                <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
+                  {children}
+                </CopilotKit>
+              </body>
+            </html>
+          );
+        }
+        ```
+      </Step>
+
+      <Step>
+        ### 🎉 Run it
+
+        Point your app at the deployment and start it. Create `.env.local`:
+
+        ```bash title=".env.local"
+        LANGGRAPH_DEPLOYMENT_URL=https://<deployment-id>.<region>.langgraph.app
+        LANGSMITH_API_KEY=lsv2_...
+        ```
+
+        Then:
+
+        ```bash
+        npm run dev
+        ```
+
+        Add a `<CopilotSidebar />` to any page and open `localhost:3000`. The frontend runs
+        wherever you host it while the agent stays on LangSmith — the `/api/copilotkit` route
+        forwards each call to your deployment using your API key.
+      </Step>
+    </TailoredContentOption>
+
+    <TailoredContentOption
+      id="existing"
+      title="I already have a deployment"
+      description="I've deployed my agent to LangSmith and have its API URL."
+    >
+      <Step>
+        ### Grab your deployment URL
+
+        CopilotKit connects to your agent through a deployment URL. Pick the option that matches how
+        you're running the agent:
+
+        <LangGraphPlatformDeploymentTabs />
+      </Step>
+
+      <Step>
+        ### Install CopilotKit
+
+        ```npm
+        npm install @copilotkit/react-core @copilotkit/runtime
+        ```
+      </Step>
+
+      <Step>
+        ### Set up CopilotKit Runtime
+
+        Create an API route that points at your LangSmith deployment:
+
+        ```typescript title="app/api/copilotkit/route.ts"
+        import {
+          CopilotRuntime,
+          ExperimentalEmptyAdapter,
+          copilotRuntimeNextJSAppRouterEndpoint,
+        } from "@copilotkit/runtime";
+        import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
+        import { NextRequest } from "next/server";
+
+        const runtime = new CopilotRuntime({
+          agents: {
+            my_agent: new LangGraphAgent({
+              deploymentUrl: process.env.LANGGRAPH_DEPLOYMENT_URL!, // your LangSmith API URL
+              graphId: "agent", // must match a key in your langgraph.json "graphs"
+              langsmithApiKey: process.env.LANGSMITH_API_KEY!,
+            }),
+          },
+        });
+
+        export const POST = async (req: NextRequest) => {
+          const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+            runtime,
+            serviceAdapter: new ExperimentalEmptyAdapter(),
+            endpoint: "/api/copilotkit",
+          });
+          return handleRequest(req);
+        };
+        ```
+
+        <Callout type="info" title="graphId must match langgraph.json">
+          `graphId` is the key from the `graphs` object in your `langgraph.json` — `agent` for the
+          LangGraph template, or whatever you named the ADK graph. If it doesn't match, the runtime
+          can't find your graph.
+        </Callout>
+      </Step>
+
+      <Step>
+        ### Add the CopilotKit provider
+
+        ```tsx title="app/layout.tsx"
+        import { CopilotKit } from "@copilotkit/react-core/v2";
+        import "@copilotkit/react-core/v2/styles.css";
+
+        export default function RootLayout({ children }: { children: React.ReactNode }) {
+          return (
+            <html lang="en">
+              <body>
+                <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
+                  {children}
+                </CopilotKit>
+              </body>
+            </html>
+          );
+        }
+        ```
+      </Step>
+
+      <Step>
+        ### 🎉 Add chat and run
+
+        Drop a chat interface into any page:
+
+        ```tsx title="app/page.tsx"
+        import { CopilotSidebar } from "@copilotkit/react-core/v2";
+
+        export default function Page() {
+          return (
+            <main>
+              <h1>My App</h1>
+              <CopilotSidebar />
+            </main>
+          );
+        }
+        ```
+
+        Set `LANGGRAPH_DEPLOYMENT_URL` and `LANGSMITH_API_KEY` in `.env.local`, then `npm run dev`.
+      </Step>
+    </TailoredContentOption>
+  </TailoredContent>
+</Steps>
+
+## Troubleshooting
+
+<Accordions>
+  <Accordion title="The runtime can't find my graph / 404 on invoke">
+    Your `graphId` must exactly match a key in the `graphs` object of your deployment's
+    `langgraph.json`. The LangGraph template names it `agent`; an ADK app uses whatever key you set
+    (e.g. `my_agent`). Check the deployment's config in the LangSmith UI if unsure.
+  </Accordion>
+  <Accordion title="401 / authentication errors from the deployment">
+    Confirm `LANGSMITH_API_KEY` is set on the **server** (where CopilotKit Runtime runs), not the
+    browser, and that the key belongs to the same LangSmith workspace as the deployment. The key
+    must start with `lsv2_`.
+  </Accordion>
+  <Accordion title="langgraph deploy fails or hangs">
+    Ensure your LangSmith account is on the **Plus plan or above** and that `LANGSMITH_API_KEY` is
+    present in `.env`. For local container builds, Docker (with the daemon running) is required — on
+    Apple Silicon you also need Docker Buildx.
+  </Accordion>
+  <Accordion title="My ADK agent won't deploy">
+    ADK agents must be wrapped with `wrap()` from `saf_sdk.adk` and use a `LangsmithSessionService`.
+    The wrapped object has to be exported as a module-level variable that `langgraph.json` points at
+    (e.g. `./agent.py:agent`). See the
+    [Deploy Google ADK agents](https://docs.langchain.com/langsmith/deploy-google-adk) guide.
+  </Accordion>
+</Accordions>
+
+## What's next?
+
+<Cards>
+  <Card
+    title="Generative UI"
+    description="Render custom React components directly from your agent's tool calls."
+    href={`/${framework ?? "langgraph"}/generative-ui/tool-rendering`}
+    icon={<PaintbrushIcon />}
+  />
+  <Card
+    title="Shared State"
+    description="Sync structured state between your agent and your React UI bidirectionally."
+    href={`/${framework ?? "langgraph"}/shared-state/in-app-agent-read`}
+    icon={<RepeatIcon />}
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/snippets/integrations/langsmith/index.mdx
+++ b/showcase/shell-docs/src/content/snippets/integrations/langsmith/index.mdx
@@ -11,8 +11,8 @@ import {
 ## CopilotKit + LangSmith Platform
 
 [LangSmith Deployment](https://docs.langchain.com/langsmith/deployment) gives your LangGraph and
-Google ADK agents a managed, serverless runtime — handling scaling, persistence, and the LangGraph
-Server API. CopilotKit gives those agents a production-ready frontend.
+Google ADK agents a managed runtime (serverless by default) — handling scaling, persistence, and
+the LangGraph Server API. CopilotKit gives those agents a production-ready frontend.
 
 ## How it works
 
@@ -48,7 +48,16 @@ point the runtime at the LangSmith deployment URL.
 <Callout type="info" title="Prerequisites">
   You need a [LangSmith account](https://smith.langchain.com) on the **Plus plan or above** and a
   LangSmith API key (`lsv2_...`). Deploying uses the LangGraph CLI; Docker is optional (only needed
-  for local container builds).
+  for local container builds). **Google ADK** additionally needs **Python 3.11+**, the
+  `deployments-wrap-sdk[google-adk]` package, and a **Google AI API key** if you use Gemini models.
+</Callout>
+
+<Callout type="info" title="Deployment models">
+  This guide uses **LangSmith Cloud** via the CLI — serverless by default, or `--deployment-type
+  dedicated` for a dedicated deployment. LangSmith also supports self-hosted control plane, hybrid,
+  and standalone-server models; see the
+  [deployment overview](https://docs.langchain.com/langsmith/deployment) to pick one. The CopilotKit
+  wiring below is the same regardless of which model you deploy to.
 </Callout>
 
 <Steps>
@@ -163,6 +172,25 @@ point the runtime at the LangSmith deployment URL.
             The `graphs` key (`my_agent` here) is the **graph ID** you'll point CopilotKit at later.
             See the [Deploy Google ADK agents](https://docs.langchain.com/langsmith/deploy-google-adk)
             guide for the full walkthrough.
+
+            <Callout type="warn" title="ADK wrapper limitations">
+              The wrapper adapts ADK onto the LangGraph Server, so some ADK and CopilotKit features
+              don't carry over. Per LangChain's
+              [ADK guide](https://docs.langchain.com/langsmith/deploy-google-adk):
+
+              - **No multimodal input** — only `messages[-1].content` is forwarded as a single text
+                part; inbound images, files, or audio are dropped.
+              - **Last message only** — just the final item in `messages` is sent to the ADK agent
+                each turn.
+              - **No live / audio / voice** — ADK's `run_live()` bidirectional streaming isn't used.
+              - **Text output only** — non-text output parts (images, audio, files) aren't surfaced.
+              - **No intermediate events** — tool calls, tool results, and sub-agent turns aren't
+                emitted as separate messages.
+              - **`LangsmithSessionService` required** — other ADK session services are rejected.
+              - **No LangGraph interrupts** — `interrupt` / `Command(resume=...)` aren't exposed, so
+                human-in-the-loop that relies on native interrupts won't work with a wrapped ADK
+                agent.
+            </Callout>
           </Tab>
         </Tabs>
       </Step>
@@ -180,6 +208,12 @@ point the runtime at the LangSmith deployment URL.
 
       <Step>
         ### Deploy
+
+        <Callout type="info" title="Verify locally first">
+          Before deploying, run `langgraph dev` from the project root to serve the graph locally and
+          confirm it starts. This catches import errors, a bad graph export, or (for ADK) a missing
+          `LangsmithSessionService` or model credentials with clearer feedback than a remote build.
+        </Callout>
 
         From the project root:
 

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -1079,6 +1079,11 @@ export const SNIPPET_MAP: Record<string, string> = {
   HeadlessThreads: "shared/threads/headless-threads.mdx",
   Threads: "shared/threads/headless-threads.mdx",
   ThreadsOverview: "shared/threads/overview.mdx",
+  // Local / Self-hosted FastAPI / LangGraph-Platform deployment-URL tabs,
+  // reused by the LangSmith deploy partial. Registered here (not just in
+  // mdx-registry's STUB_PARTIAL_MAP) so inlineSnippets resolves it and
+  // doesn't emit a spurious "snippet missing" warning.
+  LangGraphPlatformDeploymentTabs: "langgraph-platform-deployment-tabs.mdx",
   ToolRenderer: "shared/generative-ui/tool-rendering.mdx", // alias of ToolRendering
   ToolRendering: "shared/generative-ui/tool-rendering.mdx",
   DefaultToolRendering: "shared/guides/default-tool-rendering.mdx",

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -150,9 +150,6 @@ const STUB_PARTIAL_MAP: Record<string, string> = {
   HeadlessThreads: "shared/threads/headless-threads.mdx",
   Threads: "shared/threads/headless-threads.mdx",
   ThreadsOverview: "shared/threads/overview.mdx",
-  // Local / Self-hosted FastAPI / LangGraph-Platform deployment-URL tabs,
-  // reused by the LangSmith deploy partial.
-  LangGraphPlatformDeploymentTabs: "langgraph-platform-deployment-tabs.mdx",
 };
 
 // Dev-only warning helper for stub components that discard their props.
@@ -545,9 +542,6 @@ export const docsComponents = {
     <div>{children}</div>
   ),
   A2UI: stubWithPartial("A2UI"),
-  LangGraphPlatformDeploymentTabs: stubWithPartial(
-    "LangGraphPlatformDeploymentTabs",
-  ),
   RunAndConnect: stubWithPartial("RunAndConnect"),
   RunAndConnectSnippet: stubWithPartial("RunAndConnectSnippet"),
   MigrateTo: stubWithPartial("MigrateTo"),

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -150,6 +150,9 @@ const STUB_PARTIAL_MAP: Record<string, string> = {
   HeadlessThreads: "shared/threads/headless-threads.mdx",
   Threads: "shared/threads/headless-threads.mdx",
   ThreadsOverview: "shared/threads/overview.mdx",
+  // Local / Self-hosted FastAPI / LangGraph-Platform deployment-URL tabs,
+  // reused by the LangSmith deploy partial.
+  LangGraphPlatformDeploymentTabs: "langgraph-platform-deployment-tabs.mdx",
 };
 
 // Dev-only warning helper for stub components that discard their props.
@@ -504,20 +507,30 @@ export const docsComponents = {
   SharedContent: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
-  // <Content framework="..." /> on the `deploy-agentcore` pages
-  // (langgraph/* + aws-strands) renders the shared AgentCore deploy
-  // partial at src/content/snippets/integrations/agentcore/index.mdx.
-  // Unlike the generic `stubWithPartial` stubs, this one threads the
-  // page's `framework` into the partial's MDX scope so the embedded
-  // `<AgentCoreCommandTabs framework={framework} />` collapses to the
-  // single relevant framework (Strands-only / LangGraph-only) instead
-  // of showing both. `stubWithPartial` can't do this — it discards
-  // props by design — so Content is a dedicated loader call. `scope`
-  // keys surface as bare identifiers in the partial (NOT `props.*`);
-  // see PartialLoader.
-  Content: ({ framework }: { framework?: string }) => (
+  // <Content framework="..." partial="..." /> renders a shared deploy
+  // partial and threads the page's `framework` into the partial's MDX
+  // scope so framework-aware bits inside it (e.g.
+  // `<AgentCoreCommandTabs framework={framework} />`, or the
+  // `href={`/${framework}/...`}` cards in the LangSmith partial) collapse
+  // to the single relevant framework instead of showing both. Unlike the
+  // generic `stubWithPartial` stubs, this one forwards props, so it's a
+  // dedicated loader call. `scope` keys surface as bare identifiers in
+  // the partial (NOT `props.*`); see PartialLoader.
+  //
+  // Used by the per-framework deploy wrappers:
+  //   - `deploy-agentcore` (langgraph/* + aws-strands) → defaults to
+  //     integrations/agentcore/index.mdx
+  //   - `deploy-langsmith` (deploy/* + langgraph/* + adk/*) → passes
+  //     partial="integrations/langsmith/index.mdx"
+  Content: ({
+    framework,
+    partial,
+  }: {
+    framework?: string;
+    partial?: string;
+  }) => (
     <PartialLoader
-      relativePath="integrations/agentcore/index.mdx"
+      relativePath={partial ?? "integrations/agentcore/index.mdx"}
       scope={{ framework }}
       components={
         docsComponents as unknown as Record<
@@ -532,6 +545,9 @@ export const docsComponents = {
     <div>{children}</div>
   ),
   A2UI: stubWithPartial("A2UI"),
+  LangGraphPlatformDeploymentTabs: stubWithPartial(
+    "LangGraphPlatformDeploymentTabs",
+  ),
   RunAndConnect: stubWithPartial("RunAndConnect"),
   RunAndConnectSnippet: stubWithPartial("RunAndConnectSnippet"),
   MigrateTo: stubWithPartial("MigrateTo"),


### PR DESCRIPTION
## What

Adds a **LangSmith Platform** deploy guide to the CopilotKit docs, modeled after the existing AWS AgentCore deploy page.

It's a self-contained, agent-side guide: deploy a **LangGraph** or **Google ADK** agent to the LangSmith Platform, then point the CopilotKit Runtime at it. LangSmith has no frontend-hosting offering, so the guide covers only the agent side plus wiring the runtime.

## Pages

- **Canonical:** `deploy/langsmith.mdx` — renders in the Overview → Deploy sidebar.
- **Per-framework wrappers** (thin, like AgentCore):
  - `integrations/langgraph/deploy-langsmith.mdx` → `<Content framework="langgraph" .../>`
  - `integrations/adk/deploy-langsmith.mdx` → `<Content framework="adk" .../>`
  - Both registered in their `meta.json` under a new `---Deploy---` section.
- **Shared walkthrough snippet:** `snippets/integrations/langsmith/index.mdx` — single source of truth for all three pages; framework-aware via the `Content` loader scope. Reuses the existing `langgraph-platform-deployment-tabs` snippet for the "grab your deployment URL" step.

## Structure (mirrors agentcore.mdx)

Intro → How it works (ASCII flow `Browser → CopilotKit Runtime → LangSmith deployment → your agent`) → What you get → Quickstart `<Steps>` inside a `<TailoredContent>` (deploy-new vs already-deployed) → `<Callout>`s for the API key/URL and the LangSmith docs authority → framework tabs (LangGraph / Google ADK) for the deployable-app step → Troubleshooting `<Accordions>` → What's next `<Cards>`.

## Registry glue

- Generalized the `Content` MDX component to accept an optional `partial` prop (defaults to the AgentCore partial; existing AgentCore wrappers unchanged).
- Registered a `LangGraphPlatformDeploymentTabs` stub so the existing deployment-tabs snippet is reusable.

## Verification

- Commands/flags (`uv tool install langgraph-cli`, `langgraph new --template new-langgraph-project-python`, `langgraph deploy --name/--deployment-type dedicated`, deployment API URL) verified against the live LangChain quickstart.
- ADK path (`pip install "deployments-wrap-sdk[google-adk]"`, `saf_sdk.adk` `wrap()` + `LangsmithSessionService`, `langgraph.json` export) verified against the live [Deploy Google ADK agents](https://docs.langchain.com/langsmith/deploy-google-adk) guide.
- Runtime wiring (`LangGraphAgent` from `@copilotkit/runtime/langgraph` with `deploymentUrl` / `graphId` / `langsmithApiKey`) matches the repo's LangGraph quickstart.
- `oxfmt` (format) clean, `oxlint` exits 0, `tsc` clean; registry / search-href / link-rewrite tests pass. (Pre-existing failures in this worktree from an uninstalled `react-icons` and unfetched git-LFS assets are unrelated.)

## Note (small extra)

The LangGraph `deploy-agentcore.mdx` wrapper already existed but was orphaned (not in any `meta.json`). The new `---Deploy---` section surfaces it alongside `deploy-langsmith`, matching how AWS Strands already exposes it.

Ticket: GROW-540