### PR TITLE
fix: relax partialjson version constraint in sdk-python

### DIFF
--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -34,7 +34,7 @@ crewai = { version = ">=0.118.0", optional = true, python = ">=3.10,<3.14" }
 ag-ui-langgraph = { version = ">=0.0.42", extras = ["fastapi"] }
 ag-ui-protocol = ">=0.1.15"
 fastapi = ">=0.115.0,<1.0.0"
-partialjson = "^0.0.8"
+partialjson = ">=0.0.8,<2.0.0"
 toml = "^0.10.2"
 # Pin transitive: cp314 wheels first appear in 2.35.0; older versions
 # would force a Rust source build that fails on PyO3 0.24 (capped at 3.13).


### PR DESCRIPTION
## What does this PR do?

Relaxes the over-strict `partialjson` version constraint in `sdk-python/pyproject.toml` so the CopilotKit Python SDK can consume newer compatible `partialjson` releases.

**Change:** `sdk-python/pyproject.toml`
- Before: `partialjson = "^0.0.8"`
- After:  `partialjson = ">=0.0.8,<2.0.0"`

## Why

Poetry interprets `^0.0.8` on a `0.0.x` version as `>=0.0.8,<0.0.9`, which effectively pins the SDK to **exactly** `0.0.8`. This blocks users from receiving newer, compatible `partialjson` releases (currently published: `0.0.9`, `0.1.0`, `1.0.0`, `1.1.0`). Relaxing the constraint lets the SDK pick up fixes and features while still treating the next major (`2.0.0`) as the breaking-change boundary.

I verified the API the SDK actually uses — `from partialjson.json_parser import JSONParser` and `JSONParser().parse(...)` — is unchanged across all published versions up to `1.1.0` (the `JSONParser.__init__` / `parse` signatures are backward compatible, and the SDK call passes no arguments). There is no breaking-API risk within the chosen range.

## Test plan

- [x] Validated `sdk-python/pyproject.toml` is well-formed:
  `python3 -c "import tomllib,pathlib; tomllib.load(pathlib.Path('sdk-python/pyproject.toml').open('rb'))"`
- [x] Grepped `sdk-python` for `partialjson` usages — only `copilotkit/runloop.py` imports/uses it; API is stable across the allowed range.
- [ ] `poetry lock` / `poetry install` in `sdk-python` resolves a `partialjson` version within `>=0.0.8,<2.0.0`.

## Changed files

- `sdk-python/pyproject.toml` — single line changed (dependency range only). No source, example, or lockfile changes.

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] No documentation change required (dependency range only)
- [x] "Allow edits by maintainers" is checked

Relates to #4131
