### PR TITLE
fix(channels): finalize direct render turns

### DIFF
--- a/packages/channels-intelligence/src/http-transports.ts
+++ b/packages/channels-intelligence/src/http-transports.ts
@@ -47,7 +47,7 @@ export interface IntelligenceTransportConfig {
   apiKey: string;
   /** Project-unique channel name; defaults from `createChannel({ name })`. */
   channelName: string;
-  /** Stable runtime instance id (`rti_…`); generated when omitted. */
+  /** Transport-instance id (`rti_…`); generated when omitted. */
   runtimeInstanceId: string;
   /** Adapter kind. First slice is `"slack"`. */
   adapter: string;

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -269,6 +269,9 @@ export class IntelligenceAdapter implements PlatformAdapter {
   /** Per-turn egress sequence; reset at the start of each turn's processing so
    * a redelivered turn reproduces the same operation id sequence. */
   private readonly seq = new Map<string, number>();
+  /** Whether the last durably accepted realtime frame for a live turn still
+   * needs a terminal `finalize` before its delivery may complete. */
+  private readonly renderNeedsFinalize = new Map<string, boolean>();
 
   constructor(private readonly opts: IntelligenceAdapterOptions = {}) {
     this.source = opts.source;
@@ -356,8 +359,12 @@ export class IntelligenceAdapter implements PlatformAdapter {
     // true for at-least-once, lease-based delivery; overlapping redeliveries of
     // the same turnId would perturb the counter.
     this.seq.set(env.turnId, 0);
+    if (this.renderSink) {
+      this.renderNeedsFinalize.set(env.turnId, false);
+    }
     try {
       await this.dispatchTo(env);
+      await this.finalizeRenderedTurn(env);
       await this.requireSource().ack(env.deliveryId);
     } catch (err) {
       await this.requireSource().nack(
@@ -369,6 +376,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
       // chain drained inside dispatchTo) so the Map can't grow unbounded over a
       // long-running Channel Bot. A redelivery re-seeds it at the top.
       this.seq.delete(env.turnId);
+      this.renderNeedsFinalize.delete(env.turnId);
     }
   }
 
@@ -521,6 +529,58 @@ export class IntelligenceAdapter implements PlatformAdapter {
     return seq;
   }
 
+  /**
+   * Records the terminal state only after the render sink durably accepts a
+   * frame. A later post/update/file/delete after an agent-run finalize flips
+   * the turn back to non-terminal so dispatch emits one final finalize.
+   */
+  private recordAcceptedRenderEvent(
+    turnId: string,
+    event: ChannelRenderEvent,
+  ): void {
+    if (!this.renderNeedsFinalize.has(turnId)) return;
+    this.renderNeedsFinalize.set(turnId, event.kind !== "finalize");
+  }
+
+  /**
+   * Pushes one realtime frame immediately and records its accepted terminal
+   * state. Sequence allocation stays deterministic across delivery retries.
+   */
+  private async pushRenderFrame(
+    target: ChannelReplyTarget,
+    event: ChannelRenderEvent,
+  ): Promise<{ receipt: RenderAccepted; seq: number }> {
+    const seq = this.nextFrameSeq(target.turnId);
+    const receipt = await this.requireRenderSink().push({
+      deliveryId: target.deliveryId,
+      turnId: target.turnId,
+      slot: "main",
+      seq,
+      event,
+    });
+    this.recordAcceptedRenderEvent(target.turnId, event);
+    return { receipt, seq };
+  }
+
+  /**
+   * Closes a successfully handled delivery's realtime render lane when a
+   * discrete post/update/file/delete was its last accepted frame. Agent runs
+   * already finish themselves, so their terminal frame is not duplicated.
+   */
+  private async finalizeRenderedTurn(
+    env: ChannelIngressEnvelope,
+  ): Promise<void> {
+    if (!this.renderNeedsFinalize.get(env.turnId)) return;
+    await this.pushRenderFrame(
+      {
+        route: env.route,
+        turnId: env.turnId,
+        deliveryId: env.deliveryId,
+      },
+      { kind: "finalize" },
+    );
+  }
+
   private mintOp(target: ChannelReplyTarget, op: EgressOp): EgressOperation {
     const seq = this.nextFrameSeq(target.turnId);
     return {
@@ -542,14 +602,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
     target: ChannelReplyTarget,
     event: ChannelRenderEvent,
   ): Promise<MessageRef> {
-    const seq = this.nextFrameSeq(target.turnId);
-    const receipt = await this.requireRenderSink().push({
-      deliveryId: target.deliveryId,
-      turnId: target.turnId,
-      slot: "main",
-      seq,
-      event,
-    });
+    const { receipt, seq } = await this.pushRenderFrame(target, event);
     return {
       id: receipt.egressOperationId ?? `${target.turnId}:main:${seq}`,
       __route: target.route,
@@ -793,6 +846,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
         if (pushError !== undefined) return;
         try {
           await sink.push(frame);
+          this.recordAcceptedRenderEvent(t.turnId, event);
         } catch (err) {
           pushError = err;
         }

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -266,12 +266,14 @@ export class IntelligenceAdapter implements PlatformAdapter {
   /** Streaming render transport — injected via opts (realtime path). When unset,
    * the run renderer translates frames to `post` ops on {@link egress}. */
   private renderSink?: RenderEventSink;
-  /** Per-turn egress sequence; reset at the start of each turn's processing so
-   * a redelivered turn reproduces the same operation id sequence. */
-  private readonly seq = new Map<string, number>();
-  /** Whether the last durably accepted realtime frame for a live turn still
-   * needs a terminal `finalize` before its delivery may complete. */
-  private readonly renderNeedsFinalize = new Map<string, boolean>();
+  /** Per-turn render state; reset at the start of each turn's processing so a
+   * redelivery reproduces the same operation ids. A realtime turn starts
+   * non-terminal: even an output-free handler must durably accept `finalize`
+   * before its delivery may complete. */
+  private readonly renderState = new Map<
+    string,
+    { nextSeq: number; needsFinalize: boolean }
+  >();
 
   constructor(private readonly opts: IntelligenceAdapterOptions = {}) {
     this.source = opts.source;
@@ -358,10 +360,10 @@ export class IntelligenceAdapter implements PlatformAdapter {
     // DeliverySource delivers (and awaits) one envelope per turnId at a time —
     // true for at-least-once, lease-based delivery; overlapping redeliveries of
     // the same turnId would perturb the counter.
-    this.seq.set(env.turnId, 0);
-    if (this.renderSink) {
-      this.renderNeedsFinalize.set(env.turnId, false);
-    }
+    this.renderState.set(env.turnId, {
+      nextSeq: 0,
+      needsFinalize: this.renderSink !== undefined,
+    });
     try {
       await this.dispatchTo(env);
       await this.finalizeRenderedTurn(env);
@@ -372,11 +374,10 @@ export class IntelligenceAdapter implements PlatformAdapter {
         err instanceof Error ? err.message : String(err),
       );
     } finally {
-      // Drop the per-turn counter once the turn is fully processed (renderer
+      // Drop the per-turn state once the turn is fully processed (renderer
       // chain drained inside dispatchTo) so the Map can't grow unbounded over a
       // long-running Channel Bot. A redelivery re-seeds it at the top.
-      this.seq.delete(env.turnId);
-      this.renderNeedsFinalize.delete(env.turnId);
+      this.renderState.delete(env.turnId);
     }
   }
 
@@ -524,8 +525,13 @@ export class IntelligenceAdapter implements PlatformAdapter {
    * renderer and discrete post/update so all of a turn's render frames land on
    * one ordered `(turnId, "main")` lane. Reset per delivery in {@link dispatch}. */
   private nextFrameSeq(turnId: string): number {
-    const seq = this.seq.get(turnId) ?? 0;
-    this.seq.set(turnId, seq + 1);
+    const state = this.renderState.get(turnId);
+    if (!state) {
+      this.renderState.set(turnId, { nextSeq: 1, needsFinalize: false });
+      return 0;
+    }
+    const seq = state.nextSeq;
+    state.nextSeq += 1;
     return seq;
   }
 
@@ -538,8 +544,9 @@ export class IntelligenceAdapter implements PlatformAdapter {
     turnId: string,
     event: ChannelRenderEvent,
   ): void {
-    if (!this.renderNeedsFinalize.has(turnId)) return;
-    this.renderNeedsFinalize.set(turnId, event.kind !== "finalize");
+    const state = this.renderState.get(turnId);
+    if (!state) return;
+    state.needsFinalize = event.kind !== "finalize";
   }
 
   /**
@@ -570,7 +577,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
   private async finalizeRenderedTurn(
     env: ChannelIngressEnvelope,
   ): Promise<void> {
-    if (!this.renderNeedsFinalize.get(env.turnId)) return;
+    if (!this.renderState.get(env.turnId)?.needsFinalize) return;
     await this.pushRenderFrame(
       {
         route: env.route,

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.test.ts
@@ -76,8 +76,42 @@ async function waitFor(pred: () => boolean, tries = 50): Promise<void> {
   throw new Error("waitFor: condition not met within the poll window");
 }
 
+/** Read the semantic render kind from a recorded gateway push. */
+function renderKind(push: {
+  event: string;
+  payload: unknown;
+}): string | undefined {
+  const envelope = push.payload;
+  if (
+    push.event !== "channel.render_event.v1" ||
+    envelope === null ||
+    typeof envelope !== "object" ||
+    !("payload" in envelope)
+  ) {
+    return undefined;
+  }
+  const payload = envelope.payload;
+  if (
+    payload === null ||
+    typeof payload !== "object" ||
+    !("event" in payload)
+  ) {
+    return undefined;
+  }
+  const event = payload.event;
+  if (
+    event === null ||
+    typeof event !== "object" ||
+    !("kind" in event) ||
+    typeof event.kind !== "string"
+  ) {
+    return undefined;
+  }
+  return event.kind;
+}
+
 describe("startChannelsWithGatewaySession — Channel runtime over Realtime Gateway (OSS-406)", () => {
-  it("runs a delivered turn end-to-end: handler → render frame → completion intent, never self-ack", async () => {
+  it("finalizes a direct post before requesting delivery completion", async () => {
     const fake = makeFakeSession();
     let ran = false;
     const bot = createChannel({
@@ -103,10 +137,20 @@ describe("startChannelsWithGatewaySession — Channel runtime over Realtime Gate
     );
 
     const events = fake.pushes.map((p) => p.event);
+    const renderKinds = fake.pushes
+      .filter((p) => p.event === "channel.render_event.v1")
+      .map(renderKind);
     expect(ran).toBe(true); // the Channel handler ran off a gateway-delivered turn
-    expect(events).toContain("channel.render_event.v1"); // rendered over the gateway session
+    expect(renderKinds).toEqual(["post", "finalize"]); // every rendered delivery has a terminal frame
     expect(events).toContain("channel.delivery.complete_requested.v1"); // completion INTENT
     expect(events).not.toContain("channel.delivery.ack.v1"); // SDK never commits the ack
+    expect(
+      fake.pushes.findIndex((p) => renderKind(p) === "finalize"),
+    ).toBeLessThan(
+      fake.pushes.findIndex(
+        (p) => p.event === "channel.delivery.complete_requested.v1",
+      ),
+    );
 
     await handle.stop();
   });

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.test.ts
@@ -77,41 +77,25 @@ async function waitFor(pred: () => boolean, tries = 50): Promise<void> {
 }
 
 /** Read the semantic render kind from a recorded gateway push. */
-function renderKind(push: {
-  event: string;
-  payload: unknown;
-}): string | undefined {
-  const envelope = push.payload;
-  if (
-    push.event !== "channel.render_event.v1" ||
-    envelope === null ||
-    typeof envelope !== "object" ||
-    !("payload" in envelope)
-  ) {
+function renderKind(push: { event: string; payload: unknown }) {
+  if (push.event !== "channel.render_event.v1") return undefined;
+  if (!isObject(push.payload) || !isObject(push.payload.payload)) {
     return undefined;
   }
-  const payload = envelope.payload;
-  if (
-    payload === null ||
-    typeof payload !== "object" ||
-    !("event" in payload)
-  ) {
-    return undefined;
-  }
-  const event = payload.event;
-  if (
-    event === null ||
-    typeof event !== "object" ||
-    !("kind" in event) ||
-    typeof event.kind !== "string"
-  ) {
-    return undefined;
-  }
-  return event.kind;
+  const event = push.payload.payload.event;
+  return isObject(event) && typeof event.kind === "string"
+    ? event.kind
+    : undefined;
+}
+
+function isObject(value: unknown): value is {
+  readonly [key: string]: unknown;
+} {
+  return value !== null && typeof value === "object";
 }
 
 describe("startChannelsWithGatewaySession — Channel runtime over Realtime Gateway (OSS-406)", () => {
-  it("finalizes a direct post before requesting delivery completion", async () => {
+  it("finalizes a direct post before requesting completion and never self-acks", async () => {
     const fake = makeFakeSession();
     let ran = false;
     const bot = createChannel({
@@ -151,6 +135,65 @@ describe("startChannelsWithGatewaySession — Channel runtime over Realtime Gate
         (p) => p.event === "channel.delivery.complete_requested.v1",
       ),
     );
+
+    await handle.stop();
+  });
+
+  it("finalizes an output-free turn so completion has an accepted pointer", async () => {
+    const fake = makeFakeSession();
+    const bot = createChannel({
+      name: "opentag",
+      agent: () => new FakeAgent(),
+    });
+    bot.onMessage(async () => {});
+
+    const handle = await startChannelsWithGatewaySession([bot], {
+      session: fake.session,
+      scope,
+      runtimeInstanceId: "rti_1",
+    });
+
+    deliverText(fake.handlers);
+    await waitFor(() =>
+      fake.pushes.some(
+        (push) => push.event === "channel.delivery.complete_requested.v1",
+      ),
+    );
+
+    expect(fake.pushes.map(renderKind).filter(Boolean)).toEqual(["finalize"]);
+
+    await handle.stop();
+  });
+
+  it("adds one trailing finalize when a direct post follows an agent finalize", async () => {
+    const fake = makeFakeSession();
+    const bot = createChannel({
+      name: "opentag",
+      agent: () => new FakeAgent(),
+    });
+    bot.onMessage(async ({ thread }) => {
+      await thread.runAgent();
+      await thread.post(Section({ children: "after run" }));
+    });
+
+    const handle = await startChannelsWithGatewaySession([bot], {
+      session: fake.session,
+      scope,
+      runtimeInstanceId: "rti_1",
+    });
+
+    deliverText(fake.handlers);
+    await waitFor(() =>
+      fake.pushes.some(
+        (push) => push.event === "channel.delivery.complete_requested.v1",
+      ),
+    );
+
+    expect(fake.pushes.map(renderKind).filter(Boolean)).toEqual([
+      "finalize",
+      "post",
+      "finalize",
+    ]);
 
     await handle.stop();
   });

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.ts
@@ -70,7 +70,11 @@ export interface StartChannelsWithGatewaySessionOptions {
   session: RealtimeGatewaySession;
   /** Authoritative org/project/channel scope echoed on every SDK→gateway envelope. */
   scope: ChannelRealtimeScope;
-  /** Stable runtime instance id (`rti_…`), echoed on every envelope. */
+  /**
+   * One live Channel activation id (`rti_…`), echoed on every envelope.
+   * Unique across concurrent replicas, stable across reconnects for this
+   * activation, and re-minted on process/ChannelManager restart.
+   */
   runtimeInstanceId: string;
   /** Intelligence app-api HTTP base URL — enables file/history parity on the
    * realtime path (OSS-476), which are HTTP-only. With {@link apiKey}. */
@@ -133,7 +137,7 @@ export async function startChannelsWithGatewaySession(
   const observableSession = opts.session as Partial<{
     onClose(cb: () => void): void;
     onStateChange(
-      cb: (state: "online" | "reconnecting" | "gave_up") => void,
+      cb: (state: "online" | "reconnecting" | "gave_up" | "fenced") => void,
     ): void;
   }>;
   // Call the seams ON the session (not via detached references) so a
@@ -149,7 +153,9 @@ export async function startChannelsWithGatewaySession(
       ...(observableSession.onStateChange
         ? {
             onStateChange: (
-              cb: (state: "online" | "reconnecting" | "gave_up") => void,
+              cb: (
+                state: "online" | "reconnecting" | "gave_up" | "fenced",
+              ) => void,
             ) => observableSession.onStateChange!(cb),
           }
         : {}),
@@ -167,7 +173,10 @@ export interface StartChannelsOverRealtimeGatewayOptions {
   apiKey: string;
   /** Authoritative org/project/channel scope echoed on every SDK→gateway envelope. */
   scope: ChannelRealtimeScope;
-  /** Stable runtime instance id (`rti_…`). */
+  /**
+   * One live Channel activation id (`rti_…`). Must be unique across concurrent
+   * replicas; reuse it only for transport reconnects of this activation.
+   */
   runtimeInstanceId: string;
   /** Adapter kind declared to the gateway on join (default `"slack"`). */
   adapter?: string;
@@ -290,7 +299,7 @@ export async function startChannelsOverRealtimeGateway(
     // so they stay correct even if that helper's internals change.
     onClose: (cb: () => void) => session.onClose(cb),
     onStateChange: (
-      cb: (state: "online" | "reconnecting" | "gave_up") => void,
+      cb: (state: "online" | "reconnecting" | "gave_up" | "fenced") => void,
     ) => session.onStateChange(cb),
     stop: async () => {
       // Always close the connection even if stopping the channels throws — the

--- a/packages/channels-intelligence/src/realtime-gateway.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.test.ts
@@ -172,6 +172,34 @@ function makeFakeWebSocket(mode: JoinMode) {
       });
     }
 
+    /**
+     * Simulate the gateway's explicit generation-fence notification followed by
+     * its clean `phx_close`. Phoenix treats that close as terminal and will not
+     * auto-rejoin this Channel instance.
+     */
+    triggerListenerFenced(): void {
+      if (this.lastJoinRef === undefined || this.lastTopic === undefined)
+        return;
+      this.onmessage?.({
+        data: JSON.stringify([
+          this.lastJoinRef,
+          null,
+          this.lastTopic,
+          "channel.listener_fenced.v1",
+          { reason: "listener_activation_fenced" },
+        ]),
+      });
+      this.onmessage?.({
+        data: JSON.stringify([
+          this.lastJoinRef,
+          null,
+          this.lastTopic,
+          "phx_close",
+          {},
+        ]),
+      });
+    }
+
     close(): void {
       this.closed = true;
       this.readyState = 3;
@@ -617,6 +645,35 @@ describe("connectRealtimeGateway — connection-health state (OSS-473)", () => {
     // ok reply restores online.
     await waitUntil(() => states.includes("online"), 8000);
     expect(states[states.length - 1]).toBe("online");
+
+    session.disconnect();
+  });
+
+  it("surfaces a superseded listener as fenced instead of pretending Phoenix will rejoin it", async () => {
+    const { FakeWebSocket, instances } = makeFakeWebSocket("ok");
+    const session = await connectRealtimeGateway({
+      wsUrl: "wss://gateway.example/socket",
+      apiKey: "cpk-test",
+      projectId: 7,
+      join: {
+        runtimeInstanceId: "rti_1",
+        declaredChannels: [{ channelName: "opentag", adapter: "slack" }],
+        observedAt: "2026-07-10T00:00:00.000Z",
+      },
+      webSocket: FakeWebSocket,
+    });
+
+    const states: string[] = [];
+    session.onStateChange((state) => states.push(state));
+
+    instances[0]!.triggerListenerFenced();
+
+    expect(states).toEqual(["fenced"]);
+    expect(
+      instances[0]!.frames.filter(
+        (frame) => Array.isArray(frame) && frame[3] === "phx_join",
+      ),
+    ).toHaveLength(1);
 
     session.disconnect();
   });

--- a/packages/channels-intelligence/src/realtime-gateway.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.ts
@@ -62,11 +62,16 @@ export interface ConnectRealtimeGatewayOptions {
  *   rejoin transitions back to `online` (self-healing a transient outage without
  *   a process restart) and re-arms the window so a genuinely fresh drop episode
  *   can transition back to `reconnecting`.
+ * - `fenced`: app-api superseded this listener activation generation. Terminal
+ *   for this Channel; Phoenix receives a clean close and does not auto-rejoin it.
  */
 export type RealtimeGatewayConnectionState =
   | "online"
   | "reconnecting"
-  | "gave_up";
+  | "gave_up"
+  | "fenced";
+
+const LISTENER_FENCED_EVENT = "channel.listener_fenced.v1";
 
 /**
  * Signals that a join was rejected because the declared channel/provider is not
@@ -206,6 +211,8 @@ export interface ConnectedRealtimeGatewaySession extends RealtimeGatewaySession 
    *   outage do NOT re-emit `reconnecting`. NOT terminal — a later SUCCESSFUL
    *   rejoin transitions back to `online` (a transient outage self-heals) and
    *   re-arms the window so a fresh drop episode can transition to `reconnecting`.
+   * - an explicit `channel.listener_fenced.v1` gateway event → terminal `fenced`;
+   *   the following clean Phoenix close is not reported as reconnecting.
    *
    * Our own {@link disconnect} is silent (it is not a drop). Distinct from
    * {@link onClose}, which is a single per-episode drop breadcrumb; this observer
@@ -276,6 +283,10 @@ export async function connectRealtimeGateway(
   // Set true when the give-up window fires; suppresses further `reconnecting`
   // emissions until a successful rejoin (`enterOnline`) clears it.
   let gaveUp = false;
+  // A generation-fenced Channel is terminal. Phoenix deliberately does not
+  // auto-rejoin a clean `phx_close`, and this latch prevents a later socket
+  // callback from misreporting that terminal close as a reconnecting outage.
+  let listenerFenced = false;
   const clearGiveUpTimer = (): void => {
     if (giveUpTimer !== undefined) {
       clearTimeout(giveUpTimer);
@@ -297,7 +308,7 @@ export async function connectRealtimeGateway(
     }
   };
   const enterReconnecting = (): void => {
-    if (closingIntentionally) return;
+    if (closingIntentionally || listenerFenced) return;
     // Sticky give-up: once the window has fired we stay `gave_up` while Phoenix
     // keeps retrying a dead link, so a failed retry during the SAME outage must
     // NOT re-enter `reconnecting`. Only a successful rejoin (`enterOnline`)
@@ -317,6 +328,7 @@ export async function connectRealtimeGateway(
     emitState("reconnecting");
   };
   const enterOnline = (): void => {
+    if (listenerFenced) return;
     // A successful (re)join heals the outage: clear the sticky latch and the
     // give-up timer so a FUTURE drop episode re-arms its own bounded window and
     // can transition `reconnecting` → `gave_up` again.
@@ -411,6 +423,14 @@ export async function connectRealtimeGateway(
   socket.onError(() => {
     notifyClose();
     enterReconnecting();
+  });
+  // The gateway sends this immediately before cleanly closing a superseded
+  // Channel. Record the terminal reason before Phoenix dispatches `phx_close`
+  // so the close hook below cannot imply that an auto-rejoin will occur.
+  channel.on(LISTENER_FENCED_EVENT, () => {
+    listenerFenced = true;
+    clearGiveUpTimer();
+    emitState("fenced");
   });
   // A CHANNEL-level close/error is ALSO non-sendable: Phoenix can error and
   // rejoin a channel while the socket stays open (so the socket handlers above

--- a/packages/channels-intelligence/src/runtime.ts
+++ b/packages/channels-intelligence/src/runtime.ts
@@ -63,7 +63,8 @@ export interface ChannelActivationMetadata extends ChannelActivationEnv {
  * Gather the process-level runtime activation env — `COPILOTKIT_RUNTIME_ENV`
  * (override) → `NODE_ENV` → "development", and the Node version. Caller
  * `overrides` win and supply what only the runtime knows: package versions
- * (`runtimePackageVersion`/`channelsPackageVersion`) and a stable `runtimeInstanceId`.
+ * (`runtimePackageVersion`/`channelsPackageVersion`) and an activation-scoped
+ * `runtimeInstanceId` that is stable only across transport reconnects.
  */
 export function resolveChannelActivationEnv(
   overrides: Partial<ChannelActivationEnv> = {},
@@ -147,7 +148,7 @@ export interface ChannelsHandle {
    * `ConnectedRealtimeGatewaySession.onStateChange` in `realtime-gateway.ts`).
    */
   onStateChange?(
-    cb: (state: "online" | "reconnecting" | "gave_up") => void,
+    cb: (state: "online" | "reconnecting" | "gave_up" | "fenced") => void,
   ): void;
 }
 

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager-reconnect.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager-reconnect.test.ts
@@ -10,11 +10,12 @@ import type { ActivateChannelEngine, ChannelsHandle } from "../channel-manager";
  * re-activate a Channel on a drop — but it MUST reflect real connection health
  * through the session's `onStateChange` observer so `status()` is honest rather
  * than reporting `online` forever after a drop. These tests pin that contract:
- * a drop → `reconnecting`, a rejoin → `online`, a bounded give-up → `error`,
- * with NO further engine call and the manager left coherent and usable.
+ * a drop → `reconnecting`, a rejoin → `online`, and either a bounded give-up or
+ * a generation fence → `error`, with NO further engine call and the manager
+ * left coherent and usable.
  * --------------------------------------------------------------------------------------------- */
 
-type ConnectionState = "online" | "reconnecting" | "gave_up";
+type ConnectionState = "online" | "reconnecting" | "gave_up" | "fenced";
 
 /** A CopilotKitIntelligence whose runner API key carries a parseable project id. */
 function fakeIntelligence(): CopilotKitIntelligence {

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
@@ -83,6 +83,33 @@ describe("ChannelManager", () => {
     await mgr.ready();
   });
 
+  it("marks a generation-fenced managed session as an explicit error", async () => {
+    let stateCallback:
+      | ((state: "online" | "reconnecting" | "gave_up" | "fenced") => void)
+      | undefined;
+    const logs: string[] = [];
+    const handle: ChannelsHandle = {
+      metadata: {},
+      stop: async () => {},
+      onStateChange: (callback) => {
+        stateCallback = callback;
+      },
+    };
+    const mgr = new ChannelManager({
+      intelligence: fakeIntelligence(),
+      channels: [createChannel({ name: "support" })],
+      activateChannel: async () => handle,
+      log: (message) => logs.push(message),
+    });
+
+    mgr.activate();
+    await mgr.ready();
+    stateCallback?.("fenced");
+
+    expect(mgr.status().channels.support).toBe("error");
+    expect(logs.some((message) => message.includes("fenced"))).toBe(true);
+  });
+
   it("does not call the engine at construction; stop() stops each handle once and is idempotent", async () => {
     const handleA = fakeHandle();
     const handleB = fakeHandle();

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -25,7 +25,8 @@ import type { Channel } from "@copilotkit/channels";
  *   session reports via its `onStateChange` observer.
  * - `stopped`: {@link ChannelManager.stop} has torn the Channel down.
  * - `error`: activation rejected with a non-setup error, OR a previously-online
- *   session gave up reconnecting after its bounded reconnect window.
+ *   session gave up reconnecting after its bounded reconnect window or was
+ *   generation-fenced by a replacement.
  *
  * Both MANAGED (Intelligence-gateway) and DIRECT (developer-supplied adapter)
  * Channels move through these states. A direct Channel is driven by the manager
@@ -114,7 +115,7 @@ export interface ChannelsHandle {
    * `handle.onStateChange?.(cb)`.
    */
   onStateChange?(
-    cb: (state: "online" | "reconnecting" | "gave_up") => void,
+    cb: (state: "online" | "reconnecting" | "gave_up" | "fenced") => void,
   ): void;
 }
 
@@ -797,7 +798,8 @@ export class ChannelManager implements ChannelsControl {
    *
    * - `reconnecting` → status `reconnecting` (dropped, Phoenix retrying);
    * - `online` → status `online` (rejoined, sendable again);
-   * - `gave_up` → status `error` (dead after the bounded reconnect window).
+   * - `gave_up` → status `error` (dead after the bounded reconnect window);
+   * - `fenced` → status `error` immediately (another activation superseded it).
    *
    * Makes NO re-activation — reconnection is delegated to the Phoenix connection
    * layer (see {@link ChannelManager}), which auto-rejoins under the persistent
@@ -822,10 +824,15 @@ export class ChannelManager implements ChannelsControl {
       } else if (state === "online") {
         entry.status = "online";
         this.log?.(`channel "${name}" managed session back online`);
-      } else {
+      } else if (state === "gave_up") {
         entry.status = "error";
         this.log?.(
           `channel "${name}" managed session gave up reconnecting; marking error`,
+        );
+      } else {
+        entry.status = "error";
+        this.log?.(
+          `channel "${name}" managed session was generation-fenced by a replacement; marking error`,
         );
       }
     });


### PR DESCRIPTION
## Problem

Realtime Channel deliveries could complete without a terminal `finalize` frame. Direct operations left the Connector Outbox lane open, output-free handlers had no accepted completion pointer, and a discrete operation after `runAgent()` could leave the agent's earlier finalize in the middle of the lane.

## Why

Only the agent renderer owned a finish lifecycle. Discrete operations bypassed it, and realtime delivery state started as already terminal, so handler completion did not guarantee that the lane ended in `finalize`.

## Fix

- Track sequence and terminal state together for each realtime turn.
- Start every realtime delivery as needing finalization, then append `finalize` after the handler only when its last accepted frame is non-terminal.
- Preserve deterministic sequence numbers on redelivery and avoid duplicating an agent run's existing finalizer.
- Treat the gateway's explicit listener-fenced signal as an immediate terminal error instead of claiming a clean Phoenix channel close will reconnect.
- Document that runtime instance ids are unique per live Channel activation, stable only across that activation's transport reconnects, and re-minted on restart.
- Cover direct post, output-free, and `finalize → post → finalize` lifecycles while retaining the never-self-ack assertion.
- Verify with formatting, lint, typechecks, builds, all 185 Channels Intelligence tests, all 1,755 runtime tests, and the repository pre-commit package checks.
