### PR TITLE
feat(channels): make Slack reply-continuation limits configurable (refs OSS-689)

### DIFF
--- a/packages/channels-core/src/create-channel.ts
+++ b/packages/channels-core/src/create-channel.ts
@@ -196,6 +196,34 @@ export interface StoreConfig<
   dedupTtl?: number;
 }
 
+/**
+ * Tuning for how a long reply is spread across continuation messages.
+ *
+ * Providers cap how much text one message can hold; past that the reply is
+ * split, and past {@link ReplyContinuationOptions.maxMessages} it is truncated
+ * with a visible marker. Defaults are conservative and suit most bots — reach
+ * for these when a provider's real ceiling differs, when a product wants a
+ * different tolerance for how many messages one reply may occupy, or when the
+ * truncation notice needs to be in another language.
+ *
+ * Currently honoured by managed and direct Slack.
+ */
+export interface ReplyContinuationOptions {
+  /**
+   * Soft cap on the UTF-8 bytes one message may hold before continuing into a
+   * new one. Bytes rather than characters because the provider ceiling may be
+   * counted either way, and bytes are the safe reading for non-Latin scripts.
+   */
+  readonly messageByteLimit?: number;
+  /**
+   * Ceiling on messages a single reply may occupy before it is truncated with a
+   * visible marker. Bounds a runaway reply.
+   */
+  readonly maxMessages?: number;
+  /** Notice appended when `maxMessages` is reached. Defaults to English copy. */
+  readonly truncationMarker?: string;
+}
+
 export interface CreateChannelOptions<
   TStateSchema extends StandardSchemaV1 | undefined = undefined,
 > {
@@ -237,6 +265,12 @@ export interface CreateChannelOptions<
    * `slack({ showToolStatus: true })` instead.
    */
   showToolStatus?: boolean;
+  /**
+   * Tuning for splitting a long reply across continuation messages. See
+   * {@link ReplyContinuationOptions}. Applies to managed and direct Slack;
+   * configure direct Slack with `slack({ replyContinuation })` instead.
+   */
+  replyContinuation?: ReplyContinuationOptions;
   agent?: AbstractAgent | ((threadId: string) => AbstractAgent);
   /** @deprecated Pass `store.adapter` instead. */
   actionStore?: ActionStore;
@@ -273,6 +307,11 @@ export interface Channel<TState = unknown> {
    * undefined. Ignored for direct-adapter Channels.
    */
   readonly showToolStatus?: boolean;
+  /**
+   * Continuation-message tuning from `createChannel({ replyContinuation })`.
+   * Undefined leaves the provider defaults in place.
+   */
+  readonly replyContinuation?: ReplyContinuationOptions;
   /** Declared slash-command names (normalized). Surfaced for Channel activation metadata. */
   readonly commandNames: string[];
   onMention(h: ChannelHandler<TState>): void;
@@ -815,6 +854,9 @@ export function createChannel<
     ...(opts.provider !== undefined ? { provider: opts.provider } : {}),
     ...(opts.showToolStatus !== undefined
       ? { showToolStatus: opts.showToolStatus }
+      : {}),
+    ...(opts.replyContinuation !== undefined
+      ? { replyContinuation: opts.replyContinuation }
       : {}),
     get adapters() {
       // Defensive read-only copy: mutating the returned array must not affect

--- a/packages/channels-core/src/index.ts
+++ b/packages/channels-core/src/index.ts
@@ -6,6 +6,7 @@ export type {
   Channel,
   CreateChannelOptions,
   ManagedChannelProvider,
+  ReplyContinuationOptions,
   ChannelHandler,
   ThreadStartHandler,
   ReactionEvent,

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -22,6 +22,7 @@ import type {
   StateStore,
   SurfaceCapabilities,
   UserQuery,
+  ReplyContinuationOptions,
 } from "@copilotkit/channels-core";
 import {
   createRunRenderer as createSlackRunRenderer,
@@ -84,6 +85,8 @@ export interface DeliveryAdapterOptions {
   store?: StateStore;
   log?: (message: string, meta?: unknown) => void;
   showToolStatus?: boolean;
+  /** Continuation-message tuning for long Slack replies. */
+  replyContinuation?: ReplyContinuationOptions;
 }
 
 /** Typed rejection for two overlapping agent calls on one canonical thread. */
@@ -584,6 +587,9 @@ export class DeliveryAdapter implements PlatformAdapter {
       nativeStreaming: {
         strict: true,
         minIntervalMs: 0,
+        ...(this.options.replyContinuation !== undefined
+          ? { replyContinuation: this.options.replyContinuation }
+          : {}),
         transport: {
           startStream: async () => {
             providerReference = providerReferenceFromResult(

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.ts
@@ -1,4 +1,7 @@
-import type { Channel } from "@copilotkit/channels-core";
+import type {
+  Channel,
+  ReplyContinuationOptions,
+} from "@copilotkit/channels-core";
 import type { Message } from "@ag-ui/client";
 import {
   assertValidChannelNames,
@@ -97,6 +100,8 @@ export interface StartChannelsWithGatewayControlOptions {
   log?: (message: string, meta?: unknown) => void;
   /** Override managed provider tool-call visibility; omission is forwarded. */
   showToolStatus?: boolean;
+  /** Continuation-message tuning forwarded to the Slack renderer. */
+  replyContinuation?: ReplyContinuationOptions;
   /** Execute one outer Channel run through the runtime's standard runner. */
   runCanonical(
     args: CanonicalChannelRunArgs,
@@ -144,6 +149,8 @@ export async function startChannelsWithGatewayControl(
       ...(store ? { store } : {}),
       ...(opts.log ? { log: opts.log } : {}),
       showToolStatus: opts.showToolStatus ?? channel.showToolStatus,
+      replyContinuation:
+        opts.replyContinuation ?? channel.replyContinuation,
     }),
   );
   await channel.ɵruntime.start();
@@ -236,6 +243,8 @@ export interface StartChannelsOverRealtimeGatewayOptions {
   log?: (message: string, meta?: unknown) => void;
   /** Override managed provider tool-call visibility; omission is forwarded. */
   showToolStatus?: boolean;
+  /** Continuation-message tuning forwarded to the Slack renderer. */
+  replyContinuation?: ReplyContinuationOptions;
   /** Execute one outer Channel run through the runtime's standard runner. */
   runCanonical(
     args: CanonicalChannelRunArgs,
@@ -315,6 +324,7 @@ export async function startChannelsOverRealtimeGateway(
       ...(config.env ? { env: config.env } : {}),
       ...(config.log ? { log: config.log } : {}),
       showToolStatus: config.showToolStatus,
+      replyContinuation: config.replyContinuation,
     });
   } catch (err) {
     session.disconnect();

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.ts
@@ -149,8 +149,7 @@ export async function startChannelsWithGatewayControl(
       ...(store ? { store } : {}),
       ...(opts.log ? { log: opts.log } : {}),
       showToolStatus: opts.showToolStatus ?? channel.showToolStatus,
-      replyContinuation:
-        opts.replyContinuation ?? channel.replyContinuation,
+      replyContinuation: opts.replyContinuation ?? channel.replyContinuation,
     }),
   );
   await channel.ɵruntime.start();

--- a/packages/channels-slack/src/__tests__/native-renderer.test.ts
+++ b/packages/channels-slack/src/__tests__/native-renderer.test.ts
@@ -99,6 +99,34 @@ const chunksOf = (events: Event[]): AnyChunk[] =>
 const tick = () => new Promise((r) => setTimeout(r, 0));
 
 describe("createRunRenderer — native streaming", () => {
+  it("forwards replyContinuation to the turn stream", async () => {
+    // The renderer is the seam between a caller's `replyContinuation` and
+    // NativeMessageStream's own options; without the pass-through the limits are
+    // silently ignored and a long reply stays in one (over-cap) message.
+    const fake = makeFakeClient();
+    const nt = makeFakeNativeTransport();
+    const { subscriber: sub, finish } = createRunRenderer({
+      transport: fake.transport,
+      target: { channel: "C1", threadTs: "100.0" },
+      nativeStreaming: {
+        transport: nt.transport,
+        replyContinuation: { messageByteLimit: 400, maxMessages: 2 },
+      },
+    });
+
+    await sub.onTextMessageStartEvent!({ event: { messageId: "m1" } } as never);
+    sub.onTextMessageContentEvent!({
+      event: { messageId: "m1", delta: "word ".repeat(500) },
+    } as never);
+    await sub.onTextMessageEndEvent!({ event: { messageId: "m1" } } as never);
+    await finish!();
+
+    // Split by the configured byte limit and capped by maxMessages, rather than
+    // the 11k/20 defaults which would have produced a single message.
+    expect(nt.messages).toHaveLength(2);
+    expect(textOf(nt.messages[1]!.events)).toContain("reply truncated");
+  });
+
   it("streams multiple AG-UI messages into ONE turn message, separated by a blank line", async () => {
     const fake = makeFakeClient();
     const nt = makeFakeNativeTransport();

--- a/packages/channels-slack/src/__tests__/native-stream.test.ts
+++ b/packages/channels-slack/src/__tests__/native-stream.test.ts
@@ -1019,6 +1019,27 @@ describe("NativeMessageStream", () => {
     expect(withChunk[0]!.ts).toBe(messages[messages.length - 1]!.ts);
   });
 
+  it("uses a configured truncation marker", async () => {
+    // The default marker is English copy posted into the customer's channel, so
+    // a non-English workspace has to be able to replace it.
+    const { transport, messages } = makeFakeTransport();
+    const stream = new NativeMessageStream({
+      transport,
+      fallback: makeFakeFallback,
+      minIntervalMs: 0,
+      maxMessages: 2,
+      messageByteLimit: 400,
+      truncationMarker: "\n\n_…réponse tronquée._",
+    });
+
+    stream.append("word ".repeat(500));
+    await stream.finish();
+
+    const last = textOf(messages[messages.length - 1]!.events);
+    expect(last).toContain("réponse tronquée");
+    expect(last).not.toContain("reply truncated");
+  });
+
   it("does not fail the turn when the truncation marker cannot be posted", async () => {
     const messages: { ts: string; text: string }[] = [];
     let starts = 0;

--- a/packages/channels-slack/src/adapter.ts
+++ b/packages/channels-slack/src/adapter.ts
@@ -22,6 +22,7 @@ import type {
   UserQuery,
   EphemeralResult,
   NativePayload,
+  ReplyContinuationOptions,
 } from "@copilotkit/channels-core";
 import type { AbstractAgent } from "@ag-ui/client";
 import type {
@@ -81,6 +82,11 @@ export interface SlackAdapterOptions {
   interruptEventNames?: ReadonlySet<string>;
   /** Surface tool-call progress in Slack. Default false. */
   showToolStatus?: boolean;
+  /**
+   * Tuning for splitting a long reply across continuation messages once Slack's
+   * per-message ceiling is reached. See {@link ReplyContinuationOptions}.
+   */
+  replyContinuation?: ReplyContinuationOptions;
   /**
    * Assistant-pane behavior ("Agents & AI Apps"). ON by default — the pane
    * activates whenever the app's Slack config has the toggle (see the README),
@@ -416,6 +422,15 @@ export class SlackAdapter implements PlatformAdapter {
         onStartFailure: () => {
           this.nativeStreamingOk = false;
         },
+        ...(this.opts.replyContinuation?.messageByteLimit !== undefined
+          ? { messageByteLimit: this.opts.replyContinuation.messageByteLimit }
+          : {}),
+        ...(this.opts.replyContinuation?.maxMessages !== undefined
+          ? { maxMessages: this.opts.replyContinuation.maxMessages }
+          : {}),
+        ...(this.opts.replyContinuation?.truncationMarker !== undefined
+          ? { truncationMarker: this.opts.replyContinuation.truncationMarker }
+          : {}),
       });
     } else {
       sink = makeLegacy();
@@ -624,6 +639,9 @@ export class SlackAdapter implements PlatformAdapter {
             onChunkFailure: () => {
               this.nativeTaskChunksOk = false;
             },
+            ...(this.opts.replyContinuation !== undefined
+              ? { replyContinuation: this.opts.replyContinuation }
+              : {}),
           }
         : undefined,
       // Native AI feedback row (opt-in); only attached to native streamed

--- a/packages/channels-slack/src/event-renderer.ts
+++ b/packages/channels-slack/src/event-renderer.ts
@@ -4,6 +4,7 @@ import type {
   RunRenderer,
   CapturedToolCall,
   CapturedInterrupt,
+  ReplyContinuationOptions,
 } from "@copilotkit/channels-core";
 import { ChunkedMessageStream } from "./chunked-message-stream.js";
 import { markdownToMrkdwn } from "./markdown-to-mrkdwn.js";
@@ -116,6 +117,11 @@ export function createRunRenderer(args: {
     strict?: boolean;
     /** Override the native text flush floor. Managed sessions use `0`. */
     minIntervalMs?: number;
+    /**
+     * Tuning for splitting a long reply across continuation messages. Passed
+     * straight through to the turn stream; unset leaves its defaults.
+     */
+    replyContinuation?: ReplyContinuationOptions;
     onStartFailure?: (err: unknown) => void;
     /**
      * Whether structured `task_update` chunks are known to work on this
@@ -273,6 +279,15 @@ export function createRunRenderer(args: {
       onStartFailure: ns.onStartFailure,
       strict: ns.strict,
       minIntervalMs: ns.minIntervalMs,
+      ...(ns.replyContinuation?.messageByteLimit !== undefined
+        ? { messageByteLimit: ns.replyContinuation.messageByteLimit }
+        : {}),
+      ...(ns.replyContinuation?.maxMessages !== undefined
+        ? { maxMessages: ns.replyContinuation.maxMessages }
+        : {}),
+      ...(ns.replyContinuation?.truncationMarker !== undefined
+        ? { truncationMarker: ns.replyContinuation.truncationMarker }
+        : {}),
       onChunkFailure: () => {
         // Structured chunks unsupported on this workspace — degrade tool
         // progress to `:wrench:` rows for the rest of the run, and let the

--- a/packages/channels-slack/src/native-stream.ts
+++ b/packages/channels-slack/src/native-stream.ts
@@ -103,6 +103,12 @@ export interface NativeMessageStreamConfig {
    * visible marker. Defaults to {@link DEFAULT_MAX_MESSAGES}.
    */
   maxMessages?: number;
+  /**
+   * Notice appended when `maxMessages` is reached. Defaults to
+   * {@link TRUNCATION_MARKER}, which is English — replace it for a workspace
+   * that is not.
+   */
+  truncationMarker?: string;
 }
 
 /**
@@ -348,6 +354,7 @@ export class NativeMessageStream implements TextStream {
   private readonly minIntervalMs: number;
   private readonly messageByteLimit: number;
   private readonly maxMessages: number;
+  private readonly truncationMarker: string;
 
   constructor(config: NativeMessageStreamConfig) {
     this.transport = config.transport;
@@ -359,6 +366,7 @@ export class NativeMessageStream implements TextStream {
     this.messageByteLimit =
       config.messageByteLimit ?? DEFAULT_MESSAGE_BYTE_LIMIT;
     this.maxMessages = config.maxMessages ?? DEFAULT_MAX_MESSAGES;
+    this.truncationMarker = config.truncationMarker ?? TRUNCATION_MARKER;
   }
 
   /** The first streamed message's ts (or the fallback's), available after finish(). */
@@ -748,7 +756,7 @@ export class NativeMessageStream implements TextStream {
     // terminal rather than re-entering here on the next flush.
     this.curPosted = this.buffer.length;
     const closer = renderContextCloser(detectOpenContext(posted), posted);
-    const marker = closer + TRUNCATION_MARKER;
+    const marker = closer + this.truncationMarker;
     try {
       await this.transport.appendText(this.curTs!, marker);
       // Charged like every other append; this was the one path that neither

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
@@ -904,6 +904,59 @@ describe("defaultActivateChannel", () => {
     expect(opts.showToolStatus).toBe(true);
   });
 
+  it("forwards createChannel({ replyContinuation }) to the managed launcher", async () => {
+    const { start, importer } = captureChannelsIntelligenceLaunch();
+    const channel = createChannel({
+      name: "support",
+      replyContinuation: { maxMessages: 5, truncationMarker: "…cut" },
+    });
+    const activationConfig = deriveChannelActivationConfig({
+      intelligence: fakeIntelligence(),
+      channel,
+      runtimeInstanceId: "rti_x",
+    });
+
+    await defaultActivateChannel(
+      activationConfig,
+      channel,
+      importer,
+      undefined,
+      fakeServices(),
+    );
+
+    expect(activationConfig.replyContinuation).toEqual({
+      maxMessages: 5,
+      truncationMarker: "…cut",
+    });
+    const [, opts] = start.mock.calls[0]!;
+    expect(opts.replyContinuation).toEqual({
+      maxMessages: 5,
+      truncationMarker: "…cut",
+    });
+  });
+
+  it("omits replyContinuation when createChannel does not set it", async () => {
+    const { start, importer } = captureChannelsIntelligenceLaunch();
+    const channel = createChannel({ name: "support" });
+    const activationConfig = deriveChannelActivationConfig({
+      intelligence: fakeIntelligence(),
+      channel,
+      runtimeInstanceId: "rti_x",
+    });
+
+    await defaultActivateChannel(
+      activationConfig,
+      channel,
+      importer,
+      undefined,
+      fakeServices(),
+    );
+
+    expect(activationConfig).not.toHaveProperty("replyContinuation");
+    const [, opts] = start.mock.calls[0]!;
+    expect(opts).not.toHaveProperty("replyContinuation");
+  });
+
   it("forwards the log sink to the launcher opts so transport-level drops surface", async () => {
     const { start, importer } = captureChannelsIntelligenceLaunch();
     const channel = createChannel({ name: "support" });

--- a/packages/runtime/src/v2/runtime/core/channel-activation-config.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-activation-config.ts
@@ -1,10 +1,7 @@
 import type { CopilotKitIntelligence } from "../intelligence-platform";
 // Type-only: @copilotkit/channels is pure-ESM, so a value import would break this
 // package's CJS output (see `runtime.ts` for the same constraint).
-import type {
-  Channel,
-  ReplyContinuationOptions,
-} from "@copilotkit/channels";
+import type { Channel, ReplyContinuationOptions } from "@copilotkit/channels";
 
 /**
  * Error thrown when a Channel activation config cannot be derived — either the

--- a/packages/runtime/src/v2/runtime/core/channel-activation-config.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-activation-config.ts
@@ -1,7 +1,10 @@
 import type { CopilotKitIntelligence } from "../intelligence-platform";
 // Type-only: @copilotkit/channels is pure-ESM, so a value import would break this
 // package's CJS output (see `runtime.ts` for the same constraint).
-import type { Channel } from "@copilotkit/channels";
+import type {
+  Channel,
+  ReplyContinuationOptions,
+} from "@copilotkit/channels";
 
 /**
  * Error thrown when a Channel activation config cannot be derived — either the
@@ -47,6 +50,11 @@ export interface ChannelActivationConfig {
    * default.
    */
   showToolStatus?: boolean;
+  /**
+   * Optional per-Channel tuning for splitting a long reply across continuation
+   * messages. Unset leaves the provider renderer's defaults in place.
+   */
+  replyContinuation?: ReplyContinuationOptions;
   /** Identifier for the runtime instance activating this Channel. */
   runtimeInstanceId: string;
 }
@@ -173,6 +181,9 @@ export function deriveChannelActivationConfig(args: {
     adapter: trimmedProvider ? trimmedProvider : "slack",
     ...(channel.showToolStatus !== undefined
       ? { showToolStatus: channel.showToolStatus }
+      : {}),
+    ...(channel.replyContinuation !== undefined
+      ? { replyContinuation: channel.replyContinuation }
       : {}),
     runtimeInstanceId,
   };

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -18,8 +18,7 @@ import type { AgentRunner } from "../runner/agent-runner";
 // Type-only: @copilotkit/channels is pure-ESM, so a value import would break this
 // package's CJS output (see `core/runtime.ts` and `channel-activation-config.ts`
 // for the same constraint).
-import type { Channel } from "@copilotkit/channels";
-import type { StartChannelsOverRealtimeGatewayOptions } from "@copilotkit/channels-intelligence";
+import type { Channel, ReplyContinuationOptions } from "@copilotkit/channels";
 
 /**
  * Lifecycle status of a single Channel activation, or of the manager overall.
@@ -206,21 +205,61 @@ interface ChannelEntry {
 const CHANNELS_INTELLIGENCE_SPECIFIER = "@copilotkit/channels-intelligence";
 
 /**
- * The `@copilotkit/channels-intelligence` module surface the default engine
- * consumes.
- *
- * The launcher's own options type is imported rather than re-declared: a
- * hand-written mirror drifts silently, since a new launcher option type-checks
- * clean here while the managed path quietly ignores it. The CJS/ESM boundary
- * above constrains the *value* import — hence the non-literal specifier — but a
- * type-only import is erased, leaks no `require` into the CJS build, and this
- * interface is not part of the emitted `.d.cts` surface, so no CJS consumer
- * resolves the ESM-only package for it.
+ * Structural view of the `@copilotkit/channels-intelligence` module surface the
+ * default engine consumes. Declared locally (not imported) for the same
+ * CJS/ESM-boundary reason the {@link ChannelsHandle} view is.
  */
 export interface ChannelsIntelligenceModule {
   startChannelsOverRealtimeGateway: (
     channels: Channel[],
-    opts: StartChannelsOverRealtimeGatewayOptions,
+    opts: {
+      wsUrl: string;
+      apiKey: string;
+      scope: { projectId: number; channelName: string };
+      runtimeInstanceId: string;
+      adapter?: string;
+      /** Optional per-Channel override for managed tool-call visibility. */
+      showToolStatus?: boolean;
+      /** Optional per-Channel tuning for continuation messages on long replies. */
+      replyContinuation?: ReplyContinuationOptions;
+      /** Intelligence app-api HTTP base URL, forwarded to the transport so the
+       * managed realtime path enables file/history parity (HTTP-only) — OSS-476. */
+      appApiBaseUrl?: string;
+      /** Diagnostic sink forwarded to the launcher/transport so transport-level
+       * drop diagnostics (e.g. a version-skew missing-leaseToken outage) are not
+       * silent in the managed path. */
+      log?: (msg: string, meta?: unknown) => void;
+      runCanonical(args: {
+        agent: AbstractAgent;
+        threadId: string;
+        runId: string;
+        userId: string;
+        agentId: string;
+        tools: readonly {
+          name: string;
+          description: string;
+          parameters: Record<string, unknown>;
+        }[];
+        context: readonly { description: string; value: string }[];
+        persistedInputMessages: Message[];
+        execute(
+          subscriber: AgentSubscriber,
+          canonicalRun?: { threadId: string; runId: string },
+        ): Promise<{
+          iterations: number;
+          interrupted: boolean;
+          deliveryError?: unknown;
+        }>;
+      }): Promise<{
+        iterations: number;
+        interrupted: boolean;
+        deliveryError?: unknown;
+      }>;
+      loadHistory(args: {
+        threadId: string;
+        appUserId: string;
+      }): Promise<Message[]>;
+    },
   ) => Promise<ChannelsHandle>;
 }
 

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -18,7 +18,10 @@ import type { AgentRunner } from "../runner/agent-runner";
 // Type-only: @copilotkit/channels is pure-ESM, so a value import would break this
 // package's CJS output (see `core/runtime.ts` and `channel-activation-config.ts`
 // for the same constraint).
-import type { Channel } from "@copilotkit/channels";
+import type {
+  Channel,
+  ReplyContinuationOptions,
+} from "@copilotkit/channels";
 
 /**
  * Lifecycle status of a single Channel activation, or of the manager overall.
@@ -220,6 +223,8 @@ export interface ChannelsIntelligenceModule {
       adapter?: string;
       /** Optional per-Channel override for managed tool-call visibility. */
       showToolStatus?: boolean;
+      /** Optional per-Channel tuning for continuation messages on long replies. */
+      replyContinuation?: ReplyContinuationOptions;
       /** Intelligence app-api HTTP base URL, forwarded to the transport so the
        * managed realtime path enables file/history parity (HTTP-only) — OSS-476. */
       appApiBaseUrl?: string;
@@ -324,6 +329,9 @@ export async function defaultActivateChannel(
     adapter: config.adapter,
     ...(config.showToolStatus !== undefined
       ? { showToolStatus: config.showToolStatus }
+      : {}),
+    ...(config.replyContinuation !== undefined
+      ? { replyContinuation: config.replyContinuation }
       : {}),
     // Forward the app-api HTTP base URL so the transport wires file/history
     // (HTTP-only) on the NORMAL managed path — without this, Channels started by

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -18,10 +18,7 @@ import type { AgentRunner } from "../runner/agent-runner";
 // Type-only: @copilotkit/channels is pure-ESM, so a value import would break this
 // package's CJS output (see `core/runtime.ts` and `channel-activation-config.ts`
 // for the same constraint).
-import type {
-  Channel,
-  ReplyContinuationOptions,
-} from "@copilotkit/channels";
+import type { Channel, ReplyContinuationOptions } from "@copilotkit/channels";
 
 /**
  * Lifecycle status of a single Channel activation, or of the manager overall.

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -18,7 +18,8 @@ import type { AgentRunner } from "../runner/agent-runner";
 // Type-only: @copilotkit/channels is pure-ESM, so a value import would break this
 // package's CJS output (see `core/runtime.ts` and `channel-activation-config.ts`
 // for the same constraint).
-import type { Channel, ReplyContinuationOptions } from "@copilotkit/channels";
+import type { Channel } from "@copilotkit/channels";
+import type { StartChannelsOverRealtimeGatewayOptions } from "@copilotkit/channels-intelligence";
 
 /**
  * Lifecycle status of a single Channel activation, or of the manager overall.
@@ -205,61 +206,21 @@ interface ChannelEntry {
 const CHANNELS_INTELLIGENCE_SPECIFIER = "@copilotkit/channels-intelligence";
 
 /**
- * Structural view of the `@copilotkit/channels-intelligence` module surface the
- * default engine consumes. Declared locally (not imported) for the same
- * CJS/ESM-boundary reason the {@link ChannelsHandle} view is.
+ * The `@copilotkit/channels-intelligence` module surface the default engine
+ * consumes.
+ *
+ * The launcher's own options type is imported rather than re-declared: a
+ * hand-written mirror drifts silently, since a new launcher option type-checks
+ * clean here while the managed path quietly ignores it. The CJS/ESM boundary
+ * above constrains the *value* import — hence the non-literal specifier — but a
+ * type-only import is erased, leaks no `require` into the CJS build, and this
+ * interface is not part of the emitted `.d.cts` surface, so no CJS consumer
+ * resolves the ESM-only package for it.
  */
 export interface ChannelsIntelligenceModule {
   startChannelsOverRealtimeGateway: (
     channels: Channel[],
-    opts: {
-      wsUrl: string;
-      apiKey: string;
-      scope: { projectId: number; channelName: string };
-      runtimeInstanceId: string;
-      adapter?: string;
-      /** Optional per-Channel override for managed tool-call visibility. */
-      showToolStatus?: boolean;
-      /** Optional per-Channel tuning for continuation messages on long replies. */
-      replyContinuation?: ReplyContinuationOptions;
-      /** Intelligence app-api HTTP base URL, forwarded to the transport so the
-       * managed realtime path enables file/history parity (HTTP-only) — OSS-476. */
-      appApiBaseUrl?: string;
-      /** Diagnostic sink forwarded to the launcher/transport so transport-level
-       * drop diagnostics (e.g. a version-skew missing-leaseToken outage) are not
-       * silent in the managed path. */
-      log?: (msg: string, meta?: unknown) => void;
-      runCanonical(args: {
-        agent: AbstractAgent;
-        threadId: string;
-        runId: string;
-        userId: string;
-        agentId: string;
-        tools: readonly {
-          name: string;
-          description: string;
-          parameters: Record<string, unknown>;
-        }[];
-        context: readonly { description: string; value: string }[];
-        persistedInputMessages: Message[];
-        execute(
-          subscriber: AgentSubscriber,
-          canonicalRun?: { threadId: string; runId: string },
-        ): Promise<{
-          iterations: number;
-          interrupted: boolean;
-          deliveryError?: unknown;
-        }>;
-      }): Promise<{
-        iterations: number;
-        interrupted: boolean;
-        deliveryError?: unknown;
-      }>;
-      loadHistory(args: {
-        threadId: string;
-        appUserId: string;
-      }): Promise<Message[]>;
-    },
+    opts: StartChannelsOverRealtimeGatewayOptions,
   ) => Promise<ChannelsHandle>;
 }
 


### PR DESCRIPTION
## What

PR #6244 taught the Slack renderer to split a long reply across continuation messages instead of silently truncating it. Its tuning was hardcoded. Three of those constants are genuinely caller-dependent; this exposes them through one `replyContinuation` option on both the direct and managed surfaces.

```ts
// direct
slack({ replyContinuation: { maxMessages: 5 } });

// managed
createChannel({
  name: "support",
  replyContinuation: {
    messageByteLimit: 11_000,
    maxMessages: 20,
    truncationMarker: "\n\n_…réponse tronquée._",
  },
});
```

## Which constants, and why only these

| exposed | why it is a caller's decision |
| --- | --- |
| `messageByteLimit` | Slack's cumulative per-message ceiling is **undocumented**. 11k is inferred from a single production datapoint (11,607 bytes observed accepted) and deliberately conservative. If the real ceiling differs by plan or workspace, an operator needs a knob, not a release. |
| `maxMessages` | How many messages one reply may occupy is a product decision, not a platform fact. 20 was chosen to bound a runaway (500k chars → 46 messages); a support bot and an internal ops bot want different answers. |
| `truncationMarker` | Hardcoded **English** copy posted into the customer's channel. The one constant with no correct default. |

Deliberately **not** exposed, because they are correctness rather than preference:

- `APPEND_CHAR_LIMIT` — a documented Slack per-call limit. A provider fact; exposing it only invites `msg_too_long`.
- `MIN_MESSAGE_PROGRESS_BYTES` — loop-safety invariant. Exposing it lets a caller reintroduce the unbounded-message bug #6244 fixed.
- `MAX_FENCE_LANG_CHARS`, `FINISH_DRAIN_ATTEMPTS` — internal heuristics. If either is wrong that is a bug to fix, not a knob.

## Shape

Grouped under one nested option rather than three flat fields. `maxMessages` sitting bare on a Channel reads ambiguously (thread history?), and the group keeps the next continuation knob from adding another top-level field. The trade-off is that it diverges from `showToolStatus`'s flat precedent — happy to flatten if reviewers prefer consistency over disambiguation.

The shared `ReplyContinuationOptions` type lives in `channels-core`, the common ancestor of all four packages that touch it.

## Plumbing

Both surfaces follow `showToolStatus` exactly:

- **Direct:** `slack({ replyContinuation })` → `adapter.ts` → `event-renderer.ts` → `NativeMessageStream`, covering both the renderer path and `adapter.stream()`'s own stream.
- **Managed:** `createChannel({ replyContinuation })` → `Channel` → `ChannelActivationConfig` → `channel-manager` → `realtime-gateway-launcher` → `DeliveryAdapter` → the renderer's `nativeStreaming` block.

**No gateway or Intelligence change is required.** Managed Slack renders in the SDK process over a gateway live session and only emits `slack.stream.*` effects; the Elixir `provider_executor` is a dumb effect applier that owns no message boundaries. Render config therefore never has to cross into Intelligence.

One non-obvious touchpoint: `channel-manager.ts` keeps a **hand-written structural mirror** of the launcher's options, so the field has to be declared there as well or the managed path type-drifts silently.

## Testing

```
channels-core           171 passed
channels-slack          318 passed
channels-intelligence    67 passed
runtime                1809 passed, 3 failed
```

The 3 runtime failures are pre-existing Gemini `AIMessage` filtering tests, unrelated to this change — confirmed by re-running them with these changes stashed on `main`. `check-types` passes for all four packages.

New coverage:
- the marker override at the leaf (`native-stream`);
- the renderer's pass-through — this one fails without the change, since the 11k/20 defaults would keep that reply in a single message;
- the managed chain end to end via `createChannel` → activation config → launcher opts, plus the negative case that an unset option adds no property anywhere.

## Follow-ups (tracked on OSS-689, not in scope here)

- Confirm the byte-vs-char question with a manual >12k mostly-CJK/Cyrillic reply against a real workspace. It decides whether `messageByteLimit`'s default is right; the option makes it adjustable either way.
- Under the managed path's `minIntervalMs: 0` cadence a table row can still be cut mid-row, so a continuation's re-emitted header is followed by a malformed row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)