### PR TITLE
fix(showcase/ci): make a partially-cancelled build loud, and verify what it actually shipped

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -556,17 +556,35 @@ jobs:
           SERVICE: ${{ matrix.service.dispatch_name }}
           BUILD_STATUS: ${{ job.status }}
         run: |
-          # job.status is one of: success, failure, cancelled. Normalize
-          # cancelled→skipped to match the BuildOutcome contract in
+          # job.status is one of: success, failure, cancelled — mapped
+          # 1:1 onto the BuildOutcome contract in
           # showcase/scripts/lib/build-outputs.ts. We deliberately do NOT
           # write to $GITHUB_OUTPUT — matrix-slot outputs are not
           # aggregable across slots in GitHub Actions, so we publish the
           # per-slot result as an artifact instead. The downstream
           # aggregator job downloads every `build-result-*` artifact.
+          #
+          # `cancelled` used to be laundered into `skipped` here. That one
+          # line is what made a partially-cancelled fleet build silent:
+          # this slot's result is the ONLY place the cancellation is
+          # recorded, because GitHub's own status functions cannot see it
+          # downstream. Proven on run 30166429073 (a purpose-built probe:
+          # matrix leg killed by `timeout-minutes` → job.status=cancelled,
+          # rollup `needs.*.result`=cancelled, yet BOTH `if: cancelled()`
+          # and `if: failure()` evaluated FALSE in dependent jobs). With
+          # `cancelled` collapsed to `skipped` it was indistinguishable
+          # from a slot that legitimately never built, so nothing could
+          # alert and nothing could red the run. Keep it distinct.
+          #
+          # The `*)` catch-all stays as a defensive fallback in case
+          # GitHub ever introduces a fourth job.status value; `skipped` is
+          # the conservative choice because it is excluded from both the
+          # redeploy success-set and the cancelled-slot alert.
           case "$BUILD_STATUS" in
-            success) STATUS=success ;;
-            failure) STATUS=failure ;;
-            *)       STATUS=skipped ;;
+            success)   STATUS=success ;;
+            failure)   STATUS=failure ;;
+            cancelled) STATUS=cancelled ;;
+            *)         STATUS=skipped ;;
           esac
           mkdir -p "$RUNNER_TEMP/build-result"
           printf '{"service":"%s","status":"%s"}\n' "$SERVICE" "$STATUS" \
@@ -808,6 +826,14 @@ jobs:
     outputs:
       results: ${{ steps.collect.outputs.results }}
       any_success: ${{ steps.collect.outputs.any_success }}
