### PR TITLE
fix(showcase): restore Angular runtime parity

### DIFF
--- a/packages/angular/src/lib/components/chat/__tests__/copilot-chat-assistant-message-renderer.spec.ts
+++ b/packages/angular/src/lib/components/chat/__tests__/copilot-chat-assistant-message-renderer.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from "@angular/core/testing";
+import { describe, expect, it } from "vitest";
+import { CopilotChatAssistantMessageRenderer } from "../copilot-chat-assistant-message-renderer";
+
+describe("CopilotChatAssistantMessageRenderer math parsing", () => {
+  function render(content: string): string {
+    TestBed.resetTestingModule();
+    const fixture = TestBed.createComponent(
+      CopilotChatAssistantMessageRenderer,
+    );
+    fixture.componentRef.setInput("content", content);
+    fixture.detectChanges();
+    return fixture.nativeElement.querySelector("div").innerHTML;
+  }
+
+  it("preserves currency ranges as prose", () => {
+    const rendered = render(
+      "United at $349 (departing 08:00) and Delta at $289, both on time.",
+    );
+
+    expect(rendered).toContain("$349");
+    expect(rendered).toContain("$289");
+    expect(rendered).not.toContain('class="katex"');
+  });
+
+  it("renders inline math with non-whitespace delimiters", () => {
+    const rendered = render("Euler's identity is $e^{i\\pi} + 1 = 0$.");
+
+    expect(rendered).toContain('class="katex"');
+    expect(rendered).not.toContain("$e^{i\\pi} + 1 = 0$");
+  });
+
+  it("leaves dollar signs in inline code untouched", () => {
+    const rendered = render("Run `echo $PATH`.");
+
+    expect(rendered).toContain("<code>echo $PATH</code>");
+    expect(rendered).not.toContain('class="katex"');
+  });
+});

--- a/packages/angular/src/lib/components/chat/copilot-chat-assistant-message-renderer.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat-assistant-message-renderer.ts
@@ -18,6 +18,69 @@ import { completePartialMarkdown } from "@copilotkit/core";
 import { copyToClipboard } from "@copilotkit/shared";
 import { injectChatLabels } from "../../chat-config";
 
