### PR TITLE
fix: avoid duplicate tool results when resuming interrupts

### DIFF
--- a/packages/angular/src/lib/interrupt.spec.ts
+++ b/packages/angular/src/lib/interrupt.spec.ts
@@ -109,8 +109,14 @@ describe("InterruptController", () => {
   it("accumulates multiple decisions, persists tool results, and resumes once", async () => {
     const { agent, controller, run, startResume } = setup();
     finalizeStandard(agent, [
-      makeInterrupt("one", { toolCallId: "tool-one" }),
-      makeInterrupt("two", { toolCallId: "tool-two" }),
+      makeInterrupt("one", {
+        reason: "tool_call",
+        toolCallId: "tool-one",
+      }),
+      makeInterrupt("two", {
+        reason: "tool_call",
+        toolCallId: "tool-two",
+      }),
     ]);
 
     await controller.cancel("two");
@@ -143,6 +149,32 @@ describe("InterruptController", () => {
     startResume();
     await Promise.all([resumePromise, duplicatePromise]);
     expect(controller.hasInterrupt()).toBe(false);
+  });
+
+  it("does not persist synthetic results for backend-owned interrupts", async () => {
+    const { agent, controller, run, startResume } = setup();
+    finalizeStandard(agent, [
+      makeInterrupt("suspend-one", {
+        reason: "human_approval",
+        toolCallId: "tool-one",
+      }),
+    ]);
+
+    const resumePromise = controller.resolve({ approved: true });
+
+    expect(agent.addMessage).not.toHaveBeenCalled();
+    expect(run).toHaveBeenCalledWith(agent, {
+      resume: [
+        {
+          interruptId: "suspend-one",
+          status: "resolved",
+          payload: { approved: true },
+        },
+      ],
+    });
+
+    startResume();
+    await resumePromise;
   });
 
   it("resumes legacy events with forwarded command data", async () => {

--- a/packages/core/src/__tests__/interrupt-state.test.ts
+++ b/packages/core/src/__tests__/interrupt-state.test.ts
@@ -3,10 +3,10 @@ import { describe, expect, it } from "vitest";
 
 import { ɵInterruptState } from "../interrupt-state";
 
-function interrupt(id: string, toolCallId?: string): Interrupt {
+function interrupt(id: string, toolCallId?: string, reason = id): Interrupt {
   return {
     id,
-    reason: id,
+    reason,
     ...(toolCallId ? { toolCallId } : {}),
   };
 }
@@ -14,7 +14,10 @@ function interrupt(id: string, toolCallId?: string): Interrupt {
 describe("ɵInterruptState", () => {
   it("waits for every interrupt and emits one resume decision", () => {
     const state = new ɵInterruptState();
-    state.setStandard([interrupt("one", "call-one"), interrupt("two")]);
+    state.setStandard([
+      interrupt("one", "call-one", "tool_call"),
+      interrupt("two"),
+    ]);
 
     expect(state.resolve({ approved: true }, "one")).toEqual({
       kind: "waiting",
@@ -35,6 +38,23 @@ describe("ɵInterruptState", () => {
           content: JSON.stringify({ approved: true }),
         },
       ],
+    });
+  });
+
+  it("does not synthesize a result for backend-owned tool interrupts", () => {
+    const state = new ɵInterruptState();
+    state.setStandard([interrupt("suspend-one", "call-one", "human_approval")]);
+
+    expect(state.resolve({ approved: true })).toEqual({
+      kind: "resume",
+      resume: [
+        {
+          interruptId: "suspend-one",
+          status: "resolved",
+          payload: { approved: true },
+        },
+      ],
+      toolResults: [],
     });
   });
 

--- a/packages/core/src/interrupt-state.ts
+++ b/packages/core/src/interrupt-state.ts
@@ -145,7 +145,10 @@ export class ɵInterruptState<TValue = unknown> {
     const mutableInterrupts = [...interrupts];
     const resume = buildResumeArray(mutableInterrupts, this.#responses);
     const toolResults = mutableInterrupts.flatMap((interrupt) => {
-      if (!interrupt.toolCallId) return [];
+      // Executor-less interrupt tools rely on the client to persist the human
+      // response as their result. Suspend/resume backends emit the real result
+      // themselves after resuming, even when the interrupt references a tool.
+      if (!interrupt.toolCallId || interrupt.reason !== "tool_call") return [];
       return [
         {
           toolCallId: interrupt.toolCallId,

--- a/packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx
@@ -868,7 +868,7 @@ describe("useInterrupt", () => {
       runAgentMock.mockResolvedValue({ result: undefined, newMessages: [] });
       const TOOL_INT: Interrupt = {
         id: "int-1",
-        reason: "tool_approval",
+        reason: "tool_call",
         toolCallId: "tc-1",
       };
       const calls: any[] = [];


### PR DESCRIPTION
## What does this PR do?

Fixes executor-less interrupt result ownership so suspend/resume agents can publish their real tool result without a client-generated result shadowing it.

- synthesize `ToolCallResult` messages only for `tool_call` interrupts, whose tools have no executor
- keep backend-owned interrupts limited to resume decisions
- cover the shared interrupt state plus Angular and React consumers

## Related PRs and Issues

- Fixes https://github.com/CopilotKit/CopilotKit/issues/6201

## Validation

- `pnpm -C packages/core test` — 58 files, 616 tests passed
- `pnpm -C packages/angular test` — 46 files, 293 tests passed
- `pnpm -C packages/react-core test` — 122 files, 1,471 Vitest tests and 2 script tests passed
- `check-types` passed for Core, Angular, and React Core
- pre-commit affected-package `test`, `publint`, and `attw` targets passed for 21 projects
- targeted formatting, lint, and `git diff --check` passed

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)

Documentation is unchanged because this corrects internal result ownership without changing the public API.
