### PR TITLE
fix(showcase/built-in-agent): real beautiful-chat backend (verified vs real LLM)

### DIFF
--- a/showcase/integrations/built-in-agent/.gitignore
+++ b/showcase/integrations/built-in-agent/.gitignore
@@ -1,0 +1,4 @@
+
+# local secrets (real OpenAI key for prod-parity testing) — never commit
+.env
+.env*.local

--- a/showcase/integrations/built-in-agent/PARITY_NOTES.md
+++ b/showcase/integrations/built-in-agent/PARITY_NOTES.md
@@ -251,6 +251,103 @@ context-scoped aimock prove otherwise — both are GREEN:
   `create_view` entry, and the flowchart entry in `mcp-apps.json`). The external
   MCP server IS reachable from the demo container — not an external blocker.
 
+## Real-LLM backend audit (fixes verified against REAL OpenAI, not aimock)
+
+An audit that ran the demos against a **real** `OPENAI_API_KEY` (no aimock,
+`OPENAI_BASE_URL` unset) surfaced backend bugs that the aimock fixtures masked.
+Each item below was fixed and re-verified end-to-end in a browser against real
+OpenAI (rendered testids + assistant text). These are orthogonal to the
+aimock/D6 notes above.
+
+### `cvdiag` `.js` import extensions — dev-only `/api/copilotkit` 500 (BLOCKER)
+
+`src/cvdiag/*.ts` imported siblings with explicit `.js` extensions (e.g.
+`from "./schema.js"`). Under `next dev --turbopack` + `moduleResolution:
+bundler` those specifiers don't resolve, so `/api/copilotkit` returned 500 for
+every request in dev. Prod `next build` tolerated it. Fixed by dropping the
+`.js` extensions on the relative sibling imports in `schema.ts`,
+`edge-headers.ts`, `emit.ts`, `pb-writer-fetch.ts`, `cvdiag-emitter.ts`.
+
+### `shared-state-read` / `shared-state-read-write` — UI state never reached the backend
+
+Root cause was a **client seeding race in the demo frontend**, not the
+converter: the seed effect ran with `[]` deps, so it seeded the _provisional_
+agent `useAgent` returns while the runtime `/info` sync is still in flight. When
+the real runtime-synced agent swapped in (a new reference), the `[]`-deps effect
+never re-ran, so the real agent — the one `runAgent` serialises into
+`input.state` — shipped `state: {}` and the model answered "I don't see a
+recipe." (The runtime's `convertInputToTanStackAI` already injects `input.state`
+into the system prompt correctly.) Fixed by seeding on `[agent]` deps in both
+demo pages, guarded by the existing `!recipe`/`!preferences` check so user edits
+aren't clobbered. Verified: the model reads the seeded recipe/preferences.
+
+### `shared-state-read-write` — `set_notes` result not turned into state
+
+`set_notes` is a server tool (`server-tools.ts`) returning `{ notes }`, but
+`tanstack-factory.ts`'s `convertStream` only translated
+`AGUISendStateSnapshot` / `AGUISendStateDelta` / `set_steps` into STATE events.
+Added a `set_notes` → `STATE_DELTA add /notes` branch (same RFC-6902 `add`-not-
+`replace` rationale as `set_steps`). Verified: asking the agent to remember
+something populates `notes-list` / `note-item`.
+
+### `declarative-gen-ui` / `a2ui-recovery` — secondary A2UI LLM emitted empty output
+
+`a2ui-factory.ts`'s `generate_a2ui` passed
+`modelOptions.response_format: { type: "json_object" }`. TanStack's `openaiText`
+targets the OpenAI _Responses_ API, which does NOT accept the Chat-Completions
+`response_format` param — passing it made the secondary call return an **empty
+string** (verified), so the surface never painted. Fixed by removing
+`response_format` (JSON-only output is enforced by the system prompt, mirroring
+the byoc factories) plus a defensive `stripJsonFences` unwrap. Verified against
+real OpenAI: `declarative-gen-ui` and `a2ui-recovery`'s heal turn paint
+`declarative-metric` / `declarative-pie-chart` / `declarative-bar-chart`.
+(`a2ui-recovery`'s _exhaust_/failure-card path is driven by deterministic aimock
+fixtures that force every validation pass to fail — a real LLM produces a valid
+surface, so the failure card is not reproducible against a real key by design.)
+
+### Reasoning trio — real reasoning trace via the Responses API
+
+Real OpenAI chat-completions does NOT stream `reasoning_content` (only aimock
+did), so the previous chat-completions `extractReasoning` adapter produced no
+trace against a real key. `reasoning-factory.ts` now uses `openaiText` (the
+Responses API, the same transport as every other demo) with
+`modelOptions.reasoning = { effort: "high", summary: "auto" }` and a `type:
+"custom"` converter that maps the Responses-API thinking STEP chunks
+(`STEP_STARTED` `stepType:"thinking"` + `STEP_FINISHED` deltas) to
+`REASONING_MESSAGE_*` AG-UI events. Verified against real OpenAI:
+`reasoning-custom` renders the `reasoning-block`, `reasoning-default` renders the
+built-in "Thought for …" block, and `tool-rendering-reasoning-chain` renders
+BOTH the reasoning block and its tool cards (no tool-render regression).
+
+Caveats (documented, not blockers):
+
+- Reasoning summaries require `effort: "high"`; at `low`/`medium` real OpenAI
+  frequently completes short prompts without emitting a summary part.
+- OpenAI's prompt caching means an _identical_ prompt asked repeatedly may
+  return a cached completion with no fresh reasoning summary — the first/fresh
+  ask reliably produces one.
+- This switches the reasoning demos' transport from chat-completions to the
+  Responses API. Text + tool-call behaviour is unchanged (verified); the aimock
+  D6 reasoning fixtures, if they were recorded for the chat-completions
+  `reasoning_content` shape, would need re-recording for Responses-API reasoning
+  summaries. The `manifest.yaml` `not_supported_features` entries were left
+  untouched (not verifiable here without aimock).
+
+### `auth` + `voice` `[[...slug]]` routes — dev-server-only 500, prod unaffected
+
+`/api/copilotkit-auth/*` and `/api/copilotkit-voice/*` (the only two catch-all
+`[[...slug]]` routes; every other route is a single `route.ts`) crash the dev
+server's route worker at request time — under `next dev --turbopack` via a
+PostCSS/worker panic, and under plain `next dev` (webpack) via a masked
+"Jest worker encountered … child process exceptions" `WorkerError`. The crash is
+below the handler (a try/catch inside the route never fires) and does NOT
+reproduce in production: after `next build` + `next start`, `auth /info` returns
+200 with a valid token and 401 without one, the auth chat runs end-to-end
+(assistant replies, all `/info` + `/run` responses 200, zero console errors),
+and `voice /info` returns 200. This is a `next dev` dev-server limitation with
+catch-all API routes + the V2 runtime handler, not an integration bug — no
+code change is warranted. Prod is unaffected.
+
 ## When to update this file
 
 - Adding a per-demo capability divergence vs. LGP → document the rationale.

--- a/showcase/integrations/built-in-agent/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/built-in-agent/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -3,19 +3,51 @@ import {
   createCopilotRuntimeHandler,
   InMemoryAgentRunner,
 } from "@copilotkit/runtime/v2";
-import { createBuiltInAgent } from "@/lib/factory/tanstack-factory";
+import { createBeautifulChatAgent } from "@/lib/factory/beautiful-chat-factory";
 // Wrap handlers so inbound x-* headers (e.g. x-aimock-context) are bound
 // into ALS for the factory's `forwardingFetch` to re-attach on outbound
 // LLM calls. See @/lib/header-forwarding for the full rationale.
 import { withForwardedHeaders } from "@/lib/header-forwarding";
 
