### PR TITLE
fix(channels): start Slack streams with first text

### DIFF
--- a/packages/channels-intelligence/src/delivery-adapter-final.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-final.test.ts
@@ -241,9 +241,19 @@ describe("DeliveryAdapter Slack cadence", () => {
           .map((call) => call[1])
           .filter((payload) => payload.kind === "slack.stream.append");
 
-      expect(appendPayloads()).toHaveLength(1);
+      expect(effect.mock.calls.map((call) => call[1])).toContainEqual({
+        kind: "slack.stream.start",
+        initialText: "A",
+      });
+      expect(appendPayloads()).toHaveLength(0);
       await vi.advanceTimersByTimeAsync(1);
-      expect(appendPayloads()).toHaveLength(2);
+      expect(appendPayloads()).toEqual([
+        {
+          kind: "slack.stream.append",
+          providerReference: "pref_v1_slack_stream_01",
+          delta: "B",
+        },
+      ]);
 
       await subscriber.onTextMessageEndEvent!({
         event: { messageId: "message-1" },

--- a/packages/channels-intelligence/src/delivery-adapter-slack-stream.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-slack-stream.test.ts
@@ -1,0 +1,181 @@
+import { EventType } from "@ag-ui/client";
+import { expect, test, vi } from "vitest";
+import { DeliveryAdapter } from "./delivery-adapter.js";
+import {
+  ChannelDeliveryTransport,
+  ClaimedChannelDelivery,
+} from "./delivery-transport.js";
+import type { PreparedChannelDelivery } from "./delivery-transport.js";
+import { assertDeliveryPacket } from "./delivery-contracts.js";
+import type { ChannelProviderPayload } from "./delivery-contracts.js";
+import type {
+  RealtimeGatewayDeliveryChannel,
+  RealtimeGatewaySession,
+} from "./realtime-gateway.js";
+
+function preparedDelivery(): PreparedChannelDelivery {
+  return {
+    protocol: "channel_delivery_v1",
+    deliveryId: "dlv_slack_stream_01",
+    deliveryExpiresAt: "2099-07-29T17:00:00.000Z",
+    channelId: "channel_support",
+    channelName: "support",
+    canonicalThreadId: "thread_slack_stream",
+    appUserId: "slack:T1:U1",
+    adapter: "slack",
+    turn: {
+      eventId: "evt_slack_stream",
+      receivedAt: "2026-07-29T17:00:00.000Z",
+      input: {
+        kind: "text",
+        text: "hello",
+        operation: {
+          kind: "created",
+          logicalMessageId: "message-slack-stream",
+          revisionId: "revision-slack-stream",
+          mentioned: true,
+        },
+      },
+    },
+  };
+}
+
+function setup() {
+  const delivery = preparedDelivery();
+  const payloads: ChannelProviderPayload[] = [];
+  const deliveryChannel: RealtimeGatewayDeliveryChannel = {
+    joinReply: delivery,
+    push: vi.fn(async (_event, value) => {
+      assertDeliveryPacket(value);
+      if (
+        value.payload.kind === "channel.delivery.terminal" ||
+        value.payload.kind === "channel.delivery.commit"
+      ) {
+        throw new TypeError("expected a provider delivery packet");
+      }
+      payloads.push(value.payload);
+      return {
+        ...value,
+        phase: "applied",
+        result:
+          value.payload.kind === "slack.stream.start"
+            ? { providerReference: "pref_v1_slack_stream_01" }
+            : {},
+      };
+    }),
+    on: vi.fn(),
+    onClose: vi.fn(),
+    leave: vi.fn(),
+  };
+  const claimedDelivery = new ClaimedChannelDelivery(
+    delivery,
+    { ownerGeneration: 1, runtimeInstanceId: "rti_slack_stream_01" },
+    deliveryChannel,
+    async () => ({
+      channel: deliveryChannel,
+      owner: {
+        ownerGeneration: 1,
+        runtimeInstanceId: "rti_slack_stream_01",
+      },
+    }),
+  );
+  const session: RealtimeGatewaySession = {
+    push: vi.fn(),
+    on: vi.fn(),
+  };
+  const adapter = new DeliveryAdapter({
+    channelName: "support",
+    transport: new ChannelDeliveryTransport({
+      session,
+      runtimeInstanceId: "rti_slack_stream_01",
+    }),
+    runCanonical: async () => ({ iterations: 0, interrupted: false }),
+    loadHistory: async () => [],
+  });
+
+  return {
+    adapter,
+    payloads,
+    target: { claimedDelivery, delivery },
+    teardown: () => claimedDelivery.leave(),
+  };
+}
+
+/** Yield text chunks through the adapter's public streaming boundary. */
+async function* streamChunks(...chunks: string[]): AsyncGenerator<string> {
+  yield* chunks;
+}
+
+test("starts a managed Slack stream with the first text delta", async () => {
+  vi.useFakeTimers();
+  const fixture = setup();
+  try {
+    const renderer = fixture.adapter.createRunRenderer(fixture.target);
+
+    renderer.subscriber.onTextMessageContentEvent?.({
+      event: {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: "message-1",
+        delta: "Hello",
+      },
+      textMessageBuffer: "",
+    } as never);
+    await renderer.finish?.();
+
+    expect(fixture.payloads).toEqual([
+      { kind: "slack.stream.start", initialText: "Hello" },
+      { kind: "slack.thread.status", status: "" },
+      {
+        kind: "slack.stream.stop",
+        providerReference: "pref_v1_slack_stream_01",
+      },
+    ]);
+  } finally {
+    fixture.teardown();
+    vi.useRealTimers();
+  }
+});
+
+test("starts an explicit managed Slack stream with its first text chunk", async () => {
+  const fixture = setup();
+
+  try {
+    await fixture.adapter.stream(
+      fixture.target,
+      streamChunks("", "Hello", " world"),
+    );
+
+    expect(fixture.payloads).toEqual([
+      { kind: "slack.stream.start", initialText: "Hello" },
+      {
+        kind: "slack.stream.append",
+        providerReference: "pref_v1_slack_stream_01",
+        delta: " world",
+      },
+      {
+        kind: "slack.stream.stop",
+        providerReference: "pref_v1_slack_stream_01",
+      },
+    ]);
+  } finally {
+    fixture.teardown();
+  }
+});
+
+test("preserves the managed Slack stream lifecycle without text chunks", async () => {
+  const fixture = setup();
+
+  try {
+    await fixture.adapter.stream(fixture.target, streamChunks(""));
+
+    expect(fixture.payloads).toEqual([
+      { kind: "slack.stream.start" },
+      {
+        kind: "slack.stream.stop",
+        providerReference: "pref_v1_slack_stream_01",
+      },
+    ]);
+  } finally {
+    fixture.teardown();
+  }
+});

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -510,20 +510,33 @@ export class DeliveryAdapter implements PlatformAdapter {
       let bodyError: unknown;
       let streamStarted = false;
       try {
-        // Start lives inside try/finally so a missing providerReference after
-        // an applied start still attempts stream.stop cleanup.
-        const startResult = await target.claimedDelivery.effect(responseId, {
-          kind: "slack.stream.start",
-        });
-        streamStarted = true;
-        providerReference = providerReferenceFromResult(startResult);
         for await (const delta of chunks) {
           if (delta.length === 0) continue;
+          if (!streamStarted) {
+            const startResult = await target.claimedDelivery.effect(
+              responseId,
+              {
+                kind: "slack.stream.start",
+                initialText: delta,
+              },
+            );
+            streamStarted = true;
+            providerReference = providerReferenceFromResult(startResult);
+            continue;
+          }
+          assertProviderReference(providerReference);
           await target.claimedDelivery.effect(responseId, {
             kind: "slack.stream.append",
             providerReference,
             delta,
           });
+        }
+        if (!streamStarted) {
+          const startResult = await target.claimedDelivery.effect(responseId, {
+            kind: "slack.stream.start",
+          });
+          streamStarted = true;
+          providerReference = providerReferenceFromResult(startResult);
         }
       } catch (error) {
         bodyError = error;
@@ -841,6 +854,15 @@ export class DeliveryAdapter implements PlatformAdapter {
             providerReference = providerReferenceFromResult(
               await claimedDelivery.effect(responseId, {
                 kind: "slack.stream.start",
+              }),
+            );
+            return responseId;
+          },
+          startStreamWithText: async (initialText) => {
+            providerReference = providerReferenceFromResult(
+              await claimedDelivery.effect(responseId, {
+                kind: "slack.stream.start",
+                initialText,
               }),
             );
             return responseId;

--- a/packages/channels-slack/src/adapter.ts
+++ b/packages/channels-slack/src/adapter.ts
@@ -480,24 +480,25 @@ export class SlackAdapter implements PlatformAdapter {
     // channel and implicit in DMs / assistant threads — pass them only for
     // non-DM targets (DM channel ids start with "D").
     const isChannel = !t.channel.startsWith("D");
+    const startStream = async (markdownText?: string): Promise<string> => {
+      const args: ChatStartStreamArguments = {
+        channel: t.channel,
+        thread_ts: threadTs,
+        task_display_mode: "timeline",
+        ...(markdownText !== undefined ? { markdown_text: markdownText } : {}),
+        ...(isChannel && t.recipientUserId
+          ? { recipient_user_id: t.recipientUserId }
+          : {}),
+        ...(isChannel && this.teamId ? { recipient_team_id: this.teamId } : {}),
+      };
+      const res = await this.client.chat.startStream(args);
+      if (!res.ts) throw new Error("startStream returned no ts");
+      onFirstTs(res.ts, res.channel);
+      return res.ts;
+    };
     return {
-      startStream: async () => {
-        const args: ChatStartStreamArguments = {
-          channel: t.channel,
-          thread_ts: threadTs,
-          task_display_mode: "timeline",
-          ...(isChannel && t.recipientUserId
-            ? { recipient_user_id: t.recipientUserId }
-            : {}),
-          ...(isChannel && this.teamId
-            ? { recipient_team_id: this.teamId }
-            : {}),
-        };
-        const res = await this.client.chat.startStream(args);
-        if (!res.ts) throw new Error("startStream returned no ts");
-        onFirstTs(res.ts, res.channel);
-        return res.ts;
-      },
+      startStream: () => startStream(),
+      startStreamWithText: startStream,
       appendText: async (ts, markdownText) => {
         const args: ChatAppendStreamArguments = {
           channel: t.channel,

--- a/packages/channels-slack/src/event-renderer.ts
+++ b/packages/channels-slack/src/event-renderer.ts
@@ -271,6 +271,16 @@ export function createRunRenderer(args: {
           await onFirstReply();
           return ts;
         },
+        ...(ns.transport.startStreamWithText
+          ? {
+              startStreamWithText: async (markdownText: string) => {
+                const ts =
+                  await ns.transport.startStreamWithText!(markdownText);
+                await onFirstReply();
+                return ts;
+              },
+            }
+          : {}),
         appendText: (ts, md) => ns.transport.appendText(ts, md),
         appendChunks: (ts, chunks) => ns.transport.appendChunks(ts, chunks),
         stopStream: (ts, blocks) => ns.transport.stopStream(ts, blocks),

--- a/packages/channels-slack/src/native-stream.ts
+++ b/packages/channels-slack/src/native-stream.ts
@@ -60,6 +60,12 @@ export interface TextStream {
 export interface NativeStreamTransport {
   /** `chat.startStream` → resolves with the new streamed message's `ts`. Throws on failure. */
   startStream(): Promise<string>;
+  /**
+   * `chat.startStream` with the first raw markdown delta included in the open.
+   * When omitted, {@link NativeMessageStream} falls back to an empty start plus
+   * `appendText` for backward-compatible transports.
+   */
+  startStreamWithText?(markdownText: string): Promise<string>;
   /** `chat.appendStream` — append a raw `markdown_text` delta to the message at `ts`. */
   appendText(ts: string, markdownText: string): Promise<void>;
   /** `chat.appendStream` — append structured {@link AnyChunk}s to the message at `ts`. */
@@ -604,50 +610,84 @@ export class NativeMessageStream implements TextStream {
   private async appendPending(): Promise<void> {
     if (this.truncated) return; // terminal; see truncate()
     while (this.curPosted < this.buffer.length) {
-      if (!(await this.ensureStarted())) return; // failed over to legacy
-      const roomBytes = this.messageByteLimit - this.curMessageBytes;
-      // Defensive: every branch below that fills a message rolls over in the same
-      // iteration, so a full message is not observed at the top of the next one.
-      // Kept so the loop cannot spin if that ever stops holding — which is also
-      // why it has no test: it is unreachable at any configuration.
-      if (roomBytes <= 0) {
+      // A rollover clears curTs but leaves the prior message's byte count in
+      // place until ensureStarted opens and resets the continuation.
+      if (!this.curTs && this.firstTsValue !== undefined) {
+        if (!(await this.ensureStarted())) return;
+      }
+      const next = this.nextTextSlice();
+      if (!next) {
         if (!(await this.rollOver())) return;
         continue;
       }
-      // How far the byte budget reaches, and how far one call may reach.
-      const byteEnd = spanWithinBudget(
-        this.buffer,
-        this.curPosted,
-        roomBytes,
-        Number.MAX_SAFE_INTEGER,
-      );
-      const callEnd = spanWithinBudget(
-        this.buffer,
-        this.curPosted,
-        Number.MAX_SAFE_INTEGER,
-        APPEND_CHAR_LIMIT,
-      );
-      if (byteEnd >= this.buffer.length) {
-        // The rest of the reply fits in this message; only the per-call cap applies.
-        await this.appendSlice(Math.min(callEnd, this.buffer.length));
-        continue;
+
+      if (
+        !this.curTs &&
+        this.firstTsValue === undefined &&
+        this.transport.startStreamWithText
+      ) {
+        if (!(await this.startWithInitialSlice(next.end))) return;
+      } else {
+        if (!(await this.ensureStarted())) return; // failed over to legacy
+        await this.appendSlice(next.end);
       }
-      if (byteEnd <= this.curPosted) {
-        // Not even one code point fits — the message is full. Defensive, like the
-        // `roomBytes <= 0` check above: reaching it needs leftover room smaller
-        // than one character at the top of an iteration, and every branch that
-        // could leave that state rolls over first. Untestable, deliberately kept.
-        if (!(await this.rollOver())) return;
-        continue;
-      }
-      if (callEnd < byteEnd) {
-        // Per-call-limited, not message-limited: send a full call, keep the message.
-        await this.appendSlice(callEnd);
-        continue;
-      }
-      // Message-limited with text remaining: freeze the boundary, then roll over.
-      await this.appendSlice(this.breakPoint(this.curPosted, byteEnd));
-      if (!(await this.rollOver())) return;
+
+      if (next.rollOverAfter && !(await this.rollOver())) return;
+    }
+  }
+
+  /** Select the next bounded text slice and whether it fills this message. */
+  private nextTextSlice():
+    | { readonly end: number; readonly rollOverAfter: boolean }
+    | undefined {
+    const roomBytes = this.messageByteLimit - this.curMessageBytes;
+    // Defensive: every branch that fills a message rolls over in the same
+    // iteration, so a full message should not reach the next one.
+    if (roomBytes <= 0) return undefined;
+
+    const byteEnd = spanWithinBudget(
+      this.buffer,
+      this.curPosted,
+      roomBytes,
+      Number.MAX_SAFE_INTEGER,
+    );
+    const callEnd = spanWithinBudget(
+      this.buffer,
+      this.curPosted,
+      Number.MAX_SAFE_INTEGER,
+      APPEND_CHAR_LIMIT,
+    );
+    if (byteEnd >= this.buffer.length) {
+      return {
+        end: Math.min(callEnd, this.buffer.length),
+        rollOverAfter: false,
+      };
+    }
+    // Not even one code point fits. The caller rolls over before retrying.
+    if (byteEnd <= this.curPosted) return undefined;
+    if (callEnd < byteEnd) {
+      return { end: callEnd, rollOverAfter: false };
+    }
+    return {
+      end: this.breakPoint(this.curPosted, byteEnd),
+      rollOverAfter: true,
+    };
+  }
+
+  /** Start the first message with text and advance only after Slack accepts it. */
+  private async startWithInitialSlice(end: number): Promise<boolean> {
+    const initialText = this.buffer.slice(this.curPosted, end);
+    try {
+      this.curTs = await this.transport.startStreamWithText!(initialText);
+      this.firstTsValue = this.curTs;
+      this.messageCount += 1;
+      this.curPosted = end;
+      this.curMessageBytes = utf8Length(initialText);
+      return true;
+    } catch (err) {
+      if (this.strict) throw err;
+      this.failOverToLegacy(err);
+      return false;
     }
   }
 
@@ -790,14 +830,13 @@ export class NativeMessageStream implements TextStream {
   private async flushChunk(chunk: AnyChunk): Promise<void> {
     if (this.legacy || this.chunksDisabled) return;
     try {
-      // Start the stream even if no text yet — a tool call can be the first
-      // thing the agent emits (`startStream` accepts a content-less open; the
-      // chunk is the message's first content).
-      if (!(await this.ensureStarted())) {
+      await this.flushTextInline();
+      // Start without text only when the chunk is the first content. Pending
+      // text uses startStreamWithText when the transport supports it.
+      if (!this.curTs && !(await this.ensureStarted())) {
         this.disableChunks(new Error("startStream failed"));
         return;
       }
-      await this.flushTextInline();
       // A rollover inside the text flush retargets the stream, and a legacy
       // failover removes it entirely; re-check before addressing the chunk.
       if (this.legacy || !this.curTs) {


### PR DESCRIPTION
## Summary

- Send the first bounded Slack text delta in stream.start for direct and managed delivery.
- Keep later appends, continuation messages, and empty-stream cleanup behavior.
- Add managed delivery integration tests for first-text, empty-chunk, and empty-stream paths.

## Root cause

Slack received stream.start without text, so it rendered Thinking... until a separate append arrived.

## Tests

- pnpm nx run-many -t test,check-types,build -p @copilotkit/channels-slack @copilotkit/channels-intelligence --skip-nx-cache
- pnpm nx test @copilotkit/react-core --skip-nx-cache
- pre-commit test, publint, and attw checks for 12 affected projects