### PR TITLE
fix(showcase): pin ag2<1.0.0 to unblock CI after upstream module rename

### DIFF
--- a/showcase/integrations/ag2/requirements.txt
+++ b/showcase/integrations/ag2/requirements.txt
@@ -1,4 +1,18 @@
-ag2[openai,ag-ui]>=0.9.0
+# Upper bound pins us below ag2 1.0.0 (published 2026-07-27), which renames the
+# top-level module `autogen` -> `ag2` and drops `autogen/` entirely, so every
+# `from autogen... import` under src/agents/ raises ModuleNotFoundError.
+#
+# This is NOT a pure rename -- 1.0.0 promotes the old `autogen.beta.ag_ui`
+# stream in place of the stable adapter and changes the public API:
+#   - `autogen/ag_ui/adapter.py` (AgentService-based AGUIStream) is deleted
+#   - `AGUIStream.__init__` drops the `event_interceptors` kwarg
+#   - `AGUIStream.dispatch()` drops `context=` in favour of `variables=`
+#     (plus new prompt/dependencies/config/tools/middleware/observers/hitl_hook)
+# `src/agents/_multimodal_normalize.py` calls `super().dispatch(..., context=...)`,
+# so migrating the import path alone would trade an import error for a runtime
+# TypeError. Lift this bound only as part of a real 1.0 migration that ports the
+# ~20 `autogen` import sites and re-verifies every ag2 demo cell.
+ag2[openai,ag-ui]>=0.9.0,<1.0.0
 ag-ui-protocol>=0.1.10
 fastapi>=0.115.0
 uvicorn>=0.34.0

--- a/showcase/scripts/fail-baseline.json
+++ b/showcase/scripts/fail-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Drift ratchet baseline for showcase_validate.yml. `validatePinsFailCount` holds the last-known FAIL count; `validatePinsFailHash` is a SHA-256 of the stderr-only `[FAIL] ...` lines from validate-pins.ts, deduplicated and sorted with `LC_ALL=C sort -u`. CI compares BOTH: if the count changes, it tells you to ratchet (up rejected, down instructed). If the count is equal but the hash differs, the FAIL *set* has drifted (one item fixed, another regressed) and CI fails with a diff. Never raise the count without an explicit review + sign-off. `baselineDemoCount` is the exact expected demo count per package (single source of truth consumed by both the workflow and validate-parity.ts); deviation in either direction triggers a baseline-deviation warning. NOTE: validate-parity.ts `BASELINE_DEMO_COUNT` default must match `baselineDemoCount` here; keep them in sync. See .github/workflows/showcase_validate.yml 'Run validate-pins (ratchet)' step.",
   "validatePinsFailCount": 31,
-  "validatePinsFailHash": "b47ca987fd6e2701f1c565ed2ce5214f18f777971489a739a4230f84f014f6a5",
+  "validatePinsFailHash": "d97afe4919215cdb0a63121d00fce3f8d29d4f3c1422819a163daf73b90f8551",
   "baselineDemoCount": 9
 }


### PR DESCRIPTION
## What's broken

`ag2` **1.0.0 was published to PyPI at 2026-07-27T00:58:37Z**. It renames the top-level module from `autogen` to `ag2` and ships **no `autogen/` package at all**.

`showcase/integrations/ag2/requirements.txt` floated on `ag2[openai,ag-ui]>=0.9.0`, so every *fresh* CI dependency resolution now pulls 1.0.0 and pytest collection dies on import.

This breaks `Python unit tests (3.10)` and `Python unit tests (3.12)` in `showcase_validate.yml` **on `main` and on every open PR**. It's time-based, not commit-based — `main` currently reads green only because it hasn't re-run since the release landed.

### Release timing evidence

From the PyPI JSON API:

| version | upload_time_iso_8601 |
|---|---|
| 0.14.0 | `2026-06-26T04:48:39.784002Z` |
| 1.0.0  | `2026-07-27T00:58:37.996353Z` |

### Wheel layout proof

Top-level directories in each wheel:

```
=== ag2 0.14.0 ===        === ag2 1.0.0 ===
ag2-0.14.0.dist-info      ag2
autogen                   ag2-1.0.0.dist-info
templates
```

`autogen/` is simply gone in 1.0.0.

## Why pin instead of migrating the imports

**Because 1.0.0 is not a rename — it's an API change.** Diffing the wheels:

1. `autogen/ag_ui/adapter.py` (the stable, `AgentService`-based `AGUIStream`) is **deleted**. `ag2/ag_ui/` in 1.0.0 is the *promoted former `autogen.beta.ag_ui`* — a different implementation with `events.py`/`stream.py`, matching old `autogen/beta/ag_ui/`, not old `autogen/ag_ui/`.

2. The constructor lost a parameter:
   ```python
   # 0.14.0 autogen/ag_ui/adapter.py
   def __init__(self, agent, *, event_interceptors=()) -> None:
   # 1.0.0 ag2/ag_ui/stream.py
   def __init__(self, agent: Agent) -> None:
   ```

3. `dispatch()` changed shape — `context=` is **gone**, replaced by `variables=` plus new `prompt`/`dependencies`/`config`/`tools`/`middleware`/`observers`/`hitl_hook` kwargs.

`showcase/integrations/ag2/src/agents/_multimodal_normalize.py:330` subclasses `AGUIStream` and calls:

```python
async for chunk in super().dispatch(incoming, context=context, accept=accept):
```

