### PR TITLE
fix(channels): contain terminal provider failures

### DIFF
--- a/packages/channels-core/src/canonical-run-loop.test.ts
+++ b/packages/channels-core/src/canonical-run-loop.test.ts
@@ -13,6 +13,7 @@ import { expect, test } from "vitest";
 import { z } from "zod";
 import type { CapturedToolCall, RunRenderer } from "./platform-adapter.js";
 import { runAgentLoop } from "./run-loop.js";
+import { ChannelDeliveryTerminatedError } from "./delivery-error.js";
 import { FakeAgent } from "./testing/fake-agent.js";
 import type { ChannelTool } from "./tools.js";
 
@@ -378,6 +379,77 @@ test("managed renderer failure freezes later rendering while canonical ingestion
     { type: EventType.TEXT_MESSAGE_CONTENT, messageId: "message-2" },
     { type: EventType.RUN_FINISHED, messageId: undefined },
   ]);
+});
+
+test("terminal delivery tool failure stops the loop and closes renderer fanout", async () => {
+  const deliveryError = new ChannelDeliveryTerminatedError(
+    "provider delivery timed out",
+  );
+  let agent!: FakeAgent;
+  agent = new FakeAgent([
+    (subscriber) =>
+      emitBatch(subscriber, agent, "inner-run-1", [
+        {
+          type: EventType.TOOL_CALL_END,
+          toolCallId: "tool-call-1",
+        },
+      ]),
+    (subscriber) =>
+      emitBatch(subscriber, agent, "inner-run-2", [
+        textEvent("message-after-failure", "should not render"),
+      ]),
+  ]);
+  const { renderer, renderedEvents } = setupRenderer();
+  const ingestedEvents: BaseEvent[] = [];
+  const postFile: ChannelTool = {
+    name: "echo",
+    description: "Post a managed file.",
+    parameters: z.object({ value: z.string() }),
+    handler: () => {
+      throw deliveryError;
+    },
+  };
+
+  await expect(
+    runAgentLoop({
+      agent,
+      renderer,
+      tools: new Map([["echo", postFile]]),
+      toolDescriptors: [],
+      context: [],
+      makeToolCtx: () => ({ thread: {} as never, platform: "fake" }),
+      subscriber: {
+        onEvent: ({ event }) => {
+          ingestedEvents.push(event);
+        },
+      },
+      canonicalRun,
+    }),
+  ).rejects.toBe(deliveryError);
+
+  expect(agent.runAgentCalls).toBe(1);
+  expect(agent.messages.some(({ role }) => role === "tool")).toBe(false);
+  expect(
+    renderedEvents
+      .filter(
+        ({ type }) =>
+          type === EventType.RUN_STARTED ||
+          type === EventType.RUN_FINISHED ||
+          type === EventType.RUN_ERROR ||
+          type === EventType.TEXT_MESSAGE_CONTENT,
+      )
+      .map(({ type }) => type),
+  ).toEqual([EventType.RUN_STARTED]);
+  expect(
+    ingestedEvents
+      .filter(
+        ({ type }) =>
+          type === EventType.RUN_STARTED ||
+          type === EventType.RUN_FINISHED ||
+          type === EventType.RUN_ERROR,
+      )
+      .map(({ type }) => type),
+  ).toEqual([EventType.RUN_STARTED, EventType.RUN_ERROR]);
 });
 
 test("inner RUN_ERROR becomes one canonical outer RUN_ERROR", async () => {

--- a/packages/channels-core/src/delivery-error.ts
+++ b/packages/channels-core/src/delivery-error.ts
@@ -1,0 +1,33 @@
+/**
+ * A provider delivery has already reached a terminal outcome.
+ *
+ * Tool handlers must not convert this error into model-visible tool output:
+ * continuing the agent would let later events render through a closed delivery.
+ */
+const CHANNEL_DELIVERY_TERMINATED = Symbol.for(
+  "copilotkit.channels.deliveryTerminated",
+);
+
+export class ChannelDeliveryTerminatedError extends Error {
+  readonly [CHANNEL_DELIVERY_TERMINATED] = true;
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ChannelDeliveryTerminatedError";
+  }
+}
+
+/**
+ * Recognize terminal delivery errors across duplicated package installations.
+ */
+export function isChannelDeliveryTerminatedError(
+  error: unknown,
+): error is ChannelDeliveryTerminatedError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { [CHANNEL_DELIVERY_TERMINATED]?: unknown })[
+      CHANNEL_DELIVERY_TERMINATED
+    ] === true
+  );
+}

