### PR TITLE
test(showcase): vacuity + constant-drift gate for the #6156 toothless-guard classes

### DIFF
--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -371,6 +371,26 @@ jobs:
           fi
           echo "Pin drift unchanged at baseline ($baseline, hash $baseline_hash)."
 
+      - name: Run test-vacuity + constant-drift gate
+        working-directory: showcase/scripts
+        # Fails the PR on assertions that are satisfied by the DEGENERATE input
+        # (`Math.max(...[])` is -Infinity, so an upper bound holds when zero
+        # elements were produced), on one-sided pins of tuned constants (a cap
+        # asserted only as `toBeLessThanOrEqual` cannot catch the source value
+        # being lowered), and on drift between knowingly-duplicated constants
+        # (`duplicated-constants.json`). Pre-existing violations are grandfathered
+        # by the dated, individually-justified, SHRINK-ONLY
+        # `test-vacuity-allowlist.json`; a stale entry (its violation fixed but
+        # the entry left behind) also fails. See
+        # showcase/scripts/lib/test-vacuity-core.ts for why each rule exists.
+        #
+        # The same checks also run inside the vitest step below (as
+        # __tests__/validate-test-vacuity.test.ts) — that is the real gate and
+        # cannot be forgotten. This step exists so the failure is NAMED in the
+        # CI log instead of being one assertion among a thousand, and so the
+        # CLI's exit code is exercised. Runtime ~0.6s over ~1,190 test files.
+        run: pnpm exec tsx validate-test-vacuity.ts
+
       - name: Run build pipeline tests
         working-directory: showcase/scripts
         # Use pnpm to resolve the workspace-installed vitest (pinned via

