### PR TITLE
feat(runtime): default the Intelligence platform URLs to the managed service

### DIFF
--- a/dev-docs/architecture/setup-intelligence.md
+++ b/dev-docs/architecture/setup-intelligence.md
@@ -71,8 +71,23 @@ import { CopilotKitIntelligence } from "@copilotkit/runtime";
 const intelligence = new CopilotKitIntelligence({
   apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!,
   organizationId: process.env.COPILOTKIT_INTELLIGENCE_ORGANIZATION_ID!,
-  apiUrl: "https://your-intelligence-host/api",
-  wsUrl: "wss://your-intelligence-host/socket",
+});
+```
+
+`apiUrl` and `wsUrl` default to the managed platform
+(`https://api.intelligence.copilotkit.ai` and
+`wss://realtime.intelligence.copilotkit.ai`). To target a non-production or
+self-hosted deployment, override **both** — they are separate hosts, so neither
+derives from the other, and setting one alone leaves the other plane on the
+managed platform. Pass bare bases: the client appends `/api/...` and the socket
+layer appends `/runner` or `/client` itself.
+
+```typescript
+const intelligence = new CopilotKitIntelligence({
+  apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!,
+  organizationId: process.env.COPILOTKIT_INTELLIGENCE_ORGANIZATION_ID!,
+  apiUrl: "https://api.your-intelligence-host",
+  wsUrl: "wss://realtime.your-intelligence-host",
 });
 ```
 

--- a/examples/slack/.env.example
+++ b/examples/slack/.env.example
@@ -49,13 +49,15 @@ OPENAI_API_KEY=sk-...
 # starts those adapters for you (there is no launcher, and no infra ids to
 # supply — the runtime derives project/adapter/channel from the config below
 # plus the channel name chosen in code).
-# Intelligence platform API base URL.
-COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
-# Websocket base URL for the realtime plane. This is a DIFFERENT host from the
-# API URL above (api.… vs realtime.…), so it cannot be derived from it — set both.
-COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
-# Project runtime API key (cpk-…).
+# Project runtime API key (cpk-…). The only Intelligence value you need: the SDK
+# defaults both URLs to the managed platform.
 COPILOTKIT_API_KEY=cpk-...
