### PR TITLE
fix(react-core,vue,angular): stable chat row keys prevent HITL remount flash

### DIFF
--- a/packages/angular/src/lib/components/chat/__tests__/row-render-keys.spec.ts
+++ b/packages/angular/src/lib/components/chat/__tests__/row-render-keys.spec.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+import type { Message, ToolCall } from "@ag-ui/core";
+import {
+  createRowKeyStore,
+  pruneRowKeyStore,
+  resolveRowRenderKeys,
+} from "../row-render-keys";
+
+function toolCall(id: string, name = "approve"): ToolCall {
+  return { id, type: "function", function: { name, arguments: "{}" } };
+}
+
+function assistant(id: string, toolCalls?: ToolCall[]): Message {
+  return { id, role: "assistant", content: "…", toolCalls } as Message;
+}
+
+function user(id: string): Message {
+  return { id, role: "user", content: "hi" } as Message;
+}
+
+describe("resolveRowRenderKeys", () => {
+  it("tracks by message.id when there are no tool calls, leaving the store empty", () => {
+    const store = createRowKeyStore();
+
+    const keys = resolveRowRenderKeys(store, [user("u1"), assistant("a1")]);
+
+    expect(keys).toEqual(["u1", "a1"]);
+    // Unaffected conversations carry no state and behave exactly like plain id
+    // tracking.
+    expect(store.overrides.size).toBe(0);
+  });
+
+  it("holds the key steady when a tool call appears on an already-streaming message", () => {
+    // TOOL_CALL_START mutates the SAME message that TEXT_MESSAGE_START created.
+    // Deriving the key from the tool call would change it here and recreate the
+    // row.
+    const store = createRowKeyStore();
+
+    const streaming = resolveRowRenderKeys(store, [assistant("lc_run--1")]);
+    const withTool = resolveRowRenderKeys(store, [
+      assistant("lc_run--1", [toolCall("call_A")]),
+    ]);
+
+    expect(streaming).toEqual(["lc_run--1"]);
+    expect(withTool).toEqual(["lc_run--1"]);
+  });
+
+  it("holds the key steady when the snapshot re-keys the message id", () => {
+    const store = createRowKeyStore();
+
+    resolveRowRenderKeys(store, [assistant("lc_run--1", [toolCall("call_A")])]);
+    const afterRekey = resolveRowRenderKeys(store, [
+      assistant("resp_1", [toolCall("call_A")]),
+    ]);
+
+    expect(afterRekey).toEqual(["lc_run--1"]);
+  });
+
+  it("holds the key steady across the full streaming sequence", () => {
+    const store = createRowKeyStore();
+
+    const k1 = resolveRowRenderKeys(store, [assistant("lc_run--1")])[0];
+    const k2 = resolveRowRenderKeys(store, [
+      assistant("lc_run--1", [toolCall("call_A")]),
+    ])[0];
+    const k3 = resolveRowRenderKeys(store, [
+      assistant("resp_1", [toolCall("call_A")]),
+    ])[0];
+
+    expect(new Set([k1, k2, k3]).size).toBe(1);
+  });
+
+  it("resolves through a surviving anchor when tool calls are reordered", () => {
+    const store = createRowKeyStore();
+
+    resolveRowRenderKeys(store, [
+      assistant("lc_run--1", [toolCall("call_A"), toolCall("call_B")]),
+    ]);
+    const afterRekey = resolveRowRenderKeys(store, [
+      assistant("resp_1", [toolCall("call_B"), toolCall("call_A")]),
+    ]);
+
+    expect(afterRekey).toEqual(["lc_run--1"]);
+  });
+
+  it("keeps a later tool call from stealing an established key", () => {
+    const store = createRowKeyStore();
+
+    resolveRowRenderKeys(store, [assistant("lc_run--1", [toolCall("call_A")])]);
+    const keys = resolveRowRenderKeys(store, [
+      assistant("lc_run--1", [toolCall("call_A"), toolCall("call_B")]),
+    ]);
+
+    expect(keys).toEqual(["lc_run--1"]);
+    expect(store.overrides.get("tc:call_B")).toBe("lc_run--1");
+  });
+
+  it("falls back to message.id when two messages share a tool-call id", () => {
+    const store = createRowKeyStore();
+
+    const keys = resolveRowRenderKeys(store, [
+      assistant("a-1", [toolCall("call_X")]),
+      assistant("a-2", [toolCall("call_X")]),
+    ]);
+
+    expect(keys).toEqual(["a-1", "a-2"]);
+  });
+
+  it("keeps a shared-anchor fallback stable across renders", () => {
+    const store = createRowKeyStore();
+    const messages = [
+      assistant("a-1", [toolCall("call_X")]),
+      assistant("a-2", [toolCall("call_X")]),
+    ];
+
+    const first = resolveRowRenderKeys(store, messages);
+    const second = resolveRowRenderKeys(store, messages);
+
+    expect(second).toEqual(first);
+  });
+
+  it("keeps keys unique when the list contains duplicate message ids", () => {
+    // This component does not deduplicate, so duplicate ids reach the template.
+    // Angular reports duplicated track values as an error, so uniqueness has to
+    // be structural.
+    const store = createRowKeyStore();
+
+    const keys = resolveRowRenderKeys(store, [
+      assistant("dup"),
+      assistant("dup"),
+      assistant("dup"),
+    ]);
+
+    expect(new Set(keys).size).toBe(3);
+    expect(keys[0]).toBe("dup");
+  });
+
+  it("disambiguates when an override vends a key equal to a later message's id", () => {
+    const store = createRowKeyStore();
+    resolveRowRenderKeys(store, [assistant("ghost", [toolCall("call_X")])]);
+
+    const keys = resolveRowRenderKeys(store, [
+      assistant("live", [toolCall("call_X")]),
+      assistant("ghost"),
+    ]);
+
+    expect(keys[0]).toBe("ghost");
+    expect(keys[1]).not.toBe("ghost");
+    expect(new Set(keys).size).toBe(2);
+  });
+
+  it("is idempotent, so a re-evaluated computed yields the same keys", () => {
+    const store = createRowKeyStore();
+    const messages = [
+      assistant("a-1", [toolCall("call_A")]),
+      assistant("a-2", [toolCall("call_B")]),
+      user("u-1"),
+    ];
+
+    const first = resolveRowRenderKeys(store, messages);
+    const snapshot = new Map(store.overrides);
+    const second = resolveRowRenderKeys(store, messages);
+
+    expect(second).toEqual(first);
+    expect([...store.overrides.entries()]).toEqual([...snapshot.entries()]);
+  });
+
+  it("preserves the previous index fallback for a message with no id", () => {
+    const store = createRowKeyStore();
+    const idless = { role: "assistant", content: "x" } as unknown as Message;
+
+    const keys = resolveRowRenderKeys(store, [assistant("a-1"), idless]);
+
+    expect(keys).toEqual(["a-1", "index-1"]);
+  });
+
+  it("tolerates a sparse list without throwing", () => {
+    const store = createRowKeyStore();
+
+    const keys = resolveRowRenderKeys(store, [undefined, assistant("a-1")]);
+
+    expect(keys[0]).toBe("index-0");
+    expect(keys[1]).toBe("a-1");
+  });
+
+  it("does not register anchors for non-assistant roles", () => {
+    const store = createRowKeyStore();
+    const toolMessage = {
+      id: "t-1",
+      role: "tool",
+      content: "ok",
+      toolCallId: "call_A",
+    } as unknown as Message;
+
+    resolveRowRenderKeys(store, [toolMessage]);
+
+    expect(store.overrides.size).toBe(0);
+  });
+
+  it("ignores an empty toolCalls array", () => {
+    const store = createRowKeyStore();
+
+    const keys = resolveRowRenderKeys(store, [assistant("a-1", [])]);
+
+    expect(keys).toEqual(["a-1"]);
+    expect(store.overrides.size).toBe(0);
+  });
+
+  it("still re-keys a text-only message (documented limitation)", () => {
+    // No anchor exists for a text-only message, so nothing can correlate it
+    // across a rename. Recorded so a future change that fixes it is deliberate.
+    const store = createRowKeyStore();
+
+    const before = resolveRowRenderKeys(store, [assistant("lc_run--1")]);
+    const after = resolveRowRenderKeys(store, [assistant("resp_1")]);
+
+    expect(before).toEqual(["lc_run--1"]);
+    expect(after).toEqual(["resp_1"]);
+  });
+});
+
+describe("pruneRowKeyStore", () => {
+  it("drops anchors whose messages are gone and keeps live ones", () => {
+    const store = createRowKeyStore();
+    resolveRowRenderKeys(store, [
+      assistant("a-1", [toolCall("call_A")]),
+      assistant("a-2", [toolCall("call_B")]),
+    ]);
+    expect(store.overrides.size).toBe(2);
+
+    pruneRowKeyStore(store, [assistant("a-2", [toolCall("call_B")])]);
+
+    expect([...store.overrides.keys()]).toEqual(["tc:call_B"]);
+  });
+
+  it("bounds the store to the visible list rather than the conversation", () => {
+    const store = createRowKeyStore();
+    for (let i = 0; i < 50; i++) {
+      const live = [assistant(`a-${i}`, [toolCall(`call_${i}`)])];
+      resolveRowRenderKeys(store, live);
+      pruneRowKeyStore(store, live);
+    }
+
+    expect(store.overrides.size).toBe(1);
+  });
+
+  it("preserves the key of a row that survives a prune", () => {
+    const store = createRowKeyStore();
+    const live = [assistant("lc_run--1", [toolCall("call_A")])];
+    resolveRowRenderKeys(store, live);
+    pruneRowKeyStore(store, live);
+
+    const afterRekey = resolveRowRenderKeys(store, [
+      assistant("resp_1", [toolCall("call_A")]),
+    ]);
+
+    expect(afterRekey).toEqual(["lc_run--1"]);
+  });
+});

--- a/packages/angular/src/lib/components/chat/copilot-chat-message-view.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat-message-view.ts
@@ -7,6 +7,7 @@ import {
   Type,
   ChangeDetectionStrategy,
   ViewEncapsulation,
+  afterRenderEffect,
   computed,
   inject,
 } from "@angular/core";
@@ -20,6 +21,11 @@ import { CopilotChatReasoningMessage } from "./copilot-chat-reasoning-message";
 import { cn } from "../../utils";
 import { CopilotKit } from "../../copilotkit";
 import type { RenderActivityMessageConfig } from "../../activity-renderer";
+import {
+  createRowKeyStore,
+  pruneRowKeyStore,
+  resolveRowRenderKeys,
+} from "./row-render-keys";
 
 /**
  * CopilotChatMessageView component - Angular port of the React component.
@@ -51,7 +57,7 @@ import type { RenderActivityMessageConfig } from "../../activity-renderer";
       <!-- Default layout - exact React DOM structure: div with "flex flex-col" classes -->
       <div [class]="computedClass()">
         <!-- Message iteration - simplified without tool calls -->
-        @for (message of messagesValue(); track trackByMessageId($index, message)) {
+        @for (message of messagesValue(); track rowRenderKey($index, message)) {
           @if (message && message.role === "assistant") {
             <!-- Assistant message with slot support -->
             @if (assistantMessageComponent() || assistantMessageTemplate()) {
@@ -199,6 +205,21 @@ export class CopilotChatMessageView {
 
   // Derived values from inputs
   protected messagesValue = computed(() => this.messages());
+
+  /**
+   * Override table backing `rowRenderKey`. Per component instance, so its
+   * lifetime matches the rendered list.
+   */
+  private readonly rowKeyStore = createRowKeyStore();
+  protected rowRenderKeys = computed(() =>
+    resolveRowRenderKeys(this.rowKeyStore, this.messagesValue()),
+  );
+
+  // Prune after render, never inside the computed: dropping an anchor the
+  // rendered rows still need would re-mint their keys and recreate them.
+  private readonly rowKeyStorePrune = afterRenderEffect(() => {
+    pruneRowKeyStore(this.rowKeyStore, this.messagesValue());
+  });
   protected showCursorValue = computed(
     () => this.showCursor() && this.lastMessage()?.role !== "reasoning",
   );
