### PR TITLE
fix(release): make verify:runtime-package pass on channels release PRs

### DIFF
--- a/scripts/release/__tests__/verify-runtime-package.test.ts
+++ b/scripts/release/__tests__/verify-runtime-package.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHANNELS_INTELLIGENCE,
+  createRuntimeConsumerManifest,
+  RUNTIME,
+  workspaceDependencyClosure,
+} from "../lib/pack-workspace.js";
+import type { SourceManifest } from "../lib/pack-workspace.js";
+
+/**
+ * A release PR mid-flight: every first-party version is bumped past what the
+ * registry has (channels 0.3.0 vs. published 0.2.1), and the monorepo packages
+ * are wired together with `workspace:` ranges that `pnpm pack` rewrites into
+ * those unpublished versions.
+ */
+const RELEASE_PR_WORKSPACE: Record<string, SourceManifest> = {
+  [RUNTIME]: {
+    dependencies: {
+      "@copilotkit/channels-core": "workspace:^",
+      [CHANNELS_INTELLIGENCE]: "workspace:*",
+      "@copilotkit/shared": "workspace:*",
+      // Published, externally versioned — must not be packed locally.
+      "@copilotkit/license-verifier": "~0.5.0",
+      express: "^4.21.2",
+    },
+    peerDependencies: { openai: ">=5.0.0" },
+  },
+  "@copilotkit/channels-core": {
+    dependencies: {
+      "@copilotkit/channels-ui": "workspace:~",
+      "@copilotkit/core": "workspace:^",
+      "@copilotkit/shared": "workspace:^",
+    },
+  },
+  [CHANNELS_INTELLIGENCE]: {
+    dependencies: {
+      "@copilotkit/channels-core": "workspace:^",
+      "@copilotkit/channels-ui": "workspace:^",
+    },
+  },
+  "@copilotkit/channels-ui": {
+    dependencies: { "@copilotkit/shared": "workspace:^" },
+  },
+  "@copilotkit/core": {
+    dependencies: { "@copilotkit/shared": "workspace:*" },
+  },
+  "@copilotkit/shared": {
+    dependencies: { "@copilotkit/license-verifier": "~0.5.0" },
+  },
+};
+
+function readManifest(name: string): SourceManifest {
+  const manifest = RELEASE_PR_WORKSPACE[name];
+  if (!manifest) throw new Error(`unexpected package read: ${name}`);
+  return manifest;
+}
+
+const closure = () => workspaceDependencyClosure([RUNTIME], readManifest);
+
+describe("workspaceDependencyClosure", () => {
+  it("reaches every transitive workspace dependency of the runtime", () => {
+    expect([...closure()].sort()).toEqual([
+      "@copilotkit/channels-core",
+      CHANNELS_INTELLIGENCE,
+      "@copilotkit/channels-ui",
+      "@copilotkit/core",
+      "@copilotkit/shared",
+    ]);
+  });
+
+  it("excludes the roots and every non-workspace dependency", () => {
+    const found = closure();
+    expect(found).not.toContain(RUNTIME);
+    // Registry-versioned first-party and third-party deps resolve normally.
+    expect(found).not.toContain("@copilotkit/license-verifier");
+    expect(found).not.toContain("express");
+    expect(found).not.toContain("openai");
+  });
+
+  it("terminates on cyclic workspace graphs", () => {
+    const cyclic: Record<string, SourceManifest> = {
+      a: { dependencies: { "@copilotkit/b": "workspace:*" } },
+      "@copilotkit/b": { dependencies: { "@copilotkit/c": "workspace:*" } },
+      "@copilotkit/c": { dependencies: { "@copilotkit/b": "workspace:*" } },
+    };
+    expect(workspaceDependencyClosure(["a"], (name) => cyclic[name])).toEqual([
+      "@copilotkit/b",
+      "@copilotkit/c",
+    ]);
+  });
+});
+
+describe("createRuntimeConsumerManifest", () => {
+  const overrides = new Map(
+    closure().map((name) => [
+      name,
+      `/tmp/tarballs/${name.replace("@copilotkit/", "copilotkit-")}-0.3.0.tgz`,
+    ]),
+  );
+
+  const manifest = createRuntimeConsumerManifest({
+    runtimeTarball: "/tmp/tarballs/copilotkit-runtime-1.63.2.tgz",
+    packageManager: "pnpm@10.33.4",
+    overrides,
+  }) as {
+    dependencies: Record<string, string>;
+    pnpm?: { overrides: Record<string, string> };
+  };
+
+  it("installs the runtime from its local tarball", () => {
+    expect(manifest.dependencies[RUNTIME]).toBe(
+      "file:/tmp/tarballs/copilotkit-runtime-1.63.2.tgz",
+    );
+  });
+
+  it("pins the unpublished channels version to a local tarball", () => {
+    // Without this the install resolves `@copilotkit/channels-intelligence@0.3.0`
+    // from npm, where this release has not published it yet.
+    expect(manifest.pnpm?.overrides[CHANNELS_INTELLIGENCE]).toBe(
+      `file:${overrides.get(CHANNELS_INTELLIGENCE)}`,
+    );
+  });
+
+  it("leaves no workspace dependency resolvable from the registry", () => {
+    const pinned = manifest.pnpm?.overrides ?? {};
+    for (const name of closure()) {
+      expect(pinned[name], `${name} is not pinned locally`).toMatch(/^file:/);
+    }
+  });
+
+  it("omits the overrides block when nothing needs pinning", () => {
+    expect(
+      createRuntimeConsumerManifest({
+        runtimeTarball: "/tmp/tarballs/copilotkit-runtime-1.63.2.tgz",
+        packageManager: "pnpm@10.33.4",
+        overrides: new Map(),
+      }),
+    ).not.toHaveProperty("pnpm");
+  });
+});

