### PR TITLE
feat(runtime): add agentId to AgentRunnerConnectRequest

### DIFF
--- a/packages/runtime/src/v2/runtime/handlers/sse/__tests__/sse-connect-agent-id.test.ts
+++ b/packages/runtime/src/v2/runtime/handlers/sse/__tests__/sse-connect-agent-id.test.ts
@@ -79,6 +79,46 @@ describe("handleSseConnect → debug envelope agentId", () => {
 });
 
 /**
+ * Regression guard: `handleSseConnect` must forward the route-resolved
+ * `agentId` into the `runner.connect` request so custom runners can
+ * hydrate messages from it when the cache is empty.
+ */
+describe("handleSseConnect → agentId in runner.connect call", () => {
+  it("forwards agentId into the runner.connect request", async () => {
+    const event: BaseEvent = {
+      type: EventType.RUN_STARTED,
+      threadId: "t-1",
+      runId: "r-1",
+    } as BaseEvent;
+
+    const connectSpy = vi.fn(() => of(event));
+    const fakeRuntime = {
+      debugEventBus: new DebugEventBus(),
+      forwardHeadersPolicy: defaultPolicy,
+      runner: { connect: connectSpy },
+    } as any;
+
+    const response = handleSseConnect({
+      runtime: fakeRuntime,
+      request: new Request("http://localhost/agent/weather-agent/connect", {
+        method: "POST",
+      }),
+      agentId: "weather-agent",
+      threadId: "t-1",
+    });
+
+    const reader = response.body!.getReader();
+    while (true) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+    expect(connectSpy.mock.calls[0][0].agentId).toBe("weather-agent");
+  });
+});
+
+/**
  * Regression guard for issue #5712 on the /connect path. `handleSseConnect`
  * used to forward raw inbound `authorization`/`x-*` headers straight to
  * `runner.connect`, ignoring server-configured `agent.headers` entirely — so

--- a/packages/runtime/src/v2/runtime/handlers/sse/__tests__/sse-connect-agent-id.test.ts
+++ b/packages/runtime/src/v2/runtime/handlers/sse/__tests__/sse-connect-agent-id.test.ts
@@ -15,6 +15,7 @@ vi.mock("../../../telemetry", () => ({
 }));
 
 import { handleSseConnect } from "../connect";
+import type { AgentRunnerConnectRequest } from "../../../runner/agent-runner";
 import { DebugEventBus } from "../../../core/debug-event-bus";
 import { resolveForwardHeadersPolicy } from "../../header-utils";
 import type { ResolvedForwardHeadersPolicy } from "../../header-utils";
@@ -91,7 +92,7 @@ describe("handleSseConnect → agentId in runner.connect call", () => {
       runId: "r-1",
     } as BaseEvent;
 
-    const connectSpy = vi.fn(() => of(event));
+    const connectSpy = vi.fn((_req: AgentRunnerConnectRequest) => of(event));
     const fakeRuntime = {
       debugEventBus: new DebugEventBus(),
       forwardHeadersPolicy: defaultPolicy,

--- a/packages/runtime/src/v2/runtime/handlers/sse/connect.ts
+++ b/packages/runtime/src/v2/runtime/handlers/sse/connect.ts
@@ -46,6 +46,7 @@ export function handleSseConnect({
     observableFactory: () =>
       runtime.runner.connect({
         threadId,
+        agentId,
         // Forward-looking plumbing: we compute the merged header set (server
         // `agent.headers` win on collision, case-insensitively; non-colliding
         // inbound headers still forward — see `mergeForwardableHeaders`, #5712)

--- a/packages/runtime/src/v2/runtime/runner/agent-runner.ts
+++ b/packages/runtime/src/v2/runtime/runner/agent-runner.ts
@@ -15,6 +15,7 @@ export interface AgentRunnerRunRequest {
 
 export interface AgentRunnerConnectRequest {
   threadId: string;
+  agentId?: string;
   headers?: Record<string, string>;
   joinCode?: string;
 }


### PR DESCRIPTION
Closes #5911

Adds an optional `agentId` field to `AgentRunnerConnectRequest` so custom agent runners can hydrate messages when the cache is empty. Also passes the already-available `agentId` in `handleSseConnect` through to `runner.connect()`.

## Changes

- `packages/runtime/src/v2/runtime/runner/agent-runner.ts`: Added `agentId?: string` to `AgentRunnerConnectRequest` interface
- `packages/runtime/src/v2/runtime/handlers/sse/connect.ts`: Pass `agentId` to `runner.connect()`

## Verification

- Runtime package builds successfully (`pnpm --filter @copilotkit/runtime build`)
- The change is purely additive — the field is optional and does not affect existing runners