### PR TITLE
fix(react-ui): preserve cursor during textarea resize

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
@@ -707,12 +707,22 @@ export function CopilotChatInput({
       textarea.style.maxHeight = `${maxHeight}px`;
     }
 
+    // Save cursor position before height reset — Chrome reflows on `height = "auto"`
+    // which resets selectionStart/End to the end of the text (issue #6167).
+    const { selectionStart, selectionEnd, selectionDirection } = textarea;
     textarea.style.height = "auto";
     const scrollHeight = textarea.scrollHeight;
     if (maxHeight) {
       textarea.style.height = `${Math.min(scrollHeight, maxHeight)}px`;
     } else {
       textarea.style.height = `${scrollHeight}px`;
+    }
+    if (document.activeElement === textarea) {
+      textarea.setSelectionRange(
+        selectionStart,
+        selectionEnd,
+        selectionDirection as "forward" | "backward" | "none",
+      );
     }
 
     return scrollHeight;

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatInput.cursor.test.ts
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatInput.cursor.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression test for GitHub issue #6167.
+ *
+ * In the v2 CopilotChatInput the `adjustTextareaHeight` callback that resizes
+ * the textarea sets `textarea.style.height = "auto"`, triggering a browser
+ * reflow. In Chromium this reflow resets `selectionStart`/`selectionEnd` to
+ * the end of the text, so typing a character while the cursor is mid-word
+ * causes it to jump to the end.
+ *
+ * The fix reads the cursor position before the height manipulation and calls
+ * `setSelectionRange()` to restore it afterwards, but only when the textarea
+ * is the active element (to avoid side-effects when it has no focus).
+ *
+ * jsdom does not simulate Chromium reflow behaviour, so a rendering-level
+ * test would pass with or without the fix. These source-level assertions
+ * verify the save/restore pattern exists and will fail if it is accidentally
+ * removed.
+ */
+
+const src = readFileSync(
+  resolve(__dirname, "../CopilotChatInput.tsx"),
+  "utf-8",
+);
+
+describe("CopilotChatInput adjustTextareaHeight cursor-position fix (#6167)", () => {
+  it("captures selectionStart/End immediately before the height reset", () => {
+    // The cursor position must be saved BEFORE `style.height = "auto"` so
+    // that the pre-reflow value is available to restore afterwards.
+    expect(src).toMatch(
+      /const\s*\{\s*selectionStart[\s\S]{0,200}textarea\.style\.height\s*=\s*"auto"/,
+    );
+  });
+
+  it("calls setSelectionRange after the final height assignment", () => {
+    // The restore call must come AFTER the last height assignment so that the
+    // final rendered height is already in place when we reposition the cursor.
+    // In v2 the else-branch (`${scrollHeight}px`) is the last assignment before
+    // the restore, so the pattern anchors there.
+    expect(src).toMatch(
+      /textarea\.style\.height\s*=\s*`[^`]+`[\s\S]{0,400}setSelectionRange/,
+    );
+  });
+
+  it("guards the setSelectionRange call with a focus check", () => {
+    // Calling setSelectionRange on an unfocused element can steal focus in
+    // some browsers. The guard `document.activeElement === textarea` prevents
+    // that for background textareas.
+    expect(src).toMatch(/document\.activeElement\s*===\s*textarea/);
+  });
+});

--- a/packages/react-ui/src/components/chat/Textarea.cursor.test.ts
+++ b/packages/react-ui/src/components/chat/Textarea.cursor.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression test for GitHub issue #6167.
+ *
+ * In expanded (narrow) mode the `AutoResizingTextarea` useEffect that resizes
+ * the element sets `textarea.style.height = "auto"`, triggering a browser
+ * reflow. In Chromium this reflow resets `selectionStart`/`selectionEnd` to
+ * the end of the text, so typing a character while the cursor is mid-word
+ * causes it to jump to the end.
+ *
+ * The fix reads the cursor position before the height manipulation and calls
+ * `setSelectionRange()` to restore it afterwards, but only when the textarea
+ * is the active element (to avoid side-effects when it has no focus).
+ *
+ * These source-level assertions verify the fix exists and will fail if the
+ * save/restore pattern is accidentally removed.
+ */
+
+const src = readFileSync(resolve(__dirname, "Textarea.tsx"), "utf-8");
+
+describe("AutoResizingTextarea cursor-position fix (#6167)", () => {
+  it("captures selectionStart/End immediately before the height reset", () => {
+    // The cursor position must be saved BEFORE `style.height = "auto"` so
+    // that the pre-reflow value is available to restore afterwards.
+    // This pattern verifies the destructuring happens first, then the reset.
+    expect(src).toMatch(
+      /const\s*\{\s*selectionStart[\s\S]{0,200}textarea\.style\.height\s*=\s*"auto"/,
+    );
+  });
+
+  it("calls setSelectionRange after the final height assignment", () => {
+    // The restore call must come AFTER both height assignments so that the
+    // final rendered height is already in place when we reposition the cursor.
+    // Pattern: the last `textarea.style.height = ...` line is followed by
+    // the `setSelectionRange` call somewhere after it.
+    expect(src).toMatch(
+      /textarea\.style\.height\s*=\s*`[^`]+`[\s\S]{0,400}setSelectionRange/,
+    );
+  });
+
+  it("guards the setSelectionRange call with a focus check", () => {
+    // Calling setSelectionRange on an unfocused element can steal focus in
+    // some browsers. The guard `document.activeElement === textarea` prevents
+    // that for background textareas.
+    expect(src).toMatch(/document\.activeElement\s*===\s*textarea/);
+  });
+});

--- a/packages/react-ui/src/components/chat/Textarea.tsx
+++ b/packages/react-ui/src/components/chat/Textarea.tsx
@@ -63,8 +63,18 @@ const AutoResizingTextarea = forwardRef<
     useEffect(() => {
       const textarea = internalTextareaRef.current;
       if (textarea) {
+        // Save cursor position before height reset — Chrome reflows on `height = "auto"`
+        // which resets selectionStart/End to the end of the text (issue #6167).
+        const { selectionStart, selectionEnd, selectionDirection } = textarea;
         textarea.style.height = "auto";
         textarea.style.height = `${Math.min(textarea.scrollHeight, maxHeight)}px`;
+        if (document.activeElement === textarea) {
+          textarea.setSelectionRange(
+            selectionStart,
+            selectionEnd,
+            selectionDirection as "forward" | "backward" | "none",
+          );
+        }
       }
     }, [value, maxHeight]);
 


### PR DESCRIPTION
## What Problem This Solves

Editing text in the middle of CopilotChat's expanded input can move the cursor to the end after each character.

## Why This Change Was Made

The auto-resizing textarea recalculates its height whenever its value changes. This change preserves the focused textarea's selection across that resize and restores it after the final height is applied.

## User Impact

Users can edit text mid-sentence without the cursor jumping to the end.

## Evidence

- `@copilotkit/react-ui` tests: 57 passed
- React UI TypeScript checks passed
- Pre-commit package checks, build, publint, and attw passed

Fixes CopilotKit/CopilotKit#6167
