### PR TITLE
fix(channels): use channel name for thread lock

### DIFF
--- a/packages/channels-intelligence/src/delivery-adapter-postfile.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-postfile.test.ts
@@ -32,6 +32,7 @@ function replyTarget(session: ChannelDeliverySession) {
 
 function makeAdapter() {
   return new DeliveryAdapter({
+    channelName: "support",
     transport: {} as never,
     runCanonical: async () => ({ iterations: 0, interrupted: false }),
     loadHistory: async () => [],

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -73,6 +73,8 @@ export interface CanonicalChannelRunArgs {
 }
 
 export interface DeliveryAdapterOptions {
+  /** Declared Channel name used to own the canonical Intelligence thread. */
+  channelName: string;
   transport: ChannelDeliveryTransport;
   runCanonical(args: CanonicalChannelRunArgs): Promise<ChannelAgentLoopResult>;
   loadHistory(args: {
@@ -337,7 +339,7 @@ export class DeliveryAdapter implements PlatformAdapter {
       threadId,
       runId,
       userId: target.delivery.appUserId,
-      agentId: args.agent.agentId ?? "default",
+      agentId: this.options.channelName,
       tools: args.tools,
       context: args.context,
       persistedInputMessages: args.agent.messages.filter(

--- a/packages/channels-intelligence/src/delivery-channel-name.test.ts
+++ b/packages/channels-intelligence/src/delivery-channel-name.test.ts
@@ -1,0 +1,38 @@
+import { createChannel, FakeAgent } from "@copilotkit/channels-core";
+import { expect, test, vi } from "vitest";
+import {
+  DeliveryTestGateway,
+  preparedDelivery,
+} from "./delivery-test-gateway.js";
+import { startChannelsWithGatewayControl } from "./realtime-gateway-launcher.js";
+
+test("managed deliveries use the declared Channel name for canonical runs", async () => {
+  const gateway = new DeliveryTestGateway();
+  const agent = new FakeAgent();
+  const runCanonical = vi.fn(async (args) => args.execute({}));
+  const channel = createChannel({ name: "support", agent: () => agent });
+  channel.onMessage(async ({ thread, message }) => {
+    await thread.runAgent({ prompt: message.text });
+  });
+  const handle = await startChannelsWithGatewayControl([channel], {
+    session: gateway,
+    scope: { projectId: 1, channelName: "support" },
+    runtimeInstanceId: "rti_channel_name",
+    runCanonical,
+    loadHistory: async () => [],
+  });
+
+  try {
+    await gateway.deliver(
+      preparedDelivery("channel_name", "slack", {
+        kind: "text",
+        text: "hello",
+      }),
+    );
+
+    expect(runCanonical).toHaveBeenCalledOnce();
+    expect(runCanonical.mock.calls[0]![0].agentId).toBe("support");
+  } finally {
+    await handle.stop();
+  }
+});

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.ts
@@ -137,6 +137,7 @@ export async function startChannelsWithGatewayControl(
   const channel = channels[0]!;
   channel.ɵruntime.addAdapter(
     new DeliveryAdapter({
+      channelName: opts.scope.channelName,
       transport,
       runCanonical: opts.runCanonical,
       loadHistory: opts.loadHistory,


### PR DESCRIPTION
## Problem

Managed Channel deliveries can request a canonical thread lock with the inner agent ID, or `default` when that ID is unset. Intelligence owns the thread under the declared Channel name, so the lock fails with `THREAD_AGENT_MISMATCH`.

## Why

The SDK treated the agent object identity as the managed Channel identity. Those values are independent: `createChannel({ name })` declares the managed thread owner, while an agent ID is optional and may differ.

## Fix

Pass the declared Channel name into the managed delivery adapter and use it for canonical runs. Add a public `thread.runAgent()` regression test that proves an agent with a different ID still runs under the Channel name.

Validated with the Channels Intelligence test suite, type check, and build; the runtime Channel manager tests, type check, and build; repo lint; and the affected-package pre-commit checks.