### PR TITLE
fix(react-native): add /headless subpath so custom-UI consumers skip chat/attachment native deps

### DIFF
--- a/packages/react-native/USAGE.md
+++ b/packages/react-native/USAGE.md
@@ -114,3 +114,33 @@ Components can also be imported from the `/components` subpath:
 ```tsx
 import { CopilotChat, CopilotModal } from "@copilotkit/react-native/components";
 ```
+
+## Headless Import Path (custom UI, no chat/attachment native deps)
+
+If you build a fully custom chat UI and only need the provider and the
+agent/tool hooks, import from `@copilotkit/react-native/headless`:
+
+```tsx
+import {
+  CopilotKitProvider,
+  useAgent,
+  useFrontendTool,
+  useRenderTool,
+} from "@copilotkit/react-native/headless";
+```
+
+The default barrel (`@copilotkit/react-native`) statically re-exports the
+prebuilt chat components (`CopilotChat` / `CopilotModal` / `CopilotSidebar` /
+`CopilotPopup`, which import `@gorhom/bottom-sheet`) and `useAttachments` (which
+imports `expo-document-picker` + `expo-file-system`). Even though those are
+optional peer dependencies, the static re-export forces Metro to resolve them at
+bundle time — so a headless consumer previously had to install every chat and
+attachment native dep, or stub them in `metro.config.js`, to get past
+`Unable to resolve module expo-document-picker`.
+
+The `/headless` entry re-exports only the provider, the platform-agnostic hooks,
+the render-tool registry, and the core/AG-UI types — none of the chat UI or
+`useAttachments` — so those native deps never enter the bundle graph and the
+`metro.config.js` stub workaround is no longer needed. Polyfills are still
+auto-installed, so no separate `import "@copilotkit/react-native/polyfills"` is
+required.

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -19,6 +19,7 @@
   "type": "module",
   "sideEffects": [
     "./dist/index.*",
+    "./dist/headless.*",
     "./dist/polyfills.*",
     "./dist/polyfills/**/*"
   ],