--- a/packages/channels-core/src/index.ts
+++ b/packages/channels-core/src/index.ts
@@ -122,6 +122,10 @@ export { mintId, stableStringify } from "./mint-id.js";
 // Run loop
 export { runAgentLoop } from "./run-loop.js";
 export type { RunLoopArgs } from "./run-loop.js";
+export {
+  ChannelDeliveryTerminatedError,
+  isChannelDeliveryTerminatedError,
+} from "./delivery-error.js";
 
 // Pure per-platform codec seam shared with managed Intelligence delivery.
 // The Intelligence Channel adapter itself lives in

--- a/packages/channels-core/src/run-loop.test.ts
+++ b/packages/channels-core/src/run-loop.test.ts
@@ -62,6 +62,46 @@ describe("runAgentLoop", () => {
     expect((toolResult as { toolCallId?: string }).toolCallId).toBe("t1");
   });
 
+  it("keeps ordinary tool failures recoverable by the agent", async () => {
+    const renderer = makeFakeRunRenderer();
+    const tool: ChannelTool = {
+      name: "recoverable",
+      description: "Fail without closing the delivery.",
+      parameters: z.object({}),
+      handler: () => {
+        throw new Error("try something else");
+      },
+    };
+    const agent = new FakeAgent([
+      (sub: AgentSubscriber) => {
+        sub.onToolCallEndEvent?.({
+          event: { toolCallId: "t1" },
+          toolCallName: "recoverable",
+          toolCallArgs: {},
+        } as never);
+        sub.onRunFinishedEvent?.({ event: {} } as never);
+      },
+      (sub: AgentSubscriber) => {
+        sub.onRunFinishedEvent?.({ event: {} } as never);
+      },
+    ]);
+
+    await runAgentLoop({
+      agent,
+      renderer,
+      tools: new Map([["recoverable", tool]]),
+      toolDescriptors,
+      context,
+      makeToolCtx: () => ({ thread: {} as never, platform: "fake" }),
+    });
+
+    expect(agent.runAgentCalls).toBe(2);
+    expect(agent.messages.find(({ role }) => role === "tool")).toMatchObject({
+      toolCallId: "t1",
+      content: JSON.stringify({ error: "try something else" }),
+    });
+  });
+
   it("posts the picker via handleInterrupt and returns without running tools", async () => {
     const renderer = makeFakeRunRenderer();
     const tools = new Map<string, ChannelTool>();

--- a/packages/channels-core/src/run-loop.ts
+++ b/packages/channels-core/src/run-loop.ts
@@ -21,6 +21,7 @@ import type {
   ContextEntry,
 } from "./tools.js";
 import { parseToolArgs, stringifyHandlerResult } from "./tools.js";
+import { isChannelDeliveryTerminatedError } from "./delivery-error.js";
 
 export interface RunLoopArgs {
   agent: AbstractAgent;
@@ -404,6 +405,13 @@ export async function runAgentLoop(
               ),
             );
           } catch (err) {
+            if (isChannelDeliveryTerminatedError(err)) {
+              // The provider already terminalled this delivery. Freeze renderer
+              // fanout before the canonical RUN_ERROR is ingested, then stop the
+              // loop instead of inviting the model to emit through a closed path.
+              deferRendererError(err);
+              throw err;
+            }
             result = JSON.stringify({ error: (err as Error).message });
           }
         }