--- a/scripts/release/lib/pack-workspace.ts
+++ b/scripts/release/lib/pack-workspace.ts
@@ -1,0 +1,152 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+);
+
+export type { PackedManifest } from "./channels-umbrella.js";
+import type { PackedManifest } from "./channels-umbrella.js";
+
+export interface SourceManifest {
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+}
+
+export function packageDirectory(name: string): string {
+  return join(ROOT, "packages", name.replace("@copilotkit/", ""));
+}
+
+export function tarballName(manifest: PackedManifest): string {
+  return `${manifest.name.replace(/^@/, "").replace("/", "-")}-${manifest.version}.tgz`;
+}
+
+function capture(command: string, args: string[], cwd = ROOT): string {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    maxBuffer: 10 * 1024 * 1024,
+    env: { ...process.env, CI: "true" },
+  });
+}
+
+function readSourceManifest(name: string): SourceManifest {
+  return JSON.parse(
+    readFileSync(join(packageDirectory(name), "package.json"), "utf8"),
+  ) as SourceManifest;
+}
+
+export function packPackage(
+  name: string,
+  tarballDir: string,
+): { manifest: PackedManifest; tarball: string } {
+  const cwd = packageDirectory(name);
+  const source = JSON.parse(
+    readFileSync(join(cwd, "package.json"), "utf8"),
+  ) as PackedManifest;
+  capture("pnpm", ["pack", "--pack-destination", tarballDir], cwd);
+
+  const tarball = join(tarballDir, tarballName(source));
+  const manifest = JSON.parse(
+    capture("tar", ["-xOf", tarball, "package/package.json"]),
+  ) as PackedManifest;
+
+  return { manifest, tarball };
+}
+
+/**
+ * Every monorepo package reachable from `roots` through the `workspace:`
+ * protocol, excluding the roots themselves.
+ *
+ * `pnpm pack` rewrites `workspace:` ranges to the workspace's current version —
+ * which, on a release PR, is the freshly-bumped version that is not on the
+ * registry until this very release publishes. Packing the whole closure locally
+ * and pinning it through pnpm `overrides` keeps a packed-consumer install
+ * hermetic instead of racing the registry against our own in-flight release.
+ * Discovered transitively so the list never drifts as internal dependencies
+ * change.
+ */
+export function workspaceDependencyClosure(
+  roots: readonly string[],
+  readManifest: (name: string) => SourceManifest = readSourceManifest,
+): string[] {
+  const seen = new Set<string>(roots);
+  const closure: string[] = [];
+  const queue: string[] = [...roots];
+
+  while (queue.length) {
+    const name = queue.shift() as string;
+    const source = readManifest(name);
+    for (const deps of [source.dependencies, source.peerDependencies]) {
+      for (const [dep, range] of Object.entries(deps ?? {})) {
+        if (!dep.startsWith("@copilotkit/")) continue;
+        if (!range.startsWith("workspace:")) continue;
+        if (seen.has(dep)) continue;
+        seen.add(dep);
+        closure.push(dep);
+        queue.push(dep);
+      }
+    }
+  }
+
+  return closure;
+}
+
+/**
+ * Packs `workspaceDependencyClosure(roots)` and returns a name → tarball map
+ * suitable for pnpm `overrides`.
+ */
+export function packWorkspaceClosure(
+  roots: readonly string[],
+  tarballDir: string,
+): Map<string, string> {
+  const tarballs = new Map<string, string>();
+  for (const name of workspaceDependencyClosure(roots)) {
+    tarballs.set(name, packPackage(name, tarballDir).tarball);
+  }
+  return tarballs;
+}
+
+export function toFileOverrides(
+  tarballs: ReadonlyMap<string, string>,
+): Record<string, string> {
+  return Object.fromEntries(
+    [...tarballs].map(([name, tarball]) => [name, `file:${tarball}`]),
+  );
+}
+
+export const RUNTIME = "@copilotkit/runtime";
+export const CHANNELS_INTELLIGENCE = "@copilotkit/channels-intelligence";
+
+interface RuntimeConsumerOptions {
+  runtimeTarball: string;
+  packageManager: string;
+  overrides: ReadonlyMap<string, string>;
+}
+
+export function createRuntimeConsumerManifest({
+  runtimeTarball,
+  packageManager,
+  overrides,
+}: RuntimeConsumerOptions): Record<string, unknown> {
+  const manifest: Record<string, unknown> = {
+    name: "runtime-package-consumer",
+    version: "0.0.0",
+    private: true,
+    type: "module",
+    packageManager,
+    dependencies: {
+      [RUNTIME]: `file:${runtimeTarball}`,
+    },
+  };
+
+  if (overrides.size) {
+    manifest.pnpm = { overrides: toFileOverrides(overrides) };
+  }
+
+  return manifest;
+}

