### PR TITLE
docs(showcase): align A2UI docs with v0.9 helpers

### DIFF
--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui/index.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui/index.mdx
@@ -38,14 +38,15 @@ frontend renderer. The difference is *where the schema comes from* and
 
 ## How it works
 
-Every A2UI surface is assembled from three kinds of operations emitted
-by the agent and consumed by the frontend renderer:
+Every A2UI surface is assembled from three operations emitted by the
+agent and consumed by the frontend renderer:
 
-1. **`createSurface` / `surfaceUpdate`** declares (or pins) the
-   component tree (the schema) for a surface.
-2. **`updateComponents` / `dataModelUpdate`** supplies the data that
-   populates the components via JSON Pointer paths.
-3. **`beginRendering`** tells the client the first frame is ready.
+1. **`createSurface`** initializes the surface with its catalog and must
+   come first.
+2. **`updateComponents`** defines the component tree (the schema) for
+   the surface.
+3. **`updateDataModel`** supplies the data that populates the
+   components via JSON Pointer paths.
 
 The CopilotKit Python SDK provides helpers for each:
 
@@ -55,8 +56,7 @@ from copilotkit import a2ui
 a2ui.create_surface(surface_id, catalog_id=...)
 a2ui.update_components(surface_id, components)
 a2ui.update_data_model(surface_id, {"items": data})
-a2ui.begin_rendering(surface_id, root_id)
-a2ui.render(operations=[...])  # wraps and serializes for a tool result
+a2ui.render(operations=[...])  # wraps in a2ui_operations and serializes
 ```
 
 ## Setup

--- a/showcase/shell-docs/src/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx
@@ -27,13 +27,14 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
 
 <Steps>
   <Step>
-    ### Clone the A2A starter template
+    ### Use the A2A starter template
 
     ```bash
-    git clone https://github.com/copilotkit/with-a2a-a2ui.git
+    git clone https://github.com/CopilotKit/CopilotKit.git
+    cd CopilotKit/examples/integrations/a2a-a2ui
     ```
 
-    The cloned starter currently uses the legacy v0.8 renderer and its agent emits a JSON list of v0.8 operation objects. This page documents that accepted starter payload. Migrating the starter to the v0.9 renderer and `a2ui_operations` envelope requires changes outside this documentation target.
+    The archived `copilotkit/with-a2a-a2ui` starter now lives at this monorepo path. The current starter uses its local v0.8 renderer and emits a JSON list of v0.8 operation objects. This page documents that accepted starter payload. Migrating the starter to the v0.9 renderer and `a2ui_operations` envelope requires changes outside this documentation target.
 
   </Step>
   <Step>
@@ -127,7 +128,7 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
     In the example repo, all of the widgets are defined in a single variable in the prompt_builder.py file, but you can structure them however you like,
     they simply need to be injected into the agent's prompt in a clearly delineated way. The v0.9 SDK migration is not demonstrated by this starter page.
 
-    The button payload uses the v0.8 `action.name` field. The published renderer sends that value as `userAction.name`, while the current starter executor reads `userAction.actionName` before selecting its `book_restaurant` branch. As a result, the click reaches the agent but follows the executor's generic event path instead of the booking-specific path. Updating that starter field is outside this documentation-only change.
+    The current starter's v0.8 renderer displays the `Book Now` control without an `onClick` handler or action dispatch. The button is inert, so no click reaches the agent and the executor's `book_restaurant` branch is not reached. Adding action wiring is outside this documentation-only change.
 
   </Step>
   <Step>
@@ -150,26 +151,27 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
     AG-UI handles communicating with your a2a agent, and passes the a2ui messages back and forth as `ActivityMessage` objects.
     In order to render them in your frontend, you need to configure activity message rendering.
 
-    The cloned starter renders these messages with the v0.8-compatible `@copilotkit/a2ui-renderer` package and its theme. The setup below mirrors the starter's current `app/page.tsx`; the v0.9 renderer and `a2ui_operations` envelope are documented in the other A2UI integration guides.
+    The current starter registers its local v0.8 renderer and its v0.8 theme. The setup below mirrors that `app/page.tsx`; the v0.9 renderer and `a2ui_operations` envelope are documented in the other A2UI integration guides.
 
     ```tsx title="app/page.tsx"
     "use client";
 
     import { CopilotChat, CopilotKitProvider } from "@copilotkit/react-core/v2";
-    import { createA2UIMessageRenderer } from "@copilotkit/a2ui-renderer";
+    import { a2uiV08Renderer } from "./components/a2ui-v0-8-renderer";
     import { theme } from "./theme";
 
     // Disable static optimization for this page
     export const dynamic = "force-dynamic";
 
