### PR TITLE
fix(docs): correct the documented Intelligence endpoints for Channels

### DIFF
--- a/examples/slack/.env.example
+++ b/examples/slack/.env.example
@@ -50,12 +50,12 @@ OPENAI_API_KEY=sk-...
 # supply — the runtime derives project/adapter/channel from the config below
 # plus the channel name chosen in code).
 # Intelligence platform API base URL.
-COPILOTKIT_INTELLIGENCE_URL=https://api.copilotkit.ai
+COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
+# Websocket base URL for the realtime plane. This is a DIFFERENT host from the
+# API URL above (api.… vs realtime.…), so it cannot be derived from it — set both.
+COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 # Project runtime API key (cpk-…).
 COPILOTKIT_API_KEY=cpk-...
-# Optional: websocket base URL. Derived from COPILOTKIT_INTELLIGENCE_URL by a
-# scheme-only swap (http→ws, same host+port) when unset.
-# COPILOTKIT_INTELLIGENCE_WS_URL=
 # Optional: port for the Intelligence runtime that owns the Channel lifecycle
 # (loopback-only; keeps the process alive; distinct from WhatsApp's $PORT
 # webhook). Defaults to 8300.

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -117,7 +117,8 @@ bot.onMention(async ({ thread, message }) => {
 // lifecycle — it starts the direct Slack adapter for us.
 const intelligence = new CopilotKitIntelligence({
   apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
-  wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!, // or derive from apiUrl
+  // Separate host from apiUrl (api.… vs realtime.…) — not derivable from it.
+  wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
   apiKey: process.env.COPILOTKIT_API_KEY!,
 });
 const runtime = new CopilotRuntime({

--- a/examples/slack/app/index.ts
+++ b/examples/slack/app/index.ts
@@ -77,13 +77,6 @@ const required = (name: string): string => {
 const have = (...names: string[]): boolean =>
   names.every((n) => Boolean(process.env[n]));
 
-/**
- * Derive the Intelligence websocket base URL from the API base URL when it
- * isn't set explicitly: `http(s)://…` → `ws(s)://…` (same host + port).
- */
-const deriveWsUrl = (apiUrl: string): string =>
-  apiUrl.replace(/^http(s?):\/\//, "ws$1://");
-
 async function main() {
   const agentUrl = required("AGENT_URL");
   const agentHeaders = process.env.AGENT_AUTH_HEADER
@@ -287,12 +280,11 @@ async function main() {
   // The Intelligence client the Channel-owning runtime is configured with. A
   // Channel runs only through the Intelligence runtime — the direct adapters
   // keep their own platform credentials, but the runtime is what starts them.
-  const intelligenceApiUrl = required("COPILOTKIT_INTELLIGENCE_URL");
+  // Both URLs are required: the API and realtime planes are separate hosts
+  // (api.… vs realtime.…), so neither can be derived from the other.
   const intelligence = new CopilotKitIntelligence({
-    apiUrl: intelligenceApiUrl,
-    wsUrl:
-      process.env.COPILOTKIT_INTELLIGENCE_WS_URL ??
-      deriveWsUrl(intelligenceApiUrl),
+    apiUrl: required("COPILOTKIT_INTELLIGENCE_URL"),
+    wsUrl: required("COPILOTKIT_INTELLIGENCE_WS_URL"),
     apiKey: required("COPILOTKIT_API_KEY"),
   });
 

--- a/examples/slack/app/managed.test.ts
+++ b/examples/slack/app/managed.test.ts
@@ -83,7 +83,9 @@ describe("managed channel entrypoint", () => {
     for (const key of envKeys) previousEnv.set(key, process.env[key]);
     process.env.AGENT_URL = "http://agent.test/run";
     process.env.COPILOTKIT_INTELLIGENCE_URL = "http://localhost:4201";
-    delete process.env.COPILOTKIT_INTELLIGENCE_WS_URL;
+    // Required, and deliberately a different host+port from the API URL: the
+    // realtime plane is deployed separately, so there is no derive from apiUrl.
+    process.env.COPILOTKIT_INTELLIGENCE_WS_URL = "ws://localhost:4401";
     process.env.COPILOTKIT_API_KEY = "cpk-test";
 
     let sigterm: (() => void) | undefined;

--- a/examples/slack/app/managed.ts
+++ b/examples/slack/app/managed.ts
@@ -52,14 +52,6 @@ const required = (name: string): string => {
 };
 
 /**
- * Derive the Intelligence websocket base URL from the API base URL when it
- * isn't set explicitly: `http(s)://…` → `ws(s)://…`. The runner + client socket
- * URLs are derived from this by the client.
- */
-const deriveWsUrl = (apiUrl: string): string =>
-  apiUrl.replace(/^http(s?):\/\//, "ws$1://");
-
-/**
  * The managed Channel `name` is chosen HERE, in code — it is the project-unique
  * identifier the runtime uses to derive the managed Channel's activation config
  * (there is no launcher and no `INTELLIGENCE_CHANNEL_*` env to supply).
@@ -133,10 +125,11 @@ async function main() {
   // (plus the channel `name`) the runtime derives the managed Channel's
   // activation config — project id, adapter, socket URL/auth — with no infra
   // ids supplied by the developer.
-  const apiUrl = required("COPILOTKIT_INTELLIGENCE_URL");
+  // Both URLs are required: the API and realtime planes are separate hosts
+  // (api.… vs realtime.…), so neither can be derived from the other.
   const intelligence = new CopilotKitIntelligence({
-    apiUrl,
-    wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL ?? deriveWsUrl(apiUrl),
+    apiUrl: required("COPILOTKIT_INTELLIGENCE_URL"),
+    wsUrl: required("COPILOTKIT_INTELLIGENCE_WS_URL"),
     apiKey: required("COPILOTKIT_API_KEY"),
   });
 

--- a/examples/teams/.env.example
+++ b/examples/teams/.env.example
@@ -8,12 +8,12 @@ OPENAI_API_KEY=
 # DIRECT (no Microsoft creds needed in the Playground), but the runtime that
 # starts/stops it is configured with an Intelligence key. Free tier is enough.
 # Intelligence platform API base URL.
-COPILOTKIT_INTELLIGENCE_URL=https://api.copilotkit.ai
+COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
+# Websocket base URL for the realtime plane. This is a DIFFERENT host from the
+# API URL above (api.… vs realtime.…), so it cannot be derived from it — set both.
+COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 # Project runtime API key (cpk-…).
 COPILOTKIT_API_KEY=cpk-...
-# Optional: websocket base URL. Derived from COPILOTKIT_INTELLIGENCE_URL by a
-# scheme-only swap (http→ws, same host+port) when unset.
-# COPILOTKIT_INTELLIGENCE_WS_URL=
 
 # The Microsoft 365 Agents Playground connects to the bot anonymously, so NO
 # Microsoft credentials are needed for local development. Just run `pnpm start`.

--- a/examples/teams/README.md
+++ b/examples/teams/README.md
@@ -23,7 +23,8 @@ From this directory (after `pnpm install` at the repo root):
 
 ```sh
 export OPENAI_API_KEY=sk-...              # or add it to .env (see .env.example)
-export COPILOTKIT_INTELLIGENCE_URL=https://api.copilotkit.ai
+export COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
+export COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 export COPILOTKIT_API_KEY=cpk-...          # Intelligence key (free tier)
 pnpm start                                 # starts the bot on http://localhost:3978/api/messages
 ```
@@ -177,12 +178,15 @@ Set the environment for wherever you deploy:
 - `OPENAI_API_KEY` _(required)_: the bot runs a `BuiltInAgent` and exits at
   startup without it.
 - `OPENAI_MODEL` _(optional)_: defaults to `openai/gpt-5.5`.
-- `COPILOTKIT_INTELLIGENCE_URL` / `COPILOTKIT_API_KEY` _(required)_: the
-  Intelligence runtime that owns the Channel lifecycle. A Channel runs only
-  through Intelligence, so the bot exits at startup without these (free tier is
-  enough).
-- `COPILOTKIT_INTELLIGENCE_WS_URL` _(optional)_: websocket base URL; derived from
-  `COPILOTKIT_INTELLIGENCE_URL` (http→ws, same host+port) when unset.
+- `COPILOTKIT_INTELLIGENCE_URL` / `COPILOTKIT_INTELLIGENCE_WS_URL` /
+  `COPILOTKIT_API_KEY` _(all required)_: the Intelligence runtime that owns the
+  Channel lifecycle. A Channel runs only through Intelligence, so the bot exits
+  at startup without these (free tier is enough). The API and realtime planes are
+  **separate hosts** (`api.intelligence.copilotkit.ai` vs
+  `realtime.intelligence.copilotkit.ai`), so the websocket URL cannot be derived
+  from the API URL by swapping the scheme — both are shown on your project's
+  Intelligence dashboard. Getting the websocket host wrong does not produce an
+  error; the Channel sits in `connecting` until it times out.
 - `CHANNELS_PORT` _(optional)_: port for the Intelligence runtime that owns the
   Channel (loopback-only, default 8300).
 - `clientId` / `clientSecret` / `tenantId`: needed to reach real Teams (see

--- a/examples/teams/app/index.tsx
+++ b/examples/teams/app/index.tsx
@@ -70,21 +70,16 @@ const required = (name: string): string => {
       `Missing ${name}.\n` +
         "Channels run only through the Intelligence runtime, which needs an " +
         "Intelligence key (free tier).\n" +
-        "  export COPILOTKIT_INTELLIGENCE_URL=https://api.copilotkit.ai\n" +
+        "  export COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai\n" +
+        "  export COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai\n" +
         "  export COPILOTKIT_API_KEY=cpk-...   (or add them to examples/teams/.env)\n" +
-        "Optional: COPILOTKIT_INTELLIGENCE_WS_URL (derived from the API URL when unset).",
+        "The API and websocket URLs are DIFFERENT hosts (api.… vs realtime.…), so\n" +
+        "the websocket URL cannot be derived from the API URL — set both.",
     );
     process.exit(1);
   }
   return v;
 };
-
-/**
- * Derive the Intelligence websocket base URL from the API base URL when it
- * isn't set explicitly: `http(s)://…` → `ws(s)://…` (same host + port).
- */
-const deriveWsUrl = (apiUrl: string): string =>
-  apiUrl.replace(/^http(s?):\/\//, "ws$1://");
 
 const port = Number(process.env.PORT ?? 3978);
 
@@ -241,12 +236,11 @@ bot.onMessage(async ({ thread, message }) => {
 // Teams adapter stays DIRECT (it keeps its own credentials/transport), but a
 // Channel runs only through the Intelligence runtime, so the runtime is what
 // starts and stops it.
-const intelligenceApiUrl = required("COPILOTKIT_INTELLIGENCE_URL");
+// Both URLs are required: the API and realtime planes are separate hosts, so
+// there is no derive that produces one from the other.
 const intelligence = new CopilotKitIntelligence({
-  apiUrl: intelligenceApiUrl,
-  wsUrl:
-    process.env.COPILOTKIT_INTELLIGENCE_WS_URL ??
-    deriveWsUrl(intelligenceApiUrl),
+  apiUrl: required("COPILOTKIT_INTELLIGENCE_URL"),
+  wsUrl: required("COPILOTKIT_INTELLIGENCE_WS_URL"),
   apiKey: required("COPILOTKIT_API_KEY"),
 });
 

--- a/packages/channels-core/README.md
+++ b/packages/channels-core/README.md
@@ -81,8 +81,10 @@ const channel = createChannel({
 
 const runtime = new CopilotRuntime({
   intelligence: new CopilotKitIntelligence({
-    apiUrl: "https://api.copilotkit.ai",
-    wsUrl: "wss://api.copilotkit.ai",
+    // The API and realtime planes are DIFFERENT hosts — do not scheme-swap one
+    // into the other. Both are shown on your project's Intelligence dashboard.
+    apiUrl: "https://api.intelligence.copilotkit.ai",
+    wsUrl: "wss://realtime.intelligence.copilotkit.ai",
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
   identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),

--- a/packages/channels-discord/README.md
+++ b/packages/channels-discord/README.md
@@ -63,8 +63,10 @@ bot.onMention(({ thread }) => thread.runAgent());
 // The runtime owns the channel's lifecycle — there is no `bot.start()`.
 const runtime = new CopilotRuntime({
   intelligence: new CopilotKitIntelligence({
-    apiUrl: "https://api.copilotkit.ai",
-    wsUrl: "wss://api.copilotkit.ai",
+    // The API and realtime planes are DIFFERENT hosts — do not scheme-swap one
+    // into the other. Both are shown on your project's Intelligence dashboard.
+    apiUrl: "https://api.intelligence.copilotkit.ai",
+    wsUrl: "wss://realtime.intelligence.copilotkit.ai",
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
   identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.test.ts
@@ -246,7 +246,7 @@ describe("startChannelsOverRealtimeGateway — fail-fast validation (OSS-406)", 
 
     await expect(
       startChannelsOverRealtimeGateway([bot], {
-        wsUrl: "wss://gateway.example/socket",
+        wsUrl: "wss://gateway.example/runner",
         apiKey: "cpk-test",
         scope: { ...scope, channelId: "bot_1" },
         runtimeInstanceId: "rti_1",
@@ -272,7 +272,7 @@ describe("startChannelsOverRealtimeGateway — fail-fast validation (OSS-406)", 
 
     await expect(
       startChannelsOverRealtimeGateway([a, b], {
-        wsUrl: "wss://gateway.example/socket",
+        wsUrl: "wss://gateway.example/runner",
         apiKey: "cpk-test",
         scope,
         runtimeInstanceId: "rti_1",
@@ -298,7 +298,7 @@ describe("startChannelsOverRealtimeGateway — fail-fast validation (OSS-406)", 
 
     await expect(
       startChannelsOverRealtimeGateway([a, b], {
-        wsUrl: "wss://gateway.example/socket",
+        wsUrl: "wss://gateway.example/runner",
         apiKey: "cpk-test",
         scope,
         runtimeInstanceId: "rti_1",
@@ -493,7 +493,7 @@ describe("startChannelsOverRealtimeGateway — socket lifecycle cleanup (OSS-406
 
     await expect(
       startChannelsOverRealtimeGateway([bot], {
-        wsUrl: "wss://gateway.example/socket",
+        wsUrl: "wss://gateway.example/runner",
         apiKey: "cpk-test",
         scope,
         runtimeInstanceId: "rti_1",
@@ -515,7 +515,7 @@ describe("startChannelsOverRealtimeGateway — socket lifecycle cleanup (OSS-406
 
     await expect(
       startChannelsOverRealtimeGateway([bot], {
-        wsUrl: "wss://gateway.example/socket",
+        wsUrl: "wss://gateway.example/runner",
         apiKey: "cpk-test",
         scope,
         runtimeInstanceId: "rti_1",
@@ -546,7 +546,7 @@ describe("startChannelsOverRealtimeGateway — socket lifecycle cleanup (OSS-406
 
     await expect(
       startChannelsOverRealtimeGateway([bot], {
-        wsUrl: "wss://gateway.example/socket",
+        wsUrl: "wss://gateway.example/runner",
         apiKey: "cpk-test",
         scope,
         runtimeInstanceId: "rti_1",
@@ -571,7 +571,7 @@ describe("startChannelsOverRealtimeGateway — onClose drop notification (OSS-47
     });
 
     const handle = await startChannelsOverRealtimeGateway([bot], {
-      wsUrl: "wss://gateway.example/socket",
+      wsUrl: "wss://gateway.example/runner",
       apiKey: "cpk-test",
       scope,
       runtimeInstanceId: "rti_1",
@@ -599,7 +599,7 @@ describe("startChannelsOverRealtimeGateway — onClose drop notification (OSS-47
     });
 
     const handle = await startChannelsOverRealtimeGateway([bot], {
-      wsUrl: "wss://gateway.example/socket",
+      wsUrl: "wss://gateway.example/runner",
       apiKey: "cpk-test",
       scope,
       runtimeInstanceId: "rti_1",

--- a/packages/channels-intelligence/src/realtime-gateway.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.test.ts
@@ -220,7 +220,7 @@ describe("connectRealtimeGateway", () => {
 
     await expect(
       connectRealtimeGateway({
-        wsUrl: "wss://gateway.example/socket",
+        wsUrl: "wss://gateway.example/runner",
         apiKey: "cpk-test",
         projectId: 0,
         join: {
@@ -243,7 +243,7 @@ describe("connectRealtimeGateway", () => {
     };
 
     const session = await connectRealtimeGateway({
-      wsUrl: "wss://gateway.example/socket",
+      wsUrl: "wss://gateway.example/runner",
       apiKey: "cpk-test",
       projectId: 7,
       join,
@@ -266,7 +266,7 @@ describe("connectRealtimeGateway — onClose drop notification (OSS-473)", () =>
   it("fires a registered onClose callback exactly once when the socket drops unexpectedly", async () => {
     const { FakeWebSocket, instances } = makeFakeWebSocket("ok");
     const session = await connectRealtimeGateway({
-      wsUrl: "wss://gateway.example/socket",
+      wsUrl: "wss://gateway.example/runner",
       apiKey: "cpk-test",
       projectId: 7,
       join: {
@@ -293,7 +293,7 @@ describe("connectRealtimeGateway — onClose drop notification (OSS-473)", () =>
   it("fires onClose again for a second drop after the socket reopens", async () => {
     const { FakeWebSocket, instances } = makeFakeWebSocket("ok");
     const session = await connectRealtimeGateway({
-      wsUrl: "wss://gateway.example/socket",
+      wsUrl: "wss://gateway.example/runner",
       apiKey: "cpk-test",
       projectId: 7,
       join: {
@@ -337,7 +337,7 @@ describe("connectRealtimeGateway — onClose drop notification (OSS-473)", () =>
   it("does not fire onClose when the drop is our own disconnect()", async () => {
     const { FakeWebSocket, instances } = makeFakeWebSocket("ok");
     const session = await connectRealtimeGateway({
-      wsUrl: "wss://gateway.example/socket",
+      wsUrl: "wss://gateway.example/runner",
       apiKey: "cpk-test",
       projectId: 7,
       join: {
@@ -362,7 +362,7 @@ describe("connectRealtimeGateway — onClose drop notification (OSS-473)", () =>
   it("still fires later onClose callbacks when an earlier one throws", async () => {
     const { FakeWebSocket, instances } = makeFakeWebSocket("ok");
     const session = await connectRealtimeGateway({
-      wsUrl: "wss://gateway.example/socket",
+      wsUrl: "wss://gateway.example/runner",
       apiKey: "cpk-test",
       projectId: 7,
       join: {
@@ -394,7 +394,7 @@ describe("connectRealtimeGateway — join failure teardown (OSS-473)", () => {
 
     await expect(
       connectRealtimeGateway({
-        wsUrl: "wss://gateway.example/socket",
+        wsUrl: "wss://gateway.example/runner",
         apiKey: "cpk-test",
         projectId: 7,
         join: {
@@ -417,7 +417,7 @@ describe("connectRealtimeGateway — join failure teardown (OSS-473)", () => {
 
     await expect(
       connectRealtimeGateway({
-        wsUrl: "wss://gateway.example/socket",
+        wsUrl: "wss://gateway.example/runner",
         apiKey: "cpk-test",
         projectId: 7,
         join: {
@@ -437,7 +437,7 @@ describe("connectRealtimeGateway — join failure teardown (OSS-473)", () => {
 
     await expect(
       connectRealtimeGateway({
-        wsUrl: "wss://gateway.example/socket",
+        wsUrl: "wss://gateway.example/runner",
         apiKey: "cpk-test",
         projectId: 7,
         join: {
@@ -462,7 +462,7 @@ describe("connectRealtimeGateway — per-channel state classification (OSS-473)"
     );
 
     const err = await connectRealtimeGateway({
-      wsUrl: "wss://gateway.example/socket",
+      wsUrl: "wss://gateway.example/runner",
       apiKey: "cpk-test",
       projectId: 7,
       join: {
@@ -499,7 +499,7 @@ describe("connectRealtimeGateway — per-channel state classification (OSS-473)"
     );
 
     const err = await connectRealtimeGateway({
-      wsUrl: "wss://gateway.example/socket",
+      wsUrl: "wss://gateway.example/runner",
       apiKey: "cpk-test",
       projectId: 7,
       join: {
@@ -523,7 +523,7 @@ describe("connectRealtimeGateway — per-channel state classification (OSS-473)"
     const { FakeWebSocket, instances } = makeFakeWebSocket("error-conflict");
 
     const err = await connectRealtimeGateway({
-      wsUrl: "wss://gateway.example/socket",
+      wsUrl: "wss://gateway.example/runner",
       apiKey: "cpk-test",
       projectId: 7,
       join: {
@@ -554,7 +554,7 @@ describe("connectRealtimeGateway — per-channel state classification (OSS-473)"
     const { FakeWebSocket } = makeFakeWebSocket("error-mixed");
 
     const err = await connectRealtimeGateway({
-      wsUrl: "wss://gateway.example/socket",
+      wsUrl: "wss://gateway.example/runner",
       apiKey: "cpk-test",
       projectId: 7,
       join: {
@@ -589,7 +589,7 @@ describe("connectRealtimeGateway — connection-health state (OSS-473)", () => {
   it("transitions to reconnecting on an unexpected drop and back to online on a successful rejoin", async () => {
     const { FakeWebSocket, instances } = makeFakeWebSocket("ok");
     const session = await connectRealtimeGateway({
-      wsUrl: "wss://gateway.example/socket",
+      wsUrl: "wss://gateway.example/runner",
       apiKey: "cpk-test",
       projectId: 7,
       join: {
@@ -618,7 +618,7 @@ describe("connectRealtimeGateway — connection-health state (OSS-473)", () => {
   it("transitions to reconnecting on a channel-level error while the socket stays open, then back to online on channel rejoin", async () => {
     const { FakeWebSocket, instances } = makeFakeWebSocket("ok");
     const session = await connectRealtimeGateway({
-      wsUrl: "wss://gateway.example/socket",
+      wsUrl: "wss://gateway.example/runner",
       apiKey: "cpk-test",
       projectId: 7,
       join: {
@@ -652,7 +652,7 @@ describe("connectRealtimeGateway — connection-health state (OSS-473)", () => {
   it("surfaces a superseded listener as fenced instead of pretending Phoenix will rejoin it", async () => {
     const { FakeWebSocket, instances } = makeFakeWebSocket("ok");
     const session = await connectRealtimeGateway({
-      wsUrl: "wss://gateway.example/socket",
+      wsUrl: "wss://gateway.example/runner",
       apiKey: "cpk-test",
       projectId: 7,
       join: {
@@ -681,7 +681,7 @@ describe("connectRealtimeGateway — connection-health state (OSS-473)", () => {
   it("gives up (emits gave_up) when the reconnect window elapses without a successful rejoin", async () => {
     const { FakeWebSocket, instances } = makeFakeWebSocket("ok-then-silent");
     const session = await connectRealtimeGateway({
-      wsUrl: "wss://gateway.example/socket",
+      wsUrl: "wss://gateway.example/runner",
       apiKey: "cpk-test",
       projectId: 7,
       join: {
@@ -712,7 +712,7 @@ describe("connectRealtimeGateway — connection-health state (OSS-473)", () => {
       "give-up-then-recover",
     );
     const session = await connectRealtimeGateway({
-      wsUrl: "wss://gateway.example/socket",
+      wsUrl: "wss://gateway.example/runner",
       apiKey: "cpk-test",
       projectId: 7,
       join: {
@@ -749,7 +749,7 @@ describe("connectRealtimeGateway — connection-health state (OSS-473)", () => {
       "give-up-then-recover",
     );
     const session = await connectRealtimeGateway({
-      wsUrl: "wss://gateway.example/socket",
+      wsUrl: "wss://gateway.example/runner",
       apiKey: "cpk-test",
       projectId: 7,
       join: {
@@ -800,7 +800,7 @@ describe("connectRealtimeGateway — connection-health state (OSS-473)", () => {
   it("does not emit a connection-state transition for our own disconnect()", async () => {
     const { FakeWebSocket, instances } = makeFakeWebSocket("ok");
     const session = await connectRealtimeGateway({
-      wsUrl: "wss://gateway.example/socket",
+      wsUrl: "wss://gateway.example/runner",
       apiKey: "cpk-test",
       projectId: 7,
       join: {

--- a/packages/channels-intelligence/src/realtime-gateway.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.ts
@@ -12,7 +12,13 @@ export interface RealtimeGatewaySession {
 
 /** @internal Options for {@link connectRealtimeGateway}. */
 export interface ConnectRealtimeGatewayOptions {
-  /** Gateway socket URL, e.g. `wss://gateway.example/socket`. */
+  /**
+   * Fully-resolved gateway **runner** socket URL, e.g.
+   * `wss://gateway.example/runner`. This is not the public `wsUrl` a developer
+   * configures — the Intelligence client appends the `/runner` (or `/client`)
+   * suffix to that base before it reaches here, and Phoenix appends
+   * `/websocket` to this value on connect. `/socket` is not a mounted path.
+   */
   wsUrl: string;
   /** Runtime API key (`cpk-…`) authenticating the socket. */
   apiKey: string;

--- a/packages/channels-slack/README.md
+++ b/packages/channels-slack/README.md
@@ -53,8 +53,10 @@ bot.onMention(({ thread }) => thread.runAgent());
 // The runtime owns the channel's lifecycle — there is no `bot.start()`.
 const runtime = new CopilotRuntime({
   intelligence: new CopilotKitIntelligence({
-    apiUrl: "https://api.copilotkit.ai",
-    wsUrl: "wss://api.copilotkit.ai",
+    // The API and realtime planes are DIFFERENT hosts — do not scheme-swap one
+    // into the other. Both are shown on your project's Intelligence dashboard.
+    apiUrl: "https://api.intelligence.copilotkit.ai",
+    wsUrl: "wss://realtime.intelligence.copilotkit.ai",
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
   identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),

--- a/packages/channels-teams/README.md
+++ b/packages/channels-teams/README.md
@@ -43,8 +43,10 @@ bot.onMessage(({ thread, message }) => thread.post(`Echo: ${message.text}`));
 // The runtime owns the channel's lifecycle — there is no `bot.start()`.
 const runtime = new CopilotRuntime({
   intelligence: new CopilotKitIntelligence({
-    apiUrl: "https://api.copilotkit.ai",
-    wsUrl: "wss://api.copilotkit.ai",
+    // The API and realtime planes are DIFFERENT hosts — do not scheme-swap one
+    // into the other. Both are shown on your project's Intelligence dashboard.
+    apiUrl: "https://api.intelligence.copilotkit.ai",
+    wsUrl: "wss://realtime.intelligence.copilotkit.ai",
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
   identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),

--- a/packages/channels-telegram/README.md
+++ b/packages/channels-telegram/README.md
@@ -74,8 +74,10 @@ bot.onThreadStarted(async ({ thread }) => {
 // The runtime owns the channel's lifecycle — there is no `bot.start()`.
 const runtime = new CopilotRuntime({
   intelligence: new CopilotKitIntelligence({
-    apiUrl: "https://api.copilotkit.ai",
-    wsUrl: "wss://api.copilotkit.ai",
+    // The API and realtime planes are DIFFERENT hosts — do not scheme-swap one
+    // into the other. Both are shown on your project's Intelligence dashboard.
+    apiUrl: "https://api.intelligence.copilotkit.ai",
+    wsUrl: "wss://realtime.intelligence.copilotkit.ai",
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
   identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),

--- a/packages/channels-whatsapp/README.md
+++ b/packages/channels-whatsapp/README.md
@@ -58,8 +58,10 @@ bot.onMessage(async ({ thread }) => {
 // The runtime owns the channel's lifecycle — there is no `bot.start()`.
 const runtime = new CopilotRuntime({
   intelligence: new CopilotKitIntelligence({
-    apiUrl: "https://api.copilotkit.ai",
-    wsUrl: "wss://api.copilotkit.ai",
+    // The API and realtime planes are DIFFERENT hosts — do not scheme-swap one
+    // into the other. Both are shown on your project's Intelligence dashboard.
+    apiUrl: "https://api.intelligence.copilotkit.ai",
+    wsUrl: "wss://realtime.intelligence.copilotkit.ai",
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
   identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),

--- a/packages/channels/README.md
+++ b/packages/channels/README.md
@@ -55,8 +55,10 @@ channel.onMessage(({ thread, message }) =>
 // The runtime owns the Channel's lifecycle — there is no `channel.start()`.
 const runtime = new CopilotRuntime({
   intelligence: new CopilotKitIntelligence({
-    apiUrl: "https://api.copilotkit.ai",
-    wsUrl: "wss://api.copilotkit.ai",
+    // The API and realtime planes are DIFFERENT hosts — do not scheme-swap one
+    // into the other. Both are shown on your project's Intelligence dashboard.
+    apiUrl: "https://api.intelligence.copilotkit.ai",
+    wsUrl: "wss://realtime.intelligence.copilotkit.ai",
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
   identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),

--- a/packages/runtime/skills/runtime/references/intelligence-mode.md
+++ b/packages/runtime/skills/runtime/references/intelligence-mode.md
@@ -16,14 +16,21 @@ or `/client` suffixes internally. Pass the bare base URLs — do NOT append `/ap
 `/socket`, `/runner`, or `/client` yourself:
 
 ```typescript
-// Correct — bare base URLs
-apiUrl: "https://api.copilotkit.ai",
-wsUrl:  "wss://api.copilotkit.ai",
+// Correct — bare base URLs, and note the two planes are DIFFERENT hosts
+apiUrl: "https://api.intelligence.copilotkit.ai",
+wsUrl:  "wss://realtime.intelligence.copilotkit.ai",
 
 // Wrong — adding /api produces /api/api/... on every REST call; /socket/runner is not a real path
-apiUrl: "https://api.copilotkit.ai/api",
-wsUrl:  "wss://api.copilotkit.ai/socket",
+apiUrl: "https://api.intelligence.copilotkit.ai/api",
+wsUrl:  "wss://realtime.intelligence.copilotkit.ai/socket",
 ```
+
+`apiUrl` and `wsUrl` are **separate hosts** (`api.…` vs `realtime.…`), so you cannot
+produce one from the other by swapping the scheme. Deriving `wsUrl` as
+`apiUrl.replace(/^http/, "ws")` yields `wss://api.intelligence.copilotkit.ai`, which
+serves no socket — and the resulting failure is a silent hang, not an error, because
+the socket layer treats an unreachable host as a retryable reconnect. Always configure
+both explicitly. Both values are shown on your project's Intelligence dashboard.
 
 Source: `packages/runtime/src/v2/runtime/intelligence-platform/client.ts:41-46, 259,
 356-357, 437, 468, 682-708`.
@@ -38,8 +45,8 @@ import {
 } from "@copilotkit/runtime/v2";
 
 const intelligence = new CopilotKitIntelligence({
-  apiUrl: "https://api.copilotkit.ai",
-  wsUrl: "wss://api.copilotkit.ai",
+  apiUrl: "https://api.intelligence.copilotkit.ai",
+  wsUrl: "wss://realtime.intelligence.copilotkit.ai",
   apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!,
   organizationId: process.env.COPILOTKIT_INTELLIGENCE_ORG_ID!,
 });
@@ -167,14 +174,22 @@ scoped to a user ID.
 
 Source: `packages/runtime/src/v2/runtime/core/runtime.ts:156-160`.
 
-### CRITICAL Adding /api or /socket suffixes, or pointing at an unsupported self-hosted server
+### CRITICAL Deriving wsUrl from apiUrl, adding /api or /socket suffixes, or pointing at an unsupported self-hosted server
 
 Wrong:
 
 ```typescript
 new CopilotKitIntelligence({
-  apiUrl: "https://api.copilotkit.ai/api", // double /api prefix
-  wsUrl: "wss://api.copilotkit.ai/socket", // /socket is not a real path
+  apiUrl: "https://api.intelligence.copilotkit.ai",
+  // Scheme-swapped from apiUrl — WRONG HOST. Serves no socket; hangs instead of erroring.
+  wsUrl: apiUrl.replace(/^http/, "ws"),
+  apiKey,
+  organizationId,
+});
+
+new CopilotKitIntelligence({
+  apiUrl: "https://api.intelligence.copilotkit.ai/api", // double /api prefix
+  wsUrl: "wss://realtime.intelligence.copilotkit.ai/socket", // /socket is not a real path
   apiKey,
   organizationId,
 });
@@ -191,21 +206,26 @@ Correct:
 
 ```typescript
 new CopilotKitIntelligence({
-  apiUrl: "https://api.copilotkit.ai",
-  wsUrl: "wss://api.copilotkit.ai",
+  apiUrl: "https://api.intelligence.copilotkit.ai",
+  wsUrl: "wss://realtime.intelligence.copilotkit.ai",
   apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!,
   organizationId: process.env.COPILOTKIT_INTELLIGENCE_ORG_ID!,
 });
 // For on-prem durability without Intelligence: SSE mode + SqliteAgentRunner.
 ```
 
-Two failure modes to avoid:
+Three failure modes to avoid:
 
-1. The client prepends `/api/...` to every REST call (`#request` at line 356-357) and
+1. The API and realtime planes are **different hosts**, so `wsUrl` cannot be derived
+   from `apiUrl`. A scheme-only swap keeps the API host (and port) and produces a URL
+   that serves no socket. This one is expensive to debug: a wrong `apiUrl` fails fast
+   with an HTTP error, while a wrong `wsUrl` sits in `connecting` until the settle
+   timeout and reports only "did not settle in time".
+2. The client prepends `/api/...` to every REST call (`#request` at line 356-357) and
    the websocket layer derives `/runner` / `/client` suffixes from `wsUrl` internally.
    Passing `apiUrl: ".../api"` produces double-prefixed `/api/api/threads`; passing
    `wsUrl: ".../socket"` produces a broken `.../socket/runner` upgrade path.
-2. Self-hosting Intelligence is not yet supported. The `ɵ`-prefixed runtime internals
+3. Self-hosting Intelligence is not yet supported. The `ɵ`-prefixed runtime internals
    and REST/WebSocket contract are still stabilizing. `organizationId` is reserved for
    future self-hosted instances. For on-prem durable threads today, use SSE mode +
    `SqliteAgentRunner` (see `copilotkit/agent-runners`).

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -51,8 +51,8 @@ export class PlatformRequestError extends Error {
  * import { CopilotKitIntelligence, CopilotRuntime } from "@copilotkit/runtime";
  *
  * const intelligence = new CopilotKitIntelligence({
- *   apiUrl: "https://api.copilotkit.ai",
- *   wsUrl: "wss://api.copilotkit.ai",
+ *   apiUrl: "https://api.intelligence.copilotkit.ai",
+ *   wsUrl: "wss://realtime.intelligence.copilotkit.ai",
  *   apiKey: process.env.COPILOTKIT_API_KEY!,
  * });
  *
@@ -71,9 +71,16 @@ export interface ThreadDeletedPayload {
 }
 
 export interface CopilotKitIntelligenceConfig {
-  /** Base URL of the intelligence platform API, e.g. "https://api.copilotkit.ai" */
+  /** Base URL of the intelligence platform API, e.g. "https://api.intelligence.copilotkit.ai" */
   apiUrl: string;
-  /** Intelligence websocket base URL. Runner and client socket URLs are derived from this. */
+  /**
+   * Intelligence websocket base URL, e.g. "wss://realtime.intelligence.copilotkit.ai".
+   * Runner and client socket URLs are derived from this by appending `/runner` or
+   * `/client`, so pass the bare base.
+   *
+   * This is a DIFFERENT host from {@link apiUrl} — the API and realtime planes are
+   * deployed separately — so it cannot be derived by scheme-swapping `apiUrl`.
+   */
   wsUrl: string;
   /** API key for authenticating with the intelligence platform */
   apiKey: string;

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -109,6 +109,10 @@ channel.onMessage(async ({ thread, message }) => {
 const runtime = new CopilotRuntime({
   agents: {},
   intelligence: new CopilotKitIntelligence({
+    // Both URLs come from your Intelligence dashboard; see the Quickstart for the
+
+    // full env block. Self-hosted deployments use their own two hosts.
+
     apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
     // A separate host from apiUrl — the realtime plane is deployed apart, so
     // this cannot be derived by swapping the API URL scheme.

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -106,12 +106,13 @@ channel.onMessage(async ({ thread, message }) => {
 
 // The runtime owns the channel's lifecycle. A CopilotKit Intelligence key runs
 // any channel (free tier available); `ready()` activates it.
-const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
 const runtime = new CopilotRuntime({
   agents: {},
   intelligence: new CopilotKitIntelligence({
-    apiUrl,
-    wsUrl: apiUrl.replace(/^http/, "ws"),
+    apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
+    // A separate host from apiUrl — the realtime plane is deployed apart, so
+    // this cannot be derived by swapping the API URL scheme.
+    wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
     apiKey: process.env.COPILOTKIT_API_KEY!,
   }),
   identifyUser: () => ({ id: "demo-user", name: "Demo User" }),

--- a/showcase/shell-docs/src/content/docs/channels/mcp.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/mcp.mdx
@@ -78,12 +78,13 @@ channel.onMessage(async ({ thread, message }) => {
 
 // The runtime owns the channel; a CopilotKit Intelligence key runs it (free
 // tier available). `ready()` activates it.
-const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
 const runtime = new CopilotRuntime({
   agents: {},
   intelligence: new CopilotKitIntelligence({
-    apiUrl,
-    wsUrl: apiUrl.replace(/^http/, "ws"),
+    apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
+    // A separate host from apiUrl — the realtime plane is deployed apart, so
+    // this cannot be derived by swapping the API URL scheme.
+    wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
     apiKey: process.env.COPILOTKIT_API_KEY!,
   }),
   identifyUser: () => ({ id: "demo-user", name: "Demo User" }),

--- a/showcase/shell-docs/src/content/docs/channels/mcp.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/mcp.mdx
@@ -81,6 +81,10 @@ channel.onMessage(async ({ thread, message }) => {
 const runtime = new CopilotRuntime({
   agents: {},
   intelligence: new CopilotKitIntelligence({
+    // Both URLs come from your Intelligence dashboard; see the Quickstart for the
+
+    // full env block. Self-hosted deployments use their own two hosts.
+
     apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
     // A separate host from apiUrl — the realtime plane is deployed apart, so
     // this cannot be derived by swapping the API URL scheme.

--- a/showcase/shell-docs/src/content/docs/channels/platforms/discord.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/discord.mdx
@@ -26,6 +26,7 @@ DISCORD_GUILD_ID=...   # optional, for faster command registration in one server
 # even for a direct adapter (free tier available).
 COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
 # A separate host from the API URL above, so it cannot be derived from it.
+# Self-hosted deployments substitute their own two hosts.
 COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 COPILOTKIT_API_KEY=cpk-...
 ```

--- a/showcase/shell-docs/src/content/docs/channels/platforms/discord.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/discord.mdx
@@ -24,7 +24,9 @@ DISCORD_GUILD_ID=...   # optional, for faster command registration in one server
 
 # The runtime runs every channel, so a CopilotKit Intelligence key is required
 # even for a direct adapter (free tier available).
-COPILOTKIT_INTELLIGENCE_URL=https://your-intelligence-url
+COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
+# A separate host from the API URL above, so it cannot be derived from it.
+COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 COPILOTKIT_API_KEY=cpk-...
 ```
 
@@ -55,12 +57,13 @@ channel.onMessage(async ({ thread, message }) => {
 
 // The runtime drives the channel — it starts the Discord adapter, you don't
 // call channel.start() yourself. `ready()` activates it.
-const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
 const runtime = new CopilotRuntime({
   agents: {},
   intelligence: new CopilotKitIntelligence({
-    apiUrl,
-    wsUrl: apiUrl.replace(/^http/, "ws"),
+    apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
+    // A separate host from apiUrl — the realtime plane is deployed apart, so
+    // this cannot be derived by swapping the API URL scheme.
+    wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
     apiKey: process.env.COPILOTKIT_API_KEY!,
   }),
   identifyUser: () => ({ id: "demo-user", name: "Demo User" }),

--- a/showcase/shell-docs/src/content/docs/channels/platforms/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/slack.mdx
@@ -23,7 +23,9 @@ SLACK_APP_TOKEN=xapp-...   # App-level token, for Socket Mode
 
 # The runtime runs every channel, so a CopilotKit Intelligence key is required
 # even for a direct adapter (free tier available).
-COPILOTKIT_INTELLIGENCE_URL=https://your-intelligence-url
+COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
+# A separate host from the API URL above, so it cannot be derived from it.
+COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 COPILOTKIT_API_KEY=cpk-...
 ```
 
@@ -61,12 +63,13 @@ channel.onMessage(async ({ thread, message }) => {
 // The runtime drives the channel — it starts the Slack adapter, you don't call
 // channel.start() yourself. A CopilotKit Intelligence key runs every channel,
 // direct adapters included (free tier available); `ready()` activates it.
-const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
 const runtime = new CopilotRuntime({
   agents: {},
   intelligence: new CopilotKitIntelligence({
-    apiUrl,
-    wsUrl: apiUrl.replace(/^http/, "ws"),
+    apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
+    // A separate host from apiUrl — the realtime plane is deployed apart, so
+    // this cannot be derived by swapping the API URL scheme.
+    wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
     apiKey: process.env.COPILOTKIT_API_KEY!,
   }),
   identifyUser: () => ({ id: "demo-user", name: "Demo User" }),

--- a/showcase/shell-docs/src/content/docs/channels/platforms/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/slack.mdx
@@ -25,6 +25,7 @@ SLACK_APP_TOKEN=xapp-...   # App-level token, for Socket Mode
 # even for a direct adapter (free tier available).
 COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
 # A separate host from the API URL above, so it cannot be derived from it.
+# Self-hosted deployments substitute their own two hosts.
 COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 COPILOTKIT_API_KEY=cpk-...
 ```

--- a/showcase/shell-docs/src/content/docs/channels/platforms/teams.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/teams.mdx
@@ -28,7 +28,9 @@ tenantId=...
 
 # The runtime runs every channel, so a CopilotKit Intelligence key is required
 # even for a direct adapter (free tier available).
-COPILOTKIT_INTELLIGENCE_URL=https://your-intelligence-url
+COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
+# A separate host from the API URL above, so it cannot be derived from it.
+COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 COPILOTKIT_API_KEY=cpk-...
 ```
 
@@ -61,12 +63,13 @@ channel.onMessage(async ({ thread, message }) => {
 
 // The runtime drives the channel — it starts the Teams adapter, you don't call
 // channel.start() yourself. `ready()` activates it.
-const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
 const runtime = new CopilotRuntime({
   agents: {},
   intelligence: new CopilotKitIntelligence({
-    apiUrl,
-    wsUrl: apiUrl.replace(/^http/, "ws"),
+    apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
+    // A separate host from apiUrl — the realtime plane is deployed apart, so
+    // this cannot be derived by swapping the API URL scheme.
+    wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
     apiKey: process.env.COPILOTKIT_API_KEY!,
   }),
   identifyUser: () => ({ id: "demo-user", name: "Demo User" }),

--- a/showcase/shell-docs/src/content/docs/channels/platforms/teams.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/teams.mdx
@@ -30,6 +30,7 @@ tenantId=...
 # even for a direct adapter (free tier available).
 COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
 # A separate host from the API URL above, so it cannot be derived from it.
+# Self-hosted deployments substitute their own two hosts.
 COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 COPILOTKIT_API_KEY=cpk-...
 ```

--- a/showcase/shell-docs/src/content/docs/channels/platforms/telegram.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/telegram.mdx
@@ -24,6 +24,7 @@ TELEGRAM_BOT_TOKEN=...
 # even for a direct adapter (free tier available).
 COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
 # A separate host from the API URL above, so it cannot be derived from it.
+# Self-hosted deployments substitute their own two hosts.
 COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 COPILOTKIT_API_KEY=cpk-...
 ```

--- a/showcase/shell-docs/src/content/docs/channels/platforms/telegram.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/telegram.mdx
@@ -22,7 +22,9 @@ TELEGRAM_BOT_TOKEN=...
 
 # The runtime runs every channel, so a CopilotKit Intelligence key is required
 # even for a direct adapter (free tier available).
-COPILOTKIT_INTELLIGENCE_URL=https://your-intelligence-url
+COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
+# A separate host from the API URL above, so it cannot be derived from it.
+COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 COPILOTKIT_API_KEY=cpk-...
 ```
 
@@ -49,12 +51,13 @@ channel.onMessage(async ({ thread, message }) => {
 
 // The runtime drives the channel — it starts the Telegram adapter, you don't
 // call channel.start() yourself. `ready()` activates it.
-const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
 const runtime = new CopilotRuntime({
   agents: {},
   intelligence: new CopilotKitIntelligence({
-    apiUrl,
-    wsUrl: apiUrl.replace(/^http/, "ws"),
+    apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
+    // A separate host from apiUrl — the realtime plane is deployed apart, so
+    // this cannot be derived by swapping the API URL scheme.
+    wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
     apiKey: process.env.COPILOTKIT_API_KEY!,
   }),
   identifyUser: () => ({ id: "demo-user", name: "Demo User" }),

--- a/showcase/shell-docs/src/content/docs/channels/platforms/whatsapp.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/whatsapp.mdx
@@ -27,6 +27,7 @@ WHATSAPP_VERIFY_TOKEN=...   # a string you choose, used to verify the webhook
 # even for a direct adapter (free tier available).
 COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
 # A separate host from the API URL above, so it cannot be derived from it.
+# Self-hosted deployments substitute their own two hosts.
 COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 COPILOTKIT_API_KEY=cpk-...
 ```

--- a/showcase/shell-docs/src/content/docs/channels/platforms/whatsapp.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/whatsapp.mdx
@@ -25,7 +25,9 @@ WHATSAPP_VERIFY_TOKEN=...   # a string you choose, used to verify the webhook
 
 # The runtime runs every channel, so a CopilotKit Intelligence key is required
 # even for a direct adapter (free tier available).
-COPILOTKIT_INTELLIGENCE_URL=https://your-intelligence-url
+COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
+# A separate host from the API URL above, so it cannot be derived from it.
+COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 COPILOTKIT_API_KEY=cpk-...
 ```
 
@@ -62,12 +64,13 @@ channel.onMessage(async ({ thread, message }) => {
 
 // The runtime drives the channel — it starts the WhatsApp adapter, you don't
 // call channel.start() yourself. `ready()` activates it.
-const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
 const runtime = new CopilotRuntime({
   agents: {},
   intelligence: new CopilotKitIntelligence({
-    apiUrl,
-    wsUrl: apiUrl.replace(/^http/, "ws"),
+    apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
+    // A separate host from apiUrl — the realtime plane is deployed apart, so
+    // this cannot be derived by swapping the API URL scheme.
+    wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
     apiKey: process.env.COPILOTKIT_API_KEY!,
   }),
   identifyUser: () => ({ id: "demo-user", name: "Demo User" }),

--- a/showcase/shell-docs/src/content/docs/channels/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/quickstart.mdx
@@ -53,11 +53,18 @@ walkthrough and per-platform install links.
 <Step>
 ### Set the environment
 
-The Intelligence runtime reads the first two. For a managed channel no platform
+The Intelligence runtime reads the first three. For a managed channel no platform
 tokens live in your app. `OPENAI_API_KEY` powers the agent's model.
 
+The API and websocket URLs are **different hosts**, so the websocket URL cannot be
+derived from the API URL by swapping the scheme — set both. Getting the websocket
+host wrong does not raise an error; the channel sits in `connecting` until it times
+out. Self-hosted deployments substitute their own two hosts.
+
 ```bash
-COPILOTKIT_INTELLIGENCE_URL=https://your-intelligence-url
+COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
+# A separate host from the API URL above, so it cannot be derived from it.
+COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 COPILOTKIT_API_KEY=cpk-...
 OPENAI_API_KEY=sk-...
 ```
@@ -121,10 +128,11 @@ channel.onMessage(async ({ thread, message }) => {
 // The runtime owns the channel. Declare it here, mount the listener, and
 // `ready()` activates it. The Intelligence key (free tier available) is what
 // lets the runtime run any channel.
-const apiUrl = process.env.COPILOTKIT_INTELLIGENCE_URL!;
 const intelligence = new CopilotKitIntelligence({
-  apiUrl,
-  wsUrl: apiUrl.replace(/^http/, "ws"), // ws base derives from the api base
+  apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
+  // A separate host from apiUrl — the realtime plane is deployed apart, so
+  // this cannot be derived by swapping the API URL scheme.
+  wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
   apiKey: process.env.COPILOTKIT_API_KEY!,
 });
 

--- a/skills/copilotkit-debug/references/runtime-debugging.md
+++ b/skills/copilotkit-debug/references/runtime-debugging.md
@@ -199,7 +199,7 @@ For Intelligence mode, the response also includes:
 ```json
 {
   "intelligence": {
-    "wsUrl": "wss://api.copilotkit.ai/client"
+    "wsUrl": "wss://realtime.intelligence.copilotkit.ai/client"
   }
 }
 ```

--- a/skills/runtime/references/intelligence-mode.md
+++ b/skills/runtime/references/intelligence-mode.md
@@ -16,14 +16,21 @@ or `/client` suffixes internally. Pass the bare base URLs — do NOT append `/ap
 `/socket`, `/runner`, or `/client` yourself:
 
 ```typescript
-// Correct — bare base URLs
-apiUrl: "https://api.copilotkit.ai",
-wsUrl:  "wss://api.copilotkit.ai",
+// Correct — bare base URLs, and note the two planes are DIFFERENT hosts
+apiUrl: "https://api.intelligence.copilotkit.ai",
+wsUrl:  "wss://realtime.intelligence.copilotkit.ai",
 
 // Wrong — adding /api produces /api/api/... on every REST call; /socket/runner is not a real path
-apiUrl: "https://api.copilotkit.ai/api",
-wsUrl:  "wss://api.copilotkit.ai/socket",
+apiUrl: "https://api.intelligence.copilotkit.ai/api",
+wsUrl:  "wss://realtime.intelligence.copilotkit.ai/socket",
 ```
+
+`apiUrl` and `wsUrl` are **separate hosts** (`api.…` vs `realtime.…`), so you cannot
+produce one from the other by swapping the scheme. Deriving `wsUrl` as
+`apiUrl.replace(/^http/, "ws")` yields `wss://api.intelligence.copilotkit.ai`, which
+serves no socket — and the resulting failure is a silent hang, not an error, because
+the socket layer treats an unreachable host as a retryable reconnect. Always configure
+both explicitly. Both values are shown on your project's Intelligence dashboard.
 
 Source: `packages/runtime/src/v2/runtime/intelligence-platform/client.ts:41-46, 259,
 356-357, 437, 468, 682-708`.
@@ -38,8 +45,8 @@ import {
 } from "@copilotkit/runtime/v2";
 
 const intelligence = new CopilotKitIntelligence({
-  apiUrl: "https://api.copilotkit.ai",
-  wsUrl: "wss://api.copilotkit.ai",
+  apiUrl: "https://api.intelligence.copilotkit.ai",
+  wsUrl: "wss://realtime.intelligence.copilotkit.ai",
   apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!,
   organizationId: process.env.COPILOTKIT_INTELLIGENCE_ORG_ID!,
 });
@@ -167,14 +174,22 @@ scoped to a user ID.
 
 Source: `packages/runtime/src/v2/runtime/core/runtime.ts:156-160`.
 
-### CRITICAL Adding /api or /socket suffixes, or pointing at an unsupported self-hosted server
+### CRITICAL Deriving wsUrl from apiUrl, adding /api or /socket suffixes, or pointing at an unsupported self-hosted server
 
 Wrong:
 
 ```typescript
 new CopilotKitIntelligence({
-  apiUrl: "https://api.copilotkit.ai/api", // double /api prefix
-  wsUrl: "wss://api.copilotkit.ai/socket", // /socket is not a real path
+  apiUrl: "https://api.intelligence.copilotkit.ai",
+  // Scheme-swapped from apiUrl — WRONG HOST. Serves no socket; hangs instead of erroring.
+  wsUrl: apiUrl.replace(/^http/, "ws"),
+  apiKey,
+  organizationId,
+});
+
+new CopilotKitIntelligence({
+  apiUrl: "https://api.intelligence.copilotkit.ai/api", // double /api prefix
+  wsUrl: "wss://realtime.intelligence.copilotkit.ai/socket", // /socket is not a real path
   apiKey,
   organizationId,
 });
@@ -191,21 +206,26 @@ Correct:
 
 ```typescript
 new CopilotKitIntelligence({
-  apiUrl: "https://api.copilotkit.ai",
-  wsUrl: "wss://api.copilotkit.ai",
+  apiUrl: "https://api.intelligence.copilotkit.ai",
+  wsUrl: "wss://realtime.intelligence.copilotkit.ai",
   apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!,
   organizationId: process.env.COPILOTKIT_INTELLIGENCE_ORG_ID!,
 });
 // For on-prem durability without Intelligence: SSE mode + SqliteAgentRunner.
 ```
 
-Two failure modes to avoid:
+Three failure modes to avoid:
 
-1. The client prepends `/api/...` to every REST call (`#request` at line 356-357) and
+1. The API and realtime planes are **different hosts**, so `wsUrl` cannot be derived
+   from `apiUrl`. A scheme-only swap keeps the API host (and port) and produces a URL
+   that serves no socket. This one is expensive to debug: a wrong `apiUrl` fails fast
+   with an HTTP error, while a wrong `wsUrl` sits in `connecting` until the settle
+   timeout and reports only "did not settle in time".
+2. The client prepends `/api/...` to every REST call (`#request` at line 356-357) and
    the websocket layer derives `/runner` / `/client` suffixes from `wsUrl` internally.
    Passing `apiUrl: ".../api"` produces double-prefixed `/api/api/threads`; passing
    `wsUrl: ".../socket"` produces a broken `.../socket/runner` upgrade path.
-2. Self-hosting Intelligence is not yet supported. The `ɵ`-prefixed runtime internals
+3. Self-hosting Intelligence is not yet supported. The `ɵ`-prefixed runtime internals
    and REST/WebSocket contract are still stabilizing. `organizationId` is reserved for
    future self-hosted instances. For on-prem durable threads today, use SSE mode +
    `SqliteAgentRunner` (see `copilotkit/agent-runners`).


### PR DESCRIPTION
Fixes the Channels docs/examples pointing at an Intelligence host that does not serve the API, and the websocket URL guidance that can never produce a working prod value. Linear: [OSS-621](https://linear.app/copilotkit/issue/OSS-621).

## The two bugs

**1. The documented host does not serve the API.** Probed every plausible path, not just `/`:

| URL | Result |
| --- | --- |
| `api.copilotkit.ai` — `/`, `/api`, `/api/health`, `/health`, `/api/threads`, `/api/v1/threads` | **404 on all**, `server: awselb/2.0`, `content-length: 0` — an ALB with no target-group rule behind it |
| `realtime.copilotkit.ai` | **no DNS record at all** |
| `api.intelligence.copilotkit.ai/` and `/api/health` | 200, `x-powered-by: Express` |
| `api.intelligence.copilotkit.ai/api/threads` | **401** — a real, auth-gated endpoint |
| `realtime.intelligence.copilotkit.ai/runner/websocket` | **403** — mounted and auth-gated (a 404 would mean unmounted) |

So the documented host is not merely returning 404 at the root — nothing is routed there on any path, and it is not the app (no `x-powered-by`). The working pair, matching the CLI's baked-in prod defaults and `gitops/environments/prod/values.yaml`, is `https://api.intelligence.copilotkit.ai` + `wss://realtime.intelligence.copilotkit.ai`.

**2. `wsUrl` was documented as derivable from `apiUrl`.** Prod splits the API and realtime planes across *different hosts*, so a scheme-only swap yields `wss://api.intelligence.copilotkit.ai` — wrong host. That failure is silent: a wrong `apiUrl` returns a clean HTTP error, but a wrong `wsUrl` sits in `connecting` until the settle timeout and reports only "did not settle in time". The derive is not even correct locally, where the API and gateway are on different ports (4201 vs 4401) and the swap preserves the port. It is essentially never right, so it is deleted rather than relabelled.

Demonstrated end to end rather than asserted — running `examples/teams` with the WS URL unset:

```
# on main: derive(https://api.intelligence.copilotkit.ai) -> wss://api.intelligence.copilotkit.ai   (wrong host, 30s hang)
# on this branch:
exit code: 1
Missing COPILOTKIT_INTELLIGENCE_WS_URL.
  export COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
  export COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
The API and websocket URLs are DIFFERENT hosts (api.… vs realtime.…), so
the websocket URL cannot be derived from the API URL — set both.
```

## Scope note

The ticket listed 8 sites; the actual blast radius was 30 across 22 files. Beyond the ticket's list:

- **Five more channels package READMEs** — `channels`, `channels-core`, `channels-discord`, `channels-slack`, `channels-teams` (the ticket named only telegram + whatsapp).
- **The live product docs** — `showcase/shell-docs/src/content/docs/channels/` taught the broken derive in 8 files. These escaped the ticket's grep because their host was already a `your-intelligence-url` placeholder; only bug 2 was present. This is the surface developers actually read.
- **A generated skills mirror** — `skills/runtime/` is produced from `packages/runtime/skills/runtime/` by `pnpm sync:plugin-skills`; fixing one without the other leaves the bug live and fails the `check-plugin-skills` gate.
- `skills/copilotkit-debug/references/runtime-debugging.md` and a third occurrence in `client.ts`.

## Acceptance item 4 — resolved, chain verified

The ticket flagged a contradiction: `realtime-gateway.ts` documented `wss://gateway.example/socket` while the runtime skill listed `/socket` as a mistake. **The skill is right**, confirmed by tracing the real runtime path rather than inferring it:

1. `channel-activation-config.ts:145` — `const wsUrl = intelligence.ɵgetRunnerWsUrl()`, i.e. base + `/runner`.
2. → `channel-manager.ts:237` `wsUrl: config.wsUrl` → `startChannelsOverRealtimeGateway` → `connectRealtimeGateway`.
3. `realtime-gateway.ts:253` hands that to Phoenix's `Socket`, which appends `/websocket`.
4. The gateway mounts exactly `/runner` and `/client` (`realtime_gateway/endpoint.ex:10,17`). There is no `/socket`.

The two docs survived contradicting each other because they describe **different layers**: the public `wsUrl` is a bare base, while `connectRealtimeGateway` receives the already-derived runner URL. Its doc comment and the test fixtures move to `/runner` and now name the layer. Independently, `get-runtime-info.ts:93` uses `ɵgetClientWsUrl()`, which confirms the `/info` sample in the debug skill correctly keeps its `/client` suffix — only the host there was wrong.

## Acceptance item 3 — split out

Failing loudly instead of hanging is a behavior change in the launcher's connect path that overlaps OSS-622's error classification, so it is [OSS-623](https://linear.app/copilotkit/issue/OSS-623) rather than smuggled into a docs fix.

## Verification

- 44/44 gateway tests in `packages/channels-intelligence`; `examples/slack/app/managed.test.ts` passes; `examples/teams` typechecks clean.
- `nx run-many -t test,publint,attw` across the 15 affected projects passed via the pre-commit hook; full CI green (38 checks, including `build-check (shell-docs)`).
- Behavior proven by running the example, not by mocks (above).
- 45 commits behind `main` at time of review with **zero overlap** on changed files, and the diff covers every dead-host and derive site present on *current* `main`.
- No logic changes in either published package — `client.ts` and `realtime-gateway.ts` are JSDoc/field-comment only. Behavior changes are confined to the three example apps.

## Self-review pass

An adversarial pass over this PR tried to falsify its central claim (that `api.copilotkit.ai` does not serve the API) by probing non-root paths — the evidence got stronger, not weaker. It also cleared a suspected regression: three `channels-intelligence` files read `COPILOTKIT_INTELLIGENCE_URL` without the WS var, but they are the HTTP-only transport path and need no socket URL. Two genuine gaps it *did* find are fixed in the last commit: the five platform pages had lost deployment neutrality (managed hosts now carry a self-hosted note), and `index.mdx`/`mcp.mdx` referenced the new variable without telling the reader where it comes from.

**One product decision for the reviewer:** `api.copilotkit.ai` is a live ALB that routes nothing. If it is meant to become the public API alias, this PR is documenting the wrong long-term string and the ALB wants a listener rule instead. I used the host the product actually hands users today (CLI prod defaults + gitops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)