### PR TITLE
fix(showcase/built-in-agent): use gpt-5.4 — staging returns empty on gpt-5.5

### DIFF
--- a/showcase/integrations/built-in-agent/src/lib/factory/a2ui-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/a2ui-factory.ts
@@ -149,7 +149,7 @@ async function runA2uiDesignAttempt(
   parentAbortController: AbortController,
 ): Promise<A2uiAttemptResult> {
   const text = await chat({
-    adapter: openaiText("gpt-4o", { fetch: forwardingFetch }),
+    adapter: openaiText("gpt-5.4", { fetch: forwardingFetch }),
     messages: [{ role: "user", content: brief }],
     systemPrompts: [systemPrompt],
     stream: false,
@@ -397,7 +397,7 @@ function createA2uiAgent(recovery?: A2uiRecoveryConfig) {
       );
 
       return chat({
-        adapter: openaiText("gpt-4o", { fetch: forwardingFetch }),
+        adapter: openaiText("gpt-5.4", { fetch: forwardingFetch }),
         messages,
         systemPrompts: [SYSTEM_PROMPT, ...systemPrompts],
         tools: [generateA2ui],

--- a/showcase/integrations/built-in-agent/src/lib/factory/a2ui-fixed-schema-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/a2ui-fixed-schema-factory.ts
@@ -139,7 +139,7 @@ export function createA2UIFixedSchemaAgent() {
     factory: ({ input, abortController }) => {
       const { messages, systemPrompts } = convertInputToTanStackAI(input);
       return chat({
-        adapter: openaiText("gpt-4o-mini", { fetch: forwardingFetch }),
+        adapter: openaiText("gpt-5.4", { fetch: forwardingFetch }),
         messages,
         systemPrompts: [A2UI_FIXED_SCHEMA_SYSTEM_PROMPT, ...systemPrompts],
         tools: [displayFlightTool],

--- a/showcase/integrations/built-in-agent/src/lib/factory/agentic-chat-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/agentic-chat-factory.ts
@@ -28,7 +28,7 @@ export function createAgenticChatAgent() {
     factory: ({ input, abortController }) => {
       const { messages, systemPrompts } = convertInputToTanStackAI(input);
       return chat({
-        adapter: openaiText("gpt-5.5", { fetch: forwardingFetch }),
+        adapter: openaiText("gpt-5.4", { fetch: forwardingFetch }),
         messages,
         systemPrompts: [AGENTIC_CHAT_SYSTEM_PROMPT, ...systemPrompts],
         tools: [],

--- a/showcase/integrations/built-in-agent/src/lib/factory/byoc-hashbrown-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/byoc-hashbrown-factory.ts
@@ -120,7 +120,7 @@ export function createByocHashbrownAgent() {
       const { messages, systemPrompts } = convertInputToTanStackAI(input);
 
       const stream = chat({
-        adapter: openaiText("gpt-4o-mini", { fetch: forwardingFetch }),
+        adapter: openaiText("gpt-5.4", { fetch: forwardingFetch }),
         messages,
         systemPrompts: [BYOC_HASHBROWN_SYSTEM_PROMPT, ...systemPrompts],
         tools: [],

--- a/showcase/integrations/built-in-agent/src/lib/factory/byoc-json-render-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/byoc-json-render-factory.ts
@@ -151,7 +151,7 @@ export function createByocJsonRenderAgent() {
       const { messages, systemPrompts } = convertInputToTanStackAI(input);
 
       const stream = chat({
-        adapter: openaiText("gpt-4o-mini", { fetch: forwardingFetch }),
+        adapter: openaiText("gpt-5.4", { fetch: forwardingFetch }),
         messages,
         systemPrompts: [SYSTEM_PROMPT, ...systemPrompts],
         tools: [],

--- a/showcase/integrations/built-in-agent/src/lib/factory/mcp-apps-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/mcp-apps-factory.ts
@@ -55,7 +55,7 @@ export function createMcpAppsAgent() {
         }),
       );
       return chat({
-        adapter: openaiText("gpt-4o-mini", { fetch: forwardingFetch }),
+        adapter: openaiText("gpt-5.4", { fetch: forwardingFetch }),
         messages,
         systemPrompts: [MCP_APPS_SYSTEM_PROMPT, ...systemPrompts],
         tools,

--- a/showcase/integrations/built-in-agent/src/lib/factory/multimodal-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/multimodal-factory.ts
@@ -4,7 +4,7 @@ import { createBuiltInAgent } from "./tanstack-factory";
 
 // Built-in agent for the Multimodal Attachments demo.
 //
-// The base built-in agent (gpt-5.5) consumes image `document`/`image` content
+// The base built-in agent (gpt-5.4) consumes image `document`/`image` content
 // parts natively via its vision adapter, but the OpenAI TEXT adapter cannot
 // consume PDF `document` parts — the turn is dropped before the model is even
 // called (aimock records zero PDF requests). LGP solves this by flattening

--- a/showcase/integrations/built-in-agent/src/lib/factory/ogui-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/ogui-factory.ts
@@ -39,7 +39,7 @@ export function createOguiAgent() {
         }),
       );
       return chat({
-        adapter: openaiText("gpt-4o", { fetch: forwardingFetch }),
+        adapter: openaiText("gpt-5.4", { fetch: forwardingFetch }),
         messages,
         systemPrompts,
         tools,

--- a/showcase/integrations/built-in-agent/src/lib/factory/subagent-tools.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/subagent-tools.ts
@@ -61,7 +61,7 @@ export function buildSubagentTools(parentAbortController: AbortController) {
       }),
     }).server(async ({ task }) => {
       const text = await chat({
-        adapter: openaiText("gpt-4o", { fetch: forwardingFetch }),
+        adapter: openaiText("gpt-5.4", { fetch: forwardingFetch }),
         messages: [{ role: "user", content: task }],
         systemPrompts: [role.systemPrompt],
         abortController: parentAbortController,

--- a/showcase/integrations/built-in-agent/src/lib/factory/tanstack-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/tanstack-factory.ts
@@ -296,7 +296,7 @@ export function createBuiltInAgent(options: BuiltInAgentOptions = {}) {
         // x-* headers (e.g. x-aimock-context) bound into ALS by the
         // route handler. Without this, /v1/responses calls to aimock
         // miss every fixture (404) and the D6 subset goes 0/6.
-        adapter: openaiText("gpt-5.5", { fetch: forwardingFetch }),
+        adapter: openaiText("gpt-5.4", { fetch: forwardingFetch }),
         messages,
         systemPrompts,
         tools: [...serverTools, ...frontendTools],


### PR DESCRIPTION
## Problem
After #6106 merged, **staging showed every built-in-agent cell capped at D3** with the backend red:
```
Failure: empty assistant response   (level: chat)
Backend: https://showcase-built-in-agent-staging.up.railway.app
```
The D4 chat probe hits the main agent (`agentic_chat` / generic `createBuiltInAgent`), which used **`gpt-5.5`** → the real OpenAI call returns empty → the whole D-ladder gates → all cells stuck at D3.

## Root cause
- `gpt-5.5` is **unique to built-in-agent** (introduced in #6106). Every other integration — including the **LGP reference that works on staging** — uses **`gpt-5.4`** (38× across the repo).
- Staging's OpenAI account doesn't serve `gpt-5.5`, so every real call came back empty.
- **aimock ignores the model id**, so this was invisible in local D6 (which is why it passed locally but broke on staging).
- The other factories also still had leftover `gpt-4o` / `gpt-4o-mini` (a2ui, byoc, mcp-apps, ogui, subagents).

## Fix
Switch **all** `built-in-agent` `openaiText()` calls to **`gpt-5.4`** (matches LGP, served on staging). `reasoning-factory` keeps `gpt-5.2` (reasoning-capable; those demos are NSF-quarantined). 10 factory files, model-string-only changes.

> Note: this deviates from the general "always gpt-5.5" preference because this is an **LGP-parity** integration and staging only serves `gpt-5.4` — parity + a working staging both require it.

## Verify
Once merged + redeployed, staging D4 chat should return real text and the cells should climb past D3. (Can't be verified in local D6 since aimock ignores the model.)