### PR TITLE
feat(showcase): add "Show unique" filter to dashboard feature grid

### DIFF
--- a/showcase/shell-dashboard/src/components/feature-grid.test.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.test.tsx
@@ -7,13 +7,13 @@
  * separately — the cell model incorporates all relevant signals.
  */
 import { describe, it, expect } from "vitest";
-import { render } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 import { LiveIndicator, computeColumnTally, FeatureGrid } from "./feature-grid";
 import type { CellContext, CellRenderer } from "./feature-grid";
 import { OverlayColumnHeader } from "./overlay-column-header";
 import type { Overlay } from "@/lib/overlay-types";
 import { urlsFor } from "./cell-pieces";
-import { getIntegrations } from "@/lib/registry";
+import { getIntegrations, getFeatures } from "@/lib/registry";
 import { starterIsSupported, STARTER_LEVELS } from "@/lib/live-status";
 import type { Integration, Feature } from "@/lib/registry";
 import type {
@@ -604,5 +604,71 @@ describe("OverlayColumnHeader — loading / offline rendering (§5.3)", () => {
       />,
     );
     expect(container.querySelector("[data-stale='true']")).toBeNull();
+  });
+});
+
+describe("FeatureGrid — Show unique filter", () => {
+  const integrations = getIntegrations();
+  const features = getFeatures();
+
+  // "framework supports a demo" === the integration ships one (isWired).
+  const frameworkCount = (featureId: string) =>
+    integrations.filter((i) => i.demos.some((d) => d.id === featureId)).length;
+
+  const uniqueFeatures = features.filter((f) => frameworkCount(f.id) < 2);
+  // A feature shipped by ≥2 frameworks and not deprecated — visible by default.
+  const commonFeature = features.find(
+    (f) => frameworkCount(f.id) >= 2 && f.deprecated !== true,
+  );
+  // A "unique" feature (≤1 framework) that is NOT deprecated, so only the
+  // unique filter — not the deprecated filter — governs its visibility.
+  const uniqueNonDeprecated = uniqueFeatures.find((f) => f.deprecated !== true);
+
+  const renderGrid = () =>
+    render(
+      <FeatureGrid
+        title="Feature Matrix"
+        renderCell={() => null}
+        liveStatus={new Map() as LiveStatusMap}
+        connection="live"
+        shellUrl="https://showcase.staging.copilotkit.ai"
+      />,
+    );
+
+  it("registry sanity: there is a common feature and a non-deprecated unique feature to assert on", () => {
+    expect(commonFeature, "need a common non-deprecated feature").toBeDefined();
+    expect(
+      uniqueNonDeprecated,
+      "need a non-deprecated unique feature (e.g. a2ui-recovery)",
+    ).toBeDefined();
+  });
+
+  it("hides non-common demo rows by default and shows common ones", () => {
+    const { queryByTestId } = renderGrid();
+    expect(
+      queryByTestId(`feature-row-${commonFeature!.id}`),
+      "common feature row must be visible by default",
+    ).not.toBeNull();
+    expect(
+      queryByTestId(`feature-row-${uniqueNonDeprecated!.id}`),
+      "unique feature row must be hidden by default",
+    ).toBeNull();
+  });
+
+  it("labels the toggle with the count of unique (frameworkCount < 2) features", () => {
+    const { getByTestId } = renderGrid();
+    const toggle = getByTestId("show-unique-toggle");
+    expect(toggle.textContent).toContain("Show unique");
+    expect(toggle.textContent).toContain(`(${uniqueFeatures.length})`);
+  });
+
+  it("reveals the unique rows when the toggle is checked", () => {
+    const { getByTestId, queryByTestId } = renderGrid();
+    const checkbox = getByTestId("show-unique-toggle").querySelector("input")!;
+    fireEvent.click(checkbox);
+    expect(
+      queryByTestId(`feature-row-${uniqueNonDeprecated!.id}`),
+      "unique feature row must appear after enabling Show unique",
+    ).not.toBeNull();
   });
 });

