### PR TITLE
chore(showcase): compile-time exhaustiveness for cell-model vocabularies

### DIFF
--- a/showcase/harness/src/probes/helpers/starter-mapping.ts
+++ b/showcase/harness/src/probes/helpers/starter-mapping.ts
@@ -32,6 +32,10 @@
  * key spaces are disjoint.
  */
 
+// Type-only: feeds the `STARTER_LEVELS` parity pin below. Erased at emit, so no
+// runtime import edge from the probe helpers into the shared cell-model fold.
+import type { StarterLevel as SharedStarterLevel } from "../../shared/cell-model/live-status.js";
+
 /**
  * Starter slug (as it appears in the smoke matrix) → dashboard column slug
  * (the `showcase/integrations/<slug>` directory name).
@@ -67,6 +71,33 @@ export const STARTER_LEVELS = [
 ] as const;
 
 export type StarterLevel = (typeof STARTER_LEVELS)[number];
+
+/**
+ * Compile-time parity pin between THIS producer-side level list and the
+ * consumer-side `STARTER_LEVELS` in `shared/cell-model/live-status.ts`, whose
+ * doc comment asserts the two lists MIRROR each other. Before this pin the claim
+ * was prose only: either copy could gain or lose a level and both packages would
+ * still build, leaving the producer emitting a `starter:<col>/<level>` row the
+ * dashboard has no sub-row for (or vice versa).
+ *
+ * Intersecting the two `Record<…, true>`s makes the mirror bidirectional and
+ * compiler-checked: a level missing from EITHER side is `Property '<level>' is
+ * missing in type … but required in type 'Record<StarterLevel, true>'` (the
+ * message names whichever side is unsatisfied), and a name in neither union
+ * fails as an excess property. `import type` keeps this a pure type-level
+ * dependency — nothing is emitted, so no runtime import edge is created from the
+ * probe helpers into the shared fold.
+ */
+type StarterLevelMirror = Record<StarterLevel, true> &
+  Record<SharedStarterLevel, true>;
+
+const starterLevelsMirrorShared = {
+  health: true,
+  agent: true,
+  chat: true,
+  interaction: true,
+} satisfies StarterLevelMirror;
+void starterLevelsMirrorShared;
 
 /**
  * Resolve a starter slug to its dashboard column slug, or `undefined` if the

--- a/showcase/harness/src/shared/cell-model/cell-model-v2.test.ts
+++ b/showcase/harness/src/shared/cell-model/cell-model-v2.test.ts
@@ -11,8 +11,14 @@
  */
 import { describe, it, expect } from "vitest";
 import type { StatusRow, State } from "./live-status.js";
-import { keyFor, mergeRowsToMap, CATALOG_TO_D5_KEY } from "./live-status.js";
-import { buildCellModel, type CellModelInput } from "./cell-model.js";
+import {
+  keyFor,
+  mergeRowsToMap,
+  CATALOG_TO_D5_KEY,
+  STARTER_LEVELS,
+} from "./live-status.js";
+import { buildCellModel } from "./cell-model.js";
+import type { CellModelInput } from "./cell-model.js";
 import { E2E_STALE_AFTER_MS, FUTURE_SKEW_TOLERANCE_MS } from "./staleness.js";
 
 const NOW = Date.parse("2026-06-04T12:00:00.000Z");
