### PR TITLE
fix(showcase/mastra): sanitize OpenAI Responses input[].id so multi-turn chat stops 400-ing (OSS-381)

### DIFF
--- a/showcase/integrations/mastra/src/mastra/_header_forwarding.ts
+++ b/showcase/integrations/mastra/src/mastra/_header_forwarding.ts
@@ -70,10 +70,65 @@ function getForwardedHeaders(): Record<string, string> {
   return headersStorage.getStore() ?? {};
 }
 
+/**
+ * OpenAI's Responses API validates `input[].id` and REJECTS any id containing
+ * a dash. (Its 400 message misleadingly lists dashes as allowed — empirically
+ * only `[A-Za-z0-9_]` is accepted; an id like `msg-92Y7BhMpWBhXt7dm` 400s while
+ * `msg_92Y7BhMpWBhXt7dm` succeeds.) CopilotKit mints message ids like `msg-…`,
+ * and @ag-ui/mastra + the AI SDK forward them straight into `input[].id`, so
+ * every multi-turn run fails with
+ *   AI_APICallError: Invalid 'input[N].id': 'msg-…'
+ * (OSS-381). Fix at the HTTP boundary: rewrite dashes (and any other
+ * non-`[A-Za-z0-9_]` char) in each outbound `input[].id` to `_`.
+ *
+ * Why here and not in the bridge's message conversion: this touches ONLY the
+ * bytes sent to OpenAI. Mastra's in-memory `CoreMessage.id` — which drives its
+ * upsert-by-id history dedup — is left untouched, so dedup is unaffected.
+ * OpenAI-issued ids (`msg_…`, `rs_…`) contain no dashes and pass through
+ * unchanged, preserving server-side conversation-state references.
+ */
+export function toOpenAiResponsesSafeId(id: string): string {
+  return /^[A-Za-z0-9_]+$/.test(id) ? id : id.replace(/[^A-Za-z0-9_]/g, "_");
+}
+
+/**
+ * Rewrite out-of-charset `input[].id`s in an outbound OpenAI Responses request
+ * body. Returns the body unchanged when it isn't a JSON string, has no `input`
+ * array, or needs no rewrite (the common case — a no-op).
+ */
+export function sanitizeOutboundResponsesIds(
+  body: BodyInit | null | undefined,
+): BodyInit | null | undefined {
+  if (typeof body !== "string") return body;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return body;
+  }
+  const input = (parsed as { input?: unknown } | null)?.input;
+  if (!Array.isArray(input)) return body;
+  let changed = false;
+  for (const item of input) {
+    const withId = item as { id?: unknown } | null;
+    if (withId && typeof withId.id === "string") {
+      const safe = toOpenAiResponsesSafeId(withId.id);
+      if (safe !== withId.id) {
+        withId.id = safe;
+        changed = true;
+      }
+    }
+  }
+  return changed ? JSON.stringify(parsed) : body;
+}
+
 /** fetch wrapper that injects ALS-bound x-* headers into every outbound call. */
 const forwardingFetch: typeof fetch = (input, init) => {
   const forwarded = getForwardedHeaders();
   const merged = new Headers(init?.headers);
+  // Make client-minted message ids (e.g. `msg-…`) legal for the OpenAI
+  // Responses API. No-op for valid ids; never touches Mastra's dedup state.
+  const body = sanitizeOutboundResponsesIds(init?.body);
   for (const [k, v] of Object.entries(forwarded)) {
     // Don't clobber an explicit per-call header.
     if (!merged.has(k)) merged.set(k, v);
@@ -96,7 +151,7 @@ const forwardingFetch: typeof fetch = (input, init) => {
   const runId = forwarded["x-diag-run-id"];
   const diagnosticPresent = runId != null || slug != null;
   if (!diagnosticPresent) {
-    return fetch(input, { ...init, headers: merged });
+    return fetch(input, { ...init, headers: merged, body });
   }
   // CVDIAG (outbound-llm): append this layer's hop tag to the breadcrumb
   // and log header presence at the moment the outbound LLM request is
@@ -114,7 +169,7 @@ const forwardingFetch: typeof fetch = (input, init) => {
       `hop=${hopCount} status=${slug ? "ok" : "miss"} ` +
       `test_id=${forwarded["x-test-id"] ?? "none"} error=`,
   );
-  return fetch(input, { ...init, headers: merged });
+  return fetch(input, { ...init, headers: merged, body });
 };
 
 /**

--- a/showcase/integrations/mastra/tests/vitest/header-forwarding-id-sanitize.test.ts
+++ b/showcase/integrations/mastra/tests/vitest/header-forwarding-id-sanitize.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  toOpenAiResponsesSafeId,
+  sanitizeOutboundResponsesIds,
+} from "@/mastra/_header_forwarding";
+
+// OpenAI's Responses API rejects any input[].id containing a dash (its 400
+// message misleadingly lists dashes as allowed). CopilotKit mints `msg-…` ids,
+// which the AI SDK forwards into input[].id → every multi-turn run 400s
+// (OSS-381). These helpers rewrite the id at the HTTP boundary.
+describe("toOpenAiResponsesSafeId", () => {
+  it("rewrites the real failing client id (dash → underscore)", () => {
+    // The exact id observed 400-ing on staging.
+    expect(toOpenAiResponsesSafeId("msg-92Y7BhMpWBhXt7dm")).toBe(
+      "msg_92Y7BhMpWBhXt7dm",
+    );
+  });
+
+  it("leaves OpenAI-issued ids (no dashes) unchanged — a no-op", () => {
+    expect(toOpenAiResponsesSafeId("msg_03f181993e")).toBe("msg_03f181993e");
+    expect(toOpenAiResponsesSafeId("rs_abc123DEF")).toBe("rs_abc123DEF");
+  });
+
+  it("maps every non-[A-Za-z0-9_] char to underscore", () => {
+    expect(toOpenAiResponsesSafeId("a-b+c/d=e")).toBe("a_b_c_d_e");
+  });
+
+  it("is idempotent (already-safe id round-trips)", () => {
+    const once = toOpenAiResponsesSafeId("msg-92Y7BhMpWBhXt7dm");
+    expect(toOpenAiResponsesSafeId(once)).toBe(once);
+  });
+});
+
+describe("sanitizeOutboundResponsesIds", () => {
+  const responsesBody = (ids: (string | undefined)[]) =>
+    JSON.stringify({
+      model: "gpt-4o",
+      input: ids.map((id, i) =>
+        id === undefined
+          ? { type: "message", role: "user", content: `m${i}` }
+          : {
+              type: "message",
+              role: "assistant",
+              id,
+              content: [{ type: "output_text", text: `m${i}` }],
+            },
+      ),
+    });
+
+  it("rewrites out-of-charset input[].id in the request body", () => {
+    const out = JSON.parse(
+      sanitizeOutboundResponsesIds(
+        responsesBody([undefined, "msg-92Y7BhMpWBhXt7dm", undefined]),
+      ) as string,
+    );
+    expect(out.input[1].id).toBe("msg_92Y7BhMpWBhXt7dm");
+    // untouched siblings preserved
+    expect(out.input[0].content).toBe("m0");
+    expect(out.input[2].content).toBe("m2");
+  });
+
+  it("returns the body byte-identical when no id needs rewriting (no-op)", () => {
+    const clean = responsesBody([undefined, "msg_valid123", undefined]);
+    expect(sanitizeOutboundResponsesIds(clean)).toBe(clean);
+  });
+
+  it("passes through non-JSON / undefined bodies untouched", () => {
+    expect(sanitizeOutboundResponsesIds(undefined)).toBeUndefined();
+    expect(sanitizeOutboundResponsesIds("not json")).toBe("not json");
+  });
+
+  it("ignores bodies without an input[] array (chat-completions unaffected)", () => {
+    const chat = JSON.stringify({ messages: [{ id: "msg-x", role: "user" }] });
+    expect(sanitizeOutboundResponsesIds(chat)).toBe(chat);
+  });
+});


### PR DESCRIPTION
## What

Fixes multi-turn chat on every mastra showcase demo, which 400s on the 2nd turn:

> `AI_APICallError: Invalid 'input[3].id': 'msg-92Y7BhMpWBhXt7dm'. Expected an ID that contains letters, numbers, underscores, or dashes, but this value contained additional characters.` (`INCOMPLETE_STREAM`)

## Root cause

OpenAI's Responses API actually **rejects dashes** in `input[].id`. Its 400 message misleadingly lists dashes as allowed, but empirically only `[A-Za-z0-9_]` is accepted:

| `input[].id` | result |
|---|---|
| *(omitted)* | ✅ 200 |
| `msg_92Y7BhMpWBhXt7dm` (underscore) | ✅ 200 |
| `msg-92Y7BhMpWBhXt7dm` (**the failing client id**) | ❌ 400 |

CopilotKit mints message ids like `msg-…`, and `@ag-ui/mastra` + the AI SDK forward them straight into `input[].id` when replaying prior-turn history — so turn 1 works (no prior ids) and every turn after dies.

## Fix

The mastra provider already routes every outbound LLM call through `forwardingFetch` (the header-forwarding shim). This rewrites dashes (and any other non-`[A-Za-z0-9_]` char) in each outbound `input[].id` to `_` there.

**Why here, not in the bridge's message conversion:** it touches only the bytes sent to OpenAI. Mastra's in-memory `CoreMessage.id` — which drives its upsert-by-id history **dedup** — is untouched, so dedup is unaffected. OpenAI-issued ids (`msg_…`, `rs_…`, no dashes) pass through unchanged, preserving server-side conversation-state references. Chat Completions bodies (no `input[]` array) are untouched.

This **supersedes ag-ui-protocol/ag-ui#2227** — a bridge-layer charset munge that *kept* dashes (`[^A-Za-z0-9_-] → -`), making it a no-op on the real failing ids. That PR is being reverted.

## Tests

`tests/vitest/header-forwarding-id-sanitize.test.ts` — 8 cases: the real failing id, valid-id no-op, full-charset mapping, in-body rewrite, no-op/passthrough, and chat-completions-untouched. All green.

## Verification status

- ✅ Transform verified against the exact failing id; `msg_…` form confirmed accepted by the real OpenAI Responses API.
- ✅ 8 unit tests pass in-module.
- ⚠️ Full end-to-end wasn't run locally (the showcase runtime OOMs a 16 GB box), but **every** showcase OpenAI call flows through this wrapper, so **staging is the final check** — deploy and re-run a two-click multi-turn on `/demos/agentic-chat`.

## Refs

- Linear **OSS-381** (mastra refresh umbrella).
- Supersedes ag-ui-protocol/ag-ui#2227 (revert incoming).
- Follow-up worth filing upstream: `@ag-ui/mastra` / AI SDK shouldn't forward non-provider message ids into `input[].id` at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
