### PR TITLE
fix(react-ui): restore cursor position after textarea height resize

### DIFF
--- a/packages/react-ui/src/components/chat/Textarea.cursor.test.ts
+++ b/packages/react-ui/src/components/chat/Textarea.cursor.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression test for GitHub issue #6167.
+ *
+ * In expanded (narrow) mode the `AutoResizingTextarea` useEffect that resizes
+ * the element sets `textarea.style.height = "auto"`, triggering a browser
+ * reflow. In Chromium this reflow resets `selectionStart`/`selectionEnd` to
+ * the end of the text, so typing a character while the cursor is mid-word
+ * causes it to jump to the end.
+ *
+ * The fix reads the cursor position before the height manipulation and calls
+ * `setSelectionRange()` to restore it afterwards, but only when the textarea
+ * is the active element (to avoid side-effects when it has no focus).
+ *
+ * These source-level assertions verify the fix exists and will fail if the
+ * save/restore pattern is accidentally removed.
+ */
+
+const src = readFileSync(resolve(__dirname, "Textarea.tsx"), "utf-8");
+
+describe("AutoResizingTextarea cursor-position fix (#6167)", () => {
+  it("captures selectionStart/End immediately before the height reset", () => {
+    // The cursor position must be saved BEFORE `style.height = "auto"` so
+    // that the pre-reflow value is available to restore afterwards.
+    // This pattern verifies the destructuring happens first, then the reset.
+    expect(src).toMatch(
+      /const\s*\{\s*selectionStart[\s\S]{0,200}textarea\.style\.height\s*=\s*"auto"/,
+    );
+  });
+
+  it("calls setSelectionRange after the final height assignment", () => {
+    // The restore call must come AFTER both height assignments so that the
+    // final rendered height is already in place when we reposition the cursor.
+    // Pattern: the last `textarea.style.height = ...` line is followed by
+    // the `setSelectionRange` call somewhere after it.
+    expect(src).toMatch(
+      /textarea\.style\.height\s*=\s*`[^`]+`[\s\S]{0,400}setSelectionRange/,
+    );
+  });
+
+  it("guards the setSelectionRange call with a focus check", () => {
+    // Calling setSelectionRange on an unfocused element can steal focus in
+    // some browsers. The guard `document.activeElement === textarea` prevents
+    // that for background textareas.
+    expect(src).toMatch(/document\.activeElement\s*===\s*textarea/);
+  });
+});

--- a/packages/react-ui/src/components/chat/Textarea.tsx
+++ b/packages/react-ui/src/components/chat/Textarea.tsx
@@ -63,8 +63,18 @@ const AutoResizingTextarea = forwardRef<
     useEffect(() => {
       const textarea = internalTextareaRef.current;
       if (textarea) {
+        // Save cursor position before height reset — Chrome reflows on `height = "auto"`
+        // which resets selectionStart/End to the end of the text (issue #6167).
+        const { selectionStart, selectionEnd, selectionDirection } = textarea;
         textarea.style.height = "auto";
         textarea.style.height = `${Math.min(textarea.scrollHeight, maxHeight)}px`;
+        if (document.activeElement === textarea) {
+          textarea.setSelectionRange(
+            selectionStart,
+            selectionEnd,
+            selectionDirection as "forward" | "backward" | "none",
+          );
+        }
       }
     }, [value, maxHeight]);
 


### PR DESCRIPTION
## What Problem This Solves

In CopilotChat's expanded (narrow-sidebar) mode, typing a character while the cursor is in the middle of text caused the cursor to jump to the end of the input.

Steps to reproduce:
1. Open CopilotChat in expanded/sidebar mode at narrow width
2. Type some text in the input
3. Move the cursor to the middle of the text
4. Type a character

**Expected:** cursor stays immediately after the inserted character  
**Actual:** cursor jumps to the end of the text

## Why This Change Was Made

The `AutoResizingTextarea` component has a `useEffect` that resizes the textarea whenever `value` changes. It does this by setting `textarea.style.height = "auto"` to read the natural `scrollHeight`, then setting the final height. This forced browser reflow resets `selectionStart`/`selectionEnd` to the end of the text in Chromium — a documented side-effect of layout reflow on focused text elements.

The bug is most visible in expanded/narrow mode because text is more likely to wrap to a new line with each keystroke, making the height change more significant and the reflow more likely to disturb the selection.

**Fix:** save `{ selectionStart, selectionEnd, selectionDirection }` before the height manipulation and call `textarea.setSelectionRange()` to restore the cursor position afterwards. The restore is guarded by `document.activeElement === textarea` to avoid stealing focus from other elements when the textarea is not focused.

## User Impact

Users can now edit text mid-word in the expanded CopilotChat input without their cursor jumping to the end.

## Evidence / Tests Run

- Added `Textarea.cursor.test.ts` — 3 source-level assertions that verify the save/restore pattern is in place:
  - `selectionStart` is captured before the height reset
  - `setSelectionRange` is called after the final height assignment
  - The call is guarded by a focus check

- All 57 unit tests in `@copilotkit/react-ui` pass: `nx run @copilotkit/react-ui:test`
- TypeScript typecheck passes: `nx run @copilotkit/react-ui:check-types`
- Pre-commit lint hook passed (the `autoFocus` exhaustive-deps warning shown is pre-existing and unrelated)

Fixes CopilotKit/CopilotKit#6167