### PR TITLE
feat(runtime): auto-start managed Channels on long-running hosts (OSS-641)

### DIFF
--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -125,8 +125,8 @@ const runtime = new CopilotRuntime({
   channels: [bot],
 });
 
-// Mounting the listener exposes `.channels` for activation + shutdown but opens
-// no connection; `ready()` activates the Channel (starting its adapters).
+// Mounting the listener starts the Channel (and its adapters) and exposes
+// `.channels` to observe or shut it down; `ready()` waits until it is live.
 // No bot.start()/bot.stop().
 const listener = createCopilotNodeListener({
   runtime,

--- a/examples/slack/app/index.ts
+++ b/examples/slack/app/index.ts
@@ -18,8 +18,9 @@
  * Slack/Discord/Telegram/WhatsApp credentials + transports); the runtime OWNS
  * the Channel's lifecycle and STARTS all of its direct adapters for us. So all
  * four platforms stay on the ONE Channel — you declare it on
- * `new CopilotRuntime({ intelligence, identifyUser, channels: [bot] })`, mount a
- * node listener, and drive `listener.channels.ready()` / `.stop()`. There is no
+ * `new CopilotRuntime({ intelligence, identifyUser, channels: [bot] })` and mount
+ * a node listener — which starts the Channel. `listener.channels.ready()` waits
+ * for it to be live and `.stop()` tears it down. There is no
  * `bot.start()`/`bot.stop()` and no standalone path.
  *
  * Defaults are not auto-applied — you spread them explicitly. That's
@@ -298,22 +299,11 @@ async function main() {
     channels: [bot],
   });
 
