### PR TITLE
fix(release): make canary publishes reachable and cross-scope composable

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -30,13 +30,20 @@ on:
   workflow_dispatch:
     inputs:
       scope:
-        description: "Package scope to publish a canary for. Regenerated from release.config.json — do NOT hand-edit (the release-scope-dropdown-sync CI guard enforces parity)."
+        description: "Package scope to publish a canary for, or 'all' when the change spans scopes (e.g. runtime↔channels). Regenerated from release.config.json — do NOT hand-edit (the release-scope-dropdown-sync CI guard enforces parity)."
         required: true
         type: choice
         options:
           - monorepo
           - angular
           - channels
+          # Sentinel, not a scope (see ALL_SCOPES in scripts/release/lib/config.ts):
+          # publishes every scope from this commit under one shared canary id.
+          # Required whenever the change spans scopes, because cross-scope
+          # `workspace:` deps (e.g. @copilotkit/runtime -> @copilotkit/channels-intelligence)
+          # are packed against whatever is in the tree — a single-scope canary
+          # pins them to the other scope's last STABLE release.
+          - all
       suffix:
         description: "Prerelease suffix (e.g. 'fix-user-issue'); blank = unix timestamp. Allowed: [a-zA-Z0-9._-]+. Reuse a suffix only if the base version moved, else the publish collides."
         required: false

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -33,13 +33,18 @@ on:
   workflow_dispatch:
     inputs:
       scope:
-        description: "What to release"
+        description: "What to release ('all' is prerelease-only: every scope under one shared canary id)"
         required: true
         type: choice
         options:
           - monorepo
           - angular
           - channels
+          # Sentinel, not a scope (see ALL_SCOPES in scripts/release/lib/config.ts).
+          # PRERELEASE ONLY — rejected for mode=stable by the "Determine scope and
+          # mode" guard below, since a stable release derives its tag, release
+          # branch, and Slack/npm links from a single scope name.
+          - all
       mode:
         description: "Release mode: stable (full release with tag + GH Release) or prerelease (canary, no tag/release)"
         required: false
@@ -113,6 +118,15 @@ jobs:
             SCOPE="${SCOPE%%/v*}"
           fi
           MODE="${INPUT_MODE:-stable}"
+          # `all` is a prerelease-only selector: it publishes every scope under one
+          # shared canary id so cross-scope `workspace:` deps resolve within the run.
+          # A stable release cannot be multi-scope — the tag (`<scope>/v<version>`),
+          # the release branch, and the notify job's npm URL each assume ONE scope,
+          # and the scopes carry independent version lines.
+          if [ "$SCOPE" = "all" ] && [ "$MODE" != "prerelease" ]; then
+            echo "::error::scope=all is only valid with mode=prerelease (canary). Release each scope separately via the 'release / create-pr' workflow."
+            exit 1
+          fi
           echo "scope=$SCOPE" >> "$GITHUB_OUTPUT"
           echo "mode=$MODE"   >> "$GITHUB_OUTPUT"
           echo "Detected scope: $SCOPE, mode: $MODE"
@@ -221,6 +235,13 @@ jobs:
             exit 1
           fi
           MODE="${INPUT_MODE:-stable}"
+          # Same guard as the build job (this job re-derives scope/mode from the
+          # event rather than inheriting them). Defense in depth: nothing may reach
+          # the tag/GH-Release/notify path with the multi-scope sentinel.
+          if [ "$SCOPE" = "all" ] && [ "$MODE" != "prerelease" ]; then
+            echo "::error::scope=all is only valid with mode=prerelease (canary)."
+            exit 1
+          fi
           echo "scope=$SCOPE" >> "$GITHUB_OUTPUT"
           echo "mode=$MODE"   >> "$GITHUB_OUTPUT"
 
@@ -416,7 +437,9 @@ jobs:
             echo "## Prerelease Published"
             echo ""
             echo "**Scope:** ${{ steps.meta.outputs.scope }}"
-            echo "**Version:** ${{ steps.publish.outputs.version }}"
+            # `versions` lists every published scope (`<scope>@<version>`), which is
+            # the whole story for scope=all; `version` alone names only the first.
+            echo "**Versions:** ${{ steps.publish.outputs.versions || steps.publish.outputs.version }}"
             echo "**Tag:** (prerelease — no tag created)"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/scripts/release/bump-prerelease.ts
+++ b/scripts/release/bump-prerelease.ts
@@ -16,7 +16,7 @@ import {
   computePrereleaseVersion,
   resolvePrereleaseId,
   bumpPackages,
-  findCrossScopeWorkspaceDeps,
+  findCrossScopePins,
 } from "./lib/versions.js";
 import { ALL_SCOPES, loadConfig, resolveScopes } from "./lib/config.js";
 
