### PR TITLE
fix(channels-intelligence): classify channel_not_declared as setup-required

### DIFF
--- a/packages/channels-intelligence/src/realtime-gateway.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.test.ts
@@ -18,6 +18,9 @@ type JoinMode =
   // `channel_declaration_unavailable` with NO channels array — the defensive
   // fallback path (nothing to classify) degrades to setup_required.
   | "error-setup-required-no-channels"
+  // `channel_declaration_unavailable` where the declared channel does not exist
+  // in the project at all (OSS-622) → setup_required, not a hard failure.
+  | "error-channel-not-declared"
   // `channel_declaration_unavailable` where a non-live channel is a hard-error
   // state (`runtime_conflict`) → must NOT downgrade to setup_required.
   | "error-conflict"
@@ -62,6 +65,11 @@ function makeFakeWebSocket(mode: JoinMode) {
         };
       case "error-setup-required-no-channels":
         return { reason: "channel_declaration_unavailable" };
+      case "error-channel-not-declared":
+        return {
+          reason: "channel_declaration_unavailable",
+          channels: [{ state: "channel_not_declared" }],
+        };
       case "error-conflict":
         return {
           reason: "channel_declaration_unavailable",
@@ -491,6 +499,42 @@ describe("connectRealtimeGateway — per-channel state classification (OSS-473)"
     ]);
     // The socket-leak-teardown behavior is unchanged: a failed join still tears
     // the socket down rather than leaking it.
+    expect(instances[0]!.closed).toBe(true);
+  });
+
+  it("classifies channel_not_declared as SETUP_REQUIRED (OSS-622)", async () => {
+    // app-api reports `channel_not_declared` when the declared channel name does
+    // not exist in the project. Creating the channel and attaching credentials is
+    // the setup step every new channel goes through, so this is the first-run
+    // path — it must resolve `ready()` as setup_required, not crash startup.
+    const { FakeWebSocket, instances } = makeFakeWebSocket(
+      "error-channel-not-declared",
+    );
+
+    const err = await connectRealtimeGateway({
+      wsUrl: "wss://gateway.example/socket",
+      apiKey: "cpk-test",
+      projectId: 7,
+      join: {
+        runtimeInstanceId: "rti_1",
+        declaredChannels: [{ channelName: "never-created", adapter: "slack" }],
+        observedAt: "2026-07-10T00:00:00.000Z",
+      },
+      webSocket: FakeWebSocket,
+    }).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(RealtimeGatewaySetupRequiredError);
+    expect((err as RealtimeGatewaySetupRequiredError).code).toBe(
+      "SETUP_REQUIRED",
+    );
+    // Preserved so an operator can tell this apart from the other ways a channel
+    // reaches setup_required.
+    expect((err as RealtimeGatewaySetupRequiredError).channelStates).toEqual([
+      "channel_not_declared",
+    ]);
     expect(instances[0]!.closed).toBe(true);
   });
 

