### PR TITLE
docs(channels): clarify availability and self-hosting

### DIFF
--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -2,14 +2,14 @@
 title: Channels
 nav_title: Overview
 icon: "lucide/MessagesSquare"
-description: Run one AG-UI agent in Slack or Microsoft Teams through managed CopilotKit Intelligence connections.
+description: Run one AG-UI agent in Slack, Microsoft Teams, and more through managed CopilotKit Intelligence connections.
 doc_type: explanation
 ---
 
 Channels brings your agent into the conversations where work already happens.
 Your agent still runs in your infrastructure. CopilotKit Intelligence owns the
-Slack or Microsoft Teams connection, delivers each turn to your Channels SDK
-listener, and sends the response back as native channel UI.
+channel connection (Slack, Teams, Discord, etc.), delivers each turn to your
+Channels SDK listener, and sends the response back as native channel UI.
 
 ## How Channels connects your agent
 
@@ -30,6 +30,16 @@ between those systems and the path each message takes.
   width={4000}
   height={2400}
   className="hidden dark:block my-8 w-full rounded-xl"
+/>
+
+<OpsPlatformCTA
+  variant="inline"
+  title="More channels are on the way"
+  body="Slack and Teams are available now. More channels like Discord, WhatsApp, Telegram, and SMS are on the way. Talk to us about what you need."
+  ctaLabel="Book time with an engineer"
+  surface="docs_channels_more_channels_contact"
+  href="https://copilotkit.ai/talk-to-an-engineer"
+  analyticsEvent="talk_to_us_clicked"
 />
 
 Each message moves through the same five stages:
@@ -53,6 +63,14 @@ your agent, tools, or business logic into CopilotKit.
 | A long-running Channels SDK listener   | Platform ingress and credentialed delivery    |
 | Tools and approval business logic      | Runtime registration, health, and reconnects  |
 | Deployment, logs, and application auth | Conversation-history delivery to the listener |
+
+## Production self-hosting: Run Enterprise Intelligence in your own infrastructure
+
+Production self-hosting keeps your Channels configuration, provider credentials,
+delivery state, and platform operations inside your network, giving your
+organization control over data residency, security, and infrastructure.
+CopilotKit Engineering helps your team deploy Enterprise Intelligence in your
+Kubernetes environment. <DocsTrackedLink href="https://copilotkit.ai/talk-to-an-engineer" surface="docs_channels_self_hosting_contact">Book time with a CopilotKit engineer</DocsTrackedLink> to get started.
 
 ## Next step
 

--- a/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
@@ -104,6 +104,26 @@ describe("Channels documentation journey", () => {
     expect(overview?.source).not.toContain(
       "## Match your Channels configuration",
     );
+    expect(overview?.source).toContain(
+      "description: Run one AG-UI agent in Slack, Microsoft Teams, and more",
+    );
+    expect(overview?.source).toContain(
+      "channel connection (Slack, Teams, Discord, etc.)",
+    );
+    expect(overview?.source).toContain('title="More channels are on the way"');
+    expect(overview?.source).toContain(
+      'surface="docs_channels_more_channels_contact"',
+    );
+    expect(overview?.source).toContain('ctaLabel="Book time with an engineer"');
+    expect(overview?.source).toContain(
+      "## Production self-hosting: Run Enterprise Intelligence in your own infrastructure",
+    );
+    expect(overview?.source).toContain(
+      'surface="docs_channels_self_hosting_contact"',
+    );
+    expect(overview?.source).toContain(
+      ">Book time with a CopilotKit engineer</DocsTrackedLink>",
+    );
     expect(overview?.source).toContain("## Next step");
     expect(overview?.source).toContain(
       "[Configure the Channel in Intelligence](/channels/intelligence)",


### PR DESCRIPTION
## Summary

- broaden the shared Channels overview copy from Slack and Teams to Slack, Microsoft Teams, and more
- clarify that CopilotKit Intelligence owns the channel connection across providers
- add an availability CTA for upcoming Discord, WhatsApp, Telegram, and SMS support
- add a production self-hosting section with an engineering contact path
- extend the Channels docs assertions to cover the new copy and tracked CTAs

## User impact

The Slack and Microsoft Teams overview routes now set clearer expectations about currently available and upcoming providers, while giving enterprise evaluators direct paths for roadmap needs and self-hosted deployments.

## Validation

- `pnpm exec oxfmt --check showcase/shell-docs/src/content/docs/channels/index.mdx showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts`
- `npm run lint` (passes with existing package warnings)
- `npm run typecheck`
- `npm test` (51 files, 351 tests)
- `npm run build`
- verified the shared copy rendered on both `/slack` and `/teams` locally