### PR TITLE
docs: add governed action approval UI pattern

### DIFF
--- a/showcase/shell-docs/src/content/docs/human-in-the-loop/governed-actions.mdx
+++ b/showcase/shell-docs/src/content/docs/human-in-the-loop/governed-actions.mdx
@@ -1,0 +1,258 @@
+---
+title: Governed Action Approval UI
+icon: "lucide/ShieldCheck"
+description: Gate side-effecting agent actions with an approval UI before they execute.
+hideTOC: true
+---
+
+## What is this?
+
+Some agent actions are safe to run immediately, while others should be
+blocked or paused for user approval before they create side effects. A
+governed action approval UI gives the user a clear checkpoint:
+
+- **What** the agent wants to do
+- **Why** it wants to do it
+- **Which reference or policy decision** produced the verdict
+- **What happens next** if the user approves or rejects it
+
+Use this pattern when the agent proposes an action such as sending an
+email, updating a record, creating a ticket, applying a discount, or
+calling any write API.
+
+## Action envelope
+
+Keep the approval payload small, serializable, and vendor-neutral. The
+agent or backend can attach any policy engine result to the action as long
+as the UI receives the same basic envelope:
+
+```ts
+type GovernedAction = {
+  id: string;
+  summary: string;
+  tool: string;
+  reference: string;
+  verdict: "allow" | "deny" | "require_approval";
+  arguments: Record<string, unknown>;
+};
+```
+
+The frontend should handle each verdict deterministically:
+
+| Verdict | UI behavior |
+| --- | --- |
+| `allow` | Execute the action without asking again, optionally showing an audit note. |
+| `deny` | Do not execute the action. Show the reason or reference and ask the agent to choose a safer path. |
+| `require_approval` | Render a user approval card. Execute only if the user approves. |
+
+## Inline approval with `useInterrupt`
+
+If your runtime can pause an agent run, model the approval as an interrupt.
+The agent proposes the action, the UI renders the checkpoint, and the run
+resumes with the user's decision:
+
+```tsx
+import { useEffect } from "react";
+import { useInterrupt } from "@copilotkit/react-core/v2";
+
+function GovernedActionApproval() {
+  useInterrupt({
+    render: ({ interrupt, resolve, cancel }) => {
+      const action = interrupt?.metadata?.action as GovernedAction | undefined;
+
+      if (!action) {
+        return null;
+      }
+
+      return (
+        <GovernedActionCard
+          action={action}
+          onApprove={() =>
+            resolve({
+              approved: true,
+              actionId: action.id,
+              reference: action.reference,
+            })
+          }
+          onReject={() =>
+            resolve({
+              approved: false,
+              actionId: action.id,
+              reference: action.reference,
+            })
+          }
+          onBlock={() => cancel()}
+        />
+      );
+    },
+  });
+
+  return null;
+}
+
+function GovernedActionCard({
+  action,
+  onApprove,
+  onReject,
+  onBlock,
+}: {
+  action: GovernedAction;
+  onApprove: () => void;
+  onReject: () => void;
+  onBlock: () => void;
+}) {
+  useEffect(() => {
+    if (action.verdict === "allow") onApprove();
+    if (action.verdict === "deny") onBlock();
+  }, [action.id, action.verdict]);
+
+  const status =
+    action.verdict === "allow"
+      ? "Allowed by policy"
+      : action.verdict === "deny"
+        ? "Blocked by policy"
+        : "User approval required";
+
+  return (
+    <section className="rounded-lg border p-4 shadow-sm">
+      <div className="space-y-1">
+        <p className="text-sm font-medium">{status}</p>
+        <h3 className="text-base font-semibold">{action.summary}</h3>
+        <p className="text-sm text-muted-foreground">Tool: {action.tool}</p>
+        <p className="text-sm text-muted-foreground">
+          Reference: {action.reference}
+        </p>
+      </div>
+
+      <pre className="mt-3 overflow-auto rounded bg-muted p-3 text-xs">
+        {JSON.stringify(action.arguments, null, 2)}
+      </pre>
+
+      {action.verdict === "require_approval" && (
+        <div className="mt-4 flex gap-2">
+          <button type="button" onClick={onApprove}>
+            Approve and run
+          </button>
+          <button type="button" onClick={onReject}>
+            Reject
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+```
+
+On resume, the agent should execute only when it receives an approved
+response for the same action id and reference:
+
+```ts
+type ApprovalResponse = {
+  approved: boolean;
+  actionId: string;
+  reference: string;
+};
+
+async function handleApproval(action: GovernedAction, response: ApprovalResponse) {
+  if (
+    response.approved &&
+    response.actionId === action.id &&
+    response.reference === action.reference
+  ) {
+    return executeSideEffect(action.tool, action.arguments);
+  }
+
+  return {
+    skipped: true,
+    reason: "The user did not approve this action.",
+  };
+}
+```
+
+## Tool-call approval with `useHumanInTheLoop`
+
+For LLM-initiated pauses, register the approval checkpoint as a
+human-in-the-loop tool. The model asks to call `approve_governed_action`,
+your UI renders the card, and the tool result tells the agent whether it
+may continue:
+
+```tsx
+import { ToolCallStatus, useHumanInTheLoop } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+const governedActionSchema = z.object({
+  id: z.string(),
+  summary: z.string(),
+  tool: z.string(),
+  reference: z.string(),
+  verdict: z.enum(["allow", "deny", "require_approval"]),
+  arguments: z.record(z.unknown()),
+});
+
+function GovernedActionTool() {
+  useHumanInTheLoop(
+    {
+      name: "approve_governed_action",
+      description:
+        "Ask the user to approve a governed side-effect action before it runs.",
+      parameters: governedActionSchema,
+      render: ({ args, status, respond }) => {
+        if (status !== ToolCallStatus.Executing || !respond) {
+          return null;
+        }
+
+        return (
+          <GovernedActionCard
+            action={args}
+            onApprove={() =>
+              respond({
+                approved: true,
+                actionId: args.id,
+                reference: args.reference,
+              })
+            }
+            onReject={() =>
+              respond({
+                approved: false,
+                actionId: args.id,
+                reference: args.reference,
+              })
+            }
+            onBlock={() =>
+              respond({
+                approved: false,
+                actionId: args.id,
+                reference: args.reference,
+              })
+            }
+          />
+        );
+      },
+    },
+    [],
+  );
+
+  return null;
+}
+```
+
+## Recommended guardrails
+
+- Check policy on the server before presenting the approval, not only in
+  the browser.
+- Include a stable `action.id` and `reference` so the approval cannot be
+  replayed for a different action.
+- Show the exact action arguments before the user approves.
+- Treat `deny` as terminal for that proposed action; do not execute a
+  denied side effect from a later UI callback.
+- Log the proposal, verdict, user decision, and execution result so the
+  action is auditable.
+
+## Going further
+
+- [Pausing the Agent for Input](./useInterrupt) — use graph-enforced
+  interrupts when the backend must stop before a side effect.
+- [HITL Overview](../human-in-the-loop) — compare tool-based and
+  interrupt-based human-in-the-loop patterns.
+- [Frontend Tools](../frontend-tools) — register browser-side tools that
+  can display approval UI or update application state.

--- a/showcase/shell-docs/src/content/docs/human-in-the-loop/meta.json
+++ b/showcase/shell-docs/src/content/docs/human-in-the-loop/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Human-in-the-Loop",
   "icon": "lucide/User",
-  "pages": ["index", "useInterrupt", "headless"]
+  "pages": ["index", "useInterrupt", "headless", "governed-actions"]
 }


### PR DESCRIPTION
## Summary
- Adds a Human-in-the-Loop guide for governed side-effect actions
- Shows a vendor-neutral action envelope with summary, tool, reference, verdict, and arguments
- Covers allow, deny, and require_approval handling with useInterrupt and useHumanInTheLoop examples

## Validation
- Parsed human-in-the-loop meta.json and verified governed-actions is present
- Checked the new MDX frontmatter and required approval terms/hooks
- Confirmed the new guide contains no OSuite/osuite branding