### PR TITLE
fix(react-core): stop CopilotPopup remounting chat on resize

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotPopup.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotPopup.tsx
@@ -1,10 +1,74 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useContext, useEffect, useMemo } from "react";
 import { useLicenseContext } from "../../providers/CopilotKitProvider";
 import { InlineFeatureWarning } from "../license-warning-banner";
 
-import { CopilotChat, CopilotChatProps } from "./CopilotChat";
-import CopilotChatView, { CopilotChatViewProps } from "./CopilotChatView";
-import CopilotPopupView, { CopilotPopupViewProps } from "./CopilotPopupView";
+import type { CopilotChatProps } from "./CopilotChat";
+import { CopilotChat } from "./CopilotChat";
+import type { CopilotChatViewProps } from "./CopilotChatView";
+import CopilotChatView from "./CopilotChatView";
+import type { CopilotPopupViewProps } from "./CopilotPopupView";
+import CopilotPopupView from "./CopilotPopupView";
+
+/**
+ * Carries the popup shell props (header, toggle, width, height, …) to the
+ * chatView override without baking them into the override's component
+ * identity. Width/height change on every resize; if they were `useMemo`
+ * dependencies of the override component, each change would mint a new
+ * component function, and rendering a new element *type* makes React unmount
+ * and remount the entire chat subtree — resetting scrollTop to 0 and firing
+ * `initial="smooth"`, which visibly scrolls the message list from top to
+ * bottom on every resize. Routing them through context keeps the override
+ * identity stable (no remount) while still re-rendering CopilotPopupView with
+ * the new dimensions on change.
+ */
+type PopupShellProps = {
+  header?: CopilotPopupViewProps["header"];
+  toggleButton?: CopilotPopupViewProps["toggleButton"];
+  width?: CopilotPopupViewProps["width"];
+  height?: CopilotPopupViewProps["height"];
+  clickOutsideToClose?: CopilotPopupViewProps["clickOutsideToClose"];
+  defaultOpen?: boolean;
+};
+
+const PopupShellPropsContext = React.createContext<PopupShellProps>({});
+
+// Stable override component. Its identity never changes, so the chat subtree
+// is never remounted on resize. Popup props flow in via context, so changing
+// width/height re-renders CopilotPopupView (a style update) instead.
+const PopupViewOverride: React.FC<CopilotChatViewProps> = (viewProps) => {
+  const {
+    header: viewHeader,
+    toggleButton: viewToggleButton,
+    width: viewWidth,
+    height: viewHeight,
+    clickOutsideToClose: viewClickOutsideToClose,
+    defaultOpen: viewDefaultOpen,
+    ...restProps
+  } = viewProps as CopilotPopupViewProps;
+
+  const shell = useContext(PopupShellPropsContext);
+
+  return (
+    <CopilotPopupView
+      {...(restProps as CopilotPopupViewProps)}
+      header={shell.header ?? viewHeader}
+      toggleButton={shell.toggleButton ?? viewToggleButton}
+      width={shell.width ?? viewWidth}
+      height={shell.height ?? viewHeight}
+      clickOutsideToClose={shell.clickOutsideToClose ?? viewClickOutsideToClose}
+      defaultOpen={shell.defaultOpen ?? viewDefaultOpen}
+    />
+  );
+};
+
+// Preserve the static slot members (WelcomeScreen, etc.) that callers reach
+// through the CopilotChatView namespace. The cast restores those statics on
+// the type after Object.assign, matching the shape CopilotChat's `chatView`
+// slot expects (typeof CopilotChatView).
+const PopupViewOverrideWithStatics = Object.assign(
+  PopupViewOverride,
+  CopilotChatView,
+) as typeof CopilotChatView;
 
 export type CopilotPopupProps = Omit<CopilotChatProps, "chatView"> & {
   header?: CopilotPopupViewProps["header"];
@@ -35,43 +99,29 @@ export function CopilotPopup({
     }
   }, [isPopupLicensed]);
 
