### PR TITLE
Prevent legacy chat errors from escaping event handlers

### DIFF
--- a/packages/react-core/src/components/error-boundary/__tests__/error-boundary.test.tsx
+++ b/packages/react-core/src/components/error-boundary/__tests__/error-boundary.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
+import { CopilotErrorBoundary } from "../error-boundary";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+class ConsumerErrorBoundary extends React.Component<
+  React.PropsWithChildren,
+  { error?: Error }
+> {
+  state: { error?: Error } = {};
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) {
+      return <div>Consumer caught: {this.state.error.message}</div>;
+    }
+    return this.props.children;
+  }
+}
+
+function ThrowingChild(): never {
+  throw new Error("render failed");
+}
+
+describe("CopilotErrorBoundary", () => {
+  it("lets non-CopilotKit render errors reach a consumer boundary", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <ConsumerErrorBoundary>
+        <CopilotErrorBoundary>
+          <ThrowingChild />
+        </CopilotErrorBoundary>
+      </ConsumerErrorBoundary>,
+    );
+
+    expect(screen.getByText("Consumer caught: render failed")).toBeTruthy();
+  });
+});

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -68,9 +68,11 @@
     "remark-math": "^6.0.0"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.0",
     "@types/react-syntax-highlighter": "^15.5.7",
     "eslint": "^8.56.0",
+    "jsdom": "^26.1.0",
     "postcss": "^8.4.20",
     "react": "^18.2.0",
     "react-dom": "^19.2.0",

