### PR TITLE
fix(showcase/ci): make a partially-cancelled STARTER build loud

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -225,6 +225,13 @@ jobs:
           GITHUB_REF_NAME_ENV: ${{ github.ref_name }}
           FILTER_CHANGES: ${{ steps.filter.outputs.changes }}
         run: |
+          # `set -euo pipefail` (the sibling "Build starter matrix" step has it,
+          # this one did not): without it, a failing `jq` in the MATRIX=$(...)
+          # assignment below leaves MATRIX empty, the step still exits 0, and it
+          # writes `matrix=` plus `has_changes=true` — which surfaces much later
+          # as an opaque `fromJSON('')` error in the `build` job's strategy
+          # instead of a clear failure here.
+          set -euo pipefail
           # Full service config as JSON
           # Fields: dispatch_name, filter_key, context, image, railway_id, timeout, lfs, build_args, build_args_sha, build_args_branch, dockerfile, health_path, skip_build
           # skip_build (optional, boolean): when true, the Docker build step

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -814,21 +814,42 @@ jobs:
         run: |
           # Mirror of the main `build` matrix's per-slot result write
           # (see "Write per-slot build result" above). job.status is one of
-          # success, failure, cancelled; normalize cancelled→skipped to match
-          # the same {service,status} shape. We publish per-slot via artifact
+          # success, failure, cancelled; each is recorded VERBATIM, in the
+          # same {service,status} shape. We publish per-slot via artifact
           # because matrix-slot outputs aren't aggregable across slots.
+          #
+          # `cancelled` used to be laundered into `skipped` by the `*)`
+          # catch-all here — the same one-line bug #6171 fixed in the
+          # showcase lane, left un-fixed in this one. This artifact is the
+          # ONLY place a leg-level cancellation survives, because GitHub's
+          # status functions cannot see it: `cancelled()` is workflow-scoped
+          # (a leg killed by `timeout-minutes` does not cancel the RUN) and a
+          # CANCELLED ancestor did not FAIL, so `failure()` is false too —
+          # both measured on probe run 30166429073. Collapsed to `skipped`, a
+          # timed-out starter was indistinguishable from one that never
+          # built, and BOTH fail-loud checks in redeploy-staging-starters are
+          # gated on `build-starters.result == 'success'` — which a cancelled
+          # leg rolls up to `cancelled`. Net: no alert, no red run, no
+          # `:latest` advance, no self-heal. Keep it distinct.
+          #
+          # The `*)` catch-all stays as a defensive fallback in case GitHub
+          # ever introduces a fourth job.status value; `skipped` is the
+          # conservative choice because it is excluded from both the redeploy
+          # success-set and the cancelled-slot alert.
           #
           # IMPORTANT: starter artifacts use the `starter-build-result-*`
           # prefix, NOT `build-result-*`. The aggregate-build-results job
           # downloads every `build-result-*` and feeds it to the showcase
           # redeploy set (keyed by showcase dispatch_name). Starters are a
           # separate namespace and must NOT pollute that intersection, so
-          # they get their own prefix. This artifact exists to give the
-          # `notify` job a durable per-starter failure surface.
+          # they get their own prefix. This artifact is what gives the
+          # `notify` and `notify-cancelled-starter-builds` jobs a durable
+          # per-starter failure surface.
           case "$BUILD_STATUS" in
-            success) STATUS=success ;;
-            failure) STATUS=failure ;;
-            *)       STATUS=skipped ;;
+            success)   STATUS=success ;;
+            failure)   STATUS=failure ;;
+            cancelled) STATUS=cancelled ;;
+            *)         STATUS=skipped ;;
           esac
           mkdir -p "$RUNNER_TEMP/starter-build-result"
           printf '{"service":"%s","status":"%s"}\n' "$SERVICE" "$STATUS" \
