### PR TITLE
fix(showcase/ms-agent-dotnet): Instructions wiring + hashbrown/json-render/gen-ui/state demos

### DIFF
--- a/showcase/integrations/ms-agent-dotnet/agent/A2uiFixedSchemaAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/A2uiFixedSchemaAgent.cs
@@ -53,7 +53,7 @@ public class A2uiFixedSchemaAgent
         return new ChatClientAgent(
             chatClient,
             name: "A2uiFixedSchemaAgent",
-            description: @"You help users find flights. When asked about a flight, call
+            instructions: @"You help users find flights. When asked about a flight, call
 `display_flight` with origin, destination, airline, and price.
 Use short airport codes (e.g. ""SFO"", ""JFK"") for origin/destination and a price
 string like ""$289"". Keep any chat reply to one short sentence.",

--- a/showcase/integrations/ms-agent-dotnet/agent/BeautifulChatA2uiHelpers.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/BeautifulChatA2uiHelpers.cs
@@ -19,9 +19,35 @@ internal static class BeautifulChatA2ui
     internal const string DeclarativeGenUiCatalogId = "declarative-gen-ui-catalog";
 
     /// <summary>
-    /// Secondary-LLM system prompt for the beautiful-chat / app-dashboard catalog.
+    /// Secondary-LLM system prompt for the beautiful-chat / app-dashboard catalog
+    /// (includes DashboardCard, FlightCard, Badge, …).
     /// </summary>
     internal static string DesignSystemPrompt(string catalogId) =>
+        BuildDesignSystemPrompt(
+            catalogId,
+            allowedTypes:
+            "Metric, PieChart, BarChart, Card, Row, Column, Text, DashboardCard, " +
+            "DataTable, Badge, StatusBadge, InfoRow, PrimaryButton, Button, FlightCard");
+
+    /// <summary>
+    /// Secondary-LLM system prompt for declarative-gen-ui catalog only.
+    /// DashboardCard / FlightCard are NOT registered here — inventing them
+    /// paints "Unknown component: DashboardCard" on the client.
+    /// </summary>
+    internal static string DeclarativeGenUiDesignSystemPrompt() =>
+        BuildDesignSystemPrompt(
+            DeclarativeGenUiCatalogId,
+            allowedTypes:
+            "Metric, PieChart, BarChart, Card, Row, Column, Text, DataTable, " +
+            "StatusBadge, InfoRow, PrimaryButton") +
+        "\nComposition guidance:\n" +
+        "- KPI / dashboard snapshot → root Column of Metric tiles + optional PieChart/BarChart.\n" +
+        "- Team performance / quota → DataTable.\n" +
+        "- Risk / health → StatusBadge + InfoRow inside Card.\n" +
+        "- Single account details → Card with InfoRow children.\n" +
+        "- Never emit DashboardCard, SummaryCard, FlightCard, or Chart.\n";
+
+    private static string BuildDesignSystemPrompt(string catalogId, string allowedTypes) =>
         "You are an A2UI v0.9 component designer. Emit a single tool call whose\n" +
         "arguments are a JSON object matching this exact shape (no code fences,\n" +
         "no prose outside the tool arguments):\n\n" +
@@ -34,13 +60,10 @@ internal static class BeautifulChatA2ui
         "CRITICAL:\n" +
         "- catalogId MUST be exactly \"" + catalogId + "\". Never invent another id.\n" +
         "- For each component: set \"id\" to a unique string and \"component\" to the\n" +
-        "  type name as a STRING (e.g. \"Metric\", \"PieChart\", \"BarChart\", \"Card\",\n" +
-        "  \"Row\", \"Column\", \"Text\", \"DashboardCard\", \"DataTable\", \"Badge\",\n" +
-        "  \"StatusBadge\", \"InfoRow\", \"PrimaryButton\", \"Button\", \"FlightCard\").\n" +
+        "  type name as a STRING. Allowed types ONLY: " + allowedTypes + ".\n" +
         "  Put all props as top-level keys next to id/component.\n" +
         "- Exactly ONE component MUST have id \"root\" (the surface entry point).\n" +
-        "- Do NOT invent types like SummaryCard / KPICard / Chart that are not\n" +
-        "  listed above. Compose with Card + Metric + PieChart + BarChart instead.\n" +
+        "- Do NOT invent types outside the allowed list.\n" +
         "- Pass prop values as inline literals only. Keep top-level \"data\" as {}.\n" +
         "- Example component:\n" +
         "  {\"id\":\"m1\",\"component\":\"Metric\",\"label\":\"Revenue\",\"value\":\"$4.2M\",\"trend\":\"up\",\"trendValue\":\"+12%\"}\n";

--- a/showcase/integrations/ms-agent-dotnet/agent/BeautifulChatAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/BeautifulChatAgent.cs
@@ -138,7 +138,7 @@ internal sealed class BeautifulChatAgentFactory
         var chatClientAgent = new ChatClientAgent(
             chatClient,
             name: "BeautifulChatAgent",
-            description: @"You are a polished, professional demo assistant. Keep responses to 1-2 sentences.
+            instructions: @"You are a polished, professional demo assistant. Keep responses to 1-2 sentences.
 
 Tool guidance:
 - Flights: call search_flights to show flight cards with a pre-built schema. Return exactly 2 flights.

--- a/showcase/integrations/ms-agent-dotnet/agent/ByocHashbrownAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/ByocHashbrownAgent.cs
@@ -98,12 +98,21 @@ Example response (sales dashboard):
     {
         var chatClient = _openAiClient.GetChatClient("gpt-4o-mini").AsIChatClient();
 
-        // `description` on ChatClientAgent is passed to the chat client as the
-        // system-instruction equivalent, so it steers the model to emit a
-        // single <ui>...</ui> envelope for every response.
+        // Mirror langgraph-python: force JSON-object mode so the frontend's
+        // useJsonParser does not receive prose/code fences and bail to null.
+        // System prompts must go through `Instructions` (not Description) —
+        // Description is agent metadata only and is not sent to the model.
         return new ChatClientAgent(
             chatClient,
-            name: "ByocHashbrownAgent",
-            description: SystemPrompt);
+            new ChatClientAgentOptions
+            {
+                Name = "ByocHashbrownAgent",
+                Description = "Hashbrown structured UI demo agent",
+                Instructions = SystemPrompt,
+                ChatOptions = new ChatOptions
+                {
+                    ResponseFormat = ChatResponseFormat.Json,
+                },
+            });
     }
 }