--- a/packages/react-ui/src/components/chat/Chat.tsx
+++ b/packages/react-ui/src/components/chat/Chat.tsx
@@ -743,7 +743,9 @@ export function CopilotChat({
     // Trigger message regenerated event
     triggerObservabilityHook("onMessageRegenerated", messageId);
 
-    reloadMessages(messageId);
+    // The async callback has already surfaced failures through CopilotKit's
+    // error UI. Avoid leaving its rethrown rejection unhandled here.
+    void reloadMessages(messageId).catch(() => {});
   };
 
   const handleCopy = (message: string) => {
@@ -969,7 +971,11 @@ export function CopilotChat({
         >
           {currentSuggestions.length > 0 && (
             <RenderSuggestionsList
-              onSuggestionClick={handleSendMessage}
+              onSuggestionClick={(message) => {
+                // Suggestions are event-handler entry points just like the
+                // text input, so their send promise needs a terminal catch.
+                void handleSendMessage(message).catch(() => {});
+              }}
               suggestions={currentSuggestions}
               isLoading={isLoadingSuggestions}
             />

--- a/packages/react-ui/src/components/chat/Input.test.tsx
+++ b/packages/react-ui/src/components/chat/Input.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
+import { ChatContextProvider } from "./ChatContext";
+import { Input } from "./Input";
+
+Object.defineProperty(window, "matchMedia", {
+  configurable: true,
+  value: vi.fn(() => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })),
+});
+
+vi.mock("@copilotkit/react-core", () => ({
+  useCopilotContext: () => ({
+    copilotApiConfig: { publicApiKey: "test-key" },
+  }),
+  useCopilotChatInternal: () => ({
+    interrupt: null,
+  }),
+}));
+
+vi.mock("../../hooks/use-push-to-talk", () => ({
+  usePushToTalk: () => ({
+    pushToTalkState: "idle",
+    setPushToTalkState: vi.fn(),
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Input", () => {
+  it("handles the promise returned by onSend", () => {
+    const sendPromise = new Promise<never>(() => {});
+    const catchSpy = vi.spyOn(sendPromise, "catch");
+    const onSend = vi.fn(() => sendPromise);
+
+    render(
+      <ChatContextProvider open={true} setOpen={vi.fn()}>
+        <Input inProgress={false} chatReady={true} onSend={onSend} />
+      </ChatContextProvider>,
+    );
+
+    fireEvent.change(screen.getByTestId("copilot-chat-textarea"), {
+      target: { value: "hello" },
+    });
+    fireEvent.click(screen.getByTestId("copilot-send-button"));
+
+    expect(onSend).toHaveBeenCalledWith("hello");
+    expect(catchSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react-ui/src/components/chat/Input.tsx
+++ b/packages/react-ui/src/components/chat/Input.tsx
@@ -47,7 +47,10 @@ export const Input = ({
   const [text, setText] = useState("");
   const send = () => {
     if (inProgress) return;
-    onSend(text);
+    // useCopilotChatInternal reports rejected sends through its error UI before
+    // rethrowing. This component is the final consumer of the promise, so mark
+    // the rejection as handled instead of leaking it from the event handler.
+    void onSend(text).catch(() => {});
     setText("");
 
     textareaRef.current?.focus();

--- a/packages/react-ui/src/hooks/__tests__/use-push-to-talk.test.ts
+++ b/packages/react-ui/src/hooks/__tests__/use-push-to-talk.test.ts
@@ -1,4 +1,29 @@
-import { describe, it, expect, vi } from "vitest";
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { usePushToTalk } from "../use-push-to-talk";
+
+vi.mock("@copilotkit/react-core", () => ({
+  useCopilotContext: () => ({
+    copilotApiConfig: {
+      transcribeAudioUrl: "/transcribe",
+    },
+  }),
+  useCopilotMessagesContext: () => ({
+    messages: [],
+  }),
+}));
+
+vi.mock("@copilotkit/runtime-client-gql", () => ({
+  gqlToAGUI: (messages: unknown[]) => messages,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 /**
  * Tests for the sendFunction handling in usePushToTalk.
@@ -45,5 +70,35 @@ describe("usePushToTalk sendFunction handling", () => {
     }
 
     expect(startReadingFromMessageId).toBe("msg-123");
+  });
+
+  it("handles a rejected send after transcription", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ text: "Hello" }),
+      }),
+    );
+    const sendFunction = vi.fn().mockRejectedValue(new Error("send failed"));
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { result } = renderHook(() =>
+      usePushToTalk({ sendFunction, inProgress: false }),
+    );
+
+    act(() => {
+      result.current.setPushToTalkState("transcribing");
+    });
+
+    await waitFor(() => {
+      expect(sendFunction).toHaveBeenCalledWith("Hello");
+      expect(result.current.pushToTalkState).toBe("idle");
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "Error transcribing or sending audio:",
+      expect.objectContaining({ message: "send failed" }),
+    );
   });
 });

--- a/packages/react-ui/src/hooks/use-push-to-talk.tsx
+++ b/packages/react-ui/src/hooks/use-push-to-talk.tsx
@@ -3,8 +3,9 @@ import {
   useCopilotMessagesContext,
 } from "@copilotkit/react-core";
 import { gqlToAGUI } from "@copilotkit/runtime-client-gql";
-import { Message } from "@copilotkit/shared";
-import { MutableRefObject, useEffect, useRef, useState } from "react";
+import type { Message } from "@copilotkit/shared";
+import type { MutableRefObject } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export const checkMicrophonePermission = async () => {
   try {
@@ -158,18 +159,24 @@ export const usePushToTalk = ({
     } else {
       stopRecording(mediaRecorderRef, mediaStreamRef);
       if (pushToTalkState === "transcribing") {
-        transcribeAudio(
+        void transcribeAudio(
           recordedChunks.current,
           context.copilotApiConfig.transcribeAudioUrl!,
           mediaType,
-        ).then(async (transcription) => {
-          recordedChunks.current = [];
-          setPushToTalkState("idle");
-          const message = await sendFunction(transcription);
-          if (message) {
-            setStartReadingFromMessageId(message.id);
-          }
-        });
+        )
+          .then(async (transcription) => {
+            recordedChunks.current = [];
+            setPushToTalkState("idle");
+            const message = await sendFunction(transcription);
+            if (message) {
+              setStartReadingFromMessageId(message.id);
+            }
+          })
+          .catch((error) => {
+            recordedChunks.current = [];
+            setPushToTalkState("idle");
+            console.error("Error transcribing or sending audio:", error);
+          });
       }
     }
 

--- a/packages/react-ui/vitest.config.mjs
+++ b/packages/react-ui/vitest.config.mjs
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: true,
-    include: ["src/**/*.{test,spec}.ts"],
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
     reporters: [["default", { summary: false }]],
     silent: true,
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3146,6 +3146,9 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.1(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/react':
         specifier: 19.1.8
         version: 19.1.8
@@ -3155,6 +3158,9 @@ importers:
       eslint:
         specifier: ^8.56.0
         version: 8.57.1
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       postcss:
         specifier: ^8.4.20
         version: 8.5.6


### PR DESCRIPTION
## Summary

- terminally handle rejected promises from legacy chat send, suggestion, and regenerate event handlers
- catch push-to-talk transcription/send failures and restore its state to idle
- add regression coverage for the event-handler promise path and for propagation of synchronous render failures to a consumer Error Boundary

## Root cause

React Error Boundaries do not catch errors from event handlers or asynchronous code. CopilotKit's async callback helper reports operational failures through its error UI and then rethrows them so programmatic callers can handle the rejection. The legacy `@copilotkit/react-ui` event handlers invoked those promises without awaiting or catching them, which left failures as unhandled promise rejections in the host application.

This preserves rejection behavior for programmatic hook consumers while making the built-in UI, which is the terminal consumer, handle those rejections.

## User impact

A runtime/send failure triggered through the legacy React chat UI no longer escapes to the host as an unhandled rejection. Consumer Error Boundaries continue to receive synchronous non-CopilotKit render errors.

## Validation

- `pnpm nx run-many -t test check-types --projects=@copilotkit/react-core,@copilotkit/react-ui --excludeTaskDependencies --skip-nx-cache`
- `pnpm nx format:check --files=packages/react-core/src/components/error-boundary/__tests__/error-boundary.test.tsx,packages/react-ui/package.json,packages/react-ui/src/components/chat/Chat.tsx,packages/react-ui/src/components/chat/Input.test.tsx,packages/react-ui/src/components/chat/Input.tsx,packages/react-ui/src/hooks/__tests__/use-push-to-talk.test.ts,packages/react-ui/src/hooks/use-push-to-talk.tsx,packages/react-ui/vitest.config.mjs`
- `pnpm nx run @copilotkit/react-ui:build --skip-nx-cache`
- repository pre-commit gate: tests, publint, and are-the-types-wrong checks for 27 projects