@@ -1114,6 +1135,18 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+    # Starter analogue of aggregate-build-results' `any_cancelled` /
+    # `cancelled_services`. They are the ONLY downstream signal that one or
+    # more starter build slots were cancelled (in practice: killed by
+    # `timeout-minutes`), derived from the per-slot artifacts rather than from
+    # GitHub's status functions, which are blind to a leg-level cancellation —
+    # see the `notify-cancelled-starter-builds` job below. This job already
+    # downloads and parses every per-slot starter result, so the derivation
+    # rides along here instead of standing up a second aggregator job (the
+    # same reason the success intersection lives here).
+    outputs:
+      any_cancelled: ${{ steps.changed.outputs.any_cancelled }}
+      cancelled_starters: ${{ steps.changed.outputs.cancelled_starters }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1165,6 +1198,22 @@ jobs:
             records="$(find "$RESULTS_DIR" -name result.json -exec cat {} + \
               | jq -sc '.')"
           fi
+          # Cancelled-slot signal, published FIRST so it survives every exit
+          # path below. A starter slot killed by `timeout-minutes` reports
+          # job.status=cancelled and pushes NO image; the per-slot artifact is
+          # the only place that survives (see build-starters' writer and the
+          # `notify-cancelled-starter-builds` job). Emitted unconditionally so
+          # a clean run publishes an explicit 'false' rather than an empty
+          # string — the alert guard tests for 'true', and a SKIPPED job's
+          # outputs are '' either way.
+          cancelled_starters="$(echo "$records" \
+            | jq -r '[.[] | select(.status == "cancelled") | .service] | join(",")')"
+          if [ -n "$cancelled_starters" ]; then
+            echo "any_cancelled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "any_cancelled=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "cancelled_starters=$cancelled_starters" >> "$GITHUB_OUTPUT"
           # Fail-loud artifact-completeness check (Finding 2): every matrix slot
           # writes a result.json ("Write per-slot starter build result" runs
           # `if: always()`), so when ALL slots built (build-starters.result ==
@@ -1374,6 +1423,83 @@ jobs:
           payload: |
             { "text": ${{ toJSON(format(':warning: *Showcase build INCOMPLETE — slots cancelled*{5}Cancelled (no image pushed): `{4}`{5}Staging keeps the previous :latest for those services.{5}Commit: `{0}` by {1}{5}<https://github.com/{2}/actions/runs/{3}|View run>', github.sha, github.actor, github.repository, github.run_id, needs.aggregate-build-results.outputs.cancelled_services, fromJSON('"\n"'))) }} }
 
+  notify-cancelled-starter-builds:
+    name: Notify cancelled/timed-out starter build slots
+    needs: [detect-starter-changes, redeploy-staging-starters]
+    # ── Why this job exists ───────────────────────────────────────────────
+    #
+    # Starter analogue of `notify-cancelled-builds` above. #6171 closed the
+    # silent-partial-cancel hole for the showcase `build` lane only; the
+    # starter lane kept laundering `job.status: cancelled` into `skipped` in
+    # its per-slot writer, so a starter slot killed by `timeout-minutes`
+    # produced NOTHING: no alert, no red run, no `:latest` advance for that
+    # starter, and no self-heal.
+    #
+    # Every pre-existing guard was blind to it, for the reasons measured on
+    # probe run 30166429073 and documented on `notify-cancelled-builds`:
+    #   - `cancelled()` is workflow-scoped → FALSE (the RUN wasn't cancelled);
+    #   - a CANCELLED ancestor did not FAIL → `failure()` FALSE;
+    #   - `build-starters.result` rolls up to `cancelled`, so BOTH fail-loud
+    #     checks in `redeploy-staging-starters` — each gated on
+    #     `== 'success'` — are inert;
+    #   - `notify`'s three clauses were all keyed on the SHOWCASE aggregator,
+    #     which on a starter-only change is itself skipped (its outputs are
+    #     '', not 'false'), so `notify` was SKIPPED too.
+    # The only signal that survives is the per-slot one, which is why the
+    # writer must record `cancelled` verbatim and this job reads it from
+    # `redeploy-staging-starters.outputs.any_cancelled`.
+    #
+    # Like its showcase sibling, this job does the two things a cancelled
+    # slot must do:
+    #   1. RED THE RUN (step 1 exits 1) so the conclusion is `failure`, not
+    #      `cancelled`. A slot killed by its timeout budget IS a failure, and
+    #      `cancelled` is precisely the state that suppressed everything.
+    #   2. ALERT, naming the affected starters so the run can be re-run with
+    #      "Re-run failed jobs".
+    # It does NOT block the healthy subset: `redeploy-staging-starters` has
+    # already redeployed exactly the starters that built.
+    #
+    # `!cancelled()` is the intentional-vs-flake discriminator, same as the
+    # showcase sibling: a human cancelling the whole RUN keeps this silent,
+    # while a leg-level timeout leaves `cancelled()` FALSE so the alert
+    # fires. Belt and braces: on a run-level cancel
+    # `redeploy-staging-starters` is itself skipped by its own `!cancelled()`
+    # guard, so `any_cancelled` would be '' rather than 'true' anyway.
+    if: >-
+      ${{ !cancelled()
+          && needs.detect-starter-changes.outputs.has_changes == 'true'
+          && needs.redeploy-staging-starters.outputs.any_cancelled == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+    env:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+    steps:
+      - name: Mark workflow red (starter build incomplete)
+        env:
+          CANCELLED_STARTERS: ${{ needs.redeploy-staging-starters.outputs.cancelled_starters }}
+        run: |
+          echo "::error::Starter build INCOMPLETE — these starter slots were cancelled (typically killed by timeout-minutes) and pushed NO image: ${CANCELLED_STARTERS}"
+          echo "Those starters were correctly excluded from the staging redeploy (matrix ∩ build-success), so staging still serves their previous :latest."
+          echo "Re-run the failed jobs on this run to finish the starter fleet."
+          exit 1
+      - name: Slack #oss-alerts
+        # `always()` so the alert still goes out after step 1 deliberately
+        # exits non-zero to red the run.
+        if: always() && env.SLACK_WEBHOOK != ''
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          # NOTE: `\n` is NOT an escape sequence in GitHub Actions expression
+          # string literals — `format()` would emit the two literal characters
+          # backslash+n, which `toJSON` then encodes as `\\n`, so Slack renders
+          # a literal "\n". Inject real newlines via `fromJSON('"\n"')` ({5}) so
+          # `toJSON` encodes them as a single `\n` that Slack honors.
+          payload: |
+            { "text": ${{ toJSON(format(':warning: *Starter build INCOMPLETE — slots cancelled*{5}Cancelled (no image pushed): `{4}`{5}Staging keeps the previous :latest for those starters.{5}Commit: `{0}` by {1}{5}<https://github.com/{2}/actions/runs/{3}|View run>', github.sha, github.actor, github.repository, github.run_id, needs.redeploy-staging-starters.outputs.cancelled_starters, fromJSON('"\n"'))) }} }
+
   notify:
     name: Notify on failure
     # Cover the whole detect→build→aggregate→redeploy pipeline. `needs: [build]`
@@ -1434,11 +1560,23 @@ jobs:
     # equals 'true'. `notify-cancelled-builds` fires alongside this job on
     # that path; two alerts for one event is the same convention already used
     # by `notify-all-builds-failed` + this job, and matches the alert SOP.
+    #
+    # The fourth clause is the STARTER-lane equivalent, and it is not
+    # redundant with the third: all three showcase clauses are keyed on the
+    # showcase aggregator, and on a starter-only change
+    # (`detect-changes.has_changes == 'false'`) that aggregator is skipped, so
+    # its outputs are '' — every showcase clause goes false and this job was
+    # SKIPPED on an incomplete starter build. That is the only path on which
+    # the merge author gets a PR comment. Same no-noise argument as above: a
+    # starter build with no cancelled slot emits `any_cancelled=false`, and a
+    # push with no starter changes skips `redeploy-staging-starters` so the
+    # output is '' — neither equals 'true'.
     if: >-
       ${{ !cancelled()
           && (failure()
               || needs.aggregate-build-results.outputs.any_success == 'false'
-              || needs.aggregate-build-results.outputs.any_cancelled == 'true') }}
+              || needs.aggregate-build-results.outputs.any_cancelled == 'true'
+              || needs.redeploy-staging-starters.outputs.any_cancelled == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -1465,8 +1603,11 @@ jobs:
         env:
           # Non-empty only on the partial-cancel path, where the generic
           # "the build failed" wording would be wrong (most slots built and
-          # were redeployed; a subset was killed mid-build).
+          # were redeployed; a subset was killed mid-build). Two vars, one per
+          # lane — a combined push can have cancelled slots in either or both,
+          # and the script joins them into one list.
           CANCELLED_SERVICES: ${{ needs.aggregate-build-results.outputs.cancelled_services }}
+          CANCELLED_STARTERS: ${{ needs.redeploy-staging-starters.outputs.cancelled_starters }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
@@ -1480,7 +1621,11 @@ jobs:
               console.log('No merged PR found for this commit — skipping comment');
               return;
             }
-            const cancelled = (process.env.CANCELLED_SERVICES || '')
+            const cancelled = [
+              process.env.CANCELLED_SERVICES || '',
+              process.env.CANCELLED_STARTERS || '',
+            ]
+              .join(',')
               .split(',')
               .map(s => s.trim())
               .filter(Boolean);

--- a/showcase/scripts/redeploy-guard.test.ts
+++ b/showcase/scripts/redeploy-guard.test.ts
@@ -33,17 +33,97 @@ const WORKFLOW_PATH = join(
   "showcase_build.yml",
 );
 
+interface WorkflowStep {
+  name?: string;
+  run?: string;
+  env?: Record<string, string>;
+  with?: Record<string, string>;
+}
+
+interface WorkflowJob {
+  if?: string;
+  needs?: string[] | string;
+  outputs?: Record<string, string>;
+  steps?: WorkflowStep[];
+}
+
+function readWorkflow(): { jobs: Record<string, WorkflowJob> } {
+  return parseYaml(readFileSync(WORKFLOW_PATH, "utf8"));
+}
+
 /** Read the LIVE `if:` expression of the given job from the workflow YAML. */
 function readJobGuard(jobId: string): string {
-  const doc = parseYaml(readFileSync(WORKFLOW_PATH, "utf8")) as {
-    jobs: Record<string, { if?: string }>;
-  };
-  const job = doc.jobs[jobId];
+  const job = readWorkflow().jobs[jobId];
   if (!job) throw new Error(`Job '${jobId}' not found in ${WORKFLOW_PATH}`);
   if (typeof job.if !== "string") {
     throw new Error(`Job '${jobId}' has no string 'if:' guard`);
   }
   return job.if;
+}
+
+/** Read the LIVE `run:` script of a named step of a named job. */
+function readStepScript(jobId: string, stepName: string): string {
+  const job = readWorkflow().jobs[jobId];
+  if (!job) throw new Error(`Job '${jobId}' not found in ${WORKFLOW_PATH}`);
+  const step = (job.steps ?? []).find((s) => s.name === stepName);
+  if (!step) {
+    throw new Error(`Step '${stepName}' not found in job '${jobId}'`);
+  }
+  if (typeof step.run !== "string") {
+    throw new Error(
+      `Step '${stepName}' of job '${jobId}' has no 'run:' script`,
+    );
+  }
+  return step.run;
+}
+
+/**
+ * Parse the LIVE `case "$BUILD_STATUS" in ... esac` block out of a per-slot
+ * result-writer step and return the function it implements:
+ * `job.status` → the `status` value recorded in the per-slot result artifact.
+ *
+ * This reads the REAL shell out of the REAL workflow rather than restating it,
+ * so deleting or altering an arm changes what these tests observe. That is the
+ * whole point: the per-slot artifact is the ONLY place a leg-level
+ * cancellation survives (GitHub's status functions are blind to it), so the
+ * mapping this `case` implements IS the alerting capability under test.
+ */
+function readSlotStatusMapper(
+  jobId: string,
+  stepName: string,
+): (jobStatus: string) => string {
+  const script = readStepScript(jobId, stepName);
+  const block = script.match(
+    /case\s+"\$BUILD_STATUS"\s+in\s*\n([\s\S]*?)\n\s*esac/,
+  );
+  if (!block) {
+    throw new Error(
+      `No 'case "$BUILD_STATUS" in ... esac' block in step '${stepName}' of job '${jobId}'`,
+    );
+  }
+  const arms: { patterns: string[]; status: string }[] = [];
+  const armRe = /^\s*([^)\n]+?)\)\s*STATUS=(\S+)\s*;;\s*$/gm;
+  let m: RegExpExecArray | null;
+  while ((m = armRe.exec(block[1])) !== null) {
+    arms.push({
+      patterns: m[1].split("|").map((p) => p.trim()),
+      status: m[2],
+    });
+  }
+  if (arms.length === 0) {
+    throw new Error(
+      `Parsed zero case arms in step '${stepName}' of job '${jobId}' — the parser has drifted from the YAML`,
+    );
+  }
+  return (jobStatus: string) => {
+    for (const arm of arms) {
+      // `*` is the only glob these arms use; everything else is a literal.
+      if (arm.patterns.some((p) => p === "*" || p === jobStatus)) {
+        return arm.status;
+      }
+    }
+    throw new Error(`No case arm matched job.status='${jobStatus}'`);
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -302,6 +382,21 @@ function contextFor(
             }
           : { any_success: "", any_cancelled: "", cancelled_services: "" },
       },
+      // The STARTER lane, as it looks on a showcase-only change: no starter
+      // paths changed, so `detect-starter-changes` reports 'false',
+      // `redeploy-staging-starters` is skipped by its own guard, and a skipped
+      // job's outputs resolve to the EMPTY STRING. Modelled explicitly (rather
+      // than omitted) because `notify` reads
+      // `redeploy-staging-starters.outputs.any_cancelled`, and because '' is
+      // exactly what keeps the starter clause from adding noise here.
+      "detect-starter-changes": { outputs: { has_changes: "false" } },
+      "check-lockfile": { result: "success" },
+      "verify-image-refs": { result: "success" },
+      "build-starters": { result: "skipped" },
+      "redeploy-staging": { result: "success" },
+      "redeploy-staging-starters": {
+        outputs: { any_cancelled: "", cancelled_starters: "" },
+      },
     },
   };
 }
