### PR TITLE
fix(channels): isolate factory-returned agents so multi-turn replies work

### DIFF
--- a/packages/channels-core/src/create-channel.test.ts
+++ b/packages/channels-core/src/create-channel.test.ts
@@ -58,18 +58,18 @@ function collectText(nodes: ChannelNode[]): string {
 }
 
 /**
- * Capture user messages injected into a fake agent (and every clone of it).
- * createChannel always isolates via `clone()`, so spies on the prototype alone
- * would miss the agent instance that actually runs the turn.
+ * Apply `patch` to `agent` and, recursively, to every clone descended from it.
+ *
+ * `createChannel` isolates every turn via `clone()`, so the instance that
+ * actually runs is never the one configured in the test. A spy installed only on
+ * the configured agent would observe nothing.
  */
-function captureAddedMessages(agent: FakeAgent): unknown[] {
-  const added: unknown[] = [];
+function patchAgentAndClones(
+  agent: FakeAgent,
+  patch: (target: FakeAgent) => void,
+): void {
   const wrap = (target: FakeAgent): void => {
-    const addMessage = target.addMessage.bind(target);
-    target.addMessage = (message) => {
-      added.push(message);
-      return addMessage(message);
-    };
+    patch(target);
     const origClone = target.clone.bind(target);
     target.clone = () => {
       const cloned = origClone();
@@ -78,27 +78,32 @@ function captureAddedMessages(agent: FakeAgent): unknown[] {
     };
   };
   wrap(agent);
+}
+
+/** Capture user messages injected into a fake agent (and every clone of it). */
+function captureAddedMessages(agent: FakeAgent): unknown[] {
+  const added: unknown[] = [];
+  patchAgentAndClones(agent, (target) => {
+    const addMessage = target.addMessage.bind(target);
+    target.addMessage = (message) => {
+      added.push(message);
+      return addMessage(message);
+    };
+  });
   return added;
 }
 
-/** Sum `runAgentCalls` across the prototype and every clone produced from it. */
+/** Sum `runAgent` calls across the configured agent and every clone of it. */
 function trackRunAgentCalls(agent: FakeAgent): { total: () => number } {
   let total = 0;
-  const wrap = (target: FakeAgent): void => {
+  patchAgentAndClones(agent, (target) => {
     const orig = target.runAgent.bind(target);
     target.runAgent = async (parameters, subscriber) => {
       total += 1;
       // Keep FakeAgent's own counter in sync for any direct assertions.
       return orig(parameters, subscriber);
     };
-    const origClone = target.clone.bind(target);
-    target.clone = () => {
-      const cloned = origClone();
-      wrap(cloned);
-      return cloned;
-    };
-  };
-  wrap(agent);
+  });
   return { total: () => total };
 }
 
@@ -460,7 +465,7 @@ describe("createChannel", () => {
     // Capture the context/tools passed to the (isolated) agent's first runAgent call.
     let seenContext: unknown;
     let seenTools: unknown;
-    const wrapRun = (target: FakeAgent): void => {
+    patchAgentAndClones(agent, (target) => {
       const origRunAgent = target.runAgent.bind(target);
       target.runAgent = async (parameters, subscriber) => {
         if (seenContext === undefined) {
@@ -470,14 +475,7 @@ describe("createChannel", () => {
         }
         return origRunAgent(parameters, subscriber);
       };
-      const origClone = target.clone.bind(target);
-      target.clone = () => {
-        const cloned = origClone();
-        wrapRun(cloned);
-        return cloned;
-      };
-    };
-    wrapRun(agent);
+    });
 
     const channel = createChannel({
       adapters: [fake],
@@ -850,17 +848,9 @@ describe("createChannel", () => {
   it("factory that returns a shared instance still isolates per turn", async () => {
     const state = new MemoryStore();
     const shared = new FakeAgent();
-    const seen: FakeAgent[] = [];
 
     const fake = new FakeAdapter();
-    const origGetOrCreate = fake.conversationStore.getOrCreate.bind(
-      fake.conversationStore,
-    );
-    fake.conversationStore.getOrCreate = async (key, target, makeAgent) => {
-      const session = await origGetOrCreate(key, target, makeAgent);
-      seen.push(session.agent as FakeAgent);
-      return session;
-    };
+    const { agents: seen } = captureSessionAgents(fake);
 
     // Common "singleton factory" anti-pattern: returns the same object every call.
     // Parallel turns must still get distinct clones, not serialize on one agent.
@@ -1056,10 +1046,8 @@ describe("createChannel", () => {
     // Capture the context the agent receives on its first runAgent call, and
     // have the fake produce an assistant message with text on agent.messages
     // (mirroring how run-loop expects assistant replies to land there).
-    // Applied to the prototype and every isolate/clone — createChannel never
-    // runs the configured prototype directly.
     let seenContext: unknown;
-    const wrapRun = (target: FakeAgent): void => {
+    patchAgentAndClones(agent, (target) => {
       const origRunAgent = target.runAgent.bind(target);
       target.runAgent = async (parameters, subscriber) => {
         if (seenContext === undefined) {
@@ -1073,14 +1061,7 @@ describe("createChannel", () => {
         });
         return origRunAgent(parameters, subscriber);
       };
-      const origClone = target.clone.bind(target);
-      target.clone = () => {
-        const cloned = origClone();
-        wrapRun(cloned);
-        return cloned;
-      };
-    };
-    wrapRun(agent);
+    });
 
     channel.onMention(async ({ thread }) => {
       await thread.runAgent({ transcript: true });

--- a/packages/channels-core/src/create-channel.test.ts
+++ b/packages/channels-core/src/create-channel.test.ts
@@ -57,15 +57,66 @@ function collectText(nodes: ChannelNode[]): string {
   return out;
 }
 
-/** Capture user messages injected into a fake agent without changing its behavior. */
+/**
+ * Capture user messages injected into a fake agent (and every clone of it).
+ * createChannel always isolates via `clone()`, so spies on the prototype alone
+ * would miss the agent instance that actually runs the turn.
+ */
 function captureAddedMessages(agent: FakeAgent): unknown[] {
   const added: unknown[] = [];
-  const addMessage = agent.addMessage.bind(agent);
-  agent.addMessage = (message) => {
-    added.push(message);
-    return addMessage(message);
+  const wrap = (target: FakeAgent): void => {
+    const addMessage = target.addMessage.bind(target);
+    target.addMessage = (message) => {
+      added.push(message);
+      return addMessage(message);
+    };
+    const origClone = target.clone.bind(target);
+    target.clone = () => {
+      const cloned = origClone();
+      wrap(cloned);
+      return cloned;
+    };
   };
+  wrap(agent);
   return added;
+}
+
+/** Sum `runAgentCalls` across the prototype and every clone produced from it. */
+function trackRunAgentCalls(agent: FakeAgent): { total: () => number } {
+  let total = 0;
+  const wrap = (target: FakeAgent): void => {
+    const orig = target.runAgent.bind(target);
+    target.runAgent = async (parameters, subscriber) => {
+      total += 1;
+      // Keep FakeAgent's own counter in sync for any direct assertions.
+      return orig(parameters, subscriber);
+    };
+    const origClone = target.clone.bind(target);
+    target.clone = () => {
+      const cloned = origClone();
+      wrap(cloned);
+      return cloned;
+    };
+  };
+  wrap(agent);
+  return { total: () => total };
+}
+
+/**
+ * Capture the agent instance handed to the conversation store (post-isolation).
+ * Use when asserting on the agent that actually ran, not the configured prototype.
+ */
+function captureSessionAgents(
+  fake: FakeAdapter,
+): { agents: FakeAgent[] } {
+  const agents: FakeAgent[] = [];
+  const orig = fake.conversationStore.getOrCreate.bind(fake.conversationStore);
+  fake.conversationStore.getOrCreate = async (key, target, makeAgent) => {
+    const session = await orig(key, target, makeAgent);
+    agents.push(session.agent as FakeAgent);
+    return session;
+  };
+  return { agents };
 }
 
 describe("createChannel", () => {
@@ -137,6 +188,7 @@ describe("createChannel", () => {
     Object.defineProperty(fake, "injectInboundTurnOnce", { value: true });
     const agent = new FakeAgent();
     const added = captureAddedMessages(agent);
+    const runs = trackRunAgentCalls(agent);
     const channel = createChannel({ adapters: [fake], agent: () => agent });
 
     channel.onMention(async ({ thread }) => {
@@ -152,7 +204,9 @@ describe("createChannel", () => {
       platform: "fake",
     });
 
-    expect(agent.runAgentCalls).toBe(2);
+    // Two runAgent calls in one handler → two isolated agent instances, each run once.
+    expect(runs.total()).toBe(2);
+    // Implicit inbound prompt is injected only on the first run of the turn.
     expect(added).toEqual([
       expect.objectContaining({
         role: "user",
@@ -184,6 +238,7 @@ describe("createChannel", () => {
       },
       () => undefined,
     ]);
+    const sessionAgents = captureSessionAgents(fake);
     const channel = createChannel({
       adapters: [fake],
       agent: () => agent,
@@ -210,10 +265,12 @@ describe("createChannel", () => {
     });
 
     expect(lifecycleCalls).toHaveLength(1);
-    expect(agent.runAgentCalls).toBe(2);
+    // Tool loop runs twice on the isolated session agent, not the prototype.
+    expect(sessionAgents.agents).toHaveLength(1);
+    expect(sessionAgents.agents[0]!.runAgentCalls).toBe(2);
     expect(canonicalToolEnds).toEqual(["tool-1"]);
     expect(
-      agent.messages.some(
+      sessionAgents.agents[0]!.messages.some(
         (message) => message.role === "tool" && message.toolCallId === "tool-1",
       ),
     ).toBe(true);
@@ -402,18 +459,27 @@ describe("createChannel", () => {
   it("merges per-turn runAgent context with the channel-level context", async () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    // Capture the context/tools passed to the agent's first runAgent call.
+    // Capture the context/tools passed to the (isolated) agent's first runAgent call.
     let seenContext: unknown;
     let seenTools: unknown;
-    const origRunAgent = agent.runAgent.bind(agent);
-    agent.runAgent = async (parameters, subscriber) => {
-      if (seenContext === undefined) {
-        seenContext = (parameters as { context?: unknown } | undefined)
-          ?.context;
-        seenTools = (parameters as { tools?: unknown } | undefined)?.tools;
-      }
-      return origRunAgent(parameters, subscriber);
+    const wrapRun = (target: FakeAgent): void => {
+      const origRunAgent = target.runAgent.bind(target);
+      target.runAgent = async (parameters, subscriber) => {
+        if (seenContext === undefined) {
+          seenContext = (parameters as { context?: unknown } | undefined)
+            ?.context;
+          seenTools = (parameters as { tools?: unknown } | undefined)?.tools;
+        }
+        return origRunAgent(parameters, subscriber);
+      };
+      const origClone = target.clone.bind(target);
+      target.clone = () => {
+        const cloned = origClone();
+        wrapRun(cloned);
+        return cloned;
+      };
     };
+    wrapRun(agent);
 
     const channel = createChannel({
       adapters: [fake],
@@ -783,6 +849,60 @@ describe("createChannel", () => {
     ).rejects.toThrow(/clone\(\) must return a distinct instance/);
   });
 
+  it("factory that returns a shared instance still isolates per turn", async () => {
+    const state = new MemoryStore();
+    const shared = new FakeAgent();
+    const seen: FakeAgent[] = [];
+
+    const fake = new FakeAdapter();
+    const origGetOrCreate = fake.conversationStore.getOrCreate.bind(
+      fake.conversationStore,
+    );
+    fake.conversationStore.getOrCreate = async (key, target, makeAgent) => {
+      const session = await origGetOrCreate(key, target, makeAgent);
+      seen.push(session.agent as FakeAgent);
+      return session;
+    };
+
+    // Common "singleton factory" anti-pattern: returns the same object every call.
+    // Parallel turns must still get distinct clones, not serialize on one agent.
+    const channel = createChannel({
+      adapters: [fake],
+      agent: (threadId) => {
+        shared.threadId = threadId;
+        return shared;
+      },
+      store: { adapter: state },
+    });
+    channel.onMention(async ({ thread }) => {
+      await thread.runAgent({ prompt: "hi" });
+    });
+
+    await channel.ɵruntime.start();
+    const sink = fake.getSink();
+    await Promise.all([
+      sink.onTurn({
+        conversationKey: "c1",
+        replyTarget: {},
+        userText: "a",
+        platform: "fake" as const,
+        eventId: "E1",
+      }),
+      sink.onTurn({
+        conversationKey: "c1",
+        replyTarget: {},
+        userText: "b",
+        platform: "fake" as const,
+        eventId: "E2",
+      }),
+    ]);
+
+    expect(seen.length).toBe(2);
+    expect(seen[0]).not.toBe(shared);
+    expect(seen[1]).not.toBe(shared);
+    expect(seen[0]).not.toBe(seen[1]);
+  });
+
   it("dedupes turns by eventId", async () => {
     const state = new MemoryStore();
     let runs = 0;
@@ -938,20 +1058,31 @@ describe("createChannel", () => {
     // Capture the context the agent receives on its first runAgent call, and
     // have the fake produce an assistant message with text on agent.messages
     // (mirroring how run-loop expects assistant replies to land there).
+    // Applied to the prototype and every isolate/clone — createChannel never
+    // runs the configured prototype directly.
     let seenContext: unknown;
-    const origRunAgent = agent.runAgent.bind(agent);
-    agent.runAgent = async (parameters, subscriber) => {
-      if (seenContext === undefined) {
-        seenContext = (parameters as { context?: unknown } | undefined)
-          ?.context;
-      }
-      agent.addMessage({
-        id: globalThis.crypto.randomUUID(),
-        role: "assistant",
-        content: "the assistant reply",
-      });
-      return origRunAgent(parameters, subscriber);
+    const wrapRun = (target: FakeAgent): void => {
+      const origRunAgent = target.runAgent.bind(target);
+      target.runAgent = async (parameters, subscriber) => {
+        if (seenContext === undefined) {
+          seenContext = (parameters as { context?: unknown } | undefined)
+            ?.context;
+        }
+        target.addMessage({
+          id: globalThis.crypto.randomUUID(),
+          role: "assistant",
+          content: "the assistant reply",
+        });
+        return origRunAgent(parameters, subscriber);
+      };
+      const origClone = target.clone.bind(target);
+      target.clone = () => {
+        const cloned = origClone();
+        wrapRun(cloned);
+        return cloned;
+      };
     };
+    wrapRun(agent);
 
     channel.onMention(async ({ thread }) => {
       await thread.runAgent({ transcript: true });

--- a/packages/channels-core/src/create-channel.test.ts
+++ b/packages/channels-core/src/create-channel.test.ts
@@ -106,9 +106,7 @@ function trackRunAgentCalls(agent: FakeAgent): { total: () => number } {
  * Capture the agent instance handed to the conversation store (post-isolation).
  * Use when asserting on the agent that actually ran, not the configured prototype.
  */
-function captureSessionAgents(
-  fake: FakeAdapter,
-): { agents: FakeAgent[] } {
+function captureSessionAgents(fake: FakeAdapter): { agents: FakeAgent[] } {
   const agents: FakeAgent[] = [];
   const orig = fake.conversationStore.getOrCreate.bind(fake.conversationStore);
   fake.conversationStore.getOrCreate = async (key, target, makeAgent) => {

--- a/packages/channels-core/src/create-channel.ts
+++ b/packages/channels-core/src/create-channel.ts
@@ -84,13 +84,23 @@ export type ChannelConcurrency = "parallel" | "serial" | "drop";
 /**
  * Isolate an agent for one turn via `clone()`.
  *
- * Used for:
+ * Applied to every configured shape, so the object a turn runs on is never one
+ * the caller still holds a reference to:
  * - `createChannel({ agent: shared })` (singleton config)
- * - factories that return a shared instance (`agent: (id) => shared`)
+ * - `agent: (id) => new Agent()` (fresh factory — clone of an unused agent)
+ * - `agent: (id) => shared` (factory returning a shared instance)
  *
- * Post-clone hygiene matters: `HttpAgent.clone()` will start aborted if the
- * prototype's AbortController was aborted, and `isRunning` is copied from the
- * source — either leaves concurrent/follow-up turns dead. Always reset both.
+ * The last shape is the one that needs this. A factory returning the same object
+ * every call hands each turn an agent already mutated by the previous turn, and
+ * `DeliveryAdapter.acquireAgent` keys on object identity, so those turns also
+ * serialize behind one another instead of running independently.
+ *
+ * Caveat for custom agents: `AbstractAgent.prototype.clone()` copies a fixed
+ * field list, so fields declared by a subclass (auth clients, config, caches)
+ * are **not** carried onto the clone and read back as `undefined`. There is no
+ * loud failure for this — `clone()` always exists on the base class and returns
+ * a correctly-typed instance. Subclasses with their own state must override
+ * `clone()` to copy it.
  */
 export function isolateAgentInstance(
   prototype: AbstractAgent,
@@ -99,7 +109,8 @@ export function isolateAgentInstance(
   if (typeof prototype.clone !== "function") {
     throw new Error(
       "createChannel: agent must implement clone() that returns a new instance " +
-        "(HttpAgent, BuiltInAgent, etc.), or pass agent: (threadId) => new Agent() factory",
+        "(HttpAgent, BuiltInAgent, etc.). Every turn is isolated via clone(), " +
+        "including agents returned from an agent: (threadId) => ... factory.",
     );
   }
   const cloned = prototype.clone() as AbstractAgent;
@@ -109,21 +120,22 @@ export function isolateAgentInstance(
     );
   }
   cloned.threadId = threadId;
-  // Never inherit a mid-run or aborted lifecycle from the prototype / prior clone.
+  // `clone()` copies both of these from the source, so a clone taken from an
+  // agent that has already run starts out claiming to be mid-run with a spent
+  // (possibly aborted) controller. A fresh turn is neither.
+  //
+  // Note this is hygiene, not the fix for a dead follow-up turn: `runAgent`
+  // assigns `abortController = params?.abortController ?? new AbortController()`
+  // before each run, so an inherited aborted controller cannot reach the next
+  // request on its own. Reset it anyway so anything reading the signal between
+  // isolation and the run sees a live one.
   cloned.isRunning = false;
   const withAbort = cloned as AbstractAgent & {
     abortController?: AbortController;
   };
-  if ("abortController" in withAbort || withAbort.abortController) {
+  if ("abortController" in withAbort) {
     withAbort.abortController = new AbortController();
   }
-  // Drop any in-flight run handles Object.create may have left undefined/shared.
-  const withRun = cloned as AbstractAgent & {
-    activeRunDetach$?: unknown;
-    activeRunCompletionPromise?: unknown;
-  };
-  withRun.activeRunDetach$ = undefined;
-  withRun.activeRunCompletionPromise = undefined;
   return cloned;
 }
 
@@ -564,17 +576,17 @@ export function createChannel<
   let telemetry: ChannelTelemetry | undefined;
 
   /**
-   * Per-turn agent resolution — always isolate via `clone()`.
+   * Per-turn agent resolution — always isolate via `clone()`, for both the
+   * singleton config and the result of a factory.
    *
-   * Why always (not only on concurrent conflict):
-   * - `agent: shared` and `agent: () => shared` must never *run* the prototype.
-   *   Running it mutates abortController / isRunning / messages; the next clone
-   *   from an aborted HttpAgent starts dead (HttpAgent.clone re-aborts when the
-   *   source signal is aborted), so only the first turn replies.
-   * - Fresh factories (`() => new Agent()`) still work: clone of an unused agent
-   *   is a clean independent instance.
-   * - DeliveryAdapter.acquireAgent keys on object identity; distinct clones are
-   *   what allow concurrent same-thread turns instead of serializing on one agent.
+   * Isolating the singleton config alone is not enough: a factory is free to
+   * return the same object on every call (`agent: (id) => shared`), which is an
+   * easy shape to write by accident. Left un-isolated, each turn runs an agent
+   * still carrying the previous turn's messages and lifecycle flags, and
+   * `DeliveryAdapter.acquireAgent` — which keys on object identity — serializes
+   * those turns behind one another. Cloning the factory's result costs nothing
+   * for a fresh factory (`() => new Agent()` clones an unused agent) and closes
+   * the shared-instance case.
    */
   const agentFactory: (threadId: string) => AbstractAgent = (() => {
     // Applied here rather than at each call site so a developer never has to
@@ -596,8 +608,7 @@ export function createChannel<
       return (threadId: string) =>
         sanitize(isolateAgentInstance(a(threadId), threadId));
     }
-    return (threadId: string) =>
-      sanitize(isolateAgentInstance(a, threadId));
+    return (threadId: string) => sanitize(isolateAgentInstance(a, threadId));
   })();
 
   /** Per-conversation serial turn queue (error-boundaried so one failure cannot poison the chain). */

--- a/packages/channels-core/src/create-channel.ts
+++ b/packages/channels-core/src/create-channel.ts
@@ -82,8 +82,15 @@ export type LockConflictDecision = "drop" | "force";
 export type ChannelConcurrency = "parallel" | "serial" | "drop";
 
 /**
- * Isolate a configured singleton agent for one run via `clone()`.
- * Fail loud when clone is missing or returns the same instance.
+ * Isolate an agent for one turn via `clone()`.
+ *
+ * Used for:
+ * - `createChannel({ agent: shared })` (singleton config)
+ * - factories that return a shared instance (`agent: (id) => shared`)
+ *
+ * Post-clone hygiene matters: `HttpAgent.clone()` will start aborted if the
+ * prototype's AbortController was aborted, and `isRunning` is copied from the
+ * source — either leaves concurrent/follow-up turns dead. Always reset both.
  */
 export function isolateAgentInstance(
   prototype: AbstractAgent,
@@ -91,8 +98,8 @@ export function isolateAgentInstance(
 ): AbstractAgent {
   if (typeof prototype.clone !== "function") {
     throw new Error(
-      "createChannel: singleton agent must implement clone() that returns a new instance " +
-        "(HttpAgent, BuiltInAgent, etc.), or pass agent: (threadId) => ... factory",
+      "createChannel: agent must implement clone() that returns a new instance " +
+        "(HttpAgent, BuiltInAgent, etc.), or pass agent: (threadId) => new Agent() factory",
     );
   }
   const cloned = prototype.clone() as AbstractAgent;
@@ -102,6 +109,21 @@ export function isolateAgentInstance(
     );
   }
   cloned.threadId = threadId;
+  // Never inherit a mid-run or aborted lifecycle from the prototype / prior clone.
+  cloned.isRunning = false;
+  const withAbort = cloned as AbstractAgent & {
+    abortController?: AbortController;
+  };
+  if ("abortController" in withAbort || withAbort.abortController) {
+    withAbort.abortController = new AbortController();
+  }
+  // Drop any in-flight run handles Object.create may have left undefined/shared.
+  const withRun = cloned as AbstractAgent & {
+    activeRunDetach$?: unknown;
+    activeRunCompletionPromise?: unknown;
+  };
+  withRun.activeRunDetach$ = undefined;
+  withRun.activeRunCompletionPromise = undefined;
   return cloned;
 }
 
@@ -541,6 +563,19 @@ export function createChannel<
   let registry: ActionRegistry | undefined;
   let telemetry: ChannelTelemetry | undefined;
 
+  /**
+   * Per-turn agent resolution — always isolate via `clone()`.
+   *
+   * Why always (not only on concurrent conflict):
+   * - `agent: shared` and `agent: () => shared` must never *run* the prototype.
+   *   Running it mutates abortController / isRunning / messages; the next clone
+   *   from an aborted HttpAgent starts dead (HttpAgent.clone re-aborts when the
+   *   source signal is aborted), so only the first turn replies.
+   * - Fresh factories (`() => new Agent()`) still work: clone of an unused agent
+   *   is a clean independent instance.
+   * - DeliveryAdapter.acquireAgent keys on object identity; distinct clones are
+   *   what allow concurrent same-thread turns instead of serializing on one agent.
+   */
   const agentFactory: (threadId: string) => AbstractAgent = (() => {
     // Applied here rather than at each call site so a developer never has to
     // know the workaround exists. Idempotent, so reusing one agent instance
@@ -550,16 +585,19 @@ export function createChannel<
         ? (agent: AbstractAgent) => agent
         : sanitizeAgentEventStream;
     const a = opts.agent;
-    if (typeof a === "function")
-      return (threadId: string) => sanitize(a(threadId));
-    // Singleton config: clone per run so concurrent turns never share one mutable agent.
-    if (a)
-      return (threadId: string) => sanitize(isolateAgentInstance(a, threadId));
-    return () => {
-      throw new Error(
-        "createChannel: no agent configured (pass `agent` to use runAgent)",
-      );
-    };
+    if (!a) {
+      return () => {
+        throw new Error(
+          "createChannel: no agent configured (pass `agent` to use runAgent)",
+        );
+      };
+    }
+    if (typeof a === "function") {
+      return (threadId: string) =>
+        sanitize(isolateAgentInstance(a(threadId), threadId));
+    }
+    return (threadId: string) =>
+      sanitize(isolateAgentInstance(a, threadId));
   })();
 
   /** Per-conversation serial turn queue (error-boundaried so one failure cannot poison the chain). */

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-canonical-run.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-canonical-run.test.ts
@@ -24,12 +24,6 @@ const canonicalIdentity = {
   runId: "canonical-run",
 };
 
-/** Product lock cleanup args — scoped per delivery so concurrent turns do not collide. */
-const canonicalLockCleanup = {
-  ...canonicalIdentity,
-  lockKeyPrefix: `channel-run:${canonicalIdentity.runId}`,
-};
-
 class NoopAgent extends AbstractAgent {
   run(_input: RunAgentInput): ReturnType<AbstractAgent["run"]> {
     return EMPTY;
@@ -176,7 +170,7 @@ test("runCanonical rejects a RUN_ERROR event even when the runner completes", as
     message: "agent failed",
     code: "AGENT_FAILED",
   });
-  expect(cleanup).toHaveBeenCalledWith(canonicalLockCleanup);
+  expect(cleanup).toHaveBeenCalledWith(canonicalIdentity);
 });
 
 test("runCanonical renews the standard thread lock until the run settles", async () => {
@@ -210,8 +204,6 @@ test("runCanonical renews the standard thread lock until the run settles", async
       threadId: canonicalIdentity.threadId,
       runId: canonicalIdentity.runId,
       ttlSeconds: 120,
-      // Per-delivery lock prefix so concurrent Channel turns do not 409.
-      lockKeyPrefix: `channel-run:${canonicalIdentity.runId}`,
     });
 
     completeRun?.();
@@ -258,7 +250,7 @@ test("runCanonical stops the standard runner when lock renewal fails", async () 
 
     await failed;
     expect(stopRun).toHaveBeenCalledWith({
-      threadId: `${canonicalIdentity.threadId}::${canonicalIdentity.runId}`,
+      threadId: canonicalIdentity.threadId,
     });
   } finally {
     vi.useRealTimers();
@@ -313,14 +305,14 @@ test("runCanonical acquires the standard lock and uses the runner project key", 
     userId: "app-user-1",
     agentId: "support-agent",
     ttlSeconds: 20,
-    // Per-delivery prefix so concurrent Channel turns on one thread do not 409.
-    lockKeyPrefix: `channel-run:${canonicalIdentity.runId}`,
   });
   expect(request).not.toHaveProperty("authToken");
-  // Local runner is keyed per-run; product thread id stays on the AG-UI input.
-  expect(request?.threadId).toBe(
-    `${canonicalIdentity.threadId}::${canonicalIdentity.runId}`,
-  );
+  // Regression guard: `request.threadId` must stay the canonical product thread
+  // id and must never be decorated with the run id or any other local key.
+  // IntelligenceAgentRunner does not treat it as a local map key — it sends it
+  // as `thread_id` when joining `ingestion:<runId>`, and the gateway resolves it
+  // against `cpki.threads`, rejecting anything else with `thread_not_found`.
+  expect(request?.threadId).toBe(canonicalIdentity.threadId);
   expect(request?.input.threadId).toBe(canonicalIdentity.threadId);
 });
 
@@ -418,7 +410,7 @@ test("runCanonical cleans up the lock when the runner cannot start", async () =>
   await expect(runCanonical(runArgs())).rejects.toThrow(
     "runner startup failed",
   );
-  expect(cleanup).toHaveBeenCalledWith(canonicalLockCleanup);
+  expect(cleanup).toHaveBeenCalledWith(canonicalIdentity);
 });
 
 test("runCanonical cleans up the lock after a successful runner stream", async () => {
@@ -435,7 +427,7 @@ test("runCanonical cleans up the lock after a successful runner stream", async (
 
   await runCanonical(runArgs());
 
-  expect(cleanup).toHaveBeenCalledWith(canonicalLockCleanup);
+  expect(cleanup).toHaveBeenCalledWith(canonicalIdentity);
 });
 
 test("runCanonical rejects an outer agent error completed by the standard runner", async () => {

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-canonical-run.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-canonical-run.test.ts
@@ -24,6 +24,12 @@ const canonicalIdentity = {
   runId: "canonical-run",
 };
 
+/** Product lock cleanup args — scoped per delivery so concurrent turns do not collide. */
+const canonicalLockCleanup = {
+  ...canonicalIdentity,
+  lockKeyPrefix: `channel-run:${canonicalIdentity.runId}`,
+};
+
 class NoopAgent extends AbstractAgent {
   run(_input: RunAgentInput): ReturnType<AbstractAgent["run"]> {
     return EMPTY;
@@ -170,7 +176,7 @@ test("runCanonical rejects a RUN_ERROR event even when the runner completes", as
     message: "agent failed",
     code: "AGENT_FAILED",
   });
-  expect(cleanup).toHaveBeenCalledWith(canonicalIdentity);
+  expect(cleanup).toHaveBeenCalledWith(canonicalLockCleanup);
 });
 
 test("runCanonical renews the standard thread lock until the run settles", async () => {
@@ -204,6 +210,8 @@ test("runCanonical renews the standard thread lock until the run settles", async
       threadId: canonicalIdentity.threadId,
       runId: canonicalIdentity.runId,
       ttlSeconds: 120,
+      // Per-delivery lock prefix so concurrent Channel turns do not 409.
+      lockKeyPrefix: `channel-run:${canonicalIdentity.runId}`,
     });
 
     completeRun?.();
@@ -250,7 +258,7 @@ test("runCanonical stops the standard runner when lock renewal fails", async () 
 
     await failed;
     expect(stopRun).toHaveBeenCalledWith({
-      threadId: canonicalIdentity.threadId,
+      threadId: `${canonicalIdentity.threadId}::${canonicalIdentity.runId}`,
     });
   } finally {
     vi.useRealTimers();
@@ -305,8 +313,15 @@ test("runCanonical acquires the standard lock and uses the runner project key", 
     userId: "app-user-1",
     agentId: "support-agent",
     ttlSeconds: 20,
+    // Per-delivery prefix so concurrent Channel turns on one thread do not 409.
+    lockKeyPrefix: `channel-run:${canonicalIdentity.runId}`,
   });
   expect(request).not.toHaveProperty("authToken");
+  // Local runner is keyed per-run; product thread id stays on the AG-UI input.
+  expect(request?.threadId).toBe(
+    `${canonicalIdentity.threadId}::${canonicalIdentity.runId}`,
+  );
+  expect(request?.input.threadId).toBe(canonicalIdentity.threadId);
 });
 
 test("runCanonical returns a deferred delivery error only after the runner records RUN_FINISHED", async () => {
@@ -403,7 +418,7 @@ test("runCanonical cleans up the lock when the runner cannot start", async () =>
   await expect(runCanonical(runArgs())).rejects.toThrow(
     "runner startup failed",
   );
-  expect(cleanup).toHaveBeenCalledWith(canonicalIdentity);
+  expect(cleanup).toHaveBeenCalledWith(canonicalLockCleanup);
 });
 
 test("runCanonical cleans up the lock after a successful runner stream", async () => {
@@ -420,7 +435,7 @@ test("runCanonical cleans up the lock after a successful runner stream", async (
 
   await runCanonical(runArgs());
 
-  expect(cleanup).toHaveBeenCalledWith(canonicalIdentity);
+  expect(cleanup).toHaveBeenCalledWith(canonicalLockCleanup);
 });
 
 test("runCanonical rejects an outer agent error completed by the standard runner", async () => {

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -435,16 +435,29 @@ async function runCanonicalChannelAgent(
   interrupted: boolean;
   deliveryError?: unknown;
 }> {
+  // Scope the product lock + local runner store per delivery run so concurrent
+  // Channel turns on the same conversation (same Intelligence threadId) do not
+  // 409 the lock or hit InMemoryAgentRunner's "Thread already running".
+  // History is still loaded from the real canonical threadId by the adapter.
+  const runLockPrefix = [
+    lockKeyPrefix,
+    "channel-run",
+    args.runId,
+  ]
+    .filter((part): part is string => typeof part === "string" && part.length > 0)
+    .join(":");
   const lock = await intelligence.ɵacquireThreadLock({
     threadId: args.threadId,
     runId: args.runId,
     userId: args.userId,
     agentId: args.agentId,
     ttlSeconds: lockTtlSeconds,
-    ...(lockKeyPrefix !== undefined ? { lockKeyPrefix } : {}),
+    lockKeyPrefix: runLockPrefix,
   });
   const canonicalThreadId = lock.threadId;
   const canonicalRunId = lock.runId;
+  /** Local runner key — unique per delivery so concurrent same-thread turns do not collide. */
+  const runnerThreadId = `${canonicalThreadId}::${canonicalRunId}`;
   let result = { iterations: 0, interrupted: false };
   const outer = new ChannelOuterAgent(
     args.agent,
@@ -459,7 +472,7 @@ async function runCanonicalChannelAgent(
   let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
   const stopCanonicalRun = (): void => {
     stopPromise ??= Promise.resolve()
-      .then(() => runner.stop({ threadId: canonicalThreadId }))
+      .then(() => runner.stop({ threadId: runnerThreadId }))
       .catch(() => false);
   };
   heartbeatTimer = setInterval(() => {
@@ -468,7 +481,7 @@ async function runCanonicalChannelAgent(
         threadId: canonicalThreadId,
         runId: canonicalRunId,
         ttlSeconds: lockTtlSeconds,
-        ...(lockKeyPrefix !== undefined ? { lockKeyPrefix } : {}),
+        lockKeyPrefix: runLockPrefix,
       })
       .catch((error: unknown) => {
         if (heartbeatTimer === undefined) return;
@@ -489,7 +502,7 @@ async function runCanonicalChannelAgent(
     await new Promise<void>((resolve, reject) => {
       let terminalError: (Error & { code?: string }) | undefined;
       const stream = runner.run({
-        threadId: canonicalThreadId,
+        threadId: runnerThreadId,
         agent: outer,
         input: {
           threadId: canonicalThreadId,
@@ -541,6 +554,7 @@ async function runCanonicalChannelAgent(
       .ɵcleanupThreadLock({
         threadId: canonicalThreadId,
         runId: canonicalRunId,
+        lockKeyPrefix: runLockPrefix,
       })
       .catch(() => undefined);
   }

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -435,27 +435,23 @@ async function runCanonicalChannelAgent(
   interrupted: boolean;
   deliveryError?: unknown;
 }> {
-  // Scope the product lock + local runner store per delivery run so concurrent
-  // Channel turns on the same conversation (same Intelligence threadId) do not
-  // 409 the lock or hit InMemoryAgentRunner's "Thread already running".
-  // History is still loaded from the real canonical threadId by the adapter.
-  const runLockPrefix = [lockKeyPrefix, "channel-run", args.runId]
-    .filter(
-      (part): part is string => typeof part === "string" && part.length > 0,
-    )
-    .join(":");
+  // The product thread lock stays exclusive per (org, thread) and unprefixed
+  // unless the runtime explicitly configures a prefix. Do NOT namespace it per
+  // run: the Realtime Gateway derives this same key itself and reads its value
+  // as "which run is active on this thread" (validate_active_lock,
+  // lookup_active_run, stream_idle gating). It is also the only mutual
+  // exclusion that spans runtime replicas — DeliveryTransport's per-thread
+  // admission gate is instance state, so it cannot fence two replicas.
   const lock = await intelligence.ɵacquireThreadLock({
     threadId: args.threadId,
     runId: args.runId,
     userId: args.userId,
     agentId: args.agentId,
     ttlSeconds: lockTtlSeconds,
-    lockKeyPrefix: runLockPrefix,
+    ...(lockKeyPrefix !== undefined ? { lockKeyPrefix } : {}),
   });
   const canonicalThreadId = lock.threadId;
   const canonicalRunId = lock.runId;
-  /** Local runner key — unique per delivery so concurrent same-thread turns do not collide. */
-  const runnerThreadId = `${canonicalThreadId}::${canonicalRunId}`;
   let result = { iterations: 0, interrupted: false };
   const outer = new ChannelOuterAgent(
     args.agent,
@@ -470,7 +466,7 @@ async function runCanonicalChannelAgent(
   let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
   const stopCanonicalRun = (): void => {
     stopPromise ??= Promise.resolve()
-      .then(() => runner.stop({ threadId: runnerThreadId }))
+      .then(() => runner.stop({ threadId: canonicalThreadId }))
       .catch(() => false);
   };
   heartbeatTimer = setInterval(() => {
@@ -479,7 +475,7 @@ async function runCanonicalChannelAgent(
         threadId: canonicalThreadId,
         runId: canonicalRunId,
         ttlSeconds: lockTtlSeconds,
-        lockKeyPrefix: runLockPrefix,
+        ...(lockKeyPrefix !== undefined ? { lockKeyPrefix } : {}),
       })
       .catch((error: unknown) => {
         if (heartbeatTimer === undefined) return;
@@ -500,7 +496,7 @@ async function runCanonicalChannelAgent(
     await new Promise<void>((resolve, reject) => {
       let terminalError: (Error & { code?: string }) | undefined;
       const stream = runner.run({
-        threadId: runnerThreadId,
+        threadId: canonicalThreadId,
         agent: outer,
         input: {
           threadId: canonicalThreadId,
@@ -552,7 +548,7 @@ async function runCanonicalChannelAgent(
       .ɵcleanupThreadLock({
         threadId: canonicalThreadId,
         runId: canonicalRunId,
-        lockKeyPrefix: runLockPrefix,
+        ...(lockKeyPrefix !== undefined ? { lockKeyPrefix } : {}),
       })
       .catch(() => undefined);
   }

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -439,12 +439,10 @@ async function runCanonicalChannelAgent(
   // Channel turns on the same conversation (same Intelligence threadId) do not
   // 409 the lock or hit InMemoryAgentRunner's "Thread already running".
   // History is still loaded from the real canonical threadId by the adapter.
-  const runLockPrefix = [
-    lockKeyPrefix,
-    "channel-run",
-    args.runId,
-  ]
-    .filter((part): part is string => typeof part === "string" && part.length > 0)
+  const runLockPrefix = [lockKeyPrefix, "channel-run", args.runId]
+    .filter(
+      (part): part is string => typeof part === "string" && part.length > 0,
+    )
     .join(":");
   const lock = await intelligence.ɵacquireThreadLock({
     threadId: args.threadId,

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/run.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/run.ts
@@ -141,6 +141,11 @@ export async function handleIntelligenceRun({
       .ɵcleanupThreadLock({
         threadId: canonicalThreadId || input.threadId,
         runId: canonicalRunId || input.runId,
+        // Must match the prefix used on acquire/renew above, or the release
+        // targets the unprefixed key and the real lock is never freed.
+        ...(runtime.lockKeyPrefix !== undefined
+          ? { lockKeyPrefix: runtime.lockKeyPrefix }
+          : {}),
       })
       .catch((cleanupError) => {
         logger.error(

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -407,6 +407,8 @@ export interface RenewThreadLockRequest {
 export interface CleanupThreadLockRequest {
   threadId: string;
   runId: string;
+  /** Must match the prefix used when acquiring. */
+  lockKeyPrefix?: string;
 }
 
 export interface RenewThreadLockResponse {
@@ -1155,6 +1157,9 @@ export class CopilotKitIntelligence {
       `/api/threads/${encodeURIComponent(params.threadId)}/lock`,
       {
         runId: params.runId,
+        ...(params.lockKeyPrefix !== undefined
+          ? { lockKeyPrefix: params.lockKeyPrefix }
+          : {}),
       },
     );
   }


### PR DESCRIPTION
## Summary

Follow-up to #6256. Singleton / shared-factory agents still only replied to the first message. This PR fixes that.

The branch originally also carried a mechanism for concurrent same-thread Channel turns (a per-run runner thread id and a per-run product-lock namespace). **That mechanism has been removed** — see [What changed after review](#what-changed-after-review). What remains is the isolation fix and a set of cleanups.

## Root cause (what is actually broken on `main`)

`createChannel` resolves an agent per turn through `agentFactory`. #6256 made the singleton config (`agent: shared`) isolate via `clone()` on every turn, but left the factory branch returning its result raw:

```ts
if (typeof a === "function") return a as (threadId: string) => AbstractAgent;
```

A factory is free to return the same object on every call — `agent: (threadId) => shared` — which is an easy shape to write by accident (and the shape a singleton gets refactored into when someone needs the `threadId`). Left un-isolated, every turn runs an agent still carrying the previous turn's messages and lifecycle flags. It also serializes: `DeliveryAdapter.acquireAgent` chains a chronological tail keyed on **object identity**, so identical objects queue behind one another instead of running independently.

## Fix

- Isolate via `clone()` for **both** the singleton config and the result of a factory, so the object a turn runs on is never one the caller still holds a reference to. A fresh factory (`() => new Agent()`) is unaffected — cloning an unused agent is a clean independent instance.
- Reset `isRunning` and `abortController` on the clone. `clone()` copies both from the source, so a clone taken from an agent that has already run starts out claiming to be mid-run with a spent controller.
- Document that `AbstractAgent.prototype.clone()` copies a fixed field list, so **subclass-declared fields are silently dropped** and read back as `undefined`. There is no loud failure available here: `clone()` always exists on the base class and returns a correctly-typed instance. Subclasses holding their own state must override it.
- Correct the `clone()` error text. It previously offered the factory as an escape hatch; factories are now cloned too, so it is not one.
- Forward `lockKeyPrefix` on lock **cleanup** in both the Channel path and `handlers/intelligence/run.ts`. Acquire and renew already sent it, so a configured prefix acquired one key and released another, leaking the lock until TTL. Pre-existing; one line each now that `CleanupThreadLockRequest` carries the field.
- Collapse four copy-pasted recursive clone-patching test scaffolds into one `patchAgentAndClones` helper.

## What changed after review

Thanks to @BenTaylorDev's review, which was correct on both blocking points. Two landings on `main` also moved underneath this branch while it was open, which is worth recording because it explains the original diff:

| | |
|---|---|
| Branch point (`72750c369a`) | 17:36 UTC |
| This branch's commit | 18:23 UTC |
| #6256 *parallel-by-default turn concurrency* | 17:10 UTC — **26 min before** the branch point |
| #6257 *ordered managed delivery* | 19:53 UTC — **90 min after** the commit |

**#6256 superseded half of the original root cause.** Before it, the singleton branch was `if (a) return () => a;` — the raw shared instance, no cloning at all. Every turn ran the configured object. #6256 fixed that for the singleton config; the factory branch described above is the part it left behind, and the part this PR fixes.

**#6257 removed the scenario the concurrency mechanism was built for.** `DeliveryTransport` now declines any invitation for a thread it is already serving:

```ts
if (this.activeThreads.has(value.canonicalThreadId)) {
  this.options.log?.("channel delivery invitation declined", { reason: "thread_active" });
  return;
}
```

Concurrent same-thread deliveries are no longer reachable within a runtime process, so the per-run runner key and per-run lock namespace had no remaining purpose. Both are removed. Independently, both were broken against the platform:

- **Per-run runner thread id.** `runner.run({ threadId })` is not a local map key for managed Channels. `IntelligenceAgentRunner` sends it as `thread_id` when joining `ingestion:<runId>`, and `RunnerChannel.validate_thread_owner` resolves it against `cpki.threads` — a `<threadId>::<runId>` value fails the join with `thread_not_found`. `buildRunStartedEvent` also re-stamps `event.input.threadId` from it, so preserving the canonical id on the AG-UI input did not survive the real runner. A regression guard now asserts the canonical id reaches `runner.run`.
- **Per-run lock namespace.** The Realtime Gateway derives `thread:{org}:{threadId}:lock` itself in four places and reads its **value** as "which run is active on this thread" (`validate_active_lock`, `lookup_active_run`, `stream_idle` gating). Namespacing per run makes that unanswerable and fails the ingestion join with `active_lock_mismatch`. The lock stays unprefixed unless the runtime explicitly configures a prefix.

One consequence worth flagging separately: `#6257`'s admission gate is **instance state** on `DeliveryTransport`, so it fences one runtime process, not two replicas. Cross-replica, the unprefixed thread lock is the only remaining mutual exclusion — another reason not to namespace it. Filed on [OSS-686](https://linear.app/copilotkit/issue/OSS-686).

The companion PR CopilotKit/Intelligence#669 (app-api honoring `lockKeyPrefix`) is closed: with per-run namespacing removed it has no consumer, and no gateway path honors a prefix today.

## Test plan

- [x] `nx run-many -t test,check-types -p @copilotkit/channels-core @copilotkit/runtime @copilotkit/channels-intelligence` — passed
- [x] channels-core 177, runtime 1812, channels-intelligence 77
- [x] Same suites re-run rebased onto current `main` (post-#6257): channels-core 177, runtime 1813, channels-intelligence 92
- [x] New test: a factory returning a shared instance yields distinct clones for two concurrent turns, neither of them the configured object
- [x] New regression guard: `request.threadId` and `request.input.threadId` reaching `runner.run` are both the canonical product thread id
- [ ] Singleton `agent: new HttpAgent(...)` — 2+ sequential mentions, both get replies
- [ ] Factory `agent: (threadId) => new HttpAgent(...)` still works
- [ ] Managed Channel sequential turn against a live gateway (the path the removed mechanism would have broken)

### Note on the original root cause #2

The original description attributed dead follow-up turns to `HttpAgent.clone()` inheriting an aborted signal. That is real — a clone of an aborted agent does report `signal.aborted === true` — but it cannot be the mechanism: `@ag-ui/client` 0.0.57 `runAgent` assigns `abortController = params?.abortController ?? new AbortController()` before every run, and `channels-core`'s run loop passes no controller. The reset is kept as hygiene and is now commented as such rather than as the fix.
