### PR TITLE
fix(showcase): stage Angular assets in deployment images

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -16,6 +16,11 @@ on:
     paths:
       - "showcase/**"
       - "examples/integrations/**"
+      - "packages/a2ui-renderer/**"
+      - "packages/angular/**"
+      - "packages/core/**"
+      - "packages/shared/**"
+      - "packages/web-components/**"
       - ".github/workflows/showcase_build.yml"
       - ".github/workflows/showcase_build_check.yml"
   workflow_dispatch:
@@ -92,6 +97,7 @@ jobs:
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
       has_changes: ${{ steps.build-matrix.outputs.has_changes }}
+      needs_angular: ${{ steps.build-matrix.outputs.needs_angular }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -109,6 +115,13 @@ jobs:
             workflow_config:
               - '.github/workflows/showcase_build.yml'
               - '.github/workflows/showcase_build_check.yml'
+            angular:
+              - 'showcase/angular/**'
+              - 'packages/a2ui-renderer/**'
+              - 'packages/angular/**'
+              - 'packages/core/**'
+              - 'packages/shared/**'
+              - 'packages/web-components/**'
             shell:
               - 'showcase/shell/**'
               - 'showcase/shared/**'
@@ -274,7 +287,14 @@ jobs:
               (.filter_key as $fk | select(
               $dispatch == "all" or
               ($dispatch != "" and $dispatch != "all" and $dispatch == .dispatch_name) or
-              ($dispatch == "" and (($changes | index("workflow_config") != null) or ($changes | index($fk) != null)))
+              ($dispatch == "" and (
+                ($changes | index("workflow_config") != null) or
+                ($changes | index($fk) != null) or
+                (($changes | index("angular") != null) and (
+                  (.context | startswith("showcase/integrations/")) or
+                  .dispatch_name == "shell"
+                ))
+              ))
             ))]
           ')
 
@@ -303,6 +323,7 @@ jobs:
           esac
 
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          echo "needs_angular=$(echo "$MATRIX" | jq -r 'any(.[]; (.context | startswith("showcase/integrations/")))')" >> $GITHUB_OUTPUT
           if [ "$MATRIX" = "[]" ]; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
@@ -349,8 +370,53 @@ jobs:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: npx tsx showcase/scripts/verify-railway-image-refs.ts
 
+  # Build one browser bundle for every selected integration image. Staging
+  # redeploys these GHCR images directly; production promotion pins the same
+  # tested image digest, so both environments receive this exact artifact.
+  build-angular:
+    name: Build canonical Angular browser artifact
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.has_changes == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        if: needs.detect-changes.outputs.needs_angular == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        if: needs.detect-changes.outputs.needs_angular == 'true'
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node
+        if: needs.detect-changes.outputs.needs_angular == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.x
+
+      - name: Install
+        if: needs.detect-changes.outputs.needs_angular == 'true'
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build
+        if: needs.detect-changes.outputs.needs_angular == 'true'
+        run: pnpm nx build @copilotkit/showcase-angular-host
+
+      - name: Upload canonical Angular browser artifact
+        if: needs.detect-changes.outputs.needs_angular == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: showcase-angular-browser-${{ github.sha }}
+          path: showcase/angular/dist/showcase-angular/browser
+          if-no-files-found: error
+          retention-days: 1
+
   build:
-    needs: [detect-changes, check-lockfile, verify-image-refs]
+    needs: [detect-changes, check-lockfile, verify-image-refs, build-angular]
     if: needs.detect-changes.outputs.has_changes == 'true'
     runs-on: depot-ubuntu-24.04-4
     timeout-minutes: ${{ fromJSON(matrix.service.timeout) }}
@@ -381,6 +447,13 @@ jobs:
           # forget.
           lfs: true
           persist-credentials: false
+
+      - name: Download canonical Angular browser artifact
+        if: startsWith(matrix.service.context, 'showcase/integrations/')
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: showcase-angular-browser-${{ github.sha }}
+          path: ${{ runner.temp }}/showcase-angular-browser
 
       - name: Setup Depot
         uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1
@@ -415,6 +488,8 @@ jobs:
           echo "BUILDARGS_EOF" >> $GITHUB_OUTPUT
 
       - name: Copy shared modules into build context
+        env:
+          ANGULAR_BROWSER: ${{ runner.temp }}/showcase-angular-browser
         run: |
           set -euo pipefail
           CONTEXT="${{ matrix.service.context }}"
@@ -451,6 +526,11 @@ jobs:
               fi
             fi
           done
+
+          if [ -L "$CONTEXT/public/angular" ]; then
+            source showcase/scripts/cli/_common.sh
+            stage_angular "$CONTEXT" "$ANGULAR_BROWSER"
+          fi
 
       - name: Build and push
         if: ${{ matrix.service.skip_build != true }}

