### PR TITLE
fix(core): preserve Intelligence replay run IDs

### DIFF
--- a/packages/core/src/__tests__/intelligence-agent.test.ts
+++ b/packages/core/src/__tests__/intelligence-agent.test.ts
@@ -13,6 +13,7 @@ vi.mock("phoenix", () => ({
 // Must come after vi.mock so phoenix is mocked when the module is loaded.
 const { IntelligenceAgent } = await import("../intelligence-agent");
 const { ProxiedCopilotRuntimeAgent } = await import("../agent");
+const { CopilotKitCore } = await import("../core");
 type IntelligenceAgentInstance = InstanceType<typeof IntelligenceAgent>;
 
 let mockFetch: ReturnType<typeof vi.fn>;
@@ -360,8 +361,17 @@ describe("IntelligenceAgent", () => {
       } as BaseEvent;
       channel.serverPush("ag_ui_event", toolEvent);
 
+      const runStartedEvent = {
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "standard-run-id",
+        run_id: "legacy-run-id",
+      } as BaseEvent;
+      channel.serverPush("ag_ui_event", runStartedEvent);
+
       expect(events).toContainEqual(textEvent);
       expect(events).toContainEqual(toolEvent);
+      expect(events).toContainEqual(runStartedEvent);
     });
   });
 
@@ -1286,6 +1296,90 @@ describe("IntelligenceAgent", () => {
       await secondConnectPromise;
     });
 
