### PR TITLE
perf(release): cut canary publish wall-clock from ~20min to ~7min

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -225,7 +225,9 @@ jobs:
           RUN_ID=""
           ERR=$(mktemp)
           for i in $(seq 1 30); do
-            sleep 6
+            # Poll BEFORE sleeping: Actions has usually indexed the run by the
+            # time the dispatch call returns, so sleeping first paid a guaranteed
+            # 6s on every canary. Same 30-attempt / 3-min tolerance.
             RUN_ID=$(gh run list \
               --repo "$GITHUB_REPOSITORY" \
               --workflow=publish-release.yml \
@@ -241,6 +243,7 @@ jobs:
             if [ -n "$RUN_ID" ]; then
               break
             fi
+            sleep 6
           done
           if [ -z "$RUN_ID" ]; then
             echo "::error::Dispatched publish-release run never appeared on ${BRANCH}. Leaving the ref in place for debugging; delete it manually once resolved."

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -140,7 +140,18 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 0
+          # Canaries need no git history: the prerelease path pushes no tag, cuts
+          # no GitHub Release, reads no commit range for release notes, and the
+          # build is `nx run-many` (NOT `nx affected`), so there is no merge base
+          # to resolve. Full history costs ~25-48s of clone time here AND rides
+          # along in the workspace artifact this job uploads.
+          #
+          # Stable releases MUST keep depth 0: the publish job resolves and
+          # pushes tags out of this checkout's .git (shipped via that artifact),
+          # and the release notes diff against the previous release tag.
+          # `inputs.mode` is empty on the merged-release-PR path, so that path
+          # correctly evaluates to 0.
+          fetch-depth: ${{ inputs.mode == 'prerelease' && 1 || 0 }}
           persist-credentials: false
 
       - name: Setup pnpm
@@ -152,6 +163,31 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.x
+          # Do NOT use cache: "pnpm" here — its key omits the Node.js version.
+          # Cached manually below with the node version in the key, matching
+          # test_unit.yml's reasoning.
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store-path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      # Without this, every job here installed all 4608 packages cold from the
+      # registry on every release. Usually ~45s, but it is npm-registry-bandwidth
+      # bound and therefore heavy-tailed: an observed canary spent 9m08s in this
+      # step on tarballs trickling in at 2-49 KiB/s.
+      #
+      # Cache-poisoning posture: `--frozen-lockfile` forbids resolution changes
+      # and pnpm verifies every store file against the lockfile's integrity
+      # hashes on link, so a tampered cache entry fails the install rather than
+      # injecting code. The worst case is a denied install, not a compromised
+      # publish.
+      - name: Cache pnpm store
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store-path }}
+          key: ${{ runner.os }}-pnpm-store-22.x-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-22.x-
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -197,6 +233,10 @@ jobs:
           name: workspace
           path: /tmp/workspace.tgz
           retention-days: 1
+          # The payload is already gzipped by "Pack workspace"; re-deflating it
+          # into the artifact zip burns time on both upload and download for
+          # ~no size win.
+          compression-level: 0
 
     outputs:
       scope: ${{ steps.meta.outputs.scope }}
@@ -272,6 +312,21 @@ jobs:
         with:
           node-version: 22.x
           registry-url: https://registry.npmjs.org
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store-path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      # Same cache as the build job (see the rationale there). This job is where
+      # the observed 9m08s cold-install stall happened, so the cache matters most
+      # here: it is the only step between a built artifact and a publish.
+      - name: Cache pnpm store
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store-path }}
+          key: ${{ runner.os }}-pnpm-store-22.x-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-22.x-
 
       # Restore node_modules — the build job excludes them from the
       # uploaded workspace artifact (see "Upload workspace" above). Uses
@@ -720,10 +775,21 @@ jobs:
     # always() so we still report on a failed lane, but guard on a real release
     # context: a workflow_dispatch (manual release) OR a *merged* PR. A
     # closed-unmerged PR is not a release attempt and must not notify.
+    #
+    # Canaries are excluded up front. For mode=prerelease the builder already
+    # returns should_post=false and the self-watchdog's Slack post is already
+    # gated off (npm_intended is false for a prerelease dispatch), so this job
+    # could only ever checkout + install + compute "post nothing" — ~85s of dead
+    # work sitting on the canary critical path, since canary.yml waits for the
+    # whole run. `inputs.python_publish == true` keeps the PyPI lane's
+    # notification and self-alert reachable under a prerelease-mode dispatch, and
+    # `inputs.mode` is empty on the merged-PR path so stable releases are
+    # unaffected.
     if: >
       always() &&
       (github.event_name == 'workflow_dispatch' ||
-        github.event.pull_request.merged == true)
+        github.event.pull_request.merged == true) &&
+      (inputs.mode != 'prerelease' || inputs.python_publish == true)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -801,6 +867,19 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.x
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store-path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      # Same cache as the build job (see the rationale there).
+      - name: Cache pnpm store
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store-path }}
+          key: ${{ runner.os }}-pnpm-store-22.x-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-22.x-
 
       # Restore node_modules so `pnpm tsx` (and the release-config import the
       # notifier does) resolves. The build/publish jobs install before running

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -366,7 +366,34 @@ jobs:
       # uploaded workspace artifact (see "Upload workspace" above). Uses
       # pnpm-lock.yaml from the artifact, so this is a deterministic
       # restore of exactly what the build job ran with.
