### PR TITLE
fix(channels-intelligence): fence delivery terminal attempts

### DIFF
--- a/packages/channels-intelligence/src/claim-mapping.test.ts
+++ b/packages/channels-intelligence/src/claim-mapping.test.ts
@@ -14,6 +14,8 @@ const baseDelivery = (
   channel: { id: "channel_1", name: "support" },
   adapter: "slack",
   leaseToken: "lease_1",
+  attempt: 2,
+  leaseExpiresAt: "2099-07-01T00:02:30.000Z",
   turn: {
     id: "turn_1",
     eventId: "evt_1",
@@ -70,6 +72,25 @@ describe("conversationKeyFromReplyTarget", () => {
 });
 
 describe("mapDeliveryToEnvelope — identity (OSS-476)", () => {
+  it("maps the exact delivery attempt identity onto the envelope", () => {
+    const env = mapDeliveryToEnvelope(baseDelivery());
+
+    expect(env.deliveryAttempt).toEqual({
+      deliveryId: "dlv_1",
+      attemptCount: 2,
+      leaseExpiresAt: "2099-07-01T00:02:30.000Z",
+    });
+  });
+
+  it("rejects a parseable non-ISO lease expiry", () => {
+    expect(() =>
+      mapDeliveryToEnvelope({
+        ...baseDelivery(),
+        leaseExpiresAt: "0",
+      }),
+    ).toThrow(/invalid delivery lease expiry/);
+  });
+
   it("maps the provider actor to env.user (id + displayName)", () => {
     const env = mapDeliveryToEnvelope(
       baseDelivery({

--- a/packages/channels-intelligence/src/claim-mapping.ts
+++ b/packages/channels-intelligence/src/claim-mapping.ts
@@ -1,5 +1,12 @@
 import type { MessageRef } from "@copilotkit/channels-ui";
 import type { ChannelFileRef, ChannelIngressEnvelope } from "./contracts.js";
+import { deliveryAttemptFromClaim } from "./delivery-attempt.js";
+import type { DeliveryAttemptRef } from "./delivery-attempt.js";
+
+/** A live claimed envelope always carries validated attempt identity. */
+export type ClaimedChannelIngressEnvelope = ChannelIngressEnvelope & {
+  deliveryAttempt: DeliveryAttemptRef;
+};
 
 /**
  * Shared claim → ingress-envelope mapping used by BOTH transports (the HTTP
@@ -51,11 +58,13 @@ export interface ClaimedDeliveryActor {
 /** Successful `claim` delivery envelope (the subset the bridge reads). */
 export interface ClaimedDelivery {
   id: string;
+  attempt: number;
   organizationId: string;
   projectId: number;
   channel: { id: string; name: string };
   adapter: string;
   leaseToken: string;
+  leaseExpiresAt: string;
   turn: {
     id: string;
     eventId: string;
@@ -139,9 +148,10 @@ export function conversationKeyFromReplyTarget(rt: ReplyTarget): string {
  */
 export function mapDeliveryToEnvelope(
   d: ClaimedDelivery,
-): ChannelIngressEnvelope {
+): ClaimedChannelIngressEnvelope {
   const base = {
     deliveryId: d.id,
+    deliveryAttempt: deliveryAttemptFromClaim(d),
     eventId: d.turn.eventId,
     turnId: d.turn.id,
     // `ChannelIngressEnvelope` remains aligned with the channels framework's

--- a/packages/channels-intelligence/src/contracts.ts
+++ b/packages/channels-intelligence/src/contracts.ts
@@ -6,6 +6,7 @@
 // left out and noted inline so the swap later is a pure import change.
 
 import type { ChannelNode, MessageRef } from "@copilotkit/channels-ui";
+import type { DeliveryAttemptRef } from "./delivery-attempt.js";
 
 /**
  * Opaque return address minted by Intelligence and echoed back on egress. The
@@ -30,8 +31,13 @@ export interface ChannelDeliveryScope {
 
 /** Fields common to every Intelligence Channel ingress envelope. */
 export interface ChannelIngressBase {
-  /** Unique per delivery attempt (lease). At-least-once: may be redelivered. */
+  /** Stable delivery id; redelivery increments `deliveryAttempt.attemptCount`. */
   deliveryId: string;
+  /**
+   * Exact leased attempt. Live HTTP/realtime transports always populate this;
+   * optional only for compatibility with legacy injected DeliverySources.
+   */
+  deliveryAttempt?: DeliveryAttemptRef;
   /** Stable platform event id (idempotency / dedup). */
   eventId: string;
   /** Stable per-logical-turn id. Egress operation ids derive from it. */
@@ -124,6 +130,12 @@ export interface EgressOperation {
   operationId: string;
   turnId: string;
   deliveryId: string;
+  /**
+   * Exact leased attempt that minted this operation. Live HTTP deliveries
+   * always populate this; optional only for compatibility with injected legacy
+   * operations.
+   */
+  deliveryAttempt?: DeliveryAttemptRef;
   route: EgressRoute;
   op: EgressOp;
 }
@@ -189,6 +201,11 @@ export type ChannelRenderEventKind = ChannelRenderEvent["kind"];
  */
 export interface RenderFrame {
   deliveryId: string;
+  /**
+   * Exact attempt that minted this frame. Optional only for compatibility with
+   * injected legacy sinks; live mapped deliveries always provide it.
+   */
+  deliveryAttempt?: DeliveryAttemptRef;
   turnId: string;
   /** Render lane; a single turn uses `"main"` for V1. */
   slot: string;

--- a/packages/channels-intelligence/src/delivery-attempt.ts
+++ b/packages/channels-intelligence/src/delivery-attempt.ts
@@ -1,0 +1,320 @@
+/** Exact identity of one leased delivery attempt. */
+export interface DeliveryAttemptRef {
+  readonly deliveryId: string;
+  readonly attemptCount: number;
+  readonly leaseExpiresAt: string;
+}
+
+/** Compatibility input for injected/older delivery sources. */
+export type DeliveryAttemptInput = DeliveryAttemptRef | string;
+
+/** Safety window reserved for sending the terminal intent before lease expiry. */
+export const DELIVERY_LEASE_SAFETY_MARGIN_MS = 10_000;
+
+const ISO_DATETIME_WITH_OFFSET_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/u;
+
+/** Stable in-process key for state that must never bleed across redeliveries. */
+export function deliveryAttemptKey(attempt: DeliveryAttemptRef): string {
+  return `${attempt.deliveryId}:${attempt.attemptCount}:${attempt.leaseExpiresAt}`;
+}
+
+/** Attempt counters are authoritative; lease timestamps never reorder them. */
+export function isStrictlyNewerDeliveryAttempt(
+  candidate: DeliveryAttemptRef,
+  active: DeliveryAttemptRef,
+): boolean {
+  return (
+    candidate.deliveryId === active.deliveryId &&
+    candidate.attemptCount > active.attemptCount
+  );
+}
+
+/** Validate and map the wire claim fields to their handler-facing identity. */
+export function deliveryAttemptFromClaim(input: {
+  id: string;
+  attempt: unknown;
+  leaseExpiresAt: unknown;
+}): DeliveryAttemptRef {
+  if (
+    typeof input.attempt !== "number" ||
+    !Number.isSafeInteger(input.attempt) ||
+    input.attempt <= 0
+  ) {
+    throw new Error(
+      `invalid delivery attempt count for ${input.id}: ${JSON.stringify(input.attempt)}`,
+    );
+  }
+  if (
+    typeof input.leaseExpiresAt !== "string" ||
+    !ISO_DATETIME_WITH_OFFSET_RE.test(input.leaseExpiresAt) ||
+    !Number.isFinite(Date.parse(input.leaseExpiresAt))
+  ) {
+    throw new Error(
+      `invalid delivery lease expiry for ${input.id}: ${JSON.stringify(input.leaseExpiresAt)}`,
+    );
+  }
+  return {
+    deliveryId: input.id,
+    attemptCount: input.attempt,
+    leaseExpiresAt: input.leaseExpiresAt,
+  };
+}
+
+/**
+ * Cap a configured handler deadline so the terminal intent retains a safety
+ * window before the attempt lease expires.
+ */
+export function effectiveDeliveryTimeoutMs(
+  configuredTimeoutMs: number,
+  attempt: DeliveryAttemptRef,
+  nowMs: number,
+): number {
+  return Math.max(
+    0,
+    Math.min(
+      configuredTimeoutMs,
+      Date.parse(attempt.leaseExpiresAt) -
+        nowMs -
+        DELIVERY_LEASE_SAFETY_MARGIN_MS,
+    ),
+  );
+}
+
+export function isDeliveryAttemptExpired(
+  attempt: DeliveryAttemptRef,
+  nowMs: number,
+): boolean {
+  return Date.parse(attempt.leaseExpiresAt) <= nowMs;
+}
+
+/**
+ * Evict attempt state at expiry even when no later operation touches it.
+ * Long leases are re-armed in bounded chunks to avoid setTimeout's 32-bit cap.
+ */
+export function scheduleDeliveryAttemptExpiry(
+  attempt: DeliveryAttemptRef,
+  nowMs: () => number,
+  onExpire: () => void,
+): () => void {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let canceled = false;
+  const schedule = (): void => {
+    if (canceled) return;
+    const remaining = Date.parse(attempt.leaseExpiresAt) - nowMs();
+    if (remaining <= 0) {
+      onExpire();
+      return;
+    }
+    timer = setTimeout(schedule, Math.min(remaining, 2_147_000_000));
+    (timer as unknown as { unref?: () => void }).unref?.();
+  };
+  schedule();
+  return () => {
+    canceled = true;
+    if (timer !== undefined) clearTimeout(timer);
+  };
+}
+
+interface ChannelErrorDetails {
+  code?: string;
+  message?: string;
+  reason?: string;
+  retryable?: boolean;
+  status?: number;
+}
+
+/** Error that preserves app-api/gateway metadata instead of flattening JSON. */
+export class ChannelTransportError extends Error {
+  readonly code?: string;
+  readonly reason?: string;
+  readonly retryable?: boolean;
+  readonly status?: number;
+
+  constructor(
+    message: string,
+    options: {
+      code?: string;
+      reason?: string;
+      retryable?: boolean;
+      status?: number;
+      cause?: unknown;
+    } = {},
+  ) {
+    super(message, options.cause !== undefined ? { cause: options.cause } : {});
+    this.name = "ChannelTransportError";
+    this.code = options.code;
+    this.reason = options.reason;
+    this.retryable = options.retryable;
+    this.status = options.status;
+  }
+}
+
+function errorDetails(value: unknown): ChannelErrorDetails | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  const nested =
+    (record["error"] as Record<string, unknown> | undefined) ??
+    ((record["payload"] as Record<string, unknown> | undefined)?.["error"] as
+      | Record<string, unknown>
+      | undefined);
+  const candidate = nested ?? record;
+  const code =
+    typeof candidate["code"] === "string" ? candidate["code"] : undefined;
+  const message =
+    typeof candidate["message"] === "string" ? candidate["message"] : undefined;
+  const reason =
+    typeof record["reason"] === "string"
+      ? record["reason"]
+      : typeof candidate["reason"] === "string"
+        ? candidate["reason"]
+        : undefined;
+  const retryable =
+    typeof candidate["retryable"] === "boolean"
+      ? candidate["retryable"]
+      : undefined;
+  const rawStatus = record["status"] ?? candidate["status"];
+  const status =
+    typeof rawStatus === "number" && Number.isInteger(rawStatus)
+      ? rawStatus
+      : undefined;
+  return code ||
+    message ||
+    reason ||
+    retryable !== undefined ||
+    status !== undefined
+    ? { code, message, reason, retryable, status }
+    : undefined;
+}
+
+function isDeterministicGatewayValidationReason(
+  reason: string | undefined,
+): boolean {
+  return (
+    reason !== undefined &&
+    (/^(?:invalid_|unsafe_json_)/u.test(reason) ||
+      reason === "unexpected_keys" ||
+      reason === "organization_scope_mismatch" ||
+      reason === "runtime_scope_mismatch" ||
+      reason === "project_scope_mismatch" ||
+      reason === "channel_not_declared")
+  );
+}
+
+const NON_RETRYABLE_DELIVERY_CODES = new Set([
+  "CHANNEL_RENDER_FRAME_CONFLICT",
+  "CHANNEL_DELIVERY_RENDER_INCOMPLETE",
+  "CHANNEL_DELIVERY_LEASE_INVALID",
+  "VALIDATION_ERROR",
+]);
+
+/** Preserve structured error fields received over HTTP or Phoenix. */
+export function channelTransportError(
+  prefix: string,
+  reason: unknown,
+  status?: number,
+): ChannelTransportError {
+  const details = errorDetails(reason);
+  const deterministic =
+    (details?.code !== undefined &&
+      NON_RETRYABLE_DELIVERY_CODES.has(details.code)) ||
+    isDeterministicGatewayValidationReason(details?.reason);
+  const retryable = deterministic ? false : details?.retryable;
+  const message = details?.message ?? details?.code ?? details?.reason;
+  return new ChannelTransportError(message ? `${prefix}: ${message}` : prefix, {
+    ...(details?.code ? { code: details.code } : {}),
+    ...(details?.reason ? { reason: details.reason } : {}),
+    ...(retryable !== undefined ? { retryable } : {}),
+    ...((status ?? details?.status) !== undefined
+      ? { status: status ?? details?.status }
+      : {}),
+    cause: reason,
+  });
+}
+
+/** Retryability for a failed handler/render operation, kept deliberately narrow. */
+export function isRetryableDeliveryError(error: unknown): boolean {
+  if (error && typeof error === "object") {
+    const value = error as {
+      code?: unknown;
+      reason?: unknown;
+      retryable?: unknown;
+    };
+    if (
+      typeof value.code === "string" &&
+      NON_RETRYABLE_DELIVERY_CODES.has(value.code)
+    ) {
+      return false;
+    }
+    if (
+      typeof value.reason === "string" &&
+      isDeterministicGatewayValidationReason(value.reason)
+    ) {
+      return false;
+    }
+    if (typeof value.retryable === "boolean") return value.retryable;
+  }
+  return true;
+}
+
+/** A lease-invalid response definitively fences this local attempt. */
+export function isDefinitiveAttemptFence(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    (error as { code?: unknown }).code === "CHANNEL_DELIVERY_LEASE_INVALID"
+  );
+}
+
+export type DeliveryTerminalKind = "complete" | "fail";
+
+export interface AttemptTerminalState {
+  terminal?: {
+    kind: DeliveryTerminalKind;
+    /** First payload's sender; retained so a retry is byte-equivalent. */
+    send: () => Promise<void>;
+    inFlight?: Promise<void>;
+  };
+}
+
+/**
+ * First terminal kind wins for one exact attempt. Same-kind concurrent calls
+ * share the request; transient failure keeps the chosen kind retryable.
+ */
+export async function runAttemptTerminalIntent(
+  state: AttemptTerminalState,
+  kind: DeliveryTerminalKind,
+  send: () => Promise<void>,
+  cleanup: () => void,
+  log?: (message: string, meta?: unknown) => void,
+): Promise<void> {
+  const selected = state.terminal;
+  if (selected && selected.kind !== kind) {
+    log?.("intelligence terminal intent ignored: opposite kind already won", {
+      selected: selected.kind,
+      ignored: kind,
+    });
+    return;
+  }
+  if (selected?.inFlight) {
+    await selected.inFlight;
+    return;
+  }
+
+  const terminal = selected ?? { kind, send };
+  state.terminal = terminal;
+  let inFlight!: Promise<void>;
+  inFlight = (async () => {
+    try {
+      await terminal.send();
+      cleanup();
+    } catch (error) {
+      if (isDefinitiveAttemptFence(error)) cleanup();
+      throw error;
+    } finally {
+      if (terminal.inFlight === inFlight) terminal.inFlight = undefined;
+    }
+  })();
+  terminal.inFlight = inFlight;
+  await inFlight;
+}

--- a/packages/channels-intelligence/src/http-transports.test.ts
+++ b/packages/channels-intelligence/src/http-transports.test.ts
@@ -1499,11 +1499,16 @@ describe("HttpRenderEventSink", () => {
     );
     const conf = cfg({ fetch });
     const src = new HttpDeliverySource(conf);
-    await src.claimOnce(); // populates per-delivery scope
+    const claim = await src.claimOnce(); // populates per-delivery scope
+    if (!("env" in claim)) throw new Error("expected a claim");
     const sink = new HttpRenderEventSink(conf, src);
+    const atomicIdentity = vi.spyOn(src, "leaseIdentityFor");
+    const separateScope = vi.spyOn(src, "scopeFor");
+    const separateToken = vi.spyOn(src, "leaseTokenFor");
 
     const receipt = await sink.push({
       deliveryId: "dlv_9",
+      deliveryAttempt: claim.env.deliveryAttempt,
       turnId: "turn_9",
       slot: "main",
       seq: 0,
@@ -1533,6 +1538,9 @@ describe("HttpRenderEventSink", () => {
     });
     // The accept route rejects a body that also carries deliveryId.
     expect("deliveryId" in accept.body).toBe(false);
+    expect(atomicIdentity).toHaveBeenCalledOnce();
+    expect(separateScope).not.toHaveBeenCalled();
+    expect(separateToken).not.toHaveBeenCalled();
   });
 
   it("throws when no leased scope exists for the delivery", async () => {
@@ -1548,6 +1556,56 @@ describe("HttpRenderEventSink", () => {
         event: { kind: "run_started" },
       }),
     ).rejects.toThrow(/no leased scope/);
+  });
+
+  it("rejects render work after a terminal intent wins, even when its response is lost", async () => {
+    const { fetch, calls } = fakeFetch((c) => {
+      if (c.url.endsWith("/claim")) {
+        return { body: { claimed: true, delivery: claimedDelivery() } };
+      }
+      if (c.url.endsWith("/ack")) {
+        return {
+          ok: false,
+          status: 503,
+          body: {
+            error: {
+              code: "INTERNAL_SERVER_ERROR",
+              message: "completion response lost",
+              retryable: true,
+            },
+          },
+        };
+      }
+      return {
+        body: {
+          idempotencyKey: "turn_9:main:0",
+          acceptance: "accepted",
+        },
+      };
+    });
+    const conf = cfg({ fetch });
+    const src = new HttpDeliverySource(conf);
+    const claim = await src.claimOnce();
+    if (!("env" in claim)) throw new Error("expected a claim");
+    const sink = new HttpRenderEventSink(conf, src);
+
+    await expect(src.ack(claim.env.deliveryAttempt)).rejects.toThrow(
+      /completion response lost/,
+    );
+    await expect(
+      sink.push({
+        deliveryId: "dlv_9",
+        deliveryAttempt: claim.env.deliveryAttempt,
+        turnId: "turn_9",
+        slot: "main",
+        seq: 0,
+        event: { kind: "run_started" },
+      }),
+    ).rejects.toThrow(/stale delivery attempt/);
+
+    expect(
+      calls.filter((c) => c.url.endsWith("/render-events/accept")),
+    ).toHaveLength(0);
   });
 
   it("rejects a stale attempt frame instead of fencing it with the active attempt's token", async () => {

--- a/packages/channels-intelligence/src/http-transports.test.ts
+++ b/packages/channels-intelligence/src/http-transports.test.ts
@@ -12,12 +12,14 @@ import type {
   IntelligenceTransportConfig,
 } from "./http-transports.js";
 import { intelligenceAdapter } from "./intelligence-adapter.js";
+import { InMemoryEgressSink } from "./in-memory-transports.js";
 import type { EgressOperation } from "./contracts.js";
 
 interface Call {
   url: string;
   method: string;
   headers: Record<string, string>;
+  rawBody: string;
   body: Record<string, unknown>;
 }
 
@@ -30,6 +32,7 @@ function fakeFetch(
       url,
       method: init.method,
       headers: init.headers,
+      rawBody: init.body,
       body: JSON.parse(init.body) as Record<string, unknown>,
     };
     calls.push(call);
@@ -99,8 +102,23 @@ function cfg(
   });
 }
 
-const text = (value: string): ChannelNode =>
-  ({ type: "text", props: { value } }) as unknown as ChannelNode;
+const text = (value: string): ChannelNode => ({
+  type: "text",
+  props: { value },
+});
+
+function egressOperation(
+  overrides: Partial<EgressOperation> = {},
+): EgressOperation {
+  return {
+    operationId: "turn_9:0",
+    turnId: "turn_9",
+    deliveryId: "dlv_9",
+    route: { adapter: "slack", teamId: "T1", channel: "C1" },
+    op: { kind: "post", ir: [text("hi")] },
+    ...overrides,
+  };
+}
 
 const claimedDelivery = (over?: Record<string, unknown>) => ({
   id: "dlv_9",
@@ -110,7 +128,7 @@ const claimedDelivery = (over?: Record<string, unknown>) => ({
   channel: { id: "channel_1", name: "opentagbot" },
   adapter: "slack",
   leaseToken: "lease_z",
-  leaseExpiresAt: "2026-06-30T00:00:00.000Z",
+  leaseExpiresAt: "2099-06-30T00:00:00.000Z",
   turn: {
     id: "turn_9",
     eventId: "evt_9",
@@ -150,18 +168,158 @@ describe("resolveTransportConfig", () => {
 });
 
 describe("HttpEgressSink", () => {
+  it("posts the exact claiming source identity when the sink config has a different runtime instance", async () => {
+    const { fetch, calls } = fakeFetch((call) =>
+      call.url.endsWith("/claim")
+        ? { body: { claimed: true, delivery: claimedDelivery() } }
+        : {
+            body: { operationId: "eop_1", status: "sent", acceptedAt: "t" },
+          },
+    );
+    const source = new HttpDeliverySource(
+      cfg({ fetch, runtimeInstanceId: "rti_claiming_source" }),
+    );
+    const claim = await source.claimOnce();
+    if (!("env" in claim)) throw new Error("expected a claim");
+    const sink = new HttpEgressSink(
+      cfg({ fetch, runtimeInstanceId: "rti_sink_config" }),
+      source,
+    );
+
+    const res = await sink.emit(
+      egressOperation({
+        deliveryAttempt: claim.env.deliveryAttempt,
+      }),
+    );
+
+    expect(res).toEqual({ ok: true, ref: "eop_1" });
+    const egress = calls.find((call) =>
+      call.url.endsWith("/api/channels/egress/messages"),
+    )!;
+    expect(egress.body).toMatchObject({
+      turnId: "turn_9",
+      runtimeInstanceId: "rti_claiming_source",
+      leaseToken: "lease_z",
+    });
+  });
+
+  it("does not resolve an old egress operation through a newer delivery attempt", async () => {
+    let claims = 0;
+    const { fetch, calls } = fakeFetch((call) => {
+      if (call.url.endsWith("/claim")) {
+        claims += 1;
+        return {
+          body: {
+            claimed: true,
+            delivery: claimedDelivery({
+              attempt: claims,
+              leaseToken: `lease_${claims}`,
+              leaseExpiresAt: `2099-06-30T00:0${claims}:00.000Z`,
+            }),
+          },
+        };
+      }
+      return {
+        body: { operationId: "eop_1", status: "sent", acceptedAt: "t" },
+      };
+    });
+    const conf = cfg({ fetch });
+    const source = new HttpDeliverySource(conf);
+    const first = await source.claimOnce();
+    const second = await source.claimOnce();
+    if (!("env" in first) || !("env" in second)) {
+      throw new Error("expected two claims");
+    }
+    const sink = new HttpEgressSink(conf, source);
+
+    await expect(
+      sink.emit(
+        egressOperation({
+          deliveryAttempt: first.env.deliveryAttempt,
+        }),
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      code: "delivery_attempt_unavailable",
+    });
+    expect(
+      calls.filter((call) =>
+        call.url.endsWith("/api/channels/egress/messages"),
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("fails an attempt-scoped egress operation before POST when its lease state is missing", async () => {
+    const { fetch, calls } = fakeFetch(() => ({
+      body: { operationId: "eop_1", status: "sent", acceptedAt: "t" },
+    }));
+    const conf = cfg({ fetch });
+    const source = new HttpDeliverySource(conf);
+    const sink = new HttpEgressSink(conf, source);
+
+    await expect(
+      sink.emit(
+        egressOperation({
+          deliveryAttempt: {
+            deliveryId: "dlv_9",
+            attemptCount: 1,
+            leaseExpiresAt: "2099-06-30T00:00:00.000Z",
+          },
+        }),
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      code: "delivery_attempt_unavailable",
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("fails an expired attempt-scoped egress operation before POST", async () => {
+    const { fetch, calls } = fakeFetch((call) =>
+      call.url.endsWith("/claim")
+        ? {
+            body: {
+              claimed: true,
+              delivery: claimedDelivery({
+                leaseExpiresAt: "2000-01-01T00:00:00.000Z",
+              }),
+            },
+          }
+        : {
+            body: { operationId: "eop_1", status: "sent", acceptedAt: "t" },
+          },
+    );
+    const conf = cfg({ fetch });
+    const source = new HttpDeliverySource(conf);
+    const claim = await source.claimOnce();
+    if (!("env" in claim)) throw new Error("expected a claim");
+    const sink = new HttpEgressSink(conf, source);
+
+    await expect(
+      sink.emit(
+        egressOperation({
+          deliveryAttempt: claim.env.deliveryAttempt,
+        }),
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      code: "delivery_attempt_unavailable",
+    });
+    expect(
+      calls.filter((call) =>
+        call.url.endsWith("/api/channels/egress/messages"),
+      ),
+    ).toHaveLength(0);
+  });
+
   it("posts flattened text with the op id as idempotency key", async () => {
     const { fetch, calls } = fakeFetch(() => ({
       body: { operationId: "eop_1", status: "sent", acceptedAt: "t" },
     }));
     const sink = new HttpEgressSink(cfg({ fetch }));
-    const op: EgressOperation = {
-      operationId: "turn_9:0",
-      turnId: "turn_9",
-      deliveryId: "dlv_9",
+    const op = egressOperation({
       route: { adapter: "slack", teamId: "T1", channel: "C1", threadTs: "1.2" },
-      op: { kind: "post", ir: [text("hi")] },
-    };
+    });
     const res = await sink.emit(op);
     expect(res).toEqual({ ok: true, ref: "eop_1" });
     expect(calls[0]!.url).toBe("http://x/api/channels/egress/messages");
@@ -186,13 +344,7 @@ describe("HttpEgressSink", () => {
       },
     }));
     const sink = new HttpEgressSink(cfg({ fetch }));
-    const res = await sink.emit({
-      operationId: "turn_9:0",
-      turnId: "turn_9",
-      deliveryId: "dlv_9",
-      route: { adapter: "slack", teamId: "T1", channel: "C1" },
-      op: { kind: "post", ir: [text("hi")] },
-    });
+    const res = await sink.emit(egressOperation());
     expect(res).toEqual({ ok: false, code: "provider_error" });
   });
 
@@ -200,22 +352,21 @@ describe("HttpEgressSink", () => {
     const { fetch, calls } = fakeFetch(() => ({ body: {} }));
     const sink = new HttpEgressSink(cfg({ fetch }));
     expect(
-      await sink.emit({
-        operationId: "turn_9:0",
-        turnId: "turn_9",
-        deliveryId: "dlv_9",
-        route: {},
-        op: { kind: "delete", ref: "r" },
-      }),
+      await sink.emit(
+        egressOperation({
+          route: {},
+          op: { kind: "delete", ref: "r" },
+        }),
+      ),
     ).toEqual({ ok: true, ref: "turn_9:0" });
     expect(
-      await sink.emit({
-        operationId: "turn_9:1",
-        turnId: "turn_9",
-        deliveryId: "dlv_9",
-        route: {},
-        op: { kind: "post", ir: [] },
-      }),
+      await sink.emit(
+        egressOperation({
+          operationId: "turn_9:1",
+          route: {},
+          op: { kind: "post", ir: [] },
+        }),
+      ),
     ).toEqual({ ok: true, ref: "turn_9:1" });
     expect(calls).toHaveLength(0);
   });
@@ -228,13 +379,13 @@ describe("HttpEgressSink", () => {
     const { fetch, calls } = fakeFetch(() => ({ body: {} }));
     const logs: string[] = [];
     const sink = new HttpEgressSink(cfg({ fetch, log: (m) => logs.push(m) }));
-    const res = await sink.emit({
-      operationId: "turn_9:2",
-      turnId: "turn_9",
-      deliveryId: "dlv_9",
-      route: {},
-      op: { kind: "update", ref: "r", ir: [] },
-    });
+    const res = await sink.emit(
+      egressOperation({
+        operationId: "turn_9:2",
+        route: {},
+        op: { kind: "update", ref: "r", ir: [] },
+      }),
+    );
     expect(res).toEqual({ ok: true, ref: "turn_9:2" });
     expect(calls).toHaveLength(0);
     expect(logs.some((m) => /empty-text update/u.test(m))).toBe(true);
@@ -249,17 +400,15 @@ describe("HttpEgressSink", () => {
       body: { operationId: "eop_t", status: "sent" },
     }));
     const sink = new HttpEgressSink(cfg({ fetch, adapter: "slack" }));
-    await sink.emit({
-      operationId: "turn_9:0",
-      turnId: "turn_9",
-      deliveryId: "dlv_9",
-      route: {
-        adapter: "teams",
-        tenantId: "tenant-1",
-        conversationId: "19:abc@thread.tacv2",
-      },
-      op: { kind: "post", ir: [text("hi")] },
-    });
+    await sink.emit(
+      egressOperation({
+        route: {
+          adapter: "teams",
+          tenantId: "tenant-1",
+          conversationId: "19:abc@thread.tacv2",
+        },
+      }),
+    );
     expect(calls[0]!.body).toMatchObject({ adapter: "teams" });
   });
 
@@ -268,13 +417,9 @@ describe("HttpEgressSink", () => {
       body: { operationId: "eop_f", status: "sent" },
     }));
     const sink = new HttpEgressSink(cfg({ fetch, adapter: "slack" }));
-    await sink.emit({
-      operationId: "turn_9:0",
-      turnId: "turn_9",
-      deliveryId: "dlv_9",
-      route: { teamId: "T1", channel: "C1" },
-      op: { kind: "post", ir: [text("hi")] },
-    });
+    await sink.emit(
+      egressOperation({ route: { teamId: "T1", channel: "C1" } }),
+    );
     expect(calls[0]!.body).toMatchObject({ adapter: "slack" });
   });
 });
@@ -313,6 +458,11 @@ describe("HttpDeliverySource", () => {
     expect(r.env).toMatchObject({
       kind: "turn",
       deliveryId: "dlv_9",
+      deliveryAttempt: {
+        deliveryId: "dlv_9",
+        attemptCount: 1,
+        leaseExpiresAt: "2099-06-30T00:00:00.000Z",
+      },
       turnId: "turn_9",
       eventId: "evt_9",
       channelName: "opentagbot",
@@ -549,6 +699,272 @@ describe("HttpDeliverySource", () => {
     });
   });
 
+  it("does not let an old handler ack with a newer attempt's lease token", async () => {
+    let claims = 0;
+    const { fetch, calls } = fakeFetch((c) => {
+      if (c.url.endsWith("/claim")) {
+        claims += 1;
+        return {
+          body: {
+            claimed: true,
+            delivery: claimedDelivery({
+              attempt: claims,
+              leaseToken: `lease_${claims}`,
+              leaseExpiresAt: `2099-06-30T00:0${claims}:00.000Z`,
+            }),
+          },
+        };
+      }
+      return { body: { acknowledged: true } };
+    });
+    const logs: string[] = [];
+    const src = new HttpDeliverySource(
+      cfg({ fetch, log: (message) => logs.push(message) }),
+    );
+    const first = await src.claimOnce();
+    const second = await src.claimOnce();
+    if (!("env" in first) || !("env" in second)) {
+      throw new Error("expected two claimed deliveries");
+    }
+
+    await src.ack(first.env.deliveryAttempt);
+    await src.ack(second.env.deliveryAttempt);
+
+    const acks = calls.filter((c) => c.url.endsWith("/ack"));
+    expect(acks).toHaveLength(1);
+    expect(acks[0]!.body).toMatchObject({ leaseToken: "lease_2" });
+    expect(logs.some((message) => message.includes("stale attempt"))).toBe(
+      true,
+    );
+  });
+
+  it("ignores late older and same-count changed-expiry claims", async () => {
+    const claims = [
+      {
+        attempt: 2,
+        leaseToken: "lease_2",
+        leaseExpiresAt: "2099-06-30T00:02:00.000Z",
+      },
+      {
+        attempt: 1,
+        leaseToken: "lease_1_late",
+        leaseExpiresAt: "2099-06-30T00:01:00.000Z",
+      },
+      {
+        attempt: 2,
+        leaseToken: "lease_2_changed",
+        leaseExpiresAt: "2099-06-30T00:01:30.000Z",
+      },
+    ];
+    let claimIndex = 0;
+    const { fetch, calls } = fakeFetch((call) => {
+      if (call.url.endsWith("/claim")) {
+        return {
+          body: {
+            claimed: true,
+            delivery: claimedDelivery(claims[claimIndex++]),
+          },
+        };
+      }
+      return { body: { acknowledged: true } };
+    });
+    const src = new HttpDeliverySource(cfg({ fetch }));
+
+    const active = await src.claimOnce();
+    if (!("env" in active)) throw new Error("expected active claim");
+    await expect(src.claimOnce()).resolves.toEqual({ pollAfterMs: 1000 });
+    await expect(src.claimOnce()).resolves.toEqual({ pollAfterMs: 1000 });
+    await src.ack(active.env.deliveryAttempt);
+
+    const acks = calls.filter((call) => call.url.endsWith("/ack"));
+    expect(acks).toHaveLength(1);
+    expect(acks[0]!.body).toMatchObject({ leaseToken: "lease_2" });
+  });
+
+  it("fails malformed attempt identity non-retryably with the real lease", async () => {
+    const { fetch, calls } = fakeFetch((call) =>
+      call.url.endsWith("/claim")
+        ? {
+            body: {
+              claimed: true,
+              delivery: claimedDelivery({
+                attempt: 0,
+                leaseExpiresAt: "not-a-date",
+              }),
+            },
+          }
+        : { body: { failed: true, status: "dead_letter" } },
+    );
+    const src = new HttpDeliverySource(cfg({ fetch }));
+
+    await expect(src.claimOnce()).resolves.toEqual({ pollAfterMs: 1000 });
+
+    const fail = calls.find((call) => call.url.endsWith("/fail"))!;
+    expect(fail.url).toContain("/deliveries/dlv_9/fail");
+    expect(fail.body).toMatchObject({
+      turnId: "turn_9",
+      leaseToken: "lease_z",
+      error: { retryable: false },
+    });
+  });
+
+  it("evicts attempt state when the lease expires without another operation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-01T00:00:00.000Z"));
+    try {
+      const { fetch } = fakeFetch(() => ({
+        body: {
+          claimed: true,
+          delivery: claimedDelivery({
+            leaseExpiresAt: "2026-07-01T00:00:01.000Z",
+          }),
+        },
+      }));
+      const logs: string[] = [];
+      const src = new HttpDeliverySource(
+        cfg({ fetch, log: (message) => logs.push(message) }),
+      );
+
+      await src.claimOnce();
+      await vi.advanceTimersByTimeAsync(1_001);
+
+      expect(logs.some((message) => message.includes("attempt expired"))).toBe(
+        true,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries the first terminal payload byte-for-byte after a transient failure", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-01T00:00:00.000Z"));
+    try {
+      let ackAttempts = 0;
+      const { fetch, calls } = fakeFetch((c) => {
+        if (c.url.endsWith("/claim")) {
+          return { body: { claimed: true, delivery: claimedDelivery() } };
+        }
+        if (c.url.endsWith("/fail")) {
+          return { body: { failed: true } };
+        }
+        ackAttempts += 1;
+        return ackAttempts === 1
+          ? {
+              ok: false,
+              status: 503,
+              body: {
+                error: {
+                  code: "INTERNAL_SERVER_ERROR",
+                  message: "try again",
+                  retryable: true,
+                },
+              },
+            }
+          : { body: { acknowledged: true } };
+      });
+      const src = new HttpDeliverySource(cfg({ fetch }));
+      const claim = await src.claimOnce();
+      if (!("env" in claim)) throw new Error("expected a claim");
+
+      await expect(src.ack(claim.env.deliveryAttempt)).rejects.toThrow(
+        /try again/,
+      );
+      // A duplicate available/claim for the exact same attempt must not reset
+      // the selected terminal kind or its frozen payload.
+      await expect(src.claimOnce()).resolves.toEqual({ pollAfterMs: 1000 });
+      vi.setSystemTime(new Date("2026-07-01T00:01:00.000Z"));
+      await expect(
+        src.nack(claim.env.deliveryAttempt, "late opposite"),
+      ).resolves.toBeUndefined();
+      expect(calls.filter((c) => c.url.endsWith("/fail"))).toHaveLength(0);
+      await expect(src.ack(claim.env.deliveryAttempt)).resolves.toBeUndefined();
+
+      const acks = calls.filter((c) => c.url.endsWith("/ack"));
+      expect(acks).toHaveLength(2);
+      expect(acks[1]!.rawBody).toBe(acks[0]!.rawBody);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cleans up terminal state after a definitive lease fence", async () => {
+    const { fetch, calls } = fakeFetch((c) =>
+      c.url.endsWith("/claim")
+        ? { body: { claimed: true, delivery: claimedDelivery() } }
+        : {
+            ok: false,
+            status: 409,
+            body: {
+              error: {
+                code: "CHANNEL_DELIVERY_LEASE_INVALID",
+                message: "lease expired",
+                retryable: false,
+              },
+            },
+          },
+    );
+    const src = new HttpDeliverySource(cfg({ fetch }));
+    const claim = await src.claimOnce();
+    if (!("env" in claim)) throw new Error("expected a claim");
+
+    await expect(src.ack(claim.env.deliveryAttempt)).rejects.toMatchObject({
+      code: "CHANNEL_DELIVERY_LEASE_INVALID",
+    });
+    await expect(src.ack(claim.env.deliveryAttempt)).resolves.toBeUndefined();
+
+    expect(calls.filter((c) => c.url.endsWith("/ack"))).toHaveLength(1);
+  });
+
+  it("coalesces concurrent terminal intents of the same kind", async () => {
+    let releaseAck: (() => void) | undefined;
+    const calls: Call[] = [];
+    const fetch: FetchLike = async (url, init) => {
+      calls.push({
+        url,
+        method: init.method,
+        headers: init.headers,
+        rawBody: init.body,
+        body: JSON.parse(init.body) as Record<string, unknown>,
+      });
+      if (url.endsWith("/claim")) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () =>
+            JSON.stringify({
+              claimed: true,
+              delivery: claimedDelivery(),
+            }),
+        };
+      }
+      await new Promise<void>((resolve) => {
+        releaseAck = resolve;
+      });
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ acknowledged: true }),
+      };
+    };
+    const src = new HttpDeliverySource(cfg({ fetch }));
+    const claim = await src.claimOnce();
+    if (!("env" in claim)) throw new Error("expected a claim");
+
+    let secondSettled = false;
+    const first = src.ack(claim.env.deliveryAttempt);
+    const second = src.ack(claim.env.deliveryAttempt).then(() => {
+      secondSettled = true;
+    });
+    await Promise.resolve();
+
+    expect(calls.filter((c) => c.url.endsWith("/ack"))).toHaveLength(1);
+    expect(secondSettled).toBe(false);
+    releaseAck?.();
+    await Promise.all([first, second]);
+    expect(secondSettled).toBe(true);
+  });
+
   it("nacks (non-retryable) an unmappable delivery kind instead of wedging the loop", async () => {
     const { fetch, calls } = fakeFetch((c) =>
       c.url.endsWith("/claim")
@@ -608,6 +1024,44 @@ describe("HttpDeliverySource", () => {
     const fail = calls.find((c) => c.url.includes("/deliveries/dlv_9/fail"));
     expect(fail).toBeDefined();
     expect(fail!.body["error"]).toMatchObject({ code: "runtime_error" });
+  });
+
+  it("does not start a handler once its lease is inside the safety margin", async () => {
+    let claimCalls = 0;
+    const { fetch, calls } = fakeFetch((c) => {
+      if (c.url.endsWith("/claim")) {
+        claimCalls += 1;
+        return claimCalls === 1
+          ? {
+              body: {
+                claimed: true,
+                delivery: claimedDelivery({
+                  leaseExpiresAt: new Date(Date.now() + 5_000).toISOString(),
+                }),
+              },
+            }
+          : { body: { claimed: false, pollAfterMs: 60_000 } };
+      }
+      return { body: { failed: true, status: "retry_wait" } };
+    });
+    let handlerCalls = 0;
+    const src = new HttpDeliverySource(
+      cfg({
+        fetch,
+        turnTimeoutMs: 60_000,
+        sleep: () => new Promise<void>(() => {}),
+      }),
+    );
+
+    await src.start(async () => {
+      handlerCalls += 1;
+    });
+    await vi.waitFor(() =>
+      expect(calls.some((c) => c.url.endsWith("/fail"))).toBe(true),
+    );
+    await src.stop();
+
+    expect(handlerCalls).toBe(0);
   });
 
   it("keeps heartbeating while a long turn is in flight (no mid-turn starvation)", async () => {
@@ -1095,6 +1549,104 @@ describe("HttpRenderEventSink", () => {
       }),
     ).rejects.toThrow(/no leased scope/);
   });
+
+  it("rejects a stale attempt frame instead of fencing it with the active attempt's token", async () => {
+    let claims = 0;
+    const { fetch, calls } = fakeFetch((c) => {
+      if (c.url.endsWith("/claim")) {
+        claims += 1;
+        return {
+          body: {
+            claimed: true,
+            delivery: claimedDelivery({
+              attempt: claims,
+              leaseToken: `lease_${claims}`,
+              leaseExpiresAt: `2099-06-30T00:0${claims}:00.000Z`,
+            }),
+          },
+        };
+      }
+      return {
+        body: {
+          idempotencyKey: "turn_9:main:0",
+          acceptance: "accepted",
+        },
+      };
+    });
+    const conf = cfg({ fetch });
+    const src = new HttpDeliverySource(conf);
+    const first = await src.claimOnce();
+    const second = await src.claimOnce();
+    if (!("env" in first) || !("env" in second)) {
+      throw new Error("expected two claims");
+    }
+    const sink = new HttpRenderEventSink(conf, src);
+
+    await expect(
+      sink.push({
+        deliveryId: "dlv_9",
+        deliveryAttempt: first.env.deliveryAttempt,
+        turnId: "turn_9",
+        slot: "main",
+        seq: 0,
+        event: { kind: "run_started" },
+      }),
+    ).rejects.toThrow(/stale delivery attempt/);
+
+    expect(
+      calls.filter((c) => c.url.endsWith("/render-events/accept")),
+    ).toHaveLength(0);
+
+    await sink.push({
+      deliveryId: "dlv_9",
+      deliveryAttempt: second.env.deliveryAttempt,
+      turnId: "turn_9",
+      slot: "main",
+      seq: 0,
+      event: { kind: "run_started" },
+    });
+    const accept = calls.find((c) => c.url.endsWith("/render-events/accept"))!;
+    expect(accept.body).toMatchObject({ leaseToken: "lease_2" });
+  });
+
+  it("preserves deterministic render-conflict error metadata", async () => {
+    const { fetch } = fakeFetch((c) =>
+      c.url.endsWith("/claim")
+        ? { body: { claimed: true, delivery: claimedDelivery() } }
+        : {
+            ok: false,
+            status: 409,
+            body: {
+              error: {
+                code: "CHANNEL_RENDER_FRAME_CONFLICT",
+                message: "different frame already exists",
+                category: "conflict",
+                retryable: false,
+              },
+            },
+          },
+    );
+    const conf = cfg({ fetch });
+    const src = new HttpDeliverySource(conf);
+    const claim = await src.claimOnce();
+    if (!("env" in claim)) throw new Error("expected a claim");
+    const sink = new HttpRenderEventSink(conf, src);
+
+    await expect(
+      sink.push({
+        deliveryId: "dlv_9",
+        deliveryAttempt: claim.env.deliveryAttempt,
+        turnId: "turn_9",
+        slot: "main",
+        seq: 0,
+        event: { kind: "run_started" },
+      }),
+    ).rejects.toMatchObject({
+      code: "CHANNEL_RENDER_FRAME_CONFLICT",
+      status: 409,
+      retryable: false,
+    });
+  });
 });
 
 describe("intelligenceAdapter() — config-free default transports", () => {
@@ -1151,5 +1703,69 @@ describe("intelligenceAdapter() — config-free default transports", () => {
       declaredChannels: [{ channelName: "opentagbot", adapter: "slack" }],
     });
     expect(calls.some((c) => c.url.endsWith("/claim"))).toBe(true);
+  });
+
+  it("retries a lost completion response once with the exact first payload", async () => {
+    let claimCalls = 0;
+    let ackCalls = 0;
+    const { fetch, calls } = fakeFetch((call) => {
+      if (call.url.endsWith("/heartbeat")) return { body: {} };
+      if (call.url.endsWith("/claim")) {
+        claimCalls += 1;
+        return claimCalls === 1
+          ? { body: { claimed: true, delivery: claimedDelivery() } }
+          : { body: { claimed: false, pollAfterMs: 60_000 } };
+      }
+      if (call.url.endsWith("/ack")) {
+        ackCalls += 1;
+        return ackCalls === 1
+          ? {
+              ok: false,
+              status: 503,
+              body: {
+                error: {
+                  code: "INTERNAL_SERVER_ERROR",
+                  message: "response lost after commit",
+                  retryable: true,
+                },
+              },
+            }
+          : { body: { acknowledged: true } };
+      }
+      return { body: { failed: true } };
+    });
+    const source = new HttpDeliverySource(
+      cfg({
+        fetch,
+        sleep: () => new Promise<void>(() => {}),
+      }),
+    );
+    const bot = createChannel({
+      adapters: [
+        intelligenceAdapter({
+          source,
+          egress: new InMemoryEgressSink(),
+        }),
+      ],
+      agent: () => new FakeAgent(),
+    });
+    bot.onMessage(async () => {});
+
+    await bot.ɵruntime.start();
+    try {
+      await vi.waitFor(
+        () =>
+          expect(
+            calls.filter((call) => call.url.endsWith("/ack")),
+          ).toHaveLength(2),
+        { timeout: 500 },
+      );
+    } finally {
+      await bot.ɵruntime.stop();
+    }
+
+    const acks = calls.filter((call) => call.url.endsWith("/ack"));
+    expect(acks[1]!.rawBody).toBe(acks[0]!.rawBody);
+    expect(calls.filter((call) => call.url.endsWith("/fail"))).toHaveLength(0);
   });
 });

--- a/packages/channels-intelligence/src/http-transports.ts
+++ b/packages/channels-intelligence/src/http-transports.ts
@@ -16,8 +16,27 @@ import type {
 } from "./contracts.js";
 import { irToText } from "./ir-to-text.js";
 import { mapDeliveryToEnvelope } from "./claim-mapping.js";
-import type { ClaimedDelivery } from "./claim-mapping.js";
+import type {
+  ClaimedChannelIngressEnvelope,
+  ClaimedDelivery,
+} from "./claim-mapping.js";
 import { IntelligenceFileHistoryClient } from "./intelligence-file-history.js";
+import {
+  channelTransportError,
+  deliveryAttemptFromClaim,
+  deliveryAttemptKey,
+  effectiveDeliveryTimeoutMs,
+  isDeliveryAttemptExpired,
+  isRetryableDeliveryError,
+  isStrictlyNewerDeliveryAttempt,
+  runAttemptTerminalIntent,
+  scheduleDeliveryAttemptExpiry,
+} from "./delivery-attempt.js";
+import type {
+  AttemptTerminalState,
+  DeliveryAttemptInput,
+  DeliveryAttemptRef,
+} from "./delivery-attempt.js";
 
 /**
  * @internal Default HTTP transports for {@link intelligenceAdapter}.
@@ -206,18 +225,40 @@ class IntelligenceHttp {
     });
     const raw = await res.text();
     if (!res.ok) {
-      throw new Error(
-        `intelligence ${path} -> ${res.status}: ${raw.slice(0, 300)}`,
+      let reason: unknown = raw.slice(0, 300);
+      try {
+        reason = raw ? (JSON.parse(raw) as unknown) : reason;
+      } catch {
+        // Preserve the bounded raw response in the fallback error message.
+      }
+      throw channelTransportError(
+        `intelligence ${path} -> ${res.status}`,
+        reason,
+        res.status,
       );
     }
     return raw ? (JSON.parse(raw) as T) : ({} as T);
   }
 }
 
-interface LeaseRecord {
+interface LeaseRecord extends AttemptTerminalState {
+  attempt: DeliveryAttemptRef;
+  cancelExpiry?: () => void;
   turnId: string;
   leaseToken: string;
   scope: ChannelDeliveryScope;
+}
+
+interface DeliveryLeaseIdentity {
+  turnId: string;
+  runtimeInstanceId: string;
+  leaseToken: string;
+}
+
+interface DeliveryLeaseIdentitySource {
+  leaseIdentityFor(
+    attempt: DeliveryAttemptRef,
+  ): DeliveryLeaseIdentity | undefined;
 }
 
 /**
@@ -229,7 +270,10 @@ interface LeaseRecord {
 export class HttpDeliverySource implements DeliverySource {
   private readonly http: IntelligenceHttp;
   private readonly fileHistory: IntelligenceFileHistoryClient;
+  /** Attempt-keyed so a late handler can never resolve through newer state. */
   private readonly leases = new Map<string, LeaseRecord>();
+  /** Compatibility/current-attempt index for legacy string callers. */
+  private readonly activeAttempts = new Map<string, string>();
   private running = false;
   private loop?: Promise<void>;
   /** Standalone recurring heartbeat timer, independent of the claim loop. */
@@ -260,6 +304,109 @@ export class HttpDeliverySource implements DeliverySource {
     });
   }
 
+  private registerLease(record: LeaseRecord): boolean {
+    const key = deliveryAttemptKey(record.attempt);
+    if (this.leases.has(key)) {
+      this.cfg.log?.("intelligence duplicate delivery attempt ignored", {
+        deliveryId: record.attempt.deliveryId,
+        attemptCount: record.attempt.attemptCount,
+      });
+      return false;
+    }
+    const previousKey = this.activeAttempts.get(record.attempt.deliveryId);
+    if (previousKey) {
+      const previous = this.leases.get(previousKey);
+      if (previous) {
+        if (!isStrictlyNewerDeliveryAttempt(record.attempt, previous.attempt)) {
+          this.cfg.log?.(
+            "intelligence stale/conflicting delivery attempt ignored",
+            {
+              deliveryId: record.attempt.deliveryId,
+              incomingAttemptCount: record.attempt.attemptCount,
+              activeAttemptCount: previous.attempt.attemptCount,
+            },
+          );
+          return false;
+        }
+        this.cleanupLease(previous);
+        this.cfg.log?.("intelligence delivery attempt superseded", {
+          deliveryId: record.attempt.deliveryId,
+          previousAttemptKey: previousKey,
+          activeAttemptKey: key,
+        });
+      }
+    }
+    this.leases.set(key, record);
+    this.activeAttempts.set(record.attempt.deliveryId, key);
+    record.cancelExpiry = scheduleDeliveryAttemptExpiry(
+      record.attempt,
+      () => Date.now(),
+      () => {
+        if (this.leases.get(key) !== record) return;
+        this.cleanupLease(record);
+        this.cfg.log?.("intelligence delivery attempt expired", {
+          deliveryId: record.attempt.deliveryId,
+          attemptCount: record.attempt.attemptCount,
+        });
+      },
+    );
+    return true;
+  }
+
+  private cleanupLease(record: LeaseRecord): void {
+    record.cancelExpiry?.();
+    delete record.cancelExpiry;
+    const key = deliveryAttemptKey(record.attempt);
+    const ownsAttempt = this.leases.get(key) === record;
+    if (ownsAttempt) this.leases.delete(key);
+    if (
+      ownsAttempt &&
+      this.activeAttempts.get(record.attempt.deliveryId) === key
+    ) {
+      this.activeAttempts.delete(record.attempt.deliveryId);
+    }
+  }
+
+  private resolveLease(
+    input: DeliveryAttemptInput,
+    operation: string,
+  ): LeaseRecord | undefined {
+    const deliveryId = typeof input === "string" ? input : input.deliveryId;
+    const activeKey = this.activeAttempts.get(deliveryId);
+    const requestedKey =
+      typeof input === "string" ? activeKey : deliveryAttemptKey(input);
+    if (!activeKey) {
+      this.cfg.log?.(
+        `intelligence ${operation}: no lease for delivery ${deliveryId}`,
+      );
+      return undefined;
+    }
+    if (requestedKey !== activeKey) {
+      this.cfg.log?.(`intelligence ${operation}: stale attempt ignored`, {
+        deliveryId,
+        requestedAttemptKey: requestedKey,
+        activeAttemptKey: activeKey,
+      });
+      return undefined;
+    }
+    const lease = this.leases.get(requestedKey);
+    if (!lease) {
+      this.cfg.log?.(
+        `intelligence ${operation}: no lease for delivery ${deliveryId}`,
+      );
+      return undefined;
+    }
+    if (isDeliveryAttemptExpired(lease.attempt, Date.now())) {
+      this.cleanupLease(lease);
+      this.cfg.log?.(`intelligence ${operation}: expired attempt ignored`, {
+        deliveryId,
+        attemptCount: lease.attempt.attemptCount,
+      });
+      return undefined;
+    }
+    return lease;
+  }
+
   private sleep(ms: number): Promise<void> {
     const base = (this.cfg.sleep ?? defaultSleep)(ms);
     // Interruptible: stop() resolves stopWait so an in-flight poll-sleep ends at
@@ -280,7 +427,7 @@ export class HttpDeliverySource implements DeliverySource {
 
   /** Claim a single delivery; returns the mapped envelope, or the idle backoff. */
   async claimOnce(): Promise<
-    { env: ChannelIngressEnvelope } | { pollAfterMs: number }
+    { env: ClaimedChannelIngressEnvelope } | { pollAfterMs: number }
   > {
     const res = await this.http.post<ClaimResponse>(
       "/api/channels/listener/claim",
@@ -295,7 +442,25 @@ export class HttpDeliverySource implements DeliverySource {
       },
     );
     if (!res.claimed) return { pollAfterMs: res.pollAfterMs ?? 1000 };
-    this.leases.set(res.delivery.id, {
+    let attempt: DeliveryAttemptRef;
+    try {
+      attempt = deliveryAttemptFromClaim(res.delivery);
+    } catch (attemptErr) {
+      this.cfg.log?.(
+        "intelligence claim: invalid attempt identity; failing non-retryable",
+        attemptErr,
+      );
+      await this.failClaimWithoutAttempt(res.delivery, attemptErr).catch(
+        (failErr) =>
+          this.cfg.log?.(
+            "intelligence fail after invalid attempt identity failed",
+            failErr,
+          ),
+      );
+      return { pollAfterMs: 1000 };
+    }
+    const registered = this.registerLease({
+      attempt,
       turnId: res.delivery.turn.id,
       leaseToken: res.delivery.leaseToken,
       scope: {
@@ -305,6 +470,7 @@ export class HttpDeliverySource implements DeliverySource {
         channelName: res.delivery.channel.name,
       },
     });
+    if (!registered) return { pollAfterMs: 1000 };
     try {
       return { env: mapDeliveryToEnvelope(res.delivery) };
     } catch (mapErr) {
@@ -314,7 +480,7 @@ export class HttpDeliverySource implements DeliverySource {
       // let app-api dead-letter it rather than burn retries) and fall through to
       // an idle poll so the loop keeps draining the queue. Without this the
       // throw escapes to runLoop's catch, which only logs+sleeps, leaking the
-      // lease until the 120s expiry redelivers the same poison payload forever.
+      // lease until expiry redelivers the same poison payload forever.
       this.cfg.log?.("intelligence claim: unmappable delivery", mapErr);
       await this.nack(
         res.delivery.id,
@@ -330,15 +496,52 @@ export class HttpDeliverySource implements DeliverySource {
     }
   }
 
+  private async failClaimWithoutAttempt(
+    delivery: ClaimedDelivery,
+    reason: unknown,
+  ): Promise<void> {
+    await this.http.post(
+      `/api/channels/deliveries/${encodeURIComponent(delivery.id)}/fail`,
+      {
+        turnId: delivery.turn.id,
+        runtimeInstanceId: this.cfg.runtimeInstanceId,
+        leaseToken: delivery.leaseToken,
+        failedAt: new Date().toISOString(),
+        error: {
+          code: "runtime_error",
+          message: (reason instanceof Error
+            ? reason.message
+            : String(reason)
+          ).slice(0, 500),
+          retryable: false,
+        },
+      },
+    );
+  }
+
   /** The org/project/channel scope for a leased delivery, for render-frame egress. */
-  scopeFor(deliveryId: string): ChannelDeliveryScope | undefined {
-    return this.leases.get(deliveryId)?.scope;
+  scopeFor(attempt: DeliveryAttemptInput): ChannelDeliveryScope | undefined {
+    return this.resolveLease(attempt, "render")?.scope;
   }
 
   /** The lease token for a leased delivery, so a render frame can fence its
    * accept against `lease_token_hash` the same way ack/fail already do. */
-  leaseTokenFor(deliveryId: string): string | undefined {
-    return this.leases.get(deliveryId)?.leaseToken;
+  leaseTokenFor(attempt: DeliveryAttemptInput): string | undefined {
+    return this.resolveLease(attempt, "render")?.leaseToken;
+  }
+
+  /** Exact live lease identity for attempt-fenced direct HTTP egress. */
+  leaseIdentityFor(
+    attempt: DeliveryAttemptRef,
+  ): DeliveryLeaseIdentity | undefined {
+    const lease = this.resolveLease(attempt, "egress");
+    return lease
+      ? {
+          turnId: lease.turnId,
+          runtimeInstanceId: this.cfg.runtimeInstanceId,
+          leaseToken: lease.leaseToken,
+        }
+      : undefined;
   }
 
   async start(
@@ -398,7 +601,30 @@ export class HttpDeliverySource implements DeliverySource {
           // we time it out, `nack` to release the lease immediately (app-api
           // then retries / dead-letters at max_attempts), and keep polling.
           const env = r.env;
-          const timeoutMs = this.cfg.turnTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS;
+          const configuredTimeoutMs =
+            this.cfg.turnTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS;
+          const timeoutMs = effectiveDeliveryTimeoutMs(
+            configuredTimeoutMs,
+            env.deliveryAttempt,
+            Date.now(),
+          );
+          if (timeoutMs <= 0) {
+            const reason =
+              `turn ${env.turnId} cannot start inside the delivery lease ` +
+              "safety margin";
+            this.cfg.log?.("intelligence turn skipped near lease expiry", {
+              deliveryId: env.deliveryId,
+              attemptCount: env.deliveryAttempt.attemptCount,
+              leaseExpiresAt: env.deliveryAttempt.leaseExpiresAt,
+            });
+            await this.nack(env.deliveryAttempt, reason).catch((nackErr) =>
+              this.cfg.log?.(
+                "intelligence nack after lease-margin skip failed",
+                nackErr,
+              ),
+            );
+            continue;
+          }
           // Always attach a terminal handler so a turn that rejects AFTER we've
           // stopped (below) never surfaces as an unhandled rejection.
           const settled = withTimeout(
@@ -425,10 +651,11 @@ export class HttpDeliverySource implements DeliverySource {
           if (!outcome.ok) {
             this.cfg.log?.("intelligence turn failed/timed out", outcome.err);
             await this.nack(
-              env.deliveryId,
+              env.deliveryAttempt,
               outcome.err instanceof Error
                 ? outcome.err.message
                 : String(outcome.err),
+              isRetryableDeliveryError(outcome.err),
             ).catch((nackErr) =>
               this.cfg.log?.(
                 "intelligence nack after turn failure failed",
@@ -446,53 +673,56 @@ export class HttpDeliverySource implements DeliverySource {
     }
   }
 
-  async ack(deliveryId: string): Promise<void> {
-    const lease = this.leases.get(deliveryId);
-    if (!lease) {
-      this.cfg.log?.(`intelligence ack: no lease for delivery ${deliveryId}`);
-      return;
-    }
-    // Claim the terminal signal BEFORE the wire call. A turn that completes in
-    // the background after a timeout-`nack` (both close over this lease) must
-    // not also ack: whichever of ack/nack runs first deletes the lease, so the
-    // other sees none and no-ops — exactly one of ack XOR fail reaches app-api.
-    this.leases.delete(deliveryId);
-    await this.http.post(
-      `/api/channels/deliveries/${encodeURIComponent(deliveryId)}/ack`,
-      {
-        turnId: lease.turnId,
-        runtimeInstanceId: this.cfg.runtimeInstanceId,
-        leaseToken: lease.leaseToken,
-        acknowledgedAt: new Date().toISOString(),
-      },
+  async ack(attempt: DeliveryAttemptInput): Promise<void> {
+    const lease = this.resolveLease(attempt, "ack");
+    if (!lease) return;
+    const payload = {
+      turnId: lease.turnId,
+      runtimeInstanceId: this.cfg.runtimeInstanceId,
+      leaseToken: lease.leaseToken,
+      acknowledgedAt: new Date().toISOString(),
+    };
+    await runAttemptTerminalIntent(
+      lease,
+      "complete",
+      () =>
+        this.http.post(
+          `/api/channels/deliveries/${encodeURIComponent(lease.attempt.deliveryId)}/ack`,
+          payload,
+        ),
+      () => this.cleanupLease(lease),
+      this.cfg.log,
     );
   }
 
   async nack(
-    deliveryId: string,
+    attempt: DeliveryAttemptInput,
     reason: string,
     retryable = true,
   ): Promise<void> {
-    const lease = this.leases.get(deliveryId);
-    if (!lease) {
-      this.cfg.log?.(`intelligence nack: no lease for delivery ${deliveryId}`);
-      return;
-    }
-    // Delete-before-POST for the same reason as `ack`: single terminal signal.
-    this.leases.delete(deliveryId);
-    await this.http.post(
-      `/api/channels/deliveries/${encodeURIComponent(deliveryId)}/fail`,
-      {
-        turnId: lease.turnId,
-        runtimeInstanceId: this.cfg.runtimeInstanceId,
-        leaseToken: lease.leaseToken,
-        failedAt: new Date().toISOString(),
-        error: {
-          code: "runtime_error",
-          message: (reason || "runtime error").slice(0, 500),
-          retryable,
-        },
+    const lease = this.resolveLease(attempt, "nack");
+    if (!lease) return;
+    const payload = {
+      turnId: lease.turnId,
+      runtimeInstanceId: this.cfg.runtimeInstanceId,
+      leaseToken: lease.leaseToken,
+      failedAt: new Date().toISOString(),
+      error: {
+        code: "runtime_error",
+        message: (reason || "runtime error").slice(0, 500),
+        retryable,
       },
+    };
+    await runAttemptTerminalIntent(
+      lease,
+      "fail",
+      () =>
+        this.http.post(
+          `/api/channels/deliveries/${encodeURIComponent(lease.attempt.deliveryId)}/fail`,
+          payload,
+        ),
+      () => this.cleanupLease(lease),
+      this.cfg.log,
     );
   }
 
@@ -531,6 +761,9 @@ export class HttpDeliverySource implements DeliverySource {
       this.heartbeatTimer = undefined;
     }
     await this.loop?.catch(() => {});
+    for (const lease of this.leases.values()) lease.cancelExpiry?.();
+    this.leases.clear();
+    this.activeAttempts.clear();
   }
 }
 
@@ -543,7 +776,10 @@ export class HttpDeliverySource implements DeliverySource {
 export class HttpEgressSink implements EgressSink {
   private readonly http: IntelligenceHttp;
 
-  constructor(private readonly cfg: IntelligenceTransportConfig) {
+  constructor(
+    private readonly cfg: IntelligenceTransportConfig,
+    private readonly leaseSource?: DeliveryLeaseIdentitySource,
+  ) {
     this.http = new IntelligenceHttp(cfg);
   }
 
@@ -578,6 +814,34 @@ export class HttpEgressSink implements EgressSink {
     // to the config adapter when the route carries none.
     const routeAdapter = (op.route as { adapter?: string } | null | undefined)
       ?.adapter;
+    let attemptCredentials:
+      | {
+          turnId: string;
+          runtimeInstanceId: string;
+          leaseToken: string;
+        }
+      | undefined;
+    if (op.deliveryAttempt) {
+      const lease =
+        op.deliveryAttempt.deliveryId === op.deliveryId
+          ? this.leaseSource?.leaseIdentityFor(op.deliveryAttempt)
+          : undefined;
+      if (!lease || lease.turnId !== op.turnId) {
+        this.cfg.log?.(
+          "intelligence egress: exact delivery attempt unavailable",
+          {
+            deliveryId: op.deliveryId,
+            attemptCount: op.deliveryAttempt.attemptCount,
+          },
+        );
+        return { ok: false, code: "delivery_attempt_unavailable" };
+      }
+      attemptCredentials = {
+        turnId: op.turnId,
+        runtimeInstanceId: lease.runtimeInstanceId,
+        leaseToken: lease.leaseToken,
+      };
+    }
     try {
       const res = await this.http.post<EgressResponse>(
         "/api/channels/egress/messages",
@@ -588,6 +852,7 @@ export class HttpEgressSink implements EgressSink {
           idempotencyKey: op.operationId,
           replyTarget: op.route,
           text,
+          ...attemptCredentials,
         },
       );
       if (res.status === "failed") {
@@ -629,25 +894,28 @@ export class HttpRenderEventSink implements RenderEventSink {
   constructor(
     private readonly cfg: IntelligenceTransportConfig,
     private readonly scopeSource: {
-      scopeFor(deliveryId: string): ChannelDeliveryScope | undefined;
-      leaseTokenFor(deliveryId: string): string | undefined;
+      scopeFor(attempt: DeliveryAttemptInput): ChannelDeliveryScope | undefined;
+      leaseTokenFor(attempt: DeliveryAttemptInput): string | undefined;
     },
   ) {
     this.http = new IntelligenceHttp(cfg);
   }
 
   async push(frame: RenderFrame): Promise<RenderAccepted> {
-    const scope = this.scopeSource.scopeFor(frame.deliveryId);
+    const attempt = frame.deliveryAttempt ?? frame.deliveryId;
+    const scope = this.scopeSource.scopeFor(attempt);
     if (!scope) {
       throw new Error(
-        `intelligenceAdapter: no leased scope for delivery ${frame.deliveryId}`,
+        frame.deliveryAttempt
+          ? `intelligenceAdapter: stale delivery attempt cannot render for ${frame.deliveryId}`
+          : `intelligenceAdapter: no leased scope for delivery ${frame.deliveryId}`,
       );
     }
     // Fence the render-accept on the delivery's lease token (OSS-446), the same
     // way ack/fail already do. Optional: app-api falls back to instance-id +
     // expiry when it's absent, so an older lease record without a token still
     // renders — but supplying it lets app-api reject a stale/rotated lease.
-    const leaseToken = this.scopeSource.leaseTokenFor(frame.deliveryId);
+    const leaseToken = this.scopeSource.leaseTokenFor(attempt);
     const idempotencyKey = `${frame.turnId}:${frame.slot}:${frame.seq}`;
     const res = await this.http.post<RenderAcceptedResponse>(
       `/api/channels/deliveries/${encodeURIComponent(frame.deliveryId)}/render-events/accept`,

--- a/packages/channels-intelligence/src/http-transports.ts
+++ b/packages/channels-intelligence/src/http-transports.ts
@@ -253,11 +253,13 @@ interface DeliveryLeaseIdentity {
   turnId: string;
   runtimeInstanceId: string;
   leaseToken: string;
+  scope: ChannelDeliveryScope;
 }
 
 interface DeliveryLeaseIdentitySource {
   leaseIdentityFor(
     attempt: DeliveryAttemptRef,
+    operation?: "egress" | "render",
   ): DeliveryLeaseIdentity | undefined;
 }
 
@@ -404,6 +406,20 @@ export class HttpDeliverySource implements DeliverySource {
       });
       return undefined;
     }
+    if (
+      lease.terminal !== undefined &&
+      (operation === "render" || operation === "egress")
+    ) {
+      this.cfg.log?.(
+        `intelligence ${operation}: terminal attempt cannot emit more output`,
+        {
+          deliveryId,
+          attemptCount: lease.attempt.attemptCount,
+          terminalKind: lease.terminal.kind,
+        },
+      );
+      return undefined;
+    }
     return lease;
   }
 
@@ -533,13 +549,15 @@ export class HttpDeliverySource implements DeliverySource {
   /** Exact live lease identity for attempt-fenced direct HTTP egress. */
   leaseIdentityFor(
     attempt: DeliveryAttemptRef,
+    operation: "egress" | "render" = "egress",
   ): DeliveryLeaseIdentity | undefined {
-    const lease = this.resolveLease(attempt, "egress");
+    const lease = this.resolveLease(attempt, operation);
     return lease
       ? {
           turnId: lease.turnId,
           runtimeInstanceId: this.cfg.runtimeInstanceId,
           leaseToken: lease.leaseToken,
+          scope: lease.scope,
         }
       : undefined;
   }
@@ -896,14 +914,37 @@ export class HttpRenderEventSink implements RenderEventSink {
     private readonly scopeSource: {
       scopeFor(attempt: DeliveryAttemptInput): ChannelDeliveryScope | undefined;
       leaseTokenFor(attempt: DeliveryAttemptInput): string | undefined;
+      leaseIdentityFor?(
+        attempt: DeliveryAttemptRef,
+        operation?: "egress" | "render",
+      ): DeliveryLeaseIdentity | undefined;
     },
   ) {
     this.http = new IntelligenceHttp(cfg);
   }
 
   async push(frame: RenderFrame): Promise<RenderAccepted> {
-    const attempt = frame.deliveryAttempt ?? frame.deliveryId;
-    const scope = this.scopeSource.scopeFor(attempt);
+    let scope: ChannelDeliveryScope | undefined;
+    let leaseToken: string | undefined;
+    if (frame.deliveryAttempt) {
+      // Resolve scope + token from one lease record. Separate lookups allow a
+      // newer attempt to supersede the old one between calls, retaining the
+      // old scope but dropping its token and accidentally sending an unfenced
+      // render accept.
+      const lease =
+        frame.deliveryAttempt.deliveryId === frame.deliveryId
+          ? this.scopeSource.leaseIdentityFor?.(frame.deliveryAttempt, "render")
+          : undefined;
+      if (lease?.turnId === frame.turnId) {
+        scope = lease.scope;
+        leaseToken = lease.leaseToken;
+      }
+    } else {
+      // Compatibility path for legacy injected frames that carry only a
+      // delivery id. Live mapped frames always take the atomic path above.
+      scope = this.scopeSource.scopeFor(frame.deliveryId);
+      leaseToken = this.scopeSource.leaseTokenFor(frame.deliveryId);
+    }
     if (!scope) {
       throw new Error(
         frame.deliveryAttempt
@@ -912,10 +953,9 @@ export class HttpRenderEventSink implements RenderEventSink {
       );
     }
     // Fence the render-accept on the delivery's lease token (OSS-446), the same
-    // way ack/fail already do. Optional: app-api falls back to instance-id +
-    // expiry when it's absent, so an older lease record without a token still
-    // renders — but supplying it lets app-api reject a stale/rotated lease.
-    const leaseToken = this.scopeSource.leaseTokenFor(attempt);
+    // way ack/fail already do. Exact-attempt frames require the atomic snapshot
+    // above; only legacy delivery-id-only frames retain app-api's tokenless
+    // instance-id + expiry fallback.
     const idempotencyKey = `${frame.turnId}:${frame.slot}:${frame.seq}`;
     const res = await this.http.post<RenderAcceptedResponse>(
       `/api/channels/deliveries/${encodeURIComponent(frame.deliveryId)}/render-events/accept`,

--- a/packages/channels-intelligence/src/in-memory-transports.ts
+++ b/packages/channels-intelligence/src/in-memory-transports.ts
@@ -12,6 +12,10 @@ import type {
   RenderFrame,
   RenderAccepted,
 } from "./contracts.js";
+import type {
+  DeliveryAttemptInput,
+  DeliveryAttemptRef,
+} from "./delivery-attempt.js";
 
 /**
  * In-memory {@link EgressSink} that records every emitted operation and acks it
@@ -54,7 +58,13 @@ export class InMemoryRenderEventSink implements RenderEventSink {
  */
 export class InMemoryDeliverySource implements DeliverySource {
   readonly acked: string[] = [];
-  readonly nacked: { deliveryId: string; reason: string }[] = [];
+  readonly ackedAttempts: DeliveryAttemptRef[] = [];
+  readonly nacked: {
+    deliveryId: string;
+    reason: string;
+    retryable: boolean;
+    deliveryAttempt?: DeliveryAttemptRef;
+  }[] = [];
   /** Seed by handle so a turn's file refs hydrate into content parts. */
   readonly files = new Map<string, { bytes: Uint8Array; mimeType?: string }>();
   /**
@@ -89,11 +99,25 @@ export class InMemoryDeliverySource implements DeliverySource {
     await this.onDelivery(env);
   }
 
-  async ack(deliveryId: string): Promise<void> {
+  async ack(attempt: DeliveryAttemptInput): Promise<void> {
+    const deliveryId =
+      typeof attempt === "string" ? attempt : attempt.deliveryId;
     this.acked.push(deliveryId);
+    if (typeof attempt !== "string") this.ackedAttempts.push(attempt);
   }
-  async nack(deliveryId: string, reason: string): Promise<void> {
-    this.nacked.push({ deliveryId, reason });
+  async nack(
+    attempt: DeliveryAttemptInput,
+    reason: string,
+    retryable = true,
+  ): Promise<void> {
+    const deliveryId =
+      typeof attempt === "string" ? attempt : attempt.deliveryId;
+    this.nacked.push({
+      deliveryId,
+      reason,
+      retryable,
+      ...(typeof attempt === "string" ? {} : { deliveryAttempt: attempt }),
+    });
   }
   async fetchFile(
     handle: string,

--- a/packages/channels-intelligence/src/intelligence-adapter.test.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   createChannel,
   FakeAdapter,
@@ -15,7 +15,7 @@ import {
 } from "./in-memory-transports.js";
 import { IntelligenceStateStore } from "./intelligence-state-store.js";
 import type { FetchLike } from "./http-transports.js";
-import type { EgressSink } from "./transports.js";
+import type { EgressSink, RenderEventSink } from "./transports.js";
 import type {
   ChannelIngressEnvelope,
   ChannelIngressBase,
@@ -25,6 +25,11 @@ type TurnEnvelope = Extract<ChannelIngressEnvelope, { kind: "turn" }>;
 function envelope(partial?: Partial<TurnEnvelope>): ChannelIngressEnvelope {
   return {
     deliveryId: "d1",
+    deliveryAttempt: {
+      deliveryId: "d1",
+      attemptCount: 1,
+      leaseExpiresAt: "2099-07-01T00:02:30.000Z",
+    },
     eventId: "e1",
     turnId: "t1",
     channelName: "support",
@@ -56,6 +61,13 @@ describe("intelligenceAdapter — ingress dispatch", () => {
     expect(egress.ops).toHaveLength(1);
     expect(egress.ops[0]!.op.kind).toBe("post");
     expect(egress.ops[0]!.turnId).toBe("t1");
+    expect(egress.ops[0]).toMatchObject({
+      deliveryAttempt: {
+        deliveryId: "d1",
+        attemptCount: 1,
+        leaseExpiresAt: "2099-07-01T00:02:30.000Z",
+      },
+    });
     expect(seen?.turnId).toBe("t1");
     expect(seen?.deliveryId).toBe("d1");
     expect(seen?.eventId).toBe("e1");
@@ -94,8 +106,55 @@ describe("intelligenceAdapter — ingress dispatch", () => {
     });
     bot.onMessage(async () => {});
     await bot.ɵruntime.start();
-    await source.deliver(envelope({ deliveryId: "d9" }));
+    await source.deliver(
+      envelope({
+        deliveryId: "d9",
+        deliveryAttempt: {
+          deliveryId: "d9",
+          attemptCount: 4,
+          leaseExpiresAt: "2099-07-01T00:04:30.000Z",
+        },
+      }),
+    );
     expect(source.acked).toEqual(["d9"]);
+    expect(source.ackedAttempts).toEqual([
+      {
+        deliveryId: "d9",
+        attemptCount: 4,
+        leaseExpiresAt: "2099-07-01T00:04:30.000Z",
+      },
+    ]);
+    expect(source.nacked).toEqual([]);
+  });
+
+  it("keeps legacy injected envelopes working without attempt metadata", async () => {
+    const source = new InMemoryDeliverySource();
+    const egress = new InMemoryEgressSink();
+    const bot = createChannel({
+      adapters: [intelligenceAdapter({ source, egress })],
+      agent: () => new FakeAgent(),
+    });
+    bot.onMessage(async ({ thread }) => {
+      await thread.post(Section({ children: "legacy reply" }));
+    });
+    await bot.ɵruntime.start();
+    const legacyEnvelope: ChannelIngressEnvelope = {
+      deliveryId: "d_legacy",
+      eventId: "e_legacy",
+      turnId: "t_legacy",
+      channelName: "support",
+      platform: "slack",
+      conversationKey: "c_legacy",
+      kind: "turn",
+      text: "hello from an injected source",
+      route: { r: "legacy" },
+    };
+
+    await source.deliver(legacyEnvelope);
+
+    expect(egress.ops).toHaveLength(1);
+    expect(source.acked).toEqual(["d_legacy"]);
+    expect(source.ackedAttempts).toEqual([]);
     expect(source.nacked).toEqual([]);
   });
 
@@ -110,9 +169,175 @@ describe("intelligenceAdapter — ingress dispatch", () => {
       throw new Error("boom");
     });
     await bot.ɵruntime.start();
-    await source.deliver(envelope({ deliveryId: "d9" }));
+    await source.deliver(
+      envelope({
+        deliveryId: "d9",
+        deliveryAttempt: {
+          deliveryId: "d9",
+          attemptCount: 4,
+          leaseExpiresAt: "2099-07-01T00:04:30.000Z",
+        },
+      }),
+    );
     expect(source.acked).toEqual([]);
     expect(source.nacked.map((n) => n.deliveryId)).toEqual(["d9"]);
+  });
+
+  it("marks deterministic render conflicts non-retryable even when metadata says retryable", async () => {
+    const source = new InMemoryDeliverySource();
+    const renderSink: RenderEventSink = {
+      push: async () => {
+        throw Object.assign(new Error("different frame already exists"), {
+          code: "CHANNEL_RENDER_FRAME_CONFLICT",
+          retryable: true,
+        });
+      },
+    };
+    const bot = createChannel({
+      adapters: [
+        intelligenceAdapter({
+          source,
+          egress: new InMemoryEgressSink(),
+          renderSink,
+        }),
+      ],
+      agent: () => new FakeAgent(),
+    });
+    bot.onMessage(async ({ thread }) => {
+      await thread.post(Section({ children: "reply" }));
+    });
+    await bot.ɵruntime.start();
+
+    await source.deliver(envelope());
+
+    expect(source.nacked).toHaveLength(1);
+    expect(source.nacked[0]).toMatchObject({
+      deliveryId: "d1",
+      retryable: false,
+    });
+  });
+
+  it("logs a non-retryable completion failure without nacking or retrying", async () => {
+    const source = new InMemoryDeliverySource();
+    const logs: { msg: string; meta?: unknown }[] = [];
+    const ack = vi
+      .spyOn(source, "ack")
+      .mockRejectedValueOnce(
+        Object.assign(new Error("lease fenced"), {
+          code: "CHANNEL_DELIVERY_LEASE_INVALID",
+        }),
+      )
+      // Mirrors a real source after a definitive fence cleans its local state:
+      // an incorrect retry would no-op and swallow the original error.
+      .mockResolvedValueOnce();
+    const bot = createChannel({
+      adapters: [
+        intelligenceAdapter({
+          source,
+          egress: new InMemoryEgressSink(),
+          config: { log: (msg, meta) => logs.push({ msg, meta }) },
+        }),
+      ],
+      agent: () => new FakeAgent(),
+    });
+    bot.onMessage(async () => {});
+    await bot.ɵruntime.start();
+
+    await expect(source.deliver(envelope())).resolves.toBeUndefined();
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(source.nacked).toEqual([]);
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        msg: expect.stringMatching(/ack failed.*not nacking/i),
+        meta: expect.objectContaining({ message: "lease fenced" }),
+      }),
+    );
+  });
+
+  it("logs after one retryable completion retry without nacking", async () => {
+    const source = new InMemoryDeliverySource();
+    const logs: { msg: string; meta?: unknown }[] = [];
+    const ack = vi
+      .spyOn(source, "ack")
+      .mockRejectedValue(
+        Object.assign(new Error("gateway unavailable"), { retryable: true }),
+      );
+    const bot = createChannel({
+      adapters: [
+        intelligenceAdapter({
+          source,
+          egress: new InMemoryEgressSink(),
+          config: { log: (msg, meta) => logs.push({ msg, meta }) },
+        }),
+      ],
+      agent: () => new FakeAgent(),
+    });
+    bot.onMessage(async () => {});
+    await bot.ɵruntime.start();
+
+    await expect(source.deliver(envelope())).resolves.toBeUndefined();
+    expect(ack).toHaveBeenCalledTimes(2);
+    expect(source.nacked).toEqual([]);
+    expect(logs.some((entry) => /retrying once/i.test(entry.msg))).toBe(true);
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        msg: expect.stringMatching(/ack failed.*not nacking/i),
+        meta: expect.objectContaining({ message: "gateway unavailable" }),
+      }),
+    );
+  });
+
+  it("evicts attempt render state at lease expiry while its handler is still hung", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-01T00:00:00.000Z"));
+    try {
+      const source = new InMemoryDeliverySource();
+      const adapter = intelligenceAdapter({
+        source,
+        egress: new InMemoryEgressSink(),
+      });
+      const bot = createChannel({
+        adapters: [adapter],
+        agent: () => new FakeAgent(),
+      });
+      let releaseHandler!: () => void;
+      const handlerGate = new Promise<void>((resolve) => {
+        releaseHandler = resolve;
+      });
+      let markStarted!: () => void;
+      const handlerStarted = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      bot.onMessage(async () => {
+        markStarted();
+        await handlerGate;
+      });
+      await bot.ɵruntime.start();
+
+      const pending = source.deliver(
+        envelope({
+          deliveryId: "d_expiring",
+          deliveryAttempt: {
+            deliveryId: "d_expiring",
+            attemptCount: 1,
+            leaseExpiresAt: "2026-07-01T00:00:01.000Z",
+          },
+        }),
+      );
+      await handlerStarted;
+      const renderState = (
+        adapter as unknown as { renderState: Map<string, unknown> }
+      ).renderState;
+      expect(renderState.size).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(1_001);
+      expect(renderState.size).toBe(0);
+
+      releaseHandler();
+      await pending;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -528,6 +753,11 @@ describe("intelligenceAdapter — ack failure isolation (OSS-491)", () => {
 describe("intelligenceAdapter — all ingress kinds route to bot core", () => {
   const base: ChannelIngressBase = {
     deliveryId: "d1",
+    deliveryAttempt: {
+      deliveryId: "d1",
+      attemptCount: 1,
+      leaseExpiresAt: "2099-07-01T00:02:30.000Z",
+    },
     eventId: "e1",
     turnId: "t1",
     channelName: "support",
@@ -597,6 +827,11 @@ describe("intelligenceAdapter — all ingress kinds route to bot core", () => {
     await source.deliver({
       ...base,
       deliveryId: "d_click",
+      deliveryAttempt: {
+        deliveryId: "d_click",
+        attemptCount: 1,
+        leaseExpiresAt: "2099-07-01T00:02:30.000Z",
+      },
       turnId: "t_click",
       kind: "interaction",
       actionId: "ck:approve",

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -42,12 +42,30 @@ import {
 import type { IntelligenceTransportConfig } from "./http-transports.js";
 import { IntelligenceStateStore } from "./intelligence-state-store.js";
 import { buildContentParts } from "./content-parts.js";
+import {
+  deliveryAttemptKey,
+  isDeliveryAttemptExpired,
+  isRetryableDeliveryError,
+  scheduleDeliveryAttemptExpiry,
+} from "./delivery-attempt.js";
+import type {
+  DeliveryAttemptInput,
+  DeliveryAttemptRef,
+} from "./delivery-attempt.js";
 
 /** Reply target the adapter mints during ingress and threads back to egress. */
 interface ChannelReplyTarget {
   route: unknown;
   turnId: string;
   deliveryId: string;
+  /** Present for every live claimed delivery; optional for legacy injected targets. */
+  deliveryAttempt?: DeliveryAttemptRef;
+}
+
+interface AdapterRenderState {
+  nextSeq: number;
+  needsFinalize: boolean;
+  cancelExpiry?: () => void;
 }
 
 /** Recover the routing a minted {@link MessageRef} carries (for update/delete). */
@@ -71,6 +89,9 @@ function targetFromRef(ref: MessageRef): ChannelReplyTarget {
     route: ref.__route,
     turnId: String(ref.__turnId),
     deliveryId: String(ref.__deliveryId),
+    ...(ref.__deliveryAttempt
+      ? { deliveryAttempt: ref.__deliveryAttempt as DeliveryAttemptRef }
+      : {}),
   };
 }
 
@@ -276,14 +297,11 @@ export class IntelligenceAdapter implements PlatformAdapter {
   /** Streaming render transport — injected via opts (realtime path). When unset,
    * the run renderer translates frames to `post` ops on {@link egress}. */
   private renderSink?: RenderEventSink;
-  /** Per-turn render state; reset at the start of each turn's processing so a
+  /** Per-attempt render state; reset at the start of each attempt so a
    * redelivery reproduces the same operation ids. A realtime turn starts
    * non-terminal: even an output-free handler must durably accept `finalize`
    * before its delivery may complete. */
-  private readonly renderState = new Map<
-    string,
-    { nextSeq: number; needsFinalize: boolean }
-  >();
+  private readonly renderState = new Map<string, AdapterRenderState>();
 
   constructor(private readonly opts: IntelligenceAdapterOptions = {}) {
     this.source = opts.source;
@@ -348,7 +366,10 @@ export class IntelligenceAdapter implements PlatformAdapter {
         channelName: this.opts.config?.channelName ?? ctx?.channelName,
       });
       const source = (this.source ??= new HttpDeliverySource(cfg));
-      this.egress ??= new HttpEgressSink(cfg);
+      this.egress ??= new HttpEgressSink(
+        cfg,
+        source instanceof HttpDeliverySource ? source : undefined,
+      );
       // Default the realtime render path to the HTTP render-accept route,
       // sharing the HttpDeliverySource's per-delivery scope. Only when we built
       // (or were given) an HttpDeliverySource — injected in-memory sources fall
@@ -379,37 +400,88 @@ export class IntelligenceAdapter implements PlatformAdapter {
     // DeliverySource delivers (and awaits) one envelope per turnId at a time —
     // true for at-least-once, lease-based delivery; overlapping redeliveries of
     // the same turnId would perturb the counter.
-    this.renderState.set(env.turnId, {
+    const attemptKey = env.deliveryAttempt
+      ? deliveryAttemptKey(env.deliveryAttempt)
+      : `legacy:${env.deliveryId}:${env.turnId}`;
+    const attempt = env.deliveryAttempt ?? env.deliveryId;
+    const renderState: AdapterRenderState = {
       nextSeq: 0,
       needsFinalize: this.renderSink !== undefined,
-    });
-    let turnProcessed = false;
-    try {
-      await this.dispatchTo(env);
-      await this.finalizeRenderedTurn(env);
-      turnProcessed = true;
-    } catch (err) {
-      await this.requireSource().nack(
-        env.deliveryId,
-        err instanceof Error ? err.message : String(err),
+    };
+    this.renderState.set(attemptKey, renderState);
+    if (env.deliveryAttempt) {
+      renderState.cancelExpiry = scheduleDeliveryAttemptExpiry(
+        env.deliveryAttempt,
+        () => Date.now(),
+        () => {
+          if (this.renderState.get(attemptKey) !== renderState) return;
+          this.renderState.delete(attemptKey);
+          this.opts.config?.log?.("intelligence adapter render state expired", {
+            deliveryId: env.deliveryId,
+            attemptCount: env.deliveryAttempt?.attemptCount,
+          });
+        },
       );
+    }
+    try {
+      try {
+        await this.dispatchTo(env);
+        await this.finalizeRenderedTurn(env);
+      } catch (err) {
+        await this.requireSource().nack(
+          attempt,
+          err instanceof Error ? err.message : String(err),
+          isRetryableDeliveryError(err),
+        );
+        return;
+      }
+      await this.completeDelivery(attempt, env.deliveryId);
     } finally {
       // Drop the per-turn state once the turn is fully processed (renderer
       // chain drained inside dispatchTo) so the Map can't grow unbounded over a
       // long-running Channel Bot. A redelivery re-seeds it at the top.
-      this.renderState.delete(env.turnId);
+      renderState.cancelExpiry?.();
+      if (this.renderState.get(attemptKey) === renderState) {
+        this.renderState.delete(attemptKey);
+      }
     }
-    if (!turnProcessed) return;
-    // Ack is its own phase: the turn already succeeded, so a failed ack is NOT a
-    // turn failure and must never nack (that would redeliver and rerun the whole
-    // turn). Log it and move on — the lease simply lapses and the transport may
-    // redeliver, but we never actively re-enqueue a completed turn.
+  }
+
+  /**
+   * Completion is distinct from handler/render failure: once complete wins,
+   * an opposite nack cannot recover a lost response. Retry one retryable
+   * completion immediately with the transport's exact frozen payload. If the
+   * completion still fails, log and leave the lease to lapse; throwing would
+   * make the delivery loop treat a successfully processed turn as failed.
+   */
+  private async completeDelivery(
+    attempt: DeliveryAttemptInput,
+    deliveryId: string,
+  ): Promise<void> {
+    const source = this.requireSource();
     try {
-      await this.requireSource().ack(env.deliveryId);
-    } catch (ackErr) {
+      await source.ack(attempt);
+      return;
+    } catch (err) {
+      let finalError = err;
+      if (isRetryableDeliveryError(err)) {
+        this.opts.config?.log?.(
+          "intelligence completion failed; retrying once",
+          err,
+        );
+        try {
+          await source.ack(attempt);
+          return;
+        } catch (retryErr) {
+          finalError = retryErr;
+        }
+      }
+      // Ack is its own phase: the turn already succeeded, so a failed ack must
+      // never nack (that would redeliver and rerun the whole turn). Log it and
+      // leave the lease to lapse instead of actively re-enqueueing the turn.
       this.opts.config?.log?.(
-        `intelligence ack failed for delivery ${env.deliveryId} after a successful turn; not nacking (turn already processed)`,
-        ackErr,
+        `intelligence ack failed for delivery ${deliveryId} after a successful turn; not nacking (turn already processed)`,
+        finalError,
       );
     }
   }
@@ -421,6 +493,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
       route: env.route,
       turnId: env.turnId,
       deliveryId: env.deliveryId,
+      ...(env.deliveryAttempt ? { deliveryAttempt: env.deliveryAttempt } : {}),
     };
     // Forward the provider identity the claim mapper resolved (OSS-476), not
     // just the id. The wire field is `displayName`; the public `PlatformUser`
@@ -498,6 +571,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
               __route: replyTarget.route,
               __turnId: replyTarget.turnId,
               __deliveryId: replyTarget.deliveryId,
+              __deliveryAttempt: replyTarget.deliveryAttempt,
             }
           : undefined;
         await sink.onInteraction({
@@ -557,10 +631,25 @@ export class IntelligenceAdapter implements PlatformAdapter {
   /** Allocate the next monotonic frame/op seq for a turn. Shared by the run
    * renderer and discrete post/update so all of a turn's render frames land on
    * one ordered `(turnId, "main")` lane. Reset per delivery in {@link dispatch}. */
-  private nextFrameSeq(turnId: string): number {
-    const state = this.renderState.get(turnId);
+  private renderStateKey(target: ChannelReplyTarget): string {
+    return target.deliveryAttempt
+      ? deliveryAttemptKey(target.deliveryAttempt)
+      : `legacy:${target.deliveryId}:${target.turnId}`;
+  }
+
+  private nextFrameSeq(target: ChannelReplyTarget): number {
+    const stateKey = this.renderStateKey(target);
+    const state = this.renderState.get(stateKey);
     if (!state) {
-      this.renderState.set(turnId, { nextSeq: 1, needsFinalize: false });
+      if (
+        target.deliveryAttempt &&
+        isDeliveryAttemptExpired(target.deliveryAttempt, Date.now())
+      ) {
+        throw new Error(
+          `IntelligenceAdapter: delivery attempt expired for ${target.deliveryId}`,
+        );
+      }
+      this.renderState.set(stateKey, { nextSeq: 1, needsFinalize: false });
       return 0;
     }
     const seq = state.nextSeq;
@@ -574,10 +663,10 @@ export class IntelligenceAdapter implements PlatformAdapter {
    * the turn back to non-terminal so dispatch emits one final finalize.
    */
   private recordAcceptedRenderEvent(
-    turnId: string,
+    target: ChannelReplyTarget,
     event: ChannelRenderEvent,
   ): void {
-    const state = this.renderState.get(turnId);
+    const state = this.renderState.get(this.renderStateKey(target));
     if (!state) return;
     state.needsFinalize = event.kind !== "finalize";
   }
@@ -590,15 +679,18 @@ export class IntelligenceAdapter implements PlatformAdapter {
     target: ChannelReplyTarget,
     event: ChannelRenderEvent,
   ): Promise<{ receipt: RenderAccepted; seq: number }> {
-    const seq = this.nextFrameSeq(target.turnId);
+    const seq = this.nextFrameSeq(target);
     const receipt = await this.requireRenderSink().push({
       deliveryId: target.deliveryId,
+      ...(target.deliveryAttempt
+        ? { deliveryAttempt: target.deliveryAttempt }
+        : {}),
       turnId: target.turnId,
       slot: "main",
       seq,
       event,
     });
-    this.recordAcceptedRenderEvent(target.turnId, event);
+    this.recordAcceptedRenderEvent(target, event);
     return { receipt, seq };
   }
 
@@ -610,23 +702,27 @@ export class IntelligenceAdapter implements PlatformAdapter {
   private async finalizeRenderedTurn(
     env: ChannelIngressEnvelope,
   ): Promise<void> {
-    if (!this.renderState.get(env.turnId)?.needsFinalize) return;
-    await this.pushRenderFrame(
-      {
-        route: env.route,
-        turnId: env.turnId,
-        deliveryId: env.deliveryId,
-      },
-      { kind: "finalize" },
-    );
+    const target: ChannelReplyTarget = {
+      route: env.route,
+      turnId: env.turnId,
+      deliveryId: env.deliveryId,
+      ...(env.deliveryAttempt ? { deliveryAttempt: env.deliveryAttempt } : {}),
+    };
+    if (!this.renderState.get(this.renderStateKey(target))?.needsFinalize) {
+      return;
+    }
+    await this.pushRenderFrame(target, { kind: "finalize" });
   }
 
   private mintOp(target: ChannelReplyTarget, op: EgressOp): EgressOperation {
-    const seq = this.nextFrameSeq(target.turnId);
+    const seq = this.nextFrameSeq(target);
     return {
       operationId: `${target.turnId}:${seq}`,
       turnId: target.turnId,
       deliveryId: target.deliveryId,
+      ...(target.deliveryAttempt
+        ? { deliveryAttempt: target.deliveryAttempt }
+        : {}),
       route: target.route,
       op,
     };
@@ -648,6 +744,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
       __route: target.route,
       __turnId: target.turnId,
       __deliveryId: target.deliveryId,
+      __deliveryAttempt: target.deliveryAttempt,
     };
   }
 
@@ -674,6 +771,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
       __route: target.route,
       __turnId: target.turnId,
       __deliveryId: target.deliveryId,
+      __deliveryAttempt: target.deliveryAttempt,
     };
   }
 
@@ -764,6 +862,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
         __route: target.route,
         __turnId: target.turnId,
         __deliveryId: target.deliveryId,
+        __deliveryAttempt: target.deliveryAttempt,
       };
     }
     if (this.renderSink) {
@@ -905,16 +1004,17 @@ export class IntelligenceAdapter implements PlatformAdapter {
     const enqueue = (event: ChannelRenderEvent): void => {
       const frame: RenderFrame = {
         deliveryId: t.deliveryId,
+        ...(t.deliveryAttempt ? { deliveryAttempt: t.deliveryAttempt } : {}),
         turnId: t.turnId,
         slot: "main",
-        seq: this.nextFrameSeq(t.turnId),
+        seq: this.nextFrameSeq(t),
         event,
       };
       chain = chain.then(async () => {
         if (pushError !== undefined) return;
         try {
           await sink.push(frame);
-          this.recordAcceptedRenderEvent(t.turnId, event);
+          this.recordAcceptedRenderEvent(t, event);
         } catch (err) {
           pushError = err;
         }

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.test.ts
@@ -52,7 +52,9 @@ function deliverText(handlers: Map<string, (p: unknown) => void>) {
     payload: {
       delivery: {
         id: "dlv_1",
+        attempt: 1,
         leaseToken: "lease_1",
+        leaseExpiresAt: "2099-07-01T00:02:30.000Z",
         adapter: "slack",
         channel: { id: "channel_1", name: "opentag" },
         turn: {

--- a/packages/channels-intelligence/src/realtime-gateway-transport.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-transport.ts
@@ -420,6 +420,17 @@ export class RealtimeGatewayTransport
       });
       return undefined;
     }
+    if (state.terminal !== undefined && operation === "render") {
+      this.log?.(
+        "realtime gateway render: terminal attempt cannot emit more output",
+        {
+          deliveryId,
+          attemptCount: state.attempt.attemptCount,
+          terminalKind: state.terminal.kind,
+        },
+      );
+      return undefined;
+    }
     return state;
   }
 

--- a/packages/channels-intelligence/src/realtime-gateway-transport.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-transport.ts
@@ -34,8 +34,25 @@ import type {
 } from "./contracts.js";
 import type { RealtimeGatewaySession } from "./realtime-gateway.js";
 import { mapDeliveryToEnvelope } from "./claim-mapping.js";
-import type { ClaimedDelivery } from "./claim-mapping.js";
+import type {
+  ClaimedChannelIngressEnvelope,
+  ClaimedDelivery,
+} from "./claim-mapping.js";
 import { IntelligenceFileHistoryClient } from "./intelligence-file-history.js";
+import {
+  deliveryAttemptKey,
+  effectiveDeliveryTimeoutMs,
+  isDeliveryAttemptExpired,
+  isRetryableDeliveryError,
+  isStrictlyNewerDeliveryAttempt,
+  runAttemptTerminalIntent,
+  scheduleDeliveryAttemptExpiry,
+} from "./delivery-attempt.js";
+import type {
+  AttemptTerminalState,
+  DeliveryAttemptInput,
+  DeliveryAttemptRef,
+} from "./delivery-attempt.js";
 
 /** The org/project/channel scope every realtime envelope carries. */
 export interface ChannelRealtimeScope extends ChannelDeliveryScope {}
@@ -187,7 +204,9 @@ const COMPLETE_REQUESTED = "channel.delivery.complete_requested.v1";
 const DELIVERY_FAIL = "channel.delivery.fail.v1";
 
 /** Per-delivery state the transport needs to build completion/fail intents. */
-interface DeliveryState {
+interface DeliveryState extends AttemptTerminalState {
+  attempt: DeliveryAttemptRef;
+  cancelExpiry?: () => void;
   turnId: string;
   /** app-api's per-delivery lease token, fences the complete/fail intent. */
   leaseToken: string;
@@ -234,7 +253,10 @@ export class RealtimeGatewayTransport
   private readonly now: () => string;
   private readonly log?: (message: string, meta?: unknown) => void;
   private readonly deliveryTimeoutMs: number;
+  /** Exact-attempt state; never indexed directly by delivery id. */
   private readonly deliveries = new Map<string, DeliveryState>();
+  /** Current-attempt index for legacy string callers. */
+  private readonly activeAttempts = new Map<string, string>();
   private onDelivery?: (env: ChannelIngressEnvelope) => Promise<void>;
   /** Tail of the serial delivery-processing chain — see {@link start}. */
   private processing: Promise<void> = Promise.resolve();
@@ -293,6 +315,114 @@ export class RealtimeGatewayTransport
     }
   }
 
+  private nowMs(): number {
+    const parsed = Date.parse(this.now());
+    return Number.isFinite(parsed) ? parsed : Date.now();
+  }
+
+  private registerDelivery(state: DeliveryState): boolean {
+    const key = deliveryAttemptKey(state.attempt);
+    if (this.deliveries.has(key)) {
+      this.log?.("realtime gateway duplicate delivery attempt ignored", {
+        deliveryId: state.attempt.deliveryId,
+        attemptCount: state.attempt.attemptCount,
+      });
+      return false;
+    }
+    const previousKey = this.activeAttempts.get(state.attempt.deliveryId);
+    if (previousKey) {
+      const previous = this.deliveries.get(previousKey);
+      if (previous) {
+        if (!isStrictlyNewerDeliveryAttempt(state.attempt, previous.attempt)) {
+          this.log?.(
+            "realtime gateway stale/conflicting delivery attempt ignored",
+            {
+              deliveryId: state.attempt.deliveryId,
+              incomingAttemptCount: state.attempt.attemptCount,
+              activeAttemptCount: previous.attempt.attemptCount,
+            },
+          );
+          return false;
+        }
+        this.cleanupDelivery(previous);
+        this.log?.("realtime gateway delivery attempt superseded", {
+          deliveryId: state.attempt.deliveryId,
+          previousAttemptKey: previousKey,
+          activeAttemptKey: key,
+        });
+      }
+    }
+    this.deliveries.set(key, state);
+    this.activeAttempts.set(state.attempt.deliveryId, key);
+    state.cancelExpiry = scheduleDeliveryAttemptExpiry(
+      state.attempt,
+      () => this.nowMs(),
+      () => {
+        if (this.deliveries.get(key) !== state) return;
+        this.cleanupDelivery(state);
+        this.log?.("realtime gateway delivery attempt expired", {
+          deliveryId: state.attempt.deliveryId,
+          attemptCount: state.attempt.attemptCount,
+        });
+      },
+    );
+    return true;
+  }
+
+  private cleanupDelivery(state: DeliveryState): void {
+    state.cancelExpiry?.();
+    delete state.cancelExpiry;
+    const key = deliveryAttemptKey(state.attempt);
+    const ownsAttempt = this.deliveries.get(key) === state;
+    if (ownsAttempt) this.deliveries.delete(key);
+    if (
+      ownsAttempt &&
+      this.activeAttempts.get(state.attempt.deliveryId) === key
+    ) {
+      this.activeAttempts.delete(state.attempt.deliveryId);
+    }
+  }
+
+  private resolveDelivery(
+    input: DeliveryAttemptInput,
+    operation: string,
+  ): DeliveryState | undefined {
+    const deliveryId = typeof input === "string" ? input : input.deliveryId;
+    const activeKey = this.activeAttempts.get(deliveryId);
+    const requestedKey =
+      typeof input === "string" ? activeKey : deliveryAttemptKey(input);
+    if (!activeKey) {
+      this.log?.(`realtime gateway ${operation}: no delivery state`, {
+        deliveryId,
+      });
+      return undefined;
+    }
+    if (requestedKey !== activeKey) {
+      this.log?.(`realtime gateway ${operation}: stale attempt ignored`, {
+        deliveryId,
+        requestedAttemptKey: requestedKey,
+        activeAttemptKey: activeKey,
+      });
+      return undefined;
+    }
+    const state = this.deliveries.get(requestedKey);
+    if (!state) {
+      this.log?.(`realtime gateway ${operation}: no delivery state`, {
+        deliveryId,
+      });
+      return undefined;
+    }
+    if (isDeliveryAttemptExpired(state.attempt, this.nowMs())) {
+      this.cleanupDelivery(state);
+      this.log?.(`realtime gateway ${operation}: expired attempt ignored`, {
+        deliveryId,
+        attemptCount: state.attempt.attemptCount,
+      });
+      return undefined;
+    }
+    return state;
+  }
+
   async start(
     onDelivery: (env: ChannelIngressEnvelope) => Promise<void>,
   ): Promise<void> {
@@ -330,7 +460,7 @@ export class RealtimeGatewayTransport
     if (this.stopped) return;
     let claimed:
       | {
-          env: ChannelIngressEnvelope;
+          env: ClaimedChannelIngressEnvelope;
           scope: ChannelDeliveryScope;
           leaseToken: string;
         }
@@ -339,29 +469,30 @@ export class RealtimeGatewayTransport
       claimed = this.toIngressEnvelope(payload);
     } catch (err) {
       if (err instanceof PoisonDeliveryError) {
-        // Unmappable delivery with a valid lease: register minimal state and
-        // fail it NON-retryably so app-api dead-letters it instead of re-leasing
-        // the identical poison payload forever (parity with the HTTP path).
-        this.deliveries.set(err.deliveryId, {
-          turnId: err.turnId,
-          leaseToken: err.leaseToken,
-          scope: err.scope,
-          accepted: new Map(),
-        });
+        // The lease itself is valid, but an invalid attempt identity must not
+        // be fabricated just to enter the normal attempt registry. Send the
+        // non-retryable poison failure directly with the claim's real lease.
         this.log?.(
           "realtime gateway delivery unmappable; failing non-retryable (dead-letter)",
           { deliveryId: err.deliveryId, error: err.message },
         );
-        await this.nack(err.deliveryId, err.message, false).catch(
-          (nackErr: unknown) =>
-            this.log?.(
-              "realtime gateway nack after unmappable delivery failed",
-              {
-                deliveryId: err.deliveryId,
-                error:
-                  nackErr instanceof Error ? nackErr.message : String(nackErr),
-              },
-            ),
+        await this.sendFailureIntent(
+          this.buildFailureIntent(
+            {
+              deliveryId: err.deliveryId,
+              turnId: err.turnId,
+              leaseToken: err.leaseToken,
+              scope: err.scope,
+              accepted: new Map(),
+            },
+            err.message,
+            false,
+          ),
+        ).catch((nackErr: unknown) =>
+          this.log?.("realtime gateway nack after unmappable delivery failed", {
+            deliveryId: err.deliveryId,
+            error: nackErr instanceof Error ? nackErr.message : String(nackErr),
+          }),
         );
         return;
       }
@@ -369,21 +500,45 @@ export class RealtimeGatewayTransport
     }
     if (!claimed) return;
     const { env, scope, leaseToken } = claimed;
-    this.deliveries.set(env.deliveryId, {
+    const registered = this.registerDelivery({
+      attempt: env.deliveryAttempt,
       turnId: env.turnId,
       leaseToken,
       scope,
       accepted: new Map(),
     });
+    if (!registered) return;
     // Bound the turn (parity with the HTTP runLoop): a handler that throws or
     // hangs past deliveryTimeoutMs must not wedge the delivery or leave the
     // render stream half-open. On failure, nack so app-api releases the lease
     // and redelivers rather than the turn silently pinning the delivery.
+    const timeoutMs = effectiveDeliveryTimeoutMs(
+      this.deliveryTimeoutMs,
+      env.deliveryAttempt,
+      this.nowMs(),
+    );
+    if (timeoutMs <= 0) {
+      const reason =
+        `realtime gateway turn ${env.turnId} cannot start inside the ` +
+        "delivery lease safety margin";
+      this.log?.("realtime gateway turn skipped near lease expiry", {
+        deliveryId: env.deliveryId,
+        attemptCount: env.deliveryAttempt.attemptCount,
+        leaseExpiresAt: env.deliveryAttempt.leaseExpiresAt,
+      });
+      await this.nack(env.deliveryAttempt, reason).catch((nackErr: unknown) =>
+        this.log?.("realtime gateway nack after lease-margin skip failed", {
+          deliveryId: env.deliveryId,
+          error: nackErr instanceof Error ? nackErr.message : String(nackErr),
+        }),
+      );
+      return;
+    }
     try {
       await withDeliveryTimeout(
         Promise.resolve(this.onDelivery?.(env)),
-        this.deliveryTimeoutMs,
-        `realtime gateway turn ${env.turnId} exceeded ${this.deliveryTimeoutMs}ms`,
+        timeoutMs,
+        `realtime gateway turn ${env.turnId} exceeded ${timeoutMs}ms`,
       );
     } catch (err) {
       this.log?.("realtime gateway turn failed/timed out; nacking", {
@@ -391,8 +546,9 @@ export class RealtimeGatewayTransport
         error: err instanceof Error ? err.message : String(err),
       });
       await this.nack(
-        env.deliveryId,
+        env.deliveryAttempt,
         err instanceof Error ? err.message : String(err),
+        isRetryableDeliveryError(err),
       ).catch((nackErr: unknown) =>
         this.log?.("realtime gateway nack after turn failure failed", {
           deliveryId: env.deliveryId,
@@ -419,7 +575,7 @@ export class RealtimeGatewayTransport
    */
   private toIngressEnvelope(payload: unknown):
     | {
-        env: ChannelIngressEnvelope;
+        env: ClaimedChannelIngressEnvelope;
         scope: ChannelDeliveryScope;
         leaseToken: string;
       }
@@ -496,11 +652,13 @@ export class RealtimeGatewayTransport
     try {
       const claimed: ClaimedDelivery = {
         id: String(delivery.id),
+        attempt: delivery.attempt as number,
         organizationId: organizationId ?? "",
         projectId: scope.projectId,
         channel: { id: channelId ?? "", name: scope.channelName },
         adapter: String(delivery.adapter ?? "slack"),
         leaseToken,
+        leaseExpiresAt: delivery.leaseExpiresAt as string,
         turn: delivery.turn as ClaimedDelivery["turn"],
       };
       return { scope, leaseToken, env: mapDeliveryToEnvelope(claimed) };
@@ -521,7 +679,15 @@ export class RealtimeGatewayTransport
   }
 
   async push(frame: RenderFrame): Promise<RenderAccepted> {
-    const state = this.deliveries.get(frame.deliveryId);
+    const state = this.resolveDelivery(
+      frame.deliveryAttempt ?? frame.deliveryId,
+      "render",
+    );
+    if (frame.deliveryAttempt && !state) {
+      throw new Error(
+        `RealtimeGatewayTransport: stale delivery attempt cannot render for ${frame.deliveryId}`,
+      );
+    }
     const idempotencyKey = `${frame.turnId}:${frame.slot}:${frame.seq}`;
     const envelope = {
       type: RENDER_EVENT,
@@ -588,19 +754,12 @@ export class RealtimeGatewayTransport
    * delivery ack. `acceptedThrough` carries the completion high-water pointer
    * per slot (the frozen contract requires at least one).
    */
-  async ack(deliveryId: string): Promise<void> {
-    const state = this.deliveries.get(deliveryId);
+  async ack(attempt: DeliveryAttemptInput): Promise<void> {
+    const state = this.resolveDelivery(attempt, "ack");
     if (!state) return;
-    // Claim the terminal signal BEFORE the wire call, mirroring the HTTP
-    // transport's delete-before-POST. A turn that times out (handleDeliveryAvailable
-    // nacks) while its dispatch keeps running in the background will call ack()
-    // here; deleting first guarantees whichever of ack/nack runs first wins and
-    // the loser no-ops on missing state — exactly one of complete_requested XOR
-    // fail reaches app-api for a given delivery.
     const acceptedThrough = Array.from(state.accepted.entries()).map(
       ([slot, seq]) => ({ turnId: state.turnId, slot, seq }),
     );
-    this.deliveries.delete(deliveryId);
     if (acceptedThrough.length === 0) {
       // Nothing was accepted (e.g. an empty turn). Without an accepted frame
       // there is nothing to complete; let the lease lapse / redeliver instead
@@ -614,25 +773,34 @@ export class RealtimeGatewayTransport
       // in this transport logs).
       this.log?.(
         "realtime gateway ack: empty turn (no accepted frames) — no completion sent; will redeliver until max_attempts (OSS-491)",
-        { deliveryId },
+        { deliveryId: state.attempt.deliveryId },
       );
       return;
     }
-    await this.session.push(COMPLETE_REQUESTED, {
+    const intent = {
       type: COMPLETE_REQUESTED,
       occurredAt: this.now(),
       payload: {
         ...state.scope,
-        deliveryId,
+        deliveryId: state.attempt.deliveryId,
         turnId: state.turnId,
         runtimeInstanceId: this.runtimeInstanceId,
-        // Fence the completion intent on the lease token (OSS-446), matching
-        // the fail path; app-api fences when present, falls back otherwise.
+        // The attempt ref remains SDK-internal: app-api derives the attempt
+        // atomically from this fenced lease token.
         leaseToken: state.leaseToken,
         acceptedThrough,
         requestedAt: this.now(),
       },
-    });
+    };
+    await runAttemptTerminalIntent(
+      state,
+      "complete",
+      async () => {
+        await this.session.push(COMPLETE_REQUESTED, intent);
+      },
+      () => this.cleanupDelivery(state),
+      this.log,
+    );
   }
 
   /**
@@ -646,21 +814,41 @@ export class RealtimeGatewayTransport
    * the retryable path so it never contradicts a non-retryable fail.
    */
   async nack(
-    deliveryId: string,
+    attempt: DeliveryAttemptInput,
     reason: string,
     retryable = true,
   ): Promise<void> {
-    const state = this.deliveries.get(deliveryId);
+    const state = this.resolveDelivery(attempt, "nack");
     if (!state) {
-      // No state → no leaseToken to build a fenced fail intent, so nothing can
-      // be sent; app-api releases the delivery on lease lapse. Reachable only
-      // for an already-terminal/evicted delivery today; log rather than drop
-      // silently so an unexpected hit is diagnosable.
-      this.log?.("realtime gateway nack: no delivery state; dropping fail", {
-        deliveryId,
-        reason,
-      });
       return;
+    }
+    const intent = this.buildFailureIntent(state, reason, retryable);
+    await runAttemptTerminalIntent(
+      state,
+      "fail",
+      () => this.sendFailureIntent(intent),
+      () => this.cleanupDelivery(state),
+      this.log,
+    );
+  }
+
+  private buildFailureIntent(
+    state: {
+      turnId: string;
+      leaseToken: string;
+      scope: ChannelDeliveryScope;
+      accepted: Map<string, number>;
+      deliveryId?: string;
+      attempt?: DeliveryAttemptRef;
+    },
+    reason: string,
+    retryable: boolean,
+  ): unknown {
+    const deliveryId = state.attempt?.deliveryId ?? state.deliveryId;
+    if (!deliveryId) {
+      throw new Error(
+        "RealtimeGatewayTransport: failure intent has no delivery id",
+      );
     }
     const accepted = Array.from(state.accepted.entries()).map(
       ([slot, seq]) => ({
@@ -670,9 +858,7 @@ export class RealtimeGatewayTransport
       }),
     );
     const lastAccepted = accepted[accepted.length - 1];
-    // Claim the terminal signal BEFORE the wire call (XOR with ack) — see ack().
-    this.deliveries.delete(deliveryId);
-    await this.session.push(DELIVERY_FAIL, {
+    return {
       type: DELIVERY_FAIL,
       occurredAt: this.now(),
       payload: {
@@ -692,7 +878,11 @@ export class RealtimeGatewayTransport
           retryable,
         },
       },
-    });
+    };
+  }
+
+  private async sendFailureIntent(intent: unknown): Promise<void> {
+    await this.session.push(DELIVERY_FAIL, intent);
   }
 
   async stop(): Promise<void> {
@@ -703,6 +893,8 @@ export class RealtimeGatewayTransport
     // redelivers. Mirrors HttpDeliverySource.stop() (running=false + await loop).
     this.stopped = true;
     await this.processing.catch(() => {});
+    for (const state of this.deliveries.values()) state.cancelExpiry?.();
     this.deliveries.clear();
+    this.activeAttempts.clear();
   }
 }

--- a/packages/channels-intelligence/src/realtime-gateway.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.test.ts
@@ -9,6 +9,9 @@ import type { RealtimeGatewayConnectionState } from "./realtime-gateway.js";
 
 type JoinMode =
   | "ok"
+  | "ok-push-error"
+  | "ok-push-validation-error"
+  | "ok-push-scope-error"
   | "error"
   | "never"
   | "error-undefined-reason"
@@ -129,7 +132,39 @@ function makeFakeWebSocket(mode: JoinMode) {
         string,
         string,
       ];
-      if (event !== "phx_join") return;
+      if (event !== "phx_join") {
+        if (
+          mode === "ok-push-error" ||
+          mode === "ok-push-validation-error" ||
+          mode === "ok-push-scope-error"
+        ) {
+          const response =
+            mode === "ok-push-validation-error"
+              ? { reason: "invalid_render_event" }
+              : mode === "ok-push-scope-error"
+                ? { reason: "organization_scope_mismatch" }
+                : {
+                    reason: "app_api_error",
+                    status: 409,
+                    code: "CHANNEL_RENDER_FRAME_CONFLICT",
+                  };
+          queueMicrotask(() =>
+            this.onmessage?.({
+              data: JSON.stringify([
+                joinRef,
+                ref,
+                topic,
+                "phx_reply",
+                {
+                  status: "error",
+                  response,
+                },
+              ]),
+            }),
+          );
+        }
+        return;
+      }
       this.lastJoinRef = joinRef;
       this.lastTopic = topic;
       joinCount += 1;
@@ -145,6 +180,9 @@ function makeFakeWebSocket(mode: JoinMode) {
       }
       const isOkMode =
         mode === "ok" ||
+        mode === "ok-push-error" ||
+        mode === "ok-push-validation-error" ||
+        mode === "ok-push-scope-error" ||
         mode === "ok-then-silent" ||
         mode === "give-up-then-recover";
       const status = isOkMode ? "ok" : "error";
@@ -268,6 +306,77 @@ describe("connectRealtimeGateway", () => {
 
     session.disconnect();
     expect(instances[0]!.closed).toBe(true);
+  });
+
+  it("preserves structured server error metadata on a failed push", async () => {
+    const { FakeWebSocket } = makeFakeWebSocket("ok-push-error");
+    const session = await connectRealtimeGateway({
+      wsUrl: "wss://gateway.example/runner",
+      apiKey: "cpk-test",
+      projectId: 7,
+      join: {
+        runtimeInstanceId: "rti_1",
+        declaredChannels: [{ channelName: "opentag", adapter: "slack" }],
+        observedAt: "2026-07-10T00:00:00.000Z",
+      },
+      webSocket: FakeWebSocket,
+    });
+
+    await expect(
+      session.push("channel.render_event.v1", {}),
+    ).rejects.toMatchObject({
+      code: "CHANNEL_RENDER_FRAME_CONFLICT",
+      message: expect.stringContaining("CHANNEL_RENDER_FRAME_CONFLICT"),
+      retryable: false,
+      status: 409,
+    });
+    session.disconnect();
+  });
+
+  it("classifies a deterministic gateway validation rejection as non-retryable", async () => {
+    const { FakeWebSocket } = makeFakeWebSocket("ok-push-validation-error");
+    const session = await connectRealtimeGateway({
+      wsUrl: "wss://gateway.example/runner",
+      apiKey: "cpk-test",
+      projectId: 7,
+      join: {
+        runtimeInstanceId: "rti_1",
+        declaredChannels: [{ channelName: "opentag", adapter: "slack" }],
+        observedAt: "2026-07-10T00:00:00.000Z",
+      },
+      webSocket: FakeWebSocket,
+    });
+
+    await expect(
+      session.push("channel.render_event.v1", {}),
+    ).rejects.toMatchObject({
+      reason: "invalid_render_event",
+      retryable: false,
+    });
+    session.disconnect();
+  });
+
+  it("classifies an organization scope mismatch as non-retryable", async () => {
+    const { FakeWebSocket } = makeFakeWebSocket("ok-push-scope-error");
+    const session = await connectRealtimeGateway({
+      wsUrl: "wss://gateway.example/runner",
+      apiKey: "cpk-test",
+      projectId: 7,
+      join: {
+        runtimeInstanceId: "rti_1",
+        declaredChannels: [{ channelName: "opentag", adapter: "slack" }],
+        observedAt: "2026-07-10T00:00:00.000Z",
+      },
+      webSocket: FakeWebSocket,
+    });
+
+    await expect(
+      session.push("channel.render_event.v1", {}),
+    ).rejects.toMatchObject({
+      reason: "organization_scope_mismatch",
+      retryable: false,
+    });
+    session.disconnect();
   });
 });
 

--- a/packages/channels-intelligence/src/realtime-gateway.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.ts
@@ -1,4 +1,5 @@
 import { Socket } from "phoenix";
+import { channelTransportError } from "./delivery-attempt.js";
 
 /**
  * Minimal Realtime Gateway session surface used by the delivery/render
@@ -822,8 +823,9 @@ export async function connectRealtimeGateway(
           .receive("ok", (reply: unknown) => resolve(reply))
           .receive("error", (reason: unknown) =>
             reject(
-              new Error(
-                `realtime gateway session push ${event} failed: ${safeReason(reason)}`,
+              channelTransportError(
+                `realtime gateway session push ${event} failed`,
+                reason,
               ),
             ),
           )

--- a/packages/channels-intelligence/src/render-events.test.ts
+++ b/packages/channels-intelligence/src/render-events.test.ts
@@ -662,6 +662,23 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     await expect(t.nack(attempt, "first reason", false)).rejects.toThrow(
       /response lost/,
     );
+    // Selecting a terminal intent freezes the attempt's accepted-through
+    // boundary immediately. Even though the terminal response was lost and the
+    // same payload remains retryable, no later frame may extend that boundary.
+    await expect(
+      t.push({
+        deliveryId: attempt.deliveryId,
+        deliveryAttempt: attempt,
+        turnId: "turn_replayed",
+        slot: "main",
+        seq: 0,
+        event: { kind: "run_started" },
+      }),
+    ).rejects.toThrow(/stale delivery attempt/);
+    expect(
+      fake.pushes.filter((push) => push.event === "channel.render_event.v1"),
+    ).toHaveLength(0);
+
     now = "2026-07-01T00:01:00.000Z";
     fake.handlers.get("channel.delivery.available.v1")?.(available);
     await vi.waitFor(() =>

--- a/packages/channels-intelligence/src/render-events.test.ts
+++ b/packages/channels-intelligence/src/render-events.test.ts
@@ -13,11 +13,23 @@ import {
 import type { RealtimeGatewaySession } from "./realtime-gateway.js";
 import type { ChannelIngressEnvelope } from "./contracts.js";
 
+const targetAttempt = {
+  deliveryId: "dlv_d1",
+  attemptCount: 1,
+  leaseExpiresAt: "2099-07-01T00:02:30.000Z",
+};
+
 const target = {
   route: { channel: "C1", threadTs: "100.0" },
   turnId: "turn_t1",
   deliveryId: "dlv_d1",
+  deliveryAttempt: targetAttempt,
 } as unknown as ReplyTarget;
+
+const validWireAttempt = {
+  attempt: 1,
+  leaseExpiresAt: "2026-07-01T00:02:30.000Z",
+};
 
 /** Drive a subscriber handler that may be sync or async. */
 type Sub = Record<string, (p: { event: Record<string, unknown> }) => unknown>;
@@ -64,6 +76,9 @@ describe("run renderer — render-event streaming (OSS-402)", () => {
     expect(renderSink.frames.map((f) => f.seq)).toEqual([0, 1, 2, 3, 4, 5, 6]);
     expect(renderSink.frames.every((f) => f.slot === "main")).toBe(true);
     expect(renderSink.frames.every((f) => f.turnId === "turn_t1")).toBe(true);
+    expect(
+      renderSink.frames.every((f) => f.deliveryAttempt === targetAttempt),
+    ).toBe(true);
   });
 
   it("markInterrupted emits an interrupt frame then a finalize", async () => {
@@ -229,6 +244,7 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     fake.handlers.get("channel.delivery.available.v1")?.({
       payload: {
         delivery: {
+          ...validWireAttempt,
           id: "dlv_d1",
           leaseToken: "lease_l1",
           adapter: "slack",
@@ -307,6 +323,7 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     fake.handlers.get("channel.delivery.available.v1")?.({
       payload: {
         delivery: {
+          ...validWireAttempt,
           id: "dlv_d1",
           leaseToken: "lease_l1",
           adapter: "slack",
@@ -363,6 +380,7 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     fake.handlers.get("channel.delivery.available.v1")?.({
       payload: {
         delivery: {
+          ...validWireAttempt,
           id: "dlv_d1",
           leaseToken: "lease_l1",
           adapter: "slack",
@@ -406,6 +424,7 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     fake.handlers.get("channel.delivery.available.v1")?.({
       payload: {
         delivery: {
+          ...validWireAttempt,
           id: "dlv_d1",
           leaseToken: "lease_l1",
           adapter: "slack",
@@ -445,6 +464,7 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     fake.handlers.get("channel.delivery.available.v1")?.({
       payload: {
         delivery: {
+          ...validWireAttempt,
           id: "dlv_d1",
           leaseToken: "lease_l1",
           adapter: "slack",
@@ -469,6 +489,41 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     expect(logs.some((m) => m.includes("turn failed/timed out"))).toBe(true);
   });
 
+  it("caps the handler deadline at lease expiry minus the safety margin", async () => {
+    const fake = makeFakeSession();
+    const t = new RealtimeGatewayTransport({
+      ...cfg(fake.session),
+      deliveryTimeoutMs: 60_000,
+    });
+    await t.start(() => new Promise<void>(() => {}));
+    fake.handlers.get("channel.delivery.available.v1")?.({
+      payload: {
+        delivery: {
+          attempt: 1,
+          leaseExpiresAt: "2026-07-01T00:00:10.010Z",
+          id: "dlv_deadline",
+          leaseToken: "lease_deadline",
+          adapter: "slack",
+          channel: { id: "channel_1", name: "support" },
+          turn: {
+            id: "turn_deadline",
+            eventId: "evt_deadline",
+            replyTarget: { adapter: "slack", teamId: "T1", channel: "C1" },
+            input: { kind: "text", text: "hi" },
+          },
+        },
+      },
+    });
+
+    await vi.waitFor(
+      () =>
+        expect(fake.pushes.map((p) => p.event)).toContain(
+          "channel.delivery.fail.v1",
+        ),
+      { timeout: 1_000 },
+    );
+  });
+
   it("fails an UNMAPPABLE (poison) delivery non-retryable instead of dropping it into a re-lease loop", async () => {
     const fake = makeFakeSession();
     const logs: string[] = [];
@@ -486,6 +541,7 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     fake.handlers.get("channel.delivery.available.v1")?.({
       payload: {
         delivery: {
+          ...validWireAttempt,
           id: "dlv_poison",
           leaseToken: "lease_l1",
           adapter: "slack",
@@ -516,7 +572,7 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     expect(fail.payload.leaseToken).toBe("lease_l1");
   });
 
-  it("sends exactly one terminal signal per delivery (delete-before-push): a late ack after nack no-ops", async () => {
+  it("sends exactly one terminal signal per attempt: a late ack after nack no-ops", async () => {
     const fake = makeFakeSession();
     const t = new RealtimeGatewayTransport(cfg(fake.session));
     let delivered = false;
@@ -526,6 +582,7 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     fake.handlers.get("channel.delivery.available.v1")?.({
       payload: {
         delivery: {
+          ...validWireAttempt,
           id: "dlv_d1",
           leaseToken: "lease_l1",
           adapter: "slack",
@@ -542,8 +599,8 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     await vi.waitFor(() => expect(delivered).toBe(true));
 
     // Simulate the timeout race: the per-turn timeout nacks while the still-
-    // running dispatch later acks. delete-before-push guarantees the first wins
-    // and the second no-ops — exactly one terminal signal reaches app-api.
+    // running dispatch later acks. The attempt terminal state guarantees the
+    // first kind wins and the second no-ops.
     await t.nack("dlv_d1", "timed out", true);
     await t.ack("dlv_d1"); // late ack — state already gone, must send nothing
 
@@ -555,6 +612,233 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
           e === "channel.delivery.complete_requested.v1",
       );
     expect(terminals).toEqual(["channel.delivery.fail.v1"]);
+  });
+
+  it("preserves terminal state and the first payload across an exact-attempt replay", async () => {
+    const fake = makeFakeSession();
+    let failPushes = 0;
+    const session: RealtimeGatewaySession = {
+      on: fake.session.on,
+      push: async (event, payload) => {
+        const reply = await fake.session.push(event, payload);
+        if (event === "channel.delivery.fail.v1" && failPushes++ === 0) {
+          throw new Error("response lost after accept");
+        }
+        return reply;
+      },
+    };
+    let now = "2026-07-01T00:00:00.000Z";
+    const logs: string[] = [];
+    const attempts: ChannelIngressEnvelope[] = [];
+    const t = new RealtimeGatewayTransport({
+      ...cfg(session),
+      now: () => now,
+      log: (message) => logs.push(message),
+    });
+    await t.start(async (env) => {
+      attempts.push(env);
+    });
+    const available = {
+      payload: {
+        delivery: {
+          ...validWireAttempt,
+          id: "dlv_replayed",
+          leaseToken: "lease_replayed",
+          adapter: "slack",
+          channel: { id: "channel_1", name: "support" },
+          turn: {
+            id: "turn_replayed",
+            eventId: "evt_replayed",
+            replyTarget: { adapter: "slack", teamId: "T1", channel: "C1" },
+            input: { kind: "text", text: "hi" },
+          },
+        },
+      },
+    };
+    fake.handlers.get("channel.delivery.available.v1")?.(available);
+    await vi.waitFor(() => expect(attempts).toHaveLength(1));
+    const attempt = attempts[0]!.deliveryAttempt!;
+
+    await expect(t.nack(attempt, "first reason", false)).rejects.toThrow(
+      /response lost/,
+    );
+    now = "2026-07-01T00:01:00.000Z";
+    fake.handlers.get("channel.delivery.available.v1")?.(available);
+    await vi.waitFor(() =>
+      expect(
+        logs.some((message) => message.includes("duplicate delivery attempt")),
+      ).toBe(true),
+    );
+    expect(attempts).toHaveLength(1);
+
+    await expect(
+      t.nack(attempt, "different retry reason", true),
+    ).resolves.toBeUndefined();
+
+    const failures = fake.pushes.filter(
+      (push) => push.event === "channel.delivery.fail.v1",
+    );
+    expect(failures).toHaveLength(2);
+    expect(JSON.stringify(failures[1]!.payload)).toBe(
+      JSON.stringify(failures[0]!.payload),
+    );
+  });
+
+  it("does not let attempt 1 settle with attempt 2's lease token", async () => {
+    const fake = makeFakeSession();
+    const logs: string[] = [];
+    const t = new RealtimeGatewayTransport({
+      ...cfg(fake.session),
+      log: (message) => logs.push(message),
+    });
+    const attempts: ChannelIngressEnvelope[] = [];
+    await t.start(async (env) => {
+      attempts.push(env);
+    });
+    const fire = (attempt: number, leaseToken: string) =>
+      fake.handlers.get("channel.delivery.available.v1")?.({
+        payload: {
+          delivery: {
+            id: "dlv_same",
+            attempt,
+            leaseExpiresAt: `2026-07-01T00:0${attempt}:30.000Z`,
+            leaseToken,
+            adapter: "slack",
+            channel: { id: "channel_1", name: "support" },
+            turn: {
+              id: "turn_same",
+              eventId: "evt_same",
+              replyTarget: { adapter: "slack", teamId: "T1", channel: "C1" },
+              input: { kind: "text", text: "hi" },
+            },
+          },
+        },
+      });
+    fire(1, "lease_1");
+    fire(2, "lease_2");
+    await vi.waitFor(() => expect(attempts).toHaveLength(2));
+
+    await t.push({
+      deliveryId: "dlv_same",
+      deliveryAttempt: attempts[1]!.deliveryAttempt,
+      turnId: "turn_same",
+      slot: "main",
+      seq: 0,
+      event: { kind: "run_started" },
+    });
+    await t.ack(attempts[0]!.deliveryAttempt!);
+    await t.ack(attempts[1]!.deliveryAttempt!);
+
+    const terminals = fake.pushes.filter(
+      (p) => p.event === "channel.delivery.complete_requested.v1",
+    );
+    expect(terminals).toHaveLength(1);
+    expect(
+      (terminals[0]!.payload as { payload: { leaseToken: string } }).payload
+        .leaseToken,
+    ).toBe("lease_2");
+    expect(logs.some((message) => message.includes("stale attempt"))).toBe(
+      true,
+    );
+  });
+
+  it("ignores late older and same-count changed-expiry gateway deliveries", async () => {
+    const fake = makeFakeSession();
+    const logs: string[] = [];
+    const attempts: ChannelIngressEnvelope[] = [];
+    const t = new RealtimeGatewayTransport({
+      ...cfg(fake.session),
+      log: (message) => logs.push(message),
+    });
+    await t.start(async (env) => {
+      attempts.push(env);
+    });
+    const fire = (
+      attempt: number,
+      leaseToken: string,
+      leaseExpiresAt: string,
+    ) =>
+      fake.handlers.get("channel.delivery.available.v1")?.({
+        payload: {
+          delivery: {
+            id: "dlv_ordered",
+            attempt,
+            leaseExpiresAt,
+            leaseToken,
+            adapter: "slack",
+            channel: { id: "channel_1", name: "support" },
+            turn: {
+              id: "turn_ordered",
+              eventId: "evt_ordered",
+              replyTarget: { adapter: "slack", teamId: "T1", channel: "C1" },
+              input: { kind: "text", text: "hi" },
+            },
+          },
+        },
+      });
+    fire(2, "lease_2", "2026-07-01T00:02:30.000Z");
+    fire(1, "lease_1_late", "2026-07-01T00:01:30.000Z");
+    fire(2, "lease_2_changed", "2026-07-01T00:02:00.000Z");
+
+    await vi.waitFor(() => expect(attempts).toHaveLength(1));
+    await vi.waitFor(() =>
+      expect(
+        logs.filter((message) => message.includes("attempt ignored")),
+      ).toHaveLength(2),
+    );
+    const active = attempts[0]!.deliveryAttempt!;
+    await t.push({
+      deliveryId: active.deliveryId,
+      deliveryAttempt: active,
+      turnId: "turn_ordered",
+      slot: "main",
+      seq: 0,
+      event: { kind: "run_started" },
+    });
+    await t.ack(active);
+
+    const terminal = fake.pushes.find(
+      (push) => push.event === "channel.delivery.complete_requested.v1",
+    )!.payload as { payload: { leaseToken: string } };
+    expect(terminal.payload.leaseToken).toBe("lease_2");
+  });
+
+  it("rejects invalid attempt identity as a non-retryable poison delivery", async () => {
+    const fake = makeFakeSession();
+    const t = new RealtimeGatewayTransport(cfg(fake.session));
+    let delivered = false;
+    await t.start(async () => {
+      delivered = true;
+    });
+    fake.handlers.get("channel.delivery.available.v1")?.({
+      payload: {
+        delivery: {
+          id: "dlv_invalid_attempt",
+          attempt: 0,
+          leaseExpiresAt: "not-a-date",
+          leaseToken: "lease_invalid_attempt",
+          adapter: "slack",
+          channel: { id: "channel_1", name: "support" },
+          turn: {
+            id: "turn_invalid_attempt",
+            eventId: "evt_invalid_attempt",
+            replyTarget: { adapter: "slack", teamId: "T1", channel: "C1" },
+            input: { kind: "text", text: "hi" },
+          },
+        },
+      },
+    });
+
+    await vi.waitFor(() =>
+      expect(fake.pushes.map((p) => p.event)).toContain(
+        "channel.delivery.fail.v1",
+      ),
+    );
+    expect(delivered).toBe(false);
+    const fail = fake.pushes.find(
+      (p) => p.event === "channel.delivery.fail.v1",
+    )!.payload as { payload: { error: { retryable: boolean } } };
+    expect(fail.payload.error.retryable).toBe(false);
   });
 
   it("processes deliveries serially — a second delivery waits for the first to finish", async () => {
@@ -574,6 +858,7 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
       fake.handlers.get("channel.delivery.available.v1")?.({
         payload: {
           delivery: {
+            ...validWireAttempt,
             id,
             leaseToken: "l",
             adapter: "slack",
@@ -617,6 +902,7 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
       fake.handlers.get("channel.delivery.available.v1")?.({
         payload: {
           delivery: {
+            ...validWireAttempt,
             id,
             leaseToken: `lease_${id}`,
             adapter: "slack",
@@ -664,6 +950,7 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     fake.handlers.get("channel.delivery.available.v1")?.({
       payload: {
         delivery: {
+          ...validWireAttempt,
           id: "dlv_d1",
           // no leaseToken → the SDK can't build a fenced complete/fail intent
           adapter: "slack",
@@ -707,6 +994,7 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     fake.handlers.get("channel.delivery.available.v1")?.({
       payload: {
         delivery: {
+          ...validWireAttempt,
           id: "dlv_d1",
           leaseToken: "lease_l1",
           organizationId: "org_OTHER",
@@ -760,6 +1048,7 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     fake.handlers.get("channel.delivery.available.v1")?.({
       payload: {
         delivery: {
+          ...validWireAttempt,
           id: "dlv_d1",
           leaseToken: "lease_l1",
           adapter: "slack",

--- a/packages/channels-intelligence/src/runtime.test.ts
+++ b/packages/channels-intelligence/src/runtime.test.ts
@@ -156,6 +156,11 @@ describe("startChannels", () => {
 
     await sources.get("support")!.deliver({
       deliveryId: "d1",
+      deliveryAttempt: {
+        deliveryId: "d1",
+        attemptCount: 1,
+        leaseExpiresAt: "2099-07-01T00:02:30.000Z",
+      },
       eventId: "e1",
       turnId: "t1",
       channelName: "support",
@@ -193,6 +198,11 @@ describe("startChannels", () => {
 
     await source.deliver({
       deliveryId: "d1",
+      deliveryAttempt: {
+        deliveryId: "d1",
+        attemptCount: 1,
+        leaseExpiresAt: "2099-07-01T00:02:30.000Z",
+      },
       eventId: "e1",
       turnId: "t1",
       channelName: "support",

--- a/packages/channels-intelligence/src/transports.ts
+++ b/packages/channels-intelligence/src/transports.ts
@@ -7,6 +7,7 @@ import type {
   RenderFrame,
   RenderAccepted,
 } from "./contracts.js";
+import type { DeliveryAttemptInput } from "./delivery-attempt.js";
 
 /**
  * A conversation-history message the adapter seeds onto a fresh agent's
@@ -36,9 +37,13 @@ export interface DeliverySource {
     onDelivery: (env: ChannelIngressEnvelope) => Promise<void>,
   ): Promise<void>;
   /** Acknowledge successful processing of a delivery (lease release). */
-  ack(deliveryId: string): Promise<void>;
+  ack(attempt: DeliveryAttemptInput): Promise<void>;
   /** Negatively acknowledge — the work will be redelivered (at-least-once). */
-  nack(deliveryId: string, reason: string): Promise<void>;
+  nack(
+    attempt: DeliveryAttemptInput,
+    reason: string,
+    retryable?: boolean,
+  ): Promise<void>;
   /**
    * Fetch an inbound file's bytes by handle (Channel multimodal content).
    * Optional: sources without a file-serve backing omit it and the adapter


### PR DESCRIPTION
## Problem

Channel delivery state was keyed only by delivery ID, so terminal requests could outlive or cross lease attempts. A lost completion response also left the SDK without a safe, byte-equivalent retry, while failed completion handling risked turning a successful run into a nack and rerun.

[OSS-631](https://linear.app/copilotkit/issue/OSS-631/investigate-runtime-crash-while-using-channels-sdk)

## Why

At-least-once delivery can lease the same delivery more than once. Late render, ack, or fail work from an older attempt must never borrow the current lease token or race an opposite terminal intent. Once a turn has succeeded, completion failure also cannot become a nack because that would rerun the agent and duplicate side effects.

## Fix

- Thread exact delivery-attempt identity through claim mapping, adapter render state, HTTP delivery, and realtime gateway state.
- Fence stale or expired attempts, cap handler deadlines inside the lease safety margin, and centralize first-terminal-wins coordination.
- Freeze the first terminal payload so a retryable completion can retry once byte-for-byte; preserve OSS-491 behavior by logging any final completion failure without nacking a successful turn.
- Add regression coverage for stale attempts, terminal races, retry payload stability, lease expiry, and HTTP/realtime parity.

Validated with scoped formatting; repository lint; package typecheck, build, tests, publint, and ATTW; and the full uncached package test and build graphs.
