### PR TITLE
fix(channels): isolate factory-returned agents per turn

### DIFF
--- a/packages/channels-core/src/create-channel.test.ts
+++ b/packages/channels-core/src/create-channel.test.ts
@@ -57,15 +57,68 @@ function collectText(nodes: ChannelNode[]): string {
   return out;
 }
 
-/** Capture user messages injected into a fake agent without changing its behavior. */
+/**
+ * Apply `patch` to `agent` and, recursively, to every clone descended from it.
+ *
+ * `createChannel` isolates every turn via `clone()`, so the instance a turn
+ * actually runs on is never the one the test configured. A spy installed only on
+ * the configured agent would observe nothing.
+ */
+function patchAgentAndClones(
+  agent: FakeAgent,
+  patch: (target: FakeAgent) => void,
+): void {
+  const wrap = (target: FakeAgent): void => {
+    patch(target);
+    const origClone = target.clone.bind(target);
+    target.clone = () => {
+      const cloned = origClone();
+      wrap(cloned);
+      return cloned;
+    };
+  };
+  wrap(agent);
+}
+
+/** Capture user messages injected into a fake agent (and every clone of it). */
 function captureAddedMessages(agent: FakeAgent): unknown[] {
   const added: unknown[] = [];
-  const addMessage = agent.addMessage.bind(agent);
-  agent.addMessage = (message) => {
-    added.push(message);
-    return addMessage(message);
-  };
+  patchAgentAndClones(agent, (target) => {
+    const addMessage = target.addMessage.bind(target);
+    target.addMessage = (message) => {
+      added.push(message);
+      return addMessage(message);
+    };
+  });
   return added;
+}
+
+/** Sum `runAgent` calls across the configured agent and every clone of it. */
+function trackRunAgentCalls(agent: FakeAgent): { total: () => number } {
+  let total = 0;
+  patchAgentAndClones(agent, (target) => {
+    const orig = target.runAgent.bind(target);
+    target.runAgent = async (parameters, subscriber) => {
+      total += 1;
+      return orig(parameters, subscriber);
+    };
+  });
+  return { total: () => total };
+}
+
+/**
+ * Capture the agent instances handed to the conversation store — i.e. the ones
+ * that actually run, post-isolation — rather than the configured prototype.
+ */
+function captureSessionAgents(fake: FakeAdapter): { agents: FakeAgent[] } {
+  const agents: FakeAgent[] = [];
+  const orig = fake.conversationStore.getOrCreate.bind(fake.conversationStore);
+  fake.conversationStore.getOrCreate = async (key, target, makeAgent) => {
+    const session = await orig(key, target, makeAgent);
+    agents.push(session.agent as FakeAgent);
+    return session;
+  };
+  return { agents };
 }
 
 describe("createChannel", () => {
@@ -137,6 +190,7 @@ describe("createChannel", () => {
     Object.defineProperty(fake, "injectInboundTurnOnce", { value: true });
     const agent = new FakeAgent();
     const added = captureAddedMessages(agent);
+    const runs = trackRunAgentCalls(agent);
     const channel = createChannel({ adapters: [fake], agent: () => agent });
 
     channel.onMention(async ({ thread }) => {
@@ -152,7 +206,9 @@ describe("createChannel", () => {
       platform: "fake",
     });
 
-    expect(agent.runAgentCalls).toBe(2);
+    // Each `thread.runAgent()` resolves its own isolated instance, so count runs
+    // across the configured agent and its clones rather than on one object.
+    expect(runs.total()).toBe(2);
     expect(added).toEqual([
       expect.objectContaining({
         role: "user",
@@ -184,6 +240,7 @@ describe("createChannel", () => {
       },
       () => undefined,
     ]);
+    const sessionAgents = captureSessionAgents(fake);
     const channel = createChannel({
       adapters: [fake],
       agent: () => agent,
@@ -210,10 +267,14 @@ describe("createChannel", () => {
     });
 
     expect(lifecycleCalls).toHaveLength(1);
-    expect(agent.runAgentCalls).toBe(2);
+    // One `thread.runAgent()` → one isolated instance, and the tool loop iterates
+    // twice on that instance. Assert on it, not on the configured prototype.
+    expect(sessionAgents.agents).toHaveLength(1);
+    const ran = sessionAgents.agents[0]!;
+    expect(ran.runAgentCalls).toBe(2);
     expect(canonicalToolEnds).toEqual(["tool-1"]);
     expect(
-      agent.messages.some(
+      ran.messages.some(
         (message) => message.role === "tool" && message.toolCallId === "tool-1",
       ),
     ).toBe(true);
@@ -402,18 +463,21 @@ describe("createChannel", () => {
   it("merges per-turn runAgent context with the channel-level context", async () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    // Capture the context/tools passed to the agent's first runAgent call.
+    // Capture the context/tools passed to the first runAgent call on whichever
+    // isolated instance ends up running.
     let seenContext: unknown;
     let seenTools: unknown;
-    const origRunAgent = agent.runAgent.bind(agent);
-    agent.runAgent = async (parameters, subscriber) => {
-      if (seenContext === undefined) {
-        seenContext = (parameters as { context?: unknown } | undefined)
-          ?.context;
-        seenTools = (parameters as { tools?: unknown } | undefined)?.tools;
-      }
-      return origRunAgent(parameters, subscriber);
-    };
+    patchAgentAndClones(agent, (target) => {
+      const origRunAgent = target.runAgent.bind(target);
+      target.runAgent = async (parameters, subscriber) => {
+        if (seenContext === undefined) {
+          seenContext = (parameters as { context?: unknown } | undefined)
+            ?.context;
+          seenTools = (parameters as { tools?: unknown } | undefined)?.tools;
+        }
+        return origRunAgent(parameters, subscriber);
+      };
+    });
 
     const channel = createChannel({
       adapters: [fake],
@@ -708,18 +772,9 @@ describe("createChannel", () => {
   it("singleton agent is cloned per run (distinct instances)", async () => {
     const state = new MemoryStore();
     const prototype = new FakeAgent();
-    const seen: FakeAgent[] = [];
 
     const fake = new FakeAdapter();
-    // Capture agents the conversation store receives from makeAgent.
-    const origGetOrCreate = fake.conversationStore.getOrCreate.bind(
-      fake.conversationStore,
-    );
-    fake.conversationStore.getOrCreate = async (key, target, makeAgent) => {
-      const session = await origGetOrCreate(key, target, makeAgent);
-      seen.push(session.agent as FakeAgent);
-      return session;
-    };
+    const { agents: seen } = captureSessionAgents(fake);
 
     const channel = createChannel({
       adapters: [fake],
@@ -781,6 +836,126 @@ describe("createChannel", () => {
         eventId: "E1",
       }),
     ).rejects.toThrow(/clone\(\) must return a distinct instance/);
+  });
+
+  it("factory returning a shared instance isolates each turn from the others", async () => {
+    const state = new MemoryStore();
+    const shared = new FakeAgent();
+
+    const fake = new FakeAdapter();
+    const { agents: seen } = captureSessionAgents(fake);
+
+    // The shape this exists for: a factory that hands back the same object on
+    // every call. Turn concurrency is parallel by default, so without isolation
+    // both turns would run on `shared` and append into its one `messages` array.
+    const channel = createChannel({
+      adapters: [fake],
+      agent: (threadId) => {
+        shared.threadId = threadId;
+        return shared;
+      },
+      store: { adapter: state },
+    });
+    channel.onMention(async ({ thread }) => {
+      await thread.runAgent();
+    });
+
+    await channel.ɵruntime.start();
+    const sink = fake.getSink();
+    await Promise.all([
+      sink.onTurn({
+        conversationKey: "c1",
+        replyTarget: {},
+        userText: "first",
+        platform: "fake" as const,
+        eventId: "E1",
+      }),
+      sink.onTurn({
+        conversationKey: "c1",
+        replyTarget: {},
+        userText: "second",
+        platform: "fake" as const,
+        eventId: "E2",
+      }),
+    ]);
+
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).not.toBe(shared);
+    expect(seen[1]).not.toBe(shared);
+    expect(seen[0]).not.toBe(seen[1]);
+    // Nothing ever runs on the configured object, so it stays pristine.
+    expect(shared.messages).toEqual([]);
+
+    // The point of isolating: neither turn can see the other's user message.
+    // Completion order between the two turns isn't guaranteed, so compare as a set.
+    const perTurn = seen.map((a) => a.messages.map((m) => m.content));
+    expect(perTurn.map((messages) => messages.length)).toEqual([1, 1]);
+    expect(perTurn.flat().sort()).toEqual(["first", "second"]);
+  });
+
+  it("agent whose clone() drops subclass state fails loud", async () => {
+    const state = new MemoryStore();
+
+    // Inherits `FakeAgent.clone()`, which builds a plain `FakeAgent` and so
+    // cannot carry this field — the same shape as a subclass inheriting
+    // `AbstractAgent.prototype.clone()`, which copies a fixed field list.
+    class StatefulAgent extends FakeAgent {
+      authClient = { token: "secret" };
+    }
+    const agent = new StatefulAgent();
+
+    const fake = new FakeAdapter();
+    const channel = createChannel({
+      adapters: [fake],
+      agent: () => agent,
+      store: { adapter: state },
+    });
+    channel.onMention(async ({ thread }) => {
+      await thread.runAgent({ prompt: "hi" });
+    });
+
+    await channel.ɵruntime.start();
+    const sink = fake.getSink();
+    await expect(
+      sink.onTurn({
+        conversationKey: "c1",
+        replyTarget: {},
+        userText: "hi",
+        platform: "fake" as const,
+        eventId: "E1",
+      }),
+    ).rejects.toThrow(/StatefulAgent\.clone\(\) dropped authClient/);
+  });
+
+  it("does not fail loud when clone() drops an instance-patched method", async () => {
+    const state = new MemoryStore();
+    const agent = new FakeAgent();
+    // Spies and instrumentation assign methods on the instance. `FakeAgent.clone()`
+    // does not carry them, but the prototype method survives, so the clone still
+    // behaves correctly and this must not be treated as dropped state.
+    agent.runAgent = async (parameters, subscriber) =>
+      FakeAgent.prototype.runAgent.call(agent, parameters, subscriber);
+
+    const fake = new FakeAdapter();
+    const channel = createChannel({
+      adapters: [fake],
+      agent: () => agent,
+      store: { adapter: state },
+    });
+    channel.onMention(async ({ thread }) => {
+      await thread.runAgent({ prompt: "hi" });
+    });
+
+    await channel.ɵruntime.start();
+    await expect(
+      fake.getSink().onTurn({
+        conversationKey: "c1",
+        replyTarget: {},
+        userText: "hi",
+        platform: "fake" as const,
+        eventId: "E1",
+      }),
+    ).resolves.not.toThrow();
   });
 
   it("dedupes turns by eventId", async () => {
@@ -939,19 +1114,23 @@ describe("createChannel", () => {
     // have the fake produce an assistant message with text on agent.messages
     // (mirroring how run-loop expects assistant replies to land there).
     let seenContext: unknown;
-    const origRunAgent = agent.runAgent.bind(agent);
-    agent.runAgent = async (parameters, subscriber) => {
-      if (seenContext === undefined) {
-        seenContext = (parameters as { context?: unknown } | undefined)
-          ?.context;
-      }
-      agent.addMessage({
-        id: globalThis.crypto.randomUUID(),
-        role: "assistant",
-        content: "the assistant reply",
-      });
-      return origRunAgent(parameters, subscriber);
-    };
+    patchAgentAndClones(agent, (target) => {
+      const origRunAgent = target.runAgent.bind(target);
+      target.runAgent = async (parameters, subscriber) => {
+        if (seenContext === undefined) {
+          seenContext = (parameters as { context?: unknown } | undefined)
+            ?.context;
+        }
+        // Add to the instance that is running, so the reply lands on the
+        // messages the run loop reads back.
+        target.addMessage({
+          id: globalThis.crypto.randomUUID(),
+          role: "assistant",
+          content: "the assistant reply",
+        });
+        return origRunAgent(parameters, subscriber);
+      };
+    });
 
     channel.onMention(async ({ thread }) => {
       await thread.runAgent({ transcript: true });

--- a/packages/channels-core/src/create-channel.test.ts
+++ b/packages/channels-core/src/create-channel.test.ts
@@ -856,6 +856,24 @@ describe("createChannel", () => {
       },
       store: { adapter: state },
     });
+    // What each run believes it was asked, read while both turns are in flight.
+    const askedPerRun: string[] = [];
+    patchAgentAndClones(shared, (target) => {
+      const orig = target.runAgent.bind(target);
+      target.runAgent = async (parameters, subscriber) => {
+        // Hold the run open so the turns genuinely overlap, then read back. On a
+        // shared instance the other turn's user message has landed by now.
+        await new Promise((r) => setTimeout(r, 20));
+        askedPerRun.push(
+          target.messages
+            .filter((m) => m.role === "user")
+            .map((m) => String(m.content))
+            .join("+"),
+        );
+        return orig(parameters, subscriber);
+      };
+    });
+
     channel.onMention(async ({ thread }) => {
       await thread.runAgent();
     });
@@ -879,18 +897,20 @@ describe("createChannel", () => {
       }),
     ]);
 
+    // Assert the symptom before the mechanism, so a regression reports the
+    // user-visible defect rather than an object-identity puzzle: without
+    // isolation both runs read "first+second" off the one shared `messages`
+    // array, so each turn is prompted with the other user's question too.
+    // Completion order between the turns isn't guaranteed — compare as a set.
+    expect(askedPerRun.sort()).toEqual(["first", "second"]);
+
+    // Mechanism: two distinct clones, neither of them the configured object.
     expect(seen).toHaveLength(2);
     expect(seen[0]).not.toBe(shared);
     expect(seen[1]).not.toBe(shared);
     expect(seen[0]).not.toBe(seen[1]);
     // Nothing ever runs on the configured object, so it stays pristine.
     expect(shared.messages).toEqual([]);
-
-    // The point of isolating: neither turn can see the other's user message.
-    // Completion order between the two turns isn't guaranteed, so compare as a set.
-    const perTurn = seen.map((a) => a.messages.map((m) => m.content));
-    expect(perTurn.map((messages) => messages.length)).toEqual([1, 1]);
-    expect(perTurn.flat().sort()).toEqual(["first", "second"]);
   });
 
   it("agent whose clone() drops subclass state fails loud", async () => {

--- a/packages/channels-core/src/create-channel.ts
+++ b/packages/channels-core/src/create-channel.ts
@@ -82,8 +82,30 @@ export type LockConflictDecision = "drop" | "force";
 export type ChannelConcurrency = "parallel" | "serial" | "drop";
 
 /**
- * Isolate a configured singleton agent for one run via `clone()`.
- * Fail loud when clone is missing or returns the same instance.
+ * Isolate an agent for one turn via `clone()`.
+ *
+ * Applied to every configured shape, so the object a turn runs on is never one
+ * the caller still holds a reference to:
+ * - `createChannel({ agent: shared })` — singleton config
+ * - `agent: (id) => new Agent()` — fresh factory, cloning an unused agent
+ * - `agent: (id) => shared` — factory returning the same object every call
+ *
+ * The last shape is the one that needs this, and it is easy to write by accident
+ * (it is also what a singleton becomes when someone refactors to get at the
+ * `threadId`). Sharing one `AbstractAgent` across turns is not safe, because
+ * turn concurrency defaults to `"parallel"` — see {@link ChannelConcurrency} —
+ * and only the managed adapter serializes same-thread deliveries. On a directly
+ * connected adapter two turns in one conversation can run at the same time, and
+ * on the same instance they corrupt each other: `messages` is a single array
+ * both runs append into, so each run's new-message diff picks up the other's,
+ * and `isRunning` / `activeRunDetach$` / `activeRunCompletionPromise` are
+ * single-slot fields the second run overwrites while the first is still
+ * streaming. Managed delivery serializes them instead, on object identity, which
+ * head-of-line blocks two *different* conversations that share one instance.
+ *
+ * Fails loud on all three ways cloning can fail to isolate: a missing `clone()`,
+ * a `clone()` that hands back the same object, and a `clone()` that silently
+ * drops subclass state (see {@link assertCloneKeptOwnFields}).
  */
 export function isolateAgentInstance(
   prototype: AbstractAgent,
@@ -91,8 +113,9 @@ export function isolateAgentInstance(
 ): AbstractAgent {
   if (typeof prototype.clone !== "function") {
     throw new Error(
-      "createChannel: singleton agent must implement clone() that returns a new instance " +
-        "(HttpAgent, BuiltInAgent, etc.), or pass agent: (threadId) => ... factory",
+      "createChannel: agent must implement clone() that returns a new instance " +
+        "(HttpAgent, BuiltInAgent, etc.). Every turn is isolated via clone(), " +
+        "including agents returned from an agent: (threadId) => ... factory.",
     );
   }
   const cloned = prototype.clone() as AbstractAgent;
@@ -101,8 +124,65 @@ export function isolateAgentInstance(
       "createChannel: agent.clone() must return a distinct instance for concurrent turns",
     );
   }
+  assertCloneKeptOwnFields(prototype, cloned);
   cloned.threadId = threadId;
+  // `clone()` copies `isRunning` from the source, and a source that has already
+  // run can be mid-run at the moment it is cloned. A fresh turn is not.
+  //
+  // Hygiene, not a fix for a dead turn: `runAgent` assigns
+  // `abortController = params?.abortController ?? new AbortController()` before
+  // each run and the run loop passes no controller, so an inherited aborted
+  // controller cannot reach the next request on its own. Reset it anyway so
+  // anything reading the signal between isolation and the run sees a live one.
+  // Note this deliberately discards `HttpAgent.clone()`'s propagation of the
+  // source's aborted state, which exists for callers that clone mid-run.
+  cloned.isRunning = false;
+  const withAbort = cloned as AbstractAgent & {
+    abortController?: AbortController;
+  };
+  if ("abortController" in withAbort) {
+    withAbort.abortController = new AbortController();
+  }
   return cloned;
+}
+
+/**
+ * Fail loud when `clone()` silently drops subclass state.
+ *
+ * `AbstractAgent.prototype.clone()` copies a fixed field list, so a subclass
+ * that declares its own fields (an auth client, config, a cache) gets them back
+ * as `undefined` on the clone — and because the base implementation always
+ * exists and returns a correctly-typed instance, nothing else surfaces it. The
+ * agent just runs gutted.
+ *
+ * Comparing own enumerable keys catches exactly that and stays quiet for the
+ * agents that do override `clone()` (`HttpAgent`, `LangGraphAgent`,
+ * `BuiltInAgent`, `IntelligenceAgent`). Symbol-keyed and non-enumerable fields
+ * are not covered.
+ *
+ * Own *functions* are deliberately exempt. Assigning a method on the instance is
+ * how spies and instrumentation wrap an agent, and losing that wrapper leaves
+ * the class's prototype method intact — the clone still behaves correctly, it
+ * just isn't wrapped. Only dropped state leaves an agent genuinely gutted.
+ */
+function assertCloneKeptOwnFields(
+  prototype: AbstractAgent,
+  cloned: AbstractAgent,
+): void {
+  const source = prototype as unknown as Record<string, unknown>;
+  const dropped = Object.keys(prototype).filter(
+    (key) =>
+      typeof source[key] !== "function" &&
+      !Object.prototype.hasOwnProperty.call(cloned, key),
+  );
+  if (dropped.length === 0) return;
+  const name = prototype.constructor?.name ?? "the configured agent";
+  throw new Error(
+    `createChannel: ${name}.clone() dropped ${dropped.join(", ")}. ` +
+      "Every turn runs on a clone, and AbstractAgent's clone() only copies its " +
+      `own fixed field list, so those fields would read as undefined. Override ` +
+      `clone() on ${name} to copy them (HttpAgent.clone() is the reference).`,
+  );
 }
 
 /**
@@ -550,16 +630,23 @@ export function createChannel<
         ? (agent: AbstractAgent) => agent
         : sanitizeAgentEventStream;
     const a = opts.agent;
-    if (typeof a === "function")
-      return (threadId: string) => sanitize(a(threadId));
-    // Singleton config: clone per run so concurrent turns never share one mutable agent.
-    if (a)
-      return (threadId: string) => sanitize(isolateAgentInstance(a, threadId));
-    return () => {
-      throw new Error(
-        "createChannel: no agent configured (pass `agent` to use runAgent)",
-      );
-    };
+    if (!a) {
+      return () => {
+        throw new Error(
+          "createChannel: no agent configured (pass `agent` to use runAgent)",
+        );
+      };
+    }
+    // Clone per turn for both shapes, so concurrent turns never share one
+    // mutable agent. Isolating only the singleton config is not enough: a
+    // factory is free to return the same object on every call. Cloning a fresh
+    // factory's result costs an unused instance and closes the shared case —
+    // see `isolateAgentInstance`.
+    if (typeof a === "function") {
+      return (threadId: string) =>
+        sanitize(isolateAgentInstance(a(threadId), threadId));
+    }
+    return (threadId: string) => sanitize(isolateAgentInstance(a, threadId));
   })();
 
   /** Per-conversation serial turn queue (error-boundaried so one failure cannot poison the chain). */

--- a/packages/channels-intelligence/src/delivery-adapter.concurrency.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.concurrency.test.ts
@@ -87,7 +87,7 @@ describe("DeliveryAdapter concurrent same-thread runs", () => {
       makeAgent,
     );
 
-    // Both must be in flight (second must not throw ChannelAgentConcurrencyError).
+    // Both must be in flight — the second must not be rejected for overlapping.
     await vi.waitFor(() => expect(loadCalls).toBeGreaterThanOrEqual(1));
     release1();
     const [s1, s2] = await Promise.all([p1, p2]);

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -99,19 +99,6 @@ export interface DeliveryAdapterOptions {
   replyContinuation?: ReplyContinuationOptions;
 }
 
-/**
- * @deprecated Concurrent same-thread agent runs are supported (parallel default).
- * Kept so older importers do not break; no longer thrown by DeliveryAdapter.
- */
-export class ChannelAgentConcurrencyError extends Error {
-  readonly code = "channel_agent_concurrency_not_supported";
-
-  constructor(threadId: string) {
-    super(`Channel agent execution is already active for thread ${threadId}`);
-    this.name = "ChannelAgentConcurrencyError";
-  }
-}
-
 /** Stable managed-v1 rejection for Slack slash commands that request agent output. */
 class ChannelSlashCommandAgentNotSupportedError extends Error {
   readonly code = "channel_slash_command_agent_not_supported";

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-canonical-run.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-canonical-run.test.ts
@@ -307,6 +307,14 @@ test("runCanonical acquires the standard lock and uses the runner project key", 
     ttlSeconds: 20,
   });
   expect(request).not.toHaveProperty("authToken");
+  // The thread id reaching the runner must stay the canonical product thread id,
+  // never decorated with a run id or any other process-local key.
+  // `IntelligenceAgentRunner` does not treat it as a local map key: it sends it as
+  // `thread_id` when joining `ingestion:<runId>`, and the gateway resolves that
+  // against `cpki.threads`, rejecting anything else with `thread_not_found`.
+  // `buildRunStartedEvent` also re-stamps `input.threadId` from it, so both must hold.
+  expect(request?.threadId).toBe(canonicalIdentity.threadId);
+  expect(request?.input.threadId).toBe(canonicalIdentity.threadId);
 });
 
 test("runCanonical returns a deferred delivery error only after the runner records RUN_FINISHED", async () => {


### PR DESCRIPTION
## Summary

Every Channel turn now runs on an agent instance nobody else holds a reference to, for **both** configured shapes — the singleton config and the result of an `agent: (threadId) => …` factory.

This is a fresh start on #6260 (thanks @AlemTuzlak and @maxkorp — the isolation change is theirs). That PR carried a per-run runner thread id and a per-run lock namespace, both of which broke managed ingestion and were removed during review. Rather than keep iterating on a branch whose description had drifted from its diff, this restates the change from `main` with an accurate root cause and the two corrections below.

**This is a concurrency-isolation fix.** Two overlapping mentions on one conversation currently get prompted with each other's questions; that is reproduced below and fixed here. It is *not* a fix for "only the first mention gets a reply" — see [What the original report actually was](#what-the-original-report-actually-was), which turns out to have been fixed already in #6256.

## Root cause

`createChannel` resolves an agent per turn through `agentFactory`. The singleton config was cloned per turn; a factory's result was returned raw:

```ts
if (typeof a === "function") return (threadId: string) => sanitize(a(threadId));
```

A factory is free to return the same object on every call — `agent: (threadId) => shared` — which is easy to write by accident, and is what a singleton becomes when someone refactors to get at the `threadId`.

That matters because **turn concurrency defaults to `"parallel"`** (`ChannelConcurrency`), and the only per-thread admission gate lives in `channels-intelligence` (`ChannelDeliveryTransport.activeThreads`, added in #6257). A **directly connected** adapter — Slack, Discord, Teams, Telegram, WhatsApp — has no such gate, so two turns in one conversation can genuinely run at the same time. On one shared instance they corrupt each other:

- `messages` is a single array both runs append into, so each run's new-message diff picks up the other's
- `isRunning`, `activeRunDetach$` and `activeRunCompletionPromise` are single-slot fields the second run overwrites while the first is still streaming
- managed delivery instead serializes on **object identity** (`DeliveryAdapter.acquireAgent`), so two *different* conversations sharing one instance head-of-line block each other
- managed `historyIds` is a `WeakMap` keyed on the agent, so a second concurrent turn clobbers the first's "which messages are new" baseline

## Changes

- **Clone for both shapes.** A fresh factory (`() => new Agent()`) is unaffected beyond one unused instance.
- **Guard the failure that mandatory cloning introduces.** `AbstractAgent.prototype.clone()` copies a fixed field list, so a subclass declaring its own state (auth client, config, cache) reads it back as `undefined` — and nothing surfaces it, because the base method always exists and returns a correctly-typed instance. Comparing own enumerable keys catches exactly that and names the dropped fields.
  - Own **functions** are exempt. Assigning a method on the instance is how spies and instrumentation wrap an agent, and losing that wrapper leaves the prototype method intact, so the clone still behaves correctly. This is not hypothetical — an unconditional check failed 8 existing tests in this repo, all of which patch `runAgent` on the instance.
- **Reset `isRunning` / `abortController` on the clone**, commented as hygiene rather than as a fix: `runAgent` assigns `abortController = params?.abortController ?? new AbortController()` before every run and the run loop passes none, so an inherited aborted controller cannot reach the next request. Noted inline that this discards `HttpAgent.clone()`'s deliberate propagation of the source's aborted state.
- **Correct the `clone()` error text** — it offered the factory as an escape hatch, which cloning factory results removes.
- **Test scaffolding**: one `patchAgentAndClones` / `captureSessionAgents` pair replaces five hand-rolled copies of the same recursive clone-patching setup.
- **Remove `ChannelAgentConcurrencyError`** — unthrown since #6256. Its doc said it was kept so older importers would not break, but `channels-intelligence` exports only `.` and never re-exported it from `index.ts` (`git log -S` over that file confirms it never did), so nothing outside the package could ever reach it.
- **Preventive regression guard** in `channel-canonical-run.test.ts`: the thread id reaching `runner.run` must stay the canonical product thread id. `IntelligenceAgentRunner` sends it as `thread_id` when joining `ingestion:<runId>` and the gateway resolves it against `cpki.threads`, so decorating it fails the join with `thread_not_found`. Nothing decorates it on `main` — this pins the invariant so that stays true.

### Two things #6260 asserted that are not true

Recording these so they don't get re-derived:

1. **There is no lock-key leak to fix.** #6260 forwarded `lockKeyPrefix` on lock cleanup, described as fixing a prefixed lock acquired under one key and released under another. Intelligence `main` has `threadLockKey = (organizationId, threadId) => \`thread:${org}:${threadId}:lock\`` — no prefix parameter — and `lockKeyPrefix` is read **nowhere** in `apps/`. Acquire, renew and cleanup all hit the same unprefixed key, so nothing leaks. My own review said the same thing and was equally wrong. Omitted here.
2. **A loud failure for dropped subclass fields *is* available** — #6260 states none is. It's the guard above.

## What the original report actually was

#6260 framed this as fixing "2+ **sequential** mentions, only the first gets a reply." That framing was wrong, and the sequential mechanism it implied does not exist. #6256's own root cause is the accurate one:

> Tagging a Slack bot multiple times (or five people asking in one thread) only answered the first turn. Root cause was SDK turn locking (`onLockConflict: drop`) and managed per-thread exclusive agent execution — not Intelligence ingress.

Those are **overlapping** mentions, and both causes were fixed in #6256. There was never a sequential bug: the stated mechanism cannot produce one, because both real adapters replace the message list before the run — managed does `agent.messages = [...history]`, Slack does `agent.messages = history` plus a fresh per-turn threadId. Subscribers are passed per-run to `runAgent(params, subscriber)` rather than accumulated, `session.release?.()` sits in a `finally`, and `isRunning` is cleared by `runAgent`'s own `finally`.

What #6256 left behind is the last hole in *its* story, and it is what this PR closes: under the new parallel default, `agent: (id) => shared` still hands both turns one instance. Both turns reply — so the symptom is not a dead turn — but each is prompted with the other user's question. Reproduced above.

## Follow-ups worth filing (not in this PR)

Two of the four I flagged are handled in this PR (the dead error class, and the sequential mystery — resolved above). Two are not, deliberately:

1. **`lockKeyPrefix` is a no-op end to end**, yet configured in two mainline Intelligence demos (`demos/splat-demo/bff/src/main.ts:371`, `demos/simple-agent/bff/src/main.ts:457`). Deleting it is a breaking removal of a public `CopilotRuntime` option spanning ~30 references across `runtime.ts`, `channel-manager.ts`, `client.ts`, `fetch-handler.ts` and `handlers/intelligence/run.ts`, and it needs a lockstep Intelligence PR for the demos. It also carries a real product question — implement per-prefix locks server-side (the closed #669) or drop the concept. Too big and too breaking to ride along here.
2. **Directly connected adapters have no equivalent of #6257's per-thread admission gate.** A design decision, not a removal: #6256 deliberately made same-conversation turns parallel. Adjacent to OSS-686's cross-replica question, where the unprefixed thread lock is the only fence spanning replicas.

## Testing

Everything below was run in-session on this branch, based on `fcc8616e91`.

**Automated**

| Suite | Result |
|---|---|
| `nx run @copilotkit/channels-core:test` | 190 passed (33 files) — was 187, +3 new |
| `nx run @copilotkit/channels-intelligence:test` | 92 passed (15 files) |
| `nx run @copilotkit/channels-slack:test` | 318 passed (23 files) |
| `nx run @copilotkit/channels-teams:test` | 90 passed (14 files) |
| `nx run @copilotkit/runtime:test` | 1813 passed (128 files) |
| `nx run @copilotkit/channels-core:check-types` | pass |
| `oxfmt` + `oxlint` on changed files | clean (4 pre-existing warnings) |

The first `runtime` run had one failure — `[Fetch] Debug Events > streams debug event envelopes…` in `node-servers.integration.test.ts`. It passes in isolation and passed on a full re-run; it is a full-suite flake, unrelated to this change (the only runtime change here is a test assertion in a different file).

**The bug is reproduced at the symptom level.** Two overlapping turns, a factory returning a shared instance, each run reporting what it believes it was asked — read while both turns are in flight. Against `main`'s source:

```
expected [ 'first+second', 'first+second' ] to deeply equal [ 'first', 'second' ]
```

Both runs saw both users' questions. With the fix each run sees only its own. The test asserts the symptom before the mechanism, so a regression reports that rather than an object-identity puzzle.

**The new tests fail without the fix.** Verified by swapping in `main`'s `create-channel.ts` via `git show` and re-running with the tests kept:

```
× factory returning a shared instance isolates each turn from the others
  AssertionError: expected FakeAgent{…} not to be FakeAgent{…} // Object.is equality
× agent whose clone() drops subclass state fails loud
  AssertionError: promise resolved "undefined" instead of rejecting
✓ does not fail loud when clone() drops an instance-patched method   ← passes both ways, by design
```

The third is a regression guard on the guard itself: it must pass before *and* after, or the check is too strict.

**`clone()` behavior probed directly against the installed `@ag-ui/client` 0.0.57**, rather than assumed — this is what the guard is built on:

```
CustomAgent  source own keys: …,authClient,…,retries,…
CustomAgent  clone  own keys: (authClient and retries absent)
CustomAgent  authClient on clone: undefined | retries: undefined
CustomAgent  instanceof CustomAgent: true        ← typed correctly, silently gutted
CustomAgent  dropped: [ 'authClient', 'retries' ] ← detector fires
HttpAgent    dropped: [ ]                         ← no false positive
```

`HttpAgent`, `LangGraphAgent`, `BuiltInAgent` and `IntelligenceAgent` all override `clone()` and stay quiet. `SanitizingHttpAgent` (channels-slack/teams) declares no own fields, so its prototype methods survive untouched. `ChannelOuterAgent` has three own fields and no override, but never passes through `isolateAgentInstance` — it goes straight to `runner.run`.

**Not verified:** a live managed-gateway turn. Carried over from #6260 as still unchecked.

## Behavior change to be aware of

The new guard turns a previously silent failure into a startup-time throw for anyone using a custom `AbstractAgent` subclass **with its own state and no `clone()` override**. Via the singleton config that shape was already broken (silently); via a factory it used to work. It's a real break, it's loud, and the message names the fields and the fix. Flagging it explicitly rather than burying it in a doc comment.