@@ -361,8 +456,23 @@ function starterContextFor(
  * enforced one level down.
  */
 function starterRedeployStepRuns(legResults: readonly string[]): boolean {
-  return legResults.includes("success");
+  // Derived through the LIVE case block, not restated: the CSV is built from
+  // records whose recorded `status` is `success`.
+  return legResults.some((leg) => recordStarterSlot(leg) === "success");
 }
+
+/**
+ * The LIVE `job.status` → recorded-`status` mapping for each lane's per-slot
+ * result writer, parsed out of the workflow's own shell.
+ */
+const recordShowcaseSlot = readSlotStatusMapper(
+  "build",
+  "Write per-slot build result",
+);
+const recordStarterSlot = readSlotStatusMapper(
+  "build-starters",
+  "Write per-slot starter build result",
+);
 
 describe("redeploy-staging guard — matrix cancellation regression", () => {
   const guard = readJobGuard("redeploy-staging");
@@ -640,5 +750,290 @@ describe("notify-cancelled-builds guard", () => {
 
   it("does NOT fire when there were no changes to build", () => {
     expect(jobRuns(guard, contextFor([], { hasChanges: false }))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression guard for the SILENT PARTIAL-CANCEL hole in the STARTER lane.
+//
+// #6171 closed this hole for the showcase `build` lane only. The starter lane
+// (`detect-starter-changes` → `build-starters` → `redeploy-staging-starters`)
+// kept laundering `job.status: cancelled` into `skipped` in its per-slot
+// result writer:
+//
+//     case "$BUILD_STATUS" in
+//       success) STATUS=success ;;
+//       failure) STATUS=failure ;;
+//       *)       STATUS=skipped ;;    # ← cancelled lands here
+//     esac
+//
+// The per-slot artifact is the ONLY place a leg-level cancellation survives:
+// `cancelled()` is workflow-scoped (a killed leg does not cancel the RUN) and
+// a CANCELLED ancestor did not FAIL, so `failure()` is false too — both
+// measured on probe run 30166429073. With `cancelled` collapsed to `skipped`,
+// a starter slot killed by `timeout-minutes` was indistinguishable from one
+// that legitimately never built, so:
+//   - the two fail-loud checks in `redeploy-staging-starters` are both gated
+//     on `build-starters.result == 'success'` — and a cancelled leg rolls the
+//     matrix up to `cancelled`, so neither can fire;
+//   - `notify`'s three clauses were all keyed on the SHOWCASE aggregator, so
+//     on a starter-only change (`detect-changes.has_changes == 'false'`) the
+//     aggregator is skipped, its outputs are `''`, and `notify` was SKIPPED;
+//   - nothing redded the run, and nothing named the starter to re-run.
+// Net: no alert, no red, no `:latest` advance, no self-heal.
+// ---------------------------------------------------------------------------
+describe("build-starters per-slot writer — cancelled must not be laundered", () => {
+  it("records a timeout-killed starter slot as 'cancelled', NOT 'skipped'", () => {
+    // RED on pre-fix main: the `*)` catch-all returns 'skipped', which is
+    // excluded from BOTH the redeploy success-set and any cancelled-slot
+    // alert — the laundering that made the whole lane silent.
+    expect(recordStarterSlot("cancelled")).toBe("cancelled");
+  });
+
+  it("records the other job.status values unchanged", () => {
+    expect(recordStarterSlot("success")).toBe("success");
+    expect(recordStarterSlot("failure")).toBe("failure");
+  });
+
+  it("keeps the defensive catch-all conservative (unknown → skipped)", () => {
+    // `skipped` is the conservative fallback for a hypothetical fourth
+    // job.status: excluded from the redeploy set AND from the alert.
+    expect(recordStarterSlot("some-future-github-status")).toBe("skipped");
+  });
+
+  it("is byte-for-byte equivalent to the showcase lane's mapping", () => {
+    // The two lanes' per-slot writers must agree on the contract; a drift
+    // between them is exactly how the starter hole survived #6171.
+    for (const status of [
+      "success",
+      "failure",
+      "cancelled",
+      "some-future-github-status",
+    ]) {
+      expect(recordStarterSlot(status)).toBe(recordShowcaseSlot(status));
+    }
+  });
+
+  it("does not let a cancelled starter into the redeploy set", () => {
+    // Unchanged invariant: a slot that pushed no image can never be deployed.
+    expect(recordStarterSlot("cancelled")).not.toBe("success");
+    expect(starterRedeployStepRuns(["cancelled", "cancelled"])).toBe(false);
+    expect(starterRedeployStepRuns(["success", "cancelled"])).toBe(true);
+  });
+});
+
+/**
+ * Build a GH context for the jobs that consume the starter lane's
+ * cancelled-slot outputs. `any_cancelled` / `cancelled_starters` are derived
+ * from the per-slot records THROUGH THE LIVE CASE BLOCK — so if the writer
+ * ever launders `cancelled` again, these contexts stop reporting it and every
+ * assertion below flips, exactly as production would.
+ *
+ * `redeploy-staging-starters` is skipped (outputs `''`, not `'false'`) when the
+ * whole RUN is cancelled or there are no starter changes, mirroring its own
+ * `!cancelled() && has_changes == 'true'` guard.
+ *
+ * `detect-changes.has_changes` is 'false' and the showcase aggregator's outputs
+ * are `''` throughout: this models a STARTER-ONLY change, the exact shape on
+ * which `notify` was silent.
+ */
+function starterCancelContextFor(
+  legResults: readonly string[],
+  opts: { runCancelled?: boolean; hasChanges?: boolean } = {},
+): GhContext {
+  const runCancelled = opts.runCancelled ?? false;
+  const hasChanges = opts.hasChanges ?? true;
+  const cancelled = legResults
+    .map((leg, i) => ({
+      service: `starter-${i}`,
+      status: recordStarterSlot(leg),
+    }))
+    .filter((r) => r.status === "cancelled")
+    .map((r) => r.service);
+  const starterRedeployRan = !runCancelled && hasChanges;
+  return {
+    runCancelled,
+    needs: {
+      "detect-changes": { outputs: { has_changes: "false" } },
+      "detect-starter-changes": {
+        outputs: { has_changes: String(hasChanges) },
+      },
+      "check-lockfile": { result: "success" },
+      "verify-image-refs": { result: "success" },
+      build: { result: "skipped" },
+      "build-starters": { result: rollupBuildResult(legResults) },
+      "aggregate-build-results": {
+        outputs: { any_success: "", any_cancelled: "", cancelled_services: "" },
+      },
+      "redeploy-staging": { result: "skipped" },
+      "redeploy-staging-starters": {
+        outputs: starterRedeployRan
+          ? {
+              any_cancelled: String(cancelled.length > 0),
+              cancelled_starters: cancelled.join(","),
+            }
+          : { any_cancelled: "", cancelled_starters: "" },
+      },
+    },
+  };
+}
+
+describe("notify-cancelled-starter-builds guard", () => {
+  // Read lazily (inside each test) so a MISSING job fails these tests
+  // individually instead of blowing up collection for the whole file.
+  const runs = (ctx: GhContext) =>
+    jobRuns(
+      readJobGuard("notify-cancelled-starter-builds"),
+      ctx,
+      "build-starters",
+    );
+
+  it("fires on a partial starter cancel (some built, one killed by timeout)", () => {
+    const legs = [...Array(5).fill("success"), "cancelled"];
+    const ctx = starterCancelContextFor(legs);
+    // Every pre-existing signal goes the wrong way — this is the hole.
+    expect(rollupBuildResult(legs)).toBe("cancelled"); // so the `== 'success'`-gated fail-louds are inert
+    expect(anyDepFailed(ctx)).toBe(false); // failure() === false
+    expect(ctx.runCancelled).toBe(false); // cancelled() === false
+    expect(runs(ctx)).toBe(true); // ...and the new guard still fires
+  });
+
+  it("fires when every starter leg was cancelled", () => {
+    expect(runs(starterCancelContextFor(Array(6).fill("cancelled")))).toBe(
+      true,
+    );
+  });
+
+  it("does NOT fire on a clean starter build", () => {
+    expect(runs(starterCancelContextFor(Array(6).fill("success")))).toBe(false);
+  });
+
+  it("does NOT fire on an all-FAILED starter build (that is notify's job)", () => {
+    expect(runs(starterCancelContextFor(Array(6).fill("failure")))).toBe(false);
+  });
+
+  it("does NOT fire when a human cancelled the whole RUN (intentional)", () => {
+    const legs = [...Array(5).fill("success"), "cancelled"];
+    expect(runs(starterCancelContextFor(legs, { runCancelled: true }))).toBe(
+      false,
+    );
+  });
+
+  it("does NOT fire when there were no starter changes", () => {
+    expect(runs(starterCancelContextFor([], { hasChanges: false }))).toBe(
+      false,
+    );
+  });
+});
+
+describe("notify guard — starter-only partial cancel", () => {
+  const guard = readJobGuard("notify");
+  const runs = (ctx: GhContext) => jobRuns(guard, ctx, "build-starters");
+
+  /**
+   * The pre-fix `notify` guard, verbatim from origin/main at the time the
+   * starter hole was found. Pinned as a literal so these tests prove the
+   * DIFFERENCE the fix makes rather than merely restating current behaviour.
+   */
+  const PRE_FIX_GUARD = `\${{ !cancelled()
+          && (failure()
+              || needs.aggregate-build-results.outputs.any_success == 'false'
+              || needs.aggregate-build-results.outputs.any_cancelled == 'true') }}`;
+
+  const partialCancelLegs = [...Array(5).fill("success"), "cancelled"];
+
+  it("RED: the pre-fix guard stays SILENT on a starter-only partial cancel", () => {
+    const ctx = starterCancelContextFor(partialCancelLegs);
+    // A starter-only change skips the showcase aggregator, so all three of the
+    // pre-fix clauses read '' or false. No Slack, no PR comment.
+    expect(jobRuns(PRE_FIX_GUARD, ctx, "build-starters")).toBe(false);
+  });
+
+  it("GREEN: the live guard FIRES on a starter-only partial cancel", () => {
+    expect(runs(starterCancelContextFor(partialCancelLegs))).toBe(true);
+  });
+
+  it("adds no noise: silent on a clean starter-only build", () => {
+    expect(runs(starterCancelContextFor(Array(6).fill("success")))).toBe(false);
+  });
+
+  it("adds no noise: silent when a human cancels the whole RUN", () => {
+    const ctx = starterCancelContextFor(partialCancelLegs, {
+      runCancelled: true,
+    });
+    expect(runs(ctx)).toBe(false);
+  });
+
+  it("adds no noise: silent when there were no starter changes", () => {
+    expect(runs(starterCancelContextFor([], { hasChanges: false }))).toBe(
+      false,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The expression model above proves the GUARDS fire on the right shapes, but
+// it derives `any_cancelled` in TypeScript. These assertions pin the WIRING in
+// between — the parts that carry the signal from the per-slot artifact to the
+// guard — so deleting any single link breaks a test rather than silently
+// re-opening the hole:
+//   build-starters writer records `cancelled`   (covered by recordStarterSlot)
+//     → redeploy-staging-starters derives it from the records   (here)
+//     → and publishes it as a job output                        (here)
+//     → notify-cancelled-starter-builds reads that output       (here)
+//     → and exits non-zero so the run goes RED, not `cancelled` (here)
+// ---------------------------------------------------------------------------
+describe("starter cancelled-slot signal — end-to-end wiring", () => {
+  const workflow = readWorkflow();
+
+  it("redeploy-staging-starters derives the signal from the per-slot records", () => {
+    const script = readStepScript(
+      "redeploy-staging-starters",
+      "Compute successfully-built starter services",
+    );
+    // It must select on the RECORDED status the writer emits — not on the
+    // matrix, not on the rollup.
+    expect(script).toMatch(/select\(\s*\.status\s*==\s*"cancelled"\s*\)/);
+    // ...and publish both halves to $GITHUB_OUTPUT.
+    expect(script).toMatch(/any_cancelled=true/);
+    expect(script).toMatch(/any_cancelled=false/);
+    expect(script).toMatch(/cancelled_starters=\$cancelled_starters/);
+  });
+
+  it("redeploy-staging-starters exposes the signal as job outputs", () => {
+    const job = workflow.jobs["redeploy-staging-starters"];
+    expect(job.outputs?.any_cancelled).toContain(
+      "steps.changed.outputs.any_cancelled",
+    );
+    expect(job.outputs?.cancelled_starters).toContain(
+      "steps.changed.outputs.cancelled_starters",
+    );
+  });
+
+  it("notify-cancelled-starter-builds consumes that output and reds the run", () => {
+    const guard = readJobGuard("notify-cancelled-starter-builds");
+    expect(guard).toContain(
+      "needs.redeploy-staging-starters.outputs.any_cancelled",
+    );
+    const job = workflow.jobs["notify-cancelled-starter-builds"];
+    expect(job.needs).toContain("redeploy-staging-starters");
+    // Step 1 must exit non-zero: that is what turns the run's conclusion from
+    // `cancelled` (which suppresses downstream verification) into `failure`.
+    const redStep = (job.steps ?? [])[0];
+    expect(redStep?.run).toMatch(/exit 1/);
+    // Step 2 must alert, naming the cancelled starters.
+    const alertStep = (job.steps ?? [])[1];
+    expect(alertStep?.with?.payload).toContain(
+      "needs.redeploy-staging-starters.outputs.cancelled_starters",
+    );
+  });
+
+  it("notify's PR comment names the cancelled starters", () => {
+    const job = workflow.jobs["notify"];
+    const comment = (job.steps ?? []).find((s) => s.name === "Comment on PR");
+    expect(comment?.env?.CANCELLED_STARTERS).toContain(
+      "needs.redeploy-staging-starters.outputs.cancelled_starters",
+    );
+    expect(comment?.with?.script).toContain("CANCELLED_STARTERS");
   });
 });


### PR DESCRIPTION
## The hole

#6171 made a partially-cancelled **showcase** build loud. It did not touch the **starter** lane, which had the identical bug — still live on `main` until this PR.

`build-starters`' per-slot result writer had only three `case` arms:

```yaml
# .github/workflows/showcase_build.yml, "Write per-slot starter build result"
case "$BUILD_STATUS" in
  success) STATUS=success ;;
  failure) STATUS=failure ;;
  *)       STATUS=skipped ;;    # ← job.status=cancelled lands here
esac
```

Compare the showcase lane, which #6171 deliberately made four-armed:

```yaml
# same file, "Write per-slot build result"
case "$BUILD_STATUS" in
  success)   STATUS=success ;;
  failure)   STATUS=failure ;;
  cancelled) STATUS=cancelled ;;
  *)         STATUS=skipped ;;
esac
```

That artifact is the **only** place a leg-level cancellation survives. Per probe run [`30166429073`](https://github.com/CopilotKit/CopilotKit/actions/runs/30166429073) (built for #6171): a matrix leg killed by `timeout-minutes` reports `job.status=cancelled`, the rollup `needs.*.result` is `cancelled`, and **both** `if: cancelled()` (workflow-scoped) and `if: failure()` (a cancelled ancestor did not *fail*) evaluate FALSE. Laundered to `skipped`, a timed-out starter became indistinguishable from one that legitimately never built, so:

| guard | why it could not fire |
|---|---|
| `redeploy-staging-starters` artifact-completeness check | `if [ "$BUILD_STARTERS_RESULT" = "success" ] && …` — a cancelled leg rolls the matrix up to `cancelled` |
| `redeploy-staging-starters` empty-deploy-set check | `if [ -z "$csv" ] && [ "$BUILD_STARTERS_RESULT" = "success" ]` — same |
| `notify` | all three clauses keyed on the SHOWCASE aggregator; on a starter-only change `detect-changes.has_changes == 'false'` so that aggregator is skipped and its outputs are `''`, not `'false'`. `failure()` is FALSE (cancelled ≠ failed). Job SKIPPED. |
| `notify-cancelled-builds` (#6171's new job) | **does not cover starters at all.** `needs: [detect-changes, build, aggregate-build-results]`, and its `any_cancelled` comes from the aggregator's `pattern: build-result-*` download — which by design does **not** match `starter-build-result-*` (the prefixes are kept disjoint so starters never pollute the showcase redeploy intersection). |

Net for a timed-out starter slot: no alert, no red run, no `:latest` advance, no self-heal.

**So #6171's notifier needed its own wiring — it was not merely unreachable.**

## The fix

Extends #6171's shape rather than standing up a parallel mechanism:

1. **Stop laundering.** `build-starters`' writer gains `cancelled) STATUS=cancelled ;;`, making the two lanes' mappings identical. The `*)` fallback stays for a hypothetical fourth `job.status`. `showcase/scripts/lib/build-outputs.ts` already admits `cancelled` in `BUILD_OUTCOMES` (from #6171), so no TS contract change was needed.
2. **Derive the signal where the records already are.** `redeploy-staging-starters` publishes `any_cancelled` / `cancelled_starters` as job outputs, computed from the per-slot artifacts it already downloads and parses. No second aggregator job — the same reason the success intersection lives in that job.
3. **Red it and alert.** New `notify-cancelled-starter-builds` mirrors `notify-cancelled-builds`: step 1 `exit 1` so the conclusion is `failure` rather than the `cancelled` that suppressed everything, step 2 Slacks `#oss-alerts` naming the starters. `!cancelled()` is retained as the intentional-vs-flake discriminator (a human run-cancel stays silent).
4. **Tell the merge author.** `notify` gains a fourth clause plus a `CANCELLED_STARTERS` env var, so the PR comment lists cancelled starters alongside cancelled showcase services.

The healthy subset is untouched: `successSet` still excludes `cancelled`, so a starter that pushed no image can never enter the redeploy CSV, and `redeploy-staging-starters` still ships exactly what built before this job fires.

## Red-green

A real Depot timeout is impractical to stage, so the proof is at the layer that carries the signal. `showcase/scripts/redeploy-guard.test.ts` (introduced by #6171) parses the **live** `if:` strings out of the YAML and evaluates them against a model of GitHub's rollup semantics. This PR extends it to also parse the **live `case` block** out of the writer's `run:` script, so the tests observe the real shell rather than a restatement of it.

**RED — on unmodified `origin/main`'s YAML** (the new tests, before any workflow change):

```
 ❯ redeploy-guard.test.ts (47 tests | 9 failed)
   × records a timeout-killed starter slot as 'cancelled', NOT 'skipped'
   × is byte-for-byte equivalent to the showcase lane's mapping
   × fires on a partial starter cancel (some built, one killed by timeout)
   × fires when every starter leg was cancelled
   × does NOT fire on a clean starter build
   × does NOT fire on an all-FAILED starter build (that is notify's job)
   × does NOT fire when a human cancelled the whole RUN (intentional)
   × does NOT fire when there were no starter changes
   × GREEN: the live guard FIRES on a starter-only partial cancel

AssertionError: expected 'skipped' to be 'cancelled'      ← the laundering, read out of the live YAML
Error: Job 'notify-cancelled-starter-builds' not found     ← no alert surface existed
AssertionError: expected false to be true                 ← notify stayed silent

 Tests  9 failed | 38 passed (47)
```

**GREEN — after the fix:**

```
 Test Files  1 passed (1)
      Tests  51 passed (51)
```

### Non-vacuity

The sibling PR's tests asserted shape and stayed green through mutation of the very protections they guarded. So each protection here was reverted independently against the final test file, and each is detected:

| mutation | result |
|---|---|
| baseline (all protections in place) | `51 passed (51)` |
| **M1** re-launder `cancelled`→`skipped` (the actual bug) | `5 failed \| 46 passed` |
| **M2** delete the `notify-cancelled-starter-builds` job | `7 failed \| 44 passed` |
| **M3** drop the starter clause from `notify`'s guard | `1 failed \| 50 passed` |
| **M4** break the `jq` derivation of `cancelled_starters` | `1 failed \| 50 passed` |
| **M5** make the red step `exit 0` instead of `exit 1` | `1 failed \| 50 passed` |
| restored | `51 passed (51)` |

M4 and M5 are why the wiring assertions exist: the expression model derives `any_cancelled` in TypeScript, so without them the `jq` selector could be deleted and the run could stop going red with every other test still green.

The pre-fix `notify` guard is also pinned as a verbatim literal (`PRE_FIX_GUARD`), so the suite encodes the *difference* the fix makes rather than merely asserting current behaviour, and there are explicit no-noise tests: silent on a clean starter build, on an all-failed build, on a human run-cancel, and on a push with no starter changes.

## The `set -euo pipefail` one-liner (second commit, droppable)

A reviewer flagged that the "Build service matrix" step lacks `set -euo pipefail` while its sibling "Build starter matrix" step has it. Confirmed, and it is a one-line change in the same file, so it is included — as its own commit.

Red-green, by extracting the step's script and running it under bash with a malformed `FILTER_CHANGES` (so `jq --argjson` fails):

```
RED   (pre-fix, no set -euo pipefail)  exit=0
    GITHUB_OUTPUT: ['matrix=', 'needs_angular=', 'has_changes=true']   ← becomes fromJSON('') much later
GREEN (post-fix, set -euo pipefail)   exit=2
    GITHUB_OUTPUT: []                                                  ← fails at the source
```

No behaviour change in any legitimate mode — all seven dispatch paths produce identical slot counts and exit codes:

```
OK push, real changes: exit=0  slots=2   has_changes=true
OK push, no changes:   exit=0  slots=0   has_changes=false
OK push, FILTER_CHANGES unset (tests set -u): exit=0  slots=0  has_changes=false
OK dispatch all:       exit=0  slots=28  has_changes=true
OK dispatch single:    exit=0  slots=1   has_changes=true
OK dispatch starter-*: exit=0  slots=0   has_changes=false
OK dispatch typo (must still fail loud): exit=1
```

## Lint

Reported as deltas against the merge base (`origin/main`), not raw counts.

- **actionlint** — 10 findings on base, 10 on head; after normalising file paths and the intra-script line/col offsets that shifted by the 7 added lines, the finding **sets are identical (zero delta)**. All 10 are pre-existing: 2× unknown `depot-ubuntu-24.04-4` runner label, 8× shellcheck `info`/`style` notes on untouched scripts.
- **zizmor** — with the repo's own `.github/zizmor.yml` at CI's `min-severity: low`: *No findings to report* on both base and head. The new job routes `CANCELLED_STARTERS` through `env:` rather than interpolating into `run:`, matching the existing convention and the `template-injection` rule's `ignore: []`.

## Suite

`showcase/scripts` full suite, serial (`--no-file-parallelism`): **72 files / 2365 tests, all passing.** Under default parallelism 1–3 files flake on `/tmp/copilotkit-showcase-generated-data.lock` contention (`acquireGeneratedDataLock: timed out after 30000ms`) — pre-existing test-infra behaviour, unrelated to this change.

## What remains unproven until it runs on `main`

- The **production** starter partial-cancel path end-to-end. The expression semantics are proven on the real YAML; a live Depot timeout on a real starter slot is not.
- The new Slack message and the extended PR comment have not been rendered against a live webhook. The `fromJSON('"\n"')` newline handling copies the convention already in this file verbatim.

## CI, and a live sighting of the same phenomenon (follow-up, not fixed here)

**Final tally: 50 passing, 0 failing, 0 pending** (3 legitimately skipped: `create-check`, `fork-pr-monitor`, `notify`).

Attempt 1 was not clean, and the reason is worth recording. Six `build-check` slots concluded **`cancelled`**, each at exactly its `timeout-minutes` budget:

| slot | budget | died at |
|---|---|---|
| `shell` | 10 | 10m03s |
| `shell-dashboard` | 10 | 10m02s |
| `shell-docs` | 10 | 10m02s |
| `shell-dojo` | 10 | 10m02s |
| `mastra` | 15 | 15m04s |
| `showcase-aimock` | 5 | 5m02s |

Not this change: the diff is two files (a `case` arm, three job outputs, one new job, one `set -euo pipefail`) and touches no Dockerfile, no build context, and nothing `showcase_build_check.yml` reads. It is Depot contention — `showcase_build_check.yml`'s paths-filter includes `.github/workflows/showcase_build.yml`, so any edit to that file forces a full 28-slot PR-side rebuild, and PR#5900 had one in flight concurrently. #6171's own PR ran the identical full fleet with the identical budgets and every slot finished in **2–6 minutes**. "Re-run failed jobs" cleared all six in under four minutes.

The follow-up this exposes: **#6171 raised the timeout budgets in `showcase_build.yml` but not in `showcase_build_check.yml`**, which still carries the pre-#6171 values (`shell` 10, `showcase-aimock` 5) that were measured as too tight under contention. Left out of this PR deliberately — it is the same mitigation-not-root-fix tradeoff #6171 documented, and it does not belong in a starter-lane alerting fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYdjeveT8Xof9TyHWMLoJr