--- a/showcase/integrations/ms-agent-dotnet/agent/ByocJsonRenderAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/ByocJsonRenderAgent.cs
@@ -166,12 +166,21 @@ Respond with the JSON object only.";
         var chatClient = _openAiClient.GetChatClient("gpt-4o-mini").AsIChatClient();
 
         // The frontend json-render-renderer.tsx buffers until the assistant
-        // content parses as a complete JSON object, then renders. The agent
-        // is steered to emit a single JSON object per reply by the
-        // SystemPrompt above.
+        // content parses as a complete JSON object, then renders. Force
+        // response_format=json_object (parity with LGP / built-in-agent) so
+        // the model cannot dump prose that falls through to the default
+        // text bubble. Instructions (not Description) carry the system prompt.
         return new ChatClientAgent(
             chatClient,
-            name: "ByocJsonRenderAgent",
-            description: SystemPrompt);
+            new ChatClientAgentOptions
+            {
+                Name = "ByocJsonRenderAgent",
+                Description = "json-render structured UI demo agent",
+                Instructions = SystemPrompt,
+                ChatOptions = new ChatOptions
+                {
+                    ResponseFormat = ChatResponseFormat.Json,
+                },
+            });
     }
 }

--- a/showcase/integrations/ms-agent-dotnet/agent/D5ParityAgents.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/D5ParityAgents.cs
@@ -41,7 +41,7 @@ public sealed class D5ParityAgentFactory
         var inner = new ChatClientAgent(
             _openAiClient.GetChatClient("gpt-4o-mini").AsIChatClient(),
             name: "GenUiToolBasedAgent",
-            description: """
+            instructions: """
                 You are a data visualization assistant.
                 When the user asks for a chart, call render_bar_chart or render_pie_chart
                 with a concise title, description, and data array of {label, value} items.
@@ -58,7 +58,7 @@ public sealed class D5ParityAgentFactory
         var inner = new ChatClientAgent(
             _openAiClient.GetChatClient("gpt-4o-mini").AsIChatClient(),
             name: "ReadonlyStateAgentContext",
-            description: "You are a helpful concise assistant. Use any frontend-provided context about the user when it is relevant.",
+            instructions: "You are a helpful concise assistant. Use any frontend-provided context about the user when it is relevant.",
             tools: []);
 
         return new ReadonlyContextAgent(inner, _loggerFactory.CreateLogger<ReadonlyContextAgent>());
@@ -90,7 +90,7 @@ public sealed class D5ParityAgentFactory
         var inner = new ChatClientAgent(
             _openAiClient.GetChatClient("gpt-4o-mini").AsIChatClient(),
             name: "GenUiAgent",
-            description: """
+            instructions: """
                 You are an agentic planner. For each user request, plan exactly 3 concrete
                 steps and call set_steps every time a step changes status. Walk each step
                 through pending, in_progress, and completed, then send one concise final
@@ -141,7 +141,7 @@ public sealed class D5ParityAgentFactory
         var inner = new ChatClientAgent(
             _openAiClient.GetChatClient("gpt-4o-mini").AsIChatClient(),
             name: "SharedStateStreamingAgent",
-            description: "You are a collaborative writing assistant. Whenever the user asks you to write, draft, or revise text, ALWAYS call write_document with the full content as a single string in the `document` argument. Never paste the document into a chat message directly - the document belongs in shared state and the UI renders it live as you type.",
+            instructions: "You are a collaborative writing assistant. Whenever the user asks you to write, draft, or revise text, ALWAYS call write_document with the full content as a single string in the `document` argument. Never paste the document into a chat message directly - the document belongs in shared state and the UI renders it live as you type.",
             tools: [writeDocument]);
 
         return new SnapshotAfterRunAgent<string>(
@@ -174,7 +174,7 @@ public sealed class D5ParityAgentFactory
         var inner = new ChatClientAgent(
             _openAiClient.GetChatClient("gpt-4o-mini").AsIChatClient(),
             name: reasoning ? "ToolRenderingReasoningChainAgent" : "ToolRenderingAgent",
-            description: reasoning ? ReasoningAgentFactory.SystemPrompt + "\n\n" + prompt : prompt,
+            instructions: reasoning ? ReasoningAgentFactory.SystemPrompt + "\n\n" + prompt : prompt,
             tools: tools);
 
         return reasoning
@@ -217,7 +217,7 @@ public sealed class D5ParityAgentFactory
         return new ChatClientAgent(
             _openAiClient.GetChatClient("gpt-4o-mini").AsIChatClient(),
             name: "HeadlessCompleteAgent",
-            description: prompt,
+            instructions: prompt,
             tools: tools);
     }
 
@@ -226,7 +226,7 @@ public sealed class D5ParityAgentFactory
         return new ChatClientAgent(
             _openAiClient.GetChatClient("gpt-4o-mini").AsIChatClient(),
             name: "VoiceAgent",
-            description: "You are a concise voice demo assistant. Answer directly and do not call tools.",
+            instructions: "You are a concise voice demo assistant. Answer directly and do not call tools.",
             tools: []);
     }
 

--- a/showcase/integrations/ms-agent-dotnet/agent/DeclarativeGenUiAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/DeclarativeGenUiAgent.cs
@@ -48,13 +48,28 @@ public class DeclarativeGenUiAgent
     {
         var chatClient = _openAiClient.GetChatClient("gpt-4o-mini").AsIChatClient();
 
+        // Instructions (not Description) is the system prompt ChatClientAgent
+        // actually sends to the model. Without it the agent narrates walls of
+        // text and only sometimes calls generate_a2ui.
         return new ChatClientAgent(
             chatClient,
+            instructions: """
+                You are the embedded sales analyst for a B2B company. Answer every
+                business question by calling `generate_a2ui` to draw a rich visual
+                surface, and keep the chat reply to ONE short sentence (or none).
+
+                Rules:
+                - ALWAYS call `generate_a2ui` once per user turn that needs a visual.
+                - Pass a short `context` string summarising what to render.
+                - Never invent component types outside the registered catalog
+                  (Card, Metric, PieChart, BarChart, DataTable, StatusBadge, InfoRow,
+                  PrimaryButton, Row, Column, Text). Use Card — never DashboardCard.
+                - Prefer PieChart for part-of-whole, BarChart for comparisons,
+                  DataTable for rankings, StatusBadge for risk, InfoRow for facts.
+                - Do NOT dump the UI as markdown/prose. The UI is the product.
+                """,
             name: "DeclarativeGenUiAgent",
-            description: @"You are an assistant that helps the user visualise information with dynamic UI.
-Whenever the user asks for a dashboard, chart, status report, or any rich visual output,
-ALWAYS call the `generate_a2ui` tool with a short natural-language description of what
-should be rendered. Keep any textual reply to one short sentence — the UI speaks for itself.",
+            description: "Declarative A2UI dynamic-schema demo agent",
             tools: [
                 AIFunctionFactory.Create(GenerateA2ui, options: new() { Name = "generate_a2ui", SerializerOptions = _jsonSerializerOptions })
             ]);
@@ -78,7 +93,7 @@ should be rendered. Keep any textual reply to one short sentence — the UI spea
         {
             content = await A2uiSecondaryToolCaller.GetDesignToolArgumentsAsync(
                 _configuration,
-                BeautifulChatA2ui.DesignSystemPrompt(BeautifulChatA2ui.DeclarativeGenUiCatalogId),
+                BeautifulChatA2ui.DeclarativeGenUiDesignSystemPrompt(),
                 userContent,
                 cancellationToken).ConfigureAwait(false);
         }

--- a/showcase/integrations/ms-agent-dotnet/agent/HitlInAppAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/HitlInAppAgent.cs
@@ -74,7 +74,7 @@ public sealed class HitlInAppAgentFactory
         return new ChatClientAgent(
             chatClient,
             name: "HitlInAppAgent",
-            description: SystemPrompt,
+            instructions: SystemPrompt,
             tools: []);
     }
 }