@@ -24,10 +24,8 @@ import { ALL_SCOPES, loadConfig, resolveScopes } from "./lib/config.js";
 const VALID_SCOPES = Object.keys(loadConfig().scopes);
 
 /**
- * Warn about dependency edges leaving the published set. `pnpm pack` pins them
- * to the dependency's current working-tree version — the other scope's last
- * stable release — so the canary only composes with THAT release. Silent before
- * this warning existed: a `monorepo` canary of a commit that changed the
+ * Warn about cross-scope pins that won't carry a version from this run. Silent
+ * before this warning existed: a `monorepo` canary of a commit that changed the
  * runtime↔channels contract shipped pinned to the pre-change channels release,
  * and the mismatch only surfaced as a TypeError in a consumer's app.
  *
@@ -35,15 +33,19 @@ const VALID_SCOPES = Object.keys(loadConfig().scopes);
  * the change doesn't cross the edge.
  */
 function warnOnCrossScopePins(scopes: ReturnType<typeof resolveScopes>): void {
-  const crossScope = findCrossScopeWorkspaceDeps(scopes);
-  if (crossScope.length === 0) return;
+  const pins = findCrossScopePins(scopes);
+  if (pins.length === 0) return;
 
   console.log(
-    `\n${crossScope.length} dependency edge(s) leave this publish and will be pinned to already-released versions:`,
+    `\n${pins.length} cross-scope pin(s) will NOT carry a version from this publish:`,
   );
-  for (const edge of crossScope) {
+  for (const pin of pins) {
+    const remedy =
+      pin.reason === "literal-range"
+        ? `That range is written literally in ${pin.from}'s package.json, so no bump rewrites it — scope=${ALL_SCOPES} does NOT fix this. Convert the dep to the workspace: protocol.`
+        : `If this commit changed both sides, re-run the canary with scope=${ALL_SCOPES}.`;
     console.log(
-      `::warning::${edge.from} depends on ${edge.dep} (scope "${edge.depScope}", not part of this publish) — the packed tarball pins ${edge.dep}@${edge.resolvesTo}, so this canary is only usable with that release. If this commit changed both sides, re-run the canary with scope=${ALL_SCOPES}.`,
+      `::warning::${pin.from} depends on ${pin.dep} (scope "${pin.depScope}") — the published manifest will pin ${pin.dep}@${pin.resolvesTo}, so this canary is only usable with that release. ${remedy}`,
     );
   }
 }

--- a/scripts/release/bump-prerelease.ts
+++ b/scripts/release/bump-prerelease.ts
@@ -5,51 +5,98 @@
  * the build, in a job that has no access to NPM_TOKEN or other publish secrets.
  * The publish job then receives pre-built, correctly-versioned artifacts.
  *
- * Usage: tsx scripts/release/bump-prerelease.ts --scope <scope from release.config.json> [--suffix <label>]
+ * Every scope bumped in one invocation shares a single prerelease id, so a
+ * multi-scope canary is one identifiable set of versions.
+ *
+ * Usage: tsx scripts/release/bump-prerelease.ts --scope <scope from release.config.json | all> [--suffix <label>]
  */
 
 import {
   getCurrentVersion,
   computePrereleaseVersion,
+  resolvePrereleaseId,
   bumpPackages,
-  getPackagesForScope,
+  findCrossScopeWorkspaceDeps,
 } from "./lib/versions.js";
-import { loadConfig, type ReleaseScope } from "./lib/config.js";
+import { ALL_SCOPES, loadConfig, resolveScopes } from "./lib/config.js";
 
 // Valid scopes come from release.config.json — the single source of truth.
 const VALID_SCOPES = Object.keys(loadConfig().scopes);
+
+/**
+ * Warn about dependency edges leaving the published set. `pnpm pack` pins them
+ * to the dependency's current working-tree version — the other scope's last
+ * stable release — so the canary only composes with THAT release. Silent before
+ * this warning existed: a `monorepo` canary of a commit that changed the
+ * runtime↔channels contract shipped pinned to the pre-change channels release,
+ * and the mismatch only surfaced as a TypeError in a consumer's app.
+ *
+ * A warning, not a failure: a single-scope canary is still the right call when
+ * the change doesn't cross the edge.
+ */
+function warnOnCrossScopePins(scopes: ReturnType<typeof resolveScopes>): void {
+  const crossScope = findCrossScopeWorkspaceDeps(scopes);
+  if (crossScope.length === 0) return;
+
+  console.log(
+    `\n${crossScope.length} dependency edge(s) leave this publish and will be pinned to already-released versions:`,
+  );
+  for (const edge of crossScope) {
+    console.log(
+      `::warning::${edge.from} depends on ${edge.dep} (scope "${edge.depScope}", not part of this publish) — the packed tarball pins ${edge.dep}@${edge.resolvesTo}, so this canary is only usable with that release. If this commit changed both sides, re-run the canary with scope=${ALL_SCOPES}.`,
+    );
+  }
+}
 
 function main() {
   const argv = process.argv.slice(2);
   const suffixIdx = argv.indexOf("--suffix");
   const suffix = suffixIdx !== -1 ? argv[suffixIdx + 1] : undefined;
   const scopeIdx = argv.indexOf("--scope");
-  const scope = (
-    scopeIdx !== -1 ? argv[scopeIdx + 1] : null
-  ) as ReleaseScope | null;
+  const selector = scopeIdx !== -1 ? argv[scopeIdx + 1] : null;
 
-  if (!scope || !VALID_SCOPES.includes(scope)) {
+  if (!selector) {
     console.error(
-      `Usage: bump-prerelease.ts --scope <${VALID_SCOPES.join("|")}> [--suffix <label>]`,
+      `Usage: bump-prerelease.ts --scope <${[...VALID_SCOPES, ALL_SCOPES].join("|")}> [--suffix <label>]`,
     );
     process.exit(1);
   }
 
-  const config = loadConfig();
-  const distTag = config.prereleaseTag;
-  const currentVersion = getCurrentVersion(scope);
-  const prereleaseVersion = computePrereleaseVersion(currentVersion, suffix);
-  console.log(`Scope: ${scope}`);
-  console.log(`Current version: ${currentVersion}`);
-  console.log(`Prerelease version: ${prereleaseVersion}`);
+  let scopes: ReturnType<typeof resolveScopes>;
+  try {
+    scopes = resolveScopes(selector);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    console.error(
+      `Usage: bump-prerelease.ts --scope <${[...VALID_SCOPES, ALL_SCOPES].join("|")}> [--suffix <label>]`,
+    );
+    process.exit(1);
+  }
+
+  const distTag = loadConfig().prereleaseTag;
+  // One id for every scope in this run (see resolvePrereleaseId).
+  const id = resolvePrereleaseId(suffix);
+  console.log(`Scope: ${selector} -> ${scopes.join(", ")}`);
+  console.log(`Prerelease id: ${id}`);
   console.log(`Dist tag: ${distTag}`);
 
-  // Bump versions in working directory (no commit)
-  const updated = bumpPackages(scope, prereleaseVersion);
-  console.log(`\nBumped ${updated.length} packages to ${prereleaseVersion}`);
-  for (const p of updated) {
-    console.log(`  ${p.name}: ${p.oldVersion} -> ${p.newVersion}`);
+  for (const scope of scopes) {
+    const currentVersion = getCurrentVersion(scope);
+    const prereleaseVersion = computePrereleaseVersion(currentVersion, id);
+    console.log(
+      `\n[${scope}] current version: ${currentVersion} -> prerelease version: ${prereleaseVersion}`,
+    );
+
+    // Bump versions in working directory (no commit)
+    const updated = bumpPackages(scope, prereleaseVersion);
+    console.log(`Bumped ${updated.length} packages to ${prereleaseVersion}`);
+    for (const p of updated) {
+      console.log(`  ${p.name}: ${p.oldVersion} -> ${p.newVersion}`);
+    }
   }
+
+  // After every bump: the surviving cross-scope pins are now final.
+  warnOnCrossScopePins(scopes);
 }
 
 main();

--- a/scripts/release/lib/config.test.ts
+++ b/scripts/release/lib/config.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { getScopeConfig } from "./config.js";
+import {
+  ALL_SCOPES,
+  getScopeConfig,
+  loadConfig,
+  resolveScopes,
+} from "./config.js";
 import { getPackagesForScope } from "./versions.js";
 
 const CHANNELS_PACKAGES = [
@@ -27,5 +32,27 @@ describe("Channels release scope", () => {
     expect(getPackagesForScope("channels").map((pkg) => pkg.name)).toEqual(
       CHANNELS_PACKAGES,
     );
+  });
+});
+
+describe("resolveScopes", () => {
+  it("resolves a single scope to itself", () => {
+    expect(resolveScopes("channels")).toEqual(["channels"]);
+  });
+
+  it("expands the all sentinel to every configured scope, in config order", () => {
+    expect(resolveScopes(ALL_SCOPES)).toEqual(Object.keys(loadConfig().scopes));
+  });
+
+  it("rejects an unknown scope and names the valid selectors", () => {
+    expect(() => resolveScopes("runtime")).toThrow(
+      /Unknown scope: runtime\. Valid scopes: .*channels, all/,
+    );
+  });
+
+  // "all" is a selector, never a scope: a scope named `all` in
+  // release.config.json would make the sentinel ambiguous.
+  it("keeps the sentinel out of the configured scope names", () => {
+    expect(Object.keys(loadConfig().scopes)).not.toContain(ALL_SCOPES);
   });
 });

--- a/scripts/release/lib/config.ts
+++ b/scripts/release/lib/config.ts
@@ -25,6 +25,36 @@ export function loadConfig(): ReleaseConfig {
   return JSON.parse(fs.readFileSync(configPath, "utf8"));
 }
 
+/**
+ * Sentinel `scope` value selecting EVERY scope in release.config.json.
+ *
+ * Canary-only (the stable lane derives its tag and release branch from a single
+ * scope name). It exists because scopes are only independent on the version
+ * axis, not the dependency axis: `@copilotkit/runtime` carries
+ * `"@copilotkit/channels-intelligence": "workspace:*"`, and `pnpm pack`
+ * rewrites that against whatever is in the working tree. A canary of one scope
+ * therefore ships pinned to the OTHER scope's last stable release, which is a
+ * broken combination whenever the change spans both. Publishing every scope
+ * from one commit rewrites those pins to same-run canary versions instead.
+ */
+export const ALL_SCOPES = "all";
+
+/**
+ * Resolve a dispatched `scope` input into the concrete scopes to act on:
+ * {@link ALL_SCOPES} expands to every scope in release.config.json order, any
+ * other value must name exactly one scope.
+ */
+export function resolveScopes(selector: string): ReleaseScope[] {
+  const scopes = Object.keys(loadConfig().scopes) as ReleaseScope[];
+  if (selector === ALL_SCOPES) return scopes;
+  if (!scopes.includes(selector as ReleaseScope)) {
+    throw new Error(
+      `Unknown scope: ${selector}. Valid scopes: ${[...scopes, ALL_SCOPES].join(", ")}`,
+    );
+  }
+  return [selector as ReleaseScope];
+}
+
 export function getScopeConfig(scope: ReleaseScope): ScopeConfig {
   const config = loadConfig();
   const scopeConfig = config.scopes[scope];

--- a/scripts/release/lib/versions.test.ts
+++ b/scripts/release/lib/versions.test.ts
@@ -8,7 +8,7 @@ import {
   computePrereleaseVersion,
   resolvePrereleaseId,
   bumpPackages,
-  findCrossScopeWorkspaceDeps,
+  findCrossScopePins,
   getPackagesForScope,
 } from "./versions.js";
 
@@ -264,7 +264,7 @@ describe("bumpPackages", () => {
 // a package in one release scope carrying a workspace: dep on a package owned by
 // another. pnpm pack pins those to the working-tree version, so a canary of only
 // the depending scope ships against the OTHER scope's last stable release.
-describe("findCrossScopeWorkspaceDeps", () => {
+describe("findCrossScopePins", () => {
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "release-test-"));
     const packagesDir = path.join(tmpDir, "packages");
@@ -294,23 +294,48 @@ describe("findCrossScopeWorkspaceDeps", () => {
   });
 
   it("reports the version a dependency outside the published scopes pins to", () => {
-    expect(findCrossScopeWorkspaceDeps(["monorepo"])).toEqual([
+    expect(findCrossScopePins(["monorepo"])).toEqual([
       {
         from: "@copilotkit/react-core",
         dep: "@copilotkit/angular",
         depScope: "angular",
         resolvesTo: "0.2.0",
+        reason: "unpublished-scope",
       },
     ]);
   });
 
   it("reports nothing once every scope on the edge is published together", () => {
-    expect(findCrossScopeWorkspaceDeps(["monorepo", "angular"])).toEqual([]);
+    expect(findCrossScopePins(["monorepo", "angular"])).toEqual([]);
   });
 
   it("ignores in-scope deps and third-party ranges", () => {
-    const found = findCrossScopeWorkspaceDeps(["monorepo"]);
-    expect(found.map((edge) => edge.dep)).not.toContain("@copilotkit/shared");
-    expect(found.map((edge) => edge.dep)).not.toContain("some-third-party");
+    const found = findCrossScopePins(["monorepo"]);
+    expect(found.map((pin) => pin.dep)).not.toContain("@copilotkit/shared");
+    expect(found.map((pin) => pin.dep)).not.toContain("some-third-party");
+  });
+
+  // bumpPackages rewrites literal ranges for in-scope packages only, so a literal
+  // cross-scope range survives every bump — publishing both scopes together does
+  // NOT make it carry this run's version, which is why it reports even then.
+  it("reports a literal cross-scope range even when both scopes are published", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "packages/react-core/package.json"),
+      JSON.stringify({
+        name: "@copilotkit/react-core",
+        version: "1.55.2",
+        dependencies: { "@copilotkit/angular": "^0.2.0" },
+      }),
+    );
+
+    expect(findCrossScopePins(["monorepo", "angular"])).toEqual([
+      {
+        from: "@copilotkit/react-core",
+        dep: "@copilotkit/angular",
+        depScope: "angular",
+        resolvesTo: "^0.2.0",
+        reason: "literal-range",
+      },
+    ]);
   });
 });

--- a/scripts/release/lib/versions.test.ts
+++ b/scripts/release/lib/versions.test.ts
@@ -6,7 +6,9 @@ import {
   parseSemver,
   computeNextStableVersion,
   computePrereleaseVersion,
+  resolvePrereleaseId,
   bumpPackages,
+  findCrossScopeWorkspaceDeps,
   getPackagesForScope,
 } from "./versions.js";
 
@@ -118,28 +120,49 @@ describe("computeNextStableVersion", () => {
   });
 });
 
+describe("resolvePrereleaseId", () => {
+  it("uses the supplied suffix verbatim", () => {
+    expect(resolvePrereleaseId("fix-user-issue")).toBe("fix-user-issue");
+  });
+
+  it("falls back to a unix timestamp", () => {
+    expect(resolvePrereleaseId()).toMatch(/^\d+$/);
+    expect(resolvePrereleaseId("")).toMatch(/^\d+$/);
+  });
+});
+
 describe("computePrereleaseVersion", () => {
   it("appends canary tag with timestamp when no suffix given", () => {
     const result = computePrereleaseVersion("1.55.2");
-    expect(result).toMatch(/^1\.55\.2-canary\.\d+$/);
+    expect(result).toMatch(/^1\.55\.3-canary\.\d+$/);
   });
 
   it("appends canary tag with custom suffix", () => {
     expect(computePrereleaseVersion("1.55.2", "fix-user-issue")).toBe(
-      "1.55.2-canary.fix-user-issue",
+      "1.55.3-canary.fix-user-issue",
     );
   });
 
-  it("uses the base version as-is (no bump)", () => {
+  // A stable release leaves the working tree on the version it published, so
+  // basing the canary on that version would publish a prerelease BELOW the
+  // release it was cut from — unreachable by any dependent range, and a `canary`
+  // dist-tag pointing behind `latest`.
+  it("bumps the patch so the canary sorts above the released version", () => {
     expect(computePrereleaseVersion("1.55.2", "test")).toBe(
-      "1.55.2-canary.test",
+      "1.55.3-canary.test",
     );
-    expect(computePrereleaseVersion("2.0.0", "test")).toBe("2.0.0-canary.test");
+    expect(computePrereleaseVersion("2.0.0", "test")).toBe("2.0.1-canary.test");
+    expect(computePrereleaseVersion("0.2.1", "test")).toBe("0.2.2-canary.test");
   });
 
-  it("strips existing prerelease before appending", () => {
+  // An existing prerelease means the tree is ALREADY on an unreleased version;
+  // bumping again would skip it.
+  it("reuses the base version when it already carries a prerelease", () => {
     expect(computePrereleaseVersion("1.55.2-canary.old", "new")).toBe(
       "1.55.2-canary.new",
+    );
+    expect(computePrereleaseVersion("1.56.0-alpha.1", "new")).toBe(
+      "1.56.0-canary.new",
     );
   });
 });
@@ -234,5 +257,60 @@ describe("bumpPackages", () => {
       "@copilotkit/react-core",
       "@copilotkit/shared",
     ]);
+  });
+});
+
+// Mirrors the real @copilotkit/runtime -> @copilotkit/channels-intelligence edge:
+// a package in one release scope carrying a workspace: dep on a package owned by
+// another. pnpm pack pins those to the working-tree version, so a canary of only
+// the depending scope ships against the OTHER scope's last stable release.
+describe("findCrossScopeWorkspaceDeps", () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "release-test-"));
+    const packagesDir = path.join(tmpDir, "packages");
+
+    const write = (dir: string, pkg: Record<string, unknown>) => {
+      const target = path.join(packagesDir, dir);
+      fs.mkdirSync(target, { recursive: true });
+      fs.writeFileSync(path.join(target, "package.json"), JSON.stringify(pkg));
+    };
+
+    write("shared", { name: "@copilotkit/shared", version: "1.55.2" });
+    write("react-core", {
+      name: "@copilotkit/react-core",
+      version: "1.55.2",
+      dependencies: {
+        "@copilotkit/shared": "workspace:*",
+        "@copilotkit/angular": "workspace:^",
+        "some-third-party": "^1.0.0",
+      },
+      devDependencies: { "@copilotkit/angular": "workspace:*" },
+    });
+    write("angular", { name: "@copilotkit/angular", version: "0.2.0" });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reports the version a dependency outside the published scopes pins to", () => {
+    expect(findCrossScopeWorkspaceDeps(["monorepo"])).toEqual([
+      {
+        from: "@copilotkit/react-core",
+        dep: "@copilotkit/angular",
+        depScope: "angular",
+        resolvesTo: "0.2.0",
+      },
+    ]);
+  });
+
+  it("reports nothing once every scope on the edge is published together", () => {
+    expect(findCrossScopeWorkspaceDeps(["monorepo", "angular"])).toEqual([]);
+  });
+
+  it("ignores in-scope deps and third-party ranges", () => {
+    const found = findCrossScopeWorkspaceDeps(["monorepo"]);
+    expect(found.map((edge) => edge.dep)).not.toContain("@copilotkit/shared");
+    expect(found.map((edge) => edge.dep)).not.toContain("some-third-party");
   });
 });