--- a/scripts/release/verify-channels-umbrella.ts
+++ b/scripts/release/verify-channels-umbrella.ts
@@ -16,6 +16,10 @@ import {
   validatePackedManifests,
 } from "./lib/channels-umbrella.js";
 import type { PackedManifest } from "./lib/channels-umbrella.js";
+import {
+  packPackage,
+  workspaceDependencyClosure,
+} from "./lib/pack-workspace.js";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 
@@ -53,70 +57,6 @@ function readJson<T>(path: string): T {
   return JSON.parse(readFileSync(path, "utf8")) as T;
 }
 
-function packageDirectory(name: string): string {
-  return join(ROOT, "packages", name.replace("@copilotkit/", ""));
-}
-
-function tarballName(manifest: PackedManifest): string {
-  return `${manifest.name.replace(/^@/, "").replace("/", "-")}-${manifest.version}.tgz`;
-}
-
-function packPackage(
-  name: string,
-  tarballDir: string,
-): { manifest: PackedManifest; tarball: string } {
-  const cwd = packageDirectory(name);
-  const source = readJson<PackedManifest>(join(cwd, "package.json"));
-  capture("pnpm", ["pack", "--pack-destination", tarballDir], cwd);
-
-  const tarball = join(tarballDir, tarballName(source));
-  const manifest = JSON.parse(
-    capture("tar", ["-xOf", tarball, "package/package.json"]),
-  ) as PackedManifest;
-
-  return { manifest, tarball };
-}
-
-interface SourceManifest {
-  dependencies?: Record<string, string>;
-  peerDependencies?: Record<string, string>;
-}
-
-/**
- * The Channels family depends on monorepo-versioned packages (e.g.
- * `@copilotkit/core`, `@copilotkit/shared`) via the `workspace:` protocol.
- * `pnpm pack` rewrites those ranges to the workspace's current version — which,
- * on a release PR, is the freshly-bumped version that is not on the registry
- * until this very release publishes. Packing them locally too keeps the
- * consumer install hermetic instead of racing the registry against our own
- * in-flight release. Discovered transitively via `workspace:` so the list never
- * drifts as the family's internal dependencies change.
- */
-function workspaceSiblings(): string[] {
-  const seen = new Set<string>(FAMILY);
-  const siblings: string[] = [];
-  const queue: string[] = [...FAMILY];
-
-  while (queue.length) {
-    const name = queue.shift() as string;
-    const source = readJson<SourceManifest>(
-      join(packageDirectory(name), "package.json"),
-    );
-    for (const deps of [source.dependencies, source.peerDependencies]) {
-      for (const [dep, range] of Object.entries(deps ?? {})) {
-        if (!dep.startsWith("@copilotkit/")) continue;
-        if (!range.startsWith("workspace:")) continue;
-        if (seen.has(dep)) continue;
-        seen.add(dep);
-        siblings.push(dep);
-        queue.push(dep);
-      }
-    }
-  }
-
-  return siblings;
-}
-
 function packLocalFamily(tarballDir: string): {
   manifests: Map<string, PackedManifest>;
   tarballs: Map<string, string>;
@@ -132,7 +72,7 @@ function packLocalFamily(tarballDir: string): {
 
   // Pin monorepo siblings to local tarballs too (overrides only — they are not
   // part of the packed-manifest contract that `validatePackedManifests` checks).
-  for (const name of workspaceSiblings()) {
+  for (const name of workspaceDependencyClosure(FAMILY)) {
     const { tarball } = packPackage(name, tarballDir);
     tarballs.set(name, tarball);
   }

--- a/scripts/release/verify-runtime-package.ts
+++ b/scripts/release/verify-runtime-package.ts
@@ -10,26 +10,18 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createConsumerWorkspaceYaml } from "./lib/channels-umbrella.js";
+import {
+  CHANNELS_INTELLIGENCE,
+  createRuntimeConsumerManifest,
+  packPackage,
+  packWorkspaceClosure,
+  RUNTIME,
+} from "./lib/pack-workspace.js";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
-const RUNTIME_DIR = join(ROOT, "packages", "runtime");
-const CHANNELS_INTELLIGENCE = "@copilotkit/channels-intelligence";
 
-interface PackageManifest {
-  name: string;
-  version: string;
+interface RootManifest {
   packageManager?: string;
-  dependencies?: Record<string, string>;
-}
-
-function capture(command: string, args: string[], cwd = ROOT): string {
-  return execFileSync(command, args, {
-    cwd,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-    maxBuffer: 10 * 1024 * 1024,
-    env: { ...process.env, CI: "true" },
-  });
 }
 
 function run(command: string, args: string[], cwd = ROOT): void {
@@ -44,16 +36,9 @@ function readJson<T>(path: string): T {
   return JSON.parse(readFileSync(path, "utf8")) as T;
 }
 
-function tarballName(manifest: PackageManifest): string {
-  return `${manifest.name.replace(/^@/, "").replace("/", "-")}-${manifest.version}.tgz`;
-}
-
 function main(): void {
-  const rootManifest = readJson<PackageManifest>(join(ROOT, "package.json"));
-  const runtimeManifest = readJson<PackageManifest>(
-    join(RUNTIME_DIR, "package.json"),
-  );
-  if (!rootManifest.packageManager) {
+  const { packageManager } = readJson<RootManifest>(join(ROOT, "package.json"));
+  if (!packageManager) {
     throw new Error("root package.json is missing packageManager");
   }
 
@@ -64,14 +49,23 @@ function main(): void {
   mkdirSync(consumerDir);
 
   try {
-    capture("pnpm", ["pack", "--pack-destination", tarballDir], RUNTIME_DIR);
-    const tarball = join(tarballDir, tarballName(runtimeManifest));
-    const packedManifest = JSON.parse(
-      capture("tar", ["-xOf", tarball, "package/package.json"]),
-    ) as PackageManifest;
+    const { manifest: packedManifest, tarball } = packPackage(
+      RUNTIME,
+      tarballDir,
+    );
     if (!packedManifest.dependencies?.[CHANNELS_INTELLIGENCE]) {
       throw new Error(
         `packed runtime must install ${CHANNELS_INTELLIGENCE} as a dependency`,
+      );
+    }
+
+    // Resolve every first-party `workspace:` dependency from a local tarball.
+    // On a release PR the packed ranges name freshly-bumped versions that this
+    // very release is about to publish, so the registry cannot serve them yet.
+    const overrides = packWorkspaceClosure([RUNTIME], tarballDir);
+    if (!overrides.has(CHANNELS_INTELLIGENCE)) {
+      throw new Error(
+        `${CHANNELS_INTELLIGENCE} must be a workspace dependency of the runtime so the packed consumer installs it locally instead of from the registry`,
       );
     }
 
@@ -82,16 +76,11 @@ function main(): void {
     writeFileSync(
       join(consumerDir, "package.json"),
       `${JSON.stringify(
-        {
-          name: "runtime-package-consumer",
-          version: "0.0.0",
-          private: true,
-          type: "module",
-          packageManager: rootManifest.packageManager,
-          dependencies: {
-            "@copilotkit/runtime": `file:${tarball}`,
-          },
-        },
+        createRuntimeConsumerManifest({
+          runtimeTarball: tarball,
+          packageManager,
+          overrides,
+        }),
         null,
         2,
       )}\n`,

--- a/scripts/release/vitest.config.mts
+++ b/scripts/release/vitest.config.mts
@@ -4,7 +4,10 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: true,
-    include: ["scripts/release/lib/**/*.{test,spec}.ts"],
+    include: [
+      "scripts/release/lib/**/*.{test,spec}.ts",
+      "scripts/release/__tests__/**/*.{test,spec}.ts",
+    ],
     reporters: [["default", { summary: false }]],
     silent: true,
   },


### PR DESCRIPTION
Fixes OSS-616

## Problem

`scripts/release/verify-runtime-package.ts` **cannot pass on a channels release PR**, so the `unit (20.x)` leg is red by construction on exactly the PRs the gate exists to protect — and gets merged past.

1. `packages/runtime/package.json` declares `@copilotkit/channels-intelligence: workspace:*`.
2. `pnpm pack` rewrites `workspace:` to the workspace's *current* version — on a release PR, the freshly-bumped one (e.g. `0.3.0`).
3. The temp consumer then has to resolve `@copilotkit/channels-intelligence@0.3.0` **from npm**.
4. That version doesn't exist yet. This PR is what publishes it.

Real CI output from #6185:

```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for
@copilotkit/channels-intelligence@0.3.0 while fetching it from https://registry.npmjs.org/
This error happened while installing the dependencies of @copilotkit/runtime@1.63.2
The latest release of @copilotkit/channels-intelligence is "0.2.1". Published at 7/17/2026
```

Red instances: **#6185** (`channels/v0.3.0`) and **#6025** (`channels/v0.2.1`, merged red on 2026-07-17). #5989 (`v0.2.0`) passed only because the hard runtime dependency landed the next day in `fea464de52`.

## Fix

`verify-channels-umbrella.ts` already solved this — its own comment describes the problem verbatim. Same approach applied here: pack the whole first-party `workspace:` closure locally and pin it through pnpm `overrides` so nothing unpublished is resolved over the network.

The packing helpers (`packPackage`, the transitive `workspace:` walk) move into `scripts/release/lib/pack-workspace.ts`, shared by both scripts instead of duplicated. `verify-channels-umbrella` behavior is unchanged — it just calls the extracted helpers.

**The check is not weakened.** It still asserts the packed runtime declares `@copilotkit/channels-intelligence` as a real dependency and that the package loads through both ESM and CJS. A new guard fails loudly if channels-intelligence ever stops being a `workspace:` dep, so a silent fallback to registry resolution can't creep back in. Runtime dependency ranges were not touched.

## Testing

All runs under Node 20 in a clean worktree off `origin/main`.

**1. Reproduced the failure** — applied the exact 9 version bumps from `release/publish/channels/v0.3.0`, then ran the pre-fix script from `origin/main`:

```
The latest release of @copilotkit/channels-core is "0.2.1". Published at 7/17/2026
Command failed: pnpm install --ignore-scripts
```

**2. Fixed script, same bumped state** — acceptance criterion 1:

```
$ pnpm run verify:runtime-package
OK: packed runtime installs @copilotkit/channels-intelligence and loads through ESM and CJS.
EXIT=0
```

**3. Still fails when the dependency is removed** — deleted `@copilotkit/channels-intelligence` from `packages/runtime/package.json`:

```
packed runtime must install @copilotkit/channels-intelligence as a dependency
EXIT=1
```

**4. Still fails on a genuine ESM load break** — `throw` at the top of `packages/channels-intelligence/src/index.ts`:

```
Error: simulated ESM load break
Command failed: pnpm exec node --experimental-import-meta-resolve --input-type=module --eval ...
EXIT=1
```

**5. Still fails on a genuine CJS load break** — `throw` at the top of `packages/runtime/src/v2/index.ts`:

```
Error: simulated CJS load break
Command failed: pnpm exec node --eval require("@copilotkit/runtime");
EXIT=1
```

**6. Umbrella check unaffected by the helper extraction:**

```
$ pnpm run verify:channels-umbrella
OK: local Channels snapshot is exact, compatible, singly resolved, and TSX-consumable.
```

**7. Release script tests** — new `scripts/release/__tests__/verify-runtime-package.test.ts` models the release-PR case (bumped local versions absent from the registry) and asserts no workspace dependency is left registry-resolvable. The vitest include glob was extended to cover `__tests__/`:

```
Test Files  10 passed (10)
     Tests  137 passed (137)
```

**8.** `oxfmt --check` clean, `oxlint` 0 warnings / 0 errors, `tsc --strict --noEmit` clean on all four touched scripts.

All mutations from steps 1 and 3–5 were reverted; the final diff touches `scripts/release/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
