### PR TITLE
feat: add managed Channels terminal batching brownout

### DIFF
--- a/packages/channels-intelligence/src/intelligence-adapter.test.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.test.ts
@@ -7,7 +7,10 @@ import {
 import type { ReplyTarget } from "@copilotkit/channels-core";
 import { Section } from "@copilotkit/channels-ui";
 import type { IncomingMessage } from "@copilotkit/channels-ui";
-import { intelligenceAdapter } from "./intelligence-adapter.js";
+import {
+  intelligenceAdapter,
+  intelligenceAdapterInternal,
+} from "./intelligence-adapter.js";
 import {
   InMemoryDeliverySource,
   InMemoryEgressSink,
@@ -113,6 +116,47 @@ describe("intelligenceAdapter — ingress dispatch", () => {
     await source.deliver(envelope({ deliveryId: "d9" }));
     expect(source.acked).toEqual([]);
     expect(source.nacked.map((n) => n.deliveryId)).toEqual(["d9"]);
+  });
+
+  it("flushes terminal-batched partial history before nacking a rejected agent run", async () => {
+    const source = new InMemoryDeliverySource();
+    const renderSink = new InMemoryRenderEventSink();
+    const agent = new FakeAgent([
+      async (subscriber) => {
+        await subscriber.onTextMessageContentEvent?.({
+          event: { messageId: "m1", delta: "partial answer" },
+        } as never);
+        throw new Error("agent transport failed");
+      },
+    ]);
+    const channel = createChannel({
+      adapters: [
+        intelligenceAdapterInternal(
+          {
+            source,
+            egress: new InMemoryEgressSink(),
+            renderSink,
+          },
+          { terminalBatchingEnabled: true },
+        ),
+      ],
+      agent: () => agent,
+    });
+    channel.onMessage(async ({ thread }) => {
+      await thread.runAgent();
+    });
+
+    await channel.ɵruntime.start();
+    await source.deliver(envelope());
+
+    expect(renderSink.frames.map((frame) => frame.event.kind)).toEqual([
+      "run_started",
+      "text_delta",
+    ]);
+    expect(source.acked).toEqual([]);
+    expect(source.nacked).toEqual([
+      { deliveryId: "d1", reason: "agent transport failed" },
+    ]);
   });
 
   it("abandons (not nacks) the delivery when the lease was revoked mid-turn", async () => {

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -1190,7 +1190,8 @@ export class IntelligenceAdapter implements PlatformAdapter {
       if (tailFlushTimer !== undefined || pendingText === undefined) return;
       tailFlushTimer = setTimeout(() => {
         tailFlushTimer = undefined;
-        flushPendingTextBatch();
+        flushPendingText();
+        if (streaming) flushBatch();
       }, RENDER_TEXT_TAIL_FLUSH_MS);
     };
 
@@ -1276,6 +1277,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
           firstTextFlushed = true;
           flushPendingTextBatch();
         }
+        scheduleTailFlush();
         return;
       }
 

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -190,13 +190,16 @@ const INTERNAL_INTELLIGENCE_ADAPTER_OPTIONS = Symbol(
   "internal-intelligence-adapter-options",
 );
 
-interface InternalIntelligenceAdapterOptions {
-  terminalBatchingEnabled: boolean;
+export interface InternalChannelActivationDecision {
+  readonly terminalBatchingEnabled: boolean;
 }
 
 type IntelligenceAdapterConstructionOptions = IntelligenceAdapterOptions & {
-  [INTERNAL_INTELLIGENCE_ADAPTER_OPTIONS]?: InternalIntelligenceAdapterOptions;
+  [INTERNAL_INTELLIGENCE_ADAPTER_OPTIONS]?: InternalChannelActivationDecision;
 };
+
+export const STREAMING_CHANNEL_ACTIVATION_DECISION: InternalChannelActivationDecision =
+  Object.freeze({ terminalBatchingEnabled: false });
 
 /**
  * @internal Not a publicly documented API.
@@ -356,8 +359,8 @@ export class IntelligenceAdapter implements PlatformAdapter {
   >();
   /** Shared per-turn transport tail for renderer batches and discrete effects. */
   private readonly renderLaneTails = new Map<string, Promise<void>>();
-  /** Flush buffered renderer text before a discrete effect claims its seq. */
-  private readonly renderLaneFlushers = new Map<string, () => void>();
+  /** Flush every active renderer before another renderer/effect claims its seq. */
+  private readonly renderLaneFlushers = new Map<string, Set<() => void>>();
 
   constructor(private readonly opts: IntelligenceAdapterOptions = {}) {
     this.terminalBatchingEnabled =
@@ -489,7 +492,12 @@ export class IntelligenceAdapter implements PlatformAdapter {
       await this.finalizeRenderedTurn(env);
       turnProcessed = true;
     } catch (err) {
-      if (isLeaseRevoked(err)) {
+      const leaseRevoked = isLeaseRevoked(err);
+      if (this.terminalBatchingEnabled && !leaseRevoked) {
+        this.flushRenderLane(env.turnId);
+        await this.renderLaneTails.get(env.turnId);
+      }
+      if (leaseRevoked) {
         // This delivery's lease was revoked mid-turn, so another owner holds it
         // now and app-api owns redelivery. A nack here would send a `fail` the
         // same fence rejects — the doomed intent whose 409 used to be reported
@@ -732,6 +740,26 @@ export class IntelligenceAdapter implements PlatformAdapter {
     return result;
   }
 
+  private flushRenderLane(turnId: string, except?: () => void): void {
+    for (const flush of this.renderLaneFlushers.get(turnId) ?? []) {
+      if (flush !== except) flush();
+    }
+  }
+
+  private registerRenderLaneFlusher(
+    turnId: string,
+    flush: () => void,
+  ): () => void {
+    const flushers = this.renderLaneFlushers.get(turnId) ?? new Set();
+    flushers.add(flush);
+    this.renderLaneFlushers.set(turnId, flushers);
+    return () => {
+      const current = this.renderLaneFlushers.get(turnId);
+      current?.delete(flush);
+      if (current?.size === 0) this.renderLaneFlushers.delete(turnId);
+    };
+  }
+
   /**
    * Pushes one realtime frame immediately and records its accepted terminal
    * state. Sequence allocation stays deterministic across delivery retries.
@@ -740,7 +768,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
     target: ChannelReplyTarget,
     event: ChannelRenderEvent,
   ): Promise<{ receipt: RenderBatchAccepted; seq: number }> {
-    this.renderLaneFlushers.get(target.turnId)?.();
+    this.flushRenderLane(target.turnId);
     const seq = this.nextFrameSeq(target.turnId);
     return this.enqueueRenderLane(target.turnId, async () => {
       const receipt = await this.requireRenderSink().pushBatch(
@@ -887,7 +915,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
     // semantic boundary for the run renderer. Drain its prefix and permanently
     // enter streaming before bytes leave this process, so renderer callbacks
     // that arrive while the upload is in flight cannot overtake the effect.
-    this.renderLaneFlushers.get(channelTarget.turnId)?.();
+    this.flushRenderLane(channelTarget.turnId);
     try {
       // Stream bytes to app-api first (durable in S3), then emit a `file` frame
       // referencing the handle; the Connector Outbox does the Slack uploadV2.
@@ -1230,7 +1258,14 @@ export class IntelligenceAdapter implements PlatformAdapter {
       }, RENDER_TEXT_TAIL_FLUSH_MS);
     };
 
-    this.renderLaneFlushers.set(t.turnId, flushForDiscreteEffect);
+    if ((this.renderLaneFlushers.get(t.turnId)?.size ?? 0) > 0) {
+      this.flushRenderLane(t.turnId);
+      streaming = true;
+    }
+    const unregisterRenderLaneFlusher = this.registerRenderLaneFlusher(
+      t.turnId,
+      flushForDiscreteEffect,
+    );
 
     const enqueueStreaming = (event: ChannelRenderEvent): void => {
       if (transportError !== undefined || enqueueError !== undefined) return;
@@ -1277,6 +1312,9 @@ export class IntelligenceAdapter implements PlatformAdapter {
 
     const enqueue = (event: ChannelRenderEvent): void => {
       if (transportError !== undefined || enqueueError !== undefined) return;
+      if ((this.renderLaneFlushers.get(t.turnId)?.size ?? 0) > 1) {
+        this.flushRenderLane(t.turnId, flushForDiscreteEffect);
+      }
       if (streaming) {
         enqueueStreaming(event);
         return;
@@ -1338,9 +1376,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
         }
       } finally {
         clearTailFlushTimer();
-        if (this.renderLaneFlushers.get(t.turnId) === flushForDiscreteEffect) {
-          this.renderLaneFlushers.delete(t.turnId);
-        }
+        unregisterRenderLaneFlusher();
       }
     };
 
@@ -1495,10 +1531,10 @@ export function intelligenceAdapter(
  */
 export function intelligenceAdapterInternal(
   opts: IntelligenceAdapterOptions,
-  internal: InternalIntelligenceAdapterOptions,
+  decision: InternalChannelActivationDecision,
 ): IntelligenceAdapter {
   return new IntelligenceAdapter({
     ...opts,
-    [INTERNAL_INTELLIGENCE_ADAPTER_OPTIONS]: internal,
+    [INTERNAL_INTELLIGENCE_ADAPTER_OPTIONS]: decision,
   } as IntelligenceAdapterConstructionOptions);
 }

--- a/packages/channels-intelligence/src/intelligence-adapter.ts
+++ b/packages/channels-intelligence/src/intelligence-adapter.ts
@@ -175,6 +175,18 @@ export interface IntelligenceAdapterOptions {
   historyLimit?: number;
 }
 
+const INTERNAL_INTELLIGENCE_ADAPTER_OPTIONS = Symbol(
+  "internal-intelligence-adapter-options",
+);
+
+interface InternalIntelligenceAdapterOptions {
+  terminalBatchingEnabled: boolean;
+}
+
+type IntelligenceAdapterConstructionOptions = IntelligenceAdapterOptions & {
+  [INTERNAL_INTELLIGENCE_ADAPTER_OPTIONS]?: InternalIntelligenceAdapterOptions;
+};
+
 /**
  * @internal Not a publicly documented API.
  *
@@ -321,6 +333,8 @@ export class IntelligenceAdapter implements PlatformAdapter {
   /** Streaming render transport — injected via opts (realtime path). When unset,
    * the run renderer translates frames to `post` ops on {@link egress}. */
   private renderSink?: RenderEventSink;
+  /** Activation-scoped managed-path brownout decision. Never public config. */
+  private readonly terminalBatchingEnabled: boolean;
   /** Per-turn render state; reset at the start of each turn's processing so a
    * redelivery reproduces the same operation ids. A realtime turn starts
    * non-terminal: even an output-free handler must durably accept `finalize`
@@ -335,6 +349,10 @@ export class IntelligenceAdapter implements PlatformAdapter {
   private readonly renderLaneFlushers = new Map<string, () => void>();
 
   constructor(private readonly opts: IntelligenceAdapterOptions = {}) {
+    this.terminalBatchingEnabled =
+      (opts as IntelligenceAdapterConstructionOptions)[
+        INTERNAL_INTELLIGENCE_ADAPTER_OPTIONS
+      ]?.terminalBatchingEnabled ?? false;
     this.source = opts.source;
     this.egress = opts.egress;
     this.renderSink = opts.renderSink;
@@ -830,6 +848,11 @@ export class IntelligenceAdapter implements PlatformAdapter {
         error: "Channel adapter: outbound file upload is not available",
       };
     }
+    // The upload is asynchronous, but invoking a file effect is still a
+    // semantic boundary for the run renderer. Drain its prefix and permanently
+    // enter streaming before bytes leave this process, so renderer callbacks
+    // that arrive while the upload is in flight cannot overtake the effect.
+    this.renderLaneFlushers.get(channelTarget.turnId)?.();
     try {
       // Stream bytes to app-api first (durable in S3), then emit a `file` frame
       // referencing the handle; the Connector Outbox does the Slack uploadV2.
@@ -1011,6 +1034,8 @@ export class IntelligenceAdapter implements PlatformAdapter {
       | undefined;
     let pendingTextDeltaCount = 0;
     let firstTextFlushed = false;
+    let rendererTextSeen = false;
+    let streaming = !this.terminalBatchingEnabled;
     let tailFlushTimer: ReturnType<typeof setTimeout> | undefined;
     let lanePendingBytes = 0;
     // OSS-648: time each push so the per-frame round-trip cost of this serial
@@ -1102,19 +1127,25 @@ export class IntelligenceAdapter implements PlatformAdapter {
       });
     };
 
+    const wouldOverflowBatch = (frame: RenderFrame): boolean => {
+      const nextFrames = [...batchFrames, frame];
+      return (
+        batchFrames.length > 0 &&
+        (nextFrames.length > RENDER_BATCH_MAX_FRAMES ||
+          encodedJsonBytes(nextFrames) > RENDER_BATCH_MAX_BYTES)
+      );
+    };
+
     const addFrame = (event: ChannelRenderEvent): void => {
       if (transportError !== undefined || enqueueError !== undefined) return;
       const frame: RenderFrame = {
         seq: this.nextFrameSeq(t.turnId),
         event,
       };
-      const nextFrames = [...batchFrames, frame];
-      if (
-        batchFrames.length > 0 &&
-        (nextFrames.length > RENDER_BATCH_MAX_FRAMES ||
-          encodedJsonBytes(nextFrames) > RENDER_BATCH_MAX_BYTES)
-      ) {
+      if (wouldOverflowBatch(frame)) {
         flushBatch();
+        streaming = true;
+        firstTextFlushed ||= rendererTextSeen;
       }
       if (encodedJsonBytes([frame]) > RENDER_BATCH_MAX_BYTES) {
         enqueueError = new Error(
@@ -1144,6 +1175,17 @@ export class IntelligenceAdapter implements PlatformAdapter {
       flushBatch();
     };
 
+    const flushForDiscreteEffect = (): void => {
+      if (!streaming) {
+        flushPendingText();
+        flushBatch();
+        streaming = true;
+        firstTextFlushed ||= rendererTextSeen;
+        return;
+      }
+      flushPendingTextBatch();
+    };
+
     const scheduleTailFlush = (): void => {
       if (tailFlushTimer !== undefined || pendingText === undefined) return;
       tailFlushTimer = setTimeout(() => {
@@ -1152,9 +1194,9 @@ export class IntelligenceAdapter implements PlatformAdapter {
       }, RENDER_TEXT_TAIL_FLUSH_MS);
     };
 
-    this.renderLaneFlushers.set(t.turnId, flushPendingTextBatch);
+    this.renderLaneFlushers.set(t.turnId, flushForDiscreteEffect);
 
-    const enqueue = (event: ChannelRenderEvent): void => {
+    const enqueueStreaming = (event: ChannelRenderEvent): void => {
       if (transportError !== undefined || enqueueError !== undefined) return;
       if (event.kind === "text_delta") {
         if (!firstTextFlushed) {
@@ -1197,6 +1239,51 @@ export class IntelligenceAdapter implements PlatformAdapter {
       flushBatch();
     };
 
+    const enqueue = (event: ChannelRenderEvent): void => {
+      if (transportError !== undefined || enqueueError !== undefined) return;
+      if (streaming) {
+        enqueueStreaming(event);
+        return;
+      }
+
+      if (event.kind === "text_delta") {
+        rendererTextSeen = true;
+        if (
+          pendingText &&
+          (pendingText.messageId !== event.messageId ||
+            Buffer.byteLength(pendingText.delta + event.delta, "utf8") >
+              RENDER_TEXT_MAX_BYTES ||
+            pendingTextDeltaCount >= RENDER_TEXT_MAX_DELTAS)
+        ) {
+          flushPendingText();
+          if (streaming) {
+            flushBatch();
+            enqueueStreaming(event);
+            return;
+          }
+        }
+        pendingText = pendingText
+          ? { ...pendingText, delta: pendingText.delta + event.delta }
+          : event;
+        pendingTextDeltaCount += 1;
+        const pendingFrame: RenderFrame = {
+          seq: this.renderState.get(t.turnId)?.nextSeq ?? 0,
+          event: pendingText,
+        };
+        if (wouldOverflowBatch(pendingFrame)) {
+          flushBatch();
+          streaming = true;
+          firstTextFlushed = true;
+          flushPendingTextBatch();
+        }
+        return;
+      }
+
+      flushPendingText();
+      addFrame(event);
+      if (streaming) flushBatch();
+    };
+
     const drain = async (): Promise<void> => {
       flushPendingTextBatch();
       try {
@@ -1214,7 +1301,7 @@ export class IntelligenceAdapter implements PlatformAdapter {
         }
       } finally {
         clearTailFlushTimer();
-        if (this.renderLaneFlushers.get(t.turnId) === flushPendingTextBatch) {
+        if (this.renderLaneFlushers.get(t.turnId) === flushForDiscreteEffect) {
           this.renderLaneFlushers.delete(t.turnId);
         }
       }
@@ -1354,4 +1441,18 @@ export function intelligenceAdapter(
   opts: IntelligenceAdapterOptions = {},
 ): IntelligenceAdapter {
   return new IntelligenceAdapter(opts);
+}
+
+/**
+ * Activation-only construction seam. Intentionally not re-exported from the
+ * package root: terminal batching is an Operations brownout, not public config.
+ */
+export function intelligenceAdapterInternal(
+  opts: IntelligenceAdapterOptions,
+  internal: InternalIntelligenceAdapterOptions,
+): IntelligenceAdapter {
+  return new IntelligenceAdapter({
+    ...opts,
+    [INTERNAL_INTELLIGENCE_ADAPTER_OPTIONS]: internal,
+  } as IntelligenceAdapterConstructionOptions);
 }

--- a/packages/channels-intelligence/src/operations-feature-flags.test.ts
+++ b/packages/channels-intelligence/src/operations-feature-flags.test.ts
@@ -32,6 +32,7 @@ test("requests the Operations flag for the Intelligence project identity", async
   expect(init).toEqual({
     method: "POST",
     headers: { "Content-Type": "application/json" },
+    signal: expect.any(AbortSignal),
     body: JSON.stringify({
       token: OPERATIONS_TOKEN,
       distinct_id: "intelligence-project:123",
@@ -70,6 +71,35 @@ test("returns false for a network failure", async () => {
   await expect(
     isChannelsTerminalBatchingEnabled(123, fetch as typeof globalThis.fetch),
   ).resolves.toBe(false);
+});
+
+test("aborts a request after 3 seconds and returns false", async () => {
+  vi.useFakeTimers();
+  try {
+    const fetch = vi.fn(
+      async (_input: string | URL | Request, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("aborted", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    const settled = vi.fn();
+
+    const evaluation = isChannelsTerminalBatchingEnabled(123, fetch);
+    void evaluation.then(settled);
+
+    await vi.advanceTimersByTimeAsync(2_999);
+    expect(settled).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(settled).toHaveBeenCalledWith(false);
+    await expect(evaluation).resolves.toBe(false);
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 test("returns false for malformed JSON", async () => {

--- a/packages/channels-intelligence/src/operations-feature-flags.test.ts
+++ b/packages/channels-intelligence/src/operations-feature-flags.test.ts
@@ -1,0 +1,115 @@
+import { expect, test, vi } from "vitest";
+import { isChannelsTerminalBatchingEnabled } from "./operations-feature-flags.js";
+
+const FLAG_KEY = "channels-terminal-batching";
+const OPERATIONS_TOKEN = "phc_XZdymVYjrph9Mi0xZYGNyCKexxgblXRR1jMENCtdz5Q";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+test("requests the Operations flag for the Intelligence project identity", async () => {
+  const fetch = vi.fn(
+    async (_input: string | URL | Request, _init?: RequestInit) =>
+      jsonResponse({
+        flags: {
+          "unrelated-flag": { key: "unrelated-flag", enabled: true },
+          [FLAG_KEY]: { key: FLAG_KEY, enabled: true },
+        },
+      }),
+  );
+
+  await expect(isChannelsTerminalBatchingEnabled(123, fetch)).resolves.toBe(
+    true,
+  );
+  expect(fetch).toHaveBeenCalledOnce();
+
+  const [url, init] = fetch.mock.calls[0]!;
+  expect(url).toBe("https://eu.i.posthog.com/flags/?v=2");
+  expect(init).toEqual({
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      token: OPERATIONS_TOKEN,
+      distinct_id: "intelligence-project:123",
+      geoip_disable: true,
+    }),
+  });
+});
+
+test("returns false when the target flag is explicitly disabled", async () => {
+  const fetch = vi.fn(async () =>
+    jsonResponse({
+      flags: {
+        [FLAG_KEY]: { key: FLAG_KEY, enabled: false },
+      },
+    }),
+  ) as typeof globalThis.fetch;
+
+  await expect(isChannelsTerminalBatchingEnabled(123, fetch)).resolves.toBe(
+    false,
+  );
+});
+
+test("returns false for an HTTP error", async () => {
+  const fetch = vi.fn(async () => jsonResponse({ error: "unavailable" }, 503));
+
+  await expect(
+    isChannelsTerminalBatchingEnabled(123, fetch as typeof globalThis.fetch),
+  ).resolves.toBe(false);
+});
+
+test("returns false for a network failure", async () => {
+  const fetch = vi.fn(async () => {
+    throw new Error("network unavailable");
+  });
+
+  await expect(
+    isChannelsTerminalBatchingEnabled(123, fetch as typeof globalThis.fetch),
+  ).resolves.toBe(false);
+});
+
+test("returns false for malformed JSON", async () => {
+  const fetch = vi.fn(
+    async () =>
+      new Response("{", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+  );
+
+  await expect(
+    isChannelsTerminalBatchingEnabled(123, fetch as typeof globalThis.fetch),
+  ).resolves.toBe(false);
+});
+
+test("returns false when the target flag is missing", async () => {
+  const fetch = vi.fn(async () =>
+    jsonResponse({
+      flags: {
+        "unrelated-flag": { key: "unrelated-flag", enabled: true },
+      },
+    }),
+  ) as typeof globalThis.fetch;
+
+  await expect(isChannelsTerminalBatchingEnabled(123, fetch)).resolves.toBe(
+    false,
+  );
+});
+
+test("returns false when enabled is not a boolean", async () => {
+  const fetch = vi.fn(async () =>
+    jsonResponse({
+      flags: {
+        [FLAG_KEY]: { key: FLAG_KEY, enabled: "true" },
+      },
+    }),
+  ) as typeof globalThis.fetch;
+
+  await expect(isChannelsTerminalBatchingEnabled(123, fetch)).resolves.toBe(
+    false,
+  );
+});

--- a/packages/channels-intelligence/src/operations-feature-flags.test.ts
+++ b/packages/channels-intelligence/src/operations-feature-flags.test.ts
@@ -16,7 +16,7 @@ test("requests the Operations flag for the Intelligence project identity", async
     async (_input: string | URL | Request, _init?: RequestInit) =>
       jsonResponse({
         flags: {
-          "unrelated-flag": { key: "unrelated-flag", enabled: true },
+          "unrelated-flag": { key: "unrelated-flag", enabled: false },
           [FLAG_KEY]: { key: FLAG_KEY, enabled: true },
         },
       }),
@@ -80,6 +80,18 @@ test("returns false for malformed JSON", async () => {
         headers: { "Content-Type": "application/json" },
       }),
   );
+
+  await expect(
+    isChannelsTerminalBatchingEnabled(123, fetch as typeof globalThis.fetch),
+  ).resolves.toBe(false);
+});
+
+test.each([
+  ["a non-record body", null],
+  ["a non-record flags value", { flags: [] }],
+  ["a non-record target flag", { flags: { [FLAG_KEY]: null } }],
+])("returns false for %s", async (_description, body) => {
+  const fetch = vi.fn(async () => jsonResponse(body));
 
   await expect(
     isChannelsTerminalBatchingEnabled(123, fetch as typeof globalThis.fetch),

--- a/packages/channels-intelligence/src/operations-feature-flags.test.ts
+++ b/packages/channels-intelligence/src/operations-feature-flags.test.ts
@@ -67,10 +67,19 @@ test("returns false for a network failure", async () => {
   const fetch = vi.fn(async () => {
     throw new Error("network unavailable");
   });
+  const log = vi.fn();
 
   await expect(
-    isChannelsTerminalBatchingEnabled(123, fetch as typeof globalThis.fetch),
+    isChannelsTerminalBatchingEnabled(
+      123,
+      fetch as typeof globalThis.fetch,
+      log,
+    ),
   ).resolves.toBe(false);
+  expect(log).toHaveBeenCalledWith(
+    "channels terminal batching flag evaluation failed; using streaming",
+    { reason: "request_failed" },
+  );
 });
 
 test("aborts a request after 3 seconds and returns false", async () => {

--- a/packages/channels-intelligence/src/operations-feature-flags.ts
+++ b/packages/channels-intelligence/src/operations-feature-flags.ts
@@ -1,0 +1,38 @@
+const OPERATIONS_POSTHOG_FLAGS_URL = "https://eu.i.posthog.com/flags/?v=2";
+const OPERATIONS_POSTHOG_PROJECT_TOKEN =
+  "phc_XZdymVYjrph9Mi0xZYGNyCKexxgblXRR1jMENCtdz5Q";
+const CHANNELS_TERMINAL_BATCHING_FLAG = "channels-terminal-batching";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export async function isChannelsTerminalBatchingEnabled(
+  projectId: number,
+  fetch: typeof globalThis.fetch = globalThis.fetch,
+): Promise<boolean> {
+  try {
+    const response = await fetch(OPERATIONS_POSTHOG_FLAGS_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        token: OPERATIONS_POSTHOG_PROJECT_TOKEN,
+        distinct_id: `intelligence-project:${projectId}`,
+        geoip_disable: true,
+      }),
+    });
+    if (!response.ok) {
+      return false;
+    }
+
+    const body: unknown = await response.json();
+    if (!isRecord(body) || !isRecord(body.flags)) {
+      return false;
+    }
+
+    const flag = body.flags[CHANNELS_TERMINAL_BATCHING_FLAG];
+    return isRecord(flag) && flag.enabled === true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/channels-intelligence/src/operations-feature-flags.ts
+++ b/packages/channels-intelligence/src/operations-feature-flags.ts
@@ -2,6 +2,7 @@ const OPERATIONS_POSTHOG_FLAGS_URL = "https://eu.i.posthog.com/flags/?v=2";
 const OPERATIONS_POSTHOG_PROJECT_TOKEN =
   "phc_XZdymVYjrph9Mi0xZYGNyCKexxgblXRR1jMENCtdz5Q";
 const CHANNELS_TERMINAL_BATCHING_FLAG = "channels-terminal-batching";
+const OPERATIONS_POSTHOG_REQUEST_TIMEOUT_MS = 3_000;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -11,10 +12,17 @@ export async function isChannelsTerminalBatchingEnabled(
   projectId: number,
   fetch: typeof globalThis.fetch = globalThis.fetch,
 ): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    OPERATIONS_POSTHOG_REQUEST_TIMEOUT_MS,
+  );
+
   try {
     const response = await fetch(OPERATIONS_POSTHOG_FLAGS_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
+      signal: controller.signal,
       body: JSON.stringify({
         token: OPERATIONS_POSTHOG_PROJECT_TOKEN,
         distinct_id: `intelligence-project:${projectId}`,
@@ -34,5 +42,7 @@ export async function isChannelsTerminalBatchingEnabled(
     return isRecord(flag) && flag.enabled === true;
   } catch {
     return false;
+  } finally {
+    clearTimeout(timeout);
   }
 }

--- a/packages/channels-intelligence/src/operations-feature-flags.ts
+++ b/packages/channels-intelligence/src/operations-feature-flags.ts
@@ -11,12 +11,22 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 export async function isChannelsTerminalBatchingEnabled(
   projectId: number,
   fetch: typeof globalThis.fetch = globalThis.fetch,
+  log?: (message: string, meta?: unknown) => void,
 ): Promise<boolean> {
   const controller = new AbortController();
   const timeout = setTimeout(
     () => controller.abort(),
     OPERATIONS_POSTHOG_REQUEST_TIMEOUT_MS,
   );
+  const failClosed = (
+    reason: "http_error" | "invalid_response" | "request_failed",
+  ): false => {
+    log?.(
+      "channels terminal batching flag evaluation failed; using streaming",
+      { reason },
+    );
+    return false;
+  };
 
   try {
     const response = await fetch(OPERATIONS_POSTHOG_FLAGS_URL, {
@@ -30,18 +40,21 @@ export async function isChannelsTerminalBatchingEnabled(
       }),
     });
     if (!response.ok) {
-      return false;
+      return failClosed("http_error");
     }
 
     const body: unknown = await response.json();
     if (!isRecord(body) || !isRecord(body.flags)) {
-      return false;
+      return failClosed("invalid_response");
     }
 
     const flag = body.flags[CHANNELS_TERMINAL_BATCHING_FLAG];
-    return isRecord(flag) && flag.enabled === true;
+    if (!isRecord(flag) || typeof flag.enabled !== "boolean") {
+      return failClosed("invalid_response");
+    }
+    return flag.enabled;
   } catch {
-    return false;
+    return failClosed("request_failed");
   } finally {
     clearTimeout(timeout);
   }

--- a/packages/channels-intelligence/src/public-api.test.ts
+++ b/packages/channels-intelligence/src/public-api.test.ts
@@ -1,0 +1,16 @@
+import { describe, expectTypeOf, it } from "vitest";
+import type { IntelligenceAdapter } from "./index.js";
+import type { IntelligenceAdapterOptions } from "./index.js";
+
+describe("channels-intelligence public API", () => {
+  it("keeps IntelligenceAdapter construction to its single public options object", () => {
+    expectTypeOf<
+      ConstructorParameters<typeof IntelligenceAdapter>
+    >().toEqualTypeOf<[opts?: IntelligenceAdapterOptions]>();
+    expectTypeOf<
+      "terminalBatchingEnabled" extends keyof IntelligenceAdapterOptions
+        ? true
+        : false
+    >().toEqualTypeOf<false>();
+  });
+});

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { createChannel, FakeAgent } from "@copilotkit/channels-core";
 import { Section } from "@copilotkit/channels-ui";
 import {
@@ -94,6 +94,10 @@ function isObject(value: unknown): value is {
 } {
   return value !== null && typeof value === "object";
 }
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("startChannelsWithGatewaySession — Channel runtime over Realtime Gateway (OSS-406)", () => {
   it("finalizes a direct post before requesting completion and never self-acks", async () => {
@@ -485,6 +489,66 @@ function makeFakeWebSocket(mode: JoinMode) {
 }
 
 describe("startChannelsOverRealtimeGateway — socket lifecycle cleanup (OSS-406)", () => {
+  it("evaluates terminal batching once only for the exact managed production activation", async () => {
+    const evaluateFlag = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        flags: { "channels-terminal-batching": { enabled: true } },
+      }),
+    }));
+    vi.stubGlobal("fetch", evaluateFlag);
+    const { FakeWebSocket } = makeFakeWebSocket("ok");
+    const makeBot = () =>
+      createChannel({
+        name: "opentag",
+        agent: () => new FakeAgent(),
+      });
+
+    const managed = await startChannelsOverRealtimeGateway([makeBot()], {
+      wsUrl: "wss://realtime.intelligence.copilotkit.ai/runner",
+      appApiBaseUrl: "https://api.intelligence.copilotkit.ai",
+      apiKey: "cpk-test",
+      scope,
+      runtimeInstanceId: "rti_managed",
+      env: { runtimeEnv: "production" },
+      webSocket: FakeWebSocket,
+    });
+    expect(evaluateFlag).toHaveBeenCalledTimes(1);
+    await managed.stop();
+
+    const custom = await startChannelsOverRealtimeGateway([makeBot()], {
+      wsUrl: "wss://gateway.example/runner",
+      appApiBaseUrl: "https://api.example",
+      apiKey: "cpk-test",
+      scope,
+      runtimeInstanceId: "rti_custom",
+      env: { runtimeEnv: "production" },
+      webSocket: FakeWebSocket,
+    });
+    await custom.stop();
+
+    const development = await startChannelsOverRealtimeGateway([makeBot()], {
+      wsUrl: "wss://realtime.intelligence.copilotkit.ai/runner",
+      appApiBaseUrl: "https://api.intelligence.copilotkit.ai",
+      apiKey: "cpk-test",
+      scope,
+      runtimeInstanceId: "rti_development",
+      env: { runtimeEnv: "development" },
+      webSocket: FakeWebSocket,
+    });
+    await development.stop();
+
+    const callerOwned = await startChannelsWithGatewaySession([makeBot()], {
+      session: makeFakeSession().session,
+      scope,
+      runtimeInstanceId: "rti_caller_owned",
+      env: { runtimeEnv: "production" },
+    });
+    await callerOwned.stop();
+
+    expect(evaluateFlag).toHaveBeenCalledTimes(1);
+  });
+
   it("disconnects the socket when the channel join times out", async () => {
     const { FakeWebSocket, instances } = makeFakeWebSocket("never");
     const bot = createChannel({

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.test.ts
@@ -49,7 +49,11 @@ function makeFakeSession() {
 
 /** Simulate one leased text-turn delivery arriving over the gateway session. */
 function deliverText(handlers: Map<string, (p: unknown) => void>) {
-  handlers.get("channel.delivery.available.v1")?.({
+  handlers.get("channel.delivery.available.v1")?.(textDeliveryPayload());
+}
+
+function textDeliveryPayload() {
+  return {
     payload: {
       delivery: {
         id: "dlv_1",
@@ -64,7 +68,7 @@ function deliverText(handlers: Map<string, (p: unknown) => void>) {
         },
       },
     },
-  });
+  };
 }
 
 /** The gateway session `delivery.available` handler is fire-and-forget, so poll until
@@ -556,6 +560,9 @@ function makeFakeWebSocket(mode: JoinMode) {
     onerror: ((ev?: unknown) => void) | null = null;
     onclose: ((ev?: unknown) => void) | null = null;
     closed = false;
+    readonly frames: unknown[] = [];
+    private joinRef: string | undefined;
+    private topic: string | undefined;
     constructor(public readonly url: string) {
       instances.push(this);
       queueMicrotask(() => {
@@ -571,16 +578,40 @@ function makeFakeWebSocket(mode: JoinMode) {
       } catch {
         return;
       }
+      this.frames.push(frame);
       if (!Array.isArray(frame)) return;
-      const [joinRef, ref, topic, event] = frame as [
+      const [joinRef, ref, topic, event, payload] = frame as [
         string,
         string,
         string,
         string,
+        unknown,
       ];
-      if (event !== "phx_join") return;
-      const status = mode === "ok" ? "ok" : "error";
-      const response = mode === "ok" ? {} : { reason: "unauthorized" };
+      const joining = event === "phx_join";
+      if (joining) {
+        this.joinRef = joinRef;
+        this.topic = topic;
+      }
+      const status = joining && mode === "error" ? "error" : "ok";
+      const renderPayload =
+        isObject(payload) && isObject(payload.payload)
+          ? payload.payload
+          : undefined;
+      const response =
+        status === "error"
+          ? { reason: "unauthorized" }
+          : event === "channel.render_batch.v1" && renderPayload
+            ? {
+                type: "channel.render_batch_accepted.v1",
+                occurredAt: "2026-07-09T00:00:00.000Z",
+                payload: {
+                  batchId: renderPayload.batchId,
+                  egressOperationId: "eop_1",
+                  acceptedThroughSeq: renderPayload.endSeq,
+                  duplicate: false,
+                },
+              }
+            : {};
       const reply = JSON.stringify([
         joinRef,
         ref,
@@ -589,6 +620,14 @@ function makeFakeWebSocket(mode: JoinMode) {
         { status, response },
       ]);
       queueMicrotask(() => this.onmessage?.({ data: reply }));
+    }
+    pushServer(event: string, payload: unknown): void {
+      if (this.joinRef === undefined || this.topic === undefined) {
+        throw new Error("fake socket has not joined");
+      }
+      this.onmessage?.({
+        data: JSON.stringify([this.joinRef, null, this.topic, event, payload]),
+      });
     }
     close(): void {
       this.closed = true;
@@ -600,6 +639,71 @@ function makeFakeWebSocket(mode: JoinMode) {
 }
 
 describe("startChannelsOverRealtimeGateway — socket lifecycle cleanup (OSS-406)", () => {
+  it("carries an enabled managed-production decision into terminal adapter behavior", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          flags: { "channels-terminal-batching": { enabled: true } },
+        }),
+      })),
+    );
+    const { FakeWebSocket, instances } = makeFakeWebSocket("ok");
+    const agent = new FakeAgent([
+      async (subscriber) => {
+        await subscriber.onTextMessageContentEvent?.({
+          event: { messageId: "m1", delta: "hello" },
+        } as never);
+        await subscriber.onTextMessageEndEvent?.({
+          event: { messageId: "m1" },
+        } as never);
+      },
+    ]);
+    const channel = createChannel({
+      name: "opentag",
+      agent: () => agent,
+    });
+    channel.onMessage(async ({ thread }) => {
+      await thread.runAgent();
+    });
+
+    const handle = await startChannelsOverRealtimeGateway([channel], {
+      wsUrl: "wss://realtime.intelligence.copilotkit.ai/runner",
+      appApiBaseUrl: "https://api.intelligence.copilotkit.ai",
+      apiKey: "cpk-test",
+      scope,
+      runtimeInstanceId: "rti_managed_behavior",
+      env: { runtimeEnv: "production" },
+      webSocket: FakeWebSocket,
+    });
+    instances[0]!.pushServer(
+      "channel.delivery.available.v1",
+      textDeliveryPayload(),
+    );
+    await waitFor(() =>
+      instances[0]!.frames.some(
+        (frame) =>
+          Array.isArray(frame) &&
+          frame[3] === "channel.delivery.complete_requested.v1",
+      ),
+    );
+
+    const renderPushes = instances[0]!.frames.filter(
+      (frame) => Array.isArray(frame) && frame[3] === "channel.render_batch.v1",
+    ) as Array<
+      [string, string, string, string, { payload: { frames: unknown[] } }]
+    >;
+    expect(renderPushes).toHaveLength(1);
+    expect(
+      renderPushes[0]![4].payload.frames.map((frame) =>
+        isObject(frame) && isObject(frame.event) ? frame.event.kind : undefined,
+      ),
+    ).toEqual(["run_started", "text_delta", "text_end", "finalize"]);
+
+    await handle.stop();
+  });
+
   it("evaluates terminal batching once only for the exact managed production activation", async () => {
     const evaluateFlag = vi.fn(async () => ({
       ok: true,
@@ -609,6 +713,7 @@ describe("startChannelsOverRealtimeGateway — socket lifecycle cleanup (OSS-406
     }));
     vi.stubGlobal("fetch", evaluateFlag);
     const { FakeWebSocket } = makeFakeWebSocket("ok");
+    const log = vi.fn();
     const makeBot = () =>
       createChannel({
         name: "opentag",
@@ -623,8 +728,19 @@ describe("startChannelsOverRealtimeGateway — socket lifecycle cleanup (OSS-406
       runtimeInstanceId: "rti_managed",
       env: { runtimeEnv: "production" },
       webSocket: FakeWebSocket,
+      log,
     });
     expect(evaluateFlag).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith(
+      "channels terminal batching activation decision",
+      {
+        eligible: true,
+        enabled: true,
+        managedAppApi: true,
+        managedGateway: true,
+        production: true,
+      },
+    );
     await managed.stop();
 
     const custom = await startChannelsOverRealtimeGateway([makeBot()], {
@@ -635,7 +751,18 @@ describe("startChannelsOverRealtimeGateway — socket lifecycle cleanup (OSS-406
       runtimeInstanceId: "rti_custom",
       env: { runtimeEnv: "production" },
       webSocket: FakeWebSocket,
+      log,
     });
+    expect(log).toHaveBeenCalledWith(
+      "channels terminal batching activation decision",
+      {
+        eligible: false,
+        enabled: false,
+        managedAppApi: false,
+        managedGateway: false,
+        production: true,
+      },
+    );
     await custom.stop();
 
     const development = await startChannelsOverRealtimeGateway([makeBot()], {

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.ts
@@ -1,6 +1,6 @@
 import type { Channel } from "@copilotkit/channels-core";
 import {
-  startChannels,
+  startChannelsInternal,
   assertValidChannelNames,
   buildChannelActivationMetadata,
   resolveChannelActivationEnv,
@@ -15,6 +15,11 @@ import type { ChannelRealtimeScope } from "./realtime-gateway-transport.js";
 import type { RealtimeGatewaySession } from "./realtime-gateway.js";
 import type { EgressSink } from "./transports.js";
 import { RENDER_BATCH_PROTOCOL_CAPABILITY } from "./render-batches.js";
+import { isChannelsTerminalBatchingEnabled } from "./operations-feature-flags.js";
+
+const MANAGED_PRODUCTION_GATEWAY_URL =
+  "wss://realtime.intelligence.copilotkit.ai/runner";
+const MANAGED_PRODUCTION_APP_API_URL = "https://api.intelligence.copilotkit.ai";
 
 /**
  * Realtime Gateway egress is vestigial: with a render sink wired (the transport
@@ -108,6 +113,14 @@ export async function startChannelsWithGatewaySession(
   channels: Channel[],
   opts: StartChannelsWithGatewaySessionOptions,
 ): Promise<ChannelsHandle> {
+  return startChannelsWithGatewaySessionInternal(channels, opts, false);
+}
+
+async function startChannelsWithGatewaySessionInternal(
+  channels: Channel[],
+  opts: StartChannelsWithGatewaySessionOptions,
+  terminalBatchingEnabled: boolean,
+): Promise<ChannelsHandle> {
   assertScopeMatchesChannel(channels, opts.scope);
   const transport = new RealtimeGatewayTransport({
     scope: opts.scope,
@@ -117,18 +130,21 @@ export async function startChannelsWithGatewaySession(
     ...(opts.apiKey ? { apiKey: opts.apiKey } : {}),
     ...(opts.log ? { log: opts.log } : {}),
   });
-  const handle = await startChannels({
-    channels,
-    resolveTransport: () => ({
-      source: transport,
-      renderSink: transport,
-      egress: realtimeGatewayEgress,
-    }),
-    // The required runtimeInstanceId is authoritative: merge it in LAST so
-    // `handle.metadata` reports the same id the transport stamps on every
-    // envelope, regardless of any `env` overrides (which cannot carry it).
-    env: { ...opts.env, runtimeInstanceId: opts.runtimeInstanceId },
-  });
+  const handle = await startChannelsInternal(
+    {
+      channels,
+      resolveTransport: () => ({
+        source: transport,
+        renderSink: transport,
+        egress: realtimeGatewayEgress,
+      }),
+      // The required runtimeInstanceId is authoritative: merge it in LAST so
+      // `handle.metadata` reports the same id the transport stamps on every
+      // envelope, regardless of any `env` overrides (which cannot carry it).
+      env: { ...opts.env, runtimeInstanceId: opts.runtimeInstanceId },
+    },
+    terminalBatchingEnabled,
+  );
   // This variant does not own the socket (the caller passed an
   // already-joined session), so it neither connects nor disconnects it. Still
   // pass through drop notification when the session supports it (it does not
@@ -238,6 +254,12 @@ export async function startChannelsOverRealtimeGateway(
     channels,
     resolveChannelActivationEnv(envOverrides),
   );
+  const terminalBatchingEnabled =
+    config.wsUrl === MANAGED_PRODUCTION_GATEWAY_URL &&
+    config.appApiBaseUrl === MANAGED_PRODUCTION_APP_API_URL &&
+    activation.runtimeEnv === "production"
+      ? await isChannelsTerminalBatchingEnabled(config.scope.projectId)
+      : false;
 
   const session = await connectRealtimeGateway({
     wsUrl: config.wsUrl,
@@ -281,20 +303,26 @@ export async function startChannelsOverRealtimeGateway(
   // handle — so disconnect the socket here rather than leak it, then rethrow.
   let handle: ChannelsHandle;
   try {
-    handle = await startChannelsWithGatewaySession(channels, {
-      session,
-      scope: config.scope,
-      runtimeInstanceId: config.runtimeInstanceId,
-      // File/history parity is HTTP-only; forward the app-api coordinates (the
-      // apiKey is the same one used as the socket authToken) so the transport
-      // can reach the file/history REST endpoints directly.
-      ...(config.appApiBaseUrl ? { appApiBaseUrl: config.appApiBaseUrl } : {}),
-      apiKey: config.apiKey,
-      // The session-start helper re-merges the authoritative runtimeInstanceId,
-      // so forward only the caller's overrides here (they cannot carry the id).
-      ...(config.env ? { env: config.env } : {}),
-      ...(config.log ? { log: config.log } : {}),
-    });
+    handle = await startChannelsWithGatewaySessionInternal(
+      channels,
+      {
+        session,
+        scope: config.scope,
+        runtimeInstanceId: config.runtimeInstanceId,
+        // File/history parity is HTTP-only; forward the app-api coordinates (the
+        // apiKey is the same one used as the socket authToken) so the transport
+        // can reach the file/history REST endpoints directly.
+        ...(config.appApiBaseUrl
+          ? { appApiBaseUrl: config.appApiBaseUrl }
+          : {}),
+        apiKey: config.apiKey,
+        // The session-start helper re-merges the authoritative runtimeInstanceId,
+        // so forward only the caller's overrides here (they cannot carry the id).
+        ...(config.env ? { env: config.env } : {}),
+        ...(config.log ? { log: config.log } : {}),
+      },
+      terminalBatchingEnabled,
+    );
   } catch (err) {
     session.disconnect();
     throw err;

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.ts
@@ -16,6 +16,8 @@ import type { RealtimeGatewaySession } from "./realtime-gateway.js";
 import type { EgressSink } from "./transports.js";
 import { RENDER_BATCH_PROTOCOL_CAPABILITY } from "./render-batches.js";
 import { isChannelsTerminalBatchingEnabled } from "./operations-feature-flags.js";
+import { STREAMING_CHANNEL_ACTIVATION_DECISION } from "./intelligence-adapter.js";
+import type { InternalChannelActivationDecision } from "./intelligence-adapter.js";
 
 const MANAGED_PRODUCTION_GATEWAY_URL =
   "wss://realtime.intelligence.copilotkit.ai/runner";
@@ -115,13 +117,17 @@ export async function startChannelsWithGatewaySession(
   channels: Channel[],
   opts: StartChannelsWithGatewaySessionOptions,
 ): Promise<ChannelsHandle> {
-  return startChannelsWithGatewaySessionInternal(channels, opts, false);
+  return startChannelsWithGatewaySessionInternal(
+    channels,
+    opts,
+    STREAMING_CHANNEL_ACTIVATION_DECISION,
+  );
 }
 
 async function startChannelsWithGatewaySessionInternal(
   channels: Channel[],
   opts: StartChannelsWithGatewaySessionOptions,
-  terminalBatchingEnabled: boolean,
+  decision: InternalChannelActivationDecision,
 ): Promise<ChannelsHandle> {
   assertScopeMatchesChannel(channels, opts.scope);
   const transport = new RealtimeGatewayTransport({
@@ -146,7 +152,7 @@ async function startChannelsWithGatewaySessionInternal(
       env: { ...opts.env, runtimeInstanceId: opts.runtimeInstanceId },
       showToolStatus: opts.showToolStatus,
     },
-    terminalBatchingEnabled,
+    decision,
   );
   // This variant does not own the socket (the caller passed an
   // already-joined session), so it neither connects nor disconnects it. Still
@@ -263,12 +269,27 @@ export async function startChannelsOverRealtimeGateway(
     channels,
     resolveChannelActivationEnv(envOverrides),
   );
-  const terminalBatchingEnabled =
-    config.wsUrl === MANAGED_PRODUCTION_GATEWAY_URL &&
-    config.appApiBaseUrl === MANAGED_PRODUCTION_APP_API_URL &&
-    activation.runtimeEnv === "production"
-      ? await isChannelsTerminalBatchingEnabled(config.scope.projectId)
-      : false;
+  const managedGateway = config.wsUrl === MANAGED_PRODUCTION_GATEWAY_URL;
+  const managedAppApi = config.appApiBaseUrl === MANAGED_PRODUCTION_APP_API_URL;
+  const production = activation.runtimeEnv === "production";
+  const eligible = managedGateway && managedAppApi && production;
+  const terminalBatchingEnabled = eligible
+    ? await isChannelsTerminalBatchingEnabled(
+        config.scope.projectId,
+        globalThis.fetch,
+        config.log,
+      )
+    : false;
+  const activationDecision: InternalChannelActivationDecision = Object.freeze({
+    terminalBatchingEnabled,
+  });
+  config.log?.("channels terminal batching activation decision", {
+    eligible,
+    enabled: terminalBatchingEnabled,
+    managedAppApi,
+    managedGateway,
+    production,
+  });
 
   const session = await connectRealtimeGateway({
     wsUrl: config.wsUrl,
@@ -331,7 +352,7 @@ export async function startChannelsOverRealtimeGateway(
         ...(config.log ? { log: config.log } : {}),
         showToolStatus: config.showToolStatus,
       },
-      terminalBatchingEnabled,
+      activationDecision,
     );
   } catch (err) {
     session.disconnect();

--- a/packages/channels-intelligence/src/render-batches.test.ts
+++ b/packages/channels-intelligence/src/render-batches.test.ts
@@ -262,6 +262,33 @@ describe("managed render batch compaction", () => {
     ]);
   });
 
+  it("preserves the 250 ms text boundary without submitting the terminal batch early", async () => {
+    vi.useFakeTimers();
+    const sink = new RecordingBatchSink();
+    const { renderer, subscriber } = createTerminalBatchingRenderer(sink);
+
+    subscriber.onTextMessageContentEvent?.({
+      event: { messageId: "m1", delta: "first" },
+    });
+    await vi.advanceTimersByTimeAsync(250);
+    expect(sink.batches).toHaveLength(0);
+
+    subscriber.onTextMessageContentEvent?.({
+      event: { messageId: "m1", delta: " second" },
+    });
+    await renderer.finish?.();
+
+    expect(sink.batches).toHaveLength(1);
+    expect(
+      sink.batches[0]?.frames
+        .filter((frame) => frame.event.kind === "text_delta")
+        .map((frame) => frame.event),
+    ).toEqual([
+      { kind: "text_delta", messageId: "m1", delta: "first" },
+      { kind: "text_delta", messageId: "m1", delta: " second" },
+    ]);
+  });
+
   it.each([
     {
       name: "interrupt",
@@ -358,7 +385,9 @@ describe("managed render batch compaction", () => {
       event: { toolCallId: "tc64", toolCallName: "search" },
     });
     await settle();
-    expect(sink.batches.at(-1)?.frames).toHaveLength(1);
+    expect(sink.batches.map((batch) => batch.frames.length)).toEqual([
+      64, 1, 1,
+    ]);
 
     await renderer.finish?.();
   });
@@ -383,7 +412,7 @@ describe("managed render batch compaction", () => {
       event: { toolCallId: "tc4", toolCallName: "small" },
     });
     await settle();
-    expect(sink.batches.at(-1)?.frames).toHaveLength(1);
+    expect(sink.batches.map((batch) => batch.frames.length)).toEqual([4, 1, 1]);
 
     await renderer.finish?.();
   });

--- a/packages/channels-intelligence/src/render-batches.test.ts
+++ b/packages/channels-intelligence/src/render-batches.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ReplyTarget } from "@copilotkit/channels-core";
-import { intelligenceAdapter } from "./intelligence-adapter.js";
+import {
+  intelligenceAdapter,
+  intelligenceAdapterInternal,
+} from "./intelligence-adapter.js";
 import {
   InMemoryDeliverySource,
   InMemoryEgressSink,
@@ -53,6 +56,23 @@ const createRenderer = (sink: RenderEventSink) => {
   });
   const renderer = adapter.createRunRenderer(target);
   return {
+    renderer,
+    subscriber: renderer.subscriber as unknown as Subscriber,
+  };
+};
+
+const createTerminalBatchingRenderer = (sink: RenderEventSink) => {
+  const adapter = intelligenceAdapterInternal(
+    {
+      source: new InMemoryDeliverySource(),
+      egress: new InMemoryEgressSink(),
+      renderSink: sink,
+    },
+    { terminalBatchingEnabled: true },
+  );
+  const renderer = adapter.createRunRenderer(target);
+  return {
+    adapter,
     renderer,
     subscriber: renderer.subscriber as unknown as Subscriber,
   };
@@ -157,7 +177,7 @@ describe("managed render batch compaction", () => {
     expect(attempts).toHaveLength(1);
   });
 
-  it("flushes the first non-empty text immediately with contiguous post-compaction sequence numbers", async () => {
+  it("keeps eager first-text streaming when terminal batching is disabled", async () => {
     const sink = new RecordingBatchSink();
     const { renderer, subscriber } = createRenderer(sink);
 
@@ -184,6 +204,188 @@ describe("managed render batch compaction", () => {
         },
       ],
     });
+  });
+
+  it("holds a bounded effect-free run and submits one ordered terminal batch on success", async () => {
+    const sink = new RecordingBatchSink();
+    const { renderer, subscriber } = createTerminalBatchingRenderer(sink);
+
+    subscriber.onTextMessageContentEvent?.({
+      event: { messageId: "m1", delta: "hello " },
+    });
+    subscriber.onTextMessageContentEvent?.({
+      event: { messageId: "m1", delta: "world" },
+    });
+    subscriber.onToolCallStartEvent?.({
+      event: { toolCallId: "tc1", toolCallName: "search" },
+    });
+    subscriber.onToolCallEndEvent?.({
+      event: { toolCallId: "tc1" },
+      toolCallName: "search",
+      toolCallArgs: {},
+    } as never);
+    subscriber.onTextMessageEndEvent?.({ event: { messageId: "m1" } });
+    await settle();
+
+    expect(sink.batches).toHaveLength(0);
+    await renderer.finish?.();
+
+    expect(sink.batches).toHaveLength(1);
+    expect(sink.batches[0]?.frames).toEqual([
+      { seq: 0, event: { kind: "run_started" } },
+      {
+        seq: 1,
+        event: {
+          kind: "text_delta",
+          messageId: "m1",
+          delta: "hello world",
+        },
+      },
+      {
+        seq: 2,
+        event: {
+          kind: "tool_start",
+          toolCallId: "tc1",
+          toolName: "search",
+        },
+      },
+      {
+        seq: 3,
+        event: {
+          kind: "tool_end",
+          toolCallId: "tc1",
+          toolName: "search",
+        },
+      },
+      { seq: 4, event: { kind: "text_end", messageId: "m1" } },
+      { seq: 5, event: { kind: "finalize" } },
+    ]);
+  });
+
+  it.each([
+    {
+      name: "interrupt",
+      drive: async (
+        renderer: ReturnType<typeof createTerminalBatchingRenderer>["renderer"],
+        subscriber: Subscriber,
+      ) => {
+        subscriber.onTextMessageContentEvent?.({
+          event: { messageId: "m1", delta: "partial" },
+        });
+        await renderer.markInterrupted();
+      },
+      expected: ["run_started", "text_delta", "interrupt", "finalize"],
+    },
+    {
+      name: "run_error",
+      drive: async (
+        renderer: ReturnType<typeof createTerminalBatchingRenderer>["renderer"],
+        subscriber: Subscriber,
+      ) => {
+        subscriber.onRunErrorEvent?.({
+          event: { message: "failed" },
+        });
+        await renderer.finish?.();
+      },
+      expected: ["run_started", "run_error", "finalize"],
+    },
+  ])(
+    "submits one complete ordered terminal history for $name",
+    async ({ drive, expected }) => {
+      const sink = new RecordingBatchSink();
+      const { renderer, subscriber } = createTerminalBatchingRenderer(sink);
+
+      await drive(renderer, subscriber);
+
+      expect(sink.batches).toHaveLength(1);
+      expect(sink.batches[0]?.frames.map((frame) => frame.event.kind)).toEqual(
+        expected,
+      );
+    },
+  );
+
+  it("flushes the buffered prefix before an explicit effect and streams the rest contiguously", async () => {
+    const sink = new RecordingBatchSink();
+    const { adapter, renderer, subscriber } =
+      createTerminalBatchingRenderer(sink);
+    const card = [
+      { type: "section", props: { children: "card" } },
+    ] as unknown as Parameters<typeof adapter.post>[1];
+
+    subscriber.onTextMessageContentEvent?.({
+      event: { messageId: "m1", delta: "before" },
+    });
+    await adapter.post(target, card);
+
+    subscriber.onTextMessageContentEvent?.({
+      event: { messageId: "m1", delta: " after" },
+    });
+    subscriber.onTextMessageEndEvent?.({ event: { messageId: "m1" } });
+    await settle();
+
+    expect(
+      sink.batches.map((batch) =>
+        batch.frames.map((frame) => frame.event.kind),
+      ),
+    ).toEqual([
+      ["run_started", "text_delta"],
+      ["post"],
+      ["text_delta", "text_end"],
+    ]);
+    expect(
+      sink.batches.flatMap((batch) => batch.frames.map((frame) => frame.seq)),
+    ).toEqual([0, 1, 2, 3, 4]);
+
+    await renderer.finish?.();
+    expect(sink.batches.at(-1)?.frames).toEqual([
+      { seq: 5, event: { kind: "finalize" } },
+    ]);
+  });
+
+  it("flushes a full 64-frame prefix and permanently falls back to streaming", async () => {
+    const sink = new RecordingBatchSink();
+    const { renderer, subscriber } = createTerminalBatchingRenderer(sink);
+
+    for (let index = 0; index < 64; index += 1) {
+      subscriber.onToolCallStartEvent?.({
+        event: { toolCallId: `tc${index}`, toolCallName: "search" },
+      });
+    }
+    await settle();
+
+    expect(sink.batches.map((batch) => batch.frames.length)).toEqual([64, 1]);
+    subscriber.onToolCallStartEvent?.({
+      event: { toolCallId: "tc64", toolCallName: "search" },
+    });
+    await settle();
+    expect(sink.batches.at(-1)?.frames).toHaveLength(1);
+
+    await renderer.finish?.();
+  });
+
+  it("flushes a byte-bounded prefix and permanently falls back to streaming", async () => {
+    const sink = new RecordingBatchSink();
+    const { renderer, subscriber } = createTerminalBatchingRenderer(sink);
+    const largeToolName = "x".repeat(40 * 1024);
+
+    for (let index = 0; index < 3; index += 1) {
+      subscriber.onToolCallStartEvent?.({
+        event: { toolCallId: `tc${index}`, toolCallName: largeToolName },
+      });
+    }
+    subscriber.onTextMessageContentEvent?.({
+      event: { messageId: "m1", delta: "x".repeat(16 * 1024) },
+    });
+    await settle();
+
+    expect(sink.batches.map((batch) => batch.frames.length)).toEqual([4, 1]);
+    subscriber.onToolCallStartEvent?.({
+      event: { toolCallId: "tc4", toolCallName: "small" },
+    });
+    await settle();
+    expect(sink.batches.at(-1)?.frames).toHaveLength(1);
+
+    await renderer.finish?.();
   });
 
   it("flushes later adjacent text at a deterministic delta count and before a semantic boundary", async () => {

--- a/packages/channels-intelligence/src/render-batches.test.ts
+++ b/packages/channels-intelligence/src/render-batches.test.ts
@@ -643,6 +643,53 @@ describe("managed render batch compaction", () => {
     ]);
   });
 
+  it("keeps every concurrent renderer on one ordered turn lane before an effect", async () => {
+    const sink = new RecordingBatchSink();
+    const adapter = intelligenceAdapterInternal(
+      {
+        source: new InMemoryDeliverySource(),
+        egress: new InMemoryEgressSink(),
+        renderSink: sink,
+      },
+      { terminalBatchingEnabled: true },
+    );
+    const first = adapter.createRunRenderer(target);
+    const second = adapter.createRunRenderer(target);
+    const firstSubscriber = first.subscriber as unknown as Subscriber;
+    const secondSubscriber = second.subscriber as unknown as Subscriber;
+    const card = [
+      { type: "section", props: { children: "card" } },
+    ] as unknown as Parameters<typeof adapter.post>[1];
+
+    firstSubscriber.onTextMessageContentEvent?.({
+      event: { messageId: "m1", delta: "first" },
+    });
+    secondSubscriber.onTextMessageContentEvent?.({
+      event: { messageId: "m2", delta: "second" },
+    });
+    await adapter.post(target, card);
+    await first.finish?.();
+    await second.finish?.();
+
+    const frames = sink.batches.flatMap((batch) => batch.frames);
+    expect(
+      frames.map((frame) =>
+        frame.event.kind === "text_delta"
+          ? `${frame.event.kind}:${frame.event.delta}`
+          : frame.event.kind,
+      ),
+    ).toEqual([
+      "run_started",
+      "text_delta:first",
+      "run_started",
+      "text_delta:second",
+      "post",
+      "finalize",
+      "finalize",
+    ]);
+    expect(frames.map((frame) => frame.seq)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+  });
+
   it("fails the lane with a stable bounded-memory error while transport is stalled", async () => {
     const sink: RenderEventSink = {
       pushBatch: async () => new Promise(() => undefined),

--- a/packages/channels-intelligence/src/runtime.ts
+++ b/packages/channels-intelligence/src/runtime.ts
@@ -5,9 +5,10 @@ import type {
   RenderEventSink,
 } from "./transports.js";
 import {
-  intelligenceAdapter,
   intelligenceAdapterInternal,
+  STREAMING_CHANNEL_ACTIVATION_DECISION,
 } from "./intelligence-adapter.js";
+import type { InternalChannelActivationDecision } from "./intelligence-adapter.js";
 
 /** Lowercase kebab-case Channel name, 3–64 characters. */
 const CHANNEL_NAME_RE = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
@@ -172,7 +173,7 @@ export interface ChannelsHandle {
 export async function startChannels(
   opts: StartChannelsOptions,
 ): Promise<ChannelsHandle> {
-  return startChannelsInternal(opts, false);
+  return startChannelsInternal(opts, STREAMING_CHANNEL_ACTIVATION_DECISION);
 }
 
 /**
@@ -181,7 +182,7 @@ export async function startChannels(
  */
 export async function startChannelsInternal(
   opts: StartChannelsOptions,
-  terminalBatchingEnabled: boolean,
+  decision: InternalChannelActivationDecision,
 ): Promise<ChannelsHandle> {
   assertValidChannelNames(opts.channels);
   if (opts.channels.length === 0) {
@@ -212,11 +213,7 @@ export async function startChannelsInternal(
         showToolStatus: opts.showToolStatus ?? channel.showToolStatus,
       };
       channel.ɵruntime.addAdapter(
-        terminalBatchingEnabled
-          ? intelligenceAdapterInternal(adapterOptions, {
-              terminalBatchingEnabled: true,
-            })
-          : intelligenceAdapter(adapterOptions),
+        intelligenceAdapterInternal(adapterOptions, decision),
       );
       await channel.ɵruntime.start();
       startedChannels.push(channel);

--- a/packages/channels-intelligence/src/runtime.ts
+++ b/packages/channels-intelligence/src/runtime.ts
@@ -4,7 +4,10 @@ import type {
   EgressSink,
   RenderEventSink,
 } from "./transports.js";
-import { intelligenceAdapter } from "./intelligence-adapter.js";
+import {
+  intelligenceAdapter,
+  intelligenceAdapterInternal,
+} from "./intelligence-adapter.js";
 
 /** Lowercase kebab-case Channel name, 3–64 characters. */
 const CHANNEL_NAME_RE = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
@@ -164,6 +167,17 @@ export interface ChannelsHandle {
 export async function startChannels(
   opts: StartChannelsOptions,
 ): Promise<ChannelsHandle> {
+  return startChannelsInternal(opts, false);
+}
+
+/**
+ * Managed-activation seam for carrying private Operations decisions to adapter
+ * construction without widening the public runtime or adapter options.
+ */
+export async function startChannelsInternal(
+  opts: StartChannelsOptions,
+  terminalBatchingEnabled: boolean,
+): Promise<ChannelsHandle> {
   assertValidChannelNames(opts.channels);
   if (opts.channels.length === 0) {
     console.warn(
@@ -186,7 +200,12 @@ export async function startChannels(
         channel.name!,
       );
       channel.ɵruntime.addAdapter(
-        intelligenceAdapter({ source, egress, renderSink, store }),
+        terminalBatchingEnabled
+          ? intelligenceAdapterInternal(
+              { source, egress, renderSink, store },
+              { terminalBatchingEnabled: true },
+            )
+          : intelligenceAdapter({ source, egress, renderSink, store }),
       );
       await channel.ɵruntime.start();
       startedChannels.push(channel);


### PR DESCRIPTION
## Summary

Implements the approved managed Channels terminal-batching brownout in `@copilotkit/channels-intelligence`.

- evaluates `channels-terminal-batching` once per exact managed production activation, scoped to `intelligence-project:<projectId>`, and fails closed
- carries the activation-wide flag decision through the private launcher/runtime seams into observable adapter batching behavior
- buffers bounded, effect-free renderer history into one terminal render batch
- flushes buffered partial history before nacking a run that rejects before renderer completion
- preserves ordering when multiple renderers share a turn and when explicit effects force streaming fallback
- logs safe managed-eligibility and flag-failure diagnostics without customer identifiers, secrets, or response bodies
- keeps direct/custom/self-hosted paths and the public `IntelligenceAdapter` constructor unchanged

## Validation

- `@copilotkit/channels-intelligence`: 274 tests passing
- focused managed-production integration test proves PostHog `true` reaches terminal batching behavior
- regressions cover rejected-run partial history and concurrent same-turn renderers
- public API type guard preserves `constructor(opts?: IntelligenceAdapterOptions)`
- uncached Nx test, check-types, build, publint, and attw: passing
- repository pre-commit test/publint/attw gate: passing
- commitlint and `git diff --check`: passing

`PLAN.md` is a local task input and is intentionally not part of this PR.