### PR TITLE
feat(channels): make identity and memory access explicit

### DIFF
--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -80,6 +80,7 @@ import { appTools } from "./tools/index.js";
 import { appContext } from "./context/app-context.js";
 
 const bot = createChannel({
+  identifyUser: "platform",
   name: "triage", // every declared Channel needs a unique name
   adapters: [
     slack({
@@ -109,7 +110,9 @@ const bot = createChannel({
 // One handler covers explicit @-mentions and normal DMs.
 // senderContext names the requesting user so the agent acts "as" them.
 bot.onMention(async ({ thread, message }) => {
-  await thread.runAgent({ context: senderContext(message.user) });
+  await thread.runAgent({
+    context: senderContext(message.user, thread.platform),
+  });
 });
 
 // A Channel runs only through the Intelligence runtime, which OWNS its
@@ -121,7 +124,6 @@ const intelligence = new CopilotKitIntelligence({
 const runtime = new CopilotRuntime({
   agents: {}, // the Channel supplies its own agent
   intelligence,
-  identifyUser: () => ({ id: "demo-user", name: "Demo User" }), // demo stub
   channels: [bot],
 });
 
@@ -145,7 +147,7 @@ plain replies in a thread can continue after the bot has posted there.
 
 The bot's tools are plain `ChannelTool`s, collected into `appTools` and spread
 into `createChannel({ tools })`. Each handler receives the generic
-`ChannelToolContext` (`{ thread, message?, user?, signal?, platform }`) the
+`ChannelToolContext` (`{ thread, message?, user, actor, signal?, platform }`) the
 adapter supplies at call time; tools reach platform power (post, postFile,
 `thread.getMessages()`, …) via the `thread` methods:
 
@@ -238,7 +240,10 @@ defineChannelCommand({
   description: "Ask the triage agent anything (no @mention needed).",
   async handler({ thread, text, user }) {
     if (!text) return void thread.post("Usage: `/agent <your question>`");
-    await thread.runAgent({ prompt: text, context: senderContext(user) });
+    await thread.runAgent({
+      prompt: text,
+      context: senderContext(user, thread.platform),
+    });
   },
 });
 ```
@@ -380,16 +385,14 @@ follow-up unless you enabled legacy thread continuation:
 
 ## Per-user identity
 
-The `onMention` handler forwards the **requesting user** (resolved to name +
-email where the platform exposes it) to the agent each turn via
-`senderContext(message.user)`, so the bot acts on behalf of whoever's asking:
-"my issues" is scoped to you, and issues it files are assigned to you. On Slack
-this needs the `users:read.email` scope (already in the manifest — reinstall
-the app once after adding it).
+The `onMention` handler forwards the canonical **application user** returned by
+the Channel `identifyUser` policy to the agent each turn via
+`senderContext(message.user, thread.platform)`. The standard `"platform"`
+policy namespaces each confirmed human by provider and workspace. Use a custom
+policy when Slack and another surface must map to one application user.
 
-Caveat: a single API key can't forge Linear's `creator`, so created issues
-are _authored_ by the bot and _assigned_ to the requester. True per-user
-attribution (and reliable Notion personalization) needs per-user OAuth.
+Caveat: a single API key cannot forge Linear's `creator`, so the bot authors
+created issues. True per-user attribution needs per-user OAuth.
 
 ## Files → charts, diagrams & tables
 

--- a/examples/slack/app/commands/__tests__/commands.test.ts
+++ b/examples/slack/app/commands/__tests__/commands.test.ts
@@ -98,11 +98,12 @@ describe("example slash commands", () => {
       text: "Login button is broken",
       options: {},
       user: { id: "U1", name: "Ada" },
+      actor: { id: "U1", kind: "human", name: "Ada" },
       platform: "slack",
     } as never);
     expect(postEphemeral).toHaveBeenCalledTimes(1);
-    const [user, , opts] = postEphemeral.mock.calls[0]!;
-    expect(user).toEqual({ id: "U1", name: "Ada" });
+    const [actor, , opts] = postEphemeral.mock.calls[0]!;
+    expect(actor).toEqual({ id: "U1", kind: "human", name: "Ada" });
     expect(opts).toEqual({ fallbackToDM: true });
   });
 
@@ -119,6 +120,24 @@ describe("example slash commands", () => {
       platform: "slack",
     } as never);
     expect(post).toHaveBeenCalledWith(expect.stringContaining("Usage"));
+    expect(postEphemeral).not.toHaveBeenCalled();
+  });
+
+  it("/preview refuses a private reply when the provider actor is missing", async () => {
+    const preview = appCommands.find((c) => c.name === "preview")!;
+    const postEphemeral = vi.fn();
+    const post = vi.fn().mockResolvedValue({ id: "1" });
+    await preview.handler({
+      thread: { postEphemeral, post } as never,
+      command: "preview",
+      text: "Login button is broken",
+      options: {},
+      user: { id: "customer-42", name: "Ada" },
+      platform: "slack",
+    } as never);
+    expect(post).toHaveBeenCalledWith(
+      expect.stringContaining("can't send a private preview"),
+    );
     expect(postEphemeral).not.toHaveBeenCalled();
   });
 
@@ -197,6 +216,7 @@ describe("example slash commands", () => {
       text: "Login broken",
       options: {},
       user: { id: "U1", name: "Ada" },
+      actor: { id: "U1", kind: "human", name: "Ada" },
       platform: "discord",
     } as never);
     expect(postEphemeral).toHaveBeenCalledTimes(1);
@@ -216,6 +236,7 @@ describe("example slash commands", () => {
       text: "Login broken",
       options: {},
       user: { id: "U1", name: "Ada" },
+      actor: { id: "U1", kind: "human", name: "Ada" },
       platform: "discord",
     } as never);
     expect(postEphemeral).toHaveBeenCalledTimes(1);

--- a/examples/slack/app/commands/index.ts
+++ b/examples/slack/app/commands/index.ts
@@ -63,12 +63,12 @@ export const appCommands: ChannelCommand[] = [
   defineChannelCommand({
     name: "preview",
     description: "Privately preview the issue I'd file (only you see it).",
-    async handler({ thread, text, user, platform }) {
+    async handler({ thread, text, actor, platform }) {
       if (!text) {
         await thread.post("Usage: `/preview <issue title>`");
         return;
       }
-      if (!user) {
+      if (!actor) {
         await thread.post(
           "I couldn't tell who you are, so I can't send a private preview here.",
         );
@@ -80,7 +80,7 @@ export const appCommands: ChannelCommand[] = [
         state: "Triage",
         description: "_Draft — nothing is filed until you run_ `/file-issue`.",
       });
-      const res = await thread.postEphemeral(user, draft, {
+      const res = await thread.postEphemeral(actor, draft, {
         fallbackToDM: true,
       });
       // Degrade, never throw: report what actually happened.

--- a/examples/slack/app/index.ts
+++ b/examples/slack/app/index.ts
@@ -193,6 +193,7 @@ async function main() {
   }
 
   const bot = createChannel({
+    identifyUser: "platform",
     // Every declared Channel needs a unique `name` — the Intelligence runtime
     // keys its lifecycle by it. All four platforms ride this ONE Channel; the
     // runtime starts each of its direct adapters when the Channel activates.
@@ -293,9 +294,6 @@ async function main() {
   const channelRuntime = new CopilotRuntime({
     agents: {},
     intelligence,
-    // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
-    // before any multi-user deployment, or all users share one thread history.
-    identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
     channels: [bot],
   });
 

--- a/examples/slack/app/managed.ts
+++ b/examples/slack/app/managed.ts
@@ -69,6 +69,7 @@ async function main() {
   // Slack tools/context (the native example adds these conditionally per active
   // adapter).
   const support = createChannel({
+    identifyUser: "platform",
     name: channelName,
     agent: (threadId) => {
       const a = new HttpAgent({
@@ -139,9 +140,6 @@ async function main() {
     // additional runtime-hosted agents are needed here.
     agents: {},
     intelligence,
-    // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
-    // before any multi-user deployment, or all users share one thread history.
-    identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
     channels: [support],
   });
 

--- a/examples/slack/app/sender-context.test.ts
+++ b/examples/slack/app/sender-context.test.ts
@@ -3,18 +3,15 @@ import { senderContext } from "./sender-context.js";
 
 describe("senderContext", () => {
   it("returns [] when there is no user", () => {
-    expect(senderContext(undefined, "slack")).toEqual([]);
+    expect(senderContext(null, "slack")).toEqual([]);
   });
 
-  it("labels a slack user with email", () => {
-    const out = senderContext(
-      { id: "U1", name: "Ada", email: "ada@x.io" },
-      "slack",
-    );
+  it("labels the canonical application user", () => {
+    const out = senderContext({ id: "user-1", name: "Ada" }, "slack");
     expect(out).toEqual([
       {
         description: "Requesting slack user",
-        value: "Ada <ada@x.io> (slack id U1)",
+        value: "Ada (application user user-1)",
       },
     ]);
   });
@@ -24,17 +21,7 @@ describe("senderContext", () => {
     expect(out).toEqual([
       {
         description: "Requesting whatsapp user",
-        value: "Bob (whatsapp id 15551230000)",
-      },
-    ]);
-  });
-
-  it("falls back to the id when the user has no name (e.g. a WhatsApp sender)", () => {
-    const out = senderContext({ id: "15551230000" }, "whatsapp");
-    expect(out).toEqual([
-      {
-        description: "Requesting whatsapp user",
-        value: "15551230000 (whatsapp id 15551230000)",
+        value: "Bob (application user 15551230000)",
       },
     ]);
   });

--- a/examples/slack/app/sender-context.ts
+++ b/examples/slack/app/sender-context.ts
@@ -1,22 +1,17 @@
 import type { ContextEntry } from "@copilotkit/channels";
-import type { PlatformUser } from "@copilotkit/channels";
+import type { ApplicationUser } from "@copilotkit/channels";
 
 /**
  * Build the per-turn context naming the requesting user, so the agent can act
- * "as" them (filter Linear by their email, @-mention/tag them). The platform
- * adapter resolves `{ id, name?, email? }` per turn; if it's absent there's
- * nothing to attribute, so we add no entry. `platform` is the surface the turn
- * came from (`thread.platform`), so the label is correct across Slack, Discord,
- * Telegram, and WhatsApp alike.
+ * "as" them. `createChannel` resolves the provider actor to this canonical
+ * application user once per turn. If no application user maps, there is
+ * nothing to attribute, so we add no entry.
  */
 export function senderContext(
-  user: PlatformUser | undefined,
+  user: ApplicationUser | null,
   platform: string,
 ): ContextEntry[] {
-  // `createChannel` substitutes `{ id: "" }` for an unresolved sender (a truthy
-  // object), so guard on a usable id — not mere object presence — otherwise we
-  // emit a "Requesting <platform> user (... id )" entry with nothing to attribute.
   if (!user?.id) return [];
-  const label = `${user.name ?? user.id}${user.email ? ` <${user.email}>` : ""} (${platform} id ${user.id})`;
+  const label = `${user.name} (application user ${user.id})`;
   return [{ description: `Requesting ${platform} user`, value: label }];
 }

--- a/examples/slack/app/tools/__tests__/read-thread.test.ts
+++ b/examples/slack/app/tools/__tests__/read-thread.test.ts
@@ -19,12 +19,12 @@ describe("read_thread tool", () => {
   it("returns the thread messages in a normalized shape", async () => {
     const ctx = makeCtx([
       {
-        user: { id: "UALICE", name: "Alice" },
+        user: { id: "UALICE", kind: "human", name: "Alice" },
         text: "checkout is 500ing",
         ts: "1700000000.000100",
       },
       {
-        user: { id: "UBOT", name: "Triage Bot" },
+        user: { id: "UBOT", kind: "bot", name: "Triage Bot" },
         text: "looking into it",
         ts: "1700000000.000200",
         isBot: true,

--- a/examples/teams/app/index.tsx
+++ b/examples/teams/app/index.tsx
@@ -201,6 +201,7 @@ const showCard = defineChannelTool({
 });
 
 const bot = createChannel({
+  identifyUser: "platform",
   // Every declared Channel needs a unique `name` — the Intelligence runtime
   // keys its lifecycle (and, for managed Channels, its activation config) by it.
   name: "teams-assistant",
@@ -258,9 +259,6 @@ const intelligence = new CopilotKitIntelligence({
 const channelRuntime = new CopilotRuntime({
   agents: {},
   intelligence,
-  // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
-  // before any multi-user deployment, or all users share one thread history.
-  identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
   channels: [bot],
 });
 

--- a/packages/channels-core/README.md
+++ b/packages/channels-core/README.md
@@ -35,7 +35,7 @@ import { slack } from "@copilotkit/channels-slack";
   `{ thread, message }`. Bot mentions select `onMention` when registered and
   otherwise fall back to `onMessage`; other content selects `onMessage`.
 - `onThreadStarted(handler)` — a conversation surface opened (e.g. the Slack
-  assistant pane); receives `{ thread, user? }`. Greet, set suggested prompts
+  assistant pane); receives `{ thread, user, actor }`. Greet, set suggested prompts
   or a title, or run the agent. Adapters without the concept never fire it.
 - `onWelcome(handler)` — a provider installation or conversation activation;
   receives `{ thread, user?, platform }`. Adapters without a reliable
@@ -43,10 +43,10 @@ import { slack } from "@copilotkit/channels-slack";
 - `onInteraction<TValue>(id, handler)` — explicit escape-hatch handler for a
   known action id, bypassing the registry; `ctx.action.value` is typed `TValue`.
 - `onInterrupt<TPayload>(eventName, handler)` — handle a captured agent
-  interrupt (LangGraph-style `on_interrupt`); receives `{ payload, thread }`
+  interrupt (LangGraph-style `on_interrupt`); receives `{ payload, thread, user, actor }`
   with `payload` typed `TPayload`.
 - `onCommand(command)` / `onCommand(name, handler)` — register a slash command.
-  The handler gets `{ thread, command, text, options, user }`. `text` is the
+  The handler gets `{ thread, command, text, options, user, actor }`. `text` is the
   raw args (Slack); `options` is the typed, parsed form (`defineChannelCommand`
   with an `options` Standard Schema) for surfaces with native structured args
   (e.g. Discord). This is a direct-adapter capability: managed Slack and Teams
@@ -78,6 +78,7 @@ import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 
 const channel = createChannel({
   name: "support-bot", // project-unique Intelligence Channel name
+  identifyUser: "platform",
   adapters: [slack({ botToken, appToken })],
 });
 
@@ -87,7 +88,6 @@ const runtime = new CopilotRuntime({
     // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
-  identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),
   channels: [channel],
 });
 
@@ -119,8 +119,15 @@ interface Thread {
   runAgent(input?: {
     context?: ContextEntry[];
     tools?: ChannelTool[];
+    memory?: MemoryGrant;
   }): Promise<MessageRef | undefined>;
-  resume(value: unknown): Promise<MessageRef | undefined>;
+  resume(
+    value: unknown,
+    options?: {
+      memory?: MemoryGrant;
+      subject?: "initiator" | "actor";
+    },
+  ): Promise<MessageRef | undefined>;
   awaitChoice<T = unknown>(ui: Renderable): Promise<T>;
   // Capability-gated (return { ok: false } on surfaces without support):
   setSuggestedPrompts(

--- a/packages/channels-core/src/action-registry.test.ts
+++ b/packages/channels-core/src/action-registry.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { ActionRegistry, ActionExpiredError } from "./action-registry.js";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  ActionRegistry,
+  ActionContinuationMismatchError,
+  ActionExpiredError,
+} from "./action-registry.js";
 import { InMemoryActionStore } from "./action-store.js";
+import type { ActionContinuationSnapshot } from "./action-store.js";
 import { MemoryStore } from "./state/memory-store.js";
 import { kvActionStore } from "./state/kv-action-store.js";
 import type { ChannelNode, InteractionContext } from "@copilotkit/channels-ui";
@@ -164,6 +169,193 @@ describe("ActionRegistry", () => {
       await expect(regBPrime.dispatch(id, ctx)).rejects.toBeInstanceOf(
         ActionExpiredError,
       );
+    });
+  });
+
+  describe("one-use HITL continuations", () => {
+    const continuation = {
+      channelName: "approvals",
+      conversationKey: "conv1",
+      threadId: "thread1",
+      runChainId: "run-chain-1",
+      initiator: {
+        user: { id: "user-1", name: "Alice" },
+        actor: { id: "actor-1", kind: "human" as const },
+      },
+    };
+
+    it("mints random capabilities and stores the trusted binding in the action snapshot", async () => {
+      const store = new InMemoryActionStore();
+      const reg = new ActionRegistry({ store, retentionMs: 60_000 });
+      reg.registerComponent("Confirm", Confirm as never);
+
+      const first = await reg.bindTree(
+        "Confirm",
+        { action: "approve" },
+        "conv1",
+        continuation,
+      );
+      const second = await reg.bindTree(
+        "Confirm",
+        { action: "approve" },
+        "conv1",
+        continuation,
+      );
+      const firstId = (
+        (first[0]!.props.children as ChannelNode[])[0]!.props.onClick as {
+          id: string;
+        }
+      ).id;
+      const secondId = (
+        (second[0]!.props.children as ChannelNode[])[0]!.props.onClick as {
+          id: string;
+        }
+      ).id;
+
+      expect(firstId).not.toBe(secondId);
+      expect(await store.get(firstId)).toMatchObject({
+        continuation: { ...continuation, actionId: firstId },
+      });
+    });
+
+    it("allows exactly one claimant across concurrent resume attempts", async () => {
+      const reg = new ActionRegistry({
+        store: new InMemoryActionStore(),
+        retentionMs: 60_000,
+      });
+      reg.registerComponent("Confirm", Confirm as never);
+      const tree = await reg.bindTree(
+        "Confirm",
+        { action: "approve" },
+        "conv1",
+        continuation,
+      );
+      const id = (
+        (tree[0]!.props.children as ChannelNode[])[0]!.props.onClick as {
+          id: string;
+        }
+      ).id;
+
+      const outcomes = await Promise.allSettled([
+        reg.claimContinuation(id, continuation),
+        reg.claimContinuation(id, continuation),
+      ]);
+
+      expect(
+        outcomes.filter((outcome) => outcome.status === "fulfilled"),
+      ).toHaveLength(1);
+      expect(
+        outcomes.filter((outcome) => outcome.status === "rejected"),
+      ).toHaveLength(1);
+      expect(
+        (
+          outcomes.find(
+            (outcome) => outcome.status === "rejected",
+          ) as PromiseRejectedResult
+        ).reason,
+      ).toBeInstanceOf(ActionExpiredError);
+    });
+
+    it.each([
+      ["Channel", { channelName: "wrong" }],
+      ["conversation", { conversationKey: "wrong" }],
+      ["Thread", { threadId: "wrong" }],
+    ])(
+      "rejects a wrong %s binding without consuming the valid continuation",
+      async (_label, tampered) => {
+        const reg = new ActionRegistry({
+          store: new InMemoryActionStore(),
+          retentionMs: 60_000,
+        });
+        reg.registerComponent("Confirm", Confirm as never);
+        const tree = await reg.bindTree(
+          "Confirm",
+          { action: "approve" },
+          "conv1",
+          continuation,
+        );
+        const id = (
+          (tree[0]!.props.children as ChannelNode[])[0]!.props.onClick as {
+            id: string;
+          }
+        ).id;
+
+        await expect(
+          reg.claimContinuation(id, { ...continuation, ...tampered }),
+        ).rejects.toBeInstanceOf(ActionContinuationMismatchError);
+        await expect(
+          reg.claimContinuation(id, continuation),
+        ).resolves.toMatchObject({
+          actionId: id,
+          runChainId: "run-chain-1",
+        });
+      },
+    );
+
+    it.each([
+      ["run chain", { runChainId: "" }],
+      ["action", { actionId: "ck:other" }],
+      [
+        "initiator actor",
+        { initiator: { ...continuation.initiator, actor: {} } },
+      ],
+    ])("rejects a snapshot with a tampered %s", async (_label, tampered) => {
+      const id = `ck:${globalThis.crypto.randomUUID()}`;
+      const store = new InMemoryActionStore();
+      const reg = new ActionRegistry({ store, retentionMs: 60_000 });
+      await store.put(id, {
+        path: [0, "onClick"],
+        conversationKey: "conv1",
+        continuation: {
+          ...continuation,
+          actionId: id,
+          ...tampered,
+        } as unknown as ActionContinuationSnapshot,
+      });
+
+      await expect(
+        reg.claimContinuation(id, continuation),
+      ).rejects.toBeInstanceOf(ActionContinuationMismatchError);
+    });
+
+    it("rejects a wrong random capability", async () => {
+      const reg = new ActionRegistry({
+        store: new InMemoryActionStore(),
+        retentionMs: 60_000,
+      });
+
+      await expect(
+        reg.claimContinuation("ck:wrong-capability", continuation),
+      ).rejects.toBeInstanceOf(ActionExpiredError);
+    });
+
+    it("expires with the action retention window", async () => {
+      vi.useFakeTimers();
+      try {
+        const reg = new ActionRegistry({
+          store: new InMemoryActionStore(),
+          retentionMs: 100,
+        });
+        reg.registerComponent("Confirm", Confirm as never);
+        const tree = await reg.bindTree(
+          "Confirm",
+          { action: "approve" },
+          "conv1",
+          continuation,
+        );
+        const id = (
+          (tree[0]!.props.children as ChannelNode[])[0]!.props.onClick as {
+            id: string;
+          }
+        ).id;
+        vi.advanceTimersByTime(101);
+
+        await expect(
+          reg.claimContinuation(id, continuation),
+        ).rejects.toBeInstanceOf(ActionExpiredError);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/packages/channels-core/src/action-registry.ts
+++ b/packages/channels-core/src/action-registry.ts
@@ -8,12 +8,29 @@ import type {
 } from "@copilotkit/channels-ui";
 import { isBound, getBoundArgs, renderToIR } from "@copilotkit/channels-ui";
 import { mintId } from "./mint-id.js";
-import type { ActionStore } from "./action-store.js";
+import type {
+  ActionContinuationContext,
+  ActionContinuationBinding,
+  ActionContinuationSnapshot,
+  ActionStore,
+} from "./action-store.js";
 
 export class ActionExpiredError extends Error {
+  readonly code = "channel_action_expired";
+
   constructor(id: string) {
     super(`Action "${id}" has expired or is no longer available.`);
     this.name = "ActionExpiredError";
+  }
+}
+
+/** A continuation capability was presented outside its trusted Channel binding. */
+export class ActionContinuationMismatchError extends Error {
+  readonly code = "channel_continuation_mismatch";
+
+  constructor() {
+    super("The Channel continuation does not match this interaction");
+    this.name = "ActionContinuationMismatchError";
   }
 }
 
@@ -36,14 +53,20 @@ export class ActionRegistry {
   // needed to resolve HITL `awaitChoice` waiters on platforms whose callback
   // payload can't carry it (e.g. Telegram's 64-byte callback_data only holds
   // the action id), where `evt.value` arrives undefined.
-  private hot = new Map<string, { handler: ClickHandler; value: unknown }>();
+  private hot = new Map<
+    string,
+    { handler: ClickHandler; value: unknown; continuation?: true }
+  >();
   // Same-process fast path for `<Message onReaction>` handlers, keyed by the
   // posted message's id. Mirrors the `hot` action cache; the durable snapshot
   // (below) is the cross-restart counterpart, exactly like onClick.
   private messageReactions = new Map<string, MessageReactionHandler>();
 
-  constructor(opts: { store: ActionStore }) {
+  private readonly retentionMs?: number;
+
+  constructor(opts: { store: ActionStore; retentionMs?: number }) {
     this.store = opts.store;
+    this.retentionMs = opts.retentionMs;
   }
 
   /** Cache a `<Message onReaction>` handler for the posted message (same-process). */
@@ -111,10 +134,18 @@ export class ActionRegistry {
     componentName: string,
     props: Record<string, unknown>,
     conversationKey: string,
+    continuation?: ActionContinuationContext,
   ): Promise<ChannelNode[]> {
     const fn = this.components.get(componentName);
     const root = renderToIR((fn ? fn(props) : props) as Renderable);
-    await this.walk(root, [], componentName, props, conversationKey);
+    await this.walk(
+      root,
+      [],
+      componentName,
+      props,
+      conversationKey,
+      continuation,
+    );
     return root;
   }
 
@@ -128,6 +159,7 @@ export class ActionRegistry {
   async bindRenderable(
     ui: Renderable,
     conversationKey: string,
+    continuation?: ActionContinuationContext,
   ): Promise<{
     root: ChannelNode[];
     onReaction?: MessageReactionHandler;
@@ -146,10 +178,15 @@ export class ActionRegistry {
       component = fn.name || "anonymous";
       props = (ui.props ?? {}) as Record<string, unknown>;
       this.registerComponent(component, fn);
-      root = await this.bindTree(component, props, conversationKey);
+      root = await this.bindTree(
+        component,
+        props,
+        conversationKey,
+        continuation,
+      );
     } else {
       root = renderToIR(ui);
-      await this.walk(root, [], "", undefined, conversationKey);
+      await this.walk(root, [], "", undefined, conversationKey, continuation);
     }
     const onReaction = takeMessageReaction(root);
     return {
@@ -166,6 +203,7 @@ export class ActionRegistry {
     comp: string,
     props: unknown,
     conv: string,
+    continuation?: ActionContinuationContext,
   ): Promise<void> {
     for (let i = 0; i < nodes.length; i++) {
       const node = nodes[i]!;
@@ -174,18 +212,28 @@ export class ActionRegistry {
         const handler = node.props[ep];
         if (typeof handler === "function") {
           const fullPath: (string | number)[] = [...path, ep];
-          const id = mintId(comp, fullPath, props);
+          const id = continuation
+            ? `ck:${globalThis.crypto.randomUUID()}`
+            : mintId(comp, fullPath, props);
           this.hot.set(id, {
             handler: handler as ClickHandler,
             value: node.props.value,
+            ...(continuation ? { continuation: true as const } : {}),
           });
-          await this.store.put(id, {
-            component: comp,
-            props,
-            path: fullPath,
-            conversationKey: conv,
-            boundArgs: isBound(handler) ? getBoundArgs(handler) : undefined,
-          });
+          await this.store.put(
+            id,
+            {
+              component: comp,
+              props,
+              path: fullPath,
+              conversationKey: conv,
+              boundArgs: isBound(handler) ? getBoundArgs(handler) : undefined,
+              ...(continuation
+                ? { continuation: { ...continuation, actionId: id } }
+                : {}),
+            },
+            continuation ? this.retentionMs : undefined,
+          );
           node.props[ep] = { id };
         }
       }
@@ -197,6 +245,7 @@ export class ActionRegistry {
           comp,
           props,
           conv,
+          continuation,
         );
       }
     }
@@ -213,6 +262,10 @@ export class ActionRegistry {
     let value: unknown;
     const hot = this.hot.get(id);
     if (hot) {
+      if (hot.continuation && !(await this.store.get(id))) {
+        this.hot.delete(id);
+        throw new ActionExpiredError(id);
+      }
       handler = hot.handler;
       value = hot.value;
     } else {
@@ -229,6 +282,51 @@ export class ActionRegistry {
     }
     await handler({ ...ctx, action: { ...ctx.action, id } });
     return value;
+  }
+
+  /** Read and validate one continuation capability without consuming it. */
+  async getContinuation(
+    id: string,
+    expected: ActionContinuationBinding,
+  ): Promise<ActionContinuationSnapshot> {
+    const available = await this.store.get(id);
+    if (!available?.continuation) throw new ActionExpiredError(id);
+    assertContinuationBinding(available.continuation, id, expected);
+    return available.continuation;
+  }
+
+  /** Validate and atomically consume one continuation capability. */
+  async claimContinuation(
+    id: string,
+    expected: ActionContinuationBinding,
+  ): Promise<ActionContinuationSnapshot> {
+    await this.getContinuation(id, expected);
+
+    const claimed = await this.store.consume(id);
+    if (!claimed?.continuation) throw new ActionExpiredError(id);
+    assertContinuationBinding(claimed.continuation, id, expected);
+    this.hot.delete(id);
+    return claimed.continuation;
+  }
+}
+
+function assertContinuationBinding(
+  actual: ActionContinuationSnapshot,
+  actionId: string,
+  expected: ActionContinuationBinding,
+): void {
+  if (
+    actual.actionId !== actionId ||
+    actual.channelName !== expected.channelName ||
+    actual.conversationKey !== expected.conversationKey ||
+    actual.threadId !== expected.threadId ||
+    typeof actual.runChainId !== "string" ||
+    actual.runChainId.length === 0 ||
+    typeof actual.initiator?.actor?.id !== "string" ||
+    (actual.initiator.user !== null &&
+      typeof actual.initiator.user?.id !== "string")
+  ) {
+    throw new ActionContinuationMismatchError();
   }
 }
 

--- a/packages/channels-core/src/action-store.ts
+++ b/packages/channels-core/src/action-store.ts
@@ -1,14 +1,44 @@
+import type { ApplicationUser, ProviderActor } from "@copilotkit/channels-ui";
+
+/** Trusted principal captured when one HITL run chain starts. */
+export interface ActionContinuationInitiator {
+  user: ApplicationUser | null;
+  actor: ProviderActor;
+}
+
+/** Trusted facts bound to every one-use action rendered by a HITL run chain. */
+export interface ActionContinuationContext {
+  channelName: string;
+  conversationKey: string;
+  threadId: string;
+  runChainId: string;
+  initiator: ActionContinuationInitiator;
+}
+
+/** Server-derived delivery facts used to validate a presented continuation. */
+export type ActionContinuationBinding = Pick<
+  ActionContinuationContext,
+  "channelName" | "conversationKey" | "threadId"
+>;
+
+/** Persisted continuation binding, including its random action capability. */
+export interface ActionContinuationSnapshot extends ActionContinuationContext {
+  actionId: string;
+}
+
 export interface ActionSnapshot {
   component?: string;
   props?: unknown;
   path: (string | number)[];
   boundArgs?: unknown;
   conversationKey: string;
+  continuation?: ActionContinuationSnapshot;
 }
 /** @deprecated Configure `createChannel({ state })` instead. Action snapshots are stored via `StateStore.kv`. */
 export interface ActionStore {
   put(id: string, snap: ActionSnapshot, ttlMs?: number): Promise<void>;
   get(id: string): Promise<ActionSnapshot | undefined>;
+  consume(id: string): Promise<ActionSnapshot | undefined>;
   delete(id: string): Promise<void>;
 }
 /** @deprecated Configure `createChannel({ state })` instead. Action snapshots are stored via `StateStore.kv`. */
@@ -31,5 +61,15 @@ export class InMemoryActionStore implements ActionStore {
   }
   async delete(id: string): Promise<void> {
     this.map.delete(id);
+  }
+  async consume(id: string): Promise<ActionSnapshot | undefined> {
+    const entry = this.map.get(id);
+    if (!entry) return undefined;
+    if (entry.expiresAt !== undefined && Date.now() > entry.expiresAt) {
+      this.map.delete(id);
+      return undefined;
+    }
+    this.map.delete(id);
+    return entry.snap;
   }
 }

--- a/packages/channels-core/src/canonical-run-loop.test.ts
+++ b/packages/channels-core/src/canonical-run-loop.test.ts
@@ -417,7 +417,12 @@ test("terminal delivery tool failure stops the loop and closes renderer fanout",
       tools: new Map([["echo", postFile]]),
       toolDescriptors: [],
       context: [],
-      makeToolCtx: () => ({ thread: {} as never, platform: "fake" }),
+      makeToolCtx: () => ({
+        thread: {} as never,
+        user: null,
+        actor: { id: "actor", kind: "unknown" },
+        platform: "fake",
+      }),
       subscriber: {
         onEvent: ({ event }) => {
           ingestedEvents.push(event);

--- a/packages/channels-core/src/channel-identity.test.ts
+++ b/packages/channels-core/src/channel-identity.test.ts
@@ -1,0 +1,332 @@
+import type { AgentSubscriber } from "@ag-ui/client";
+import { expect, test, vi } from "vitest";
+import { createChannel } from "./create-channel.js";
+import { FakeAdapter } from "./testing/fake-adapter.js";
+import { FakeAgent } from "./testing/fake-agent.js";
+
+test("a Channel rejects construction without an explicit identity strategy", () => {
+  expect(() =>
+    createChannel({ adapters: [new FakeAdapter()] } as unknown as Parameters<
+      typeof createChannel
+    >[0]),
+  ).toThrow('createChannel: `identifyUser` must be "platform" or a callback');
+});
+
+test("a custom Channel identity callback maps the provider actor once before the message handler", async () => {
+  const identifyUser = vi.fn(() => ({ id: "person-1", name: "Pat Lee" }));
+  const adapter = new FakeAdapter({ platform: "intelligence" });
+  const channel = createChannel({
+    adapters: [adapter],
+    identifyUser,
+  } as unknown as Parameters<typeof createChannel>[0]);
+  let received: unknown;
+  channel.onMessage(({ message }) => {
+    received = message;
+  });
+  await channel.ɵruntime.start();
+
+  await adapter.getSink().onTurn({
+    conversationKey: "conversation-1",
+    replyTarget: {},
+    userText: "hello",
+    platform: "slack",
+    actor: {
+      id: "U123",
+      kind: "human",
+      name: "Pat on Slack",
+      handle: "pat",
+    },
+    identityContext: {
+      tenant: { id: "T123", name: "Acme" },
+      installation: { id: "I123" },
+      conversation: { id: "C123", kind: "channel" },
+      trigger: "message",
+      event: { id: "E123", occurredAt: "2026-07-31T12:00:00.000Z" },
+      raw: { type: "app_mention" },
+    },
+  } as unknown as Parameters<ReturnType<FakeAdapter["getSink"]>["onTurn"]>[0]);
+
+  expect(identifyUser).toHaveBeenCalledTimes(1);
+  expect(identifyUser).toHaveBeenCalledWith({
+    provider: "slack",
+    tenant: { id: "T123", name: "Acme" },
+    installation: { id: "I123" },
+    actor: {
+      id: "U123",
+      kind: "human",
+      name: "Pat on Slack",
+      handle: "pat",
+    },
+    conversation: { id: "C123", kind: "channel" },
+    trigger: "message",
+    event: { id: "E123", occurredAt: "2026-07-31T12:00:00.000Z" },
+    raw: { type: "app_mention" },
+  });
+  expect(received).toEqual(
+    expect.objectContaining({
+      user: { id: "person-1", name: "Pat Lee" },
+      actor: {
+        id: "U123",
+        kind: "human",
+        name: "Pat on Slack",
+        handle: "pat",
+      },
+    }),
+  );
+  expect(Object.isFrozen((received as { user: unknown }).user)).toBe(true);
+  expect(Object.isFrozen((received as { actor: unknown }).actor)).toBe(true);
+});
+
+test("a command resolves identity once and exposes the canonical user and provider actor", async () => {
+  const identifyUser = vi.fn(() => ({ id: "person-2", name: "Jo Kim" }));
+  const adapter = new FakeAdapter({ platform: "intelligence" });
+  const channel = createChannel({
+    adapters: [adapter],
+    identifyUser,
+  } as unknown as Parameters<typeof createChannel>[0]);
+  let received: unknown;
+  channel.onCommand("who", (context) => {
+    received = context;
+  });
+  await channel.ɵruntime.start();
+
+  await adapter.getSink().onCommand({
+    command: "who",
+    conversationKey: "conversation-2",
+    replyTarget: {},
+    text: "",
+    platform: "teams",
+    actor: { id: "29:actor", kind: "human", name: "Jo on Teams" },
+    identityContext: {
+      tenant: { id: "tenant-2" },
+      installation: { id: "install-2" },
+      conversation: { id: "conversation-2", kind: "channel" },
+      trigger: "command",
+      event: { id: "event-2" },
+      raw: { name: "who" },
+    },
+  } as unknown as Parameters<
+    ReturnType<FakeAdapter["getSink"]>["onCommand"]
+  >[0]);
+
+  expect(identifyUser).toHaveBeenCalledTimes(1);
+  expect(received).toEqual(
+    expect.objectContaining({
+      user: { id: "person-2", name: "Jo Kim" },
+      actor: { id: "29:actor", kind: "human", name: "Jo on Teams" },
+    }),
+  );
+});
+
+test("an agent interrupt handler receives the event's canonical user and provider actor", async () => {
+  const identifyUser = vi.fn(() => ({ id: "person-3", name: "Sam Rao" }));
+  const adapter = new FakeAdapter({ platform: "intelligence" });
+  const agent = new FakeAgent([
+    (subscriber: AgentSubscriber) => {
+      subscriber.onCustomEvent?.({
+        event: { name: "approval", value: { requestId: "request-1" } },
+      } as never);
+      subscriber.onRunFinishedEvent?.({ event: {} } as never);
+    },
+  ]);
+  const channel = createChannel({
+    adapters: [adapter],
+    identifyUser,
+    agent,
+  } as unknown as Parameters<typeof createChannel>[0]);
+  let received: unknown;
+  channel.onMessage(async ({ thread }) => {
+    await thread.runAgent();
+  });
+  channel.onInterrupt("approval", (context) => {
+    received = context;
+  });
+  await channel.ɵruntime.start();
+
+  await adapter.getSink().onTurn({
+    conversationKey: "conversation-3",
+    replyTarget: {},
+    userText: "approve",
+    platform: "slack",
+    actor: { id: "U3", kind: "human", name: "Sam on Slack" },
+    identityContext: {
+      tenant: { id: "T3" },
+      installation: { id: "I3" },
+      conversation: { id: "C3", kind: "channel" },
+      trigger: "message",
+      event: { id: "E3" },
+      raw: {},
+    },
+  } as never);
+
+  expect(identifyUser).toHaveBeenCalledTimes(1);
+  expect(received).toEqual(
+    expect.objectContaining({
+      payload: { requestId: "request-1" },
+      user: { id: "person-3", name: "Sam Rao" },
+      actor: { id: "U3", kind: "human", name: "Sam on Slack" },
+    }),
+  );
+});
+
+test("every non-message Channel trigger resolves identity once before its handler", async () => {
+  const identifyUser = vi.fn(({ actor }: { actor: { id: string } }) => ({
+    id: `person:${actor.id}`,
+    name: actor.id,
+  }));
+  const adapter = new FakeAdapter({ platform: "intelligence" });
+  const channel = createChannel({
+    adapters: [adapter],
+    identifyUser,
+  } as unknown as Parameters<typeof createChannel>[0]);
+  const received: unknown[] = [];
+  channel.onThreadStarted((context) => {
+    received.push(context);
+  });
+  channel.onInteraction("approve", (context) => {
+    received.push(context);
+  });
+  channel.onReaction((context) => {
+    received.push(context);
+  });
+  channel.onModalSubmit("submit", (context) => {
+    received.push(context);
+  });
+  channel.onModalClose("close", (context) => {
+    received.push(context);
+  });
+  await channel.ɵruntime.start();
+  const sink = adapter.getSink();
+  const facts = (id: string, trigger: string) => ({
+    actor: { id, kind: "human" as const },
+    identityContext: {
+      tenant: { id: "tenant" },
+      installation: { id: "installation" },
+      conversation: { id: "conversation", kind: "channel" },
+      trigger,
+      event: { id: `event:${id}` },
+      raw: { trigger },
+    },
+  });
+
+  await sink.onThreadStarted({
+    conversationKey: "conversation",
+    replyTarget: {},
+    platform: "slack",
+    ...facts("thread-actor", "thread-start"),
+  } as never);
+  await sink.onInteraction({
+    id: "approve",
+    conversationKey: "conversation",
+    replyTarget: {},
+    platform: "slack",
+    ...facts("interaction-actor", "interaction"),
+  } as never);
+  await sink.onReaction({
+    added: true,
+    conversationKey: "conversation",
+    messageId: "message",
+    raw: {},
+    rawEmoji: "+1",
+    replyTarget: {},
+    platform: "slack",
+    ...facts("reaction-actor", "reaction"),
+  } as never);
+  await sink.onModalSubmit({
+    callbackId: "submit",
+    values: {},
+    conversationKey: "conversation",
+    replyTarget: {},
+    platform: "slack",
+    raw: {},
+    ...facts("submit-actor", "modal-submit"),
+  } as never);
+  await sink.onModalClose({
+    callbackId: "close",
+    conversationKey: "conversation",
+    replyTarget: {},
+    platform: "slack",
+    raw: {},
+    ...facts("close-actor", "modal-close"),
+  } as never);
+
+  expect(identifyUser).toHaveBeenCalledTimes(5);
+  expect(received).toHaveLength(5);
+  expect(received).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        user: { id: "person:thread-actor", name: "thread-actor" },
+        actor: { id: "thread-actor", kind: "human" },
+      }),
+      expect.objectContaining({
+        user: { id: "person:interaction-actor", name: "interaction-actor" },
+        actor: { id: "interaction-actor", kind: "human" },
+      }),
+      expect.objectContaining({
+        user: { id: "person:reaction-actor", name: "reaction-actor" },
+        actor: { id: "reaction-actor", kind: "human" },
+      }),
+      expect.objectContaining({
+        user: { id: "person:submit-actor", name: "submit-actor" },
+        actor: { id: "submit-actor", kind: "human" },
+      }),
+      expect.objectContaining({
+        user: { id: "person:close-actor", name: "close-actor" },
+        actor: { id: "close-actor", kind: "human" },
+      }),
+    ]),
+  );
+});
+
+test("parallel actors in one conversation keep their own immutable identity", async () => {
+  const releases = new Map<string, () => void>();
+  const identifyUser = vi.fn(
+    async ({ actor }: { actor: { id: string; name?: string } }) => {
+      await new Promise<void>((resolve) => releases.set(actor.id, resolve));
+      return { id: `person:${actor.id}`, name: actor.name ?? actor.id };
+    },
+  );
+  const adapter = new FakeAdapter({ platform: "intelligence" });
+  const channel = createChannel({ adapters: [adapter], identifyUser } as never);
+  const received: unknown[] = [];
+  channel.onMessage(({ message }) => {
+    received.push(message);
+  });
+  await channel.ɵruntime.start();
+  const sink = adapter.getSink();
+  const event = (actorId: string) => ({
+    conversationKey: "shared-conversation",
+    replyTarget: {},
+    userText: `hello from ${actorId}`,
+    platform: "slack",
+    actor: { id: actorId, kind: "human" as const, name: actorId.toUpperCase() },
+    identityContext: {
+      tenant: { id: "T1" },
+      installation: { id: "I1" },
+      conversation: { id: "C1", kind: "channel" },
+      trigger: "message",
+      event: { id: `event:${actorId}` },
+      raw: { actorId },
+    },
+  });
+
+  const first = sink.onTurn(event("ada") as never);
+  const second = sink.onTurn(event("grace") as never);
+  await vi.waitFor(() => expect(identifyUser).toHaveBeenCalledTimes(2));
+  releases.get("grace")?.();
+  releases.get("ada")?.();
+  await Promise.all([first, second]);
+
+  expect(received).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        user: { id: "person:ada", name: "ADA" },
+        actor: { id: "ada", kind: "human", name: "ADA" },
+      }),
+      expect.objectContaining({
+        user: { id: "person:grace", name: "GRACE" },
+        actor: { id: "grace", kind: "human", name: "GRACE" },
+      }),
+    ]),
+  );
+});

--- a/packages/channels-core/src/channel-memory.test.ts
+++ b/packages/channels-core/src/channel-memory.test.ts
@@ -1,0 +1,241 @@
+import { expect, test, vi } from "vitest";
+import { createChannel } from "./create-channel.js";
+import { FakeAdapter } from "./testing/fake-adapter.js";
+import { FakeAgent } from "./testing/fake-agent.js";
+import type {
+  ChannelAgentLifecycleArgs,
+  PlatformAdapter,
+} from "./platform-adapter.js";
+
+test("an omitted Memory grant runs on a direct Channel without Intelligence", async () => {
+  const adapter = new FakeAdapter();
+  const agent = new FakeAgent();
+  const channel = createChannel({
+    identifyUser: "platform",
+    adapters: [adapter],
+    agent: () => agent,
+  });
+  let ran = false;
+  channel.onMessage(async ({ thread }) => {
+    await thread.runAgent();
+    ran = true;
+  });
+  await channel.ɵruntime.start();
+
+  await adapter.getSink().onTurn({
+    conversationKey: "conversation",
+    replyTarget: {},
+    userText: "hello",
+    platform: "slack",
+  });
+
+  expect(ran).toBe(true);
+});
+
+test("an explicit Memory grant fails before a direct Channel agent runs without Intelligence", async () => {
+  const adapter = new FakeAdapter();
+  const agent = new FakeAgent();
+  const channel = createChannel({
+    identifyUser: "platform",
+    adapters: [adapter],
+    agent: () => agent,
+  });
+  channel.onMessage(async ({ thread }) => {
+    await thread.runAgent({ memory: { project: "read" } });
+  });
+  await channel.ɵruntime.start();
+
+  await expect(
+    adapter.getSink().onTurn({
+      conversationKey: "conversation",
+      replyTarget: {},
+      userText: "hello",
+      platform: "slack",
+    }),
+  ).rejects.toMatchObject({ code: "channel_memory_unavailable" });
+  expect(agent.runAgentCalls).toBe(0);
+});
+
+test("project-only Memory works when Channel identity is null", async () => {
+  const adapter = new FakeAdapter();
+  const lifecycle = vi.fn(async (args: ChannelAgentLifecycleArgs) =>
+    args.execute({}, undefined),
+  );
+  adapter.supportsIntelligenceMemory = true;
+  adapter.runAgentLifecycle = lifecycle;
+  const channel = createChannel({
+    identifyUser: () => null,
+    adapters: [adapter],
+    agent: () => new FakeAgent(),
+  });
+  channel.onMessage(async ({ thread }) => {
+    await thread.runAgent({ memory: { project: "read-write" } });
+  });
+  await channel.ɵruntime.start();
+
+  await adapter.getSink().onTurn({
+    conversationKey: "conversation",
+    replyTarget: {},
+    userText: "hello",
+    platform: "slack",
+  });
+
+  expect(lifecycle).toHaveBeenCalledWith(
+    expect.objectContaining({
+      memory: {
+        grant: { user: "none", project: "read-write" },
+        user: null,
+      },
+    }),
+  );
+});
+
+test("a custom identity callback may map a non-human actor to personal Memory", async () => {
+  const adapter = new FakeAdapter();
+  const lifecycle = vi.fn(async (args: ChannelAgentLifecycleArgs) =>
+    args.execute({}, undefined),
+  );
+  adapter.supportsIntelligenceMemory = true;
+  adapter.runAgentLifecycle = lifecycle;
+  const channel = createChannel({
+    identifyUser: ({ actor }) => ({
+      id: `service:${actor.id}`,
+      name: actor.name ?? actor.id,
+    }),
+    adapters: [adapter],
+    agent: () => new FakeAgent(),
+  });
+  channel.onMessage(async ({ thread }) => {
+    await thread.runAgent({ memory: { user: "read" } });
+  });
+  await channel.ɵruntime.start();
+
+  await adapter.getSink().onTurn({
+    conversationKey: "conversation",
+    replyTarget: {},
+    userText: "refresh",
+    platform: "slack",
+    actor: { id: "sync-bot", kind: "bot", name: "Sync Bot" },
+  });
+
+  expect(lifecycle).toHaveBeenCalledWith(
+    expect.objectContaining({
+      memory: {
+        grant: { user: "read", project: "none" },
+        user: { id: "service:sync-bot", name: "Sync Bot" },
+      },
+    }),
+  );
+});
+
+test("personal Memory fails before execution when Channel identity is null", async () => {
+  const adapter = new FakeAdapter();
+  adapter.supportsIntelligenceMemory = true;
+  adapter.runAgentLifecycle = vi.fn();
+  const channel = createChannel({
+    identifyUser: () => null,
+    adapters: [adapter],
+    agent: () => new FakeAgent(),
+  });
+  channel.onMessage(async ({ thread }) => {
+    await thread.runAgent({ memory: { user: "read", project: "none" } });
+  });
+  await channel.ɵruntime.start();
+
+  await expect(
+    adapter.getSink().onTurn({
+      conversationKey: "conversation",
+      replyTarget: {},
+      userText: "hello",
+      platform: "slack",
+    }),
+  ).rejects.toMatchObject({ code: "channel_memory_user_required" });
+  expect(adapter.runAgentLifecycle).not.toHaveBeenCalled();
+});
+
+test("an invalid JavaScript Memory grant fails before agent execution", async () => {
+  const adapter = new FakeAdapter();
+  adapter.supportsIntelligenceMemory = true;
+  adapter.runAgentLifecycle = vi.fn();
+  const channel = createChannel({
+    identifyUser: "platform",
+    adapters: [adapter],
+    agent: () => new FakeAgent(),
+  });
+  channel.onMessage(async ({ thread }) => {
+    await thread.runAgent({
+      memory: { user: "admin" } as never,
+    });
+  });
+  await channel.ɵruntime.start();
+
+  await expect(
+    adapter.getSink().onTurn({
+      conversationKey: "conversation",
+      replyTarget: {},
+      userText: "hello",
+      platform: "slack",
+      actor: { id: "alice", kind: "human" },
+    }),
+  ).rejects.toMatchObject({ code: "channel_memory_grant_invalid" });
+  expect(adapter.runAgentLifecycle).not.toHaveBeenCalled();
+});
+
+test("runAgent snapshots its Memory grant before queued execution", async () => {
+  const adapter = new FakeAdapter();
+  adapter.supportsIntelligenceMemory = true;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queuedAdapter = adapter as FakeAdapter & PlatformAdapter;
+  queuedAdapter.trackThreadOperation = (_target, operation) =>
+    gate.then(operation);
+  const lifecycle = vi.fn(async (args: ChannelAgentLifecycleArgs) =>
+    args.execute(args.renderer.subscriber, undefined),
+  );
+  adapter.runAgentLifecycle = lifecycle;
+  const channel = createChannel({
+    identifyUser: "platform",
+    adapters: [adapter],
+    agent: new FakeAgent(),
+  });
+  let thread:
+    | Parameters<Parameters<typeof channel.onMessage>[0]>[0]["thread"]
+    | undefined;
+  channel.onMessage((context) => {
+    thread = context.thread;
+  });
+  await channel.ɵruntime.start();
+  await adapter.getSink().onTurn({
+    conversationKey: "thread-queued",
+    replyTarget: {},
+    userText: "hello",
+    platform: "slack",
+    actor: { id: "U1", kind: "human" },
+    identityContext: {
+      tenant: { id: "T1" },
+      installation: { id: "I1" },
+      conversation: { id: "C1" },
+      trigger: "message",
+      event: { id: "E1" },
+      raw: {},
+    },
+  });
+  if (!thread) throw new Error("message handler did not receive a Thread");
+
+  const memory = { user: "read" as const, project: "none" as const };
+  const run = thread.runAgent({ memory });
+  (memory as { user: "read" | "none" }).user = "none";
+  release();
+  await run;
+
+  expect(lifecycle).toHaveBeenCalledWith(
+    expect.objectContaining({
+      memory: {
+        grant: { user: "read", project: "none" },
+        user: { id: "slack:T1:U1", name: "U1" },
+      },
+    }),
+  );
+});

--- a/packages/channels-core/src/commands.ts
+++ b/packages/channels-core/src/commands.ts
@@ -1,6 +1,11 @@
 import type { InferSchemaOutput, ObjectSchema } from "./standard-schema.js";
 import { toJsonSchema } from "./standard-schema.js";
-import type { Thread, PlatformUser, ModalView } from "@copilotkit/channels-ui";
+import type {
+  ApplicationUser,
+  ModalView,
+  ProviderActor,
+  Thread,
+} from "@copilotkit/channels-ui";
 
 /**
  * Context handed to a slash-command handler. `text` is the raw argument string
@@ -17,8 +22,10 @@ export interface CommandContext<TOptions = Record<string, never>> {
   text: string;
   /** Parsed, typed options (empty on surfaces that only deliver `text`). */
   options: TOptions;
-  /** The invoking user, when the surface provides it. */
-  user?: PlatformUser;
+  /** Canonical application user selected for this event. */
+  user: ApplicationUser | null;
+  /** Provider account that invoked the command. */
+  actor: ProviderActor;
   platform: string;
   /** Open a modal in response to this command (requires the surface's trigger; `undefined` when unavailable). */
   openModal?(view: ModalView): Promise<{ ok: boolean; error?: string }>;

--- a/packages/channels-core/src/create-channel.foundations.test.ts
+++ b/packages/channels-core/src/create-channel.foundations.test.ts
@@ -14,7 +14,10 @@ describe("createChannel — optional adapters + addAdapter", () => {
   it("allows a managed delivery adapter to coexist with a direct adapter", async () => {
     const managed = new ManagedFakeAdapter({ platform: "intelligence" });
     const direct = new FakeAdapter({ platform: "direct" });
-    const channel = createChannel({ adapters: [managed, direct] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [managed, direct],
+    });
 
     await channel.ɵruntime.start();
 
@@ -24,7 +27,10 @@ describe("createChannel — optional adapters + addAdapter", () => {
 
   it("starts with no adapters and runs one added before start()", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ agent: () => new FakeAgent() });
+    const channel = createChannel({
+      identifyUser: "platform",
+      agent: () => new FakeAgent(),
+    });
     channel.ɵruntime.addAdapter(fake);
     await channel.ɵruntime.start();
     expect(fake.started).toBe(true);
@@ -32,6 +38,7 @@ describe("createChannel — optional adapters + addAdapter", () => {
 
   it("throws when addAdapter is called after start()", async () => {
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [new FakeAdapter()],
       agent: () => new FakeAgent(),
     });
@@ -44,6 +51,7 @@ describe("createChannel — optional adapters + addAdapter", () => {
   it("is idempotent: a second start() does not re-start adapters or rebuild state", async () => {
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => new FakeAgent(),
     });
@@ -59,6 +67,7 @@ describe("createChannel — optional adapters + addAdapter", () => {
   it("allows a real restart after stop() (start → stop → start re-inits)", async () => {
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => new FakeAgent(),
     });
@@ -73,11 +82,11 @@ describe("createChannel — optional adapters + addAdapter", () => {
 describe("createChannel — transcripts deferred to start()", () => {
   it("throws if channel.transcripts is accessed before start()", () => {
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [new FakeAdapter()],
       agent: () => new FakeAgent(),
       store: {
         adapter: new MemoryStore(),
-        identity: () => "u@x.com",
         transcripts: {},
       },
     });
@@ -92,11 +101,11 @@ describe("createChannel — store resolution", () => {
     // Seed the adapter's store via a throwaway channel so we can prove the real
     // channel reads from that exact instance.
     const seeder = createChannel({
+      identifyUser: "platform",
       adapters: [new FakeAdapter()],
       agent: () => new FakeAgent(),
       store: {
         adapter: adapterStore,
-        identity: () => "u@x.com",
         transcripts: {},
       },
     });
@@ -104,19 +113,20 @@ describe("createChannel — store resolution", () => {
     await seeder.transcripts.append(
       { platform: "fake", conversationKey: "c" },
       { role: "user", text: "seeded" },
-      { userKey: "u@x.com" },
+      { userId: "u@x.com" },
     );
 
     const fake = new FakeAdapter();
     fake.stateStore = adapterStore;
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => new FakeAgent(),
-      store: { identity: () => "u@x.com", transcripts: {} },
+      store: { transcripts: {} },
     });
     await channel.ɵruntime.start();
 
-    const entries = await channel.transcripts.list({ userKey: "u@x.com" });
+    const entries = await channel.transcripts.list({ userId: "u@x.com" });
     expect(entries.map((e) => e.text)).toContain("seeded");
   });
 
@@ -126,11 +136,11 @@ describe("createChannel — store resolution", () => {
     fake.stateStore = new MemoryStore();
     const explicit = new MemoryStore();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => new FakeAgent(),
       store: {
         adapter: explicit,
-        identity: () => "u@x.com",
         transcripts: {},
       },
     });
@@ -146,6 +156,7 @@ describe("createChannel — store resolution", () => {
     const b = new FakeAdapter({ platform: "b" });
     b.stateStore = new MemoryStore();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [a, b],
       agent: () => new FakeAgent(),
     });
@@ -159,6 +170,7 @@ describe("createChannel — id propagation to handler context", () => {
   it("threads turnId/deliveryId from IncomingTurn onto message", async () => {
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => new FakeAgent(),
     });

--- a/packages/channels-core/src/create-channel.test.ts
+++ b/packages/channels-core/src/create-channel.test.ts
@@ -18,7 +18,10 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
  * `ctx.action.value`.
  */
 const __handlerTypeGuards = () => {
-  const channel = createChannel({ adapters: [new FakeAdapter()] });
+  const channel = createChannel({
+    identifyUser: "platform",
+    adapters: [new FakeAdapter()],
+  });
   channel.onInterrupt<{ question: string }>("ask", ({ payload }) => {
     payload.question.toUpperCase();
     // @ts-expect-error 'missing' is not on the payload type
@@ -124,7 +127,11 @@ function captureSessionAgents(fake: FakeAdapter): { agents: FakeAgent[] } {
 describe("createChannel", () => {
   it("rejects activation when a message-capable adapter has no eligible handler", async () => {
     const fake = new FakeAdapter({ messageEvents: true });
-    const channel = createChannel({ name: "support", adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      name: "support",
+      adapters: [fake],
+    });
 
     await expect(channel.ɵruntime.start()).rejects.toThrow(
       'channel "support" must register onMention or onMessage',
@@ -134,7 +141,10 @@ describe("createChannel", () => {
 
   it("routes an explicit mention only to onMention", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     const mentions = vi.fn();
     const messages = vi.fn();
     channel.onMention(mentions);
@@ -160,7 +170,10 @@ describe("createChannel", () => {
 
   it("falls an explicit mention back to onMessage", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     const messages = vi.fn();
     channel.onMessage(messages);
 
@@ -194,7 +207,10 @@ describe("createChannel", () => {
 
   it("routes an ordinary message only to onMessage", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     const mentions = vi.fn();
     const messages = vi.fn();
     channel.onMention(mentions);
@@ -221,7 +237,11 @@ describe("createChannel", () => {
   it("routes a mention to a handler that posts UI", async () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    const channel = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => agent,
+    });
 
     channel.onMention(async ({ thread }) => {
       await thread.post(Section({ children: "hi" }));
@@ -240,7 +260,11 @@ describe("createChannel", () => {
   it("calls renderer.finish() once after a turn's run-loop resolves", async () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    const channel = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => agent,
+    });
 
     channel.onMention(async ({ thread }) => {
       await thread.runAgent();
@@ -260,7 +284,11 @@ describe("createChannel", () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
     const added = captureAddedMessages(agent);
-    const channel = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => agent,
+    });
 
     channel.onMention(async ({ thread }) => {
       await thread.runAgent();
@@ -287,7 +315,11 @@ describe("createChannel", () => {
     const agent = new FakeAgent();
     const added = captureAddedMessages(agent);
     const runs = trackRunAgentCalls(agent);
-    const channel = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => agent,
+    });
 
     channel.onMention(async ({ thread }) => {
       await thread.runAgent();
@@ -338,6 +370,7 @@ describe("createChannel", () => {
     ]);
     const sessionAgents = captureSessionAgents(fake);
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => agent,
       tools: [
@@ -395,7 +428,11 @@ describe("createChannel", () => {
       });
       return session;
     };
-    const channel = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => agent,
+    });
 
     channel.onMention(async ({ thread }) => {
       await thread.runAgent();
@@ -436,7 +473,11 @@ describe("createChannel", () => {
       });
       return session;
     };
-    const channel = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => agent,
+    });
 
     channel.onMention(async ({ thread, message }) => {
       await thread.runAgent({ prompt: message.text });
@@ -458,7 +499,11 @@ describe("createChannel", () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
     const added = captureAddedMessages(agent);
-    const channel = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => agent,
+    });
     const parts = [
       { type: "text" as const, text: "look" },
       {
@@ -491,7 +536,11 @@ describe("createChannel", () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
     const added = captureAddedMessages(agent);
-    const channel = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => agent,
+    });
 
     const explicitParts = [
       { type: "text" as const, text: "use this instead" },
@@ -524,7 +573,11 @@ describe("createChannel", () => {
   it("dispatches a bound onClick handler on interaction", async () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    const channel = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => agent,
+    });
 
     let clicked = false;
     channel.onMention(async ({ thread }) => {
@@ -560,7 +613,11 @@ describe("createChannel", () => {
   it("resolves a HITL awaitChoice with the element value when the event carries none (Telegram)", async () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    const channel = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => agent,
+    });
 
     let chosen: unknown;
     channel.onMention(async ({ thread }) => {
@@ -613,6 +670,7 @@ describe("createChannel", () => {
     });
 
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => agent,
       context: [{ description: "channel-level", value: "always here" }],
@@ -638,7 +696,11 @@ describe("createChannel", () => {
   it("thread.postFile returns a capability-gated error when the adapter can't upload", async () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    const channel = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => agent,
+    });
 
     let result: { ok: boolean; error?: string } | undefined;
     channel.onMention(async ({ thread }) => {
@@ -661,11 +723,20 @@ describe("createChannel", () => {
   it("thread.getMessages and thread.lookupUser surface the adapter's data", async () => {
     const fake = new FakeAdapter();
     fake.messages = [
-      { user: { id: "u1", name: "Ada" }, text: "hi", ts: "1", isBot: false },
+      {
+        user: { id: "u1", kind: "human", name: "Ada" },
+        text: "hi",
+        ts: "1",
+        isBot: false,
+      },
     ];
-    fake.user = { id: "u1", name: "Ada" };
+    fake.user = { id: "u1", kind: "human", name: "Ada" };
     const agent = new FakeAgent();
-    const channel = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => agent,
+    });
 
     let history: unknown;
     let resolved: unknown;
@@ -679,15 +750,24 @@ describe("createChannel", () => {
     await tick();
 
     expect(history).toEqual([
-      { user: { id: "u1", name: "Ada" }, text: "hi", ts: "1", isBot: false },
+      {
+        user: { id: "u1", kind: "human", name: "Ada" },
+        text: "hi",
+        ts: "1",
+        isBot: false,
+      },
     ]);
-    expect(resolved).toEqual({ id: "u1", name: "Ada" });
+    expect(resolved).toEqual({ id: "u1", kind: "human", name: "Ada" });
   });
 
   it("resolves awaitChoice when a matching interaction arrives", async () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
-    const channel = createChannel({ adapters: [fake], agent: () => agent });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => agent,
+    });
 
     let choicePromise: Promise<unknown> | undefined;
     channel.onMention(async ({ thread }) => {
@@ -731,6 +811,7 @@ describe("createChannel", () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => agent,
       store: { adapter: state, onLockConflict: "drop" },
@@ -768,6 +849,7 @@ describe("createChannel", () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => agent,
       store: { adapter: state, onLockConflict: "force" },
@@ -804,6 +886,7 @@ describe("createChannel", () => {
 
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => new FakeAgent(),
       store: { adapter: state },
@@ -839,6 +922,7 @@ describe("createChannel", () => {
 
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => new FakeAgent(),
       store: { adapter: state, concurrency: "serial" },
@@ -877,6 +961,7 @@ describe("createChannel", () => {
 
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => new FakeAgent(),
       store: { adapter: state, concurrency: "drop" },
@@ -910,6 +995,7 @@ describe("createChannel", () => {
     const { agents: seen } = captureSessionAgents(fake);
 
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: prototype, // singleton, not factory
       store: { adapter: state },
@@ -950,6 +1036,7 @@ describe("createChannel", () => {
 
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: bad,
       store: { adapter: state },
@@ -982,6 +1069,7 @@ describe("createChannel", () => {
     // every call. Turn concurrency is parallel by default, so without isolation
     // both turns would run on `shared` and append into its one `messages` array.
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: (threadId) => {
         shared.threadId = threadId;
@@ -1059,6 +1147,7 @@ describe("createChannel", () => {
 
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => agent,
       store: { adapter: state },
@@ -1091,6 +1180,7 @@ describe("createChannel", () => {
 
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => agent,
       store: { adapter: state },
@@ -1118,6 +1208,7 @@ describe("createChannel", () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => agent,
       store: { adapter: state },
@@ -1146,47 +1237,34 @@ describe("createChannel", () => {
     expect(runs).toBe(2);
   });
 
-  it("throws when identity is set without transcripts", () => {
+  it("configures transcripts without a second identity callback", async () => {
     const fake = new FakeAdapter();
-    expect(() =>
-      createChannel({
-        adapters: [fake],
-        store: { identity: () => "key" },
-      }),
-    ).toThrow(
-      "createChannel: `identity` and `transcripts` must be configured together.",
-    );
+    const channel = createChannel({
+      adapters: [fake],
+      identifyUser: "platform",
+      store: { transcripts: { maxPerUser: 100 } },
+    });
+    await channel.ɵruntime.start();
+    expect(channel.transcripts).toBeDefined();
   });
 
-  it("throws when transcripts is set without identity", () => {
-    const fake = new FakeAdapter();
-    expect(() =>
-      createChannel({
-        adapters: [fake],
-        store: { transcripts: { maxPerUser: 100 } },
-      }),
-    ).toThrow(
-      "createChannel: `identity` and `transcripts` must be configured together.",
-    );
-  });
-
-  it("stamps message.userKey when identity resolves a key", async () => {
+  it("stamps message.user when identifyUser resolves an application user", async () => {
     const state = new MemoryStore();
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
     const channel = createChannel({
       adapters: [fake],
       agent: () => agent,
+      identifyUser: () => ({ id: "user@example.com", name: "Alice" }),
       store: {
         adapter: state,
-        identity: () => "user@example.com",
         transcripts: {},
       },
     });
 
     let capturedKey: string | undefined;
     channel.onMention(async ({ message }) => {
-      capturedKey = message.userKey;
+      capturedKey = message.user?.id;
     });
 
     await channel.ɵruntime.start();
@@ -1196,7 +1274,7 @@ describe("createChannel", () => {
       replyTarget: {},
       userText: "hello",
       platform: "fake" as const,
-      user: { id: "u1" },
+      actor: { id: "u1", kind: "human" },
     });
 
     expect(capturedKey).toBe("user@example.com");
@@ -1207,11 +1285,11 @@ describe("createChannel", () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => agent,
       store: {
         adapter: state,
-        identity: () => "alice@example.com",
         transcripts: { maxPerUser: 50 },
       },
     });
@@ -1229,17 +1307,17 @@ describe("createChannel", () => {
       thread,
       { role: "user", text: "hi there" },
       {
-        userKey: "alice@example.com",
+        userId: "alice@example.com",
       },
     );
     await channel.transcripts.append(
       thread,
       { role: "assistant", text: "hello!" },
-      { userKey: "alice@example.com" },
+      { userId: "alice@example.com" },
     );
 
     const entries = await channel.transcripts.list({
-      userKey: "alice@example.com",
+      userId: "alice@example.com",
     });
     expect(entries).toHaveLength(2);
     expect(entries[0]!.role).toBe("user");
@@ -1256,9 +1334,9 @@ describe("createChannel", () => {
     const channel = createChannel({
       adapters: [fake],
       agent: () => agent,
+      identifyUser: () => ({ id: "u@x.com", name: "User" }),
       store: {
         adapter: state,
-        identity: () => "u@x.com",
         transcripts: {},
       },
     });
@@ -1296,7 +1374,7 @@ describe("createChannel", () => {
     await channel.transcripts.append(
       { platform: "discord", conversationKey: "other" },
       { role: "user", text: "remembered from discord" },
-      { userKey: "u@x.com" },
+      { userId: "u@x.com" },
     );
     const sink = fake.getSink();
     await sink.onTurn({
@@ -1304,12 +1382,12 @@ describe("createChannel", () => {
       replyTarget: {},
       userText: "hello from fake",
       platform: "fake" as const,
-      user: { id: "u1" },
+      actor: { id: "u1", kind: "human" },
     });
 
     // Append side: both the user turn and the assistant reply are recorded,
     // oldest-first (after the seeded discord entry).
-    const entries = await channel.transcripts.list({ userKey: "u@x.com" });
+    const entries = await channel.transcripts.list({ userId: "u@x.com" });
     const fakeEntries = entries.filter((e) => e.platform === "fake");
     expect(fakeEntries).toHaveLength(2);
     expect(fakeEntries[0]!.role).toBe("user");
@@ -1333,6 +1411,7 @@ describe("createChannel", () => {
     const fake = new FakeAdapter();
     const agent = new FakeAgent();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => agent,
       store: {
@@ -1373,6 +1452,7 @@ describe("createChannel lock and dedup edge cases", () => {
     const fake = new FakeAdapter();
     // Use a separate channel so the throwing handler is isolated.
     const bot1 = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       store: { adapter: state, onLockConflict: "drop", lockTtl: 5000 },
     });
@@ -1416,6 +1496,7 @@ describe("createChannel lock and dedup edge cases", () => {
 
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       store: {
         adapter: state,
@@ -1458,6 +1539,7 @@ describe("createChannel lock and dedup edge cases", () => {
 
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       store: {
         adapter: state,
@@ -1486,48 +1568,52 @@ describe("createChannel lock and dedup edge cases", () => {
     expect(runs).toBe(2);
   });
 
-  it("identity throws: handler still runs and userKey is undefined", async () => {
+  it("identifyUser errors fail the trigger before its handler runs", async () => {
     const state = new MemoryStore();
     const fake = new FakeAdapter();
     const channel = createChannel({
       adapters: [fake],
+      identifyUser: () => {
+        throw new Error("identity failed");
+      },
       store: {
         adapter: state,
-        identity: () => {
-          throw new Error("x");
-        },
         transcripts: {},
       },
     });
 
-    let capturedUserKey: string | undefined = "SENTINEL";
-    channel.onMention(async ({ message }) => {
-      capturedUserKey = message.userKey;
+    let handled = false;
+    channel.onMention(async () => {
+      handled = true;
     });
 
     await channel.ɵruntime.start();
     const sink = fake.getSink();
-    await sink.onTurn({
+    const delivery = sink.onTurn({
       conversationKey: "c1",
       replyTarget: {},
       userText: "hi",
       platform: "fake" as const,
     });
-
-    expect(capturedUserKey).toBeUndefined();
+    await expect(delivery).rejects.toMatchObject({
+      code: "channel_identity_failed",
+      cause: expect.objectContaining({ message: "identity failed" }),
+    });
+    expect(handled).toBe(false);
   });
 
-  it("identity returns null: userKey is undefined", async () => {
+  it("identifyUser may return null without substituting the provider actor", async () => {
     const state = new MemoryStore();
     const fake = new FakeAdapter();
     const channel = createChannel({
       adapters: [fake],
-      store: { adapter: state, identity: () => null, transcripts: {} },
+      identifyUser: () => null,
+      store: { adapter: state, transcripts: {} },
     });
 
-    let capturedUserKey: string | undefined = "SENTINEL";
+    let capturedUser: unknown = "SENTINEL";
     channel.onMention(async ({ message }) => {
-      capturedUserKey = message.userKey;
+      capturedUser = message.user;
     });
 
     await channel.ɵruntime.start();
@@ -1539,7 +1625,7 @@ describe("createChannel lock and dedup edge cases", () => {
       platform: "fake" as const,
     });
 
-    expect(capturedUserKey).toBeUndefined();
+    expect(capturedUser).toBeNull();
   });
 
   it("dedup+lock ordering: deduped turn never takes the lock", async () => {
@@ -1548,6 +1634,7 @@ describe("createChannel lock and dedup edge cases", () => {
 
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       store: { adapter: state, onLockConflict: "drop" },
     });
@@ -1592,6 +1679,7 @@ describe("createChannel lock and dedup edge cases", () => {
     let runs = 0;
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       store: { adapter: state },
     });
@@ -1621,6 +1709,7 @@ describe("createChannel lock and dedup edge cases", () => {
 
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       store: { adapter: state, onLockConflict: "drop" },
     });
@@ -1670,6 +1759,7 @@ describe("createChannel lock and dedup edge cases", () => {
 
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       store: { adapter: state },
     });
@@ -1700,7 +1790,10 @@ describe("createChannel lock and dedup edge cases", () => {
 describe("createChannel slash commands", () => {
   it("routes a command to its handler with the raw text", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     let seen: { command: string; text: string } | undefined;
     channel.onCommand("triage", ({ command, text }) => {
       seen = { command, text };
@@ -1712,7 +1805,10 @@ describe("createChannel slash commands", () => {
 
   it("ignores a command with no registered handler", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     let fired = false;
     channel.onCommand("triage", () => {
       fired = true;
@@ -1726,6 +1822,7 @@ describe("createChannel slash commands", () => {
     let captured: { seat: string } | undefined;
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       commands: [
         defineChannelCommand({
@@ -1748,7 +1845,10 @@ describe("createChannel slash commands", () => {
 
   it("hands declared commands to adapters that implement registerCommands", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     channel.onCommand("triage", () => {});
     channel.onCommand("status", () => {});
     await channel.ɵruntime.start();
@@ -1764,7 +1864,10 @@ describe("createChannel slash commands", () => {
       const bad = new FakeAdapter({ platform: "telegram", failStart: true });
       const badStop = vi.spyOn(bad, "stop");
       const good = new FakeAdapter({ platform: "slack" });
-      const channel = createChannel({ adapters: [bad, good] });
+      const channel = createChannel({
+        identifyUser: "platform",
+        adapters: [bad, good],
+      });
       await expect(channel.ɵruntime.start()).resolves.toBeUndefined();
       expect(good.started).toBe(true);
       expect(badStop).toHaveBeenCalledTimes(1);
@@ -1899,7 +2002,10 @@ describe("createChannel slash commands", () => {
         failRegisterCommands: true,
       });
       const good = new FakeAdapter({ platform: "slack" });
-      const channel = createChannel({ adapters: [bad, good] });
+      const channel = createChannel({
+        identifyUser: "platform",
+        adapters: [bad, good],
+      });
       channel.onCommand("triage", () => {});
       await expect(channel.ɵruntime.start()).resolves.toBeUndefined();
       expect(good.started).toBe(true);
@@ -1918,7 +2024,10 @@ describe("createChannel slash commands", () => {
       const bad = new FakeAdapter({ platform: "telegram", failStop: true });
       const good = new FakeAdapter({ platform: "slack" });
       const stopSpy = vi.spyOn(good, "stop");
-      const channel = createChannel({ adapters: [bad, good] });
+      const channel = createChannel({
+        identifyUser: "platform",
+        adapters: [bad, good],
+      });
       await channel.ɵruntime.start();
       await expect(channel.ɵruntime.stop()).resolves.toBeUndefined();
       expect(stopSpy).toHaveBeenCalled();
@@ -1932,7 +2041,10 @@ describe("createChannel slash commands", () => {
 
   it("exposes attached adapters through a read-only, non-mutable-through accessor", () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
 
     expect(channel.adapters).toContain(fake);
     expect(channel.adapters).toHaveLength(1);
@@ -1943,7 +2055,7 @@ describe("createChannel slash commands", () => {
   });
 
   it("reflects an adapter attached via addAdapter in the adapters accessor", () => {
-    const channel = createChannel({});
+    const channel = createChannel({ identifyUser: "platform" });
     expect(channel.adapters).toHaveLength(0);
 
     const fake = new FakeAdapter();

--- a/packages/channels-core/src/create-channel.test.ts
+++ b/packages/channels-core/src/create-channel.test.ts
@@ -1885,7 +1885,10 @@ describe("createChannel slash commands", () => {
       const failed = new FakeAdapter({ platform: "telegram", failStart: true });
       const failedRegister = vi.spyOn(failed, "registerCommands");
       const healthy = new FakeAdapter({ platform: "slack" });
-      const channel = createChannel({ adapters: [failed, healthy] });
+      const channel = createChannel({
+        identifyUser: "platform",
+        adapters: [failed, healthy],
+      });
       channel.onCommand("triage", () => {});
 
       await expect(channel.ɵruntime.start()).resolves.toBeUndefined();
@@ -1908,7 +1911,10 @@ describe("createChannel slash commands", () => {
         { __intelligenceChannel: true as const },
       );
       const managedStop = vi.spyOn(managed, "stop");
-      const channel = createChannel({ adapters: [direct, managed] });
+      const channel = createChannel({
+        identifyUser: "platform",
+        adapters: [direct, managed],
+      });
 
       await expect(channel.ɵruntime.start()).rejects.toThrow(
         "failed to start its managed Intelligence adapter",
@@ -1935,7 +1941,10 @@ describe("createChannel slash commands", () => {
         { __intelligenceChannel: true as const },
       );
       const managedStop = vi.spyOn(managed, "stop");
-      const channel = createChannel({ adapters: [throwing, healthy, managed] });
+      const channel = createChannel({
+        identifyUser: "platform",
+        adapters: [throwing, healthy, managed],
+      });
 
       await expect(channel.ɵruntime.start()).rejects.toThrow(
         "failed to start its managed Intelligence adapter",
@@ -1958,7 +1967,10 @@ describe("createChannel slash commands", () => {
         new FakeAdapter({ platform: "intelligence", failStart: true }),
         { __intelligenceChannel: true as const },
       );
-      const channel = createChannel({ adapters: [stuck, managed] });
+      const channel = createChannel({
+        identifyUser: "platform",
+        adapters: [stuck, managed],
+      });
 
       const starting = expect(channel.ɵruntime.start()).rejects.toThrow(
         "failed to start its managed Intelligence adapter",
@@ -1983,7 +1995,10 @@ describe("createChannel slash commands", () => {
     try {
       const adapter = new FakeAdapter({ platform: "slack", failStart: true });
       const stop = vi.spyOn(adapter, "stop");
-      const channel = createChannel({ adapters: [adapter] });
+      const channel = createChannel({
+        identifyUser: "platform",
+        adapters: [adapter],
+      });
 
       await expect(channel.ɵruntime.start()).rejects.toThrow(
         "all 1 adapter(s) failed to connect",

--- a/packages/channels-core/src/create-channel.ts
+++ b/packages/channels-core/src/create-channel.ts
@@ -28,7 +28,8 @@ import type {
   ChannelMessage,
   InteractionContext,
   IncomingMessage,
-  PlatformUser,
+  ProviderActor,
+  ApplicationUser,
   EmojiValue,
   EmojiPlatform,
   ModalView,
@@ -41,7 +42,12 @@ import {
   renderToIR,
 } from "@copilotkit/channels-ui";
 import { Transcripts } from "./transcripts.js";
-import type { Identity, TranscriptsConfig } from "./transcripts.js";
+import type { TranscriptsConfig } from "./transcripts.js";
+import { resolveChannelUser } from "./identity.js";
+import type {
+  ChannelIdentifyUser,
+  ChannelIdentityContext,
+} from "./identity.js";
 import type { StandardSchemaV1, InferSchemaOutput } from "./standard-schema.js";
 import { ChannelTelemetry } from "./telemetry/channel-telemetry.js";
 import { errorClass, normalizePlatform } from "./telemetry/sanitize-error.js";
@@ -226,13 +232,15 @@ export type ChannelHandler<TState = unknown> = (ctx: {
 /** Handler for a "conversation opened" lifecycle event (e.g. the Slack assistant pane). */
 export type ThreadStartHandler<TState = unknown> = (ctx: {
   thread: StatefulThread<TState>;
-  user?: PlatformUser;
+  user: ApplicationUser | null;
+  actor: ProviderActor;
 }) => void | Promise<void>;
 
 /** Handler for a provider installation or conversation activation. */
 export type WelcomeHandler<TState = unknown> = (ctx: {
   thread: StatefulThread<TState>;
-  user?: PlatformUser;
+  user: ApplicationUser | null;
+  actor: ProviderActor;
   platform: string;
 }) => void | Promise<void>;
 
@@ -245,7 +253,8 @@ export interface ReactionEvent {
   /** true = added, false = removed. */
   added: boolean;
   /** The reacting user, when the platform reports one. */
-  user?: PlatformUser;
+  user: ApplicationUser | null;
+  actor: ProviderActor;
   messageId: string;
   /** Update-capable ref to the reacted message (`thread.update(messageRef, ui)`). */
   messageRef: MessageRef;
@@ -260,7 +269,8 @@ export type ReactionHandler = (evt: ReactionEvent) => void | Promise<void>;
 export interface ModalSubmitEvent {
   callbackId: string;
   values: Record<string, unknown>;
-  user?: PlatformUser;
+  user: ApplicationUser | null;
+  actor: ProviderActor;
   /** Present when the submission carried a conversation context. */
   thread?: Thread;
   privateMetadata?: string;
@@ -273,7 +283,8 @@ export type ModalSubmitHandler = (
 /** Event passed to an `onModalClose` handler. */
 export interface ModalCloseEvent {
   callbackId: string;
-  user?: PlatformUser;
+  user: ApplicationUser | null;
+  actor: ProviderActor;
   privateMetadata?: string;
   raw: unknown;
 }
@@ -301,9 +312,7 @@ export interface StoreConfig<
   adapter?: StateStore;
   /** Standard Schema for per-thread state. When set, thread.state()/setState() are typed to its output and setState validates at runtime. */
   state?: TStateSchema;
-  /** Resolve a stable cross-platform identity key (e.g. email). Paired with `transcripts`. */
-  identity?: Identity;
-  /** Cross-platform transcript storage config. Paired with `identity`. */
+  /** Cross-platform transcript storage keyed by the identified application user. */
   transcripts?: TranscriptsConfig;
   /**
    * How overlapping turns on the same conversationKey are handled.
@@ -327,6 +336,8 @@ export interface StoreConfig<
   lockTtl?: number;
   /** TTL (ms) for the inbound event dedup window. Default 300_000. */
   dedupTtl?: number;
+  /** TTL (ms) for durable actions and HITL continuations. Default 604_800_000 (7 days). */
+  actionRetentionMs?: number;
 }
 
 /**
@@ -360,6 +371,8 @@ export interface ReplyContinuationOptions {
 export interface CreateChannelOptions<
   TStateSchema extends StandardSchemaV1 | undefined = undefined,
 > {
+  /** Select the canonical application user for every incoming Channel event. */
+  identifyUser: ChannelIdentifyUser;
   /**
    * Project-unique Intelligence Channel name. Required for Intelligence Channel
    * Bots — it ties the runtime declaration to the Intelligence setup — and
@@ -463,6 +476,8 @@ export interface Channel<TState = unknown> {
     h: (args: {
       payload: TPayload;
       thread: StatefulThread<TState>;
+      user: ApplicationUser | null;
+      actor: ProviderActor;
     }) => void | Promise<void>,
   ): void;
   /** Register a slash command (with optional typed options). */
@@ -492,6 +507,8 @@ export interface Channel<TState = unknown> {
     start(): Promise<void>;
     stop(): Promise<void>;
     addAdapter(adapter: PlatformAdapter): void;
+    /** @internal Mark this Channel as attached to an Intelligence Memory backend. */
+    enableIntelligenceMemory(): void;
   };
 }
 
@@ -500,7 +517,8 @@ function msgFromTurn(turn: IncomingTurn): ChannelMessage {
   return {
     text: turn.userText,
     contentParts: turn.contentParts,
-    user: turn.user ?? { id: "" },
+    user: null,
+    actor: turn.actor,
     ref: turn.messageRef ?? { id: "" },
     platform: turn.platform,
     operation: turn.operation,
@@ -508,6 +526,47 @@ function msgFromTurn(turn: IncomingTurn): ChannelMessage {
     turnId: turn.turnId,
     deliveryId: turn.deliveryId,
   };
+}
+
+function identityContextFromIngress(
+  provider: string,
+  event: {
+    conversationKey?: string;
+    actor?: ProviderActor;
+    identityContext?: import("./identity.js").IngressIdentityContext;
+  },
+  trigger: string,
+): ChannelIdentityContext {
+  const actor: ProviderActor = Object.freeze({
+    ...(event.actor ?? { id: "", kind: "unknown" as const }),
+  });
+  const tenant = Object.freeze({
+    ...(event.identityContext?.tenant ?? { id: "" }),
+  });
+  const installation = Object.freeze({
+    ...(event.identityContext?.installation ?? { id: "" }),
+  });
+  const conversation = Object.freeze({
+    ...(event.identityContext?.conversation ?? {
+      id: event.conversationKey ?? "",
+    }),
+  });
+  const normalizedEvent = Object.freeze({
+    ...event.identityContext?.event,
+  });
+  return Object.freeze({
+    provider,
+    tenant,
+    installation,
+    actor,
+    conversation,
+    trigger: event.identityContext?.trigger ?? trigger,
+    event: normalizedEvent,
+    raw: event.identityContext?.raw,
+    ...(event.identityContext?.lookupProfile
+      ? { lookupProfile: event.identityContext.lookupProfile }
+      : {}),
+  });
 }
 
 /** Resolve the provider that produced an event without changing adapter identity. */
@@ -546,15 +605,15 @@ export function createChannel<
 >(
   opts: CreateChannelOptions<TStateSchema>,
 ): Channel<ThreadStateOf<TStateSchema>> {
-  const cfg = opts.store ?? {};
   if (
-    (cfg.identity && !cfg.transcripts) ||
-    (!cfg.identity && cfg.transcripts)
+    opts.identifyUser !== "platform" &&
+    typeof opts.identifyUser !== "function"
   ) {
     throw new Error(
-      "createChannel: `identity` and `transcripts` must be configured together.",
+      'createChannel: `identifyUser` must be "platform" or a callback',
     );
   }
+  const cfg = opts.store ?? {};
 
   // Adapters can be supplied up front or added later via
   // `channel.ɵruntime.addAdapter` (before `channel.ɵruntime.start()`). The
@@ -635,7 +694,12 @@ export function createChannel<
   >();
   const interruptHandlers = new Map<
     string,
-    (args: { payload: unknown; thread: Thread }) => void | Promise<void>
+    (args: {
+      payload: unknown;
+      thread: Thread;
+      user: ApplicationUser | null;
+      actor: ProviderActor;
+    }) => void | Promise<void>
   >();
   const commandHandlers = new Map<string, ChannelCommand>();
   for (const c of opts.commands ?? [])
@@ -647,6 +711,7 @@ export function createChannel<
   const modalSubmitHandlers = new Map<string, ModalSubmitHandler>();
   const modalCloseHandlers = new Map<string, ModalCloseHandler>();
   const waiters = new Map<string, (value: unknown) => void>();
+  let intelligenceMemoryAvailable = false;
 
   // Recomputed on start() so tools added via channel.tool() before start are picked up.
   let toolDescriptors = toAgentToolDescriptors([...toolMap.values()]);
@@ -657,8 +722,10 @@ export function createChannel<
     conversationKey: string,
     extras?: {
       platform?: string;
-      userKey?: string;
       message?: IncomingMessage;
+      user?: ApplicationUser | null;
+      actor?: ProviderActor;
+      interactionActionId?: string;
     },
   ): Thread {
     if (!backend || !registry || !telemetry) {
@@ -681,8 +748,13 @@ export function createChannel<
       state: backend,
       stateSchema: cfg.state,
       transcripts,
-      userKey: extras?.userKey,
       message: extras?.message,
+      user: extras?.user ?? null,
+      actor: extras?.actor ?? { id: "unknown", kind: "unknown" },
+      channelName: opts.name ?? adapter.platform,
+      threadId: adapter.getCanonicalThreadId?.(replyTarget) ?? conversationKey,
+      interactionActionId: extras?.interactionActionId,
+      intelligenceMemoryAvailable,
       telemetry,
     };
     return new Thread(deps);
@@ -735,32 +807,30 @@ export function createChannel<
         }
       }
 
-      // Resolve cross-platform identity key (if configured) and stamp it on
-      // the message so handlers and transcript storage can use it. Done
-      // BEFORE makeThread so the thread carries the userKey + message for
-      // the transcript auto-bridge (runAgent({ transcript: true })).
-      let userKey: string | undefined;
-      if (cfg.identity) {
-        try {
-          const resolved = await cfg.identity({
-            adapter: platform,
-            author: turn.user ?? { id: "" },
-            message: msgFromTurn(turn),
-          });
-          userKey = resolved ?? undefined;
-        } catch (err) {
-          console.warn(
-            `[channel] identity resolution failed for ${platform}; continuing without userKey`,
-            err,
-          );
-        }
-      }
-      const message: ChannelMessage = { ...msgFromTurn(turn), userKey };
+      const identityContext = identityContextFromIngress(
+        platform,
+        turn,
+        "message",
+      );
+      const user: ApplicationUser | null = await resolveChannelUser(
+        opts.identifyUser,
+        identityContext,
+      );
+      const message: ChannelMessage = {
+        ...msgFromTurn(turn),
+        user,
+        actor: identityContext.actor,
+      };
       const thread = makeThread(
         adapter,
         turn.replyTarget,
         turn.conversationKey,
-        { platform, userKey, message },
+        {
+          platform,
+          message,
+          user,
+          actor: identityContext.actor,
+        },
       );
       const handlers = turn.operation.mentioned
         ? mentionHandlers.length > 0
@@ -831,24 +901,39 @@ export function createChannel<
           }
         }
 
+        const identityContext = identityContextFromIngress(
+          platform,
+          evt,
+          "interaction",
+        );
+        const canonicalUser = await resolveChannelUser(
+          opts.identifyUser,
+          identityContext,
+        );
         const thread = makeThread(
           adapter,
           evt.replyTarget,
           evt.conversationKey,
-          { platform },
+          {
+            platform,
+            user: canonicalUser,
+            actor: identityContext.actor,
+            interactionActionId: evt.id,
+          },
         );
-        const user = evt.user ?? { id: "" };
         const ctx: InteractionContext = {
           thread,
           message: {
             text: "",
-            user,
+            user: canonicalUser,
+            actor: identityContext.actor,
             ref: evt.messageRef ?? { id: "" },
             platform,
           },
           action: { id: evt.id, value: evt.value },
           values: evt.values ?? {},
-          user,
+          user: canonicalUser,
+          actor: identityContext.actor,
           platform,
         };
         const openModal = makeOpenModal(
@@ -899,11 +984,24 @@ export function createChannel<
 
         const command = commandHandlers.get(normalizeCommandName(cmd.command));
         if (!command) return; // unregistered command → skip
+        const identityContext = identityContextFromIngress(
+          platform,
+          cmd,
+          "command",
+        );
+        const user = await resolveChannelUser(
+          opts.identifyUser,
+          identityContext,
+        );
         const thread = makeThread(
           adapter,
           cmd.replyTarget,
           cmd.conversationKey,
-          { platform },
+          {
+            platform,
+            user,
+            actor: identityContext.actor,
+          },
         );
         // Resolve typed options from any structured args the surface supplied
         // (e.g. Discord); text-only surfaces (Slack) leave `options` empty and
@@ -918,7 +1016,8 @@ export function createChannel<
           command: normalizeCommandName(cmd.command),
           text: cmd.text,
           options,
-          user: cmd.user,
+          user,
+          actor: identityContext.actor,
           platform,
         };
         const openModal = makeOpenModal(
@@ -942,28 +1041,47 @@ export function createChannel<
             );
           }
         }
+        const identityContext = identityContextFromIngress(
+          platform,
+          evt,
+          "welcome",
+        );
+        const user = await resolveChannelUser(
+          opts.identifyUser,
+          identityContext,
+        );
         const thread = makeThread(
           adapter,
           evt.replyTarget,
           evt.conversationKey,
-          { platform },
+          { platform, user, actor: identityContext.actor },
         );
         for (const h of welcomeHandlers) {
-          await h({ thread, user: evt.user, platform });
+          await h({ thread, user, actor: identityContext.actor, platform });
         }
       },
       async onThreadStarted(evt: IncomingThreadStart) {
         // The adapter has already applied its static defaults (greeting /
         // prompts) before emitting this, so handlers layer on top and never
         // race. Zero handlers → no-op.
+        const platform = ingressPlatform(adapter, evt);
+        const identityContext = identityContextFromIngress(
+          platform,
+          evt,
+          "thread-start",
+        );
+        const user = await resolveChannelUser(
+          opts.identifyUser,
+          identityContext,
+        );
         const thread = makeThread(
           adapter,
           evt.replyTarget,
           evt.conversationKey,
-          { platform: ingressPlatform(adapter, evt) },
+          { platform, user, actor: identityContext.actor },
         );
         for (const h of threadStartedHandlers)
-          await h({ thread, user: evt.user });
+          await h({ thread, user, actor: identityContext.actor });
       },
       async onReaction(evt: IncomingReaction) {
         // Normalize by source platform, falling back to adapter identity for
@@ -973,11 +1091,24 @@ export function createChannel<
           ? normalizeEmoji(evt.rawEmoji, sourcePlatform)
           : undefined;
         const value: EmojiValue = normalized ?? evt.rawEmoji;
+        const identityContext = identityContextFromIngress(
+          sourcePlatform,
+          evt,
+          "reaction",
+        );
+        const user = await resolveChannelUser(
+          opts.identifyUser,
+          identityContext,
+        );
         const thread = makeThread(
           adapter,
           evt.replyTarget,
           evt.conversationKey,
-          { platform: sourcePlatform },
+          {
+            platform: sourcePlatform,
+            user,
+            actor: identityContext.actor,
+          },
         );
         // Prefer the adapter's update-capable ref; fall back to the bare id.
         const messageRef: MessageRef = evt.messageRef ?? { id: evt.messageId };
@@ -985,7 +1116,8 @@ export function createChannel<
           emoji: value,
           rawEmoji: evt.rawEmoji,
           added: evt.added,
-          user: evt.user,
+          user,
+          actor: identityContext.actor,
           messageId: evt.messageId,
           messageRef,
           threadId: evt.threadId,
@@ -1010,7 +1142,8 @@ export function createChannel<
             emoji: value,
             rawEmoji: evt.rawEmoji,
             added: evt.added,
-            user: evt.user,
+            user,
+            actor: identityContext.actor,
             messageId: evt.messageId,
             thread,
             messageRef,
@@ -1020,16 +1153,28 @@ export function createChannel<
       async onModalSubmit(evt: IncomingModalSubmit) {
         const handler = modalSubmitHandlers.get(evt.callbackId);
         if (!handler) return; // unregistered → closes
+        const identityContext = identityContextFromIngress(
+          evt.platform,
+          evt,
+          "modal-submit",
+        );
+        const user = await resolveChannelUser(
+          opts.identifyUser,
+          identityContext,
+        );
         const thread =
           evt.conversationKey !== undefined && evt.replyTarget !== undefined
             ? makeThread(adapter, evt.replyTarget, evt.conversationKey, {
                 platform: evt.platform,
+                user,
+                actor: identityContext.actor,
               })
             : undefined;
         const result = await handler({
           callbackId: evt.callbackId,
           values: evt.values,
-          user: evt.user,
+          user,
+          actor: identityContext.actor,
           thread,
           privateMetadata: evt.privateMetadata,
           raw: evt.raw,
@@ -1039,9 +1184,19 @@ export function createChannel<
       async onModalClose(evt: IncomingModalClose) {
         const handler = modalCloseHandlers.get(evt.callbackId);
         if (!handler) return;
+        const identityContext = identityContextFromIngress(
+          evt.platform,
+          evt,
+          "modal-close",
+        );
+        const user = await resolveChannelUser(
+          opts.identifyUser,
+          identityContext,
+        );
         await handler({
           callbackId: evt.callbackId,
-          user: evt.user,
+          user,
+          actor: identityContext.actor,
           privateMetadata: evt.privateMetadata,
           raw: evt.raw,
         });
@@ -1074,6 +1229,9 @@ export function createChannel<
       return transcripts;
     },
     ɵruntime: {
+      enableIntelligenceMemory() {
+        intelligenceMemoryAvailable = true;
+      },
       addAdapter(adapter) {
         if (started) {
           throw new Error(
@@ -1112,7 +1270,12 @@ export function createChannel<
         });
         telemetry = tel;
         const registryInstance = new ActionRegistry({
-          store: opts.actionStore ?? kvActionStore(backend),
+          store:
+            opts.actionStore ??
+            kvActionStore(backend, {
+              defaultTtlMs: cfg.actionRetentionMs ?? 7 * 24 * 60 * 60 * 1000,
+            }),
+          retentionMs: cfg.actionRetentionMs ?? 7 * 24 * 60 * 60 * 1000,
         });
         registry = registryInstance;
         for (const c of opts.components ?? []) {
@@ -1138,7 +1301,6 @@ export function createChannel<
           commandsCount: commandHandlers.size,
           contextCount: context.length,
           transcripts: !!cfg.transcripts,
-          identity: !!cfg.identity,
         });
         // Isolate per-adapter startup failures: one adapter rejecting (e.g.
         // Telegram's setMyCommands rejecting a hyphenated command name, a revoked
@@ -1345,6 +1507,8 @@ export function createChannel<
       h: (args: {
         payload: TPayload;
         thread: StatefulThread<ThreadStateOf<TStateSchema>>;
+        user: ApplicationUser | null;
+        actor: ProviderActor;
       }) => void | Promise<void>,
     ) {
       interruptHandlers.set(
@@ -1352,6 +1516,8 @@ export function createChannel<
         h as (args: {
           payload: unknown;
           thread: Thread;
+          user: ApplicationUser | null;
+          actor: ProviderActor;
         }) => void | Promise<void>,
       );
     },

--- a/packages/channels-core/src/hitl-continuation.test.tsx
+++ b/packages/channels-core/src/hitl-continuation.test.tsx
@@ -1,0 +1,516 @@
+import type { AgentSubscriber } from "@ag-ui/client";
+import { Button } from "@copilotkit/channels-ui";
+import { afterEach, expect, test, vi } from "vitest";
+import type { ActionSnapshot } from "./action-store.js";
+import { createChannel } from "./create-channel.js";
+import type { MemoryGrant } from "./memory.js";
+import type { ChannelAgentLifecycleArgs } from "./platform-adapter.js";
+import { MemoryStore } from "./state/memory-store.js";
+import { FakeAdapter } from "./testing/fake-adapter.js";
+import { FakeAgent } from "./testing/fake-agent.js";
+
+const activeChannels: Array<{ stop(): Promise<void> }> = [];
+
+afterEach(async () => {
+  await Promise.all(activeChannels.splice(0).map((channel) => channel.stop()));
+});
+
+function firstActionId(adapter: FakeAdapter): string {
+  const button = adapter.posted.flat().find((node) => node.type === "button");
+  const action = button?.props.onClick as { id?: unknown } | undefined;
+  if (typeof action?.id !== "string") throw new Error("missing action id");
+  return action.id;
+}
+
+function actionIds(adapter: FakeAdapter): string[] {
+  return adapter.posted
+    .flat()
+    .filter((node) => node.type === "button")
+    .map((node) => (node.props.onClick as { id?: unknown } | undefined)?.id)
+    .filter((id): id is string => typeof id === "string");
+}
+
+function interrupt(subscriber: AgentSubscriber): void {
+  subscriber.onCustomEvent?.({
+    event: { name: "approval", value: { requestId: "request-1" } },
+  } as never);
+  subscriber.onRunFinishedEvent?.({ event: {} } as never);
+}
+
+async function setup(
+  subject: "initiator" | "actor" | undefined,
+  memory: MemoryGrant,
+) {
+  const adapter = new FakeAdapter();
+  adapter.supportsIntelligenceMemory = true;
+  const lifecycleCalls: ChannelAgentLifecycleArgs[] = [];
+  adapter.runAgentLifecycle = vi.fn(async (args: ChannelAgentLifecycleArgs) => {
+    lifecycleCalls.push(args);
+    return args.execute(args.renderer.subscriber, undefined);
+  });
+  const state = new MemoryStore();
+  const agent = new FakeAgent([interrupt]);
+
+  function Approval() {
+    return (
+      <Button
+        value={{ approved: true }}
+        onClick={async ({ thread }) => {
+          await thread.resume({ approved: true }, { memory, subject });
+        }}
+      >
+        Approve
+      </Button>
+    );
+  }
+
+  const channel = createChannel({
+    name: "approvals",
+    identifyUser: ({ actor }) =>
+      actor.kind === "human"
+        ? { id: `app:${actor.id}`, name: actor.name ?? actor.id }
+        : null,
+    adapters: [adapter],
+    agent,
+    components: [Approval],
+    store: { adapter: state, actionRetentionMs: 60_000 },
+  });
+  channel.onMessage(async ({ thread }) => {
+    await thread.runAgent();
+  });
+  channel.onInterrupt("approval", async ({ thread }) => {
+    await thread.post(<Approval />);
+  });
+  await channel.ɵruntime.start();
+  activeChannels.push({ stop: () => channel.ɵruntime.stop() });
+
+  await adapter.getSink().onTurn({
+    conversationKey: "thread-1",
+    replyTarget: {},
+    userText: "start",
+    platform: "slack",
+    actor: { id: "alice", kind: "human", name: "Alice" },
+  });
+
+  return { adapter, lifecycleCalls, state, actionId: firstActionId(adapter) };
+}
+
+test("resume with initiator Memory keeps the original user when Bob clicks", async () => {
+  const { adapter, lifecycleCalls, actionId } = await setup("initiator", {
+    user: "read",
+  });
+
+  await adapter.getSink().onInteraction({
+    id: actionId,
+    conversationKey: "thread-1",
+    replyTarget: {},
+    eventId: "bob-click",
+    actor: { id: "bob", kind: "human", name: "Bob" },
+  });
+
+  expect(lifecycleCalls).toHaveLength(2);
+  expect(lifecycleCalls[1]!.memory).toEqual({
+    grant: { user: "read", project: "none" },
+    user: { id: "app:alice", name: "Alice" },
+  });
+});
+
+test("a managed continuation keeps its initiator across a Runtime restart", async () => {
+  const state = new MemoryStore();
+  const lifecycleCalls: ChannelAgentLifecycleArgs[] = [];
+
+  function Approval() {
+    return (
+      <Button
+        value={{ approved: true }}
+        onClick={async ({ thread }) => {
+          await thread.resume(
+            { approved: true },
+            { memory: { user: "read" }, subject: "initiator" },
+          );
+        }}
+      >
+        Approve
+      </Button>
+    );
+  }
+
+  const makeRuntime = (agent: FakeAgent) => {
+    const adapter = new FakeAdapter();
+    adapter.supportsIntelligenceMemory = true;
+    adapter.runAgentLifecycle = vi.fn(
+      async (args: ChannelAgentLifecycleArgs) => {
+        lifecycleCalls.push(args);
+        return args.execute(args.renderer.subscriber, undefined);
+      },
+    );
+    const channel = createChannel({
+      name: "approvals",
+      identifyUser: ({ actor }) =>
+        actor.kind === "human"
+          ? { id: `app:${actor.id}`, name: actor.name ?? actor.id }
+          : null,
+      adapters: [adapter],
+      agent,
+      components: [Approval],
+      store: { adapter: state, actionRetentionMs: 60_000 },
+    });
+    channel.onMessage(async ({ thread }) => {
+      await thread.runAgent();
+    });
+    channel.onInterrupt("approval", async ({ thread }) => {
+      await thread.post(<Approval />);
+    });
+    return { adapter, channel };
+  };
+
+  const first = makeRuntime(new FakeAgent([interrupt]));
+  await first.channel.ɵruntime.start();
+  await first.adapter.getSink().onTurn({
+    conversationKey: "thread-1",
+    replyTarget: {},
+    userText: "start",
+    platform: "slack",
+    actor: { id: "alice", kind: "human", name: "Alice" },
+  });
+  const actionId = firstActionId(first.adapter);
+  await first.channel.ɵruntime.stop();
+
+  const restarted = makeRuntime(new FakeAgent());
+  await restarted.channel.ɵruntime.start();
+  activeChannels.push({ stop: () => restarted.channel.ɵruntime.stop() });
+  await restarted.adapter.getSink().onInteraction({
+    id: actionId,
+    conversationKey: "thread-1",
+    replyTarget: {},
+    eventId: "bob-click-after-restart",
+    actor: { id: "bob", kind: "human", name: "Bob" },
+  });
+
+  expect(lifecycleCalls).toHaveLength(2);
+  expect(lifecycleCalls[1]!.memory).toEqual({
+    grant: { user: "read", project: "none" },
+    user: { id: "app:alice", name: "Alice" },
+  });
+  expect(lifecycleCalls[1]!.isResume).toBe(true);
+});
+
+test("independent runs on one Thread snapshot new initiators", async () => {
+  const state = new MemoryStore();
+  const adapter = new FakeAdapter();
+
+  function Approval() {
+    return (
+      <Button value={{ approved: true }} onClick={() => undefined}>
+        Approve
+      </Button>
+    );
+  }
+
+  const channel = createChannel({
+    name: "approvals",
+    identifyUser: ({ actor }) =>
+      actor.kind === "human"
+        ? { id: `app:${actor.id}`, name: actor.name ?? actor.id }
+        : null,
+    adapters: [adapter],
+    agent: new FakeAgent([interrupt]),
+    components: [Approval],
+    store: { adapter: state, actionRetentionMs: 60_000 },
+  });
+  channel.onMessage(async ({ thread }) => {
+    await thread.runAgent();
+  });
+  channel.onInterrupt("approval", async ({ thread }) => {
+    await thread.post(<Approval />);
+  });
+  await channel.ɵruntime.start();
+  activeChannels.push({ stop: () => channel.ɵruntime.stop() });
+
+  for (const actor of [
+    { id: "alice", kind: "human" as const, name: "Alice" },
+    { id: "bob", kind: "human" as const, name: "Bob" },
+  ]) {
+    await adapter.getSink().onTurn({
+      conversationKey: "thread-1",
+      replyTarget: {},
+      userText: "start",
+      platform: "slack",
+      actor,
+    });
+  }
+
+  const snapshots = await Promise.all(
+    actionIds(adapter).map((id) =>
+      state.kv.get<ActionSnapshot>(`action:${id}`),
+    ),
+  );
+  expect(snapshots).toHaveLength(2);
+  expect(
+    snapshots.map((snapshot) => snapshot?.continuation?.initiator.user?.id),
+  ).toEqual(["app:alice", "app:bob"]);
+  expect(
+    new Set(snapshots.map((snapshot) => snapshot?.continuation?.runChainId))
+      .size,
+  ).toBe(2);
+});
+
+test("concurrent independent runs cannot share a continuation chain", async () => {
+  const state = new MemoryStore();
+  const adapter = new FakeAdapter();
+
+  function Approval() {
+    return (
+      <Button value={{ approved: true }} onClick={() => undefined}>
+        Approve
+      </Button>
+    );
+  }
+
+  const channel = createChannel({
+    name: "approvals",
+    identifyUser: "platform",
+    adapters: [adapter],
+    agent: () => new FakeAgent([interrupt]),
+    components: [Approval],
+    store: { adapter: state, actionRetentionMs: 60_000 },
+  });
+  let receivedThread:
+    | Parameters<Parameters<typeof channel.onMessage>[0]>[0]["thread"]
+    | undefined;
+  channel.onMessage(({ thread }) => {
+    receivedThread = thread;
+  });
+  channel.onInterrupt("approval", async ({ thread }) => {
+    await thread.post(<Approval />);
+  });
+  await channel.ɵruntime.start();
+  activeChannels.push({ stop: () => channel.ɵruntime.stop() });
+
+  await adapter.getSink().onTurn({
+    conversationKey: "thread-concurrent",
+    replyTarget: {},
+    userText: "start",
+    platform: "slack",
+    actor: { id: "alice", kind: "human", name: "Alice" },
+    identityContext: {
+      tenant: { id: "T1" },
+      installation: { id: "I1" },
+      conversation: { id: "C1" },
+      trigger: "message",
+      event: { id: "E1" },
+      raw: {},
+    },
+  });
+  if (!receivedThread)
+    throw new Error("message handler did not receive a Thread");
+
+  await Promise.all([receivedThread.runAgent(), receivedThread.runAgent()]);
+
+  const snapshots = await Promise.all(
+    actionIds(adapter).map((id) =>
+      state.kv.get<ActionSnapshot>(`action:${id}`),
+    ),
+  );
+  expect(snapshots).toHaveLength(2);
+  expect(
+    new Set(snapshots.map((snapshot) => snapshot?.continuation?.runChainId))
+      .size,
+  ).toBe(2);
+});
+
+test("resume with actor Memory selects the current interaction user", async () => {
+  const { adapter, lifecycleCalls, actionId } = await setup("actor", {
+    user: "read-write",
+  });
+
+  await adapter.getSink().onInteraction({
+    id: actionId,
+    conversationKey: "thread-1",
+    replyTarget: {},
+    eventId: "bob-click",
+    actor: { id: "bob", kind: "human", name: "Bob" },
+  });
+
+  expect(lifecycleCalls[1]!.memory?.user).toEqual({
+    id: "app:bob",
+    name: "Bob",
+  });
+});
+
+test("project-only resume needs no personal subject or fabricated user", async () => {
+  const { adapter, lifecycleCalls, actionId } = await setup(undefined, {
+    project: "read",
+  });
+
+  await adapter.getSink().onInteraction({
+    id: actionId,
+    conversationKey: "thread-1",
+    replyTarget: {},
+    eventId: "system-click",
+    actor: { id: "approval-bot", kind: "bot" },
+  });
+
+  expect(lifecycleCalls[1]!.memory).toEqual({
+    grant: { user: "none", project: "read" },
+    user: null,
+  });
+});
+
+test("personal resume requires an explicit trusted subject selector", async () => {
+  const { adapter, lifecycleCalls, actionId } = await setup(undefined, {
+    user: "read",
+  });
+
+  await expect(
+    adapter.getSink().onInteraction({
+      id: actionId,
+      conversationKey: "thread-1",
+      replyTarget: {},
+      eventId: "bob-click",
+      actor: { id: "bob", kind: "human", name: "Bob" },
+    }),
+  ).rejects.toMatchObject({ code: "channel_memory_subject_required" });
+  expect(lifecycleCalls).toHaveLength(1);
+});
+
+test("personal resume fails before execution when the selected actor has no application user", async () => {
+  const { adapter, lifecycleCalls, actionId } = await setup("actor", {
+    user: "read",
+  });
+
+  await expect(
+    adapter.getSink().onInteraction({
+      id: actionId,
+      conversationKey: "thread-1",
+      replyTarget: {},
+      eventId: "system-click",
+      actor: { id: "approval-bot", kind: "bot" },
+    }),
+  ).rejects.toMatchObject({ code: "channel_memory_user_required" });
+  expect(lifecycleCalls).toHaveLength(1);
+});
+
+test("a continuation starts only one resumed run", async () => {
+  const { adapter, lifecycleCalls, actionId } = await setup("actor", {
+    project: "read",
+  });
+  const click = (eventId: string) =>
+    adapter.getSink().onInteraction({
+      id: actionId,
+      conversationKey: "thread-1",
+      replyTarget: {},
+      eventId,
+      actor: { id: "bob", kind: "human", name: "Bob" },
+    });
+
+  await Promise.all([click("click-1"), click("click-2")]);
+
+  expect(lifecycleCalls).toHaveLength(2);
+});
+
+test("a wrong conversation cannot consume another conversation's continuation", async () => {
+  const { adapter, lifecycleCalls, actionId } = await setup("actor", {
+    project: "read",
+  });
+
+  await expect(
+    adapter.getSink().onInteraction({
+      id: actionId,
+      conversationKey: "thread-wrong",
+      replyTarget: {},
+      eventId: "wrong-thread-click",
+      actor: { id: "bob", kind: "human", name: "Bob" },
+    }),
+  ).rejects.toMatchObject({ code: "channel_continuation_mismatch" });
+  expect(lifecycleCalls).toHaveLength(1);
+
+  await adapter.getSink().onInteraction({
+    id: actionId,
+    conversationKey: "thread-1",
+    replyTarget: {},
+    eventId: "correct-thread-click",
+    actor: { id: "bob", kind: "human", name: "Bob" },
+  });
+  expect(lifecycleCalls).toHaveLength(2);
+});
+
+test("normal runs write no continuation state and one resume consumes once", async () => {
+  const state = new MemoryStore();
+  const set = vi.spyOn(state.kv, "set");
+  const consume = vi.spyOn(state.kv, "consume");
+  const adapter = new FakeAdapter();
+  adapter.supportsIntelligenceMemory = true;
+
+  function Approval() {
+    return (
+      <Button
+        value={{ approved: true }}
+        onClick={async ({ thread }) => {
+          await thread.resume(
+            { approved: true },
+            { memory: { project: "read" } },
+          );
+        }}
+      >
+        Approve
+      </Button>
+    );
+  }
+
+  const finish = (subscriber: AgentSubscriber): void => {
+    subscriber.onRunFinishedEvent?.({ event: {} } as never);
+  };
+  const agent = new FakeAgent([finish]);
+  const channel = createChannel({
+    name: "approvals",
+    identifyUser: ({ actor }) =>
+      actor.kind === "human"
+        ? { id: `app:${actor.id}`, name: actor.name ?? actor.id }
+        : null,
+    adapters: [adapter],
+    agent,
+    components: [Approval],
+    store: { adapter: state, actionRetentionMs: 60_000 },
+  });
+  channel.onMessage(async ({ thread, message }) => {
+    agent.setScript([message.text === "interrupt" ? interrupt : finish]);
+    await thread.runAgent();
+  });
+  channel.onInterrupt("approval", async ({ thread }) => {
+    await thread.post(<Approval />);
+  });
+  await channel.ɵruntime.start();
+  activeChannels.push({ stop: () => channel.ɵruntime.stop() });
+
+  const turn = (userText: string) =>
+    adapter.getSink().onTurn({
+      conversationKey: "thread-1",
+      replyTarget: {},
+      userText,
+      platform: "slack",
+      actor: { id: "alice", kind: "human", name: "Alice" },
+    });
+  await turn("normal");
+  expect(set).not.toHaveBeenCalled();
+  expect(consume).not.toHaveBeenCalled();
+
+  await turn("interrupt");
+  const actionId = firstActionId(adapter);
+  expect(set).toHaveBeenCalledTimes(1);
+  expect(set.mock.calls[0]?.[0]).toBe(`action:${actionId}`);
+  expect(consume).not.toHaveBeenCalled();
+
+  const click = (eventId: string) =>
+    adapter.getSink().onInteraction({
+      id: actionId,
+      conversationKey: "thread-1",
+      replyTarget: {},
+      eventId,
+      actor: { id: "bob", kind: "human", name: "Bob" },
+    });
+  await click("bob-click");
+  await click("bob-click-redelivery");
+  expect(consume).toHaveBeenCalledTimes(1);
+  expect(consume.mock.calls[0]?.[0]).toBe(`action:${actionId}`);
+});

--- a/packages/channels-core/src/identity.test.ts
+++ b/packages/channels-core/src/identity.test.ts
@@ -1,0 +1,153 @@
+import { expect, test, vi } from "vitest";
+import {
+  ChannelIdentityResolutionError,
+  ChannelIdentityResultError,
+  resolveChannelUser,
+} from "./identity.js";
+import type { ChannelIdentityContext } from "./identity.js";
+
+function context(
+  kind: ChannelIdentityContext["actor"]["kind"] = "human",
+): ChannelIdentityContext {
+  return {
+    provider: "slack",
+    tenant: { id: "T1", name: "Acme" },
+    installation: { id: "I1" },
+    actor: {
+      id: "U1",
+      kind,
+      name: "Ada Lovelace",
+      handle: "ada",
+    },
+    conversation: { id: "C1", kind: "channel" },
+    trigger: "message",
+    event: { id: "E1" },
+    raw: { type: "app_mention" },
+  };
+}
+
+test("platform identity maps a human actor to a tenant-namespaced application user", async () => {
+  await expect(resolveChannelUser("platform", context())).resolves.toEqual({
+    id: "slack:T1:U1",
+    name: "Ada Lovelace",
+  });
+});
+
+test("platform identity keeps provider and tenant namespaces distinct", async () => {
+  const slack = context();
+  const otherTenant = { ...context(), tenant: { id: "T2" } };
+  const teams = { ...context(), provider: "teams" };
+
+  await expect(resolveChannelUser("platform", slack)).resolves.toMatchObject({
+    id: "slack:T1:U1",
+  });
+  await expect(
+    resolveChannelUser("platform", otherTenant),
+  ).resolves.toMatchObject({ id: "slack:T2:U1" });
+  await expect(resolveChannelUser("platform", teams)).resolves.toMatchObject({
+    id: "teams:T1:U1",
+  });
+});
+
+test.each(["bot", "app", "system", "unknown"] as const)(
+  "platform identity maps a %s actor to null",
+  async (kind) => {
+    await expect(
+      resolveChannelUser("platform", context(kind)),
+    ).resolves.toBeNull();
+  },
+);
+
+test("platform identity falls back from name to handle and provider id", async () => {
+  const withHandle = {
+    ...context(),
+    actor: { id: "U1", kind: "human" as const, handle: "ada" },
+  };
+  await expect(
+    resolveChannelUser("platform", withHandle),
+  ).resolves.toMatchObject({
+    name: "ada",
+  });
+
+  const withId = {
+    ...context(),
+    actor: { id: "U1", kind: "human" as const },
+  };
+  await expect(resolveChannelUser("platform", withId)).resolves.toMatchObject({
+    name: "U1",
+  });
+});
+
+test("a custom identity callback may map a bot actor", async () => {
+  const botContext = context("bot");
+  await expect(
+    resolveChannelUser(
+      () => ({ id: "service-1", name: "Build bot" }),
+      botContext,
+    ),
+  ).resolves.toEqual({ id: "service-1", name: "Build bot" });
+});
+
+test.each([
+  undefined,
+  {},
+  { id: "", name: "Ada" },
+  { id: "person-1", name: "" },
+])(
+  "a malformed custom identity result fails with the stable public error",
+  async (result) => {
+    await expect(
+      resolveChannelUser(() => result as never, context()),
+    ).rejects.toMatchObject({
+      code: "channel_identity_invalid",
+      name: new ChannelIdentityResultError().name,
+    });
+  },
+);
+
+test("a thrown custom identity error uses a stable public failure without platform fallback", async () => {
+  const failure = new Error("identity service unavailable");
+  const result = resolveChannelUser(() => {
+    throw failure;
+  }, context());
+
+  await expect(result).rejects.toMatchObject({
+    code: "channel_identity_failed",
+    cause: failure,
+  });
+  await expect(result).rejects.toBeInstanceOf(ChannelIdentityResolutionError);
+});
+
+test("profile lookup stays lazy unless the custom callback calls it", async () => {
+  const lookupProfile = vi.fn(async () => ({
+    id: "U1",
+    kind: "human" as const,
+    email: "ada@example.com",
+  }));
+  const identityContext = { ...context(), lookupProfile };
+
+  await resolveChannelUser("platform", identityContext);
+  expect(lookupProfile).not.toHaveBeenCalled();
+
+  await resolveChannelUser(async (received) => {
+    const profile = await received.lookupProfile?.();
+    return { id: "person-1", name: profile?.email ?? "Ada" };
+  }, identityContext);
+  expect(lookupProfile).toHaveBeenCalledTimes(1);
+});
+
+test("a failing lazy profile lookup cannot break platform identity", async () => {
+  const lookupProfile = vi.fn(async () => {
+    throw new Error("provider profile unavailable");
+  });
+  const identityContext = {
+    ...context(),
+    actor: { id: "U1", kind: "human" as const },
+    lookupProfile,
+  };
+
+  await expect(
+    resolveChannelUser("platform", identityContext),
+  ).resolves.toEqual({ id: "slack:T1:U1", name: "U1" });
+  expect(lookupProfile).not.toHaveBeenCalled();
+});

--- a/packages/channels-core/src/identity.ts
+++ b/packages/channels-core/src/identity.ts
@@ -1,0 +1,117 @@
+import type { ApplicationUser, ProviderActor } from "@copilotkit/channels-ui";
+
+/** Provider tenant or workspace facts available at ingress. */
+export interface ChannelTenant {
+  readonly id: string;
+  readonly name?: string;
+}
+
+/** Provider installation facts available at ingress. */
+export interface ChannelInstallation {
+  readonly id: string;
+}
+
+/** Provider conversation facts available at ingress. */
+export interface ChannelConversation {
+  readonly id: string;
+  readonly kind?: string;
+}
+
+/** Normalized provider event facts available at ingress. */
+export interface ChannelEvent {
+  readonly id?: string;
+  readonly occurredAt?: string;
+  readonly [key: string]: unknown;
+}
+
+/** Adapter-provided facts used to select one canonical application user. */
+export interface ChannelIdentityContext {
+  readonly provider: string;
+  readonly tenant: ChannelTenant;
+  readonly installation: ChannelInstallation;
+  readonly actor: ProviderActor;
+  readonly conversation: ChannelConversation;
+  readonly trigger: string;
+  readonly event: ChannelEvent;
+  readonly raw: unknown;
+  readonly lookupProfile?: () => Promise<ProviderActor | undefined>;
+}
+
+/** Explicit Channel identity strategy. */
+export type ChannelIdentifyUser =
+  | "platform"
+  | ((
+      context: ChannelIdentityContext,
+    ) => ApplicationUser | null | Promise<ApplicationUser | null>);
+
+/** Identity facts supplied by an adapter alongside every ingress event. */
+export type IngressIdentityContext = Omit<
+  ChannelIdentityContext,
+  "provider" | "actor"
+>;
+
+/** Stable public failure for malformed custom identity results. */
+export class ChannelIdentityResultError extends Error {
+  readonly code = "channel_identity_invalid";
+
+  constructor() {
+    super(
+      "Channel identifyUser must return null or an application user with non-empty id and name",
+    );
+    this.name = "ChannelIdentityResultError";
+  }
+}
+
+/** Stable public failure for a configured identity callback exception. */
+export class ChannelIdentityResolutionError extends Error {
+  readonly code = "channel_identity_failed";
+  override readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    super("Channel identifyUser failed");
+    this.name = "ChannelIdentityResolutionError";
+    this.cause = cause;
+  }
+}
+
+function hasText(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function validateApplicationUser(value: unknown): ApplicationUser | null {
+  if (value === null) return null;
+  if (
+    typeof value !== "object" ||
+    value === undefined ||
+    !hasText((value as { id?: unknown }).id) ||
+    !hasText((value as { name?: unknown }).name)
+  ) {
+    throw new ChannelIdentityResultError();
+  }
+  return Object.freeze({
+    id: (value as { id: string }).id,
+    name: (value as { name: string }).name,
+  });
+}
+
+/** Resolve one immutable canonical application user for one ingress event. */
+export async function resolveChannelUser(
+  identifyUser: ChannelIdentifyUser | undefined,
+  context: ChannelIdentityContext,
+): Promise<ApplicationUser | null> {
+  if (identifyUser === undefined) return null;
+  if (identifyUser === "platform") {
+    if (context.actor.kind !== "human") return null;
+    return Object.freeze({
+      id: [context.provider, context.tenant.id, context.actor.id].join(":"),
+      name: context.actor.name ?? context.actor.handle ?? context.actor.id,
+    });
+  }
+  let identified: ApplicationUser | null;
+  try {
+    identified = await identifyUser(context);
+  } catch (cause) {
+    throw new ChannelIdentityResolutionError(cause);
+  }
+  return validateApplicationUser(identified);
+}

--- a/packages/channels-core/src/index.ts
+++ b/packages/channels-core/src/index.ts
@@ -31,6 +31,20 @@ export type {
   StatefulThread,
   ChannelComponent,
 } from "./create-channel.js";
+export {
+  ChannelIdentityResolutionError,
+  ChannelIdentityResultError,
+  resolveChannelUser,
+} from "./identity.js";
+export type {
+  ChannelConversation,
+  ChannelEvent,
+  ChannelIdentifyUser,
+  ChannelIdentityContext,
+  ChannelInstallation,
+  ChannelTenant,
+  IngressIdentityContext,
+} from "./identity.js";
 
 // Thread
 export { Thread } from "./thread.js";
@@ -78,10 +92,21 @@ export type {
 
 // Action store
 export { InMemoryActionStore } from "./action-store.js";
-export type { ActionStore, ActionSnapshot } from "./action-store.js";
+export type {
+  ActionStore,
+  ActionSnapshot,
+  ActionContinuationContext,
+  ActionContinuationBinding,
+  ActionContinuationInitiator,
+  ActionContinuationSnapshot,
+} from "./action-store.js";
 
 // Action registry
-export { ActionRegistry, ActionExpiredError } from "./action-registry.js";
+export {
+  ActionRegistry,
+  ActionContinuationMismatchError,
+  ActionExpiredError,
+} from "./action-registry.js";
 
 // State store
 export type { StateStore } from "./state/state-store.js";
@@ -96,11 +121,7 @@ export { createStateBackedConversationStore } from "./state/state-conversation-s
 
 // Transcripts
 export { Transcripts } from "./transcripts.js";
-export type {
-  TranscriptEntry,
-  Identity,
-  TranscriptsConfig,
-} from "./transcripts.js";
+export type { TranscriptEntry, TranscriptsConfig } from "./transcripts.js";
 
 // Tools & context
 export {
@@ -124,6 +145,12 @@ export { mintId, stableStringify } from "./mint-id.js";
 export { runAgentLoop } from "./run-loop.js";
 export type { RunLoopArgs } from "./run-loop.js";
 export {
+  ChannelContinuationRequiredError,
+  ChannelMemorySubjectRequiredError,
+  ChannelMemoryUnavailableError,
+  ChannelMemoryUserRequiredError,
+} from "./thread.js";
+export {
   ChannelDeliveryTerminatedError,
   isChannelDeliveryTerminatedError,
 } from "./delivery-error.js";
@@ -132,6 +159,18 @@ export {
 // The Intelligence Channel adapter itself lives in
 // `@copilotkit/channels-intelligence`.
 export type { PlatformCodec } from "./codec.js";
+
+// Per-run Intelligence Memory grants.
+export {
+  ChannelMemoryGrantInvalidError,
+  hasMemoryAccess,
+  resolveMemoryGrant,
+} from "./memory.js";
+export type {
+  MemoryAccess,
+  MemoryGrant,
+  ResolvedChannelMemory,
+} from "./memory.js";
 
 // Test utilities (also surfaces them for downstream adapter packages' tests).
 export { FakeAdapter, makeFakeRunRenderer } from "./testing/fake-adapter.js";

--- a/packages/channels-core/src/managed-v1-await-choice-guard.test.ts
+++ b/packages/channels-core/src/managed-v1-await-choice-guard.test.ts
@@ -15,7 +15,10 @@ class NonBlockingManagedAdapter extends FakeAdapter {
 
 async function setupNonBlockingManagedThread() {
   const adapter = new NonBlockingManagedAdapter();
-  const channel = createChannel({ adapters: [adapter] });
+  const channel = createChannel({
+    identifyUser: "platform",
+    adapters: [adapter],
+  });
   let thread: Pick<Thread, "awaitChoice"> | undefined;
   channel.onThreadStarted(({ thread: activeThread }) => {
     thread = activeThread;

--- a/packages/channels-core/src/memory.ts
+++ b/packages/channels-core/src/memory.ts
@@ -1,0 +1,48 @@
+import type { ApplicationUser } from "@copilotkit/channels-ui";
+
+/** Access granted to one Intelligence Memory scope for one agent run. */
+export type MemoryAccess = "none" | "read" | "read-write";
+
+/** Explicit user and project Memory access for one agent run. */
+export interface MemoryGrant {
+  readonly user?: MemoryAccess;
+  readonly project?: MemoryAccess;
+}
+
+/** Fully resolved, immutable Memory context passed to managed execution. */
+export interface ResolvedChannelMemory {
+  readonly grant: Required<MemoryGrant>;
+  readonly user: ApplicationUser | null;
+}
+
+/** A JavaScript caller bypassed the typed Channel Memory grant contract. */
+export class ChannelMemoryGrantInvalidError extends Error {
+  readonly code = "channel_memory_grant_invalid";
+
+  constructor() {
+    super('Channel Memory access must be "none", "read", or "read-write"');
+    this.name = "ChannelMemoryGrantInvalidError";
+  }
+}
+
+const MEMORY_ACCESS = new Set<unknown>(["none", "read", "read-write"]);
+
+/** Fill omitted scopes with no access. */
+export function resolveMemoryGrant(grant: MemoryGrant): Required<MemoryGrant> {
+  const resolved = Object.freeze({
+    user: grant.user ?? "none",
+    project: grant.project ?? "none",
+  });
+  if (
+    !MEMORY_ACCESS.has(resolved.user) ||
+    !MEMORY_ACCESS.has(resolved.project)
+  ) {
+    throw new ChannelMemoryGrantInvalidError();
+  }
+  return resolved;
+}
+
+/** True when a grant requests any Intelligence Memory operation. */
+export function hasMemoryAccess(grant: Required<MemoryGrant>): boolean {
+  return grant.user !== "none" || grant.project !== "none";
+}

--- a/packages/channels-core/src/modal-submit.test.ts
+++ b/packages/channels-core/src/modal-submit.test.ts
@@ -6,7 +6,10 @@ import { FakeAdapter } from "./testing/fake-adapter.js";
 describe("channel.onModalSubmit / onModalClose", () => {
   it("routes a submission by callbackId and parses values; thread present when conversation context exists", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      adapters: [fake],
+      identifyUser: ({ actor }) => ({ id: actor.id, name: actor.id }),
+    });
     const seen: {
       values: Record<string, unknown>;
       user?: string;
@@ -25,7 +28,7 @@ describe("channel.onModalSubmit / onModalClose", () => {
     const res = await fake.emitModalSubmit({
       callbackId: "triage",
       values: { summary: "boom", prio: "high" },
-      user: { id: "U1" },
+      actor: { id: "U1", kind: "human" },
       conversationKey: "c",
       replyTarget: {},
     });
@@ -42,7 +45,10 @@ describe("channel.onModalSubmit / onModalClose", () => {
 
   it("returns the handler's field errors so the adapter can keep the modal open", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     channel.onModalSubmit("triage", (evt) =>
       evt.values.summary ? undefined : { errors: { summary: "Required" } },
     );
@@ -56,7 +62,10 @@ describe("channel.onModalSubmit / onModalClose", () => {
 
   it("ignores submissions with no registered handler", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     await channel.ɵruntime.start();
     const res = await fake.emitModalSubmit({
       callbackId: "unknown",
@@ -67,13 +76,19 @@ describe("channel.onModalSubmit / onModalClose", () => {
 
   it("routes a close by callbackId", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     const closed: string[] = [];
     channel.onModalClose("triage", (evt) => {
       closed.push(evt.callbackId);
     });
     await channel.ɵruntime.start();
-    await fake.emitModalClose({ callbackId: "triage", user: { id: "U2" } });
+    await fake.emitModalClose({
+      callbackId: "triage",
+      actor: { id: "U2", kind: "human" },
+    });
     expect(closed).toEqual(["triage"]);
   });
 });

--- a/packages/channels-core/src/open-modal.test.tsx
+++ b/packages/channels-core/src/open-modal.test.tsx
@@ -14,7 +14,10 @@ const view = Modal({
 describe("ctx.openModal", () => {
   it("opens a modal from an interaction when a triggerId is present", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     let res: unknown;
     channel.onInteraction("ck:open", async (ctx) => {
       res = await ctx.openModal!(view);
@@ -30,7 +33,10 @@ describe("ctx.openModal", () => {
 
   it("opens a modal from a command", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     let res: unknown;
     channel.onCommand("triage", async (ctx) => {
       res = await ctx.openModal!(view);
@@ -43,7 +49,10 @@ describe("ctx.openModal", () => {
 
   it("omits openModal when no triggerId is present", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     let hasOpen = true;
     channel.onInteraction("ck:noop", (ctx) => {
       hasOpen = typeof ctx.openModal === "function";
@@ -56,7 +65,10 @@ describe("ctx.openModal", () => {
 
   it("omits openModal when the adapter has no modal support", async () => {
     const fake = new FakeAdapter({ modals: false });
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     let hasOpen = true;
     channel.onInteraction("ck:x", (ctx) => {
       hasOpen = typeof ctx.openModal === "function";

--- a/packages/channels-core/src/platform-adapter.ts
+++ b/packages/channels-core/src/platform-adapter.ts
@@ -6,9 +6,11 @@ import type {
   EphemeralResult,
   MessageRef,
   MessageOperation,
-  PlatformUser,
+  ProviderActor,
   ThreadMessage,
 } from "@copilotkit/channels-ui";
+import type { IngressIdentityContext } from "./identity.js";
+import type { ResolvedChannelMemory } from "./memory.js";
 import type { CommandSpec } from "./commands.js";
 import type { StateStore } from "./state/state-store.js";
 import type { AgentToolDescriptor, ContextEntry } from "./tools.js";
@@ -110,6 +112,8 @@ export interface ChannelAgentLifecycleArgs {
    * agent command and never crosses the managed run-open boundary.
    */
   isResume?: boolean;
+  /** Explicit Memory access resolved before agent execution. */
+  memory?: ResolvedChannelMemory;
   execute(
     subscriber: AgentSubscriber,
     canonicalRun?: CanonicalRunIdentity,
@@ -124,7 +128,10 @@ export interface ChannelAgentLifecycleArgs {
 export interface IngressEventBase {
   conversationKey: string;
   replyTarget: ReplyTarget;
-  user?: PlatformUser;
+  /** Provider account that caused this event. */
+  actor: ProviderActor;
+  /** Provider facts used by the Channel identity strategy. */
+  identityContext: IngressIdentityContext;
   /**
    * Provider that produced this event when it differs from the transport
    * adapter identity. Multiplexing adapters set it per event.
@@ -230,7 +237,8 @@ export interface IncomingModalSubmit {
   callbackId: string;
   /** Field id → value (text string, selected option value, etc.). */
   values: Record<string, unknown>;
-  user?: PlatformUser;
+  actor: ProviderActor;
+  identityContext: IngressIdentityContext;
   privateMetadata?: string;
   /** Present when the submission carries a conversation context (so the engine can build a Thread). */
   conversationKey?: string;
@@ -242,7 +250,8 @@ export interface IncomingModalSubmit {
 /** A modal dismissal (Slack `view_closed`; requires `notifyOnClose`). */
 export interface IncomingModalClose {
   callbackId: string;
-  user?: PlatformUser;
+  actor: ProviderActor;
+  identityContext: IngressIdentityContext;
   privateMetadata?: string;
   /** Present when the dismissal carries a conversation context (so the engine can build a Thread). */
   conversationKey?: string;
@@ -323,6 +332,8 @@ export interface PlatformAdapter {
   readonly platform: string;
   readonly capabilities: SurfaceCapabilities;
   readonly ackDeadlineMs: number;
+  /** Return the trusted canonical Thread bound to an opaque reply target. */
+  getCanonicalThreadId?(target: ReplyTarget): string;
   start(sink: IngressSink, ctx?: AdapterStartContext): Promise<void>;
   stop(): Promise<void>;
   render(ir: ChannelNode[]): NativePayload;
@@ -342,6 +353,8 @@ export interface PlatformAdapter {
    * containing delivery.
    */
   assertRunAgentSupported?(target: ReplyTarget): void;
+  /** True when this adapter is attached to an Intelligence Memory backend. */
+  supportsIntelligenceMemory?: boolean;
   runAgentLifecycle?(
     args: ChannelAgentLifecycleArgs,
   ): Promise<ChannelAgentLoopResult>;
@@ -355,7 +368,7 @@ export interface PlatformAdapter {
     operation: () => Promise<T>,
   ): Promise<T>;
   decodeInteraction(raw: unknown): InteractionEvent | undefined;
-  lookupUser(q: UserQuery): Promise<PlatformUser | undefined>;
+  lookupUser(q: UserQuery): Promise<ProviderActor | undefined>;
   readonly conversationStore: ConversationStore;
   /**
    * Optional persistence backend supplied by the adapter. `createChannel` uses it
@@ -452,7 +465,7 @@ export interface PlatformAdapter {
    */
   postEphemeral?(
     target: ReplyTarget,
-    user: PlatformUser | string,
+    user: ProviderActor | string,
     ir: ChannelNode[],
     opts: { fallbackToDM: boolean },
   ): Promise<EphemeralResult | null>;

--- a/packages/channels-core/src/reactions.test.ts
+++ b/packages/channels-core/src/reactions.test.ts
@@ -10,7 +10,11 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
 describe("channel.onReaction", () => {
   it("routes a specific reaction, normalizing the platform token", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      adapters: [fake],
+      identifyUser: ({ actor }) =>
+        actor.kind === "human" ? { id: actor.id, name: actor.id } : null,
+    });
     const seen: { emoji: string; raw: string; added: boolean }[] = [];
     channel.onReaction([emoji.thumbs_up], (evt) => {
       seen.push({ emoji: evt.emoji, raw: evt.rawEmoji, added: evt.added });
@@ -27,11 +31,16 @@ describe("channel.onReaction", () => {
 
   it("fires a catch-all for any reaction and reports added/removed", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      adapters: [fake],
+      identifyUser: ({ actor }) =>
+        actor.kind === "human" ? { id: actor.id, name: actor.id } : null,
+    });
     const seen: {
       raw: string;
       added: boolean;
       user?: string;
+      actor: string;
       messageId: string;
       platform: string;
     }[] = [];
@@ -40,6 +49,7 @@ describe("channel.onReaction", () => {
         raw: evt.rawEmoji,
         added: evt.added,
         user: evt.user?.id,
+        actor: evt.actor.id,
         messageId: evt.messageId,
         platform: evt.thread.platform,
       });
@@ -48,17 +58,25 @@ describe("channel.onReaction", () => {
     fake.emitReaction({
       rawEmoji: "🎉",
       added: true,
-      user: { id: "U1" },
+      actor: { id: "U1", kind: "human" },
       messageId: "m9",
     });
     fake.emitReaction({ rawEmoji: "🎉", added: false, messageId: "m9" });
     await tick();
     expect(seen).toEqual([
-      { raw: "🎉", added: true, user: "U1", messageId: "m9", platform: "fake" },
+      {
+        raw: "🎉",
+        added: true,
+        user: "U1",
+        actor: "U1",
+        messageId: "m9",
+        platform: "fake",
+      },
       {
         raw: "🎉",
         added: false,
         user: undefined,
+        actor: "",
         messageId: "m9",
         platform: "fake",
       },
@@ -69,7 +87,10 @@ describe("channel.onReaction", () => {
     // A fake whose platform === "slack" so normalizeEmoji maps the shortcode.
     const fake = new FakeAdapter();
     Object.defineProperty(fake, "platform", { value: "slack" });
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     const hits: string[] = [];
     channel.onReaction(["thumbs_up"], (evt) => {
       hits.push(evt.emoji);
@@ -86,7 +107,10 @@ describe("channel.onReaction", () => {
     // its source provider. Core must normalize by that source platform, so a
     // Teams `<codepoint>_<name>` token resolves to its canonical name.
     const fake = new FakeAdapter({ platform: "intelligence" });
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     const hits: string[] = [];
     channel.onReaction(["refresh"], (evt) => {
       hits.push(evt.emoji);
@@ -103,7 +127,10 @@ describe("channel.onReaction", () => {
 
   it("routes a reaction on a posted message to its <Message onReaction>", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     const seen: { emoji: string; added: boolean }[] = [];
     channel.onMessage(async ({ thread }) => {
       await thread.post(
@@ -132,7 +159,10 @@ describe("channel.onReaction", () => {
 
   it("resolves <Message onReaction> by postedMessageId when the reaction id differs (Channel path)", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     const seen: string[] = [];
     channel.onMessage(async ({ thread }) => {
       await thread.post(
@@ -175,6 +205,7 @@ describe("channel.onReaction", () => {
     // Bot 1 posts the component message, persisting a reaction snapshot.
     const fake1 = new FakeAdapter();
     const bot1 = createChannel({
+      identifyUser: "platform",
       adapters: [fake1],
       store: { adapter: backend },
       components: [Card],
@@ -192,6 +223,7 @@ describe("channel.onReaction", () => {
     // Its reaction hot cache is empty, so it must resolve via the durable snapshot.
     const fake2 = new FakeAdapter();
     const bot2 = createChannel({
+      identifyUser: "platform",
       adapters: [fake2],
       store: { adapter: backend },
       components: [Card],
@@ -204,7 +236,10 @@ describe("channel.onReaction", () => {
 
   it("gives the handler a thread to post new UI and the reacted message's ref", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     let seenRefId: string | undefined;
     channel.onMessage(async ({ thread }) => {
       await thread.post(
@@ -231,7 +266,10 @@ describe("channel.onReaction", () => {
 
   it("does not fire a message handler for a reaction on a different message", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     let fired = false;
     channel.onMessage(async ({ thread }) => {
       await thread.post(
@@ -256,7 +294,10 @@ describe("channel.onReaction", () => {
     // Slack alias to the canonical "thumbs_up", so the filter must too.
     const fake = new FakeAdapter();
     Object.defineProperty(fake, "platform", { value: "slack" });
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     const hits: string[] = [];
     channel.onReaction(["👍"], (evt) => {
       hits.push(evt.emoji);

--- a/packages/channels-core/src/run-loop.test.ts
+++ b/packages/channels-core/src/run-loop.test.ts
@@ -52,7 +52,12 @@ describe("runAgentLoop", () => {
       tools,
       toolDescriptors,
       context,
-      makeToolCtx: () => ({ thread: {} as never, platform: "fake" }),
+      makeToolCtx: () => ({
+        thread: {} as never,
+        user: null,
+        actor: { id: "actor", kind: "unknown" as const },
+        platform: "fake",
+      }),
     });
 
     expect(recorded).toEqual([{ msg: "hi" }]);
@@ -92,7 +97,12 @@ describe("runAgentLoop", () => {
       tools: new Map([["recoverable", tool]]),
       toolDescriptors,
       context,
-      makeToolCtx: () => ({ thread: {} as never, platform: "fake" }),
+      makeToolCtx: () => ({
+        thread: {} as never,
+        user: null,
+        actor: { id: "actor", kind: "unknown" as const },
+        platform: "fake",
+      }),
     });
 
     expect(agent.runAgentCalls).toBe(2);
@@ -122,7 +132,12 @@ describe("runAgentLoop", () => {
       tools,
       toolDescriptors,
       context,
-      makeToolCtx: () => ({ thread: {} as never, platform: "fake" }),
+      makeToolCtx: () => ({
+        thread: {} as never,
+        user: null,
+        actor: { id: "actor", kind: "unknown" as const },
+        platform: "fake",
+      }),
       handleInterrupt,
     });
 
@@ -155,7 +170,12 @@ describe("runAgentLoop", () => {
       tools,
       toolDescriptors,
       context,
-      makeToolCtx: () => ({ thread: {} as never, platform: "fake" }),
+      makeToolCtx: () => ({
+        thread: {} as never,
+        user: null,
+        actor: { id: "actor", kind: "unknown" as const },
+        platform: "fake",
+      }),
       handleInterrupt,
     };
 
@@ -180,7 +200,12 @@ describe("runAgentLoop", () => {
       tools,
       toolDescriptors,
       context,
-      makeToolCtx: () => ({ thread: {} as never, platform: "fake" }),
+      makeToolCtx: () => ({
+        thread: {} as never,
+        user: null,
+        actor: { id: "actor", kind: "unknown" as const },
+        platform: "fake",
+      }),
     };
 
     const result = await runAgentLoop(args);

--- a/packages/channels-core/src/sanitize-agent-events.test.ts
+++ b/packages/channels-core/src/sanitize-agent-events.test.ts
@@ -194,6 +194,7 @@ describe("createChannel({ sanitizeAgentEvents })", () => {
   ): Promise<unknown> {
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => agent,
       ...opts,
@@ -225,6 +226,7 @@ describe("createChannel({ sanitizeAgentEvents })", () => {
     // sanitizing has to live on the transport to reach the cloned instance.
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: agentServing(nullParentRun()),
     });

--- a/packages/channels-core/src/source-platform.test.ts
+++ b/packages/channels-core/src/source-platform.test.ts
@@ -13,6 +13,8 @@ test("an ingress source platform reaches the text thread and its tool context", 
     threadPlatform?: string;
     toolPlatform?: string;
     toolThreadPlatform?: string;
+    toolUser?: string;
+    toolActor?: string;
   } = {};
   const adapter = new FakeAdapter({ platform: "intelligence" });
   const agent = new FakeAgent([
@@ -29,6 +31,7 @@ test("an ingress source platform reaches the text thread and its tool context", 
     },
   ]);
   const channel = createChannel({
+    identifyUser: "platform",
     adapters: [adapter],
     agent: () => agent,
     tools: [
@@ -39,6 +42,8 @@ test("an ingress source platform reaches the text thread and its tool context", 
         handler: (_args: Record<string, never>, ctx: ChannelToolContext) => {
           observed.toolPlatform = ctx.platform;
           observed.toolThreadPlatform = ctx.thread.platform;
+          observed.toolUser = ctx.user?.id;
+          observed.toolActor = ctx.actor.id;
           return "captured";
         },
       },
@@ -56,6 +61,15 @@ test("an ingress source platform reaches the text thread and its tool context", 
     replyTarget: {},
     userText: "hello",
     platform: "slack",
+    actor: { id: "U1", kind: "human", name: "Ada" },
+    identityContext: {
+      tenant: { id: "T1" },
+      installation: { id: "I1" },
+      conversation: { id: "conversation-1", kind: "channel" },
+      trigger: "message",
+      event: { id: "E1" },
+      raw: {},
+    },
   });
 
   expect(observed).toEqual({
@@ -63,25 +77,27 @@ test("an ingress source platform reaches the text thread and its tool context", 
     threadPlatform: "slack",
     toolPlatform: "slack",
     toolThreadPlatform: "slack",
+    toolUser: "slack:T1:U1",
+    toolActor: "U1",
   });
 });
 
 test("an ingress source platform scopes identity resolution and event dedupe", async () => {
   const state = new MemoryStore();
   const dedupeSeen = vi.spyOn(state.dedup, "seen").mockResolvedValue(false);
-  const identity = vi.fn(() => "person-1");
+  const identifyUser = vi.fn(() => ({ id: "person-1", name: "Person One" }));
   const adapter = new FakeAdapter({ platform: "intelligence" });
   const channel = createChannel({
     adapters: [adapter],
+    identifyUser,
     store: {
       adapter: state,
-      identity,
       transcripts: {},
     },
   });
-  let userKey: string | undefined;
+  let userId: string | undefined;
   channel.onMessage(({ message }) => {
-    userKey = message.userKey;
+    userId = message.user?.id;
   });
   await channel.ɵruntime.start();
 
@@ -91,20 +107,20 @@ test("an ingress source platform scopes identity resolution and event dedupe", a
     userText: "hello",
     platform: "teams",
     eventId: "event-1",
-    user: { id: "user-1" },
+    actor: { id: "user-1", kind: "human" },
   });
 
   expect(dedupeSeen).toHaveBeenCalledWith(
     "message:teams:created:event-1:event-1",
     300_000,
   );
-  expect(identity).toHaveBeenCalledWith(
+  expect(identifyUser).toHaveBeenCalledWith(
     expect.objectContaining({
-      adapter: "teams",
-      message: expect.objectContaining({ platform: "teams" }),
+      provider: "teams",
+      actor: expect.objectContaining({ id: "user-1" }),
     }),
   );
-  expect(userKey).toBe("person-1");
+  expect(userId).toBe("person-1");
 });
 
 test("non-text ingress keeps source platform in handler contexts and dedupe keys", async () => {
@@ -113,6 +129,7 @@ test("non-text ingress keeps source platform in handler contexts and dedupe keys
   const adapter = new FakeAdapter({ platform: "intelligence" });
   const observed: Record<string, string> = {};
   const channel = createChannel({
+    identifyUser: "platform",
     adapters: [adapter],
     store: { adapter: state },
   });

--- a/packages/channels-core/src/state/kv-action-store.test.ts
+++ b/packages/channels-core/src/state/kv-action-store.test.ts
@@ -19,4 +19,17 @@ describe("kvActionStore", () => {
     await store.delete("ck:abc");
     expect(await store.get("ck:abc")).toBeUndefined();
   });
+
+  it("consumes a snapshot once via state.kv", async () => {
+    const state = new MemoryStore();
+    const store = kvActionStore(state);
+    const snap = {
+      path: [0, "onClick"],
+      conversationKey: "c",
+    };
+    await store.put("ck:once", snap);
+
+    expect(await store.consume("ck:once")).toEqual(snap);
+    expect(await store.consume("ck:once")).toBeUndefined();
+  });
 });

--- a/packages/channels-core/src/state/kv-action-store.ts
+++ b/packages/channels-core/src/state/kv-action-store.ts
@@ -12,6 +12,7 @@ export function kvActionStore(
     put: (id, snap, ttlMs) =>
       state.kv.set<ActionSnapshot>(key(id), snap, ttlMs ?? opts?.defaultTtlMs),
     get: (id) => state.kv.get<ActionSnapshot>(key(id)),
+    consume: (id) => state.kv.consume<ActionSnapshot>(key(id)),
     delete: (id) => state.kv.delete(key(id)),
   };
 }

--- a/packages/channels-core/src/state/memory-store.ts
+++ b/packages/channels-core/src/state/memory-store.ts
@@ -31,6 +31,15 @@ export class MemoryStore implements StateStore {
     delete: async (key: string): Promise<void> => {
       this.kvMap.delete(key);
     },
+    consume: async <T>(key: string): Promise<T | undefined> => {
+      const e = this.kvMap.get(key);
+      if (!live(e)) {
+        this.kvMap.delete(key);
+        return undefined;
+      }
+      this.kvMap.delete(key);
+      return e.value as T;
+    },
   };
 
   list = {

--- a/packages/channels-core/src/state/state-store.ts
+++ b/packages/channels-core/src/state/state-store.ts
@@ -12,6 +12,8 @@ export interface StateStore {
     get<T>(key: string): Promise<T | undefined>;
     set<T>(key: string, value: T, ttlMs?: number): Promise<void>;
     delete(key: string): Promise<void>;
+    /** Atomically return and delete one live value. */
+    consume<T>(key: string): Promise<T | undefined>;
   };
   list: {
     /**

--- a/packages/channels-core/src/telemetry/create-channel-telemetry.test.ts
+++ b/packages/channels-core/src/telemetry/create-channel-telemetry.test.ts
@@ -26,6 +26,7 @@ describe("createChannel telemetry wiring", () => {
     // telemetry) is resolved there, not at construction, so an adapter attached
     // via addAdapter can still provide the persistence backend.
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [new FakeAdapter()],
       components: [
         function Card() {
@@ -45,7 +46,7 @@ describe("createChannel telemetry wiring", () => {
 
   it("emits oss.channel.started on start, start_failed (category only) on a throwing adapter", async () => {
     const ok = new FakeAdapter();
-    const channel = createChannel({ adapters: [ok] });
+    const channel = createChannel({ identifyUser: "platform", adapters: [ok] });
     await channel.ɵruntime.start();
     expect(
       capture.mock.calls.find((c) => c[0] === "oss.channel.started")?.[1]
@@ -58,7 +59,7 @@ describe("createChannel telemetry wiring", () => {
       Promise.reject(
         Object.assign(new Error("xoxb-SECRET token bad"), { code: "EAUTH" }),
       );
-    const bot2 = createChannel({ adapters: [bad] });
+    const bot2 = createChannel({ identifyUser: "platform", adapters: [bad] });
     // All adapters failed → start() rejects (the channel is dead; the runtime
     // reports status "error"). The start_failed telemetry is still captured
     // before the throw.
@@ -74,6 +75,7 @@ describe("createChannel telemetry wiring", () => {
   it("emits oss.channel.agent_run on a successful run", async () => {
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => new FakeAgent(),
     });

--- a/packages/channels-core/src/telemetry/e2e-telemetry.test.ts
+++ b/packages/channels-core/src/telemetry/e2e-telemetry.test.ts
@@ -39,6 +39,7 @@ describe("oss.channel.* end-to-end (real ChannelTelemetry, only network boundary
   it("flows configured -> started -> agent_run with anonymous_id + channel_session_id and no env config", async () => {
     const fake = new FakeAdapter();
     const channel = createChannel({
+      identifyUser: "platform",
       adapters: [fake],
       agent: () => new FakeAgent(),
     });

--- a/packages/channels-core/src/telemetry/install-id.test.ts
+++ b/packages/channels-core/src/telemetry/install-id.test.ts
@@ -12,6 +12,11 @@ class FakeDurableStore implements StateStore {
     get: async <T>(k: string) => this.map.get(k) as T | undefined,
     set: async <T>(k: string, v: T) => void this.map.set(k, v),
     delete: async (k: string) => void this.map.delete(k),
+    consume: async <T>(k: string): Promise<T | undefined> => {
+      const value = this.map.get(k) as T | undefined;
+      this.map.delete(k);
+      return value;
+    },
   };
   list = {} as StateStore["list"];
   lock = {} as StateStore["lock"];

--- a/packages/channels-core/src/testing/fake-adapter.ts
+++ b/packages/channels-core/src/testing/fake-adapter.ts
@@ -2,7 +2,7 @@ import type { AgentSubscriber } from "@ag-ui/client";
 import type {
   ChannelNode,
   MessageRef,
-  PlatformUser,
+  ProviderActor,
   ThreadMessage,
 } from "@copilotkit/channels-ui";
 import type {
@@ -28,6 +28,33 @@ import type {
 } from "../platform-adapter.js";
 import type { CommandSpec } from "../commands.js";
 import type { StateStore } from "../state/state-store.js";
+
+type OptionalIdentity<T extends { actor: unknown; identityContext: unknown }> =
+  Omit<T, "actor" | "identityContext"> &
+    Partial<Pick<T, "actor" | "identityContext">>;
+
+type FakeIngressSink = {
+  onTurn(
+    turn: OptionalIdentity<Omit<IncomingTurn, "operation">> & {
+      operation?: IncomingTurn["operation"];
+    },
+  ): void | Promise<void>;
+  onInteraction(
+    event: OptionalIdentity<InteractionEvent>,
+  ): void | Promise<void>;
+  onCommand(event: OptionalIdentity<IncomingCommand>): void | Promise<void>;
+  onThreadStarted(
+    event: OptionalIdentity<IncomingThreadStart>,
+  ): void | Promise<void>;
+  onWelcome(event: OptionalIdentity<IncomingWelcome>): void | Promise<void>;
+  onReaction(event: OptionalIdentity<IncomingReaction>): void | Promise<void>;
+  onModalSubmit(
+    event: OptionalIdentity<IncomingModalSubmit>,
+  ): Promise<ModalSubmitResult | void>;
+  onModalClose(
+    event: OptionalIdentity<IncomingModalClose>,
+  ): void | Promise<void>;
+};
 
 /** A RunRenderer whose subscriber captures tool-call-end and custom (interrupt) events — used by run-loop tests. */
 export function makeFakeRunRenderer(): RunRenderer {
@@ -68,6 +95,8 @@ export class FakeAdapter implements PlatformAdapter {
   platform = "fake";
   readonly capabilities: SurfaceCapabilities;
   readonly ackDeadlineMs = 3000;
+  supportsIntelligenceMemory?: boolean;
+  runAgentLifecycle?: PlatformAdapter["runAgentLifecycle"];
 
   /** When true, `start()` rejects (set via constructor `failStart`). */
   readonly failStart: boolean;
@@ -185,7 +214,7 @@ export class FakeAdapter implements PlatformAdapter {
   /** History returned by getMessages(); override in tests. */
   messages: ThreadMessage[] = [];
   /** User returned by lookupUser(); override in tests. */
-  user?: PlatformUser;
+  user?: ProviderActor;
   /** Optional persistence backend the adapter provides (test-only); exercises createChannel's store resolution. */
   stateStore?: StateStore;
   private sink?: IngressSink;
@@ -193,13 +222,7 @@ export class FakeAdapter implements PlatformAdapter {
   private turnCounter = 0;
 
   /** Expose the registered sink so tests can invoke onTurn() directly for overlap/lock tests. */
-  getSink(): Omit<IngressSink, "onTurn"> & {
-    onTurn(
-      turn: Omit<IncomingTurn, "operation"> & {
-        operation?: IncomingTurn["operation"];
-      },
-    ): void | Promise<void>;
-  } {
+  getSink(): FakeIngressSink {
     if (!this.sink)
       throw new Error(
         "FakeAdapter: sink not set — start the channel (channel.ɵruntime.start()) first",
@@ -208,33 +231,71 @@ export class FakeAdapter implements PlatformAdapter {
     const adapter = this;
     return new Proxy(sink, {
       get(target, property, receiver) {
-        if (property !== "onTurn") {
-          return Reflect.get(target, property, receiver);
+        if (property === "onTurn") {
+          return (turn: Parameters<FakeIngressSink["onTurn"]>[0]) => {
+            const syntheticId =
+              turn.eventId ?? `fake-message-${++adapter.turnCounter}`;
+            return sink.onTurn(
+              adapter.withIdentity(
+                {
+                  ...turn,
+                  operation: turn.operation ?? {
+                    kind: "created",
+                    logicalMessageId: syntheticId,
+                    revisionId: syntheticId,
+                    mentioned: true,
+                  },
+                },
+                "message",
+              ) as IncomingTurn,
+            );
+          };
         }
-        return (
-          turn: Omit<IncomingTurn, "operation"> & {
-            operation?: IncomingTurn["operation"];
-          },
-        ) => {
-          const syntheticId =
-            turn.eventId ?? `fake-message-${++adapter.turnCounter}`;
-          return sink.onTurn({
-            ...turn,
-            operation: turn.operation ?? {
-              kind: "created",
-              logicalMessageId: syntheticId,
-              revisionId: syntheticId,
-              mentioned: true,
-            },
-          });
+        const triggers: Partial<Record<keyof IngressSink, string>> = {
+          onInteraction: "interaction",
+          onCommand: "command",
+          onThreadStarted: "thread-start",
+          onWelcome: "welcome",
+          onReaction: "reaction",
+          onModalSubmit: "modal-submit",
+          onModalClose: "modal-close",
         };
+        const trigger = triggers[property as keyof IngressSink];
+        if (trigger) {
+          return (event: Record<string, unknown>) =>
+            (
+              target[property as keyof IngressSink] as (
+                value: unknown,
+              ) => unknown
+            )(adapter.withIdentity(event, trigger));
+        }
+        return Reflect.get(target, property, receiver);
       },
-    }) as Omit<IngressSink, "onTurn"> & {
-      onTurn(
-        turn: Omit<IncomingTurn, "operation"> & {
-          operation?: IncomingTurn["operation"];
-        },
-      ): void | Promise<void>;
+    }) as FakeIngressSink;
+  }
+
+  private withIdentity<T extends Record<string, unknown>>(
+    event: T,
+    trigger: string,
+  ): T & Pick<IncomingTurn, "actor" | "identityContext"> {
+    const conversationKey =
+      typeof event.conversationKey === "string" ? event.conversationKey : "c";
+    const actor =
+      (event.actor as IncomingTurn["actor"] | undefined) ??
+      ({ id: "", kind: "unknown" } as const);
+    return {
+      ...event,
+      actor,
+      identityContext: (event.identityContext as
+        | IncomingTurn["identityContext"]
+        | undefined) ?? {
+        tenant: { id: "fake-tenant" },
+        installation: { id: "fake-installation" },
+        conversation: { id: conversationKey, kind: "test" },
+        trigger,
+        event: {},
+        raw: {},
+      },
     };
   }
 
@@ -276,7 +337,7 @@ export class FakeAdapter implements PlatformAdapter {
   decodeInteraction(raw: unknown): InteractionEvent | undefined {
     return raw as InteractionEvent;
   }
-  async lookupUser(_q: UserQuery): Promise<PlatformUser | undefined> {
+  async lookupUser(_q: UserQuery): Promise<ProviderActor | undefined> {
     return this.user;
   }
   async getMessages(_target: ReplyTarget): Promise<ThreadMessage[]> {
@@ -317,7 +378,7 @@ export class FakeAdapter implements PlatformAdapter {
   // --- test helpers ---
   emitTurn(partial: Partial<IncomingTurn>): void {
     const syntheticId = partial.eventId ?? `fake-message-${++this.turnCounter}`;
-    void this.sink?.onTurn({
+    void this.getSink().onTurn({
       conversationKey: "c",
       replyTarget: {},
       userText: "",
@@ -334,7 +395,7 @@ export class FakeAdapter implements PlatformAdapter {
   emitThreadStarted(
     partial?: Partial<IncomingThreadStart>,
   ): Promise<void> | void {
-    return this.sink?.onThreadStarted({
+    return this.getSink().onThreadStarted({
       conversationKey: "c",
       replyTarget: {},
       platform: "fake",
@@ -342,27 +403,34 @@ export class FakeAdapter implements PlatformAdapter {
     });
   }
   emitWelcome(partial?: Partial<IncomingWelcome>): Promise<void> | void {
-    return this.sink?.onWelcome({
-      conversationKey: "c",
-      replyTarget: {},
-      platform: "fake",
-      ...partial,
-    });
+    return this.getSink().onWelcome(
+      this.withIdentity(
+        {
+          conversationKey: "c",
+          replyTarget: {},
+          platform: "fake",
+          ...partial,
+        },
+        "welcome",
+      ) as IncomingWelcome,
+    );
   }
   emitInteraction(partial: Partial<InteractionEvent>): void {
-    const evt: InteractionEvent = {
+    const evt = {
       id: "",
       conversationKey: "c",
       replyTarget: {},
       ...partial,
     };
-    this.interactionsSeen.push(evt);
-    void this.sink?.onInteraction(evt);
+    this.interactionsSeen.push(
+      this.withIdentity(evt, "interaction") as InteractionEvent,
+    );
+    void this.getSink().onInteraction(evt);
   }
   emitCommand(
     partial: Partial<IncomingCommand> & { command: string },
   ): Promise<void> | void {
-    return this.sink?.onCommand({
+    return this.getSink().onCommand({
       text: "",
       conversationKey: "c",
       replyTarget: {},
@@ -373,7 +441,7 @@ export class FakeAdapter implements PlatformAdapter {
   emitReaction(
     partial: Partial<IncomingReaction> & { rawEmoji: string },
   ): Promise<void> | void {
-    return this.sink?.onReaction({
+    return this.getSink().onReaction({
       added: true,
       conversationKey: "c",
       replyTarget: {},
@@ -385,7 +453,7 @@ export class FakeAdapter implements PlatformAdapter {
   emitModalSubmit(
     partial: Partial<IncomingModalSubmit> & { callbackId: string },
   ): Promise<ModalSubmitResult | void> | undefined {
-    return this.sink?.onModalSubmit({
+    return this.getSink().onModalSubmit({
       values: {},
       platform: "fake",
       raw: {},
@@ -395,7 +463,11 @@ export class FakeAdapter implements PlatformAdapter {
   emitModalClose(
     partial: Partial<IncomingModalClose> & { callbackId: string },
   ): Promise<void> | void {
-    return this.sink?.onModalClose({ platform: "fake", raw: {}, ...partial });
+    return this.getSink().onModalClose({
+      platform: "fake",
+      raw: {},
+      ...partial,
+    });
   }
 
   /** Commands handed to the adapter via `registerCommands`; asserts the capability hook fires. */

--- a/packages/channels-core/src/testing/state-store-conformance.ts
+++ b/packages/channels-core/src/testing/state-store-conformance.ts
@@ -25,10 +25,26 @@ export function runStateStoreConformance(
       });
       it("missing key is undefined", async () =>
         expect(await s.kv.get("nope")).toBeUndefined());
+      it("atomically consumes one live value", async () => {
+        await s.kv.set("once", { n: 1 });
+        const results = await Promise.all([
+          s.kv.consume<{ n: number }>("once"),
+          s.kv.consume<{ n: number }>("once"),
+        ]);
+        expect(results.filter((value) => value !== undefined)).toEqual([
+          { n: 1 },
+        ]);
+        expect(await s.kv.get("once")).toBeUndefined();
+      });
       it("expires after ttl", async () => {
         await s.kv.set("t", 1, 30);
         await new Promise((r) => setTimeout(r, 60));
         expect(await s.kv.get("t")).toBeUndefined();
+      });
+      it("does not return an expired value from consume", async () => {
+        await s.kv.set("expired-once", 1, 30);
+        await new Promise((r) => setTimeout(r, 60));
+        expect(await s.kv.consume("expired-once")).toBeUndefined();
       });
     });
 

--- a/packages/channels-core/src/thread-capabilities.test.ts
+++ b/packages/channels-core/src/thread-capabilities.test.ts
@@ -5,20 +5,31 @@ import { FakeAdapter } from "./testing/fake-adapter.js";
 describe("onThreadStarted routing", () => {
   it("invokes registered handlers with the thread and user", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
-    const seen: { user?: string; platform: string }[] = [];
-    channel.onThreadStarted(({ thread, user }) => {
-      seen.push({ user: user?.id, platform: thread.platform });
+    const channel = createChannel({
+      adapters: [fake],
+      identifyUser: ({ actor }) => ({
+        id: actor.id,
+        name: actor.name ?? actor.id,
+      }),
+    });
+    const seen: { user?: string; actor: string; platform: string }[] = [];
+    channel.onThreadStarted(({ thread, user, actor }) => {
+      seen.push({ user: user?.id, actor: actor.id, platform: thread.platform });
     });
     await channel.ɵruntime.start();
 
-    await fake.emitThreadStarted({ user: { id: "U1", name: "Ada" } });
-    expect(seen).toEqual([{ user: "U1", platform: "fake" }]);
+    await fake.emitThreadStarted({
+      actor: { id: "U1", kind: "human", name: "Ada" },
+    });
+    expect(seen).toEqual([{ user: "U1", actor: "U1", platform: "fake" }]);
   });
 
   it("invokes every registered handler in order", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     const order: number[] = [];
     channel.onThreadStarted(() => {
       order.push(1);
@@ -33,7 +44,10 @@ describe("onThreadStarted routing", () => {
 
   it("is a no-op when no handler is registered", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     await channel.ɵruntime.start();
     // Should not throw.
     await expect(
@@ -45,7 +59,10 @@ describe("onThreadStarted routing", () => {
 describe("Thread.setSuggestedPrompts / setTitle capability gating", () => {
   it("delegates to the adapter when supported", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     const results: { ok: boolean; error?: string }[] = [];
     channel.onThreadStarted(async ({ thread }) => {
       results.push(
@@ -73,7 +90,10 @@ describe("Thread.setSuggestedPrompts / setTitle capability gating", () => {
 
   it("returns { ok: false } without throwing when unsupported", async () => {
     const fake = new FakeAdapter({ paneMethods: false });
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     const results: { ok: boolean; error?: string }[] = [];
     channel.onThreadStarted(async ({ thread }) => {
       results.push(await thread.setSuggestedPrompts([]));

--- a/packages/channels-core/src/thread-ephemeral.test.ts
+++ b/packages/channels-core/src/thread-ephemeral.test.ts
@@ -6,10 +6,13 @@ async function runOnMessage(
   fake: FakeAdapter,
   fn: Parameters<ReturnType<typeof createChannel>["onMessage"]>[0],
 ) {
-  const channel = createChannel({ adapters: [fake] });
+  const channel = createChannel({ identifyUser: "platform", adapters: [fake] });
   channel.onMessage(fn);
   await channel.ɵruntime.start();
-  fake.emitTurn({ userText: "hi", user: { id: "U1" } });
+  fake.emitTurn({
+    userText: "hi",
+    actor: { id: "U1", kind: "human" },
+  });
   await new Promise((r) => setTimeout(r, 0));
 }
 
@@ -18,7 +21,7 @@ describe("Thread.postEphemeral", () => {
     const fake = new FakeAdapter({ nativeEphemeral: true });
     let res: unknown;
     await runOnMessage(fake, async ({ thread, message }) => {
-      res = await thread.postEphemeral(message.user, "psst", {
+      res = await thread.postEphemeral(message.actor, "psst", {
         fallbackToDM: false,
       });
     });
@@ -32,7 +35,7 @@ describe("Thread.postEphemeral", () => {
     const fake = new FakeAdapter({ nativeEphemeral: false });
     let res: unknown;
     await runOnMessage(fake, async ({ thread, message }) => {
-      res = await thread.postEphemeral(message.user, "psst", {
+      res = await thread.postEphemeral(message.actor, "psst", {
         fallbackToDM: true,
       });
     });
@@ -43,7 +46,7 @@ describe("Thread.postEphemeral", () => {
     const fake = new FakeAdapter({ nativeEphemeral: false });
     let res: unknown = "sentinel";
     await runOnMessage(fake, async ({ thread, message }) => {
-      res = await thread.postEphemeral(message.user, "psst", {
+      res = await thread.postEphemeral(message.actor, "psst", {
         fallbackToDM: false,
       });
     });

--- a/packages/channels-core/src/thread-promise-contract.test.ts
+++ b/packages/channels-core/src/thread-promise-contract.test.ts
@@ -15,6 +15,8 @@ function setupThreadWithSyncDeleteFailure(failure: Error): Thread {
     adapter,
     replyTarget: {},
     conversationKey: "thread-promise-contract",
+    channelName: "test",
+    threadId: "thread-promise-contract",
     registry: new ActionRegistry({ store: new InMemoryActionStore() }),
     agentFactory: (threadId) => {
       throw new Error(`agentFactory not needed in this test: ${threadId}`);
@@ -25,6 +27,8 @@ function setupThreadWithSyncDeleteFailure(failure: Error): Thread {
     registerWaiter: () => undefined,
     interruptHandlers: new Map(),
     state: new MemoryStore(),
+    user: null,
+    actor: { id: "actor", kind: "unknown" },
   };
   return new Thread(deps);
 }

--- a/packages/channels-core/src/thread-reactions.test.ts
+++ b/packages/channels-core/src/thread-reactions.test.ts
@@ -6,7 +6,10 @@ import { FakeAdapter } from "./testing/fake-adapter.js";
 describe("Thread.react / unreact", () => {
   it("delegates to the adapter when supported", async () => {
     const fake = new FakeAdapter();
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     const results: { ok: boolean }[] = [];
     channel.onMessage(async ({ thread, message }) => {
       results.push(await thread.react(message.ref, emoji.thumbs_up));
@@ -27,7 +30,10 @@ describe("Thread.react / unreact", () => {
 
   it("returns { ok: false } without throwing when unsupported", async () => {
     const fake = new FakeAdapter({ reactions: false });
-    const channel = createChannel({ adapters: [fake] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+    });
     let res: { ok: boolean; error?: string } | undefined;
     channel.onMessage(async ({ thread, message }) => {
       res = await thread.react(message.ref, emoji.heart);

--- a/packages/channels-core/src/thread.test.ts
+++ b/packages/channels-core/src/thread.test.ts
@@ -16,6 +16,8 @@ function makeTestThread(overrides: {
     adapter,
     replyTarget: {},
     conversationKey: overrides.conversationKey ?? "c1",
+    channelName: "test",
+    threadId: overrides.conversationKey ?? "c1",
     registry,
     agentFactory: (id) => {
       throw new Error(`agentFactory not needed in this test: ${id}`);
@@ -26,6 +28,8 @@ function makeTestThread(overrides: {
     registerWaiter: () => {},
     interruptHandlers: new Map(),
     state: overrides.state,
+    user: null,
+    actor: { id: "actor", kind: "unknown" },
   };
   return new Thread(deps);
 }

--- a/packages/channels-core/src/thread.ts
+++ b/packages/channels-core/src/thread.ts
@@ -1,10 +1,15 @@
 import type { PlatformAdapter, ReplyTarget } from "./platform-adapter.js";
 import type { ActionRegistry } from "./action-registry.js";
 import type {
+  ActionContinuationContext,
+  ActionContinuationSnapshot,
+} from "./action-store.js";
+import type {
   AgentContentPart,
   Renderable,
   MessageRef,
-  PlatformUser,
+  ProviderActor,
+  ApplicationUser,
   ThreadMessage,
   IncomingMessage,
   Thread as ThreadInterface,
@@ -26,6 +31,50 @@ import type { AbstractAgent } from "@ag-ui/client";
 import type { StateStore } from "./state/state-store.js";
 import { validateSchema } from "./standard-schema.js";
 import type { StandardSchemaV1 } from "./standard-schema.js";
+import { hasMemoryAccess, resolveMemoryGrant } from "./memory.js";
+import type { MemoryGrant, ResolvedChannelMemory } from "./memory.js";
+
+/** A Channel run requested Memory without an attached Intelligence backend. */
+export class ChannelMemoryUnavailableError extends Error {
+  readonly code = "channel_memory_unavailable";
+
+  constructor() {
+    super("Channel Memory requires an attached Intelligence Runtime");
+    this.name = "ChannelMemoryUnavailableError";
+  }
+}
+
+/** A Channel run requested personal Memory without an application user. */
+export class ChannelMemoryUserRequiredError extends Error {
+  readonly code = "channel_memory_user_required";
+
+  constructor() {
+    super("Channel user Memory requires an identified application user");
+    this.name = "ChannelMemoryUserRequiredError";
+  }
+}
+
+/** A personal-Memory resume omitted the trusted principal selector. */
+export class ChannelMemorySubjectRequiredError extends Error {
+  readonly code = "channel_memory_subject_required";
+
+  constructor() {
+    super(
+      'Channel user Memory on resume requires subject "initiator" or "actor"',
+    );
+    this.name = "ChannelMemorySubjectRequiredError";
+  }
+}
+
+/** A resume was not triggered by a persisted one-use action capability. */
+export class ChannelContinuationRequiredError extends Error {
+  readonly code = "channel_continuation_required";
+
+  constructor() {
+    super("Channel resume requires a valid interaction continuation");
+    this.name = "ChannelContinuationRequiredError";
+  }
+}
 
 export interface ThreadDeps {
   adapter: PlatformAdapter;
@@ -44,7 +93,12 @@ export interface ThreadDeps {
   ) => void;
   interruptHandlers: Map<
     string,
-    (args: { payload: unknown; thread: Thread }) => void | Promise<void>
+    (args: {
+      payload: unknown;
+      thread: Thread;
+      user: ApplicationUser | null;
+      actor: ProviderActor;
+    }) => void | Promise<void>
   >;
   /** Pluggable persistence. Injected by createChannel; always required. */
   state: StateStore;
@@ -55,10 +109,18 @@ export interface ThreadDeps {
   stateSchema?: StandardSchemaV1;
   /** Cross-platform transcript store. Present only when `store.transcripts` is configured. */
   transcripts?: Transcripts;
-  /** Resolved cross-platform identity key for this turn (if any). */
-  userKey?: string;
   /** The inbound message that triggered this turn (for transcript bridging). */
   message?: IncomingMessage;
+  user: ApplicationUser | null;
+  actor: ProviderActor;
+  /** Declared Channel identity bound to one-use continuations. */
+  channelName: string;
+  /** Trusted canonical Thread identity bound to one-use continuations. */
+  threadId: string;
+  /** Action capability that created this interaction Thread. */
+  interactionActionId?: string;
+  /** Set only when the owning Runtime attached Intelligence Memory. */
+  intelligenceMemoryAvailable?: boolean;
   /**
    * Optional anonymous telemetry sink. Structural type (not the concrete
    * ChannelTelemetry) avoids an import cycle; the real ChannelTelemetry satisfies it.
@@ -89,6 +151,8 @@ export class Thread implements ThreadInterface {
   readonly supportsBlockingChoice?: boolean;
   private readonly store: StateStore;
   private implicitInboundConsumed = false;
+  private activeContinuation?: ActionContinuationContext;
+  private agentRunTail: Promise<void> = Promise.resolve();
 
   constructor(private deps: ThreadDeps) {
     this.platform = deps.platform ?? deps.adapter.platform;
@@ -99,7 +163,11 @@ export class Thread implements ThreadInterface {
   }
 
   private async bindForPost(ui: Renderable) {
-    return this.deps.registry.bindRenderable(ui, this.deps.conversationKey);
+    return this.deps.registry.bindRenderable(
+      ui,
+      this.deps.conversationKey,
+      this.activeContinuation,
+    );
   }
 
   private trackOperation<T>(operation: () => Promise<T>): Promise<T> {
@@ -114,6 +182,16 @@ export class Thread implements ThreadInterface {
       this.deps.replyTarget,
       operation,
     );
+  }
+
+  /** Keep one Thread's agent runs isolated while preserving failure independence. */
+  private enqueueAgentRun<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.agentRunTail.then(operation, operation);
+    this.agentRunTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   }
 
   /**
@@ -267,7 +345,7 @@ export class Thread implements ThreadInterface {
    * resolve to `null` when native ephemeral is unsupported.
    */
   postEphemeral(
-    user: PlatformUser | string,
+    user: ProviderActor | string,
     ui: Renderable,
     opts: { fallbackToDM: boolean },
   ): Promise<EphemeralResult | null> {
@@ -345,7 +423,7 @@ export class Thread implements ThreadInterface {
   }
 
   /** Resolve a platform user by free-form query (returns `undefined` when unsupported). */
-  lookupUser(query: string): Promise<PlatformUser | undefined> {
+  lookupUser(query: string): Promise<ProviderActor | undefined> {
     return this.trackOperation(() => this.deps.adapter.lookupUser({ query }));
   }
 
@@ -379,7 +457,7 @@ export class Thread implements ThreadInterface {
     prompt?: string | AgentContentPart[];
     /**
      * Auto-bridge cross-platform transcripts for this run. When truthy AND the
-     * thread has a resolved `userKey` AND a `Transcripts` instance, this:
+     * thread has a resolved `userId` AND a `Transcripts` instance, this:
      *   1. injects prior history (`transcripts.list`, default limit 20) as a
      *      context entry,
      *   2. appends the current user turn,
@@ -390,35 +468,158 @@ export class Thread implements ThreadInterface {
      * No-ops with a one-time warning when identity/transcripts aren't configured.
      */
     transcript?: boolean | { limit?: number };
+    /** Intelligence Memory access for this run only. Omission disables Memory. */
+    memory?: MemoryGrant;
   }): Promise<MessageRef | undefined> {
     try {
       this.deps.adapter.assertRunAgentSupported?.(this.deps.replyTarget);
     } catch (error) {
       return Promise.reject(error);
     }
+    const memoryRequest =
+      input?.memory === undefined
+        ? undefined
+        : { user: input.memory.user, project: input.memory.project };
+    return this.enqueueAgentRun(() =>
+      this.trackOperation(async () => {
+        const memory = this.resolveMemory(memoryRequest, this.deps.user);
+        const message = this.deps.message;
+        const defaultPrompt =
+          message?.contentParts && message.contentParts.length > 0
+            ? message.contentParts
+            : message?.text;
+        const implicitPrompt =
+          input?.prompt === undefined &&
+          !this.deps.adapter.conversationStore.seedsInboundTurn &&
+          (!this.deps.adapter.injectInboundTurnOnce ||
+            !this.implicitInboundConsumed);
+        if (implicitPrompt && defaultPrompt) {
+          this.implicitInboundConsumed = true;
+        }
+        const continuation: ActionContinuationContext = {
+          channelName: this.deps.channelName,
+          conversationKey: this.deps.conversationKey,
+          threadId: this.deps.threadId,
+          runChainId: globalThis.crypto.randomUUID(),
+          initiator: { user: this.deps.user, actor: this.deps.actor },
+        };
+        this.activeContinuation = continuation;
+        try {
+          return await this.run(undefined, {
+            ...input,
+            memory,
+            prompt:
+              input?.prompt ?? (!implicitPrompt ? undefined : defaultPrompt),
+          });
+        } finally {
+          if (this.activeContinuation === continuation) {
+            this.activeContinuation = undefined;
+          }
+        }
+      }),
+    );
+  }
+
+  resume(
+    value: unknown,
+    options?: {
+      memory?: MemoryGrant;
+      subject?: "initiator" | "actor";
+    },
+  ): Promise<MessageRef | undefined> {
+    const memoryRequest =
+      options?.memory === undefined
+        ? undefined
+        : { user: options.memory.user, project: options.memory.project };
+    const subject = options?.subject;
+    const actionId = this.deps.interactionActionId;
+    if (!actionId) {
+      return Promise.reject(new ChannelContinuationRequiredError());
+    }
     return this.trackOperation(async () => {
-      const message = this.deps.message;
-      const defaultPrompt =
-        message?.contentParts && message.contentParts.length > 0
-          ? message.contentParts
-          : message?.text;
-      const implicitPrompt =
-        input?.prompt === undefined &&
-        !this.deps.adapter.conversationStore.seedsInboundTurn &&
-        (!this.deps.adapter.injectInboundTurnOnce ||
-          !this.implicitInboundConsumed);
-      if (implicitPrompt && defaultPrompt) {
-        this.implicitInboundConsumed = true;
+      const binding = {
+        channelName: this.deps.channelName,
+        conversationKey: this.deps.conversationKey,
+        threadId: this.deps.threadId,
+      };
+      const available = await this.deps.registry.getContinuation(
+        actionId,
+        binding,
+      );
+      const memory = this.resolveResumeMemory(
+        memoryRequest === undefined && subject === undefined
+          ? undefined
+          : { memory: memoryRequest, subject },
+        available,
+      );
+      const claimed = await this.deps.registry.claimContinuation(
+        actionId,
+        binding,
+      );
+      const continuation: ActionContinuationContext = {
+        channelName: claimed.channelName,
+        conversationKey: claimed.conversationKey,
+        threadId: claimed.threadId,
+        runChainId: claimed.runChainId,
+        initiator: claimed.initiator,
+      };
+      this.activeContinuation = continuation;
+      try {
+        return await this.run({ resume: value }, { memory });
+      } finally {
+        if (this.activeContinuation === continuation) {
+          this.activeContinuation = undefined;
+        }
       }
-      return this.run(undefined, {
-        ...input,
-        prompt: input?.prompt ?? (!implicitPrompt ? undefined : defaultPrompt),
-      });
     });
   }
 
-  resume(value: unknown): Promise<MessageRef | undefined> {
-    return this.trackOperation(() => this.run({ resume: value }));
+  private resolveResumeMemory(
+    options:
+      | { memory?: MemoryGrant; subject?: "initiator" | "actor" }
+      | undefined,
+    continuation: ActionContinuationSnapshot,
+  ): ResolvedChannelMemory | undefined {
+    if (options?.memory === undefined) return undefined;
+    const grant = resolveMemoryGrant(options.memory);
+    if (!hasMemoryAccess(grant)) return undefined;
+    let user: ApplicationUser | null = null;
+    if (grant.user !== "none") {
+      if (!options.subject) throw new ChannelMemorySubjectRequiredError();
+      user =
+        options.subject === "initiator"
+          ? continuation.initiator.user
+          : this.deps.user;
+      if (user === null) throw new ChannelMemoryUserRequiredError();
+    }
+    this.assertMemoryAvailable();
+    return Object.freeze({ grant, user });
+  }
+
+  private resolveMemory(
+    requested: MemoryGrant | undefined,
+    user: ApplicationUser | null,
+  ): ResolvedChannelMemory | undefined {
+    if (requested === undefined) return undefined;
+    const grant = resolveMemoryGrant(requested);
+    if (!hasMemoryAccess(grant)) return undefined;
+    if (grant.user !== "none" && user === null) {
+      throw new ChannelMemoryUserRequiredError();
+    }
+    this.assertMemoryAvailable();
+    return Object.freeze({
+      grant,
+      user: grant.user === "none" ? null : user,
+    });
+  }
+
+  private assertMemoryAvailable(): void {
+    if (
+      this.deps.intelligenceMemoryAvailable !== true &&
+      this.deps.adapter.supportsIntelligenceMemory !== true
+    ) {
+      throw new ChannelMemoryUnavailableError();
+    }
   }
 
   private async run(
@@ -428,6 +629,7 @@ export class Thread implements ThreadInterface {
       tools?: ChannelTool[];
       prompt?: string | AgentContentPart[];
       transcript?: boolean | { limit?: number };
+      memory?: ResolvedChannelMemory;
     },
   ): Promise<MessageRef | undefined> {
     const session = await this.deps.adapter.conversationStore.getOrCreate(
@@ -464,17 +666,17 @@ export class Thread implements ThreadInterface {
       // bridge — see `runAgent`'s `transcript` doc. No-ops with one warning when
       // identity/transcripts aren't configured.
       const transcripts = this.deps.transcripts;
-      const userKey = this.deps.userKey;
+      const userId = this.deps.user?.id;
       let transcriptContext: ContextEntry | undefined;
       if (extra?.transcript) {
-        if (transcripts && userKey) {
+        if (transcripts && userId) {
           const limit =
             typeof extra.transcript === "object"
               ? (extra.transcript.limit ?? 20)
               : 20;
           // List BEFORE appending the current user turn so the current message
           // isn't counted as its own "prior history".
-          const prior = await transcripts.list({ userKey, limit });
+          const prior = await transcripts.list({ userId, limit });
           if (prior.length > 0) {
             transcriptContext = {
               description: `Prior cross-platform conversation history with this user. Current channel: ${this.platform}.`,
@@ -484,7 +686,7 @@ export class Thread implements ThreadInterface {
             };
           }
           if (this.deps.message) {
-            await transcripts.append(this, this.deps.message, { userKey });
+            await transcripts.append(this, this.deps.message, { userId });
           }
         } else {
           warnTranscriptIgnored();
@@ -529,11 +731,20 @@ export class Thread implements ThreadInterface {
           context,
           makeToolCtx: (): ChannelToolContext => ({
             thread: this,
+            message: this.deps.message,
+            user: this.deps.user,
+            actor: this.deps.actor,
             platform: this.platform,
           }),
           handleInterrupt: async (interrupt) => {
             const h = this.deps.interruptHandlers.get(interrupt.eventName);
-            if (h) await h({ payload: interrupt.value, thread: this });
+            if (h)
+              await h({
+                payload: interrupt.value,
+                thread: this,
+                user: this.deps.user,
+                actor: this.deps.actor,
+              });
           },
           initialResume,
         };
@@ -545,6 +756,7 @@ export class Thread implements ThreadInterface {
               tools: toolDescriptors,
               context,
               isResume: initialResume !== undefined,
+              memory: extra?.memory,
               execute: (subscriber, canonicalRun) =>
                 runAgentLoop({
                   ...loopArgs,
@@ -556,8 +768,8 @@ export class Thread implements ThreadInterface {
         stage = "finalize";
         // Transcript auto-bridge (step 4): capture the assistant text this run
         // produced and append it. Only when the bridge actually applied (transcripts
-        // + userKey both present and `transcript` was requested).
-        if (extra?.transcript && transcripts && userKey) {
+        // + userId both present and `transcript` was requested).
+        if (extra?.transcript && transcripts && userId) {
           const produced = session.agent.messages.slice(messagesBefore);
           const text = produced
             .filter(
@@ -572,7 +784,7 @@ export class Thread implements ThreadInterface {
             await transcripts.append(
               this,
               { role: "assistant", text },
-              { userKey },
+              { userId },
             );
           }
         }
@@ -635,6 +847,6 @@ function warnTranscriptIgnored(): void {
   if (transcriptWarned) return;
   transcriptWarned = true;
   console.warn(
-    "[channel] runAgent({ transcript }) ignored — configure store.identity + store.transcripts so a userKey resolves",
+    "[channel] runAgent({ transcript }) ignored — configure store.transcripts and identify the current application user",
   );
 }

--- a/packages/channels-core/src/tools.ts
+++ b/packages/channels-core/src/tools.ts
@@ -3,7 +3,8 @@ import { toJsonSchema, validateSchema } from "./standard-schema.js";
 import type {
   Thread,
   IncomingMessage,
-  PlatformUser,
+  ApplicationUser,
+  ProviderActor,
 } from "@copilotkit/channels-ui";
 
 export type { ObjectSchema } from "./standard-schema.js";
@@ -11,7 +12,8 @@ export type { ObjectSchema } from "./standard-schema.js";
 export interface ChannelToolContext {
   thread: Thread;
   message?: IncomingMessage;
-  user?: PlatformUser;
+  user: ApplicationUser | null;
+  actor: ProviderActor;
   signal?: AbortSignal;
   platform: string;
 }
@@ -45,7 +47,8 @@ export type ChannelTool<Schema extends ObjectSchema = ObjectSchema> = {
 /**
  * Define a {@link ChannelTool} with full type inference. The handler's `args` are
  * inferred from `parameters`, and `ctx` is the generic {@link ChannelToolContext}
- * ({@link Thread} + optional message/user/signal + platform). Reach for
+ * ({@link Thread} + optional message/signal + application user + provider actor
+ * + platform). Reach for
  * platform power via capability-gated `thread` methods (e.g.
  * `thread.getMessages()`, `thread.lookupUser(query)`).
  *

--- a/packages/channels-core/src/transcripts.test.ts
+++ b/packages/channels-core/src/transcripts.test.ts
@@ -11,59 +11,54 @@ const thread: Pick<Thread, "platform"> & { conversationKey: string } = {
 describe("Transcripts", () => {
   it("appends and lists oldest-first, filters compose", async () => {
     const t = new Transcripts(new MemoryStore(), { maxPerUser: 100 });
-    await t.append(
-      thread,
-      { role: "user", text: "hi" },
-      { userKey: "u@x.com" },
-    );
+    await t.append(thread, { role: "user", text: "hi" }, { userId: "u@x.com" });
     await t.append(
       thread,
       { role: "assistant", text: "hello" },
-      { userKey: "u@x.com" },
+      { userId: "u@x.com" },
     );
-    const all = await t.list({ userKey: "u@x.com" });
+    const all = await t.list({ userId: "u@x.com" });
     expect(all.map((e) => e.role)).toEqual(["user", "assistant"]);
-    expect(await t.list({ userKey: "u@x.com", roles: ["user"] })).toHaveLength(
+    expect(await t.list({ userId: "u@x.com", roles: ["user"] })).toHaveLength(
       1,
     );
   });
   it("delete wipes and reports count", async () => {
     const t = new Transcripts(new MemoryStore());
-    await t.append(thread, { role: "user", text: "x" }, { userKey: "k" });
-    expect(await t.delete({ userKey: "k" })).toEqual({ deleted: 1 });
-    expect(await t.list({ userKey: "k" })).toEqual([]);
+    await t.append(thread, { role: "user", text: "x" }, { userId: "k" });
+    expect(await t.delete({ userId: "k" })).toEqual({ deleted: 1 });
+    expect(await t.list({ userId: "k" })).toEqual([]);
   });
 
   it("TTL expiry: entries not visible after retention window", async () => {
     const t = new Transcripts(new MemoryStore(), { retention: "30ms" });
-    await t.append(thread, { role: "user", text: "hi" }, { userKey: "u" });
+    await t.append(thread, { role: "user", text: "hi" }, { userId: "u" });
     await new Promise((r) => setTimeout(r, 60));
-    expect(await t.list({ userKey: "u" })).toEqual([]);
+    expect(await t.list({ userId: "u" })).toEqual([]);
   });
 
   it("maxPerUser: only newest N entries are kept", async () => {
     const t = new Transcripts(new MemoryStore(), { maxPerUser: 2 });
-    await t.append(thread, { role: "user", text: "1" }, { userKey: "u" });
-    await t.append(thread, { role: "user", text: "2" }, { userKey: "u" });
-    await t.append(thread, { role: "user", text: "3" }, { userKey: "u" });
-    const entries = await t.list({ userKey: "u" });
+    await t.append(thread, { role: "user", text: "1" }, { userId: "u" });
+    await t.append(thread, { role: "user", text: "2" }, { userId: "u" });
+    await t.append(thread, { role: "user", text: "3" }, { userId: "u" });
+    const entries = await t.list({ userId: "u" });
     expect(entries).toHaveLength(2);
     expect(entries.map((e) => e.text)).toEqual(["2", "3"]);
   });
 
-  it("no userKey resolved: no-op, list returns empty for any key", async () => {
+  it("no userId resolved: no-op, list returns empty for any key", async () => {
     const t = new Transcripts(new MemoryStore());
-    // neither opts.userKey nor msg.userKey is set
-    await t.append(thread, { role: "user", text: "ghost" });
-    expect(await t.list({ userKey: "anyone" })).toEqual([]);
+    await t.append(thread, { role: "user", text: "ghost" }, { userId: null });
+    expect(await t.list({ userId: "anyone" })).toEqual([]);
   });
 
   it("list with limit: returns only the last N entries", async () => {
     const t = new Transcripts(new MemoryStore());
-    await t.append(thread, { role: "user", text: "a" }, { userKey: "u" });
-    await t.append(thread, { role: "user", text: "b" }, { userKey: "u" });
-    await t.append(thread, { role: "user", text: "c" }, { userKey: "u" });
-    const last = await t.list({ userKey: "u", limit: 1 });
+    await t.append(thread, { role: "user", text: "a" }, { userId: "u" });
+    await t.append(thread, { role: "user", text: "b" }, { userId: "u" });
+    await t.append(thread, { role: "user", text: "c" }, { userId: "u" });
+    const last = await t.list({ userId: "u", limit: 1 });
     expect(last).toHaveLength(1);
     expect(last[0]!.text).toBe("c");
   });
@@ -81,9 +76,9 @@ describe("Transcripts retention", () => {
     const t = new Transcripts(store, { retention: "1h" });
     vi.useFakeTimers();
     try {
-      await t.append(thread, { role: "user", text: "old" }, { userKey: "u" });
+      await t.append(thread, { role: "user", text: "old" }, { userId: "u" });
       vi.advanceTimersByTime(2 * 60 * 60 * 1000); // advance 2h
-      expect(await t.list({ userKey: "u" })).toEqual([]);
+      expect(await t.list({ userId: "u" })).toEqual([]);
     } finally {
       vi.useRealTimers();
     }
@@ -99,11 +94,11 @@ describe("Transcripts retention", () => {
     const t = new Transcripts(store, { retention: "1h" });
     vi.useFakeTimers();
     try {
-      await t.append(thread, { role: "user", text: "A" }, { userKey: "u" });
+      await t.append(thread, { role: "user", text: "A" }, { userId: "u" });
       vi.advanceTimersByTime(50 * 60 * 1000); // +50m: A still within window, key TTL refreshed to +110m
-      await t.append(thread, { role: "user", text: "B" }, { userKey: "u" });
+      await t.append(thread, { role: "user", text: "B" }, { userId: "u" });
       vi.advanceTimersByTime(50 * 60 * 1000); // +100m: key still live (expires +110m), but A is now 100m old
-      await t.append(thread, { role: "user", text: "C" }, { userKey: "u" });
+      await t.append(thread, { role: "user", text: "C" }, { userId: "u" });
       const raw = await store.list.range<{ text: string }>("transcript:user:u");
       expect(raw.map((e) => e.text)).toEqual(["B", "C"]); // A pruned by age, not whole-key expiry
     } finally {
@@ -116,10 +111,10 @@ describe("Transcripts retention", () => {
     const t = new Transcripts(store, { retention: "1h" });
     vi.useFakeTimers();
     try {
-      await t.append(thread, { role: "user", text: "A" }, { userKey: "u" });
+      await t.append(thread, { role: "user", text: "A" }, { userId: "u" });
       vi.advanceTimersByTime(30 * 60 * 1000); // advance 30m — A still within 1h
-      await t.append(thread, { role: "user", text: "B" }, { userKey: "u" });
-      const entries = await t.list({ userKey: "u" });
+      await t.append(thread, { role: "user", text: "B" }, { userId: "u" });
+      const entries = await t.list({ userId: "u" });
       expect(entries).toHaveLength(2);
     } finally {
       vi.useRealTimers();

--- a/packages/channels-core/src/transcripts.ts
+++ b/packages/channels-core/src/transcripts.ts
@@ -1,28 +1,21 @@
 import type { StateStore } from "./state/state-store.js";
 import { parseDuration } from "./state/duration.js";
-import type { PlatformUser, IncomingMessage } from "@copilotkit/channels-ui";
 
 export interface TranscriptEntry {
   role: "user" | "assistant";
   text: string;
   platform: string;
   threadId: string;
-  userKey: string;
+  userId: string;
   ts: number;
 }
-
-export type Identity = (ctx: {
-  adapter: string;
-  author: PlatformUser;
-  message: IncomingMessage;
-}) => string | null | Promise<string | null>;
 
 export interface TranscriptsConfig {
   retention?: string | number;
   maxPerUser?: number;
 }
 
-const keyFor = (userKey: string) => `transcript:user:${userKey}`;
+const keyFor = (userId: string) => `transcript:user:${userId}`;
 
 export class Transcripts {
   private readonly retentionMs: number | undefined;
@@ -37,47 +30,47 @@ export class Transcripts {
 
   /**
    * Append a message to the user's transcript.
-   * No-ops silently when no `userKey` is resolved (from `opts.userKey` or `msg.userKey`).
+   * No-ops silently when no canonical application user ID is supplied.
    */
   async append(
     thread: { platform: string; conversationKey: string },
-    msg: { role?: "user" | "assistant"; text: string; userKey?: string },
-    opts?: { userKey?: string },
+    msg: { role?: "user" | "assistant"; text: string },
+    opts: { userId: string | null },
   ): Promise<void> {
-    const userKey = opts?.userKey ?? msg.userKey;
-    if (!userKey) return; // identity unresolved → no-op
+    const userId = opts.userId;
+    if (!userId) return; // identity unresolved → no-op
     const entry: TranscriptEntry = {
       role: msg.role ?? "user",
       text: msg.text,
       platform: thread.platform,
       threadId: thread.conversationKey,
-      userKey,
+      userId,
       ts: Date.now(),
     };
-    await this.state.list.append(keyFor(userKey), entry, {
+    await this.state.list.append(keyFor(userId), entry, {
       maxLen: this.cfg.maxPerUser,
       ttlMs: this.retentionMs,
     });
     if (this.retentionMs !== undefined) {
       const cutoff = Date.now() - this.retentionMs;
-      const all = await this.state.list.range<TranscriptEntry>(keyFor(userKey));
+      const all = await this.state.list.range<TranscriptEntry>(keyFor(userId));
       const expired = all.filter((e) => e.ts < cutoff).length;
       if (expired > 0) {
         const survivors = all.length - expired;
-        if (survivors <= 0) await this.state.list.delete(keyFor(userKey));
-        else await this.state.list.trim(keyFor(userKey), survivors);
+        if (survivors <= 0) await this.state.list.delete(keyFor(userId));
+        else await this.state.list.trim(keyFor(userId), survivors);
       }
     }
   }
 
   async list(q: {
-    userKey: string;
+    userId: string;
     limit?: number;
     platforms?: string[];
     threadId?: string;
     roles?: ("user" | "assistant")[];
   }): Promise<TranscriptEntry[]> {
-    let items = await this.state.list.range<TranscriptEntry>(keyFor(q.userKey));
+    let items = await this.state.list.range<TranscriptEntry>(keyFor(q.userId));
     if (this.retentionMs !== undefined) {
       const cutoff = Date.now() - this.retentionMs;
       items = items.filter((e) => e.ts >= cutoff);
@@ -90,9 +83,9 @@ export class Transcripts {
     return items; // oldest-first
   }
 
-  async delete(q: { userKey: string }): Promise<{ deleted: number }> {
-    const n = (await this.state.list.range(keyFor(q.userKey))).length;
-    await this.state.list.delete(keyFor(q.userKey));
+  async delete(q: { userId: string }): Promise<{ deleted: number }> {
+    const n = (await this.state.list.range(keyFor(q.userId))).length;
+    await this.state.list.delete(keyFor(q.userId));
     return { deleted: n };
   }
 }

--- a/packages/channels-core/src/welcome.test.ts
+++ b/packages/channels-core/src/welcome.test.ts
@@ -6,7 +6,10 @@ test("routes a welcome lifecycle event without synthesizing a message turn", asy
   const adapter = new FakeAdapter();
   const onWelcome = vi.fn();
   const onMessage = vi.fn();
-  const channel = createChannel({ adapters: [adapter] });
+  const channel = createChannel({
+    identifyUser: () => ({ id: "app-user-1", name: "Ada App" }),
+    adapters: [adapter],
+  });
   channel.onWelcome(onWelcome);
   channel.onMessage(onMessage);
   await channel.ɵruntime.start();
@@ -15,13 +18,18 @@ test("routes a welcome lifecycle event without synthesizing a message turn", asy
     conversationKey: "teams:tenant:conversation",
     replyTarget: { conversationId: "conversation" },
     platform: "teams",
-    user: { id: "user-1", name: "Ada" },
+    actor: { id: "provider-user-1", kind: "human", name: "Ada Provider" },
   });
 
   expect(onWelcome).toHaveBeenCalledOnce();
   expect(onWelcome).toHaveBeenCalledWith(
     expect.objectContaining({
-      user: { id: "user-1", name: "Ada" },
+      user: { id: "app-user-1", name: "Ada App" },
+      actor: {
+        id: "provider-user-1",
+        kind: "human",
+        name: "Ada Provider",
+      },
       platform: "teams",
     }),
   );
@@ -31,7 +39,10 @@ test("routes a welcome lifecycle event without synthesizing a message turn", asy
 test("exposes submitted input values separately from the action envelope", async () => {
   const adapter = new FakeAdapter();
   const handler = vi.fn();
-  const channel = createChannel({ adapters: [adapter] });
+  const channel = createChannel({
+    identifyUser: "platform",
+    adapters: [adapter],
+  });
   channel.onInteraction("approve", handler);
   await channel.ɵruntime.start();
 

--- a/packages/channels-discord/ARCHITECTURE.md
+++ b/packages/channels-discord/ARCHITECTURE.md
@@ -185,7 +185,7 @@ members become `choices`).
 ### Sender / files
 
 `postFile` sends a file attachment via `channel.send({ files: [...] })`.
-Discord bots cannot read user email addresses; `PlatformUser.email` is
+Discord bots cannot read user email addresses; `ProviderActor.email` is
 always `undefined`.
 
 ## Preserved mechanics

--- a/packages/channels-discord/README.md
+++ b/packages/channels-discord/README.md
@@ -33,6 +33,7 @@ import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
 import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 
 const bot = createChannel({
+  identifyUser: "platform",
   name: "support-bot", // project-unique Intelligence Channel name
   adapters: [
     discord({
@@ -64,7 +65,6 @@ const runtime = new CopilotRuntime({
     // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
-  identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),
   channels: [bot],
 });
 
@@ -239,10 +239,10 @@ The adapter supports both Discord-native capabilities:
 
 ### Sender-profile resolution
 
-The adapter resolves each turn's Discord user id to a `PlatformUser`
-(`{ id, name?, handle? }`), cached per id. Note that Discord bots cannot read
-user email addresses — `PlatformUser.email` is always `undefined` on this
-platform. Inbound file attachments can be downloaded and delivered to the agent
+The adapter resolves each turn's Discord user id to a `ProviderActor`
+(`{ id, kind, name?, handle? }`), cached per id. Discord bots cannot read
+user email addresses, so `ProviderActor.email` stays unset on this platform.
+Inbound file attachments can be downloaded and delivered to the agent
 as multimodal content parts (`buildFileContentParts`); a tool can post a file
 back out via `thread.postFile(...)`.
 
@@ -263,7 +263,7 @@ only through capability-gated `thread` methods, which this adapter backs:
 - `thread.getMessages()` — the current channel's recent messages (via
   `channel.messages.fetch`), each a `ThreadMessage` (`{ user?, text, ts?,
 isBot? }`).
-- `thread.lookupUser(query)` — resolve a name/handle to a `PlatformUser` by
+- `thread.lookupUser(query)` — resolve a name/handle to a `ProviderActor` by
   searching guild members.
 - `thread.postFile({ bytes, filename, title?, altText? })` — upload a file
   into the channel as an attachment.

--- a/packages/channels-discord/src/__tests__/ephemeral.test.ts
+++ b/packages/channels-discord/src/__tests__/ephemeral.test.ts
@@ -22,7 +22,7 @@ it("DM-falls-back when fallbackToDM=true (usedFallback=true)", async () => {
   const { adapter, send } = makeAdapter();
   const res = await adapter.postEphemeral!(
     { channelId: "C1" },
-    { id: "U1" },
+    { id: "U1", kind: "human" },
     [{ type: "text", props: { value: "hi" } }],
     { fallbackToDM: true },
   );
@@ -34,7 +34,7 @@ it("returns null when fallbackToDM=false and no live interaction", async () => {
   const { adapter } = makeAdapter();
   const res = await adapter.postEphemeral!(
     { channelId: "C1" },
-    { id: "U1" },
+    { id: "U1", kind: "human" },
     [{ type: "text", props: { value: "hi" } }],
     { fallbackToDM: false },
   );

--- a/packages/channels-discord/src/__tests__/modal-submit.test.ts
+++ b/packages/channels-discord/src/__tests__/modal-submit.test.ts
@@ -19,7 +19,12 @@ it("decodes a modal submission's text fields by custom_id", () => {
   expect(evt).toMatchObject({
     callbackId: "triage",
     values: { summary: "boom", detail: "ctx" },
-    user: { id: "U1", name: "ada" },
+    actor: { id: "U1", kind: "human", name: "ada" },
+    identityContext: {
+      tenant: { id: "G1" },
+      conversation: { id: "C1", kind: "guild" },
+      trigger: "modal_submit",
+    },
     conversationKey: "C1",
     replyTarget: { channelId: "C1", guildId: "G1" },
     platform: "discord",

--- a/packages/channels-discord/src/__tests__/reactions.test.ts
+++ b/packages/channels-discord/src/__tests__/reactions.test.ts
@@ -15,7 +15,12 @@ it("decodes a unicode reaction add", () => {
   expect(evt).toMatchObject({
     rawEmoji: "👍",
     added: true,
-    user: { id: "U1", name: "ada" },
+    actor: { id: "U1", kind: "human", name: "ada" },
+    identityContext: {
+      tenant: { id: "G1" },
+      conversation: { id: "C1", kind: "guild" },
+      trigger: "reaction",
+    },
     conversationKey: "C1",
     messageId: "m1",
     replyTarget: { channelId: "C1", guildId: "G1" },

--- a/packages/channels-discord/src/adapter.test.ts
+++ b/packages/channels-discord/src/adapter.test.ts
@@ -145,12 +145,17 @@ describe("DiscordAdapter", () => {
     );
 
     const first = await a.resolveUser("u1");
-    expect(first).toEqual({ id: "u1" }); // bare-id fallback
+    expect(first).toEqual({ id: "u1", kind: "unknown" }); // bare-id fallback
 
     const second = await a.resolveUser("u1");
     // A retry happened (not served from cache) and resolved the real user.
     expect(fetch).toHaveBeenCalledTimes(2);
-    expect(second).toEqual({ id: "u1", name: "Ada", handle: "ada" });
+    expect(second).toEqual({
+      id: "u1",
+      kind: "human",
+      name: "Ada",
+      handle: "ada",
+    });
   });
 
   it("getMessages excludes the bot's own streaming placeholders from history", async () => {

--- a/packages/channels-discord/src/adapter.ts
+++ b/packages/channels-discord/src/adapter.ts
@@ -14,10 +14,11 @@ import type {
   ReplyTarget as BotReplyTarget,
   ConversationStore,
   MessageRef,
-  PlatformUser,
+  ProviderActor,
   UserQuery,
   CommandSpec,
   NativePayload,
+  IngressIdentityContext,
 } from "@copilotkit/channels-core";
 import type {
   ChannelNode,
@@ -130,7 +131,7 @@ export class DiscordAdapter implements PlatformAdapter {
   private botUserId = "";
   private isReady = false;
   private pendingCommands: readonly CommandSpec[] = [];
-  private readonly userCache = new Map<string, PlatformUser>();
+  private readonly userCache = new Map<string, ProviderActor>();
   /**
    * Tracks live component interactions so a handler can open a modal (which
    * must be the interaction's INITIAL response, within ~3s) before the adapter
@@ -236,23 +237,32 @@ export class DiscordAdapter implements PlatformAdapter {
           },
           replyTarget: turn.replyTarget,
           userText: turn.userText,
-          user: turn.senderUserId
-            ? await this.resolveUser(turn.senderUserId)
-            : undefined,
+          actor: turn.actor,
+          identityContext: this.identityContext({
+            actor: turn.actor,
+            target: turn.replyTarget,
+            trigger: "message",
+            eventId: turn.messageId,
+            raw: turn.raw,
+          }),
           platform: "discord",
         });
       },
       onCommand: async (cmd) => {
-        const user = cmd.senderUserId
-          ? await this.resolveUser(cmd.senderUserId)
-          : undefined;
         await sink.onCommand({
           command: cmd.command,
           text: cmd.text,
           rawOptions: cmd.rawOptions,
           conversationKey: cmd.conversationKey,
           replyTarget: cmd.replyTarget,
-          user,
+          actor: cmd.actor,
+          identityContext: this.identityContext({
+            actor: cmd.actor,
+            target: cmd.replyTarget,
+            trigger: "command",
+            eventId: cmd.triggerId,
+            raw: cmd.raw,
+          }),
           platform: "discord",
           triggerId: cmd.triggerId,
         });
@@ -410,7 +420,7 @@ export class DiscordAdapter implements PlatformAdapter {
     return decodeInteraction(raw);
   }
 
-  async lookupUser(q: UserQuery): Promise<PlatformUser | undefined> {
+  async lookupUser(q: UserQuery): Promise<ProviderActor | undefined> {
     const query = q.query.trim();
     if (!query) return undefined;
     // Search guild members by username/displayName across cached guilds.
@@ -422,6 +432,7 @@ export class DiscordAdapter implements PlatformAdapter {
           const user = member.user;
           return {
             id: user.id,
+            kind: user.bot ? "bot" : "human",
             name: user.globalName ?? user.username,
             handle: user.username,
           };
@@ -468,6 +479,7 @@ export class DiscordAdapter implements PlatformAdapter {
             user: m.author
               ? {
                   id: m.author.id,
+                  kind: m.author.bot ? "bot" : "human",
                   name: m.author.globalName ?? m.author.username,
                   handle: m.author.username,
                 }
@@ -553,7 +565,7 @@ export class DiscordAdapter implements PlatformAdapter {
 
   async postEphemeral(
     _target: BotReplyTarget,
-    user: PlatformUser | string,
+    user: ProviderActor | string,
     ir: ChannelNode[],
     opts: { fallbackToDM: boolean },
   ): Promise<EphemeralResult | null> {
@@ -618,25 +630,48 @@ export class DiscordAdapter implements PlatformAdapter {
         };
   }
 
-  async resolveUser(userId: string): Promise<PlatformUser> {
+  async resolveUser(userId: string): Promise<ProviderActor> {
     const cached = this.userCache.get(userId);
     if (cached) return cached;
     try {
       const u = await this.client.users.fetch(userId);
-      const user: PlatformUser = {
+      const user: ProviderActor = {
         id: u.id,
+        kind: u.bot ? "bot" : "human",
         name: u.globalName ?? u.username,
         handle: u.username,
       };
-      // Note: bots cannot read user email; PlatformUser.email stays undefined.
+      // Note: bots cannot read user email; ProviderActor.email stays undefined.
       // Cache ONLY on success — a transient fetch failure must not pin the
       // bare-id fallback forever; a later call should retry.
       this.userCache.set(userId, user);
       return user;
     } catch (err) {
       console.error(`[bot-discord] resolveUser fetch failed (${userId}):`, err);
-      return { id: userId }; // bare-id fallback, intentionally not cached
+      return { id: userId, kind: "unknown" }; // bare-id fallback, intentionally not cached
     }
+  }
+
+  private identityContext(input: {
+    actor: ProviderActor;
+    target: ReplyTarget;
+    trigger: string;
+    eventId?: string;
+    raw: unknown;
+  }): IngressIdentityContext {
+    const tenantId = input.target.guildId ?? "direct";
+    return {
+      tenant: { id: tenantId },
+      installation: { id: this.opts.appId },
+      conversation: {
+        id: input.target.channelId,
+        kind: input.target.guildId ? "guild" : "direct",
+      },
+      trigger: input.trigger,
+      event: { id: input.eventId },
+      raw: input.raw,
+      lookupProfile: () => this.resolveUser(input.actor.id),
+    };
   }
 
   private channelIdOf(ref: MessageRef): string {

--- a/packages/channels-discord/src/discord-listener.test.ts
+++ b/packages/channels-discord/src/discord-listener.test.ts
@@ -65,7 +65,12 @@ describe("attachDiscordListener", () => {
         messageId: "m1",
         mentioned: true,
         replyTarget: { channelId: "c1", guildId: "g1" },
-        senderUserId: "u1",
+        actor: {
+          id: "u1",
+          kind: "human",
+          name: "Ann",
+          handle: "ann",
+        },
       }),
     );
   });
@@ -160,7 +165,10 @@ describe("attachDiscordListener", () => {
       }),
     );
     expect(onTurn).toHaveBeenCalledWith(
-      expect.objectContaining({ conversationKey: "c1", senderUserId: "u1" }),
+      expect.objectContaining({
+        conversationKey: "c1",
+        actor: expect.objectContaining({ id: "u1", kind: "human" }),
+      }),
     );
   });
 

--- a/packages/channels-discord/src/discord-listener.ts
+++ b/packages/channels-discord/src/discord-listener.ts
@@ -1,4 +1,5 @@
 import type { IncomingReaction } from "@copilotkit/channels-core";
+import type { ProviderActor } from "@copilotkit/channels-ui";
 import type { IncomingTurn, ReplyTarget } from "./types.js";
 import { decodeReaction } from "./interaction.js";
 import type { PendingInteractions } from "./pending-interactions.js";
@@ -51,7 +52,8 @@ export interface IncomingCommandRaw {
   rawOptions: Record<string, unknown>;
   conversationKey: string;
   replyTarget: ReplyTarget;
-  senderUserId: string;
+  actor: ProviderActor;
+  raw: unknown;
   /** Pending-interaction triggerId (the live interaction id) — backs `openModal`. */
   triggerId?: string;
 }
@@ -96,7 +98,13 @@ export function attachDiscordListener(cfg: ListenerConfig): void {
         mentioned: msg.mentions.has(botId),
         replyTarget,
         userText: stripMention(msg.content, botId),
-        senderUserId: msg.author.id,
+        actor: {
+          id: msg.author.id,
+          kind: msg.author.bot ? "bot" : "human",
+          name: msg.author.globalName ?? msg.author.username,
+          handle: msg.author.username,
+        },
+        raw: msg,
       }),
     ).catch((e) => console.error("[bot-discord] onTurn handler failed:", e));
   });
@@ -123,7 +131,13 @@ export function attachDiscordListener(cfg: ListenerConfig): void {
         rawOptions,
         conversationKey: i.channelId,
         replyTarget,
-        senderUserId: i.user.id,
+        actor: {
+          id: i.user.id,
+          kind: "human",
+          name: i.user.globalName ?? i.user.username,
+          handle: i.user.username,
+        },
+        raw: i,
         triggerId,
       });
     } catch (e) {

--- a/packages/channels-discord/src/interaction.test.ts
+++ b/packages/channels-discord/src/interaction.test.ts
@@ -19,7 +19,12 @@ describe("decodeInteraction", () => {
       id: "ck:abc123",
       conversationKey: "c1",
       replyTarget: { channelId: "c1", guildId: "g1" },
-      user: { id: "u1", name: "Ann", handle: "ann" },
+      actor: { id: "u1", kind: "human", name: "Ann", handle: "ann" },
+      identityContext: {
+        tenant: { id: "g1" },
+        conversation: { id: "c1", kind: "guild" },
+        trigger: "interaction",
+      },
       messageRef: { id: "m1", channelId: "c1" },
     });
   });

--- a/packages/channels-discord/src/interaction.ts
+++ b/packages/channels-discord/src/interaction.ts
@@ -3,7 +3,7 @@ import type {
   IncomingReaction,
   IncomingModalSubmit,
 } from "@copilotkit/channels-core";
-import type { PlatformUser } from "@copilotkit/channels-ui";
+import type { ProviderActor } from "@copilotkit/channels-ui";
 
 /** The structural subset of a discord.js component interaction we read. */
 interface ComponentInteractionLike {
@@ -20,6 +20,7 @@ interface ComponentInteractionLike {
   message?: { id: string };
   channelId?: string;
   guildId?: string | null;
+  applicationId?: string;
   user?: { id: string; username?: string; globalName?: string | null };
 }
 
@@ -33,7 +34,7 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
 
   const customId = i.customId ?? "";
   const channelId = i.channelId ?? "";
-  const user = toUser(i.user);
+  const actor = toUser(i.user);
 
   // A button custom_id may be a handler id ("ck:…"), a packed value
   // ("v:<json>"), or BOTH ("ck:…;v:<json>") when a button carries an onClick AND
@@ -68,7 +69,15 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
     conversationKey: channelId,
     replyTarget: { channelId, ...(i.guildId ? { guildId: i.guildId } : {}) },
     value,
-    user,
+    actor: actor ?? { id: "unknown", kind: "unknown" },
+    identityContext: identityContext({
+      guildId: i.guildId,
+      applicationId: i.applicationId,
+      channelId,
+      trigger: "interaction",
+      eventId: i.message?.id,
+      raw,
+    }),
     messageRef: i.message ? { id: i.message.id, channelId } : undefined,
     // Filled by the adapter from the pending-interaction registry; the bare
     // decode has no live trigger to attach.
@@ -96,9 +105,37 @@ function unpackValue(customId: string): unknown {
   }
 }
 
-function toUser(u: ComponentInteractionLike["user"]): PlatformUser | undefined {
+function toUser(
+  u: ComponentInteractionLike["user"],
+): ProviderActor | undefined {
   if (!u?.id) return undefined;
-  return { id: u.id, name: u.globalName ?? u.username, handle: u.username };
+  return {
+    id: u.id,
+    kind: "human",
+    name: u.globalName ?? u.username,
+    handle: u.username,
+  };
+}
+
+function identityContext(input: {
+  guildId?: string | null;
+  applicationId?: string;
+  channelId?: string;
+  trigger: string;
+  eventId?: string;
+  raw: unknown;
+}) {
+  return {
+    tenant: { id: input.guildId ?? "direct" },
+    installation: { id: input.applicationId ?? "unknown" },
+    conversation: {
+      id: input.channelId ?? "unknown",
+      kind: input.guildId ? "guild" : "direct",
+    },
+    trigger: input.trigger,
+    event: { id: input.eventId },
+    raw: input.raw,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -130,6 +167,8 @@ interface ModalSubmitLike {
   customId?: string;
   channelId?: string;
   guildId?: string | null;
+  applicationId?: string;
+  id?: string;
   user?: { id?: string; username?: string; globalName?: string };
   fields?: { fields?: Map<string, { customId?: string; value?: string }> };
 }
@@ -144,9 +183,21 @@ export function decodeModalSubmit(interaction: unknown): IncomingModalSubmit {
   return {
     callbackId: i.customId ?? "",
     values,
-    user: i.user?.id
-      ? { id: i.user.id, name: i.user.globalName ?? i.user.username }
-      : undefined,
+    actor: i.user?.id
+      ? {
+          id: i.user.id,
+          kind: "human",
+          name: i.user.globalName ?? i.user.username,
+        }
+      : { id: "unknown", kind: "unknown" },
+    identityContext: identityContext({
+      guildId: i.guildId,
+      applicationId: i.applicationId,
+      channelId: i.channelId,
+      trigger: "modal_submit",
+      eventId: i.id,
+      raw: interaction,
+    }),
     conversationKey: i.channelId,
     replyTarget: i.channelId
       ? { channelId: i.channelId, ...(i.guildId ? { guildId: i.guildId } : {}) }
@@ -178,7 +229,20 @@ export function decodeReaction(
   return {
     rawEmoji: token,
     added,
-    user: u.id ? { id: u.id, name: u.globalName ?? u.username } : undefined,
+    actor: u.id
+      ? {
+          id: u.id,
+          kind: u.bot ? "bot" : "human",
+          name: u.globalName ?? u.username,
+        }
+      : { id: "unknown", kind: "unknown" },
+    identityContext: identityContext({
+      guildId: r.message?.guildId,
+      channelId,
+      trigger: "reaction",
+      eventId: messageId,
+      raw: reaction,
+    }),
     conversationKey: channelId,
     replyTarget: {
       channelId,

--- a/packages/channels-discord/src/types.ts
+++ b/packages/channels-discord/src/types.ts
@@ -5,17 +5,19 @@ export interface ReplyTarget {
   guildId?: string;
 }
 
-/** A normalized inbound turn, before the adapter resolves the sender profile. */
+/** A normalized inbound turn with immutable provider identity facts. */
 export interface IncomingTurn {
   conversationKey: string;
   messageId: string;
   mentioned: boolean;
   replyTarget: ReplyTarget;
   userText: string;
-  senderUserId?: string;
+  actor: ProviderActor;
+  raw: unknown;
 }
 
 /** The conversation key is just the channel id (threads have their own id). */
 export function conversationKeyOf(target: ReplyTarget): string {
   return target.channelId;
 }
+import type { ProviderActor } from "@copilotkit/channels-ui";

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -12,7 +12,7 @@ import type {
   ChannelNode,
   EmojiValue,
   MessageRef,
-  PlatformUser,
+  ProviderActor,
   ThreadMessage,
 } from "@copilotkit/channels-ui";
 import { toPlatformEmoji } from "@copilotkit/channels-ui";
@@ -33,6 +33,7 @@ import type {
   SurfaceCapabilities,
   UserQuery,
   ReplyContinuationOptions,
+  ResolvedChannelMemory,
 } from "@copilotkit/channels-core";
 import { ChannelDeliveryTerminatedError } from "@copilotkit/channels-core";
 import {
@@ -99,6 +100,7 @@ export interface CanonicalChannelRunArgs {
   threadId: string;
   runId: string;
   userId: string;
+  memory?: ResolvedChannelMemory;
   agentId: string;
   tools: readonly AgentToolDescriptor[];
   context: readonly ContextEntry[];
@@ -130,6 +132,7 @@ export interface DeliveryAdapterOptions {
 export class DeliveryAdapter implements PlatformAdapter {
   readonly platform = "intelligence";
   readonly __intelligenceChannel = true;
+  readonly supportsIntelligenceMemory = true;
   readonly skipIngressDedup = true;
   readonly injectInboundTurnOnce = true;
   readonly ackDeadlineMs = 0;
@@ -327,6 +330,10 @@ export class DeliveryAdapter implements PlatformAdapter {
     return { ok: true };
   }
 
+  getCanonicalThreadId(targetValue: ReplyTarget): string {
+    return asDeliveryTarget(targetValue).delivery.canonicalThreadId;
+  }
+
   private async dispatch(
     claimedDelivery: ClaimedChannelDelivery,
     delivery: PreparedChannelDelivery,
@@ -334,6 +341,22 @@ export class DeliveryAdapter implements PlatformAdapter {
     const sink = this.sink;
     if (!sink) throw new Error("DeliveryAdapter is not started");
     const replyTarget: DeliveryReplyTarget = { claimedDelivery, delivery };
+    const input = delivery.turn.input;
+    const actor = delivery.turn.actor
+      ? {
+          id: delivery.turn.actor.externalUserId,
+          kind: delivery.turn.actor.kind,
+          ...(delivery.turn.actor.displayName
+            ? { name: delivery.turn.actor.displayName }
+            : {}),
+          ...(delivery.turn.actor.handle
+            ? { handle: delivery.turn.actor.handle }
+            : {}),
+          ...(delivery.turn.actor.email
+            ? { email: delivery.turn.actor.email }
+            : {}),
+        }
+      : { id: "", kind: "unknown" as const };
     const base = {
       conversationKey: delivery.canonicalThreadId,
       replyTarget,
@@ -341,17 +364,22 @@ export class DeliveryAdapter implements PlatformAdapter {
       turnId: `turn_${delivery.deliveryId.slice("dlv_".length)}`,
       deliveryId: delivery.deliveryId,
       platform: delivery.adapter,
-      user: delivery.turn.actor
-        ? {
-            id: delivery.turn.actor.externalUserId,
-            kind: delivery.turn.actor.kind,
-            ...(delivery.turn.actor.displayName
-              ? { name: delivery.turn.actor.displayName }
-              : {}),
-          }
-        : undefined,
+      actor,
+      identityContext: {
+        tenant: delivery.tenant ?? { id: "unknown" },
+        installation: delivery.installation ?? { id: "unknown" },
+        conversation: delivery.conversation ?? {
+          id: delivery.canonicalThreadId,
+          kind: "thread",
+        },
+        trigger: input.kind === "text" ? "message" : input.kind,
+        event: {
+          id: delivery.turn.eventId,
+          occurredAt: delivery.turn.receivedAt,
+        },
+        raw: delivery.turn.raw ?? { kind: delivery.turn.input.kind },
+      },
     };
-    const input = delivery.turn.input;
     switch (input.kind) {
       case "text": {
         const parts = await claimedDelivery.getContentParts(
@@ -454,6 +482,7 @@ export class DeliveryAdapter implements PlatformAdapter {
       threadId,
       runId,
       userId: target.delivery.appUserId,
+      memory: args.memory,
       agentId: this.options.channelName,
       tools: args.tools,
       context: args.context,
@@ -1060,6 +1089,7 @@ export class DeliveryAdapter implements PlatformAdapter {
       isBot: message.role !== "user",
       user: {
         id: message.role === "user" ? "user" : "bot",
+        kind: message.role === "user" ? "human" : "bot",
         name: message.role === "user" ? "user" : "bot",
       },
     }));
@@ -1069,7 +1099,7 @@ export class DeliveryAdapter implements PlatformAdapter {
     return raw as InteractionEvent;
   }
 
-  lookupUser(_query: UserQuery): Promise<PlatformUser | undefined> {
+  lookupUser(_query: UserQuery): Promise<ProviderActor | undefined> {
     return Promise.resolve(undefined);
   }
 }

--- a/packages/channels-intelligence/src/delivery-channel-name.test.ts
+++ b/packages/channels-intelligence/src/delivery-channel-name.test.ts
@@ -46,9 +46,16 @@ test("managed deliveries use the declared Channel name for canonical runs", asyn
       }),
     );
   });
-  const channel = createChannel({ name: "support", agent: () => agent });
+  const channel = createChannel({
+    identifyUser: "platform",
+    name: "support",
+    agent: () => agent,
+  });
   channel.onMessage(async ({ thread, message }) => {
-    await thread.runAgent({ prompt: message.text });
+    await thread.runAgent({
+      prompt: message.text,
+      memory: { user: "read", project: "read-write" },
+    });
   });
   const handle = await startChannelsWithGatewayControl([channel], {
     session: gateway,
@@ -78,6 +85,13 @@ test("managed deliveries use the declared Channel name for canonical runs", asyn
 
     expect(runCanonical).toHaveBeenCalledOnce();
     expect(runCanonical.mock.calls[0]![0].agentId).toBe("support");
+    expect(runCanonical.mock.calls[0]![0].memory).toEqual({
+      grant: { user: "read", project: "read-write" },
+      user: {
+        id: "slack:tenant_channel_name:user_channel_name",
+        name: "Ada",
+      },
+    });
   } finally {
     await handle.stop();
   }

--- a/packages/channels-intelligence/src/delivery-interaction-reference.test.ts
+++ b/packages/channels-intelligence/src/delivery-interaction-reference.test.ts
@@ -10,7 +10,7 @@ import { startChannelsWithGatewayControl } from "./realtime-gateway-launcher.js"
 test("interaction update and delete preserve the opaque provider reference", async () => {
   const providerReference = "pref_v1_opaqueReference_123";
   const gateway = new DeliveryTestGateway();
-  const channel = createChannel({ name: "support" });
+  const channel = createChannel({ identifyUser: "platform", name: "support" });
   channel.onMessage(async () => {});
   channel.onInteraction("approve", async ({ thread, message }) => {
     await thread.update(
@@ -48,7 +48,7 @@ test("interaction update and delete preserve the opaque provider reference", asy
 test("invalid interaction references fail before handler dispatch", async () => {
   const gateway = new DeliveryTestGateway();
   const handler = vi.fn();
-  const channel = createChannel({ name: "support" });
+  const channel = createChannel({ identifyUser: "platform", name: "support" });
   channel.onMessage(async () => {});
   channel.onInteraction("approve", handler);
   const handle = await startChannelsWithGatewayControl([channel], {

--- a/packages/channels-intelligence/src/delivery-source-platform.test.ts
+++ b/packages/channels-intelligence/src/delivery-source-platform.test.ts
@@ -115,7 +115,10 @@ test("delivery handlers receive the source provider", async () => {
 
 test("managed text selects onMention with onMessage fallback", async () => {
   const mentionGateway = new DeliveryTestGateway();
-  const mentionChannel = createChannel({ name: "support" });
+  const mentionChannel = createChannel({
+    identifyUser: "platform",
+    name: "support",
+  });
   const onMention = vi.fn();
   const onMessage = vi.fn();
   mentionChannel.onMention(onMention);
@@ -153,7 +156,10 @@ test("managed text selects onMention with onMessage fallback", async () => {
   }
 
   const fallbackGateway = new DeliveryTestGateway();
-  const fallbackChannel = createChannel({ name: "support" });
+  const fallbackChannel = createChannel({
+    identifyUser: "platform",
+    name: "support",
+  });
   const fallback = vi.fn();
   fallbackChannel.onMessage(fallback);
   const fallbackHandle = await startChannelsWithGatewayControl(

--- a/packages/channels-intelligence/src/delivery-source-platform.test.ts
+++ b/packages/channels-intelligence/src/delivery-source-platform.test.ts
@@ -8,16 +8,18 @@ import { startChannelsWithGatewayControl } from "./realtime-gateway-launcher.js"
 
 test("delivery handlers receive the source provider", async () => {
   const observed: Record<string, string> = {};
-  const identity = vi.fn(() => "person-1");
+  const identifyUser = vi.fn(() => ({ id: "person-1", name: "Ada App" }));
   const gateway = new DeliveryTestGateway();
   const channel = createChannel({
+    identifyUser,
     name: "support",
-    store: { identity, transcripts: {} },
   });
   channel.onMessage(({ message, thread }) => {
     observed.textMessagePlatform = message.platform;
     observed.textMessageRef = message.ref.id;
     observed.textThreadPlatform = thread.platform;
+    observed.applicationUser = message.user?.id ?? "null";
+    observed.providerActor = `${message.actor.kind}:${message.actor.id}`;
   });
   channel.onInteraction("approve", ({ message, platform, thread }) => {
     observed.interactionMessagePlatform = message.platform;
@@ -80,6 +82,8 @@ test("delivery handlers receive the source provider", async () => {
       textMessagePlatform: "slack",
       textMessageRef: "pref_v1_sourcePlatformText_123",
       textThreadPlatform: "slack",
+      applicationUser: "person-1",
+      providerActor: "human:user_text_pad000",
       interactionMessagePlatform: "slack",
       interactionPlatform: "slack",
       interactionThreadPlatform: "slack",
@@ -88,8 +92,21 @@ test("delivery handlers receive the source provider", async () => {
       welcomePlatform: "teams",
       welcomeThreadPlatform: "teams",
     });
-    expect(identity).toHaveBeenCalledWith(
-      expect.objectContaining({ adapter: "slack" }),
+    expect(identifyUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "slack",
+        tenant: { id: "tenant_text_pad000" },
+        installation: { id: "installation_text_pad000" },
+        conversation: {
+          id: "conversation_text_pad000",
+          kind: "thread",
+        },
+        actor: expect.objectContaining({
+          id: "user_text_pad000",
+          kind: "human",
+        }),
+        trigger: "message",
+      }),
     );
   } finally {
     await handle.stop();

--- a/packages/channels-intelligence/src/delivery-test-gateway.ts
+++ b/packages/channels-intelligence/src/delivery-test-gateway.ts
@@ -143,6 +143,9 @@ export function preparedDelivery(
     channelId: "channel_support",
     channelName: "support",
     adapter,
+    tenant: { id: `tenant_${idSuffix}` },
+    installation: { id: `installation_${idSuffix}` },
+    conversation: { id: `conversation_${idSuffix}`, kind: "thread" },
     turn: {
       eventId: `evt_${idSuffix}`,
       receivedAt: "2026-07-29T17:00:00.000Z",
@@ -152,6 +155,7 @@ export function preparedDelivery(
         kind: "human",
         displayName: "Ada",
       },
+      raw: { deliveryKind: input.kind },
     },
   };
 }

--- a/packages/channels-intelligence/src/delivery-transport.ts
+++ b/packages/channels-intelligence/src/delivery-transport.ts
@@ -85,6 +85,9 @@ export interface PreparedChannelDelivery {
   channelId: string;
   channelName: string;
   adapter: ChannelDeliveryAdapter;
+  tenant?: { id: string; name?: string };
+  installation?: { id: string };
+  conversation?: { id: string; kind?: string };
   /** Trusted provider surface used to decide whether a response is expected. */
   surfaceKind?:
     | "direct_message"
@@ -104,9 +107,12 @@ export interface PreparedChannelDelivery {
     input: ChannelDeliveryTurnInput;
     actor?: {
       externalUserId: string;
-      kind: "human" | "bot" | "app" | "system";
+      kind: "human" | "bot" | "app" | "system" | "unknown";
       displayName?: string;
+      handle?: string;
+      email?: string;
     };
+    raw?: unknown;
   };
 }
 

--- a/packages/channels-intelligence/src/delivery-transport.ts
+++ b/packages/channels-intelligence/src/delivery-transport.ts
@@ -1299,7 +1299,7 @@ function assertPreparedDelivery(
         "adapter",
         "turn",
       ],
-      ["surfaceKind"],
+      ["tenant", "installation", "conversation", "surfaceKind"],
     )
   ) {
     throw new TypeError("Gateway returned an invalid prepared delivery");
@@ -1315,6 +1315,11 @@ function assertPreparedDelivery(
     !isSafeExternalId(prepared.canonicalThreadId) ||
     !isSafeExternalId(prepared.appUserId) ||
     (prepared.adapter !== "slack" && prepared.adapter !== "teams") ||
+    (prepared.tenant !== undefined && !isPreparedTenant(prepared.tenant)) ||
+    (prepared.installation !== undefined &&
+      !isPreparedInstallation(prepared.installation)) ||
+    (prepared.conversation !== undefined &&
+      !isPreparedConversation(prepared.conversation)) ||
     (prepared.surfaceKind !== undefined &&
       (typeof prepared.surfaceKind !== "string" ||
         !PREPARED_SURFACE_KINDS.has(prepared.surfaceKind))) ||
@@ -1322,7 +1327,7 @@ function assertPreparedDelivery(
     !hasExactFields(
       prepared.turn,
       ["eventId", "receivedAt", "input"],
-      ["typingDelayMs", "actor"],
+      ["typingDelayMs", "actor", "raw"],
     ) ||
     !isEventId(prepared.turn.eventId) ||
     !isIsoDateTime(prepared.turn.receivedAt) ||
@@ -1487,13 +1492,45 @@ function isSafeExternalId(value: unknown): value is string {
 function isPreparedActor(value: unknown): boolean {
   return (
     isRecord(value) &&
-    hasExactFields(value, ["externalUserId", "kind"], ["displayName"]) &&
+    hasExactFields(
+      value,
+      ["externalUserId", "kind"],
+      ["displayName", "handle", "email"],
+    ) &&
     isBoundedString(value.externalUserId, 1, 512) &&
-    ["human", "bot", "app", "system"].includes(String(value.kind)) &&
+    ["human", "bot", "app", "system", "unknown"].includes(String(value.kind)) &&
     (value.displayName === undefined ||
       (typeof value.displayName === "string" &&
         value.displayName.trim().length >= 1 &&
-        value.displayName.trim().length <= 120))
+        value.displayName.trim().length <= 120)) &&
+    (value.handle === undefined || isBoundedString(value.handle, 1, 512)) &&
+    (value.email === undefined || isBoundedString(value.email, 1, 512))
+  );
+}
+
+function isPreparedTenant(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasExactFields(value, ["id"], ["name"]) &&
+    isBoundedString(value.id, 1, 512) &&
+    (value.name === undefined || isBoundedString(value.name, 1, 512))
+  );
+}
+
+function isPreparedInstallation(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasExactFields(value, ["id"]) &&
+    isBoundedString(value.id, 1, 512)
+  );
+}
+
+function isPreparedConversation(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasExactFields(value, ["id"], ["kind"]) &&
+    isBoundedString(value.id, 1, 512) &&
+    (value.kind === undefined || isBoundedString(value.kind, 1, 120))
   );
 }
 

--- a/packages/channels-intelligence/src/delivery-typing.test.ts
+++ b/packages/channels-intelligence/src/delivery-typing.test.ts
@@ -20,7 +20,10 @@ test("managed delivery advertises its backend-owned typing lifecycle", () => {
 
 async function deliverNoopTeamsMessage(typingDelayMs: 0 | 300) {
   const gateway = new DeliveryTestGateway();
-  const channel = createChannel({ name: "support" });
+  const channel = createChannel({
+    identifyUser: "platform",
+    name: "support",
+  });
   channel.onMessage(() => undefined);
   const handle = await startChannelsWithGatewayControl([channel], {
     session: gateway,
@@ -65,7 +68,10 @@ test.each([
   async (action, expectedKinds) => {
     const gateway = new DeliveryTestGateway();
     const onMessage = vi.fn();
-    const channel = createChannel({ name: "support" });
+    const channel = createChannel({
+      identifyUser: "platform",
+      name: "support",
+    });
     channel.onMessage(onMessage);
     const handle = await startChannelsWithGatewayControl([channel], {
       session: gateway,

--- a/packages/channels-intelligence/src/intelligence-state-store.test.ts
+++ b/packages/channels-intelligence/src/intelligence-state-store.test.ts
@@ -35,6 +35,10 @@ function fakeKvFetch(): FetchLike {
       });
     } else if (url.endsWith("/api/channels/kv/delete")) {
       map.delete(body.key);
+    } else if (url.endsWith("/api/channels/kv/consume")) {
+      const e = map.get(body.key);
+      map.delete(body.key);
+      payload = live(e) ? { value: e!.value } : { value: null };
     } else {
       throw new Error(`unexpected KV route: ${url}`);
     }

--- a/packages/channels-intelligence/src/intelligence-state-store.ts
+++ b/packages/channels-intelligence/src/intelligence-state-store.ts
@@ -104,6 +104,14 @@ export class IntelligenceStateStore implements StateStore {
     delete: async (key: string): Promise<void> => {
       await this.post("/api/channels/kv/delete", { key });
     },
+    /** Atomically read and remove a one-use capability. */
+    consume: async <T>(key: string): Promise<T | undefined> => {
+      const { value } = await this.post<{ value: T | null }>(
+        "/api/channels/kv/consume",
+        { key },
+      );
+      return value === null ? undefined : value;
+    },
   };
 
   // Delegated to in-memory — see class doc for why these are not durable.

--- a/packages/channels-intelligence/src/realtime-gateway-project-join.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-project-join.test.ts
@@ -24,7 +24,7 @@ function setup() {
   connectRealtimeGatewayMock.mockReset();
   connectRealtimeGatewayMock.mockResolvedValue(session);
 
-  const channel = createChannel({ name: "support" });
+  const channel = createChannel({ identifyUser: "platform", name: "support" });
   channel.onMessage(async () => {});
 
   return {

--- a/packages/channels-slack/ARCHITECTURE.md
+++ b/packages/channels-slack/ARCHITECTURE.md
@@ -91,7 +91,7 @@ Slack event ──► attachSlackListener ──► IngressSink.onTurn(IncomingT
 `attachSlackListener` is the translation layer between Slack's event model
 and the engine's domain. It filters subtypes, bot echoes, untracked threads,
 and mention duplicates, and emits a normalized turn. The adapter resolves the
-sender to a `PlatformUser` (cached per id) and calls `sink.onTurn` with a
+sender to a `ProviderActor` (cached per id) and calls `sink.onTurn` with a
 `conversationKey` (`conversationKeyOf`), `replyTarget`, `userText`, and
 `user`.
 

--- a/packages/channels-slack/README.md
+++ b/packages/channels-slack/README.md
@@ -34,6 +34,7 @@ import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 
 const bot = createChannel({
   name: "support-bot", // project-unique Intelligence Channel name
+  identifyUser: "platform", // provider + workspace + human Slack user
   adapters: [
     slack({
       botToken: process.env.SLACK_BOT_TOKEN!, // xoxb-…
@@ -54,7 +55,6 @@ const runtime = new CopilotRuntime({
     // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
-  identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),
   channels: [bot],
 });
 
@@ -276,10 +276,29 @@ resumes the agent via `thread.resume(value)`.
 
 ### Sender-profile resolution & file download
 
-The adapter resolves each turn's Slack user id to a richer `PlatformUser`
-(`{ id, name?, email? }`), cached per id. Inbound files can be downloaded and
-delivered to the agent as multimodal content parts (`buildFileContentParts`);
-a tool can post a file back out via `thread.postFile(...)`.
+Handlers receive `actor`, the Slack account that caused the event, and `user`,
+the nullable application user returned by the Channel's `identifyUser` policy.
+The standard `"platform"` policy namespaces confirmed humans by provider and
+workspace. It does not map bots, apps, system actors, or unknown actors. Inbound
+files can be delivered to the agent as multimodal content parts; a tool can post
+a file back out via `thread.postFile(...)`.
+
+### Intelligence Memory
+
+Memory is off unless the specific run grants it:
+
+```ts
+bot.onMention(async ({ thread }) => {
+  await thread.runAgent({
+    memory: { user: "read", project: "read-write" },
+  });
+});
+```
+
+User Memory fails before the agent starts when `identifyUser` returns `null`.
+Project-only Memory works without an application user. A resumed run with user
+Memory must choose `subject: "initiator"` or `subject: "actor"`; callers cannot
+pass a raw user ID.
 
 ### Built-ins
 
@@ -298,7 +317,7 @@ methods, which this adapter backs:
 - `thread.getMessages()` — the current thread's messages (via
   `conversations.replies`), each a `ThreadMessage` (`{ user?, text, ts?,
 isBot? }`).
-- `thread.lookupUser(query)` — resolve a name/handle/email to a `PlatformUser`.
+- `thread.lookupUser(query)` — resolve a name/handle/email to a `ProviderActor`.
 - `thread.postFile({ bytes, filename, title?, altText? })` — upload a file
   back into the thread (`files.uploadV2`).
 

--- a/packages/channels-slack/src/__tests__/assistant.test.ts
+++ b/packages/channels-slack/src/__tests__/assistant.test.ts
@@ -23,7 +23,7 @@ vi.mock("@slack/bolt", () => ({
 }));
 
 import { attachAssistant } from "../assistant.js";
-import type { IngressSink, PlatformUser } from "@copilotkit/channels-core";
+import type { IngressSink } from "@copilotkit/channels-core";
 import type { SlackAssistantOptions } from "../types.js";
 
 function setup(opts: SlackAssistantOptions = {}) {
@@ -40,14 +40,30 @@ function setup(opts: SlackAssistantOptions = {}) {
     onModalSubmit: vi.fn(async () => {}),
     onModalClose: vi.fn(),
   };
-  const resolveUser = vi.fn(
-    async (id: string): Promise<PlatformUser> => ({ id, name: `name-${id}` }),
+  const identityContext = vi.fn(
+    (input: {
+      conversationKey: string;
+      conversationKind: string;
+      trigger: string;
+      eventId?: string;
+      raw: unknown;
+    }) => ({
+      tenant: { id: "T1" },
+      installation: { id: "A1" },
+      conversation: {
+        id: input.conversationKey,
+        kind: input.conversationKind,
+      },
+      trigger: input.trigger,
+      event: input.eventId ? { id: input.eventId } : {},
+      raw: input.raw,
+    }),
   );
   // The Bolt App is only used for `app.assistant(...)`, which our mocked
   // Assistant ignores — capture happens in the constructor above.
   const app = { assistant: vi.fn() } as never;
-  const handle = attachAssistant({ app, sink, opts, resolveUser });
-  return { handle, onTurn, onThreadStarted, resolveUser };
+  const handle = attachAssistant({ app, sink, opts, identityContext });
+  return { handle, onTurn, onThreadStarted, identityContext };
 }
 
 const threadStartedEvent = {
@@ -106,7 +122,13 @@ describe("attachAssistant — threadStarted", () => {
           threadTs: "100.0",
           recipientUserId: "U1",
         },
-        user: { id: "U1", name: "name-U1" },
+        actor: { id: "U1", kind: "human" },
+        identityContext: expect.objectContaining({
+          tenant: { id: "T1" },
+          installation: { id: "A1" },
+          conversation: { id: "D1::100.0", kind: "assistant_thread" },
+          trigger: "thread-start",
+        }),
         platform: "slack",
       }),
     );
@@ -157,6 +179,13 @@ describe("attachAssistant — userMessage", () => {
           recipientUserId: "U1",
         },
         userText: "hello",
+        actor: { id: "U1", kind: "human" },
+        identityContext: expect.objectContaining({
+          tenant: { id: "T1" },
+          installation: { id: "A1" },
+          conversation: { id: "D1::100.0", kind: "assistant_thread" },
+          trigger: "message",
+        }),
         platform: "slack",
       }),
     );

--- a/packages/channels-slack/src/__tests__/built-ins.test.ts
+++ b/packages/channels-slack/src/__tests__/built-ins.test.ts
@@ -7,13 +7,13 @@ import {
   slackConversationModelContext,
 } from "../built-in-context.js";
 import type { ChannelToolContext } from "@copilotkit/channels-core";
-import type { PlatformUser, Thread } from "@copilotkit/channels-ui";
+import type { ProviderActor, Thread } from "@copilotkit/channels-ui";
 
 /**
  * Build a minimal handler ctx whose `thread.lookupUser` is the only capability
  * the lookup tool touches. The fake resolves to whatever `user` we hand it.
  */
-function makeCtx(user?: PlatformUser): {
+function makeCtx(user?: ProviderActor): {
   ctx: ChannelToolContext;
   lookupUser: ReturnType<typeof vi.fn>;
 } {
@@ -29,6 +29,7 @@ describe("lookup_slack_user", () => {
   it("resolves a user via thread.lookupUser and returns a <@USERID> mention", async () => {
     const { ctx, lookupUser } = makeCtx({
       id: "U001",
+      kind: "human",
       name: "Atai Barkai",
       handle: "atai",
       email: "atai@copilotkit.ai",
@@ -59,7 +60,7 @@ describe("lookup_slack_user", () => {
   });
 
   it("returns a raw object (NOT a JSON string) for the run-loop to serialize", async () => {
-    const { ctx } = makeCtx({ id: "U002" });
+    const { ctx } = makeCtx({ id: "U002", kind: "human" });
     const r = await lookupSlackUserTool.handler({ query: "sarah" }, ctx);
     expect(typeof r).toBe("object");
   });

--- a/packages/channels-slack/src/__tests__/ephemeral.test.ts
+++ b/packages/channels-slack/src/__tests__/ephemeral.test.ts
@@ -16,7 +16,7 @@ describe("SlackAdapter.postEphemeral", () => {
     const ir = [{ type: "text", props: { value: "hi" } }];
     const res = await adapter.postEphemeral!(
       { channel: "C1", threadTs: "1.0" },
-      { id: "U1" },
+      { id: "U1", kind: "human" },
       ir,
       { fallbackToDM: false },
     );
@@ -60,9 +60,14 @@ describe("SlackAdapter.postEphemeral", () => {
       .mockResolvedValue({ ok: true, message_ts: "7.0" });
     // @ts-expect-error inject stub
     adapter.client = { chat: { postEphemeral } };
-    await adapter.postEphemeral!({ channel: "C3" }, { id: "U3" }, [], {
-      fallbackToDM: false,
-    });
+    await adapter.postEphemeral!(
+      { channel: "C3" },
+      { id: "U3", kind: "human" },
+      [],
+      {
+        fallbackToDM: false,
+      },
+    );
     const args = postEphemeral.mock.calls[0]![0] as Record<string, unknown>;
     expect(args["thread_ts"]).toBeUndefined();
   });
@@ -80,7 +85,7 @@ describe("SlackAdapter.postEphemeral", () => {
     adapter.client = { chat: { postEphemeral } };
     const res = await adapter.postEphemeral!(
       { channel: "C4" },
-      { id: "U4" },
+      { id: "U4", kind: "human" },
       [],
       { fallbackToDM: true },
     );
@@ -100,7 +105,7 @@ describe("SlackAdapter.postEphemeral", () => {
     adapter.client = { chat: { postEphemeral } };
     const res = await adapter.postEphemeral!(
       { channel: "C5" },
-      { id: "U5" },
+      { id: "U5", kind: "human" },
       [],
       { fallbackToDM: false },
     );

--- a/packages/channels-slack/src/__tests__/reactions.test.ts
+++ b/packages/channels-slack/src/__tests__/reactions.test.ts
@@ -15,7 +15,7 @@ describe("decodeReaction", () => {
     expect(evt).toMatchObject({
       rawEmoji: "thumbsup",
       added: true,
-      user: { id: "U1" },
+      actor: { id: "U1", kind: "human" },
       messageId: "171.1",
       replyTarget: { channel: "C9" },
     });
@@ -178,25 +178,31 @@ describe("adapter reaction ingress loop guard", () => {
     expect(sink.onReaction).toHaveBeenCalledTimes(1);
   });
 
-  it("enriches the reaction user via resolveUser (name + email), not a bare {id}", async () => {
+  it("keeps profile lookup lazy until identity code requests it", async () => {
     const { fireReaction, sink, usersInfo } = await startWithFakes();
     await fireReaction("reaction_added", {
       user: "UHUMAN",
       reaction: "thumbsup",
       item: { type: "message", channel: "C9", ts: "171.1" },
     });
-    expect(usersInfo).toHaveBeenCalledWith({ user: "UHUMAN" });
+    expect(usersInfo).not.toHaveBeenCalled();
     const evt = sink.onReaction.mock.calls[0]?.[0] as {
-      user?: { id: string; name?: string; email?: string };
+      actor: { id: string; kind: string };
+      identityContext: {
+        lookupProfile?: () => Promise<unknown>;
+      };
     };
-    expect(evt.user).toEqual({
+    expect(evt.actor).toEqual({ id: "UHUMAN", kind: "human" });
+    await expect(evt.identityContext.lookupProfile?.()).resolves.toEqual({
       id: "UHUMAN",
+      kind: "human",
       name: "Human User",
       email: "human@example.com",
     });
+    expect(usersInfo).toHaveBeenCalledWith({ user: "UHUMAN" });
   });
 
-  it("enriches the reaction user on reaction_removed too", async () => {
+  it("classifies the reaction_removed actor without fetching a profile", async () => {
     const { fireReaction, sink } = await startWithFakes();
     await fireReaction("reaction_removed", {
       user: "UHUMAN",
@@ -204,9 +210,11 @@ describe("adapter reaction ingress loop guard", () => {
       item: { type: "message", channel: "C9", ts: "171.1" },
     });
     const evt = sink.onReaction.mock.calls[0]?.[0] as {
-      user?: { id: string; name?: string; email?: string };
+      actor: { id: string; kind: string };
+      identityContext: { tenant: { id: string } };
     };
-    expect(evt.user).toMatchObject({ name: "Human User" });
+    expect(evt.actor).toEqual({ id: "UHUMAN", kind: "human" });
+    expect(evt.identityContext.tenant).toEqual({ id: "T1" });
   });
 });
 

--- a/packages/channels-slack/src/__tests__/views.test.ts
+++ b/packages/channels-slack/src/__tests__/views.test.ts
@@ -27,13 +27,13 @@ describe("decodeViewSubmission", () => {
           },
         },
       },
-      { id: "U1" },
+      { id: "U1", kind: "human" },
     );
     expect(evt).toMatchObject({
       callbackId: "triage",
       privateMetadata: "meta",
       values: { summary: "boom", prio: "high", team: "core" },
-      user: { id: "U1" },
+      actor: { id: "U1", kind: "human" },
       platform: "slack",
     });
   });
@@ -48,7 +48,7 @@ describe("decodeViewSubmission", () => {
         }),
         state: { values: {} },
       },
-      { id: "U1" },
+      { id: "U1", kind: "human" },
     );
     expect(evt.conversationKey).toBe("C123::1700.5");
     expect(evt.replyTarget).toEqual({ channel: "C123", threadTs: "1700.5" });
@@ -64,7 +64,7 @@ describe("decodeViewSubmission", () => {
         }),
         state: { values: {} },
       },
-      { id: "U1" },
+      { id: "U1", kind: "human" },
     );
     expect(evt.conversationKey).toBe("D999::dm");
     expect(evt.replyTarget).toEqual({ channel: "D999" });
@@ -78,7 +78,7 @@ describe("decodeViewSubmission", () => {
         private_metadata: "just-a-string",
         state: { values: {} },
       },
-      { id: "U1" },
+      { id: "U1", kind: "human" },
     );
     expect(evt.privateMetadata).toBe("just-a-string");
     expect(evt.conversationKey).toBeUndefined();
@@ -96,7 +96,7 @@ describe("decodeViewClosed", () => {
           pm: "authorMeta",
         }),
       },
-      { id: "U1" },
+      { id: "U1", kind: "human" },
     );
     expect(evt.conversationKey).toBe("C123::1700.5");
     expect(evt.replyTarget).toEqual({ channel: "C123", threadTs: "1700.5" });
@@ -109,7 +109,7 @@ describe("decodeViewClosed", () => {
         callback_id: "triage",
         private_metadata: "plain",
       },
-      { id: "U1" },
+      { id: "U1", kind: "human" },
     );
     expect(evt.privateMetadata).toBe("plain");
     expect(evt.conversationKey).toBeUndefined();

--- a/packages/channels-slack/src/adapter.test.ts
+++ b/packages/channels-slack/src/adapter.test.ts
@@ -235,7 +235,12 @@ describe("SlackAdapter.getMessages", () => {
       text: "hello",
       ts: "100.0",
       isBot: false,
-      user: { id: "U1", name: "Ana Smith", email: undefined },
+      user: {
+        id: "U1",
+        kind: "human",
+        name: "Ana Smith",
+        email: undefined,
+      },
     });
     expect(msgs[1]!.isBot).toBe(true);
     expect(msgs[1]!.text).toBe("bot reply");
@@ -356,7 +361,7 @@ describe("SlackAdapter.capabilities / ackDeadlineMs", () => {
 });
 
 describe("SlackAdapter.resolveUser", () => {
-  it("resolves a sender id to a richer PlatformUser (name + email) and caches it", async () => {
+  it("resolves a sender id to a richer ProviderActor (name + email) and caches it", async () => {
     const { adapter } = makeAdapter();
     const info = vi.fn(async (_arg: { user: string }) => ({
       user: {
@@ -373,6 +378,7 @@ describe("SlackAdapter.resolveUser", () => {
     const u = await adapter.resolveUser("U1");
     expect(u).toEqual({
       id: "U1",
+      kind: "human",
       name: "Ana Smith",
       email: "ana@example.com",
     });
@@ -393,7 +399,7 @@ describe("SlackAdapter.resolveUser", () => {
     };
 
     const u = await adapter.resolveUser("U2");
-    expect(u).toEqual({ id: "U2" });
+    expect(u).toEqual({ id: "U2", kind: "human" });
   });
 });
 

--- a/packages/channels-slack/src/adapter.ts
+++ b/packages/channels-slack/src/adapter.ts
@@ -18,11 +18,12 @@ import type {
   ConversationStore,
   AgentSession,
   MessageRef,
-  PlatformUser,
+  ProviderActor,
   UserQuery,
   EphemeralResult,
   NativePayload,
   ReplyContinuationOptions,
+  IngressIdentityContext,
 } from "@copilotkit/channels-core";
 import type { AbstractAgent } from "@ag-ui/client";
 import type {
@@ -129,7 +130,7 @@ export class SlackAdapter implements PlatformAdapter {
   private readonly store: SlackConversationStore;
   private sink: IngressSink | undefined;
   /** Per-id cache for sender-profile resolution (repeat turns are cheap). */
-  private readonly userCache = new Map<string, PlatformUser>();
+  private readonly userCache = new Map<string, ProviderActor>();
   /** Set once the Assistant middleware is attached (when assistant !== false). */
   private assistantHandle: AssistantHandle | undefined;
   /** Our team id (from auth.test); native channel streams need it. */
@@ -211,7 +212,7 @@ export class SlackAdapter implements PlatformAdapter {
         app: this.app,
         sink,
         opts: this.opts.assistant ?? {},
-        resolveUser: (id) => this.resolveUser(id),
+        identityContext: (input) => this.identityContext(input),
       });
     }
 
@@ -224,8 +225,12 @@ export class SlackAdapter implements PlatformAdapter {
       respondTo: resolveSlackRespondToOptions(this.opts.respondTo),
       isAssistantThread: this.assistantHandle?.isAssistantThread,
       onTurn: async (turn) => {
+        const conversationKey = conversationKeyOf(turn.conversation);
+        const actor = turn.senderUserId
+          ? { id: turn.senderUserId, kind: "human" as const }
+          : { id: "", kind: "unknown" as const };
         await sink.onTurn({
-          conversationKey: conversationKeyOf(turn.conversation),
+          conversationKey,
           // Carry the sender id so native channel streams can pass
           // `recipient_user_id` to chat.startStream.
           replyTarget: {
@@ -234,9 +239,16 @@ export class SlackAdapter implements PlatformAdapter {
           },
           userText: turn.userText,
           operation: turn.operation,
-          user: turn.senderUserId
-            ? await this.resolveUser(turn.senderUserId)
-            : undefined,
+          actor,
+          identityContext: this.identityContext({
+            conversationKey,
+            conversationKind:
+              turn.conversation.scope === DM_SCOPE ? "direct" : "thread",
+            trigger: "message",
+            eventId: turn.eventId,
+            actor,
+            raw: { operation: turn.operation },
+          }),
           // Stable per-delivery id for inbound dedup (Events API event_id, or a
           // fallback derived by the listener); undefined when unavailable.
           eventId: turn.eventId,
@@ -244,16 +256,27 @@ export class SlackAdapter implements PlatformAdapter {
         });
       },
       onCommand: async (cmd) => {
+        const conversationKey = conversationKeyOf(cmd.conversation);
+        const actor = cmd.senderUserId
+          ? { id: cmd.senderUserId, kind: "human" as const }
+          : { id: "", kind: "unknown" as const };
         await sink.onCommand({
           command: cmd.command,
           text: cmd.text,
           // Slack delivers args as free text only; structured `rawOptions`
           // are a Discord-style capability, so they're left unset here.
-          conversationKey: conversationKeyOf(cmd.conversation),
+          conversationKey,
           replyTarget: cmd.replyTarget,
-          user: cmd.senderUserId
-            ? await this.resolveUser(cmd.senderUserId)
-            : undefined,
+          actor,
+          identityContext: this.identityContext({
+            conversationKey,
+            conversationKind:
+              cmd.conversation.scope === DM_SCOPE ? "direct" : "thread",
+            trigger: "command",
+            eventId: cmd.eventId,
+            actor,
+            raw: { command: cmd.command },
+          }),
           // Stable per-invocation id for inbound dedup (command:user:trigger_id).
           eventId: cmd.eventId,
           platform: "slack",
@@ -285,14 +308,28 @@ export class SlackAdapter implements PlatformAdapter {
       // Enrich the reactor to parity with onTurn/onCommand so per-user
       // attribution (e.g. senderContext(evt.user) → filter by email) works
       // for reaction-triggered runs, not just mentions and commands.
-      if (event.user) evt.user = await this.resolveUser(event.user);
+      if (event.user) evt.actor = { id: event.user, kind: "human" };
+      evt.identityContext = this.identityContext({
+        conversationKey: evt.conversationKey,
+        conversationKind: "thread",
+        trigger: "reaction",
+        actor: evt.actor ?? { id: "", kind: "unknown" },
+        raw: { rawEmoji: evt.rawEmoji, added: evt.added },
+      });
       await sink.onReaction(evt);
     });
     this.app.event("reaction_removed", async ({ event }) => {
       if (event.user === this.botUserId) return;
       const evt = decodeReaction(event, false);
       if (!evt) return;
-      if (event.user) evt.user = await this.resolveUser(event.user);
+      if (event.user) evt.actor = { id: event.user, kind: "human" };
+      evt.identityContext = this.identityContext({
+        conversationKey: evt.conversationKey,
+        conversationKind: "thread",
+        trigger: "reaction",
+        actor: evt.actor ?? { id: "", kind: "unknown" },
+        raw: { rawEmoji: evt.rawEmoji, added: evt.added },
+      });
       await sink.onReaction(evt);
     });
 
@@ -301,10 +338,18 @@ export class SlackAdapter implements PlatformAdapter {
     // open with inline messages); otherwise a plain ack closes the modal.
     // A catch-all `/.*/` callback_id constraint defaults to `view_submission`.
     this.app.view(/.*/, async ({ ack, body, view }) => {
-      const user = body.user?.id
-        ? { id: body.user.id, name: body.user.name }
+      const actor = body.user?.id
+        ? { id: body.user.id, kind: "human" as const, name: body.user.name }
         : undefined;
-      const result = await sink.onModalSubmit(decodeViewSubmission(view, user));
+      const event = decodeViewSubmission(view, actor);
+      event.identityContext = this.identityContext({
+        conversationKey: event.conversationKey ?? `modal:${event.callbackId}`,
+        conversationKind: "modal",
+        trigger: "modal-submit",
+        actor: actor ?? { id: "", kind: "unknown" },
+        raw: { callbackId: event.callbackId },
+      });
+      const result = await sink.onModalSubmit(event);
       if (result?.errors) {
         await ack({ response_action: "errors", errors: result.errors });
       } else {
@@ -315,10 +360,18 @@ export class SlackAdapter implements PlatformAdapter {
     this.app.view(
       { type: "view_closed", callback_id: /.*/ },
       async ({ ack, body, view }) => {
-        const user = body.user?.id
-          ? { id: body.user.id, name: body.user.name }
+        const actor = body.user?.id
+          ? { id: body.user.id, kind: "human" as const, name: body.user.name }
           : undefined;
-        await sink.onModalClose(decodeViewClosed(view, user));
+        const event = decodeViewClosed(view, actor);
+        event.identityContext = this.identityContext({
+          conversationKey: event.conversationKey ?? `modal:${event.callbackId}`,
+          conversationKind: "modal",
+          trigger: "modal-close",
+          actor: actor ?? { id: "", kind: "unknown" },
+          raw: { callbackId: event.callbackId },
+        });
+        await sink.onModalClose(event);
         await ack();
       },
     );
@@ -587,7 +640,11 @@ export class SlackAdapter implements PlatformAdapter {
         messageTs,
         threadTs: body.message?.thread_ts,
         user: body.user?.id
-          ? { id: body.user.id, name: body.user.name ?? body.user.username }
+          ? {
+              id: body.user.id,
+              kind: "human",
+              name: body.user.name ?? body.user.username,
+            }
           : undefined,
       }),
     ).catch((err) =>
@@ -728,10 +785,48 @@ export class SlackAdapter implements PlatformAdapter {
   }
 
   decodeInteraction(raw: unknown): InteractionEvent | undefined {
-    return decodeInteraction(raw);
+    const event = decodeInteraction(raw);
+    if (!event) return undefined;
+    const actor = event.actor ?? { id: "", kind: "unknown" };
+    event.identityContext = this.identityContext({
+      conversationKey: event.conversationKey,
+      conversationKind: "thread",
+      trigger: "interaction",
+      eventId: event.eventId,
+      actor,
+      raw: { actionId: event.id },
+    });
+    return event;
   }
 
-  async lookupUser(q: UserQuery): Promise<PlatformUser | undefined> {
+  /** Build bounded identity facts without fetching a Slack profile eagerly. */
+  private identityContext(input: {
+    conversationKey: string;
+    conversationKind: string;
+    trigger: string;
+    eventId?: string;
+    actor: ProviderActor;
+    raw: unknown;
+  }): IngressIdentityContext {
+    return {
+      tenant: { id: this.teamId ?? "unknown" },
+      installation: {
+        id: this.appId ?? this.botId ?? this.botUserId ?? "unknown",
+      },
+      conversation: {
+        id: input.conversationKey,
+        kind: input.conversationKind,
+      },
+      trigger: input.trigger,
+      event: input.eventId ? { id: input.eventId } : {},
+      raw: input.raw,
+      ...(input.actor.id && input.actor.kind === "human"
+        ? { lookupProfile: () => this.resolveUser(input.actor.id) }
+        : {}),
+    };
+  }
+
+  async lookupUser(q: UserQuery): Promise<ProviderActor | undefined> {
     const query = q.query.trim().toLowerCase();
     if (!query) return undefined;
     try {
@@ -761,6 +856,7 @@ export class SlackAdapter implements PlatformAdapter {
           if (candidates.some((c) => c === query || c.startsWith(query))) {
             return {
               id: m.id,
+              kind: "human",
               name: m.real_name ?? m.name,
               handle: m.name,
               email: m.profile?.email,
@@ -776,14 +872,14 @@ export class SlackAdapter implements PlatformAdapter {
   }
 
   /**
-   * Resolve a Slack user id to a richer `PlatformUser` (name + email) for each
+   * Resolve a Slack user id to a richer `ProviderActor` (name + email) for each
    * turn, cached by id so repeat turns in the same conversation are cheap.
    * Tolerates lookup failure by falling back to a bare `{ id }`.
    */
-  async resolveUser(userId: string): Promise<PlatformUser> {
+  async resolveUser(userId: string): Promise<ProviderActor> {
     const cached = this.userCache.get(userId);
     if (cached) return cached;
-    let user: PlatformUser = { id: userId };
+    let user: ProviderActor = { id: userId, kind: "human" };
     try {
       const r = (await this.client.users.info({ user: userId })) as {
         user?: {
@@ -801,6 +897,7 @@ export class SlackAdapter implements PlatformAdapter {
       if (u?.id) {
         user = {
           id: u.id,
+          kind: "human",
           name:
             u.real_name ??
             u.profile?.real_name ??
@@ -977,7 +1074,7 @@ export class SlackAdapter implements PlatformAdapter {
    */
   async postEphemeral(
     target: BotReplyTarget,
-    user: PlatformUser | string,
+    user: ProviderActor | string,
     ir: ChannelNode[],
     _opts: { fallbackToDM: boolean },
   ): Promise<EphemeralResult | null> {

--- a/packages/channels-slack/src/assistant.ts
+++ b/packages/channels-slack/src/assistant.ts
@@ -21,7 +21,11 @@
  */
 import { Assistant } from "@slack/bolt";
 import type { App } from "@slack/bolt";
-import type { IngressSink, PlatformUser } from "@copilotkit/channels-core";
+import type {
+  IngressIdentityContext,
+  IngressSink,
+  ProviderActor,
+} from "@copilotkit/channels-core";
 import { conversationKeyOf } from "./interaction.js";
 import type { SlackAssistantOptions } from "./types.js";
 
@@ -31,8 +35,14 @@ export interface AttachAssistantConfig {
   sink: IngressSink;
   /** Static pane behavior (greeting / prompts / title). */
   opts: SlackAssistantOptions;
-  /** Resolve a Slack user id to a richer PlatformUser (adapter-owned, cached). */
-  resolveUser: (userId: string) => Promise<PlatformUser>;
+  identityContext: (input: {
+    conversationKey: string;
+    conversationKind: string;
+    trigger: string;
+    eventId?: string;
+    actor: ProviderActor;
+    raw: unknown;
+  }) => IngressIdentityContext;
 }
 
 export interface AssistantHandle {
@@ -42,7 +52,7 @@ export interface AssistantHandle {
 
 /** Register the Bolt `Assistant` middleware and bridge it to the engine sink. */
 export function attachAssistant(cfg: AttachAssistantConfig): AssistantHandle {
-  const { app, sink, opts, resolveUser } = cfg;
+  const { app, sink, opts, identityContext } = cfg;
 
   // Pane threads seen this process (channelId::threadTs). Populated on
   // thread_started and (defensively, after a restart) on the first message.
@@ -86,15 +96,29 @@ export function attachAssistant(cfg: AttachAssistantConfig): AssistantHandle {
       }
 
       // ── Then hand off to the engine (onThreadStarted handlers layer on top). ──
-      const user = at.user_id ? await resolveUser(at.user_id) : undefined;
+      const actor = at.user_id
+        ? { id: at.user_id, kind: "human" as const }
+        : { id: "", kind: "unknown" as const };
+      const conversationKey = conversationKeyOf({
+        channelId,
+        scope: threadTs,
+      });
       await sink.onThreadStarted({
-        conversationKey: conversationKeyOf({ channelId, scope: threadTs }),
+        conversationKey,
         replyTarget: {
           channel: channelId,
           threadTs,
           recipientUserId: at.user_id,
         },
-        user,
+        actor,
+        identityContext: identityContext({
+          conversationKey,
+          conversationKind: "assistant_thread",
+          trigger: "thread-start",
+          eventId: threadTs,
+          actor,
+          raw: { channelId, threadTs },
+        }),
         platform: "slack",
       });
     },
@@ -139,7 +163,19 @@ export function attachAssistant(cfg: AttachAssistantConfig): AssistantHandle {
           revisionId: m.ts ?? threadTs,
           mentioned: false,
         },
-        user: m.user ? await resolveUser(m.user) : undefined,
+        actor: m.user
+          ? { id: m.user, kind: "human" as const }
+          : { id: "", kind: "unknown" as const },
+        identityContext: identityContext({
+          conversationKey: key,
+          conversationKind: "assistant_thread",
+          trigger: "message",
+          eventId: m.ts,
+          actor: m.user
+            ? { id: m.user, kind: "human" }
+            : { id: "", kind: "unknown" },
+          raw: { channelId, threadTs, messageTs: m.ts },
+        }),
         platform: "slack",
       });
     },

--- a/packages/channels-slack/src/interaction.test.ts
+++ b/packages/channels-slack/src/interaction.test.ts
@@ -27,7 +27,7 @@ describe("decodeInteraction", () => {
     expect(evt!.value).toEqual({ confirmed: true });
     expect(evt!.conversationKey).toBe("C1::100.0");
     expect(evt!.replyTarget).toEqual({ channel: "C1", threadTs: "100.0" });
-    expect(evt!.user).toEqual({ id: "U1", name: "Ana" });
+    expect(evt!.actor).toEqual({ id: "U1", kind: "human", name: "Ana" });
     expect(evt!.messageRef).toEqual({ id: "111.1", channel: "C1" });
   });
 
@@ -42,7 +42,7 @@ describe("decodeInteraction", () => {
     expect(evt!.conversationKey).toBe("D5::dm");
     expect(evt!.replyTarget).toEqual({ channel: "D5", threadTs: undefined });
     expect(evt!.value).toBe("yes");
-    expect(evt!.user).toEqual({ id: "U2", name: "bob" });
+    expect(evt!.actor).toEqual({ id: "U2", kind: "human", name: "bob" });
   });
 
   it("scopes a THREADED DM (assistant pane) by its thread ts, not DM_SCOPE", () => {
@@ -70,7 +70,7 @@ describe("decodeInteraction", () => {
     });
     expect(evt!.conversationKey).toBe("C3::200.0");
     expect(evt!.value).toBe("opt-1");
-    expect(evt!.user).toBeUndefined();
+    expect(evt!.actor).toEqual({ id: "unknown", kind: "unknown" });
   });
 
   it("decodes a multi_static_select's selected_options into a string[] value", () => {

--- a/packages/channels-slack/src/interaction.ts
+++ b/packages/channels-slack/src/interaction.ts
@@ -27,6 +27,8 @@ export function conversationKeyOf(key: ConversationKey): string {
 export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
   const body = raw as {
     type?: string;
+    api_app_id?: string;
+    team?: { id?: string };
     trigger_id?: string;
     user?: { id?: string; name?: string; username?: string };
     channel?: { id?: string };
@@ -84,9 +86,13 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
     value = parseValue(action.value ?? action.selected_option?.value);
   }
 
-  const user = body.user?.id
-    ? { id: body.user.id, name: body.user.name ?? body.user.username }
-    : undefined;
+  const actor = body.user?.id
+    ? {
+        id: body.user.id,
+        kind: "human" as const,
+        name: body.user.name ?? body.user.username,
+      }
+    : { id: "unknown", kind: "unknown" as const };
 
   // The picker message's ts: an onClick `thread.update(message.ref, …)`
   // targets this message in place (the adapter's `update` reads `channel`
@@ -110,10 +116,18 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
     conversationKey,
     replyTarget,
     value,
-    user,
+    actor,
     messageRef,
     triggerId: body.trigger_id,
     eventId,
+    identityContext: {
+      tenant: { id: body.team?.id ?? "unknown" },
+      installation: { id: body.api_app_id ?? "unknown" },
+      conversation: { id: conversationKey, kind: "thread" },
+      trigger: "interaction",
+      event: eventId ? { id: eventId } : {},
+      raw: { type: body.type, actionId: action.action_id },
+    },
   };
 }
 
@@ -129,6 +143,8 @@ function parseValue(raw: string | undefined): unknown {
 
 interface SlackReactionEvent {
   user?: string;
+  team?: string;
+  event_ts?: string;
   reaction?: string;
   item?: { type?: string; channel?: string; ts?: string };
 }
@@ -147,8 +163,21 @@ export function decodeReaction(
   return {
     rawEmoji: e.reaction,
     added,
-    user: e.user ? { id: e.user } : undefined,
+    actor: e.user
+      ? { id: e.user, kind: "human" }
+      : { id: "unknown", kind: "unknown" },
     conversationKey: conversationKeyOf({ channelId: channel, scope }),
+    identityContext: {
+      tenant: { id: e.team ?? "unknown" },
+      installation: { id: "unknown" },
+      conversation: {
+        id: conversationKeyOf({ channelId: channel, scope }),
+        kind: "thread",
+      },
+      trigger: "reaction",
+      event: e.event_ts ? { id: e.event_ts } : {},
+      raw: { reaction: e.reaction, added },
+    },
     // Thread the reply under the reacted message (channel/thread reactions);
     // DMs stay flat. A handler replying via thread.post/runAgent must land
     // under the reacted message, not at the channel root. Carry the reactor id
@@ -268,14 +297,25 @@ function decodeModalContext(privateMetadata: string | undefined): {
 /** Decode a Slack `view_submission` payload into an `IncomingModalSubmit`. */
 export function decodeViewSubmission(
   view: unknown,
-  user?: { id: string; name?: string },
+  actor?: { id: string; kind: "human"; name?: string },
 ): IncomingModalSubmit {
   const v = view as SlackViewState;
   const ctx = decodeModalContext(v.private_metadata);
   return {
     callbackId: v.callback_id ?? "",
     values: flattenViewValues(v),
-    user,
+    actor: actor ?? { id: "unknown", kind: "unknown" },
+    identityContext: {
+      tenant: { id: "unknown" },
+      installation: { id: "unknown" },
+      conversation: {
+        id: ctx.conversationKey ?? `modal:${v.callback_id ?? ""}`,
+        kind: "modal",
+      },
+      trigger: "modal-submit",
+      event: {},
+      raw: { callbackId: v.callback_id },
+    },
     privateMetadata: ctx.privateMetadata,
     ...(ctx.conversationKey ? { conversationKey: ctx.conversationKey } : {}),
     ...(ctx.replyTarget ? { replyTarget: ctx.replyTarget } : {}),
@@ -287,13 +327,24 @@ export function decodeViewSubmission(
 /** Decode a Slack `view_closed` payload into an `IncomingModalClose`. */
 export function decodeViewClosed(
   view: unknown,
-  user?: { id: string; name?: string },
+  actor?: { id: string; kind: "human"; name?: string },
 ): IncomingModalClose {
   const v = view as SlackViewState;
   const ctx = decodeModalContext(v.private_metadata);
   return {
     callbackId: v.callback_id ?? "",
-    user,
+    actor: actor ?? { id: "unknown", kind: "unknown" },
+    identityContext: {
+      tenant: { id: "unknown" },
+      installation: { id: "unknown" },
+      conversation: {
+        id: ctx.conversationKey ?? `modal:${v.callback_id ?? ""}`,
+        kind: "modal",
+      },
+      trigger: "modal-close",
+      event: {},
+      raw: { callbackId: v.callback_id },
+    },
     privateMetadata: ctx.privateMetadata,
     ...(ctx.conversationKey ? { conversationKey: ctx.conversationKey } : {}),
     ...(ctx.replyTarget ? { replyTarget: ctx.replyTarget } : {}),

--- a/packages/channels-slack/src/types.ts
+++ b/packages/channels-slack/src/types.ts
@@ -1,4 +1,4 @@
-import type { PlatformUser } from "@copilotkit/channels-core";
+import type { ProviderActor } from "@copilotkit/channels-core";
 import type { MessageOperation } from "@copilotkit/channels-ui";
 
 /**
@@ -56,7 +56,7 @@ export interface SlackAssistantOptions {
 export interface SlackFeedback {
   sentiment: "positive" | "negative";
   /** The user who clicked, if Slack supplied their identity. */
-  user?: PlatformUser;
+  user?: ProviderActor;
   /** Channel (or DM) the reply lives in. */
   channel: string;
   /** Thread the reply belongs to, if any. */

--- a/packages/channels-teams/README.md
+++ b/packages/channels-teams/README.md
@@ -32,6 +32,7 @@ import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 
 const bot = createChannel({
   name: "support-bot", // project-unique Intelligence Channel name
+  identifyUser: "platform",
   adapters: [teams({ port: 3978 })],
 });
 
@@ -44,7 +45,6 @@ const runtime = new CopilotRuntime({
     // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
-  identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),
   channels: [bot],
 });
 

--- a/packages/channels-teams/src/adapter.test.ts
+++ b/packages/channels-teams/src/adapter.test.ts
@@ -115,8 +115,10 @@ function messageContext(
     type: ActivityTypes.Message,
     text,
     attachments,
-    conversation: { id: "conv-1" },
-    from: { id: "user-1", name: "Sam" },
+    id: "event-1",
+    timestamp: new Date("2026-07-31T12:00:00.000Z"),
+    conversation: { id: "conv-1", tenantId: "tenant-1" },
+    from: { id: "user-1", name: "Sam", role: "user" },
     removeRecipientMention: () => text,
     getConversationReference: () => ({
       conversation: { id: "conv-1" },
@@ -152,6 +154,22 @@ describe("TeamsAdapter inbound files", () => {
     expect(sink.onTurn).toHaveBeenCalledTimes(1);
     const turn = sink.onTurn.mock.calls[0]![0];
     expect(turn.userText).toBe("chart this");
+    expect(turn.actor).toEqual({
+      id: "user-1",
+      kind: "human",
+      name: "Sam",
+    });
+    expect(turn.identityContext).toEqual(
+      expect.objectContaining({
+        tenant: { id: "tenant-1" },
+        conversation: { id: "conv-1", kind: "conversation" },
+        trigger: "message",
+        event: {
+          id: "event-1",
+          occurredAt: "2026-07-31T12:00:00.000Z",
+        },
+      }),
+    );
     expect(turn.contentParts).toBeDefined();
     // Leads with the user's text, then the decoded CSV as a text part.
     expect(turn.contentParts[0]).toEqual({ type: "text", text: "chart this" });

--- a/packages/channels-teams/src/adapter.ts
+++ b/packages/channels-teams/src/adapter.ts
@@ -14,8 +14,9 @@ import type {
   ReplyTarget,
   ConversationStore,
   MessageRef,
-  PlatformUser,
+  ProviderActor,
   UserQuery,
+  IngressIdentityContext,
 } from "@copilotkit/channels-core";
 import type {
   ChannelNode,
@@ -135,10 +136,13 @@ export class TeamsAdapter implements PlatformAdapter {
 
     const conversationKey = conversationKeyOf(activity);
     const reference = activity.getConversationReference();
-    const from = activity.from;
-    const user: PlatformUser | undefined = from?.id
-      ? { id: from.id, name: from.name }
-      : undefined;
+    const actor = this.actorFrom(activity);
+    const identityContext = this.identityContext(
+      activity,
+      conversationKey,
+      actor,
+      "message",
+    );
 
     // An Adaptive Card `Action.Submit` arrives as a Message activity carrying
     // our action `data` in `value` (and no user text). Route it as an
@@ -152,7 +156,11 @@ export class TeamsAdapter implements PlatformAdapter {
             id: action.id,
             conversationKey,
             value: action.value,
-            user,
+            actor,
+            identityContext: {
+              ...identityContext,
+              trigger: "interaction",
+            },
             replyTarget: {
               conversationKey,
               reference,
@@ -242,7 +250,8 @@ export class TeamsAdapter implements PlatformAdapter {
             revisionId: activity.id ?? conversationKey,
             mentioned: false,
           },
-          user,
+          actor,
+          identityContext,
           platform: this.platform,
           contentParts,
         });
@@ -533,12 +542,18 @@ export class TeamsAdapter implements PlatformAdapter {
     if (!action) return undefined;
     const conversationKey = conversationKeyOf(activity);
     const reference = activity.getConversationReference?.();
-    const from = activity.from;
+    const actor = this.actorFrom(activity);
     return {
       id: action.id,
       conversationKey,
       value: action.value,
-      user: from?.id ? { id: from.id, name: from.name } : undefined,
+      actor,
+      identityContext: this.identityContext(
+        activity,
+        conversationKey,
+        actor,
+        "interaction",
+      ),
       replyTarget: { conversationKey, reference } satisfies TeamsReplyTarget,
       messageRef: {
         id: activity.replyToId ?? "",
@@ -548,9 +563,74 @@ export class TeamsAdapter implements PlatformAdapter {
     };
   }
 
-  async lookupUser(_q: UserQuery): Promise<PlatformUser | undefined> {
+  async lookupUser(_q: UserQuery): Promise<ProviderActor | undefined> {
     // Directory lookups require Microsoft Graph; not wired in milestone-1.
     return undefined;
+  }
+
+  /** Classify the provider principal from the role Microsoft supplies. */
+  private actorFrom(activity: Activity): ProviderActor {
+    const from = activity.from as
+      | { id?: string; name?: string; role?: string }
+      | undefined;
+    const kind: ProviderActor["kind"] =
+      from?.role === "user"
+        ? "human"
+        : from?.role === "bot"
+          ? "bot"
+          : from?.role === "application"
+            ? "app"
+            : from?.role === "system"
+              ? "system"
+              : "unknown";
+    return {
+      id: from?.id ?? "",
+      kind,
+      ...(from?.name ? { name: from.name } : {}),
+    };
+  }
+
+  /** Build bounded identity facts from one Teams activity. */
+  private identityContext(
+    activity: Activity,
+    conversationKey: string,
+    _actor: ProviderActor,
+    trigger: string,
+  ): IngressIdentityContext {
+    const value = activity as Activity & {
+      id?: string;
+      timestamp?: Date | string;
+      conversation?: { id?: string; tenantId?: string };
+      channelData?: { tenant?: { id?: string }; channel?: { id?: string } };
+    };
+    const occurredAt = value.timestamp
+      ? new Date(value.timestamp).toISOString()
+      : undefined;
+    return {
+      tenant: {
+        id:
+          value.conversation?.tenantId ??
+          value.channelData?.tenant?.id ??
+          this.opts.tenantId ??
+          "unknown",
+      },
+      installation: {
+        id: this.opts.clientId ?? process.env.clientId ?? "anonymous",
+      },
+      conversation: {
+        id: value.conversation?.id ?? conversationKey,
+        kind: "conversation",
+      },
+      trigger,
+      event: {
+        ...(value.id ? { id: value.id } : {}),
+        ...(occurredAt ? { occurredAt } : {}),
+      },
+      raw: {
+        type: value.type,
+        channelId: value.channelData?.channel?.id,
+      },
+    };
   }
 
   get conversationStore(): ConversationStore {

--- a/packages/channels-telegram/README.md
+++ b/packages/channels-telegram/README.md
@@ -46,6 +46,7 @@ import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
 import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 
 const bot = createChannel({
+  identifyUser: "platform",
   name: "support-bot", // project-unique Intelligence Channel name
   adapters: [
     telegram({
@@ -75,7 +76,6 @@ const runtime = new CopilotRuntime({
     // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
-  identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),
   channels: [bot],
 });
 
@@ -260,7 +260,7 @@ await bot.api.setWebhook(url, {
 
 `telegram`, `TelegramAdapter`, `TelegramAdapterOptions`;
 `createRunRenderer`, `CreateRunRendererArgs`;
-`decodeInteraction`, `conversationKeyOf`, `deriveConversationKey`, `toPlatformUser`;
+`decodeInteraction`, `conversationKeyOf`, `deriveConversationKey`, `toProviderActor`;
 `renderTelegram`; `TELEGRAM_LIMITS`, `truncateText`, `clampArray`, `byteLen`;
 `defaultTelegramTools`, `lookupTelegramUserTool`;
 `defaultTelegramContext`, `telegramTaggingContext`, `telegramFormattingContext`,

--- a/packages/channels-telegram/src/__tests__/ephemeral.test.ts
+++ b/packages/channels-telegram/src/__tests__/ephemeral.test.ts
@@ -11,7 +11,7 @@ it("DMs the user when fallbackToDM=true", async () => {
   a.bot = { api: { sendMessage } };
   const res = await a.postEphemeral!(
     { chatId: 99 },
-    { id: "1" },
+    { id: "1", kind: "human" },
     [{ type: "text", props: { value: "hi" } }],
     { fallbackToDM: true },
   );
@@ -27,7 +27,7 @@ it("returns null when fallbackToDM=false", async () => {
   const a = new TelegramAdapter({ token: "t" });
   const res = await a.postEphemeral!(
     { chatId: 99 },
-    { id: "1" },
+    { id: "1", kind: "human" },
     [{ type: "text", props: { value: "hi" } }],
     { fallbackToDM: false },
   );

--- a/packages/channels-telegram/src/__tests__/interaction.test.ts
+++ b/packages/channels-telegram/src/__tests__/interaction.test.ts
@@ -127,7 +127,17 @@ describe("interaction", () => {
     expect(evt?.id).toBe("ck:abc");
     expect(evt?.conversationKey).toBe("tg:42:dm");
     expect(evt?.messageRef).toMatchObject({ chatId: 42, messageId: 99 });
-    expect(evt?.user).toMatchObject({ id: "7", name: "Ada", handle: "ada" });
+    expect(evt?.actor).toMatchObject({
+      id: "7",
+      kind: "human",
+      name: "Ada",
+      handle: "ada",
+    });
+    expect(evt?.identityContext).toMatchObject({
+      tenant: { id: "42" },
+      conversation: { id: "tg:42:dm", kind: "private" },
+      trigger: "interaction",
+    });
   });
   it("returns undefined for non-callback payloads", () => {
     expect(decodeInteraction({ message: {} })).toBeUndefined();

--- a/packages/channels-telegram/src/__tests__/reactions.test.ts
+++ b/packages/channels-telegram/src/__tests__/reactions.test.ts
@@ -17,7 +17,11 @@ it("emits an added event for a newly added emoji", () => {
     rawEmoji: "👍",
     added: true,
     messageId: "7",
-    user: { id: "1", handle: "ada" },
+    actor: { id: "1", kind: "human", handle: "ada" },
+    identityContext: {
+      tenant: { id: "42" },
+      trigger: "reaction",
+    },
   });
 });
 

--- a/packages/channels-telegram/src/adapter.ts
+++ b/packages/channels-telegram/src/adapter.ts
@@ -9,7 +9,7 @@ import type {
   ReplyTarget as BotReplyTarget,
   ConversationStore,
   MessageRef,
-  PlatformUser,
+  ProviderActor,
   UserQuery,
   CommandSpec,
 } from "@copilotkit/channels-core";
@@ -509,7 +509,7 @@ export class TelegramAdapter implements PlatformAdapter {
     return decodeInteraction(raw);
   }
 
-  async lookupUser(q: UserQuery): Promise<PlatformUser | undefined> {
+  async lookupUser(q: UserQuery): Promise<ProviderActor | undefined> {
     const query = q.query.trim();
     if (!query.startsWith("@")) return undefined;
     try {
@@ -521,6 +521,7 @@ export class TelegramAdapter implements PlatformAdapter {
       };
       return {
         id: String(chat.id),
+        kind: "human",
         name: chat.title ?? chat.first_name,
         handle: chat.username,
       };
@@ -655,7 +656,7 @@ export class TelegramAdapter implements PlatformAdapter {
 
   async postEphemeral(
     _target: BotReplyTarget,
-    user: PlatformUser | string,
+    user: ProviderActor | string,
     ir: ChannelNode[],
     opts: { fallbackToDM: boolean },
   ): Promise<EphemeralResult | null> {

--- a/packages/channels-telegram/src/index.ts
+++ b/packages/channels-telegram/src/index.ts
@@ -7,7 +7,7 @@ export {
   decodeInteraction,
   conversationKeyOf,
   deriveConversationKey,
-  toPlatformUser,
+  toProviderActor,
 } from "./interaction.js";
 
 export { renderTelegram } from "./render/telegram.js";

--- a/packages/channels-telegram/src/interaction.ts
+++ b/packages/channels-telegram/src/interaction.ts
@@ -2,7 +2,7 @@ import type {
   InteractionEvent,
   IncomingReaction,
 } from "@copilotkit/channels-core";
-import type { PlatformUser } from "@copilotkit/channels-ui";
+import type { ProviderActor } from "@copilotkit/channels-ui";
 import { DM_SCOPE } from "./types.js";
 import type {
   ConversationKey,
@@ -64,19 +64,20 @@ export function deriveConversationKey(
 }
 
 /**
- * Map a Telegram `from` user to a PlatformUser.
+ * Map a Telegram `from` user to a ProviderActor.
  */
-export function toPlatformUser(from: {
+export function toProviderActor(from: {
   id: number;
   first_name?: string;
   last_name?: string;
   username?: string;
-}): PlatformUser | undefined {
+}): ProviderActor | undefined {
   if (!from) return undefined;
   const name =
     [from.first_name, from.last_name].filter(Boolean).join(" ") || undefined;
   return {
     id: String(from.id),
+    kind: "human",
     name,
     handle: from.username,
   };
@@ -126,15 +127,23 @@ export function decodeReaction(update: unknown): IncomingReaction[] {
     messageThreadId: mr.chat.is_forum ? mr.message_thread_id : undefined,
     conversationKey,
   };
-  const user = mr.user
+  const actor = mr.user
     ? {
         id: String(mr.user.id),
+        kind: "human" as const,
         name: mr.user.first_name,
         handle: mr.user.username,
       }
     : undefined;
   const base = {
-    user,
+    actor: actor ?? { id: "unknown", kind: "unknown" as const },
+    identityContext: telegramIdentityContext({
+      chat: mr.chat,
+      conversationKey,
+      trigger: "reaction",
+      eventId: String(mr.message_id),
+      raw: update,
+    }),
     conversationKey,
     replyTarget,
     messageId: String(mr.message_id),
@@ -209,13 +218,41 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
     messageId: message.message_id,
   };
 
-  const user = from ? toPlatformUser(from) : undefined;
+  const actor = from ? toProviderActor(from) : undefined;
 
   return {
     id: cq.data as string,
     conversationKey,
     replyTarget,
     messageRef,
-    user,
+    actor: actor ?? { id: "unknown", kind: "unknown" },
+    identityContext: telegramIdentityContext({
+      chat: message.chat,
+      conversationKey,
+      trigger: "interaction",
+      eventId: String(cq.id ?? message.message_id),
+      raw,
+    }),
+  };
+}
+
+/** Build event-scoped Telegram identity facts without resolving a profile. */
+export function telegramIdentityContext(input: {
+  chat?: { id?: number | string; type?: string };
+  conversationKey: string;
+  trigger: string;
+  eventId?: string;
+  raw: unknown;
+}) {
+  return {
+    tenant: { id: String(input.chat?.id ?? "unknown") },
+    installation: { id: "telegram-bot" },
+    conversation: {
+      id: input.conversationKey,
+      kind: input.chat?.type,
+    },
+    trigger: input.trigger,
+    event: { id: input.eventId },
+    raw: input.raw,
   };
 }

--- a/packages/channels-telegram/src/listener.ts
+++ b/packages/channels-telegram/src/listener.ts
@@ -4,9 +4,10 @@ import type { TelegramConversationStore } from "./conversation-store.js";
 import {
   conversationKeyOf,
   deriveConversationKey,
-  toPlatformUser,
+  toProviderActor,
   decodeInteraction,
   decodeReaction,
+  telegramIdentityContext,
 } from "./interaction.js";
 import { buildFileContentParts } from "./download-files.js";
 import type { AgentContentPart, TelegramFileRef } from "./download-files.js";
@@ -233,7 +234,7 @@ export function attachTelegramListener(config: ListenerConfig): void {
       text: strippedText,
       ts: String(msg.message_id),
       isBot: false,
-      user: from ? toPlatformUser(from) : undefined,
+      user: from ? toProviderActor(from) : undefined,
     });
 
     // CRITICAL: run the turn WITHOUT blocking grammY's poll loop. grammY's
@@ -268,7 +269,16 @@ export function attachTelegramListener(config: ListenerConfig): void {
           conversationKey: turnConversationKey,
         },
         userText: strippedText,
-        user: from ? toPlatformUser(from) : undefined,
+        actor: from
+          ? toProviderActor(from)!
+          : { id: "unknown", kind: "unknown" },
+        identityContext: telegramIdentityContext({
+          chat: ctx.chat,
+          conversationKey: turnConversationKey,
+          trigger: "message",
+          eventId: String(msg.message_id),
+          raw: msg,
+        }),
         platform: "telegram",
       }),
     ).catch((e: unknown) => {
@@ -411,7 +421,16 @@ export function attachTelegramListener(config: ListenerConfig): void {
               : undefined,
             conversationKey: commandConversationKey,
           },
-          user: from ? toPlatformUser(from) : undefined,
+          actor: from
+            ? toProviderActor(from)!
+            : { id: "unknown", kind: "unknown" },
+          identityContext: telegramIdentityContext({
+            chat: ctx.chat,
+            conversationKey: commandConversationKey,
+            trigger: "command",
+            eventId: String(msg.message_id),
+            raw: msg,
+          }),
           platform: "telegram",
         }),
       ).catch((e: unknown) =>
@@ -564,7 +583,16 @@ export function attachTelegramListener(config: ListenerConfig): void {
         chatId: ctx.chat.id,
         conversationKey: startConversationKey,
       },
-      user: msg.from ? toPlatformUser(msg.from) : undefined,
+      actor: msg.from
+        ? toProviderActor(msg.from)!
+        : { id: "unknown", kind: "unknown" },
+      identityContext: telegramIdentityContext({
+        chat: ctx.chat,
+        conversationKey: startConversationKey,
+        trigger: "thread_start",
+        eventId: String(msg.message_id),
+        raw: msg,
+      }),
       platform: "telegram",
     });
   });

--- a/packages/channels-ui/README.md
+++ b/packages/channels-ui/README.md
@@ -154,7 +154,8 @@ interface InteractionContext<TValue = unknown> {
   message: IncomingMessage;
   action: { id: string; value?: TValue };
   values: Record<string, unknown>;
-  user: PlatformUser;
+  user: ApplicationUser | null;
+  actor: ProviderActor;
   platform: string;
 }
 ```
@@ -163,7 +164,7 @@ interface InteractionContext<TValue = unknown> {
 from `value` — `<Button value={{ confirmed: true }} onClick={(ctx) => ctx.action.value?.confirmed}>`
 type-checks with no cast. `Select`/`Input` resolve the value to `string`.
 
-The structural types `Thread`, `IncomingMessage`, `PlatformUser`,
+The structural types `Thread`, `IncomingMessage`, `ApplicationUser`, `ProviderActor`,
 `MessageRef`, and `ClickHandler` are declared here for handler typing only —
 they're implemented at runtime by `@copilotkit/channels` and its adapters.
 `@copilotkit/channels-ui` has no runtime dependency on them.
@@ -192,6 +193,6 @@ Runtime: `renderToIR`, `Fragment`, `bind`, and the vocabulary
 (`Message`, `Header`, `Section`, `Markdown`, `Field`, `Fields`, `Context`,
 `Actions`, `Button`, `Select`, `Input`, `Image`, `Divider`).
 Types: `BotNode`, `BotChildren`, `ComponentFn`, `Renderable`, `Thread`,
-`InteractionContext`, `PlatformUser`, `IncomingMessage`, `MessageRef`,
+`InteractionContext`, `ApplicationUser`, `ProviderActor`, `IncomingMessage`, `MessageRef`,
 `ClickHandler`, and the per-component prop types (`MessageProps`,
 `ButtonProps`, `SelectProps`, `TableProps`, `TableColumn`, …).

--- a/packages/channels-ui/src/types.ts
+++ b/packages/channels-ui/src/types.ts
@@ -14,13 +14,20 @@ export interface EphemeralResult {
   ref?: MessageRef;
   error?: string;
 }
-export interface PlatformUser {
-  id: string;
+/** Canonical application identity selected by the Channel developer. */
+export interface ApplicationUser {
+  readonly id: string;
+  readonly name: string;
+}
+
+/** Provider account that caused the current Channel event. */
+export interface ProviderActor {
+  readonly id: string;
   /** Provider-reported category; untrusted identity metadata, never authorization. */
-  kind?: "human" | "bot" | "app" | "system";
-  name?: string;
-  handle?: string;
-  email?: string;
+  readonly kind: "human" | "bot" | "app" | "system" | "unknown";
+  readonly name?: string;
+  readonly handle?: string;
+  readonly email?: string;
 }
 
 /** Provider-neutral identity and dispatch semantics for one message revision. */
@@ -56,7 +63,10 @@ export type AgentContentPart =
 
 export interface IncomingMessage {
   text: string;
-  user: PlatformUser;
+  /** Canonical application user for this event, or null when identity did not map. */
+  user: ApplicationUser | null;
+  /** Provider account that caused this event. Never used as a canonical user implicitly. */
+  actor: ProviderActor;
   ref: MessageRef;
   platform: string;
   /** Present for provider message hooks; specialized interaction contexts omit it. */
@@ -67,11 +77,6 @@ export interface IncomingMessage {
    * `text` as the agent prompt so the model receives the attachments.
    */
   contentParts?: AgentContentPart[];
-  /**
-   * Cross-platform identity key resolved by the channel's `identity` resolver, if
-   * any. Stable across platforms for the same human (e.g. an email address).
-   */
-  userKey?: string;
   /**
    * Stable platform event id (managed/Intelligence path), for customer-side
    * idempotency. Omitted by adapters that don't surface one.
@@ -88,7 +93,7 @@ export interface ChannelMessage extends IncomingMessage {
   operation: MessageOperation;
 }
 export interface ThreadMessage {
-  user?: PlatformUser;
+  user?: ProviderActor;
   text: string;
   /** Structured AG-UI message content when the platform preserves it. */
   content?: unknown;
@@ -147,7 +152,16 @@ export interface Thread {
    */
   awaitChoice<T = unknown>(ui: Renderable): Promise<T>;
   runAgent(input?: unknown): Promise<MessageRef | undefined>;
-  resume(value: unknown): Promise<MessageRef | undefined>;
+  resume(
+    value: unknown,
+    options?: {
+      memory?: {
+        user?: "none" | "read" | "read-write";
+        project?: "none" | "read" | "read-write";
+      };
+      subject?: "initiator" | "actor";
+    },
+  ): Promise<MessageRef | undefined>;
   stream(src: string | AsyncIterable<string>): Promise<MessageRef>;
   postFile(args: {
     bytes: Uint8Array;
@@ -163,7 +177,7 @@ export interface Thread {
   /** Read the conversation's messages (capability-gated; returns `[]` when the adapter can't read history). */
   getMessages(): Promise<ThreadMessage[]>;
   /** Resolve a platform user by a free-form query (capability-gated; returns `undefined` when unsupported). */
-  lookupUser(query: string): Promise<PlatformUser | undefined>;
+  lookupUser(query: string): Promise<ProviderActor | undefined>;
   /** Pin suggested prompts (capability-gated; returns `{ ok: false }` on surfaces without support). */
   setSuggestedPrompts(
     prompts: ReadonlyArray<{ title: string; message: string }>,
@@ -187,7 +201,7 @@ export interface Thread {
    * resolve to `null` when native ephemeral is unsupported.
    */
   postEphemeral(
-    user: PlatformUser | string,
+    user: ProviderActor | string,
     ui: Renderable,
     opts: { fallbackToDM: boolean },
   ): Promise<EphemeralResult | null>;
@@ -208,7 +222,8 @@ export interface InteractionContext<TValue = unknown> {
   /** The clicked control: its opaque `id` and the `value` it carried (typed as `TValue`). */
   action: { id: string; value?: TValue };
   values: Record<string, unknown>;
-  user: PlatformUser;
+  user: ApplicationUser | null;
+  actor: ProviderActor;
   platform: string;
   /**
    * Open a modal in response to this interaction (capability-gated; requires a
@@ -231,7 +246,8 @@ export interface MessageReaction {
   /** `true` = added, `false` = removed. */
   added: boolean;
   /** The reacting user, when the platform reports one. */
-  user?: PlatformUser;
+  user: ApplicationUser | null;
+  actor: ProviderActor;
   /** Id of the reacted-to message. */
   messageId: string;
   /**

--- a/packages/channels-whatsapp/README.md
+++ b/packages/channels-whatsapp/README.md
@@ -32,6 +32,7 @@ import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
 import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 
 const bot = createChannel({
+  identifyUser: "platform",
   name: "support-bot", // project-unique Intelligence Channel name
   adapters: [
     whatsapp({
@@ -59,7 +60,6 @@ const runtime = new CopilotRuntime({
     // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
-  identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),
   channels: [bot],
 });
 

--- a/packages/channels-whatsapp/src/adapter.ts
+++ b/packages/channels-whatsapp/src/adapter.ts
@@ -10,7 +10,7 @@ import type {
 import type {
   ChannelNode,
   MessageRef,
-  PlatformUser,
+  ProviderActor,
   ThreadMessage,
 } from "@copilotkit/channels-ui";
 import type {
@@ -99,6 +99,7 @@ export class WhatsAppAdapter implements PlatformAdapter {
           sink: this.sink,
           history: this.history,
           phoneNumberId: this.opts.phoneNumberId,
+          tenantId: entry.id,
           commandPrefix: this.commandPrefix,
           client: this.client,
           files: this.opts.files ?? {},
@@ -162,7 +163,7 @@ export class WhatsAppAdapter implements PlatformAdapter {
     return decodeInteraction(r.message, r.replyTarget);
   }
 
-  async lookupUser(_q: UserQuery): Promise<PlatformUser | undefined> {
+  async lookupUser(_q: UserQuery): Promise<ProviderActor | undefined> {
     return undefined; // WhatsApp exposes no user directory.
   }
 

--- a/packages/channels-whatsapp/src/interaction.test.ts
+++ b/packages/channels-whatsapp/src/interaction.test.ts
@@ -22,12 +22,18 @@ describe("decodeInteraction", () => {
       },
     };
     const evt = decodeInteraction(msg, target);
-    expect(evt).toEqual({
+    expect(evt).toMatchObject({
       id: "ck:42",
       conversationKey: "whatsapp:15551234567",
       replyTarget: target,
       value: undefined,
-      user: { id: "15551234567" },
+      actor: { id: "15551234567", kind: "human" },
+      identityContext: {
+        tenant: { id: "PNID" },
+        installation: { id: "PNID" },
+        conversation: { id: "whatsapp:15551234567", kind: "direct" },
+        trigger: "interaction",
+      },
       messageRef: { id: "wamid.A", to: "15551234567", phoneNumberId: "PNID" },
     });
   });

--- a/packages/channels-whatsapp/src/interaction.ts
+++ b/packages/channels-whatsapp/src/interaction.ts
@@ -54,7 +54,15 @@ export function decodeInteraction(
     conversationKey: conversationKeyOf(msg.from),
     replyTarget,
     value,
-    user: { id: msg.from },
+    actor: { id: msg.from, kind: "human" },
+    identityContext: {
+      tenant: { id: replyTarget.phoneNumberId },
+      installation: { id: replyTarget.phoneNumberId },
+      conversation: { id: conversationKeyOf(msg.from), kind: "direct" },
+      trigger: "interaction",
+      event: { id: msg.id, occurredAt: msg.timestamp },
+      raw: msg,
+    },
     messageRef: {
       id: msg.id,
       to: replyTarget.to,

--- a/packages/channels-whatsapp/src/webhook-listener.test.ts
+++ b/packages/channels-whatsapp/src/webhook-listener.test.ts
@@ -45,7 +45,13 @@ describe("handleWebhookValue", () => {
         },
         userText: "hello",
         platform: "whatsapp",
-        user: { id: "111", name: "Ada" },
+        actor: { id: "111", kind: "human", name: "Ada" },
+        identityContext: expect.objectContaining({
+          tenant: { id: "PNID" },
+          installation: { id: "PNID" },
+          conversation: { id: "whatsapp:111", kind: "direct" },
+          trigger: "message",
+        }),
         replyTarget: { to: "111", phoneNumberId: "PNID" },
       }),
     );

--- a/packages/channels-whatsapp/src/webhook-listener.ts
+++ b/packages/channels-whatsapp/src/webhook-listener.ts
@@ -1,5 +1,5 @@
 import type { IngressSink } from "@copilotkit/channels-core";
-import type { PlatformUser } from "@copilotkit/channels-ui";
+import type { ProviderActor } from "@copilotkit/channels-ui";
 import type { ChangeValue, ReplyTarget } from "./types.js";
 import type { HistoryStore } from "./history-store.js";
 import type { WhatsAppClient } from "./client.js";
@@ -12,6 +12,7 @@ export interface WebhookListenerArgs {
   sink: IngressSink;
   history: HistoryStore;
   phoneNumberId: string;
+  tenantId?: string;
   commandPrefix: string;
   client: Pick<WhatsAppClient, "downloadMedia" | "sendReadReceipt">;
   files: FileDeliveryConfig;
@@ -36,9 +37,20 @@ export async function handleWebhookValue(
       to: msg.from,
       phoneNumberId: args.phoneNumberId,
     };
-    const user: PlatformUser = { id: msg.from };
     const name = nameByWaId.get(msg.from);
-    if (name) user.name = name;
+    const actor: ProviderActor = {
+      id: msg.from,
+      kind: "human",
+      ...(name ? { name } : {}),
+    };
+    const conversationKey = conversationKeyOf(msg.from);
+    const identityContext = {
+      tenant: { id: args.tenantId ?? args.phoneNumberId },
+      installation: { id: args.phoneNumberId },
+      conversation: { id: conversationKey, kind: "direct" },
+      event: { id: msg.id, occurredAt: msg.timestamp },
+      raw: msg,
+    };
 
     // Acknowledge immediately: mark read + show a typing indicator so the user
     // sees activity during the (non-streaming) agent run. Best-effort — a
@@ -53,7 +65,11 @@ export async function handleWebhookValue(
     if (msg.type === "interactive") {
       const evt = decodeInteraction(msg, replyTarget);
       if (evt) {
-        if (name) evt.user = { id: msg.from, name };
+        evt.actor = actor;
+        evt.identityContext = {
+          ...identityContext,
+          trigger: "interaction",
+        };
         await args.sink.onInteraction(evt);
       }
       continue;
@@ -62,7 +78,6 @@ export async function handleWebhookValue(
     // 2. Text → command or turn.
     if (msg.type === "text" && msg.text?.body) {
       const body = msg.text.body;
-      const conversationKey = conversationKeyOf(msg.from);
       if (body.startsWith(args.commandPrefix)) {
         const rest = body.slice(args.commandPrefix.length);
         const space = rest.indexOf(" ");
@@ -78,7 +93,8 @@ export async function handleWebhookValue(
           text,
           conversationKey,
           replyTarget,
-          user,
+          actor,
+          identityContext: { ...identityContext, trigger: "command" },
           platform: "whatsapp",
         });
         continue;
@@ -115,7 +131,8 @@ export async function handleWebhookValue(
         },
         replyTarget,
         userText,
-        user,
+        actor,
+        identityContext: { ...identityContext, trigger: "message" },
         platform: "whatsapp",
       });
       continue;
@@ -123,7 +140,6 @@ export async function handleWebhookValue(
 
     // 3. Media → turn with multimodal content stored in history.
     if (MEDIA_TYPES.includes(msg.type as (typeof MEDIA_TYPES)[number])) {
-      const conversationKey = conversationKeyOf(msg.from);
       const mediaObj = (msg as unknown as Record<string, WhatsAppMediaRef>)[
         msg.type
       ];
@@ -159,7 +175,8 @@ export async function handleWebhookValue(
         },
         replyTarget,
         userText: caption,
-        user,
+        actor,
+        identityContext: { ...identityContext, trigger: "message" },
         platform: "whatsapp",
       });
       continue;

--- a/packages/channels/README.md
+++ b/packages/channels/README.md
@@ -33,6 +33,7 @@ import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 
 const channel = createChannel({
   name: "support-bot", // project-unique Intelligence Channel name
+  identifyUser: "platform",
   adapters: [
     slack({
       botToken: process.env.SLACK_BOT_TOKEN!,
@@ -56,7 +57,6 @@ const runtime = new CopilotRuntime({
     // both together only for a self-hosted deployment.
     apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!, // free tier available
   }),
-  identifyUser: async () => ({ id: "support-bot", name: "Support Bot" }),
   channels: [channel],
 });
 

--- a/packages/core/src/__tests__/memory.test.ts
+++ b/packages/core/src/__tests__/memory.test.ts
@@ -353,6 +353,26 @@ describe("memory store realtime", () => {
     return store;
   }
 
+  async function connectedProjectOnlyRealtimeStore() {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [] }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          projectJoinToken: "pjt-1",
+          projectJoinCode: "pjc-1",
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const store = createMemoryStore(memoryEnvironment(fetchMock));
+    store.start();
+    store.setContext(realtimeContext);
+    await flushEffects();
+    return store;
+  }
+
   /** A `project`-scoped `created` event as broadcast on the project channel. */
   function projectCreatedEvent(
     id: string,
@@ -603,6 +623,20 @@ describe("memory store realtime", () => {
     // Both channels are actually joined.
     expect(phoenix.sockets[0]?.channels[0]?.joinCount).toBeGreaterThan(0);
     expect(phoenix.sockets[1]?.channels[0]?.joinCount).toBeGreaterThan(0);
+
+    store.stop();
+  });
+
+  it("opens the project channel when personal Memory is denied", async () => {
+    const store = await connectedProjectOnlyRealtimeStore();
+
+    expect(phoenix.sockets).toHaveLength(1);
+    expect(phoenix.sockets[0]?.channels[0]?.topic).toBe(
+      "project_meta:memories:pjc-1",
+    );
+    expect(phoenix.sockets[0]?.opts.params).toMatchObject({
+      join_token: "pjt-1",
+    });
 
     store.stop();
   });

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -205,8 +205,8 @@ const memoryRestEvents = createActionGroup("Memory REST", {
   credentialsRequested: props<{ sessionId: number }>(),
   credentialsSucceeded: props<{
     sessionId: number;
-    joinToken: string;
-    joinCode: string;
+    joinToken?: string;
+    joinCode?: string;
     // Optional project-scoped realtime credentials. Present only when the
     // caller's API key resolves a project scope (B1b `/memories/subscribe`
     // returns them alongside the user credentials); omitted otherwise. When
@@ -697,8 +697,8 @@ function createMemoryCredentialsFetchObservable(
         }
 
         return response.json() as Promise<{
-          joinToken: string;
-          joinCode: string;
+          joinToken?: string;
+          joinCode?: string;
           projectJoinToken?: string;
           projectJoinCode?: string;
         }>;
@@ -715,12 +715,11 @@ function createMemoryCredentialsFetchObservable(
         },
       }),
       map((data) => {
-        if (typeof data.joinToken !== "string" || data.joinToken.length === 0) {
-          throw new Error("missing joinToken");
-        }
-        if (typeof data.joinCode !== "string" || data.joinCode.length === 0) {
-          throw new Error("missing joinCode");
-        }
+        const hasUserCreds =
+          typeof data.joinToken === "string" &&
+          data.joinToken.length > 0 &&
+          typeof data.joinCode === "string" &&
+          data.joinCode.length > 0;
 
         // Project credentials are optional and only forwarded when BOTH are
         // non-empty strings (the silent-degrade contract): a partial/malformed
@@ -732,11 +731,15 @@ function createMemoryCredentialsFetchObservable(
           data.projectJoinToken.length > 0 &&
           typeof data.projectJoinCode === "string" &&
           data.projectJoinCode.length > 0;
+        if (!hasUserCreds && !hasProjectCreds) {
+          throw new Error("missing memory realtime credentials");
+        }
 
         return memoryRestEvents.credentialsSucceeded({
           sessionId,
-          joinToken: data.joinToken,
-          joinCode: data.joinCode,
+          ...(hasUserCreds
+            ? { joinToken: data.joinToken, joinCode: data.joinCode }
+            : {}),
           ...(hasProjectCreds
             ? {
                 projectJoinToken: data.projectJoinToken,
@@ -1203,6 +1206,11 @@ function createMemoryStore(environment: MemoryEnvironment): MemoryStore {
           const context = state.context as MemoryRuntimeContext;
           const { joinToken, joinCode, projectJoinToken, projectJoinCode } =
             action;
+          const primaryJoinToken = joinToken ?? projectJoinToken!;
+          const primaryTopic =
+            joinToken && joinCode
+              ? `user_meta:memories:${joinCode}`
+              : `project_meta:memories:${projectJoinCode!}`;
           const sessionId = action.sessionId;
           const shutdown$ = actions$.pipe(
             ofType(
@@ -1266,14 +1274,14 @@ function createMemoryStore(environment: MemoryEnvironment): MemoryStore {
             const socket$ = ɵphoenixSocket$({
               url: context.wsUrl,
               options: {
-                params: { join_token: joinToken },
+                params: { join_token: primaryJoinToken },
                 reconnectAfterMs: phoenixExponentialBackoff(100, 10_000),
                 rejoinAfterMs: phoenixExponentialBackoff(1_000, 30_000),
               },
             }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
             const channel$ = ɵphoenixChannel$({
               socket$,
-              topic: `user_meta:memories:${joinCode}`,
+              topic: primaryTopic,
             }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
             const socketSignals$ =
               ɵobservePhoenixSocketSignals$(socket$).pipe(share());
@@ -1334,10 +1342,7 @@ function createMemoryStore(environment: MemoryEnvironment): MemoryStore {
                 of(memoryDomainEvents.realtimeConnected({ sessionId })),
               ),
               catchError((error) => {
-                console.warn(
-                  `[memory] failed to join user_meta:memories:${joinCode}`,
-                  error,
-                );
+                console.warn(`[memory] failed to join ${primaryTopic}`, error);
                 return of(
                   memoryDomainEvents.realtimeUnavailable({ sessionId }),
                 );
@@ -1350,7 +1355,7 @@ function createMemoryStore(environment: MemoryEnvironment): MemoryStore {
             // without going stale. Absent project creds -> `EMPTY`: user-only,
             // no second socket, no status regression (silent degrade).
             const projectMetadata$ =
-              projectJoinToken && projectJoinCode
+              joinToken && joinCode && projectJoinToken && projectJoinCode
                 ? channelMetadata$(
                     projectJoinToken,
                     `project_meta:memories:${projectJoinCode}`,

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -55,6 +55,41 @@
 
 To get started with CopilotKit, please check out the [documentation](https://docs.copilotkit.ai).
 
+## Intelligence identity and Memory
+
+An Intelligence Runtime supports web only, Channels only, or both. Web routes
+need `identifyUser(request)`. Each Channel has its own `identifyUser` policy in
+`createChannel`. A Channels-only Runtime omits the web callback and exposes no
+functional web routes.
+
+```ts
+const runtime = new CopilotRuntime({
+  agents,
+  intelligence,
+  identifyUser: authenticateApplicationUser,
+  channels: [supportChannel],
+  memory: {
+    access: async ({ request, user, consumer }) => {
+      const role = await roleFor(request, user);
+      if (role === "blocked") return null;
+      return consumer === "client"
+        ? { user: "read", project: "none" }
+        : { user: "read-write", project: "read" };
+    },
+  },
+});
+```
+
+The callback runs once per web request. Its user owns ordinary web Threads and
+is reused for agent and browser Memory policy. Adding `memory` exposes the
+browser Memory routes and agent tools under the same policy. A denial returns
+403; a policy error fails the request. Omitting `memory` hides the browser
+routes and does not attach Memory tools.
+
+`exposeMemoryRoutes` and
+`CopilotKitIntelligence({ enableEnterpriseLearning: true })` remain for one
+compatibility window. New code should use `memory.access`.
+
 ## Analytics & Privacy
 
 CopilotKit uses [Scarf](https://scarf.sh) for anonymous usage analytics to help improve the product. Scarf handles all privacy compliance and does not store raw IP addresses. This helps us understand how CopilotKit is being used and prioritize improvements.

--- a/packages/runtime/src/v2/runtime/__tests__/channels-integration.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/channels-integration.test.ts
@@ -107,7 +107,12 @@ describe("createCopilotRuntimeHandler — channel activation (integration)", () 
       intelligence,
       identifyUser,
       channels: [
-        createChannel({ name: "support", agent, showToolStatus: true }),
+        createChannel({
+          identifyUser: "platform",
+          name: "support",
+          agent,
+          showToolStatus: true,
+        }),
       ],
     });
 

--- a/packages/runtime/src/v2/runtime/__tests__/channels-option.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/channels-option.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { CopilotRuntime } from "../core/runtime";
+import { createCopilotRuntimeHandler } from "../core/fetch-handler";
 import { CopilotKitIntelligence } from "../intelligence-platform";
 import { createChannel } from "@copilotkit/channels";
 
@@ -13,7 +14,7 @@ const identifyUser = vi.fn().mockResolvedValue({ id: "u", name: "U" });
 
 describe("CopilotRuntime — channels option", () => {
   it("intelligence runtime exposes declared channels", () => {
-    const ch = createChannel({ name: "support" });
+    const ch = createChannel({ identifyUser: "platform", name: "support" });
     const rt = new CopilotRuntime({
       agents: {},
       intelligence: intelligence(),
@@ -23,8 +24,128 @@ describe("CopilotRuntime — channels option", () => {
     expect(rt.channels).toEqual([ch]);
   });
 
+  it("accepts a Channels-only Intelligence runtime", () => {
+    const ch = createChannel({ identifyUser: "platform", name: "support" });
+    const rt = new CopilotRuntime({
+      agents: {},
+      intelligence: intelligence(),
+      channels: [ch],
+    });
+
+    expect(rt.channels).toEqual([ch]);
+    expect(rt.identifyUser).toBeUndefined();
+  });
+
+  it("copies the declared Channel list during construction", () => {
+    const ch = createChannel({ identifyUser: "platform", name: "support" });
+    const channels: [typeof ch] = [ch];
+    const rt = new CopilotRuntime({
+      agents: {},
+      intelligence: intelligence(),
+      channels,
+    });
+
+    channels.pop();
+    expect(rt.channels).toHaveLength(1);
+    expect(rt.channels?.[0]).toBe(ch);
+  });
+
+  it("web Memory configuration exposes both agent policy and client routes", () => {
+    const access = vi.fn().mockReturnValue({
+      user: "read-write",
+      project: "read",
+    });
+    const rt = new CopilotRuntime({
+      agents: {},
+      intelligence: intelligence(),
+      identifyUser,
+      memory: { access },
+    });
+
+    expect(rt.memory).toEqual({ access });
+    expect(rt.exposeMemoryRoutes).toBe(true);
+  });
+
+  it.each([
+    { agents: {}, intelligence: intelligence() },
+    { agents: {}, intelligence: intelligence(), channels: [] },
+    {
+      agents: {},
+      intelligence: intelligence(),
+      identifyUser: "not-a-callback",
+    },
+    {
+      agents: {},
+      intelligence: intelligence(),
+      identifyUser,
+      memory: { access: "not-a-callback" },
+    },
+  ])("rejects an Intelligence runtime with no valid surface", (options) => {
+    expect(
+      () =>
+        new CopilotRuntime(
+          options as unknown as ConstructorParameters<typeof CopilotRuntime>[0],
+        ),
+    ).toThrow(/identifyUser|Channel|surface|memory/i);
+  });
+
+  it("hides every functional web route for a Channels-only runtime", async () => {
+    const runtime = new CopilotRuntime({
+      agents: { hidden: {} as never },
+      intelligence: intelligence(),
+      transcriptionService: {} as never,
+      exposeMemoryRoutes: true,
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
+    });
+    const handler = createCopilotRuntimeHandler({
+      runtime,
+      activateChannels: false,
+    });
+    const routes: Array<[string, string]> = [
+      ["POST", "/agent/hidden/run"],
+      ["POST", "/agent/hidden/suggest"],
+      ["POST", "/agent/hidden/connect"],
+      ["POST", "/agent/hidden/stop/thread-1"],
+      ["POST", "/transcribe"],
+      ["GET", "/threads"],
+      ["POST", "/threads/subscribe"],
+      ["GET", "/threads/thread-1/messages"],
+      ["GET", "/threads/thread-1/events"],
+      ["GET", "/threads/thread-1/state"],
+      ["PATCH", "/threads/thread-1"],
+      ["POST", "/threads/thread-1/archive"],
+      ["GET", "/memories"],
+      ["POST", "/memories/recall"],
+      ["POST", "/memories/subscribe"],
+      ["POST", "/annotate"],
+    ];
+
+    for (const [method, path] of routes) {
+      const response = await handler(
+        new Request(`http://runtime.test${path}`, { method }),
+      );
+      expect(response.status, `${method} ${path}`).toBe(404);
+    }
+
+    const infoResponse = await handler(
+      new Request("http://runtime.test/info", { method: "GET" }),
+    );
+    expect(infoResponse.status).toBe(200);
+    await expect(infoResponse.json()).resolves.toMatchObject({
+      agents: {},
+      audioFileTranscriptionEnabled: false,
+      suggestions: false,
+      threadEndpoints: {
+        list: false,
+        inspect: false,
+        mutations: false,
+        realtimeMetadata: false,
+      },
+    });
+  });
+
   it("sse runtime rejects channels", () => {
-    const ch = createChannel({ name: "support" });
+    const ch = createChannel({ identifyUser: "platform", name: "support" });
     expect(
       () =>
         new CopilotRuntime({

--- a/packages/runtime/src/v2/runtime/__tests__/cross-surface-memory.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/cross-surface-memory.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  createChannel,
+  FakeAdapter,
+  FakeAgent,
+} from "@copilotkit/channels-core";
+import type {
+  ChannelAgentLifecycleArgs,
+  MemoryGrant as ChannelMemoryGrant,
+  ResolvedChannelMemory,
+} from "@copilotkit/channels-core";
+import { CopilotRuntime } from "../core/runtime";
+import { handleCreateMemory } from "../handlers/handle-memories";
+import { CopilotKitIntelligence } from "../intelligence-platform";
+
+const activeChannels: Array<{ stop(): Promise<void> }> = [];
+
+afterEach(async () => {
+  await Promise.all(activeChannels.splice(0).map((channel) => channel.stop()));
+  vi.restoreAllMocks();
+});
+
+class ContractMemoryStore {
+  private readonly users = new Map<string, string[]>();
+  private readonly project: string[] = [];
+
+  /** Save one test fact under the same user/project domains as Intelligence Memory. */
+  save(scope: "user" | "project", userId: string, content: string): void {
+    if (scope === "project") {
+      this.project.push(content);
+      return;
+    }
+    const memories = this.users.get(userId) ?? [];
+    this.users.set(userId, [...memories, content]);
+  }
+
+  /** Recall only the scopes selected by the immutable per-run grant. */
+  recall(memory: ResolvedChannelMemory): string[] {
+    return [
+      ...(memory.grant.user === "none"
+        ? []
+        : (this.users.get(memory.user?.id ?? "") ?? [])),
+      ...(memory.grant.project === "none" ? [] : this.project),
+    ];
+  }
+}
+
+function intelligence(): CopilotKitIntelligence {
+  return new CopilotKitIntelligence({
+    apiUrl: "https://intelligence.example",
+    wsUrl: "wss://intelligence.example",
+    apiKey: "cpk-42_short_long",
+  });
+}
+
+function memoryAdapter(
+  platform: "slack" | "teams",
+  execute: (
+    memory: ResolvedChannelMemory,
+    lifecycle: ChannelAgentLifecycleArgs,
+  ) => void | Promise<void>,
+): FakeAdapter {
+  const adapter = new FakeAdapter({ platform });
+  adapter.supportsIntelligenceMemory = true;
+  adapter.runAgentLifecycle = async (args: ChannelAgentLifecycleArgs) => {
+    if (!args.memory) throw new Error("expected an explicit Memory grant");
+    await execute(args.memory, args);
+    return args.execute(args.renderer.subscriber, undefined);
+  };
+  return adapter;
+}
+
+function linkedUser(actorId: string): { id: string; name: string } | null {
+  const mapping: Record<string, { id: string; name: string }> = {
+    "slack-alice": { id: "person-42", name: "Alice" },
+    "teams-alice": { id: "person-42", name: "Alice" },
+    "slack-bob": { id: "person-99", name: "Bob" },
+  };
+  return mapping[actorId] ?? null;
+}
+
+async function startChannel(args: {
+  adapters: FakeAdapter[];
+  memory: ChannelMemoryGrant;
+}) {
+  const channel = createChannel({
+    name: "cross-surface-contract",
+    identifyUser: ({ actor }) => linkedUser(actor.id),
+    adapters: args.adapters,
+    agent: () => new FakeAgent(),
+  });
+  channel.onMessage(async ({ thread }) => {
+    await thread.runAgent({ memory: args.memory });
+  });
+  await channel.ɵruntime.start();
+  activeChannels.push({ stop: () => channel.ɵruntime.stop() });
+  return channel;
+}
+
+test("Memory saved on web is recalled from Slack through one canonical user", async () => {
+  const store = new ContractMemoryStore();
+  const recalled: string[][] = [];
+  const slack = memoryAdapter("slack", (memory) => {
+    recalled.push(store.recall(memory));
+  });
+  const channel = await startChannel({
+    adapters: [slack],
+    memory: { user: "read" },
+  });
+  const platform = intelligence();
+  vi.spyOn(platform, "createMemory").mockImplementation(async (input) => {
+    store.save(
+      input.scope === "project" ? "project" : "user",
+      input.userId,
+      input.content,
+    );
+    return {
+      id: "memory-1",
+      kind: input.kind,
+      scope: input.scope ?? "user",
+      content: input.content,
+      sourceThreadIds: input.sourceThreadIds ?? [],
+      invalidatedAt: null,
+    };
+  });
+  const identifyUser = vi.fn(async () => ({ id: "person-42", name: "Alice" }));
+  const runtime = new CopilotRuntime({
+    agents: {},
+    intelligence: platform,
+    identifyUser,
+    memory: {
+      access: () => ({ user: "read-write", project: "none" }),
+    },
+    channels: [channel],
+  });
+  const request = new Request("https://app.example/api/copilotkit/memories", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      kind: "topical",
+      scope: "user",
+      content: "Prefers oat milk",
+    }),
+  });
+
+  const response = await handleCreateMemory({ runtime, request });
+  expect(response.status).toBe(201);
+  expect(identifyUser).toHaveBeenCalledTimes(1);
+
+  await slack.getSink().onTurn({
+    conversationKey: "slack-thread",
+    replyTarget: {},
+    userText: "What milk do I prefer?",
+    platform: "slack",
+    actor: { id: "slack-alice", kind: "human", name: "Alice" },
+  });
+
+  expect(recalled).toEqual([["Prefers oat milk"]]);
+});
+
+test("Memory saved from Slack is recalled from Teams through the same mapping", async () => {
+  const store = new ContractMemoryStore();
+  const teamsRecall: string[][] = [];
+  const slack = memoryAdapter("slack", (memory) => {
+    store.save("user", memory.user!.id, "Uses compact table rows");
+  });
+  const teams = memoryAdapter("teams", (memory) => {
+    teamsRecall.push(store.recall(memory));
+  });
+  await startChannel({
+    adapters: [slack, teams],
+    memory: { user: "read-write" },
+  });
+
+  await slack.getSink().onTurn({
+    conversationKey: "slack-thread",
+    replyTarget: {},
+    userText: "Remember my display preference",
+    platform: "slack",
+    actor: { id: "slack-alice", kind: "human", name: "Alice" },
+  });
+  await teams.getSink().onTurn({
+    conversationKey: "teams-thread",
+    replyTarget: {},
+    userText: "What display style do I use?",
+    platform: "teams",
+    actor: { id: "teams-alice", kind: "human", name: "Alice" },
+  });
+
+  expect(teamsRecall).toEqual([["Uses compact table rows"]]);
+});
+
+test("Alice and Bob share one Channel Thread but receive isolated user Memory", async () => {
+  const store = new ContractMemoryStore();
+  store.save("user", "person-42", "Alice likes oat milk");
+  store.save("user", "person-99", "Bob likes soy milk");
+  store.save("project", "", "Support hours start at 09:00");
+  const observations: Array<{
+    threadId: string;
+    userId: string | null;
+    memories: string[];
+  }> = [];
+  const slack = memoryAdapter("slack", (memory, lifecycle) => {
+    observations.push({
+      threadId: lifecycle.agent.threadId,
+      userId: memory.user?.id ?? null,
+      memories: store.recall(memory),
+    });
+  });
+  await startChannel({
+    adapters: [slack],
+    memory: { user: "read", project: "read" },
+  });
+
+  for (const actor of [
+    { id: "slack-alice", kind: "human" as const, name: "Alice" },
+    { id: "slack-bob", kind: "human" as const, name: "Bob" },
+  ]) {
+    await slack.getSink().onTurn({
+      conversationKey: "shared-provider-thread",
+      replyTarget: {},
+      userText: "Recall my preference and the support hours",
+      platform: "slack",
+      actor,
+    });
+  }
+
+  expect(observations).toEqual([
+    {
+      threadId: "shared-provider-thread",
+      userId: "person-42",
+      memories: ["Alice likes oat milk", "Support hours start at 09:00"],
+    },
+    {
+      threadId: "shared-provider-thread",
+      userId: "person-99",
+      memories: ["Bob likes soy milk", "Support hours start at 09:00"],
+    },
+  ]);
+});

--- a/packages/runtime/src/v2/runtime/__tests__/endpoints-channels.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/endpoints-channels.test.ts
@@ -75,7 +75,7 @@ const intelRuntimeWith1Channel = () =>
     agents: {},
     intelligence: intelligence(),
     identifyUser,
-    channels: [createChannel({ name: "support" })],
+    channels: [createChannel({ identifyUser: "platform", name: "support" })],
   });
 
 /**
@@ -193,8 +193,8 @@ describe("endpoint wrappers — managed channels propagation", () => {
       intelligence: intelligence(),
       identifyUser,
       channels: [
-        createChannel({ name: "support" }),
-        createChannel({ name: "support" }),
+        createChannel({ identifyUser: "platform", name: "support" }),
+        createChannel({ identifyUser: "platform", name: "support" }),
       ],
     });
 

--- a/packages/runtime/src/v2/runtime/__tests__/handle-memories.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handle-memories.test.ts
@@ -20,6 +20,7 @@ describe("memory handlers", () => {
       request: Request,
     ) => { id: string; name: string } | Promise<{ id: string; name: string }>;
     intelligence?: Record<string, unknown>;
+    memory?: Record<string, unknown>;
   }) =>
     ({
       agents: Promise.resolve({}),
@@ -32,6 +33,7 @@ describe("memory handlers", () => {
       mode: "intelligence",
       identifyUser: options?.identifyUser ?? createIdentifyUser(),
       intelligence: options?.intelligence,
+      memory: options?.memory,
     }) as unknown as CopilotRuntime;
 
   it("returns 422 when intelligence is not configured", async () => {
@@ -84,6 +86,68 @@ describe("memory handlers", () => {
     expect(intelligence.listMemories).toHaveBeenCalledWith({
       userId: "user-1",
     });
+  });
+
+  it("evaluates configured client Memory access and forwards the immutable grant", async () => {
+    const intelligence = {
+      listMemories: vi.fn().mockResolvedValue({ memories: [] }),
+    };
+    const access = vi.fn().mockReturnValue({
+      user: "read",
+      project: "none",
+    });
+    const runtime = createIntelligenceRuntime({
+      intelligence,
+      memory: { access },
+    });
+    const request = new Request("https://example.com/memories");
+
+    const response = await handleListMemories({ runtime, request });
+
+    expect(response.status).toBe(200);
+    expect(access).toHaveBeenCalledWith({
+      request,
+      user: { id: "user-1", name: "User One" },
+      consumer: "client",
+    });
+    expect(intelligence.listMemories).toHaveBeenCalledWith({
+      userId: "user-1",
+      memoryGrant: { user: "read", project: "none" },
+    });
+  });
+
+  it("returns forbidden without a platform call when client Memory is denied", async () => {
+    const intelligence = { listMemories: vi.fn() };
+    const runtime = createIntelligenceRuntime({
+      intelligence,
+      memory: { access: vi.fn().mockReturnValue(null) },
+    });
+
+    const response = await handleListMemories({
+      runtime,
+      request: new Request("https://example.com/memories"),
+    });
+
+    expect(response.status).toBe(403);
+    expect(intelligence.listMemories).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the configured Memory policy throws", async () => {
+    const intelligence = { listMemories: vi.fn() };
+    const runtime = createIntelligenceRuntime({
+      intelligence,
+      memory: {
+        access: vi.fn().mockRejectedValue(new Error("policy unavailable")),
+      },
+    });
+
+    const response = await handleListMemories({
+      runtime,
+      request: new Request("https://example.com/memories"),
+    });
+
+    expect(response.status).toBe(500);
+    expect(intelligence.listMemories).not.toHaveBeenCalled();
   });
 
   it("forwards includeInvalidated=true to the platform", async () => {

--- a/packages/runtime/src/v2/runtime/__tests__/handler-channels-public-export.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handler-channels-public-export.test.ts
@@ -43,7 +43,7 @@ const intelRuntimeWith1Channel = () =>
     agents: {},
     intelligence: intelligence(),
     identifyUser: vi.fn().mockResolvedValue({ id: "u", name: "U" }),
-    channels: [createChannel({ name: "support" })],
+    channels: [createChannel({ identifyUser: "platform", name: "support" })],
   });
 
 /**

--- a/packages/runtime/src/v2/runtime/__tests__/handler-channels-types.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handler-channels-types.test.ts
@@ -3,6 +3,7 @@ import { createCopilotRuntimeHandler } from "../core/fetch-handler";
 import { createCopilotNodeListener } from "../endpoints/node";
 import { CopilotRuntime } from "../core/runtime";
 import type { IdentifyUserCallback } from "../core/runtime";
+import type { CopilotRuntimeOptions } from "../core/runtime";
 import type { CopilotKitIntelligence } from "../intelligence-platform";
 import type { Channel } from "@copilotkit/channels";
 
@@ -28,6 +29,8 @@ type KeyIsRequired<T, K extends keyof T> = {} extends Pick<T, K> ? false : true;
 
 /** Compile error (constraint violation) unless `T` resolves to exactly `true`. */
 function assertTrue<_T extends true>(): void {}
+
+type IsRuntimeOption<T> = T extends CopilotRuntimeOptions ? true : false;
 
 // Purely type-only fixtures — never constructed at runtime.
 declare const intelligence: CopilotKitIntelligence;
@@ -61,6 +64,20 @@ async function _channelsHandlerTypeContracts(): Promise<void> {
   // branded overload lands.
   assertTrue<KeyIsRequired<typeof handler, "channels">>();
 
+  const hybridWithMemory = new CopilotRuntime({
+    agents: {},
+    intelligence,
+    identifyUser,
+    memory: {
+      access: () => ({ user: "read", project: "none" }),
+    },
+    channels: [support],
+  });
+  const hybridHandler = createCopilotRuntimeHandler({
+    runtime: hybridWithMemory,
+  });
+  assertTrue<KeyIsRequired<typeof hybridHandler, "channels">>();
+
   // A plain SSE runtime's handler must keep `.channels` OPTIONAL (not required).
   const sseHandler = createCopilotRuntimeHandler({
     runtime: new CopilotRuntime({ agents: {} }),
@@ -77,6 +94,61 @@ async function _channelsHandlerTypeContracts(): Promise<void> {
   });
   assertTrue<
     KeyIsRequired<typeof optedOut, "channels"> extends false ? true : false
+  >();
+}
+
+function _runtimeSurfaceTypeContracts(): void {
+  assertTrue<
+    IsRuntimeOption<{
+      agents: {};
+      intelligence: CopilotKitIntelligence;
+      identifyUser: IdentifyUserCallback;
+      memory: {
+        access: () => { user: "read"; project: "none" };
+      };
+    }>
+  >();
+  assertTrue<
+    IsRuntimeOption<{
+      agents: {};
+      intelligence: CopilotKitIntelligence;
+      channels: [Channel];
+    }>
+  >();
+  assertTrue<
+    IsRuntimeOption<{
+      agents: {};
+      intelligence: CopilotKitIntelligence;
+      channels: [Channel];
+      memory: { access: () => { user: "read"; project: "none" } };
+    }> extends false
+      ? true
+      : false
+  >();
+  assertTrue<
+    IsRuntimeOption<{
+      agents: {};
+      intelligence: CopilotKitIntelligence;
+      identifyUser: IdentifyUserCallback;
+      channels: [Channel];
+    }>
+  >();
+  assertTrue<
+    IsRuntimeOption<{
+      agents: {};
+      intelligence: CopilotKitIntelligence;
+    }> extends false
+      ? true
+      : false
+  >();
+  assertTrue<
+    IsRuntimeOption<{
+      agents: {};
+      intelligence: CopilotKitIntelligence;
+      channels: [];
+    }> extends false
+      ? true
+      : false
   >();
 }
 
@@ -129,4 +201,5 @@ async function _channelsNodeListenerTypeContracts(): Promise<void> {
 test("handler.channels type contracts are enforced at compile time", () => {
   expect(typeof _channelsHandlerTypeContracts).toBe("function");
   expect(typeof _channelsNodeListenerTypeContracts).toBe("function");
+  expect(typeof _runtimeSurfaceTypeContracts).toBe("function");
 });

--- a/packages/runtime/src/v2/runtime/__tests__/handler-channels.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handler-channels.test.ts
@@ -46,7 +46,7 @@ const intelRuntimeWith1Channel = () =>
     agents: {},
     intelligence: intelligence(),
     identifyUser,
-    channels: [createChannel({ name: "support" })],
+    channels: [createChannel({ identifyUser: "platform", name: "support" })],
   });
 
 /* ------------------------------------------------------------------------------------------------
@@ -162,8 +162,8 @@ describe("createCopilotRuntimeHandler — managed channels", () => {
       intelligence: intelligence(),
       identifyUser,
       channels: [
-        createChannel({ name: "support" }),
-        createChannel({ name: "support" }),
+        createChannel({ identifyUser: "platform", name: "support" }),
+        createChannel({ identifyUser: "platform", name: "support" }),
       ],
     });
 

--- a/packages/runtime/src/v2/runtime/__tests__/managed-channels.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/managed-channels.test.ts
@@ -13,7 +13,10 @@ const identifyUser = vi.fn().mockResolvedValue({ id: "u", name: "U" });
 
 describe("CopilotRuntime — managed channels option", () => {
   it("stores declared channels on the intelligence runtime and exposes them via the facade", () => {
-    const channel = createChannel({ name: "support" });
+    const channel = createChannel({
+      identifyUser: "platform",
+      name: "support",
+    });
     const rt = new CopilotRuntime({
       agents: {},
       intelligence: intelligence(),
@@ -45,7 +48,9 @@ describe("CopilotRuntime — managed channels option", () => {
       () =>
         new CopilotRuntime({
           agents: {},
-          channels: [createChannel({ name: "support" })],
+          channels: [
+            createChannel({ identifyUser: "platform", name: "support" }),
+          ],
         } as unknown as ConstructorParameters<typeof CopilotRuntime>[0]),
     ).toThrow(/Intelligence runtime/i);
   });
@@ -57,7 +62,7 @@ describe("CopilotRuntime — managed channels option", () => {
           agents: {},
           intelligence: intelligence(),
           identifyUser,
-          channels: [createChannel({})],
+          channels: [createChannel({ identifyUser: "platform" })],
         }),
     ).toThrow(/name/i);
   });

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-activation-config.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-activation-config.test.ts
@@ -105,7 +105,10 @@ describe("parseProjectIdFromApiKey", () => {
 describe("deriveChannelActivationConfig", () => {
   it("resolves the provider-neutral activation fields from the intelligence config and channel", () => {
     const intelligence = fakeIntelligence("cpk-42_short_long");
-    const channel = createChannel({ name: "support" });
+    const channel = createChannel({
+      identifyUser: "platform",
+      name: "support",
+    });
 
     const config = deriveChannelActivationConfig({
       intelligence,
@@ -125,7 +128,10 @@ describe("deriveChannelActivationConfig", () => {
 
   it("does not carry a provider selector because one managed activation declares Slack and Teams together", () => {
     const intelligence = fakeIntelligence("cpk-7_a_b");
-    const channel = createChannel({ name: "support" });
+    const channel = createChannel({
+      identifyUser: "platform",
+      name: "support",
+    });
 
     const config = deriveChannelActivationConfig({
       intelligence,
@@ -139,7 +145,7 @@ describe("deriveChannelActivationConfig", () => {
 
   it("throws ChannelConfigError when the channel has no name", () => {
     const intelligence = fakeIntelligence("cpk-42_short_long");
-    const channel = createChannel({});
+    const channel = createChannel({ identifyUser: "platform" });
 
     expect(() =>
       deriveChannelActivationConfig({
@@ -158,7 +164,7 @@ describe("deriveChannelActivationConfig", () => {
     const intelligence = fakeIntelligence("cpk-42_short_long");
     const config = deriveChannelActivationConfig({
       intelligence,
-      channel: createChannel({ name: "Slack" }),
+      channel: createChannel({ identifyUser: "platform", name: "Slack" }),
       runtimeInstanceId: "rti_x",
     });
 

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-canonical-run.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-canonical-run.test.ts
@@ -105,7 +105,7 @@ async function captureRunCanonical(
       channelName: "support",
       runtimeInstanceId: "rti_test",
     },
-    createChannel({ name: "support" }),
+    createChannel({ identifyUser: "platform", name: "support" }),
     importer,
     undefined,
     {

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager-reconnect.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager-reconnect.test.ts
@@ -58,7 +58,7 @@ describe("ChannelManager connection health (onStateChange)", () => {
 
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
     });
     mgr.activate();
@@ -85,7 +85,7 @@ describe("ChannelManager connection health (onStateChange)", () => {
 
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
     });
     mgr.activate();
@@ -105,7 +105,7 @@ describe("ChannelManager connection health (onStateChange)", () => {
 
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
     });
     mgr.activate();
@@ -121,7 +121,7 @@ describe("ChannelManager connection health (onStateChange)", () => {
 
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
     });
     mgr.activate();
@@ -141,7 +141,7 @@ describe("ChannelManager connection health (onStateChange)", () => {
 
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
     });
     mgr.activate();
@@ -162,7 +162,7 @@ describe("ChannelManager connection health (onStateChange)", () => {
 
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
       log: (m: string) => logs.push(m),
       reconnectLogIntervalMs: 5,
@@ -199,7 +199,7 @@ describe("ChannelManager connection health (onStateChange)", () => {
 
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
       log: (m: string) => logs.push(m),
     });

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
@@ -185,7 +185,11 @@ describe("ChannelManager", () => {
   it("starts and stops direct adapters when managed setup is incomplete", async () => {
     const direct = new FakeAdapter({ platform: "direct" });
     const directStop = vi.spyOn(direct, "stop");
-    const channel = createChannel({ name: "support", adapters: [direct] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      name: "support",
+      adapters: [direct],
+    });
     const engine: ActivateChannelEngine = async () => {
       throw new ChannelSetupRequiredError("managed Teams is not installed");
     };
@@ -212,7 +216,11 @@ describe("ChannelManager", () => {
     const direct = new FakeAdapter({ platform: "direct" });
     const start = vi.spyOn(direct, "start").mockReturnValue(startAttempt);
     const stop = vi.spyOn(direct, "stop");
-    const channel = createChannel({ name: "support", adapters: [direct] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      name: "support",
+      adapters: [direct],
+    });
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
       channels: [channel],
@@ -720,7 +728,11 @@ describe("ChannelManager", () => {
         platform: "intelligence",
         failStart: true,
       });
-      const channel = createChannel({ name: "sales", adapters: [direct] });
+      const channel = createChannel({
+        identifyUser: "platform",
+        name: "sales",
+        adapters: [direct],
+      });
       const engine: ActivateChannelEngine = vi.fn(
         async (_config, candidate) => {
           candidate.ɵruntime.addAdapter(managed);

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager.test.ts
@@ -62,8 +62,8 @@ describe("ChannelSetupRequiredError", () => {
 
 describe("ChannelManager", () => {
   it("activate() starts one engine call per channel with distinct runtimeInstanceIds and reaches online after ready()", async () => {
-    const chA = createChannel({ name: "support" });
-    const chB = createChannel({ name: "sales" });
+    const chA = createChannel({ identifyUser: "platform", name: "support" });
+    const chB = createChannel({ identifyUser: "platform", name: "sales" });
     const seenIds: string[] = [];
     const engine: ActivateChannelEngine = vi.fn(async (config) => {
       seenIds.push(config.runtimeInstanceId);
@@ -95,7 +95,7 @@ describe("ChannelManager", () => {
     const engine: ActivateChannelEngine = vi.fn(async () => fakeHandle());
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
     });
 
@@ -116,8 +116,8 @@ describe("ChannelManager", () => {
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
       channels: [
-        createChannel({ name: "support" }),
-        createChannel({ name: "sales" }),
+        createChannel({ identifyUser: "platform", name: "support" }),
+        createChannel({ identifyUser: "platform", name: "sales" }),
       ],
       activateChannel: engine,
     });
@@ -151,8 +151,8 @@ describe("ChannelManager", () => {
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
       channels: [
-        createChannel({ name: "support" }),
-        createChannel({ name: "sales" }),
+        createChannel({ identifyUser: "platform", name: "support" }),
+        createChannel({ identifyUser: "platform", name: "sales" }),
       ],
       activateChannel: engine,
     });
@@ -173,7 +173,7 @@ describe("ChannelManager", () => {
     };
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
     });
     mgr.activate();
@@ -238,7 +238,7 @@ describe("ChannelManager", () => {
     };
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
     });
     mgr.activate();
@@ -258,7 +258,7 @@ describe("ChannelManager", () => {
   it("status() reports overall 'stopped' when stop() runs before activate() (SIGTERM during startup)", async () => {
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: async () => fakeHandle(),
     });
     // stop() before activate() — no entries were ever created, so the empty-set
@@ -273,7 +273,7 @@ describe("ChannelManager", () => {
       new Promise<ChannelsHandle>(() => {});
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
     });
     mgr.activate();
@@ -291,8 +291,8 @@ describe("ChannelManager", () => {
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
       channels: [
-        createChannel({ name: "support" }),
-        createChannel({ name: "sales" }),
+        createChannel({ identifyUser: "platform", name: "support" }),
+        createChannel({ identifyUser: "platform", name: "sales" }),
       ],
       activateChannel: engine,
     });
@@ -319,8 +319,8 @@ describe("ChannelManager", () => {
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
       channels: [
-        createChannel({ name: "support" }),
-        createChannel({ name: "support" }),
+        createChannel({ identifyUser: "platform", name: "support" }),
+        createChannel({ identifyUser: "platform", name: "support" }),
       ],
       activateChannel: engine,
     });
@@ -340,7 +340,7 @@ describe("ChannelManager", () => {
     );
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
     });
     mgr.activate();
@@ -371,7 +371,7 @@ describe("ChannelManager", () => {
     };
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: async () => wedged,
       stopHandleTimeoutMs: 20,
       log: (...args) => logs.push(args),
@@ -416,8 +416,8 @@ describe("ChannelManager", () => {
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
       channels: [
-        createChannel({ name: "support" }),
-        createChannel({ name: "sales" }),
+        createChannel({ identifyUser: "platform", name: "support" }),
+        createChannel({ identifyUser: "platform", name: "sales" }),
       ],
       activateChannel: engine,
     });
@@ -441,7 +441,7 @@ describe("ChannelManager", () => {
     };
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
     });
     mgr.activate();
@@ -461,7 +461,7 @@ describe("ChannelManager", () => {
     );
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
     });
     mgr.activate();
@@ -501,7 +501,7 @@ describe("ChannelManager", () => {
     const engine: ActivateChannelEngine = vi.fn(async () => handle);
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
     });
     mgr.activate();
@@ -535,7 +535,7 @@ describe("ChannelManager", () => {
     };
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
     });
     mgr.activate();
@@ -556,7 +556,7 @@ describe("ChannelManager", () => {
     };
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
       log,
     });
@@ -583,7 +583,7 @@ describe("ChannelManager", () => {
     const engine: ActivateChannelEngine = async () => syncThrowHandle;
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
       log,
     });
@@ -606,7 +606,7 @@ describe("ChannelManager", () => {
     const engine: ActivateChannelEngine = vi.fn(async () => fakeHandle());
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
-      channels: [createChannel({ name: "support" })],
+      channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
     });
 
@@ -621,8 +621,8 @@ describe("ChannelManager", () => {
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
       channels: [
-        createChannel({ name: "support" }),
-        createChannel({ name: "support" }),
+        createChannel({ identifyUser: "platform", name: "support" }),
+        createChannel({ identifyUser: "platform", name: "support" }),
       ],
       activateChannel: engine,
     });
@@ -649,7 +649,11 @@ describe("ChannelManager", () => {
     const managed = new ManagedFakeAdapter({ platform: "intelligence" });
     const directStop = vi.spyOn(direct, "stop");
     const managedStop = vi.spyOn(managed, "stop");
-    const channel = createChannel({ name: "sales", adapters: [direct] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      name: "sales",
+      adapters: [direct],
+    });
     const engine: ActivateChannelEngine = vi.fn(async (_config, candidate) => {
       candidate.ɵruntime.addAdapter(managed);
       await candidate.ɵruntime.start();
@@ -680,7 +684,11 @@ describe("ChannelManager", () => {
   it("keeps managed activation online when a coexisting direct adapter fails to start", async () => {
     const direct = new FakeAdapter({ platform: "direct", failStart: true });
     const managed = new ManagedFakeAdapter({ platform: "intelligence" });
-    const channel = createChannel({ name: "sales", adapters: [direct] });
+    const channel = createChannel({
+      identifyUser: "platform",
+      name: "sales",
+      adapters: [direct],
+    });
     const engine: ActivateChannelEngine = vi.fn(async (_config, candidate) => {
       candidate.ɵruntime.addAdapter(managed);
       await candidate.ɵruntime.start();
@@ -750,8 +758,9 @@ describe("ChannelManager", () => {
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
       channels: [
-        createChannel({ name: "support" }),
+        createChannel({ identifyUser: "platform", name: "support" }),
         createChannel({
+          identifyUser: "platform",
           name: "support",
           adapters: [new FakeAdapter({ platform: "slack" })],
         }),
@@ -772,8 +781,14 @@ describe("ChannelManager", () => {
     const mgr = new ChannelManager({
       intelligence: fakeIntelligence(),
       channels: [
-        createChannel({ name: "support" }),
-        createChannel({ name: "sales" }),
+        createChannel({
+          identifyUser: "platform",
+          name: "support",
+        }),
+        createChannel({
+          identifyUser: "platform",
+          name: "sales",
+        }),
       ],
       activateChannel: engine,
     });
@@ -797,7 +812,10 @@ describe("defaultActivateChannel", () => {
 
   it("maps config to launcher opts and returns the launcher's handle", async () => {
     const { handle, start, importer } = captureChannelsIntelligenceLaunch();
-    const channel = createChannel({ name: "support" });
+    const channel = createChannel({
+      identifyUser: "platform",
+      name: "support",
+    });
 
     const result = await defaultActivateChannel(
       config,
@@ -870,7 +888,7 @@ describe("defaultActivateChannel", () => {
 
     await defaultActivateChannel(
       config,
-      createChannel({ name: "support" }),
+      createChannel({ identifyUser: "platform", name: "support" }),
       importer,
       undefined,
       services,
@@ -914,7 +932,10 @@ describe("defaultActivateChannel", () => {
 
   it("keeps tool status omitted when createChannel() does not configure it", async () => {
     const { start, importer } = captureChannelsIntelligenceLaunch();
-    const channel = createChannel({ name: "support" });
+    const channel = createChannel({
+      identifyUser: "platform",
+      name: "support",
+    });
     const activationConfig = deriveChannelActivationConfig({
       intelligence: fakeIntelligence(),
       channel,
@@ -937,6 +958,7 @@ describe("defaultActivateChannel", () => {
   it("forwards createChannel({ showToolStatus: true }) to the managed launcher", async () => {
     const { start, importer } = captureChannelsIntelligenceLaunch();
     const channel = createChannel({
+      identifyUser: "platform",
       name: "support",
       showToolStatus: true,
     });
@@ -962,6 +984,7 @@ describe("defaultActivateChannel", () => {
   it("forwards createChannel({ replyContinuation }) to the managed launcher", async () => {
     const { start, importer } = captureChannelsIntelligenceLaunch();
     const channel = createChannel({
+      identifyUser: "platform",
       name: "support",
       replyContinuation: { maxMessages: 5, truncationMarker: "…cut" },
     });
@@ -992,7 +1015,10 @@ describe("defaultActivateChannel", () => {
 
   it("omits replyContinuation when createChannel does not set it", async () => {
     const { start, importer } = captureChannelsIntelligenceLaunch();
-    const channel = createChannel({ name: "support" });
+    const channel = createChannel({
+      identifyUser: "platform",
+      name: "support",
+    });
     const activationConfig = deriveChannelActivationConfig({
       intelligence: fakeIntelligence(),
       channel,
@@ -1014,7 +1040,10 @@ describe("defaultActivateChannel", () => {
 
   it("forwards the log sink to the launcher opts so transport-level drops surface", async () => {
     const { start, importer } = captureChannelsIntelligenceLaunch();
-    const channel = createChannel({ name: "support" });
+    const channel = createChannel({
+      identifyUser: "platform",
+      name: "support",
+    });
     const log = vi.fn();
 
     await defaultActivateChannel(
@@ -1030,7 +1059,10 @@ describe("defaultActivateChannel", () => {
   });
 
   it("throws a friendly install hint when the module is not found", async () => {
-    const channel = createChannel({ name: "support" });
+    const channel = createChannel({
+      identifyUser: "platform",
+      name: "support",
+    });
     const importer = async (): Promise<ChannelsIntelligenceModule> => {
       throw Object.assign(new Error("not found"), {
         code: "ERR_MODULE_NOT_FOUND",
@@ -1045,7 +1077,10 @@ describe("defaultActivateChannel", () => {
   });
 
   it("rethrows a generic import failure unchanged", async () => {
-    const channel = createChannel({ name: "support" });
+    const channel = createChannel({
+      identifyUser: "platform",
+      name: "support",
+    });
     const importer = async (): Promise<ChannelsIntelligenceModule> => {
       throw new Error("boom");
     };

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-memory.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-memory.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import type { AbstractAgent } from "@ag-ui/client";
+
+const middlewareCalls: unknown[][] = [];
+vi.mock("@ag-ui/mcp-middleware", () => ({
+  MCPMiddleware: class MockMCPMiddleware {
+    constructor(...args: unknown[]) {
+      middlewareCalls.push(args);
+    }
+  },
+}));
+
+import { attachChannelMemory } from "../channel-manager";
+import { CopilotKitIntelligence } from "../../intelligence-platform";
+import {
+  INTELLIGENCE_MEMORY_GRANT_HEADER,
+  INTELLIGENCE_USER_ID_HEADER,
+} from "../../intelligence-platform/client";
+
+const intelligence = new CopilotKitIntelligence({
+  apiUrl: "https://intelligence.example",
+  wsUrl: "wss://intelligence.example",
+  apiKey: "cpk-42_short_long",
+});
+
+beforeEach(() => middlewareCalls.splice(0));
+
+test("Channel Memory attaches an immutable personal and project grant", () => {
+  const use = vi.fn();
+  const agent = { use } as unknown as AbstractAgent;
+
+  attachChannelMemory(agent, intelligence, {
+    grant: { user: "read", project: "read-write" },
+    user: { id: "person-1", name: "Ada" },
+  });
+
+  expect(use).toHaveBeenCalledTimes(1);
+  expect(middlewareCalls).toEqual([
+    [
+      [
+        {
+          type: "http",
+          url: "https://intelligence.example/mcp",
+          serverId: "intelligence",
+          headers: {
+            Authorization: "Bearer cpk-42_short_long",
+            [INTELLIGENCE_MEMORY_GRANT_HEADER]: JSON.stringify({
+              user: "read",
+              project: "read-write",
+            }),
+            [INTELLIGENCE_USER_ID_HEADER]: "person-1",
+          },
+        },
+      ],
+    ],
+  ]);
+});
+
+test("project-only Channel Memory sends no fabricated user", () => {
+  const agent = { use: vi.fn() } as unknown as AbstractAgent;
+
+  attachChannelMemory(agent, intelligence, {
+    grant: { user: "none", project: "read" },
+    user: null,
+  });
+
+  const [[servers]] = middlewareCalls as [[Array<{ headers: object }>]];
+  expect(servers[0]?.headers).toEqual({
+    Authorization: "Bearer cpk-42_short_long",
+    [INTELLIGENCE_MEMORY_GRANT_HEADER]: JSON.stringify({
+      user: "none",
+      project: "read",
+    }),
+  });
+});
+
+test("Channel Memory rejects an agent without middleware before its run", () => {
+  expect(() =>
+    attachChannelMemory({} as AbstractAgent, intelligence, {
+      grant: { user: "none", project: "read" },
+      user: null,
+    }),
+  ).toThrow(
+    expect.objectContaining({ code: "channel_memory_agent_unsupported" }),
+  );
+});

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -14,11 +14,20 @@ import type {
   RunAgentResult,
 } from "@ag-ui/client";
 import { EMPTY } from "rxjs";
+import { MCPMiddleware } from "@ag-ui/mcp-middleware";
 import type { AgentRunner } from "../runner/agent-runner";
+import {
+  INTELLIGENCE_MEMORY_GRANT_HEADER,
+  INTELLIGENCE_USER_ID_HEADER,
+} from "../intelligence-platform/client";
 // Type-only: @copilotkit/channels is pure-ESM, so a value import would break this
 // package's CJS output (see `core/runtime.ts` and `channel-activation-config.ts`
 // for the same constraint).
-import type { Channel, ReplyContinuationOptions } from "@copilotkit/channels";
+import type {
+  Channel,
+  ReplyContinuationOptions,
+  ResolvedChannelMemory,
+} from "@copilotkit/channels";
 
 /**
  * Lifecycle status of a single Channel activation, or of the manager overall.
@@ -359,6 +368,7 @@ interface CanonicalRunArgs {
   threadId: string;
   runId: string;
   userId: string;
+  memory?: ResolvedChannelMemory;
   agentId: string;
   tools: readonly {
     name: string;
@@ -375,6 +385,42 @@ interface CanonicalRunArgs {
     interrupted: boolean;
     deliveryError?: unknown;
   }>;
+}
+
+/** Attach grant-scoped Intelligence Memory tools to one isolated Channel agent. */
+export function attachChannelMemory(
+  agent: AbstractAgent,
+  intelligence: CopilotKitIntelligence,
+  memory: ResolvedChannelMemory | undefined,
+): void {
+  if (!memory) return;
+  const middlewareAgent = agent as AbstractAgent & {
+    use?: (middleware: unknown) => void;
+  };
+  if (typeof middlewareAgent.use !== "function") {
+    const error = new Error(
+      "Channel Memory requires an agent with middleware support",
+    ) as Error & { code?: string };
+    error.name = "ChannelMemoryAgentUnsupportedError";
+    error.code = "channel_memory_agent_unsupported";
+    throw error;
+  }
+  middlewareAgent.use(
+    new MCPMiddleware([
+      {
+        type: "http",
+        url: `${intelligence.ɵgetApiUrl()}/mcp`,
+        serverId: "intelligence",
+        headers: {
+          Authorization: `Bearer ${intelligence.ɵgetApiKey()}`,
+          [INTELLIGENCE_MEMORY_GRANT_HEADER]: JSON.stringify(memory.grant),
+          ...(memory.user
+            ? { [INTELLIGENCE_USER_ID_HEADER]: memory.user.id }
+            : {}),
+        },
+      },
+    ]),
+  );
 }
 
 /** One outer agent that lets the standard runner own the whole local tool loop. */
@@ -440,6 +486,7 @@ async function runCanonicalChannelAgent(
   const canonicalThreadId = lock.threadId;
   const canonicalRunId = lock.runId;
   let result = { iterations: 0, interrupted: false };
+  attachChannelMemory(args.agent, intelligence, args.memory);
   const outer = new ChannelOuterAgent(
     args.agent,
     canonicalThreadId,
@@ -836,6 +883,7 @@ export class ChannelManager implements ChannelsControl {
     // direct adapters stay in the same adapter array and are started by the
     // launcher's single `channel.ɵruntime.start()` call.
     for (const channel of this.channels) {
+      channel.ɵruntime.enableIntelligenceMemory();
       const name = channel.name!;
       const runtimeInstanceId = this.mintRuntimeInstanceId();
 

--- a/packages/runtime/src/v2/runtime/core/fetch-handler.ts
+++ b/packages/runtime/src/v2/runtime/core/fetch-handler.ts
@@ -526,6 +526,14 @@ function dispatchRoute(
   route: RouteInfo,
   options: { threadEndpointsEnabled: boolean },
 ): Promise<Response> {
+  if (
+    isIntelligenceRuntime(runtime) &&
+    runtime.identifyUser === undefined &&
+    route.method !== "info"
+  ) {
+    throw jsonResponse({ error: "Not found" }, 404);
+  }
+
   // Opt-in gate for the client-facing memory proxy routes (secure default:
   // off). When not explicitly enabled, every `/memories/*` route 404s as if it
   // did not exist — this MUST run before the per-handler `isIntelligenceRuntime`

--- a/packages/runtime/src/v2/runtime/core/runtime.ts
+++ b/packages/runtime/src/v2/runtime/core/runtime.ts
@@ -178,6 +178,9 @@ interface BaseCopilotRuntimeOptions extends CopilotRuntimeMiddlewares {
    * Flip to `true` to power a client memory inspector (e.g. the dev console's
    * Memory tab). Existing Intelligence deployments relying on the previously
    * always-on Learning tab must set this to restore it.
+   *
+   * @deprecated Configure `memory.access` on an Intelligence Runtime. That one
+   * policy enables and limits both agent and browser Memory.
    */
   exposeMemoryRoutes?: boolean;
 }
@@ -191,6 +194,24 @@ export type IdentifyUserCallback = (
   request: Request,
 ) => MaybePromise<CopilotRuntimeUser>;
 
+export type MemoryAccess = "none" | "read" | "read-write";
+
+export interface MemoryGrant {
+  readonly user: MemoryAccess;
+  readonly project: MemoryAccess;
+}
+
+export type MemoryConsumer = "agent" | "client";
+
+export interface CopilotRuntimeMemoryConfig {
+  /** Resolves immutable Memory access for one authenticated web request. */
+  access(input: {
+    readonly request: Request;
+    readonly user: CopilotRuntimeUser;
+    readonly consumer: MemoryConsumer;
+  }): MaybePromise<MemoryGrant | null>;
+}
+
 export interface CopilotSseRuntimeOptions extends BaseCopilotRuntimeOptions {
   /** The runner to use for running agents in SSE mode. */
   runner?: AgentRunner;
@@ -200,11 +221,9 @@ export interface CopilotSseRuntimeOptions extends BaseCopilotRuntimeOptions {
   channels?: undefined;
 }
 
-export interface CopilotIntelligenceRuntimeOptions extends BaseCopilotRuntimeOptions {
+interface CopilotIntelligenceRuntimeBaseOptions extends BaseCopilotRuntimeOptions {
   /** Configures Intelligence mode for durable threads and realtime events. */
   intelligence: CopilotKitIntelligence;
-  /** Resolves the authenticated user for intelligence requests. */
-  identifyUser: IdentifyUserCallback;
   /** Auto-generate short names for newly created threads. */
   generateThreadNames?: boolean;
   /** Max delay (ms) for WebSocket reconnect backoff. @default 10_000 */
@@ -224,8 +243,28 @@ export interface CopilotIntelligenceRuntimeOptions extends BaseCopilotRuntimeOpt
    * to delivery/egress transports when activated via `startChannels` from
    * `@copilotkit/channels-intelligence` — not at construction.
    */
-  channels?: Channel[];
 }
+
+type NonEmptyChannels = readonly [Channel, ...Channel[]];
+
+/** Intelligence runtime options with web identity, Channels, or both. */
+export type CopilotIntelligenceRuntimeOptions =
+  CopilotIntelligenceRuntimeBaseOptions &
+    (
+      | {
+          /** Resolves the authenticated user for web requests. */
+          identifyUser: IdentifyUserCallback;
+          /** Enables agent and browser Memory under one request policy. */
+          memory?: CopilotRuntimeMemoryConfig;
+          channels?: readonly Channel[];
+        }
+      | {
+          /** Channels-only runtimes expose no functional web surface. */
+          identifyUser?: undefined;
+          memory?: undefined;
+          channels: NonEmptyChannels;
+        }
+    );
 
 export type CopilotRuntimeOptions =
   | CopilotSseRuntimeOptions
@@ -264,6 +303,7 @@ export interface CopilotRuntimeLike {
    * (`BaseCopilotRuntime`) always resolve and set it.
    */
   exposeMemoryRoutes?: boolean;
+  memory?: CopilotRuntimeMemoryConfig;
 }
 
 export interface CopilotSseRuntimeLike extends CopilotRuntimeLike {
@@ -273,7 +313,7 @@ export interface CopilotSseRuntimeLike extends CopilotRuntimeLike {
 
 export interface CopilotIntelligenceRuntimeLike extends CopilotRuntimeLike {
   intelligence: CopilotKitIntelligence;
-  identifyUser: IdentifyUserCallback;
+  identifyUser?: IdentifyUserCallback;
   generateThreadNames: boolean;
   lockTtlSeconds: number;
   lockKeyPrefix?: string;
@@ -297,6 +337,7 @@ abstract class BaseCopilotRuntime implements CopilotRuntimeLike {
   public debugLogger?: CopilotRuntimeLogger;
   public readonly forwardHeadersPolicy: ResolvedForwardHeadersPolicy;
   public readonly exposeMemoryRoutes: boolean;
+  public readonly memory?: CopilotRuntimeMemoryConfig;
 
   /**
    * License token resolved once with the env fallback, so telemetry
@@ -358,7 +399,9 @@ abstract class BaseCopilotRuntime implements CopilotRuntimeLike {
     );
     // Secure default: the client-facing memory proxy routes stay hidden (404)
     // unless a deployment explicitly opts in.
-    this.exposeMemoryRoutes = options.exposeMemoryRoutes ?? false;
+    this.memory = (options as { memory?: CopilotRuntimeMemoryConfig }).memory;
+    this.exposeMemoryRoutes =
+      this.memory !== undefined || (options.exposeMemoryRoutes ?? false);
     this.debug = resolveDebugConfig(options.debug);
     if (this.debug.enabled) {
       this.debugLogger = createLogger({
@@ -398,7 +441,7 @@ export class CopilotIntelligenceRuntime
   implements CopilotIntelligenceRuntimeLike
 {
   readonly intelligence: CopilotKitIntelligence;
-  readonly identifyUser: IdentifyUserCallback;
+  readonly identifyUser?: IdentifyUserCallback;
   readonly generateThreadNames: boolean;
   readonly lockTtlSeconds: number;
   readonly lockKeyPrefix?: string;
@@ -412,6 +455,47 @@ export class CopilotIntelligenceRuntime
   static readonly MAX_HEARTBEAT_INTERVAL_SECONDS = 3_000;
 
   constructor(options: CopilotIntelligenceRuntimeOptions) {
+    const rawOptions = options as CopilotIntelligenceRuntimeBaseOptions & {
+      identifyUser?: unknown;
+      channels?: unknown;
+      memory?: unknown;
+    };
+    if (
+      rawOptions.identifyUser !== undefined &&
+      typeof rawOptions.identifyUser !== "function"
+    ) {
+      throw new Error("Intelligence Runtime `identifyUser` must be a callback");
+    }
+    if (
+      rawOptions.channels !== undefined &&
+      !Array.isArray(rawOptions.channels)
+    ) {
+      throw new Error("Intelligence Runtime `channels` must be an array");
+    }
+    const hasWebIdentity = typeof rawOptions.identifyUser === "function";
+    const hasChannels =
+      Array.isArray(rawOptions.channels) && rawOptions.channels.length > 0;
+    if (!hasWebIdentity && !hasChannels) {
+      throw new Error(
+        "Intelligence Runtime requires web `identifyUser`, at least one Channel, or both surfaces",
+      );
+    }
+    if (
+      rawOptions.memory !== undefined &&
+      (typeof rawOptions.memory !== "object" ||
+        rawOptions.memory === null ||
+        typeof (rawOptions.memory as { access?: unknown }).access !==
+          "function")
+    ) {
+      throw new Error(
+        "Intelligence Runtime `memory.access` must be a callback",
+      );
+    }
+    if (rawOptions.memory !== undefined && !hasWebIdentity) {
+      throw new Error(
+        "Intelligence Runtime web `memory` requires `identifyUser`",
+      );
+    }
     super(
       options,
       new IntelligenceAgentRunner({
@@ -422,7 +506,9 @@ export class CopilotIntelligenceRuntime
       }),
     );
     this.intelligence = options.intelligence;
-    this.identifyUser = options.identifyUser;
+    this.identifyUser = hasWebIdentity
+      ? (rawOptions.identifyUser as IdentifyUserCallback)
+      : undefined;
     this.generateThreadNames = options.generateThreadNames ?? true;
     // Telemetry attribution is handled by the base constructor for all modes;
     // here we only need the token for feature gating. Reuse the base-resolved
@@ -446,9 +532,11 @@ export class CopilotIntelligenceRuntime
     // one Channel per launcher call, so the launcher never sees the full set.
     // Fail fast on the most common misconfiguration (a missing name) right here
     // at construction, though, rather than only at activation.
-    this.channels = options.channels ?? [];
+    this.channels = [
+      ...((rawOptions.channels as readonly Channel[] | undefined) ?? []),
+    ];
     for (const c of this.channels) {
-      if (!c.name) {
+      if (!c || typeof c !== "object" || !c.name) {
         throw new Error(
           "Intelligence Channel is missing a `name` — pass createChannel({ name }) for each Channel in `channels`",
         );
@@ -534,9 +622,19 @@ export interface CopilotRuntime extends CopilotRuntimeLike {
  */
 export interface CopilotRuntimeConstructor {
   new (
-    options: Omit<CopilotIntelligenceRuntimeOptions, "channels"> & {
-      channels: readonly [Channel, ...Channel[]];
-    },
+    options: CopilotIntelligenceRuntimeBaseOptions &
+      (
+        | {
+            identifyUser: IdentifyUserCallback;
+            memory?: CopilotRuntimeMemoryConfig;
+            channels: NonEmptyChannels;
+          }
+        | {
+            identifyUser?: undefined;
+            memory?: undefined;
+            channels: NonEmptyChannels;
+          }
+      ),
   ): CopilotRuntime & RuntimeWithDeclaredChannels;
   new (options: CopilotRuntimeOptions): CopilotRuntime;
 }
@@ -656,6 +754,10 @@ class CopilotRuntimeShim implements CopilotRuntime {
 
   get exposeMemoryRoutes(): boolean | undefined {
     return this.delegate.exposeMemoryRoutes;
+  }
+
+  get memory(): CopilotRuntimeMemoryConfig | undefined {
+    return this.delegate.memory;
   }
 }
 

--- a/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
+++ b/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
@@ -40,7 +40,11 @@ export async function handleGetRuntimeInfo({
   threadEndpointsEnabled = true,
 }: HandleGetRuntimeInfoParameters) {
   try {
-    const agents = await resolveAgents(runtime.agents, request);
+    const webEnabled =
+      !isIntelligenceRuntime(runtime) || runtime.identifyUser !== undefined;
+    const agents = webEnabled
+      ? await resolveAgents(runtime.agents, request)
+      : {};
 
     const agentEntries = await Promise.all(
       Object.entries(agents).map(async ([name, agent]) => {
@@ -76,18 +80,19 @@ export async function handleGetRuntimeInfo({
     const runtimeInfo: RuntimeInfo = {
       version: VERSION,
       agents: agentsDict,
-      audioFileTranscriptionEnabled: !!runtime.transcriptionService,
+      audioFileTranscriptionEnabled:
+        webEnabled && !!runtime.transcriptionService,
       mode: runtime.mode,
       threadEndpoints: resolveThreadEndpointInfo(
         runtime,
-        threadEndpointsEnabled,
+        threadEndpointsEnabled && webEnabled,
       ),
       // Advertised unconditionally. Multi-route runtimes expose the dedicated
       // POST /agent/:agentId/suggest path; single-route clients fall back to a
       // client-side run (they don't construct the single-route envelope for
       // suggest). The flag lets multi-route clients detect the stateless path.
-      suggestions: true,
-      ...(isIntelligenceRuntime(runtime)
+      suggestions: webEnabled,
+      ...(isIntelligenceRuntime(runtime) && webEnabled
         ? {
             intelligence: {
               wsUrl: runtime.intelligence.ɵgetClientWsUrl(),
@@ -99,8 +104,8 @@ export async function handleGetRuntimeInfo({
       // boolean discards (see CopilotKit/CopilotKit#5369). Both go through the
       // shared isA2UIEnabled() predicate so an explicit `enabled: false`
       // disables a2ui here exactly as it does on the run path.
-      a2uiEnabled: isA2UIEnabled(runtime.a2ui),
-      ...(isA2UIEnabled(runtime.a2ui)
+      a2uiEnabled: webEnabled && isA2UIEnabled(runtime.a2ui),
+      ...(webEnabled && isA2UIEnabled(runtime.a2ui)
         ? {
             a2ui: {
               enabled: true,
@@ -108,7 +113,7 @@ export async function handleGetRuntimeInfo({
             },
           }
         : {}),
-      openGenerativeUIEnabled: !!runtime.openGenerativeUI,
+      openGenerativeUIEnabled: webEnabled && !!runtime.openGenerativeUI,
       ...(isIntelligenceRuntime(runtime)
         ? { licenseStatus: resolveLicenseStatus(runtime) }
         : {}),

--- a/packages/runtime/src/v2/runtime/handlers/handle-run.ts
+++ b/packages/runtime/src/v2/runtime/handlers/handle-run.ts
@@ -63,7 +63,12 @@ export async function handleRunAgent({
       agent,
       providerA2UIHasCatalog,
     });
-    await attachIntelligenceEnterpriseLearning({ runtime, request, agent });
+    const memoryResponse = await attachIntelligenceEnterpriseLearning({
+      runtime,
+      request,
+      agent,
+    });
+    if (memoryResponse instanceof Response) return memoryResponse;
 
     agent.setMessages(input.messages);
     agent.setState(input.state);

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/memories.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/memories.ts
@@ -1,8 +1,12 @@
-import type { CopilotRuntimeLike } from "../../core/runtime";
+import type {
+  CopilotIntelligenceRuntimeLike,
+  CopilotRuntimeLike,
+} from "../../core/runtime";
 import { isIntelligenceRuntime } from "../../core/runtime";
 import { logger } from "@copilotkit/shared";
 import { errorResponse, isHandlerResponse } from "../shared/json-response";
 import { resolveIntelligenceUser } from "../shared/resolve-intelligence-user";
+import { resolveWebMemory } from "../shared/memory-policy";
 import { PlatformRequestError } from "../../intelligence-platform/client";
 
 interface MemoriesHandlerParams {
@@ -12,6 +16,15 @@ interface MemoriesHandlerParams {
 
 interface MemoryMutationParams extends MemoriesHandlerParams {
   memoryId: string;
+}
+
+async function resolveClientMemory(
+  runtime: CopilotIntelligenceRuntimeLike,
+  request: Request,
+) {
+  const user = await resolveIntelligenceUser({ runtime, request });
+  if (isHandlerResponse(user)) return user;
+  return resolveWebMemory(runtime, request, user, "client");
 }
 
 const MISSING_INTELLIGENCE_MESSAGE =
@@ -176,11 +189,12 @@ export async function handleListMemories({
       const includeInvalidated =
         url.searchParams.get("includeInvalidated") === "true";
 
-      const user = await resolveIntelligenceUser({ runtime, request });
-      if (isHandlerResponse(user)) return user;
+      const access = await resolveClientMemory(runtime, request);
+      if (isHandlerResponse(access)) return access;
 
       const data = await runtime.intelligence.listMemories({
-        userId: user.id,
+        userId: access.user.id,
+        ...(runtime.memory ? { memoryGrant: access.grant } : {}),
         ...(includeInvalidated ? { includeInvalidated: true } : {}),
       });
 
@@ -235,11 +249,12 @@ export async function handleRecallMemories({
     const fields = parseRecallBody(body);
     if (isHandlerResponse(fields)) return fields;
 
-    const user = await resolveIntelligenceUser({ runtime, request });
-    if (isHandlerResponse(user)) return user;
+    const access = await resolveClientMemory(runtime, request);
+    if (isHandlerResponse(access)) return access;
 
     const data = await runtime.intelligence.recallMemories({
-      userId: user.id,
+      userId: access.user.id,
+      ...(runtime.memory ? { memoryGrant: access.grant } : {}),
       ...fields,
     });
 
@@ -285,16 +300,21 @@ export async function handleSubscribeToMemories({
 }: MemoriesHandlerParams): Promise<Response> {
   if (isIntelligenceRuntime(runtime)) {
     try {
-      const user = await resolveIntelligenceUser({ runtime, request });
-      if (isHandlerResponse(user)) return user;
+      const access = await resolveClientMemory(runtime, request);
+      if (isHandlerResponse(access)) return access;
 
       const credentials = await runtime.intelligence.ɵsubscribeToMemories({
-        userId: user.id,
+        userId: access.user.id,
+        ...(runtime.memory ? { memoryGrant: access.grant } : {}),
       });
 
       return Response.json({
-        joinToken: credentials.joinToken,
-        joinCode: credentials.joinCode,
+        ...(credentials.joinToken !== undefined
+          ? { joinToken: credentials.joinToken }
+          : {}),
+        ...(credentials.joinCode !== undefined
+          ? { joinCode: credentials.joinCode }
+          : {}),
         // Project-scoped credentials ride along only when the platform minted
         // them; omit both when absent (silent-degrade contract).
         ...(credentials.projectJoinToken !== undefined
@@ -331,11 +351,12 @@ export async function handleCreateMemory({
     const fields = parseMemoryBody(body);
     if (isHandlerResponse(fields)) return fields;
 
-    const user = await resolveIntelligenceUser({ runtime, request });
-    if (isHandlerResponse(user)) return user;
+    const access = await resolveClientMemory(runtime, request);
+    if (isHandlerResponse(access)) return access;
 
     const data = await runtime.intelligence.createMemory({
-      userId: user.id,
+      userId: access.user.id,
+      ...(runtime.memory ? { memoryGrant: access.grant } : {}),
       ...fields,
     });
     return Response.json(data, { status: 201 });
@@ -363,11 +384,12 @@ export async function handleUpdateMemory({
     const fields = parseMemoryBody(body);
     if (isHandlerResponse(fields)) return fields;
 
-    const user = await resolveIntelligenceUser({ runtime, request });
-    if (isHandlerResponse(user)) return user;
+    const access = await resolveClientMemory(runtime, request);
+    if (isHandlerResponse(access)) return access;
 
     const data = await runtime.intelligence.updateMemory({
-      userId: user.id,
+      userId: access.user.id,
+      ...(runtime.memory ? { memoryGrant: access.grant } : {}),
       id: memoryId,
       ...fields,
     });
@@ -391,10 +413,14 @@ export async function handleRemoveMemory({
     return errorResponse(MISSING_INTELLIGENCE_MESSAGE, 422);
   }
   try {
-    const user = await resolveIntelligenceUser({ runtime, request });
-    if (isHandlerResponse(user)) return user;
+    const access = await resolveClientMemory(runtime, request);
+    if (isHandlerResponse(access)) return access;
 
-    await runtime.intelligence.removeMemory({ userId: user.id, id: memoryId });
+    await runtime.intelligence.removeMemory({
+      userId: access.user.id,
+      id: memoryId,
+      ...(runtime.memory ? { memoryGrant: access.grant } : {}),
+    });
     return new Response(null, { status: 204 });
   } catch (error) {
     logger.error({ err: error }, "Error removing memory");

--- a/packages/runtime/src/v2/runtime/handlers/shared/__tests__/attach-intelligence-enterprise-learning.test.ts
+++ b/packages/runtime/src/v2/runtime/handlers/shared/__tests__/attach-intelligence-enterprise-learning.test.ts
@@ -14,6 +14,7 @@ vi.mock("@ag-ui/mcp-middleware", () => ({
 
 import { attachIntelligenceEnterpriseLearning } from "../agent-utils";
 import { INTELLIGENCE_USER_ID_HEADER } from "../../../intelligence-platform/client";
+import { INTELLIGENCE_MEMORY_GRANT_HEADER } from "../../../intelligence-platform/client";
 import type { CopilotRuntimeLike } from "../../../core/runtime";
 import { RUNTIME_MODE_INTELLIGENCE, logger } from "@copilotkit/shared";
 
@@ -35,11 +36,13 @@ function makeAgent(): AbstractAgent & {
 function makeRuntime(opts: {
   intelligence?: IntelligenceStub;
   identifyUser?: (req: Request) => Promise<{ id: string; name: string }>;
+  memory?: CopilotRuntimeLike["memory"];
 }): CopilotRuntimeLike {
   return {
     mode: opts.intelligence ? RUNTIME_MODE_INTELLIGENCE : "sse",
     intelligence: opts.intelligence,
     identifyUser: opts.identifyUser,
+    memory: opts.memory,
   } as unknown as CopilotRuntimeLike;
 }
 
@@ -113,6 +116,64 @@ describe("attachIntelligenceEnterpriseLearning", () => {
         },
       },
     ]);
+  });
+
+  it("evaluates agent Memory once and sends its grant with the resolved user", async () => {
+    const agent = makeAgent();
+    const identifyUser = vi
+      .fn()
+      .mockResolvedValue({ id: "user-42", name: "Forty Two" });
+    const access = vi.fn().mockReturnValue({
+      user: "read",
+      project: "read-write",
+    });
+    const runRequest = request();
+    const result = await attachIntelligenceEnterpriseLearning({
+      runtime: makeRuntime({
+        intelligence: makeIntelligenceStub({
+          ɵisEnterpriseLearningEnabled: () => false,
+        }),
+        identifyUser,
+        memory: { access },
+      }),
+      request: runRequest,
+      agent,
+    });
+
+    expect(result).toBeUndefined();
+    expect(identifyUser).toHaveBeenCalledTimes(1);
+    expect(access).toHaveBeenCalledWith({
+      request: runRequest,
+      user: { id: "user-42", name: "Forty Two" },
+      consumer: "agent",
+    });
+    const [servers] = mcpMiddlewareCalls[0] as [
+      Array<{ headers: Record<string, string> }>,
+    ];
+    expect(servers[0]?.headers).toMatchObject({
+      [INTELLIGENCE_USER_ID_HEADER]: "user-42",
+      [INTELLIGENCE_MEMORY_GRANT_HEADER]: JSON.stringify({
+        user: "read",
+        project: "read-write",
+      }),
+    });
+  });
+
+  it("returns forbidden when configured agent Memory is denied", async () => {
+    const agent = makeAgent();
+    const result = await attachIntelligenceEnterpriseLearning({
+      runtime: makeRuntime({
+        intelligence: makeIntelligenceStub(),
+        identifyUser: async () => ({ id: "u1", name: "User" }),
+        memory: { access: () => null },
+      }),
+      request: request(),
+      agent,
+    });
+
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(403);
+    expect(agent.use).not.toHaveBeenCalled();
   });
 
   it("skips silently when identifyUser returns an invalid user", async () => {

--- a/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
@@ -10,12 +10,17 @@ import {
   resolveAgents,
 } from "../../core/runtime";
 import { OpenGenerativeUIMiddleware } from "../../open-generative-ui-middleware";
-import { INTELLIGENCE_USER_ID_HEADER } from "../../intelligence-platform/client";
+import {
+  INTELLIGENCE_MEMORY_GRANT_HEADER,
+  INTELLIGENCE_USER_ID_HEADER,
+} from "../../intelligence-platform/client";
 import {
   mergeForwardableHeaders,
   resolveForwardHeadersPolicy,
 } from "../header-utils";
 import { resolveIntelligenceUser } from "./resolve-intelligence-user";
+import { resolveWebMemory } from "./memory-policy";
+import { errorResponse } from "./json-response";
 import { logger } from "@copilotkit/shared";
 
 type MiddlewareCapableAgent = AbstractAgent & {
@@ -185,13 +190,14 @@ export async function attachIntelligenceEnterpriseLearning(params: {
   runtime: CopilotRuntimeLike;
   request: Request;
   agent: AbstractAgent;
-}): Promise<void> {
+}): Promise<void | Response> {
   const { runtime, request } = params;
   const agent = params.agent as MiddlewareCapableAgent;
 
   if (
     !isIntelligenceRuntime(runtime) ||
-    !runtime.intelligence?.ɵisEnterpriseLearningEnabled?.()
+    (runtime.memory === undefined &&
+      !runtime.intelligence?.ɵisEnterpriseLearningEnabled?.())
   ) {
     return;
   }
@@ -200,6 +206,12 @@ export async function attachIntelligenceEnterpriseLearning(params: {
   // middleware — surface it rather than silently shipping a run with none
   // of the tools the operator opted into.
   if (typeof agent.use !== "function") {
+    if (runtime.memory) {
+      return errorResponse(
+        "Memory is configured, but this agent does not support middleware",
+        500,
+      );
+    }
     logger.warn(
       "CopilotKitIntelligence.enableEnterpriseLearning is enabled, but the agent " +
         "does not support middleware (no `.use()` method); Intelligence tools were " +
@@ -209,7 +221,9 @@ export async function attachIntelligenceEnterpriseLearning(params: {
   }
 
   const userResult = await resolveIntelligenceUser({ runtime, request });
-  if (userResult instanceof Response) return;
+  if (userResult instanceof Response) return userResult;
+  const access = await resolveWebMemory(runtime, request, userResult, "agent");
+  if (access instanceof Response) return access;
 
   agent.use(
     new MCPMiddleware([
@@ -220,6 +234,13 @@ export async function attachIntelligenceEnterpriseLearning(params: {
         headers: {
           Authorization: `Bearer ${runtime.intelligence.ɵgetApiKey()}`,
           [INTELLIGENCE_USER_ID_HEADER]: userResult.id,
+          ...(runtime.memory
+            ? {
+                [INTELLIGENCE_MEMORY_GRANT_HEADER]: JSON.stringify(
+                  access.grant,
+                ),
+              }
+            : {}),
         },
       },
     ]),

--- a/packages/runtime/src/v2/runtime/handlers/shared/memory-policy.ts
+++ b/packages/runtime/src/v2/runtime/handlers/shared/memory-policy.ts
@@ -1,0 +1,42 @@
+import type {
+  CopilotIntelligenceRuntimeLike,
+  CopilotRuntimeUser,
+  MemoryConsumer,
+  MemoryGrant,
+} from "../../core/runtime";
+import { errorResponse } from "./json-response";
+
+const ACCESS = new Set(["none", "read", "read-write"]);
+
+export interface ResolvedWebMemory {
+  readonly user: CopilotRuntimeUser;
+  readonly grant: MemoryGrant;
+}
+
+/** Evaluates and validates one configured web Memory policy. */
+export async function resolveWebMemory(
+  runtime: CopilotIntelligenceRuntimeLike,
+  request: Request,
+  user: CopilotRuntimeUser,
+  consumer: MemoryConsumer,
+): Promise<ResolvedWebMemory | Response> {
+  if (!runtime.memory) {
+    return {
+      user,
+      grant: { user: "read-write", project: "read-write" },
+    };
+  }
+
+  try {
+    const grant = await runtime.memory.access({ request, user, consumer });
+    if (grant === null || (grant.user === "none" && grant.project === "none")) {
+      return errorResponse("Memory access denied", 403);
+    }
+    if (!ACCESS.has(grant.user) || !ACCESS.has(grant.project)) {
+      return errorResponse("Memory policy returned an invalid grant", 500);
+    }
+    return { user, grant: { user: grant.user, project: grant.project } };
+  } catch {
+    return errorResponse("Memory policy failed", 500);
+  }
+}

--- a/packages/runtime/src/v2/runtime/handlers/shared/resolve-intelligence-user.ts
+++ b/packages/runtime/src/v2/runtime/handlers/shared/resolve-intelligence-user.ts
@@ -1,9 +1,14 @@
-import {
+import type {
   CopilotIntelligenceRuntimeLike,
   CopilotRuntimeUser,
 } from "../../core/runtime";
 import { errorResponse } from "./json-response";
 import { isValidIdentifier } from "./intelligence-utils";
+
+const resolvedUsers = new WeakMap<
+  Request,
+  Promise<CopilotRuntimeUser | Response>
+>();
 
 export async function resolveIntelligenceUser(params: {
   runtime: CopilotIntelligenceRuntimeLike;
@@ -11,6 +16,18 @@ export async function resolveIntelligenceUser(params: {
 }): Promise<CopilotRuntimeUser | Response> {
   const { runtime, request } = params;
 
+  const existing = resolvedUsers.get(request);
+  if (existing) return existing;
+
+  const resolution = resolveUser(runtime, request);
+  resolvedUsers.set(request, resolution);
+  return resolution;
+}
+
+async function resolveUser(
+  runtime: CopilotIntelligenceRuntimeLike,
+  request: Request,
+): Promise<CopilotRuntimeUser | Response> {
   try {
     const user = await runtime.identifyUser(request);
     if (!isValidIdentifier(user?.id)) {

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -12,6 +12,23 @@ import { randomUUID } from "crypto";
  * @internal
  */
 export const INTELLIGENCE_USER_ID_HEADER = "x-cpki-user-id";
+/** Immutable user/project Memory grant forwarded to Intelligence. */
+export const INTELLIGENCE_MEMORY_GRANT_HEADER = "x-cpki-memory-grant";
+
+interface RuntimeMemoryGrant {
+  readonly user: "none" | "read" | "read-write";
+  readonly project: "none" | "read" | "read-write";
+}
+
+const memoryRequestHeaders = (
+  userId: string,
+  grant?: RuntimeMemoryGrant,
+): Record<string, string> => ({
+  [INTELLIGENCE_USER_ID_HEADER]: userId,
+  ...(grant
+    ? { [INTELLIGENCE_MEMORY_GRANT_HEADER]: JSON.stringify(grant) }
+    : {}),
+});
 
 /**
  * REST base URL of CopilotKit's managed Intelligence platform — the default
@@ -97,6 +114,9 @@ export interface CopilotKitIntelligenceConfig {
    *
    * Defaults to `false` — opt-in. Existing intelligence setups continue
    * to work without these tools unless they flip this flag.
+   *
+   * @deprecated Configure `memory.access` on `CopilotRuntime` so each web
+   * request receives an explicit agent or client Memory grant.
    */
   enableEnterpriseLearning?: boolean;
   /**
@@ -247,6 +267,7 @@ export interface SubscribeToThreadsResponse {
 
 export interface SubscribeToMemoriesRequest {
   userId: string;
+  memoryGrant?: RuntimeMemoryGrant;
 }
 
 /**
@@ -256,8 +277,8 @@ export interface SubscribeToMemoriesRequest {
  * `user_meta:memories:<joinCode>` channel topic.
  */
 export interface SubscribeToMemoriesResponse {
-  joinToken: string;
-  joinCode: string;
+  joinToken?: string;
+  joinCode?: string;
   /**
    * Project-scoped realtime credentials, minted by the platform only when the
    * caller's API key resolves to a project scope. Absent when project scope is
@@ -686,6 +707,7 @@ export class CopilotKitIntelligence {
    */
   async listMemories(params: {
     userId: string;
+    memoryGrant?: RuntimeMemoryGrant;
     includeInvalidated?: boolean;
   }): Promise<ListMemoriesResponse> {
     const qs = params.includeInvalidated ? "?includeInvalidated=true" : "";
@@ -693,7 +715,7 @@ export class CopilotKitIntelligence {
       "GET",
       `/api/memories${qs}`,
       undefined,
-      { [INTELLIGENCE_USER_ID_HEADER]: params.userId },
+      memoryRequestHeaders(params.userId, params.memoryGrant),
     );
   }
 
@@ -705,6 +727,7 @@ export class CopilotKitIntelligence {
    */
   async createMemory(params: {
     userId: string;
+    memoryGrant?: RuntimeMemoryGrant;
     content: string;
     kind: string;
     /** Optional: when omitted, the platform applies its default (`"user"`). */
@@ -720,7 +743,7 @@ export class CopilotKitIntelligence {
         ...(params.scope !== undefined ? { scope: params.scope } : {}),
         sourceThreadIds: params.sourceThreadIds ?? [],
       },
-      { [INTELLIGENCE_USER_ID_HEADER]: params.userId },
+      memoryRequestHeaders(params.userId, params.memoryGrant),
     );
   }
 
@@ -734,6 +757,7 @@ export class CopilotKitIntelligence {
    */
   async updateMemory(params: {
     userId: string;
+    memoryGrant?: RuntimeMemoryGrant;
     id: string;
     content: string;
     kind: string;
@@ -750,7 +774,7 @@ export class CopilotKitIntelligence {
         ...(params.scope !== undefined ? { scope: params.scope } : {}),
         sourceThreadIds: params.sourceThreadIds ?? [],
       },
-      { [INTELLIGENCE_USER_ID_HEADER]: params.userId },
+      memoryRequestHeaders(params.userId, params.memoryGrant),
     );
   }
 
@@ -758,12 +782,16 @@ export class CopilotKitIntelligence {
    * Non-lossily retire (forget) a memory (platform `DELETE /api/memories/:id`).
    * @throws {@link PlatformRequestError} on non-2xx responses.
    */
-  async removeMemory(params: { userId: string; id: string }): Promise<void> {
+  async removeMemory(params: {
+    userId: string;
+    id: string;
+    memoryGrant?: RuntimeMemoryGrant;
+  }): Promise<void> {
     await this.#request<void>(
       "DELETE",
       `/api/memories/${encodeURIComponent(params.id)}`,
       undefined,
-      { [INTELLIGENCE_USER_ID_HEADER]: params.userId },
+      memoryRequestHeaders(params.userId, params.memoryGrant),
     );
   }
 
@@ -775,6 +803,7 @@ export class CopilotKitIntelligence {
    */
   async recallMemories(params: {
     userId: string;
+    memoryGrant?: RuntimeMemoryGrant;
     query: string;
     limit?: number;
     scope?: string;
@@ -787,7 +816,7 @@ export class CopilotKitIntelligence {
         ...(params.limit !== undefined ? { limit: params.limit } : {}),
         ...(params.scope !== undefined ? { scope: params.scope } : {}),
       },
-      { [INTELLIGENCE_USER_ID_HEADER]: params.userId },
+      memoryRequestHeaders(params.userId, params.memoryGrant),
     );
   }
 
@@ -827,7 +856,7 @@ export class CopilotKitIntelligence {
       "POST",
       "/api/memories/subscribe",
       undefined,
-      { [INTELLIGENCE_USER_ID_HEADER]: params.userId },
+      memoryRequestHeaders(params.userId, params.memoryGrant),
     );
   }
 

--- a/showcase/shell-docs/src/content/docs/channels/history-and-transcripts.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/history-and-transcripts.mdx
@@ -63,8 +63,9 @@ binary data in `ThreadMessage`.
 ## Add cross-platform SDK transcripts
 
 Use SDK transcripts when your application needs a user-centric record across
-Slack and Teams. Configure both `identity` and `transcripts`; providing only
-one is an error.
+Slack and Teams. Configure top-level `identifyUser` and `store.transcripts`.
+When identity resolves to `null`, the transcript bridge skips personal reads
+and writes.
 
 <FrontendOnly frontend="slack">
 
@@ -74,16 +75,16 @@ import { durableStateStore } from "./state-store.js";
 
 const channel = createChannel({
   name: required("CHANNEL_CODE"),
+  identifyUser: async ({ provider, actor }) => {
+    const account = await accounts.findByExternalIdentity({
+      provider,
+      externalUserId: actor.id,
+    });
+    return account ? { id: account.id, name: account.name } : null;
+  },
   agent: makeAgent,
   store: {
     adapter: durableStateStore,
-    identity: async ({ author, message }) => {
-      const account = await accounts.findByExternalIdentity({
-        provider: message.platform,
-        externalUserId: author.id,
-      });
-      return account?.id ?? null;
-    },
     transcripts: {
       retention: "30d",
       maxPerUser: 500,
@@ -102,16 +103,16 @@ import { durableStateStore } from "./state-store.js";
 
 const channel = createChannel({
   name: required("CHANNEL_CODE"),
+  identifyUser: async ({ provider, actor }) => {
+    const account = await accounts.findByExternalIdentity({
+      provider,
+      externalUserId: actor.id,
+    });
+    return account ? { id: account.id, name: account.name } : null;
+  },
   agent: makeAgent,
   store: {
     adapter: durableStateStore,
-    identity: async ({ author, message }) => {
-      const account = await accounts.findByExternalIdentity({
-        provider: message.platform,
-        externalUserId: author.id,
-      });
-      return account?.id ?? null;
-    },
     transcripts: {
       retention: "30d",
       maxPerUser: 500,
@@ -153,19 +154,19 @@ duplicate the record.
 
 ```ts title="transcripts.ts"
 const recent = await channel.transcripts.list({
-  userKey: "usr_123",
+  userId: "usr_123",
   limit: 50,
 });
 
 const { deleted } = await channel.transcripts.delete({
-  userKey: "usr_123",
+  userId: "usr_123",
 });
 ```
 
 `list()` returns entries oldest-first. You can filter by platform, thread id, or
-role. Managed entries use the native `"slack"` or `"teams"` platform. Resolve
-cross-provider identity through `userKey`; use the platform filter only when
-you intentionally want one provider's entries.
+role. Managed entries use the native `"slack"` or `"teams"` provider. Resolve
+cross-provider identity through the application `userId`; use the platform
+filter only when you intentionally want one provider\'s entries.
 
 `delete()` removes the SDK-owned transcript for that user; provider history and
 any separate Intelligence retention policy remain independent.

--- a/showcase/shell-docs/src/content/docs/channels/history-and-transcripts.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/history-and-transcripts.mdx
@@ -166,7 +166,7 @@ const { deleted } = await channel.transcripts.delete({
 `list()` returns entries oldest-first. You can filter by platform, thread id, or
 role. Managed entries use the native `"slack"` or `"teams"` provider. Resolve
 cross-provider identity through the application `userId`; use the platform
-filter only when you intentionally want one provider\'s entries.
+filter only when you intentionally want one provider's entries.
 
 `delete()` removes the SDK-owned transcript for that user; provider history and
 any separate Intelligence retention policy remain independent.

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -35,7 +35,7 @@ between those systems and the path each message takes.
 <OpsPlatformCTA
   variant="inline"
   title="More channels are on the way"
-  body="Slack and Teams are available now. More channels like Discord, WhatsApp, Telegram, and SMS are on the way. Talk to us about what you need."
+  body="Managed Slack is available now. Managed Teams is a controlled integration target. Direct SDK adapters also support Teams, Discord, WhatsApp, and Telegram."
   ctaLabel="Book time with an engineer"
   surface="docs_channels_more_channels_contact"
   href="https://copilotkit.ai/talk-to-an-engineer"

--- a/showcase/shell-docs/src/content/docs/channels/intelligence.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/intelligence.mdx
@@ -84,6 +84,7 @@ interactive behavior, state, and deployment.
 
     const channel = createChannel({
       name: "support",
+      identifyUser: "platform",
       agent: makeAgent,
     });
     ```

--- a/showcase/shell-docs/src/content/docs/channels/interactive/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/interactive/index.mdx
@@ -152,6 +152,7 @@ function required(name: string): string {
 
 const channel = createChannel({
   name: required("CHANNEL_CODE"),
+  identifyUser: "platform",
   agent: makeAgent,
   components: [ApprovalCard],
 });
@@ -181,6 +182,7 @@ function required(name: string): string {
 
 const channel = createChannel({
   name: required("CHANNEL_CODE"),
+  identifyUser: "platform",
   agent: makeAgent,
   components: [ApprovalCard],
 });

--- a/showcase/shell-docs/src/content/docs/channels/persistence-and-scaling.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/persistence-and-scaling.mdx
@@ -51,6 +51,7 @@ const workflowState = z.object({
 
 const channel = createChannel({
   name: required("CHANNEL_CODE"),
+  identifyUser: "platform",
   agent: makeAgent,
   store: {
     adapter: durableStateStore,
@@ -86,6 +87,7 @@ const workflowState = z.object({
 
 const channel = createChannel({
   name: required("CHANNEL_CODE"),
+  identifyUser: "platform",
   agent: makeAgent,
   store: {
     adapter: durableStateStore,
@@ -117,7 +119,7 @@ A complete production store implements:
 
 | Facet   | Required behavior                                          |
 | ------- | ---------------------------------------------------------- |
-| `kv`    | Get, set with optional TTL, and delete                     |
+| `kv`    | Get, set with optional TTL, atomic consume, and delete     |
 | `list`  | Oldest-first append/range, cap, trim, delete, and list TTL |
 | `lock`  | Atomic acquire plus token-checked release                  |
 | `dedup` | Atomic first-seen check with TTL                           |
@@ -166,6 +168,7 @@ A callback survives only when both conditions are true:
 ```tsx title="channel.tsx"
 const channel = createChannel({
   name: required("CHANNEL_CODE"),
+  identifyUser: "platform",
   agent: makeAgent,
   components: [ApprovalCard],
   store: { adapter: durableStateStore },
@@ -179,6 +182,7 @@ const channel = createChannel({
 ```tsx title="channel.tsx"
 const channel = createChannel({
   name: required("CHANNEL_CODE"),
+  identifyUser: "platform",
   agent: makeAgent,
   components: [ApprovalCard],
   store: { adapter: durableStateStore },

--- a/showcase/shell-docs/src/content/docs/channels/threads-and-state.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/threads-and-state.mdx
@@ -101,6 +101,7 @@ const workflowState = z.object({
 
 const channel = createChannel({
   name: required("CHANNEL_CODE"),
+  identifyUser: "platform",
   agent: makeAgent,
   store: {
     state: workflowState,
@@ -141,6 +142,7 @@ const workflowState = z.object({
 
 const channel = createChannel({
   name: required("CHANNEL_CODE"),
+  identifyUser: "platform",
   agent: makeAgent,
   store: {
     state: workflowState,

--- a/showcase/shell-docs/src/content/docs/channels/tools.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/tools.mdx
@@ -54,6 +54,7 @@ function required(name: string): string {
 
 const channel = createChannel({
   name: required("CHANNEL_CODE"),
+  identifyUser: "platform",
   agent: makeAgent,
   tools: [getIncident],
 });
@@ -76,6 +77,7 @@ function required(name: string): string {
 
 const channel = createChannel({
   name: required("CHANNEL_CODE"),
+  identifyUser: "platform",
   agent: makeAgent,
   tools: [getIncident],
 });
@@ -108,6 +110,7 @@ function required(name: string): string {
 
 const channel = createChannel({
   name: required("CHANNEL_CODE"),
+  identifyUser: "platform",
   agent: makeAgent,
   context: [
     {
@@ -139,6 +142,7 @@ function required(name: string): string {
 
 const channel = createChannel({
   name: required("CHANNEL_CODE"),
+  identifyUser: "platform",
   agent: makeAgent,
   context: [
     {
@@ -182,7 +186,7 @@ channel.onMessage(async ({ thread, message }) => {
       { description: "Originating platform", value: message.platform },
       {
         description: "Requesting user",
-        value: message.user.name ?? message.user.id,
+        value: message.user?.name ?? "Unidentified application user",
       },
     ],
   });
@@ -194,12 +198,13 @@ pass it for that run. Its closure captures the trusted inbound identity:
 
 ```ts title="channel.ts"
 channel.onMessage(async ({ thread, message }) => {
+  if (!message.user) return;
   const listMyApprovals = defineChannelTool({
     name: "list_my_approvals",
     description: "List approvals assigned to the requesting user.",
     parameters: z.object({}),
     async handler() {
-      return approvals.forPlatformUser(message.platform, message.user.id);
+      return approvals.forApplicationUser(message.user.id);
     },
   });
 
@@ -210,8 +215,8 @@ channel.onMessage(async ({ thread, message }) => {
 });
 ```
 
-Treat platform user ids as external identifiers. Resolve them to an authenticated
-application identity before allowing a consequential write.
+Treat provider actor IDs as external identifiers. Use the resolved application
+`user` for personal product data, and check it for `null` before a write.
 
 ## Render a tool result as native UI
 

--- a/showcase/shell-docs/src/content/docs/frontends/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/slack.mdx
@@ -96,6 +96,7 @@ You should have `CHANNEL_CODE` and `INTELLIGENCE_API_KEY`.
 
     const channel = createChannel({
       name: required("CHANNEL_CODE"),
+      identifyUser: "platform",
       agent: makeAgent,
     });
 
@@ -127,9 +128,6 @@ You should have `CHANNEL_CODE` and `INTELLIGENCE_API_KEY`.
     const runtime = new CopilotRuntime({
       agents: {},
       intelligence,
-      // Replace this stub with your authenticated application identity if this
-      // listener also serves normal Copilot Runtime requests.
-      identifyUser: () => ({ id: "channels-runtime", name: "Channels Runtime" }),
       channels: [channel],
     });
 
@@ -255,6 +253,7 @@ Opt in per Channel when the live tool timeline is useful:
 ```ts title="channel.ts"
 const channel = createChannel({
   name: required("CHANNEL_CODE"),
+  identifyUser: "platform",
   agent: makeAgent,
   showToolStatus: true,
 });

--- a/showcase/shell-docs/src/content/docs/frontends/teams.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/teams.mdx
@@ -92,6 +92,7 @@ You should have `CHANNEL_CODE` and `INTELLIGENCE_API_KEY`.
 
     const channel = createChannel({
       name: required("CHANNEL_CODE"),
+      identifyUser: "platform",
       agent: makeAgent,
     });
 
@@ -122,7 +123,6 @@ You should have `CHANNEL_CODE` and `INTELLIGENCE_API_KEY`.
     const runtime = new CopilotRuntime({
       agents: {},
       intelligence,
-      identifyUser: () => ({ id: "channels-runtime", name: "Channels Runtime" }),
       channels: [channel],
     });
 

--- a/showcase/shell-docs/src/content/reference/channels/classes/Channel.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/classes/Channel.mdx
@@ -25,7 +25,7 @@ both Slack and Teams for this Channel and keeps each delivery provider-scoped.
 | Option           | Type                                                   | Description                                                                                                                 |
 | ---------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
 | `name`           | `string`                                               | Project-unique Intelligence Code. Required for managed Channels; lowercase kebab-case, 3–64 characters, and not `channels`. |
-| `identifyUser`   | `"platform" \| ChannelIdentifyUser`                  | Required identity policy. Returns one application user or `null` for each provider event.                                  |
+| `identifyUser`   | `"platform" \| ChannelIdentifyUser`                    | Required identity policy. Returns one application user or `null` for each provider event.                                   |
 | `showToolStatus` | `boolean`                                              | Controls managed Slack tool-call progress. It is hidden by default; set `true` to show it.                                  |
 | `agent`          | `AbstractAgent \| (threadId: string) => AbstractAgent` | Agent instance or factory. Factory preferred; a singleton is isolated per run via `clone()`.                                |
 | `tools`          | `ChannelTool[]`                                        | Typed tools forwarded to the agent.                                                                                         |
@@ -40,16 +40,16 @@ unique inside one `CopilotRuntime`.
 
 ## StoreConfig
 
-| Option           | Type                            | Description                                                                                                                    |
-| ---------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `state`          | `StandardSchema`                | Types `thread.state()` and validates every `setState(value)`.                                                                  |
-| `adapter`        | `StateStore`                    | Persistence implementation for SDK state. Without it, the current managed realtime path falls back to process memory.          |
-| `transcripts`    | `TranscriptsConfig`             | SDK-owned cross-platform transcript configuration keyed by the application user from top-level `identifyUser`.                |
-| `actionRetentionMs` | `number`                    | Durable callback and one-use HITL continuation retention. Default: seven days.                                                 |
-| `concurrency`    | `"parallel" \| "serial" \| "drop"` | How overlapping turns on the same conversation are handled. Default: `"parallel"`. See [`StoreConfig`](/reference/channels/types/StoreConfig). |
-| `onLockConflict` | `"drop" \| "force" \| callback`    | **Deprecated.** Prefer `concurrency`. Maps to drop/parallel when static.                                                                       |
-| `lockTtl`        | `number`                           | Conversation lock TTL in milliseconds (drop / legacy paths). Default: `60_000`.                                                                |
-| `dedupTtl`       | `number`                           | Inbound event deduplication window in milliseconds. Default: `300_000`.                                                                        |
+| Option              | Type                               | Description                                                                                                                                    |
+| ------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `state`             | `StandardSchema`                   | Types `thread.state()` and validates every `setState(value)`.                                                                                  |
+| `adapter`           | `StateStore`                       | Persistence implementation for SDK state. Without it, the current managed realtime path falls back to process memory.                          |
+| `transcripts`       | `TranscriptsConfig`                | SDK-owned cross-platform transcript configuration keyed by the application user from top-level `identifyUser`.                                 |
+| `actionRetentionMs` | `number`                           | Durable callback and one-use HITL continuation retention. Default: seven days.                                                                 |
+| `concurrency`       | `"parallel" \| "serial" \| "drop"` | How overlapping turns on the same conversation are handled. Default: `"parallel"`. See [`StoreConfig`](/reference/channels/types/StoreConfig). |
+| `onLockConflict`    | `"drop" \| "force" \| callback`    | **Deprecated.** Prefer `concurrency`. Maps to drop/parallel when static.                                                                       |
+| `lockTtl`           | `number`                           | Conversation lock TTL in milliseconds (drop / legacy paths). Default: `60_000`.                                                                |
+| `dedupTtl`          | `number`                           | Inbound event deduplication window in milliseconds. Default: `300_000`.                                                                        |
 
 `StateStore` contains `kv`, `list`, `lock`, `dedup`, and `queue` facets. Remote
 implementations must preserve JSON-serializable values.
@@ -137,12 +137,12 @@ channel.onMessage(async ({ thread, message }) => {
 });
 ```
 
-| Method                     | Handler input                              | Notes                                                                                                                          |
-| -------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
-| `onMessage(handler)`       | `{ thread, message }`                      | Use this for managed Slack and Teams turns.                                                                                    |
-| `onMention(handler)`       | `{ thread, message }`                      | A bot mention selects this handler when registered; otherwise it falls back to `onMessage`. Other content selects `onMessage`. |
-| `onWelcome(handler)`       | `{ thread, user, actor, platform }`        | Runs once for a supported provider installation or conversation activation. No handler means no welcome output.                |
-| `onThreadStarted(handler)` | `{ thread, user, actor }`                  | Fires for provider surfaces that report a conversation-open event.                                                             |
+| Method                     | Handler input                       | Notes                                                                                                                          |
+| -------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `onMessage(handler)`       | `{ thread, message }`               | Use this for managed Slack and Teams turns.                                                                                    |
+| `onMention(handler)`       | `{ thread, message }`               | A bot mention selects this handler when registered; otherwise it falls back to `onMessage`. Other content selects `onMessage`. |
+| `onWelcome(handler)`       | `{ thread, user, actor, platform }` | Runs once for a supported provider installation or conversation activation. No handler means no welcome output.                |
+| `onThreadStarted(handler)` | `{ thread, user, actor }`           | Fires for provider surfaces that report a conversation-open event.                                                             |
 
 `message.platform` is the native provider (`"slack"` or `"teams"`).
 `thread.platform` carries that same native provider on a managed Channel.

--- a/showcase/shell-docs/src/content/reference/channels/classes/Channel.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/classes/Channel.mdx
@@ -12,6 +12,7 @@ import { makeAgent } from "./agent.js";
 
 const channel = createChannel({
   name: "support",
+  identifyUser: "platform",
   agent: makeAgent,
 });
 ```
@@ -24,6 +25,7 @@ both Slack and Teams for this Channel and keeps each delivery provider-scoped.
 | Option           | Type                                                   | Description                                                                                                                 |
 | ---------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
 | `name`           | `string`                                               | Project-unique Intelligence Code. Required for managed Channels; lowercase kebab-case, 3–64 characters, and not `channels`. |
+| `identifyUser`   | `"platform" \| ChannelIdentifyUser`                  | Required identity policy. Returns one application user or `null` for each provider event.                                  |
 | `showToolStatus` | `boolean`                                              | Controls managed Slack tool-call progress. It is hidden by default; set `true` to show it.                                  |
 | `agent`          | `AbstractAgent \| (threadId: string) => AbstractAgent` | Agent instance or factory. Factory preferred; a singleton is isolated per run via `clone()`.                                |
 | `tools`          | `ChannelTool[]`                                        | Typed tools forwarded to the agent.                                                                                         |
@@ -38,12 +40,12 @@ unique inside one `CopilotRuntime`.
 
 ## StoreConfig
 
-| Option           | Type                               | Description                                                                                                                                    |
-| ---------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `state`          | `StandardSchema`                   | Types `thread.state()` and validates every `setState(value)`.                                                                                  |
-| `adapter`        | `StateStore`                       | Persistence implementation for SDK state. Without it, the current managed realtime path falls back to process memory.                          |
-| `identity`       | `Identity`                         | Resolves a stable user key for the optional transcript bridge. Must be paired with `transcripts`.                                              |
-| `transcripts`    | `TranscriptsConfig`                | SDK-owned cross-platform transcript configuration. Distinct from managed conversation history. Must be paired with `identity`.                 |
+| Option           | Type                            | Description                                                                                                                    |
+| ---------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `state`          | `StandardSchema`                | Types `thread.state()` and validates every `setState(value)`.                                                                  |
+| `adapter`        | `StateStore`                    | Persistence implementation for SDK state. Without it, the current managed realtime path falls back to process memory.          |
+| `transcripts`    | `TranscriptsConfig`             | SDK-owned cross-platform transcript configuration keyed by the application user from top-level `identifyUser`.                |
+| `actionRetentionMs` | `number`                    | Durable callback and one-use HITL continuation retention. Default: seven days.                                                 |
 | `concurrency`    | `"parallel" \| "serial" \| "drop"` | How overlapping turns on the same conversation are handled. Default: `"parallel"`. See [`StoreConfig`](/reference/channels/types/StoreConfig). |
 | `onLockConflict` | `"drop" \| "force" \| callback`    | **Deprecated.** Prefer `concurrency`. Maps to drop/parallel when static.                                                                       |
 | `lockTtl`        | `number`                           | Conversation lock TTL in milliseconds (drop / legacy paths). Default: `60_000`.                                                                |
@@ -63,6 +65,7 @@ interface StateStore {
   kv: {
     get<T>(key: string): Promise<T | undefined>;
     set<T>(key: string, value: T, ttlMs?: number): Promise<void>;
+    consume<T>(key: string): Promise<T | undefined>;
     delete(key: string): Promise<void>;
   };
   list: {
@@ -134,12 +137,12 @@ channel.onMessage(async ({ thread, message }) => {
 });
 ```
 
-| Method                     | Handler input                 | Notes                                                                                                                          |
-| -------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `onMessage(handler)`       | `{ thread, message }`         | Use this for managed Slack and Teams turns.                                                                                    |
-| `onMention(handler)`       | `{ thread, message }`         | A bot mention selects this handler when registered; otherwise it falls back to `onMessage`. Other content selects `onMessage`. |
-| `onWelcome(handler)`       | `{ thread, user?, platform }` | Runs once for a supported provider installation or conversation activation. No handler means no welcome output.                |
-| `onThreadStarted(handler)` | `{ thread, user? }`           | Fires for provider surfaces that report a conversation-open event.                                                             |
+| Method                     | Handler input                              | Notes                                                                                                                          |
+| -------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| `onMessage(handler)`       | `{ thread, message }`                      | Use this for managed Slack and Teams turns.                                                                                    |
+| `onMention(handler)`       | `{ thread, message }`                      | A bot mention selects this handler when registered; otherwise it falls back to `onMessage`. Other content selects `onMessage`. |
+| `onWelcome(handler)`       | `{ thread, user, actor, platform }`        | Runs once for a supported provider installation or conversation activation. No handler means no welcome output.                |
+| `onThreadStarted(handler)` | `{ thread, user, actor }`                  | Fires for provider surfaces that report a conversation-open event.                                                             |
 
 `message.platform` is the native provider (`"slack"` or `"teams"`).
 `thread.platform` carries that same native provider on a managed Channel.

--- a/showcase/shell-docs/src/content/reference/channels/classes/MemoryStore.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/classes/MemoryStore.mdx
@@ -13,6 +13,7 @@ const store = new MemoryStore();
 
 const channel = createChannel({
   name: "support-slack",
+  identifyUser: "platform",
   agent: makeAgent,
   store: { adapter: store },
 });

--- a/showcase/shell-docs/src/content/reference/channels/classes/Thread.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/classes/Thread.mdx
@@ -49,16 +49,17 @@ allowed to fail the workflow.
 | Method             | Returns                            | Description                                                  |
 | ------------------ | ---------------------------------- | ------------------------------------------------------------ |
 | `runAgent(input?)` | `Promise<MessageRef \| undefined>` | Run the thread's agent and render its output.                |
-| `resume(value)`    | `Promise<MessageRef \| undefined>` | Re-enter an interrupted run with a human or external result. |
+| `resume(value, options?)` | `Promise<MessageRef \| undefined>` | Consume the action continuation and re-enter an interrupted run. |
 
 `runAgent` accepts:
 
 | Field        | Type                            | Description                                                                                                             |
 | ------------ | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `prompt`     | `string \| AgentContentPart[]`  | Explicit user turn. When omitted in a message handler, the SDK injects the inbound text or content parts automatically. |
-| `context`    | `ContextEntry[]`                | Context for this run only.                                                                                              |
-| `tools`      | `ChannelTool[]`                 | Tools for this run only.                                                                                                |
-| `transcript` | `boolean \| { limit?: number }` | Optional SDK transcript bridge when `identity` and `transcripts` are configured.                                        |
+| `context`    | `ContextEntry[]`                | Context for this run only.                                                                     |
+| `tools`      | `ChannelTool[]`                 | Tools for this run only.                                                                       |
+| `transcript` | `boolean \| { limit?: number }` | Optional SDK transcript bridge when `identifyUser` resolves a user and transcripts are configured. |
+| `memory` | `{ user?, project? }` | Per-run Intelligence Memory access. Each scope is `"none"`, `"read"`, or `"read-write"`; omission disables Memory. |
 
 ```ts title="channel.ts"
 channel.onMessage(async ({ thread, message }) => {
@@ -81,12 +82,33 @@ handler, and call `resume(value)` when a later click arrives. Do not call
 `awaitChoice`; see the interactive messages guide for
 [Slack](/slack/interactive) or [Teams](/teams/interactive).
 
+Personal Memory on resume needs a trusted subject selector:
+
+```ts
+await thread.resume(value, {
+  memory: { user: "read", project: "read" },
+  subject: "initiator", // or "actor"
+});
+```
+
+`initiator` keeps the application user that started this HITL chain. `actor`
+uses the application user resolved for the current interaction. Project-only
+Memory needs no subject and carries no made-up user. A continuation expires
+with action retention and can start only one resumed run.
+
+Memory and continuation failures expose stable codes:
+
+- `channel_memory_grant_invalid`, `channel_memory_user_required`, and
+  `channel_memory_unavailable`
+- `channel_memory_subject_required`, `channel_continuation_required`,
+  `channel_continuation_mismatch`, and `channel_action_expired`
+
 ## Conversation history and users
 
 | Method              | Returns                              | Description                                                          |
 | ------------------- | ------------------------------------ | -------------------------------------------------------------------- |
 | `getMessages()`     | `Promise<ThreadMessage[]>`           | Managed history in chronological order; returns `[]` if unavailable. |
-| `lookupUser(query)` | `Promise<PlatformUser \| undefined>` | Provider lookup where supported.                                     |
+| `lookupUser(query)` | `Promise<ProviderActor \| undefined>` | Provider lookup where supported.                                     |
 
 ## Per-conversation state
 

--- a/showcase/shell-docs/src/content/reference/channels/classes/Thread.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/classes/Thread.mdx
@@ -46,9 +46,9 @@ allowed to fail the workflow.
 
 ## Run and resume the agent
 
-| Method             | Returns                            | Description                                                  |
-| ------------------ | ---------------------------------- | ------------------------------------------------------------ |
-| `runAgent(input?)` | `Promise<MessageRef \| undefined>` | Run the thread's agent and render its output.                |
+| Method                    | Returns                            | Description                                                      |
+| ------------------------- | ---------------------------------- | ---------------------------------------------------------------- |
+| `runAgent(input?)`        | `Promise<MessageRef \| undefined>` | Run the thread's agent and render its output.                    |
 | `resume(value, options?)` | `Promise<MessageRef \| undefined>` | Consume the action continuation and re-enter an interrupted run. |
 
 `runAgent` accepts:
@@ -56,10 +56,10 @@ allowed to fail the workflow.
 | Field        | Type                            | Description                                                                                                             |
 | ------------ | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `prompt`     | `string \| AgentContentPart[]`  | Explicit user turn. When omitted in a message handler, the SDK injects the inbound text or content parts automatically. |
-| `context`    | `ContextEntry[]`                | Context for this run only.                                                                     |
-| `tools`      | `ChannelTool[]`                 | Tools for this run only.                                                                       |
-| `transcript` | `boolean \| { limit?: number }` | Optional SDK transcript bridge when `identifyUser` resolves a user and transcripts are configured. |
-| `memory` | `{ user?, project? }` | Per-run Intelligence Memory access. Each scope is `"none"`, `"read"`, or `"read-write"`; omission disables Memory. |
+| `context`    | `ContextEntry[]`                | Context for this run only.                                                                                              |
+| `tools`      | `ChannelTool[]`                 | Tools for this run only.                                                                                                |
+| `transcript` | `boolean \| { limit?: number }` | Optional SDK transcript bridge when `identifyUser` resolves a user and transcripts are configured.                      |
+| `memory`     | `{ user?, project? }`           | Per-run Intelligence Memory access. Each scope is `"none"`, `"read"`, or `"read-write"`; omission disables Memory.      |
 
 ```ts title="channel.ts"
 channel.onMessage(async ({ thread, message }) => {
@@ -105,9 +105,9 @@ Memory and continuation failures expose stable codes:
 
 ## Conversation history and users
 
-| Method              | Returns                              | Description                                                          |
-| ------------------- | ------------------------------------ | -------------------------------------------------------------------- |
-| `getMessages()`     | `Promise<ThreadMessage[]>`           | Managed history in chronological order; returns `[]` if unavailable. |
+| Method              | Returns                               | Description                                                          |
+| ------------------- | ------------------------------------- | -------------------------------------------------------------------- |
+| `getMessages()`     | `Promise<ThreadMessage[]>`            | Managed history in chronological order; returns `[]` if unavailable. |
 | `lookupUser(query)` | `Promise<ProviderActor \| undefined>` | Provider lookup where supported.                                     |
 
 ## Per-conversation state

--- a/showcase/shell-docs/src/content/reference/channels/classes/Transcripts.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/classes/Transcripts.mdx
@@ -4,18 +4,17 @@ description: Append, query, retain, and delete an application-owned transcript k
 ---
 
 `Transcripts` stores an optional SDK-owned record on the Channel's
-`StateStore`. Configure `store.identity` and `store.transcripts` together.
+`StateStore`. Configure top-level `identifyUser` and `store.transcripts`.
 
 ## Configuration
 
 ```ts
 const channel = createChannel({
   name: "support-slack",
+  identifyUser: ({ actor }) => accounts.resolveApplicationUser(actor.id),
   agent: makeAgent,
   store: {
     adapter: durableStateStore,
-    identity: async ({ author, message }) =>
-      accounts.resolveUserId(message.platform, author.id),
     transcripts: {
       retention: "30d",
       maxPerUser: 500,
@@ -30,21 +29,23 @@ the `list` facet, so that facet must be durable for production transcripts.
 ## append
 
 ```ts
-await channel.transcripts.append(thread, {
-  role: "assistant",
-  text: "The incident owner is Payments.",
-  userKey: "usr_123",
-});
+await channel.transcripts.append(
+  thread,
+  {
+    role: "assistant",
+    text: "The incident owner is Payments.",
+  },
+  { userId: "usr_123" },
+);
 ```
 
-Append silently does nothing when neither the message nor `opts` supplies a
-`userKey`.
+Append silently does nothing when `userId` is `null`.
 
 ## list
 
 ```ts
 const entries = await channel.transcripts.list({
-  userKey: "usr_123",
+  userId: "usr_123",
   limit: 20,
   roles: ["user", "assistant"],
 });
@@ -52,14 +53,14 @@ const entries = await channel.transcripts.list({
 
 Entries are oldest-first and can be filtered by platform, `threadId`, or role.
 On managed Channels, `platform` is the native provider (`"slack"` or
-`"teams"`). Use the stable `userKey` to carry context between providers, and
-filter by platform only when you want one provider's entries.
+`"teams"`). Use the stable application `userId` to carry context between
+providers, and filter by platform only when you want one provider\'s entries.
 
 ## delete
 
 ```ts
 const { deleted } = await channel.transcripts.delete({
-  userKey: "usr_123",
+  userId: "usr_123",
 });
 ```
 

--- a/showcase/shell-docs/src/content/reference/channels/classes/Transcripts.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/classes/Transcripts.mdx
@@ -54,7 +54,7 @@ const entries = await channel.transcripts.list({
 Entries are oldest-first and can be filtered by platform, `threadId`, or role.
 On managed Channels, `platform` is the native provider (`"slack"` or
 `"teams"`). Use the stable application `userId` to carry context between
-providers, and filter by platform only when you want one provider\'s entries.
+providers, and filter by platform only when you want one provider's entries.
 
 ## delete
 

--- a/showcase/shell-docs/src/content/reference/channels/functions/createChannel.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/functions/createChannel.mdx
@@ -25,6 +25,7 @@ import { createChannel } from "@copilotkit/channels";
 ```ts title="channel.ts"
 const channel = createChannel({
   name: "support",
+  identifyUser: "platform",
   agent: makeAgent,
   tools: [getIncident],
   context: [
@@ -49,6 +50,7 @@ prepared delivery only to its originating provider.
 | Option           | Type                                           | Notes                                                                                                                                |
 | ---------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `name`           | `string`                                       | Required for managed delivery. Must match the project-unique Intelligence Code.                                                      |
+| `identifyUser`   | `"platform" \| ChannelIdentifyUser`          | Required. Maps each provider actor to an application user or `null`.                                                          |
 | `showToolStatus` | `boolean`                                      | Managed Slack hides tool-call progress by default. Set `true` to show it; tool history remains available in Intelligence either way. |
 | `agent`          | `AbstractAgent \| (threadId) => AbstractAgent` | Prefer a factory; a singleton is isolated per run via `clone()`.                                                                     |
 | `tools`          | `ChannelTool[]`                                | Channel-level typed tools.                                                                                                           |
@@ -60,6 +62,15 @@ prepared delivery only to its originating provider.
 
 The managed runtime validates `name` as lowercase kebab-case, 3–64 characters,
 not equal to `channels`, and unique within the Runtime.
+
+Handlers receive both the required provider `actor` and the nullable
+application `user`. The SDK resolves that pair once for each incoming event.
+Both objects are immutable snapshots. The SDK does not link accounts by email,
+name, or handle.
+
+Malformed callback output rejects with `channel_identity_invalid`. A callback
+exception rejects with `channel_identity_failed` and never falls back to the
+standard platform policy.
 
 ## Registration methods
 

--- a/showcase/shell-docs/src/content/reference/channels/functions/createChannel.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/functions/createChannel.mdx
@@ -50,7 +50,7 @@ prepared delivery only to its originating provider.
 | Option           | Type                                           | Notes                                                                                                                                |
 | ---------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `name`           | `string`                                       | Required for managed delivery. Must match the project-unique Intelligence Code.                                                      |
-| `identifyUser`   | `"platform" \| ChannelIdentifyUser`          | Required. Maps each provider actor to an application user or `null`.                                                          |
+| `identifyUser`   | `"platform" \| ChannelIdentifyUser`            | Required. Maps each provider actor to an application user or `null`.                                                                 |
 | `showToolStatus` | `boolean`                                      | Managed Slack hides tool-call progress by default. Set `true` to show it; tool history remains available in Intelligence either way. |
 | `agent`          | `AbstractAgent \| (threadId) => AbstractAgent` | Prefer a factory; a singleton is isolated per run via `clone()`.                                                                     |
 | `tools`          | `ChannelTool[]`                                | Channel-level typed tools.                                                                                                           |

--- a/showcase/shell-docs/src/content/reference/channels/functions/defineChannelCommand.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/functions/defineChannelCommand.mdx
@@ -57,16 +57,16 @@ an `IncomingCommand`.
 
 ## CommandContext
 
-| Field       | Type                       | Notes                                                                                     |
-| ----------- | -------------------------- | ----------------------------------------------------------------------------------------- |
-| `thread`    | `Thread`                   | Conversation where the command was invoked.                                               |
-| `command`   | `string`                   | Normalized name: no leading slash, lowercase, hyphens and underscores route equivalently. |
-| `text`      | `string`                   | Raw argument text supplied by the direct adapter.                                         |
-| `options`   | `TOptions`                 | Structured options when the adapter supplies them.                                        |
+| Field       | Type                      | Notes                                                                                     |
+| ----------- | ------------------------- | ----------------------------------------------------------------------------------------- |
+| `thread`    | `Thread`                  | Conversation where the command was invoked.                                               |
+| `command`   | `string`                  | Normalized name: no leading slash, lowercase, hyphens and underscores route equivalently. |
+| `text`      | `string`                  | Raw argument text supplied by the direct adapter.                                         |
+| `options`   | `TOptions`                | Structured options when the adapter supplies them.                                        |
 | `user`      | `ApplicationUser \| null` | Application user selected by `identifyUser`.                                              |
-| `actor`     | `ProviderActor`            | Provider account that invoked the command.                                                |
-| `platform`  | `string`                   | Native provider reported by the direct adapter.                                           |
-| `openModal` | function or `undefined`    | Present only when the adapter supports modal opening.                                     |
+| `actor`     | `ProviderActor`           | Provider account that invoked the command.                                                |
+| `platform`  | `string`                  | Native provider reported by the direct adapter.                                           |
+| `openModal` | function or `undefined`   | Present only when the adapter supports modal opening.                                     |
 
 See [Commands and reactions](/slack/commands-and-reactions) for the managed
 provider boundary.

--- a/showcase/shell-docs/src/content/reference/channels/functions/defineChannelCommand.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/functions/defineChannelCommand.mdx
@@ -57,15 +57,16 @@ an `IncomingCommand`.
 
 ## CommandContext
 
-| Field       | Type                        | Notes                                                                                     |
-| ----------- | --------------------------- | ----------------------------------------------------------------------------------------- |
-| `thread`    | `Thread`                    | Conversation where the command was invoked.                                               |
-| `command`   | `string`                    | Normalized name: no leading slash, lowercase, hyphens and underscores route equivalently. |
-| `text`      | `string`                    | Raw argument text supplied by the direct adapter.                                         |
-| `options`   | `TOptions`                  | Structured options when the adapter supplies them.                                        |
-| `user`      | `PlatformUser \| undefined` | Invoking provider user.                                                                   |
-| `platform`  | `string`                    | Native provider reported by the direct adapter.                                           |
-| `openModal` | function or `undefined`     | Present only when the adapter supports modal opening.                                     |
+| Field       | Type                       | Notes                                                                                     |
+| ----------- | -------------------------- | ----------------------------------------------------------------------------------------- |
+| `thread`    | `Thread`                   | Conversation where the command was invoked.                                               |
+| `command`   | `string`                   | Normalized name: no leading slash, lowercase, hyphens and underscores route equivalently. |
+| `text`      | `string`                   | Raw argument text supplied by the direct adapter.                                         |
+| `options`   | `TOptions`                 | Structured options when the adapter supplies them.                                        |
+| `user`      | `ApplicationUser \| null` | Application user selected by `identifyUser`.                                              |
+| `actor`     | `ProviderActor`            | Provider account that invoked the command.                                                |
+| `platform`  | `string`                   | Native provider reported by the direct adapter.                                           |
+| `openModal` | function or `undefined`    | Present only when the adapter supports modal opening.                                     |
 
 See [Commands and reactions](/slack/commands-and-reactions) for the managed
 provider boundary.

--- a/showcase/shell-docs/src/content/reference/channels/functions/defineChannelTool.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/functions/defineChannelTool.mdx
@@ -50,13 +50,14 @@ before startup, or pass turn-scoped tools to `thread.runAgent({ tools })`.
 
 ## Handler context
 
-| Field      | Type                           | Managed behavior                                                                                                                                |
-| ---------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `thread`   | `Thread`                       | Current conversation handle.                                                                                                                    |
-| `message`  | `IncomingMessage \| undefined` | Reserved optional field; the current SDK tool runner leaves it undefined. Capture validated message data in the handler when the tool needs it. |
-| `user`     | `PlatformUser \| undefined`    | Reserved optional field; the current SDK tool runner leaves it undefined.                                                                       |
-| `signal`   | `AbortSignal \| undefined`     | Reserved optional field; the current SDK tool runner leaves it undefined.                                                                       |
-| `platform` | `string`                       | Native provider. Managed tools report `"slack"` or `"teams"`.                                                                                   |
+| Field | Type | Managed behavior |
+| --- | --- | --- |
+| `thread` | `Thread` | Current conversation handle. |
+| `message` | `IncomingMessage \| undefined` | Current inbound message when the run began from a message trigger. |
+| `user` | `ApplicationUser \| null` | Application user selected for this event. |
+| `actor` | `ProviderActor` | Provider account that caused this event. |
+| `signal` | `AbortSignal \| undefined` | Reserved optional field; the current SDK tool runner leaves it undefined. |
+| `platform` | `string` | Normalized source provider, such as `"slack"` or `"teams"`. |
 
 Return raw objects or arrays for data. The SDK JSON-serializes non-string
 results for the model. A tool that already posted UI should return a short

--- a/showcase/shell-docs/src/content/reference/channels/functions/defineChannelTool.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/functions/defineChannelTool.mdx
@@ -50,14 +50,14 @@ before startup, or pass turn-scoped tools to `thread.runAgent({ tools })`.
 
 ## Handler context
 
-| Field | Type | Managed behavior |
-| --- | --- | --- |
-| `thread` | `Thread` | Current conversation handle. |
-| `message` | `IncomingMessage \| undefined` | Current inbound message when the run began from a message trigger. |
-| `user` | `ApplicationUser \| null` | Application user selected for this event. |
-| `actor` | `ProviderActor` | Provider account that caused this event. |
-| `signal` | `AbortSignal \| undefined` | Reserved optional field; the current SDK tool runner leaves it undefined. |
-| `platform` | `string` | Normalized source provider, such as `"slack"` or `"teams"`. |
+| Field      | Type                           | Managed behavior                                                          |
+| ---------- | ------------------------------ | ------------------------------------------------------------------------- |
+| `thread`   | `Thread`                       | Current conversation handle.                                              |
+| `message`  | `IncomingMessage \| undefined` | Current inbound message when the run began from a message trigger.        |
+| `user`     | `ApplicationUser \| null`      | Application user selected for this event.                                 |
+| `actor`    | `ProviderActor`                | Provider account that caused this event.                                  |
+| `signal`   | `AbortSignal \| undefined`     | Reserved optional field; the current SDK tool runner leaves it undefined. |
+| `platform` | `string`                       | Normalized source provider, such as `"slack"` or `"teams"`.               |
 
 Return raw objects or arrays for data. The SDK JSON-serializes non-string
 results for the model. A tool that already posted UI should return a short

--- a/showcase/shell-docs/src/content/reference/channels/sdk/direct-adapters.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/sdk/direct-adapters.mdx
@@ -5,10 +5,10 @@ description: Public Slack, Teams, Discord, Telegram, and WhatsApp adapter entry 
 
 `@copilotkit/channels` supports two provider-connection models:
 
-| Model                | Channel declaration                        | Provider connection                                                                       | Available providers                                     |
-| -------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| Managed Intelligence | `createChannel({ name, agent })`           | CopilotKit Intelligence stores provider credentials and owns ingress and egress           | Slack and Microsoft Teams                               |
-| Direct adapter       | `createChannel({ name, adapters, agent })` | Your Channels process stores provider credentials and owns the provider socket or webhook | Slack, Microsoft Teams, Discord, Telegram, and WhatsApp |
+| Model                | Channel declaration                                      | Provider connection                                                                       | Available providers                                     |
+| -------------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| Managed Intelligence | `createChannel({ name, identifyUser, agent })`           | CopilotKit Intelligence stores provider credentials and owns ingress and egress           | Slack and Microsoft Teams                               |
+| Direct adapter       | `createChannel({ name, adapters, identifyUser, agent })` | Your Channels process stores provider credentials and owns the provider socket or webhook | Slack, Microsoft Teams, Discord, Telegram, and WhatsApp |
 
 Managed Intelligence support for Discord and WhatsApp is coming soon. Their
 direct adapters already ship in `@copilotkit/channels@0.5.0`.
@@ -48,6 +48,7 @@ function required(name: string): string {
 
 export const channel = createChannel({
   name: "support-direct",
+  identifyUser: "platform",
   adapters: [
     slack({
       botToken: required("SLACK_BOT_TOKEN"),
@@ -178,6 +179,6 @@ the adapter. Capability-result Thread methods can also return `{ ok: false }`;
 handle that result instead of assuming a provider name guarantees one
 behavior.
 
-The Slack and Teams guides in the provider picker document the production-ready
-managed path. Use this page when your deployment intentionally owns provider
+The provider guides document the managed contract and each provider's release
+status. Use this page when your deployment intentionally owns provider
 credentials, sockets, webhooks, and provider-specific operations.

--- a/showcase/shell-docs/src/content/reference/channels/types/ActionStore.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/types/ActionStore.mdx
@@ -14,6 +14,7 @@ import { durableStateStore } from "./state-store.js";
 
 const channel = createChannel({
   name: required("CHANNEL_CODE"),
+  identifyUser: "platform",
   agent: makeAgent,
   components: [ApprovalCard],
   store: { adapter: durableStateStore },
@@ -30,9 +31,13 @@ preserves the snapshot across process restarts.
 interface ActionStore {
   put(id: string, snapshot: ActionSnapshot, ttlMs?: number): Promise<void>;
   get(id: string): Promise<ActionSnapshot | undefined>;
+  consume(id: string): Promise<ActionSnapshot | undefined>;
   delete(id: string): Promise<void>;
 }
 ```
+
+`consume` must atomically return and delete one snapshot so a HITL
+continuation can start at most one resumed run.
 
 `InMemoryActionStore` never survives a process restart. Do not introduce it in
 new managed Slack or Teams runners. See [`StateStore`](/reference/channels/types/StateStore)

--- a/showcase/shell-docs/src/content/reference/channels/types/IncomingMessage.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/types/IncomingMessage.mdx
@@ -22,26 +22,24 @@ interface IncomingMessage {
 }
 ```
 
-| Field | Managed Slack and Teams behavior |
-| --- | --- |
-| `text` | Provider text after ingress normalization. |
-| `user` | Nullable application user returned by the Channel's `identifyUser` policy. |
-| `actor` | Provider account that caused the event. It includes a required actor kind. |
-| `ref` | In ordinary message handlers this may have an empty id; do not assume every inbound turn can be edited. |
-| `platform` | Native source: `"slack"` or `"teams"` for message deliveries. |
-| `contentParts` | Hydrated file/media parts when attachments were retrieved. |
-| `eventId` | Stable provider-event id for application idempotency. |
-| `turnId` | Managed turn correlation id. |
-| `deliveryId` | Managed lease/delivery correlation id. |
+| Field          | Managed Slack and Teams behavior                                                                        |
+| -------------- | ------------------------------------------------------------------------------------------------------- |
+| `text`         | Provider text after ingress normalization.                                                              |
+| `user`         | Nullable application user returned by the Channel's `identifyUser` policy.                              |
+| `actor`        | Provider account that caused the event. It includes a required actor kind.                              |
+| `ref`          | In ordinary message handlers this may have an empty id; do not assume every inbound turn can be edited. |
+| `platform`     | Native source: `"slack"` or `"teams"` for message deliveries.                                           |
+| `contentParts` | Hydrated file/media parts when attachments were retrieved.                                              |
+| `eventId`      | Stable provider-event id for application idempotency.                                                   |
+| `turnId`       | Managed turn correlation id.                                                                            |
+| `deliveryId`   | Managed lease/delivery correlation id.                                                                  |
 
 ## Multimodal prompt
 
 ```ts
 const prompt = message.contentParts?.length
   ? [
-      ...(message.text
-        ? [{ type: "text" as const, text: message.text }]
-        : []),
+      ...(message.text ? [{ type: "text" as const, text: message.text }] : []),
       ...message.contentParts,
     ]
   : message.text;

--- a/showcase/shell-docs/src/content/reference/channels/types/IncomingMessage.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/types/IncomingMessage.mdx
@@ -11,11 +11,11 @@ description: The normalized provider message passed to Channels handlers, includ
 ```ts
 interface IncomingMessage {
   text: string;
-  user: PlatformUser;
+  user: ApplicationUser | null;
+  actor: ProviderActor;
   ref: MessageRef;
   platform: string;
   contentParts?: AgentContentPart[];
-  userKey?: string;
   eventId?: string;
   turnId?: string;
   deliveryId?: string;
@@ -25,11 +25,11 @@ interface IncomingMessage {
 | Field | Managed Slack and Teams behavior |
 | --- | --- |
 | `text` | Provider text after ingress normalization. |
-| `user` | Provider user id and available display fields. Treat it as an external identity. |
+| `user` | Nullable application user returned by the Channel's `identifyUser` policy. |
+| `actor` | Provider account that caused the event. It includes a required actor kind. |
 | `ref` | In ordinary message handlers this may have an empty id; do not assume every inbound turn can be edited. |
 | `platform` | Native source: `"slack"` or `"teams"` for message deliveries. |
 | `contentParts` | Hydrated file/media parts when attachments were retrieved. |
-| `userKey` | Stable value returned by `store.identity`, when configured. |
 | `eventId` | Stable provider-event id for application idempotency. |
 | `turnId` | Managed turn correlation id. |
 | `deliveryId` | Managed lease/delivery correlation id. |

--- a/showcase/shell-docs/src/content/reference/channels/types/InteractionContext.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/types/InteractionContext.mdx
@@ -30,7 +30,7 @@ interface InteractionContext<TValue = unknown> {
 | `action.id`    | Opaque SDK action id.                                                                                  |
 | `action.value` | Round-tripped `Button.value`, selected value, or submitted text. Guard `undefined`.                    |
 | `values`       | Other submitted form values. Teams `Action.Submit` callbacks include named Adaptive Card input values. |
-| `user`         | Nullable application user selected by `identifyUser`.                                                   |
+| `user`         | Nullable application user selected by `identifyUser`.                                                  |
 | `actor`        | Provider account that caused the interaction.                                                          |
 | `platform`     | Native provider; managed callbacks report `"slack"` or `"teams"`.                                      |
 | `openModal`    | Capability-gated and omitted on the managed Slack and Teams path.                                      |

--- a/showcase/shell-docs/src/content/reference/channels/types/InteractionContext.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/types/InteractionContext.mdx
@@ -16,7 +16,8 @@ interface InteractionContext<TValue = unknown> {
     value?: TValue;
   };
   values: Record<string, unknown>;
-  user: PlatformUser;
+  user: ApplicationUser | null;
+  actor: ProviderActor;
   platform: string;
   openModal?(view: ModalView): Promise<{ ok: boolean; error?: string }>;
 }
@@ -29,7 +30,8 @@ interface InteractionContext<TValue = unknown> {
 | `action.id`    | Opaque SDK action id.                                                                                  |
 | `action.value` | Round-tripped `Button.value`, selected value, or submitted text. Guard `undefined`.                    |
 | `values`       | Other submitted form values. Teams `Action.Submit` callbacks include named Adaptive Card input values. |
-| `user`         | Provider user who interacted.                                                                          |
+| `user`         | Nullable application user selected by `identifyUser`.                                                   |
+| `actor`        | Provider account that caused the interaction.                                                          |
 | `platform`     | Native provider; managed callbacks report `"slack"` or `"teams"`.                                      |
 | `openModal`    | Capability-gated and omitted on the managed Slack and Teams path.                                      |
 

--- a/showcase/shell-docs/src/content/reference/channels/types/JSXCallbacks.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/types/JSXCallbacks.mdx
@@ -64,8 +64,9 @@ or omit a component when the native provider has no equivalent.
 | `action.id`    | `string`                  | Opaque action identifier.                                                                                             |
 | `action.value` | `TValue \| undefined`     | The control's round-tripped value. Guard it before use even when the component declares `value`.                      |
 | `values`       | `Record<string, unknown>` | Submitted form values.                                                                                                |
-| `user`         | `PlatformUser`            | Person who interacted.                                                                                                |
-| `platform`     | `string`                  | Native provider. Managed interactions report `"slack"` or `"teams"`.                                                  |
+| `user`         | `ApplicationUser \| null` | Application user selected by `identifyUser`.                                                                          |
+| `actor`        | `ProviderActor`            | Provider account that caused the interaction.                                                                         |
+| `platform`     | `string`                  | Normalized source provider, such as `"slack"` or `"teams"`.                                                          |
 | `openModal`    | function or `undefined`   | Capability-gated modal opener. Not part of the managed Slack/Teams realtime path.                                     |
 
 ```tsx title="decision.tsx"
@@ -131,6 +132,7 @@ function required(name: string): string {
 
 const channel = createChannel({
   name: required("CHANNEL_CODE"),
+  identifyUser: "platform",
   agent: makeAgent,
   components: [Decision],
   store: { adapter: durableStateStore },

--- a/showcase/shell-docs/src/content/reference/channels/types/JSXCallbacks.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/types/JSXCallbacks.mdx
@@ -65,8 +65,8 @@ or omit a component when the native provider has no equivalent.
 | `action.value` | `TValue \| undefined`     | The control's round-tripped value. Guard it before use even when the component declares `value`.                      |
 | `values`       | `Record<string, unknown>` | Submitted form values.                                                                                                |
 | `user`         | `ApplicationUser \| null` | Application user selected by `identifyUser`.                                                                          |
-| `actor`        | `ProviderActor`            | Provider account that caused the interaction.                                                                         |
-| `platform`     | `string`                  | Normalized source provider, such as `"slack"` or `"teams"`.                                                          |
+| `actor`        | `ProviderActor`           | Provider account that caused the interaction.                                                                         |
+| `platform`     | `string`                  | Normalized source provider, such as `"slack"` or `"teams"`.                                                           |
 | `openModal`    | function or `undefined`   | Capability-gated modal opener. Not part of the managed Slack/Teams realtime path.                                     |
 
 ```tsx title="decision.tsx"

--- a/showcase/shell-docs/src/content/reference/channels/types/StateStore.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/types/StateStore.mdx
@@ -13,6 +13,7 @@ interface StateStore {
   kv: {
     get<T>(key: string): Promise<T | undefined>;
     set<T>(key: string, value: T, ttlMs?: number): Promise<void>;
+    consume<T>(key: string): Promise<T | undefined>;
     delete(key: string): Promise<void>;
   };
   list: {
@@ -53,6 +54,8 @@ interface StateStore {
 ## Semantics
 
 - `list.range` is oldest-first and uses non-negative, inclusive indices.
+- `kv.consume` atomically returns and deletes one value. Concurrent callers
+  must observe at most one non-`undefined` result.
 - `list.append({ ttlMs })` sets the expiry for the whole list. An append without
   `ttlMs` preserves an existing expiry.
 - `lock.acquire` returns `null` while another token holds an unexpired lock.
@@ -72,7 +75,7 @@ import { runStateStoreConformance } from "@copilotkit/channels/testing";
 runStateStoreConformance("postgres", () => createPostgresStateStore());
 ```
 
-Locks, deduplication, and queues must be atomic across processes. Use
+KV consumption, locks, deduplication, and queues must be atomic across processes. Use
 project/Channel namespacing to prevent key collisions.
 
 Pass the adapter through `createChannel({ store: { adapter } })`. See

--- a/showcase/shell-docs/src/content/reference/channels/types/StoreConfig.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/types/StoreConfig.mdx
@@ -1,6 +1,6 @@
 ---
 title: StoreConfig
-description: Configure per-thread state, the StateStore backend, transcript identity, and turn concurrency controls.
+description: Configure per-thread state, the StateStore backend, transcripts, and turn concurrency controls.
 ---
 
 `StoreConfig` is the `createChannel({ store })` value.
@@ -9,8 +9,8 @@ description: Configure per-thread state, the StateStore backend, transcript iden
 interface StoreConfig<TStateSchema> {
   adapter?: StateStore;
   state?: TStateSchema;
-  identity?: Identity;
   transcripts?: TranscriptsConfig;
+  actionRetentionMs?: number;
   concurrency?: "parallel" | "serial" | "drop";
   /** @deprecated Prefer `concurrency`. */
   onLockConflict?:
@@ -25,13 +25,13 @@ interface StoreConfig<TStateSchema> {
 }
 ```
 
-| Option           | Default                   | Behavior                                                                                                                                           |
-| ---------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `adapter`        | `MemoryStore`             | Persistence backend for SDK state.                                                                                                                 |
-| `state`          | none                      | Standard Schema that types and validates `thread.state()` and `setState()`.                                                                        |
-| `identity`       | none                      | Resolves an inbound provider user to a stable transcript key. Must be paired with `transcripts`.                                                   |
-| `transcripts`    | none                      | Optional retention and per-user cap. Must be paired with `identity`.                                                                               |
-| `concurrency`    | `"parallel"`              | How overlapping turns on the same conversation are handled (see below).                                                                            |
+| Option | Default | Behavior |
+| --- | --- | --- |
+| `adapter` | `MemoryStore` | Persistence backend for SDK state. |
+| `state` | none | Standard Schema that types and validates `thread.state()` and `setState()`. |
+| `transcripts` | none | Optional retention and per-user cap, keyed by the application user from top-level `identifyUser`. |
+| `actionRetentionMs` | `604_800_000` | Retention for durable callbacks and one-use HITL continuations. |
+| `concurrency` | `"parallel"` | How overlapping turns on the same conversation are handled (see below). |
 | `onLockConflict` | (maps into `concurrency`) | **Deprecated.** Prefer `concurrency`. Static `"drop"` / `"force"` map to `"drop"` / `"parallel"`. A callback keeps the legacy exclusive-lock path. |
 | `lockTtl`        | `60_000`                  | Per-conversation turn-lock TTL in milliseconds (used by `drop` / legacy lock paths).                                                               |
 | `dedupTtl`       | `300_000`                 | Inbound event deduplication window in milliseconds.                                                                                                |
@@ -61,6 +61,7 @@ const stateSchema = z.object({
 
 const channel = createChannel({
   name: "support-slack",
+  identifyUser: "platform",
   agent: makeAgent,
   store: {
     adapter: durableStateStore,

--- a/showcase/shell-docs/src/content/reference/channels/types/StoreConfig.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/types/StoreConfig.mdx
@@ -25,16 +25,16 @@ interface StoreConfig<TStateSchema> {
 }
 ```
 
-| Option | Default | Behavior |
-| --- | --- | --- |
-| `adapter` | `MemoryStore` | Persistence backend for SDK state. |
-| `state` | none | Standard Schema that types and validates `thread.state()` and `setState()`. |
-| `transcripts` | none | Optional retention and per-user cap, keyed by the application user from top-level `identifyUser`. |
-| `actionRetentionMs` | `604_800_000` | Retention for durable callbacks and one-use HITL continuations. |
-| `concurrency` | `"parallel"` | How overlapping turns on the same conversation are handled (see below). |
-| `onLockConflict` | (maps into `concurrency`) | **Deprecated.** Prefer `concurrency`. Static `"drop"` / `"force"` map to `"drop"` / `"parallel"`. A callback keeps the legacy exclusive-lock path. |
-| `lockTtl`        | `60_000`                  | Per-conversation turn-lock TTL in milliseconds (used by `drop` / legacy lock paths).                                                               |
-| `dedupTtl`       | `300_000`                 | Inbound event deduplication window in milliseconds.                                                                                                |
+| Option              | Default                   | Behavior                                                                                                                                           |
+| ------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `adapter`           | `MemoryStore`             | Persistence backend for SDK state.                                                                                                                 |
+| `state`             | none                      | Standard Schema that types and validates `thread.state()` and `setState()`.                                                                        |
+| `transcripts`       | none                      | Optional retention and per-user cap, keyed by the application user from top-level `identifyUser`.                                                  |
+| `actionRetentionMs` | `604_800_000`             | Retention for durable callbacks and one-use HITL continuations.                                                                                    |
+| `concurrency`       | `"parallel"`              | How overlapping turns on the same conversation are handled (see below).                                                                            |
+| `onLockConflict`    | (maps into `concurrency`) | **Deprecated.** Prefer `concurrency`. Static `"drop"` / `"force"` map to `"drop"` / `"parallel"`. A callback keeps the legacy exclusive-lock path. |
+| `lockTtl`           | `60_000`                  | Per-conversation turn-lock TTL in milliseconds (used by `drop` / legacy lock paths).                                                               |
+| `dedupTtl`          | `300_000`                 | Inbound event deduplication window in milliseconds.                                                                                                |
 
 ### Turn concurrency
 

--- a/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
@@ -563,7 +563,7 @@ describe("Channels documentation journey", () => {
     expect(history).toContain("`thread.getMessages()`");
     expect(history).toContain("`runAgent({ transcript: ... })`");
     expect(history).toMatch(
-      /Managed entries use the native `"slack"` or `"teams"` platform/i,
+      /managed entries use the native `"slack"` or `"teams"` provider/i,
     );
     expect(history).not.toContain('platforms: ["slack", "teams"]');
 


### PR DESCRIPTION
## Summary

- Require `identifyUser` at Channel creation and separate application users from provider actors.
- Add user/project Memory grants for Channels and the web runtime, including project-only Channel access.
- Bind HITL continuations to immutable identity snapshots and consume each continuation once.
- Update first-party adapters, examples, public docs, and cross-surface tests.

## Why

Channel threads are provider conversations, not personal owners. Each turn must resolve identity and Memory access explicitly so a shared channel cannot inherit the wrong person.

## Impact

This is a hard API cut. It removes `PlatformUser`, `userKey`, and `store.identity`; makes Channel `user` nullable; adds `actor`; and uses one Memory policy for agent and browser access.

Intelligence counterpart: https://github.com/CopilotKit/Intelligence/pull/706

## Validation

- `pnpm nx run-many -t test,build,check-types --projects @copilotkit/channels-core,@copilotkit/channels-intelligence,@copilotkit/channels-slack,@copilotkit/channels-teams,@copilotkit/channels-discord,@copilotkit/channels-telegram,@copilotkit/channels-whatsapp,@copilotkit/channels-ui,@copilotkit/channels,@copilotkit/core,@copilotkit/runtime --outputStyle=static`
- `pnpm lint`
- `npx vitest run && npm run typecheck && npm run build` in `showcase/shell-docs`
- Pre-commit test, publint, and attw checks for 22 public projects.