--- a/showcase/integrations/ms-agent-dotnet/agent/HitlInChatAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/HitlInChatAgent.cs
@@ -49,7 +49,7 @@ public sealed class HitlInChatAgentFactory
         return new ChatClientAgent(
             chatClient,
             name: "HitlInChatAgent",
-            description: SystemPrompt,
+            instructions: SystemPrompt,
             tools: []);
     }
 }

--- a/showcase/integrations/ms-agent-dotnet/agent/InterruptAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/InterruptAgent.cs
@@ -57,7 +57,7 @@ public sealed class InterruptAgentFactory
         var chatClientAgent = new ChatClientAgent(
             chatClient,
             name: "InterruptAgent",
-            description: @"You are a scheduling assistant. Whenever the user asks you to book a call
+            instructions: @"You are a scheduling assistant. Whenever the user asks you to book a call
 or schedule a meeting, you MUST call the `schedule_meeting` tool. Pass a short `topic`
 describing the purpose and `attendee` describing who the meeting is with. After the tool
 returns, confirm briefly whether the meeting was scheduled and at what time, or that the

--- a/showcase/integrations/ms-agent-dotnet/agent/McpAppsAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/McpAppsAgent.cs
@@ -73,7 +73,7 @@ public sealed class McpAppsAgentFactory
         return new ChatClientAgent(
             chatClient,
             name: "McpAppsAgent",
-            description: SystemPrompt,
+            instructions: SystemPrompt,
             tools: []);
     }
 }

