### PR TITLE
feat(channels)!: Plan C — channels run only through the Intelligence runtime

### DIFF
--- a/examples/slack/.env.example
+++ b/examples/slack/.env.example
@@ -40,21 +40,26 @@ AGENT_URL=http://localhost:8200/api/copilotkit/agent/triage/run
 # AGENT_MODEL=openai/gpt-5.5-mini
 OPENAI_API_KEY=sk-...
 
-# ── Intelligence (managed Channel) mode — app/managed.ts (`pnpm channel`) ─
-# The managed variant runs the SAME bot over Intelligence instead of a native
-# adapter — it holds NO Slack tokens (Intelligence owns the Slack edge). Set
-# these to run `pnpm channel`; the native `pnpm dev` ignores them. The agent
-# brain reuses AGENT_URL / AGENT_AUTH_HEADER above. There is NO launcher and no
-# infra ids to supply: the runtime derives project, adapter, and channel from
-# the config below plus the channel name chosen in app/managed.ts.
+# ── Intelligence (REQUIRED — owns the Channel lifecycle) ────────────────
+# A Channel runs ONLY through the Intelligence runtime, so BOTH the native path
+# (`pnpm dev` / `pnpm start`, app/index.ts) AND the zero-adapter managed variant
+# (`pnpm channel`, app/managed.ts) need these. Free tier is enough. The direct
+# platform adapters keep their own Slack/Discord/… credentials above; the
+# runtime that owns the Channel is configured with the Intelligence key and
+# starts those adapters for you (there is no launcher, and no infra ids to
+# supply — the runtime derives project/adapter/channel from the config below
+# plus the channel name chosen in code).
 # Intelligence platform API base URL.
-# COPILOTKIT_INTELLIGENCE_URL=http://localhost:4201
+COPILOTKIT_INTELLIGENCE_URL=https://api.copilotkit.ai
 # Project runtime API key (cpk-…).
-# COPILOTKIT_API_KEY=cpk-...
+COPILOTKIT_API_KEY=cpk-...
 # Optional: websocket base URL. Derived from COPILOTKIT_INTELLIGENCE_URL by a