@@ -279,9 +300,13 @@ export class CopilotChatMessageView {
     return message as ReasoningMessage;
   }
 
-  // TrackBy function for performance optimization
-  trackByMessageId(index: number, message: Message): string {
-    return message?.id || `index-${index}`;
+  /**
+   * Stable `@for` track key. A message's canonical id can change mid-stream, and
+   * tracking by it destroys and recreates the row on that swap (the HITL chat
+   * flash). See ./row-render-keys for the mechanism and its limits.
+   */
+  rowRenderKey(index: number, message: Message): string {
+    return this.rowRenderKeys()[index] ?? message?.id ?? `index-${index}`;
   }
 
   private pickActivityRenderer(

--- a/packages/angular/src/lib/components/chat/row-render-keys.ts
+++ b/packages/angular/src/lib/components/chat/row-render-keys.ts
@@ -1,0 +1,195 @@
+import type { AssistantMessage, Message } from "@ag-ui/core";
+
+/**
+ * Stable `@for` track keys for chat rows, across backends that re-key a message
+ * mid-stream.
+ *
+ * ## The problem
+ *
+ * A message's canonical `id` is not stable within a turn. LangChain stamps a
+ * placeholder id on the first streamed chunk when the provider didn't supply
+ * one (`chat_models.py`: `if chunk.message.id is None: chunk.message.id =
+ * "lc_run-" + "-" + run_id`), then prefers any provider-assigned id it sees
+ * while merging chunks (`messages/ai.py`, "Ranks are defined by the order of
+ * preference"). The `MESSAGES_SNAPSHOT` therefore carries the provider's final
+ * id (e.g. `resp_…`) for a message the client already knows as `lc_run--…`.
+ *
+ * Because `@for` destroys and recreates a row whose track value changes, that
+ * swap produced the visible HITL chat flash, where a rendered approval card
+ * appears to reset during a tool's `executing → complete` transition.
+ *
+ * This is provider-conditional: providers that stamp an id on every chunk (so
+ * `chunk.message.id is None` never holds) never trigger a rename.
+ *
+ * ## The approach
+ *
+ * Tool-call ids survive the rename, so they are used as *anchors*: the first
+ * message seen carrying a given tool call records the row key it was assigned,
+ * and any later message carrying that same tool call reuses it. The store is an
+ * override table consulted before falling back to `message.id`:
+ *
+ * ```text
+ * render 1  id=lc_run--1  no tools    key = message.id = lc_run--1     store {}
+ * render 2  id=lc_run--1  tc call_A   key = message.id = lc_run--1     store { tc:call_A -> lc_run--1 }
+ * render 3  id=resp_1     tc call_A   key = store[tc:call_A]           store unchanged
+ *                                         = lc_run--1  (row survives)
+ * ```
+ *
+ * Registering the anchor at render 2 — while the id is still stable — is what
+ * makes render 3 resolvable. The fix does not depend on render 2 existing: a
+ * message born already carrying a tool call registers its anchor on the render
+ * that first shows it, under whatever id it holds then.
+ *
+ * ## Why an override table rather than tracking by tool-call id
+ *
+ * Deriving the key from the tool call directly (`tc:<id>` whenever a tool call
+ * is present) needs no state, but changes the key the moment a tool call
+ * *appears* — so an assistant message that streams text and then calls a tool
+ * is destroyed and recreated on that transition, for every provider, whether or
+ * not it renames. That trades a conditional flash for an unconditional one.
+ * Recording an override keeps the key the row already had.
+ *
+ * ## Keys are returned by position, not by message id
+ *
+ * Unlike the React and Vue ports, this returns an array parallel to the input
+ * list. Those ports deduplicate messages by id before rendering; this component
+ * does not, so a duplicate id would collapse two rows into one map entry and
+ * hand `@for` the same track value twice (which Angular reports as an error).
+ * Indexing by position sidesteps that, and every returned key is unique by
+ * construction.
+ *
+ * ## Cost
+ *
+ * The store holds only `tc:<toolCallId>` entries, so a conversation with no tool
+ * calls keeps an empty store and behaviour identical to tracking by `id`. Size
+ * is bounded to the tool calls of the currently-rendered messages (see
+ * `pruneRowKeyStore`), not the conversation length.
+ *
+ * ## Known gaps
+ *
+ * - A text-only assistant message has no anchor, so its row is still recreated
+ *   when re-keyed. No client-side correlation signal exists for it; the fix is
+ *   stable ids upstream.
+ * - If the tool call's arrival and the id swap land in the same change-detection
+ *   pass, the intermediate state never renders, the anchor is never registered,
+ *   and the row is recreated as before.
+ *
+ * Kept per-package (rather than shared) to match how message-view helpers are
+ * handled across the framework packages. The React and Vue ports carry the same
+ * logic; changes here should be mirrored there.
+ */
+
+const TOOL_ANCHOR_PREFIX = "tc:";
+
+export interface RowKeyStore {
+  /**
+   * `tc:<toolCallId>` → the row key first assigned to a message carrying that
+   * tool call. Populated only for assistant messages that carry tool calls.
+   */
+  overrides: Map<string, string>;
+}
+
+export function createRowKeyStore(): RowKeyStore {
+  return { overrides: new Map() };
+}
+
+/**
+ * Anchors a message contributes. Only assistant tool calls qualify: LangChain's
+ * id preference applies when merging `AIMessageChunk`s, so user message ids are
+ * not renamed, and `role: "tool"` messages are not rendered as rows. Every tool
+ * call is used (not just the first) so the anchor survives tool-call reordering
+ * between snapshots.
+ */
+function toolAnchorsOf(message: Message | undefined): string[] {
+  if (message?.role !== "assistant") return [];
+  const toolCalls = (message as AssistantMessage).toolCalls;
+  if (!toolCalls?.length) return [];
+
+  const anchors: string[] = [];
+  for (const toolCall of toolCalls) {
+    if (toolCall?.id) anchors.push(`${TOOL_ANCHOR_PREFIX}${toolCall.id}`);
+  }
+  return anchors;
+}
+
+/**
+ * Resolves the track key for every message, returned by position.
+ *
+ * Mutates `store` additively — it registers anchors but never removes them, so
+ * the call is idempotent for a given message list. That matters because this
+ * runs inside a `computed`, which Angular may re-evaluate at will: re-running
+ * yields the same keys. Removal happens in `pruneRowKeyStore` after render,
+ * never during evaluation, so an anchor the rendered rows still need can't be
+ * dropped out from under them.
+ *
+ * Iteration order is significant — the first message to claim a key keeps it.
+ */
+export function resolveRowRenderKeys(
+  store: RowKeyStore,
+  messages: readonly (Message | undefined)[],
+): string[] {
+  const keys: string[] = [];
+  const claimed = new Set<string>();
+
+  messages.forEach((message, index) => {
+    const anchors = toolAnchorsOf(message);
+
+    // Reuse the key recorded for any of this message's anchors. An override
+    // pointing at a key another row already claimed this pass is skipped: two
+    // messages can share a tool-call id (upstream bug, or replayed state), and
+    // the later one falls back to its own id instead.
+    let key: string | undefined;
+    for (const anchor of anchors) {
+      const recorded = store.overrides.get(anchor);
+      if (recorded !== undefined && !claimed.has(recorded)) {
+        key = recorded;
+        break;
+      }
+    }
+
+    // Mirrors the previous trackBy fallback for a message with no usable id.
+    key ??= message?.id || `index-${index}`;
+
+    // Uniqueness is structural rather than assumed: this component does not
+    // deduplicate, so two rows can legitimately arrive with the same id, and an
+    // override can vend a key equal to a later message's own id.
+    if (claimed.has(key)) {
+      let suffix = 2;
+      while (claimed.has(`${key}:${suffix}`)) suffix += 1;
+      key = `${key}:${suffix}`;
+    }
+
+    keys.push(key);
+    claimed.add(key);
+
+    // First claimant of an anchor owns it, so a re-keyed message resolves to
+    // the key the row already had rather than overwriting it.
+    for (const anchor of anchors) {
+      if (!store.overrides.has(anchor)) store.overrides.set(anchor, key);
+    }
+  });
+
+  return keys;
+}
+
+/**
+ * Drops anchors no longer present in `messages`, bounding the store to the tool
+ * calls of the currently-rendered messages. Call after render (an
+ * `afterRenderEffect`), never during `computed` evaluation.
+ *
+ * Pruned entries are unreachable by construction: `resolveRowRenderKeys` only
+ * looks up anchors belonging to messages in the list it is given.
+ */
+export function pruneRowKeyStore(
+  store: RowKeyStore,
+  messages: readonly (Message | undefined)[],
+): void {
+  const live = new Set<string>();
+  for (const message of messages) {
+    for (const anchor of toolAnchorsOf(message)) live.add(anchor);
+  }
+
+  for (const anchor of store.overrides.keys()) {
+    if (!live.has(anchor)) store.overrides.delete(anchor);
+  }
+}

--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -4,6 +4,7 @@ import React, {
   useLayoutEffect,
   useMemo,
   useReducer,
+  useRef,
   useState,
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -32,6 +33,12 @@ import {
 } from "../intelligence-indicator";
 import type { IntelligenceIndicatorView } from "../intelligence-indicator";
 import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
+import {
+  createRowKeyStore,
+  pruneRowKeyStore,
+  resolveRowRenderKeys,
+} from "./rowRenderKeys";
+import type { RowKeyStore } from "./rowRenderKeys";
 
 /**
  * Resolves a slot value into a { Component, slotProps } pair, handling the three
@@ -491,6 +498,24 @@ export function CopilotChatMessageView({
     [messages],
   );
 
+  // Stable per-row React keys. Backends can re-key a message mid-stream, and
+  // keying rows by the canonical id remounts the row on that swap (the HITL
+  // chat flash). See ./rowRenderKeys for the mechanism and its limits.
+  const rowKeyStoreRef = useRef<RowKeyStore | null>(null);
+  rowKeyStoreRef.current ??= createRowKeyStore();
+  const rowKeyStore = rowKeyStoreRef.current;
+
+  const rowRenderKeys = useMemo(
+    () => resolveRowRenderKeys(rowKeyStore, deduplicatedMessages),
+    [rowKeyStore, deduplicatedMessages],
+  );
+
+  // Prune after commit, never during render: dropping an anchor in a render
+  // React later abandons could re-mint a committed row's key and remount it.
+  useEffect(() => {
+    pruneRowKeyStore(rowKeyStore, deduplicatedMessages);
+  }, [rowKeyStore, deduplicatedMessages]);
+
   if (
     process.env.NODE_ENV === "development" &&
     deduplicatedMessages.length < messages.length
@@ -634,11 +659,14 @@ export function CopilotChatMessageView({
   const renderMessageBlock = (message: Message): React.ReactElement[] => {
     const elements: (React.ReactElement | null | undefined)[] = [];
     const stateSnapshot = getStateSnapshotForMessage(message.id);
+    // Row key only — everything keyed to message identity (state snapshots,
+    // tool lookups) must keep using message.id.
+    const rowKey = rowRenderKeys.get(message.id) ?? message.id;
 
     if (renderCustomMessage) {
       elements.push(
         <MemoizedCustomMessage
-          key={`${message.id}-custom-before`}
+          key={`${rowKey}-custom-before`}
           message={message}
           position="before"
           renderCustomMessage={renderCustomMessage}
@@ -650,7 +678,7 @@ export function CopilotChatMessageView({
     if (message.role === "assistant") {
       elements.push(
         <MemoizedAssistantMessage
-          key={message.id}
+          key={rowKey}
           message={message as AssistantMessage}
           messages={messages}
           isRunning={isRunning}
@@ -661,7 +689,7 @@ export function CopilotChatMessageView({
     } else if (message.role === "user") {
       elements.push(
         <MemoizedUserMessage
-          key={message.id}
+          key={rowKey}
           message={message as UserMessage}
           UserMessageComponent={UserComponent}
           slotProps={userSlotProps}
@@ -670,7 +698,7 @@ export function CopilotChatMessageView({
     } else if (message.role === "activity") {
       elements.push(
         <MemoizedActivityMessage
-          key={message.id}
+          key={rowKey}
           message={message as ActivityMessage}
           renderActivityMessage={renderActivityMessage}
         />,
@@ -678,7 +706,7 @@ export function CopilotChatMessageView({
     } else if (message.role === "reasoning") {
       elements.push(
         <MemoizedReasoningMessage
-          key={message.id}
+          key={rowKey}
           message={message as ReasoningMessage}
           messages={messages}
           isRunning={isRunning}
@@ -691,7 +719,7 @@ export function CopilotChatMessageView({
     if (renderCustomMessage) {
       elements.push(
         <MemoizedCustomMessage
-          key={`${message.id}-custom-after`}
+          key={`${rowKey}-custom-after`}
           message={message}
           position="after"
           renderCustomMessage={renderCustomMessage}
@@ -762,7 +790,7 @@ export function CopilotChatMessageView({
             const message = deduplicatedMessages[virtualItem.index]!;
             return (
               <div
-                key={message.id}
+                key={rowRenderKeys.get(message.id) ?? message.id}
                 data-index={virtualItem.index}
                 ref={virtualizer.measureElement}
                 style={{

--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -4,6 +4,7 @@ import React, {
   useLayoutEffect,
   useMemo,
   useReducer,
+  useRef,
   useState,
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -31,6 +32,12 @@ import {
 } from "../intelligence-indicator";
 import type { IntelligenceIndicatorView } from "../intelligence-indicator";
 import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
+import {
+  createRowKeyStore,
+  pruneRowKeyStore,
+  resolveRowRenderKeys,
+} from "./rowRenderKeys";
+import type { RowKeyStore } from "./rowRenderKeys";
 
 /**
  * Resolves a slot value into a { Component, slotProps } pair, handling the three
@@ -447,6 +454,24 @@ export function CopilotChatMessageView({
     [messages],
   );
 
+  // Stable per-row React keys. Backends can re-key a message mid-stream, and
+  // keying rows by the canonical id remounts the row on that swap (the HITL
+  // chat flash). See ./rowRenderKeys for the mechanism and its limits.
+  const rowKeyStoreRef = useRef<RowKeyStore | null>(null);
+  rowKeyStoreRef.current ??= createRowKeyStore();
+  const rowKeyStore = rowKeyStoreRef.current;
+
+  const rowRenderKeys = useMemo(
+    () => resolveRowRenderKeys(rowKeyStore, deduplicatedMessages),
+    [rowKeyStore, deduplicatedMessages],
+  );
+
+  // Prune after commit, never during render: dropping an anchor in a render
+  // React later abandons could re-mint a committed row's key and remount it.
+  useEffect(() => {
+    pruneRowKeyStore(rowKeyStore, deduplicatedMessages);
+  }, [rowKeyStore, deduplicatedMessages]);
+
   if (
     process.env.NODE_ENV === "development" &&
     deduplicatedMessages.length < messages.length
@@ -557,11 +582,14 @@ export function CopilotChatMessageView({
   const renderMessageBlock = (message: Message): React.ReactElement[] => {
     const elements: (React.ReactElement | null | undefined)[] = [];
     const stateSnapshot = getStateSnapshotForMessage(message.id);
+    // Row key only — everything keyed to message identity (state snapshots,
+    // tool lookups) must keep using message.id.
+    const rowKey = rowRenderKeys.get(message.id) ?? message.id;
 
     if (renderCustomMessage) {
       elements.push(
         <MemoizedCustomMessage
-          key={`${message.id}-custom-before`}
+          key={`${rowKey}-custom-before`}
           message={message}
           position="before"
           renderCustomMessage={renderCustomMessage}
@@ -573,7 +601,7 @@ export function CopilotChatMessageView({
     if (message.role === "assistant") {
       elements.push(
         <MemoizedAssistantMessage
-          key={message.id}
+          key={rowKey}
           message={message as AssistantMessage}
           messages={messages}
           isRunning={isRunning}
@@ -584,7 +612,7 @@ export function CopilotChatMessageView({
     } else if (message.role === "user") {
       elements.push(
         <MemoizedUserMessage
-          key={message.id}
+          key={rowKey}
           message={message as UserMessage}
           UserMessageComponent={UserComponent}
           slotProps={userSlotProps}
@@ -593,7 +621,7 @@ export function CopilotChatMessageView({
     } else if (message.role === "activity") {
       elements.push(
         <MemoizedActivityMessage
-          key={message.id}
+          key={rowKey}
           message={message as ActivityMessage}
           renderActivityMessage={renderActivityMessage}
         />,
@@ -601,7 +629,7 @@ export function CopilotChatMessageView({
     } else if (message.role === "reasoning") {
       elements.push(
         <MemoizedReasoningMessage
-          key={message.id}
+          key={rowKey}
           message={message as ReasoningMessage}
           messages={messages}
           isRunning={isRunning}
@@ -614,7 +642,7 @@ export function CopilotChatMessageView({
     if (renderCustomMessage) {
       elements.push(
         <MemoizedCustomMessage
-          key={`${message.id}-custom-after`}
+          key={`${rowKey}-custom-after`}
           message={message}
           position="after"
           renderCustomMessage={renderCustomMessage}
@@ -685,7 +713,7 @@ export function CopilotChatMessageView({
             const message = deduplicatedMessages[virtualItem.index]!;
             return (
               <div
-                key={message.id}
+                key={rowRenderKeys.get(message.id) ?? message.id}
                 data-index={virtualItem.index}
                 ref={virtualizer.measureElement}
                 style={{

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatMessageView.rowKeys.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatMessageView.rowKeys.test.tsx
@@ -1,0 +1,164 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
+import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
+import CopilotChatMessageView from "../CopilotChatMessageView";
+import type { Message, ToolCall } from "@ag-ui/core";
+
+const AGENT_ID = "default";
+const THREAD_ID = "thread-test";
+
+function toolCall(id: string, name = "approve"): ToolCall {
+  return { id, type: "function", function: { name, arguments: "{}" } };
+}
+
+function assistantMsg(id: string, content?: string, toolCalls?: ToolCall[]) {
+  return { id, role: "assistant" as const, content, toolCalls };
+}
+
+function tree(messages: Message[]) {
+  return (
+    <CopilotKitProvider>
+      <CopilotChatConfigurationProvider agentId={AGENT_ID} threadId={THREAD_ID}>
+        <CopilotChatMessageView messages={messages} />
+      </CopilotChatConfigurationProvider>
+    </CopilotKitProvider>
+  );
+}
+
+/**
+ * Remount-vs-reconcile is only observable by rerendering ONE root and
+ * comparing DOM node identity, so these tests build the tree directly rather
+ * than using the shared render helper.
+ */
+function rerenderWith(before: Message[], after: Message[]) {
+  const view = render(tree(before));
+  const node = screen.getByTestId("copilot-assistant-message");
+  view.rerender(tree(after));
+  return { node, nodeAfter: screen.getByTestId("copilot-assistant-message") };
+}
+
+function duplicateKeyWarnings(spy: ReturnType<typeof vi.spyOn>) {
+  // React's message is "two children with the same key", NOT "duplicate key".
+  return spy.mock.calls.filter(
+    (call) =>
+      typeof call[0] === "string" &&
+      call[0].includes("two children with the same key"),
+  );
+}
+
+describe("CopilotChatMessageView stable row keys", () => {
+  it("reconciles in place when the message id changes but a tool call is stable", () => {
+    const { node, nodeAfter } = rerenderWith(
+      [assistantMsg("lc_run--1", "Working...", [toolCall("call_A")])],
+      [assistantMsg("resp_1", "Done", [toolCall("call_A")])],
+    );
+
+    expect(nodeAfter).toBe(node);
+    // Proves React reconciled AND re-rendered, rather than keeping a stale node.
+    expect(nodeAfter.textContent).toContain("Done");
+  });
+
+  it("does not remount when a tool call arrives on an already-streaming message", () => {
+    // Regression guard: keying rows by the tool-call id instead of recording an
+    // override remounts here, for every provider, renaming or not.
+    const { node, nodeAfter } = rerenderWith(
+      [assistantMsg("lc_run--1", "Let me check that...")],
+      [assistantMsg("lc_run--1", "Let me check that...", [toolCall("call_A")])],
+    );
+
+    expect(nodeAfter).toBe(node);
+  });
+
+  it("does not remount when a second tool call arrives", () => {
+    const { node, nodeAfter } = rerenderWith(
+      [assistantMsg("m1", "hi", [toolCall("call_A")])],
+      [assistantMsg("m1", "hi", [toolCall("call_A"), toolCall("call_B", "b")])],
+    );
+
+    expect(nodeAfter).toBe(node);
+  });
+
+  it("survives the whole sequence: text, then tool call, then id re-key", () => {
+    const view = render(tree([assistantMsg("lc_run--1", "Let me check...")]));
+    const node = screen.getByTestId("copilot-assistant-message");
+
+    view.rerender(
+      tree([
+        assistantMsg("lc_run--1", "Let me check...", [toolCall("call_A")]),
+      ]),
+    );
+    expect(screen.getByTestId("copilot-assistant-message")).toBe(node);
+
+    view.rerender(tree([assistantMsg("resp_1", "Done", [toolCall("call_A")])]));
+    expect(screen.getByTestId("copilot-assistant-message")).toBe(node);
+  });
+
+  it("remounts a text-only message on an id change (documented limitation)", () => {
+    // Not a contract: if a future change gives text-only rows a stable anchor,
+    // update this to assert in-place reconcile rather than reverting it.
+    const { node, nodeAfter } = rerenderWith(
+      [assistantMsg("lc_run--1", "Working...")],
+      [assistantMsg("resp_1", "Done")],
+    );
+
+    expect(nodeAfter).not.toBe(node);
+  });
+
+  it("renders both rows without duplicate keys when a tool-call id is shared", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      tree([
+        assistantMsg("a-1", "First", [toolCall("call_X")]),
+        assistantMsg("a-2", "Second", [toolCall("call_X")]),
+      ]),
+    );
+
+    const rows = screen.getAllByTestId("copilot-assistant-message");
+    expect(rows).toHaveLength(2);
+    // Input order is pinned: the first claimant keeps the established key.
+    expect(rows[0]!.textContent).toContain("First");
+    expect(rows[1]!.textContent).toContain("Second");
+    expect(duplicateKeyWarnings(spy)).toHaveLength(0);
+
+    spy.mockRestore();
+  });
+
+  it("renders both rows without duplicate keys when an id collides with a vended key", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const view = render(
+      tree([assistantMsg("ghost", "First", [toolCall("call_X")])]),
+    );
+    // "ghost" is now the key recorded for call_X; a later list has a different
+    // message carrying call_X plus a message whose own id is "ghost".
+    view.rerender(
+      tree([
+        assistantMsg("live", "First", [toolCall("call_X")]),
+        assistantMsg("ghost", "Second"),
+      ]),
+    );
+
+    expect(screen.getAllByTestId("copilot-assistant-message")).toHaveLength(2);
+    expect(duplicateKeyWarnings(spy)).toHaveLength(0);
+
+    spy.mockRestore();
+  });
+
+  it("keeps rows stable when the list grows around them", () => {
+    const first = assistantMsg("lc_run--1", "First", [toolCall("call_A")]);
+    const view = render(tree([first]));
+    const node = screen.getByTestId("copilot-assistant-message");
+
+    view.rerender(
+      tree([
+        { ...first, id: "resp_1" },
+        assistantMsg("lc_run--2", "Second", [toolCall("call_B", "b")]),
+      ]),
+    );
+
+    expect(screen.getAllByTestId("copilot-assistant-message")[0]).toBe(node);
+  });
+});

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatMessageView.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatMessageView.test.tsx
@@ -157,10 +157,13 @@ describe("CopilotChatMessageView duplicate message deduplication", () => {
     const userMessages = screen.getAllByTestId("copilot-user-message");
     expect(userMessages).toHaveLength(1);
 
-    // Should NOT produce React duplicate key warnings
+    // Should NOT produce React duplicate key warnings. React's wording is
+    // "two children with the same key" — matching "duplicate key" never fired,
+    // so this assertion passed vacuously.
     const duplicateKeyWarnings = consoleSpy.mock.calls.filter(
       (call) =>
-        typeof call[0] === "string" && call[0].includes("duplicate key"),
+        typeof call[0] === "string" &&
+        call[0].includes("two children with the same key"),
     );
     expect(duplicateKeyWarnings).toHaveLength(0);
 

--- a/packages/react-core/src/v2/components/chat/__tests__/rowRenderKeys.test.ts
+++ b/packages/react-core/src/v2/components/chat/__tests__/rowRenderKeys.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "vitest";
+import type { Message, ToolCall } from "@ag-ui/core";
+import {
+  createRowKeyStore,
+  pruneRowKeyStore,
+  resolveRowRenderKeys,
+} from "../rowRenderKeys";
+
+function toolCall(id: string, name = "approve"): ToolCall {
+  return { id, type: "function", function: { name, arguments: "{}" } };
+}
+
+function assistant(id: string, toolCalls?: ToolCall[]): Message {
+  return { id, role: "assistant", content: "…", toolCalls } as Message;
+}
+
+function user(id: string): Message {
+  return { id, role: "user", content: "hi" } as Message;
+}
+
+/** The row key a message resolves to for a given list. */
+function keyOf(
+  store: ReturnType<typeof createRowKeyStore>,
+  messages: Message[],
+  id: string,
+) {
+  return resolveRowRenderKeys(store, messages).get(id);
+}
+
+describe("resolveRowRenderKeys", () => {
+  it("keys by message.id when there are no tool calls, leaving the store empty", () => {
+    const store = createRowKeyStore();
+    const messages = [user("u1"), assistant("a1")];
+
+    const keys = resolveRowRenderKeys(store, messages);
+
+    expect(keys.get("u1")).toBe("u1");
+    expect(keys.get("a1")).toBe("a1");
+    // The whole point of the override-table design: unaffected conversations
+    // carry no state and behave exactly like plain id keying.
+    expect(store.overrides.size).toBe(0);
+  });
+
+  it("holds the key steady when a tool call appears on an already-streaming message", () => {
+    // Real sequence: TEXT_MESSAGE_START creates the message, TOOL_CALL_START
+    // then mutates that SAME message. Deriving the key from the tool call
+    // would change it here and remount the row.
+    const store = createRowKeyStore();
+
+    const streaming = keyOf(store, [assistant("lc_run--1")], "lc_run--1");
+    const withTool = keyOf(
+      store,
+      [assistant("lc_run--1", [toolCall("call_A")])],
+      "lc_run--1",
+    );
+
+    expect(streaming).toBe("lc_run--1");
+    expect(withTool).toBe("lc_run--1");
+  });
+
+  it("holds the key steady when the snapshot re-keys the message id", () => {
+    const store = createRowKeyStore();
+
+    resolveRowRenderKeys(store, [assistant("lc_run--1", [toolCall("call_A")])]);
+    const afterRekey = keyOf(
+      store,
+      [assistant("resp_1", [toolCall("call_A")])],
+      "resp_1",
+    );
+
+    expect(afterRekey).toBe("lc_run--1");
+  });
+
+  it("holds the key steady across the full streaming sequence", () => {
+    const store = createRowKeyStore();
+
+    const k1 = keyOf(store, [assistant("lc_run--1")], "lc_run--1");
+    const k2 = keyOf(
+      store,
+      [assistant("lc_run--1", [toolCall("call_A")])],
+      "lc_run--1",
+    );
+    const k3 = keyOf(
+      store,
+      [assistant("resp_1", [toolCall("call_A")])],
+      "resp_1",
+    );
+
+    expect(new Set([k1, k2, k3]).size).toBe(1);
+  });
+
+  it("resolves through a surviving anchor when tool calls are reordered", () => {
+    const store = createRowKeyStore();
+
+    resolveRowRenderKeys(store, [
+      assistant("lc_run--1", [toolCall("call_A"), toolCall("call_B")]),
+    ]);
+    // Snapshot re-keys the message AND presents the tool calls in the other
+    // order — anchoring on every tool call (not just the first) survives it.
+    const afterRekey = keyOf(
+      store,
+      [assistant("resp_1", [toolCall("call_B"), toolCall("call_A")])],
+      "resp_1",
+    );
+
+    expect(afterRekey).toBe("lc_run--1");
+  });
+
+  it("keeps a later tool call from stealing an established key", () => {
+    const store = createRowKeyStore();
+
+    resolveRowRenderKeys(store, [assistant("lc_run--1", [toolCall("call_A")])]);
+    // A second tool call arrives on the same row; call_A already owns the key.
+    const keys = resolveRowRenderKeys(store, [
+      assistant("lc_run--1", [toolCall("call_A"), toolCall("call_B")]),
+    ]);
+
+    expect(keys.get("lc_run--1")).toBe("lc_run--1");
+    expect(store.overrides.get("tc:call_B")).toBe("lc_run--1");
+  });
+
+  it("falls back to message.id when two messages share a tool-call id", () => {
+    const store = createRowKeyStore();
+    const messages = [
+      assistant("a-1", [toolCall("call_X")]),
+      assistant("a-2", [toolCall("call_X")]),
+    ];
+
+    const keys = resolveRowRenderKeys(store, messages);
+
+    expect(keys.get("a-1")).toBe("a-1");
+    expect(keys.get("a-2")).toBe("a-2");
+    expect(new Set(keys.values()).size).toBe(2);
+  });
+
+  it("keeps a shared-anchor fallback stable across renders", () => {
+    // The loser of a shared anchor must not drift between renders, or it
+    // remounts on every update.
+    const store = createRowKeyStore();
+    const messages = [
+      assistant("a-1", [toolCall("call_X")]),
+      assistant("a-2", [toolCall("call_X")]),
+    ];
+
+    const first = resolveRowRenderKeys(store, messages);
+    const second = resolveRowRenderKeys(store, messages);
+
+    expect(second.get("a-1")).toBe(first.get("a-1"));
+    expect(second.get("a-2")).toBe(first.get("a-2"));
+  });
+
+  it("disambiguates when an override vends a key equal to a later message's id", () => {
+    // Pathological: the store vends "ghost" for one row, and another message
+    // literally has id "ghost". Keys must still be unique.
+    const store = createRowKeyStore();
+    resolveRowRenderKeys(store, [assistant("ghost", [toolCall("call_X")])]);
+
+    const keys = resolveRowRenderKeys(store, [
+      assistant("live", [toolCall("call_X")]),
+      assistant("ghost"),
+    ]);
+
+    expect(keys.get("live")).toBe("ghost");
+    expect(keys.get("ghost")).not.toBe("ghost");
+    expect(new Set(keys.values()).size).toBe(2);
+  });
+
+  it("is idempotent, so a repeated or abandoned render yields the same keys", () => {
+    const store = createRowKeyStore();
+    const messages = [
+      assistant("a-1", [toolCall("call_A")]),
+      assistant("a-2", [toolCall("call_B")]),
+      user("u-1"),
+    ];
+
+    const first = resolveRowRenderKeys(store, messages);
+    const snapshot = new Map(store.overrides);
+    const second = resolveRowRenderKeys(store, messages);
+
+    expect([...second.entries()]).toEqual([...first.entries()]);
+    expect([...store.overrides.entries()]).toEqual([...snapshot.entries()]);
+  });
+
+  it("does not register anchors for non-assistant roles", () => {
+    const store = createRowKeyStore();
+    const toolMessage = {
+      id: "t-1",
+      role: "tool",
+      content: "ok",
+      toolCallId: "call_A",
+    } as unknown as Message;
+
+    resolveRowRenderKeys(store, [toolMessage]);
+
+    expect(store.overrides.size).toBe(0);
+  });
+
+  it("ignores an empty toolCalls array", () => {
+    const store = createRowKeyStore();
+
+    const keys = resolveRowRenderKeys(store, [assistant("a-1", [])]);
+
+    expect(keys.get("a-1")).toBe("a-1");
+    expect(store.overrides.size).toBe(0);
+  });
+
+  it("still re-keys a text-only message (documented limitation)", () => {
+    // No anchor exists for a text-only message, so nothing can correlate it
+    // across a rename. Recorded so a future change that fixes it is a
+    // deliberate update rather than an accident.
+    const store = createRowKeyStore();
+
+    const before = keyOf(store, [assistant("lc_run--1")], "lc_run--1");
+    const after = keyOf(store, [assistant("resp_1")], "resp_1");
+
+    expect(before).toBe("lc_run--1");
+    expect(after).toBe("resp_1");
+  });
+});
+
+describe("pruneRowKeyStore", () => {
+  it("drops anchors whose messages are gone and keeps live ones", () => {
+    const store = createRowKeyStore();
+    resolveRowRenderKeys(store, [
+      assistant("a-1", [toolCall("call_A")]),
+      assistant("a-2", [toolCall("call_B")]),
+    ]);
+    expect(store.overrides.size).toBe(2);
+
+    pruneRowKeyStore(store, [assistant("a-2", [toolCall("call_B")])]);
+
+    expect([...store.overrides.keys()]).toEqual(["tc:call_B"]);
+  });
+
+  it("bounds the store to the visible list rather than the conversation", () => {
+    const store = createRowKeyStore();
+    for (let i = 0; i < 50; i++) {
+      const live = [assistant(`a-${i}`, [toolCall(`call_${i}`)])];
+      resolveRowRenderKeys(store, live);
+      pruneRowKeyStore(store, live);
+    }
+
+    expect(store.overrides.size).toBe(1);
+  });
+
+  it("preserves the key of a row that survives a prune", () => {
+    const store = createRowKeyStore();
+    const live = [assistant("lc_run--1", [toolCall("call_A")])];
+    resolveRowRenderKeys(store, live);
+    pruneRowKeyStore(store, live);
+
+    // The re-key must still resolve after an intervening prune.
+    const afterRekey = keyOf(
+      store,
+      [assistant("resp_1", [toolCall("call_A")])],
+      "resp_1",
+    );
+
+    expect(afterRekey).toBe("lc_run--1");
+  });
+});

--- a/packages/react-core/src/v2/components/chat/rowRenderKeys.ts
+++ b/packages/react-core/src/v2/components/chat/rowRenderKeys.ts
@@ -1,0 +1,187 @@
+import type { AssistantMessage, Message } from "@ag-ui/core";
+
+/**
+ * Stable React keys for chat rows, across backends that re-key a message
+ * mid-stream.
+ *
+ * ## The problem
+ *
+ * A message's canonical `id` is not stable within a turn. LangChain stamps a
+ * placeholder id on the first streamed chunk when the provider didn't supply
+ * one (`chat_models.py`: `if chunk.message.id is None: chunk.message.id =
+ * "lc_run-" + "-" + run_id`), then prefers any provider-assigned id it sees
+ * while merging chunks (`messages/ai.py`, "Ranks are defined by the order of
+ * preference"). The `MESSAGES_SNAPSHOT` therefore carries the provider's final
+ * id (e.g. `resp_…`) for a message the client already knows as `lc_run--…`.
+ *
+ * Keying rows by `id` made React unmount and remount the row on that swap —
+ * the visible HITL chat flash, where a rendered approval card appears to
+ * reset during a tool's `executing → complete` transition.
+ *
+ * This is provider-conditional: providers that stamp an id on every chunk
+ * (so `chunk.message.id is None` never holds) never trigger a rename.
+ *
+ * ## The approach
+ *
+ * Tool-call ids survive the rename, so they are used as *anchors*: the first
+ * message seen carrying a given tool call records the row key it was assigned,
+ * and any later message carrying that same tool call reuses it. The store is
+ * an override table consulted before falling back to `message.id`:
+ *
+ * ```text
+ * render 1  id=lc_run--1  no tools    key = message.id = lc_run--1     store {}
+ * render 2  id=lc_run--1  tc call_A   key = message.id = lc_run--1     store { tc:call_A -> lc_run--1 }
+ * render 3  id=resp_1     tc call_A   key = store[tc:call_A]           store unchanged
+ *                                         = lc_run--1  (no remount)
+ * ```
+ *
+ * Registering the anchor at render 2 — while the id is still stable — is what
+ * makes render 3 resolvable. Note the fix does not depend on render 2 existing:
+ * a message born already carrying a tool call registers its anchor on the
+ * render that first shows it, under whatever id it holds then.
+ *
+ * ## Why an override table rather than keying rows by tool-call id
+ *
+ * Deriving the key from the tool call directly (`tc:<id>` whenever a tool call
+ * is present) needs no state, but changes the key the moment a tool call
+ * *appears* — so an assistant message that streams text and then calls a tool
+ * remounts on that transition, for every provider, whether or not it renames.
+ * That trades a conditional flash for an unconditional one. Recording an
+ * override keeps the key the row already had.
+ *
+ * ## Cost
+ *
+ * The store holds only `tc:<toolCallId>` entries, so a conversation with no
+ * tool calls keeps an empty store and behaviour byte-identical to keying by
+ * `id`. Size is bounded to the tool calls of the currently-rendered messages
+ * (see `pruneRowKeyStore`), not the conversation length. Deleting the store
+ * reverts to plain `id` keying.
+ *
+ * ## Known gaps
+ *
+ * - A text-only assistant message has no anchor, so it still remounts when
+ *   re-keyed. No client-side correlation signal exists for it; the fix is
+ *   stable ids upstream.
+ * - If the tool call's arrival and the id swap land in the same React batch,
+ *   the intermediate state never renders, the anchor is never registered, and
+ *   the row remounts as before. Correlating in the event-apply layer (i.e. in
+ *   the AG-UI client, which observes every intermediate state) would be immune.
+ */
+
+const TOOL_ANCHOR_PREFIX = "tc:";
+
+export interface RowKeyStore {
+  /**
+   * `tc:<toolCallId>` → the row key first assigned to a message carrying that
+   * tool call. Populated only for assistant messages that carry tool calls.
+   */
+  overrides: Map<string, string>;
+}
+
+export function createRowKeyStore(): RowKeyStore {
+  return { overrides: new Map() };
+}
+
+/**
+ * Anchors a message contributes. Only assistant tool calls qualify: LangChain's
+ * id preference applies when merging `AIMessageChunk`s, so user message ids are
+ * not renamed, and `role: "tool"` messages are not rendered as rows at all.
+ * Every tool call is used (not just the first) so the anchor survives tool-call
+ * reordering between snapshots.
+ */
+function toolAnchorsOf(message: Message): string[] {
+  if (message.role !== "assistant") return [];
+  const toolCalls = (message as AssistantMessage).toolCalls;
+  if (!toolCalls?.length) return [];
+
+  const anchors: string[] = [];
+  for (const toolCall of toolCalls) {
+    if (toolCall?.id) anchors.push(`${TOOL_ANCHOR_PREFIX}${toolCall.id}`);
+  }
+  return anchors;
+}
+
+/**
+ * Resolves `message.id` → row key for one render pass.
+ *
+ * Mutates `store` additively — it registers anchors but never removes them, so
+ * the call is idempotent for a given message list. That matters because this
+ * runs during render: React may double-invoke render in StrictMode, and may
+ * abandon a render entirely under concurrent rendering. Re-running yields the
+ * same keys, and entries left behind by an abandoned render are swept by
+ * `pruneRowKeyStore` after commit rather than deleted mid-render (deleting
+ * during an abandoned render could drop an anchor the committed tree still
+ * needs, re-minting its key and remounting the row).
+ *
+ * `messages` must be deduplicated (see `deduplicateMessages`): duplicate ids
+ * would overwrite each other in the returned map. Iteration order is
+ * significant — the first message to claim a key keeps it.
+ */
+export function resolveRowRenderKeys(
+  store: RowKeyStore,
+  messages: Message[],
+): Map<string, string> {
+  const keys = new Map<string, string>();
+  const claimed = new Set<string>();
+
+  for (const message of messages) {
+    const anchors = toolAnchorsOf(message);
+
+    // Reuse the key recorded for any of this message's anchors. An override
+    // pointing at a key another row already claimed this pass is skipped:
+    // two messages can share a tool-call id (upstream bug, or replayed
+    // state), and the later one falls back to its own id instead.
+    let key: string | undefined;
+    for (const anchor of anchors) {
+      const recorded = store.overrides.get(anchor);
+      if (recorded !== undefined && !claimed.has(recorded)) {
+        key = recorded;
+        break;
+      }
+    }
+
+    key ??= message.id;
+
+    // Backstop for a pathological collision: an override vends a key equal to
+    // a later message's own id. Deduplicated ids can't collide with each
+    // other, so this only triggers against an override-supplied key.
+    if (claimed.has(key)) {
+      let suffix = 2;
+      while (claimed.has(`${key}:${suffix}`)) suffix += 1;
+      key = `${key}:${suffix}`;
+    }
+
+    keys.set(message.id, key);
+    claimed.add(key);
+
+    // First claimant of an anchor owns it, so a re-keyed message resolves to
+    // the key the row already had rather than overwriting it.
+    for (const anchor of anchors) {
+      if (!store.overrides.has(anchor)) store.overrides.set(anchor, key);
+    }
+  }
+
+  return keys;
+}
+
+/**
+ * Drops anchors no longer present in `messages`, bounding the store to the
+ * tool calls of the currently-rendered messages. Call after commit (in an
+ * effect), never during render — see `resolveRowRenderKeys`.
+ *
+ * Pruned entries are unreachable by construction: `resolveRowRenderKeys` only
+ * looks up anchors belonging to messages in the list it is given.
+ */
+export function pruneRowKeyStore(
+  store: RowKeyStore,
+  messages: Message[],
+): void {
+  const live = new Set<string>();
+  for (const message of messages) {
+    for (const anchor of toolAnchorsOf(message)) live.add(anchor);
+  }
+
+  for (const anchor of store.overrides.keys()) {
+    if (!live.has(anchor)) store.overrides.delete(anchor);
+  }
+}

--- a/packages/vue/src/v2/components/chat/CopilotChatMessageView.vue
+++ b/packages/vue/src/v2/components/chat/CopilotChatMessageView.vue
@@ -20,6 +20,11 @@ import { useCopilotChatConfiguration } from "../../providers/useCopilotChatConfi
 import CopilotChatAssistantMessage from "./CopilotChatAssistantMessage.vue";
 import CopilotChatReasoningMessage from "./CopilotChatReasoningMessage.vue";
 import CopilotChatUserMessage from "./CopilotChatUserMessage.vue";
+import {
+  createRowKeyStore,
+  pruneRowKeyStore,
+  resolveRowRenderKeys,
+} from "./rowRenderKeys";
 
 interface MessageMetaProps {
   message: Message;
@@ -187,6 +192,23 @@ function deduplicateMessages(messages: Message[]): Message[] {
 const deduplicatedMessages = computed(() =>
   deduplicateMessages(props.messages),
 );
+
+// Stable per-row keys. Backends can re-key a message mid-stream, and keying
+// rows by the canonical id tears the row down on that swap (the HITL chat
+// flash). See ./rowRenderKeys for the mechanism and its limits.
+const rowKeyStore = createRowKeyStore();
+const rowRenderKeys = computed(() =>
+  resolveRowRenderKeys(rowKeyStore, deduplicatedMessages.value),
+);
+
+// Prune after the DOM is patched, never during computed evaluation: dropping an
+// anchor the rendered rows still need would re-mint their keys and tear them
+// down.
+watch(
+  deduplicatedMessages,
+  (messages) => pruneRowKeyStore(rowKeyStore, messages),
+  { flush: "post" },
+);
 const lastMessage = computed(() => props.messages[props.messages.length - 1]);
 const showCursor = computed(
   () => props.isRunning && lastMessage.value?.role !== "reasoning",
@@ -345,7 +367,10 @@ function resolveToolMessage(
 
 <template>
   <div data-copilotkit class="cpk:flex cpk:flex-col" v-bind="$attrs">
-    <template v-for="message in deduplicatedMessages" :key="message.id">
+    <template
+      v-for="message in deduplicatedMessages"
+      :key="rowRenderKeys.get(message.id) ?? message.id"
+    >
       <slot
         v-if="componentSlots['message-before']"
         name="message-before"

--- a/packages/vue/src/v2/components/chat/CopilotChatMessageView.vue
+++ b/packages/vue/src/v2/components/chat/CopilotChatMessageView.vue
@@ -19,6 +19,11 @@ import { useCopilotChatConfiguration } from "../../providers/useCopilotChatConfi
 import CopilotChatAssistantMessage from "./CopilotChatAssistantMessage.vue";
 import CopilotChatReasoningMessage from "./CopilotChatReasoningMessage.vue";
 import CopilotChatUserMessage from "./CopilotChatUserMessage.vue";
+import {
+  createRowKeyStore,
+  pruneRowKeyStore,
+  resolveRowRenderKeys,
+} from "./rowRenderKeys";
 
 interface MessageMetaProps {
   message: Message;
@@ -185,6 +190,23 @@ function deduplicateMessages(messages: Message[]): Message[] {
 const deduplicatedMessages = computed(() =>
   deduplicateMessages(props.messages),
 );
+
+// Stable per-row keys. Backends can re-key a message mid-stream, and keying
+// rows by the canonical id tears the row down on that swap (the HITL chat
+// flash). See ./rowRenderKeys for the mechanism and its limits.
+const rowKeyStore = createRowKeyStore();
+const rowRenderKeys = computed(() =>
+  resolveRowRenderKeys(rowKeyStore, deduplicatedMessages.value),
+);
+
+// Prune after the DOM is patched, never during computed evaluation: dropping an
+// anchor the rendered rows still need would re-mint their keys and tear them
+// down.
+watch(
+  deduplicatedMessages,
+  (messages) => pruneRowKeyStore(rowKeyStore, messages),
+  { flush: "post" },
+);
 const lastMessage = computed(() => props.messages[props.messages.length - 1]);
 const showCursor = computed(
   () => props.isRunning && lastMessage.value?.role !== "reasoning",
@@ -343,7 +365,10 @@ function resolveToolMessage(
 
 <template>
   <div data-copilotkit class="cpk:flex cpk:flex-col" v-bind="$attrs">
-    <template v-for="message in deduplicatedMessages" :key="message.id">
+    <template
+      v-for="message in deduplicatedMessages"
+      :key="rowRenderKeys.get(message.id) ?? message.id"
+    >
       <slot
         v-if="componentSlots['message-before']"
         name="message-before"

--- a/packages/vue/src/v2/components/chat/__tests__/CopilotChatMessageView.rowKeys.test.ts
+++ b/packages/vue/src/v2/components/chat/__tests__/CopilotChatMessageView.rowKeys.test.ts
@@ -1,0 +1,140 @@
+import { defineComponent, ref } from "vue";
+import { render, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+import type { Message, ToolCall } from "@ag-ui/core";
+import CopilotKitProvider from "../../../providers/CopilotKitProvider.vue";
+import CopilotChatConfigurationProvider from "../../../providers/CopilotChatConfigurationProvider.vue";
+import CopilotChatMessageView from "../CopilotChatMessageView.vue";
+
+const AGENT_ID = "default";
+const THREAD_ID = "thread-test";
+
+function toolCall(id: string, name = "approve"): ToolCall {
+  return { id, type: "function", function: { name, arguments: "{}" } };
+}
+
+function assistantMsg(id: string, content?: string, toolCalls?: ToolCall[]) {
+  return { id, role: "assistant" as const, content, toolCalls } as Message;
+}
+
+/**
+ * Renders the view over a reactive message list and returns a setter, so a test
+ * can swap the list on the SAME mounted instance. Row teardown-vs-reuse is only
+ * observable that way — comparing DOM node identity across an update.
+ */
+function renderWithSwappableMessages(initial: Message[]) {
+  const messages = ref<Message[]>(initial);
+
+  const Host = defineComponent({
+    components: {
+      CopilotKitProvider,
+      CopilotChatConfigurationProvider,
+      CopilotChatMessageView,
+    },
+    setup() {
+      return { messages, agentId: AGENT_ID, threadId: THREAD_ID };
+    },
+    template: `
+      <CopilotKitProvider runtime-url="/api/copilotkit">
+        <CopilotChatConfigurationProvider :agent-id="agentId" :thread-id="threadId">
+          <CopilotChatMessageView :messages="messages" />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>
+    `,
+  });
+
+  render(Host);
+
+  return {
+    async setMessages(next: Message[]) {
+      messages.value = next;
+      // Let Vue flush the patch (and the post-flush prune watcher).
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    },
+  };
+}
+
+function assistantRow() {
+  return screen.getByTestId("copilot-assistant-message");
+}
+
+describe("CopilotChatMessageView stable row keys", () => {
+  it("reuses the row when the message id changes but a tool call is stable", async () => {
+    const { setMessages } = renderWithSwappableMessages([
+      assistantMsg("lc_run--1", "Working...", [toolCall("call_A")]),
+    ]);
+    const node = assistantRow();
+
+    await setMessages([assistantMsg("resp_1", "Done", [toolCall("call_A")])]);
+
+    expect(assistantRow()).toBe(node);
+    expect(assistantRow().textContent).toContain("Done");
+  });
+
+  it("does not tear down the row when a tool call arrives mid-stream", async () => {
+    // Regression guard: keying by the tool-call id instead of recording an
+    // override tears the row down here, for every provider.
+    const { setMessages } = renderWithSwappableMessages([
+      assistantMsg("lc_run--1", "Let me check that..."),
+    ]);
+    const node = assistantRow();
+
+    await setMessages([
+      assistantMsg("lc_run--1", "Let me check that...", [toolCall("call_A")]),
+    ]);
+
+    expect(assistantRow()).toBe(node);
+  });
+
+  it("survives the whole sequence: text, then tool call, then id re-key", async () => {
+    const { setMessages } = renderWithSwappableMessages([
+      assistantMsg("lc_run--1", "Let me check..."),
+    ]);
+    const node = assistantRow();
+
+    await setMessages([
+      assistantMsg("lc_run--1", "Let me check...", [toolCall("call_A")]),
+    ]);
+    expect(assistantRow()).toBe(node);
+
+    await setMessages([assistantMsg("resp_1", "Done", [toolCall("call_A")])]);
+    expect(assistantRow()).toBe(node);
+  });
+
+  it("tears down a text-only row on an id change (documented limitation)", async () => {
+    const { setMessages } = renderWithSwappableMessages([
+      assistantMsg("lc_run--1", "Working..."),
+    ]);
+    const node = assistantRow();
+
+    await setMessages([assistantMsg("resp_1", "Done")]);
+
+    expect(assistantRow()).not.toBe(node);
+  });
+
+  it("renders both rows when a tool-call id is shared", async () => {
+    renderWithSwappableMessages([
+      assistantMsg("a-1", "First", [toolCall("call_X")]),
+      assistantMsg("a-2", "Second", [toolCall("call_X")]),
+    ]);
+
+    const rows = screen.getAllByTestId("copilot-assistant-message");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.textContent).toContain("First");
+    expect(rows[1]!.textContent).toContain("Second");
+  });
+
+  it("keeps the first row when the list grows around it", async () => {
+    const { setMessages } = renderWithSwappableMessages([
+      assistantMsg("lc_run--1", "First", [toolCall("call_A")]),
+    ]);
+    const node = assistantRow();
+
+    await setMessages([
+      assistantMsg("resp_1", "First", [toolCall("call_A")]),
+      assistantMsg("lc_run--2", "Second", [toolCall("call_B", "b")]),
+    ]);
+
+    expect(screen.getAllByTestId("copilot-assistant-message")[0]).toBe(node);
+  });
+});

--- a/packages/vue/src/v2/components/chat/__tests__/rowRenderKeys.test.ts
+++ b/packages/vue/src/v2/components/chat/__tests__/rowRenderKeys.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "vitest";
+import type { Message, ToolCall } from "@ag-ui/core";
+import {
+  createRowKeyStore,
+  pruneRowKeyStore,
+  resolveRowRenderKeys,
+} from "../rowRenderKeys";
+
+function toolCall(id: string, name = "approve"): ToolCall {
+  return { id, type: "function", function: { name, arguments: "{}" } };
+}
+
+function assistant(id: string, toolCalls?: ToolCall[]): Message {
+  return { id, role: "assistant", content: "…", toolCalls } as Message;
+}
+
+function user(id: string): Message {
+  return { id, role: "user", content: "hi" } as Message;
+}
+
+/** The row key a message resolves to for a given list. */
+function keyOf(
+  store: ReturnType<typeof createRowKeyStore>,
+  messages: Message[],
+  id: string,
+) {
+  return resolveRowRenderKeys(store, messages).get(id);
+}
+
+describe("resolveRowRenderKeys", () => {
+  it("keys by message.id when there are no tool calls, leaving the store empty", () => {
+    const store = createRowKeyStore();
+    const messages = [user("u1"), assistant("a1")];
+
+    const keys = resolveRowRenderKeys(store, messages);
+
+    expect(keys.get("u1")).toBe("u1");
+    expect(keys.get("a1")).toBe("a1");
+    // The whole point of the override-table design: unaffected conversations
+    // carry no state and behave exactly like plain id keying.
+    expect(store.overrides.size).toBe(0);
+  });
+
+  it("holds the key steady when a tool call appears on an already-streaming message", () => {
+    // Real sequence: TEXT_MESSAGE_START creates the message, TOOL_CALL_START
+    // then mutates that SAME message. Deriving the key from the tool call
+    // would change it here and remount the row.
+    const store = createRowKeyStore();
+
+    const streaming = keyOf(store, [assistant("lc_run--1")], "lc_run--1");
+    const withTool = keyOf(
+      store,
+      [assistant("lc_run--1", [toolCall("call_A")])],
+      "lc_run--1",
+    );
+
+    expect(streaming).toBe("lc_run--1");
+    expect(withTool).toBe("lc_run--1");
+  });
+
+  it("holds the key steady when the snapshot re-keys the message id", () => {
+    const store = createRowKeyStore();
+
+    resolveRowRenderKeys(store, [assistant("lc_run--1", [toolCall("call_A")])]);
+    const afterRekey = keyOf(
+      store,
+      [assistant("resp_1", [toolCall("call_A")])],
+      "resp_1",
+    );
+
+    expect(afterRekey).toBe("lc_run--1");
+  });
+
+  it("holds the key steady across the full streaming sequence", () => {
+    const store = createRowKeyStore();
+
+    const k1 = keyOf(store, [assistant("lc_run--1")], "lc_run--1");
+    const k2 = keyOf(
+      store,
+      [assistant("lc_run--1", [toolCall("call_A")])],
+      "lc_run--1",
+    );
+    const k3 = keyOf(
+      store,
+      [assistant("resp_1", [toolCall("call_A")])],
+      "resp_1",
+    );
+
+    expect(new Set([k1, k2, k3]).size).toBe(1);
+  });
+
+  it("resolves through a surviving anchor when tool calls are reordered", () => {
+    const store = createRowKeyStore();
+
+    resolveRowRenderKeys(store, [
+      assistant("lc_run--1", [toolCall("call_A"), toolCall("call_B")]),
+    ]);
+    // Snapshot re-keys the message AND presents the tool calls in the other
+    // order — anchoring on every tool call (not just the first) survives it.
+    const afterRekey = keyOf(
+      store,
+      [assistant("resp_1", [toolCall("call_B"), toolCall("call_A")])],
+      "resp_1",
+    );
+
+    expect(afterRekey).toBe("lc_run--1");
+  });
+
+  it("keeps a later tool call from stealing an established key", () => {
+    const store = createRowKeyStore();
+
+    resolveRowRenderKeys(store, [assistant("lc_run--1", [toolCall("call_A")])]);
+    // A second tool call arrives on the same row; call_A already owns the key.
+    const keys = resolveRowRenderKeys(store, [
+      assistant("lc_run--1", [toolCall("call_A"), toolCall("call_B")]),
+    ]);
+
+    expect(keys.get("lc_run--1")).toBe("lc_run--1");
+    expect(store.overrides.get("tc:call_B")).toBe("lc_run--1");
+  });
+
+  it("falls back to message.id when two messages share a tool-call id", () => {
+    const store = createRowKeyStore();
+    const messages = [
+      assistant("a-1", [toolCall("call_X")]),
+      assistant("a-2", [toolCall("call_X")]),
+    ];
+
+    const keys = resolveRowRenderKeys(store, messages);
+
+    expect(keys.get("a-1")).toBe("a-1");
+    expect(keys.get("a-2")).toBe("a-2");
+    expect(new Set(keys.values()).size).toBe(2);
+  });
+
+  it("keeps a shared-anchor fallback stable across renders", () => {
+    // The loser of a shared anchor must not drift between renders, or it
+    // remounts on every update.
+    const store = createRowKeyStore();
+    const messages = [
+      assistant("a-1", [toolCall("call_X")]),
+      assistant("a-2", [toolCall("call_X")]),
+    ];
+
+    const first = resolveRowRenderKeys(store, messages);
+    const second = resolveRowRenderKeys(store, messages);
+
+    expect(second.get("a-1")).toBe(first.get("a-1"));
+    expect(second.get("a-2")).toBe(first.get("a-2"));
+  });
+
+  it("disambiguates when an override vends a key equal to a later message's id", () => {
+    // Pathological: the store vends "ghost" for one row, and another message
+    // literally has id "ghost". Keys must still be unique.
+    const store = createRowKeyStore();
+    resolveRowRenderKeys(store, [assistant("ghost", [toolCall("call_X")])]);
+
+    const keys = resolveRowRenderKeys(store, [
+      assistant("live", [toolCall("call_X")]),
+      assistant("ghost"),
+    ]);
+
+    expect(keys.get("live")).toBe("ghost");
+    expect(keys.get("ghost")).not.toBe("ghost");
+    expect(new Set(keys.values()).size).toBe(2);
+  });
+
+  it("is idempotent, so a repeated or abandoned render yields the same keys", () => {
+    const store = createRowKeyStore();
+    const messages = [
+      assistant("a-1", [toolCall("call_A")]),
+      assistant("a-2", [toolCall("call_B")]),
+      user("u-1"),
+    ];
+
+    const first = resolveRowRenderKeys(store, messages);
+    const snapshot = new Map(store.overrides);
+    const second = resolveRowRenderKeys(store, messages);
+
+    expect([...second.entries()]).toEqual([...first.entries()]);
+    expect([...store.overrides.entries()]).toEqual([...snapshot.entries()]);
+  });
+
+  it("does not register anchors for non-assistant roles", () => {
+    const store = createRowKeyStore();
+    const toolMessage = {
+      id: "t-1",
+      role: "tool",
+      content: "ok",
+      toolCallId: "call_A",
+    } as unknown as Message;
+
+    resolveRowRenderKeys(store, [toolMessage]);
+
+    expect(store.overrides.size).toBe(0);
+  });
+
+  it("ignores an empty toolCalls array", () => {
+    const store = createRowKeyStore();
+
+    const keys = resolveRowRenderKeys(store, [assistant("a-1", [])]);
+
+    expect(keys.get("a-1")).toBe("a-1");
+    expect(store.overrides.size).toBe(0);
+  });
+
+  it("still re-keys a text-only message (documented limitation)", () => {
+    // No anchor exists for a text-only message, so nothing can correlate it
+    // across a rename. Recorded so a future change that fixes it is a
+    // deliberate update rather than an accident.
+    const store = createRowKeyStore();
+
+    const before = keyOf(store, [assistant("lc_run--1")], "lc_run--1");
+    const after = keyOf(store, [assistant("resp_1")], "resp_1");
+
+    expect(before).toBe("lc_run--1");
+    expect(after).toBe("resp_1");
+  });
+});
+
+describe("pruneRowKeyStore", () => {
+  it("drops anchors whose messages are gone and keeps live ones", () => {
+    const store = createRowKeyStore();
+    resolveRowRenderKeys(store, [
+      assistant("a-1", [toolCall("call_A")]),
+      assistant("a-2", [toolCall("call_B")]),
+    ]);
+    expect(store.overrides.size).toBe(2);
+
+    pruneRowKeyStore(store, [assistant("a-2", [toolCall("call_B")])]);
+
+    expect([...store.overrides.keys()]).toEqual(["tc:call_B"]);
+  });
+
+  it("bounds the store to the visible list rather than the conversation", () => {
+    const store = createRowKeyStore();
+    for (let i = 0; i < 50; i++) {
+      const live = [assistant(`a-${i}`, [toolCall(`call_${i}`)])];
+      resolveRowRenderKeys(store, live);
+      pruneRowKeyStore(store, live);
+    }
+
+    expect(store.overrides.size).toBe(1);
+  });
+
+  it("preserves the key of a row that survives a prune", () => {
+    const store = createRowKeyStore();
+    const live = [assistant("lc_run--1", [toolCall("call_A")])];
+    resolveRowRenderKeys(store, live);
+    pruneRowKeyStore(store, live);
+
+    // The re-key must still resolve after an intervening prune.
+    const afterRekey = keyOf(
+      store,
+      [assistant("resp_1", [toolCall("call_A")])],
+      "resp_1",
+    );
+
+    expect(afterRekey).toBe("lc_run--1");
+  });
+});

--- a/packages/vue/src/v2/components/chat/rowRenderKeys.ts
+++ b/packages/vue/src/v2/components/chat/rowRenderKeys.ts
@@ -1,0 +1,187 @@
+import type { AssistantMessage, Message } from "@ag-ui/core";
+
+/**
+ * Stable Vue keys for chat rows, across backends that re-key a message
+ * mid-stream.
+ *
+ * ## The problem
+ *
+ * A message's canonical `id` is not stable within a turn. LangChain stamps a
+ * placeholder id on the first streamed chunk when the provider didn't supply
+ * one (`chat_models.py`: `if chunk.message.id is None: chunk.message.id =
+ * "lc_run-" + "-" + run_id`), then prefers any provider-assigned id it sees
+ * while merging chunks (`messages/ai.py`, "Ranks are defined by the order of
+ * preference"). The `MESSAGES_SNAPSHOT` therefore carries the provider's final
+ * id (e.g. `resp_…`) for a message the client already knows as `lc_run--…`.
+ *
+ * Keying rows by `id` makes Vue tear down and recreate the row on that swap —
+ * the visible HITL chat flash, where a rendered approval card appears to reset
+ * during a tool's `executing → complete` transition.
+ *
+ * This is provider-conditional: providers that stamp an id on every chunk (so
+ * `chunk.message.id is None` never holds) never trigger a rename.
+ *
+ * ## The approach
+ *
+ * Tool-call ids survive the rename, so they are used as *anchors*: the first
+ * message seen carrying a given tool call records the row key it was assigned,
+ * and any later message carrying that same tool call reuses it. The store is an
+ * override table consulted before falling back to `message.id`:
+ *
+ * ```text
+ * render 1  id=lc_run--1  no tools    key = message.id = lc_run--1     store {}
+ * render 2  id=lc_run--1  tc call_A   key = message.id = lc_run--1     store { tc:call_A -> lc_run--1 }
+ * render 3  id=resp_1     tc call_A   key = store[tc:call_A]           store unchanged
+ *                                         = lc_run--1  (no teardown)
+ * ```
+ *
+ * Registering the anchor at render 2 — while the id is still stable — is what
+ * makes render 3 resolvable. The fix does not depend on render 2 existing: a
+ * message born already carrying a tool call registers its anchor on the render
+ * that first shows it, under whatever id it holds then.
+ *
+ * ## Why an override table rather than keying rows by tool-call id
+ *
+ * Deriving the key from the tool call directly (`tc:<id>` whenever a tool call
+ * is present) needs no state, but changes the key the moment a tool call
+ * *appears* — so an assistant message that streams text and then calls a tool
+ * is torn down on that transition, for every provider, whether or not it
+ * renames. That trades a conditional flash for an unconditional one. Recording
+ * an override keeps the key the row already had.
+ *
+ * ## Cost
+ *
+ * The store holds only `tc:<toolCallId>` entries, so a conversation with no
+ * tool calls keeps an empty store and behaviour identical to keying by `id`.
+ * Size is bounded to the tool calls of the currently-rendered messages (see
+ * `pruneRowKeyStore`), not the conversation length.
+ *
+ * ## Known gaps
+ *
+ * - A text-only assistant message has no anchor, so it is still torn down when
+ *   re-keyed. No client-side correlation signal exists for it; the fix is
+ *   stable ids upstream.
+ * - If the tool call's arrival and the id swap land in the same render pass,
+ *   the intermediate state never renders, the anchor is never registered, and
+ *   the row is torn down as before.
+ *
+ * Kept per-package (rather than shared) to match how `deduplicateMessages` is
+ * handled across the framework packages. The React and Angular ports carry the
+ * same logic; changes here should be mirrored there.
+ */
+
+const TOOL_ANCHOR_PREFIX = "tc:";
+
+export interface RowKeyStore {
+  /**
+   * `tc:<toolCallId>` → the row key first assigned to a message carrying that
+   * tool call. Populated only for assistant messages that carry tool calls.
+   */
+  overrides: Map<string, string>;
+}
+
+export function createRowKeyStore(): RowKeyStore {
+  return { overrides: new Map() };
+}
+
+/**
+ * Anchors a message contributes. Only assistant tool calls qualify: LangChain's
+ * id preference applies when merging `AIMessageChunk`s, so user message ids are
+ * not renamed, and `role: "tool"` messages are not rendered as rows. Every tool
+ * call is used (not just the first) so the anchor survives tool-call reordering
+ * between snapshots.
+ */
+function toolAnchorsOf(message: Message): string[] {
+  if (message.role !== "assistant") return [];
+  const toolCalls = (message as AssistantMessage).toolCalls;
+  if (!toolCalls?.length) return [];
+
+  const anchors: string[] = [];
+  for (const toolCall of toolCalls) {
+    if (toolCall?.id) anchors.push(`${TOOL_ANCHOR_PREFIX}${toolCall.id}`);
+  }
+  return anchors;
+}
+
+/**
+ * Resolves `message.id` → row key for one render pass.
+ *
+ * Mutates `store` additively — it registers anchors but never removes them, so
+ * the call is idempotent for a given message list. That matters because this
+ * runs inside a `computed`, which Vue may re-evaluate: re-running yields the
+ * same keys. Removal happens in `pruneRowKeyStore` after the DOM has been
+ * patched, never during evaluation, so an anchor the rendered rows still need
+ * can't be dropped out from under them.
+ *
+ * `messages` must be deduplicated: duplicate ids would overwrite each other in
+ * the returned map. Iteration order is significant — the first message to claim
+ * a key keeps it.
+ */
+export function resolveRowRenderKeys(
+  store: RowKeyStore,
+  messages: Message[],
+): Map<string, string> {
+  const keys = new Map<string, string>();
+  const claimed = new Set<string>();
+
+  for (const message of messages) {
+    const anchors = toolAnchorsOf(message);
+
+    // Reuse the key recorded for any of this message's anchors. An override
+    // pointing at a key another row already claimed this pass is skipped: two
+    // messages can share a tool-call id (upstream bug, or replayed state), and
+    // the later one falls back to its own id instead.
+    let key: string | undefined;
+    for (const anchor of anchors) {
+      const recorded = store.overrides.get(anchor);
+      if (recorded !== undefined && !claimed.has(recorded)) {
+        key = recorded;
+        break;
+      }
+    }
+
+    key ??= message.id;
+
+    // Backstop for a pathological collision: an override vends a key equal to
+    // a later message's own id. Deduplicated ids can't collide with each other,
+    // so this only triggers against an override-supplied key.
+    if (claimed.has(key)) {
+      let suffix = 2;
+      while (claimed.has(`${key}:${suffix}`)) suffix += 1;
+      key = `${key}:${suffix}`;
+    }
+
+    keys.set(message.id, key);
+    claimed.add(key);
+
+    // First claimant of an anchor owns it, so a re-keyed message resolves to
+    // the key the row already had rather than overwriting it.
+    for (const anchor of anchors) {
+      if (!store.overrides.has(anchor)) store.overrides.set(anchor, key);
+    }
+  }
+
+  return keys;
+}
+
+/**
+ * Drops anchors no longer present in `messages`, bounding the store to the tool
+ * calls of the currently-rendered messages. Call after the DOM is patched (a
+ * post-flush watcher), never during `computed` evaluation.
+ *
+ * Pruned entries are unreachable by construction: `resolveRowRenderKeys` only
+ * looks up anchors belonging to messages in the list it is given.
+ */
+export function pruneRowKeyStore(
+  store: RowKeyStore,
+  messages: Message[],
+): void {
+  const live = new Set<string>();
+  for (const message of messages) {
+    for (const anchor of toolAnchorsOf(message)) live.add(anchor);
+  }
+
+  for (const anchor of store.overrides.keys()) {
+    if (!live.has(anchor)) store.overrides.delete(anchor);
+  }
+}


### PR DESCRIPTION
## Summary

Chat rows were keyed by `message.id` in all three frontends, but **a message's canonical id is not stable within a turn**. When the id swaps mid-stream, React/Vue/Angular unmount and rebuild the row — the visible flash where a rendered HITL approval card appears to reset during a tool's `executing → complete` transition.

Fixes it in `react-core`, `vue`, and `angular`. Supersedes #5340 and #5354, and makes ag-ui-protocol/ag-ui#1908 unnecessary. Relates to FOR-131.

## Root cause (verified in LangChain source, not inferred)

Two deliberate LangChain behaviours combine:

1. `language_models/chat_models.py` stamps a placeholder id on the first streamed chunk **only when the provider supplied none**:
   ```python
   run_id = "-".join((LC_ID_PREFIX, str(run_manager.run_id)))
   for chunk in self._stream(...):
       if chunk.message.id is None:
           chunk.message.id = run_id
   ```
   With `LC_ID_PREFIX = "lc_run-"` (`utils/utils.py:498`), joining on `"-"` produces the doubled dash in `lc_run--019eb164…` — matching the id in the SSE capture on #5354.

2. `messages/ai.py` then **prefers** any provider-assigned id while merging chunks:
   ```python
   # Ranks are defined by the order of preference. Higher is better:
   # 2. Provider-assigned IDs (non lc_* and non lc_run-*)
   # 1. lc_run-* IDs
   # 0. lc_* and other remaining IDs
   ...
   if not id_.startswith(LC_ID_PREFIX) and not id_.startswith(LC_AUTO_PREFIX):
       chunk_id = id_
       break  # highest rank, return instantly
   ```

So the `MESSAGES_SNAPSHOT` carries the provider's final `resp_…` id for a message the client already knows as `lc_run--…`. AG-UI's snapshot merge drops the old-id message and appends the new one (`sdks/typescript/packages/client/src/apply/default.ts`), so the row re-keys and remounts.

Two consequences worth recording:

- **It's provider-conditional.** `if chunk.message.id is None` means providers that stamp an id on every chunk (OpenAI chat completions → `chatcmpl-…` from chunk 1) never rename. The reported `resp_…` ids are the OpenAI Responses API.
- **There is nothing to wait for upstream.** From LangChain's perspective the final message correctly carries the provider's id — there's no defect to fix. Confirmed unchanged in `langchain_core` **1.5.1** (published 2026-07-23) as well as **1.3.2** (what `examples/integrations/langgraph-python` installs); the placeholder assignment has in fact spread from three call sites to four.

## Approach

Tool-call ids survive the rename, so they're used as **anchors** in an override table: the first message seen carrying a given tool call records the row key it was assigned, and any later message carrying that same tool call reuses it.

```text
render 1  id=lc_run--1  no tools    key = message.id = lc_run--1     store {}
render 2  id=lc_run--1  tc call_A   key = message.id = lc_run--1     store { tc:call_A -> lc_run--1 }
render 3  id=resp_1     tc call_A   key = store[tc:call_A]           store unchanged
                                       = lc_run--1  (no remount)
```

Registering the anchor at render 2 — while the id is still stable — is what makes render 3 resolvable. The fix doesn't depend on render 2 existing: a message born already carrying a tool call registers its anchor on the render that first shows it.

**Why an override table rather than just keying rows by tool-call id.** Deriving the key from the tool call directly (`tc:<id>` whenever a tool call is present) needs no state, but it changes the key the moment a tool call *appears* — so an assistant message that streams text and *then* calls a tool remounts on that transition, **for every provider, whether or not it renames**. That trades a conditional flash for an unconditional one. This is exactly what #5354 does; a probe test on that branch remounts with the id held constant at `lc_run--1` throughout, while the same probe passes on `main`. Recording an override keeps the key the row already had.

**Cost is zero for unaffected users.** The store holds only `tc:<toolCallId>` entries, so a conversation with no tool calls keeps an **empty store and behaviour byte-identical to plain `id` keying**. Size is bounded to the tool calls of the currently-rendered messages, not the conversation length. Delete the store and you get today's behaviour.

**Render-phase purity.** Key resolution mutates the store *additively* and is idempotent, so React StrictMode double-renders and abandoned concurrent renders are safe. Pruning happens after commit — `useEffect` / post-flush `watch` / `afterRenderEffect` — never during render, because dropping an anchor a committed row still needs would re-mint its key and remount it.

### Per-framework wiring

| | store | keys resolved | pruned |
|---|---|---|---|
| react-core | `useRef` | `useMemo` | `useEffect` |
| vue | setup-scope object | `computed` | `watch(…, { flush: "post" })` |
| angular | instance field | `computed` | `afterRenderEffect` |

Kept as a per-package copy rather than a shared helper, matching how `deduplicateMessages` is already handled (react-core exports one, Vue has its own reimplementation). Each file's docs cross-reference the others.

**One deliberate divergence:** the Angular port returns keys **by position** rather than keyed by `message.id`. React and Vue deduplicate before rendering; Angular does not (`messagesValue = computed(() => this.messages())`), so a duplicate id would collapse two rows into one lookup and hand `@for` the same track value twice — which Angular reports as an error. Positional keys make uniqueness structural, and the previous `index-N` fallback for an id-less message is preserved.

## Known limitations (each pinned by a test, so changing them is deliberate)

- **Text-only assistant messages still re-key.** They have no anchor, and no client-side correlation signal exists for them. The fix would be stable ids upstream.
- **Same-batch arrival.** If the tool call and the id swap land in the same render pass, the intermediate state never renders, the anchor is never registered, and the row remounts as before. Correlating in the AG-UI client's event-apply layer (which observes every intermediate state) would be immune — that's the trigger for revisiting the `renderId` approach if this ever bites in practice.

## Testing

**Rebased onto current `main`** (was 2106 commits behind; applied with no conflicts). All three target files had moved on `main` since the branch point, so the numbers below are from re-running everything post-rebase — not from the original branch point.

A differential against a **pristine `origin/main` worktree in the identical environment** shows **0 new failures and 0 fixed** among pre-existing tests. That comparison matters: symlinked `node_modules` in a worktree resolves a stale `@copilotkit/shared` dist, which fails ~800 tests on pristine `main` too. All counts below are from an environment with the workspace deps built locally.

`main`'s `eee580f6da` (collapse duplicate tool-call ids) landed in the same function neighbourhood and is complementary, not conflicting: it collapses duplicate ids *within* a message, while these anchors are consumed after dedup, and cross-message shared tool-call ids are covered by the `claimed`-set guard plus the suffix backstop.

Verified per package. `oxfmt` produced no changes (files already conformant); `oxlint` reports 0 errors (the component's 4 warnings are pre-existing on `main`).

| package | logic tests | component tests | full suite | typecheck |
|---|---|---|---|---|
| react-core | 16/16 | 8/8 | **1576 pass / 137 files** | 0 errors (`tsc --noEmit`) |
| vue | 16/16 | 6/6 | **1114 pass / 103 files** | 0 errors (`vue-tsc`) |
| angular | 19/19 | n/a (package has none) | **153 pass** (134 on `main` + 19 new) | 0 errors + ngc template gate |

<details>
<summary>react-core — full suite</summary>

```
 Test Files  136 passed | 1 skipped (137)
      Tests  1576 passed | 2 skipped (1578)
```
</details>

<details>
<summary>vue — full suite</summary>

```
 Test Files  103 passed (103)
      Tests  1114 passed (1114)
```
</details>

<details>
<summary>angular — helper logic (19 tests)</summary>

```
 ✓ src/lib/components/chat/__tests__/row-render-keys.spec.ts (19 tests) 3ms
 Test Files  1 passed (1)
      Tests  19 passed (19)
```
</details>

**Regression coverage for the two transitions.** Probe tests assert DOM node identity across a rerender. Both pass here; the text→tool-call one fails on #5354's approach:

```
✓ does not remount when a tool call arrives on an already-streaming message
✓ reconciles in place when the message id changes but a tool call is stable
✓ survives the whole sequence: text, then tool call, then id re-key
```

**The Vue component tests are proven non-vacuous.** Reverting only the `:key` expression back to `message.id` makes 3 of 6 fail; restoring it makes them pass:

```
=== with key reverted to message.id (main's behaviour) ===
     × reuses the row when the message id changes but a tool call is stable
     ✓ does not tear down the row when a tool call arrives mid-stream
     × survives the whole sequence: text, then tool call, then id re-key
     ✓ tears down a text-only row on an id change (documented limitation)
     ✓ renders both rows when a tool-call id is shared
     × keeps the first row when the list grows around it
 Tests  3 failed | 3 passed (6)

=== restored ===
 Tests  6 passed (6)
```

Also repairs a pre-existing **vacuous assertion** in `CopilotChatMessageView.test.tsx`: it filtered console output for `"duplicate key"`, but React's wording is `"two children with the same key"`, so it never fired. Now matches the real message and still passes.

### Angular port — now verified locally (previous caveat resolved)

An earlier revision of this description said the Angular tests could not be run locally and that CI was the real gate. **The tests now run, and the template expression is now gated locally.** Two separate local-workspace problems were in the way, both install state rather than config: the analog plugin resolves once the package's `node_modules` is wired to a complete workspace, and `ngc` needed a missing `@copilotkit/web-inspector` link.

- **Helper logic: 19/19 passing.** Full package suite goes 134 → 153 tests, i.e. exactly the 19 new ones, with the same 23 environment-broken files as a pristine `main` baseline (missing `axe-core`, unresolvable `web-inspector` — install state, present on both sides).
- **The template expression is now gated.** `tsc --noEmit` is clean and `ng-packagr -p ng-package.json -c tsconfig.json` builds clean, which type-checks `track rowRenderKey($index, message)` through `ngc`.
- **That gate is proven non-vacuous.** Renaming the method in the template only:

```
$ sed -i 's/track rowRenderKey(/track rowRenderKeyTYPO(/' copilot-chat-message-view.ts
src/lib/components/chat/copilot-chat-message-view.ts:60:49 - error TS2551:
  Property 'rowRenderKeyTYPO' does not exist on type 'CopilotChatMessageView'.
  Did you mean 'rowRenderKey'?

$ # restored
Built Angular Package
```

- **The three helpers are mutation-checked** post-rebase, not just green. Reverting the row key to `message.id` fails 3/8 react-core component tests and 3/6 Vue ones; disabling anchor reuse in the Angular helper fails 5/19. All pass restored.

To be precise about what remains thinner on Angular than on the other two: the `afterRenderEffect` prune is type-checked and compiles, but the package has no component tests, so its *runtime* behaviour is not covered the way react-core's `useEffect` prune and Vue's post-flush `watch` are. The prune is a bounded-size optimisation whose entries are unreachable by construction, so the blast radius if it misbehaved is store growth, not wrong keys.

**Still unverified: the live end-to-end flash.** Everything above proves the mechanism via DOM-node-identity probes across the exact id-swap sequence; nobody has yet watched a real LangGraph + OpenAI Responses API turn to confirm the HITL card visibly stops resetting. That is the one thing worth a manual look before merge.

## Follow-ups (not in this PR)

- **Angular has no message deduplication** — pre-existing, and a real latent bug now that `@for` errors on duplicated track values. Deserves its own fix; deliberately left out to keep this scoped.
- Close #5340, #5354, and ag-ui-protocol/ag-ui#1908 once this lands. Note ag-ui#1908 also lacks a key-uniqueness guard: two rows can inherit the same `renderId`, which reproduces 3 React duplicate-key errors.
- If the same-batch limitation ever matters in practice, revive the `renderId` approach in the AG-UI client (with the uniqueness guard added) and delete these three helpers in favour of a one-line `renderId ?? id` per framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

