### PR TITLE
chore: format repository documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ https://github.com/user-attachments/assets/72b7b4f3-b6e7-460c-a932-5746fe3c8db3
 
 One agent backend. Every frontend.
 
-| Platform                                    | Status       | Get Started                                                                                                 |
-| ------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------- |
-| ⚛️ React / Next.js                          | ✅ GA        | [Quickstart](https://docs.copilotkit.ai/built-in-agent/quickstart)                                          |
-| 🅰️ Angular                                  | ✅ Supported | [Source Code & Quickstart](https://github.com/CopilotKit/CopilotKit/tree/main/packages/angular) |
-| 💚 Vue                                      | ✅ Supported | [Source Code - Quickstart coming soon](https://github.com/CopilotKit/CopilotKit/tree/main/packages/vue)     |
-| 📱 React Native                             | ✅ Supported | [Quickstart](https://docs.copilotkit.ai/react-native)                                                       |
-| 💬 Slack / MS Teams / Discord / Google Chat | 🟡 Beta      | [Request early access](https://go.copilotkit.ai/beyond-the-web-form)                                        |
+| Platform                                    | Status       | Get Started                                                                                             |
+| ------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------- |
+| ⚛️ React / Next.js                          | ✅ GA        | [Quickstart](https://docs.copilotkit.ai/built-in-agent/quickstart)                                      |
+| 🅰️ Angular                                  | ✅ Supported | [Source Code & Quickstart](https://github.com/CopilotKit/CopilotKit/tree/main/packages/angular)         |
+| 💚 Vue                                      | ✅ Supported | [Source Code - Quickstart coming soon](https://github.com/CopilotKit/CopilotKit/tree/main/packages/vue) |
+| 📱 React Native                             | ✅ Supported | [Quickstart](https://docs.copilotkit.ai/react-native)                                                   |
+| 💬 Slack / MS Teams / Discord / Google Chat | 🟡 Beta      | [Request early access](https://go.copilotkit.ai/beyond-the-web-form)                                    |
 
 Your agent logic stays the same — AG-UI handles the wire protocol, CopilotKit handles the UI layer for each framework.
 

--- a/examples/integrations/adk-angular/README.md
+++ b/examples/integrations/adk-angular/README.md
@@ -6,11 +6,11 @@ This is a starter template for building AI agents using Google's [ADK](https://g
 
 Three processes run behind a single `npm run dev` (via `concurrently`):
 
-| Process | Port | What it is |
-| --- | --- | --- |
-| `ui` | `4200` | The Angular app (`ng serve`) |
+| Process   | Port   | What it is                                                                    |
+| --------- | ------ | ----------------------------------------------------------------------------- |
+| `ui`      | `4200` | The Angular app (`ng serve`)                                                  |
 | `runtime` | `8200` | The standalone Copilot Runtime (`tsx server.ts`), served at `/api/copilotkit` |
-| `agent` | `8000` | The Python ADK agent (`uv`) |
+| `agent`   | `8000` | The Python ADK agent (`uv`)                                                   |
 
 The Angular app talks to the runtime (`http://localhost:8200/api/copilotkit`), and the runtime proxies the ADK agent (`AGENT_URL`, default `http://localhost:8000/`).
 

--- a/showcase/integrations/claude-sdk-python/docs/setup/agent-config-setup.mdx
+++ b/showcase/integrations/claude-sdk-python/docs/setup/agent-config-setup.mdx
@@ -7,5 +7,6 @@
     lets users tune model behavior without rebuilding the backend.
 
     <DemoCode file="src/agents/agent_config_agent.py" region="agent-config-setup" />
+
   </Step>
 </Steps>

--- a/showcase/integrations/claude-sdk-python/docs/setup/agent-context-setup.mdx
+++ b/showcase/integrations/claude-sdk-python/docs/setup/agent-context-setup.mdx
@@ -7,5 +7,6 @@
     answer with the current UI state in mind.
 
     <DemoCode file="src/agents/agent.py" region="agent-context-setup" />
+
   </Step>
 </Steps>

--- a/showcase/integrations/claude-sdk-python/docs/setup/agent-setup.mdx
+++ b/showcase/integrations/claude-sdk-python/docs/setup/agent-setup.mdx
@@ -5,6 +5,7 @@
     ```bash
     uv add claude-agent-sdk ag-ui-claude-sdk ag-ui-protocol anthropic fastapi uvicorn python-dotenv
     ```
+
   </Step>
 
   <Step>
@@ -15,5 +16,6 @@
     backend tools through an in-process Claude SDK MCP server.
 
     <DemoCode file="src/agents/claude_agent_sdk_adapter.py" region="claude-agent-sdk-agent-setup" />
+
   </Step>
 </Steps>

--- a/showcase/integrations/claude-sdk-python/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/claude-sdk-python/docs/setup/frontend-tools-setup.mdx
@@ -12,5 +12,6 @@
       region="frontend-tools-setup"
       highlight="23-29"
     />
+
   </Step>
 </Steps>

--- a/showcase/integrations/claude-sdk-python/docs/setup/human-in-the-loop-setup.mdx
+++ b/showcase/integrations/claude-sdk-python/docs/setup/human-in-the-loop-setup.mdx
@@ -8,5 +8,6 @@
     that result. Register the approval UI from the page component.
 
     <DemoCode file="src/app/demos/hitl-in-chat/page.tsx" region="hitl-frontend-tool" title="page.tsx - useHumanInTheLoop" />
+
   </Step>
 </Steps>

--- a/showcase/integrations/claude-sdk-python/docs/setup/programmatic-control-setup.mdx
+++ b/showcase/integrations/claude-sdk-python/docs/setup/programmatic-control-setup.mdx
@@ -8,5 +8,6 @@
     message to the agent and dispatch the run.
 
     <DemoCode file="src/app/demos/headless-simple/chat.tsx" region="use-agent-simple" title="chat.tsx - useAgent run control" />
+
   </Step>
 </Steps>

--- a/showcase/integrations/claude-sdk-python/docs/setup/shared-state-setup.mdx
+++ b/showcase/integrations/claude-sdk-python/docs/setup/shared-state-setup.mdx
@@ -7,5 +7,6 @@
     typed, and mirrored by the UI components that read the same values.
 
     <DemoCode file="src/agents/shared_state_read_write_agent.py" region="shared-state-setup" />
+
   </Step>
 </Steps>

--- a/showcase/integrations/claude-sdk-python/docs/setup/state-streaming-setup.mdx
+++ b/showcase/integrations/claude-sdk-python/docs/setup/state-streaming-setup.mdx
@@ -7,5 +7,6 @@
     branch runs inside the streamed tool-argument handler.
 
     <DemoCode file="src/agents/agent.py" region="state-streaming-delta-emission" />
+
   </Step>
 </Steps>

--- a/showcase/integrations/claude-sdk-python/docs/setup/subagents-setup.mdx
+++ b/showcase/integrations/claude-sdk-python/docs/setup/subagents-setup.mdx
@@ -8,5 +8,6 @@
     one tool schema per specialist.
 
     <DemoCode file="src/agents/subagents_agent.py" region="supervisor-delegation-tools" title="subagents_agent.py - supervisor tool schemas" />
+
   </Step>
 </Steps>

--- a/showcase/integrations/claude-sdk-typescript/docs/setup/agent-config-setup.mdx
+++ b/showcase/integrations/claude-sdk-typescript/docs/setup/agent-config-setup.mdx
@@ -7,5 +7,6 @@
     lets users tune model behavior without rebuilding the backend.
 
     <DemoCode file="src/agent/agent-config-prompt.ts" region="agent-config-setup" />
+
   </Step>
 </Steps>

--- a/showcase/integrations/claude-sdk-typescript/docs/setup/agent-context-setup.mdx
+++ b/showcase/integrations/claude-sdk-typescript/docs/setup/agent-context-setup.mdx
@@ -7,5 +7,6 @@
     answer with the current UI state in mind.
 
     <DemoCode file="src/agent_server.ts" region="agent-context-setup" />
+
   </Step>
 </Steps>

--- a/showcase/integrations/claude-sdk-typescript/docs/setup/agent-setup.mdx
+++ b/showcase/integrations/claude-sdk-typescript/docs/setup/agent-setup.mdx
@@ -5,6 +5,7 @@
     ```bash
     npm install @ag-ui/core @ag-ui/encoder @ag-ui/claude-agent-sdk @anthropic-ai/claude-agent-sdk@^0.2.58 @anthropic-ai/sdk zod
     ```
+
   </Step>
 
   <Step>
@@ -15,5 +16,6 @@
     expose backend tools through an in-process Claude SDK MCP server.
 
     <DemoCode file="src/claude-agent-sdk-adapter.ts" region="claude-agent-sdk-agent-setup" />
+
   </Step>
 </Steps>

--- a/showcase/integrations/claude-sdk-typescript/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/claude-sdk-typescript/docs/setup/frontend-tools-setup.mdx
@@ -12,5 +12,6 @@
       region="frontend-tools-setup"
       highlight="28-32"
     />
+
   </Step>
 </Steps>

--- a/showcase/integrations/claude-sdk-typescript/docs/setup/human-in-the-loop-setup.mdx
+++ b/showcase/integrations/claude-sdk-typescript/docs/setup/human-in-the-loop-setup.mdx
@@ -8,5 +8,6 @@
     that result. Register the approval UI from the page component.
 
     <DemoCode file="src/app/demos/hitl-in-chat/page.tsx" region="hitl-frontend-tool" title="page.tsx - useHumanInTheLoop" />
+
   </Step>
 </Steps>

--- a/showcase/integrations/claude-sdk-typescript/docs/setup/programmatic-control-setup.mdx
+++ b/showcase/integrations/claude-sdk-typescript/docs/setup/programmatic-control-setup.mdx
@@ -8,5 +8,6 @@
     message to the agent and dispatch the run.
 
     <DemoCode file="src/app/demos/headless-simple/chat.tsx" region="use-agent-simple" title="chat.tsx - useAgent run control" />
+
   </Step>
 </Steps>

--- a/showcase/integrations/claude-sdk-typescript/docs/setup/shared-state-setup.mdx
+++ b/showcase/integrations/claude-sdk-typescript/docs/setup/shared-state-setup.mdx
@@ -7,5 +7,6 @@
     typed, and mirrored by the UI components that read the same values.
 
     <DemoCode file="src/agent/shared-state-read-write-prompt.ts" region="shared-state-setup" />
+
   </Step>
 </Steps>

--- a/showcase/integrations/claude-sdk-typescript/docs/setup/state-streaming-setup.mdx
+++ b/showcase/integrations/claude-sdk-typescript/docs/setup/state-streaming-setup.mdx
@@ -7,5 +7,6 @@
     branch runs inside the streamed tool-argument handler.
 
     <DemoCode file="src/agent_server.ts" region="state-streaming-delta-emission" />
+
   </Step>
 </Steps>

--- a/showcase/integrations/claude-sdk-typescript/docs/setup/subagents-setup.mdx
+++ b/showcase/integrations/claude-sdk-typescript/docs/setup/subagents-setup.mdx
@@ -8,5 +8,6 @@
     one tool schema per specialist.
 
     <DemoCode file="src/agent/subagents-prompts.ts" region="supervisor-delegation-tools" title="subagents-prompts.ts - supervisor tool schemas" />
+
   </Step>
 </Steps>


### PR DESCRIPTION
## Summary

Apply the repository formatter to the 20 documentation files that fail on current `main`.

## Why

Restore the global format gate so unrelated changes, including the Slack streaming fix, can be pushed and reviewed.

## How

Run `oxfmt` only on the files named by `pnpm run check-format`; this PR has no content or behavior changes.