### PR TITLE
fix(react-core): forward credentials to provisional agents

### DIFF
--- a/packages/react-core/src/v2/hooks/__tests__/use-agent-stability.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent-stability.test.tsx
@@ -5,7 +5,10 @@ import type { AbstractAgent } from "@ag-ui/client";
 import { useCopilotKit } from "../../context";
 import { MockStepwiseAgent } from "../../__tests__/utils/test-helpers";
 import { useAgent } from "../use-agent";
-import { CopilotKitCoreRuntimeConnectionStatus } from "@copilotkit/core";
+import {
+  CopilotKitCoreRuntimeConnectionStatus,
+  ProxiedCopilotRuntimeAgent,
+} from "@copilotkit/core";
 
 // Mock the CopilotKit context to control copilotkit state directly
 vi.mock("../../context", () => ({
@@ -27,6 +30,7 @@ describe("useAgent stability during runtime connection", () => {
     runtimeUrl: string | undefined;
     runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus;
     runtimeTransport: string;
+    credentials: RequestCredentials | undefined;
     headers: Record<string, string>;
     agents: Record<string, AbstractAgent>;
     applyHeadersToAgent: (agent: AbstractAgent) => void;
@@ -43,6 +47,7 @@ describe("useAgent stability during runtime connection", () => {
       runtimeConnectionStatus:
         CopilotKitCoreRuntimeConnectionStatus.Disconnected,
       runtimeTransport: "rest",
+      credentials: undefined,
       headers: {},
       agents: {},
       // Additive stand-in for core's merge (core headers ON TOP of the
@@ -136,6 +141,38 @@ describe("useAgent stability during runtime connection", () => {
     // BUG: Current code creates a new agent on each re-render (agentInstances.length >= 3)
     // FIX: Should still be 1 (same provisional reused throughout connecting phase)
     expect(agentInstances.length).toBe(1);
+  });
+
+  it("should keep credentials current on the cached provisional agent", () => {
+    mockCopilotkit.credentials = "include";
+    const agentInstances: AbstractAgent[] = [];
+
+    function AgentTracker() {
+      const { agent } = useAgent({ agentId: "test-agent" });
+      if (
+        agentInstances.length === 0 ||
+        agentInstances[agentInstances.length - 1] !== agent
+      ) {
+        agentInstances.push(agent);
+      }
+      return null;
+    }
+
+    const { rerender } = render(<AgentTracker />);
+
+    expect(agentInstances).toHaveLength(1);
+    expect(agentInstances[0]).toBeInstanceOf(ProxiedCopilotRuntimeAgent);
+    expect((agentInstances[0] as ProxiedCopilotRuntimeAgent).credentials).toBe(
+      "include",
+    );
+
+    mockCopilotkit.credentials = "omit";
+    rerender(<AgentTracker />);
+
+    expect(agentInstances).toHaveLength(1);
+    expect((agentInstances[0] as ProxiedCopilotRuntimeAgent).credentials).toBe(
+      "omit",
+    );
   });
 
   it("should keep the same agent instance across the full Disconnected→Connected lifecycle", () => {

--- a/packages/react-core/src/v2/hooks/use-agent.tsx
+++ b/packages/react-core/src/v2/hooks/use-agent.tsx
@@ -106,9 +106,6 @@ export function useAgent({ agentId, updates, throttleMs }: UseAgentProps = {}) {
       // Return cached provisional if available (keeps reference stable)
       const cached = provisionalAgentCache.current.get(resolvedAgentId);
       if (cached) {
-        // Update request settings on the cached agent in case they changed
-        copilotkit.applyHeadersToAgent(cached);
-        cached.credentials = copilotkit.credentials;
         return { agent: cached, isReady: false };
       }
 
@@ -136,8 +133,6 @@ export function useAgent({ agentId, updates, throttleMs }: UseAgentProps = {}) {
     ) {
       const cached = provisionalAgentCache.current.get(resolvedAgentId);
       if (cached) {
-        copilotkit.applyHeadersToAgent(cached);
-        cached.credentials = copilotkit.credentials;
         return { agent: cached, isReady: false };
       }
       const provisional = new ProxiedCopilotRuntimeAgent({
@@ -231,9 +226,9 @@ export function useAgent({ agentId, updates, throttleMs }: UseAgentProps = {}) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agent, forceUpdate, throttleMs, providerThrottleMs, updateFlags]);
 
-  // Keep HttpAgent headers fresh without mutating inside useMemo, which is
-  // unsafe in concurrent mode (React may invoke useMemo multiple times and
-  // discard intermediate results, but mutations always land).
+  // Keep HttpAgent request settings fresh without mutating inside useMemo,
+  // which is unsafe in concurrent mode (React may invoke useMemo multiple
+  // times and discard intermediate results, but mutations always land).
   useEffect(() => {
     if (agent instanceof HttpAgent) {
       // Merge core headers on top of the agent's own headers rather than
@@ -241,8 +236,11 @@ export function useAgent({ agentId, updates, throttleMs }: UseAgentProps = {}) {
       // self-hosted backend) are preserved (see #5635).
       copilotkit.applyHeadersToAgent(agent);
     }
+    if (agent instanceof ProxiedCopilotRuntimeAgent) {
+      agent.credentials = copilotkit.credentials;
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [agent, JSON.stringify(copilotkit.headers)]);
+  }, [agent, JSON.stringify(copilotkit.headers), copilotkit.credentials]);
 
   // Propagate the caller-supplied threadId from the chat configuration onto
   // the agent. AbstractAgent's constructor auto-mints a UUID when no threadId

--- a/packages/react-core/src/v2/hooks/use-agent.tsx
+++ b/packages/react-core/src/v2/hooks/use-agent.tsx
@@ -106,8 +106,9 @@ export function useAgent({ agentId, updates, throttleMs }: UseAgentProps = {}) {
       // Return cached provisional if available (keeps reference stable)
       const cached = provisionalAgentCache.current.get(resolvedAgentId);
       if (cached) {
-        // Update headers on the cached agent in case they changed
+        // Update request settings on the cached agent in case they changed
         copilotkit.applyHeadersToAgent(cached);
+        cached.credentials = copilotkit.credentials;
         return { agent: cached, isReady: false };
       }
 
@@ -115,6 +116,7 @@ export function useAgent({ agentId, updates, throttleMs }: UseAgentProps = {}) {
         runtimeUrl: copilotkit.runtimeUrl,
         agentId: resolvedAgentId,
         transport: copilotkit.runtimeTransport,
+        credentials: copilotkit.credentials,
         runtimeMode: "pending",
       });
       // Apply current headers so runs/connects inherit them
@@ -135,12 +137,14 @@ export function useAgent({ agentId, updates, throttleMs }: UseAgentProps = {}) {
       const cached = provisionalAgentCache.current.get(resolvedAgentId);
       if (cached) {
         copilotkit.applyHeadersToAgent(cached);
+        cached.credentials = copilotkit.credentials;
         return { agent: cached, isReady: false };
       }
       const provisional = new ProxiedCopilotRuntimeAgent({
         runtimeUrl: copilotkit.runtimeUrl,
         agentId: resolvedAgentId,
         transport: copilotkit.runtimeTransport,
+        credentials: copilotkit.credentials,
         runtimeMode: "pending",
       });
       copilotkit.applyHeadersToAgent(provisional);
@@ -167,6 +171,7 @@ export function useAgent({ agentId, updates, throttleMs }: UseAgentProps = {}) {
     copilotkit.runtimeConnectionStatus,
     copilotkit.runtimeUrl,
     copilotkit.runtimeTransport,
+    copilotkit.credentials,
     JSON.stringify(copilotkit.headers),
   ]);
 


### PR DESCRIPTION
## What does this PR do?

Provisional agents returned by `useAgent` now receive the provider's `credentials` setting when they are created. Cached provisional agents also refresh that setting when the provider configuration changes, while keeping the same agent instance.

The regression test covers both the initial value and a later `include` to `omit` update on the cached provisional agent.

### Verification

- `pnpm nx run @copilotkit/react-core:test`
- `pnpm nx run @copilotkit/react-core:check-types`
- `pnpm nx run @copilotkit/react-core:build`
- `pnpm check-format`

## Related PRs and Issues

- Closes https://github.com/CopilotKit/CopilotKit/issues/6116

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)