### PR TITLE
fix(runtime): populate request headers in runtime error context

### DIFF
--- a/.changeset/populate-runtime-error-request-headers.md
+++ b/.changeset/populate-runtime-error-request-headers.md
@@ -1,5 +1,0 @@
----
-"@copilotkit/runtime": patch
----
-
-fix(runtime): populate request headers in runtime error context

--- a/.changeset/populate-runtime-error-request-headers.md
+++ b/.changeset/populate-runtime-error-request-headers.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+fix(runtime): populate request headers in runtime error context

--- a/packages/runtime/src/lib/runtime/__tests__/copilot-runtime-error.test.ts
+++ b/packages/runtime/src/lib/runtime/__tests__/copilot-runtime-error.test.ts
@@ -243,9 +243,10 @@ describe("CopilotRuntime onError types", () => {
   it("preserves the response when the rejecting runtime error handler runs", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
+      const onError = vi.fn().mockRejectedValue(new Error("callback failed"));
       const runtime = new CopilotRuntime({
         agents: Promise.reject(new Error("agent lookup failed")),
-        onError: vi.fn().mockRejectedValue(new Error("callback failed")),
+        onError,
       });
       const handler = createCopilotRuntimeHandler({
         runtime: runtime.instance,
@@ -263,6 +264,13 @@ describe("CopilotRuntime onError types", () => {
         error: "Failed to run agent",
         message: "agent lookup failed",
       });
+      expect(onError).toHaveBeenCalledOnce();
+      await vi.waitFor(() =>
+        expect(errorSpy).toHaveBeenCalledWith(
+          "CopilotRuntime onError reporting failed:",
+          expect.any(Error),
+        ),
+      );
     } finally {
       errorSpy.mockRestore();
     }

--- a/packages/runtime/src/lib/runtime/__tests__/copilot-runtime-error.test.ts
+++ b/packages/runtime/src/lib/runtime/__tests__/copilot-runtime-error.test.ts
@@ -1,8 +1,13 @@
-import {
+import type {
   CopilotErrorEvent,
   CopilotRequestContext,
   CopilotErrorHandler,
 } from "@copilotkit/shared";
+import { Observable } from "rxjs";
+import { HttpAgent } from "@ag-ui/client";
+import type { BaseEvent } from "@ag-ui/client";
+import { createCopilotRuntimeHandler } from "../../../v2/runtime";
+import { CopilotRuntime } from "../copilot-runtime";
 
 describe("CopilotRuntime onError types", () => {
   it("should have correct CopilotTraceEvent type structure", () => {
@@ -179,5 +184,110 @@ describe("CopilotRuntime onError types", () => {
       expect(shouldHandleError(onError, cloudKey)).toBe(true);
       expect(shouldHandleError(onError, nonCloudKey)).toBe(true);
     });
+  });
+
+  it("forwards request headers from a failing local runtime", async () => {
+    const onError = vi.fn();
+    const runner = {
+      run: () =>
+        new Observable<BaseEvent>((subscriber) => {
+          subscriber.error(new Error("local runner failed"));
+        }),
+      connect: () => new Observable<BaseEvent>(() => {}),
+      isRunning: async () => false,
+      stop: async () => false,
+    };
+    const runtime = new CopilotRuntime({
+      agents: { default: new HttpAgent({ url: "https://agent.example" }) },
+      onError,
+      runner,
+    });
+    const handler = createCopilotRuntimeHandler({ runtime: runtime.instance });
+
+    const response = await handler(
+      new Request("https://example.com/agent/default/run", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-User-Id": "issue-2716-user",
+        },
+        body: JSON.stringify({
+          threadId: "thread-1",
+          runId: "run-1",
+          state: {},
+          messages: [],
+          tools: [],
+          context: [],
+          forwardedProps: {},
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await response.text();
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledOnce());
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+        context: expect.objectContaining({
+          request: expect.objectContaining({
+            headers: expect.objectContaining({
+              "x-user-id": "issue-2716-user",
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("preserves the response when the rejecting runtime error handler runs", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const runtime = new CopilotRuntime({
+        agents: Promise.reject(new Error("agent lookup failed")),
+        onError: vi.fn().mockRejectedValue(new Error("callback failed")),
+      });
+      const handler = createCopilotRuntimeHandler({
+        runtime: runtime.instance,
+      });
+      const response = await handler(
+        new Request("https://example.com/agent/default/run", {
+          method: "POST",
+          headers: { "X-User-Id": "issue-2716-user" },
+          body: JSON.stringify({}),
+        }),
+      );
+
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({
+        error: "Failed to run agent",
+        message: "agent lookup failed",
+      });
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("reports a pre-response agent failure without changing the response", async () => {
+    const onError = vi.fn();
+    const runtime = new CopilotRuntime({
+      agents: Promise.reject(new Error("pre-response failure")),
+      onError,
+    });
+    const handler = createCopilotRuntimeHandler({ runtime: runtime.instance });
+
+    const response = await handler(
+      new Request("https://example.com/agent/default/run", {
+        method: "POST",
+        body: JSON.stringify({}),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to run agent",
+      message: "pre-response failure",
+    });
+    expect(onError).toHaveBeenCalledOnce();
   });
 });

--- a/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -37,6 +37,11 @@ import {
   CopilotRuntime as CopilotRuntimeVNext,
   InMemoryAgentRunner,
 } from "../../v2/runtime";
+import {
+  createRuntimeErrorReporter,
+  runtimeErrorReporterOption,
+} from "../../v2/runtime/core/runtime-error-reporter";
+import type { RuntimeErrorReporterOptions } from "../../v2/runtime/core/runtime-error-reporter";
 import type {
   CopilotRuntimeOptions,
   CopilotRuntimeOptions as CopilotRuntimeOptionsVNext,
@@ -343,7 +348,7 @@ export class CopilotRuntime<const T extends Parameter[] | [] = []> {
   // Cache MCP tools per endpoint to avoid re-fetching repeatedly
   private mcpToolsCache: Map<string, BuiltInAgentClassicConfig["tools"]> =
     new Map();
-  private runtimeArgs: CopilotRuntimeOptions;
+  private runtimeArgs: CopilotRuntimeOptions & RuntimeErrorReporterOptions;
   private _instance: CopilotRuntimeVNext;
 
   constructor(
@@ -414,6 +419,7 @@ export class CopilotRuntime<const T extends Parameter[] | [] = []> {
       a2ui: params?.a2ui,
       mcpApps: params?.mcpApps,
       openGenerativeUI: params?.openGenerativeUI,
+      [runtimeErrorReporterOption]: createRuntimeErrorReporter(params?.onError),
     };
     this.params = params;
     this.observability = params?.observability_c;

--- a/packages/runtime/src/v2/runtime/__tests__/intelligence-run-telemetry.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/intelligence-run-telemetry.test.ts
@@ -242,4 +242,149 @@ describe("intelligence/run.ts — telemetry lifecycle", () => {
       }),
     );
   });
+
+  it("reports a pre-start RUN_ERROR event as an intelligence startup failure", async () => {
+    const onError = vi.fn();
+    const failing = new Observable<BaseEvent>((subscriber) => {
+      subscriber.next({
+        type: "RUN_ERROR",
+        message: "startup event failed",
+      } as BaseEvent);
+      subscriber.complete();
+    });
+    const cleanupThreadLock = vi.fn().mockResolvedValue(undefined);
+    const runtime = makeIntelligenceRuntime(
+      failing,
+      { ɵcleanupThreadLock: cleanupThreadLock },
+      onError,
+    );
+
+    const response = await handleRunAgent({
+      runtime,
+      request: makeRunRequest(),
+      agentId: "my-agent",
+    });
+
+    expect(response.status).toBe(502);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][0]).toMatchObject({
+      error: new Error("startup event failed"),
+      context: { metadata: { phase: "intelligence.startup" } },
+    });
+    expect(cleanupThreadLock).toHaveBeenCalledWith({
+      threadId: "thread-1",
+      runId: "run-1",
+    });
+  });
+
+  it("reports a post-start RUN_ERROR event as an intelligence subscription failure", async () => {
+    const onError = vi.fn();
+    const failing = new Observable<BaseEvent>((subscriber) => {
+      subscriber.next({
+        type: "RUN_STARTED",
+        threadId: "thread-1",
+        runId: "run-1",
+      } as BaseEvent);
+      subscriber.next({
+        type: "RUN_ERROR",
+        message: "subscription event failed",
+      } as BaseEvent);
+      subscriber.complete();
+    });
+    const runtime = makeIntelligenceRuntime(failing, {}, onError);
+
+    await handleRunAgent({
+      runtime,
+      request: makeRunRequest(),
+      agentId: "my-agent",
+    });
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][0]).toMatchObject({
+      error: new Error("subscription event failed"),
+      context: { metadata: { phase: "intelligence.subscription" } },
+    });
+  });
+
+  it.each([
+    [
+      "intelligence is not configured",
+      (runtime: any) => (runtime.intelligence = undefined),
+    ],
+    [
+      "user resolution fails",
+      (runtime: any) => {
+        runtime.identifyUser = vi
+          .fn()
+          .mockRejectedValue(new Error("auth failed"));
+      },
+    ],
+    [
+      "user id is invalid",
+      (runtime: any) => {
+        runtime.identifyUser = vi.fn().mockResolvedValue({
+          id: "",
+          name: "User One",
+        });
+      },
+    ],
+    [
+      "user name is invalid",
+      (runtime: any) => {
+        runtime.identifyUser = vi.fn().mockResolvedValue({
+          id: "user-1",
+          name: "",
+        });
+      },
+    ],
+    [
+      "thread creation fails",
+      (runtime: any) => {
+        runtime.intelligence.getOrCreateThread = vi
+          .fn()
+          .mockRejectedValue(new Error("thread failed"));
+      },
+    ],
+    [
+      "thread lock fails",
+      (runtime: any) => {
+        runtime.intelligence.ɵacquireThreadLock = vi
+          .fn()
+          .mockRejectedValue(new Error("lock failed"));
+      },
+    ],
+    [
+      "thread lock response is malformed",
+      (runtime: any) => {
+        runtime.intelligence.ɵacquireThreadLock = vi.fn().mockResolvedValue({});
+      },
+    ],
+    [
+      "thread history lookup fails",
+      (runtime: any) => {
+        runtime.intelligence.getThreadMessages = vi
+          .fn()
+          .mockRejectedValue(new Error("history failed"));
+      },
+    ],
+  ])(
+    "does not report %s before the runner starts",
+    async (_name, configure) => {
+      const onError = vi.fn();
+      const runtime = makeIntelligenceRuntime(
+        new Observable<BaseEvent>(() => {}),
+        {},
+        onError,
+      );
+      configure(runtime);
+
+      await handleRunAgent({
+        runtime,
+        request: makeRunRequest(),
+        agentId: "my-agent",
+      });
+
+      expect(onError).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/packages/runtime/src/v2/runtime/__tests__/intelligence-run-telemetry.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/intelligence-run-telemetry.test.ts
@@ -20,6 +20,10 @@ import { IntelligenceAgentRunner } from "../runner/intelligence";
 import { telemetry } from "../telemetry";
 import { resolveForwardHeadersPolicy } from "../handlers/header-utils";
 import type { CopilotRuntime } from "../core/runtime";
+import {
+  attachRuntimeErrorReporter,
+  createRuntimeErrorReporter,
+} from "../core/runtime-error-reporter";
 
 // --- Minimal helpers (mirroring handle-run.test.ts's intelligence block) ---
 
@@ -51,6 +55,7 @@ function makeAgent(): AbstractAgent {
 function makeIntelligenceRuntime(
   runObservable: Observable<BaseEvent>,
   extraPlatform: MockIntelligencePlatform = {},
+  onError?: ReturnType<typeof vi.fn>,
 ): CopilotRuntime {
   const runner = Object.create(IntelligenceAgentRunner.prototype);
   runner.run = vi.fn(() => runObservable);
@@ -72,7 +77,7 @@ function makeIntelligenceRuntime(
     ...extraPlatform,
   };
 
-  return {
+  const runtime = {
     agents: Promise.resolve({ "my-agent": makeAgent() }),
     transcriptionService: undefined,
     beforeRequestMiddleware: undefined,
@@ -86,6 +91,10 @@ function makeIntelligenceRuntime(
     lockTtlSeconds: 20,
     lockHeartbeatIntervalSeconds: 15,
   } as unknown as CopilotRuntime;
+  if (onError) {
+    attachRuntimeErrorReporter(runtime, createRuntimeErrorReporter(onError));
+  }
+  return runtime;
 }
 
 function makeRunRequest(): Request {
@@ -176,7 +185,8 @@ describe("intelligence/run.ts — telemetry lifecycle", () => {
     const failing = new Observable<BaseEvent>((subscriber) => {
       subscriber.error(new Error("agent exploded"));
     });
-    const runtime = makeIntelligenceRuntime(failing);
+    const onError = vi.fn();
+    const runtime = makeIntelligenceRuntime(failing, {}, onError);
 
     await handleRunAgent({
       runtime,
@@ -191,6 +201,45 @@ describe("intelligence/run.ts — telemetry lifecycle", () => {
     expect(captureSpy).toHaveBeenCalledWith(
       "oss.runtime.agent_execution_stream_errored",
       expect.objectContaining({ error: "agent exploded" }),
+    );
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][0].context.request.headers).toEqual({
+      "content-type": "application/json",
+    });
+  });
+
+  it("reports a post-start subscription failure once and keeps lock cleanup", async () => {
+    const failing = new Observable<BaseEvent>((subscriber) => {
+      subscriber.next({
+        type: "RUN_STARTED",
+        threadId: "thread-1",
+        runId: "run-1",
+      } as BaseEvent);
+      subscriber.error(new Error("subscription exploded"));
+    });
+    const onError = vi.fn();
+    const cleanupThreadLock = vi.fn().mockResolvedValue(undefined);
+    const runtime = makeIntelligenceRuntime(
+      failing,
+      { ɵcleanupThreadLock: cleanupThreadLock },
+      onError,
+    );
+
+    await handleRunAgent({
+      runtime,
+      request: makeRunRequest(),
+      agentId: "my-agent",
+    });
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][0].context.metadata).toEqual({
+      phase: "intelligence.subscription",
+    });
+    await vi.waitFor(() =>
+      expect(cleanupThreadLock).toHaveBeenCalledWith({
+        threadId: "thread-1",
+        runId: "run-1",
+      }),
     );
   });
 });

--- a/packages/runtime/src/v2/runtime/__tests__/runtime-error-reporter.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/runtime-error-reporter.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CopilotErrorEvent } from "@copilotkit/shared";
+
+import {
+  attachRuntimeErrorReporter,
+  createRuntimeErrorReporter,
+  getRuntimeErrorReporter,
+} from "../core/runtime-error-reporter";
+
+function makeRequest(headers?: Record<string, string>): Request {
+  return new Request("https://example.com/agent/default/run", {
+    method: "POST",
+    headers,
+  });
+}
+
+describe("runtime error reporter", () => {
+  it("builds an isolated event with a request header snapshot", () => {
+    const handler = vi.fn<(event: CopilotErrorEvent) => void>();
+    const reporter = createRuntimeErrorReporter(handler);
+    const request = makeRequest({ "X-User-Id": "user-1" });
+
+    reporter.report({
+      request,
+      error: new Error("agent failed"),
+      operation: "agent.run",
+      agentId: "default",
+      phase: "common",
+    });
+
+    expect(handler).toHaveBeenCalledOnce();
+    const event = handler.mock.calls[0][0];
+    expect(event).toMatchObject({
+      type: "error",
+      error: expect.any(Error),
+      context: {
+        source: "runtime",
+        agent: { name: "default" },
+        request: {
+          operation: "agent.run",
+          headers: { "x-user-id": "user-1" },
+        },
+      },
+    });
+
+    event.context.request!.headers!["x-user-id"] = "changed";
+    reporter.report({
+      request,
+      error: new Error("agent failed again"),
+      operation: "agent.run",
+      agentId: "default",
+      phase: "sse.subscription",
+    });
+
+    expect(handler.mock.calls[1][0].context.request!.headers).toEqual({
+      "x-user-id": "user-1",
+    });
+    expect(request.headers.get("x-user-id")).toBe("user-1");
+  });
+
+  it("does nothing without a handler and contains handler rejection", async () => {
+    const absent = createRuntimeErrorReporter();
+    absent.report({
+      request: makeRequest(),
+      error: new Error("ignored"),
+      operation: "agent.run",
+    });
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const rejecting = createRuntimeErrorReporter(
+        vi.fn().mockRejectedValue(new Error("callback failed")),
+      );
+      rejecting.report({
+        request: makeRequest(),
+        error: new Error("agent failed"),
+        operation: "agent.run",
+      });
+      await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledOnce());
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("keeps reporter state isolated per runtime instance", () => {
+    const first = {};
+    const second = {};
+    const firstReporter = createRuntimeErrorReporter(vi.fn());
+    const secondReporter = createRuntimeErrorReporter(vi.fn());
+
+    attachRuntimeErrorReporter(first, firstReporter);
+    attachRuntimeErrorReporter(second, secondReporter);
+
+    expect(getRuntimeErrorReporter(first as never)).toBe(firstReporter);
+    expect(getRuntimeErrorReporter(second as never)).toBe(secondReporter);
+  });
+});

--- a/packages/runtime/src/v2/runtime/__tests__/runtime-error-reporter.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/runtime-error-reporter.test.ts
@@ -82,6 +82,30 @@ describe("runtime error reporter", () => {
     }
   });
 
+  it("contains malformed request event construction", () => {
+    const handler = vi.fn();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      createRuntimeErrorReporter(handler).report({
+        request: {
+          method: "POST",
+          url: "not-a-url",
+          headers: { entries: () => [] },
+        } as unknown as Request,
+        error: new Error("agent failed"),
+        operation: "agent.run",
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith(
+        "CopilotRuntime onError reporting failed:",
+        expect.any(TypeError),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it("keeps reporter state isolated per runtime instance", () => {
     const first = {};
     const second = {};

--- a/packages/runtime/src/v2/runtime/__tests__/runtime-error-reporter.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/runtime-error-reporter.test.ts
@@ -15,10 +15,17 @@ function makeRequest(headers?: Record<string, string>): Request {
 }
 
 describe("runtime error reporter", () => {
-  it("builds an isolated event with a request header snapshot", () => {
+  it("builds an isolated event with a sanitized request header snapshot", () => {
     const handler = vi.fn<(event: CopilotErrorEvent) => void>();
     const reporter = createRuntimeErrorReporter(handler);
-    const request = makeRequest({ "X-User-Id": "user-1" });
+    const request = makeRequest({
+      "X-User-Id": "user-1",
+      "X-Request-Id": "req-123",
+      Authorization: "Bearer secret-token",
+      Cookie: "session=abc",
+      "X-Api-Key": "api-secret",
+      "X-Copilotcloud-Public-Api-Key": "cloud-key",
+    });
 
     reporter.report({
       request,
@@ -38,12 +45,27 @@ describe("runtime error reporter", () => {
         agent: { name: "default" },
         request: {
           operation: "agent.run",
-          headers: { "x-user-id": "user-1" },
+          headers: {
+            "x-user-id": "user-1",
+            "x-request-id": "req-123",
+          },
         },
       },
     });
 
-    event.context.request!.headers!["x-user-id"] = "changed";
+    const headers = event.context.request!.headers!;
+    expect(headers).not.toHaveProperty("authorization");
+    expect(headers).not.toHaveProperty("proxy-authorization");
+    expect(headers).not.toHaveProperty("cookie");
+    expect(headers).not.toHaveProperty("x-api-key");
+    expect(headers).not.toHaveProperty("api-key");
+    expect(headers).not.toHaveProperty("x-copilotcloud-public-api-key");
+    expect(request.headers.get("authorization")).toBe("Bearer secret-token");
+    expect(request.headers.get("x-copilotcloud-public-api-key")).toBe(
+      "cloud-key",
+    );
+
+    headers["x-user-id"] = "changed";
     reporter.report({
       request,
       error: new Error("agent failed again"),
@@ -54,6 +76,7 @@ describe("runtime error reporter", () => {
 
     expect(handler.mock.calls[1][0].context.request!.headers).toEqual({
       "x-user-id": "user-1",
+      "x-request-id": "req-123",
     });
     expect(request.headers.get("x-user-id")).toBe("user-1");
   });

--- a/packages/runtime/src/v2/runtime/__tests__/sse-response-telemetry.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/sse-response-telemetry.test.ts
@@ -149,6 +149,29 @@ describe("sse-response.ts — telemetry lifecycle", () => {
     );
   });
 
+  it("reports a RUN_ERROR event as an SSE subscription failure", async () => {
+    const onError = vi.fn();
+    const failing = new Observable<BaseEvent>((subscriber) => {
+      subscriber.next({
+        type: "RUN_ERROR",
+        message: "run event failed",
+      } as BaseEvent);
+      subscriber.complete();
+    });
+    const response = createSseEventResponse({
+      request: makeRequest(),
+      observableFactory: () => failing,
+      runtimeErrorReporter: createRuntimeErrorReporter(onError),
+    });
+
+    expect(response.status).toBe(200);
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledOnce());
+    expect(onError.mock.calls[0][0]).toMatchObject({
+      error: new Error("run event failed"),
+      context: { metadata: { phase: "sse.subscription" } },
+    });
+  });
+
   it("does not report successful completion or request abort", async () => {
     const onError = vi.fn();
     const completed = new Observable<BaseEvent>((subscriber) => {

--- a/packages/runtime/src/v2/runtime/__tests__/sse-response-telemetry.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/sse-response-telemetry.test.ts
@@ -10,15 +10,20 @@
  * intelligence/run path of the same event names — kept separate so a
  * regression in one source file fails only its own test.
  */
-import { BaseEvent } from "@ag-ui/client";
+import type { BaseEvent } from "@ag-ui/client";
 import { Observable } from "rxjs";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { createSseEventResponse } from "../handlers/shared/sse-response";
 import { telemetry } from "../telemetry";
+import { createRuntimeErrorReporter } from "../core/runtime-error-reporter";
 
-function makeRequest(): Request {
-  return new Request("https://example.com/agent/test/run", { method: "POST" });
+function makeRequest(signal?: AbortSignal): Request {
+  return new Request("https://example.com/agent/test/run", {
+    method: "POST",
+    headers: { "X-User-Id": "issue-2716-user" },
+    signal,
+  });
 }
 
 describe("sse-response.ts — telemetry lifecycle", () => {
@@ -104,5 +109,67 @@ describe("sse-response.ts — telemetry lifecycle", () => {
       "oss.runtime.agent_execution_stream_started",
       {},
     );
+  });
+
+  it("reports an observable factory failure once and closes the response", async () => {
+    const onError = vi.fn();
+    const response = createSseEventResponse({
+      request: makeRequest(),
+      observableFactory: async () => {
+        throw new Error("factory failed");
+      },
+      runtimeErrorReporter: createRuntimeErrorReporter(onError),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("");
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledOnce());
+    expect(onError.mock.calls[0][0].context.request.headers).toEqual({
+      "x-user-id": "issue-2716-user",
+    });
+  });
+
+  it("reports a subscription failure once while preserving telemetry and close", async () => {
+    const onError = vi.fn();
+    const failing = new Observable<BaseEvent>((subscriber) => {
+      subscriber.error(new Error("subscription failed"));
+    });
+    const response = createSseEventResponse({
+      request: makeRequest(),
+      observableFactory: () => failing,
+      runtimeErrorReporter: createRuntimeErrorReporter(onError),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("");
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledOnce());
+    expect(captureSpy).toHaveBeenCalledWith(
+      "oss.runtime.agent_execution_stream_errored",
+      expect.objectContaining({ error: "subscription failed" }),
+    );
+  });
+
+  it("does not report successful completion or request abort", async () => {
+    const onError = vi.fn();
+    const completed = new Observable<BaseEvent>((subscriber) => {
+      subscriber.complete();
+    });
+    const response = createSseEventResponse({
+      request: makeRequest(),
+      observableFactory: () => completed,
+      runtimeErrorReporter: createRuntimeErrorReporter(onError),
+    });
+    await response.text();
+
+    const controller = new AbortController();
+    createSseEventResponse({
+      request: makeRequest(controller.signal),
+      observableFactory: () => new Observable<BaseEvent>(() => {}),
+      runtimeErrorReporter: createRuntimeErrorReporter(onError),
+    });
+    controller.abort();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onError).not.toHaveBeenCalled();
   });
 });

--- a/packages/runtime/src/v2/runtime/core/runtime-error-reporter.ts
+++ b/packages/runtime/src/v2/runtime/core/runtime-error-reporter.ts
@@ -1,0 +1,107 @@
+import type {
+  CopilotErrorEvent,
+  CopilotErrorHandler,
+} from "@copilotkit/shared";
+
+import type { CopilotRuntimeLike } from "./runtime";
+
+export const runtimeErrorReporterOption = Symbol(
+  "copilotkit.runtimeErrorReporter",
+);
+
+export interface RuntimeErrorReportParams {
+  request: Request;
+  error: unknown;
+  operation: string;
+  agentId?: string;
+  threadId?: string;
+  runId?: string;
+  phase?: string;
+  startTime?: number;
+}
+
+export interface RuntimeErrorReporter {
+  report(params: RuntimeErrorReportParams): void;
+}
+
+export interface RuntimeErrorReporterOptions {
+  [runtimeErrorReporterOption]?: RuntimeErrorReporter;
+}
+
+export function createRuntimeErrorReporter(
+  handler?: CopilotErrorHandler,
+): RuntimeErrorReporter {
+  return {
+    report({
+      request,
+      error,
+      operation,
+      agentId,
+      threadId,
+      runId,
+      phase,
+      startTime,
+    }) {
+      if (!handler) return;
+
+      const event: CopilotErrorEvent = {
+        type: "error",
+        timestamp: Date.now(),
+        context: {
+          source: "runtime",
+          ...(threadId ? { threadId } : {}),
+          ...(runId ? { runId } : {}),
+          request: {
+            operation,
+            method: request.method,
+            url: request.url,
+            path: new URL(request.url).pathname,
+            headers: Object.fromEntries(request.headers.entries()),
+            startTime: startTime ?? Date.now(),
+          },
+          ...(agentId ? { agent: { name: agentId } } : {}),
+          ...(phase ? { metadata: { phase } } : {}),
+        },
+        error,
+      };
+
+      try {
+        const result = handler(event);
+        if (result && typeof (result as Promise<void>).catch === "function") {
+          void (result as Promise<void>).catch((handlerError) => {
+            console.error(
+              "CopilotRuntime onError handler failed:",
+              handlerError,
+            );
+          });
+        }
+      } catch (handlerError) {
+        console.error("CopilotRuntime onError handler failed:", handlerError);
+      }
+    },
+  };
+}
+
+export function getRuntimeErrorReporterFromOptions(
+  options: object,
+): RuntimeErrorReporter | undefined {
+  return (options as RuntimeErrorReporterOptions)[runtimeErrorReporterOption];
+}
+
+export function attachRuntimeErrorReporter(
+  runtime: object,
+  reporter: RuntimeErrorReporter,
+): void {
+  Object.defineProperty(runtime, runtimeErrorReporterOption, {
+    configurable: true,
+    value: reporter,
+  });
+}
+
+export function getRuntimeErrorReporter(
+  runtime: CopilotRuntimeLike,
+): RuntimeErrorReporter | undefined {
+  return (runtime as CopilotRuntimeLike & RuntimeErrorReporterOptions)[
+    runtimeErrorReporterOption
+  ];
+}

--- a/packages/runtime/src/v2/runtime/core/runtime-error-reporter.ts
+++ b/packages/runtime/src/v2/runtime/core/runtime-error-reporter.ts
@@ -9,6 +9,13 @@ export const runtimeErrorReporterOption = Symbol(
   "copilotkit.runtimeErrorReporter",
 );
 
+export type RuntimeErrorPhase =
+  | "common"
+  | "sse.factory"
+  | "sse.subscription"
+  | "intelligence.startup"
+  | "intelligence.subscription";
+
 export interface RuntimeErrorReportParams {
   request: Request;
   error: unknown;
@@ -16,7 +23,7 @@ export interface RuntimeErrorReportParams {
   agentId?: string;
   threadId?: string;
   runId?: string;
-  phase?: string;
+  phase?: RuntimeErrorPhase;
   startTime?: number;
 }
 
@@ -44,39 +51,39 @@ export function createRuntimeErrorReporter(
     }) {
       if (!handler) return;
 
-      const event: CopilotErrorEvent = {
-        type: "error",
-        timestamp: Date.now(),
-        context: {
-          source: "runtime",
-          ...(threadId ? { threadId } : {}),
-          ...(runId ? { runId } : {}),
-          request: {
-            operation,
-            method: request.method,
-            url: request.url,
-            path: new URL(request.url).pathname,
-            headers: Object.fromEntries(request.headers.entries()),
-            startTime: startTime ?? Date.now(),
-          },
-          ...(agentId ? { agent: { name: agentId } } : {}),
-          ...(phase ? { metadata: { phase } } : {}),
-        },
-        error,
-      };
-
       try {
+        const event: CopilotErrorEvent = {
+          type: "error",
+          timestamp: Date.now(),
+          context: {
+            source: "runtime",
+            ...(threadId ? { threadId } : {}),
+            ...(runId ? { runId } : {}),
+            request: {
+              operation,
+              method: request.method,
+              url: request.url,
+              path: new URL(request.url).pathname,
+              headers: Object.fromEntries(request.headers.entries()),
+              startTime: startTime ?? Date.now(),
+            },
+            ...(agentId ? { agent: { name: agentId } } : {}),
+            ...(phase ? { metadata: { phase } } : {}),
+          },
+          error,
+        };
+
         const result = handler(event);
         if (result && typeof (result as Promise<void>).catch === "function") {
           void (result as Promise<void>).catch((handlerError) => {
             console.error(
-              "CopilotRuntime onError handler failed:",
+              "CopilotRuntime onError reporting failed:",
               handlerError,
             );
           });
         }
       } catch (handlerError) {
-        console.error("CopilotRuntime onError handler failed:", handlerError);
+        console.error("CopilotRuntime onError reporting failed:", handlerError);
       }
     },
   };

--- a/packages/runtime/src/v2/runtime/core/runtime-error-reporter.ts
+++ b/packages/runtime/src/v2/runtime/core/runtime-error-reporter.ts
@@ -35,6 +35,26 @@ export interface RuntimeErrorReporterOptions {
   [runtimeErrorReporterOption]?: RuntimeErrorReporter;
 }
 
+const SENSITIVE_REQUEST_HEADERS = new Set([
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "set-cookie",
+  "x-api-key",
+  "api-key",
+  "x-copilotcloud-public-api-key",
+]);
+
+function sanitizeRequestHeaders(headers: Headers): Record<string, string> {
+  const sanitized: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    if (!SENSITIVE_REQUEST_HEADERS.has(key.toLowerCase())) {
+      sanitized[key] = value;
+    }
+  });
+  return sanitized;
+}
+
 export function createRuntimeErrorReporter(
   handler?: CopilotErrorHandler,
 ): RuntimeErrorReporter {
@@ -64,7 +84,7 @@ export function createRuntimeErrorReporter(
               method: request.method,
               url: request.url,
               path: new URL(request.url).pathname,
-              headers: Object.fromEntries(request.headers.entries()),
+              headers: sanitizeRequestHeaders(request.headers),
               startTime: startTime ?? Date.now(),
             },
             ...(agentId ? { agent: { name: agentId } } : {}),

--- a/packages/runtime/src/v2/runtime/core/runtime.ts
+++ b/packages/runtime/src/v2/runtime/core/runtime.ts
@@ -39,6 +39,10 @@ import type { CopilotKitIntelligence } from "../intelligence-platform";
 // by the Channel-listener bootstrap — not here.
 import type { Channel } from "@copilotkit/channels-core";
 import telemetry from "../telemetry/telemetry-client";
+import {
+  attachRuntimeErrorReporter,
+  getRuntimeErrorReporterFromOptions,
+} from "./runtime-error-reporter";
 
 export const VERSION = pkg.version;
 
@@ -556,6 +560,11 @@ class CopilotRuntimeShim implements CopilotRuntime {
     this.delegate = hasIntelligenceOptions(options)
       ? new CopilotIntelligenceRuntime(options)
       : new CopilotSseRuntime(options);
+
+    const reporter = getRuntimeErrorReporterFromOptions(options);
+    if (reporter) {
+      attachRuntimeErrorReporter(this, reporter);
+    }
   }
 
   get agents(): CopilotRuntimeOptions["agents"] {

--- a/packages/runtime/src/v2/runtime/handlers/handle-run.ts
+++ b/packages/runtime/src/v2/runtime/handlers/handle-run.ts
@@ -9,12 +9,14 @@ import {
 } from "./shared/agent-utils";
 import { handleIntelligenceRun } from "./intelligence/run";
 import { handleSseRun } from "./sse/run";
+import { getRuntimeErrorReporter } from "../core/runtime-error-reporter";
 
 export async function handleRunAgent({
   runtime,
   request,
   agentId,
 }: RunAgentParameters) {
+  const startTime = Date.now();
   telemetry.capture("oss.runtime.copilot_request_created", {
     "cloud.guardrails.enabled": false,
     requestType: "run",
@@ -83,6 +85,7 @@ export async function handleRunAgent({
         agentId,
         agent,
         input,
+        startTime,
       });
     }
 
@@ -94,8 +97,17 @@ export async function handleRunAgent({
       agentId,
       debug: runtime.debug,
       logger: runtime.debugLogger,
+      startTime,
     });
   } catch (error) {
+    getRuntimeErrorReporter(runtime)?.report({
+      request,
+      error,
+      operation: "agent.run",
+      agentId,
+      phase: "common",
+      startTime,
+    });
     console.error("Error running agent:", error);
     console.error(
       "Error stack:",

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/run.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/run.ts
@@ -14,6 +14,7 @@ import { isHandlerResponse } from "../shared/json-response";
 import type { AgentRunnerRunRequest } from "../../runner/agent-runner";
 import type { Observable } from "rxjs";
 import { getRuntimeErrorReporter } from "../../core/runtime-error-reporter";
+import type { RuntimeErrorPhase } from "../../core/runtime-error-reporter";
 
 /**
  * Builds browser-facing realtime connection metadata owned by the runtime.
@@ -243,7 +244,7 @@ export async function handleIntelligenceRun({
 
   const runtimeErrorReporter = getRuntimeErrorReporter(runtime);
   let agentErrorReported = false;
-  const reportAgentError = (error: unknown, phase: string) => {
+  const reportAgentError = (error: unknown, phase: RuntimeErrorPhase) => {
     if (agentErrorReported) return;
     agentErrorReported = true;
     runtimeErrorReporter?.report({
@@ -271,18 +272,22 @@ export async function handleIntelligenceRun({
         if (event.type === EventType.RUN_STARTED) {
           runStarted.current = true;
         }
-        if (event.type === EventType.RUN_ERROR && !runStarted.current) {
-          const error =
-            "message" in event && typeof event.message === "string"
-              ? new Error(event.message)
-              : new Error("Runner failed before the run started");
-          reportAgentError(error, "intelligence.startup");
-          clearHeartbeat();
-          immediateStartupErrorMessage =
+        if (event.type === EventType.RUN_ERROR) {
+          const message =
             "message" in event && typeof event.message === "string"
               ? event.message
               : "Runner failed before the run started";
-          immediateStartupCleanup = cleanupLock("runner-start-failed");
+          reportAgentError(
+            new Error(message),
+            runStarted.current
+              ? "intelligence.subscription"
+              : "intelligence.startup",
+          );
+          if (!runStarted.current) {
+            clearHeartbeat();
+            immediateStartupErrorMessage = message;
+            immediateStartupCleanup = cleanupLock("runner-start-failed");
+          }
         }
       },
       error: (error) => {

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/run.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/run.ts
@@ -13,6 +13,7 @@ import { resolveIntelligenceUser } from "../shared/resolve-intelligence-user";
 import { isHandlerResponse } from "../shared/json-response";
 import type { AgentRunnerRunRequest } from "../../runner/agent-runner";
 import type { Observable } from "rxjs";
+import { getRuntimeErrorReporter } from "../../core/runtime-error-reporter";
 
 /**
  * Builds browser-facing realtime connection metadata owned by the runtime.
@@ -55,6 +56,7 @@ interface HandleIntelligenceRunParams {
   agentId: string;
   agent: AbstractAgent;
   input: RunAgentInput;
+  startTime?: number;
 }
 
 export async function handleIntelligenceRun({
@@ -63,6 +65,7 @@ export async function handleIntelligenceRun({
   agentId,
   agent,
   input,
+  startTime,
 }: HandleIntelligenceRunParams): Promise<Response> {
   if (!runtime.intelligence) {
     return Response.json(
@@ -238,6 +241,23 @@ export async function handleIntelligenceRun({
     ...(persistedInputMessages !== undefined ? { persistedInputMessages } : {}),
   };
 
+  const runtimeErrorReporter = getRuntimeErrorReporter(runtime);
+  let agentErrorReported = false;
+  const reportAgentError = (error: unknown, phase: string) => {
+    if (agentErrorReported) return;
+    agentErrorReported = true;
+    runtimeErrorReporter?.report({
+      request,
+      error,
+      operation: "agent.run",
+      agentId,
+      threadId: canonicalThreadId,
+      runId: canonicalRunId,
+      phase,
+      startTime,
+    });
+  };
+
   try {
     const runStart = hasRunnerStartupBoundary(runtime.runner)
       ? runtime.runner.runWithStartupBoundary(runRequest)
@@ -252,6 +272,11 @@ export async function handleIntelligenceRun({
           runStarted.current = true;
         }
         if (event.type === EventType.RUN_ERROR && !runStarted.current) {
+          const error =
+            "message" in event && typeof event.message === "string"
+              ? new Error(event.message)
+              : new Error("Runner failed before the run started");
+          reportAgentError(error, "intelligence.startup");
           clearHeartbeat();
           immediateStartupErrorMessage =
             "message" in event && typeof event.message === "string"
@@ -261,6 +286,12 @@ export async function handleIntelligenceRun({
         }
       },
       error: (error) => {
+        reportAgentError(
+          error,
+          runStarted.current
+            ? "intelligence.subscription"
+            : "intelligence.startup",
+        );
         clearHeartbeat();
         if (!runStarted.current) {
           immediateStartupErrorMessage =
@@ -282,6 +313,7 @@ export async function handleIntelligenceRun({
 
     await runStart.startup;
   } catch (error) {
+    reportAgentError(error, "intelligence.startup");
     clearHeartbeat();
     await (immediateStartupCleanup ?? cleanupLock("runner-start-threw"));
     logger.error("Error starting agent runner:", error);

--- a/packages/runtime/src/v2/runtime/handlers/shared/sse-response.ts
+++ b/packages/runtime/src/v2/runtime/handlers/shared/sse-response.ts
@@ -6,7 +6,10 @@ import { createLogger } from "../../../../lib/logger";
 import type { CopilotRuntimeLogger } from "../../../../lib/logger";
 import { telemetry } from "../../telemetry";
 import type { DebugEventBus } from "../../core/debug-event-bus";
-import type { RuntimeErrorReporter } from "../../core/runtime-error-reporter";
+import type {
+  RuntimeErrorPhase,
+  RuntimeErrorReporter,
+} from "../../core/runtime-error-reporter";
 
 interface CreateSseEventResponseParams {
   request: Request;
@@ -80,7 +83,7 @@ export function createSseEventResponse({
   let subscription: Subscription | undefined;
   let agentErrorReported = false;
 
-  const reportAgentError = (error: unknown, phase: string) => {
+  const reportAgentError = (error: unknown, phase: RuntimeErrorPhase) => {
     if (agentErrorReported) return;
     agentErrorReported = true;
     runtimeErrorReporter?.report({
@@ -116,6 +119,24 @@ export function createSseEventResponse({
           const e = event as { threadId?: string; runId?: string };
           debugThreadId = e.threadId ?? "";
           debugRunId = e.runId ?? "";
+        }
+
+        if (event.type === "RUN_ERROR") {
+          const e = event as {
+            message?: unknown;
+            threadId?: string;
+            runId?: string;
+          };
+          debugThreadId = e.threadId ?? debugThreadId;
+          debugRunId = e.runId ?? debugRunId;
+          reportAgentError(
+            new Error(
+              typeof e.message === "string"
+                ? e.message
+                : "Runner reported a run error",
+            ),
+            "sse.subscription",
+          );
         }
 
         // Broadcast to debug listeners BEFORE the stream-closed gate below.

--- a/packages/runtime/src/v2/runtime/handlers/shared/sse-response.ts
+++ b/packages/runtime/src/v2/runtime/handlers/shared/sse-response.ts
@@ -6,6 +6,7 @@ import { createLogger } from "../../../../lib/logger";
 import type { CopilotRuntimeLogger } from "../../../../lib/logger";
 import { telemetry } from "../../telemetry";
 import type { DebugEventBus } from "../../core/debug-event-bus";
+import type { RuntimeErrorReporter } from "../../core/runtime-error-reporter";
 
 interface CreateSseEventResponseParams {
   request: Request;
@@ -25,6 +26,8 @@ interface CreateSseEventResponseParams {
    * run telemetry.
    */
   captureTelemetry?: boolean;
+  runtimeErrorReporter?: RuntimeErrorReporter;
+  startTime?: number;
 }
 
 export function createSseEventResponse({
@@ -35,6 +38,8 @@ export function createSseEventResponse({
   debug,
   logger,
   captureTelemetry = true,
+  runtimeErrorReporter,
+  startTime,
 }: CreateSseEventResponseParams): Response {
   const stream = new TransformStream();
   const writer = stream.writable.getWriter();
@@ -73,6 +78,22 @@ export function createSseEventResponse({
   };
 
   let subscription: Subscription | undefined;
+  let agentErrorReported = false;
+
+  const reportAgentError = (error: unknown, phase: string) => {
+    if (agentErrorReported) return;
+    agentErrorReported = true;
+    runtimeErrorReporter?.report({
+      request,
+      error,
+      operation: "agent.run",
+      agentId,
+      threadId: debugThreadId || undefined,
+      runId: debugRunId || undefined,
+      phase,
+      startTime,
+    });
+  };
 
   (async () => {
     const observable = await observableFactory();
@@ -152,6 +173,7 @@ export function createSseEventResponse({
         }
       },
       error: async (error) => {
+        reportAgentError(error, "sse.subscription");
         if (captureTelemetry) {
           telemetry.capture("oss.runtime.agent_execution_stream_errored", {
             error: error instanceof Error ? error.message : String(error),
@@ -186,6 +208,7 @@ export function createSseEventResponse({
       subscription.unsubscribe();
     }
   })().catch(async (error) => {
+    reportAgentError(error, "sse.factory");
     logError(error);
     await closeStream();
   });

--- a/packages/runtime/src/v2/runtime/handlers/sse/run.ts
+++ b/packages/runtime/src/v2/runtime/handlers/sse/run.ts
@@ -1,7 +1,8 @@
-import { AbstractAgent, RunAgentInput } from "@ag-ui/client";
-import { ResolvedDebugConfig } from "@copilotkit/shared";
-import { type CopilotRuntimeLogger } from "../../../../lib/logger";
-import { CopilotRuntimeLike } from "../../core/runtime";
+import type { AbstractAgent, RunAgentInput } from "@ag-ui/client";
+import type { ResolvedDebugConfig } from "@copilotkit/shared";
+import type { CopilotRuntimeLogger } from "../../../../lib/logger";
+import type { CopilotRuntimeLike } from "../../core/runtime";
+import { getRuntimeErrorReporter } from "../../core/runtime-error-reporter";
 import { createSseEventResponse } from "../shared/sse-response";
 
 interface HandleSseRunParams {
@@ -13,6 +14,7 @@ interface HandleSseRunParams {
   debug?: ResolvedDebugConfig;
   /** Pre-created logger instance to avoid creating a new pino logger per request. */
   logger?: CopilotRuntimeLogger;
+  startTime?: number;
 }
 
 export function handleSseRun({
@@ -23,6 +25,7 @@ export function handleSseRun({
   agentId,
   debug,
   logger,
+  startTime,
 }: HandleSseRunParams): Response {
   return createSseEventResponse({
     request,
@@ -30,6 +33,8 @@ export function handleSseRun({
     agentId,
     debug,
     logger,
+    runtimeErrorReporter: getRuntimeErrorReporter(runtime),
+    startTime,
     observableFactory: () =>
       runtime.runner.run({
         threadId: input.threadId,


### PR DESCRIPTION
## Summary

`CopilotRuntime` exposes an `onError` callback, but the v1-to-v2 delegation drops it before server request processing. Runtime failures therefore can't provide the incoming request headers that applications use to correlate errors with a user or tenant.

## Root cause

The legacy constructor retains the callback type, while delegated runtime options omit it. Common, SSE, and Intelligence handlers consume failures inside their own boundaries, before a generic endpoint hook can reconstruct the legacy event.

## Changes

- Add one internal runtime reporter that snapshots incoming Fetch request headers.
- Attach the configured legacy callback to the delegated runtime instance.
- Route common, SSE, and Intelligence agent-run failures, including standard `RUN_ERROR` events, through that reporter exactly once.
- Redact sensitive request headers (authorization, proxy-authorization, cookie, set-cookie, x-api-key, api-key, and the CopilotKit public-key header) before they reach the `onError` event.
- Preserve responses, stream close behavior, telemetry, cleanup, logging, endpoint hooks, and callback isolation.
- Add production-path regressions.

## Compatibility

The existing `CopilotErrorEvent` type and optional `context.request.headers` field remain unchanged. Header names and values come from the failing request's Fetch `Headers` object, with sensitive credentials stripped before the event is emitted. The callback receives a fresh record, so mutation cannot alter the request or a later event.

## Out of scope

React provider propagation, Chat, CopilotMessages, the deprecated runtime-client hook, redaction policy, HTTP response exposure, v2 endpoint-hook semantics, and non-agent runtime routes remain outside this slice.

## Related PRs and Issues

Addresses #2716.

Scope follows https://github.com/CopilotKit/CopilotKit/issues/2716#issuecomment-5086936254. Runtime error-routing precedent: https://github.com/CopilotKit/CopilotKit/pull/2143.

## Test plan

- [x] Runtime error regression and reporter tests, 12 + 4 tests passed. Covers public routing, sanitized header propagation with credential redaction, callback rejection containment, snapshots, mutation isolation, and malformed requests.
- [x] SSE and Intelligence telemetry tests, 7 + 14 tests passed. Covers agent-run failures, `RUN_ERROR`, setup boundaries, exact-once reporting, telemetry, cleanup, and response preservation.
- [x] Runtime preservation suites, 57 + 129 + 56 tests passed. Existing request, endpoint-hook, and runtime-library behavior remains intact.
- [x] Typecheck, formatting, and lint passed on changed runtime files; lint reported four pre-existing warnings.
- [ ] CI green (`static / quality`, `test / unit` on Node 20/22/24).