-  // Mounting the Node listener creates the runtime handler and exposes
-  // `.channels` for readiness + shutdown. It opens NO connection yet — the
-  // `ready()` call below is what activates the Channel (starting all its direct
-  // adapters). This listener holds the Intelligence key and needs no
-  // public ingress (each platform adapter has its own — e.g. WhatsApp's webhook
-  // on $PORT); it only owns the Channel lifecycle and keeps the process alive.
-  const channelPort = Number(process.env.CHANNELS_PORT ?? 8300);
-  const listener = createCopilotNodeListener({
-    runtime: channelRuntime,
-    basePath: "/api/copilotkit",
-  });
-  createServer(listener).listen(channelPort, "127.0.0.1", () => {
-    console.log(
-      `[channel] runtime (owns lifecycle) listening on 127.0.0.1:${channelPort}`,
-    );
-  });
+  // Teardown is wired BEFORE the listener exists, because creating the listener
+  // is what starts the Channel: `stopChannels` is assigned in the same tick as
+  // the creation below, so a Ctrl-C can never land in a window where the Channel
+  // is connecting but nothing knows how to tear it down.
+  let stopChannels: (() => Promise<void>) | undefined;
 
   const shutdown = async (signal: string) => {
     console.log(`\n[channel] received ${signal}, stopping…`);
@@ -321,7 +311,7 @@ async function main() {
     try {
       // Stop through the runtime's Channel control, which tears down every direct
       // adapter it started.
-      await listener.channels.stop();
+      await stopChannels?.();
     } catch (err) {
       console.error("[channel] error stopping Channel", err);
       exitCode = 1;
@@ -344,17 +334,35 @@ async function main() {
       process.exit(1);
     });
   };
-  // Registered BEFORE activation on purpose: `ready()` below can take up to its
-  // timeout, and a Ctrl-C inside that window must still tear the Channel down
-  // rather than hit Node's default handler and skip teardown.
+  // Registered BEFORE activation on purpose: activation begins the moment the
+  // listener is created and `ready()` below can take up to its timeout — a
+  // Ctrl-C anywhere in that window must still tear the Channel down rather than
+  // hit Node's default handler and skip teardown.
   process.on("SIGINT", () => runShutdown("SIGINT"));
   process.on("SIGTERM", () => runShutdown("SIGTERM"));
 
-  // Activate through the runtime's Channel control instead of a (now-removed)
-  // bot.start(): this is what connects the Channel, and it resolves once every
-  // direct adapter's transport is up across all active platforms. Required —
-  // skip it and the process serves HTTP with nothing connected.
-  // Bound startup so a wedged adapter connect can't hang readiness forever.
+  // Mounting the Node listener creates the runtime handler and STARTS the Channel
+  // (connecting all its direct adapters); `.channels` is how you observe and stop
+  // it. This listener holds the Intelligence key and needs no public ingress
+  // (each platform adapter has its own — e.g. WhatsApp's webhook on $PORT); it
+  // only owns the Channel lifecycle and keeps the process alive.
+  const channelPort = Number(process.env.CHANNELS_PORT ?? 8300);
+  const listener = createCopilotNodeListener({
+    runtime: channelRuntime,
+    basePath: "/api/copilotkit",
+  });
+  stopChannels = () => listener.channels.stop();
+  createServer(listener).listen(channelPort, "127.0.0.1", () => {
+    console.log(
+      `[channel] runtime (owns lifecycle) listening on 127.0.0.1:${channelPort}`,
+    );
+  });
+
+  // Wait for the activation started above to settle, instead of a (now-removed)
+  // bot.start(): this resolves once every direct adapter's transport is up across
+  // all active platforms, and rejects if one failed — so a broken deploy exits
+  // non-zero instead of pretending to be a live bot.
+  // Bound it so a wedged adapter connect can't hang readiness forever.
   await listener.channels.ready({ timeoutMs: 30_000 });
   console.log(
     `[channel] started on: ${adapters.map((a) => a.platform).join(", ")}`,

--- a/examples/slack/app/managed.ts
+++ b/examples/slack/app/managed.ts
@@ -13,8 +13,8 @@
  * IDENTICAL to the native bot; only the transport changes. Instead of a
  * launcher, the managed path now goes through the NORMAL runtime handler: you
  * hand your `createChannel(...)` to `new CopilotRuntime({ …, channels })` and
- * mount it with `createCopilotNodeListener`, then `await
- * listener.channels.ready()` to activate the managed Channel (the runtime
+ * mount it with `createCopilotNodeListener` — which activates the managed Channel
+ * — then `await listener.channels.ready()` to wait until it is live (the runtime
  * derives every infra id — project, adapter, channel — from the Intelligence
  * config + the channel `name`, so the developer supplies NONE of them):
  *
@@ -145,26 +145,16 @@ async function main() {
     channels: [support],
   });
 
-  // The NORMAL handler is what runs the managed Channel: the Node listener
-  // creates the runtime handler and exposes `.channels` for activation +
-  // shutdown. Mounting it opens NO connection — `ready()` below activates the
-  // Channel over the Intelligence transport. There is no public Slack ingress on
-  // this port — Intelligence owns the Slack edge — but the server keeps the
-  // lifecycle-owning process alive.
-  const listener = createCopilotNodeListener({
-    runtime,
-    basePath: "/api/copilotkit",
-  });
-  const port = Number(process.env.PORT ?? 8300);
-  createServer(listener).listen(port, () => {
-    console.log(`[channel] listener on :${port}`);
-  });
+  // Teardown is wired BEFORE the listener exists, because creating the listener
+  // is what activates the managed Channel; `stopChannels` is assigned in the same
+  // tick as that creation, so no signal can land in an untearable window.
+  let stopChannels: (() => Promise<void>) | undefined;
 
   const shutdown = async (signal: string) => {
     console.log(`\n[channel] received ${signal}, stopping…`);
     let exitCode = 0;
     try {
-      await listener.channels.stop();
+      await stopChannels?.();
     } catch (err) {
       console.error("[channel] error stopping managed Channel", err);
       exitCode = 1;
@@ -186,14 +176,30 @@ async function main() {
       process.exit(1);
     });
   };
-  // Registered BEFORE activation on purpose: `ready()` below can take up to its
-  // timeout, and a Ctrl-C inside that window must still tear the Channel down
-  // rather than hit Node's default handler and skip teardown.
+  // Registered BEFORE activation on purpose: activation begins the moment the
+  // listener is created and `ready()` below can take up to its timeout — a
+  // Ctrl-C anywhere in that window must still tear the Channel down rather than
+  // hit Node's default handler and skip teardown.
   process.on("SIGINT", () => runShutdown("SIGINT"));
   process.on("SIGTERM", () => runShutdown("SIGTERM"));
 
-  // Required: this is the call that connects the managed Channel to the Realtime
-  // Gateway. Bound it so a wedged connect can't hang startup forever.
+  // The NORMAL handler is what runs the managed Channel: creating the Node
+  // listener activates it over the Intelligence transport and exposes `.channels`
+  // to observe or stop it. There is no public Slack ingress on this port —
+  // Intelligence owns the Slack edge — but the server keeps the lifecycle-owning
+  // process alive.
+  const listener = createCopilotNodeListener({
+    runtime,
+    basePath: "/api/copilotkit",
+  });
+  stopChannels = () => listener.channels.stop();
+  const port = Number(process.env.PORT ?? 8300);
+  createServer(listener).listen(port, () => {
+    console.log(`[channel] listener on :${port}`);
+  });
+
+  // Wait for that activation to settle, bounded so a wedged connect can't hang
+  // startup forever — and so a failure exits non-zero instead of looking live.
   await listener.channels.ready({ timeoutMs: 30_000 });
   console.log(`[channel] started managed Channel "${channelName}"`);
 }

--- a/examples/teams/README.md
+++ b/examples/teams/README.md
@@ -13,8 +13,8 @@ A Channel runs **only** through the Intelligence runtime. The Teams adapter stay
 _direct_ (it keeps the Playground/Teams ingress), but the runtime owns the
 Channel's lifecycle: the bot is declared on
 `new CopilotRuntime({ intelligence, identifyUser, channels: [bot] })` and started
-/ stopped via `listener.channels.ready()` / `.stop()` — there is no
-`bot.start()`/`bot.stop()`. That's why an Intelligence key is required even
+by mounting the node listener — `listener.channels.ready()` waits until it is live
+and `.stop()` tears it down. There is no `bot.start()`/`bot.stop()`. That's why an Intelligence key is required even
 though no Microsoft credentials are.
 
 ## Run it

--- a/examples/teams/app/index.tsx
+++ b/examples/teams/app/index.tsx
@@ -10,10 +10,10 @@
  * RUN MODEL — a Channel runs ONLY through the Intelligence runtime. The Teams
  * `teams({ port })` adapter stays DIRECT (it keeps its own transport / the
  * Playground ingress), but the runtime OWNS its lifecycle: the Channel is
- * declared on `new CopilotRuntime({ intelligence, identifyUser, channels })`,
- * and you drive readiness/shutdown through the handler's `channels` control
- * (`listener.channels.ready()` / `.stop()`) — there is no `bot.start()`/
- * `bot.stop()` and no standalone path.
+ * declared on `new CopilotRuntime({ intelligence, identifyUser, channels })` and
+ * started by mounting the node listener; you observe readiness and drive shutdown
+ * through the handler's `channels` control (`listener.channels.ready()` /
+ * `.stop()`) — there is no `bot.start()`/`bot.stop()` and no standalone path.
  *
  * Requires `OPENAI_API_KEY` (the BuiltInAgent's LLM) AND an Intelligence key
  * (`COPILOTKIT_API_KEY` — free tier; the platform URLs default to the managed
@@ -264,31 +264,20 @@ const channelRuntime = new CopilotRuntime({
   channels: [bot],
 });
 
-// Mounting the Node listener creates the runtime handler and exposes
-// `.channels` for readiness + shutdown. It opens NO connection yet — the
-// `ready()` call below activates the Channel (starting the direct Teams
-// adapter). Bind loopback: this runtime holds the Intelligence key
-// and needs no public ingress (the Teams adapter has its own on :${port}); the
-// listener only owns the Channel lifecycle and keeps the process alive.
-const channelPort = Number(process.env.CHANNELS_PORT ?? 8300);
-const listener = createCopilotNodeListener({
-  runtime: channelRuntime,
-  basePath: "/api/copilotkit",
-});
-createServer(listener).listen(channelPort, "127.0.0.1", () => {
-  console.log(
-    `Channel runtime (owns lifecycle) listening on 127.0.0.1:${channelPort}`,
-  );
-});
-
 // Stop the bot cleanly on exit — through the runtime's Channel control, which
 // tears down the direct Teams adapter it started. A teardown failure is logged
 // and reported as a nonzero exit rather than swallowed.
+//
+// Wired BEFORE the listener exists, because creating the listener is what starts
+// the Channel; `stopChannels` is assigned in the same tick as that creation, so
+// no signal can land in a window where the Channel is connecting untearable.
+let stopChannels: (() => Promise<void>) | undefined;
+
 const shutdown = async (signal: string): Promise<void> => {
   console.log(`\nReceived ${signal}, stopping…`);
   let exitCode = 0;
   try {
-    await listener.channels.stop();
+    await stopChannels?.();
   } catch (err) {
     console.error("Error stopping Channel", err);
     exitCode = 1;
@@ -303,16 +292,33 @@ const runShutdown = (signal: string): void => {
     process.exit(1);
   });
 };
-// Registered BEFORE activation on purpose: `ready()` below can take up to its
-// timeout, and a Ctrl-C inside that window must still tear the Channel down
-// rather than hit Node's default handler and skip teardown.
+// Registered BEFORE activation on purpose: activation begins the moment the
+// listener is created and `ready()` below can take up to its timeout — a Ctrl-C
+// anywhere in that window must still tear the Channel down rather than hit
+// Node's default handler and skip teardown.
 process.on("SIGINT", () => runShutdown("SIGINT"));
 process.on("SIGTERM", () => runShutdown("SIGTERM"));
 
-// Activate through the runtime's Channel control instead of a (now-removed)
-// bot.start(): this is what connects the Channel, and it resolves once the
-// direct Teams adapter's transport is up. Required — skip it and nothing
-// connects.
+// Mounting the Node listener creates the runtime handler and STARTS the Channel
+// (connecting the direct Teams adapter); `.channels` is how you observe and stop
+// it. Bind loopback: this runtime holds the Intelligence key and needs no public
+// ingress (the Teams adapter has its own on :${port}); the listener only owns the
+// Channel lifecycle and keeps the process alive.
+const channelPort = Number(process.env.CHANNELS_PORT ?? 8300);
+const listener = createCopilotNodeListener({
+  runtime: channelRuntime,
+  basePath: "/api/copilotkit",
+});
+stopChannels = () => listener.channels.stop();
+createServer(listener).listen(channelPort, "127.0.0.1", () => {
+  console.log(
+    `Channel runtime (owns lifecycle) listening on 127.0.0.1:${channelPort}`,
+  );
+});
+
+// Wait for that activation to settle instead of a (now-removed) bot.start(): it
+// resolves once the direct Teams adapter's transport is up, and rejects if it
+// failed — so a broken deploy exits non-zero instead of looking live.
 // Bound startup so a wedged adapter connect can't hang readiness forever.
 await listener.channels.ready({ timeoutMs: 30_000 });
 

--- a/packages/channels-core/README.md
+++ b/packages/channels-core/README.md
@@ -68,11 +68,8 @@ handler:
 ```ts
 import { createChannel } from "@copilotkit/channels-core";
 import { slack } from "@copilotkit/channels-slack";
-import {
-  CopilotRuntime,
-  CopilotKitIntelligence,
-  createCopilotRuntimeHandler,
-} from "@copilotkit/runtime/v2";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 
 const channel = createChannel({
   name: "support-bot", // project-unique Intelligence Channel name
@@ -89,9 +86,11 @@ const runtime = new CopilotRuntime({
   channels: [channel],
 });
 
-const handler = createCopilotRuntimeHandler({ runtime });
-await handler.channels.ready(); // starts every declared channel
-// await handler.channels.stop(); // tears them down
+// Creating the listener starts every declared channel's connection.
+const listener = createCopilotNodeListener({ runtime });
+// Optional: await that activation so a broken config fails startup loudly.
+await listener.channels.ready();
+// await listener.channels.stop(); // tears them down
 ```
 
 ## `Thread`

--- a/packages/channels-discord/README.md
+++ b/packages/channels-discord/README.md
@@ -29,11 +29,8 @@ import {
   defaultDiscordTools,
   defaultDiscordContext,
 } from "@copilotkit/channels-discord";
-import {
-  CopilotRuntime,
-  CopilotKitIntelligence,
-  createCopilotRuntimeHandler,
-} from "@copilotkit/runtime/v2";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 
 const bot = createChannel({
   name: "support-bot", // project-unique Intelligence Channel name
@@ -71,8 +68,10 @@ const runtime = new CopilotRuntime({
   channels: [bot],
 });
 
-const handler = createCopilotRuntimeHandler({ runtime });
-await handler.channels.ready(); // starts the channel; handler.channels.stop() tears it down
+// Creating the listener starts the Channel's connection.
+const listener = createCopilotNodeListener({ runtime });
+// Optional: await that activation so a broken config fails startup loudly.
+await listener.channels.ready(); // listener.channels.stop() tears it down
 ```
 
 `discord(opts)` returns a `DiscordAdapter`. The adapter connects via the
@@ -275,7 +274,7 @@ work against any adapter that advertises the same capabilities.
 ## Slash commands
 
 Slash commands are registered up front — when the runtime activates the
-channel (`await handler.channels.ready()`) — via `registerCommands`. When
+channel (`await listener.channels.ready()`) — via `registerCommands`. When
 `guildId` is set they register to that guild instantly; without it they
 register globally and take ~1 hour to propagate. Register handlers with
 `bot.onCommand`:

--- a/packages/channels-slack/README.md
+++ b/packages/channels-slack/README.md
@@ -29,11 +29,8 @@ import {
   defaultSlackTools,
   defaultSlackContext,
 } from "@copilotkit/channels-slack";
-import {
-  CopilotRuntime,
-  CopilotKitIntelligence,
-  createCopilotRuntimeHandler,
-} from "@copilotkit/runtime/v2";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 
 const bot = createChannel({
   name: "support-bot", // project-unique Intelligence Channel name
@@ -61,8 +58,10 @@ const runtime = new CopilotRuntime({
   channels: [bot],
 });
 
-const handler = createCopilotRuntimeHandler({ runtime });
-await handler.channels.ready(); // starts the channel; handler.channels.stop() tears it down
+// Creating the listener starts the Channel's connection.
+const listener = createCopilotNodeListener({ runtime });
+// Optional: await that activation so a broken config fails startup loudly.
+await listener.channels.ready(); // listener.channels.stop() tears it down
 ```
 
 `slack(opts)` returns a `SlackAdapter`. By default it runs in **Socket Mode**

--- a/packages/channels-teams/README.md
+++ b/packages/channels-teams/README.md
@@ -27,11 +27,8 @@ pnpm add @copilotkit/channels @copilotkit/channels-ui @copilotkit/channels-teams
 ```ts
 import { createChannel } from "@copilotkit/channels";
 import { teams } from "@copilotkit/channels-teams";
-import {
-  CopilotRuntime,
-  CopilotKitIntelligence,
-  createCopilotRuntimeHandler,
-} from "@copilotkit/runtime/v2";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 
 const bot = createChannel({
   name: "support-bot", // project-unique Intelligence Channel name
@@ -51,8 +48,11 @@ const runtime = new CopilotRuntime({
   channels: [bot],
 });
 
-const handler = createCopilotRuntimeHandler({ runtime });
-await handler.channels.ready(); // POST /api/messages now listening on :3978
+// Creating the listener starts the Channel's connection.
+const listener = createCopilotNodeListener({ runtime });
+// Optional: await that activation; once settled, POST /api/messages is listening
+// on :3978.
+await listener.channels.ready();
 ```
 
 Then point the **Microsoft 365 Agents Playground** at it. No Microsoft

--- a/packages/channels-telegram/README.md
+++ b/packages/channels-telegram/README.md
@@ -42,11 +42,8 @@ import {
   defaultTelegramContext,
 } from "@copilotkit/channels-telegram";
 import { Message, Section } from "@copilotkit/channels-ui";
-import {
-  CopilotRuntime,
-  CopilotKitIntelligence,
-  createCopilotRuntimeHandler,
-} from "@copilotkit/runtime/v2";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 
 const bot = createChannel({
   name: "support-bot", // project-unique Intelligence Channel name
@@ -82,8 +79,10 @@ const runtime = new CopilotRuntime({
   channels: [bot],
 });
 
-const handler = createCopilotRuntimeHandler({ runtime });
-await handler.channels.ready(); // starts the channel; handler.channels.stop() tears it down
+// Creating the listener starts the Channel's connection.
+const listener = createCopilotNodeListener({ runtime });
+// Optional: await that activation so a broken config fails startup loudly.
+await listener.channels.ready(); // listener.channels.stop() tears it down
 ```
 
 `telegram(opts)` returns a `TelegramAdapter`. By default it runs in

--- a/packages/channels-whatsapp/README.md
+++ b/packages/channels-whatsapp/README.md
@@ -28,11 +28,8 @@ import {
   whatsapp,
   defaultWhatsAppContext,
 } from "@copilotkit/channels-whatsapp";
-import {
-  CopilotRuntime,
-  CopilotKitIntelligence,
-  createCopilotRuntimeHandler,
-} from "@copilotkit/runtime/v2";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 
 const bot = createChannel({
   name: "support-bot", // project-unique Intelligence Channel name
@@ -66,8 +63,10 @@ const runtime = new CopilotRuntime({
   channels: [bot],
 });
 
-const handler = createCopilotRuntimeHandler({ runtime });
-await handler.channels.ready(); // starts the channel; handler.channels.stop() tears it down
+// Creating the listener starts the Channel's connection.
+const listener = createCopilotNodeListener({ runtime });
+// Optional: await that activation so a broken config fails startup loudly.
+await listener.channels.ready(); // listener.channels.stop() tears it down
 console.log("[whatsapp-bot] listening for webhooks");
 ```
 

--- a/packages/channels/README.md
+++ b/packages/channels/README.md
@@ -28,11 +28,8 @@ Configure TypeScript to use the Channels JSX runtime:
 ```tsx
 import { createChannel, Message, Section } from "@copilotkit/channels";
 import { slack } from "@copilotkit/channels/slack";
-import {
-  CopilotRuntime,
-  CopilotKitIntelligence,
-  createCopilotRuntimeHandler,
-} from "@copilotkit/runtime/v2";
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 
 const channel = createChannel({
   name: "support-bot", // project-unique Intelligence Channel name
@@ -63,8 +60,10 @@ const runtime = new CopilotRuntime({
   channels: [channel],
 });
 
-const handler = createCopilotRuntimeHandler({ runtime });
-await handler.channels.ready(); // starts the channel; handler.channels.stop() tears it down
+// Creating the listener starts the Channel's connection.
+const listener = createCopilotNodeListener({ runtime });
+// Optional: await that activation so a broken config fails startup loudly.
+await listener.channels.ready(); // listener.channels.stop() tears it down
 ```
 
 ## Adapter entry points

--- a/packages/runtime/src/v2/runtime/__tests__/endpoints-channels.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/endpoints-channels.test.ts
@@ -1,17 +1,27 @@
 /**
- * Propagation of `handler.channels` through the endpoint wrappers.
+ * Managed-Channel lifecycle across the endpoint wrappers.
  *
- * `createCopilotRuntimeHandler` constructs the managed-Channel control surface
- * but defers activation lazily to the first `handler.channels.ready()` — it
- * opens NO socket at creation (serverless-safe; see `handler-channels.test.ts`).
- * This suite asserts that the Node, Express, and Hono wrappers around that
- * handler propagate `.channels` unchanged: activation still does not happen at
- * creation, and a `ready()` through the wrapper's surface activates exactly
- * once. Node — the long-running, lifecycle-owning entry point — surfaces
- * `.channels` on its returned listener; Express/Hono attach `.channels`
- * best-effort on their returned framework objects too.
+ * `createCopilotRuntimeHandler` constructs the control surface but opens NO
+ * socket at creation: activation stays LAZY there because the generic Fetch
+ * handler is the serverless/edge entry point (see `handler-channels.test.ts`).
+ *
+ * The LONG-RUNNING wrappers are different — they can only run inside a process
+ * that owns its own lifetime, so they AUTO-START activation at creation
+ * (OSS-641) and `ready()` becomes await-and-observe rather than the trigger:
+ *
+ * - Node (`createCopilotNodeListener`) — auto-starts.
+ * - Express (`createCopilotExpressHandler`) — auto-starts; an Express router
+ *   requires a long-running `http.Server`.
+ * - Hono (`createCopilotHonoHandler`) — stays LAZY: it is our Next.js App
+ *   Router / edge surface (every `examples/showcases/*` route handler builds one
+ *   at module scope), where per-isolate auto-start would mint competing
+ *   listeners for the same Channel.
+ *
+ * `activateChannels: false` remains the opt-out for a long-running host that
+ * does not want a socket (tests, short-lived scripts).
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { logger } from "@copilotkit/shared";
 import { createCopilotNodeListener } from "../endpoints/node";
 import { createCopilotExpressHandler } from "../endpoints/express";
 import { createCopilotHonoHandler } from "../endpoints/hono";
@@ -55,6 +65,11 @@ function countingEngine(): {
   return { engine, state };
 }
 
+/** An activation engine that always fails, standing in for an unreachable gateway. */
+const failingEngine: ActivateChannelEngine = async () => {
+  throw new Error("gateway unreachable");
+};
+
 const intelRuntimeWith1Channel = () =>
   new CopilotRuntime({
     agents: {},
@@ -63,12 +78,37 @@ const intelRuntimeWith1Channel = () =>
     channels: [createChannel({ name: "support" })],
   });
 
+/**
+ * Collect `unhandledRejection` reasons raised while `fn` runs, then wait long
+ * enough for Node to have reported any (it fires the event a macrotask after a
+ * rejected promise is left unhandled).
+ *
+ * @param fn - Work whose stray rejections should be captured.
+ * @returns The reasons Node reported as unhandled during `fn` plus the drain.
+ */
+async function unhandledRejectionsDuring(fn: () => void): Promise<unknown[]> {
+  const reasons: unknown[] = [];
+  const onUnhandled = (reason: unknown) => reasons.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    fn();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+  }
+  return reasons;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 /* ------------------------------------------------------------------------------------------------
  * Tests
  * --------------------------------------------------------------------------------------------- */
 
 describe("endpoint wrappers — managed channels propagation", () => {
-  it("Node listener exposes .channels and defers activation to ready()", async () => {
+  it("Node listener starts activation at creation, without any ready() call", () => {
     const { engine, state } = countingEngine();
 
     const listener = createCopilotNodeListener({
@@ -76,15 +116,24 @@ describe("endpoint wrappers — managed channels propagation", () => {
       __channelEngine: engine,
     });
 
-    // Creation is lazy: no socket opened yet.
-    expect(state.calls).toBe(0);
+    // Written without `!` on purpose: the branded overload makes `.channels`
+    // non-optional for a runtime with declared Channels (OSS-646); the
+    // compile-time proof lives in `handler-channels-types.test.ts`.
     expect(listener.channels).toBeDefined();
+    expect(state.calls).toBe(1);
+    expect(listener.channels.status().overall).toBe("connecting");
+  });
 
-    // ready() activates exactly once. Written without `!` on purpose: the
-    // branded overload makes `.channels` non-optional for a runtime with
-    // declared Channels (OSS-646), and the compile-time proof of that lives in
-    // `handler-channels-types.test.ts`.
+  it("Node listener's ready() observes the auto-started activation instead of a second one", async () => {
+    const { engine, state } = countingEngine();
+
+    const listener = createCopilotNodeListener({
+      runtime: intelRuntimeWith1Channel(),
+      __channelEngine: engine,
+    });
+
     await listener.channels.ready({ timeoutMs: 1000 });
+
     expect(state.calls).toBe(1);
     expect(listener.channels.status().overall).toBe("online");
     await listener.channels.stop();
@@ -102,7 +151,70 @@ describe("endpoint wrappers — managed channels propagation", () => {
     expect(state.calls).toBe(0);
   });
 
-  it("Express handler defers activation to ready() and exposes .channels on the returned Router", async () => {
+  it("activateChannels: false opts a Node listener out of the auto-start", () => {
+    const { engine, state } = countingEngine();
+
+    const listener = createCopilotNodeListener({
+      runtime: intelRuntimeWith1Channel(),
+      activateChannels: false,
+      __channelEngine: engine,
+    });
+
+    expect(listener.channels).toBeUndefined();
+    expect(state.calls).toBe(0);
+  });
+
+  it("Node listener logs a failed auto-start instead of leaving an unhandled rejection", async () => {
+    vi.spyOn(logger, "warn").mockImplementation(() => logger);
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => logger);
+    let listener!: ReturnType<typeof createCopilotNodeListener>;
+
+    const unhandled = await unhandledRejectionsDuring(() => {
+      listener = createCopilotNodeListener({
+        runtime: intelRuntimeWith1Channel(),
+        __channelEngine: failingEngine,
+      });
+    });
+
+    expect(unhandled).toEqual([]);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    // The reason survives to a later ready(), so a host that DOES await it still
+    // sees the real failure rather than a silently-degraded listener.
+    await expect(listener.channels!.ready({ timeoutMs: 1000 })).rejects.toThrow(
+      /failed to activate/,
+    );
+  });
+
+  it("Node listener logs a duplicate-Channel-name misconfiguration rather than throwing out of the factory", async () => {
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => logger);
+    const { engine, state } = countingEngine();
+    const runtime = new CopilotRuntime({
+      agents: {},
+      intelligence: intelligence(),
+      identifyUser,
+      channels: [
+        createChannel({ name: "support" }),
+        createChannel({ name: "support" }),
+      ],
+    });
+
+    const unhandled = await unhandledRejectionsDuring(() => {
+      expect(() =>
+        createCopilotNodeListener({ runtime, __channelEngine: engine }),
+      ).not.toThrow();
+    });
+
+    expect(unhandled).toEqual([]);
+    expect(state.calls).toBe(0);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0]?.[0]).toMatchObject({
+      err: expect.objectContaining({
+        message: expect.stringMatching(/Duplicate managed Channel name/),
+      }),
+    });
+  });
+
+  it("Express handler starts activation at creation and exposes .channels on the returned Router", async () => {
     const { engine, state } = countingEngine();
 
     const router = createCopilotExpressHandler({
@@ -111,15 +223,39 @@ describe("endpoint wrappers — managed channels propagation", () => {
       __channelEngine: engine,
     });
 
-    expect(state.calls).toBe(0);
     expect(router.channels).toBeDefined();
+    expect(state.calls).toBe(1);
     await router.channels!.ready({ timeoutMs: 1000 });
     expect(state.calls).toBe(1);
     expect(router.channels!.status().overall).toBe("online");
     await router.channels!.stop();
   });
 
-  it("Hono handler defers activation to ready() and exposes .channels on the returned app", async () => {
+  it("two wrappers over the SAME runtime activate its Channels once, not twice", async () => {
+    const { engine, state } = countingEngine();
+    const runtime = intelRuntimeWith1Channel();
+
+    // Auto-start makes the per-runtime manager cache load-bearing: before
+    // OSS-641 a second wrapper could only double-activate if someone called
+    // ready() twice, now merely constructing it would.
+    const listener = createCopilotNodeListener({
+      runtime,
+      __channelEngine: engine,
+    });
+    const router = createCopilotExpressHandler({
+      runtime,
+      basePath: "/api/copilotkit",
+      __channelEngine: engine,
+    });
+
+    expect(state.calls).toBe(1);
+    expect(router.channels).toBe(listener.channels);
+    await listener.channels.ready({ timeoutMs: 1000 });
+    expect(state.calls).toBe(1);
+    await listener.channels.stop();
+  });
+
+  it("Hono handler stays lazy so an edge/serverless isolate opens no socket at creation", async () => {
     const { engine, state } = countingEngine();
 
     const app = createCopilotHonoHandler({

--- a/packages/runtime/src/v2/runtime/core/fetch-handler.ts
+++ b/packages/runtime/src/v2/runtime/core/fetch-handler.ts
@@ -33,14 +33,21 @@
  * is LAZY: it is triggered by the first `await handler.channels.ready()` and
  * never before — not at handler creation, not on the first HTTP request.
  *
- * - On a LONG-RUNNING host (a Node server / container / the node/express/hono
- *   endpoint wrappers), call `await handler.channels.ready()` ONCE at startup to
- *   open the listener; the process owns it for its lifetime.
+ * - On a LONG-RUNNING host (a Node server / container / a Bun or Deno server),
+ *   call `await handler.channels.ready()` ONCE at startup to open the listener;
+ *   the process owns it for its lifetime.
  * - On a SERVERLESS / EDGE host (Cloudflare Workers, Next.js App Router), do NOT
  *   call `ready()` — those hosts freeze/recycle per-request isolates and cannot
  *   own a persistent listener, and separate cold starts would mint conflicting
  *   listeners. The generic Fetch handler stays a pure request/response function
  *   there, exactly as documented above.
+ *
+ * This laziness is a property of THIS handler, because it is the one entry point
+ * that must stay serverless-safe. The process-owning wrappers do not inherit it:
+ * `createCopilotNodeListener` and `createCopilotExpressHandler` START activation
+ * at creation (OSS-641), so `ready()` there is optional and await-and-observe.
+ * `createCopilotHonoHandler` keeps this handler's lazy behavior — a Hono app is
+ * multi-runtime and is our Next.js/edge surface in practice.
  *
  * @example
  * ```typescript
@@ -153,6 +160,11 @@ export interface CopilotRuntimeHandlerOptions {
    * TSDoc). Set `false` to opt out entirely: no {@link ChannelManager} is
    * constructed and the returned handler has no `.channels`. Non-intelligence or
    * channel-less runtimes never build a control surface regardless of this flag.
+   *
+   * The process-owning wrappers (`createCopilotNodeListener`,
+   * `createCopilotExpressHandler`) also START activation when this is left on,
+   * so `false` is the opt-out that keeps a mounted listener socket-free in a test
+   * or a short-lived script.
    */
   activateChannels?: boolean;
 

--- a/packages/runtime/src/v2/runtime/endpoints/auto-start-channels.ts
+++ b/packages/runtime/src/v2/runtime/endpoints/auto-start-channels.ts
@@ -1,0 +1,47 @@
+import { logger } from "@copilotkit/shared";
+import type { ChannelsControl } from "../core/channel-manager";
+
+/**
+ * Begin activation of a runtime's declared managed Channels on behalf of a
+ * LONG-RUNNING host (OSS-641).
+ *
+ * The generic Fetch handler deliberately defers activation to the first
+ * `channels.ready()`: it is the serverless/edge entry point, where an isolate
+ * freezes and recycles per request and separate cold starts would mint
+ * competing listeners for the same Channel. That constraint does not apply to a
+ * host that owns its own lifetime — a Node server or an Express app — so those
+ * wrappers start activation as soon as they are created and leave `ready()` as
+ * a pure await-and-observe call.
+ *
+ * Fire-and-forget by necessity: a factory is synchronous, so the activation
+ * outcome cannot be returned. That is a deliberate trade against the failure
+ * mode it replaces — a process that serves HTTP, looks healthy, and is silently
+ * disconnected because nothing ever called `ready()`. Here the worst case is an
+ * activation error in the logs. `ready()` is idempotent and one-shot, so a host
+ * that DOES await it afterwards observes THIS activation's outcome (including
+ * its rejection reason) rather than triggering a second one.
+ *
+ * The rejection is logged at `error`, not swallowed: an up-front
+ * misconfiguration (duplicate or missing Channel names) rejects `ready()`
+ * synchronously-ish from `activate()` and would otherwise be invisible to a
+ * host that never awaits `ready()` — the exact silence this change exists to
+ * remove. Per-Channel activation failures ALSO emit their own `warn`
+ * breadcrumbs through the manager's log bridge (see `fetch-handler.ts`), so the
+ * `error` here is the set-level summary, not the only signal.
+ *
+ * @param channels - The handler's control surface, or `undefined` when the
+ *   runtime declares no Channels or opted out via `activateChannels: false`
+ *   (both no-op, so the opt-out stays a genuine "open no socket").
+ */
+export function autoStartChannels(channels: ChannelsControl | undefined): void {
+  if (!channels) {
+    return;
+  }
+  channels.ready().catch((err) => {
+    logger.error(
+      { err },
+      "CopilotKit managed Channels failed to activate. The runtime is serving " +
+        "requests but one or more declared Channels are not connected.",
+    );
+  });
+}

--- a/packages/runtime/src/v2/runtime/endpoints/express.ts
+++ b/packages/runtime/src/v2/runtime/endpoints/express.ts
@@ -14,16 +14,17 @@ import type {
   ChannelsControl,
 } from "../core/channel-manager";
 import { createExpressNodeHandler } from "./express-fetch-bridge";
+import { autoStartChannels } from "./auto-start-channels";
 import type { CopilotRuntimeHooks } from "../core/hooks";
 
 /**
  * An Express {@link Router} that may also carry an optional
- * {@link ChannelsControl} surface. Express's Router is a request-scoped
- * middleware object, not a long-running process owner — Node
- * (`createCopilotNodeListener`) is the lifecycle-owning surface for
- * `.channels`. It is attached here too, best-effort, for callers that mount
- * the router directly and want to start (`ready()`), observe, or stop managed
- * Channel activation without also standing up a Node listener.
+ * {@link ChannelsControl} surface. The Router object itself is request-scoped
+ * middleware, but an Express app can only run inside a long-running
+ * `http.Server` — so this wrapper is a lifecycle-owning host like
+ * `createCopilotNodeListener`: it STARTS activation of the runtime's declared
+ * managed Channels at creation, and `.channels` is here to observe (`ready()`)
+ * or tear down (`stop()`) that activation.
  */
 export type CopilotExpressRouter = Router & { channels?: ChannelsControl };
 
@@ -53,8 +54,9 @@ export interface CopilotExpressEndpointParams {
 
   /**
    * Whether the underlying handler builds the control surface for the runtime's
-   * declared managed Channels. Defaults to `true`. Building it opens no
-   * connection — activation is deferred to the first `channels.ready()`. See
+   * declared managed Channels — and, because Express is a long-running host,
+   * starts their activation at creation. Defaults to `true`. Set `false` to
+   * build no surface and open no socket (tests, short-lived scripts). See
    * `CopilotRuntimeHandlerOptions.activateChannels`.
    */
   activateChannels?: boolean;
@@ -190,6 +192,7 @@ export function createCopilotExpressHandler({
 
   const exposedRouter: CopilotExpressRouter = router;
   exposedRouter.channels = handler.channels;
+  autoStartChannels(exposedRouter.channels);
   return exposedRouter;
 }
 

--- a/packages/runtime/src/v2/runtime/endpoints/hono.ts
+++ b/packages/runtime/src/v2/runtime/endpoints/hono.ts
@@ -10,11 +10,20 @@ import type {
 
 /**
  * A Hono app that may also carry an optional {@link ChannelsControl} surface.
- * Hono's app object is request-scoped routing config, not a long-running
- * process owner — Node (`createCopilotNodeListener`) is the lifecycle-owning
- * surface for `.channels`. It is attached here too, best-effort, for callers
- * that mount the Hono app directly and want to start (`ready()`), observe, or
- * stop managed Channel activation without also standing up a Node listener.
+ *
+ * Unlike the Node and Express wrappers — which own a process and therefore START
+ * managed-Channel activation at creation (OSS-641) — this wrapper stays LAZY:
+ * activation is triggered by the first `app.channels.ready()` and never before.
+ * A Hono app is multi-runtime and is our edge/serverless surface in practice:
+ * every Next.js App Router route handler in `examples/showcases/*` builds one at
+ * module scope, and those isolates freeze and recycle per request. Auto-starting
+ * there would mint a competing listener for the same Channel on every cold
+ * start, which is exactly what the lazy design exists to prevent (see the
+ * `createCopilotRuntimeHandler` TSDoc).
+ *
+ * So on a LONG-RUNNING Hono host (`@hono/node-server`, Bun, Deno) calling
+ * `await app.channels.ready()` once at startup is REQUIRED to connect declared
+ * Channels; on an edge/serverless host do NOT call it.
  */
 export type CopilotHonoApp = Hono & { channels?: ChannelsControl };
 

--- a/packages/runtime/src/v2/runtime/endpoints/node.ts
+++ b/packages/runtime/src/v2/runtime/endpoints/node.ts
@@ -4,14 +4,15 @@ import type { RuntimeWithDeclaredChannels } from "../core/runtime";
 import type { ChannelsControl } from "../core/channel-manager";
 import { createCopilotNodeHandler } from "./node-fetch-handler";
 import type { NodeFetchHandler } from "./node-fetch-handler";
+import { autoStartChannels } from "./auto-start-channels";
 
 /**
  * A Node.js HTTP request listener that is also a callable object carrying an
  * optional {@link ChannelsControl} surface, mirroring
  * `CopilotRuntimeFetchHandler.channels`. Node is the long-running,
  * lifecycle-owning entry point for the runtime, so it is the surface that
- * exposes `.channels` for callers that need to start, observe, or stop managed
- * Channel activation.
+ * exposes `.channels` for callers that need to observe or stop the managed
+ * Channel activation the listener starts at creation.
  */
 export type NodeCopilotListener = NodeFetchHandler & {
   channels?: ChannelsControl;
@@ -41,15 +42,24 @@ export type NodeCopilotListenerWithChannels = NodeFetchHandler & {
  *
  * ## Managed Channels lifecycle
  *
- * Creating the listener opens NO connection. Activation — which opens the
- * persistent Realtime Gateway WebSocket and starts every direct adapter on the
- * declared Channels — is LAZY: it is triggered by the first
- * `await listener.channels.ready()` and never before, neither at creation nor on
- * the first HTTP request. On a long-running host that call is REQUIRED, not
- * optional: without it the process serves HTTP but no Channel is ever connected.
- * `listener.channels.stop()` tears activation down. See the
- * `createCopilotRuntimeHandler` TSDoc for why activation is deferred
- * (serverless/edge safety).
+ * Creating the listener STARTS activation — which opens the persistent Realtime
+ * Gateway WebSocket and starts every direct adapter on the declared Channels.
+ * Node owns its own process lifetime, so there is nothing to defer to and no
+ * required incantation: a declared Channel connects because it was declared.
+ * (The generic `createCopilotRuntimeHandler` is the opposite — it stays lazy for
+ * serverless/edge safety; see its TSDoc.)
+ *
+ * `await listener.channels.ready()` is therefore OPTIONAL and purely
+ * await-and-observe: it resolves once every declared Channel has settled to
+ * `online`/`setup_required` and rejects with the activation failure, observing
+ * the activation started at creation rather than triggering a second one. Await
+ * it when startup should block on Channels being live (or should exit non-zero
+ * when they are not); skip it and activation failures land in the logs instead.
+ * `listener.channels.stop()` tears activation down.
+ *
+ * Pass `activateChannels: false` to build no control surface and open no socket
+ * — the clean opt-out for a test or a short-lived script that mounts the
+ * listener without wanting its Channels connected.
  *
  * @example
  * ```typescript
@@ -63,9 +73,10 @@ export type NodeCopilotListenerWithChannels = NodeFetchHandler & {
  *   cors: true,
  * });
  * createServer(listener).listen(3000);
+ * // Declared managed Channels are already connecting at this point.
  *
- * // Required to connect declared managed Channels. Bound it so one wedged
- * // adapter cannot hang startup forever.
+ * // Optional: block startup on them being live. Bound it so one wedged adapter
+ * // cannot hang startup forever.
  * await listener.channels.ready({ timeoutMs: 30_000 });
  * ```
  */
@@ -103,5 +114,6 @@ export function createCopilotNodeListener(
   const handler = createCopilotRuntimeHandler(options);
   const listener: NodeCopilotListener = createCopilotNodeHandler(handler);
   listener.channels = handler.channels;
+  autoStartChannels(listener.channels);
   return listener;
 }

--- a/showcase/shell-docs/src/content/docs/channels/deploy-and-operate.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/deploy-and-operate.mdx
@@ -21,16 +21,14 @@ available in Node.js 22+.
 Upgrade Channels and Runtime together, then run the same real-provider smoke
 test used for the initial quickstart.
 
-## Start before reporting ready
+## Settle before reporting ready
 
-Creating the Node listener exposes the optional Channels control surface but
-does not open the managed connection. Call `ready()` and inspect `status()`:
+Creating the Node listener starts the managed connection — a declared Channel
+connects because it was declared, with no start call to forget. Await `ready()`
+to observe that activation settling, then inspect `status()`:
 
 ```ts title="health.ts"
 const channels = listener.channels;
-if (!channels) {
-  throw new Error("Managed Channels control surface was not created.");
-}
 
 await channels.ready({ timeoutMs: 30_000 });
 
@@ -82,18 +80,28 @@ or error.
 
 ## Shut down cleanly
 
-Register signal handlers before calling `ready()`:
+Register signal handlers before **creating the listener**, not just before
+`ready()`. Creating it begins activation, so a signal that arrives during the
+connect window must already have somewhere to land — otherwise it hits Node's
+default handler and leaves a live gateway session behind:
 
 ```ts title="channel.ts"
+let teardown: (() => Promise<void>) | undefined;
 const shutdown = async () => {
-  await channels.stop();
-  if (server.listening) server.close();
+  await teardown?.();
 };
 
 process.once("SIGINT", shutdown);
 process.once("SIGTERM", shutdown);
 
-await channels.ready({ timeoutMs: 30_000 });
+const listener = createCopilotNodeListener({ runtime });
+const server = createServer(listener);
+teardown = async () => {
+  await listener.channels.stop();
+  if (server.listening) server.close();
+};
+
+await listener.channels.ready({ timeoutMs: 30_000 });
 ```
 
 Give the worker enough termination grace to stop its managed sessions. Avoid

--- a/showcase/shell-docs/src/content/docs/frontends/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/slack.mdx
@@ -140,40 +140,48 @@ You should have `CHANNEL_CODE` and `INTELLIGENCE_API_KEY`.
       channels: [channel],
     });
 
-    const listener = createCopilotNodeListener({
-      runtime,
-      basePath: "/api/copilotkit",
-    });
-
-    const channels = listener.channels;
-    if (!channels) {
-      throw new Error("Managed Channels control surface was not created.");
-    }
-
-    const server = createServer(listener);
-    const port = Number(process.env.PORT ?? 3000);
+    // Wire teardown before the listener exists, because creating it is what
+    // starts the Channel. A Ctrl-C during the connect window then still tears
+    // the Channel down instead of hitting Node's default handler.
+    let teardown: (() => Promise<void>) | undefined;
     const shutdown = async () => {
-      await channels.stop();
-      if (server.listening) server.close();
+      await teardown?.();
     };
     process.once("SIGINT", shutdown);
     process.once("SIGTERM", shutdown);
 
+    const listener = createCopilotNodeListener({
+      runtime,
+      basePath: "/api/copilotkit",
+    });
+    const channels = listener.channels;
+    const server = createServer(listener);
+    teardown = async () => {
+      await channels.stop();
+      if (server.listening) server.close();
+    };
+
+    // Optional: block startup until the activation above settles, so a broken
+    // deploy fails loudly instead of serving as a bot that never answers.
     await channels.ready({ timeoutMs: 30_000 });
     const status = channels.status();
     if (status.overall !== "online") {
       throw new Error(`Slack Channel is not online: ${JSON.stringify(status)}`);
     }
 
+    const port = Number(process.env.PORT ?? 3000);
     server.listen(port, () => {
       console.log(`Slack Channel online; lifecycle server listening on :${port}`);
     });
     ```
 
-    Creating the Node listener exposes Channel lifecycle control but opens no
-    connection. On this long-running host, `ready()` is required: its first call
-    lazily opens the Realtime Gateway connection. It can resolve with setup
-    still required, so inspect `status()` before reporting the Channel online.
+    Creating the Node listener starts the Channel: it owns its own process
+    lifetime, so a declared Channel connects because it was declared. `ready()`
+    is therefore optional and purely await-and-observe — it resolves once
+    activation settles and rejects with the activation failure. Because it can
+    settle with setup still required, inspect `status()` before reporting the
+    Channel online. Skip `ready()` and activation failures land in your logs
+    instead.
 
   </Step>
 
@@ -209,15 +217,16 @@ You should have `CHANNEL_CODE` and `INTELLIGENCE_API_KEY`.
 
     #### Know the healthy state
 
-    After you start the process and call `await channels.ready(...)` on the
-    guarded control from this guide, the Channel should become **Online**.
+    Starting the process is what connects the Channel, so it should become
+    **Online** on its own; the `await channels.ready(...)` in this guide only
+    waits for that to settle.
 
     | Status | What to check |
     | --- | --- |
     | **Disabled** | Enable the Channel before expecting delivery. |
     | **Setup incomplete** | Finish the selected provider's required setup fields before starting the runtime. |
     | **Setup failed** | Reopen platform setup and correct the rejected credentials or configuration. |
-    | **Waiting for runtime** | Start the process, call `await channels.ready(...)` on the guarded control, and match its Code and provider to this Channel. |
+    | **Waiting for runtime** | Start the process — creating the listener connects the Channel — and match its Code and provider to this Channel. |
     | **Conflict** | Compare every replica's complete Channel declaration set. Identical replicas should elect one active owner and connected standbys; different but overlapping sets are unsafe. |
     | **Offline** | Check the listener process, network, and Intelligence gateway connection. |
     | **Delivery failing** | Check platform credentials, app permissions, and the provider response. |

--- a/showcase/shell-docs/src/content/docs/frontends/teams.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/teams.mdx
@@ -133,40 +133,48 @@ You should have `CHANNEL_CODE` and `INTELLIGENCE_API_KEY`.
       channels: [channel],
     });
 
-    const listener = createCopilotNodeListener({
-      runtime,
-      basePath: "/api/copilotkit",
-    });
-
-    const channels = listener.channels;
-    if (!channels) {
-      throw new Error("Managed Channels control surface was not created.");
-    }
-
-    const server = createServer(listener);
-    const port = Number(process.env.PORT ?? 3000);
+    // Wire teardown before the listener exists, because creating it is what
+    // starts the Channel. A Ctrl-C during the connect window then still tears
+    // the Channel down instead of hitting Node's default handler.
+    let teardown: (() => Promise<void>) | undefined;
     const shutdown = async () => {
-      await channels.stop();
-      if (server.listening) server.close();
+      await teardown?.();
     };
     process.once("SIGINT", shutdown);
     process.once("SIGTERM", shutdown);
 
+    const listener = createCopilotNodeListener({
+      runtime,
+      basePath: "/api/copilotkit",
+    });
+    const channels = listener.channels;
+    const server = createServer(listener);
+    teardown = async () => {
+      await channels.stop();
+      if (server.listening) server.close();
+    };
+
+    // Optional: block startup until the activation above settles, so a broken
+    // deploy fails loudly instead of serving as a bot that never answers.
     await channels.ready({ timeoutMs: 30_000 });
     const status = channels.status();
     if (status.overall !== "online") {
       throw new Error(`Teams Channel is not online: ${JSON.stringify(status)}`);
     }
 
+    const port = Number(process.env.PORT ?? 3000);
     server.listen(port, () => {
       console.log(`Teams Channel online; lifecycle server listening on :${port}`);
     });
     ```
 
-    Creating the Node listener exposes Channel lifecycle control but opens no
-    connection. On this long-running host, `ready()` is required: its first call
-    lazily opens the Realtime Gateway connection. It can resolve with setup
-    still required, so inspect `status()` before reporting the Channel online.
+    Creating the Node listener starts the Channel: it owns its own process
+    lifetime, so a declared Channel connects because it was declared. `ready()`
+    is therefore optional and purely await-and-observe — it resolves once
+    activation settles and rejects with the activation failure. Because it can
+    settle with setup still required, inspect `status()` before reporting the
+    Channel online. Skip `ready()` and activation failures land in your logs
+    instead.
 
     The runner does not expose a Teams webhook. The public messaging endpoint
     remains the Intelligence endpoint you copied into Azure Bot.
@@ -204,15 +212,16 @@ You should have `CHANNEL_CODE` and `INTELLIGENCE_API_KEY`.
 
     #### Know the healthy state
 
-    After you start the process and call `await channels.ready(...)` on the
-    guarded control from this guide, the Channel should become **Online**.
+    Starting the process is what connects the Channel, so it should become
+    **Online** on its own; the `await channels.ready(...)` in this guide only
+    waits for that to settle.
 
     | Status | What to check |
     | --- | --- |
     | **Disabled** | Enable the Channel before expecting delivery. |
     | **Setup incomplete** | Finish the selected provider's required setup fields before starting the runtime. |
     | **Setup failed** | Reopen platform setup and correct the rejected credentials or configuration. |
-    | **Waiting for runtime** | Start the process, call `await channels.ready(...)` on the guarded control, and match its Code and provider to this Channel. |
+    | **Waiting for runtime** | Start the process — creating the listener connects the Channel — and match its Code and provider to this Channel. |
     | **Conflict** | Compare every replica's complete Channel declaration set. Identical replicas should elect one active owner and connected standbys; different but overlapping sets are unsafe. |
     | **Offline** | Check the listener process, network, and Intelligence gateway connection. |
     | **Delivery failing** | Check platform credentials, app permissions, and the provider response. |


### PR DESCRIPTION
Resolves [OSS-641](https://linear.app/copilotkit/issue/OSS-641). Mike's report: *"You have to `await channels.ready()` for it to connect to the Realtime Gateway. Seems like there's some clunkiness to creating the runtime and getting it connected."* He then picked the fix: *"I think it should autostart in the long running wrappers."*

## What changes

**`createCopilotNodeListener` and `createCopilotExpressHandler` start activation at creation.** A declared Channel connects because it was declared; `channels.ready()` becomes await-and-observe rather than the call you must remember. Failure-mode asymmetry is the argument: forgetting `ready()` today gives you a process that serves HTTP, looks healthy, and is silently disconnected with **zero output**, while auto-start's worst case is an activation error in the logs.

**`createCopilotRuntimeHandler` and `createCopilotHonoHandler` stay lazy.** The generic Fetch handler is the serverless/edge entry point — isolates freeze and recycle per request, so separate cold starts would mint competing listeners for the same Channel (the reason activation was deferred in `fbf35ac59` in the first place). Hono keeps that behavior because it is our Next.js App Router surface in practice: every route handler in `examples/showcases/*` (banking, mcp-apps, generative-ui-playground, oracle-agent-memory) plus the vue/nuxt demo builds one at module scope. Its TSDoc now states why, loudly, so nobody "finishes the job" later.

`activateChannels: false` remains the clean opt-out that opens no socket.

## Consequence for host code: the shutdown boundary moves earlier

Signal handlers must now be registered **before the listener is created**, not merely before `ready()`. Otherwise a Ctrl-C during the connect window hits Node's default handler and leaks a live gateway session. `examples/slack`, `examples/teams`, and the docs snippets are restructured to wire teardown before the listener exists (a `stopChannels`/`teardown` binding assigned in the same tick as creation). **Worth calling out in the changelog** — it is the general hazard for any user code that registers shutdown after mounting.

## Failure semantics

Fire-and-forget by necessity, since a factory is synchronous. Set-level failures log at `error`; per-Channel failures keep their existing `warn` breadcrumbs; an up-front misconfiguration (duplicate/missing Channel names) now surfaces as a logged error at creation rather than a throw out of the factory — the factory still never throws. `ready()` stays idempotent and one-shot, so a host that *does* await it observes this activation's outcome, including its rejection, rather than triggering a second one.

## READMEs

Every `channels-*/README.md` quickstart built the *generic* handler and needed `await handler.channels.ready()` — for a socket-mode Slack bot, a request handler you construct and never serve, which is likely closer to what actually felt clunky. All seven now use the Node listener, so they inherit auto-start and agree with the docs-site quickstarts. No new public surface: a bot-only `startChannels(runtime)` host was the alternative and is deliberately not taken here.

## Testing

- **`packages/runtime` unit suite: 1815 passed / 128 files** (`npx vitest run`), including 9 tests in `endpoints-channels.test.ts` covering: auto-start on node + express; Hono still lazy; `activateChannels: false` opens no socket; a failed auto-start logs instead of leaving an unhandled rejection (asserted via an `unhandledRejection` listener) and the reason survives to a later `ready()`; a duplicate-name misconfig logs without throwing; and two wrappers over one runtime activate once (the per-runtime manager cache is load-bearing now that *construction* activates).
- **`examples/slack`: 63 passed / 12 files; `examples/teams`: 2 passed / 1 file** (`npm test` in each).
- **Typecheck clean:** `examples/slack` and `examples/teams` (`tsc --noEmit`), plus a full `@copilotkit/runtime` tsdown build.
- **Lint/format clean:** `oxlint` reports 0 findings in every changed file (the 21 warnings in that run are pre-existing, all in untouched example render/tool files), `oxfmt --check` passes on all 9 changed source files.
- **Docs:** verified no stale lifecycle claims remain (`opens no connection` / `ready() is required` / `control surface` guards) across `docs/channels/**` and the Slack + Teams platform guides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