--- a/showcase/shell-dashboard/src/components/feature-grid.test.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.test.tsx
@@ -671,4 +671,17 @@ describe("FeatureGrid — Show unique filter", () => {
       "unique feature row must appear after enabling Show unique",
     ).not.toBeNull();
   });
+
+  it("notes unique rows are hidden in the subtitle by default", () => {
+    const { container } = renderGrid();
+    expect(container.textContent).toContain(
+      `${uniqueFeatures.length} unique hidden`,
+    );
+  });
+
+  it("drops the unique-hidden note once Show unique is enabled", () => {
+    const { getByTestId, container } = renderGrid();
+    fireEvent.click(getByTestId("show-unique-toggle").querySelector("input")!);
+    expect(container.textContent).not.toContain("unique hidden");
+  });
 });

--- a/showcase/shell-dashboard/src/components/feature-grid.test.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.test.tsx
@@ -674,9 +674,8 @@ describe("FeatureGrid — Show unique filter", () => {
 
   it("notes unique rows are hidden in the subtitle by default", () => {
     const { container } = renderGrid();
-    expect(container.textContent).toContain(
-      `${uniqueFeatures.length} unique hidden`,
-    );
+    expect(container.textContent).toContain(`${uniqueFeatures.length} unique`);
+    expect(container.textContent).toMatch(/\([^)]*hidden\)/);
   });
 
   it("drops the unique-hidden note once Show unique is enabled", () => {

--- a/showcase/shell-dashboard/src/components/feature-grid.test.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.test.tsx
@@ -683,4 +683,11 @@ describe("FeatureGrid — Show unique filter", () => {
     fireEvent.click(getByTestId("show-unique-toggle").querySelector("input")!);
     expect(container.textContent).not.toContain("unique hidden");
   });
+
+  it("tooltip wording is accurate for the <2 definition (not 'only one framework')", () => {
+    const { getByTestId } = renderGrid();
+    const title = getByTestId("show-unique-toggle").getAttribute("title") ?? "";
+    expect(title).toContain("fewer than two frameworks");
+    expect(title).not.toContain("only one framework");
+  });
 });

--- a/showcase/shell-dashboard/src/components/feature-grid.test.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.test.tsx
@@ -672,16 +672,24 @@ describe("FeatureGrid — Show unique filter", () => {
     ).not.toBeNull();
   });
 
