### PR TITLE
chore(deps): widen @anthropic-ai/sdk optional peer range

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -146,7 +146,7 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@anthropic-ai/sdk": "^0.57.0",
+    "@anthropic-ai/sdk": ">=0.57.0",
     "@langchain/aws": ">=0.1.9",
     "@langchain/community": ">=0.3.58",
     "@langchain/core": ">=0.3.66",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3222,7 +3222,7 @@ importers:
         specifier: ^3.0.36
         version: 3.0.36(zod@3.25.76)
       '@anthropic-ai/sdk':
-        specifier: ^0.57.0
+        specifier: '>=0.57.0'
         version: 0.57.0
       '@copilotkit/channels-core':
         specifier: workspace:^


### PR DESCRIPTION
## What

Widens the optional `@anthropic-ai/sdk` peer dependency of `@copilotkit/runtime` from `^0.57.0` to `>=0.57.0`.

## Why

An outside contributor reported that `@copilotkit/runtime` still declares an optional peer of `@anthropic-ai/sdk@^0.57.0`, which conflicts with current SDK versions (e.g. `0.109`) and forces consumers to install with `--legacy-peer-deps`.

The `^0.57.0` caret pins the range within `0.57.x` (since it's a `0.x` version), so any newer minor trips the peer-conflict warning even though the SDK works fine at runtime.

## Safety

The anthropic adapter only relies on stable `@anthropic-ai/sdk` APIs — client construction (`new Anthropic({})`), `messages.create`, and ephemeral `cache_control` — which have been stable across `0.x` releases. The reporter confirms `0.109` works at runtime today; this only removes the false install-time peer conflict.

## Change

One line in `packages/runtime/package.json`:

```diff
-    "@anthropic-ai/sdk": "^0.57.0",
+    "@anthropic-ai/sdk": ">=0.57.0",
```