### PR TITLE
fix: remove all changesets

### DIFF
--- a/.changeset/coalesce-anthropic-same-role-messages.md
+++ b/.changeset/coalesce-anthropic-same-role-messages.md
@@ -1,9 +1,0 @@
----
-"@copilotkit/runtime": patch
----
-
-fix(runtime): coalesce consecutive same-role Anthropic messages before dispatch
-
-Fixes multi-turn conversations with Anthropic where a text + tool_use turn produced
-two consecutive assistant messages in the API payload, violating role-alternation and
-causing subsequent assistant responses to appear appended to the previous message.

--- a/.changeset/fix-parallel-tool-order.md
+++ b/.changeset/fix-parallel-tool-order.md
@@ -1,5 +1,0 @@
----
-"@copilotkit/core": patch
----
-
-fix(core): preserve tool result ordering for parallel frontend tool calls


### PR DESCRIPTION
Recently we made a few commits that let in some changesets. As a result, agents now frequently try to add them to every change that gets made to CopilotKit. Likely this was just an old branch and review didn't catch them getting merged in.

Immediate remediation is to just remove the folder and make this commit message so future agents can find the decision in commit history.
