### PR TITLE
fix(adk): pin working GCP resource detector

### DIFF
--- a/examples/integrations/adk/agent/pyproject.toml
+++ b/examples/integrations/adk/agent/pyproject.toml
@@ -12,4 +12,6 @@ dependencies = [
   "google-genai",
   "ag-ui-adk==0.6.3",
   "ag-ui-protocol==0.1.18",
+  # uv skips transitive prereleases, and the only stable release was yanked.
+  "opentelemetry-resourcedetector-gcp==1.12.0a0",
 ]


### PR DESCRIPTION
## What does this PR do?

Pins `opentelemetry-resourcedetector-gcp==1.12.0a0` in the ADK starter.

`google-adk` accepts prerelease resource-detector versions, but `uv` skips transitive prereleases by default. The only stable candidate, `1.13.0`, was yanked because it breaks imports. That left the ADK starter with no valid dependency set.

The direct pin selects the last working release without allowing prereleases for every dependency. The ADK starter image can build again.

## Related PRs and Issues

- Failing job: https://github.com/CopilotKit/CopilotKit/actions/runs/30027772426/job/89285780349

## Validation

- RED: `docker build --progress=plain -f examples/integrations/adk/Dockerfile examples/integrations/adk` failed at `uv pip install --system -e .` because the requirements were unsatisfiable.
- GREEN: the same command resolved 124 Python packages, installed the pinned detector, built the Next.js app, and exported the image.
- `pnpm nx affected -t lint,check-types,test,build --base=origin/main --head=HEAD` found no affected Nx tasks because this starter is built outside the Nx project graph.
- `oxfmt --check examples/integrations/adk/agent/pyproject.toml` passed.

## Checklist

- [x] I have read the Contribution Guide.
- [x] No documentation change is needed; this restores the existing starter build.
- [x] Allow edits by maintainers is enabled.