### PR TITLE
Add Teams-native Adaptive Cards for Channels

### DIFF
--- a/packages/channels-core/src/action-registry.test.ts
+++ b/packages/channels-core/src/action-registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { ActionRegistry, ActionExpiredError } from "./action-registry.js";
 import { InMemoryActionStore } from "./action-store.js";
+import type { ActionSnapshot, ActionStore } from "./action-store.js";
 import { MemoryStore } from "./state/memory-store.js";
 import { kvActionStore } from "./state/kv-action-store.js";
 import type { ChannelNode, InteractionContext } from "@copilotkit/channels-ui";
@@ -165,5 +166,32 @@ describe("ActionRegistry", () => {
         ActionExpiredError,
       );
     });
+  });
+
+  it("runs preflight before writing any action snapshot", async () => {
+    const writes: string[] = [];
+    const store: ActionStore = {
+      async put(id: string, _snap: ActionSnapshot): Promise<void> {
+        writes.push(id);
+      },
+      async get(): Promise<ActionSnapshot | undefined> {
+        return undefined;
+      },
+      async delete(): Promise<void> {},
+    };
+    const reg = new ActionRegistry({ store });
+    const tree: ChannelNode = {
+      type: "button",
+      props: { onClick: () => undefined },
+    };
+
+    await expect(
+      reg.bindRenderable(tree, "conv", {
+        preflight: () => {
+          throw new Error("unsupported UI");
+        },
+      }),
+    ).rejects.toThrow("unsupported UI");
+    expect(writes).toEqual([]);
   });
 });