+    it("preserves server run identity across cumulative gateway replay snapshots", async () => {
+      mockFetch.mockResolvedValueOnce(
+        await jsonResponse(runtimeCredentials({ runId: null })),
+      );
+
+      const agent = createAgent();
+      setThreadIdForTest(agent, "thread-1");
+      const core = new CopilotKitCore({});
+      core.addAgent__unsafe_dev_only({ id: "my-agent", agent });
+
+      const firstMessage = {
+        id: "message-1",
+        role: "assistant" as const,
+        content: "First response",
+      };
+      const secondMessage = {
+        id: "message-2",
+        role: "assistant" as const,
+        content: "Second response",
+      };
+
+      const promise = agent.connectAgent({ runId: "connect-run" });
+      await waitForConnection(agent);
+
+      const channel = getChannel(agent)!;
+      channel.triggerJoin("ok");
+      channel.serverPush("ag_ui_event", {
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        run_id: "server-run-1",
+        input: { messages: [] },
+      } as BaseEvent);
+      channel.serverPush("ag_ui_event", {
+        type: EventType.STATE_SNAPSHOT,
+        snapshot: { turn: 1 },
+      } as BaseEvent);
+      channel.serverPush("ag_ui_event", {
+        type: EventType.MESSAGES_SNAPSHOT,
+        messages: [firstMessage],
+      } as BaseEvent);
+      channel.serverPush("ag_ui_event", {
+        type: EventType.RUN_FINISHED,
+        threadId: "thread-1",
+        run_id: "server-run-1",
+      } as BaseEvent);
+
+      channel.serverPush("ag_ui_event", {
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        run_id: "server-run-2",
+        input: { messages: [firstMessage] },
+      } as BaseEvent);
+      channel.serverPush("ag_ui_event", {
+        type: EventType.STATE_SNAPSHOT,
+        snapshot: { turn: 2 },
+      } as BaseEvent);
+      channel.serverPush("ag_ui_event", {
+        type: EventType.MESSAGES_SNAPSHOT,
+        messages: [firstMessage, secondMessage],
+      } as BaseEvent);
+      channel.serverPush("ag_ui_event", {
+        type: EventType.RUN_FINISHED,
+        threadId: "thread-1",
+        run_id: "server-run-2",
+      } as BaseEvent);
+      channel.serverPush("replay_complete", { latestEventId: "event-8" });
+      channel.serverPush("stream_idle", { latestEventId: "event-8" });
+
+      await promise;
+
+      expect(
+        core.getRunIdForMessage("my-agent", "thread-1", firstMessage.id),
+      ).toBe("server-run-1");
+      expect(
+        core.getRunIdForMessage("my-agent", "thread-1", secondMessage.id),
+      ).toBe("server-run-2");
+      expect(
+        core.getStateByRun("my-agent", "thread-1", "server-run-1"),
+      ).toEqual({ turn: 1 });
+      expect(
+        core.getStateByRun("my-agent", "thread-1", "server-run-2"),
+      ).toEqual({ turn: 2 });
+    });
+
     it("hydrates agent state from gateway replay events through connectAgent", async () => {
       const finalSnapshot = {
         todos: [
@@ -1375,6 +1469,7 @@ describe("IntelligenceAgent", () => {
       expect(events[0]).toEqual({
         type: EventType.RUN_STARTED,
         threadId: "thread-1",
+        runId: "backend-run-1",
         run_id: "backend-run-1",
         input: {
           messages: [

--- a/packages/core/src/__tests__/intelligence-agent.test.ts
+++ b/packages/core/src/__tests__/intelligence-agent.test.ts
@@ -371,7 +371,10 @@ describe("IntelligenceAgent", () => {
 
       expect(events).toContainEqual(textEvent);
       expect(events).toContainEqual(toolEvent);
-      expect(events).toContainEqual(runStartedEvent);
+      expect(events.at(-1)).toMatchObject({
+        runId: "standard-run-id",
+        run_id: "legacy-run-id",
+      });
     });
   });
 

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -29,7 +29,16 @@ class EventEmittingMockAgent extends AbstractAgent {
   }
 
   // Helper to emit run started event
-  public async emitRunStarted(runId: string, state: State = {}) {
+  public async emitRunStarted(
+    runId: string | undefined,
+    state: State = {},
+    inputRunId?: string,
+  ) {
+    const resolvedInputRunId = inputRunId ?? runId;
+    if (resolvedInputRunId === undefined) {
+      throw new Error("inputRunId is required when event runId is omitted");
+    }
+
     this.state = state;
     for (const sub of this.testSubscribers) {
       if (sub.onRunStartedEvent) {
@@ -42,14 +51,18 @@ class EventEmittingMockAgent extends AbstractAgent {
           messages: this.messages,
           state: this.state,
           agent: this,
-          input: this.createRunInput(runId),
+          input: this.createRunInput(resolvedInputRunId),
         });
       }
     }
   }
 
   // Helper to emit run finished event
-  public async emitRunFinished(runId: string, state: State = {}) {
+  public async emitRunFinished(
+    runId: string,
+    state: State = {},
+    inputRunId = runId,
+  ) {
     this.state = state;
     for (const sub of this.testSubscribers) {
       if (sub.onRunFinishedEvent) {
@@ -62,7 +75,7 @@ class EventEmittingMockAgent extends AbstractAgent {
           messages: this.messages,
           state: this.state,
           agent: this,
-          input: this.createRunInput(runId),
+          input: this.createRunInput(inputRunId),
         });
       }
     }
@@ -340,6 +353,28 @@ describe("StateManager - Multiple Runs", () => {
     );
   });
 
+  it("should preserve run isolation when RUN_STARTED omits runId", async () => {
+    const inputRunId = "reused-input-run";
+    const firstRunState = { count: 1 };
+    const secondRunState = { count: 2 };
+
+    await agent.emitRunStarted(undefined, firstRunState, inputRunId);
+    await agent.emitRunFinished(inputRunId, firstRunState, inputRunId);
+    await agent.emitRunStarted(undefined, secondRunState, inputRunId);
+
+    const runIds = copilotKitCore.getRunIdsForThread("agent1", "thread1");
+    const generatedRunId = runIds.find((runId) => runId !== inputRunId);
+
+    expect(runIds).toHaveLength(2);
+    expect(
+      copilotKitCore.getStateByRun("agent1", "thread1", inputRunId),
+    ).toEqual(firstRunState);
+    expect(generatedRunId).toBeDefined();
+    expect(
+      copilotKitCore.getStateByRun("agent1", "thread1", generatedRunId!),
+    ).toEqual(secondRunState);
+  });
+
   it("should list all run IDs for a thread", async () => {
     await agent.emitRunStarted("run1", { count: 1 });
     await agent.emitRunFinished("run1", { count: 1 });
@@ -450,6 +485,39 @@ describe("StateManager - Message Tracking", () => {
     );
     expect(copilotKitCore.getRunIdForMessage("agent1", "thread1", "msg3")).toBe(
       runId,
+    );
+  });
+
+  it("should preserve server run IDs during cumulative connect replay", async () => {
+    const connectionRunId = "connect-run";
+    const firstRunId = "server-run-1";
+    const secondRunId = "server-run-2";
+    const firstMessage: Message = {
+      id: "msg1",
+      role: "assistant",
+      content: "First response",
+    };
+    const secondMessage: Message = {
+      id: "msg2",
+      role: "assistant",
+      content: "Second response",
+    };
+
+    await agent.emitRunStarted(firstRunId, {}, connectionRunId);
+    await agent.emitMessagesSnapshot(connectionRunId, [firstMessage]);
+    await agent.emitRunFinished(firstRunId, {}, connectionRunId);
+
+    await agent.emitRunStarted(secondRunId, {}, connectionRunId);
+    await agent.emitMessagesSnapshot(connectionRunId, [
+      firstMessage,
+      secondMessage,
+    ]);
+
+    expect(copilotKitCore.getRunIdForMessage("agent1", "thread1", "msg1")).toBe(
+      firstRunId,
+    );
+    expect(copilotKitCore.getRunIdForMessage("agent1", "thread1", "msg2")).toBe(
+      secondRunId,
     );
   });
 
@@ -859,41 +927,26 @@ describe("StateManager - RunErrorEvent Handling", () => {
     expect(storedState).toEqual(errorState);
   });
 
-  it("should allow a new run after a run error (runFinished resets)", async () => {
-    // First run errors out
-    const run1Id = "run1";
+  it("should preserve run isolation after RUN_ERROR when RUN_STARTED omits runId", async () => {
+    const inputRunId = "reused-input-run";
     const run1State = { count: 1, status: "error" };
+    const run2State = { count: 2, status: "started" };
 
-    await agent.emitRunStarted(run1Id, { count: 1 });
-    await agent.emitRunErrorEvent(run1Id, run1State, "oops", "internal");
+    await agent.emitRunStarted(undefined, { count: 1 }, inputRunId);
+    await agent.emitRunErrorEvent(inputRunId, run1State, "oops", "internal");
+    await agent.emitRunStarted(undefined, run2State, inputRunId);
 
-    const storedRun1 = copilotKitCore.getStateByRun(
-      "agent1",
-      "thread1",
-      run1Id,
-    );
-    expect(storedRun1).toEqual(run1State);
-
-    // Second run succeeds — verifies runFinished flag was set by error
-    // and resets on the next RUN_STARTED
-    const run2Id = "run2";
-    const run2State = { count: 2, status: "completed" };
-
-    await agent.emitRunStarted(run2Id, { count: 2 });
-    await agent.emitRunFinished(run2Id, run2State);
-
-    const storedRun2 = copilotKitCore.getStateByRun(
-      "agent1",
-      "thread1",
-      run2Id,
-    );
-    expect(storedRun2).toEqual(run2State);
-
-    // Both runs are tracked independently
     const runIds = copilotKitCore.getRunIdsForThread("agent1", "thread1");
+    const generatedRunId = runIds.find((runId) => runId !== inputRunId);
+
     expect(runIds).toHaveLength(2);
-    expect(runIds).toContain(run1Id);
-    expect(runIds).toContain(run2Id);
+    expect(
+      copilotKitCore.getStateByRun("agent1", "thread1", inputRunId),
+    ).toEqual(run1State);
+    expect(generatedRunId).toBeDefined();
+    expect(
+      copilotKitCore.getStateByRun("agent1", "thread1", generatedRunId!),
+    ).toEqual(run2State);
   });
 });
 

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -369,7 +369,6 @@ describe("StateManager - Multiple Runs", () => {
     expect(
       copilotKitCore.getStateByRun("agent1", "thread1", inputRunId),
     ).toEqual(firstRunState);
-    expect(generatedRunId).toBeDefined();
     expect(
       copilotKitCore.getStateByRun("agent1", "thread1", generatedRunId!),
     ).toEqual(secondRunState);
@@ -485,39 +484,6 @@ describe("StateManager - Message Tracking", () => {
     );
     expect(copilotKitCore.getRunIdForMessage("agent1", "thread1", "msg3")).toBe(
       runId,
-    );
-  });
-
-  it("should preserve server run IDs during cumulative connect replay", async () => {
-    const connectionRunId = "connect-run";
-    const firstRunId = "server-run-1";
-    const secondRunId = "server-run-2";
-    const firstMessage: Message = {
-      id: "msg1",
-      role: "assistant",
-      content: "First response",
-    };
-    const secondMessage: Message = {
-      id: "msg2",
-      role: "assistant",
-      content: "Second response",
-    };
-
-    await agent.emitRunStarted(firstRunId, {}, connectionRunId);
-    await agent.emitMessagesSnapshot(connectionRunId, [firstMessage]);
-    await agent.emitRunFinished(firstRunId, {}, connectionRunId);
-
-    await agent.emitRunStarted(secondRunId, {}, connectionRunId);
-    await agent.emitMessagesSnapshot(connectionRunId, [
-      firstMessage,
-      secondMessage,
-    ]);
-
-    expect(copilotKitCore.getRunIdForMessage("agent1", "thread1", "msg1")).toBe(
-      firstRunId,
-    );
-    expect(copilotKitCore.getRunIdForMessage("agent1", "thread1", "msg2")).toBe(
-      secondRunId,
     );
   });
 
@@ -943,7 +909,6 @@ describe("StateManager - RunErrorEvent Handling", () => {
     expect(
       copilotKitCore.getStateByRun("agent1", "thread1", inputRunId),
     ).toEqual(run1State);
-    expect(generatedRunId).toBeDefined();
     expect(
       copilotKitCore.getStateByRun("agent1", "thread1", generatedRunId!),
     ).toEqual(run2State);

--- a/packages/core/src/core/state-manager.ts
+++ b/packages/core/src/core/state-manager.ts
@@ -56,7 +56,7 @@ export class StateManager {
 
     // Subscribe to agent events.
     //
-    // Two invariants this subscription must uphold:
+    // Three invariants this subscription must uphold:
     //
     // 1. Revocation: the ag-ui pipeline captures `o = [...agent.subscribers]` at
     //    runAgent() start. If this subscription is replaced by a newer one before
@@ -64,14 +64,19 @@ export class StateManager {
     //    with the old input.runId. `revoked = true` turns them into no-ops once
     //    the replacement subscription is in place.
     //
-    // 2. Run isolation within one subscription: in tests (and edge cases), a new
+    // 2. Run identity: `input.runId` identifies the client invocation, while a
+    //    connect replay can contain multiple server runs in the same pipeline.
+    //    Each RUN_STARTED event provides the authoritative runId for its logical
+    //    run. Capture it and apply it to subsequent state and message callbacks.
+    //
+    // 3. Run isolation within one subscription: in tests (and edge cases), a new
     //    run's events can arrive through the same subscription before the new
     //    pipeline is set up. Concretely: the test emits RUN_STARTED for run2
     //    before copilotkit.runAgent() has had a chance to set up the new
     //    pipeline. At that point S1 is still active and sees run2's events with
-    //    input1.runId. To prevent both runs from sharing the same runId key, we
-    //    detect the "seen RUN_FINISHED, then RUN_STARTED again" pattern and
-    //    generate a fresh runId for the second logical run.
+    //    input1.runId. When legacy or custom agents omit event.runId, detect the
+    //    "seen RUN_FINISHED, then RUN_STARTED again" pattern and generate a fresh
+    //    runId so both runs remain isolated.
     let revoked = false;
     let subRunId: string | undefined; // runId assigned to the current logical run
     let runFinished = false; // true after RUN_FINISHED, reset on next RUN_STARTED
@@ -82,9 +87,11 @@ export class StateManager {
     });
 
     const { unsubscribe } = agent.subscribe({
-      onRunStartedEvent: ({ input, state }) => {
+      onRunStartedEvent: ({ event, input, state }) => {
         if (revoked) return;
-        if (runFinished && input.runId === subRunId) {
+        if (event.runId != null) {
+          subRunId = event.runId;
+        } else if (runFinished && input.runId === subRunId) {
           // A new logical run's events are arriving through this same (old)
           // subscription. This happens when the test emits events before
           // copilotkit.runAgent() has had a chance to set up the new pipeline:
@@ -358,7 +365,10 @@ export class StateManager {
     }
     const threadMessages = agentMessages.get(threadId)!;
 
-    threadMessages.set(messageId, runId);
+    // Later cumulative snapshots may contain messages from earlier runs.
+    if (!threadMessages.has(messageId)) {
+      threadMessages.set(messageId, runId);
+    }
   }
 
   /**

--- a/packages/core/src/intelligence-agent.ts
+++ b/packages/core/src/intelligence-agent.ts
@@ -33,6 +33,7 @@ import {
   filter,
   finalize,
   ignoreElements,
+  map,
   mergeMap,
   share,
   shareReplay,
@@ -698,6 +699,7 @@ export class IntelligenceAgent extends AbstractAgent {
       switchMapOperator(({ channel }) =>
         this.observeChannelEvent$<BaseEvent>(channel, CLIENT_AG_UI_EVENT),
       ),
+      map((payload) => this.normalizeAgUiEvent(payload)),
       tap((payload) => {
         this.updateLastSeenEventId(threadId, payload);
       }),
@@ -711,6 +713,28 @@ export class IntelligenceAgent extends AbstractAgent {
       ),
       dematerialize(),
     );
+  }
+
+  private normalizeAgUiEvent(payload: BaseEvent): BaseEvent {
+    const gatewayPayload = payload as BaseEvent & {
+      runId?: unknown;
+      run_id?: unknown;
+    };
+
+    // Phoenix gateway payloads use snake_case, while AG-UI subscribers expect
+    // the protocol-standard camelCase field. Normalize once at the transport
+    // boundary and preserve an already-standardized value.
+    if (
+      typeof gatewayPayload.runId === "string" ||
+      typeof gatewayPayload.run_id !== "string"
+    ) {
+      return payload;
+    }
+
+    return {
+      ...payload,
+      runId: gatewayPayload.run_id,
+    } as BaseEvent;
   }
 
   private observeControlEvent$(

--- a/packages/react-core/src/v2/__tests__/utils/test-helpers.tsx
+++ b/packages/react-core/src/v2/__tests__/utils/test-helpers.tsx
@@ -225,8 +225,15 @@ export function renderWithCopilotKit({
 /**
  * Helper to create a RUN_STARTED event
  */
-export function runStartedEvent(): BaseEvent {
-  return { type: EventType.RUN_STARTED } as BaseEvent;
+export function runStartedEvent(
+  runId = testId("run"),
+  threadId = "test-thread",
+): BaseEvent {
+  return {
+    type: EventType.RUN_STARTED,
+    threadId,
+    runId,
+  };
 }
 
 /**

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.intelligenceReplayRunId.e2e.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.intelligenceReplayRunId.e2e.test.tsx
@@ -1,0 +1,175 @@
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import type { BaseEvent, Message } from "@ag-ui/client";
+import { EventType } from "@ag-ui/client";
+import { IntelligenceAgent } from "@copilotkit/core";
+import { renderWithCopilotKit } from "../../__tests__/utils/test-helpers";
+import type { ReactCustomMessageRenderer } from "../../types/react-custom-message-renderer";
+import type {
+  MockChannel,
+  MockSocket,
+} from "../../../../../core/src/__tests__/test-utils";
+
+const socketInstances = vi.hoisted(() => [] as MockSocket[]);
+
+vi.mock("phoenix", async () => {
+  const { MockSocket: TestSocket } =
+    await import("../../../../../core/src/__tests__/test-utils");
+
+  return {
+    Socket: class extends TestSocket {
+      constructor(url: string, options: Record<string, unknown>) {
+        super(url, options);
+        socketInstances.push(this);
+      }
+    },
+  };
+});
+
+afterEach(() => {
+  socketInstances.length = 0;
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(body: unknown): Promise<Response> {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as Response);
+}
+
+type ReplayRendererProps = React.ComponentProps<
+  NonNullable<ReactCustomMessageRenderer["render"]>
+>;
+
+function ReplayRenderer({
+  message,
+  position,
+  runId,
+  messageIndexInRun,
+  numberOfMessagesInRun,
+  stateSnapshot,
+}: ReplayRendererProps): React.ReactElement | null {
+  if (position !== "after" || message.role !== "assistant") {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid={`replay-${message.id}`}
+      data-run-id={runId}
+      data-message-index-in-run={messageIndexInRun}
+      data-messages-in-run={numberOfMessagesInRun}
+    >
+      State: {(stateSnapshot as { turn?: number } | undefined)?.turn ?? "none"}
+    </div>
+  );
+}
+
+describe("CopilotKitProvider Intelligence replay run identity", () => {
+  it("renders cumulative replay messages with their server run IDs and state", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({
+          threadId: "test-thread",
+          runId: null,
+          joinToken: "join-token",
+          realtime: {
+            clientUrl: "ws://localhost:4401/client",
+            topic: "thread:test-thread",
+          },
+        }),
+      ),
+    );
+
+    const agent = new IntelligenceAgent({
+      url: "ws://localhost:4401/client",
+      runtimeUrl: "http://localhost:4000",
+      agentId: "default",
+    });
+    agent.threadId = "test-thread";
+
+    renderWithCopilotKit({
+      agent,
+      renderCustomMessages: [{ render: ReplayRenderer }],
+    });
+
+    let channel: MockChannel | undefined;
+    await waitFor(() => {
+      channel = socketInstances.at(-1)?.channels.at(-1);
+      expect(channel).toBeDefined();
+    });
+    channel!.triggerJoin("ok");
+
+    const firstMessage: Message = {
+      id: "message-1",
+      role: "assistant",
+      content: "First response",
+    };
+    const secondMessage: Message = {
+      id: "message-2",
+      role: "assistant",
+      content: "Second response",
+    };
+
+    channel!.serverPush("ag_ui_event", {
+      type: EventType.RUN_STARTED,
+      threadId: "test-thread",
+      run_id: "server-run-1",
+      input: { messages: [] },
+    } as BaseEvent);
+    channel!.serverPush("ag_ui_event", {
+      type: EventType.STATE_SNAPSHOT,
+      snapshot: { turn: 1 },
+    } as BaseEvent);
+    channel!.serverPush("ag_ui_event", {
+      type: EventType.MESSAGES_SNAPSHOT,
+      messages: [firstMessage],
+    } as BaseEvent);
+    channel!.serverPush("ag_ui_event", {
+      type: EventType.RUN_FINISHED,
+      threadId: "test-thread",
+      run_id: "server-run-1",
+    } as BaseEvent);
+
+    channel!.serverPush("ag_ui_event", {
+      type: EventType.RUN_STARTED,
+      threadId: "test-thread",
+      run_id: "server-run-2",
+      input: { messages: [firstMessage] },
+    } as BaseEvent);
+    channel!.serverPush("ag_ui_event", {
+      type: EventType.STATE_SNAPSHOT,
+      snapshot: { turn: 2 },
+    } as BaseEvent);
+    channel!.serverPush("ag_ui_event", {
+      type: EventType.MESSAGES_SNAPSHOT,
+      messages: [firstMessage, secondMessage],
+    } as BaseEvent);
+    channel!.serverPush("ag_ui_event", {
+      type: EventType.RUN_FINISHED,
+      threadId: "test-thread",
+      run_id: "server-run-2",
+    } as BaseEvent);
+    channel!.serverPush("replay_complete", { latestEventId: "event-8" });
+    channel!.serverPush("stream_idle", { latestEventId: "event-8" });
+
+    const firstRendered = await screen.findByTestId("replay-message-1");
+    const secondRendered = await screen.findByTestId("replay-message-2");
+
+    expect(firstRendered.getAttribute("data-run-id")).toBe("server-run-1");
+    expect(firstRendered.getAttribute("data-message-index-in-run")).toBe("0");
+    expect(firstRendered.getAttribute("data-messages-in-run")).toBe("1");
+    expect(firstRendered.textContent).toBe("State: 1");
+
+    expect(secondRendered.getAttribute("data-run-id")).toBe("server-run-2");
+    expect(secondRendered.getAttribute("data-message-index-in-run")).toBe("0");
+    expect(secondRendered.getAttribute("data-messages-in-run")).toBe("1");
+    expect(secondRendered.textContent).toBe("State: 2");
+  });
+});

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.renderCustomMessages.e2e.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.renderCustomMessages.e2e.test.tsx
@@ -11,12 +11,12 @@ import {
   textMessageContentEvent,
   textMessageEndEvent,
 } from "../../__tests__/utils/test-helpers";
-import { ReactCustomMessageRenderer } from "../../types/react-custom-message-renderer";
+import type { ReactCustomMessageRenderer } from "../../types/react-custom-message-renderer";
 import { useCopilotKit } from "../../providers/CopilotKitProvider";
 import { useCopilotChatConfiguration } from "../../providers/CopilotChatConfigurationProvider";
 import { useAgent } from "../../hooks/use-agent";
 import { CopilotKitCoreReact } from "../../lib/react-core";
-import { Message } from "@ag-ui/core";
+import type { Message } from "@ag-ui/core";
 
 // Test shim: some environments lack setCredentials on CopilotKitCoreReact.
 if (!(CopilotKitCoreReact.prototype as any).setCredentials) {
@@ -38,6 +38,8 @@ const SnapshotRenderer: React.FC<SnapshotRendererProps> = ({
   position,
   message,
   runId,
+  messageIndexInRun,
+  numberOfMessagesInRun,
   stateSnapshot,
 }) => {
   if (position !== "after" || message.role !== "assistant") {
@@ -66,7 +68,12 @@ const SnapshotRenderer: React.FC<SnapshotRendererProps> = ({
   }
 
   return (
-    <div data-testid={`state-${message.id}`} data-run-id={runId}>
+    <div
+      data-testid={`state-${message.id}`}
+      data-run-id={runId}
+      data-message-index-in-run={messageIndexInRun}
+      data-messages-in-run={numberOfMessagesInRun}
+    >
       State: {count ?? "null"}
     </div>
   );
@@ -128,6 +135,8 @@ describe("CopilotKitProvider custom message renderers E2E", () => {
   it("renders stored state snapshots for sequential runs", async () => {
     const agent = new MockStepwiseAgent();
     const history: number[] = [];
+    const firstServerRunId = "server-run-1";
+    const secondServerRunId = "server-run-2";
 
     const emitSnapshot = (count: number) => {
       history.push(count);
@@ -153,7 +162,7 @@ describe("CopilotKitProvider custom message renderers E2E", () => {
       expect(screen.getByText("First question")).toBeDefined();
     });
 
-    agent.emit(runStartedEvent());
+    agent.emit(runStartedEvent(firstServerRunId));
     emitSnapshot(1);
     agent.emit(textMessageStartEvent(firstAssistantId));
     agent.emit(textMessageContentEvent(firstAssistantId, "First answer"));
@@ -168,7 +177,17 @@ describe("CopilotKitProvider custom message renderers E2E", () => {
     const firstRunId = screen
       .getByTestId(`state-${firstAssistantId}`)
       .getAttribute("data-run-id");
-    expect(firstRunId).toBeTruthy();
+    expect(firstRunId).toBe(firstServerRunId);
+    expect(
+      screen
+        .getByTestId(`state-${firstAssistantId}`)
+        .getAttribute("data-message-index-in-run"),
+    ).toBe("0");
+    expect(
+      screen
+        .getByTestId(`state-${firstAssistantId}`)
+        .getAttribute("data-messages-in-run"),
+    ).toBe("1");
 
     const secondAssistantId = testId("assistant-message");
     fireEvent.change(input, { target: { value: "Second question" } });
@@ -178,7 +197,7 @@ describe("CopilotKitProvider custom message renderers E2E", () => {
       expect(screen.getByText("Second question")).toBeDefined();
     });
 
-    agent.emit(runStartedEvent());
+    agent.emit(runStartedEvent(secondServerRunId));
     emitSnapshot(2);
     agent.emit(textMessageStartEvent(secondAssistantId));
     agent.emit(textMessageContentEvent(secondAssistantId, "Second answer"));
@@ -195,7 +214,17 @@ describe("CopilotKitProvider custom message renderers E2E", () => {
       .getByTestId(`state-${secondAssistantId}`)
       .getAttribute("data-run-id");
 
-    expect(secondRunId).not.toBe(firstRunId);
+    expect(secondRunId).toBe(secondServerRunId);
+    expect(
+      screen
+        .getByTestId(`state-${secondAssistantId}`)
+        .getAttribute("data-message-index-in-run"),
+    ).toBe("0");
+    expect(
+      screen
+        .getByTestId(`state-${secondAssistantId}`)
+        .getAttribute("data-messages-in-run"),
+    ).toBe("1");
 
     const firstRunIdAfterSecond = screen
       .getByTestId(`state-${firstAssistantId}`)

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.renderCustomMessages.e2e.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.renderCustomMessages.e2e.test.tsx
@@ -38,8 +38,6 @@ const SnapshotRenderer: React.FC<SnapshotRendererProps> = ({
   position,
   message,
   runId,
-  messageIndexInRun,
-  numberOfMessagesInRun,
   stateSnapshot,
 }) => {
   if (position !== "after" || message.role !== "assistant") {
@@ -68,12 +66,7 @@ const SnapshotRenderer: React.FC<SnapshotRendererProps> = ({
   }
 
   return (
-    <div
-      data-testid={`state-${message.id}`}
-      data-run-id={runId}
-      data-message-index-in-run={messageIndexInRun}
-      data-messages-in-run={numberOfMessagesInRun}
-    >
+    <div data-testid={`state-${message.id}`} data-run-id={runId}>
       State: {count ?? "null"}
     </div>
   );
@@ -135,8 +128,6 @@ describe("CopilotKitProvider custom message renderers E2E", () => {
   it("renders stored state snapshots for sequential runs", async () => {
     const agent = new MockStepwiseAgent();
     const history: number[] = [];
-    const firstServerRunId = "server-run-1";
-    const secondServerRunId = "server-run-2";
 
     const emitSnapshot = (count: number) => {
       history.push(count);
@@ -162,7 +153,7 @@ describe("CopilotKitProvider custom message renderers E2E", () => {
       expect(screen.getByText("First question")).toBeDefined();
     });
 
-    agent.emit(runStartedEvent(firstServerRunId));
+    agent.emit(runStartedEvent());
     emitSnapshot(1);
     agent.emit(textMessageStartEvent(firstAssistantId));
     agent.emit(textMessageContentEvent(firstAssistantId, "First answer"));
@@ -177,17 +168,7 @@ describe("CopilotKitProvider custom message renderers E2E", () => {
     const firstRunId = screen
       .getByTestId(`state-${firstAssistantId}`)
       .getAttribute("data-run-id");
-    expect(firstRunId).toBe(firstServerRunId);
-    expect(
-      screen
-        .getByTestId(`state-${firstAssistantId}`)
-        .getAttribute("data-message-index-in-run"),
-    ).toBe("0");
-    expect(
-      screen
-        .getByTestId(`state-${firstAssistantId}`)
-        .getAttribute("data-messages-in-run"),
-    ).toBe("1");
+    expect(firstRunId).toBeTruthy();
 
     const secondAssistantId = testId("assistant-message");
     fireEvent.change(input, { target: { value: "Second question" } });
@@ -197,7 +178,7 @@ describe("CopilotKitProvider custom message renderers E2E", () => {
       expect(screen.getByText("Second question")).toBeDefined();
     });
 
-    agent.emit(runStartedEvent(secondServerRunId));
+    agent.emit(runStartedEvent());
     emitSnapshot(2);
     agent.emit(textMessageStartEvent(secondAssistantId));
     agent.emit(textMessageContentEvent(secondAssistantId, "Second answer"));
@@ -214,17 +195,7 @@ describe("CopilotKitProvider custom message renderers E2E", () => {
       .getByTestId(`state-${secondAssistantId}`)
       .getAttribute("data-run-id");
 
-    expect(secondRunId).toBe(secondServerRunId);
-    expect(
-      screen
-        .getByTestId(`state-${secondAssistantId}`)
-        .getAttribute("data-message-index-in-run"),
-    ).toBe("0");
-    expect(
-      screen
-        .getByTestId(`state-${secondAssistantId}`)
-        .getAttribute("data-messages-in-run"),
-    ).toBe("1");
+    expect(secondRunId).not.toBe(firstRunId);
 
     const firstRunIdAfterSecond = screen
       .getByTestId(`state-${firstAssistantId}`)


### PR DESCRIPTION
## Summary

- normalize Phoenix `run_id` to the AG-UI `runId` at the Intelligence transport boundary while preserving an existing standard `runId`
- treat `RUN_STARTED.runId` as authoritative in `StateManager` and preserve first message-to-run ownership across cumulative replay snapshots
- add real `connectAgent` and React renderer regression coverage for sequential server runs and per-run state

## Testing

- `pnpm exec nx run @copilotkit/core:test --skip-nx-cache --excludeTaskDependencies --outputStyle=static` (617 tests)
- `pnpm exec nx run @copilotkit/core:check-types --skip-nx-cache --excludeTaskDependencies --outputStyle=static`
- `pnpm exec nx run @copilotkit/react-core:test --skip-nx-cache --excludeTaskDependencies --outputStyle=static` (1472 Vitest tests + 2 script tests)
- `pnpm exec nx run @copilotkit/react-core:check-types --skip-nx-cache --excludeTaskDependencies --outputStyle=static`
- pre-commit package checks (`test`, `publint`, `attw`)
