### PR TITLE
fix(channels): treat a revoked delivery lease as fenced and make gateway outages diagnosable (refs OSS-670)

### DIFF
--- a/packages/channels-intelligence/src/http-transports.test.ts
+++ b/packages/channels-intelligence/src/http-transports.test.ts
@@ -551,6 +551,35 @@ describe("HttpDeliverySource", () => {
     });
   });
 
+  it("abandon retires the lease record without posting anything", async () => {
+    // The fenced path (OSS-670): the adapter swallows the revoked-lease error, so
+    // runLoop sees a successful turn and neither ack nor nack — the only other
+    // branches that drop the lease — ever runs. `abandon` must free the record
+    // itself, and must not put an intent the fence would reject on the wire.
+    const logs: string[] = [];
+    const { fetch, calls } = fakeFetch((c) =>
+      c.url.endsWith("/claim")
+        ? { body: { claimed: true, delivery: claimedDelivery() } }
+        : { body: {} },
+    );
+    const src = new HttpDeliverySource(
+      cfg({ fetch, log: (m) => logs.push(m) }),
+    );
+    await src.claimOnce();
+    expect(src.leaseTokenFor("dlv_9")).toBe("lease_z");
+
+    src.abandon("dlv_9", "lease revoked mid-turn");
+
+    expect(src.leaseTokenFor("dlv_9")).toBeUndefined();
+    expect(src.scopeFor("dlv_9")).toBeUndefined();
+    expect(calls.filter((c) => c.url.includes("/deliveries/"))).toHaveLength(0);
+    // With the record gone, a later ack/nack for the same delivery is a no-op
+    // rather than a doomed intent — proof the state was retired, not orphaned.
+    await src.nack("dlv_9", "boom");
+    expect(calls.filter((c) => c.url.includes("/deliveries/"))).toHaveLength(0);
+    expect(logs.some((m) => m.includes("nack: no lease"))).toBe(true);
+  });
+
   it("nacks (non-retryable) an unmappable delivery kind instead of wedging the loop", async () => {
     const { fetch, calls } = fakeFetch((c) =>
       c.url.endsWith("/claim")

--- a/packages/channels-intelligence/src/http-transports.ts
+++ b/packages/channels-intelligence/src/http-transports.ts
@@ -526,6 +526,21 @@ export class HttpDeliverySource implements DeliverySource {
     );
   }
 
+  /**
+   * Retire a delivery's lease record without POSTing anything — see
+   * {@link DeliverySource.abandon}. On the fenced path the adapter's `dispatch`
+   * resolves normally, so `runLoop` sees a successful turn and neither `ack` nor
+   * `nack` runs: this is the only thing that drops the record, and without it
+   * every fence leaks a lease token + scope for the process's lifetime.
+   */
+  abandon(deliveryId: string, reason: string): void {
+    if (!this.leases.delete(deliveryId)) {
+      this.cfg.log?.(
+        `intelligence abandon: no lease for delivery ${deliveryId} (${reason})`,
+      );
+    }
+  }
+
   // fetchFile / getHistory / uploadFile delegate to the shared
   // IntelligenceFileHistoryClient so the HTTP and realtime transports stay in
   // lockstep (OSS-476). See {@link IntelligenceFileHistoryClient}.

--- a/packages/channels-intelligence/src/in-memory-transports.ts
+++ b/packages/channels-intelligence/src/in-memory-transports.ts
@@ -66,6 +66,9 @@ export class InMemoryRenderEventSink implements RenderEventSink {
 export class InMemoryDeliverySource implements DeliverySource {
   readonly acked: string[] = [];
   readonly nacked: { deliveryId: string; reason: string }[] = [];
+  /** Every `abandon` call, in order — a fenced delivery must retire its lease
+   * state here rather than through ack/nack (see {@link DeliverySource.abandon}). */
+  readonly abandoned: { deliveryId: string; reason: string }[] = [];
   /** Seed by handle so a turn's file refs hydrate into content parts. */
   readonly files = new Map<string, { bytes: Uint8Array; mimeType?: string }>();
   /**
@@ -105,6 +108,9 @@ export class InMemoryDeliverySource implements DeliverySource {
   }
   async nack(deliveryId: string, reason: string): Promise<void> {
     this.nacked.push({ deliveryId, reason });
+  }
+  abandon(deliveryId: string, reason: string): void {
+    this.abandoned.push({ deliveryId, reason });
   }
   async fetchFile(
     handle: string,

--- a/packages/channels-intelligence/src/intelligence-adapter.test.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.test.ts
@@ -115,6 +115,29 @@ describe("intelligenceAdapter — ingress dispatch", () => {
     expect(source.nacked.map((n) => n.deliveryId)).toEqual(["d9"]);
   });
 
+  it("abandons (not nacks) the delivery when the lease was revoked mid-turn", async () => {
+    const source = new InMemoryDeliverySource();
+    const egress = new InMemoryEgressSink();
+    const bot = createChannel({
+      adapters: [intelligenceAdapter({ source, egress })],
+      agent: () => new FakeAgent(),
+    });
+    bot.onMessage(async () => {
+      throw Object.assign(new Error("push failed"), {
+        code: "CHANNEL_DELIVERY_LEASE_INVALID",
+      });
+    });
+    await bot.ɵruntime.start();
+    await source.deliver(envelope({ deliveryId: "d9" }));
+
+    // Fenced: another owner holds the delivery, so no intent can land and
+    // app-api owns redelivery — but the source's per-delivery lease state must
+    // still be retired, which only `abandon` does on this path (OSS-670).
+    expect(source.acked).toEqual([]);
+    expect(source.nacked).toEqual([]);
+    expect(source.abandoned.map((a) => a.deliveryId)).toEqual(["d9"]);
+  });
+
   it("drops the per-turn render flusher after dispatch", async () => {
     const source = new InMemoryDeliverySource();
     const egress = new InMemoryEgressSink();

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -60,6 +60,11 @@ import {
 const PERMANENT_RENDER_BATCH_ERROR_CODES = new Set([
   "CHANNEL_RENDER_BATCH_CONFLICT",
   "CHANNEL_RENDER_SEQUENCE_GAP",
+  // A revoked/superseded lease can never accept another batch: app-api fences
+  // every intent on `leased_until > now() AND lease_token_hash`, so retrying
+  // only spends the backoff ladder against a lease that is already gone
+  // (OSS-670).
+  "CHANNEL_DELIVERY_LEASE_INVALID",
 ]);
 
 /** Return whether retrying the same render batch cannot succeed. */

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -25,6 +25,7 @@ import type {
   RenderEventSink,
   AgentMessage,
 } from "./transports.js";
+import { isLeaseRevoked } from "./transports.js";
 import type {
   ChannelIngressEnvelope,
   EgressOp,
@@ -465,10 +466,21 @@ export class IntelligenceAdapter implements PlatformAdapter {
       await this.finalizeRenderedTurn(env);
       turnProcessed = true;
     } catch (err) {
-      await this.requireSource().nack(
-        env.deliveryId,
-        err instanceof Error ? err.message : String(err),
-      );
+      if (isLeaseRevoked(err)) {
+        // This delivery's lease was revoked mid-turn, so another owner holds it
+        // now and app-api owns redelivery. A nack here would send a `fail` the
+        // same fence rejects — the doomed intent whose 409 used to be reported
+        // as a turn failure, with a generic error reaching the end user
+        // (OSS-670). Stay quiet; this is not the user's problem.
+        this.opts.config?.log?.(
+          `intelligence delivery ${env.deliveryId} lease revoked mid-turn; abandoning (app-api owns redelivery)`,
+        );
+      } else {
+        await this.requireSource().nack(
+          env.deliveryId,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
     } finally {
       // Drop the per-turn state once the turn is fully processed (renderer
       // chain drained inside dispatchTo) so the Map can't grow unbounded over a

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -472,6 +472,19 @@ export class IntelligenceAdapter implements PlatformAdapter {
         // same fence rejects — the doomed intent whose 409 used to be reported
         // as a turn failure, with a generic error reaching the end user
         // (OSS-670). Stay quiet; this is not the user's problem.
+        //
+        // Retire the source's lease state explicitly. Swallowing the error here
+        // means the source sees a SUCCESSFUL onDelivery, so neither its own
+        // revoked-lease branch nor `ack` below runs — and those are the only
+        // other places the lease record is dropped. Without this the lease
+        // token, delivery scope and accepted-seq high-water marks are retained
+        // for a delivery we can never speak for again (app-api may already have
+        // handed it to another runtime, so the id may never be seen here again),
+        // leaking once per fence until the process exits.
+        this.requireSource().abandon?.(
+          env.deliveryId,
+          "lease revoked mid-turn",
+        );
         this.opts.config?.log?.(
           `intelligence delivery ${env.deliveryId} lease revoked mid-turn; abandoning (app-api owns redelivery)`,
         );

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.ts
@@ -138,7 +138,10 @@ export async function startChannelsWithGatewaySession(
   const observableSession = opts.session as Partial<{
     onClose(cb: () => void): void;
     onStateChange(
-      cb: (state: "online" | "reconnecting" | "gave_up" | "fenced") => void,
+      cb: (
+        state: "online" | "reconnecting" | "gave_up" | "fenced",
+        detail?: { reason?: string; code?: string },
+      ) => void,
     ): void;
   }>;
   // Call the seams ON the session (not via detached references) so a
@@ -156,6 +159,7 @@ export async function startChannelsWithGatewaySession(
             onStateChange: (
               cb: (
                 state: "online" | "reconnecting" | "gave_up" | "fenced",
+                detail?: { reason?: string; code?: string },
               ) => void,
             ) => observableSession.onStateChange!(cb),
           }
@@ -306,7 +310,10 @@ export async function startChannelsOverRealtimeGateway(
     // so they stay correct even if that helper's internals change.
     onClose: (cb: () => void) => session.onClose(cb),
     onStateChange: (
-      cb: (state: "online" | "reconnecting" | "gave_up" | "fenced") => void,
+      cb: (
+        state: "online" | "reconnecting" | "gave_up" | "fenced",
+        detail?: { reason?: string; code?: string },
+      ) => void,
     ) => session.onStateChange(cb),
     stop: async () => {
       // Always close the connection even if stopping the channels throws — the

--- a/packages/channels-intelligence/src/realtime-gateway-transport.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-transport.ts
@@ -186,6 +186,26 @@ const DELIVERY_AVAILABLE = "channel.delivery.available.v1";
 const COMPLETE_REQUESTED = "channel.delivery.complete_requested.v1";
 const DELIVERY_FAIL = "channel.delivery.fail.v1";
 
+/**
+ * app-api's lease fence: another owner holds this delivery. Every intent —
+ * render batch, complete, fail — is validated against `leased_until > now()`
+ * AND the lease-token hash, so once a lease is revoked (the listener was
+ * released under a gateway restart, or a replacement runtime re-leased the
+ * work) NOTHING this transport can send for that delivery will be accepted.
+ * Redelivery is app-api's job, so the only correct move is to drop our state
+ * quietly (OSS-670).
+ */
+const LEASE_REVOKED_CODE = "CHANNEL_DELIVERY_LEASE_INVALID";
+
+/** Whether an error is app-api's revoked-lease fence (see {@link LEASE_REVOKED_CODE}). */
+function isLeaseRevoked(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: unknown }).code === LEASE_REVOKED_CODE
+  );
+}
+
 /** Per-delivery state the transport needs to build completion/fail intents. */
 interface DeliveryState {
   turnId: string;
@@ -386,6 +406,21 @@ export class RealtimeGatewayTransport
         `realtime gateway turn ${env.turnId} exceeded ${this.deliveryTimeoutMs}ms`,
       );
     } catch (err) {
+      if (isLeaseRevoked(err)) {
+        // Nacking here would send a `fail` the same fence rejects, and that
+        // second 409 is what used to surface as "nack after turn failure
+        // failed" followed by "no delivery state". Drop the state and report
+        // the real condition once.
+        this.deliveries.delete(env.deliveryId);
+        this.log?.(
+          "realtime gateway delivery lease revoked; abandoning (app-api owns redelivery)",
+          {
+            deliveryId: env.deliveryId,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        );
+        return;
+      }
       this.log?.("realtime gateway turn failed/timed out; nacking", {
         deliveryId: env.deliveryId,
         error: err instanceof Error ? err.message : String(err),
@@ -676,27 +711,37 @@ export class RealtimeGatewayTransport
     const lastAccepted = accepted[accepted.length - 1];
     // Claim the terminal signal BEFORE the wire call (XOR with ack) — see ack().
     this.deliveries.delete(deliveryId);
-    await this.session.push(DELIVERY_FAIL, {
-      type: DELIVERY_FAIL,
-      occurredAt: this.now(),
-      payload: {
-        ...state.scope,
-        deliveryId,
-        turnId: state.turnId,
-        runtimeInstanceId: this.runtimeInstanceId,
-        leaseToken: state.leaseToken,
-        ...(retryable ? { deliveryStatus: "retry_wait" } : {}),
-        ...(lastAccepted ? { lastAccepted } : {}),
-        failedAt: this.now(),
-        // Bound the reason (parity with HttpDeliverySource.nack) so a long
-        // error/stack isn't sent verbatim over the gateway socket.
-        error: {
-          code: "runtime_error",
-          message: (reason || "runtime error").slice(0, 500),
-          retryable,
+    try {
+      await this.session.push(DELIVERY_FAIL, {
+        type: DELIVERY_FAIL,
+        occurredAt: this.now(),
+        payload: {
+          ...state.scope,
+          deliveryId,
+          turnId: state.turnId,
+          runtimeInstanceId: this.runtimeInstanceId,
+          leaseToken: state.leaseToken,
+          ...(retryable ? { deliveryStatus: "retry_wait" } : {}),
+          ...(lastAccepted ? { lastAccepted } : {}),
+          failedAt: this.now(),
+          // Bound the reason (parity with HttpDeliverySource.nack) so a long
+          // error/stack isn't sent verbatim over the gateway socket.
+          error: {
+            code: "runtime_error",
+            message: (reason || "runtime error").slice(0, 500),
+            retryable,
+          },
         },
-      },
-    });
+      });
+    } catch (err) {
+      if (!isLeaseRevoked(err)) throw err;
+      // The fence already moved this delivery to another owner; a fail we
+      // cannot land is not a caller error.
+      this.log?.(
+        "realtime gateway fail intent fenced by a revoked lease; dropping",
+        { deliveryId, reason },
+      );
+    }
   }
 
   async stop(): Promise<void> {

--- a/packages/channels-intelligence/src/realtime-gateway-transport.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-transport.ts
@@ -25,6 +25,7 @@ import type {
   RenderEventSink,
   AgentMessage,
 } from "./transports.js";
+import { isLeaseRevoked } from "./transports.js";
 import type {
   ChannelIngressEnvelope,
   ChannelDeliveryScope,
@@ -185,26 +186,6 @@ const RENDER_BATCH_ACCEPTED = "channel.render_batch_accepted.v1";
 const DELIVERY_AVAILABLE = "channel.delivery.available.v1";
 const COMPLETE_REQUESTED = "channel.delivery.complete_requested.v1";
 const DELIVERY_FAIL = "channel.delivery.fail.v1";
-
-/**
- * app-api's lease fence: another owner holds this delivery. Every intent —
- * render batch, complete, fail — is validated against `leased_until > now()`
- * AND the lease-token hash, so once a lease is revoked (the listener was
- * released under a gateway restart, or a replacement runtime re-leased the
- * work) NOTHING this transport can send for that delivery will be accepted.
- * Redelivery is app-api's job, so the only correct move is to drop our state
- * quietly (OSS-670).
- */
-const LEASE_REVOKED_CODE = "CHANNEL_DELIVERY_LEASE_INVALID";
-
-/** Whether an error is app-api's revoked-lease fence (see {@link LEASE_REVOKED_CODE}). */
-function isLeaseRevoked(err: unknown): boolean {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    (err as { code?: unknown }).code === LEASE_REVOKED_CODE
-  );
-}
 
 /** Per-delivery state the transport needs to build completion/fail intents. */
 interface DeliveryState {

--- a/packages/channels-intelligence/src/realtime-gateway-transport.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-transport.ts
@@ -392,7 +392,7 @@ export class RealtimeGatewayTransport
         // second 409 is what used to surface as "nack after turn failure
         // failed" followed by "no delivery state". Drop the state and report
         // the real condition once.
-        this.deliveries.delete(env.deliveryId);
+        this.abandon(env.deliveryId, "lease revoked mid-turn");
         this.log?.(
           "realtime gateway delivery lease revoked; abandoning (app-api owns redelivery)",
           {
@@ -722,6 +722,23 @@ export class RealtimeGatewayTransport
         "realtime gateway fail intent fenced by a revoked lease; dropping",
         { deliveryId, reason },
       );
+    }
+  }
+
+  /**
+   * Retire a delivery's {@link DeliveryState} without sending anything — see
+   * {@link DeliverySource.abandon}. Reached when the lease was revoked mid-turn,
+   * whether the fence surfaced here (a direct-source run) or was swallowed by
+   * `IntelligenceAdapter.dispatch` (production, where `dispatch` resolves
+   * normally on the fenced path so neither the catch below nor `ack` runs and
+   * this is the ONLY thing that frees the lease token, scope and accepted map).
+   */
+  abandon(deliveryId: string, reason: string): void {
+    if (!this.deliveries.delete(deliveryId)) {
+      this.log?.("realtime gateway abandon: no delivery state", {
+        deliveryId,
+        reason,
+      });
     }
   }
 

--- a/packages/channels-intelligence/src/realtime-gateway.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.test.ts
@@ -1368,3 +1368,40 @@ describe("connectRealtimeGateway — unreachable gateway host (OSS-623)", () => 
     session.disconnect();
   });
 });
+
+describe("connection-health detail (OSS-670)", () => {
+  it("reports the drop cause alongside reconnecting/gave_up", async () => {
+    const { FakeWebSocket, instances } = makeFakeWebSocket("ok-then-silent");
+    const session = await connectRealtimeGateway({
+      wsUrl: "wss://gateway.example/runner",
+      apiKey: "cpk-test",
+      projectId: 7,
+      join: {
+        runtimeInstanceId: "rti_1",
+        declaredChannels: [{ channelName: "opentag", adapter: "slack" }],
+        observedAt: "2026-07-10T00:00:00.000Z",
+      },
+      webSocket: FakeWebSocket,
+      reconnectGiveUpMs: 40,
+    });
+
+    const seen: {
+      state: RealtimeGatewayConnectionState;
+      detail?: { reason?: string; code?: string };
+    }[] = [];
+    session.onStateChange((state, detail) => seen.push({ state, detail }));
+
+    // A transport error with an OS code, then the drop it belongs to.
+    instances[0]!.onerror?.(
+      Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+    );
+    instances[0]!.onclose?.();
+    await waitUntil(() => seen.some((s) => s.state === "gave_up"));
+
+    const gaveUp = seen.find((s) => s.state === "gave_up")!;
+    expect(gaveUp.detail?.code).toBe("ECONNRESET");
+    expect(gaveUp.detail?.reason).toContain("ECONNRESET");
+
+    session.disconnect();
+  });
+});

--- a/packages/channels-intelligence/src/realtime-gateway.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.test.ts
@@ -1404,4 +1404,44 @@ describe("connection-health detail (OSS-670)", () => {
 
     session.disconnect();
   });
+
+  it("probes the endpoint when a reconnect is refused and names the cause", async () => {
+    const { FakeWebSocket, instances } = makeFakeWebSocket("ok-then-silent");
+    const session = await connectRealtimeGateway({
+      wsUrl: "wss://gateway.example/runner",
+      apiKey: "cpk-test",
+      projectId: 7,
+      join: {
+        runtimeInstanceId: "rti_1",
+        declaredChannels: [{ channelName: "opentag", adapter: "slack" }],
+        observedAt: "2026-07-10T00:00:00.000Z",
+      },
+      webSocket: FakeWebSocket,
+      reconnectGiveUpMs: 40,
+      // The host is up and answers HTTP; only the WS upgrade is refused — the
+      // signature of a rejected runner credential.
+      diagnosticFetch: (async () =>
+        new Response("", { status: 403 })) as typeof fetch,
+    });
+
+    const seen: {
+      state: RealtimeGatewayConnectionState;
+      detail?: { reason?: string; code?: string };
+    }[] = [];
+    session.onStateChange((state, detail) => seen.push({ state, detail }));
+
+    instances[0]!.onerror?.(new Error("Received network error"));
+    instances[0]!.onclose?.();
+    await waitUntil(() =>
+      seen.some((s) => s.detail?.reason?.includes("refused the WebSocket")),
+    );
+
+    const named = seen.find((s) =>
+      s.detail?.reason?.includes("refused the WebSocket"),
+    )!;
+    expect(named.detail!.reason).toContain("403");
+    expect(named.detail!.reason).toMatch(/API key/i);
+
+    session.disconnect();
+  });
 });

--- a/packages/channels-intelligence/src/realtime-gateway.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.test.ts
@@ -1405,6 +1405,89 @@ describe("connection-health detail (OSS-670)", () => {
     session.disconnect();
   });
 
+  it("does not attribute a later outage to the previous one's cause", async () => {
+    const { FakeWebSocket, instances, control } = makeFakeWebSocket(
+      "give-up-then-recover",
+    );
+    const session = await connectRealtimeGateway({
+      wsUrl: "wss://gateway.example/runner",
+      apiKey: "cpk-test",
+      projectId: 7,
+      join: {
+        runtimeInstanceId: "rti_1",
+        declaredChannels: [{ channelName: "opentag", adapter: "slack" }],
+        observedAt: "2026-07-10T00:00:00.000Z",
+      },
+      webSocket: FakeWebSocket,
+      reconnectGiveUpMs: 40,
+      timeoutMs: 50,
+    });
+
+    const seen: {
+      state: RealtimeGatewayConnectionState;
+      detail?: { reason?: string; code?: string };
+    }[] = [];
+    session.onStateChange((state, detail) => seen.push({ state, detail }));
+
+    // Outage 1 reports a concrete OS code, then heals.
+    instances[0]!.onerror?.(
+      Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+    );
+    instances[0]!.onclose?.();
+    control.recover = true;
+    await waitUntil(() => seen.some((s) => s.state === "online"), 8000);
+
+    // Outage 2 is a clean close that reports NOTHING. Inheriting outage 1's
+    // cause would send an operator chasing an error that already healed.
+    const afterOnline = seen.length;
+    instances[instances.length - 1]!.onclose?.();
+    await waitUntil(
+      () => seen.slice(afterOnline).some((s) => s.state === "reconnecting"),
+      8000,
+    );
+
+    const second = seen
+      .slice(afterOnline)
+      .find((s) => s.state === "reconnecting")!;
+    expect(second.detail?.code).toBeUndefined();
+    expect(second.detail?.reason ?? "").not.toContain("ECONNRESET");
+
+    session.disconnect();
+  });
+
+  it("reports an unhealthy gateway as unhealthy, not as a bad credential", async () => {
+    const { FakeWebSocket, instances } = makeFakeWebSocket("ok-then-silent");
+    const session = await connectRealtimeGateway({
+      wsUrl: "wss://gateway.example/runner",
+      apiKey: "cpk-test",
+      projectId: 7,
+      join: {
+        runtimeInstanceId: "rti_1",
+        declaredChannels: [{ channelName: "opentag", adapter: "slack" }],
+        observedAt: "2026-07-10T00:00:00.000Z",
+      },
+      webSocket: FakeWebSocket,
+      reconnectGiveUpMs: 40,
+      // A gateway mid-rolling-restart: reachable, answering 503. Telling an
+      // operator to rotate a working API key here is worse than saying nothing.
+      diagnosticFetch: (async () =>
+        new Response("", { status: 503 })) as typeof fetch,
+    });
+
+    const seen: { reason?: string }[] = [];
+    session.onStateChange((_state, detail) => seen.push({ ...detail }));
+
+    instances[0]!.onerror?.(new Error("Received network error"));
+    instances[0]!.onclose?.();
+    await waitUntil(() => seen.some((s) => s.reason?.includes("503")));
+
+    const named = seen.find((s) => s.reason?.includes("503"))!;
+    expect(named.reason).toMatch(/reachable but not healthy/i);
+    expect(named.reason).not.toMatch(/API key/i);
+
+    session.disconnect();
+  });
+
   it("probes the endpoint when a reconnect is refused and names the cause", async () => {
     const { FakeWebSocket, instances } = makeFakeWebSocket("ok-then-silent");
     const session = await connectRealtimeGateway({
@@ -1433,11 +1516,11 @@ describe("connection-health detail (OSS-670)", () => {
     instances[0]!.onerror?.(new Error("Received network error"));
     instances[0]!.onclose?.();
     await waitUntil(() =>
-      seen.some((s) => s.detail?.reason?.includes("refused the WebSocket")),
+      seen.some((s) => s.detail?.reason?.includes("handshake was refused")),
     );
 
     const named = seen.find((s) =>
-      s.detail?.reason?.includes("refused the WebSocket"),
+      s.detail?.reason?.includes("handshake was refused"),
     )!;
     expect(named.detail!.reason).toContain("403");
     expect(named.detail!.reason).toMatch(/API key/i);

--- a/packages/channels-intelligence/src/realtime-gateway.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.ts
@@ -106,6 +106,20 @@ export type RealtimeGatewayConnectionState =
   | "gave_up"
   | "fenced";
 
+/**
+ * Why a connection-health transition happened. Present on `reconnecting` and
+ * `gave_up` when the transport (or the endpoint probe in
+ * {@link connectRealtimeGateway}) reported something; absent on `online` and
+ * whenever nothing was reported. Contains no secrets — the auth token travels as
+ * a WebSocket subprotocol, never in a URL or an error message.
+ */
+export interface RealtimeGatewayConnectionDetail {
+  /** Rendered cause, phrased for whoever operates the runtime. */
+  reason?: string;
+  /** OS-level code behind the failure, when the transport exposed one. */
+  code?: string;
+}
+
 const LISTENER_FENCED_EVENT = "channel.listener_fenced.v1";
 
 /**
@@ -461,7 +475,12 @@ export interface ConnectedRealtimeGatewaySession extends RealtimeGatewaySession 
    * {@link onClose}, which is a single per-episode drop breadcrumb; this observer
    * tracks the full health lifecycle so a manager's `status()` can reflect it.
    */
-  onStateChange(cb: (state: RealtimeGatewayConnectionState) => void): void;
+  onStateChange(
+    cb: (
+      state: RealtimeGatewayConnectionState,
+      detail?: RealtimeGatewayConnectionDetail,
+    ) => void,
+  ): void;
 }
 
 /**
@@ -536,6 +555,10 @@ export async function connectRealtimeGateway(
   let lastTransportError: string | undefined;
   let lastTransportCode: string | undefined;
   let lastTransportRaw: unknown;
+  // Set by the per-outage endpoint probe (see `probeOutage`), which can explain
+  // a refused reconnect the WebSocket layer reports without detail. Preferred
+  // over `lastTransportError` when present, and cleared when the outage ends.
+  let lastOutageDiagnosis: string | undefined;
   let connectDeadline: ReturnType<typeof setTimeout> | undefined;
   // The initial connect settles from several places (the join push's reply
   // hooks, a non-retryable transport error, the connect deadline), so the
@@ -608,10 +631,16 @@ export async function connectRealtimeGateway(
     clearConnectDeadline();
   });
   socket.onError((error, _transport, establishedConnections) => {
-    // A drop after a successful connect belongs to the reconnect path.
-    if (everConnected || establishedConnections > 0) return;
-    lastTransportRaw = error;
     const detail = describeTransportError(error);
+    // A drop after a successful connect belongs to the reconnect path — but it
+    // must still be RECORDED, or the health observer reports an outage with no
+    // cause at all (the `{ meta: undefined }` give-up log, OSS-670).
+    if (everConnected || establishedConnections > 0) {
+      lastTransportError = detail.text ?? lastTransportError;
+      lastTransportCode = detail.code ?? lastTransportCode;
+      return;
+    }
+    lastTransportRaw = error;
     lastTransportError = detail.text ?? lastTransportError;
     lastTransportCode = detail.code ?? lastTransportCode;
     // A host that does not exist cannot start existing: fail now rather than
@@ -654,7 +683,12 @@ export async function connectRealtimeGateway(
   // (`closingIntentionally` is declared with the connect watchdog above, which
   // also tears the socket down and must mark that teardown intentional.)
   let connectionState: RealtimeGatewayConnectionState = "online";
-  const stateCallbacks: Array<(s: RealtimeGatewayConnectionState) => void> = [];
+  const stateCallbacks: Array<
+    (
+      s: RealtimeGatewayConnectionState,
+      detail?: RealtimeGatewayConnectionDetail,
+    ) => void
+  > = [];
   let giveUpTimer: ReturnType<typeof setTimeout> | undefined;
   // Set true when the give-up window fires; suppresses further `reconnecting`
   // emissions until a successful rejoin (`enterOnline`) clears it.
@@ -669,14 +703,26 @@ export async function connectRealtimeGateway(
       giveUpTimer = undefined;
     }
   };
+  /** Build the cause attached to a non-`online` transition, or `undefined`. */
+  const currentDetail = (): RealtimeGatewayConnectionDetail | undefined => {
+    const reason = lastOutageDiagnosis ?? lastTransportError;
+    if (reason === undefined && lastTransportCode === undefined) {
+      return undefined;
+    }
+    return {
+      ...(reason !== undefined ? { reason } : {}),
+      ...(lastTransportCode !== undefined ? { code: lastTransportCode } : {}),
+    };
+  };
   const emitState = (next: RealtimeGatewayConnectionState): void => {
     if (closingIntentionally || connectionState === next) {
       return;
     }
     connectionState = next;
+    const detail = next === "online" ? undefined : currentDetail();
     for (const cb of stateCallbacks) {
       try {
-        cb(next);
+        cb(next, detail);
       } catch {
         // Isolate observers: a throwing callback must not skip later ones or
         // propagate back into Phoenix's socket/join dispatch.

--- a/packages/channels-intelligence/src/realtime-gateway.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.ts
@@ -275,6 +275,31 @@ const NON_RETRYABLE_TRANSPORT_CODES: ReadonlySet<string> = new Set([
   "EAI_NONAME",
 ]);
 
+/**
+ * Phrase a post-connect probe result for whoever operates the runtime.
+ *
+ * The probe is deliberately UNAUTHENTICATED (see {@link diagnoseEndpoint}), so a
+ * `401`/`403` from it says nothing about whether OUR key is still valid — an
+ * unauthenticated GET is refused either way. What the probe does establish is
+ * reachability: the host answered, so a socket that still will not open is
+ * failing at the handshake rather than in the network. Say exactly that, and
+ * separate "answered but unhealthy" (5xx — typically a gateway restart) from
+ * "answered fine, handshake refused", where a credential is worth checking.
+ */
+function describeRefusedUpgrade(result: EndpointDiagnosis): string | undefined {
+  if (result.status === undefined) return result.text;
+  if (result.status >= 500) {
+    return (
+      `the gateway host answered HTTP ${result.status}, so it is reachable but not healthy — ` +
+      "it may be restarting"
+    );
+  }
+  return (
+    `the gateway host answered HTTP ${result.status} but the WebSocket handshake was refused, ` +
+    "so this is not a network outage — verify the project API key"
+  );
+}
+
 /** What {@link diagnoseEndpoint} learned about an endpoint that would not connect. */
 interface EndpointDiagnosis {
   /** Human-readable cause, phrased for the person who set `wsUrl`. */
@@ -603,6 +628,9 @@ export async function connectRealtimeGateway(
   // memoised for the life of the connect, so reusing it would report a stale
   // verdict for a later, different outage. Reset by `enterOnline`.
   let outageProbe: Promise<void> | undefined;
+  // Counts healed outages, so a probe that resolves late can tell whether the
+  // episode it was investigating is still the current one.
+  let outageEpisode = 0;
   /**
    * Ask the endpoint over HTTP why it will not take us back. A refused upgrade
    * (a rejected/rotated project API key) is indistinguishable at the WebSocket
@@ -611,18 +639,18 @@ export async function connectRealtimeGateway(
    */
   const probeOutage = (): void => {
     if (outageProbe !== undefined) return;
+    // Stamp the episode this probe belongs to. A probe is slower than a
+    // reconnect can be, so its verdict may land AFTER the link healed; applying
+    // it then would latch this outage's cause onto the next, unrelated one.
+    const episode = outageEpisode;
     outageProbe = diagnoseEndpoint(
       config.wsUrl,
       probeTimeoutMs,
       config.diagnosticFetch,
     ).then(
       (result) => {
-        if (result === undefined) return;
-        lastOutageDiagnosis =
-          result.status !== undefined
-            ? `the gateway host answered HTTP ${result.status} but refused the WebSocket handshake — ` +
-              "the project API key may have been revoked or rotated"
-            : result.text;
+        if (result === undefined || episode !== outageEpisode) return;
+        lastOutageDiagnosis = describeRefusedUpgrade(result);
       },
       () => undefined,
     );
@@ -792,10 +820,15 @@ export async function connectRealtimeGateway(
     // can transition `reconnecting` → `gave_up` again.
     gaveUp = false;
     clearGiveUpTimer();
-    // The outage is over: drop its verdict so the NEXT one is diagnosed on its
-    // own evidence rather than reusing this one's.
+    // The outage is over: drop its evidence so the NEXT one is diagnosed on its
+    // own rather than inheriting this one's. Without clearing the transport
+    // fields too, a later clean drop that reports nothing would be attributed to
+    // this outage's error.
+    outageEpisode += 1;
     outageProbe = undefined;
     lastOutageDiagnosis = undefined;
+    lastTransportError = undefined;
+    lastTransportCode = undefined;
     emitState("online");
   };
 

--- a/packages/channels-intelligence/src/realtime-gateway.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.ts
@@ -283,6 +283,8 @@ interface EndpointDiagnosis {
   readonly code?: string;
   /** Whether the cause cannot clear on its own (fail now, don't wait). */
   readonly nonRetryable: boolean;
+  /** HTTP status the host answered with, when it answered at all. */
+  readonly status?: number;
   /** The raw failure, attached to the thrown error as `cause`. */
   readonly cause?: unknown;
 }
@@ -341,6 +343,7 @@ async function diagnoseEndpoint(
         "connections — only the WebSocket handshake failed, so the wsUrl path may not be the " +
         "gateway's socket endpoint",
       nonRetryable: false,
+      status: response.status,
     };
   } catch (err) {
     const { text, code } = describeTransportError(err);
@@ -596,6 +599,34 @@ export async function connectRealtimeGateway(
     }
     return diagnosis;
   };
+  // A reconnect probe is per OUTAGE, not per process: `diagnosis` above is
+  // memoised for the life of the connect, so reusing it would report a stale
+  // verdict for a later, different outage. Reset by `enterOnline`.
+  let outageProbe: Promise<void> | undefined;
+  /**
+   * Ask the endpoint over HTTP why it will not take us back. A refused upgrade
+   * (a rejected/rotated project API key) is indistinguishable at the WebSocket
+   * layer from a gateway that is simply down, and Phoenix retries both forever —
+   * so without this the operator sees nothing at all (OSS-670).
+   */
+  const probeOutage = (): void => {
+    if (outageProbe !== undefined) return;
+    outageProbe = diagnoseEndpoint(
+      config.wsUrl,
+      probeTimeoutMs,
+      config.diagnosticFetch,
+    ).then(
+      (result) => {
+        if (result === undefined) return;
+        lastOutageDiagnosis =
+          result.status !== undefined
+            ? `the gateway host answered HTTP ${result.status} but refused the WebSocket handshake — ` +
+              "the project API key may have been revoked or rotated"
+            : result.text;
+      },
+      () => undefined,
+    );
+  };
   /** Reject the initial connect as unreachable and stop the retry loop. */
   const failUnreachable = (): void => {
     if (initialJoinSettled) return;
@@ -638,6 +669,11 @@ export async function connectRealtimeGateway(
     if (everConnected || establishedConnections > 0) {
       lastTransportError = detail.text ?? lastTransportError;
       lastTransportCode = detail.code ?? lastTransportCode;
+      // Only probe when the transport did NOT name the cause. A transport that
+      // exposes an OS code (`ECONNRESET`, `ECONNREFUSED`) has already said what
+      // happened, and the probe would both waste a request and overwrite a
+      // better answer — the same trust rule the initial-connect path applies.
+      if (detail.code === undefined) probeOutage();
       return;
     }
     lastTransportRaw = error;
@@ -756,6 +792,10 @@ export async function connectRealtimeGateway(
     // can transition `reconnecting` → `gave_up` again.
     gaveUp = false;
     clearGiveUpTimer();
+    // The outage is over: drop its verdict so the NEXT one is diagnosed on its
+    // own evidence rather than reusing this one's.
+    outageProbe = undefined;
+    lastOutageDiagnosis = undefined;
     emitState("online");
   };
 

--- a/packages/channels-intelligence/src/render-events.test.ts
+++ b/packages/channels-intelligence/src/render-events.test.ts
@@ -188,13 +188,25 @@ describe("run renderer — render-event streaming (OSS-402)", () => {
   });
 });
 
-/** A fake Realtime Gateway session that records pushes and replies with batch receipts. */
-function makeFakeSession() {
+/**
+ * A fake Realtime Gateway session that records pushes and replies with batch
+ * receipts. `failEvents` makes the named pushes reject with a coded error (the
+ * shape app-api's fences arrive in), so a test can fence part of a turn.
+ */
+function makeFakeSession(options?: {
+  failEvents?: readonly string[];
+  code?: string;
+}) {
   const pushes: { event: string; payload: unknown }[] = [];
   const handlers = new Map<string, (payload: unknown) => void>();
   const session: RealtimeGatewaySession = {
     push: async (event, payload) => {
       pushes.push({ event, payload });
+      if (options?.failEvents?.includes(event)) {
+        throw Object.assign(new Error("realtime gateway push failed"), {
+          code: options.code ?? "CHANNEL_DELIVERY_LEASE_INVALID",
+        });
+      }
       if (event === "channel.render_batch.v1") {
         const p = (payload as { payload: Record<string, unknown> }).payload;
         return {
@@ -803,6 +815,55 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     expect(logs.some((m) => m.includes("nack after turn failure failed"))).toBe(
       false,
     );
+  });
+
+  it("abandons a fenced delivery from the adapter's dispatch, sending no fail intent", async () => {
+    const fake = makeFakeSession({
+      failEvents: ["channel.render_batch.v1", "channel.delivery.fail.v1"],
+    });
+    const logs: string[] = [];
+    const transport = new RealtimeGatewayTransport({
+      ...cfg(fake.session),
+      log: (m) => logs.push(m),
+    });
+    const adapter = intelligenceAdapter({
+      source: transport,
+      egress: new InMemoryEgressSink(),
+      renderSink: transport,
+      config: { log: (m: string) => logs.push(m) },
+    } as unknown as Parameters<typeof intelligenceAdapter>[0]);
+
+    // Go through the REAL `start()`, so the delivery is handled by
+    // `source.start(env => dispatch(env))`. Every other test in this file drives
+    // `createRunRenderer` directly and therefore never exercises `dispatch`'s
+    // catch — which is exactly how the fenced-lease gap stayed invisible.
+    await adapter.start({
+      onTurn: async (turn: { replyTarget: ReplyTarget }) => {
+        const renderer = adapter.createRunRenderer(turn.replyTarget);
+        const sub = renderer.subscriber as unknown as Sub;
+        sub.onTextMessageContentEvent?.({
+          event: { messageId: "m1", delta: "hi" },
+        });
+        await sub.onTextMessageEndEvent?.({ event: { messageId: "m1" } });
+        await renderer.finish?.();
+      },
+    } as unknown as Parameters<typeof adapter.start>[0]);
+
+    fake.handlers.get("channel.delivery.available.v1")?.(
+      makeDeliveryPayload({
+        deliveryId: "dlv_d3",
+        turnId: "turn_t3",
+        leaseToken: "lease_l3",
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 50));
+
+    const events = fake.pushes.map((p) => p.event);
+    expect(events).toContain("channel.render_batch.v1");
+    expect(events).not.toContain("channel.delivery.fail.v1");
+    expect(
+      logs.some((m) => m.includes("lease revoked mid-turn; abandoning")),
+    ).toBe(true);
   });
 
   it("swallows a fail intent that is itself fenced by a revoked lease", async () => {

--- a/packages/channels-intelligence/src/render-events.test.ts
+++ b/packages/channels-intelligence/src/render-events.test.ts
@@ -864,6 +864,17 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     expect(
       logs.some((m) => m.includes("lease revoked mid-turn; abandoning")),
     ).toBe(true);
+
+    // ...and the transport's own DeliveryState is GONE. `dispatch` swallowing
+    // the fence means the transport saw a successful onDelivery, so neither its
+    // revoked-lease catch nor `ack` ran — only the explicit `abandon` retires
+    // the lease token / scope / accepted map. Probe it through `nack`, which
+    // needs that state to build a fail intent: if it were still retained the
+    // fence would leak one record per fenced delivery until shutdown.
+    const pushesBefore = fake.pushes.length;
+    await transport.nack("dlv_d3", "probe");
+    expect(fake.pushes).toHaveLength(pushesBefore);
+    expect(logs.some((m) => m.includes("no delivery state"))).toBe(true);
   });
 
   it("swallows a fail intent that is itself fenced by a revoked lease", async () => {

--- a/packages/channels-intelligence/src/render-events.test.ts
+++ b/packages/channels-intelligence/src/render-events.test.ts
@@ -270,6 +270,28 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
     now: () => "2026-07-01T00:00:00.000Z",
   });
 
+  /** A `delivery.available` payload for one leased text turn. */
+  const makeDeliveryPayload = (input: {
+    deliveryId: string;
+    turnId: string;
+    leaseToken: string;
+  }) => ({
+    payload: {
+      delivery: {
+        id: input.deliveryId,
+        leaseToken: input.leaseToken,
+        adapter: "slack",
+        channel: { id: "channel_1", name: "support" },
+        turn: {
+          id: input.turnId,
+          eventId: "evt_1",
+          replyTarget: { adapter: "slack", teamId: "T1", channel: "C1" },
+          input: { kind: "text", text: "hi" },
+        },
+      },
+    },
+  });
+
   it("streams render frames, awaits receipts, then sends complete_requested (not ack)", async () => {
     const fake = makeFakeSession();
     const t = new RealtimeGatewayTransport(cfg(fake.session));
@@ -749,6 +771,73 @@ describe("RealtimeGatewayTransport — completion intent, never self-ack", () =>
 
     expect(fake.pushes).toHaveLength(0);
     expect(logs.some((m) => m.includes("no delivery state"))).toBe(true);
+  });
+
+  it("abandons a delivery whose lease was revoked instead of nacking it", async () => {
+    const fake = makeFakeSession();
+    const logs: string[] = [];
+    const t = new RealtimeGatewayTransport({
+      ...cfg(fake.session),
+      log: (m) => logs.push(m),
+    });
+    await t.start(async () => {
+      throw Object.assign(new Error("push failed"), {
+        code: "CHANNEL_DELIVERY_LEASE_INVALID",
+      });
+    });
+    fake.handlers.get("channel.delivery.available.v1")?.(
+      makeDeliveryPayload({
+        deliveryId: "dlv_d1",
+        turnId: "turn_t1",
+        leaseToken: "lease_l1",
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(logs.some((m) => m.includes("lease revoked; abandoning"))).toBe(
+      true,
+    );
+    expect(fake.pushes.map((p) => p.event)).not.toContain(
+      "channel.delivery.fail.v1",
+    );
+    expect(logs.some((m) => m.includes("nack after turn failure failed"))).toBe(
+      false,
+    );
+  });
+
+  it("swallows a fail intent that is itself fenced by a revoked lease", async () => {
+    const fake = makeFakeSession();
+    const logs: string[] = [];
+    // Reject only the fail intent, the way app-api's 409 arrives on the wire.
+    const session: RealtimeGatewaySession = {
+      ...fake.session,
+      push: async (event, payload) => {
+        if (event === "channel.delivery.fail.v1") {
+          throw Object.assign(new Error("push failed"), {
+            code: "CHANNEL_DELIVERY_LEASE_INVALID",
+          });
+        }
+        return fake.session.push(event, payload);
+      },
+    };
+    const t = new RealtimeGatewayTransport({
+      ...cfg(session),
+      log: (m) => logs.push(m),
+    });
+    await t.start(async () => {});
+    fake.handlers.get("channel.delivery.available.v1")?.(
+      makeDeliveryPayload({
+        deliveryId: "dlv_d2",
+        turnId: "turn_t2",
+        leaseToken: "lease_l2",
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 10));
+
+    await expect(t.nack("dlv_d2", "boom")).resolves.toBeUndefined();
+    expect(logs.some((m) => m.includes("fenced by a revoked lease"))).toBe(
+      true,
+    );
   });
 
   it("stamps the delivery's authoritative scope (not the transport default) on render + fail", async () => {

--- a/packages/channels-intelligence/src/render-events.test.ts
+++ b/packages/channels-intelligence/src/render-events.test.ts
@@ -950,3 +950,33 @@ describe("run renderer — push instrumentation (OSS-648)", () => {
     ).toHaveLength(1);
   });
 });
+
+describe("render-batch retry policy (OSS-670)", () => {
+  it("does not retry a batch whose lease was revoked", async () => {
+    let calls = 0;
+    const renderSink = {
+      pushBatch: async () => {
+        calls += 1;
+        throw Object.assign(new Error("realtime gateway session push failed"), {
+          code: "CHANNEL_DELIVERY_LEASE_INVALID",
+        });
+      },
+    };
+    const adapter = intelligenceAdapter({
+      source: new InMemoryDeliverySource(),
+      egress: new InMemoryEgressSink(),
+      renderSink,
+    });
+    const renderer = adapter.createRunRenderer(target);
+    const sub = renderer.subscriber as unknown as Sub;
+
+    sub.onTextMessageContentEvent?.({
+      event: { messageId: "m1", delta: "hi" },
+    });
+    await sub.onTextMessageEndEvent?.({ event: { messageId: "m1" } });
+    // The transport error surfaces here; its shape is not what this test pins.
+    await renderer.finish?.().catch(() => undefined);
+
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/channels-intelligence/src/runtime.ts
+++ b/packages/channels-intelligence/src/runtime.ts
@@ -148,7 +148,10 @@ export interface ChannelsHandle {
    * `ConnectedRealtimeGatewaySession.onStateChange` in `realtime-gateway.ts`).
    */
   onStateChange?(
-    cb: (state: "online" | "reconnecting" | "gave_up" | "fenced") => void,
+    cb: (
+      state: "online" | "reconnecting" | "gave_up" | "fenced",
+      detail?: { reason?: string; code?: string },
+    ) => void,
   ): void;
 }
 

--- a/packages/channels-intelligence/src/transports.ts
+++ b/packages/channels-intelligence/src/transports.ts
@@ -40,6 +40,23 @@ export interface DeliverySource {
   /** Negatively acknowledge — the work will be redelivered (at-least-once). */
   nack(deliveryId: string, reason: string): Promise<void>;
   /**
+   * Retire this delivery's local lease state WITHOUT sending any terminal intent
+   * — the third outcome alongside ack and nack, for a delivery this runtime can
+   * no longer speak for (its lease was revoked, so app-api owns redelivery and
+   * every intent we could send is fenced anyway; see {@link isLeaseRevoked}).
+   *
+   * Synchronous and wire-free by design: there is nothing to send, and the point
+   * is that ack/nack — the only other branches that drop the lease record — are
+   * both deliberately skipped on the fenced path, so without this the token,
+   * scope and accepted-seq high-water marks accumulate until shutdown. Callers
+   * own the diagnostic log (they know the cause); this is pure state retirement
+   * and a no-op for an unknown/already-terminal delivery.
+   *
+   * Optional so an existing {@link DeliverySource} implementation stays valid;
+   * sources that keep no per-delivery state simply omit it.
+   */
+  abandon?(deliveryId: string, reason: string): void;
+  /**
    * Fetch an inbound file's bytes by handle (Channel multimodal content).
    * Optional: sources without a file-serve backing omit it and the adapter
    * skips content-part hydration (text-only turn).

--- a/packages/channels-intelligence/src/transports.ts
+++ b/packages/channels-intelligence/src/transports.ts
@@ -97,3 +97,25 @@ export interface EgressSink {
 export interface RenderEventSink {
   pushBatch(batch: RenderBatch): Promise<RenderBatchAccepted>;
 }
+
+/**
+ * app-api's lease fence: another owner holds this delivery. Every intent — render
+ * batch, complete, fail — is validated against `leased_until > now()` AND the
+ * lease-token hash, so once a lease is revoked (the listener was released under a
+ * gateway restart, or a replacement runtime re-leased the work) NOTHING can be
+ * sent for that delivery. Redelivery is app-api's job.
+ *
+ * Lives here rather than in a transport module because BOTH transports surface
+ * it: the realtime path as a push reject and the HTTP path as a 409 body
+ * (OSS-670).
+ */
+export const LEASE_REVOKED_CODE = "CHANNEL_DELIVERY_LEASE_INVALID";
+
+/** Whether an error is app-api's revoked-lease fence (see {@link LEASE_REVOKED_CODE}). */
+export function isLeaseRevoked(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: unknown }).code === LEASE_REVOKED_CODE
+  );
+}

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager-reconnect.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager-reconnect.test.ts
@@ -17,6 +17,9 @@ import type { ActivateChannelEngine, ChannelsHandle } from "../channel-manager";
 
 type ConnectionState = "online" | "reconnecting" | "gave_up" | "fenced";
 
+/** The cause the session attaches to a non-`online` transition (OSS-670). */
+type ConnectionDetail = { reason?: string; code?: string };
+
 /** A CopilotKitIntelligence whose runner API key carries a parseable project id. */
 function fakeIntelligence(): CopilotKitIntelligence {
   return new CopilotKitIntelligence({
@@ -29,17 +32,21 @@ function fakeIntelligence(): CopilotKitIntelligence {
 /** A fake ChannelsHandle whose connection-state observer can be driven on demand. */
 function observableHandle(): ChannelsHandle & {
   stop: ReturnType<typeof vi.fn>;
-  fireState: (state: ConnectionState) => void;
+  fireState: (state: ConnectionState, detail?: ConnectionDetail) => void;
 } {
-  let cb: ((state: ConnectionState) => void) | undefined;
+  let cb:
+    | ((state: ConnectionState, detail?: ConnectionDetail) => void)
+    | undefined;
   return {
     metadata: {},
     stop: vi.fn(async () => {}),
-    onStateChange(fn: (state: ConnectionState) => void) {
+    onStateChange(
+      fn: (state: ConnectionState, detail?: ConnectionDetail) => void,
+    ) {
       cb = fn;
     },
-    fireState(state: ConnectionState) {
-      cb?.(state);
+    fireState(state: ConnectionState, detail?: ConnectionDetail) {
+      cb?.(state, detail);
     },
   };
 }
@@ -146,5 +153,67 @@ describe("ChannelManager connection health (onStateChange)", () => {
 
     expect(mgr.status().channels.support).toBe("stopped");
     expect(mgr.status().overall).toBe("stopped");
+  });
+
+  it("logs the drop cause and keeps logging while the session is down (OSS-670)", async () => {
+    const handle = observableHandle();
+    const engine: ActivateChannelEngine = vi.fn(async () => handle);
+    const logs: string[] = [];
+
+    const mgr = new ChannelManager({
+      intelligence: fakeIntelligence(),
+      channels: [createChannel({ name: "support" })],
+      activateChannel: engine,
+      log: (m: string) => logs.push(m),
+      reconnectLogIntervalMs: 5,
+    });
+    mgr.activate();
+    await mgr.ready();
+
+    handle.fireState("reconnecting", {
+      reason: "read ECONNRESET",
+      code: "ECONNRESET",
+    });
+    expect(logs.some((m) => m.includes("ECONNRESET"))).toBe(true);
+
+    // Still down: the operator must keep hearing about it.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(logs.filter((m) => m.includes("still down")).length).toBeGreaterThan(
+      0,
+    );
+
+    const before = logs.length;
+    handle.fireState("online");
+    await new Promise((r) => setTimeout(r, 20));
+    // Recovery stops the repeat: only the "back online" line lands after it.
+    expect(
+      logs.slice(before).filter((m) => m.includes("still down")),
+    ).toHaveLength(0);
+    await mgr.stop();
+  });
+
+  it("says retries continue when the give-up window elapses (OSS-670)", async () => {
+    const handle = observableHandle();
+    const engine: ActivateChannelEngine = vi.fn(async () => handle);
+    const logs: string[] = [];
+
+    const mgr = new ChannelManager({
+      intelligence: fakeIntelligence(),
+      channels: [createChannel({ name: "support" })],
+      activateChannel: engine,
+      log: (m: string) => logs.push(m),
+    });
+    mgr.activate();
+    await mgr.ready();
+
+    handle.fireState("reconnecting", { reason: "handshake refused" });
+    handle.fireState("gave_up", { reason: "handshake refused" });
+
+    const line = logs.find((m) => m.includes("gave up reconnecting"))!;
+    expect(line).toContain("handshake refused");
+    expect(line).toMatch(/still retrying/i);
+    // Status semantics are unchanged.
+    expect(mgr.status().channels.support).toBe("error");
+    await mgr.stop();
   });
 });

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -148,6 +148,13 @@ export interface ChannelManagerArgs {
    * activation engine is used, so transport-level drops surface in the managed
    * path (not just activation-level events). */
   log?: (msg: string, meta?: unknown) => void;
+  /**
+   * How often (ms) to repeat a "still down" log while a managed session is
+   * disconnected. A dropped session was previously silent for as long as the
+   * outage lasted, which made a dead bot indistinguishable from an idle one
+   * (OSS-670). Injectable so tests need no fake timers. Default 30000.
+   */
+  reconnectLogIntervalMs?: number;
   /** Per-handle deadline (ms) for `handle.stop()` during {@link ChannelManager.stop}
    * so a wedged stop can't hang SIGTERM shutdown. Default 5000. */
   stopHandleTimeoutMs?: number;
@@ -166,6 +173,10 @@ interface ChannelEntry {
    * once.
    */
   handleStopped: boolean;
+  /** Epoch ms this outage episode began; unset while the session is healthy. */
+  downSince?: number;
+  /** Repeating "still down" logger for this outage; cleared on recovery/teardown. */
+  reconnectLogTimer?: ReturnType<typeof setInterval>;
 }
 
 /**
@@ -288,6 +299,9 @@ export function isModuleNotFound(err: unknown): boolean {
 /** Default deadline (ms) for a single `handle.stop()` during teardown. */
 const DEFAULT_STOP_HANDLE_TIMEOUT_MS = 5_000;
 
+/** Default cadence (ms) for the "still down" log while a session is dropped. */
+const DEFAULT_RECONNECT_LOG_INTERVAL_MS = 30_000;
+
 /**
  * Reject with `timeoutMessage` after `timeoutMs` if `inner` has not settled,
  * otherwise pass `inner` through. When `timeoutMs` is undefined, `inner` is
@@ -366,6 +380,7 @@ export class ChannelManager implements ChannelsControl {
   private readonly mintRuntimeInstanceId: () => string;
   private readonly log?: (msg: string, meta?: unknown) => void;
   private readonly stopHandleTimeoutMs: number;
+  private readonly reconnectLogIntervalMs: number;
 
   private readonly entries = new Map<string, ChannelEntry>();
   private activated = false;
@@ -389,6 +404,8 @@ export class ChannelManager implements ChannelsControl {
       (() => `rti_${randomUUID().replace(/-/g, "")}`);
     this.stopHandleTimeoutMs =
       args.stopHandleTimeoutMs ?? DEFAULT_STOP_HANDLE_TIMEOUT_MS;
+    this.reconnectLogIntervalMs =
+      args.reconnectLogIntervalMs ?? DEFAULT_RECONNECT_LOG_INTERVAL_MS;
   }
 
   /**
@@ -823,31 +840,78 @@ export class ChannelManager implements ChannelsControl {
    * @param entry - The Channel's activation entry.
    */
   private registerConnectionObserver(name: string, entry: ChannelEntry): void {
-    entry.handle?.onStateChange?.((state) => {
+    entry.handle?.onStateChange?.((state, detail) => {
       // A stopped manager (or a stopped entry) ignores late connection events.
       if (this.stopped || entry.status === "stopped") {
         return;
       }
+      const cause = detail?.reason ?? detail?.code;
+      const because = cause !== undefined ? ` — ${cause}` : "";
       if (state === "reconnecting") {
         entry.status = "reconnecting";
+        entry.downSince ??= Date.now();
         this.log?.(
-          `channel "${name}" managed session dropped; reconnecting (Phoenix auto-rejoin)`,
+          `channel "${name}" managed session dropped; reconnecting (Phoenix auto-rejoin)${because}`,
         );
+        this.startReconnectLog(name, entry);
       } else if (state === "online") {
         entry.status = "online";
+        this.clearReconnectLog(entry);
+        entry.downSince = undefined;
         this.log?.(`channel "${name}" managed session back online`);
       } else if (state === "gave_up") {
+        // `error` here means "not sendable", NOT "dead": Phoenix keeps retrying
+        // underneath and a successful rejoin restores `online`. Say so, or the
+        // line reads as terminal (OSS-670). The repeat keeps running.
         entry.status = "error";
         this.log?.(
-          `channel "${name}" managed session gave up reconnecting; marking error`,
+          `channel "${name}" managed session gave up reconnecting after ${this.downFor(entry)}; ` +
+            `marking error (still retrying — a successful rejoin restores online)${because}`,
         );
       } else {
         entry.status = "error";
+        this.clearReconnectLog(entry);
         this.log?.(
           `channel "${name}" managed session was generation-fenced by a replacement; marking error`,
         );
       }
     });
+  }
+
+  /** Rendered downtime for this outage episode (`"45s"`), or `"unknown"`. */
+  private downFor(entry: ChannelEntry): string {
+    return entry.downSince === undefined
+      ? "unknown"
+      : `${Math.round((Date.now() - entry.downSince) / 1000)}s`;
+  }
+
+  /**
+   * Repeat a "still down" line for as long as this outage lasts. Runs THROUGH
+   * `gave_up` on purpose: that transition is where the old behavior went quiet,
+   * and an operator watching a silent process cannot tell a dead bot from an
+   * idle one.
+   */
+  private startReconnectLog(name: string, entry: ChannelEntry): void {
+    if (entry.reconnectLogTimer !== undefined) return;
+    const timer = setInterval(() => {
+      if (this.stopped || entry.status === "stopped") {
+        this.clearReconnectLog(entry);
+        return;
+      }
+      this.log?.(
+        `channel "${name}" managed session still down after ${this.downFor(entry)}; Phoenix is retrying`,
+      );
+    }, this.reconnectLogIntervalMs);
+    (timer as unknown as { unref?: () => void }).unref?.();
+    entry.reconnectLogTimer = timer;
+  }
+
+  /** Stop this entry's "still down" repeat, if one is running. */
+  private clearReconnectLog(entry: ChannelEntry): void {
+    if (entry.reconnectLogTimer !== undefined) {
+      clearInterval(entry.reconnectLogTimer);
+      entry.reconnectLogTimer = undefined;
+    }
   }
 
   /**
@@ -887,6 +951,9 @@ export class ChannelManager implements ChannelsControl {
    */
   private async stopEntry(entry: ChannelEntry): Promise<void> {
     entry.status = "stopped";
+    // An unref'd interval would not hold the process open, but a stopped
+    // manager must not keep logging about a session it no longer owns.
+    this.clearReconnectLog(entry);
     if (entry.handle && !entry.handleStopped) {
       entry.handleStopped = true;
       const handle = entry.handle;

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -123,7 +123,10 @@ export interface ChannelsHandle {
    * `handle.onStateChange?.(cb)`.
    */
   onStateChange?(
-    cb: (state: "online" | "reconnecting" | "gave_up" | "fenced") => void,
+    cb: (
+      state: "online" | "reconnecting" | "gave_up" | "fenced",
+      detail?: { reason?: string; code?: string },
+    ) => void,
   ): void;
 }
 


### PR DESCRIPTION
Three fixes from the OSS-670 investigation, where a dev gateway restart landed mid-turn: the agent's answer was produced and then thrown away, the end user got a generic error, and the bot went silent for 19 minutes with nothing in its logs.

## A revoked lease is a fenced outcome, not a turn failure

`CHANNEL_DELIVERY_LEASE_INVALID` means another owner holds the delivery — app-api fences every intent on `leased_until > now()` AND the lease-token hash, so nothing we send can be accepted and redelivery is app-api's job.

- The guard lives in `IntelligenceAdapter.dispatch`, the site that actually runs. An earlier revision guarded only the realtime transport, which is unreachable in production because `dispatch` catches every turn error and nacks first — so a fenced delivery still put a doomed `channel.delivery.fail.v1` on the wire, and that second 409 is what surfaced as `nack after turn failure failed` followed by `no delivery state`.
- The code is no longer retried through the 3-attempt render-batch ladder.
- A `fail` intent that is itself fenced is logged and dropped rather than rejected.
- The predicate lives in `transports.ts` because both transports surface the same code (the HTTP path as a 409 body).

The adapter-dispatch test is a real regression test: reverting the guard makes it fail on `channel.delivery.fail.v1` being pushed.

### Abandoning is a third outcome, not a silent one

Swallowing the coded error means the `DeliverySource` observes a **successful** `onDelivery` — so neither its own revoked-lease branch nor `ack` runs, and those are the only two places the per-delivery lease record is dropped. Without more, every fence leaked a lease token, delivery scope and accepted-seq high-water map for a delivery this runtime can never speak for again (app-api may already have handed it to another runtime, so the id may never be seen here again).

`DeliverySource.abandon(deliveryId, reason)` is that third outcome alongside ack/nack: retire local state, send nothing. It is synchronous and wire-free by design, optional on the interface so existing implementations stay valid, and implemented on `RealtimeGatewayTransport` (`deliveries`), `HttpDeliverySource` (`leases`) and `InMemoryDeliverySource`. The transport's internal revoked-lease catch routes through it too, so there is one retirement path rather than two.

Both wiring tests fail with the `abandon` call reverted — the adapter test on an empty `abandoned[]`, and the composed adapter+transport test because its probe `nack` pushes a second, doomed `channel.delivery.fail.v1` off the retained state.

## A refused reconnect is diagnosed instead of retried in silence

`socket.onError` returned early once the socket had connected, so a refused *reconnect* recorded nothing and Phoenix retried forever with no output. The cause is now recorded, and when the transport exposes no OS code an HTTP probe of the endpoint runs once per outage.

The probe is unauthenticated, so it deliberately does **not** claim your key is revoked — its 401/403 would look identical with a perfectly good credential. It establishes reachability: 5xx reads as an unhealthy/restarting gateway, anything else as "reachable, handshake refused — verify the project API key".

## Honest status, loud while down

`gave_up` maps to status `error`, but Phoenix keeps retrying underneath and a successful rejoin restores `online` — the log now says so instead of reading as terminal. The drop cause travels with each state transition (it was previously `{ meta: undefined }`), and a "still down" line repeats while the session is out, including after `gave_up`. Channel status semantics and the "manager never re-activates on a drop" contract are unchanged.

## Not included

Delivery-lease renewal has no owner across a gateway restart — draining stops the channel process that renews it, so a long turn loses its lease to expiry regardless. That, and bounding an in-flight turn whose lease is already dead, are follow-ups on the ticket. Retiring the local record (above) stops the leak; it does not keep the lease alive.

Tests: `channels-intelligence` 13 files / 244 tests; `runtime` 127 files / 1799 tests; `check-types` clean on both.