--- a/packages/channels-intelligence/src/realtime-gateway.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.ts
@@ -368,12 +368,17 @@ function toHttpProbeUrl(wsUrl: string): string | undefined {
 }
 
 /**
- * Per-channel `state` values (from the gateway's `CHANNEL_STATE_KINDS`) that
- * mean a declared channel is genuinely unconfigured or waiting — a degraded
- * `setup_required` condition, not a hard failure. Any other non-`channel_live`
- * state (`runtime_conflict`, `platform_setup_failed`, `delivery_failed`,
- * `egress_failed`, `runtime_offline`, `runtime_not_declared`) is treated as a
- * hard error; see {@link classifyJoinError}.
+ * Per-channel `state` values that mean a declared channel is genuinely
+ * unconfigured or waiting — a degraded `setup_required` condition, not a hard
+ * failure. Any other non-`channel_live` state (`runtime_conflict`,
+ * `platform_setup_failed`, `delivery_failed`, `egress_failed`, `runtime_offline`,
+ * `runtime_not_declared`) is treated as a hard error; see
+ * {@link classifyJoinError}.
+ *
+ * Sourced from two Intelligence vocabularies, not one. Most are read-model
+ * `CHANNEL_STATE_KINDS` members. `channel_not_declared` is declaration-only
+ * (`CHANNEL_LISTENER_DECLARATION_STATES`) and has no read-model counterpart:
+ * only a join needs to name a channel the project does not have.
  *
  * Verified against Intelligence `sdk_channel.ex` +
  * `libs/app-api-contracts/src/channels.ts`: the gateway rejects a join with
@@ -384,6 +389,7 @@ function toHttpProbeUrl(wsUrl: string): string | undefined {
  */
 const SETUP_REQUIRED_CHANNEL_STATES: ReadonlySet<string> = new Set([
   "no_channels_yet",
+  "channel_not_declared",
   "adapter_setup_required",
   "slack_setup_complete_waiting_for_runtime",
   "channel_setup_complete_waiting_for_runtime",
@@ -935,9 +941,16 @@ function describeTransportError(error: unknown): {
  *
  * `runtime_not_declared` is treated as a HARD error here: during our own join
  * the runtime IS declaring itself, so the gateway reporting the channel as
- * runtime-not-declared is a server/runtime disagreement, not user setup. TODO
- * (gateway-owner): confirm this is never a benign join-vs-heartbeat race; if it
- * is, add it to {@link SETUP_REQUIRED_CHANNEL_STATES} and document why.
+ * runtime-not-declared is a server/runtime disagreement, not user setup.
+ *
+ * OSS-622 settled the open question this comment used to carry. app-api WAS
+ * sending `runtime_not_declared` on the join path for a benign condition — a
+ * declared channel the project does not have — because the declaration contract
+ * had no token for it. The token meant the inverse of its read-model sense, so
+ * reading it literally (correctly) turned every first run of a new channel into a
+ * crashed startup. app-api now sends `channel_not_declared` for that case, which
+ * is classified setup-required above. `runtime_not_declared` keeps its literal
+ * reading and stays a hard error.
  *
  * When a `channel_declaration_unavailable` reject carries no parseable
  * per-channel detail, we degrade to `setup_required` (the conservative


### PR DESCRIPTION
## What does this PR do?

A runtime that declares a managed channel the Intelligence project does not have
crashed startup: `ready()` rejected and the channel settled to `error`.

```
realtime gateway session join failed: channel_declaration_unavailable (channel states: runtime_not_declared)
status: { overall: "error", channels: { "managed-teams-probe": "error" } }
```

Creating the channel and attaching credentials is the setup step every new
channel goes through, so this was the first run of *every* managed channel,
before anyone reached the happy path.

### Cause

app-api had no declaration-response token for "the project has no channel by that
name", so it sent `runtime_not_declared`. That token means the inverse on a join —
a channel exists but no runtime declared it, while on a join the runtime is the
one declaring. `classifyJoinError` read it literally, which was correct, and so
treated a benign setup gap as a hard failure.

The fix is split by which side owns the mistake. app-api now sends
`channel_not_declared` for that case (Intelligence#615). This PR teaches the
classifier the new token.

### Change

- `channel_not_declared` added to `SETUP_REQUIRED_CHANNEL_STATES`, so the channel
  settles to `setup_required` and `ready()` resolves.
- `runtime_not_declared` keeps its literal reading and stays a hard error, as do
  `runtime_conflict`, `platform_setup_failed`, `delivery_failed`, `egress_failed`
  and `runtime_offline`.
- Retired the `TODO (gateway-owner)` the classifier carried, which asked whether
  `runtime_not_declared` was ever benign. It was — but not for the reason the
  comment guessed. The server was overloading the token, not racing a heartbeat.
  Replaced the TODO with what the answer turned out to be.
- Documented that `SETUP_REQUIRED_CHANNEL_STATES` now draws on two Intelligence
  vocabularies: most members are read-model `CHANNEL_STATE_KINDS`, while
  `channel_not_declared` is declaration-only and has no read-model counterpart.

An SDK without this change treats the unknown token as a hard error, which is the
pre-fix behavior — so old clients are no worse off, they just keep the bug.

## Related PRs and Issues

- Server side: CopilotKit/Intelligence#615
- OSS-622

## Checklist

- [x] I have read the Contribution Guide
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked

## Tests

Added `classifies channel_not_declared as SETUP_REQUIRED (OSS-622)`, plus an
`error-channel-not-declared` join mode. RED before the fix: the join produced
`RealtimeGatewayChannelStateError` instead of `RealtimeGatewaySetupRequiredError`.

`npx vitest run src/realtime-gateway.test.ts` — 21 pass.

33 failures elsewhere in this package reproduce on `origin/main` with these
changes stashed (a stale `@copilotkit/channels` build missing the `ɵruntime`
symbol) and are unrelated.
