### PR TITLE
docs(angular): add standalone guides and references

### DIFF
--- a/showcase/scripts/lib/angular-feature-search.test.ts
+++ b/showcase/scripts/lib/angular-feature-search.test.ts
@@ -1,37 +1,55 @@
-import { describe, expect, it } from "vitest";
+import { expect, test } from "vitest";
 
 import featureRegistry from "../../shared/feature-registry.json";
 import frontendRegistry from "../../shared/frontend-registry.json";
 import { buildAngularFeatureSearchEntries } from "./angular-feature-search";
 
-describe("Angular feature search entries", () => {
-  it("indexes every supported Angular feature", () => {
-    const entries = buildAngularFeatureSearchEntries(
-      frontendRegistry,
-      featureRegistry,
-    );
+test("indexes every supported Angular feature", () => {
+  const entries = buildAngularFeatureSearchEntries(
+    frontendRegistry,
+    featureRegistry,
+  );
 
-    expect(entries).toHaveLength(41);
-    for (const entry of entries) {
-      expect(entry.type).toBe("page");
-      expect(entry.title).toMatch(/ — Angular example$/);
-      expect(entry.section).toBe("Angular features");
-      expect(entry.href).toMatch(/^\/angular\/features#[a-z0-9-]+$/);
-    }
+  expect(entries).toHaveLength(41);
+  for (const entry of entries) {
+    expect(entry.type).toBe("page");
+    expect(entry.title).toMatch(/ — Angular example$/);
+    expect(entry.section).toBe("Angular features");
+    expect(entry.href).toMatch(/^\/angular\/features#[a-z0-9-]+$/);
+  }
+});
+
+test("uses standalone Angular names and descriptions", () => {
+  const entries = buildAngularFeatureSearchEntries(
+    frontendRegistry,
+    featureRegistry,
+  );
+  const componentRendering = entries.find(
+    (entry) => entry.href === "/angular/features#gen-ui-tool-based",
+  );
+  const renderedCopy = entries
+    .flatMap((entry) => [entry.title, entry.subtitle])
+    .join("\n");
+
+  expect(componentRendering).toMatchObject({
+    title: "Generative UI: component rendering — Angular example",
+    subtitle:
+      "Render typed tool results with registerFrontendTool and a standalone Angular component.",
   });
+  expect(renderedCopy).not.toMatch(/\bReact\b|\buse[A-Z]|<Copilot[A-Z]/);
+});
 
-  it("omits CLI, Hashbrown, and JSON Renderer entries", () => {
-    const hrefs = buildAngularFeatureSearchEntries(
-      frontendRegistry,
-      featureRegistry,
-    ).map((entry) => entry.href);
+test("omits CLI, Hashbrown, and JSON Renderer entries", () => {
+  const hrefs = buildAngularFeatureSearchEntries(
+    frontendRegistry,
+    featureRegistry,
+  ).map((entry) => entry.href);
 
-    expect(hrefs).not.toEqual(
-      expect.arrayContaining([
-        "/angular/features#cli-start",
-        "/angular/features#declarative-hashbrown",
-        "/angular/features#declarative-json-render",
-      ]),
-    );
-  });
+  expect(hrefs).not.toEqual(
+    expect.arrayContaining([
+      "/angular/features#cli-start",
+      "/angular/features#declarative-hashbrown",
+      "/angular/features#declarative-json-render",
+    ]),
+  );
 });

--- a/showcase/scripts/lib/angular-feature-search.ts
+++ b/showcase/scripts/lib/angular-feature-search.ts
@@ -7,7 +7,15 @@ export interface AngularFeatureSearchEntry {
 }
 
 interface FrontendRegistry {
-  feature_support: Record<string, { angular?: { state: string } }>;
+  feature_support: Record<
+    string,
+    {
+      angular?: {
+        state: string;
+        docs?: { name: string; description: string };
+      };
+    }
+  >;
 }
 
 interface FeatureRegistry {
@@ -21,7 +29,7 @@ export function buildAngularFeatureSearchEntries(
 ): AngularFeatureSearchEntry[] {
   return Object.entries(frontendRegistry.feature_support)
     .filter(([, declaration]) => declaration.angular?.state === "supported")
-    .map(([id]) => {
+    .map(([id, declaration]) => {
       const feature = featureRegistry.features.find(
         (candidate) => candidate.id === id,
       );
@@ -33,8 +41,8 @@ export function buildAngularFeatureSearchEntries(
 
       return {
         type: "page" as const,
-        title: `${feature.name} — Angular example`,
-        subtitle: feature.description,
+        title: `${declaration.angular?.docs?.name ?? feature.name} — Angular example`,
+        subtitle: declaration.angular?.docs?.description ?? feature.description,
         section: "Angular features" as const,
         href: `/angular/features#${id}`,
       };

--- a/showcase/scripts/lib/frontend-registry.ts
+++ b/showcase/scripts/lib/frontend-registry.ts
@@ -26,6 +26,10 @@ export interface FrontendSupportDeclaration {
   owner?: string;
   review_date?: string;
   issue?: string;
+  docs?: {
+    name: string;
+    description: string;
+  };
 }
 
 export interface FrontendRegistry {

--- a/showcase/shared/frontend-registry.json
+++ b/showcase/shared/frontend-registry.json
@@ -67,15 +67,33 @@
     },
     "agentic-chat": {
       "react": { "state": "supported" },
-      "angular": { "state": "supported" }
+      "angular": {
+        "state": "supported",
+        "docs": {
+          "name": "Prebuilt chat",
+          "description": "Add a full chat surface with the standalone CopilotChat component."
+        }
+      }
     },
     "prebuilt-sidebar": {
       "react": { "state": "supported" },
-      "angular": { "state": "supported" }
+      "angular": {
+        "state": "supported",
+        "docs": {
+          "name": "Prebuilt sidebar",
+          "description": "Add a responsive docked or overlay chat with CopilotSidebar."
+        }
+      }
     },
     "prebuilt-popup": {
       "react": { "state": "supported" },
-      "angular": { "state": "supported" }
+      "angular": {
+        "state": "supported",
+        "docs": {
+          "name": "Prebuilt popup",
+          "description": "Add a floating, accessible chat dialog with CopilotPopup."
+        }
+      }
     },
     "chat-slots": {
       "react": { "state": "supported" },
@@ -95,19 +113,43 @@
     },
     "gen-ui-tool-based": {
       "react": { "state": "supported" },
-      "angular": { "state": "supported" }
+      "angular": {
+        "state": "supported",
+        "docs": {
+          "name": "Generative UI: component rendering",
+          "description": "Render typed tool results with registerFrontendTool and a standalone Angular component."
+        }
+      }
     },
     "hitl-in-chat": {
       "react": { "state": "supported" },
-      "angular": { "state": "supported" }
+      "angular": {
+        "state": "supported",
+        "docs": {
+          "name": "Human in the loop: in chat",
+          "description": "Pause a tool call for user input with registerHumanInTheLoop and render the decision inside chat."
+        }
+      }
     },
     "gen-ui-interrupt": {
       "react": { "state": "supported" },
-      "angular": { "state": "supported" }
+      "angular": {
+        "state": "supported",
+        "docs": {
+          "name": "Human in the loop: interrupts",
+          "description": "Handle an agent interrupt with injectInterrupt and render the response controls inside chat."
+        }
+      }
     },
     "interrupt-headless": {
       "react": { "state": "supported" },
-      "angular": { "state": "supported" }
+      "angular": {
+        "state": "supported",
+        "docs": {
+          "name": "Human in the loop: headless interrupts",
+          "description": "Resolve an agent interrupt with injectInterrupt from application UI outside the chat."
+        }
+      }
     },
     "declarative-gen-ui": {
       "react": { "state": "supported" },
@@ -155,11 +197,23 @@
     },
     "reasoning-custom": {
       "react": { "state": "supported" },
-      "angular": { "state": "supported" }
+      "angular": {
+        "state": "supported",
+        "docs": {
+          "name": "Reasoning: custom",
+          "description": "Replace the reasoning-message slot with a standalone Angular component."
+        }
+      }
     },
     "gen-ui-agent": {
       "react": { "state": "supported" },
-      "angular": { "state": "supported" }
+      "angular": {
+        "state": "supported",
+        "docs": {
+          "name": "Generative UI: agent state",
+          "description": "Read live agent state with injectAgentStore and render it in the chat transcript."
+        }
+      }
     },
     "frontend-tools": {
       "react": { "state": "supported" },
@@ -167,15 +221,33 @@
     },
     "frontend-tools-async": {
       "react": { "state": "supported" },
-      "angular": { "state": "supported" }
+      "angular": {
+        "state": "supported",
+        "docs": {
+          "name": "Frontend tools: async",
+          "description": "Register an async browser tool whose result returns to the agent."
+        }
+      }
     },
     "threadid-frontend-tool-roundtrip": {
       "react": { "state": "supported" },
-      "angular": { "state": "supported" }
+      "angular": {
+        "state": "supported",
+        "docs": {
+          "name": "Thread ID: frontend tool round trip",
+          "description": "Keep an explicit thread ID across an async frontend-tool call and resumed agent run."
+        }
+      }
     },
     "hitl-in-app": {
       "react": { "state": "supported" },
-      "angular": { "state": "supported" }
+      "angular": {
+        "state": "supported",
+        "docs": {
+          "name": "Human in the loop: in app",
+          "description": "Render approval UI outside chat and resolve the pending tool with the user's decision."
+        }
+      }
     },
     "shared-state-read-write": {
       "react": { "state": "supported" },
@@ -191,7 +263,13 @@
     },
     "readonly-state-agent-context": {
       "react": { "state": "supported" },
-      "angular": { "state": "supported" }
+      "angular": {
+        "state": "supported",
+        "docs": {
+          "name": "Shared state: agent context",
+          "description": "Share read-only application state with the agent through connectAgentContext."
+        }
+      }
     },
     "subagents": {
       "react": { "state": "supported" },

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/__tests__/framework-root-shell-layout.test.ts
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/__tests__/framework-root-shell-layout.test.ts
@@ -1,87 +1,88 @@
 import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { expect, test } from "vitest";
 
 const pageSource = readFileSync(
   new URL("../page.tsx", import.meta.url),
   "utf8",
 );
 
-describe("FrameworkRootShell layout", () => {
-  it("does not add top padding above framework landing content", () => {
-    const shellSource = pageSource.match(
-      /function FrameworkRootShell[\s\S]*?<\/ShellDocsLayout>/,
-    )?.[0];
+test("does not add top padding above framework landing content", () => {
+  const shellSource = pageSource.match(
+    /function FrameworkRootShell[\s\S]*?<\/ShellDocsLayout>/,
+  )?.[0];
 
-    expect(shellSource).toContain(
-      'className="docs-inner-content max-w-[900px] mx-auto px-4 md:px-6 pt-0 pb-6"',
-    );
-    expect(shellSource).not.toContain("pt-2 pb-6 md:pt-3 xl:pt-4");
-  });
+  expect(shellSource).toContain(
+    'className="docs-inner-content max-w-[900px] mx-auto px-4 md:px-6 pt-0 pb-6"',
+  );
+  expect(shellSource).not.toContain("pt-2 pb-6 md:pt-3 xl:pt-4");
+});
 
-  it("parses frontend routes before resolving frontend content slugs", () => {
-    expect(pageSource).toContain("parseFrontendRoutePath");
-    expect(pageSource).toContain("activeBackendFramework");
-    expect(pageSource).toContain("frameworkOverride={activeBackendFramework}");
-  });
+test("parses frontend routes before resolving frontend content slugs", () => {
+  expect(pageSource).toContain("parseFrontendRoutePath");
+  expect(pageSource).toContain("activeBackendFramework");
+  expect(pageSource).toContain("frameworkOverride={activeBackendFramework}");
+});
 
-  it("redirects retired frontend URL shapes instead of rendering them", () => {
-    expect(pageSource).toContain('if (framework === "frontends")');
-    expect(pageSource).toContain("legacyFrontendPathRedirect(");
-    expect(pageSource).toContain(
-      "const frontendRedirect = legacyFrontendPathRedirect(",
-    );
-  });
+test("redirects retired frontend URL shapes instead of rendering them", () => {
+  expect(pageSource).toContain('if (framework === "frontends")');
+  expect(pageSource).toContain("legacyFrontendPathRedirect(");
+  expect(pageSource).toContain(
+    "const frontendRedirect = legacyFrontendPathRedirect(",
+  );
+});
 
-  it("canonicalizes React guidance routes to the React root", () => {
-    expect(pageSource).toContain(
-      'return frontendPathForBackend("react", slugPath);',
-    );
-  });
+test("canonicalizes React guidance routes to the React root", () => {
+  expect(pageSource).toContain(
+    'return frontendPathForBackend("react", slugPath);',
+  );
+});
 
-  it("renders backend docs when a frontend route includes a backend slug", () => {
-    expect(pageSource).toContain("scopedFramework = activeBackendFramework");
-    expect(pageSource).toContain("scopedSlugHrefPrefix = frontendRoutePath(");
-    expect(pageSource).toContain("frameworkOverride={scopedFramework}");
-    expect(pageSource).toContain(
-      "slugHrefPrefix={scopedSlugHrefPrefix ?? `/${scopedFramework}`}",
-    );
-    expect(pageSource).toContain(
-      "preferIndexMdx={Boolean(scopedSlugHrefPrefix)}",
-    );
-  });
+test("renders backend docs for non-Angular frontend routes with a backend slug", () => {
+  expect(pageSource).toContain(
+    'if (activeBackendFramework && framework !== "angular")',
+  );
+  expect(pageSource).toContain("scopedFramework = activeBackendFramework");
+  expect(pageSource).toContain("scopedSlugHrefPrefix = frontendRoutePath(");
+  expect(pageSource).toContain("frameworkOverride={scopedFramework}");
+  expect(pageSource).toContain(
+    "slugHrefPrefix={scopedSlugHrefPrefix ?? `/${scopedFramework}`}",
+  );
+  expect(pageSource).toContain(
+    "preferIndexMdx={Boolean(scopedSlugHrefPrefix)}",
+  );
+});
 
-  it("keeps frontend root pages available under frontend/backend routes", () => {
-    const frontendRootIndex = pageSource.indexOf(
-      "if (!activeFrontendSlugPath) {\n      return (\n        <FrontendQuickstartDocsPage",
-    );
-    const backendScopingIndex = pageSource.indexOf(
-      "if (activeBackendFramework) {\n      scopedFramework = activeBackendFramework",
-    );
+test("keeps frontend root pages available under frontend/backend routes", () => {
+  const frontendRootIndex = pageSource.indexOf(
+    "if (!activeFrontendSlugPath) {\n      return (\n        <FrontendQuickstartDocsPage",
+  );
+  const backendScopingIndex = pageSource.indexOf(
+    'if (activeBackendFramework && framework !== "angular") {\n      scopedFramework = activeBackendFramework',
+  );
 
-    expect(frontendRootIndex).toBeGreaterThan(-1);
-    expect(backendScopingIndex).toBeGreaterThan(-1);
-    expect(frontendRootIndex).toBeLessThan(backendScopingIndex);
-  });
+  expect(frontendRootIndex).toBeGreaterThan(-1);
+  expect(backendScopingIndex).toBeGreaterThan(-1);
+  expect(frontendRootIndex).toBeLessThan(backendScopingIndex);
+});
 
-  it("keeps frontend guidance pages available under frontend/backend routes", () => {
-    const guidanceIndex = pageSource.indexOf(
-      "if (isFrontendGuidanceSlug(activeFrontendSlugPath))",
-    );
-    const backendScopingIndex = pageSource.indexOf(
-      "if (activeBackendFramework) {\n      scopedFramework = activeBackendFramework",
-    );
+test("keeps frontend guidance pages available under frontend/backend routes", () => {
+  const guidanceIndex = pageSource.indexOf(
+    "if (isFrontendGuidanceSlug(activeFrontendSlugPath))",
+  );
+  const backendScopingIndex = pageSource.indexOf(
+    'if (activeBackendFramework && framework !== "angular") {\n      scopedFramework = activeBackendFramework',
+  );
 
-    expect(guidanceIndex).toBeGreaterThan(-1);
-    expect(backendScopingIndex).toBeGreaterThan(-1);
-    expect(guidanceIndex).toBeLessThan(backendScopingIndex);
-    expect(pageSource).toContain("<FrontendGuidanceDocsPage");
-  });
+  expect(guidanceIndex).toBeGreaterThan(-1);
+  expect(backendScopingIndex).toBeGreaterThan(-1);
+  expect(guidanceIndex).toBeLessThan(backendScopingIndex);
+  expect(pageSource).toContain("<FrontendGuidanceDocsPage");
+});
 
-  it("uses backend metadata for frontend routes that include a backend slug", () => {
-    expect(pageSource).toContain("frameworkMetadata(");
-    expect(pageSource).toMatch(
-      /frameworkMetadata\(\s*activeBackendFramework,\s*activeFrontendSlugPath/s,
-    );
-    expect(pageSource).toContain("scopedRoutePath(");
-  });
+test("uses backend metadata for frontend routes that include a backend slug", () => {
+  expect(pageSource).toContain("frameworkMetadata(");
+  expect(pageSource).toMatch(
+    /frameworkMetadata\(\s*activeBackendFramework,\s*activeFrontendSlugPath/s,
+  );
+  expect(pageSource).toContain("scopedRoutePath(");
 });

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -41,6 +41,7 @@ import { resolveFrontendDocPage } from "@/lib/frontend-doc-policy";
 import {
   getFrontendGuidanceContentSlug,
   getFrontendContentSlug,
+  getFrontendCanonicalSlug,
   getFrontendQuickstartNavTree,
 } from "@/lib/frontend-page-content";
 import type { FrontendPageId } from "@/lib/frontend-page-content";
@@ -402,7 +403,22 @@ export default async function FrameworkScopedDocsPage({
       getIntegrations().map((integration) => integration.slug),
     );
     const activeBackendFramework = frontendRoute?.backend ?? null;
-    const activeFrontendSlugPath = frontendRoute?.slugPath ?? frontendSlugPath;
+    const requestedFrontendSlugPath =
+      frontendRoute?.slugPath ?? frontendSlugPath;
+    const activeFrontendSlugPath = getFrontendCanonicalSlug(
+      framework,
+      requestedFrontendSlugPath,
+    );
+
+    if (activeFrontendSlugPath !== requestedFrontendSlugPath) {
+      redirect(
+        frontendRoutePath(
+          framework,
+          activeFrontendSlugPath,
+          activeBackendFramework,
+        ),
+      );
+    }
 
     if (activeBackendFramework === ROOT_FRAMEWORK) {
       redirect(frontendRoutePath(framework, activeFrontendSlugPath));
@@ -437,7 +453,7 @@ export default async function FrameworkScopedDocsPage({
       );
     }
 
-    if (activeBackendFramework) {
+    if (activeBackendFramework && framework !== "angular") {
       scopedFramework = activeBackendFramework;
       scopedSlug = activeFrontendSlugPath
         ? activeFrontendSlugPath.split("/").filter(Boolean)

--- a/showcase/shell-docs/src/app/sitemap.test.ts
+++ b/showcase/shell-docs/src/app/sitemap.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "vitest";
+
+import sitemap from "./sitemap";
+
+test("publishes the Angular feature catalog at its canonical URL", () => {
+  const urls = sitemap().map((entry) => entry.url);
+
+  expect(urls.some((url) => url.endsWith("/angular/features"))).toBe(true);
+});

--- a/showcase/shell-docs/src/app/sitemap.test.ts
+++ b/showcase/shell-docs/src/app/sitemap.test.ts
@@ -7,3 +7,18 @@ test("publishes the Angular feature catalog at its canonical URL", () => {
 
   expect(urls.some((url) => url.endsWith("/angular/features"))).toBe(true);
 });
+
+test("publishes every Angular task guide at its canonical URL", () => {
+  const urls = sitemap().map((entry) => entry.url);
+  const guidePaths = [
+    "/angular/guides/chat-ui",
+    "/angular/guides/frontend-tools-generative-ui",
+    "/angular/guides/human-in-the-loop",
+    "/angular/guides/shared-state",
+    "/angular/guides/threads-memory-attachments-headless",
+  ];
+
+  for (const guidePath of guidePaths) {
+    expect(urls.some((url) => url.endsWith(guidePath))).toBe(true);
+  }
+});

--- a/showcase/shell-docs/src/app/sitemap.ts
+++ b/showcase/shell-docs/src/app/sitemap.ts
@@ -137,6 +137,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
     }
   }
 
+  const angularFeaturesDoc = loadDoc("frontends/angular/features");
+  if (angularFeaturesDoc) {
+    entries.push({
+      url: `${baseUrl}/angular/features`,
+      lastModified: resolveLastModified(angularFeaturesDoc.filePath),
+    });
+  }
+
   // Status/guidance page, emitted once per non-React frontend.
   for (const frontend of FRONTEND_PAGE_IDS) {
     const doc = loadDoc(getFrontendGuidanceContentSlug(frontend));

--- a/showcase/shell-docs/src/app/sitemap.ts
+++ b/showcase/shell-docs/src/app/sitemap.ts
@@ -25,6 +25,7 @@ import {
   resolveLastModified,
 } from "@/lib/sitemap-helpers";
 import {
+  ANGULAR_GUIDE_PAGES,
   FRONTEND_PAGE_IDS,
   getFrontendContentSlug,
   getFrontendGuidanceContentSlug,
@@ -143,6 +144,16 @@ export default function sitemap(): MetadataRoute.Sitemap {
       url: `${baseUrl}/angular/features`,
       lastModified: resolveLastModified(angularFeaturesDoc.filePath),
     });
+  }
+
+  for (const guide of ANGULAR_GUIDE_PAGES) {
+    const doc = loadDoc(`frontends/angular/${guide.slug}`);
+    if (doc) {
+      entries.push({
+        url: `${baseUrl}/angular/${guide.slug}`,
+        lastModified: resolveLastModified(doc.filePath),
+      });
+    }
   }
 
   // Status/guidance page, emitted once per non-React frontend.

--- a/showcase/shell-docs/src/components/__tests__/angular-feature-catalog.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/angular-feature-catalog.test.tsx
@@ -1,0 +1,14 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { expect, test } from "vitest";
+
+import { AngularFeatureCatalog } from "../angular-feature-catalog";
+
+test("shows only claims supplied by the Angular feature registry", () => {
+  const markup = renderToStaticMarkup(<AngularFeatureCatalog />);
+
+  expect(markup).toContain("View source");
+  expect(markup).toContain("API inventory");
+  expect(markup).not.toMatch(
+    /loading, failure, recovery|SSR-safe|hydration|Compiling source/,
+  );
+});

--- a/showcase/shell-docs/src/components/angular-feature-catalog.tsx
+++ b/showcase/shell-docs/src/components/angular-feature-catalog.tsx
@@ -26,28 +26,6 @@ export function AngularFeatureCatalog() {
           <p className="mt-3 text-sm text-[var(--text-secondary)]">
             {feature.description}
           </p>
-          <dl className="mt-4 grid gap-2 text-sm sm:grid-cols-[8rem_1fr]">
-            <dt className="font-medium text-[var(--text)]">Setup</dt>
-            <dd className="text-[var(--text-secondary)]">
-              Configure <code>provideCopilotKit</code>, then load this feature's
-              standalone component from the source view.
-            </dd>
-            <dt className="font-medium text-[var(--text)]">Lifecycle</dt>
-            <dd className="text-[var(--text-secondary)]">
-              Registrations follow the owning injection context and clean up
-              when Angular destroys it.
-            </dd>
-            <dt className="font-medium text-[var(--text)]">Errors</dt>
-            <dd className="text-[var(--text-secondary)]">
-              The runnable example shows loading, failure, recovery, and
-              unsupported backend states without a frontend fallback.
-            </dd>
-            <dt className="font-medium text-[var(--text)]">Rendering</dt>
-            <dd className="text-[var(--text-secondary)]">
-              The example supports SSR-safe setup, hydration, and zoneless
-              signal updates where browser APIs allow the feature to run.
-            </dd>
-          </dl>
           <nav
             aria-label={`${feature.name} resources`}
             className="mt-4 flex flex-wrap gap-4 text-sm"
@@ -68,13 +46,15 @@ export function AngularFeatureCatalog() {
               className="text-[var(--accent)] underline"
               href={feature.sourceHref}
             >
-              Compiling source
+              View source
             </a>
             <a
               className="text-[var(--accent)] underline"
               href={feature.apiHref}
             >
-              Typed API
+              {feature.apiHref === "/reference/angular/public-api"
+                ? "API inventory"
+                : "API reference"}
             </a>
           </nav>
         </section>

--- a/showcase/shell-docs/src/content/docs/cookbook/angular-adk-agentic-app.mdx
+++ b/showcase/shell-docs/src/content/docs/cookbook/angular-adk-agentic-app.mdx
@@ -1,35 +1,35 @@
 ---
 title: "Angular + Google ADK"
-description: "Wire an Angular frontend to a Google ADK agent over AG-UI, with optional persistent threads and memory. The non-obvious production gotchas, as symptom, cause, and fix."
+description: "Connect an Angular frontend to a Google ADK agent over AG-UI, then add request identity, server-side policy, threads, and memory."
 icon: "custom/google-adk"
 showIcon: true
 doc_type: how-to
 ---
 
-This recipe assembles a production agentic app from three pieces: an **Angular** frontend built with [`@copilotkit/angular`](/frontends/angular), a **Google ADK** agent (running Gemini by default, or any model ADK supports) served over the open [AG-UI](https://docs.ag-ui.com/) protocol, and an optional [CopilotKit Intelligence](/premium/overview) layer for persistent threads and cross-session memory.
+This recipe assembles a production agentic app from three pieces: an **Angular** frontend built with [`@copilotkit/angular`](/angular), a **Google ADK** agent served over the open [AG-UI](https://docs.ag-ui.com/) protocol, and an optional [CopilotKit Intelligence](/premium/overview) layer for persistent threads and cross-session memory.
 
-Both halves have their own quickstarts already, and this recipe does not repeat them:
+Start with these two quickstarts:
 
-- [Angular frontend](/frontends/angular) gets you a working Angular app with a chat UI backed by a local Copilot Runtime.
-- [ADK quickstart](/integrations/adk/quickstart) turns your ADK agents into an agent-native application.
+- [Angular frontend](/angular) gets you a working Angular app with a chat UI backed by a local Copilot Runtime.
+- [ADK quickstart](/integrations/adk/quickstart) serves an ADK agent over AG-UI.
 
-What this recipe covers is the part that bites once the two are wired together: the handful of correctness issues that only show up in a real, multi-user, governed app. Each one is framed as symptom, cause, and fix.
+This recipe covers production concerns that arise after the two quickstarts are connected: shared chat state, request identity, model choice, server-side policy, threads, and memory.
 
 ## How the pieces fit
 
-Three processes, with one load-bearing seam between them:
+The app has three processes:
 
 1. The **Angular client** renders chat and generative UI and runs the agent.
-2. A **runtime / backend-for-frontend (BFF)** wires the Copilot Runtime, resolves the per-request user, enforces governance, proxies memory, and forwards each run to your agent. Most of the subtle, correctness-critical logic lives here, not in the browser or the agent.
+2. A **runtime / backend-for-frontend (BFF)** wires the Copilot Runtime, resolves the per-request user, enforces tool policy, proxies memory, and forwards each run to your agent. This layer handles identity, policy, and memory access.
 3. The **Google ADK agent** does the reasoning and emits generative UI. An optional deterministic specialist agent handles fixed payloads.
 
-<Callout type="info" title="The BFF is where correctness lives">
-  Treat the browser as untrusted and the agent as replaceable. The seam that resolves the user, strips disallowed tools, and proxies memory is the part to get right.
+<Callout type="info" title="Validate identity and policy in the BFF">
+  Treat data from the browser as untrusted. Resolve the authenticated user, enforce tool policy, and scope memory requests on the server.
 </Callout>
 
-## The chat surface: one agent, one store
+## Share agent state across the chat surface
 
-`injectAgentStore("default")` returns a **shared** store keyed by agent id. Every component that injects `"default"` sees the same messages and run state.
+Calls to `injectAgentStore("default")` resolve the same underlying agent. Components that use the same agent id observe the same messages and run state.
 
 ```ts title="chat.component.ts"
 import { Component } from "@angular/core";
@@ -39,7 +39,7 @@ import { CopilotChat, injectAgentStore } from "@copilotkit/angular";
   selector: "app-chat",
   imports: [CopilotChat],
   template: `<copilot-chat agentId="default" />`,
-  // Give the surface a bounded height, or the composer slides off-screen on long threads.
+  // Give the surface a bounded height to keep the composer visible on long threads.
   styles: [`:host { display: block; height: 100%; min-height: 0; }`],
 })
 export class ChatComponent {
@@ -47,10 +47,8 @@ export class ChatComponent {
 }
 ```
 
-<Callout type="warn" title="A second composer must not create its own agent store">
-  **Symptom:** a welcome or secondary composer submits, but its messages never appear in the conversation.
-  **Cause:** that composer called `injectAgentStore` itself, so it holds a *different* instance than the one your surface renders.
-  **Fix:** route every composer's submit through the one shared store. There is one surface and one store per agent id.
+<Callout type="info" title="Use one owner for custom submission logic">
+  A second composer may inject the same agent id and will observe the same agent. For consistent validation, attachments, and message submission, pass one submit function or service to each custom composer.
 </Callout>
 
 <Callout type="warn" title="Do not fetch history for a brand-new thread">
@@ -59,23 +57,17 @@ export class ChatComponent {
   **Fix:** only fetch history for an existing, user-selected thread. Run new conversations on a fresh id, and reload stored messages only when the bound thread id changes.
 </Callout>
 
-<Callout type="error" title="Never reconfigure the runtime mid-submit">
-  **Symptom:** intermittent blank conversations, where a just-sent user message vanishes.
-  **Cause:** mutating runtime config (for example swapping `headers` or `runtimeUrl`) invalidates the agent-store computed and **recreates the store mid-run**, dropping the message that was just added.
-  **Fix:** carry per-request values in the run body (see below), and do any config changes *before* the chat mounts, never during a submit.
+<Callout type="warn" title="Change runtime configuration between runs">
+  The runtime URL and request headers take part in agent resolution. Apply configuration changes before a run starts. Put non-secret values that change on each request in the run body instead.
 </Callout>
 
-## Scope the user through the run body, not a header
+## Send changing context with each run
 
-This is the single most common correctness bug on this stack.
-
-<Callout type="error" title="An HTTP header lags by one user switch">
-  **Symptom:** right after switching users in the same session, the agent recalls the *previous* user's data. Fresh page loads are always fine.
-  **Cause:** if you identify the user with an HTTP header, the transport reuses connections, so the outbound run still carries the prior user's header for one run after an in-session switch.
-  **Fix:** put the user id in the **run body**, which is serialized fresh on every run and never lags.
+<Callout type="warn" title="Do not use browser context as authorization">
+  A user id sent by the browser is untrusted. Resolve the authenticated user on the server. Use run context only to give the agent current, non-secret application state, and validate any identity value against the server session before using it to scope data.
 </Callout>
 
-Carry the user id as **agent context**, not as `properties`. This matters on ADK: the adapter copies the run's `state` and `context` into the ADK session, but it does **not** mirror `forwardedProps` (CopilotKit `properties`) into session state. A user id sent through `properties` never reaches `tool_context.state`, so the scoping silently fails. Use [`connectAgentContext`](/reference/angular/functions/connectAgentContext), which rides the run body and is serialized fresh every run:
+Use [`connectAgentContext`](/reference/angular/functions/connectAgentContext) to send current, non-secret application state with each run:
 
 ```ts title="chat.component.ts"
 import { Component, signal } from "@angular/core";
@@ -92,14 +84,11 @@ export class ChatComponent {
 }
 ```
 
-On the agent side, the AG-UI adapter stores context under the `_ag_ui_context` key, so a tool reads the user id from there:
+Do not use this browser value as proof of identity. The BFF must compare it with the authenticated session or replace it with the server identity. If an ADK tool needs the validated user id, map that value into ADK session state in the BFF or agent adapter. The tool can then read the application-defined state key:
 
 ```python title="agent/main.py"
 def _user_id(tool_context) -> str | None:
-    for entry in tool_context.state.get("_ag_ui_context", []):
-        if entry.get("description") == "userId":
-            return entry.get("value")
-    return None
+    return tool_context.state.get("user_id")
 
 def recall_for_user(tool_context) -> dict:
     user_id = _user_id(tool_context)
@@ -107,17 +96,17 @@ def recall_for_user(tool_context) -> dict:
     return {"ok": True}
 ```
 
-Shared agent **state** works too, and lands directly as `tool_context.state["userId"]` (no `_ag_ui_context` scan). Pick one. If your BFF also accepts a user header, **prefer the run-body value over the header** when scoping, so a stale header can never win.
+The exact mapping belongs to your server bridge. Keep it explicit and test it with the version of the ADK adapter you deploy.
 
 ## Choose a capable model
 
-ADK runs Google's Gemini by default, but it is model-flexible: you can point it at any model ADK supports (see [the ADK quickstart](/integrations/adk/quickstart)). Whatever you pick, the agentic-flow guidance is the same.
+ADK uses Google's Gemini by default and also supports other models. See the [ADK quickstart](/integrations/adk/quickstart) for configuration.
 
-- Prefer a **current, capable agentic model**. Governance and tool substitution are multi-step instructions, and a strong instruction-follower handles them reliably without paying for a top-tier reasoning model.
-- An **under-powered or generation-old model is a false economy** for agentic flows. It follows multi-step instructions inconsistently, for example removing a disallowed tool from context but forgetting to emit the substitute, which yields an empty or half answer.
-- A **top-tier reasoning model** has the best instruction-following and tool use, but it is slower and pricier, and usually overkill outside the hardest reasoning step.
+- Prefer a current model with reliable instruction following and tool use.
+- Test older or smaller models against your full tool and policy flow. They may skip steps in multi-part instructions.
+- Use a reasoning model when the task needs it, and account for its added latency and cost.
 
-<Callout type="tip" title="Validate availability against your provider, do not trust web summaries">
+<Callout type="tip" title="Check model access with your provider">
   Confirm a model id actually exists for your account before wiring it in. On Gemini, for example:
   ```bash
   curl "https://generativelanguage.googleapis.com/v1beta/models?key=$GOOGLE_API_KEY" | grep '"name"'
@@ -126,8 +115,8 @@ ADK runs Google's Gemini by default, but it is model-flexible: you can point it 
 
 Two more agent-side habits:
 
-- **Keep MCP and tool timeouts short.** A generous timeout lets a slow or cold external tool server stall the first reply. A tight timeout degrades gracefully instead of hanging.
-- **For exact, fixed generative-UI payloads, use a deterministic sub-agent.** Asking an LLM to "echo this verbatim" mangles non-trivial JSON. Emit the payload directly from code.
+- **Keep MCP and tool timeouts short.** A long timeout lets a slow external tool server delay the first reply. A shorter timeout reports the failure sooner.
+- **Emit fixed generated-UI payloads from code.** A model may change JSON even when asked to return it unchanged.
 
 ## Enforce governance on the server
 
@@ -137,16 +126,16 @@ Two more agent-side habits:
   **Fix:** on the BFF, strip disallowed tools from the inbound run body so the model cannot call them, and filter the outbound generative-UI stream. Emit a single governance receipt rather than silently dropping output.
 </Callout>
 
-- **Make the per-request allow-list ride the run body.** Toggling a capability mid-conversation then takes effect on the next run without recreating the agent store and without leaking a suppressed surface.
-- **Normalize capability names across casings** (for example `pieChart` versus `PieChart`) on both the inbound strip and the outbound filter, or governance leaks through a casing mismatch.
+- **Include the per-request allow-list in the run body.** A capability change then takes effect on the next run.
+- **Normalize capability-name casing** (for example `pieChart` versus `PieChart`) in both the inbound and outbound checks. A casing mismatch can bypass a policy check.
 - **Let generative-UI cards reflow, do not truncate.** Long dynamic labels overflow fixed-size cards. Let the layout grow rather than clipping content.
 
 ## Add persistent threads and memory (optional)
 
-[CopilotKit Intelligence](/premium/overview) adds persistent [threads](/threads) and durable cross-session memory. Build so a missing or unreachable platform degrades gracefully instead of erroring on every call:
+[CopilotKit Intelligence](/premium/overview) adds persistent [threads](/threads) and durable cross-session memory. Handle a missing or unreachable platform without failing every request:
 
 - **Auto-detect:** at startup, probe the platform health endpoint with a short timeout. If it is unreachable or unlicensed, fall back to an in-memory runner.
-- **Configurable endpoint:** honor a single base-URL env var from the runtime, the agent's memory client, and the probe, so a non-default host or port just works. Re-detection happens on restart.
+- **Configurable endpoint:** use one base-URL environment variable for the runtime, the agent's memory client, and the health probe. Check the endpoint again after a restart.
 
 Memory tools call the platform's streaming JSON-RPC `/mcp` endpoint, scoped per user:
 
@@ -160,9 +149,9 @@ Accept: application/json, text/event-stream
  "params":{"name":"recall_memory","arguments":{}}}
 ```
 
-The response is a server-sent event stream. Read the JSON-RPC body from the first `data:` line and join the text content. Writes hit an embedding step and can take several seconds, so give the call generous timeout headroom and keep it async.
+The response is a server-sent event stream. Read the JSON-RPC body from the first `data:` line and join the text content. Writes may include an embedding step and can take several seconds, so run them asynchronously and set a suitable timeout.
 
-<Callout type="warn" title="Do not let saved memories disappear from a memory browser">
+<Callout type="warn" title="Query each supported memory scope">
   **Symptom:** the agent clearly remembers things a custom memory panel never shows.
   **Cause:** recall often defaults to *user* scope and caps at a small top-N, so a panel that hard-codes user scope hides project- or team-scoped memories.
   **Fix:** if you build a memory browser, query both user and project scopes, de-duplicate, and merge.
@@ -172,18 +161,18 @@ The response is a server-sent event stream. Read the JSON-RPC body from the firs
   Running CopilotKit Intelligence yourself has its own setup notes (license verification and the embedding service). See [Self-hosting](/premium/self-hosting).
 </Callout>
 
-## The five that bite hardest
+## Production checklist
 
-1. **One agent, one store.** A second composer that injects its own store is a different instance, and its messages never appear.
-2. **Scope the user through the run body, never an HTTP header.** A header lags by one in-session switch.
-3. **Never reconfigure the runtime mid-submit.** It recreates the agent store and eats the just-sent message.
-4. **Governance is server-side.** Strip disallowed tools from the run body and let the per-request allow-list ride it.
-5. **Use a current, capable agentic model** (Gemini or any model ADK supports), and validate availability against your provider.
+1. Use one agent id across the chat surface. Share one submit function or service across custom composers.
+2. Resolve identity on the server. Send changing, non-secret application context with each run.
+3. Apply runtime URL and header changes between runs.
+4. Enforce tool policy on the server. Strip disallowed tools from inbound runs and filter outbound generated UI.
+5. Test a current agentic model against your full tool and policy flow, and confirm that your provider offers it.
 
 ## Going further
 
 - **Local dev:** only your frontend dev server hot-reloads. A `tsx`/`node` BFF and a Python agent do not, so restart them after edits. Give each service a stable, non-colliding port and write them down.
-- **Porting a rich React chat UI?** The Angular client is leaner. You build the welcome and empty states yourself, customize through `messageViewComponent` rather than a template, and iterate the full message list yourself to interleave generative UI. See the [Angular guide](/frontends/angular).
+- **Custom chat UI:** Build welcome and empty states in your application, customize message rendering through `messageViewComponent`, and iterate the full message list when you need to interleave generated UI. See the [Angular guide](/angular).
 - **Threads in depth:** see [Threads explained](/premium/threads-explained).
 
 ## Get started with a coding agent
@@ -191,20 +180,16 @@ The response is a server-sent event stream. Read the JSON-RPC body from the firs
 Paste this into your coding agent (Cursor, Claude Code, etc.) once you have the Angular and ADK quickstarts running:
 
 ```text
-In my Angular + Google ADK + CopilotKit app, harden it for multi-user production:
+Update my Angular + Google ADK + CopilotKit app for multi-user production:
 
-1. Standardize on one chat surface: a single `injectAgentStore("default")`, and route every
-   composer (including any welcome composer) through that one shared store.
-2. Scope the user via the run body, not a header. On ADK, `forwardedProps` (CopilotKit `properties`)
-   is NOT mirrored into session state, so carry the user id as agent context with
-   `connectAgentContext({ description: "userId", value: userId })`, and read it in ADK tools by
-   scanning `tool_context.state["_ag_ui_context"]` for the `userId` entry (or use shared agent state,
-   which lands directly as `tool_context.state["userId"]`). If the BFF also accepts a user header,
-   prefer the run-body value over the header.
-3. Never mutate runtime config (runtimeUrl/headers) during a submit. Do config changes before the
-   chat mounts. Carry per-request values in the run body instead.
-4. Enforce governance on the server: strip disallowed tools from the inbound run body and filter the
-   outbound generative-UI stream. Make the allow-list ride the run body, and normalize tool-name casing.
+1. Use one agent id across the chat surface. Calls to `injectAgentStore("default")` resolve the
+   same agent. Route custom composers through one shared submit function or service.
+2. Resolve the authenticated user on the BFF. If ADK tools need that id, map the server-validated
+   value into an application-defined ADK session-state key. Do not trust browser context alone.
+3. Apply runtime config changes (runtimeUrl/headers) between runs. Carry changing, non-secret
+   application context in the run body.
+4. Enforce tool policy on the server: strip disallowed tools from the inbound run body and filter the
+   outbound generative-UI stream. Include the allow-list in the run body, and normalize tool-name casing.
 5. Give the chat surface a bounded height, and only fetch thread history for an existing thread id.
 
 Keep my existing Angular and ADK setup otherwise unchanged.

--- a/showcase/shell-docs/src/content/docs/frontends/angular.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/angular.mdx
@@ -13,13 +13,13 @@ The runtime runs on your server, keeps model credentials out of the browser, and
 
 CopilotKit for Angular is the first-party, signal-based Angular frontend for
 AG-UI agents and Copilot Runtime. It provides complete chat surfaces and
-headless APIs without requiring React or Zone.js.
+headless APIs, and it supports zoneless applications.
 
 ## Prerequisites
 
-- An OpenAI API key (or another model provider supported by [Model Selection](https://docs.copilotkit.ai/model-selection))
+- An OpenAI API key (or another model provider supported by [Model Selection](/model-selection))
 - Angular 20, 21, or 22
-- Node.js 20+
+- Node.js 22
 
 ## Getting started
 
@@ -183,13 +183,8 @@ headless APIs without requiring React or Zone.js.
 
 ## Next steps
 
-- [Angular Showcase examples](https://showcase.copilotkit.ai/angular/langgraph-python/agentic-chat): switch between Angular and React while keeping the same integration and feature.
-- [Copilot Runtime](/backend/copilot-runtime): runtime setup, auth, middleware, and routing.
-- [Built-in Agent quickstart](/quickstart): configure the in-process agent used in this quickstart.
-- [Integrations](/integrations/langgraph): connect LangGraph, CrewAI, Mastra, and other agents through the runtime.
-- [Angular + Google ADK in production](/cookbook/angular-adk-agentic-app): the non-obvious gotchas when you wire Angular to an ADK agent with threads and memory.
-- [Angular API reference](https://docs.copilotkit.ai/reference/angular): components, signals, tools, context, and runtime services.
-- [Production and lifecycle](https://docs.copilotkit.ai/reference/angular/production-lifecycle): cleanup, errors, SSR, hydration, zoneless Angular, and browser-only feature boundaries.
-- [Public API inventory](https://docs.copilotkit.ai/reference/angular/public-api): supported entry points and the machine-validated export contract.
-
-For headless setups and custom UIs with `injectAgentStore`, see the [`@copilotkit/angular` README](https://github.com/CopilotKit/CopilotKit/tree/main/packages/angular). The installed package also includes `API.md` beside its README with the exact export list for that version.
+- [Angular Showcase example](https://showcase.copilotkit.ai/angular/langgraph-python/agentic-chat): run the agentic chat example and inspect its source.
+- [Angular feature examples](/angular/features): find runnable examples and source for each supported feature.
+- [Angular API reference](/reference/angular): use components, signals, tools, context, and runtime services.
+- [Headless agent state](/reference/angular/functions/injectAgentStore): build a custom UI from agent messages, state, and run status.
+- [Production and lifecycle](/reference/angular/production-lifecycle): handle cleanup, errors, server rendering, hydration, zoneless Angular, and browser-only features.

--- a/showcase/shell-docs/src/content/docs/frontends/angular.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/angular.mdx
@@ -184,7 +184,7 @@ headless APIs, and it supports zoneless applications.
 ## Next steps
 
 - [Angular Showcase example](https://showcase.copilotkit.ai/angular/langgraph-python/agentic-chat): run the agentic chat example and inspect its source.
+- [Angular task guides](/angular/guides/chat-ui): build chat UI, tools, generative UI, interrupts, shared state, threads, memory, attachments, and headless UI.
 - [Angular feature examples](/angular/features): find runnable examples and source for each supported feature.
 - [Angular API reference](/reference/angular): use components, signals, tools, context, and runtime services.
-- [Headless agent state](/reference/angular/functions/injectAgentStore): build a custom UI from agent messages, state, and run status.
 - [Production and lifecycle](/reference/angular/production-lifecycle): handle cleanup, errors, server rendering, hydration, zoneless Angular, and browser-only features.

--- a/showcase/shell-docs/src/content/docs/frontends/angular/docs-status.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/angular/docs-status.mdx
@@ -1,15 +1,16 @@
 ---
 title: Angular docs
-description: Use the Angular quickstart, feature examples, source views, and typed API reference.
+description: Use the Angular quickstart, task guides, feature examples, source views, and typed API reference.
 hideTOC: true
 ---
 
 Use these pages based on what you want to build:
 
 1. Start with the [Angular quickstart](/angular) to install the package, configure `provideCopilotKit`, and render the first standalone chat component.
-2. Browse [Angular feature examples](/angular/features) for all 41 supported features. Forty entries include a runnable example, and every entry links to source and API docs.
-3. Use the [Angular API reference](/reference/angular) for components, functions, services, directives, inputs, outputs, signals, and lifecycle rules.
+2. Use the task guides for [chat UI](/angular/guides/chat-ui), [frontend tools and generative UI](/angular/guides/frontend-tools-generative-ui), [human-in-the-loop flows](/angular/guides/human-in-the-loop), [shared state](/angular/guides/shared-state), and [threads, memory, attachments, and headless UI](/angular/guides/threads-memory-attachments-headless).
+3. Browse [Angular feature examples](/angular/features) for all 41 supported features. Forty entries include a runnable example, and every entry links to source and API docs.
+4. Use the [Angular API reference](/reference/angular) for components, functions, services, directives, inputs, outputs, signals, and lifecycle rules.
 
-JSON Renderer is not applicable to the Angular package. Use [A2UI](/generative-ui/a2ui) for declarative generated UI.
+JSON Renderer is not applicable to the Angular package. Use the [generative UI guide](/angular/guides/frontend-tools-generative-ui#choose-a-generative-ui-path) for A2UI and the other Angular rendering paths.
 
 For cleanup, errors, server rendering, hydration, and zoneless updates, see [Production and lifecycle](/reference/angular/production-lifecycle).

--- a/showcase/shell-docs/src/content/docs/frontends/angular/docs-status.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/angular/docs-status.mdx
@@ -1,15 +1,15 @@
 ---
-title: Angular docs status
-description: Use the complete Angular guide, feature examples, source views, and typed API reference.
+title: Angular docs
+description: Use the Angular quickstart, feature examples, source views, and typed API reference.
 hideTOC: true
 ---
 
-The Angular docs stand on their own. Use them in this order:
+Use these pages based on what you want to build:
 
 1. Start with the [Angular quickstart](/angular) to install the package, configure `provideCopilotKit`, and render the first standalone chat component.
-2. Open [Angular feature guides](/angular/features) for all 41 supported features. Each entry links to a runnable route, its compiling source, and typed APIs.
+2. Browse [Angular feature examples](/angular/features) for all 41 supported features. Forty entries include a runnable example, and every entry links to source and API docs.
 3. Use the [Angular API reference](/reference/angular) for components, functions, services, directives, inputs, outputs, signals, and lifecycle rules.
 
 JSON Renderer is not applicable to the Angular package. Use [A2UI](/generative-ui/a2ui) for declarative generated UI.
 
-The feature guides call out cleanup, errors, SSR, hydration, and zoneless updates. Package-internal `ɵ` exports do not appear in user-facing API guidance.
+For cleanup, errors, server rendering, hydration, and zoneless updates, see [Production and lifecycle](/reference/angular/production-lifecycle).

--- a/showcase/shell-docs/src/content/docs/frontends/angular/features.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/angular/features.mdx
@@ -1,10 +1,10 @@
 ---
-title: Angular feature guides
-description: Runnable examples, compiling source, typed APIs, lifecycle rules, and support state for all 41 Angular features.
+title: Angular feature examples
+description: Browse examples, source, API docs, and support state for all 41 Angular features.
 hideTOC: true
 ---
 
-Every entry below is supported. Each runnable example and source view uses the same integration image and relative Copilot Runtime route.
+The catalog covers all 41 supported Angular features. Forty entries include a runnable example. Every entry links to its source and the closest API documentation.
 
 ## Shared setup
 
@@ -19,6 +19,6 @@ export const appConfig: ApplicationConfig = {
 };
 ```
 
-The linked source view opens the feature's real standalone Angular component. It is the minimal compiling example used by the runnable route.
+The source link opens the standalone Angular component used for that feature.
 
 <AngularFeatureCatalog />

--- a/showcase/shell-docs/src/content/docs/frontends/angular/guides/chat-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/angular/guides/chat-ui.mdx
@@ -1,0 +1,180 @@
+---
+title: Chat UI and customization
+description: Add a full Angular chat, choose its layout, and customize messages, slots, labels, and styles.
+icon: "lucide/MessageSquare"
+doc_type: how-to
+---
+
+`CopilotChat` gives you a complete chat surface backed by the agent from your
+Copilot Runtime. It owns message streaming, suggestions, the composer,
+attachments, transcription, and the active thread.
+
+This guide starts from the provider in the [Angular quickstart](/angular) and
+shows how to choose and customize the visible chat.
+
+## Choose a chat surface
+
+| Surface | Use it when |
+| --- | --- |
+| `CopilotChat` | Chat belongs inside an existing page or panel. |
+| `CopilotPopup` | Chat should open from a floating launcher. |
+| `CopilotSidebar` | Chat should sit beside the main application or open as an overlay. |
+| `CopilotChatView` | You own the agent wiring and only need the chat layout. |
+
+All four are standalone Angular components.
+
+## Add an inline chat
+
+Import `CopilotChat`, give its host a real height, and point it at an agent when
+you do not want the default agent.
+
+```ts title="src/app/support-chat.component.ts"
+import { ChangeDetectionStrategy, Component } from "@angular/core";
+import { CopilotChat } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-support-chat",
+  imports: [CopilotChat],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <section class="chat-shell" aria-label="Support assistant">
+      <copilot-chat agentId="support" />
+    </section>
+  `,
+  styles: `
+    .chat-shell {
+      height: min(48rem, 80vh);
+      overflow: hidden;
+      border: 1px solid #dbe3eb;
+      border-radius: 1rem;
+    }
+  `,
+})
+export class SupportChatComponent {}
+```
+
+Import the package stylesheet once in the application's global stylesheet:
+
+```css title="src/styles.css"
+@import "@copilotkit/angular/styles.css";
+```
+
+## Use a popup or sidebar
+
+Both modal surfaces manage focus, Escape closing, and launcher-focus restore.
+Their `open` model supports two-way binding.
+
+```ts title="src/app/app.component.ts"
+import { Component, signal } from "@angular/core";
+import { CopilotPopup, CopilotSidebar } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-root",
+  imports: [CopilotPopup, CopilotSidebar],
+  template: `
+    <copilot-popup
+      [(open)]="popupOpen"
+      title="Support assistant"
+      [clickOutsideToClose]="true"
+    />
+
+    <copilot-sidebar
+      [(open)]="sidebarOpen"
+      mode="docked"
+      position="right"
+      title="Workspace assistant"
+      [width]="480"
+    />
+  `,
+})
+export class AppComponent {
+  readonly popupOpen = signal(false);
+  readonly sidebarOpen = signal(false);
+}
+```
+
+Compact viewports render the sidebar as a modal even when `mode` is `"docked"`.
+Only one open docked sidebar can own the page margin at a time.
+
+## Replace an assistant message
+
+Pass a standalone component class to `assistantMessageComponent`. CopilotKit
+creates it for each assistant message and binds its `message` input.
+
+```ts title="src/app/custom-assistant-message.component.ts"
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+
+type AssistantMessage = {
+  id: string;
+  role: "assistant";
+  content?: string;
+};
+
+@Component({
+  selector: "app-custom-assistant-message",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <article class="answer">
+      <span class="answer__label">Assistant</span>
+      <p>{{ message().content }}</p>
+    </article>
+  `,
+})
+export class CustomAssistantMessageComponent {
+  readonly message = input.required<AssistantMessage>();
+}
+```
+
+```ts title="src/app/support-chat.component.ts"
+import { Component } from "@angular/core";
+import { CopilotChat } from "@copilotkit/angular";
+import { CustomAssistantMessageComponent } from "./custom-assistant-message.component";
+
+@Component({
+  selector: "app-support-chat",
+  imports: [CopilotChat],
+  template: `
+    <copilot-chat
+      [assistantMessageComponent]="assistantMessageComponent"
+      assistantMessageClass="support-answer"
+    />
+  `,
+})
+export class SupportChatComponent {
+  protected readonly assistantMessageComponent =
+    CustomAssistantMessageComponent;
+}
+```
+
+`CopilotChat` also accepts component or template slots for reasoning messages,
+the composer, and content after the transcript. Use `CopilotChatView` directly
+when you need its scroll view, disclaimer, feather, input-container, or
+scroll-to-bottom slots.
+
+## Scope CSS changes
+
+The package stylesheet exposes stable chat classes. Put a scope class on your
+feature host so the change stays local.
+
+```css title="src/styles.css"
+.support-chat .copilotKitUserMessage {
+  color: white;
+  background: #2563eb;
+  border-radius: 0.75rem;
+}
+
+.support-chat .copilotKitAssistantMessage {
+  padding: 0.75rem;
+  color: #172554;
+  background: #eff6ff;
+  border-radius: 0.75rem;
+}
+```
+
+## Next steps
+
+- [CopilotChat API](/reference/angular/components/CopilotChat)
+- [CopilotChatView slots](/reference/angular/components/CopilotChatView)
+- [CopilotPopup API](/reference/angular/components/CopilotPopup)
+- [CopilotSidebar API](/reference/angular/components/CopilotSidebar)
+- [Runnable chat examples](/angular/features#agentic-chat)

--- a/showcase/shell-docs/src/content/docs/frontends/angular/guides/frontend-tools-generative-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/angular/guides/frontend-tools-generative-ui.mdx
@@ -1,0 +1,188 @@
+---
+title: Frontend tools and generative UI
+description: Let an agent run browser code and render typed, protocol-driven, or sandboxed UI in Angular.
+icon: "lucide/Wrench"
+doc_type: how-to
+---
+
+Frontend tools let an agent call code inside the user's browser. Add a renderer
+to the same registration when the tool should show progress or a result in
+chat.
+
+## Register a browser tool
+
+Call `registerFrontendTool` from an Angular injection context. The registration
+is removed when that injector is destroyed.
+
+```ts title="src/app/todo-board.component.ts"
+import { Component, signal } from "@angular/core";
+import { registerFrontendTool } from "@copilotkit/angular";
+import { z } from "zod";
+
+@Component({
+  selector: "app-todo-board",
+  template: `
+    <ul>
+      @for (todo of todos(); track todo) {
+        <li>{{ todo }}</li>
+      }
+    </ul>
+  `,
+})
+export class TodoBoardComponent {
+  readonly todos = signal<string[]>([]);
+
+  constructor() {
+    registerFrontendTool({
+      name: "addTodo",
+      description: "Add an item to the user's todo list",
+      parameters: z.object({
+        text: z.string().describe("The todo text"),
+      }),
+      handler: async ({ text }) => {
+        this.todos.update((todos) => [...todos, text]);
+        return { added: text };
+      },
+    });
+  }
+}
+```
+
+The schema advertises the input shape and supplies TypeScript inference.
+Runtime arguments arrive as parsed JSON; validate inside the handler when the
+action needs a hard trust boundary. The handler receives the calling agent,
+the raw tool call, and an optional abort signal as its second argument.
+
+## Render a tool result
+
+A renderer is a standalone component with a required `toolCall` signal input.
+Its status moves through `"in-progress"`, `"executing"`, and `"complete"`.
+
+```ts title="src/app/weather-card.component.ts"
+import { Component, input } from "@angular/core";
+import {
+  type AngularToolCall,
+  type ToolRenderer,
+} from "@copilotkit/angular";
+
+type WeatherArgs = { city: string };
+
+@Component({
+  selector: "app-weather-card",
+  template: `
+    @let call = toolCall();
+    @if (call.status === "complete") {
+      <article>
+        <strong>{{ call.args.city }}</strong>
+        <p>{{ call.result }}</p>
+      </article>
+    } @else {
+      <p>Loading weather for {{ call.args.city ?? "…" }}</p>
+    }
+  `,
+})
+export class WeatherCardComponent implements ToolRenderer<WeatherArgs> {
+  readonly toolCall = input.required<AngularToolCall<WeatherArgs>>();
+}
+```
+
+Pass the class as `component` when the tool runs in the browser:
+
+```ts
+registerFrontendTool({
+  name: "getWeather",
+  description: "Get the current weather for a city",
+  parameters: z.object({ city: z.string() }),
+  component: WeatherCardComponent,
+  handler: async ({ city }, { signal }) => {
+    const response = await fetch(`/api/weather?city=${encodeURIComponent(city)}`, {
+      signal,
+    });
+    return response.text();
+  },
+});
+```
+
+Use `registerRenderToolCall` instead when the tool runs on the server and the
+browser only renders its call:
+
+```ts
+registerRenderToolCall({
+  name: "getWeather",
+  args: z.object({ city: z.string() }),
+  component: WeatherCardComponent,
+});
+```
+
+## Choose a generative UI path
+
+| Path | Best fit | Angular setup |
+| --- | --- | --- |
+| Your components | Known data shapes and application actions | `registerFrontendTool` or `registerRenderToolCall` with a component |
+| A2UI | A server emits A2UI operations or snapshots | Runtime capability turns on the built-in renderer; an optional `a2ui` config supplies a catalog or theme |
+| Open Generative UI | The agent produces streamed HTML, CSS, and script expressions | Set `openGenerativeUI` in `provideCopilotKit` |
+| MCP Apps | An MCP server returns an interactive app resource | Add `provideMCPApps()` from `@copilotkit/angular/mcp-apps` |
+
+### Open Generative UI
+
+An `openGenerativeUI` object opts the frontend into the built-in sandboxed
+renderer. Expose narrow host functions when generated UI must ask the
+application to act.
+
+```ts title="src/app/app.config.ts"
+import { ApplicationConfig } from "@angular/core";
+import {
+  provideCopilotKit,
+  type SandboxFunction,
+} from "@copilotkit/angular";
+import { z } from "zod";
+
+const setDashboardFilter: SandboxFunction<{ filter: string }> = {
+  name: "setDashboardFilter",
+  description: "Set the active dashboard filter",
+  parameters: z.object({ filter: z.string() }),
+  handler: async ({ filter }) => {
+    sessionStorage.setItem("dashboard-filter", filter);
+    return { applied: filter };
+  },
+};
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideCopilotKit({
+      runtimeUrl: "/api/copilotkit",
+      openGenerativeUI: {
+        sandboxFunctions: [setDashboardFilter],
+      },
+    }),
+  ],
+};
+```
+
+Generated code runs in a sandboxed iframe without same-origin access. It calls
+only the host functions you list in `sandboxFunctions`.
+
+### MCP Apps
+
+```ts title="src/app/app.config.ts"
+import { ApplicationConfig } from "@angular/core";
+import { provideCopilotKit } from "@copilotkit/angular";
+import { provideMCPApps } from "@copilotkit/angular/mcp-apps";
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideCopilotKit({ runtimeUrl: "/api/copilotkit" }),
+    provideMCPApps(),
+  ],
+};
+```
+
+MCP resource and tool requests travel through the selected AG-UI agent. The
+browser provider does not take a server URL.
+
+## Next steps
+
+- [registerFrontendTool API](/reference/angular/functions/registerFrontendTool)
+- [registerRenderToolCall API](/reference/angular/functions/registerRenderToolCall)
+- [Activity renderers](/reference/angular/functions/registerRenderActivityMessage)
+- [Runnable tool and generative UI examples](/angular/features#frontend-tools)

--- a/showcase/shell-docs/src/content/docs/frontends/angular/guides/human-in-the-loop.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/angular/guides/human-in-the-loop.mdx
@@ -1,0 +1,167 @@
+---
+title: Human-in-the-loop and interrupts
+description: Pause an Angular agent flow for a user decision, then resume it from a typed component or interrupt controller.
+icon: "lucide/UserRoundCheck"
+doc_type: how-to
+---
+
+Human-in-the-loop flows pause agent work until a person supplies a decision.
+Angular has two paths with different owners.
+
+| Pattern | Who chooses the pause? | Angular API |
+| --- | --- | --- |
+| Human-in-the-loop tool | The agent calls a registered browser tool | `registerHumanInTheLoop` |
+| Interrupt | The backend agent emits an AG-UI interrupt | `injectInterrupt` |
+
+Use a tool when the model should decide whether to ask. Use an interrupt when
+the backend workflow must stop at a fixed checkpoint.
+
+## Register a decision tool
+
+The renderer receives a `toolCall` signal. Call `respond(result)` once the user
+has made a choice.
+
+```ts title="src/app/approval-card.component.ts"
+import { Component, input } from "@angular/core";
+import {
+  type HumanInTheLoopToolCall,
+  type HumanInTheLoopToolRenderer,
+} from "@copilotkit/angular";
+
+type ApprovalArgs = {
+  action: string;
+  reason: string;
+};
+
+@Component({
+  selector: "app-approval-card",
+  template: `
+    @let call = toolCall();
+    <article>
+      <h3>Approve {{ call.args.action ?? "this action" }}?</h3>
+      <p>{{ call.args.reason }}</p>
+
+      @if (call.status !== "complete") {
+        <button type="button" (click)="call.respond({ approved: true })">
+          Approve
+        </button>
+        <button type="button" (click)="call.respond({ approved: false })">
+          Reject
+        </button>
+      }
+    </article>
+  `,
+})
+export class ApprovalCardComponent
+  implements HumanInTheLoopToolRenderer<ApprovalArgs>
+{
+  readonly toolCall =
+    input.required<HumanInTheLoopToolCall<ApprovalArgs>>();
+}
+```
+
+Register the tool from the component or service that owns the decision UI:
+
+```ts title="src/app/approval-tools.service.ts"
+import { Injectable } from "@angular/core";
+import { registerHumanInTheLoop } from "@copilotkit/angular";
+import { z } from "zod";
+import { ApprovalCardComponent } from "./approval-card.component";
+
+@Injectable()
+export class ApprovalToolsService {
+  constructor() {
+    registerHumanInTheLoop({
+      name: "requestApproval",
+      description: "Ask the user before a consequential action",
+      parameters: z.object({
+        action: z.string(),
+        reason: z.string(),
+      }),
+      component: ApprovalCardComponent,
+    });
+  }
+}
+```
+
+There is no handler. CopilotKit supplies one that waits for `respond`, returns
+the decision to the agent, and continues the run. The registration is removed
+when the owning injector is destroyed.
+
+## Handle an interrupt
+
+`injectInterrupt` subscribes to one agent and exposes the pending decision as
+signals. It supports standard AG-UI interrupts and the legacy
+`on_interrupt` custom event.
+
+```ts title="src/app/interrupt-panel.component.ts"
+import { Component } from "@angular/core";
+import { injectInterrupt } from "@copilotkit/angular";
+
+type ReviewRequest = {
+  title?: string;
+  choices?: Array<{ id: string; label: string }>;
+};
+
+@Component({
+  selector: "app-interrupt-panel",
+  template: `
+    @if (controller.event(); as event) {
+      @let request = asReviewRequest(event.value);
+      <section aria-labelledby="review-title">
+        <h2 id="review-title">{{ request.title ?? "Review required" }}</h2>
+
+        @for (choice of request.choices ?? []; track choice.id) {
+          <button type="button" (click)="resolve(choice.id)">
+            {{ choice.label }}
+          </button>
+        }
+
+        <button type="button" (click)="cancel()">Cancel</button>
+      </section>
+    }
+
+    @if (controller.error()) {
+      <p role="alert">The decision could not be submitted.</p>
+    }
+  `,
+})
+export class InterruptPanelComponent {
+  protected readonly controller =
+    injectInterrupt<ReviewRequest>({ agentId: "default" });
+
+  protected asReviewRequest(value: unknown): ReviewRequest {
+    return typeof value === "object" && value !== null
+      ? (value as ReviewRequest)
+      : {};
+  }
+
+  protected resolve(choiceId: string): void {
+    this.controller.resolve({ choiceId }).catch(() => undefined);
+  }
+
+  protected cancel(): void {
+    this.controller.cancel().catch(() => undefined);
+  }
+}
+```
+
+The controller clears stale decisions when the thread changes. Calls to
+`resolve` or `cancel` share one in-flight resume promise, so a double click
+does not start two resume runs.
+
+Use the controller's `enabled` option when several components listen to the
+same agent and each should accept only certain interrupt payloads. Use
+`handler` when the view needs async data prepared before it appears.
+
+## Place the decision UI
+
+The tool renderer appears in the tool-call flow inside chat. An interrupt
+controller is headless: bind its signals anywhere in the application, including
+a route-level dialog, side panel, or task view.
+
+## Next steps
+
+- [registerHumanInTheLoop API](/reference/angular/functions/registerHumanInTheLoop)
+- [injectInterrupt API](/reference/angular/functions/injectInterrupt)
+- [Runnable interrupt examples](/angular/features#gen-ui-interrupt)

--- a/showcase/shell-docs/src/content/docs/frontends/angular/guides/shared-state.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/angular/guides/shared-state.mdx
@@ -1,0 +1,153 @@
+---
+title: Shared state and agent context
+description: Read and write agent state with Angular signals, and send application-owned context to the agent.
+icon: "lucide/Repeat2"
+doc_type: how-to
+---
+
+Shared state and agent context solve two different data flows.
+
+| Data flow | Use |
+| --- | --- |
+| Agent and application both read and write the value | `injectAgentStore` and `agent.setState` |
+| The application owns the value and the agent only reads it | `connectAgentContext` or `CopilotKitAgentContext` |
+
+## Read agent state
+
+`injectAgentStore` returns a signal that resolves one agent. The store exposes
+messages, state, and run status as nested signals.
+
+```ts title="src/app/workspace.component.ts"
+import { Component, computed } from "@angular/core";
+import { injectAgentStore } from "@copilotkit/angular";
+
+type WorkspaceState = {
+  notes: string[];
+  priority: "low" | "normal" | "high";
+};
+
+const EMPTY_STATE: WorkspaceState = {
+  notes: [],
+  priority: "normal",
+};
+
+@Component({
+  selector: "app-workspace",
+  template: `
+    <p>Priority: {{ state().priority }}</p>
+    <ul>
+      @for (note of state().notes; track note) {
+        <li>{{ note }}</li>
+      }
+    </ul>
+    <button type="button" (click)="setPriority('high')">
+      Mark high priority
+    </button>
+  `,
+})
+export class WorkspaceComponent {
+  readonly store = injectAgentStore("default");
+  readonly state = computed(
+    () => (this.store().state() as WorkspaceState | undefined) ?? EMPTY_STATE,
+  );
+
+  protected setPriority(priority: WorkspaceState["priority"]): void {
+    const agent = this.store().agent;
+    const current = (agent.state as WorkspaceState | undefined) ?? EMPTY_STATE;
+    agent.setState({ ...current, priority });
+  }
+}
+```
+
+Read through `store().state()` so Angular tracks changes. Write through the
+plain AG-UI agent at `store().agent`. Replace the object instead of mutating it
+in place.
+
+The same store gives you:
+
+- `store().messages()` for the current conversation
+- `store().isRunning()` for loading controls
+- `store().agent` for `setState`, `addMessage`, `runAgent`, and `abortRun`
+
+## Send read-only application context
+
+Use `connectAgentContext` for values such as the signed-in user's name,
+selected record, timezone, or current screen. Pass an accessor so signal reads
+stay reactive.
+
+```ts title="src/app/account-context.component.ts"
+import { Component, signal } from "@angular/core";
+import { connectAgentContext } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-account-context",
+  template: `
+    <button type="button" (click)="timezone.set('Europe/London')">
+      Use London time
+    </button>
+  `,
+})
+export class AccountContextComponent {
+  readonly userName = signal("Ada");
+  readonly timezone = signal("America/Los_Angeles");
+
+  constructor() {
+    connectAgentContext(() => ({
+      description: "Current account and timezone",
+      value: JSON.stringify({
+        userName: this.userName(),
+        timezone: this.timezone(),
+      }),
+    }));
+  }
+}
+```
+
+The internal effect removes the old context and registers the new value when a
+read signal changes. It removes the final registration when the owning
+injector is destroyed. If you already have an `Injector`, pass it as
+`{ injector }`; that injector takes precedence over the ambient one.
+
+## Bind context in a template
+
+Use `CopilotKitAgentContext` when the context is already shaped in the
+template.
+
+```ts title="src/app/selection-context.component.ts"
+import { Component, computed, signal } from "@angular/core";
+import { CopilotKitAgentContext } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-selection-context",
+  imports: [CopilotKitAgentContext],
+  template: `
+    <div [copilotkitAgentContext]="selectionContext()"></div>
+  `,
+})
+export class SelectionContextComponent {
+  readonly selectedId = signal("record-42");
+  readonly selectionContext = computed(() => ({
+    description: "The record selected in the application",
+    value: this.selectedId(),
+  }));
+}
+```
+
+Render the directive only after you have a complete context. If it starts
+without one, later input changes do not create the first registration.
+
+## Keep ownership clear
+
+- Use shared state for data that the agent may change.
+- Use context for application-owned facts.
+- Keep durable user preferences in your own data store; publish only the part
+  the current agent needs.
+- Scope `injectAgentStore` to the same agent id as the chat or workflow that
+  reads the state.
+
+## Next steps
+
+- [injectAgentStore API](/reference/angular/functions/injectAgentStore)
+- [connectAgentContext API](/reference/angular/functions/connectAgentContext)
+- [CopilotKitAgentContext API](/reference/angular/directives/CopilotKitAgentContext)
+- [Runnable state examples](/angular/features#shared-state-read-write)

--- a/showcase/shell-docs/src/content/docs/frontends/angular/guides/threads-memory-attachments-headless.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/angular/guides/threads-memory-attachments-headless.mdx
@@ -1,0 +1,246 @@
+---
+title: Threads, memory, attachments, and headless UI
+description: Build persistent and multimodal Angular agent experiences, or own the complete UI with signal-based APIs.
+icon: "lucide/Layers3"
+doc_type: how-to
+---
+
+`CopilotChat` covers the common conversation path. Use the lower-level Angular
+APIs when you need saved threads, user memory, file input, or a fully custom
+interface.
+
+## Resume a specific thread
+
+Pass `threadId` to connect the chat to an existing conversation:
+
+```html
+<copilot-chat agentId="support" [threadId]="selectedThreadId()" />
+```
+
+For a custom thread list, use `injectThreads`. Its inputs accept plain values
+or signals.
+
+```ts title="src/app/thread-list.component.ts"
+import { Component } from "@angular/core";
+import { injectThreads } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-thread-list",
+  template: `
+    <button type="button" (click)="threads.startNewThread()">
+      New conversation
+    </button>
+
+    @if (threads.isLoading()) {
+      <p>Loading conversations…</p>
+    } @else {
+      @for (thread of threads.threads(); track thread.id) {
+        <button type="button" (click)="select(thread.id)">
+          {{ thread.name ?? "Untitled conversation" }}
+        </button>
+      }
+    }
+
+    @if (threads.listError()) {
+      <button type="button" (click)="threads.refetchThreads()">Retry</button>
+    }
+  `,
+})
+export class ThreadListComponent {
+  readonly threads = injectThreads({
+    agentId: "support",
+    limit: 20,
+  });
+
+  protected select(threadId: string): void {
+    // Store this id and bind it to CopilotChat's threadId input.
+    console.log(threadId);
+  }
+}
+```
+
+The list is server-authoritative and uses realtime updates when the platform
+supplies a WebSocket URL. Rename, archive, unarchive, and delete return
+promises. Deletion is permanent; ask the user before calling `deleteThread`.
+
+`CopilotThreadsDrawer` supplies a ready-made list, selection, filtering,
+pagination, and mutation controls. Put the drawer and chat under the same
+`provideCopilotChatConfiguration` provider so selection and new-thread actions
+update the chat. The drawer reads the platform's `threads` license feature and
+shows its locked state when that feature is unavailable.
+
+```ts
+import { Component } from "@angular/core";
+import {
+  CopilotChat,
+  CopilotThreadsDrawer,
+  provideCopilotChatConfiguration,
+} from "@copilotkit/angular";
+
+@Component({
+  selector: "app-conversations",
+  imports: [CopilotChat, CopilotThreadsDrawer],
+  providers: [provideCopilotChatConfiguration({ agentId: "support" })],
+  template: `
+    <copilot-threads-drawer agentId="support" [limit]="20" />
+    <copilot-chat />
+  `,
+})
+export class ConversationsComponent {}
+```
+
+## Read and manage memory
+
+`injectMemories` exposes the current runtime-authenticated user's memory list.
+Check `isAvailable()` before showing memory controls because a runtime may not
+provide the memory routes.
+
+```ts title="src/app/memory-list.component.ts"
+import { Component } from "@angular/core";
+import { injectMemories } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-memory-list",
+  template: `
+    @if (!memory.isAvailable()) {
+      <p>Memory is not available for this runtime.</p>
+    } @else {
+      @for (item of memory.memories(); track item.id) {
+        <article>
+          <p>{{ item.content }}</p>
+          <button type="button" (click)="remove(item.id)">Forget</button>
+        </article>
+      }
+    }
+  `,
+})
+export class MemoryListComponent {
+  readonly memory = injectMemories();
+
+  protected remove(id: string): void {
+    this.memory.removeMemory(id).catch(() => undefined);
+  }
+
+  protected addPreference(): void {
+    this.memory
+      .addMemory({
+        kind: "operational",
+        content: "Prefer concise status updates.",
+      })
+      .catch(() => undefined);
+  }
+}
+```
+
+`updateMemory` supersedes a memory with a full replacement and returns a new
+record with a new id. Re-send `content`, `kind`, and any
+`sourceThreadIds` you want to keep.
+
+## Enable attachments
+
+Pass an `AttachmentsConfig` to `CopilotChat`. The built-in input supports the
+file picker, drag and drop, and paste.
+
+```ts title="src/app/media-chat.component.ts"
+import { Component } from "@angular/core";
+import {
+  CopilotChat,
+  type AttachmentsConfig,
+} from "@copilotkit/angular";
+
+@Component({
+  selector: "app-media-chat",
+  imports: [CopilotChat],
+  template: `
+    <copilot-chat [attachments]="attachments" />
+  `,
+})
+export class MediaChatComponent {
+  protected readonly attachments: AttachmentsConfig = {
+    enabled: true,
+    accept: "image/*,application/pdf",
+    maxSize: 10 * 1024 * 1024,
+    onUploadFailed: (error) => {
+      console.error(error.reason, error.message);
+    },
+  };
+}
+```
+
+Without `onUpload`, files are read as base64. Supply `onUpload` to place large
+files in your own storage and return a URL. The selected model and backend must
+support each content type you allow.
+
+## Build a headless chat
+
+`injectAgentStore` gives you the state needed to render your own transcript and
+composer. Add the user message to the agent, then run that same agent through
+`CopilotKitCore`.
+
+```ts title="src/app/headless-chat.component.ts"
+import { Component, inject, signal } from "@angular/core";
+import { CopilotKit, injectAgentStore } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-headless-chat",
+  template: `
+    <div aria-live="polite">
+      @for (message of store().messages(); track message.id) {
+        <article [attr.data-role]="message.role">
+          {{ message.content }}
+        </article>
+      }
+      @if (store().isRunning()) {
+        <p>Agent is working…</p>
+      }
+    </div>
+
+    <textarea
+      aria-label="Message"
+      [value]="draft()"
+      (input)="updateDraft($event)"
+    ></textarea>
+    <button
+      type="button"
+      [disabled]="store().isRunning() || !draft().trim()"
+      (click)="send()"
+    >
+      Send
+    </button>
+  `,
+})
+export class HeadlessChatComponent {
+  private readonly copilotKit = inject(CopilotKit);
+  readonly store = injectAgentStore("default");
+  readonly draft = signal("");
+
+  protected updateDraft(event: Event): void {
+    this.draft.set((event.target as HTMLTextAreaElement).value);
+  }
+
+  protected async send(): Promise<void> {
+    const content = this.draft().trim();
+    if (!content || this.store().isRunning()) return;
+
+    const agent = this.store().agent;
+    agent.addMessage({
+      id: crypto.randomUUID(),
+      role: "user",
+      content,
+    });
+    this.draft.set("");
+    await this.copilotKit.core.runAgent({ agent });
+  }
+}
+```
+
+Add error handling around `runAgent` in production and disable repeated sends
+while `isRunning()` is true. The store tears down its agent subscription with
+the owning injector.
+
+## Next steps
+
+- [injectAgentStore API](/reference/angular/functions/injectAgentStore)
+- [CopilotChat attachments input](/reference/angular/components/CopilotChat)
+- [Runnable headless example](/angular/features#headless-simple)
+- [Runnable multimodal example](/angular/features#multimodal)

--- a/showcase/shell-docs/src/content/reference/angular/components/CopilotChat.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/components/CopilotChat.mdx
@@ -1,13 +1,13 @@
 ---
 title: "CopilotChat"
-description: "Angular standalone component that wires an agent to the chat UI, the @copilotkit/angular equivalent of React's CopilotChat"
+description: "Angular standalone component that wires an agent to a complete chat UI"
 ---
 
 ## Overview
 
 `CopilotChat` is the all-in-one chat component. It wires an agent into [`CopilotChatView`](/reference/angular/components/CopilotChatView) so you get a working chat interface with one selector. It resolves the agent through [`injectAgentStore`](/reference/angular/functions/injectAgentStore), subscribes to that agent's messages and running state, manages suggestions, tracks the input value, handles audio transcription, wires file attachments, and clears the input after each message is sent.
 
-This is the Angular equivalent of React's `<CopilotChat>`. Where React composes the agent wiring in the component, Angular `CopilotChat` extends the internal `ChatState` and provides itself as the `ChatState` for the view and input beneath it. You usually only need to point it at an agent.
+`CopilotChat` extends `ChatState` and provides itself to the view and input beneath it. You usually only need to point it at an agent.
 
 For the layout without the agent wiring, use [`CopilotChatView`](/reference/angular/components/CopilotChatView) directly.
 
@@ -50,6 +50,42 @@ Remember to import the stylesheet once in your global styles:
 
 <PropertyReference name="inputComponent" type="Type<any>">
   A custom Angular component class to render in place of the default [`CopilotChatInput`](/reference/angular/components/CopilotChatInput). Forwarded to the underlying [`CopilotChatView`](/reference/angular/components/CopilotChatView).
+</PropertyReference>
+
+<PropertyReference name="assistantMessageComponent" type="Type<any>">
+  Component class used for assistant messages.
+</PropertyReference>
+
+<PropertyReference name="assistantMessageTemplate" type="TemplateRef<any>">
+  Template used for assistant messages. Takes precedence over `assistantMessageComponent`.
+</PropertyReference>
+
+<PropertyReference name="assistantMessageClass" type="string">
+  CSS classes forwarded to the assistant-message slot.
+</PropertyReference>
+
+<PropertyReference name="reasoningMessageComponent" type="Type<any>">
+  Component class used for reasoning messages.
+</PropertyReference>
+
+<PropertyReference name="reasoningMessageTemplate" type="TemplateRef<any>">
+  Template used for reasoning messages. Takes precedence over `reasoningMessageComponent`.
+</PropertyReference>
+
+<PropertyReference name="reasoningMessageClass" type="string">
+  CSS classes forwarded to the reasoning-message slot.
+</PropertyReference>
+
+<PropertyReference name="messageViewChildrenComponent" type="Type<any>">
+  Component rendered after the message list and before the streaming cursor.
+</PropertyReference>
+
+<PropertyReference name="messageViewChildrenTemplate" type="TemplateRef<any>">
+  Template rendered after the message list. Takes precedence over `messageViewChildrenComponent`.
+</PropertyReference>
+
+<PropertyReference name="messageViewChildrenClass" type="string">
+  CSS classes forwarded to the message-list children slot.
 </PropertyReference>
 
 ## Outputs

--- a/showcase/shell-docs/src/content/reference/angular/components/CopilotChatAssistantMessage.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/components/CopilotChatAssistantMessage.mdx
@@ -5,7 +5,7 @@ description: "Angular standalone component that renders a single assistant messa
 
 ## Overview
 
-`CopilotChatAssistantMessage` renders one assistant message. It shows the message content through a markdown renderer, renders any tool calls attached to the message, and shows a toolbar with copy, thumbs up/down, read-aloud, and regenerate actions. It mirrors React's `CopilotChatAssistantMessage`.
+`CopilotChatAssistantMessage` renders one assistant message. It shows the message content through a markdown renderer, renders attached tool calls, and shows a toolbar with copy, thumbs up/down, read-aloud, and regenerate actions.
 
 The toolbar appears only when the message has non-empty text content. The copy button always renders; the thumbs up and thumbs down buttons render when you provide a custom slot for them or when a thumbs handler is available from a surrounding [`CopilotChatView`](/reference/angular/components/CopilotChatView). The read-aloud and regenerate buttons render only when you provide a custom slot for them.
 
@@ -25,11 +25,7 @@ import type { AssistantMessage } from "@ag-ui/client";
   standalone: true,
   imports: [CopilotChatAssistantMessage],
   template: `
-    <copilot-chat-assistant-message
-      [message]="message()"
-      (thumbsUp)="onThumbsUp($event)"
-      (regenerate)="onRegenerate($event)"
-    />
+    <copilot-chat-assistant-message [message]="message()" />
   `,
 })
 export class AssistantComponent {
@@ -38,14 +34,6 @@ export class AssistantComponent {
     role: "assistant",
     content: "Hello, how can I help?",
   });
-
-  onThumbsUp(event: { message: AssistantMessage }) {
-    console.log("liked", event.message.id);
-  }
-
-  onRegenerate(event: { message: AssistantMessage }) {
-    console.log("regenerate", event.message.id);
-  }
 }
 ```
 
@@ -75,13 +63,9 @@ export class AssistantComponent {
   A template appended to the end of the default toolbar, after the built-in buttons.
 </PropertyReference>
 
-<PropertyReference name="inputClass" type="string">
-  Extra CSS classes merged onto the message container.
-</PropertyReference>
-
 ### Slot class inputs
 
-Each of these passes extra CSS classes to the corresponding default sub-component.
+The current release applies `markdownRendererClass`, `toolbarClass`, and `copyButtonClass` to their default parts.
 
 <PropertyReference name="markdownRendererClass" type="string">
   Classes for the default markdown renderer.
@@ -95,25 +79,9 @@ Each of these passes extra CSS classes to the corresponding default sub-componen
   Classes for the default copy button.
 </PropertyReference>
 
-<PropertyReference name="thumbsUpButtonClass" type="string">
-  Classes for the default thumbs-up button.
-</PropertyReference>
-
-<PropertyReference name="thumbsDownButtonClass" type="string">
-  Classes for the default thumbs-down button.
-</PropertyReference>
-
-<PropertyReference name="readAloudButtonClass" type="string">
-  Classes for the default read-aloud button.
-</PropertyReference>
-
-<PropertyReference name="regenerateButtonClass" type="string">
-  Classes for the default regenerate button.
-</PropertyReference>
-
-<PropertyReference name="toolCallsViewClass" type="string">
-  Classes for the default tool calls view.
-</PropertyReference>
+<Callout type="warn">
+  `inputClass`, the thumbs, read-aloud, regenerate class inputs, and `toolCallsViewClass` are declared but do not affect rendering in the current release. Use component or template overrides for those parts.
+</Callout>
 
 ### Slot component inputs
 
@@ -154,19 +122,19 @@ Each of these replaces the corresponding default sub-component with a component 
 ## Outputs
 
 <PropertyReference name="thumbsUp" type="CopilotChatAssistantMessageOnThumbsUpProps">
-  Emitted when the thumbs-up button is clicked. The payload is `{ message: AssistantMessage }`.
+  Emitted when a configured thumbs-up component or template is clicked. The payload is `{ message: AssistantMessage }`.
 </PropertyReference>
 
 <PropertyReference name="thumbsDown" type="CopilotChatAssistantMessageOnThumbsDownProps">
-  Emitted when the thumbs-down button is clicked. The payload is `{ message: AssistantMessage }`.
+  Emitted when a configured thumbs-down component or template is clicked. The payload is `{ message: AssistantMessage }`.
 </PropertyReference>
 
 <PropertyReference name="readAloud" type="CopilotChatAssistantMessageOnReadAloudProps">
-  Emitted when the read-aloud button is clicked. The payload is `{ message: AssistantMessage }`.
+  Emitted when a configured read-aloud component or template is clicked. The payload is `{ message: AssistantMessage }`.
 </PropertyReference>
 
 <PropertyReference name="regenerate" type="CopilotChatAssistantMessageOnRegenerateProps">
-  Emitted when the regenerate button is clicked. The payload is `{ message: AssistantMessage }`.
+  Emitted when a configured regenerate component or template is clicked. The payload is `{ message: AssistantMessage }`.
 </PropertyReference>
 
 ## Slots and content projection

--- a/showcase/shell-docs/src/content/reference/angular/components/CopilotChatInput.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/components/CopilotChatInput.mdx
@@ -1,26 +1,32 @@
 ---
 title: "CopilotChatInput"
-description: "Angular standalone component for the chat input area: textarea, send button, tools menu, file upload, and audio transcription, the @copilotkit/angular equivalent of React's CopilotChatInput"
+description: "Angular standalone component for chat input, tools, file upload, and audio transcription"
 ---
 
 ## Overview
 
 `CopilotChatInput` is the input area of the chat. It renders the textarea, the send button, an optional tools menu, an add-file button, and the audio transcription controls. It has three modes: `"input"` (the default textarea), `"transcribe"` (records audio and shows transcription controls), and `"processing"` (disables the textarea and send button while the agent runs).
 
-This is the Angular equivalent of React's `<CopilotChatInput>`. When rendered inside [`CopilotChat`](/reference/angular/components/CopilotChat) or [`CopilotChatView`](/reference/angular/components/CopilotChatView), it reads the surrounding `ChatState` (through `injectChatState`) and wires submission, value changes, transcription, and file uploads to it automatically. Its outputs fire in addition to that built-in behavior, so you can observe interactions without disabling them.
+`CopilotChatInput` requires a parent injector to provide `ChatState`. It reads that state through `injectChatState` and wires submission, value changes, transcription, and file uploads to it. Its outputs fire in addition to that built-in behavior, so you can observe interactions without disabling them.
 
 ## Usage
 
-`CopilotChatInput` is a standalone component with the selector `copilot-chat-input`. Import the class into your component's `imports` array and use the element in the template.
+`CopilotChatInput` is a standalone component with the selector `copilot-chat-input`. The example below provides the required `ChatState`. Use [`CopilotChat`](/reference/angular/components/CopilotChat) when you want CopilotKit to manage this state for you.
 
 ```ts title="src/app/chat.component.ts"
-import { Component } from "@angular/core";
-import { CopilotChatInput } from "@copilotkit/angular";
+import { Component, forwardRef, signal } from "@angular/core";
+import { ChatState, CopilotChatInput } from "@copilotkit/angular";
 
 @Component({
   selector: "app-chat",
   standalone: true,
   imports: [CopilotChatInput],
+  providers: [
+    {
+      provide: ChatState,
+      useExisting: forwardRef(() => ChatComponent),
+    },
+  ],
   template: `
     <copilot-chat-input
       [autoFocus]="true"
@@ -28,9 +34,16 @@ import { CopilotChatInput } from "@copilotkit/angular";
     />
   `,
 })
-export class ChatComponent {
-  onSubmit(value: string) {
+export class ChatComponent extends ChatState {
+  readonly inputValue = signal("");
+
+  submitInput(value: string) {
+    // Send the message through your chat state owner.
     console.log("user submitted:", value);
+  }
+
+  changeInput(value: string) {
+    this.inputValue.set(value);
   }
 }
 ```
@@ -40,7 +53,7 @@ export class ChatComponent {
 ### Behavior inputs
 
 <PropertyReference name="mode" type='"input" | "transcribe" | "processing"'>
-  Initial input mode. The component manages transitions between these modes during audio transcription. When omitted, the input starts in `"input"` mode.
+  Declared by the component, but the current release does not read this input. The component starts in `"input"` mode and manages later transitions itself.
 </PropertyReference>
 
 <PropertyReference name="toolsMenu" type='(ToolsMenuItem | "-")[]'>
@@ -52,11 +65,11 @@ export class ChatComponent {
 </PropertyReference>
 
 <PropertyReference name="value" type="string">
-  Controlled value for the textarea. When provided, it takes precedence over the value held in the surrounding `ChatState`.
+  Controlled value for the textarea when it is non-empty. An empty string falls back to the value held in `ChatState`.
 </PropertyReference>
 
 <PropertyReference name="inputClass" type="string">
-  Class applied to the internal input wrapper. Prefer the host `class` for styling the component itself.
+  Declared by the component, but the current release does not apply it. Use the host `class` or a slot override.
 </PropertyReference>
 
 <PropertyReference name="additionalToolbarItems" type="TemplateRef<any>">
@@ -79,14 +92,14 @@ export class ChatComponent {
 
 ### Slot override inputs
 
-Each interactive piece can be replaced with a component class (`*Component`) and styled with a class (`*Class`). Templates for the same slots are read from content projection (see Slots below).
+Each interactive piece can be replaced with a component class (`*Component`). Templates for the same slots are read from content projection.
 
 <PropertyReference name="sendButtonComponent" type="Type<any>">
   Component class for the send button. Style the default with `sendButtonClass`.
 </PropertyReference>
 
 <PropertyReference name="toolbarComponent" type="Type<any>">
-  Component class for the toolbar. Style the default with `toolbarClass`.
+  Component class for the toolbar.
 </PropertyReference>
 
 <PropertyReference name="textAreaComponent" type="Type<any>">
@@ -94,28 +107,32 @@ Each interactive piece can be replaced with a component class (`*Component`) and
 </PropertyReference>
 
 <PropertyReference name="audioRecorderComponent" type="Type<any>">
-  Component class for the audio recorder shown in transcribe mode. Style the default with `audioRecorderClass`.
+  Component class for the audio recorder shown in transcribe mode.
 </PropertyReference>
 
 <PropertyReference name="startTranscribeButtonComponent" type="Type<any>">
-  Component class for the start-transcribe button. Style the default with `startTranscribeButtonClass`.
+  Component class for the start-transcribe button.
 </PropertyReference>
 
 <PropertyReference name="cancelTranscribeButtonComponent" type="Type<any>">
-  Component class for the cancel-transcribe button. Style the default with `cancelTranscribeButtonClass`.
+  Component class for the cancel-transcribe button.
 </PropertyReference>
 
 <PropertyReference name="finishTranscribeButtonComponent" type="Type<any>">
-  Component class for the finish-transcribe button. Style the default with `finishTranscribeButtonClass`.
+  Component class for the finish-transcribe button.
 </PropertyReference>
 
 <PropertyReference name="addFileButtonComponent" type="Type<any>">
-  Component class for the add-file button. Style the default with `addFileButtonClass`.
+  Component class for the add-file button.
 </PropertyReference>
 
 <PropertyReference name="toolsButtonComponent" type="Type<any>">
-  Component class for the tools menu button. Style the default with `toolsButtonClass`.
+  Component class for the tools menu button.
 </PropertyReference>
+
+<Callout type="warn">
+  The current release declares class inputs for the toolbar, audio recorder, transcription buttons, add-file button, and tools button, but does not apply them. `sendButtonClass` and `textAreaClass` do apply.
+</Callout>
 
 ## Outputs
 
@@ -192,19 +209,26 @@ For deep customization, provide named `<ng-template>` elements inside `<copilot-
 ### Tools menu example
 
 ```ts title="src/app/chat.component.ts"
-import { Component } from "@angular/core";
-import { CopilotChatInput } from "@copilotkit/angular";
+import { Component, forwardRef, signal } from "@angular/core";
+import { ChatState, CopilotChatInput } from "@copilotkit/angular";
 import type { ToolsMenuItem } from "@copilotkit/angular";
 
 @Component({
   selector: "app-chat",
   standalone: true,
   imports: [CopilotChatInput],
+  providers: [
+    {
+      provide: ChatState,
+      useExisting: forwardRef(() => ChatComponent),
+    },
+  ],
   template: `
     <copilot-chat-input [toolsMenu]="toolsMenu" />
   `,
 })
-export class ChatComponent {
+export class ChatComponent extends ChatState {
+  readonly inputValue = signal("");
   toolsMenu: (ToolsMenuItem | "-")[] = [
     { label: "Summarize", action: () => this.summarize() },
     "-",
@@ -213,6 +237,14 @@ export class ChatComponent {
 
   summarize() {}
   translate() {}
+
+  submitInput(value: string) {
+    // Send the message through your chat state owner.
+  }
+
+  changeInput(value: string) {
+    this.inputValue.set(value);
+  }
 }
 ```
 

--- a/showcase/shell-docs/src/content/reference/angular/components/CopilotChatInput.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/components/CopilotChatInput.mdx
@@ -53,7 +53,7 @@ export class ChatComponent extends ChatState {
 ### Behavior inputs
 
 <PropertyReference name="mode" type='"input" | "transcribe" | "processing"'>
-  Declared by the component, but the current release does not read this input. The component starts in `"input"` mode and manages later transitions itself.
+  Controlled input mode. When omitted, the component starts in `"input"` mode and manages later transitions itself.
 </PropertyReference>
 
 <PropertyReference name="toolsMenu" type='(ToolsMenuItem | "-")[]'>
@@ -65,7 +65,7 @@ export class ChatComponent extends ChatState {
 </PropertyReference>
 
 <PropertyReference name="value" type="string">
-  Controlled value for the textarea when it is non-empty. An empty string falls back to the value held in `ChatState`.
+  Controlled value for the textarea. When omitted, the component reads the value held in `ChatState`. An explicit empty string keeps the textarea empty.
 </PropertyReference>
 
 <PropertyReference name="inputClass" type="string">

--- a/showcase/shell-docs/src/content/reference/angular/components/CopilotChatMessageView.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/components/CopilotChatMessageView.mdx
@@ -7,7 +7,7 @@ description: "Angular standalone component that renders a list of chat messages,
 
 `CopilotChatMessageView` renders an array of messages and routes each one to the correct renderer based on its `role`: assistant messages go to [`CopilotChatAssistantMessage`](/reference/angular/components/CopilotChatAssistantMessage), user messages to [`CopilotChatUserMessage`](/reference/angular/components/CopilotChatUserMessage), reasoning messages to the reasoning renderer, and activity messages to any registered activity renderer. It optionally renders a typing cursor at the end of the list while the agent is streaming.
 
-This is the message-list layer used internally by [`CopilotChatView`](/reference/angular/components/CopilotChatView). It mirrors React's `CopilotChatMessageView`. Use it directly when you manage your own `messages` array and want only the list rendering without the surrounding scroll container and input.
+This is the message-list layer used by [`CopilotChatView`](/reference/angular/components/CopilotChatView). Use it directly when you manage your own `messages` array and want the list without the surrounding scroll container and input.
 
 The component is standalone and uses `OnPush` change detection. Reactive inputs are Angular [signals](https://angular.dev/guide/signals).
 
@@ -49,7 +49,11 @@ export class MessagesComponent {
 </PropertyReference>
 
 <PropertyReference name="isLoading" type="boolean" default="false">
-  Whether the agent is currently streaming. Forwarded to assistant, reasoning, and activity renderers so they can show in-progress state.
+  Whether the agent is currently streaming. Forwarded to assistant and reasoning renderers.
+</PropertyReference>
+
+<PropertyReference name="state" type="unknown" default="{}">
+  Current agent state passed to the content rendered after the message list.
 </PropertyReference>
 
 <PropertyReference name="inputClass" type="string">
@@ -80,6 +84,34 @@ export class MessagesComponent {
   A component class to render each user message in place of the default [`CopilotChatUserMessage`](/reference/angular/components/CopilotChatUserMessage).
 </PropertyReference>
 
+### Reasoning message slot inputs
+
+<PropertyReference name="reasoningMessageComponent" type="Type<any>">
+  Component class used for reasoning messages.
+</PropertyReference>
+
+<PropertyReference name="reasoningMessageTemplate" type="TemplateRef<any>">
+  Template used for reasoning messages. Takes precedence over `reasoningMessageComponent`.
+</PropertyReference>
+
+<PropertyReference name="reasoningMessageClass" type="string">
+  CSS classes forwarded to the reasoning-message slot.
+</PropertyReference>
+
+### Content after the message list
+
+<PropertyReference name="childrenComponent" type="Type<any>">
+  Component rendered after the messages and before the streaming cursor.
+</PropertyReference>
+
+<PropertyReference name="childrenTemplate" type="TemplateRef<any>">
+  Template rendered after the messages. Takes precedence over `childrenComponent`.
+</PropertyReference>
+
+<PropertyReference name="childrenClass" type="string">
+  CSS classes forwarded to the children slot.
+</PropertyReference>
+
 <PropertyReference name="userMessageTemplate" type="TemplateRef<any>">
   A template to render each user message. Takes precedence over `userMessageComponent` when both are set.
 </PropertyReference>
@@ -104,7 +136,7 @@ export class MessagesComponent {
 
 ## Outputs
 
-These bubble up from the per-message child components so you can observe toolbar interactions from the list level. Each payload is `{ message: Message }`.
+Assistant actions bubble up from the assistant-message child component. Each payload is `{ message: Message }`.
 
 <PropertyReference name="assistantMessageThumbsUp" type="{ message: Message }">
   Emitted when the thumbs-up action is triggered on an assistant message.
@@ -122,13 +154,9 @@ These bubble up from the per-message child components so you can observe toolbar
   Emitted when the regenerate action is triggered on an assistant message.
 </PropertyReference>
 
-<PropertyReference name="userMessageCopy" type="{ message: Message }">
-  Emitted when a user message is copied.
-</PropertyReference>
-
-<PropertyReference name="userMessageEdit" type="{ message: Message }">
-  Emitted when a user message edit action is triggered.
-</PropertyReference>
+<Callout type="warn">
+  The current release declares `userMessageCopy` and `userMessageEdit`, but the default user-message child does not forward those events. Listen on a custom user-message component when you need them.
+</Callout>
 
 ## Custom layout
 

--- a/showcase/shell-docs/src/content/reference/angular/components/CopilotChatUserMessage.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/components/CopilotChatUserMessage.mdx
@@ -5,7 +5,7 @@ description: "Angular standalone component that renders a single user message wi
 
 ## Overview
 
-`CopilotChatUserMessage` renders one user message. It shows any image or file attachments, renders the message text through a renderer, and shows a toolbar with copy and edit actions. When the message belongs to a set of regenerated branches, a branch navigation control lets you step between them. It mirrors React's `CopilotChatUserMessage`.
+`CopilotChatUserMessage` renders one user message. It shows image or file attachments, renders the message text, and shows a toolbar with copy and edit actions. When the message belongs to a set of regenerated branches, a branch control lets you move between them.
 
 The copy and edit buttons always render. The branch navigation control renders only when `numberOfBranches` is greater than 1.
 

--- a/showcase/shell-docs/src/content/reference/angular/components/CopilotChatView.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/components/CopilotChatView.mdx
@@ -1,35 +1,50 @@
 ---
 title: "CopilotChatView"
-description: "Angular standalone component that renders the chat layout (message feed and input) without agent wiring, the @copilotkit/angular equivalent of React's CopilotChatView"
+description: "Angular standalone component that renders the chat layout without agent wiring"
 ---
 
 ## Overview
 
 `CopilotChatView` is the layout-only chat view. It renders the message feed, the input container, the feather effect, the disclaimer, the suggestion pills, and a welcome screen when there are no messages. It does not wire an agent on its own. You pass it `messages` and read interaction handlers from the surrounding `ChatState`.
 
-This is the Angular equivalent of React's `<CopilotChatView>`. Contrast it with [`CopilotChat`](/reference/angular/components/CopilotChat): `CopilotChat` wires the agent (resolving messages, running state, suggestions, and submission) and renders `CopilotChatView` underneath, while `CopilotChatView` is presentational. Use it directly when you manage messages and handlers yourself, or when you need deep control over the layout and its slots.
+[`CopilotChat`](/reference/angular/components/CopilotChat) wires the agent, messages, running state, suggestions, and submission, then renders `CopilotChatView`. Use `CopilotChatView` directly when you manage those values and handlers, or when you need full control over the layout and its slots.
 
-Almost every visual piece is a slot. Each slot accepts either a component class (`*Component`) or an Angular template (`*Template`), plus an optional class string (`*Class`).
+The active slot inputs accept a component class (`*Component`) or an Angular template (`*Template`). The template takes precedence when both are set.
 
 ## Usage
 
-`CopilotChatView` is a standalone component with the selector `copilot-chat-view`. Import the class into your component's `imports` array and use the element in the template.
+`CopilotChatView` is a standalone component with the selector `copilot-chat-view`. Its default input needs a `ChatState` provider. The example below supplies one.
 
 ```ts title="src/app/chat.component.ts"
-import { Component, signal } from "@angular/core";
-import { CopilotChatView } from "@copilotkit/angular";
+import { Component, forwardRef, signal } from "@angular/core";
+import { ChatState, CopilotChatView } from "@copilotkit/angular";
 import type { Message } from "@ag-ui/client";
 
 @Component({
   selector: "app-chat",
   standalone: true,
   imports: [CopilotChatView],
+  providers: [
+    {
+      provide: ChatState,
+      useExisting: forwardRef(() => ChatComponent),
+    },
+  ],
   template: `
     <copilot-chat-view [messages]="messages()" [autoScroll]="true" />
   `,
 })
-export class ChatComponent {
-  messages = signal<Message[]>([]);
+export class ChatComponent extends ChatState {
+  readonly messages = signal<Message[]>([]);
+  readonly inputValue = signal("");
+
+  submitInput(value: string) {
+    // Send the message through your chat state owner.
+  }
+
+  changeInput(value: string) {
+    this.inputValue.set(value);
+  }
 }
 ```
 
@@ -39,6 +54,10 @@ export class ChatComponent {
 
 <PropertyReference name="messages" type="Message[]" default="[]">
   The messages to render in the feed. When empty (and no explicit thread is selected), the welcome screen is shown instead.
+</PropertyReference>
+
+<PropertyReference name="state" type="unknown" default="{}">
+  Current agent state passed to message-list child content.
 </PropertyReference>
 
 <PropertyReference name="agentId" type="string">
@@ -59,7 +78,7 @@ export class ChatComponent {
 
 ### Slot inputs
 
-Each visual region exposes a component override, a template override, and a class. The template takes precedence over the component when both are set.
+The view forwards message, input, scroll-button, input-container, feather, and disclaimer slots.
 
 <PropertyReference name="messageViewComponent" type="Type<any>">
   Component class to render the message list. Pair with `messageViewClass` to style it, or use `messageViewTemplate` for a template.
@@ -73,16 +92,44 @@ Each visual region exposes a component override, a template override, and a clas
   Class applied to the message list.
 </PropertyReference>
 
-<PropertyReference name="scrollViewComponent" type="Type<any>">
-  Component class for the scrolling container around the message list.
+<Callout type="warn">
+  The current release declares `scrollViewComponent`, `scrollViewTemplate`, and `scrollViewClass`, but the default layout always uses its built-in scroll view. Use `customLayout` when you need to replace it.
+</Callout>
+
+<PropertyReference name="assistantMessageComponent" type="Type<any>">
+  Component class used for assistant messages.
 </PropertyReference>
 
-<PropertyReference name="scrollViewTemplate" type="TemplateRef<any>">
-  Template for the scrolling container.
+<PropertyReference name="assistantMessageTemplate" type="TemplateRef<any>">
+  Template used for assistant messages. Takes precedence over `assistantMessageComponent`.
 </PropertyReference>
 
-<PropertyReference name="scrollViewClass" type="string">
-  Class applied to the scrolling container.
+<PropertyReference name="assistantMessageClass" type="string">
+  CSS classes forwarded to assistant messages.
+</PropertyReference>
+
+<PropertyReference name="reasoningMessageComponent" type="Type<any>">
+  Component class used for reasoning messages.
+</PropertyReference>
+
+<PropertyReference name="reasoningMessageTemplate" type="TemplateRef<any>">
+  Template used for reasoning messages. Takes precedence over `reasoningMessageComponent`.
+</PropertyReference>
+
+<PropertyReference name="reasoningMessageClass" type="string">
+  CSS classes forwarded to reasoning messages.
+</PropertyReference>
+
+<PropertyReference name="messageViewChildrenComponent" type="Type<any>">
+  Component rendered after the message list and before the cursor.
+</PropertyReference>
+
+<PropertyReference name="messageViewChildrenTemplate" type="TemplateRef<any>">
+  Template rendered after the message list. Takes precedence over `messageViewChildrenComponent`.
+</PropertyReference>
+
+<PropertyReference name="messageViewChildrenClass" type="string">
+  CSS classes forwarded to the message-list children slot.
 </PropertyReference>
 
 <PropertyReference name="scrollToBottomButtonComponent" type="Type<any>">
@@ -125,9 +172,9 @@ Each visual region exposes a component override, a template override, and a clas
   Template for the feather effect.
 </PropertyReference>
 
-<PropertyReference name="featherClass" type="string">
-  Class applied to the feather effect.
-</PropertyReference>
+<Callout type="warn">
+  `featherClass` is declared but the current release does not pass its string value to the feather slot. Use a feather component or template to style that region.
+</Callout>
 
 <PropertyReference name="disclaimerComponent" type="Type<any>">
   Component class for the disclaimer shown beneath the input.
@@ -147,7 +194,7 @@ Each visual region exposes a component override, a template override, and a clas
 
 ## Outputs
 
-`CopilotChatView` bubbles message-level interaction events from the message feed. Each payload is an object with the relevant `message`.
+`CopilotChatView` bubbles assistant-message actions from the message feed. Each payload is an object with the relevant `message`.
 
 <PropertyReference name="assistantMessageThumbsUp" type="{ message: Message }">
   Emitted when the thumbs-up action is triggered on an assistant message.
@@ -165,82 +212,66 @@ Each visual region exposes a component override, a template override, and a clas
   Emitted when the regenerate action is triggered on an assistant message.
 </PropertyReference>
 
-<PropertyReference name="userMessageCopy" type="{ message: Message }">
-  Emitted when the copy action is triggered on a user message.
-</PropertyReference>
-
-<PropertyReference name="userMessageEdit" type="{ message: Message }">
-  Emitted when the edit action is triggered on a user message.
-</PropertyReference>
+<Callout type="warn">
+  The current release declares `userMessageCopy` and `userMessageEdit`, but the default message view does not emit them.
+</Callout>
 
 ## Content projection
 
-Beyond the slot inputs, `CopilotChatView` reads named templates from content projection (via `@ContentChild`) for deep customization. Provide them as `<ng-template>` elements with the matching reference variable inside `<copilot-chat-view>`.
+`CopilotChatView` supports one active projected template named `customLayout`.
 
 <PropertyReference name="customLayout" type="TemplateRef<CopilotChatViewLayoutContext>">
-  Replaces the entire default layout (render-prop pattern). Receives a context object with the resolved slots: `messageView`, `input`, `scrollView`, `scrollToBottomButton`, `feather`, `inputContainer`, and `disclaimer`.
+  Replaces the entire default layout. The template has named context values for the configured `messageView`, `input`, `scrollView`, `scrollToBottomButton`, `feather`, `inputContainer`, and `disclaimer` slots. A value can be undefined when you did not configure that slot.
 </PropertyReference>
 
-<PropertyReference name="sendButton" type="TemplateRef<any>">
-  Custom send button passed down to the input.
-</PropertyReference>
-
-<PropertyReference name="toolbar" type="TemplateRef<any>">
-  Custom input toolbar.
-</PropertyReference>
-
-<PropertyReference name="textArea" type="TemplateRef<any>">
-  Custom textarea for the input.
-</PropertyReference>
-
-<PropertyReference name="audioRecorder" type="TemplateRef<any>">
-  Custom audio recorder for transcription mode.
-</PropertyReference>
-
-<PropertyReference name="assistantMessageMarkdownRenderer" type="TemplateRef<any>">
-  Custom markdown renderer for assistant messages.
-</PropertyReference>
-
-<PropertyReference name="thumbsUpButton" type="TemplateRef<any>">
-  Custom thumbs-up button on assistant messages.
-</PropertyReference>
-
-<PropertyReference name="thumbsDownButton" type="TemplateRef<any>">
-  Custom thumbs-down button on assistant messages.
-</PropertyReference>
-
-<PropertyReference name="readAloudButton" type="TemplateRef<any>">
-  Custom read-aloud button on assistant messages.
-</PropertyReference>
-
-<PropertyReference name="regenerateButton" type="TemplateRef<any>">
-  Custom regenerate button on assistant messages.
-</PropertyReference>
+<Callout type="warn">
+  The class declares projected templates for input buttons and assistant-message parts, but the current release does not forward them. Configure those parts through `inputComponent`, the message slot inputs, or a custom layout.
+</Callout>
 
 ### Custom layout example
 
 ```ts title="src/app/chat.component.ts"
-import { Component, signal } from "@angular/core";
-import { CopilotChatView } from "@copilotkit/angular";
+import { Component, forwardRef, signal } from "@angular/core";
+import {
+  ChatState,
+  CopilotChatInput,
+  CopilotChatMessageView,
+  CopilotChatView,
+} from "@copilotkit/angular";
 import type { Message } from "@ag-ui/client";
 
 @Component({
   selector: "app-chat",
   standalone: true,
-  imports: [CopilotChatView],
+  imports: [CopilotChatInput, CopilotChatMessageView, CopilotChatView],
+  providers: [
+    {
+      provide: ChatState,
+      useExisting: forwardRef(() => ChatComponent),
+    },
+  ],
   template: `
     <copilot-chat-view [messages]="messages()">
-      <ng-template #customLayout let-ctx>
+      <ng-template #customLayout>
         <div class="my-layout">
-          <ng-container [ngTemplateOutlet]="ctx.messageView" />
-          <ng-container [ngTemplateOutlet]="ctx.input" />
+          <copilot-chat-message-view [messages]="messages()" />
+          <copilot-chat-input />
         </div>
       </ng-template>
     </copilot-chat-view>
   `,
 })
-export class ChatComponent {
-  messages = signal<Message[]>([]);
+export class ChatComponent extends ChatState {
+  readonly messages = signal<Message[]>([]);
+  readonly inputValue = signal("");
+
+  submitInput(value: string) {
+    // Send the message through your chat state owner.
+  }
+
+  changeInput(value: string) {
+    this.inputValue.set(value);
+  }
 }
 ```
 

--- a/showcase/shell-docs/src/content/reference/angular/directives/CopilotKitAgentContext.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/directives/CopilotKitAgentContext.mdx
@@ -5,11 +5,11 @@ description: "Angular standalone directive that shares application state with th
 
 ## Overview
 
-`CopilotKitAgentContext` is a standalone Angular directive that shares a piece of [context](https://docs.ag-ui.com/concepts/context) with the agent from your template. Apply it to any element. It adds the context when the element initializes, updates it when its inputs change, and removes it when the element is destroyed.
+`CopilotKitAgentContext` is a standalone Angular directive that shares a piece of [context](https://docs.ag-ui.com/concepts/context) with the agent from your template. Apply it to any element. It adds a complete context when the element initializes, updates an existing registration when its inputs change, and removes it when the element is destroyed.
 
 You can supply the context either as a single object via the directive selector input, or as separate `description` and `value` inputs. The context object takes precedence when both are provided.
 
-This is the template-based equivalent of the [`connectAgentContext`](/reference/angular/functions/connectAgentContext) function, which mirrors React's `useAgentContext()`.
+This is the template-based alternative to [`connectAgentContext`](/reference/angular/functions/connectAgentContext).
 
 ## Import
 
@@ -26,12 +26,13 @@ import { CopilotKitAgentContext } from "@copilotkit/angular";
   template: `
     <div copilotkitAgentContext
          description="User profile"
-         [value]="profile">
+         [value]="profileJson">
     </div>
   `,
 })
 export class ProfileComponent {
   profile = { name: "Ada", plan: "pro" };
+  profileJson = JSON.stringify(this.profile);
 }
 ```
 
@@ -54,7 +55,11 @@ It is an attribute directive, so apply it to any element.
 </PropertyReference>
 
 <PropertyReference name="value" type="any">
-  The context value. Used together with `description` to build the context object when the `copilotkitAgentContext` object input is not provided. The context is only registered when both `description` and `value` are set.
+  The value forwarded with `description` when the object input is not provided.
+  The directive currently declares this input as `any`, but the AG-UI `Context`
+  contract requires a string. Serialize objects before binding them. The context
+  is registered only when both `description` and `value` are set during
+  initialization.
 </PropertyReference>
 
 ## Usage
@@ -64,7 +69,7 @@ It is an attribute directive, so apply it to any element.
 ```html
 <div copilotkitAgentContext
      description="User preferences"
-     [value]="userSettings">
+     [value]="userSettingsJson">
 </div>
 ```
 
@@ -76,21 +81,29 @@ Pass a complete `{ description, value }` object through the selector input.
 <div [copilotkitAgentContext]="contextObject"></div>
 ```
 
-### Dynamic values
+### Updating a registered context
 
-The directive re-registers the context whenever its inputs change, so binding a dynamic value keeps the agent in sync.
+The directive re-registers a context when inputs change after a complete context
+was registered during initialization. Supply both fields at initialization.
 
 ```html
-<div copilotkitAgentContext
-     description="Form state"
-     [value]="formData$ | async">
-</div>
+<div [copilotkitAgentContext]="formContext"></div>
 ```
+
+If the initial object or separate value is missing, a later input change does
+not create the first registration. Render the directive only after the complete
+context is available, or use
+[`connectAgentContext`](/reference/angular/functions/connectAgentContext) for a
+reactive accessor.
 
 ## Behavior
 
 - **Adds on init.** The context is registered with the agent in `ngOnInit`.
-- **Updates on change.** When `copilotkitAgentContext`, `description`, or `value` change, the directive removes the previous context and adds the new one. The first change is handled by init, so it is not double-registered.
+- **Updates an existing registration.** When `copilotkitAgentContext`,
+  `description`, or `value` changes after initialization registered a context,
+  the directive removes the previous context and adds the new one.
+- **Does not add after an empty initialization.** If initialization has no
+  complete context, later input changes do not create the first registration.
 - **Removes on destroy.** The context is removed when the host element is destroyed.
 - **Object input precedence.** When the `copilotkitAgentContext` object input is set, it is used and the separate `description` and `value` inputs are ignored. Otherwise, the context is built from `description` and `value`, and is only registered when both are set.
 

--- a/showcase/shell-docs/src/content/reference/angular/functions/connectAgentContext.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/connectAgentContext.mdx
@@ -5,21 +5,21 @@ description: "Angular function that adds reactive context for the agent and clea
 
 ## Overview
 
-`connectAgentContext` registers a piece of [context](https://docs.ag-ui.com/concepts/context) with the agent so the agent can read your application state. It accepts a static `Context` object or a `Signal<Context>`. When you pass a signal, the registered context updates reactively as the signal changes, and the previous context is removed and the new one added.
+`connectAgentContext` registers [context](https://docs.ag-ui.com/concepts/context) with the agent so it can read your application state. It accepts a static `Context` object or a zero-argument accessor. The internal Angular `effect` tracks any signals read by the accessor and updates the context when they change.
 
 The registration is wrapped in an Angular `effect`, so the context is cleaned up automatically when the owning component or service is destroyed.
 
-This is the function-based equivalent of React's `useAgentContext()`. For a template-driven alternative, use the [`CopilotKitAgentContext`](/reference/angular/directives/CopilotKitAgentContext) directive.
+For a template-driven alternative, use the [`CopilotKitAgentContext`](/reference/angular/directives/CopilotKitAgentContext) directive.
 
 <Callout type="warn">
-  Call this from an Angular injection context (a constructor or a field initializer). If you cannot, pass an `injector` in the config. If neither is available, it throws.
+  Call this from an Angular injection context, such as a constructor or field initializer. The current implementation resolves the ambient injector before it reads the config, so passing `config.injector` does not make an outside-context call valid.
 </Callout>
 
 ## Signature
 
 ```ts
 import { connectAgentContext } from "@copilotkit/angular";
-import type { Signal, Injector } from "@angular/core";
+import type { Injector } from "@angular/core";
 import type { Context } from "@ag-ui/client";
 
 interface ConnectAgentContextConfig {
@@ -27,15 +27,15 @@ interface ConnectAgentContextConfig {
 }
 
 function connectAgentContext(
-  context: Context | Signal<Context>,
+  context: Context | (() => Context),
   config?: ConnectAgentContextConfig,
 ): void;
 ```
 
 ## Parameters
 
-<PropertyReference name="context" type="Context | Signal<Context>" required>
-  The context to share with the agent, or a signal of it. A `Context` is an object with the following fields. When you pass a `Signal<Context>`, the context re-registers whenever the signal value changes.
+<PropertyReference name="context" type="Context | (() => Context)" required>
+  The context to share with the agent, or a zero-argument accessor that returns it. A `Context` is an object with the following fields. When the accessor reads Angular signals, the context re-registers when those signals change.
 
   <PropertyReference name="description" type="string" required>
     A human-readable description of what this context represents, for example `"User preferences"`.
@@ -47,10 +47,10 @@ function connectAgentContext(
 </PropertyReference>
 
 <PropertyReference name="config" type="ConnectAgentContextConfig">
-  Optional configuration.
+  Optional configuration. You must still call the function from an injection context.
 
   <PropertyReference name="injector" type="Injector">
-    An explicit `Injector` to use when `connectAgentContext` is called outside an injection context. When omitted, the ambient injector is used. The injector also scopes the internal `effect`, so cleanup runs when that injector is destroyed.
+    Accepted for API compatibility. The current implementation uses the ambient injector when one is present.
   </PropertyReference>
 </PropertyReference>
 
@@ -77,12 +77,12 @@ export class PreferencesComponent {
 }
 ```
 
-### Reactive context with a signal
+### Reactive context with an accessor
 
-Pass a `Signal<Context>` so the agent always sees the current value.
+Pass an accessor that reads signals so the agent always sees the current value.
 
 ```ts title="src/app/cart.component.ts"
-import { Component, computed, signal } from "@angular/core";
+import { Component, signal } from "@angular/core";
 import { connectAgentContext } from "@copilotkit/angular";
 
 @Component({
@@ -93,13 +93,13 @@ import { connectAgentContext } from "@copilotkit/angular";
 export class CartComponent {
   readonly items = signal<string[]>([]);
 
-  // Re-registers with the agent whenever the cart changes.
-  readonly cartContext = connectAgentContext(
-    computed(() => ({
+  constructor() {
+    // Re-registers with the agent whenever the cart changes.
+    connectAgentContext(() => ({
       description: "Current shopping cart",
       value: JSON.stringify(this.items()),
-    })),
-  );
+    }));
+  }
 
   add() {
     this.items.update((items) => [...items, "Item"]);
@@ -107,32 +107,11 @@ export class CartComponent {
 }
 ```
 
-### Passing an explicit injector
-
-When you call `connectAgentContext` outside an injection context, pass an `injector`.
-
-```ts title="src/app/late-context.service.ts"
-import { inject, Injectable, Injector } from "@angular/core";
-import { connectAgentContext } from "@copilotkit/angular";
-
-@Injectable({ providedIn: "root" })
-export class LateContextService {
-  private readonly injector = inject(Injector);
-
-  register(value: string) {
-    connectAgentContext(
-      { description: "Late context", value },
-      { injector: this.injector },
-    );
-  }
-}
-```
-
 ## Behavior
 
-- **Reactive updates.** When given a `Signal<Context>`, the context is removed and re-added whenever the signal value changes, so the agent always sees the current value.
+- **Reactive updates.** When an accessor reads signals, the context is removed and re-added whenever one of those signals changes.
 - **Automatic cleanup.** Registration runs inside an Angular `effect`; the context is removed when the effect is torn down, which happens when the owning component, service, or injector is destroyed.
-- **Injection context required.** Throws if called outside an injection context without an `injector` in the config.
+- **Injection context required.** Angular throws `NG0203` when you call the function outside an injection context.
 
 ## Related
 

--- a/showcase/shell-docs/src/content/reference/angular/functions/connectAgentContext.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/connectAgentContext.mdx
@@ -50,7 +50,8 @@ function connectAgentContext(
   Optional configuration. You must still call the function from an injection context.
 
   <PropertyReference name="injector" type="Injector">
-    Accepted for API compatibility. The current implementation uses the ambient injector when one is present.
+    Injector used to resolve `CopilotKit` and own the reactive effect. When
+    supplied, it takes precedence over the ambient injector.
   </PropertyReference>
 </PropertyReference>
 

--- a/showcase/shell-docs/src/content/reference/angular/functions/injectAgentStore.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/injectAgentStore.mdx
@@ -9,10 +9,10 @@ description: "Angular function that subscribes to an AG-UI agent and returns a s
 
 Read the store by calling the outer signal, then read each member by calling its signal: `store().messages()`, `store().isRunning()`, `store().state()`. The `agent` member is the plain AG-UI instance (not a signal), so you read it directly: `store().agent`.
 
-This is the Angular equivalent of React's `useAgent()`. Call it from an injection context (a constructor or a field initializer). The subscription is torn down automatically when the owning component or service is destroyed.
+Call it from an injection context such as a constructor or field initializer. The subscription is torn down automatically when the owning component or service is destroyed.
 
 <Callout type="warn">
-  Resolution of the agent is lazy and reactive. If no agent can be resolved for the given `agentId` after the runtime has synced (for example, the id does not match any agent reported by your runtime `/info` or registered via `agents__unsafe_dev_only`), reading the store signal throws an error listing the known agents.
+  Resolution of the agent is lazy and reactive. If no agent can be resolved for the given `agentId` after the runtime has synced (for example, the id does not match any agent reported by your runtime `/info` or configured through `agents` or `selfManagedAgents`), reading the store signal throws an error listing the known agents.
 </Callout>
 
 ## Signature
@@ -48,7 +48,7 @@ function injectAgentStore(
   </PropertyReference>
 
   <PropertyReference name="state" type="Signal<unknown>">
-    A readonly signal of the agent's shared state object, synchronized between your app and the agent. Read it with `store().state()`. It is `undefined` until the agent reports state. Cast or type it as needed for your agent's state shape.
+    A readonly signal of the agent's shared state object, synchronized between your app and the agent. Read it with `store().state()`. The store seeds this signal synchronously from the agent's current `state`, including state restored before subscription. Cast or type it as needed for your agent's state shape.
   </PropertyReference>
 
   <PropertyReference name="isRunning" type="Signal<boolean>">

--- a/showcase/shell-docs/src/content/reference/angular/functions/provideCopilotChatLabels.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/provideCopilotChatLabels.mdx
@@ -7,7 +7,7 @@ description: "Angular provider that overrides the default text labels used by th
 
 `provideCopilotChatLabels` returns an Angular [`Provider`](https://angular.dev/guide/di/dependency-injection-providers) that customizes the text labels used throughout the prebuilt chat components, such as the input placeholder, toolbar button labels, the disclaimer text, and the welcome message. You pass a partial set of labels and they are merged over the defaults, so you only override the strings you want to change.
 
-Add it to an application or component `providers` array. Components read the merged labels through [`injectChatLabels`](/reference/angular/functions/injectChatLabels). This mirrors React's chat label configuration via `useCopilotChatConfiguration`.
+Add it to an application or component `providers` array. Components read the merged labels through [`injectChatLabels`](/reference/angular/functions/injectChatLabels).
 
 The full set of defaults lives in `COPILOT_CHAT_DEFAULT_LABELS`. Any field you omit falls back to its default value.
 

--- a/showcase/shell-docs/src/content/reference/angular/functions/provideCopilotKit.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/provideCopilotKit.mdx
@@ -5,9 +5,9 @@ description: "Angular provider that configures CopilotKit through dependency inj
 
 ## Overview
 
-`provideCopilotKit` is the primary setup entry point for `@copilotkit/angular`. It returns an Angular [`Provider`](https://angular.dev/guide/di/dependency-injection-providers) that you add to your application (or component) `providers` array. The provider stores your [`CopilotKitConfig`](#parameters) behind the `COPILOT_KIT_CONFIG` injection token, where the [`CopilotKit`](/reference/angular/services/CopilotKit) service and every CopilotKit function reads it.
+`provideCopilotKit` is the primary setup entry point for `@copilotkit/angular`. It returns an Angular [`Provider`](https://angular.dev/guide/di/dependency-injection-providers) that you add to your application providers. The provider stores your [`CopilotKitConfig`](#parameters) behind the `COPILOT_KIT_CONFIG` injection token, where the root [`CopilotKit`](/reference/angular/services/CopilotKit) service reads it.
 
-This is the Angular equivalent of React's `<CopilotKit>` provider. Because Angular configures CopilotKit through dependency injection rather than a wrapper component, you register it once in `app.config.ts` (or in a feature component's `providers`) and everything below it in the injector tree can connect to your runtime and agents.
+Register it once in `app.config.ts`. A component-local config provider alone does not configure the root `CopilotKit` service.
 
 You typically configure the connection one of two ways: point at a CopilotKit runtime with `runtimeUrl`, or connect directly to one or more AG-UI agents with `selfManagedAgents`.
 
@@ -32,16 +32,17 @@ function provideCopilotKit(config: CopilotKitConfig): Provider;
 
   <PropertyReference name="headers" type="Record<string, string>">
     Extra HTTP headers sent with every runtime request, for example an
-    `Authorization` header. If you pass a `licenseKey`, a
+    `Authorization` header. If you pass a format-valid `licenseKey`, a
     `X-CopilotCloud-Public-Api-Key` header is merged in automatically unless you
     already set one here.
   </PropertyReference>
 
   <PropertyReference name="licenseKey" type="string">
-    Your CopilotCloud license key (a `ck_pub_...` value). When present and valid
-    it is sent as the `X-CopilotCloud-Public-Api-Key` header and removes the
-    license watermark. An absent or malformed key logs a one-time console
-    warning.
+    Your CopilotCloud public key. A value matching `ck_pub_` followed by 32
+    hexadecimal characters is sent as the
+    `X-CopilotCloud-Public-Api-Key` header unless that header is already set.
+    Watermark rendering and missing-key warnings are disabled in the current
+    package.
   </PropertyReference>
 
   <PropertyReference name="properties" type="Record<string, unknown>">
@@ -106,6 +107,11 @@ function provideCopilotKit(config: CopilotKitConfig): Provider;
     for tools scoped to a component.
   </PropertyReference>
 
+  <PropertyReference name="defaultToolRendering" type="boolean" default="false">
+    Opts into the text-only fallback renderer for otherwise unknown tool calls.
+    Unknown tools are hidden when this is omitted or `false`.
+  </PropertyReference>
+
   <PropertyReference name="a2ui" type="A2UIConfig">
     Configuration for A2UI (agent-to-UI declarative surfaces). A runtime may
     advertise A2UI through `/info`; supplying a catalog also enables the
@@ -124,6 +130,20 @@ function provideCopilotKit(config: CopilotKitConfig): Provider;
     <PropertyReference name="includeSchema" type="boolean" default="true">
       Whether to send the catalog component schemas to the agent as context. Set
       to `false` to omit the schema context.
+    </PropertyReference>
+    <PropertyReference name="recovery" type="A2UIRecoveryOptions">
+      Controls when A2UI retry and diagnostic state becomes visible.
+
+      <PropertyReference name="showAfterMs" type="number" default="2000">
+        Delay before revealing a transient retry.
+      </PropertyReference>
+      <PropertyReference name="showAfterAttempts" type="number" default="2">
+        Attempt number that reveals retry state immediately.
+      </PropertyReference>
+      <PropertyReference name="debugExposure" type='"hidden" | "collapsed" | "verbose"'>
+        Client diagnostic visibility. Authoritative server lifecycle content may
+        override it.
+      </PropertyReference>
     </PropertyReference>
   </PropertyReference>
 
@@ -145,7 +165,7 @@ function provideCopilotKit(config: CopilotKitConfig): Provider;
 
 ## Return Value
 
-Returns an Angular `Provider` that binds your (header-augmented) config to the `COPILOT_KIT_CONFIG` injection token. Add it to a `providers` array.
+Returns an Angular `Provider` that binds your (header-augmented) config to the `COPILOT_KIT_CONFIG` injection token. Add it to the application providers.
 
 ## Usage
 
@@ -221,7 +241,9 @@ export const appConfig: ApplicationConfig = {
 ## Behavior
 
 - The provided config is bound to the `COPILOT_KIT_CONFIG` injection token. Read it with [`injectCopilotKitConfig`](/reference/angular/functions/injectCopilotKitConfig).
-- If `licenseKey` (or an `X-CopilotCloud-Public-Api-Key` header) is missing or malformed, a one-time license watermark warning is logged to the console.
+- A format-valid `licenseKey` is merged into the
+  `X-CopilotCloud-Public-Api-Key` header unless that header is already present.
+  The current package does not render a watermark or log a missing-key warning.
 - `agents` and `selfManagedAgents` are merged together when the underlying core is created, so an id present in both resolves to the `selfManagedAgents` entry.
 
 ## Related

--- a/showcase/shell-docs/src/content/reference/angular/functions/provideMCPApps.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/provideMCPApps.mdx
@@ -27,6 +27,7 @@ export const appConfig: ApplicationConfig = {
 interface MCPAppsConfig {
   idleTimeoutMs?: number;
   initializationTimeoutMs?: number;
+  sandboxProxyUrl?: string;
   hostInfo?: { name: string; version: string };
   hostCapabilities?: Record<string, unknown>;
   hostContext?: Record<string, unknown>;
@@ -35,8 +36,13 @@ interface MCPAppsConfig {
 
 `provideMCPApps` contributes a lower-precedence built-in renderer for
 `activityType: "mcp-apps"`; an explicit application activity renderer still
-wins. It deliberately accepts no server URL. Resource loads, tool calls, and
-follow-up messages travel through the selected AG-UI agent.
+wins. It deliberately accepts no MCP server URL. Resource loads, tool calls,
+and follow-up messages travel through the selected AG-UI agent.
+
+`sandboxProxyUrl` selects a dedicated sandbox proxy document for hosts with a
+strict response-level content security policy. The document must implement the
+CopilotKit MCP sandbox proxy protocol and use an opaque response sandbox without
+`allow-same-origin`.
 
 Each widget owns an abortable FIFO queue and iframe listener. Destroying one
 widget cancels only its work; changing threads drops queued stale work. Busy

--- a/showcase/shell-docs/src/content/reference/angular/functions/registerFrontendTool.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/registerFrontendTool.mdx
@@ -7,9 +7,9 @@ description: "Angular function for registering a client-side frontend tool with 
 
 `registerFrontendTool` registers a client-side tool with CopilotKit. When the agent decides to call the tool, the provided `handler` function executes in the browser, and the value it resolves to is surfaced back to the agent as the tool result. Optionally, you can supply a `component` (a standalone Angular component) to render custom UI in the chat that shows the tool call's progress and result.
 
-You call `registerFrontendTool` inside an Angular injection context (a component or service constructor, or a field initializer). The tool registers immediately, and CopilotKit removes it automatically when the owning component or service is destroyed. Parameter schemas are defined with a [Standard Schema](https://standardschema.dev) such as a [Zod](https://zod.dev) object, which is used for both validation and type inference of the handler's arguments.
+You call `registerFrontendTool` inside an Angular injection context (a component or service constructor, or a field initializer). The tool registers immediately. When the owning injector is destroyed, CopilotKit removes tool and renderer registrations with the same name and optional agent id. Parameter schemas use a [Standard Schema](https://standardschema.dev), such as a [Zod](https://zod.dev) object, for the advertised tool schema and TypeScript inference. Runtime arguments are JSON-parsed but are not validated against that schema.
 
-This is the Angular equivalent of React's `useFrontendTool()`. The handler runs inside the same injector that registered the tool, so it can call `inject()` to reach your other Angular services.
+The handler runs inside the same injector that registered the tool, so it can call `inject()` to reach your other Angular services.
 
 <Callout type="info">
   Import from the package root, `@copilotkit/angular`. There is no `/v2`
@@ -35,8 +35,9 @@ function registerFrontendTool<Args extends Record<string, unknown>>(
 
   <PropertyReference name="name" type="string" required>
     A unique name for the tool. The agent references this name when it decides
-    to call the tool. Registering another tool with the same name (for the same
-    `agentId`) adds a second registration, so use distinct names per tool.
+    to call the tool. Core skips a second tool with the same name and `agentId`,
+    although Angular still appends its frontend-tool render config. Avoid
+    duplicate keys.
   </PropertyReference>
 
   <PropertyReference name="description" type="string" required>
@@ -46,9 +47,10 @@ function registerFrontendTool<Args extends Record<string, unknown>>(
 
   <PropertyReference name="parameters" type="StandardSchemaV1<unknown, Args>" required>
     A [Standard Schema](https://standardschema.dev) (for example a Zod object)
-    that defines the tool's input parameters. The schema drives both validation
-    and the type inference of the `handler` arguments. For a tool that takes no
-    parameters, pass an empty object schema such as `z.object({})`.
+    that defines the advertised tool input schema and drives type inference for
+    the `handler` arguments. Runtime arguments are JSON-parsed and cast to
+    `Args`; this helper does not validate them against the schema. For a tool
+    that takes no parameters, pass an empty object schema such as `z.object({})`.
   </PropertyReference>
 
   <PropertyReference
@@ -57,7 +59,7 @@ function registerFrontendTool<Args extends Record<string, unknown>>(
     required
   >
     An async function that runs when the agent calls the tool. It receives the
-    validated, typed `args` and a `context` object, and runs inside the
+    parsed `args` cast to the inferred type and a `context` object, and runs inside the
     injection context that registered the tool, so you can call `inject()`
     inside it. The resolved value is returned to the agent as the tool result.
 
@@ -69,10 +71,10 @@ function registerFrontendTool<Args extends Record<string, unknown>>(
       The agent instance that invoked the tool.
     </PropertyReference>
 
-    <PropertyReference name="context.signal" type="AbortSignal">
-      An `AbortSignal` that is aborted when the user stops the agent. Long
-      running handlers can check `signal.aborted` or pass `signal` to `fetch`
-      to cancel cooperatively.
+    <PropertyReference name="context.signal" type="AbortSignal | undefined">
+      An optional `AbortSignal` for the active run. When present, it is aborted
+      when the user stops the agent. Check that it exists before reading
+      `signal.aborted` or pass it as an optional `fetch` signal.
     </PropertyReference>
   </PropertyReference>
 
@@ -97,13 +99,16 @@ function registerFrontendTool<Args extends Record<string, unknown>>(
 
 ## Return Value
 
-`registerFrontendTool` returns `void`. It performs the registration as a side effect and wires up automatic cleanup.
+`registerFrontendTool` returns `void`. It performs the registration as a side effect and wires up name-and-agent-id cleanup for the owning injector.
 
 ## Behavior
 
 - **Immediate registration.** The tool is added to CopilotKit as soon as the function runs, so call it during construction or field initialization, not inside an event handler.
 - **Runs in the injection context.** The `handler` is invoked with `runInInjectionContext` using the injector that registered the tool, so `inject()` works inside it.
-- **Automatic cleanup.** CopilotKit removes the tool when the owning component or service is destroyed, using the same `name` and `agentId` you registered with. There is no manual unregister step.
+- **Cleanup by key.** When the owning component or service is destroyed,
+  CopilotKit removes frontend tools, human-in-the-loop tools, and tool-call
+  renderers with the same `name` and optional `agentId`. Registrations sharing
+  that key are removed together.
 - **Optional renderer.** When you pass a `component`, it is registered alongside the tool so the chat can render the tool call's progress and result.
 
 ## Usage

--- a/showcase/shell-docs/src/content/reference/angular/functions/registerHumanInTheLoop.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/registerHumanInTheLoop.mdx
@@ -5,11 +5,11 @@ description: "Angular function for registering a human-in-the-loop tool with Cop
 
 ## Overview
 
-`registerHumanInTheLoop` registers a tool that pauses the agent and waits for human input. When the agent calls the tool, CopilotKit renders the `component` you provide and suspends the agent run. The component collects a decision from the user (for example a confirm or reject choice) and calls `respond(result)`. That call resolves the tool, surfaces the result back to the agent, and lets the run continue.
+`registerHumanInTheLoop` registers a tool that pauses the agent and waits for human input. When the agent calls the tool, CopilotKit renders the `component` you provide and suspends the agent run. The component collects a decision from the user (for example a confirm or reject choice) and calls `respond(result)`. That call resolves the tool with the serialized result envelope described below and lets the run continue.
 
-You call `registerHumanInTheLoop` inside an Angular injection context (a component or service constructor, or a field initializer). The tool registers immediately, and CopilotKit removes it automatically when the owning component or service is destroyed.
+You call `registerHumanInTheLoop` inside an Angular injection context (a component or service constructor, or a field initializer). The tool registers immediately. When the owning injector is destroyed, CopilotKit removes tool and renderer registrations with the same name and optional agent id.
 
-This is the Angular equivalent of React's `useHumanInTheLoop()`. Unlike [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool), you do not write a `handler`. The handler is supplied internally and simply awaits the user's `respond` call, so the rendered component drives when the agent resumes.
+Unlike [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool), you do not write a `handler`. CopilotKit supplies one that waits for the user's `respond` call, so the rendered component controls when the agent resumes.
 
 <Callout type="info">
   Import from the package root, `@copilotkit/angular`. There is no `/v2`
@@ -45,9 +45,10 @@ function registerHumanInTheLoop<Args extends Record<string, unknown>>(
 
   <PropertyReference name="parameters" type="StandardSchemaV1<unknown, Args>" required>
     A [Standard Schema](https://standardschema.dev) (for example a Zod object)
-    that defines the tool's input parameters. The schema drives both validation
-    and the type inference of the `args` exposed to your component. For a tool
-    that takes no parameters, pass an empty object schema such as
+    that defines the advertised tool input schema and drives type inference for
+    the `args` exposed to your component. Runtime arguments are JSON-parsed and
+    cast to `Args`; this helper does not validate them against the schema. For a
+    tool that takes no parameters, pass an empty object schema such as
     `z.object({})`.
   </PropertyReference>
 
@@ -65,7 +66,7 @@ function registerHumanInTheLoop<Args extends Record<string, unknown>>(
 
 ## Return Value
 
-`registerHumanInTheLoop` returns `void`. It registers the tool as a side effect and wires up automatic cleanup.
+`registerHumanInTheLoop` returns `void`. It registers the tool as a side effect and wires up name-and-agent-id cleanup for the owning injector.
 
 ## The renderer component
 
@@ -103,18 +104,19 @@ type HumanInTheLoopToolCall<Args extends Record<string, unknown>> =
       name?: string;
       args: Args; // fully parsed
       status: "complete";
-      result: string; // the value you passed to respond
+      result: string; // stored tool-message content
       respond: (result: unknown) => void;
     };
 ```
 
-The `respond(result)` callback is how your component resumes the agent. Calling it resolves the underlying tool handler with the value you pass, and that value becomes the tool result the agent sees. While the agent waits, `status` is `executing` (or `in-progress` while the arguments are still streaming). After you call `respond`, the tool call resolves and `status` becomes `complete` with `result` set to the value you sent.
+The `respond(result)` callback is how your component resumes the agent. The current implementation resolves the internal handler with `{ toolCallId, toolName, result }`; core serializes that object to JSON for the tool result. While the agent waits, `status` is `executing` (or `in-progress` while the arguments are still streaming). Once the tool message arrives, `status` becomes `complete` and `result` contains the stored tool-message string.
 
 ## Usage
 
 ### A confirmation dialog
 
-This component renders a confirm and a reject button. Each calls `respond` with a different value, which resumes the agent with that decision.
+This component renders a confirm and a reject button. Each records a different
+decision and resumes the agent.
 
 ```ts title="src/app/confirm-dialog.component.ts"
 import { Component, computed, input } from "@angular/core";
@@ -128,7 +130,7 @@ type ConfirmArgs = { message: string };
   template: `
     @let call = toolCall();
     @if (call.status === "complete") {
-      <div class="text-sm opacity-70">You chose: {{ call.result }}</div>
+      <pre class="text-sm opacity-70">{{ call.result }}</pre>
     } @else {
       <div class="rounded border p-4">
         <p>{{ message() }}</p>
@@ -173,7 +175,11 @@ export class ChatComponent {
 }
 ```
 
-When the agent calls `confirmAction`, the dialog appears in the chat and the run pauses. As soon as the user clicks a button, `respond` resumes the agent with `"confirmed"` or `"rejected"`, and the tool call moves to `status: "complete"`.
+When the agent calls `confirmAction`, the dialog appears in the chat and the run pauses. A button click sends `"confirmed"` or `"rejected"` in the serialized result envelope described above. The completed tool call exposes that stored string.
+
+Cleanup uses the same shared name-and-agent-id removal path as the other tool
+registration helpers. Frontend tools, human-in-the-loop tools, and tool-call
+renderers that share that key are removed together.
 
 ## Related
 

--- a/showcase/shell-docs/src/content/reference/angular/functions/registerRenderToolCall.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/registerRenderToolCall.mdx
@@ -7,9 +7,9 @@ description: "Angular function for registering a renderer component for a tool c
 
 `registerRenderToolCall` registers a renderer for a tool call. It does not run a handler. It tells CopilotKit which standalone Angular component to render whenever a tool call with a matching `name` appears in the conversation. Use it to visualize tool calls that execute somewhere other than the browser, for example a server-side tool or an agentic (long-running) tool, where you only want to show progress and results in the chat.
 
-You call `registerRenderToolCall` inside an Angular injection context (a component or service constructor, or a field initializer). The renderer registers immediately, and CopilotKit removes it automatically when the owning component or service is destroyed.
+You call `registerRenderToolCall` inside an Angular injection context (a component or service constructor, or a field initializer). The renderer registers immediately. When the owning injector is destroyed, CopilotKit removes tool and renderer registrations with the same name and optional agent id.
 
-This is the Angular equivalent of React's `useRenderTool()` / `useRenderToolCall()`. If you want to both run a browser handler and render UI, use [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool) with its `component` field instead.
+If you want to run a browser handler and render UI, use [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool) with its `component` field instead.
 
 <Callout type="info">
   Import from the package root, `@copilotkit/angular`. There is no `/v2`
@@ -65,7 +65,7 @@ function registerRenderToolCall<Args extends Record<string, unknown>>(
 
 ## Return Value
 
-`registerRenderToolCall` returns `void`. It registers the renderer as a side effect and wires up automatic cleanup.
+`registerRenderToolCall` returns `void`. It registers the renderer as a side effect and wires up name-and-agent-id cleanup for the owning injector. Frontend tools, human-in-the-loop tools, and renderer registrations sharing that key are removed together.
 
 ## The renderer component
 

--- a/showcase/shell-docs/src/content/reference/angular/index.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/index.mdx
@@ -3,12 +3,12 @@ title: "Angular"
 description: "API reference for @copilotkit/angular: the CopilotKit providers, prebuilt chat components, services, and functions for building CopilotKit into an Angular app."
 ---
 
-`@copilotkit/angular` brings CopilotKit to Angular. It ships a set of [providers](/reference/angular/functions/provideCopilotKit), prebuilt chat components, a `CopilotKit` service, and standalone functions that mirror the React SDK. Everything is built on the [AG-UI](https://docs.ag-ui.com) agent protocol.
+`@copilotkit/angular` provides [providers](/reference/angular/functions/provideCopilotKit), prebuilt chat components, a `CopilotKit` service, and standalone functions for Angular applications. Everything is built on the [AG-UI](https://docs.ag-ui.com) agent protocol.
 
 <Callout type="info">
   The package targets Angular 20, 21, and 22, and ships as standalone components
-  and providers. Import everything from the package root, `@copilotkit/angular`.
-  There is no `/v2` subpath.
+  and providers. Import the main API from `@copilotkit/angular`. MCP Apps uses
+  the `@copilotkit/angular/mcp-apps` entry point. There is no `/v2` subpath.
 </Callout>
 
 ## Installation
@@ -29,7 +29,7 @@ When using the prebuilt UI components, import the stylesheet once in your global
 
 ## Provider setup
 
-CopilotKit is configured through Angular's dependency injection rather than a wrapper component. Add [`provideCopilotKit`](/reference/angular/functions/provideCopilotKit) to your application providers and configure the runtime connection there. Every component, service, and function reads this configuration through the injector, so they must be used within an application (or component) that has the provider in scope.
+Add [`provideCopilotKit`](/reference/angular/functions/provideCopilotKit) to your application providers and configure the runtime connection there. The root `CopilotKit` service reads this application-level configuration.
 
 ```ts title="src/app/app.config.ts"
 import { ApplicationConfig } from "@angular/core";
@@ -79,13 +79,13 @@ export class AppComponent {}
 
 ## Angular conventions
 
-A few patterns recur across this reference and differ from the React SDK:
+CopilotKit follows Angular's dependency-injection and signal patterns:
 
-- **Setup is a provider, not a component.** Where the React SDK wraps your app in `<CopilotKit>`, the Angular SDK registers [`provideCopilotKit`](/reference/angular/functions/provideCopilotKit) in your application or component providers.
-- **State is exposed as signals.** Where React hooks return values that trigger re-renders, the Angular SDK exposes Angular [signals](https://angular.dev/guide/signals). Read them by calling the signal, for example `agentStore().messages()`.
-- **Functions run in an injection context.** Functions such as [`injectAgentStore`](/reference/angular/functions/injectAgentStore), [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool), and [`connectAgentContext`](/reference/angular/functions/connectAgentContext) use Angular's `inject()` under the hood. Call them from a constructor, a field initializer, or another injection context. They clean themselves up when the owning component or service is destroyed.
-- **Components are standalone.** Import the component class into your `imports` array and use its element selector in the template, for example `<copilot-chat>` for [`CopilotChat`](/reference/angular/components/CopilotChat).
-- **Templates and directives replace render props.** Where the React SDK uses render props or `children`, the Angular components accept Angular templates and content projection for the same customization.
+- Register [`provideCopilotKit`](/reference/angular/functions/provideCopilotKit) in application providers.
+- Read reactive state by calling signals such as `agentStore().messages()`.
+- Call injectable helpers from a constructor, field initializer, or another injection context.
+- Import standalone components in the component `imports` array.
+- Customize UI with component inputs, templates, directives, and content projection.
 
 ## Lifecycle and rendering environments
 
@@ -96,9 +96,9 @@ injected controller beyond that injector's lifetime. Application-owned work
 started inside a tool handler, such as a fetch, remains the application's
 responsibility to cancel.
 
-CopilotKit's Angular components use signals and OnPush change detection and are
-tested with `provideZonelessChangeDetection()`. Browser-only behavior is inert
-during server rendering and activates after hydration. Keep configuration and
+CopilotKit's main chat components use signals and support zoneless change
+detection. Browser-only behavior is inert during server rendering and
+activates after hydration. Keep configuration and
 initial model/input values identical for the server and the first client
 render, avoid running agents or tools on the server, and place
 application-owned DOM work behind an Angular platform guard or

--- a/showcase/shell-docs/src/content/reference/angular/production-lifecycle.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/production-lifecycle.mdx
@@ -3,18 +3,19 @@ title: "Production and lifecycle"
 description: "Cleanup, errors, SSR, hydration, and zoneless behavior for @copilotkit/angular."
 ---
 
-`@copilotkit/angular` is signal-first, standalone, OnPush, and compatible with
-zoneless Angular. This page describes the environment and ownership rules that
-apply across the public API.
+`@copilotkit/angular` uses signals and standalone Angular APIs and is compatible
+with zoneless Angular. Most UI components use `OnPush`; `RenderToolCalls`
+currently uses Angular's default change-detection strategy. This page describes
+the environment and ownership rules that apply across the public API.
 
 ## Minimal production setup
 
 ```ts title="src/app/app.config.ts"
 import {
   ApplicationConfig,
-  provideClientHydration,
   provideZonelessChangeDetection,
 } from "@angular/core";
+import { provideClientHydration } from "@angular/platform-browser";
 import { provideCopilotKit } from "@copilotkit/angular";
 
 export const appConfig: ApplicationConfig = {
@@ -39,7 +40,8 @@ Angular injection context. They use the owning `DestroyRef`:
 | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------ |
 | `injectAgentStore`                                                                                          | Agent subscription and signal projection                        | Replaces the subscription when `agentId` changes; unsubscribes on destroy      |
 | `connectAgentContext`                                                                                       | Reactive context registration                                   | Removes the context when the owning effect is destroyed                        |
-| `registerFrontendTool`, `registerRenderToolCall`, `registerHumanInTheLoop`, `registerRenderActivityMessage` | Runtime renderer or tool registration                           | Removes the exact registration on destroy                                      |
+| `registerFrontendTool`, `registerRenderToolCall`, `registerHumanInTheLoop`                                  | Runtime renderer or tool registration                           | Removes registrations matching the same name and optional agent ID on destroy  |
+| `registerRenderActivityMessage`                                                                             | Activity renderer registration                                  | Removes the exact renderer object on destroy                                   |
 | `injectInterrupt`                                                                                           | Agent subscription, pending interrupt state, handler generation | Disconnects and invalidates pending asynchronous handler work on destroy       |
 | `injectThreads`                                                                                             | Store selectors, realtime lifecycle, runtime registration       | Unsubscribes, stops, and unregisters the store on destroy                      |
 | `injectMemories`                                                                                            | RxJS selectors converted to signals                             | Angular's signal interop owns the subscriptions                                |
@@ -55,9 +57,10 @@ manually constructed advanced stores; injected stores clean themselves up.
 
 - Agent lookup throws an error containing the requested agent, runtime URL,
   and known agent IDs after runtime synchronization cannot resolve it.
-- Frontend-tool and renderer input is validated by its Standard Schema before
-  use. Unknown tools remain hidden unless `defaultToolRendering` is explicitly
-  enabled.
+- Activity-renderer content must pass its Standard Schema before rendering.
+  Frontend-tool and tool-call-renderer schemas define advertised JSON Schema and
+  TypeScript types, but runtime arguments are only JSON-parsed. Unknown tools
+  remain hidden unless `defaultToolRendering` is explicitly enabled.
 - Interrupt predicate and preparation failures are exposed on the controller's
   `error` signal. Expired interrupts produce `InterruptExpiredError`. Resume
   failures are not retried automatically.

--- a/showcase/shell-docs/src/content/reference/angular/services/CopilotKit.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/services/CopilotKit.mdx
@@ -7,7 +7,7 @@ description: "The root Angular service that exposes CopilotKit agents, tools, ru
 
 `CopilotKit` is the central injectable service for `@copilotkit/angular`. It is `providedIn: "root"`, so a single instance is shared across your application. It builds and owns the underlying `CopilotKitCore` from the [`CopilotKitConfig`](/reference/angular/functions/provideCopilotKit#parameters) you registered with [`provideCopilotKit`](/reference/angular/functions/provideCopilotKit), exposes reactive runtime state as Angular [signals](https://angular.dev/guide/signals), and provides methods to register tools, manage suggestions, and update the runtime connection.
 
-This is the Angular equivalent of React's `useCopilotKit()`. In most apps you do not call its methods directly. The injectable functions such as [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool), [`registerRenderToolCall`](/reference/angular/functions/registerRenderToolCall), and [`registerHumanInTheLoop`](/reference/angular/functions/registerHumanInTheLoop) wrap it and add automatic cleanup. Inject the service when you need direct access to its signals or the `core` instance.
+In most apps you do not call its methods directly. The injectable functions such as [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool), [`registerRenderToolCall`](/reference/angular/functions/registerRenderToolCall), and [`registerHumanInTheLoop`](/reference/angular/functions/registerHumanInTheLoop) register against the current injector and remove registrations with the same name and optional agent id when that injector is destroyed. Inject the service when you need direct access to its signals or the `core` instance.
 
 ## Accessing the service
 
@@ -54,6 +54,21 @@ All reactive state is exposed as read-only Angular signals. Read a signal by cal
   The HTTP headers currently sent with runtime requests.
 </PropertyReference>
 
+<PropertyReference name="threadEndpoints" type="Signal<ThreadEndpointRuntimeInfo | undefined>">
+  Thread endpoint support advertised by the connected runtime's `/info`
+  response. It is `undefined` until the runtime reports the capability.
+</PropertyReference>
+
+<PropertyReference name="intelligence" type="Signal<IntelligenceRuntimeInfo | undefined>">
+  Intelligence runtime information advertised by `/info`, including the
+  realtime WebSocket URL when available.
+</PropertyReference>
+
+<PropertyReference name="licenseStatus" type="Signal<RuntimeLicenseStatus | undefined>">
+  License status reported by the connected runtime, or `undefined` before the
+  runtime reports it.
+</PropertyReference>
+
 <PropertyReference name="suggestionsByAgent" type="Signal<Record<string, CopilotKitCoreGetSuggestionsResult>>">
   Suggestions keyed by agent id. Each value is
   `{ suggestions: Suggestion[]; isLoading: boolean }`.
@@ -85,30 +100,40 @@ All reactive state is exposed as read-only Angular signals. Read a signal by cal
   or subscribing to core events.
 </PropertyReference>
 
+<PropertyReference name="defaultToolRenderingEnabled" type="boolean">
+  Whether the text-only fallback renderer for otherwise unknown tools was
+  enabled with `defaultToolRendering: true`.
+</PropertyReference>
+
 ## Methods
 
 <PropertyReference name="addFrontendTool" type="(tool: FrontendToolConfig & { injector: Injector }) => void">
   Register a client-side tool. The handler is rebound to run inside the provided
   `injector`, so it can use `inject()`. Prefer
   [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool),
-  which supplies the injector and removes the tool on destroy.
+  which supplies the injector and removes registrations with the same name and
+  optional agent id on destroy.
 </PropertyReference>
 
 <PropertyReference name="addRenderToolCall" type="(renderConfig: RenderToolCallConfig) => void">
   Register a renderer for a tool call. Prefer
   [`registerRenderToolCall`](/reference/angular/functions/registerRenderToolCall)
-  for automatic cleanup.
+  for injector-scoped, name-based cleanup.
 </PropertyReference>
 
 <PropertyReference name="addRenderActivityMessage" type="(renderConfig: RenderActivityMessageConfig) => void">
   Register a renderer for an agent activity message type.
 </PropertyReference>
 
+<PropertyReference name="removeRenderActivityMessage" type="(renderConfig: RenderActivityMessageConfig) => void">
+  Remove a dynamically registered activity renderer by object identity.
+</PropertyReference>
+
 <PropertyReference name="addHumanInTheLoop" type="(humanInTheLoopTool: HumanInTheLoopConfig) => void">
   Register a human-in-the-loop tool. The tool pauses the run until the user
   responds. Prefer
   [`registerHumanInTheLoop`](/reference/angular/functions/registerHumanInTheLoop)
-  for automatic cleanup.
+  for injector-scoped, name-based cleanup.
 </PropertyReference>
 
 <PropertyReference name="addSuggestionsConfig" type="(config: SuggestionsConfig) => string">
@@ -227,7 +252,7 @@ export class SuggestionsComponent {
   />
   <Card
     title="registerFrontendTool"
-    description="Register a client-side tool from a component, with automatic cleanup on destroy."
+    description="Register a client-side tool from an injection context, with name-based cleanup on destroy."
     href="/reference/angular/functions/registerFrontendTool"
   />
   <Card

--- a/showcase/shell-docs/src/lib/__tests__/angular-docs-content.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/angular-docs-content.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+
+function markdownFiles(path: string): string[] {
+  return readdirSync(path, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = join(path, entry.name);
+    if (entry.isDirectory()) return markdownFiles(entryPath);
+    return entry.name.endsWith(".mdx") ? [entryPath] : [];
+  });
+}
+
+test("keeps published Angular docs standalone and canonical", () => {
+  const contentRoot = join(process.cwd(), "src/content");
+  const paths = [
+    join(contentRoot, "docs/frontends/angular.mdx"),
+    join(contentRoot, "docs/cookbook/angular-adk-agentic-app.mdx"),
+    ...markdownFiles(join(contentRoot, "docs/frontends/angular")),
+    ...markdownFiles(join(contentRoot, "reference/angular")),
+  ];
+  const publishedCopy = paths
+    .map((path) => readFileSync(path, "utf8"))
+    .join("\n");
+
+  expect(publishedCopy).not.toMatch(/\bReact\b/);
+  expect(publishedCopy).not.toContain("/frontends/angular");
+});

--- a/showcase/shell-docs/src/lib/__tests__/angular-feature-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/angular-feature-docs.test.ts
@@ -1,31 +1,46 @@
-import { describe, expect, it } from "vitest";
+import { expect, test } from "vitest";
 
 import { getAngularFeatureDocs } from "../angular-feature-docs";
 
-describe("Angular feature docs", () => {
-  it("publishes typed source for every supported feature", () => {
-    const features = getAngularFeatureDocs();
+test("publishes typed source for every supported feature", () => {
+  const features = getAngularFeatureDocs();
 
-    expect(features).toHaveLength(41);
-    for (const feature of features) {
-      expect(feature.state).toBe("supported");
-      const route = `https://showcase.copilotkit.ai/angular/${feature.integration}/${feature.id}`;
-      expect(feature.runHref).toBe(feature.runnable ? route : null);
-      expect(feature.sourceHref).toBe(`${route}/code`);
-      expect(feature.apiHref).toMatch(/^\/reference\/angular/);
-    }
-    expect(
-      features.filter((feature) => !feature.runnable).map(({ id }) => id),
-    ).toEqual(["threadid-frontend-tool-roundtrip"]);
-  });
+  expect(features).toHaveLength(41);
+  for (const feature of features) {
+    expect(feature.state).toBe("supported");
+    const route = `https://showcase.copilotkit.ai/angular/${feature.integration}/${feature.id}`;
+    expect(feature.runHref).toBe(feature.runnable ? route : null);
+    expect(feature.sourceHref).toBe(`${route}/code`);
+    expect(feature.apiHref).toMatch(/^\/reference\/angular/);
+  }
+  expect(
+    features.filter((feature) => !feature.runnable).map(({ id }) => id),
+  ).toEqual(["threadid-frontend-tool-roundtrip"]);
+});
 
-  it("omits CLI, Hashbrown, and JSON Renderer from Angular feature docs", () => {
-    expect(getAngularFeatureDocs().map((feature) => feature.id)).not.toEqual(
-      expect.arrayContaining([
-        "cli-start",
-        "declarative-hashbrown",
-        "declarative-json-render",
-      ]),
-    );
+test("uses standalone Angular names and descriptions", () => {
+  const features = getAngularFeatureDocs();
+  const componentRendering = features.find(
+    (feature) => feature.id === "gen-ui-tool-based",
+  );
+  const renderedCopy = features
+    .flatMap((feature) => [feature.name, feature.description])
+    .join("\n");
+
+  expect(componentRendering).toMatchObject({
+    name: "Generative UI: component rendering",
+    description:
+      "Render typed tool results with registerFrontendTool and a standalone Angular component.",
   });
+  expect(renderedCopy).not.toMatch(/\bReact\b|\buse[A-Z]|<Copilot[A-Z]/);
+});
+
+test("omits CLI, Hashbrown, and JSON Renderer from Angular feature docs", () => {
+  expect(getAngularFeatureDocs().map((feature) => feature.id)).not.toEqual(
+    expect.arrayContaining([
+      "cli-start",
+      "declarative-hashbrown",
+      "declarative-json-render",
+    ]),
+  );
 });

--- a/showcase/shell-docs/src/lib/__tests__/angular-guide-search.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/angular-guide-search.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "vitest";
+
+import searchIndex from "../../data/search-index.json";
+
+test("indexes every Angular task guide at its canonical URL", () => {
+  const hrefs = searchIndex.map((entry) => entry.href);
+
+  expect(hrefs).toEqual(
+    expect.arrayContaining([
+      "/angular/guides/chat-ui",
+      "/angular/guides/frontend-tools-generative-ui",
+      "/angular/guides/human-in-the-loop",
+      "/angular/guides/shared-state",
+      "/angular/guides/threads-memory-attachments-headless",
+    ]),
+  );
+  expect(
+    hrefs.some((href) => href.startsWith("/docs/frontends/angular/guides/")),
+  ).toBe(false);
+});

--- a/showcase/shell-docs/src/lib/__tests__/frontend-options.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/frontend-options.test.ts
@@ -8,6 +8,7 @@ import {
   backendPathForCurrentPath,
   frontendFromPathname,
   frontendPathFor,
+  frontendPathForBackend,
   frontendPathForCurrentPath,
   getFrontendOption,
   isFrontendEarlyAccess,
@@ -58,6 +59,14 @@ function collectPageUrls(tree: PageTree.Root): string[] {
 function renderNavNameToMarkup(name: React.ReactNode): string {
   return renderToStaticMarkup(React.createElement(React.Fragment, null, name));
 }
+
+const angularGuideSlugs = [
+  "guides/chat-ui",
+  "guides/frontend-tools-generative-ui",
+  "guides/human-in-the-loop",
+  "guides/shared-state",
+  "guides/threads-memory-attachments-headless",
+] as const;
 
 test("keeps React as the full docs surface and routes other frontends to their guides", () => {
   expect(frontendPathFor("react")).toBe("/");
@@ -231,6 +240,27 @@ test("gives Angular a standalone feature guide without React fallback", () => {
   expect(getFrontendCanonicalSlug("angular", "docs-status")).toBe(
     "using-these-docs",
   );
+});
+
+test("publishes Angular task guides in unscoped and backend-scoped routes", () => {
+  const pageUrls = collectPageUrls(
+    navTreeToPageTree(getFrontendQuickstartNavTree("angular"), "/angular"),
+  );
+
+  for (const slug of angularGuideSlugs) {
+    expect(pageUrls).toContain(`/angular/${slug}`);
+    expect(resolveFrontendDocPage("angular", slug)).toEqual(
+      expect.objectContaining({
+        status: "found",
+        slugPath: slug,
+        contentSlugPath: `frontends/angular/${slug}`,
+        canonicalPath: `/angular/${slug}`,
+      }),
+    );
+    expect(frontendPathForBackend("angular", slug, "langgraph-python")).toBe(
+      `/angular/langgraph-python/${slug}`,
+    );
+  }
 });
 
 test("routes frontend sidebars to the most specific reference docs available", () => {

--- a/showcase/shell-docs/src/lib/__tests__/frontend-options.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/frontend-options.test.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { describe, expect, it } from "vitest";
+import { expect, test } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import {
@@ -19,6 +19,7 @@ import {
   FRONTEND_GUIDANCE_CONTENT_SLUG,
   FRONTEND_PAGE_IDS,
   getFrontendContentSlug,
+  getFrontendCanonicalSlug,
   getFrontendGuidanceContentSlug,
   getFrontendGuidanceTitle,
   getFrontendReferenceSlug,
@@ -58,282 +59,299 @@ function renderNavNameToMarkup(name: React.ReactNode): string {
   return renderToStaticMarkup(React.createElement(React.Fragment, null, name));
 }
 
-describe("frontend options", () => {
-  it("keeps React as the full docs surface and routes other frontends to their guides", () => {
-    expect(frontendPathFor("react")).toBe("/");
-    expect(frontendPathFor("vue")).toBe("/vue");
-    expect(frontendPathFor("react-native")).toBe("/react-native");
-    expect(frontendPathFor("react", "concepts/architecture")).toBe(
-      "/concepts/architecture",
-    );
-    expect(frontendPathFor("slack", "concepts/architecture")).toBe(
-      "/slack/concepts/architecture",
-    );
-    expect(frontendPathFor("react", "quickstart")).toBe("/");
-    expect(frontendPathFor("react", "using-these-docs")).toBe("/");
-    expect(frontendFromPathname("/vue")).toBe("vue");
-    expect(frontendFromPathname("/vue/concepts/architecture")).toBe("vue");
-    expect(frontendFromPathname("/react")).toBeNull();
-    expect(frontendFromPathname("/frontends/vue")).toBeNull();
-    expect(frontendFromPathname("/langgraph-python/quickstart")).toBeNull();
+test("keeps React as the full docs surface and routes other frontends to their guides", () => {
+  expect(frontendPathFor("react")).toBe("/");
+  expect(frontendPathFor("vue")).toBe("/vue");
+  expect(frontendPathFor("react-native")).toBe("/react-native");
+  expect(frontendPathFor("react", "concepts/architecture")).toBe(
+    "/concepts/architecture",
+  );
+  expect(frontendPathFor("slack", "concepts/architecture")).toBe(
+    "/slack/concepts/architecture",
+  );
+  expect(frontendPathFor("react", "quickstart")).toBe("/");
+  expect(frontendPathFor("react", "using-these-docs")).toBe("/");
+  expect(frontendFromPathname("/vue")).toBe("vue");
+  expect(frontendFromPathname("/vue/concepts/architecture")).toBe("vue");
+  expect(frontendFromPathname("/react")).toBeNull();
+  expect(frontendFromPathname("/frontends/vue")).toBeNull();
+  expect(frontendFromPathname("/langgraph-python/quickstart")).toBeNull();
+});
+
+test("maps picker selections across frontend URL shapes", () => {
+  const backendSlugs = ["built-in-agent", "langgraph-python", "mastra"];
+
+  expect(
+    frontendPathForCurrentPath("slack", "/vue/concepts/architecture"),
+  ).toBe("/slack/concepts/architecture");
+  expect(
+    frontendPathForCurrentPath("react", "/slack/concepts/architecture"),
+  ).toBe("/concepts/architecture");
+  expect(frontendPathForCurrentPath("teams", "/quickstart")).toBe("/teams");
+  expect(
+    frontendPathForCurrentPath(
+      "slack",
+      "/langgraph-python/quickstart",
+      backendSlugs,
+    ),
+  ).toBe("/slack/langgraph-python");
+  expect(
+    frontendPathForCurrentPath(
+      "slack",
+      "/vue/langgraph-python/concepts/architecture",
+      backendSlugs,
+    ),
+  ).toBe("/slack/langgraph-python/concepts/architecture");
+  expect(
+    frontendPathForCurrentPath(
+      "react",
+      "/vue/langgraph-python/concepts/architecture",
+      backendSlugs,
+    ),
+  ).toBe("/langgraph-python/concepts/architecture");
+});
+
+test("parses and builds two-axis frontend/backend routes", () => {
+  const backendSlugs = ["built-in-agent", "langgraph-python", "mastra"];
+
+  expect(
+    parseFrontendRoutePath(
+      "/vue/langgraph-python/concepts/architecture",
+      backendSlugs,
+    ),
+  ).toEqual({
+    frontend: "vue",
+    backend: "langgraph-python",
+    slugPath: "concepts/architecture",
   });
-
-  it("maps picker selections across frontend URL shapes", () => {
-    const backendSlugs = ["built-in-agent", "langgraph-python", "mastra"];
-
-    expect(
-      frontendPathForCurrentPath("slack", "/vue/concepts/architecture"),
-    ).toBe("/slack/concepts/architecture");
-    expect(
-      frontendPathForCurrentPath("react", "/slack/concepts/architecture"),
-    ).toBe("/concepts/architecture");
-    expect(frontendPathForCurrentPath("teams", "/quickstart")).toBe("/teams");
-    expect(
-      frontendPathForCurrentPath(
-        "slack",
-        "/langgraph-python/quickstart",
-        backendSlugs,
-      ),
-    ).toBe("/slack/langgraph-python");
-    expect(
-      frontendPathForCurrentPath(
-        "slack",
-        "/vue/langgraph-python/concepts/architecture",
-        backendSlugs,
-      ),
-    ).toBe("/slack/langgraph-python/concepts/architecture");
-    expect(
-      frontendPathForCurrentPath(
-        "react",
-        "/vue/langgraph-python/concepts/architecture",
-        backendSlugs,
-      ),
-    ).toBe("/langgraph-python/concepts/architecture");
-  });
-
-  it("parses and builds two-axis frontend/backend routes", () => {
-    const backendSlugs = ["built-in-agent", "langgraph-python", "mastra"];
-
-    expect(
-      parseFrontendRoutePath(
-        "/vue/langgraph-python/concepts/architecture",
-        backendSlugs,
-      ),
-    ).toEqual({
-      frontend: "vue",
-      backend: "langgraph-python",
-      slugPath: "concepts/architecture",
-    });
-    expect(
-      parseFrontendRoutePath("/vue/using-these-docs", backendSlugs),
-    ).toEqual({
+  expect(parseFrontendRoutePath("/vue/using-these-docs", backendSlugs)).toEqual(
+    {
       frontend: "vue",
       backend: null,
       slugPath: "using-these-docs",
-    });
-    expect(backendFromPathname("/vue/langgraph-python", backendSlugs)).toBe(
+    },
+  );
+  expect(backendFromPathname("/vue/langgraph-python", backendSlugs)).toBe(
+    "langgraph-python",
+  );
+  expect(backendFromPathname("/langgraph-python", backendSlugs)).toBe(
+    "langgraph-python",
+  );
+  expect(
+    backendPathForCurrentPath(
       "langgraph-python",
-    );
-    expect(backendFromPathname("/langgraph-python", backendSlugs)).toBe(
-      "langgraph-python",
-    );
-    expect(
-      backendPathForCurrentPath(
-        "langgraph-python",
-        "/vue",
-        backendSlugs,
-        "built-in-agent",
-      ),
-    ).toBe("/vue/langgraph-python");
-    expect(
-      backendPathForCurrentPath(
-        "mastra",
-        "/vue/langgraph-python/concepts/architecture",
-        backendSlugs,
-        "built-in-agent",
-      ),
-    ).toBe("/vue/mastra/concepts/architecture");
-    expect(
-      backendPathForCurrentPath(
-        "built-in-agent",
-        "/vue/langgraph-python",
-        backendSlugs,
-        "built-in-agent",
-      ),
-    ).toBe("/vue");
-  });
-
-  it("maps every non-React frontend to an MDX guide page", () => {
-    const nonReactIds = FRONTEND_OPTIONS.filter(
-      (option) => option.id !== "react",
-    ).map((option) => option.id);
-
-    expect(FRONTEND_PAGE_IDS).toEqual(nonReactIds);
-    for (const id of FRONTEND_PAGE_IDS) {
-      expect(isFrontendId(id)).toBe(true);
-      expect(getFrontendOption(id).name).toBeTruthy();
-      expect(getFrontendContentSlug(id)).toBe(`frontends/${id}`);
-      expect(getFrontendUsingTheseDocsPath(id)).toBe(`/${id}/using-these-docs`);
-      expect(loadDoc(getFrontendContentSlug(id))?.fm.title).toBeTruthy();
-    }
-    expect(isFrontendEarlyAccess("vue")).toBe(false);
-    expect(isFrontendEarlyAccess("react-native")).toBe(false);
-    expect(isFrontendEarlyAccess("slack")).toBe(true);
-    expect(isFrontendEarlyAccess("teams")).toBe(true);
-    expect(loadDoc(FRONTEND_GUIDANCE_CONTENT_SLUG)?.fm.title).toBe(
-      "About early access",
-    );
-    expect(loadDoc(FRONTEND_DOCS_STATUS_CONTENT_SLUG)?.fm.title).toBe(
-      "Docs status",
-    );
-    expect(getFrontendGuidanceContentSlug("vue")).toBe(
-      FRONTEND_DOCS_STATUS_CONTENT_SLUG,
-    );
-    expect(getFrontendGuidanceContentSlug("angular")).toBe(
-      "frontends/angular/docs-status",
-    );
-    expect(getFrontendGuidanceContentSlug("slack")).toBe(
-      FRONTEND_GUIDANCE_CONTENT_SLUG,
-    );
-    expect(getFrontendGuidanceTitle("vue")).toBe("Docs status");
-    expect(getFrontendGuidanceTitle("slack")).toBe("About early access");
-    expect(isFrontendEarlyAccess("react")).toBe(false);
-  });
-
-  it("gives Angular a standalone feature guide without React fallback", () => {
-    const guidance = loadDoc(getFrontendGuidanceContentSlug("angular"));
-    const pageUrls = collectPageUrls(
-      navTreeToPageTree(getFrontendQuickstartNavTree("angular"), "/angular"),
-    );
-
-    expect(guidance?.source).not.toMatch(/React/i);
-    expect(pageUrls).toContain("/angular/features");
-    expect(getFrontendQuickstartNavTree("angular")).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ variant: "react-docs-proxy" }),
-      ]),
-    );
-  });
-
-  it("routes frontend sidebars to the most specific reference docs available", () => {
-    expect(getFrontendReferenceSlug("react-native")).toBe(
-      "reference/react-native",
-    );
-    expect(getFrontendReferenceSlug("slack")).toBe("reference/channels");
-    expect(getFrontendReferenceSlug("vue")).toBe("reference");
-    expect(getFrontendReferenceSlug("teams")).toBe("reference");
-  });
-
-  it("keeps the early-access guidance link iconless", () => {
-    const guidanceLink = getFrontendQuickstartNavTree("slack").find(
-      (node) => node.type === "page" && node.title === "About early access",
-    );
-
-    expect(guidanceLink).not.toHaveProperty("icon");
-  });
-
-  it("keeps non-React frontend sidebars limited to quickstart and reference links", () => {
-    const navTree = getFrontendQuickstartNavTree("slack");
-    const flattenedNavTree = flattenNavTree(navTree);
-
-    expect(flattenedNavTree).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: "section",
-          title: "Concepts",
-          variant: "react-docs-proxy",
-        }),
-        expect.objectContaining({
-          type: "page",
-          title: "Architecture",
-          variant: "react-docs-proxy",
-        }),
-      ]),
-    );
-
-    expect(flattenedNavTree).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ variant: "react-docs-proxy" }),
-      ]),
-    );
-
-    const pageUrls = collectPageUrls(navTreeToPageTree(navTree, "/slack"));
-    expect(pageUrls).toEqual([
-      "/slack",
-      "/slack/using-these-docs",
-      "/reference/channels",
-    ]);
-    expect(pageUrls).not.toEqual(
-      expect.arrayContaining([
-        "/concepts/architecture",
-        "/slack/concepts/architecture",
-        "/slack/concepts/which-hook",
-        "/slack/prebuilt-components",
-        "/prebuilt-components",
-      ]),
-    );
-
-    expect(getFrontendQuickstartNavTree("vue")).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: "section",
-          variant: "frontend-docs-upcoming",
-          frontendDocsStatus: "feature-complete",
-        }),
-      ]),
-    );
-    expect(getFrontendQuickstartNavTree("slack")).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: "section",
-          variant: "frontend-docs-upcoming",
-          frontendDocsStatus: "early-access",
-        }),
-      ]),
-    );
-
-    expect(resolveFrontendDocPage("slack", "agentic-protocols")).toEqual(
-      expect.objectContaining({
-        status: "found",
-        slugPath: "agentic-protocols",
-        contentSlugPath: "agentic-protocols",
-        canonicalPath: "/slack/agentic-protocols",
-      }),
-    );
-  });
-
-  it("renders frontend docs status copy by frontend availability", () => {
-    const vueTree = navTreeToPageTree(
-      getFrontendQuickstartNavTree("vue"),
       "/vue",
-    );
-    const slackTree = navTreeToPageTree(
-      getFrontendQuickstartNavTree("slack"),
-      "/slack",
-    );
+      backendSlugs,
+      "built-in-agent",
+    ),
+  ).toBe("/vue/langgraph-python");
+  expect(
+    backendPathForCurrentPath(
+      "mastra",
+      "/vue/langgraph-python/concepts/architecture",
+      backendSlugs,
+      "built-in-agent",
+    ),
+  ).toBe("/vue/mastra/concepts/architecture");
+  expect(
+    backendPathForCurrentPath(
+      "built-in-agent",
+      "/vue/langgraph-python",
+      backendSlugs,
+      "built-in-agent",
+    ),
+  ).toBe("/vue");
+});
 
-    const vueUpcoming = vueTree.children.find(
-      (node) =>
-        node.type === "separator" &&
-        renderNavNameToMarkup(node.name).includes("Guides coming soon"),
-    );
-    const slackUpcoming = slackTree.children.find(
-      (node) =>
-        node.type === "separator" &&
-        renderNavNameToMarkup(node.name).includes("Guides coming soon"),
-    );
+test("maps every non-React frontend to an MDX guide page", () => {
+  const nonReactIds = FRONTEND_OPTIONS.filter(
+    (option) => option.id !== "react",
+  ).map((option) => option.id);
 
-    expect(renderNavNameToMarkup(vueUpcoming?.name)).toContain(
-      "Vue is feature complete, but the docs are still catching up. The ",
-    );
-    expect(renderNavNameToMarkup(vueUpcoming?.name)).toContain(
-      " guides are ready with more guides on the way.",
-    );
-    expect(renderNavNameToMarkup(slackUpcoming?.name)).toContain(
-      "Slack is currently in early access. The ",
-    );
-    expect(renderNavNameToMarkup(slackUpcoming?.name)).toContain(
-      " guides are ready; more are on the way after early access.",
-    );
+  expect(FRONTEND_PAGE_IDS).toEqual(nonReactIds);
+  for (const id of FRONTEND_PAGE_IDS) {
+    expect(isFrontendId(id)).toBe(true);
+    expect(getFrontendOption(id).name).toBeTruthy();
+    expect(getFrontendContentSlug(id)).toBe(`frontends/${id}`);
+    expect(getFrontendUsingTheseDocsPath(id)).toBe(`/${id}/using-these-docs`);
+    expect(loadDoc(getFrontendContentSlug(id))?.fm.title).toBeTruthy();
+  }
+  expect(isFrontendEarlyAccess("vue")).toBe(false);
+  expect(isFrontendEarlyAccess("react-native")).toBe(false);
+  expect(isFrontendEarlyAccess("slack")).toBe(true);
+  expect(isFrontendEarlyAccess("teams")).toBe(true);
+  expect(loadDoc(FRONTEND_GUIDANCE_CONTENT_SLUG)?.fm.title).toBe(
+    "About early access",
+  );
+  expect(loadDoc(FRONTEND_DOCS_STATUS_CONTENT_SLUG)?.fm.title).toBe(
+    "Docs status",
+  );
+  expect(getFrontendGuidanceContentSlug("vue")).toBe(
+    FRONTEND_DOCS_STATUS_CONTENT_SLUG,
+  );
+  expect(getFrontendGuidanceContentSlug("angular")).toBe(
+    "frontends/angular/docs-status",
+  );
+  expect(getFrontendGuidanceContentSlug("slack")).toBe(
+    FRONTEND_GUIDANCE_CONTENT_SLUG,
+  );
+  expect(getFrontendGuidanceTitle("vue")).toBe("Docs status");
+  expect(getFrontendGuidanceTitle("slack")).toBe("About early access");
+  expect(isFrontendEarlyAccess("react")).toBe(false);
+});
+
+test("gives Angular a standalone feature guide without React fallback", () => {
+  const guidance = loadDoc(getFrontendGuidanceContentSlug("angular"));
+  const pageUrls = collectPageUrls(
+    navTreeToPageTree(getFrontendQuickstartNavTree("angular"), "/angular"),
+  );
+
+  expect(guidance?.source).not.toMatch(/React/i);
+  expect(pageUrls).toContain("/angular/features");
+  expect(pageUrls).toContain("/reference/angular");
+  expect(getFrontendQuickstartNavTree("angular")).not.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        variant: expect.stringMatching(
+          /react-docs-proxy|frontend-docs-upcoming/,
+        ),
+      }),
+    ]),
+  );
+  expect(resolveFrontendDocPage("angular", "features")).toEqual(
+    expect.objectContaining({
+      status: "found",
+      slugPath: "features",
+      contentSlugPath: "frontends/angular/features",
+    }),
+  );
+  expect(resolveFrontendDocPage("angular", "concepts/architecture")).toEqual({
+    status: "not-found",
   });
+  expect(getFrontendCanonicalSlug("angular", "docs-status")).toBe(
+    "using-these-docs",
+  );
+});
+
+test("routes frontend sidebars to the most specific reference docs available", () => {
+  expect(getFrontendReferenceSlug("angular")).toBe("reference/angular");
+  expect(getFrontendReferenceSlug("react-native")).toBe(
+    "reference/react-native",
+  );
+  expect(getFrontendReferenceSlug("slack")).toBe("reference/channels");
+  expect(getFrontendReferenceSlug("vue")).toBe("reference");
+  expect(getFrontendReferenceSlug("teams")).toBe("reference");
+});
+
+test("keeps the early-access guidance link iconless", () => {
+  const guidanceLink = getFrontendQuickstartNavTree("slack").find(
+    (node) => node.type === "page" && node.title === "About early access",
+  );
+
+  expect(guidanceLink).not.toHaveProperty("icon");
+});
+
+test("keeps non-React frontend sidebars limited to quickstart and reference links", () => {
+  const navTree = getFrontendQuickstartNavTree("slack");
+  const flattenedNavTree = flattenNavTree(navTree);
+
+  expect(flattenedNavTree).not.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        type: "section",
+        title: "Concepts",
+        variant: "react-docs-proxy",
+      }),
+      expect.objectContaining({
+        type: "page",
+        title: "Architecture",
+        variant: "react-docs-proxy",
+      }),
+    ]),
+  );
+
+  expect(flattenedNavTree).not.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ variant: "react-docs-proxy" }),
+    ]),
+  );
+
+  const pageUrls = collectPageUrls(navTreeToPageTree(navTree, "/slack"));
+  expect(pageUrls).toEqual([
+    "/slack",
+    "/slack/using-these-docs",
+    "/reference/channels",
+  ]);
+  expect(pageUrls).not.toEqual(
+    expect.arrayContaining([
+      "/concepts/architecture",
+      "/slack/concepts/architecture",
+      "/slack/concepts/which-hook",
+      "/slack/prebuilt-components",
+      "/prebuilt-components",
+    ]),
+  );
+
+  expect(getFrontendQuickstartNavTree("vue")).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        type: "section",
+        variant: "frontend-docs-upcoming",
+        frontendDocsStatus: "feature-complete",
+      }),
+    ]),
+  );
+  expect(getFrontendQuickstartNavTree("slack")).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        type: "section",
+        variant: "frontend-docs-upcoming",
+        frontendDocsStatus: "early-access",
+      }),
+    ]),
+  );
+
+  expect(resolveFrontendDocPage("slack", "agentic-protocols")).toEqual(
+    expect.objectContaining({
+      status: "found",
+      slugPath: "agentic-protocols",
+      contentSlugPath: "agentic-protocols",
+      canonicalPath: "/slack/agentic-protocols",
+    }),
+  );
+});
+
+test("renders frontend docs status copy by frontend availability", () => {
+  const vueTree = navTreeToPageTree(
+    getFrontendQuickstartNavTree("vue"),
+    "/vue",
+  );
+  const slackTree = navTreeToPageTree(
+    getFrontendQuickstartNavTree("slack"),
+    "/slack",
+  );
+
+  const vueUpcoming = vueTree.children.find(
+    (node) =>
+      node.type === "separator" &&
+      renderNavNameToMarkup(node.name).includes("Guides coming soon"),
+  );
+  const slackUpcoming = slackTree.children.find(
+    (node) =>
+      node.type === "separator" &&
+      renderNavNameToMarkup(node.name).includes("Guides coming soon"),
+  );
+
+  expect(renderNavNameToMarkup(vueUpcoming?.name)).toContain(
+    "Vue is feature complete, but the docs are still catching up. The ",
+  );
+  expect(renderNavNameToMarkup(vueUpcoming?.name)).toContain(
+    " guides are ready with more guides on the way.",
+  );
+  expect(renderNavNameToMarkup(slackUpcoming?.name)).toContain(
+    "Slack is currently in early access. The ",
+  );
+  expect(renderNavNameToMarkup(slackUpcoming?.name)).toContain(
+    " guides are ready; more are on the way after early access.",
+  );
 });

--- a/showcase/shell-docs/src/lib/__tests__/llm-text.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/llm-text.test.ts
@@ -9,6 +9,11 @@ test("publishes canonical Angular URLs instead of source-tree URLs", () => {
     expect.arrayContaining([
       "angular",
       "angular/features",
+      "angular/guides/chat-ui",
+      "angular/guides/frontend-tools-generative-ui",
+      "angular/guides/human-in-the-loop",
+      "angular/guides/shared-state",
+      "angular/guides/threads-memory-attachments-headless",
       "angular/using-these-docs",
     ]),
   );

--- a/showcase/shell-docs/src/lib/__tests__/llm-text.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/llm-text.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "vitest";
+
+import { getAllLlmPages } from "../llm-text";
+
+test("publishes canonical Angular URLs instead of source-tree URLs", () => {
+  const urls = getAllLlmPages().map((page) => page.url);
+
+  expect(urls).toEqual(
+    expect.arrayContaining([
+      "angular",
+      "angular/features",
+      "angular/using-these-docs",
+    ]),
+  );
+  expect(urls.some((url) => url.startsWith("frontends/angular"))).toBe(false);
+});

--- a/showcase/shell-docs/src/lib/__tests__/reference-discovery.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/reference-discovery.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "vitest";
+import type * as PageTree from "fumadocs-core/page-tree";
+
+import { getAllLlmPages } from "../llm-text";
+import { buildReferencePageTree } from "../reference-items";
+
+function collectPageUrls(tree: PageTree.Root): string[] {
+  const urls: string[] = [];
+
+  function visit(nodes: PageTree.Node[]): void {
+    for (const node of nodes) {
+      if (node.type === "page") urls.push(node.url);
+      if (node.type === "folder") {
+        if (node.index) urls.push(node.index.url);
+        visit(node.children);
+      }
+    }
+  }
+
+  visit(tree.children);
+  return urls;
+}
+
+test("publishes Angular reference guides in navigation and LLM output", () => {
+  const navigationUrls = collectPageUrls(buildReferencePageTree("angular"));
+  const llmUrls = getAllLlmPages().map((page) => page.url);
+
+  expect(navigationUrls).toEqual(
+    expect.arrayContaining([
+      "/reference/angular/public-api",
+      "/reference/angular/production-lifecycle",
+    ]),
+  );
+  expect(llmUrls).toEqual(
+    expect.arrayContaining([
+      "reference/angular/public-api",
+      "reference/angular/production-lifecycle",
+    ]),
+  );
+});

--- a/showcase/shell-docs/src/lib/angular-feature-docs.ts
+++ b/showcase/shell-docs/src/lib/angular-feature-docs.ts
@@ -37,7 +37,15 @@ const API_BY_FEATURE: Record<string, string> = {
 export function getAngularFeatureDocs(): AngularFeatureDoc[] {
   const support = (
     frontendRegistryData as {
-      feature_support: Record<string, { angular: { state: string } }>;
+      feature_support: Record<
+        string,
+        {
+          angular: {
+            state: string;
+            docs?: { name: string; description: string };
+          };
+        }
+      >;
     }
   ).feature_support;
   const features = (
@@ -51,7 +59,7 @@ export function getAngularFeatureDocs(): AngularFeatureDoc[] {
 
   return Object.entries(support)
     .filter(([, declaration]) => declaration.angular.state === "supported")
-    .map(([id]) => {
+    .map(([id, declaration]) => {
       const feature = features.find((candidate) => candidate.id === id);
       const runnableCell = cells.find(
         (candidate) =>
@@ -74,8 +82,9 @@ export function getAngularFeatureDocs(): AngularFeatureDoc[] {
       const route = `https://showcase.copilotkit.ai/angular/${cell.integration}/${id}`;
       return {
         id,
-        name: feature.name,
-        description: feature.description,
+        name: declaration.angular.docs?.name ?? feature.name,
+        description:
+          declaration.angular.docs?.description ?? feature.description,
         state: "supported" as const,
         integration: cell.integration,
         runnable: runnableCell !== undefined,

--- a/showcase/shell-docs/src/lib/frontend-doc-policy.ts
+++ b/showcase/shell-docs/src/lib/frontend-doc-policy.ts
@@ -119,6 +119,21 @@ export function resolveFrontendDocPage(
   const variantDoc = loadDoc(variantContentSlug);
   const policy = getFrontendDocPolicy(slugPath);
 
+  // Angular publishes only its own authored pages. Shared pages can contain
+  // APIs and examples for a different frontend, so they must not appear under
+  // an Angular URL.
+  if (frontend === "angular") {
+    return variantDoc
+      ? {
+          status: "found",
+          slugPath,
+          contentSlugPath: variantContentSlug,
+          canonicalPath: `/${frontend}/${slugPath}`,
+          policy: { kind: "frontend-variant", fallback: "hide" },
+        }
+      : { status: "not-found" };
+  }
+
   if (policy?.kind === "frontend-variant") {
     if (variantDoc) {
       return {

--- a/showcase/shell-docs/src/lib/frontend-page-content.ts
+++ b/showcase/shell-docs/src/lib/frontend-page-content.ts
@@ -8,6 +8,23 @@ export const FRONTEND_PAGE_IDS = FRONTEND_OPTIONS.filter(
   (option) => option.id !== "react",
 ).map((option) => option.id) as FrontendPageId[];
 
+export const ANGULAR_GUIDE_PAGES = [
+  { title: "Chat UI and customization", slug: "guides/chat-ui" },
+  {
+    title: "Frontend tools and generative UI",
+    slug: "guides/frontend-tools-generative-ui",
+  },
+  {
+    title: "Human-in-the-loop and interrupts",
+    slug: "guides/human-in-the-loop",
+  },
+  { title: "Shared state and agent context", slug: "guides/shared-state" },
+  {
+    title: "Threads, memory, attachments, and headless UI",
+    slug: "guides/threads-memory-attachments-headless",
+  },
+] as const;
+
 export function getFrontendContentSlug(id: FrontendPageId): string {
   return `frontends/${id}`;
 }
@@ -56,9 +73,19 @@ export function getFrontendQuickstartNavTree(id: FrontendPageId): NavNode[] {
   const frontendName =
     FRONTEND_OPTIONS.find((option) => option.id === id)?.name ?? id;
 
-  const featureGuides: NavNode[] =
+  const authoredGuides: NavNode[] =
     id === "angular"
-      ? [{ type: "page", title: "Feature examples", slug: "features" }]
+      ? [
+          { type: "page", title: "Feature examples", slug: "features" },
+          { type: "section", title: "Guides", icon: "lucide/BookOpen" },
+          ...ANGULAR_GUIDE_PAGES.map(
+            (guide): NavNode => ({
+              type: "page",
+              title: guide.title,
+              slug: guide.slug,
+            }),
+          ),
+        ]
       : [];
   const upcomingGuides: NavNode[] =
     id === "angular"
@@ -85,7 +112,7 @@ export function getFrontendQuickstartNavTree(id: FrontendPageId): NavNode[] {
       title: getFrontendGuidanceTitle(id),
       slug: "using-these-docs",
     },
-    ...featureGuides,
+    ...authoredGuides,
     {
       type: "page",
       title: "Reference docs",

--- a/showcase/shell-docs/src/lib/frontend-page-content.ts
+++ b/showcase/shell-docs/src/lib/frontend-page-content.ts
@@ -30,10 +30,20 @@ export function getFrontendUsingTheseDocsPath(id: FrontendPageId): string {
   return `/${id}/using-these-docs`;
 }
 
+/** Collapse legacy frontend guide slugs to the public canonical path. */
+export function getFrontendCanonicalSlug(
+  id: FrontendPageId,
+  slugPath: string,
+): string {
+  return id === "angular" && slugPath === "docs-status"
+    ? "using-these-docs"
+    : slugPath;
+}
+
 const FRONTEND_REFERENCE_SLUGS = {
   vue: "reference",
   "react-native": "reference/react-native",
-  angular: "reference",
+  angular: "reference/angular",
   slack: "reference/channels",
   teams: "reference",
 } satisfies Record<FrontendPageId, string>;
@@ -48,8 +58,24 @@ export function getFrontendQuickstartNavTree(id: FrontendPageId): NavNode[] {
 
   const featureGuides: NavNode[] =
     id === "angular"
-      ? [{ type: "page", title: "Feature guides", slug: "features" }]
+      ? [{ type: "page", title: "Feature examples", slug: "features" }]
       : [];
+  const upcomingGuides: NavNode[] =
+    id === "angular"
+      ? []
+      : [
+          {
+            type: "section",
+            title: frontendName,
+            icon: "lucide/RefreshCw",
+            variant: "frontend-docs-upcoming",
+            quickstartHref: `/${id}`,
+            referenceHref: `/${getFrontendReferenceSlug(id)}`,
+            frontendDocsStatus: isFrontendEarlyAccess(id)
+              ? "early-access"
+              : "feature-complete",
+          },
+        ];
 
   return [
     { type: "section", title: "Getting Started", icon: "lucide/Rocket" },
@@ -66,16 +92,6 @@ export function getFrontendQuickstartNavTree(id: FrontendPageId): NavNode[] {
       slug: getFrontendReferenceSlug(id),
       href: `/${getFrontendReferenceSlug(id)}`,
     },
-    {
-      type: "section",
-      title: frontendName,
-      icon: "lucide/RefreshCw",
-      variant: "frontend-docs-upcoming",
-      quickstartHref: `/${id}`,
-      referenceHref: `/${getFrontendReferenceSlug(id)}`,
-      frontendDocsStatus: isFrontendEarlyAccess(id)
-        ? "early-access"
-        : "feature-complete",
-    },
+    ...upcomingGuides,
   ];
 }

--- a/showcase/shell-docs/src/lib/llm-text.ts
+++ b/showcase/shell-docs/src/lib/llm-text.ts
@@ -83,6 +83,20 @@ const SNIPPET_FRAMEWORK_PREFERENCE = [
   "built-in-agent",
 ];
 
+/**
+ * Map Angular frontend source slugs to the URLs served by the docs router.
+ */
+function canonicalDocsUrl(slug: string): string {
+  if (slug === "frontends/angular") return "angular";
+  if (slug === "frontends/angular/docs-status") {
+    return "angular/using-these-docs";
+  }
+  if (slug.startsWith("frontends/angular/")) {
+    return slug.replace(/^frontends\//, "");
+  }
+  return slug;
+}
+
 // -----------------------------------------------------------------------
 // Public types
 // -----------------------------------------------------------------------
@@ -158,7 +172,7 @@ export function getAllLlmPages(): LlmPage[] {
     const overridePath = rootOverrides.get(slug);
     const meta = readMetaFromFile(overridePath ?? filePath);
     push({
-      url: slug,
+      url: canonicalDocsUrl(slug),
       title: meta.title ?? slug,
       description: meta.description,
       filePath: overridePath ?? filePath,

--- a/showcase/shell-docs/src/lib/reference-items.ts
+++ b/showcase/shell-docs/src/lib/reference-items.ts
@@ -41,6 +41,7 @@ export type ReferenceVersion = (typeof REFERENCE_VERSIONS)[number];
 const ROOT_VERSION: ReferenceVersion = "v2";
 
 export const REFERENCE_CATEGORIES = [
+  "Guides",
   "Components",
   "Hooks",
   "Functions",
@@ -76,6 +77,12 @@ const VERSION_SUBDIRS: Record<ReferenceVersion, ReferenceSubdir[]> = {
   angular: ["components", "functions", "services", "directives"],
   core: ["classes", "types", "enums"],
   channels: ["components", "functions", "classes", "types", "slack", "discord"],
+};
+
+const VERSION_TOP_LEVEL_PAGES: Partial<
+  Record<ReferenceVersion, readonly string[]>
+> = {
+  angular: ["public-api", "production-lifecycle"],
 };
 
 const CATEGORY_BY_SUBDIR: Record<ReferenceSubdir, ReferenceCategory> = {
@@ -271,9 +278,45 @@ export function loadReferenceItems(
 export function loadReferenceVersionItems(
   version: ReferenceVersion,
 ): ReferenceItem[] {
-  return VERSION_SUBDIRS[version].flatMap((subdir) =>
-    loadReferenceItems(version, subdir),
+  const topLevelItems = (VERSION_TOP_LEVEL_PAGES[version] ?? []).flatMap(
+    (pageSlug): ReferenceItem[] => {
+      const resolved = resolveReferencePage([version, pageSlug]);
+      if (!resolved) return [];
+
+      let data: Record<string, unknown>;
+      try {
+        ({ data } = matter(resolved.raw));
+      } catch (err) {
+        console.error(
+          `[reference-items] Failed to parse frontmatter in ${resolved.filePath}:`,
+          err,
+        );
+        return [];
+      }
+
+      return [
+        {
+          slug: pageSlug,
+          title:
+            typeof data.title === "string" && data.title.length > 0
+              ? data.title
+              : fallbackTitle(pageSlug),
+          description:
+            typeof data.description === "string" ? data.description : undefined,
+          category: "Guides",
+          version,
+          url: referenceHref(version, pageSlug),
+        },
+      ];
+    },
   );
+
+  return [
+    ...topLevelItems,
+    ...VERSION_SUBDIRS[version].flatMap((subdir) =>
+      loadReferenceItems(version, subdir),
+    ),
+  ];
 }
 
 function itemToPage(item: ReferenceItem): PageTree.Item {


### PR DESCRIPTION
## Summary

- rewrite the Angular quickstart, feature catalog, ADK cookbook, and API reference around Angular patterns and current package behavior
- add task guides for chat UI, frontend tools and generative UI, human-in-the-loop flows, shared state, and threads, memory, attachments, and headless UI
- expose each guide through Angular navigation, search, sitemap, LLM text, canonical routes, and backend-scoped routes
- add guards for Angular-only wording, guide discovery, canonical links, feature metadata, and reference discovery

## Why

The Angular docs added in #6109 did not include task guides and contained examples and lifecycle claims that did not match the current Angular package. This change gives Angular users both API reference pages and task-based paths grounded in the package source.

## Validation

- `npm run test` in `showcase/shell-docs` — 41 files, 195 tests
- `npm run typecheck` in `showcase/shell-docs`
- `npm run lint` in `showcase/shell-docs` — no errors; existing warnings only
- `npm run build` in `showcase/shell-docs` — 221 static pages
- `pnpm nx test @copilotkit/showcase-scripts --skip-nx-cache --output-style=static` — 72 files, 2,321 tests
- `pnpm nx test @copilotkit/angular --skip-nx-cache --output-style=static` — 45 files, 293 tests
- production server smoke test — direct and backend-scoped guide routes returned HTTP 200

Stacked on #6109. Base commit: `cd0b5b4061de07f966b1225f89b9767236d571f8`.