--- a/packages/channels-core/src/action-registry.ts
+++ b/packages/channels-core/src/action-registry.ts
@@ -19,6 +19,14 @@ export class ActionExpiredError extends Error {
 
 const EVENT_PROPS = ["onClick", "onSelect", "onSubmit"] as const;
 
+export interface BindRenderableOptions {
+  /**
+   * Runs after JSX expansion and before any action record is written. This is
+   * the boundary where an adapter rejects a UI tree it cannot render.
+   */
+  preflight?: (root: ChannelNode[]) => void | Promise<void>;
+}
+
 function isComponentElement(
   ui: unknown,
 ): ui is { type: ComponentFn; props: Record<string, unknown> } {
@@ -111,9 +119,11 @@ export class ActionRegistry {
     componentName: string,
     props: Record<string, unknown>,
     conversationKey: string,
+    options?: BindRenderableOptions,
   ): Promise<ChannelNode[]> {
     const fn = this.components.get(componentName);
     const root = renderToIR((fn ? fn(props) : props) as Renderable);
+    await options?.preflight?.(root);
     await this.walk(root, [], componentName, props, conversationKey);
     return root;
   }
@@ -128,6 +138,7 @@ export class ActionRegistry {
   async bindRenderable(
     ui: Renderable,
     conversationKey: string,
+    options?: BindRenderableOptions,
   ): Promise<{
     root: ChannelNode[];
     onReaction?: MessageReactionHandler;
@@ -146,9 +157,10 @@ export class ActionRegistry {
       component = fn.name || "anonymous";
       props = (ui.props ?? {}) as Record<string, unknown>;
       this.registerComponent(component, fn);
-      root = await this.bindTree(component, props, conversationKey);
+      root = await this.bindTree(component, props, conversationKey, options);
     } else {
       root = renderToIR(ui);
+      await options?.preflight?.(root);
       await this.walk(root, [], "", undefined, conversationKey);
     }
     const onReaction = takeMessageReaction(root);

--- a/packages/channels-core/src/create-channel.test.ts
+++ b/packages/channels-core/src/create-channel.test.ts
@@ -5,7 +5,13 @@ import { defineChannelCommand } from "./commands.js";
 import { FakeAdapter } from "./testing/fake-adapter.js";
 import { FakeAgent } from "./testing/fake-agent.js";
 import { MemoryStore } from "./state/memory-store.js";
-import { Section, Actions, Button } from "@copilotkit/channels-ui";
+import {
+  Section,
+  Actions,
+  Button,
+  platformNode,
+  PlatformUiMismatchError,
+} from "@copilotkit/channels-ui";
 import type { ChannelNode } from "@copilotkit/channels-ui";
 import type { PlatformAdapter } from "./platform-adapter.js";
 
@@ -85,6 +91,106 @@ describe("createChannel", () => {
     const ir = fake.posted[0]!;
     expect(findNode(ir, "section")).toBeDefined();
     expect(collectText(ir)).toBe("hi");
+  });
+
+  it("uses the managed delivery platform for thread and message context", async () => {
+    const fake = new FakeAdapter({ platform: "intelligence" });
+    const channel = createChannel({ adapters: [fake] });
+    let platform = "";
+    let messagePlatform = "";
+    channel.onMention(({ thread, message }) => {
+      platform = thread.platform;
+      messagePlatform = message.platform;
+    });
+
+    await channel.ɵruntime.start();
+    await fake.getSink().onTurn({
+      conversationKey: "c1",
+      replyTarget: {},
+      userText: "hello",
+      platform: "teams",
+    });
+
+    expect(platform).toBe("teams");
+    expect(messagePlatform).toBe("teams");
+  });
+
+  it("uses the managed interaction platform and preserves submitted values", async () => {
+    const fake = new FakeAdapter({ platform: "intelligence" });
+    const channel = createChannel({ adapters: [fake] });
+    let received:
+      | {
+          threadPlatform: string;
+          messagePlatform: string;
+          platform: string;
+          values: Record<string, unknown>;
+        }
+      | undefined;
+    channel.onInteraction("deploy", ({ thread, message, platform, values }) => {
+      received = {
+        threadPlatform: thread.platform,
+        messagePlatform: message.platform,
+        platform,
+        values,
+      };
+    });
+
+    await channel.ɵruntime.start();
+    await fake.getSink().onInteraction({
+      id: "deploy",
+      conversationKey: "c1",
+      replyTarget: {},
+      platform: "teams",
+      values: { environment: "production", regions: ["us-east", "us-west"] },
+    });
+
+    expect(received).toEqual({
+      threadPlatform: "teams",
+      messagePlatform: "teams",
+      platform: "teams",
+      values: { environment: "production", regions: ["us-east", "us-west"] },
+    });
+  });
+
+  it("rejects native UI before the action registry persists it", async () => {
+    const fake = new FakeAdapter({ platform: "slack" });
+    const writes: string[] = [];
+    const channel = createChannel({
+      adapters: [fake],
+      actionStore: {
+        async put(id) {
+          writes.push(id);
+        },
+        async get() {
+          return undefined;
+        },
+        async delete() {},
+      },
+    });
+    channel.onMention(async ({ thread }) => {
+      await thread.post(
+        platformNode({
+          protocol: 1,
+          platform: "teams",
+          dialect: "adaptive-card",
+          dialectVersion: "1.5",
+          element: "AdaptiveCard",
+          attributes: {},
+          onSubmit: () => undefined,
+        }),
+      );
+    });
+
+    await channel.ɵruntime.start();
+    await expect(
+      fake.getSink().onTurn({
+        conversationKey: "c1",
+        replyTarget: {},
+        userText: "hello",
+        platform: "slack",
+      }),
+    ).rejects.toBeInstanceOf(PlatformUiMismatchError);
+    expect(writes).toEqual([]);
   });
 
   it("calls renderer.finish() once after a turn's run-loop resolves", async () => {

--- a/packages/channels-core/src/create-channel.ts
+++ b/packages/channels-core/src/create-channel.ts
@@ -447,7 +447,11 @@ export function createChannel<
     adapter: PlatformAdapter,
     replyTarget: unknown,
     conversationKey: string,
-    extras?: { userKey?: string; message?: IncomingMessage },
+    extras?: {
+      userKey?: string;
+      message?: IncomingMessage;
+      targetPlatform?: string;
+    },
   ): Thread {
     if (!backend || !registry || !telemetry) {
       throw new Error(
@@ -470,6 +474,7 @@ export function createChannel<
       transcripts,
       userKey: extras?.userKey,
       message: extras?.message,
+      targetPlatform: extras?.targetPlatform,
       telemetry,
     };
     return new Thread(deps);
@@ -559,7 +564,7 @@ export function createChannel<
             adapter,
             turn.replyTarget,
             turn.conversationKey,
-            { userKey, message },
+            { userKey, message, targetPlatform: turn.platform },
           );
           // v1 routing: there is no turn `kind`, so prefer mention handlers; if
           // none are registered, fall back to message handlers. (The reference
@@ -587,10 +592,12 @@ export function createChannel<
           }
         }
 
+        const sourcePlatform = evt.platform ?? adapter.platform;
         const thread = makeThread(
           adapter,
           evt.replyTarget,
           evt.conversationKey,
+          { targetPlatform: sourcePlatform },
         );
         const user = evt.user ?? { id: "" };
         const ctx: InteractionContext = {
@@ -599,12 +606,12 @@ export function createChannel<
             text: "",
             user,
             ref: evt.messageRef ?? { id: "" },
-            platform: adapter.platform,
+            platform: sourcePlatform,
           },
           action: { id: evt.id, value: evt.value },
-          values: {},
+          values: evt.values ?? {},
           user,
-          platform: adapter.platform,
+          platform: sourcePlatform,
         };
         const openModal = makeOpenModal(
           adapter,
@@ -657,6 +664,7 @@ export function createChannel<
           adapter,
           cmd.replyTarget,
           cmd.conversationKey,
+          { targetPlatform: cmd.platform },
         );
         // Resolve typed options from any structured args the surface supplied
         // (e.g. Discord); text-only surfaces (Slack) leave `options` empty and
@@ -690,6 +698,7 @@ export function createChannel<
           adapter,
           evt.replyTarget,
           evt.conversationKey,
+          { targetPlatform: evt.platform },
         );
         for (const h of threadStartedHandlers)
           await h({ thread, user: evt.user });
@@ -710,6 +719,7 @@ export function createChannel<
           adapter,
           evt.replyTarget,
           evt.conversationKey,
+          { targetPlatform: evt.platform ?? adapter.platform },
         );
         // Prefer the adapter's update-capable ref; fall back to the bare id.
         const messageRef: MessageRef = evt.messageRef ?? { id: evt.messageId };

--- a/packages/channels-core/src/platform-adapter.ts
+++ b/packages/channels-core/src/platform-adapter.ts
@@ -107,6 +107,10 @@ export interface IncomingTurn extends IngressEventBase, IngressIds {
 export interface InteractionEvent extends IngressEventBase, IngressIds {
   id: string; // opaque minted action id (ck:...)
   value?: unknown;
+  /** Provider-faithful named input values submitted with the interaction. */
+  values?: Record<string, unknown>;
+  /** Source provider for a managed interaction (for example, "teams"). */
+  platform?: string;
   /** The message the interaction occurred on (the picker), so handlers can update it in place. */
   messageRef?: MessageRef;
   /** Opaque platform trigger for opening a modal (Slack `trigger_id`; Discord interaction id). */

--- a/packages/channels-core/src/thread.ts
+++ b/packages/channels-core/src/thread.ts
@@ -1,5 +1,6 @@
 import type { PlatformAdapter, ReplyTarget } from "./platform-adapter.js";
 import type { ActionRegistry } from "./action-registry.js";
+import { validatePlatformUi } from "@copilotkit/channels-ui";
 import type {
   AgentContentPart,
   Renderable,
@@ -56,6 +57,8 @@ export interface ThreadDeps {
   userKey?: string;
   /** The inbound message that triggered this turn (for transcript bridging). */
   message?: IncomingMessage;
+  /** Source platform for a managed delivery (for example, "teams"). */
+  targetPlatform?: string;
   /**
    * Optional anonymous telemetry sink. Structural type (not the concrete
    * ChannelTelemetry) avoids an import cycle; the real ChannelTelemetry satisfies it.
@@ -75,7 +78,7 @@ export class Thread implements ThreadInterface {
   private readonly store: StateStore;
 
   constructor(private deps: ThreadDeps) {
-    this.platform = deps.adapter.platform;
+    this.platform = deps.targetPlatform ?? deps.adapter.platform;
     this.conversationKey = deps.conversationKey;
     this.supportsBlockingChoice =
       deps.adapter.capabilities.supportsBlockingChoice;
@@ -83,7 +86,9 @@ export class Thread implements ThreadInterface {
   }
 
   private async bindForPost(ui: Renderable) {
-    return this.deps.registry.bindRenderable(ui, this.deps.conversationKey);
+    return this.deps.registry.bindRenderable(ui, this.deps.conversationKey, {
+      preflight: (root) => validatePlatformUi(root, this.platform),
+    });
   }
 
   /**

--- a/packages/channels-intelligence/src/contracts.ts
+++ b/packages/channels-intelligence/src/contracts.ts
@@ -88,6 +88,8 @@ export type ChannelIngressEnvelope =
       /** Minted action id (ck:...) the rendered control carries. */
       actionId: string;
       value?: unknown;
+      /** Provider-faithful named form values submitted with the action. */
+      values?: Record<string, unknown>;
       /** The message the interaction occurred on (so handlers can update it). */
       messageRef?: MessageRef;
       triggerId?: string;

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -532,6 +532,8 @@ export class IntelligenceAdapter implements PlatformAdapter {
           conversationKey: env.conversationKey,
           replyTarget,
           value: env.value,
+          values: env.values,
+          platform: env.platform,
           user,
           eventId: env.eventId,
           turnId: env.turnId,

--- a/packages/channels-teams/package.json
+++ b/packages/channels-teams/package.json
@@ -37,6 +37,14 @@
     "./render": {
       "types": "./dist/render/index.d.ts",
       "import": "./dist/render/index.js"
+    },
+    "./ui": {
+      "types": "./dist/ui.d.ts",
+      "import": "./dist/ui.js"
+    },
+    "./codec": {
+      "types": "./dist/codec.d.ts",
+      "import": "./dist/codec.js"
     }
   },
   "scripts": {
@@ -56,6 +64,7 @@
     "@copilotkit/shared": "workspace:^",
     "@microsoft/agents-activity": "^1.5.3",
     "@microsoft/agents-hosting": "^1.5.3",
+    "@microsoft/teams.cards": "2.0.14",
     "express": "^4.21.2",
     "rxjs": "^7.8.1",
     "zod": "^3.25.76",

--- a/packages/channels-teams/src/adapter.test.ts
+++ b/packages/channels-teams/src/adapter.test.ts
@@ -17,7 +17,14 @@ import { TeamsAdapter } from "./adapter.js";
 function cardClickContext(): TurnContext {
   const activity = {
     type: ActivityTypes.Message,
-    value: { ckActionId: "ck:abc123", value: { confirmed: true } },
+    value: {
+      __copilotkit: {
+        version: 1,
+        actionId: "ck:abc123",
+        value: { confirmed: true },
+      },
+      environment: "production",
+    },
     conversation: { id: "conv-1" },
     from: { id: "user-1", name: "Tester" },
     replyToId: "card-activity-1",
@@ -79,6 +86,8 @@ describe("TeamsAdapter card interactions", () => {
     const evt = sink.onInteraction.mock.calls[0]![0];
     expect(evt.id).toBe("ck:abc123");
     expect(evt.value).toEqual({ confirmed: true });
+    expect(evt.values).toEqual({ environment: "production" });
+    expect(evt.platform).toBe("teams");
     // The reply/edit context must be the proactive one, NOT the (anonymous)
     // inbound click context. That was the 401 bug.
     expect(evt.replyTarget.context).toBe(proactiveCtx);

--- a/packages/channels-teams/src/adapter.ts
+++ b/packages/channels-teams/src/adapter.ts
@@ -32,8 +32,7 @@ import { createTeamsServer } from "./listener.js";
 import type { TeamsServer } from "./listener.js";
 import { conversationKeyOf, parseCardAction } from "./interaction.js";
 import { createRunRenderer } from "./event-renderer.js";
-import { renderTeamsMarkdown } from "./render/markdown.js";
-import { renderAdaptiveCard, isPlainText } from "./render/adaptive-card.js";
+import { teamsCodec } from "./codec.js";
 import type { AdaptiveCard } from "./render/adaptive-card.js";
 import { TeamsMessageStream } from "./message-stream.js";
 import type { TeamsAdapterOptions, TeamsReplyTarget } from "./types.js";
@@ -152,6 +151,8 @@ export class TeamsAdapter implements PlatformAdapter {
             id: action.id,
             conversationKey,
             value: action.value,
+            values: action.values,
+            platform: "teams",
             user,
             replyTarget: {
               conversationKey,
@@ -387,9 +388,7 @@ export class TeamsAdapter implements PlatformAdapter {
    * or interactive UI becomes a card.)
    */
   render(ir: ChannelNode[]): TeamsActivityPayload {
-    return isPlainText(ir)
-      ? { text: renderTeamsMarkdown(ir) }
-      : { card: renderAdaptiveCard(ir) };
+    return teamsCodec.renderEgress(ir) as TeamsActivityPayload;
   }
 
   async post(target: ReplyTarget, ir: ChannelNode[]): Promise<MessageRef> {
@@ -532,6 +531,8 @@ export class TeamsAdapter implements PlatformAdapter {
       id: action.id,
       conversationKey,
       value: action.value,
+      values: action.values,
+      platform: "teams",
       user: from?.id ? { id: from.id, name: from.name } : undefined,
       replyTarget: { conversationKey, reference } satisfies TeamsReplyTarget,
       messageRef: {

--- a/packages/channels-teams/src/button-action-envelope.contract.test.ts
+++ b/packages/channels-teams/src/button-action-envelope.contract.test.ts
@@ -38,19 +38,22 @@ const buttonAction = () => {
 };
 
 describe("HITL button action envelope (contract)", () => {
-  it("emits a <Button> as Action.Submit carrying { ckActionId, value } in `data` — NOT Action.Execute", () => {
+  it("emits a <Button> as Action.Submit carrying reserved metadata in `data` — NOT Action.Execute", () => {
     const action = buttonAction();
 
     expect(action.type).toBe("Action.Submit");
     // It is a Submit, not an Execute: no `verb`, and the payload rides in `data`.
     expect(action).not.toHaveProperty("verb");
     expect(action.data).toEqual({
-      ckActionId: "ck:approve",
-      value: { decision: "yes" },
+      __copilotkit: {
+        version: 1,
+        actionId: "ck:approve",
+        value: { decision: "yes" },
+      },
     });
   });
 
-  it("round-trips: the emitted `data` is exactly Teams' inbound activity.value, decoding to { id, value }", () => {
+  it("round-trips action metadata and separate submitted form values", () => {
     const action = buttonAction();
 
     // Teams delivers a Button click as a *Message* activity whose `value` IS the
@@ -61,9 +64,18 @@ describe("HITL button action envelope (contract)", () => {
       conversation: { id: "conv-1" },
     };
 
-    expect(parseCardAction(inboundActivity)).toEqual({
+    expect(
+      parseCardAction({
+        ...inboundActivity,
+        value: {
+          ...(action.data as Record<string, unknown>),
+          environment: "production",
+        },
+      }),
+    ).toEqual({
       id: "ck:approve",
       value: { decision: "yes" },
+      values: { environment: "production" },
     });
     expect(conversationKeyOf(inboundActivity)).toBe("conv-1");
   });

--- a/packages/channels-teams/src/codec.test.ts
+++ b/packages/channels-teams/src/codec.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import type { ChannelNode } from "@copilotkit/channels-ui";
+import { teamsCodec } from "./codec.js";
+
+describe("teamsCodec", () => {
+  it("renders portable IR without adapter credentials", () => {
+    const ir: ChannelNode[] = [
+      {
+        type: "header",
+        props: { children: [{ type: "text", props: { value: "hi" } }] },
+      },
+    ];
+
+    expect(teamsCodec.platform).toBe("teams");
+    expect(teamsCodec.renderEgress(ir)).toEqual({
+      card: {
+        type: "AdaptiveCard",
+        $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+        version: "1.5",
+        body: [
+          {
+            type: "TextBlock",
+            text: "hi",
+            size: "Large",
+            weight: "Bolder",
+            wrap: true,
+          },
+        ],
+      },
+    });
+  });
+});

--- a/packages/channels-teams/src/codec.ts
+++ b/packages/channels-teams/src/codec.ts
@@ -1,0 +1,14 @@
+import type { PlatformCodec } from "@copilotkit/channels-core";
+import type { ChannelNode } from "@copilotkit/channels-ui";
+import { isPlainText, renderAdaptiveCard } from "./render/adaptive-card.js";
+import { renderTeamsMarkdown } from "./render/markdown.js";
+
+/** Credential-free Teams renderer for the managed Connector Outbox path. */
+export const teamsCodec: PlatformCodec = {
+  platform: "teams",
+  renderEgress(ir: ChannelNode[]): { text: string } | { card: unknown } {
+    return isPlainText(ir)
+      ? { text: renderTeamsMarkdown(ir) }
+      : { card: renderAdaptiveCard(ir) };
+  },
+};

--- a/packages/channels-teams/src/index.ts
+++ b/packages/channels-teams/src/index.ts
@@ -25,6 +25,7 @@ export type { AdaptiveCard } from "./render/adaptive-card.js";
 export { TEAMS_LIMITS, truncateText, clampArray } from "./render/budget.js";
 export { TeamsMessageStream } from "./message-stream.js";
 export type { TeamsMessageStreamConfig } from "./message-stream.js";
+export { teamsCodec } from "./codec.js";
 
 export { createTeamsServer } from "./listener.js";
 export type { TeamsServer, TeamsServerConfig } from "./listener.js";

--- a/packages/channels-teams/src/interaction.test.ts
+++ b/packages/channels-teams/src/interaction.test.ts
@@ -26,11 +26,22 @@ describe("conversationKeyOf", () => {
 });
 
 describe("parseCardAction", () => {
-  it("decodes an Action.Submit carrying our ckActionId + value", () => {
+  it("decodes the reserved Action.Submit envelope and submitted input values", () => {
     const parsed = parseCardAction({
-      value: { ckActionId: "ck:approve-1", value: { confirmed: true } },
+      value: {
+        __copilotkit: {
+          version: 1,
+          actionId: "ck:approve-1",
+          value: { confirmed: true },
+        },
+        environment: "production",
+      },
     });
-    expect(parsed).toEqual({ id: "ck:approve-1", value: { confirmed: true } });
+    expect(parsed).toEqual({
+      id: "ck:approve-1",
+      value: { confirmed: true },
+      values: { environment: "production" },
+    });
   });
 
   it("returns undefined for an ordinary chat message (no value)", () => {
@@ -45,7 +56,7 @@ describe("parseCardAction", () => {
     ).toBeUndefined();
   });
 
-  it("passes through a falsy/absent button value", () => {
+  it("continues decoding legacy flat action envelopes", () => {
     expect(parseCardAction({ value: { ckActionId: "ck:x" } })).toEqual({
       id: "ck:x",
       value: undefined,

--- a/packages/channels-teams/src/interaction.ts
+++ b/packages/channels-teams/src/interaction.ts
@@ -16,9 +16,17 @@ export interface TeamsActivityLike {
 }
 
 /** The `data` our buttons round-trip (see `render/adaptive-card.ts` `renderButton`). */
-interface CardActionData {
+interface LegacyCardActionData {
   ckActionId?: string;
   value?: unknown;
+}
+
+interface CardActionData extends LegacyCardActionData {
+  __copilotkit?: {
+    version?: unknown;
+    actionId?: unknown;
+    value?: unknown;
+  };
 }
 
 /**
@@ -40,14 +48,33 @@ export function conversationKeyOf(activity: TeamsActivityLike): string {
  */
 export function parseCardAction(
   activity: TeamsActivityLike,
-): { id: string; value: unknown } | undefined {
+):
+  | { id: string; value: unknown; values?: Record<string, unknown> }
+  | undefined {
   const data = activity.value as CardActionData | undefined;
-  if (
-    !data ||
-    typeof data !== "object" ||
-    typeof data.ckActionId !== "string"
-  ) {
+  if (!data || typeof data !== "object") {
     return undefined;
   }
-  return { id: data.ckActionId, value: data.value };
+  const metadata = data.__copilotkit;
+  if (
+    metadata &&
+    typeof metadata === "object" &&
+    metadata.version === 1 &&
+    typeof metadata.actionId === "string"
+  ) {
+    const { __copilotkit: _metadata, ...values } = data;
+    return {
+      id: metadata.actionId,
+      value: metadata.value,
+      ...(Object.keys(values).length > 0 ? { values } : {}),
+    };
+  }
+  // Cards posted before the reserved envelope shipped have this flat shape.
+  if (typeof data.ckActionId !== "string") return undefined;
+  const { ckActionId: _id, value, ...values } = data;
+  return {
+    id: data.ckActionId,
+    value,
+    ...(Object.keys(values).length > 0 ? { values } : {}),
+  };
 }

--- a/packages/channels-teams/src/render/adaptive-card.test.ts
+++ b/packages/channels-teams/src/render/adaptive-card.test.ts
@@ -81,7 +81,13 @@ describe("renderAdaptiveCard", () => {
       {
         type: "Action.Submit",
         title: "Approve",
-        data: { ckActionId: "ck:approve", value: { decision: "yes" } },
+        data: {
+          __copilotkit: {
+            version: 1,
+            actionId: "ck:approve",
+            value: { decision: "yes" },
+          },
+        },
         style: "positive",
       },
     ]);
@@ -152,7 +158,7 @@ describe("renderAdaptiveCard", () => {
     ]);
     const table = card.body[0] as Record<string, unknown>;
     expect(table.type).toBe("Table");
-    expect(table.firstRowAsHeader).toBe(true);
+    expect(table.firstRowAsHeaders).toBe(true);
     const rows = table.rows as Array<Record<string, unknown>>;
     expect(rows).toHaveLength(2); // header + 1 data row
     expect(rows[0]!.type).toBe("TableRow");
@@ -166,9 +172,10 @@ describe("renderAdaptiveCard", () => {
     expect(card.actions).toHaveLength(6);
   });
 
-  it("skips unknown intrinsics without throwing", () => {
-    const card = renderAdaptiveCard([el("mystery", [text("x")])]);
-    expect(card.body).toHaveLength(0);
+  it("rejects unknown intrinsics instead of silently omitting them", () => {
+    expect(() => renderAdaptiveCard([el("mystery", [text("x")])])).toThrow(
+      /does not support this intrinsic/,
+    );
   });
 
   it("renders a vertical-bar <Chart> with title and axis titles", () => {

--- a/packages/channels-teams/src/render/adaptive-card.ts
+++ b/packages/channels-teams/src/render/adaptive-card.ts
@@ -1,24 +1,29 @@
+import {
+  isPlatformNode,
+  UnsupportedUiNodeError,
+} from "@copilotkit/channels-ui";
 import type { ChannelNode } from "@copilotkit/channels-ui";
 import { TEAMS_LIMITS, truncateText, clampArray } from "./budget.js";
+import { renderNativeAdaptiveCard } from "./native-adaptive-card.js";
+import {
+  assertAdaptiveCardPayload,
+  TEAMS_CARD_SCHEMA_URL,
+  TEAMS_CARD_VERSION,
+} from "./schema.js";
+import type { AdaptiveCardPayload } from "./schema.js";
 
 /** Teams attachment content type for an Adaptive Card. */
 export const ADAPTIVE_CARD_CONTENT_TYPE =
   "application/vnd.microsoft.card.adaptive";
 
-/** A minimally-typed Adaptive Card (1.5). Elements/actions are open bags: the
- *  schema is large and we only emit a curated subset. */
-export interface AdaptiveCard {
-  type: "AdaptiveCard";
-  $schema: string;
-  version: string;
-  body: CardElement[];
-  actions?: CardAction[];
-}
+/** @deprecated Use {@link AdaptiveCardPayload}. */
+export type AdaptiveCard = AdaptiveCardPayload;
+export type { AdaptiveCardPayload } from "./schema.js";
 type CardElement = Record<string, unknown>;
 type CardAction = Record<string, unknown>;
 
-const SCHEMA = "http://adaptivecards.io/schemas/adaptive-card.json";
-const VERSION = "1.5";
+const SCHEMA = TEAMS_CARD_SCHEMA_URL;
+const VERSION = TEAMS_CARD_VERSION;
 
 /**
  * Render a cross-platform component IR tree (already expanded by `renderToIR`
@@ -34,16 +39,38 @@ const VERSION = "1.5";
  * registry-stamped opaque id in its `data`/`id` so a later interaction can be
  * decoded back into the engine (round-trip is a follow-up; rendering is here).
  *
- * The renderer is total: unknown intrinsics are skipped. Collections clamp and
- * text truncates to {@link TEAMS_LIMITS} so the card stays within Teams' payload
- * ceiling.
+ * Unknown intrinsics fail explicitly. Collections clamp and text truncates to
+ * {@link TEAMS_LIMITS} so the card stays within Teams' payload ceiling.
  */
-export function renderAdaptiveCard(ir: ChannelNode[]): AdaptiveCard {
+export function renderAdaptiveCard(ir: ChannelNode[]): AdaptiveCardPayload {
+  const only = ir.length === 1 ? ir[0] : undefined;
+  if (only?.type === "raw") {
+    assertAdaptiveCardPayload(only.props.value);
+    return only.props.value;
+  }
+  if (ir.some(isPlatformNode)) {
+    if (!only || !isPlatformNode(only)) {
+      throw new UnsupportedUiNodeError({
+        element: "$platform",
+        path: [],
+        reason:
+          "portable and platform-native nodes cannot be mixed; a native post must have one native root",
+      });
+    }
+    return renderNativeAdaptiveCard(only);
+  }
   const body: CardElement[] = [];
   const actions: CardAction[] = [];
-  for (const node of ir) renderNode(node, body, actions);
+  for (const [index, node] of ir.entries())
+    renderNode(node, body, actions, [index]);
 
-  const card: AdaptiveCard = {
+  const card: {
+    type: "AdaptiveCard";
+    $schema: string;
+    version: string;
+    body: CardElement[];
+    actions?: CardAction[];
+  } = {
     type: "AdaptiveCard",
     $schema: SCHEMA,
     version: VERSION,
@@ -51,7 +78,7 @@ export function renderAdaptiveCard(ir: ChannelNode[]): AdaptiveCard {
   };
   const clampedActions = clampArray(actions, TEAMS_LIMITS.actions).items;
   if (clampedActions.length > 0) card.actions = clampedActions;
-  return card;
+  return card as unknown as AdaptiveCardPayload;
 }
 
 /** Render a single IR node, pushing body elements and/or top-level actions. */
@@ -59,13 +86,15 @@ function renderNode(
   node: ChannelNode,
   body: CardElement[],
   actions: CardAction[],
+  path: (string | number)[],
 ): void {
   if (typeof node.type !== "string") return; // non-intrinsic, already expanded
   const props = node.props ?? {};
   switch (node.type) {
     case "message":
       // The message container is not an element; flatten its children.
-      for (const child of childNodes(node)) renderNode(child, body, actions);
+      for (const [index, child] of childNodes(node).entries())
+        renderNode(child, body, actions, [...path, "children", index]);
       return;
     case "header":
       body.push({
@@ -124,7 +153,8 @@ function renderNode(
       body.push(renderChart(node));
       return;
     case "actions":
-      for (const child of childNodes(node)) renderNode(child, body, actions);
+      for (const [index, child] of childNodes(node).entries())
+        renderNode(child, body, actions, [...path, "children", index]);
       return;
     case "button":
       actions.push(renderButton(node));
@@ -136,8 +166,11 @@ function renderNode(
       body.push(renderInput(node));
       return;
     default:
-      // Unknown intrinsic: skip (total renderer).
-      return;
+      throw new UnsupportedUiNodeError({
+        element: String(node.type),
+        path,
+        reason: "the Teams portable renderer does not support this intrinsic",
+      });
   }
 }
 
@@ -181,12 +214,17 @@ function renderButton(node: ChannelNode): CardAction {
     type: "Action.Submit",
     title: truncateText(collectText(node), TEAMS_LIMITS.buttonText),
   };
-  // Forward-ready: carry the opaque action id + value so a later
-  // `decodeInteraction` can route the submit back into the engine.
+  // Keep Channels metadata under a reserved namespace so Teams can merge named
+  // form values at the top level without colliding with the action id/value.
   const id = idFromHandler(props.onClick);
   const data: Record<string, unknown> = {};
-  if (id) data.ckActionId = id;
-  if (props.value !== undefined) data.value = props.value;
+  if (id) {
+    data.__copilotkit = {
+      version: 1,
+      actionId: id,
+      ...(props.value === undefined ? {} : { value: props.value }),
+    };
+  }
   if (Object.keys(data).length > 0) action.data = data;
   if (props.style === "danger" || props.style === "destructive") {
     action.style = "destructive";
@@ -274,7 +312,7 @@ function renderTable(node: ChannelNode): CardElement {
         : {}),
     })),
     rows,
-    firstRowAsHeader: !!(columns && columns.length > 0),
+    firstRowAsHeaders: !!(columns && columns.length > 0),
     gridStyle: "default",
   };
   return table;
@@ -417,6 +455,7 @@ export function isPlainText(ir: ChannelNode[]): boolean {
     "context",
   ]);
   const visit = (node: ChannelNode): boolean => {
+    if (isPlatformNode(node)) return false;
     if (typeof node.type === "string" && RICH.has(node.type)) return false;
     return childNodes(node).every(visit);
   };

--- a/packages/channels-teams/src/render/index.ts
+++ b/packages/channels-teams/src/render/index.ts
@@ -8,4 +8,12 @@ export {
   collectPlainText,
   ADAPTIVE_CARD_CONTENT_TYPE,
 } from "./adaptive-card.js";
+export { renderNativeAdaptiveCard } from "./native-adaptive-card.js";
+export {
+  assertAdaptiveCardPayload,
+  TEAMS_SCHEMA_LOCK,
+  TEAMS_CARD_SCHEMA_URL,
+  TEAMS_CARD_VERSION,
+} from "./schema.js";
+export type { AdaptiveCardPayload } from "./schema.js";
 export { createRunRenderer } from "../event-renderer.js";

--- a/packages/channels-teams/src/render/native-adaptive-card.test.ts
+++ b/packages/channels-teams/src/render/native-adaptive-card.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { renderToIR } from "@copilotkit/channels-ui";
+import type { PlatformNode } from "@copilotkit/channels-ui";
+import {
+  Action,
+  AdaptiveCard,
+  Input,
+  TextBlock,
+  rawAdaptiveCard,
+} from "../ui.js";
+import { renderAdaptiveCard } from "./adaptive-card.js";
+
+describe("Teams-native Adaptive Cards", () => {
+  it("serializes native JSX directly and preserves submit data separately", () => {
+    const ui = AdaptiveCard({
+      children: [
+        TextBlock({ text: "Deploy application", weight: "Bolder" }),
+        Input.ChoiceSet({
+          id: "environment",
+          choices: [
+            { title: "Staging", value: "staging" },
+            { title: "Production", value: "production" },
+          ],
+        }),
+        Action.Submit({
+          title: "Deploy",
+          data: { intent: "deploy" },
+          onSubmit: async () => undefined,
+        }),
+      ],
+    });
+    const ir = renderToIR(ui);
+    const submit = (ir[0]!.props.children as PlatformNode[])[2]!;
+    (submit.props as unknown as { onSubmit: unknown }).onSubmit = {
+      id: "ck:deploy",
+    };
+
+    expect(renderAdaptiveCard(ir)).toEqual({
+      type: "AdaptiveCard",
+      $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+      version: "1.5",
+      body: [
+        { type: "TextBlock", text: "Deploy application", weight: "Bolder" },
+        {
+          type: "Input.ChoiceSet",
+          id: "environment",
+          choices: [
+            { title: "Staging", value: "staging" },
+            { title: "Production", value: "production" },
+          ],
+        },
+      ],
+      actions: [
+        {
+          type: "Action.Submit",
+          title: "Deploy",
+          data: {
+            __copilotkit: {
+              version: 1,
+              actionId: "ck:deploy",
+              value: { intent: "deploy" },
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  it("rejects duplicate and reserved native input ids", () => {
+    const duplicate = renderToIR(
+      AdaptiveCard({
+        children: [
+          Input.Text({ id: "environment" }),
+          Input.Text({ id: "environment" }),
+        ],
+      }),
+    );
+    const reserved = renderToIR(
+      AdaptiveCard({ children: [Input.Text({ id: "__copilotkit_value" })] }),
+    );
+
+    expect(() => renderAdaptiveCard(duplicate)).toThrow(/duplicate input id/);
+    expect(() => renderAdaptiveCard(reserved)).toThrow(/reserved __copilotkit/);
+  });
+
+  it("validates raw cards without accepting executable or unsupported data", () => {
+    const card = {
+      type: "AdaptiveCard",
+      $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+      version: "1.5",
+      body: [],
+    };
+    expect(rawAdaptiveCard(card).raw).toBe(card);
+    expect(() => rawAdaptiveCard({ ...card, version: "1.6" })).toThrow(
+      /at most 1.5/,
+    );
+    expect(() =>
+      rawAdaptiveCard({
+        ...card,
+        actions: [{ type: "Action.Execute", verb: "nope" }],
+      }),
+    ).toThrow(/Action.Execute/);
+  });
+});

--- a/packages/channels-teams/src/render/native-adaptive-card.test.ts
+++ b/packages/channels-teams/src/render/native-adaptive-card.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  platformNode,
   renderToIR,
   PlatformUiMismatchError,
   validatePlatformUi,
@@ -14,6 +15,7 @@ import {
   rawAdaptiveCard,
 } from "../ui.js";
 import { renderAdaptiveCard } from "./adaptive-card.js";
+import { RAW_ADAPTIVE_CARD_ELEMENT } from "./native-adaptive-card.js";
 
 describe("Teams-native Adaptive Cards", () => {
   it("serializes native JSX directly and preserves submit data separately", () => {
@@ -111,6 +113,25 @@ describe("Teams-native Adaptive Cards", () => {
         actions: [{ type: "Action.Execute", verb: "nope" }],
       }),
     ).toThrow(/Action.Execute/);
+    expect(() =>
+      rawAdaptiveCard({
+        ...card,
+        actions: [
+          {
+            type: "Action.Submit",
+            data: {
+              __copilotkit: { version: 1, actionId: "ck:forged" },
+            },
+          },
+        ],
+      }),
+    ).toThrow(/reserved Channels action metadata/);
+    expect(() =>
+      rawAdaptiveCard({
+        ...card,
+        body: [{ type: "Input.Text", id: "ckActionId" }],
+      }),
+    ).toThrow(/reserved Channels input id/);
   });
 
   it("marks raw cards as Teams-native before they can reach another platform", () => {
@@ -123,6 +144,34 @@ describe("Teams-native Adaptive Cards", () => {
 
     expect(() => validatePlatformUi(renderToIR(card), "slack")).toThrow(
       PlatformUiMismatchError,
+    );
+  });
+
+  it("enforces raw-card callback isolation for hand-built platform IR", () => {
+    const forged = platformNode({
+      protocol: 1,
+      platform: "teams",
+      dialect: "adaptive-card",
+      dialectVersion: "1.5",
+      element: RAW_ADAPTIVE_CARD_ELEMENT,
+      attributes: {
+        type: "AdaptiveCard",
+        $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+        version: "1.5",
+        body: [],
+        actions: [
+          {
+            type: "Action.Submit",
+            data: {
+              __copilotkit: { version: 1, actionId: "ck:forged" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(() => renderAdaptiveCard([forged])).toThrow(
+      /reserved Channels action metadata/,
     );
   });
 

--- a/packages/channels-teams/src/render/native-adaptive-card.test.ts
+++ b/packages/channels-teams/src/render/native-adaptive-card.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { renderToIR } from "@copilotkit/channels-ui";
+import {
+  renderToIR,
+  PlatformUiMismatchError,
+  validatePlatformUi,
+} from "@copilotkit/channels-ui";
 import type { PlatformNode } from "@copilotkit/channels-ui";
+import { ActionRegistry } from "@copilotkit/channels-core";
 import {
   Action,
   AdaptiveCard,
@@ -90,15 +95,63 @@ describe("Teams-native Adaptive Cards", () => {
       version: "1.5",
       body: [],
     };
-    expect(rawAdaptiveCard(card).raw).toBe(card);
+    expect(renderAdaptiveCard(renderToIR(rawAdaptiveCard(card)))).toBe(card);
     expect(() => rawAdaptiveCard({ ...card, version: "1.6" })).toThrow(
       /at most 1.5/,
     );
     expect(() =>
       rawAdaptiveCard({
         ...card,
+        body: [{ type: "NotAnAdaptiveCardElement" }],
+      }),
+    ).toThrow(/unsupported type/);
+    expect(() =>
+      rawAdaptiveCard({
+        ...card,
         actions: [{ type: "Action.Execute", verb: "nope" }],
       }),
     ).toThrow(/Action.Execute/);
+  });
+
+  it("marks raw cards as Teams-native before they can reach another platform", () => {
+    const card = rawAdaptiveCard({
+      type: "AdaptiveCard",
+      $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+      version: "1.5",
+      body: [],
+    });
+
+    expect(() => validatePlatformUi(renderToIR(card), "slack")).toThrow(
+      PlatformUiMismatchError,
+    );
+  });
+
+  it("validates native structure before persisting submit handlers", async () => {
+    const writes: string[] = [];
+    const registry = new ActionRegistry({
+      store: {
+        async put(id) {
+          writes.push(id);
+        },
+        async get() {
+          return undefined;
+        },
+        async delete() {},
+      },
+    });
+    const invalid = AdaptiveCard({
+      children: [
+        Input.Text({ id: "environment" }),
+        Input.Text({ id: "environment" }),
+        Action.Submit({ title: "Deploy", onSubmit: async () => undefined }),
+      ],
+    });
+
+    await expect(
+      registry.bindRenderable(invalid, "conversation", {
+        preflight: (root) => validatePlatformUi(root, "teams"),
+      }),
+    ).rejects.toThrow(/duplicate input id/);
+    expect(writes).toEqual([]);
   });
 });

--- a/packages/channels-teams/src/render/native-adaptive-card.ts
+++ b/packages/channels-teams/src/render/native-adaptive-card.ts
@@ -1,0 +1,353 @@
+import {
+  isPlatformNode,
+  UnsupportedUiNodeError,
+  validatePlatformUi,
+} from "@copilotkit/channels-ui";
+import type {
+  JsonObject,
+  JsonValue,
+  PlatformNode,
+} from "@copilotkit/channels-ui";
+import {
+  assertAdaptiveCardPayload,
+  TEAMS_CARD_SCHEMA_URL,
+  TEAMS_CARD_VERSION,
+} from "./schema.js";
+import type { AdaptiveCardPayload } from "./schema.js";
+
+const ACTIONS = new Set(["Action.Submit", "Action.OpenUrl"]);
+const BODY_ELEMENTS = new Set([
+  "Container",
+  "ColumnSet",
+  "ActionSet",
+  "TextBlock",
+  "RichTextBlock",
+  "Image",
+  "ImageSet",
+  "FactSet",
+  "Table",
+  "Input.Text",
+  "Input.Number",
+  "Input.Date",
+  "Input.Time",
+  "Input.Toggle",
+  "Input.ChoiceSet",
+]);
+interface RenderState {
+  inputIds: Set<string>;
+}
+
+/** Serialize a platform-native Teams IR tree directly to Adaptive Card JSON. */
+export function renderNativeAdaptiveCard(
+  root: PlatformNode,
+): AdaptiveCardPayload {
+  validatePlatformUi([root], "teams");
+  if (root.props.element !== "AdaptiveCard") {
+    throw new UnsupportedUiNodeError({
+      element: root.props.element,
+      path: [0],
+      reason: "a Teams-native post must have one AdaptiveCard root",
+    });
+  }
+  const payload = renderNode(root, [0], { inputIds: new Set() });
+  assertAdaptiveCardPayload(payload);
+  return payload as AdaptiveCardPayload;
+}
+
+function renderNode(
+  node: PlatformNode,
+  path: (string | number)[],
+  state: RenderState,
+): JsonObject {
+  const { element, attributes } = node.props;
+  const children = platformChildren(node, path);
+  const renderedChildren = children.map(({ node: child, path: childPath }) =>
+    renderNode(child, childPath, state),
+  );
+
+  switch (element) {
+    case "AdaptiveCard": {
+      const { actions, body } = partitionRootChildren(
+        children,
+        renderedChildren,
+        path,
+      );
+      return {
+        ...attributes,
+        type: "AdaptiveCard",
+        $schema: TEAMS_CARD_SCHEMA_URL,
+        version: TEAMS_CARD_VERSION,
+        body,
+        ...(actions.length > 0 ? { actions } : {}),
+      };
+    }
+    case "Container":
+    case "Column":
+    case "TableCell":
+      return withSlot(
+        element,
+        attributes,
+        children,
+        renderedChildren,
+        BODY_ELEMENTS,
+        "items",
+        path,
+      );
+    case "ColumnSet":
+      return withSlot(
+        element,
+        attributes,
+        children,
+        renderedChildren,
+        new Set(["Column"]),
+        "columns",
+        path,
+      );
+    case "ActionSet":
+      return withSlot(
+        element,
+        attributes,
+        children,
+        renderedChildren,
+        ACTIONS,
+        "actions",
+        path,
+      );
+    case "RichTextBlock":
+      return withSlot(
+        element,
+        attributes,
+        children,
+        renderedChildren,
+        new Set(["TextRun"]),
+        "inlines",
+        path,
+      );
+    case "ImageSet":
+      return withSlot(
+        element,
+        attributes,
+        children,
+        renderedChildren,
+        new Set(["Image"]),
+        "images",
+        path,
+      );
+    case "FactSet":
+      return withSlot(
+        element,
+        attributes,
+        children,
+        renderedChildren,
+        new Set(["Fact"]),
+        "facts",
+        path,
+      );
+    case "Table":
+      return withSlot(
+        element,
+        attributes,
+        children,
+        renderedChildren,
+        new Set(["TableRow"]),
+        "rows",
+        path,
+      );
+    case "TableRow":
+      return withSlot(
+        element,
+        attributes,
+        children,
+        renderedChildren,
+        new Set(["TableCell"]),
+        "cells",
+        path,
+      );
+    case "TextBlock":
+    case "TextRun":
+    case "Image":
+    case "Fact":
+    case "Action.OpenUrl":
+      requireNoChildren(element, children, path);
+      return { ...attributes, type: element };
+    case "Input.Text":
+    case "Input.Number":
+    case "Input.Date":
+    case "Input.Time":
+    case "Input.Toggle":
+    case "Input.ChoiceSet":
+      requireNoChildren(element, children, path);
+      assertInputId(attributes, element, path, state);
+      return { ...attributes, type: element };
+    case "Action.Submit": {
+      requireNoChildren(element, children, path);
+      const actionId = actionIdFrom(node.props.onSubmit);
+      if (!actionId) {
+        throw new UnsupportedUiNodeError({
+          element,
+          path,
+          reason: "Action.Submit must have a bound onSubmit handler",
+        });
+      }
+      return {
+        ...attributes,
+        type: element,
+        data: {
+          __copilotkit: {
+            version: 1,
+            actionId,
+            ...(node.props.value === undefined
+              ? {}
+              : { value: node.props.value as JsonValue }),
+          },
+        },
+      };
+    }
+    default:
+      throw new UnsupportedUiNodeError({
+        element,
+        path,
+        reason: "this element is not in the Teams-native Channels catalog",
+      });
+  }
+}
+
+function partitionRootChildren(
+  children: { node: PlatformNode; path: (string | number)[] }[],
+  rendered: JsonObject[],
+  parentPath: (string | number)[],
+): { body: JsonObject[]; actions: JsonObject[] } {
+  const body: JsonObject[] = [];
+  const actions: JsonObject[] = [];
+  children.forEach(({ node, path }, index) => {
+    if (ACTIONS.has(node.props.element)) {
+      actions.push(rendered[index]!);
+    } else if (BODY_ELEMENTS.has(node.props.element)) {
+      body.push(rendered[index]!);
+    } else {
+      throw new UnsupportedUiNodeError({
+        element: node.props.element,
+        path,
+        reason: `cannot appear in an AdaptiveCard at ${formatPath(parentPath)}`,
+      });
+    }
+  });
+  return { body, actions };
+}
+
+function withSlot(
+  element: string,
+  attributes: JsonObject,
+  children: { node: PlatformNode; path: (string | number)[] }[],
+  renderedChildren: JsonObject[],
+  allowed: ReadonlySet<string>,
+  slot: string,
+  path: (string | number)[],
+): JsonObject {
+  const values = takeChildren(children, renderedChildren, allowed, path, slot);
+  return {
+    ...attributes,
+    type: element,
+    ...(values.length > 0 ? { [slot]: values } : {}),
+  };
+}
+
+function takeChildren(
+  children: { node: PlatformNode; path: (string | number)[] }[],
+  rendered: JsonObject[],
+  allowed: ReadonlySet<string>,
+  parentPath: (string | number)[],
+  slot: string,
+): JsonObject[] {
+  const result: JsonObject[] = [];
+  children.forEach(({ node, path }, index) => {
+    if (!allowed.has(node.props.element)) {
+      throw new UnsupportedUiNodeError({
+        element: node.props.element,
+        path,
+        reason: `cannot appear in the ${slot} slot at ${formatPath(parentPath)}`,
+      });
+    }
+    result.push(rendered[index]!);
+  });
+  return result;
+}
+
+function platformChildren(
+  node: PlatformNode,
+  path: (string | number)[],
+): { node: PlatformNode; path: (string | number)[] }[] {
+  const children = node.props.children ?? [];
+  return children.map((child, index) => {
+    const childPath = [...path, "children", index];
+    if (!isPlatformNode(child)) {
+      throw new UnsupportedUiNodeError({
+        element: String(child.type),
+        path: childPath,
+        reason: "portable and platform-native nodes cannot be mixed",
+      });
+    }
+    return { node: child, path: childPath };
+  });
+}
+
+function requireNoChildren(
+  element: string,
+  children: unknown[],
+  path: (string | number)[],
+): void {
+  if (children.length > 0) {
+    throw new UnsupportedUiNodeError({
+      element,
+      path,
+      reason: "this element does not accept JSX children",
+    });
+  }
+}
+
+function assertInputId(
+  attributes: JsonObject,
+  element: string,
+  path: (string | number)[],
+  state: RenderState,
+): void {
+  const id = attributes.id;
+  if (typeof id !== "string" || id.length === 0) {
+    throw new UnsupportedUiNodeError({
+      element,
+      path,
+      reason: "input elements require a non-empty id",
+    });
+  }
+  if (id.startsWith("__copilotkit")) {
+    throw new UnsupportedUiNodeError({
+      element,
+      path,
+      reason: "input ids may not use the reserved __copilotkit namespace",
+    });
+  }
+  if (state.inputIds.has(id)) {
+    throw new UnsupportedUiNodeError({
+      element,
+      path,
+      reason: `duplicate input id ${JSON.stringify(id)}`,
+    });
+  }
+  state.inputIds.add(id);
+}
+
+function actionIdFrom(handler: unknown): string | undefined {
+  if (!handler || typeof handler !== "object" || !("id" in handler)) {
+    return undefined;
+  }
+  const id = (handler as { id?: unknown }).id;
+  return typeof id === "string" ? id : undefined;
+}
+
+function formatPath(path: (string | number)[]): string {
+  return path.reduce<string>(
+    (result, part) =>
+      typeof part === "number" ? `${result}[${part}]` : `${result}.${part}`,
+    "root",
+  );
+}

--- a/packages/channels-teams/src/render/native-adaptive-card.ts
+++ b/packages/channels-teams/src/render/native-adaptive-card.ts
@@ -1,5 +1,6 @@
 import {
   isPlatformNode,
+  registerPlatformUiValidator,
   UnsupportedUiNodeError,
   validatePlatformUi,
 } from "@copilotkit/channels-ui";
@@ -35,13 +36,38 @@ const BODY_ELEMENTS = new Set([
 ]);
 interface RenderState {
   inputIds: Set<string>;
+  allowUnboundSubmitHandlers: boolean;
 }
+
+/** Internal platform-node marker for the data-only raw-card escape hatch. */
+export const RAW_ADAPTIVE_CARD_ELEMENT = "RawAdaptiveCard";
 
 /** Serialize a platform-native Teams IR tree directly to Adaptive Card JSON. */
 export function renderNativeAdaptiveCard(
   root: PlatformNode,
 ): AdaptiveCardPayload {
   validatePlatformUi([root], "teams");
+  return serializeNativeAdaptiveCard(root, false);
+}
+
+/**
+ * Structural validation used during action-registry preflight. Submit handlers
+ * have not been bound yet at that point, so a temporary id is used only while
+ * validating the resulting payload shape.
+ */
+function validateNativeAdaptiveCard(root: PlatformNode): void {
+  void serializeNativeAdaptiveCard(root, true);
+}
+
+function serializeNativeAdaptiveCard(
+  root: PlatformNode,
+  allowUnboundSubmitHandlers: boolean,
+): AdaptiveCardPayload {
+  if (root.props.element === RAW_ADAPTIVE_CARD_ELEMENT) {
+    requireNoChildren(root.props.element, root.props.children ?? [], [0]);
+    assertAdaptiveCardPayload(root.props.attributes);
+    return root.props.attributes as unknown as AdaptiveCardPayload;
+  }
   if (root.props.element !== "AdaptiveCard") {
     throw new UnsupportedUiNodeError({
       element: root.props.element,
@@ -49,7 +75,10 @@ export function renderNativeAdaptiveCard(
       reason: "a Teams-native post must have one AdaptiveCard root",
     });
   }
-  const payload = renderNode(root, [0], { inputIds: new Set() });
+  const payload = renderNode(root, [0], {
+    inputIds: new Set(),
+    allowUnboundSubmitHandlers,
+  });
   assertAdaptiveCardPayload(payload);
   return payload as AdaptiveCardPayload;
 }
@@ -181,7 +210,17 @@ function renderNode(
       return { ...attributes, type: element };
     case "Action.Submit": {
       requireNoChildren(element, children, path);
-      const actionId = actionIdFrom(node.props.onSubmit);
+      let actionId = actionIdFrom(node.props.onSubmit);
+      if (!actionId) {
+        if (typeof node.props.onSubmit !== "function") {
+          throw new UnsupportedUiNodeError({
+            element,
+            path,
+            reason: "Action.Submit must have an onSubmit handler",
+          });
+        }
+        if (state.allowUnboundSubmitHandlers) actionId = "ck:preflight";
+      }
       if (!actionId) {
         throw new UnsupportedUiNodeError({
           element,
@@ -351,3 +390,9 @@ function formatPath(path: (string | number)[]): string {
     "root",
   );
 }
+
+registerPlatformUiValidator(
+  "teams",
+  "adaptive-card",
+  validateNativeAdaptiveCard,
+);

--- a/packages/channels-teams/src/render/native-adaptive-card.ts
+++ b/packages/channels-teams/src/render/native-adaptive-card.ts
@@ -11,6 +11,7 @@ import type {
 } from "@copilotkit/channels-ui";
 import {
   assertAdaptiveCardPayload,
+  assertRawAdaptiveCardPayload,
   TEAMS_CARD_SCHEMA_URL,
   TEAMS_CARD_VERSION,
 } from "./schema.js";
@@ -65,7 +66,7 @@ function serializeNativeAdaptiveCard(
 ): AdaptiveCardPayload {
   if (root.props.element === RAW_ADAPTIVE_CARD_ELEMENT) {
     requireNoChildren(root.props.element, root.props.children ?? [], [0]);
-    assertAdaptiveCardPayload(root.props.attributes);
+    assertRawAdaptiveCardPayload(root.props.attributes);
     return root.props.attributes as unknown as AdaptiveCardPayload;
   }
   if (root.props.element !== "AdaptiveCard") {

--- a/packages/channels-teams/src/render/schema.ts
+++ b/packages/channels-teams/src/render/schema.ts
@@ -64,6 +64,55 @@ export function assertAdaptiveCardPayload(
   }
 }
 
+/**
+ * Validate the data-only raw-card escape hatch. Native JSX owns the reserved
+ * callback envelope; accepting it from raw JSON would let a card bypass action
+ * binding and target a persisted Channels handler directly.
+ */
+export function assertRawAdaptiveCardPayload(
+  payload: unknown,
+): asserts payload is AdaptiveCardPayload {
+  assertAdaptiveCardPayload(payload);
+  assertNoReservedChannelsMetadata(payload, "card");
+}
+
+function assertNoReservedChannelsMetadata(value: unknown, path: string): void {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) =>
+      assertNoReservedChannelsMetadata(entry, `${path}[${index}]`),
+    );
+    return;
+  }
+  if (!isRecord(value)) return;
+
+  if (value.type === "Action.Submit" && isRecord(value.data)) {
+    if (
+      Object.hasOwn(value.data, "__copilotkit") ||
+      Object.hasOwn(value.data, "ckActionId")
+    ) {
+      throw new Error(
+        `Adaptive Card ${path}.data may not contain reserved Channels action metadata. Use native Action.Submit JSX for callbacks.`,
+      );
+    }
+  }
+
+  if (typeof value.type === "string" && value.type.startsWith("Input.")) {
+    const id = value.id;
+    if (
+      typeof id === "string" &&
+      (id === "ckActionId" || id.startsWith("__copilotkit"))
+    ) {
+      throw new Error(
+        `Adaptive Card ${path}.id uses a reserved Channels input id.`,
+      );
+    }
+  }
+
+  for (const [key, entry] of Object.entries(value)) {
+    assertNoReservedChannelsMetadata(entry, `${path}.${key}`);
+  }
+}
+
 const CARD_ELEMENTS = new Set([
   "ActionSet",
   "Column",

--- a/packages/channels-teams/src/render/schema.ts
+++ b/packages/channels-teams/src/render/schema.ts
@@ -55,12 +55,196 @@ export function assertAdaptiveCardPayload(
       "Adaptive Card payload contains Action.Execute, which is not supported by the Teams-native Channels surface.",
     );
   }
+  validateAdaptiveCardStructure(payload);
   const bytes = new TextEncoder().encode(JSON.stringify(payload)).byteLength;
   if (bytes > TEAMS_CARD_MAX_BYTES) {
     throw new Error(
       `Adaptive Card payload is ${bytes} bytes; Teams allows at most ${TEAMS_CARD_MAX_BYTES} bytes.`,
     );
   }
+}
+
+const CARD_ELEMENTS = new Set([
+  "ActionSet",
+  "Column",
+  "ColumnSet",
+  "Container",
+  "FactSet",
+  "Image",
+  "ImageSet",
+  "Input.ChoiceSet",
+  "Input.Date",
+  "Input.Number",
+  "Input.Text",
+  "Input.Time",
+  "Input.Toggle",
+  "Media",
+  "RichTextBlock",
+  "Table",
+  "TextBlock",
+]);
+const ACTIONS = new Set([
+  "Action.OpenUrl",
+  "Action.ShowCard",
+  "Action.Submit",
+  "Action.ToggleVisibility",
+]);
+const CERTIFIED_ELEMENTS = new Set([
+  "ActionSet",
+  "Column",
+  "ColumnSet",
+  "Container",
+  "FactSet",
+  "Image",
+  "ImageSet",
+  "Input.ChoiceSet",
+  "Input.Date",
+  "Input.Number",
+  "Input.Text",
+  "Input.Time",
+  "Input.Toggle",
+  "RichTextBlock",
+  "Table",
+  "TextBlock",
+  "Action.OpenUrl",
+  "Action.Submit",
+]);
+
+/**
+ * Validate the part of the pinned Teams host profile that changes tree shape.
+ * This prevents malformed raw payloads from reaching Teams while retaining the
+ * raw-card escape hatch for known-but-not-yet-certified Adaptive Card features.
+ */
+function validateAdaptiveCardStructure(card: Record<string, unknown>): void {
+  validateElementArray(card.body, "card.body");
+  if (card.actions !== undefined)
+    validateActionArray(card.actions, "card.actions");
+}
+
+function validateElementArray(value: unknown, path: string): void {
+  if (!Array.isArray(value)) {
+    throw new Error(`Adaptive Card ${path} must be an array.`);
+  }
+  value.forEach((element, index) =>
+    validateElement(element, `${path}[${index}]`),
+  );
+}
+
+function validateActionArray(value: unknown, path: string): void {
+  if (!Array.isArray(value)) {
+    throw new Error(`Adaptive Card ${path} must be an array.`);
+  }
+  value.forEach((action, index) => validateAction(action, `${path}[${index}]`));
+}
+
+function validateElement(value: unknown, path: string): void {
+  const element = requireTypedRecord(value, path);
+  const type = requireType(element, path, CARD_ELEMENTS);
+  warnUncertified(type, path);
+
+  switch (type) {
+    case "ActionSet":
+      validateActionArray(element.actions, `${path}.actions`);
+      return;
+    case "Column":
+    case "Container":
+      validateOptionalElementArray(element.items, `${path}.items`);
+      return;
+    case "ColumnSet":
+      validateOptionalTypedArray(element.columns, `${path}.columns`, "Column");
+      return;
+    case "ImageSet":
+      validateOptionalTypedArray(element.images, `${path}.images`, "Image");
+      return;
+    case "RichTextBlock":
+      validateOptionalTypedArray(element.inlines, `${path}.inlines`, "TextRun");
+      return;
+    case "Table":
+      validateOptionalTypedArray(element.rows, `${path}.rows`, "TableRow");
+      return;
+    case "FactSet":
+      validateOptionalTypedArray(element.facts, `${path}.facts`, "Fact");
+      return;
+    case "TextBlock":
+      if (typeof element.text !== "string") {
+        throw new Error(`Adaptive Card ${path}.text must be a string.`);
+      }
+      return;
+    case "Image":
+      if (typeof element.url !== "string") {
+        throw new Error(`Adaptive Card ${path}.url must be a string.`);
+      }
+      return;
+    default:
+      if (type.startsWith("Input.") && typeof element.id !== "string") {
+        throw new Error(`Adaptive Card ${path}.id must be a string.`);
+      }
+  }
+}
+
+function validateAction(value: unknown, path: string): void {
+  const action = requireTypedRecord(value, path);
+  const type = requireType(action, path, ACTIONS);
+  warnUncertified(type, path);
+  if (type === "Action.OpenUrl" && typeof action.url !== "string") {
+    throw new Error(`Adaptive Card ${path}.url must be a string.`);
+  }
+}
+
+function validateOptionalElementArray(value: unknown, path: string): void {
+  if (value !== undefined) validateElementArray(value, path);
+}
+
+function validateOptionalTypedArray(
+  value: unknown,
+  path: string,
+  expectedType: string,
+): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    throw new Error(`Adaptive Card ${path} must be an array.`);
+  }
+  value.forEach((entry, index) => {
+    const item = requireTypedRecord(entry, `${path}[${index}]`);
+    if (item.type !== expectedType) {
+      throw new Error(
+        `Adaptive Card ${path}[${index}] must have type ${expectedType}.`,
+      );
+    }
+  });
+}
+
+function requireTypedRecord(
+  value: unknown,
+  path: string,
+): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`Adaptive Card ${path} must be an object.`);
+  }
+  return value;
+}
+
+function requireType(
+  value: Record<string, unknown>,
+  path: string,
+  allowed: ReadonlySet<string>,
+): string {
+  const type = value.type;
+  if (typeof type !== "string" || !allowed.has(type)) {
+    throw new Error(
+      `Adaptive Card ${path} has an unsupported type ${String(type)}.`,
+    );
+  }
+  return type;
+}
+
+function warnUncertified(type: string, path: string): void {
+  if (CERTIFIED_ELEMENTS.has(type) || process.env.NODE_ENV === "production") {
+    return;
+  }
+  console.warn(
+    `[channels-teams] ${type} at ${path} is schema-valid but not yet certified for the Teams host profile.`,
+  );
 }
 
 function assertJsonData(

--- a/packages/channels-teams/src/render/schema.ts
+++ b/packages/channels-teams/src/render/schema.ts
@@ -1,0 +1,135 @@
+import type { JsonObject, JsonValue } from "@copilotkit/channels-ui";
+
+/**
+ * The authoring schema is pinned for reproducibility. Runtime validation is
+ * self-contained and never fetches this URL; the Microsoft package version is
+ * the compile-time source for the public prop vocabulary.
+ */
+export const TEAMS_SCHEMA_LOCK = {
+  url: "https://adaptivecards.microsoft.com/schemas/adaptive-card-2026-01-13.json",
+  sha256: "b8aad7c59ee252e619601a27057d44aecffbfc8969962924846c26fc185d1cfc",
+  package: "@microsoft/teams.cards@2.0.14",
+} as const;
+
+/** The schema URL emitted for Teams-hosted Adaptive Cards. */
+export const TEAMS_CARD_SCHEMA_URL =
+  "http://adaptivecards.io/schemas/adaptive-card.json";
+export const TEAMS_CARD_VERSION = "1.5";
+export const TEAMS_CARD_MAX_BYTES = 28 * 1024;
+
+/** JSON payload accepted by the Teams attachment API. */
+export interface AdaptiveCardPayload {
+  type: "AdaptiveCard";
+  $schema: string;
+  version: string;
+  body: JsonObject[];
+  actions?: JsonObject[];
+  [key: string]: JsonValue | undefined;
+}
+
+/**
+ * Validate the safe boundary required by both raw cards and the native JSX
+ * serializer. This validator intentionally has no Ajv runtime dependency and
+ * catches the class of errors Teams otherwise reports as an opaque send error.
+ */
+export function assertAdaptiveCardPayload(
+  payload: unknown,
+): asserts payload is AdaptiveCardPayload {
+  assertJsonData(payload, new WeakSet<object>(), "card");
+  if (!isRecord(payload) || payload.type !== "AdaptiveCard") {
+    throw new Error("Adaptive Card payload must have an AdaptiveCard root.");
+  }
+  if (!Array.isArray(payload.body)) {
+    throw new Error("Adaptive Card payload must provide a body array.");
+  }
+  if (
+    typeof payload.version !== "string" ||
+    !isSupportedVersion(payload.version)
+  ) {
+    throw new Error(
+      `Adaptive Card version must be at most ${TEAMS_CARD_VERSION}; received ${String(payload.version)}.`,
+    );
+  }
+  if (containsUnsupportedTeamsFeature(payload)) {
+    throw new Error(
+      "Adaptive Card payload contains Action.Execute, which is not supported by the Teams-native Channels surface.",
+    );
+  }
+  const bytes = new TextEncoder().encode(JSON.stringify(payload)).byteLength;
+  if (bytes > TEAMS_CARD_MAX_BYTES) {
+    throw new Error(
+      `Adaptive Card payload is ${bytes} bytes; Teams allows at most ${TEAMS_CARD_MAX_BYTES} bytes.`,
+    );
+  }
+}
+
+function assertJsonData(
+  value: unknown,
+  seen: WeakSet<object>,
+  path: string,
+): void {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean" ||
+    typeof value === "number"
+  ) {
+    if (typeof value === "number" && !Number.isFinite(value)) {
+      throw new Error(
+        `Adaptive Card payload has a non-finite number at ${path}.`,
+      );
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    if (seen.has(value))
+      throw new Error(`Adaptive Card payload has a cycle at ${path}.`);
+    seen.add(value);
+    value.forEach((entry, index) =>
+      assertJsonData(entry, seen, `${path}[${index}]`),
+    );
+    seen.delete(value);
+    return;
+  }
+  if (!isRecord(value)) {
+    throw new Error(
+      `Adaptive Card payload must contain JSON data; found ${typeof value} at ${path}.`,
+    );
+  }
+  if (seen.has(value))
+    throw new Error(`Adaptive Card payload has a cycle at ${path}.`);
+  seen.add(value);
+  for (const [key, entry] of Object.entries(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (descriptor?.get || descriptor?.set) {
+      throw new Error(
+        `Adaptive Card payload cannot contain accessors (${path}.${key}).`,
+      );
+    }
+    assertJsonData(entry, seen, `${path}.${key}`);
+  }
+  seen.delete(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+function isSupportedVersion(version: string): boolean {
+  const match = /^(\d+)\.(\d+)$/.exec(version);
+  if (!match) return false;
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  return major < 1 || (major === 1 && minor <= 5);
+}
+
+function containsUnsupportedTeamsFeature(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsUnsupportedTeamsFeature);
+  if (!isRecord(value)) return false;
+  if (value.type === "Action.Execute") return true;
+  return Object.values(value).some(containsUnsupportedTeamsFeature);
+}

--- a/packages/channels-teams/src/ui.ts
+++ b/packages/channels-teams/src/ui.ts
@@ -1,0 +1,246 @@
+import type {
+  IActionSet,
+  IAdaptiveCard,
+  IChoiceSetInput,
+  IColumn,
+  IColumnSet,
+  IContainer,
+  IDateInput,
+  IFact,
+  IFactSet,
+  IImage,
+  IImageSet,
+  INumberInput,
+  IOpenUrlAction,
+  IRichTextBlock,
+  ISubmitAction,
+  ITable,
+  ITableCell,
+  ITableRow,
+  ITextBlock,
+  ITextInput,
+  ITextRun,
+  ITimeInput,
+  IToggleInput,
+} from "@microsoft/teams.cards";
+import { platformNode } from "@copilotkit/channels-ui";
+import type {
+  ChannelNode,
+  ClickHandler,
+  JsonObject,
+  PlatformNode,
+} from "@copilotkit/channels-ui";
+import { assertAdaptiveCardPayload } from "./render/schema.js";
+import type { AdaptiveCardPayload } from "./render/schema.js";
+
+export const TEAMS_PLATFORM = "teams";
+export const ADAPTIVE_CARD_DIALECT = "adaptive-card";
+export const TEAMS_ADAPTIVE_CARD_VERSION = "1.5";
+
+type Children = ChannelNode | ChannelNode[];
+type WithChildren<T> = T & { children?: Children };
+type ElementProps<T, ChildFields extends string = never> = WithChildren<
+  Omit<T, "type" | ChildFields>
+>;
+
+export type AdaptiveCardProps = ElementProps<
+  IAdaptiveCard,
+  "body" | "actions" | "$schema" | "version"
+>;
+export type ContainerProps = ElementProps<IContainer, "items">;
+export type ColumnSetProps = ElementProps<IColumnSet, "columns">;
+export type ColumnProps = ElementProps<IColumn, "items">;
+export type ActionSetProps = ElementProps<IActionSet, "actions">;
+export type TextBlockProps = Omit<ITextBlock, "type"> & { children?: never };
+export type RichTextBlockProps = ElementProps<IRichTextBlock, "inlines">;
+export type TextRunProps = Omit<ITextRun, "type"> & { children?: never };
+export type ImageProps = Omit<IImage, "type"> & { children?: never };
+export type ImageSetProps = ElementProps<IImageSet, "images">;
+export type FactSetProps = ElementProps<IFactSet, "facts">;
+export type FactProps = Omit<IFact, "type"> & { children?: never };
+export type TableProps = ElementProps<ITable, "rows">;
+export type TableRowProps = ElementProps<ITableRow, "cells">;
+export type TableCellProps = ElementProps<ITableCell, "items">;
+export type TextInputProps = Omit<ITextInput, "type" | "id"> & {
+  id: string;
+  children?: never;
+};
+export type NumberInputProps = Omit<INumberInput, "type" | "id"> & {
+  id: string;
+  children?: never;
+};
+export type DateInputProps = Omit<IDateInput, "type" | "id"> & {
+  id: string;
+  children?: never;
+};
+export type TimeInputProps = Omit<ITimeInput, "type" | "id"> & {
+  id: string;
+  children?: never;
+};
+export type ToggleInputProps = Omit<IToggleInput, "type" | "id"> & {
+  id: string;
+  children?: never;
+};
+export type ChoiceSetInputProps = Omit<IChoiceSetInput, "type" | "id"> & {
+  id: string;
+  children?: never;
+};
+export type SubmitActionProps = Omit<ISubmitAction, "type" | "data"> & {
+  /** Application data delivered separately as `ctx.action.value`. */
+  data?: JsonObject;
+  /** Required because an unhandled native submit is not useful to Channels. */
+  onSubmit: ClickHandler;
+  children?: never;
+};
+export type OpenUrlActionProps = Omit<IOpenUrlAction, "type"> & {
+  children?: never;
+};
+
+function createElement(
+  element: string,
+  props: Record<string, unknown>,
+): PlatformNode {
+  const { children, onSubmit, data, ...attributes } = props;
+  const node = platformNode({
+    protocol: 1,
+    platform: TEAMS_PLATFORM,
+    dialect: ADAPTIVE_CARD_DIALECT,
+    dialectVersion: TEAMS_ADAPTIVE_CARD_VERSION,
+    element,
+    attributes: withoutUndefined(attributes),
+    ...(children === undefined
+      ? {}
+      : { children: children as unknown as ChannelNode[] }),
+    ...(typeof onSubmit === "function"
+      ? { onSubmit: onSubmit as ClickHandler }
+      : {}),
+    ...(data === undefined ? {} : { value: data }),
+  });
+  return node;
+}
+
+function withoutUndefined(value: Record<string, unknown>): JsonObject {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  ) as JsonObject;
+}
+
+/** Root of a Teams 1.5 Adaptive Card. */
+export function AdaptiveCard(props: AdaptiveCardProps): PlatformNode {
+  return createElement("AdaptiveCard", props);
+}
+
+export function Container(props: ContainerProps): PlatformNode {
+  return createElement("Container", props);
+}
+
+export function ColumnSet(props: ColumnSetProps): PlatformNode {
+  return createElement("ColumnSet", props);
+}
+
+export function Column(props: ColumnProps): PlatformNode {
+  return createElement("Column", props);
+}
+
+export function ActionSet(props: ActionSetProps): PlatformNode {
+  return createElement("ActionSet", props);
+}
+
+export function TextBlock(props: TextBlockProps): PlatformNode {
+  return createElement("TextBlock", props);
+}
+
+export function RichTextBlock(props: RichTextBlockProps): PlatformNode {
+  return createElement("RichTextBlock", props);
+}
+
+export function TextRun(props: TextRunProps): PlatformNode {
+  return createElement("TextRun", props);
+}
+
+export function Image(props: ImageProps): PlatformNode {
+  return createElement("Image", props);
+}
+
+export function ImageSet(props: ImageSetProps): PlatformNode {
+  return createElement("ImageSet", props);
+}
+
+export function FactSet(props: FactSetProps): PlatformNode {
+  return createElement("FactSet", props);
+}
+
+export function Fact(props: FactProps): PlatformNode {
+  return createElement("Fact", props);
+}
+
+export function Table(props: TableProps): PlatformNode {
+  return createElement("Table", props);
+}
+
+export function TableRow(props: TableRowProps): PlatformNode {
+  return createElement("TableRow", props);
+}
+
+export function TableCell(props: TableCellProps): PlatformNode {
+  return createElement("TableCell", props);
+}
+
+function TextInput(props: TextInputProps): PlatformNode {
+  return createElement("Input.Text", props);
+}
+
+function NumberInput(props: NumberInputProps): PlatformNode {
+  return createElement("Input.Number", props);
+}
+
+function DateInput(props: DateInputProps): PlatformNode {
+  return createElement("Input.Date", props);
+}
+
+function TimeInput(props: TimeInputProps): PlatformNode {
+  return createElement("Input.Time", props);
+}
+
+function ToggleInput(props: ToggleInputProps): PlatformNode {
+  return createElement("Input.Toggle", props);
+}
+
+function ChoiceSetInput(props: ChoiceSetInputProps): PlatformNode {
+  return createElement("Input.ChoiceSet", props);
+}
+
+function SubmitAction(props: SubmitActionProps): PlatformNode {
+  return createElement("Action.Submit", props);
+}
+
+function OpenUrlAction(props: OpenUrlActionProps): PlatformNode {
+  return createElement("Action.OpenUrl", props);
+}
+
+/** Teams input components, matching Adaptive Card element names. */
+export const Input = {
+  Text: TextInput,
+  Number: NumberInput,
+  Date: DateInput,
+  Time: TimeInput,
+  Toggle: ToggleInput,
+  ChoiceSet: ChoiceSetInput,
+};
+
+/** Teams action components. `Action.Execute` is intentionally not exported. */
+export const Action = {
+  Submit: SubmitAction,
+  OpenUrl: OpenUrlAction,
+};
+
+/**
+ * Escape hatch for an already-authored card. It is deliberately data-only:
+ * callbacks must use `Action.Submit` JSX so Channels can bind them durably.
+ */
+export function rawAdaptiveCard(payload: unknown): {
+  raw: AdaptiveCardPayload;
+} {
+  assertAdaptiveCardPayload(payload);
+  return { raw: payload };
+}

--- a/packages/channels-teams/src/ui.ts
+++ b/packages/channels-teams/src/ui.ts
@@ -32,7 +32,6 @@ import type {
 } from "@copilotkit/channels-ui";
 import { RAW_ADAPTIVE_CARD_ELEMENT } from "./render/native-adaptive-card.js";
 import { assertAdaptiveCardPayload } from "./render/schema.js";
-import type { AdaptiveCardPayload } from "./render/schema.js";
 
 export const TEAMS_PLATFORM = "teams";
 export const ADAPTIVE_CARD_DIALECT = "adaptive-card";

--- a/packages/channels-teams/src/ui.ts
+++ b/packages/channels-teams/src/ui.ts
@@ -30,6 +30,7 @@ import type {
   JsonObject,
   PlatformNode,
 } from "@copilotkit/channels-ui";
+import { RAW_ADAPTIVE_CARD_ELEMENT } from "./render/native-adaptive-card.js";
 import { assertAdaptiveCardPayload } from "./render/schema.js";
 import type { AdaptiveCardPayload } from "./render/schema.js";
 
@@ -238,9 +239,14 @@ export const Action = {
  * Escape hatch for an already-authored card. It is deliberately data-only:
  * callbacks must use `Action.Submit` JSX so Channels can bind them durably.
  */
-export function rawAdaptiveCard(payload: unknown): {
-  raw: AdaptiveCardPayload;
-} {
+export function rawAdaptiveCard(payload: unknown): PlatformNode {
   assertAdaptiveCardPayload(payload);
-  return { raw: payload };
+  return platformNode({
+    protocol: 1,
+    platform: TEAMS_PLATFORM,
+    dialect: ADAPTIVE_CARD_DIALECT,
+    dialectVersion: TEAMS_ADAPTIVE_CARD_VERSION,
+    element: RAW_ADAPTIVE_CARD_ELEMENT,
+    attributes: payload as unknown as JsonObject,
+  });
 }

--- a/packages/channels-teams/src/ui.ts
+++ b/packages/channels-teams/src/ui.ts
@@ -31,7 +31,7 @@ import type {
   PlatformNode,
 } from "@copilotkit/channels-ui";
 import { RAW_ADAPTIVE_CARD_ELEMENT } from "./render/native-adaptive-card.js";
-import { assertAdaptiveCardPayload } from "./render/schema.js";
+import { assertRawAdaptiveCardPayload } from "./render/schema.js";
 
 export const TEAMS_PLATFORM = "teams";
 export const ADAPTIVE_CARD_DIALECT = "adaptive-card";
@@ -239,7 +239,7 @@ export const Action = {
  * callbacks must use `Action.Submit` JSX so Channels can bind them durably.
  */
 export function rawAdaptiveCard(payload: unknown): PlatformNode {
-  assertAdaptiveCardPayload(payload);
+  assertRawAdaptiveCardPayload(payload);
   return platformNode({
     protocol: 1,
     platform: TEAMS_PLATFORM,

--- a/packages/channels-ui/src/index.ts
+++ b/packages/channels-ui/src/index.ts
@@ -5,3 +5,4 @@ export * from "./bind.js";
 export * from "./components.js";
 export * from "./emoji.js";
 export * from "./modal.js";
+export * from "./platform.js";

--- a/packages/channels-ui/src/platform.test.ts
+++ b/packages/channels-ui/src/platform.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  findPlatformNodes,
+  platformNode,
+  PlatformUiMismatchError,
+  UnsupportedUiNodeError,
+  validatePlatformUi,
+} from "./platform.js";
+import type { ChannelNode, PlatformNode } from "./index.js";
+
+function teamsNode(
+  element: string,
+  children: ChannelNode[] = [],
+): PlatformNode {
+  return platformNode({
+    protocol: 1,
+    platform: "teams",
+    dialect: "adaptive-card",
+    dialectVersion: "1.5",
+    element,
+    attributes: {},
+    ...(children.length > 0 ? { children } : {}),
+  });
+}
+
+describe("platform-native IR", () => {
+  it("preserves platform nodes and their paths", () => {
+    const root = [teamsNode("AdaptiveCard", [teamsNode("TextBlock")])];
+
+    expect(findPlatformNodes(root)).toEqual([
+      { node: root[0], path: [0] },
+      { node: root[0]!.props.children![0], path: [0, "children", 0] },
+    ]);
+  });
+
+  it("rejects a native tree before it reaches another platform", () => {
+    expect(() =>
+      validatePlatformUi([teamsNode("AdaptiveCard")], "slack"),
+    ).toThrow(PlatformUiMismatchError);
+
+    try {
+      validatePlatformUi([teamsNode("AdaptiveCard")], "slack");
+    } catch (error) {
+      expect(error).toMatchObject({
+        actualPlatform: "slack",
+        expectedPlatform: "teams",
+        element: "AdaptiveCard",
+        path: [0],
+      });
+    }
+  });
+
+  it("rejects mixed portable and native UI", () => {
+    const portable: ChannelNode = { type: "section", props: {} };
+    expect(() =>
+      validatePlatformUi([teamsNode("AdaptiveCard", [portable])], "teams"),
+    ).toThrow(UnsupportedUiNodeError);
+  });
+
+  it("rejects trees that combine platform dialects", () => {
+    const otherDialect = platformNode({
+      protocol: 1,
+      platform: "teams",
+      dialect: "another-dialect",
+      dialectVersion: "1.5",
+      element: "Other",
+      attributes: {},
+    });
+
+    expect(() =>
+      validatePlatformUi([teamsNode("AdaptiveCard", [otherDialect])], "teams"),
+    ).toThrow(/mixed dialect tree/);
+  });
+});

--- a/packages/channels-ui/src/platform.ts
+++ b/packages/channels-ui/src/platform.ts
@@ -1,0 +1,199 @@
+import type { ChannelNode } from "./ir.js";
+import type { ClickHandler } from "./types.js";
+
+/** JSON values that can be carried in a platform-native UI node. */
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+export interface JsonObject {
+  [key: string]: JsonValue;
+}
+
+/**
+ * The serializable portion of a platform-native UI element. Handlers and their
+ * values deliberately remain top-level so the action registry can persist and
+ * recover them independently of the provider payload.
+ */
+export interface PlatformNodeProps extends Record<string, unknown> {
+  protocol: 1;
+  platform: string;
+  dialect: string;
+  dialectVersion: string;
+  element: string;
+  attributes: JsonObject;
+  children?: ChannelNode[];
+  onSubmit?: ClickHandler;
+  value?: unknown;
+}
+
+/** A reserved IR node for a platform-specific rendering dialect. */
+export interface PlatformNode extends Omit<ChannelNode, "type" | "props"> {
+  type: "$platform";
+  props: PlatformNodeProps;
+}
+
+export interface PlatformNodeVisit {
+  node: PlatformNode;
+  path: readonly (string | number)[];
+}
+
+/** Create a platform-native node without exposing the reserved IR marker. */
+export function platformNode(props: PlatformNodeProps): PlatformNode {
+  return { type: "$platform", props };
+}
+
+/** True when a Channel IR node is a platform-specific node. */
+export function isPlatformNode(node: ChannelNode): node is PlatformNode {
+  return node.type === "$platform";
+}
+
+/** Find every platform-native node in a tree, preserving its user-visible path. */
+export function findPlatformNodes(root: ChannelNode[]): PlatformNodeVisit[] {
+  const found: PlatformNodeVisit[] = [];
+  const visit = (nodes: ChannelNode[], base: (string | number)[]): void => {
+    for (let index = 0; index < nodes.length; index++) {
+      const node = nodes[index]!;
+      const path = [...base, index];
+      if (isPlatformNode(node)) found.push({ node, path });
+      const children = node.props.children;
+      if (Array.isArray(children)) {
+        visit(children as ChannelNode[], [...path, "children"]);
+      }
+    }
+  };
+  visit(root, []);
+  return found;
+}
+
+/** A native UI tree was posted through an adapter for a different platform. */
+export class PlatformUiMismatchError extends Error {
+  readonly actualPlatform: string;
+  readonly expectedPlatform: string;
+  readonly element: string;
+  readonly path: readonly (string | number)[];
+
+  constructor(args: {
+    actualPlatform: string;
+    expectedPlatform: string;
+    element: string;
+    path: readonly (string | number)[];
+  }) {
+    const path = formatPlatformPath(args.path);
+    super(
+      `Cannot render ${args.expectedPlatform}-native ${args.element} on ${args.actualPlatform} at ${path}. ` +
+        `Post portable UI for ${args.actualPlatform}, or branch on thread.platform.`,
+    );
+    this.name = "PlatformUiMismatchError";
+    this.actualPlatform = args.actualPlatform;
+    this.expectedPlatform = args.expectedPlatform;
+    this.element = args.element;
+    this.path = args.path;
+  }
+}
+
+/** A platform-native tree violates the shared IR contract. */
+export class UnsupportedUiNodeError extends Error {
+  readonly element: string;
+  readonly path: readonly (string | number)[];
+
+  constructor(args: {
+    element: string;
+    path: readonly (string | number)[];
+    reason: string;
+  }) {
+    super(
+      `Unsupported UI node ${args.element} at ${formatPlatformPath(args.path)}: ${args.reason}`,
+    );
+    this.name = "UnsupportedUiNodeError";
+    this.element = args.element;
+    this.path = args.path;
+  }
+}
+
+/**
+ * Validate shared invariants before an action handler is persisted. Adapters
+ * can rely on this boundary to reject a native tree before any side effect,
+ * rather than allowing their renderer to silently omit it.
+ */
+export function validatePlatformUi(
+  root: ChannelNode[],
+  actualPlatform: string,
+): void {
+  const nativeNodes = findPlatformNodes(root);
+  if (nativeNodes.length === 0) return;
+
+  const first = nativeNodes[0]!;
+  if (root.length !== 1 || !isPlatformNode(root[0]!)) {
+    throw new UnsupportedUiNodeError({
+      element: first.node.props.element,
+      path: first.path,
+      reason:
+        "portable and platform-native nodes cannot be mixed; a native post must have one native root",
+    });
+  }
+
+  const expectedPlatform = first.node.props.platform;
+  const dialect = first.node.props.dialect;
+  const dialectVersion = first.node.props.dialectVersion;
+
+  const visit = (nodes: ChannelNode[], base: (string | number)[]): void => {
+    for (let index = 0; index < nodes.length; index++) {
+      const node = nodes[index]!;
+      const path = [...base, index];
+      if (!isPlatformNode(node)) {
+        throw new UnsupportedUiNodeError({
+          element: String(node.type),
+          path,
+          reason: "portable and platform-native nodes cannot be mixed",
+        });
+      }
+      const props = node.props;
+      if (props.protocol !== 1) {
+        throw new UnsupportedUiNodeError({
+          element: props.element,
+          path,
+          reason: `platform UI protocol ${String(props.protocol)} is not supported`,
+        });
+      }
+      if (props.platform !== expectedPlatform) {
+        throw new UnsupportedUiNodeError({
+          element: props.element,
+          path,
+          reason: `mixed platform tree (${expectedPlatform} and ${props.platform})`,
+        });
+      }
+      if (
+        props.dialect !== dialect ||
+        props.dialectVersion !== dialectVersion
+      ) {
+        throw new UnsupportedUiNodeError({
+          element: props.element,
+          path,
+          reason: `mixed dialect tree (${dialect}@${dialectVersion} and ${props.dialect}@${props.dialectVersion})`,
+        });
+      }
+      const children = props.children;
+      if (Array.isArray(children)) visit(children, [...path, "children"]);
+    }
+  };
+
+  visit(root, []);
+
+  if (expectedPlatform !== actualPlatform) {
+    throw new PlatformUiMismatchError({
+      actualPlatform,
+      expectedPlatform,
+      element: first.node.props.element,
+      path: first.path,
+    });
+  }
+}
+
+export function formatPlatformPath(path: readonly (string | number)[]): string {
+  return path.reduce<string>(
+    (result, segment) =>
+      typeof segment === "number"
+        ? `${result}[${segment}]`
+        : `${result}.${segment}`,
+    "root",
+  );
+}

--- a/packages/channels-ui/src/platform.ts
+++ b/packages/channels-ui/src/platform.ts
@@ -36,6 +36,32 @@ export interface PlatformNodeVisit {
   path: readonly (string | number)[];
 }
 
+/**
+ * Dialect packages register their structural validator when their UI entrypoint
+ * is imported. Keeping this registry in the shared IR layer lets action binding
+ * reject invalid native trees before it persists any callbacks, without making
+ * channels-core depend on every platform package.
+ */
+export type PlatformUiValidator = (root: PlatformNode) => void;
+
+const platformUiValidators = new Map<string, PlatformUiValidator>();
+
+/** Register the structural validator for one platform-native UI dialect. */
+export function registerPlatformUiValidator(
+  platform: string,
+  dialect: string,
+  validator: PlatformUiValidator,
+): void {
+  const key = platformUiValidatorKey(platform, dialect);
+  const existing = platformUiValidators.get(key);
+  if (existing && existing !== validator) {
+    throw new Error(
+      `A platform UI validator is already registered for ${platform}/${dialect}.`,
+    );
+  }
+  platformUiValidators.set(key, validator);
+}
+
 /** Create a platform-native node without exposing the reserved IR marker. */
 export function platformNode(props: PlatformNodeProps): PlatformNode {
   return { type: "$platform", props };
@@ -186,6 +212,18 @@ export function validatePlatformUi(
       path: first.path,
     });
   }
+
+  const validator = platformUiValidators.get(
+    platformUiValidatorKey(expectedPlatform, dialect),
+  );
+  if (!validator) {
+    throw new UnsupportedUiNodeError({
+      element: first.node.props.element,
+      path: first.path,
+      reason: `no validator is registered for ${expectedPlatform}/${dialect}`,
+    });
+  }
+  validator(root[0]! as PlatformNode);
 }
 
 export function formatPlatformPath(path: readonly (string | number)[]): string {
@@ -196,4 +234,8 @@ export function formatPlatformPath(path: readonly (string | number)[]): string {
         : `${result}.${segment}`,
     "root",
   );
+}
+
+function platformUiValidatorKey(platform: string, dialect: string): string {
+  return `${platform}\u0000${dialect}`;
 }

--- a/packages/channels/package.json
+++ b/packages/channels/package.json
@@ -52,6 +52,10 @@
       "types": "./dist/ui.d.ts",
       "import": "./dist/ui.js"
     },
+    "./ui/teams": {
+      "types": "./dist/ui/teams.d.ts",
+      "import": "./dist/ui/teams.js"
+    },
     "./slack": {
       "types": "./dist/slack.d.ts",
       "import": "./dist/slack.js"
@@ -71,6 +75,10 @@
     "./teams/render": {
       "types": "./dist/teams/render.d.ts",
       "import": "./dist/teams/render.js"
+    },
+    "./teams/codec": {
+      "types": "./dist/teams/codec.d.ts",
+      "import": "./dist/teams/codec.js"
     },
     "./intelligence": {
       "types": "./dist/intelligence.d.ts",

--- a/packages/channels/src/teams/codec.ts
+++ b/packages/channels/src/teams/codec.ts
@@ -1,0 +1,1 @@
+export * from "@copilotkit/channels-teams/codec";

--- a/packages/channels/src/ui/teams.ts
+++ b/packages/channels/src/ui/teams.ts
@@ -1,0 +1,1 @@
+export * from "@copilotkit/channels-teams/ui";

--- a/packages/channels/src/umbrella.smoke.test.tsx
+++ b/packages/channels/src/umbrella.smoke.test.tsx
@@ -9,8 +9,34 @@ import { discord } from "@copilotkit/channels/discord";
 import { telegram } from "@copilotkit/channels/telegram";
 import { whatsapp } from "@copilotkit/channels/whatsapp";
 import { slackCodec } from "@copilotkit/channels/slack/codec";
+import { teamsCodec } from "@copilotkit/channels/teams/codec";
+import {
+  Action,
+  AdaptiveCard,
+  Input,
+  TextBlock,
+} from "@copilotkit/channels/ui/teams";
 import { renderSlackMessage } from "@copilotkit/channels/slack/render";
 import { renderAdaptiveCard } from "@copilotkit/channels/teams/render";
+
+// Compile-only coverage for the typed Teams-native JSX catalog through the
+// umbrella entrypoint. In particular, inputs require an `id` and submits
+// require a Channels callback.
+const typedTeamsCard = (
+  <AdaptiveCard>
+    <TextBlock text="Choose an environment" weight="Bolder" />
+    <Input.ChoiceSet
+      id="environment"
+      choices={[{ title: "Production", value: "production" }]}
+    />
+    <Action.Submit
+      title="Deploy"
+      data={{ intent: "deploy" }}
+      onSubmit={async () => undefined}
+    />
+  </AdaptiveCard>
+);
+void typedTeamsCard;
 
 describe("@copilotkit/channels umbrella", () => {
   it("exposes the existing engine, testing API, and JSX vocabulary", () => {
@@ -38,6 +64,8 @@ describe("@copilotkit/channels umbrella", () => {
       expect(typeof value).toBe("function");
     }
     expect(typeof slackCodec).toBe("object");
+    expect(typeof teamsCodec).toBe("object");
+    expect(typeof AdaptiveCard).toBe("function");
   });
 
   it("keeps Intelligence gateway and bootstrap internals private", () => {

--- a/packages/channels/tsconfig.check.json
+++ b/packages/channels/tsconfig.check.json
@@ -6,7 +6,11 @@
     "types": ["node"],
     "jsx": "react-jsx",
     "jsxImportSource": "@copilotkit/channels",
-    "paths": { "@copilotkit/channels/jsx-runtime": ["./src/jsx-runtime.ts"] }
+    "paths": {
+      "@copilotkit/channels/jsx-runtime": ["./src/jsx-runtime.ts"],
+      "@copilotkit/channels/teams/codec": ["./src/teams/codec.ts"],
+      "@copilotkit/channels/ui/teams": ["./src/ui/teams.ts"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["dist", "node_modules"]

--- a/packages/channels/tsconfig.json
+++ b/packages/channels/tsconfig.json
@@ -6,7 +6,11 @@
     "lib": ["es2022"],
     "jsx": "react-jsx",
     "jsxImportSource": "@copilotkit/channels",
-    "paths": { "@copilotkit/channels/jsx-runtime": ["./src/jsx-runtime.ts"] }
+    "paths": {
+      "@copilotkit/channels/jsx-runtime": ["./src/jsx-runtime.ts"],
+      "@copilotkit/channels/teams/codec": ["./src/teams/codec.ts"],
+      "@copilotkit/channels/ui/teams": ["./src/ui/teams.ts"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["dist", "node_modules"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2566,6 +2566,9 @@ importers:
       '@microsoft/agents-hosting':
         specifier: ^1.5.3
         version: 1.6.1(@opentelemetry/api@1.9.0)
+      '@microsoft/teams.cards':
+        specifier: 2.0.14
+        version: 2.0.14
       express:
         specifier: '>=4.20.0'
         version: 5.2.1
@@ -8979,6 +8982,10 @@ packages:
   '@microsoft/m365agentsplayground@0.2.27':
     resolution: {integrity: sha512-8MdQyAdKv1H56IjI1iGosRwS1MZatpbp+9OZg77LWOCmmlWQXMofOAU3PrbIwgBfW75oejaUlXkqnZMVQVJjDQ==}
     hasBin: true
+
+  '@microsoft/teams.cards@2.0.14':
+    resolution: {integrity: sha512-qrWnjJVgMPO8vvbLEiTeBLrrRLsr4rletQnuP9fPMXTTcrNx+Dh0gYWtQAOBvpoAuFo5tTXR/waNFNUm8IZtBw==}
+    engines: {node: '>=20'}
 
   '@mintlify/cli@4.0.864':
     resolution: {integrity: sha512-xJDFBgvmUn3lplOr8q2roFncdRuI74x9NTg5Y8LthhDuvxKpThtC1bZFQjKJa8uFS/b7d4n+6vi73E41oUODGw==}
@@ -25375,8 +25382,8 @@ packages:
   vue-component-type-helpers@3.3.1:
     resolution: {integrity: sha512-pu58kqxmVyEH6VfNYW1UyEfR3XAnJ27ZXT3yzXxxpjLxVzAbyC35Zk/nm/RMs7ijWnJNSd9fWkeex2OhUsx3MA==}
 
-  vue-component-type-helpers@3.3.7:
-    resolution: {integrity: sha512-Skkhw9agYSgsWqv7bxSOGJZa9SaiJbZVGdXuFWnrzKaQYHnw9qbjD630rw6RyMqDbp54nfLCLw5SZA55if7JLg==}
+  vue-component-type-helpers@3.3.8:
+    resolution: {integrity: sha512-troqCMmQodQDqUqn63NQaFi+CDSclSe7sc8VEBFqf5GFLqmGR2Ph3P2WEC7qwpRVyEWsTi/aAr4vyOe/B1hU3g==}
 
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
@@ -34865,6 +34872,8 @@ snapshots:
 
   '@microsoft/m365agentsplayground@0.2.27': {}
 
+  '@microsoft/teams.cards@2.0.14': {}
+
   '@mintlify/cli@4.0.864(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/node@25.6.0)(@types/react@19.1.8)(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@25.6.0)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@inquirer/prompts': 7.9.0(@types/node@25.6.0)
@@ -39426,7 +39435,7 @@ snapshots:
       storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.34(typescript@5.8.2)
-      vue-component-type-helpers: 3.3.7
+      vue-component-type-helpers: 3.3.8
 
   '@swc/core-darwin-arm64@1.15.8':
     optional: true
@@ -57289,7 +57298,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.1: {}
 
-  vue-component-type-helpers@3.3.7: {}
+  vue-component-type-helpers@3.3.8: {}
 
   vue-devtools-stub@0.1.0: {}
 


### PR DESCRIPTION
## Summary

Add Teams-native Adaptive Cards to Channels, including a typed JSX catalog, direct codec, durable submit envelope, and platform-safe IR delivery.

## Why

Teams needs to preserve native card schema and form submissions without silently falling back to portable UI or persisting an action before platform validation succeeds.

## How

- introduce reserved platform IR validation before ActionStore writes, with managed target-platform propagation
- add `@copilotkit/channels-teams/ui`, direct/umbrella codec exports, and Adaptive Card serialization
- validate raw/native card payloads, input IDs, submit callbacks, schema/version limits, and unsupported actions
- carry submitted form values through the reserved `__copilotkit` envelope while retaining legacy inbound parsing
- cover native serialization, interaction decoding, public exports, preflight behavior, and package type/export checks

Not included in this review slice: Connector Outbox lifecycle work, live Teams tenant smoke coverage, and docs/examples.