### PR TITLE
feat(react-core): add client-only custom messages

### DIFF
--- a/.changeset/add-client-only-custom-messages.md
+++ b/.changeset/add-client-only-custom-messages.md
@@ -1,0 +1,7 @@
+---
+"@copilotkit/react-core": minor
+---
+
+feat(react-core): add client-only custom chat messages
+
+Adds provider-scoped ephemeral custom messages that render in CopilotChat without entering persisted agent history or outbound runs.

--- a/packages/react-core/src/__tests__/threadid-propagation.contract.test.tsx
+++ b/packages/react-core/src/__tests__/threadid-propagation.contract.test.tsx
@@ -41,6 +41,8 @@ const mockUseCopilotKit = useCopilotKit as ReturnType<typeof vi.fn>;
 describe("useAgent → agent.threadId sync from chat configuration", () => {
   let mockCopilotkit: {
     getAgent: ReturnType<typeof vi.fn>;
+    getEphemeralMessages: ReturnType<typeof vi.fn>;
+    subscribe: ReturnType<typeof vi.fn>;
     registerProxiedAgent: ReturnType<typeof vi.fn>;
     runtimeUrl: string | undefined;
     runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus;
@@ -57,6 +59,8 @@ describe("useAgent → agent.threadId sync from chat configuration", () => {
   beforeEach(() => {
     mockCopilotkit = {
       getAgent: vi.fn(() => undefined),
+      getEphemeralMessages: vi.fn(() => []),
+      subscribe: vi.fn(() => ({ unsubscribe: vi.fn() })),
       // Mini-registry stand-in for CopilotKitCore.registerProxiedAgent: hands
       // back a real ProxiedCopilotRuntimeAgent (so `.threadId` and
       // `.runtimeAgentId` behave authentically) registered under the local

--- a/packages/react-core/src/__tests__/threadid-propagation.contract.test.tsx
+++ b/packages/react-core/src/__tests__/threadid-propagation.contract.test.tsx
@@ -42,6 +42,7 @@ describe("useAgent → agent.threadId sync from chat configuration", () => {
   let mockCopilotkit: {
     getAgent: ReturnType<typeof vi.fn>;
     getEphemeralMessages: ReturnType<typeof vi.fn>;
+    reconcileEphemeralMessages: ReturnType<typeof vi.fn>;
     subscribe: ReturnType<typeof vi.fn>;
     registerProxiedAgent: ReturnType<typeof vi.fn>;
     runtimeUrl: string | undefined;
@@ -60,6 +61,7 @@ describe("useAgent → agent.threadId sync from chat configuration", () => {
     mockCopilotkit = {
       getAgent: vi.fn(() => undefined),
       getEphemeralMessages: vi.fn(() => []),
+      reconcileEphemeralMessages: vi.fn(() => false),
       subscribe: vi.fn(() => ({ unsubscribe: vi.fn() })),
       // Mini-registry stand-in for CopilotKitCore.registerProxiedAgent: hands
       // back a real ProxiedCopilotRuntimeAgent (so `.threadId` and

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -1,4 +1,5 @@
 import { useAgent } from "../../hooks/use-agent";
+import { getApplicableCustomMessageRenderers } from "../../hooks/use-render-custom-messages";
 import { useAttachments } from "../../hooks/use-attachments";
 import { useSuggestions } from "../../hooks/use-suggestions";
 import type { CopilotChatViewProps } from "./CopilotChatView";
@@ -46,6 +47,7 @@ export type CopilotChatProps = Omit<
   CopilotChatViewProps,
   | "messages"
   | "ephemeralMessages"
+  | "hasRenderableEphemeralMessages"
   | "isRunning"
   | "suggestions"
   | "suggestionLoadingIndexes"
@@ -121,11 +123,15 @@ export function CopilotChat({
   const hasExplicitThreadId =
     !!threadId || !!existingConfig?.hasExplicitThreadId;
 
-  const { agent } = useAgent({
+  const { agent, ephemeralMessages } = useAgent({
     agentId: resolvedAgentId,
     throttleMs,
   });
   const { copilotkit } = useCopilotKit();
+  const hasRenderableEphemeralMessages = getApplicableCustomMessageRenderers(
+    copilotkit.renderCustomMessages,
+    resolvedAgentId,
+  ).some((renderer) => renderer.renderEphemeral);
   const [, forceEphemeralUpdate] = useState(0);
 
   useEffect(() => {
@@ -1020,11 +1026,6 @@ export function CopilotChat({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [messagesMemoKey],
   );
-  const ephemeralMessages = copilotkit.getEphemeralMessages(
-    resolvedAgentId,
-    resolvedThreadId,
-  );
-
   // Compute the ID of the last user message for scroll-pinning logic.
   const lastUserMessageId = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -1060,6 +1061,7 @@ export function CopilotChat({
     ...mergedProps,
     messages,
     ephemeralMessages,
+    hasRenderableEphemeralMessages,
     // Input behavior props
     onSubmitMessage: onSubmitInput,
     onStop: effectiveStopHandler,

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -91,21 +91,19 @@ export type CopilotChatProps = Omit<
    */
   throttleMs?: number;
 };
+type CopilotChatInnerProps = Omit<
+  CopilotChatProps,
+  "agentId" | "threadId" | "labels" | "isModalDefaultOpen"
+>;
+
 export function CopilotChat({
   agentId,
   threadId,
   labels,
-  chatView,
   isModalDefaultOpen,
-  attachments: attachmentsConfig,
-  onError,
-  throttleMs,
   ...props
 }: CopilotChatProps) {
-  // Check for existing configuration provider
   const existingConfig = useCopilotChatConfiguration();
-
-  // Apply priority: props > existing config > defaults
   const resolvedAgentId =
     agentId ?? existingConfig?.agentId ?? DEFAULT_AGENT_ID;
   const providedThreadId = threadId ?? existingConfig?.threadId;
@@ -113,15 +111,34 @@ export function CopilotChat({
     () => providedThreadId ?? randomUUID(),
     [providedThreadId],
   );
-  // "Explicit" means a caller actually picked this thread — via the
-  // `threadId` prop on CopilotChat or a wrapping provider that marked its
-  // threadId as caller-chosen. An auto-minted UUID leaking down through a
-  // CopilotChatConfigurationProvider (e.g. from the v1 CopilotKit →
-  // ThreadsProvider chain) does NOT count; treating it as explicit is
-  // what made /connect fire against 404s and the welcome screen stay
-  // hidden for fresh empty chats.
   const hasExplicitThreadId =
     !!threadId || !!existingConfig?.hasExplicitThreadId;
+
+  return (
+    <CopilotChatConfigurationProvider
+      agentId={resolvedAgentId}
+      threadId={resolvedThreadId}
+      hasExplicitThreadId={hasExplicitThreadId}
+      labels={labels}
+      isModalDefaultOpen={isModalDefaultOpen}
+    >
+      <CopilotChatInner {...props} />
+    </CopilotChatConfigurationProvider>
+  );
+}
+
+function CopilotChatInner({
+  chatView,
+  attachments: attachmentsConfig,
+  onError,
+  throttleMs,
+  ...props
+}: CopilotChatInnerProps) {
+  // Check for the configuration provider owned by CopilotChat.
+  const existingConfig = useCopilotChatConfiguration();
+  const resolvedAgentId = existingConfig?.agentId ?? DEFAULT_AGENT_ID;
+  const resolvedThreadId = existingConfig?.threadId ?? "";
+  const hasExplicitThreadId = existingConfig?.hasExplicitThreadId ?? false;
 
   const { agent, ephemeralMessages } = useAgent({
     agentId: resolvedAgentId,
@@ -1087,53 +1104,43 @@ export function CopilotChat({
     hasExplicitThreadId,
   };
 
-  // Always create a provider with merged values
-  // This ensures priority: props > existing config > defaults
   const RenderedChatView = renderSlot(chatView, CopilotChatView, finalProps);
 
   return (
-    <CopilotChatConfigurationProvider
-      agentId={resolvedAgentId}
-      threadId={resolvedThreadId}
-      hasExplicitThreadId={hasExplicitThreadId}
-      labels={labels}
-      isModalDefaultOpen={isModalDefaultOpen}
-    >
-      <div ref={chatContainerRef} style={{ display: "contents" }}>
-        {attachmentsEnabled && (
-          <input
-            type="file"
-            multiple
-            ref={fileInputRef}
-            onChange={handleFileUpload}
-            accept={attachmentsConfig?.accept ?? "*/*"}
-            style={{ display: "none" }}
-          />
-        )}
-        {!isChatLicensed && <InlineFeatureWarning featureName="Chat" />}
-        {transcriptionError && (
-          <div
-            style={{
-              position: "absolute",
-              bottom: "100px",
-              left: "50%",
-              transform: "translateX(-50%)",
-              backgroundColor: "#ef4444",
-              color: "white",
-              padding: "8px 16px",
-              borderRadius: "8px",
-              fontSize: "14px",
-              zIndex: 50,
-            }}
-          >
-            {transcriptionError}
-          </div>
-        )}
-        <LastUserMessageContext.Provider value={lastUserMessageState}>
-          {RenderedChatView}
-        </LastUserMessageContext.Provider>
-      </div>
-    </CopilotChatConfigurationProvider>
+    <div ref={chatContainerRef} style={{ display: "contents" }}>
+      {attachmentsEnabled && (
+        <input
+          type="file"
+          multiple
+          ref={fileInputRef}
+          onChange={handleFileUpload}
+          accept={attachmentsConfig?.accept ?? "*/*"}
+          style={{ display: "none" }}
+        />
+      )}
+      {!isChatLicensed && <InlineFeatureWarning featureName="Chat" />}
+      {transcriptionError && (
+        <div
+          style={{
+            position: "absolute",
+            bottom: "100px",
+            left: "50%",
+            transform: "translateX(-50%)",
+            backgroundColor: "#ef4444",
+            color: "white",
+            padding: "8px 16px",
+            borderRadius: "8px",
+            fontSize: "14px",
+            zIndex: 50,
+          }}
+        >
+          {transcriptionError}
+        </div>
+      )}
+      <LastUserMessageContext.Provider value={lastUserMessageState}>
+        {RenderedChatView}
+      </LastUserMessageContext.Provider>
+    </div>
   );
 }
 

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -91,16 +91,15 @@ export type CopilotChatProps = Omit<
    */
   throttleMs?: number;
 };
-type CopilotChatInnerProps = Omit<
-  CopilotChatProps,
-  "agentId" | "threadId" | "labels" | "isModalDefaultOpen"
->;
-
 export function CopilotChat({
   agentId,
   threadId,
   labels,
+  chatView,
   isModalDefaultOpen,
+  attachments: attachmentsConfig,
+  onError,
+  throttleMs,
   ...props
 }: CopilotChatProps) {
   const existingConfig = useCopilotChatConfiguration();
@@ -114,36 +113,17 @@ export function CopilotChat({
   const hasExplicitThreadId =
     !!threadId || !!existingConfig?.hasExplicitThreadId;
 
-  return (
-    <CopilotChatConfigurationProvider
-      agentId={resolvedAgentId}
-      threadId={resolvedThreadId}
-      hasExplicitThreadId={hasExplicitThreadId}
-      labels={labels}
-      isModalDefaultOpen={isModalDefaultOpen}
-    >
-      <CopilotChatInner {...props} />
-    </CopilotChatConfigurationProvider>
+  const { agent, ephemeralMessages } = useAgent(
+    {
+      agentId: resolvedAgentId,
+      throttleMs,
+    },
+    {
+      agentId: resolvedAgentId,
+      threadId: resolvedThreadId,
+      hasExplicitThreadId,
+    },
   );
-}
-
-function CopilotChatInner({
-  chatView,
-  attachments: attachmentsConfig,
-  onError,
-  throttleMs,
-  ...props
-}: CopilotChatInnerProps) {
-  // Check for the configuration provider owned by CopilotChat.
-  const existingConfig = useCopilotChatConfiguration();
-  const resolvedAgentId = existingConfig?.agentId ?? DEFAULT_AGENT_ID;
-  const resolvedThreadId = existingConfig?.threadId ?? "";
-  const hasExplicitThreadId = existingConfig?.hasExplicitThreadId ?? false;
-
-  const { agent, ephemeralMessages } = useAgent({
-    agentId: resolvedAgentId,
-    throttleMs,
-  });
   const { copilotkit } = useCopilotKit();
   const hasRenderableEphemeralMessages = getApplicableCustomMessageRenderers(
     copilotkit.renderCustomMessages,
@@ -1107,40 +1087,48 @@ function CopilotChatInner({
   const RenderedChatView = renderSlot(chatView, CopilotChatView, finalProps);
 
   return (
-    <div ref={chatContainerRef} style={{ display: "contents" }}>
-      {attachmentsEnabled && (
-        <input
-          type="file"
-          multiple
-          ref={fileInputRef}
-          onChange={handleFileUpload}
-          accept={attachmentsConfig?.accept ?? "*/*"}
-          style={{ display: "none" }}
-        />
-      )}
-      {!isChatLicensed && <InlineFeatureWarning featureName="Chat" />}
-      {transcriptionError && (
-        <div
-          style={{
-            position: "absolute",
-            bottom: "100px",
-            left: "50%",
-            transform: "translateX(-50%)",
-            backgroundColor: "#ef4444",
-            color: "white",
-            padding: "8px 16px",
-            borderRadius: "8px",
-            fontSize: "14px",
-            zIndex: 50,
-          }}
-        >
-          {transcriptionError}
-        </div>
-      )}
-      <LastUserMessageContext.Provider value={lastUserMessageState}>
-        {RenderedChatView}
-      </LastUserMessageContext.Provider>
-    </div>
+    <CopilotChatConfigurationProvider
+      agentId={resolvedAgentId}
+      threadId={resolvedThreadId}
+      hasExplicitThreadId={hasExplicitThreadId}
+      labels={labels}
+      isModalDefaultOpen={isModalDefaultOpen}
+    >
+      <div ref={chatContainerRef} style={{ display: "contents" }}>
+        {attachmentsEnabled && (
+          <input
+            type="file"
+            multiple
+            ref={fileInputRef}
+            onChange={handleFileUpload}
+            accept={attachmentsConfig?.accept ?? "*/*"}
+            style={{ display: "none" }}
+          />
+        )}
+        {!isChatLicensed && <InlineFeatureWarning featureName="Chat" />}
+        {transcriptionError && (
+          <div
+            style={{
+              position: "absolute",
+              bottom: "100px",
+              left: "50%",
+              transform: "translateX(-50%)",
+              backgroundColor: "#ef4444",
+              color: "white",
+              padding: "8px 16px",
+              borderRadius: "8px",
+              fontSize: "14px",
+              zIndex: 50,
+            }}
+          >
+            {transcriptionError}
+          </div>
+        )}
+        <LastUserMessageContext.Provider value={lastUserMessageState}>
+          {RenderedChatView}
+        </LastUserMessageContext.Provider>
+      </div>
+    </CopilotChatConfigurationProvider>
   );
 }
 

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -91,15 +91,21 @@ export type CopilotChatProps = Omit<
    */
   throttleMs?: number;
 };
+
+type CopilotChatInnerProps = Omit<
+  CopilotChatProps,
+  "agentId" | "threadId" | "labels" | "isModalDefaultOpen"
+> & {
+  agentId: string;
+  threadId: string;
+  hasExplicitThreadId: boolean;
+};
+
 export function CopilotChat({
   agentId,
   threadId,
   labels,
-  chatView,
   isModalDefaultOpen,
-  attachments: attachmentsConfig,
-  onError,
-  throttleMs,
   ...props
 }: CopilotChatProps) {
   const existingConfig = useCopilotChatConfiguration();
@@ -112,6 +118,41 @@ export function CopilotChat({
   );
   const hasExplicitThreadId =
     !!threadId || !!existingConfig?.hasExplicitThreadId;
+
+  return (
+    <CopilotChatConfigurationProvider
+      agentId={resolvedAgentId}
+      threadId={resolvedThreadId}
+      hasExplicitThreadId={hasExplicitThreadId}
+      labels={labels}
+      isModalDefaultOpen={isModalDefaultOpen}
+    >
+      <CopilotChatInner
+        {...props}
+        agentId={resolvedAgentId}
+        threadId={resolvedThreadId}
+        hasExplicitThreadId={hasExplicitThreadId}
+      />
+    </CopilotChatConfigurationProvider>
+  );
+}
+
+function CopilotChatInner({
+  agentId: scopedAgentId,
+  threadId: scopedThreadId,
+  hasExplicitThreadId: scopedHasExplicitThreadId,
+  chatView,
+  attachments: attachmentsConfig,
+  onError,
+  throttleMs,
+  ...props
+}: CopilotChatInnerProps) {
+  const existingConfig = useCopilotChatConfiguration();
+  const resolvedAgentId =
+    existingConfig?.agentId ?? scopedAgentId ?? DEFAULT_AGENT_ID;
+  const resolvedThreadId = existingConfig?.threadId ?? scopedThreadId;
+  const hasExplicitThreadId =
+    existingConfig?.hasExplicitThreadId ?? scopedHasExplicitThreadId;
 
   const { agent, ephemeralMessages } = useAgent(
     {
@@ -1087,48 +1128,40 @@ export function CopilotChat({
   const RenderedChatView = renderSlot(chatView, CopilotChatView, finalProps);
 
   return (
-    <CopilotChatConfigurationProvider
-      agentId={resolvedAgentId}
-      threadId={resolvedThreadId}
-      hasExplicitThreadId={hasExplicitThreadId}
-      labels={labels}
-      isModalDefaultOpen={isModalDefaultOpen}
-    >
-      <div ref={chatContainerRef} style={{ display: "contents" }}>
-        {attachmentsEnabled && (
-          <input
-            type="file"
-            multiple
-            ref={fileInputRef}
-            onChange={handleFileUpload}
-            accept={attachmentsConfig?.accept ?? "*/*"}
-            style={{ display: "none" }}
-          />
-        )}
-        {!isChatLicensed && <InlineFeatureWarning featureName="Chat" />}
-        {transcriptionError && (
-          <div
-            style={{
-              position: "absolute",
-              bottom: "100px",
-              left: "50%",
-              transform: "translateX(-50%)",
-              backgroundColor: "#ef4444",
-              color: "white",
-              padding: "8px 16px",
-              borderRadius: "8px",
-              fontSize: "14px",
-              zIndex: 50,
-            }}
-          >
-            {transcriptionError}
-          </div>
-        )}
-        <LastUserMessageContext.Provider value={lastUserMessageState}>
-          {RenderedChatView}
-        </LastUserMessageContext.Provider>
-      </div>
-    </CopilotChatConfigurationProvider>
+    <div ref={chatContainerRef} style={{ display: "contents" }}>
+      {attachmentsEnabled && (
+        <input
+          type="file"
+          multiple
+          ref={fileInputRef}
+          onChange={handleFileUpload}
+          accept={attachmentsConfig?.accept ?? "*/*"}
+          style={{ display: "none" }}
+        />
+      )}
+      {!isChatLicensed && <InlineFeatureWarning featureName="Chat" />}
+      {transcriptionError && (
+        <div
+          style={{
+            position: "absolute",
+            bottom: "100px",
+            left: "50%",
+            transform: "translateX(-50%)",
+            backgroundColor: "#ef4444",
+            color: "white",
+            padding: "8px 16px",
+            borderRadius: "8px",
+            fontSize: "14px",
+            zIndex: 50,
+          }}
+        >
+          {transcriptionError}
+        </div>
+      )}
+      <LastUserMessageContext.Provider value={lastUserMessageState}>
+        {RenderedChatView}
+      </LastUserMessageContext.Provider>
+    </div>
   );
 }
 

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -45,6 +45,7 @@ import type { LastUserMessageState } from "./last-user-message-context";
 export type CopilotChatProps = Omit<
   CopilotChatViewProps,
   | "messages"
+  | "ephemeralMessages"
   | "isRunning"
   | "suggestions"
   | "suggestionLoadingIndexes"
@@ -125,6 +126,21 @@ export function CopilotChat({
     throttleMs,
   });
   const { copilotkit } = useCopilotKit();
+  const [, forceEphemeralUpdate] = useState(0);
+
+  useEffect(() => {
+    const subscription = copilotkit.subscribe({
+      onEphemeralMessagesChanged: (event) => {
+        if (
+          event.agentId === resolvedAgentId &&
+          event.threadId === resolvedThreadId
+        ) {
+          forceEphemeralUpdate((value) => value + 1);
+        }
+      },
+    });
+    return () => subscription.unsubscribe();
+  }, [copilotkit, resolvedAgentId, resolvedThreadId]);
   const { suggestions: autoSuggestions } = useSuggestions({
     agentId: resolvedAgentId,
   });
@@ -1004,6 +1020,10 @@ export function CopilotChat({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [messagesMemoKey],
   );
+  const ephemeralMessages = copilotkit.getEphemeralMessages(
+    resolvedAgentId,
+    resolvedThreadId,
+  );
 
   // Compute the ID of the last user message for scroll-pinning logic.
   const lastUserMessageId = useMemo(() => {
@@ -1039,6 +1059,7 @@ export function CopilotChat({
   const finalProps: CopilotChatViewProps = {
     ...mergedProps,
     messages,
+    ephemeralMessages,
     // Input behavior props
     onSubmitMessage: onSubmitInput,
     onStop: effectiveStopHandler,

--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -460,10 +460,13 @@ export type CopilotChatMessageViewProps = Omit<
 // full DOM tree. Below the threshold the overhead of virtualization isn't
 // worth it and the simpler flat render is faster.
 const VIRTUALIZE_THRESHOLD = 50;
+const EMPTY_MESSAGES: Message[] = [];
+const EMPTY_EPHEMERAL_MESSAGES: ReadonlyArray<ReactEphemeralMessage> =
+  Object.freeze([]);
 
 export function CopilotChatMessageView({
-  messages = [],
-  ephemeralMessages = [],
+  messages = EMPTY_MESSAGES,
+  ephemeralMessages = EMPTY_EPHEMERAL_MESSAGES,
   assistantMessage,
   userMessage,
   reasoningMessage,
@@ -624,14 +627,18 @@ export function CopilotChatMessageView({
   // on the virtualizer's total-size div — same as the flat path. Adding
   // deduplicatedMessages.length here would forcibly yank the user to the bottom
   // on every streaming chunk even if they've scrolled up to read history.
-  const firstMessageId = deduplicatedMessages[0]?.id;
+  const threadChangeKey = [
+    config?.agentId ?? "",
+    config?.threadId ?? "",
+    deduplicatedMessages[0]?.id ?? ephemeralMessages[0]?.id ?? "",
+  ].join(":");
   useLayoutEffect(() => {
     if (!shouldVirtualize || !composedMessages.length) return;
     virtualizer.scrollToIndex(composedMessages.length - 1, {
       align: "end",
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldVirtualize, firstMessageId]);
+  }, [shouldVirtualize, threadChangeKey]);
 
   // Map each Intelligence-using turn's anchor message → stable turn id. One
   // indicator is emitted per turn (keyed by the turn id) at its anchor, so it

--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -630,7 +630,7 @@ export function CopilotChatMessageView({
   const threadChangeKey = [
     config?.agentId ?? "",
     config?.threadId ?? "",
-    deduplicatedMessages[0]?.id ?? ephemeralMessages[0]?.id ?? "",
+    deduplicatedMessages[0]?.id ?? "",
   ].join(":");
   useLayoutEffect(() => {
     if (!shouldVirtualize || !composedMessages.length) return;

--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -386,6 +386,47 @@ export function deduplicateMessages(messages: Message[]): Message[] {
   return [...acc.values()];
 }
 
+type ComposedMessage =
+  | { kind: "persisted"; message: Message }
+  | { kind: "ephemeral"; message: ReactEphemeralMessage };
+
+function composeMessages(
+  persistedMessages: Message[],
+  ephemeralMessages: ReadonlyArray<ReactEphemeralMessage>,
+): ComposedMessage[] {
+  const persistedIds = new Set(persistedMessages.map((message) => message.id));
+  const anchoredEphemeral = new Map<string, ReactEphemeralMessage[]>();
+  const unanchoredEphemeral: ReactEphemeralMessage[] = [];
+  const orphanedEphemeral: ReactEphemeralMessage[] = [];
+
+  for (const message of ephemeralMessages) {
+    if (!message.anchorMessageId) {
+      unanchoredEphemeral.push(message);
+    } else if (persistedIds.has(message.anchorMessageId)) {
+      const anchored = anchoredEphemeral.get(message.anchorMessageId) ?? [];
+      anchored.push(message);
+      anchoredEphemeral.set(message.anchorMessageId, anchored);
+    } else {
+      orphanedEphemeral.push(message);
+    }
+  }
+
+  const composed: ComposedMessage[] = unanchoredEphemeral.map((message) => ({
+    kind: "ephemeral",
+    message,
+  }));
+  for (const message of persistedMessages) {
+    composed.push({ kind: "persisted", message });
+    for (const ephemeralMessage of anchoredEphemeral.get(message.id) ?? []) {
+      composed.push({ kind: "ephemeral", message: ephemeralMessage });
+    }
+  }
+  for (const message of orphanedEphemeral) {
+    composed.push({ kind: "ephemeral", message });
+  }
+  return composed;
+}
+
 export type CopilotChatMessageViewProps = Omit<
   WithSlots<
     {
@@ -486,17 +527,12 @@ export function CopilotChatMessageView({
     [messages],
   );
   const composedMessages = useMemo(
-    () => [
-      ...deduplicatedMessages.map((message) => ({
-        kind: "persisted" as const,
-        message,
-      })),
-      ...ephemeralMessages.map((message) => ({
-        kind: "ephemeral" as const,
-        message,
-      })),
-    ],
-    [deduplicatedMessages, ephemeralMessages],
+    () =>
+      composeMessages(
+        deduplicatedMessages,
+        renderEphemeralMessage ? ephemeralMessages : [],
+      ),
+    [deduplicatedMessages, ephemeralMessages, renderEphemeralMessage],
   );
 
   if (
@@ -607,7 +643,7 @@ export function CopilotChatMessageView({
   // Per-message rendering helper (shared by flat and virtual paths)
   // ---------------------------------------------------------------------------
   const renderMessageBlock = (
-    entry: (typeof composedMessages)[number],
+    entry: ComposedMessage,
     entryIndex: number,
   ): React.ReactElement[] => {
     const elements: (React.ReactElement | null | undefined)[] = [];

--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -324,6 +324,8 @@ const MemoizedEphemeralMessage = React.memo(
     renderEphemeralMessage,
   }: {
     message: ReactEphemeralMessage;
+    agentId: string;
+    threadId: string;
     messageIndex: number;
     numberOfMessages: number;
     renderEphemeralMessage: (params: {
@@ -339,6 +341,8 @@ const MemoizedEphemeralMessage = React.memo(
     });
   },
   (prevProps, nextProps) => {
+    if (prevProps.agentId !== nextProps.agentId) return false;
+    if (prevProps.threadId !== nextProps.threadId) return false;
     if (prevProps.message.id !== nextProps.message.id) return false;
     if (prevProps.message.content !== nextProps.message.content) return false;
     if (prevProps.messageIndex !== nextProps.messageIndex) return false;
@@ -651,8 +655,10 @@ export function CopilotChatMessageView({
       if (renderEphemeralMessage) {
         elements.push(
           <MemoizedEphemeralMessage
-            key={`${entry.message.id}-ephemeral`}
+            key={`${config?.agentId ?? ""}-${config?.threadId ?? ""}-${entry.message.id}-ephemeral`}
             message={entry.message}
+            agentId={config?.agentId ?? ""}
+            threadId={config?.threadId ?? ""}
             messageIndex={entryIndex}
             numberOfMessages={composedMessages.length}
             renderEphemeralMessage={renderEphemeralMessage}
@@ -792,7 +798,7 @@ export function CopilotChatMessageView({
             const entry = composedMessages[virtualItem.index]!;
             return (
               <div
-                key={`${entry.kind}-${entry.message.id}`}
+                key={`${config?.agentId ?? ""}-${config?.threadId ?? ""}-${entry.kind}-${entry.message.id}`}
                 data-index={virtualItem.index}
                 ref={virtualizer.measureElement}
                 style={{

--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -415,15 +415,15 @@ function composeMessages(
     }
   }
 
-  const composed: ComposedMessage[] = unanchoredEphemeral.map((message) => ({
-    kind: "ephemeral",
-    message,
-  }));
+  const composed: ComposedMessage[] = [];
   for (const message of persistedMessages) {
     composed.push({ kind: "persisted", message });
     for (const ephemeralMessage of anchoredEphemeral.get(message.id) ?? []) {
       composed.push({ kind: "ephemeral", message: ephemeralMessage });
     }
+  }
+  for (const message of unanchoredEphemeral) {
+    composed.push({ kind: "ephemeral", message });
   }
   for (const message of orphanedEphemeral) {
     composed.push({ kind: "ephemeral", message });
@@ -530,13 +530,14 @@ export function CopilotChatMessageView({
     () => deduplicateMessages(messages),
     [messages],
   );
+  const hasEphemeralRenderer = !!renderEphemeralMessage;
   const composedMessages = useMemo(
     () =>
       composeMessages(
         deduplicatedMessages,
-        renderEphemeralMessage ? ephemeralMessages : [],
+        hasEphemeralRenderer ? ephemeralMessages : [],
       ),
-    [deduplicatedMessages, ephemeralMessages, renderEphemeralMessage],
+    [deduplicatedMessages, ephemeralMessages, hasEphemeralRenderer],
   );
 
   if (
@@ -623,7 +624,7 @@ export function CopilotChatMessageView({
   // on the virtualizer's total-size div — same as the flat path. Adding
   // deduplicatedMessages.length here would forcibly yank the user to the bottom
   // on every streaming chunk even if they've scrolled up to read history.
-  const firstMessageId = composedMessages[0]?.message.id;
+  const firstMessageId = deduplicatedMessages[0]?.id;
   useLayoutEffect(() => {
     if (!shouldVirtualize || !composedMessages.length) return;
     virtualizer.scrollToIndex(composedMessages.length - 1, {

--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -22,7 +22,11 @@ import type {
   UserMessage,
 } from "@ag-ui/core";
 import { twMerge } from "tailwind-merge";
-import { useRenderActivityMessage, useRenderCustomMessages } from "../../hooks";
+import {
+  useRenderActivityMessage,
+  useRenderCustomMessages,
+  useRenderEphemeralMessages,
+} from "../../hooks";
 import { useCopilotKit } from "../../providers/CopilotKitProvider";
 import { useCopilotChatConfiguration } from "../../providers/CopilotChatConfigurationProvider";
 import {
@@ -31,6 +35,7 @@ import {
 } from "../intelligence-indicator";
 import type { IntelligenceIndicatorView } from "../intelligence-indicator";
 import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
+import type { ReactEphemeralMessage } from "../../types/react-custom-message-renderer";
 
 /**
  * Resolves a slot value into a { Component, slotProps } pair, handling the three
@@ -311,6 +316,37 @@ const MemoizedCustomMessage = React.memo(
   },
 );
 
+const MemoizedEphemeralMessage = React.memo(
+  function MemoizedEphemeralMessage({
+    message,
+    messageIndex,
+    numberOfMessages,
+    renderEphemeralMessage,
+  }: {
+    message: ReactEphemeralMessage;
+    messageIndex: number;
+    numberOfMessages: number;
+    renderEphemeralMessage: (params: {
+      message: ReactEphemeralMessage;
+      messageIndex: number;
+      numberOfMessages: number;
+    }) => React.ReactElement | null;
+  }) {
+    return renderEphemeralMessage({
+      message,
+      messageIndex,
+      numberOfMessages,
+    });
+  },
+  (prevProps, nextProps) => {
+    if (prevProps.message.id !== nextProps.message.id) return false;
+    if (prevProps.message.content !== nextProps.message.content) return false;
+    if (prevProps.messageIndex !== nextProps.messageIndex) return false;
+    if (prevProps.numberOfMessages !== nextProps.numberOfMessages) return false;
+    return true;
+  },
+);
+
 /**
  * Deduplicates messages by ID. For assistant messages, merges occurrences:
  * recovers non-empty content from any earlier occurrence if the latest wiped it
@@ -362,6 +398,7 @@ export type CopilotChatMessageViewProps = Omit<
     {
       isRunning?: boolean;
       messages?: Message[];
+      ephemeralMessages?: ReadonlyArray<ReactEphemeralMessage>;
     } & React.HTMLAttributes<HTMLDivElement>
   >,
   "children"
@@ -381,6 +418,7 @@ const VIRTUALIZE_THRESHOLD = 50;
 
 export function CopilotChatMessageView({
   messages = [],
+  ephemeralMessages = [],
   assistantMessage,
   userMessage,
   reasoningMessage,
@@ -392,6 +430,7 @@ export function CopilotChatMessageView({
   ...props
 }: CopilotChatMessageViewProps) {
   const renderCustomMessage = useRenderCustomMessages();
+  const renderEphemeralMessage = useRenderEphemeralMessages();
   const { renderActivityMessage } = useRenderActivityMessage();
   const { copilotkit } = useCopilotKit();
   const config = useCopilotChatConfiguration();
@@ -445,6 +484,19 @@ export function CopilotChatMessageView({
   const deduplicatedMessages = useMemo(
     () => deduplicateMessages(messages),
     [messages],
+  );
+  const composedMessages = useMemo(
+    () => [
+      ...deduplicatedMessages.map((message) => ({
+        kind: "persisted" as const,
+        message,
+      })),
+      ...ephemeralMessages.map((message) => ({
+        kind: "ephemeral" as const,
+        message,
+      })),
+    ],
+    [deduplicatedMessages, ephemeralMessages],
   );
 
   if (
@@ -509,11 +561,11 @@ export function CopilotChatMessageView({
   const shouldVirtualize =
     !!scrollElement &&
     !children &&
-    deduplicatedMessages.length > VIRTUALIZE_THRESHOLD;
+    composedMessages.length > VIRTUALIZE_THRESHOLD;
 
   const virtualizer = useVirtualizer({
     // count=0 disables the virtualizer without changing hook call order.
-    count: shouldVirtualize ? deduplicatedMessages.length : 0,
+    count: shouldVirtualize ? composedMessages.length : 0,
     getScrollElement: () => scrollElement,
     // Conservative height estimate. Items are measured by ResizeObserver after
     // first render so the estimate only affects the initial total height.
@@ -531,10 +583,10 @@ export function CopilotChatMessageView({
   // on the virtualizer's total-size div — same as the flat path. Adding
   // deduplicatedMessages.length here would forcibly yank the user to the bottom
   // on every streaming chunk even if they've scrolled up to read history.
-  const firstMessageId = deduplicatedMessages[0]?.id;
+  const firstMessageId = composedMessages[0]?.message.id;
   useLayoutEffect(() => {
-    if (!shouldVirtualize || !deduplicatedMessages.length) return;
-    virtualizer.scrollToIndex(deduplicatedMessages.length - 1, {
+    if (!shouldVirtualize || !composedMessages.length) return;
+    virtualizer.scrollToIndex(composedMessages.length - 1, {
       align: "end",
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -554,8 +606,27 @@ export function CopilotChatMessageView({
   // ---------------------------------------------------------------------------
   // Per-message rendering helper (shared by flat and virtual paths)
   // ---------------------------------------------------------------------------
-  const renderMessageBlock = (message: Message): React.ReactElement[] => {
+  const renderMessageBlock = (
+    entry: (typeof composedMessages)[number],
+    entryIndex: number,
+  ): React.ReactElement[] => {
     const elements: (React.ReactElement | null | undefined)[] = [];
+    if (entry.kind === "ephemeral") {
+      if (renderEphemeralMessage) {
+        elements.push(
+          <MemoizedEphemeralMessage
+            key={`${entry.message.id}-ephemeral`}
+            message={entry.message}
+            messageIndex={entryIndex}
+            numberOfMessages={composedMessages.length}
+            renderEphemeralMessage={renderEphemeralMessage}
+          />,
+        );
+      }
+      return elements.filter(Boolean) as React.ReactElement[];
+    }
+
+    const message = entry.message;
     const stateSnapshot = getStateSnapshotForMessage(message.id);
 
     if (renderCustomMessage) {
@@ -647,7 +718,7 @@ export function CopilotChatMessageView({
   // creating 500 React elements that we'd immediately discard).
   const messageElements: React.ReactElement[] = shouldVirtualize
     ? []
-    : deduplicatedMessages.flatMap(renderMessageBlock);
+    : composedMessages.flatMap(renderMessageBlock);
 
   // ---------------------------------------------------------------------------
   // children render prop (custom layout, always non-virtual)
@@ -682,10 +753,10 @@ export function CopilotChatMessageView({
           style={{ height: virtualizer.getTotalSize(), position: "relative" }}
         >
           {virtualizer.getVirtualItems().map((virtualItem) => {
-            const message = deduplicatedMessages[virtualItem.index]!;
+            const entry = composedMessages[virtualItem.index]!;
             return (
               <div
-                key={message.id}
+                key={`${entry.kind}-${entry.message.id}`}
                 data-index={virtualItem.index}
                 ref={virtualizer.measureElement}
                 style={{
@@ -696,7 +767,7 @@ export function CopilotChatMessageView({
                   transform: `translateY(${virtualItem.start}px)`,
                 }}
               >
-                {renderMessageBlock(message)}
+                {renderMessageBlock(entry, virtualItem.index)}
               </div>
             );
           })}

--- a/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
@@ -65,6 +65,7 @@ export type CopilotChatViewProps = WithSlots<
   {
     messages?: Message[];
     ephemeralMessages?: ReadonlyArray<ReactEphemeralMessage>;
+    hasRenderableEphemeralMessages?: boolean;
     autoScroll?: AutoScrollMode | boolean;
     isRunning?: boolean;
     suggestions?: Suggestion[];
@@ -146,6 +147,7 @@ export function CopilotChatView({
   welcomeScreen,
   messages = [],
   ephemeralMessages = [],
+  hasRenderableEphemeralMessages = false,
   autoScroll = true,
   isRunning = false,
   suggestions,
@@ -320,7 +322,9 @@ export function CopilotChatView({
   });
 
   // Welcome screen logic
-  const isEmpty = messages.length === 0 && ephemeralMessages.length === 0;
+  const isEmpty =
+    messages.length === 0 &&
+    (!hasRenderableEphemeralMessages || ephemeralMessages.length === 0);
   // Type assertion needed because TypeScript doesn't fully propagate `| boolean` through WithSlots
   const welcomeScreenDisabled = (welcomeScreen as unknown) === false;
   // Suppress the welcome screen (1) while the initial connect is in flight

--- a/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
@@ -21,6 +21,7 @@ import CopilotChatSuggestionView, {
 import type { Suggestion } from "@copilotkit/core";
 import type { Message } from "@ag-ui/core";
 import type { Attachment } from "@copilotkit/shared";
+import type { ReactEphemeralMessage } from "../../types/react-custom-message-renderer";
 import { CopilotChatAttachmentQueue } from "./CopilotChatAttachmentQueue";
 import { twMerge } from "tailwind-merge";
 import {
@@ -63,6 +64,7 @@ export type CopilotChatViewProps = WithSlots<
   },
   {
     messages?: Message[];
+    ephemeralMessages?: ReadonlyArray<ReactEphemeralMessage>;
     autoScroll?: AutoScrollMode | boolean;
     isRunning?: boolean;
     suggestions?: Suggestion[];
@@ -143,6 +145,7 @@ export function CopilotChatView({
   suggestionView,
   welcomeScreen,
   messages = [],
+  ephemeralMessages = [],
   autoScroll = true,
   isRunning = false,
   suggestions,
@@ -247,6 +250,7 @@ export function CopilotChatView({
 
   const BoundMessageView = renderSlot(messageView, CopilotChatMessageView, {
     messages,
+    ephemeralMessages,
     isRunning,
     intelligenceIndicator,
   });
@@ -316,7 +320,7 @@ export function CopilotChatView({
   });
 
   // Welcome screen logic
-  const isEmpty = messages.length === 0;
+  const isEmpty = messages.length === 0 && ephemeralMessages.length === 0;
   // Type assertion needed because TypeScript doesn't fully propagate `| boolean` through WithSlots
   const welcomeScreenDisabled = (welcomeScreen as unknown) === false;
   // Suppress the welcome screen (1) while the initial connect is in flight

--- a/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
@@ -43,6 +43,9 @@ import { usePinToSend } from "../../hooks/use-pin-to-send";
 
 // Vertical gap between the scroll-to-bottom button and the input container.
 const SCROLL_BUTTON_OFFSET = 16;
+const EMPTY_MESSAGES: Message[] = [];
+const EMPTY_EPHEMERAL_MESSAGES: ReadonlyArray<ReactEphemeralMessage> =
+  Object.freeze([]);
 
 // Forward declaration for WelcomeScreen component type
 export type WelcomeScreenProps = WithSlots<
@@ -145,8 +148,8 @@ export function CopilotChatView({
   scrollView,
   suggestionView,
   welcomeScreen,
-  messages = [],
-  ephemeralMessages = [],
+  messages = EMPTY_MESSAGES,
+  ephemeralMessages = EMPTY_EPHEMERAL_MESSAGES,
   hasRenderableEphemeralMessages = false,
   autoScroll = true,
   isRunning = false,

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.ephemeralMessages.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.ephemeralMessages.e2e.test.tsx
@@ -489,6 +489,43 @@ describe("CopilotChat ephemeral messages", () => {
     });
   });
 
+  it("appends an unanchored runtime card after replayed persisted history", async () => {
+    const agent = new CapturingAgent();
+    renderWithCopilotKit({
+      agent,
+      renderCustomMessages: [ephemeralRenderer],
+      children: (
+        <CopilotChatMessageView
+          messages={[
+            {
+              id: "replayed-message-0",
+              role: "user",
+              content: "Replayed message 0",
+            },
+            {
+              id: "replayed-message-1",
+              role: "assistant",
+              content: "Replayed message 1",
+            },
+          ]}
+          ephemeralMessages={[
+            {
+              id: "runtime-card",
+              content: "Runtime card",
+            },
+          ]}
+        />
+      ),
+    });
+
+    await waitFor(() => {
+      const list = screen.getByTestId("copilot-message-list");
+      expect(list.textContent?.indexOf("Replayed message 1")).toBeLessThan(
+        list.textContent?.indexOf("Runtime card") ?? -1,
+      );
+    });
+  });
+
   it("renders the core-composed transcript in persisted-then-ephemeral order", async () => {
     const agent = new CapturingAgent();
     agent.addMessage({

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.ephemeralMessages.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.ephemeralMessages.e2e.test.tsx
@@ -155,6 +155,67 @@ describe("CopilotChat ephemeral messages", () => {
     });
   });
 
+  it("uses CopilotChat's resolved agent and thread over an outer provider scope", async () => {
+    const outerAgent = new CapturingAgent();
+    const resolvedAgent = new CapturingAgent();
+
+    function ResolvedScopeView({
+      ephemeralMessages = [],
+    }: {
+      ephemeralMessages?: ReadonlyArray<{ id: string; content: unknown }>;
+    }) {
+      const { addEphemeralMessage } = useAgent();
+      return (
+        <>
+          <button
+            data-testid="add-resolved-scope-card"
+            onClick={() =>
+              addEphemeralMessage({
+                id: "resolved-scope-card",
+                content: "resolved scope",
+              })
+            }
+          >
+            Add resolved scope card
+          </button>
+          <output data-testid="resolved-scope-cards">
+            {ephemeralMessages.map((message) => message.id).join(",")}
+          </output>
+        </>
+      );
+    }
+
+    render(
+      <CopilotKitProvider
+        agents__unsafe_dev_only={{ outer: outerAgent, resolved: resolvedAgent }}
+      >
+        <CopilotChatConfigurationProvider
+          agentId="outer"
+          threadId="outer-thread"
+        >
+          <CopilotChat
+            agentId="resolved"
+            threadId="resolved-thread"
+            chatView={ResolvedScopeView as any}
+          />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+
+    fireEvent.click(await screen.findByTestId("add-resolved-scope-card"));
+    await waitFor(() => {
+      expect(screen.getByTestId("resolved-scope-cards").textContent).toBe(
+        "resolved-scope-card",
+      );
+    });
+    expect(
+      resolvedAgent.messages.some(
+        (message) => message.id === "resolved-scope-card",
+      ),
+    ).toBe(false);
+    expect(outerAgent.messages).toEqual([]);
+  });
+
   it("renders the core-composed transcript in persisted-then-ephemeral order", async () => {
     const agent = new CapturingAgent();
     agent.addMessage({

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.ephemeralMessages.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.ephemeralMessages.e2e.test.tsx
@@ -340,6 +340,64 @@ describe("CopilotChat ephemeral messages", () => {
     });
   });
 
+  it("resets virtual scrolling for an ephemeral-only thread", async () => {
+    const ephemeralMessages = Array.from({ length: 51 }, (_, index) => ({
+      id: `ephemeral-only-${index}`,
+      content: `Ephemeral-only ${index}`,
+    }));
+    const fakeScrollElement = document.createElement("div");
+    Object.defineProperty(fakeScrollElement, "clientHeight", {
+      configurable: true,
+      get: () => 600,
+    });
+    fakeScrollElement.getBoundingClientRect = () =>
+      ({
+        height: 600,
+        width: 800,
+        top: 0,
+        left: 0,
+        bottom: 600,
+        right: 800,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    const { rerender, unmount } = renderWithCopilotKit({
+      renderCustomMessages: [ephemeralRenderer],
+      children: (
+        <CopilotChatConfigurationProvider threadId="ephemeral-thread-a">
+          <ScrollElementContext.Provider value={fakeScrollElement}>
+            <CopilotChatMessageView ephemeralMessages={ephemeralMessages} />
+          </ScrollElementContext.Provider>
+        </CopilotChatConfigurationProvider>
+      ),
+    });
+
+    expect(
+      (
+        screen.getByTestId("copilot-message-list")
+          .firstElementChild as HTMLElement
+      ).style.height,
+    ).toBe("4000px");
+    rerender(
+      <CopilotKitProvider renderCustomMessages={[ephemeralRenderer]}>
+        <CopilotChatConfigurationProvider threadId="ephemeral-thread-b">
+          <ScrollElementContext.Provider value={fakeScrollElement}>
+            <CopilotChatMessageView ephemeralMessages={ephemeralMessages} />
+          </ScrollElementContext.Provider>
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+    expect(
+      (
+        screen.getByTestId("copilot-message-list")
+          .firstElementChild as HTMLElement
+      ).style.height,
+    ).toBe("4000px");
+    unmount();
+  });
+
   it("prefers an agent-specific ephemeral renderer over the generic renderer", async () => {
     const agent = new CapturingAgent();
     const genericRenderer = {

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.ephemeralMessages.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.ephemeralMessages.e2e.test.tsx
@@ -6,7 +6,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Message } from "@ag-ui/core";
 import type { RunAgentInput } from "@ag-ui/client";
 import {
@@ -395,6 +395,85 @@ describe("CopilotChat ephemeral messages", () => {
           .firstElementChild as HTMLElement
       ).style.height,
     ).toBe("4000px");
+    unmount();
+  });
+
+  it("does not reset virtual scrolling when the first ephemeral entry is removed", async () => {
+    const ephemeralMessages = Array.from({ length: 52 }, (_, index) => ({
+      id: `removable-ephemeral-${index}`,
+      content: `Removable ephemeral ${index}`,
+    }));
+    const fakeScrollElement = document.createElement("div");
+    const scrollTo = vi.fn();
+    fakeScrollElement.scrollTo = (
+      optionsOrX: ScrollToOptions | number = {},
+      y?: number,
+    ) => {
+      scrollTo(optionsOrX, y);
+      fakeScrollElement.scrollTop =
+        typeof optionsOrX === "number"
+          ? (y ?? optionsOrX)
+          : (optionsOrX.top ?? 0);
+    };
+    Object.defineProperty(fakeScrollElement, "clientHeight", {
+      configurable: true,
+      get: () => 600,
+    });
+    fakeScrollElement.getBoundingClientRect = () =>
+      ({
+        height: 600,
+        width: 800,
+        top: 0,
+        left: 0,
+        bottom: 600,
+        right: 800,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    const { rerender, unmount } = renderWithCopilotKit({
+      renderCustomMessages: [ephemeralRenderer],
+      children: (
+        <ScrollElementContext.Provider value={fakeScrollElement}>
+          <CopilotChatMessageView ephemeralMessages={ephemeralMessages} />
+        </ScrollElementContext.Provider>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(
+        document.querySelector(
+          '[data-testid="copilot-message-list"] > div[style*="position: relative"]',
+        ),
+      ).not.toBeNull();
+    });
+    await act(async () => {
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => resolve()),
+      );
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => resolve()),
+      );
+    });
+    scrollTo.mockClear();
+    globalThis.requestAnimationFrame = noopRAF;
+    if (typeof window !== "undefined") {
+      window.requestAnimationFrame = noopRAF;
+    }
+
+    rerender(
+      <CopilotKitProvider renderCustomMessages={[ephemeralRenderer]}>
+        <CopilotChatConfigurationProvider threadId="test-thread">
+          <ScrollElementContext.Provider value={fakeScrollElement}>
+            <CopilotChatMessageView
+              ephemeralMessages={ephemeralMessages.slice(1)}
+            />
+          </ScrollElementContext.Provider>
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+    expect(scrollTo).not.toHaveBeenCalled();
     unmount();
   });
 

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.ephemeralMessages.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.ephemeralMessages.e2e.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { RunAgentInput } from "@ag-ui/client";
 import {
@@ -9,6 +9,7 @@ import {
   runStartedEvent,
 } from "../../../__tests__/utils/test-helpers";
 import { useAgent } from "../../../hooks/use-agent";
+import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
 import { useCopilotKit } from "../../../providers/CopilotKitProvider";
 import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
 import { CopilotChat } from "../CopilotChat";
@@ -109,6 +110,51 @@ describe("CopilotChat ephemeral messages", () => {
     agent.complete();
   });
 
+  it("keeps the welcome screen when an ephemeral entry has no renderer", async () => {
+    const agent = new CapturingAgent();
+
+    function UnrenderedControls() {
+      const { addEphemeralMessage } = useAgent();
+      return (
+        <>
+          <button
+            data-testid="add-unrendered-card"
+            onClick={() =>
+              addEphemeralMessage({
+                id: "unrendered-card",
+                content: "No renderer",
+              })
+            }
+          >
+            Add unrendered card
+          </button>
+        </>
+      );
+    }
+
+    render(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <CopilotChatConfigurationProvider
+          agentId="default"
+          threadId="thread-a"
+          hasExplicitThreadId={false}
+        >
+          <UnrenderedControls />
+          <div style={{ height: 400 }}>
+            <CopilotChat />
+          </div>
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+
+    expect(screen.getByText("How can I help you today?")).toBeDefined();
+    fireEvent.click(await screen.findByTestId("add-unrendered-card"));
+    await waitFor(() => {
+      expect(screen.getByText("How can I help you today?")).toBeDefined();
+      expect(screen.queryByTestId("ephemeral-card-unrendered-card")).toBeNull();
+    });
+  });
+
   it("renders the core-composed transcript in persisted-then-ephemeral order", async () => {
     const agent = new CapturingAgent();
     agent.addMessage({
@@ -123,6 +169,11 @@ describe("CopilotChat ephemeral messages", () => {
         addEphemeralMessage({
           id: "ephemeral-message",
           content: "Ephemeral message",
+        });
+        hookAgent.addMessage({
+          id: "later-persisted-message",
+          role: "user",
+          content: "Later persisted message",
         });
       }, [addEphemeralMessage, hookAgent]);
 
@@ -143,8 +194,12 @@ describe("CopilotChat ephemeral messages", () => {
       const list = screen.getByTestId("copilot-message-list");
       expect(list.textContent).toContain("Persisted message");
       expect(list.textContent).toContain("Ephemeral message");
+      expect(list.textContent).toContain("Later persisted message");
       expect(list.textContent?.indexOf("Persisted message")).toBeLessThan(
         list.textContent?.indexOf("Ephemeral message") ?? -1,
+      );
+      expect(list.textContent?.indexOf("Ephemeral message")).toBeLessThan(
+        list.textContent?.indexOf("Later persisted message") ?? -1,
       );
     });
   });
@@ -236,7 +291,11 @@ describe("CopilotChat ephemeral messages", () => {
     function Harness() {
       const [threadId, setThreadId] = React.useState("thread-a");
       return (
-        <CopilotChatConfigurationProvider agentId="default" threadId={threadId}>
+        <CopilotChatConfigurationProvider
+          agentId="default"
+          threadId={threadId}
+          hasExplicitThreadId={false}
+        >
           <ScopedControls onSwitchThread={() => setThreadId("thread-b")} />
           <div style={{ height: 400 }}>
             <CopilotChat welcomeScreen={false} />
@@ -245,11 +304,14 @@ describe("CopilotChat ephemeral messages", () => {
       );
     }
 
-    renderWithCopilotKit({
-      agent,
-      renderCustomMessages: [ephemeralRenderer],
-      children: <Harness />,
-    });
+    render(
+      <CopilotKitProvider
+        agents__unsafe_dev_only={{ default: agent }}
+        renderCustomMessages={[ephemeralRenderer]}
+      >
+        <Harness />
+      </CopilotKitProvider>,
+    );
 
     fireEvent.click(await screen.findByTestId("add-scoped-card"));
     expect(

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.ephemeralMessages.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.ephemeralMessages.e2e.test.tsx
@@ -1,6 +1,13 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Message } from "@ag-ui/core";
 import type { RunAgentInput } from "@ag-ui/client";
 import {
   MockStepwiseAgent,
@@ -13,6 +20,8 @@ import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
 import { useCopilotKit } from "../../../providers/CopilotKitProvider";
 import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
 import { CopilotChat } from "../CopilotChat";
+import { CopilotChatMessageView } from "../CopilotChatMessageView";
+import { ScrollElementContext } from "../scroll-element-context";
 
 class CapturingAgent extends MockStepwiseAgent {
   lastRunInput?: RunAgentInput;
@@ -39,6 +48,70 @@ const ephemeralRenderer = {
   render: null,
   renderEphemeral: EphemeralCard,
 };
+
+const ScopeSwitchContext = React.createContext<() => void>(() => {});
+
+const realRAF = globalThis.requestAnimationFrame;
+const realWindowRAF =
+  typeof window !== "undefined" ? window.requestAnimationFrame : realRAF;
+const isKnownTanstackTeardownError = (err: unknown): boolean => {
+  const message =
+    (err as { message?: string } | null | undefined)?.message ?? "";
+  return (
+    message.includes("Cannot read properties of null") &&
+    message.includes("requestAnimationFrame")
+  );
+};
+const wrapRAF = (real: typeof requestAnimationFrame) =>
+  ((cb: FrameRequestCallback) =>
+    real((time) => {
+      try {
+        cb(time);
+      } catch (err) {
+        if (isKnownTanstackTeardownError(err)) return;
+        throw err;
+      }
+    })) as typeof requestAnimationFrame;
+const noopRAF = ((_cb: FrameRequestCallback) =>
+  0) as typeof requestAnimationFrame;
+
+beforeEach(() => {
+  globalThis.requestAnimationFrame = wrapRAF(realRAF);
+  if (typeof window !== "undefined") {
+    window.requestAnimationFrame = wrapRAF(realWindowRAF);
+  }
+});
+
+afterEach(async () => {
+  await act(async () => {
+    await new Promise<void>((resolve) => realRAF(() => resolve()));
+    await new Promise<void>((resolve) => realRAF(() => resolve()));
+  });
+  globalThis.requestAnimationFrame = noopRAF;
+  if (typeof window !== "undefined") {
+    window.requestAnimationFrame = noopRAF;
+  }
+});
+
+function ScopeAwareChatView({
+  messages = [],
+  ephemeralMessages = [],
+  isRunning = false,
+}: any) {
+  const switchThread = React.useContext(ScopeSwitchContext);
+  return (
+    <>
+      <button data-testid="switch-renderer-scope" onClick={switchThread}>
+        Switch renderer scope
+      </button>
+      <CopilotChatMessageView
+        messages={messages}
+        ephemeralMessages={ephemeralMessages}
+        isRunning={isRunning}
+      />
+    </>
+  );
+}
 
 describe("CopilotChat ephemeral messages", () => {
   it("keeps a frontend event card out of the next agent run", async () => {
@@ -214,6 +287,206 @@ describe("CopilotChat ephemeral messages", () => {
       ),
     ).toBe(false);
     expect(outerAgent.messages).toEqual([]);
+  });
+
+  it("remounts an unchanged ephemeral card when its agent and thread scope changes", async () => {
+    const agent = new CapturingAgent();
+
+    function Harness() {
+      const [threadId, setThreadId] = React.useState("thread-a");
+      const { copilotkit } = useCopilotKit();
+      React.useEffect(() => {
+        copilotkit.addEphemeralMessage("default", "thread-a", {
+          id: "same-scope-card",
+          content: "same content",
+        });
+        copilotkit.addEphemeralMessage("default", "thread-b", {
+          id: "same-scope-card",
+          content: "same content",
+        });
+      }, [copilotkit]);
+
+      return (
+        <ScopeSwitchContext.Provider value={() => setThreadId("thread-b")}>
+          <CopilotChat
+            threadId={threadId}
+            chatView={ScopeAwareChatView as any}
+          />
+        </ScopeSwitchContext.Provider>
+      );
+    }
+
+    const scopedRenderer = {
+      render: null,
+      renderEphemeral: ({ agentId, threadId, message }: any) => (
+        <div data-testid="scope-rendered-card">
+          {`${agentId}:${threadId}:${message.content}`}
+        </div>
+      ),
+    };
+
+    renderWithCopilotKit({
+      agent,
+      renderCustomMessages: [scopedRenderer],
+      children: <Harness />,
+    });
+
+    expect(
+      await screen.findByText("default:thread-a:same content"),
+    ).toBeDefined();
+    fireEvent.click(screen.getByTestId("switch-renderer-scope"));
+    await waitFor(() => {
+      expect(screen.getByText("default:thread-b:same content")).toBeDefined();
+    });
+  });
+
+  it("prefers an agent-specific ephemeral renderer over the generic renderer", async () => {
+    const agent = new CapturingAgent();
+    const genericRenderer = {
+      render: null,
+      renderEphemeral: () => (
+        <div data-testid="generic-ephemeral-renderer">generic</div>
+      ),
+    };
+    const agentRenderer = {
+      agentId: "default",
+      render: null,
+      renderEphemeral: () => (
+        <div data-testid="agent-ephemeral-renderer">agent-specific</div>
+      ),
+    };
+
+    function Controls() {
+      const { addEphemeralMessage } = useAgent();
+      return (
+        <>
+          <button
+            data-testid="add-priority-card"
+            onClick={() =>
+              addEphemeralMessage({
+                id: "priority-card",
+                content: "priority",
+              })
+            }
+          >
+            Add priority card
+          </button>
+          <div style={{ height: 400 }}>
+            <CopilotChat welcomeScreen={false} />
+          </div>
+        </>
+      );
+    }
+
+    renderWithCopilotKit({
+      agent,
+      renderCustomMessages: [genericRenderer, agentRenderer],
+      children: <Controls />,
+    });
+
+    fireEvent.click(await screen.findByTestId("add-priority-card"));
+    expect(await screen.findByTestId("agent-ephemeral-renderer")).toBeDefined();
+    expect(screen.queryByTestId("generic-ephemeral-renderer")).toBeNull();
+  });
+
+  it("composes anchored and orphaned cards in the virtualized transcript", async () => {
+    const TOTAL = 51;
+    const messages: Message[] = Array.from({ length: TOTAL }, (_, index) => ({
+      id: `virtual-message-${index}`,
+      role: "user",
+      content: `Virtual message ${index}`,
+    }));
+    const fakeScrollElement = document.createElement("div");
+    Object.defineProperty(fakeScrollElement, "clientHeight", {
+      configurable: true,
+      get: () => 600,
+    });
+    fakeScrollElement.getBoundingClientRect = () =>
+      ({
+        height: 600,
+        width: 800,
+        top: 0,
+        left: 0,
+        bottom: 600,
+        right: 800,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    const { unmount } = renderWithCopilotKit({
+      renderCustomMessages: [ephemeralRenderer],
+      children: (
+        <ScrollElementContext.Provider value={fakeScrollElement}>
+          <CopilotChatMessageView
+            messages={messages}
+            ephemeralMessages={[
+              {
+                id: "anchored-virtual-card",
+                content: "Anchored virtual card",
+                anchorMessageId: "virtual-message-0",
+              },
+              {
+                id: "orphaned-virtual-card",
+                content: "Orphaned virtual card",
+                anchorMessageId: "missing-message",
+              },
+            ]}
+          />
+        </ScrollElementContext.Provider>
+      ),
+    });
+
+    await waitFor(() => {
+      const virtualContainer = document.querySelector(
+        '[data-testid="copilot-message-list"] > div[style*="position: relative"]',
+      ) as HTMLElement | null;
+      expect(virtualContainer).not.toBeNull();
+      expect(virtualContainer?.style.height).toBe("4200px");
+    });
+
+    await act(async () => {
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => resolve()),
+      );
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => resolve()),
+      );
+    });
+    unmount();
+  });
+
+  it("renders an orphaned card after the persisted transcript", async () => {
+    const agent = new CapturingAgent();
+    renderWithCopilotKit({
+      agent,
+      renderCustomMessages: [ephemeralRenderer],
+      children: (
+        <CopilotChatMessageView
+          messages={[
+            {
+              id: "persisted-before-orphan",
+              role: "user",
+              content: "Persisted before orphan",
+            },
+          ]}
+          ephemeralMessages={[
+            {
+              id: "orphaned-card",
+              content: "Orphaned card",
+              anchorMessageId: "missing-message",
+            },
+          ]}
+        />
+      ),
+    });
+
+    await waitFor(() => {
+      const list = screen.getByTestId("copilot-message-list");
+      expect(list.textContent?.indexOf("Persisted before orphan")).toBeLessThan(
+        list.textContent?.indexOf("Orphaned card") ?? -1,
+      );
+    });
   });
 
   it("renders the core-composed transcript in persisted-then-ephemeral order", async () => {

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.ephemeralMessages.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.ephemeralMessages.e2e.test.tsx
@@ -1,0 +1,279 @@
+import React from "react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { RunAgentInput } from "@ag-ui/client";
+import {
+  MockStepwiseAgent,
+  renderWithCopilotKit,
+  runFinishedEvent,
+  runStartedEvent,
+} from "../../../__tests__/utils/test-helpers";
+import { useAgent } from "../../../hooks/use-agent";
+import { useCopilotKit } from "../../../providers/CopilotKitProvider";
+import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
+import { CopilotChat } from "../CopilotChat";
+
+class CapturingAgent extends MockStepwiseAgent {
+  lastRunInput?: RunAgentInput;
+
+  run(input: RunAgentInput) {
+    this.lastRunInput = input;
+    return super.run(input);
+  }
+}
+
+function EphemeralCard({
+  message,
+}: {
+  message: { id: string; content: unknown };
+}) {
+  return (
+    <div data-testid={`ephemeral-card-${message.id}`}>
+      {String(message.content)}
+    </div>
+  );
+}
+
+const ephemeralRenderer = {
+  render: null,
+  renderEphemeral: EphemeralCard,
+};
+
+describe("CopilotChat ephemeral messages", () => {
+  it("keeps a frontend event card out of the next agent run", async () => {
+    const agent = new CapturingAgent();
+
+    function Harness() {
+      const { addEphemeralMessage, agent: hookAgent } = useAgent();
+      const { copilotkit } = useCopilotKit();
+
+      return (
+        <>
+          <button
+            data-testid="add-card"
+            onClick={() =>
+              addEphemeralMessage({
+                id: "frontend-event",
+                content: "Frontend event card",
+              })
+            }
+          >
+            Add card
+          </button>
+          <button
+            data-testid="run-agent"
+            onClick={() => {
+              hookAgent.addMessage({
+                id: "ephemeral-card-lookalike",
+                role: "user",
+                content: "Persisted lookalike",
+              });
+              void copilotkit.runAgent({ agent: hookAgent });
+            }}
+          >
+            Run agent
+          </button>
+          <div style={{ height: 400 }}>
+            <CopilotChat welcomeScreen={false} />
+          </div>
+        </>
+      );
+    }
+
+    renderWithCopilotKit({
+      agent,
+      renderCustomMessages: [ephemeralRenderer],
+      children: <Harness />,
+    });
+
+    fireEvent.click(await screen.findByTestId("add-card"));
+    expect(
+      (await screen.findByTestId("ephemeral-card-frontend-event")).textContent,
+    ).toContain("Frontend event card");
+
+    fireEvent.click(screen.getByTestId("run-agent"));
+    await waitFor(() => expect(agent.lastRunInput).toBeDefined());
+
+    expect(agent.messages.map((message) => message.id)).toEqual([
+      "ephemeral-card-lookalike",
+    ]);
+    expect(agent.lastRunInput?.messages.map((message) => message.id)).toEqual([
+      "ephemeral-card-lookalike",
+    ]);
+    expect(
+      screen.getByTestId("ephemeral-card-frontend-event").textContent,
+    ).toContain("Frontend event card");
+
+    agent.emit(runStartedEvent());
+    agent.emit(runFinishedEvent());
+    agent.complete();
+  });
+
+  it("renders the core-composed transcript in persisted-then-ephemeral order", async () => {
+    const agent = new CapturingAgent();
+    agent.addMessage({
+      id: "persisted-message",
+      role: "user",
+      content: "Persisted message",
+    });
+
+    function Harness() {
+      const { addEphemeralMessage, agent: hookAgent } = useAgent();
+      React.useEffect(() => {
+        addEphemeralMessage({
+          id: "ephemeral-message",
+          content: "Ephemeral message",
+        });
+      }, [addEphemeralMessage, hookAgent]);
+
+      return (
+        <div style={{ height: 400 }}>
+          <CopilotChat welcomeScreen={false} />
+        </div>
+      );
+    }
+
+    renderWithCopilotKit({
+      agent,
+      renderCustomMessages: [ephemeralRenderer],
+      children: <Harness />,
+    });
+
+    await waitFor(() => {
+      const list = screen.getByTestId("copilot-message-list");
+      expect(list.textContent).toContain("Persisted message");
+      expect(list.textContent).toContain("Ephemeral message");
+      expect(list.textContent?.indexOf("Persisted message")).toBeLessThan(
+        list.textContent?.indexOf("Ephemeral message") ?? -1,
+      );
+    });
+  });
+
+  it("keeps a persisted lookalike in history beside an explicit ephemeral card", async () => {
+    const agent = new CapturingAgent();
+    agent.addMessage({
+      id: "ephemeral-card-lookalike",
+      role: "user",
+      content: "Persisted lookalike",
+    });
+
+    function Harness() {
+      const { addEphemeralMessage, agent: hookAgent } = useAgent();
+      React.useEffect(() => {
+        addEphemeralMessage({
+          id: "real-ephemeral-card",
+          content: "Real ephemeral card",
+        });
+      }, [addEphemeralMessage, hookAgent]);
+
+      return (
+        <div style={{ height: 400 }}>
+          <CopilotChat welcomeScreen={false} />
+        </div>
+      );
+    }
+
+    renderWithCopilotKit({
+      agent,
+      renderCustomMessages: [ephemeralRenderer],
+      children: <Harness />,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Persisted lookalike")).toBeDefined();
+      expect(
+        screen.getByTestId("ephemeral-card-real-ephemeral-card").textContent,
+      ).toContain("Real ephemeral card");
+    });
+  });
+
+  it("isolates ephemeral cards across thread changes and supports remove and clear", async () => {
+    const agent = new CapturingAgent();
+
+    function ScopedControls({
+      onSwitchThread,
+    }: {
+      onSwitchThread: () => void;
+    }) {
+      const {
+        addEphemeralMessage,
+        removeEphemeralMessage,
+        clearEphemeralMessages,
+      } = useAgent();
+
+      return (
+        <>
+          <button
+            data-testid="add-scoped-card"
+            onClick={() =>
+              addEphemeralMessage({
+                id: "scoped-card",
+                content: "Scoped card",
+              })
+            }
+          >
+            Add scoped card
+          </button>
+          <button
+            data-testid="remove-scoped-card"
+            onClick={() => removeEphemeralMessage("scoped-card")}
+          >
+            Remove scoped card
+          </button>
+          <button
+            data-testid="clear-scoped-cards"
+            onClick={() => clearEphemeralMessages()}
+          >
+            Clear scoped cards
+          </button>
+          <button data-testid="switch-thread" onClick={onSwitchThread}>
+            Switch thread
+          </button>
+        </>
+      );
+    }
+
+    function Harness() {
+      const [threadId, setThreadId] = React.useState("thread-a");
+      return (
+        <CopilotChatConfigurationProvider agentId="default" threadId={threadId}>
+          <ScopedControls onSwitchThread={() => setThreadId("thread-b")} />
+          <div style={{ height: 400 }}>
+            <CopilotChat welcomeScreen={false} />
+          </div>
+        </CopilotChatConfigurationProvider>
+      );
+    }
+
+    renderWithCopilotKit({
+      agent,
+      renderCustomMessages: [ephemeralRenderer],
+      children: <Harness />,
+    });
+
+    fireEvent.click(await screen.findByTestId("add-scoped-card"));
+    expect(
+      await screen.findByTestId("ephemeral-card-scoped-card"),
+    ).toBeDefined();
+
+    fireEvent.click(screen.getByTestId("switch-thread"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("ephemeral-card-scoped-card")).toBeNull();
+    });
+
+    fireEvent.click(screen.getByTestId("add-scoped-card"));
+    expect(
+      await screen.findByTestId("ephemeral-card-scoped-card"),
+    ).toBeDefined();
+    fireEvent.click(screen.getByTestId("remove-scoped-card"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("ephemeral-card-scoped-card")).toBeNull();
+    });
+
+    fireEvent.click(screen.getByTestId("add-scoped-card"));
+    fireEvent.click(screen.getByTestId("clear-scoped-cards"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("ephemeral-card-scoped-card")).toBeNull();
+    });
+  });
+});

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.runActivityReconnect.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.runActivityReconnect.test.tsx
@@ -169,6 +169,7 @@ function createTestCore(
     connectAgent,
     defaultThrottleMs: undefined,
     getEphemeralMessages: vi.fn(() => []),
+    reconcileEphemeralMessages: vi.fn(() => false),
     getAgent: vi.fn(
       (agentId: string) => agents[agentId as keyof typeof agents],
     ),

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.runActivityReconnect.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.runActivityReconnect.test.tsx
@@ -168,6 +168,7 @@ function createTestCore(
     applyHeadersToAgent: vi.fn(),
     connectAgent,
     defaultThrottleMs: undefined,
+    getEphemeralMessages: vi.fn(() => []),
     getAgent: vi.fn(
       (agentId: string) => agents[agentId as keyof typeof agents],
     ),
@@ -179,6 +180,7 @@ function createTestCore(
         : (options.registeredStore ?? store),
     ),
     headers: {},
+    renderCustomMessages: [],
     intelligence: options.intelligence,
     registerThreadStore: vi.fn(),
     runtimeConnectionStatus:

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.welcomeGate.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.welcomeGate.test.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeEach } from "vitest";
 import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
 import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
@@ -95,7 +95,7 @@ describe("CopilotChat welcome / connect integration", () => {
       expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
     });
 
-    it("does not let its view provider override the chat lifecycle scope", async () => {
+    it("lets its provider lifecycle follow a local thread selection", async () => {
       const agent = new TrackingAgent();
       agent.agentId = DEFAULT_AGENT_ID;
 
@@ -119,8 +119,48 @@ describe("CopilotChat welcome / connect integration", () => {
           "view-selected-thread",
         );
       });
-      expect(TrackingAgent.connectCalls).toHaveLength(0);
-      expect(agent.threadId).not.toBe("view-selected-thread");
+      await waitFor(() => {
+        expect(
+          TrackingAgent.connectCalls.some(
+            (call) => call.threadId === "view-selected-thread",
+          ),
+        ).toBe(true);
+      });
+      expect(agent.threadId).toBe("view-selected-thread");
+    });
+  });
+
+  it("runs the chat lifecycle from an outer provider thread switch", async () => {
+    const agent = new TrackingAgent();
+    agent.agentId = DEFAULT_AGENT_ID;
+
+    function ThreadSwitcher() {
+      const config = useCopilotChatConfiguration();
+      return (
+        <button
+          data-testid="switch-outer-thread"
+          onClick={() => config?.setActiveThreadId("provider-selected-thread")}
+        >
+          Switch thread
+        </button>
+      );
+    }
+
+    renderWithKit(
+      <CopilotChatConfigurationProvider>
+        <ThreadSwitcher />
+        <CopilotChat />
+      </CopilotChatConfigurationProvider>,
+      agent,
+    );
+
+    fireEvent.click(screen.getByTestId("switch-outer-thread"));
+    await waitFor(() => {
+      expect(
+        TrackingAgent.connectCalls.some(
+          (call) => call.threadId === "provider-selected-thread",
+        ),
+      ).toBe(true);
     });
   });
 

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.welcomeGate.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.welcomeGate.test.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeEach } from "vitest";
 import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
 import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
+import { useCopilotChatConfiguration } from "../../../providers/CopilotChatConfigurationProvider";
 import { CopilotChat } from "../CopilotChat";
 import { MockStepwiseAgent } from "../../../__tests__/utils/test-helpers";
 import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
@@ -92,6 +93,34 @@ describe("CopilotChat welcome / connect integration", () => {
 
       expect(TrackingAgent.connectCalls).toHaveLength(0);
       expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
+    });
+
+    it("does not let its view provider override the chat lifecycle scope", async () => {
+      const agent = new TrackingAgent();
+      agent.agentId = DEFAULT_AGENT_ID;
+
+      function ViewWithLocalThreadAction() {
+        const config = useCopilotChatConfiguration();
+        useEffect(() => {
+          config?.setActiveThreadId("view-selected-thread", { explicit: true });
+        }, [config]);
+        return (
+          <output data-testid="view-provider-thread">{config?.threadId}</output>
+        );
+      }
+
+      renderWithKit(
+        <CopilotChat chatView={ViewWithLocalThreadAction as any} />,
+        agent,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("view-provider-thread").textContent).toBe(
+          "view-selected-thread",
+        );
+      });
+      expect(TrackingAgent.connectCalls).toHaveLength(0);
+      expect(agent.threadId).not.toBe("view-selected-thread");
     });
   });
 

--- a/packages/react-core/src/v2/components/chat/__tests__/copilot-chat-throttle.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/copilot-chat-throttle.test.tsx
@@ -106,6 +106,11 @@ describe("CopilotChat throttleMs prop", () => {
       expect.objectContaining({
         throttleMs: 500,
       }),
+      expect.objectContaining({
+        agentId: "default",
+        threadId: "mock-thread-id",
+        hasExplicitThreadId: false,
+      }),
     );
   });
 
@@ -115,6 +120,11 @@ describe("CopilotChat throttleMs prop", () => {
     expect(mockUseAgent).toHaveBeenCalledWith(
       expect.objectContaining({
         throttleMs: undefined,
+      }),
+      expect.objectContaining({
+        agentId: "default",
+        threadId: "mock-thread-id",
+        hasExplicitThreadId: false,
       }),
     );
   });

--- a/packages/react-core/src/v2/components/chat/__tests__/copilot-chat-throttle.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/copilot-chat-throttle.test.tsx
@@ -74,6 +74,7 @@ function createMockChatContext(agent: MockStepwiseAgent) {
       runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Connected,
       runtimeTransport: "rest",
       headers: {},
+      renderCustomMessages: [],
       agents: { [String(agent.agentId)]: agent },
       connectAgent: vi.fn().mockResolvedValue(undefined),
       subscribe: vi.fn(() => ({ unsubscribe: vi.fn() })),

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent-stability.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent-stability.test.tsx
@@ -28,6 +28,7 @@ describe("useAgent stability during runtime connection", () => {
   let mockCopilotkit: {
     getAgent: ReturnType<typeof vi.fn>;
     getEphemeralMessages: ReturnType<typeof vi.fn>;
+    reconcileEphemeralMessages: ReturnType<typeof vi.fn>;
     subscribe: ReturnType<typeof vi.fn>;
     runtimeUrl: string | undefined;
     runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus;
@@ -46,6 +47,7 @@ describe("useAgent stability during runtime connection", () => {
     mockCopilotkit = {
       getAgent: vi.fn(() => undefined),
       getEphemeralMessages: vi.fn(() => []),
+      reconcileEphemeralMessages: vi.fn(() => false),
       subscribe: vi.fn(() => ({ unsubscribe: vi.fn() })),
       runtimeUrl: "http://localhost:3000/api/copilotkit",
       runtimeConnectionStatus:

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent-stability.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent-stability.test.tsx
@@ -27,6 +27,8 @@ const mockUseCopilotKit = useCopilotKit as ReturnType<typeof vi.fn>;
 describe("useAgent stability during runtime connection", () => {
   let mockCopilotkit: {
     getAgent: ReturnType<typeof vi.fn>;
+    getEphemeralMessages: ReturnType<typeof vi.fn>;
+    subscribe: ReturnType<typeof vi.fn>;
     runtimeUrl: string | undefined;
     runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus;
     runtimeTransport: string;
@@ -43,6 +45,8 @@ describe("useAgent stability during runtime connection", () => {
   beforeEach(() => {
     mockCopilotkit = {
       getAgent: vi.fn(() => undefined),
+      getEphemeralMessages: vi.fn(() => []),
+      subscribe: vi.fn(() => ({ unsubscribe: vi.fn() })),
       runtimeUrl: "http://localhost:3000/api/copilotkit",
       runtimeConnectionStatus:
         CopilotKitCoreRuntimeConnectionStatus.Disconnected,

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent-throttle.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent-throttle.test.tsx
@@ -145,12 +145,14 @@ function createMockContext(
   return {
     copilotkit: {
       getAgent: () => agent,
+      getEphemeralMessages: () => [],
       runtimeUrl: "http://localhost:3000/api/copilot",
       runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Connected,
       runtimeTransport: "rest",
       headers: {},
       agents: { [String(agent.agentId)]: agent },
       defaultThrottleMs: core.defaultThrottleMs,
+      subscribe: () => ({ unsubscribe: () => {} }),
       subscribeToAgentWithOptions: core.subscribeToAgentWithOptions.bind(core),
     },
     executingToolCallIds: new Set(),

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent-throttle.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent-throttle.test.tsx
@@ -146,6 +146,7 @@ function createMockContext(
     copilotkit: {
       getAgent: () => agent,
       getEphemeralMessages: () => [],
+      reconcileEphemeralMessages: () => false,
       runtimeUrl: "http://localhost:3000/api/copilot",
       runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Connected,
       runtimeTransport: "rest",

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent.e2e.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent.e2e.test.tsx
@@ -232,6 +232,62 @@ describe("useAgent e2e", () => {
     });
   });
 
+  it("resets messages across non-explicit provider thread changes", async () => {
+    const agent = new MockStepwiseAgent();
+
+    function Harness() {
+      const { agent: hookAgent } = useAgent();
+      return (
+        <output data-testid="non-explicit-thread-messages">
+          {hookAgent.messages.map((message) => message.id).join(",")}
+        </output>
+      );
+    }
+
+    const { rerender } = render(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <CopilotChatConfigurationProvider
+          agentId="default"
+          threadId="thread-a"
+          hasExplicitThreadId={false}
+        >
+          <Harness />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+
+    await waitFor(() => expect(agent.threadId).toBeDefined());
+    agent.addMessage({
+      id: "thread-a-message",
+      role: "user",
+      content: "Thread A history",
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("non-explicit-thread-messages").textContent,
+      ).toContain("thread-a-message");
+    });
+
+    rerender(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <CopilotChatConfigurationProvider
+          agentId="default"
+          threadId="thread-b"
+          hasExplicitThreadId={false}
+        >
+          <Harness />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+
+    await waitFor(() => {
+      expect(agent.threadId).toBe("thread-b");
+      expect(
+        screen.getByTestId("non-explicit-thread-messages").textContent,
+      ).toBe("");
+    });
+  });
+
   it("keeps new-thread ephemeral IDs valid while the previous messages are still present", async () => {
     const agent = new MockStepwiseAgent();
     let currentAdd:
@@ -454,6 +510,49 @@ describe("useAgent e2e", () => {
     await waitFor(() => {
       expect(
         screen.getByTestId("reconciled-ephemeral-values").textContent,
+      ).toBe("");
+    });
+  });
+
+  it("refreshes the rendered snapshot for a mount-time persisted collision", async () => {
+    const agent = new MockStepwiseAgent();
+
+    function SeededHarness() {
+      const { copilotkit } = useCopilotKit();
+      const seeded = React.useRef(false);
+      if (!seeded.current) {
+        seeded.current = true;
+        copilotkit.addEphemeralMessage("default", "test-thread", {
+          id: "mount-collision-card",
+          content: "client-only",
+        });
+        agent.addMessage({
+          id: "mount-collision-card",
+          role: "user",
+          content: "persisted",
+        });
+      }
+
+      return <ObservedEphemeralMessages />;
+    }
+
+    function ObservedEphemeralMessages() {
+      const { ephemeralMessages } = useAgent({ updates: [] });
+      return (
+        <output data-testid="mount-reconciled-ephemeral-values">
+          {ephemeralMessages.map((message) => message.id).join(",")}
+        </output>
+      );
+    }
+
+    renderWithCopilotKit({
+      agent,
+      children: <SeededHarness />,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("mount-reconciled-ephemeral-values").textContent,
       ).toBe("");
     });
   });

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent.e2e.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent.e2e.test.tsx
@@ -156,4 +156,74 @@ describe("useAgent e2e", () => {
       });
     });
   });
+
+  it("routes ephemeral operations to the current agent and thread", async () => {
+    const agent = new MockStepwiseAgent();
+
+    function EphemeralTestComponent() {
+      const {
+        addEphemeralMessage,
+        removeEphemeralMessage,
+        clearEphemeralMessages,
+        ephemeralMessages,
+      } = useAgent();
+
+      return (
+        <div>
+          <button
+            data-testid="add-ephemeral"
+            onClick={() =>
+              addEphemeralMessage({
+                id: "frontend-event",
+                content: "Frontend event",
+              })
+            }
+          >
+            Add
+          </button>
+          <button
+            data-testid="remove-ephemeral"
+            onClick={() => removeEphemeralMessage("frontend-event")}
+          >
+            Remove
+          </button>
+          <button
+            data-testid="clear-ephemeral"
+            onClick={() => clearEphemeralMessages()}
+          >
+            Clear
+          </button>
+          <output data-testid="ephemeral-values">
+            {ephemeralMessages.map(
+              (message) => `${message.id}:${message.content}`,
+            )}
+          </output>
+        </div>
+      );
+    }
+
+    renderWithCopilotKit({
+      agent,
+      threadId: "thread-a",
+      children: <EphemeralTestComponent />,
+    });
+
+    fireEvent.click(await screen.findByTestId("add-ephemeral"));
+    await waitFor(() => {
+      expect(screen.getByTestId("ephemeral-values").textContent).toContain(
+        "frontend-event:Frontend event",
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("remove-ephemeral"));
+    await waitFor(() => {
+      expect(screen.getByTestId("ephemeral-values").textContent).toBe("");
+    });
+
+    fireEvent.click(screen.getByTestId("add-ephemeral"));
+    fireEvent.click(screen.getByTestId("clear-ephemeral"));
+    await waitFor(() => {
+      expect(screen.getByTestId("ephemeral-values").textContent).toBe("");
+    });
+  });
 });

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent.e2e.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent.e2e.test.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
-import { type BaseEvent, type RunAgentInput } from "@ag-ui/client";
-import { Observable } from "rxjs";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
+import type { Observable } from "rxjs";
 import {
   MockStepwiseAgent,
   renderWithCopilotKit,
@@ -224,6 +224,65 @@ describe("useAgent e2e", () => {
     fireEvent.click(screen.getByTestId("clear-ephemeral"));
     await waitFor(() => {
       expect(screen.getByTestId("ephemeral-values").textContent).toBe("");
+    });
+  });
+
+  it("uses a private thread argument over the surrounding chat thread", async () => {
+    const runtimeAgent = new MockStepwiseAgent();
+
+    function PrivateThreadComponent() {
+      const { addEphemeralMessage, isReady } = useAgent({
+        agentId: "private",
+        runtimeAgentId: "runtime",
+        threadId: "private-thread",
+      });
+      const { copilotkit } = useCopilotKit();
+
+      return (
+        <>
+          <output data-testid="private-agent-ready">{String(isReady)}</output>
+          <button
+            data-testid="add-private-thread-card"
+            onClick={() =>
+              addEphemeralMessage({
+                id: "private-thread-card",
+                content: "private thread",
+              })
+            }
+          >
+            Add private thread card
+          </button>
+          <output data-testid="private-thread-values">
+            {copilotkit
+              .getEphemeralMessages("private", "private-thread")
+              .map((message) => message.id)}
+          </output>
+          <output data-testid="outer-thread-values">
+            {copilotkit
+              .getEphemeralMessages("private", "outer-thread")
+              .map((message) => message.id)}
+          </output>
+        </>
+      );
+    }
+
+    renderWithCopilotKit({
+      agents: { runtime: runtimeAgent },
+      threadId: "outer-thread",
+      children: <PrivateThreadComponent />,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("private-agent-ready").textContent).toBe(
+        "true",
+      );
+    });
+    fireEvent.click(screen.getByTestId("add-private-thread-card"));
+    await waitFor(() => {
+      expect(screen.getByTestId("private-thread-values").textContent).toBe(
+        "private-thread-card",
+      );
+      expect(screen.getByTestId("outer-thread-values").textContent).toBe("");
     });
   });
 });

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent.e2e.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent.e2e.test.tsx
@@ -297,6 +297,131 @@ describe("useAgent e2e", () => {
     });
   });
 
+  it("clears non-explicit history before returning to an explicit thread", async () => {
+    const agent = new MockStepwiseAgent();
+    let switchScope:
+      | ((threadId: string, hasExplicitThreadId: boolean) => void)
+      | undefined;
+
+    function ScopeControls() {
+      const {
+        agent: hookAgent,
+        addEphemeralMessage,
+        ephemeralMessages,
+      } = useAgent();
+      const [lastAddResult, setLastAddResult] = React.useState<boolean | null>(
+        null,
+      );
+
+      return (
+        <>
+          <button
+            data-testid="switch-to-non-explicit-b"
+            onClick={() => switchScope?.("thread-b", false)}
+          >
+            Switch to B
+          </button>
+          <button
+            data-testid="switch-to-explicit-a"
+            onClick={() => switchScope?.("thread-a", true)}
+          >
+            Switch to A
+          </button>
+          <button
+            data-testid="add-persisted-b-message"
+            onClick={() =>
+              hookAgent.addMessage({
+                id: "shared-message-id",
+                role: "user",
+                content: "thread B history",
+              })
+            }
+          >
+            Add B history
+          </button>
+          <button
+            data-testid="add-ephemeral-a-message"
+            onClick={() =>
+              setLastAddResult(
+                addEphemeralMessage({
+                  id: "shared-message-id",
+                  content: "thread A card",
+                }),
+              )
+            }
+          >
+            Add A card
+          </button>
+          <output data-testid="persisted-message-ids">
+            {hookAgent.messages.map((message) => message.id).join(",")}
+          </output>
+          <output data-testid="ephemeral-message-values">
+            {ephemeralMessages
+              .map((message) => `${message.id}:${message.content}`)
+              .join(",")}
+          </output>
+          <output data-testid="last-ephemeral-add-result">
+            {lastAddResult === null ? "" : String(lastAddResult)}
+          </output>
+        </>
+      );
+    }
+
+    function Harness() {
+      const [scope, setScope] = React.useState({
+        threadId: "thread-a",
+        hasExplicitThreadId: true,
+      });
+      switchScope = (threadId, hasExplicitThreadId) =>
+        setScope({ threadId, hasExplicitThreadId });
+
+      return (
+        <CopilotChatConfigurationProvider
+          agentId="default"
+          threadId={scope.threadId}
+          hasExplicitThreadId={scope.hasExplicitThreadId}
+        >
+          <ScopeControls />
+          <div style={{ height: 400 }}>
+            <CopilotChat welcomeScreen={false} />
+          </div>
+        </CopilotChatConfigurationProvider>
+      );
+    }
+
+    render(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <Harness />
+      </CopilotKitProvider>,
+    );
+
+    fireEvent.click(await screen.findByTestId("switch-to-non-explicit-b"));
+    await waitFor(() => expect(agent.threadId).toBe("thread-b"));
+
+    fireEvent.click(screen.getByTestId("add-persisted-b-message"));
+    await waitFor(() => {
+      expect(screen.getByTestId("persisted-message-ids").textContent).toBe(
+        "shared-message-id",
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("switch-to-explicit-a"));
+    await waitFor(() => expect(agent.threadId).toBe("thread-a"));
+    await waitFor(() => {
+      expect(screen.getByTestId("persisted-message-ids").textContent).toBe("");
+    });
+
+    fireEvent.click(screen.getByTestId("add-ephemeral-a-message"));
+    await waitFor(() => {
+      expect(screen.getByTestId("last-ephemeral-add-result").textContent).toBe(
+        "true",
+      );
+      expect(
+        screen.getByTestId("ephemeral-message-values").textContent,
+      ).toContain("shared-message-id:thread A card");
+    });
+  });
+
   it("reconciles persisted collisions when message updates are disabled", async () => {
     const agent = new MockStepwiseAgent();
 

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent.e2e.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent.e2e.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
 import type { Observable } from "rxjs";
@@ -12,8 +12,12 @@ import {
   testId,
 } from "../../__tests__/utils/test-helpers";
 import { useAgent } from "../use-agent";
-import { useCopilotKit } from "../../providers/CopilotKitProvider";
+import {
+  CopilotKitProvider,
+  useCopilotKit,
+} from "../../providers/CopilotKitProvider";
 import { CopilotChat } from "../../components/chat/CopilotChat";
+import { CopilotChatConfigurationProvider } from "../../providers/CopilotChatConfigurationProvider";
 
 /**
  * Mock agent that captures RunAgentInput to verify state is passed correctly
@@ -227,6 +231,42 @@ describe("useAgent e2e", () => {
     });
   });
 
+  it("reconciles persisted collisions when message updates are disabled", async () => {
+    const agent = new MockStepwiseAgent();
+
+    function Harness() {
+      const { agent: hookAgent, ephemeralMessages } = useAgent({
+        updates: [],
+      });
+      const { copilotkit } = useCopilotKit();
+
+      React.useEffect(() => {
+        copilotkit.addEphemeralMessage("default", "test-thread", {
+          id: "collision-card",
+          content: "client-only",
+        });
+        hookAgent.addMessage({
+          id: "collision-card",
+          role: "user",
+          content: "persisted",
+        });
+      }, [copilotkit, hookAgent]);
+
+      return (
+        <output data-testid="reconciled-ephemeral-values">
+          {ephemeralMessages.map((message) => message.id).join(",")}
+        </output>
+      );
+    }
+
+    renderWithCopilotKit({ agent, children: <Harness /> });
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("reconciled-ephemeral-values").textContent,
+      ).toBe("");
+    });
+  });
+
   it("uses a private thread argument over the surrounding chat thread", async () => {
     const runtimeAgent = new MockStepwiseAgent();
 
@@ -283,6 +323,87 @@ describe("useAgent e2e", () => {
         "private-thread-card",
       );
       expect(screen.getByTestId("outer-thread-values").textContent).toBe("");
+    });
+  });
+
+  it("rejects a deferred callback captured before an explicit thread switch", async () => {
+    const agent = new MockStepwiseAgent();
+    let staleAdd:
+      | ((message: { id: string; content: string }) => boolean)
+      | null = null;
+
+    function Harness() {
+      const { addEphemeralMessage } = useAgent();
+      React.useEffect(() => {
+        staleAdd ??= addEphemeralMessage;
+      }, [addEphemeralMessage]);
+      return null;
+    }
+
+    const { rerender } = render(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <CopilotChatConfigurationProvider agentId="default" threadId="thread-a">
+          <Harness />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+
+    await waitFor(() => expect(staleAdd).not.toBeNull());
+    rerender(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <CopilotChatConfigurationProvider agentId="default" threadId="thread-b">
+          <Harness />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+
+    await waitFor(() => {
+      expect(staleAdd?.({ id: "stale-thread-card", content: "stale" })).toBe(
+        false,
+      );
+    });
+  });
+
+  it("rejects a deferred callback captured before an explicit agent switch", async () => {
+    const firstAgent = new MockStepwiseAgent();
+    const secondAgent = new MockStepwiseAgent();
+    let staleAdd:
+      | ((message: { id: string; content: string }) => boolean)
+      | null = null;
+
+    function Harness() {
+      const { addEphemeralMessage } = useAgent();
+      React.useEffect(() => {
+        staleAdd ??= addEphemeralMessage;
+      }, [addEphemeralMessage]);
+      return null;
+    }
+
+    const { rerender } = render(
+      <CopilotKitProvider
+        agents__unsafe_dev_only={{ first: firstAgent, second: secondAgent }}
+      >
+        <CopilotChatConfigurationProvider agentId="first" threadId="thread-a">
+          <Harness />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+
+    await waitFor(() => expect(staleAdd).not.toBeNull());
+    rerender(
+      <CopilotKitProvider
+        agents__unsafe_dev_only={{ first: firstAgent, second: secondAgent }}
+      >
+        <CopilotChatConfigurationProvider agentId="second" threadId="thread-a">
+          <Harness />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+
+    await waitFor(() => {
+      expect(staleAdd?.({ id: "stale-agent-card", content: "stale" })).toBe(
+        false,
+      );
     });
   });
 });

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent.e2e.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent.e2e.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
 import { describe, it, expect } from "vitest";
 import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
 import type { Observable } from "rxjs";
@@ -228,6 +229,71 @@ describe("useAgent e2e", () => {
     fireEvent.click(screen.getByTestId("clear-ephemeral"));
     await waitFor(() => {
       expect(screen.getByTestId("ephemeral-values").textContent).toBe("");
+    });
+  });
+
+  it("keeps new-thread ephemeral IDs valid while the previous messages are still present", async () => {
+    const agent = new MockStepwiseAgent();
+    let currentAdd:
+      | ((message: { id: string; content: string }) => boolean)
+      | undefined;
+    let seeded = false;
+
+    function Harness() {
+      const {
+        agent: hookAgent,
+        addEphemeralMessage,
+        ephemeralMessages,
+      } = useAgent();
+      const { copilotkit } = useCopilotKit();
+      currentAdd = addEphemeralMessage;
+
+      useEffect(() => {
+        if (seeded) return;
+        seeded = true;
+        hookAgent.addMessage({
+          id: "reused-card-id",
+          role: "user",
+          content: "thread A history",
+        });
+        copilotkit.addEphemeralMessage("default", "thread-b", {
+          id: "reused-card-id",
+          content: "thread B card",
+        });
+      }, [copilotkit, hookAgent]);
+
+      return (
+        <output data-testid="transition-ephemeral-values">
+          {ephemeralMessages.map(
+            (message) => `${message.id}:${message.content}`,
+          )}
+        </output>
+      );
+    }
+
+    const { rerender } = render(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <CopilotChatConfigurationProvider agentId="default" threadId="thread-a">
+          <Harness />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+
+    rerender(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <CopilotChatConfigurationProvider agentId="default" threadId="thread-b">
+          <Harness />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+
+    await waitFor(() => {
+      expect(currentAdd?.({ id: "reused-card-id", content: "updated" })).toBe(
+        true,
+      );
+      expect(
+        screen.getByTestId("transition-ephemeral-values").textContent,
+      ).toContain("reused-card-id");
     });
   });
 

--- a/packages/react-core/src/v2/hooks/__tests__/use-render-custom-messages.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-render-custom-messages.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useRenderCustomMessages } from "../use-render-custom-messages";
 import { CopilotKitProvider } from "../../providers/CopilotKitProvider";
@@ -14,6 +14,35 @@ import { CopilotChatConfigurationProvider } from "../../providers/CopilotChatCon
  * throwing an error.
  */
 describe("useRenderCustomMessages (#3497)", () => {
+  it("returns null when applicable renderers only render ephemeral messages", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <CopilotKitProvider
+        renderCustomMessages={[
+          {
+            render: null,
+            renderEphemeral: () => <div>Ephemeral</div>,
+          },
+          {
+            agentId: "default",
+            render: null,
+            renderEphemeral: () => <div>Agent ephemeral</div>,
+          },
+        ]}
+      >
+        <CopilotChatConfigurationProvider
+          agentId="default"
+          threadId="test-thread"
+        >
+          {children}
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>
+    );
+
+    const { result } = renderHook(() => useRenderCustomMessages(), { wrapper });
+
+    expect(result.current).toBeNull();
+  });
+
   it("returns null instead of throwing when agent is not found", () => {
     // Render the hook inside a CopilotKitProvider with an agentId that
     // does NOT exist in the registry (simulating connecting state).

--- a/packages/react-core/src/v2/hooks/index.ts
+++ b/packages/react-core/src/v2/hooks/index.ts
@@ -1,7 +1,10 @@
 // React hooks for CopilotKit2
 export { useRenderToolCall } from "./use-render-tool-call";
-export { useRenderCustomMessages } from "./use-render-custom-messages";
-export { useRenderEphemeralMessages } from "./use-render-custom-messages";
+export {
+  getApplicableCustomMessageRenderers,
+  useRenderCustomMessages,
+  useRenderEphemeralMessages,
+} from "./use-render-custom-messages";
 export { useRenderActivityMessage } from "./use-render-activity-message";
 export { useFrontendTool } from "./use-frontend-tool";
 export { useComponent } from "./use-component";

--- a/packages/react-core/src/v2/hooks/index.ts
+++ b/packages/react-core/src/v2/hooks/index.ts
@@ -1,6 +1,7 @@
 // React hooks for CopilotKit2
 export { useRenderToolCall } from "./use-render-tool-call";
 export { useRenderCustomMessages } from "./use-render-custom-messages";
+export { useRenderEphemeralMessages } from "./use-render-custom-messages";
 export { useRenderActivityMessage } from "./use-render-activity-message";
 export { useFrontendTool } from "./use-frontend-tool";
 export { useComponent } from "./use-component";

--- a/packages/react-core/src/v2/hooks/use-agent.tsx
+++ b/packages/react-core/src/v2/hooks/use-agent.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useMemo,
   useEffect,
+  useLayoutEffect,
   useReducer,
   useRef,
   useState,
@@ -147,13 +148,22 @@ interface UseAgentUnscopedProps {
 export type UseAgentProps = UseAgentPropsBase &
   (UseAgentThreadScopedProps | UseAgentUnscopedProps);
 
-export function useAgent({
-  agentId,
-  threadId,
-  runtimeAgentId,
-  updates,
-  throttleMs,
-}: UseAgentProps = {}) {
+type UseAgentChatScope = {
+  agentId: string;
+  threadId: string;
+  hasExplicitThreadId: boolean;
+};
+
+export function useAgent(
+  {
+    agentId,
+    threadId,
+    runtimeAgentId,
+    updates,
+    throttleMs,
+  }: UseAgentProps = {},
+  chatScope?: UseAgentChatScope,
+) {
   // `threadId` and `runtimeAgentId` are all-or-nothing. UseAgentProps already
   // rejects a lone one at compile time; these are the runtime backstop for
   // callers TypeScript doesn't cover — plain JS, `as any`, and props widened to
@@ -211,7 +221,8 @@ export function useAgent({
   // <CopilotChat agentId="..."> subtree resolves to 'default' and throws once
   // the runtime has synced only a non-default agent (#5533).
   const chatConfig = useCopilotChatConfiguration();
-  const resolvedAgentId = agentId ?? chatConfig?.agentId ?? DEFAULT_AGENT_ID;
+  const resolvedAgentId =
+    chatScope?.agentId ?? agentId ?? chatConfig?.agentId ?? DEFAULT_AGENT_ID;
 
   const { copilotkit } = useCopilotKit();
   // Read the provider-level default so it appears in the effect's dep array.
@@ -461,8 +472,9 @@ export function useAgent({
   //      doesn't overwrite the auto-minted agent UUID (both are random and
   //      useless to the backend; the explicit gate keeps the agent's UUID
   //      stable across renders).
-  const configThreadId = chatConfig?.threadId;
-  const configHasExplicitThreadId = chatConfig?.hasExplicitThreadId;
+  const configThreadId = chatScope?.threadId ?? chatConfig?.threadId;
+  const configHasExplicitThreadId =
+    chatScope?.hasExplicitThreadId ?? chatConfig?.hasExplicitThreadId;
   const resolvedThreadId =
     threadId ?? (configHasExplicitThreadId ? configThreadId : undefined);
   useEffect(() => {
@@ -471,9 +483,35 @@ export function useAgent({
   }, [agent, resolvedThreadId]);
 
   const ephemeralThreadId =
-    resolvedThreadId ?? chatConfig?.threadId ?? agent.threadId;
-  const ephemeralThreadIdRef = useRef(ephemeralThreadId);
-  ephemeralThreadIdRef.current = ephemeralThreadId;
+    resolvedThreadId ?? configThreadId ?? agent.threadId;
+  const ephemeralScopeRef = useRef({
+    agentId: resolvedAgentId,
+    threadId: ephemeralThreadId,
+  });
+  useLayoutEffect(() => {
+    ephemeralScopeRef.current = {
+      agentId: resolvedAgentId,
+      threadId: ephemeralThreadId,
+    };
+  }, [ephemeralThreadId, resolvedAgentId]);
+
+  useEffect(() => {
+    copilotkit.reconcileEphemeralMessages(
+      resolvedAgentId,
+      ephemeralThreadId,
+      agent.messages,
+    );
+    const subscription = agent.subscribe({
+      onMessagesChanged: () => {
+        copilotkit.reconcileEphemeralMessages(
+          resolvedAgentId,
+          ephemeralThreadId,
+          agent.messages,
+        );
+      },
+    });
+    return () => subscription.unsubscribe();
+  }, [agent, copilotkit, ephemeralThreadId, resolvedAgentId]);
 
   useEffect(() => {
     const subscription = copilotkit.subscribe({
@@ -482,7 +520,7 @@ export function useAgent({
         threadId: eventThreadId,
       }) => {
         const currentThreadId =
-          resolvedThreadId ?? chatConfig?.threadId ?? agent.threadId;
+          resolvedThreadId ?? configThreadId ?? agent.threadId;
         if (
           eventAgentId === resolvedAgentId &&
           eventThreadId === currentThreadId
@@ -494,7 +532,7 @@ export function useAgent({
     return () => subscription.unsubscribe();
   }, [
     agent,
-    chatConfig,
+    configThreadId,
     copilotkit,
     ephemeralThreadId,
     forceUpdate,
@@ -504,86 +542,53 @@ export function useAgent({
 
   const addEphemeralMessage = useCallback(
     (message: ReactEphemeralMessage): boolean => {
+      const currentScope = ephemeralScopeRef.current;
       if (
-        !resolvedThreadId &&
-        chatConfig &&
-        ephemeralThreadIdRef.current !== ephemeralThreadId
+        currentScope.agentId !== resolvedAgentId ||
+        currentScope.threadId !== ephemeralThreadId
       ) {
         return false;
       }
-      const currentThreadId = resolvedThreadId
-        ? resolvedThreadId
-        : chatConfig
-          ? ephemeralThreadIdRef.current
-          : agent.threadId;
       return copilotkit.addEphemeralMessage(
-        resolvedAgentId,
-        currentThreadId,
+        currentScope.agentId,
+        currentScope.threadId,
         message,
       );
     },
-    [
-      agent,
-      chatConfig,
-      copilotkit,
-      ephemeralThreadId,
-      resolvedAgentId,
-      resolvedThreadId,
-    ],
+    [copilotkit, ephemeralThreadId, resolvedAgentId],
   );
 
   const removeEphemeralMessage = useCallback(
     (messageId: string): boolean => {
+      const currentScope = ephemeralScopeRef.current;
       if (
-        !resolvedThreadId &&
-        chatConfig &&
-        ephemeralThreadIdRef.current !== ephemeralThreadId
+        currentScope.agentId !== resolvedAgentId ||
+        currentScope.threadId !== ephemeralThreadId
       ) {
         return false;
       }
-      const currentThreadId = resolvedThreadId
-        ? resolvedThreadId
-        : chatConfig
-          ? ephemeralThreadIdRef.current
-          : agent.threadId;
       return copilotkit.removeEphemeralMessage(
-        resolvedAgentId,
-        currentThreadId,
+        currentScope.agentId,
+        currentScope.threadId,
         messageId,
       );
     },
-    [
-      agent,
-      chatConfig,
-      copilotkit,
-      ephemeralThreadId,
-      resolvedAgentId,
-      resolvedThreadId,
-    ],
+    [copilotkit, ephemeralThreadId, resolvedAgentId],
   );
 
   const clearEphemeralMessages = useCallback((): boolean => {
+    const currentScope = ephemeralScopeRef.current;
     if (
-      !resolvedThreadId &&
-      chatConfig &&
-      ephemeralThreadIdRef.current !== ephemeralThreadId
+      currentScope.agentId !== resolvedAgentId ||
+      currentScope.threadId !== ephemeralThreadId
     ) {
       return false;
     }
-    const currentThreadId = resolvedThreadId
-      ? resolvedThreadId
-      : chatConfig
-        ? ephemeralThreadIdRef.current
-        : agent.threadId;
-    return copilotkit.clearEphemeralMessages(resolvedAgentId, currentThreadId);
-  }, [
-    agent,
-    chatConfig,
-    copilotkit,
-    ephemeralThreadId,
-    resolvedAgentId,
-    resolvedThreadId,
-  ]);
+    return copilotkit.clearEphemeralMessages(
+      currentScope.agentId,
+      currentScope.threadId,
+    );
+  }, [copilotkit, ephemeralThreadId, resolvedAgentId]);
 
   const ephemeralMessages = copilotkit.getEphemeralMessages(
     resolvedAgentId,

--- a/packages/react-core/src/v2/hooks/use-agent.tsx
+++ b/packages/react-core/src/v2/hooks/use-agent.tsx
@@ -477,9 +477,16 @@ export function useAgent(
     chatScope?.hasExplicitThreadId ?? chatConfig?.hasExplicitThreadId;
   const resolvedThreadId =
     threadId ?? (configHasExplicitThreadId ? configThreadId : undefined);
+  const previousResolvedThreadIdRef = useRef(resolvedThreadId);
   useEffect(() => {
     if (!resolvedThreadId) return;
+    const threadChanged =
+      previousResolvedThreadIdRef.current !== resolvedThreadId;
+    previousResolvedThreadIdRef.current = resolvedThreadId;
     agent.threadId = resolvedThreadId;
+    if (threadChanged && agent.messages.length > 0) {
+      agent.setMessages([]);
+    }
   }, [agent, resolvedThreadId]);
 
   const ephemeralThreadId =
@@ -496,19 +503,18 @@ export function useAgent(
   }, [ephemeralThreadId, resolvedAgentId]);
 
   useEffect(() => {
-    copilotkit.reconcileEphemeralMessages(
-      resolvedAgentId,
-      ephemeralThreadId,
-      agent.messages,
-    );
+    const reconcile = () => {
+      if (agent.threadId !== ephemeralThreadId) return;
+      copilotkit.reconcileEphemeralMessages(
+        resolvedAgentId,
+        ephemeralThreadId,
+        agent.messages,
+      );
+    };
+
+    reconcile();
     const subscription = agent.subscribe({
-      onMessagesChanged: () => {
-        copilotkit.reconcileEphemeralMessages(
-          resolvedAgentId,
-          ephemeralThreadId,
-          agent.messages,
-        );
-      },
+      onMessagesChanged: reconcile,
     });
     return () => subscription.unsubscribe();
   }, [agent, copilotkit, ephemeralThreadId, resolvedAgentId]);

--- a/packages/react-core/src/v2/hooks/use-agent.tsx
+++ b/packages/react-core/src/v2/hooks/use-agent.tsx
@@ -477,17 +477,25 @@ export function useAgent(
     chatScope?.hasExplicitThreadId ?? chatConfig?.hasExplicitThreadId;
   const resolvedThreadId =
     threadId ?? (configHasExplicitThreadId ? configThreadId : undefined);
-  const previousResolvedThreadIdRef = useRef(resolvedThreadId);
+  const previousThreadScopeRef = useRef({
+    resolvedThreadId,
+    hasExplicitThreadId: configHasExplicitThreadId,
+  });
   useEffect(() => {
-    if (!resolvedThreadId) return;
     const threadChanged =
-      previousResolvedThreadIdRef.current !== resolvedThreadId;
-    previousResolvedThreadIdRef.current = resolvedThreadId;
+      previousThreadScopeRef.current.resolvedThreadId !== resolvedThreadId ||
+      previousThreadScopeRef.current.hasExplicitThreadId !==
+        configHasExplicitThreadId;
+    previousThreadScopeRef.current = {
+      resolvedThreadId,
+      hasExplicitThreadId: configHasExplicitThreadId,
+    };
+    if (!resolvedThreadId) return;
     agent.threadId = resolvedThreadId;
     if (threadChanged && agent.messages.length > 0) {
       agent.setMessages([]);
     }
-  }, [agent, resolvedThreadId]);
+  }, [agent, configHasExplicitThreadId, resolvedThreadId]);
 
   const ephemeralThreadId =
     resolvedThreadId ?? configThreadId ?? agent.threadId;

--- a/packages/react-core/src/v2/hooks/use-agent.tsx
+++ b/packages/react-core/src/v2/hooks/use-agent.tsx
@@ -1,5 +1,12 @@
 import { useCopilotKit } from "../context";
-import { useMemo, useEffect, useReducer, useRef, useState } from "react";
+import {
+  useCallback,
+  useMemo,
+  useEffect,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
@@ -9,6 +16,7 @@ import {
 } from "@copilotkit/core";
 import type { SubscribeToAgentSubscriber } from "@copilotkit/core";
 import { useCopilotChatConfiguration } from "../providers/CopilotChatConfigurationProvider";
+import type { ReactEphemeralMessage } from "../types/react-custom-message-renderer";
 
 export enum UseAgentUpdate {
   OnMessagesChanged = "OnMessagesChanged",
@@ -462,8 +470,74 @@ export function useAgent({
     agent.threadId = resolvedThreadId;
   }, [agent, resolvedThreadId]);
 
+  const ephemeralThreadId = resolvedThreadId ?? agent.threadId;
+
+  useEffect(() => {
+    const subscription = copilotkit.subscribe({
+      onEphemeralMessagesChanged: ({
+        agentId: eventAgentId,
+        threadId: eventThreadId,
+      }) => {
+        if (
+          eventAgentId === resolvedAgentId &&
+          eventThreadId === ephemeralThreadId
+        ) {
+          forceUpdate();
+        }
+      },
+    });
+    return () => subscription.unsubscribe();
+  }, [copilotkit, ephemeralThreadId, forceUpdate, resolvedAgentId]);
+
+  const addEphemeralMessage = useCallback(
+    (message: ReactEphemeralMessage): boolean => {
+      if (agent.threadId !== ephemeralThreadId) {
+        return false;
+      }
+      return copilotkit.addEphemeralMessage(
+        resolvedAgentId,
+        ephemeralThreadId,
+        message,
+      );
+    },
+    [agent, copilotkit, ephemeralThreadId, resolvedAgentId],
+  );
+
+  const removeEphemeralMessage = useCallback(
+    (messageId: string): boolean => {
+      if (agent.threadId !== ephemeralThreadId) {
+        return false;
+      }
+      return copilotkit.removeEphemeralMessage(
+        resolvedAgentId,
+        ephemeralThreadId,
+        messageId,
+      );
+    },
+    [agent, copilotkit, ephemeralThreadId, resolvedAgentId],
+  );
+
+  const clearEphemeralMessages = useCallback((): boolean => {
+    if (agent.threadId !== ephemeralThreadId) {
+      return false;
+    }
+    return copilotkit.clearEphemeralMessages(
+      resolvedAgentId,
+      ephemeralThreadId,
+    );
+  }, [agent, copilotkit, ephemeralThreadId, resolvedAgentId]);
+
+  const ephemeralMessages = copilotkit.getEphemeralMessages(
+    resolvedAgentId,
+    ephemeralThreadId,
+  );
+
   return {
     agent,
+    ephemeralMessages,
+    addEphemeralMessage,
+    removeEphemeralMessage,
+    clearEphemeralMessages,
     /**
      * Whether `agent` is the real, runtime-synced (or locally-registered) agent
      * rather than a provisional stand-in returned while the runtime is still

--- a/packages/react-core/src/v2/hooks/use-agent.tsx
+++ b/packages/react-core/src/v2/hooks/use-agent.tsx
@@ -477,25 +477,32 @@ export function useAgent(
     chatScope?.hasExplicitThreadId ?? chatConfig?.hasExplicitThreadId;
   const resolvedThreadId =
     threadId ?? (configHasExplicitThreadId ? configThreadId : undefined);
+  const threadScopeId = threadId ?? configThreadId;
   const previousThreadScopeRef = useRef({
-    resolvedThreadId,
+    threadScopeId,
     hasExplicitThreadId: configHasExplicitThreadId,
+    explicitThreadId: threadId,
   });
   useEffect(() => {
     const threadChanged =
-      previousThreadScopeRef.current.resolvedThreadId !== resolvedThreadId ||
-      previousThreadScopeRef.current.hasExplicitThreadId !==
-        configHasExplicitThreadId;
+      previousThreadScopeRef.current.threadScopeId !== threadScopeId ||
+      previousThreadScopeRef.current.explicitThreadId !== threadId ||
+      (threadId === undefined &&
+        previousThreadScopeRef.current.hasExplicitThreadId !==
+          configHasExplicitThreadId);
     previousThreadScopeRef.current = {
-      resolvedThreadId,
+      threadScopeId,
       hasExplicitThreadId: configHasExplicitThreadId,
+      explicitThreadId: threadId,
     };
-    if (!resolvedThreadId) return;
-    agent.threadId = resolvedThreadId;
+    if (!threadScopeId) return;
+    if (threadId !== undefined || configHasExplicitThreadId || threadChanged) {
+      agent.threadId = threadScopeId;
+    }
     if (threadChanged && agent.messages.length > 0) {
       agent.setMessages([]);
     }
-  }, [agent, configHasExplicitThreadId, resolvedThreadId]);
+  }, [agent, configHasExplicitThreadId, threadId, threadScopeId]);
 
   const ephemeralThreadId =
     resolvedThreadId ?? configThreadId ?? agent.threadId;
@@ -509,23 +516,6 @@ export function useAgent(
       threadId: ephemeralThreadId,
     };
   }, [ephemeralThreadId, resolvedAgentId]);
-
-  useEffect(() => {
-    const reconcile = () => {
-      if (agent.threadId !== ephemeralThreadId) return;
-      copilotkit.reconcileEphemeralMessages(
-        resolvedAgentId,
-        ephemeralThreadId,
-        agent.messages,
-      );
-    };
-
-    reconcile();
-    const subscription = agent.subscribe({
-      onMessagesChanged: reconcile,
-    });
-    return () => subscription.unsubscribe();
-  }, [agent, copilotkit, ephemeralThreadId, resolvedAgentId]);
 
   useEffect(() => {
     const subscription = copilotkit.subscribe({
@@ -553,6 +543,23 @@ export function useAgent(
     resolvedAgentId,
     resolvedThreadId,
   ]);
+
+  useEffect(() => {
+    const reconcile = () => {
+      if (agent.threadId !== ephemeralThreadId) return;
+      copilotkit.reconcileEphemeralMessages(
+        resolvedAgentId,
+        ephemeralThreadId,
+        agent.messages,
+      );
+    };
+
+    reconcile();
+    const subscription = agent.subscribe({
+      onMessagesChanged: reconcile,
+    });
+    return () => subscription.unsubscribe();
+  }, [agent, copilotkit, ephemeralThreadId, resolvedAgentId]);
 
   const addEphemeralMessage = useCallback(
     (message: ReactEphemeralMessage): boolean => {

--- a/packages/react-core/src/v2/hooks/use-agent.tsx
+++ b/packages/react-core/src/v2/hooks/use-agent.tsx
@@ -471,7 +471,7 @@ export function useAgent({
   }, [agent, resolvedThreadId]);
 
   const ephemeralThreadId =
-    chatConfig?.threadId ?? resolvedThreadId ?? agent.threadId;
+    resolvedThreadId ?? chatConfig?.threadId ?? agent.threadId;
   const ephemeralThreadIdRef = useRef(ephemeralThreadId);
   ephemeralThreadIdRef.current = ephemeralThreadId;
 
@@ -482,7 +482,7 @@ export function useAgent({
         threadId: eventThreadId,
       }) => {
         const currentThreadId =
-          chatConfig?.threadId ?? resolvedThreadId ?? agent.threadId;
+          resolvedThreadId ?? chatConfig?.threadId ?? agent.threadId;
         if (
           eventAgentId === resolvedAgentId &&
           eventThreadId === currentThreadId
@@ -504,12 +504,18 @@ export function useAgent({
 
   const addEphemeralMessage = useCallback(
     (message: ReactEphemeralMessage): boolean => {
-      if (chatConfig && ephemeralThreadIdRef.current !== ephemeralThreadId) {
+      if (
+        !resolvedThreadId &&
+        chatConfig &&
+        ephemeralThreadIdRef.current !== ephemeralThreadId
+      ) {
         return false;
       }
-      const currentThreadId = chatConfig
-        ? ephemeralThreadIdRef.current
-        : (resolvedThreadId ?? agent.threadId);
+      const currentThreadId = resolvedThreadId
+        ? resolvedThreadId
+        : chatConfig
+          ? ephemeralThreadIdRef.current
+          : agent.threadId;
       return copilotkit.addEphemeralMessage(
         resolvedAgentId,
         currentThreadId,
@@ -528,12 +534,18 @@ export function useAgent({
 
   const removeEphemeralMessage = useCallback(
     (messageId: string): boolean => {
-      if (chatConfig && ephemeralThreadIdRef.current !== ephemeralThreadId) {
+      if (
+        !resolvedThreadId &&
+        chatConfig &&
+        ephemeralThreadIdRef.current !== ephemeralThreadId
+      ) {
         return false;
       }
-      const currentThreadId = chatConfig
-        ? ephemeralThreadIdRef.current
-        : (resolvedThreadId ?? agent.threadId);
+      const currentThreadId = resolvedThreadId
+        ? resolvedThreadId
+        : chatConfig
+          ? ephemeralThreadIdRef.current
+          : agent.threadId;
       return copilotkit.removeEphemeralMessage(
         resolvedAgentId,
         currentThreadId,
@@ -551,12 +563,18 @@ export function useAgent({
   );
 
   const clearEphemeralMessages = useCallback((): boolean => {
-    if (chatConfig && ephemeralThreadIdRef.current !== ephemeralThreadId) {
+    if (
+      !resolvedThreadId &&
+      chatConfig &&
+      ephemeralThreadIdRef.current !== ephemeralThreadId
+    ) {
       return false;
     }
-    const currentThreadId = chatConfig
-      ? ephemeralThreadIdRef.current
-      : (resolvedThreadId ?? agent.threadId);
+    const currentThreadId = resolvedThreadId
+      ? resolvedThreadId
+      : chatConfig
+        ? ephemeralThreadIdRef.current
+        : agent.threadId;
     return copilotkit.clearEphemeralMessages(resolvedAgentId, currentThreadId);
   }, [
     agent,

--- a/packages/react-core/src/v2/hooks/use-agent.tsx
+++ b/packages/react-core/src/v2/hooks/use-agent.tsx
@@ -470,7 +470,10 @@ export function useAgent({
     agent.threadId = resolvedThreadId;
   }, [agent, resolvedThreadId]);
 
-  const ephemeralThreadId = resolvedThreadId ?? agent.threadId;
+  const ephemeralThreadId =
+    chatConfig?.threadId ?? resolvedThreadId ?? agent.threadId;
+  const ephemeralThreadIdRef = useRef(ephemeralThreadId);
+  ephemeralThreadIdRef.current = ephemeralThreadId;
 
   useEffect(() => {
     const subscription = copilotkit.subscribe({
@@ -478,54 +481,91 @@ export function useAgent({
         agentId: eventAgentId,
         threadId: eventThreadId,
       }) => {
+        const currentThreadId =
+          chatConfig?.threadId ?? resolvedThreadId ?? agent.threadId;
         if (
           eventAgentId === resolvedAgentId &&
-          eventThreadId === ephemeralThreadId
+          eventThreadId === currentThreadId
         ) {
           forceUpdate();
         }
       },
     });
     return () => subscription.unsubscribe();
-  }, [copilotkit, ephemeralThreadId, forceUpdate, resolvedAgentId]);
+  }, [
+    agent,
+    chatConfig,
+    copilotkit,
+    ephemeralThreadId,
+    forceUpdate,
+    resolvedAgentId,
+    resolvedThreadId,
+  ]);
 
   const addEphemeralMessage = useCallback(
     (message: ReactEphemeralMessage): boolean => {
-      if (agent.threadId !== ephemeralThreadId) {
+      if (chatConfig && ephemeralThreadIdRef.current !== ephemeralThreadId) {
         return false;
       }
+      const currentThreadId = chatConfig
+        ? ephemeralThreadIdRef.current
+        : (resolvedThreadId ?? agent.threadId);
       return copilotkit.addEphemeralMessage(
         resolvedAgentId,
-        ephemeralThreadId,
+        currentThreadId,
         message,
       );
     },
-    [agent, copilotkit, ephemeralThreadId, resolvedAgentId],
+    [
+      agent,
+      chatConfig,
+      copilotkit,
+      ephemeralThreadId,
+      resolvedAgentId,
+      resolvedThreadId,
+    ],
   );
 
   const removeEphemeralMessage = useCallback(
     (messageId: string): boolean => {
-      if (agent.threadId !== ephemeralThreadId) {
+      if (chatConfig && ephemeralThreadIdRef.current !== ephemeralThreadId) {
         return false;
       }
+      const currentThreadId = chatConfig
+        ? ephemeralThreadIdRef.current
+        : (resolvedThreadId ?? agent.threadId);
       return copilotkit.removeEphemeralMessage(
         resolvedAgentId,
-        ephemeralThreadId,
+        currentThreadId,
         messageId,
       );
     },
-    [agent, copilotkit, ephemeralThreadId, resolvedAgentId],
+    [
+      agent,
+      chatConfig,
+      copilotkit,
+      ephemeralThreadId,
+      resolvedAgentId,
+      resolvedThreadId,
+    ],
   );
 
   const clearEphemeralMessages = useCallback((): boolean => {
-    if (agent.threadId !== ephemeralThreadId) {
+    if (chatConfig && ephemeralThreadIdRef.current !== ephemeralThreadId) {
       return false;
     }
-    return copilotkit.clearEphemeralMessages(
-      resolvedAgentId,
-      ephemeralThreadId,
-    );
-  }, [agent, copilotkit, ephemeralThreadId, resolvedAgentId]);
+    const currentThreadId = chatConfig
+      ? ephemeralThreadIdRef.current
+      : (resolvedThreadId ?? agent.threadId);
+    return copilotkit.clearEphemeralMessages(resolvedAgentId, currentThreadId);
+  }, [
+    agent,
+    chatConfig,
+    copilotkit,
+    ephemeralThreadId,
+    resolvedAgentId,
+    resolvedThreadId,
+  ]);
 
   const ephemeralMessages = copilotkit.getEphemeralMessages(
     resolvedAgentId,

--- a/packages/react-core/src/v2/hooks/use-render-custom-messages.tsx
+++ b/packages/react-core/src/v2/hooks/use-render-custom-messages.tsx
@@ -1,5 +1,6 @@
 import { useCopilotChatConfiguration, useCopilotKit } from "../providers";
 import type {
+  ReactCustomMessageRenderer,
   ReactCustomMessageRendererPosition,
   ReactEphemeralMessage,
 } from "../types/react-custom-message-renderer";
@@ -8,6 +9,23 @@ import type { Message } from "@ag-ui/core";
 interface UseRenderCustomMessagesParams {
   message: Message;
   position: ReactCustomMessageRendererPosition;
+}
+
+export function getApplicableCustomMessageRenderers(
+  renderers: ReadonlyArray<ReactCustomMessageRenderer>,
+  agentId: string,
+): ReactCustomMessageRenderer[] {
+  return renderers
+    .filter(
+      (renderer) =>
+        renderer.agentId === undefined || renderer.agentId === agentId,
+    )
+    .sort((a, b) => {
+      const aHasAgent = a.agentId !== undefined;
+      const bHasAgent = b.agentId !== undefined;
+      if (aHasAgent === bHasAgent) return 0;
+      return aHasAgent ? -1 : 1;
+    });
 }
 
 export function useRenderCustomMessages() {
@@ -20,17 +38,10 @@ export function useRenderCustomMessages() {
 
   const { agentId, threadId } = config;
 
-  const customMessageRenderers = copilotkit.renderCustomMessages
-    .filter(
-      (renderer) =>
-        renderer.agentId === undefined || renderer.agentId === agentId,
-    )
-    .sort((a, b) => {
-      const aHasAgent = a.agentId !== undefined;
-      const bHasAgent = b.agentId !== undefined;
-      if (aHasAgent === bHasAgent) return 0;
-      return aHasAgent ? -1 : 1;
-    });
+  const customMessageRenderers = getApplicableCustomMessageRenderers(
+    copilotkit.renderCustomMessages,
+    agentId,
+  );
 
   return function (params: UseRenderCustomMessagesParams) {
     if (!customMessageRenderers.length) {
@@ -104,17 +115,13 @@ export function useRenderEphemeralMessages() {
   }
 
   const { agentId, threadId } = config;
-  const renderers = copilotkit.renderCustomMessages
-    .filter(
-      (renderer) =>
-        renderer.agentId === undefined || renderer.agentId === agentId,
-    )
-    .sort((a, b) => {
-      const aHasAgent = a.agentId !== undefined;
-      const bHasAgent = b.agentId !== undefined;
-      if (aHasAgent === bHasAgent) return 0;
-      return aHasAgent ? -1 : 1;
-    });
+  const renderers = getApplicableCustomMessageRenderers(
+    copilotkit.renderCustomMessages,
+    agentId,
+  );
+  if (!renderers.some((renderer) => renderer.renderEphemeral)) {
+    return null;
+  }
 
   return function (params: {
     message: ReactEphemeralMessage;

--- a/packages/react-core/src/v2/hooks/use-render-custom-messages.tsx
+++ b/packages/react-core/src/v2/hooks/use-render-custom-messages.tsx
@@ -42,6 +42,9 @@ export function useRenderCustomMessages() {
     copilotkit.renderCustomMessages,
     agentId,
   );
+  if (!customMessageRenderers.some((renderer) => renderer.render)) {
+    return null;
+  }
 
   return function (params: UseRenderCustomMessagesParams) {
     if (!customMessageRenderers.length) {

--- a/packages/react-core/src/v2/hooks/use-render-custom-messages.tsx
+++ b/packages/react-core/src/v2/hooks/use-render-custom-messages.tsx
@@ -1,6 +1,9 @@
 import { useCopilotChatConfiguration, useCopilotKit } from "../providers";
-import { ReactCustomMessageRendererPosition } from "../types/react-custom-message-renderer";
-import { Message } from "@ag-ui/core";
+import type {
+  ReactCustomMessageRendererPosition,
+  ReactEphemeralMessage,
+} from "../types/react-custom-message-renderer";
+import type { Message } from "@ag-ui/core";
 
 interface UseRenderCustomMessagesParams {
   message: Message;
@@ -89,5 +92,55 @@ export function useRenderCustomMessages() {
       }
     }
     return result;
+  };
+}
+
+export function useRenderEphemeralMessages() {
+  const { copilotkit } = useCopilotKit();
+  const config = useCopilotChatConfiguration();
+
+  if (!config) {
+    return null;
+  }
+
+  const { agentId, threadId } = config;
+  const renderers = copilotkit.renderCustomMessages
+    .filter(
+      (renderer) =>
+        renderer.agentId === undefined || renderer.agentId === agentId,
+    )
+    .sort((a, b) => {
+      const aHasAgent = a.agentId !== undefined;
+      const bHasAgent = b.agentId !== undefined;
+      if (aHasAgent === bHasAgent) return 0;
+      return aHasAgent ? -1 : 1;
+    });
+
+  return function (params: {
+    message: ReactEphemeralMessage;
+    messageIndex: number;
+    numberOfMessages: number;
+  }) {
+    if (!renderers.length) {
+      return null;
+    }
+
+    for (const renderer of renderers) {
+      if (!renderer.renderEphemeral) {
+        continue;
+      }
+      const Component = renderer.renderEphemeral;
+      return (
+        <Component
+          key={`ephemeral-${threadId}-${params.message.id}`}
+          message={params.message}
+          agentId={agentId}
+          threadId={threadId}
+          messageIndex={params.messageIndex}
+          numberOfMessages={params.numberOfMessages}
+        />
+      );
+    }
+    return null;
   };
 }

--- a/packages/react-core/src/v2/hooks/use-render-custom-messages.tsx
+++ b/packages/react-core/src/v2/hooks/use-render-custom-messages.tsx
@@ -139,7 +139,7 @@ export function useRenderEphemeralMessages() {
       const Component = renderer.renderEphemeral;
       return (
         <Component
-          key={`ephemeral-${threadId}-${params.message.id}`}
+          key={`ephemeral-${agentId}-${threadId}-${params.message.id}`}
           message={params.message}
           agentId={agentId}
           threadId={threadId}

--- a/packages/react-core/src/v2/lib/__tests__/react-core.ephemeral-messages.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/react-core.ephemeral-messages.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import { MockStepwiseAgent } from "../../__tests__/utils/test-helpers";
+import { CopilotKitCoreReact } from "../react-core";
+
+describe("CopilotKitCoreReact ephemeral messages", () => {
+  it("keeps ordered immutable snapshots and rejects persisted ID collisions", () => {
+    const agent = new MockStepwiseAgent();
+    agent.addMessage({
+      id: "persisted-card",
+      role: "user",
+      content: "Persisted card-shaped message",
+    });
+    const core = new CopilotKitCoreReact({
+      agents__unsafe_dev_only: { default: agent },
+    });
+
+    expect(
+      core.addEphemeralMessage("default", "thread-a", {
+        id: "first",
+        content: { label: "first" },
+      }),
+    ).toBe(true);
+    expect(
+      core.addEphemeralMessage("default", "thread-a", {
+        id: "second",
+        content: { label: "second" },
+      }),
+    ).toBe(true);
+    const initialSnapshot = core.getEphemeralMessages("default", "thread-a");
+
+    expect(
+      core.addEphemeralMessage("default", "thread-a", {
+        id: "first",
+        content: { label: "updated" },
+      }),
+    ).toBe(true);
+    expect(core.getEphemeralMessages("default", "thread-a")).toEqual([
+      { id: "first", content: { label: "updated" } },
+      { id: "second", content: { label: "second" } },
+    ]);
+    expect(initialSnapshot).toEqual([
+      { id: "first", content: { label: "first" } },
+      { id: "second", content: { label: "second" } },
+    ]);
+    expect(
+      core.addEphemeralMessage("default", "thread-a", {
+        id: "persisted-card",
+        content: "must remain persisted",
+      }),
+    ).toBe(false);
+    expect(agent.messages).toHaveLength(1);
+  });
+
+  it("isolates scopes and limits remove and clear to the selected scope", () => {
+    const core = new CopilotKitCoreReact({});
+    core.addEphemeralMessage("agent-a", "thread-a", {
+      id: "shared-id",
+      content: "A",
+    });
+    core.addEphemeralMessage("agent-a", "thread-b", {
+      id: "shared-id",
+      content: "B",
+    });
+    core.addEphemeralMessage("agent-b", "thread-a", {
+      id: "shared-id",
+      content: "C",
+    });
+
+    expect(
+      core.removeEphemeralMessage("agent-a", "thread-a", "shared-id"),
+    ).toBe(true);
+    expect(core.getEphemeralMessages("agent-a", "thread-a")).toEqual([]);
+    expect(core.getEphemeralMessages("agent-a", "thread-b")).toEqual([
+      { id: "shared-id", content: "B" },
+    ]);
+    expect(core.getEphemeralMessages("agent-b", "thread-a")).toEqual([
+      { id: "shared-id", content: "C" },
+    ]);
+
+    expect(core.clearEphemeralMessages("agent-a", "thread-b")).toBe(true);
+    expect(core.getEphemeralMessages("agent-a", "thread-b")).toEqual([]);
+    expect(core.clearEphemeralMessages("agent-a", "thread-b")).toBe(false);
+  });
+
+  it("notifies subscribers with the scoped immutable snapshot", async () => {
+    const core = new CopilotKitCoreReact({});
+    const onEphemeralMessagesChanged = vi.fn();
+    const subscription = core.subscribe({ onEphemeralMessagesChanged });
+
+    core.addEphemeralMessage("default", "thread-a", {
+      id: "event",
+      content: "visible",
+    });
+    await vi.waitFor(() =>
+      expect(onEphemeralMessagesChanged).toHaveBeenCalled(),
+    );
+
+    expect(onEphemeralMessagesChanged).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        agentId: "default",
+        threadId: "thread-a",
+        messages: [{ id: "event", content: "visible" }],
+      }),
+    );
+    subscription.unsubscribe();
+  });
+
+  it("starts empty when the provider-owned core is remounted", () => {
+    const firstProvider = new CopilotKitCoreReact({});
+    firstProvider.addEphemeralMessage("default", "thread-a", {
+      id: "event",
+      content: "only in the first provider",
+    });
+
+    const remountedProvider = new CopilotKitCoreReact({});
+    expect(
+      remountedProvider.getEphemeralMessages("default", "thread-a"),
+    ).toEqual([]);
+  });
+});

--- a/packages/react-core/src/v2/lib/__tests__/react-core.ephemeral-messages.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/react-core.ephemeral-messages.test.ts
@@ -5,6 +5,7 @@ import { CopilotKitCoreReact } from "../react-core";
 describe("CopilotKitCoreReact ephemeral messages", () => {
   it("keeps ordered immutable snapshots and rejects persisted ID collisions", () => {
     const agent = new MockStepwiseAgent();
+    agent.threadId = "thread-a";
     agent.addMessage({
       id: "persisted-card",
       role: "user",
@@ -35,12 +36,28 @@ describe("CopilotKitCoreReact ephemeral messages", () => {
       }),
     ).toBe(true);
     expect(core.getEphemeralMessages("default", "thread-a")).toEqual([
-      { id: "first", content: { label: "updated" } },
-      { id: "second", content: { label: "second" } },
+      {
+        id: "first",
+        content: { label: "updated" },
+        anchorMessageId: "persisted-card",
+      },
+      {
+        id: "second",
+        content: { label: "second" },
+        anchorMessageId: "persisted-card",
+      },
     ]);
     expect(initialSnapshot).toEqual([
-      { id: "first", content: { label: "first" } },
-      { id: "second", content: { label: "second" } },
+      {
+        id: "first",
+        content: { label: "first" },
+        anchorMessageId: "persisted-card",
+      },
+      {
+        id: "second",
+        content: { label: "second" },
+        anchorMessageId: "persisted-card",
+      },
     ]);
     expect(
       core.addEphemeralMessage("default", "thread-a", {
@@ -80,6 +97,43 @@ describe("CopilotKitCoreReact ephemeral messages", () => {
     expect(core.clearEphemeralMessages("agent-a", "thread-b")).toBe(true);
     expect(core.getEphemeralMessages("agent-a", "thread-b")).toEqual([]);
     expect(core.clearEphemeralMessages("agent-a", "thread-b")).toBe(false);
+    expect(
+      (core as unknown as { _ephemeralMessages: Map<unknown, unknown> })
+        ._ephemeralMessages.size,
+    ).toBe(1);
+  });
+
+  it("drops an ephemeral entry when its persisted ID arrives later", () => {
+    const agent = new MockStepwiseAgent();
+    agent.threadId = "thread-a";
+    const core = new CopilotKitCoreReact({
+      agents__unsafe_dev_only: { default: agent },
+    });
+
+    expect(
+      core.addEphemeralMessage("default", "thread-a", {
+        id: "later-persisted",
+        content: "client-only first",
+      }),
+    ).toBe(true);
+    agent.addMessage({
+      id: "later-persisted",
+      role: "user",
+      content: "persisted owns this ID",
+    });
+
+    expect(core.getEphemeralMessages("default", "thread-a")).toEqual([]);
+    expect(agent.messages).toEqual([
+      {
+        id: "later-persisted",
+        role: "user",
+        content: "persisted owns this ID",
+      },
+    ]);
+    expect(
+      (core as unknown as { _ephemeralMessages: Map<unknown, unknown> })
+        ._ephemeralMessages.size,
+    ).toBe(0);
   });
 
   it("notifies subscribers with the scoped immutable snapshot", async () => {

--- a/packages/react-core/src/v2/lib/__tests__/react-core.ephemeral-messages.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/react-core.ephemeral-messages.test.ts
@@ -122,6 +122,19 @@ describe("CopilotKitCoreReact ephemeral messages", () => {
       content: "persisted owns this ID",
     });
 
+    expect(core.getEphemeralMessages("default", "thread-a")).toEqual([
+      {
+        id: "later-persisted",
+        content: "client-only first",
+      },
+    ]);
+    expect(
+      (core as unknown as { _ephemeralMessages: Map<unknown, unknown> })
+        ._ephemeralMessages.size,
+    ).toBe(1);
+    expect(
+      core.reconcileEphemeralMessages("default", "thread-a", agent.messages),
+    ).toBe(true);
     expect(core.getEphemeralMessages("default", "thread-a")).toEqual([]);
     expect(agent.messages).toEqual([
       {

--- a/packages/react-core/src/v2/lib/__tests__/react-core.ephemeral-messages.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/react-core.ephemeral-messages.test.ts
@@ -136,6 +136,112 @@ describe("CopilotKitCoreReact ephemeral messages", () => {
     ).toBe(0);
   });
 
+  it("preserves the original anchor across updates and keeps unanchored entries unanchored", () => {
+    const anchoredAgent = new MockStepwiseAgent();
+    anchoredAgent.threadId = "thread-a";
+    anchoredAgent.addMessage({
+      id: "first-persisted",
+      role: "user",
+      content: "first",
+    });
+    const unanchoredAgent = new MockStepwiseAgent();
+    unanchoredAgent.threadId = "thread-b";
+    const core = new CopilotKitCoreReact({
+      agents__unsafe_dev_only: {
+        anchored: anchoredAgent,
+        unanchored: unanchoredAgent,
+      },
+    });
+
+    expect(
+      core.addEphemeralMessage("anchored", "thread-a", {
+        id: "anchored-card",
+        content: "before later history",
+      }),
+    ).toBe(true);
+    anchoredAgent.addMessage({
+      id: "later-persisted",
+      role: "user",
+      content: "later",
+    });
+    expect(
+      core.addEphemeralMessage("anchored", "thread-a", {
+        id: "anchored-card",
+        content: "updated after later history",
+      }),
+    ).toBe(true);
+    expect(core.getEphemeralMessages("anchored", "thread-a")).toEqual([
+      {
+        id: "anchored-card",
+        content: "updated after later history",
+        anchorMessageId: "first-persisted",
+      },
+    ]);
+
+    expect(
+      core.addEphemeralMessage("unanchored", "thread-b", {
+        id: "unanchored-card",
+        content: "without history",
+      }),
+    ).toBe(true);
+    unanchoredAgent.addMessage({
+      id: "first-persisted-in-thread-b",
+      role: "user",
+      content: "arrived later",
+    });
+    expect(
+      core.addEphemeralMessage("unanchored", "thread-b", {
+        id: "unanchored-card",
+        content: "still without an anchor",
+      }),
+    ).toBe(true);
+    expect(core.getEphemeralMessages("unanchored", "thread-b")).toEqual([
+      { id: "unanchored-card", content: "still without an anchor" },
+    ]);
+  });
+
+  it("checks persisted collisions and automatic anchors only in the requested thread", () => {
+    const agent = new MockStepwiseAgent();
+    agent.threadId = "thread-b";
+    agent.addMessage({
+      id: "thread-b-persisted",
+      role: "user",
+      content: "only in thread b",
+    });
+    const core = new CopilotKitCoreReact({
+      agents__unsafe_dev_only: { default: agent },
+    });
+
+    expect(
+      core.addEphemeralMessage("default", "thread-a", {
+        id: "thread-b-persisted",
+        content: "allowed in thread a",
+      }),
+    ).toBe(true);
+    expect(core.getEphemeralMessages("default", "thread-a")).toEqual([
+      { id: "thread-b-persisted", content: "allowed in thread a" },
+    ]);
+    expect(
+      core.addEphemeralMessage("default", "thread-b", {
+        id: "thread-b-persisted",
+        content: "collision in thread b",
+      }),
+    ).toBe(false);
+    expect(
+      core.addEphemeralMessage("default", "thread-b", {
+        id: "thread-b-card",
+        content: "anchored in thread b",
+      }),
+    ).toBe(true);
+    expect(core.getEphemeralMessages("default", "thread-b")).toEqual([
+      {
+        id: "thread-b-card",
+        content: "anchored in thread b",
+        anchorMessageId: "thread-b-persisted",
+      },
+    ]);
+  });
+
   it("notifies subscribers with the scoped immutable snapshot", async () => {
     const core = new CopilotKitCoreReact({});
     const onEphemeralMessagesChanged = vi.fn();

--- a/packages/react-core/src/v2/lib/react-core.ts
+++ b/packages/react-core/src/v2/lib/react-core.ts
@@ -1,11 +1,17 @@
 import React from "react";
-import { ReactActivityMessageRenderer, ReactToolCallRenderer } from "../types";
-import { ReactCustomMessageRenderer } from "../types/react-custom-message-renderer";
-import {
-  CopilotKitCore,
-  type CopilotKitCoreConfig,
-  type CopilotKitCoreSubscriber,
-  type CopilotKitCoreSubscription,
+import type {
+  ReactActivityMessageRenderer,
+  ReactToolCallRenderer,
+} from "../types";
+import type {
+  ReactCustomMessageRenderer,
+  ReactEphemeralMessage,
+} from "../types/react-custom-message-renderer";
+import { CopilotKitCore } from "@copilotkit/core";
+import type {
+  CopilotKitCoreConfig,
+  CopilotKitCoreSubscriber,
+  CopilotKitCoreSubscription,
 } from "@copilotkit/core";
 
 export interface CopilotKitCoreReactConfig extends CopilotKitCoreConfig {
@@ -26,7 +32,16 @@ export interface CopilotKitCoreReactSubscriber extends CopilotKitCoreSubscriber 
     copilotkit: CopilotKitCore;
     interruptElement: React.ReactElement | null;
   }) => void | Promise<void>;
+  onEphemeralMessagesChanged?: (event: {
+    copilotkit: CopilotKitCoreReact;
+    agentId: string;
+    threadId: string;
+    messages: ReadonlyArray<ReactEphemeralMessage>;
+  }) => void | Promise<void>;
 }
+
+const EMPTY_EPHEMERAL_MESSAGES: ReadonlyArray<ReactEphemeralMessage> =
+  Object.freeze([]);
 
 export class CopilotKitCoreReact extends CopilotKitCore {
   private _renderToolCalls: ReactToolCallRenderer<any>[] = [];
@@ -37,6 +52,10 @@ export class CopilotKitCoreReact extends CopilotKitCore {
   private _renderCustomMessages: ReactCustomMessageRenderer[] = [];
   private _renderActivityMessages: ReactActivityMessageRenderer<any>[] = [];
   private _interruptElement: React.ReactElement | null = null;
+  private _ephemeralMessages = new Map<
+    string,
+    ReadonlyArray<ReactEphemeralMessage>
+  >();
 
   constructor(config: CopilotKitCoreReactConfig) {
     super(config);
@@ -80,6 +99,106 @@ export class CopilotKitCoreReact extends CopilotKitCore {
 
   setRenderCustomMessages(renderers: ReactCustomMessageRenderer[]): void {
     this._renderCustomMessages = renderers;
+  }
+
+  getEphemeralMessages(
+    agentId: string,
+    threadId: string,
+  ): ReadonlyArray<ReactEphemeralMessage> {
+    return (
+      this._ephemeralMessages.get(this._ephemeralScopeKey(agentId, threadId)) ??
+      EMPTY_EPHEMERAL_MESSAGES
+    );
+  }
+
+  addEphemeralMessage(
+    agentId: string,
+    threadId: string,
+    message: ReactEphemeralMessage,
+  ): boolean {
+    const agent = this.getAgent(agentId);
+    if (
+      agent?.messages.some(
+        (persistedMessage) => persistedMessage.id === message.id,
+      )
+    ) {
+      return false;
+    }
+
+    const key = this._ephemeralScopeKey(agentId, threadId);
+    const previous = this.getEphemeralMessages(agentId, threadId);
+    const existingIndex = previous.findIndex(
+      (existingMessage) => existingMessage.id === message.id,
+    );
+    const nextMessage = Object.freeze({ ...message });
+    const next = [...previous];
+    if (existingIndex >= 0) {
+      next[existingIndex] = nextMessage;
+    } else {
+      next.push(nextMessage);
+    }
+    const snapshot = Object.freeze(next);
+    this._ephemeralMessages.set(key, snapshot);
+    this._notifyEphemeralMessagesChanged(agentId, threadId, snapshot);
+    return true;
+  }
+
+  removeEphemeralMessage(
+    agentId: string,
+    threadId: string,
+    messageId: string,
+  ): boolean {
+    const key = this._ephemeralScopeKey(agentId, threadId);
+    const previous = this.getEphemeralMessages(agentId, threadId);
+    const existingIndex = previous.findIndex(
+      (message) => message.id === messageId,
+    );
+    if (existingIndex < 0) {
+      return false;
+    }
+
+    const next = Object.freeze(
+      previous.filter((message) => message.id !== messageId),
+    );
+    this._ephemeralMessages.set(key, next);
+    this._notifyEphemeralMessagesChanged(agentId, threadId, next);
+    return true;
+  }
+
+  clearEphemeralMessages(agentId: string, threadId: string): boolean {
+    const key = this._ephemeralScopeKey(agentId, threadId);
+    const previous = this.getEphemeralMessages(agentId, threadId);
+    if (previous.length === 0) {
+      return false;
+    }
+
+    this._ephemeralMessages.set(key, EMPTY_EPHEMERAL_MESSAGES);
+    this._notifyEphemeralMessagesChanged(
+      agentId,
+      threadId,
+      EMPTY_EPHEMERAL_MESSAGES,
+    );
+    return true;
+  }
+
+  private _ephemeralScopeKey(agentId: string, threadId: string): string {
+    return JSON.stringify([agentId, threadId]);
+  }
+
+  private _notifyEphemeralMessagesChanged(
+    agentId: string,
+    threadId: string,
+    messages: ReadonlyArray<ReactEphemeralMessage>,
+  ): void {
+    void this.notifySubscribers((subscriber) => {
+      const reactSubscriber = subscriber as CopilotKitCoreReactSubscriber;
+      reactSubscriber.onEphemeralMessagesChanged?.({
+        copilotkit: this,
+        agentId,
+        threadId,
+        messages,
+      });
+    }, "Subscriber onEphemeralMessagesChanged error:");
   }
 
   setRenderToolCalls(renderToolCalls: ReactToolCallRenderer<any>[]): void {

--- a/packages/react-core/src/v2/lib/react-core.ts
+++ b/packages/react-core/src/v2/lib/react-core.ts
@@ -110,28 +110,41 @@ export class CopilotKitCoreReact extends CopilotKitCore {
     if (!messages) {
       return EMPTY_EPHEMERAL_MESSAGES;
     }
+    return messages;
+  }
 
-    const agent = this.getAgent(agentId);
-    if (!agent || agent.threadId !== threadId) {
-      return messages;
+  reconcileEphemeralMessages(
+    agentId: string,
+    threadId: string,
+    persistedMessages: ReadonlyArray<{ id: string }>,
+  ): boolean {
+    const key = this._ephemeralScopeKey(agentId, threadId);
+    const messages = this._ephemeralMessages.get(key);
+    if (!messages) {
+      return false;
     }
 
-    const persistedIds = new Set(agent.messages.map((message) => message.id));
+    const persistedIds = new Set(
+      persistedMessages.map((message) => message.id),
+    );
     const withoutCollisions = messages.filter(
       (message) => !persistedIds.has(message.id),
     );
     if (withoutCollisions.length === messages.length) {
-      return messages;
+      return false;
     }
 
-    if (withoutCollisions.length === 0) {
+    const next =
+      withoutCollisions.length === 0
+        ? EMPTY_EPHEMERAL_MESSAGES
+        : Object.freeze(withoutCollisions);
+    if (next.length === 0) {
       this._ephemeralMessages.delete(key);
-      return EMPTY_EPHEMERAL_MESSAGES;
+    } else {
+      this._ephemeralMessages.set(key, next);
     }
-
-    const snapshot = Object.freeze(withoutCollisions);
-    this._ephemeralMessages.set(key, snapshot);
-    return snapshot;
+    this._notifyEphemeralMessagesChanged(agentId, threadId, next);
+    return true;
   }
 
   addEphemeralMessage(

--- a/packages/react-core/src/v2/lib/react-core.ts
+++ b/packages/react-core/src/v2/lib/react-core.ts
@@ -140,8 +140,10 @@ export class CopilotKitCoreReact extends CopilotKitCore {
     message: ReactEphemeralMessage,
   ): boolean {
     const agent = this.getAgent(agentId);
+    const persistedMessages =
+      agent?.threadId === threadId ? agent.messages : [];
     if (
-      agent?.messages.some(
+      persistedMessages.some(
         (persistedMessage) => persistedMessage.id === message.id,
       )
     ) {
@@ -152,16 +154,20 @@ export class CopilotKitCoreReact extends CopilotKitCore {
     const existingIndex = previous.findIndex(
       (existingMessage) => existingMessage.id === message.id,
     );
-    const persistedMessages = agent?.messages ?? [];
+    const {
+      anchorMessageId: requestedAnchorMessageId,
+      ...messageWithoutAnchor
+    } = message;
     const existingMessage =
       existingIndex >= 0 ? previous[existingIndex] : undefined;
     const anchorMessageId =
-      existingMessage?.anchorMessageId ??
-      message.anchorMessageId ??
-      persistedMessages[persistedMessages.length - 1]?.id;
+      existingMessage !== undefined
+        ? existingMessage.anchorMessageId
+        : (requestedAnchorMessageId ??
+          persistedMessages[persistedMessages.length - 1]?.id);
     const nextMessage = Object.freeze({
-      ...message,
-      ...(anchorMessageId ? { anchorMessageId } : {}),
+      ...messageWithoutAnchor,
+      ...(anchorMessageId !== undefined ? { anchorMessageId } : {}),
     });
     const key = this._ephemeralScopeKey(agentId, threadId);
     const next = [...previous];

--- a/packages/react-core/src/v2/lib/react-core.ts
+++ b/packages/react-core/src/v2/lib/react-core.ts
@@ -105,10 +105,33 @@ export class CopilotKitCoreReact extends CopilotKitCore {
     agentId: string,
     threadId: string,
   ): ReadonlyArray<ReactEphemeralMessage> {
-    return (
-      this._ephemeralMessages.get(this._ephemeralScopeKey(agentId, threadId)) ??
-      EMPTY_EPHEMERAL_MESSAGES
+    const key = this._ephemeralScopeKey(agentId, threadId);
+    const messages = this._ephemeralMessages.get(key);
+    if (!messages) {
+      return EMPTY_EPHEMERAL_MESSAGES;
+    }
+
+    const agent = this.getAgent(agentId);
+    if (!agent || agent.threadId !== threadId) {
+      return messages;
+    }
+
+    const persistedIds = new Set(agent.messages.map((message) => message.id));
+    const withoutCollisions = messages.filter(
+      (message) => !persistedIds.has(message.id),
     );
+    if (withoutCollisions.length === messages.length) {
+      return messages;
+    }
+
+    if (withoutCollisions.length === 0) {
+      this._ephemeralMessages.delete(key);
+      return EMPTY_EPHEMERAL_MESSAGES;
+    }
+
+    const snapshot = Object.freeze(withoutCollisions);
+    this._ephemeralMessages.set(key, snapshot);
+    return snapshot;
   }
 
   addEphemeralMessage(
@@ -125,12 +148,22 @@ export class CopilotKitCoreReact extends CopilotKitCore {
       return false;
     }
 
-    const key = this._ephemeralScopeKey(agentId, threadId);
     const previous = this.getEphemeralMessages(agentId, threadId);
     const existingIndex = previous.findIndex(
       (existingMessage) => existingMessage.id === message.id,
     );
-    const nextMessage = Object.freeze({ ...message });
+    const persistedMessages = agent?.messages ?? [];
+    const existingMessage =
+      existingIndex >= 0 ? previous[existingIndex] : undefined;
+    const anchorMessageId =
+      existingMessage?.anchorMessageId ??
+      message.anchorMessageId ??
+      persistedMessages[persistedMessages.length - 1]?.id;
+    const nextMessage = Object.freeze({
+      ...message,
+      ...(anchorMessageId ? { anchorMessageId } : {}),
+    });
+    const key = this._ephemeralScopeKey(agentId, threadId);
     const next = [...previous];
     if (existingIndex >= 0) {
       next[existingIndex] = nextMessage;
@@ -160,7 +193,11 @@ export class CopilotKitCoreReact extends CopilotKitCore {
     const next = Object.freeze(
       previous.filter((message) => message.id !== messageId),
     );
-    this._ephemeralMessages.set(key, next);
+    if (next.length === 0) {
+      this._ephemeralMessages.delete(key);
+    } else {
+      this._ephemeralMessages.set(key, next);
+    }
     this._notifyEphemeralMessagesChanged(agentId, threadId, next);
     return true;
   }
@@ -172,7 +209,7 @@ export class CopilotKitCoreReact extends CopilotKitCore {
       return false;
     }
 
-    this._ephemeralMessages.set(key, EMPTY_EPHEMERAL_MESSAGES);
+    this._ephemeralMessages.delete(key);
     this._notifyEphemeralMessagesChanged(
       agentId,
       threadId,

--- a/packages/react-core/src/v2/types/react-custom-message-renderer.ts
+++ b/packages/react-core/src/v2/types/react-custom-message-renderer.ts
@@ -5,6 +5,8 @@ export type ReactCustomMessageRendererPosition = "before" | "after";
 export interface ReactEphemeralMessage<T = unknown> {
   id: string;
   content: T;
+  /** Persisted message ID after which this entry should render. */
+  anchorMessageId?: string;
 }
 
 export interface ReactCustomMessageRenderer {

--- a/packages/react-core/src/v2/types/react-custom-message-renderer.ts
+++ b/packages/react-core/src/v2/types/react-custom-message-renderer.ts
@@ -1,6 +1,11 @@
-import { Message } from "@ag-ui/core";
+import type { Message } from "@ag-ui/core";
 
 export type ReactCustomMessageRendererPosition = "before" | "after";
+
+export interface ReactEphemeralMessage<T = unknown> {
+  id: string;
+  content: T;
+}
 
 export interface ReactCustomMessageRenderer {
   agentId?: string;
@@ -13,5 +18,12 @@ export interface ReactCustomMessageRenderer {
     numberOfMessagesInRun: number;
     agentId: string;
     stateSnapshot: any;
+  }> | null;
+  renderEphemeral?: React.ComponentType<{
+    message: ReactEphemeralMessage;
+    agentId: string;
+    threadId: string;
+    messageIndex: number;
+    numberOfMessages: number;
   }> | null;
 }


### PR DESCRIPTION
## Summary

Frontend events need structured cards in the chat transcript without adding those cards to the next agent request. Existing custom renderers decorate persisted messages, and `agent.addMessage` persists new entries, so neither path provides a client-only history entry.

## Changes

- Add a provider-lifetime, agent-and-thread-scoped ephemeral message channel to v2 React.
- Expose additive add, update, remove, and clear operations through `useAgent`.
- Render entries through an explicit ephemeral renderer while preserving persisted history and legacy append behavior.
- Cover lifecycle, ordering, scope, cleanup, renderer activation, virtual scrolling, and outbound-history isolation.

## Out of scope

AG-UI roles, `AbstractAgent` history, outbound run payloads, persisted custom-renderer behavior, legacy append semantics, Vue, Angular, and any new product-boundary decision remain outside this target.

## Related PRs and Issues

Closes #3388.

The API follows the boundary described by the maintainer in https://github.com/CopilotKit/CopilotKit/issues/3388#issuecomment-5086936139.

## Test plan

- [x] Ephemeral lifecycle regressions, 26 passed. Covers non-explicit scope changes, mount reconciliation, render-only custom renderers, and virtual first-entry removal.
- [x] Store, chat, persistence, and rendering regressions, 52 passed; throttle compatibility tests, 4 passed.
- [x] React Core package suite, 124 files and 1,503 tests passed; the isolated A2UI renderer rerun passed 8/8.
- [x] Typecheck, formatting, lint, and whitespace validation passed; lint reported existing warnings only.
- [ ] CI green (`static / quality`, `test / unit` on Node 20/22/24).