So a naive import-path rewrite would trade a loud `ModuleNotFoundError` at import time for a **silent-until-hit `TypeError` at request time** — strictly worse while CI is on fire. A genuine 1.0 migration has to port ~20 `autogen` import sites (including `autogen.agentchat.ContextVariables`, `autogen.tools.tool`, `autogen.code_utils.content_str`) and re-verify every ag2 demo cell behaviorally. That's real work, not an unblock.

## Coverage — every `ag2` dependency site

Swept all `requirements*.txt`, `*.lock`, `uv.lock`, `poetry.lock`, and `pyproject.toml` in the repo:

```
./showcase/integrations/ag2/requirements.txt:1:ag2[openai,ag-ui]>=0.9.0
```

**Exactly one** declaration — no lockfile pins it, no other integration depends on it, transitively or otherwise. All `autogen` imports live under `showcase/integrations/ag2/`. This one-line bound closes the whole surface; nothing else is left floating.

## Red-green proof

Both runs use a clean `python3.12 -m venv` + `pip install -r requirements.txt`, i.e. a fresh resolution exactly like CI's.

### RED — before the fix (resolves ag2 1.0.0)

```
$ pip show ag2 | head -2
Name: ag2
Version: 1.0.0

$ python -m pytest tests/python/ -q
==================== ERRORS ====================
________ ERROR collecting tests/python/test_multimodal_normalize.py ________
ImportError while importing test module '.../tests/python/test_multimodal_normalize.py'.
Traceback:
tests/python/test_multimodal_normalize.py:77: in <module>
    from agents._multimodal_normalize import (  # noqa: E402
src/agents/_multimodal_normalize.py:75: in <module>
    from autogen.ag_ui import AGUIStream, RunAgentInput
E   ModuleNotFoundError: No module named 'autogen'
=============== short test summary info ===============
ERROR tests/python/test_multimodal_normalize.py
!!!!!! Interrupted: 1 error during collection !!!!!!
1 warning, 1 error in 0.30s
```

### GREEN — after the fix (resolves ag2 0.14.0)

```
$ pip show ag2 | head -2
Name: ag2
Version: 0.14.0

$ python -m pytest tests/python/ -q
......................                                        [100%]
=============== warnings summary ===============
tests/python/test_cvdiag_boundaries.py:34
  StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated

22 passed, 1 warning in 1.52s
```

## Follow-up left undone

Pinning defers the migration; it doesn't cancel it. What remains:

- **Port to ag2 1.x.** Rewrite ~20 `autogen.*` imports to `ag2.*`, replace the deleted adapter-based `AGUIStream` with the new stream API, drop/replace `event_interceptors` in `_multimodal_normalize.py`, and convert `dispatch(context=...)` to `dispatch(variables=...)`. Then behaviorally re-verify every ag2 demo cell — the beta stream promoted into `ag2.ag_ui` is a different implementation, so cell-level parity cannot be assumed from a green unit suite.
- **Renovate** will eventually propose lifting the `<1.0.0` bound. That PR must not be merged as a routine bump; it's the migration above.
- The inline comment in `requirements.txt` records all of this at the point of change so the bound isn't lifted casually.

## Second commit: `validate-pins` ratchet hash

The `Validate Showcase` job's `validate-pins (ratchet)` step failed on the first push. Cause is benign and expected: `ag2` matches `FRAMEWORK_PATTERNS`, which demands an exact `==` pin, so the dep was **already** in the drift baseline as a `[FAIL]`. Adding `,<1.0.0` changes that line's text, which changes the SHA-256 the ratchet takes over the sorted FAIL set.

Verified the FAIL *set* is otherwise untouched — I reproduced the committed baseline hash on a pristine `origin/main` tree, then diffed:

```
$ diff <(pristine FAIL lines) <(fixed FAIL lines)
 [FAIL] ag2: ag-ui-protocol is not an exact pin (>=0.1.10)
-[FAIL] ag2: ag2 is not an exact pin (>=0.9.0)
+[FAIL] ag2: ag2 is not an exact pin (>=0.9.0,<1.0.0)
 [FAIL] ag2: openai is not an exact pin (>=1.50.0)
```

Exactly one line differs. `Summary: OK=5 SKIP=0 WARN=3 FAIL=31` both before and after — **count unchanged at 31**, nothing healed, nothing regressed. So this is a hash-only baseline update and the "never raise the count without sign-off" invariant is not engaged.

Pristine run reproduced `b47ca987…` (identical to the committed baseline), confirming the validator is deterministic and this diff is the sole delta.

### Why a range bound rather than an exact `==0.14.0`

An exact pin would satisfy `validate-pins` outright and ratchet the count 31 → 30, but I kept the range deliberately:

- `0.14.0` is the highest final pre-1.0 release and the 0.x line is now legacy, so the range resolves to exactly `0.14.0` today — proven by the GREEN run above.
- `1.0.0b0` sorts below `1.0.0` under PEP 440, but pip excludes pre-releases when a final release satisfies the specifier, so the bound cannot pull the beta. Empirically confirmed: the GREEN venv resolved `0.14.0`.
- It leaves room for a future `0.14.x` patch or security release without another PR.
- It matches the sibling deps in the same file (`ag-ui-protocol>=`, `openai>=`) and keeps this urgent fix to a pure hash bump rather than a count ratchet.

Tightening to an exact pin (and ratcheting the count down) is reasonable follow-up if the team wants to drive `validate-pins` drift toward zero, but it's a pin-discipline cleanup, not part of this unblock.
