### PR TITLE
fix(channels-slack): remove duplicate thinking posts

### DIFF
--- a/packages/channels-slack/src/__tests__/chunked-message-stream.test.ts
+++ b/packages/channels-slack/src/__tests__/chunked-message-stream.test.ts
@@ -26,7 +26,7 @@ const longString = (n: number) =>
   "lorem ipsum ".repeat(Math.ceil(n / 12)).slice(0, n);
 
 describe("ChunkedMessageStream", () => {
-  it("stays as a single message when buffer fits in one chunk", async () => {
+  it("seeds a single message with its buffered response", async () => {
     const slack = makeFakeSlack();
     const s = new ChunkedMessageStream({
       ...slack,
@@ -36,7 +36,7 @@ describe("ChunkedMessageStream", () => {
     s.append("short reply");
     await s.finish();
     expect(slack.posts).toHaveLength(1);
-    expect(slack.posts[0]!.text).toBe("_thinking…_");
+    expect(slack.posts[0]!.text).toBe("short reply");
     expect(slack.updates.at(-1)?.text).toBe("short reply");
   });
 
@@ -50,8 +50,10 @@ describe("ChunkedMessageStream", () => {
     s.append(longString(200));
     await s.finish();
     expect(slack.posts.length).toBeGreaterThanOrEqual(4);
-    // First placeholder = thinking, rest = continued
-    expect(slack.posts[0]!.text).toBe("_thinking…_");
+    // The first message is seeded with its actual response; only later chunks
+    // use the continuation placeholder.
+    const firstChunk = slack.updates.find((update) => update.ts === "1.0");
+    expect(slack.posts[0]!.text).toBe(firstChunk?.text);
     expect(slack.posts[1]!.text).toBe("_…(continued)_");
   });
 
@@ -131,6 +133,7 @@ describe("ChunkedMessageStream", () => {
     });
     s.append("hello world");
     await s.finish();
+    expect(slack.posts[0]?.text).toBe("HELLO WORLD");
     expect(slack.updates.at(-1)?.text).toBe("HELLO WORLD");
   });
 
@@ -210,9 +213,9 @@ describe("ChunkedMessageStream", () => {
     expect(slack.posts.length).toBeGreaterThan(1); // multiple messages
     // The text of each subsequent message (after applying our manual mrkdwn-free transform here)
     // is checked via slack.updates. Examine the SECOND chunk's last text:
-    const lastForSecondTs = [...slack.updates]
-      .reverse()
-      .find((u) => u.ts === "2.0");
+    const lastForSecondTs = slack.updates
+      .filter((update) => update.ts === "2.0")
+      .at(-1);
     expect(lastForSecondTs?.text.startsWith("```python\n")).toBe(true);
   });
 
@@ -227,7 +230,7 @@ describe("ChunkedMessageStream", () => {
     s.append(fullText);
     await s.finish();
     expect(slack.posts.length).toBeGreaterThan(1);
-    const second = [...slack.updates].reverse().find((u) => u.ts === "2.0");
+    const second = slack.updates.filter((update) => update.ts === "2.0").at(-1);
     expect(second?.text.startsWith("```\n")).toBe(true);
   });
 

--- a/packages/channels-slack/src/__tests__/event-renderer.test.ts
+++ b/packages/channels-slack/src/__tests__/event-renderer.test.ts
@@ -55,6 +55,15 @@ describe("createRunRenderer", () => {
       event: { messageId: id, delta: "E" },
       textMessageBuffer: "",
     } as never);
+
+    await vi.waitFor(() => {
+      expect(fake.posts).toHaveLength(1);
+      expect(fake.posts[0]?.text).toBe("E");
+      expect(fake.posts.every((post) => post.text !== "_thinking…_")).toBe(
+        true,
+      );
+    });
+
     sub.onTextMessageContentEvent!({
       event: { messageId: id, delta: "CHO" },
       textMessageBuffer: "E",
@@ -64,8 +73,6 @@ describe("createRunRenderer", () => {
     // (a) The first post contains the buffered response, then updates track
     // the fully accumulated text.
     expect(fake.posts).toHaveLength(1);
-    expect(fake.posts[0]?.text).toBe("ECHO");
-    expect(fake.posts.every((post) => post.text !== "_thinking…_")).toBe(true);
     expect(fake.updates.length).toBeGreaterThan(0);
     expect(fake.updates.at(-1)?.text).toBe("ECHO");
   });

--- a/packages/channels-slack/src/__tests__/event-renderer.test.ts
+++ b/packages/channels-slack/src/__tests__/event-renderer.test.ts
@@ -61,10 +61,11 @@ describe("createRunRenderer", () => {
     } as never);
     await sub.onTextMessageEndEvent!({ event: { messageId: id } } as never);
 
-    // (a) Text streaming posts a placeholder then updates it; the LAST
-    // update must be the fully-accumulated text.
+    // (a) The first post contains the buffered response, then updates track
+    // the fully accumulated text.
     expect(fake.posts).toHaveLength(1);
-    expect(fake.posts[0]?.text).toBe("_thinking…_");
+    expect(fake.posts[0]?.text).toBe("ECHO");
+    expect(fake.posts.every((post) => post.text !== "_thinking…_")).toBe(true);
     expect(fake.updates.length).toBeGreaterThan(0);
     expect(fake.updates.at(-1)?.text).toBe("ECHO");
   });
@@ -287,6 +288,10 @@ describe("createRunRenderer", () => {
       textMessageBuffer: "",
     } as never);
     await sub.onTextMessageEndEvent!({ event: { messageId: "m1" } } as never);
+    const initial = fake.posts[0]?.text ?? "";
+    expect(initial).toContain("*hi*");
+    expect(initial).toContain("<https://x.com|docs>");
+    expect(initial).toContain("•  a");
     const last = fake.updates.at(-1)?.text ?? "";
     expect(last).toContain("*hi*");
     expect(last).toContain("<https://x.com|docs>");

--- a/packages/channels-slack/src/__tests__/native-renderer.test.ts
+++ b/packages/channels-slack/src/__tests__/native-renderer.test.ts
@@ -13,14 +13,18 @@ function makeFakeClient() {
     ts: string;
   }[] = [];
   const updates: { channel: string; ts: string; text: string }[] = [];
+  const events: string[] = [];
   let counter = 0;
   const transport: SlackRenderTransport = {
-    setStatus: vi.fn(async () => {}),
+    setStatus: vi.fn(async (args: { status: string }) => {
+      events.push(`status:${args.status}`);
+    }),
     postMessage: vi.fn(
       async (args: { channel: string; thread_ts?: string; text: string }) => {
         counter++;
         const ts = `${counter}.000`;
         posts.push({ ...args, ts });
+        events.push(`post:${args.text}`);
         return { ts };
       },
     ),
@@ -30,7 +34,7 @@ function makeFakeClient() {
       },
     ),
   };
-  return { transport, posts, updates };
+  return { transport, posts, updates, events };
 }
 
 type Event =
@@ -38,7 +42,10 @@ type Event =
   | { kind: "chunks"; value: AnyChunk[] };
 
 /** Fake native streaming transport recording every streamed message's lifecycle. */
-function makeFakeNativeTransport(opts?: { failChunks?: boolean }) {
+function makeFakeNativeTransport(opts?: {
+  failChunks?: boolean;
+  failStart?: boolean;
+}) {
   const messages: {
     ts: string;
     events: Event[];
@@ -48,6 +55,7 @@ function makeFakeNativeTransport(opts?: { failChunks?: boolean }) {
   let counter = 0;
   const transport: NativeStreamTransport = {
     startStream: vi.fn(async () => {
+      if (opts?.failStart) throw new Error("startStream unavailable");
       counter++;
       const ts = `S${counter}`;
       messages.push({ ts, events: [], stopped: false });
@@ -247,6 +255,32 @@ describe("createRunRenderer — native streaming", () => {
     await finish!();
 
     expect(fake.posts.some((p) => p.text.includes(":wrench:"))).toBe(true);
+  });
+
+  it("posts transformed fallback text and clears status after native start failure", async () => {
+    const fake = makeFakeClient();
+    const nt = makeFakeNativeTransport({ failStart: true });
+    const { subscriber: sub, finish } = createRunRenderer({
+      transport: fake.transport,
+      target: { channel: "C1", threadTs: "100.0" },
+      status: { threadTs: "100.0", isPane: false, config: {} },
+      nativeStreaming: { transport: nt.transport },
+    });
+
+    await sub.onRunStartedEvent!({} as never);
+    sub.onTextMessageContentEvent!({
+      event: { messageId: "m1", delta: "**fallback**" },
+    } as never);
+    await finish!();
+
+    expect(nt.transport.startStream).toHaveBeenCalledTimes(1);
+    expect(fake.posts).toHaveLength(1);
+    expect(fake.posts[0]?.text).toBe("*fallback*");
+    expect(fake.posts.every((post) => post.text !== "_thinking…_")).toBe(true);
+    expect(fake.updates.at(-1)?.text).toBe("*fallback*");
+    expect(fake.events.indexOf("post:*fallback*")).toBeLessThan(
+      fake.events.indexOf("status:"),
+    );
   });
 
   it("does NOT attach the feedback row to an interrupted partial reply", async () => {

--- a/packages/channels-slack/src/chunked-message-stream.ts
+++ b/packages/channels-slack/src/chunked-message-stream.ts
@@ -37,13 +37,18 @@ export interface ChunkedMessageStreamConfig {
   limit?: number;
   /** Throttle floor for each underlying stream's chat.update. */
   minIntervalMs?: number;
-  /** Posts a new Slack message with placeholder text; resolves with its `ts`. */
+  /**
+   * Posts a new Slack message. The first chunk is seeded with its transformed
+   * buffered response text; later chunks use the continuation placeholder.
+   * Resolves with the message's `ts`.
+   */
   postPlaceholder: (text: string) => Promise<string>;
   /** Updates the Slack message at `ts` with `text`. */
   updateAt: (ts: string, text: string) => Promise<void>;
   /**
-   * Optional transformer for the text *just before* it hits chat.update —
-   * e.g. markdown→mrkdwn translation. Applied per-chunk.
+   * Optional transformer for text just before it hits Slack — e.g.
+   * markdown→mrkdwn translation. Applied per chunk to the first post and
+   * every chat.update.
    */
   transform?: (text: string) => string;
 }
@@ -147,8 +152,11 @@ export class ChunkedMessageStream {
     const chunkCount = this.boundaries.length + 1;
     while (this.streams.length < chunkCount) {
       const i = this.streams.length;
-      const placeholder = i === 0 ? "_thinking…_" : "_…(continued)_";
-      const ts = await this.postPlaceholder(placeholder);
+      const initialText =
+        i === 0
+          ? this.transform(this.buffer.slice(0, this.boundaries[0])) || " "
+          : "_…(continued)_";
+      const ts = await this.postPlaceholder(initialText);
       this.streams.push(
         new MessageStream({
           update: (text) => this.updateAt(ts, this.transform(text) || " "),


### PR DESCRIPTION
## Problem

Slack legacy fallback posted `_thinking…_` before replacing it with the reply, so native status and response content appeared as duplicate thinking UI.

## Why

When `chat.startStream` falls back, the first legacy post should contain available response text, not a second thinking indicator.

## Fix

Seed the first legacy Slack post with transformed response content and retain continuation placeholders for later chunks. Add direct-legacy and native-start-failure regressions, including status clearing.

Refs OSS-635. Global formatting currently awaits [#6210](https://github.com/CopilotKit/CopilotKit/pull/6210).