### PR TITLE
fix(runtime): honor *_BASE_URL env vars in resolveModel for OpenAI-compatible endpoints

### DIFF
--- a/packages/runtime/src/agent/__tests__/resolve-model-baseurl.test.ts
+++ b/packages/runtime/src/agent/__tests__/resolve-model-baseurl.test.ts
@@ -3,15 +3,15 @@ import { resolveModel } from "../index";
 
 // Mock the SDK provider factories so we can assert the options resolveModel passes them
 // (the returned LanguageModel does not expose baseURL publicly, so we verify at the factory).
-const createOpenAI = vi.fn(() => (modelId: string) => ({
+const createOpenAI = vi.fn((_opts?: unknown) => (modelId: string) => ({
   modelId,
   provider: "openai",
 }));
-const createAnthropic = vi.fn(() => (modelId: string) => ({
+const createAnthropic = vi.fn((_opts?: unknown) => (modelId: string) => ({
   modelId,
   provider: "anthropic",
 }));
-const createGoogleGenerativeAI = vi.fn(() => (modelId: string) => ({
+const createGoogleGenerativeAI = vi.fn((_opts?: unknown) => (modelId: string) => ({
   modelId,
   provider: "google",
 }));

--- a/packages/runtime/src/agent/__tests__/resolve-model-baseurl.test.ts
+++ b/packages/runtime/src/agent/__tests__/resolve-model-baseurl.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { resolveModel } from "../index";
+
+// Mock the SDK provider factories so we can assert the options resolveModel passes them
+// (the returned LanguageModel does not expose baseURL publicly, so we verify at the factory).
+const createOpenAI = vi.fn(() => (modelId: string) => ({ modelId, provider: "openai" }));
+const createAnthropic = vi.fn(() => (modelId: string) => ({ modelId, provider: "anthropic" }));
+const createGoogleGenerativeAI = vi.fn(() => (modelId: string) => ({ modelId, provider: "google" }));
+
+vi.mock("@ai-sdk/openai", () => ({ createOpenAI: (opts: unknown) => createOpenAI(opts) }));
+vi.mock("@ai-sdk/anthropic", () => ({ createAnthropic: (opts: unknown) => createAnthropic(opts) }));
+vi.mock("@ai-sdk/google", () => ({
+  createGoogleGenerativeAI: (opts: unknown) => createGoogleGenerativeAI(opts),
+}));
+
+describe("resolveModel — custom baseURL via env", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    process.env.OPENAI_API_KEY = "test-openai-key";
+    process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+    process.env.GOOGLE_API_KEY = "test-google-key";
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("passes OPENAI_BASE_URL to the OpenAI provider (OpenAI-compatible endpoints)", () => {
+    process.env.OPENAI_BASE_URL = "https://openrouter.ai/api/v1";
+    resolveModel("openai/gpt-4o-mini");
+    expect(createOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "https://openrouter.ai/api/v1" }),
+    );
+  });
+
+  it("passes ANTHROPIC_BASE_URL to the Anthropic provider", () => {
+    process.env.ANTHROPIC_BASE_URL = "https://anthropic.internal/v1";
+    resolveModel("anthropic/claude-sonnet-4.5");
+    expect(createAnthropic).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "https://anthropic.internal/v1" }),
+    );
+  });
+
+  it("passes GOOGLE_GENERATIVE_AI_BASE_URL to the Google provider", () => {
+    process.env.GOOGLE_GENERATIVE_AI_BASE_URL = "https://google.internal/v1beta";
+    resolveModel("google/gemini-2.5-pro");
+    expect(createGoogleGenerativeAI).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "https://google.internal/v1beta" }),
+    );
+  });
+
+  it("leaves baseURL undefined when the env var is unset (default endpoint, backward compatible)", () => {
+    delete process.env.OPENAI_BASE_URL;
+    resolveModel("openai/gpt-4o");
+    expect(createOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: undefined }),
+    );
+  });
+});

--- a/packages/runtime/src/agent/__tests__/resolve-model-baseurl.test.ts
+++ b/packages/runtime/src/agent/__tests__/resolve-model-baseurl.test.ts
@@ -3,12 +3,25 @@ import { resolveModel } from "../index";
 
 // Mock the SDK provider factories so we can assert the options resolveModel passes them
 // (the returned LanguageModel does not expose baseURL publicly, so we verify at the factory).
-const createOpenAI = vi.fn(() => (modelId: string) => ({ modelId, provider: "openai" }));
-const createAnthropic = vi.fn(() => (modelId: string) => ({ modelId, provider: "anthropic" }));
-const createGoogleGenerativeAI = vi.fn(() => (modelId: string) => ({ modelId, provider: "google" }));
+const createOpenAI = vi.fn(() => (modelId: string) => ({
+  modelId,
+  provider: "openai",
+}));
+const createAnthropic = vi.fn(() => (modelId: string) => ({
+  modelId,
+  provider: "anthropic",
+}));
+const createGoogleGenerativeAI = vi.fn(() => (modelId: string) => ({
+  modelId,
+  provider: "google",
+}));
 