-// Dedicated runtime for the Beautiful Chat starter demo. The generic
-// all-tools agent backs it (the polished two-pane chat + gen-UI chart
-// examples ride the shared server tools); per-demo behavior is driven by
-// the aimock fixture. Matches the LGP reference route/agent id.
+// Dedicated runtime for the Beautiful Chat flagship showcase cell.
+//
+// Beautiful Chat simultaneously exercises A2UI (dynamic + fixed schema), Open
+// Generative UI, and MCP Apps. The canonical starter
+// (examples/integrations/langgraph-python) ships all three flags on a single
+// runtime; this restores that combined runtime for the one cell that needs it,
+// backed by the built-in (TanStack) `beautiful_chat` port.
+//
+// The three middleware flags each inject tools into the agent's `input.tools`
+// at request time — the beautiful-chat factory declares those injected tools
+// so the model can call them:
+//   - `openGenerativeUI: true`  → injects `generateSandboxedUi`
+//   - `a2ui.injectA2UITool: true` → injects the dynamic `render_a2ui` tool
+//     (the middleware's default injected tool name) plus its usage guidelines
+//     and serialises the registered catalog into the agent context
+//   - `mcpApps.servers` (Excalidraw) → injects the remote MCP tools (create_view, …)
 const runtime = new CopilotRuntime({
-  agents: { "beautiful-chat": createBuiltInAgent() },
+  agents: { "beautiful-chat": createBeautifulChatAgent() },
   runner: new InMemoryAgentRunner(),
+  openGenerativeUI: true,
+  a2ui: {
+    // Inject the dynamic A2UI render tool (`render_a2ui`) into the agent.
+    injectA2UITool: true,
+    // Models follow the tool-usage guide and omit `catalogId`; the middleware
+    // then falls back to the unregistered spec basic catalog ("Catalog not
+    // found" render error). Pin the catalog the page registers.
+    defaultCatalogId: "copilotkit://app-dashboard-catalog",
+  },
+  mcpApps: {
+    servers: [
+      {
+        type: "http",
+        url: process.env.MCP_SERVER_URL || "https://mcp.excalidraw.com",
+        // Stable serverId so persisted threads keep restoring the same MCP
+        // server across URL changes.
+        serverId: "beautiful_chat_mcp",
+      },
+    ],
+  },
 });
 
 const handler = createCopilotRuntimeHandler({

--- a/showcase/integrations/built-in-agent/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/shared-state-read-write/page.tsx
@@ -57,14 +57,22 @@ function DemoContent() {
   // Seed initial preferences + empty notes into agent state once, so the
   // agent has something to read on the very first turn.
   useEffect(() => {
-    if (!agentState?.preferences) {
+    // Seed against the CURRENT agent instance. `useAgent` returns a
+    // provisional agent while the runtime /info sync is still in flight and
+    // swaps in the real (runtime-synced) agent once it resolves — a new
+    // reference. Seeding with `[]` deps ran once against the provisional
+    // agent, so the real agent (the one `runAgent` serialises into
+    // `input.state`) was never seeded and the backend saw `state: {}`.
+    // Depending on `[agent]` re-seeds whenever the instance changes; the
+    // `!recipe/!preferences` guard keeps it from clobbering user edits.
+    if (!(agent.state as RWAgentState | undefined)?.preferences) {
       agent.setState({
         preferences: INITIAL_PREFERENCES,
         notes: [],
       } as RWAgentState);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [agent]);
 
   // @region[set-state]
   // @region[use-agent-write]

--- a/showcase/integrations/built-in-agent/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/shared-state-read/page.tsx
@@ -63,15 +63,23 @@ function Recipe() {
     available: "always",
   });
 
-  // Seed the initial recipe into agent state once so the agent has
-  // something to read on the first turn. After this, every edit lands
-  // via `agent.setState` below.
+  // Seed the initial recipe into agent state so the agent has something to
+  // read on the first turn. After this, every edit lands via `agent.setState`
+  // below.
+  //
+  // Deps are `[agent]`, NOT `[]`: `useAgent` returns a provisional agent while
+  // the runtime /info sync is still in flight, then swaps in the real
+  // (runtime-synced) agent once it resolves — a new reference. A `[]`-deps
+  // effect seeded only the provisional agent, so the real agent (the one
+  // `runAgent` serialises into `input.state`) shipped `state: {}` and the model
+  // replied "I don't see a recipe". Re-seeding on every `agent` reference change
+  // fixes that; the `!recipe` guard keeps it from clobbering user edits.
   useEffect(() => {
     if (!(agent.state as RecipeAgentState | undefined)?.recipe) {
       agent.setState({ recipe: INITIAL_RECIPE } satisfies RecipeAgentState);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [agent]);
 
   const recipe =
     (agent.state as RecipeAgentState | undefined)?.recipe ?? INITIAL_RECIPE;

--- a/showcase/integrations/built-in-agent/src/cvdiag/cvdiag-emitter.ts
+++ b/showcase/integrations/built-in-agent/src/cvdiag/cvdiag-emitter.ts
@@ -32,7 +32,7 @@ export {
   isValidTestId,
   validateEnvelope,
   validateMetadata,
-} from "./schema.js";
+} from "./schema";
 
 export type {
   CvdiagLayer,
@@ -46,7 +46,7 @@ export type {
   CvdiagEnvelope,
   EnvelopeValidationResult,
   MetadataValidationResult,
-} from "./schema.js";
+} from "./schema";
 
 // ── Edge-header allow/deny filter + PII scrub ───────────────────────────────
 export {
@@ -58,7 +58,7 @@ export {
   SCRUB_REPLACEMENT,
   scrubSecrets,
   filterEdgeHeaders,
-} from "./edge-headers.js";
+} from "./edge-headers";
 
 // ── Emitter (tier resolution, fail-closed DEBUG, byte caps, span/id minters) ─
 export {
@@ -71,7 +71,7 @@ export {
   resolveEnvLabel,
   mintTestId,
   mintSpanId,
-} from "./emit.js";
+} from "./emit";
 
 export type {
   CvdiagTier,
@@ -79,15 +79,12 @@ export type {
   CvdiagEnv,
   CvdiagEmitterOptions,
   CvdiagEmitArgs,
-} from "./emit.js";
+} from "./emit";
 
 // ── Concrete writer-role PB writer (plain fetch; auth-with-password→Bearer) ──
 export {
   CvdiagFetchPbWriter,
   createCvdiagFetchPbWriterFromEnv,
-} from "./pb-writer-fetch.js";
+} from "./pb-writer-fetch";
 
-export type {
-  FetchLike,
-  CvdiagFetchPbWriterOptions,
-} from "./pb-writer-fetch.js";
+export type { FetchLike, CvdiagFetchPbWriterOptions } from "./pb-writer-fetch";

--- a/showcase/integrations/built-in-agent/src/cvdiag/edge-headers.ts
+++ b/showcase/integrations/built-in-agent/src/cvdiag/edge-headers.ts
@@ -14,8 +14,8 @@
  *     case-insensitive); both lists are stored lowercase.
  */
 
-import type { EdgeHeaders, EdgeHeaderKey } from "./schema.js";
-import { EDGE_HEADER_KEYS } from "./schema.js";
+import type { EdgeHeaders, EdgeHeaderKey } from "./schema";
+import { EDGE_HEADER_KEYS } from "./schema";
 
 // Secret/PII scrub primitives live in the leaf `scrub.ts` module so that
 // `schema.ts` can scrub metadata values without forming a `schema → edge-headers
@@ -30,7 +30,7 @@ export {
   SCRUB_REPLACEMENT,
   scrubSecrets,
   scrubDeep,
-} from "./scrub.js";
+} from "./scrub";
 
 /** The 9 allow-listed edge-header keys (spec §5). */
 export const EDGE_HEADER_ALLOWLIST: readonly string[] = EDGE_HEADER_KEYS;

--- a/showcase/integrations/built-in-agent/src/cvdiag/emit.ts
+++ b/showcase/integrations/built-in-agent/src/cvdiag/emit.ts
@@ -14,14 +14,14 @@
 
 import crypto from "node:crypto";
 
-import { EDGE_HEADER_MAX_LEN } from "./edge-headers.js";
+import { EDGE_HEADER_MAX_LEN } from "./edge-headers";
 import {
   EDGE_HEADER_KEYS,
   SCHEMA_VERSION,
   isValidTestId,
   validateEnvelope,
   validateMetadata,
-} from "./schema.js";
+} from "./schema";
 import type {
   CvdiagBoundary,
   CvdiagDataPlaneBoundary,
@@ -29,7 +29,7 @@ import type {
   CvdiagLayer,
   CvdiagOutcome,
   EdgeHeaders,
-} from "./schema.js";
+} from "./schema";
 
 /** Resolved verbosity tier (cumulative). */
 export type CvdiagTier = "default" | "verbose" | "debug";

--- a/showcase/integrations/built-in-agent/src/cvdiag/pb-writer-fetch.ts
+++ b/showcase/integrations/built-in-agent/src/cvdiag/pb-writer-fetch.ts
@@ -43,7 +43,7 @@
  * observes.
  */
 
-import type { CvdiagEnvelope } from "./schema.js";
+import type { CvdiagEnvelope } from "./schema";
 
 /** The `cvdiag_events` collection name (mirrors migration 1779990200). */
 const CVDIAG_EVENTS_COLLECTION = "cvdiag_events";

--- a/showcase/integrations/built-in-agent/src/cvdiag/schema.ts
+++ b/showcase/integrations/built-in-agent/src/cvdiag/schema.ts
@@ -39,7 +39,7 @@
  *     pipeline owned by a later slot — never by this module.
  */
 
-import { scrubDeep, scrubSecrets } from "./scrub.js";
+import { scrubDeep, scrubSecrets } from "./scrub";
 
 /** Current schema version. Bumps only on a breaking (rename/type) change. */
 export const SCHEMA_VERSION = 1 as const;

--- a/showcase/integrations/built-in-agent/src/lib/factory/a2ui-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/a2ui-factory.ts
@@ -27,6 +27,18 @@ revenue, headcount by team, signups per month). \`generate_a2ui\` takes a \
 single \`brief\` argument summarising what the UI should communicate. Keep \
 chat replies to one short sentence; let the UI do the talking.`;
 
+/**
+ * Defensively unwrap a fenced code block (```json … ``` or ``` … ```) that the
+ * secondary LLM may wrap its JSON in, despite the system prompt asking for no
+ * fences. Returns the inner text trimmed; a non-fenced string is returned
+ * as-is (trimmed).
+ */
+function stripJsonFences(text: string): string {
+  const trimmed = text.trim();
+  const fence = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```$/i);
+  return (fence ? fence[1] : trimmed).trim();
+}
+
 function createSurfaceOp(
   surfaceId: string,
   catalogId: string = BASIC_CATALOG_ID,
@@ -148,15 +160,22 @@ async function runA2uiDesignAttempt(
   systemPrompt: string,
   parentAbortController: AbortController,
 ): Promise<A2uiAttemptResult> {
+  // NOTE: no `response_format: { type: "json_object" }` here. TanStack AI's
+  // OpenAI adapter (`openaiText`) targets the *Responses* API
+  // (`client.responses.create()`), which does NOT accept the Chat-Completions
+  // `response_format` param — passing it makes the call return an EMPTY string
+  // (verified against real OpenAI), so the secondary LLM produced no schema and
+  // the surface never painted. JSON-only output is instead enforced by
+  // SECONDARY_LLM_INSTRUCTIONS ("Output ONLY a single JSON object … no code
+  // fences"), the same approach the byoc-hashbrown / byoc-json-render factories
+  // use. `stripJsonFences` below defensively unwraps a ```json … ``` block in
+  // case the model adds one anyway.
   const text = await chat({
     adapter: openaiText("gpt-5.4", { fetch: forwardingFetch }),
     messages: [{ role: "user", content: brief }],
     systemPrompts: [systemPrompt],
     stream: false,
     abortController: parentAbortController,
-    modelOptions: {
-      response_format: { type: "json_object" },
-    },
   });
 
   // A non-string `chat()` return cannot be parsed and must not be
@@ -179,7 +198,7 @@ async function runA2uiDesignAttempt(
     data?: Record<string, unknown>;
   };
   try {
-    parsed = JSON.parse(text);
+    parsed = JSON.parse(stripJsonFences(text));
   } catch {
     return { ok: false, error: "Secondary LLM returned non-JSON output" };
   }

--- a/showcase/integrations/built-in-agent/src/lib/factory/beautiful-chat-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/beautiful-chat-factory.ts
@@ -1,0 +1,739 @@
+import { BuiltInAgent, convertInputToTanStackAI } from "@copilotkit/runtime/v2";
+import { EventType } from "@ag-ui/client";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
+import { chat, toolDefinition } from "@tanstack/ai";
+import { openaiText } from "@tanstack/ai-openai";
+import { z } from "zod";
+import { jsonSchemaToZod } from "./tanstack-factory";
+// Custom fetch that injects ALS-bound inbound x-* headers (e.g.
+// x-aimock-context) onto every outbound OpenAI call. Required so aimock
+// can match fixtures by integration context. See ../header-forwarding.ts
+// for the full rationale; mirrors the Mastra precedent.
+import { forwardingFetch } from "../header-forwarding";
+
+// ─── Constants ──────────────────────────────────────────────────────
+
+// Catalog + surface ids MUST match what the frontend registers. The
+// beautiful-chat page registers its A2UI catalog with catalogId
+// "copilotkit://app-dashboard-catalog" (see
+// src/app/demos/beautiful-chat/declarative-generative-ui/renderers.tsx) and
+// the runtime's `a2ui.defaultCatalogId` is pinned to the same value in the
+// route. Fixed-schema flight cards render onto their own surface.
+const CATALOG_ID = "copilotkit://app-dashboard-catalog";
+const FLIGHT_SURFACE_ID = "flight-search-results";
+const A2UI_OPERATIONS_KEY = "a2ui_operations";
+
+// ─── Data (query_data) ──────────────────────────────────────────────
+
+// Financial sales data. Inlined as a TS const (mirrors a2ui-fixed-schema's
+// inlined FLIGHT_SCHEMA) so it ships into the Next.js route bundle without
+// runtime fs access — the LGP reference reads this from
+// `beautiful_chat_data/db.csv` at module load. Values are kept as strings to
+// match Python's `csv.DictReader` result shape (`query_data` returns the raw
+// rows and the model derives chart data from them).
+interface SalesRow {
+  date: string;
+  category: string;
+  subcategory: string;
+  amount: string;
+  type: string;
+  notes: string;
+}
+
+const SALES_DATA: SalesRow[] = [
+  {
+    date: "2026-01-05",
+    category: "Revenue",
+    subcategory: "Enterprise Subscriptions",
+    amount: "28000",
+    type: "income",
+    notes: "3 new enterprise customers (Acme Corp, TechFlow, DataViz Inc)",
+  },
+  {
+    date: "2026-01-05",
+    category: "Revenue",
+    subcategory: "Pro Tier Upgrades",
+    amount: "18000",
+    type: "income",
+    notes: "24 users upgraded from free to pro",
+  },
+  {
+    date: "2026-01-08",
+    category: "Revenue",
+    subcategory: "API Usage Overages",
+    amount: "9500",
+    type: "income",
+    notes: "High API usage from top 5 customers",
+  },
+  {
+    date: "2026-01-10",
+    category: "Expenses",
+    subcategory: "Engineering Salaries",
+    amount: "42000",
+    type: "expense",
+    notes: "7 engineers + 2 contractors",
+  },
+  {
+    date: "2026-01-10",
+    category: "Expenses",
+    subcategory: "Product Team",
+    amount: "18000",
+    type: "expense",
+    notes: "PM and 2 designers",
+  },
+  {
+    date: "2026-01-12",
+    category: "Expenses",
+    subcategory: "AWS Infrastructure",
+    amount: "8200",
+    type: "expense",
+    notes: "Increased compute for new AI features",
+  },
+  {
+    date: "2026-01-15",
+    category: "Expenses",
+    subcategory: "Marketing - Paid Ads",
+    amount: "12000",
+    type: "expense",
+    notes: "Google Ads and LinkedIn campaigns",
+  },
+  {
+    date: "2026-01-18",
+    category: "Revenue",
+    subcategory: "Consulting Services",
+    amount: "14500",
+    type: "income",
+    notes: "Custom integration for Acme Corp",
+  },
+  {
+    date: "2026-01-20",
+    category: "Expenses",
+    subcategory: "Customer Success",
+    amount: "15000",
+    type: "expense",
+    notes: "3 CSMs + support tools (Intercom)",
+  },
+  {
+    date: "2026-01-22",
+    category: "Expenses",
+    subcategory: "AI Model Costs",
+    amount: "4200",
+    type: "expense",
+    notes: "OpenAI API usage for product features",
+  },
+  {
+    date: "2026-01-25",
+    category: "Revenue",
+    subcategory: "Marketplace Sales",
+    amount: "12800",
+    type: "income",
+    notes: "Template and plugin sales",
+  },
+  {
+    date: "2026-01-28",
+    category: "Expenses",
+    subcategory: "Office & Equipment",
+    amount: "3500",
+    type: "expense",
+    notes: "New laptops and coworking spaces",
+  },
+  {
+    date: "2026-02-03",
+    category: "Revenue",
+    subcategory: "Enterprise Subscriptions",
+    amount: "31000",
+    type: "income",
+    notes: "2 new customers + expansion from TechFlow",
+  },
+  {
+    date: "2026-02-03",
+    category: "Revenue",
+    subcategory: "Pro Tier Upgrades",
+    amount: "22500",
+    type: "income",
+    notes: "31 upgrades + reduced churn",
+  },
+  {
+    date: "2026-02-05",
+    category: "Revenue",
+    subcategory: "API Usage Overages",
+    amount: "11800",
+    type: "income",
+    notes: "DataViz Inc heavy API usage spike",
+  },
+  {
+    date: "2026-02-07",
+    category: "Expenses",
+    subcategory: "Engineering Salaries",
+    amount: "42000",
+    type: "expense",
+    notes: "Same headcount as January",
+  },
+  {
+    date: "2026-02-07",
+    category: "Expenses",
+    subcategory: "Product Team",
+    amount: "18000",
+    type: "expense",
+    notes: "No changes to product team",
+  },
+  {
+    date: "2026-02-10",
+    category: "Expenses",
+    subcategory: "AWS Infrastructure",
+    amount: "9500",
+    type: "expense",
+    notes: "Traffic spike from viral social post",
+  },
+  {
+    date: "2026-02-12",
+    category: "Expenses",
+    subcategory: "Marketing - Paid Ads",
+    amount: "15000",
+    type: "expense",
+    notes: "Increased ad spend for Q1 push",
+  },
+  {
+    date: "2026-02-14",
+    category: "Revenue",
+    subcategory: "Consulting Services",
+    amount: "18000",
+    type: "income",
+    notes: "2 custom projects (TechFlow + new client)",
+  },
+  {
+    date: "2026-02-18",
+    category: "Expenses",
+    subcategory: "Customer Success",
+    amount: "16500",
+    type: "expense",
+    notes: "Hired 1 additional CSM",
+  },
+  {
+    date: "2026-02-20",
+    category: "Expenses",
+    subcategory: "AI Model Costs",
+    amount: "5800",
+    type: "expense",
+    notes: "Increased usage from new AI features launch",
+  },
+  {
+    date: "2026-02-22",
+    category: "Revenue",
+    subcategory: "Marketplace Sales",
+    amount: "14200",
+    type: "income",
+    notes: "Top template hit featured list",
+  },
+  {
+    date: "2026-02-25",
+    category: "Expenses",
+    subcategory: "Conference & Travel",
+    amount: "4500",
+    type: "expense",
+    notes: "Team attended SaaS Conference 2026",
+  },
+  {
+    date: "2026-02-27",
+    category: "Revenue",
+    subcategory: "Partnership Revenue",
+    amount: "11500",
+    type: "income",
+    notes: "Referral fees from integration partners",
+  },
+  {
+    date: "2026-03-02",
+    category: "Revenue",
+    subcategory: "Enterprise Subscriptions",
+    amount: "35000",
+    type: "income",
+    notes: "Major win: Fortune 500 customer signed",
+  },
+  {
+    date: "2026-03-02",
+    category: "Revenue",
+    subcategory: "Pro Tier Upgrades",
+    amount: "26000",
+    type: "income",
+    notes: "42 upgrades - best month yet",
+  },
+  {
+    date: "2026-03-05",
+    category: "Revenue",
+    subcategory: "API Usage Overages",
+    amount: "13200",
+    type: "income",
+    notes: "Consistent high usage across top tier",
+  },
+  {
+    date: "2026-03-08",
+    category: "Expenses",
+    subcategory: "Engineering Salaries",
+    amount: "48000",
+    type: "expense",
+    notes: "Hired 1 senior engineer for AI team",
+  },
+  {
+    date: "2026-03-08",
+    category: "Expenses",
+    subcategory: "Product Team",
+    amount: "21000",
+    type: "expense",
+    notes: "Promoted designer to senior level",
+  },
+  {
+    date: "2026-03-10",
+    category: "Expenses",
+    subcategory: "AWS Infrastructure",
+    amount: "11000",
+    type: "expense",
+    notes: "Scaled infrastructure for enterprise client",
+  },
+  {
+    date: "2026-03-12",
+    category: "Expenses",
+    subcategory: "Marketing - Paid Ads",
+    amount: "18000",
+    type: "expense",
+    notes: "Doubled down on successful campaigns",
+  },
+  {
+    date: "2026-03-14",
+    category: "Revenue",
+    subcategory: "Consulting Services",
+    amount: "21500",
+    type: "income",
+    notes: "Fortune 500 onboarding + 2 other projects",
+  },
+  {
+    date: "2026-03-16",
+    category: "Expenses",
+    subcategory: "Customer Success",
+    amount: "19500",
+    type: "expense",
+    notes: "Hired dedicated enterprise CSM",
+  },
+  {
+    date: "2026-03-18",
+    category: "Expenses",
+    subcategory: "AI Model Costs",
+    amount: "7200",
+    type: "expense",
+    notes: "Fortune 500 client heavy AI usage",
+  },
+  {
+    date: "2026-03-20",
+    category: "Revenue",
+    subcategory: "Marketplace Sales",
+    amount: "15800",
+    type: "income",
+    notes: "3 new templates in top 10",
+  },
+  {
+    date: "2026-03-22",
+    category: "Expenses",
+    subcategory: "Sales & BD",
+    amount: "12000",
+    type: "expense",
+    notes: "Hired first sales rep for enterprise",
+  },
+  {
+    date: "2026-03-24",
+    category: "Revenue",
+    subcategory: "Partnership Revenue",
+    amount: "14200",
+    type: "income",
+    notes: "New integration partnerships launched",
+  },
+  {
+    date: "2026-03-26",
+    category: "Expenses",
+    subcategory: "Security & Compliance",
+    amount: "6500",
+    type: "expense",
+    notes: "SOC 2 audit and security tools",
+  },
+  {
+    date: "2026-03-28",
+    category: "Revenue",
+    subcategory: "Training & Workshops",
+    amount: "10200",
+    type: "income",
+    notes: "Conducted 2 customer training sessions",
+  },
+];
+
+// ─── Todo state ─────────────────────────────────────────────────────
+
+// Mirrors LGP's `Todo` TypedDict. The frontend (todo-list.tsx) reads exactly
+// these fields off `agent.state.todos`.
+interface Todo {
+  id: string;
+  title: string;
+  description: string;
+  emoji: string;
+  status: "pending" | "completed";
+}
+
+const todoSchema = z.object({
+  id: z.string().optional(),
+  title: z.string(),
+  description: z.string(),
+  emoji: z.string(),
+  status: z.enum(["pending", "completed"]),
+});
+
+// ─── A2UI operation helpers (mirror a2ui.render / create_surface /
+//     update_components from the Python SDK) ─────────────────────────
+
+function createSurfaceOp(surfaceId: string, catalogId: string) {
+  return { version: "v0.9", createSurface: { surfaceId, catalogId } };
+}
+
+function updateComponentsOp(surfaceId: string, components: unknown[]) {
+  return { version: "v0.9", updateComponents: { surfaceId, components } };
+}
+
+function renderA2uiOperations(operations: unknown[]) {
+  return { [A2UI_OPERATIONS_KEY]: operations };
+}
+
+// Flight card props — all optional so the model can omit auxiliary fields
+// (e.g. statusColor) without tripping tool-arg validation. Mirrors LGP's
+// `Flight` TypedDict (total=False).
+const flightSchema = z.object({
+  airline: z.string().optional(),
+  airlineLogo: z.string().optional(),
+  flightNumber: z.string().optional(),
+  origin: z.string().optional(),
+  destination: z.string().optional(),
+  date: z.string().optional(),
+  departureTime: z.string().optional(),
+  arrivalTime: z.string().optional(),
+  duration: z.string().optional(),
+  status: z.string().optional(),
+  price: z.string().optional(),
+});
+type Flight = z.infer<typeof flightSchema>;
+
+/**
+ * Build a flat A2UI component tree with one literal FlightCard per flight.
+ *
+ * Mirrors LGP's `_build_flight_components`: inline the values per-flight so we
+ * avoid the structural-children template form (Row.children = { componentId,
+ * path }), which only expands for STRUCTURAL-children schemas. The frontend
+ * FlightCard renderer resolves these literal props directly.
+ */
+function buildFlightComponents(flights: Flight[]): unknown[] {
+  const cardIds: string[] = [];
+  const components: unknown[] = [];
+  flights.forEach((flight, index) => {
+    const id = `flight-card-${index}`;
+    cardIds.push(id);
+    components.push({
+      id,
+      component: "FlightCard",
+      airline: flight.airline ?? "",
+      airlineLogo: flight.airlineLogo ?? "",
+      flightNumber: flight.flightNumber ?? "",
+      origin: flight.origin ?? "",
+      destination: flight.destination ?? "",
+      date: flight.date ?? "",
+      departureTime: flight.departureTime ?? "",
+      arrivalTime: flight.arrivalTime ?? "",
+      duration: flight.duration ?? "",
+      status: flight.status ?? "",
+      price: flight.price ?? "",
+    });
+  });
+  const root = { id: "root", component: "Row", children: cardIds, gap: 16 };
+  return [root, ...components];
+}
+
+// ─── System prompt (ported from beautiful_chat.py) ──────────────────
+
+const SYSTEM_PROMPT = `\
+You are a polished, professional demo assistant. Keep responses to 1-2 sentences.
+
+Tool guidance:
+- Charts: call \`query_data\` FIRST to fetch the data, then render it with the
+  \`pieChart\` or \`barChart\` component (part-of-whole → pieChart; comparison
+  across categories → barChart).
+- Dashboards & rich UI: call \`render_a2ui\` to create dashboard UIs with
+  metrics, charts, tables, and cards. It handles rendering automatically. Call
+  \`query_data\` first when the dashboard should reflect real data.
+- Flights: call \`search_flights\` to show flight cards with a pre-built schema.
+  Return exactly 2 flights.
+- Sandboxed apps (calculators, mini-tools): call \`generateSandboxedUi\`.
+- Diagrams: use the Excalidraw MCP tool (\`create_view\`) to draw diagrams.
+- Scheduling: call \`scheduleTime\` (human-in-the-loop) so the user can pick a time.
+- Theme: call \`toggleTheme\` to switch light/dark.
+- Todos: call \`enableAppMode\` first, then \`manage_todos\` to create/update the
+  task board; use \`get_todos\` to read the current list.
+- A2UI actions: when you see a log_a2ui_event result (e.g. "view_details"),
+  respond with a brief confirmation. The UI already updated on the frontend.`;
+
+// Server-tool names owned by this agent — used to filter them out of the
+// frontend/injected tool declarations below so they are not double-declared.
+const SERVER_TOOL_NAMES = new Set([
+  "query_data",
+  "manage_todos",
+  "get_todos",
+  "search_flights",
+]);
+
+// ─── Server tools ───────────────────────────────────────────────────
+
+/**
+ * Build the beautiful-chat server tools per-request so `get_todos` can close
+ * over the inbound frontend state (`input.state.todos`) — the built-in agent
+ * has no persistent per-agent state schema, so the current todo list arrives
+ * on each run via AG-UI state (the frontend calls `agent.setState`).
+ */
+function buildServerTools(input: RunAgentInput) {
+  const queryData = toolDefinition({
+    name: "query_data",
+    description:
+      "Query the database, takes natural language. Always call before " +
+      "showing a chart or graph.",
+    inputSchema: z.object({
+      query: z
+        .string()
+        .describe("Natural-language description of the data to fetch"),
+    }),
+  }).server(async () => SALES_DATA);
+
+  const manageTodos = toolDefinition({
+    name: "manage_todos",
+    description: "Manage the current todos. Pass the FULL updated list.",
+    inputSchema: z.object({
+      todos: z.array(todoSchema),
+    }),
+  }).server(async ({ todos }) => {
+    // Ensure every todo has a stable unique id (mirrors LGP).
+    const withIds: Todo[] = todos.map((t) => ({
+      ...t,
+      id: t.id && t.id.length > 0 ? t.id : crypto.randomUUID(),
+    }));
+    // Return `{ todos }` — the converter detects `manage_todos` results and
+    // emits a STATE_DELTA that populates `/todos` on the agent state, which
+    // the frontend `useAgent` subscriber renders in the todo board.
+    return { todos: withIds };
+  });
+
+  const getTodos = toolDefinition({
+    name: "get_todos",
+    description: "Get the current todos.",
+    inputSchema: z.object({}),
+  }).server(async () => {
+    const state = input.state as { todos?: Todo[] } | undefined;
+    return state?.todos ?? [];
+  });
+
+  const searchFlights = toolDefinition({
+    name: "search_flights",
+    description:
+      "Search for flights and display the results as rich cards. Return " +
+      'exactly 2 flights. Each flight must have: airline (e.g. "United ' +
+      'Airlines"), airlineLogo (use the Google favicon API: ' +
+      "https://www.google.com/s2/favicons?domain={airline_domain}&sz=128 — " +
+      'e.g. "https://www.google.com/s2/favicons?domain=united.com&sz=128"), ' +
+      "flightNumber, origin, destination, date (short readable format like " +
+      '"Tue, Mar 18"), departureTime, arrivalTime, duration (e.g. "4h 25m"), ' +
+      'status (e.g. "On Time" or "Delayed"), and price (e.g. "$289").',
+    inputSchema: z.object({
+      flights: z.array(flightSchema),
+    }),
+  }).server(async ({ flights }) =>
+    // Returns an `a2ui_operations` container directly. The runtime's A2UI
+    // middleware detects this shape in the tool result and forwards the
+    // operations to the frontend renderer (parity with LGP's
+    // `a2ui.render(...)`). `injectA2UITool: true` on the route does NOT affect
+    // this — it only controls whether the middleware also injects its own
+    // dynamic `generate_a2ui` tool.
+    renderA2uiOperations([
+      createSurfaceOp(FLIGHT_SURFACE_ID, CATALOG_ID),
+      updateComponentsOp(FLIGHT_SURFACE_ID, buildFlightComponents(flights)),
+    ]),
+  );
+
+  return [queryData, manageTodos, getTodos, searchFlights];
+}
+
+// ─── TanStack → AG-UI stream converter ──────────────────────────────
+
+function randomUUID(): string {
+  return crypto.randomUUID();
+}
+
+/**
+ * Convert a TanStack AI stream to AG-UI events for the beautiful-chat agent.
+ *
+ * Same shape as the base built-in agent's converter (multi-turn safe: does NOT
+ * stop after the first RUN_FINISHED, dedupes re-emitted tool-call chunks) plus
+ * one beautiful-chat-specific behaviour: a `manage_todos` tool result is
+ * translated into a STATE_DELTA on `/todos` so the frontend todo board updates
+ * (mirrors LGP's StateStreamingMiddleware for the `todos` state key).
+ */
+async function* convertStream(
+  stream: AsyncIterable<unknown>,
+  abortSignal: AbortSignal,
+): AsyncGenerator<BaseEvent> {
+  const messageId = randomUUID();
+  const completedToolCalls = new Set<string>();
+  const toolNamesById = new Map<string, string>();
+
+  for await (const chunk of stream) {
+    if (abortSignal.aborted) break;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const raw = chunk as any;
+    const type = raw.type as string;
+
+    if (type === "RUN_FINISHED") continue;
+
+    if (type === "TEXT_MESSAGE_CONTENT" && raw.delta != null) {
+      yield {
+        type: EventType.TEXT_MESSAGE_CHUNK,
+        role: "assistant",
+        messageId,
+        delta: raw.delta as string,
+      };
+    } else if (type === "TOOL_CALL_START") {
+      const toolCallId = raw.toolCallId as string;
+      if (completedToolCalls.has(toolCallId)) continue;
+      toolNamesById.set(toolCallId, raw.toolCallName as string);
+      yield {
+        type: EventType.TOOL_CALL_START,
+        parentMessageId: messageId,
+        toolCallId,
+        toolCallName: raw.toolCallName as string,
+      };
+    } else if (type === "TOOL_CALL_ARGS") {
+      const toolCallId = raw.toolCallId as string;
+      if (completedToolCalls.has(toolCallId)) continue;
+      yield {
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId,
+        delta: raw.delta as string,
+      };
+    } else if (type === "TOOL_CALL_END") {
+      const toolCallId = raw.toolCallId as string;
+      if (completedToolCalls.has(toolCallId)) continue;
+      completedToolCalls.add(toolCallId);
+      yield { type: EventType.TOOL_CALL_END, toolCallId };
+    } else if (type === "TOOL_CALL_RESULT") {
+      const toolCallId = raw.toolCallId as string;
+      const toolName = toolNamesById.get(toolCallId);
+      const rawPayload = raw.content ?? raw.result;
+      const parsedContent =
+        typeof rawPayload === "string" ? safeParseJSON(rawPayload) : rawPayload;
+
+      // `manage_todos` → STATE_DELTA on `/todos`. Use RFC-6902 `add` (not
+      // `replace`): the agent's initial state may be `{}` with no preceding
+      // STATE_SNAPSHOT, and `fast-json-patch` strict mode rejects `replace` on
+      // an unresolvable path. `add` creates `/todos` on first emission and
+      // overwrites idempotently afterwards.
+      if (
+        toolName === "manage_todos" &&
+        parsedContent &&
+        typeof parsedContent === "object" &&
+        "todos" in parsedContent
+      ) {
+        yield {
+          type: EventType.STATE_DELTA,
+          delta: [
+            {
+              op: "add",
+              path: "/todos",
+              value: (parsedContent as { todos: unknown }).todos,
+            },
+          ],
+        };
+      }
+
+      let serializedContent: string;
+      if (typeof rawPayload === "string") {
+        serializedContent = rawPayload;
+      } else {
+        try {
+          serializedContent = JSON.stringify(rawPayload ?? null);
+        } catch {
+          serializedContent = "[Unserializable tool result]";
+        }
+      }
+
+      yield {
+        type: EventType.TOOL_CALL_RESULT,
+        role: "tool",
+        messageId: randomUUID(),
+        toolCallId,
+        content: serializedContent,
+      };
+    }
+  }
+}
+
+function safeParseJSON(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+// ─── Agent ──────────────────────────────────────────────────────────
+
+/**
+ * Built-in (TanStack) agent backing the Beautiful Chat flagship showcase cell.
+ *
+ * Faithful port of `beautiful_chat.py`. Owns four server tools (query_data,
+ * manage_todos, get_todos, search_flights) and declares — declaration-only —
+ * every frontend tool AND every runtime-injected tool it receives on
+ * `input.tools`:
+ *   - frontend: pieChart, barChart, scheduleTime, toggleTheme, enableAppMode,
+ *     enableChatMode
+ *   - runtime-injected: render_a2ui (A2UI middleware, injectA2UITool: true —
+ *     the default injected tool name), generateSandboxedUi (Open Generative
+ *     UI), and the Excalidraw MCP tools (MCP Apps middleware)
+ * The respective middleware executes the injected tools; declaring them here
+ * is what lets the model actually CALL them (otherwise it replies with plain
+ * text / raw code blocks and nothing renders).
+ *
+ * Uses `type: "custom"` so the multi-turn agent loop survives (server tool →
+ * result → follow-up model turn); the runtime's built-in tanstack converter
+ * halts after the first RUN_FINISHED and would break query_data→chart chains.
+ */
+export function createBeautifulChatAgent() {
+  return new BuiltInAgent({
+    type: "custom",
+    factory: ({ input, abortController }) => {
+      const { messages, systemPrompts } = convertInputToTanStackAI(input);
+
+      const serverTools = buildServerTools(input);
+
+      // Declare frontend + runtime-injected tools (declaration-only, no
+      // executor) so the model can call them. Skip any that collide with our
+      // server tools.
+      const declaredTools = (input.tools ?? [])
+        .filter((t) => !SERVER_TOOL_NAMES.has(t.name))
+        .map((t) =>
+          toolDefinition({
+            name: t.name,
+            description: t.description ?? "",
+            inputSchema: jsonSchemaToZod(t.parameters),
+          }),
+        );
+
+      const stream = chat({
+        adapter: openaiText("gpt-5.4", { fetch: forwardingFetch }),
+        messages,
+        systemPrompts: [SYSTEM_PROMPT, ...systemPrompts],
+        tools: [...serverTools, ...declaredTools],
+        abortController,
+      });
+
+      return convertStream(stream, abortController.signal);
+    },
+  });
+}

--- a/showcase/integrations/built-in-agent/src/lib/factory/reasoning-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/reasoning-factory.ts
@@ -1,9 +1,8 @@
 import { BuiltInAgent, convertInputToTanStackAI } from "@copilotkit/runtime/v2";
+import { EventType } from "@ag-ui/client";
+import type { BaseEvent } from "@ag-ui/client";
 import { chat } from "@tanstack/ai";
-import {
-  OpenAIChatCompletionsTextAdapter,
-  type OpenAIChatCompletionsProviderOptions,
-} from "@tanstack/ai-openai";
+import { openaiText } from "@tanstack/ai-openai";
 import { baseServerTools } from "./server-tools";
 // Custom fetch that injects ALS-bound inbound x-* headers (e.g.
 // x-aimock-context) onto every outbound OpenAI call. Required so aimock
@@ -14,111 +13,209 @@ import { forwardingFetch } from "../header-forwarding";
 /**
  * Reasoning model used by all three reasoning demos.
  *
- * GPT-5.2 is a reasoning-capable variant; OpenAI's chat completions API
- * accepts the `reasoning_effort` parameter for it. If GPT-5.2 isn't
- * accessible in your environment swap to another reasoning-capable model
- * such as `o3` or `gpt-5-thinking`.
+ * GPT-5.2 is a reasoning-capable model exposed through OpenAI's *Responses*
+ * API, which streams a natural-language reasoning summary when asked with
+ * `reasoning: { effort, summary }`. Swap via the `REASONING_MODEL` env var to
+ * another Responses-API reasoning model (e.g. `o3`, `gpt-5-thinking`) if
+ * GPT-5.2 isn't accessible in your environment.
  */
 const REASONING_MODEL = process.env.REASONING_MODEL ?? "gpt-5.2";
 
 /**
- * Chat-completions adapter that surfaces the model's reasoning trace.
- *
- * Why a custom subclass instead of `openaiText`:
- *   - `openaiText` uses TanStack's OpenAI *Responses*-API adapter. On the
- *     reasoning path it emits the trace as `STEP_STARTED` / `STEP_FINISHED`
- *     (`stepType: "thinking"`) chunks. The `@copilotkit/runtime` tanstack
- *     converter only maps upstream `REASONING_*` chunks to AG-UI
- *     `REASONING_MESSAGE_*` events — it has no `STEP_*` handler — so the
- *     reasoning is silently dropped and the `<ReasoningBlock>` never mounts.
- *   - The base chat-completions adapter DOES emit the proper
- *     `REASONING_START` / `REASONING_MESSAGE_START` (role `"reasoning"`) /
- *     `REASONING_MESSAGE_CONTENT` lifecycle — but only when
- *     `extractReasoning()` returns text, and its default returns `undefined`
- *     because the vanilla OpenAI chat-completions chunk shape has no
- *     reasoning field.
- *
- * OpenAI's chat-completions streaming places reasoning on
- * `choices[0].delta.reasoning_content` (the same field aimock emits for the
- * reasoning fixtures). Overriding `extractReasoning` to read it makes the
- * adapter emit `REASONING_MESSAGE_*`, which the runtime converter forwards
- * to the frontend as AG-UI reasoning events.
+ * Reasoning effort for the summary. Must be `high`: at `low`/`medium`, real
+ * OpenAI (verified) frequently completes the turn WITHOUT emitting any
+ * reasoning summary part for short prompts, so the `<ReasoningBlock>` never
+ * mounts. `high` reliably streams `response.reasoning_summary_text.delta`
+ * events for the demo prompts.
  */
-/**
- * Provider options for the chat-completions reasoning path.
- *
- * TanStack's exported `OpenAIChatCompletionsProviderOptions` only models the
- * *Responses*-API reasoning shape (`reasoning: { effort, summary }`) and has
- * no flat `reasoning_effort` field. But `mapOptionsToRequest` spreads
- * `modelOptions` verbatim into the `/v1/chat/completions` body, where OpenAI
- * expects the flat scalar `reasoning_effort` — the nested `reasoning` object
- * is a Responses-API construct that chat-completions rejects/ignores. We
- * widen the provider-options type with the correct chat-completions field so
- * the body carries `reasoning_effort` and the literal type-checks.
- */
-type ReasoningProviderOptions = OpenAIChatCompletionsProviderOptions & {
-  reasoning_effort?: "minimal" | "low" | "medium" | "high";
-};
+const REASONING_EFFORT: "low" | "medium" | "high" =
+  (process.env.REASONING_EFFORT as "low" | "medium" | "high") ?? "high";
 
-class ReasoningChatCompletionsAdapter extends OpenAIChatCompletionsTextAdapter<
-  "gpt-5.2",
-  ReasoningProviderOptions
-> {
-  protected override extractReasoning(
-    chunk: unknown,
-  ): { text: string } | undefined {
-    const delta = (
-      chunk as {
-        choices?: Array<{
-          delta?: { reasoning_content?: string; reasoning?: string };
-        }>;
-      }
-    )?.choices?.[0]?.delta;
-    const text = delta?.reasoning_content ?? delta?.reasoning;
-    return text ? { text } : undefined;
+function randomUUID(): string {
+  return crypto.randomUUID();
+}
+
+/**
+ * Convert a TanStack AI (Responses-API) stream to AG-UI events, mapping the
+ * model's reasoning summary into AG-UI `REASONING_MESSAGE_*` events.
+ *
+ * Why this custom converter instead of `type: "tanstack"`:
+ *   - `openaiText` (TanStack's OpenAI *Responses*-API adapter) surfaces the
+ *     reasoning summary as `STEP_STARTED` (`stepType: "thinking"`) followed by
+ *     a run of `STEP_FINISHED` chunks that each carry a `delta` of summary
+ *     text — NOT as upstream `REASONING_*` chunks.
+ *   - The runtime's built-in `convertTanStackStream` only maps `REASONING_*`
+ *     chunks to AG-UI reasoning events; it has no `STEP_*` handler, so the
+ *     whole trace is silently dropped and `<ReasoningBlock>` never mounts.
+ *   - Chat-completions streaming (the previous approach) places reasoning on
+ *     `choices[0].delta.reasoning_content`, which real OpenAI does NOT emit
+ *     (only aimock did) — so that path produced no trace against a real key.
+ *
+ * This converter translates the thinking STEP chunks into a
+ * REASONING_START → REASONING_MESSAGE_START → REASONING_MESSAGE_CONTENT* →
+ * REASONING_MESSAGE_END → REASONING_END lifecycle, closes the reasoning block
+ * as soon as text or a tool call begins, and forwards text + tool-call events
+ * (de-duplicated across TanStack's multi-turn re-announcements, like
+ * tanstack-factory's converter).
+ */
+async function* convertReasoningStream(
+  stream: AsyncIterable<unknown>,
+  abortSignal: AbortSignal,
+): AsyncGenerator<BaseEvent> {
+  const messageId = randomUUID();
+  let reasoningMessageId = randomUUID();
+  let reasoningOpen = false;
+  const completedToolCalls = new Set<string>();
+
+  function* openReasoningIfNeeded(): Generator<BaseEvent> {
+    if (reasoningOpen) return;
+    reasoningOpen = true;
+    reasoningMessageId = randomUUID();
+    yield { type: EventType.REASONING_START, messageId: reasoningMessageId };
+    yield {
+      type: EventType.REASONING_MESSAGE_START,
+      messageId: reasoningMessageId,
+      role: "reasoning",
+    };
   }
-}
 
-function createReasoningAdapter() {
-  const apiKey = process.env.OPENAI_API_KEY ?? "";
-  // REASONING_MODEL is read from env (string); the adapter's generic is
-  // pinned to a concrete reasoning-capable chat model for typing.
-  return new ReasoningChatCompletionsAdapter(
-    { apiKey, fetch: forwardingFetch },
-    REASONING_MODEL as "gpt-5.2",
-  );
+  function* closeReasoningIfOpen(): Generator<BaseEvent> {
+    if (!reasoningOpen) return;
+    reasoningOpen = false;
+    yield {
+      type: EventType.REASONING_MESSAGE_END,
+      messageId: reasoningMessageId,
+    };
+    yield { type: EventType.REASONING_END, messageId: reasoningMessageId };
+  }
+
+  for await (const chunk of stream) {
+    if (abortSignal.aborted) break;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const raw = chunk as any;
+    const type = raw.type as string;
+
+    if (type === "RUN_STARTED" || type === "RUN_FINISHED") continue;
+
+    if (type === "RUN_ERROR") {
+      throw new Error(
+        typeof raw.message === "string" ? raw.message : "TanStack AI run error",
+      );
+    }
+
+    // Reasoning summary: STEP_STARTED(stepType:"thinking") begins the trace;
+    // subsequent STEP_STARTED/STEP_FINISHED chunks carry summary text on
+    // `delta`. Only treat STEPs as reasoning while a thinking step is active.
+    if (type === "STEP_STARTED" || type === "STEP_FINISHED") {
+      const isThinking = raw.stepType === "thinking" || reasoningOpen;
+      if (isThinking) {
+        yield* openReasoningIfNeeded();
+        const delta = raw.delta;
+        if (typeof delta === "string" && delta.length > 0) {
+          yield {
+            type: EventType.REASONING_MESSAGE_CONTENT,
+            messageId: reasoningMessageId,
+            delta,
+          };
+        }
+      }
+      continue;
+    }
+
+    if (type === "TEXT_MESSAGE_CONTENT" && raw.delta != null) {
+      yield* closeReasoningIfOpen();
+      if ((raw.delta as string).length === 0) continue;
+      yield {
+        type: EventType.TEXT_MESSAGE_CHUNK,
+        role: "assistant",
+        messageId,
+        delta: raw.delta as string,
+      };
+    } else if (type === "TOOL_CALL_START") {
+      const toolCallId = raw.toolCallId as string;
+      if (completedToolCalls.has(toolCallId)) continue;
+      yield* closeReasoningIfOpen();
+      yield {
+        type: EventType.TOOL_CALL_START,
+        parentMessageId: messageId,
+        toolCallId,
+        toolCallName: raw.toolCallName as string,
+      };
+    } else if (type === "TOOL_CALL_ARGS") {
+      const toolCallId = raw.toolCallId as string;
+      if (completedToolCalls.has(toolCallId)) continue;
+      yield {
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId,
+        delta: raw.delta as string,
+      };
+    } else if (type === "TOOL_CALL_END") {
+      const toolCallId = raw.toolCallId as string;
+      if (completedToolCalls.has(toolCallId)) continue;
+      completedToolCalls.add(toolCallId);
+      yield { type: EventType.TOOL_CALL_END, toolCallId };
+    } else if (type === "TOOL_CALL_RESULT") {
+      const toolCallId = raw.toolCallId as string;
+      const rawPayload = raw.content ?? raw.result;
+      let serializedContent: string;
+      if (typeof rawPayload === "string") {
+        serializedContent = rawPayload;
+      } else {
+        try {
+          serializedContent = JSON.stringify(rawPayload ?? null);
+        } catch {
+          serializedContent = "[Unserializable tool result]";
+        }
+      }
+      yield {
+        type: EventType.TOOL_CALL_RESULT,
+        role: "tool",
+        messageId: randomUUID(),
+        toolCallId,
+        content: serializedContent,
+      };
+    }
+  }
+
+  yield* closeReasoningIfOpen();
 }
 
 /**
- * Built-in agent for `reasoning-custom` — visible thinking chain
- * during normal conversation. Uses the shared server tools so the model
- * can interleave tool calls with reasoning naturally.
+ * Built-in agent for `reasoning-custom` — visible thinking chain during
+ * normal conversation. Uses the shared server tools so the model can
+ * interleave tool calls with reasoning naturally.
  */
 export function createAgenticChatReasoningAgent() {
   return new BuiltInAgent({
-    type: "tanstack",
+    // `custom` (not `tanstack`) so our converter can map the Responses-API
+    // thinking STEPs to REASONING_MESSAGE_* — the built-in tanstack converter
+    // drops STEP_* chunks.
+    type: "custom",
     factory: ({ input, abortController }) => {
       const { messages, systemPrompts } = convertInputToTanStackAI(input);
-      return chat({
-        adapter: createReasoningAdapter(),
+      const stream = chat({
+        adapter: openaiText(REASONING_MODEL as "gpt-5.2", {
+          fetch: forwardingFetch,
+        }),
         messages,
         systemPrompts,
         tools: [...baseServerTools],
         modelOptions: {
-          reasoning_effort: "low",
+          reasoning: { effort: REASONING_EFFORT, summary: "auto" },
         },
         abortController,
       });
+      return convertReasoningStream(stream, abortController.signal);
     },
   });
 }
 
 /**
- * Built-in agent for `reasoning-default` — same backend behaviour
- * as `reasoning-custom`; the demo's value is that the frontend
- * passes NO custom `reasoningMessage` slot, so CopilotKit's built-in
- * `CopilotChatReasoningMessage` renders the chain. Kept as its own
- * factory for clarity even though the body is identical today.
+ * Built-in agent for `reasoning-default` — same backend behaviour as
+ * `reasoning-custom`; the demo's value is that the frontend passes NO custom
+ * `reasoningMessage` slot, so CopilotKit's built-in
+ * `CopilotChatReasoningMessage` renders the chain.
  */
 export function createReasoningDefaultRenderAgent() {
   return createAgenticChatReasoningAgent();

--- a/showcase/integrations/built-in-agent/src/lib/factory/tanstack-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/tanstack-factory.ts
@@ -201,6 +201,36 @@ async function* convertStream(
           ],
         };
       }
+      // `set_notes` is the shared-state-read-write demo's agent-authored
+      // notes tool (see server-tools.ts). Its server handler returns
+      // `{ notes }`; translate that into a STATE_DELTA that adds `/notes`
+      // on the agent state, so the frontend `useAgent` subscriber sees the
+      // update and the notes card (`notes-list` / `note-item`) populates.
+      //
+      // Same RFC-6902 `add`-not-`replace` rationale as `set_steps` above:
+      // the agent's initial state carries no `/notes` snapshot before the
+      // first delta, and `fast-json-patch` strict mode rejects `replace` on
+      // an unresolvable path (OPERATION_PATH_UNRESOLVABLE), which
+      // `@ag-ui/client` swallows with a console.warn and never applies —
+      // leaving the panel in its placeholder. `add` creates `/notes` on the
+      // first emission and idempotently overwrites on subsequent calls.
+      if (
+        toolName === "set_notes" &&
+        parsedContent &&
+        typeof parsedContent === "object" &&
+        "notes" in parsedContent
+      ) {
+        yield {
+          type: EventType.STATE_DELTA,
+          delta: [
+            {
+              op: "add",
+              path: "/notes",
+              value: (parsedContent as { notes: unknown }).notes,
+            },
+          ],
+        };
+      }
 
       let serializedContent: string;
       if (typeof rawPayload === "string") {


### PR DESCRIPTION
## Why
Follow-up to #6106 / #6149. Prod testing (real LLM) revealed the flagship **beautiful-chat** cell was a **stub**: it was wired to the generic all-tools agent on a bare route, so the model reported `query_data` / Excalidraw / gen-UI tools "not available." It only passed local aimock D6 because fixtures scripted the tool calls — **aimock can't validate real-LLM tool availability**, which is why this slipped through.

## Fix
Port the real beautiful-chat backend, mirroring `langgraph-python/src/agents/beautiful_chat.py`:
- **New `createBeautifulChatAgent()`** — server tools `query_data` (sales data), `manage_todos`, `get_todos`, `search_flights` (A2UI fixed-schema flight cards); declares the runtime-injected tools (`render_a2ui`, `generateSandboxedUi`, Excalidraw MCP) so the model can actually call them; `manage_todos` → `STATE_DELTA /todos` for the app-mode board. Model `gpt-5.4`.
- **Route** configures the combined runtime like LGP: `openGenerativeUI: true`, `a2ui.injectA2UITool: true` (catalog `copilotkit://app-dashboard-catalog`), `mcpApps` (Excalidraw).
- Shared factory defaults unchanged (new opt-in factory).

## Verified against a REAL OpenAI LLM (not aimock)
Drove a headless browser against the demo pointed at real OpenAI — all 6 flows fire the tool + render the component:
| Flow | Result |
|---|---|
| Pie chart (`query_data`→`pieChart`) | ✅ real data |
| Bar chart (`query_data`→`barChart`) | ✅ real data |
| Calculator (`generateSandboxedUi`) | ✅ sandboxed iframe |
| Flights (`search_flights` A2UI) | ✅ 2 FlightCards |
| Excalidraw (`create_view` MCP) | ✅ MCP iframe |
| Todos (`enableAppMode`→`manage_todos`→`get_todos`) | ✅ board populated |

Zero "not available" apologies.

## Follow-up (tracked, not in this PR yet)
Auditing the other generic-agent-backed demos against a real LLM for the same class of under-wiring; fixes will be added here or in a follow-up.