--- a/.github/workflows/showcase_build_check.yml
+++ b/.github/workflows/showcase_build_check.yml
@@ -9,6 +9,11 @@ on:
   pull_request:
     paths:
       - "showcase/**"
+      - "packages/a2ui-renderer/**"
+      - "packages/angular/**"
+      - "packages/core/**"
+      - "packages/shared/**"
+      - "packages/web-components/**"
       - ".github/workflows/showcase_build.yml"
       - ".github/workflows/showcase_build_check.yml"
 
@@ -28,6 +33,7 @@ jobs:
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
       has_changes: ${{ steps.build-matrix.outputs.has_changes }}
+      needs_angular: ${{ steps.build-matrix.outputs.needs_angular }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -41,6 +47,13 @@ jobs:
             workflow_config:
               - '.github/workflows/showcase_build.yml'
               - '.github/workflows/showcase_build_check.yml'
+            angular:
+              - 'showcase/angular/**'
+              - 'packages/a2ui-renderer/**'
+              - 'packages/angular/**'
+              - 'packages/core/**'
+              - 'packages/shared/**'
+              - 'packages/web-components/**'
             shell:
               - 'showcase/shell/**'
               - 'showcase/shared/**'
@@ -167,19 +180,66 @@ jobs:
               if .build_args_branch == "__GH_REF_NAME__" then .build_args_branch = $ref else . end |
               (.filter_key as $fk | select(
               ($changes | index("workflow_config") != null) or
-              ($changes | index($fk) != null)
+              ($changes | index($fk) != null) or
+              (($changes | index("angular") != null) and (
+                (.context | startswith("showcase/integrations/")) or
+                .dispatch_name == "shell"
+              ))
             ))]
           ')
 
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          echo "needs_angular=$(echo "$MATRIX" | jq -r 'any(.[]; (.context | startswith("showcase/integrations/")))')" >> $GITHUB_OUTPUT
           if [ "$MATRIX" = "[]" ]; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
 
-  build-check:
+  build-angular:
+    name: Build canonical Angular browser artifact
     needs: [detect-changes]
+    if: needs.detect-changes.outputs.has_changes == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        if: needs.detect-changes.outputs.needs_angular == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        if: needs.detect-changes.outputs.needs_angular == 'true'
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node
+        if: needs.detect-changes.outputs.needs_angular == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.x
+
+      - name: Install
+        if: needs.detect-changes.outputs.needs_angular == 'true'
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build
+        if: needs.detect-changes.outputs.needs_angular == 'true'
+        run: pnpm nx build @copilotkit/showcase-angular-host
+
+      - name: Upload canonical Angular browser artifact
+        if: needs.detect-changes.outputs.needs_angular == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: showcase-angular-browser-${{ github.sha }}
+          path: showcase/angular/dist/showcase-angular/browser
+          if-no-files-found: error
+          retention-days: 1
+
+  build-check:
+    needs: [detect-changes, build-angular]
     if: needs.detect-changes.outputs.has_changes == 'true'
     runs-on: depot-ubuntu-24.04-4
     timeout-minutes: ${{ fromJSON(matrix.service.timeout) }}
@@ -197,6 +257,13 @@ jobs:
         with:
           lfs: ${{ matrix.service.lfs }}
           persist-credentials: false
+
+      - name: Download canonical Angular browser artifact
+        if: startsWith(matrix.service.context, 'showcase/integrations/')
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: showcase-angular-browser-${{ github.sha }}
+          path: ${{ runner.temp }}/showcase-angular-browser
 
       - name: Setup Depot
         uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1
@@ -218,6 +285,8 @@ jobs:
           echo "BUILDARGS_EOF" >> $GITHUB_OUTPUT
 
       - name: Copy shared modules into build context
+        env:
+          ANGULAR_BROWSER: ${{ runner.temp }}/showcase-angular-browser
         run: |
           set -euo pipefail
           CONTEXT="${{ matrix.service.context }}"
@@ -250,6 +319,11 @@ jobs:
               fi
             fi
           done
+
+          if [ -L "$CONTEXT/public/angular" ]; then
+            source showcase/scripts/cli/_common.sh
+            stage_angular "$CONTEXT" "$ANGULAR_BROWSER"
+          fi
 
       - name: Build Docker image (no push)
         uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1.18.0

--- a/showcase/scripts/__tests__/angular-integration-hosting.test.ts
+++ b/showcase/scripts/__tests__/angular-integration-hosting.test.ts
@@ -75,6 +75,23 @@ test("stages a bounded same-origin runtime manifest", async () => {
   expect(staging).not.toContain("ANGULAR_BACKEND_URL");
 });
 