-  const PopupViewOverride = useMemo(() => {
-    const Component: React.FC<CopilotChatViewProps> = (viewProps) => {
-      const {
-        header: viewHeader,
-        toggleButton: viewToggleButton,
-        width: viewWidth,
-        height: viewHeight,
-        clickOutsideToClose: viewClickOutsideToClose,
-        defaultOpen: viewDefaultOpen,
-        ...restProps
-      } = viewProps as CopilotPopupViewProps;
-
-      return (
-        <CopilotPopupView
-          {...(restProps as CopilotPopupViewProps)}
-          header={header ?? viewHeader}
-          toggleButton={toggleButton ?? viewToggleButton}
-          width={width ?? viewWidth}
-          height={height ?? viewHeight}
-          clickOutsideToClose={clickOutsideToClose ?? viewClickOutsideToClose}
-          defaultOpen={defaultOpen ?? viewDefaultOpen}
-        />
-      );
-    };
-
-    return Object.assign(Component, CopilotChatView);
-  }, [clickOutsideToClose, header, toggleButton, height, width, defaultOpen]);
+  const shellProps = useMemo<PopupShellProps>(
+    () => ({
+      header,
+      toggleButton,
+      width,
+      height,
+      clickOutsideToClose,
+      defaultOpen,
+    }),
+    [clickOutsideToClose, header, toggleButton, height, width, defaultOpen],
+  );
 
   return (
     <>
       {!isPopupLicensed && <InlineFeatureWarning featureName="Popup" />}
-      <CopilotChat
-        welcomeScreen={CopilotPopupView.WelcomeScreen}
-        {...chatProps}
-        isModalDefaultOpen={defaultOpen}
-        chatView={PopupViewOverride}
-      />
+      <PopupShellPropsContext.Provider value={shellProps}>
+        <CopilotChat
+          welcomeScreen={CopilotPopupView.WelcomeScreen}
+          {...chatProps}
+          isModalDefaultOpen={defaultOpen}
+          chatView={PopupViewOverrideWithStatics}
+        />
+      </PopupShellPropsContext.Provider>
     </>
   );
 }

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotPopup.resizeRemount.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotPopup.resizeRemount.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Regression test: resizing CopilotPopup must NOT remount the chat subtree.
+ *
+ * Root cause (pre-fix): CopilotPopup built its `chatView` override component
+ * inside a `useMemo` keyed on `width`/`height`. Every resize commit produced a
+ * NEW component function; rendering a new element *type* at that position makes
+ * React unmount and remount the whole chat subtree. The remount reset the
+ * scroll container's scrollTop to 0, after which `initial="smooth"` animated
+ * the message list from top to bottom — the visible "scrolls from top to
+ * bottom on every resize, from any scroll position" bug reported by consumers
+ * driving width/height from a drag handle (e.g. Amazon's InkAgenticUITools
+ * `useResize`).
+ *
+ * Fix: the override component identity is now stable (defined at module scope);
+ * popup shell props flow through React context instead of the memo deps. A
+ * resize is a plain re-render / style update — no remount.
+ *
+ * This test injects a mount-counting component through the `input` slot (which
+ * renders inside the chat subtree) and asserts its mount count stays at 1
+ * across width/height changes. On unfixed code the count increments on every
+ * resize, reproducing the bug.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { AbstractAgent } from "@ag-ui/client";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
+import type { Observable } from "rxjs";
+import { Subject } from "rxjs";
+import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
+import { CopilotPopup } from "../CopilotPopup";
+import type { CopilotChatInputProps } from "../CopilotChatInput";
+
+// Minimal agent so the popup renders a real chat subtree without a runtime.
+class MockAgent extends AbstractAgent {
+  private subject = new Subject<BaseEvent>();
+  clone(): MockAgent {
+    const cloned = new MockAgent();
+    cloned.agentId = this.agentId;
+    (cloned as unknown as { subject: Subject<BaseEvent> }).subject =
+      this.subject;
+    return cloned;
+  }
+  async detachActiveRun(): Promise<void> {}
+  run(_input: RunAgentInput): Observable<BaseEvent> {
+    return this.subject.asObservable();
+  }
+}
+
+// Counts how many times it MOUNTS (not renders). A remount of the chat subtree
+// unmounts the previous instance and mounts a fresh one, incrementing this.
+let inputMountCount = 0;
+function MountCountingInput(_props: CopilotChatInputProps) {
+  React.useEffect(() => {
+    inputMountCount++;
+  }, []);
+  return <div data-testid="mount-probe" />;
+}
+
+// Wrapper that lets the test drive width/height the way a resize handle would.
+function Harness({ width, height }: { width: number; height: number }) {
+  const agent = React.useMemo(() => new MockAgent(), []);
+  return (
+    <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+      <CopilotPopup
+        defaultOpen
+        width={width}
+        height={height}
+        input={
+          MountCountingInput as unknown as typeof import("../CopilotChatInput").default
+        }
+      />
+    </CopilotKitProvider>
+  );
+}
+
+describe("CopilotPopup resize does not remount the chat subtree", () => {
+  beforeEach(() => {
+    inputMountCount = 0;
+  });
+
+  it("keeps the chat subtree mounted across width/height changes", async () => {
+    const { rerender } = render(<Harness width={420} height={560} />);
+
+    // Subtree mounted once.
+    expect(await screen.findByTestId("mount-probe")).toBeTruthy();
+    expect(inputMountCount).toBe(1);
+
+    // Simulate several resize commits (as a drag handle would on mouseup).
+    rerender(<Harness width={500} height={600} />);
+    rerender(<Harness width={360} height={700} />);
+    rerender(<Harness width={420} height={560} />);
+
+    // Regression guard: the subtree must NOT have remounted. On unfixed code
+    // inputMountCount would be > 1 (one extra mount per resize).
+    expect(inputMountCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where resizing a `CopilotPopup` (v2) rescrolls the message list from top to bottom on every resize, regardless of the user's scroll position.

**Root cause.** `CopilotPopup` built its `chatView` override component inside a `useMemo` keyed on `width`/`height`. When those props change — which happens continuously for consumers driving them from a drag-to-resize handle that commits new dimensions on `mouseup` — `useMemo` returns a **new component function**. That function is passed to `CopilotChat` as the `chatView` slot and rendered via `React.createElement(newType, …)`. Because React sees a new element **type** at that position, it unmounts and remounts the entire chat subtree rather than re-rendering it. The remount resets the scroll container's `scrollTop` to `0`, after which the default `initial="smooth"` auto-scroll animates the list from the top back down to the bottom — the visible "rescroll" on every resize.

**Fix.** Give the override a stable module-scope identity so its type never changes, and pass the popup shell props (`header`, `toggleButton`, `width`, `height`, `clickOutsideToClose`, `defaultOpen`) through React context instead of baking them into the override via `useMemo` deps. Resizing is now a plain style update on `CopilotPopupView` — no remount — so scroll position is preserved. `Object.assign` still copies the `CopilotChatView` static slot members onto the override so callers reaching them through the namespace continue to work.

**Test.** Adds a regression test (`CopilotPopup.resizeRemount.test.tsx`) that injects a mount-counting component into the chat subtree and asserts its mount count stays at `1` across several `width`/`height` changes. It fails on the pre-fix code (one extra mount per resize — observed `4` for 3 resizes) and passes with the fix.

Scope is limited to `packages/react-core`:

```
packages/react-core/src/v2/components/chat/CopilotPopup.tsx                               | 124 +++++++++------
packages/react-core/src/v2/components/chat/__tests__/CopilotPopup.resizeRemount.test.tsx  |  98 +++++++++++
2 files changed, 185 insertions(+), 37 deletions(-)
```

Verification: full `@copilotkit/react-core` unit suite green (1443 tests), `check-types` green.

## Related PRs and Issues

- Closes #6172

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation — _N/A: internal behavior fix, no public API or documented behavior change_
- [x] "Allow edits by maintainers" is checked