-    const A2UIMessageRenderer = createA2UIMessageRenderer({ theme });
-    const activityRenderers = [A2UIMessageRenderer];
+    const activityRenderers = [a2uiV08Renderer];
 
     export default function Home() {
       return (
         <CopilotKitProvider
           runtimeUrl="/api/copilotkit"
           showDevConsole="auto"
+          useSingleEndpoint={false}
+          a2ui={{ theme }}
           renderActivityMessages={activityRenderers}
         >
           <main
@@ -184,7 +186,7 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
     ```
 
     ```tsx title="app/theme.ts"
-    import { v0_8 } from "@a2ui/lit";
+    import { Styles, type Types } from "@a2ui/lit/0.8";
 
     /** Elements */
 
@@ -339,29 +341,29 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
       "layout-el-cv": true,
     };
 
-    const aLight = v0_8.Styles.merge(a, { "color-c-n5": true });
-    const inputLight = v0_8.Styles.merge(input, { "color-c-n5": true });
-    const textareaLight = v0_8.Styles.merge(textarea, { "color-c-n5": true });
-    const buttonLight = v0_8.Styles.merge(button, { "color-c-n100": true });
-    const h1Light = v0_8.Styles.merge(h1, { "color-c-n5": true });
-    const h2Light = v0_8.Styles.merge(h2, { "color-c-n5": true });
-    const h3Light = v0_8.Styles.merge(h3, { "color-c-n5": true });
-    const h4Light = v0_8.Styles.merge(h4, { "color-c-n5": true });
-    const h5Light = v0_8.Styles.merge(h5, { "color-c-n5": true });
-    const bodyLight = v0_8.Styles.merge(body, { "color-c-n5": true });
-    const pLight = v0_8.Styles.merge(p, { "color-c-n35": true });
-    const preLight = v0_8.Styles.merge(pre, { "color-c-n35": true });
-    const orderedListLight = v0_8.Styles.merge(orderedList, {
+    const aLight = Styles.merge(a, { "color-c-n5": true });
+    const inputLight = Styles.merge(input, { "color-c-n5": true });
+    const textareaLight = Styles.merge(textarea, { "color-c-n5": true });
+    const buttonLight = Styles.merge(button, { "color-c-n100": true });
+    const h1Light = Styles.merge(h1, { "color-c-n5": true });
+    const h2Light = Styles.merge(h2, { "color-c-n5": true });
+    const h3Light = Styles.merge(h3, { "color-c-n5": true });
+    const h4Light = Styles.merge(h4, { "color-c-n5": true });
+    const h5Light = Styles.merge(h5, { "color-c-n5": true });
+    const bodyLight = Styles.merge(body, { "color-c-n5": true });
+    const pLight = Styles.merge(p, { "color-c-n35": true });
+    const preLight = Styles.merge(pre, { "color-c-n35": true });
+    const orderedListLight = Styles.merge(orderedList, {
       "color-c-n35": true,
     });
-    const unorderedListLight = v0_8.Styles.merge(unorderedList, {
+    const unorderedListLight = Styles.merge(unorderedList, {
       "color-c-n35": true,
     });
-    const listItemLight = v0_8.Styles.merge(listItem, {
+    const listItemLight = Styles.merge(listItem, {
       "color-c-n35": true,
     });
 
-    export const theme: v0_8.Types.Theme = {
+    export const theme: Types.Theme = {
       additionalStyles: {
         Button: {
           "--n-35": "var(--n-100)",
@@ -604,8 +606,7 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
   <Step>
     ### Give it a try!
 
-    That's it! When your agent generates an A2UI message, it will be rendered in your frontend.
-    A2UI actions (like button clicks) are sent back to your agent via AG-UI. In the current starter, the renderer emits the button's action as `userAction.name`, but the executor checks `userAction.actionName`, so the documented `book_restaurant` button does not select the booking-specific branch until that starter mismatch is migrated.
+    That's it! When your agent generates an A2UI message, it will be rendered in your frontend. The current starter's v0.8 `Book Now` control is inert because its renderer doesn't attach a click handler or dispatch an action. No button click reaches the agent until that starter behavior is implemented.
 
   </Step>
 </Steps>

--- a/showcase/shell-docs/src/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx
@@ -33,7 +33,7 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
     git clone https://github.com/copilotkit/with-a2a-a2ui.git
     ```
 
-    The cloned starter currently ships a legacy v0.8 renderer. Replace that renderer with the v0.9 createA2UIMessageRenderer setup below before using the v0.9 operation example; the legacy renderer does not consume a2ui_operations.
+    The cloned starter currently uses the legacy v0.8 renderer and its agent emits a JSON list of v0.8 operation objects. This page documents that accepted starter payload. Migrating the starter to the v0.9 renderer and `a2ui_operations` envelope requires changes outside this documentation target.
 
   </Step>
   <Step>
@@ -61,82 +61,78 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
   <Step>
     ### Setting up your agent with components
 
-    After replacing the legacy renderer, use the v0.9 operation envelope below to add your own components.
+    The starter's current agent accepts the v0.8 operation list below. Keep the operation order and shapes when adding your own components; each list entry is sent as an individual A2A data part by the starter agent.
 
     ```python title="agent/restaurant_finder/prompt_builder.py"
       RESTAURANT_UI_EXAMPLES = """
       ...
       ---BEGIN SINGLE_COLUMN_LIST_EXAMPLE---
-      {{
-        "a2ui_operations": [
-          {{ "version": "v0.9", "createSurface": {{ "surfaceId": "default", "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json" }} }},
-          {{ "version": "v0.9", "updateComponents": {{
-            "surfaceId": "default",
-            "components": [
-              {{ "id": "root", "component": "Column", "children": ["title-heading", "item-list"] }},
-              {{ "id": "title-heading", "component": "Text", "text": "Top Restaurants", "variant": "h1" }},
-              {{ "id": "item-list", "component": "List", "direction": "vertical", "children": {{ "componentId": "item-card-template", "path": "/items" }} }},
-              {{ "id": "item-card-template", "component": "Card", "child": "card-layout" }},
-              {{ "id": "card-layout", "component": "Row", "children": ["template-image", "card-details"] }},
-              {{ "id": "template-image", "component": "Image", "url": {{ "path": "imageUrl" }} }},
-              {{ "id": "card-details", "component": "Column", "children": ["template-name", "template-rating", "template-detail", "template-link", "template-book-button"] }},
-              {{ "id": "template-name", "component": "Text", "text": {{ "path": "name" }}, "variant": "h3" }},
-              {{ "id": "template-rating", "component": "Text", "text": {{ "path": "rating" }}, "variant": "caption" }},
-              {{ "id": "template-detail", "component": "Text", "text": {{ "path": "detail" }}, "variant": "body" }},
-              {{ "id": "template-link", "component": "Text", "text": {{ "path": "infoLink" }}, "variant": "body" }},
-              {{
-                "id": "template-book-button",
-                "component": "Button",
-                "child": "book-now-text",
-                "variant": "primary",
-                "action": {{
-                  "event": {{
-                    "name": "book_restaurant",
-                    "context": {{
-                      "restaurantName": {{ "path": "name" }},
-                      "imageUrl": {{ "path": "imageUrl" }},
-                      "address": {{ "path": "address" }}
-                    }}
-                  }}
-                }}
-              }},
-              {{ "id": "book-now-text", "component": "Text", "text": "Book Now" }}
-            ]
-          }} }},
-          {{ "version": "v0.9", "updateDataModel": {{
-            "surfaceId": "default",
-            "path": "/",
-            "value": {{
-              "items": [
-                {{ "name": "The Fancy Place", "rating": 4.8, "detail": "Fine dining experience", "infoLink": "https://example.com/fancy", "imageUrl": "https://example.com/fancy.jpg", "address": "123 Main St" }},
-                {{ "name": "Quick Bites", "rating": 4.2, "detail": "Casual and fast", "infoLink": "https://example.com/quick", "imageUrl": "https://example.com/quick.jpg", "address": "456 Oak Ave" }}
-              ]
-            }}
-          }} }}
-        ]
-      }}
+      [
+        {{ "beginRendering": {{ "surfaceId": "default", "root": "root-column", "styles": {{ "primaryColor": "#FF0000", "font": "Roboto" }} }} }},
+        {{ "surfaceUpdate": {{
+          "surfaceId": "default",
+          "components": [
+            {{ "id": "root-column", "component": {{ "Column": {{ "children": {{ "explicitList": ["title-heading", "item-list"] }} }} }} }},
+            {{ "id": "title-heading", "component": {{ "Text": {{ "usageHint": "h1", "text": {{ "literalString": "Top Restaurants" }} }} }} }},
+            {{ "id": "item-list", "component": {{ "List": {{ "direction": "vertical", "children": {{ "template": {{ "componentId": "item-card-template", "dataBinding": "/items" }} }} }} }} }},
+            {{ "id": "item-card-template", "component": {{ "Card": {{ "child": "card-layout" }} }} }},
+            {{ "id": "card-layout", "component": {{ "Row": {{ "children": {{ "explicitList": ["template-image", "card-details"] }} }} }} }},
+            {{ "id": "template-image", "weight": 1, "component": {{ "Image": {{ "url": {{ "path": "imageUrl" }} }} }} }},
+            {{ "id": "card-details", "weight": 2, "component": {{ "Column": {{ "children": {{ "explicitList": ["template-name", "template-rating", "template-detail", "template-link", "template-book-button"] }} }} }} }},
+            {{ "id": "template-name", "component": {{ "Text": {{ "usageHint": "h3", "text": {{ "path": "name" }} }} }} }},
+            {{ "id": "template-rating", "component": {{ "Text": {{ "text": {{ "path": "rating" }} }} }} }},
+            {{ "id": "template-detail", "component": {{ "Text": {{ "text": {{ "path": "detail" }} }} }} }},
+            {{ "id": "template-link", "component": {{ "Text": {{ "text": {{ "path": "infoLink" }} }} }} }},
+            {{ "id": "template-book-button", "component": {{ "Button": {{ "child": "book-now-text", "primary": true, "action": {{ "name": "book_restaurant", "context": [{{ "key": "restaurantName", "value": {{ "path": "name" }} }}, {{ "key": "imageUrl", "value": {{ "path": "imageUrl" }} }}, {{ "key": "address", "value": {{ "path": "address" }}}} ] }} }} }} }},
+            {{ "id": "book-now-text", "component": {{ "Text": {{ "text": {{ "literalString": "Book Now" }} }} }} }}
+          ]
+        }} }},
+        {{ "dataModelUpdate": {{
+          "surfaceId": "default",
+          "path": "/",
+          "contents": [
+            {{ "key": "items", "valueMap": [
+              {{ "key": "item1", "valueMap": [
+                {{ "key": "name", "valueString": "The Fancy Place" }},
+                {{ "key": "rating", "valueNumber": 4.8 }},
+                {{ "key": "detail", "valueString": "Fine dining experience" }},
+                {{ "key": "infoLink", "valueString": "https://example.com/fancy" }},
+                {{ "key": "imageUrl", "valueString": "https://example.com/fancy.jpg" }},
+                {{ "key": "address", "valueString": "123 Main St" }}
+              ] }},
+              {{ "key": "item2", "valueMap": [
+                {{ "key": "name", "valueString": "Quick Bites" }},
+                {{ "key": "rating", "valueNumber": 4.2 }},
+                {{ "key": "detail", "valueString": "Casual and fast" }},
+                {{ "key": "infoLink", "valueString": "https://example.com/quick" }},
+                {{ "key": "imageUrl", "valueString": "https://example.com/quick.jpg" }},
+                {{ "key": "address", "valueString": "456 Oak Ave" }}
+              ] }}
+            ] }}
+          ]
+        }} }}
+      ]
       ---END SINGLE_COLUMN_LIST_EXAMPLE---
       # ... more examples below
       ```
 
     The widgets are injected into the agent's prompt, in this case using the `RESTAURANT_UI_EXAMPLES` variable.
-    Widgets are defined for the agent using examples of the JSON objects they should output, wrapped in a comment block.
+    Widgets are defined for the agent using an example of the JSON array it should output, wrapped in a comment block.
     - A comment indicating the start of the example
-    - a2ui_operations: The envelope containing the v0.9 operations
-    - createSurface: Initializes the widget surface and must come first
-    - updateComponents: An example of the JSON structure for the widget
-    - updateDataModel: An example of the data that will populate the widget
+    - beginRendering: Starts the v0.8 surface
+    - surfaceUpdate: Defines the v0.8 component tree
+    - dataModelUpdate: Provides the v0.8 data model contents
     - A comment indicating the end of the example
 
     In the example repo, all of the widgets are defined in a single variable in the prompt_builder.py file, but you can structure them however you like,
-    they simply need to be injected into the agent's prompt in a clearly delineated way.
+    they simply need to be injected into the agent's prompt in a clearly delineated way. The v0.9 SDK migration is not demonstrated by this starter page.
 
   </Step>
   <Step>
     ### Generating components with the A2UI Composer
     If you want an easy way to generate components, you can use the A2UI Composer.
     Go to https://a2ui-composer.ag-ui.com/ to create your own components.
-    The composer will generate the json spec for you, all you have to do is copy and paste it into your agent's prompt.
+    The composer will generate the JSON spec for you, all you have to do is copy and paste it into your agent's prompt.
     <a href="https://a2ui-editor.ag-ui.com/gallery" target="_blank" rel="noopener noreferrer">
       <Image 
         src="/images/a2ui-composer.png" 
@@ -152,51 +148,45 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
     AG-UI handles communicating with your a2a agent, and passes the a2ui messages back and forth as `ActivityMessage` objects.
     In order to render them in your frontend, you need to configure activity message rendering.
 
-    Copilotkit provides a renderer for A2UI messages, all you need to do is instantiate it with a theme and pass it to your CopilotKit.
+    The cloned starter renders these messages with its v0.8 renderer and theme. The setup below mirrors the current starter; it is not a v0.9 `createA2UIMessageRenderer` walkthrough.
 
     ```tsx title="app/page.tsx"
     "use client";
 
     import {
       CopilotChat,
-      CopilotKit,
-      createA2UIMessageRenderer,
+      CopilotKitProvider,
     } from "@copilotkit/react-core/v2";
-    import "@copilotkit/react-core/v2/styles.css";
+    import { a2uiV08Renderer } from "./components/a2ui-v0-8-renderer";
     import { theme } from "./theme";
 
     // Disable static optimization for this page
     export const dynamic = "force-dynamic";
 
-    const A2UIMessageRenderer = createA2UIMessageRenderer({ theme });
+    const activityRenderers = [a2uiV08Renderer];
 
     export default function Home() {
       return (
-        <CopilotKit
+        <CopilotKitProvider
           runtimeUrl="/api/copilotkit"
           showDevConsole="auto"
-          renderActivityMessages={[A2UIMessageRenderer]}
+          useSingleEndpoint={false}
+          a2ui={{ theme }}
+          renderActivityMessages={activityRenderers}
         >
           <main
             className="flex min-h-screen flex-1 flex-col overflow-hidden"
             style={{ minHeight: "100dvh" }}
           >
-            <Chat />
+            <CopilotChat />
           </main>
-        </CopilotKit>
-      );
-    }
-
-    function Chat() {
-      return (
-        <div className="flex flex-1 flex-col overflow-hidden">
-          <CopilotChat style={{ flex: 1, minHeight: "100%" }} />
-        </div>
+        </CopilotKitProvider>
       );
     }
     ```
 
     ```tsx title="app/theme.ts"
+    import { Styles, type Types } from "@a2ui/lit/0.8";
 
     /** Elements */
 
@@ -341,30 +331,27 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
       "layout-el-cv": true,
     };
 
-    const mergeStyles = (...styles: Record<string, boolean>[]) =>
-      Object.assign({}, ...styles);
-
-    const aLight = mergeStyles(a, { "color-c-n5": true });
-    const inputLight = mergeStyles(input, { "color-c-n5": true });
-    const textareaLight = mergeStyles(textarea, { "color-c-n5": true });
-    const buttonLight = mergeStyles(button, { "color-c-n100": true });
-    const h1Light = mergeStyles(h1, { "color-c-n5": true });
-    const h2Light = mergeStyles(h2, { "color-c-n5": true });
-    const h3Light = mergeStyles(h3, { "color-c-n5": true });
-    const bodyLight = mergeStyles(body, { "color-c-n5": true });
-    const pLight = mergeStyles(p, { "color-c-n35": true });
-    const preLight = mergeStyles(pre, { "color-c-n35": true });
-    const orderedListLight = mergeStyles(orderedList, {
+    const aLight = Styles.merge(a, { "color-c-n5": true });
+    const inputLight = Styles.merge(input, { "color-c-n5": true });
+    const textareaLight = Styles.merge(textarea, { "color-c-n5": true });
+    const buttonLight = Styles.merge(button, { "color-c-n100": true });
+    const h1Light = Styles.merge(h1, { "color-c-n5": true });
+    const h2Light = Styles.merge(h2, { "color-c-n5": true });
+    const h3Light = Styles.merge(h3, { "color-c-n5": true });
+    const bodyLight = Styles.merge(body, { "color-c-n5": true });
+    const pLight = Styles.merge(p, { "color-c-n35": true });
+    const preLight = Styles.merge(pre, { "color-c-n35": true });
+    const orderedListLight = Styles.merge(orderedList, {
       "color-c-n35": true,
     });
-    const unorderedListLight = mergeStyles(unorderedList, {
+    const unorderedListLight = Styles.merge(unorderedList, {
       "color-c-n35": true,
     });
-    const listItemLight = mergeStyles(listItem, {
+    const listItemLight = Styles.merge(listItem, {
       "color-c-n35": true,
     });
 
-    export const theme: Record<string, unknown> = {
+    export const theme: Types.Theme = {
       additionalStyles: {
         Button: {
           "--n-35": "var(--n-100)",

--- a/showcase/shell-docs/src/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx
@@ -67,12 +67,13 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
       RESTAURANT_UI_EXAMPLES = """
       ...
       ---BEGIN SINGLE_COLUMN_LIST_EXAMPLE---
-      [
-        {{ "beginRendering": {{ "surfaceId": "default", "root": "root-column", "styles": {{ "primaryColor": "#FF0000", "font": "Roboto" }} }} }},
-        {{ "surfaceUpdate": {{
-          "surfaceId": "default",
-          "components": [
-            {{ "id": "root-column", "component": {{ "Column": {{ "children": {{ "explicitList": ["title-heading", "item-list"] }} }} }} }},
+      {{
+        "a2ui_operations": [
+          {{ "version": "v0.9", "createSurface": {{ "surfaceId": "default", "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json" }} }},
+          {{ "version": "v0.9", "updateComponents": {{
+            "surfaceId": "default",
+            "components": [
+            {{ "id": "root", "component": {{ "Column": {{ "children": {{ "explicitList": ["title-heading", "item-list"] }} }} }} }},
             {{ "id": "title-heading", "component": {{ "Text": {{ "usageHint": "h1", "text": {{ "literalString": "Top Restaurants" }} }} }} }},
             {{ "id": "item-list", "component": {{ "List": {{ "direction": "vertical", "children": {{ "template": {{ "componentId": "item-card-template", "dataBinding": "/items" }} }} }} }} }},
             {{ "id": "item-card-template", "component": {{ "Card": {{ "child": "card-layout" }} }} }},
@@ -85,33 +86,20 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
             {{ "id": "template-link", "component": {{ "Text": {{ "text": {{ "path": "infoLink" }} }} }} }},
             {{ "id": "template-book-button", "component": {{ "Button": {{ "child": "book-now-text", "primary": true, "action": {{ "name": "book_restaurant", "context": [ {{ "key": "restaurantName", "value": {{ "path": "name" }} }}, {{ "key": "imageUrl", "value": {{ "path": "imageUrl" }} }}, {{ "key": "address", "value": {{ "path": "address" }} }} ] }} }} }} }},
             {{ "id": "book-now-text", "component": {{ "Text": {{ "text": {{ "literalString": "Book Now" }} }} }} }}
-          ]
-        }} }},
-        {{ "dataModelUpdate": {{
-          "surfaceId": "default",
-          "path": "/",
-          "contents": [
-            {{ "key": "items", "valueMap": [
-              {{ "key": "item1", "valueMap": [
-                {{ "key": "name", "valueString": "The Fancy Place" }},
-                {{ "key": "rating", "valueNumber": 4.8 }},
-                {{ "key": "detail", "valueString": "Fine dining experience" }},
-                {{ "key": "infoLink", "valueString": "https://example.com/fancy" }},
-                {{ "key": "imageUrl", "valueString": "https://example.com/fancy.jpg" }},
-                {{ "key": "address", "valueString": "123 Main St" }}
-              ] }},
-              {{ "key": "item2", "valueMap": [
-                {{ "key": "name", "valueString": "Quick Bites" }},
-                {{ "key": "rating", "valueNumber": 4.2 }},
-                {{ "key": "detail", "valueString": "Casual and fast" }},
-                {{ "key": "infoLink", "valueString": "https://example.com/quick" }},
-                {{ "key": "imageUrl", "valueString": "https://example.com/quick.jpg" }},
-                {{ "key": "address", "valueString": "456 Oak Ave" }}
-              ] }}
-            ] }} // Populate this with restaurant data
-          ]
-        }} }}
-      ]
+            ]
+          }} }},
+          {{ "version": "v0.9", "updateDataModel": {{
+            "surfaceId": "default",
+            "path": "/",
+            "value": {{
+              "items": [
+                {{ "name": "The Fancy Place", "rating": 4.8, "detail": "Fine dining experience", "infoLink": "https://example.com/fancy", "imageUrl": "https://example.com/fancy.jpg", "address": "123 Main St" }},
+                {{ "name": "Quick Bites", "rating": 4.2, "detail": "Casual and fast", "infoLink": "https://example.com/quick", "imageUrl": "https://example.com/quick.jpg", "address": "456 Oak Ave" }}
+              ]
+            }}
+          }} }}
+        ]
+      }}
       ---END SINGLE_COLUMN_LIST_EXAMPLE---
       # ... more examples below
       ```
@@ -119,9 +107,10 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
     The widgets are injected into the agent's prompt, in this case using the `RESTAURANT_UI_EXAMPLES` variable.
     Widgets are defined for the agent using examples of the json arrays they should output, wrapped in a comment block.
     - A comment indicating the start of the example
-    - beginRendering: The start of the widget's rendering
-    - surfaceUpdate: An example of the json structure for the widget
-    - dataModelUpdate: an example of the data that will be used to populate the widget
+    - createSurface: Initializes the widget surface and must come first
+    - updateComponents: An example of the JSON structure for the widget
+    - updateDataModel: An example of the data that will populate the widget
+    - a2ui_operations: The envelope containing the v0.9 operations
     - A comment indicating the end of the example
 
     In the example repo, all of the widgets are defined in a single variable int the prompt_builder.py file, but you can structure them however you like,

--- a/showcase/shell-docs/src/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx
@@ -63,7 +63,7 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
 
     The starter's current agent accepts the v0.8 operation list below. Keep the operation order and shapes when adding your own components; each list entry is sent as an individual A2A data part by the starter agent.
 
-    ```python title="agent/restaurant_finder/prompt_builder.py"
+    ```python title="agent/prompt_builder.py"
       RESTAURANT_UI_EXAMPLES = """
       ...
       ---BEGIN SINGLE_COLUMN_LIST_EXAMPLE---
@@ -153,32 +153,28 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
     ```tsx title="app/page.tsx"
     "use client";
 
-    import {
-      CopilotChat,
-      CopilotKitProvider,
-    } from "@copilotkit/react-core/v2";
-    import { a2uiV08Renderer } from "./components/a2ui-v0-8-renderer";
+    import { CopilotChat, CopilotKitProvider } from "@copilotkit/react-core/v2";
+    import { createA2UIMessageRenderer } from "@copilotkit/a2ui-renderer";
     import { theme } from "./theme";
 
     // Disable static optimization for this page
     export const dynamic = "force-dynamic";
 
-    const activityRenderers = [a2uiV08Renderer];
+    const A2UIMessageRenderer = createA2UIMessageRenderer({ theme });
+    const activityRenderers = [A2UIMessageRenderer];
 
     export default function Home() {
       return (
         <CopilotKitProvider
           runtimeUrl="/api/copilotkit"
           showDevConsole="auto"
-          useSingleEndpoint={false}
-          a2ui={{ theme }}
           renderActivityMessages={activityRenderers}
         >
           <main
             className="flex min-h-screen flex-1 flex-col overflow-hidden"
             style={{ minHeight: "100dvh" }}
           >
-            <CopilotChat />
+            <CopilotChat className="h-full" />
           </main>
         </CopilotKitProvider>
       );
@@ -186,7 +182,7 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
     ```
 
     ```tsx title="app/theme.ts"
-    import { Styles, type Types } from "@a2ui/lit/0.8";
+    import { v0_8 } from "@a2ui/lit";
 
     /** Elements */
 
@@ -331,27 +327,27 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
       "layout-el-cv": true,
     };
 
-    const aLight = Styles.merge(a, { "color-c-n5": true });
-    const inputLight = Styles.merge(input, { "color-c-n5": true });
-    const textareaLight = Styles.merge(textarea, { "color-c-n5": true });
-    const buttonLight = Styles.merge(button, { "color-c-n100": true });
-    const h1Light = Styles.merge(h1, { "color-c-n5": true });
-    const h2Light = Styles.merge(h2, { "color-c-n5": true });
-    const h3Light = Styles.merge(h3, { "color-c-n5": true });
-    const bodyLight = Styles.merge(body, { "color-c-n5": true });
-    const pLight = Styles.merge(p, { "color-c-n35": true });
-    const preLight = Styles.merge(pre, { "color-c-n35": true });
-    const orderedListLight = Styles.merge(orderedList, {
+    const aLight = v0_8.Styles.merge(a, { "color-c-n5": true });
+    const inputLight = v0_8.Styles.merge(input, { "color-c-n5": true });
+    const textareaLight = v0_8.Styles.merge(textarea, { "color-c-n5": true });
+    const buttonLight = v0_8.Styles.merge(button, { "color-c-n100": true });
+    const h1Light = v0_8.Styles.merge(h1, { "color-c-n5": true });
+    const h2Light = v0_8.Styles.merge(h2, { "color-c-n5": true });
+    const h3Light = v0_8.Styles.merge(h3, { "color-c-n5": true });
+    const bodyLight = v0_8.Styles.merge(body, { "color-c-n5": true });
+    const pLight = v0_8.Styles.merge(p, { "color-c-n35": true });
+    const preLight = v0_8.Styles.merge(pre, { "color-c-n35": true });
+    const orderedListLight = v0_8.Styles.merge(orderedList, {
       "color-c-n35": true,
     });
-    const unorderedListLight = Styles.merge(unorderedList, {
+    const unorderedListLight = v0_8.Styles.merge(unorderedList, {
       "color-c-n35": true,
     });
-    const listItemLight = Styles.merge(listItem, {
+    const listItemLight = v0_8.Styles.merge(listItem, {
       "color-c-n35": true,
     });
 
-    export const theme: Types.Theme = {
+    export const theme: v0_8.Types.Theme = {
       additionalStyles: {
         Button: {
           "--n-35": "var(--n-100)",

--- a/showcase/shell-docs/src/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx
@@ -148,31 +148,30 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
     AG-UI handles communicating with your a2a agent, and passes the a2ui messages back and forth as `ActivityMessage` objects.
     In order to render them in your frontend, you need to configure activity message rendering.
 
-    The cloned starter renders these messages with its local v0.8 renderer and theme. The setup below mirrors that current starter; the v0.9 renderer and `a2ui_operations` envelope are documented in the other A2UI integration guides.
+    The cloned starter renders these messages with the v0.8-compatible `@copilotkit/a2ui-renderer` package and its theme. The setup below mirrors the starter's current `app/page.tsx`; the v0.9 renderer and `a2ui_operations` envelope are documented in the other A2UI integration guides.
 
     ```tsx title="app/page.tsx"
     "use client";
 
     import { CopilotChat, CopilotKitProvider } from "@copilotkit/react-core/v2";
-    import { a2uiV08Renderer } from "./components/a2ui-v0-8-renderer";
+    import { createA2UIMessageRenderer } from "@copilotkit/a2ui-renderer";
     import { theme } from "./theme";
 
     // Disable static optimization for this page
     export const dynamic = "force-dynamic";
 
-    const activityRenderers = [a2uiV08Renderer];
+    const A2UIMessageRenderer = createA2UIMessageRenderer({ theme });
+    const activityRenderers = [A2UIMessageRenderer];
 
     export default function Home() {
       return (
         <CopilotKitProvider
           runtimeUrl="/api/copilotkit"
           showDevConsole="auto"
-          useSingleEndpoint={false}
-          a2ui={{ theme }}
           renderActivityMessages={activityRenderers}
         >
           <main
-            className="flex min-h-screen flex-1 flex-col overflow-hidden"
+            className="h-full overflow-auto w-screen"
             style={{ minHeight: "100dvh" }}
           >
             <CopilotChat className="h-full" />
@@ -183,7 +182,7 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
     ```
 
     ```tsx title="app/theme.ts"
-    import { Styles, type Types } from "@a2ui/lit/0.8";
+    import { v0_8 } from "@a2ui/lit";
 
     /** Elements */
 
@@ -328,27 +327,27 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
       "layout-el-cv": true,
     };
 
-    const aLight = Styles.merge(a, { "color-c-n5": true });
-    const inputLight = Styles.merge(input, { "color-c-n5": true });
-    const textareaLight = Styles.merge(textarea, { "color-c-n5": true });
-    const buttonLight = Styles.merge(button, { "color-c-n100": true });
-    const h1Light = Styles.merge(h1, { "color-c-n5": true });
-    const h2Light = Styles.merge(h2, { "color-c-n5": true });
-    const h3Light = Styles.merge(h3, { "color-c-n5": true });
-    const bodyLight = Styles.merge(body, { "color-c-n5": true });
-    const pLight = Styles.merge(p, { "color-c-n35": true });
-    const preLight = Styles.merge(pre, { "color-c-n35": true });
-    const orderedListLight = Styles.merge(orderedList, {
+    const aLight = v0_8.Styles.merge(a, { "color-c-n5": true });
+    const inputLight = v0_8.Styles.merge(input, { "color-c-n5": true });
+    const textareaLight = v0_8.Styles.merge(textarea, { "color-c-n5": true });
+    const buttonLight = v0_8.Styles.merge(button, { "color-c-n100": true });
+    const h1Light = v0_8.Styles.merge(h1, { "color-c-n5": true });
+    const h2Light = v0_8.Styles.merge(h2, { "color-c-n5": true });
+    const h3Light = v0_8.Styles.merge(h3, { "color-c-n5": true });
+    const bodyLight = v0_8.Styles.merge(body, { "color-c-n5": true });
+    const pLight = v0_8.Styles.merge(p, { "color-c-n35": true });
+    const preLight = v0_8.Styles.merge(pre, { "color-c-n35": true });
+    const orderedListLight = v0_8.Styles.merge(orderedList, {
       "color-c-n35": true,
     });
-    const unorderedListLight = Styles.merge(unorderedList, {
+    const unorderedListLight = v0_8.Styles.merge(unorderedList, {
       "color-c-n35": true,
     });
-    const listItemLight = Styles.merge(listItem, {
+    const listItemLight = v0_8.Styles.merge(listItem, {
       "color-c-n35": true,
     });
 
-    export const theme: Types.Theme = {
+    export const theme: v0_8.Types.Theme = {
       additionalStyles: {
         Button: {
           "--n-35": "var(--n-100)",

--- a/showcase/shell-docs/src/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx
@@ -127,6 +127,8 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
     In the example repo, all of the widgets are defined in a single variable in the prompt_builder.py file, but you can structure them however you like,
     they simply need to be injected into the agent's prompt in a clearly delineated way. The v0.9 SDK migration is not demonstrated by this starter page.
 
+    The button payload uses the v0.8 `action.name` field. The published renderer sends that value as `userAction.name`, while the current starter executor reads `userAction.actionName` before selecting its `book_restaurant` branch. As a result, the click reaches the agent but follows the executor's generic event path instead of the booking-specific path. Updating that starter field is outside this documentation-only change.
+
   </Step>
   <Step>
     ### Generating components with the A2UI Composer
@@ -251,6 +253,16 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
       "typography-sz-ts": true,
     };
 
+    const h4 = {
+      ...heading,
+      "typography-sz-bl": true,
+    };
+
+    const h5 = {
+      ...heading,
+      "typography-sz-bm": true,
+    };
+
     const iframe = {
       "behavior-sw-n": true,
     };
@@ -334,6 +346,8 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
     const h1Light = v0_8.Styles.merge(h1, { "color-c-n5": true });
     const h2Light = v0_8.Styles.merge(h2, { "color-c-n5": true });
     const h3Light = v0_8.Styles.merge(h3, { "color-c-n5": true });
+    const h4Light = v0_8.Styles.merge(h4, { "color-c-n5": true });
+    const h5Light = v0_8.Styles.merge(h5, { "color-c-n5": true });
     const bodyLight = v0_8.Styles.merge(body, { "color-c-n5": true });
     const pLight = v0_8.Styles.merge(p, { "color-c-n35": true });
     const preLight = v0_8.Styles.merge(pre, { "color-c-n35": true });
@@ -559,6 +573,8 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
         h1: h1Light,
         h2: h2Light,
         h3: h3Light,
+        h4: h4Light,
+        h5: h5Light,
         iframe,
         input: inputLight,
         p: pLight,
@@ -571,8 +587,8 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
         h1: [...Object.keys(h1Light)],
         h2: [...Object.keys(h2Light)],
         h3: [...Object.keys(h3Light)],
-        h4: [],
-        h5: [],
+        h4: [...Object.keys(h4Light)],
+        h5: [...Object.keys(h5Light)],
         h6: [],
         ul: [...Object.keys(unorderedListLight)],
         ol: [...Object.keys(orderedListLight)],
@@ -589,7 +605,7 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
     ### Give it a try!
 
     That's it! When your agent generates an A2UI message, it will be rendered in your frontend.
-    A2UI actions (like button clicks) are automatically sent back to your agent via AG-UI.
+    A2UI actions (like button clicks) are sent back to your agent via AG-UI. In the current starter, the renderer emits the button's action as `userAction.name`, but the executor checks `userAction.actionName`, so the documented `book_restaurant` button does not select the booking-specific branch until that starter mismatch is migrated.
 
   </Step>
 </Steps>

--- a/showcase/shell-docs/src/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx
@@ -148,26 +148,27 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
     AG-UI handles communicating with your a2a agent, and passes the a2ui messages back and forth as `ActivityMessage` objects.
     In order to render them in your frontend, you need to configure activity message rendering.
 
-    The cloned starter renders these messages with its v0.8 renderer and theme. The setup below mirrors the current starter; it is not a v0.9 `createA2UIMessageRenderer` walkthrough.
+    The cloned starter renders these messages with its local v0.8 renderer and theme. The setup below mirrors that current starter; the v0.9 renderer and `a2ui_operations` envelope are documented in the other A2UI integration guides.
 
     ```tsx title="app/page.tsx"
     "use client";
 
     import { CopilotChat, CopilotKitProvider } from "@copilotkit/react-core/v2";
-    import { createA2UIMessageRenderer } from "@copilotkit/a2ui-renderer";
+    import { a2uiV08Renderer } from "./components/a2ui-v0-8-renderer";
     import { theme } from "./theme";
 
     // Disable static optimization for this page
     export const dynamic = "force-dynamic";
 
-    const A2UIMessageRenderer = createA2UIMessageRenderer({ theme });
-    const activityRenderers = [A2UIMessageRenderer];
+    const activityRenderers = [a2uiV08Renderer];
 
     export default function Home() {
       return (
         <CopilotKitProvider
           runtimeUrl="/api/copilotkit"
           showDevConsole="auto"
+          useSingleEndpoint={false}
+          a2ui={{ theme }}
           renderActivityMessages={activityRenderers}
         >
           <main
@@ -182,7 +183,7 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
     ```
 
     ```tsx title="app/theme.ts"
-    import { v0_8 } from "@a2ui/lit";
+    import { Styles, type Types } from "@a2ui/lit/0.8";
 
     /** Elements */
 
@@ -327,27 +328,27 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
       "layout-el-cv": true,
     };
 
-    const aLight = v0_8.Styles.merge(a, { "color-c-n5": true });
-    const inputLight = v0_8.Styles.merge(input, { "color-c-n5": true });
-    const textareaLight = v0_8.Styles.merge(textarea, { "color-c-n5": true });
-    const buttonLight = v0_8.Styles.merge(button, { "color-c-n100": true });
-    const h1Light = v0_8.Styles.merge(h1, { "color-c-n5": true });
-    const h2Light = v0_8.Styles.merge(h2, { "color-c-n5": true });
-    const h3Light = v0_8.Styles.merge(h3, { "color-c-n5": true });
-    const bodyLight = v0_8.Styles.merge(body, { "color-c-n5": true });
-    const pLight = v0_8.Styles.merge(p, { "color-c-n35": true });
-    const preLight = v0_8.Styles.merge(pre, { "color-c-n35": true });
-    const orderedListLight = v0_8.Styles.merge(orderedList, {
+    const aLight = Styles.merge(a, { "color-c-n5": true });
+    const inputLight = Styles.merge(input, { "color-c-n5": true });
+    const textareaLight = Styles.merge(textarea, { "color-c-n5": true });
+    const buttonLight = Styles.merge(button, { "color-c-n100": true });
+    const h1Light = Styles.merge(h1, { "color-c-n5": true });
+    const h2Light = Styles.merge(h2, { "color-c-n5": true });
+    const h3Light = Styles.merge(h3, { "color-c-n5": true });
+    const bodyLight = Styles.merge(body, { "color-c-n5": true });
+    const pLight = Styles.merge(p, { "color-c-n35": true });
+    const preLight = Styles.merge(pre, { "color-c-n35": true });
+    const orderedListLight = Styles.merge(orderedList, {
       "color-c-n35": true,
     });
-    const unorderedListLight = v0_8.Styles.merge(unorderedList, {
+    const unorderedListLight = Styles.merge(unorderedList, {
       "color-c-n35": true,
     });
-    const listItemLight = v0_8.Styles.merge(listItem, {
+    const listItemLight = Styles.merge(listItem, {
       "color-c-n35": true,
     });
 
-    export const theme: v0_8.Types.Theme = {
+    export const theme: Types.Theme = {
       additionalStyles: {
         Button: {
           "--n-35": "var(--n-100)",

--- a/showcase/shell-docs/src/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx
@@ -33,7 +33,7 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
     git clone https://github.com/copilotkit/with-a2a-a2ui.git
     ```
 
-    The agent and application from the starter template are already configured to use A2UI, but details are included below for completeness.
+    The cloned starter currently ships a legacy v0.8 renderer. Replace that renderer with the v0.9 createA2UIMessageRenderer setup below before using the v0.9 operation example; the legacy renderer does not consume a2ui_operations.
 
   </Step>
   <Step>
@@ -61,7 +61,7 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
   <Step>
     ### Setting up your agent with components
 
-    The starter template is already configured to use A2UI, but lets look at how to add your own components.
+    After replacing the legacy renderer, use the v0.9 operation envelope below to add your own components.
 
     ```python title="agent/restaurant_finder/prompt_builder.py"
       RESTAURANT_UI_EXAMPLES = """
@@ -73,19 +73,34 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
           {{ "version": "v0.9", "updateComponents": {{
             "surfaceId": "default",
             "components": [
-            {{ "id": "root", "component": {{ "Column": {{ "children": {{ "explicitList": ["title-heading", "item-list"] }} }} }} }},
-            {{ "id": "title-heading", "component": {{ "Text": {{ "usageHint": "h1", "text": {{ "literalString": "Top Restaurants" }} }} }} }},
-            {{ "id": "item-list", "component": {{ "List": {{ "direction": "vertical", "children": {{ "template": {{ "componentId": "item-card-template", "dataBinding": "/items" }} }} }} }} }},
-            {{ "id": "item-card-template", "component": {{ "Card": {{ "child": "card-layout" }} }} }},
-            {{ "id": "card-layout", "component": {{ "Row": {{ "children": {{ "explicitList": ["template-image", "card-details"] }} }} }} }},
-            {{ "id": "template-image", weight: 1, "component": {{ "Image": {{ "url": {{ "path": "imageUrl" }} }} }} }},
-            {{ "id": "card-details", weight: 2, "component": {{ "Column": {{ "children": {{ "explicitList": ["template-name", "template-rating", "template-detail", "template-link", "template-book-button"] }} }} }} }},
-            {{ "id": "template-name", "component": {{ "Text": {{ "usageHint": "h3", "text": {{ "path": "name" }} }} }} }},
-            {{ "id": "template-rating", "component": {{ "Text": {{ "text": {{ "path": "rating" }} }} }} }},
-            {{ "id": "template-detail", "component": {{ "Text": {{ "text": {{ "path": "detail" }} }} }} }},
-            {{ "id": "template-link", "component": {{ "Text": {{ "text": {{ "path": "infoLink" }} }} }} }},
-            {{ "id": "template-book-button", "component": {{ "Button": {{ "child": "book-now-text", "primary": true, "action": {{ "name": "book_restaurant", "context": [ {{ "key": "restaurantName", "value": {{ "path": "name" }} }}, {{ "key": "imageUrl", "value": {{ "path": "imageUrl" }} }}, {{ "key": "address", "value": {{ "path": "address" }} }} ] }} }} }} }},
-            {{ "id": "book-now-text", "component": {{ "Text": {{ "text": {{ "literalString": "Book Now" }} }} }} }}
+              {{ "id": "root", "component": "Column", "children": ["title-heading", "item-list"] }},
+              {{ "id": "title-heading", "component": "Text", "text": "Top Restaurants", "variant": "h1" }},
+              {{ "id": "item-list", "component": "List", "direction": "vertical", "children": {{ "componentId": "item-card-template", "path": "/items" }} }},
+              {{ "id": "item-card-template", "component": "Card", "child": "card-layout" }},
+              {{ "id": "card-layout", "component": "Row", "children": ["template-image", "card-details"] }},
+              {{ "id": "template-image", "component": "Image", "url": {{ "path": "imageUrl" }} }},
+              {{ "id": "card-details", "component": "Column", "children": ["template-name", "template-rating", "template-detail", "template-link", "template-book-button"] }},
+              {{ "id": "template-name", "component": "Text", "text": {{ "path": "name" }}, "variant": "h3" }},
+              {{ "id": "template-rating", "component": "Text", "text": {{ "path": "rating" }}, "variant": "caption" }},
+              {{ "id": "template-detail", "component": "Text", "text": {{ "path": "detail" }}, "variant": "body" }},
+              {{ "id": "template-link", "component": "Text", "text": {{ "path": "infoLink" }}, "variant": "body" }},
+              {{
+                "id": "template-book-button",
+                "component": "Button",
+                "child": "book-now-text",
+                "variant": "primary",
+                "action": {{
+                  "event": {{
+                    "name": "book_restaurant",
+                    "context": {{
+                      "restaurantName": {{ "path": "name" }},
+                      "imageUrl": {{ "path": "imageUrl" }},
+                      "address": {{ "path": "address" }}
+                    }}
+                  }}
+                }}
+              }},
+              {{ "id": "book-now-text", "component": "Text", "text": "Book Now" }}
             ]
           }} }},
           {{ "version": "v0.9", "updateDataModel": {{
@@ -105,16 +120,16 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
       ```
 
     The widgets are injected into the agent's prompt, in this case using the `RESTAURANT_UI_EXAMPLES` variable.
-    Widgets are defined for the agent using examples of the json arrays they should output, wrapped in a comment block.
+    Widgets are defined for the agent using examples of the JSON objects they should output, wrapped in a comment block.
     - A comment indicating the start of the example
+    - a2ui_operations: The envelope containing the v0.9 operations
     - createSurface: Initializes the widget surface and must come first
     - updateComponents: An example of the JSON structure for the widget
     - updateDataModel: An example of the data that will populate the widget
-    - a2ui_operations: The envelope containing the v0.9 operations
     - A comment indicating the end of the example
 
-    In the example repo, all of the widgets are defined in a single variable int the prompt_builder.py file, but you can structure them however you like,
-    they simply need to be be injected into the agent's prompt in a clearly delineated way.
+    In the example repo, all of the widgets are defined in a single variable in the prompt_builder.py file, but you can structure them however you like,
+    they simply need to be injected into the agent's prompt in a clearly delineated way.
 
   </Step>
   <Step>
@@ -142,6 +157,13 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
     ```tsx title="app/page.tsx"
     "use client";
 
+    import {
+      CopilotChat,
+      CopilotKit,
+      createA2UIMessageRenderer,
+    } from "@copilotkit/react-core/v2";
+    import "@copilotkit/react-core/v2/styles.css";
+    import { theme } from "./theme";
 
     // Disable static optimization for this page
     export const dynamic = "force-dynamic";
@@ -319,27 +341,30 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
       "layout-el-cv": true,
     };
 
-    const aLight = v0_8.Styles.merge(a, { "color-c-n5": true });
-    const inputLight = v0_8.Styles.merge(input, { "color-c-n5": true });
-    const textareaLight = v0_8.Styles.merge(textarea, { "color-c-n5": true });
-    const buttonLight = v0_8.Styles.merge(button, { "color-c-n100": true });
-    const h1Light = v0_8.Styles.merge(h1, { "color-c-n5": true });
-    const h2Light = v0_8.Styles.merge(h2, { "color-c-n5": true });
-    const h3Light = v0_8.Styles.merge(h3, { "color-c-n5": true });
-    const bodyLight = v0_8.Styles.merge(body, { "color-c-n5": true });
-    const pLight = v0_8.Styles.merge(p, { "color-c-n35": true });
-    const preLight = v0_8.Styles.merge(pre, { "color-c-n35": true });
-    const orderedListLight = v0_8.Styles.merge(orderedList, {
+    const mergeStyles = (...styles: Record<string, boolean>[]) =>
+      Object.assign({}, ...styles);
+
+    const aLight = mergeStyles(a, { "color-c-n5": true });
+    const inputLight = mergeStyles(input, { "color-c-n5": true });
+    const textareaLight = mergeStyles(textarea, { "color-c-n5": true });
+    const buttonLight = mergeStyles(button, { "color-c-n100": true });
+    const h1Light = mergeStyles(h1, { "color-c-n5": true });
+    const h2Light = mergeStyles(h2, { "color-c-n5": true });
+    const h3Light = mergeStyles(h3, { "color-c-n5": true });
+    const bodyLight = mergeStyles(body, { "color-c-n5": true });
+    const pLight = mergeStyles(p, { "color-c-n35": true });
+    const preLight = mergeStyles(pre, { "color-c-n35": true });
+    const orderedListLight = mergeStyles(orderedList, {
       "color-c-n35": true,
     });
-    const unorderedListLight = v0_8.Styles.merge(unorderedList, {
+    const unorderedListLight = mergeStyles(unorderedList, {
       "color-c-n35": true,
     });
-    const listItemLight = v0_8.Styles.merge(listItem, {
+    const listItemLight = mergeStyles(listItem, {
       "color-c-n35": true,
     });
 
-    export const theme: v0_8.Types.Theme = {
+    export const theme: Record<string, unknown> = {
       additionalStyles: {
         Button: {
           "--n-35": "var(--n-100)",

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/advanced.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/advanced.mdx
@@ -117,32 +117,32 @@ As the secondary LLM generates the A2UI surface, the `parameters` object accumul
 | `components` | `array` | The component tree (schema) — arrives first |
 | `root` | `string` | Root component ID |
 | `items` | `array` | Data items — arrive after the schema |
-| `actionHandlers` | `object` | Optional button action handlers |
 
 A common pattern is to show a skeleton layout once `components` has data, then show item count as `items` streams in.
 
 ## Action Handlers
 
-Action handling in this section is client-side. The fixed-schema guide documents the current Python SDK limitation and the supported button context.
+Action handling in this section is client-side. The current Python SDK's `a2ui.render` does not support the `action_handlers=` keyword; the fixed-schema guide preserves the button schema and documents that server-side handlers are not supported. The current React API exposes `createA2UIMessageRenderer` with an `onAction` interceptor.
 
-The Python SDK's `a2ui.render` does not yet support the `action_handlers=` keyword. The frontend hook and custom orchestrator examples below remain available for client-side handling.
-
-This section covers the frontend-side APIs for custom handling, the resolution chain, and the schema button format.
+This section covers the current frontend interceptor and the v0.9 schema button format.
 
 ### Schema button with action context
 
-The A2UI schema defines buttons with action names and data-bound context fields. When the button is clicked, the context values are resolved from the data model for that specific item:
+The v0.9 A2UI schema defines buttons with an event and data-bound context fields. Components inside a repeating list use relative paths, so the context values resolve from the clicked item:
 
 ```json
 {
-  "Button": {
-    "label": "Book",
-    "action": {
+  "id": "book-button",
+  "component": "Button",
+  "child": "book-label",
+  "variant": "primary",
+  "action": {
+    "event": {
       "name": "book_flight",
-      "context": [
-        { "key": "flightNumber", "value": { "path": "/flightNumber" } },
-        { "key": "price", "value": { "path": "/price" } }
-      ]
+      "context": {
+        "flightNumber": { "path": "flightNumber" },
+        "price": { "path": "price" }
+      }
     }
   }
 }
@@ -160,79 +160,67 @@ The resulting `A2UIUserAction` will include the resolved context:
 }
 ```
 
-### `useA2UIActionHandler` hook (frontend)
+### `onAction` interceptor
 
-For custom frontend logic, register a handler with `useA2UIActionHandler`. Your handler receives every action and the pre-declared ops (if any), and decides whether to handle it:
-
-```tsx
-import { useA2UIActionHandler } from "@copilotkit/react-core/v2";
-
-// Handle a specific action with custom ops
-useA2UIActionHandler((action, declaredOps) => {
-  if (action.name === "book_flight") {
-    // Return custom operations
-    return [
-      { updateComponents: { surfaceId: action.surfaceId, components: mySchema } },
-    ];
-  }
-  return null; // skip — let other handlers or fallback try
-});
-
-// Delegate to pre-declared ops from the agent
-useA2UIActionHandler((action, declaredOps) => {
-  if (action.name === "book_flight") return declaredOps;
-  return null;
-});
-
-// Handle all actions on a specific surface
-useA2UIActionHandler((action, declaredOps) => {
-  if (action.surfaceId === "my-surface") return declaredOps;
-  return null;
-});
-```
-
-### Resolution order
-
-The default orchestrator resolves actions in this order:
-
-1. **Hook handlers** — registered via `useA2UIActionHandler`. Each receives `(action, declaredOps)`. The first handler that returns a non-empty operations array wins.
-2. **Pre-declared ops** — if no hook handles the action, uses operations already present in the supported payload.
-
-The current Python SDK does not create pre-declared operations from an `action_handlers=` argument. Use the frontend hook for custom handling.
-
-### Custom orchestrator (full control)
-
-To completely replace the resolution logic, pass a custom `onAction` to `createA2UIMessageRenderer`:
+Pass `onAction` to the exported renderer factory to handle an action in the browser. Return `null` after handling the action locally; return `undefined` to forward it unchanged to the agent:
 
 ```tsx
 import {
   createA2UIMessageRenderer,
-  resolveDeclaredOps,
+  type A2UIUserAction,
 } from "@copilotkit/react-core/v2";
+import { theme } from "./theme";
 
-const activityRenderers = [
-  createA2UIMessageRenderer({
-    theme,
-    onAction: (action, handlers, declaredHandlers) => {
-      // Custom dispatch logic — you control everything
-      const declaredOps = resolveDeclaredOps(action, declaredHandlers);
-
-      // Example: always use declared ops, ignore hooks
-      return declaredOps;
-    },
-  }),
-];
+const A2UIMessageRenderer = createA2UIMessageRenderer({
+  theme,
+  onAction: (action: A2UIUserAction) => {
+    if (action.name === "book_flight") {
+      console.info("Booking requested", action.context);
+      return null;
+    }
+    return undefined;
+  },
+});
 ```
+
+Register `A2UIMessageRenderer` in the provider's `renderActivityMessages` list, as shown in the integration setup pages.
+
+### Forward a modified action
+
+An interceptor can return a modified exported `A2UIUserAction`; the renderer forwards that action to the agent:
+
+```tsx
+const A2UIMessageRenderer = createA2UIMessageRenderer({
+  theme,
+  onAction: (action) => {
+    if (action.name !== "book_flight") return;
+
+    return {
+      ...action,
+      context: {
+        ...(action.context ?? {}),
+        source: "a2ui",
+      },
+    };
+  },
+});
+```
+
+### Current action flow
+
+The current renderer applies `onAction` before forwarding an action:
+
+1. Returning `null` handles the action in the browser and skips the agent.
+2. Returning an `A2UIUserAction` forwards that modified action.
+3. Returning `undefined` forwards the original action.
+
+The current Python SDK does not create server-side action handlers from an `action_handlers=` argument. The frontend interceptor is the supported custom-handling path in this documentation.
 
 ### Types reference
 
 | Type | Description |
 |---|---|
 | `A2UIUserAction` | Dispatched action: `{ name, surfaceId, sourceComponentId, context?, dataContextPath? }` |
-| `A2UIOps` | `Array<Record<string, unknown>>` — array of A2UI operations |
-| `A2UIDeclaredOps` | `A2UIOps \| null` — resolved pre-declared ops, or null if no match |
-| `A2UIActionHandler` | `(action: A2UIUserAction, declaredOps: A2UIDeclaredOps) => A2UIOps \| null` |
-| `A2UIActionOrchestrator` | `(action, handlers, declaredHandlers) => A2UIOps \| null` — full control |
-| `resolveDeclaredOps` | Helper: resolves exact match or `"*"` catch-all from declared handlers map |
-| `defaultActionOrchestrator` | The built-in orchestrator — hooks first, then declared fallback |
+| `A2UIActionInterceptor` | `(action, forward) => A2UIUserAction \| null \| void` — exported interceptor type |
+| `createA2UIMessageRenderer` | Exported factory that accepts `theme` and optional `onAction` |
 

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/advanced.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/advanced.mdx
@@ -123,7 +123,7 @@ A common pattern is to show a skeleton layout once `components` has data, then s
 
 ## Action Handlers
 
-Each A2UI approach has its own way to declare action handlers on the agent side — see the individual guides for [Fixed Schema](./fixed-schema#adding-interactivity-action-handlers), [Streaming](./fixed-schema-streaming#adding-interactivity-action-handlers), and [Dynamic Schema](./dynamic-schema#action-handlers-in-dynamic-schemas).
+Action handling in this section is client-side. The fixed-schema guide documents the current Python SDK limitation and the supported button context.
 
 The Python SDK's `a2ui.render` does not yet support the `action_handlers=` keyword. The frontend hook and custom orchestrator examples below remain available for client-side handling.
 
@@ -172,7 +172,6 @@ useA2UIActionHandler((action, declaredOps) => {
   if (action.name === "book_flight") {
     // Return custom operations
     return [
-      { createSurface: { surfaceId: action.surfaceId, catalogId: "https://a2ui.org/specification/v0_9/basic_catalog.json" } },
       { updateComponents: { surfaceId: action.surfaceId, components: mySchema } },
     ];
   }
@@ -197,9 +196,9 @@ useA2UIActionHandler((action, declaredOps) => {
 The default orchestrator resolves actions in this order:
 
 1. **Hook handlers** — registered via `useA2UIActionHandler`. Each receives `(action, declaredOps)`. The first handler that returns a non-empty operations array wins.
-2. **Pre-declared ops** — if no hook handles the action, falls back to the agent's `action_handlers` (exact name match first, then `"*"` catch-all).
+2. **Pre-declared ops** — if no hook handles the action, uses operations already present in the supported payload.
 
-This means pre-declared ops work out of the box, and hooks can override or extend them when needed.
+The current Python SDK does not create pre-declared operations from an `action_handlers=` argument. Use the frontend hook for custom handling.
 
 ### Custom orchestrator (full control)
 

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/advanced.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/advanced.mdx
@@ -154,7 +154,8 @@ The resulting `A2UIUserAction` will include the resolved context:
 {
   name: "book_flight",
   surfaceId: "flight-search-results",
-  sourceComponentId: "button-123",
+  sourceComponentId: "book-button",
+  timestamp: "2025-01-01T00:00:00.000Z",
   context: { flightNumber: "AA100", price: "$350" },
   dataContextPath: "/flights/0",
 }
@@ -220,7 +221,7 @@ The current Python SDK does not create server-side action handlers from an `acti
 
 | Type | Description |
 |---|---|
-| `A2UIUserAction` | Dispatched action: `{ name, surfaceId, sourceComponentId, context?, dataContextPath? }` |
-| `A2UIActionInterceptor` | `(action, forward) => A2UIUserAction \| null \| void` — exported interceptor type |
+| `A2UIUserAction` | Dispatched action: `{ name, surfaceId, sourceComponentId, timestamp, context?, dataContextPath? }` |
+| `A2UIActionInterceptor` | `(action, forward) => A2UIUserAction \| null \| void \| Promise<void \| A2UIUserAction \| null>` — exported interceptor type |
 | `createA2UIMessageRenderer` | Exported factory that accepts `theme` and optional `onAction` |
 

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/advanced.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/advanced.mdx
@@ -157,7 +157,6 @@ The resulting `A2UIUserAction` will include the resolved context:
   sourceComponentId: "book-button",
   timestamp: "2025-01-01T00:00:00.000Z",
   context: { flightNumber: "AA100", price: "$350" },
-  dataContextPath: "/flights/0",
 }
 ```
 
@@ -184,7 +183,7 @@ const A2UIMessageRenderer = createA2UIMessageRenderer({
 });
 ```
 
-Register `A2UIMessageRenderer` in the provider's `renderActivityMessages` list, as shown in the integration setup pages.
+Pass the returned renderer through the provider's `renderActivityMessages` prop when you need this custom `onAction` behavior. User-provided renderers take precedence over the provider's built-in A2UI renderer.
 
 ### Forward a modified action
 

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/advanced.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/advanced.mdx
@@ -125,6 +125,8 @@ A common pattern is to show a skeleton layout once `components` has data, then s
 
 Each A2UI approach has its own way to declare action handlers on the agent side — see the individual guides for [Fixed Schema](./fixed-schema#adding-interactivity-action-handlers), [Streaming](./fixed-schema-streaming#adding-interactivity-action-handlers), and [Dynamic Schema](./dynamic-schema#action-handlers-in-dynamic-schemas).
 
+The Python SDK's `a2ui.render` does not yet support the `action_handlers=` keyword. The frontend hook and custom orchestrator examples below remain available for client-side handling.
+
 This section covers the frontend-side APIs for custom handling, the resolution chain, and the schema button format.
 
 ### Schema button with action context
@@ -170,8 +172,8 @@ useA2UIActionHandler((action, declaredOps) => {
   if (action.name === "book_flight") {
     // Return custom operations
     return [
-      { surfaceUpdate: { surfaceId: action.surfaceId, components: mySchema } },
-      { beginRendering: { surfaceId: action.surfaceId, root: "root" } },
+      { createSurface: { surfaceId: action.surfaceId, catalogId: "https://a2ui.org/specification/v0_9/basic_catalog.json" } },
+      { updateComponents: { surfaceId: action.surfaceId, components: mySchema } },
     ];
   }
   return null; // skip — let other handlers or fallback try

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/advanced.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/advanced.mdx
@@ -214,13 +214,13 @@ The current renderer applies `onAction` before forwarding an action:
 2. Returning an `A2UIUserAction` forwards that modified action.
 3. Returning `undefined` forwards the original action.
 
-The current Python SDK does not create server-side action handlers from an `action_handlers=` argument. The frontend interceptor is the supported custom-handling path in this documentation.
+The current Python SDK does not create server-side action handlers from an `action_handlers=` argument. The frontend interceptor is the supported custom-handling path in this documentation. The current React bridge does not include `dataContextPath` in the action passed to `onAction`; use `context` for values needed by the callback.
 
 ### Types reference
 
 | Type | Description |
 |---|---|
-| `A2UIUserAction` | Dispatched action: `{ name, surfaceId, sourceComponentId, timestamp, context?, dataContextPath? }` |
+| `A2UIUserAction` | Dispatched action: `{ name, surfaceId, sourceComponentId, timestamp, context? }` |
 | `A2UIActionInterceptor` | `(action, forward) => A2UIUserAction \| null \| void \| Promise<void \| A2UIUserAction \| null>` — exported interceptor type |
 | `createA2UIMessageRenderer` | Exported factory that accepts `theme` and optional `onAction` |
 

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/dynamic-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/dynamic-schema.mdx
@@ -63,8 +63,8 @@ The secondary LLM's `render_a2ui` tool call streams through LangGraph as `TOOL_C
 
 1. Extracts the `components` array as it streams — waits for the full schema before rendering
 2. Extracts `surfaceId` and `root` from the partial JSON
-3. Once the schema is complete, emits `surfaceUpdate` + `beginRendering`
-4. Extracts complete `items` objects progressively and emits `dataModelUpdate` for each
+3. Once the schema is complete, emits `createSurface` + `updateComponents`
+4. Extracts complete `items` objects progressively and emits `updateDataModel` for each
 5. Cards appear one by one as data streams in
 
 ## Built-in progress indicator

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/fixed-schema.mdx
@@ -52,10 +52,6 @@ SURFACE_ID = "flight-search-results"
 FLIGHT_SCHEMA = a2ui.load_schema(
     Path(__file__).parent / "a2ui" / "schemas" / "flight_schema.json"
 )
-BOOKED_SCHEMA = a2ui.load_schema(
-    Path(__file__).parent / "a2ui" / "schemas" / "booked_schema.json"
-)
-
 @tool
 def search_flights(flights: list[Flight]) -> str:
     """Search for flights and display results as rich cards."""
@@ -106,7 +102,7 @@ const runtime = new CopilotRuntime({
 
 ## Action handler details
 
-The `action_handlers` option is reserved for future Python SDK support. The button schema can still define the action context used by frontend handlers. Here's how the schema side looks:
+The current Python SDK does not support the `action_handlers=` option. The button schema can still define the action context used by frontend handlers. Here's how the schema side looks:
 
 ### Button with action context
 

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/fixed-schema.mdx
@@ -110,14 +110,17 @@ In your `flight_schema.json`, buttons declare an `action` with data-bound contex
 
 ```json
 {
-  "Button": {
-    "label": "Book",
-    "action": {
+  "id": "book-button",
+  "component": "Button",
+  "child": "book-label",
+  "variant": "primary",
+  "action": {
+    "event": {
       "name": "book_flight",
-      "context": [
-        { "key": "flightNumber", "value": { "path": "/flightNumber" } },
-        { "key": "price", "value": { "path": "/price" } }
-      ]
+      "context": {
+        "flightNumber": { "path": "flightNumber" },
+        "price": { "path": "price" }
+      }
     }
   }
 }
@@ -126,5 +129,5 @@ In your `flight_schema.json`, buttons declare an `action` with data-bound contex
 When this button is clicked on a card showing flight AA100 at $350, frontend action handling receives `context: { flightNumber: "AA100", price: "$350" }`. The Python `action_handlers=` path is not yet supported.
 
 <Callout type="info">
-For custom frontend handling with `useA2UIActionHandler`, custom orchestrators, and the full resolution chain, see the [Advanced — Action Handlers](./advanced#action-handlers) guide.
+For custom frontend handling with `createA2UIMessageRenderer` and its `onAction` option, see the [Advanced — Action Handlers](./advanced#action-handlers) guide.
 </Callout>

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/fixed-schema.mdx
@@ -8,7 +8,7 @@ In the fixed-schema approach, you design the UI schema once (in a JSON file or u
 
 1. Schema is loaded from a JSON file at startup
 2. Agent tool receives data from the LLM (e.g., flight search results)
-3. Tool returns `a2ui.render()` with surfaceUpdate + dataModelUpdate + beginRendering
+3. Tool returns `a2ui.render()` with createSurface + updateComponents + updateDataModel
 4. The A2UI middleware intercepts the tool result and renders the surface
 
 ## Implementation
@@ -61,34 +61,17 @@ def search_flights(flights: list[Flight]) -> str:
     """Search for flights and display results as rich cards."""
     return a2ui.render(
         operations=[
-            a2ui.surface_update(SURFACE_ID, FLIGHT_SCHEMA),
-            a2ui.data_model_update(SURFACE_ID, {"flights": flights}),
-            a2ui.begin_rendering(SURFACE_ID, "root"),
+            a2ui.create_surface(SURFACE_ID),
+            a2ui.update_components(SURFACE_ID, FLIGHT_SCHEMA),
+            a2ui.update_data_model(SURFACE_ID, {"flights": flights}),
         ],
-        action_handlers={
-            # Exact match: fires when a button with action.name="book_flight" is clicked
-            "book_flight": [
-                a2ui.surface_update(SURFACE_ID, BOOKED_SCHEMA),
-                a2ui.data_model_update(SURFACE_ID, {
-                    "title": "Booking Confirmed",
-                    "detail": "Your flight has been booked.",
-                }),
-                a2ui.begin_rendering(SURFACE_ID, "root"),
-            ],
-            # Catch-all: fires for any button action without a specific match
-            "*": [
-                a2ui.data_model_update(SURFACE_ID, {
-                    "status": "Action received",
-                }),
-            ],
-        },
     )
 ```
 
 Key points:
 - The `Flight` TypedDict is essential — LangChain serializes it into the tool's JSON schema, which is what the LLM sees when deciding what data to generate.
-- `action_handlers` declares optimistic UI responses. When a user clicks a button, the matching handler replaces the surface instantly — no round-trip to the server.
-- `"book_flight"` matches the `action.name` from the schema button. `"*"` is a catch-all for any unmatched action.
+- The Python SDK's `a2ui.render` does not yet support the `action_handlers=` keyword, so the example keeps the button schema but does not declare server-side handlers. Button clicks are currently inert.
+- `"book_flight"` is the action name used by the schema button and can be handled with the frontend APIs in the [Advanced — Action Handlers](./advanced#action-handlers) guide.
 </Step>
 
 <Step>
@@ -123,7 +106,7 @@ const runtime = new CopilotRuntime({
 
 ## Action handler details
 
-The `action_handlers` in the example above work together with buttons defined in the A2UI schema. Here's how the schema side looks:
+The `action_handlers` option is reserved for future Python SDK support. The button schema can still define the action context used by frontend handlers. Here's how the schema side looks:
 
 ### Button with action context
 
@@ -144,7 +127,7 @@ In your `flight_schema.json`, buttons declare an `action` with data-bound contex
 }
 ```
 
-When this button is clicked on a card showing flight AA100 at $350, the `"book_flight"` handler fires with `context: { flightNumber: "AA100", price: "$350" }`, and the surface instantly replaces with the booking confirmation.
+When this button is clicked on a card showing flight AA100 at $350, frontend action handling receives `context: { flightNumber: "AA100", price: "$350" }`. The Python `action_handlers=` path is not yet supported.
 
 <Callout type="info">
 For custom frontend handling with `useA2UIActionHandler`, custom orchestrators, and the full resolution chain, see the [Advanced — Action Handlers](./advanced#action-handlers) guide.

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/fixed-schema.mdx
@@ -52,6 +52,8 @@ SURFACE_ID = "flight-search-results"
 FLIGHT_SCHEMA = a2ui.load_schema(
     Path(__file__).parent / "a2ui" / "schemas" / "flight_schema.json"
 )
+
+
 @tool
 def search_flights(flights: list[Flight]) -> str:
     """Search for flights and display results as rich cards."""
@@ -66,7 +68,7 @@ def search_flights(flights: list[Flight]) -> str:
 
 Key points:
 - The `Flight` TypedDict is essential — LangChain serializes it into the tool's JSON schema, which is what the LLM sees when deciding what data to generate.
-- The Python SDK's `a2ui.render` does not yet support the `action_handlers=` keyword, so the example keeps the button schema but does not declare server-side handlers. Button clicks are currently inert.
+- The Python SDK's `a2ui.render` does not yet support the `action_handlers=` keyword, so the example keeps the button schema but does not declare server-side handlers. Button clicks are forwarded to the agent, but this example has no server-side handler for them.
 - `"book_flight"` is the action name used by the schema button and can be handled with the frontend APIs in the [Advanced — Action Handlers](./advanced#action-handlers) guide.
 </Step>
 

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/index.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/index.mdx
@@ -57,21 +57,21 @@ All three approaches use the same A2UI protocol and renderer. The difference is 
 
 ## How it works
 
-Every A2UI surface is built from three operations:
+Every A2UI v0.9 surface is built from three operations:
 
-1. **`surfaceUpdate`** — defines the component tree (the schema)
-2. **`dataModelUpdate`** — provides the data that populates the components
-3. **`beginRendering`** — tells the client to start rendering
+1. **`createSurface`** — initializes the surface with its catalog (must come first)
+2. **`updateComponents`** — defines the component tree (the schema)
+3. **`updateDataModel`** — provides the data that populates the components
 
 The CopilotKit Python SDK provides helpers to build these operations:
 
 ```python
 from copilotkit import a2ui
 
-a2ui.surface_update(surface_id, components)
-a2ui.data_model_update(surface_id, {"items": data})
-a2ui.begin_rendering(surface_id, root_id)
-a2ui.render(operations)  # wraps and serializes
+a2ui.create_surface(surface_id)
+a2ui.update_components(surface_id, components)
+a2ui.update_data_model(surface_id, {"items": data})
+a2ui.render(operations)  # wraps in a2ui_operations and serializes
 ```
 
 Continue to one of the approach guides above to see the full implementation.

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/advanced.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/advanced.mdx
@@ -117,32 +117,32 @@ As the secondary LLM generates the A2UI surface, the `parameters` object accumul
 | `components` | `array` | The component tree (schema) — arrives first |
 | `root` | `string` | Root component ID |
 | `items` | `array` | Data items — arrive after the schema |
-| `actionHandlers` | `object` | Optional button action handlers |
 
 A common pattern is to show a skeleton layout once `components` has data, then show item count as `items` streams in.
 
 ## Action Handlers
 
-Action handling in this section is client-side. The fixed-schema guide documents the current Python SDK limitation and the supported button context.
+Action handling in this section is client-side. The current Python SDK's `a2ui.render` does not support the `action_handlers=` keyword; the fixed-schema guide preserves the button schema and documents that server-side handlers are not supported. The current React API exposes `createA2UIMessageRenderer` with an `onAction` interceptor.
 
-The Python SDK's `a2ui.render` does not yet support the `action_handlers=` keyword. The frontend hook and custom orchestrator examples below remain available for client-side handling.
-
-This section covers the frontend-side APIs for custom handling, the resolution chain, and the schema button format.
+This section covers the current frontend interceptor and the v0.9 schema button format.
 
 ### Schema button with action context
 
-The A2UI schema defines buttons with action names and data-bound context fields. When the button is clicked, the context values are resolved from the data model for that specific item:
+The v0.9 A2UI schema defines buttons with an event and data-bound context fields. Components inside a repeating list use relative paths, so the context values resolve from the clicked item:
 
 ```json
 {
-  "Button": {
-    "label": "Book",
-    "action": {
+  "id": "book-button",
+  "component": "Button",
+  "child": "book-label",
+  "variant": "primary",
+  "action": {
+    "event": {
       "name": "book_flight",
-      "context": [
-        { "key": "flightNumber", "value": { "path": "/flightNumber" } },
-        { "key": "price", "value": { "path": "/price" } }
-      ]
+      "context": {
+        "flightNumber": { "path": "flightNumber" },
+        "price": { "path": "price" }
+      }
     }
   }
 }
@@ -160,79 +160,67 @@ The resulting `A2UIUserAction` will include the resolved context:
 }
 ```
 
-### `useA2UIActionHandler` hook (frontend)
+### `onAction` interceptor
 
-For custom frontend logic, register a handler with `useA2UIActionHandler`. Your handler receives every action and the pre-declared ops (if any), and decides whether to handle it:
-
-```tsx
-import { useA2UIActionHandler } from "@copilotkit/react-core/v2";
-
-// Handle a specific action with custom ops
-useA2UIActionHandler((action, declaredOps) => {
-  if (action.name === "book_flight") {
-    // Return custom operations
-    return [
-      { updateComponents: { surfaceId: action.surfaceId, components: mySchema } },
-    ];
-  }
-  return null; // skip — let other handlers or fallback try
-});
-
-// Delegate to pre-declared ops from the agent
-useA2UIActionHandler((action, declaredOps) => {
-  if (action.name === "book_flight") return declaredOps;
-  return null;
-});
-
-// Handle all actions on a specific surface
-useA2UIActionHandler((action, declaredOps) => {
-  if (action.surfaceId === "my-surface") return declaredOps;
-  return null;
-});
-```
-
-### Resolution order
-
-The default orchestrator resolves actions in this order:
-
-1. **Hook handlers** — registered via `useA2UIActionHandler`. Each receives `(action, declaredOps)`. The first handler that returns a non-empty operations array wins.
-2. **Pre-declared ops** — if no hook handles the action, uses operations already present in the supported payload.
-
-The current Python SDK does not create pre-declared operations from an `action_handlers=` argument. Use the frontend hook for custom handling.
-
-### Custom orchestrator (full control)
-
-To completely replace the resolution logic, pass a custom `onAction` to `createA2UIMessageRenderer`:
+Pass `onAction` to the exported renderer factory to handle an action in the browser. Return `null` after handling the action locally; return `undefined` to forward it unchanged to the agent:
 
 ```tsx
 import {
   createA2UIMessageRenderer,
-  resolveDeclaredOps,
+  type A2UIUserAction,
 } from "@copilotkit/react-core/v2";
+import { theme } from "./theme";
 
-const activityRenderers = [
-  createA2UIMessageRenderer({
-    theme,
-    onAction: (action, handlers, declaredHandlers) => {
-      // Custom dispatch logic — you control everything
-      const declaredOps = resolveDeclaredOps(action, declaredHandlers);
-
-      // Example: always use declared ops, ignore hooks
-      return declaredOps;
-    },
-  }),
-];
+const A2UIMessageRenderer = createA2UIMessageRenderer({
+  theme,
+  onAction: (action: A2UIUserAction) => {
+    if (action.name === "book_flight") {
+      console.info("Booking requested", action.context);
+      return null;
+    }
+    return undefined;
+  },
+});
 ```
+
+Register `A2UIMessageRenderer` in the provider's `renderActivityMessages` list, as shown in the integration setup pages.
+
+### Forward a modified action
+
+An interceptor can return a modified exported `A2UIUserAction`; the renderer forwards that action to the agent:
+
+```tsx
+const A2UIMessageRenderer = createA2UIMessageRenderer({
+  theme,
+  onAction: (action) => {
+    if (action.name !== "book_flight") return;
+
+    return {
+      ...action,
+      context: {
+        ...(action.context ?? {}),
+        source: "a2ui",
+      },
+    };
+  },
+});
+```
+
+### Current action flow
+
+The current renderer applies `onAction` before forwarding an action:
+
+1. Returning `null` handles the action in the browser and skips the agent.
+2. Returning an `A2UIUserAction` forwards that modified action.
+3. Returning `undefined` forwards the original action.
+
+The current Python SDK does not create server-side action handlers from an `action_handlers=` argument. The frontend interceptor is the supported custom-handling path in this documentation.
 
 ### Types reference
 
 | Type | Description |
 |---|---|
 | `A2UIUserAction` | Dispatched action: `{ name, surfaceId, sourceComponentId, context?, dataContextPath? }` |
-| `A2UIOps` | `Array<Record<string, unknown>>` — array of A2UI operations |
-| `A2UIDeclaredOps` | `A2UIOps \| null` — resolved pre-declared ops, or null if no match |
-| `A2UIActionHandler` | `(action: A2UIUserAction, declaredOps: A2UIDeclaredOps) => A2UIOps \| null` |
-| `A2UIActionOrchestrator` | `(action, handlers, declaredHandlers) => A2UIOps \| null` — full control |
-| `resolveDeclaredOps` | Helper: resolves exact match or `"*"` catch-all from declared handlers map |
-| `defaultActionOrchestrator` | The built-in orchestrator — hooks first, then declared fallback |
+| `A2UIActionInterceptor` | `(action, forward) => A2UIUserAction \| null \| void` — exported interceptor type |
+| `createA2UIMessageRenderer` | Exported factory that accepts `theme` and optional `onAction` |
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/advanced.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/advanced.mdx
@@ -123,7 +123,7 @@ A common pattern is to show a skeleton layout once `components` has data, then s
 
 ## Action Handlers
 
-Each A2UI approach has its own way to declare action handlers on the agent side — see the individual guides for [Fixed Schema](./fixed-schema#adding-interactivity-action-handlers), [Streaming](./fixed-schema-streaming#adding-interactivity-action-handlers), and [Dynamic Schema](./dynamic-schema#action-handlers-in-dynamic-schemas).
+Action handling in this section is client-side. The fixed-schema guide documents the current Python SDK limitation and the supported button context.
 
 The Python SDK's `a2ui.render` does not yet support the `action_handlers=` keyword. The frontend hook and custom orchestrator examples below remain available for client-side handling.
 
@@ -172,7 +172,6 @@ useA2UIActionHandler((action, declaredOps) => {
   if (action.name === "book_flight") {
     // Return custom operations
     return [
-      { createSurface: { surfaceId: action.surfaceId, catalogId: "https://a2ui.org/specification/v0_9/basic_catalog.json" } },
       { updateComponents: { surfaceId: action.surfaceId, components: mySchema } },
     ];
   }
@@ -197,9 +196,9 @@ useA2UIActionHandler((action, declaredOps) => {
 The default orchestrator resolves actions in this order:
 
 1. **Hook handlers** — registered via `useA2UIActionHandler`. Each receives `(action, declaredOps)`. The first handler that returns a non-empty operations array wins.
-2. **Pre-declared ops** — if no hook handles the action, falls back to the agent's `action_handlers` (exact name match first, then `"*"` catch-all).
+2. **Pre-declared ops** — if no hook handles the action, uses operations already present in the supported payload.
 
-This means pre-declared ops work out of the box, and hooks can override or extend them when needed.
+The current Python SDK does not create pre-declared operations from an `action_handlers=` argument. Use the frontend hook for custom handling.
 
 ### Custom orchestrator (full control)
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/advanced.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/advanced.mdx
@@ -154,7 +154,8 @@ The resulting `A2UIUserAction` will include the resolved context:
 {
   name: "book_flight",
   surfaceId: "flight-search-results",
-  sourceComponentId: "button-123",
+  sourceComponentId: "book-button",
+  timestamp: "2025-01-01T00:00:00.000Z",
   context: { flightNumber: "AA100", price: "$350" },
   dataContextPath: "/flights/0",
 }
@@ -220,7 +221,7 @@ The current Python SDK does not create server-side action handlers from an `acti
 
 | Type | Description |
 |---|---|
-| `A2UIUserAction` | Dispatched action: `{ name, surfaceId, sourceComponentId, context?, dataContextPath? }` |
-| `A2UIActionInterceptor` | `(action, forward) => A2UIUserAction \| null \| void` — exported interceptor type |
+| `A2UIUserAction` | Dispatched action: `{ name, surfaceId, sourceComponentId, timestamp, context?, dataContextPath? }` |
+| `A2UIActionInterceptor` | `(action, forward) => A2UIUserAction \| null \| void \| Promise<void \| A2UIUserAction \| null>` — exported interceptor type |
 | `createA2UIMessageRenderer` | Exported factory that accepts `theme` and optional `onAction` |
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/advanced.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/advanced.mdx
@@ -157,7 +157,6 @@ The resulting `A2UIUserAction` will include the resolved context:
   sourceComponentId: "book-button",
   timestamp: "2025-01-01T00:00:00.000Z",
   context: { flightNumber: "AA100", price: "$350" },
-  dataContextPath: "/flights/0",
 }
 ```
 
@@ -184,7 +183,7 @@ const A2UIMessageRenderer = createA2UIMessageRenderer({
 });
 ```
 
-Register `A2UIMessageRenderer` in the provider's `renderActivityMessages` list, as shown in the integration setup pages.
+Pass the returned renderer through the provider's `renderActivityMessages` prop when you need this custom `onAction` behavior. User-provided renderers take precedence over the provider's built-in A2UI renderer.
 
 ### Forward a modified action
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/advanced.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/advanced.mdx
@@ -125,6 +125,8 @@ A common pattern is to show a skeleton layout once `components` has data, then s
 
 Each A2UI approach has its own way to declare action handlers on the agent side — see the individual guides for [Fixed Schema](./fixed-schema#adding-interactivity-action-handlers), [Streaming](./fixed-schema-streaming#adding-interactivity-action-handlers), and [Dynamic Schema](./dynamic-schema#action-handlers-in-dynamic-schemas).
 
+The Python SDK's `a2ui.render` does not yet support the `action_handlers=` keyword. The frontend hook and custom orchestrator examples below remain available for client-side handling.
+
 This section covers the frontend-side APIs for custom handling, the resolution chain, and the schema button format.
 
 ### Schema button with action context

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/advanced.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/advanced.mdx
@@ -214,13 +214,13 @@ The current renderer applies `onAction` before forwarding an action:
 2. Returning an `A2UIUserAction` forwards that modified action.
 3. Returning `undefined` forwards the original action.
 
-The current Python SDK does not create server-side action handlers from an `action_handlers=` argument. The frontend interceptor is the supported custom-handling path in this documentation.
+The current Python SDK does not create server-side action handlers from an `action_handlers=` argument. The frontend interceptor is the supported custom-handling path in this documentation. The current React bridge does not include `dataContextPath` in the action passed to `onAction`; use `context` for values needed by the callback.
 
 ### Types reference
 
 | Type | Description |
 |---|---|
-| `A2UIUserAction` | Dispatched action: `{ name, surfaceId, sourceComponentId, timestamp, context?, dataContextPath? }` |
+| `A2UIUserAction` | Dispatched action: `{ name, surfaceId, sourceComponentId, timestamp, context? }` |
 | `A2UIActionInterceptor` | `(action, forward) => A2UIUserAction \| null \| void \| Promise<void \| A2UIUserAction \| null>` — exported interceptor type |
 | `createA2UIMessageRenderer` | Exported factory that accepts `theme` and optional `onAction` |
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx
@@ -52,6 +52,8 @@ SURFACE_ID = "flight-search-results"
 FLIGHT_SCHEMA = a2ui.load_schema(
     Path(__file__).parent / "a2ui" / "schemas" / "flight_schema.json"
 )
+
+
 @tool
 def search_flights(flights: list[Flight]) -> str:
     """Search for flights and display results as rich cards."""
@@ -66,7 +68,7 @@ def search_flights(flights: list[Flight]) -> str:
 
 Key points:
 - The `Flight` TypedDict is essential — LangGraph serializes it into the tool's JSON schema, which is what the LLM sees when deciding what data to generate.
-- The Python SDK's `a2ui.render` does not yet support the `action_handlers=` keyword, so the example keeps the button schema but does not declare server-side handlers. Button clicks are currently inert.
+- The Python SDK's `a2ui.render` does not yet support the `action_handlers=` keyword, so the example keeps the button schema but does not declare server-side handlers. Button clicks are forwarded to the agent, but this example has no server-side handler for them.
 - `"book_flight"` is the action name used by the schema button and can be handled with the frontend APIs in the [Advanced — Action Handlers](./advanced#action-handlers) guide.
 </Step>
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx
@@ -8,7 +8,7 @@ In the fixed-schema approach, you design the UI schema once (in a JSON file or u
 
 1. Schema is loaded from a JSON file at startup
 2. Agent tool receives data from the LLM (e.g., flight search results)
-3. Tool returns `a2ui.render()` with surfaceUpdate + dataModelUpdate + beginRendering
+3. Tool returns `a2ui.render()` with createSurface + updateComponents + updateDataModel
 4. The A2UI middleware intercepts the tool result and renders the surface
 
 ## Implementation
@@ -61,34 +61,17 @@ def search_flights(flights: list[Flight]) -> str:
     """Search for flights and display results as rich cards."""
     return a2ui.render(
         operations=[
-            a2ui.surface_update(SURFACE_ID, FLIGHT_SCHEMA),
-            a2ui.data_model_update(SURFACE_ID, {"flights": flights}),
-            a2ui.begin_rendering(SURFACE_ID, "root"),
+            a2ui.create_surface(SURFACE_ID),
+            a2ui.update_components(SURFACE_ID, FLIGHT_SCHEMA),
+            a2ui.update_data_model(SURFACE_ID, {"flights": flights}),
         ],
-        action_handlers={
-            # Exact match: fires when a button with action.name="book_flight" is clicked
-            "book_flight": [
-                a2ui.surface_update(SURFACE_ID, BOOKED_SCHEMA),
-                a2ui.data_model_update(SURFACE_ID, {
-                    "title": "Booking Confirmed",
-                    "detail": "Your flight has been booked.",
-                }),
-                a2ui.begin_rendering(SURFACE_ID, "root"),
-            ],
-            # Catch-all: fires for any button action without a specific match
-            "*": [
-                a2ui.data_model_update(SURFACE_ID, {
-                    "status": "Action received",
-                }),
-            ],
-        },
     )
 ```
 
 Key points:
 - The `Flight` TypedDict is essential — LangGraph serializes it into the tool's JSON schema, which is what the LLM sees when deciding what data to generate.
-- `action_handlers` declares optimistic UI responses. When a user clicks a button, the matching handler replaces the surface instantly — no round-trip to the server.
-- `"book_flight"` matches the `action.name` from the schema button. `"*"` is a catch-all for any unmatched action.
+- The Python SDK's `a2ui.render` does not yet support the `action_handlers=` keyword, so the example keeps the button schema but does not declare server-side handlers. Button clicks are currently inert.
+- `"book_flight"` is the action name used by the schema button and can be handled with the frontend APIs in the [Advanced — Action Handlers](./advanced#action-handlers) guide.
 </Step>
 
 <Step>
@@ -120,7 +103,7 @@ const runtime = new CopilotRuntime({
 
 ## Action handler details
 
-The `action_handlers` in the example above work together with buttons defined in the A2UI schema. Here's how the schema side looks:
+The `action_handlers` option is reserved for future Python SDK support. The button schema can still define the action context used by frontend handlers. Here's how the schema side looks:
 
 ### Button with action context
 
@@ -141,7 +124,7 @@ In your `flight_schema.json`, buttons declare an `action` with data-bound contex
 }
 ```
 
-When this button is clicked on a card showing flight AA100 at $350, the `"book_flight"` handler fires with `context: { flightNumber: "AA100", price: "$350" }`, and the surface instantly replaces with the booking confirmation.
+When this button is clicked on a card showing flight AA100 at $350, frontend action handling receives `context: { flightNumber: "AA100", price: "$350" }`. The Python `action_handlers=` path is not yet supported.
 
 <Callout type="info">
 For custom frontend handling with `useA2UIActionHandler`, custom orchestrators, and the full resolution chain, see the [Advanced — Action Handlers](./advanced#action-handlers) guide.

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx
@@ -52,10 +52,6 @@ SURFACE_ID = "flight-search-results"
 FLIGHT_SCHEMA = a2ui.load_schema(
     Path(__file__).parent / "a2ui" / "schemas" / "flight_schema.json"
 )
-BOOKED_SCHEMA = a2ui.load_schema(
-    Path(__file__).parent / "a2ui" / "schemas" / "booked_schema.json"
-)
-
 @tool
 def search_flights(flights: list[Flight]) -> str:
     """Search for flights and display results as rich cards."""
@@ -103,7 +99,7 @@ const runtime = new CopilotRuntime({
 
 ## Action handler details
 
-The `action_handlers` option is reserved for future Python SDK support. The button schema can still define the action context used by frontend handlers. Here's how the schema side looks:
+The current Python SDK does not support the `action_handlers=` option. The button schema can still define the action context used by frontend handlers. Here's how the schema side looks:
 
 ### Button with action context
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx
@@ -107,14 +107,17 @@ In your `flight_schema.json`, buttons declare an `action` with data-bound contex
 
 ```json
 {
-  "Button": {
-    "label": "Book",
-    "action": {
+  "id": "book-button",
+  "component": "Button",
+  "child": "book-label",
+  "variant": "primary",
+  "action": {
+    "event": {
       "name": "book_flight",
-      "context": [
-        { "key": "flightNumber", "value": { "path": "/flightNumber" } },
-        { "key": "price", "value": { "path": "/price" } }
-      ]
+      "context": {
+        "flightNumber": { "path": "flightNumber" },
+        "price": { "path": "price" }
+      }
     }
   }
 }
@@ -123,5 +126,5 @@ In your `flight_schema.json`, buttons declare an `action` with data-bound contex
 When this button is clicked on a card showing flight AA100 at $350, frontend action handling receives `context: { flightNumber: "AA100", price: "$350" }`. The Python `action_handlers=` path is not yet supported.
 
 <Callout type="info">
-For custom frontend handling with `useA2UIActionHandler`, custom orchestrators, and the full resolution chain, see the [Advanced — Action Handlers](./advanced#action-handlers) guide.
+For custom frontend handling with `createA2UIMessageRenderer` and its `onAction` option, see the [Advanced — Action Handlers](./advanced#action-handlers) guide.
 </Callout>


### PR DESCRIPTION
## Summary

The A2UI integration docs still use helper names and wire keys from before the Python SDK's v0.9 API. The examples now match the current SDK, while the A2A page clearly labels its cloned starter's v0.8 compatibility contract.

## Changes

- Update the generic, DeepAgents, and LangGraph A2UI pages to current helper names, wire keys, and operation order.
- Reconcile the A2A page to the cloned starter's v0.8 payload and defer its v0.9 migration.
- Remove unsupported `action_handlers=` and `dataContextPath` claims from the advanced examples.
- Use the exported `createA2UIMessageRenderer` `onAction` interceptor in the React guides.

## Out of scope

Migrating `examples/integrations/a2a-a2ui/` from its v0.8 renderer and operation list requires source and example changes outside this documentation-only target.

## Related PRs and Issues

Addresses the v0.9 documentation portion of #4821.

The corrected names follow `sdk-python/copilotkit/a2ui.py`; the A2A page follows the cloned starter's current v0.8 contract. Closed partial work is tracked in https://github.com/CopilotKit/CopilotKit/pull/5854.

## Test plan

- [x] Documentation search passed. The v0.9 pages contain no stale Python helper names, current wire names are present, and the A2A compatibility page is labeled.
- [x] Diff validation passed. Only the eight named MDX files changed.
- [ ] Shell-docs typecheck, lint, and formatting were unavailable because this worktree has no installed `node_modules`; CI will run them on the PR.
- [ ] CI green (`static / quality`, `test / unit` on Node 20/22/24).