-vi.mock("@ai-sdk/openai", () => ({ createOpenAI: (opts: unknown) => createOpenAI(opts) }));
-vi.mock("@ai-sdk/anthropic", () => ({ createAnthropic: (opts: unknown) => createAnthropic(opts) }));
+vi.mock("@ai-sdk/openai", () => ({
+  createOpenAI: (opts: unknown) => createOpenAI(opts),
+}));
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: (opts: unknown) => createAnthropic(opts),
+}));
 vi.mock("@ai-sdk/google", () => ({
   createGoogleGenerativeAI: (opts: unknown) => createGoogleGenerativeAI(opts),
 }));
@@ -45,7 +58,8 @@ describe("resolveModel — custom baseURL via env", () => {
   });
 
   it("passes GOOGLE_GENERATIVE_AI_BASE_URL to the Google provider", () => {
-    process.env.GOOGLE_GENERATIVE_AI_BASE_URL = "https://google.internal/v1beta";
+    process.env.GOOGLE_GENERATIVE_AI_BASE_URL =
+      "https://google.internal/v1beta";
     resolveModel("google/gemini-2.5-pro");
     expect(createGoogleGenerativeAI).toHaveBeenCalledWith(
       expect.objectContaining({ baseURL: "https://google.internal/v1beta" }),

--- a/packages/runtime/src/agent/__tests__/resolve-model-baseurl.test.ts
+++ b/packages/runtime/src/agent/__tests__/resolve-model-baseurl.test.ts
@@ -11,10 +11,12 @@ const createAnthropic = vi.fn((_opts?: unknown) => (modelId: string) => ({
   modelId,
   provider: "anthropic",
 }));
-const createGoogleGenerativeAI = vi.fn((_opts?: unknown) => (modelId: string) => ({
-  modelId,
-  provider: "google",
-}));
+const createGoogleGenerativeAI = vi.fn(
+  (_opts?: unknown) => (modelId: string) => ({
+    modelId,
+    provider: "google",
+  }),
+);
 
 vi.mock("@ai-sdk/openai", () => ({
   createOpenAI: (opts: unknown) => createOpenAI(opts),

--- a/packages/runtime/src/agent/index.ts
+++ b/packages/runtime/src/agent/index.ts
@@ -201,6 +201,11 @@ export function resolveModel(
       // Use provided apiKey, or fall back to environment variable
       const openai = createOpenAI({
         apiKey: apiKey || process.env.OPENAI_API_KEY!,
+        // Honor an OpenAI-COMPATIBLE endpoint (Azure OpenAI, OpenRouter, a gateway,
+        // vLLM/LM Studio/Ollama, etc.) via the standard OPENAI_BASE_URL env var.
+        // Undefined when unset, so the provider falls back to its default
+        // (api.openai.com) — fully backward compatible.
+        baseURL: process.env.OPENAI_BASE_URL,
       });
       // Accepts any OpenAI model id, e.g. "gpt-4o", "gpt-4.1-mini", "o3-mini"
       return openai(model);
@@ -211,6 +216,8 @@ export function resolveModel(
       // Use provided apiKey, or fall back to environment variable
       const anthropic = createAnthropic({
         apiKey: apiKey || process.env.ANTHROPIC_API_KEY!,
+        // Honor a custom Anthropic-compatible endpoint via ANTHROPIC_BASE_URL (see OpenAI note).
+        baseURL: process.env.ANTHROPIC_BASE_URL,
       });
       // Accepts any Claude id, e.g. "claude-3.7-sonnet", "claude-3.5-haiku"
       return anthropic(model);
@@ -223,6 +230,8 @@ export function resolveModel(
       // Use provided apiKey, or fall back to environment variable
       const google = createGoogleGenerativeAI({
         apiKey: apiKey || process.env.GOOGLE_API_KEY!,
+        // Honor a custom Google-compatible endpoint via GOOGLE_GENERATIVE_AI_BASE_URL (see OpenAI note).
+        baseURL: process.env.GOOGLE_GENERATIVE_AI_BASE_URL,
       });
       // Accepts any Gemini id, e.g. "gemini-2.5-pro", "gemini-2.5-flash"
       return google(model);


### PR DESCRIPTION
## Problem

`resolveModel()` builds each provider with only an `apiKey`, so a **string model spec** (e.g. `"openai/gpt-4o-mini"`) cannot target an **OpenAI-compatible endpoint** — Azure OpenAI, OpenRouter, an LLM gateway, or a local server (vLLM / LM Studio / Ollama). `OPENAI_BASE_URL` is silently ignored, and the only workaround is to drop the ergonomic string form and construct a `LanguageModel` instance yourself. The same gap exists for Anthropic and Google.

## Fix

`resolveModel` now passes `baseURL` from the standard env var for each provider:

| Provider | Env var |
|---|---|
| OpenAI | `OPENAI_BASE_URL` |
| Anthropic | `ANTHROPIC_BASE_URL` |
| Google | `GOOGLE_GENERATIVE_AI_BASE_URL` |

It is `undefined` when the var is unset, so each provider falls back to its default endpoint — **fully backward compatible** (no behavior change unless you opt in).

## Tests

Adds `resolve-model-baseurl.test.ts` (4 cases): each provider forwards its env var to the SDK factory, and an unset var leaves `baseURL` undefined. All existing `resolveModel` tests pass unchanged (118 runtime tests green locally).

## Context

Found while building an OpenAI-compatible agent on the V2 runtime + `@copilotkit/react-native`, where the string model form couldn't reach the configured endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)