--- a/showcase/scripts/__tests__/validate-test-vacuity.test.ts
+++ b/showcase/scripts/__tests__/validate-test-vacuity.test.ts
@@ -1,0 +1,650 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+import {
+  MIN_OPT_OUT_REASON_LENGTH,
+  checkDuplicatedConstants,
+  evalNumericLiteralExpr,
+  maskNonCode,
+  readConstantDeclaration,
+  scanTestSource,
+} from "../lib/test-vacuity-core.js";
+import type { Violation } from "../lib/test-vacuity-core.js";
+import {
+  ALLOWLIST_PATH,
+  DUPLICATED_CONSTANTS_PATH,
+  loadAllowlist,
+  loadDuplicatedConstants,
+  runGate,
+} from "../validate-test-vacuity.js";
+import { REPO_ROOT } from "./paths";
+
+// ===========================================================================
+// This file is BOTH the unit suite for the vacuity/drift gate AND the gate
+// itself: the final `describe` runs it over the whole showcase tree and fails
+// on anything not in the dated allowlist. It is picked up by the
+// `pnpm exec vitest run` step ("Run build pipeline tests") in
+// .github/workflows/showcase_validate.yml, which fires on every PR touching
+// showcase/** — i.e. the gate rides CI that already runs today.
+//
+// Every violating snippet below lives in a STRING, so the gate scanning this
+// very file must not flag them. That is asserted explicitly at the bottom.
+// ===========================================================================
+
+const rules = (vs: Violation[]): string[] => vs.map((v) => v.rule);
+const scan = (src: string, file = "showcase/x/fake.test.ts"): Violation[] =>
+  scanTestSource(file, src);
+
+// ---------------------------------------------------------------------------
+// Masking
+// ---------------------------------------------------------------------------
+
+describe("maskNonCode", () => {
+  it("preserves length and every newline so line numbers stay exact", () => {
+    const src =
+      'const a = 1; // note\nconst b = "str";\n/* x\ny */\nconst c = 2;\n';
+    const masked = maskNonCode(src);
+    expect(masked).toHaveLength(src.length);
+    expect(masked.split("\n")).toHaveLength(src.split("\n").length);
+  });
+
+  it("blanks comments, strings and template literals but keeps code", () => {
+    const masked = maskNonCode(
+      "expect(1).toBe(1); // expect(Math.max(...xs)).toBe(0)\n",
+    );
+    expect(masked).toContain("expect(1).toBe(1);");
+    expect(masked).not.toContain("Math.max");
+  });
+
+  it("does not mistake a URL inside a regex literal for a line comment", () => {
+    // `/https?:\/\//` contains `//`. A naive comment stripper eats the rest of
+    // the line and the code after it becomes invisible to every rule.
+    const src = "const re = /https?:\\/\\//; expect(xs).toHaveLength(2);\n";
+    const masked = maskNonCode(src);
+    expect(masked).toContain("expect(xs).toHaveLength(2);");
+  });
+
+  it("treats `/` after an identifier or `)` as division, not a regex", () => {
+    const src = "const r = total / count; const s = f(1) / 2; const t = 3;\n";
+    expect(maskNonCode(src)).toContain("const t = 3;");
+  });
+
+  it("keeps a `/` inside a regex character class from closing the literal", () => {
+    const src = "const re = /[/]x/; expect(ys).toHaveLength(1);\n";
+    expect(maskNonCode(src)).toContain("expect(ys).toHaveLength(1);");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A1 — degenerate-input vacuity
+// ---------------------------------------------------------------------------
+
+describe("degenerate-spread-aggregate (A1)", () => {
+  it("flags the REAL #6156 shape: expect(Math.max(...pages)) against a cap", () => {
+    // Verbatim shape from useLiveStatus.supplemental-bounds.test.tsx:406-417.
+    const src = `
+      const EXPECTED_MAX_INITIAL_PAGES = 20;
+      it("stops after the cap", () => {
+        expect(runawaySupplementalPages.length).toBeLessThanOrEqual(
+          EXPECTED_MAX_INITIAL_PAGES,
+        );
+        expect(Math.max(...runawaySupplementalPages)).toBeLessThanOrEqual(
+          EXPECTED_MAX_INITIAL_PAGES,
+        );
+        expect(runawaySupplementalPages).not.toContain(
+          EXPECTED_MAX_INITIAL_PAGES + 1,
+        );
+      });
+    `;
+    const found = scan(src).filter(
+      (v) => v.rule === "degenerate-spread-aggregate",
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].symbol).toBe("runawaySupplementalPages");
+    expect(found[0].message).toContain("-Infinity");
+  });
+
+  it("flags the HOISTED variant — the aggregate reaches expect() via a const", () => {
+    // Syntactically different from anything in the review, same defect: nothing
+    // here mentions Math.max inside expect(), so a grep for the reviewed idiom
+    // misses it entirely.
+    const src = `
+      it("caps the walk", () => {
+        const highestPageRequested = Math.max(...pagesRequested);
+        expect(highestPageRequested).toBeLessThanOrEqual(20);
+      });
+    `;
+    const found = scan(src);
+    expect(rules(found)).toContain("degenerate-spread-aggregate");
+    expect(found[0].symbol).toBe("pagesRequested");
+  });
+
+  it("flags Math.min used as a LOWER bound (the +Infinity trapdoor)", () => {
+    const src = `
+      it("never goes below the floor", () => {
+        expect(Math.min(...observedDelays)).toBeGreaterThanOrEqual(100);
+      });
+    `;
+    expect(rules(scan(src))).toContain("degenerate-spread-aggregate");
+  });
+
+  it("flags a seeded spread too — Math.max(0, ...xs) is still 0 on empty", () => {
+    const src = `
+      it("reads at most once", () => {
+        expect(Math.max(0, ...perPollCounts)).toBeLessThanOrEqual(1);
+      });
+    `;
+    expect(rules(scan(src))).toContain("degenerate-spread-aggregate");
+  });
+
+  it("accepts a spread whose collection is pinned non-empty", () => {
+    for (const guard of [
+      "expect(pages).toHaveLength(4);",
+      "expect(pages).not.toHaveLength(0);",
+      "expect(pages.length).toBeGreaterThan(0);",
+      "expect(pages.length).toBeGreaterThanOrEqual(1);",
+      "expect(pages).toContain(1);",
+      "expect(pages).toEqual([1, 2, 3]);",
+    ]) {
+      const src = `
+        it("caps the walk", () => {
+          ${guard}
+          expect(Math.max(...pages)).toBeLessThanOrEqual(20);
+        });
+      `;
+      expect(rules(scan(src)), guard).not.toContain(
+        "degenerate-spread-aggregate",
+      );
+    }
+  });
+
+  it("rejects guards that are themselves satisfied by the empty input", () => {
+    for (const nonGuard of [
+      "expect(pages).toHaveLength(0);",
+      "expect(pages).toEqual([]);",
+      "expect(pages.length).toBeGreaterThanOrEqual(0);",
+      "expect(pages).not.toContain(21);",
+    ]) {
+      const src = `
+        it("caps the walk", () => {
+          ${nonGuard}
+          expect(Math.max(...pages)).toBeLessThanOrEqual(20);
+        });
+      `;
+      expect(rules(scan(src)), nonGuard).toContain(
+        "degenerate-spread-aggregate",
+      );
+    }
+  });
+
+  it("ignores Math.max with fixed arity and no spread", () => {
+    const src = `it("x", () => { expect(Math.max(a, b)).toBeLessThan(9); });`;
+    expect(rules(scan(src))).not.toContain("degenerate-spread-aggregate");
+  });
+
+  it("ignores a spread aggregate that never reaches an assertion", () => {
+    const src = `
+      const widest = Math.max(...columnWidths);
+      function render() { return widest; }
+    `;
+    expect(rules(scan(src))).not.toContain("degenerate-spread-aggregate");
+  });
+
+  it("treats .map() as length-preserving: guarding the base is enough", () => {
+    // Real shape from probes/frontend-matrix.test.ts — `first` is pinned to 32
+    // and `.map` cannot shorten it, so this is NOT vacuous.
+    const src = `
+      it("shards evenly", () => {
+        expect(first).toHaveLength(32);
+        expect(Math.max(...first.map((shard) => shard.length))).toBeLessThanOrEqual(
+          Math.min(...first.map((shard) => shard.length)) + 1,
+        );
+      });
+    `;
+    expect(rules(scan(src))).not.toContain("degenerate-filtered-aggregate");
+  });
+
+  it("does NOT accept a base-identifier guard for a FILTERED spread", () => {
+    const src = `
+      it("caps the reds", () => {
+        expect(rows).toHaveLength(12);
+        expect(Math.max(...rows.filter((r) => r.red).map((r) => r.age))).toBeLessThanOrEqual(60);
+      });
+    `;
+    const found = scan(src).filter(
+      (v) => v.rule === "degenerate-filtered-aggregate",
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].message).toContain(
+      "derived/filtered set can still be empty",
+    );
+  });
+
+  it("honours a loop that guards every bucket of an object", () => {
+    // Real shape from calculator-fixture-routing.test.ts, including the
+    // two-argument `expect(value, message)` form.
+    const src = `
+      it("orders entries", () => {
+        for (const [bucket, indices] of Object.entries(idx)) {
+          expect(indices.length, \`no \${bucket} entries\`).toBeGreaterThan(0);
+        }
+        expect(Math.max(...idx.followUps)).toBeLessThan(Math.min(...leg1));
+      });
+    `;
+    expect(rules(scan(src))).not.toContain("degenerate-spread-aggregate");
+  });
+});
+
+describe("degenerate-filtered-aggregate (A1)", () => {
+  it("flags .every() over a filtered collection — [].every(p) is always true", () => {
+    const src = `
+      it("all retries are backed off", () => {
+        expect(attempts.filter((a) => a.retried).every((a) => a.delayMs >= 900)).toBe(true);
+      });
+    `;
+    const found = scan(src);
+    expect(rules(found)).toContain("degenerate-filtered-aggregate");
+    expect(found[0].message).toContain(
+      "[].every(p) is true for EVERY predicate",
+    );
+  });
+
+  it("flags .reduce() over a filtered collection — the seed passes through", () => {
+    const src = `
+      it("stays under the cap", () => {
+        expect(
+          pages.filter((p) => p > 0).reduce((a, b) => Math.max(a, b), 0),
+        ).toBeLessThanOrEqual(20);
+      });
+    `;
+    expect(rules(scan(src))).toContain("degenerate-filtered-aggregate");
+  });
+
+  it("accepts a filtered aggregate whose filtered set is size-pinned", () => {
+    const src = `
+      it("all retries are backed off", () => {
+        expect(attempts.filter((a) => a.retried)).toHaveLength(3);
+        expect(attempts.filter((a) => a.retried).every((a) => a.delayMs >= 900)).toBe(true);
+      });
+    `;
+    expect(rules(scan(src))).not.toContain("degenerate-filtered-aggregate");
+  });
+
+  it("ignores .every() with no filter in the chain", () => {
+    const src = `
+      it("all rows have keys", () => {
+        expect(rows).toHaveLength(3);
+        expect(rows.every((r) => r.key)).toBe(true);
+      });
+    `;
+    expect(rules(scan(src))).not.toContain("degenerate-filtered-aggregate");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A2 — one-sided pins and hand-copied source-of-truth
+// ---------------------------------------------------------------------------
+
+describe("one-sided-tuned-constant (A2)", () => {
+  it("flags the REAL #6156 pin: a cap asserted only as an upper bound", () => {
+    // Verbatim structure of EXPECTED_MAX_INITIAL_PAGES, including prettier's
+    // wrapped argument with its dangling comma. Reviewers PROVED that lowering
+    // the production constant to 10 — and to 5 — kept this suite green.
+    const src = `
+      /**
+       * The supplemental fetch's page cap. MUST match \`MAX_INITIAL_FETCH_PAGES\` in
+       * \`useLiveStatus.ts\`; pinned as a literal here on purpose.
+       */
+      const EXPECTED_MAX_INITIAL_PAGES = 20;
+
+      it("stops at the cap", () => {
+        expect(pagesRequested.length).toBeLessThanOrEqual(
+          EXPECTED_MAX_INITIAL_PAGES,
+        );
+        expect(pagesRequested).not.toContain(EXPECTED_MAX_INITIAL_PAGES + 1);
+      });
+    `;
+    const found = scan(src).filter(
+      (v) => v.rule === "one-sided-tuned-constant",
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].symbol).toBe("EXPECTED_MAX_INITIAL_PAGES");
+    expect(found[0].message).toContain("silently LOWERED");
+  });
+
+  it("flags the mirror image: a floor asserted only as a lower bound", () => {
+    const src = `
+      // Drift guard: must equal MIN_POLL_INTERVAL_MS in the worker.
+      const EXPECTED_MIN_POLL_MS = 250;
+      it("floors the poll", () => {
+        expect(observedIntervalMs).toBeGreaterThanOrEqual(EXPECTED_MIN_POLL_MS);
+      });
+    `;
+    const found = scan(src).filter(
+      (v) => v.rule === "one-sided-tuned-constant",
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].message).toContain("silently RAISED");
+  });
+
+  it("accepts a genuinely two-sided pin", () => {
+    const src = `
+      // MUST match MAX_INITIAL_FETCH_PAGES.
+      const EXPECTED_MAX_INITIAL_PAGES = 20;
+      it("stops exactly at the cap", () => {
+        expect(pagesRequested.length).toBeLessThanOrEqual(EXPECTED_MAX_INITIAL_PAGES);
+        expect(pagesRequested.length).toBeGreaterThanOrEqual(EXPECTED_MAX_INITIAL_PAGES);
+      });
+    `;
+    expect(rules(scan(src))).not.toContain("one-sided-tuned-constant");
+  });
+
+  it("accepts an exact pin (toBe / toContain on the bare constant)", () => {
+    for (const matcher of [
+      "expect(pagesRequested.length).toBe(EXPECTED_MAX_INITIAL_PAGES);",
+      "expect(pagesRequested).toContain(EXPECTED_MAX_INITIAL_PAGES);",
+      "expect(pagesRequested).toHaveLength(EXPECTED_MAX_INITIAL_PAGES);",
+    ]) {
+      const src = `
+        // MUST match MAX_INITIAL_FETCH_PAGES.
+        const EXPECTED_MAX_INITIAL_PAGES = 20;
+        it("x", () => {
+          expect(pagesRequested.length).toBeLessThanOrEqual(EXPECTED_MAX_INITIAL_PAGES);
+          ${matcher}
+        });
+      `;
+      expect(rules(scan(src)), matcher).not.toContain(
+        "one-sided-tuned-constant",
+      );
+    }
+  });
+
+  it("does not count CONST + 1 as pinning CONST", () => {
+    // This is precisely how the real guard read as two-sided while being
+    // one-sided: `not.toContain(CAP + 1)` constrains the neighbour, not the cap.
+    const src = `
+      // MUST match MAX_INITIAL_FETCH_PAGES.
+      const EXPECTED_MAX_INITIAL_PAGES = 20;
+      it("x", () => {
+        expect(pagesRequested.length).toBeLessThanOrEqual(EXPECTED_MAX_INITIAL_PAGES);
+        expect(pagesRequested).toContain(EXPECTED_MAX_INITIAL_PAGES + 1);
+      });
+    `;
+    expect(rules(scan(src))).toContain("one-sided-tuned-constant");
+  });
+
+  it("leaves untagged numeric constants alone (no pin intent declared)", () => {
+    const src = `
+      const PER_PAGE_CLAMP = 500;
+      it("x", () => { expect(perPage).toBeLessThanOrEqual(PER_PAGE_CLAMP); });
+    `;
+    expect(rules(scan(src))).not.toContain("one-sided-tuned-constant");
+  });
+
+  it("honours the explicit tunedConstants registry for undocumented pins", () => {
+    const src = `
+      const PER_PAGE_CLAMP = 500;
+      it("x", () => { expect(perPage).toBeLessThanOrEqual(PER_PAGE_CLAMP); });
+    `;
+    const found = scanTestSource("showcase/x/fake.test.ts", src, [
+      {
+        file: "showcase/x/fake.test.ts",
+        constant: "PER_PAGE_CLAMP",
+        reason: "mirrors the PocketBase perPage clamp",
+      },
+    ]);
+    expect(rules(found)).toContain("one-sided-tuned-constant");
+  });
+});
+
+describe("pin-comment-without-import (A2)", () => {
+  it("flags a hand-copied constant the file claims MUST match another module", () => {
+    const src = `
+      /** MUST match \`MAX_INITIAL_FETCH_PAGES\` in useLiveStatus.ts. */
+      const EXPECTED_MAX_INITIAL_PAGES = 20;
+    `;
+    const found = scan(src).filter(
+      (v) => v.rule === "pin-comment-without-import",
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].symbol).toBe("MAX_INITIAL_FETCH_PAGES");
+  });
+
+  it("is satisfied when the identifier is actually imported", () => {
+    const src = `
+      import { MAX_INITIAL_FETCH_PAGES } from "./useLiveStatus";
+      /** MUST match \`MAX_INITIAL_FETCH_PAGES\`. */
+      const EXPECTED = MAX_INITIAL_FETCH_PAGES;
+    `;
+    expect(rules(scan(src))).not.toContain("pin-comment-without-import");
+  });
+
+  it("does not fire on prose that merely contains the words", () => {
+    const src = `
+      // The response shape must match the wire contract described above.
+      const x = 1;
+    `;
+    expect(rules(scan(src))).not.toContain("pin-comment-without-import");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Opt-out hygiene
+// ---------------------------------------------------------------------------
+
+describe("opt-out marker", () => {
+  const offending = `
+    it("caps the walk", () => {
+      MARKER
+      expect(Math.max(...pages)).toBeLessThanOrEqual(20);
+    });
+  `;
+
+  it("suppresses a rule when given a real justification", () => {
+    const src = offending.replace(
+      "MARKER",
+      "// vacuity-gate-allow: degenerate-spread-aggregate — the server always serves page 1, proven by the honest-server suite",
+    );
+    expect(rules(scan(src))).not.toContain("degenerate-spread-aggregate");
+  });
+
+  it("reports a marker with no justification instead of honouring it", () => {
+    const src = offending.replace(
+      "MARKER",
+      "// vacuity-gate-allow: degenerate-spread-aggregate",
+    );
+    const found = rules(scan(src));
+    expect(found).toContain("opt-out-without-reason");
+    expect(found).toContain("degenerate-spread-aggregate");
+  });
+
+  it("requires a reason of at least MIN_OPT_OUT_REASON_LENGTH characters", () => {
+    const src = offending.replace(
+      "MARKER",
+      "// vacuity-gate-allow: degenerate-spread-aggregate — nope",
+    );
+    expect(rules(scan(src))).toContain("opt-out-without-reason");
+    expect(MIN_OPT_OUT_REASON_LENGTH).toBeGreaterThan(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rule 3 — duplicated-constant drift
+// ---------------------------------------------------------------------------
+
+describe("evalNumericLiteralExpr", () => {
+  it("evaluates the arithmetic forms these constants are written in", () => {
+    expect(evalNumericLiteralExpr("5 * 60 * 1000")).toBe(300_000);
+    expect(evalNumericLiteralExpr("2_000")).toBe(2000);
+    expect(evalNumericLiteralExpr("(30 + 15) * 1000")).toBe(45_000);
+    expect(evalNumericLiteralExpr("7")).toBe(7);
+  });
+
+  it("refuses anything that is not a literal arithmetic expression", () => {
+    expect(evalNumericLiteralExpr("BASE * 2")).toBeNull();
+    expect(evalNumericLiteralExpr('"5"')).toBeNull();
+    expect(evalNumericLiteralExpr("computeWindow()")).toBeNull();
+    expect(evalNumericLiteralExpr("5 * ")).toBeNull();
+  });
+});
+
+describe("readConstantDeclaration", () => {
+  it("finds an exported and a module-private declaration", () => {
+    expect(
+      readConstantDeclaration("export const A = 5 * 60 * 1000;\n", "A")?.value,
+    ).toBe(300_000);
+    expect(readConstantDeclaration("const B = 1_500;\n", "B")?.value).toBe(
+      1500,
+    );
+  });
+
+  it("does not match a mention inside a comment or a string", () => {
+    const src = '// const C = 9;\nconst s = "const C = 8;";\n';
+    expect(readConstantDeclaration(src, "C")).toBeNull();
+  });
+});
+
+describe("checkDuplicatedConstants (rule 3)", () => {
+  const pin = {
+    reason: "test pin",
+    declarations: [
+      { file: "a.ts", constant: "A_MS" },
+      { file: "b.ts", constant: "B_MS" },
+    ],
+  };
+
+  it("passes while the duplicates hold the same value", () => {
+    const found = checkDuplicatedConstants([pin], (f) =>
+      f === "a.ts"
+        ? "export const A_MS = 5 * 60 * 1000;"
+        : "const B_MS = 300000;",
+    );
+    expect(found).toEqual([]);
+  });
+
+  it("FAILS with both values when they drift", () => {
+    const found = checkDuplicatedConstants([pin], (f) =>
+      f === "a.ts"
+        ? "export const A_MS = 5 * 60 * 1000;"
+        : "const B_MS = 10 * 60 * 1000;",
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].rule).toBe("duplicated-constant-drift");
+    expect(found[0].message).toContain("600000");
+    expect(found[0].message).toContain("300000");
+  });
+
+  it("FAILS when a declaration is renamed away — a rename must not disable the pin", () => {
+    const found = checkDuplicatedConstants([pin], (f) =>
+      f === "a.ts"
+        ? "export const A_MS = 300000;"
+        : "const RENAMED_MS = 300000;",
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].message).toContain("no longer declared");
+  });
+
+  it("FAILS when a pinned file disappears", () => {
+    const found = checkDuplicatedConstants([pin], (f) =>
+      f === "a.ts" ? "export const A_MS = 300000;" : null,
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].message).toContain("does not exist");
+  });
+
+  it("FAILS when an initializer stops being comparable", () => {
+    const found = checkDuplicatedConstants([pin], (f) =>
+      f === "a.ts"
+        ? "export const A_MS = 300000;"
+        : "const B_MS = computeWindow();",
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].message).toContain("cannot be compared");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registry + allowlist integrity
+// ---------------------------------------------------------------------------
+
+describe("gate configuration", () => {
+  it("loads the allowlist with every entry dated, justified and owned", () => {
+    // loadAllowlist throws on a malformed entry; this asserts it and pins the
+    // shape so an undated/unowned entry cannot be slipped in.
+    const entries = loadAllowlist();
+    for (const e of entries) {
+      expect(e.added).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(e.justification.length).toBeGreaterThan(30);
+      expect(e.owner.length).toBeGreaterThan(0);
+    }
+    expect(fs.existsSync(ALLOWLIST_PATH)).toBe(true);
+  });
+
+  it("keeps at least one duplicated-constant pin registered", () => {
+    // Emptying `pins` would make rule 3 pass trivially. The registry is the
+    // rule's whole input, so a non-empty floor is what stops it being gutted.
+    const config = loadDuplicatedConstants();
+    expect(config.pins.length).toBeGreaterThanOrEqual(1);
+    expect(fs.existsSync(DUPLICATED_CONSTANTS_PATH)).toBe(true);
+    for (const p of config.pins) {
+      expect(p.declarations.length).toBeGreaterThanOrEqual(2);
+      expect(p.reason.length).toBeGreaterThan(30);
+    }
+  });
+
+  it("pins the live COMM_ERROR_FUTURE_SKEW_TOLERANCE_MS / FUTURE_SKEW_TOLERANCE_MS pair", () => {
+    // The concrete instance the gate was built for. Asserted here by NAME as
+    // well as by value, so dropping it from the registry breaks a test rather
+    // than silently removing the guard.
+    const config = loadDuplicatedConstants();
+    const names = config.pins.flatMap((p) =>
+      p.declarations.map((d) => d.constant),
+    );
+    expect(names).toContain("COMM_ERROR_FUTURE_SKEW_TOLERANCE_MS");
+    expect(names).toContain("FUTURE_SKEW_TOLERANCE_MS");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// THE GATE
+// ---------------------------------------------------------------------------
+
+describe("showcase test-vacuity gate", () => {
+  const result = runGate(REPO_ROOT);
+
+  it("scans the showcase test tree", () => {
+    // A path/glob regression that silently scanned nothing would make every
+    // assertion below pass vacuously — exactly the class this gate polices.
+    expect(result.filesScanned).toBeGreaterThan(500);
+  });
+
+  it("finds no vacuous assertions or constant drift outside the allowlist", () => {
+    const report = result.violations
+      .map((v) => `${v.file}:${v.line} [${v.rule}] ${v.message}`)
+      .join("\n\n");
+    expect(report).toBe("");
+  });
+
+  it("has no STALE allowlist entries (the allowlist is shrink-only)", () => {
+    const report = result.stale
+      .map(
+        (s) =>
+          `${s.file} [${s.rule}] \`${s.symbol}\` no longer fires — delete this entry (added ${s.added}, owner ${s.owner})`,
+      )
+      .join("\n");
+    expect(report).toBe("");
+  });
+
+  it("does not flag the violating snippets in THIS file (they are all strings)", () => {
+    const self = path.join(
+      REPO_ROOT,
+      "showcase/scripts/__tests__/validate-test-vacuity.test.ts",
+    );
+    const found = scanTestSource(
+      "showcase/scripts/__tests__/validate-test-vacuity.test.ts",
+      fs.readFileSync(self, "utf8"),
+    );
+    expect(found).toEqual([]);
+  });
+});

--- a/showcase/scripts/duplicated-constants.json
+++ b/showcase/scripts/duplicated-constants.json
@@ -1,0 +1,19 @@
+{
+  "_policy": "Registry for showcase/scripts/validate-test-vacuity.ts. TWO sections. `tunedConstants` declares test-file constants that are pins on a value owned elsewhere and therefore MUST be asserted two-sidedly (the scanner also infers this from a pin-intent comment on the declaration, so this list is only for pins whose intent is not written down). `pins` declares constants KNOWINGLY duplicated across modules; the gate asserts every declaration in a pin still exists AND still evaluates to the same number. Importing the sibling instead of duplicating it is always the better fix -- an entry here is an admission that we did not.",
+  "tunedConstants": [],
+  "pins": [
+    {
+      "reason": "cell-model.ts declares its own copy of staleness.ts's 5-minute future-skew tolerance. staleness.ts OWNS the value (and cell-model.ts already imports isFutureSkewed from it), but the copy was justified on cycle grounds and never linked to the original. /api/matrix publishes only staleness.ts's value, so a consumer told to reproduce the reasoning for commError/surfaceState is handed the wrong window the moment these drift. Until cell-model.ts imports FUTURE_SKEW_TOLERANCE_MS (a product-source edit), this pin is what makes drift loud.",
+      "declarations": [
+        {
+          "file": "showcase/harness/src/shared/cell-model/staleness.ts",
+          "constant": "FUTURE_SKEW_TOLERANCE_MS"
+        },
+        {
+          "file": "showcase/harness/src/shared/cell-model/cell-model.ts",
+          "constant": "COMM_ERROR_FUTURE_SKEW_TOLERANCE_MS"
+        }
+      ]
+    }
+  ]
+}

--- a/showcase/scripts/lib/test-vacuity-core.ts
+++ b/showcase/scripts/lib/test-vacuity-core.ts
@@ -1,0 +1,1194 @@
+/**
+ * Test-Vacuity + Constant-Drift Gate — core analysis
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * PR #6156 went through two 12-reviewer code-review rounds. A convergence
+ * audit measured that **16 of 37 round-2 "toothless guard" clusters (43%) lived
+ * in files the round-1 fixes had just created**. Two defect classes accounted
+ * for most of them, and both are mechanically detectable from test source text:
+ *
+ *   A1 — DEGENERATE-INPUT VACUITY. An assertion that is satisfied when the
+ *        thing it claims to pin never ran. The canonical shape:
+ *
+ *            expect(Math.max(...pages)).toBeLessThanOrEqual(CAP);
+ *
+ *        `Math.max(...[])` is `-Infinity` and `Math.min(...[])` is `+Infinity`,
+ *        so that assertion passes when ZERO pages were fetched — i.e. it also
+ *        passes for a hook that never issued a request at all. Same shape via
+ *        an aggregate (`.every`/`.reduce`) over a `.filter(...)` whose result
+ *        may be empty: `[].every(p)` is `true` for every predicate `p`.
+ *
+ *   A2 — ONE-SIDED / HAND-COPIED PINS. A "drift guard" that only catches drift
+ *        in one direction, or a constant hand-copied from the module it claims
+ *        to mirror. Real instance: `EXPECTED_MAX_INITIAL_PAGES = 20` was
+ *        asserted ONLY as `toBeLessThanOrEqual`, and reviewers PROVED that
+ *        lowering the production `MAX_INITIAL_FETCH_PAGES` to 10 — and even to
+ *        5 — left the whole suite green. The unguarded direction was the
+ *        harmful one (a silently narrowed first-paint budget is the exact bug
+ *        that PR was fixing).
+ *
+ * A third rule covers the duplicated-constant case that has no test-file
+ * expression at all: two product modules each declaring their own copy of the
+ * same tuned value with nothing asserting the two equal
+ * (`COMM_ERROR_FUTURE_SKEW_TOLERANCE_MS` in `cell-model.ts` vs
+ * `FUTURE_SKEW_TOLERANCE_MS` in `staleness.ts`). That rule lives in
+ * `checkDuplicatedConstants` and is driven by an explicit registry, because
+ * "these two constants are knowingly duplicated" is a human declaration, not
+ * something a scanner can infer.
+ *
+ * DESIGN
+ * ------
+ * The scanner is deliberately NOT a bare grep for the literal idioms found in
+ * review — a trivially reworded equivalent must not slip past. So:
+ *
+ *   - it MASKS comments, strings, template literals and regex literals first
+ *     (length-preserving, so byte offsets and line numbers stay exact), then
+ *     matches parens by depth. `expect("Math.max(...xs)")` in a string, or in
+ *     a comment, is not code and is not flagged;
+ *   - `Math.max(...xs)` is flagged whether it sits INSIDE the `expect(...)`
+ *     call or is hoisted into a `const` that an `expect(...)` later consumes;
+ *   - the "is it guarded?" question is answered by looking for a real
+ *     non-emptiness precondition on the SAME collection expression
+ *     (`toHaveLength(n>0)`, `.length` compared above zero, `toContain(...)`,
+ *     `toEqual([non-empty])`), not by the mere presence of the word "length".
+ *
+ * A pure-text scanner cannot be a type checker, so it is scoped to shapes where
+ * a text match IS the defect. Everything it reports names a file, a line, the
+ * offending symbol, and why the assertion holds on the degenerate input.
+ *
+ * OPT-OUT
+ * -------
+ * A line may carry `vacuity-gate-allow: <rule-id> — <reason>` (in a comment on
+ * the offending line or the line directly above). The reason is MANDATORY and
+ * must be at least {@link MIN_OPT_OUT_REASON_LENGTH} characters; a marker with
+ * no reason is itself reported as `opt-out-without-reason`, so the escape hatch
+ * cannot be used to silence the gate wordlessly.
+ *
+ * This module is pure: text in, violations out. No filesystem, no process exit.
+ * `validate-test-vacuity.ts` owns IO, the allowlist and the exit code.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type RuleId =
+  | "degenerate-spread-aggregate"
+  | "degenerate-filtered-aggregate"
+  | "one-sided-tuned-constant"
+  | "pin-comment-without-import"
+  | "duplicated-constant-drift"
+  | "opt-out-without-reason";
+
+export interface Violation {
+  rule: RuleId;
+  /** Repo-relative POSIX path. */
+  file: string;
+  /** 1-based line number in the ORIGINAL source. */
+  line: number;
+  /**
+   * The thing the violation is about — the collection expression, the constant
+   * name, the referenced identifier. Together with `rule` + `file` this is the
+   * allowlist key, so it must be stable across unrelated edits to the file
+   * (which is why the line number is NOT part of the key).
+   */
+  symbol: string;
+  /** One-line explanation, ready to print. */
+  message: string;
+}
+
+/** Minimum length of the justification an inline opt-out marker must carry. */
+export const MIN_OPT_OUT_REASON_LENGTH = 15;
+
+/**
+ * Phrases in a leading comment that declare "this literal is a pin against
+ * another module's value". Any constant so annotated is treated as a TUNED
+ * CONSTANT and must be pinned two-sidedly. This is the "declared set" the
+ * one-sided-pin rule needs: authors opt IN by writing the intent down, which
+ * they already do — `EXPECTED_MAX_INITIAL_PAGES`'s own JSDoc says both
+ * "MUST match `MAX_INITIAL_FETCH_PAGES`" and "pinned as a literal here on
+ * purpose".
+ */
+const PIN_INTENT_PATTERNS: readonly RegExp[] = [
+  /\bMUST\s+match\b/i,
+  /\bmust\s+equal\b/i,
+  /\bpinned\s+as\s+a\s+literal\b/i,
+  /\bdrift\s+guard\b/i,
+  /\bkeep\s+in\s+(?:lockstep|sync)\b/i,
+  /\bmirrors?\s+(?:the\s+)?(?:production|source|engine)\b/i,
+];
+
+// ---------------------------------------------------------------------------
+// Masking: strip non-code, keep byte offsets
+// ---------------------------------------------------------------------------
+
+/**
+ * Replace every comment, string literal, template literal and regex literal
+ * body with spaces, preserving total length and every newline. Byte offsets and
+ * line numbers in the result therefore map 1:1 onto the original source, which
+ * lets the rules match on masked text and report positions in the real file.
+ *
+ * Template literals are masked WHOLESALE, including any `${...}` substitution.
+ * That is a deliberate false-negative: an assertion buried inside a template
+ * substitution is not a shape this gate is trying to catch, and tracking nested
+ * template/expression state is exactly the kind of hand-rolled lexing that goes
+ * wrong. Everything else is masked precisely.
+ */
+/** A comment, with its offsets in the ORIGINAL source. */
+export interface CommentBlock {
+  text: string;
+  start: number;
+  end: number;
+}
+
+export interface MaskedSource {
+  /** Length-identical copy of `src` with all non-code blanked out. */
+  masked: string;
+  /** Every comment, in source order, with original offsets. */
+  comments: CommentBlock[];
+}
+
+/**
+ * Single lexing pass: blank non-code AND record where the comments were.
+ *
+ * These MUST come from one pass. An earlier version re-derived comment
+ * boundaries by looking for `//` at a position the mask had blanked — but string
+ * literals are blanked too, so `"// vacuity-gate-allow: x"` inside a string
+ * registered as a comment. One pass, one answer.
+ */
+export function maskAndExtract(src: string): MaskedSource {
+  const n = src.length;
+  const comments: CommentBlock[] = [];
+  // Char-code buffer rather than a string array: this runs over ~1,200 test
+  // files on every CI invocation, and per-char string/regex work dominated the
+  // first implementation's runtime.
+  const out = new Uint16Array(n);
+  for (let k = 0; k < n; k++) out[k] = src.charCodeAt(k);
+  const SPACE = 32;
+  const NEWLINE = 10;
+  let i = 0;
+  /** Last non-whitespace character of actual code seen so far. */
+  let prev = "";
+
+  const blank = (from: number, to: number): void => {
+    for (let k = from; k < to && k < n; k++) {
+      if (out[k] !== NEWLINE) out[k] = SPACE;
+    }
+  };
+
+  while (i < n) {
+    const c = src[i];
+    const next = src[i + 1];
+
+    // Line comment.
+    if (c === "/" && next === "/") {
+      let j = i;
+      while (j < n && src[j] !== "\n") j++;
+      comments.push({ text: src.slice(i, j), start: i, end: j });
+      blank(i, j);
+      i = j;
+      continue;
+    }
+
+    // Block comment.
+    if (c === "/" && next === "*") {
+      const close = src.indexOf("*/", i + 2);
+      const end = close === -1 ? n : close + 2;
+      comments.push({ text: src.slice(i, end), start: i, end });
+      blank(i, end);
+      i = end;
+      continue;
+    }
+
+    // String literal.
+    if (c === '"' || c === "'") {
+      let j = i + 1;
+      while (j < n) {
+        if (src[j] === "\\") {
+          j += 2;
+          continue;
+        }
+        if (src[j] === c || src[j] === "\n") break;
+        j++;
+      }
+      const end = Math.min(j + 1, n);
+      blank(i, end);
+      prev = c;
+      i = end;
+      continue;
+    }
+
+    // Template literal (masked wholesale — see the doc comment).
+    if (c === "`") {
+      let j = i + 1;
+      while (j < n) {
+        if (src[j] === "\\") {
+          j += 2;
+          continue;
+        }
+        if (src[j] === "`") break;
+        j++;
+      }
+      const end = Math.min(j + 1, n);
+      blank(i, end);
+      prev = "`";
+      i = end;
+      continue;
+    }
+
+    // Regex literal. `/` is division when the previous meaningful character
+    // could end an expression (identifier char, `)`, `]`); otherwise it opens a
+    // regex. Conservative, and unit-tested against the shapes that actually
+    // appear in these suites (`/https?:\/\//`, character classes with `/`).
+    if (c === "/" && !isExpressionEnd(prev)) {
+      let j = i + 1;
+      let inClass = false;
+      let closed = false;
+      while (j < n) {
+        const d = src[j];
+        if (d === "\\") {
+          j += 2;
+          continue;
+        }
+        if (d === "\n") break; // unterminated — bail, treat as division
+        if (d === "[") inClass = true;
+        else if (d === "]") inClass = false;
+        else if (d === "/" && !inClass) {
+          closed = true;
+          break;
+        }
+        j++;
+      }
+      if (closed) {
+        blank(i, j + 1);
+        prev = "/";
+        i = j + 1;
+        continue;
+      }
+      // Fall through: treat as a division operator.
+    }
+
+    const code = src.charCodeAt(i);
+    // Not whitespace: space, tab, LF, CR, VT, FF, NBSP.
+    if (
+      code !== 32 &&
+      code !== 9 &&
+      code !== 10 &&
+      code !== 13 &&
+      code !== 11 &&
+      code !== 12 &&
+      code !== 160
+    ) {
+      prev = c;
+    }
+    i++;
+  }
+
+  // Chunked to stay clear of the argument-count limit on large files.
+  let masked = "";
+  const CHUNK = 8192;
+  for (let k = 0; k < n; k += CHUNK) {
+    masked += String.fromCharCode(...out.subarray(k, Math.min(k + CHUNK, n)));
+  }
+  return { masked, comments };
+}
+
+/** Length-preserving mask of every comment/string/template/regex. */
+export function maskNonCode(src: string): string {
+  return maskAndExtract(src).masked;
+}
+
+/** Could this character terminate an expression (so a following `/` divides)? */
+function isExpressionEnd(ch: string): boolean {
+  return ch !== "" && (/[A-Za-z0-9_$)\]]/.test(ch) || ch === "`");
+}
+
+// ---------------------------------------------------------------------------
+// Small text utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * 1-based line number of a byte offset.
+ *
+ * Memoized on the most recent source string (we process one file at a time).
+ * The naive O(index) scan was the runtime hot spot: the tuned-constant rule
+ * asks for the line of every comment for every numeric declaration, which made
+ * the whole gate quadratic in file size.
+ */
+let lineStartsCacheSrc: string | null = null;
+let lineStartsCache: number[] = [];
+
+function lineStartsFor(src: string): number[] {
+  if (lineStartsCacheSrc === src) return lineStartsCache;
+  const starts = [0];
+  for (let i = 0; i < src.length; i++) {
+    if (src.charCodeAt(i) === 10) starts.push(i + 1);
+  }
+  lineStartsCacheSrc = src;
+  lineStartsCache = starts;
+  return starts;
+}
+
+export function lineOf(src: string, index: number): number {
+  const starts = lineStartsFor(src);
+  let lo = 0;
+  let hi = starts.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (starts[mid] <= index) lo = mid;
+    else hi = mid - 1;
+  }
+  return lo + 1;
+}
+
+/**
+ * Index of the `)` matching the `(` at `openIdx`, or -1 if unbalanced. Runs on
+ * MASKED source, so parens inside strings/comments/regexes cannot skew it.
+ */
+export function matchParen(masked: string, openIdx: number): number {
+  let depth = 0;
+  for (let i = openIdx; i < masked.length; i++) {
+    const c = masked[i];
+    if (c === "(") depth++;
+    else if (c === ")") {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/** Collapse all whitespace runs to single spaces and trim. */
+function norm(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Normalize a single call argument. Prettier wraps long matcher calls, leaving a
+ * DANGLING COMMA in the argument text:
+ *
+ *     expect(pages.length).toBeLessThanOrEqual(
+ *       EXPECTED_MAX_INITIAL_PAGES,
+ *     );
+ *
+ * Without stripping it, `arg === "EXPECTED_MAX_INITIAL_PAGES,"` never equals the
+ * constant name and the one-sided-pin rule silently sees zero assertions — which
+ * is precisely the "guard that quietly stops guarding" failure this gate exists
+ * to prevent, so it is unit-tested in both the wrapped and unwrapped forms.
+ */
+function normArg(s: string): string {
+  return norm(s).replace(/,+$/, "").trim();
+}
+
+/** Split an argument list on TOP-LEVEL commas (paren/bracket/brace aware). */
+function splitTopLevel(args: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < args.length; i++) {
+    const c = args[i];
+    if (c === "(" || c === "[" || c === "{") depth++;
+    else if (c === ")" || c === "]" || c === "}") depth--;
+    else if (c === "," && depth === 0) {
+      parts.push(args.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(args.slice(start));
+  return parts;
+}
+
+/** Leading identifier of an expression (`pages.filter(x)` -> `pages`). */
+function baseIdentifier(expr: string): string {
+  const m = /^[A-Za-z_$][\w$]*/.exec(expr.trim());
+  return m ? m[0] : expr.trim();
+}
+
+// ---------------------------------------------------------------------------
+// expect(...) discovery
+// ---------------------------------------------------------------------------
+
+interface ExpectCall {
+  /** Offset of the `e` in `expect`. */
+  start: number;
+  /** Offset of the `(` opening the argument list. */
+  openIdx: number;
+  /** Offset of the matching `)`. */
+  closeIdx: number;
+  /** Raw (masked) subject text between the parens. */
+  subject: string;
+  /**
+   * The chained matcher text following the closing paren, up to the end of the
+   * statement — e.g. `.toBeLessThanOrEqual(CAP)` or `.not.toHaveLength(0)`.
+   */
+  tail: string;
+}
+
+/** Every `expect(...)` call in the masked source, with subject and matcher. */
+function findExpectCalls(masked: string): ExpectCall[] {
+  const calls: ExpectCall[] = [];
+  const re = /\bexpect\s*\(/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(masked)) !== null) {
+    const openIdx = m.index + m[0].length - 1;
+    const closeIdx = matchParen(masked, openIdx);
+    if (closeIdx === -1) continue;
+    // Matcher tail: everything up to the statement terminator. `;` is the
+    // common case; a newline followed by a non-`.`/non-`)` char also ends it
+    // (prettier splits long chains across lines).
+    let end = closeIdx + 1;
+    let depth = 0;
+    while (end < masked.length) {
+      const c = masked[end];
+      if (c === "(") depth++;
+      else if (c === ")") {
+        if (depth === 0) break;
+        depth--;
+      } else if (c === ";" && depth === 0) break;
+      end++;
+    }
+    // vitest/jest accept a second "message" argument — `expect(x, "why")` —
+    // which several showcase suites use heavily. The SUBJECT is the first
+    // top-level argument only; taking the whole argument list made every
+    // annotated assertion unrecognisable, so a correctly-written
+    // `expect(indices.length, "...").toBeGreaterThan(0)` guard was invisible.
+    const rawArgs = masked.slice(openIdx + 1, closeIdx);
+    calls.push({
+      start: m.index,
+      openIdx,
+      closeIdx,
+      subject: splitTopLevel(rawArgs)[0] ?? rawArgs,
+      tail: masked.slice(closeIdx + 1, end),
+    });
+    re.lastIndex = closeIdx;
+  }
+  return calls;
+}
+
+/**
+ * Collection expressions this file proves NON-EMPTY, normalized. A guard counts
+ * only if it forces at least one element:
+ *
+ *   expect(xs).toHaveLength(3)              -> xs
+ *   expect(xs).not.toHaveLength(0)          -> xs
+ *   expect(xs.length).toBeGreaterThan(0)    -> xs
+ *   expect(xs.length).toBeGreaterThanOrEqual(1) -> xs
+ *   expect(xs.length).toBe(4)               -> xs
+ *   expect(xs).toContain(7)                 -> xs
+ *   expect(xs).toEqual([1, 2])              -> xs
+ *
+ * `toHaveLength(0)`, `toEqual([])` and `toBeGreaterThanOrEqual(0)` prove
+ * nothing and are deliberately NOT guards — they are satisfied by the empty
+ * input, which is the whole defect.
+ */
+function collectNonEmptyGuards(masked: string): Set<string> {
+  const guards = new Set<string>();
+  /**
+   * `for (const [name, xs] of Object.entries(obj))` / `for (const xs of
+   * Object.values(obj))` — guarding the loop ALIAS guards every property of the
+   * object, which is how a suite says "no bucket may be empty" in one place.
+   * Recorded as `obj.*` and consulted by {@link isGuarded}.
+   */
+  const loopAliases: Array<{ alias: string; object: string }> = [];
+  const loopRe =
+    /\bfor\s*\(\s*(?:const|let|var)\s+(?:\[\s*[A-Za-z_$][\w$]*\s*,\s*([A-Za-z_$][\w$]*)\s*\]|([A-Za-z_$][\w$]*))\s+of\s+Object\s*\.\s*(?:entries|values)\s*\(\s*([A-Za-z_$][\w$.]*)\s*\)/g;
+  let loop: RegExpExecArray | null;
+  while ((loop = loopRe.exec(masked)) !== null) {
+    loopAliases.push({ alias: loop[1] ?? loop[2], object: loop[3] });
+  }
+  for (const call of findExpectCalls(masked)) {
+    const subject = norm(call.subject);
+    const tail = norm(call.tail);
+    const negated = /^\.\s*not\s*\./.test(tail);
+
+    const lengthMatch = /^(.*)\.length$/.exec(subject);
+    const target = lengthMatch ? norm(lengthMatch[1]) : subject;
+
+    // The tail always begins at the `.` after `expect(...)`; the matcher is the
+    // first identifier after an optional `not.`, e.g. `.not.toHaveLength(0)`.
+    const matcher = /^\.\s*(?:not\s*\.\s*)?([A-Za-z]\w*)\s*\(/.exec(tail);
+    if (!matcher) continue;
+    const name = matcher[1];
+    const argOpen = matcher[0].length - 1;
+    const argClose = matchParen(tail, argOpen);
+    const arg =
+      argClose === -1 ? "" : normArg(tail.slice(argOpen + 1, argClose));
+    const numeric = Number(arg);
+
+    if (!negated && lengthMatch) {
+      if (
+        (name === "toBeGreaterThan" &&
+          Number.isFinite(numeric) &&
+          numeric >= 0) ||
+        (name === "toBeGreaterThanOrEqual" &&
+          Number.isFinite(numeric) &&
+          numeric >= 1) ||
+        ((name === "toBe" || name === "toEqual" || name === "toStrictEqual") &&
+          Number.isFinite(numeric) &&
+          numeric > 0)
+      ) {
+        guards.add(target);
+      }
+      continue;
+    }
+
+    if (!negated) {
+      if (name === "toHaveLength" && Number.isFinite(numeric) && numeric > 0) {
+        guards.add(target);
+      } else if (name === "toContain" || name === "toContainEqual") {
+        guards.add(target);
+      } else if (
+        (name === "toEqual" || name === "toStrictEqual") &&
+        /^\[\s*[^\]\s]/.test(arg)
+      ) {
+        // Non-empty array literal. The character class must EXCLUDE `]`:
+        // `/^\[\s*\S/` matched `[]`, which turned `expect(xs).toEqual([])` --
+        // the single strongest statement that the collection IS empty -- into a
+        // non-emptiness guard.
+        guards.add(target);
+      }
+    } else if (name === "toHaveLength" && numeric === 0) {
+      // `expect(xs).not.toHaveLength(0)` — an explicit non-emptiness pin.
+      guards.add(target);
+    }
+  }
+  for (const { alias, object } of loopAliases) {
+    if (guards.has(alias)) guards.add(`${object}.*`);
+  }
+  return guards;
+}
+
+// ---------------------------------------------------------------------------
+// Opt-out markers
+// ---------------------------------------------------------------------------
+
+const OPT_OUT_RE = /vacuity-gate-allow\s*:\s*([a-z-]+)\s*(?:[—:-]\s*)?(.*)$/;
+
+interface OptOut {
+  rule: string;
+  reason: string;
+  line: number;
+}
+
+/**
+ * Parse every `vacuity-gate-allow:` marker out of the source's COMMENTS.
+ *
+ * Comments only — a marker inside a string literal is data, not a directive.
+ * (This file's own test suite embeds marker text inside fixture strings; reading
+ * markers line-wise made the gate flag its own test file.)
+ */
+function findOptOuts(src: string, comments: readonly CommentBlock[]): OptOut[] {
+  const found: OptOut[] = [];
+  for (const comment of comments) {
+    for (const raw of comment.text.split("\n")) {
+      const m = OPT_OUT_RE.exec(raw);
+      if (!m) continue;
+      const offsetInComment = comment.text.indexOf(raw);
+      found.push({
+        rule: m[1],
+        reason: m[2]
+          .trim()
+          .replace(/\*\/\s*$/, "")
+          .trim(),
+        line: lineOf(src, comment.start + Math.max(offsetInComment, 0)),
+      });
+    }
+  }
+  return found;
+}
+
+/**
+ * Is `rule` opted out at `line`? A marker applies to its own line and to the
+ * line directly below it (the usual "comment above the code" placement).
+ */
+function isOptedOut(optOuts: OptOut[], rule: RuleId, line: number): boolean {
+  return optOuts.some(
+    (o) =>
+      o.rule === rule &&
+      o.reason.length >= MIN_OPT_OUT_REASON_LENGTH &&
+      (o.line === line || o.line === line - 1),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Rule A1 — degenerate-input vacuity
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregates that are DEFINED on the empty collection and therefore assert
+ * nothing about it: `Math.max(...[]) === -Infinity` (so any upper bound holds),
+ * `Math.min(...[]) === +Infinity` (so any lower bound holds), `[].every(p) ===
+ * true` for every predicate, and `[].reduce(f, seed) === seed`.
+ */
+const SPREAD_AGGREGATE_RE = /\bMath\s*\.\s*(max|min)\s*\(/g;
+const FILTERED_AGGREGATE_RE = /\.\s*(every|reduce|reduceRight)\s*\(/g;
+
+/** Array operations that can make the result SHORTER than their input. */
+const CARDINALITY_CHANGING_RE = /\.\s*(?:filter|flatMap|slice|splice)\s*\(/;
+
+/**
+ * Is `collection` proven non-empty by `guards`?
+ *
+ * `derived` collections (those built with a cardinality-changing op) must be
+ * guarded as a WHOLE expression. Everything else may also be guarded via its
+ * base identifier, or via a `<obj>.*` wildcard produced by a loop that guards
+ * every property of an object (see {@link collectNonEmptyGuards}).
+ */
+function isGuarded(
+  guards: Set<string>,
+  collection: string,
+  derived: boolean,
+): boolean {
+  if (guards.has(collection)) return true;
+  if (derived) return false;
+  if (guards.has(baseIdentifier(collection))) return true;
+  const member = /^([A-Za-z_$][\w$.]*)\.[A-Za-z_$][\w$]*$/.exec(collection);
+  return member !== null && guards.has(`${member[1]}.*`);
+}
+
+function checkDegenerateAggregates(
+  file: string,
+  src: string,
+  masked: string,
+  optOuts: OptOut[],
+): Violation[] {
+  const violations: Violation[] = [];
+  const guards = collectNonEmptyGuards(masked);
+  const expects = findExpectCalls(masked);
+
+  const insideExpect = (idx: number): ExpectCall | undefined =>
+    expects.find((e) => idx > e.openIdx && idx < e.closeIdx);
+
+  /** Names bound by `const NAME = <expr containing idx>`. */
+  const boundName = (idx: number): string | undefined => {
+    const from = Math.max(
+      masked.lastIndexOf(";", idx),
+      masked.lastIndexOf("{", idx),
+      masked.lastIndexOf("}", idx),
+      masked.lastIndexOf("\n", idx),
+    );
+    const prefix = masked.slice(from + 1, idx);
+    const m =
+      /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::[^=]*)?=\s*$/.exec(
+        prefix.replace(/\s+$/, " "),
+      );
+    return m?.[1];
+  };
+
+  /** Is `name` later consumed by an `expect(...)` subject? */
+  const consumedByExpect = (name: string, after: number): boolean =>
+    expects.some(
+      (e) =>
+        e.openIdx > after &&
+        new RegExp(`\\b${name.replace(/\$/g, "\\$")}\\b`).test(e.subject),
+    );
+
+  const report = (
+    rule: RuleId,
+    idx: number,
+    symbol: string,
+    message: string,
+  ): void => {
+    const line = lineOf(src, idx);
+    if (isOptedOut(optOuts, rule, line)) return;
+    violations.push({ rule, file, line, symbol, message });
+  };
+
+  // --- Math.max/min over a spread ------------------------------------------
+  SPREAD_AGGREGATE_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = SPREAD_AGGREGATE_RE.exec(masked)) !== null) {
+    const fn = m[1];
+    const openIdx = m.index + m[0].length - 1;
+    const closeIdx = matchParen(masked, openIdx);
+    if (closeIdx === -1) continue;
+    const args = splitTopLevel(masked.slice(openIdx + 1, closeIdx));
+    const spread = args.map(norm).find((a) => a.startsWith("..."));
+    if (!spread) continue; // Math.max(a, b) has fixed arity — not degenerate.
+    const collection = spread.slice(3).trim();
+    if (collection === "") continue;
+
+    // Only flag when the value reaches an assertion — a spread aggregate used
+    // to build a fixture is not making a claim.
+    const enclosing = insideExpect(m.index);
+    let reached = Boolean(enclosing);
+    if (!reached) {
+      const name = boundName(m.index);
+      reached = Boolean(name && consumedByExpect(name, closeIdx));
+    }
+    if (!reached) continue;
+
+    // `.map(...)` PRESERVES cardinality, so guarding the base identifier is
+    // sufficient for `Math.max(...xs.map(f))`. `.filter`/`.flatMap`/`.slice`
+    // do not: a guarded base can still yield an empty derived set, so those
+    // demand a guard on the whole expression.
+    const derived = CARDINALITY_CHANGING_RE.test(collection);
+    if (isGuarded(guards, collection, derived)) continue;
+
+    const empty = fn === "max" ? "-Infinity" : "+Infinity";
+    const bound = fn === "max" ? "upper" : "lower";
+    report(
+      derived ? "degenerate-filtered-aggregate" : "degenerate-spread-aggregate",
+      m.index,
+      collection,
+      `Math.${fn}(...${collection}) is ${empty} when \`${collection}\` is empty, so this ${bound} bound is satisfied by a run that produced ZERO elements — it pins nothing.` +
+        ` Add a non-emptiness precondition (e.g. expect(${collection}).not.toHaveLength(0), or assert the expected element is present) before the bound.` +
+        (derived
+          ? ` Guarding \`${baseIdentifier(collection)}\` is not enough: the derived/filtered set can still be empty.`
+          : ""),
+    );
+  }
+
+  // --- .every()/.reduce() over a filtered collection, inside expect() ------
+  for (const call of expects) {
+    FILTERED_AGGREGATE_RE.lastIndex = 0;
+    let a: RegExpExecArray | null;
+    while ((a = FILTERED_AGGREGATE_RE.exec(call.subject)) !== null) {
+      const before = call.subject.slice(0, a.index);
+      const filterIdx = before.search(/\.\s*(?:filter|flatMap)\s*\(/);
+      if (filterIdx === -1) continue;
+      const collection = norm(before);
+      if (collection === "") continue;
+      if (isGuarded(guards, collection, true)) continue;
+      const idx = call.openIdx + 1 + a.index;
+      const aggregate = a[1];
+      const degenerate =
+        aggregate === "every"
+          ? "[].every(p) is true for EVERY predicate"
+          : "[].reduce(f, seed) returns seed unchanged";
+      report(
+        "degenerate-filtered-aggregate",
+        idx,
+        collection,
+        `\`.${aggregate}(...)\` aggregates the FILTERED collection \`${collection}\`, which can be empty — ${degenerate}, so this assertion is satisfied when the filter matched nothing.` +
+          ` Pin the filtered set's size first (e.g. expect(${collection}).toHaveLength(<n>)), then assert over it.`,
+      );
+    }
+  }
+
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// Rule A2 — one-sided pins and hand-copied source-of-truth
+// ---------------------------------------------------------------------------
+
+const UPPER_MATCHERS = new Set(["toBeLessThanOrEqual", "toBeLessThan"]);
+const LOWER_MATCHERS = new Set(["toBeGreaterThanOrEqual", "toBeGreaterThan"]);
+const EXACT_MATCHERS = new Set([
+  "toBe",
+  "toEqual",
+  "toStrictEqual",
+  "toContain",
+  "toContainEqual",
+  "toHaveLength",
+  "toBeCloseTo",
+]);
+
+/** An explicitly declared tuned constant: `{file, constant, reason}`. */
+export interface TunedConstantEntry {
+  file: string;
+  constant: string;
+  reason: string;
+}
+
+/**
+ * Which numeric constants in this file are TUNED — i.e. are asserted as a pin
+ * on a value owned elsewhere, so a one-directional assertion is a bug. Two
+ * sources: an immediately-preceding comment declaring pin intent, or an entry
+ * in the explicit registry.
+ */
+function findTunedConstants(
+  file: string,
+  src: string,
+  masked: string,
+  comments: readonly CommentBlock[],
+  registry: readonly TunedConstantEntry[],
+): Array<{ name: string; index: number }> {
+  const declared = new Set(
+    registry.filter((e) => e.file === file).map((e) => e.constant),
+  );
+  const out: Array<{ name: string; index: number }> = [];
+  const re =
+    /\b(?:const|let)\s+([A-Za-z_$][\w$]*)\s*(?::[^=;]*)?=\s*([^;\n]+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(masked)) !== null) {
+    const name = m[1];
+    const init = norm(m[2]);
+    // Numeric literal, or a product/sum of numeric literals (5 * 60 * 1000).
+    if (!/^[\d_.\s*+\-/()]+$/.test(init)) continue;
+    if (declared.has(name)) {
+      out.push({ name, index: m.index });
+      continue;
+    }
+    // Leading comment: the nearest comment ending within 3 lines above.
+    const declLine = lineOf(src, m.index);
+    const lead = comments.find((c) => {
+      const endLine = lineOf(src, c.end);
+      return endLine >= declLine - 3 && endLine <= declLine;
+    });
+    if (lead && PIN_INTENT_PATTERNS.some((p) => p.test(lead.text))) {
+      out.push({ name, index: m.index });
+    }
+  }
+  return out;
+}
+
+function checkOneSidedPins(
+  file: string,
+  src: string,
+  masked: string,
+  comments: readonly CommentBlock[],
+  optOuts: OptOut[],
+  registry: readonly TunedConstantEntry[],
+): Violation[] {
+  const violations: Violation[] = [];
+  const tuned = findTunedConstants(file, src, masked, comments, registry);
+  if (tuned.length === 0) return violations;
+
+  // Every matcher call in the file, with its (masked) argument text and
+  // whether it sits behind `.not.`.
+  interface MatcherUse {
+    name: string;
+    arg: string;
+    negated: boolean;
+    index: number;
+  }
+  const uses: MatcherUse[] = [];
+  const re = /\.\s*(not\s*\.\s*)?([A-Za-z]\w*)\s*\(/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(masked)) !== null) {
+    const openIdx = m.index + m[0].length - 1;
+    const closeIdx = matchParen(masked, openIdx);
+    if (closeIdx === -1) continue;
+    uses.push({
+      name: m[2],
+      arg: normArg(masked.slice(openIdx + 1, closeIdx)),
+      negated: Boolean(m[1]),
+      index: m.index,
+    });
+  }
+
+  for (const { name, index } of tuned) {
+    // Only BARE uses of the constant pin it. `CAP + 1` pins the neighbour, not
+    // the constant — which is exactly how the real `EXPECTED_MAX_INITIAL_PAGES`
+    // guard convinced its author it was two-sided while lowering the
+    // production constant to 5 kept the suite green.
+    const bare = uses.filter((u) => u.arg === name && !u.negated);
+    let upper = 0;
+    let lower = 0;
+    let exact = 0;
+    for (const u of bare) {
+      if (UPPER_MATCHERS.has(u.name)) upper++;
+      else if (LOWER_MATCHERS.has(u.name)) lower++;
+      else if (EXACT_MATCHERS.has(u.name)) exact++;
+    }
+    if (exact > 0) continue;
+    if (upper === 0 && lower === 0) continue; // not asserted as a bound at all
+    if (upper > 0 && lower > 0) continue; // genuinely two-sided
+    const line = lineOf(src, index);
+    if (isOptedOut(optOuts, "one-sided-tuned-constant", line)) continue;
+    const held = upper > 0 ? "an UPPER" : "a LOWER";
+    const missed = upper > 0 ? "LOWERED" : "RAISED";
+    const suggest =
+      upper > 0 ? "toBeGreaterThanOrEqual" : "toBeLessThanOrEqual";
+    violations.push({
+      rule: "one-sided-tuned-constant",
+      file,
+      line,
+      symbol: name,
+      message:
+        `\`${name}\` is declared as a pin on a value owned elsewhere but is only asserted as ${held} bound` +
+        ` (${upper > 0 ? [...UPPER_MATCHERS].join("/") : [...LOWER_MATCHERS].join("/")}).` +
+        ` The source value can be silently ${missed} and this suite stays green, so it is not a drift guard.` +
+        ` Add a bare two-sided assertion — \`.${suggest}(${name})\`, or an exact \`.toBe(${name})\`/\`.toContain(${name})\`.` +
+        ` Note \`${name} + 1\` does NOT count: it constrains the neighbouring value, not \`${name}\`.`,
+    });
+  }
+  return violations;
+}
+
+/**
+ * A comment that says "MUST match `SOME_CONSTANT`" is a hand-copy: the value
+ * now lives in two places and nothing links them. Require the file to actually
+ * IMPORT the identifier it claims to mirror — importing is the only version of
+ * this guard that cannot rot.
+ *
+ * Scoped to UPPER_SNAKE_CASE identifiers so prose ("must match the shape",
+ * "must match `useLiveStatus.ts`") does not fire.
+ */
+function checkPinCommentImports(
+  file: string,
+  src: string,
+  comments: readonly CommentBlock[],
+  optOuts: OptOut[],
+): Violation[] {
+  const violations: Violation[] = [];
+  const importedNames = new Set<string>();
+  const importRe = /\bimport\s+(?:type\s+)?\{([^}]*)\}/g;
+  let im: RegExpExecArray | null;
+  while ((im = importRe.exec(src)) !== null) {
+    for (const raw of im[1].split(",")) {
+      const name = norm(raw).split(/\s+as\s+/)[0];
+      if (name) importedNames.add(name);
+    }
+  }
+
+  for (const comment of comments) {
+    const re = /\bMUST\s+match\s+`([A-Z][A-Z0-9_]{2,})`/gi;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(comment.text)) !== null) {
+      const ident = m[1];
+      if (importedNames.has(ident)) continue;
+      const line = lineOf(src, comment.start + m.index);
+      if (isOptedOut(optOuts, "pin-comment-without-import", line)) continue;
+      violations.push({
+        rule: "pin-comment-without-import",
+        file,
+        line,
+        symbol: ident,
+        message:
+          `This comment declares the value MUST match \`${ident}\`, but \`${ident}\` is never imported here — the value is hand-copied and will rot silently.` +
+          ` Export \`${ident}\` from its owning module and import it, so drift is a compile error instead of a stale literal.`,
+      });
+    }
+  }
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// Opt-out hygiene
+// ---------------------------------------------------------------------------
+
+function checkOptOutHygiene(
+  file: string,
+  optOuts: readonly OptOut[],
+): Violation[] {
+  return optOuts
+    .filter((o) => o.reason.length < MIN_OPT_OUT_REASON_LENGTH)
+    .map((o) => ({
+      rule: "opt-out-without-reason" as RuleId,
+      file,
+      line: o.line,
+      symbol: o.rule,
+      message:
+        `\`vacuity-gate-allow: ${o.rule}\` carries no justification (needs at least ${MIN_OPT_OUT_REASON_LENGTH} characters).` +
+        ` The escape hatch exists for cases the scanner cannot see — say which one, so the next reader can re-check it.`,
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Public: scan one test source
+// ---------------------------------------------------------------------------
+
+/**
+ * Analyze one test file's text. `file` is the repo-relative POSIX path used in
+ * messages and as part of the allowlist key.
+ */
+export function scanTestSource(
+  file: string,
+  src: string,
+  registry: readonly TunedConstantEntry[] = [],
+): Violation[] {
+  const { masked, comments } = maskAndExtract(src);
+  const optOuts = findOptOuts(src, comments);
+  return [
+    ...checkDegenerateAggregates(file, src, masked, optOuts),
+    ...checkOneSidedPins(file, src, masked, comments, optOuts, registry),
+    ...checkPinCommentImports(file, src, comments, optOuts),
+    ...checkOptOutHygiene(file, optOuts),
+  ].sort((a, b) => a.line - b.line || a.rule.localeCompare(b.rule));
+}
+
+// ---------------------------------------------------------------------------
+// Rule 3 — duplicated-constant drift
+// ---------------------------------------------------------------------------
+
+export interface DuplicatedConstantDecl {
+  /** Repo-relative POSIX path of the declaring module. */
+  file: string;
+  /** Constant name as declared (need not be exported). */
+  constant: string;
+}
+
+export interface DuplicatedConstantPin {
+  /** Why these are knowingly duplicated rather than imported. */
+  reason: string;
+  declarations: DuplicatedConstantDecl[];
+}
+
+/**
+ * Evaluate a constant initializer that is a pure arithmetic expression over
+ * numeric literals (`5 * 60 * 1000`, `2_000`, `(30 + 15) * 1000`). Returns
+ * `null` for anything else — a non-literal initializer means the value is no
+ * longer a hand-copied constant and the pin must be re-stated, which the caller
+ * reports rather than guessing at.
+ */
+export function evalNumericLiteralExpr(expr: string): number | null {
+  const cleaned = expr.replace(/_/g, "").trim();
+  if (!/^[\d.\s*+\-/()]+$/.test(cleaned)) return null;
+  if (!/\d/.test(cleaned)) return null;
+  // Tokenized shunting-free evaluation via Function is avoided; the grammar is
+  // small enough to evaluate with a tiny recursive-descent parser.
+  let pos = 0;
+  const peek = (): string => {
+    while (cleaned[pos] === " ") pos++;
+    return cleaned[pos] ?? "";
+  };
+  const parseExpr = (): number | null => {
+    let left = parseTerm();
+    if (left === null) return null;
+    for (;;) {
+      const c = peek();
+      if (c !== "+" && c !== "-") return left;
+      pos++;
+      const right = parseTerm();
+      if (right === null) return null;
+      left = c === "+" ? left + right : left - right;
+    }
+  };
+  const parseTerm = (): number | null => {
+    let left = parseFactor();
+    if (left === null) return null;
+    for (;;) {
+      const c = peek();
+      if (c !== "*" && c !== "/") return left;
+      pos++;
+      const right = parseFactor();
+      if (right === null) return null;
+      left = c === "*" ? left * right : left / right;
+    }
+  };
+  const parseFactor = (): number | null => {
+    const c = peek();
+    if (c === "(") {
+      pos++;
+      const inner = parseExpr();
+      if (inner === null || peek() !== ")") return null;
+      pos++;
+      return inner;
+    }
+    if (c === "-") {
+      pos++;
+      const inner = parseFactor();
+      return inner === null ? null : -inner;
+    }
+    const m = /^\d+(?:\.\d+)?/.exec(cleaned.slice(pos));
+    if (!m) return null;
+    pos += m[0].length;
+    return Number(m[0]);
+  };
+  const value = parseExpr();
+  if (value === null) return null;
+  return peek() === "" ? value : null;
+}
+
+/**
+ * Locate `const NAME = <expr>;` in a module and return its value and line.
+ * Runs on masked source so a mention inside a comment or string cannot be
+ * mistaken for the declaration.
+ */
+export function readConstantDeclaration(
+  src: string,
+  constant: string,
+): { value: number | null; line: number; raw: string } | null {
+  const masked = maskNonCode(src);
+  const re = new RegExp(
+    `\\b(?:export\\s+)?(?:const|let)\\s+${constant.replace(/\$/g, "\\$")}\\s*(?::[^=;]*)?=\\s*([^;\\n]+)`,
+  );
+  const m = re.exec(masked);
+  if (!m) return null;
+  const raw = norm(m[1]);
+  return {
+    value: evalNumericLiteralExpr(raw),
+    line: lineOf(src, m.index),
+    raw,
+  };
+}
+
+/**
+ * Assert every knowingly-duplicated constant pair still holds the same value.
+ *
+ * Fails loudly in THREE ways, all of which matter:
+ *   - the values differ (the drift this exists to catch);
+ *   - a declaration is MISSING (renamed or deleted) — otherwise a rename would
+ *     silently disable the pin, which is the failure mode of every guard this
+ *     gate was built to stop;
+ *   - an initializer stopped being a numeric literal, so the pin can no longer
+ *     compare them and a human has to restate it.
+ *
+ * `readFile` returns `null` for a path that does not exist.
+ */
+export function checkDuplicatedConstants(
+  pins: readonly DuplicatedConstantPin[],
+  readFile: (relPath: string) => string | null,
+): Violation[] {
+  const violations: Violation[] = [];
+  for (const pin of pins) {
+    const resolved: Array<{
+      decl: DuplicatedConstantDecl;
+      value: number;
+      line: number;
+    }> = [];
+    for (const decl of pin.declarations) {
+      const src = readFile(decl.file);
+      if (src === null) {
+        violations.push({
+          rule: "duplicated-constant-drift",
+          file: decl.file,
+          line: 1,
+          symbol: decl.constant,
+          message:
+            `Pinned duplicated constant \`${decl.constant}\` names a file that does not exist.` +
+            ` Update showcase/scripts/duplicated-constants.json (the pin must follow the code, or be removed with its sibling). Pin reason: ${pin.reason}`,
+        });
+        continue;
+      }
+      const found = readConstantDeclaration(src, decl.constant);
+      if (!found) {
+        violations.push({
+          rule: "duplicated-constant-drift",
+          file: decl.file,
+          line: 1,
+          symbol: decl.constant,
+          message:
+            `Pinned duplicated constant \`${decl.constant}\` is no longer declared in this file (renamed or removed), so the equality pin against ${pin.declarations
+              .filter((d) => d !== decl)
+              .map((d) => `\`${d.constant}\``)
+              .join(", ")} silently stopped guarding anything.` +
+            ` Re-point or delete the entry in showcase/scripts/duplicated-constants.json. Pin reason: ${pin.reason}`,
+        });
+        continue;
+      }
+      if (found.value === null) {
+        violations.push({
+          rule: "duplicated-constant-drift",
+          file: decl.file,
+          line: found.line,
+          symbol: decl.constant,
+          message:
+            `Pinned duplicated constant \`${decl.constant}\` is initialized to \`${found.raw}\`, which is not an arithmetic expression over numeric literals, so its value cannot be compared with its duplicate.` +
+            ` Either import the sibling constant instead of duplicating it, or restate the pin. Pin reason: ${pin.reason}`,
+        });
+        continue;
+      }
+      resolved.push({ decl, value: found.value, line: found.line });
+    }
+    if (resolved.length < 2) continue;
+    const [first, ...rest] = resolved;
+    for (const other of rest) {
+      if (other.value === first.value) continue;
+      violations.push({
+        rule: "duplicated-constant-drift",
+        file: other.decl.file,
+        line: other.line,
+        symbol: other.decl.constant,
+        message:
+          `Duplicated-constant DRIFT: \`${other.decl.constant}\` = ${other.value} but \`${first.decl.constant}\` = ${first.value} (${first.decl.file}:${first.line}).` +
+          ` These two are declared duplicates of one tuned value and must stay equal. Pin reason: ${pin.reason}`,
+      });
+    }
+  }
+  return violations;
+}

--- a/showcase/scripts/test-vacuity-allowlist.json
+++ b/showcase/scripts/test-vacuity-allowlist.json
@@ -1,0 +1,53 @@
+{
+  "_policy": "Allowlist for showcase/scripts/validate-test-vacuity.ts. SHRINK-ONLY RATCHET. Every entry is keyed by {rule, file, symbol} -- deliberately NOT by line number, so unrelated edits above a violation do not invalidate it. Rules: (1) every entry carries `added` (ISO date), `justification` (what is actually going on, and what removing it requires) and `owner` (who/what removes it); (2) an entry whose file EXISTS but whose violation no longer fires is reported STALE and FAILS the gate, so a fixed violation forces its entry to be deleted rather than leaving permanent cover; (3) an entry naming a file that does not exist yet is PENDING -- used to pre-register violations arriving on an unmerged branch -- and is neither enforced nor reported stale; (4) additions need the same scrutiny as a `// eslint-disable`: prefer fixing the assertion. This list should only ever get shorter.",
+  "entries": [
+    {
+      "rule": "degenerate-spread-aggregate",
+      "file": "showcase/harness/src/fleet/queue-client.test.ts",
+      "symbol": "hist",
+      "added": "2026-07-24",
+      "justification": "TRUE POSITIVE, pre-existing on main, deliberately not fixed in this gate-only PR. `Math.max(...hist)` at :1748 and the `for (const count of hist)` band-check above it are BOTH satisfied when firstAttemptHistogram returns an empty array, so the uniform-shuffle fairness claim is unpinned on the degenerate input. Fix is one line -- assert `hist` has PAGE_IDS.length entries before the band check -- and belongs to whoever next touches the queue-client shuffle tests. Remove this entry with that fix.",
+      "owner": "harness/fleet queue-client owner (next change to the shuffle fairness tests)"
+    },
+    {
+      "rule": "degenerate-spread-aggregate",
+      "file": "showcase/harness/src/probes/helpers/conversation-runner.test.ts",
+      "symbol": "perPollCounts",
+      "added": "2026-07-24",
+      "justification": "Non-emptiness IS asserted here, in a shape the scanner cannot read: the line after the bound asserts `perPollCounts.reduce((a, b) => a + b, 0)` is greater than 0, which can only hold for a non-empty array. The seeded `Math.max(0, ...perPollCounts)` still returns 0 on the empty input, so the bound alone would be vacuous -- the reduce is what saves it. Replacing that reduce with `expect(perPollCounts).not.toHaveLength(0)` makes the guard machine-visible and this entry disappears.",
+      "owner": "harness/probes conversation-runner owner (next change to the surface-read poll tests)"
+    },
+    {
+      "rule": "degenerate-spread-aggregate",
+      "file": "showcase/shell-dashboard/src/hooks/useLiveStatus.supplemental-bounds.test.tsx",
+      "symbol": "runawaySupplementalPages",
+      "added": "2026-07-24",
+      "justification": "PENDING -- arrives with PR #6156 (branch fix/cold-load-gray-masks-red, head 938be2accf2a), which is unmerged, so this file does not exist on main yet and the entry is inert until it lands. This is one of the two instances the gate was built for: `Math.max(...runawaySupplementalPages)` at :409 is -Infinity when the supplemental loop never ran, so the cap assertion passes for a hook that fetched nothing. Owned by the #6156 A1-vacuity fix agent; delete this entry with that fix rather than merging it forward.",
+      "owner": "PR #6156 A1-vacuity fix agent"
+    },
+    {
+      "rule": "degenerate-spread-aggregate",
+      "file": "showcase/shell-dashboard/src/hooks/useLiveStatus.supplemental-bounds.test.tsx",
+      "symbol": "runawayBulkOnlyPages",
+      "added": "2026-07-24",
+      "justification": "PENDING -- arrives with PR #6156 (see the sibling entry). Second known instance: `Math.max(...runawayBulkOnlyPages)` at :533 pins the bulk-loop page cap and is satisfied when the bulk loop issued zero requests. Owned by the #6156 A1-vacuity fix agent.",
+      "owner": "PR #6156 A1-vacuity fix agent"
+    },
+    {
+      "rule": "one-sided-tuned-constant",
+      "file": "showcase/shell-dashboard/src/hooks/useLiveStatus.supplemental-bounds.test.tsx",
+      "symbol": "EXPECTED_MAX_INITIAL_PAGES",
+      "added": "2026-07-24",
+      "justification": "PENDING -- arrives with PR #6156 (see the sibling entries). The headline A2 instance: the cap is asserted only via toBeLessThanOrEqual, and reviewers empirically halved the production MAX_INITIAL_FETCH_PAGES to 10 and then to 5 with the suite staying fully green. `not.toContain(EXPECTED_MAX_INITIAL_PAGES + 1)` constrains the neighbouring page number, not the cap. Owned by the #6156 A2-pin fix agent.",
+      "owner": "PR #6156 A2-pin fix agent"
+    },
+    {
+      "rule": "pin-comment-without-import",
+      "file": "showcase/shell-dashboard/src/hooks/useLiveStatus.supplemental-bounds.test.tsx",
+      "symbol": "MAX_INITIAL_FETCH_PAGES",
+      "added": "2026-07-24",
+      "justification": "PENDING -- arrives with PR #6156 (see the sibling entries). The file's own JSDoc says the literal MUST match `MAX_INITIAL_FETCH_PAGES` in useLiveStatus.ts, but that constant is not exported and is therefore hand-copied. The durable fix is to export it from useLiveStatus.ts and import it here, which also dissolves the one-sided-pin entry above. Owned by the #6156 A2-pin fix agent.",
+      "owner": "PR #6156 A2-pin fix agent"
+    }
+  ]
+}

--- a/showcase/scripts/validate-test-vacuity.ts
+++ b/showcase/scripts/validate-test-vacuity.ts
@@ -1,0 +1,330 @@
+/**
+ * Test-Vacuity + Constant-Drift Gate — IO driver / CLI
+ *
+ * Walks every test source under `showcase/`, runs the pure rules in
+ * `lib/test-vacuity-core.ts` over each one, checks the duplicated-constant pins
+ * in `duplicated-constants.json`, subtracts `test-vacuity-allowlist.json`, and
+ * exits non-zero with `file:line — why` for anything left.
+ *
+ * See `lib/test-vacuity-core.ts` for WHY each rule exists (short version: 43% of
+ * PR #6156's round-2 toothless-guard findings were in files its own round-1
+ * fixes had just written, and two mechanically-detectable shapes accounted for
+ * most of them).
+ *
+ * The gate that actually runs in CI is `__tests__/validate-test-vacuity.test.ts`
+ * — it is picked up by the `pnpm exec vitest run` step ("Run build pipeline
+ * tests") in `.github/workflows/showcase_validate.yml`, which fires on every PR
+ * touching `showcase/**`. This CLI exists so the same check is one command
+ * locally, and so its output is quotable in a PR body.
+ *
+ * ALLOWLIST POLICY
+ * ----------------
+ * `test-vacuity-allowlist.json` is a SHRINK-ONLY ratchet. Every entry carries a
+ * date, a justification and the owner that will remove it. Entries are keyed by
+ * `{rule, file, symbol}` — NOT by line number, so unrelated edits above the
+ * violation do not invalidate them. An entry whose file exists but whose
+ * violation is gone is reported as STALE and fails the gate, so the allowlist
+ * cannot quietly become permanent cover. An entry naming a file that does not
+ * exist yet is PENDING (used to pre-register violations arriving on an unmerged
+ * branch) and is neither enforced nor reported stale.
+ *
+ * Usage:
+ *   pnpm exec tsx showcase/scripts/validate-test-vacuity.ts
+ *   pnpm exec tsx showcase/scripts/validate-test-vacuity.ts --json
+ *   pnpm exec tsx showcase/scripts/validate-test-vacuity.ts --all   # ignore allowlist
+ *
+ * Exit code 0 = clean; 1 = violations (or a stale allowlist entry).
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+import {
+  checkDuplicatedConstants,
+  scanTestSource,
+} from "./lib/test-vacuity-core.js";
+import type {
+  DuplicatedConstantPin,
+  TunedConstantEntry,
+  Violation,
+} from "./lib/test-vacuity-core.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const SCRIPTS_DIR = __dirname;
+export const SHOWCASE_ROOT = path.resolve(__dirname, "..");
+export const REPO_ROOT = path.resolve(SHOWCASE_ROOT, "..");
+
+export const ALLOWLIST_PATH = path.join(
+  SCRIPTS_DIR,
+  "test-vacuity-allowlist.json",
+);
+export const DUPLICATED_CONSTANTS_PATH = path.join(
+  SCRIPTS_DIR,
+  "duplicated-constants.json",
+);
+
+/** Directory names never worth scanning (vendored, generated, or inert data). */
+const SKIP_DIRS = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  ".next",
+  ".turbo",
+  ".venv",
+  "venv",
+  "coverage",
+  "__pycache__",
+  "playwright-report",
+  "test-results",
+  // Inert `*.spec.ts` data consumed BY validate-parity's tests; not suites.
+  "fixtures",
+]);
+
+const TEST_FILE_RE = /\.(?:test|spec)\.tsx?$/;
+
+export interface AllowlistEntry {
+  rule: string;
+  file: string;
+  symbol: string;
+  /** ISO date the entry was added. */
+  added: string;
+  /** Why it is not fixed here, and who/what owns the fix. */
+  justification: string;
+  owner: string;
+}
+
+interface AllowlistFile {
+  _policy?: string;
+  entries: AllowlistEntry[];
+}
+
+interface DuplicatedConstantsFile {
+  _policy?: string;
+  tunedConstants?: TunedConstantEntry[];
+  pins: DuplicatedConstantPin[];
+}
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+/** Every test file under `root`, as repo-relative POSIX paths, sorted. */
+export function findTestFiles(root: string, repoRoot: string): string[] {
+  const found: string[] = [];
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isSymbolicLink()) {
+        // showcase/integrations/*/{tools,_shared,shared-tools} are symlinks into
+        // showcase/shared/... — following them would scan the same file under
+        // many paths and duplicate every violation. The shared source is walked
+        // directly via showcase/shared.
+        continue;
+      }
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRS.has(entry.name)) walk(full);
+        continue;
+      }
+      if (entry.isFile() && TEST_FILE_RE.test(entry.name)) {
+        found.push(path.relative(repoRoot, full).split(path.sep).join("/"));
+      }
+    }
+  };
+  walk(root);
+  return found.sort();
+}
+
+// ---------------------------------------------------------------------------
+// Config loading
+// ---------------------------------------------------------------------------
+
+function readJson<T>(file: string, fallback: T): T {
+  if (!fs.existsSync(file)) return fallback;
+  const text = fs.readFileSync(file, "utf8");
+  try {
+    return JSON.parse(text) as T;
+  } catch (e) {
+    throw new Error(
+      `${path.basename(file)}: JSON syntax error: ${(e as Error).message}`,
+      { cause: e },
+    );
+  }
+}
+
+export function loadAllowlist(file = ALLOWLIST_PATH): AllowlistEntry[] {
+  const parsed = readJson<AllowlistFile>(file, { entries: [] });
+  const entries = parsed.entries ?? [];
+  for (const [i, entry] of entries.entries()) {
+    for (const field of [
+      "rule",
+      "file",
+      "symbol",
+      "added",
+      "justification",
+      "owner",
+    ] as const) {
+      if (typeof entry[field] !== "string" || entry[field].trim() === "") {
+        throw new Error(
+          `${path.basename(file)}: entries[${i}] is missing required field "${field}". Every allowlist entry must be dated, justified and owned.`,
+        );
+      }
+    }
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(entry.added)) {
+      throw new Error(
+        `${path.basename(file)}: entries[${i}].added ("${entry.added}") must be an ISO date (YYYY-MM-DD).`,
+      );
+    }
+  }
+  return entries;
+}
+
+export function loadDuplicatedConstants(
+  file = DUPLICATED_CONSTANTS_PATH,
+): DuplicatedConstantsFile {
+  const parsed = readJson<DuplicatedConstantsFile>(file, { pins: [] });
+  return {
+    tunedConstants: parsed.tunedConstants ?? [],
+    pins: parsed.pins ?? [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+export interface GateResult {
+  /** Violations not covered by the allowlist. */
+  violations: Violation[];
+  /** All violations, allowlisted or not. */
+  all: Violation[];
+  /** Allowlist entries whose file exists but whose violation is gone. */
+  stale: AllowlistEntry[];
+  /** Allowlist entries whose file does not exist yet (pre-registered). */
+  pending: AllowlistEntry[];
+  filesScanned: number;
+}
+
+/**
+ * Allowlist / violation identity: rule + file + symbol, deliberately WITHOUT
+ * the line number so an unrelated edit above a violation does not invalidate
+ * its entry. JSON-encoded rather than joined on a separator character, because
+ * a symbol is an arbitrary source expression and any printable delimiter could
+ * appear inside one.
+ */
+const key = (v: { rule: string; file: string; symbol: string }): string =>
+  JSON.stringify([v.rule, v.file, v.symbol]);
+
+/**
+ * Run every rule over the tree and reconcile against the allowlist.
+ *
+ * `repoRoot` is the monorepo root; scanning starts at `<repoRoot>/showcase`.
+ */
+export function runGate(
+  repoRoot: string = REPO_ROOT,
+  options: {
+    allowlist?: AllowlistEntry[];
+    config?: DuplicatedConstantsFile;
+    ignoreAllowlist?: boolean;
+  } = {},
+): GateResult {
+  const allowlist = options.allowlist ?? loadAllowlist();
+  const config = options.config ?? loadDuplicatedConstants();
+  const showcaseRoot = path.join(repoRoot, "showcase");
+
+  const files = findTestFiles(showcaseRoot, repoRoot);
+  const all: Violation[] = [];
+  for (const rel of files) {
+    const src = fs.readFileSync(path.join(repoRoot, rel), "utf8");
+    all.push(...scanTestSource(rel, src, config.tunedConstants ?? []));
+  }
+  all.push(
+    ...checkDuplicatedConstants(config.pins, (rel) => {
+      const abs = path.join(repoRoot, rel);
+      return fs.existsSync(abs) ? fs.readFileSync(abs, "utf8") : null;
+    }),
+  );
+
+  const found = new Set(all.map(key));
+  const allowed = options.ignoreAllowlist
+    ? new Set<string>()
+    : new Set(allowlist.map(key));
+
+  const stale: AllowlistEntry[] = [];
+  const pending: AllowlistEntry[] = [];
+  if (!options.ignoreAllowlist) {
+    for (const entry of allowlist) {
+      if (found.has(key(entry))) continue;
+      if (fs.existsSync(path.join(repoRoot, entry.file))) stale.push(entry);
+      else pending.push(entry);
+    }
+  }
+
+  return {
+    violations: all.filter((v) => !allowed.has(key(v))),
+    all,
+    stale,
+    pending,
+    filesScanned: files.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  const asJson = argv.includes("--json");
+  const ignoreAllowlist = argv.includes("--all");
+  const started = Date.now();
+
+  let result: GateResult;
+  try {
+    result = runGate(REPO_ROOT, { ignoreAllowlist });
+  } catch (e) {
+    console.error(`[ERROR] ${(e as Error).message}`);
+    process.exit(2);
+  }
+  const elapsedMs = Date.now() - started;
+
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        {
+          filesScanned: result.filesScanned,
+          elapsedMs,
+          violations: result.violations,
+          allowlisted: result.all.length - result.violations.length,
+          stale: result.stale,
+          pending: result.pending,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    for (const v of result.violations) {
+      console.error(`[FAIL] ${v.file}:${v.line} [${v.rule}] ${v.message}`);
+    }
+    for (const s of result.stale) {
+      console.error(
+        `[FAIL] ${s.file} [stale-allowlist] ${s.rule} on \`${s.symbol}\` no longer fires — delete this entry from test-vacuity-allowlist.json (added ${s.added}, owner ${s.owner}).`,
+      );
+    }
+    console.log(
+      `Summary: FILES=${result.filesScanned} VIOLATIONS=${result.violations.length} ALLOWLISTED=${result.all.length - result.violations.length} PENDING=${result.pending.length} STALE=${result.stale.length} MS=${elapsedMs}`,
+    );
+  }
+
+  process.exit(result.violations.length + result.stale.length > 0 ? 1 : 0);
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) main();


### PR DESCRIPTION
## What this is

A mechanical gate for two of the defect classes that kept PR #6156 from converging. The [convergence audit](https://github.com/CopilotKit/CopilotKit/pull/6156) measured that **16 of 37 round-2 toothless-guard clusters (43%) lived in files that #6156's own round-1 fixes had just written** — including a one-sided drift guard written inside the file whose purpose was to stop one-sided drift guards. Both recurring shapes are detectable from test source text, so this makes them un-committable rather than something a reviewer has to spot again.

Strictly additive: no product behavior changes. The only non-additive-looking file is a new step in `showcase_validate.yml`.

## Defect classes it prevents

**A1 — degenerate-input vacuity.** An assertion satisfied when the thing it claims to pin never ran.

- `Math.max(...[])` is `-Infinity` and `Math.min(...[])` is `+Infinity`, so `expect(Math.max(...pages)).toBeLessThanOrEqual(CAP)` passes for a hook that fetched **zero** pages. Rule: `degenerate-spread-aggregate`.
- `[].every(p)` is `true` for every predicate and `[].reduce(f, seed)` returns `seed`, so an aggregate over a `.filter(...)` that matched nothing asserts nothing. Rule: `degenerate-filtered-aggregate`.

**A2 — one-sided / hand-copied pins.**

- A tuned constant asserted only as an upper (or only a lower) bound. Rule: `one-sided-tuned-constant`.
- A comment declaring the value MUST match `SOME_CONST` in a file that never imports it. Rule: `pin-comment-without-import`.

**Duplicated-constant drift.** Registry-driven equality pin over constants we knowingly duplicated across modules, seeded with the concrete instance the audit named: `cell-model.ts:279`'s `COMM_ERROR_FUTURE_SKEW_TOLERANCE_MS` vs `staleness.ts:81`'s `FUTURE_SKEW_TOLERANCE_MS`. Rule: `duplicated-constant-drift`.

## It is not a grep

A reworded equivalent has to be caught too, so:

- comments, strings, template literals and regex literals are masked in **one** length-preserving lexing pass (offsets and line numbers stay exact), then parens are matched by depth — `expect("Math.max(...xs)")` inside a string is data, not code;
- the aggregate is flagged whether it sits inside `expect(...)` or is hoisted into a `const` that `expect(...)` later consumes;
- "is it guarded?" is answered by looking for a precondition that forces **at least one element**. `toHaveLength(0)`, `toEqual([])` and `toBeGreaterThanOrEqual(0)` are explicitly **not** guards — they are satisfied by the empty input, which is the whole defect;
- `.map()` is treated as length-preserving (guarding the base suffices), `.filter`/`.flatMap`/`.slice` are not;
- `CONST + 1` does not pin `CONST`. This is exactly how #6156's guard read as two-sided while being one-sided.

## Proof it catches the known instances

`#6156` is unmerged, so its files are not on `main`. Scanned its tree (`origin/fix/cold-load-gray-masks-red`, head `938be2accf2a`) directly:

```
FILES=255 VIOLATIONS=6
showcase/shell-dashboard/src/hooks/useLiveStatus.supplemental-bounds.test.tsx:65  [pin-comment-without-import]  MAX_INITIAL_FETCH_PAGES
showcase/shell-dashboard/src/hooks/useLiveStatus.supplemental-bounds.test.tsx:71  [one-sided-tuned-constant]    EXPECTED_MAX_INITIAL_PAGES
showcase/shell-dashboard/src/hooks/useLiveStatus.supplemental-bounds.test.tsx:409 [degenerate-spread-aggregate]  runawaySupplementalPages
showcase/shell-dashboard/src/hooks/useLiveStatus.supplemental-bounds.test.tsx:533 [degenerate-spread-aggregate]  runawayBulkOnlyPages
```

All four named instances: both `Math.max(...[])` sites (`:409`, `:533` — audit cited `:406-417` and `:533-538`), the `EXPECTED_MAX_INITIAL_PAGES = 20` one-sided pin (which reviewers proved survives lowering the production constant to 10 and to 5), and the hand-copy comment. Sample message:

```
[FAIL] .../useLiveStatus.supplemental-bounds.test.tsx:409 [degenerate-spread-aggregate]
Math.max(...runawaySupplementalPages) is -Infinity when `runawaySupplementalPages`
is empty, so this upper bound is satisfied by a run that produced ZERO elements —
it pins nothing. Add a non-emptiness precondition (e.g.
expect(runawaySupplementalPages).not.toHaveLength(0), or assert the expected
element is present) before the bound.
```

## Proof it catches a variant I wrote myself

Same defect, different syntax — nothing here mentions `Math.max` inside `expect()`, so a grep for the reviewed idiom misses it entirely:

```ts
it("caps the walk", () => {
  const highestPageRequested = Math.max(...pagesRequested);
  expect(highestPageRequested).toBeLessThanOrEqual(20);
});
```

Run live against a temporary file in the tree:

```
[FAIL] showcase/scripts/__tests__/zz-temp-vacuity-demo.test.ts:4 [degenerate-spread-aggregate]
Math.max(...pagesRequested) is -Infinity when `pagesRequested` is empty, ...
Summary: FILES=1188 VIOLATIONS=1 ALLOWLISTED=2 PENDING=4 STALE=0 MS=360
exit=1
```

Other self-written variants covered in the suite: `Math.min` as a lower bound, a seeded `Math.max(0, ...xs)`, `.every()` over a filter, `.reduce()` over a filter, and the mirror-image one-sided pin (`toBeGreaterThanOrEqual` only).

## Proof the constant-drift pin has teeth (live red-green)

Mutated the real `cell-model.ts` from `5 * 60 * 1000` to `10 * 60 * 1000`, ran the gate, reverted:

```
(a) GREEN as committed:  VIOLATIONS=0  exit=0
(b) RED after mutation:
    [FAIL] showcase/harness/src/shared/cell-model/cell-model.ts:279 [duplicated-constant-drift]
    Duplicated-constant DRIFT: `COMM_ERROR_FUTURE_SKEW_TOLERANCE_MS` = 600000 but
    `FUTURE_SKEW_TOLERANCE_MS` = 300000 (.../staleness.ts:81). These two are declared
    duplicates of one tuned value and must stay equal. Pin reason: ...
    exit=1
(c) GREEN after revert:  VIOLATIONS=0  exit=0
```

The pin also fails if either declaration is **renamed away** or stops being a literal — a rename must not silently disable it. Both are unit-tested.

## Which CI job runs it — verified, not assumed

`.github/workflows/showcase_validate.yml`, job `validate`. It triggers on `pull_request` and `push:main` for `showcase/**`, and its existing step **"Run build pipeline tests"** is `pnpm exec vitest run` in `showcase/scripts` — so `__tests__/validate-test-vacuity.test.ts` is picked up with no wiring at all, which means the wiring cannot rot.

I also added a named step **"Run test-vacuity + constant-drift gate"** immediately before it, running the CLI. That is not a second gate so much as legibility: a failure gets its own name in the CI log instead of being one assertion among 2,372, and it exercises the CLI's exit code. Costs ~0.5s.

`static_quality.yml` was the suggested candidate; I checked and it is the wrong host — it does not run anything in `showcase/scripts`, and no CI job runs the harness or dashboard unit suites at all, which is why the gate lives in `showcase/scripts` rather than beside the code it polices.

## Allowlist policy

`showcase/scripts/test-vacuity-allowlist.json`. **Shrink-only ratchet.**

- Keyed by `{rule, file, symbol}` — deliberately **not** by line number, so an unrelated edit above a violation does not invalidate the entry.
- Every entry carries `added` (ISO date), `justification` and `owner`. `loadAllowlist` **throws** on a missing or undated field, and a test asserts every justification is substantive.
- An entry whose file **exists** but whose violation no longer fires is reported **STALE** and fails the gate. A fixed violation therefore forces its entry to be deleted rather than leaving permanent cover. (Proven: injecting a bogus entry produced `STALE=1 exit=1`.)
- An entry naming a file that does not exist yet is **PENDING** — used to pre-register violations arriving on an unmerged branch — and is neither enforced nor reported stale.
- `duplicated-constants.json` cannot be gutted either: a test asserts at least one pin remains and that the `COMM_ERROR_FUTURE_SKEW_TOLERANCE_MS` / `FUTURE_SKEW_TOLERANCE_MS` pair is registered by name.

**Contents — 6 entries, 2 live and 4 pending.** None are fixed here; separate fix agents own them.

| rule | file | symbol | status | owner |
|---|---|---|---|---|
| `degenerate-spread-aggregate` | `harness/src/fleet/queue-client.test.ts` | `hist` | live | queue-client shuffle tests |
| `degenerate-spread-aggregate` | `harness/src/probes/helpers/conversation-runner.test.ts` | `perPollCounts` | live | conversation-runner poll tests |
| `degenerate-spread-aggregate` | `useLiveStatus.supplemental-bounds.test.tsx` | `runawaySupplementalPages` | pending #6156 | #6156 A1 fix agent |
| `degenerate-spread-aggregate` | `useLiveStatus.supplemental-bounds.test.tsx` | `runawayBulkOnlyPages` | pending #6156 | #6156 A1 fix agent |
| `one-sided-tuned-constant` | `useLiveStatus.supplemental-bounds.test.tsx` | `EXPECTED_MAX_INITIAL_PAGES` | pending #6156 | #6156 A2 fix agent |
| `pin-comment-without-import` | `useLiveStatus.supplemental-bounds.test.tsx` | `MAX_INITIAL_FETCH_PAGES` | pending #6156 | #6156 A2 fix agent |

The two live ones are honest and different from each other: `hist` is a **true positive** (the `for (const count of hist)` band check above it is *also* vacuous on empty), while `perPollCounts` **is** guarded — by a `reduce`-sum assertion the scanner cannot read. Both justifications say which, and what removing them requires.

## What measuring the tree changed about the rules

The first version reported 6 violations on `main`. Reading each one found three false-positive classes, all fixed in the rules rather than papered over with allowlist entries:

- `.map()` preserves cardinality, so `expect(first).toHaveLength(32)` **does** guard `first.map(f)`;
- `expect(value, "message")` — the two-argument vitest form several showcase suites use — made correctly-written guards invisible, because the whole argument list was being read as the subject;
- a loop that guards every bucket (`for (const [k, v] of Object.entries(idx)) expect(v.length).toBeGreaterThan(0)`) now guards `idx.*`.

Its own test suite also caught two real bugs in the gate: `/^\[\s*\S/` matched `[]`, turning `expect(xs).toEqual([])` — the strongest possible statement that a collection *is* empty — into a non-emptiness guard; and reading opt-out markers line-wise made the gate flag marker text inside its own fixture strings.

## Runtime

**~0.5s** for 1,187 test files (`MS=464`–`MS=571` across runs). The naive version took 15.9s; a memoized line index and a single-pass masker took it to under 0.7s.

## Escape hatch

`// vacuity-gate-allow: <rule-id> — <reason>` on the offending line or the one above. The reason is **mandatory** (≥15 chars); a marker without one is itself reported as `opt-out-without-reason`, so the hatch cannot silence the gate wordlessly.

## Verification

- `showcase/scripts` vitest: **2,372 tests, 73 files, all passing** (one file initially failed on a stale `/tmp/copilotkit-showcase-generated-data.lock` left by my own concurrent run; passes on re-run).
- New suite: **49 tests passing**, including a test asserting the gate does not flag the violating snippets in its *own* file (they are all strings).
- `oxfmt --check` clean, `oxlint` 0 warnings 0 errors on all new files.
- `tsc -p showcase/scripts/tsconfig.json` introduces no new errors (6 pre-existing errors in `equivalence-gate.ts`, `generate-search-index.ts`, `verify-prod-resweep.ts` are untouched and predate this branch).

## Not in scope

Deliberately **not** fixed here: the flagged instances themselves, and the audit's other levers (compile-time `satisfies Record<K, true>` completeness exports, the mutation manifest, the exhaustive masking sweep, and the CI job that would actually run the harness/dashboard unit suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYdjeveT8Xof9TyHWMLoJr