+test.each(["showcase_build.yml", "showcase_build_check.yml"])(
+  "materializes the canonical Angular browser artifact in %s",
+  async (workflowFile) => {
+    const workflow = await readFile(
+      resolve(repositoryRoot, ".github/workflows", workflowFile),
+      "utf8",
+    );
+
+    expect(workflow).toContain("needs_angular");
+    expect(workflow).toContain("- 'packages/angular/**'");
+    expect(workflow).toContain('$changes | index("angular")');
+    expect(workflow).toContain("Build canonical Angular browser artifact");
+    expect(workflow).toContain("Download canonical Angular browser artifact");
+    expect(workflow).toContain('stage_angular "$CONTEXT" "$ANGULAR_BROWSER"');
+  },
+);
+
 test("has no dedicated Angular host, image, proxy, or server", async () => {
   const packageJson = JSON.parse(
     await readFile(

--- a/showcase/scripts/cli/_common.sh
+++ b/showcase/scripts/cli/_common.sh
@@ -42,6 +42,31 @@ require_env() {
 
 # ── Docker / Compose helpers ─────────────────────────────────────────────────
 
+stage_angular() {
+  local pkg_dir="${1:?integration context required}"
+  local default_source="$SHOWCASE_ROOT/angular/dist/showcase-angular/browser"
+  local angular_source="${2:-$default_source}"
+  local angular_link="$pkg_dir/public/angular"
+
+  [ -L "$angular_link" ] || return 0
+
+  if [ ! -d "$angular_source" ]; then
+    if [ "$angular_source" != "$default_source" ]; then
+      die "Missing staged Angular browser artifact: $angular_source"
+    fi
+    pnpm --dir "$SHOWCASE_ROOT/angular" build
+  fi
+
+  local integration_id
+  integration_id="$(basename "${pkg_dir%/}")"
+  rm "$angular_link"
+  mkdir -p "$angular_link"
+  cp -R "$angular_source/." "$angular_link/"
+  printf '%s\n' \
+    "globalThis.__COPILOTKIT_SHOWCASE__ = Object.freeze({\"frontendId\":\"angular\",\"integrationId\":\"$integration_id\"});" \
+    > "$angular_link/runtime-config.js"
+}
+
 stage_shared() {
   # Dereference tools/, shared-tools/, and _shared/ symlinks into real copies
   # so Docker COPY can follow them (Docker build contexts can't traverse
@@ -67,25 +92,7 @@ stage_shared() {
     # Angular is built once, then the same static artifact is materialized
     # inside each selected integration context. The staged manifest contains
     # only the frontend and integration IDs; all API traffic stays same-origin.
-    local angular_link="$pkg_dir/public/angular"
-    if [ -L "$angular_link" ]; then
-      local angular_target
-      angular_target="$(readlink "$angular_link")"
-      if [[ "$angular_target" != /* ]]; then
-        angular_target="$(cd "$(dirname "$angular_link")" && pwd)/$angular_target"
-      fi
-      if [ ! -d "$angular_target" ]; then
-        pnpm --dir "$SHOWCASE_ROOT/angular" build
-      fi
-      local integration_id
-      integration_id="$(basename "${pkg_dir%/}")"
-      rm "$angular_link"
-      mkdir -p "$angular_link"
-      rsync -a "$angular_target/" "$angular_link/"
-      printf '%s\n' \
-        "globalThis.__COPILOTKIT_SHOWCASE__ = Object.freeze({\"frontendId\":\"angular\",\"integrationId\":\"$integration_id\"});" \
-        > "$angular_link/runtime-config.js"
-    fi
+    stage_angular "$pkg_dir"
   done
 }
 


### PR DESCRIPTION
## What changed

- Build the canonical Angular browser bundle once when an integration image needs it.
- Download and materialize that bundle inside each integration Docker context.
- Generate the per-integration same-origin runtime config before Depot builds the image.
- Run the same artifact path in the pre-merge build check.
- Rebuild integration images when the Angular host or its workspace dependencies change.

## Why

The deployment workflow copied `public/angular` as a symlink whose target sat outside each integration Docker context. The resulting images had no `/angular/index.html`, so deployed Angular deep links returned 404.

Staging deploys the GHCR images built here. Production promotion pins the same tested image digest, so the fix applies to both environments.

## Validation

- RED: `pnpm nx test @copilotkit/showcase-scripts -- --run __tests__/angular-integration-hosting.test.ts` — 2 new workflow assertions failed before the fix.
- GREEN: the same focused command — 46 tests passed.
- `pnpm nx test @copilotkit/showcase-scripts` — 2,322 tests passed.
- `pnpm nx build @copilotkit/showcase-angular-host` — passed, including browser artifact audit and bundle budget.
- Staged the built artifact for `langgraph-python`, `mastra`, and `ag2`; each contained `index.html` and the correct runtime config.
- `actionlint` passed for both changed workflows after ignoring existing custom-runner and unrelated shellcheck notices.
- `git diff --check` passed.

## Known check

`pnpm nx exec -p @copilotkit/showcase-scripts -- tsc --noEmit -p tsconfig.json` still reports six existing errors in `equivalence-gate.ts`, `generate-search-index.ts`, and `verify-prod-resweep.ts`. This change does not touch those files.