-      - name: Install Dependencies
+      #
+      # The prerelease path needs a NARROW slice of the workspace, and installing
+      # all 4608 projects' dependencies to get it cost ~41s. What it actually
+      # needs is exactly two things:
+      #   1. the ROOT project, for `pnpm tsx` (tsx is a root devDependency), and
+      #   2. every project under packages/, because `pnpm pack` resolves each
+      #      package's `workspace:` dependencies into real version ranges and
+      #      FAILS with ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL if a workspace
+      #      sibling is not installed. That resolution is what makes cross-scope
+      #      canary deps (runtime -> channels-intelligence) pin the same-run
+      #      version, so it is load-bearing, not incidental.
+      # Everything else in the lockfile is examples/ and showcase/ app
+      # dependencies (Next.js, Playwright, ...) which no publish step touches.
+      #
+      # Nothing else is needed because no publishable package declares `prepack`
+      # or `prepare`, so `pnpm pack` runs no lifecycle scripts; voice's
+      # `prepublishOnly` fires for neither `pnpm pack` nor `npm publish <tarball>`.
+      #
+      # Stable keeps the FULL install: publish-release.ts additionally imports
+      # lib/notion.js and the channels umbrella verifier runs a root workspace
+      # script, so its dependency surface is wider and far less worth trimming on
+      # the highest-stakes path.
+      - name: Install Dependencies (prerelease — root + packages only)
+        if: ${{ steps.meta.outputs.mode == 'prerelease' }}
+        run: pnpm install --frozen-lockfile --filter . --filter "./packages/**"
+
+      - name: Install Dependencies (stable — full workspace)
+        if: ${{ steps.meta.outputs.mode != 'prerelease' }}
         run: pnpm install --frozen-lockfile
 
       - name: Dry-run notice

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -182,11 +182,29 @@ jobs:
       # injecting code. The worst case is a denied install, not a compromised
       # publish.
       #
-      # Cost note: on a MISS the post-job save adds ~22s (measured) to this job's
-      # wall clock, so the first release after any pnpm-lock.yaml change is
-      # roughly break-even. Every release until the next lockfile change then
-      # restores in a few seconds instead of installing cold.
-      - name: Cache pnpm store
+      # WHY PRERELEASES ONLY RESTORE: canary.yml mirrors the source branch to an
+      # EPHEMERAL `canary/<slug>-<run_id>-<attempt>` ref, and Actions scopes cache
+      # entries to the writing branch (plus the default branch). A cache saved
+      # from a canary ref is therefore unreachable by every later run — measured
+      # at 874 MiB of pure orphan per canary, competing for the repo's shared
+      # 10 GB budget and evicting entries other workflows do rely on. Worse, the
+      # save cost more than it bought: 22s save + 18s restore against a 25s
+      # faster install.
+      #
+      # So canaries RESTORE ONLY (free win whenever main has an entry, zero cost
+      # and zero pollution when it doesn't), and stable releases — which run on
+      # main, where a write is durable and reused — do the writing.
+      - name: Restore pnpm store (prerelease — read-only, ephemeral ref)
+        if: ${{ steps.meta.outputs.mode == 'prerelease' }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store-path }}
+          key: ${{ runner.os }}-pnpm-store-22.x-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-22.x-
+
+      - name: Cache pnpm store (stable — read/write on main)
+        if: ${{ steps.meta.outputs.mode != 'prerelease' }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ steps.pnpm-cache.outputs.store-path }}
@@ -322,10 +340,21 @@ jobs:
         id: pnpm-cache
         run: echo "store-path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
-      # Same cache as the build job (see the rationale there). This job is where
-      # the observed 9m08s cold-install stall happened, so the cache matters most
-      # here: it is the only step between a built artifact and a publish.
-      - name: Cache pnpm store
+      # Same split as the build job, for the same reason (see the rationale
+      # there). This job is where the observed 9m08s cold-install stall happened,
+      # so a restore is worth attempting even when it may miss: it is the only
+      # step standing between a built artifact and a publish.
+      - name: Restore pnpm store (prerelease — read-only, ephemeral ref)
+        if: ${{ steps.meta.outputs.mode == 'prerelease' }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store-path }}
+          key: ${{ runner.os }}-pnpm-store-22.x-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-22.x-
+
+      - name: Cache pnpm store (stable — read/write on main)
+        if: ${{ steps.meta.outputs.mode != 'prerelease' }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ steps.pnpm-cache.outputs.store-path }}
@@ -877,8 +906,21 @@ jobs:
         id: pnpm-cache
         run: echo "store-path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
-      # Same cache as the build job (see the rationale there).
-      - name: Cache pnpm store
+      # Same split as the build job (see the rationale there). This job is
+      # normally stable-only, but a prerelease dispatch with python_publish=true
+      # still reaches it on an ephemeral canary ref — hence the same read-only
+      # arm, keyed off `inputs.mode` (the signal this job's own `if:` gate uses).
+      - name: Restore pnpm store (prerelease — read-only, ephemeral ref)
+        if: ${{ inputs.mode == 'prerelease' }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store-path }}
+          key: ${{ runner.os }}-pnpm-store-22.x-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-22.x-
+
+      - name: Cache pnpm store (stable — read/write on main)
+        if: ${{ inputs.mode != 'prerelease' }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ steps.pnpm-cache.outputs.store-path }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -181,6 +181,11 @@ jobs:
       # hashes on link, so a tampered cache entry fails the install rather than
       # injecting code. The worst case is a denied install, not a compromised
       # publish.
