### PR TITLE
fix(core): preserve server run IDs during replay

### DIFF
--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -29,7 +29,11 @@ class EventEmittingMockAgent extends AbstractAgent {
   }
 
   // Helper to emit run started event
-  public async emitRunStarted(runId: string, state: State = {}) {
+  public async emitRunStarted(
+    runId: string,
+    state: State = {},
+    inputRunId = runId,
+  ) {
     this.state = state;
     for (const sub of this.testSubscribers) {
       if (sub.onRunStartedEvent) {
@@ -42,14 +46,18 @@ class EventEmittingMockAgent extends AbstractAgent {
           messages: this.messages,
           state: this.state,
           agent: this,
-          input: this.createRunInput(runId),
+          input: this.createRunInput(inputRunId),
         });
       }
     }
   }
 
   // Helper to emit run finished event
-  public async emitRunFinished(runId: string, state: State = {}) {
+  public async emitRunFinished(
+    runId: string,
+    state: State = {},
+    inputRunId = runId,
+  ) {
     this.state = state;
     for (const sub of this.testSubscribers) {
       if (sub.onRunFinishedEvent) {
@@ -62,7 +70,7 @@ class EventEmittingMockAgent extends AbstractAgent {
           messages: this.messages,
           state: this.state,
           agent: this,
-          input: this.createRunInput(runId),
+          input: this.createRunInput(inputRunId),
         });
       }
     }
@@ -450,6 +458,39 @@ describe("StateManager - Message Tracking", () => {
     );
     expect(copilotKitCore.getRunIdForMessage("agent1", "thread1", "msg3")).toBe(
       runId,
+    );
+  });
+
+  it("should preserve server run IDs during cumulative connect replay", async () => {
+    const connectionRunId = "connect-run";
+    const firstRunId = "server-run-1";
+    const secondRunId = "server-run-2";
+    const firstMessage: Message = {
+      id: "msg1",
+      role: "assistant",
+      content: "First response",
+    };
+    const secondMessage: Message = {
+      id: "msg2",
+      role: "assistant",
+      content: "Second response",
+    };
+
+    await agent.emitRunStarted(firstRunId, {}, connectionRunId);
+    await agent.emitMessagesSnapshot(connectionRunId, [firstMessage]);
+    await agent.emitRunFinished(firstRunId, {}, connectionRunId);
+
+    await agent.emitRunStarted(secondRunId, {}, connectionRunId);
+    await agent.emitMessagesSnapshot(connectionRunId, [
+      firstMessage,
+      secondMessage,
+    ]);
+
+    expect(copilotKitCore.getRunIdForMessage("agent1", "thread1", "msg1")).toBe(
+      firstRunId,
+    );
+    expect(copilotKitCore.getRunIdForMessage("agent1", "thread1", "msg2")).toBe(
+      secondRunId,
     );
   });
 

--- a/packages/core/src/core/state-manager.ts
+++ b/packages/core/src/core/state-manager.ts
@@ -7,7 +7,6 @@ import type {
   StateDeltaEvent,
   MessagesSnapshotEvent,
 } from "@ag-ui/client";
-import { randomUUID } from "@ag-ui/client";
 import type { CopilotKitCore } from "./core";
 
 /**
@@ -54,27 +53,10 @@ export class StateManager {
       this.agentSubscriptions.delete(agentId);
     }
 
-    // Subscribe to agent events.
-    //
-    // Two invariants this subscription must uphold:
-    //
-    // 1. Revocation: the ag-ui pipeline captures `o = [...agent.subscribers]` at
-    //    runAgent() start. If this subscription is replaced by a newer one before
-    //    the pipeline finishes, the old pipeline may still call these callbacks
-    //    with the old input.runId. `revoked = true` turns them into no-ops once
-    //    the replacement subscription is in place.
-    //
-    // 2. Run isolation within one subscription: in tests (and edge cases), a new
-    //    run's events can arrive through the same subscription before the new
-    //    pipeline is set up. Concretely: the test emits RUN_STARTED for run2
-    //    before copilotkit.runAgent() has had a chance to set up the new
-    //    pipeline. At that point S1 is still active and sees run2's events with
-    //    input1.runId. To prevent both runs from sharing the same runId key, we
-    //    detect the "seen RUN_FINISHED, then RUN_STARTED again" pattern and
-    //    generate a fresh runId for the second logical run.
+    // The ag-ui pipeline captures its subscribers when a run starts. Revoke this
+    // subscription when it is replaced so an older pipeline cannot update state.
     let revoked = false;
-    let subRunId: string | undefined; // runId assigned to the current logical run
-    let runFinished = false; // true after RUN_FINISHED, reset on next RUN_STARTED
+    let subRunId: string | undefined;
 
     const effectiveInput = (input: RunAgentInput): RunAgentInput => ({
       ...input,
@@ -82,31 +64,18 @@ export class StateManager {
     });
 
     const { unsubscribe } = agent.subscribe({
-      onRunStartedEvent: ({ input, state }) => {
+      onRunStartedEvent: ({ event, input, state }) => {
         if (revoked) return;
-        if (runFinished && input.runId === subRunId) {
-          // A new logical run's events are arriving through this same (old)
-          // subscription. This happens when the test emits events before
-          // copilotkit.runAgent() has had a chance to set up the new pipeline:
-          // the old pipeline reuses input1.runId for all events, so
-          // input.runId equals the previous run's runId. Generate a fresh
-          // runId so the new run's state doesn't collide with the old one.
-          subRunId = randomUUID();
-        } else {
-          subRunId = input.runId;
-        }
-        runFinished = false;
+        subRunId = event.runId ?? input.runId;
         this.handleRunStarted(agent, effectiveInput(input), state);
       },
       onRunFinishedEvent: ({ input, state }) => {
         if (revoked) return;
-        runFinished = true;
         this.handleRunFinished(agent, effectiveInput(input), state);
       },
       // A run error terminates the run — treat identically to finished for cleanup
       onRunErrorEvent: ({ input, state }) => {
         if (revoked) return;
-        runFinished = true;
         this.handleRunFinished(agent, effectiveInput(input), state);
       },
       onStateSnapshotEvent: ({ event, input, state }) => {
@@ -358,7 +327,10 @@ export class StateManager {
     }
     const threadMessages = agentMessages.get(threadId)!;
 
-    threadMessages.set(messageId, runId);
+    // Later cumulative snapshots may contain messages from earlier runs.
+    if (!threadMessages.has(messageId)) {
+      threadMessages.set(messageId, runId);
+    }
   }
 
   /**

--- a/packages/react-core/src/v2/__tests__/utils/test-helpers.tsx
+++ b/packages/react-core/src/v2/__tests__/utils/test-helpers.tsx
@@ -226,7 +226,11 @@ export function renderWithCopilotKit({
  * Helper to create a RUN_STARTED event
  */
 export function runStartedEvent(): BaseEvent {
-  return { type: EventType.RUN_STARTED } as BaseEvent;
+  return {
+    type: EventType.RUN_STARTED,
+    threadId: "test-thread",
+    runId: testId("run"),
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- prefer the AG-UI RUN_STARTED runId and fall back to the client input runId
- preserve the first message-to-run association across cumulative snapshots
- make mocked RUN_STARTED events protocol-valid

## Testing
- core state-manager tests
- core and react-core type checks
- react-core test suite
- affected package test, publint, and attw pre-commit checks