+function processMathEquationsInHtml(html: string): string {
+  // First, temporarily replace code blocks with placeholders to protect them from math processing
+  const codeBlocks: string[] = [];
+  const placeholder = "___CODE_BLOCK_PLACEHOLDER_";
+
+  // Store code blocks and replace with placeholders
+  html = html.replace(/<pre><code[\s\S]*?<\/code><\/pre>/g, (match) => {
+    const index = codeBlocks.length;
+    codeBlocks.push(match);
+    return `${placeholder}${index}___`;
+  });
+
+  // Also protect inline code
+  const inlineCode: string[] = [];
+  const inlinePlaceholder = "___INLINE_CODE_PLACEHOLDER_";
+  html = html.replace(/<code>[\s\S]*?<\/code>/g, (match) => {
+    const index = inlineCode.length;
+    inlineCode.push(match);
+    return `${inlinePlaceholder}${index}___`;
+  });
+
+  // Process display math $$ ... $$
+  html = html.replace(/\$\$([\s\S]*?)\$\$/g, (match, equation) => {
+    try {
+      return katex.renderToString(equation, {
+        displayMode: true,
+        throwOnError: false,
+      });
+    } catch {
+      return match;
+    }
+  });
+
+  // A closing inline-math delimiter cannot be preceded by whitespace or
+  // followed by a digit. Those delimiter rules keep ordinary currency ranges
+  // such as "$349 ... $289" from becoming one large KaTeX expression.
+  html = html.replace(
+    /(?<!\\)\$(?!\s)([^$\n]*?\S)\$(?!\d)/g,
+    (match, equation) => {
+      try {
+        return katex.renderToString(equation, {
+          displayMode: false,
+          throwOnError: false,
+        });
+      } catch {
+        return match;
+      }
+    },
+  );
+
+  // Restore code blocks
+  codeBlocks.forEach((block, index) => {
+    html = html.replace(`${placeholder}${index}___`, block);
+  });
+
+  // Restore inline code
+  inlineCode.forEach((code, index) => {
+    html = html.replace(`${inlinePlaceholder}${index}___`, code);
+  });
+
+  return html;
+}
+
 @Component({
   standalone: true,
   selector: "copilot-chat-assistant-message-renderer",
@@ -278,65 +341,7 @@ export class CopilotChatAssistantMessageRenderer implements AfterViewInit {
     let html = this.markedInstance!.parse(content) as string;
 
     // Process math equations
-    html = this.processMathEquations(html);
-
-    return html;
-  }
-
-  private processMathEquations(html: string): string {
-    // First, temporarily replace code blocks with placeholders to protect them from math processing
-    const codeBlocks: string[] = [];
-    const placeholder = "___CODE_BLOCK_PLACEHOLDER_";
-
-    // Store code blocks and replace with placeholders
-    html = html.replace(/<pre><code[\s\S]*?<\/code><\/pre>/g, (match) => {
-      const index = codeBlocks.length;
-      codeBlocks.push(match);
-      return `${placeholder}${index}___`;
-    });
-
-    // Also protect inline code
-    const inlineCode: string[] = [];
-    const inlinePlaceholder = "___INLINE_CODE_PLACEHOLDER_";
-    html = html.replace(/<code>[\s\S]*?<\/code>/g, (match) => {
-      const index = inlineCode.length;
-      inlineCode.push(match);
-      return `${inlinePlaceholder}${index}___`;
-    });
-
-    // Process display math $$ ... $$
-    html = html.replace(/\$\$([\s\S]*?)\$\$/g, (match, equation) => {
-      try {
-        return katex.renderToString(equation, {
-          displayMode: true,
-          throwOnError: false,
-        });
-      } catch {
-        return match;
-      }
-    });
-
-    // Process inline math $ ... $
-    html = html.replace(/\$([^$]+)\$/g, (match, equation) => {
-      try {
-        return katex.renderToString(equation, {
-          displayMode: false,
-          throwOnError: false,
-        });
-      } catch {
-        return match;
-      }
-    });
-
-    // Restore code blocks
-    codeBlocks.forEach((block, index) => {
-      html = html.replace(`${placeholder}${index}___`, block);
-    });
-
-    // Restore inline code
-    inlineCode.forEach((code, index) => {
-      html = html.replace(`${inlinePlaceholder}${index}___`, code);
-    });
+    html = processMathEquationsInHtml(html);
 
     return html;
   }

--- a/showcase/angular/src/app/cell-context.test.ts
+++ b/showcase/angular/src/app/cell-context.test.ts
@@ -133,6 +133,21 @@ describe("Angular host browser cell context", () => {
       "/api/copilotkit-a2ui-recovery",
     );
     expect(runtimePathForFeature("open-gen-ui")).toBe("/api/copilotkit-ogui");
+    expect(runtimePathForFeature("beautiful-chat", "built-in-agent")).toBe(
+      "/api/copilotkit",
+    );
+    expect(runtimePathForFeature("headless-complete", "built-in-agent")).toBe(
+      "/api/copilotkit",
+    );
+    expect(runtimePathForFeature("reasoning-custom", "built-in-agent")).toBe(
+      "/api/copilotkit-reasoning",
+    );
+    expect(runtimePathForFeature("reasoning-default", "built-in-agent")).toBe(
+      "/api/copilotkit-reasoning",
+    );
+    expect(
+      runtimePathForFeature("tool-rendering-reasoning-chain", "built-in-agent"),
+    ).toBe("/api/copilotkit-reasoning");
     expect(runtimePathForFeature("javascript:alert(1)")).toBe(
       "/api/copilotkit",
     );

--- a/showcase/angular/src/app/cell-context.test.ts
+++ b/showcase/angular/src/app/cell-context.test.ts
@@ -133,21 +133,17 @@ describe("Angular host browser cell context", () => {
       "/api/copilotkit-a2ui-recovery",
     );
     expect(runtimePathForFeature("open-gen-ui")).toBe("/api/copilotkit-ogui");
-    expect(runtimePathForFeature("beautiful-chat", "built-in-agent")).toBe(
+    expect(runtimePathForFeature("beautiful-chat")).toBe(
+      "/api/copilotkit-beautiful-chat",
+    );
+    expect(runtimePathForFeature("headless-complete")).toBe(
+      "/api/copilotkit-mcp-apps",
+    );
+    expect(runtimePathForFeature("reasoning-custom")).toBe("/api/copilotkit");
+    expect(runtimePathForFeature("reasoning-default")).toBe("/api/copilotkit");
+    expect(runtimePathForFeature("tool-rendering-reasoning-chain")).toBe(
       "/api/copilotkit",
     );
-    expect(runtimePathForFeature("headless-complete", "built-in-agent")).toBe(
-      "/api/copilotkit",
-    );
-    expect(runtimePathForFeature("reasoning-custom", "built-in-agent")).toBe(
-      "/api/copilotkit-reasoning",
-    );
-    expect(runtimePathForFeature("reasoning-default", "built-in-agent")).toBe(
-      "/api/copilotkit-reasoning",
-    );
-    expect(
-      runtimePathForFeature("tool-rendering-reasoning-chain", "built-in-agent"),
-    ).toBe("/api/copilotkit-reasoning");
     expect(runtimePathForFeature("javascript:alert(1)")).toBe(
       "/api/copilotkit",
     );

--- a/showcase/angular/src/app/cell-context.ts
+++ b/showcase/angular/src/app/cell-context.ts
@@ -80,9 +80,28 @@ const RUNTIME_PATHS: Readonly<Record<string, string>> = {
   voice: "/api/copilotkit-voice",
 };
 
+const INTEGRATION_RUNTIME_PATHS: Readonly<Record<string, string>> = {
+  // The in-process BuiltIn runtime intentionally serves these demos from
+  // different endpoints than the external-agent integrations.
+  "built-in-agent/beautiful-chat": "/api/copilotkit",
+  "built-in-agent/headless-complete": "/api/copilotkit",
+  "built-in-agent/reasoning-custom": "/api/copilotkit-reasoning",
+  "built-in-agent/reasoning-default": "/api/copilotkit-reasoning",
+  "built-in-agent/tool-rendering-reasoning-chain": "/api/copilotkit-reasoning",
+};
+
 /** Resolve the existing same-origin runtime route for one feature. */
-export function runtimePathForFeature(feature: string): string {
-  return RUNTIME_PATHS[feature] ?? "/api/copilotkit";
+export function runtimePathForFeature(
+  feature: string,
+  integration?: string,
+): string {
+  return (
+    (integration === undefined
+      ? undefined
+      : INTEGRATION_RUNTIME_PATHS[`${integration}/${feature}`]) ??
+    RUNTIME_PATHS[feature] ??
+    "/api/copilotkit"
+  );
 }
 
 /** Resolve a browser pathname without decoding or accepting extra segments. */
@@ -124,7 +143,7 @@ export function resolveBrowserCell(
     cellId,
     integration,
     feature,
-    runtimeUrl: runtimePathForFeature(feature),
+    runtimeUrl: runtimePathForFeature(feature, integration),
   };
 }
 

--- a/showcase/angular/src/app/cell-context.ts
+++ b/showcase/angular/src/app/cell-context.ts
@@ -80,28 +80,9 @@ const RUNTIME_PATHS: Readonly<Record<string, string>> = {
   voice: "/api/copilotkit-voice",
 };
 
-const INTEGRATION_RUNTIME_PATHS: Readonly<Record<string, string>> = {
-  // The in-process BuiltIn runtime intentionally serves these demos from
-  // different endpoints than the external-agent integrations.
-  "built-in-agent/beautiful-chat": "/api/copilotkit",
-  "built-in-agent/headless-complete": "/api/copilotkit",
-  "built-in-agent/reasoning-custom": "/api/copilotkit-reasoning",
-  "built-in-agent/reasoning-default": "/api/copilotkit-reasoning",
-  "built-in-agent/tool-rendering-reasoning-chain": "/api/copilotkit-reasoning",
-};
-
 /** Resolve the existing same-origin runtime route for one feature. */
-export function runtimePathForFeature(
-  feature: string,
-  integration?: string,
-): string {
-  return (
-    (integration === undefined
-      ? undefined
-      : INTEGRATION_RUNTIME_PATHS[`${integration}/${feature}`]) ??
-    RUNTIME_PATHS[feature] ??
-    "/api/copilotkit"
-  );
+export function runtimePathForFeature(feature: string): string {
+  return RUNTIME_PATHS[feature] ?? "/api/copilotkit";
 }
 
 /** Resolve a browser pathname without decoding or accepting extra segments. */
@@ -143,7 +124,7 @@ export function resolveBrowserCell(
     cellId,
     integration,
     feature,
-    runtimeUrl: runtimePathForFeature(feature, integration),
+    runtimeUrl: runtimePathForFeature(feature),
   };
 }
 

--- a/showcase/angular/src/app/feature-agent.test.ts
+++ b/showcase/angular/src/app/feature-agent.test.ts
@@ -14,16 +14,49 @@ describe("Angular showcase agent selection", () => {
     expect(agentIdForFeature(feature, "langgraph-python")).toBe(agentId);
   });
 
-  it("uses bounded integration-specific agent overrides", () => {
+  it("uses the BuiltIn runtime's default agent for ordinary features", () => {
     expect(agentIdForFeature("beautiful-chat", "google-adk")).toBe(
       "beautiful-chat",
     );
-    expect(agentIdForFeature("agentic-chat", "built-in-agent")).toBe("default");
+    for (const feature of [
+      "agentic-chat",
+      "agent-config",
+      "auth",
+      "beautiful-chat",
+      "frontend-tools",
+      "tool-rendering",
+    ]) {
+      expect(agentIdForFeature(feature, "built-in-agent")).toBe("default");
+    }
+  });
+
+  it.each([
+    ["reasoning-custom", "agentic-chat-reasoning"],
+    ["reasoning-default", "reasoning-default-render"],
+    ["tool-rendering-reasoning-chain", "tool-rendering-reasoning-chain"],
+  ])("preserves BuiltIn's named %s agent", (feature, agentId) => {
+    expect(agentIdForFeature(feature, "built-in-agent")).toBe(agentId);
+  });
+
+  it.each([
+    ["reasoning-custom", "agentic-chat-reasoning"],
+    ["reasoning-default", "reasoning-default-render"],
+  ])("uses LlamaIndex's named %s agent", (feature, agentId) => {
+    expect(agentIdForFeature(feature, "llamaindex")).toBe(agentId);
+  });
+
+  it("preserves PydanticAI's hyphenated frontend-tools agent", () => {
+    expect(agentIdForFeature("frontend-tools", "pydantic-ai")).toBe(
+      "frontend-tools",
+    );
   });
 
   it("uses the feature contract when no integration override exists", () => {
     expect(agentIdForFeature("tool-rendering", "langgraph-python")).toBe(
       "tool-rendering",
+    );
+    expect(agentIdForFeature("reasoning-custom", "langgraph-python")).toBe(
+      "reasoning-custom",
     );
   });
 

--- a/showcase/angular/src/app/feature-agent.test.ts
+++ b/showcase/angular/src/app/feature-agent.test.ts
@@ -1,6 +1,63 @@
 import { describe, expect, it } from "vitest";
 
+import { runtimePathForFeature } from "./cell-context";
 import { agentIdForFeature, threadIdForFeature } from "./feature-agent";
+
+const BUILT_IN_REACT_BINDINGS = [
+  [
+    "a2ui-fixed-schema",
+    "/api/copilotkit-a2ui-fixed-schema",
+    "a2ui-fixed-schema",
+  ],
+  ["a2ui-recovery", "/api/copilotkit-a2ui-recovery", "a2ui-recovery"],
+  ["agent-config", "/api/copilotkit-agent-config", "agent-config-demo"],
+  ["agentic-chat", "/api/copilotkit", "agentic_chat"],
+  ["auth", "/api/copilotkit-auth", "auth-demo"],
+  ["beautiful-chat", "/api/copilotkit-beautiful-chat", "beautiful-chat"],
+  ["chat-customization-css", "/api/copilotkit", "chat-customization-css"],
+  ["chat-slots", "/api/copilotkit", "chat-slots"],
+  [
+    "declarative-gen-ui",
+    "/api/copilotkit-declarative-gen-ui",
+    "declarative-gen-ui",
+  ],
+  ["frontend-tools", "/api/copilotkit", "frontend_tools"],
+  ["frontend-tools-async", "/api/copilotkit", "frontend-tools-async"],
+  ["gen-ui-agent", "/api/copilotkit", "gen-ui-agent"],
+  ["gen-ui-tool-based", "/api/copilotkit", "gen-ui-tool-based"],
+  ["headless-complete", "/api/copilotkit-mcp-apps", "headless-complete"],
+  ["headless-simple", "/api/copilotkit", "headless-simple"],
+  ["hitl-in-app", "/api/copilotkit", "hitl-in-app"],
+  ["hitl-in-chat", "/api/copilotkit", "hitl-in-chat"],
+  ["mcp-apps", "/api/copilotkit-mcp-apps", "mcp-apps"],
+  ["multimodal", "/api/copilotkit-multimodal", "multimodal-demo"],
+  ["open-gen-ui", "/api/copilotkit-ogui", "open-gen-ui"],
+  ["open-gen-ui-advanced", "/api/copilotkit-ogui", "open-gen-ui-advanced"],
+  ["prebuilt-popup", "/api/copilotkit", "prebuilt-popup"],
+  ["prebuilt-sidebar", "/api/copilotkit", "prebuilt-sidebar"],
+  [
+    "readonly-state-agent-context",
+    "/api/copilotkit",
+    "readonly-state-agent-context",
+  ],
+  ["reasoning-custom", "/api/copilotkit", "reasoning-custom"],
+  ["reasoning-default", "/api/copilotkit", "reasoning-default"],
+  ["shared-state-read", "/api/copilotkit", "shared-state-read"],
+  ["shared-state-read-write", "/api/copilotkit", "shared-state-read-write"],
+  ["subagents", "/api/copilotkit", "subagents"],
+  ["tool-rendering", "/api/copilotkit", "tool-rendering"],
+  [
+    "tool-rendering-custom-catchall",
+    "/api/copilotkit",
+    "tool-rendering-custom-catchall",
+  ],
+  [
+    "tool-rendering-default-catchall",
+    "/api/copilotkit",
+    "tool-rendering-default-catchall",
+  ],
+  ["voice", "/api/copilotkit-voice", "voice-demo"],
+] as const;
 
 describe("Angular showcase agent selection", () => {
   it.each([
@@ -14,29 +71,13 @@ describe("Angular showcase agent selection", () => {
     expect(agentIdForFeature(feature, "langgraph-python")).toBe(agentId);
   });
 
-  it("uses the BuiltIn runtime's default agent for ordinary features", () => {
-    expect(agentIdForFeature("beautiful-chat", "google-adk")).toBe(
-      "beautiful-chat",
-    );
-    for (const feature of [
-      "agentic-chat",
-      "agent-config",
-      "auth",
-      "beautiful-chat",
-      "frontend-tools",
-      "tool-rendering",
-    ]) {
-      expect(agentIdForFeature(feature, "built-in-agent")).toBe("default");
-    }
-  });
-
-  it.each([
-    ["reasoning-custom", "agentic-chat-reasoning"],
-    ["reasoning-default", "reasoning-default-render"],
-    ["tool-rendering-reasoning-chain", "tool-rendering-reasoning-chain"],
-  ])("preserves BuiltIn's named %s agent", (feature, agentId) => {
-    expect(agentIdForFeature(feature, "built-in-agent")).toBe(agentId);
-  });
+  it.each(BUILT_IN_REACT_BINDINGS)(
+    "matches React's BuiltIn binding for %s",
+    (feature, runtimeUrl, agentId) => {
+      expect(runtimePathForFeature(feature)).toBe(runtimeUrl);
+      expect(agentIdForFeature(feature, "built-in-agent")).toBe(agentId);
+    },
+  );
 
   it.each([
     ["reasoning-custom", "agentic-chat-reasoning"],

--- a/showcase/angular/src/app/feature-agent.ts
+++ b/showcase/angular/src/app/feature-agent.ts
@@ -10,8 +10,16 @@ const AGENT_BY_FEATURE: Readonly<Record<string, string>> = {
   voice: "voice-demo",
 };
 
+const BUILT_IN_AGENT_OVERRIDES: Readonly<Record<string, string>> = {
+  "reasoning-custom": "agentic-chat-reasoning",
+  "reasoning-default": "reasoning-default-render",
+  "tool-rendering-reasoning-chain": "tool-rendering-reasoning-chain",
+};
+
 const INTEGRATION_AGENT_OVERRIDES: Readonly<Record<string, string>> = {
-  "built-in-agent/agentic-chat": "default",
+  "llamaindex/reasoning-custom": "agentic-chat-reasoning",
+  "llamaindex/reasoning-default": "reasoning-default-render",
+  "pydantic-ai/frontend-tools": "frontend-tools",
 };
 
 const THREAD_ID_OVERRIDES: Readonly<Record<string, string>> = {
@@ -23,11 +31,15 @@ export function agentIdForFeature(
   feature: string,
   integration: string,
 ): string {
-  return (
-    INTEGRATION_AGENT_OVERRIDES[`${integration}/${feature}`] ??
-    AGENT_BY_FEATURE[feature] ??
-    feature
-  );
+  if (integration === "built-in-agent") {
+    return BUILT_IN_AGENT_OVERRIDES[feature] ?? "default";
+  }
+  const integrationOverride =
+    INTEGRATION_AGENT_OVERRIDES[`${integration}/${feature}`];
+  if (integrationOverride) {
+    return integrationOverride;
+  }
+  return AGENT_BY_FEATURE[feature] ?? feature;
 }
 
 /** Resolve the generated agent identifier for an activated Showcase route. */

--- a/showcase/angular/src/app/feature-agent.ts
+++ b/showcase/angular/src/app/feature-agent.ts
@@ -1,4 +1,3 @@
-import type { ActivatedRoute } from "@angular/router";
 import { integrationId } from "./runtime-context";
 
 const AGENT_BY_FEATURE: Readonly<Record<string, string>> = {
@@ -8,12 +7,6 @@ const AGENT_BY_FEATURE: Readonly<Record<string, string>> = {
   "frontend-tools": "frontend_tools",
   multimodal: "multimodal-demo",
   voice: "voice-demo",
-};
-
-const BUILT_IN_AGENT_OVERRIDES: Readonly<Record<string, string>> = {
-  "reasoning-custom": "agentic-chat-reasoning",
-  "reasoning-default": "reasoning-default-render",
-  "tool-rendering-reasoning-chain": "tool-rendering-reasoning-chain",
 };
 
 const INTEGRATION_AGENT_OVERRIDES: Readonly<Record<string, string>> = {
@@ -31,9 +24,6 @@ export function agentIdForFeature(
   feature: string,
   integration: string,
 ): string {
-  if (integration === "built-in-agent") {
-    return BUILT_IN_AGENT_OVERRIDES[feature] ?? "default";
-  }
   const integrationOverride =
     INTEGRATION_AGENT_OVERRIDES[`${integration}/${feature}`];
   if (integrationOverride) {
@@ -42,11 +32,8 @@ export function agentIdForFeature(
   return AGENT_BY_FEATURE[feature] ?? feature;
 }
 
-/** Resolve the generated agent identifier for an activated Showcase route. */
-export function agentIdForRoute(
-  feature: string,
-  _route: ActivatedRoute,
-): string {
+/** Resolve the backend agent for the integration hosting this Angular app. */
+export function agentIdForCurrentIntegration(feature: string): string {
   return agentIdForFeature(feature, integrationId());
 }
 

--- a/showcase/angular/src/app/features/a2ui/a2ui-catalogs.test.ts
+++ b/showcase/angular/src/app/features/a2ui/a2ui-catalogs.test.ts
@@ -13,6 +13,34 @@ describe("a2uiConfigForFeature", () => {
     expect(declarative?.catalog?.components.has("DataTable")).toBe(true);
   });
 
+  it("matches the React layout alignment contract", () => {
+    const catalog = a2uiConfigForFeature("declarative-gen-ui")?.catalog;
+    const rowSchema = catalog?.components.get("Row")?.schema;
+    const columnSchema = catalog?.components.get("Column")?.schema;
+
+    expect(
+      rowSchema?.safeParse({
+        gap: 16,
+        align: "baseline",
+        justify: "spaceBetween",
+        children: [],
+      }).success,
+    ).toBe(true);
+    expect(
+      rowSchema?.safeParse({
+        align: "sideways",
+        justify: "around",
+        children: [],
+      }).success,
+    ).toBe(false);
+    expect(
+      columnSchema?.safeParse({ align: "stretch", children: [] }).success,
+    ).toBe(true);
+    expect(
+      columnSchema?.safeParse({ align: "sideways", children: [] }).success,
+    ).toBe(false);
+  });
+
   it("provides the fixed flight schema only on its dedicated route", () => {
     const fixed = a2uiConfigForFeature("a2ui-fixed-schema");
 

--- a/showcase/angular/src/app/features/a2ui/a2ui-catalogs.ts
+++ b/showcase/angular/src/app/features/a2ui/a2ui-catalogs.ts
@@ -10,15 +10,19 @@ const declarativeDefinitions = {
   Row: {
     props: z.object({
       gap: z.number().optional(),
-      align: z.string().optional(),
-      justify: z.string().optional(),
+      align: z
+        .enum(["start", "center", "end", "stretch", "baseline"])
+        .optional(),
+      justify: z.enum(["start", "center", "end", "spaceBetween"]).optional(),
       children: z.array(z.string()),
     }),
   },
   Column: {
     props: z.object({
       gap: z.number().optional(),
-      align: z.string().optional(),
+      align: z
+        .enum(["start", "center", "end", "stretch", "baseline"])
+        .optional(),
       children: z.array(z.string()),
     }),
   },

--- a/showcase/angular/src/app/features/agent-state/agent-state-feature.component.ts
+++ b/showcase/angular/src/app/features/agent-state/agent-state-feature.component.ts
@@ -8,7 +8,7 @@ import {
 import { ActivatedRoute } from "@angular/router";
 import { injectAgentStore, registerRenderToolCall } from "@copilotkit/angular";
 
-import { agentIdForRoute } from "../../feature-agent";
+import { agentIdForCurrentIntegration } from "../../feature-agent";
 import { FeatureHeaderComponent } from "../feature-header.component";
 import { ShowcaseChatHostComponent } from "../showcase-chat-host.component";
 import {
@@ -100,7 +100,7 @@ export class AgentStateFeatureComponent {
   protected readonly feature =
     (this.route.snapshot.data["feature"] as string | undefined) ??
     "gen-ui-agent";
-  private readonly agentId = agentIdForRoute(this.feature, this.route);
+  private readonly agentId = agentIdForCurrentIntegration(this.feature);
   protected readonly plannerTranscriptChildren =
     AgentStateTranscriptChildrenComponent;
   // @region[subagent-delegation-state]

--- a/showcase/angular/src/app/features/app-settings/app-settings-feature.component.ts
+++ b/showcase/angular/src/app/features/app-settings/app-settings-feature.component.ts
@@ -9,7 +9,7 @@ import {
 import { ActivatedRoute } from "@angular/router";
 import { connectAgentContext, CopilotKit } from "@copilotkit/angular";
 
-import { agentIdForRoute } from "../../feature-agent";
+import { agentIdForCurrentIntegration } from "../../feature-agent";
 import { FeatureHeaderComponent } from "../feature-header.component";
 import { ShowcaseChatHostComponent } from "../showcase-chat-host.component";
 import {
@@ -107,7 +107,7 @@ export class AppSettingsFeatureComponent {
   // @region[agent-config-context]
   protected readonly config = signal<AgentConfig>({ ...DEFAULT_AGENT_CONFIG });
   protected readonly authHeaders = DEMO_AUTH_HEADERS;
-  protected readonly agentId = agentIdForRoute(this.feature, this.route);
+  protected readonly agentId = agentIdForCurrentIntegration(this.feature);
   private readonly configContext = computed(() => ({
     description:
       "Agent response preferences. Apply tone, expertise level, and response length to every reply.",

--- a/showcase/angular/src/app/features/beautiful-chat/beautiful-chat-feature.component.ts
+++ b/showcase/angular/src/app/features/beautiful-chat/beautiful-chat-feature.component.ts
@@ -9,10 +9,8 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  inject,
   signal,
 } from "@angular/core";
-import { ActivatedRoute } from "@angular/router";
 import {
   injectAgentStore,
   registerFrontendTool,
@@ -23,7 +21,7 @@ import {
 import { mcpAppsActivityRendererConfig } from "@copilotkit/angular/mcp-apps";
 import { z } from "zod";
 
-import { agentIdForRoute } from "../../feature-agent";
+import { agentIdForCurrentIntegration } from "../../feature-agent";
 import { FeatureHeaderComponent } from "../feature-header.component";
 import { SHOWCASE_MCP_APPS_PROVIDER } from "../generated-ui/mcp-apps-provider";
 import { ShowcaseChatHostComponent } from "../showcase-chat-host.component";
@@ -197,8 +195,7 @@ const chartParameters = z.object({
 export class BeautifulChatFeatureComponent {
   protected readonly mode = signal<"chat" | "app">("chat");
   protected readonly attachments = ATTACHMENTS;
-  private readonly route = inject(ActivatedRoute);
-  private readonly agentId = agentIdForRoute("beautiful-chat", this.route);
+  private readonly agentId = agentIdForCurrentIntegration("beautiful-chat");
   private readonly agentStore = injectAgentStore(this.agentId);
   protected readonly todos = computed(() =>
     readBeautifulTodos(this.agentStore().state()),

--- a/showcase/angular/src/app/features/chat-slots-feature.component.ts
+++ b/showcase/angular/src/app/features/chat-slots-feature.component.ts
@@ -5,6 +5,7 @@ import {
   ViewContainerRef,
   inject,
   input,
+  inputBinding,
 } from "@angular/core";
 import { CopilotChat } from "@copilotkit/angular";
 
@@ -55,9 +56,16 @@ export class ChatSlotsFeatureComponent implements AfterViewInit {
   private readonly chatHost = inject(ViewContainerRef);
 
   ngAfterViewInit(): void {
-    const chat = createDynamicComponent(this.chatHost, CopilotChat);
-    chat.setInput("agentId", agentIdForCurrentIntegration("chat-slots"));
-    chat.setInput("assistantMessageComponent", CustomAssistantMessageComponent);
+    const agentId = agentIdForCurrentIntegration("chat-slots");
+    const chat = createDynamicComponent(this.chatHost, CopilotChat, {
+      bindings: [
+        inputBinding("agentId", () => agentId),
+        inputBinding(
+          "assistantMessageComponent",
+          () => CustomAssistantMessageComponent,
+        ),
+      ],
+    });
     renderDynamicComponent(chat);
   }
 }

--- a/showcase/angular/src/app/features/chat-slots-feature.component.ts
+++ b/showcase/angular/src/app/features/chat-slots-feature.component.ts
@@ -2,12 +2,17 @@ import type { AfterViewInit } from "@angular/core";
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
+  Injector,
   ViewContainerRef,
   inject,
   input,
   inputBinding,
 } from "@angular/core";
-import { CopilotChat } from "@copilotkit/angular";
+import {
+  CopilotChat,
+  provideCopilotChatConfiguration,
+} from "@copilotkit/angular";
 
 import { agentIdForCurrentIntegration } from "../feature-agent";
 import { FeatureHeaderComponent } from "./feature-header.component";
@@ -54,10 +59,18 @@ export class CustomAssistantMessageComponent {
 })
 export class ChatSlotsFeatureComponent implements AfterViewInit {
   private readonly chatHost = inject(ViewContainerRef);
+  private readonly injector = inject(Injector);
+  private readonly destroyRef = inject(DestroyRef);
 
   ngAfterViewInit(): void {
     const agentId = agentIdForCurrentIntegration("chat-slots");
+    const childInjector = Injector.create({
+      parent: this.injector,
+      providers: [...provideCopilotChatConfiguration({ agentId })],
+    });
+    this.destroyRef.onDestroy(() => childInjector.destroy());
     const chat = createDynamicComponent(this.chatHost, CopilotChat, {
+      injector: childInjector,
       bindings: [
         inputBinding("agentId", () => agentId),
         inputBinding(

--- a/showcase/angular/src/app/features/chat-slots-feature.component.ts
+++ b/showcase/angular/src/app/features/chat-slots-feature.component.ts
@@ -7,9 +7,8 @@ import {
   input,
 } from "@angular/core";
 import { CopilotChat } from "@copilotkit/angular";
-import { ActivatedRoute } from "@angular/router";
 
-import { agentIdForRoute } from "../feature-agent";
+import { agentIdForCurrentIntegration } from "../feature-agent";
 import { FeatureHeaderComponent } from "./feature-header.component";
 import {
   createDynamicComponent,
@@ -54,11 +53,10 @@ export class CustomAssistantMessageComponent {
 })
 export class ChatSlotsFeatureComponent implements AfterViewInit {
   private readonly chatHost = inject(ViewContainerRef);
-  private readonly route = inject(ActivatedRoute);
 
   ngAfterViewInit(): void {
     const chat = createDynamicComponent(this.chatHost, CopilotChat);
-    chat.setInput("agentId", agentIdForRoute("chat-slots", this.route));
+    chat.setInput("agentId", agentIdForCurrentIntegration("chat-slots"));
     chat.setInput("assistantMessageComponent", CustomAssistantMessageComponent);
     renderDynamicComponent(chat);
   }

--- a/showcase/angular/src/app/features/headless/headless-chat.ts
+++ b/showcase/angular/src/app/features/headless/headless-chat.ts
@@ -1,8 +1,7 @@
 import { DestroyRef, computed, inject, signal } from "@angular/core";
-import { ActivatedRoute } from "@angular/router";
 import { CopilotKit, injectAgentStore } from "@copilotkit/angular";
 
-import { agentIdForRoute } from "../../feature-agent";
+import { agentIdForCurrentIntegration } from "../../feature-agent";
 import type { ShowcaseMessage } from "./headless-chat.types";
 
 // @region[headless-chat-controller]
@@ -19,8 +18,7 @@ export abstract class HeadlessChatController {
   protected readonly isRunning = computed(() => this.agentStore().isRunning());
 
   protected constructor(feature: string) {
-    const route = inject(ActivatedRoute);
-    this.agentStore = injectAgentStore(agentIdForRoute(feature, route));
+    this.agentStore = injectAgentStore(agentIdForCurrentIntegration(feature));
   }
 
   protected updateInput(event: Event): void {

--- a/showcase/angular/src/app/features/headless/headless-complete-feature.component.ts
+++ b/showcase/angular/src/app/features/headless/headless-complete-feature.component.ts
@@ -95,7 +95,11 @@ export class HeadlessRevenueCard {
   template: `
     <showcase-feature-header />
     <main class="headless-page" aria-label="Complete headless chat">
-      <section class="headless-panel">
+      <section
+        class="headless-panel"
+        data-testid="copilot-chat"
+        [attr.data-copilot-running]="isRunning()"
+      >
         <h2>Headless Chat (Complete)</h2>
         <div class="headless-messages" aria-live="polite">
           @for (message of messages(); track message.id) {
@@ -192,6 +196,7 @@ export class HeadlessCompleteFeatureComponent extends HeadlessChatController {
         text: z.string(),
         color: z.string().optional(),
       }),
+      followUp: false,
       handler: async ({ text, color }) => ({ text, color: color ?? "yellow" }),
     });
   }

--- a/showcase/angular/src/app/features/interrupt/interrupt-feature.component.ts
+++ b/showcase/angular/src/app/features/interrupt/interrupt-feature.component.ts
@@ -11,7 +11,7 @@ import { injectInterrupt, registerHumanInTheLoop } from "@copilotkit/angular";
 import type { HumanInTheLoopConfig } from "@copilotkit/angular";
 import { z } from "zod";
 
-import { agentIdForRoute } from "../../feature-agent";
+import { agentIdForCurrentIntegration } from "../../feature-agent";
 import { integrationId } from "../../runtime-context";
 import { FeatureHeaderComponent } from "../feature-header.component";
 import { ShowcaseChatHostComponent } from "../showcase-chat-host.component";
@@ -126,7 +126,7 @@ export class InterruptFeatureComponent {
     (this.route.snapshot.data["feature"] as string | undefined) ??
     "gen-ui-interrupt";
   protected readonly isHeadless = this.feature === "interrupt-headless";
-  private readonly agentId = agentIdForRoute(this.feature, this.route);
+  private readonly agentId = agentIdForCurrentIntegration(this.feature);
   protected readonly controller = injectInterrupt({ agentId: this.agentId });
   protected readonly payload = computed(() =>
     parseInterruptPayload(this.controller.event()?.value),

--- a/showcase/angular/src/app/features/interrupt/interrupt-feature.component.ts
+++ b/showcase/angular/src/app/features/interrupt/interrupt-feature.component.ts
@@ -2,16 +2,28 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  effect,
   inject,
+  signal,
 } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
-import { injectInterrupt } from "@copilotkit/angular";
+import { injectInterrupt, registerHumanInTheLoop } from "@copilotkit/angular";
+import type { HumanInTheLoopConfig } from "@copilotkit/angular";
+import { z } from "zod";
 
 import { agentIdForRoute } from "../../feature-agent";
+import { integrationId } from "../../runtime-context";
 import { FeatureHeaderComponent } from "../feature-header.component";
 import { ShowcaseChatHostComponent } from "../showcase-chat-host.component";
+import { TimePickerCard } from "../tools/hitl-cards";
+import { usesFrontendSchedulingTool } from "./interrupt-mode";
 import { parseInterruptPayload } from "./interrupt-payload";
 import type { InterruptSlot } from "./interrupt-payload";
+
+type ScheduleMeetingArgs = {
+  topic: string;
+  attendee?: string;
+};
 
 @Component({
   selector: "showcase-interrupt-feature",
@@ -80,7 +92,7 @@ import type { InterruptSlot } from "./interrupt-payload";
           <article class="interrupt-picker" data-testid="time-picker-card">
             <span>Pick a time</span>
             <h2>{{ payload().topic }}</h2>
-            @if (pickedLabel; as label) {
+            @if (pickedLabel(); as label) {
               <p data-testid="time-picker-picked">Booked {{ label }}</p>
             } @else {
               <div class="interrupt-slots">
@@ -119,11 +131,38 @@ export class InterruptFeatureComponent {
   protected readonly payload = computed(() =>
     parseInterruptPayload(this.controller.event()?.value),
   );
-  protected pickedLabel: string | null = null;
+  protected readonly pickedLabel = signal<string | null>(null);
+  private lastInterruptEvent: object | null = null;
+
+  constructor() {
+    effect(() => {
+      const event = this.controller.event();
+      if (event && event !== this.lastInterruptEvent) {
+        this.lastInterruptEvent = event;
+        this.pickedLabel.set(null);
+      }
+    });
+
+    if (usesFrontendSchedulingTool(this.feature, integrationId())) {
+      const config: HumanInTheLoopConfig<ScheduleMeetingArgs> = {
+        agentId: this.agentId,
+        name: "schedule_meeting",
+        description:
+          "Ask the user to pick a meeting time and return the selected slot.",
+        parameters: z.object({
+          topic: z.string(),
+          attendee: z.string().optional(),
+        }),
+        component:
+          TimePickerCard as unknown as HumanInTheLoopConfig<ScheduleMeetingArgs>["component"],
+      };
+      registerHumanInTheLoop(config);
+    }
+  }
 
   /** Resolve the active decision while retaining its visible confirmation. */
   protected resolve(slot: InterruptSlot): void {
-    this.pickedLabel = slot.label;
+    this.pickedLabel.set(slot.label);
     this.controller
       .resolve({
         chosen_time: slot.iso,

--- a/showcase/angular/src/app/features/interrupt/interrupt-mode.test.ts
+++ b/showcase/angular/src/app/features/interrupt/interrupt-mode.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { usesFrontendSchedulingTool } from "./interrupt-mode";
+
+describe("usesFrontendSchedulingTool", () => {
+  it("selects Google ADK's frontend-tool interrupt strategy", () => {
+    expect(usesFrontendSchedulingTool("gen-ui-interrupt", "google-adk")).toBe(
+      true,
+    );
+  });
+
+  it("preserves native interrupts and unrelated Google ADK features", () => {
+    expect(usesFrontendSchedulingTool("gen-ui-interrupt", "mastra")).toBe(
+      false,
+    );
+    expect(usesFrontendSchedulingTool("hitl-in-chat", "google-adk")).toBe(
+      false,
+    );
+  });
+});

--- a/showcase/angular/src/app/features/interrupt/interrupt-mode.test.ts
+++ b/showcase/angular/src/app/features/interrupt/interrupt-mode.test.ts
@@ -13,6 +13,9 @@ describe("usesFrontendSchedulingTool", () => {
     expect(usesFrontendSchedulingTool("gen-ui-interrupt", "mastra")).toBe(
       false,
     );
+    expect(
+      usesFrontendSchedulingTool("gen-ui-interrupt", "built-in-agent"),
+    ).toBe(false);
     expect(usesFrontendSchedulingTool("hitl-in-chat", "google-adk")).toBe(
       false,
     );

--- a/showcase/angular/src/app/features/interrupt/interrupt-mode.ts
+++ b/showcase/angular/src/app/features/interrupt/interrupt-mode.ts
@@ -1,0 +1,15 @@
+const FRONTEND_TOOL_SCHEDULING_INTEGRATIONS = new Set(["google-adk"]);
+
+/**
+ * Identify backends that implement the interrupt demo with a frontend
+ * `schedule_meeting` tool instead of emitting an AG-UI interrupt event.
+ */
+export function usesFrontendSchedulingTool(
+  feature: string,
+  integration: string,
+): boolean {
+  return (
+    feature === "gen-ui-interrupt" &&
+    FRONTEND_TOOL_SCHEDULING_INTEGRATIONS.has(integration)
+  );
+}

--- a/showcase/angular/src/app/features/media/media-feature.component.ts
+++ b/showcase/angular/src/app/features/media/media-feature.component.ts
@@ -18,7 +18,7 @@ import {
 } from "@copilotkit/angular";
 import { z } from "zod";
 
-import { agentIdForRoute } from "../../feature-agent";
+import { agentIdForCurrentIntegration } from "../../feature-agent";
 import { FeatureHeaderComponent } from "../feature-header.component";
 import { ShowcaseChatHostComponent } from "../showcase-chat-host.component";
 import { WeatherToolCard } from "../tools/tool-cards";
@@ -209,7 +209,7 @@ export class MediaFeatureComponent {
   private readonly chatHost = viewChild.required(ShowcaseChatHostComponent);
   protected readonly feature =
     (this.route.snapshot.data["feature"] as string | undefined) ?? "voice";
-  protected readonly agentId = agentIdForRoute(this.feature, this.route);
+  protected readonly agentId = agentIdForCurrentIntegration(this.feature);
   private readonly agentStore = injectAgentStore(this.agentId);
   protected readonly voiceSampleText = VOICE_SAMPLE_TEXT;
   protected readonly samples = SAMPLES;

--- a/showcase/angular/src/app/features/render-dynamic-component.test.ts
+++ b/showcase/angular/src/app/features/render-dynamic-component.test.ts
@@ -7,6 +7,7 @@ import type {
 import {
   EnvironmentInjector as EnvironmentInjectorToken,
   inject,
+  inputBinding,
   InjectionToken,
   Injector,
 } from "@angular/core";
@@ -76,6 +77,40 @@ describe("renderDynamicComponent", () => {
       ),
     ).toBe(component);
     expect(createComponent).toHaveBeenCalledWith(DynamicComponent, {
+      environmentInjector,
+    });
+  });
+
+  it("forwards initial input bindings into component creation", () => {
+    const environmentInjector = {} as EnvironmentInjector;
+    const injector = Injector.create({
+      providers: [
+        {
+          provide: EnvironmentInjectorToken,
+          useValue: environmentInjector,
+        },
+      ],
+    });
+    class DynamicComponent {
+      readonly marker = "dynamic";
+    }
+    const component = {} as ComponentRef<DynamicComponent>;
+    const createComponent = vi.fn(() => component);
+    const container = {
+      injector,
+      createComponent,
+    } as unknown as ViewContainerRef;
+    const bindings = [inputBinding("agentId", () => "named-agent")];
+
+    expect(
+      createDynamicComponent(
+        container,
+        DynamicComponent as Type<DynamicComponent>,
+        { bindings },
+      ),
+    ).toBe(component);
+    expect(createComponent).toHaveBeenCalledWith(DynamicComponent, {
+      bindings,
       environmentInjector,
     });
   });

--- a/showcase/angular/src/app/features/render-dynamic-component.ts
+++ b/showcase/angular/src/app/features/render-dynamic-component.ts
@@ -1,4 +1,5 @@
 import type {
+  Binding,
   ComponentRef,
   Injector,
   Type,
@@ -10,7 +11,7 @@ import { EnvironmentInjector, runInInjectionContext } from "@angular/core";
 export function createDynamicComponent<T>(
   container: ViewContainerRef,
   component: Type<T>,
-  options?: { injector?: Injector },
+  options?: { injector?: Injector; bindings?: Binding[] },
 ): ComponentRef<T> {
   const creationOptions = {
     ...options,

--- a/showcase/angular/src/app/features/showcase-chat-host.component.ts
+++ b/showcase/angular/src/app/features/showcase-chat-host.component.ts
@@ -9,6 +9,7 @@ import {
   ViewContainerRef,
   inject,
   input,
+  inputBinding,
 } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import {
@@ -64,27 +65,28 @@ export class ShowcaseChatHostComponent implements AfterViewInit {
     if (childInjector) {
       this.destroyRef.onDestroy(() => childInjector.destroy());
     }
-    const chat = createDynamicComponent(this.viewContainer, CopilotChat, {
-      injector: childInjector,
-    });
-    this.chat = chat;
     const feature =
       (this.route.snapshot.data["feature"] as string | undefined) ?? "default";
-    chat.setInput(
-      "agentId",
-      this.agentId() ?? agentIdForCurrentIntegration(feature),
-    );
+    const agentId = this.agentId() ?? agentIdForCurrentIntegration(feature);
     const threadId = threadIdForFeature(feature);
-    if (threadId !== undefined) chat.setInput("threadId", threadId);
-    chat.setInput(
-      "reasoningMessageComponent",
-      this.reasoningMessageComponent(),
-    );
-    chat.setInput(
-      "messageViewChildrenComponent",
-      this.messageViewChildrenComponent(),
-    );
-    chat.setInput("attachments", this.attachments());
+    const bindings = [
+      inputBinding("agentId", () => agentId),
+      inputBinding("reasoningMessageComponent", () =>
+        this.reasoningMessageComponent(),
+      ),
+      inputBinding("messageViewChildrenComponent", () =>
+        this.messageViewChildrenComponent(),
+      ),
+      inputBinding("attachments", () => this.attachments()),
+    ];
+    if (threadId !== undefined) {
+      bindings.push(inputBinding("threadId", () => threadId));
+    }
+    const chat = createDynamicComponent(this.viewContainer, CopilotChat, {
+      ...(childInjector ? { injector: childInjector } : {}),
+      bindings,
+    });
+    this.chat = chat;
     renderDynamicComponent(chat);
   }
 

--- a/showcase/angular/src/app/features/showcase-chat-host.component.ts
+++ b/showcase/angular/src/app/features/showcase-chat-host.component.ts
@@ -15,6 +15,7 @@ import { ActivatedRoute } from "@angular/router";
 import {
   CopilotChat,
   CopilotKit,
+  provideCopilotChatConfiguration,
   provideCopilotChatLabels,
 } from "@copilotkit/angular";
 
@@ -53,22 +54,24 @@ export class ShowcaseChatHostComponent implements AfterViewInit {
     if (headers) {
       this.injector.get(CopilotKit).updateRuntime({ headers });
     }
-    const placeholder = this.chatPlaceholder();
-    const childInjector = placeholder
-      ? Injector.create({
-          parent: this.injector,
-          providers: [
-            provideCopilotChatLabels({ chatInputPlaceholder: placeholder }),
-          ],
-        })
-      : undefined;
-    if (childInjector) {
-      this.destroyRef.onDestroy(() => childInjector.destroy());
-    }
     const feature =
       (this.route.snapshot.data["feature"] as string | undefined) ?? "default";
     const agentId = this.agentId() ?? agentIdForCurrentIntegration(feature);
     const threadId = threadIdForFeature(feature);
+    const placeholder = this.chatPlaceholder();
+    const childInjector = Injector.create({
+      parent: this.injector,
+      providers: [
+        ...provideCopilotChatConfiguration({
+          agentId,
+          ...(threadId !== undefined ? { threadId } : {}),
+        }),
+        ...(placeholder
+          ? [provideCopilotChatLabels({ chatInputPlaceholder: placeholder })]
+          : []),
+      ],
+    });
+    this.destroyRef.onDestroy(() => childInjector.destroy());
     const bindings = [
       inputBinding("agentId", () => agentId),
       inputBinding("reasoningMessageComponent", () =>
@@ -83,7 +86,7 @@ export class ShowcaseChatHostComponent implements AfterViewInit {
       bindings.push(inputBinding("threadId", () => threadId));
     }
     const chat = createDynamicComponent(this.viewContainer, CopilotChat, {
-      ...(childInjector ? { injector: childInjector } : {}),
+      injector: childInjector,
       bindings,
     });
     this.chat = chat;

--- a/showcase/angular/src/app/features/showcase-chat-host.component.ts
+++ b/showcase/angular/src/app/features/showcase-chat-host.component.ts
@@ -17,7 +17,10 @@ import {
   provideCopilotChatLabels,
 } from "@copilotkit/angular";
 
-import { agentIdForRoute, threadIdForFeature } from "../feature-agent";
+import {
+  agentIdForCurrentIntegration,
+  threadIdForFeature,
+} from "../feature-agent";
 import {
   createDynamicComponent,
   renderDynamicComponent,
@@ -69,7 +72,7 @@ export class ShowcaseChatHostComponent implements AfterViewInit {
       (this.route.snapshot.data["feature"] as string | undefined) ?? "default";
     chat.setInput(
       "agentId",
-      this.agentId() ?? agentIdForRoute(feature, this.route),
+      this.agentId() ?? agentIdForCurrentIntegration(feature),
     );
     const threadId = threadIdForFeature(feature);
     if (threadId !== undefined) chat.setInput("threadId", threadId);

--- a/showcase/angular/src/app/features/state/state-feature.component.ts
+++ b/showcase/angular/src/app/features/state/state-feature.component.ts
@@ -13,7 +13,7 @@ import {
   injectAgentStore,
 } from "@copilotkit/angular";
 
-import { agentIdForRoute } from "../../feature-agent";
+import { agentIdForCurrentIntegration } from "../../feature-agent";
 import { FeatureHeaderComponent } from "../feature-header.component";
 import { ShowcaseChatHostComponent } from "../showcase-chat-host.component";
 import { ACTIVITIES, ContextPanelComponent } from "./context-panel.component";
@@ -171,7 +171,7 @@ export class StateFeatureComponent {
   protected readonly feature =
     (this.route.snapshot.data["feature"] as string | undefined) ??
     "shared-state-read-write";
-  private readonly agentId = agentIdForRoute(this.feature, this.route);
+  private readonly agentId = agentIdForCurrentIntegration(this.feature);
   private readonly agentStore = injectAgentStore(this.agentId);
   protected readonly isRunning = computed(() => this.agentStore().isRunning());
   protected readonly readWriteState = computed(() =>

--- a/showcase/harness/src/cli/frontend-matrix-ci.ts
+++ b/showcase/harness/src/cli/frontend-matrix-ci.ts
@@ -13,6 +13,7 @@ import {
 } from "../probes/frontend-matrix-ci.js";
 import type { FrontendMatrixAggregateReport } from "../probes/frontend-matrix-ci.js";
 import {
+  evaluateCurrentFrontendParity,
   evaluateFrontendParity,
   frontendParityCellsFromAggregate,
 } from "../probes/frontend-parity-gate.js";
@@ -30,6 +31,7 @@ import {
   buildMeasuredShardPlan,
   createFrontendMatrixArtifact,
   executeFrontendMatrixShard,
+  mergeFrontendMatrixShardArtifacts,
 } from "../probes/frontend-matrix-runner.js";
 import type {
   FrontendMatrixArtifact,
@@ -274,9 +276,17 @@ function createProgram(): Command {
     .option("--concurrency <n>", "parallel isolated cells", positiveInteger, 4)
     .action(async (options) => {
       const shardIndex = Number(options.shardIndex);
-      const matrix = await loadMatrix(options.catalog, options);
+      const matrix = await loadMatrix(options.catalog, {
+        integration: options.integration,
+        features: options.features,
+      });
       const plan = await readJson<MeasuredShardPlan>(options.plan);
-      const cells = selectFrontendMatrixShard(matrix, plan, shardIndex);
+      const plannedCells = selectFrontendMatrixShard(matrix, plan, shardIndex);
+      const cells = options.frontend
+        ? plannedCells.filter(
+            (cell) => cell.frontend === (options.frontend as RunnableFrontend),
+          )
+        : plannedCells;
       const integrationBaseUrl = new URL(
         options.integrationBaseUrl,
       ).href.replace(/\/$/, "");
@@ -326,6 +336,29 @@ function createProgram(): Command {
     });
 
   program
+    .command("merge-shard")
+    .description(
+      "Merge independently executed frontend phases for one logical shard",
+    )
+    .requiredOption(
+      "--inputs <files>",
+      "comma-separated frontend phase artifacts",
+      commaSeparatedValues,
+    )
+    .requiredOption("--output <file>")
+    .action(async (options) => {
+      const artifacts = await Promise.all(
+        (options.inputs as string[]).map((file) =>
+          readJson<FrontendMatrixArtifact>(file),
+        ),
+      );
+      await writeJson(
+        options.output,
+        mergeFrontendMatrixShardArtifacts(artifacts),
+      );
+    });
+
+  program
     .command("aggregate")
     .requiredOption("--artifacts <directory>")
     .requiredOption("--output <file>")
@@ -353,6 +386,39 @@ function createProgram(): Command {
       if (report.summary.p95ShardWallTimeMs > P95_WALL_TIME_LIMIT_MS) {
         process.exitCode = 1;
       }
+    });
+
+  program
+    .command("pair")
+    .description("Compare React and Angular at one exact source revision")
+    .requiredOption("--pull-request <file>", "verified aggregate report")
+    .requiredOption("--output <file>")
+    .option("--integration <slug>", "limit comparison to one integration")
+    .option(
+      "--features <slugs>",
+      "limit comparison to comma-separated feature slugs",
+      commaSeparatedValues,
+    )
+    .action(async (options) => {
+      const pullRequest = await readJson<FrontendMatrixAggregateReport>(
+        options.pullRequest,
+      );
+      const cells = scopeByIntegrationAndFeature(
+        frontendParityCellsFromAggregate(pullRequest),
+        {
+          integration: options.integration,
+          features: options.features,
+        },
+      );
+      const report = evaluateCurrentFrontendParity({
+        sourceCommit: pullRequest.sourceCommit,
+        cells,
+      });
+      await writeJson(options.output, report);
+      console.log(
+        `Classified ${report.comparisons.length} current-revision frontend pairs; ${report.passed ? "no Angular regressions" : "blocking Angular regressions found"}.`,
+      );
+      if (!report.passed) process.exitCode = 1;
     });
 
   program

--- a/showcase/harness/src/cli/lifecycle.test.ts
+++ b/showcase/harness/src/cli/lifecycle.test.ts
@@ -5,10 +5,28 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 // are available inside the factory closures. We capture every
 // `docker compose ...` invocation by recording execFileSync calls.
 // ---------------------------------------------------------------------------
-const { execFileSyncMock, execSyncMock, existsSyncMock } = vi.hoisted(() => ({
+const {
+  execFileSyncMock,
+  execSyncMock,
+  existsSyncMock,
+  readdirSyncMock,
+  lstatSyncMock,
+  readlinkSyncMock,
+  statSyncMock,
+  rmSyncMock,
+  cpSyncMock,
+  writeFileSyncMock,
+} = vi.hoisted(() => ({
   execFileSyncMock: vi.fn(),
   execSyncMock: vi.fn(),
   existsSyncMock: vi.fn(),
+  readdirSyncMock: vi.fn(),
+  lstatSyncMock: vi.fn(),
+  readlinkSyncMock: vi.fn(),
+  statSyncMock: vi.fn(),
+  rmSyncMock: vi.fn(),
+  cpSyncMock: vi.fn(),
+  writeFileSyncMock: vi.fn(),
 }));
 
 vi.mock("node:child_process", () => ({
@@ -23,7 +41,13 @@ vi.mock("node:fs", () => {
   // for health checks; provide stub ports for any slug the up() tests use.
   const api = {
     existsSync: (...args: unknown[]) => existsSyncMock(...args),
-    readdirSync: vi.fn(() => []),
+    readdirSync: (...args: unknown[]) => readdirSyncMock(...args),
+    lstatSync: (...args: unknown[]) => lstatSyncMock(...args),
+    readlinkSync: (...args: unknown[]) => readlinkSyncMock(...args),
+    statSync: (...args: unknown[]) => statSyncMock(...args),
+    rmSync: (...args: unknown[]) => rmSyncMock(...args),
+    cpSync: (...args: unknown[]) => cpSyncMock(...args),
+    writeFileSync: (...args: unknown[]) => writeFileSyncMock(...args),
     readFileSync: vi.fn(() =>
       JSON.stringify({
         "langgraph-python": 10001,
@@ -35,7 +59,7 @@ vi.mock("node:fs", () => {
   return { default: api, ...api };
 });
 
-import { rebuild, up } from "./lifecycle.js";
+import { down, rebuild, stageSharedModules, up } from "./lifecycle.js";
 
 /** Pull out the compose argv (after the `-f <file>` prefix) for each call. */
 function composeCalls(): string[][] {
@@ -50,10 +74,57 @@ beforeEach(() => {
   execFileSyncMock.mockReset();
   execSyncMock.mockReset();
   existsSyncMock.mockReset();
+  readdirSyncMock.mockReset();
+  lstatSyncMock.mockReset();
+  readlinkSyncMock.mockReset();
+  statSyncMock.mockReset();
+  rmSyncMock.mockReset();
+  cpSyncMock.mockReset();
+  writeFileSyncMock.mockReset();
   // No integrations dir → stageSharedModules() is a no-op.
   existsSyncMock.mockReturnValue(false);
+  readdirSyncMock.mockReturnValue([]);
   // Default: compose returns empty string.
   execFileSyncMock.mockReturnValue("");
+});
+
+describe("stageSharedModules() — Angular browser artifact", () => {
+  it("materializes the Angular browser build inside each integration context", () => {
+    existsSyncMock.mockImplementation((candidate: unknown) => {
+      const value = String(candidate);
+      return (
+        value.endsWith("/showcase/integrations") ||
+        value.endsWith("/showcase/angular/dist/showcase-angular/browser")
+      );
+    });
+    readdirSyncMock.mockReturnValue([
+      {
+        name: "langgraph-python",
+        isDirectory: () => true,
+      },
+    ]);
+    lstatSyncMock.mockImplementation((candidate: unknown) => ({
+      isSymbolicLink: () => String(candidate).endsWith("/public/angular"),
+    }));
+
+    stageSharedModules();
+
+    expect(rmSyncMock).toHaveBeenCalledWith(
+      expect.stringMatching(/integrations\/langgraph-python\/public\/angular$/),
+    );
+    expect(cpSyncMock).toHaveBeenCalledWith(
+      expect.stringMatching(/angular\/dist\/showcase-angular\/browser$/),
+      expect.stringMatching(/integrations\/langgraph-python\/public\/angular$/),
+      { recursive: true },
+    );
+    expect(writeFileSyncMock).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /integrations\/langgraph-python\/public\/angular\/runtime-config\.js$/,
+      ),
+      expect.stringContaining('"integrationId":"langgraph-python"'),
+      "utf-8",
+    );
+  });
 });
 
 describe("rebuild() — targeted slugs", () => {
@@ -98,6 +169,21 @@ describe("rebuild() — targeted slugs", () => {
     );
     expect(recreateCall).toContain("a");
     expect(recreateCall).toContain("b");
+  });
+});
+
+describe("down() — targeted slugs", () => {
+  it("loads the infra profile so integration dependencies resolve", async () => {
+    await down(["ag2"]);
+
+    expect(composeCalls()).toContainEqual([
+      "--profile",
+      "infra",
+      "--profile",
+      "ag2",
+      "stop",
+      "ag2",
+    ]);
   });
 });
 

--- a/showcase/harness/src/cli/lifecycle.ts
+++ b/showcase/harness/src/cli/lifecycle.ts
@@ -20,6 +20,13 @@ const COMPOSE_FILE =
   process.env.SHOWCASE_COMPOSE_FILE ||
   path.join(SHOWCASE_DIR, "docker-compose.local.yml");
 const INTEGRATIONS_DIR = path.join(SHOWCASE_DIR, "integrations");
+const ANGULAR_BROWSER_DIR = path.join(
+  SHOWCASE_DIR,
+  "angular",
+  "dist",
+  "showcase-angular",
+  "browser",
+);
 // Honor LOCAL_PORTS_FILE env var (set by isolation overlay) so the harness
 // reads offset ports from a temp file instead of the checked-in original.
 const PORTS_FILE =
@@ -134,11 +141,13 @@ function resolveHealthEndpoint(service: string): string {
 // ---------------------------------------------------------------------------
 
 /**
- * For each integration package directory, replace `tools`, `shared-tools`, and
- * `_shared` symlinks with real directory copies so Docker can access them
- * inside the build context. This mirrors the `stage_shared()` function in
- * dev-local.sh. `_shared` carries the single-source CVDIAG bootstrap module
- * (`showcase/integrations/_shared/`) into each Python integration's context.
+ * For each integration package directory, replace `tools`, `shared-tools`,
+ * `_shared`, and `public/angular` symlinks with real directory copies so
+ * Docker can access them inside the build context. This mirrors
+ * `stage_shared()` in `scripts/cli/_common.sh`. `_shared` carries the
+ * single-source CVDIAG bootstrap module (`showcase/integrations/_shared/`)
+ * into each Python integration's context, while `public/angular` carries one
+ * shared Angular browser build into every integration image.
  */
 export function stageSharedModules(): void {
   log.info("staging shared modules for Docker build contexts");
@@ -192,6 +201,45 @@ export function stageSharedModules(): void {
         from: target,
       });
     }
+
+    const angularLink = path.join(pkgDir, "public", "angular");
+    let angularIsSymlink = false;
+    try {
+      angularIsSymlink = fs.lstatSync(angularLink).isSymbolicLink();
+    } catch {
+      // Missing Angular link means this package does not host the shared app.
+    }
+    if (!angularIsSymlink) continue;
+
+    if (!fs.existsSync(ANGULAR_BROWSER_DIR)) {
+      log.info("building shared Angular browser artifact");
+      execFileSync(
+        "pnpm",
+        ["nx", "run", "@copilotkit/showcase-angular-host:build"],
+        {
+          cwd: path.dirname(SHOWCASE_DIR),
+          encoding: "utf-8",
+          stdio: ["pipe", "pipe", "pipe"],
+        },
+      );
+    }
+    if (!fs.existsSync(ANGULAR_BROWSER_DIR)) {
+      throw new Error(
+        `Angular browser build did not produce ${ANGULAR_BROWSER_DIR}`,
+      );
+    }
+
+    fs.rmSync(angularLink);
+    fs.cpSync(ANGULAR_BROWSER_DIR, angularLink, { recursive: true });
+    fs.writeFileSync(
+      path.join(angularLink, "runtime-config.js"),
+      `globalThis.__COPILOTKIT_SHOWCASE__ = Object.freeze({"frontendId":"angular","integrationId":"${pkg.name}"});\n`,
+      "utf-8",
+    );
+    log.debug("staged Angular browser artifact", {
+      pkg: pkg.name,
+      from: ANGULAR_BROWSER_DIR,
+    });
   }
 
   log.info("shared module staging complete");
@@ -209,7 +257,7 @@ export function restoreSymlinks(): void {
     // matches the canonical source dir `integrations/_shared` (a real tracked
     // dir, never a symlink) — a no-op restore there is harmless.
     execSync(
-      "git checkout -- integrations/*/tools integrations/*/shared-tools integrations/*/_shared",
+      "git checkout -- integrations/*/tools integrations/*/shared-tools integrations/*/_shared integrations/*/public/angular",
       {
         cwd: SHOWCASE_DIR,
         stdio: "pipe",
@@ -354,7 +402,14 @@ export async function down(
     compose("--profile", "all", "down");
   } else {
     log.info("stopping services", { slugs });
-    const profileArgs = slugs.flatMap((s) => ["--profile", s]);
+    // Integration services depend on infra services such as aimock. Compose
+    // must load the infra profile to resolve those dependencies even though
+    // `stop <slug...>` only stops the explicitly named integrations.
+    const profileArgs = [
+      "--profile",
+      "infra",
+      ...slugs.flatMap((s) => ["--profile", s]),
+    ];
     compose(...profileArgs, "stop", ...slugs);
   }
 }

--- a/showcase/harness/src/probes/frontend-matrix-playwright-timeout.test.ts
+++ b/showcase/harness/src/probes/frontend-matrix-playwright-timeout.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Browser } from "playwright";
+import type { D5Script } from "./helpers/d5-registry.js";
+import type { FrontendMatrixCell } from "./frontend-matrix.js";
+
+const mocks = vi.hoisted(() => ({
+  releaseConversation: undefined as (() => void) | undefined,
+  conversationSettled: false,
+}));
+
+vi.mock("./helpers/conversation-runner.js", () => ({
+  runConversation: vi.fn(
+    () =>
+      new Promise((resolve) => {
+        mocks.releaseConversation = () => {
+          mocks.conversationSettled = true;
+          resolve({
+            turns_completed: 1,
+            total_turns: 1,
+            turn_durations_ms: [1],
+          });
+        };
+      }),
+  ),
+}));
+
+vi.mock("./helpers/init-scripts.js", () => ({
+  installBrowserContextShims: vi.fn(async () => undefined),
+  installPrePaintFromEnv: vi.fn(async () => undefined),
+}));
+
+vi.mock("./helpers/sse-interceptor.js", () => ({
+  attachSseInterceptor: vi.fn(async () => ({
+    consumed: false,
+    stop: vi.fn(async () => {
+      throw new Error("the timed-out page is already closed");
+    }),
+  })),
+}));
+
+import { createPlaywrightProbeExecutor } from "./frontend-matrix-playwright.js";
+
+const CELL: FrontendMatrixCell = {
+  id: "angular/spring-ai/voice",
+  frontend: "angular",
+  integration: "spring-ai",
+  feature: "voice",
+  featureTypes: ["voice"],
+};
+
+describe("frontend matrix Playwright timeout cleanup", () => {
+  beforeEach(() => {
+    mocks.releaseConversation = undefined;
+    mocks.conversationSettled = false;
+  });
+
+  it("waits for the interrupted conversation task before returning", async () => {
+    const page = {
+      on: vi.fn(),
+      goto: vi.fn(async () => ({ ok: () => true })),
+      waitForFunction: vi.fn(async () => undefined),
+    };
+    const close = vi.fn(async () => {
+      setTimeout(() => mocks.releaseConversation?.(), 20);
+    });
+    const browser = {
+      newContext: vi.fn(async () => ({
+        newPage: vi.fn(async () => page),
+        close,
+      })),
+    } as unknown as Browser;
+    const script: D5Script = {
+      featureTypes: ["voice"],
+      buildTurns: () => [{ input: "hello" }],
+    };
+    const execute = createPlaywrightProbeExecutor({
+      browser,
+      scripts: new Map([["voice", script]]),
+      probeTimeoutMs: 10,
+    });
+
+    const result = await execute({
+      cell: CELL,
+      featureType: "voice",
+      url: "http://127.0.0.1:3116/angular/voice",
+      backendUrl: "http://127.0.0.1:3116",
+      testId: "timeout-cleanup",
+    });
+
+    expect(result.status).toBe("failed");
+    expect(mocks.conversationSettled).toBe(true);
+    expect(close).toHaveBeenCalled();
+  });
+});

--- a/showcase/harness/src/probes/frontend-matrix-playwright.test.ts
+++ b/showcase/harness/src/probes/frontend-matrix-playwright.test.ts
@@ -26,6 +26,26 @@ describe("frontend matrix Playwright execution", () => {
     ).toBe("settle-text-unstable");
     expect(
       conversationFailureSummary(
+        "waitForTurnComplete: reason=dom-missing, runsFinished=1",
+      ),
+    ).toBe("settle-dom-missing");
+    expect(
+      conversationFailureSummary(
+        "waitForTurnComplete: reason=sse-missing, runsFinished=0",
+      ),
+    ).toBe("settle-sse-missing");
+    expect(
+      conversationFailureSummary(
+        "waitForTurnComplete: reason=surface-missing, count=1",
+      ),
+    ).toBe("settle-surface-missing");
+    expect(
+      conversationFailureSummary(
+        "waitForTurnComplete: reason=done-signal-missing, count=1",
+      ),
+    ).toBe("settle-done-signal-missing");
+    expect(
+      conversationFailureSummary(
         'gen-ui-agent-pill: Observed: ["private generated response"]',
       ),
     ).toBe("rendered-content-mismatch");

--- a/showcase/harness/src/probes/frontend-matrix-playwright.ts
+++ b/showcase/harness/src/probes/frontend-matrix-playwright.ts
@@ -252,6 +252,7 @@ export function createPlaywrightProbeExecutor(
     let capture: SseCapture | undefined;
     let sseHandle: Awaited<ReturnType<typeof attachSseInterceptor>> | undefined;
     let timeout: ReturnType<typeof setTimeout> | undefined;
+    let runPromise: Promise<FrontendProbeResult> | undefined;
     try {
       const timedOut = new Promise<never>((_, reject) => {
         timeout = setTimeout(() => {
@@ -297,6 +298,7 @@ export function createPlaywrightProbeExecutor(
             durationMs: Date.now() - startedAt,
             testId: input.testId,
             errorClass: "conversation-error",
+            failureReason: failureSummary,
             error: `conversation failed on turn ${conversation.failure_turn} (${failureSummary})`,
             diagnostics: {
               frontend: input.cell.frontend,
@@ -327,7 +329,8 @@ export function createPlaywrightProbeExecutor(
           },
         };
       };
-      return await Promise.race([run(), timedOut]);
+      runPromise = run();
+      return await Promise.race([runPromise, timedOut]);
     } catch {
       return {
         featureType: input.featureType,
@@ -355,6 +358,12 @@ export function createPlaywrightProbeExecutor(
       };
     } finally {
       if (timeout) clearTimeout(timeout);
+      // Closing a context interrupts Playwright calls, but Promise.race does
+      // not cancel the losing `run()` promise. Wait for that interrupted task
+      // to unwind before the shard starts its next cell; otherwise its
+      // conversation loop can keep emitting diagnostics or touching shared
+      // fixture/backend state after this probe has already returned.
+      await runPromise?.catch(() => undefined);
       if (sseHandle && !sseHandle.consumed) {
         try {
           capture = await sseHandle.stop();

--- a/showcase/harness/src/probes/frontend-matrix-runner.test.ts
+++ b/showcase/harness/src/probes/frontend-matrix-runner.test.ts
@@ -5,6 +5,7 @@ import {
   buildMeasuredShardPlan,
   createFrontendMatrixArtifact,
   executeFrontendMatrixShard,
+  mergeFrontendMatrixShardArtifacts,
   percentile,
 } from "./frontend-matrix-runner.js";
 import type { FrontendCellExecutor } from "./frontend-matrix-runner.js";
@@ -30,6 +31,31 @@ const CELLS: FrontendMatrixCell[] = [
     integration: "mastra",
     feature: "frontend-tools",
     featureTypes: ["frontend-tools"],
+  },
+];
+
+const PAIRED_CELLS: FrontendMatrixCell[] = [
+  ...CELLS,
+  {
+    id: "react/langgraph-python/beautiful-chat",
+    frontend: "react",
+    integration: "langgraph-python",
+    feature: "beautiful-chat",
+    featureTypes: ["beautiful-chat-toggle-theme", "beautiful-chat-pie-chart"],
+  },
+  {
+    id: "react/mastra/frontend-tools",
+    frontend: "react",
+    integration: "mastra",
+    feature: "frontend-tools",
+    featureTypes: ["frontend-tools"],
+  },
+  {
+    id: "angular/mastra/agentic-chat",
+    frontend: "angular",
+    integration: "mastra",
+    feature: "agentic-chat",
+    featureTypes: ["agentic-chat"],
   },
 ];
 
@@ -65,6 +91,38 @@ describe("frontend matrix CI runner", () => {
     );
     expect(first.shards[0]?.estimatedDurationMs).toBe(50_000);
     expect(first.shards[1]?.estimatedDurationMs).toBe(20_000);
+  });
+
+  it("keeps React and Angular counterparts adjacent on one shard", () => {
+    const plan = buildMeasuredShardPlan(PAIRED_CELLS, {
+      targetDurationMs: 40_000,
+      minimumShardCount: 2,
+      maximumShardCount: 2,
+      defaultProbeDurationMs: 10_000,
+      measuredCellDurationsMs: {},
+    });
+
+    const pairOrders: string[][] = [];
+    for (const feature of [
+      "beautiful-chat",
+      "frontend-tools",
+      "agentic-chat",
+    ]) {
+      const ids = PAIRED_CELLS.filter((cell) => cell.feature === feature).map(
+        (cell) => cell.id,
+      );
+      const containing = plan.shards.filter((shard) =>
+        ids.every((id) => shard.cellIds.includes(id)),
+      );
+      expect(containing).toHaveLength(1);
+      const shard = containing[0]!;
+      const positions = ids.map((id) => shard.cellIds.indexOf(id)).sort();
+      expect(positions[1]! - positions[0]!).toBe(1);
+      pairOrders.push(shard.cellIds.slice(positions[0], positions[1]! + 1));
+    }
+
+    expect(pairOrders.some((ids) => ids[0]?.startsWith("angular/"))).toBe(true);
+    expect(pairOrders.some((ids) => ids[0]?.startsWith("react/"))).toBe(true);
   });
 
   it("executes every cell once and never retries a deterministic failure", async () => {
@@ -158,6 +216,90 @@ describe("frontend matrix CI runner", () => {
     expect(percentile([10, 20, 30, 40], 0.95)).toBe(40);
   });
 
+  it("merges isolated frontend phases into one logical shard", () => {
+    const createPhase = (
+      cell: FrontendMatrixCell,
+      startedAt: string,
+      finishedAt: string,
+    ) =>
+      createFrontendMatrixArtifact({
+        sourceCommit: "abc123",
+        containerImageRevision: "sha256:image",
+        fixtureRevision: "fixture123",
+        featureContractRevision: "contract123",
+        shardIndex: 1,
+        shardCount: 4,
+        startedAt,
+        finishedAt,
+        results: [
+          {
+            cell,
+            status: "passed",
+            durationMs: 10,
+            probes: cell.featureTypes.map((featureType, index) => ({
+              featureType,
+              status: "passed",
+              durationMs: 10,
+              testId: `phase-${cell.frontend}-${index}`,
+            })),
+          },
+        ],
+      });
+
+    const react = PAIRED_CELLS.find(
+      (cell) => cell.frontend === "react" && cell.feature === "beautiful-chat",
+    )!;
+    const angular = PAIRED_CELLS.find(
+      (cell) =>
+        cell.frontend === "angular" && cell.feature === "beautiful-chat",
+    )!;
+    const merged = mergeFrontendMatrixShardArtifacts([
+      createPhase(
+        react,
+        "2026-07-23T01:00:00.000Z",
+        "2026-07-23T01:01:00.000Z",
+      ),
+      createPhase(
+        angular,
+        "2026-07-23T01:02:00.000Z",
+        "2026-07-23T01:03:00.000Z",
+      ),
+    ]);
+
+    expect(merged.startedAt).toBe("2026-07-23T01:00:00.000Z");
+    expect(merged.finishedAt).toBe("2026-07-23T01:03:00.000Z");
+    expect(merged.summary).toMatchObject({ total: 2, passed: 2, failed: 0 });
+    expect(merged.cells.map((cell) => cell.frontend)).toEqual([
+      "react",
+      "angular",
+    ]);
+  });
+
+  it("rejects overlapping frontend phase evidence", () => {
+    const phase = createFrontendMatrixArtifact({
+      sourceCommit: "abc123",
+      containerImageRevision: "sha256:image",
+      fixtureRevision: "fixture123",
+      featureContractRevision: "contract123",
+      shardIndex: 0,
+      shardCount: 1,
+      startedAt: "2026-07-23T01:00:00.000Z",
+      finishedAt: "2026-07-23T01:01:00.000Z",
+      results: [
+        {
+          cell: CELLS[0]!,
+          status: "passed",
+          durationMs: 10,
+          probes: [],
+        },
+      ],
+    });
+
+    expect(() => mergeFrontendMatrixShardArtifacts([phase, phase])).toThrow(
+      /duplicate frontend phase cell/i,
+    );
+  });
+
   it("removes page content, runtime URLs, and diagnostics from CI evidence", () => {
     const cell = CELLS[1]!;
     const artifact = createFrontendMatrixArtifact({
@@ -186,6 +328,7 @@ describe("frontend matrix CI runner", () => {
               durationMs: 500,
               testId: "fm-private",
               errorClass: "assertion",
+              failureReason: "settle-dom-missing",
               error: "tool payload",
               diagnostics: { fixture: "private fixture content" },
             },
@@ -214,6 +357,7 @@ describe("frontend matrix CI runner", () => {
           durationMs: 500,
           testId: "fm-private",
           errorClass: "assertion",
+          failureReason: "settle-dom-missing",
         },
       ],
     });

--- a/showcase/harness/src/probes/frontend-matrix-runner.ts
+++ b/showcase/harness/src/probes/frontend-matrix-runner.ts
@@ -12,6 +12,8 @@ export interface FrontendProbeResult {
   durationMs: number;
   testId: string;
   errorClass?: string;
+  /** Bounded, privacy-safe classifier; never raw provider or page content. */
+  failureReason?: string;
   error?: string;
   diagnostics?: Record<string, unknown>;
 }
@@ -79,10 +81,53 @@ function estimatedCellDurationMs(
   };
 }
 
+interface WeightedFrontendPair {
+  key: string;
+  cells: Array<{
+    cell: FrontendMatrixCell;
+    durationMs: number;
+    measured: boolean;
+  }>;
+  durationMs: number;
+}
+
+function pairKey(cell: FrontendMatrixCell): string {
+  return `${cell.integration}\u0000${cell.feature}`;
+}
+
+function stablePairParity(key: string): number {
+  let hash = 2_166_136_261;
+  for (const character of key) {
+    hash ^= character.charCodeAt(0);
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Keep counterpart cells adjacent while alternating which framework receives
+ * the warm-cache position. A global React-first or Angular-first order would
+ * systematically advantage one implementation across the entire audit.
+ */
+function orderFrontendPair(
+  pair: WeightedFrontendPair,
+): WeightedFrontendPair["cells"] {
+  const angularFirst = stablePairParity(pair.key) % 2 === 0;
+  return [...pair.cells].sort(
+    (left, right) =>
+      (left.cell.frontend === (angularFirst ? "angular" : "react") ? -1 : 1) -
+        (right.cell.frontend === (angularFirst ? "angular" : "react")
+          ? -1
+          : 1) || left.cell.id.localeCompare(right.cell.id),
+  );
+}
+
 /**
  * Build a deterministic least-loaded shard plan from recorded cell timings.
- * Unmeasured cells use a conservative per-probe estimate so new catalog cells
- * participate immediately instead of disappearing from the merge gate.
+ * React/Angular counterparts are one scheduling unit so they share the same
+ * backend process and remain adjacent. Unmeasured cells use a conservative
+ * per-probe estimate so new catalog cells participate immediately instead of
+ * disappearing from the merge gate.
  */
 export function buildMeasuredShardPlan(
   cells: readonly FrontendMatrixCell[],
@@ -118,6 +163,19 @@ export function buildMeasuredShardPlan(
       defaultProbeDurationMs,
     }),
   }));
+  const pairsByKey = new Map<string, WeightedFrontendPair>();
+  for (const item of weighted) {
+    const key = pairKey(item.cell);
+    const pair = pairsByKey.get(key) ?? {
+      key,
+      cells: [],
+      durationMs: 0,
+    };
+    pair.cells.push(item);
+    pair.durationMs += item.durationMs;
+    pairsByKey.set(key, pair);
+  }
+  const pairs = [...pairsByKey.values()];
   const estimatedTotalDurationMs = weighted.reduce(
     (total, item) => total + item.durationMs,
     0,
@@ -127,9 +185,9 @@ export function buildMeasuredShardPlan(
     Math.ceil(estimatedTotalDurationMs / targetDurationMs),
   );
   const shardCount =
-    cells.length === 0
+    pairs.length === 0
       ? 0
-      : Math.min(cells.length, maximumShardCount, desiredShardCount);
+      : Math.min(pairs.length, maximumShardCount, desiredShardCount);
   const shards = Array.from(
     { length: shardCount },
     (_, index): MeasuredShard => ({
@@ -139,24 +197,24 @@ export function buildMeasuredShardPlan(
     }),
   );
 
-  weighted
+  pairs
     .sort(
       (left, right) =>
-        right.durationMs - left.durationMs ||
-        left.cell.id.localeCompare(right.cell.id),
+        right.durationMs - left.durationMs || left.key.localeCompare(right.key),
     )
-    .forEach(({ cell, durationMs }) => {
+    .forEach((pair) => {
       const target = [...shards].sort(
         (left, right) =>
           left.estimatedDurationMs - right.estimatedDurationMs ||
           left.index - right.index,
       )[0];
-      if (!target) throw new Error("cannot assign a cell without a shard");
-      target.cellIds.push(cell.id);
-      target.estimatedDurationMs += durationMs;
+      if (!target) throw new Error("cannot assign a pair without a shard");
+      target.cellIds.push(
+        ...orderFrontendPair(pair).map(({ cell }) => cell.id),
+      );
+      target.estimatedDurationMs += pair.durationMs;
     });
 
-  for (const shard of shards) shard.cellIds.sort();
   return {
     schemaVersion: 1,
     targetDurationMs,
@@ -247,6 +305,7 @@ export interface FrontendMatrixArtifactProbe {
   durationMs: number;
   testId: string;
   errorClass?: string;
+  failureReason?: string;
 }
 
 export interface FrontendMatrixArtifactCell {
@@ -283,6 +342,75 @@ export interface FrontendMatrixArtifact {
   cells: FrontendMatrixArtifactCell[];
 }
 
+/**
+ * Recombine independently executed frontend phases for one logical shard.
+ *
+ * Stateful mock providers can receive nested SDK requests that do not carry
+ * the browser test id. Running React and Angular against separately reset
+ * fixture state prevents the first framework from consuming the second
+ * framework's sequence, while this merge preserves the original one-artifact
+ * per-shard completeness contract.
+ */
+export function mergeFrontendMatrixShardArtifacts(
+  artifacts: readonly FrontendMatrixArtifact[],
+): FrontendMatrixArtifact {
+  const first = artifacts[0];
+  if (!first) throw new Error("no frontend phase artifacts to merge");
+
+  const cells: FrontendMatrixArtifactCell[] = [];
+  const cellIds = new Set<string>();
+  let startedAt = Date.parse(first.startedAt);
+  let finishedAt = Date.parse(first.finishedAt);
+
+  for (const artifact of artifacts) {
+    if (
+      artifact.schemaVersion !== first.schemaVersion ||
+      artifact.sourceCommit !== first.sourceCommit ||
+      artifact.containerImageRevision !== first.containerImageRevision ||
+      artifact.fixtureRevision !== first.fixtureRevision ||
+      artifact.featureContractRevision !== first.featureContractRevision ||
+      artifact.shard.index !== first.shard.index ||
+      artifact.shard.count !== first.shard.count
+    ) {
+      throw new Error("frontend phase artifact identity mismatch");
+    }
+    const artifactStartedAt = Date.parse(artifact.startedAt);
+    const artifactFinishedAt = Date.parse(artifact.finishedAt);
+    if (
+      !Number.isFinite(artifactStartedAt) ||
+      !Number.isFinite(artifactFinishedAt) ||
+      artifactFinishedAt < artifactStartedAt
+    ) {
+      throw new Error("frontend phase artifact has invalid timestamps");
+    }
+    startedAt = Math.min(startedAt, artifactStartedAt);
+    finishedAt = Math.max(finishedAt, artifactFinishedAt);
+    for (const cell of artifact.cells) {
+      if (cellIds.has(cell.cellId)) {
+        throw new Error(`duplicate frontend phase cell ${cell.cellId}`);
+      }
+      cellIds.add(cell.cellId);
+      cells.push(cell);
+    }
+  }
+
+  return {
+    ...first,
+    startedAt: new Date(startedAt).toISOString(),
+    finishedAt: new Date(finishedAt).toISOString(),
+    summary: {
+      total: cells.length,
+      passed: cells.filter((cell) => cell.status === "passed").length,
+      failed: cells.filter((cell) => cell.status === "failed").length,
+      p95CellDurationMs: percentile(
+        cells.map((cell) => cell.durationMs),
+        0.95,
+      ),
+    },
+    cells,
+  };
+}
+
 /** Shape the stable, frontend-aware JSON contract uploaded by each CI shard. */
 export function createFrontendMatrixArtifact(
   input: FrontendMatrixArtifactInput,
@@ -298,6 +426,9 @@ export function createFrontendMatrixArtifact(
           ...(probe.errorClass === undefined
             ? {}
             : { errorClass: probe.errorClass }),
+          ...(probe.failureReason === undefined
+            ? {}
+            : { failureReason: probe.failureReason }),
         }),
       );
       return {

--- a/showcase/harness/src/probes/frontend-parity-gate.test.ts
+++ b/showcase/harness/src/probes/frontend-parity-gate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  evaluateCurrentFrontendParity,
   evaluateFrontendParity,
   frontendParityCellsFromAggregate,
 } from "./frontend-parity-gate.js";
@@ -196,5 +197,74 @@ describe("evaluateFrontendParity", () => {
 
     expect(report.passed).toBe(false);
     expect(report.comparisons[0].outcome).toBe("missing-result");
+  });
+});
+
+describe("evaluateCurrentFrontendParity", () => {
+  it.each([
+    ["passed", "passed", true, "passed"],
+    ["passed", "failed", false, "angular-regression"],
+    ["failed", "failed", true, "shared-failure"],
+    ["failed", "passed", true, "angular-improvement"],
+  ] as const)(
+    "React %s and Angular %s yields %s / %s",
+    (react, angular, passed, outcome) => {
+      const report = evaluateCurrentFrontendParity({
+        sourceCommit: PR_COMMIT,
+        cells: [
+          cell("react", react, PR_COMMIT),
+          cell("angular", angular, PR_COMMIT),
+        ],
+      });
+
+      expect(report.passed).toBe(passed);
+      expect(report.comparisons[0]?.outcome).toBe(outcome);
+    },
+  );
+
+  it("allows a React-only catalog cell", () => {
+    const report = evaluateCurrentFrontendParity({
+      sourceCommit: PR_COMMIT,
+      cells: [cell("react", "passed", PR_COMMIT)],
+    });
+
+    expect(report).toMatchObject({
+      passed: true,
+      summary: { "react-only": 1 },
+    });
+  });
+
+  it("blocks an Angular cell without a React counterpart", () => {
+    const report = evaluateCurrentFrontendParity({
+      sourceCommit: PR_COMMIT,
+      cells: [cell("angular", "passed", PR_COMMIT)],
+    });
+
+    expect(report).toMatchObject({
+      passed: false,
+      summary: { "missing-counterpart": 1 },
+    });
+  });
+
+  it("blocks counterpart cells that did not share exact evidence identity", () => {
+    const report = evaluateCurrentFrontendParity({
+      sourceCommit: PR_COMMIT,
+      cells: [
+        cell("react", "passed", PR_COMMIT),
+        cell("angular", "passed", PR_COMMIT, {
+          containerImageRevision: "sha256:different",
+        }),
+      ],
+    });
+
+    expect(report).toMatchObject({
+      passed: false,
+      comparisons: [
+        {
+          outcome: "identity-mismatch",
+          blockingReasons: ["container image revision differs"],
+        },
+      ],
+    });
   });
 });

--- a/showcase/harness/src/probes/frontend-parity-gate.ts
+++ b/showcase/harness/src/probes/frontend-parity-gate.ts
@@ -59,6 +59,33 @@ export interface FrontendParityReport {
   comparisons: FrontendParityComparison[];
 }
 
+export type CurrentFrontendParityOutcome =
+  | "passed"
+  | "angular-regression"
+  | "shared-failure"
+  | "angular-improvement"
+  | "react-only"
+  | "identity-mismatch"
+  | "missing-counterpart";
+
+export interface CurrentFrontendParityComparison {
+  id: string;
+  integration: string;
+  feature: string;
+  react: FrontendParityStatus | null;
+  angular: FrontendParityStatus | null;
+  outcome: CurrentFrontendParityOutcome;
+  blockingReasons: string[];
+}
+
+export interface CurrentFrontendParityReport {
+  schemaVersion: 1;
+  sourceCommit: string;
+  passed: boolean;
+  summary: Record<CurrentFrontendParityOutcome, number>;
+  comparisons: CurrentFrontendParityComparison[];
+}
+
 export interface FrontendParityInput {
   frozenBaseCommit: string;
   pullRequestCommit: string;
@@ -78,6 +105,16 @@ const OUTCOMES: readonly FrontendParityOutcome[] = [
   "unowned-baseline-failure",
   "identity-mismatch",
   "missing-result",
+];
+
+const CURRENT_OUTCOMES: readonly CurrentFrontendParityOutcome[] = [
+  "passed",
+  "angular-regression",
+  "shared-failure",
+  "angular-improvement",
+  "react-only",
+  "identity-mismatch",
+  "missing-counterpart",
 ];
 
 function comparisonId(
@@ -302,6 +339,87 @@ export function evaluateFrontendParity(
     schemaVersion: 1,
     frozenBaseCommit: input.frozenBaseCommit,
     pullRequestCommit: input.pullRequestCommit,
+    passed: comparisons.every(
+      (comparison) => comparison.blockingReasons.length === 0,
+    ),
+    summary,
+    comparisons,
+  };
+}
+
+/**
+ * Compare the two frontends at one exact source revision. Shared failures stay
+ * visible but do not block an Angular-parity audit; an Angular-only failure,
+ * missing counterpart, or pair-identity mismatch does.
+ */
+export function evaluateCurrentFrontendParity(input: {
+  sourceCommit: string;
+  cells: readonly FrontendParityCell[];
+}): CurrentFrontendParityReport {
+  const indexed = indexCells(input.cells);
+  const ids = new Set<string>();
+  for (const key of indexed.keys()) {
+    ids.add(key.replace(/^(react|angular)\//, ""));
+  }
+
+  const comparisons = [...ids]
+    .sort()
+    .map((id): CurrentFrontendParityComparison => {
+      const react = indexed.get(`react/${id}`);
+      const angular = indexed.get(`angular/${id}`);
+      const [integration = "", feature = ""] = id.split("/", 2);
+      const result = (
+        outcome: CurrentFrontendParityOutcome,
+        blockingReasons: string[] = [],
+      ): CurrentFrontendParityComparison => ({
+        id,
+        integration,
+        feature,
+        react: react?.status ?? null,
+        angular: angular?.status ?? null,
+        outcome,
+        blockingReasons,
+      });
+
+      if (!react) {
+        return result("missing-counterpart", [
+          "Angular cell has no React counterpart",
+        ]);
+      }
+      if (!angular) return result("react-only");
+
+      const identityReasons = pairIdentityReasons(
+        react,
+        angular,
+        input.sourceCommit,
+      );
+      if (identityReasons.length > 0) {
+        return result("identity-mismatch", identityReasons);
+      }
+      if (react.status === "passed" && angular.status === "failed") {
+        return result("angular-regression", [
+          "React passed while Angular failed at the same revision",
+        ]);
+      }
+      if (react.status === "failed" && angular.status === "failed") {
+        return result("shared-failure");
+      }
+      if (react.status === "failed" && angular.status === "passed") {
+        return result("angular-improvement");
+      }
+      return result("passed");
+    });
+
+  const summary = Object.fromEntries(
+    CURRENT_OUTCOMES.map((outcome) => [
+      outcome,
+      comparisons.filter((comparison) => comparison.outcome === outcome).length,
+    ]),
+  ) as Record<CurrentFrontendParityOutcome, number>;
+
+  return {
+    schemaVersion: 1,
+    sourceCommit: input.sourceCommit,
     passed: comparisons.every(
       (comparison) => comparison.blockingReasons.length === 0,
     ),

--- a/showcase/harness/src/probes/helpers/d5-mapping-drift.test.ts
+++ b/showcase/harness/src/probes/helpers/d5-mapping-drift.test.ts
@@ -25,19 +25,19 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { REGISTRY_TO_D5 } from "./d5-feature-mapping.js";
 
-const DASHBOARD_FILE = resolve(
+const LIVE_STATUS_FILE = resolve(
   __dirname,
-  "../../../../shell-dashboard/src/lib/live-status.ts",
+  "../../shared/cell-model/live-status.ts",
 );
 
-/** Parse `CATALOG_TO_D5_KEY` object literal out of the dashboard source. */
-function parseDashboardCatalogMap(): Record<string, string[]> {
-  const src = readFileSync(DASHBOARD_FILE, "utf8");
+/** Parse `CATALOG_TO_D5_KEY` from the canonical shared cell-model source. */
+function parseCatalogMap(): Record<string, string[]> {
+  const src = readFileSync(LIVE_STATUS_FILE, "utf8");
   const block = src.match(/CATALOG_TO_D5_KEY[^=]+=\s*\{([\s\S]+?)\n\};/);
   if (!block || !block[1]) {
     throw new Error(
-      "drift parser: could not locate CATALOG_TO_D5_KEY in dashboard source — " +
-        "if the dashboard file's shape changed, update the regex in this test.",
+      "drift parser: could not locate CATALOG_TO_D5_KEY in shared cell-model source — " +
+        "if the shared file's shape changed, update the regex in this test.",
     );
   }
   const out: Record<string, string[]> = {};
@@ -67,11 +67,11 @@ function normalizeMap(
 }
 
 describe("d5-mapping-drift", () => {
-  it("dashboard CATALOG_TO_D5_KEY structurally mirrors harness REGISTRY_TO_D5", () => {
+  it("shared CATALOG_TO_D5_KEY structurally mirrors harness REGISTRY_TO_D5", () => {
     const harnNorm = normalizeMap(
       REGISTRY_TO_D5 as Record<string, readonly string[]>,
     );
-    const dashNorm = normalizeMap(parseDashboardCatalogMap());
+    const dashNorm = normalizeMap(parseCatalogMap());
     expect(dashNorm).toEqual(harnNorm);
   });
 });

--- a/showcase/harness/src/probes/helpers/d5-representatives.ts
+++ b/showcase/harness/src/probes/helpers/d5-representatives.ts
@@ -27,6 +27,9 @@ export const D5_REPRESENTATIVES: Readonly<
   "beautiful-chat-search-flights": "beautiful-chat.json",
   "beautiful-chat-toggle-theme": "beautiful-chat.json",
   "background-agents": "background-agents.json",
+  // Navigation-only probe: the sentinel file keeps D5 eligibility explicit;
+  // no fixture request is made because the script has no conversation turns.
+  "browser-use-smoke": "_from-feature-parity.json",
   byoc: "_from-feature-parity.json",
   "chat-css": "chat-css.json",
   "chat-slots": "chat-slots.json",

--- a/showcase/harness/src/probes/helpers/privacy-safe-diagnostics.ts
+++ b/showcase/harness/src/probes/helpers/privacy-safe-diagnostics.ts
@@ -1,5 +1,12 @@
 const SETTLE_FAILURE_REASONS = new Set([
+  "sse-missing",
+  "dom-missing",
   "text-unstable",
+  "done-signal-missing",
+  "surface-missing",
+  // Retain the historical categories while older callers and artifacts
+  // still exist. The five entries above are the current runner's exact
+  // TurnNotCompleteError reasons.
   "surface-not-ready",
   "no-assistant-message",
   "run-still-active",

--- a/showcase/harness/src/probes/scripts/_beautiful-chat-shared.test.ts
+++ b/showcase/harness/src/probes/scripts/_beautiful-chat-shared.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Page } from "../helpers/conversation-runner.js";
+import { assertSearchFlights } from "./_beautiful-chat-shared.js";
+import { buildTurns as buildToggleThemeTurns } from "./d5-beautiful-chat-toggle-theme.js";
+
+function makePage(
+  waitForSelector = vi.fn(
+    async (
+      _selector: string,
+      _opts?: { state?: "visible"; timeout?: number },
+    ) => undefined,
+  ),
+): Page {
+  return {
+    waitForSelector,
+    fill: async () => undefined,
+    press: async () => undefined,
+    evaluate: async <R>(fn: () => R): Promise<R> => fn(),
+  };
+}
+
+describe("assertSearchFlights", () => {
+  it("settles the theme turn on the mounted assistant surface", () => {
+    const [turn] = buildToggleThemeTurns({
+      integrationSlug: "langgraph-typescript",
+      featureType: "beautiful-chat-toggle-theme",
+      baseUrl: "https://example.test",
+    });
+    expect(turn?.completeOnMount).toEqual({
+      testIds: ["copilot-assistant-message"],
+    });
+  });
+
+  it("accepts the turn-scoped narration without querying global DOM text", async () => {
+    const waitForSelector = vi.fn(
+      async (
+        _selector: string,
+        _opts?: { state?: "visible"; timeout?: number },
+      ) => undefined,
+    );
+    const page = makePage(waitForSelector);
+
+    await assertSearchFlights(page, {
+      bubbleIndex: 0,
+      text: "United at $349 and Delta at $289 are available.",
+    });
+
+    expect(waitForSelector).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the rendered surface when narration lacks the literals", async () => {
+    const waitForSelector = vi.fn(
+      async (
+        _selector: string,
+        _opts?: { state?: "visible"; timeout?: number },
+      ) => undefined,
+    );
+    const page = makePage(waitForSelector);
+
+    await assertSearchFlights(page, {
+      bubbleIndex: 0,
+      text: "I rendered the flight options above.",
+    });
+
+    expect(waitForSelector.mock.calls.map(([selector]) => selector)).toEqual([
+      "text=United",
+      "text=Delta",
+      "text=$349",
+      "text=$289",
+    ]);
+  });
+});

--- a/showcase/harness/src/probes/scripts/_beautiful-chat-shared.ts
+++ b/showcase/harness/src/probes/scripts/_beautiful-chat-shared.ts
@@ -321,11 +321,13 @@ export async function assertToggleTheme(page: ConversationPage): Promise<void> {
     if (closeAware.isClosed?.()) {
       throw new Error(
         `beautiful-chat-toggle-theme: page closed before theme-flip / "Theme toggled" signal landed (initiallyDark=${initiallyDark}) — likely a renderer crash in the demo's toggleTheme handler or surrounding tree`,
+        { cause: err },
       );
     }
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(
       `beautiful-chat-toggle-theme: neither html.dark flip from ${initiallyDark ? "dark" : "light"} nor visible "Theme toggled" content within 30s — toggleTheme path did not produce either signal (${msg.slice(0, 120)})`,
+      { cause: err },
     );
   }
 }
@@ -397,12 +399,23 @@ export async function assertBarChart(page: ConversationPage): Promise<void> {
  */
 export async function assertSearchFlights(
   page: ConversationPage,
+  ctx: { bubbleIndex: number; text: string },
 ): Promise<void> {
   const tag = "beautiful-chat-search-flights";
+  const literals = ["United", "Delta", "$349", "$289"];
+
+  // Some integrations intentionally return narration instead of a tool call
+  // because their beautiful-chat runtime does not register search_flights.
+  // Consume the turn-scoped assistant text supplied by the conversation
+  // runner before falling back to DOM surface checks. This avoids racing
+  // Playwright's global text selector against Angular's post-settle repaint
+  // while preserving the stronger rendered-card path when narration is absent.
+  if (literals.every((literal) => ctx.text.includes(literal))) return;
+
   // Short brand labels — present in both the FlightCard surface and
   // the assistant's "United at $349 / Delta at $289" narration.
   await waitForText(page, "United", FIRST_SIGNAL_TIMEOUT_MS, tag);
-  for (const literal of ["Delta", "$349", "$289"]) {
+  for (const literal of literals.slice(1)) {
     await waitForText(page, literal, SIBLING_TIMEOUT_MS, tag);
   }
 }

--- a/showcase/harness/src/probes/scripts/d5-beautiful-chat-toggle-theme.ts
+++ b/showcase/harness/src/probes/scripts/d5-beautiful-chat-toggle-theme.ts
@@ -7,10 +7,8 @@
  * the rationale on per-pill scripts and the assertion implementation.
  */
 
-import {
-  registerD5Script,
-  type D5BuildContext,
-} from "../helpers/d5-registry.js";
+import { registerD5Script } from "../helpers/d5-registry.js";
+import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { ConversationTurn } from "../helpers/conversation-runner.js";
 import {
   assertToggleTheme,
@@ -22,6 +20,9 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
     {
       input: "d5 beautiful-chat probe: toggle the theme",
       assertions: assertToggleTheme,
+      completeOnMount: {
+        testIds: ["copilot-assistant-message"],
+      },
     },
   ];
 }

--- a/showcase/harness/src/probes/scripts/d5-chat-css.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-chat-css.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { getD5Script, type D5BuildContext } from "../helpers/d5-registry.js";
+import { getD5Script } from "../helpers/d5-registry.js";
+import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { Page } from "../helpers/conversation-runner.js";
 import {
   buildTurns,
@@ -7,8 +8,8 @@ import {
   validateChatCss,
   USER_BUBBLE_SELECTOR,
   ASSISTANT_BUBBLE_SELECTOR,
-  type ChatCssProbeResult,
 } from "./d5-chat-css.js";
+import type { ChatCssProbeResult } from "./d5-chat-css.js";
 
 function makePage(probe: unknown, opts: { throwOnWait?: boolean } = {}): Page {
   return {
@@ -73,6 +74,9 @@ describe("d5-chat-css script", () => {
     const turns = buildTurns(ctx);
     expect(turns).toHaveLength(1);
     expect(turns[0]!.input).toBe("verify the css theme rendering");
+    expect(turns[0]!.completeOnMount).toEqual({
+      testIds: ["copilot-assistant-message"],
+    });
   });
 
   it("exposes the bubble selectors", () => {

--- a/showcase/harness/src/probes/scripts/d5-chat-css.ts
+++ b/showcase/harness/src/probes/scripts/d5-chat-css.ts
@@ -272,6 +272,9 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
     {
       input: "verify the css theme rendering",
       assertions: buildChatCssAssertion(),
+      completeOnMount: {
+        testIds: ["copilot-assistant-message"],
+      },
     },
   ];
 }

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-a2ui-fixed.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-a2ui-fixed.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
-import { getD5Script, type D5BuildContext } from "../helpers/d5-registry.js";
+import { getD5Script } from "../helpers/d5-registry.js";
+import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { Page } from "../helpers/conversation-runner.js";
 import {
   buildTurns,
@@ -30,6 +31,9 @@ describe("d5-gen-ui-a2ui-fixed script", () => {
     const turn = buildTurns(ctx)[0]!;
     expect(turn.input).toBe(A2UI_FIXED_PILL_PROMPT);
     expect(turn.responseTimeoutMs).toBeGreaterThanOrEqual(60_000);
+    expect(turn.completeOnMount).toEqual({
+      testIds: ["a2ui-fixed-card"],
+    });
   });
 
   it("assertion succeeds when waitForSelector resolves for the testid", async () => {

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-a2ui-fixed.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-a2ui-fixed.ts
@@ -11,11 +11,8 @@
  * green even if the renderer never painted.
  */
 
-import {
-  registerD5Script,
-  type D5BuildContext,
-  type D5FeatureType,
-} from "../helpers/d5-registry.js";
+import { registerD5Script } from "../helpers/d5-registry.js";
+import type { D5BuildContext, D5FeatureType } from "../helpers/d5-registry.js";
 import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
 import { FIRST_SIGNAL_TIMEOUT_MS, waitForTestId } from "./_genuine-shared.js";
 
@@ -45,6 +42,9 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
       input: A2UI_FIXED_PILL_PROMPT,
       assertions: buildA2uiFixedAssertion(),
       responseTimeoutMs: 60_000,
+      completeOnMount: {
+        testIds: ["a2ui-fixed-card"],
+      },
     },
   ];
 }

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-agent.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-agent.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { getD5Script, type D5BuildContext } from "../helpers/d5-registry.js";
+import { getD5Script } from "../helpers/d5-registry.js";
+import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { Page } from "../helpers/conversation-runner.js";
 import {
   buildTurns,
@@ -60,6 +61,16 @@ describe("d5-gen-ui-agent script", () => {
     expect(turns[0]!.input).toContain("Plan a product launch");
     expect(turns[1]!.input).toContain("team offsite");
     expect(turns[2]!.input).toContain("top competitor");
+    expect(
+      turns.every(
+        (turn) =>
+          JSON.stringify(turn.completeOnMount) ===
+          JSON.stringify({
+            testIds: ["agent-state-card"],
+            minNewMounts: 0,
+          }),
+      ),
+    ).toBe(true);
   });
 
   it("GEN_UI_AGENT_PILLS lists three tags with expected markers", () => {

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-agent.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-agent.ts
@@ -25,10 +25,8 @@
  * from the step titles in `showcase/harness/fixtures/d5/gen-ui-agent.json`.
  */
 
-import {
-  registerD5Script,
-  type D5BuildContext,
-} from "../helpers/d5-registry.js";
+import { registerD5Script } from "../helpers/d5-registry.js";
+import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
 import { FIRST_SIGNAL_TIMEOUT_MS, waitForTestId } from "./_genuine-shared.js";
 
@@ -176,6 +174,13 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
       seenStepTextsRef,
     ),
     responseTimeoutMs: 60_000,
+    completeOnMount: {
+      testIds: ["agent-state-card"],
+      // The card persists across turns. The run-finished and new-assistant-
+      // bubble gates prove this turn completed; the assertion below then
+      // polls until this pill's exact step markers replace the prior state.
+      minNewMounts: 0,
+    },
   }));
 }
 

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-interrupt.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-interrupt.test.ts
@@ -34,28 +34,40 @@ describe("d5-gen-ui-interrupt script", () => {
     ]);
   });
 
-  it("assertion clicks slot via evaluate (JS-level click) then polls for resolved-state signal", async () => {
+  it("assertion clicks via JS then waits for a new resumed-run confirmation", async () => {
     // The probe uses `clickByJs` (page.evaluate-driven .click()) to
-    // bypass the cpk-web-inspector overlay, then polls page.evaluate
-    // for one of three resume signals: `pickedTestid` (the
-    // time-picker-picked testid mounted), `bookedBadge` (the visible
-    // "Booked" badge text), or `scheduledNarration` (the agent's
-    // resume continuation containing "scheduled" / "confirmed"). Any
-    // of those means resolve() fired and propagated.
+    // bypass the cpk-web-inspector overlay, then requires the assistant
+    // cascade to grow with a booked/scheduled confirmation. The card's
+    // synchronous local picked state alone must not advance pill 2 while
+    // pill 1 is still returning its tool result.
     //
-    // Test mock: first evaluate call is the click (returns undefined),
-    // second evaluate call is the poll (returns a signal that satisfies
-    // one of the three conditions so the assertion resolves cleanly).
+    // Test mock: first evaluate snapshots the pre-click assistant count,
+    // second performs the click, and third observes the new continuation.
     let evaluateCallCount = 0;
     const evaluate = vi.fn<(fn: () => unknown) => Promise<unknown>>(
       async () => {
         evaluateCallCount += 1;
-        if (evaluateCallCount === 1) return undefined; // click
-        // Subsequent polling calls — return a signal that triggers exit.
+        if (evaluateCallCount === 1) {
+          return {
+            count: 1,
+            lastText: "choose a time",
+            pickedTestid: false,
+            runningNow: false,
+            runStartCount: 1,
+            lastStoppedAtMs: Date.now() - 2_000,
+            runsFinished: 1,
+            sample: "",
+          };
+        }
+        if (evaluateCallCount === 2) return undefined; // click
         return {
+          count: 2,
+          lastText: "booked: sales intro call confirmed",
           pickedTestid: true,
-          bookedBadge: false,
-          scheduledNarration: false,
+          runningNow: false,
+          runStartCount: 2,
+          lastStoppedAtMs: Date.now() - 1_000,
+          runsFinished: 2,
           sample: "",
         };
       },
@@ -70,14 +82,15 @@ describe("d5-gen-ui-interrupt script", () => {
     const assertion = buildInterruptAssertion("sales-call");
     await expect(assertion(page)).resolves.toBeUndefined();
     // clickByJs builds a zero-arg function whose source contains the
-    // selector via JSON.stringify. The first evaluate call is the click;
-    // assert the function body references the slot selector.
+    // selector via JSON.stringify. Find that call among the baseline/poll
+    // evaluates and assert it references the slot selector.
     expect(evaluate).toHaveBeenCalled();
-    const firstCall = evaluate.mock.calls[0];
-    expect(firstCall).toBeDefined();
-    const clickFn = firstCall![0];
+    const clickFn = evaluate.mock.calls
+      .map(([fn]) => fn)
+      .find((fn) => fn.toString().includes("time-picker-slot"));
+    expect(clickFn).toBeDefined();
     expect(typeof clickFn).toBe("function");
-    expect(clickFn.toString()).toContain("time-picker-slot");
+    expect(clickFn?.toString()).toContain("time-picker-slot");
     // The probe waits on the time-picker-card AND the time-picker-slot
     // testids before clicking; both should have been waitForSelector'd.
     expect(waitForSelector).toHaveBeenCalledWith(

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-interrupt.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-interrupt.ts
@@ -2,25 +2,20 @@
  * D5 — gen-ui-interrupt script.
  *
  * Drives `/demos/gen-ui-interrupt`. The agent's `schedule_meeting`
- * tool calls LangGraph's `interrupt(...)`; the frontend's
- * `useInterrupt` renders the `<TimePickerCard>` inline. The user
- * picks a slot — that calls `resolve(...)` which resumes the run.
+ * tool either calls LangGraph's `interrupt(...)` or is registered as
+ * a frontend human-in-the-loop tool. The frontend renders the
+ * `<TimePickerCard>` inline, and choosing a slot resumes the run.
  *
  * Genuine assertion: send the pill prompt; assert
  * `[data-testid="time-picker-card"]` mounts; click the first slot
- * (`[data-testid="time-picker-slot"]`); assert
- * `[data-testid="time-picker-picked"]` mounts (the card flips into
- * the booked-confirmation state). The picked-state mount is the
- * downstream signal that the agent resumed and the resolve callback
- * fired — a regression that drops `resolve` (or where the Card never
- * renders the picked state) catches here, not by reading the
- * transcript.
+ * (`[data-testid="time-picker-slot"]`); assert the picker visibly
+ * resolves and the resumed run finishes. Waiting for both signals,
+ * rather than the card's synchronous local picked state alone, proves
+ * the tool result completed before the next turn starts.
  */
 
-import {
-  registerD5Script,
-  type D5BuildContext,
-} from "../helpers/d5-registry.js";
+import { registerD5Script } from "../helpers/d5-registry.js";
+import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
 import {
   FIRST_SIGNAL_TIMEOUT_MS,
@@ -40,6 +35,72 @@ export const GEN_UI_INTERRUPT_PILLS = [
     prompt: "Schedule a 1:1 with Alice next week to review Q2 goals.",
   },
 ] as const;
+
+interface AssistantContinuationState {
+  count: number;
+  lastText: string;
+  pickedTestid: boolean;
+  runningNow: boolean | null;
+  runStartCount: number;
+  lastStoppedAtMs: number;
+  runsFinished: number;
+  sample: string;
+}
+
+/** Read the same assistant-message cascade used by the conversation runner. */
+async function readAssistantContinuationState(
+  page: Page,
+): Promise<AssistantContinuationState> {
+  return (await page.evaluate(() => {
+    const win = globalThis as unknown as {
+      document: {
+        querySelector(sel: string): unknown;
+        querySelectorAll(
+          sel: string,
+        ): ArrayLike<{ textContent: string | null }>;
+        body: { textContent: string | null };
+      };
+      __hk_copilotRunning?: {
+        runningNow?: boolean | null;
+        runStartCount?: number;
+        lastStoppedAtMs?: number;
+      };
+      __hk_runsFinished?: number;
+    };
+    const selectors = [
+      '[data-testid="copilot-assistant-message"]',
+      '[role="article"]:not([data-message-role="user"])',
+      '[data-message-role="assistant"]',
+    ];
+    let nodes: ArrayLike<{ textContent: string | null }> = { length: 0 };
+    for (const selector of selectors) {
+      const found = win.document.querySelectorAll(selector);
+      if (found.length > 0) {
+        nodes = found;
+        break;
+      }
+    }
+    const running = win.__hk_copilotRunning;
+    return {
+      count: nodes.length,
+      lastText:
+        nodes.length > 0
+          ? (nodes[nodes.length - 1]?.textContent ?? "").toLowerCase()
+          : "",
+      pickedTestid: !!win.document.querySelector(
+        '[data-testid="time-picker-picked"]',
+      ),
+      runningNow: running?.runningNow ?? null,
+      runStartCount: running?.runStartCount ?? 0,
+      lastStoppedAtMs: running?.lastStoppedAtMs ?? 0,
+      runsFinished: win.__hk_runsFinished ?? 0,
+      sample: (win.document.body.textContent ?? "")
+        .slice(-200)
+        .replace(/\s+/g, " ")
+        .trim(),
+    };
+  })) as AssistantContinuationState;
+}
 
 export function buildInterruptAssertion(
   pillTag: string,
@@ -64,52 +125,51 @@ export function buildInterruptAssertion(
         `${tag}: expected [data-testid="time-picker-slot"] within ${SIBLING_TIMEOUT_MS}ms`,
       );
     }
+    const baseline = await readAssistantContinuationState(page);
     await clickByJs(page, slotSelector);
-    // Step 3: assert that the picker resolved — accept either the
-    // `time-picker-picked` testid OR the visible "Booked" badge text
-    // OR the agent's resume continuation appearing as a new assistant
-    // message after the click. The picked-state Card mounts
-    // transiently between the slot click and the agent resume; with a
-    // fast resume the testid can unmount before the 5s poll sees it,
-    // so we widen the accepted signal to "anything that proves the
-    // resolve callback fired and propagated downstream."
+    // Step 3: require both a visible resolution and an authoritative run
+    // completion. The card's local `time-picker-picked` state flips
+    // synchronously and only proves that its click handler ran; starting pill
+    // 2 at that point races the still-running pill-1 tool result. Some native
+    // interrupt backends resolve the existing card without adding another
+    // assistant bubble, while frontend-tool backends add a confirmation
+    // continuation, so either UI signal is valid once the resumed run ends.
     const deadline = Date.now() + 30_000;
     let lastSnap = "";
+    let pickedObserved = false;
+    let sseCompletionObservedAt = 0;
     while (Date.now() < deadline) {
-      const signal = await page.evaluate(() => {
-        const win = globalThis as unknown as {
-          document: {
-            querySelector(sel: string): unknown;
-            body: { textContent: string | null };
-          };
-        };
-        const pickedTestid = !!win.document.querySelector(
-          '[data-testid="time-picker-picked"]',
-        );
-        const text = (win.document.body.textContent ?? "").toLowerCase();
-        const bookedBadge = text.includes("booked");
-        // Resume continuation — the canonical fixture's follow-up
-        // assistant content for the schedule_meeting tool result.
-        const scheduledNarration =
-          text.includes("scheduled") || text.includes("confirmed");
-        const sample = (win.document.body.textContent ?? "")
-          .slice(-200)
-          .replace(/\s+/g, " ")
-          .trim();
-        return { pickedTestid, bookedBadge, scheduledNarration, sample };
-      });
-      if (
-        signal.pickedTestid ||
-        signal.bookedBadge ||
-        signal.scheduledNarration
-      ) {
+      const signal = await readAssistantContinuationState(page);
+      const scheduledNarration =
+        signal.lastText.includes("booked") ||
+        signal.lastText.includes("scheduled") ||
+        signal.lastText.includes("confirmed");
+      pickedObserved ||= signal.pickedTestid;
+      const resolvedUiObserved =
+        pickedObserved || (signal.count > baseline.count && scheduledNarration);
+      const resumedRunStopped =
+        signal.runStartCount > baseline.runStartCount &&
+        signal.runningNow === false &&
+        signal.lastStoppedAtMs > baseline.lastStoppedAtMs &&
+        Date.now() - signal.lastStoppedAtMs >= 500;
+      const sseCompletionObserved = signal.runsFinished > baseline.runsFinished;
+      if (sseCompletionObserved) {
+        sseCompletionObservedAt ||= Date.now();
+      } else {
+        sseCompletionObservedAt = 0;
+      }
+      const resumedRunFinished =
+        resumedRunStopped ||
+        (sseCompletionObservedAt > 0 &&
+          Date.now() - sseCompletionObservedAt >= 500);
+      if (resolvedUiObserved && resumedRunFinished) {
         return;
       }
       lastSnap = signal.sample;
       await new Promise<void>((r) => setTimeout(r, 250));
     }
     throw new Error(
-      `${tag}: post-pick signal never landed within 30s — neither [data-testid="time-picker-picked"] mounted, "Booked" badge text rendered, nor the agent's "scheduled / confirmed" continuation appeared. Recent body tail: ${JSON.stringify(lastSnap.slice(-200))}`,
+      `${tag}: post-pick resolution never settled within 30s — expected the picked state or a new booked/scheduled/confirmed assistant bubble plus either a stopped run lifecycle or a new RUN_FINISHED event after the slot response (pickedObserved=${pickedObserved}). Recent body tail: ${JSON.stringify(lastSnap.slice(-200))}`,
     );
   };
 }

--- a/showcase/harness/src/probes/scripts/d5-headless-simple.ts
+++ b/showcase/harness/src/probes/scripts/d5-headless-simple.ts
@@ -82,9 +82,12 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
   return [
     {
       // Empty input + chip click via preFill. The chip's onClick calls
-      // `send(text)` directly; the runner's fill+press is a no-op
-      // because the composer's send button is disabled on empty input.
+      // `send(text)` directly, so this is a true preFill-owned submission.
+      // Do not let the generic runner clear/press the textarea while that
+      // asynchronous run is starting. Those empty-input Enter attempts cannot
+      // submit or verify anything and needlessly race the headless run.
       input: "",
+      skipSend: true,
       preFill: async (page) => {
         console.debug("[d5-headless-simple] turn 1: clicking sample chip", {
           label: SAMPLE_CHIP_LABEL,

--- a/showcase/harness/src/probes/scripts/d5-mcp-apps.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-mcp-apps.test.ts
@@ -3,8 +3,8 @@ import {
   D5_REGISTRY,
   __clearD5RegistryForTesting,
   getD5Script,
-  type D5BuildContext,
 } from "../helpers/d5-registry.js";
+import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { Page } from "../helpers/conversation-runner.js";
 
 let scriptModule: typeof import("./d5-mcp-apps.js");
@@ -50,6 +50,9 @@ describe("D5 mcp-apps script — buildTurns", () => {
     const turns = scriptModule.buildTurns(ctx);
     expect(turns).toHaveLength(1);
     expect(typeof turns[0]!.assertions).toBe("function");
+    expect(turns[0]!.completeOnMount).toEqual({
+      testIds: ["mcp-app-iframe"],
+    });
   });
 
   it("drives a real MCP-tool prompt (not the previous 'hello' no-op)", () => {

--- a/showcase/harness/src/probes/scripts/d5-mcp-apps.ts
+++ b/showcase/harness/src/probes/scripts/d5-mcp-apps.ts
@@ -26,10 +26,8 @@
  * convention.
  */
 
-import {
-  registerD5Script,
-  type D5BuildContext,
-} from "../helpers/d5-registry.js";
+import { registerD5Script } from "../helpers/d5-registry.js";
+import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
 
 /**
@@ -132,6 +130,9 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
     {
       input:
         "Open Excalidraw and sketch a system diagram with a client, server, and database.",
+      completeOnMount: {
+        testIds: ["mcp-app-iframe"],
+      },
       // Wrapped so the assertions callback ignores the Phase-4 `ctx`
       // argument: `assertIframePresent` takes `(page, timeoutMs?)`, not
       // `(page, ctx)`, and ctx is irrelevant to the iframe-mount probe.

--- a/showcase/harness/vitest.quarantine.json
+++ b/showcase/harness/vitest.quarantine.json
@@ -29,18 +29,6 @@
       "since": "2026-07-24",
       "reason": "Asserts hard-coded per-frontend cell counts (react=660, angular=636) against `shell/src/data/frontend-catalog.json`, which is a GENERATED artifact. The catalog has since grown to 1302 runnable cells (react=664, angular=638), so the two literals are stale and the test fails with 'expected [ Array(664) ] to have a length of 660'. Not a product defect — the two assertions that actually express the test's stated intent ('without loss or duplication': length === metadata.runnable, and ids are unique) both PASS.",
       "unquarantineWhen": "The per-frontend expectations are derived from the catalog instead of hard-coded, so adding a demo cell no longer breaks the test. Re-hard-coding fresh numbers only resets the clock — this test will drift again on the next catalog change."
-    },
-    {
-      "file": "src/probes/helpers/d5-mapping-drift.test.ts",
-      "since": "2026-07-24",
-      "reason": "Premise no longer exists. The test scrapes `CATALOG_TO_D5_KEY` out of `shell-dashboard/src/lib/live-status.ts` with a regex to prove the dashboard's copy has not drifted from the harness's `REGISTRY_TO_D5`. A completed refactor turned that dashboard file into a one-line `export *` barrel over the canonical `harness/src/shared/cell-model/live-status.ts`, so there is no second copy to drift and nothing for the regex to find. The test throws its own 'drift parser: could not locate CATALOG_TO_D5_KEY' guard.",
-      "unquarantineWhen": "The cell-model owner either deletes this test (the single-source-of-truth refactor made drift structurally impossible, which is a strictly stronger guarantee than the test provided) or rewrites it to assert the invariant that now does the work — that the dashboard barrel re-exports the canonical harness module rather than redeclaring the map."
-    },
-    {
-      "file": "src/probes/helpers/d5-representatives.test.ts",
-      "since": "2026-07-24",
-      "reason": "GENUINE PRODUCT GAP, deliberately not fixed here. The D5 script `d5-browser-use-smoke` registers the `browser-use-smoke` feature type in `D5_REGISTRY`, but `D5_REPRESENTATIVES` has no entry for it, so `getD5Representative('browser-use-smoke')` returns undefined and the D5 driver has no representative fixture for that feature type. The test is correct and is reporting a real hole; the fix belongs to the D5 owner, not to this CI-wiring change (which is strictly additive and touches no product source).",
-      "unquarantineWhen": "`D5_REPRESENTATIVES` gains a `browser-use-smoke` entry pointing at its fixture filename."
     }
   ]
 }

--- a/showcase/scripts/__tests__/angular-integration-hosting.test.ts
+++ b/showcase/scripts/__tests__/angular-integration-hosting.test.ts
@@ -119,7 +119,6 @@ test("generates shell-docs data before tests on a fresh checkout", async () => {
 
   expect(packageJson.scripts?.pretest).toBe("npm run pretypecheck");
 });
-
 test("generates Angular source content in the shell-docs image", async () => {
   const dockerfile = await readFile(
     resolve(repositoryRoot, "showcase/shell-docs/Dockerfile"),
@@ -130,85 +129,4 @@ test("generates Angular source content in the shell-docs image", async () => {
   expect(dockerfile).toContain(
     "node node_modules/tsx/dist/cli.mjs bundle-angular-source-content.ts",
   );
-});
-
-test("does not run the broad Angular proof matrix in pull requests", async () => {
-  await expect(
-    lstat(
-      resolve(
-        repositoryRoot,
-        ".github/workflows/test_showcase-angular-proof.yml",
-      ),
-    ),
-  ).rejects.toMatchObject({ code: "ENOENT" });
-});
-
-test("keeps the exhaustive Angular audit opt-in, complete, and fail-closed", async () => {
-  const workflow = await readFile(
-    resolve(
-      repositoryRoot,
-      ".github/workflows/test_showcase-angular-audit.yml",
-    ),
-    "utf8",
-  );
-
-  expect(workflow).toContain("workflow_dispatch:");
-  expect(workflow).toContain("types: [labeled]");
-  expect(workflow).toContain("github.event.label.name == 'angular-audit'");
-  expect(workflow).not.toContain("types: [opened");
-  expect(workflow).not.toContain("types: [synchronize");
-  for (const integration of integrations) {
-    expect(workflow).toContain(`          - ${integration}`);
-  }
-  expect(workflow).toContain(
-    "pnpm nx run @copilotkit/showcase-angular-host:build --skip-nx-cache",
-  );
-  expect(workflow).toContain(
-    "ref: ${{ github.event.pull_request.head.sha || github.sha }}",
-  );
-  expect(workflow).toContain("--min-shards 4");
-  expect(workflow).toContain("--max-shards 4");
-  expect(workflow).toContain("Start four isolated fixture sidecars");
-  expect(workflow).toContain("Start four isolated integration containers");
-  expect(workflow).toContain(
-    "Run isolated Chromium phases with fresh fixture state",
-  );
-  expect(workflow).toContain("run_frontend_phase react");
-  expect(workflow).toContain('kill "$fixture_pid"');
-  expect(workflow).toContain("run_frontend_phase angular");
-  expect(workflow).toContain("frontend-matrix-ci.ts merge-shard");
-  expect(workflow).toContain("for shard in 0 1 2 3");
-  expect(workflow).toContain("fixture_port=$((4010 + shard))");
-  expect(workflow).toContain(
-    'OPENAI_BASE_URL="http://host.docker.internal:$fixture_port/v1"',
-  );
-  expect(workflow).toContain('"$RUNNER_TEMP/aimock-$shard.pid"');
-  expect(workflow).toContain(
-    'if [ "$INTEGRATION" = "spring-ai" ] || [ "$INTEGRATION" = "pydantic-ai" ]; then',
-  );
-  expect(workflow).toContain('run_shard "$shard"');
-  expect(workflow).toContain("--host 0.0.0.0");
-  expect(workflow).not.toContain("--host 127.0.0.1");
-  expect(workflow).toContain('--feature-contract-revision "$SOURCE_SHA"');
-  expect(workflow).toContain("--concurrency 1");
-  expect(workflow).toContain(')" = "80"');
-  expect(workflow).toContain("frontend-matrix-ci.ts aggregate");
-  expect(workflow).toContain(
-    '.summary.total "$RUNNER_TEMP/angular-audit-final.json")" = "1296"',
-  );
-  expect(workflow).toContain("frontend-matrix-ci.ts pair");
-  expect(workflow).toContain(
-    '.comparisons | length\' "$RUNNER_TEMP/angular-audit-parity.json")" = "660"',
-  );
-  expect(workflow).toContain(
-    '.summary["react-only"]\' "$RUNNER_TEMP/angular-audit-parity.json")" = "24"',
-  );
-  expect(workflow).toContain(
-    'Angular regressions: \\(.summary["angular-regression"])',
-  );
-  expect(workflow).not.toContain(
-    '.summary.failed "$RUNNER_TEMP/angular-audit-final.json")" = "0"',
-  );
-  expect(workflow).not.toContain("frontend-matrix-baseline");
-  expect(workflow).not.toContain("frontend-matrix-ci.ts compare");
 });

--- a/showcase/scripts/__tests__/angular-integration-hosting.test.ts
+++ b/showcase/scripts/__tests__/angular-integration-hosting.test.ts
@@ -142,3 +142,73 @@ test("does not run the broad Angular proof matrix in pull requests", async () =>
     ),
   ).rejects.toMatchObject({ code: "ENOENT" });
 });
+
+test("keeps the exhaustive Angular audit opt-in, complete, and fail-closed", async () => {
+  const workflow = await readFile(
+    resolve(
+      repositoryRoot,
+      ".github/workflows/test_showcase-angular-audit.yml",
+    ),
+    "utf8",
+  );
+
+  expect(workflow).toContain("workflow_dispatch:");
+  expect(workflow).toContain("types: [labeled]");
+  expect(workflow).toContain("github.event.label.name == 'angular-audit'");
+  expect(workflow).not.toContain("types: [opened");
+  expect(workflow).not.toContain("types: [synchronize");
+  for (const integration of integrations) {
+    expect(workflow).toContain(`          - ${integration}`);
+  }
+  expect(workflow).toContain(
+    "pnpm nx run @copilotkit/showcase-angular-host:build --skip-nx-cache",
+  );
+  expect(workflow).toContain(
+    "ref: ${{ github.event.pull_request.head.sha || github.sha }}",
+  );
+  expect(workflow).toContain("--min-shards 4");
+  expect(workflow).toContain("--max-shards 4");
+  expect(workflow).toContain("Start four isolated fixture sidecars");
+  expect(workflow).toContain("Start four isolated integration containers");
+  expect(workflow).toContain(
+    "Run isolated Chromium phases with fresh fixture state",
+  );
+  expect(workflow).toContain("run_frontend_phase react");
+  expect(workflow).toContain('kill "$fixture_pid"');
+  expect(workflow).toContain("run_frontend_phase angular");
+  expect(workflow).toContain("frontend-matrix-ci.ts merge-shard");
+  expect(workflow).toContain("for shard in 0 1 2 3");
+  expect(workflow).toContain("fixture_port=$((4010 + shard))");
+  expect(workflow).toContain(
+    'OPENAI_BASE_URL="http://host.docker.internal:$fixture_port/v1"',
+  );
+  expect(workflow).toContain('"$RUNNER_TEMP/aimock-$shard.pid"');
+  expect(workflow).toContain(
+    'if [ "$INTEGRATION" = "spring-ai" ] || [ "$INTEGRATION" = "pydantic-ai" ]; then',
+  );
+  expect(workflow).toContain('run_shard "$shard"');
+  expect(workflow).toContain("--host 0.0.0.0");
+  expect(workflow).not.toContain("--host 127.0.0.1");
+  expect(workflow).toContain('--feature-contract-revision "$SOURCE_SHA"');
+  expect(workflow).toContain("--concurrency 1");
+  expect(workflow).toContain(')" = "80"');
+  expect(workflow).toContain("frontend-matrix-ci.ts aggregate");
+  expect(workflow).toContain(
+    '.summary.total "$RUNNER_TEMP/angular-audit-final.json")" = "1296"',
+  );
+  expect(workflow).toContain("frontend-matrix-ci.ts pair");
+  expect(workflow).toContain(
+    '.comparisons | length\' "$RUNNER_TEMP/angular-audit-parity.json")" = "660"',
+  );
+  expect(workflow).toContain(
+    '.summary["react-only"]\' "$RUNNER_TEMP/angular-audit-parity.json")" = "24"',
+  );
+  expect(workflow).toContain(
+    'Angular regressions: \\(.summary["angular-regression"])',
+  );
+  expect(workflow).not.toContain(
+    '.summary.failed "$RUNNER_TEMP/angular-audit-final.json")" = "0"',
+  );
+  expect(workflow).not.toContain("frontend-matrix-baseline");
+  expect(workflow).not.toContain("frontend-matrix-ci.ts compare");
+});


### PR DESCRIPTION
## Summary

Restores Angular Showcase parity with the current React feature contracts and makes the paired browser audit distinguish Angular regressions from failures shared by both frontends.

The Angular host is still one shared application. Agent frameworks can differ behind the runtime boundary, but BuiltInAgent no longer needs frontend-only route or default-agent fallbacks: its current demos expose the same named runtime and agent contracts used by React.

## What changed

### Angular runtime parity

- align BuiltInAgent runtime routes and named agent IDs with the current React demos
- remove stale BuiltIn-only route, agent, reasoning, and interrupt branches
- configure dynamically created chats with their agent and thread before component construction, preventing the transient `default` agent lookup against named-only runtimes
- preserve the remaining integration-specific behavior only where the backend interaction contract genuinely differs
- preserve currency values in assistant messages without breaking inline KaTeX rendering
- align Angular A2UI row and column schemas with the shared layout contract
- expose authoritative running state and prevent an unnecessary follow-up run in the complete headless demo
- reset interrupt selection state between repeated turns

### Audit and probe hardening

- merge exact-cell shard artifacts and validate source, fixture, and feature-contract identity
- classify paired results as passed, Angular regression, shared failure, Angular improvement, React-only, identity mismatch, or missing counterpart
- make Angular-only failures, identity drift, and missing counterparts blocking while keeping shared failures visible
- use rendered-surface completion for tool-rendered probes while retaining lifecycle gates
- avoid duplicate or empty submissions in the headless-simple probe
- require interrupt resolution and resumed-run completion before advancing
- use turn-scoped assistant content where narration is an accepted shared contract
- add focused regression tests for Angular bindings, dynamic component creation, matrix lifecycle handling, parity classification, and representative probes

No new CI workflow is added by this PR.

## Scope of the parity claim

The audit proves the narrower parity condition: Angular has no failure in a cell where React passes at the same source revision. Shared React/Angular failures remain reported but are non-blocking, so this does not claim that every supported cell is green.

## Validation

Final rebased head: `aeb503c37` on `d80cc9244` (`main`).

Current-head local validation:

- `pnpm nx run @copilotkit/showcase-scripts:test --skip-nx-cache --output-style=static` — 74 files, 2,366 tests passed
- `pnpm nx run @copilotkit/showcase-harness:test:ci --skip-nx-cache --output-style=static` — 175 files passed, 2 skipped; 3,672 tests passed, 18 skipped
- `pnpm nx run @copilotkit/showcase-harness:test:quarantine-ratchet --skip-nx-cache --output-style=static` — passed
- `pnpm nx run @copilotkit/showcase-harness:typecheck --skip-nx-cache --output-style=static` — passed
- `pnpm nx run @copilotkit/angular:check-types --skip-nx-cache --output-style=static` — passed with dependencies
- `pnpm nx run-many --targets=typecheck,test,build --projects=@copilotkit/showcase-angular-host --parallel=1 --skip-nx-cache --output-style=static` — passed; 20 Angular files and 168 tests passed
- Angular browser build passed its performance-budget and artifact audits

Focused BuiltInAgent regression rerun at the equivalent pre-rebase implementation head `b9d51551c`:

- all six previously deterministic Angular failures passed: auth, multimodal, agent-config, voice, shared-state-read, and a2ui-fixed-schema
- 68 exact React/Angular cells classified into 35 feature comparisons
- 25 paired passes
- 7 shared failures
- 1 Angular improvement
- 2 React-only cells
- zero Angular regressions
- zero identity mismatches
- zero missing counterparts

The earlier exhaustive browser audit also passed in [GitHub Actions](https://github.com/CopilotKit/CopilotKit/actions/runs/30065131330):

- 1,296 exact cells: 660 React and 636 Angular
- 497 paired passes
- 46 Angular improvements
- 93 shared failures
- 24 React-only cells
- zero Angular regressions, identity mismatches, or missing counterparts