--- a/showcase/integrations/ms-agent-dotnet/agent/MultimodalAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/MultimodalAgent.cs
@@ -54,7 +54,7 @@ internal static class MultimodalAgentFactory
         return new ChatClientAgent(
             chatClient,
             name: "MultimodalAgent",
-            description: SystemPrompt,
+            instructions: SystemPrompt,
             tools: []);
     }
 }

--- a/showcase/integrations/ms-agent-dotnet/agent/OpenGenUiAdvancedAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/OpenGenUiAdvancedAgent.cs
@@ -121,6 +121,6 @@ Generation guidance:
         return new ChatClientAgent(
             chatClient,
             name: "OpenGenUiAdvancedAgent",
-            description: SystemPrompt);
+            instructions: SystemPrompt);
     }
 }

--- a/showcase/integrations/ms-agent-dotnet/agent/OpenGenUiAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/OpenGenUiAgent.cs
@@ -81,6 +81,6 @@ rendered visualisation.";
         return new ChatClientAgent(
             chatClient,
             name: "OpenGenUiAgent",
-            description: SystemPrompt);
+            instructions: SystemPrompt);
     }
 }

--- a/showcase/integrations/ms-agent-dotnet/agent/Program.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/Program.cs
@@ -440,7 +440,7 @@ public class SalesAgentFactory
         var chatClientAgent = new ChatClientAgent(
             chatClient,
             name: "SalesAgent",
-            description: @"A helpful assistant that helps manage a sales pipeline.
+            instructions: @"A helpful assistant that helps manage a sales pipeline.
             You have tools available to get, update, and query sales data.
             You can search for flights and generate dynamic UI.
             When discussing deals or the pipeline, ALWAYS use the get_sales_todos tool to see the current state before mentioning, updating, or discussing deals with the user.",
@@ -486,7 +486,7 @@ public class SalesAgentFactory
         var inner = new ChatClientAgent(
             chatClient,
             name: "AgentConfigInner",
-            description: "You are a helpful assistant. Follow the tone, expertise, and response-length directives in the system message for each turn.",
+            instructions: "You are a helpful assistant. Follow the tone, expertise, and response-length directives in the system message for each turn.",
             tools: []);
         return new AgentConfigAgent(inner, _loggerFactory.CreateLogger<AgentConfigAgent>());
     }

