### PR TITLE
feat(channels): implement ordered managed delivery

### DIFF
--- a/packages/channels-core/src/codec.ts
+++ b/packages/channels-core/src/codec.ts
@@ -5,7 +5,7 @@ import type { ChannelNode } from "@copilotkit/channels-ui";
  * the Intelligence side. It exists so platform *semantics* (how to render IR to
  * a native payload, and — later — how to normalize a native event to the
  * neutral ingress shape) live in ONE place, instead of being duplicated between
- * a credentialed local adapter and the Gateway-owned live delivery session.
+ * a credentialed local adapter and Gateway-owned provider delivery.
  *
  * Only the two creds/connection-bound concerns stay per-side: the transport
  * (who holds the platform connection) and the credentialed send. The codec

--- a/packages/channels-core/src/index.ts
+++ b/packages/channels-core/src/index.ts
@@ -117,7 +117,7 @@ export { mintId, stableStringify } from "./mint-id.js";
 export { runAgentLoop } from "./run-loop.js";
 export type { RunLoopArgs } from "./run-loop.js";
 
-// Pure, per-platform codec seam (shared with the Channel/Connector-Outbox path).
+// Pure per-platform codec seam shared with managed Intelligence delivery.
 // The Intelligence Channel adapter itself lives in
 // `@copilotkit/channels-intelligence`.
 export type { PlatformCodec } from "./codec.js";

--- a/packages/channels-core/src/platform-adapter.ts
+++ b/packages/channels-core/src/platform-adapter.ts
@@ -377,7 +377,14 @@ export interface PlatformAdapter {
       title?: string;
       altText?: string;
     },
-  ): Promise<{ ok: boolean; fileId?: string; error?: string }>;
+  ): Promise<{
+    ok: boolean;
+    /** Provider file or message ID for native adapters. */
+    fileId?: string;
+    /** Provider-neutral managed asset ID for Intelligence adapters. */
+    assetId?: string;
+    error?: string;
+  }>;
   /**
    * Optional slash-command support. Called once on `start()` with the channel's
    * declared commands, so a surface that registers commands up front (e.g.

--- a/packages/channels-core/src/platform-adapter.ts
+++ b/packages/channels-core/src/platform-adapter.ts
@@ -136,7 +136,7 @@ export interface IngressIds {
   eventId?: string;
   /** Stable per-turn id (Intelligence Channel path); local adapters omit it. */
   turnId?: string;
-  /** Lease/delivery id (Intelligence Channel path); local adapters omit it. */
+  /** Durable delivery id (Intelligence Channel path); local adapters omit it. */
   deliveryId?: string;
 }
 