+      # `any_cancelled` / `cancelled_services` are the ONLY downstream
+      # signal that one or more build slots were cancelled (in practice:
+      # killed by `timeout-minutes`). They are derived from the per-slot
+      # artifacts, NOT from GitHub's status functions, because those
+      # cannot see a leg-level cancellation — see the comment on the
+      # `notify-cancelled-builds` job below for the measured proof.
+      any_cancelled: ${{ steps.collect.outputs.any_cancelled }}
+      cancelled_services: ${{ steps.collect.outputs.cancelled_services }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -846,8 +872,9 @@ jobs:
           # The aggregator script (showcase/scripts/aggregate-build-results.ts)
           # reads them, merges via the shared helper (mergeBuildResultFiles),
           # writes $OUTPUT_DIR/results.json, and appends `results` +
-          # `any_success` to $GITHUB_OUTPUT. The contract (service +
-          # status enum) is enforced in one place (build-outputs.ts).
+          # `any_success` + `any_cancelled` + `cancelled_services` to
+          # $GITHUB_OUTPUT. The contract (service + status enum) is
+          # enforced in one place (build-outputs.ts).
           npx tsx showcase/scripts/aggregate-build-results.ts
 
       - name: Upload aggregated build-results artifact
@@ -1229,6 +1256,94 @@ jobs:
           payload: |
             { "text": ${{ toJSON(format(':x: *Showcase: all builds failed*{4}staging unchanged (no redeploy){4}Commit: `{0}` by {1}{4}<https://github.com/{2}/actions/runs/{3}|View run>', github.sha, github.actor, github.repository, github.run_id, fromJSON('"\n"'))) }} }
 
+  notify-cancelled-builds:
+    name: Notify cancelled/timed-out build slots
+    needs: [detect-changes, build, aggregate-build-results]
+    # ── Why this job exists ───────────────────────────────────────────────
+    #
+    # A PARTIALLY-CANCELLED fleet build used to be indistinguishable from a
+    # clean one, in BOTH directions: no alert, and no post-deploy verify.
+    # Observed on build run 30162773601 (merge of #6160): 5 of 28 slots were
+    # killed by `timeout-minutes`, 23 built and were redeployed to staging,
+    # `redeploy-staging` SUCCEEDED and uploaded `redeploy-summary` — and
+    # then:
+    #   - `notify` was SKIPPED, so no Slack alert fired, and
+    #   - the run rolled up to conclusion `cancelled`, which failed
+    #     showcase_deploy.yml's `conclusion == 'success'` gate, so the
+    #     staging redeploy was never verified.
+    # A real, partial, unverified staging deploy looked exactly like a
+    # silent success.
+    #
+    # The reason no existing guard caught it is that GitHub's status
+    # functions are blind to a leg-level cancellation. Measured on purpose-
+    # built probe run 30166429073 (matrix leg killed by `timeout-minutes`,
+    # sibling leg green):
+    #   job.status of the killed leg .... cancelled
+    #   needs.<matrix>.result (rollup) .. cancelled
+    #   `if: cancelled()` ............... SKIPPED  (i.e. evaluated FALSE)
+    #   `if: failure()` ................. SKIPPED  (i.e. evaluated FALSE)
+    #   pre-fix `notify` condition ...... SKIPPED  ← the bug
+    #   post-fix `notify` condition ..... RAN      ← the fix
+    #   workflow run conclusion ......... cancelled
+    # This matches the docs: `cancelled()` "returns true if the workflow was
+    # canceled" (workflow-scoped, not job-scoped), and `failure()` "returns
+    # true if any ancestor job fails" — a CANCELLED ancestor did not FAIL.
+    # So `failure() || cancelled()` would NOT have fixed this; the signal
+    # has to come from the per-slot build results.
+    #
+    # This job does the two things a cancelled slot must do:
+    #   1. RED THE RUN (step 1 exits 1) so the conclusion becomes `failure`
+    #      instead of `cancelled`. That is honest — a slot killed by its
+    #      timeout budget is a failure, not a cancellation — and it makes
+    #      the incomplete build visible on the commit status. It does NOT
+    #      block verification: showcase_deploy.yml no longer requires
+    #      `conclusion == 'success'` (it self-gates on the presence of the
+    #      redeploy-summary artifact instead), so the subset that really
+    #      shipped still gets probed.
+    #   2. ALERT, naming the affected services so the run can be re-run
+    #      with "Re-run failed jobs" without re-reading 28 job logs.
+    #
+    # `!cancelled()` is retained as the intentional-vs-flake discriminator:
+    # a human cancelling the whole RUN makes `cancelled()` TRUE and keeps
+    # this silent, while a leg-level timeout leaves it FALSE (proven above)
+    # so the alert still fires. Belt and braces: on a run-level cancel
+    # `aggregate-build-results` is itself skipped by its own `!cancelled()`
+    # guard, so `any_cancelled` would be '' rather than 'true' anyway.
+    if: >-
+      ${{ !cancelled()
+          && needs.detect-changes.outputs.has_changes == 'true'
+          && needs.aggregate-build-results.outputs.any_cancelled == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+    env:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+    steps:
+      - name: Mark workflow red (build incomplete)
+        env:
+          CANCELLED_SERVICES: ${{ needs.aggregate-build-results.outputs.cancelled_services }}
+        run: |
+          echo "::error::Build INCOMPLETE — these slots were cancelled (typically killed by timeout-minutes) and pushed NO image: ${CANCELLED_SERVICES}"
+          echo "Those services were correctly excluded from the staging redeploy (matrix ∩ build-success), so staging still serves their previous :latest."
+          echo "Re-run the failed jobs on this run to finish the fleet."
+          exit 1
+      - name: Slack #oss-alerts
+        # `always()` so the alert still goes out after step 1 deliberately
+        # exits non-zero to red the run.
+        if: always() && env.SLACK_WEBHOOK != ''
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          # NOTE: `\n` is NOT an escape sequence in GitHub Actions expression
+          # string literals — `format()` would emit the two literal characters
+          # backslash+n, which `toJSON` then encodes as `\\n`, so Slack renders
+          # a literal "\n". Inject real newlines via `fromJSON('"\n"')` ({5}) so
+          # `toJSON` encodes them as a single `\n` that Slack honors.
+          payload: |
+            { "text": ${{ toJSON(format(':warning: *Showcase build INCOMPLETE — slots cancelled*{5}Cancelled (no image pushed): `{4}`{5}Staging keeps the previous :latest for those services.{5}Commit: `{0}` by {1}{5}<https://github.com/{2}/actions/runs/{3}|View run>', github.sha, github.actor, github.repository, github.run_id, needs.aggregate-build-results.outputs.cancelled_services, fromJSON('"\n"'))) }} }
+
   notify:
     name: Notify on failure
     # Cover the whole detect→build→aggregate→redeploy pipeline. `needs: [build]`
@@ -1275,10 +1390,25 @@ jobs:
         redeploy-staging,
         redeploy-staging-starters,
       ]
+    #
+    # The third clause, `any_cancelled == 'true'`, closes the partial-cancel
+    # hole: with SOME slots green, `failure()` is false (a cancelled ancestor
+    # did not fail) and `any_success` is 'true', so the first two clauses both
+    # go false and this job was SKIPPED on a genuinely incomplete build — see
+    # `notify-cancelled-builds` above for the measured proof (probe run
+    # 30166429073) and the production incident (run 30162773601). This clause
+    # also restores the PR comment on that path, which is the only place the
+    # merge author gets told. It cannot add noise to a clean run: a build with
+    # no cancelled slot emits `any_cancelled=false`, and a build with no
+    # changes skips the aggregator entirely so the output is '' — neither
+    # equals 'true'. `notify-cancelled-builds` fires alongside this job on
+    # that path; two alerts for one event is the same convention already used
+    # by `notify-all-builds-failed` + this job, and matches the alert SOP.
     if: >-
       ${{ !cancelled()
           && (failure()
-              || needs.aggregate-build-results.outputs.any_success == 'false') }}
+              || needs.aggregate-build-results.outputs.any_success == 'false'
+              || needs.aggregate-build-results.outputs.any_cancelled == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -1302,6 +1432,11 @@ jobs:
             { "text": ${{ toJSON(format(':x: *Showcase Build Failed*{4}Commit: `{0}` by {1}{4}<https://github.com/{2}/actions/runs/{3}|View run>', github.sha, github.actor, github.repository, github.run_id, fromJSON('"\n"'))) }} }
 
       - name: Comment on PR
+        env:
+          # Non-empty only on the partial-cancel path, where the generic
+          # "the build failed" wording would be wrong (most slots built and
+          # were redeployed; a subset was killed mid-build).
+          CANCELLED_SERVICES: ${{ needs.aggregate-build-results.outputs.cancelled_services }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
@@ -1315,12 +1450,27 @@ jobs:
               console.log('No merged PR found for this commit — skipping comment');
               return;
             }
+            const cancelled = (process.env.CANCELLED_SERVICES || '')
+              .split(',')
+              .map(s => s.trim())
+              .filter(Boolean);
             const marker = '<!-- showcase-build-failure -->';
             const body = [
               marker,
-              `### :x: Showcase Build Failed`,
+              cancelled.length > 0
+                ? `### :warning: Showcase Build Incomplete`
+                : `### :x: Showcase Build Failed`,
               ``,
-              `The Docker build triggered by this PR's merge failed.`,
+              cancelled.length > 0
+                ? [
+                    `The Docker build triggered by this PR's merge did not finish for every service.`,
+                    `These slots were cancelled (typically killed by \`timeout-minutes\`) and pushed **no** image, so staging still serves their previous \`:latest\`:`,
+                    ``,
+                    cancelled.map(s => `- \`${s}\``).join('\n'),
+                    ``,
+                    `Everything else built and was redeployed. Use **Re-run failed jobs** on the run to finish the fleet.`,
+                  ].join('\n')
+                : `The Docker build triggered by this PR's merge failed.`,
               ``,
               `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               `**Commit:** \`${context.sha.slice(0, 8)}\``,

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -235,8 +235,38 @@ jobs:
           # reference. The actual verify probe is driven by per-service
           # drivers in verify-deploy.ts (showcase/scripts/verify-deploy.ts),
           # NOT by this field — it is informational only at this layer.
+          #
+          # timeout: the per-slot `timeout-minutes` budget. It is a BACKSTOP
+          # against a hung build, not a schedule — GitHub kills the job when
+          # it is exceeded and reports the kill as conclusion `cancelled`
+          # (Depot surfaces it as "Step canceled by GitHub"), which is a
+          # cancelled slot that pushed no image.
+          #
+          # The `context: "."` shell slots build the whole monorepo root and
+          # are the HEAVIEST builds in the fleet, yet they used to carry the
+          # SMALLEST budgets (10 min, vs 15 for each small per-integration
+          # build) — inverted, with no headroom for a cold Depot cache. When
+          # three full-fleet rebuilds ran concurrently on 2026-07-25 (~84
+          # simultaneous amd64 Depot builds), the shell builds were making
+          # real but slow progress — repeated docker.io base-image pull
+          # stalls, and the final `generate-registry` layer alone took 54s —
+          # and were still 2 steps from done when the 10-minute budget killed
+          # them. Measured evidence, same slots:
+          #   warm/uncontended ......... 2–5 min
+          #   contended, killed at ..... 10 min (runs 30162773601, 30162770765)
+          #   showcase-pocketbase ...... 8.8 min of a 10 min budget (near-miss)
+          # So the four shell slots get 20, showcase-aimock (killed at its 5
+          # min budget) gets 12, and showcase-pocketbase gets 15. `webhooks`
+          # stays at 5: it is `skip_build`, and measured at 0.6 min.
+          #
+          # NOTE this is mitigation, not the root fix. The root cause is
+          # Depot builder contention from concurrent full-fleet rebuilds; the
+          # durable fix is to not run three of them at once (this workflow
+          # deliberately has NO concurrency group — see the header — so a
+          # non-cancelling `concurrency` queue would be the lever, at the
+          # cost of serializing main builds). Left as a follow-up.
           ALL_SERVICES='[
-            {"dispatch_name":"shell","filter_key":"shell","context":".","image":"showcase-shell","railway_id":"40eea0da-6071-4ea8-bdb9-39afb19225ec","timeout":10,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","dockerfile":"showcase/shell/Dockerfile","health_path":"/"},
+            {"dispatch_name":"shell","filter_key":"shell","context":".","image":"showcase-shell","railway_id":"40eea0da-6071-4ea8-bdb9-39afb19225ec","timeout":20,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","dockerfile":"showcase/shell/Dockerfile","health_path":"/"},
             {"dispatch_name":"langgraph-python","filter_key":"langgraph_python","context":"showcase/integrations/langgraph-python","image":"showcase-langgraph-python","railway_id":"90d03214-4569-41b0-b4c1-6438a8a7b203","timeout":15,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"mastra","filter_key":"mastra","context":"showcase/integrations/mastra","image":"showcase-mastra","railway_id":"d7979eb7-2405-4aab-ad21-438f4a1b08af","timeout":15,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"crewai-crews","filter_key":"crewai_crews","context":"showcase/integrations/crewai-crews","image":"showcase-crewai-crews","railway_id":"0e9c284d-8d87-4fcf-9f82-6b704d7e4bd4","timeout":15,"build_args":"","dockerfile":"","health_path":"/api/health"},
@@ -257,12 +287,12 @@ jobs:
             {"dispatch_name":"ms-agent-harness-dotnet","filter_key":"ms_agent_harness_dotnet","context":"showcase/integrations/ms-agent-harness-dotnet","image":"showcase-ms-agent-harness-dotnet","railway_id":"6343d7f9-6c3f-4c8d-9a6e-79f03d2f1e37","timeout":15,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"claude-sdk-python","filter_key":"claude_sdk_python","context":"showcase/integrations/claude-sdk-python","image":"showcase-claude-sdk-python","railway_id":"b122ab65-9854-4cb2-a68e-b50ff13f7481","timeout":15,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"built-in-agent","filter_key":"built_in_agent","context":"showcase/integrations/built-in-agent","image":"showcase-built-in-agent","railway_id":"f4f8371a-bc46-45b2-b6d4-9c9af608bdbf","timeout":15,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"shell-dojo","filter_key":"shell_dojo","context":".","image":"showcase-shell-dojo","railway_id":"7ad1ece7-2228-49cd-8a78-bddf30322907","timeout":10,"build_args":"","dockerfile":"showcase/shell-dojo/Dockerfile","health_path":"/"},
-            {"dispatch_name":"shell-dashboard","filter_key":"shell_dashboard","context":".","image":"showcase-shell-dashboard","railway_id":"4d5dfd74-be61-40b2-8564-b53b7dd4c15b","timeout":10,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","dockerfile":"showcase/shell-dashboard/Dockerfile","health_path":"/"},
-            {"dispatch_name":"shell-docs","filter_key":"shell_docs","context":".","image":"showcase-shell-docs","railway_id":"7badfb8d-4228-414c-9145-b4026803714f","timeout":10,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","dockerfile":"showcase/shell-docs/Dockerfile","health_path":"/"},
+            {"dispatch_name":"shell-dojo","filter_key":"shell_dojo","context":".","image":"showcase-shell-dojo","railway_id":"7ad1ece7-2228-49cd-8a78-bddf30322907","timeout":20,"build_args":"","dockerfile":"showcase/shell-dojo/Dockerfile","health_path":"/"},
+            {"dispatch_name":"shell-dashboard","filter_key":"shell_dashboard","context":".","image":"showcase-shell-dashboard","railway_id":"4d5dfd74-be61-40b2-8564-b53b7dd4c15b","timeout":20,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","dockerfile":"showcase/shell-dashboard/Dockerfile","health_path":"/"},
+            {"dispatch_name":"shell-docs","filter_key":"shell_docs","context":".","image":"showcase-shell-docs","railway_id":"7badfb8d-4228-414c-9145-b4026803714f","timeout":20,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","dockerfile":"showcase/shell-docs/Dockerfile","health_path":"/"},
             {"dispatch_name":"showcase-harness","filter_key":"showcase_harness","context":".","image":"showcase-harness","railway_id":"3a14bfed-0537-4d71-897b-7c593dca161d","timeout":20,"build_args":"","dockerfile":"showcase/harness/Dockerfile","health_path":"/health"},
-            {"dispatch_name":"showcase-aimock","filter_key":"showcase_aimock","context":"showcase/aimock","image":"showcase-aimock","railway_id":"0fa0435d-8a66-46f0-84fd-e4250b580013","timeout":5,"build_args":"","dockerfile":"showcase/aimock/Dockerfile","health_path":"/health"},
-            {"dispatch_name":"showcase-pocketbase","filter_key":"pocketbase","context":"showcase/pocketbase","image":"showcase-pocketbase","railway_id":"ba11e854-d695-4738-9a45-2b0776788824","timeout":10,"build_args":"","dockerfile":"showcase/pocketbase/Dockerfile","health_path":"/api/health"},
+            {"dispatch_name":"showcase-aimock","filter_key":"showcase_aimock","context":"showcase/aimock","image":"showcase-aimock","railway_id":"0fa0435d-8a66-46f0-84fd-e4250b580013","timeout":12,"build_args":"","dockerfile":"showcase/aimock/Dockerfile","health_path":"/health"},
+            {"dispatch_name":"showcase-pocketbase","filter_key":"pocketbase","context":"showcase/pocketbase","image":"showcase-pocketbase","railway_id":"ba11e854-d695-4738-9a45-2b0776788824","timeout":15,"build_args":"","dockerfile":"showcase/pocketbase/Dockerfile","health_path":"/api/health"},
             {"dispatch_name":"webhooks","filter_key":"webhooks","context":".","image":"showcase-eval-webhook","railway_id":"ba6acc13-7585-41fe-a5ee-585b34a58fcd","timeout":5,"build_args":"","dockerfile":"","health_path":"/health","skip_build":true}
           ]'
 

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -1,10 +1,16 @@
 name: "Showcase: Verify Deploy"
 
-# Triggered after "Showcase: Build & Push" completes. Verifies that the
-# STAGING redeploy from the build workflow actually produced healthy
-# services. Push-to-main redeploys staging only. This workflow is the
-# staging gate; verify-deploy.ts is the parameterized probe driven off
-# showcase/scripts/railway-envs.ts (the SSOT).
+# Triggered after "Showcase: Build & Push" reaches a terminal conclusion.
+# Verifies that the STAGING redeploy from the build workflow actually
+# produced healthy services. Push-to-main redeploys staging only. This
+# workflow is the staging gate; verify-deploy.ts is the parameterized probe
+# driven off showcase/scripts/railway-envs.ts (the SSOT).
+#
+# Deliberately NOT gated on the build concluding `success`: a build with
+# some slots cancelled or failed still redeploys the slots that DID build,
+# and that partial deploy needs verifying just as much as a clean one.
+# What to verify is decided from the redeploy-summary artifact, not from
+# the build's rollup conclusion. See the `resolve-matrix` job's `if:`.
 
 on:
   workflow_run:
@@ -20,7 +26,22 @@ on:
         type: string
 
 concurrency:
-  group: showcase-verify-deploy
+  # Keyed PER TRIGGERING COMMIT, not globally. A global group meant any
+  # later-finishing build run preempted an earlier run's verification even
+  # though they verify DIFFERENT commits. Observed 2026-07-25: build #6168
+  # (7282ecddf) succeeded, its verify run 30163309977 started at 15:17:13 —
+  # and was cancelled 9 seconds later at 15:17:22 by run 30163312882, which
+  # was triggered by a DIFFERENT (partially-cancelled) build and then
+  # skipped every job anyway. The only legitimate verification of the day
+  # was destroyed by a run that did nothing.
+  #
+  # `github.event.workflow_run.head_sha` is the commit the upstream build
+  # built; it is null for `workflow_dispatch`, where `github.sha` (the ref
+  # the dispatch was made against) is the right key. Two dispatches against
+  # the same sha still supersede each other, which is intended — that is a
+  # genuine re-verification of the same commit, and it is strictly narrower
+  # than the previous global behaviour.
+  group: showcase-verify-deploy-${{ github.event.workflow_run.head_sha || github.sha }}
   cancel-in-progress: true
 
 permissions:
@@ -33,9 +54,42 @@ jobs:
     permissions:
       contents: read
       actions: read
+    # Previously `conclusion == 'success'`. That gate silently threw away
+    # verification for every build that redeployed a PARTIAL fleet: a build
+    # with some slots cancelled rolls up to conclusion `cancelled`, and one
+    # with some slots failed rolls up to `failure`, yet BOTH still run
+    # `redeploy-staging` (it gates on the artifact-derived `any_success`, not
+    # on the matrix rollup) and BOTH really do push new images to staging.
+    # Observed on build run 30162773601: 23 services redeployed to staging,
+    # run concluded `cancelled`, this workflow never started, zero
+    # verification. An unverified real deploy is strictly worse than a
+    # verified partial one.
+    #
+    # So the trigger is now "the build reached a terminal state", and the
+    # question of WHAT to verify is answered downstream by evidence rather
+    # than by the rollup:
+    #   - `check-redeploy-summary` asks whether the build uploaded a
+    #     `redeploy-summary` artifact at all. No artifact → nothing was
+    #     redeployed → `has_services=false` → verify + notify-harness are
+    #     skipped. So a build that died before redeploying still costs one
+    #     no-op run, exactly as it did before.
+    #   - `redeploy-gate` then narrows to the per-service SUCCESS set. A slot
+    #     that was cancelled or failed never entered the redeploy CSV (the
+    #     `matrix ∩ build-success` intersection in showcase_build.yml), so it
+    #     cannot be probed against a stale `:latest` and reported healthy.
+    # The incompleteness itself is not this workflow's job to report — the
+    # build workflow reds its own run and alerts (`notify-cancelled-builds`).
+    # This workflow's job is to verify what actually shipped.
+    #
+    # Explicit allowlist rather than `!= 'skipped'`: `success`/`failure`/
+    # `cancelled`/`timed_out` are the terminal conclusions a build run can
+    # reach after doing real work. `skipped`, `neutral`, `stale` and
+    # `action_required` mean the build never ran, so there is nothing to
+    # verify and we do not want to burn a run.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      contains(fromJSON('["success","failure","cancelled","timed_out"]'),
+               github.event.workflow_run.conclusion)
     outputs:
       services_csv: ${{ steps.matrix.outputs.services_csv }}
       has_services: ${{ steps.matrix.outputs.has_services }}
@@ -60,8 +114,13 @@ jobs:
         # — e.g. a push touching `showcase/**` that fires the build's
         # `paths:` filter, but `detect-changes` finds no buildable service
         # changed, so `redeploy-staging` is skipped and never uploads.
-        # The build still concludes `success`, so this workflow fires on
-        # `workflow_run` and `resolve-matrix` runs. Without this pre-check
+        # The build still reaches a terminal conclusion, so this workflow
+        # fires on `workflow_run` and `resolve-matrix` runs. Now that the
+        # job-level conclusion gate above accepts `failure`/`cancelled`/
+        # `timed_out` as well as `success`, this pre-check is ALSO the
+        # primary "did the build actually ship anything?" gate: a build that
+        # died before redeploying uploads no summary, so the gate no-ops and
+        # verify is skipped. Without this pre-check
         # the unguarded download would fail the job and (via
         # `enforce-redeploy-gate` tripping on `result == 'failure'`) flip
         # the whole deploy workflow RED — a false-red on a routine

--- a/showcase/scripts/__tests__/aggregate-build-results.test.ts
+++ b/showcase/scripts/__tests__/aggregate-build-results.test.ts
@@ -10,6 +10,10 @@
  *   3. non-`build-result-*` dirs are ignored
  *   4. mixed success/failure → correct merged array + any_success=true
  *   5. GITHUB_OUTPUT receives heredoc-form `results` block + any_success
+ *   6. a CANCELLED slot (a slot killed by `timeout-minutes`) survives into
+ *      results.json as `cancelled` and drives the `any_cancelled` /
+ *      `cancelled_services` outputs — the only signal that distinguishes a
+ *      partially-cancelled fleet build from a clean one
  */
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -20,7 +24,7 @@ import { run } from "../aggregate-build-results";
 function makeSlot(
   inputDir: string,
   service: string,
-  status: "success" | "failure" | "skipped",
+  status: "success" | "failure" | "cancelled" | "skipped",
 ): void {
   const dir = join(inputDir, `build-result-${service}`);
   mkdirSync(dir, { recursive: true });
@@ -128,6 +132,70 @@ describe("aggregate-build-results.run", () => {
 
     const gh = readFileSync(githubOutput, "utf-8");
     expect(gh).toContain("any_success=true");
+  });
+
+  // ── any_cancelled / cancelled_services ────────────────────────────────
+  //
+  // These two outputs are the ONLY machine-readable signal that a fleet
+  // build was partially cancelled. GitHub's `cancelled()` status function
+  // is documented as "returns true if the workflow was canceled" — it is
+  // workflow-scoped, and empirically returns FALSE when only individual
+  // matrix legs are killed (see build run 30162773601, where both
+  // `!cancelled()`-guarded jobs ran alongside 5 cancelled legs). And a
+  // cancelled leg is not a FAILED ancestor, so `failure()` is false too.
+  // With some legs succeeding, `any_success` is 'true'. That leaves the
+  // pre-fix notify guard with nothing to trip on — hence an explicit
+  // per-slot-derived signal.
+  it("sets any_cancelled=true and lists cancelled services on a partial cancel", () => {
+    makeSlot(inputDir, "mastra", "success");
+    makeSlot(inputDir, "shell", "cancelled");
+    makeSlot(inputDir, "shell-docs", "cancelled");
+
+    run({ inputDir, outputDir, githubOutput });
+
+    const gh = readFileSync(githubOutput, "utf-8");
+    // Some slots DID build, so the redeploy still fires — this is exactly
+    // the case that shipped silently.
+    expect(gh).toContain("any_success=true");
+    expect(gh).toContain("any_cancelled=true");
+    expect(gh).toMatch(/^cancelled_services=shell,shell-docs$/m);
+  });
+
+  it("sets any_cancelled=false with an empty service list on a clean build", () => {
+    makeSlot(inputDir, "alpha", "success");
+    makeSlot(inputDir, "beta", "failure");
+    makeSlot(inputDir, "gamma", "skipped");
+
+    run({ inputDir, outputDir, githubOutput });
+
+    const gh = readFileSync(githubOutput, "utf-8");
+    expect(gh).toContain("any_cancelled=false");
+    expect(gh).toMatch(/^cancelled_services=$/m);
+  });
+
+  it("sets any_cancelled=true and any_success=false when every slot was cancelled", () => {
+    makeSlot(inputDir, "shell", "cancelled");
+    makeSlot(inputDir, "shell-docs", "cancelled");
+
+    run({ inputDir, outputDir, githubOutput });
+
+    const gh = readFileSync(githubOutput, "utf-8");
+    expect(gh).toContain("any_success=false");
+    expect(gh).toContain("any_cancelled=true");
+  });
+
+  it("preserves 'cancelled' verbatim in the published results.json", () => {
+    makeSlot(inputDir, "shell", "cancelled");
+    makeSlot(inputDir, "mastra", "success");
+
+    run({ inputDir, outputDir, githubOutput });
+
+    const results = JSON.parse(
+      readFileSync(join(outputDir, "results.json"), "utf-8"),
+    ) as Array<{ service: string; status: string }>;
+    expect(results.find((r) => r.service === "shell")?.status).toBe(
+      "cancelled",
+    );
   });
 
   it("writes results to GITHUB_OUTPUT in multi-line heredoc form", () => {

--- a/showcase/scripts/aggregate-build-results.ts
+++ b/showcase/scripts/aggregate-build-results.ts
@@ -9,9 +9,10 @@
  *   2. Merge via mergeBuildResultFiles (single source of contract truth).
  *   3. Write the canonical $OUTPUT_DIR/results.json (uploaded as the
  *      `build-results` artifact for cross-workflow consumption).
- *   4. Append `results=...` and `any_success=true|false` to $GITHUB_OUTPUT
- *      so the redeploy-staging guard and the deploy workflow can read
- *      them as job-level outputs.
+ *   4. Append `results=...`, `any_success=true|false`,
+ *      `any_cancelled=true|false` and `cancelled_services=<csv>` to
+ *      $GITHUB_OUTPUT so the redeploy-staging guard, the incomplete-build
+ *      gate and the notify job can read them as job-level outputs.
  *
  * No GitHub API calls. No job-name parsing. Pure filesystem aggregation.
  *
@@ -30,7 +31,11 @@ import {
 import { randomBytes } from "node:crypto";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { mergeBuildResultFiles, successSet } from "./lib/build-outputs";
+import {
+  cancelledSet,
+  mergeBuildResultFiles,
+  successSet,
+} from "./lib/build-outputs";
 
 function requireEnv(name: string): string {
   const v = process.env[name];
@@ -79,8 +84,16 @@ function readSlotPayload(inputDir: string, slotDirName: string): string {
  * any value that might contain (or grow to contain) a newline — most
  * importantly, it survives pretty-printed JSON or other multi-line
  * payloads without truncation. A random delimiter token prevents
- * collision with embedded payloads. `any_success` stays a plain
- * key=value line since the value is a fixed boolean literal.
+ * collision with embedded payloads. `any_success` and `any_cancelled`
+ * stay plain key=value lines since the values are fixed boolean
+ * literals.
+ *
+ * `cancelled_services` is a plain CSV line. Service names are
+ * dispatch_names (validated non-blank, no commas or newlines by
+ * construction in the build matrix), so the plain form is safe and
+ * matches the CSV convention already used for the redeploy service
+ * list. It is emitted even when empty so a consumer reading it never
+ * sees an undefined output.
  *
  * Written BEFORE results.json so a $GITHUB_OUTPUT write failure
  * (e.g. the file is missing / not writable) aborts before we publish
@@ -91,6 +104,7 @@ function writeGithubOutput(
   githubOutput: string,
   resultsJson: string,
   anySuccess: boolean,
+  cancelledServices: readonly string[],
 ): void {
   const delimiter = `EOF_${randomBytes(8).toString("hex")}`;
   appendFileSync(
@@ -100,6 +114,14 @@ function writeGithubOutput(
   appendFileSync(
     githubOutput,
     `any_success=${anySuccess ? "true" : "false"}\n`,
+  );
+  appendFileSync(
+    githubOutput,
+    `any_cancelled=${cancelledServices.length > 0 ? "true" : "false"}\n`,
+  );
+  appendFileSync(
+    githubOutput,
+    `cancelled_services=${cancelledServices.join(",")}\n`,
   );
 }
 
@@ -137,10 +159,11 @@ export function run(opts: RunOptions): void {
   const merged = mergeBuildResultFiles(payloads);
   const resultsJson = JSON.stringify(merged);
   const anySuccess = successSet(merged).length > 0;
+  const cancelled = cancelledSet(merged);
 
   // Emit $GITHUB_OUTPUT first so a write failure here doesn't leave a
   // published results.json artifact without a matching job output.
-  writeGithubOutput(githubOutput, resultsJson, anySuccess);
+  writeGithubOutput(githubOutput, resultsJson, anySuccess, cancelled);
 
   // Trailing newline for consistency with conventional JSON-on-disk
   // tooling (POSIX line, diff-friendly).

--- a/showcase/scripts/lib/__tests__/build-outputs.test.ts
+++ b/showcase/scripts/lib/__tests__/build-outputs.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildResultArtifactName,
+  cancelledSet,
   mergeBuildResultFiles,
   parseBuildOutputs,
   shouldRedeployStaging,
@@ -68,9 +69,77 @@ describe("build-outputs", () => {
     expect(successSet(allFailed)).toEqual([]);
   });
 
-  it("type BuildOutcome enumerates success|failure|skipped", () => {
-    const outcomes: BuildOutcome[] = ["success", "failure", "skipped"];
-    expect(outcomes).toHaveLength(3);
+  it("type BuildOutcome enumerates success|failure|cancelled|skipped", () => {
+    const outcomes: BuildOutcome[] = [
+      "success",
+      "failure",
+      "cancelled",
+      "skipped",
+    ];
+    expect(outcomes).toHaveLength(4);
+  });
+
+  // ── cancelled is a FIRST-CLASS outcome ────────────────────────────────
+  //
+  // Regression guard for the silent-partial-cancel hole (build run
+  // 30162773601): the build job used to normalize `job.status ==
+  // 'cancelled'` down to `skipped` before writing its per-slot result,
+  // which made a slot killed by `timeout-minutes` indistinguishable from
+  // a slot that was legitimately never built. With the distinction
+  // erased, no downstream signal could tell a partially-cancelled fleet
+  // build apart from a clean one, so no alert fired and staging shipped
+  // unverified. `cancelled` must survive parse/merge as itself.
+  it("accepts status 'cancelled' as a valid outcome", () => {
+    const json = JSON.stringify([{ service: "shell", status: "cancelled" }]);
+    expect(parseBuildOutputs(json)).toEqual([
+      { service: "shell", status: "cancelled" },
+    ]);
+  });
+
+  it("mergeBuildResultFiles preserves a 'cancelled' slot payload", () => {
+    const merged = mergeBuildResultFiles([
+      JSON.stringify({ service: "shell", status: "cancelled" }),
+      JSON.stringify({ service: "mastra", status: "success" }),
+    ]);
+    expect(merged).toEqual([
+      { service: "shell", status: "cancelled" },
+      { service: "mastra", status: "success" },
+    ]);
+  });
+
+  it("cancelledSet returns only services with status === 'cancelled'", () => {
+    const mixed: ServiceBuildResult[] = [
+      { service: "shell", status: "cancelled" },
+      { service: "shell-docs", status: "cancelled" },
+      { service: "mastra", status: "success" },
+      { service: "ag2", status: "failure" },
+      { service: "never-ran", status: "skipped" },
+    ];
+    expect(cancelledSet(mixed)).toEqual(["shell", "shell-docs"]);
+  });
+
+  it("cancelledSet returns empty on a clean build", () => {
+    expect(cancelledSet(sample)).toEqual([]);
+  });
+
+  // A cancelled slot pushed NO image, so it must never enter the redeploy
+  // success-set — otherwise Railway re-pulls its stale `:latest` and
+  // verify reports a fresh healthy deploy for an image that never built.
+  it("successSet excludes cancelled services", () => {
+    const mixed: ServiceBuildResult[] = [
+      { service: "shell", status: "cancelled" },
+      { service: "mastra", status: "success" },
+    ];
+    expect(successSet(mixed)).toEqual(["mastra"]);
+  });
+
+  it("shouldRedeployStaging is false when every slot was cancelled", () => {
+    expect(
+      shouldRedeployStaging([
+        { service: "shell", status: "cancelled" },
+        { service: "shell-docs", status: "cancelled" },
+      ]),
+    ).toBe(false);
   });
 });
 

--- a/showcase/scripts/lib/build-outputs.ts
+++ b/showcase/scripts/lib/build-outputs.ts
@@ -3,7 +3,7 @@
  * emitted by `showcase_build.yml`. Each matrix slot in the build job
  * uploads a per-slot artifact named `build-result-<dispatch_name>`
  * containing a single `result.json` payload of the shape
- * `{service: "<dispatch_name>", status: "success"|"failure"|"skipped"}`.
+ * `{service: "<dispatch_name>", status: "success"|"failure"|"cancelled"|"skipped"}`.
  * The aggregate-build-results job downloads every `build-result-*`
  * artifact and merges the payloads via `mergeBuildResultFiles` below;
  * the resulting array is uploaded as the canonical `build-results`
@@ -23,7 +23,23 @@
 // Since `BuildOutcome` is derived from this tuple there is no separate
 // union that could drift out of sync — no redundant exhaustiveness
 // assertion is needed.
-const BUILD_OUTCOMES = ["success", "failure", "skipped"] as const;
+//
+// `cancelled` is DISTINCT from `skipped` on purpose. `job.status` for a
+// matrix slot is one of success|failure|cancelled, and the build job used
+// to normalize cancelled→skipped before writing its per-slot result.
+// That laundering is what made build run 30162773601 ship silently: five
+// slots were killed by `timeout-minutes` (GitHub reports a timeout kill
+// as conclusion `cancelled`), the rest built and were redeployed to
+// staging, and nothing downstream could tell that from a clean build.
+// GitHub's own status functions cannot recover the distinction either —
+// `cancelled()` is documented as "returns true if the workflow was
+// canceled" (workflow-scoped; empirically FALSE for leg-only cancels)
+// and a cancelled ancestor is not a FAILED ancestor so `failure()` is
+// false too. So the per-slot status is the ONLY place the signal exists,
+// and it must not be thrown away here. `skipped` is retained in the
+// union for forward/backward compatibility with any `build-results`
+// artifact written before this change.
+const BUILD_OUTCOMES = ["success", "failure", "cancelled", "skipped"] as const;
 
 export type BuildOutcome = (typeof BUILD_OUTCOMES)[number];
 
@@ -74,7 +90,7 @@ function validateServiceBuildResult(
     !VALID_STATUSES.has(status as BuildOutcome)
   ) {
     throw new Error(
-      `${contextLabel}: invalid "status" (must be success|failure|skipped): ${JSON.stringify(raw)}`,
+      `${contextLabel}: invalid "status" (must be ${BUILD_OUTCOMES.join("|")}): ${JSON.stringify(raw)}`,
     );
   }
   return { service: trimmedService, status: status as BuildOutcome };
@@ -105,6 +121,23 @@ export function successSet(results: ServiceBuildResult[]): string[] {
 }
 
 /**
+ * Services whose build slot was CANCELLED — in practice a slot killed by
+ * its `timeout-minutes` budget (GitHub reports a timeout kill as job
+ * conclusion `cancelled`, and Depot surfaces it as "Step canceled by
+ * GitHub"), or a slot caught in a run-level cancellation.
+ *
+ * This is the signal that makes a partially-cancelled fleet build
+ * distinguishable from a clean one. A cancelled slot pushed NO image, so
+ * it is correctly absent from `successSet` and never enters the redeploy
+ * CSV — but its absence there is silent, which is exactly how run
+ * 30162773601 redeployed 23 services to staging with 5 slots dead and
+ * emitted no alert. Consumers use this to alert and to red the run.
+ */
+export function cancelledSet(results: ServiceBuildResult[]): string[] {
+  return results.filter((r) => r.status === "cancelled").map((r) => r.service);
+}
+
+/**
  * Canonical artifact-name convention for the per-slot build-result
  * handoff. Each matrix slot in showcase_build.yml uploads exactly one
  * artifact named `build-result-<dispatch_name>` containing a single
@@ -127,7 +160,7 @@ export function buildResultArtifactName(service: string): string {
  * Merge a list of per-slot result.json payloads (raw strings, one per
  * matrix slot's uploaded artifact) into a single ServiceBuildResult[].
  * Each payload MUST be a JSON object with `service: string` and
- * `status: success|failure|skipped`. The merge is order-preserving so
+ * `status: success|failure|cancelled|skipped`. The merge is order-preserving so
  * downstream consumers can rely on stable iteration.
  *
  * Fails loud on duplicate `service` names across slots: a duplicate

--- a/showcase/scripts/redeploy-guard.test.ts
+++ b/showcase/scripts/redeploy-guard.test.ts
@@ -271,6 +271,19 @@ function contextFor(
   opts: { runCancelled?: boolean; hasChanges?: boolean } = {},
 ): GhContext {
   const anySuccess = legResults.includes("success");
+  // `any_cancelled` / `cancelled_services` are derived from the per-slot
+  // outcomes exactly as `aggregate-build-results` does.
+  //
+  // Crucially, model WHEN THE AGGREGATOR ITSELF IS SKIPPED. Its guard is
+  // `!cancelled() && detect-changes.outputs.has_changes == 'true'`, so on a
+  // RUN-level cancellation OR a no-changes push it never runs, and a skipped
+  // job's outputs resolve to the EMPTY STRING — not 'false'. That distinction
+  // is load-bearing twice over: it is what keeps an intentional run-level
+  // cancel silent, and it is what stops `any_success == 'false'` from firing
+  // the alert on every routine push that builds nothing.
+  const cancelledLegs = legResults.filter((r) => r === "cancelled");
+  const aggregatorRan =
+    !(opts.runCancelled ?? false) && (opts.hasChanges ?? true);
   return {
     runCancelled: opts.runCancelled ?? false,
     needs: {
@@ -279,7 +292,15 @@ function contextFor(
       },
       build: { result: rollupBuildResult(legResults) },
       "aggregate-build-results": {
-        outputs: { any_success: String(anySuccess) },
+        outputs: aggregatorRan
+          ? {
+              any_success: String(anySuccess),
+              any_cancelled: String(cancelledLegs.length > 0),
+              cancelled_services: cancelledLegs
+                .map((_, i) => `svc-${i}`)
+                .join(","),
+            }
+          : { any_success: "", any_cancelled: "", cancelled_services: "" },
       },
     },
   };
@@ -489,5 +510,135 @@ describe("notify guard — cancelled-rollup blind spot", () => {
     const legs = Array(28).fill("cancelled");
     const ctx = contextFor(legs, { runCancelled: true });
     expect(jobRuns(guard, ctx)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression guard for the SILENT PARTIAL-CANCEL hole.
+//
+// Production incident, build run 30162773601 (merge of #6160): a workflow-file
+// edit forced a full-fleet rebuild, 5 of 28 slots were killed by their
+// `timeout-minutes` budget, the other 23 built and WERE redeployed to staging
+// (`redeploy-staging` succeeded and uploaded `redeploy-summary`), and:
+//   - `notify` was SKIPPED — no Slack alert, no PR comment;
+//   - the run rolled up to conclusion `cancelled`, failing
+//     showcase_deploy.yml's `conclusion == 'success'` gate, so the staging
+//     redeploy was never verified.
+//
+// Why every pre-existing guard missed it — measured on purpose-built probe run
+// 30166429073, and consistent with the documented semantics of the status
+// functions ("cancelled(): returns true if the workflow was canceled";
+// "failure(): returns true if any ancestor job fails"):
+//   - the killed leg's own `job.status` is `cancelled`;
+//   - the matrix rollup `needs.build.result` is `cancelled`;
+//   - `cancelled()` is FALSE — it is workflow-scoped, and the RUN was not
+//     cancelled, only individual legs. (Confirmed in production too: both
+//     `!cancelled()`-guarded jobs RAN in run 30162773601.)
+//   - `failure()` is FALSE — a CANCELLED ancestor is not a FAILED ancestor.
+//   - `any_success` is 'true' — 23 slots did build.
+// So `failure() || cancelled()` would NOT have closed this. The only signal
+// that survives is the per-slot one: `any_cancelled`.
+// ---------------------------------------------------------------------------
+describe("notify guard — silent partial-cancel hole (run 30162773601)", () => {
+  const guard = readJobGuard("notify");
+
+  /** The exact production shape: 23 slots built, 5 killed by timeout. */
+  const partialCancelLegs = [
+    ...Array(23).fill("success"),
+    ...Array(5).fill("cancelled"),
+  ];
+
+  /**
+   * The pre-fix `notify` guard, verbatim from origin/main. Kept as a literal
+   * so the test proves the DIFFERENCE the fix makes rather than merely
+   * asserting the current guard's behaviour. If this ever starts passing, the
+   * model has drifted from GitHub's semantics.
+   */
+  const PRE_FIX_GUARD = `\${{ !cancelled()
+          && (failure()
+              || needs.aggregate-build-results.outputs.any_success == 'false') }}`;
+
+  it("RED: the pre-fix guard stays SILENT on the production partial-cancel", () => {
+    const ctx = contextFor(partialCancelLegs, { runCancelled: false });
+    // Every clause the old guard had available goes the wrong way:
+    expect(rollupBuildResult(partialCancelLegs)).toBe("cancelled");
+    expect(anyDepFailed(ctx)).toBe(false); // failure() === false
+    expect(ctx.runCancelled).toBe(false); // cancelled() === false
+    expect(
+      (
+        ctx.needs["aggregate-build-results"] as {
+          outputs: Record<string, string>;
+        }
+      ).outputs.any_success,
+    ).toBe("true"); // the any_success clause === false
+    expect(jobRuns(PRE_FIX_GUARD, ctx)).toBe(false); // ← the bug
+  });
+
+  it("GREEN: the live guard FIRES on the production partial-cancel", () => {
+    const ctx = contextFor(partialCancelLegs, { runCancelled: false });
+    expect(jobRuns(guard, ctx)).toBe(true);
+  });
+
+  it("adds no noise: still silent on a fully clean build", () => {
+    const legs = Array(28).fill("success");
+    expect(jobRuns(guard, contextFor(legs))).toBe(false);
+  });
+
+  it("adds no noise: still silent when a human cancels the whole RUN", () => {
+    const ctx = contextFor(partialCancelLegs, { runCancelled: true });
+    expect(jobRuns(guard, ctx)).toBe(false);
+  });
+
+  it("adds no noise: still silent when the build was skipped (no changes)", () => {
+    // has_changes=false → the build matrix never runs and the aggregator is
+    // skipped, so `any_cancelled` is '' — not 'true'.
+    const ctx = contextFor([], { hasChanges: false });
+    expect(jobRuns(guard, ctx)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The job that turns a partially-cancelled build RED (so its conclusion is
+// `failure`, not `cancelled`) and names the affected services in Slack.
+// ---------------------------------------------------------------------------
+describe("notify-cancelled-builds guard", () => {
+  const guard = readJobGuard("notify-cancelled-builds");
+
+  it("fires on the production partial-cancel (23 built, 5 killed)", () => {
+    const legs = [...Array(23).fill("success"), ...Array(5).fill("cancelled")];
+    const ctx = contextFor(legs, { runCancelled: false });
+    expect(jobRuns(guard, ctx)).toBe(true);
+  });
+
+  it("fires when a single leg is cancelled and everything else built", () => {
+    const legs = [...Array(27).fill("success"), "cancelled"];
+    expect(jobRuns(guard, contextFor(legs, { runCancelled: false }))).toBe(
+      true,
+    );
+  });
+
+  it("fires when every leg was cancelled", () => {
+    const legs = Array(28).fill("cancelled");
+    expect(jobRuns(guard, contextFor(legs, { runCancelled: false }))).toBe(
+      true,
+    );
+  });
+
+  it("does NOT fire on a clean build", () => {
+    expect(jobRuns(guard, contextFor(Array(28).fill("success")))).toBe(false);
+  });
+
+  it("does NOT fire on an all-FAILED build (that is notify's job, not ours)", () => {
+    expect(jobRuns(guard, contextFor(Array(28).fill("failure")))).toBe(false);
+  });
+
+  it("does NOT fire when a human cancelled the whole RUN (intentional)", () => {
+    const legs = [...Array(23).fill("success"), ...Array(5).fill("cancelled")];
+    const ctx = contextFor(legs, { runCancelled: true });
+    expect(jobRuns(guard, ctx)).toBe(false);
+  });
+
+  it("does NOT fire when there were no changes to build", () => {
+    expect(jobRuns(guard, contextFor([], { hasChanges: false }))).toBe(false);
   });
 });


### PR DESCRIPTION
## The hole

A partially-cancelled showcase build was **indistinguishable from a clean one in both directions**: it emitted no alert, and it suppressed post-deploy verification — while having actually redeployed real images to staging.

Three merges landed on `main` on 2026-07-25 with **zero post-deploy verification**. Reconstructed from the API, with run IDs:

| # | build run | conclusion | what happened |
|---|---|---|---|
| #5483 | `30162754730` | cancelled | `shell-docs` killed at 10m04s. Alert **did** fire (all-failed path). No verify. |
| — | `30162770765` | cancelled | `shell` killed at 10m04s. **Silent.** No verify. |
| #6160 | `30162773601` | cancelled | 5 slots killed, **23 redeployed to staging**. **Silent.** No verify. |
| #6168 | `30162784491` | success | clean — and its verify was then cancelled by a sibling. |

### The chain, for run `30162773601`

1. #6160's workflow edit forced a full-fleet rebuild. Five slots died — `shell`, `shell-docs`, `shell-dashboard`, `shell-dojo`, `showcase-aimock`.
2. The intersection guard correctly excluded them. `redeploy-staging` **succeeded** and uploaded `redeploy-summary`, redeploying the 23 that built.
3. The run concluded **`cancelled`** (5 legs cancelled, 0 failed → GitHub rolls the run up to `cancelled`).
4. `notify` was **skipped** → no Slack, no PR comment.
5. `showcase_deploy.yml` requires `conclusion == 'success'` → never started. 23 services redeployed, unverified.
6. The one legitimate verify — run `30163309977`, from #6168's successful build — started 15:17:13 and was **cancelled at 15:17:22** by run `30163312882`, which was triggered by a *different* partially-cancelled build and then skipped every job anyway.

## Which links I verified in the YAML, and where the brief was wrong

| Link | Verdict |
|---|---|
| Intersection guard excludes cancelled slots | ✅ Confirmed — `showcase_build.yml` `redeploy-staging` intersects matrix ∩ `status == "success"`. |
| Run concluded `cancelled`, not failure/success | ✅ Confirmed via API on all three runs. |
| `showcase_deploy.yml` requires `conclusion == 'success'` | ✅ Confirmed verbatim on `resolve-matrix`. |
| Global `showcase-verify-deploy` concurrency group preempted a sibling | ✅ Confirmed — group had no commit key, `cancel-in-progress: true`; timestamps above show the 9-second preemption. |
| **`notify`'s condition is `if: failure()`** | ❌ **Wrong.** It is already `!cancelled() && (failure() \|\| any_success == 'false')`. |
| **The suppressor is `failure()` not matching `cancelled`** | ❌ **Wrong, and the proposed fix would not have worked.** See below. |
| **Depot `Step canceled by GitHub` is a flake** | ❌ **Wrong.** It is a `timeout-minutes` kill. See "Root cause". |

### Why `if: failure() || cancelled()` would NOT have fixed this

I built a throwaway probe workflow on a scratch branch — a matrix with one leg killed by `timeout-minutes` and one green leg, plus dependent jobs guarded by each candidate expression. **Probe run [`30166429073`](https://github.com/CopilotKit/CopilotKit/actions/runs/30166429073)**:

| probe | result | conclusion |
|---|---|---|
| killed leg's `job.status` | `cancelled` | a timeout kill reports as *cancelled* |
| matrix rollup `needs.legs.result` | `cancelled` | |
| `if: cancelled()` | **SKIPPED** | `cancelled()` evaluated **FALSE** |
| `if: failure()` | **SKIPPED** | `failure()` evaluated **FALSE** |
| pre-fix `notify` condition | **SKIPPED** | ← the bug, reproduced |
| post-fix `notify` condition | **RAN** | ← the fix, proven |
| workflow run conclusion | `cancelled` | matches production |

`cancelled()` is **workflow-scoped**: ["Returns `true` if the workflow was cancelled."](https://docs.github.com/en/actions/reference/evaluate-expressions-in-workflows-and-actions) Individual legs dying does not cancel the *run*, so it is false. And `failure()` ["returns `true` if any ancestor job fails"](https://docs.github.com/en/actions/reference/evaluate-expressions-in-workflows-and-actions) — a **cancelled** ancestor did not *fail*, so it is false too. With 23 slots green, `any_success` is `'true'`. Every clause the old guard had went the wrong way.

Independently corroborated in production: in run `30162773601`, both `!cancelled()`-guarded jobs (`aggregate-build-results`, `redeploy-staging`) **ran**, which is only possible if `cancelled()` was false.

## Root cause of the cancellations: a timeout, not a flake

From the Depot log of the killed `shell` leg:

```
15:04:03  depot build --file showcase/shell/Dockerfile ... --push
15:13:29  #25 [builder 15/15] RUN cd scripts && ... generate-registry.ts   DONE 54.3s
15:13:32  failed to solve: Canceled: context canceled
15:13:32  ##[error]Step canceled by GitHub
15:13:32  BUILD_STATUS: cancelled
```

Started 15:03:28, killed 15:13:34 — **exactly `timeout-minutes: 10`**. Same for the other three shell slots; `showcase-aimock` died at exactly its 5. The build was making real but slow progress the whole time (repeated docker.io base-image pull stalls, `#9 ...` for seven minutes) and was 2 steps from done.

So **a retry is the wrong lever twice over**: a cancelled job cannot run further steps, and the build was not erroring. The underlying cause is Depot builder contention — three full-fleet rebuilds ran concurrently (~84 simultaneous amd64 builds). Measured budgets:

| slot | warm | contended | budget |
|---|---|---|---|
| shell / shell-docs / shell-dashboard / shell-dojo | 2–5 min | killed at 10 | **10 → 20** |
| showcase-aimock | 2 min | killed at 5 | **5 → 12** |
| showcase-pocketbase | — | **8.8 min** (near-miss) | **10 → 15** |
| webhooks | 0.6 min | — | 5 (unchanged, `skip_build`) |

The `context: "."` slots build the whole monorepo root and are the heaviest in the fleet, yet carried the *smallest* budgets — inverted.

## The design

**1. Stop laundering the signal** (`build-outputs.ts`, per-slot writer). `cancelled` becomes a first-class `BuildOutcome` instead of being mapped to `skipped`. The per-slot result is the *only* place the cancellation survives, because the status functions can't see it. `successSet` still excludes it, so the redeploy intersection is unchanged — a slot that pushed no image still cannot enter the redeploy CSV.

**2. Alert on it** — aggregator publishes `any_cancelled` + `cancelled_services`; `notify` gains an `any_cancelled == 'true'` clause (the exact expression proven by the probe), and its PR comment now distinguishes *incomplete* from *failed*.

**3. Red the run, don't leave it `cancelled`** — new `notify-cancelled-builds` job exits non-zero, so the conclusion is `failure`. A slot killed by its timeout budget *is* a failure, and `cancelled` is precisely what suppressed everything downstream.

**4. Verify the partial deploy anyway** — the `conclusion == 'success'` gate becomes a terminal-conclusion allowlist (`success|failure|cancelled|timed_out`).

> **Tradeoff, stated plainly.** Relaxing the gate rather than only failing loudly is deliberate: a build that redeployed 23 services *needs* verifying, and gating on `success` guaranteed it never would. It is safe because the decision of *what* to verify never depended on the rollup — no `redeploy-summary` artifact still means `has_services=false` and verify is skipped, and the redeploy gate still narrows to the per-service success set, so a cancelled slot can never be probed against a stale `:latest` and reported healthy. The cost is one extra no-op deploy run for builds that die before redeploying. Note this *also* fixes the same hole for `conclusion == 'failure'`, which was equally unverified.

**5. Key verification per commit** — `showcase-verify-deploy-${{ github.event.workflow_run.head_sha || github.sha }}`, so a later cancelled run can no longer destroy an earlier successful run's verification. `cancel-in-progress: true` is kept, so re-verifying the *same* commit still supersedes. (`github` context is [documented as available](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts) in `concurrency`.)

**6. Realistic timeout budgets** — separate commit, droppable independently. Mitigation, not the root fix; the durable lever is a non-cancelling concurrency queue on the build workflow, noted inline as a follow-up since this workflow deliberately has *no* concurrency group.

### On alerting for a genuine manual cancel

It stays **silent**, and that is correct. `!cancelled()` is retained on both notify jobs as the flake-vs-intentional discriminator, and the probe proves it discriminates: a human cancelling the whole RUN makes `cancelled()` true → silent; a leg-level timeout leaves it false → alerts. Belt and braces — on a run-level cancel, `aggregate-build-results` is itself skipped by its own `!cancelled()` guard, so `any_cancelled` resolves to `''` rather than `'true'`. Two independent reasons for silence, zero manual-cancel noise.

## What I proved

- **Real end-to-end red-green on GitHub Actions** — probe run [`30166429073`](https://github.com/CopilotKit/CopilotKit/actions/runs/30166429073), table above. Old condition skipped, new condition ran, on a genuinely timeout-killed matrix leg. Scratch branch deleted; the run is permanent.
- **Local red-green on the TS layer** — 8 tests failing before the fix (`cancelledSet is not a function`, `invalid "status" (must be success|failure|skipped)`), 46 passing after.
- **Local red-green on the live workflow expression.** `redeploy-guard.test.ts` parses the **actual `if:` strings out of the YAML** and evaluates them. Pointed at `origin/main`'s YAML, the new `GREEN: the live guard FIRES on the production partial-cancel` test fails (`expected false to be true`) and is the *only* failure; pointed at this branch, all 31 pass. The pre-fix guard is pinned as a literal so the test permanently encodes the difference rather than just the current behaviour.
- **No new alert noise** — explicit tests that `notify` stays silent on a clean build, on a human run-cancel, and on a no-changes push. That last one exposed a latent inaccuracy in the test harness's own model (a skipped aggregator's outputs are `''`, not `'false'`), now fixed.
- **Lint** — `actionlint` finding count unchanged at 10 vs the `origin/main` baseline (all pre-existing: the unknown `depot-ubuntu-24.04-4` label and shellcheck `info` notes on untouched scripts). `zizmor` with the repo's own config at `min-severity: low`: *No findings to report*.
- **Suite** — 77 tests green across the three touched files. Full `showcase/scripts` suite has 5 pre-existing failing files (`emit-railway-envs-json`, `generate-catalog`, `generate-registry`, `integration-smoke-registry`); I reproduced the identical 5 files / 8 tests on a pristine `origin/main` worktree, so they are unrelated to this change.

## What remains unproven until it runs on `main`

- The **production** partial-cancel path end-to-end. The probe reproduced the expression semantics on a synthetic matrix, not the real 28-slot fleet with real Depot builds; the Slack message and PR-comment rendering have not been exercised against a live webhook.
- The relaxed deploy gate firing on a real `cancelled`/`failure` build — including the "no artifact → skipped, no noise" path.
- The per-commit concurrency group under real rapid-fire merges.
- Whether 20 minutes is actually enough for `shell` under peak Depot contention. It was ~3 steps from done at 10; 20 is inference from that, not measurement.

`\n` handling in the new Slack payload follows the existing `fromJSON('"\n"')` convention in this file, but is not verified against a live webhook.
