### PR TITLE
docs(react-core): update useAgent thread isolation guidance

### DIFF
--- a/packages/react-core/skills/react-core/references/agent-access.md
+++ b/packages/react-core/skills/react-core/references/agent-access.md
@@ -256,16 +256,17 @@ sees.
 
 Source: `packages/react-core/src/v2/hooks/use-agent-context.tsx` (no `agentId` parameter); `packages/core/src/core/context-store.ts:26-31`
 
-### MEDIUM — Two components using the same `(agentId, threadId)` expecting isolation
+### MEDIUM — Two components using the same `agentId` expecting isolated state
 
 Wrong:
 
 ```tsx
 function A() {
-  const { agent } = useAgent({ agentId: "default", threadId: "t1" });
+  useAgent({ agentId: "default" });
 }
+
 function B() {
-  const { agent } = useAgent({ agentId: "default", threadId: "t1" });
+  useAgent({ agentId: "default" });
 }
 ```
 
@@ -273,16 +274,29 @@ Correct:
 
 ```tsx
 function A() {
-  useAgent({ agentId: "default", threadId: "a" });
+  useAgent({
+    agentId: "chat-a",
+    runtimeAgentId: "default",
+    threadId: "thread-a",
+  });
 }
+
 function B() {
-  useAgent({ agentId: "default", threadId: "b" });
+  useAgent({
+    agentId: "chat-b",
+    runtimeAgentId: "default",
+    threadId: "thread-b",
+  });
 }
 ```
 
-Per-thread clones are cached in a module-level WeakMap keyed by
-`(registryAgent, threadId)`. Two consumers of the same `(agentId,
-threadId)` observe the same state. Give each surface a distinct `threadId`
-when isolation is intentional.
+Both hooks using the same `agentId` resolve to the same registered agent
+instance. `threadId` does not create a new frontend agent or isolate state.
 
-Source: `packages/react-core/src/v2/hooks/use-agent.tsx:78-119`
+When multiple frontend surfaces need independent state while targeting the
+same runtime agent, use `runtimeAgentId` with distinct local `agentId` values.
+The local `agentId` identifies the frontend proxy, while `runtimeAgentId`
+controls which runtime agent receives requests.
+
+Source: `packages/react-core/src/v2/hooks/use-agent.tsx`;
+`packages/core/src/core/core.ts` (`registerProxiedAgent`)

--- a/skills/react-core/references/agent-access.md
+++ b/skills/react-core/references/agent-access.md
@@ -256,16 +256,17 @@ sees.
 
 Source: `packages/react-core/src/v2/hooks/use-agent-context.tsx` (no `agentId` parameter); `packages/core/src/core/context-store.ts:26-31`
 
-### MEDIUM — Two components using the same `(agentId, threadId)` expecting isolation
+### MEDIUM — Two components using the same `agentId` expecting isolated state
 
 Wrong:
 
 ```tsx
 function A() {
-  const { agent } = useAgent({ agentId: "default", threadId: "t1" });
+  useAgent({ agentId: "default" });
 }
+
 function B() {
-  const { agent } = useAgent({ agentId: "default", threadId: "t1" });
+  useAgent({ agentId: "default" });
 }
 ```
 
@@ -273,16 +274,29 @@ Correct:
 
 ```tsx
 function A() {
-  useAgent({ agentId: "default", threadId: "a" });
+  useAgent({
+    agentId: "chat-a",
+    runtimeAgentId: "default",
+    threadId: "thread-a",
+  });
 }
+
 function B() {
-  useAgent({ agentId: "default", threadId: "b" });
+  useAgent({
+    agentId: "chat-b",
+    runtimeAgentId: "default",
+    threadId: "thread-b",
+  });
 }
 ```
 
-Per-thread clones are cached in a module-level WeakMap keyed by
-`(registryAgent, threadId)`. Two consumers of the same `(agentId,
-threadId)` observe the same state. Give each surface a distinct `threadId`
-when isolation is intentional.
+Both hooks using the same `agentId` resolve to the same registered agent
+instance. `threadId` does not create a new frontend agent or isolate state.
 
-Source: `packages/react-core/src/v2/hooks/use-agent.tsx:78-119`
+When multiple frontend surfaces need independent state while targeting the
+same runtime agent, use `runtimeAgentId` with distinct local `agentId` values.
+The local `agentId` identifies the frontend proxy, while `runtimeAgentId`
+controls which runtime agent receives requests.
+
+Source: `packages/react-core/src/v2/hooks/use-agent.tsx`;
+`packages/core/src/core/core.ts` (`registerProxiedAgent`)


### PR DESCRIPTION
## What does this PR do?

Updates the React `useAgent` skill documentation to match the current implementation.

Previously, the docs described per-thread agent cloning using a module-level WeakMap. That behavior was removed, and `useAgent` now returns the registered agent instance instead.

This PR:
- Removes outdated per-thread clone guidance.
- Documents that `threadId` does not create frontend agent isolation.
- Explains that separate frontend surfaces should use distinct local `agentId` values with `runtimeAgentId` when they need isolated state while targeting the same runtime agent.

## Related PRs and Issues

- Related implementation change: `registerProxiedAgent` support and removal of implicit per-thread cloning.

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)