--- a/packages/channels-core/src/thread.ts
+++ b/packages/channels-core/src/thread.ts
@@ -178,7 +178,12 @@ export class Thread implements ThreadInterface {
     filename: string;
     title?: string;
     altText?: string;
-  }): Promise<{ ok: boolean; fileId?: string; error?: string }> {
+  }): Promise<{
+    ok: boolean;
+    fileId?: string;
+    assetId?: string;
+    error?: string;
+  }> {
     return this.trackOperation(async () => {
       const adapter = this.deps.adapter;
       if (!adapter.postFile) {

--- a/packages/channels-intelligence/src/content-parts.test.ts
+++ b/packages/channels-intelligence/src/content-parts.test.ts
@@ -1,0 +1,55 @@
+import { expect, test, vi } from "vitest";
+import { buildContentParts } from "./content-parts.js";
+
+test("logs a bounded managed-asset restore outcome and duration", async () => {
+  const log = vi.fn();
+
+  await expect(
+    buildContentParts(
+      [
+        {
+          handle: "asset_01",
+          filename: "diagram.png",
+          mimeType: "image/png",
+        },
+      ],
+      vi.fn().mockResolvedValue({
+        bytes: new Uint8Array([137, 80, 78, 71]),
+        mimeType: "image/png",
+      }),
+      log,
+    ),
+  ).resolves.toHaveLength(1);
+
+  expect(log).toHaveBeenCalledWith("channel managed asset restore", {
+    outcome: "restored",
+    code: "asset_restored",
+    durationMs: expect.any(Number),
+    byteSize: 4,
+  });
+});
+
+test("logs a bounded restore failure without raw error details", async () => {
+  const log = vi.fn();
+
+  await buildContentParts(
+    [
+      {
+        handle: "asset_01",
+        filename: "diagram.png",
+        mimeType: "image/png",
+      },
+    ],
+    vi.fn().mockRejectedValue(new Error("secret provider response")),
+    log,
+  );
+
+  expect(log).toHaveBeenCalledWith("channel managed asset restore", {
+    outcome: "failed",
+    code: "asset_restore_failed",
+    durationMs: expect.any(Number),
+  });
+  expect(JSON.stringify(log.mock.calls)).not.toContain(
+    "secret provider response",
+  );
+});

--- a/packages/channels-intelligence/src/content-parts.ts
+++ b/packages/channels-intelligence/src/content-parts.ts
@@ -32,7 +32,11 @@ export async function buildContentParts(
 ): Promise<AgentContentPart[]> {
   if (!files?.length) return [];
   if (!fetchFile) {
-    log?.("intelligence file fetch unavailable: file client is not configured");
+    log?.("channel managed asset restore", {
+      outcome: "unavailable",
+      code: "asset_restore_unavailable",
+      durationMs: 0,
+    });
     return files.map((ref) => ({
       type: "text" as const,
       text: `[attached file ${ref.filename} could not be retrieved]`,
@@ -40,6 +44,7 @@ export async function buildContentParts(
   }
   const parts: AgentContentPart[] = [];
   for (const ref of files) {
+    const startedAtMs = Date.now();
     try {
       const { bytes, mimeType } = await fetchFile(ref.handle);
       // The typed ref's mime is authoritative — the file-serve route coerces
@@ -63,8 +68,18 @@ export async function buildContentParts(
           text: `[attached file: ${ref.filename} (${mime})]`,
         });
       }
-    } catch (err) {
-      log?.("intelligence file fetch failed", err);
+      log?.("channel managed asset restore", {
+        outcome: "restored",
+        code: "asset_restored",
+        durationMs: elapsedMs(startedAtMs),
+        byteSize: bytes.byteLength,
+      });
+    } catch {
+      log?.("channel managed asset restore", {
+        outcome: "failed",
+        code: "asset_restore_failed",
+        durationMs: elapsedMs(startedAtMs),
+      });
       // Fail-visible, not fail-silent: the user attached a file the model
       // can't be shown, so surface a short note in context rather than
       // dropping it entirely (the model can acknowledge / ask to retry).
@@ -75,4 +90,8 @@ export async function buildContentParts(
     }
   }
   return parts;
+}
+
+function elapsedMs(startedAtMs: number): number {
+  return Math.max(Date.now() - startedAtMs, 0);
 }

--- a/packages/channels-intelligence/src/delivery-adapter-final.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-final.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { DeliveryAdapter } from "./delivery-adapter.js";
 import type { ChannelProviderPayload } from "./delivery-contracts.js";
 import type {
-  ChannelDeliverySession,
+  ClaimedChannelDelivery,
   PreparedChannelDelivery,
 } from "./delivery-transport.js";
 
@@ -45,9 +45,9 @@ describe("DeliveryAdapter Teams final delivery", () => {
           providerReference: "pref_v1_teams_activity_01",
         }),
       );
-      const session = { effect } as unknown as ChannelDeliverySession;
+      const session = { effect } as unknown as ClaimedChannelDelivery;
       const renderer = adapter().createRunRenderer({
-        session,
+        claimedDelivery: session,
         delivery: delivery(),
       });
       const subscriber = renderer.subscriber;
@@ -94,9 +94,9 @@ describe("DeliveryAdapter Slack cadence", () => {
             ? { providerReference: "pref_v1_slack_stream_01" }
             : {},
       );
-      const session = { effect } as unknown as ChannelDeliverySession;
+      const session = { effect } as unknown as ClaimedChannelDelivery;
       const renderer = adapter().createRunRenderer({
-        session,
+        claimedDelivery: session,
         delivery: { ...delivery(), adapter: "slack" },
       });
       const subscriber = renderer.subscriber;

--- a/packages/channels-intelligence/src/delivery-adapter-final.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-final.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import { DeliveryAdapter } from "./delivery-adapter.js";
+import type { ChannelProviderPayload } from "./delivery-contracts.js";
+import type {
+  ChannelDeliverySession,
+  PreparedChannelDelivery,
+} from "./delivery-transport.js";
+
+function adapter(): DeliveryAdapter {
+  return new DeliveryAdapter({
+    channelName: "support",
+    transport: {} as never,
+    runCanonical: async () => ({ iterations: 0, interrupted: false }),
+    loadHistory: async () => [],
+  });
+}
+
+function delivery(): PreparedChannelDelivery {
+  return {
+    protocol: "channel_delivery_v1",
+    deliveryId: "dlv_teams_final_01",
+    deliveryExpiresAt: "2099-07-29T17:00:00.000Z",
+    channelId: "channel_support",
+    channelName: "support",
+    canonicalThreadId: "thread_teams_final",
+    appUserId: "teams:user-1",
+    adapter: "teams",
+    turn: {
+      eventId: "evt_teams_final",
+      receivedAt: "2026-07-29T17:00:00.000Z",
+      input: { kind: "text", text: "hello" },
+    },
+  };
+}
+
+describe("DeliveryAdapter Teams final delivery", () => {
+  it("emits a distinct final packet after an intermediate post", async () => {
+    vi.useFakeTimers();
+    try {
+      const effect = vi.fn(
+        async (
+          _responseId: string,
+          _payload: ChannelProviderPayload,
+        ): Promise<Record<string, unknown>> => ({
+          providerReference: "pref_v1_teams_activity_01",
+        }),
+      );
+      const session = { effect } as unknown as ChannelDeliverySession;
+      const renderer = adapter().createRunRenderer({
+        session,
+        delivery: delivery(),
+      });
+      const subscriber = renderer.subscriber;
+
+      subscriber.onTextMessageStartEvent!({
+        event: { messageId: "message-1", role: "assistant" },
+      } as never);
+      subscriber.onTextMessageContentEvent!({
+        event: { messageId: "message-1", delta: "Working" },
+      } as never);
+      await vi.advanceTimersByTimeAsync(1);
+
+      subscriber.onTextMessageContentEvent!({
+        event: { messageId: "message-1", delta: " done" },
+      } as never);
+      await subscriber.onTextMessageEndEvent!({
+        event: { messageId: "message-1" },
+      } as never);
+
+      expect(effect.mock.calls.map((call) => call[1])).toEqual([
+        { kind: "teams.message.create", text: "Working" },
+        {
+          kind: "teams.message.finalize",
+          providerReference: "pref_v1_teams_activity_01",
+          text: "Working done",
+        },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("DeliveryAdapter Slack cadence", () => {
+  it("coalesces intermediate text on the 600 millisecond attempt cadence", async () => {
+    vi.useFakeTimers();
+    try {
+      const effect = vi.fn(
+        async (
+          _responseId: string,
+          payload: ChannelProviderPayload,
+        ): Promise<Record<string, unknown>> =>
+          payload.kind === "slack.stream.start"
+            ? { providerReference: "pref_v1_slack_stream_01" }
+            : {},
+      );
+      const session = { effect } as unknown as ChannelDeliverySession;
+      const renderer = adapter().createRunRenderer({
+        session,
+        delivery: { ...delivery(), adapter: "slack" },
+      });
+      const subscriber = renderer.subscriber;
+
+      subscriber.onTextMessageStartEvent!({
+        event: { messageId: "message-1", role: "assistant" },
+      } as never);
+      subscriber.onTextMessageContentEvent!({
+        event: { messageId: "message-1", delta: "A" },
+      } as never);
+      await vi.advanceTimersByTimeAsync(0);
+
+      subscriber.onTextMessageContentEvent!({
+        event: { messageId: "message-1", delta: "B" },
+      } as never);
+      await vi.advanceTimersByTimeAsync(599);
+
+      const appendPayloads = (): unknown[] =>
+        effect.mock.calls
+          .map((call) => call[1])
+          .filter((payload) => payload.kind === "slack.stream.append");
+
+      expect(appendPayloads()).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(appendPayloads()).toHaveLength(2);
+
+      await subscriber.onTextMessageEndEvent!({
+        event: { messageId: "message-1" },
+      } as never);
+      await renderer.finish!();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/channels-intelligence/src/delivery-adapter-postfile.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-postfile.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { DeliveryAdapter } from "./delivery-adapter.js";
 import { ChannelProviderDeliveryError } from "./delivery-transport.js";
 import type {
-  ChannelDeliverySession,
+  ClaimedChannelDelivery,
   PreparedChannelDelivery,
 } from "./delivery-transport.js";
 import { RealtimeGatewayPushError } from "./realtime-gateway.js";
@@ -29,8 +29,14 @@ function prepared(): PreparedChannelDelivery {
   };
 }
 
-function replyTarget(session: ChannelDeliverySession) {
-  return { session, delivery: prepared() };
+function replyTarget(
+  session: ClaimedChannelDelivery,
+  adapter: "slack" | "teams" = "slack",
+) {
+  return {
+    claimedDelivery: session,
+    delivery: { ...prepared(), adapter },
+  };
 }
 
 class NoopAgent extends AbstractAgent {
@@ -53,11 +59,12 @@ function makeAdapter(
 
 describe("DeliveryAdapter.postFile", () => {
   it("soft-returns upload failures without throwing", async () => {
+    const log = vi.fn();
     const session = {
       uploadFile: vi.fn().mockRejectedValue(new Error("upload config missing")),
       effect: vi.fn(),
-    } as unknown as ChannelDeliverySession;
-    const adapter = makeAdapter();
+    } as unknown as ClaimedChannelDelivery;
+    const adapter = makeAdapter({ log });
 
     await expect(
       adapter.postFile(replyTarget(session), {
@@ -69,6 +76,13 @@ describe("DeliveryAdapter.postFile", () => {
       error: "upload config missing",
     });
     expect(session.effect).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith("channel managed asset upload", {
+      outcome: "failed",
+      code: "asset_upload_failed",
+      durationMs: expect.any(Number),
+      deliveryId: "dlv_postfile_01",
+      byteSize: 1,
+    });
   });
 
   it("rethrows permanent effect failures so claimAndHandle cannot complete", async () => {
@@ -83,7 +97,7 @@ describe("DeliveryAdapter.postFile", () => {
             "file create failed",
           ),
         ),
-    } as unknown as ChannelDeliverySession;
+    } as unknown as ClaimedChannelDelivery;
     const adapter = makeAdapter();
 
     await expect(
@@ -102,7 +116,7 @@ describe("DeliveryAdapter.postFile", () => {
             .mockRejectedValue(
               new ChannelProviderDeliveryError("provider_failed", "failed"),
             ),
-        } as unknown as ChannelDeliverySession),
+        } as unknown as ClaimedChannelDelivery),
         { bytes: new Uint8Array([1]), filename: "a.png" },
       ),
     ).rejects.toBeInstanceOf(ChannelProviderDeliveryError);
@@ -118,7 +132,7 @@ describe("DeliveryAdapter.postFile", () => {
                 "Gateway returned a conflicting packet acknowledgement",
               ),
             ),
-        } as unknown as ChannelDeliverySession),
+        } as unknown as ClaimedChannelDelivery),
         { bytes: new Uint8Array([1]), filename: "a.png" },
       ),
     ).rejects.toBeInstanceOf(TypeError);
@@ -136,7 +150,7 @@ describe("DeliveryAdapter.postFile", () => {
     const session = {
       uploadFile: vi.fn().mockResolvedValue("file_handle_01"),
       effect: vi.fn().mockResolvedValue({}),
-    } as unknown as ChannelDeliverySession;
+    } as unknown as ClaimedChannelDelivery;
     const adapter = makeAdapter({ runCanonical });
     const target = replyTarget(session);
     const agentSession = await adapter.conversationStore.getOrCreate(
@@ -179,5 +193,64 @@ describe("DeliveryAdapter.postFile", () => {
     );
     expect(JSON.stringify(onEvent.mock.calls)).not.toContain("iVBOR");
     await agentSession.release?.();
+  });
+
+  it("returns a Teams capability error and keeps later text usable", async () => {
+    const log = vi.fn();
+    const session = {
+      uploadFile: vi.fn().mockResolvedValue("file_handle_01"),
+      effect: vi
+        .fn()
+        .mockResolvedValueOnce({ capabilityError: "teams_image_rejected" })
+        .mockResolvedValueOnce({
+          providerReference: "pref_v1_teams_activity_01",
+        }),
+    } as unknown as ClaimedChannelDelivery;
+    const adapter = makeAdapter({ log });
+    const target = replyTarget(session, "teams");
+
+    await expect(
+      adapter.postFile(target, {
+        bytes: new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]),
+        filename: "diagram.png",
+        altText: "Architecture diagram",
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: "teams_image_rejected",
+    });
+    expect(log).toHaveBeenCalledWith("channel managed asset upload", {
+      outcome: "stored",
+      code: "asset_stored",
+      durationMs: expect.any(Number),
+      deliveryId: "dlv_postfile_01",
+      byteSize: 8,
+    });
+    expect(log).toHaveBeenCalledWith("channel provider capability rejected", {
+      outcome: "failed",
+      code: "teams_image_rejected",
+      durationMs: expect.any(Number),
+      deliveryId: "dlv_postfile_01",
+      adapter: "teams",
+    });
+
+    await expect(
+      adapter.post(target, [
+        {
+          type: "text",
+          props: { value: "Here is a text fallback" },
+        },
+      ]),
+    ).resolves.toMatchObject({
+      providerReference: "pref_v1_teams_activity_01",
+    });
+    expect(session.effect).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/^response_/),
+      {
+        kind: "teams.message.create",
+        text: "Here is a text fallback",
+      },
+    );
   });
 });

--- a/packages/channels-intelligence/src/delivery-adapter-postfile.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-postfile.test.ts
@@ -1,3 +1,6 @@
+import { AbstractAgent } from "@ag-ui/client";
+import type { RunAgentInput } from "@ag-ui/client";
+import { EMPTY } from "rxjs";
 import { describe, expect, it, vi } from "vitest";
 import { DeliveryAdapter } from "./delivery-adapter.js";
 import { ChannelProviderDeliveryError } from "./delivery-transport.js";
@@ -30,12 +33,21 @@ function replyTarget(session: ChannelDeliverySession) {
   return { session, delivery: prepared() };
 }
 
-function makeAdapter() {
+class NoopAgent extends AbstractAgent {
+  run(_input: RunAgentInput): ReturnType<AbstractAgent["run"]> {
+    return EMPTY;
+  }
+}
+
+function makeAdapter(
+  options: Partial<ConstructorParameters<typeof DeliveryAdapter>[0]> = {},
+) {
   return new DeliveryAdapter({
     channelName: "support",
     transport: {} as never,
     runCanonical: async () => ({ iterations: 0, interrupted: false }),
     loadHistory: async () => [],
+    ...options,
   });
 }
 
@@ -113,17 +125,32 @@ describe("DeliveryAdapter.postFile", () => {
   });
 
   it("returns ok after a successful file create effect", async () => {
+    const onEvent = vi.fn();
+    const runCanonical = vi.fn(async (args) => {
+      await args.execute(
+        { onEvent },
+        { threadId: args.threadId, runId: args.runId },
+      );
+      return { iterations: 0, interrupted: false };
+    });
     const session = {
       uploadFile: vi.fn().mockResolvedValue("file_handle_01"),
       effect: vi.fn().mockResolvedValue({}),
     } as unknown as ChannelDeliverySession;
-    const adapter = makeAdapter();
+    const adapter = makeAdapter({ runCanonical });
+    const target = replyTarget(session);
+    const agentSession = await adapter.conversationStore.getOrCreate(
+      "thread_postfile",
+      target,
+      () => new NoopAgent(),
+    );
 
     await expect(
-      adapter.postFile(replyTarget(session), {
-        bytes: new Uint8Array([1]),
+      adapter.postFile(target, {
+        bytes: new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]),
         filename: "a.png",
         title: "chart",
+        altText: "Line chart",
       }),
     ).resolves.toEqual({ ok: true, fileId: "file_handle_01" });
     expect(session.effect).toHaveBeenCalledWith(
@@ -134,5 +161,23 @@ describe("DeliveryAdapter.postFile", () => {
         title: "chart",
       }),
     );
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          type: "ACTIVITY_SNAPSHOT",
+          activityType: "copilotkit.managed-asset",
+          content: {
+            assetId: "file_handle_01",
+            filename: "a.png",
+            mimeType: "image/png",
+            byteSize: 8,
+            title: "chart",
+            altText: "Line chart",
+          },
+        }),
+      }),
+    );
+    expect(JSON.stringify(onEvent.mock.calls)).not.toContain("iVBOR");
+    await agentSession.release?.();
   });
 });

--- a/packages/channels-intelligence/src/delivery-adapter-postfile.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-postfile.test.ts
@@ -152,7 +152,7 @@ describe("DeliveryAdapter.postFile", () => {
         title: "chart",
         altText: "Line chart",
       }),
-    ).resolves.toEqual({ ok: true, fileId: "file_handle_01" });
+    ).resolves.toEqual({ ok: true, assetId: "file_handle_01" });
     expect(session.effect).toHaveBeenCalledWith(
       expect.stringMatching(/^response_/),
       expect.objectContaining({

--- a/packages/channels-intelligence/src/delivery-adapter.concurrency.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.concurrency.test.ts
@@ -8,7 +8,7 @@ import type {
 import type { RunAgentInput } from "@ag-ui/core";
 import { DeliveryAdapter } from "./delivery-adapter.js";
 import type {
-  ChannelDeliverySession,
+  ClaimedChannelDelivery,
   PreparedChannelDelivery,
 } from "./delivery-transport.js";
 
@@ -67,7 +67,7 @@ describe("DeliveryAdapter concurrent same-thread runs", () => {
       },
     });
 
-    const session = {} as ChannelDeliverySession;
+    const session = {} as ClaimedChannelDelivery;
     const d1 = prepared("dlv_1");
     const d2 = prepared("dlv_2");
     const makeAgent = (id: string) => {
@@ -78,12 +78,12 @@ describe("DeliveryAdapter concurrent same-thread runs", () => {
 
     const p1 = gated.conversationStore.getOrCreate(
       d1.canonicalThreadId,
-      { session, delivery: d1 },
+      { claimedDelivery: session, delivery: d1 },
       makeAgent,
     );
     const p2 = gated.conversationStore.getOrCreate(
       d2.canonicalThreadId,
-      { session, delivery: d2 },
+      { claimedDelivery: session, delivery: d2 },
       makeAgent,
     );
 

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { EventType } from "@ag-ui/client";
 import type {
   AbstractAgent,
@@ -43,7 +43,7 @@ import {
 } from "@copilotkit/channels-teams/render";
 import type { ChannelProviderPayload } from "./delivery-contracts.js";
 import type {
-  ChannelDeliverySession,
+  ClaimedChannelDelivery,
   ChannelDeliveryTransport,
   PreparedChannelDelivery,
 } from "./delivery-transport.js";
@@ -54,13 +54,13 @@ import {
 } from "./delivery-files.js";
 
 interface DeliveryReplyTarget {
-  session: ChannelDeliverySession;
+  claimedDelivery: ClaimedChannelDelivery;
   delivery: PreparedChannelDelivery;
 }
 
 interface DeliveryMessageRef extends MessageRef {
   responseId: string;
-  session: ChannelDeliverySession;
+  claimedDelivery: ClaimedChannelDelivery;
   adapter: "slack" | "teams";
   providerReference?: string;
 }
@@ -229,8 +229,8 @@ export class DeliveryAdapter implements PlatformAdapter {
 
   async start(sink: IngressSink): Promise<void> {
     this.sink = sink;
-    this.options.transport.start((session, delivery) =>
-      this.dispatch(session, delivery),
+    this.options.transport.start((claimedDelivery, delivery) =>
+      this.dispatch(claimedDelivery, delivery),
     );
   }
 
@@ -242,16 +242,18 @@ export class DeliveryAdapter implements PlatformAdapter {
     targetValue: ReplyTarget,
     operation: () => Promise<T>,
   ): Promise<T> {
-    return asDeliveryTarget(targetValue).session.trackOperation(operation);
+    return asDeliveryTarget(targetValue).claimedDelivery.trackOperation(
+      operation,
+    );
   }
 
   private async dispatch(
-    session: ChannelDeliverySession,
+    claimedDelivery: ClaimedChannelDelivery,
     delivery: PreparedChannelDelivery,
   ): Promise<void> {
     const sink = this.sink;
     if (!sink) throw new Error("DeliveryAdapter is not started");
-    const replyTarget: DeliveryReplyTarget = { session, delivery };
+    const replyTarget: DeliveryReplyTarget = { claimedDelivery, delivery };
     const base = {
       conversationKey: delivery.canonicalThreadId,
       replyTarget,
@@ -271,7 +273,7 @@ export class DeliveryAdapter implements PlatformAdapter {
     const input = delivery.turn.input;
     switch (input.kind) {
       case "text": {
-        const parts = await session.getContentParts(
+        const parts = await claimedDelivery.getContentParts(
           input.files,
           this.options.log,
         );
@@ -410,7 +412,7 @@ export class DeliveryAdapter implements PlatformAdapter {
     const target = asDeliveryTarget(targetValue);
     const responseId = mintId("response_");
     const providerReference = await this.postRendered(
-      target.session,
+      target.claimedDelivery,
       target.delivery.adapter,
       responseId,
       ir,
@@ -422,7 +424,7 @@ export class DeliveryAdapter implements PlatformAdapter {
     const ref = asDeliveryRef(refValue);
     assertProviderReference(ref.providerReference);
     await this.replaceRendered(
-      ref.session,
+      ref.claimedDelivery,
       ref.adapter,
       ref.responseId,
       ir,
@@ -436,7 +438,7 @@ export class DeliveryAdapter implements PlatformAdapter {
       throw new Error("Teams message delete is not supported");
     }
     assertProviderReference(ref.providerReference);
-    await ref.session.effect(ref.responseId, {
+    await ref.claimedDelivery.effect(ref.responseId, {
       kind: "slack.message.delete",
       providerReference: ref.providerReference,
     });
@@ -450,30 +452,23 @@ export class DeliveryAdapter implements PlatformAdapter {
     const responseId = mintId("response_");
     let providerReference: string | undefined;
     if (target.delivery.adapter === "slack") {
-      let text = "";
       let bodyError: unknown;
       let streamStarted = false;
       try {
         // Start lives inside try/finally so a missing providerReference after
         // an applied start still attempts stream.stop cleanup.
-        const startResult = await target.session.effect(responseId, {
+        const startResult = await target.claimedDelivery.effect(responseId, {
           kind: "slack.stream.start",
         });
         streamStarted = true;
         providerReference = providerReferenceFromResult(startResult);
         for await (const delta of chunks) {
           if (delta.length === 0) continue;
-          const before = digest(text);
-          const nextText = text + delta;
-          await target.session.effect(responseId, {
+          await target.claimedDelivery.effect(responseId, {
             kind: "slack.stream.append",
             providerReference,
             delta,
-            beforeTextDigest: before,
-            afterTextDigest: digest(nextText),
           });
-          // Only advance local text after the append is applied.
-          text = nextText;
         }
       } catch (error) {
         bodyError = error;
@@ -482,10 +477,9 @@ export class DeliveryAdapter implements PlatformAdapter {
         // Always stop a started stream (append failure must not leave it open).
         if (streamStarted && providerReference !== undefined) {
           try {
-            await target.session.effect(responseId, {
+            await target.claimedDelivery.effect(responseId, {
               kind: "slack.stream.stop",
               providerReference,
-              finalTextDigest: digest(text),
             });
           } catch (stopError) {
             // If the body succeeded, stop failure is the delivery failure.
@@ -500,12 +494,12 @@ export class DeliveryAdapter implements PlatformAdapter {
         if (delta.length === 0) continue;
         const nextText = text + delta;
         const result = created
-          ? await target.session.effect(responseId, {
+          ? await target.claimedDelivery.effect(responseId, {
               kind: "teams.message.replace",
               providerReference: providerReference!,
               text: nextText,
             })
-          : await target.session.effect(responseId, {
+          : await target.claimedDelivery.effect(responseId, {
               kind: "teams.message.create",
               text: nextText,
             });
@@ -517,7 +511,7 @@ export class DeliveryAdapter implements PlatformAdapter {
     }
     if (!providerReference) {
       providerReference = providerReferenceFromResult(
-        await target.session.effect(responseId, {
+        await target.claimedDelivery.effect(responseId, {
           kind:
             target.delivery.adapter === "slack"
               ? "slack.message.create"
@@ -554,32 +548,58 @@ export class DeliveryAdapter implements PlatformAdapter {
         };
       }
     }
-    // Soft-fail only pre-effect failures (upload/config). Any session.effect
+    // Soft-fail only pre-effect failures (upload/config). Any provider-effect
     // failure must propagate so claimAndHandle does not emit a false complete
     // terminal after a permanent provider/protocol error.
     let handle: string;
+    const uploadStartedAtMs = Date.now();
     try {
-      handle = await target.session.uploadFile(args);
+      handle = await target.claimedDelivery.uploadFile(args);
     } catch (error) {
+      this.options.log?.("channel managed asset upload", {
+        outcome: "failed",
+        code: "asset_upload_failed",
+        durationMs: elapsedMs(uploadStartedAtMs),
+        deliveryId: target.delivery.deliveryId,
+        byteSize: args.bytes.byteLength,
+      });
       return {
         ok: false,
         error: error instanceof Error ? error.message : String(error),
       };
     }
+    this.options.log?.("channel managed asset upload", {
+      outcome: "stored",
+      code: "asset_stored",
+      durationMs: elapsedMs(uploadStartedAtMs),
+      deliveryId: target.delivery.deliveryId,
+      byteSize: args.bytes.byteLength,
+    });
     const responseId = mintId("response_");
     if (target.delivery.adapter === "slack") {
-      await target.session.effect(responseId, {
+      await target.claimedDelivery.effect(responseId, {
         kind: "slack.file.create",
         fileHandle: handle,
         ...(args.title ? { title: args.title } : {}),
         ...(args.altText ? { altText: args.altText } : {}),
       });
     } else {
-      await target.session.effect(responseId, {
+      const providerStartedAtMs = Date.now();
+      const result = await target.claimedDelivery.effect(responseId, {
         kind: "teams.image.create",
         fileHandle: handle,
         altText: args.altText ?? args.title ?? args.filename,
       });
+      if (result.capabilityError === "teams_image_rejected") {
+        this.options.log?.("channel provider capability rejected", {
+          outcome: "failed",
+          code: "teams_image_rejected",
+          durationMs: elapsedMs(providerStartedAtMs),
+          deliveryId: target.delivery.deliveryId,
+          adapter: "teams",
+        });
+        return { ok: false, error: "teams_image_rejected" };
+      }
     }
     await this.recordManagedAssetActivity(target, {
       assetId: handle,
@@ -656,26 +676,24 @@ export class DeliveryAdapter implements PlatformAdapter {
     const responseId = mintId("response_");
     const renderer =
       target.delivery.adapter === "slack"
-        ? this.createSlackRenderer(target.session, responseId)
-        : this.createTeamsRenderer(target.session, responseId);
+        ? this.createSlackRenderer(target.claimedDelivery, responseId)
+        : this.createTeamsRenderer(target.claimedDelivery, responseId);
     this.rendererResponses.set(renderer, responseId);
     return renderer;
   }
 
   private createSlackRenderer(
-    session: ChannelDeliverySession,
+    claimedDelivery: ClaimedChannelDelivery,
     responseId: string,
   ): RunRenderer {
-    let text = "";
     let providerReference: string | undefined;
     return createSlackRunRenderer({
       target: { channel: "managed", threadTs: "managed" },
       showToolStatus: this.options.showToolStatus ?? false,
       transport: {
-        setStatus: async () => undefined,
         postMessage: async ({ text: message }) => {
           providerReference = providerReferenceFromResult(
-            await session.effect(responseId, {
+            await claimedDelivery.effect(responseId, {
               kind: "slack.message.create",
               text: message,
             }),
@@ -684,7 +702,7 @@ export class DeliveryAdapter implements PlatformAdapter {
         },
         updateMessage: async ({ text: message }) => {
           assertProviderReference(providerReference);
-          await session.effect(responseId, {
+          await claimedDelivery.effect(responseId, {
             kind: "slack.message.replace",
             providerReference,
             text: message,
@@ -700,7 +718,7 @@ export class DeliveryAdapter implements PlatformAdapter {
         transport: {
           startStream: async () => {
             providerReference = providerReferenceFromResult(
-              await session.effect(responseId, {
+              await claimedDelivery.effect(responseId, {
                 kind: "slack.stream.start",
               }),
             );
@@ -709,17 +727,11 @@ export class DeliveryAdapter implements PlatformAdapter {
           appendText: async (_id, delta) => {
             if (delta.length === 0) return;
             assertProviderReference(providerReference);
-            const before = digest(text);
-            const nextText = text + delta;
-            await session.effect(responseId, {
+            await claimedDelivery.effect(responseId, {
               kind: "slack.stream.append",
               providerReference,
               delta,
-              beforeTextDigest: before,
-              afterTextDigest: digest(nextText),
             });
-            // Only advance local text after the append is applied (match stream()).
-            text = nextText;
           },
           appendChunks: async (_id, chunks) => {
             assertProviderReference(providerReference);
@@ -727,7 +739,7 @@ export class DeliveryAdapter implements PlatformAdapter {
               Record<string, unknown>
             >) {
               if (chunk.type !== "task_update") continue;
-              await session.effect(responseId, {
+              await claimedDelivery.effect(responseId, {
                 kind: "slack.stream.task",
                 providerReference,
                 taskId: String(chunk.id),
@@ -738,10 +750,9 @@ export class DeliveryAdapter implements PlatformAdapter {
           },
           stopStream: async () => {
             assertProviderReference(providerReference);
-            await session.effect(responseId, {
+            await claimedDelivery.effect(responseId, {
               kind: "slack.stream.stop",
               providerReference,
-              finalTextDigest: digest(text),
             });
           },
         },
@@ -750,14 +761,14 @@ export class DeliveryAdapter implements PlatformAdapter {
   }
 
   private createTeamsRenderer(
-    session: ChannelDeliverySession,
+    claimedDelivery: ClaimedChannelDelivery,
     responseId: string,
   ): RunRenderer {
     let providerReference: string | undefined;
     return createTeamsRunRenderer({
       post: async (text) => {
         providerReference = providerReferenceFromResult(
-          await session.effect(responseId, {
+          await claimedDelivery.effect(responseId, {
             kind: "teams.message.create",
             text,
           }),
@@ -766,7 +777,7 @@ export class DeliveryAdapter implements PlatformAdapter {
       },
       update: async (_id, text) => {
         assertProviderReference(providerReference);
-        await session.effect(responseId, {
+        await claimedDelivery.effect(responseId, {
           kind: "teams.message.replace",
           providerReference,
           text,
@@ -774,7 +785,7 @@ export class DeliveryAdapter implements PlatformAdapter {
       },
       finalize: async (_id, text) => {
         assertProviderReference(providerReference);
-        await session.effect(responseId, {
+        await claimedDelivery.effect(responseId, {
           kind: "teams.message.finalize",
           providerReference,
           text,
@@ -784,7 +795,7 @@ export class DeliveryAdapter implements PlatformAdapter {
   }
 
   private async postRendered(
-    session: ChannelDeliverySession,
+    claimedDelivery: ClaimedChannelDelivery,
     adapter: "slack" | "teams",
     responseId: string,
     ir: ChannelNode[],
@@ -792,7 +803,7 @@ export class DeliveryAdapter implements PlatformAdapter {
     if (adapter === "slack") {
       const rendered = renderSlackMessage(ir);
       return providerReferenceFromResult(
-        await session.effect(responseId, {
+        await claimedDelivery.effect(responseId, {
           kind: "slack.message.create",
           text: collectText(ir),
           blocks: rendered.blocks as unknown as Array<Record<string, unknown>>,
@@ -800,12 +811,15 @@ export class DeliveryAdapter implements PlatformAdapter {
       );
     }
     return providerReferenceFromResult(
-      await session.effect(responseId, teamsMessageEffect("create", ir)),
+      await claimedDelivery.effect(
+        responseId,
+        teamsMessageEffect("create", ir),
+      ),
     );
   }
 
   private async replaceRendered(
-    session: ChannelDeliverySession,
+    claimedDelivery: ClaimedChannelDelivery,
     adapter: "slack" | "teams",
     responseId: string,
     ir: ChannelNode[],
@@ -814,7 +828,7 @@ export class DeliveryAdapter implements PlatformAdapter {
     assertProviderReference(providerReference);
     if (adapter === "slack") {
       const rendered = renderSlackMessage(ir);
-      await session.effect(responseId, {
+      await claimedDelivery.effect(responseId, {
         kind: "slack.message.replace",
         text: collectText(ir),
         blocks: rendered.blocks as unknown as Array<Record<string, unknown>>,
@@ -822,7 +836,7 @@ export class DeliveryAdapter implements PlatformAdapter {
       });
       return;
     }
-    await session.effect(
+    await claimedDelivery.effect(
       responseId,
       teamsMessageEffect("replace", ir, providerReference),
     );
@@ -982,7 +996,7 @@ function teamsMessageEffect(
 
 function asDeliveryTarget(value: ReplyTarget): DeliveryReplyTarget {
   const target = value as Partial<DeliveryReplyTarget>;
-  if (!target.session || !target.delivery) {
+  if (!target.claimedDelivery || !target.delivery) {
     throw new Error("Channel reply target is outside a claimed delivery");
   }
   return target as DeliveryReplyTarget;
@@ -990,7 +1004,7 @@ function asDeliveryTarget(value: ReplyTarget): DeliveryReplyTarget {
 
 function asDeliveryRef(value: MessageRef): DeliveryMessageRef {
   const ref = value as Partial<DeliveryMessageRef>;
-  if (!ref.session || !ref.responseId || !ref.adapter) {
+  if (!ref.claimedDelivery || !ref.responseId || !ref.adapter) {
     throw new Error("Channel message ref is outside a claimed delivery");
   }
   return ref as DeliveryMessageRef;
@@ -1010,7 +1024,7 @@ function messageRef(
   return {
     id: providerReference ?? responseId,
     responseId,
-    session: target.session,
+    claimedDelivery: target.claimedDelivery,
     adapter: target.delivery.adapter,
     ...(providerReference ? { providerReference } : {}),
   };
@@ -1035,8 +1049,8 @@ function mintId(prefix: string): string {
   return `${prefix}${randomUUID().replaceAll("-", "")}`;
 }
 
-function digest(value: string): string {
-  return createHash("sha256").update(value).digest("hex");
+function elapsedMs(startedAtMs: number): number {
+  return Math.max(Date.now() - startedAtMs, 0);
 }
 
 function normalizeTaskStatus(

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -536,7 +536,7 @@ export class DeliveryAdapter implements PlatformAdapter {
       title?: string;
       altText?: string;
     },
-  ): Promise<{ ok: boolean; fileId?: string; error?: string }> {
+  ): Promise<{ ok: boolean; assetId?: string; error?: string }> {
     const target = asDeliveryTarget(targetValue);
     if (target.delivery.adapter === "teams") {
       const mimeType = managedImageMimeType(args.filename);
@@ -589,7 +589,7 @@ export class DeliveryAdapter implements PlatformAdapter {
       ...(args.title ? { title: args.title } : {}),
       ...(args.altText ? { altText: args.altText } : {}),
     });
-    return { ok: true, fileId: handle };
+    return { ok: true, assetId: handle };
   }
 
   /** Records provider-acknowledged managed output through canonical AG-UI. */

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -66,6 +66,7 @@ interface DeliveryMessageRef extends MessageRef {
 }
 
 const MANAGED_ASSET_ACTIVITY_TYPE = "copilotkit.managed-asset";
+const MANAGED_SLACK_TEXT_INTERVAL_MS = 600;
 
 export interface CanonicalChannelRunArgs {
   agent: AbstractAgent;
@@ -692,7 +693,7 @@ export class DeliveryAdapter implements PlatformAdapter {
       },
       nativeStreaming: {
         strict: true,
-        minIntervalMs: 0,
+        minIntervalMs: MANAGED_SLACK_TEXT_INTERVAL_MS,
         ...(this.options.replyContinuation !== undefined
           ? { replyContinuation: this.options.replyContinuation }
           : {}),
@@ -767,6 +768,14 @@ export class DeliveryAdapter implements PlatformAdapter {
         assertProviderReference(providerReference);
         await session.effect(responseId, {
           kind: "teams.message.replace",
+          providerReference,
+          text,
+        });
+      },
+      finalize: async (_id, text) => {
+        assertProviderReference(providerReference);
+        await session.effect(responseId, {
+          kind: "teams.message.finalize",
           providerReference,
           text,
         });

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -1,5 +1,12 @@
 import { createHash, randomUUID } from "node:crypto";
-import type { AbstractAgent, AgentSubscriber, Message } from "@ag-ui/client";
+import { EventType } from "@ag-ui/client";
+import type {
+  AbstractAgent,
+  AgentSubscriber,
+  BaseEvent,
+  Message,
+  RunAgentInput,
+} from "@ag-ui/client";
 import type {
   ChannelNode,
   MessageRef,
@@ -57,6 +64,8 @@ interface DeliveryMessageRef extends MessageRef {
   adapter: "slack" | "teams";
   providerReference?: string;
 }
+
+const MANAGED_ASSET_ACTIVITY_TYPE = "copilotkit.managed-asset";
 
 export interface CanonicalChannelRunArgs {
   agent: AbstractAgent;
@@ -151,6 +160,7 @@ export class DeliveryAdapter implements PlatformAdapter {
           agent,
           new Set(history.map((message) => message.id)),
         );
+        this.threadAgents.set(threadId, agent);
         let released = false;
         return {
           agent,
@@ -158,6 +168,9 @@ export class DeliveryAdapter implements PlatformAdapter {
             if (released) return;
             released = true;
             releaseAgent?.();
+            if (this.threadAgents.get(threadId) === agent) {
+              this.threadAgents.delete(threadId);
+            }
           },
         };
       } catch (error) {
@@ -174,6 +187,11 @@ export class DeliveryAdapter implements PlatformAdapter {
     ReadonlySet<string>
   >();
   private readonly agentTails = new WeakMap<AbstractAgent, Promise<void>>();
+  private readonly threadAgents = new Map<string, AbstractAgent>();
+  private readonly activeCanonicalEvents = new Map<
+    string,
+    (event: BaseEvent) => Promise<void>
+  >();
   private readonly interruptedRuns = new Map<string, string>();
 
   constructor(private readonly options: DeliveryAdapterOptions) {
@@ -334,6 +352,12 @@ export class DeliveryAdapter implements PlatformAdapter {
     const threadId = target.delivery.canonicalThreadId;
     const runId = mintId("run_");
     const historyIds = this.historyIds.get(args.agent) ?? new Set<string>();
+    const persistedInputMessages = canonicalizeManagedInputMessages(
+      args.agent.messages.filter((message) => !historyIds.has(message.id)),
+      target.delivery.turn.input.kind === "text"
+        ? target.delivery.turn.input.files
+        : undefined,
+    );
     const result = await this.options.runCanonical({
       agent: args.agent,
       threadId,
@@ -342,10 +366,29 @@ export class DeliveryAdapter implements PlatformAdapter {
       agentId: this.options.channelName,
       tools: args.tools,
       context: args.context,
-      persistedInputMessages: args.agent.messages.filter(
-        (message) => !historyIds.has(message.id),
-      ),
-      execute: args.execute,
+      persistedInputMessages,
+      execute: async (subscriber, canonicalRun) => {
+        if (!canonicalRun) {
+          return args.execute(subscriber, canonicalRun);
+        }
+        const emit = (event: BaseEvent) =>
+          emitCanonicalEvent({
+            agent: args.agent,
+            canonicalRun,
+            context: args.context,
+            event,
+            subscriber,
+            tools: args.tools,
+          });
+        this.activeCanonicalEvents.set(threadId, emit);
+        try {
+          return await args.execute(subscriber, canonicalRun);
+        } finally {
+          if (this.activeCanonicalEvents.get(threadId) === emit) {
+            this.activeCanonicalEvents.delete(threadId);
+          }
+        }
+      },
     });
     if (result.interrupted) {
       this.interruptedRuns.set(threadId, runId);
@@ -537,7 +580,74 @@ export class DeliveryAdapter implements PlatformAdapter {
         altText: args.altText ?? args.title ?? args.filename,
       });
     }
+    await this.recordManagedAssetActivity(target, {
+      assetId: handle,
+      filename: args.filename,
+      mimeType:
+        managedImageMimeType(args.filename) ?? "application/octet-stream",
+      byteSize: args.bytes.byteLength,
+      ...(args.title ? { title: args.title } : {}),
+      ...(args.altText ? { altText: args.altText } : {}),
+    });
     return { ok: true, fileId: handle };
+  }
+
+  /** Records provider-acknowledged managed output through canonical AG-UI. */
+  private async recordManagedAssetActivity(
+    target: DeliveryReplyTarget,
+    content: {
+      readonly assetId: string;
+      readonly filename: string;
+      readonly mimeType: string;
+      readonly byteSize: number;
+      readonly title?: string;
+      readonly altText?: string;
+    },
+  ): Promise<void> {
+    const event = {
+      type: EventType.ACTIVITY_SNAPSHOT,
+      messageId: mintId("activity_"),
+      activityType: MANAGED_ASSET_ACTIVITY_TYPE,
+      content,
+    } as BaseEvent;
+    const active = this.activeCanonicalEvents.get(
+      target.delivery.canonicalThreadId,
+    );
+    if (active) {
+      await active(event);
+      return;
+    }
+
+    const agent = this.threadAgents.get(target.delivery.canonicalThreadId);
+    if (!agent) {
+      throw new Error(
+        "Managed asset history requires an active Channel thread",
+      );
+    }
+    await this.options.runCanonical({
+      agent,
+      threadId: target.delivery.canonicalThreadId,
+      runId: mintId("run_"),
+      userId: target.delivery.appUserId,
+      agentId: this.options.channelName,
+      tools: [],
+      context: [],
+      persistedInputMessages: [],
+      execute: async (subscriber, canonicalRun) => {
+        if (!canonicalRun) {
+          throw new Error("Managed asset history requires a canonical run");
+        }
+        await emitCanonicalEvent({
+          agent,
+          canonicalRun,
+          context: [],
+          event,
+          subscriber,
+          tools: [],
+        });
+        return { iterations: 0, interrupted: false };
+      },
+    });
   }
 
   createRunRenderer(targetValue: ReplyTarget): RunRenderer {
@@ -559,7 +669,6 @@ export class DeliveryAdapter implements PlatformAdapter {
     let providerReference: string | undefined;
     return createSlackRunRenderer({
       target: { channel: "managed", threadTs: "managed" },
-      status: { threadTs: "managed", isPane: false },
       showToolStatus: this.options.showToolStatus ?? false,
       transport: {
         setStatus: async () => undefined,
@@ -645,7 +754,6 @@ export class DeliveryAdapter implements PlatformAdapter {
   ): RunRenderer {
     let providerReference: string | undefined;
     return createTeamsRunRenderer({
-      typing: async () => undefined,
       post: async (text) => {
         providerReference = providerReferenceFromResult(
           await session.effect(responseId, {
@@ -718,10 +826,11 @@ export class DeliveryAdapter implements PlatformAdapter {
       appUserId: target.delivery.appUserId,
     });
     return messages.map((message) => ({
-      text:
-        typeof message.content === "string"
-          ? message.content
-          : JSON.stringify(message.content),
+      text: historyText(message.content),
+      ...(message.content !== undefined ? { content: message.content } : {}),
+      ...("activityType" in message && typeof message.activityType === "string"
+        ? { activityType: message.activityType }
+        : {}),
       isBot: message.role !== "user",
       user: {
         id: message.role === "user" ? "user" : "bot",
@@ -737,6 +846,106 @@ export class DeliveryAdapter implements PlatformAdapter {
   lookupUser(_query: UserQuery): Promise<PlatformUser | undefined> {
     return Promise.resolve(undefined);
   }
+}
+
+/** Emits one canonical event through the active AgentRunner subscriber. */
+async function emitCanonicalEvent(input: {
+  readonly agent: AbstractAgent;
+  readonly canonicalRun: CanonicalRunIdentity;
+  readonly context: readonly ContextEntry[];
+  readonly event: BaseEvent;
+  readonly subscriber: AgentSubscriber;
+  readonly tools: readonly AgentToolDescriptor[];
+}): Promise<void> {
+  const runInput: RunAgentInput = {
+    threadId: input.canonicalRun.threadId,
+    runId: input.canonicalRun.runId,
+    messages: input.agent.messages,
+    state: input.agent.state,
+    tools: [...input.tools],
+    context: [...input.context],
+    forwardedProps: {},
+  };
+  await input.subscriber.onEvent?.({
+    agent: input.agent,
+    event: input.event,
+    input: runInput,
+    messages: input.agent.messages,
+    state: input.agent.state,
+  });
+}
+
+/** Replaces hydrated file bytes with durable managed-asset references. */
+function canonicalizeManagedInputMessages(
+  messages: Message[],
+  files:
+    | ReadonlyArray<{
+        handle: string;
+        filename: string;
+        mimeType?: string;
+        byteSize?: number;
+      }>
+    | undefined,
+): Message[] {
+  if (!files || files.length === 0) return messages;
+  let fileIndex = 0;
+  return messages.map((message) => {
+    if (!Array.isArray(message.content)) return message;
+    return {
+      ...message,
+      content: message.content.map((part) => {
+        if (
+          typeof part !== "object" ||
+          part === null ||
+          !("source" in part) ||
+          typeof part.source !== "object" ||
+          part.source === null ||
+          !("type" in part.source) ||
+          part.source.type !== "data"
+        ) {
+          return part;
+        }
+        const file = files[fileIndex++];
+        if (!file) return part;
+        return {
+          ...part,
+          source: {
+            type: "url" as const,
+            value: `cpki-asset://${file.handle}`,
+            ...(file.mimeType ? { mimeType: file.mimeType } : {}),
+          },
+          metadata: {
+            managedAsset: {
+              id: file.handle,
+              filename: file.filename,
+              ...(file.mimeType ? { mimeType: file.mimeType } : {}),
+              ...(file.byteSize !== undefined
+                ? { byteSize: file.byteSize }
+                : {}),
+            },
+          },
+        };
+      }),
+    } as Message;
+  });
+}
+
+/** Returns human-readable text without serializing structured AG-UI content. */
+function historyText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .flatMap((part) =>
+      typeof part === "object" &&
+      part !== null &&
+      "type" in part &&
+      part.type === "text" &&
+      "text" in part &&
+      typeof part.text === "string"
+        ? [part.text]
+        : [],
+    )
+    .join("");
 }
 
 function teamsMessageEffect(

--- a/packages/channels-intelligence/src/delivery-contracts.test.ts
+++ b/packages/channels-intelligence/src/delivery-contracts.test.ts
@@ -12,10 +12,6 @@ const appendPayload = (): ChannelProviderPayload => ({
   kind: "slack.stream.append",
   providerReference: "pref_v1_reference_01",
   delta: "Hello",
-  beforeTextDigest:
-    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-  afterTextDigest:
-    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
 });
 
 const packet = (): ChannelDeliveryPacket => {

--- a/packages/channels-intelligence/src/delivery-contracts.test.ts
+++ b/packages/channels-intelligence/src/delivery-contracts.test.ts
@@ -1,8 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { expect, test } from "vitest";
 import {
   CHANNEL_DELIVERY_PROTOCOL,
   assertDeliveryPacket,
-  deliveryPayloadDigest,
 } from "./delivery-contracts.js";
 import type {
   ChannelDeliveryPacket,
@@ -20,110 +19,102 @@ const appendPayload = (): ChannelProviderPayload => ({
 });
 
 const packet = (): ChannelDeliveryPacket => {
-  const payload = appendPayload();
   return {
     protocol: CHANNEL_DELIVERY_PROTOCOL,
     deliveryId: "dlv_delivery_01",
     runtimeInstanceId: "rti_runtime_01",
     ownerGeneration: 1,
     seq: 0,
-    effectId: "eff_01",
-    responseId: "response_01",
-    payloadDigest: deliveryPayloadDigest(payload),
-    payload,
+    packetId: "pkt_01",
+    payload: appendPayload(),
   };
 };
 
-describe("Channel delivery packet contract", () => {
-  it("uses the hard-cut realtime delivery protocol", () => {
-    expect(CHANNEL_DELIVERY_PROTOCOL).toBe("channel_delivery_v1");
-  });
+test("uses the hard-cut realtime delivery protocol", () => {
+  expect(CHANNEL_DELIVERY_PROTOCOL).toBe("channel_delivery_v1");
+});
 
-  it("accepts one destination-free packet", () => {
-    expect(() => assertDeliveryPacket(packet())).not.toThrow();
-  });
+test("accepts one destination-free packet", () => {
+  expect(() => assertDeliveryPacket(packet())).not.toThrow();
+});
 
-  it("rejects trusted addressing and credentials", () => {
-    const forged = {
+test("rejects trusted addressing and credentials", () => {
+  const forged = {
+    ...packet(),
+    payload: {
+      ...appendPayload(),
+      channel: "C_FORGED",
+      token: "xoxb-secret",
+    },
+  };
+
+  expect(() => assertDeliveryPacket(forged)).toThrow(
+    "delivery payload is invalid",
+  );
+});
+
+test("accepts valid provider payload numbers without a cross-language digest", () => {
+  const numericPacket = {
+    ...packet(),
+    payload: {
+      kind: "teams.message.create",
+      text: "numeric values",
+      cards: [{ small: 1e-7, negativeZero: -0, large: 1e23 }],
+    },
+  };
+
+  expect(() => assertDeliveryPacket(numericPacket)).not.toThrow();
+});
+
+test("rejects per-packet auth and heartbeat shapes", () => {
+  expect(() =>
+    assertDeliveryPacket({
+      ...packet(),
+      authToken: "cpk-retired-per-packet-auth",
+    }),
+  ).toThrow("delivery packet fields are invalid");
+  expect(() =>
+    assertDeliveryPacket({
+      ...packet(),
+      payload: { kind: "channel.heartbeat" },
+    }),
+  ).toThrow("delivery payload is invalid");
+});
+
+test("enforces the shared identifier and provider-reference bounds", () => {
+  expect(() =>
+    assertDeliveryPacket({
+      ...packet(),
+      deliveryId: "dlv_short",
+    }),
+  ).toThrow("delivery packet fields are invalid");
+  expect(() =>
+    assertDeliveryPacket({
+      ...packet(),
+      packetId: `pkt_${"x".repeat(129)}`,
+    }),
+  ).toThrow("delivery packet fields are invalid");
+
+  expect(() =>
+    assertDeliveryPacket({
       ...packet(),
       payload: {
         ...appendPayload(),
-        channel: "C_FORGED",
-        token: "xoxb-secret",
+        providerReference: "pref_v1_short",
       },
-    };
+    }),
+  ).toThrow("delivery payload is invalid");
+});
 
-    expect(() => assertDeliveryPacket(forged)).toThrow(
-      "delivery payload is invalid",
-    );
-  });
-
-  it("rejects a changed payload under the same digest", () => {
-    const changed = {
+test("rejects packets over 64 KiB", () => {
+  expect(() =>
+    assertDeliveryPacket({
       ...packet(),
-      payload: { ...appendPayload(), delta: "changed" },
-    };
-
-    expect(() => assertDeliveryPacket(changed)).toThrow(
-      "delivery payload digest is invalid",
-    );
-  });
-
-  it("rejects per-packet auth and heartbeat shapes", () => {
-    expect(() =>
-      assertDeliveryPacket({
-        ...packet(),
-        authToken: "cpk-retired-per-packet-auth",
-      }),
-    ).toThrow("delivery packet fields are invalid");
-    expect(() =>
-      assertDeliveryPacket({
-        ...packet(),
-        payload: { kind: "channel.heartbeat" },
-      }),
-    ).toThrow("delivery payload is invalid");
-  });
-
-  it("enforces the shared identifier and provider-reference bounds", () => {
-    expect(() =>
-      assertDeliveryPacket({
-        ...packet(),
-        deliveryId: "dlv_short",
-      }),
-    ).toThrow("delivery packet fields are invalid");
-    expect(() =>
-      assertDeliveryPacket({
-        ...packet(),
-        effectId: `eff_${"x".repeat(129)}`,
-      }),
-    ).toThrow("delivery packet fields are invalid");
-
-    const payload = {
-      ...appendPayload(),
-      providerReference: "pref_v1_short",
-    };
-    expect(() =>
-      assertDeliveryPacket({
-        ...packet(),
-        payload,
-        payloadDigest: deliveryPayloadDigest(payload),
-      }),
-    ).toThrow("delivery payload is invalid");
-  });
-
-  it("rejects packets over 64 KiB", () => {
-    const payload = {
-      kind: "slack.message.create" as const,
-      text: "",
-      blocks: [{ text: "x".repeat(40_000) }, { text: "y".repeat(40_000) }],
-    };
-
-    expect(() =>
-      assertDeliveryPacket({
-        ...packet(),
-        payload,
-        payloadDigest: deliveryPayloadDigest(payload),
-      }),
-    ).toThrow("delivery packet exceeds 64 KiB");
-  });
+      payload: {
+        kind: "slack.message.create" as const,
+        text: "",
+        blocks: [{ text: "x".repeat(40_000) }, { text: "y".repeat(40_000) }],
+      },
+    }),
+  ).toThrow("delivery packet exceeds 64 KiB");
 });

--- a/packages/channels-intelligence/src/delivery-contracts.test.ts
+++ b/packages/channels-intelligence/src/delivery-contracts.test.ts
@@ -66,6 +66,19 @@ test("accepts valid provider payload numbers without a cross-language digest", (
   expect(() => assertDeliveryPacket(numericPacket)).not.toThrow();
 });
 
+test("accepts a distinct Teams final effect for priority rate gating", () => {
+  expect(() =>
+    assertDeliveryPacket({
+      ...packet(),
+      payload: {
+        kind: "teams.message.finalize",
+        providerReference: "pref_v1_reference_01",
+        text: "final answer",
+      },
+    }),
+  ).not.toThrow();
+});
+
 test("rejects per-packet auth and heartbeat shapes", () => {
   expect(() =>
     assertDeliveryPacket({

--- a/packages/channels-intelligence/src/delivery-contracts.ts
+++ b/packages/channels-intelligence/src/delivery-contracts.ts
@@ -1,5 +1,3 @@
-import { createHash } from "node:crypto";
-
 /** Hard-cut protocol for the dedicated `/channels` socket. */
 export const CHANNEL_DELIVERY_PROTOCOL = "channel_delivery_v1" as const;
 
@@ -14,8 +12,7 @@ export const DELIVERY_PACKET_MAX_BYTES = 64 * 1024;
 
 const SHA_256_PATTERN = /^[a-f0-9]{64}$/;
 const PROVIDER_REFERENCE_PATTERN = /^pref_v1_[A-Za-z0-9_-]{8,4088}$/;
-const EFFECT_ID_PATTERN = /^eff_[A-Za-z0-9_-]{2,128}$/;
-const RESPONSE_ID_PATTERN = /^response_[A-Za-z0-9_-]{1,123}$/;
+const PACKET_ID_PATTERN = /^pkt_[A-Za-z0-9_-]{2,128}$/;
 const DELIVERY_ID_PATTERN = /^dlv_[A-Za-z0-9_-]{8,128}$/;
 const RUNTIME_ID_PATTERN = /^rti_[A-Za-z0-9_-]{4,96}$/;
 
@@ -102,19 +99,16 @@ export interface ChannelDeliveryPacket {
   runtimeInstanceId: string;
   ownerGeneration: number;
   seq: number;
-  effectId: string;
-  responseId: string;
-  payloadDigest: string;
+  packetId: string;
   payload: ChannelDeliveryPayload;
 }
 
 export interface ChannelDeliveryPacketAck {
   deliveryId: string;
   seq: number;
-  effectId: string;
-  responseId: string;
-  payloadDigest: string;
-  phase: "applied";
+  packetId: string;
+  phase: "applied" | "retry_wait" | "failed" | "uncertain";
+  retryAt?: string;
   result: Record<string, unknown>;
 }
 
@@ -134,15 +128,6 @@ export function deliveryPacketByteLength(value: unknown): number {
   return new TextEncoder().encode(JSON.stringify(value)).byteLength;
 }
 
-/** Hash the exact provider-ready payload with stable object key order. */
-export function deliveryPayloadDigest(payload: unknown): string {
-  const encoded = JSON.stringify(canonicalizeJson(payload));
-  if (encoded === undefined) {
-    throw new TypeError("delivery payload is not JSON encodable");
-  }
-  return createHash("sha256").update(encoded).digest("hex");
-}
-
 /** Validate one exact, bounded, destination-free delivery packet. */
 export function assertDeliveryPacket(
   value: unknown,
@@ -157,9 +142,7 @@ export function assertDeliveryPacket(
       "runtimeInstanceId",
       "ownerGeneration",
       "seq",
-      "effectId",
-      "responseId",
-      "payloadDigest",
+      "packetId",
       "payload",
     ]) ||
     value.protocol !== CHANNEL_DELIVERY_PROTOCOL ||
@@ -171,20 +154,13 @@ export function assertDeliveryPacket(
     (value.ownerGeneration as number) < 1 ||
     !Number.isInteger(value.seq) ||
     (value.seq as number) < 0 ||
-    typeof value.effectId !== "string" ||
-    !EFFECT_ID_PATTERN.test(value.effectId) ||
-    typeof value.responseId !== "string" ||
-    !RESPONSE_ID_PATTERN.test(value.responseId) ||
-    typeof value.payloadDigest !== "string" ||
-    !SHA_256_PATTERN.test(value.payloadDigest)
+    typeof value.packetId !== "string" ||
+    !PACKET_ID_PATTERN.test(value.packetId)
   ) {
     throw new TypeError("delivery packet fields are invalid");
   }
   if (!isDeliveryPayload(value.payload)) {
     throw new TypeError("delivery payload is invalid");
-  }
-  if (deliveryPayloadDigest(value.payload) !== value.payloadDigest) {
-    throw new TypeError("delivery payload digest is invalid");
   }
   if (deliveryPacketByteLength(value) > DELIVERY_PACKET_MAX_BYTES) {
     throw new RangeError("delivery packet exceeds 64 KiB");
@@ -313,16 +289,6 @@ function isDeliveryPayload(value: unknown): value is ChannelDeliveryPayload {
     default:
       return false;
   }
-}
-
-function canonicalizeJson(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalizeJson);
-  if (!isRecord(value)) return value;
-  return Object.fromEntries(
-    Object.keys(value)
-      .sort()
-      .map((key) => [key, canonicalizeJson(value[key])]),
-  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/channels-intelligence/src/delivery-contracts.ts
+++ b/packages/channels-intelligence/src/delivery-contracts.ts
@@ -67,6 +67,12 @@ export type ChannelProviderPayload =
       cards?: ReadonlyArray<Readonly<Record<string, unknown>>>;
     }
   | {
+      kind: "teams.message.finalize";
+      providerReference: string;
+      text: string;
+      cards?: ReadonlyArray<Readonly<Record<string, unknown>>>;
+    }
+  | {
       kind: "slack.file.create";
       fileHandle: string;
       title?: string;
@@ -244,6 +250,7 @@ function isDeliveryPayload(value: unknown): value is ChannelDeliveryPayload {
         optionalRecordArray(value.cards, 25)
       );
     case "teams.message.replace":
+    case "teams.message.finalize":
       return (
         hasExactFields(
           value,

--- a/packages/channels-intelligence/src/delivery-contracts.ts
+++ b/packages/channels-intelligence/src/delivery-contracts.ts
@@ -10,7 +10,6 @@ export const CHANNEL_DELIVERY_OWNER_TTL_SECONDS = 60 * 60;
 /** Maximum encoded size of one ordered packet. */
 export const DELIVERY_PACKET_MAX_BYTES = 64 * 1024;
 
-const SHA_256_PATTERN = /^[a-f0-9]{64}$/;
 const PROVIDER_REFERENCE_PATTERN = /^pref_v1_[A-Za-z0-9_-]{8,4088}$/;
 const PACKET_ID_PATTERN = /^pkt_[A-Za-z0-9_-]{2,128}$/;
 const DELIVERY_ID_PATTERN = /^dlv_[A-Za-z0-9_-]{8,128}$/;
@@ -25,8 +24,6 @@ export type ChannelProviderPayload =
       kind: "slack.stream.append";
       providerReference: string;
       delta: string;
-      beforeTextDigest: string;
-      afterTextDigest: string;
     }
   | {
       kind: "slack.stream.task";
@@ -38,7 +35,6 @@ export type ChannelProviderPayload =
   | {
       kind: "slack.stream.stop";
       providerReference: string;
-      finalTextDigest: string;
     }
   | {
       kind: "slack.message.create";
@@ -183,17 +179,9 @@ function isDeliveryPayload(value: unknown): value is ChannelDeliveryPayload {
       );
     case "slack.stream.append":
       return (
-        hasExactFields(value, [
-          "kind",
-          "providerReference",
-          "delta",
-          "beforeTextDigest",
-          "afterTextDigest",
-        ]) &&
+        hasExactFields(value, ["kind", "providerReference", "delta"]) &&
         validReference(value.providerReference) &&
-        boundedString(value.delta, 1, 40_000) &&
-        sha256(value.beforeTextDigest) &&
-        sha256(value.afterTextDigest)
+        boundedString(value.delta, 1, 40_000)
       );
     case "slack.stream.task":
       return (
@@ -213,13 +201,8 @@ function isDeliveryPayload(value: unknown): value is ChannelDeliveryPayload {
       );
     case "slack.stream.stop":
       return (
-        hasExactFields(value, [
-          "kind",
-          "providerReference",
-          "finalTextDigest",
-        ]) &&
-        validReference(value.providerReference) &&
-        sha256(value.finalTextDigest)
+        hasExactFields(value, ["kind", "providerReference"]) &&
+        validReference(value.providerReference)
       );
     case "slack.message.create":
       return (
@@ -332,10 +315,6 @@ function optionalRecordArray(value: unknown, max: number): boolean {
       value.length <= max &&
       value.every((entry) => isRecord(entry)))
   );
-}
-
-function sha256(value: unknown): boolean {
-  return typeof value === "string" && SHA_256_PATTERN.test(value);
 }
 
 function validReference(value: unknown): boolean {

--- a/packages/channels-intelligence/src/delivery-files.ts
+++ b/packages/channels-intelligence/src/delivery-files.ts
@@ -147,7 +147,7 @@ export class ChannelDeliveryFileClient {
     return { bytes, ...(mimeType ? { mimeType } : {}) };
   }
 
-  /** Upload one outbound file under the active delivery lease. */
+  /** Store one outbound file for the active delivery. */
   async uploadFile(
     deliveryId: string,
     args: {

--- a/packages/channels-intelligence/src/delivery-history.test.ts
+++ b/packages/channels-intelligence/src/delivery-history.test.ts
@@ -3,7 +3,7 @@ import type { Message, RunAgentInput } from "@ag-ui/client";
 import { EMPTY } from "rxjs";
 import { expect, test, vi } from "vitest";
 import { DeliveryAdapter } from "./delivery-adapter.js";
-import type { ChannelDeliverySession } from "./delivery-transport.js";
+import type { ClaimedChannelDelivery } from "./delivery-transport.js";
 import type { PreparedChannelDelivery } from "./delivery-transport.js";
 
 const delivery: PreparedChannelDelivery = {
@@ -24,7 +24,7 @@ const delivery: PreparedChannelDelivery = {
 };
 
 const target = {
-  session: {} as ChannelDeliverySession,
+  claimedDelivery: {} as ClaimedChannelDelivery,
   delivery,
 };
 
@@ -133,7 +133,7 @@ test("canonical run input stores managed asset references instead of hydrated by
 
   await adapter.runAgentLifecycle({
     replyTarget: {
-      session: {} as ChannelDeliverySession,
+      claimedDelivery: {} as ClaimedChannelDelivery,
       delivery: withFile,
     },
     agent,

--- a/packages/channels-intelligence/src/delivery-history.test.ts
+++ b/packages/channels-intelligence/src/delivery-history.test.ts
@@ -1,0 +1,166 @@
+import { AbstractAgent } from "@ag-ui/client";
+import type { Message, RunAgentInput } from "@ag-ui/client";
+import { EMPTY } from "rxjs";
+import { expect, test, vi } from "vitest";
+import { DeliveryAdapter } from "./delivery-adapter.js";
+import type { ChannelDeliverySession } from "./delivery-transport.js";
+import type { PreparedChannelDelivery } from "./delivery-transport.js";
+
+const delivery: PreparedChannelDelivery = {
+  protocol: "channel_delivery_v1",
+  deliveryId: "dlv_history_01",
+  deliveryExpiresAt: "2099-07-29T17:00:00.000Z",
+  channelId: "channel_history_01",
+  channelName: "support",
+  canonicalThreadId: "thread_history",
+  appUserId: "slack:T1:U1",
+  adapter: "slack",
+  turn: {
+    eventId: "evt_history",
+    receivedAt: "2026-07-29T17:00:00.000Z",
+    input: { kind: "text", text: "hi" },
+    actor: { externalUserId: "U1" },
+  },
+};
+
+const target = {
+  session: {} as ChannelDeliverySession,
+  delivery,
+};
+
+test("managed history keeps multimodal and activity content structured", async () => {
+  const imageContent = [
+    { type: "text", text: "What is this?" },
+    {
+      type: "image",
+      source: {
+        type: "data",
+        value: "iVBORw0KGgo=",
+        mimeType: "image/png",
+      },
+    },
+  ];
+  const activityContent = {
+    assetId: "fileref_chart",
+    filename: "chart.png",
+    mimeType: "image/png",
+    byteSize: 8,
+    altText: "Chart",
+  };
+  const history = [
+    { id: "user-image", role: "user", content: imageContent },
+    {
+      id: "asset-activity",
+      role: "activity",
+      activityType: "copilotkit.managed-asset",
+      content: activityContent,
+    },
+  ] as Message[];
+  const adapter = new DeliveryAdapter({
+    channelName: "support",
+    transport: {} as never,
+    runCanonical: async () => ({ iterations: 0, interrupted: false }),
+    loadHistory: async () => history,
+  });
+
+  await expect(adapter.getMessages(target)).resolves.toEqual([
+    expect.objectContaining({
+      text: "What is this?",
+      content: imageContent,
+    }),
+    expect.objectContaining({
+      text: "",
+      activityType: "copilotkit.managed-asset",
+      content: activityContent,
+    }),
+  ]);
+});
+
+class NoopAgent extends AbstractAgent {
+  run(_input: RunAgentInput): ReturnType<AbstractAgent["run"]> {
+    return EMPTY;
+  }
+}
+
+test("canonical run input stores managed asset references instead of hydrated bytes", async () => {
+  const withFile: PreparedChannelDelivery = {
+    ...delivery,
+    turn: {
+      ...delivery.turn,
+      input: {
+        kind: "text",
+        text: "What is this?",
+        files: [
+          {
+            handle: "fileref_inbound",
+            filename: "photo.png",
+            mimeType: "image/png",
+            byteSize: 8,
+          },
+        ],
+      },
+    },
+  };
+  let persisted: Message[] = [];
+  const adapter = new DeliveryAdapter({
+    channelName: "support",
+    transport: {} as never,
+    loadHistory: async () => [],
+    runCanonical: async (args) => {
+      persisted = args.persistedInputMessages;
+      return { iterations: 0, interrupted: false };
+    },
+  });
+  const agent = new NoopAgent({
+    initialMessages: [
+      {
+        id: "user-inbound",
+        role: "user",
+        content: [
+          { type: "text", text: "What is this?" },
+          {
+            type: "image",
+            source: {
+              type: "data",
+              value: "iVBORw0KGgo=",
+              mimeType: "image/png",
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  await adapter.runAgentLifecycle({
+    replyTarget: {
+      session: {} as ChannelDeliverySession,
+      delivery: withFile,
+    },
+    agent,
+    renderer: {} as never,
+    tools: [],
+    context: [],
+    execute: vi.fn(),
+  });
+
+  expect(JSON.stringify(persisted)).not.toContain("iVBOR");
+  expect(persisted[0]?.content).toEqual([
+    { type: "text", text: "What is this?" },
+    {
+      type: "image",
+      source: {
+        type: "url",
+        value: "cpki-asset://fileref_inbound",
+        mimeType: "image/png",
+      },
+      metadata: {
+        managedAsset: {
+          id: "fileref_inbound",
+          filename: "photo.png",
+          mimeType: "image/png",
+          byteSize: 8,
+        },
+      },
+    },
+  ]);
+});

--- a/packages/channels-intelligence/src/delivery-test-gateway.ts
+++ b/packages/channels-intelligence/src/delivery-test-gateway.ts
@@ -46,14 +46,12 @@ export class DeliveryTestGateway implements RealtimeGatewaySession {
         return {
           deliveryId: packet.deliveryId,
           seq: packet.seq,
-          effectId: packet.effectId,
-          responseId: packet.responseId,
-          payloadDigest: packet.payloadDigest,
+          packetId: packet.packetId,
           phase: "applied",
           result:
             packet.payload.kind === "channel.delivery.terminal"
               ? {}
-              : { providerReference: `pref_v1_${packet.responseId}` },
+              : { providerReference: `pref_v1_${packet.packetId}` },
         };
       },
       on: () => undefined,

--- a/packages/channels-intelligence/src/delivery-test-gateway.ts
+++ b/packages/channels-intelligence/src/delivery-test-gateway.ts
@@ -69,6 +69,7 @@ export class DeliveryTestGateway implements RealtimeGatewaySession {
     this.invitationHandler?.({
       protocol: "channel_delivery_v1",
       deliveryId: delivery.deliveryId,
+      canonicalThreadId: delivery.canonicalThreadId,
     });
     const deadline = Date.now() + 1_000;
     while (this.leaves !== expectedLeaves) {

--- a/packages/channels-intelligence/src/delivery-transport.test.ts
+++ b/packages/channels-intelligence/src/delivery-transport.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, vi } from "vitest";
 import {
   ChannelProviderDeliveryError,
-  ChannelDeliverySession,
+  ClaimedChannelDelivery,
   ChannelDeliveryTransport,
 } from "./delivery-transport.js";
 import type { PreparedChannelDelivery } from "./delivery-transport.js";
@@ -263,7 +263,7 @@ test("retries the exact packet after reconnect and calls no second sequence", as
     },
     deliveryExpiresAt: "2099-07-29T18:00:00.000Z",
   });
-  const session = new ChannelDeliverySession(
+  const session = new ClaimedChannelDelivery(
     preparedDelivery(),
     {
       ownerGeneration: 7,
@@ -320,7 +320,7 @@ test("polls the same packet after a retry-wait result", async () => {
         result: { providerReference: "pref_v1_message_01" },
       }),
     );
-  const session = new ChannelDeliverySession(
+  const session = new ClaimedChannelDelivery(
     preparedDelivery(),
     {
       ownerGeneration: 7,
@@ -340,6 +340,54 @@ test("polls the same packet after a retry-wait result", async () => {
   const secondPacket = vi.mocked(deliveryChannel.push).mock.calls[1]![1];
   expect(secondPacket).toEqual(firstPacket);
   expect(result).toEqual({ providerReference: "pref_v1_message_01" });
+});
+
+test("keeps a confirmed Teams image capability rejection non-terminal", async () => {
+  const deliveryChannel = channel();
+  vi.mocked(deliveryChannel.push)
+    .mockImplementationOnce((_event, packet) =>
+      Promise.resolve({
+        ...(packet as object),
+        phase: "applied",
+        result: { capabilityError: "teams_image_rejected" },
+      }),
+    )
+    .mockImplementationOnce((_event, packet) =>
+      Promise.resolve({
+        ...(packet as object),
+        phase: "applied",
+        result: { providerReference: "pref_v1_teams_activity_01" },
+      }),
+    );
+  const claimedDelivery = new ClaimedChannelDelivery(
+    { ...preparedDelivery(), adapter: "teams" },
+    {
+      ownerGeneration: 7,
+      runtimeInstanceId: "rti_runtime_01",
+    },
+    deliveryChannel,
+    vi.fn(),
+  );
+
+  await expect(
+    claimedDelivery.effect("response_image", {
+      kind: "teams.image.create",
+      fileHandle: "file_handle_01",
+      altText: "Architecture diagram",
+    }),
+  ).resolves.toEqual({ capabilityError: "teams_image_rejected" });
+  expect(claimedDelivery.hasProviderOutput()).toBe(false);
+
+  await expect(
+    claimedDelivery.effect("response_text", {
+      kind: "teams.message.create",
+      text: "Text fallback",
+    }),
+  ).resolves.toEqual({
+    providerReference: "pref_v1_teams_activity_01",
+  });
+  expect(claimedDelivery.hasProviderOutput()).toBe(true);
+  expect(deliveryChannel.push).toHaveBeenCalledTimes(2);
 });
 
 test("stop aborts an active retry wait and leaves its delivery topic", async () => {
@@ -435,7 +483,7 @@ test("still sends a failed terminal when complete terminal fails", async () => {
       result: {},
     });
   });
-  const session = new ChannelDeliverySession(
+  const session = new ClaimedChannelDelivery(
     preparedDelivery(),
     {
       ownerGeneration: 7,
@@ -471,7 +519,7 @@ test("refreshes owner generation on packets after reconnect", async () => {
       runtimeInstanceId: "rti_runtime_01",
     },
   });
-  const session = new ChannelDeliverySession(
+  const session = new ClaimedChannelDelivery(
     preparedDelivery(),
     {
       ownerGeneration: 7,
@@ -504,7 +552,7 @@ test("closes the packet path after a permanent push failure", async () => {
   vi.mocked(deliveryChannel.push).mockRejectedValue(
     new RealtimeGatewayPushError("packet", "conflict", "sequence conflict"),
   );
-  const session = new ChannelDeliverySession(
+  const session = new ClaimedChannelDelivery(
     preparedDelivery(),
     {
       ownerGeneration: 7,
@@ -547,7 +595,7 @@ test("still allows stream.stop after a permanent non-terminal failure", async ()
       result: { providerReference: "pref_v1_message_01" },
     });
   });
-  const session = new ChannelDeliverySession(
+  const session = new ClaimedChannelDelivery(
     preparedDelivery(),
     {
       ownerGeneration: 7,
@@ -563,15 +611,12 @@ test("still allows stream.stop after a permanent non-terminal failure", async ()
       kind: "slack.stream.append",
       providerReference: "pref_v1_message_01",
       delta: "x",
-      beforeTextDigest: "a".repeat(64),
-      afterTextDigest: "b".repeat(64),
     }),
   ).rejects.toBeInstanceOf(RealtimeGatewayPushError);
 
   await session.effect("response_01", {
     kind: "slack.stream.stop",
     providerReference: "pref_v1_message_01",
-    finalTextDigest: "c".repeat(64),
   });
   expect(pushCount).toBe(3);
   const kinds = vi
@@ -588,7 +633,7 @@ test("still allows stream.stop after a permanent non-terminal failure", async ()
 
 test("does not count stream.stop alone as provider output", async () => {
   const deliveryChannel = channel();
-  const session = new ChannelDeliverySession(
+  const session = new ClaimedChannelDelivery(
     preparedDelivery(),
     {
       ownerGeneration: 7,
@@ -601,7 +646,6 @@ test("does not count stream.stop alone as provider output", async () => {
   await session.effect("response_01", {
     kind: "slack.stream.stop",
     providerReference: "pref_v1_message_01",
-    finalTextDigest: "c".repeat(64),
   });
   expect(session.hasProviderOutput()).toBe(false);
 });
@@ -682,7 +726,7 @@ test("surfaces a failed provider result as an already-terminal error", async () 
       result: { error: "provider_call_failed", status: "failed" },
     }),
   );
-  const session = new ChannelDeliverySession(
+  const session = new ClaimedChannelDelivery(
     preparedDelivery(),
     {
       ownerGeneration: 7,

--- a/packages/channels-intelligence/src/delivery-transport.test.ts
+++ b/packages/channels-intelligence/src/delivery-transport.test.ts
@@ -4,6 +4,7 @@ import {
   ChannelDeliverySession,
   ChannelDeliveryTransport,
 } from "./delivery-transport.js";
+import type { PreparedChannelDelivery } from "./delivery-transport.js";
 import type {
   RealtimeGatewayDeliveryChannel,
   RealtimeGatewaySession,
@@ -71,6 +72,7 @@ test("claims an invitation and consumes the one-use token on delivery join", asy
   invitationHandler({
     protocol: "channel_delivery_v1",
     deliveryId: "dlv_delivery_01",
+    canonicalThreadId: "thread_01",
     channelName: "support",
     adapter: "slack",
   });
@@ -88,6 +90,165 @@ test("claims an invitation and consumes the one-use token on delivery join", asy
     ownerGeneration: 7,
     joinToken: "chj_token_01",
   });
+});
+
+test("does not claim a new invitation while the local delivery limit is full", async () => {
+  let releaseFirst: (() => void) | undefined;
+  const firstDelivery = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  const control: RealtimeGatewaySession = {
+    push: vi.fn().mockImplementation((_event, payload) => {
+      const { deliveryId } = payload as { deliveryId: string };
+      return Promise.resolve({
+        result: "claimed",
+        deliveryId,
+        ownerGeneration: 7,
+        joinToken: `chj_${deliveryId}`,
+      });
+    }),
+    on: vi.fn(),
+    join: vi.fn().mockImplementation((topic) => {
+      const deliveryId = topic.replace("delivery:", "");
+      return Promise.resolve(
+        channel({
+          ...preparedDelivery(),
+          deliveryId,
+          canonicalThreadId:
+            deliveryId === "dlv_delivery_01" ? "thread_01" : "thread_02",
+        }),
+      );
+    }),
+  };
+  const transport = new ChannelDeliveryTransport({
+    session: control,
+    runtimeInstanceId: "rti_runtime_01",
+    maxConcurrentDeliveries: 1,
+  });
+  const handled = vi.fn(async (_session, delivery: PreparedChannelDelivery) => {
+    if (delivery.deliveryId === "dlv_delivery_01") {
+      await firstDelivery;
+    }
+  });
+  transport.start(handled);
+  const invitationHandler = vi.mocked(control.on).mock.calls[0]![1];
+
+  invitationHandler({
+    protocol: "channel_delivery_v1",
+    deliveryId: "dlv_delivery_01",
+    canonicalThreadId: "thread_01",
+  });
+  await vi.waitFor(() => expect(handled).toHaveBeenCalledOnce());
+  invitationHandler({
+    protocol: "channel_delivery_v1",
+    deliveryId: "dlv_delivery_02",
+    canonicalThreadId: "thread_02",
+  });
+
+  expect(control.push).toHaveBeenCalledTimes(1);
+  expect(control.push).not.toHaveBeenCalledWith(
+    "claim",
+    expect.objectContaining({ deliveryId: "dlv_delivery_02" }),
+  );
+
+  releaseFirst?.();
+  await transport.stop();
+});
+
+test("excludes the same canonical Thread before claim while allowing another Thread", async () => {
+  let releaseFirst: (() => void) | undefined;
+  const firstDelivery = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  const threadByDelivery = new Map([
+    ["dlv_delivery_01", "thread_01"],
+    ["dlv_delivery_02", "thread_01"],
+    ["dlv_delivery_03", "thread_03"],
+  ]);
+  const control: RealtimeGatewaySession = {
+    push: vi.fn().mockImplementation((_event, payload) => {
+      const { deliveryId } = payload as { deliveryId: string };
+      return Promise.resolve({
+        result: "claimed",
+        deliveryId,
+        ownerGeneration: 7,
+        joinToken: `chj_${deliveryId}`,
+      });
+    }),
+    on: vi.fn(),
+    join: vi.fn().mockImplementation((topic) => {
+      const deliveryId = topic.replace("delivery:", "");
+      return Promise.resolve(
+        channel({
+          ...preparedDelivery(),
+          deliveryId,
+          canonicalThreadId: threadByDelivery.get(deliveryId) ?? "thread_other",
+        }),
+      );
+    }),
+  };
+  const transport = new ChannelDeliveryTransport({
+    session: control,
+    runtimeInstanceId: "rti_runtime_01",
+    maxConcurrentDeliveries: 2,
+  });
+  const handled = vi.fn(async (_session, delivery: PreparedChannelDelivery) => {
+    if (delivery.deliveryId === "dlv_delivery_01") {
+      await firstDelivery;
+    }
+  });
+  transport.start(handled);
+  const invitationHandler = vi.mocked(control.on).mock.calls[0]![1];
+
+  invitationHandler({
+    protocol: "channel_delivery_v1",
+    deliveryId: "dlv_delivery_01",
+    canonicalThreadId: "thread_01",
+  });
+  await vi.waitFor(() => expect(handled).toHaveBeenCalledOnce());
+  invitationHandler({
+    protocol: "channel_delivery_v1",
+    deliveryId: "dlv_delivery_02",
+    canonicalThreadId: "thread_01",
+  });
+  invitationHandler({
+    protocol: "channel_delivery_v1",
+    deliveryId: "dlv_delivery_03",
+    canonicalThreadId: "thread_03",
+  });
+
+  await vi.waitFor(() => expect(handled).toHaveBeenCalledTimes(2));
+  expect(control.push).not.toHaveBeenCalledWith(
+    "claim",
+    expect.objectContaining({ deliveryId: "dlv_delivery_02" }),
+  );
+  expect(control.push).toHaveBeenCalledWith(
+    "claim",
+    expect.objectContaining({ deliveryId: "dlv_delivery_03" }),
+  );
+
+  releaseFirst?.();
+  await transport.stop();
+});
+
+test("ignores an invitation without a canonical Thread admission key", () => {
+  const control: RealtimeGatewaySession = {
+    push: vi.fn(),
+    on: vi.fn(),
+  };
+  const transport = new ChannelDeliveryTransport({
+    session: control,
+    runtimeInstanceId: "rti_runtime_01",
+  });
+  transport.start(async () => undefined);
+  const invitationHandler = vi.mocked(control.on).mock.calls[0]![1];
+
+  invitationHandler({
+    protocol: "channel_delivery_v1",
+    deliveryId: "dlv_delivery_01",
+  });
+
+  expect(control.push).not.toHaveBeenCalled();
 });
 
 test("retries the exact packet after reconnect and calls no second sequence", async () => {
@@ -426,6 +587,7 @@ test("rejects prepared deliveries with incomplete turn fields", async () => {
   invitationHandler({
     protocol: "channel_delivery_v1",
     deliveryId: "dlv_delivery_01",
+    canonicalThreadId: "thread_01",
   });
   await transport.stop();
   await vi.waitFor(() => {

--- a/packages/channels-intelligence/src/delivery-transport.test.ts
+++ b/packages/channels-intelligence/src/delivery-transport.test.ts
@@ -342,6 +342,74 @@ test("polls the same packet after a retry-wait result", async () => {
   expect(result).toEqual({ providerReference: "pref_v1_message_01" });
 });
 
+test("stop aborts an active retry wait and leaves its delivery topic", async () => {
+  const deliveryChannel = channel();
+  vi.mocked(deliveryChannel.push)
+    .mockImplementationOnce((_event, packet) =>
+      Promise.resolve({
+        ...(packet as object),
+        phase: "retry_wait",
+        retryAt: new Date(Date.now() + 1_000).toISOString(),
+        result: {
+          status: "retry_wait",
+          code: "provider_rate_limited",
+        },
+      }),
+    )
+    .mockImplementation((_event, packet) =>
+      Promise.resolve({
+        ...(packet as object),
+        phase: "applied",
+        result: { providerReference: "pref_v1_message_01" },
+      }),
+    );
+  const control: RealtimeGatewaySession = {
+    push: vi.fn().mockResolvedValue({
+      result: "claimed",
+      deliveryId: "dlv_delivery_01",
+      ownerGeneration: 7,
+      joinToken: "chj_token_01",
+    }),
+    on: vi.fn(),
+    join: vi.fn().mockResolvedValue(deliveryChannel),
+  };
+  const transport = new ChannelDeliveryTransport({
+    session: control,
+    runtimeInstanceId: "rti_runtime_01",
+  });
+  transport.start(async (session) => {
+    await session.effect("response_01", {
+      kind: "slack.message.create",
+      text: "Hello",
+    });
+  });
+  const invitationHandler = vi.mocked(control.on).mock.calls[0]![1];
+  invitationHandler({
+    protocol: "channel_delivery_v1",
+    deliveryId: "dlv_delivery_01",
+    canonicalThreadId: "thread_01",
+  });
+  await vi.waitFor(() => expect(deliveryChannel.push).toHaveBeenCalledOnce());
+
+  const outcome = await Promise.race([
+    transport.stop().then(() => "stopped"),
+    new Promise<"timed_out">((resolve) =>
+      setTimeout(() => resolve("timed_out"), 100),
+    ),
+  ]);
+
+  expect(outcome).toBe("stopped");
+  expect(deliveryChannel.leave).toHaveBeenCalled();
+  expect(deliveryChannel.push).toHaveBeenCalledOnce();
+
+  invitationHandler({
+    protocol: "channel_delivery_v1",
+    deliveryId: "dlv_delivery_02",
+    canonicalThreadId: "thread_02",
+  });
+  expect(control.push).toHaveBeenCalledOnce();
+});
+
 test("still sends a failed terminal when complete terminal fails", async () => {
   const deliveryChannel = channel();
   const { RealtimeGatewayPushError } = await import("./realtime-gateway.js");
@@ -589,10 +657,10 @@ test("rejects prepared deliveries with incomplete turn fields", async () => {
     deliveryId: "dlv_delivery_01",
     canonicalThreadId: "thread_01",
   });
-  await transport.stop();
   await vi.waitFor(() => {
     expect(vi.mocked(control.join)).toHaveBeenCalled();
   });
+  await transport.stop();
   expect(deliveryChannel.leave).toHaveBeenCalled();
   // Invalid prepared turn must not emit a complete terminal packet.
   const terminalPackets = vi

--- a/packages/channels-intelligence/src/delivery-transport.test.ts
+++ b/packages/channels-intelligence/src/delivery-transport.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { expect, test, vi } from "vitest";
 import {
   ChannelProviderDeliveryError,
   ChannelDeliverySession,
@@ -46,387 +46,427 @@ function channel(
   };
 }
 
-describe("Channel delivery transport", () => {
-  it("claims an invitation and consumes the one-use token on delivery join", async () => {
-    const deliveryChannel = channel();
-    const control: RealtimeGatewaySession = {
-      push: vi.fn().mockResolvedValue({
-        result: "claimed",
-        deliveryId: "dlv_delivery_01",
-        ownerGeneration: 7,
-        joinToken: "chj_token_01",
-        joinTokenExpiresAt: "2099-07-29T16:01:00.000Z",
-        deliveryExpiresAt: "2099-07-29T17:00:00.000Z",
-      }),
-      on: vi.fn(),
-      join: vi.fn().mockResolvedValue(deliveryChannel),
-    };
-    const transport = new ChannelDeliveryTransport({
-      session: control,
-      runtimeInstanceId: "rti_runtime_01",
-    });
-    const handled = vi.fn().mockResolvedValue(undefined);
-
-    transport.start(handled);
-    const invitationHandler = vi.mocked(control.on).mock.calls[0]![1];
-    invitationHandler({
-      protocol: "channel_delivery_v1",
+test("claims an invitation and consumes the one-use token on delivery join", async () => {
+  const deliveryChannel = channel();
+  const control: RealtimeGatewaySession = {
+    push: vi.fn().mockResolvedValue({
+      result: "claimed",
       deliveryId: "dlv_delivery_01",
-      channelName: "support",
-      adapter: "slack",
-    });
-    await vi.waitFor(() => expect(handled).toHaveBeenCalledOnce());
-
-    expect(control.push).toHaveBeenCalledWith("claim", {
-      protocol: "channel_delivery_v1",
-      deliveryId: "dlv_delivery_01",
-      runtimeInstanceId: "rti_runtime_01",
-    });
-    expect(control.join).toHaveBeenCalledWith("delivery:dlv_delivery_01", {
-      protocol: "channel_delivery_v1",
-      deliveryId: "dlv_delivery_01",
-      runtimeInstanceId: "rti_runtime_01",
       ownerGeneration: 7,
       joinToken: "chj_token_01",
-    });
+      joinTokenExpiresAt: "2099-07-29T16:01:00.000Z",
+      deliveryExpiresAt: "2099-07-29T17:00:00.000Z",
+    }),
+    on: vi.fn(),
+    join: vi.fn().mockResolvedValue(deliveryChannel),
+  };
+  const transport = new ChannelDeliveryTransport({
+    session: control,
+    runtimeInstanceId: "rti_runtime_01",
   });
+  const handled = vi.fn().mockResolvedValue(undefined);
 
-  it("retries the exact packet after reconnect and calls no second sequence", async () => {
-    const first = channel();
-    const second = channel();
-    vi.mocked(first.push).mockRejectedValueOnce(new Error("socket dropped"));
-    const reconnect = vi.fn().mockResolvedValue({
-      channel: second,
-      owner: {
-        ownerGeneration: 8,
-        runtimeInstanceId: "rti_runtime_01",
-      },
-      deliveryExpiresAt: "2099-07-29T18:00:00.000Z",
-    });
-    const session = new ChannelDeliverySession(
-      preparedDelivery(),
-      {
-        ownerGeneration: 7,
-        runtimeInstanceId: "rti_runtime_01",
-      },
-      first,
-      reconnect,
-    );
-
-    const result = await session.effect("response_01", {
-      kind: "slack.message.create",
-      text: "Hello",
-    });
-
-    expect(reconnect).toHaveBeenCalledOnce();
-    expect(first.push).toHaveBeenCalledOnce();
-    expect(second.push).toHaveBeenCalledOnce();
-    const retried = vi.mocked(second.push).mock.calls[0]![1] as {
-      ownerGeneration: number;
-      seq: number;
-      effectId: string;
-    };
-    const original = vi.mocked(first.push).mock.calls[0]![1] as {
-      ownerGeneration: number;
-      seq: number;
-      effectId: string;
-    };
-    // Exact unacked packet keeps original ownerGeneration on soft retry;
-    // subsequent packets use the refreshed generation (next test).
-    expect(retried.seq).toBe(original.seq);
-    expect(retried.effectId).toBe(original.effectId);
-    expect(retried.ownerGeneration).toBe(7);
-    expect(result).toEqual({ providerReference: "pref_v1_message_01" });
+  transport.start(handled);
+  const invitationHandler = vi.mocked(control.on).mock.calls[0]![1];
+  invitationHandler({
+    protocol: "channel_delivery_v1",
+    deliveryId: "dlv_delivery_01",
+    channelName: "support",
+    adapter: "slack",
   });
+  await vi.waitFor(() => expect(handled).toHaveBeenCalledOnce());
 
-  it("still sends a failed terminal when complete terminal fails", async () => {
-    const deliveryChannel = channel();
-    const { RealtimeGatewayPushError } = await import("./realtime-gateway.js");
-    let terminalAttempts = 0;
-    vi.mocked(deliveryChannel.push).mockImplementation((_event, packet) => {
-      const body = packet as { payload?: { kind?: string } };
-      if (body.payload?.kind === "channel.delivery.terminal") {
-        terminalAttempts += 1;
-        if (terminalAttempts === 1) {
-          // Permanent push error (not soft reconnect) so we do not thrash.
-          return Promise.reject(
-            new RealtimeGatewayPushError(
-              "packet",
-              "conflict",
-              "terminal push dropped",
-            ),
-          );
-        }
-      }
-      return Promise.resolve({
-        ...(packet as object),
-        phase: "applied",
-        result: {},
-      });
-    });
-    const session = new ChannelDeliverySession(
-      preparedDelivery(),
-      {
-        ownerGeneration: 7,
-        runtimeInstanceId: "rti_runtime_01",
-      },
-      deliveryChannel,
-      vi.fn(),
-    );
-
-    await expect(
-      session.terminal({
-        status: "complete",
-        code: "provider_delivery_complete",
-      }),
-    ).rejects.toBeInstanceOf(RealtimeGatewayPushError);
-
-    await session.terminal({
-      status: "failed",
-      code: "runtime_handler_failed",
-    });
-
-    expect(terminalAttempts).toBe(2);
+  expect(control.push).toHaveBeenCalledWith("claim", {
+    protocol: "channel_delivery_v1",
+    deliveryId: "dlv_delivery_01",
+    runtimeInstanceId: "rti_runtime_01",
   });
-
-  it("refreshes owner generation on packets after reconnect", async () => {
-    const first = channel();
-    const second = channel();
-    vi.mocked(first.push).mockRejectedValueOnce(new Error("socket dropped"));
-    const reconnect = vi.fn().mockResolvedValue({
-      channel: second,
-      owner: {
-        ownerGeneration: 9,
-        runtimeInstanceId: "rti_runtime_01",
-      },
-    });
-    const session = new ChannelDeliverySession(
-      preparedDelivery(),
-      {
-        ownerGeneration: 7,
-        runtimeInstanceId: "rti_runtime_01",
-      },
-      first,
-      reconnect,
-    );
-
-    await session.effect("response_01", {
-      kind: "slack.message.create",
-      text: "Hello",
-    });
-    await session.effect("response_02", {
-      kind: "slack.message.create",
-      text: "World",
-    });
-
-    const secondPacket = vi.mocked(second.push).mock.calls[1]![1] as {
-      ownerGeneration: number;
-      seq: number;
-    };
-    expect(secondPacket.ownerGeneration).toBe(9);
-    expect(secondPacket.seq).toBe(1);
+  expect(control.join).toHaveBeenCalledWith("delivery:dlv_delivery_01", {
+    protocol: "channel_delivery_v1",
+    deliveryId: "dlv_delivery_01",
+    runtimeInstanceId: "rti_runtime_01",
+    ownerGeneration: 7,
+    joinToken: "chj_token_01",
   });
+});
 
-  it("closes the packet path after a permanent push failure", async () => {
-    const deliveryChannel = channel();
-    const { RealtimeGatewayPushError } = await import("./realtime-gateway.js");
-    vi.mocked(deliveryChannel.push).mockRejectedValue(
-      new RealtimeGatewayPushError("packet", "conflict", "sequence conflict"),
-    );
-    const session = new ChannelDeliverySession(
-      preparedDelivery(),
-      {
-        ownerGeneration: 7,
-        runtimeInstanceId: "rti_runtime_01",
-      },
-      deliveryChannel,
-      vi.fn(),
-    );
-
-    await expect(
-      session.effect("response_01", {
-        kind: "slack.message.create",
-        text: "Hello",
-      }),
-    ).rejects.toBeInstanceOf(RealtimeGatewayPushError);
-
-    await expect(
-      session.effect("response_02", {
-        kind: "slack.message.create",
-        text: "World",
-      }),
-    ).rejects.toThrow(/packet path is closed/);
-  });
-
-  it("still allows stream.stop after a permanent non-terminal failure", async () => {
-    const deliveryChannel = channel();
-    const { RealtimeGatewayPushError } = await import("./realtime-gateway.js");
-    let pushCount = 0;
-    vi.mocked(deliveryChannel.push).mockImplementation((_event, packet) => {
-      pushCount += 1;
-      const body = packet as { payload?: { kind?: string } };
-      if (body.payload?.kind === "slack.stream.append") {
-        return Promise.reject(
-          new RealtimeGatewayPushError("packet", "conflict", "append failed"),
-        );
-      }
-      return Promise.resolve({
-        ...(packet as object),
-        phase: "applied",
-        result: { providerReference: "pref_v1_message_01" },
-      });
-    });
-    const session = new ChannelDeliverySession(
-      preparedDelivery(),
-      {
-        ownerGeneration: 7,
-        runtimeInstanceId: "rti_runtime_01",
-      },
-      deliveryChannel,
-      vi.fn(),
-    );
-
-    await session.effect("response_01", { kind: "slack.stream.start" });
-    await expect(
-      session.effect("response_01", {
-        kind: "slack.stream.append",
-        providerReference: "pref_v1_message_01",
-        delta: "x",
-        beforeTextDigest: "a".repeat(64),
-        afterTextDigest: "b".repeat(64),
-      }),
-    ).rejects.toBeInstanceOf(RealtimeGatewayPushError);
-
-    await session.effect("response_01", {
-      kind: "slack.stream.stop",
-      providerReference: "pref_v1_message_01",
-      finalTextDigest: "c".repeat(64),
-    });
-    expect(pushCount).toBe(3);
-    const kinds = vi
-      .mocked(deliveryChannel.push)
-      .mock.calls.map(
-        (call) => (call[1] as { payload?: { kind?: string } }).payload?.kind,
-      );
-    expect(kinds).toEqual([
-      "slack.stream.start",
-      "slack.stream.append",
-      "slack.stream.stop",
-    ]);
-  });
-
-  it("does not count stream.stop alone as provider output", async () => {
-    const deliveryChannel = channel();
-    const session = new ChannelDeliverySession(
-      preparedDelivery(),
-      {
-        ownerGeneration: 7,
-        runtimeInstanceId: "rti_runtime_01",
-      },
-      deliveryChannel,
-      vi.fn(),
-    );
-
-    await session.effect("response_01", {
-      kind: "slack.stream.stop",
-      providerReference: "pref_v1_message_01",
-      finalTextDigest: "c".repeat(64),
-    });
-    expect(session.hasProviderOutput()).toBe(false);
-  });
-
-  it("classifies timeout/expiry errors from message text", async () => {
-    const { safeChannelErrorMetadata } =
-      await import("./delivery-transport.js");
-    expect(
-      safeChannelErrorMetadata(
-        new Error("realtime gateway delivery join timed out"),
-      ),
-    ).toEqual({ errorCategory: "timeout" });
-    expect(
-      safeChannelErrorMetadata(new Error("Channel delivery ownership expired")),
-    ).toEqual({ errorCategory: "timeout" });
-  });
-
-  it("rejects prepared deliveries with incomplete turn fields", async () => {
-    const badPrepared = {
-      ...preparedDelivery(),
-      turn: {
-        eventId: "evt_bad",
-        receivedAt: "2026-07-29T17:00:00.000Z",
-        // command kind without required `command` field
-        input: { kind: "command" as const },
-        actor: { externalUserId: "U1" },
-      },
-    };
-    const deliveryChannel = channel(
-      badPrepared as unknown as ReturnType<typeof preparedDelivery>,
-    );
-    const control: RealtimeGatewaySession = {
-      push: vi.fn().mockResolvedValue({
-        result: "claimed",
-        deliveryId: "dlv_delivery_01",
-        ownerGeneration: 1,
-        joinToken: "chj_token_01",
-      }),
-      on: vi.fn(),
-      join: vi.fn().mockResolvedValue(deliveryChannel),
-    };
-    const log = vi.fn();
-    const transport = new ChannelDeliveryTransport({
-      session: control,
+test("retries the exact packet after reconnect and calls no second sequence", async () => {
+  const first = channel();
+  const second = channel();
+  vi.mocked(first.push).mockRejectedValueOnce(new Error("socket dropped"));
+  const reconnect = vi.fn().mockResolvedValue({
+    channel: second,
+    owner: {
+      ownerGeneration: 8,
       runtimeInstanceId: "rti_runtime_01",
-      log,
-    });
-    transport.start(async () => undefined);
-    const invitationHandler = vi.mocked(control.on).mock.calls[0]![1] as (
-      invitation: unknown,
-    ) => void;
-    invitationHandler({
-      protocol: "channel_delivery_v1",
-      deliveryId: "dlv_delivery_01",
-    });
-    await transport.stop();
-    await vi.waitFor(() => {
-      expect(vi.mocked(control.join)).toHaveBeenCalled();
-    });
-    expect(deliveryChannel.leave).toHaveBeenCalled();
-    // Invalid prepared turn must not emit a complete terminal packet.
-    const terminalPackets = vi
-      .mocked(deliveryChannel.push)
-      .mock.calls.filter(
-        (call) =>
-          (call[1] as { payload?: { kind?: string } }).payload?.kind ===
-          "channel.delivery.terminal",
-      );
-    expect(terminalPackets.length).toBe(0);
+    },
+    deliveryExpiresAt: "2099-07-29T18:00:00.000Z",
+  });
+  const session = new ChannelDeliverySession(
+    preparedDelivery(),
+    {
+      ownerGeneration: 7,
+      runtimeInstanceId: "rti_runtime_01",
+    },
+    first,
+    reconnect,
+  );
+
+  const result = await session.effect("response_01", {
+    kind: "slack.message.create",
+    text: "Hello",
   });
 
-  it("surfaces an applied provider failure as an already-terminal error", async () => {
-    const deliveryChannel = channel();
-    vi.mocked(deliveryChannel.push).mockImplementation((_event, packet) =>
+  expect(reconnect).toHaveBeenCalledOnce();
+  expect(first.push).toHaveBeenCalledOnce();
+  expect(second.push).toHaveBeenCalledOnce();
+  const retried = vi.mocked(second.push).mock.calls[0]![1] as {
+    ownerGeneration: number;
+    seq: number;
+    packetId: string;
+  };
+  const original = vi.mocked(first.push).mock.calls[0]![1] as {
+    ownerGeneration: number;
+    seq: number;
+    packetId: string;
+  };
+  // Exact unacked packet keeps original ownerGeneration on soft retry;
+  // subsequent packets use the refreshed generation (next test).
+  expect(retried.seq).toBe(original.seq);
+  expect(retried.packetId).toBe(original.packetId);
+  expect(retried.ownerGeneration).toBe(7);
+  expect(result).toEqual({ providerReference: "pref_v1_message_01" });
+});
+
+test("polls the same packet after a retry-wait result", async () => {
+  const deliveryChannel = channel();
+  vi.mocked(deliveryChannel.push)
+    .mockImplementationOnce((_event, packet) =>
+      Promise.resolve({
+        ...(packet as object),
+        phase: "retry_wait",
+        retryAt: "2000-01-01T00:00:00.000Z",
+        result: {
+          status: "retry_wait",
+          code: "provider_rate_limited",
+        },
+      }),
+    )
+    .mockImplementationOnce((_event, packet) =>
       Promise.resolve({
         ...(packet as object),
         phase: "applied",
-        result: { error: "provider_call_failed", status: "failed" },
+        result: { providerReference: "pref_v1_message_01" },
       }),
     );
-    const session = new ChannelDeliverySession(
-      preparedDelivery(),
-      {
-        ownerGeneration: 7,
-        runtimeInstanceId: "rti_runtime_01",
-      },
-      deliveryChannel,
-      vi.fn(),
-    );
+  const session = new ChannelDeliverySession(
+    preparedDelivery(),
+    {
+      ownerGeneration: 7,
+      runtimeInstanceId: "rti_runtime_01",
+    },
+    deliveryChannel,
+    vi.fn(),
+  );
 
-    await expect(
-      session.effect("response_01", {
-        kind: "slack.message.create",
-        text: "Hello",
-      }),
-    ).rejects.toBeInstanceOf(ChannelProviderDeliveryError);
-    expect(session.hasProviderOutput()).toBe(false);
+  const result = await session.effect("response_01", {
+    kind: "slack.message.create",
+    text: "Hello",
   });
+
+  expect(deliveryChannel.push).toHaveBeenCalledTimes(2);
+  const firstPacket = vi.mocked(deliveryChannel.push).mock.calls[0]![1];
+  const secondPacket = vi.mocked(deliveryChannel.push).mock.calls[1]![1];
+  expect(secondPacket).toEqual(firstPacket);
+  expect(result).toEqual({ providerReference: "pref_v1_message_01" });
+});
+
+test("still sends a failed terminal when complete terminal fails", async () => {
+  const deliveryChannel = channel();
+  const { RealtimeGatewayPushError } = await import("./realtime-gateway.js");
+  let terminalAttempts = 0;
+  vi.mocked(deliveryChannel.push).mockImplementation((_event, packet) => {
+    const body = packet as { payload?: { kind?: string } };
+    if (body.payload?.kind === "channel.delivery.terminal") {
+      terminalAttempts += 1;
+      if (terminalAttempts === 1) {
+        // Permanent push error (not soft reconnect) so we do not thrash.
+        return Promise.reject(
+          new RealtimeGatewayPushError(
+            "packet",
+            "conflict",
+            "terminal push dropped",
+          ),
+        );
+      }
+    }
+    return Promise.resolve({
+      ...(packet as object),
+      phase: "applied",
+      result: {},
+    });
+  });
+  const session = new ChannelDeliverySession(
+    preparedDelivery(),
+    {
+      ownerGeneration: 7,
+      runtimeInstanceId: "rti_runtime_01",
+    },
+    deliveryChannel,
+    vi.fn(),
+  );
+
+  await expect(
+    session.terminal({
+      status: "complete",
+      code: "provider_delivery_complete",
+    }),
+  ).rejects.toBeInstanceOf(RealtimeGatewayPushError);
+
+  await session.terminal({
+    status: "failed",
+    code: "runtime_handler_failed",
+  });
+
+  expect(terminalAttempts).toBe(2);
+});
+
+test("refreshes owner generation on packets after reconnect", async () => {
+  const first = channel();
+  const second = channel();
+  vi.mocked(first.push).mockRejectedValueOnce(new Error("socket dropped"));
+  const reconnect = vi.fn().mockResolvedValue({
+    channel: second,
+    owner: {
+      ownerGeneration: 9,
+      runtimeInstanceId: "rti_runtime_01",
+    },
+  });
+  const session = new ChannelDeliverySession(
+    preparedDelivery(),
+    {
+      ownerGeneration: 7,
+      runtimeInstanceId: "rti_runtime_01",
+    },
+    first,
+    reconnect,
+  );
+
+  await session.effect("response_01", {
+    kind: "slack.message.create",
+    text: "Hello",
+  });
+  await session.effect("response_02", {
+    kind: "slack.message.create",
+    text: "World",
+  });
+
+  const secondPacket = vi.mocked(second.push).mock.calls[1]![1] as {
+    ownerGeneration: number;
+    seq: number;
+  };
+  expect(secondPacket.ownerGeneration).toBe(9);
+  expect(secondPacket.seq).toBe(1);
+});
+
+test("closes the packet path after a permanent push failure", async () => {
+  const deliveryChannel = channel();
+  const { RealtimeGatewayPushError } = await import("./realtime-gateway.js");
+  vi.mocked(deliveryChannel.push).mockRejectedValue(
+    new RealtimeGatewayPushError("packet", "conflict", "sequence conflict"),
+  );
+  const session = new ChannelDeliverySession(
+    preparedDelivery(),
+    {
+      ownerGeneration: 7,
+      runtimeInstanceId: "rti_runtime_01",
+    },
+    deliveryChannel,
+    vi.fn(),
+  );
+
+  await expect(
+    session.effect("response_01", {
+      kind: "slack.message.create",
+      text: "Hello",
+    }),
+  ).rejects.toBeInstanceOf(RealtimeGatewayPushError);
+
+  await expect(
+    session.effect("response_02", {
+      kind: "slack.message.create",
+      text: "World",
+    }),
+  ).rejects.toThrow(/packet path is closed/);
+});
+
+test("still allows stream.stop after a permanent non-terminal failure", async () => {
+  const deliveryChannel = channel();
+  const { RealtimeGatewayPushError } = await import("./realtime-gateway.js");
+  let pushCount = 0;
+  vi.mocked(deliveryChannel.push).mockImplementation((_event, packet) => {
+    pushCount += 1;
+    const body = packet as { payload?: { kind?: string } };
+    if (body.payload?.kind === "slack.stream.append") {
+      return Promise.reject(
+        new RealtimeGatewayPushError("packet", "conflict", "append failed"),
+      );
+    }
+    return Promise.resolve({
+      ...(packet as object),
+      phase: "applied",
+      result: { providerReference: "pref_v1_message_01" },
+    });
+  });
+  const session = new ChannelDeliverySession(
+    preparedDelivery(),
+    {
+      ownerGeneration: 7,
+      runtimeInstanceId: "rti_runtime_01",
+    },
+    deliveryChannel,
+    vi.fn(),
+  );
+
+  await session.effect("response_01", { kind: "slack.stream.start" });
+  await expect(
+    session.effect("response_01", {
+      kind: "slack.stream.append",
+      providerReference: "pref_v1_message_01",
+      delta: "x",
+      beforeTextDigest: "a".repeat(64),
+      afterTextDigest: "b".repeat(64),
+    }),
+  ).rejects.toBeInstanceOf(RealtimeGatewayPushError);
+
+  await session.effect("response_01", {
+    kind: "slack.stream.stop",
+    providerReference: "pref_v1_message_01",
+    finalTextDigest: "c".repeat(64),
+  });
+  expect(pushCount).toBe(3);
+  const kinds = vi
+    .mocked(deliveryChannel.push)
+    .mock.calls.map(
+      (call) => (call[1] as { payload?: { kind?: string } }).payload?.kind,
+    );
+  expect(kinds).toEqual([
+    "slack.stream.start",
+    "slack.stream.append",
+    "slack.stream.stop",
+  ]);
+});
+
+test("does not count stream.stop alone as provider output", async () => {
+  const deliveryChannel = channel();
+  const session = new ChannelDeliverySession(
+    preparedDelivery(),
+    {
+      ownerGeneration: 7,
+      runtimeInstanceId: "rti_runtime_01",
+    },
+    deliveryChannel,
+    vi.fn(),
+  );
+
+  await session.effect("response_01", {
+    kind: "slack.stream.stop",
+    providerReference: "pref_v1_message_01",
+    finalTextDigest: "c".repeat(64),
+  });
+  expect(session.hasProviderOutput()).toBe(false);
+});
+
+test("classifies timeout/expiry errors from message text", async () => {
+  const { safeChannelErrorMetadata } = await import("./delivery-transport.js");
+  expect(
+    safeChannelErrorMetadata(
+      new Error("realtime gateway delivery join timed out"),
+    ),
+  ).toEqual({ errorCategory: "timeout" });
+  expect(
+    safeChannelErrorMetadata(new Error("Channel delivery ownership expired")),
+  ).toEqual({ errorCategory: "timeout" });
+});
+
+test("rejects prepared deliveries with incomplete turn fields", async () => {
+  const badPrepared = {
+    ...preparedDelivery(),
+    turn: {
+      eventId: "evt_bad",
+      receivedAt: "2026-07-29T17:00:00.000Z",
+      // command kind without required `command` field
+      input: { kind: "command" as const },
+      actor: { externalUserId: "U1" },
+    },
+  };
+  const deliveryChannel = channel(
+    badPrepared as unknown as ReturnType<typeof preparedDelivery>,
+  );
+  const control: RealtimeGatewaySession = {
+    push: vi.fn().mockResolvedValue({
+      result: "claimed",
+      deliveryId: "dlv_delivery_01",
+      ownerGeneration: 1,
+      joinToken: "chj_token_01",
+    }),
+    on: vi.fn(),
+    join: vi.fn().mockResolvedValue(deliveryChannel),
+  };
+  const log = vi.fn();
+  const transport = new ChannelDeliveryTransport({
+    session: control,
+    runtimeInstanceId: "rti_runtime_01",
+    log,
+  });
+  transport.start(async () => undefined);
+  const invitationHandler = vi.mocked(control.on).mock.calls[0]![1] as (
+    invitation: unknown,
+  ) => void;
+  invitationHandler({
+    protocol: "channel_delivery_v1",
+    deliveryId: "dlv_delivery_01",
+  });
+  await transport.stop();
+  await vi.waitFor(() => {
+    expect(vi.mocked(control.join)).toHaveBeenCalled();
+  });
+  expect(deliveryChannel.leave).toHaveBeenCalled();
+  // Invalid prepared turn must not emit a complete terminal packet.
+  const terminalPackets = vi
+    .mocked(deliveryChannel.push)
+    .mock.calls.filter(
+      (call) =>
+        (call[1] as { payload?: { kind?: string } }).payload?.kind ===
+        "channel.delivery.terminal",
+    );
+  expect(terminalPackets.length).toBe(0);
+});
+
+test("surfaces a failed provider result as an already-terminal error", async () => {
+  const deliveryChannel = channel();
+  vi.mocked(deliveryChannel.push).mockImplementation((_event, packet) =>
+    Promise.resolve({
+      ...(packet as object),
+      phase: "failed",
+      result: { error: "provider_call_failed", status: "failed" },
+    }),
+  );
+  const session = new ChannelDeliverySession(
+    preparedDelivery(),
+    {
+      ownerGeneration: 7,
+      runtimeInstanceId: "rti_runtime_01",
+    },
+    deliveryChannel,
+    vi.fn(),
+  );
+
+  await expect(
+    session.effect("response_01", {
+      kind: "slack.message.create",
+      text: "Hello",
+    }),
+  ).rejects.toBeInstanceOf(ChannelProviderDeliveryError);
+  expect(session.hasProviderOutput()).toBe(false);
 });

--- a/packages/channels-intelligence/src/delivery-transport.ts
+++ b/packages/channels-intelligence/src/delivery-transport.ts
@@ -24,6 +24,7 @@ const INVITATION_EVENT = "delivery_invitation";
 const CLAIM_EVENT = "claim";
 const JOIN_TOKEN_EVENT = "join_token";
 const DEFAULT_MAX_CONCURRENT_DELIVERIES = 8;
+const SHUTDOWN_TIMEOUT_MS = 10_000;
 const PACKET_EVENT = "packet";
 
 export type ChannelDeliveryAdapter = "slack" | "teams";
@@ -91,6 +92,33 @@ export class ChannelProviderDeliveryError extends Error {
   }
 }
 
+class ChannelDeliveryStoppedError extends Error {
+  constructor() {
+    super("Channel delivery stopped");
+    this.name = "ChannelDeliveryStoppedError";
+  }
+}
+
+function throwIfStopped(signal: AbortSignal): void {
+  if (signal.aborted) throw new ChannelDeliveryStoppedError();
+}
+
+function waitUnlessStopped(ms: number, signal: AbortSignal): Promise<void> {
+  throwIfStopped(signal);
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      reject(new ChannelDeliveryStoppedError());
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 /**
  * Promise wrapper that records whether handler code observed a rejection.
  */
@@ -155,6 +183,7 @@ export class ChannelDeliverySession {
   /** After a successful terminal apply, refuse all further packets. */
   private terminalApplied = false;
   private owner: DeliveryOwner;
+  private left = false;
 
   constructor(
     readonly delivery: PreparedChannelDelivery,
@@ -166,6 +195,7 @@ export class ChannelDeliverySession {
       deliveryExpiresAt?: string;
     }>,
     private readonly files?: ChannelDeliveryFileClient,
+    private readonly signal: AbortSignal = new AbortController().signal,
   ) {
     this.owner = owner;
     this.channel = channel;
@@ -305,6 +335,8 @@ export class ChannelDeliverySession {
   }
 
   leave(): void {
+    if (this.left) return;
+    this.left = true;
     this.channel.leave();
   }
 
@@ -390,6 +422,7 @@ export class ChannelDeliverySession {
   ): Promise<ChannelDeliveryPacketAck> {
     let attempt = 0;
     while (Date.now() < Date.parse(this.delivery.deliveryExpiresAt)) {
+      throwIfStopped(this.signal);
       try {
         const acknowledgement = (await this.channel.push(
           PACKET_EVENT,
@@ -400,10 +433,12 @@ export class ChannelDeliverySession {
           return acknowledgement;
         }
         const retryAtMs = Date.parse(acknowledgement.retryAt ?? "");
-        await new Promise((resolve) =>
-          setTimeout(resolve, Math.max(0, retryAtMs - Date.now())),
+        await waitUnlessStopped(
+          Math.max(0, retryAtMs - Date.now()),
+          this.signal,
         );
       } catch (error) {
+        if (error instanceof ChannelDeliveryStoppedError) throw error;
         if (error instanceof RealtimeGatewayPushError) throw error;
         // Claim/join validation failures are permanent — do not thrash reconnect.
         if (
@@ -418,7 +453,7 @@ export class ChannelDeliverySession {
         attempt += 1;
         // Bound reconnect thrash: exponential backoff capped at 5s.
         const delayMs = Math.min(5_000, 50 * 2 ** Math.min(attempt, 6));
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        await waitUnlessStopped(delayMs, this.signal);
         if (Date.now() >= Date.parse(this.delivery.deliveryExpiresAt)) break;
         const refreshed = await this.reconnect();
         this.channel = refreshed.channel;
@@ -481,10 +516,12 @@ export interface ChannelDeliveryTransportOptions {
 /** Claims invitations and runs each delivery on its one-use delivery topic. */
 export class ChannelDeliveryTransport {
   private readonly active = new Map<string, Promise<void>>();
+  private readonly activeSessions = new Map<string, ChannelDeliverySession>();
   private readonly activeThreads = new Set<string>();
   private readonly files?: ChannelDeliveryFileClient;
   private readonly maxConcurrentDeliveries: number;
   private stopped = false;
+  private abortController = new AbortController();
   private invitationHandler?: (value: unknown) => void;
   private started = false;
   /** Latest handler; invitation callback always reads this so re-start re-arms. */
@@ -523,6 +560,9 @@ export class ChannelDeliveryTransport {
       delivery: PreparedChannelDelivery,
     ) => Promise<void>,
   ): void {
+    if (this.abortController.signal.aborted) {
+      this.abortController = new AbortController();
+    }
     this.stopped = false;
     this.deliveryHandler = handler;
     if (this.started && this.invitationHandler) {
@@ -552,11 +592,13 @@ export class ChannelDeliveryTransport {
         return;
       }
       const activeHandler = this.deliveryHandler;
+      const signal = this.abortController.signal;
       // Register into active before any await so stop() waits for this delivery.
       this.activeThreads.add(value.canonicalThreadId);
       const running = this.claimAndHandle(
         value.deliveryId,
         activeHandler,
+        signal,
       ).finally(() => {
         this.active.delete(value.deliveryId);
         this.activeThreads.delete(value.canonicalThreadId);
@@ -568,7 +610,17 @@ export class ChannelDeliveryTransport {
 
   async stop(): Promise<void> {
     this.stopped = true;
-    await Promise.allSettled(this.active.values());
+    this.abortController.abort();
+    for (const session of this.activeSessions.values()) session.leave();
+    const active = [...this.active.values()];
+    if (active.length === 0) return;
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(resolve, SHUTDOWN_TIMEOUT_MS);
+      void Promise.allSettled(active).then(() => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
   }
 
   private async claimAndHandle(
@@ -577,6 +629,7 @@ export class ChannelDeliveryTransport {
       session: ChannelDeliverySession,
       delivery: PreparedChannelDelivery,
     ) => Promise<void>,
+    signal: AbortSignal,
   ): Promise<void> {
     try {
       const claim = (await this.options.session.push(CLAIM_EVENT, {
@@ -585,6 +638,7 @@ export class ChannelDeliveryTransport {
         runtimeInstanceId: this.options.runtimeInstanceId,
       })) as ClaimResult;
       if (claim.result !== "claimed") return;
+      throwIfStopped(signal);
       const owner = assertClaim(
         claim,
         deliveryId,
@@ -647,8 +701,11 @@ export class ChannelDeliveryTransport {
         joined,
         reconnect,
         this.files,
+        signal,
       );
+      this.activeSessions.set(deliveryId, session);
       try {
+        throwIfStopped(signal);
         await handler(session, delivery);
         await session.terminal({
           status: "complete",
@@ -670,6 +727,7 @@ export class ChannelDeliveryTransport {
           ...safeChannelErrorMetadata(error),
         });
       } finally {
+        this.activeSessions.delete(deliveryId);
         session.leave();
       }
     } catch (error) {

--- a/packages/channels-intelligence/src/delivery-transport.ts
+++ b/packages/channels-intelligence/src/delivery-transport.ts
@@ -9,7 +9,6 @@ import {
   CHANNEL_DELIVERY_PROTOCOL,
   assertDeliveryPacket,
   assertProviderReference,
-  deliveryPayloadDigest,
 } from "./delivery-contracts.js";
 import type {
   ChannelDeliveryPacket,
@@ -185,10 +184,10 @@ export class ChannelDeliverySession {
 
   /** Send one provider-ready payload after the previous packet is applied. */
   effect(
-    responseId: string,
+    _responseId: string,
     payload: ProviderPayloadInput,
   ): Promise<Record<string, unknown>> {
-    return this.enqueue(responseId, payload).then((result) => {
+    return this.enqueue(payload).then((result) => {
       const error = typeof result.error === "string" ? result.error : undefined;
       const status =
         typeof result.status === "string" ? result.status : undefined;
@@ -219,7 +218,7 @@ export class ChannelDeliverySession {
     await this.sealAndWaitForTrackedOperations(payload.status === "complete");
     // Terminal remains sendable after effect failures so claimAndHandle can
     // report failed/uncertain; only a successful terminal seals the session.
-    await this.enqueue("response_terminal", {
+    await this.enqueue({
       kind: "channel.delivery.terminal",
       ...payload,
     });
@@ -321,7 +320,6 @@ export class ChannelDeliverySession {
   }
 
   private enqueue(
-    responseId: string,
     payload: ChannelProviderPayload | ChannelTerminalPayload,
   ): Promise<Record<string, unknown>> {
     const isTerminal = payload.kind === "channel.delivery.terminal";
@@ -341,7 +339,7 @@ export class ChannelDeliverySession {
           `Channel delivery ${this.delivery.deliveryId} packet path is closed`,
         );
       }
-      const packet = this.buildPacket(responseId, payload);
+      const packet = this.buildPacket(payload);
       this.unacknowledgedPacket = packet;
       try {
         // sendExactPacket retries the exact packet across soft transport
@@ -365,7 +363,6 @@ export class ChannelDeliverySession {
   }
 
   private buildPacket(
-    responseId: string,
     payload: ChannelProviderPayload | ChannelTerminalPayload,
   ): ChannelDeliveryPacket {
     if (
@@ -380,9 +377,7 @@ export class ChannelDeliverySession {
       runtimeInstanceId: this.owner.runtimeInstanceId,
       ownerGeneration: this.owner.ownerGeneration,
       seq: this.nextSeq,
-      effectId: `eff_${randomUUID().replaceAll("-", "")}`,
-      responseId,
-      payloadDigest: deliveryPayloadDigest(payload),
+      packetId: `pkt_${randomUUID().replaceAll("-", "")}`,
       payload,
     };
     assertDeliveryPacket(packet);
@@ -395,10 +390,18 @@ export class ChannelDeliverySession {
     let attempt = 0;
     while (Date.now() < Date.parse(this.delivery.deliveryExpiresAt)) {
       try {
-        return (await this.channel.push(
+        const acknowledgement = (await this.channel.push(
           PACKET_EVENT,
           packet,
         )) as ChannelDeliveryPacketAck;
+        this.assertExactAcknowledgement(packet, acknowledgement);
+        if (acknowledgement.phase !== "retry_wait") {
+          return acknowledgement;
+        }
+        const retryAtMs = Date.parse(acknowledgement.retryAt ?? "");
+        await new Promise((resolve) =>
+          setTimeout(resolve, Math.max(0, retryAtMs - Date.now())),
+        );
       } catch (error) {
         if (error instanceof RealtimeGatewayPushError) throw error;
         // Claim/join validation failures are permanent — do not thrash reconnect.
@@ -429,14 +432,22 @@ export class ChannelDeliverySession {
     acknowledgement: ChannelDeliveryPacketAck,
   ): void {
     if (
-      acknowledgement?.phase !== "applied" ||
+      !["applied", "retry_wait", "failed", "uncertain"].includes(
+        acknowledgement?.phase,
+      ) ||
       acknowledgement.deliveryId !== packet.deliveryId ||
       acknowledgement.seq !== packet.seq ||
-      acknowledgement.effectId !== packet.effectId ||
-      acknowledgement.responseId !== packet.responseId ||
-      acknowledgement.payloadDigest !== packet.payloadDigest ||
+      acknowledgement.packetId !== packet.packetId ||
       typeof acknowledgement.result !== "object" ||
       acknowledgement.result === null
+    ) {
+      throw new TypeError(
+        "Gateway returned a conflicting packet acknowledgement",
+      );
+    }
+    if (
+      acknowledgement.phase === "retry_wait" &&
+      !Number.isFinite(Date.parse(acknowledgement.retryAt ?? ""))
     ) {
       throw new TypeError(
         "Gateway returned a conflicting packet acknowledgement",

--- a/packages/channels-intelligence/src/delivery-transport.ts
+++ b/packages/channels-intelligence/src/delivery-transport.ts
@@ -166,7 +166,7 @@ class ObservableTrackedPromise<T> extends Promise<T> {
 }
 
 /** One claimed delivery and its exact unacknowledged packet. */
-export class ChannelDeliverySession {
+export class ClaimedChannelDelivery {
   private nextSeq = 0;
   private tail: Promise<unknown> = Promise.resolve();
   private channel: RealtimeGatewayDeliveryChannel;
@@ -234,6 +234,16 @@ export class ChannelDeliverySession {
           status,
         );
       }
+      const capabilityError =
+        typeof result.capabilityError === "string"
+          ? result.capabilityError
+          : undefined;
+      if (
+        payload.kind === "teams.image.create" &&
+        capabilityError === "teams_image_rejected"
+      ) {
+        return result;
+      }
       // Cleanup stream.stop must not count as user-visible provider output —
       // otherwise failed-before-output terminals misclassify after stop-only.
       const kind = typeof payload.kind === "string" ? payload.kind : undefined;
@@ -248,7 +258,7 @@ export class ChannelDeliverySession {
   async terminal(payload: Omit<ChannelTerminalPayload, "kind">): Promise<void> {
     await this.sealAndWaitForTrackedOperations(payload.status === "complete");
     // Terminal remains sendable after effect failures so claimAndHandle can
-    // report failed/uncertain; only a successful terminal seals the session.
+    // report failed/uncertain; only a successful terminal seals the delivery.
     await this.enqueue({
       kind: "channel.delivery.terminal",
       ...payload,
@@ -516,7 +526,7 @@ export interface ChannelDeliveryTransportOptions {
 /** Claims invitations and runs each delivery on its one-use delivery topic. */
 export class ChannelDeliveryTransport {
   private readonly active = new Map<string, Promise<void>>();
-  private readonly activeSessions = new Map<string, ChannelDeliverySession>();
+  private readonly activeDeliveries = new Map<string, ClaimedChannelDelivery>();
   private readonly activeThreads = new Set<string>();
   private readonly files?: ChannelDeliveryFileClient;
   private readonly maxConcurrentDeliveries: number;
@@ -526,7 +536,7 @@ export class ChannelDeliveryTransport {
   private started = false;
   /** Latest handler; invitation callback always reads this so re-start re-arms. */
   private deliveryHandler?: (
-    session: ChannelDeliverySession,
+    claimedDelivery: ClaimedChannelDelivery,
     delivery: PreparedChannelDelivery,
   ) => Promise<void>;
 
@@ -556,7 +566,7 @@ export class ChannelDeliveryTransport {
 
   start(
     handler: (
-      session: ChannelDeliverySession,
+      claimedDelivery: ClaimedChannelDelivery,
       delivery: PreparedChannelDelivery,
     ) => Promise<void>,
   ): void {
@@ -611,7 +621,7 @@ export class ChannelDeliveryTransport {
   async stop(): Promise<void> {
     this.stopped = true;
     this.abortController.abort();
-    for (const session of this.activeSessions.values()) session.leave();
+    for (const delivery of this.activeDeliveries.values()) delivery.leave();
     const active = [...this.active.values()];
     if (active.length === 0) return;
     await new Promise<void>((resolve) => {
@@ -626,7 +636,7 @@ export class ChannelDeliveryTransport {
   private async claimAndHandle(
     deliveryId: string,
     handler: (
-      session: ChannelDeliverySession,
+      claimedDelivery: ClaimedChannelDelivery,
       delivery: PreparedChannelDelivery,
     ) => Promise<void>,
     signal: AbortSignal,
@@ -695,7 +705,7 @@ export class ChannelDeliveryTransport {
           deliveryExpiresAt: rejoinDelivery.deliveryExpiresAt,
         };
       };
-      const session = new ChannelDeliverySession(
+      const claimedDelivery = new ClaimedChannelDelivery(
         delivery,
         owner,
         joined,
@@ -703,19 +713,19 @@ export class ChannelDeliveryTransport {
         this.files,
         signal,
       );
-      this.activeSessions.set(deliveryId, session);
+      this.activeDeliveries.set(deliveryId, claimedDelivery);
       try {
         throwIfStopped(signal);
-        await handler(session, delivery);
-        await session.terminal({
+        await handler(claimedDelivery, delivery);
+        await claimedDelivery.terminal({
           status: "complete",
           code: "provider_delivery_complete",
         });
       } catch (error) {
         if (!(error instanceof ChannelProviderDeliveryError)) {
-          await session
+          await claimedDelivery
             .terminal({
-              status: session.hasProviderOutput()
+              status: claimedDelivery.hasProviderOutput()
                 ? "failed"
                 : "failed_before_output",
               code: "runtime_handler_failed",
@@ -727,8 +737,8 @@ export class ChannelDeliveryTransport {
           ...safeChannelErrorMetadata(error),
         });
       } finally {
-        this.activeSessions.delete(deliveryId);
-        session.leave();
+        this.activeDeliveries.delete(deliveryId);
+        claimedDelivery.leave();
       }
     } catch (error) {
       this.options.log?.("channel delivery claim or join failed", {

--- a/packages/channels-intelligence/src/delivery-transport.ts
+++ b/packages/channels-intelligence/src/delivery-transport.ts
@@ -23,6 +23,7 @@ import { buildContentParts } from "./content-parts.js";
 const INVITATION_EVENT = "delivery_invitation";
 const CLAIM_EVENT = "claim";
 const JOIN_TOKEN_EVENT = "join_token";
+const DEFAULT_MAX_CONCURRENT_DELIVERIES = 8;
 const PACKET_EVENT = "packet";
 
 export type ChannelDeliveryAdapter = "slack" | "teams";
@@ -469,6 +470,8 @@ interface ClaimResult {
 export interface ChannelDeliveryTransportOptions {
   session: RealtimeGatewaySession;
   runtimeInstanceId: string;
+  /** Maximum deliveries this Runtime may claim and execute at once. */
+  maxConcurrentDeliveries?: number;
   appApiBaseUrl?: string;
   apiKey?: string;
   fileFetch?: typeof fetch;
@@ -478,7 +481,9 @@ export interface ChannelDeliveryTransportOptions {
 /** Claims invitations and runs each delivery on its one-use delivery topic. */
 export class ChannelDeliveryTransport {
   private readonly active = new Map<string, Promise<void>>();
+  private readonly activeThreads = new Set<string>();
   private readonly files?: ChannelDeliveryFileClient;
+  private readonly maxConcurrentDeliveries: number;
   private stopped = false;
   private invitationHandler?: (value: unknown) => void;
   private started = false;
@@ -489,6 +494,16 @@ export class ChannelDeliveryTransport {
   ) => Promise<void>;
 
   constructor(private readonly options: ChannelDeliveryTransportOptions) {
+    this.maxConcurrentDeliveries =
+      options.maxConcurrentDeliveries ?? DEFAULT_MAX_CONCURRENT_DELIVERIES;
+    if (
+      !Number.isSafeInteger(this.maxConcurrentDeliveries) ||
+      this.maxConcurrentDeliveries < 1
+    ) {
+      throw new TypeError(
+        "maxConcurrentDeliveries must be a positive safe integer",
+      );
+    }
     if (options.appApiBaseUrl && options.apiKey) {
       this.files = new ChannelDeliveryFileClient({
         baseUrl: options.appApiBaseUrl,
@@ -524,12 +539,28 @@ export class ChannelDeliveryTransport {
       ) {
         return;
       }
+      if (this.active.size >= this.maxConcurrentDeliveries) {
+        this.options.log?.("channel delivery invitation declined", {
+          reason: "capacity",
+        });
+        return;
+      }
+      if (this.activeThreads.has(value.canonicalThreadId)) {
+        this.options.log?.("channel delivery invitation declined", {
+          reason: "thread_active",
+        });
+        return;
+      }
       const activeHandler = this.deliveryHandler;
       // Register into active before any await so stop() waits for this delivery.
+      this.activeThreads.add(value.canonicalThreadId);
       const running = this.claimAndHandle(
         value.deliveryId,
         activeHandler,
-      ).finally(() => this.active.delete(value.deliveryId));
+      ).finally(() => {
+        this.active.delete(value.deliveryId);
+        this.activeThreads.delete(value.canonicalThreadId);
+      });
       this.active.set(value.deliveryId, running);
     };
     this.options.session.on(INVITATION_EVENT, this.invitationHandler);
@@ -797,12 +828,15 @@ function isValidPreparedTurnInput(input: Record<string, unknown>): boolean {
 function isInvitation(value: unknown): value is {
   protocol: typeof CHANNEL_DELIVERY_PROTOCOL;
   deliveryId: string;
+  canonicalThreadId: string;
 } {
   return (
     isRecord(value) &&
     value.protocol === CHANNEL_DELIVERY_PROTOCOL &&
     typeof value.deliveryId === "string" &&
-    value.deliveryId.startsWith("dlv_")
+    value.deliveryId.startsWith("dlv_") &&
+    typeof value.canonicalThreadId === "string" &&
+    value.canonicalThreadId.length > 0
   );
 }
 

--- a/packages/channels-intelligence/src/index.ts
+++ b/packages/channels-intelligence/src/index.ts
@@ -5,7 +5,6 @@ export {
   DELIVERY_PACKET_MAX_BYTES,
   assertDeliveryPacket,
   deliveryPacketByteLength,
-  deliveryPayloadDigest,
 } from "./delivery-contracts.js";
 export type {
   ChannelDeliveryPacket,

--- a/packages/channels-intelligence/src/intelligence-state-store.ts
+++ b/packages/channels-intelligence/src/intelligence-state-store.ts
@@ -26,19 +26,16 @@ export interface IntelligenceStateStoreConfig {
 }
 
 /**
- * Durable {@link StateStore} for Channel Bots, backed by Intelligence app-api's
+ * Durable {@link StateStore} for managed Channels, backed by Intelligence app-api's
  * runtime-authed KV routes (`/api/channels/kv/*`). Only the `kv` facet is durable —
  * that is what the action registry (button/`ck:` snapshots) and thread state
  * use, so a HITL card posted before a Channel-loop restart still re-renders on
  * cold-cache dispatch and can be flipped in place.
  *
  * `list` / `lock` / `dedup` / `queue` delegate to an in-memory
- * {@link MemoryStore}. On the Channel Slack path these are not durability
- * critical: dedup is skipped at ingress (`adapter.skipIngressDedup`), the
- * per-conversation turn lock is process-local (a single Channel runtime; the
- * app-api delivery lease already fences work cross-instance), and list/queue
- * (transcripts/proactive) are unused. // ponytail: promote these to durable KV
- * only if the Channel runtime is ever horizontally scaled.
+ * {@link MemoryStore}. Managed ingress owns durable dedupe, and Intelligence
+ * owns durable delivery and Thread state. The remaining list, lock, dedup, and
+ * queue facets support adapter-local helpers only.
  */
 export class IntelligenceStateStore implements StateStore {
   private readonly local = new MemoryStore();

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.ts
@@ -226,10 +226,9 @@ export interface StartChannelsOverRealtimeGatewayOptions {
   maxConcurrentDeliveries?: number;
   /** Adapter kind declared to the gateway on join (default `"slack"`). */
   adapter?: string;
-  /** Intelligence app-api HTTP base URL. Enables file/history parity on the
-   * realtime path (OSS-476) — these are HTTP-only (the gateway relays the
-   * render-event stream, not bytes/history), reached with the {@link apiKey}
-   * above. Omit and file/history stay unavailable (graceful degradation). */
+  /** Intelligence app-api HTTP base URL for managed file and Thread history
+   * calls made with the {@link apiKey} above. Omit it to leave those calls
+   * unavailable. */
   appApiBaseUrl?: string;
   /** Activation env overrides (package versions, runtimeEnv); omitted fields
    * are gathered from the process and exposed in `handle.metadata`.

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.ts
@@ -84,6 +84,8 @@ export interface StartChannelsWithGatewayControlOptions {
    * activation, and re-minted on process/ChannelManager restart.
    */
   runtimeInstanceId: string;
+  /** Maximum deliveries this Runtime may claim and execute at once. */
+  maxConcurrentDeliveries?: number;
   /** Intelligence app-api HTTP base URL — enables file/history parity on the
    * realtime path (OSS-476), which are HTTP-only. With {@link apiKey}. */
   appApiBaseUrl?: string;
@@ -128,6 +130,9 @@ export async function startChannelsWithGatewayControl(
   const transport = new ChannelDeliveryTransport({
     runtimeInstanceId: opts.runtimeInstanceId,
     session: opts.session,
+    ...(opts.maxConcurrentDeliveries !== undefined
+      ? { maxConcurrentDeliveries: opts.maxConcurrentDeliveries }
+      : {}),
     ...(opts.appApiBaseUrl ? { appApiBaseUrl: opts.appApiBaseUrl } : {}),
     ...(opts.apiKey ? { apiKey: opts.apiKey } : {}),
     ...(opts.log ? { log: opts.log } : {}),
@@ -217,6 +222,8 @@ export interface StartChannelsOverRealtimeGatewayOptions {
    * replicas; reuse it only for transport reconnects of this activation.
    */
   runtimeInstanceId: string;
+  /** Maximum deliveries this Runtime may claim and execute at once. */
+  maxConcurrentDeliveries?: number;
   /** Adapter kind declared to the gateway on join (default `"slack"`). */
   adapter?: string;
   /** Intelligence app-api HTTP base URL. Enables file/history parity on the
@@ -291,6 +298,9 @@ export async function startChannelsOverRealtimeGateway(
     join: {
       protocol: CHANNEL_DELIVERY_PROTOCOL,
       runtimeInstanceId: config.runtimeInstanceId,
+      ...(config.maxConcurrentDeliveries !== undefined
+        ? { maxConcurrentDeliveries: config.maxConcurrentDeliveries }
+        : {}),
       channels: activation.declaredChannels.map((channel) => ({
         channelName: channel.channelName,
         adapter,

--- a/packages/channels-intelligence/src/realtime-gateway.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.test.ts
@@ -144,6 +144,7 @@ function makeFakeWebSocket(
               {
                 protocol: "channel_delivery_v1",
                 deliveryId: "dlv_first_invitation",
+                canonicalThreadId: "thread_first_invitation",
                 channelName: "opentag",
                 adapter: "slack",
               },
@@ -257,6 +258,7 @@ describe("connectRealtimeGateway", () => {
       {
         protocol: "channel_delivery_v1",
         deliveryId: "dlv_first_invitation",
+        canonicalThreadId: "thread_first_invitation",
         channelName: "opentag",
         adapter: "slack",
       },

--- a/packages/channels-intelligence/src/realtime-gateway.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.test.ts
@@ -8,6 +8,7 @@ import type { RealtimeGatewayConnectionState } from "./realtime-gateway.js";
 
 type JoinMode =
   | "ok"
+  | "invitation-before-join"
   | "error"
   | "never"
   | "error-undefined-reason"
@@ -121,6 +122,7 @@ function makeFakeWebSocket(
       }
       const isOkMode =
         mode === "ok" ||
+        mode === "invitation-before-join" ||
         mode === "ok-then-silent" ||
         mode === "give-up-then-recover";
       const status = isOkMode ? "ok" : "error";
@@ -131,11 +133,27 @@ function makeFakeWebSocket(
               status,
               ...(errorResponse() ? { response: errorResponse() } : {}),
             };
-      queueMicrotask(() =>
+      queueMicrotask(() => {
+        if (mode === "invitation-before-join" && isInitialJoin) {
+          this.onmessage?.({
+            data: JSON.stringify([
+              joinRef,
+              null,
+              topic,
+              "delivery_invitation",
+              {
+                protocol: "channel_delivery_v1",
+                deliveryId: "dlv_first_invitation",
+                channelName: "opentag",
+                adapter: "slack",
+              },
+            ]),
+          });
+        }
         this.onmessage?.({
           data: JSON.stringify([joinRef, ref, topic, "phx_reply", reply]),
-        }),
-      );
+        });
+      });
     }
 
     /**
@@ -216,6 +234,34 @@ describe("connectRealtimeGateway", () => {
 
     session.disconnect();
     expect(instances[0]!.closed).toBe(true);
+  });
+
+  it("delivers an invitation sent before the control join reply", async () => {
+    const { FakeWebSocket } = makeFakeWebSocket("invitation-before-join");
+    const session = await connectRealtimeGateway({
+      wsUrl: "wss://gateway.example/channels",
+      apiKey: "cpk-test",
+      projectId: 7,
+      join: {
+        protocol: "channel_delivery_v1",
+        runtimeInstanceId: "rti_1",
+        channels: [{ channelName: "opentag", adapter: "slack" }],
+      },
+      webSocket: FakeWebSocket,
+    });
+    const invitations: unknown[] = [];
+
+    session.on("delivery_invitation", (value) => invitations.push(value));
+
+    expect(invitations).toEqual([
+      {
+        protocol: "channel_delivery_v1",
+        deliveryId: "dlv_first_invitation",
+        channelName: "opentag",
+        adapter: "slack",
+      },
+    ]);
+    session.disconnect();
   });
 });
 

--- a/packages/channels-intelligence/src/realtime-gateway.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.ts
@@ -409,7 +409,8 @@ export interface ConnectedRealtimeGatewaySession extends RealtimeGatewaySession 
  * values stay private here; callers receive only {@link RealtimeGatewaySession}.
  *
  * The session is joined (declaring the runtime's channels) before the promise
- * resolves, so the caller can immediately stream render frames.
+ * resolves, so the caller can receive delivery invitations and send ordered
+ * provider effects.
  *
  * @param config - Gateway URL, auth, project scope, and join declaration.
  * @returns The connected channel with a `disconnect()` teardown.

--- a/packages/channels-intelligence/src/realtime-gateway.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.ts
@@ -442,6 +442,7 @@ export async function connectRealtimeGateway(
       ? T
       : never,
   });
+  const channel = socket.channel("control", config.join as object);
 
   // --- Initial-connect watchdog (OSS-623) ----------------------------------
   // Phoenix treats a failed FIRST connect exactly like a dropped one: it retries
@@ -619,9 +620,34 @@ export async function connectRealtimeGateway(
   }, connectTimeoutMs);
   (connectDeadline as unknown as { unref?: () => void }).unref?.();
 
-  socket.connect();
+  const pendingInvitations: unknown[] = [];
+  const invitationHandlers: Array<(payload: unknown) => void> = [];
+  const maxPendingInvitations = 1_000;
+  channel.on("delivery_invitation", (payload: unknown) => {
+    if (invitationHandlers.length > 0) {
+      for (const handler of invitationHandlers) handler(payload);
+      return;
+    }
+    if (pendingInvitations.length >= maxPendingInvitations) {
+      if (!initialJoinSettled) {
+        initialJoinSettled = true;
+        clearConnectDeadline();
+        closingIntentionally = true;
+        socket.disconnect();
+        failConnect(
+          new Error(
+            `realtime gateway sent more than ${maxPendingInvitations} invitations before control setup completed`,
+          ),
+        );
+      }
+      return;
+    }
+    pendingInvitations.push(payload);
+  });
 
-  const channel = socket.channel("control", config.join as object);
+  // The control channel and its invitation handler exist before the transport
+  // can open or the join can succeed, so an immediate Gateway wake is retained.
+  socket.connect();
 
   // --- Connection-health state machine -------------------------------------
   // `disconnect()` flips `closingIntentionally` first so our own teardown —
@@ -799,6 +825,15 @@ export async function connectRealtimeGateway(
           );
       }),
     on: (event, handler) => {
+      if (joinedChannel === channel && event === "delivery_invitation") {
+        invitationHandlers.push(handler);
+        const buffered = pendingInvitations.splice(
+          0,
+          pendingInvitations.length,
+        );
+        for (const payload of buffered) handler(payload);
+        return;
+      }
       joinedChannel.on(event, handler);
     },
     join: async (topic, payload) => {

--- a/packages/channels-slack/src/__tests__/event-renderer.test.ts
+++ b/packages/channels-slack/src/__tests__/event-renderer.test.ts
@@ -4,8 +4,8 @@ import { createRunRenderer } from "../event-renderer.js";
 
 /**
  * Fake {@link SlackRenderTransport} — records every post / update call in
- * order. This is exactly the seam the managed Connector Outbox will drive, so
- * the renderer is verified Bolt-free (no `WebClient`).
+ * order. Local and managed delivery both drive this transport seam, so the
+ * renderer is verified Bolt-free (no `WebClient`).
  */
 function makeFakeClient() {
   const posts: {

--- a/packages/channels-slack/src/codec.ts
+++ b/packages/channels-slack/src/codec.ts
@@ -5,8 +5,8 @@ import type { SlackNeutralEvent } from "./ingress-normalize.js";
 
 /**
  * Pure Slack codec — both directions, no Bolt and no Slack credentials. Shared
- * by the local Slack adapter and (via the Connector Outbox / webhook ingress,
- * OSS-362/363) the managed path, so platform semantics live in one place:
+ * by the local Slack adapter and managed webhook ingress, so platform
+ * semantics live in one place:
  *
  * - `renderEgress`: IR → Block Kit.
  * - `normalizeIngress`: raw Slack payload (Events API envelope or slash-command

--- a/packages/channels-slack/src/event-renderer.ts
+++ b/packages/channels-slack/src/event-renderer.ts
@@ -62,8 +62,8 @@ export function createRunRenderer(args: {
   /**
    * The credentialed Slack side-effects (setStatus / postMessage / update),
    * injected so this renderer never imports `@slack/web-api`. The native
-   * adapter wraps a `WebClient`; the managed Connector Outbox wraps its own
-   * sender.
+   * adapter wraps a `WebClient`; managed Intelligence delivery maps supported
+   * calls to provider effects.
    */
   transport: SlackRenderTransport;
   target: { channel: string; threadTs?: string };
@@ -157,7 +157,7 @@ export function createRunRenderer(args: {
   const setStatus = async (text: string): Promise<void> => {
     if (!status) return;
     try {
-      await transport.setStatus({
+      await transport.setStatus?.({
         channel_id: target.channel,
         thread_ts: status.threadTs,
         status: text,

--- a/packages/channels-slack/src/event-renderer.ts
+++ b/packages/channels-slack/src/event-renderer.ts
@@ -115,7 +115,7 @@ export function createRunRenderer(args: {
      * instead of creating or updating a second legacy message.
      */
     strict?: boolean;
-    /** Override the native text flush floor. Managed sessions use `0`. */
+    /** Override the native text flush floor. */
     minIntervalMs?: number;
     /**
      * Tuning for splitting a long reply across continuation messages. Passed

--- a/packages/channels-slack/src/index.ts
+++ b/packages/channels-slack/src/index.ts
@@ -1,8 +1,7 @@
 export { SlackConversationStore } from "./conversation-store.js";
 export type { AgentSession } from "./conversation-store.js";
 
-// Pure Slack codec (render + normalize) shared with the managed/Connector-Outbox
-// and webhook-ingress paths.
+// Pure Slack codec shared by local delivery and managed webhook ingress.
 export { slackCodec } from "./codec.js";
 export {
   normalizeSlackEvent,

--- a/packages/channels-slack/src/render/transport.ts
+++ b/packages/channels-slack/src/render/transport.ts
@@ -2,8 +2,7 @@
  * The credentialed Slack side-effects the run renderer performs, injected so
  * {@link createRunRenderer} (event-renderer.ts) stays free of `@slack/web-api`
  * (no `WebClient`, no Bolt). The native Slack adapter wraps a real `WebClient`;
- * the managed Connector Outbox wraps its own credentialed sender — both drive
- * the exact same renderer.
+ * the managed Intelligence path maps renderer calls to provider effects.
  *
  * These are the three ops the renderer calls directly. The four native
  * streaming ops (`chat.startStream`/`appendStream`/`stopStream`) are injected
@@ -14,7 +13,7 @@ export interface SlackRenderTransport {
    * `assistant.threads.setStatus` — the thread-anchored "is thinking…" /
    * "is using `tool`…" indicator. Passing an empty `status` clears it.
    */
-  setStatus(args: {
+  setStatus?(args: {
     channel_id: string;
     thread_ts: string;
     status: string;

--- a/packages/channels-teams/src/event-renderer.ts
+++ b/packages/channels-teams/src/event-renderer.ts
@@ -24,6 +24,8 @@ export function createRunRenderer(args: {
   post: (text: string) => Promise<string>;
   /** Edit a previously-posted streamed message. */
   update: (id: string, text: string) => Promise<void>;
+  /** Send the final edit through a priority transport lane. */
+  finalize?: (id: string, text: string) => Promise<void>;
   /** Optional typing indicator, fired once before a message's first post. */
   typing?: () => Promise<void>;
   interruptEventNames?: ReadonlySet<string>;
@@ -46,6 +48,7 @@ export function createRunRenderer(args: {
       s = new TeamsMessageStream({
         post: args.post,
         update: args.update,
+        finalize: args.finalize,
         typing: args.typing,
       });
       streams.set(messageId, s);

--- a/packages/channels-teams/src/message-stream.test.ts
+++ b/packages/channels-teams/src/message-stream.test.ts
@@ -51,6 +51,31 @@ describe("TeamsMessageStream", () => {
     }
   });
 
+  it("uses the final transport lane after a mid-stream post", async () => {
+    vi.useFakeTimers();
+    try {
+      const post = vi.fn(async () => "act-1");
+      const update = vi.fn(async () => {});
+      const finalize = vi.fn(async () => {});
+      const s = new TeamsMessageStream({
+        post,
+        update,
+        finalize,
+        minIntervalMs: 100,
+      });
+
+      s.append("A");
+      await vi.advanceTimersByTimeAsync(150);
+      s.append("AB");
+      await s.finish();
+
+      expect(finalize).toHaveBeenCalledWith("act-1", "AB");
+      expect(update).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("rejects finish() when the final post fails (no silent 'sent')", async () => {
     const post = vi.fn(async () => {
       throw new Error("provider_down");

--- a/packages/channels-teams/src/message-stream.ts
+++ b/packages/channels-teams/src/message-stream.ts
@@ -21,6 +21,8 @@ export interface TeamsMessageStreamConfig {
   post: (text: string) => Promise<string>;
   /** Edit the posted activity to `text`. */
   update: (id: string, text: string) => Promise<void>;
+  /** Send the final edit through a priority transport lane. */
+  finalize?: (id: string, text: string) => Promise<void>;
   /** Optional: fire a typing indicator once, before the first post. */
   typing?: () => Promise<void>;
   /** Minimum gap between consecutive flushes, in ms (defaults to 700). */
@@ -98,15 +100,17 @@ export class TeamsMessageStream {
    * retries the same buffer. Throws on transport failure — callers decide whether
    * to tolerate (mid-stream) or propagate (final).
    */
-  private async doSend(): Promise<void> {
+  private async doSend(final = false): Promise<void> {
     const text = this.buffer;
-    if (text === this.posted) return;
     // Don't post an empty first message; wait for real content.
     if (this.id === undefined && text.trim().length === 0) return;
     if (this.id === undefined) {
       if (this.config.typing) await this.config.typing();
       this.id = await this.config.post(text);
+    } else if (final && this.config.finalize) {
+      await this.config.finalize(this.id, text);
     } else {
+      if (text === this.posted) return;
       await this.config.update(this.id, text);
     }
     this.posted = text;
@@ -128,7 +132,7 @@ export class TeamsMessageStream {
   /** Final flush at {@link finish}: propagate a transport failure fail-loud. */
   private async flushFinal(): Promise<void> {
     try {
-      await this.doSend();
+      await this.doSend(true);
     } finally {
       this.lastFlushedAt = Date.now();
     }

--- a/packages/channels-ui/src/types.ts
+++ b/packages/channels-ui/src/types.ts
@@ -70,6 +70,10 @@ export interface IncomingMessage {
 export interface ThreadMessage {
   user?: PlatformUser;
   text: string;
+  /** Structured AG-UI message content when the platform preserves it. */
+  content?: unknown;
+  /** Standard AG-UI activity type for activity messages. */
+  activityType?: string;
   ts?: string;
   isBot?: boolean;
 }

--- a/packages/channels-ui/src/types.ts
+++ b/packages/channels-ui/src/types.ts
@@ -104,7 +104,12 @@ export interface Thread {
     filename: string;
     title?: string;
     altText?: string;
-  }): Promise<{ ok: boolean; fileId?: string; error?: string }>;
+  }): Promise<{
+    ok: boolean;
+    fileId?: string;
+    assetId?: string;
+    error?: string;
+  }>;
   /** Read the conversation's messages (capability-gated; returns `[]` when the adapter can't read history). */
   getMessages(): Promise<ThreadMessage[]>;
   /** Resolve a platform user by a free-form query (capability-gated; returns `undefined` when unsupported). */

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
@@ -857,6 +857,83 @@ describe("defaultActivateChannel", () => {
     expect(opts.scope).not.toHaveProperty("channelId");
   });
 
+  it("hydrates managed inbound and activity assets at the Runtime boundary", async () => {
+    const { start, importer } = captureChannelsIntelligenceLaunch();
+    const services = fakeServices();
+    vi.spyOn(services.intelligence, "getThreadMessages").mockResolvedValue({
+      messages: [
+        {
+          id: "user-image",
+          role: "user",
+          content: [
+            {
+              type: "image",
+              source: {
+                type: "url",
+                value: "cpki-asset://fileref_inbound",
+                mimeType: "image/png",
+              },
+            },
+          ],
+        },
+        {
+          id: "activity-image",
+          role: "activity",
+          activityType: "copilotkit.managed-asset",
+          content: {
+            assetId: "fileref_outbound",
+            filename: "chart.png",
+            mimeType: "image/png",
+            byteSize: 8,
+          },
+        },
+      ],
+    });
+    vi.spyOn(
+      services.intelligence,
+      "ɵgetManagedChannelAsset",
+    ).mockResolvedValue({
+      bytes: new Uint8Array([137, 80, 78, 71]),
+      mimeType: "image/png",
+    });
+
+    await defaultActivateChannel(
+      config,
+      createChannel({ name: "support" }),
+      importer,
+      undefined,
+      services,
+    );
+    const loadHistory = start.mock.calls[0]![1].loadHistory;
+    const history = await loadHistory({
+      threadId: "thread-images",
+      appUserId: "app-user",
+    });
+
+    expect(history[0]?.content).toEqual([
+      {
+        type: "image",
+        source: {
+          type: "data",
+          value: "iVBORw==",
+          mimeType: "image/png",
+        },
+      },
+    ]);
+    expect(history[1]).toMatchObject({
+      role: "activity",
+      activityType: "copilotkit.managed-asset",
+      content: {
+        assetId: "fileref_outbound",
+        source: {
+          type: "data",
+          value: "iVBORw==",
+          mimeType: "image/png",
+        },
+      },
+    });
+  });
+
   it("keeps tool status omitted when createChannel() does not configure it", async () => {
     const { start, importer } = captureChannelsIntelligenceLaunch();
     const channel = createChannel({ name: "support" });

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -352,7 +352,11 @@ export async function defaultActivateChannel(
         threadId,
         userId: appUserId,
       });
-      return history.messages.map(toAgentMessage);
+      return Promise.all(
+        history.messages.map((message) =>
+          toAgentMessage(message, services.intelligence),
+        ),
+      );
     },
   });
 }
@@ -549,17 +553,23 @@ async function runCanonicalChannelAgent(
 }
 
 /** Convert canonical Intelligence history into AG-UI messages. */
-function toAgentMessage(message: {
-  id: string;
-  role: string;
-  content?: string;
-  toolCalls?: Array<{ id: string; name: string; args: string }>;
-  toolCallId?: string;
-}): Message {
+async function toAgentMessage(
+  message: {
+    id: string;
+    role: string;
+    activityType?: string;
+    content?: unknown;
+    toolCalls?: Array<{ id: string; name: string; args: string }>;
+    toolCallId?: string;
+  },
+  intelligence: CopilotKitIntelligence,
+): Promise<Message> {
+  const content = await hydrateManagedContent(message.content, intelligence);
   return {
     id: message.id,
     role: message.role as Message["role"],
-    content: message.content ?? "",
+    content: content ?? "",
+    ...(message.activityType ? { activityType: message.activityType } : {}),
     ...(message.toolCalls
       ? {
           toolCalls: message.toolCalls.map((call) => ({
@@ -571,6 +581,69 @@ function toAgentMessage(message: {
       : {}),
     ...(message.toolCallId ? { toolCallId: message.toolCallId } : {}),
   } as Message;
+}
+
+/** Resolves managed asset references only at the authorized Runtime boundary. */
+async function hydrateManagedContent(
+  content: unknown,
+  intelligence: CopilotKitIntelligence,
+): Promise<unknown> {
+  if (Array.isArray(content)) {
+    return Promise.all(
+      content.map(async (part) => {
+        if (
+          typeof part !== "object" ||
+          part === null ||
+          !("source" in part) ||
+          typeof part.source !== "object" ||
+          part.source === null ||
+          !("value" in part.source) ||
+          typeof part.source.value !== "string" ||
+          !part.source.value.startsWith("cpki-asset://")
+        ) {
+          return part;
+        }
+        const assetId = part.source.value.slice("cpki-asset://".length);
+        const asset = await intelligence.ɵgetManagedChannelAsset(assetId);
+        return {
+          ...part,
+          source: {
+            type: "data",
+            value: Buffer.from(asset.bytes).toString("base64"),
+            mimeType:
+              asset.mimeType ??
+              ("mimeType" in part.source &&
+              typeof part.source.mimeType === "string"
+                ? part.source.mimeType
+                : "application/octet-stream"),
+          },
+        };
+      }),
+    );
+  }
+
+  if (
+    typeof content === "object" &&
+    content !== null &&
+    "assetId" in content &&
+    typeof content.assetId === "string"
+  ) {
+    const asset = await intelligence.ɵgetManagedChannelAsset(content.assetId);
+    return {
+      ...content,
+      source: {
+        type: "data",
+        value: Buffer.from(asset.bytes).toString("base64"),
+        mimeType:
+          asset.mimeType ??
+          ("mimeType" in content && typeof content.mimeType === "string"
+            ? content.mimeType
+            : "application/octet-stream"),
+      },
+    };
+  }
+
+  return content;
 }
 
 /** Whether `err` signals a missing managed provider rather than a hard failure. */

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -330,8 +330,10 @@ export interface ThreadMessage {
   id: string;
   /** Message role, e.g. `"user"`, `"assistant"`, `"tool"`. */
   role: string;
-  /** Text content of the message. May be absent for tool-call-only messages. */
-  content?: string;
+  /** Structured AG-UI content. May be absent for tool-call-only messages. */
+  content?: unknown;
+  /** Standard AG-UI activity type when `role` is `"activity"`. */
+  activityType?: string;
   /** Tool calls initiated by this message (assistant role only). */
   toolCalls?: Array<{
     id: string;
@@ -958,6 +960,28 @@ export class CopilotKitIntelligence {
       "GET",
       `/api/threads/${encodeURIComponent(params.threadId)}/messages?${qs}`,
     );
+  }
+
+  /** @internal Fetches one authorized managed Channel asset for history hydration. */
+  async ɵgetManagedChannelAsset(assetId: string): Promise<{
+    bytes: Uint8Array;
+    mimeType?: string;
+  }> {
+    const path = `/api/channels/files/${encodeURIComponent(assetId)}`;
+    const response = await fetch(`${this.#apiUrl}${path}`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${this.#apiKey}` },
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new PlatformRequestError(
+        `Intelligence platform error ${response.status}: ${text || response.statusText}`,
+        response.status,
+      );
+    }
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    const mimeType = response.headers.get("content-type") ?? undefined;
+    return { bytes, ...(mimeType ? { mimeType } : {}) };
   }
 
   /**

--- a/showcase/shell-docs/src/content/docs/channels/commands-and-reactions.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/commands-and-reactions.mdx
@@ -88,8 +88,8 @@ export const supportAgent = defineChannelCommand({
 
 If you add more command names in code, add the same slash commands to the Slack
 app configuration and reinstall the app when Slack changes its requested
-permissions. Socket Mode carries the invocation; your Channels runner does not
-host the Slack request URL.
+permissions. Slack sends the invocation to the signed managed command webhook;
+your Channels runner does not host that request URL.
 
 Slack supplies arguments as `ctx.text`. `ctx.options` remains empty on this
 managed path.

--- a/showcase/shell-docs/src/content/docs/channels/deploy-and-operate.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/deploy-and-operate.mdx
@@ -123,20 +123,16 @@ tokens or the Teams client secret. Rotate the project runtime key through your
 secret manager, restart the listener with the new value, and verify it returns
 to **Online**.
 
-## Use active/standby replicas safely
+## Bound active replicas
 
-Intelligence elects one active owner per Channel Code. Additional live runtimes
-that declare the same complete Channel set stay connected as standbys and are
-promoted when the active owner releases or expires. This is supported recovery,
-not active-active load balancing: one owner serves a Channel at a time.
+Intelligence offers each prepared delivery to connected Runtimes that declare
+the matching Channel. One Runtime claims that delivery; other replicas can
+claim different deliveries at the same time.
 
-Run the same build and configuration on every replica. Do not create partial
-overlap—for example, one runtime declaring `support-slack` plus `support-teams`
-and another declaring only `support-slack`. Election authority is
-runtime-scoped, so different but overlapping declaration sets can leave a
-Channel unserved. If one agent backend serves Slack and Teams, create one
-Intelligence Channel and `createChannel` declaration per provider, each with
-its own Code, and put the same full set on every replica.
+Run the same build and Channel declarations on every replica. Set
+`maxConcurrentDeliveries` to a bound each process can sustain. A full Runtime
+declines an invitation before it claims the delivery, which leaves another
+eligible replica free to claim it.
 
 ## Observe the full delivery path
 
@@ -156,12 +152,13 @@ secrets, or raw provider payloads by default.
 
 1. Build and typecheck the runner on Node.js 22.
 2. Confirm the exact package pair is in the lockfile.
-3. Start the intended replica set and wait for the Channel to report `online`.
+3. Start the intended replica set and wait for each listener to report `online`.
 4. Send a real provider message and verify a reply.
 5. Exercise one tool, one rich message, and one interaction.
 6. Restart with a pending approval and confirm your persistence promise.
 7. Test a brief network drop and observe `reconnecting` recovery.
-8. If you run standbys, stop the active worker and verify automatic promotion.
+8. Send concurrent messages and verify replicas claim distinct deliveries
+   within their local bounds.
 9. Send `SIGTERM` and confirm graceful shutdown.
 
 Use the [Intelligence walkthrough](/channels/intelligence) for control-plane

--- a/showcase/shell-docs/src/content/docs/channels/files-and-multimodality.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/files-and-multimodality.mdx
@@ -174,17 +174,16 @@ if (!result.ok) {
 }
 ```
 
-On managed Channels, `result.ok` means Intelligence accepted the durable upload
-and render frame. Provider delivery happens later in the Connector Outbox, so
-`ok: true` is not proof that Slack or Teams displayed the attachment. Verify
-the real provider message and monitor Intelligence **Delivery failing** status.
+On managed Channels, `result.ok` means Intelligence stored the managed asset,
+the provider acknowledged the file or image effect, and the SDK recorded the
+asset in canonical Thread history.
 
 <FrontendOnly frontend="slack">
 
 Managed Slack uses Slack's external-upload flow and can send general file types.
-The Slack app needs the `files:write` bot scope, which is absent from the
-generated manifest today. Reinstall after adding it. Check `result.ok`, then
-verify the real Slack message because provider upload happens asynchronously.
+The generated manifest includes the `files:write` bot scope. Add that scope and
+reinstall if the Slack app predates the current manifest. Check `result.ok`,
+then verify the real Slack message when provider-side display matters.
 
 </FrontendOnly>
 
@@ -192,9 +191,9 @@ verify the real Slack message because provider upload happens asynchronously.
 
 Managed Teams outbound file delivery currently supports images only. It posts
 the image as an inline Bot Connector attachment. For CSV, PDF, and other
-non-image files, Intelligence posts a visible “couldn't attach” notice and the
-SDK result may still reflect accepted managed delivery. Do not advertise a
-download until the real Teams message contains the expected attachment.
+non-image files, `postFile()` returns `ok: false` before a provider call. A
+confirmed Teams size rejection returns `teams_image_rejected` without ending
+the delivery, so the agent can still send a text fallback.
 
 </FrontendOnly>
 

--- a/showcase/shell-docs/src/content/docs/channels/intelligence.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/intelligence.mdx
@@ -151,16 +151,16 @@ interactive behavior, state, and deployment.
 
     1. Copy the generated manifest, open Slack's app-creation flow, and create
        the app **From a manifest** using the YAML.
-    2. In **Basic Information → App-Level Tokens**, generate a token named
-       `CopilotKit Intelligence` with `connections:write`. Paste the `xapp-…`
-       value into **App-level token**.
-    3. In **OAuth & Permissions**, click **Install to Workspace**, approve the
+    2. In **OAuth & Permissions**, click **Install to Workspace**, approve the
        app, and paste the `xoxb-…` **Bot User OAuth Token** into **Bot token**.
+    3. In **Basic Information → App Credentials**, copy the
+       **Signing Secret** into Intelligence.
     4. Invite the app to a channel with `/invite @<app-handle>`, or open a
        direct message with it.
 
-    Intelligence uses Slack Socket Mode. You do not need a public request URL,
-    tunnel, or signing secret.
+    Slack sends signed Events API and slash-command requests to the public
+    Intelligence URLs in the generated manifest. Hosted Intelligence provides
+    those URLs; a self-hosted deployment must expose them.
 
   </Step>
 

--- a/showcase/shell-docs/src/content/docs/channels/interactive/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/interactive/index.mdx
@@ -13,7 +13,7 @@ by hand.
 <FrontendOnly frontend="slack">
 
 On Slack, Channels JSX renders as Block Kit. Button clicks return as
-`block_actions` events through the managed Socket Mode connection.
+`block_actions` events through the signed managed webhook.
 
 <Callout type="warn" title="Enable Slack Interactivity before testing buttons">
   Slack interactions require **Interactivity** to be enabled in the Slack app

--- a/showcase/shell-docs/src/content/docs/channels/interactive/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/interactive/index.mdx
@@ -204,7 +204,7 @@ approval.
 ## Use post-and-resume for managed approvals
 
 Managed deliveries cannot wait inside `thread.awaitChoice()`. The click arrives
-as a separate leased delivery, so blocking the first delivery would prevent the
+as a separate claimed delivery, so blocking the first delivery would prevent the
 approval from being processed.
 
 The safe flow is:

--- a/showcase/shell-docs/src/content/docs/channels/persistence-and-scaling.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/persistence-and-scaling.mdx
@@ -5,8 +5,9 @@ description: Make Slack and Teams workflow state restart-safe, implement the Sta
 doc_type: how-to
 ---
 
-Intelligence durably owns provider ingress, delivery leases, and rendered
-egress. Your Channels process still owns SDK workflow state. Those are separate
+Intelligence durably owns provider ingress and canonical Thread history.
+Redis-backed claims and ordered packets coordinate active provider delivery.
+Your Channels process still owns SDK workflow state. Those are separate
 persistence boundaries.
 
 ## Know what is process-local by default
@@ -196,52 +197,33 @@ old card.
 
 ## Match the managed concurrency model
 
-### Runtime election (multi-replica)
+### Delivery claims (multi-replica)
 
-Intelligence elects one active owner for each Channel Code. Other live runtimes
-with the same complete Channel declaration set remain connected as standbys and
-are promoted if the active owner releases or expires. This makes identical
-replicas a supported recovery topology, but it is not active-active load
-balancing: only one runtime serves a Channel at a time.
+Each prepared delivery has one claim winner. Every connected Runtime that
+declares the matching Channel can receive the invitation, check local capacity,
+and attempt the claim. Different replicas can serve different conversations at
+the same time; there is no Channel-wide leader.
 
-Keep every replica's full declaration set identical. Different but overlapping
-sets are unsafe—for example, one runtime declaring `support-slack` and
-`support-teams` while another declares only `support-slack`. Election is
-runtime-scoped, so losing one overlapping Channel can put that runtime fully
-standby and strand another declaration.
+Keep each replica's Channel declarations and agent code aligned. Set
+`maxConcurrentDeliveries` to a local bound each process can sustain. A Runtime
+that has reached that bound declines new invitations before claiming them.
 
-The managed path is at-least-once. Intelligence makes accepted render frames
-idempotent, but application tools can still repeat if a turn is retried. Give
-consequential writes an application idempotency key based on
-`message.eventId`, `message.turnId`, or your own durable operation id.
+Provider effects use one ordered packet at a time. The SDK retries that exact
+packet after a known retry wait or reconnect. If a provider call becomes
+uncertain, Gateway records an uncertain terminal result instead of sending it
+again. Application tools still need their own idempotency keys when the
+application may call them more than once; use `message.eventId`,
+`message.turnId`, or a durable operation ID.
 
 ### Turn concurrency (same conversation)
 
-Within the active runtime, overlapping turns on the **same** conversation run
-in **parallel by default**. Five people asking five questions in one Slack
-thread get five concurrent agent runs and replies.
+Managed admission keeps one canonical Thread exclusive on a Runtime. A second
+invitation for that Thread is not claimed while the first delivery is active.
+Unrelated Threads continue in parallel up to `maxConcurrentDeliveries`.
 
-```ts
-// Default — parallel (no config needed)
-createChannel({ name: "support", agent: makeAgent });
-
-// One-at-a-time per conversation (queue)
-createChannel({
-  name: "support",
-  agent: makeAgent,
-  store: { concurrency: "serial" },
-});
-
-// Discard overlapping turns (legacy drop)
-createChannel({
-  name: "support",
-  agent: makeAgent,
-  store: { concurrency: "drop" },
-});
-```
-
-A singleton agent is safe under parallel mode because the SDK isolates each run
-with `agent.clone()`. Prefer a factory when you want that explicit. See
+This delivery guard is separate from the SDK `store.concurrency` setting used
+by other adapter paths. Choose that setting for your application-state rules;
+do not use it to raise the managed same-Thread delivery limit. See
 [`StoreConfig`](/reference/channels/types/StoreConfig).
 
 ## Production checklist
@@ -252,7 +234,8 @@ with `agent.clone()`. Prefer a factory when you want that explicit. See
 - Run the StateStore conformance suite against the real backend.
 - Test a restart while a card is awaiting a click.
 - Make external writes idempotent.
-- Keep the complete Channel declaration set identical on every standby.
+- Keep Channel declarations aligned across replicas and set a local delivery
+  concurrency bound.
 - Alert on Intelligence **Conflict**, **Offline**, and **Delivery failing**.
 - Stop the listener on `SIGINT` and `SIGTERM`.
 

--- a/showcase/shell-docs/src/content/docs/channels/threads-and-state.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/threads-and-state.mdx
@@ -37,9 +37,10 @@ also pass a singleton (`agent: shared`); under the hood the SDK calls
 `shared.clone()` per run so concurrent turns do not share one mutable object.
 Managed history is loaded onto that per-run agent after isolation.
 
-Overlapping turns on the same conversation run in **parallel by default**. Use
-`store: { concurrency: "serial" }` when a workflow needs exclusive access to
-`thread.setState` or other shared workflow state.
+Managed delivery admission keeps one canonical conversation exclusive while
+unrelated conversations run in parallel. The SDK `store.concurrency` setting
+still governs other adapter paths and shared workflow state; it does not raise
+the managed same-Thread delivery limit.
 
 The native provider is `message.platform`. On the managed path,
 `thread.platform` is `"intelligence"` because it identifies the delivery
@@ -181,10 +182,11 @@ The contract includes key/value, list, lock, deduplication, and queue
 operations. Values must round-trip through JSON.
 
 <Callout type="warn" title="Do not infer durability from Online status">
-  **Online** confirms a healthy managed connection; the runtime may be active or
-  standby. Send a real provider message to test delivery. This status does not
-  prove your application workflow state survives a process restart, so test a
-  restart while an approval card is pending before shipping a durable workflow.
+  **Online** confirms a healthy managed connection that can receive delivery
+  invitations. Send a real provider message to test delivery. This status does
+  not prove your application workflow state survives a process restart, so test
+  a restart while an approval card is pending before shipping a durable
+  workflow.
 </Callout>
 
 ## Operational checklist

--- a/showcase/shell-docs/src/content/reference/channels/classes/Channel.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/classes/Channel.mdx
@@ -201,7 +201,7 @@ await channels.stop();
 | Status           | Meaning                                                          |
 | ---------------- | ---------------------------------------------------------------- |
 | `connecting`     | `ready()` has not activated the Channel yet, or activation is in progress. |
-| `online`         | The managed session is healthy; this replica may be active or standby. |
+| `online`         | The managed session is healthy and can receive delivery invitations. |
 | `setup_required` | The runtime declaration exists but provider setup is incomplete. |
 | `reconnecting`   | The gateway connection dropped and is retrying.                  |
 | `error`          | Activation or bounded reconnect failed.                          |

--- a/showcase/shell-docs/src/content/reference/channels/types/JSXCallbacks.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/types/JSXCallbacks.mdx
@@ -8,7 +8,7 @@ opaque action ids; the SDK resolves the original handler when the interaction
 returns.
 
 Slack renders the controls as Block Kit. With Slack app Interactivity enabled,
-clicks arrive as `block_actions` over the managed Socket Mode connection.
+clicks arrive as `block_actions` through the signed managed webhook.
 
 Teams renders the controls in Adaptive Cards. Buttons use `Action.Submit`, and
 clicks return through the managed connection as message activities. A Teams

--- a/showcase/shell-docs/src/content/reference/channels/types/StoreConfig.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/types/StoreConfig.mdx
@@ -77,6 +77,8 @@ against `state`. It does not merge patches. Under `"parallel"`, concurrent
 turns that both call `setState` can race — use `"serial"` for workflows that
 depend on exclusive state updates.
 
-On the managed path, Intelligence owns cross-instance delivery leases and
-egress idempotency. The SDK store still owns application state and callback
+On the managed path, Intelligence owns cross-instance delivery claims and
+ordered provider effects. Managed admission also keeps one canonical Thread
+delivery active at a time on a Runtime, so `"parallel"` does not raise that
+delivery limit. The SDK store still owns application state and callback
 snapshots.

--- a/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
@@ -249,7 +249,7 @@ describe("Channels documentation journey", () => {
     expect(source).toMatch(/do not derive\s+the WebSocket URL/i);
     expect(source).toMatch(/Pass bare base URLs/i);
     expect(source).toMatch(
-      /Do not append\s+`\/api`,\s+`\/socket`,\s+`\/runner`,\s+or\s+`\/client`/i,
+      /Do not append\s+`\/api`,\s+`\/socket`,\s+`\/runner`,\s+`\/client`,\s+or\s+`\/channels`/i,
     );
     expect(source).toMatch(/replace both(?: bases)?\s+together/i);
   });
@@ -314,13 +314,12 @@ describe("Channels documentation journey", () => {
     const teams = filterFrontendScopedBlocks(source, "teams");
 
     expect(slack).toContain("### Connect Slack");
-    expect(slack).toContain("connections:write");
-    expect(slack).toContain("`xapp-…`");
     expect(slack).toContain("`xoxb-…`");
     expect(slack).toContain("`/invite @<app-handle>`");
-    expect(slack).toContain("Socket Mode");
-    expect(slack).toContain("public request URL");
-    expect(slack).toContain("signing secret");
+    expect(slack).toContain("Signing Secret");
+    expect(slack).toContain("signed Events API");
+    expect(slack).toMatch(/public\s+Intelligence URLs/);
+    expect(slack).not.toContain("Socket Mode");
     expect(slack).not.toContain("### Connect Microsoft Teams");
     expect(slack).not.toContain("Directory (tenant) ID");
 
@@ -440,9 +439,10 @@ describe("Channels documentation journey", () => {
 
     expect(slack).toContain("Block Kit");
     expect(slack).toContain("block_actions");
-    expect(slack).toContain("Socket Mode");
+    expect(slack).toContain("signed managed webhook");
     expect(slack).toContain("Interactivity");
     expect(slack).toMatch(/generated manifest[\s\S]{0,160}disabled/i);
+    expect(slack).not.toContain("Socket Mode");
 
     expect(teams).toContain("Adaptive Cards");
     expect(teams).toContain("Action.Submit");
@@ -520,10 +520,13 @@ describe("Channels documentation journey", () => {
       expect(persistence).toContain(facet);
     }
     expect(persistence).toContain('from "@copilotkit/channels/testing"');
-    expect(persistence).toMatch(/one active owner[\s\S]{0,120}Channel Code/i);
+    expect(persistence).toMatch(/Each prepared delivery has one claim winner/i);
     expect(persistence).toMatch(
-      /same complete Channel declaration set[\s\S]{0,160}standbys/i,
+      /Different replicas can serve different conversations/i,
     );
+    expect(persistence).toContain("`maxConcurrentDeliveries`");
+    expect(persistence).not.toMatch(/one active owner/i);
+    expect(persistence).not.toMatch(/standbys/i);
 
     expect(history).toMatch(/default history limit[\s\S]{0,80}20 messages/i);
     expect(history).toMatch(/current inbound turn is not part/i);
@@ -649,8 +652,9 @@ describe("Channels documentation journey", () => {
       expect(filteredThreads).toMatch(/conversationKey[\s\S]{0,120}opaque/i);
       expect(filteredThreads).toContain("durable `StateStore`");
       expect(filteredThreads).toMatch(
-        /\*\*Online\*\*[\s\S]{0,140}active or\s+standby/i,
+        /\*\*Online\*\*[\s\S]{0,180}receive delivery\s+invitations/i,
       );
+      expect(filteredThreads).not.toMatch(/active or\s+standby/i);
     }
   });
 


### PR DESCRIPTION
## What changed

- install the managed delivery handler before the control connection can receive its first invitation
- admit one local delivery per canonical Thread while allowing distinct Threads up to `maxConcurrentDeliveries`
- retry the same immutable packet only after known pre-provider failures and stop blind replay after uncertain calls
- prioritize final provider effects, bound shutdown, and keep delivery results tied to their claim fence
- preserve asset acknowledgement and restore behavior, including a non-terminal Teams image capability result
- update public Channels docs from Socket Mode, leases, and standby ownership to signed webhooks, claims, ordered packets, and local admission

## Why

The SDK must keep packet identity stable across reconnects and prevent two local handlers from serving the same Thread at once. The hard cut also makes managed provider acknowledgement visible to `postFile()` without reviving retired session state.

## Companion PR

- https://github.com/CopilotKit/Intelligence/pull/668

## Validation

- `pnpm nx run-many -t test,check-types,build -p @copilotkit/channels-intelligence @copilotkit/channels-slack @copilotkit/channels-teams @copilotkit/channels-core --skip-nx-cache` — passed
- fresh package tests: Channels Intelligence 92, Slack 318, Teams 90, Core 176
- `npm run lint && npm run typecheck && npm run test && npm run build` in `showcase/shell-docs` — passed; 351 docs tests and a 222-page production build
- focused managed docs contract — passed; 23 tests
- GitHub CI — passed at `6c7d411f9e`; all required checks passed

Live Slack and Teams provider smoke tests and a long soak were not run locally.

Draft: keep this open for review while commits land across the companion PR.