### PR TITLE
fix(runtime): preserve anyOf/oneOf unions in frontend tool schemas

### DIFF
--- a/packages/runtime/src/agent/__tests__/utils.test.ts
+++ b/packages/runtime/src/agent/__tests__/utils.test.ts
@@ -344,7 +344,7 @@ describe("convertJsonSchemaToZodSchema", () => {
     } as any;
 
     const zodSchema = convertJsonSchemaToZodSchema(jsonSchema, true);
-    expect((zodSchema as z.ZodType)._def.typeName).toBe("ZodUnion");
+    expect(zodSchema).toBeInstanceOf(z.ZodUnion);
     expect(zodSchema.parse({ kind: "text", text: "hi" })).toEqual({
       kind: "text",
       text: "hi",

--- a/packages/runtime/src/agent/__tests__/utils.test.ts
+++ b/packages/runtime/src/agent/__tests__/utils.test.ts
@@ -316,6 +316,93 @@ describe("convertJsonSchemaToZodSchema", () => {
     const valid = zodSchema.parse({ user: { name: "John" } });
     expect(valid).toEqual({ user: { name: "John" } });
   });
+
+  it("should convert anyOf/oneOf unions to a Zod union instead of dropping them", () => {
+    // A frontend tool authored with z.discriminatedUnion serializes to a node
+    // carrying `anyOf` (or `oneOf`) and no top-level `type`. Previously this hit
+    // the empty-schema guard and collapsed to z.object({}), silently dropping
+    // the union. It must become a real z.union so both variants survive.
+    const jsonSchema = {
+      anyOf: [
+        {
+          type: "object" as const,
+          properties: {
+            kind: { type: "string" as const, enum: ["text"] },
+            text: { type: "string" as const },
+          },
+          required: ["kind", "text"],
+        },
+        {
+          type: "object" as const,
+          properties: {
+            kind: { type: "string" as const, enum: ["image"] },
+            url: { type: "string" as const },
+          },
+          required: ["kind", "url"],
+        },
+      ],
+    } as any;
+
+    const zodSchema = convertJsonSchemaToZodSchema(jsonSchema, true);
+    expect((zodSchema as z.ZodType)._def.typeName).toBe("ZodUnion");
+    expect(zodSchema.parse({ kind: "text", text: "hi" })).toEqual({
+      kind: "text",
+      text: "hi",
+    });
+    expect(zodSchema.parse({ kind: "image", url: "http://x/y.png" })).toEqual({
+      kind: "image",
+      url: "http://x/y.png",
+    });
+  });
+
+  it("should preserve a union nested inside array items (the oneOf trap)", () => {
+    // The exact reported trap: a z.discriminatedUnion inside array items. The
+    // union node must survive conversion; before the fix the array items became
+    // an empty object and the union-typed data was lost.
+    const jsonSchema = {
+      type: "object" as const,
+      properties: {
+        blocks: {
+          type: "array" as const,
+          items: {
+            oneOf: [
+              {
+                type: "object" as const,
+                properties: {
+                  type: { type: "string" as const, enum: ["heading"] },
+                  level: { type: "number" as const },
+                },
+                required: ["type", "level"],
+              },
+              {
+                type: "object" as const,
+                properties: {
+                  type: { type: "string" as const, enum: ["paragraph"] },
+                  content: { type: "string" as const },
+                },
+                required: ["type", "content"],
+              },
+            ],
+          },
+        },
+      },
+      required: ["blocks"],
+    } as any;
+
+    const zodSchema = convertJsonSchemaToZodSchema(jsonSchema, true);
+    const parsed = zodSchema.parse({
+      blocks: [
+        { type: "heading", level: 1 },
+        { type: "paragraph", content: "hello" },
+      ],
+    });
+    expect(parsed).toEqual({
+      blocks: [
+        { type: "heading", level: 1 },
+        { type: "paragraph", content: "hello" },
+      ],
+    });
+  });
 });
 
 describe("convertToolsToVercelAITools", () => {

--- a/packages/runtime/src/agent/index.ts
+++ b/packages/runtime/src/agent/index.ts
@@ -546,12 +546,17 @@ export function convertMessagesToVercelAISDKMessages(
  * JSON Schema type definition
  */
 interface JsonSchema {
-  type: "object" | "string" | "number" | "integer" | "boolean" | "array";
+  type?: "object" | "string" | "number" | "integer" | "boolean" | "array";
   description?: string;
   properties?: Record<string, JsonSchema>;
   required?: string[];
   items?: JsonSchema;
   enum?: string[];
+  // Union combinators. A frontend tool authored with `z.discriminatedUnion`
+  // (or any `z.union`) serializes to a node carrying `anyOf` / `oneOf` and
+  // usually NO top-level `type`.
+  anyOf?: JsonSchema[];
+  oneOf?: JsonSchema[];
 }
 
 /**
@@ -561,6 +566,28 @@ export function convertJsonSchemaToZodSchema(
   jsonSchema: JsonSchema,
   required: boolean,
 ): z.ZodSchema {
+  // Handle `anyOf` / `oneOf` unions (e.g. `z.discriminatedUnion` or `z.union`
+  // on a frontend tool) as `z.union`. These nodes usually carry no top-level
+  // `type`, so they MUST be handled before the empty-schema guard below —
+  // otherwise the union collapses to an empty object (`z.object({})`), the
+  // reconstructed tool schema loses the union-typed field entirely, and the
+  // model can never emit it. This is especially load-bearing for a union
+  // nested inside array `items`, which OpenAI otherwise silently drops.
+  const unionVariants = jsonSchema.anyOf ?? jsonSchema.oneOf;
+  if (Array.isArray(unionVariants) && unionVariants.length > 0) {
+    // A single-variant union is just that variant.
+    if (unionVariants.length === 1) {
+      return convertJsonSchemaToZodSchema(unionVariants[0], required);
+    }
+    const variantSchemas = unionVariants.map((variant) =>
+      convertJsonSchemaToZodSchema(variant, true),
+    );
+    const schema = z
+      .union(variantSchemas as [z.ZodSchema, z.ZodSchema, ...z.ZodSchema[]])
+      .describe(jsonSchema.description ?? "");
+    return required ? schema : schema.optional();
+  }
+
   // Handle empty schemas {} (no input required) - treat as empty object
   if (!jsonSchema.type) {
     return required ? z.object({}) : z.object({}).optional();


### PR DESCRIPTION
## Problem

A frontend/client tool (`useFrontendTool`) whose Zod `parameters` use `z.discriminatedUnion(...)` — or any schema that serializes to a JSON-schema `anyOf`/`oneOf` node — silently loses the union-typed field when calling OpenAI. The tool call arrives with that field missing or empty. Switching the same tool to a flat object with an enum discriminant works, which points at schema conversion rather than the model.

## Root cause

The runtime has **two** JSON-Schema → Zod converters:

- `@copilotkit/shared`'s `convertJsonSchemaToZodSchema` already handles `anyOf`/`oneOf` as `z.union` (and `$ref`, null-unions, graceful fallback).
- The **local copy** in `packages/runtime/src/agent/index.ts` — used by the classic `BuiltInAgent` / AI SDK path via `convertToolsToVercelAITools` — never did.

A union node carries no top-level `type`, so it hit the empty-schema guard (`if (!jsonSchema.type)`) and collapsed to `z.object({})`. The reconstructed tool schema therefore dropped the union entirely — most visibly for a union nested inside array `items` — so the model was never offered those fields and could not emit them. (The legacy GraphQL OpenAI adapter is unaffected: it forwards the JSON schema directly.)

## Fix

Handle `anyOf`/`oneOf` as `z.union` **before** the empty-schema guard, mirroring the already-proven shared converter. A single-variant union unwraps to that variant.

## Backward compatibility

Only previously-broken union nodes change behavior (empty object → real union). Empty `{}` schemas, typed nodes, and the `isJsonSchema` gate are untouched. Two regression tests added: a direct `anyOf` conversion and the exact nested-`items` `oneOf` trap.

## Repro

A `useFrontendTool` with

```ts
parameters: z.object({
  blocks: z.array(z.discriminatedUnion("type", [
    z.object({ type: z.literal("heading"), level: z.number() }),
    z.object({ type: z.literal("paragraph"), content: z.string() }),
  ])),
})
```

against OpenAI: before, `blocks` items arrived empty; after, both variants survive into the model call.

## Note on OpenAI strict mode

This path does not enable OpenAI strict function-calling, so once the union survives conversion it serializes back to `anyOf` and OpenAI accepts it. The data loss was upstream, in CopilotKit's own converter, not an OpenAI strict-mode limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)