-  it("notes unique rows are hidden in the subtitle by default", () => {
+  it("shows the exact distinct hidden-row count in the subtitle by default", () => {
     const { container } = renderGrid();
-    expect(container.textContent).toContain(`${uniqueFeatures.length} unique`);
-    expect(container.textContent).toMatch(/\([^)]*hidden\)/);
+    // Distinct hidden = features hidden by EITHER filter (deprecated OR unique),
+    // deduped — not the sum of the two overlapping category counts.
+    const distinctHidden = features.filter(
+      (f) => f.deprecated === true || frameworkCount(f.id) < 2,
+    ).length;
+    expect(distinctHidden).toBeGreaterThan(0);
+    expect(container.textContent).toContain(`(${distinctHidden} hidden)`);
   });
 
-  it("drops the unique-hidden note once Show unique is enabled", () => {
+  it("drops the hidden-count note once both filters are enabled", () => {
     const { getByTestId, container } = renderGrid();
     fireEvent.click(getByTestId("show-unique-toggle").querySelector("input")!);
-    expect(container.textContent).not.toContain("unique hidden");
+    fireEvent.click(
+      getByTestId("show-deprecated-toggle").querySelector("input")!,
+    );
+    expect(container.textContent).not.toMatch(/\(\d+ hidden\)/);
   });
 
   it("tooltip wording is accurate for the <2 definition (not 'only one framework')", () => {

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -832,7 +832,7 @@ export function FeatureGrid({
             <label
               data-testid="show-unique-toggle"
               className={`${deprecatedCount > 0 ? "" : "ml-auto "}flex cursor-pointer items-center gap-1.5 text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)]`}
-              title={`${uniqueCount} demo${uniqueCount === 1 ? "" : "s"} supported by only one framework — hidden by default so the view shows cross-framework patterns.`}
+              title={`${uniqueCount} demo${uniqueCount === 1 ? "" : "s"} supported by fewer than two frameworks — hidden by default so the view shows cross-framework patterns.`}
             >
               <input
                 type="checkbox"

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -371,6 +371,7 @@ const CategorySection = React.memo(
             return (
               <tr
                 key={feature.id}
+                data-testid={`feature-row-${feature.id}`}
                 className="grid-row border-t border-[var(--border)]"
                 style={stripe ? STRIPE_STYLE : undefined}
               >
@@ -740,20 +741,51 @@ export function FeatureGrid({
     return map;
   }, [catalog, showRefDepth]);
 
+  // How many integrations SHIP a demo of each feature — the grid's existing
+  // `isWired` signal (`integration.demos`). A demo is "common" when ≥2
+  // frameworks ship it; anything below that is "unique" and hidden by default
+  // so the view shows cross-framework patterns. We deliberately use demos[]
+  // (NOT the stale `features[]` list, and NOT `not_supported_features`): a
+  // brand-new single-framework demo never appears in another integration's
+  // `not_supported_features`, so that signal would wrongly read it as common.
+  const frameworkCountByFeature = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const feature of features) {
+      let n = 0;
+      for (const integration of integrations) {
+        if (integration.demos.some((d) => d.id === feature.id)) n++;
+      }
+      counts.set(feature.id, n);
+    }
+    return counts;
+  }, [features, integrations]);
+
   // "Show deprecated" toggle — default OFF so the LGP gold-standard view
   // doesn't render rows for legacy/replaced patterns (e.g. `hitl`,
-  // `agentic-chat-reasoning`). Operators can flip it on to surface
-  // deprecated features for cross-integration audit.
+  // `agentic-chat-reasoning`). "Show unique" toggle — default OFF so the
+  // default view is common ∩ non-deprecated. Operators flip either on to widen
+  // the set; both combine with AND.
   const [showDeprecated, setShowDeprecated] = useState(false);
+  const [showUnique, setShowUnique] = useState(false);
 
   const visibleFeatures = useMemo(
     () =>
-      showDeprecated ? features : features.filter((f) => f.deprecated !== true),
-    [features, showDeprecated],
+      features.filter(
+        (f) =>
+          (showDeprecated || f.deprecated !== true) &&
+          (showUnique || (frameworkCountByFeature.get(f.id) ?? 0) >= 2),
+      ),
+    [features, showDeprecated, showUnique, frameworkCountByFeature],
   );
   const deprecatedCount = useMemo(
     () => features.filter((f) => f.deprecated === true).length,
     [features],
+  );
+  const uniqueCount = useMemo(
+    () =>
+      features.filter((f) => (frameworkCountByFeature.get(f.id) ?? 0) < 2)
+        .length,
+    [features, frameworkCountByFeature],
   );
 
   const featuresByCategory = useMemo(
@@ -792,6 +824,26 @@ export function FeatureGrid({
                 Show deprecated{" "}
                 <span className="text-[var(--text-muted)]">
                   ({deprecatedCount})
+                </span>
+              </span>
+            </label>
+          )}
+          {uniqueCount > 0 && (
+            <label
+              data-testid="show-unique-toggle"
+              className={`${deprecatedCount > 0 ? "" : "ml-auto "}flex cursor-pointer items-center gap-1.5 text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)]`}
+              title={`${uniqueCount} demo${uniqueCount === 1 ? "" : "s"} supported by only one framework — hidden by default so the view shows cross-framework patterns.`}
+            >
+              <input
+                type="checkbox"
+                checked={showUnique}
+                onChange={(e) => setShowUnique(e.target.checked)}
+                className="h-3.5 w-3.5 cursor-pointer accent-[var(--accent)]"
+              />
+              <span>
+                Show unique{" "}
+                <span className="text-[var(--text-muted)]">
+                  ({uniqueCount})
                 </span>
               </span>
             </label>

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -852,14 +852,9 @@ export function FeatureGrid({
         <p className="mt-1 text-sm text-[var(--text-secondary)]">
           {subtitle ? <>{subtitle} · </> : null}
           {visibleFeatures.length} features × {integrations.length} integrations
-          {(() => {
-            const hidden: string[] = [];
-            if (!showDeprecated && deprecatedCount > 0)
-              hidden.push(`${deprecatedCount} deprecated`);
-            if (!showUnique && uniqueCount > 0)
-              hidden.push(`${uniqueCount} unique`);
-            return hidden.length ? ` (${hidden.join(", ")} hidden)` : "";
-          })()}
+          {features.length - visibleFeatures.length > 0
+            ? ` (${features.length - visibleFeatures.length} hidden)`
+            : ""}
           .
         </p>
       </header>

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -852,9 +852,14 @@ export function FeatureGrid({
         <p className="mt-1 text-sm text-[var(--text-secondary)]">
           {subtitle ? <>{subtitle} · </> : null}
           {visibleFeatures.length} features × {integrations.length} integrations
-          {!showDeprecated && deprecatedCount > 0
-            ? ` (${deprecatedCount} deprecated hidden)`
-            : ""}
+          {(() => {
+            const hidden: string[] = [];
+            if (!showDeprecated && deprecatedCount > 0)
+              hidden.push(`${deprecatedCount} deprecated`);
+            if (!showUnique && uniqueCount > 0)
+              hidden.push(`${uniqueCount} unique`);
+            return hidden.length ? ` (${hidden.join(", ")} hidden)` : "";
+          })()}
           .
         </p>
       </header>


### PR DESCRIPTION
## What

Adds a **"Show unique"** filter to the Showcase Dashboard feature grid, mirroring the existing **"Show deprecated"** toggle. A demo is **common** when ≥ 2 frameworks ship it; single-framework (and zero-framework) demos are **unique**.

Both toggles default **OFF**, so the default view is **common ∩ non-deprecated** — the cross-framework gold-standard surface. Each toggle independently widens the set (AND-combined).

This makes room for framework-specific demos (e.g. the planned Mastra browser-use / observational-memory demos): once added they'll be hidden by default and revealed via "Show unique".

## Why the "ships a demo" signal

"Framework supports a demo" is defined as `integration.demos.some(d => d.id === feature.id)` (the grid's existing `isWired` signal). The two alternatives were rejected:
- `integration.features[]` — stale in the data (e.g. `interrupt-headless` has demos in ~19 integrations but 0 `features[]` declarations).
- `not_supported_features` — a brand-new single-framework demo never appears in another integration's `not_supported_features`, so it would be wrongly classified as common. This is exactly the Mastra case that motivated the feature.

## UI

- `Show unique (N)` checkbox next to `Show deprecated`, rendered only when `N > 0`. Tooltip: "N demos supported by fewer than two frameworks — hidden by default…".
- Subtitle shows the **exact distinct hidden-row count** — `(N hidden)` — rather than an additive per-category breakdown (a feature can be both deprecated and unique; the per-category badges provide attribution, faceted-filter style).

## Testing

- 6 new behavioral tests in `feature-grid.test.tsx` (default-hidden, reveal-on-toggle, count label, accurate tooltip wording, exact distinct subtitle count, note-drop when both filters enabled). Suite: **37/37 green**.
- `tsc --noEmit` clean; `oxlint` clean (on the changed files); `next build` succeeds.

## Notes / follow-up

- **Column-header tallies** count the full matrix regardless of row-visibility filters. This is pre-existing (unchanged by this PR) and arguably correct-by-design (a coverage metric over the whole matrix, per the `computeColumnTally` docstring). Flagged in review, deferred.
- The "unique" count uses `frameworkCount < 2`, intentionally grouping zero-demo features with single-framework ones (approved design decision); tooltip wording reflects this.

## Scope

Client-side view state only — no registry, catalog, props, or SSE changes; all edits internal to `FeatureGrid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
