### PR TITLE
test(showcase): mutation manifest + runner for the toothless-guard class

### DIFF
--- a/showcase/scripts/__tests__/mutation-gate-manifest.test.ts
+++ b/showcase/scripts/__tests__/mutation-gate-manifest.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The CHEAP half of the mutation gate, run by `showcase_validate.yml`'s
+ * existing `showcase/scripts` vitest step.
+ *
+ * The gate itself (applying mutations and re-running suites) needs the
+ * `shell-dashboard` and `harness` packages installed and their pretest
+ * artifacts generated, and no CI job runs those unit suites yet — see
+ * `mutation-gate/mutation-gate.ts` and the report for that dependency. What
+ * DOES gate today is manifest integrity:
+ *
+ *   1. the manifest is structurally valid, and
+ *   2. every mutation's anchor string still occurs EXACTLY ONCE in its target
+ *      file at HEAD.
+ *
+ * (2) is the failure mode that would otherwise rot silently. A refactor that
+ * moves `const lastIdx = …` does not break any test — it just means the
+ * mutation for that guard no longer applies, and the day someone runs the gate
+ * they get a green report from a manifest that tests nothing. Catching it here
+ * costs milliseconds and no test execution.
+ */
+
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  describeAnchorProblem,
+  loadManifest,
+  resolveAnchors,
+  validateManifest,
+} from "../mutation-gate/manifest";
+
+const REPO_ROOT = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  cwd: import.meta.dirname,
+  encoding: "utf8",
+}).trim();
+
+describe("mutation-gate manifest", () => {
+  const manifest = loadManifest();
+
+  it("is structurally valid", () => {
+    expect(validateManifest(manifest)).toEqual([]);
+  });
+
+  it("declares at least one known-toothless guard, so the ledger is honest", () => {
+    // A manifest in which every mutation is killed is either a genuinely
+    // airtight suite or — far more likely — a manifest that only records the
+    // mutations someone already knew would fail. The seeded set deliberately
+    // carries the survivors too; if this ever drops to zero, confirm it is
+    // because the gaps were CLOSED (each `survive` entry promoted to `kill`)
+    // and not because they were deleted.
+    const survivors = manifest.mutants.filter((m) => m.expect === "survive");
+    expect(survivors.length).toBeGreaterThan(0);
+  });
+
+  it("every anchor resolves exactly once against HEAD", () => {
+    const problems = resolveAnchors(manifest, REPO_ROOT);
+    expect(
+      problems.map(describeAnchorProblem).join("\n"),
+      problems.length === 0
+        ? ""
+        : `mutation-gate/mutants.json has rotted against the current source. ` +
+            `Each mutation below no longer applies, so the guard it checks is ` +
+            `unmeasured. Re-anchor or delete the entry:`,
+    ).toBe("");
+  });
+
+  it("every target file is inside showcase/ and tracked by git", () => {
+    const files = [
+      ...new Set(manifest.mutants.flatMap((m) => m.edits.map((e) => e.file))),
+    ];
+    for (const f of files) {
+      expect(f.startsWith("showcase/"), `${f} is outside showcase/`).toBe(true);
+      expect(() =>
+        execFileSync("git", ["ls-files", "--error-unmatch", f], {
+          cwd: REPO_ROOT,
+          stdio: "ignore",
+        }),
+      ).not.toThrow();
+    }
+  });
+
+  it("every declared suite package exists and names a vitest binary path", () => {
+    for (const [name, s] of Object.entries(manifest.suites)) {
+      expect(
+        path.isAbsolute(s.package),
+        `suite ${name}: \`package\` must be repo-relative`,
+      ).toBe(false);
+      expect(s.vitestBin, `suite ${name}`).toMatch(/vitest$/);
+    }
+  });
+});