+      #
+      # Cost note: on a MISS the post-job save adds ~22s (measured) to this job's
+      # wall clock, so the first release after any pnpm-lock.yaml change is
+      # roughly break-even. Every release until the next lockfile change then
+      # restores in a few seconds instead of installing cold.
       - name: Cache pnpm store
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/scripts/release/lib/concurrency.test.ts
+++ b/scripts/release/lib/concurrency.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { mapWithConcurrency } from "./concurrency.js";
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+describe("mapWithConcurrency", () => {
+  it("returns results in INPUT order, not completion order", async () => {
+    // Reverse-staggered delays: later items settle first.
+    const results = await mapWithConcurrency([3, 2, 1], 3, async (n) => {
+      for (let i = 0; i < n; i++) await tick();
+      return n * 10;
+    });
+
+    expect(results.map((r) => r.value)).toEqual([30, 20, 10]);
+  });
+
+  it("never exceeds the concurrency limit", async () => {
+    let inFlight = 0;
+    let peak = 0;
+
+    await mapWithConcurrency(
+      Array.from({ length: 20 }, (_, i) => i),
+      4,
+      async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await tick();
+        await tick();
+        inFlight--;
+      },
+    );
+
+    expect(peak).toBe(4);
+  });
+
+  it("attempts EVERY item even when some reject, so one report names all failures", async () => {
+    const attempted: number[] = [];
+
+    const results = await mapWithConcurrency([1, 2, 3, 4, 5], 2, async (n) => {
+      attempted.push(n);
+      if (n % 2 === 0) throw new Error(`boom ${n}`);
+      return n;
+    });
+
+    expect(attempted.sort()).toEqual([1, 2, 3, 4, 5]);
+    const failures = results.filter((r) => r.error);
+    expect(failures).toHaveLength(2);
+    expect(failures.map((f) => f.item)).toEqual([2, 4]);
+    // Successes are still reported alongside the failures.
+    expect(results.filter((r) => !r.error).map((r) => r.value)).toEqual([
+      1, 3, 5,
+    ]);
+  });
+
+  it("pairs each error with the item that produced it", async () => {
+    const results = await mapWithConcurrency(["a", "b"], 1, async (s) => {
+      if (s === "b") throw new Error("failed-b");
+      return s;
+    });
+
+    expect(results[1].item).toBe("b");
+    expect((results[1].error as Error).message).toBe("failed-b");
+    expect(results[0].error).toBeUndefined();
+  });
+
+  it("handles an empty list without spawning workers", async () => {
+    await expect(mapWithConcurrency([], 4, async () => 1)).resolves.toEqual([]);
+  });
+
+  it("caps workers at the item count when the limit exceeds it", async () => {
+    let peak = 0;
+    let inFlight = 0;
+
+    await mapWithConcurrency([1, 2], 16, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await tick();
+      inFlight--;
+    });
+
+    expect(peak).toBe(2);
+  });
+
+  it("runs serially at limit 1, preserving the old behaviour as an escape hatch", async () => {
+    const order: string[] = [];
+
+    await mapWithConcurrency([1, 2, 3], 1, async (n) => {
+      order.push(`start${n}`);
+      await tick();
+      order.push(`end${n}`);
+    });
+
+    expect(order).toEqual([
+      "start1",
+      "end1",
+      "start2",
+      "end2",
+      "start3",
+      "end3",
+    ]);
+  });
+
+  it("rejects a nonsensical limit rather than silently running serially", async () => {
+    await expect(mapWithConcurrency([1], 0, async () => 1)).rejects.toThrow(
+      /positive integer/,
+    );
+    await expect(mapWithConcurrency([1], 1.5, async () => 1)).rejects.toThrow(
+      /positive integer/,
+    );
+    await expect(mapWithConcurrency([1], NaN, async () => 1)).rejects.toThrow(
+      /positive integer/,
+    );
+  });
+});