@@ -29,6 +30,10 @@
     ".": {
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
+    },
+    "./headless": {
+      "import": "./dist/headless.mjs",
+      "require": "./dist/headless.cjs"
     },
     "./polyfills": {
       "import": "./dist/polyfills.mjs",

--- a/packages/react-native/src/__tests__/headless-entry-surface.test.ts
+++ b/packages/react-native/src/__tests__/headless-entry-surface.test.ts
@@ -106,7 +106,10 @@ describe("@copilotkit/react-native/headless entry", () => {
   it("does not reach the chat UI / useAttachments modules", () => {
     const reached = [...seen].filter((f) =>
       FORBIDDEN_LOCAL.some((name) =>
-        path.basename(f).replace(/\.tsx?$/, "").includes(name),
+        path
+          .basename(f)
+          .replace(/\.tsx?$/, "")
+          .includes(name),
       ),
     );
     expect(

--- a/packages/react-native/src/__tests__/headless-entry-surface.test.ts
+++ b/packages/react-native/src/__tests__/headless-entry-surface.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Guards the `@copilotkit/react-native/headless` entry (src/headless.ts).
+ *
+ * The whole point of the headless entry is that a consumer using only the
+ * provider + agent/tool hooks does NOT have to install (or Metro-stub) the
+ * chat/attachment native peer deps. That guarantee lives in the *static import
+ * graph*: if any module reachable from src/headless.ts imports the chat
+ * components or `useAttachments` — which pull `@gorhom/bottom-sheet`,
+ * `expo-document-picker`, `expo-file-system` — the guarantee is silently broken
+ * (nothing in a normal typecheck/test catches it, because those are optional
+ * peers). This walks the relative-import graph and fails if that happens.
+ *
+ * Mirrors the export-surface guard added for @copilotkit/react-core/v2/headless
+ * (PR #5883).
+ */
+
+const srcDir = path.resolve(__dirname, "..");
+const headlessEntry = path.join(srcDir, "headless.ts");
+
+// Bare module specifiers a headless consumer must NOT be forced to resolve.
+const FORBIDDEN_BARE = [
+  "@gorhom/bottom-sheet",
+  "expo-document-picker",
+  "expo-file-system",
+  "react-native-streamdown",
+];
+
+// Local modules that carry the chat UI / native-attachment stack.
+const FORBIDDEN_LOCAL = [
+  "CopilotChat",
+  "CopilotModal",
+  "CopilotSidebar",
+  "CopilotPopup",
+  "use-attachments",
+];
+
+const importRe =
+  /(?:import|export)\s+(?:type\s+)?[^"']*?from\s+["']([^"']+)["']|import\s+["']([^"']+)["']/g;
+
+function resolveLocal(fromFile: string, spec: string): string | null {
+  if (!spec.startsWith(".")) return null;
+  const base = path.resolve(path.dirname(fromFile), spec);
+  const candidates = [
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    path.join(base, "index.ts"),
+    path.join(base, "index.tsx"),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c) && fs.statSync(c).isFile()) return c;
+  }
+  return null;
+}
+
+function walkGraph(entry: string) {
+  const seen = new Set<string>();
+  const bareSpecs = new Set<string>();
+  const localFiles = new Set<string>();
+  const stack = [entry];
+
+  while (stack.length) {
+    const file = stack.pop()!;
+    if (seen.has(file)) continue;
+    seen.add(file);
+
+    const code = fs.readFileSync(file, "utf8");
+    for (const m of code.matchAll(importRe)) {
+      const spec = m[1] ?? m[2];
+      if (!spec) continue;
+      if (spec.startsWith(".")) {
+        const resolved = resolveLocal(file, spec);
+        if (resolved) {
+          localFiles.add(resolved);
+          stack.push(resolved);
+        }
+      } else {
+        bareSpecs.add(spec);
+      }
+    }
+  }
+  return { seen, bareSpecs, localFiles };
+}
+
+describe("@copilotkit/react-native/headless entry", () => {
+  it("has a headless entry file", () => {
+    expect(fs.existsSync(headlessEntry)).toBe(true);
+  });
+
+  const { seen, bareSpecs } = walkGraph(headlessEntry);
+
+  it("does not pull chat/attachment native peer deps into its import graph", () => {
+    const leaked = FORBIDDEN_BARE.filter((dep) =>
+      [...bareSpecs].some((s) => s === dep || s.startsWith(`${dep}/`)),
+    );
+    expect(
+      leaked,
+      `headless graph must not import: ${leaked.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("does not reach the chat UI / useAttachments modules", () => {
+    const reached = [...seen].filter((f) =>
+      FORBIDDEN_LOCAL.some((name) =>
+        path.basename(f).replace(/\.tsx?$/, "").includes(name),
+      ),
+    );
+    expect(
+      reached,
+      `headless graph must not reach: ${reached
+        .map((f) => path.relative(srcDir, f))
+        .join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("does export the provider + core headless hooks", async () => {
+    const mod = await import("../headless");
+    for (const name of [
+      "CopilotKitProvider",
+      "useCopilotKit",
+      "useAgent",
+      "useFrontendTool",
+      "useRenderTool",
+      "RenderToolProvider",
+    ]) {
+      expect(mod, `missing export: ${name}`).toHaveProperty(name);
+    }
+  });
+
+  it("does NOT re-export chat components or useAttachments from the headless entry", async () => {
+    const mod = await import("../headless");
+    for (const name of [
+      "CopilotChat",
+      "CopilotModal",
+      "CopilotSidebar",
+      "CopilotPopup",
+      "useAttachments",
+    ]) {
+      expect(mod, `headless entry must not export: ${name}`).not.toHaveProperty(
+        name,
+      );
+    }
+  });
+});

--- a/packages/react-native/src/headless.ts
+++ b/packages/react-native/src/headless.ts
@@ -1,0 +1,110 @@
+/**
+ * @copilotkit/react-native/headless
+ *
+ * Lean entry for headless React Native consumers: just the provider and the
+ * platform-agnostic agent/tool hooks, with NONE of the prebuilt chat UI.
+ *
+ * The default barrel (`@copilotkit/react-native`) re-exports the prebuilt chat
+ * components (`CopilotChat` / `CopilotModal` / `CopilotSidebar` / `CopilotPopup`,
+ * which import `@gorhom/bottom-sheet`) and `useAttachments` (which imports
+ * `expo-document-picker` + `expo-file-system`). Those are declared as optional
+ * peer dependencies, but a static re-export still forces Metro to resolve them
+ * at bundle time — so a consumer that only uses `CopilotKitProvider` + `useAgent`
+ * + `useFrontendTool` (a fully custom UI) had to install every chat/attachment
+ * native dep or stub them in `metro.config.js`, or the release bundle fails with
+ * `Unable to resolve module expo-document-picker`.
+ *
+ * Import from here to skip that stack entirely:
+ * ```tsx
+ * import { CopilotKitProvider, useAgent, useFrontendTool } from "@copilotkit/react-native/headless";
+ * ```
+ *
+ * Mirrors `@copilotkit/react-core/v2/headless` (issue #4893 / PR #5883), which
+ * this entry builds on. The default barrel re-exports everything here plus the
+ * chat UI, so existing imports from `@copilotkit/react-native` are unchanged.
+ */
+
+// Auto-install polyfills so consumers don't need a manual import.
+// Must run before any CopilotKit code that relies on ReadableStream / fetch streaming.
+import "./polyfills";
+
+// React Native provider (no web deps, no bottom-sheet, no expo native modules)
+export { CopilotKitProvider } from "./CopilotKitProvider";
+export type { CopilotKitNativeProviderProps } from "./CopilotKitProvider";
+
+// Provider props alias (mirrors web's CopilotKitProviderProps)
+export type { CopilotKitNativeProviderProps as CopilotKitProviderProps } from "./CopilotKitProvider";
+
+// Re-export context and hooks from react-core (platform-agnostic)
+export {
+  useCopilotKit,
+  useLicenseContext,
+  CopilotKitContext,
+  type CopilotKitContextValue,
+} from "@copilotkit/react-core/v2/context";
+
+// Re-export hooks that work without web deps
+// These consume the CopilotKitContext which our provider sets
+export {
+  useAgent,
+  useFrontendTool,
+  useComponent,
+  useHumanInTheLoop,
+  useInterrupt,
+  useSuggestions,
+  useConfigureSuggestions,
+  useAgentContext,
+  useThreads,
+  useCapabilities,
+  defineToolCallRenderer,
+  CopilotChatDefaultLabels,
+  type UseAgentUpdate,
+  type UseInterruptConfig,
+  type AgentContextInput,
+  type JsonSerializable,
+  type Thread,
+  type UseThreadsInput,
+  type UseThreadsResult,
+  type CopilotChatLabels,
+  type CopilotChatConfigurationValue,
+  type InterruptEvent,
+  type InterruptHandlerProps,
+  type InterruptRenderProps,
+  type Interrupt,
+  type ResumeEntry,
+  type ResumeStatus,
+  type ReactFrontendTool,
+  type ReactHumanInTheLoop,
+  type RenderToolInProgressProps,
+  type RenderToolExecutingProps,
+  type RenderToolCompleteProps,
+} from "@copilotkit/react-core/v2/headless";
+
+// Re-export core types commonly needed
+export type {
+  CopilotKitCoreRuntimeConnectionStatus,
+  CopilotKitCoreErrorCode,
+  Suggestion,
+  FrontendTool,
+  ToolCallStatus,
+} from "@copilotkit/core";
+
+// Re-export AG-UI types for consumer convenience (matches web SDK surface)
+export type {
+  Message,
+  AssistantMessage as AssistantMessageType,
+  ToolCall,
+  ToolMessage,
+  AbstractAgent,
+  AgentCapabilities,
+} from "@ag-ui/client";
+
+// Render tool hook (React Native version with render registry integration).
+// No DOM and no chat-UI stack: the app supplies the renderers.
+export { useRenderTool } from "./hooks/useRenderTool";
+export type { UseRenderToolOptions } from "./hooks/useRenderTool";
+export {
+  RenderToolProvider,
+  useRenderToolRegistry,
+} from "./hooks/RenderToolContext";
+export type { RenderToolProps } from "./hooks/RenderToolContext";

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -14,18 +14,17 @@
  * ```
  */
 
-// Auto-install polyfills so consumers don't need a manual import.
-// Must run before any CopilotKit code that relies on ReadableStream / fetch streaming.
-import "./polyfills";
+// Headless surface: provider + platform-agnostic hooks + core/AG-UI types.
+// This also side-effect-imports "./polyfills" (as its first statement), so the
+// polyfills install before any chat-UI module below is evaluated. The prebuilt
+// chat components + useAttachments are layered on top here; consumers who don't
+// need them (and want to skip the @gorhom/bottom-sheet + expo-* native deps)
+// can import from "@copilotkit/react-native/headless" instead.
+export * from "./headless";
 
-// React Native provider (no web dependencies)
-export { CopilotKitProvider } from "./CopilotKitProvider";
-export type { CopilotKitNativeProviderProps } from "./CopilotKitProvider";
-
-// Provider props alias (mirrors web's CopilotKitProviderProps)
-export type { CopilotKitNativeProviderProps as CopilotKitProviderProps } from "./CopilotKitProvider";
-
-// Headless chat components (no DOM, consumer provides UI)
+// Prebuilt chat components (import @gorhom/bottom-sheet; not in the
+// /headless entry). Consumers who don't need these can import the provider
+// and hooks from "@copilotkit/react-native/headless" instead.
 export { CopilotChat, useCopilotChatContext } from "./CopilotChat";
 export type { CopilotChatProps, CopilotChatContextValue } from "./CopilotChat";
 export { CopilotModal } from "./CopilotModal";
@@ -49,80 +48,11 @@ export type {
 export { CopilotPopup } from "./CopilotPopup";
 export type { CopilotPopupProps, CopilotPopupHandle } from "./CopilotPopup";
 
-// Re-export context and hooks from react-core (platform-agnostic)
-export {
-  useCopilotKit,
-  useLicenseContext,
-  CopilotKitContext,
-  type CopilotKitContextValue,
-} from "@copilotkit/react-core/v2/context";
-
-// Re-export hooks that work without web deps
-// These consume the CopilotKitContext which our provider sets
-export {
-  useAgent,
-  useFrontendTool,
-  useComponent,
-  useHumanInTheLoop,
-  useInterrupt,
-  useSuggestions,
-  useConfigureSuggestions,
-  useAgentContext,
-  useThreads,
-  useCapabilities,
-  defineToolCallRenderer,
-  CopilotChatDefaultLabels,
-  type UseAgentUpdate,
-  type UseInterruptConfig,
-  type AgentContextInput,
-  type JsonSerializable,
-  type Thread,
-  type UseThreadsInput,
-  type UseThreadsResult,
-  type CopilotChatLabels,
-  type CopilotChatConfigurationValue,
-  type InterruptEvent,
-  type InterruptHandlerProps,
-  type InterruptRenderProps,
-  type Interrupt,
-  type ResumeEntry,
-  type ResumeStatus,
-  type ReactFrontendTool,
-  type ReactHumanInTheLoop,
-  type RenderToolInProgressProps,
-  type RenderToolExecutingProps,
-  type RenderToolCompleteProps,
-} from "@copilotkit/react-core/v2/headless";
-
-// useRenderToolCall — web-specific (depends on DOM elements via DefaultToolCallRenderer)
-// useRenderCustomMessages — web-specific (tightly coupled to web chat UI rendering pipeline)
-// useRenderActivityMessage — web-specific (tightly coupled to web chat UI rendering pipeline)
-// useDefaultRenderTool — web-specific (DefaultToolCallRenderer uses <div>, <svg>, etc.)
-
-// Re-export core types commonly needed
-export type {
-  CopilotKitCoreRuntimeConnectionStatus,
-  CopilotKitCoreErrorCode,
-  Suggestion,
-  FrontendTool,
-  ToolCallStatus,
-} from "@copilotkit/core";
-
-// Re-export AG-UI types for consumer convenience (matches web SDK surface)
-export type {
-  Message,
-  AssistantMessage as AssistantMessageType,
-  ToolCall,
-  ToolMessage,
-  AbstractAgent,
-  AgentCapabilities,
-} from "@ag-ui/client";
-
-// Render tool hook (React Native version with render registry integration)
-export { useRenderTool } from "./hooks/useRenderTool";
-export type { UseRenderToolOptions } from "./hooks/useRenderTool";
-export {
-  RenderToolProvider,
-  useRenderToolRegistry,
-} from "./hooks/RenderToolContext";
-export type { RenderToolProps } from "./hooks/RenderToolContext";
+// The provider, platform-agnostic hooks (useAgent / useFrontendTool / ...),
+// core + AG-UI types, and the render-tool registry are re-exported from
+// "./headless" above (`export * from "./headless"`).
+//
+// Deliberately NOT re-exported (web-specific, from @copilotkit/react-core/v2):
+//   useRenderToolCall     — depends on DOM elements via DefaultToolCallRenderer
+//   useRenderCustomMessages / useRenderActivityMessage — web chat UI pipeline
+//   useDefaultRenderTool  — DefaultToolCallRenderer uses <div>, <svg>, etc.

--- a/packages/react-native/tsdown.config.ts
+++ b/packages/react-native/tsdown.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "tsdown";
 export default defineConfig({
   entry: [
     "src/index.ts",
+    "src/headless.ts",
     "src/components/index.ts",
     "src/polyfills.ts",
     "src/polyfills/streams.ts",


### PR DESCRIPTION
## Problem

`@copilotkit/react-native`'s entry (`packages/react-native/src/index.ts`) statically re-exports the prebuilt chat UI — `CopilotChat` / `CopilotModal` / `CopilotSidebar` / `CopilotPopup`, which import `@gorhom/bottom-sheet` — and `useAttachments`, which imports `expo-document-picker` + `expo-file-system`.

Those are declared as **optional** peer deps, but a static re-export still forces Metro to resolve them at bundle time. So a **headless** consumer that mounts only `CopilotKitProvider` + `useAgent` + `useFrontendTool` (a fully custom UI, no prebuilt chat) is still forced to install all of those native deps, or Metro's release bundle fails:

```
Unable to resolve module expo-document-picker
```

Today the only workaround is stubbing the modules in `metro.config.js`.

## Fix

Add a lean `@copilotkit/react-native/headless` subpath entry that re-exports **only** the provider (`CopilotKitProvider`), the platform-agnostic hooks (`useAgent`, `useFrontendTool`, `useCopilotKit`, `useHumanInTheLoop`, `useInterrupt`, `useThreads`, `useSuggestions`, `useRenderTool`, …), the render-tool registry, and the core/AG-UI types — and **none** of the chat components or `useAttachments`. Those native deps therefore never enter the bundle graph:

```tsx
import { CopilotKitProvider, useAgent, useFrontendTool } from "@copilotkit/react-native/headless";
```

This **retires the `metro.config.js` stub workaround** for headless consumers.

## How it mirrors the precedent (#5883)

Directly mirrors `@copilotkit/react-core/v2/headless` (PR #5883, which cut multi-MB bundle bloat by exposing lean hooks from a dedicated entry — and which this RN provider already consumes):

- **Standalone entry file** — `src/headless.ts` (the lean surface).
- **tsdown** — added to the `entry` list (RN's tsdown auto-externalizes deps/peerDeps, so the native modules stay external and simply never get imported by this entry).
- **`package.json`** — new `./headless` condition in `exports`, and `./dist/headless.*` added to `sideEffects` (the entry side-effect-imports the polyfills).
- **Regression test** — a static import-graph test (`headless-entry-surface.test.ts`) that walks the transitive graph from `src/headless.ts` and fails if it ever reaches the chat/attachment modules or `@gorhom/bottom-sheet` / `expo-document-picker` / `expo-file-system`. This is the guarantee a normal typecheck can't catch, since those are optional peers.

## Backward compatibility

Fully backward compatible. The default barrel (`@copilotkit/react-native`) now does `export * from "./headless"` and layers the chat UI + `useAttachments` on top, so every existing import from `@copilotkit/react-native` is unchanged. The polyfills still auto-install from both entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)