### PR TITLE
Fix channels intelligence CI build

### DIFF
--- a/packages/channels-intelligence/src/render-events.test.ts
+++ b/packages/channels-intelligence/src/render-events.test.ts
@@ -3,6 +3,7 @@ import type { AgentSubscriber } from "@ag-ui/client";
 import { EventType } from "@ag-ui/core";
 import type { RunAgentInput } from "@ag-ui/core";
 import { FakeAgent } from "@copilotkit/channels-core";
+import type { ReplyTarget } from "@copilotkit/channels-core";
 import { intelligenceAdapter } from "./intelligence-adapter.js";
 import {
   InMemoryDeliverySource,
@@ -25,6 +26,8 @@ const target = {
   turnId: "turn_t1",
   deliveryId: "dlv_d1",
 };
+
+type Sub = Record<string, (p: { event: Record<string, unknown> }) => unknown>;
 
 function makeSubscriberContext() {
   return {


### PR DESCRIPTION
## Problem

Main CI cannot compile the channels-intelligence test suite because ReplyTarget and Sub are referenced without declarations.

## Why

The merged Slack tool-status regression coverage introduced the references but omitted the corresponding type declarations. Every dependent Nx workflow fails during the shared package build.

## Fix

Restore the ReplyTarget type import and the local Sub subscriber helper type in render-events.test.ts.

Validation: pnpm exec nx run @copilotkit/channels-intelligence:build; pnpm exec nx run @copilotkit/channels-intelligence:test; pnpm exec nx run @copilotkit/channels-intelligence:check-types.