+# Optional, for a self-hosted or dev Intelligence deployment only. Set BOTH or
+# neither: the realtime plane is a DIFFERENT host from the API (api.… vs
+# realtime.…), so it cannot be derived from the API URL, and setting one alone
+# leaves the other plane on the managed platform.
+# COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
+# COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 # Optional: port for the Intelligence runtime that owns the Channel lifecycle
 # (loopback-only; keeps the process alive; distinct from WhatsApp's $PORT
 # webhook). Defaults to 8300.

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -116,9 +116,7 @@ bot.onMention(async ({ thread, message }) => {
 // A Channel runs only through the Intelligence runtime, which OWNS its
 // lifecycle — it starts the direct Slack adapter for us.
 const intelligence = new CopilotKitIntelligence({
-  apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
-  // Separate host from apiUrl (api.… vs realtime.…) — not derivable from it.
-  wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
+  // apiUrl/wsUrl default to the managed Intelligence platform.
   apiKey: process.env.COPILOTKIT_API_KEY!,
 });
 const runtime = new CopilotRuntime({
@@ -323,7 +321,7 @@ several from one process).
 ```bash
 cp .env.example .env
 # Fill in (set SLACK_*, DISCORD_*, and/or TELEGRAM_BOT_TOKEN — whichever you want):
-#   COPILOTKIT_INTELLIGENCE_URL / COPILOTKIT_API_KEY  (REQUIRED — owns the Channel; free tier)
+#   COPILOTKIT_API_KEY                         (REQUIRED — owns the Channel; free tier)
 #   SLACK_BOT_TOKEN / SLACK_APP_TOKEN          (to run on Slack)
 #   DISCORD_BOT_TOKEN / DISCORD_APP_ID         (to run on Discord; DISCORD_GUILD_ID optional)
 #   TELEGRAM_BOT_TOKEN                         (to run on Telegram)
@@ -333,9 +331,9 @@ cp .env.example .env
 #   NOTION_MCP_AUTH_TOKEN   (any strong string; shared between the sidecar and the agent)
 ```
 
-A Channel runs only through the Intelligence runtime, so
-`COPILOTKIT_INTELLIGENCE_URL` + `COPILOTKIT_API_KEY` are **required** (free tier).
-The platform adapters stay direct — the runtime that owns the Channel starts each
+A Channel runs only through the Intelligence runtime, so `COPILOTKIT_API_KEY` is
+**required** (free tier). There are no URLs to set — the SDK defaults to the
+managed Intelligence platform. The platform adapters stay direct — the runtime that owns the Channel starts each
 of them for you. Linear and Notion are independent — set only the ones you want;
 the agent wires up whichever credentials are present.
 

--- a/examples/slack/app/index.ts
+++ b/examples/slack/app/index.ts
@@ -13,8 +13,8 @@
  * rendering) is platform-agnostic and shared verbatim.
  *
  * RUN MODEL — a Channel runs ONLY through the Intelligence runtime, so this
- * example needs an Intelligence key (free tier: `COPILOTKIT_INTELLIGENCE_URL` +
- * `COPILOTKIT_API_KEY`). The platform adapters stay DIRECT (they keep their own
+ * example needs an Intelligence key (free tier: `COPILOTKIT_API_KEY`; the
+ * platform URLs default to the managed service). The platform adapters stay DIRECT (they keep their own
  * Slack/Discord/Telegram/WhatsApp credentials + transports); the runtime OWNS
  * the Channel's lifecycle and STARTS all of its direct adapters for us. So all
  * four platforms stay on the ONE Channel — you declare it on
@@ -280,11 +280,13 @@ async function main() {
   // The Intelligence client the Channel-owning runtime is configured with. A
   // Channel runs only through the Intelligence runtime — the direct adapters
   // keep their own platform credentials, but the runtime is what starts them.
-  // Both URLs are required: the API and realtime planes are separate hosts
-  // (api.… vs realtime.…), so neither can be derived from the other.
+  // apiUrl/wsUrl default to CopilotKit's managed Intelligence platform; the env
+  // overrides target a self-hosted or dev deployment. Set both or neither: the
+  // API and realtime planes are separate hosts (api.… vs realtime.…), so
+  // neither can be derived from the other.
   const intelligence = new CopilotKitIntelligence({
-    apiUrl: required("COPILOTKIT_INTELLIGENCE_URL"),
-    wsUrl: required("COPILOTKIT_INTELLIGENCE_WS_URL"),
+    apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL,
+    wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL,
     apiKey: required("COPILOTKIT_API_KEY"),
   });
 

--- a/examples/slack/app/managed.test.ts
+++ b/examples/slack/app/managed.test.ts
@@ -82,9 +82,10 @@ describe("managed channel entrypoint", () => {
   it("mounts the normal handler over a channels-carrying runtime and stops channels on shutdown", async () => {
     for (const key of envKeys) previousEnv.set(key, process.env[key]);
     process.env.AGENT_URL = "http://agent.test/run";
+    // Overrides the managed-platform defaults to point at a local stack. Both
+    // are set together, and deliberately at a different host+port: the realtime
+    // plane is deployed separately, so there is no derive from apiUrl.
     process.env.COPILOTKIT_INTELLIGENCE_URL = "http://localhost:4201";
-    // Required, and deliberately a different host+port from the API URL: the
-    // realtime plane is deployed separately, so there is no derive from apiUrl.
     process.env.COPILOTKIT_INTELLIGENCE_WS_URL = "ws://localhost:4401";
     process.env.COPILOTKIT_API_KEY = "cpk-test";
 

--- a/examples/slack/app/managed.ts
+++ b/examples/slack/app/managed.ts
@@ -125,11 +125,13 @@ async function main() {
   // (plus the channel `name`) the runtime derives the managed Channel's
   // activation config — project id, adapter, socket URL/auth — with no infra
   // ids supplied by the developer.
-  // Both URLs are required: the API and realtime planes are separate hosts
-  // (api.… vs realtime.…), so neither can be derived from the other.
+  // apiUrl/wsUrl default to CopilotKit's managed Intelligence platform; the env
+  // overrides target a self-hosted or dev deployment. Set both or neither: the
+  // API and realtime planes are separate hosts (api.… vs realtime.…), so
+  // neither can be derived from the other.
   const intelligence = new CopilotKitIntelligence({
-    apiUrl: required("COPILOTKIT_INTELLIGENCE_URL"),
-    wsUrl: required("COPILOTKIT_INTELLIGENCE_WS_URL"),
+    apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL,
+    wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL,
     apiKey: required("COPILOTKIT_API_KEY"),
   });
 

--- a/examples/teams/.env.example
+++ b/examples/teams/.env.example
@@ -7,13 +7,15 @@ OPENAI_API_KEY=
 # A Channel runs ONLY through the Intelligence runtime. The Teams adapter stays
 # DIRECT (no Microsoft creds needed in the Playground), but the runtime that
 # starts/stops it is configured with an Intelligence key. Free tier is enough.
-# Intelligence platform API base URL.
-COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
-# Websocket base URL for the realtime plane. This is a DIFFERENT host from the
-# API URL above (api.… vs realtime.…), so it cannot be derived from it — set both.
-COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
-# Project runtime API key (cpk-…).
+# Project runtime API key (cpk-…). The only Intelligence value you need: the SDK
+# defaults both URLs to the managed platform.
 COPILOTKIT_API_KEY=cpk-...
+# Optional, for a self-hosted or dev Intelligence deployment only. Set BOTH or
+# neither: the realtime plane is a DIFFERENT host from the API (api.… vs
+# realtime.…), so it cannot be derived from the API URL, and setting one alone
+# leaves the other plane on the managed platform.
+# COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
+# COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 
 # The Microsoft 365 Agents Playground connects to the bot anonymously, so NO
 # Microsoft credentials are needed for local development. Just run `pnpm start`.

--- a/examples/teams/README.md
+++ b/examples/teams/README.md
@@ -23,8 +23,6 @@ From this directory (after `pnpm install` at the repo root):
 
 ```sh
 export OPENAI_API_KEY=sk-...              # or add it to .env (see .env.example)
-export COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
-export COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 export COPILOTKIT_API_KEY=cpk-...          # Intelligence key (free tier)
 pnpm start                                 # starts the bot on http://localhost:3978/api/messages
 ```
@@ -178,15 +176,18 @@ Set the environment for wherever you deploy:
 - `OPENAI_API_KEY` _(required)_: the bot runs a `BuiltInAgent` and exits at
   startup without it.
 - `OPENAI_MODEL` _(optional)_: defaults to `openai/gpt-5.5`.
-- `COPILOTKIT_INTELLIGENCE_URL` / `COPILOTKIT_INTELLIGENCE_WS_URL` /
-  `COPILOTKIT_API_KEY` _(all required)_: the Intelligence runtime that owns the
+- `COPILOTKIT_API_KEY` _(required)_: the Intelligence runtime that owns the
   Channel lifecycle. A Channel runs only through Intelligence, so the bot exits
-  at startup without these (free tier is enough). The API and realtime planes are
-  **separate hosts** (`api.intelligence.copilotkit.ai` vs
-  `realtime.intelligence.copilotkit.ai`), so the websocket URL cannot be derived
-  from the API URL by swapping the scheme — both are shown on your project's
-  Intelligence dashboard. Getting the websocket host wrong does not produce an
-  error; the Channel sits in `connecting` until it times out.
+  at startup without it (free tier is enough). No URLs to configure — the SDK
+  defaults to the managed Intelligence platform.
+- `COPILOTKIT_INTELLIGENCE_URL` / `COPILOTKIT_INTELLIGENCE_WS_URL` _(optional)_:
+  point the bot at a self-hosted or dev Intelligence deployment. Set **both or
+  neither**: the API and realtime planes are **separate hosts**
+  (`api.intelligence.copilotkit.ai` vs `realtime.intelligence.copilotkit.ai`), so
+  the websocket URL cannot be derived from the API URL by swapping the scheme, and
+  setting one alone leaves the other plane on the managed platform. Getting the
+  websocket host wrong does not produce an error; the Channel sits in `connecting`
+  until it times out.
 - `CHANNELS_PORT` _(optional)_: port for the Intelligence runtime that owns the
   Channel (loopback-only, default 8300).
 - `clientId` / `clientSecret` / `tenantId`: needed to reach real Teams (see

--- a/examples/teams/app/index.tsx
+++ b/examples/teams/app/index.tsx
@@ -16,9 +16,9 @@
  * `bot.stop()` and no standalone path.
  *
  * Requires `OPENAI_API_KEY` (the BuiltInAgent's LLM) AND an Intelligence key
- * (`COPILOTKIT_INTELLIGENCE_URL` + `COPILOTKIT_API_KEY` — free tier), which the
- * runtime that owns the Channel is configured with. No Microsoft credentials
- * are needed to test in the M365 Agents Playground:
+ * (`COPILOTKIT_API_KEY` — free tier; the platform URLs default to the managed
+ * service), which the runtime that owns the Channel is configured with. No
+ * Microsoft credentials are needed to test in the M365 Agents Playground:
  *
  *   pnpm start        # bot on http://localhost:3978/api/messages
  *   pnpm playground   # M365 Agents Playground UI (http://localhost:56150)
@@ -70,11 +70,11 @@ const required = (name: string): string => {
       `Missing ${name}.\n` +
         "Channels run only through the Intelligence runtime, which needs an " +
         "Intelligence key (free tier).\n" +
-        "  export COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai\n" +
-        "  export COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai\n" +
-        "  export COPILOTKIT_API_KEY=cpk-...   (or add them to examples/teams/.env)\n" +
-        "The API and websocket URLs are DIFFERENT hosts (api.… vs realtime.…), so\n" +
-        "the websocket URL cannot be derived from the API URL — set both.",
+        "  export COPILOTKIT_API_KEY=cpk-...   (or add it to examples/teams/.env)\n" +
+        "No URLs to set: the SDK defaults to the managed Intelligence platform. A\n" +
+        "self-hosted deployment exports COPILOTKIT_INTELLIGENCE_URL AND\n" +
+        "COPILOTKIT_INTELLIGENCE_WS_URL — they are DIFFERENT hosts, so the websocket\n" +
+        "URL cannot be derived from the API URL.",
     );
     process.exit(1);
   }
@@ -236,11 +236,13 @@ bot.onMessage(async ({ thread, message }) => {
 // Teams adapter stays DIRECT (it keeps its own credentials/transport), but a
 // Channel runs only through the Intelligence runtime, so the runtime is what
 // starts and stops it.
-// Both URLs are required: the API and realtime planes are separate hosts, so
-// there is no derive that produces one from the other.
+// apiUrl/wsUrl default to CopilotKit's managed Intelligence platform; the env
+// overrides target a self-hosted or dev deployment. Set both or neither: the API
+// and realtime planes are separate hosts, so there is no derive that produces one
+// from the other.
 const intelligence = new CopilotKitIntelligence({
-  apiUrl: required("COPILOTKIT_INTELLIGENCE_URL"),
-  wsUrl: required("COPILOTKIT_INTELLIGENCE_WS_URL"),
+  apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL,
+  wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL,
   apiKey: required("COPILOTKIT_API_KEY"),
 });
 

--- a/packages/channels-core/README.md
+++ b/packages/channels-core/README.md
@@ -81,10 +81,8 @@ const channel = createChannel({
 
 const runtime = new CopilotRuntime({
   intelligence: new CopilotKitIntelligence({
-    // The API and realtime planes are DIFFERENT hosts — do not scheme-swap one
-    // into the other. Both are shown on your project's Intelligence dashboard.
-    apiUrl: "https://api.intelligence.copilotkit.ai",
-    wsUrl: "wss://realtime.intelligence.copilotkit.ai",
+    // apiUrl and wsUrl default to the managed Intelligence platform — override
+    // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
   identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),

--- a/packages/channels-discord/README.md
+++ b/packages/channels-discord/README.md
@@ -63,10 +63,8 @@ bot.onMention(({ thread }) => thread.runAgent());
 // The runtime owns the channel's lifecycle — there is no `bot.start()`.
 const runtime = new CopilotRuntime({
   intelligence: new CopilotKitIntelligence({
-    // The API and realtime planes are DIFFERENT hosts — do not scheme-swap one
-    // into the other. Both are shown on your project's Intelligence dashboard.
-    apiUrl: "https://api.intelligence.copilotkit.ai",
-    wsUrl: "wss://realtime.intelligence.copilotkit.ai",
+    // apiUrl and wsUrl default to the managed Intelligence platform — override
+    // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
   identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),

--- a/packages/channels-slack/README.md
+++ b/packages/channels-slack/README.md
@@ -53,10 +53,8 @@ bot.onMention(({ thread }) => thread.runAgent());
 // The runtime owns the channel's lifecycle — there is no `bot.start()`.
 const runtime = new CopilotRuntime({
   intelligence: new CopilotKitIntelligence({
-    // The API and realtime planes are DIFFERENT hosts — do not scheme-swap one
-    // into the other. Both are shown on your project's Intelligence dashboard.
-    apiUrl: "https://api.intelligence.copilotkit.ai",
-    wsUrl: "wss://realtime.intelligence.copilotkit.ai",
+    // apiUrl and wsUrl default to the managed Intelligence platform — override
+    // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
   identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),

--- a/packages/channels-teams/README.md
+++ b/packages/channels-teams/README.md
@@ -43,10 +43,8 @@ bot.onMessage(({ thread, message }) => thread.post(`Echo: ${message.text}`));
 // The runtime owns the channel's lifecycle — there is no `bot.start()`.
 const runtime = new CopilotRuntime({
   intelligence: new CopilotKitIntelligence({
-    // The API and realtime planes are DIFFERENT hosts — do not scheme-swap one
-    // into the other. Both are shown on your project's Intelligence dashboard.
-    apiUrl: "https://api.intelligence.copilotkit.ai",
-    wsUrl: "wss://realtime.intelligence.copilotkit.ai",
+    // apiUrl and wsUrl default to the managed Intelligence platform — override
+    // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
   identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),

--- a/packages/channels-telegram/README.md
+++ b/packages/channels-telegram/README.md
@@ -74,10 +74,8 @@ bot.onThreadStarted(async ({ thread }) => {
 // The runtime owns the channel's lifecycle — there is no `bot.start()`.
 const runtime = new CopilotRuntime({
   intelligence: new CopilotKitIntelligence({
-    // The API and realtime planes are DIFFERENT hosts — do not scheme-swap one
-    // into the other. Both are shown on your project's Intelligence dashboard.
-    apiUrl: "https://api.intelligence.copilotkit.ai",
-    wsUrl: "wss://realtime.intelligence.copilotkit.ai",
+    // apiUrl and wsUrl default to the managed Intelligence platform — override
+    // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
   identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),

--- a/packages/channels-whatsapp/README.md
+++ b/packages/channels-whatsapp/README.md
@@ -58,10 +58,8 @@ bot.onMessage(async ({ thread }) => {
 // The runtime owns the channel's lifecycle — there is no `bot.start()`.
 const runtime = new CopilotRuntime({
   intelligence: new CopilotKitIntelligence({
-    // The API and realtime planes are DIFFERENT hosts — do not scheme-swap one
-    // into the other. Both are shown on your project's Intelligence dashboard.
-    apiUrl: "https://api.intelligence.copilotkit.ai",
-    wsUrl: "wss://realtime.intelligence.copilotkit.ai",
+    // apiUrl and wsUrl default to the managed Intelligence platform — override
+    // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
   identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),

--- a/packages/channels/README.md
+++ b/packages/channels/README.md
@@ -55,10 +55,8 @@ channel.onMessage(({ thread, message }) =>
 // The runtime owns the Channel's lifecycle — there is no `channel.start()`.
 const runtime = new CopilotRuntime({
   intelligence: new CopilotKitIntelligence({
-    // The API and realtime planes are DIFFERENT hosts — do not scheme-swap one
-    // into the other. Both are shown on your project's Intelligence dashboard.
-    apiUrl: "https://api.intelligence.copilotkit.ai",
-    wsUrl: "wss://realtime.intelligence.copilotkit.ai",
+    // apiUrl and wsUrl default to the managed Intelligence platform — override
+    // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
   identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),

--- a/packages/react-core/skills/react-core/references/threads.md
+++ b/packages/react-core/skills/react-core/references/threads.md
@@ -127,8 +127,7 @@ import {
 } from "@copilotkit/runtime/v2";
 
 const intelligence = new CopilotKitIntelligence({
-  apiUrl: process.env.COPILOTKIT_INTELLIGENCE_API_URL!,
-  wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
+  // apiUrl / wsUrl default to the managed Intelligence platform — leave unset.
   apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!,
   organizationId: process.env.COPILOTKIT_ORG_ID!,
 });

--- a/packages/runtime/skills/runtime/references/intelligence-mode.md
+++ b/packages/runtime/skills/runtime/references/intelligence-mode.md
@@ -11,8 +11,15 @@ Obtain `apiKey` and `organizationId` from the CopilotKit Intelligence dashboard.
 
 ### URL format
 
-The client prepends `/api/...` and the Intelligence websocket layer derives `/runner`
-or `/client` suffixes internally. Pass the bare base URLs — do NOT append `/api`,
+**Omit `apiUrl` and `wsUrl`.** Both default to the managed platform
+(`https://api.intelligence.copilotkit.ai` and
+`wss://realtime.intelligence.copilotkit.ai`), so `apiKey` is the only URL-related
+config you need. Never invent or guess these values — leaving them unset is always
+correct against the managed service.
+
+If you do set them (non-production or a future self-hosted deployment), the client
+prepends `/api/...` and the Intelligence websocket layer derives `/runner` or
+`/client` suffixes internally. Pass the bare base URLs — do NOT append `/api`,
 `/socket`, `/runner`, or `/client` yourself:
 
 ```typescript
@@ -29,8 +36,9 @@ wsUrl:  "wss://realtime.intelligence.copilotkit.ai/socket",
 produce one from the other by swapping the scheme. Deriving `wsUrl` as
 `apiUrl.replace(/^http/, "ws")` yields `wss://api.intelligence.copilotkit.ai`, which
 serves no socket — and the resulting failure is a silent hang, not an error, because
-the socket layer treats an unreachable host as a retryable reconnect. Always configure
-both explicitly. Both values are shown on your project's Intelligence dashboard.
+the socket layer treats an unreachable host as a retryable reconnect. For the same
+reason, override the two together or not at all: setting one alone leaves the other
+plane on the managed host, which the client warns about at construction.
 
 Source: `packages/runtime/src/v2/runtime/intelligence-platform/client.ts:41-46, 259,
 356-357, 437, 468, 682-708`.
@@ -45,8 +53,7 @@ import {
 } from "@copilotkit/runtime/v2";
 
 const intelligence = new CopilotKitIntelligence({
-  apiUrl: "https://api.intelligence.copilotkit.ai",
-  wsUrl: "wss://realtime.intelligence.copilotkit.ai",
+  // apiUrl / wsUrl default to the managed Intelligence platform — leave them unset.
   apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!,
   organizationId: process.env.COPILOTKIT_INTELLIGENCE_ORG_ID!,
 });
@@ -200,14 +207,20 @@ new CopilotKitIntelligence({
   apiKey,
   organizationId,
 });
+
+new CopilotKitIntelligence({
+  // Only one plane overridden — wsUrl silently stays on the managed host. Warns, then hangs.
+  apiUrl: "https://api.intelligence.copilotkit.ai",
+  apiKey,
+  organizationId,
+});
 ```
 
 Correct:
 
 ```typescript
 new CopilotKitIntelligence({
-  apiUrl: "https://api.intelligence.copilotkit.ai",
-  wsUrl: "wss://realtime.intelligence.copilotkit.ai",
+  // No apiUrl / wsUrl — they default to the managed platform.
   apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!,
   organizationId: process.env.COPILOTKIT_INTELLIGENCE_ORG_ID!,
 });

--- a/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
@@ -4,6 +4,7 @@ import { CopilotKitIntelligence } from "../client";
 const fetchMock = vi.fn();
 globalThis.fetch = fetchMock as unknown as typeof fetch;
 const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
 function jsonResponse(body: unknown, status = 200) {
   return Promise.resolve({
@@ -31,6 +32,7 @@ describe("CopilotKitIntelligence", () => {
   beforeEach(() => {
     fetchMock.mockReset();
     consoleErrorSpy.mockClear();
+    consoleWarnSpy.mockClear();
     client = new CopilotKitIntelligence({
       apiUrl: "https://api.example.com",
       wsUrl: "wss://ws.example.com/socket",
@@ -60,6 +62,90 @@ describe("CopilotKitIntelligence", () => {
 
     expect(c.ɵgetRunnerWsUrl()).toBe("wss://ws.example.com/runner");
     expect(c.ɵgetClientWsUrl()).toBe("wss://ws.example.com/client");
+  });
+
+  describe("managed platform URL defaults", () => {
+    it("defaults apiUrl to the managed Intelligence API host", async () => {
+      const c = new CopilotKitIntelligence({ apiKey: "k" });
+      fetchMock.mockReturnValue(jsonResponse({ threads: [], joinCode: "" }));
+      await c.listThreads({ userId: "u", agentId: "a" });
+      expect(fetchMock.mock.calls[0][0]).toMatch(
+        /^https:\/\/api\.intelligence\.copilotkit\.ai\/api/,
+      );
+    });
+
+    it("defaults the websocket URLs to the managed realtime host", () => {
+      const c = new CopilotKitIntelligence({ apiKey: "k" });
+      expect(c.ɵgetRunnerWsUrl()).toBe(
+        "wss://realtime.intelligence.copilotkit.ai/runner",
+      );
+      expect(c.ɵgetClientWsUrl()).toBe(
+        "wss://realtime.intelligence.copilotkit.ai/client",
+      );
+    });
+
+    it("treats blank URLs as unset, so an empty env var still reaches the managed platform", async () => {
+      const c = new CopilotKitIntelligence({
+        apiUrl: "",
+        wsUrl: "   ",
+        apiKey: "k",
+      });
+      fetchMock.mockReturnValue(jsonResponse({ threads: [], joinCode: "" }));
+      await c.listThreads({ userId: "u", agentId: "a" });
+      expect(fetchMock.mock.calls[0][0]).toMatch(
+        /^https:\/\/api\.intelligence\.copilotkit\.ai\/api/,
+      );
+      expect(c.ɵgetRunnerWsUrl()).toBe(
+        "wss://realtime.intelligence.copilotkit.ai/runner",
+      );
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not warn when both URLs are omitted", () => {
+      const c = new CopilotKitIntelligence({ apiKey: "k" });
+      expect(c).toBeInstanceOf(CopilotKitIntelligence);
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not warn when both URLs are provided", () => {
+      const c = new CopilotKitIntelligence({
+        apiUrl: "https://intelligence.internal",
+        wsUrl: "wss://realtime.intelligence.internal",
+        apiKey: "k",
+      });
+      expect(c.ɵgetRunnerWsUrl()).toBe(
+        "wss://realtime.intelligence.internal/runner",
+      );
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it("warns that wsUrl fell back to the managed host when only apiUrl is set", () => {
+      const c = new CopilotKitIntelligence({
+        apiUrl: "https://intelligence.internal",
+        apiKey: "k",
+      });
+      expect(c.ɵgetRunnerWsUrl()).toBe(
+        "wss://realtime.intelligence.copilotkit.ai/runner",
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/wsUrl falls back to the managed default/),
+      );
+    });
+
+    it("warns that apiUrl fell back to the managed host when only wsUrl is set", async () => {
+      const c = new CopilotKitIntelligence({
+        wsUrl: "wss://realtime.intelligence.internal",
+        apiKey: "k",
+      });
+      fetchMock.mockReturnValue(jsonResponse({ threads: [], joinCode: "" }));
+      await c.listThreads({ userId: "u", agentId: "a" });
+      expect(fetchMock.mock.calls[0][0]).toMatch(
+        /^https:\/\/api\.intelligence\.copilotkit\.ai\/api/,
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/apiUrl falls back to the managed default/),
+      );
+    });
   });
 
   it("sends Bearer authorization header", async () => {

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -14,6 +14,21 @@ import { randomUUID } from "crypto";
 export const INTELLIGENCE_USER_ID_HEADER = "x-cpki-user-id";
 
 /**
+ * REST base URL of CopilotKit's managed Intelligence platform — the default
+ * when {@link CopilotKitIntelligenceConfig.apiUrl} is omitted.
+ */
+const MANAGED_INTELLIGENCE_API_URL = "https://api.intelligence.copilotkit.ai";
+
+/**
+ * Websocket base URL of CopilotKit's managed Intelligence platform — the
+ * default when {@link CopilotKitIntelligenceConfig.wsUrl} is omitted.
+ *
+ * A different host from {@link MANAGED_INTELLIGENCE_API_URL}: the API and
+ * realtime planes are deployed separately.
+ */
+const MANAGED_INTELLIGENCE_WS_URL = "wss://realtime.intelligence.copilotkit.ai";
+
+/**
  * Error thrown when an Intelligence platform HTTP request returns a non-2xx
  * status. Carries the HTTP {@link status} code so callers can branch on
  * specific failures (e.g. 404 for "not found", 409 for "conflict") without
@@ -41,28 +56,6 @@ export class PlatformRequestError extends Error {
   }
 }
 
-/**
- * Client for the CopilotKit Intelligence Platform REST API.
- *
- * Construct the client once and pass it to any consumers that need it
- * (e.g. `CopilotRuntime`, `IntelligenceAgentRunner`):
- *
- * ```ts
- * import { CopilotKitIntelligence, CopilotRuntime } from "@copilotkit/runtime";
- *
- * const intelligence = new CopilotKitIntelligence({
- *   apiUrl: "https://api.intelligence.copilotkit.ai",
- *   wsUrl: "wss://realtime.intelligence.copilotkit.ai",
- *   apiKey: process.env.COPILOTKIT_API_KEY!,
- * });
- *
- * const runtime = new CopilotRuntime({
- *   agents,
- *   intelligence,
- * });
- * ```
- */
-
 /** Payload passed to `onThreadDeleted` listeners. */
 export interface ThreadDeletedPayload {
   threadId: string;
@@ -71,17 +64,27 @@ export interface ThreadDeletedPayload {
 }
 
 export interface CopilotKitIntelligenceConfig {
-  /** Base URL of the intelligence platform API, e.g. "https://api.intelligence.copilotkit.ai" */
-  apiUrl: string;
   /**
-   * Intelligence websocket base URL, e.g. "wss://realtime.intelligence.copilotkit.ai".
-   * Runner and client socket URLs are derived from this by appending `/runner` or
-   * `/client`, so pass the bare base.
+   * Base URL of the intelligence platform API.
+   *
+   * Defaults to CopilotKit's managed platform,
+   * `https://api.intelligence.copilotkit.ai`. Set it only when pointing at a
+   * self-hosted or non-production deployment — and set {@link wsUrl} with it.
+   */
+  apiUrl?: string;
+  /**
+   * Intelligence websocket base URL. Runner and client socket URLs are derived
+   * from this by appending `/runner` or `/client`, so pass the bare base.
+   *
+   * Defaults to CopilotKit's managed platform,
+   * `wss://realtime.intelligence.copilotkit.ai`.
    *
    * This is a DIFFERENT host from {@link apiUrl} — the API and realtime planes are
    * deployed separately — so it cannot be derived by scheme-swapping `apiUrl`.
+   * Overriding one without the other therefore points the two planes at
+   * different deployments, which logs a warning.
    */
-  wsUrl: string;
+  wsUrl?: string;
   /** API key for authenticating with the intelligence platform */
   apiKey: string;
   /**
@@ -401,6 +404,36 @@ interface ThreadEnvelope {
   thread: ThreadSummary;
 }
 
+/**
+ * Client for the CopilotKit Intelligence Platform REST API.
+ *
+ * Construct the client once and pass it to any consumers that need it
+ * (e.g. `CopilotRuntime`, `IntelligenceAgentRunner`):
+ *
+ * ```ts
+ * import { CopilotKitIntelligence, CopilotRuntime } from "@copilotkit/runtime";
+ *
+ * const intelligence = new CopilotKitIntelligence({
+ *   apiKey: process.env.COPILOTKIT_API_KEY!,
+ * });
+ *
+ * const runtime = new CopilotRuntime({
+ *   agents,
+ *   intelligence,
+ * });
+ * ```
+ *
+ * `apiUrl` and `wsUrl` default to CopilotKit's managed Intelligence platform.
+ * Override both together to target a self-hosted or non-production deployment:
+ *
+ * ```ts
+ * const intelligence = new CopilotKitIntelligence({
+ *   apiUrl: "https://intelligence.internal",
+ *   wsUrl: "wss://realtime.intelligence.internal",
+ *   apiKey: process.env.COPILOTKIT_API_KEY!,
+ * });
+ * ```
+ */
 export class CopilotKitIntelligence {
   #apiUrl: string;
   #runnerWsUrl: string;
@@ -412,9 +445,18 @@ export class CopilotKitIntelligence {
   #threadDeletedListeners = new Set<(params: ThreadDeletedPayload) => void>();
 
   constructor(config: CopilotKitIntelligenceConfig) {
-    const intelligenceWsUrl = normalizeIntelligenceWsUrl(config.wsUrl);
+    const configuredApiUrl = configuredUrl(config.apiUrl);
+    const configuredWsUrl = configuredUrl(config.wsUrl);
+    warnOnPartialHostOverride(configuredApiUrl, configuredWsUrl);
 
-    this.#apiUrl = config.apiUrl.replace(/\/$/, "");
+    const intelligenceWsUrl = normalizeIntelligenceWsUrl(
+      configuredWsUrl ?? MANAGED_INTELLIGENCE_WS_URL,
+    );
+
+    this.#apiUrl = (configuredApiUrl ?? MANAGED_INTELLIGENCE_API_URL).replace(
+      /\/$/,
+      "",
+    );
     this.#runnerWsUrl = deriveRunnerWsUrl(intelligenceWsUrl);
     this.#clientWsUrl = deriveClientWsUrl(intelligenceWsUrl);
     this.#apiKey = config.apiKey;
@@ -1087,6 +1129,47 @@ export class CopilotKitIntelligence {
 
     // request() returns undefined for empty/204 responses
     return result ?? null;
+  }
+}
+
+/**
+ * Normalize a configured URL to "provided" or "not provided". A blank string
+ * counts as not provided: these URLs are typically wired from environment
+ * variables, and a declared-but-empty variable (`COPILOTKIT_INTELLIGENCE_URL=`,
+ * common in generated `.env` files and container configs) arrives as `""`. Left
+ * as-is it would produce host-relative requests instead of falling back to the
+ * managed platform.
+ */
+function configuredUrl(url: string | undefined): string | undefined {
+  const trimmed = url?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Warn when exactly one of `apiUrl`/`wsUrl` is configured. The API and realtime
+ * planes are separate hosts, so a lone override silently leaves the other plane
+ * on CopilotKit's managed platform — a self-hosted API paired with the managed
+ * gateway (or vice versa), which fails as a hang rather than an error.
+ */
+function warnOnPartialHostOverride(
+  apiUrl: string | undefined,
+  wsUrl: string | undefined,
+): void {
+  if (apiUrl && !wsUrl) {
+    logger.warn(
+      `CopilotKitIntelligence: apiUrl is set to "${apiUrl}" but wsUrl is not, ` +
+        `so wsUrl falls back to the managed default "${MANAGED_INTELLIGENCE_WS_URL}". ` +
+        `The API and realtime planes are separate hosts — set both when pointing at a self-hosted deployment.`,
+    );
+    return;
+  }
+
+  if (wsUrl && !apiUrl) {
+    logger.warn(
+      `CopilotKitIntelligence: wsUrl is set to "${wsUrl}" but apiUrl is not, ` +
+        `so apiUrl falls back to the managed default "${MANAGED_INTELLIGENCE_API_URL}". ` +
+        `The API and realtime planes are separate hosts — set both when pointing at a self-hosted deployment.`,
+    );
   }
 }
 

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -109,14 +109,8 @@ channel.onMessage(async ({ thread, message }) => {
 const runtime = new CopilotRuntime({
   agents: {},
   intelligence: new CopilotKitIntelligence({
-    // Both URLs come from your Intelligence dashboard; see the Quickstart for the
-
-    // full env block. Self-hosted deployments use their own two hosts.
-
-    apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
-    // A separate host from apiUrl — the realtime plane is deployed apart, so
-    // this cannot be derived by swapping the API URL scheme.
-    wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
+    // apiUrl and wsUrl default to the managed Intelligence platform. Override
+    // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_API_KEY!,
   }),
   identifyUser: () => ({ id: "demo-user", name: "Demo User" }),

--- a/showcase/shell-docs/src/content/docs/channels/mcp.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/mcp.mdx
@@ -81,14 +81,8 @@ channel.onMessage(async ({ thread, message }) => {
 const runtime = new CopilotRuntime({
   agents: {},
   intelligence: new CopilotKitIntelligence({
-    // Both URLs come from your Intelligence dashboard; see the Quickstart for the
-
-    // full env block. Self-hosted deployments use their own two hosts.
-
-    apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
-    // A separate host from apiUrl — the realtime plane is deployed apart, so
-    // this cannot be derived by swapping the API URL scheme.
-    wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
+    // apiUrl and wsUrl default to the managed Intelligence platform. Override
+    // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_API_KEY!,
   }),
   identifyUser: () => ({ id: "demo-user", name: "Demo User" }),

--- a/showcase/shell-docs/src/content/docs/channels/platforms/discord.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/discord.mdx
@@ -24,10 +24,6 @@ DISCORD_GUILD_ID=...   # optional, for faster command registration in one server
 
 # The runtime runs every channel, so a CopilotKit Intelligence key is required
 # even for a direct adapter (free tier available).
-COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
-# A separate host from the API URL above, so it cannot be derived from it.
-# Self-hosted deployments substitute their own two hosts.
-COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 COPILOTKIT_API_KEY=cpk-...
 ```
 
@@ -61,10 +57,8 @@ channel.onMessage(async ({ thread, message }) => {
 const runtime = new CopilotRuntime({
   agents: {},
   intelligence: new CopilotKitIntelligence({
-    apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
-    // A separate host from apiUrl — the realtime plane is deployed apart, so
-    // this cannot be derived by swapping the API URL scheme.
-    wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
+    // apiUrl and wsUrl default to the managed Intelligence platform. Override
+    // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_API_KEY!,
   }),
   identifyUser: () => ({ id: "demo-user", name: "Demo User" }),

--- a/showcase/shell-docs/src/content/docs/channels/platforms/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/slack.mdx
@@ -23,10 +23,6 @@ SLACK_APP_TOKEN=xapp-...   # App-level token, for Socket Mode
 
 # The runtime runs every channel, so a CopilotKit Intelligence key is required
 # even for a direct adapter (free tier available).
-COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
-# A separate host from the API URL above, so it cannot be derived from it.
-# Self-hosted deployments substitute their own two hosts.
-COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 COPILOTKIT_API_KEY=cpk-...
 ```
 
@@ -67,10 +63,8 @@ channel.onMessage(async ({ thread, message }) => {
 const runtime = new CopilotRuntime({
   agents: {},
   intelligence: new CopilotKitIntelligence({
-    apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
-    // A separate host from apiUrl — the realtime plane is deployed apart, so
-    // this cannot be derived by swapping the API URL scheme.
-    wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
+    // apiUrl and wsUrl default to the managed Intelligence platform. Override
+    // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_API_KEY!,
   }),
   identifyUser: () => ({ id: "demo-user", name: "Demo User" }),

--- a/showcase/shell-docs/src/content/docs/channels/platforms/teams.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/teams.mdx
@@ -28,10 +28,6 @@ tenantId=...
 
 # The runtime runs every channel, so a CopilotKit Intelligence key is required
 # even for a direct adapter (free tier available).
-COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
-# A separate host from the API URL above, so it cannot be derived from it.
-# Self-hosted deployments substitute their own two hosts.
-COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 COPILOTKIT_API_KEY=cpk-...
 ```
 
@@ -67,10 +63,8 @@ channel.onMessage(async ({ thread, message }) => {
 const runtime = new CopilotRuntime({
   agents: {},
   intelligence: new CopilotKitIntelligence({
-    apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
-    // A separate host from apiUrl — the realtime plane is deployed apart, so
-    // this cannot be derived by swapping the API URL scheme.
-    wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
+    // apiUrl and wsUrl default to the managed Intelligence platform. Override
+    // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_API_KEY!,
   }),
   identifyUser: () => ({ id: "demo-user", name: "Demo User" }),

--- a/showcase/shell-docs/src/content/docs/channels/platforms/telegram.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/telegram.mdx
@@ -22,10 +22,6 @@ TELEGRAM_BOT_TOKEN=...
 
 # The runtime runs every channel, so a CopilotKit Intelligence key is required
 # even for a direct adapter (free tier available).
-COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
-# A separate host from the API URL above, so it cannot be derived from it.
-# Self-hosted deployments substitute their own two hosts.
-COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 COPILOTKIT_API_KEY=cpk-...
 ```
 
@@ -55,10 +51,8 @@ channel.onMessage(async ({ thread, message }) => {
 const runtime = new CopilotRuntime({
   agents: {},
   intelligence: new CopilotKitIntelligence({
-    apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
-    // A separate host from apiUrl — the realtime plane is deployed apart, so
-    // this cannot be derived by swapping the API URL scheme.
-    wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
+    // apiUrl and wsUrl default to the managed Intelligence platform. Override
+    // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_API_KEY!,
   }),
   identifyUser: () => ({ id: "demo-user", name: "Demo User" }),

--- a/showcase/shell-docs/src/content/docs/channels/platforms/whatsapp.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/platforms/whatsapp.mdx
@@ -25,10 +25,6 @@ WHATSAPP_VERIFY_TOKEN=...   # a string you choose, used to verify the webhook
 
 # The runtime runs every channel, so a CopilotKit Intelligence key is required
 # even for a direct adapter (free tier available).
-COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
-# A separate host from the API URL above, so it cannot be derived from it.
-# Self-hosted deployments substitute their own two hosts.
-COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 COPILOTKIT_API_KEY=cpk-...
 ```
 
@@ -68,10 +64,8 @@ channel.onMessage(async ({ thread, message }) => {
 const runtime = new CopilotRuntime({
   agents: {},
   intelligence: new CopilotKitIntelligence({
-    apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
-    // A separate host from apiUrl — the realtime plane is deployed apart, so
-    // this cannot be derived by swapping the API URL scheme.
-    wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
+    // apiUrl and wsUrl default to the managed Intelligence platform. Override
+    // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_API_KEY!,
   }),
   identifyUser: () => ({ id: "demo-user", name: "Demo User" }),

--- a/showcase/shell-docs/src/content/docs/channels/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/quickstart.mdx
@@ -53,21 +53,20 @@ walkthrough and per-platform install links.
 <Step>
 ### Set the environment
 
-The Intelligence runtime reads the first three. For a managed channel no platform
+`COPILOTKIT_API_KEY` is your Intelligence key. For a managed channel no platform
 tokens live in your app. `OPENAI_API_KEY` powers the agent's model.
 
-The API and websocket URLs are **different hosts**, so the websocket URL cannot be
-derived from the API URL by swapping the scheme — set both. Getting the websocket
-host wrong does not raise an error; the channel sits in `connecting` until it times
-out. Self-hosted deployments substitute their own two hosts.
-
 ```bash
-COPILOTKIT_INTELLIGENCE_URL=https://api.intelligence.copilotkit.ai
-# A separate host from the API URL above, so it cannot be derived from it.
-COPILOTKIT_INTELLIGENCE_WS_URL=wss://realtime.intelligence.copilotkit.ai
 COPILOTKIT_API_KEY=cpk-...
 OPENAI_API_KEY=sk-...
 ```
+
+There are no URLs to configure: the SDK defaults to the managed Intelligence
+platform. A self-hosted deployment overrides `apiUrl` **and** `wsUrl` on
+`CopilotKitIntelligence` — they are different hosts, so the websocket URL cannot be
+derived from the API URL by swapping the scheme, and setting only one leaves the
+other plane pointed at the managed host. Getting the websocket host wrong does not
+raise an error; the channel sits in `connecting` until it times out.
 </Step>
 
 <Step>
@@ -129,10 +128,8 @@ channel.onMessage(async ({ thread, message }) => {
 // `ready()` activates it. The Intelligence key (free tier available) is what
 // lets the runtime run any channel.
 const intelligence = new CopilotKitIntelligence({
-  apiUrl: process.env.COPILOTKIT_INTELLIGENCE_URL!,
-  // A separate host from apiUrl — the realtime plane is deployed apart, so
-  // this cannot be derived by swapping the API URL scheme.
-  wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
+  // apiUrl and wsUrl default to the managed Intelligence platform. Override
+  // both together only for a self-hosted deployment.
   apiKey: process.env.COPILOTKIT_API_KEY!,
 });
 

--- a/skills/react-core/references/threads.md
+++ b/skills/react-core/references/threads.md
@@ -127,8 +127,7 @@ import {
 } from "@copilotkit/runtime/v2";
 
 const intelligence = new CopilotKitIntelligence({
-  apiUrl: process.env.COPILOTKIT_INTELLIGENCE_API_URL!,
-  wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
+  // apiUrl / wsUrl default to the managed Intelligence platform — leave unset.
   apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!,
   organizationId: process.env.COPILOTKIT_ORG_ID!,
 });

--- a/skills/runtime/references/intelligence-mode.md
+++ b/skills/runtime/references/intelligence-mode.md
@@ -11,8 +11,15 @@ Obtain `apiKey` and `organizationId` from the CopilotKit Intelligence dashboard.
 
 ### URL format
 
-The client prepends `/api/...` and the Intelligence websocket layer derives `/runner`
-or `/client` suffixes internally. Pass the bare base URLs — do NOT append `/api`,
+**Omit `apiUrl` and `wsUrl`.** Both default to the managed platform
+(`https://api.intelligence.copilotkit.ai` and
+`wss://realtime.intelligence.copilotkit.ai`), so `apiKey` is the only URL-related
+config you need. Never invent or guess these values — leaving them unset is always
+correct against the managed service.
+
+If you do set them (non-production or a future self-hosted deployment), the client
+prepends `/api/...` and the Intelligence websocket layer derives `/runner` or
+`/client` suffixes internally. Pass the bare base URLs — do NOT append `/api`,
 `/socket`, `/runner`, or `/client` yourself:
 
 ```typescript
@@ -29,8 +36,9 @@ wsUrl:  "wss://realtime.intelligence.copilotkit.ai/socket",
 produce one from the other by swapping the scheme. Deriving `wsUrl` as
 `apiUrl.replace(/^http/, "ws")` yields `wss://api.intelligence.copilotkit.ai`, which
 serves no socket — and the resulting failure is a silent hang, not an error, because
-the socket layer treats an unreachable host as a retryable reconnect. Always configure
-both explicitly. Both values are shown on your project's Intelligence dashboard.
+the socket layer treats an unreachable host as a retryable reconnect. For the same
+reason, override the two together or not at all: setting one alone leaves the other
+plane on the managed host, which the client warns about at construction.
 
 Source: `packages/runtime/src/v2/runtime/intelligence-platform/client.ts:41-46, 259,
 356-357, 437, 468, 682-708`.
@@ -45,8 +53,7 @@ import {
 } from "@copilotkit/runtime/v2";
 
 const intelligence = new CopilotKitIntelligence({
-  apiUrl: "https://api.intelligence.copilotkit.ai",
-  wsUrl: "wss://realtime.intelligence.copilotkit.ai",
+  // apiUrl / wsUrl default to the managed Intelligence platform — leave them unset.
   apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!,
   organizationId: process.env.COPILOTKIT_INTELLIGENCE_ORG_ID!,
 });
@@ -200,14 +207,20 @@ new CopilotKitIntelligence({
   apiKey,
   organizationId,
 });
+
+new CopilotKitIntelligence({
+  // Only one plane overridden — wsUrl silently stays on the managed host. Warns, then hangs.
+  apiUrl: "https://api.intelligence.copilotkit.ai",
+  apiKey,
+  organizationId,
+});
 ```
 
 Correct:
 
 ```typescript
 new CopilotKitIntelligence({
-  apiUrl: "https://api.intelligence.copilotkit.ai",
-  wsUrl: "wss://realtime.intelligence.copilotkit.ai",
+  // No apiUrl / wsUrl — they default to the managed platform.
   apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!,
   organizationId: process.env.COPILOTKIT_INTELLIGENCE_ORG_ID!,
 });


### PR DESCRIPTION
Makes `new CopilotKitIntelligence({ apiKey })` the whole managed-service setup. `apiUrl` and `wsUrl` were required on every construction, so the two correct hosts had to be found and copied by hand — which is how an agent came to invent them. Linear: [OSS-638](https://linear.app/copilotkit/issue/OSS-638/add-default-rest-and-ws-api-urls-to-intelligence-sdk).

## The change

Both fields are now optional and default to CopilotKit's managed platform (`https://api.intelligence.copilotkit.ai` / `wss://realtime.intelligence.copilotkit.ai`). Overrides are unchanged for self-hosted and non-production deployments, with two guards that the previous required-field signature made unnecessary:

**A blank value counts as unset.** These URLs are almost always wired from env vars, and a declared-but-empty variable (`COPILOTKIT_INTELLIGENCE_URL=`, common in generated `.env` files and container configs) arrives as `""`. Left as-is it slips past a `??` default and produces host-relative requests — the failing test showed a request to `/api/threads?...` with no host at all.

**Setting only one of the pair warns.** The API and realtime planes are separate hosts, so a lone override silently pairs (say) a self-hosted API with the managed gateway. That failure surfaces as a 30s hang rather than an error, because the socket layer treats an unreachable host as a retryable reconnect — so it is worth a log line at construction.

## Docs

Swept the copy-paste surfaces to the short form so nobody is handed URLs to get wrong: channels quickstart/index/mcp + the 5 platform pages, the 7 channels package READMEs, the runtime and react-core skill references (package and root copies), and the slack/teams examples with their READMEs and `.env.example`s. The "separate hosts, override both or neither" lesson now lives in the quickstart's override note and the SDK JSDoc instead of in every snippet.

Two things beyond the mechanical sweep:

- `dev-docs/architecture/setup-intelligence.md` documented `apiUrl: "https://your-intelligence-host/api"` and `wsUrl: "wss://your-intelligence-host/socket"` — the exact double-`/api` and fake-`/socket` suffixes the runtime skill reference warns against. Fixed while here.
- The `CopilotKitIntelligence` class JSDoc sat above `ThreadDeletedPayload`, so it never appeared on hover of the class. Reattached — that is the discoverability half of the original complaint.

The integration examples (langgraph, mastra, adk, …) are deliberately untouched: they pass `process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201"` to target a local stack, where the managed defaults would be wrong.

## Verification

Tests written first and watched fail — 5 on undefined URLs, then the blank-URL case on the host-relative request.

- `client.test.ts` 54/54; full `runtime/src/v2` suite 1128/1128
- slack example 63/63, teams example 2/2, channels-intelligence 195/195
- `tsc --noEmit` clean on `packages/runtime`; both edited examples typecheck clean against the new signature (verified by resolving `@copilotkit/runtime` at the worktree source, since the symlinked `node_modules` otherwise reports stale required-field types)
- oxlint 0 warnings / 0 errors on touched files, oxfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)