### PR TITLE
fix(showcase/ms-agent-dotnet): copy manifest.yaml into the runtime image

### DIFF
--- a/showcase/integrations/ms-agent-dotnet/Dockerfile
+++ b/showcase/integrations/ms-agent-dotnet/Dockerfile
@@ -43,6 +43,15 @@ COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
 COPY --chown=app:app --from=frontend /app/package.json ./
 COPY --chown=app:app --from=frontend /app/public ./public
 
+# Manifest is read at runtime by `src/app/demos/layout.tsx` (`generateMetadata`
+# calls `headers()` for the `x-pathname` that `src/middleware.ts` sets, which
+# opts every `/demos/*` route into dynamic rendering, so Next can't bake the
+# demo titles into the build). Without this copy every demo page throws "An
+# error occurred in the Server Components render" (ENOENT on
+# /app/manifest.yaml) — the home page is unaffected because it has no dynamic
+# APIs and is statically prerendered at build time.
+COPY --chown=app:app manifest.yaml ./
+
 # .NET agent binary (from agent-build stage — no dotnet SDK at runtime)
 COPY --chown=app:app --from=agent-build /agent/publish /agent
 

--- a/showcase/scripts/__tests__/runtime-manifest-copy.test.ts
+++ b/showcase/scripts/__tests__/runtime-manifest-copy.test.ts
@@ -1,0 +1,49 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { globSync } from "glob";
+import { expect, test } from "vitest";
+
+const repositoryRoot = resolve(import.meta.dirname, "../../..");
+
+/**
+ * `src/app/demos/layout.tsx` reads `manifest.yaml` from `process.cwd()` inside
+ * `generateMetadata()`, but only once `headers()` returns an `x-pathname` — and
+ * only `src/middleware.ts` sets that header. So an integration that ships the
+ * middleware opts every `/demos/*` route into dynamic rendering AND into a
+ * request-time `readFileSync` of `manifest.yaml`. If the Dockerfile's runner
+ * stage doesn't copy the manifest, every demo page 500s with "An error occurred
+ * in the Server Components render" (ENOENT) while the statically-prerendered
+ * home page keeps returning 200 — which reads on the dashboard as "UI is up,
+ * every cell stuck at D3". This bit langgraph-python once and ms-agent-dotnet
+ * once (PR #6130); this test is the ratchet.
+ */
+const integrationsWithMiddleware = globSync(
+  "showcase/integrations/*/src/middleware.ts",
+  {
+    cwd: repositoryRoot,
+    posix: true,
+  },
+).map((match) => match.split("/")[2]);
+
+test("integrations that ship middleware.ts exist", () => {
+  expect(integrationsWithMiddleware.length).toBeGreaterThan(0);
+});
+
+test.each(integrationsWithMiddleware)(
+  "%s copies manifest.yaml into the runtime image",
+  (integration) => {
+    const dir = resolve(repositoryRoot, "showcase/integrations", integration);
+    // Only integrations whose demos layout actually reads the manifest need it.
+    const layout = resolve(dir, "src/app/demos/layout.tsx");
+    if (
+      !existsSync(layout) ||
+      !readFileSync(layout, "utf8").includes("manifest.yaml")
+    ) {
+      return;
+    }
+
+    const dockerfile = readFileSync(resolve(dir, "Dockerfile"), "utf8");
+    expect(dockerfile).toMatch(/^COPY .*manifest\.yaml/m);
+  },
+);


### PR DESCRIPTION
## Symptom

Every `ms-agent-dotnet` cell on staging dropped to **D3** after #6130 merged:

| Rung | Error |
|---|---|
| D6 Parity (Reference) | `chat input not found: waitForSelector locator('[role="textbox"]') to be visible` |
| D5 1P (Single Pill) | `timeout after 600000ms` |
| D4 BE (Agent) | `page.type: Timeout 59981ms exceeded waiting for locator('textarea')` |

## Root cause

Not a chat/agent bug — **every `/demos/*` page is a 500 error boundary**, so no chat input ever mounts. Verified live:

```
$ GET https://showcase-ms-agent-dotnet-staging.up.railway.app/demos/agentic-chat
Application error: a client-side exception has occurred
[showcase] Uncaught error: An error occurred in the Server Components render.
```

`/` still returns 200 (statically prerendered) — which is why the service line stays green and the cells look merely "stuck at D3".

#6130 added `src/middleware.ts`, which sets the `x-pathname` header. That header is the thing that makes `src/app/demos/layout.tsx`'s `generateMetadata()` get past its `if (!slug) return` early-out and actually call `loadDemoIndex()` — a request-time `readFileSync(process.cwd()/manifest.yaml)`. The Dockerfile's runner stage never copied `manifest.yaml` → ENOENT on every demo route.

Before the middleware existed the header was always absent, so the manifest read never ran. The middleware didn't break the layout; it *activated* a path that had never executed in production.

`langgraph-python` hit this exact bug and fixed it with the same one-line `COPY` (its Dockerfile carries a comment describing this failure verbatim). A sweep confirms `ms-agent-dotnet` was the only integration shipping `middleware.ts` without it:

```
langgraph-fastapi  middleware=yes copy=yes
langgraph-python   middleware=yes copy=yes
ms-agent-dotnet    middleware=yes copy=no   <-- broken
(all others)       middleware=no            <-- header absent, read never runs
```

## Fix

1. `COPY --chown=app:app manifest.yaml ./` in the runner stage, with the same explanatory comment as the reference.
2. `showcase/scripts/__tests__/runtime-manifest-copy.test.ts` — ratchets the invariant: any integration shipping `middleware.ts` whose demos layout reads `manifest.yaml` must copy it into the image.

## Verification

- Confirmed the live 500 on `/demos/agentic-chat` and confirmed `langgraph-python` staging renders the manifest-driven title (`LangGraph (Python) - Pre-Built: CopilotChat`) on the same route — isolating the missing COPY as the only difference.
- Ratchet test mutation-verified: passes with the fix, fails when the `COPY` line is removed.
- Not container-built locally (the .NET SDK stage is expensive and the change mirrors a proven line); the deployed staging image is the real check.

## Note, separate from this PR

D3 rendered **green** while every demo page was a 500. Whatever D3 probes, it does not detect an error-boundary page — that is red-masking worth a follow-up.