@@ -151,7 +157,10 @@ describe("§7 §C: first-strike de-amplification", () => {
 
   it("starter soft-miss fail_count 1 → amber chip", () => {
     const col = "langgraph-python";
-    const levels = ["health", "agent", "chat", "interaction"];
+    // DERIVED from the real constant, not a literal copy: the engine keys
+    // starter sub-rows off `STARTER_LEVELS`, so a level added there is probed
+    // here too instead of leaving this scenario silently short a sub-row.
+    const levels = STARTER_LEVELS;
     const live = mergeRowsToMap(
       levels.map((lvl, i) =>
         i === 0

--- a/showcase/harness/src/shared/cell-model/cell-model.contribution.test.ts
+++ b/showcase/harness/src/shared/cell-model/cell-model.contribution.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import type { StatusRow, State } from "./live-status.js";
 import {
+  ALL_CONTRIBUTION_KINDS,
   CHIP_SEVERITY,
   worseOf,
   severityIndex,
@@ -8,10 +9,8 @@ import {
   firstStrikeConfig,
   D4_FIRST_STRIKE_THRESHOLD,
   classifyRung,
-  type RawRung,
-  type RungKind,
-  type ContributionKind,
 } from "./cell-model.contribution.js";
+import type { RawRung, RungKind } from "./cell-model.contribution.js";
 import { E2E_STALE_AFTER_MS, FUTURE_SKEW_TOLERANCE_MS } from "./staleness.js";
 
 const NOW = Date.parse("2026-06-04T12:00:00.000Z");
@@ -91,18 +90,12 @@ describe("contribution lattices + config", () => {
   });
 
   it("severityIndex is defined (>= 0) for EVERY kind — no kind sorts worst-but-gray (fail-safe polarity)", () => {
-    const ALL: ContributionKind[] = [
-      "UNSUPPORTED",
-      "STUB",
-      "ABSENT",
-      "NO_DATA",
-      "GREEN_FRESH",
-      "STALE_DEGRADED",
-      "FIRST_STRIKE_FRESH",
-      "INFRA_RED_FRESH",
-      "FAIL_FRESH",
-    ];
-    for (const k of ALL) {
+    // DERIVED, not hand-copied: `ALL_CONTRIBUTION_KINDS` comes from the
+    // engine's `satisfies Record<ContributionKind, true>` completeness registry,
+    // so a kind added to the union either lands in this loop automatically or
+    // reds `tsc` at the registry. The previous literal list here claimed to
+    // cover "EVERY kind" but was a snapshot — a new kind escaped it silently.
+    for (const k of ALL_CONTRIBUTION_KINDS) {
       // Never -1: an unrecognized kind must not sort as the WORST in a fold
       // and then render gray (masking a real red). `severityKind` is exhaustive.
       expect(severityIndex(k)).toBeGreaterThanOrEqual(0);

--- a/showcase/harness/src/shared/cell-model/cell-model.contribution.ts
+++ b/showcase/harness/src/shared/cell-model/cell-model.contribution.ts
@@ -118,6 +118,43 @@ export type ContributionKind =
   | "INFRA_RED_FRESH"
   | "FAIL_FRESH";
 
+/**
+ * Completeness registry over `ContributionKind` — the compile-time PROOF that
+ * `ALL_CONTRIBUTION_KINDS` below is exhaustive, so nothing has to hand-copy the
+ * union's members and claim it covers "every kind".
+ *
+ * `satisfies Record<ContributionKind, true>` checks BOTH directions: adding a
+ * member to the union without listing it here fails the build with `Property
+ * '<NEW_KIND>' is missing in type … but required in type
+ * 'Record<ContributionKind, true>'`, and listing a name that is NOT a kind
+ * fails as an excess property. A hand-copied list has neither property — it
+ * silently under-enumerates the moment the union grows, which is exactly how an
+ * "exhaustive" guard rots into a partial one.
+ *
+ * Anything that needs "every kind" must derive it from `ALL_CONTRIBUTION_KINDS`
+ * rather than restating the list.
+ */
+const CONTRIBUTION_KIND_COMPLETENESS = {
+  UNSUPPORTED: true,
+  STUB: true,
+  ABSENT: true,
+  NO_DATA: true,
+  GREEN_FRESH: true,
+  STALE_DEGRADED: true,
+  FIRST_STRIKE_FRESH: true,
+  INFRA_RED_FRESH: true,
+  FAIL_FRESH: true,
+} satisfies Record<ContributionKind, true>;
+
+/**
+ * EVERY `ContributionKind`, derived from the completeness registry above (never
+ * hand-maintained). Order is the registry's declaration order, which mirrors the
+ * union's — it carries no severity meaning (that is `CHIP_SEVERITY`).
+ */
+export const ALL_CONTRIBUTION_KINDS = Object.keys(
+  CONTRIBUTION_KIND_COMPLETENESS,
+) as ReadonlyArray<keyof typeof CONTRIBUTION_KIND_COMPLETENESS>;
+
 export type RungKind = "D1" | "D2" | "D3" | "D4" | "D5" | "D6" | "starter";
 
 /** Stage A output — the raw PB rows a ladder position reads, no interpretation. */
@@ -147,18 +184,60 @@ export interface RungContribution {
 }
 
 /**
- * §4a chip severity, MOST-SEVERE FIRST (lower index = worse). `INFRA_RED_FRESH`
- * is re-mapped to `NO_DATA` severity BEFORE the fold (it is not a product red),
- * so it is not listed here.
+ * The kinds `severityKind` can RETURN — i.e. the closed set `CHIP_SEVERITY`
+ * must rank. The three excluded kinds are re-mapped to a peer BEFORE the fold
+ * (`INFRA_RED_FRESH` → `NO_DATA`; `UNSUPPORTED`/`STUB` → `ABSENT`), so they are
+ * deliberately absent from the severity order rather than missing from it.
  */
-export const CHIP_SEVERITY: ReadonlyArray<ContributionKind> = [
+type ChipSeverityKind = Exclude<
+  ContributionKind,
+  "INFRA_RED_FRESH" | "UNSUPPORTED" | "STUB"
+>;
+
+/**
+ * §4a chip severity, MOST-SEVERE FIRST (lower index = worse) — the ORDER is
+ * load-bearing, so this stays a literal (a derived-from-`Object.keys` list would
+ * make severity depend on key insertion order). The completeness PIN below is
+ * what stops it from silently under-covering the union.
+ */
+const CHIP_SEVERITY_ORDER = [
   "FAIL_FRESH",
   "STALE_DEGRADED",
   "FIRST_STRIKE_FRESH",
   "NO_DATA",
   "ABSENT",
   "GREEN_FRESH",
-];
+] as const;
+
+/**
+ * §4a chip severity, MOST-SEVERE FIRST (lower index = worse). `INFRA_RED_FRESH`
+ * is re-mapped to `NO_DATA` severity BEFORE the fold (it is not a product red),
+ * so it is not listed here.
+ */
+export const CHIP_SEVERITY: ReadonlyArray<ContributionKind> =
+  CHIP_SEVERITY_ORDER;
+
+/**
+ * Compile-time completeness pin for `CHIP_SEVERITY` — `Record<never, true>`
+ * (satisfied by `{}`) exactly when the severity order covers the severity-peer
+ * set with nothing left over. If a new `ContributionKind` reaches
+ * `severityKind`'s `return c` branch without being added to
+ * `CHIP_SEVERITY_ORDER`, this line fails to typecheck with `Property
+ * '<NEW_KIND>' is missing`; adding a name to `CHIP_SEVERITY_ORDER` that is
+ * re-mapped away (or is not a kind at all) fails the same way from the other
+ * direction.
+ *
+ * Without this pin, `severityIndex`'s `indexOf` returns -1 for the new kind —
+ * which sorts as MORE severe than `FAIL_FRESH` in `worseOf` and then renders
+ * gray via `contributionToColor`'s `default`: the fail-safe-polarity bug where a
+ * real red is masked by a gray chip. `assertNever` in `severityKind` alone does
+ * not catch it (handling the new kind with `return c` satisfies the switch).
+ */
+type ChipSeverityGap =
+  | Exclude<ChipSeverityKind, (typeof CHIP_SEVERITY_ORDER)[number]>
+  | Exclude<(typeof CHIP_SEVERITY_ORDER)[number], ChipSeverityKind>;
+const chipSeverityIsComplete: Record<ChipSeverityGap, true> = {};
+void chipSeverityIsComplete;
 
 /** Compile-time exhaustiveness guard — an added `ContributionKind` that no
  * `switch` handles narrows to `never` here and becomes a build error. */

--- a/showcase/harness/src/shared/cell-model/live-status.ts
+++ b/showcase/harness/src/shared/cell-model/live-status.ts
@@ -746,6 +746,12 @@ export function resolveD4Row(
  * `showcase/harness/src/probes/helpers/starter-mapping.ts` — the harness owns
  * the producer-side list, the dashboard carries its own copy because the two
  * packages do not share a module boundary (the dashboard imports only `@/*`).
+ *
+ * That mirror is COMPILER-ENFORCED, not just documented: `starter-mapping.ts`
+ * carries a `satisfies Record<StarterLevel, true>` parity pin against the
+ * `StarterLevel` exported here, so a level added to or dropped from EITHER copy
+ * fails the harness build (`tsc -p tsconfig.build.json`) rather than drifting
+ * silently into a producer row the dashboard has no sub-row for.
  */
 export const STARTER_LEVELS = [
   "health",

--- a/showcase/shell-dashboard/src/components/__tests__/dashboard-color-matrix.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/dashboard-color-matrix.test.tsx
@@ -578,7 +578,11 @@ describe("(3) per-cell D6 vs aggregate precedence (c64aebc42)", () => {
 
 describe("(4) depth chip rendering D0..D6 × wired/unwired", () => {
   // chipColorToClass mapping is the pure contract; assert each color.
-  const colors: ChipColor[] = ["green", "amber", "red", "gray"];
+  // DERIVED from `CHIP_CLASS`, which is `Record<ChipColor, string>` and so is
+  // already compiler-complete over the union: a new `ChipColor` reds `tsc` at
+  // CHIP_CLASS and then flows into this loop, instead of quietly skipping the
+  // new colour the way the previous hand-copied literal did.
+  const colors = Object.keys(CHIP_CLASS) as ChipColor[];
   for (const color of colors) {
     it(`chipColorToClass('${color}') → ${CHIP_CLASS[color]}`, () => {
       expect(chipColorToClass(color)).toBe(CHIP_CLASS[color]);


### PR DESCRIPTION
## What

Hand-maintained lists that **claim** to enumerate a union but are not compiler-enforced rot silently: the union grows, the list does not, and an "exhaustive" guard quietly becomes a partial one. This adds `satisfies Record<K, true>` completeness registries next to the union declarations and derives the previously hand-copied lists from them.

Strictly additive — **no product behavior changes**, no decoder handling altered. Three source-side pins, three test lists switched from a literal to the derived source of truth.

## Unions covered

| Union / list | Where the pin lives | What it prevents |
|---|---|---|
| `ContributionKind` | `cell-model.contribution.ts` — `CONTRIBUTION_KIND_COMPLETENESS satisfies Record<ContributionKind, true>`, exported as `ALL_CONTRIBUTION_KINDS` | A new kind escaping the "covers EVERY kind" guard in `cell-model.contribution.test.ts` |
| `CHIP_SEVERITY` coverage | `cell-model.contribution.ts` — bidirectional `Exclude`-based pin against the severity-peer set | See below — a real red masked by a gray chip |
| `STARTER_LEVELS` (producer ↔ consumer copies) | `starter-mapping.ts` — `satisfies Record<StarterLevel, true> & Record<SharedStarterLevel, true>` | A level drifting between the two copies, so the producer emits a `starter:<col>/<level>` row the dashboard has no sub-row for |
| `ChipColor` | already enforced by `CHIP_CLASS: Record<ChipColor, string>` | The test's colour loop now derives from it rather than re-copying it |

### Why the `CHIP_SEVERITY` pin matters

`severityKind`'s existing `assertNever` does **not** catch a new `ContributionKind` handled by its `return c` branch. Such a kind reaches `CHIP_SEVERITY.indexOf` as `-1`, which sorts as **more severe than `FAIL_FRESH`** in `worseOf`, and then renders gray via `contributionToColor`'s `default` — the fail-safe-polarity bug where a genuine red is masked by a gray chip. The test at `cell-model.contribution.test.ts` was the only guard, and no CI job invokes the harness unit suite. This pin moves that guard to compile time.

The severity **order** stays a literal on purpose: order is load-bearing, so deriving the list from `Object.keys` would make severity depend on object key-insertion order. The pin enforces completeness without touching ordering.

## Found but deferred

- **`RungKind`** — the audit named `ALL_RUNG_KINDS`, but on `main` every `RungKind` array is a deliberate **subset** (`["D1","D2"]`, `["D3","D4","D5"]`, the ceiling-dependent list in `cell-model.combine.test.ts`), not a false exhaustiveness claim. Adding an unused export would be speculative. The audit's real target is the `contributingKeys` drift guard in `cell-model.coherence.test.ts`, which lives on #6156.
- **`LiveDimension`, `FleetSurfaceState`, `TestStatus`, `State`** — swept, no hand-maintained list claiming to enumerate them. `commError-contract-drift.test.ts` already pins `FleetSurfaceState`'s overlay members with `satisfies`, and it is deliberately a subset (the two packages' unions are expressed over different base colour vocabularies).
- **Sites that only exist on #6156** (`fix/cold-load-gray-masks-red`, head `938be2accf2a`) — that PR is unmerged, so these need the same treatment once it lands:
  - `cell-model.coherence.test.ts` `contributingKeys` drift guard — wants `contributingKeysFor(input)` exported from the engine and the guard deriving from it (currently catches only TOTAL drift).
  - `STARTER_FIRST_STRIKE_THRESHOLD` — hand-restated rather than imported.
  - The `matrix.ts` / `live-status.ts` decoder vocabularies where a decoder handles a subset of an enum with no compile-time proof the subset is complete. Note this one is a **design** question, not a mechanical pin: the subset may be intentional, in which case the pin belongs on the intentional-exclusion list (as `ChipSeverityKind` does here).

## Fail-then-pass proof

All run with `tsc -p tsconfig.build.json` in `showcase/harness` (the harness build), and `npm run typecheck` in `showcase/shell-dashboard`.

**Baseline (clean):** exit 0 both.

**RED — add `"PROOF_NEW_KIND"` to `ContributionKind`:**

```
cell-model.contribution.ts(148,3): error TS1360: Type '{ UNSUPPORTED: true; ... FAIL_FRESH: true; }'
  does not satisfy the expected type 'Record<ContributionKind, true>'.
  Property 'PROOF_NEW_KIND' is missing in type '{ ... }' but required in type 'Record<ContributionKind, true>'.
cell-model.contribution.ts(240,7): error TS2741: Property 'PROOF_NEW_KIND' is missing in type '{}'
  but required in type 'Record<"PROOF_NEW_KIND", true>'.
cell-model.contribution.ts(270,26): error TS2345: Argument of type '"PROOF_NEW_KIND"' is not assignable to parameter of type 'never'.
EXIT=2
```

Line 148 is the completeness registry, line 240 is the `CHIP_SEVERITY` pin, line 270 is the pre-existing `assertNever`. **GREEN** — after listing the kind in the registry, in `CHIP_SEVERITY_ORDER`, and in the `severityKind` switch: `EXIT=0`.

**RED — add a level to the producer copy only** (`starter-mapping.ts`):

```
starter-mapping.ts(100,3): error TS1360: Type '{ health: true; agent: true; chat: true; interaction: true; }'
  does not satisfy the expected type 'StarterLevelMirror'.
EXIT=2
```

**RED — add a level to the consumer copy only** (`shared/cell-model/live-status.ts`) — the pin fires from the other side too:

```
starter-mapping.ts(95,40): error TS1360: ... Property 'proofLevel' is missing ...
  but required in type 'Record<"health" | "agent" | "chat" | "interaction" | "proofLevel", true>'.
live-status.ts(900,7): error TS2741: Property 'proofLevel' is missing ...
EXIT=2
```

**RED — add `"proofColor"` to `ChipColor`** (dashboard):

```
dashboard-color-matrix.test.tsx(194,7): error TS2741: Property 'proofColor' is missing in type
  '{ green: string; amber: string; red: string; gray: string; }' but required in type 'Record<ChipColor, string>'.
```

Every proof was reverted; the branch typechecks and builds clean.

## Which CI job enforces it — corrected

The convergence audit predicted `check-types`. **That is wrong for `showcase/harness`, and it is worth recording:**

- `showcase/harness/package.json` declares `typecheck`, **not** `check-types`, so `npx nx run-many -t check-types` (the `check-types` job in `static_quality.yml`) does **not** cover it.
- `typecheck` appears in **zero** workflows — `grep -rn "typecheck" .github/workflows/` returns nothing.

What actually gates these pins is the harness **build**, `tsc -p tsconfig.build.json`, run by:

1. **`showcase_validate.yml`** → *"Harness ESM boot-smoke"* step, `working-directory: showcase/harness`, `run: pnpm build`.
2. **`showcase_build_check.yml`** → the `showcase-harness` Docker slot (`showcase/harness/Dockerfile`).

All three source-side pins live in `src/` non-test files, so they are inside `tsconfig.build.json`'s include and genuinely gate. The dashboard-side `ChipColor` derivation is gated by `next build` (no `typescript.ignoreBuildErrors` in `next.config.ts`) plus the dashboard Docker slot.

Caveat worth a follow-up: `tsconfig.build.json` **excludes `**/*.test.ts`**, so the harness *test* files are not typechecked by any CI job. The pins are all in `src/`, so this does not weaken them. Adding a `check-types` script to `showcase/harness` would close that gap, but it is **not** done here: the full `tsc --noEmit` (which includes tests) has a **pre-existing** unrelated failure, `src/probes/frontend-matrix.test.ts(3,29): error TS2307: Cannot find module '../../../shell/src/data/frontend-catalog.json'` (a generated file), so wiring it up today would red `main`.

## Verification

- Harness build `tsc -p tsconfig.build.json`: clean (0), before and after.
- Dashboard `npm run typecheck`: clean (0) once the generated `@/data/*.json` files exist (`generate-registry.ts` / `probe-docs.ts`, the `pretest`/`prebuild` step).
- `oxfmt --check`: all 6 changed files correctly formatted.
- `oxlint`: 0 errors. Warning count on `cell-model.contribution.test.ts` went **3 → 1** (removing an unused inline type specifier); the two `d5Family`/`d6Family` unused-function warnings in the dashboard test are pre-existing and untouched.
- Tests: 230 passed in `showcase/harness` (`src/shared/cell-model/`, `starter-mapping-drift`, `starter-smoke`); 54 passed in the dashboard colour-matrix suite.
- Two harness failures in `src/probes/helpers/` — `d5-mapping-drift` and `d5-representatives` (`D5_REPRESENTATIVES is missing entries for registered feature types: browser-use-smoke`) — were confirmed **pre-existing** by re-running them on a pristine tree. Unrelated to this change.
- **No assertion's meaning changed.** Each test derives the same values in the same order from the real constant instead of a literal copy.