--- a/showcase/integrations/ms-agent-dotnet/agent/ReasoningAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/ReasoningAgent.cs
@@ -285,7 +285,7 @@ internal static class ReasoningAgentFactory
         var inner = new ChatClientAgent(
             chatClient,
             name: "ReasoningAgent",
-            description: SystemPrompt);
+            instructions: SystemPrompt);
 
         return new ReasoningAgent(inner, loggerFactory.CreateLogger<ReasoningAgent>());
     }

--- a/showcase/integrations/ms-agent-dotnet/agent/SharedStateReadWriteAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/SharedStateReadWriteAgent.cs
@@ -672,8 +672,14 @@ public sealed class SharedStateReadWriteAgentFactory
 
         var inner = new ChatClientAgent(
             chatClient,
+            instructions:
+                "You are a helpful, concise assistant. User preferences are injected as a " +
+                "system message each turn — always respect them. When the user asks you to " +
+                "remember something (or shares a durable fact), call `set_notes` with the " +
+                "FULL updated list of short notes (existing + new). Keep each note short. " +
+                "Otherwise answer normally in one short paragraph.",
             name: "SharedStateReadWriteAgent",
-            description: "You read user preferences from shared state and write notes back via the set_notes tool.",
+            description: "Shared-state read/write demo agent",
             tools: [setNotes]);
 
         return new SharedStateReadWriteAgent(

--- a/showcase/integrations/ms-agent-dotnet/agent/SubagentsAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/SubagentsAgent.cs
@@ -396,7 +396,7 @@ public sealed class SubagentsAgentFactory
         var inner = new ChatClientAgent(
             chatClient,
             name: "SubagentsSupervisor",
-            description: SupervisorPrompt,
+            instructions: SupervisorPrompt,
             tools: [research, writing, critique]);
 
         return new SubagentsAgent(inner, _store, _loggerFactory.CreateLogger<SubagentsAgent>());

--- a/showcase/integrations/ms-agent-dotnet/manifest.yaml
+++ b/showcase/integrations/ms-agent-dotnet/manifest.yaml
@@ -57,6 +57,7 @@ features:
   - tool-rendering
   - tool-rendering-reasoning-chain
   - shared-state-read-write
+  - shared-state-streaming
   - subagents
   - readonly-state-agent-context
   - multimodal


### PR DESCRIPTION
## Summary

Fixes more **ms-agent-dotnet** (Agent Framework) staging failures against a real LLM.

### Root cause (load-bearing)

`ChatClientAgent` ctor is `(chatClient, instructions, name, description, tools, …)`.

Almost every agent in this integration passed the system prompt as **`description:`** (metadata only). The model received **null instructions**, so:

| Demo | Symptom |
|------|---------|
| shared-state-read-write | Pills appear to do nothing / no set_notes |
| declarative-hashbrown | Empty — frontend JSON parser rejects prose |
| declarative-json-render | Wall of text instead of rendered UI |
| declarative-gen-ui | Wall of text + invented `DashboardCard` on later pills |

### Fixes

1. **Global**: `description:` → `instructions:` for every ChatClientAgent system prompt in `ms-agent-dotnet/agent`.
2. **Hashbrown + json-render**: also set `ChatResponseFormat.Json` (same contract as langgraph-python's `response_format=json_object`).
3. **declarative-gen-ui**: catalog-specific secondary design prompt (Card, not DashboardCard/FlightCard) + stricter outer agent (always call `generate_a2ui`, one short sentence).
4. **shared-state-streaming**: add feature to `manifest.yaml` `features:` so the shell no longer shows **Backend fixture unavailable** for a demo that is already wired end-to-end.

### shared-state-streaming note

You *were* supposed to be able to open that link if the feature is supported — the page existed under `demos/` but was missing from `features:`, so the shell treated it as a non-runnable cell. That is fixed. (D6 fixture content for this slug is still thin vs LGP; live LLM path is the product path.)

## Test plan

- [x] `dotnet test` SharedStateAgent.Tests 79/79 (Docker SDK 9)
- [ ] Staging after deploy:
  - [ ] `/react/ms-agent-dotnet/shared-state-read-write/preview` — all three pills respond; Remember something updates notes
  - [ ] `/react/ms-agent-dotnet/shared-state-streaming/preview` — cell loads (not fixture-unavailable); document streams
  - [ ] `/react/ms-agent-dotnet/declarative-hashbrown/preview` — pills paint metrics/charts
  - [ ] `/react/ms-agent-dotnet/declarative-json-render/preview` — pills paint MetricCard/charts not raw text
  - [ ] `/react/ms-agent-dotnet/declarative-gen-ui/preview` — all four pills paint A2UI without DashboardCard error / wall of text