--- a/showcase/scripts/mutation-gate/manifest.ts
+++ b/showcase/scripts/mutation-gate/manifest.ts
@@ -90,8 +90,37 @@ export interface Mutant {
    */
   mustFail?: string[];
   knownGap?: MutantKnownGap;
+  ratchet?: MutantRatchet;
   /** Optional per-mutant override of the suite timeout, in milliseconds. */
   timeoutMs?: number;
+}
+
+/**
+ * A SECOND declared state for the same mutation, measured at a different commit.
+ *
+ * A manifest entry cannot target code that does not exist at its own HEAD (the
+ * anchor pre-flight refuses), so an entry seeded from a base branch records the
+ * base's outcome in `expect` — while the fix that closes the gap is already
+ * measured on its own branch. `ratchet` carries that second measurement, so the
+ * manifest documents the RATCHET rather than only the current state, and the
+ * gate stays truthful on both sides of the merge.
+ *
+ * The runner accepts EITHER declared state and reports which one the tree is
+ * in. That is not laxity: an outcome matching neither is still fatal, and both
+ * states name their failing tests exactly. What it buys is that the entry does
+ * not have to be edited in lockstep with someone else's merge.
+ */
+export interface MutantRatchet {
+  /** Commit the alternative state was MEASURED at — not inferred, measured. */
+  measuredAt: string;
+  /** Human ref for that commit (branch name, unit id). */
+  ref: string;
+  /** Must differ from the entry's `expect`, or it is not a ratchet. */
+  expect: MutantExpectation;
+  mustFail?: string[];
+  knownGap?: MutantKnownGap;
+  /** What changed, and what to do once this state becomes the only one. */
+  note: string;
 }
 
 export interface MutationSuite {
@@ -108,6 +137,24 @@ export interface MutationSuite {
   requires?: string;
 }
 
+/**
+ * A fix or branch that WILL contribute mutations, recorded because it cannot
+ * contribute them yet.
+ *
+ * An entry can only target code that exists at the manifest's own HEAD — the
+ * anchor pre-flight refuses otherwise — so a guard added on an unmerged branch
+ * has nowhere to live until that branch lands. Without this list the knowledge
+ * evaporates exactly the way the hand-written mutations did.
+ */
+export interface PendingSource {
+  ref: string;
+  /** Commit if it exists, or `null` while the work is still in flight. */
+  commit: string | null;
+  status: string;
+  /** What mutations to add once it lands. */
+  seeds: string;
+}
+
 export interface MutationManifest {
   /**
    * `owner/name` the origin remote MUST resolve to. The runner edits source by
@@ -116,8 +163,11 @@ export interface MutationManifest {
    * repo) aborts instead of mutating the wrong tree.
    */
   expectedRemoteSlug: string;
+  /** The commit every entry's base state was measured at. */
+  measuredAt: string;
   suites: Record<string, MutationSuite>;
   mutants: Mutant[];
+  pendingSources?: PendingSource[];
 }
 
 // ---------------------------------------------------------------------------
@@ -146,6 +196,20 @@ export function validateManifest(m: MutationManifest): string[] {
   const errors: string[] = [];
   if (typeof m.expectedRemoteSlug !== "string" || !m.expectedRemoteSlug) {
     errors.push("`expectedRemoteSlug` must be a non-empty string");
+  }
+  if (typeof m.measuredAt !== "string" || !m.measuredAt) {
+    errors.push(
+      "`measuredAt` must name the commit the base states were measured at",
+    );
+  }
+  for (const [i, p] of (m.pendingSources ?? []).entries()) {
+    const at = `pendingSources[${i}]`;
+    if (!p.ref) errors.push(`${at}: missing \`ref\``);
+    if (p.commit !== null && !p.commit) {
+      errors.push(`${at}: \`commit\` must be a commit or explicitly null`);
+    }
+    if (!p.status) errors.push(`${at}: missing \`status\``);
+    if (!p.seeds) errors.push(`${at}: missing \`seeds\``);
   }
   if (!m.suites || Object.keys(m.suites).length === 0) {
     errors.push("`suites` must declare at least one suite");
@@ -195,42 +259,72 @@ export function validateManifest(m: MutationManifest): string[] {
     if (!Array.isArray(mut.scope) || mut.scope.length === 0) {
       errors.push(`${at}: \`scope\` must be a non-empty array`);
     }
-    if (mut.expect === "kill") {
-      if (!Array.isArray(mut.mustFail) || mut.mustFail.length === 0) {
+    errors.push(...validateState(at, mut));
+    if (mut.ratchet) {
+      const r = mut.ratchet;
+      errors.push(...validateState(`${at} ratchet`, r));
+      if (!r.measuredAt) {
         errors.push(
-          `${at}: \`expect: "kill"\` requires a non-empty \`mustFail\``,
+          `${at} ratchet: missing \`measuredAt\` — a ratchet state must name ` +
+            `the commit it was MEASURED at, never an assumed one`,
         );
       }
-      if (mut.knownGap) {
+      if (!r.ref) errors.push(`${at} ratchet: missing \`ref\``);
+      if (!r.note) errors.push(`${at} ratchet: missing \`note\``);
+      if (r.expect === mut.expect) {
         errors.push(
-          `${at}: \`knownGap\` is meaningless with \`expect: "kill"\``,
+          `${at} ratchet: \`expect\` is "${r.expect}", the same as the entry's ` +
+            `— a ratchet must record a DIFFERENT outcome or it says nothing`,
         );
       }
-    } else if (mut.expect === "survive") {
-      if (mut.mustFail && mut.mustFail.length > 0) {
-        errors.push(
-          `${at}: \`expect: "survive"\` must not declare \`mustFail\` tests`,
-        );
-      }
-      if (!mut.knownGap?.reason || !mut.knownGap?.closedBy) {
-        errors.push(
-          `${at}: \`expect: "survive"\` requires \`knownGap.reason\` and ` +
-            `\`knownGap.closedBy\` — an entry may not claim a guard is ` +
-            `toothless without saying why and what closes it`,
-        );
-      }
-      if (
-        mut.knownGap &&
-        mut.knownGap.kind !== "coverage-gap" &&
-        mut.knownGap.kind !== "by-design"
-      ) {
-        errors.push(
-          `${at}: \`knownGap.kind\` must be "coverage-gap" or "by-design"`,
-        );
-      }
-    } else {
-      errors.push(`${at}: \`expect\` must be "kill" or "survive"`);
     }
+  }
+  return errors;
+}
+
+/** Shared shape rules for a declared state (the entry itself, or its ratchet). */
+function validateState(
+  at: string,
+  s: {
+    expect: MutantExpectation;
+    mustFail?: string[];
+    knownGap?: MutantKnownGap;
+  },
+): string[] {
+  const errors: string[] = [];
+  if (s.expect === "kill") {
+    if (!Array.isArray(s.mustFail) || s.mustFail.length === 0) {
+      errors.push(
+        `${at}: \`expect: "kill"\` requires a non-empty \`mustFail\``,
+      );
+    }
+    if (s.knownGap) {
+      errors.push(`${at}: \`knownGap\` is meaningless with \`expect: "kill"\``);
+    }
+  } else if (s.expect === "survive") {
+    if (s.mustFail && s.mustFail.length > 0) {
+      errors.push(
+        `${at}: \`expect: "survive"\` must not declare \`mustFail\` tests`,
+      );
+    }
+    if (!s.knownGap?.reason || !s.knownGap?.closedBy) {
+      errors.push(
+        `${at}: \`expect: "survive"\` requires \`knownGap.reason\` and ` +
+          `\`knownGap.closedBy\` — an entry may not claim a guard is ` +
+          `toothless without saying why and what closes it`,
+      );
+    }
+    if (
+      s.knownGap &&
+      s.knownGap.kind !== "coverage-gap" &&
+      s.knownGap.kind !== "by-design"
+    ) {
+      errors.push(
+        `${at}: \`knownGap.kind\` must be "coverage-gap" or "by-design"`,
+      );
+    }
+  } else {
+    errors.push(`${at}: \`expect\` must be "kill" or "survive"`);
   }
   return errors;
 }
@@ -335,6 +429,11 @@ export type Verdict =
   | "SURVIVED_AS_DECLARED"
   /** expect:survive, something failed. The manifest is stale — promote it. */
   | "GAP_CLOSED"
+  /**
+   * The entry's base state no longer holds, but its measured `ratchet` state
+   * does — the tree is on the far side of the fix that closed the gap.
+   */
+  | "RATCHET_ADVANCED"
   /** The scope did not produce a usable measurement (load/transform error). */
   | "ERROR"
   /** The scope was not green before mutation, so nothing can be concluded. */
@@ -391,11 +490,51 @@ export function classify(
       detail: "the scope reported zero tests; check `scope` paths",
     };
   }
+  // The entry's own declared state is checked first. If it does not hold and
+  // the entry carries a measured `ratchet`, the tree may simply be on the far
+  // side of that fix — so the alternative state is checked too, and reported by
+  // name. An outcome matching NEITHER declared state stays fatal.
+  const primary = evaluateState(mut, mut, run, opts);
+  if (!primary.fatal || !mut.ratchet) return primary;
+
+  const alternative = evaluateState(mut, mut.ratchet, run, opts);
+  if (alternative.fatal) {
+    return {
+      ...primary,
+      detail:
+        `${primary.detail}\n    …and this does NOT match the ratchet state ` +
+        `measured at ${mut.ratchet.measuredAt} (${mut.ratchet.ref}) either: ` +
+        `${alternative.detail}`,
+    };
+  }
+  return {
+    verdict: "RATCHET_ADVANCED",
+    fatal: false,
+    detail:
+      `this tree is on the far side of ${mut.ratchet.ref} ` +
+      `(${mut.ratchet.measuredAt}): the entry's base state no longer holds, ` +
+      `and the RATCHET state does — ${alternative.detail}. ${mut.ratchet.note} ` +
+      `Once the base state is unreachable (the fix is on main), collapse this ` +
+      `entry onto its ratchet and delete the \`ratchet\` block.`,
+  };
+}
+
+/** Check one declared state (the entry's own, or its ratchet) against a run. */
+function evaluateState(
+  mut: Mutant,
+  state: {
+    expect: MutantExpectation;
+    mustFail?: string[];
+    knownGap?: MutantKnownGap;
+  },
+  run: RunMeasurement,
+  opts: { allowFixed?: boolean },
+): Classification {
   const failed = new Set(
     run.tests.filter((t) => t.status === "failed").map((t) => t.fullName),
   );
 
-  if (mut.expect === "survive") {
+  if (state.expect === "survive") {
     if (failed.size === 0) {
       return {
         verdict: "SURVIVED_AS_DECLARED",
@@ -403,8 +542,8 @@ export function classify(
         detail:
           `${run.tests.length} test(s) still green under the mutation, as the ` +
           `manifest declares. ` +
-          `${mut.knownGap!.kind === "by-design" ? "BY DESIGN" : "TOOTHLESS"}: ` +
-          `${mut.knownGap!.reason} (closed by: ${mut.knownGap!.closedBy})`,
+          `${state.knownGap!.kind === "by-design" ? "BY DESIGN" : "TOOTHLESS"}: ` +
+          `${state.knownGap!.reason} (closed by: ${state.knownGap!.closedBy})`,
       };
     }
     return {
@@ -418,7 +557,7 @@ export function classify(
     };
   }
 
-  const declared = mut.mustFail ?? [];
+  const declared = state.mustFail ?? [];
   const unknown = declared.filter(
     (name) => !run.tests.some((t) => t.fullName === name),
   );

--- a/showcase/scripts/mutation-gate/manifest.ts
+++ b/showcase/scripts/mutation-gate/manifest.ts
@@ -1,0 +1,455 @@
+/**
+ * Mutation-gate manifest: types, loading, and the PURE parts of the gate —
+ * schema validation, anchor resolution, and outcome classification.
+ *
+ * Split out from `mutation-gate.ts` (the CLI runner) so the cheap half can be
+ * asserted by `showcase/scripts/__tests__/mutation-gate-manifest.test.ts`,
+ * which runs in `showcase_validate.yml`'s existing `showcase/scripts` vitest
+ * step. That test catches manifest ROT (an anchor string that no longer occurs,
+ * or occurs twice, after a refactor) without executing a single mutation.
+ *
+ * WHY THIS EXISTS. Across two 12-reviewer rounds on PR #6156 the single most
+ * effective review technique was mutation testing: break the implementation and
+ * check whether the tests notice. Three different agents wrote those mutations
+ * BY HAND, independently, and threw them away each time — while the findings
+ * they produced ("the cap can be silently halved with the bounds suite 6/6
+ * green") stayed true. This file makes those mutations a committed, re-runnable
+ * artifact instead of transcript archaeology.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+/**
+ * A single textual transformation. `find` must occur EXACTLY ONCE in `file` —
+ * zero occurrences means the manifest has rotted, more than one means the
+ * mutation is ambiguous. Both abort the run rather than guessing.
+ */
+export interface MutantEdit {
+  /** Repo-root-relative POSIX path. */
+  file: string;
+  /** Exact substring to replace. Must occur exactly once. */
+  find: string;
+  /** Replacement text. */
+  replace: string;
+}
+
+/**
+ * What the manifest CLAIMS the declared scope does when this mutation is
+ * applied.
+ *
+ * - `kill`    — the declared tests in `mustFail` MUST fail. If they pass, a
+ *               guard has gone toothless and the gate fails. This is the point
+ *               of the tool.
+ * - `survive` — the mutation is KNOWN to slip past the declared scope today.
+ *               A `knownGap` is mandatory: an entry may only claim "survive"
+ *               with a written reason and a pointer to the lever that closes
+ *               it. If a `survive` entry starts getting killed the gate ALSO
+ *               fails — a manifest that lies about guard strength is the same
+ *               disease one level up. The fix is a two-line promotion of the
+ *               entry to `kill` with the test names, in the same PR as the fix.
+ */
+export type MutantExpectation = "kill" | "survive";
+
+export interface MutantKnownGap {
+  /**
+   * - `coverage-gap` — the tests SHOULD see this and do not. A toothless guard.
+   * - `by-design`    — the mutation is genuinely behaviour-preserving (e.g. a
+   *                    documented defence-in-depth redundancy), so a green
+   *                    suite is correct rather than negligent. Recording it
+   *                    stops the next reviewer re-deriving the same non-finding.
+   */
+  kind: "coverage-gap" | "by-design";
+  /** Why the declared scope cannot see this mutation. */
+  reason: string;
+  /** The lever / follow-up that would close it, so the entry is actionable. */
+  closedBy: string;
+}
+
+export interface Mutant {
+  /** Stable `area/short-name` identifier. Used in reports and `--only`. */
+  id: string;
+  /** Where this mutation came from — report file and section. */
+  provenance: string;
+  /** The defect class this mutation checks the tests can still see. */
+  guards: string;
+  /** Key into `MutationManifest.suites`. */
+  suite: string;
+  edits: MutantEdit[];
+  /** Test paths (suite-package-relative) handed to vitest. */
+  scope: string[];
+  expect: MutantExpectation;
+  /**
+   * Vitest `fullName`s that must appear as FAILED. Required (and non-empty)
+   * when `expect === "kill"`; must be absent/empty when `expect === "survive"`.
+   */
+  mustFail?: string[];
+  knownGap?: MutantKnownGap;
+  /** Optional per-mutant override of the suite timeout, in milliseconds. */
+  timeoutMs?: number;
+}
+
+export interface MutationSuite {
+  /** Repo-root-relative package directory the vitest run happens in. */
+  package: string;
+  /** Package-relative path to the vitest binary. */
+  vitestBin: string;
+  /** Default per-run timeout, in milliseconds. */
+  timeoutMs: number;
+  /**
+   * Human note on how to make the suite runnable (artifact generation etc.).
+   * Not executed — the runner refuses to mutate a tree it had to prepare.
+   */
+  requires?: string;
+}
+
+export interface MutationManifest {
+  /**
+   * `owner/name` the origin remote MUST resolve to. The runner edits source by
+   * design; it verifies this before touching a single byte, so a mis-pinned
+   * worktree (a real failure mode: an agent's writes once landed in a dotfiles
+   * repo) aborts instead of mutating the wrong tree.
+   */
+  expectedRemoteSlug: string;
+  suites: Record<string, MutationSuite>;
+  mutants: Mutant[];
+}
+
+// ---------------------------------------------------------------------------
+// Loading + validation
+// ---------------------------------------------------------------------------
+
+export const MANIFEST_FILENAME = "mutants.json";
+
+export function manifestPath(): string {
+  return path.join(import.meta.dirname, MANIFEST_FILENAME);
+}
+
+export function loadManifest(file = manifestPath()): MutationManifest {
+  const parsed = JSON.parse(readFileSync(file, "utf8")) as MutationManifest;
+  const errors = validateManifest(parsed);
+  if (errors.length > 0) {
+    throw new Error(
+      `mutation-gate: ${file} is invalid:\n  - ${errors.join("\n  - ")}`,
+    );
+  }
+  return parsed;
+}
+
+/** Structural validation. Returns a list of human-readable problems. */
+export function validateManifest(m: MutationManifest): string[] {
+  const errors: string[] = [];
+  if (typeof m.expectedRemoteSlug !== "string" || !m.expectedRemoteSlug) {
+    errors.push("`expectedRemoteSlug` must be a non-empty string");
+  }
+  if (!m.suites || Object.keys(m.suites).length === 0) {
+    errors.push("`suites` must declare at least one suite");
+  }
+  for (const [name, s] of Object.entries(m.suites ?? {})) {
+    if (!s.package) errors.push(`suite \`${name}\`: missing \`package\``);
+    if (!s.vitestBin) errors.push(`suite \`${name}\`: missing \`vitestBin\``);
+    if (!(typeof s.timeoutMs === "number" && s.timeoutMs > 0)) {
+      errors.push(`suite \`${name}\`: \`timeoutMs\` must be a positive number`);
+    }
+  }
+  if (!Array.isArray(m.mutants) || m.mutants.length === 0) {
+    errors.push("`mutants` must be a non-empty array");
+    return errors;
+  }
+  const seen = new Set<string>();
+  for (const mut of m.mutants) {
+    const at = `mutant \`${mut.id ?? "<no id>"}\``;
+    if (!mut.id) errors.push(`${at}: missing \`id\``);
+    else if (seen.has(mut.id)) errors.push(`${at}: duplicate \`id\``);
+    else seen.add(mut.id);
+    if (!mut.provenance) errors.push(`${at}: missing \`provenance\``);
+    if (!mut.guards) errors.push(`${at}: missing \`guards\``);
+    if (!m.suites?.[mut.suite]) {
+      errors.push(
+        `${at}: \`suite\` "${mut.suite}" is not declared in \`suites\``,
+      );
+    }
+    if (!Array.isArray(mut.edits) || mut.edits.length === 0) {
+      errors.push(`${at}: \`edits\` must be a non-empty array`);
+    }
+    for (const [i, e] of (mut.edits ?? []).entries()) {
+      if (!e.file) errors.push(`${at} edit[${i}]: missing \`file\``);
+      else if (path.isAbsolute(e.file) || e.file.includes("..")) {
+        errors.push(
+          `${at} edit[${i}]: \`file\` must be a repo-relative path without \`..\``,
+        );
+      }
+      if (!e.find) errors.push(`${at} edit[${i}]: missing \`find\``);
+      if (typeof e.replace !== "string") {
+        errors.push(`${at} edit[${i}]: missing \`replace\``);
+      }
+      if (e.find === e.replace) {
+        errors.push(`${at} edit[${i}]: \`find\` and \`replace\` are identical`);
+      }
+    }
+    if (!Array.isArray(mut.scope) || mut.scope.length === 0) {
+      errors.push(`${at}: \`scope\` must be a non-empty array`);
+    }
+    if (mut.expect === "kill") {
+      if (!Array.isArray(mut.mustFail) || mut.mustFail.length === 0) {
+        errors.push(
+          `${at}: \`expect: "kill"\` requires a non-empty \`mustFail\``,
+        );
+      }
+      if (mut.knownGap) {
+        errors.push(
+          `${at}: \`knownGap\` is meaningless with \`expect: "kill"\``,
+        );
+      }
+    } else if (mut.expect === "survive") {
+      if (mut.mustFail && mut.mustFail.length > 0) {
+        errors.push(
+          `${at}: \`expect: "survive"\` must not declare \`mustFail\` tests`,
+        );
+      }
+      if (!mut.knownGap?.reason || !mut.knownGap?.closedBy) {
+        errors.push(
+          `${at}: \`expect: "survive"\` requires \`knownGap.reason\` and ` +
+            `\`knownGap.closedBy\` — an entry may not claim a guard is ` +
+            `toothless without saying why and what closes it`,
+        );
+      }
+      if (
+        mut.knownGap &&
+        mut.knownGap.kind !== "coverage-gap" &&
+        mut.knownGap.kind !== "by-design"
+      ) {
+        errors.push(
+          `${at}: \`knownGap.kind\` must be "coverage-gap" or "by-design"`,
+        );
+      }
+    } else {
+      errors.push(`${at}: \`expect\` must be "kill" or "survive"`);
+    }
+  }
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Anchor resolution (pure — no writes)
+// ---------------------------------------------------------------------------
+
+export interface AnchorProblem {
+  mutantId: string;
+  file: string;
+  occurrences: number;
+  find: string;
+}
+
+/**
+ * Assert every edit's `find` occurs exactly once in its target file, reading
+ * from `repoRoot`. Zero occurrences = the manifest has rotted against a
+ * refactor; more than one = the mutation is ambiguous.
+ */
+export function resolveAnchors(
+  m: MutationManifest,
+  repoRoot: string,
+  read: (p: string) => string = (p) => readFileSync(p, "utf8"),
+): AnchorProblem[] {
+  const problems: AnchorProblem[] = [];
+  const cache = new Map<string, string>();
+  for (const mut of m.mutants) {
+    for (const e of mut.edits) {
+      const abs = path.join(repoRoot, e.file);
+      let src = cache.get(abs);
+      if (src === undefined) {
+        try {
+          src = read(abs);
+        } catch {
+          problems.push({
+            mutantId: mut.id,
+            file: e.file,
+            occurrences: -1,
+            find: e.find,
+          });
+          continue;
+        }
+        cache.set(abs, src);
+      }
+      const n = countOccurrences(src, e.find);
+      if (n !== 1) {
+        problems.push({
+          mutantId: mut.id,
+          file: e.file,
+          occurrences: n,
+          find: e.find,
+        });
+      }
+    }
+  }
+  return problems;
+}
+
+export function countOccurrences(haystack: string, needle: string): number {
+  if (needle === "") return 0;
+  let n = 0;
+  let i = haystack.indexOf(needle);
+  while (i !== -1) {
+    n++;
+    i = haystack.indexOf(needle, i + needle.length);
+  }
+  return n;
+}
+
+export function describeAnchorProblem(p: AnchorProblem): string {
+  const where = `${p.mutantId} → ${p.file}`;
+  if (p.occurrences === -1) return `${where}: file could not be read`;
+  if (p.occurrences === 0) {
+    return (
+      `${where}: anchor NOT FOUND — the code moved and this mutation no ` +
+      `longer tests anything. Re-anchor it or delete the entry. Anchor: ` +
+      JSON.stringify(truncate(p.find))
+    );
+  }
+  return (
+    `${where}: anchor occurs ${p.occurrences}× — ambiguous, widen it to a ` +
+    `unique span. Anchor: ${JSON.stringify(truncate(p.find))}`
+  );
+}
+
+function truncate(s: string, n = 90): string {
+  const flat = s.replace(/\s+/g, " ").trim();
+  return flat.length > n ? `${flat.slice(0, n)}…` : flat;
+}
+
+// ---------------------------------------------------------------------------
+// Outcome classification (pure)
+// ---------------------------------------------------------------------------
+
+export type Verdict =
+  /** expect:kill, every declared test failed. The guard has teeth. */
+  | "KILLED"
+  /** expect:kill, at least one declared test still passed. TOOTHLESS GUARD. */
+  | "SURVIVED"
+  /** expect:survive, nothing failed. Toothless as declared. */
+  | "SURVIVED_AS_DECLARED"
+  /** expect:survive, something failed. The manifest is stale — promote it. */
+  | "GAP_CLOSED"
+  /** The scope did not produce a usable measurement (load/transform error). */
+  | "ERROR"
+  /** The scope was not green before mutation, so nothing can be concluded. */
+  | "BASELINE_DIRTY"
+  /** The run exceeded its timeout. */
+  | "TIMEOUT";
+
+export interface TestOutcome {
+  fullName: string;
+  status: string;
+}
+
+export interface RunMeasurement {
+  /** Every assertion result vitest reported, across the scope. */
+  tests: TestOutcome[];
+  /** File-level load/transform errors, if any. */
+  loadErrors: string[];
+  timedOut: boolean;
+}
+
+export interface Classification {
+  verdict: Verdict;
+  /** True if this outcome must fail the gate. */
+  fatal: boolean;
+  detail: string;
+}
+
+export function classify(
+  mut: Mutant,
+  run: RunMeasurement,
+  opts: { allowFixed?: boolean } = {},
+): Classification {
+  if (run.timedOut) {
+    return {
+      verdict: "TIMEOUT",
+      fatal: true,
+      detail: `scope exceeded its timeout; no measurement (a timeout is not a kill)`,
+    };
+  }
+  if (run.loadErrors.length > 0) {
+    return {
+      verdict: "ERROR",
+      fatal: true,
+      detail:
+        `the mutated scope failed to LOAD (${run.loadErrors.length} file ` +
+        `error(s)) — a syntactically broken mutation fails everything and ` +
+        `measures nothing: ${run.loadErrors[0]}`,
+    };
+  }
+  if (run.tests.length === 0) {
+    return {
+      verdict: "ERROR",
+      fatal: true,
+      detail: "the scope reported zero tests; check `scope` paths",
+    };
+  }
+  const failed = new Set(
+    run.tests.filter((t) => t.status === "failed").map((t) => t.fullName),
+  );
+
+  if (mut.expect === "survive") {
+    if (failed.size === 0) {
+      return {
+        verdict: "SURVIVED_AS_DECLARED",
+        fatal: false,
+        detail:
+          `${run.tests.length} test(s) still green under the mutation, as the ` +
+          `manifest declares. ` +
+          `${mut.knownGap!.kind === "by-design" ? "BY DESIGN" : "TOOTHLESS"}: ` +
+          `${mut.knownGap!.reason} (closed by: ${mut.knownGap!.closedBy})`,
+      };
+    }
+    return {
+      verdict: "GAP_CLOSED",
+      fatal: !opts.allowFixed,
+      detail:
+        `the manifest declares this mutation SURVIVES, but ${failed.size} ` +
+        `test(s) now fail — the gap has been closed. PROMOTE this entry to ` +
+        `\`expect: "kill"\` with mustFail: ${JSON.stringify([...failed])}. ` +
+        `(Re-run with --allow-fixed to downgrade this to a warning.)`,
+    };
+  }
+
+  const declared = mut.mustFail ?? [];
+  const unknown = declared.filter(
+    (name) => !run.tests.some((t) => t.fullName === name),
+  );
+  if (unknown.length > 0) {
+    return {
+      verdict: "ERROR",
+      fatal: true,
+      detail:
+        `mustFail names ${unknown.length} test(s) the scope does not contain ` +
+        `— renamed or removed: ${JSON.stringify(unknown)}`,
+    };
+  }
+  const survivors = declared.filter((name) => !failed.has(name));
+  if (survivors.length === 0) {
+    return {
+      verdict: "KILLED",
+      fatal: false,
+      detail: `all ${declared.length} declared test(s) failed`,
+    };
+  }
+  return {
+    verdict: "SURVIVED",
+    fatal: true,
+    detail:
+      `TOOTHLESS GUARD — ${survivors.length}/${declared.length} declared ` +
+      `test(s) still PASSED with the mutation applied: ` +
+      `${JSON.stringify(survivors)}. Either the guard lost its teeth or the ` +
+      `mutation no longer expresses the defect. Guards: ${mut.guards}`,
+  };
+}
+
+export function sha256(s: string): string {
+  return createHash("sha256").update(s).digest("hex");
+}

--- a/showcase/scripts/mutation-gate/mutants.json
+++ b/showcase/scripts/mutation-gate/mutants.json
@@ -1,11 +1,26 @@
 {
   "expectedRemoteSlug": "CopilotKit/CopilotKit",
+  "measuredAt": "938be2accf2ae42d12003618bcd9ebd3d514609c",
+  "pendingSources": [
+    {
+      "ref": "fix/6156-pb-evaluator-fidelity (unit Q2)",
+      "commit": null,
+      "status": "IN FLIGHT — not yet a commit, so nothing can be anchored against it.",
+      "seeds": "The PB query evaluator's fidelity holes, each of which is a mutation of `shell-dashboard/src/hooks/__tests__/pb-query-eval.ts` against the autocancel + bounds suites: single-quoted string literals (the real SDK's quoting) rejected by `tokenize`; a parse throw escaping the node:http handler so no response is written; `applyPbSort` silently no-opping on `-key`; case-SENSITIVE `like()` where PB's LIKE is not; `_` in a pattern suppressing PB's implicit `%…%` wrap; `comparePbField` comparing fail_count as strings so \"10\" < \"2\". Seed from round-2-slot-5-b F1/F2/F4/F7 and round-2-slot-6-a F2/F3."
+    },
+    {
+      "ref": "fix/6156-inv7-gap-carveout (unit Q3)",
+      "commit": "49bf40943f",
+      "status": "MEASURED, NOT SEEDABLE — the carve-out it adds does not exist at this manifest's `measuredAt`, so an entry targeting it would fail the anchor pre-flight. Verified against 49bf40943f: none of the 21 existing entries change verdict there, so Q3 neither closes nor opens any gap this manifest tracks.",
+      "seeds": "Two entries once it lands: (1) delete the ladder-gap carve-out and assert only the new I1-shape test fails — Q3's own red-green; (2) flip the in-suite `opts.ladderGapAllowance` switch to `false` and assert the carve-out's tests fail, which pins the switch as load-bearing rather than dead configuration."
+    }
+  ],
   "suites": {
     "dashboard-hooks": {
       "package": "showcase/shell-dashboard",
       "vitestBin": "node_modules/.bin/vitest",
-      "timeoutMs": 180000,
-      "requires": "`npm run pretest` (generate-registry + probe-docs) must have produced src/data/*.json, or every suite fails as a load error. Scope stays under src/ on purpose: tests/runtime-env-switch.spike.test.ts stalls a bare `vitest run` for ~25 min at 0% CPU."
+      "timeoutMs": 600000,
+      "requires": "`npm run pretest` (generate-registry + probe-docs) must have produced src/data/*.json, or every suite fails as a load error. Scope stays under src/ on purpose: tests/runtime-env-switch.spike.test.ts stalls a bare `vitest run` for ~25 min at 0% CPU (0.0% CPU, never spawns its `next build`). The 10-minute timeout is deliberately far above the ~5s these jsdom suites take unloaded: on a busy machine they have been measured 3-6x slower, and one run died at 161s without writing its JSON report at all, so a tight bound produces false FATALs rather than findings. It still sits well below the spike test's hang."
     },
     "harness-cell-model": {
       "package": "showcase/harness",
@@ -129,6 +144,17 @@
         "kind": "coverage-gap",
         "reason": "`EXPECTED_MAX_INITIAL_PAGES = 20` is documented as a drift pin, but every assertion is an UPPER bound (`toBeLessThanOrEqual(20)`, `not.toContain(21)`), so `length <= 20` and `max <= 20` hold at any smaller cap. The `console.warn`/`status === \"error\"` assertions still fire because the runaway server serves 40 full pages either way.",
         "closedBy": "Assert EQUALITY, not a bound: `expect(runawaySupplementalPages).toEqual(Array.from({length: EXPECTED_MAX_INITIAL_PAGES}, (_, i) => i + 1))`, and export `MAX_INITIAL_FETCH_PAGES` so the \"MUST match\" comment is mechanical. Owned by the concurrent fetch-bounds agent."
+      },
+      "ratchet": {
+        "measuredAt": "67c2c8c5c4",
+        "ref": "fix/6156-truncated-boundary (unit Q1)",
+        "expect": "kill",
+        "mustFail": [
+          "useLiveStatus supplemental fetch — page bound pins the cap MECHANICALLY to the implementation constant, in both directions",
+          "useLiveStatus supplemental fetch — page bound stops after MAX_INITIAL_FETCH_PAGES instead of paginating without bound",
+          "useLiveStatus bulk fetch — page bound fails loud never requests past the cap, and surfaces an error instead of a partial matrix"
+        ],
+        "note": "Q1 gives the cap a TWO-SIDED guard and adds a test that pins it mechanically to the implementation constant, growing the bounds suite 6 → 7 tests. Measured on that branch: 3 of the 7 fail at cap 10 (and the same 3 at cap 5), where all 6 passed before."
       }
     },
     {
@@ -149,6 +175,17 @@
         "kind": "coverage-gap",
         "reason": "Identical one-sided-bound hole to page-cap/halved-to-10. Kept as a separate entry because a partial fix that merely tightens the bound (e.g. `>= 10`) would close one and not the other, and the gate should say which.",
         "closedBy": "Same equality pin as page-cap/halved-to-10."
+      },
+      "ratchet": {
+        "measuredAt": "67c2c8c5c4",
+        "ref": "fix/6156-truncated-boundary (unit Q1)",
+        "expect": "kill",
+        "mustFail": [
+          "useLiveStatus supplemental fetch — page bound pins the cap MECHANICALLY to the implementation constant, in both directions",
+          "useLiveStatus supplemental fetch — page bound stops after MAX_INITIAL_FETCH_PAGES instead of paginating without bound",
+          "useLiveStatus bulk fetch — page bound fails loud never requests past the cap, and surfaces an error instead of a partial matrix"
+        ],
+        "note": "Closed by the same two-sided guard as page-cap/halved-to-10, and by the same 3 tests — so the fix is not a bound that was merely tightened to some other one-sided value."
       }
     },
     {
@@ -299,6 +336,15 @@
         "kind": "coverage-gap",
         "reason": "In every `pos-d*-red-signal-unknown` fixture EVERY row of the affected family is red-with-`signal: undefined`, so the red-row scope and the family scope coincide and the widening is invisible across all 56 baseline entries. The source comment calls this scoping 'deliberately and load-bearingly so' — at golden-master level nothing pins it.",
         "closedBy": "The heterogeneous-family fixtures in convergence-audit lever 7: a D4 `{chat: green with the `signal` key OMITTED, tools: red infra}` entry separates the two scopes. Owned by the concurrent fixture/golden-master agent."
+      },
+      "ratchet": {
+        "measuredAt": "3c1177838f",
+        "ref": "fix/6156-fixture-coverage-polarity (unit Q4)",
+        "expect": "kill",
+        "mustFail": [
+          "buildCellModel — golden-master identity matches baseline for fixture: hetero-d4-green-stripped-infra-red"
+        ],
+        "note": "Q4 adds exactly the heterogeneous fixture this gap called for, and it is the ONLY new failure — the golden master grows 57 → 62 entries and one of them separates the red-row scope from the family scope."
       }
     },
     {
@@ -319,6 +365,15 @@
         "kind": "coverage-gap",
         "reason": "Every red family in the fixture matrix is HOMOGENEOUS — each variant builder maps one uniform row shape over all keys of a rung — so no fixture anywhere contains two red rows with DIFFERENT `fail_count`s, and MAX and MIN agree on all 56 entries. The source doc at `:329-339` calls MAX load-bearing ('taking the minimum would let one fresh sibling re-arm tolerance for an already-confirmed failure').",
         "closedBy": "A heterogeneous D4 fixture `{chat: red fc1, tools: red fc3}` (convergence-audit lever 7). NOTE: `aggregation/failcount-min-not-max` proves the hand-written unit suite DOES catch this, so the gap is golden-master-only, not total."
+      },
+      "ratchet": {
+        "measuredAt": "3c1177838f",
+        "ref": "fix/6156-fixture-coverage-polarity (unit Q4)",
+        "expect": "kill",
+        "mustFail": [
+          "buildCellModel — golden-master identity matches baseline for fixture: hetero-d4-red-failcount-max"
+        ],
+        "note": "Q4's `hetero-d4-red-failcount-max` fixture is a D4 family with two reds at DIFFERENT fail_counts, which is exactly what MAX and MIN disagree on. One new fixture, one new failure."
       }
     },
     {
@@ -363,6 +418,15 @@
         "kind": "coverage-gap",
         "reason": "`starterSweep` only ever reds index 0 and every other variant builder is homogeneous, so a family mixing a soft-class red with a hard-class red does not exist anywhere in the matrix — and the quantifiers agree on every family that does. Slot 7a scoped this claim to the 56 golden-master entries; measured here, ALL 198 tests in the cell-model directory stay green, so the gap is total, not golden-master-only.",
         "closedBy": "A heterogeneous starter fixture `{health: red transport-error, agent: red smoke-failed}` (convergence-audit lever 7) plus a direct `foldFamily` unit test over a mixed soft/hard red pair."
+      },
+      "ratchet": {
+        "measuredAt": "3c1177838f",
+        "ref": "fix/6156-fixture-coverage-polarity (unit Q4)",
+        "expect": "kill",
+        "mustFail": [
+          "buildCellModel — golden-master identity matches baseline for fixture: hetero-starter-mixed-soft-hard"
+        ],
+        "note": "Q4's `hetero-starter-mixed-soft-hard` fixture is the mixed soft/hard starter family that separates the EVERY and ANY quantifiers. Note the scope here is the whole cell-model directory (208 tests at Q4), so this closes the TOTAL gap, not just the golden-master one."
       }
     },
     {

--- a/showcase/scripts/mutation-gate/mutants.json
+++ b/showcase/scripts/mutation-gate/mutants.json
@@ -1,0 +1,451 @@
+{
+  "expectedRemoteSlug": "CopilotKit/CopilotKit",
+  "suites": {
+    "dashboard-hooks": {
+      "package": "showcase/shell-dashboard",
+      "vitestBin": "node_modules/.bin/vitest",
+      "timeoutMs": 180000,
+      "requires": "`npm run pretest` (generate-registry + probe-docs) must have produced src/data/*.json, or every suite fails as a load error. Scope stays under src/ on purpose: tests/runtime-env-switch.spike.test.ts stalls a bare `vitest run` for ~25 min at 0% CPU."
+    },
+    "harness-cell-model": {
+      "package": "showcase/harness",
+      "vitestBin": "node_modules/.bin/vitest",
+      "timeoutMs": 120000,
+      "requires": "Nothing generated; the cell-model suites are pure. The whole directory runs in under a second."
+    }
+  },
+  "mutants": [
+    {
+      "id": "bulk-merge/drop-short-page",
+      "provenance": "round-1-fix-A5.md §3 M1; round-1-slot-6-a.md M3; re-measured by round-1-integration.md §1.1",
+      "guards": "Class F / #4504 dropped-tail pagination. The fake PB servers originally ignored `filter`, so the supplemental fetch's leftover-append silently reconstructed any row the bulk merge dropped BEFORE the assertions ran — dropping the entire short page left all three autocancel tests green.",
+      "suite": "dashboard-hooks",
+      "edits": [
+        {
+          "file": "showcase/shell-dashboard/src/hooks/useLiveStatus.ts",
+          "find": "const lastIdx = shortIdx === -1 ? waveResults.length - 1 : shortIdx;",
+          "replace": "const lastIdx = shortIdx === -1 ? waveResults.length - 1 : shortIdx - 1;"
+        }
+      ],
+      "scope": ["src/hooks/useLiveStatus.autocancel.test.tsx"],
+      "expect": "kill",
+      "mustFail": [
+        "useLiveStatus (real PocketBase SDK — auto-cancellation regression) reaches live with ALL pages despite concurrent same-path fan-out",
+        "useLiveStatus (real PocketBase SDK — mid-wave short-page pagination) keeps the whole tail when the short page is the last wave element, with no second wave and no duplicates",
+        "useLiveStatus (real PocketBase SDK — short page as FIRST wave element) stops at a short page that is NOT the last wave element, merging no later same-wave page and never arming a second wave"
+      ]
+    },
+    {
+      "id": "bulk-merge/no-boundary",
+      "provenance": "round-1-fix-A5.md §3 M2; round-1-slot-6-a.md M2; re-measured by round-1-integration.md §1.1",
+      "guards": "The 'merge stops at the FIRST short page' boundary. Real PB pagination is monotonic, so the page after a short page is empty and appending it changes nothing — which is exactly why deleting the boundary logic used to be invisible. Only the adversarial POISON-rows fixture separates the two.",
+      "suite": "dashboard-hooks",
+      "edits": [
+        {
+          "file": "showcase/shell-dashboard/src/hooks/useLiveStatus.ts",
+          "find": "const lastIdx = shortIdx === -1 ? waveResults.length - 1 : shortIdx;",
+          "replace": "const lastIdx = waveResults.length - 1;"
+        }
+      ],
+      "scope": ["src/hooks/useLiveStatus.autocancel.test.tsx"],
+      "expect": "kill",
+      "mustFail": [
+        "useLiveStatus (real PocketBase SDK — short page as FIRST wave element) stops at a short page that is NOT the last wave element, merging no later same-wave page and never arming a second wave"
+      ]
+    },
+    {
+      "id": "bulk-merge/reverse-page-order",
+      "provenance": "round-1-fix-A5.md §3 M3; re-measured by round-1-integration.md §1.1",
+      "guards": "Page ORDER, isolated from the row SET. The old `.some(id === last)` membership probe passed on any permutation; only an `.at(-1)` boundary assertion can see a reordered merge.",
+      "suite": "dashboard-hooks",
+      "edits": [
+        {
+          "file": "showcase/shell-dashboard/src/hooks/useLiveStatus.ts",
+          "find": "return { rows: pages.flat(), truncated };",
+          "replace": "return { rows: pages.flat().reverse(), truncated };"
+        }
+      ],
+      "scope": ["src/hooks/useLiveStatus.autocancel.test.tsx"],
+      "expect": "kill",
+      "mustFail": [
+        "useLiveStatus (real PocketBase SDK — mid-wave short-page pagination) keeps the whole tail when the short page is the last wave element, with no second wave and no duplicates",
+        "useLiveStatus (real PocketBase SDK — short page as FIRST wave element) stops at a short page that is NOT the last wave element, merging no later same-wave page and never arming a second wave"
+      ]
+    },
+    {
+      "id": "bulk-fetch/requestkey-autocancel",
+      "provenance": "round-1-slot-6-a.md M1 (the suite's own headline red-green claim)",
+      "guards": "The PocketBase SDK's default auto-cancellation. Without `requestKey: null` every same-path page after the first cancels its predecessor, `Promise.all` rejects, and the hook drops to OFFLINE. This is the regression the autocancel suite exists for.",
+      "suite": "dashboard-hooks",
+      "edits": [
+        {
+          "file": "showcase/shell-dashboard/src/hooks/useLiveStatus.ts",
+          "find": "      const listOpts = filter\n        ? {\n            filter,\n            sort: INITIAL_SORT,\n            fields: STATUS_LIST_FIELDS,\n            skipTotal: true,\n            requestKey: null,\n          }\n        : {\n            sort: INITIAL_SORT,\n            fields: STATUS_LIST_FIELDS,\n            skipTotal: true,\n            requestKey: null,\n          };",
+          "replace": "      const listOpts = filter\n        ? {\n            filter,\n            sort: INITIAL_SORT,\n            fields: STATUS_LIST_FIELDS,\n            skipTotal: true,\n          }\n        : {\n            sort: INITIAL_SORT,\n            fields: STATUS_LIST_FIELDS,\n            skipTotal: true,\n          };"
+        }
+      ],
+      "scope": ["src/hooks/useLiveStatus.autocancel.test.tsx"],
+      "expect": "kill",
+      "mustFail": [
+        "useLiveStatus (real PocketBase SDK — auto-cancellation regression) reaches live with ALL pages despite concurrent same-path fan-out",
+        "useLiveStatus (real PocketBase SDK — mid-wave short-page pagination) keeps the whole tail when the short page is the last wave element, with no second wave and no duplicates",
+        "useLiveStatus (real PocketBase SDK — short page as FIRST wave element) stops at a short page that is NOT the last wave element, merging no later same-wave page and never arming a second wave"
+      ]
+    },
+    {
+      "id": "page-cap/widened-to-100000",
+      "provenance": "round-1-fix-FETCH.md §4 F1; re-measured by round-1-integration.md §1.2",
+      "guards": "The first-paint page budget in the WIDENING direction — an unbounded read blocking first paint, and the bulk path failing to surface an error instead of a partial matrix.",
+      "suite": "dashboard-hooks",
+      "edits": [
+        {
+          "file": "showcase/shell-dashboard/src/hooks/useLiveStatus.ts",
+          "find": "const MAX_INITIAL_FETCH_PAGES = 20;",
+          "replace": "const MAX_INITIAL_FETCH_PAGES = 100000;"
+        }
+      ],
+      "scope": ["src/hooks/useLiveStatus.supplemental-bounds.test.tsx"],
+      "expect": "kill",
+      "mustFail": [
+        "useLiveStatus supplemental fetch — page bound stops after MAX_INITIAL_FETCH_PAGES instead of paginating without bound",
+        "useLiveStatus bulk fetch — page bound fails loud never requests past the cap, and surfaces an error instead of a partial matrix"
+      ]
+    },
+    {
+      "id": "page-cap/halved-to-10",
+      "provenance": "round-2-slot-5-b.md F5 (empirically probed there); round-2-slot-3-b.md finding 8",
+      "guards": "The same page budget in the NARROWING direction — the harmful one. A silently narrowed first-paint budget strips `signal` off rows the supplemental fetch never reaches and makes the BULK read throw `exceeded … pages` on a healthy fleet, i.e. it converts the guard into an outage. This is the exact bug class PR #6156 exists to fix.",
+      "suite": "dashboard-hooks",
+      "edits": [
+        {
+          "file": "showcase/shell-dashboard/src/hooks/useLiveStatus.ts",
+          "find": "const MAX_INITIAL_FETCH_PAGES = 20;",
+          "replace": "const MAX_INITIAL_FETCH_PAGES = 10;"
+        }
+      ],
+      "scope": ["src/hooks/useLiveStatus.supplemental-bounds.test.tsx"],
+      "expect": "survive",
+      "knownGap": {
+        "kind": "coverage-gap",
+        "reason": "`EXPECTED_MAX_INITIAL_PAGES = 20` is documented as a drift pin, but every assertion is an UPPER bound (`toBeLessThanOrEqual(20)`, `not.toContain(21)`), so `length <= 20` and `max <= 20` hold at any smaller cap. The `console.warn`/`status === \"error\"` assertions still fire because the runaway server serves 40 full pages either way.",
+        "closedBy": "Assert EQUALITY, not a bound: `expect(runawaySupplementalPages).toEqual(Array.from({length: EXPECTED_MAX_INITIAL_PAGES}, (_, i) => i + 1))`, and export `MAX_INITIAL_FETCH_PAGES` so the \"MUST match\" comment is mechanical. Owned by the concurrent fetch-bounds agent."
+      }
+    },
+    {
+      "id": "page-cap/cut-to-5",
+      "provenance": "round-2-slot-6-a.md F1 (confirms `= 5` also passes)",
+      "guards": "Same as page-cap/halved-to-10, at a cap BELOW the collection's real page count (~7 today), which is where the narrowing becomes a live outage rather than a latent one.",
+      "suite": "dashboard-hooks",
+      "edits": [
+        {
+          "file": "showcase/shell-dashboard/src/hooks/useLiveStatus.ts",
+          "find": "const MAX_INITIAL_FETCH_PAGES = 20;",
+          "replace": "const MAX_INITIAL_FETCH_PAGES = 5;"
+        }
+      ],
+      "scope": ["src/hooks/useLiveStatus.supplemental-bounds.test.tsx"],
+      "expect": "survive",
+      "knownGap": {
+        "kind": "coverage-gap",
+        "reason": "Identical one-sided-bound hole to page-cap/halved-to-10. Kept as a separate entry because a partial fix that merely tightens the bound (e.g. `>= 10`) would close one and not the other, and the gate should say which.",
+        "closedBy": "Same equality pin as page-cap/halved-to-10."
+      }
+    },
+    {
+      "id": "supplemental/failure-becomes-fatal",
+      "provenance": "round-1-fix-FETCH.md §4 F2; re-measured by round-1-integration.md §1.2",
+      "guards": "The non-fatal-by-construction posture of the enrichment read. Letting the supplemental rejection propagate meant `setRows([])` + `status: \"error\"` — a supplemental outage blanking the ENTIRE dashboard behind an offline banner.",
+      "suite": "dashboard-hooks",
+      "edits": [
+        {
+          "file": "showcase/shell-dashboard/src/hooks/useLiveStatus.ts",
+          "find": "      const supplementalPromise = fetchSupplementalSignalRows().catch(\n        (err: unknown) => {\n          // eslint-disable-next-line no-console\n          console.warn(\n            \"[useLiveStatus] supplemental signal fetch failed; rendering with \" +\n              \"`signal` unknown (non-green rows stay red, comm-error overlays \" +\n              \"wait for their next SSE delta)\",\n            { topic: dimension ?? \"<all>\", err },\n          );\n          // Empty is exactly \"nothing to merge\" for the merge below, so the\n          // degraded path needs no separate branch.\n          return [] as StatusRow[];\n        },\n      );",
+          "replace": "      const supplementalPromise = fetchSupplementalSignalRows();"
+        }
+      ],
+      "scope": ["src/hooks/useLiveStatus.supplemental-bounds.test.tsx"],
+      "expect": "kill",
+      "mustFail": [
+        "useLiveStatus supplemental fetch — failure degrades, never blanks renders the matrix — with reds still RED — when the supplemental fetch 500s"
+      ]
+    },
+    {
+      "id": "supplemental/drop-signal-projection",
+      "provenance": "round-1-fix-FETCH.md §4 F3; re-measured by round-1-integration.md §1.2",
+      "guards": "The supplemental read's `fields=` projection. Without it the fetch returns PB's default shape, so the cold-load rows never carry `signal` and the whole point of the supplemental fetch evaporates while the bulk read still looks healthy.",
+      "suite": "dashboard-hooks",
+      "edits": [
+        {
+          "file": "showcase/shell-dashboard/src/hooks/useLiveStatus.ts",
+          "find": "        fields: STATUS_SIGNAL_FIELDS,\n",
+          "replace": ""
+        }
+      ],
+      "scope": [
+        "src/hooks/useLiveStatus.supplemental-bounds.test.tsx",
+        "src/hooks/useLiveStatus.test.tsx"
+      ],
+      "expect": "kill",
+      "mustFail": [
+        "useLiveStatus supplemental fetch — cold-load correctness + projection projects to exactly the declared StatusRow shape (signal included) and selects only the rows that need it",
+        "useLiveStatus supplemental comm-error aggregate fetch (CF7-F3 #1) requests ONLY aggregate-shaped keys for the comm-error dimensions (narrow filter)",
+        "useLiveStatus supplemental comm-error aggregate fetch (CF7-F3 #1) the unscoped supplemental filter also covers every NON-GREEN row"
+      ]
+    },
+    {
+      "id": "fanout/serialized-dispatch",
+      "provenance": "round-1-slot-6-a.md F3/M4, restated as an effective mutation (see knownGap)",
+      "guards": "The claim that the page fan-out is issued CONCURRENTLY. `INITIAL_FANOUT_BATCH = 1` makes the read fully serial — one page per wave, each awaited before the next is issued — which is the regression that reinstates the pre-fan-out first-paint latency the fan-out was added to remove.",
+      "suite": "dashboard-hooks",
+      "edits": [
+        {
+          "file": "showcase/shell-dashboard/src/hooks/useLiveStatus.ts",
+          "find": "const INITIAL_FANOUT_BATCH = 2;",
+          "replace": "const INITIAL_FANOUT_BATCH = 1;"
+        }
+      ],
+      "scope": ["src/hooks/useLiveStatus.test.tsx"],
+      "expect": "survive",
+      "knownGap": {
+        "kind": "coverage-gap",
+        "reason": "The 'AND concurrent' assertion is `initialPageRequestOrder.sort() === [1,2,3]` plus `toContain(2)`/`toContain(3)`, which is equally true of a fully serial implementation — it records WHICH pages were issued, never that any two were in flight together. Slot 6's literal mutation (`Promise.all(wave)` → sequential `await`s) is a NO-OP for the same reason it stayed green: the promises are created eagerly at `wave.push(pb…getList(…))`, so awaiting them in sequence does not serialize dispatch. Narrowing the batch to 1 does, and 24/24 still pass.",
+        "closedBy": "Record an issue-time timestamp (or an in-flight counter) per page and assert page 3 was issued while page 2 was still unresolved. Also fix the in-place `.sort()` (round-2 F11) that destroys the recorded issue order."
+      }
+    },
+    {
+      "id": "polarity/pre-pr-gray-gate",
+      "provenance": "round-1-fix-G1.md GM-1; re-measured by round-1-integration.md Deliverable 2",
+      "guards": "The whole subject of PR #6156: reinstating the pre-PR gate that painted a red rung with a projected-away `signal` as NO_DATA (gray) instead of red. This is the single most load-bearing mutation in the manifest — it is the production bug itself, and it must stay visible at golden-master, coherence AND unit level.",
+      "suite": "harness-cell-model",
+      "edits": [
+        {
+          "file": "showcase/harness/src/shared/cell-model/cell-model.contribution.ts",
+          "find": "  if (fold.redSignalKnown && !fold.hasNonInfraRed) {\n    return { ...base, contribution: \"INFRA_RED_FRESH\", rawStatus };\n  }",
+          "replace": "  if (!fold.redSignalKnown) {\n    return { ...base, contribution: \"NO_DATA\", rawStatus: null };\n  }\n  if (fold.redSignalKnown && !fold.hasNonInfraRed) {\n    return { ...base, contribution: \"INFRA_RED_FRESH\", rawStatus };\n  }"
+        }
+      ],
+      "scope": ["src/shared/cell-model/"],
+      "expect": "kill",
+      "mustFail": [
+        "§7 I5: cold-load stripped signal → red (pending attribution) red D3 with signal stripped → red, and counts as a regression",
+        "§7 §D: infra-gray precondition is RED-ROW-scoped (mixed-state family) a red row whose OWN `signal` was stripped still renders RED (fail-safe polarity retained)",
+        "cell-model coherence — cross-field invariants over the fixture matrix coheres for fixture: pos-d3-red-signal-unknown",
+        "cell-model coherence — cross-field invariants over the fixture matrix coheres for fixture: pos-d4-red-signal-unknown",
+        "cell-model coherence — cross-field invariants over the fixture matrix coheres for fixture: pos-d5-red-signal-unknown",
+        "classifyRung — §3 rules red with stripped signal → FAIL_FRESH, never grayed away (rule 4 / §D)",
+        "classifyRung — §3 rules stripped signal never reaches INFRA_RED_FRESH even with an infra sibling",
+        "buildCellModel — golden-master identity matches baseline for fixture: pos-d3-red-signal-unknown",
+        "buildCellModel — golden-master identity matches baseline for fixture: pos-d4-red-signal-unknown",
+        "buildCellModel — golden-master identity matches baseline for fixture: pos-d5-red-signal-unknown",
+        "buildCellModel — golden-master identity matches baseline for fixture: pos-d6-red-signal-unknown"
+      ]
+    },
+    {
+      "id": "polarity/drop-redsignalknown-conjunct",
+      "provenance": "round-1-fix-G1.md GM-2; re-measured by round-1-integration.md §1.3",
+      "guards": "Nothing — and that is the point of recording it. `signalHasInfraErrorClass(undefined) === false`, so a stripped red row forces `hasNonInfraRed` on its own and the conjunct is behaviourally redundant TODAY.",
+      "suite": "harness-cell-model",
+      "edits": [
+        {
+          "file": "showcase/harness/src/shared/cell-model/cell-model.contribution.ts",
+          "find": "  if (fold.redSignalKnown && !fold.hasNonInfraRed) {",
+          "replace": "  if (!fold.hasNonInfraRed) {"
+        }
+      ],
+      "scope": ["src/shared/cell-model/"],
+      "expect": "survive",
+      "knownGap": {
+        "kind": "by-design",
+        "reason": "The conjunct is documented in the source as defence-in-depth: it exists so an absent `signal` blob can never be read as an infra attribution even if `signalHasInfraErrorClass` is loosened later. It is redundant with `!hasNonInfraRed` at present, so 198/198 stay green — correctly. Recorded so the next reviewer does not re-derive this as a coverage hole (it was raised as one in round 1 and closed as not-a-defect).",
+        "closedBy": "Nothing to close. If `signalHasInfraErrorClass` is ever loosened to treat `undefined` as infra-classed, this entry becomes a `kill` and the gate will say so."
+      }
+    },
+    {
+      "id": "polarity/redsignalknown-family-scope",
+      "provenance": "round-1-fix-G1.md Route 1; re-measured by round-1-integration.md §1.3",
+      "guards": "The RED-ROW scoping of the infra-gray precondition. Widening it to the whole family lets a GREEN sibling whose `signal` was projected away suppress a legitimate infra gray — the scope regression G1 fixed, invisible to every single-key fixture because there the family's one row IS the red row.",
+      "suite": "harness-cell-model",
+      "edits": [
+        {
+          "file": "showcase/harness/src/shared/cell-model/cell-model.contribution.ts",
+          "find": "  if (fold.redSignalKnown && !fold.hasNonInfraRed) {",
+          "replace": "  if (raw.rows.every((r) => r.signal !== undefined) && !fold.hasNonInfraRed) {"
+        }
+      ],
+      "scope": ["src/shared/cell-model/"],
+      "expect": "kill",
+      "mustFail": [
+        "§7 §D: infra-gray precondition is RED-ROW-scoped (mixed-state family) D4: infra-classed red `tools` + green `chat` grays — even when the green sibling's `signal` was projected away",
+        "§7 §D: infra-gray precondition is RED-ROW-scoped (mixed-state family) D5 multi-key: one infra-classed red pill + green sibling pills grays under the cold-load projection",
+        "§7 §D: infra-gray precondition is RED-ROW-scoped (mixed-state family) D6 multi-key: the `d6Effective` badge does not drift between the server and cold-load reads",
+        "classifyRung — §3 rules a projected-away GREEN sibling does not block the infra gray (red-row scope)"
+      ]
+    },
+    {
+      "id": "goldenmaster/redsignalknown-family-scope",
+      "provenance": "round-2-slot-7-a.md N2 item 4",
+      "guards": "The SAME scope regression as polarity/redsignalknown-family-scope, measured against the golden master ALONE. The pair defines the coverage boundary: G1's hand-written unit tests catch it, the 56-entry baseline does not.",
+      "suite": "harness-cell-model",
+      "edits": [
+        {
+          "file": "showcase/harness/src/shared/cell-model/cell-model.contribution.ts",
+          "find": "  if (fold.redSignalKnown && !fold.hasNonInfraRed) {",
+          "replace": "  if (raw.rows.every((r) => r.signal !== undefined) && !fold.hasNonInfraRed) {"
+        }
+      ],
+      "scope": ["src/shared/cell-model/cell-model.equivalence.test.ts"],
+      "expect": "survive",
+      "knownGap": {
+        "kind": "coverage-gap",
+        "reason": "In every `pos-d*-red-signal-unknown` fixture EVERY row of the affected family is red-with-`signal: undefined`, so the red-row scope and the family scope coincide and the widening is invisible across all 56 baseline entries. The source comment calls this scoping 'deliberately and load-bearingly so' — at golden-master level nothing pins it.",
+        "closedBy": "The heterogeneous-family fixtures in convergence-audit lever 7: a D4 `{chat: green with the `signal` key OMITTED, tools: red infra}` entry separates the two scopes. Owned by the concurrent fixture/golden-master agent."
+      }
+    },
+    {
+      "id": "goldenmaster/failcount-min-not-max",
+      "provenance": "round-2-slot-7-a.md N2 item 1",
+      "guards": "`maxNonInfraRedFailCount`'s MAX aggregation, measured against the golden master alone. Paired with aggregation/failcount-min-not-max below.",
+      "suite": "harness-cell-model",
+      "edits": [
+        {
+          "file": "showcase/harness/src/shared/cell-model/cell-model.contribution.ts",
+          "find": ": Math.max(maxNonInfraRedFailCount, row.fail_count);",
+          "replace": ": Math.min(maxNonInfraRedFailCount, row.fail_count);"
+        }
+      ],
+      "scope": ["src/shared/cell-model/cell-model.equivalence.test.ts"],
+      "expect": "survive",
+      "knownGap": {
+        "kind": "coverage-gap",
+        "reason": "Every red family in the fixture matrix is HOMOGENEOUS — each variant builder maps one uniform row shape over all keys of a rung — so no fixture anywhere contains two red rows with DIFFERENT `fail_count`s, and MAX and MIN agree on all 56 entries. The source doc at `:329-339` calls MAX load-bearing ('taking the minimum would let one fresh sibling re-arm tolerance for an already-confirmed failure').",
+        "closedBy": "A heterogeneous D4 fixture `{chat: red fc1, tools: red fc3}` (convergence-audit lever 7). NOTE: `aggregation/failcount-min-not-max` proves the hand-written unit suite DOES catch this, so the gap is golden-master-only, not total."
+      }
+    },
+    {
+      "id": "aggregation/failcount-min-not-max",
+      "provenance": "round-2-slot-7-a.md N2 item 1, measured here at full cell-model scope",
+      "guards": "The same MAX aggregation across the WHOLE harness cell-model suite. Recorded as a `kill` because the hand-written `classifyRung` fold tests do pin it — which is what makes the golden-master entry above a bounded gap rather than a total one.",
+      "suite": "harness-cell-model",
+      "edits": [
+        {
+          "file": "showcase/harness/src/shared/cell-model/cell-model.contribution.ts",
+          "find": ": Math.max(maxNonInfraRedFailCount, row.fail_count);",
+          "replace": ": Math.min(maxNonInfraRedFailCount, row.fail_count);"
+        }
+      ],
+      "scope": ["src/shared/cell-model/"],
+      "expect": "kill",
+      "mustFail": [
+        "classifyRung — §3 rules D4 fold: sustained non-infra red (fc3) + first-strike non-infra sibling (fc1) → FAIL_FRESH, not masked to amber",
+        "classifyRung — §3 rules starter fold: sustained soft red (fc5) + first-strike soft sibling (fc1) → FAIL_FRESH, not masked to amber"
+      ]
+    },
+    {
+      "id": "aggregation/softclass-any-not-every",
+      "provenance": "round-2-slot-7-a.md N2 item 2",
+      "guards": "The `allRedSoftClass` quantifier — 'EVERY non-infra red carries a soft class' vs 'ANY does'. The two differ only on a family with a MIXED soft/hard red pair, which the whole harness suite lacks. Scoped to the entire cell-model directory on purpose: the gap is broader than slot 7a claimed.",
+      "suite": "harness-cell-model",
+      "edits": [
+        {
+          "file": "showcase/harness/src/shared/cell-model/cell-model.contribution.ts",
+          "find": "  let allRedSoftClass = true;",
+          "replace": "  let allRedSoftClass = false;"
+        },
+        {
+          "file": "showcase/harness/src/shared/cell-model/cell-model.contribution.ts",
+          "find": "        const cls = starterErrorClassFromSignal(row.signal);\n        if (cls === undefined || !SOFT_STARTER_FAILURE_CLASSES.has(cls)) {\n          allRedSoftClass = false;\n        }",
+          "replace": "        const cls = starterErrorClassFromSignal(row.signal);\n        if (cls !== undefined && SOFT_STARTER_FAILURE_CLASSES.has(cls)) {\n          allRedSoftClass = true;\n        }"
+        }
+      ],
+      "scope": ["src/shared/cell-model/"],
+      "expect": "survive",
+      "knownGap": {
+        "kind": "coverage-gap",
+        "reason": "`starterSweep` only ever reds index 0 and every other variant builder is homogeneous, so a family mixing a soft-class red with a hard-class red does not exist anywhere in the matrix — and the quantifiers agree on every family that does. Slot 7a scoped this claim to the 56 golden-master entries; measured here, ALL 198 tests in the cell-model directory stay green, so the gap is total, not golden-master-only.",
+        "closedBy": "A heterogeneous starter fixture `{health: red transport-error, agent: red smoke-failed}` (convergence-audit lever 7) plus a direct `foldFamily` unit test over a mixed soft/hard red pair."
+      }
+    },
+    {
+      "id": "goldenmaster/starter-window-doubled",
+      "provenance": "round-2-slot-7-a.md N7",
+      "guards": "`STARTER_STALE_AFTER_MS`. The 2.5h window is derived in the source ('> 2×1h so two consecutive misses are needed', 'the tightest window satisfying >2 periods'); doubling it to 5h silently doubles how long a dead starter probe reads fresh.",
+      "suite": "harness-cell-model",
+      "edits": [
+        {
+          "file": "showcase/harness/src/shared/cell-model/staleness.ts",
+          "find": "export const STARTER_STALE_AFTER_MS = 2.5 * 60 * 60 * 1000;",
+          "replace": "export const STARTER_STALE_AFTER_MS = 5 * 60 * 60 * 1000;"
+        }
+      ],
+      "scope": ["src/shared/cell-model/cell-model.equivalence.test.ts"],
+      "expect": "survive",
+      "knownGap": {
+        "kind": "coverage-gap",
+        "reason": "No starter fixture sits in the 2.5h–5h band, so widening the window changes no baseline entry. The constant's own derivation comment is the only thing defending it.",
+        "closedBy": "A `starter-one-miss-still-green` fixture at NOW−2h plus a stale counterpart just past the window (convergence-audit lever 7)."
+      }
+    },
+    {
+      "id": "goldenmaster/commerror-decode-disabled",
+      "provenance": "round-2-slot-7-a.md F1 recurrence",
+      "guards": "`decodeCellCommError` — one of the two render-time `signal` readers this PR exists to repair. Making it return `undefined` unconditionally removes the cold-load comm-error overlay entirely.",
+      "suite": "harness-cell-model",
+      "edits": [
+        {
+          "file": "showcase/harness/src/shared/cell-model/cell-model.ts",
+          "find": "): PoolCommError | undefined {\n  // Per-cell D6/D5 rows fan out over the mapped featureType family. Each",
+          "replace": "): PoolCommError | undefined {\n  return undefined;\n  // Per-cell D6/D5 rows fan out over the mapped featureType family. Each"
+        }
+      ],
+      "scope": ["src/shared/cell-model/cell-model.equivalence.test.ts"],
+      "expect": "survive",
+      "knownGap": {
+        "kind": "coverage-gap",
+        "reason": "`commErrorKind` is `null` in all 56 baseline entries, so the golden master is byte-identical whether `decodeCellCommError` decodes anything or returns nothing at all. The behaviour-preservation claim the baseline carries therefore says nothing about the comm-error surface.",
+        "closedBy": "At least one fixture with a mirrored comm-error aggregate row, plus `expect(apiCell.commError).toEqual(model.commError)` in the api↔render equality loop (round-2-slot-6-a F7)."
+      }
+    },
+    {
+      "id": "inv7/contributingkeys-total-drift",
+      "provenance": "round-1-fix-INV7.md 'Teeth proof 3' (MUTATE_VACUOUS=1)",
+      "guards": "INV7's own ANTI-VACUITY guard. `contributingKeys` is a test-side reconstruction of the engine's keyspace; if it drifts, the narrowed INV7 silently passes everything. This mutation targets a TEST file on purpose — the thing under test is the guard, not the engine.",
+      "suite": "harness-cell-model",
+      "edits": [
+        {
+          "file": "showcase/harness/src/shared/cell-model/cell-model.coherence.test.ts",
+          "find": "function contributingKeys(input: CellModelInput): string[] {",
+          "replace": "function contributingKeys(input: CellModelInput): string[] {\n  if (input) return [];"
+        }
+      ],
+      "scope": ["src/shared/cell-model/cell-model.coherence.test.ts"],
+      "expect": "kill",
+      "mustFail": [
+        "cell-model coherence — cross-field invariants over the fixture matrix coheres for fixture: pos-d3-red-infra",
+        "cell-model coherence — cross-field invariants over the fixture matrix coheres for fixture: pos-d4-red-infra",
+        "cell-model coherence — cross-field invariants over the fixture matrix coheres for fixture: pos-d5-red-infra",
+        "cell-model coherence — INV7 soundness (scope + stale exemption) PASSES a legitimately-gray infra cell when an UNRELATED cell's row is red",
+        "cell-model coherence — INV7 soundness (scope + stale exemption) PASSES the same infra cell with no unrelated rows (control)"
+      ]
+    },
+    {
+      "id": "inv7/contributingkeys-partial-drift",
+      "provenance": "round-2-slot-2-b.md M3 / convergence-audit.md Class A2",
+      "guards": "The same anti-vacuity guard against PARTIAL drift — dropping ONE key (`chat:<slug>`) rather than all of them. This is the realistic drift shape: someone adds or renames a rung family and the hand-mirrored keyspace loses one entry.",
+      "suite": "harness-cell-model",
+      "edits": [
+        {
+          "file": "showcase/harness/src/shared/cell-model/cell-model.coherence.test.ts",
+          "find": "    keyFor(\"e2e\", input.slug, featureId),\n    keyFor(\"chat\", input.slug),\n    keyFor(\"tools\", input.slug),",
+          "replace": "    keyFor(\"e2e\", input.slug, featureId),\n    keyFor(\"tools\", input.slug),"
+        }
+      ],
+      "scope": ["src/shared/cell-model/cell-model.coherence.test.ts"],
+      "expect": "survive",
+      "knownGap": {
+        "kind": "coverage-gap",
+        "reason": "The guard is `expect(redRows.length).toBeGreaterThan(0)`, which only fires when the derived key set produces NO contributing red row at all. Dropping one key still leaves others red, so INV7 quietly stops checking the `chat:<slug>` family and 66/66 stay green.",
+        "closedBy": "Export `contributingKeysFor(input)` from the engine and delete the test-side mirror (convergence-audit lever 2), or assert the derived set EQUALS the engine's collected keyspace rather than merely being non-empty."
+      }
+    }
+  ]
+}

--- a/showcase/scripts/mutation-gate/mutation-gate.ts
+++ b/showcase/scripts/mutation-gate/mutation-gate.ts
@@ -308,13 +308,18 @@ function runVitest(
   return new Promise((resolve) => {
     const child = spawn(path.join(cwd, vitestBin), args, {
       cwd,
-      stdio: ["ignore", "ignore", "pipe"],
+      // Capture BOTH streams: when vitest dies without writing its JSON (it
+      // does, under enough machine load) the only account of why is on one of
+      // them, and a non-measurement reported without its cause is useless.
+      stdio: ["ignore", "pipe", "pipe"],
       env: { ...process.env, CI: "1", FORCE_COLOR: "0" },
     });
-    let stderr = "";
-    child.stderr.on("data", (d: Buffer) => {
-      stderr += d.toString();
-    });
+    let output = "";
+    const collect = (d: Buffer) => {
+      output += d.toString();
+    };
+    child.stdout.on("data", collect);
+    child.stderr.on("data", collect);
     let timedOut = false;
     const timer = setTimeout(() => {
       timedOut = true;
@@ -325,11 +330,22 @@ function runVitest(
       clearTimeout(timer);
       const measurement = timedOut
         ? { tests: [], loadErrors: [], timedOut: true }
-        : readMeasurement(outFile, stderr);
+        : readMeasurement(outFile, output, code);
       rmSync(outDir, { recursive: true, force: true });
       resolve({ ...measurement, exitCode: code });
     });
   });
+}
+
+/**
+ * A verdict that reflects the MACHINE rather than the code. Vitest killed by
+ * its own internal timeouts under load, or a scope that overran the wall clock,
+ * says nothing about whether the guard has teeth — so these are retried once
+ * before they are allowed to fail the gate. Retrying a real SURVIVED would be
+ * corner-cutting; retrying a non-measurement is just refusing to guess.
+ */
+function isNonMeasurement(v: Verdict): boolean {
+  return v === "ERROR" || v === "TIMEOUT";
 }
 
 interface VitestJson {
@@ -342,14 +358,17 @@ interface VitestJson {
   }>;
 }
 
-function readMeasurement(outFile: string, stderr: string): RunMeasurement {
+function readMeasurement(
+  outFile: string,
+  output: string,
+  exitCode: number | null,
+): RunMeasurement {
   if (!existsSync(outFile)) {
     return {
       tests: [],
       loadErrors: [
-        `vitest produced no JSON output${
-          stderr ? `; stderr: ${firstLine(stderr)}` : ""
-        }`,
+        `vitest exited ${exitCode} without writing its JSON report` +
+          (output ? `: ${firstLine(output)}` : " and printed nothing"),
       ],
       timedOut: false,
     };
@@ -394,13 +413,14 @@ function firstLine(s: string): string {
 // ---------------------------------------------------------------------------
 
 const GLYPH: Record<Verdict, string> = {
-  KILLED: "KILLED  ",
+  KILLED: "KILLED",
   SURVIVED: "SURVIVED",
   SURVIVED_AS_DECLARED: "TOOTHLESS",
   GAP_CLOSED: "GAP-CLOSED",
-  ERROR: "ERROR   ",
+  RATCHET_ADVANCED: "RATCHETED",
+  ERROR: "ERROR",
   BASELINE_DIRTY: "BASE-RED",
-  TIMEOUT: "TIMEOUT ",
+  TIMEOUT: "TIMEOUT",
 };
 
 interface Row {
@@ -428,13 +448,24 @@ function report(rows: Row[]): void {
   const toothless = rows.filter(
     (r) => r.cls.verdict === "SURVIVED_AS_DECLARED",
   );
+  const ratcheted = rows.filter((r) => r.cls.verdict === "RATCHET_ADVANCED");
   process.stdout.write(
     `\n${rows.length} mutant(s): ` +
       `${rows.filter((r) => r.cls.verdict === "KILLED").length} killed, ` +
       `${toothless.length} declared-toothless, ` +
+      `${ratcheted.length} ratcheted, ` +
       `${fatal.length} FATAL\n`,
   );
 
+  if (ratcheted.length > 0) {
+    process.stdout.write(
+      `\nRATCHET ADVANCED (a declared gap has been CLOSED — good news, but the ` +
+        `manifest now carries a state it no longer needs)\n`,
+    );
+    for (const r of ratcheted) {
+      process.stdout.write(`  ${r.mutant.id}\n    ${r.cls.detail}\n`);
+    }
+  }
   if (toothless.length > 0) {
     process.stdout.write(
       `\nDECLARED-TOOTHLESS GUARDS (known gaps, tracked in the manifest)\n`,
@@ -466,7 +497,15 @@ function listManifest(m: MutationManifest): void {
         (mut.expect === "kill"
           ? `  mustFail   ${mut.mustFail!.length} test(s)\n`
           : `  knownGap   ${mut.knownGap!.reason}\n` +
-            `  closedBy   ${mut.knownGap!.closedBy}\n`),
+            `  closedBy   ${mut.knownGap!.closedBy}\n`) +
+        (mut.ratchet
+          ? `  ratchet    → ${mut.ratchet.expect}` +
+            (mut.ratchet.expect === "kill"
+              ? ` (${mut.ratchet.mustFail!.length} test(s))`
+              : "") +
+            ` measured at ${mut.ratchet.measuredAt} (${mut.ratchet.ref})\n` +
+            `             ${mut.ratchet.note}\n`
+          : ""),
     );
   }
 }
@@ -541,9 +580,11 @@ async function main(): Promise<void> {
   // Untracked files are noted but tolerated — the showcase packages need
   // gitignored generated artifacts (`src/data/*.json`) present for the suites
   // to load at all, so demanding a virgin tree would make the gate unrunnable.
+  // `--check` only READS (validate + resolve anchors), so it is allowed on a
+  // dirty tree — it is the check you most want while editing the manifest.
   const status = git(repoRoot, ["status", "--porcelain", "-uno"]);
   if (!status.ok) fail("`git status` failed", 2);
-  if (status.out !== "") {
+  if (status.out !== "" && !opts.check) {
     fail(
       `REFUSING TO RUN — ${status.out.split("\n").length} tracked file(s) are ` +
         `modified. This gate rewrites tracked source and reverts it, so ` +
@@ -657,26 +698,52 @@ async function main(): Promise<void> {
   }
 
   // --- the run ------------------------------------------------------------
+  /** Apply, measure, revert, classify. Reverts even if vitest plumbing throws. */
+  const attempt = async (
+    mut: Mutant,
+    s: (typeof manifest.suites)[string],
+  ): Promise<Classification> => {
+    let run: RunMeasurement;
+    try {
+      mutator.apply(mut);
+      run = await runVitest(
+        path.join(repoRoot, s.package),
+        s.vitestBin,
+        mut.scope,
+        mut.timeoutMs ?? s.timeoutMs,
+      );
+    } finally {
+      mutator.revert();
+    }
+    return classify(mut, run, { allowFixed: opts.allowFixed });
+  };
+
   const rows: Row[] = [];
   for (const mut of selected) {
     if (interrupted) break;
     const s = manifest.suites[mut.suite]!;
     process.stdout.write(`\n▸ ${mut.id}  (expect ${mut.expect})\n`);
     const started = Date.now();
-    let cls: Classification;
-    try {
-      mutator.apply(mut);
-      const run = await runVitest(
-        path.join(repoRoot, s.package),
-        s.vitestBin,
-        mut.scope,
-        mut.timeoutMs ?? s.timeoutMs,
+    // One retry, and ONLY for a non-measurement. Every attempt applies and
+    // reverts within itself, so a retry re-mutates from a verified clean tree
+    // rather than stacking on the previous attempt. Retrying a real SURVIVED
+    // would be corner-cutting; retrying a non-measurement refuses to guess.
+    const MAX_ATTEMPTS = 2;
+    let cls = await attempt(mut, s);
+    for (let n = 2; isNonMeasurement(cls.verdict) && n <= MAX_ATTEMPTS; n++) {
+      process.stdout.write(
+        `  ${cls.verdict} on attempt ${n - 1} — a non-measurement, not a ` +
+          `result; retrying.\n    ${cls.detail}\n`,
       );
-      cls = classify(mut, run, { allowFixed: opts.allowFixed });
-    } finally {
-      // Unconditional: an exception in apply(), a throw from vitest plumbing,
-      // or a normal completion all land here before the next mutant.
-      mutator.revert();
+      cls = await attempt(mut, s);
+      if (!isNonMeasurement(cls.verdict)) {
+        cls = {
+          ...cls,
+          detail:
+            `${cls.detail} [measured on attempt ${n}; earlier attempt(s) ` +
+            `were non-measurements — treat the timing below as unreliable]`,
+        };
+      }
     }
     const ms = Date.now() - started;
     process.stdout.write(`  ${GLYPH[cls.verdict].trim()} — ${cls.detail}\n`);

--- a/showcase/scripts/mutation-gate/mutation-gate.ts
+++ b/showcase/scripts/mutation-gate/mutation-gate.ts
@@ -1,0 +1,701 @@
+#!/usr/bin/env tsx
+/**
+ * mutation-gate — apply each mutation in `mutants.json` in isolation, run the
+ * declared test scope, assert the declared tests FAIL, revert, report.
+ *
+ * A test suite that stays green when the code under it is deliberately broken
+ * is not a guard, it is decoration. This tool is the mechanical check for that,
+ * seeded with the mutations that three separate review agents wrote by hand on
+ * PR #6156 and threw away.
+ *
+ * USAGE
+ *   cd showcase/scripts
+ *   npm run mutation-gate                      # every mutant
+ *   npm run mutation-gate -- --only bulk-merge # substring filter on id
+ *   npm run mutation-gate -- --list            # print the manifest, run nothing
+ *   npm run mutation-gate -- --check           # validate + resolve anchors only
+ *   npm run mutation-gate -- --restore         # recover after a hard kill
+ *   npm run mutation-gate -- --allow-fixed     # a closed gap warns, not fails
+ *   npm run mutation-gate -- --no-baseline     # skip the pre-flight green check
+ *   npm run mutation-gate -- --repo <path>     # explicit repo root
+ *
+ * EXIT CODES
+ *   0  every mutant matched its declared expectation
+ *   1  at least one fatal outcome (a toothless guard, a stale manifest entry,
+ *      an unusable measurement, or a timeout)
+ *   2  refused to run (dirty tree, wrong repo, rotted anchor, stale journal)
+ *
+ * SAFETY — this tool edits tracked source by design, so:
+ *   1. It REFUSES to run when any TRACKED file is modified
+ *      (`git status --porcelain -uno` must be empty). No `--force`. Untracked
+ *      files are reported and tolerated: the gate only ever writes to tracked
+ *      files it has verified against the manifest, so untracked work is not at
+ *      risk, and the showcase packages legitimately carry gitignored generated
+ *      artifacts (`src/data/*.json`) that the suites need in order to run.
+ *   2. It NEVER runs `git stash` — the stash stack is shared repo-wide across
+ *      worktrees and holds other sessions' entries — and never commits.
+ *   3. It verifies `origin` resolves to `expectedRemoteSlug` BEFORE the first
+ *      write, and that every target file is tracked by git.
+ *   4. Originals are backed up under the worktree's own git dir (invisible to
+ *      `git status`) and recorded in a JOURNAL. Reverts are byte restores
+ *      verified by sha256 AND by `git diff --quiet`.
+ *   5. SIGINT/SIGTERM/SIGHUP and any uncaught error revert synchronously
+ *      before exit. A SIGKILL cannot be handled, so the journal survives it:
+ *      the next invocation finds it, restores from the backups, and exits 2.
+ */
+
+import { spawn, spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+import {
+  classify,
+  describeAnchorProblem,
+  loadManifest,
+  resolveAnchors,
+  sha256,
+} from "./manifest";
+import type {
+  Classification,
+  Mutant,
+  MutationManifest,
+  RunMeasurement,
+  TestOutcome,
+  Verdict,
+} from "./manifest";
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+interface Options {
+  repo?: string;
+  only?: string;
+  list: boolean;
+  check: boolean;
+  restore: boolean;
+  allowFixed: boolean;
+  baseline: boolean;
+}
+
+function parseArgs(argv: string[]): Options {
+  const o: Options = {
+    list: false,
+    check: false,
+    restore: false,
+    allowFixed: false,
+    baseline: true,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    switch (a) {
+      case "--repo":
+        o.repo = argv[++i];
+        break;
+      case "--only":
+        o.only = argv[++i];
+        break;
+      case "--list":
+        o.list = true;
+        break;
+      case "--check":
+        o.check = true;
+        break;
+      case "--restore":
+        o.restore = true;
+        break;
+      case "--allow-fixed":
+        o.allowFixed = true;
+        break;
+      case "--no-baseline":
+        o.baseline = false;
+        break;
+      case "-h":
+      case "--help":
+        printUsage();
+        process.exit(0);
+      default:
+        fail(`unknown argument: ${a} (try --help)`, 2);
+    }
+  }
+  return o;
+}
+
+function printUsage(): void {
+  const header = readFileSync(new URL(import.meta.url), "utf8")
+    .split("\n")
+    .slice(1)
+    .filter((l) => l.startsWith(" *") || l === "/**")
+    .map((l) =>
+      l
+        .replace(/^ \*ic?/, "")
+        .replace(/^ \* ?/, "")
+        .replace(/^\/\*\*$/, ""),
+    )
+    .join("\n");
+  process.stdout.write(`${header.trimEnd()}\n`);
+}
+
+function fail(message: string, code: number): never {
+  process.stderr.write(`\nmutation-gate: ${message}\n`);
+  process.exit(code);
+}
+
+// ---------------------------------------------------------------------------
+// git helpers (read-only; the gate never mutates git state)
+// ---------------------------------------------------------------------------
+
+function git(cwd: string, args: string[]): { ok: boolean; out: string } {
+  const r = spawnSync("git", args, { cwd, encoding: "utf8" });
+  return { ok: r.status === 0, out: (r.stdout ?? "").trim() };
+}
+
+/** `https://github.com/Owner/Name.git`, `git@github.com:Owner/Name` → `owner/name`. */
+function remoteSlug(url: string): string {
+  return url
+    .replace(/\.git$/, "")
+    .replace(/^.*[:/]([^/]+\/[^/]+)$/, "$1")
+    .toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
+// Journal — the SIGKILL-survivable record of what is currently mutated
+// ---------------------------------------------------------------------------
+
+interface JournalEntry {
+  file: string;
+  backup: string;
+  originalSha256: string;
+}
+interface Journal {
+  mutantId: string;
+  startedAt: string;
+  pid: number;
+  entries: JournalEntry[];
+}
+
+class Mutator {
+  private journal: Journal | null = null;
+
+  constructor(
+    private readonly repoRoot: string,
+    private readonly journalFile: string,
+    private readonly backupDir: string,
+  ) {}
+
+  get active(): boolean {
+    return this.journal !== null;
+  }
+
+  /** Back up, journal, then write the mutated content. */
+  apply(mut: Mutant): void {
+    if (this.journal) throw new Error("a mutation is already applied");
+    mkdirSync(this.backupDir, { recursive: true });
+    const byFile = new Map<string, string>();
+    for (const e of mut.edits) {
+      const abs = path.join(this.repoRoot, e.file);
+      let src = byFile.get(abs) ?? readFileSync(abs, "utf8");
+      const n = src.split(e.find).length - 1;
+      if (n !== 1) {
+        throw new Error(
+          `anchor for \`${mut.id}\` occurs ${n}× in ${e.file} (expected 1)`,
+        );
+      }
+      byFile.set(abs, src.replace(e.find, e.replace));
+      src = byFile.get(abs)!;
+    }
+    // Journal BEFORE the first write, so a kill between them is recoverable.
+    const entries: JournalEntry[] = [];
+    let i = 0;
+    for (const abs of byFile.keys()) {
+      const original = readFileSync(abs, "utf8");
+      const backup = path.join(this.backupDir, `${i++}.orig`);
+      writeFileSync(backup, original);
+      entries.push({
+        file: abs,
+        backup,
+        originalSha256: sha256(original),
+      });
+    }
+    this.journal = {
+      mutantId: mut.id,
+      startedAt: new Date().toISOString(),
+      pid: process.pid,
+      entries,
+    };
+    writeFileSync(this.journalFile, JSON.stringify(this.journal, null, 2));
+    for (const [abs, mutated] of byFile) writeFileSync(abs, mutated);
+  }
+
+  /**
+   * Restore every journalled file and verify. Synchronous and idempotent so it
+   * is safe to call from a signal handler.
+   */
+  revert(): void {
+    const j =
+      this.journal ??
+      (existsSync(this.journalFile)
+        ? (JSON.parse(readFileSync(this.journalFile, "utf8")) as Journal)
+        : null);
+    if (!j) return;
+    const problems: string[] = [];
+    for (const e of j.entries) {
+      const original = readFileSync(e.backup, "utf8");
+      if (sha256(original) !== e.originalSha256) {
+        problems.push(`backup for ${e.file} is corrupt (sha mismatch)`);
+        continue;
+      }
+      writeFileSync(e.file, original);
+      if (sha256(readFileSync(e.file, "utf8")) !== e.originalSha256) {
+        problems.push(`restore of ${e.file} did not take`);
+      }
+    }
+    this.journal = null;
+    if (existsSync(this.journalFile)) unlinkSync(this.journalFile);
+    rmSync(this.backupDir, { recursive: true, force: true });
+    if (problems.length > 0) {
+      process.stderr.write(
+        `\nmutation-gate: REVERT PROBLEM — restore by hand:\n  - ${problems.join(
+          "\n  - ",
+        )}\n`,
+      );
+      return;
+    }
+    const status = git(this.repoRoot, ["status", "--porcelain", "-uno"]);
+    if (status.ok && status.out !== "") {
+      process.stderr.write(
+        `\nmutation-gate: tree is NOT clean after revert:\n${status.out}\n`,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// vitest execution
+// ---------------------------------------------------------------------------
+
+interface VitestRunResult extends RunMeasurement {
+  exitCode: number | null;
+}
+
+function runVitest(
+  cwd: string,
+  vitestBin: string,
+  scope: string[],
+  timeoutMs: number,
+): Promise<VitestRunResult> {
+  const outDir = mkdtempSync(path.join(tmpdir(), "mutation-gate-"));
+  const outFile = path.join(outDir, "results.json");
+  const args = [
+    "run",
+    ...scope,
+    "--reporter=json",
+    `--outputFile=${outFile}`,
+    // Silence the interleaved test-side console noise; the JSON file is the
+    // measurement. Failures are reported from the JSON, not from stdout.
+    "--silent",
+  ];
+  return new Promise((resolve) => {
+    const child = spawn(path.join(cwd, vitestBin), args, {
+      cwd,
+      stdio: ["ignore", "ignore", "pipe"],
+      env: { ...process.env, CI: "1", FORCE_COLOR: "0" },
+    });
+    let stderr = "";
+    child.stderr.on("data", (d: Buffer) => {
+      stderr += d.toString();
+    });
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), 5_000);
+    }, timeoutMs);
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      const measurement = timedOut
+        ? { tests: [], loadErrors: [], timedOut: true }
+        : readMeasurement(outFile, stderr);
+      rmSync(outDir, { recursive: true, force: true });
+      resolve({ ...measurement, exitCode: code });
+    });
+  });
+}
+
+interface VitestJson {
+  numTotalTests?: number;
+  testResults?: Array<{
+    name?: string;
+    status?: string;
+    message?: string;
+    assertionResults?: Array<{ fullName?: string; status?: string }>;
+  }>;
+}
+
+function readMeasurement(outFile: string, stderr: string): RunMeasurement {
+  if (!existsSync(outFile)) {
+    return {
+      tests: [],
+      loadErrors: [
+        `vitest produced no JSON output${
+          stderr ? `; stderr: ${firstLine(stderr)}` : ""
+        }`,
+      ],
+      timedOut: false,
+    };
+  }
+  let json: VitestJson;
+  try {
+    json = JSON.parse(readFileSync(outFile, "utf8")) as VitestJson;
+  } catch (err) {
+    return {
+      tests: [],
+      loadErrors: [`vitest JSON output was unparseable: ${String(err)}`],
+      timedOut: false,
+    };
+  }
+  const tests: TestOutcome[] = [];
+  const loadErrors: string[] = [];
+  for (const file of json.testResults ?? []) {
+    const assertions = file.assertionResults ?? [];
+    // A file that reports NO assertions but carries a message failed to
+    // load/transform. That is not a measurement of the tests — a mutation that
+    // breaks the parse "fails" everything while proving nothing.
+    if (assertions.length === 0 && (file.message || file.status === "failed")) {
+      loadErrors.push(
+        `${file.name ?? "<unknown file>"}: ${firstLine(file.message ?? "no tests ran")}`,
+      );
+      continue;
+    }
+    for (const a of assertions) {
+      tests.push({ fullName: a.fullName ?? "", status: a.status ?? "unknown" });
+    }
+  }
+  return { tests, loadErrors, timedOut: false };
+}
+
+function firstLine(s: string): string {
+  const line = s.split("\n").find((l) => l.trim() !== "") ?? "";
+  return line.length > 220 ? `${line.slice(0, 220)}…` : line.trim();
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+const GLYPH: Record<Verdict, string> = {
+  KILLED: "KILLED  ",
+  SURVIVED: "SURVIVED",
+  SURVIVED_AS_DECLARED: "TOOTHLESS",
+  GAP_CLOSED: "GAP-CLOSED",
+  ERROR: "ERROR   ",
+  BASELINE_DIRTY: "BASE-RED",
+  TIMEOUT: "TIMEOUT ",
+};
+
+interface Row {
+  mutant: Mutant;
+  cls: Classification;
+  ms: number;
+}
+
+function report(rows: Row[]): void {
+  const w = Math.max(...rows.map((r) => r.mutant.id.length), 8);
+  process.stdout.write(
+    `\n${"MUTANT".padEnd(w)}  ${"EXPECT".padEnd(8)}  ${"VERDICT".padEnd(10)}  TIME\n`,
+  );
+  process.stdout.write(
+    `${"-".repeat(w)}  ${"-".repeat(8)}  ${"-".repeat(10)}  ----\n`,
+  );
+  for (const r of rows) {
+    process.stdout.write(
+      `${r.mutant.id.padEnd(w)}  ${r.mutant.expect.padEnd(8)}  ` +
+        `${GLYPH[r.cls.verdict].padEnd(10)}  ${(r.ms / 1000).toFixed(1)}s\n`,
+    );
+  }
+
+  const fatal = rows.filter((r) => r.cls.fatal);
+  const toothless = rows.filter(
+    (r) => r.cls.verdict === "SURVIVED_AS_DECLARED",
+  );
+  process.stdout.write(
+    `\n${rows.length} mutant(s): ` +
+      `${rows.filter((r) => r.cls.verdict === "KILLED").length} killed, ` +
+      `${toothless.length} declared-toothless, ` +
+      `${fatal.length} FATAL\n`,
+  );
+
+  if (toothless.length > 0) {
+    process.stdout.write(
+      `\nDECLARED-TOOTHLESS GUARDS (known gaps, tracked in the manifest)\n`,
+    );
+    for (const r of toothless) {
+      process.stdout.write(`  ${r.mutant.id}\n    ${r.cls.detail}\n`);
+    }
+  }
+  if (fatal.length > 0) {
+    process.stderr.write(`\nFATAL\n`);
+    for (const r of fatal) {
+      process.stderr.write(
+        `  ${r.cls.verdict}: ${r.mutant.id}\n    ${r.cls.detail}\n` +
+          `    provenance: ${r.mutant.provenance}\n`,
+      );
+    }
+  }
+}
+
+function listManifest(m: MutationManifest): void {
+  for (const mut of m.mutants) {
+    process.stdout.write(
+      `${mut.id}\n` +
+        `  expect     ${mut.expect}\n` +
+        `  suite      ${mut.suite} (${m.suites[mut.suite]!.package})\n` +
+        `  scope      ${mut.scope.join(", ")}\n` +
+        `  guards     ${mut.guards}\n` +
+        `  provenance ${mut.provenance}\n` +
+        (mut.expect === "kill"
+          ? `  mustFail   ${mut.mustFail!.length} test(s)\n`
+          : `  knownGap   ${mut.knownGap!.reason}\n` +
+            `  closedBy   ${mut.knownGap!.closedBy}\n`),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2));
+  const manifest = loadManifest();
+
+  if (opts.list) {
+    listManifest(manifest);
+    return;
+  }
+
+  // --- repo resolution + HARD pre-flight -----------------------------------
+  const here = import.meta.dirname;
+  const top = opts.repo ?? git(here, ["rev-parse", "--show-toplevel"]).out;
+  if (!top || !existsSync(top)) {
+    fail(`could not resolve a repo root (tried \`${top}\`); pass --repo`, 2);
+  }
+  const repoRoot = path.resolve(top);
+
+  const inside = git(repoRoot, ["rev-parse", "--is-inside-work-tree"]);
+  if (!inside.ok || inside.out !== "true") {
+    fail(`\`${repoRoot}\` is not a git work tree`, 2);
+  }
+  const origin = git(repoRoot, ["remote", "get-url", "origin"]);
+  if (!origin.ok) fail(`\`${repoRoot}\` has no \`origin\` remote`, 2);
+  const slug = remoteSlug(origin.out);
+  if (slug !== manifest.expectedRemoteSlug.toLowerCase()) {
+    fail(
+      `REFUSING TO WRITE. \`${repoRoot}\` origin resolves to \`${slug}\`, but ` +
+        `the manifest expects \`${manifest.expectedRemoteSlug}\`. This gate ` +
+        `edits tracked source; it will not do so in an unexpected repo.`,
+      2,
+    );
+  }
+  const gitDir = git(repoRoot, ["rev-parse", "--absolute-git-dir"]);
+  if (!gitDir.ok) fail("could not resolve the git dir", 2);
+  const journalFile = path.join(gitDir.out, "mutation-gate-journal.json");
+  const backupDir = path.join(gitDir.out, "mutation-gate-backup");
+  const mutator = new Mutator(repoRoot, journalFile, backupDir);
+
+  // --- journal recovery ----------------------------------------------------
+  if (existsSync(journalFile)) {
+    const stale = JSON.parse(readFileSync(journalFile, "utf8")) as Journal;
+    process.stderr.write(
+      `\nmutation-gate: a PREVIOUS RUN DIED with \`${stale.mutantId}\` applied ` +
+        `(pid ${stale.pid}, ${stale.startedAt}). Restoring from the journal.\n`,
+    );
+    mutator.revert();
+    const after = git(repoRoot, ["status", "--porcelain", "-uno"]);
+    process.stderr.write(
+      after.out === ""
+        ? `mutation-gate: restored; tree is clean. Re-run.\n`
+        : `mutation-gate: restored, but the tree is still dirty:\n${after.out}\n`,
+    );
+    process.exit(2);
+  }
+  if (opts.restore) {
+    process.stdout.write(
+      `mutation-gate: no journal at ${journalFile} — nothing to restore.\n`,
+    );
+    return;
+  }
+
+  // --- clean tree ----------------------------------------------------------
+  // TRACKED modifications only (`-uno`): those are what a revert could clobber.
+  // Untracked files are noted but tolerated — the showcase packages need
+  // gitignored generated artifacts (`src/data/*.json`) present for the suites
+  // to load at all, so demanding a virgin tree would make the gate unrunnable.
+  const status = git(repoRoot, ["status", "--porcelain", "-uno"]);
+  if (!status.ok) fail("`git status` failed", 2);
+  if (status.out !== "") {
+    fail(
+      `REFUSING TO RUN — ${status.out.split("\n").length} tracked file(s) are ` +
+        `modified. This gate rewrites tracked source and reverts it, so ` +
+        `uncommitted work is at risk. There is no --force, and this gate never ` +
+        `uses \`git stash\` (the stash stack is shared repo-wide across ` +
+        `worktrees and holds other sessions' entries). Commit or discard ` +
+        `first:\n${status.out}`,
+      2,
+    );
+  }
+
+  // --- every target must be tracked ---------------------------------------
+  const files = [
+    ...new Set(manifest.mutants.flatMap((m) => m.edits.map((e) => e.file))),
+  ];
+  const untracked = files.filter(
+    (f) => !git(repoRoot, ["ls-files", "--error-unmatch", f]).ok,
+  );
+  if (untracked.length > 0) {
+    fail(`target file(s) are not tracked by git: ${untracked.join(", ")}`, 2);
+  }
+
+  // --- anchors resolve ----------------------------------------------------
+  const anchorProblems = resolveAnchors(manifest, repoRoot);
+  if (anchorProblems.length > 0) {
+    fail(
+      `manifest anchors do not resolve at HEAD ` +
+        `(${git(repoRoot, ["rev-parse", "--short", "HEAD"]).out}):\n  - ` +
+        anchorProblems.map(describeAnchorProblem).join("\n  - "),
+      2,
+    );
+  }
+  if (opts.check) {
+    process.stdout.write(
+      `mutation-gate: manifest valid; ${manifest.mutants.length} mutant(s), ` +
+        `all anchors resolve uniquely at ` +
+        `${git(repoRoot, ["rev-parse", "--short", "HEAD"]).out}.\n`,
+    );
+    return;
+  }
+
+  const selected = opts.only
+    ? manifest.mutants.filter((m) => m.id.includes(opts.only!))
+    : manifest.mutants;
+  if (selected.length === 0) fail(`--only "${opts.only}" matched no mutant`, 2);
+
+  // --- revert-on-death wiring ---------------------------------------------
+  let interrupted = false;
+  const onSignal = (sig: NodeJS.Signals) => {
+    interrupted = true;
+    process.stderr.write(`\nmutation-gate: ${sig} — reverting…\n`);
+    mutator.revert();
+    process.stderr.write(`mutation-gate: reverted. Exiting.\n`);
+    process.exit(130);
+  };
+  for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"] as NodeJS.Signals[]) {
+    process.on(sig, () => onSignal(sig));
+  }
+  const onCrash = (err: unknown) => {
+    process.stderr.write(
+      `\nmutation-gate: crashed — reverting…\n${String(err)}\n`,
+    );
+    mutator.revert();
+    process.exit(1);
+  };
+  process.on("uncaughtException", onCrash);
+  process.on("unhandledRejection", onCrash);
+
+  // --- baseline: the scope must be GREEN before it can be mutated ---------
+  const baselineOf = new Map<string, RunMeasurement>();
+  if (opts.baseline) {
+    const scopes = new Map<string, { suite: string; scope: string[] }>();
+    for (const m of selected) {
+      scopes.set(`${m.suite}::${[...m.scope].sort().join("|")}`, {
+        suite: m.suite,
+        scope: m.scope,
+      });
+    }
+    process.stdout.write(
+      `mutation-gate: baseline — ${scopes.size} distinct scope(s) must be green ` +
+        `before any mutation is applied.\n`,
+    );
+    for (const [key, { suite, scope }] of scopes) {
+      const s = manifest.suites[suite]!;
+      const r = await runVitest(
+        path.join(repoRoot, s.package),
+        s.vitestBin,
+        scope,
+        s.timeoutMs,
+      );
+      baselineOf.set(key, r);
+      const failed = r.tests.filter((t) => t.status === "failed").length;
+      const bad = r.timedOut || r.loadErrors.length > 0 || failed > 0;
+      process.stdout.write(
+        `  ${bad ? "RED " : "green"}  ${suite}  ${scope.join(", ")}  ` +
+          `(${r.tests.length} tests, ${failed} failed` +
+          `${r.loadErrors.length ? `, ${r.loadErrors.length} load error(s)` : ""}` +
+          `${r.timedOut ? ", TIMED OUT" : ""})\n`,
+      );
+      if (bad) {
+        fail(
+          `baseline for \`${suite}\` (${scope.join(", ")}) is NOT green, so no ` +
+            `mutation run on it can be interpreted. Nothing was mutated.` +
+            (r.loadErrors.length
+              ? `\n  first load error: ${r.loadErrors[0]}`
+              : ""),
+          2,
+        );
+      }
+    }
+  }
+
+  // --- the run ------------------------------------------------------------
+  const rows: Row[] = [];
+  for (const mut of selected) {
+    if (interrupted) break;
+    const s = manifest.suites[mut.suite]!;
+    process.stdout.write(`\n▸ ${mut.id}  (expect ${mut.expect})\n`);
+    const started = Date.now();
+    let cls: Classification;
+    try {
+      mutator.apply(mut);
+      const run = await runVitest(
+        path.join(repoRoot, s.package),
+        s.vitestBin,
+        mut.scope,
+        mut.timeoutMs ?? s.timeoutMs,
+      );
+      cls = classify(mut, run, { allowFixed: opts.allowFixed });
+    } finally {
+      // Unconditional: an exception in apply(), a throw from vitest plumbing,
+      // or a normal completion all land here before the next mutant.
+      mutator.revert();
+    }
+    const ms = Date.now() - started;
+    process.stdout.write(`  ${GLYPH[cls.verdict].trim()} — ${cls.detail}\n`);
+    rows.push({ mutant: mut, cls, ms });
+  }
+
+  // Final belt-and-braces: the tree must be exactly as we found it.
+  const finalStatus = git(repoRoot, ["status", "--porcelain", "-uno"]);
+  if (finalStatus.out !== "") {
+    process.stderr.write(
+      `\nmutation-gate: TREE NOT CLEAN at exit — investigate:\n${finalStatus.out}\n`,
+    );
+    report(rows);
+    process.exit(1);
+  }
+  process.stdout.write(`\nmutation-gate: tree verified clean at exit.\n`);
+
+  report(rows);
+  process.exit(rows.some((r) => r.cls.fatal) ? 1 : 0);
+}
+
+await main();

--- a/showcase/scripts/package.json
+++ b/showcase/scripts/package.json
@@ -12,6 +12,7 @@
     "validate-manifests": "tsx generate-registry.ts --validate-only",
     "validate-routes": "tsx validate-runtime-routes.ts --all",
     "showcase:audit": "tsx audit.ts",
+    "mutation-gate": "tsx mutation-gate/mutation-gate.ts",
     "create-integration": "tsx create-integration/index.ts",
     "bundle-content": "tsx bundle-demo-content.ts",
     "bundle-angular-content": "tsx bundle-angular-source-content.ts",

--- a/showcase/scripts/tsconfig.json
+++ b/showcase/scripts/tsconfig.json
@@ -14,6 +14,11 @@
     "isolatedModules": true,
     "allowImportingTsExtensions": false
   },
-  "include": ["*.ts", "create-integration/**/*.ts", "lib/**/*.ts"],
+  "include": [
+    "*.ts",
+    "create-integration/**/*.ts",
+    "lib/**/*.ts",
+    "mutation-gate/**/*.ts"
+  ],
   "exclude": ["node_modules", "__tests__"]
 }


### PR DESCRIPTION
## Why

Across two 12-reviewer rounds on #6156, the single most effective technique was **mutation testing** — deliberately breaking the implementation to check whether the tests notice. It caught what inspection missed entirely: dropping the whole short page left all 3 autocancel tests green; lowering `MAX_INITIAL_FETCH_PAGES` from 20 to 10, and even to 5, left the bounds suite 6/6 green; `Math.max`→`min` and `every`→`any` left the golden master byte-identical.

**Three different agents wrote those mutations by hand, independently, and threw them away each time.** This commits them.

## What

`showcase/scripts/mutation-gate/mutants.json` — a declarative manifest, one entry per mutation: target file, exact find/replace, test scope, the tests that MUST fail, and the defect class it guards. Entries known to slip past their scope declare `expect: "survive"` with a mandatory `knownGap` (reason + what closes it), so the manifest is a **ledger of guard strength**, not a list of mutations someone already knew would fail.

`mutation-gate/mutation-gate.ts` — applies each mutation in isolation, runs the declared scope, asserts the declared tests fail, reverts, reports. Fails loudly when a mutation does **not** produce its expected failure, and equally when a declared gap has been closed (a stale ledger is the same disease one level up).

`__tests__/mutation-gate-manifest.test.ts` — the cheap half, riding the `showcase/scripts` vitest step that **already runs in `showcase_validate.yml`**: asserts the manifest is valid and every anchor still occurs exactly once at HEAD. That is the failure mode that would otherwise rot silently — a refactor that moves an anchor breaks no test, it just means the guard is no longer measured.

## Seeded set — 21 mutations, every outcome measured, not assumed

Harvested from `round-1-fix-{A5,FETCH,INV7,G1}`, `round-1-slot-6-a`, `round-1-integration`, `round-2-slot-{3-b,5-b,6-a,7-a}` and `convergence-audit` (lever 3).

Full run at `938be2accf`: **11 killed, 10 declared-toothless, 0 fatal, 100s wall, tree verified clean.**

| mutant | expect | verdict |
|---|---|---|
| bulk-merge/drop-short-page | kill | KILLED (3) |
| bulk-merge/no-boundary | kill | KILLED (1) |
| bulk-merge/reverse-page-order | kill | KILLED (2) |
| bulk-fetch/requestkey-autocancel | kill | KILLED (3) |
| page-cap/widened-to-100000 | kill | KILLED (2) |
| **page-cap/halved-to-10** | survive | **TOOTHLESS** |
| **page-cap/cut-to-5** | survive | **TOOTHLESS** |
| supplemental/failure-becomes-fatal | kill | KILLED (1) |
| supplemental/drop-signal-projection | kill | KILLED (3) |
| **fanout/serialized-dispatch** | survive | **TOOTHLESS** |
| polarity/pre-pr-gray-gate | kill | KILLED (11) |
| polarity/drop-redsignalknown-conjunct | survive | TOOTHLESS (by design) |
| polarity/redsignalknown-family-scope | kill | KILLED (4) |
| **goldenmaster/redsignalknown-family-scope** | survive | **TOOTHLESS** |
| **goldenmaster/failcount-min-not-max** | survive | **TOOTHLESS** |
| aggregation/failcount-min-not-max | kill | KILLED (2) |
| **aggregation/softclass-any-not-every** | survive | **TOOTHLESS** |
| **goldenmaster/starter-window-doubled** | survive | **TOOTHLESS** |
| **goldenmaster/commerror-decode-disabled** | survive | **TOOTHLESS** |
| inv7/contributingkeys-total-drift | kill | KILLED (5) |
| **inv7/contributingkeys-partial-drift** | survive | **TOOTHLESS** |

Two findings that sharpen the reports they came from:

- **`aggregation/softclass-any-not-every` is worse than slot 7a claimed.** 7a scoped the `every`→`any` gap to the 56 golden-master entries; measured across the *whole* cell-model directory (198 tests) it is still green. The gap is total, not golden-master-only.
- **Slot 6's `Promise.all` → sequential-`await` mutation is a no-op**, for the same reason it stayed green: the page promises are created eagerly at `wave.push(pb…getList(…))`, so awaiting them in sequence does not serialize dispatch. `INITIAL_FANOUT_BATCH = 1` does — and 24/24 still pass, so the "dispatched concurrently" claim really is unpinned.

## The ratchet — both sides of a fix, each measured on the fix branch

A manifest entry cannot target code that does not exist at its own HEAD, so a gap closed on an unmerged branch had nowhere to live. `ratchet` is a **second declared state** measured at a named commit; the runner checks the entry's state first and the ratchet second and reports which one the tree is in (`RATCHETED`). An outcome matching **neither** is still fatal, and both states name their failing tests exactly — so this tolerates someone else's merge without buying laxity.

I measured these by running the gate against the fix branches, not by taking their word:

- **Q1 `fix/6156-truncated-boundary` @ `67c2c8c5c4`** — `page-cap/halved-to-10` and `page-cap/cut-to-5` both go `survive → kill`. The bounds suite grows 6 → 7 tests and **3 of the 7 fail at cap 10, the same 3 at cap 5**, where all 6 passed before. (Note: 3 *tests*, not 10 — vitest aborts an `it` at its first failing `expect`, so a count of 10 is assertions, not tests.)
- **Q4 `fix/6156-fixture-coverage-polarity` @ `3c1177838f`** — `goldenmaster/redsignalknown-family-scope`, `goldenmaster/failcount-min-not-max` and `aggregation/softclass-any-not-every` each go `survive → kill`, each via **exactly one** new heterogeneous fixture (`hetero-d4-green-stripped-infra-red`, `hetero-d4-red-failcount-max`, `hetero-starter-mixed-soft-hard`). Golden master 57 → 62.
- Gate run against both branches: **0 fatal**.

`pendingSources` records what cannot be seeded yet:
- **Q2 `fix/6156-pb-evaluator-fidelity`** — still in flight, so nothing can be anchored against it. Seeds listed (single-quote tokenizing, the parse throw escaping the `node:http` handler, `applyPbSort` no-op, case-sensitive `like()`, `_` pattern anchoring, string-compared `fail_count`).
- **Q3 `fix/6156-inv7-gap-carveout` @ `49bf40943f`** — measured; it moves **none** of the 21 existing verdicts, and its carve-out does not exist at this manifest's `measuredAt`, so an entry for it would fail the anchor pre-flight. Two entries queued for when it lands, including one that pins `opts.ladderGapAllowance` as load-bearing rather than dead configuration.

## Safety — this tool edits tracked source, so all four are proven, not asserted

1. **Refuses a dirty tree** (tracked modifications; `-uno` so gitignored generated artifacts don't block). No `--force`. → exit 2, verified.
2. **Never `git stash`** (the stash stack is shared repo-wide across worktrees and holds other sessions' entries) and never commits.
3. **Verifies the repo before the first write.** Pointed at a repo whose origin is `jpr5/env`: *"REFUSING TO WRITE … origin resolves to `jpr5/env`, but the manifest expects `CopilotKit/CopilotKit`"* → exit 2, target file byte-untouched.
4. **Reverts on interrupt.** Killed mid-run with `SIGINT` while `useLiveStatus.ts` was mutated (`1 file changed, 2 deletions`): reverted synchronously, exit 130, `git status` empty, journal removed. `SIGKILL` cannot be handled, so the journal survives it — after a `-9` the mutation is stranded and the **next invocation self-heals**: *"a PREVIOUS RUN DIED with `bulk-fetch/requestkey-autocancel` applied (pid 42704) … restored; tree is clean"* → exit 2.

Backups and the journal live inside the worktree's own git dir, so they are invisible to `git status` and per-worktree.

## CI viability — and the dependency, stated plainly

**Fast enough for CI: 100s for all 21 mutants** (harness cell-model runs are ~0.9s each; the four jsdom dashboard runs dominate). Runtime is `N × suite time`, so it scales with the manifest.

**But it gates nothing until #6168 lands.** No CI job runs the showcase harness or dashboard unit suites at all — 3,646 harness tests and 1,331 dashboard tests run nowhere, excluded twice over (`paths-ignore: showcase/**` *and* `--projects='packages/**'`), and the harness is not typechecked either because `check-types` runs `nx run-many -t check-types` while the harness script is named `typecheck`. **#6168 is the prerequisite.** Until then the only part of this PR that executes in CI is the manifest-integrity test, which rides the `showcase/scripts` vitest step — worth having on its own, since it is what stops the manifest rotting, but it runs no mutations.

Recommendation once #6168 is in: a **periodic / label-triggered** job rather than per-PR. It is fast, but it is a whole-tree source-rewriting tool and per-PR is the wrong blast radius for it. The per-PR guard is the anchor test.

## Base

Targets `fix/cold-load-gray-masks-red` (#6156), not `main` — **verified, not preference**: `--check --repo <main>` reports that `cell-model.contribution.ts` and `cell-model.coherence.test.ts` are not tracked on `main` at all. The manifest measures guards that #6156 introduces, so it cannot resolve before #6156 lands.

## Verification

- prettier `--check`: clean. oxlint: 0 warnings, 0 errors on all 3 files. `tsc -p showcase/scripts/tsconfig.json`: 0 errors from `mutation-gate` (7 pre-existing errors in `equivalence-gate.ts` / `generate-search-index.ts` / `verify-prod-resweep.ts` / `angular-package.ts`, untouched). `mutation-gate/**` was added to the scripts tsconfig `include` so the new code is actually covered.
- Manifest-integrity test: 5/5 pass.
- Scoped every run away from `tests/runtime-env-switch.spike.test.ts` (confirmed: hangs ~25 min at 0.0% CPU, never spawns its `next build`); the dashboard suite entry documents this and the scope stays under `src/`.
- `showcase/scripts` full suite: 13 pre-existing failures in `__tests__/generate-registry-pattern.test.ts`. **Not mine** — a base worktree at `938be2accf` with matched symlinks/artifacts gives the identical `13 failed | 1 passed`.

## Unverified

- Never run in CI (see above) — timings are local, on a machine with other agents active.
- One dashboard run died at 161s without writing its JSON report under heavy load. That is why the runner **retries a non-measurement once** (never a real `SURVIVED`) and why the dashboard timeout is 10 min. Both FATALs in the first full run were this, and both cleared on re-run.
- `pendingSources` seeds for Q2/Q3 are written from their reports, not measured — by construction, since neither can be anchored yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYdjeveT8Xof9TyHWMLoJr