--- a/scripts/release/lib/versions.ts
+++ b/scripts/release/lib/versions.ts
@@ -185,35 +185,49 @@ export function bumpPackages(
   return updated;
 }
 
-/** A published dependency edge that leaves the set of scopes being published. */
-export interface CrossScopeDependency {
+/** A cross-scope dependency edge whose published pin won't be this run's version. */
+export interface CrossScopePin {
   /** Package being published. */
   from: string;
-  /** Its `workspace:` dependency, owned by a scope that is NOT being published. */
+  /** Its dependency, owned by a different release scope. */
   dep: string;
   /** The scope that owns `dep`. */
   depScope: ReleaseScope;
-  /** Version `pnpm pack` will rewrite the workspace protocol to. */
+  /** Version the published manifest will carry for `dep`. */
   resolvesTo: string;
+  /**
+   * Why the pin is stale:
+   * - `unpublished-scope`: a `workspace:` range that `pnpm pack` resolves against
+   *   the working tree, where `depScope` was not bumped in this run. Publishing
+   *   that scope too (scope=all) fixes it.
+   * - `literal-range`: a hand-written version range on a cross-scope package.
+   *   `bumpPackages` only rewrites literal ranges naming packages in the SAME
+   *   scope, so this one survives every bump — scope=all does NOT fix it. Convert
+   *   the dep to the `workspace:` protocol.
+   */
+  reason: "unpublished-scope" | "literal-range";
 }
 
 /**
- * Find dependency edges that leave `scopes`: a package being published whose
- * `workspace:` dependency belongs to a scope that ISN'T.
+ * Find cross-scope dependency edges whose published pin will NOT be a version
+ * from this run.
  *
- * `pnpm pack` resolves the workspace protocol against the working tree, so every
- * such edge is pinned to the dependency's CURRENT version — for a scope that was
- * not bumped in this run, its last stable release. The published artifact then
- * only composes with that release, even when the commit being canaried changed
- * both sides of the edge. Callers surface these so the pin is a visible choice
- * rather than a silent one.
+ * The failure this exists to make visible: `pnpm pack` resolves the workspace
+ * protocol against the working tree, so a canary of one scope pins the other
+ * scope's packages to their last stable release — even when the commit being
+ * canaried changed both sides of the contract. The artifact then only composes
+ * with that release, and nothing says so until a consumer hits a runtime error.
+ *
+ * Two shapes qualify. A `workspace:` range into a scope that isn't being
+ * published is fixed by publishing every scope together; a literal range into
+ * another scope is fixed only by converting it to `workspace:`, since
+ * {@link bumpPackages} rewrites literal ranges for in-scope packages only. Both
+ * are reported, tagged by {@link CrossScopePin.reason}.
  *
  * Only `dependencies`/`peerDependencies`/`optionalDependencies` are considered —
  * devDependencies never constrain a consumer's install.
  */
-export function findCrossScopeWorkspaceDeps(
-  scopes: ReleaseScope[],
-): CrossScopeDependency[] {
+export function findCrossScopePins(scopes: ReleaseScope[]): CrossScopePin[] {
   const config = loadConfig();
   const scopeByPackage = new Map<string, ReleaseScope>();
   for (const [scope, scopeConfig] of Object.entries(config.scopes)) {
@@ -223,7 +237,7 @@ export function findCrossScopeWorkspaceDeps(
   }
 
   const publishing = new Set(scopes);
-  const found: CrossScopeDependency[] = [];
+  const found: CrossScopePin[] = [];
 
   for (const scope of scopes) {
     for (const p of getPackagesForScope(scope)) {
@@ -235,19 +249,27 @@ export function findCrossScopeWorkspaceDeps(
         const deps = p.pkg[depField] as Record<string, string> | undefined;
         if (!deps) continue;
         for (const [dep, range] of Object.entries(deps)) {
-          if (!range.startsWith("workspace:")) continue;
           const depScope = scopeByPackage.get(dep);
-          if (!depScope || publishing.has(depScope)) continue;
+          if (!depScope || depScope === scope) continue;
+          const isWorkspace = range.startsWith("workspace:");
+          // A workspace: range into a scope this run bumps resolves to that
+          // scope's canary version — the composable case, nothing to report.
+          if (isWorkspace && publishing.has(depScope)) continue;
           found.push({
             from: p.name,
             dep,
             depScope,
-            resolvesTo: JSON.parse(
-              fs.readFileSync(
-                path.join(findPackageDir(dep), "package.json"),
-                "utf8",
-              ),
-            ).version,
+            // A literal range is published verbatim; a workspace: range is
+            // rewritten to the dependency's working-tree version.
+            resolvesTo: isWorkspace
+              ? JSON.parse(
+                  fs.readFileSync(
+                    path.join(findPackageDir(dep), "package.json"),
+                    "utf8",
+                  ),
+                ).version
+              : range,
+            reason: isWorkspace ? "unpublished-scope" : "literal-range",
           });
         }
       }

--- a/scripts/release/lib/versions.ts
+++ b/scripts/release/lib/versions.ts
@@ -76,15 +76,44 @@ export function computeNextStableVersion(
   }
 }
 
+/**
+ * Resolve the identifier that separates one canary from the next: the
+ * maintainer-supplied suffix, else a unix timestamp.
+ *
+ * Resolve this ONCE per publish run and pass it to every
+ * {@link computePrereleaseVersion} call, so a multi-scope canary ships one
+ * recognizable set of versions (`1.63.3-canary.1784916581` +
+ * `0.2.2-canary.1784916581`) instead of per-scope timestamps that drift by
+ * however long each scope took to bump.
+ */
+export function resolvePrereleaseId(suffix?: string): string {
+  return suffix || String(Math.floor(Date.now() / 1000));
+}
+
+/**
+ * Compute the version a canary publishes under: the next UNRELEASED version
+ * plus `-<prereleaseTag>.<id>`.
+ *
+ * The base has to be the next version rather than the current one. A stable
+ * release leaves the working tree sitting on the version it just published, so
+ * appending `-canary` to that produces a prerelease semver sorts BELOW the
+ * release it was cut from (`0.2.1-canary.17849… < 0.2.1`). Two things break as
+ * a result: the `canary` dist-tag advertises something older than `latest`, and
+ * no dependent range can ever resolve the canary, since npm admits prereleases
+ * only for a range naming that same major.minor.patch. Bumping the patch first
+ * keeps every canary above the last stable release.
+ *
+ * A working tree already carrying a prerelease is already sitting on an
+ * unreleased version, so its base is used as-is — the same rule
+ * {@link computeNextStableVersion} applies.
+ */
 export function computePrereleaseVersion(
   currentVersion: string,
   suffix?: string,
 ): string {
-  const v = parseSemver(currentVersion);
-  const config = loadConfig();
-  const tag = config.prereleaseTag;
-  const id = suffix || String(Math.floor(Date.now() / 1000));
-  return `${v.major}.${v.minor}.${v.patch}-${tag}.${id}`;
+  const base = computeNextStableVersion(currentVersion, "patch");
+  const tag = loadConfig().prereleaseTag;
+  return `${base}-${tag}.${resolvePrereleaseId(suffix)}`;
 }
 
 /** Get all publishable packages in the order configured for a release scope. */
@@ -154,4 +183,76 @@ export function bumpPackages(
   }
 
   return updated;
+}
+
+/** A published dependency edge that leaves the set of scopes being published. */
+export interface CrossScopeDependency {
+  /** Package being published. */
+  from: string;
+  /** Its `workspace:` dependency, owned by a scope that is NOT being published. */
+  dep: string;
+  /** The scope that owns `dep`. */
+  depScope: ReleaseScope;
+  /** Version `pnpm pack` will rewrite the workspace protocol to. */
+  resolvesTo: string;
+}
+
+/**
+ * Find dependency edges that leave `scopes`: a package being published whose
+ * `workspace:` dependency belongs to a scope that ISN'T.
+ *
+ * `pnpm pack` resolves the workspace protocol against the working tree, so every
+ * such edge is pinned to the dependency's CURRENT version — for a scope that was
+ * not bumped in this run, its last stable release. The published artifact then
+ * only composes with that release, even when the commit being canaried changed
+ * both sides of the edge. Callers surface these so the pin is a visible choice
+ * rather than a silent one.
+ *
+ * Only `dependencies`/`peerDependencies`/`optionalDependencies` are considered —
+ * devDependencies never constrain a consumer's install.
+ */
+export function findCrossScopeWorkspaceDeps(
+  scopes: ReleaseScope[],
+): CrossScopeDependency[] {
+  const config = loadConfig();
+  const scopeByPackage = new Map<string, ReleaseScope>();
+  for (const [scope, scopeConfig] of Object.entries(config.scopes)) {
+    for (const name of scopeConfig.packages) {
+      scopeByPackage.set(name, scope as ReleaseScope);
+    }
+  }
+
+  const publishing = new Set(scopes);
+  const found: CrossScopeDependency[] = [];
+
+  for (const scope of scopes) {
+    for (const p of getPackagesForScope(scope)) {
+      for (const depField of [
+        "dependencies",
+        "peerDependencies",
+        "optionalDependencies",
+      ] as const) {
+        const deps = p.pkg[depField] as Record<string, string> | undefined;
+        if (!deps) continue;
+        for (const [dep, range] of Object.entries(deps)) {
+          if (!range.startsWith("workspace:")) continue;
+          const depScope = scopeByPackage.get(dep);
+          if (!depScope || publishing.has(depScope)) continue;
+          found.push({
+            from: p.name,
+            dep,
+            depScope,
+            resolvesTo: JSON.parse(
+              fs.readFileSync(
+                path.join(findPackageDir(dep), "package.json"),
+                "utf8",
+              ),
+            ).version,
+          });
+        }
+      }
+    }
+  }
+
+  return found;
 }

--- a/scripts/release/prerelease.ts
+++ b/scripts/release/prerelease.ts
@@ -7,12 +7,13 @@
  *
  * Always publishes with the "canary" dist-tag.
  *
- * Usage: tsx scripts/release/prerelease.ts --scope <scope from release.config.json> [--dry-run]
+ * Usage: tsx scripts/release/prerelease.ts --scope <scope from release.config.json | all> [--dry-run]
  */
 
 import { spawnSync } from "child_process";
-import { getPackagesForScope } from "./lib/versions.js";
-import { ROOT, loadConfig } from "./lib/config.js";
+import { getCurrentVersion, getPackagesForScope } from "./lib/versions.js";
+import type { PublishablePackage } from "./lib/versions.js";
+import { ALL_SCOPES, ROOT, loadConfig, resolveScopes } from "./lib/config.js";
 import type { ReleaseScope } from "./lib/config.js";
 import { emitGithubOutputs } from "./lib/github-output.js";
 
@@ -35,38 +36,67 @@ function main() {
   const argv = process.argv.slice(2);
   const dryRun = argv.includes("--dry-run");
   const scopeIdx = argv.indexOf("--scope");
-  const scope = (
-    scopeIdx !== -1 ? argv[scopeIdx + 1] : null
-  ) as ReleaseScope | null;
+  const selector = scopeIdx !== -1 ? argv[scopeIdx + 1] : null;
+  const usage = `Usage: prerelease.ts --scope <${[...VALID_SCOPES, ALL_SCOPES].join("|")}> [--dry-run]`;
 
-  if (!scope || !VALID_SCOPES.includes(scope)) {
-    console.error(
-      `Usage: prerelease.ts --scope <${VALID_SCOPES.join("|")}> [--dry-run]`,
-    );
+  if (!selector) {
+    console.error(usage);
+    process.exit(1);
+  }
+
+  let scopes: ReleaseScope[];
+  try {
+    scopes = resolveScopes(selector);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    console.error(usage);
     process.exit(1);
   }
 
   const config = loadConfig();
   const distTag = config.prereleaseTag;
 
-  // Read the version from package.json — already bumped by bump-prerelease.ts
+  // Read the versions from package.json — already bumped by bump-prerelease.ts
   // in the CI build job.
-  const packages = getPackagesForScope(scope);
+  const scopeVersions = scopes.map((scope) => {
+    const version = getCurrentVersion(scope);
+    if (!version) {
+      console.error(
+        `Scope "${scope}" version source has no version field; refusing to publish.`,
+      );
+      process.exit(1);
+    }
+    return { scope, version };
+  });
+
+  // Union of every scope's packages, in per-scope publish order. Deduplicated by
+  // name: a package enrolled in two scopes must be published once, not twice
+  // (the second publish would fail on an already-taken version).
+  const packages: PublishablePackage[] = [];
+  const seen = new Set<string>();
+  for (const scope of scopes) {
+    for (const p of getPackagesForScope(scope)) {
+      if (seen.has(p.name)) continue;
+      seen.add(p.name);
+      packages.push(p);
+    }
+  }
   if (packages.length === 0) {
     console.error(
-      `No packages found for scope "${scope}" — refusing to emit a version for a publish that did nothing.`,
+      `No packages found for scope "${selector}" — refusing to emit a version for a publish that did nothing.`,
     );
     process.exit(1);
   }
-  const publishVersion = packages[0].pkg.version;
-  if (!publishVersion) {
-    console.error(
-      `Package ${packages[0].name} has no version field; refusing to publish.`,
-    );
-    process.exit(1);
-  }
-  console.log(`Scope: ${scope}`);
-  console.log(`Publishing version: ${publishVersion}`);
+
+  // `version` stays single-valued for the workflow's emitted-version guard and
+  // the stable-shaped summary; `versions` carries every scope for a multi-scope
+  // canary, where no single version describes the publish.
+  const publishVersion = scopeVersions[0].version;
+  const publishVersions = scopeVersions
+    .map(({ scope, version }) => `${scope}@${version}`)
+    .join(" ");
+  console.log(`Scope: ${selector} -> ${scopes.join(", ")}`);
+  console.log(`Publishing versions: ${publishVersions}`);
   console.log(`Dist tag: ${distTag}`);
 
   if (dryRun) {
@@ -77,7 +107,11 @@ function main() {
     // Emitting in dry-run is safe — the publish workflow gates both the
     // publish step and the verify guard on `inputs.dry-run != true`, so this
     // only serves local/e2e verification of the output contract.
-    emitGithubOutputs({ version: publishVersion, scope });
+    emitGithubOutputs({
+      version: publishVersion,
+      versions: publishVersions,
+      scope: selector,
+    });
     console.log("\n[DRY RUN] Exiting.");
     return;
   }
@@ -114,9 +148,13 @@ function main() {
 
   // The workflow's "Verify publish step emitted version" guard and the
   // prerelease summary read these from steps.publish.outputs.
-  emitGithubOutputs({ version: publishVersion, scope });
+  emitGithubOutputs({
+    version: publishVersion,
+    versions: publishVersions,
+    scope: selector,
+  });
 
-  console.log(`\nPrerelease published: ${publishVersion} (tag: ${distTag})`);
+  console.log(`\nPrerelease published: ${publishVersions} (tag: ${distTag})`);
 }
 
 main();

--- a/scripts/release/prerelease.ts
+++ b/scripts/release/prerelease.ts
@@ -7,6 +7,14 @@
  *
  * Always publishes with the "canary" dist-tag.
  *
+ * Multi-scope caveat (scope=all): packages publish scope by scope, and the
+ * cross-scope dependency graph has cycles (runtime -> channels-intelligence,
+ * channels-core -> core), so NO order avoids publishing a package before the
+ * same-run version it pins. A run that dies partway therefore leaves published
+ * canaries pinning versions that never shipped — uninstallable until the rest
+ * lands. There is no resume: npm rejects republishing a version, so retry with a
+ * NEW suffix and abandon the half-published id.
+ *
  * Usage: tsx scripts/release/prerelease.ts --scope <scope from release.config.json | all> [--dry-run]
  */
 

--- a/scripts/release/verify-release-scope-dropdowns.sh
+++ b/scripts/release/verify-release-scope-dropdowns.sh
@@ -19,10 +19,15 @@
 #   .github/workflows/stable-release.yml   — create-pr `scope` input (release / create-pr)
 #   .github/workflows/canary.yml           — one-click canary orchestrator `scope` input
 #
-# Sentinel exception: none of the workflows uses a non-scope sentinel option
-# (no `all` / `canary` pseudo-scope — an empty/omitted scope is handled
-# outside the options list). If a sentinel is ever introduced, add it to
-# SENTINELS below so it is excluded from the equality check.
+# Sentinel exception: `all` is a non-scope sentinel option (see ALL_SCOPES in
+# scripts/release/lib/config.ts) that publishes every scope under one shared
+# canary id. It is excluded from the scope-equality check via SENTINELS, and
+# separately pinned per workflow by check_sentinel_placement: REQUIRED in the
+# two canary-capable workflows (canary.yml dispatches publish-release.yml, so a
+# value missing from either dropdown fails the dispatch) and FORBIDDEN in
+# stable-release.yml (a stable release is single-scope by construction — its tag,
+# release branch, and npm links all derive from one scope name). If another
+# sentinel is ever introduced, add it to SENTINELS and give it a placement rule.
 #
 # Secondary projection guarded here: publish-release.yml's `notify` job has a
 # `Resolve npm URL for scope` step whose `case "$SCOPE"` maps a dispatch
@@ -45,8 +50,8 @@ PUBLISH_WF="$REPO_ROOT/.github/workflows/publish-release.yml"
 STABLE_WF="$REPO_ROOT/.github/workflows/stable-release.yml"
 CANARY_WF="$REPO_ROOT/.github/workflows/canary.yml"
 
-# Documented non-scope sentinel options to ignore (none today). Space-separated.
-SENTINELS=""
+# Documented non-scope sentinel options to ignore. Space-separated.
+SENTINELS="all"
 
 for f in "$CONFIG" "$PUBLISH_WF" "$STABLE_WF" "$CANARY_WF"; do
   if [ ! -f "$f" ]; then
@@ -270,10 +275,55 @@ check_notify_case() {
   return 0
 }
 
+# Verify WHERE a sentinel option is offered. check_workflow strips sentinels
+# before comparing, which also hides a sentinel that has leaked into a workflow
+# where it is invalid (or vanished from one that needs it) — this restores that
+# coverage per file.
+#
+# Args: <display name> <workflow file> <sentinel> <required|forbidden>
+check_sentinel_placement() {
+  local name="$1" file="$2" sentinel="$3" expectation="$4"
+  local opts
+  opts=$(extract_scope_options "$file")
+
+  # Same distinction as check_workflow: zero options is a PARSER failure, not a
+  # verdict about the sentinel.
+  if [ -z "$opts" ]; then
+    echo "ERROR: parser could not find scope options in $file ($name) while checking '$sentinel' placement." >&2
+    return 1
+  fi
+
+  if printf '%s\n' "$opts" | grep -Fxq -- "$sentinel"; then
+    if [ "$expectation" = "forbidden" ]; then
+      echo "ERROR: $name offers the '$sentinel' sentinel, which is invalid there." >&2
+      echo "Fix: remove '$sentinel' from the 'scope' input 'options:' list in $file." >&2
+      echo "A stable release is single-scope by construction: its git tag, release branch," >&2
+      echo "and npm/Slack links all derive from one scope name, and scopes carry" >&2
+      echo "independent version lines. Multi-scope publishing is canary-only." >&2
+      return 1
+    fi
+    echo "OK: $name offers the '$sentinel' sentinel"
+    return 0
+  fi
+
+  if [ "$expectation" = "required" ]; then
+    echo "ERROR: $name is missing the '$sentinel' sentinel option." >&2
+    echo "Fix: add '$sentinel' to the 'scope' input 'options:' list in $file." >&2
+    echo "canary.yml dispatches publish-release.yml with the selected scope, so a" >&2
+    echo "value absent from EITHER dropdown is rejected at dispatch time." >&2
+    return 1
+  fi
+  echo "OK: $name does not offer the '$sentinel' sentinel"
+  return 0
+}
+
 rc=0
 check_workflow "publish-release.yml" "$PUBLISH_WF" || rc=1
 check_workflow "stable-release.yml"  "$STABLE_WF"  || rc=1
 check_workflow "canary.yml"          "$CANARY_WF"  || rc=1
+check_sentinel_placement "publish-release.yml" "$PUBLISH_WF" "all" required  || rc=1
+check_sentinel_placement "canary.yml"          "$CANARY_WF"  "all" required  || rc=1
+check_sentinel_placement "stable-release.yml"  "$STABLE_WF"  "all" forbidden || rc=1
 check_notify_case "$PUBLISH_WF" || rc=1
 
 if [ "$rc" -ne 0 ]; then


### PR DESCRIPTION
## Why

A `channels` canary and a `monorepo` canary were published from post-Plan-C commits, and the sample app built on them died with:

```
TypeError: channel.addAdapter is not a function
    at startChannels (…/@copilotkit/channels-intelligence/dist/runtime.js:97:21)
```

Two independent defects in the canary lane produced that:

1. **Canary versions were prereleases of an already-published version.** A stable release leaves the working tree on the version it just published, and `computePrereleaseVersion` appended `-canary.<id>` to exactly that — so the canary sorted *below* its own release (`0.2.1-canary.1784916581 < 0.2.1`). The `canary` dist-tag pointed behind `latest`, and no dependent range could ever resolve a canary (npm admits prereleases only for a range naming the same major.minor.patch).

2. **A canary published one scope at a time, but the scopes are only independent on the version axis.** `@copilotkit/runtime` carries `"@copilotkit/channels-intelligence": "workspace:*"`, and `pnpm pack` resolves the workspace protocol against the working tree. A `monorepo`-only canary therefore shipped pinned to the channels family's last *stable* release — `@copilotkit/runtime@1.63.2-canary.1784918757` has `"@copilotkit/channels-intelligence": "0.2.1"`, published 2026-07-17, before `Channel.start/stop/addAdapter` moved to the internal `ɵruntime` seam. The two canaries could not compose in either direction.

## What changed

- `computePrereleaseVersion` bases the canary on the next **unreleased** version (patch bump, reusing `computeNextStableVersion`'s existing prerelease rule: a tree already carrying a prerelease keeps its base). `0.2.1` → `0.2.2-canary.<id>`.
- New `resolvePrereleaseId`, resolved once per run, so every scope in a multi-scope canary shares one id (`1.63.3-canary.<id>` + `0.2.2-canary.<id>`) instead of per-scope timestamps.
- New `all` selector (`ALL_SCOPES` / `resolveScopes` in `scripts/release/lib/config.ts`): bumps and publishes every scope from one commit, so cross-scope `workspace:` deps are packed against same-run canary versions. Offered in `canary.yml` and `publish-release.yml`.
- **Prerelease-only.** A stable release is single-scope by construction (tag, release branch, and npm/Slack links all derive from one scope name); both jobs in `publish-release.yml` reject `scope=all` for `mode != prerelease`, and the dropdown guard enforces per-workflow placement — required in the two canary-capable workflows, forbidden in `stable-release.yml`.
- `findCrossScopePins` + a `::warning::` per cross-scope pin that won't carry a version from this run, naming the version the manifest will pin. This is the signal that was missing: the bad pin was previously invisible until a consumer hit a TypeError. Two shapes are reported, each with its own remedy — a `workspace:` range into an unpublished scope (fixed by `scope=all`) and a **literal** range into another scope, which `bumpPackages` never rewrites and which `scope=all` therefore does *not* fix (fixed only by converting the dep to `workspace:`).
- `prerelease.ts` publishes the deduplicated union of the selected scopes' packages and emits a new `versions` output (`<scope>@<version>` per scope); `version` stays single-valued for the existing emitted-version guard. The prerelease summary renders `versions`.
- The dropdown-parity guard documents `all` as a sentinel (`SENTINELS="all"`) and adds `check_sentinel_placement`, restoring the coverage that sentinel-stripping would otherwise hide.

## Testing

**Cross-scope warning fires on exactly the edges that broke the sample app** (`--scope monorepo`, the shape of the run that shipped the bad pin):

```
$ tsx scripts/release/bump-prerelease.ts --scope monorepo --suffix e2etest
Scope: monorepo -> monorepo
Prerelease id: e2etest
[monorepo] current version: 1.63.2 -> prerelease version: 1.63.3-canary.e2etest
Bumped 16 packages to 1.63.3-canary.e2etest
2 dependency edge(s) leave this publish and will be pinned to already-released versions:
::warning::@copilotkit/runtime depends on @copilotkit/channels-core (scope "channels", not part of this publish) — the packed tarball pins @copilotkit/channels-core@0.2.1, so this canary is only usable with that release. If this commit changed both sides, re-run the canary with scope=all.
::warning::@copilotkit/runtime depends on @copilotkit/channels-intelligence (scope "channels", not part of this publish) — the packed tarball pins @copilotkit/channels-intelligence@0.2.1, so this canary is only usable with that release. If this commit changed both sides, re-run the canary with scope=all.
```

**`--scope all` bumps every scope under one id, next-version based** (note `0.2.1` → `0.2.2`, not `0.2.1-canary`):

```
$ tsx scripts/release/bump-prerelease.ts --scope all --suffix e2etest
Scope: all -> monorepo, angular, channels
Prerelease id: e2etest
[monorepo] current version: 1.63.2 -> prerelease version: 1.63.3-canary.e2etest
Bumped 16 packages to 1.63.3-canary.e2etest
[angular] current version: 0.3.0 -> prerelease version: 0.3.1-canary.e2etest
Bumped 1 packages to 0.3.1-canary.e2etest
[channels] current version: 0.2.1 -> prerelease version: 0.2.2-canary.e2etest
Bumped 9 packages to 0.2.2-canary.e2etest
```

**Publish plan + emitted outputs** (26 packages = 16 + 1 + 9, no duplicates):

```
$ GITHUB_OUTPUT=… tsx scripts/release/prerelease.ts --scope all --dry-run
Scope: all -> monorepo, angular, channels
Publishing versions: monorepo@1.63.3-canary.e2etest angular@0.3.1-canary.e2etest channels@0.2.2-canary.e2etest
Dist tag: canary
$ cat $GITHUB_OUTPUT
version=1.63.3-canary.e2etest
versions=monorepo@1.63.3-canary.e2etest angular@0.3.1-canary.e2etest channels@0.2.2-canary.e2etest
scope=all
```

Single-scope behaviour unchanged (`--scope channels --dry-run` → `version=0.2.1`, `scope=channels`); an unknown scope exits 1 with `Unknown scope: runtime. Valid scopes: monorepo, angular, channels, all`.

**The pin rewrite itself.** `pnpm pack` cannot run in a bare worktree (`ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL`), so the rewrite was verified on a throwaway two-package pnpm workspace with this repo's pnpm, plus semver checks on the resulting ranges:

```
$ tar -xOf packtest-consumer-1.63.3-canary.e2etest.tgz package/package.json
{ "dependencies":     { "@packtest/dep": "0.2.2-canary.e2etest"  },   # workspace:*
  "peerDependencies": { "@packtest/dep": "^0.2.2-canary.e2etest" } }  # workspace:^

canary satisfies ^canary range:   true    # ^0.2.2-canary.e2etest admits the exact canary
0.2.2-canary > 0.2.1 stable:      true    # new scheme sorts above latest
old scheme 0.2.1-canary > 0.2.1:  false   # what this PR fixes
```

That matches the observed behaviour of the real publish: `@copilotkit/runtime@1.63.2-canary.1784918757` shipped `"@copilotkit/shared": "1.63.2-canary.1784918757"` (same-scope, bumped) alongside `"@copilotkit/channels-intelligence": "0.2.1"` (other scope, unbumped).

**Guards and suites**

- `scripts/release/verify-release-scope-dropdowns.sh` passes on both extractor paths (yq and the awk fallback). Negative cases confirmed by temporary mutation: `all` added to `stable-release.yml` → fails with the forbidden-placement error; `all` removed from `canary.yml` → fails with the missing-sentinel error. Both reverted.
- `vitest run --config scripts/release/vitest.config.mts` → **129 passed** (was 125; +4 covering the next-version base, prerelease-base reuse, `resolvePrereleaseId`, and `resolveScopes`, plus 3 new `findCrossScopeWorkspaceDeps` cases).
- `oxlint scripts/release` → 0 warnings, 0 errors. `oxfmt` clean.
- `shellcheck --severity=warning` on `scripts/release/**/*.sh` → clean; `actionlint` on `publish-release.yml` + `canary.yml` → clean (both are CI jobs in `lint-release-workflows.yml`).

Not exercised: an actual multi-scope publish to npm. The publish path itself is unchanged (same per-package `pnpm pack` + `npm publish --tag canary` loop, just iterated over more packages), and `canary.yml` supports `dry_run` for a live rehearsal before the first real `all` canary.

## Adversarial review of this PR

One defect found and fixed (second commit): the warning only inspected `workspace:` ranges, so a **literal** cross-scope range — which `bumpPackages` never rewrites, since it only rewrites literal ranges for in-scope packages — reported nothing even under `scope=all`, while the published artifact still resolved the dependency's last stable release. Reproduced by temporarily converting runtime's channels-intelligence dep to a literal `"0.2.1"`: the old detector was silent under `scope=all`; the new one reports it with the correct remedy. No such pin exists in the tree today (verified: all 13 cross-scope edges are `workspace:`), so this was a latent hole.

Two suspicions checked and disproven:

- **`all` breaking the angular publish.** `@copilotkit/angular` is built by ng-packagr into `dist/` with no `publishConfig.directory`, which looked like the generic `pnpm pack` loop would publish the wrong tree. The published `0.3.0` tarball contains `package/dist/fesm2022/…` — i.e. the stable lane already ships angular through this same generic path. No new breakage.
- **Lockfile drift from bumping more packages.** `bumpPackages` rewrites literal in-scope dep ranges, which would change specifiers and could trip the publish job's `pnpm install --frozen-lockfile`. There are zero literal ranges on release-scope packages anywhere in the tree, so that branch is inert; `workspace:` specifiers don't change when a version does.

Accepted residuals (documented, not fixed):

- **Partial failure under `all`** — the cross-scope graph has cycles (`runtime → channels-intelligence`, `channels-core → core`), so no publish order avoids shipping a package before the same-run version it pins. A run that dies partway leaves uninstallable canaries, and npm's no-republish rule means retrying needs a new suffix. Noted in `prerelease.ts`'s header.
- **The version invariant is "above the tree", not "above the registry".** If the working tree is behind `latest` (e.g. a hotfix released from another branch), a patch bump can still land below it. Closing that would mean a registry lookup in the build job, which deliberately runs without registry auth.
- **`all` publishes an angular canary nobody asked for** — one extra package, ~seconds. The alternative (encoding which scopes share dependency edges) is more machinery than the saved publish is worth.
- **Concurrency**: `all` occupies its own `publish-release-all` lane, so it can overlap a single-scope release. Versions can't collide, and the channels registry verifier pins exact versions within its own run.

## Follow-up (not in this PR)

A version-skew guard so a mismatch fails loudly instead of surfacing as `channel.addAdapter is not a function` in a consumer's app: a contract integer stamped on `Channel.ɵruntime`, re-exported by `channels-intelligence`, checked in `defaultActivateChannel` and the per-channel activation path — plus wiring `verify:runtime-package` (today a root script no workflow runs) into `publish-release.yml`, where it would have caught this exact combination pre-publish.