--- a/packages/channels-intelligence/src/delivery-adapter-postfile.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-postfile.test.ts
@@ -2,6 +2,7 @@ import { AbstractAgent } from "@ag-ui/client";
 import type { RunAgentInput } from "@ag-ui/client";
 import { EMPTY } from "rxjs";
 import { describe, expect, it, vi } from "vitest";
+import { ChannelDeliveryTerminatedError } from "@copilotkit/channels-core";
 import {
   ChannelFileDeliveryUnknownError,
   DeliveryAdapter,
@@ -250,12 +251,14 @@ describe("DeliveryAdapter.postFile", () => {
     } as unknown as ClaimedChannelDelivery;
     const adapter = makeAdapter();
 
-    await expect(
-      adapter.postFile(replyTarget(session), {
+    const error = await adapter
+      .postFile(replyTarget(session), {
         bytes: new Uint8Array([1]),
         filename: "a.txt",
-      }),
-    ).rejects.toBeInstanceOf(ChannelFileDeliveryUnknownError);
+      })
+      .catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(ChannelFileDeliveryUnknownError);
+    expect(error).toBeInstanceOf(ChannelDeliveryTerminatedError);
   });
 
   it("keeps confirmed success when canonical history retries exhaust", async () => {

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -32,6 +32,7 @@ import type {
   UserQuery,
   ReplyContinuationOptions,
 } from "@copilotkit/channels-core";
+import { ChannelDeliveryTerminatedError } from "@copilotkit/channels-core";
 import {
   createRunRenderer as createSlackRunRenderer,
   renderSlackMessage,
@@ -76,7 +77,7 @@ const MANAGED_ASSET_HISTORY_ATTEMPTS = 3;
 const MANAGED_SLACK_TEXT_INTERVAL_MS = 600;
 
 /** Slack could not prove whether a managed file became visible. */
-export class ChannelFileDeliveryUnknownError extends Error {
+export class ChannelFileDeliveryUnknownError extends ChannelDeliveryTerminatedError {
   readonly code = "unknown";
 
   constructor(options?: { cause?: unknown }) {

--- a/packages/channels-intelligence/src/delivery-transport.test.ts
+++ b/packages/channels-intelligence/src/delivery-transport.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from "vitest";
+import { ChannelDeliveryTerminatedError } from "@copilotkit/channels-core";
 import {
   ChannelProviderDeliveryError,
   ClaimedChannelDelivery,
@@ -1156,11 +1157,13 @@ test("surfaces a failed provider result as an already-terminal error", async () 
     vi.fn(),
   );
 
-  await expect(
-    session.effect("response_01", {
+  const error = await session
+    .effect("response_01", {
       kind: "slack.message.create",
       text: "Hello",
-    }),
-  ).rejects.toBeInstanceOf(ChannelProviderDeliveryError);
+    })
+    .catch((caught: unknown) => caught);
+  expect(error).toBeInstanceOf(ChannelProviderDeliveryError);
+  expect(error).toBeInstanceOf(ChannelDeliveryTerminatedError);
   expect(session.hasProviderOutput()).toBe(false);
 });

--- a/packages/channels-intelligence/src/delivery-transport.ts
+++ b/packages/channels-intelligence/src/delivery-transport.ts
@@ -1,4 +1,8 @@
 import { randomUUID } from "node:crypto";
+import {
+  ChannelDeliveryTerminatedError,
+  isChannelDeliveryTerminatedError,
+} from "@copilotkit/channels-core";
 import type { AgentContentPart } from "@copilotkit/channels-ui";
 import type { MessageOperation } from "@copilotkit/channels-ui";
 import type {
@@ -101,7 +105,7 @@ interface DeliveryOwner {
 }
 
 /** Gateway result for a provider call that already recorded delivery terminal state. */
-export class ChannelProviderDeliveryError extends Error {
+export class ChannelProviderDeliveryError extends ChannelDeliveryTerminatedError {
   constructor(
     readonly code: string,
     readonly status: string,
@@ -917,7 +921,7 @@ export class ChannelDeliveryTransport {
         });
       } catch (error) {
         if (
-          !(error instanceof ChannelProviderDeliveryError) &&
+          !isChannelDeliveryTerminatedError(error) &&
           !claimedDelivery.isSuperseded()
         ) {
           if (

--- a/packages/channels-slack/src/__tests__/native-stream.test.ts
+++ b/packages/channels-slack/src/__tests__/native-stream.test.ts
@@ -791,6 +791,32 @@ describe("NativeMessageStream", () => {
     expect(fallback.finished).toBe(false);
   });
 
+  it("observes a queued strict failure before finish drains it", async () => {
+    const { transport } = makeFakeTransport({ failStart: true });
+    const stream = new NativeMessageStream({
+      transport,
+      fallback: makeFakeFallback,
+      strict: true,
+      minIntervalMs: 0,
+    });
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.prependListener("unhandledRejection", onUnhandled);
+
+    try {
+      stream.append("managed reply");
+      // Let the queued start failure reject before the owner reaches finish().
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      expect(unhandled).toEqual([]);
+      await expect(stream.finish()).rejects.toThrow("startStream unavailable");
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+
   it("strict mode reports append and stop failures to the caller", async () => {
     const appendFailure = makeFakeTransport({ failAppend: true });
     const appendStream = new NativeMessageStream({

--- a/packages/channels-slack/src/native-stream.ts
+++ b/packages/channels-slack/src/native-stream.ts
@@ -404,7 +404,7 @@ export class NativeMessageStream implements TextStream {
       clearTimeout(this.flushTimer);
       this.flushTimer = undefined;
     }
-    this.queue = this.queue.then(() => this.flushChunk(chunk));
+    this.setQueue(this.queue.then(() => this.flushChunk(chunk)));
   }
 
   async finish(finalBlocks?: KnownBlock[]): Promise<void> {
@@ -506,7 +506,19 @@ export class NativeMessageStream implements TextStream {
   }
 
   private enqueueFlush(): void {
-    this.queue = this.queue.then(() => this.flushText());
+    this.setQueue(this.queue.then(() => this.flushText()));
+  }
+
+  /**
+   * Keep the rejected queue available for finish() while observing it now.
+   *
+   * A strict provider failure may settle between an event callback and the
+   * owner's later finish() call. Attaching only the later await leaves a Node
+   * unhandled-rejection window that can terminate the host process.
+   */
+  private setQueue(operation: Promise<void>): void {
+    this.queue = operation;
+    void operation.catch(() => undefined);
   }
 
   /**


### PR DESCRIPTION
## Summary

- stop the Channels agent loop when a tool handler reports an already-terminal provider delivery
- freeze managed renderer fanout while canonical ingestion records `RUN_ERROR`
- immediately observe Slack native-stream queue failures while preserving them for `finish()`
- treat uncertain managed file-delivery errors as terminal delivery outcomes

## Root cause

The Core run loop converted every tool-handler exception into a model-visible tool result. After `ChannelProviderDeliveryError` closed the effect path, the model could continue and emit text, causing Slack native rendering to call `slack.stream.start` against a closed delivery.

The native stream also retained that rejection in an unobserved internal promise until `finish()`, leaving a Node unhandled-rejection window.

## Validation

- `pnpm nx run-many -t test check-types -p @copilotkit/channels-core,@copilotkit/channels-slack,@copilotkit/channels-intelligence --skip-nx-cache`
- `pnpm nx run-many -t build publint attw -p @copilotkit/channels-core,@copilotkit/channels-slack,@copilotkit/channels-intelligence --skip-nx-cache`
- `pnpm nx run-many -t test check-types build publint attw -p @copilotkit/channels --skip-nx-cache`
- pre-commit affected-package matrix: 17 projects / 24 tasks