-# scheme-only swap (http→ws, same host+port) when unset — so the default here is
-# ws://localhost:4201, matching the API URL above.
-# COPILOTKIT_INTELLIGENCE_WS_URL=ws://localhost:4201
+# scheme-only swap (http→ws, same host+port) when unset.
+# COPILOTKIT_INTELLIGENCE_WS_URL=
+# Optional: port for the Intelligence runtime that owns the Channel lifecycle
+# (loopback-only; keeps the process alive; distinct from WhatsApp's $PORT
+# webhook). Defaults to 8300.
+# CHANNELS_PORT=8300
 
 # ── Linear MCP ──────────────────────────────────────────────────────────
 # The hosted Linear MCP accepts a raw API key as a bearer token (no OAuth

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -129,7 +129,10 @@ const runtime = new CopilotRuntime({
 
 // Mounting the listener activates the Channel (starting its adapters) and
 // exposes `.channels` for readiness + shutdown — no bot.start()/bot.stop().
-const listener = createCopilotNodeListener({ runtime, basePath: "/api/copilotkit" });
+const listener = createCopilotNodeListener({
+  runtime,
+  basePath: "/api/copilotkit",
+});
 createServer(listener).listen(8300, "127.0.0.1");
 await listener.channels?.ready();
 ```

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -56,14 +56,21 @@ Slack / Discord / Telegram ──@mention──▶  bot (app/)  ──AG-UI─�
 
 ### The bot (`app/index.ts`)
 
-The core shape is `createChannel` + one or more adapters, an `onMention` handler,
-and `start()`. The snippet below is an **abridged, single-platform sketch** —
-the real `app/index.ts` builds the adapter list from whichever secrets are
-present (Slack, Discord, and/or Telegram) and adds graceful shutdown; read the
-file for the full multi-platform wiring:
+The core shape is `createChannel` + one or more adapters + an `onMention`
+handler, then you **declare the Channel on the Intelligence runtime**, which owns
+its lifecycle. A Channel runs ONLY through the Intelligence runtime: the platform
+adapters stay direct (they keep their own credentials), but the runtime starts
+them — there is no `bot.start()`/`bot.stop()`. The snippet below is an
+**abridged, single-platform sketch** — the real `app/index.ts` builds the adapter
+list from whichever secrets are present (Slack, Discord, Telegram, and/or
+WhatsApp) and adds graceful shutdown; read the file for the full multi-platform
+wiring:
 
 ```ts
+import { createServer } from "node:http";
 import { createChannel } from "@copilotkit/channels";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 import {
   slack,
   defaultSlackTools,
@@ -74,6 +81,7 @@ import { appTools } from "./tools/index.js";
 import { appContext } from "./context/app-context.js";
 
 const bot = createChannel({
+  name: "triage", // every declared Channel needs a unique name
   adapters: [
     slack({
       botToken: process.env.SLACK_BOT_TOKEN!,
@@ -105,7 +113,25 @@ bot.onMention(async ({ thread, message }) => {
   await thread.runAgent({ context: senderContext(message.user) });
 });
 
-await bot.start();
+// A Channel runs only through the Intelligence runtime, which OWNS its
+// lifecycle — it starts the direct Slack adapter for us.
+const intelligence = new CopilotKitIntelligence({
+  apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
+  wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!, // or derive from apiUrl
+  apiKey: process.env.COPILOTKIT_API_KEY!,
+});
+const runtime = new CopilotRuntime({
+  agents: {}, // the Channel supplies its own agent
+  intelligence,
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }), // demo stub
+  channels: [bot],
+});
+
+// Mounting the listener activates the Channel (starting its adapters) and
+// exposes `.channels` for readiness + shutdown — no bot.start()/bot.stop().
+const listener = createCopilotNodeListener({ runtime, basePath: "/api/copilotkit" });
+createServer(listener).listen(8300, "127.0.0.1");
+await listener.channels?.ready();
 ```
 
 The runnable Slack example keeps DMs and the assistant pane conversational, but
@@ -293,6 +319,7 @@ several from one process).
 ```bash
 cp .env.example .env
 # Fill in (set SLACK_*, DISCORD_*, and/or TELEGRAM_BOT_TOKEN — whichever you want):
+#   COPILOTKIT_INTELLIGENCE_URL / COPILOTKIT_API_KEY  (REQUIRED — owns the Channel; free tier)
 #   SLACK_BOT_TOKEN / SLACK_APP_TOKEN          (to run on Slack)
 #   DISCORD_BOT_TOKEN / DISCORD_APP_ID         (to run on Discord; DISCORD_GUILD_ID optional)
 #   TELEGRAM_BOT_TOKEN                         (to run on Telegram)
@@ -302,8 +329,11 @@ cp .env.example .env
 #   NOTION_MCP_AUTH_TOKEN   (any strong string; shared between the sidecar and the agent)
 ```
 
-Linear and Notion are independent — set only the ones you want; the agent
-wires up whichever credentials are present.
+A Channel runs only through the Intelligence runtime, so
+`COPILOTKIT_INTELLIGENCE_URL` + `COPILOTKIT_API_KEY` are **required** (free tier).
+The platform adapters stay direct — the runtime that owns the Channel starts each
+of them for you. Linear and Notion are independent — set only the ones you want;
+the agent wires up whichever credentials are present.
 
 ### 3. Notion MCP sidecar (only if using Notion)
 

--- a/examples/slack/app/index.ts
+++ b/examples/slack/app/index.ts
@@ -6,18 +6,31 @@
  *
  * MULTI-PLATFORM: this single app drives Slack, Discord, Telegram, and/or
  * WhatsApp from one process. `@copilotkit/channels`'s `createChannel` accepts an array
- * of adapters and starts them all, so we include each platform's adapter only
- * when its secrets are present. Drop in `SLACK_*` to run Slack, `DISCORD_*` for
- * Discord, `TELEGRAM_BOT_TOKEN` for Telegram, `WHATSAPP_*` for WhatsApp — or any
+ * of adapters, so we include each platform's adapter only when its secrets are
+ * present. Drop in `SLACK_*` to run Slack, `DISCORD_*` for Discord,
+ * `TELEGRAM_BOT_TOKEN` for Telegram, `WHATSAPP_*` for WhatsApp — or any
  * combination to run them at once. The rest of `app/` (tools, components, HITL,
  * rendering) is platform-agnostic and shared verbatim.
+ *
+ * RUN MODEL — a Channel runs ONLY through the Intelligence runtime, so this
+ * example needs an Intelligence key (free tier: `COPILOTKIT_INTELLIGENCE_URL` +
+ * `COPILOTKIT_API_KEY`). The platform adapters stay DIRECT (they keep their own
+ * Slack/Discord/Telegram/WhatsApp credentials + transports); the runtime OWNS
+ * the Channel's lifecycle and STARTS all of its direct adapters for us. So all
+ * four platforms stay on the ONE Channel — you declare it on
+ * `new CopilotRuntime({ intelligence, identifyUser, channels: [bot] })`, mount a
+ * node listener, and drive `listener.channels?.ready()` / `.stop()`. There is no
+ * `bot.start()`/`bot.stop()` and no standalone path.
  *
  * Defaults are not auto-applied — you spread them explicitly. That's
  * deliberate: there's no hidden behavior, and the canonical pattern is right
  * here in the file you copy from to start a new bot.
  */
 import "dotenv/config";
+import { createServer } from "node:http";
 import { createChannel } from "@copilotkit/channels";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 import type {
   PlatformAdapter,
   ChannelTool,
@@ -63,6 +76,13 @@ const required = (name: string): string => {
 /** True only when every named env var is set and non-empty. */
 const have = (...names: string[]): boolean =>
   names.every((n) => Boolean(process.env[n]));
+
+/**
+ * Derive the Intelligence websocket base URL from the API base URL when it
+ * isn't set explicitly: `http(s)://…` → `ws(s)://…` (same host + port).
+ */
+const deriveWsUrl = (apiUrl: string): string =>
+  apiUrl.replace(/^http(s?):\/\//, "ws$1://");
 
 async function main() {
   const agentUrl = required("AGENT_URL");
@@ -184,6 +204,10 @@ async function main() {
   }
 
   const bot = createChannel({
+    // Every declared Channel needs a unique `name` — the Intelligence runtime
+    // keys its lifecycle by it. All four platforms ride this ONE Channel; the
+    // runtime starts each of its direct adapters when the Channel activates.
+    name: "triage",
     adapters,
     // One AG-UI agent per conversation. The backend is a CopilotKit
     // `BuiltInAgent` (CopilotSseRuntime), which does NOT require a UUID-format
@@ -260,14 +284,61 @@ async function main() {
     ]);
   });
 
-  await bot.start();
+  // The Intelligence client the Channel-owning runtime is configured with. A
+  // Channel runs only through the Intelligence runtime — the direct adapters
+  // keep their own platform credentials, but the runtime is what starts them.
+  const intelligenceApiUrl = required("COPILOTKIT_INTELLIGENCE_URL");
+  const intelligence = new CopilotKitIntelligence({
+    apiUrl: intelligenceApiUrl,
+    wsUrl:
+      process.env.COPILOTKIT_INTELLIGENCE_WS_URL ??
+      deriveWsUrl(intelligenceApiUrl),
+    apiKey: required("COPILOTKIT_API_KEY"),
+  });
+
+  // Declare the Channel on the Intelligence runtime, which OWNS its lifecycle:
+  // because Intelligence is configured, it starts EVERY direct adapter on the
+  // Channel (Slack + Discord + Telegram + WhatsApp alike) — there is no
+  // `bot.start()`. The runtime hosts no agents itself; the Channel supplies its
+  // own (the SanitizingHttpAgent above), so `agents` is empty.
+  const channelRuntime = new CopilotRuntime({
+    agents: {},
+    intelligence,
+    // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
+    // before any multi-user deployment, or all users share one thread history.
+    identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+    channels: [bot],
+  });
+
+  // Mounting the Node listener creates the runtime handler, which activates the
+  // Channel (starting all its direct adapters) and exposes `.channels` for
+  // readiness + shutdown. This listener holds the Intelligence key and needs no
+  // public ingress (each platform adapter has its own — e.g. WhatsApp's webhook
+  // on $PORT); it only owns the Channel lifecycle and keeps the process alive.
+  const channelPort = Number(process.env.CHANNELS_PORT ?? 8300);
+  const listener = createCopilotNodeListener({
+    runtime: channelRuntime,
+    basePath: "/api/copilotkit",
+  });
+  createServer(listener).listen(channelPort, "127.0.0.1", () => {
+    console.log(
+      `[channel] runtime (owns lifecycle) listening on 127.0.0.1:${channelPort}`,
+    );
+  });
+
+  // Drive readiness through the runtime's Channel control instead of a
+  // (now-removed) bot.start(): resolves once every direct adapter's transport is
+  // up across all active platforms.
+  await listener.channels?.ready();
   console.log(
     `[channel] started on: ${adapters.map((a) => a.platform).join(", ")}`,
   );
 
   const shutdown = async (signal: string) => {
     console.log(`\n[channel] received ${signal}, stopping…`);
-    await bot.stop();
+    // Stop through the runtime's Channel control, which tears down every direct
+    // adapter it started.
+    await listener.channels?.stop();
     // Tear down the shared headless browser used for chart/diagram rendering.
     await closeBrowser();
     process.exit(0);

--- a/examples/slack/app/index.ts
+++ b/examples/slack/app/index.ts
@@ -329,7 +329,8 @@ async function main() {
   // Drive readiness through the runtime's Channel control instead of a
   // (now-removed) bot.start(): resolves once every direct adapter's transport is
   // up across all active platforms.
-  await listener.channels?.ready();
+  // Bound startup so a wedged adapter connect can't hang readiness forever.
+  await listener.channels?.ready({ timeoutMs: 30_000 });
   console.log(
     `[channel] started on: ${adapters.map((a) => a.platform).join(", ")}`,
   );

--- a/examples/teams/.env.example
+++ b/examples/teams/.env.example
@@ -3,11 +3,26 @@ OPENAI_API_KEY=
 # Optional: defaults to openai/gpt-5.5.
 # OPENAI_MODEL=
 
+# ── Intelligence (owns the Channel lifecycle) ───────────────────────────
+# A Channel runs ONLY through the Intelligence runtime. The Teams adapter stays
+# DIRECT (no Microsoft creds needed in the Playground), but the runtime that
+# starts/stops it is configured with an Intelligence key. Free tier is enough.
+# Intelligence platform API base URL.
+COPILOTKIT_INTELLIGENCE_URL=https://api.copilotkit.ai
+# Project runtime API key (cpk-…).
+COPILOTKIT_API_KEY=cpk-...
+# Optional: websocket base URL. Derived from COPILOTKIT_INTELLIGENCE_URL by a
+# scheme-only swap (http→ws, same host+port) when unset.
+# COPILOTKIT_INTELLIGENCE_WS_URL=
+
 # The Microsoft 365 Agents Playground connects to the bot anonymously, so NO
 # Microsoft credentials are needed for local development. Just run `pnpm start`.
 
 # Port for the bot's POST /api/messages endpoint (the Playground default).
 PORT=3978
+# Optional: port for the Intelligence runtime that owns the Channel lifecycle
+# (loopback-only; keeps the process alive). Defaults to 8300.
+# CHANNELS_PORT=8300
 
 # --- Only needed to talk to REAL Microsoft Teams via Azure Bot Service ---
 # (lowercase names: the M365 Agents SDK reads these via loadAuthConfigFromEnv)

--- a/examples/teams/README.md
+++ b/examples/teams/README.md
@@ -5,16 +5,27 @@ Teams bot backed by a CopilotKit `BuiltInAgent` that shows
 **streamed-by-edit replies**, **agent-rendered Adaptive Cards**, and a
 **human-in-the-loop approval gate**, testable locally in the **Microsoft 365
 Agents Playground** with **no Microsoft credentials**. It needs an
-`OPENAI_API_KEY`. The application depends on the umbrella and imports the Teams
-integration from `@copilotkit/channels/teams`.
+`OPENAI_API_KEY` and an **Intelligence key** (free tier). The application depends
+on the umbrella and imports the Teams integration from
+`@copilotkit/channels/teams`.
+
+A Channel runs **only** through the Intelligence runtime. The Teams adapter stays
+_direct_ (it keeps the Playground/Teams ingress), but the runtime owns the
+Channel's lifecycle: the bot is declared on
+`new CopilotRuntime({ intelligence, identifyUser, channels: [bot] })` and started
+/ stopped via `listener.channels?.ready()` / `.stop()` — there is no
+`bot.start()`/`bot.stop()`. That's why an Intelligence key is required even
+though no Microsoft credentials are.
 
 ## Run it
 
 From this directory (after `pnpm install` at the repo root):
 
 ```sh
-export OPENAI_API_KEY=sk-...   # or add it to .env (see .env.example)
-pnpm start                     # starts the bot on http://localhost:3978/api/messages
+export OPENAI_API_KEY=sk-...              # or add it to .env (see .env.example)
+export COPILOTKIT_INTELLIGENCE_URL=https://api.copilotkit.ai
+export COPILOTKIT_API_KEY=cpk-...          # Intelligence key (free tier)
+pnpm start                                 # starts the bot on http://localhost:3978/api/messages
 ```
 
 In a second terminal:
@@ -166,6 +177,14 @@ Set the environment for wherever you deploy:
 - `OPENAI_API_KEY` _(required)_: the bot runs a `BuiltInAgent` and exits at
   startup without it.
 - `OPENAI_MODEL` _(optional)_: defaults to `openai/gpt-5.5`.
+- `COPILOTKIT_INTELLIGENCE_URL` / `COPILOTKIT_API_KEY` _(required)_: the
+  Intelligence runtime that owns the Channel lifecycle. A Channel runs only
+  through Intelligence, so the bot exits at startup without these (free tier is
+  enough).
+- `COPILOTKIT_INTELLIGENCE_WS_URL` _(optional)_: websocket base URL; derived from
+  `COPILOTKIT_INTELLIGENCE_URL` (http→ws, same host+port) when unset.
+- `CHANNELS_PORT` _(optional)_: port for the Intelligence runtime that owns the
+  Channel (loopback-only, default 8300).
 - `clientId` / `clientSecret` / `tenantId`: needed to reach real Teams (see
   above). The in-process `BuiltInAgent` runtime stays on `RUNTIME_PORT`
   (localhost-only, default 8200).

--- a/examples/teams/app/index.tsx
+++ b/examples/teams/app/index.tsx
@@ -7,8 +7,18 @@
  * table, list of facts) is clearer as a card than as prose. Consequential
  * actions go through a human-in-the-loop approval gate (`confirm_write`).
  *
- * Requires `OPENAI_API_KEY`. No Microsoft credentials are needed to test in the
- * M365 Agents Playground:
+ * RUN MODEL — a Channel runs ONLY through the Intelligence runtime. The Teams
+ * `teams({ port })` adapter stays DIRECT (it keeps its own transport / the
+ * Playground ingress), but the runtime OWNS its lifecycle: the Channel is
+ * declared on `new CopilotRuntime({ intelligence, identifyUser, channels })`,
+ * and you drive readiness/shutdown through the handler's `channels` control
+ * (`listener.channels?.ready()` / `.stop()`) — there is no `bot.start()`/
+ * `bot.stop()` and no standalone path.
+ *
+ * Requires `OPENAI_API_KEY` (the BuiltInAgent's LLM) AND an Intelligence key
+ * (`COPILOTKIT_INTELLIGENCE_URL` + `COPILOTKIT_API_KEY` — free tier), which the
+ * runtime that owns the Channel is configured with. No Microsoft credentials
+ * are needed to test in the M365 Agents Playground:
  *
  *   pnpm start        # bot on http://localhost:3978/api/messages
  *   pnpm playground   # M365 Agents Playground UI (http://localhost:56150)
@@ -17,7 +27,12 @@ import "dotenv/config";
 import { createServer } from "node:http";
 import { createChannel, defineChannelTool } from "@copilotkit/channels";
 import { teams, SanitizingHttpAgent } from "@copilotkit/channels/teams";
-import { BuiltInAgent, CopilotSseRuntime } from "@copilotkit/runtime/v2";
+import {
+  BuiltInAgent,
+  CopilotSseRuntime,
+  CopilotRuntime,
+  CopilotKitIntelligence,
+} from "@copilotkit/runtime/v2";
 import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 import { z } from "zod";
 import { hitlTools } from "./human-in-the-loop/index.js";
@@ -44,6 +59,32 @@ if (!process.env.OPENAI_API_KEY) {
   );
   process.exit(1);
 }
+
+// A Channel runs ONLY through the Intelligence runtime — the runtime that owns
+// the Channel's lifecycle is configured with an Intelligence key. Fail fast
+// here rather than deep in activation. Free tier is enough for this demo.
+const required = (name: string): string => {
+  const v = process.env[name];
+  if (!v) {
+    console.error(
+      `Missing ${name}.\n` +
+        "Channels run only through the Intelligence runtime, which needs an " +
+        "Intelligence key (free tier).\n" +
+        "  export COPILOTKIT_INTELLIGENCE_URL=https://api.copilotkit.ai\n" +
+        "  export COPILOTKIT_API_KEY=cpk-...   (or add them to examples/teams/.env)\n" +
+        "Optional: COPILOTKIT_INTELLIGENCE_WS_URL (derived from the API URL when unset).",
+    );
+    process.exit(1);
+  }
+  return v;
+};
+
+/**
+ * Derive the Intelligence websocket base URL from the API base URL when it
+ * isn't set explicitly: `http(s)://…` → `ws(s)://…` (same host + port).
+ */
+const deriveWsUrl = (apiUrl: string): string =>
+  apiUrl.replace(/^http(s?):\/\//, "ws$1://");
 
 const port = Number(process.env.PORT ?? 3978);
 
@@ -161,6 +202,9 @@ const showCard = defineChannelTool({
 });
 
 const bot = createChannel({
+  // Every declared Channel needs a unique `name` — the Intelligence runtime
+  // keys its lifecycle (and, for managed Channels, its activation config) by it.
+  name: "teams-assistant",
   adapters: [teams({ port })],
   agent: (threadId: string) => {
     const agent = new SanitizingHttpAgent({ url: runtimeAgentUrl });
@@ -193,7 +237,53 @@ bot.onMessage(async ({ thread, message }) => {
   await thread.runAgent();
 });
 
-await bot.start();
+// The Intelligence client the Channel-owning runtime is configured with. The
+// Teams adapter stays DIRECT (it keeps its own credentials/transport), but a
+// Channel runs only through the Intelligence runtime, so the runtime is what
+// starts and stops it.
+const intelligenceApiUrl = required("COPILOTKIT_INTELLIGENCE_URL");
+const intelligence = new CopilotKitIntelligence({
+  apiUrl: intelligenceApiUrl,
+  wsUrl:
+    process.env.COPILOTKIT_INTELLIGENCE_WS_URL ??
+    deriveWsUrl(intelligenceApiUrl),
+  apiKey: required("COPILOTKIT_API_KEY"),
+});
+
+// Declare the Channel on the Intelligence runtime. The runtime OWNS the
+// Channel's lifecycle: because Intelligence is configured, it starts the direct
+// Teams adapter for us (there is no `bot.start()`). It hosts no agents itself —
+// the Channel supplies its own agent (the SanitizingHttpAgent above, pointed at
+// the local BuiltInAgent runtime) — so `agents` is empty.
+const channelRuntime = new CopilotRuntime({
+  agents: {},
+  intelligence,
+  // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
+  // before any multi-user deployment, or all users share one thread history.
+  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+  channels: [bot],
+});
+
+// Mounting the Node listener creates the runtime handler, which activates the
+// Channel (starting the direct Teams adapter) and exposes `.channels` for
+// readiness + shutdown. Bind loopback: this runtime holds the Intelligence key
+// and needs no public ingress (the Teams adapter has its own on :${port}); the
+// listener only owns the Channel lifecycle and keeps the process alive.
+const channelPort = Number(process.env.CHANNELS_PORT ?? 8300);
+const listener = createCopilotNodeListener({
+  runtime: channelRuntime,
+  basePath: "/api/copilotkit",
+});
+createServer(listener).listen(channelPort, "127.0.0.1", () => {
+  console.log(
+    `Channel runtime (owns lifecycle) listening on 127.0.0.1:${channelPort}`,
+  );
+});
+
+// Drive readiness through the runtime's Channel control instead of a
+// (now-removed) bot.start(): resolves once the direct Teams adapter's transport
+// is up.
+await listener.channels?.ready();
 
 console.log(
   `Teams demo bot listening at http://localhost:${port}/api/messages`,
@@ -204,10 +294,11 @@ console.log(
     'or "announce X to the team" to see the HITL approval.',
 );
 
-// Stop the bot cleanly on exit.
+// Stop the bot cleanly on exit — through the runtime's Channel control, which
+// tears down the direct Teams adapter it started.
 const shutdown = async (signal: string): Promise<void> => {
   console.log(`\nReceived ${signal}, stopping…`);
-  await bot.stop().catch(() => {});
+  await listener.channels?.stop().catch(() => {});
   process.exit(0);
 };
 process.on("SIGINT", () => void shutdown("SIGINT"));

--- a/examples/teams/app/index.tsx
+++ b/examples/teams/app/index.tsx
@@ -283,7 +283,8 @@ createServer(listener).listen(channelPort, "127.0.0.1", () => {
 // Drive readiness through the runtime's Channel control instead of a
 // (now-removed) bot.start(): resolves once the direct Teams adapter's transport
 // is up.
-await listener.channels?.ready();
+// Bound startup so a wedged adapter connect can't hang readiness forever.
+await listener.channels?.ready({ timeoutMs: 30_000 });
 
 console.log(
   `Teams demo bot listening at http://localhost:${port}/api/messages`,

--- a/packages/channels-core/README.md
+++ b/packages/channels-core/README.md
@@ -4,6 +4,11 @@ The supported platform-neutral foundation behind `@copilotkit/channels`.
 Most applications should use the batteries-included `@copilotkit/channels` package;
 install core directly when building an adapter or intentionally selecting one platform.
 
+**Every Channel requires a CopilotKit Intelligence connection** (an API key — a
+free tier is available). There is no standalone / DIY run path: a Channel is
+started and owned by the `CopilotRuntime` once Intelligence is configured, not
+by calling a method on the Channel itself. See "Running a Channel" below.
+
 ## Selective install
 
 ```sh
@@ -45,11 +50,49 @@ import { slack } from "@copilotkit/channels-slack";
   (e.g. Discord). Forwarded to adapters that support commands and ignored
   elsewhere — also pass them up front via `commands` in `CreateChannelOptions`.
 - `tool(t)` — register a `ChannelTool` (alternative to `opts.tools`); must be
-  added before `start()`.
-- `start()` / `stop()` — bring adapters up / down.
+  added before the runtime activates the channel.
 
 `agent` is optional. If omitted, calling `thread.runAgent()` throws; supply
 an `AbstractAgent` or a `(threadId) => AbstractAgent` factory.
+
+A `Channel` has no public `start()` / `stop()` — lifecycle is runtime-owned
+(see below).
+
+## Running a Channel
+
+A Channel only runs when it's declared on an Intelligence-configured
+`CopilotRuntime`; there is no `channel.start()` and no standalone/DIY runner.
+Pass the `Channel` in `channels`, then drive activation through the returned
+handler:
+
+```ts
+import { createChannel } from "@copilotkit/channels-core";
+import { slack } from "@copilotkit/channels-slack";
+import {
+  CopilotRuntime,
+  CopilotKitIntelligence,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+
+const channel = createChannel({
+  name: "support-bot", // project-unique Intelligence Channel name
+  adapters: [slack({ botToken, appToken })],
+});
+
+const runtime = new CopilotRuntime({
+  intelligence: new CopilotKitIntelligence({
+    apiUrl: "https://api.copilotkit.ai",
+    wsUrl: "wss://api.copilotkit.ai",
+    apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
+  }),
+  identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),
+  channels: [channel],
+});
+
+const handler = createCopilotRuntimeHandler({ runtime });
+await handler.channels.ready(); // starts every declared channel
+// await handler.channels.stop(); // tears them down
+```
 
 ## `Thread`
 

--- a/packages/channels-core/src/create-channel.foundations.test.ts
+++ b/packages/channels-core/src/create-channel.foundations.test.ts
@@ -10,8 +10,8 @@ describe("createChannel — optional adapters + addAdapter", () => {
   it("starts with no adapters and runs one added before start()", async () => {
     const fake = new FakeAdapter();
     const channel = createChannel({ agent: () => new FakeAgent() });
-    channel.addAdapter(fake);
-    await channel.start();
+    channel.ɵruntime.addAdapter(fake);
+    await channel.ɵruntime.start();
     expect(fake.started).toBe(true);
   });
 
@@ -20,8 +20,8 @@ describe("createChannel — optional adapters + addAdapter", () => {
       adapters: [new FakeAdapter()],
       agent: () => new FakeAgent(),
     });
-    await channel.start();
-    expect(() => channel.addAdapter(new FakeAdapter())).toThrow(/start/i);
+    await channel.ɵruntime.start();
+    expect(() => channel.ɵruntime.addAdapter(new FakeAdapter())).toThrow(/start/i);
   });
 
   it("is idempotent: a second start() does not re-start adapters or rebuild state", async () => {
@@ -31,9 +31,9 @@ describe("createChannel — optional adapters + addAdapter", () => {
       agent: () => new FakeAgent(),
     });
     const startSpy = vi.spyOn(fake, "start");
-    await channel.start();
+    await channel.ɵruntime.start();
     const transcriptsAfterFirst = channel.transcripts;
-    await channel.start(); // second call must be a no-op
+    await channel.ɵruntime.start(); // second call must be a no-op
     expect(startSpy).toHaveBeenCalledTimes(1);
     // Same transcript-store instance → state (locks/dedup/actions) not wiped.
     expect(channel.transcripts).toBe(transcriptsAfterFirst);
@@ -46,9 +46,9 @@ describe("createChannel — optional adapters + addAdapter", () => {
       agent: () => new FakeAgent(),
     });
     const startSpy = vi.spyOn(fake, "start");
-    await channel.start();
-    await channel.stop();
-    await channel.start(); // stop() cleared `started`, so this is a real restart
+    await channel.ɵruntime.start();
+    await channel.ɵruntime.stop();
+    await channel.ɵruntime.start(); // stop() cleared `started`, so this is a real restart
     expect(startSpy).toHaveBeenCalledTimes(2);
   });
 });
@@ -83,7 +83,7 @@ describe("createChannel — store resolution", () => {
         transcripts: {},
       },
     });
-    await seeder.start();
+    await seeder.ɵruntime.start();
     await seeder.transcripts.append(
       { platform: "fake", conversationKey: "c" },
       { role: "user", text: "seeded" },
@@ -97,7 +97,7 @@ describe("createChannel — store resolution", () => {
       agent: () => new FakeAgent(),
       store: { identity: () => "u@x.com", transcripts: {} },
     });
-    await channel.start();
+    await channel.ɵruntime.start();
 
     const entries = await channel.transcripts.list({ userKey: "u@x.com" });
     expect(entries.map((e) => e.text)).toContain("seeded");
@@ -117,7 +117,7 @@ describe("createChannel — store resolution", () => {
         transcripts: {},
       },
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
   });
@@ -132,7 +132,7 @@ describe("createChannel — store resolution", () => {
       adapters: [a, b],
       agent: () => new FakeAgent(),
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("state store"));
     warn.mockRestore();
   });
@@ -153,7 +153,7 @@ describe("createChannel — id propagation to handler context", () => {
         eventId: message.eventId,
       };
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitTurn({
       userText: "hi",
       conversationKey: "c1",

--- a/packages/channels-core/src/create-channel.foundations.test.ts
+++ b/packages/channels-core/src/create-channel.foundations.test.ts
@@ -21,7 +21,9 @@ describe("createChannel — optional adapters + addAdapter", () => {
       agent: () => new FakeAgent(),
     });
     await channel.ɵruntime.start();
-    expect(() => channel.ɵruntime.addAdapter(new FakeAdapter())).toThrow(/start/i);
+    expect(() => channel.ɵruntime.addAdapter(new FakeAdapter())).toThrow(
+      /start/i,
+    );
   });
 
   it("is idempotent: a second start() does not re-start adapters or rebuild state", async () => {

--- a/packages/channels-core/src/create-channel.test.ts
+++ b/packages/channels-core/src/create-channel.test.ts
@@ -66,7 +66,7 @@ describe("createChannel", () => {
       await thread.post(Section({ children: "hi" }));
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitTurn({ userText: "yo", conversationKey: "c1" });
     await tick();
 
@@ -85,7 +85,7 @@ describe("createChannel", () => {
       await thread.runAgent();
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitTurn({ userText: "yo", conversationKey: "c1" });
     await tick();
 
@@ -124,7 +124,7 @@ describe("createChannel", () => {
       });
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitTurn({
       userText: "look",
       conversationKey: "c1",
@@ -161,7 +161,7 @@ describe("createChannel", () => {
       );
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitTurn({ userText: "yo", conversationKey: "c1" });
     await tick();
 
@@ -195,7 +195,7 @@ describe("createChannel", () => {
       );
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitTurn({ userText: "create a thing", conversationKey: "c1" });
     await tick();
 
@@ -239,7 +239,7 @@ describe("createChannel", () => {
       });
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitTurn({ userText: "go", conversationKey: "c1" });
     await tick();
 
@@ -263,7 +263,7 @@ describe("createChannel", () => {
       });
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitTurn({ userText: "hi", conversationKey: "c1" });
     await tick();
 
@@ -289,7 +289,7 @@ describe("createChannel", () => {
       resolved = await thread.lookupUser("Ada");
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitTurn({ userText: "hi", conversationKey: "c1" });
     await tick();
 
@@ -319,7 +319,7 @@ describe("createChannel", () => {
       );
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitTurn({ userText: "decide", conversationKey: "c1" });
     await tick();
 
@@ -355,7 +355,7 @@ describe("createChannel", () => {
       await gate;
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     const sink = fake.getSink();
     const turn = {
       conversationKey: "c1",
@@ -392,7 +392,7 @@ describe("createChannel", () => {
       await gate;
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     const sink = fake.getSink();
     const turn = {
       conversationKey: "c1",
@@ -426,7 +426,7 @@ describe("createChannel", () => {
       runs++;
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     const sink = fake.getSink();
     const base = {
       conversationKey: "c",
@@ -489,7 +489,7 @@ describe("createChannel", () => {
       capturedKey = message.userKey;
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     const sink = fake.getSink();
     await sink.onTurn({
       conversationKey: "c1",
@@ -516,7 +516,7 @@ describe("createChannel", () => {
       },
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     const sink = fake.getSink();
 
     // Drive a turn so identity is resolved and we can verify transcripts exist
@@ -585,7 +585,7 @@ describe("createChannel", () => {
       await thread.runAgent({ transcript: true });
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     // Seed one prior cross-platform entry (different platform label) so we can
     // assert it shows up in the injected context. Seeded post-start: transcripts
     // are only available once the backend is resolved in start().
@@ -651,7 +651,7 @@ describe("createChannel", () => {
       }
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitTurn({ userText: "go", conversationKey: "c1" });
     await tick();
 
@@ -680,7 +680,7 @@ describe("createChannel lock and dedup edge cases", () => {
       throw new Error("boom");
     });
 
-    await bot1.start();
+    await bot1.ɵruntime.start();
     const sink = fake.getSink();
     const turn = {
       conversationKey: "c1",
@@ -727,7 +727,7 @@ describe("createChannel lock and dedup edge cases", () => {
       await gate;
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     const sink = fake.getSink();
     const turn = {
       conversationKey: "c1",
@@ -765,7 +765,7 @@ describe("createChannel lock and dedup edge cases", () => {
       await gate;
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     const sink = fake.getSink();
     const turn = {
       conversationKey: "c1",
@@ -801,7 +801,7 @@ describe("createChannel lock and dedup edge cases", () => {
       capturedUserKey = message.userKey;
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     const sink = fake.getSink();
     await sink.onTurn({
       conversationKey: "c1",
@@ -826,7 +826,7 @@ describe("createChannel lock and dedup edge cases", () => {
       capturedUserKey = message.userKey;
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     const sink = fake.getSink();
     await sink.onTurn({
       conversationKey: "c1",
@@ -851,7 +851,7 @@ describe("createChannel lock and dedup edge cases", () => {
       runs++;
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     const sink = fake.getSink();
     const base = {
       conversationKey: "c1",
@@ -895,7 +895,7 @@ describe("createChannel lock and dedup edge cases", () => {
       runs++;
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     const sink = fake.getSink();
     await sink.onTurn({
       conversationKey: "c1",
@@ -925,7 +925,7 @@ describe("createChannel lock and dedup edge cases", () => {
       await gate;
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     const sink = fake.getSink();
     const turnA = {
       conversationKey: "c1",
@@ -973,7 +973,7 @@ describe("createChannel lock and dedup edge cases", () => {
       runs++;
     });
 
-    await channel.start();
+    await channel.ɵruntime.start();
     const sink = fake.getSink();
     const turn = {
       conversationKey: "c2",
@@ -1001,7 +1001,7 @@ describe("createChannel slash commands", () => {
     channel.onCommand("triage", ({ command, text }) => {
       seen = { command, text };
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     await fake.emitCommand({ command: "/Triage", text: "db is down" });
     expect(seen).toEqual({ command: "triage", text: "db is down" });
   });
@@ -1013,7 +1013,7 @@ describe("createChannel slash commands", () => {
     channel.onCommand("triage", () => {
       fired = true;
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     await fake.emitCommand({ command: "unknown", text: "x" });
     expect(fired).toBe(false);
   });
@@ -1033,7 +1033,7 @@ describe("createChannel slash commands", () => {
         }),
       ],
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     await fake.emitCommand({
       command: "book",
       text: "raw",
@@ -1047,7 +1047,7 @@ describe("createChannel slash commands", () => {
     const channel = createChannel({ adapters: [fake] });
     channel.onCommand("triage", () => {});
     channel.onCommand("status", () => {});
-    await channel.start();
+    await channel.ɵruntime.start();
     expect(fake.registeredCommands?.map((c) => c.name).sort()).toEqual([
       "status",
       "triage",
@@ -1060,7 +1060,7 @@ describe("createChannel slash commands", () => {
       const bad = new FakeAdapter({ platform: "telegram", failStart: true });
       const good = new FakeAdapter({ platform: "slack" });
       const channel = createChannel({ adapters: [bad, good] });
-      await expect(channel.start()).resolves.toBeUndefined();
+      await expect(channel.ɵruntime.start()).resolves.toBeUndefined();
       expect(good.started).toBe(true);
       expect(
         errSpy.mock.calls.some((c) => String(c[0]).includes("telegram")),
@@ -1080,7 +1080,7 @@ describe("createChannel slash commands", () => {
       const good = new FakeAdapter({ platform: "slack" });
       const channel = createChannel({ adapters: [bad, good] });
       channel.onCommand("triage", () => {});
-      await expect(channel.start()).resolves.toBeUndefined();
+      await expect(channel.ɵruntime.start()).resolves.toBeUndefined();
       expect(good.started).toBe(true);
       expect(good.registeredCommands?.map((c) => c.name)).toEqual(["triage"]);
       expect(
@@ -1098,8 +1098,8 @@ describe("createChannel slash commands", () => {
       const good = new FakeAdapter({ platform: "slack" });
       const stopSpy = vi.spyOn(good, "stop");
       const channel = createChannel({ adapters: [bad, good] });
-      await channel.start();
-      await expect(channel.stop()).resolves.toBeUndefined();
+      await channel.ɵruntime.start();
+      await expect(channel.ɵruntime.stop()).resolves.toBeUndefined();
       expect(stopSpy).toHaveBeenCalled();
       expect(
         errSpy.mock.calls.some((c) => String(c[0]).includes("telegram")),
@@ -1126,7 +1126,7 @@ describe("createChannel slash commands", () => {
     expect(channel.adapters).toHaveLength(0);
 
     const fake = new FakeAdapter();
-    channel.addAdapter(fake);
+    channel.ɵruntime.addAdapter(fake);
     expect(channel.adapters).toEqual([fake]);
   });
 });

--- a/packages/channels-core/src/create-channel.ts
+++ b/packages/channels-core/src/create-channel.ts
@@ -304,6 +304,19 @@ export interface Channel<TState = unknown> {
   stop(): Promise<void>;
   /** Cross-platform transcript store. Append, list, and delete entries per user. */
   transcripts: Transcripts;
+  /**
+   * Internal lifecycle seam. Holds the real `start`/`stop`/`addAdapter`
+   * implementations (and the resolved `provider`) that the public methods of
+   * the same name delegate to. Lets a Channel runner drive the lifecycle
+   * directly, without going through the public API.
+   * @internal
+   */
+  ɵruntime: {
+    start(): Promise<void>;
+    stop(): Promise<void>;
+    addAdapter(adapter: PlatformAdapter): void;
+    readonly provider?: ManagedChannelProvider;
+  };
 }
 
 /** Build the IncomingMessage object from an IncomingTurn (shared by lock-conflict callback and handler path). */
@@ -786,14 +799,145 @@ export function createChannel<
       }
       return transcripts;
     },
-    addAdapter(adapter) {
-      if (started) {
-        throw new Error(
-          "channel.addAdapter must be called before channel.start()",
+    ɵruntime: {
+      ...(opts.provider !== undefined ? { provider: opts.provider } : {}),
+      addAdapter(adapter) {
+        if (started) {
+          throw new Error(
+            "channel.addAdapter must be called before channel.start()",
+          );
+        }
+        assertExclusive([...adapters, adapter]);
+        adapters.push(adapter);
+      },
+      async start() {
+        // Idempotent: a second start() must not re-resolve the backend and
+        // rebuild Transcripts/Telemetry/ActionRegistry or re-call adapter.start()
+        // — with a MemoryStore that wipes all lock/dedup/transcript/action state,
+        // and real adapters would connect/port-bind twice.
+        if (started) return;
+        started = true;
+        assertExclusive(adapters);
+        // Resolve persistence now that all adapters (including any attached via
+        // addAdapter) are known, then build the transcript store, action
+        // registry, and register components against it.
+        backend = resolveBackend(cfg.adapter, adapters);
+        transcripts = new Transcripts(backend, cfg.transcripts ?? {});
+        const tel = new ChannelTelemetry({
+          backend,
+          packageName: pkg.name,
+          packageVersion: pkg.version,
+        });
+        telemetry = tel;
+        const registryInstance = new ActionRegistry({
+          store: opts.actionStore ?? kvActionStore(backend),
+        });
+        registry = registryInstance;
+        for (const c of opts.components ?? []) {
+          if (!c.name) {
+            console.warn(
+              "[channel] createChannel: skipping anonymous component — give it a name to enable durable actions after restart.",
+            );
+            continue;
+          }
+          registryInstance.registerComponent(
+            c.name,
+            c as unknown as ComponentFn,
+          );
+        }
+        toolDescriptors = toAgentToolDescriptors([...toolMap.values()]);
+        tel.capture("oss.channel.configured", {
+          platforms: adapters.map((a) => normalizePlatform(a.platform)),
+          adapterCount: adapters.length,
+          store: storeKind(backend),
+          hasComponents: (opts.components?.length ?? 0) > 0,
+          componentsCount: opts.components?.length ?? 0,
+          toolsCount: toolMap.size,
+          commandsCount: commandHandlers.size,
+          contextCount: context.length,
+          transcripts: !!cfg.transcripts,
+          identity: !!cfg.identity,
+        });
+        // Isolate per-adapter startup failures: one adapter rejecting (e.g.
+        // Telegram's setMyCommands rejecting a hyphenated command name, a revoked
+        // token, a port already in use) must NOT crash the channel or prevent the
+        // other adapters from starting. Log + degrade, never throw.
+        const startResults = await Promise.allSettled(
+          adapters.map((a) => a.start(makeSink(a), { channelName: opts.name })),
         );
-      }
-      assertExclusive([...adapters, adapter]);
-      adapters.push(adapter);
+        const startedPlatforms: string[] = [];
+        const failedPlatforms: string[] = [];
+        startResults.forEach((r, i) => {
+          const rawPlatform = adapters[i]!.platform;
+          // Raw label for the human-facing log; normalized label for telemetry.
+          const platform = normalizePlatform(rawPlatform);
+          if (r.status === "rejected") {
+            failedPlatforms.push(platform);
+            console.error(
+              `[channel] adapter "${rawPlatform}" failed to start:`,
+              r.reason,
+            );
+            tel.capture("oss.channel.start_failed", {
+              platform,
+              errorClass: errorClass(r.reason),
+            });
+          } else {
+            startedPlatforms.push(platform);
+          }
+        });
+        if (startedPlatforms.length > 0) {
+          tel.capture("oss.channel.started", {
+            platforms: startedPlatforms,
+            startedCount: startedPlatforms.length,
+            failedCount: failedPlatforms.length,
+            hasMentionHandler: mentionHandlers.length > 0,
+            hasMessageHandler: messageHandlers.length > 0,
+            interruptHandlers: interruptHandlers.size,
+            commandsCount: commandHandlers.size,
+            toolsCount: toolMap.size,
+          });
+        }
+        // Hand declared commands to adapters that register them up front (e.g.
+        // Discord); adapters without `registerCommands` are skipped. Per-adapter
+        // failures are isolated the same way as start().
+        const commandSpecs = [...commandHandlers.values()].map(toCommandSpec);
+        if (commandSpecs.length > 0) {
+          const registerResults = await Promise.allSettled(
+            adapters.map((a) => a.registerCommands?.(commandSpecs)),
+          );
+          registerResults.forEach((r, i) => {
+            if (r.status === "rejected") {
+              console.error(
+                `[channel] adapter "${adapters[i]!.platform}" failed to register commands:`,
+                r.reason,
+              );
+            }
+          });
+        }
+      },
+      async stop() {
+        // Clear the started flag so a later start() is a real restart (re-resolve
+        // backend, rebuild components, reconnect adapters) rather than a silent
+        // no-op. The idempotency guard in start() only exists to block a DOUBLE
+        // start() while running — not a legitimate start→stop→start cycle.
+        started = false;
+        // Isolate per-adapter shutdown failures: one adapter's stop() rejecting
+        // must not prevent the others from being stopped.
+        const stopResults = await Promise.allSettled(
+          adapters.map((a) => a.stop()),
+        );
+        stopResults.forEach((r, i) => {
+          if (r.status === "rejected") {
+            console.error(
+              `[channel] adapter "${adapters[i]!.platform}" failed to stop:`,
+              r.reason,
+            );
+          }
+        });
+      },
+    },
+    addAdapter(adapter) {
+      this.ɵruntime.addAdapter(adapter);
     },
     onMention(h) {
       // The public surface narrows `thread` to StatefulThread<TState>; the
@@ -874,126 +1018,10 @@ export function createChannel<
       toolMap.set(t.name, t);
     },
     async start() {
-      // Idempotent: a second start() must not re-resolve the backend and
-      // rebuild Transcripts/Telemetry/ActionRegistry or re-call adapter.start()
-      // — with a MemoryStore that wipes all lock/dedup/transcript/action state,
-      // and real adapters would connect/port-bind twice.
-      if (started) return;
-      started = true;
-      assertExclusive(adapters);
-      // Resolve persistence now that all adapters (including any attached via
-      // addAdapter) are known, then build the transcript store, action
-      // registry, and register components against it.
-      backend = resolveBackend(cfg.adapter, adapters);
-      transcripts = new Transcripts(backend, cfg.transcripts ?? {});
-      const tel = new ChannelTelemetry({
-        backend,
-        packageName: pkg.name,
-        packageVersion: pkg.version,
-      });
-      telemetry = tel;
-      const registryInstance = new ActionRegistry({
-        store: opts.actionStore ?? kvActionStore(backend),
-      });
-      registry = registryInstance;
-      for (const c of opts.components ?? []) {
-        if (!c.name) {
-          console.warn(
-            "[channel] createChannel: skipping anonymous component — give it a name to enable durable actions after restart.",
-          );
-          continue;
-        }
-        registryInstance.registerComponent(c.name, c as unknown as ComponentFn);
-      }
-      toolDescriptors = toAgentToolDescriptors([...toolMap.values()]);
-      tel.capture("oss.channel.configured", {
-        platforms: adapters.map((a) => normalizePlatform(a.platform)),
-        adapterCount: adapters.length,
-        store: storeKind(backend),
-        hasComponents: (opts.components?.length ?? 0) > 0,
-        componentsCount: opts.components?.length ?? 0,
-        toolsCount: toolMap.size,
-        commandsCount: commandHandlers.size,
-        contextCount: context.length,
-        transcripts: !!cfg.transcripts,
-        identity: !!cfg.identity,
-      });
-      // Isolate per-adapter startup failures: one adapter rejecting (e.g.
-      // Telegram's setMyCommands rejecting a hyphenated command name, a revoked
-      // token, a port already in use) must NOT crash the channel or prevent the
-      // other adapters from starting. Log + degrade, never throw.
-      const startResults = await Promise.allSettled(
-        adapters.map((a) => a.start(makeSink(a), { channelName: opts.name })),
-      );
-      const startedPlatforms: string[] = [];
-      const failedPlatforms: string[] = [];
-      startResults.forEach((r, i) => {
-        const rawPlatform = adapters[i]!.platform;
-        // Raw label for the human-facing log; normalized label for telemetry.
-        const platform = normalizePlatform(rawPlatform);
-        if (r.status === "rejected") {
-          failedPlatforms.push(platform);
-          console.error(
-            `[channel] adapter "${rawPlatform}" failed to start:`,
-            r.reason,
-          );
-          tel.capture("oss.channel.start_failed", {
-            platform,
-            errorClass: errorClass(r.reason),
-          });
-        } else {
-          startedPlatforms.push(platform);
-        }
-      });
-      if (startedPlatforms.length > 0) {
-        tel.capture("oss.channel.started", {
-          platforms: startedPlatforms,
-          startedCount: startedPlatforms.length,
-          failedCount: failedPlatforms.length,
-          hasMentionHandler: mentionHandlers.length > 0,
-          hasMessageHandler: messageHandlers.length > 0,
-          interruptHandlers: interruptHandlers.size,
-          commandsCount: commandHandlers.size,
-          toolsCount: toolMap.size,
-        });
-      }
-      // Hand declared commands to adapters that register them up front (e.g.
-      // Discord); adapters without `registerCommands` are skipped. Per-adapter
-      // failures are isolated the same way as start().
-      const commandSpecs = [...commandHandlers.values()].map(toCommandSpec);
-      if (commandSpecs.length > 0) {
-        const registerResults = await Promise.allSettled(
-          adapters.map((a) => a.registerCommands?.(commandSpecs)),
-        );
-        registerResults.forEach((r, i) => {
-          if (r.status === "rejected") {
-            console.error(
-              `[channel] adapter "${adapters[i]!.platform}" failed to register commands:`,
-              r.reason,
-            );
-          }
-        });
-      }
+      return this.ɵruntime.start();
     },
     async stop() {
-      // Clear the started flag so a later start() is a real restart (re-resolve
-      // backend, rebuild components, reconnect adapters) rather than a silent
-      // no-op. The idempotency guard in start() only exists to block a DOUBLE
-      // start() while running — not a legitimate start→stop→start cycle.
-      started = false;
-      // Isolate per-adapter shutdown failures: one adapter's stop() rejecting
-      // must not prevent the others from being stopped.
-      const stopResults = await Promise.allSettled(
-        adapters.map((a) => a.stop()),
-      );
-      stopResults.forEach((r, i) => {
-        if (r.status === "rejected") {
-          console.error(
-            `[channel] adapter "${adapters[i]!.platform}" failed to stop:`,
-            r.reason,
-          );
-        }
-      });
+      return this.ɵruntime.stop();
     },
   };
   return channel;

--- a/packages/channels-core/src/create-channel.ts
+++ b/packages/channels-core/src/create-channel.ts
@@ -304,16 +304,15 @@ export interface Channel<TState = unknown> {
   transcripts: Transcripts;
   /**
    * Internal lifecycle seam. Holds the `start`/`stop`/`addAdapter`
-   * implementations (and the resolved `provider`) that a Channel runner uses
-   * to drive the lifecycle directly — there is no public equivalent; channels
-   * are runtime-driven only.
+   * implementations that the runtime uses to drive the lifecycle directly —
+   * there is no public equivalent; channels are runtime-driven only. (Read the
+   * managed provider off the top-level `channel.provider`, not here.)
    * @internal
    */
   ɵruntime: {
     start(): Promise<void>;
     stop(): Promise<void>;
     addAdapter(adapter: PlatformAdapter): void;
-    readonly provider?: ManagedChannelProvider;
   };
 }
 
@@ -800,7 +799,6 @@ export function createChannel<
       return transcripts;
     },
     ɵruntime: {
-      ...(opts.provider !== undefined ? { provider: opts.provider } : {}),
       addAdapter(adapter) {
         if (started) {
           throw new Error(

--- a/packages/channels-core/src/create-channel.ts
+++ b/packages/channels-core/src/create-channel.ts
@@ -895,6 +895,16 @@ export function createChannel<
             toolsCount: toolMap.size,
           });
         }
+        // A channel that has adapters but where NONE started is dead — surface an
+        // error so the runtime reports status "error", not a false "online". A
+        // PARTIAL start (>=1 adapter live) still counts as started. Reset the
+        // `started` guard so a caller can retry after fixing the misconfiguration.
+        if (adapters.length > 0 && startedPlatforms.length === 0) {
+          started = false;
+          throw new Error(
+            `channel "${opts.name ?? "(unnamed)"}" failed to start: all ${failedPlatforms.length} adapter(s) failed to connect (${failedPlatforms.join(", ")}) — see the logged errors above`,
+          );
+        }
         // Hand declared commands to adapters that register them up front (e.g.
         // Discord); adapters without `registerCommands` are skipped. Per-adapter
         // failures are isolated the same way as start().

--- a/packages/channels-core/src/create-channel.ts
+++ b/packages/channels-core/src/create-channel.ts
@@ -87,9 +87,10 @@ export type LockConflictDecision = "drop" | "force";
  * (Intelligence OSS-450 / #511).
  *
  * Distinct from a {@link PlatformAdapter} attached via
- * `createChannel({ adapters })` / {@link Channel.addAdapter}: an adapter is a
- * *direct*, developer-owned connection this handler does not manage, whereas
- * `provider` selects the *managed* platform for a Channel with no adapters.
+ * `createChannel({ adapters })` / `channel.ɵruntime.addAdapter`: an adapter is
+ * a *direct*, developer-owned connection this handler does not manage,
+ * whereas `provider` selects the *managed* platform for a Channel with no
+ * adapters.
  */
 export type ManagedChannelProvider = "slack" | "teams";
 
@@ -207,7 +208,8 @@ export interface CreateChannelOptions<
   name?: string;
   /**
    * Adapters supplied at construction. Optional — adapters can also be attached
-   * before `start()` via {@link Channel.addAdapter} (the Channel runtime uses this).
+   * before the runner starts the channel, via `channel.ɵruntime.addAdapter`
+   * (the Channel runtime uses this).
    */
   adapters?: PlatformAdapter[];
   /**
@@ -222,8 +224,8 @@ export interface CreateChannelOptions<
    * {@link ManagedChannelProvider}.
    *
    * Ignored for direct-adapter Channels (those created with `adapters` /
-   * {@link Channel.addAdapter}) — a direct Channel is owned by the developer's
-   * own adapter, not by managed activation.
+   * `channel.ɵruntime.addAdapter`) — a direct Channel is owned by the
+   * developer's own adapter, not by managed activation.
    */
   provider?: ManagedChannelProvider;
   agent?: AbstractAgent | ((threadId: string) => AbstractAgent);
@@ -298,17 +300,13 @@ export interface Channel<TState = unknown> {
   /** Handle a modal dismissal for `callbackId` (Slack `view_closed`). */
   onModalClose(callbackId: string, handler: ModalCloseHandler): void;
   tool(t: ChannelTool): void;
-  /** Attach an adapter before `start()`. Throws if called after the channel has started. */
-  addAdapter(adapter: PlatformAdapter): void;
-  start(): Promise<void>;
-  stop(): Promise<void>;
   /** Cross-platform transcript store. Append, list, and delete entries per user. */
   transcripts: Transcripts;
   /**
-   * Internal lifecycle seam. Holds the real `start`/`stop`/`addAdapter`
-   * implementations (and the resolved `provider`) that the public methods of
-   * the same name delegate to. Lets a Channel runner drive the lifecycle
-   * directly, without going through the public API.
+   * Internal lifecycle seam. Holds the `start`/`stop`/`addAdapter`
+   * implementations (and the resolved `provider`) that a Channel runner uses
+   * to drive the lifecycle directly — there is no public equivalent; channels
+   * are runtime-driven only.
    * @internal
    */
   ɵruntime: {
@@ -387,17 +385,19 @@ export function createChannel<
     );
   }
 
-  // Adapters can be supplied up front or added later via `channel.addAdapter`
-  // (before `start()`). The runtime uses the latter to attach Channel delivery.
+  // Adapters can be supplied up front or added later via
+  // `channel.ɵruntime.addAdapter` (before `channel.ɵruntime.start()`). The
+  // runtime uses the latter to attach Channel delivery.
   const adapters: PlatformAdapter[] = [...(opts.adapters ?? [])];
   assertExclusive(adapters);
   let started = false;
 
   // Backend, transcripts, telemetry, the action registry, and component
-  // registration are resolved in `start()` — not at construction — so an
-  // adapter added via `addAdapter` after `createChannel` can still supply the
-  // persistence backend (see `resolveBackend`). Nothing reads these before the
-  // first event, which can only arrive after `start()`.
+  // registration are resolved in `ɵruntime.start()` — not at construction —
+  // so an adapter added via `ɵruntime.addAdapter` after `createChannel` can
+  // still supply the persistence backend (see `resolveBackend`). Nothing
+  // reads these before the first event, which can only arrive after
+  // `ɵruntime.start()`.
   let backend: StateStore | undefined;
   let transcripts: Transcripts | undefined;
   let registry: ActionRegistry | undefined;
@@ -452,7 +452,7 @@ export function createChannel<
   ): Thread {
     if (!backend || !registry || !telemetry) {
       throw new Error(
-        "channel not started: call channel.start() before handling events",
+        "channel not started: the runner must start the channel (channel.ɵruntime.start()) before handling events",
       );
     }
     const deps: ThreadDeps = {
@@ -794,7 +794,7 @@ export function createChannel<
     get transcripts() {
       if (!transcripts) {
         throw new Error(
-          "channel.transcripts is available after channel.start()",
+          "channel.transcripts is available after the runner starts the channel (channel.ɵruntime.start())",
         );
       }
       return transcripts;
@@ -804,7 +804,7 @@ export function createChannel<
       addAdapter(adapter) {
         if (started) {
           throw new Error(
-            "channel.addAdapter must be called before channel.start()",
+            "channel.ɵruntime.addAdapter must be called before channel.ɵruntime.start()",
           );
         }
         assertExclusive([...adapters, adapter]);
@@ -936,9 +936,6 @@ export function createChannel<
         });
       },
     },
-    addAdapter(adapter) {
-      this.ɵruntime.addAdapter(adapter);
-    },
     onMention(h) {
       // The public surface narrows `thread` to StatefulThread<TState>; the
       // internal arrays hold the loose `ChannelHandler` shape. A real Thread is
@@ -1016,12 +1013,6 @@ export function createChannel<
     },
     tool(t) {
       toolMap.set(t.name, t);
-    },
-    async start() {
-      return this.ɵruntime.start();
-    },
-    async stop() {
-      return this.ɵruntime.stop();
     },
   };
   return channel;

--- a/packages/channels-core/src/modal-submit.test.ts
+++ b/packages/channels-core/src/modal-submit.test.ts
@@ -21,7 +21,7 @@ describe("channel.onModalSubmit / onModalClose", () => {
         hasThread: !!evt.thread,
       });
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     const res = await fake.emitModalSubmit({
       callbackId: "triage",
       values: { summary: "boom", prio: "high" },
@@ -46,7 +46,7 @@ describe("channel.onModalSubmit / onModalClose", () => {
     channel.onModalSubmit("triage", (evt) =>
       evt.values.summary ? undefined : { errors: { summary: "Required" } },
     );
-    await channel.start();
+    await channel.ɵruntime.start();
     const res = await fake.emitModalSubmit({
       callbackId: "triage",
       values: {},
@@ -57,7 +57,7 @@ describe("channel.onModalSubmit / onModalClose", () => {
   it("ignores submissions with no registered handler", async () => {
     const fake = new FakeAdapter();
     const channel = createChannel({ adapters: [fake] });
-    await channel.start();
+    await channel.ɵruntime.start();
     const res = await fake.emitModalSubmit({
       callbackId: "unknown",
       values: {},
@@ -72,7 +72,7 @@ describe("channel.onModalSubmit / onModalClose", () => {
     channel.onModalClose("triage", (evt) => {
       closed.push(evt.callbackId);
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     await fake.emitModalClose({ callbackId: "triage", user: { id: "U2" } });
     expect(closed).toEqual(["triage"]);
   });

--- a/packages/channels-core/src/open-modal.test.tsx
+++ b/packages/channels-core/src/open-modal.test.tsx
@@ -19,7 +19,7 @@ describe("ctx.openModal", () => {
     channel.onInteraction("ck:open", async (ctx) => {
       res = await ctx.openModal!(view);
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitInteraction({ id: "ck:open", triggerId: "T123" });
     await tick();
     expect(res).toEqual({ ok: true });
@@ -35,7 +35,7 @@ describe("ctx.openModal", () => {
     channel.onCommand("triage", async (ctx) => {
       res = await ctx.openModal!(view);
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     await fake.emitCommand({ command: "triage", triggerId: "T999" });
     expect(res).toEqual({ ok: true });
     expect(fake.openedModals[0]!.triggerId).toBe("T999");
@@ -48,7 +48,7 @@ describe("ctx.openModal", () => {
     channel.onInteraction("ck:noop", (ctx) => {
       hasOpen = typeof ctx.openModal === "function";
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitInteraction({ id: "ck:noop" });
     await tick();
     expect(hasOpen).toBe(false);
@@ -61,7 +61,7 @@ describe("ctx.openModal", () => {
     channel.onInteraction("ck:x", (ctx) => {
       hasOpen = typeof ctx.openModal === "function";
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitInteraction({ id: "ck:x", triggerId: "T1" });
     await tick();
     expect(hasOpen).toBe(false);

--- a/packages/channels-core/src/reactions.test.ts
+++ b/packages/channels-core/src/reactions.test.ts
@@ -15,7 +15,7 @@ describe("channel.onReaction", () => {
     channel.onReaction([emoji.thumbs_up], (evt) => {
       seen.push({ emoji: evt.emoji, raw: evt.rawEmoji, added: evt.added });
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     // FakeAdapter.platform === "fake": normalizeEmoji falls through, but engine
     // normalizes by adapter.platform. Use a Slack-style token via a fake whose
     // platform normalizes — here we assert passthrough + catch-all instead.
@@ -44,7 +44,7 @@ describe("channel.onReaction", () => {
         platform: evt.thread.platform,
       });
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitReaction({
       rawEmoji: "🎉",
       added: true,
@@ -74,7 +74,7 @@ describe("channel.onReaction", () => {
     channel.onReaction(["thumbs_up"], (evt) => {
       hits.push(evt.emoji);
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitReaction({ rawEmoji: "thumbsup", added: true }); // Slack alias
     await tick();
     expect(hits).toEqual(["thumbs_up"]);
@@ -91,7 +91,7 @@ describe("channel.onReaction", () => {
     channel.onReaction(["refresh"], (evt) => {
       hits.push(evt.emoji);
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitReaction({
       rawEmoji: "1f504_refresh",
       added: true,
@@ -115,7 +115,7 @@ describe("channel.onReaction", () => {
         }),
       );
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitTurn({});
     await tick();
     // The handler is a closure, never serialized into the native payload.
@@ -144,7 +144,7 @@ describe("channel.onReaction", () => {
         }),
       );
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitTurn({});
     await tick();
     // Channel delivery: the reaction arrives keyed by the provider ts (NOT the
@@ -184,7 +184,7 @@ describe("channel.onReaction", () => {
       // pre-rendered Message() node.
       await thread.post({ type: Card, props: {} });
     });
-    await bot1.start();
+    await bot1.ɵruntime.start();
     fake1.emitTurn({});
     await tick();
 
@@ -196,7 +196,7 @@ describe("channel.onReaction", () => {
       store: { adapter: backend },
       components: [Card],
     });
-    await bot2.start();
+    await bot2.ɵruntime.start();
     fake2.emitReaction({ rawEmoji: "🎉", added: true, messageId: "msg-1" });
     await tick();
     expect(seen).toEqual(["🎉"]);
@@ -217,7 +217,7 @@ describe("channel.onReaction", () => {
         }),
       );
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitTurn({});
     await tick();
     const before = fake.posted.length;
@@ -243,7 +243,7 @@ describe("channel.onReaction", () => {
         }),
       );
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitTurn({});
     await tick();
     fake.emitReaction({ rawEmoji: "🎉", added: true, messageId: "other" });
@@ -264,7 +264,7 @@ describe("channel.onReaction", () => {
     channel.onReaction(["thumbsup"], (evt) => {
       hits.push(`alias:${evt.emoji}`);
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitReaction({ rawEmoji: "thumbsup", added: true }); // Slack alias
     await tick();
     expect(hits).toEqual(["thumbs_up", "alias:thumbs_up"]);

--- a/packages/channels-core/src/telemetry/create-channel-telemetry.test.ts
+++ b/packages/channels-core/src/telemetry/create-channel-telemetry.test.ts
@@ -33,7 +33,7 @@ describe("createChannel telemetry wiring", () => {
         },
       ],
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     const call = capture.mock.calls.find(
       (c) => c[0] === "oss.channel.configured",
     );
@@ -46,7 +46,7 @@ describe("createChannel telemetry wiring", () => {
   it("emits oss.channel.started on start, start_failed (category only) on a throwing adapter", async () => {
     const ok = new FakeAdapter();
     const channel = createChannel({ adapters: [ok] });
-    await channel.start();
+    await channel.ɵruntime.start();
     expect(
       capture.mock.calls.find((c) => c[0] === "oss.channel.started")?.[1]
         .startedCount,
@@ -59,7 +59,7 @@ describe("createChannel telemetry wiring", () => {
         Object.assign(new Error("xoxb-SECRET token bad"), { code: "EAUTH" }),
       );
     const bot2 = createChannel({ adapters: [bad] });
-    await bot2.start();
+    await bot2.ɵruntime.start();
     const f = capture.mock.calls.find(
       (c) => c[0] === "oss.channel.start_failed",
     );
@@ -77,7 +77,7 @@ describe("createChannel telemetry wiring", () => {
     channel.onMention(async ({ thread }) => {
       await thread.runAgent();
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     capture.mockClear();
     fake.emitTurn({ userText: "hi", conversationKey: "c1" });
     await tick();

--- a/packages/channels-core/src/telemetry/create-channel-telemetry.test.ts
+++ b/packages/channels-core/src/telemetry/create-channel-telemetry.test.ts
@@ -59,7 +59,10 @@ describe("createChannel telemetry wiring", () => {
         Object.assign(new Error("xoxb-SECRET token bad"), { code: "EAUTH" }),
       );
     const bot2 = createChannel({ adapters: [bad] });
-    await bot2.ɵruntime.start();
+    // All adapters failed → start() rejects (the channel is dead; the runtime
+    // reports status "error"). The start_failed telemetry is still captured
+    // before the throw.
+    await expect(bot2.ɵruntime.start()).rejects.toThrow(/failed to start/i);
     const f = capture.mock.calls.find(
       (c) => c[0] === "oss.channel.start_failed",
     );

--- a/packages/channels-core/src/telemetry/e2e-telemetry.test.ts
+++ b/packages/channels-core/src/telemetry/e2e-telemetry.test.ts
@@ -45,7 +45,7 @@ describe("oss.channel.* end-to-end (real ChannelTelemetry, only network boundary
     channel.onMention(async ({ thread }) => {
       await thread.runAgent();
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitTurn({ userText: "hi", conversationKey: "c1" });
 
     await waitFor(() =>

--- a/packages/channels-core/src/testing/fake-adapter.ts
+++ b/packages/channels-core/src/testing/fake-adapter.ts
@@ -190,7 +190,9 @@ export class FakeAdapter implements PlatformAdapter {
   /** Expose the registered sink so tests can invoke onTurn() directly for overlap/lock tests. */
   getSink(): IngressSink {
     if (!this.sink)
-      throw new Error("FakeAdapter: sink not set — call channel.start() first");
+      throw new Error(
+        "FakeAdapter: sink not set — start the channel (channel.ɵruntime.start()) first",
+      );
     return this.sink;
   }
 

--- a/packages/channels-core/src/thread-capabilities.test.ts
+++ b/packages/channels-core/src/thread-capabilities.test.ts
@@ -10,7 +10,7 @@ describe("onThreadStarted routing", () => {
     channel.onThreadStarted(({ thread, user }) => {
       seen.push({ user: user?.id, platform: thread.platform });
     });
-    await channel.start();
+    await channel.ɵruntime.start();
 
     await fake.emitThreadStarted({ user: { id: "U1", name: "Ada" } });
     expect(seen).toEqual([{ user: "U1", platform: "fake" }]);
@@ -26,7 +26,7 @@ describe("onThreadStarted routing", () => {
     channel.onThreadStarted(() => {
       order.push(2);
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     await fake.emitThreadStarted();
     expect(order).toEqual([1, 2]);
   });
@@ -34,7 +34,7 @@ describe("onThreadStarted routing", () => {
   it("is a no-op when no handler is registered", async () => {
     const fake = new FakeAdapter();
     const channel = createChannel({ adapters: [fake] });
-    await channel.start();
+    await channel.ɵruntime.start();
     // Should not throw.
     await expect(
       Promise.resolve(fake.emitThreadStarted()),
@@ -56,7 +56,7 @@ describe("Thread.setSuggestedPrompts / setTitle capability gating", () => {
       );
       results.push(await thread.setTitle("My conversation"));
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     await fake.emitThreadStarted({ replyTarget: { channel: "D1" } });
 
     expect(results).toEqual([{ ok: true }, { ok: true }]);
@@ -79,7 +79,7 @@ describe("Thread.setSuggestedPrompts / setTitle capability gating", () => {
       results.push(await thread.setSuggestedPrompts([]));
       results.push(await thread.setTitle("nope"));
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     await fake.emitThreadStarted();
 
     expect(results[0]!.ok).toBe(false);

--- a/packages/channels-core/src/thread-ephemeral.test.ts
+++ b/packages/channels-core/src/thread-ephemeral.test.ts
@@ -8,7 +8,7 @@ async function runOnMessage(
 ) {
   const channel = createChannel({ adapters: [fake] });
   channel.onMessage(fn);
-  await channel.start();
+  await channel.ɵruntime.start();
   fake.emitTurn({ userText: "hi", user: { id: "U1" } });
   await new Promise((r) => setTimeout(r, 0));
 }

--- a/packages/channels-core/src/thread-reactions.test.ts
+++ b/packages/channels-core/src/thread-reactions.test.ts
@@ -12,7 +12,7 @@ describe("Thread.react / unreact", () => {
       results.push(await thread.react(message.ref, emoji.thumbs_up));
       results.push(await thread.unreact(message.ref, emoji.thumbs_up));
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitTurn({ userText: "hi" });
     await new Promise((r) => setTimeout(r, 0));
 
@@ -32,7 +32,7 @@ describe("Thread.react / unreact", () => {
     channel.onMessage(async ({ thread, message }) => {
       res = await thread.react(message.ref, emoji.heart);
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     fake.emitTurn({ userText: "hi" });
     await new Promise((r) => setTimeout(r, 0));
 

--- a/packages/channels-discord/README.md
+++ b/packages/channels-discord/README.md
@@ -8,6 +8,12 @@ streaming, opaque-id interactions, and HITL.
 You write your UI as JSX once (`@copilotkit/channels-ui`) and drive the bot with
 `@copilotkit/channels`; this package is the only one that talks to Discord.
 
+The adapter keeps its own Discord credentials (`botToken` / `appId` / …) — but
+the Channel itself only runs inside a CopilotKit Intelligence-configured
+`CopilotRuntime` (an API key; a free tier is available). There is no
+standalone / DIY runner and no `channel.start()`; the runtime starts and owns
+the channel because Intelligence is configured.
+
 ## Install
 
 ```sh
@@ -23,8 +29,14 @@ import {
   defaultDiscordTools,
   defaultDiscordContext,
 } from "@copilotkit/channels-discord";
+import {
+  CopilotRuntime,
+  CopilotKitIntelligence,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 
 const bot = createChannel({
+  name: "support-bot", // project-unique Intelligence Channel name
   adapters: [
     discord({
       botToken: process.env.DISCORD_BOT_TOKEN!, // Bot token — Gateway + REST
@@ -48,7 +60,19 @@ const bot = createChannel({
 
 bot.onMention(({ thread }) => thread.runAgent());
 
-await bot.start();
+// The runtime owns the channel's lifecycle — there is no `bot.start()`.
+const runtime = new CopilotRuntime({
+  intelligence: new CopilotKitIntelligence({
+    apiUrl: "https://api.copilotkit.ai",
+    wsUrl: "wss://api.copilotkit.ai",
+    apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
+  }),
+  identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),
+  channels: [bot],
+});
+
+const handler = createCopilotRuntimeHandler({ runtime });
+await handler.channels.ready(); // starts the channel; handler.channels.stop() tears it down
 ```
 
 `discord(opts)` returns a `DiscordAdapter`. The adapter connects via the
@@ -250,8 +274,9 @@ work against any adapter that advertises the same capabilities.
 
 ## Slash commands
 
-Slash commands are registered up front on `bot.start()` via `registerCommands`.
-When `guildId` is set they register to that guild instantly; without it they
+Slash commands are registered up front — when the runtime activates the
+channel (`await handler.channels.ready()`) — via `registerCommands`. When
+`guildId` is set they register to that guild instantly; without it they
 register globally and take ~1 hour to propagate. Register handlers with
 `bot.onCommand`:
 

--- a/packages/channels-intelligence/src/http-transports.test.ts
+++ b/packages/channels-intelligence/src/http-transports.test.ts
@@ -1135,7 +1135,7 @@ describe("intelligenceAdapter() — config-free default transports", () => {
         }),
       ],
     });
-    await bot.start();
+    await bot.ɵruntime.start();
     // Let the loop heartbeat + poll at least once.
     const deadline = Date.now() + 200;
     while (
@@ -1144,7 +1144,7 @@ describe("intelligenceAdapter() — config-free default transports", () => {
     ) {
       await new Promise((r) => setTimeout(r, 5));
     }
-    await bot.stop();
+    await bot.ɵruntime.stop();
 
     const hb = calls.find((c) => c.url.endsWith("/heartbeat"))!;
     expect(hb.body).toMatchObject({

--- a/packages/channels-intelligence/src/in-memory-transports.ts
+++ b/packages/channels-intelligence/src/in-memory-transports.ts
@@ -83,7 +83,7 @@ export class InMemoryDeliverySource implements DeliverySource {
   async deliver(env: ChannelIngressEnvelope): Promise<void> {
     if (!this.onDelivery) {
       throw new Error(
-        "InMemoryDeliverySource: not started — call channel.start() first",
+        "InMemoryDeliverySource: not started — the runner must start the channel first",
       );
     }
     await this.onDelivery(env);

--- a/packages/channels-intelligence/src/intelligence-adapter.test.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.test.ts
@@ -49,7 +49,7 @@ describe("intelligenceAdapter — ingress dispatch", () => {
       seen = message;
       await thread.post(Section({ children: "reply" }));
     });
-    await bot.start();
+    await bot.ɵruntime.start();
     await source.deliver(envelope({ turnId: "t1", eventId: "e1" }));
 
     expect(egress.ops).toHaveLength(1);
@@ -72,7 +72,7 @@ describe("intelligenceAdapter — ingress dispatch", () => {
     channel.onMessage(async ({ message }) => {
       seenUser = message.user;
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     // The wire field is `displayName`; it must surface as PlatformUser.name so
     // `message.user.name` is observable through the typed API (parity with the
     // direct Slack adapter, which populates `name`).
@@ -92,7 +92,7 @@ describe("intelligenceAdapter — ingress dispatch", () => {
       agent: () => new FakeAgent(),
     });
     bot.onMessage(async () => {});
-    await bot.start();
+    await bot.ɵruntime.start();
     await source.deliver(envelope({ deliveryId: "d9" }));
     expect(source.acked).toEqual(["d9"]);
     expect(source.nacked).toEqual([]);
@@ -108,7 +108,7 @@ describe("intelligenceAdapter — ingress dispatch", () => {
     bot.onMessage(async () => {
       throw new Error("boom");
     });
-    await bot.start();
+    await bot.ɵruntime.start();
     await source.deliver(envelope({ deliveryId: "d9" }));
     expect(source.acked).toEqual([]);
     expect(source.nacked.map((n) => n.deliveryId)).toEqual(["d9"]);
@@ -129,7 +129,7 @@ describe("intelligenceAdapter — inbound file content parts", () => {
     bot.onMessage(async ({ message }) => {
       seen = message;
     });
-    await bot.start();
+    await bot.ɵruntime.start();
     await source.deliver(
       envelope({
         text: "what is this?",
@@ -168,7 +168,7 @@ describe("intelligenceAdapter — inbound file content parts", () => {
     bot.onMessage(async ({ message }) => {
       seen = message;
     });
-    await bot.start();
+    await bot.ɵruntime.start();
     await source.deliver(
       envelope({
         text: "hi",
@@ -200,7 +200,7 @@ describe("intelligenceAdapter — inbound file content parts", () => {
     bot.onMessage(async ({ message }) => {
       seen = message;
     });
-    await bot.start();
+    await bot.ɵruntime.start();
     await source.deliver(
       envelope({
         files: [
@@ -233,7 +233,7 @@ describe("intelligenceAdapter — inbound file content parts", () => {
     bot.onMessage(async ({ message }) => {
       seen = message;
     });
-    await bot.start();
+    await bot.ɵruntime.start();
     await source.deliver(
       envelope({
         files: [
@@ -264,7 +264,7 @@ describe("intelligenceAdapter — deterministic egress ids", () => {
       await thread.post(Section({ children: "a" }));
       await thread.post(Section({ children: "b" }));
     });
-    await bot.start();
+    await bot.ɵruntime.start();
 
     await source.deliver(envelope({ turnId: "t1", deliveryId: "d1" }));
     expect(egress.ops.map((o) => o.operationId)).toEqual(["t1:0", "t1:1"]);
@@ -298,7 +298,7 @@ describe("intelligenceAdapter — egress fail-loud", () => {
         postError = err;
       }
     });
-    await channel.start();
+    await channel.ɵruntime.start();
     await source.deliver(envelope());
 
     // Before the fix, thread.post resolved with a synthetic ref and postError
@@ -365,7 +365,7 @@ describe("intelligenceAdapter — all ingress kinds route to bot core", () => {
       ran = text;
       await thread.post(Section({ children: "ok" }));
     });
-    await bot.start();
+    await bot.ɵruntime.start();
     await source.deliver({
       ...base,
       kind: "command",
@@ -388,7 +388,7 @@ describe("intelligenceAdapter — all ingress kinds route to bot core", () => {
       seenValue = action.value;
       await thread.post(Section({ children: "clicked" }));
     });
-    await bot.start();
+    await bot.ɵruntime.start();
     await source.deliver({
       ...base,
       kind: "interaction",
@@ -410,7 +410,7 @@ describe("intelligenceAdapter — all ingress kinds route to bot core", () => {
       // Flip the card that was clicked (posted in a PRIOR delivery) in place.
       await thread.update(message.ref, Section({ children: "approved" }));
     });
-    await bot.start();
+    await bot.ɵruntime.start();
     await source.deliver({
       ...base,
       deliveryId: "d_click",
@@ -446,7 +446,7 @@ describe("intelligenceAdapter — all ingress kinds route to bot core", () => {
       ran = true;
       await thread.post(Section({ children: "hi" }));
     });
-    await bot.start();
+    await bot.ɵruntime.start();
     await source.deliver({ ...base, kind: "thread_started" });
     expect(ran).toBe(true);
     expect(egress.ops).toHaveLength(1);
@@ -463,7 +463,7 @@ describe("intelligenceAdapter — all ingress kinds route to bot core", () => {
     bot.onReaction(async (evt) => {
       seenEmoji = evt.rawEmoji;
     });
-    await bot.start();
+    await bot.ɵruntime.start();
     await source.deliver({
       ...base,
       kind: "reaction",
@@ -496,7 +496,7 @@ describe("intelligenceAdapter — exclusivity (V1)", () => {
       adapters: [ia()],
       agent: () => new FakeAgent(),
     });
-    expect(() => bot.addAdapter(new FakeAdapter())).toThrow(
+    expect(() => bot.ɵruntime.addAdapter(new FakeAdapter())).toThrow(
       /only adapter|alternative modes/i,
     );
   });
@@ -506,7 +506,7 @@ describe("intelligenceAdapter — exclusivity (V1)", () => {
       adapters: [new FakeAdapter()],
       agent: () => new FakeAgent(),
     });
-    expect(() => bot.addAdapter(ia())).toThrow(
+    expect(() => bot.ɵruntime.addAdapter(ia())).toThrow(
       /only adapter|alternative modes/i,
     );
   });

--- a/packages/channels-intelligence/src/runtime.test.ts
+++ b/packages/channels-intelligence/src/runtime.test.ts
@@ -226,7 +226,7 @@ describe("startChannels", () => {
   it("rolls back already-started bots when a later bot fails to start", async () => {
     const a = createChannel({ name: "support", agent: () => new FakeAgent() });
     const b = createChannel({ name: "triage", agent: () => new FakeAgent() });
-    const stopA = vi.spyOn(a, "stop");
+    const stopA = vi.spyOn(a.ɵruntime, "stop");
     await expect(
       startChannels({
         channels: [a, b],

--- a/packages/channels-intelligence/src/runtime.ts
+++ b/packages/channels-intelligence/src/runtime.ts
@@ -184,20 +184,20 @@ export async function startChannels(
       const { source, egress, renderSink, store } = opts.resolveTransport(
         channel.name!,
       );
-      channel.addAdapter(
+      channel.ɵruntime.addAdapter(
         intelligenceAdapter({ source, egress, renderSink, store }),
       );
-      await channel.start();
+      await channel.ɵruntime.start();
       startedChannels.push(channel);
     }
   } catch (err) {
-    await Promise.allSettled(startedChannels.map((c) => c.stop()));
+    await Promise.allSettled(startedChannels.map((c) => c.ɵruntime.stop()));
     throw err;
   }
   return {
     metadata,
     async stop() {
-      await Promise.all(opts.channels.map((c) => c.stop()));
+      await Promise.all(opts.channels.map((c) => c.ɵruntime.stop()));
     },
   };
 }

--- a/packages/channels-slack/README.md
+++ b/packages/channels-slack/README.md
@@ -8,6 +8,12 @@ streaming, opaque-id interactions, and HITL.
 You write your UI as JSX once (`@copilotkit/channels-ui`) and drive the bot with
 `@copilotkit/channels`; this package is the only one that talks to Slack.
 
+The adapter keeps its own Slack credentials (`botToken` / `appToken`) — but the
+Channel itself only runs inside a CopilotKit Intelligence-configured
+`CopilotRuntime` (an API key; a free tier is available). There is no
+standalone / DIY runner and no `channel.start()`; the runtime starts and owns
+the channel because Intelligence is configured.
+
 ## Install
 
 ```sh
@@ -23,8 +29,14 @@ import {
   defaultSlackTools,
   defaultSlackContext,
 } from "@copilotkit/channels-slack";
+import {
+  CopilotRuntime,
+  CopilotKitIntelligence,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 
 const bot = createChannel({
+  name: "support-bot", // project-unique Intelligence Channel name
   adapters: [
     slack({
       botToken: process.env.SLACK_BOT_TOKEN!, // xoxb-…
@@ -38,7 +50,19 @@ const bot = createChannel({
 
 bot.onMention(({ thread }) => thread.runAgent());
 
-await bot.start();
+// The runtime owns the channel's lifecycle — there is no `bot.start()`.
+const runtime = new CopilotRuntime({
+  intelligence: new CopilotKitIntelligence({
+    apiUrl: "https://api.copilotkit.ai",
+    wsUrl: "wss://api.copilotkit.ai",
+    apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
+  }),
+  identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),
+  channels: [bot],
+});
+
+const handler = createCopilotRuntimeHandler({ runtime });
+await handler.channels.ready(); // starts the channel; handler.channels.stop() tears it down
 ```
 
 `slack(opts)` returns a `SlackAdapter`. By default it runs in **Socket Mode**

--- a/packages/channels-teams/README.md
+++ b/packages/channels-teams/README.md
@@ -9,6 +9,13 @@ on Teams by adding this adapter.
 It is built on the **Microsoft 365 Agents SDK** (`@microsoft/agents-hosting`),
 the successor to the Bot Framework SDK.
 
+The adapter keeps its own Teams/Microsoft 365 credentials (`clientId` /
+`clientSecret` / `tenantId`, or none for anonymous local dev) — but the
+Channel itself only runs inside a CopilotKit Intelligence-configured
+`CopilotRuntime` (an API key; a free tier is available). There is no
+standalone / DIY runner and no `channel.start()`; the runtime starts and owns
+the channel because Intelligence is configured.
+
 ## Install
 
 ```sh
@@ -20,14 +27,32 @@ pnpm add @copilotkit/channels @copilotkit/channels-ui @copilotkit/channels-teams
 ```ts
 import { createChannel } from "@copilotkit/channels";
 import { teams } from "@copilotkit/channels-teams";
+import {
+  CopilotRuntime,
+  CopilotKitIntelligence,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 
 const bot = createChannel({
+  name: "support-bot", // project-unique Intelligence Channel name
   adapters: [teams({ port: 3978 })],
 });
 
 bot.onMessage(({ thread, message }) => thread.post(`Echo: ${message.text}`));
 
-await bot.start(); // POST /api/messages now listening on :3978
+// The runtime owns the channel's lifecycle — there is no `bot.start()`.
+const runtime = new CopilotRuntime({
+  intelligence: new CopilotKitIntelligence({
+    apiUrl: "https://api.copilotkit.ai",
+    wsUrl: "wss://api.copilotkit.ai",
+    apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
+  }),
+  identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),
+  channels: [bot],
+});
+
+const handler = createCopilotRuntimeHandler({ runtime });
+await handler.channels.ready(); // POST /api/messages now listening on :3978
 ```
 
 Then point the **Microsoft 365 Agents Playground** at it. No Microsoft

--- a/packages/channels-telegram/README.md
+++ b/packages/channels-telegram/README.md
@@ -8,6 +8,12 @@ plus streaming via chunked message edits, opaque-id interactions, and HITL.
 You write your UI as JSX once (`@copilotkit/channels-ui`) and drive the bot with
 `@copilotkit/channels`; this package is the only one that talks to Telegram.
 
+The adapter keeps its own Telegram bot token — but the Channel itself only runs
+inside a CopilotKit Intelligence-configured `CopilotRuntime` (an API key; a
+free tier is available). There is no standalone / DIY runner and no
+`channel.start()`; the runtime starts and owns the channel because
+Intelligence is configured.
+
 ## Install
 
 ```sh
@@ -36,8 +42,14 @@ import {
   defaultTelegramContext,
 } from "@copilotkit/channels-telegram";
 import { Message, Section } from "@copilotkit/channels-ui";
+import {
+  CopilotRuntime,
+  CopilotKitIntelligence,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 
 const bot = createChannel({
+  name: "support-bot", // project-unique Intelligence Channel name
   adapters: [
     telegram({
       token: process.env.TELEGRAM_BOT_TOKEN!,
@@ -59,7 +71,19 @@ bot.onThreadStarted(async ({ thread }) => {
   );
 });
 
-await bot.start();
+// The runtime owns the channel's lifecycle — there is no `bot.start()`.
+const runtime = new CopilotRuntime({
+  intelligence: new CopilotKitIntelligence({
+    apiUrl: "https://api.copilotkit.ai",
+    wsUrl: "wss://api.copilotkit.ai",
+    apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
+  }),
+  identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),
+  channels: [bot],
+});
+
+const handler = createCopilotRuntimeHandler({ runtime });
+await handler.channels.ready(); // starts the channel; handler.channels.stop() tears it down
 ```
 
 `telegram(opts)` returns a `TelegramAdapter`. By default it runs in

--- a/packages/channels-whatsapp/README.md
+++ b/packages/channels-whatsapp/README.md
@@ -8,6 +8,12 @@ vocabulary, opaque-id interactions, and HITL.
 You write your UI as JSX once (`@copilotkit/channels-ui`) and drive the bot with
 `@copilotkit/channels`; this package is the only one that talks to the WhatsApp Cloud API.
 
+The adapter keeps its own WhatsApp Cloud API credentials (`accessToken` /
+`phoneNumberId` / …) — but the Channel itself only runs inside a CopilotKit
+Intelligence-configured `CopilotRuntime` (an API key; a free tier is
+available). There is no standalone / DIY runner and no `channel.start()`; the
+runtime starts and owns the channel because Intelligence is configured.
+
 ## Install
 
 ```sh
@@ -22,8 +28,14 @@ import {
   whatsapp,
   defaultWhatsAppContext,
 } from "@copilotkit/channels-whatsapp";
+import {
+  CopilotRuntime,
+  CopilotKitIntelligence,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 
 const bot = createChannel({
+  name: "support-bot", // project-unique Intelligence Channel name
   adapters: [
     whatsapp({
       accessToken: process.env.WHATSAPP_ACCESS_TOKEN!,
@@ -43,7 +55,19 @@ bot.onMessage(async ({ thread }) => {
   await thread.runAgent();
 });
 
-await bot.start();
+// The runtime owns the channel's lifecycle — there is no `bot.start()`.
+const runtime = new CopilotRuntime({
+  intelligence: new CopilotKitIntelligence({
+    apiUrl: "https://api.copilotkit.ai",
+    wsUrl: "wss://api.copilotkit.ai",
+    apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
+  }),
+  identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),
+  channels: [bot],
+});
+
+const handler = createCopilotRuntimeHandler({ runtime });
+await handler.channels.ready(); // starts the channel; handler.channels.stop() tears it down
 console.log("[whatsapp-bot] listening for webhooks");
 ```
 

--- a/packages/channels/README.md
+++ b/packages/channels/README.md
@@ -3,6 +3,11 @@
 `@copilotkit/channels` is the batteries-included CopilotKit Channels package. One install
 provides the engine, JSX vocabulary, UI primitives, testing API, and every supported adapter.
 
+**Channels require a CopilotKit Intelligence connection** (an API key — a free tier
+is available, so this is "connect your Intelligence account," not "pay for it").
+There is no standalone / DIY way to run a Channel: the `CopilotRuntime` starts and
+owns each Channel's lifecycle once Intelligence is configured.
+
 ## Install
 
 ```sh
@@ -23,8 +28,14 @@ Configure TypeScript to use the Channels JSX runtime:
 ```tsx
 import { createChannel, Message, Section } from "@copilotkit/channels";
 import { slack } from "@copilotkit/channels/slack";
+import {
+  CopilotRuntime,
+  CopilotKitIntelligence,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 
 const channel = createChannel({
+  name: "support-bot", // project-unique Intelligence Channel name
   adapters: [
     slack({
       botToken: process.env.SLACK_BOT_TOKEN!,
@@ -40,6 +51,20 @@ channel.onMessage(({ thread, message }) =>
     </Message>,
   ),
 );
+
+// The runtime owns the Channel's lifecycle — there is no `channel.start()`.
+const runtime = new CopilotRuntime({
+  intelligence: new CopilotKitIntelligence({
+    apiUrl: "https://api.copilotkit.ai",
+    wsUrl: "wss://api.copilotkit.ai",
+    apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
+  }),
+  identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),
+  channels: [channel],
+});
+
+const handler = createCopilotRuntimeHandler({ runtime });
+await handler.channels.ready(); // starts the channel; handler.channels.stop() tears it down
 ```
 
 ## Adapter entry points

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
@@ -571,7 +571,7 @@ describe("ChannelManager", () => {
     expect(engine).not.toHaveBeenCalled();
   });
 
-  it("skips managed activation for a direct-adapter channel but records it unmanaged; the managed one reflects its real state", async () => {
+  it("starts a direct-adapter channel via its own transport seam (not the managed engine) and reflects online; the managed one reflects its real state", async () => {
     const log = vi.fn();
     const engine: ActivateChannelEngine = vi.fn(async () => fakeHandle());
     const managed = createChannel({ name: "support" });
@@ -579,6 +579,11 @@ describe("ChannelManager", () => {
       name: "sales",
       adapters: [new FakeAdapter({ platform: "slack" })],
     });
+    // The manager now DRIVES a direct channel through its own transport seam —
+    // spy on it so the managed engine and this seam can be told apart.
+    const directStart = vi
+      .spyOn(direct.ɵruntime, "start")
+      .mockResolvedValue(undefined);
 
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
@@ -588,16 +593,17 @@ describe("ChannelManager", () => {
     });
     mgr.activate();
 
+    // The managed engine runs only for the managed channel; the direct channel
+    // is started through `channel.ɵruntime.start()` instead.
     expect(engine).toHaveBeenCalledTimes(1);
+    expect(directStart).toHaveBeenCalledTimes(1);
 
     await expect(mgr.ready()).resolves.toBeUndefined();
-    // The direct channel is surfaced as `unmanaged` (never omitted, never
-    // `online`); the managed channel reflects its real activated state; and
-    // `overall` folds over the managed channel only, so a healthy managed
-    // channel beside an unmanaged one still reads `online`.
+    // Both channels read `online`: the managed one via activation, the direct one
+    // once its own transport is up. `overall` now folds over BOTH.
     expect(mgr.status().channels).toEqual({
       support: "online",
-      sales: "unmanaged",
+      sales: "online",
     });
     expect(mgr.status().overall).toBe("online");
 
@@ -608,17 +614,20 @@ describe("ChannelManager", () => {
           typeof msg === "string" &&
           msg.includes("sales") &&
           msg.includes("direct adapter") &&
-          msg.includes("unmanaged"),
+          msg.includes("ɵruntime.start()"),
       ),
     ).toBe(true);
   });
 
-  it("reports a lone direct-adapter channel as unmanaged (not online), keeps it in status, and ready() still resolves", async () => {
+  it("starts a lone direct-adapter channel and reads online (not empty/false-healthy); ready() resolves", async () => {
     const engine: ActivateChannelEngine = vi.fn(async () => fakeHandle());
     const direct = createChannel({
       name: "sales",
       adapters: [new FakeAdapter({ platform: "slack" })],
     });
+    const directStart = vi
+      .spyOn(direct.ɵruntime, "start")
+      .mockResolvedValue(undefined);
 
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
@@ -627,23 +636,32 @@ describe("ChannelManager", () => {
     });
     mgr.activate();
 
+    // The managed engine is never called for a direct channel; its own transport
+    // seam is used instead.
     expect(engine).not.toHaveBeenCalled();
-    // A runtime whose only channel is direct must NOT read healthy: overall is
-    // `unmanaged`, and the channel is present in status (never an empty map).
-    expect(mgr.status().overall).toBe("unmanaged");
-    expect(mgr.status().channels).toEqual({ sales: "unmanaged" });
-    // ready() may resolve (nothing on the managed path to wait for) but that
-    // resolution implies no health — the truthfulness lives in status().
+    expect(directStart).toHaveBeenCalledTimes(1);
+    // Before its start settles the channel reads `connecting` — present in status
+    // (never an empty map), never false-healthy.
+    expect(mgr.status().channels).toEqual({ sales: "connecting" });
+    expect(mgr.status().overall).toBe("connecting");
+
     await expect(mgr.ready()).resolves.toBeUndefined();
+    // Once the direct transport is up, the lone direct channel reads `online`.
+    expect(mgr.status().channels).toEqual({ sales: "online" });
+    expect(mgr.status().overall).toBe("online");
   });
 
-  it("leaves an unmanaged channel unmanaged through stop() — the manager never owned its lifecycle", async () => {
+  it("stops a direct-adapter channel through its own transport seam on stop()", async () => {
     const engine: ActivateChannelEngine = vi.fn(async () => fakeHandle());
     const managed = createChannel({ name: "support" });
     const direct = createChannel({
       name: "sales",
       adapters: [new FakeAdapter({ platform: "slack" })],
     });
+    vi.spyOn(direct.ɵruntime, "start").mockResolvedValue(undefined);
+    const directStop = vi
+      .spyOn(direct.ɵruntime, "stop")
+      .mockResolvedValue(undefined);
 
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
@@ -653,13 +671,43 @@ describe("ChannelManager", () => {
     await mgr.ready();
     await mgr.stop();
 
-    // The managed channel is torn down to `stopped`; the direct one stays
-    // `unmanaged` (the manager cannot stop what it never started), so overall
-    // folds to `stopped` over the managed channel.
+    // Both channels are torn down: the managed handle via handle.stop(), the
+    // direct one via channel.ɵruntime.stop(). `overall` folds to `stopped`.
+    expect(directStop).toHaveBeenCalledTimes(1);
     expect(mgr.status().channels).toEqual({
       support: "stopped",
-      sales: "unmanaged",
+      sales: "stopped",
     });
+    expect(mgr.status().overall).toBe("stopped");
+  });
+
+  it("drives a direct channel's REAL transport end-to-end: the adapter starts on ready() and stops on stop()", async () => {
+    // No ɵruntime spy — exercise the REAL create-channel start/stop seam with a
+    // FakeAdapter, so the spy-based tests above can't hide a broken real path.
+    // (Channel telemetry is disabled under VITEST, so start() makes no network
+    // call.)
+    const engine: ActivateChannelEngine = vi.fn(async () => fakeHandle());
+    const adapter = new FakeAdapter({ platform: "slack" });
+    const adapterStop = vi.spyOn(adapter, "stop");
+    const direct = createChannel({ name: "sales", adapters: [adapter] });
+
+    const mgr = new ChannelManager({
+      intelligence: fakeIntelligence(),
+      channels: [direct],
+      activateChannel: engine,
+    });
+    await mgr.ready();
+
+    // The manager started the direct channel's own transport, which started the
+    // developer's adapter.
+    expect(adapter.started).toBe(true);
+    expect(mgr.status().channels).toEqual({ sales: "online" });
+
+    await mgr.stop();
+
+    // Teardown routed through channel.ɵruntime.stop() reached the adapter.
+    expect(adapterStop).toHaveBeenCalledTimes(1);
+    expect(mgr.status().channels).toEqual({ sales: "stopped" });
     expect(mgr.status().overall).toBe("stopped");
   });
 

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
@@ -711,6 +711,28 @@ describe("ChannelManager", () => {
     expect(mgr.status().overall).toBe("stopped");
   });
 
+  it("a direct channel whose adapters ALL fail to start reads 'error', not a false 'online'", async () => {
+    // Regression for the false-`online` defect: ɵruntime.start() used to swallow
+    // adapter start failures and resolve, so the manager reported `online` on a
+    // dead bot. Now an all-failed start rejects → the manager surfaces `error`.
+    const engine: ActivateChannelEngine = vi.fn(async () => fakeHandle());
+    const adapter = new FakeAdapter({ platform: "slack", failStart: true });
+    const direct = createChannel({ name: "sales", adapters: [adapter] });
+
+    const mgr = new ChannelManager({
+      intelligence: fakeIntelligence(),
+      channels: [direct],
+      activateChannel: engine,
+    });
+
+    // A dead channel must not resolve ready() clean, and must not read `online`.
+    await expect(mgr.ready()).rejects.toBeDefined();
+    expect(mgr.status().channels).toEqual({ sales: "error" });
+    expect(mgr.status().overall).toBe("error");
+
+    await mgr.stop();
+  });
+
   it("still enforces unique names across all declared channels, including direct ones", () => {
     const engine: ActivateChannelEngine = vi.fn(async () => fakeHandle());
     const mgr = new ChannelManager({

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -24,14 +24,16 @@ import type { Channel } from "@copilotkit/channels";
  *   delegated to the Phoenix connection layer); it only reflects the health the
  *   session reports via its `onStateChange` observer.
  * - `stopped`: {@link ChannelManager.stop} has torn the Channel down.
- * - `unmanaged`: the Channel carries a developer-supplied direct adapter, so this
- *   handler does NOT own its lifecycle — the developer starts it via
- *   `channel.start()`. The manager records the Channel with this status purely so
- *   its presence is observable and never misreported as `online`. It is neither
- *   activated, awaited, nor stopped here. Real routing of direct channels is
- *   deferred (tracked in OSS-486).
  * - `error`: activation rejected with a non-setup error, OR a previously-online
  *   session gave up reconnecting after its bounded reconnect window.
+ *
+ * Both MANAGED (Intelligence-gateway) and DIRECT (developer-supplied adapter)
+ * Channels move through these states. A direct Channel is driven by the manager
+ * too — it is started via {@link Channel.ɵruntime}`.start()` and reaches `online`
+ * once its own transport is up — but it is NOT wired into the Intelligence
+ * gateway/canonical/reliability layer (deferred, OSS-599): it simply runs its
+ * own adapter transport, started and stopped by the manager. A direct Channel
+ * has no managed-session drop signal, so it never reports `reconnecting`.
  */
 export type ChannelStatus =
   | "connecting"
@@ -39,7 +41,6 @@ export type ChannelStatus =
   | "setup_required"
   | "reconnecting"
   | "stopped"
-  | "unmanaged"
   | "error";
 
 /**
@@ -310,9 +311,15 @@ function withTimeout<T>(
 }
 
 /**
- * Drives managed Channel activation for an Intelligence runtime: lazily
- * activates each declared Channel through an engine, tracks per-Channel
- * lifecycle status, exposes readiness, and tears everything down.
+ * Drives Channel activation for an Intelligence runtime: lazily activates each
+ * declared Channel, tracks per-Channel lifecycle status, exposes readiness, and
+ * tears everything down. A MANAGED Channel (empty `adapters`) is activated
+ * through the injected engine over the Intelligence gateway; a DIRECT Channel
+ * (developer-supplied adapter) is started through its own transport seam
+ * (`channel.ɵruntime.start()`) — driven by the manager, but running only its own
+ * adapter transport, not the gateway path (gateway/canonical/reliability wiring
+ * for direct Channels is deferred, OSS-599). Its very existence means Intelligence
+ * is configured, so there is no standalone/self-started path.
  *
  * Activation is lazy and idempotent — constructing the manager does nothing;
  * {@link activate} starts it and a second call is a no-op. Activation throws
@@ -396,36 +403,24 @@ export class ChannelManager implements ChannelsControl {
     // Partition declared Channels by transport. A Channel carrying ANY adapter
     // that is NOT the Intelligence managed adapter (a developer-supplied
     // slack/discord/... adapter, which lacks `__intelligenceChannel`) is a
-    // DIRECT channel: it is started by the developer via `channel.start()`, not
-    // managed-activated here. The skip is EXCLUSIVE PER CHANNEL, not per platform
-    // — a Channel served by a direct adapter is not also managed: ANY direct
-    // adapter makes the WHOLE Channel `unmanaged` and skips managed activation,
-    // regardless of platform. Attaching the managed adapter alongside a direct
-    // one would double-deliver every turn (and trip the SDK's `assertExclusive`
-    // guard, moving the Channel to `error`). Per the SoT rule, never infer
-    // managed intent from a local direct adapter — a managed-eligible Channel has
-    // an empty `adapters` at declaration time. Managed+direct coexistence on the
-    // same Channel is NOT supported today; it is deferred (OSS-484), as is real
-    // routing of direct channels (OSS-486).
+    // DIRECT channel. The manager still owns its lifecycle — but a direct Channel
+    // runs its OWN adapter transport rather than the Intelligence gateway path:
+    // it is started here via `channel.ɵruntime.start()` (not the managed engine)
+    // and torn down via `channel.ɵruntime.stop()`. The distinction is EXCLUSIVE
+    // PER CHANNEL, not per platform — a Channel served by a direct adapter is not
+    // also managed: ANY direct adapter makes the WHOLE Channel direct, regardless
+    // of platform. Attaching the managed adapter alongside a direct one would
+    // double-deliver every turn (and trip the SDK's `assertExclusive` guard,
+    // moving the Channel to `error`). Per the SoT rule, never infer managed intent
+    // from a local direct adapter — a managed-eligible Channel has an empty
+    // `adapters` at declaration time. Managed+direct coexistence on the same
+    // Channel is NOT supported today; it is deferred (OSS-484). Direct Channels
+    // run only their own transport here; wiring them into the Intelligence
+    // gateway/canonical/reliability layer is deferred (OSS-599).
     for (const channel of this.channels) {
       const isDirect = channel.adapters.some((a) => !a.__intelligenceChannel);
       if (isDirect) {
-        this.log?.(
-          `channel "${channel.name!}" carries a direct adapter — recording status "unmanaged" and skipping managed activation (this handler does not own its lifecycle; start it via channel.start(); exclusive per Channel: a Channel served by a direct adapter is not also managed, regardless of platform — managed+direct coexistence deferred (OSS-484); routing of direct channels deferred (OSS-486))`,
-        );
-        // Record an EXPLICIT `unmanaged` entry rather than skipping silently.
-        // A skipped Channel with no entry vanishes from status()/computeOverall,
-        // so a runtime whose only Channel is direct would falsely read `online`
-        // and ready() would imply a health this handler never established. The
-        // entry keeps the Channel observable and truthful: it is never
-        // activated, its `settled` is already resolved (nothing on the managed
-        // path to wait for), and stopEntry leaves it untouched (see stopEntry).
-        this.entries.set(channel.name!, {
-          status: "unmanaged",
-          handle: undefined,
-          handleStopped: false,
-          settled: Promise.resolve(),
-        });
+        this.startDirectChannel(channel);
         continue;
       }
       const name = channel.name!;
@@ -518,6 +513,109 @@ export class ChannelManager implements ChannelsControl {
   }
 
   /**
+   * Start a DIRECT-adapter Channel through its own transport seam
+   * ({@link Channel.ɵruntime}`.start()`), recording a live entry so
+   * {@link ready}/{@link status}/{@link stop} all cover it. A direct Channel is
+   * driven by the manager — but only because the Intelligence runtime constructed
+   * this manager at all — and runs its OWN adapter transport, NOT the Intelligence
+   * gateway path. It is deliberately NOT wired into the gateway/canonical/
+   * reliability layer (deferred, OSS-599).
+   *
+   * Mirrors the managed path's settle machinery so teardown resilience is shared:
+   * the entry's `handle` is a synthetic {@link ChannelsHandle} whose `stop()`
+   * calls `channel.ɵruntime.stop()`, so the SAME idempotent, bounded, resilient
+   * {@link stopEntry} that tears down a managed handle tears down a direct Channel
+   * too. The handle is assigned only AFTER `start()` resolves (exactly as the
+   * managed path assigns its handle only on resolve), so a `stop()` during a
+   * still-starting direct Channel returns promptly with nothing to stop and the
+   * post-settle guard tears down the late transport. A direct Channel exposes no
+   * managed-session drop signal, so no connection observer is wired and it never
+   * reaches `reconnecting`.
+   *
+   * @param channel - The direct-adapter Channel to start.
+   */
+  private startDirectChannel(channel: Channel): void {
+    const name = channel.name!;
+    this.log?.(
+      `channel "${name}" carries a direct adapter — starting its own transport via channel.ɵruntime.start() (the Intelligence runtime drives its lifecycle; it runs its own adapter transport, NOT the managed gateway path — gateway/canonical/reliability wiring deferred (OSS-599); managed+direct coexistence deferred (OSS-484))`,
+    );
+
+    let resolveSettled!: () => void;
+    let rejectSettled!: (err: unknown) => void;
+    const settled = new Promise<void>((resolve, reject) => {
+      resolveSettled = resolve;
+      rejectSettled = reject;
+    });
+    // ready() awaits `settled`; attach a no-op catch so a rejection is always
+    // considered handled (ready() still sees the reason).
+    settled.catch(() => {});
+
+    // Synthetic handle wrapping the Channel's own stop seam. Assigned to the
+    // entry only on successful start (below) so the shared teardown machinery
+    // (handleStopped guard, withTimeout bounding, resilient allSettled) stops a
+    // direct Channel exactly as it stops a managed handle.
+    const directHandle: ChannelsHandle = {
+      metadata: {},
+      stop: () => channel.ɵruntime.stop(),
+    };
+
+    // Start the direct transport synchronously so it is observably started the
+    // moment activate() returns (callers see `connecting` before awaiting ready).
+    // A synchronous throw becomes this Channel's status rather than throwing out
+    // of activate().
+    let activation: Promise<void>;
+    try {
+      activation = channel.ɵruntime.start();
+    } catch (err) {
+      activation = Promise.reject(err);
+    }
+
+    const entry: ChannelEntry = {
+      status: "connecting",
+      handle: undefined,
+      handleStopped: false,
+      settled,
+    };
+
+    activation
+      .then(
+        async () => {
+          entry.handle = directHandle;
+          if (this.stopped) {
+            // stop() ran before start() settled, so it could not tear down a
+            // transport that was not up yet. Release it now (idempotent) and keep
+            // the Channel `stopped`.
+            await this.stopEntry(entry);
+            resolveSettled();
+            return;
+          }
+          entry.status = "online";
+          resolveSettled();
+        },
+        async (err: unknown) => {
+          if (this.stopped) {
+            // A start rejection that arrives AFTER stop() must NOT resurrect the
+            // entry into `error`: the Channel is already being torn down. Keep it
+            // `stopped` and resolve `settled` so a later ready() does not reject.
+            entry.handle = directHandle;
+            await this.stopEntry(entry);
+            resolveSettled();
+            return;
+          }
+          entry.status = "error";
+          this.log?.(
+            `channel "${name}" failed to start its direct transport`,
+            err,
+          );
+          rejectSettled(err);
+        },
+      )
+      .catch(() => {});
+
+    this.entries.set(name, entry);
+  }
+
+  /**
    * Throw if two declared Channels share a `name`. `entries` is keyed by name,
    * so a duplicate would overwrite the first Channel's entry and leak its live
    * session. Called at the very start of {@link activate}, before any engine
@@ -551,12 +649,12 @@ export class ChannelManager implements ChannelsControl {
   }
 
   /**
-   * Resolve when every managed Channel has settled to `online`/`setup_required`.
+   * Resolve when every declared Channel — managed OR direct — has settled to
+   * `online`/`setup_required`.
    *
-   * A direct-adapter (`unmanaged`) Channel has an already-resolved `settled` and
-   * so never blocks — but its resolution implies NO health: this handler does not
-   * own it. Truthfulness about direct Channels lives in {@link status} (they read
-   * `unmanaged`, never `online`), not in `ready()` resolving.
+   * A direct-adapter Channel is awaited too: its `settled` resolves once its own
+   * transport is up (`channel.ɵruntime.start()` settling) and rejects if that
+   * start fails, exactly as a managed Channel's `settled` tracks its activation.
    *
    * Activates lazily if not already started — so a first call rejects with the
    * same {@link ChannelConfigError} as the synchronous throw from
@@ -615,22 +713,18 @@ export class ChannelManager implements ChannelsControl {
   }
 
   /**
-   * Snapshot status. Every declared Channel — managed OR direct/`unmanaged` —
-   * appears keyed by name in `channels`; a direct-adapter Channel this handler
-   * does not own is always surfaced as `unmanaged`, never `online`.
+   * Snapshot status. Every declared Channel — managed OR direct — appears keyed
+   * by name in `channels`; a direct-adapter Channel reads `online` once its own
+   * transport is up, exactly like a managed one.
    *
-   * `overall` is folded over the MANAGED Channels only (see {@link computeOverall}),
+   * `overall` is folded over ALL declared Channels (see {@link computeOverall}),
    * by precedence `error` > `reconnecting` > `setup_required` > `connecting` >
-   * `online`. `online` means every managed Channel can currently send.
-   * `reconnecting` outranks `setup_required` because a dropped-but-retrying
-   * Channel is an active outage, louder than a steadily-degraded unprovisioned
-   * one. `unmanaged` Channels are EXCLUDED from that fold — they carry no health
-   * this handler established — so a healthy managed Channel alongside an
-   * `unmanaged` one still reports `overall: "online"` while the `unmanaged` one
-   * stays visible per-Channel. When every declared Channel is `unmanaged`,
-   * `overall` is `unmanaged` (NOT `online`). With no declared Channels at all,
-   * `overall` is `online` (nothing is degraded); once every managed Channel has
-   * been stopped, `overall` is `stopped`.
+   * `online`. `online` means every Channel can currently send. `reconnecting`
+   * outranks `setup_required` because a dropped-but-retrying Channel is an active
+   * outage, louder than a steadily-degraded unprovisioned one (only managed
+   * Channels ever reach `reconnecting`; a direct Channel has no managed-session
+   * drop signal). With no declared Channels at all, `overall` is `online` (nothing
+   * is degraded); once every Channel has been stopped, `overall` is `stopped`.
    */
   status(): {
     overall: ChannelStatus;
@@ -665,37 +759,32 @@ export class ChannelManager implements ChannelsControl {
   /**
    * Fold per-Channel statuses into a single overall status (see {@link status}).
    *
-   * `unmanaged` Channels are folded out FIRST: they carry no lifecycle this
-   * handler owns, so they must neither count as `online` nor mask a real managed
-   * outage. The remaining MANAGED statuses are ranked
+   * Every declared Channel — managed OR direct — participates: a started direct
+   * Channel reads `online` and counts toward health exactly like a managed one,
+   * and its `error` is a real outage that must dominate. Statuses are ranked
    * `error` > `reconnecting` > `setup_required` > `connecting` > `online`, so a
-   * genuine managed failure still dominates while a healthy managed Channel
-   * beside an `unmanaged` one reads `online`. If NO managed Channels remain (every
-   * declared Channel is direct/`unmanaged`) the result is `unmanaged` — never the
-   * false-healthy `online`. The empty-input case (no declared Channels at all)
-   * stays `online` (nothing is degraded).
+   * genuine failure still dominates a healthy sibling. (Only managed Channels ever
+   * reach `reconnecting`; a direct Channel has no managed-session drop signal.)
+   * The empty-input case (no declared Channels at all) stays `online` (nothing is
+   * degraded).
    */
   private computeOverall(values: ChannelStatus[]): ChannelStatus {
     if (values.length === 0) {
       return "online";
     }
-    const managed = values.filter((v) => v !== "unmanaged");
-    if (managed.length === 0) {
-      return "unmanaged";
-    }
-    if (managed.every((v) => v === "stopped")) {
+    if (values.every((v) => v === "stopped")) {
       return "stopped";
     }
-    if (managed.includes("error")) {
+    if (values.includes("error")) {
       return "error";
     }
-    if (managed.includes("reconnecting")) {
+    if (values.includes("reconnecting")) {
       return "reconnecting";
     }
-    if (managed.includes("setup_required")) {
+    if (values.includes("setup_required")) {
       return "setup_required";
     }
-    if (managed.includes("connecting")) {
+    if (values.includes("connecting")) {
       return "connecting";
     }
     return "online";
@@ -749,10 +838,14 @@ export class ChannelManager implements ChannelsControl {
    * not-yet-stopped handle (gated by {@link ChannelEntry.handleStopped}).
    *
    * This is the ONE guarded teardown path shared by both `stop()` and the
-   * post-settle guard in {@link activate}. Because the guard is per-entry and
-   * idempotent, a handle assigned in the same tick as `stop()` is stopped
-   * exactly once even when both callers reach the entry, and a late settle can
-   * never resurrect a `stopped` entry.
+   * post-settle guard in {@link activate}/{@link startDirectChannel}. Because the
+   * guard is per-entry and idempotent, a handle assigned in the same tick as
+   * `stop()` is stopped exactly once even when both callers reach the entry, and a
+   * late settle can never resurrect a `stopped` entry. It is transport-agnostic: a
+   * managed entry's `handle.stop()` releases the gateway session, and a direct
+   * entry's synthetic handle (assigned in {@link startDirectChannel}) routes the
+   * same `handle.stop()` to `channel.ɵruntime.stop()` — so direct and managed
+   * Channels share one bounded, resilient teardown.
    *
    * `handle.stop()` failures are logged (via {@link ChannelManager.log}) but NOT
    * rethrown: the real launcher's `stop()` rethrows after `session.disconnect()`,
@@ -762,11 +855,9 @@ export class ChannelManager implements ChannelsControl {
    * `.catch` — otherwise the sync throw would escape, skip `resolveSettled()` in
    * the fulfilled-then-stopped branch of {@link activate}, and hang `settled`.
    *
-   * An `unmanaged` entry (a direct-adapter Channel this handler never activated)
-   * is left untouched: the manager owns no handle and no lifecycle for it, so
-   * claiming to have `stopped` it would be as untruthful as calling it `online`.
-   * The developer's `channel.start()`/stop path is unaffected by manager
-   * teardown.
+   * An entry with no handle yet (a still-`connecting` Channel whose transport has
+   * not come up) is only marked `stopped`: there is nothing to tear down, and the
+   * post-settle guard releases the transport if it arrives after `stop()`.
    *
    * A WEDGED `handle.stop()` (one that never settles) is bounded by
    * {@link ChannelManagerArgs.stopHandleTimeoutMs}: after the deadline the call
@@ -776,9 +867,6 @@ export class ChannelManager implements ChannelsControl {
    * @param entry - The Channel entry to stop.
    */
   private async stopEntry(entry: ChannelEntry): Promise<void> {
-    if (entry.status === "unmanaged") {
-      return;
-    }
     entry.status = "stopped";
     if (entry.handle && !entry.handleStopped) {
       entry.handleStopped = true;


### PR DESCRIPTION
## Summary

**Plan C: channels are an Intelligence capability.** A valid Intelligence configuration (API key) is required to run any channel. There's a **free tier**, so this is "connect your account," not "pay."

The Intelligence runtime runs every channel: managed (Slack/Teams) over the gateway, and **direct-adapter** channels (Discord/Telegram/WhatsApp, or self-hosted Slack/Teams) via their own credentialed transport, started by the runtime. The SSE runtime type-rejects `channels`, and the handler builds channel activation for an Intelligence runtime.

> Note: the `channel.ɵruntime.{start,stop,addAdapter}` seam is an internal (`ɵ`) contract the runtime and the managed launcher drive — not a public API.

Design doc: [Channels = Intelligence-only (Plan C)](https://app.notion.com/p/3a63aa381852814e83dafedc0742e7cc)

## What changed

- **`refactor(channels-core)`** — relocate the `Channel` lifecycle onto an internal `channel.ɵruntime.{start,stop,addAdapter}` seam.
- **`feat(channels-core)!`** — **remove** public `Channel.start()/stop()/addAdapter()`. Channels are runtime-driven only.
- **`feat(runtime)!`** — the `ChannelManager` (built only for an Intelligence runtime) now **starts direct-adapter channels** via `ɵruntime.start()` instead of recording them `"unmanaged"` and skipping. Dead `"unmanaged"` status removed. Direct channels reuse the same bounded/idempotent/resilient teardown via a synthetic handle.
- **`fix(channels-core)`** — a channel whose adapters **all** fail to start now **errors** instead of falsely reporting `online` (a partial start, ≥1 adapter live, still counts as started).
- **`fix(examples)`** — examples bound `channels.ready({ timeoutMs })` so a wedged adapter start can't hang readiness.
- **`docs`** — 7 channels READMEs + the teams/slack examples reworked to `new CopilotRuntime({ intelligence, channels })` + `handler.channels.ready()/stop()`; no `channel.start()`, no DIY. Multi-platform slack now runs under Intelligence (one `ɵruntime.start()` starts all its direct adapters).

**Breaking:** `Channel.start()/stop()/addAdapter()` removed (`channels-core` 0.2.x) — channels are driven by the runtime (`new CopilotRuntime({ intelligence, channels })`).

## Validation

**Unit** (per-package raw `tsc` + `vitest`): channels-core **156**, channels-intelligence **182**, runtime channel-manager **38** (incl. a new `failStart` regression test), channels-integration 8.

**Independent whole-branch review:** direct-channel lifecycle traced correct for every start/stop interleaving (no wedge, single-stop, bounded/idempotent teardown shared with the managed path); public-API removal complete (zero callers); no DIY/`channelRunner`/guard-relaxation debris; SSE guard intact.

**Adversarial review** (tried to break it) surfaced two real items, both handled here:
- **False `online`** — `ɵruntime.start()` swallowed adapter start failures and resolved, so a dead channel read `online`. **Fixed** (`fix(channels-core)` + `failStart` test).
- **Overstated invariant** — "no standalone path" is enforced by the runtime gate + `ɵ` convention, not the type system. **Clarified** (see the note above). Also bounded example `ready()` (`fix(examples)`).

**Live run** against a real Intelligence key (**7/7**): the gate rejects channels-without-Intelligence; the runtime starts a direct channel via `ɵruntime.start()` (a real turn invoked the agent, clean `stop()`); and the real key **authenticated against the real gateway** (a managed join was rejected by a project feature-flag, not an auth error — so the key was accepted).

> Examples typecheck only in CI — the worktree can't build every `@copilotkit/*` sibling; those `TS2307`/`TS2305` are environmental.

## Related

- **Improvements (fast-follow):** [OSS-599](https://linear.app/copilotkit/issue/OSS-599) — §2 response policy, four-mode agent binding, run-correctness (Intelligence-side).
- **Managed-provider parity:** [OSS-600](https://linear.app/copilotkit/issue/OSS-600) + [601](https://linear.app/copilotkit/issue/OSS-601)/[602](https://linear.app/copilotkit/issue/OSS-602)/[603](https://linear.app/copilotkit/issue/OSS-603) (Discord/Telegram/WhatsApp) — hosted transport for the remaining platforms; also closes the direct-channel key-validation gap (managed = gateway-validated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
