### PR TITLE
fix(channels): a single failed stream append no longer crashes the runtime (OSS-699)

### DIFF
--- a/packages/channels-intelligence/src/delivery-transport.test.ts
+++ b/packages/channels-intelligence/src/delivery-transport.test.ts
@@ -691,6 +691,46 @@ test("retries the exact packet after reconnect and calls no second sequence", as
   expect(result).toEqual({ providerReference: "pref_v1_message_01" });
 });
 
+test("stream content after a mid-stream effect failure is dropped benignly, not thrown as an uncatchable 'packet path is closed' (OSS-699)", async () => {
+  const deliveryChannel = channel();
+  // The gateway rejects the streamed text (e.g. Slack streaming_mode_mismatch).
+  vi.mocked(deliveryChannel.push).mockImplementation((_event, packet) => {
+    const kind = (packet as { payload?: { kind?: string } }).payload?.kind;
+    const result =
+      kind === "slack.stream.append"
+        ? { status: "failed", error: "provider_call_failed" }
+        : { providerReference: "pref_v1_message_01" };
+    return Promise.resolve({ ...(packet as object), phase: "applied", result });
+  });
+  const session = new ClaimedChannelDelivery(
+    preparedDelivery(),
+    { ownerGeneration: 7, runtimeInstanceId: "rti_runtime_01" },
+    deliveryChannel,
+    vi.fn(),
+  );
+
+  // First streamed text append fails → surfaces once and closes the effect path.
+  await expect(
+    session.effect("response_01", {
+      kind: "slack.stream.append",
+      providerReference: "pref_v1_message_01",
+      delta: "It's 13:20 UTC.",
+    }),
+  ).rejects.toBeInstanceOf(ChannelProviderDeliveryError);
+
+  // native-stream keeps flushing after that failure. A follow-up stream append
+  // must NOT throw an uncatchable "packet path is closed" (which becomes an
+  // unhandled rejection and crashes the whole runtime) — it is moot now, so it
+  // resolves benignly and is dropped.
+  await expect(
+    session.effect("response_01", {
+      kind: "slack.stream.append",
+      providerReference: "pref_v1_message_01",
+      delta: " and some more",
+    }),
+  ).resolves.toBeDefined();
+});
+
 test("polls the same packet after a retry-wait result", async () => {
   const deliveryChannel = channel();
   vi.mocked(deliveryChannel.push)

--- a/packages/channels-intelligence/src/delivery-transport.ts
+++ b/packages/channels-intelligence/src/delivery-transport.ts
@@ -184,6 +184,19 @@ class ObservableTrackedPromise<T> extends Promise<T> {
   }
 }
 
+/**
+ * Streamed reply content (native `*.stream.append` / `*.stream.task`). Once the
+ * effect path is closed by a prior failure, further content of this kind is
+ * moot and must be dropped rather than throw — see the guard in {@link
+ * ClaimedChannelDelivery.effect} (OSS-699).
+ */
+function isStreamContentKind(kind: unknown): boolean {
+  return (
+    typeof kind === "string" &&
+    (kind.endsWith(".stream.append") || kind.endsWith(".stream.task"))
+  );
+}
+
 /** One claimed delivery and its exact unacknowledged packet. */
 export class ClaimedChannelDelivery {
   private nextSeq = 0;
@@ -257,6 +270,16 @@ export class ClaimedChannelDelivery {
     payload: ProviderPayloadInput,
     options: { charge?: boolean } = {},
   ): Promise<Record<string, unknown>> {
+    // OSS-699: once a mid-stream effect fails, the packet path is closed and the
+    // failure has already surfaced (the delivery is marked failed). The renderer
+    // keeps flushing streamed content (append/task); enqueuing it would throw an
+    // uncatchable "packet path is closed" that becomes an unhandled rejection and
+    // crashes the whole runtime. That content is moot now — drop it benignly. A
+    // non-stream effect after close is a genuine misuse and still hard-errors via
+    // enqueue.
+    if (this.effectsClosed && isStreamContentKind(payload.kind)) {
+      return Promise.resolve({});
+    }
     const charged =
       options.charge === false ? Promise.resolve() : this.charge();
     return charged


### PR DESCRIPTION
## Problem
A single failed Slack streaming provider call crashed the **entire** Channels runtime process (exit 1), taking down every channel/user on that instance. A routine Slack hiccup (rate limit, `msg_too_long`, `streaming_mode_mismatch`, transient network) should degrade the turn — not kill the process.

## Root cause
Once a mid-stream effect fails, `ClaimedChannelDelivery` closes the packet path (`effectsClosed`) and surfaces the failure. But the Slack renderer keeps flushing streamed content (`*.stream.append` / `*.stream.task`) into the now-closed path, and each such packet threw an uncatchable `"packet path is closed"` from `enqueue`. One of those throws escaped the awaited handler chain as an **unhandled rejection** → process exit.

## Fix
Drop moot stream content benignly in `ClaimedChannelDelivery.effect` once the path is closed:
- The **first** failure still surfaces (the delivery is still marked `failed`) — nothing is swallowed.
- Only the **redundant follow-up** stream appends/tasks are dropped.
- Non-stream effects after close still hard-error via `enqueue`.

**Invariant:** a single provider error ends the turn as `failed` but can never crash the runtime — and this generalizes to *any* mid-stream effect failure, not just the tool-status trigger.

## Tests
- New regression test in `delivery-transport.test.ts`: after a mid-stream append fails, a follow-up stream append resolves benignly instead of throwing `"packet path is closed"`.
- Full `@copilotkit/channels-intelligence` suite: **118/118** green. `check-types` / `oxlint` / `oxfmt` clean.

## Notes
- This is the **crash** (severity) fix. The **trigger** — the Slack tool-status renderer mixing `task_update` cards + streamed text in one message (`streaming_mode_mismatch`) — is tracked separately (the opt-in `showToolStatus` rendering).
- Surfaced while verifying OSS-636's default-off behaviour end-to-end against real Slack.

Ref OSS-699