--- a/scripts/release/lib/concurrency.ts
+++ b/scripts/release/lib/concurrency.ts
@@ -1,0 +1,60 @@
+/**
+ * Bounded-concurrency task runner for the publish loop.
+ *
+ * Publishing N packages serially costs N x (pack + registry round-trip). After
+ * the npx fix (see npm-cli.ts) that is ~4.7s per package, so a 26-package
+ * `scope=all` canary still spent ~125s almost entirely waiting on the network.
+ *
+ * Ordering is deliberately NOT preserved as a correctness property: prerelease.ts
+ * documents that the cross-scope dependency graph has cycles (runtime ->
+ * channels-intelligence, channels-core -> core), so NO serial order avoids
+ * publishing a package before the same-run version it pins. Concurrency
+ * therefore does not weaken an invariant that serial execution was providing.
+ */
+
+/**
+ * Run `fn` over every item with at most `limit` in flight.
+ *
+ * Every item is attempted even if others reject — a half-published release is
+ * unrecoverable either way (npm refuses to republish a version), so the operator
+ * is better served by ONE report naming every failure than by a fail-fast that
+ * hides which packages still need attention. Results are returned in input
+ * order regardless of completion order.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<Array<{ item: T; value?: R; error?: unknown }>> {
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new Error(
+      `Concurrency limit must be a positive integer, got ${limit}`,
+    );
+  }
+
+  const results: Array<{ item: T; value?: R; error?: unknown }> = Array.from(
+    { length: items.length },
+    () => ({}) as { item: T; value?: R; error?: unknown },
+  );
+  let cursor = 0;
+
+  async function worker(): Promise<void> {
+    // Each worker claims the next index atomically — JS is single-threaded
+    // between awaits, so the read-then-increment cannot interleave.
+    while (cursor < items.length) {
+      const index = cursor++;
+      const item = items[index];
+      try {
+        results[index] = { item, value: await fn(item, index) };
+      } catch (error) {
+        results[index] = { item, error };
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
+  );
+
+  return results;
+}

--- a/scripts/release/lib/npm-cli.test.ts
+++ b/scripts/release/lib/npm-cli.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  NPM_PUBLISH_VERSION,
+  resetPublishNpmCache,
+  resolvePublishNpm,
+} from "./npm-cli.js";
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+const existsSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("child_process", () => ({
+  spawnSync: spawnSyncMock,
+}));
+
+vi.mock("fs", () => ({
+  default: {
+    mkdtempSync: (prefix: string) => `${prefix}test`,
+    existsSync: existsSyncMock,
+  },
+}));
+
+beforeEach(() => {
+  resetPublishNpmCache();
+  spawnSyncMock.mockReset();
+  existsSyncMock.mockReset();
+  existsSyncMock.mockReturnValue(true);
+});
+
+describe("resolvePublishNpm", () => {
+  it("installs the pinned npm into a throwaway prefix, never mutating the ambient npm", () => {
+    spawnSyncMock.mockReturnValue({ status: 0 });
+
+    const bin = resolvePublishNpm();
+
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    const [command, args] = spawnSyncMock.mock.calls[0];
+    expect(command).toBe("npm");
+    expect(args).toContain(`npm@${NPM_PUBLISH_VERSION}`);
+    // --prefix is what keeps this hermetic; a bare `-g` would replace the
+    // runner's (or a developer's) global npm.
+    expect(args).toContain("--prefix");
+    expect(bin).toMatch(/\/bin\/npm$/);
+  });
+
+  it("pins a version npm can actually publish with via OIDC (>= 11.5.1)", () => {
+    const [major, minor, patch] = NPM_PUBLISH_VERSION.split(".").map(Number);
+    expect(major).toBeGreaterThanOrEqual(11);
+    // Guard the exact floor so a future downgrade to e.g. 11.4.x — which cannot
+    // do OIDC trusted publishing — fails here instead of at publish time.
+    if (major === 11 && minor === 5) expect(patch).toBeGreaterThanOrEqual(1);
+    if (major === 11) expect(minor).toBeGreaterThanOrEqual(5);
+  });
+
+  it("installs only once across many packages (the whole point of the helper)", () => {
+    spawnSyncMock.mockReturnValue({ status: 0 });
+
+    const first = resolvePublishNpm();
+    const second = resolvePublishNpm();
+    const third = resolvePublishNpm();
+
+    expect(first).toBe(second);
+    expect(second).toBe(third);
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws rather than falling back to the too-old ambient npm when install fails", () => {
+    spawnSyncMock.mockReturnValue({ status: 1 });
+
+    expect(() => resolvePublishNpm()).toThrow(/Failed to install npm@/);
+  });
+
+  it("throws when the install reports success but produced no binary", () => {
+    spawnSyncMock.mockReturnValue({ status: 0 });
+    existsSyncMock.mockReturnValue(false);
+
+    expect(() => resolvePublishNpm()).toThrow(/does not exist/);
+  });
+
+  it("does not memoize a failed install", () => {
+    spawnSyncMock.mockReturnValueOnce({ status: 1 });
+    expect(() => resolvePublishNpm()).toThrow();
+
+    spawnSyncMock.mockReturnValue({ status: 0 });
+    expect(resolvePublishNpm()).toMatch(/\/bin\/npm$/);
+    expect(spawnSyncMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/scripts/release/lib/npm-cli.ts
+++ b/scripts/release/lib/npm-cli.ts
@@ -1,0 +1,74 @@
+/**
+ * Resolve the pinned npm CLI used to publish to the registry.
+ *
+ * WHY A PINNED npm AT ALL: npm >= 11.5.1 authenticates via GitHub Actions OIDC
+ * trusted publishers, which is what the @copilotkit trusted-publisher records
+ * are bound to (see publish-release.yml's header). The runner's bundled npm 10.x
+ * cannot publish under that binding, so the publish scripts must invoke a newer
+ * npm than the one on PATH. The version pin lives HERE as the single source of
+ * truth for both prerelease.ts and publish-release.ts.
+ *
+ * WHY INSTALL ONCE instead of `npx --yes npm@<version>` per package: npx
+ * re-resolves the spec against the registry on EVERY invocation. Measured on a
+ * channels canary, that was ~16s of the ~21s spent per package — 9 packages paid
+ * ~2.4 minutes of pure npx overhead, and a 16-package monorepo release paid over
+ * 4 minutes. Installing into one throwaway prefix collapses all of it into a
+ * single ~15s install, after which each publish is just the ~5s of real work.
+ *
+ * A throwaway prefix (rather than `npm i -g npm@<version>`) keeps this hermetic:
+ * it never mutates the ambient npm, so running these scripts locally does not
+ * downgrade/upgrade a developer's global npm.
+ */
+
+import { spawnSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+/**
+ * The npm version used for every registry publish. Must stay >= 11.5.1 for OIDC
+ * trusted publishing; bumping it here updates both publish scripts at once.
+ */
+export const NPM_PUBLISH_VERSION = "11.15.0";
+
+let cachedNpmBin: string | null = null;
+
+/**
+ * Install the pinned npm into a temp prefix (once per process) and return the
+ * path to its CLI entrypoint. Memoized, so callers may invoke it per package
+ * without repaying the install.
+ */
+export function resolvePublishNpm(): string {
+  if (cachedNpmBin) return cachedNpmBin;
+
+  const prefix = fs.mkdtempSync(path.join(os.tmpdir(), "cpk-publish-npm-"));
+  console.log(`Installing npm@${NPM_PUBLISH_VERSION} into ${prefix}...`);
+  const result = spawnSync(
+    "npm",
+    ["install", "--global", "--prefix", prefix, `npm@${NPM_PUBLISH_VERSION}`],
+    { stdio: "inherit", encoding: "utf8" },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to install npm@${NPM_PUBLISH_VERSION} (exit ${result.status}). Refusing to fall back to the ambient npm, which is too old for OIDC trusted publishing.`,
+    );
+  }
+
+  // Assert the binary exists rather than trusting exit 0: publishing with a
+  // missing/!executable path would fail deep inside the per-package loop, after
+  // earlier packages had already shipped.
+  const bin = path.join(prefix, "bin", "npm");
+  if (!fs.existsSync(bin)) {
+    throw new Error(
+      `Installed npm@${NPM_PUBLISH_VERSION} but ${bin} does not exist.`,
+    );
+  }
+
+  cachedNpmBin = bin;
+  return bin;
+}
+
+/** Test-only: drop the memoized binary so each test observes a fresh install. */
+export function resetPublishNpmCache(): void {
+  cachedNpmBin = null;
+}

--- a/scripts/release/prerelease.ts
+++ b/scripts/release/prerelease.ts
@@ -18,30 +18,66 @@
  * Usage: tsx scripts/release/prerelease.ts --scope <scope from release.config.json | all> [--dry-run]
  */
 
-import { spawnSync } from "child_process";
+import { spawn } from "child_process";
 import { getCurrentVersion, getPackagesForScope } from "./lib/versions.js";
 import type { PublishablePackage } from "./lib/versions.js";
 import { ALL_SCOPES, ROOT, loadConfig, resolveScopes } from "./lib/config.js";
 import type { ReleaseScope } from "./lib/config.js";
 import { emitGithubOutputs } from "./lib/github-output.js";
 import { resolvePublishNpm } from "./lib/npm-cli.js";
+import { mapWithConcurrency } from "./lib/concurrency.js";
 
-function run(cmd: string, args: string[], opts?: { cwd?: string }) {
-  const result = spawnSync(cmd, args, {
-    cwd: opts?.cwd ?? ROOT,
-    stdio: "inherit",
-    encoding: "utf8",
+/**
+ * How many packages to pack+publish at once. Each one is dominated by a registry
+ * round-trip, so a small pool removes most of the serial wait without hammering
+ * npm. Override with CANARY_PUBLISH_CONCURRENCY=1 to fall back to serial when
+ * debugging an individual package's publish.
+ */
+const PUBLISH_CONCURRENCY = Number(
+  process.env.CANARY_PUBLISH_CONCURRENCY ?? "4",
+);
+
+/**
+ * Run a command to completion, capturing its output.
+ *
+ * Output is CAPTURED rather than inherited, then replayed as one block per
+ * package once that package finishes. With a pool in flight, inheriting stdio
+ * would interleave several npm publishes line-by-line and make the log
+ * unreadable — and this log is the only forensic record when a canary
+ * half-publishes.
+ */
+function runCaptured(
+  cmd: string,
+  args: string[],
+  opts?: { cwd?: string },
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: opts?.cwd ?? ROOT,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    child.stdout?.on("data", (chunk) => (output += chunk));
+    child.stderr?.on("data", (chunk) => (output += chunk));
+    child.on("error", reject);
+    child.on("close", (status) => {
+      if (status === 0) {
+        resolve(output);
+        return;
+      }
+      reject(
+        new Error(
+          `Command failed (exit ${status}): ${cmd} ${args.join(" ")}\n${output}`,
+        ),
+      );
+    });
   });
-  if (result.status !== 0) {
-    throw new Error(`Command failed: ${cmd} ${args.join(" ")}`);
-  }
-  return result;
 }
 
 // Valid scopes come from release.config.json — the single source of truth.
 const VALID_SCOPES = Object.keys(loadConfig().scopes);
 
-function main() {
+async function main() {
   const argv = process.argv.slice(2);
   const dryRun = argv.includes("--dry-run");
   const scopeIdx = argv.indexOf("--scope");
@@ -131,20 +167,51 @@ function main() {
   // We intentionally do NOT rebuild/retest here to keep NPM_TOKEN out
   // of the build process tree.
 
-  // Publish each package via pnpm pack + the pinned OIDC-aware npm. Resolved
-  // ONCE up front: see lib/npm-cli.ts for why this is not `npx npm@<v>` per
-  // package (npx re-resolved the spec every time, ~16s of each package's ~21s).
+  // Publish via pnpm pack + the pinned OIDC-aware npm. Resolved ONCE up front:
+  // see lib/npm-cli.ts for why this is not `npx npm@<v>` per package (npx
+  // re-resolved the spec every time, ~16s of each package's ~21s).
+  //
+  // Packages go out with bounded concurrency because each is dominated by a
+  // registry round-trip. This does not weaken an ordering invariant — see the
+  // multi-scope caveat in this file's header and lib/concurrency.ts: the
+  // cross-scope graph has cycles, so no serial order was ever safe either.
   const npmBin = resolvePublishNpm();
-  console.log("\nPublishing packages...");
-  for (const p of packages) {
-    console.log(
-      `  Publishing ${p.name}@${p.pkg.version} with tag ${distTag}...`,
+  console.log(
+    `\nPublishing ${packages.length} package(s), ${PUBLISH_CONCURRENCY} at a time...`,
+  );
+  const results = await mapWithConcurrency(
+    packages,
+    PUBLISH_CONCURRENCY,
+    async (p) => {
+      const label = `${p.name}@${p.pkg.version}`;
+      const tarball = `${p.name.replace("@", "").replace("/", "-")}-${p.pkg.version}.tgz`;
+      await runCaptured("pnpm", ["pack"], { cwd: p.dir });
+      await runCaptured(
+        npmBin,
+        ["publish", tarball, "--tag", distTag, "--access", "public"],
+        { cwd: p.dir },
+      );
+      console.log(`  Published ${label} with tag ${distTag}`);
+      return label;
+    },
+  );
+
+  // Report EVERY failure rather than just the first: npm refuses to republish a
+  // version, so a partially-published canary id must be abandoned wholesale, and
+  // the operator needs the full picture to judge that (see the header's
+  // multi-scope caveat).
+  const failures = results.filter((r) => r.error);
+  if (failures.length > 0) {
+    console.error(
+      `\n${failures.length} of ${packages.length} package(s) failed to publish:`,
     );
-    run("pnpm", ["pack"], { cwd: p.dir });
-    const tarball = `${p.name.replace("@", "").replace("/", "-")}-${p.pkg.version}.tgz`;
-    run(npmBin, ["publish", tarball, "--tag", distTag, "--access", "public"], {
-      cwd: p.dir,
-    });
+    for (const { item, error } of failures) {
+      console.error(`\n--- ${item.name}@${item.pkg.version} ---`);
+      console.error(error instanceof Error ? error.message : error);
+    }
+    throw new Error(
+      `Prerelease aborted: ${failures.length} package(s) failed. This canary id is now half-published and cannot be resumed — retry with a NEW suffix.`,
+    );
   }
 
   // The workflow's "Verify publish step emitted version" guard and the
@@ -158,4 +225,9 @@ function main() {
   console.log(`\nPrerelease published: ${publishVersions} (tag: ${distTag})`);
 }
 
-main();
+// Explicit non-zero exit: an unhandled rejection from the now-async main would
+// otherwise let the publish step pass while packages failed to publish.
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/release/prerelease.ts
+++ b/scripts/release/prerelease.ts
@@ -24,6 +24,7 @@ import type { PublishablePackage } from "./lib/versions.js";
 import { ALL_SCOPES, ROOT, loadConfig, resolveScopes } from "./lib/config.js";
 import type { ReleaseScope } from "./lib/config.js";
 import { emitGithubOutputs } from "./lib/github-output.js";
+import { resolvePublishNpm } from "./lib/npm-cli.js";
 
 function run(cmd: string, args: string[], opts?: { cwd?: string }) {
   const result = spawnSync(cmd, args, {
@@ -130,7 +131,10 @@ function main() {
   // We intentionally do NOT rebuild/retest here to keep NPM_TOKEN out
   // of the build process tree.
 
-  // Publish each package via pnpm pack + npx npm@11 (OIDC-aware)
+  // Publish each package via pnpm pack + the pinned OIDC-aware npm. Resolved
+  // ONCE up front: see lib/npm-cli.ts for why this is not `npx npm@<v>` per
+  // package (npx re-resolved the spec every time, ~16s of each package's ~21s).
+  const npmBin = resolvePublishNpm();
   console.log("\nPublishing packages...");
   for (const p of packages) {
     console.log(
@@ -138,20 +142,9 @@ function main() {
     );
     run("pnpm", ["pack"], { cwd: p.dir });
     const tarball = `${p.name.replace("@", "").replace("/", "-")}-${p.pkg.version}.tgz`;
-    run(
-      "npx",
-      [
-        "--yes",
-        "npm@11.15.0",
-        "publish",
-        tarball,
-        "--tag",
-        distTag,
-        "--access",
-        "public",
-      ],
-      { cwd: p.dir },
-    );
+    run(npmBin, ["publish", tarball, "--tag", distTag, "--access", "public"], {
+      cwd: p.dir,
+    });
   }
 
   // The workflow's "Verify publish step emitted version" guard and the

--- a/scripts/release/publish-release.ts
+++ b/scripts/release/publish-release.ts
@@ -13,7 +13,8 @@
  *   NOTION_API_KEY    — for reading edited release notes from Notion (optional)
  *   GITHUB_OUTPUT     — CI output file
  *
- * Auth: Uses npm OIDC trusted publishers (id-token: write) via npx npm@11.
+ * Auth: Uses npm OIDC trusted publishers (id-token: write) via the pinned npm 11
+ * resolved by lib/npm-cli.ts.
  * No NPM_TOKEN needed — NODE_AUTH_TOKEN must be empty to avoid blocking OIDC.
  *
  * Usage: tsx scripts/release/publish-release.ts --scope <scope from release.config.json>
@@ -31,6 +32,7 @@ import { readReleaseDraft } from "./lib/notion.js";
 import { ROOT, getScopeConfig, loadConfig } from "./lib/config.js";
 import type { ReleaseScope } from "./lib/config.js";
 import { emitGithubOutputs } from "./lib/github-output.js";
+import { resolvePublishNpm } from "./lib/npm-cli.js";
 
 type PublishPhase = "all" | "dependencies" | "umbrella";
 
@@ -194,10 +196,14 @@ async function main() {
   // build process tree.
 
   // Publish each package in scope.
-  // Uses pnpm pack (workspace-aware) + npx npm@11 publish (OIDC-aware).
+  // Uses pnpm pack (workspace-aware) + the pinned npm 11 publish (OIDC-aware).
   // npm 11 uses GitHub Actions OIDC tokens for auth when id-token: write
   // is granted, eliminating the need for long-lived NPM_TOKEN secrets.
   // Skips packages already published at this version (idempotent retries).
+  //
+  // The npm CLI is resolved ONCE up front rather than via `npx npm@<v>` per
+  // package — see lib/npm-cli.ts for the measured cost of the old approach.
+  const npmBin = resolvePublishNpm();
   console.log("\nPublishing packages...");
   let skipped = 0;
   for (const p of packagesToPublish) {
@@ -210,20 +216,9 @@ async function main() {
     console.log(`  Publishing ${p.name}@${version}...`);
     run("pnpm", ["pack"], { cwd: p.dir });
     const tarball = `${p.name.replace("@", "").replace("/", "-")}-${version}.tgz`;
-    run(
-      "npx",
-      [
-        "--yes",
-        "npm@11.15.0",
-        "publish",
-        tarball,
-        "--tag",
-        "latest",
-        "--access",
-        "public",
-      ],
-      { cwd: p.dir },
-    );
+    run(npmBin, ["publish", tarball, "--tag", "latest", "--access", "public"], {
+      cwd: p.dir,
+    });
   }
   if (skipped > 0) {
     console.log(`\n${skipped} package(s) skipped (already at ${version}).`);


### PR DESCRIPTION
## Why

A `scope=all` canary took ~20 minutes. Profiling run [30473483745](https://github.com/CopilotKit/CopilotKit/actions/runs/30473483745) step-by-step showed almost none of that was real work.

The dominant cost: `npx --yes npm@11.15.0 publish` ran **once per package**, and npx re-resolves the spec against the registry on every invocation — **~16s of each package's ~21s**, leaving ~5s of actual pack + upload. That is why `all` hurt worst: 26 packages paid ~7 minutes of pure npx overhead. The same loop exists in the stable path, so a 16-package monorepo release paid over 4 minutes of it too.

## What changed

1. **`scripts/release/lib/npm-cli.ts` (new)** — installs the pinned npm **once** into a throwaway prefix and memoizes it; `prerelease.ts` and `publish-release.ts` both reuse the binary. The version pin now has a single source of truth (it was duplicated as a literal in both scripts). A throwaway prefix rather than `npm i -g` keeps it hermetic, so running these scripts locally doesn't rewrite a developer's global npm.
2. **Shallow checkout for canaries only** — prereleases push no tag, cut no GH Release, read no commit range, and build with `nx run-many` (not `affected`), so there is no merge base to resolve. Stable **keeps `fetch-depth: 0`**, because its publish job resolves and pushes tags out of that checkout's `.git` (shipped via the workspace artifact).
3. **Artifact slimming** — `compression-level: 0`, since the payload was already gzipped by "Pack workspace" and was then re-deflated into the artifact zip for ~no size win.
4. **`notify` job skipped for canaries** — the builder already returns `should_post=false` for `mode=prerelease`, success *and* failure (`build-release-notification.ts:196`), and the self-watchdog's Slack post is already gated off since `npm_intended` is false for a prerelease. So the job could only ever checkout + install + compute "post nothing", on the critical path because canary.yml waits for the whole run. `python_publish=true` still reaches it.
5. **pnpm store cache**, restore-only on canary refs (see the note below).
6. Orchestrator polled for the delegated run *after* a 6s sleep; now polls first.

## Results

Real `scope=all` publishes of all 26 packages across all three scopes: **~20 min -> ~4m40s**.

| Step | Before | After |
|---|---|---|
| **Publish loop** (26 pkgs) | ~546s (26 x 21s serial) | **38s** (4 at a time) |
| publish: Install deps | 41s | **27s** (root + packages only) |
| build: Checkout | 48s | **6s** |
| build: Pack workspace | 33s | **12s** |
| build: Upload workspace | 27s | **2s** |
| publish: Download / Unpack | 31s / 6s | **1s / 2s** |
| notify job | 76s | **skipped** |
| **build job total** | 261s | **164s** |
| **publish job total** | 107s + publish | **81s incl. publish** |

Measured runs: [30504035212](https://github.com/CopilotKit/CopilotKit/actions/runs/30504035212) (4m44s) and [30504493051](https://github.com/CopilotKit/CopilotKit/actions/runs/30504493051) (4m52s).

Honest note on those two totals: the second is 8s *slower* end-to-end even though it added the narrow install, because its build job drifted +17s on unrelated runner variance (Setup pnpm 4s->8s, build 91s->95s). The narrow install did exactly what it should at step level — publish-job install 41s -> 27s. Treat ~4m40s +/- 15s as the real figure; per-step numbers are the controlled measurement, end-to-end totals carry runner noise.

The publish log now shows one `Installing npm@11.15.0`, then `Publishing 26 package(s), 4 at a time...`, then 26 `Published` lines in 34s.

The build job (164s: 95s `nx run-many` + 46s full install) is now the dominant remaining cost and is deliberately untouched — see Further options below.

## On the pnpm cache — deliberately restore-only

Worth calling out because my first attempt here was wrong. `publish-release.yml` was the only workflow in the repo with no pnpm store cache, and one observed canary spent **9m08s** installing on tarballs arriving at 2–49 KiB/s. But adding a plain read/write cache turned out to be a *net negative* for canaries:

canary.yml mirrors the source branch to a unique `canary/<slug>-<run_id>-<attempt>` ref, and Actions scopes cache entries to the writing branch (plus the default branch). A cache saved from a canary ref is **unreachable by every later canary** — measured at 874 MiB of orphan per run, competing for the repo's shared 10 GB budget and evicting entries other workflows depend on. It also cost more than it bought: 20s + 26s of post-job saves against a 25s faster install.

So canaries **restore read-only** (free win whenever main has an entry, zero cost and zero pollution when it doesn't), and stable releases — which run on main, where a write is durable and reused — do the writing. Verified in CI that the read-only arm runs, the read/write arm is skipped, and no `Post Cache pnpm store` save step is planned at all.

Honest framing on the mean: the cache is roughly break-even on typical time (18s restore + 21s install vs 46s cold). Its value is bounding the registry-throttle tail, not shaving the average.

## Testing

- **Real `scope=all` canary publish** ([30503117837](https://github.com/CopilotKit/CopilotKit/actions/runs/30503117837), success): all 26 packages published across monorepo + angular + channels under one shared canary id, confirming cross-scope `workspace:` deps still resolve in-run. Verified live on the registry: `@copilotkit/react-core@1.64.2-canary.perfall1`, `@copilotkit/channels@0.4.1-canary.perfall1`, `@copilotkit/angular@0.3.1-canary.perfall1`.
- **Dry-run canary** ([30502850575](https://github.com/CopilotKit/CopilotKit/actions/runs/30502850575), success): confirmed the shallow checkout, artifact slimming, and that the `notify` job is genuinely skipped.
- **Cache-fix validation run**: step conclusions confirm `Restore pnpm store (prerelease — read-only)` → success, `Cache pnpm store (stable — read/write)` → skipped, and no post-job save step exists.
- `143` release-script tests pass, including 6 new ones for the helper (install-once, memoization, the OIDC `>= 11.5.1` version floor, and that a failed install throws rather than silently falling back to the too-old ambient npm).
- `actionlint` clean on all four release workflows; `shellcheck --severity=warning` clean on `scripts/release/**/*.sh`; `verify-release-scope-dropdowns.sh` clean; `oxlint` 0 warnings/errors; `oxfmt` applied.
- Live probe of the helper: installs npm 11.15.0 in 3.2s, second call 0ms, same path, resolved binary reports `11.15.0`.
- `prerelease.ts --dry-run` still enumerates all 9 channels packages.

## Notes

- `@copilotkit/*@canary` now points at `…-canary.perfall1` from the verification publish. Content-wise that is main's package code (this diff only touches release scripts/workflows). Happy to republish from main if you'd prefer the tag moved.
- No npm OIDC surface changed: the workflow filename, the `npm`/`pypi` environments, and the trusted-publisher bindings are all untouched. `npm` stays >= 11.5.1 (pinned at 11.15.0, now enforced by a test).
## Further options (want your call before I touch these)

The build job is now the long pole. Each remaining lever trades something I don't think is mine to trade:

- **Bigger Depot runner for the build job** (~95s of CPU-bound `nx run-many`). Depot is already used elsewhere in this repo, but it requires `id-token: write` — on the one job deliberately kept credential-free, and the job that runs arbitrary package build scripts. npm's trusted-publisher record also demands the `npm` environment claim which the build job lacks, so a token minted there almost certainly cannot publish. Still your call, not mine.
- **Merge build + publish** (~60s: second install, artifact round-trip, job spin-up). Directly erodes the build/publish credential boundary this file's comments defend.
- **Scope-aware build.** An `angular` canary builds all ~70 projects to publish 1 package. Zero help for `scope=all`, large win for single-scope canaries.
- **Narrow the build job's install too.** `nx run-many -t build --projects=packages/**` shouldn't need examples/ or showcase/ deps. Lower confidence than the publish-job version, since nx builds a full project graph.

Nx caching is a dead end here: Nx Cloud stays off per team decision, and a local `.nx` cache hits the same ephemeral-canary-ref scoping problem documented above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
