### PR TITLE
fix(react-core): support async header builders

### DIFF
--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -97,6 +97,7 @@ export type CopilotKitCoreGetSuggestionsResult = {
 };
 
 export enum CopilotKitCoreErrorCode {
+  HEADER_RESOLUTION_FAILED = "header_resolution_failed",
   RUNTIME_INFO_FETCH_FAILED = "runtime_info_fetch_failed",
   AGENT_CONNECT_FAILED = "agent_connect_failed",
   AGENT_RUN_FAILED = "agent_run_failed",

--- a/packages/react-core/skills/react-core/references/provider-setup.md
+++ b/packages/react-core/skills/react-core/references/provider-setup.md
@@ -339,7 +339,10 @@ Source: `packages/react-core/src/v2/providers/CopilotKitProvider.tsx` (context)
 ## Async headers
 
 Pass a stable header builder when credentials are resolved asynchronously. The
-provider invokes it once per function identity, withholds its concrete
-descendants until the first valid record settles, and keeps the last-good record
-active if a refresh fails. Change the builder reference to request a declarative
-refresh; use `copilotkit.setHeaders()` for an imperative refresh.
+provider invokes it once per function identity and keeps children mounted while
+the first result is pending. Header-bearing requests wait for that result, reject
+with the header-resolution error after an initial failure, and keep using the
+last-good record if a refresh fails. A pending builder replaced by a new function
+on each render emits one development warning, so memoize the builder. Change the
+builder reference for a declarative refresh; use `copilotkit.setHeaders()` for an
+imperative refresh.

--- a/packages/react-core/skills/react-core/references/provider-setup.md
+++ b/packages/react-core/skills/react-core/references/provider-setup.md
@@ -335,3 +335,11 @@ any other CopilotKit hook must be a descendant of the `CopilotKit`
 provider. Placing the provider beside or below a consumer throws at mount.
 
 Source: `packages/react-core/src/v2/providers/CopilotKitProvider.tsx` (context)
+
+## Async headers
+
+Pass a stable header builder when credentials are resolved asynchronously. The
+provider invokes it once per function identity, withholds its concrete
+descendants until the first valid record settles, and keeps the last-good record
+active if a refresh fails. Change the builder reference to request a declarative
+refresh; use `copilotkit.setHeaders()` for an imperative refresh.

--- a/packages/react-core/src/components/copilot-provider/__tests__/copilotkit-async-headers.test.tsx
+++ b/packages/react-core/src/components/copilot-provider/__tests__/copilotkit-async-headers.test.tsx
@@ -36,4 +36,27 @@ describe("v1 async headers", () => {
     expect(headers.get("Authorization")).toBe("Bearer settled");
     fetchMock.mockRestore();
   });
+
+  it("forwards an initial header failure through the v1 error shape", async () => {
+    const onError = vi.fn();
+    const original = new Error("token unavailable");
+    render(
+      <CopilotKit
+        runtimeUrl="https://runtime.example"
+        headers={() => Promise.reject(original)}
+        onError={onError}
+      >
+        <div>v1-child</div>
+      </CopilotKit>,
+    );
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({
+      type: "error",
+      error: original,
+      context: {
+        source: "headers",
+        request: { operation: "header_resolution_failed" },
+      },
+    });
+  });
 });

--- a/packages/react-core/src/components/copilot-provider/__tests__/copilotkit-async-headers.test.tsx
+++ b/packages/react-core/src/components/copilot-provider/__tests__/copilotkit-async-headers.test.tsx
@@ -26,7 +26,7 @@ describe("v1 async headers", () => {
         <div>v1-child</div>
       </CopilotKit>,
     );
-    expect(view.queryByText("v1-child")).toBeNull();
+    expect(view.queryByText("v1-child")).not.toBeNull();
     release({ Authorization: "Bearer settled" });
     await waitFor(() => expect(view.queryByText("v1-child")).not.toBeNull());
     await waitFor(() => expect(fetchMock).toHaveBeenCalled());
@@ -34,13 +34,14 @@ describe("v1 async headers", () => {
       (fetchMock.mock.calls[0]?.[1] as RequestInit).headers,
     );
     expect(headers.get("Authorization")).toBe("Bearer settled");
+    view.unmount();
     fetchMock.mockRestore();
   });
 
   it("forwards an initial header failure through the v1 error shape", async () => {
     const onError = vi.fn();
     const original = new Error("token unavailable");
-    render(
+    const view = render(
       <CopilotKit
         runtimeUrl="https://runtime.example"
         headers={() => Promise.reject(original)}
@@ -58,5 +59,6 @@ describe("v1 async headers", () => {
         request: { operation: "header_resolution_failed" },
       },
     });
+    view.unmount();
   });
 });

--- a/packages/react-core/src/components/copilot-provider/__tests__/copilotkit-async-headers.test.tsx
+++ b/packages/react-core/src/components/copilot-provider/__tests__/copilotkit-async-headers.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CopilotKit } from "../copilotkit";
+
+describe("v1 async headers", () => {
+  it("hands the settled concrete record to the v1 subtree", async () => {
+    let release!: (value: Record<string, string>) => void;
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: "1", agents: {} }), {
+        status: 200,
+      }),
+    );
+    const view = render(
+      <CopilotKit
+        runtimeUrl="https://runtime.example"
+        agents__unsafe_dev_only={{
+          default: {
+            clone: vi.fn(),
+            run: vi.fn(),
+            subscribe: vi.fn(() => ({ unsubscribe: () => {} })),
+          } as any,
+        }}
+        headers={() => new Promise((resolve) => (release = resolve))}
+      >
+        <div>v1-child</div>
+      </CopilotKit>,
+    );
+    expect(view.queryByText("v1-child")).toBeNull();
+    release({ Authorization: "Bearer settled" });
+    await waitFor(() => expect(view.queryByText("v1-child")).not.toBeNull());
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const headers = new Headers(
+      (fetchMock.mock.calls[0]?.[1] as RequestInit).headers,
+    );
+    expect(headers.get("Authorization")).toBe("Bearer settled");
+    fetchMock.mockRestore();
+  });
+});

--- a/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import type { AuthState } from "../../context/copilot-context";
 import type { CopilotErrorHandler, DebugConfig } from "@copilotkit/shared";
 import type { CopilotKitProviderProps } from "../../v2";
+import type { MaybePromise } from "@copilotkit/shared";
 /**
  * Props for CopilotKit.
  */
@@ -55,19 +56,22 @@ export interface CopilotKitProps extends Omit<
 
   /**
    * Additional headers to be sent with the request.
-   * Can be a static object or a function that returns headers dynamically
-   * (useful for refreshing auth tokens).
+   * Can be a static object or a stable function that returns headers, including
+   * an async result. Change the function reference to refresh declaratively;
+   * call `copilotkit.setHeaders()` for an imperative refresh.
    *
    * For example:
    * ```tsx
    * // Static headers
    * headers={{ "Authorization": "Bearer X" }}
    *
-   * // Dynamic headers (re-evaluated on each render)
-   * headers={() => ({ "Authorization": `Bearer ${getToken()}` })}
+   * // Dynamic headers (memoize the builder)
+   * headers={useCallback(async () => ({ "Authorization": `Bearer ${await getToken()}` }), [])}
    * ```
    */
-  headers?: Record<string, string> | (() => Record<string, string>);
+  headers?:
+    | Record<string, string>
+    | (() => MaybePromise<Record<string, string>>);
 
   /**
    * The children to be rendered within the CopilotKit.

--- a/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -58,7 +58,11 @@ export interface CopilotKitProps extends Omit<
    * Additional headers to be sent with the request.
    * Can be a static object or a stable function that returns headers, including
    * an async result. Change the function reference to refresh declaratively;
-   * call `copilotkit.setHeaders()` for an imperative refresh.
+   * call `copilotkit.setHeaders()` for an imperative refresh. Children remain
+   * mounted while an async result is pending or fails; header-bearing requests
+   * wait for the first result or reject with the header-resolution error. A
+   * pending async source replaced by a new function each render emits a
+   * development warning, so memoize the builder.
    *
    * For example:
    * ```tsx

--- a/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -28,7 +28,11 @@ import {
   CopilotKitProvider as CopilotKitV2Provider,
   useCopilotKit,
 } from "../../v2";
-import { useResolvedHeaderRecord } from "../../v2/providers/ResolvedHeadersContext";
+import {
+  useHeaderReadiness,
+  useResolvedHeaderRecord,
+} from "../../v2/providers/ResolvedHeadersContext";
+import { bindConfigHeaderReadiness } from "../../v2/providers/header-readiness";
 import type {
   CopilotApiConfig,
   ChatComponentsCache,
@@ -101,11 +105,6 @@ export function CopilotKit({ children, ...props }: CopilotKitProps) {
       context: Record<string, any>;
     }) => {
       if (event.context?.source !== "headers") {
-        console.error(
-          `[CopilotKit] Error (${event.code}):`,
-          event.error,
-          event.context ?? {},
-        );
         return;
       }
       if (!_onError) return;
@@ -172,6 +171,7 @@ function CopilotKitErrorBridge() {
 
     const subscription = copilotkit.subscribe({
       onError: async (event) => {
+        if (event.context?.source === "headers") return;
         // Convert v2.x error event to v1.x CopilotErrorEvent format
         const errorEvent: CopilotErrorEvent = {
           type: "error",
@@ -216,6 +216,7 @@ function CopilotKitErrorBridge() {
 export function CopilotKitInternal(cpkProps: CopilotKitProps) {
   const { children, ...props } = cpkProps;
   const resolvedHeaderRecord = useResolvedHeaderRecord();
+  const headerReadiness = useHeaderReadiness();
 
   /**
    * This will throw an error if the props are invalid.
@@ -384,6 +385,9 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
     props.cloudRestrictToTopic,
     props.guardrails_c,
   ]);
+  if (headerReadiness) {
+    bindConfigHeaderReadiness(copilotApiConfig, headerReadiness);
+  }
 
   const headers = useMemo(() => {
     const authHeaders = Object.values(authStates || {}).reduce((acc, state) => {

--- a/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -28,6 +28,7 @@ import {
   CopilotKitProvider as CopilotKitV2Provider,
   useCopilotKit,
 } from "../../v2";
+import { useResolvedHeaderRecord } from "../../v2/providers/ResolvedHeadersContext";
 import type {
   CopilotApiConfig,
   ChatComponentsCache,
@@ -173,6 +174,7 @@ function CopilotKitErrorBridge() {
 
 export function CopilotKitInternal(cpkProps: CopilotKitProps) {
   const { children, ...props } = cpkProps;
+  const resolvedHeaderRecord = useResolvedHeaderRecord();
 
   /**
    * This will throw an error if the props are invalid.
@@ -323,9 +325,8 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
       ...(cloud ? { cloud } : {}),
       chatApiEndpoint: chatApiEndpoint,
       headers:
-        typeof props.headers === "function"
-          ? props.headers()
-          : props.headers || {},
+        resolvedHeaderRecord ??
+        (typeof props.headers === "function" ? {} : props.headers || {}),
       properties: props.properties || {},
       transcribeAudioUrl: props.transcribeAudioUrl,
       textToSpeechUrl: props.textToSpeechUrl,
@@ -333,6 +334,7 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
     };
   }, [
     publicApiKey,
+    resolvedHeaderRecord,
     props.headers,
     props.properties,
     props.transcribeAudioUrl,

--- a/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -100,7 +100,15 @@ export function CopilotKit({ children, ...props }: CopilotKitProps) {
       code: string;
       context: Record<string, any>;
     }) => {
-      if (!_onError || event.context?.source !== "headers") return;
+      if (event.context?.source !== "headers") {
+        console.error(
+          `[CopilotKit] Error (${event.code}):`,
+          event.error,
+          event.context ?? {},
+        );
+        return;
+      }
+      if (!_onError) return;
       await _onError({
         type: "error",
         timestamp: Date.now(),

--- a/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -94,6 +94,38 @@ export function CopilotKit({ children, ...props }: CopilotKitProps) {
   // error events to the v1 shape — so it must not be spread into the v2
   // provider directly.
   const { onError: _onError, ...v2Props } = props;
+  const handleV2HeaderError = useCallback(
+    async (event: {
+      error: Error;
+      code: string;
+      context: Record<string, any>;
+    }) => {
+      if (!_onError || event.context?.source !== "headers") return;
+      await _onError({
+        type: "error",
+        timestamp: Date.now(),
+        context: {
+          source: "agent",
+          request: {
+            operation: event.code,
+            url: props.runtimeUrl,
+            startTime: Date.now(),
+          },
+          technical: {
+            environment: "browser",
+            userAgent:
+              typeof navigator !== "undefined"
+                ? navigator.userAgent
+                : undefined,
+            stackTrace: event.error.stack,
+          },
+          ...event.context,
+        },
+        error: event.error,
+      });
+    },
+    [_onError, props.runtimeUrl],
+  );
 
   return (
     <ToastProvider enabled={enabled}>
@@ -107,6 +139,7 @@ export function CopilotKit({ children, ...props }: CopilotKitProps) {
             showDevConsole={showInspector}
             renderCustomMessages={renderArr}
             useSingleEndpoint={props.useSingleEndpoint ?? true}
+            onError={_onError ? handleV2HeaderError : undefined}
           >
             <CopilotKitInternal {...props}>{children}</CopilotKitInternal>
           </CopilotKitV2Provider>

--- a/packages/react-core/src/lib/copilot-task.ts
+++ b/packages/react-core/src/lib/copilot-task.ts
@@ -66,6 +66,7 @@ import { CopilotContextParams } from "../context";
 import { defaultCopilotContextCategories } from "../components";
 import {
   headerReadinessHeadersFor,
+  headerReadinessRuntimeUrlFor,
   waitForHeaderReadiness,
 } from "../v2/providers/header-readiness";
 
@@ -146,7 +147,9 @@ export class CopilotTask<T = any> {
     const messages: Message[] = [systemMessage];
 
     const runtimeClient = new CopilotRuntimeClient({
-      url: context.copilotApiConfig.chatApiEndpoint,
+      url:
+        headerReadinessRuntimeUrlFor(context.copilotApiConfig) ??
+        context.copilotApiConfig.chatApiEndpoint,
       publicApiKey: context.copilotApiConfig.publicApiKey,
       headers:
         headerReadinessHeadersFor(context.copilotApiConfig) ??

--- a/packages/react-core/src/lib/copilot-task.ts
+++ b/packages/react-core/src/lib/copilot-task.ts
@@ -64,6 +64,10 @@ import {
 } from "../types/frontend-action";
 import { CopilotContextParams } from "../context";
 import { defaultCopilotContextCategories } from "../components";
+import {
+  headerReadinessHeadersFor,
+  waitForHeaderReadiness,
+} from "../v2/providers/header-readiness";
 
 export interface CopilotTaskConfig {
   /**
@@ -110,6 +114,7 @@ export class CopilotTask<T = any> {
    * @param data The data to use for the task.
    */
   async run(context: CopilotContextParams, data?: T): Promise<void> {
+    await waitForHeaderReadiness(context.copilotApiConfig);
     const actions = this.includeCopilotActions
       ? Object.assign({}, context.actions)
       : {};
@@ -143,7 +148,9 @@ export class CopilotTask<T = any> {
     const runtimeClient = new CopilotRuntimeClient({
       url: context.copilotApiConfig.chatApiEndpoint,
       publicApiKey: context.copilotApiConfig.publicApiKey,
-      headers: context.copilotApiConfig.headers,
+      headers:
+        headerReadinessHeadersFor(context.copilotApiConfig) ??
+        context.copilotApiConfig.headers,
       credentials: context.copilotApiConfig.credentials,
     });
 

--- a/packages/react-core/src/v2/components/MCPAppsActivityRenderer.tsx
+++ b/packages/react-core/src/v2/components/MCPAppsActivityRenderer.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState, useCallback } from "react";
 import { z } from "zod";
 import type { AbstractAgent, RunAgentResult } from "@ag-ui/client";
 import { useCopilotKit } from "../providers/CopilotKitProvider";
+import { waitForHeaderReadiness } from "../providers/header-readiness";
 
 /**
  * The subset of `CopilotKitCore` that {@link ɵrunMcpFollowUp} depends on.
@@ -414,6 +415,7 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
       // Create the fetch promise using the queue to serialize requests
       const fetchPromise = (async (): Promise<FetchedResource | null> => {
         try {
+          await waitForHeaderReadiness(copilotkit);
           // Use queue to wait for agent to be idle and serialize requests
           const runResult = await mcpAppsRequestQueue.enqueue(agent, () =>
             agent.runAgent({
@@ -698,6 +700,7 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
                   }
 
                   try {
+                    await waitForHeaderReadiness(copilotkit);
                     // Use queue to wait for agent to be idle and serialize requests
                     const runResult = await mcpAppsRequestQueue.enqueue(
                       currentAgent,

--- a/packages/react-core/src/v2/hooks/use-learn-from-user-action.tsx
+++ b/packages/react-core/src/v2/hooks/use-learn-from-user-action.tsx
@@ -4,6 +4,7 @@ import { recordAnnotation } from "../lib/record-annotation";
 import {
   headerReadinessFor,
   headerReadinessHeadersFor,
+  headerReadinessRuntimeUrlFor,
 } from "../providers/header-readiness";
 
 /**
@@ -103,7 +104,8 @@ export function useLearnFromUserAction(): UseLearnFromUserActionRecorder {
       };
 
       return recordAnnotation({
-        runtimeUrl,
+        runtimeUrl: () =>
+          headerReadinessRuntimeUrlFor(copilotkit) ?? copilotkit.runtimeUrl,
         headers: () =>
           headerReadinessHeadersFor(copilotkit) ?? copilotkit.headers ?? {},
         readiness: headerReadinessFor(copilotkit),

--- a/packages/react-core/src/v2/hooks/use-learn-from-user-action.tsx
+++ b/packages/react-core/src/v2/hooks/use-learn-from-user-action.tsx
@@ -1,6 +1,10 @@
 import { useCallback } from "react";
 import { useCopilotKit } from "../context";
 import { recordAnnotation } from "../lib/record-annotation";
+import {
+  headerReadinessFor,
+  headerReadinessHeadersFor,
+} from "../providers/header-readiness";
 
 /**
  * Input to {@link UseLearnFromUserActionRecorder}, the function returned
@@ -100,7 +104,9 @@ export function useLearnFromUserAction(): UseLearnFromUserActionRecorder {
 
       return recordAnnotation({
         runtimeUrl,
-        headers: copilotkit.headers ?? {},
+        headers: () =>
+          headerReadinessHeadersFor(copilotkit) ?? copilotkit.headers ?? {},
+        readiness: headerReadinessFor(copilotkit),
         type: "user_action",
         payload: Object.keys(payload).length > 0 ? payload : undefined,
         threadId: input.threadId,

--- a/packages/react-core/src/v2/hooks/use-learning-containers.tsx
+++ b/packages/react-core/src/v2/hooks/use-learning-containers.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useRef } from "react";
 import { useCopilotKit } from "../context";
 import { recordAnnotation } from "../lib/record-annotation";
+import {
+  headerReadinessFor,
+  headerReadinessHeadersFor,
+} from "../providers/header-readiness";
 
 /** The default learning containers value. Matches the backend default. */
 const DEFAULT_CONTAINERS: string[] = ["project"];
@@ -96,8 +100,6 @@ export function useLearningContainers({
   // threadId changes are handled by Effect 2's cleanup.
   useEffect(() => {
     const runtimeUrl = copilotkit.runtimeUrl;
-    const headers = copilotkit.headers ?? {};
-
     /**
      * Fire-and-forget emit; errors must not surface in render.
      * Failures are logged as warnings so they are diagnosable without
@@ -115,7 +117,9 @@ export function useLearningContainers({
       }
       recordAnnotation({
         runtimeUrl,
-        headers,
+        headers: () =>
+          headerReadinessHeadersFor(copilotkit) ?? copilotkit.headers ?? {},
+        readiness: headerReadinessFor(copilotkit),
         type: "set_learning_containers",
         payload: { containers },
         threadId,
@@ -162,7 +166,9 @@ export function useLearningContainers({
       if (capturedRuntimeUrl) {
         recordAnnotation({
           runtimeUrl: capturedRuntimeUrl,
-          headers: capturedHeaders,
+          headers: () =>
+            headerReadinessHeadersFor(copilotkit) ?? capturedHeaders ?? {},
+          readiness: headerReadinessFor(copilotkit),
           type: "set_learning_containers",
           payload: { containers: DEFAULT_CONTAINERS },
           threadId: capturedThreadId,

--- a/packages/react-core/src/v2/hooks/use-learning-containers.tsx
+++ b/packages/react-core/src/v2/hooks/use-learning-containers.tsx
@@ -4,6 +4,7 @@ import { recordAnnotation } from "../lib/record-annotation";
 import {
   headerReadinessFor,
   headerReadinessHeadersFor,
+  headerReadinessRuntimeUrlFor,
 } from "../providers/header-readiness";
 
 /** The default learning containers value. Matches the backend default. */
@@ -116,7 +117,8 @@ export function useLearningContainers({
         return;
       }
       recordAnnotation({
-        runtimeUrl,
+        runtimeUrl: () =>
+          headerReadinessRuntimeUrlFor(copilotkit) ?? copilotkit.runtimeUrl,
         headers: () =>
           headerReadinessHeadersFor(copilotkit) ?? copilotkit.headers ?? {},
         readiness: headerReadinessFor(copilotkit),
@@ -165,7 +167,10 @@ export function useLearningContainers({
 
       if (capturedRuntimeUrl) {
         recordAnnotation({
-          runtimeUrl: capturedRuntimeUrl,
+          runtimeUrl: () =>
+            headerReadinessRuntimeUrlFor(copilotkit) ??
+            copilotkit.runtimeUrl ??
+            capturedRuntimeUrl,
           headers: () =>
             headerReadinessHeadersFor(copilotkit) ?? capturedHeaders ?? {},
           readiness: headerReadinessFor(copilotkit),

--- a/packages/react-core/src/v2/lib/__tests__/record-annotation.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/record-annotation.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { recordAnnotation } from "../record-annotation";
+import { HeaderReadinessBarrier } from "../../providers/header-readiness";
 
 // Override randomUUID with a counter so each call produces a distinct,
 // predictable value (mirrors the pattern used in the hook tests).
@@ -81,6 +82,32 @@ it("POSTs the correct wire body to ${runtimeUrl}/annotate", async () => {
   expect(calls[0]!.body).not.toHaveProperty("userId");
   expect(typeof calls[0]!.body!.clientEventId).toBe("string");
   expect((calls[0]!.body!.clientEventId as string).length).toBeGreaterThan(0);
+});
+
+it("reads the current headers after readiness releases the request", async () => {
+  const { calls, fetch } = mockFetch([
+    { status: 200, body: { id: "evt-ready", duplicate: false } },
+  ]);
+  globalThis.fetch = fetch;
+  const barrier = new HeaderReadinessBarrier();
+  let headers: Record<string, string> = {};
+
+  const pending = recordAnnotation({
+    runtimeUrl: "https://bff.example.com/api/copilotkit",
+    headers: () => headers,
+    readiness: barrier,
+    type: "user_action",
+    threadId: "thread-ready",
+  });
+  await Promise.resolve();
+  expect(calls).toHaveLength(0);
+
+  headers = { Authorization: "Bearer current" };
+  barrier.ready(headers);
+  await pending;
+  expect(new Headers(calls[0]!.init?.headers).get("Authorization")).toBe(
+    "Bearer current",
+  );
 });
 
 it("uses the caller-supplied clientEventId verbatim when provided", async () => {

--- a/packages/react-core/src/v2/lib/react-core.ts
+++ b/packages/react-core/src/v2/lib/react-core.ts
@@ -7,6 +7,11 @@ import {
   type CopilotKitCoreSubscriber,
   type CopilotKitCoreSubscription,
 } from "@copilotkit/core";
+import {
+  headerReadinessFor,
+  isProviderHeaderSync,
+  waitForHeaderReadiness,
+} from "../providers/header-readiness";
 
 export interface CopilotKitCoreReactConfig extends CopilotKitCoreConfig {
   // Add any additional configuration properties specific to the React implementation
@@ -29,6 +34,8 @@ export interface CopilotKitCoreReactSubscriber extends CopilotKitCoreSubscriber 
 }
 
 export class CopilotKitCoreReact extends CopilotKitCore {
+  private _deferredRuntimeUrl: string | undefined;
+  private _hasDeferredRuntimeUrl = false;
   private _renderToolCalls: ReactToolCallRenderer<any>[] = [];
   private _hookRenderToolCalls: Map<string, ReactToolCallRenderer<any>> =
     new Map();
@@ -152,5 +159,61 @@ export class CopilotKitCoreReact extends CopilotKitCore {
    */
   async waitForPendingFrameworkUpdates(): Promise<void> {
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+
+  override setHeaders(
+    headers: Record<string, string | null | undefined>,
+  ): void {
+    super.setHeaders(headers);
+    if (!isProviderHeaderSync(this)) {
+      headerReadinessFor(this)?.ready(this.headers);
+    }
+  }
+
+  override setRuntimeUrl(runtimeUrl: string | undefined): void {
+    const readiness = headerReadinessFor(this);
+    if (readiness && readiness.state !== "ready") {
+      this._deferredRuntimeUrl = runtimeUrl;
+      this._hasDeferredRuntimeUrl = true;
+      return;
+    }
+    super.setRuntimeUrl(runtimeUrl);
+  }
+
+  override connect(): void {
+    const readiness = headerReadinessFor(this);
+    const waitForConnect =
+      readiness?.state === "failed"
+        ? readiness.waitForRecovery()
+        : (readiness?.wait() ?? waitForHeaderReadiness(this));
+    void waitForConnect
+      .then(() => {
+        if (this._hasDeferredRuntimeUrl) {
+          super.setRuntimeUrl(this._deferredRuntimeUrl);
+          this._hasDeferredRuntimeUrl = false;
+        }
+        super.connect();
+      })
+      .catch(() => {});
+  }
+
+  override reloadSuggestions(agentId: string): void {
+    void (headerReadinessFor(this)?.wait() ?? waitForHeaderReadiness(this))
+      .then(() => super.reloadSuggestions(agentId))
+      .catch(() => {});
+  }
+
+  override async connectAgent(
+    params: Parameters<CopilotKitCore["connectAgent"]>[0],
+  ): ReturnType<CopilotKitCore["connectAgent"]> {
+    await (headerReadinessFor(this)?.wait() ?? waitForHeaderReadiness(this));
+    return super.connectAgent(params);
+  }
+
+  override async runAgent(
+    params: Parameters<CopilotKitCore["runAgent"]>[0],
+  ): ReturnType<CopilotKitCore["runAgent"]> {
+    await (headerReadinessFor(this)?.wait() ?? waitForHeaderReadiness(this));
+    return super.runAgent(params);
   }
 }

--- a/packages/react-core/src/v2/lib/react-core.ts
+++ b/packages/react-core/src/v2/lib/react-core.ts
@@ -166,7 +166,9 @@ export class CopilotKitCoreReact extends CopilotKitCore {
   ): void {
     super.setHeaders(headers);
     if (!isProviderHeaderSync(this)) {
-      headerReadinessFor(this)?.ready(this.headers);
+      const readiness = headerReadinessFor(this);
+      readiness?.update(this.headers);
+      readiness?.ready();
     }
   }
 

--- a/packages/react-core/src/v2/lib/react-core.ts
+++ b/packages/react-core/src/v2/lib/react-core.ts
@@ -168,7 +168,7 @@ export class CopilotKitCoreReact extends CopilotKitCore {
     if (!isProviderHeaderSync(this)) {
       const readiness = headerReadinessFor(this);
       readiness?.update(this.headers);
-      readiness?.ready();
+      readiness?.recover();
     }
   }
 
@@ -179,6 +179,7 @@ export class CopilotKitCoreReact extends CopilotKitCore {
       this._hasDeferredRuntimeUrl = true;
       return;
     }
+    readiness?.updateRuntimeUrl(runtimeUrl);
     super.setRuntimeUrl(runtimeUrl);
   }
 

--- a/packages/react-core/src/v2/lib/react-core.ts
+++ b/packages/react-core/src/v2/lib/react-core.ts
@@ -168,7 +168,11 @@ export class CopilotKitCoreReact extends CopilotKitCore {
     if (!isProviderHeaderSync(this)) {
       const readiness = headerReadinessFor(this);
       readiness?.update(this.headers);
-      readiness?.recover();
+      if (readiness) {
+        this.syncDeferredRuntimeUrl();
+        readiness.recover();
+        this.connect();
+      }
     }
   }
 
@@ -191,13 +195,16 @@ export class CopilotKitCoreReact extends CopilotKitCore {
         : (readiness?.wait() ?? waitForHeaderReadiness(this));
     void waitForConnect
       .then(() => {
-        if (this._hasDeferredRuntimeUrl) {
-          super.setRuntimeUrl(this._deferredRuntimeUrl);
-          this._hasDeferredRuntimeUrl = false;
-        }
+        this.syncDeferredRuntimeUrl();
         super.connect();
       })
       .catch(() => {});
+  }
+
+  syncDeferredRuntimeUrl(): void {
+    if (!this._hasDeferredRuntimeUrl) return;
+    super.setRuntimeUrl(this._deferredRuntimeUrl);
+    this._hasDeferredRuntimeUrl = false;
   }
 
   override reloadSuggestions(agentId: string): void {

--- a/packages/react-core/src/v2/lib/record-annotation.ts
+++ b/packages/react-core/src/v2/lib/record-annotation.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "@copilotkit/shared";
+import type { HeaderReadiness } from "../providers/header-readiness";
 
 /**
  * The result shape returned by the CopilotKit runtime `/annotate` endpoint.
@@ -31,7 +32,9 @@ export interface RecordAnnotationArgs {
    * Extra HTTP headers forwarded from `copilotkit.headers` — typically used
    * for customer auth tokens that the BFF needs to identify the user.
    */
-  headers: Record<string, string>;
+  headers: Record<string, string> | (() => Record<string, string>);
+  /** Private provider barrier used to avoid requests before headers settle. */
+  readiness?: HeaderReadiness;
   /**
    * The annotation discriminant understood by the Intelligence platform.
    * `"user_action"` records a UI interaction for the self-learning loop.
@@ -84,7 +87,10 @@ export interface RecordAnnotationArgs {
 export async function recordAnnotation(
   args: RecordAnnotationArgs,
 ): Promise<RecordAnnotationResult> {
-  const { runtimeUrl, headers, type, payload, threadId, occurredAt } = args;
+  await args.readiness?.wait();
+  const { runtimeUrl, type, payload, threadId, occurredAt } = args;
+  const headers =
+    typeof args.headers === "function" ? args.headers() : args.headers;
 
   const clientEventId = args.clientEventId ?? randomUUID();
 

--- a/packages/react-core/src/v2/lib/record-annotation.ts
+++ b/packages/react-core/src/v2/lib/record-annotation.ts
@@ -27,7 +27,7 @@ export interface RecordAnnotationArgs {
    * (e.g. `https://bff.example.com/api/copilotkit`).
    * The function appends `/annotate`.
    */
-  runtimeUrl: string;
+  runtimeUrl: string | (() => string | undefined);
   /**
    * Extra HTTP headers forwarded from `copilotkit.headers` — typically used
    * for customer auth tokens that the BFF needs to identify the user.
@@ -88,7 +88,12 @@ export async function recordAnnotation(
   args: RecordAnnotationArgs,
 ): Promise<RecordAnnotationResult> {
   await args.readiness?.wait();
-  const { runtimeUrl, type, payload, threadId, occurredAt } = args;
+  const runtimeUrl =
+    typeof args.runtimeUrl === "function" ? args.runtimeUrl() : args.runtimeUrl;
+  if (!runtimeUrl) {
+    throw new Error("recordAnnotation: runtimeUrl is not configured");
+  }
+  const { type, payload, threadId, occurredAt } = args;
   const headers =
     typeof args.headers === "function" ? args.headers() : args.headers;
 

--- a/packages/react-core/src/v2/lib/transcription-client.ts
+++ b/packages/react-core/src/v2/lib/transcription-client.ts
@@ -1,4 +1,5 @@
 import type { CopilotKitCoreReact } from "./react-core";
+import { waitForHeaderReadiness } from "../providers/header-readiness";
 import {
   TranscriptionErrorCode,
   type TranscriptionErrorResponse,
@@ -94,6 +95,7 @@ export async function transcribeAudio(
   audioBlob: Blob,
   filename: string = "recording.webm",
 ): Promise<TranscriptionResult> {
+  await waitForHeaderReadiness(core);
   const runtimeUrl = core.runtimeUrl;
   if (!runtimeUrl) {
     throw new TranscriptionError({

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -65,6 +65,7 @@ import {
   useHeaderReadiness,
 } from "./ResolvedHeadersContext";
 import {
+  applyDeferredHeaderRuntimeUrl,
   bindHeaderReadiness,
   HeaderReadinessBarrier,
   withProviderHeaderSync,
@@ -984,8 +985,10 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = (
   }
   const barrier = barrierRef.current;
   useEffect(() => {
-    if (status === "ready") barrier.ready(headers ?? EMPTY_HEADERS);
-    else if (status === "failed") barrier.failed(error);
+    if (status === "ready") {
+      applyDeferredHeaderRuntimeUrl(barrier);
+      barrier.ready(headers ?? EMPTY_HEADERS);
+    } else if (status === "failed") barrier.failed(error);
     else barrier.pending();
   }, [barrier, error, headers, status]);
   useEffect(

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -60,7 +60,15 @@ import { schemaToJsonSchema } from "@copilotkit/shared";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import type { MaybePromise } from "@copilotkit/shared";
 import { useHeaderSource } from "./use-header-source";
-import { ResolvedHeadersProvider } from "./ResolvedHeadersContext";
+import {
+  ResolvedHeadersProvider,
+  useHeaderReadiness,
+} from "./ResolvedHeadersContext";
+import {
+  bindHeaderReadiness,
+  HeaderReadinessBarrier,
+  withProviderHeaderSync,
+} from "./header-readiness";
 
 // Adapts zod-to-json-schema's zod-specific signature to the injectable
 // `zodToJsonSchema` contract of `schemaToJsonSchema`, which only invokes it
@@ -302,6 +310,7 @@ const CopilotKitProviderInner: React.FC<
   inspectorDefaultAnchor,
   debug,
 }) => {
+  const headerReadiness = useHeaderReadiness();
   const [shouldRenderInspector, setShouldRenderInspector] = useState(false);
   const [runtimeA2UIEnabled, setRuntimeA2UIEnabled] = useState(false);
   const [runtimeOpenGenUIEnabled, setRuntimeOpenGenUIEnabled] = useState(false);
@@ -643,6 +652,7 @@ const CopilotKitProviderInner: React.FC<
     }
   }
   const copilotkit = copilotkitRef.current;
+  if (headerReadiness) bindHeaderReadiness(copilotkit, headerReadiness);
 
   // Register the full A2UI catalog component list onto core so the inspector can
   // read `core.catalogComponents`, and re-derive the filtered catalog whenever
@@ -788,7 +798,9 @@ const CopilotKitProviderInner: React.FC<
           ? "rest"
           : "auto",
     );
-    copilotkit.setHeaders(mergedHeaders);
+    withProviderHeaderSync(copilotkit, () =>
+      copilotkit.setHeaders(mergedHeaders),
+    );
     copilotkit.setCredentials(credentials);
     // Forward a per-run signal when the provider has an A2UI catalog so the
     // runtime can turn A2UI on (and inject the render tool) without a separate
@@ -963,7 +975,17 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = (
     children,
     ...innerProps
   } = props;
-  const { headers, error } = useHeaderSource(source);
+  const { headers, error, status } = useHeaderSource(source);
+  const barrierRef = useRef<HeaderReadinessBarrier | null>(null);
+  if (barrierRef.current === null) {
+    barrierRef.current = new HeaderReadinessBarrier();
+  }
+  const barrier = barrierRef.current;
+  useEffect(() => {
+    if (status === "ready") barrier.ready(headers ?? EMPTY_HEADERS);
+    else if (status === "failed") barrier.failed(error);
+    else barrier.pending();
+  }, [barrier, error, headers, status]);
   const reportedError = useRef<{
     source: typeof source;
     error: Error;
@@ -994,14 +1016,13 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = (
     }
   }, [error, onError, runtimeUrl, source]);
 
-  if (!headers) return null;
   return (
-    <ResolvedHeadersProvider value={headers}>
+    <ResolvedHeadersProvider value={headers ?? EMPTY_HEADERS} barrier={barrier}>
       <CopilotKitProviderInner
         {...innerProps}
         runtimeUrl={runtimeUrl}
         onError={onError}
-        headers={headers}
+        headers={headers ?? EMPTY_HEADERS}
       >
         {children}
       </CopilotKitProviderInner>

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -27,7 +27,7 @@ import type {
   DebugConfig,
   RuntimeLicenseStatus,
 } from "@copilotkit/shared";
-import type { CopilotKitCoreErrorCode } from "@copilotkit/core";
+import { CopilotKitCoreErrorCode } from "@copilotkit/core";
 import {
   MCPAppsActivityContentSchema,
   MCPAppsActivityRenderer,
@@ -58,6 +58,9 @@ import type { SandboxFunction } from "../types/sandbox-function";
 import { SandboxFunctionsContext } from "./SandboxFunctionsContext";
 import { schemaToJsonSchema } from "@copilotkit/shared";
 import { zodToJsonSchema } from "zod-to-json-schema";
+import type { MaybePromise } from "@copilotkit/shared";
+import { useHeaderSource } from "./use-header-source";
+import { ResolvedHeadersProvider } from "./ResolvedHeadersContext";
 
 // Adapts zod-to-json-schema's zod-specific signature to the injectable
 // `zodToJsonSchema` contract of `schemaToJsonSchema`, which only invokes it
@@ -114,7 +117,9 @@ const GENERATE_SANDBOXED_UI_DESCRIPTION =
 export interface CopilotKitProviderProps {
   children: ReactNode;
   runtimeUrl?: string;
-  headers?: Record<string, string> | (() => Record<string, string>);
+  headers?:
+    | Record<string, string>
+    | (() => MaybePromise<Record<string, string>>);
   /**
    * Credentials mode for fetch requests (e.g., "include" for HTTP-only cookies in cross-origin requests).
    */
@@ -268,7 +273,11 @@ function useStableArrayProp<T>(
 }
 
 // Provider component
-export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
+const CopilotKitProviderInner: React.FC<
+  Omit<CopilotKitProviderProps, "headers"> & {
+    headers?: Record<string, string>;
+  }
+> = ({
   children,
   runtimeUrl,
   headers: headersProp = EMPTY_HEADERS,
@@ -456,8 +465,7 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   }, [hasSelfManagedAgents, resolvedPublicKey]);
 
   // Resolve headers from function or static object
-  const headers =
-    typeof headersProp === "function" ? headersProp() : headersProp;
+  const headers = headersProp;
 
   // Merge a provided publicApiKey into headers (without overwriting an explicit header).
   const mergedHeaders = useMemo(() => {
@@ -942,6 +950,44 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
         </LicenseContext.Provider>
       </CopilotKitContext.Provider>
     </SandboxFunctionsContext.Provider>
+  );
+};
+
+export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = (
+  props,
+) => {
+  const {
+    headers: source = EMPTY_HEADERS,
+    onError,
+    runtimeUrl,
+    children,
+    ...innerProps
+  } = props;
+  const { headers, error } = useHeaderSource(source);
+  const reportedError = useRef<Error | null>(null);
+
+  useEffect(() => {
+    if (!error || reportedError.current === error) return;
+    reportedError.current = error;
+    onError?.({
+      error,
+      code: CopilotKitCoreErrorCode.HEADER_RESOLUTION_FAILED,
+      context: { source: "headers", runtimeUrl },
+    });
+  }, [error, onError, runtimeUrl]);
+
+  if (!headers) return null;
+  return (
+    <ResolvedHeadersProvider value={headers}>
+      <CopilotKitProviderInner
+        {...innerProps}
+        runtimeUrl={runtimeUrl}
+        onError={onError}
+        headers={headers}
+      >
+        {children}
+      </CopilotKitProviderInner>
+    </ResolvedHeadersProvider>
   );
 };
 

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -791,6 +791,7 @@ const CopilotKitProviderInner: React.FC<
 
   useEffect(() => {
     copilotkit.setRuntimeUrl(chatApiEndpoint);
+    headerReadiness?.updateRuntimeUrl(chatApiEndpoint);
     copilotkit.setRuntimeTransport(
       useSingleEndpoint === true
         ? "single"
@@ -987,6 +988,11 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = (
     else if (status === "failed") barrier.failed(error);
     else barrier.pending();
   }, [barrier, error, headers, status]);
+  useEffect(
+    () => () =>
+      barrier.dispose(new Error("Header resolution ended before completion")),
+    [barrier],
+  );
   const reportedError = useRef<{
     source: typeof source;
     error: Error;

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -964,17 +964,26 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = (
     ...innerProps
   } = props;
   const { headers, error } = useHeaderSource(source);
-  const reportedError = useRef<Error | null>(null);
+  const reportedError = useRef<{
+    source: typeof source;
+    error: Error;
+  } | null>(null);
 
   useEffect(() => {
-    if (!error || reportedError.current === error) return;
-    reportedError.current = error;
+    if (
+      !error ||
+      (reportedError.current?.source === source &&
+        reportedError.current.error === error)
+    ) {
+      return;
+    }
+    reportedError.current = { source, error };
     onError?.({
       error,
       code: CopilotKitCoreErrorCode.HEADER_RESOLUTION_FAILED,
       context: { source: "headers", runtimeUrl },
     });
-  }, [error, onError, runtimeUrl]);
+  }, [error, onError, runtimeUrl, source]);
 
   if (!headers) return null;
   return (

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -801,6 +801,7 @@ const CopilotKitProviderInner: React.FC<
     withProviderHeaderSync(copilotkit, () =>
       copilotkit.setHeaders(mergedHeaders),
     );
+    headerReadiness?.update(copilotkit.headers);
     copilotkit.setCredentials(credentials);
     // Forward a per-run signal when the provider has an A2UI catalog so the
     // runtime can turn A2UI on (and inject the render tool) without a separate

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -978,11 +978,20 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = (
       return;
     }
     reportedError.current = { source, error };
-    onError?.({
+    const event = {
       error,
       code: CopilotKitCoreErrorCode.HEADER_RESOLUTION_FAILED,
       context: { source: "headers", runtimeUrl },
-    });
+    };
+    if (onError) {
+      onError(event);
+    } else {
+      console.error(
+        `[CopilotKit] Error (${event.code}):`,
+        event.error,
+        event.context,
+      );
+    }
   }, [error, onError, runtimeUrl, source]);
 
   if (!headers) return null;

--- a/packages/react-core/src/v2/providers/ResolvedHeadersContext.ts
+++ b/packages/react-core/src/v2/providers/ResolvedHeadersContext.ts
@@ -1,0 +1,20 @@
+import { createContext, createElement, useContext } from "react";
+import type { ReactNode } from "react";
+
+export type ResolvedHeaderRecord = Record<string, string>;
+
+const ResolvedHeadersContext = createContext<ResolvedHeaderRecord | null>(null);
+
+export function ResolvedHeadersProvider({
+  value,
+  children,
+}: {
+  value: ResolvedHeaderRecord;
+  children: ReactNode;
+}) {
+  return createElement(ResolvedHeadersContext.Provider, { value }, children);
+}
+
+export function useResolvedHeaderRecord(): ResolvedHeaderRecord | null {
+  return useContext(ResolvedHeadersContext);
+}

--- a/packages/react-core/src/v2/providers/ResolvedHeadersContext.ts
+++ b/packages/react-core/src/v2/providers/ResolvedHeadersContext.ts
@@ -1,20 +1,36 @@
 import { createContext, createElement, useContext } from "react";
 import type { ReactNode } from "react";
+import type { HeaderReadiness } from "./header-readiness";
 
 export type ResolvedHeaderRecord = Record<string, string>;
 
-const ResolvedHeadersContext = createContext<ResolvedHeaderRecord | null>(null);
+type ResolvedHeadersValue = {
+  headers: ResolvedHeaderRecord;
+  barrier: HeaderReadiness;
+};
+
+const ResolvedHeadersContext = createContext<ResolvedHeadersValue | null>(null);
 
 export function ResolvedHeadersProvider({
   value,
+  barrier,
   children,
 }: {
   value: ResolvedHeaderRecord;
+  barrier: HeaderReadiness;
   children: ReactNode;
 }) {
-  return createElement(ResolvedHeadersContext.Provider, { value }, children);
+  return createElement(
+    ResolvedHeadersContext.Provider,
+    { value: { headers: value, barrier } },
+    children,
+  );
 }
 
 export function useResolvedHeaderRecord(): ResolvedHeaderRecord | null {
-  return useContext(ResolvedHeadersContext);
+  return useContext(ResolvedHeadersContext)?.headers ?? null;
+}
+
+export function useHeaderReadiness(): HeaderReadiness | null {
+  return useContext(ResolvedHeadersContext)?.barrier ?? null;
 }

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.asyncHeaders.production.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.asyncHeaders.production.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CopilotKitProvider } from "../CopilotKitProvider";
+
+describe("CopilotKitProvider async header production anchor", () => {
+  it("holds the first request until the async header is settled", async () => {
+    let release!: (value: Record<string, string>) => void;
+    const source = () =>
+      new Promise<Record<string, string>>((resolve) => (release = resolve));
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: "1", agents: {} }), {
+        status: 200,
+      }),
+    );
+
+    render(
+      <CopilotKitProvider runtimeUrl="https://runtime.example" headers={source}>
+        <div>child</div>
+      </CopilotKitProvider>,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    release({ Authorization: "Bearer resolved" });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(
+      new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("Authorization"),
+    ).toBe("Bearer resolved");
+    console.log(
+      `pre-settle requests: 0; first request Authorization: ${new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("Authorization")}`,
+    );
+    fetchMock.mockRestore();
+  });
+});

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.asyncHeaders.production.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.asyncHeaders.production.test.tsx
@@ -25,9 +25,6 @@ describe("CopilotKitProvider async header production anchor", () => {
     expect(
       new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("Authorization"),
     ).toBe("Bearer resolved");
-    console.log(
-      `pre-settle requests: 0; first request Authorization: ${new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("Authorization")}`,
-    );
     fetchMock.mockRestore();
   });
 });

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.asyncHeaders.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.asyncHeaders.test.tsx
@@ -48,4 +48,26 @@ describe("CopilotKitProvider async headers", () => {
       context: { source: "headers", runtimeUrl: "https://runtime.example" },
     });
   });
+
+  it("keeps core nullish-value normalization for static records", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: "1", agents: {} }), {
+        status: 200,
+      }),
+    );
+    render(
+      <CopilotKitProvider
+        runtimeUrl="https://runtime.example"
+        headers={
+          { Authorization: undefined } as unknown as Record<string, string>
+        }
+      >
+        <div>child</div>
+      </CopilotKitProvider>,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const requestHeaders = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+    expect(requestHeaders.has("Authorization")).toBe(false);
+    fetchMock.mockRestore();
+  });
 });

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.asyncHeaders.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.asyncHeaders.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { CopilotKitProvider } from "../CopilotKitProvider";
+import { CopilotKitProvider, useCopilotKit } from "../CopilotKitProvider";
 import { CopilotKitCoreErrorCode } from "@copilotkit/core";
 
 describe("CopilotKitProvider async headers", () => {
@@ -88,6 +88,71 @@ describe("CopilotKitProvider async headers", () => {
     expect(
       new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("Authorization"),
     ).toBe("Bearer recovered");
+    view.unmount();
+    fetchMock.mockRestore();
+  });
+
+  it("waits for an async retry after an initial failure", async () => {
+    const initial = new Error("token unavailable");
+    let release!: (value: Record<string, string>) => void;
+    let source: () => Promise<Record<string, string>> = () =>
+      Promise.reject(initial);
+    const onError = vi.fn();
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: "1", agents: {} }), {
+        status: 200,
+      }),
+    );
+    const view = render(
+      <CopilotKitProvider
+        runtimeUrl="https://runtime.example"
+        headers={source}
+        onError={onError}
+      >
+        <div>child</div>
+      </CopilotKitProvider>,
+    );
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+    source = () =>
+      new Promise<Record<string, string>>((resolve) => (release = resolve));
+    view.rerender(
+      <CopilotKitProvider
+        runtimeUrl="https://runtime.example"
+        headers={source}
+        onError={onError}
+      >
+        <div>child</div>
+      </CopilotKitProvider>,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    release({ Authorization: "Bearer retried" });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    view.unmount();
+    fetchMock.mockRestore();
+  });
+
+  it("releases the initial barrier when setHeaders supplies concrete headers", async () => {
+    let core: ReturnType<typeof useCopilotKit> | undefined;
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: "1", agents: {} }), {
+        status: 200,
+      }),
+    );
+    const Child = () => {
+      core = useCopilotKit();
+      return <div>child</div>;
+    };
+    const view = render(
+      <CopilotKitProvider
+        runtimeUrl="https://runtime.example"
+        headers={() => new Promise<Record<string, string>>(() => {})}
+      >
+        <Child />
+      </CopilotKitProvider>,
+    );
+    await waitFor(() => expect(core?.copilotkit).toBeDefined());
+    core!.copilotkit!.setHeaders({ Authorization: "Bearer manual" });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     view.unmount();
     fetchMock.mockRestore();
   });

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.asyncHeaders.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.asyncHeaders.test.tsx
@@ -19,7 +19,7 @@ describe("CopilotKitProvider async headers", () => {
         <div>child</div>
       </CopilotKitProvider>,
     );
-    expect(queryByText("child")).toBeNull();
+    expect(queryByText("child")).not.toBeNull();
     expect(fetchMock).not.toHaveBeenCalled();
     release({ Authorization: "Bearer resolved" });
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
@@ -32,7 +32,7 @@ describe("CopilotKitProvider async headers", () => {
   it("reports the original initial resolution error", async () => {
     const original = new Error("token unavailable");
     const onError = vi.fn();
-    render(
+    const view = render(
       <CopilotKitProvider
         runtimeUrl="https://runtime.example"
         headers={() => Promise.reject(original)}
@@ -42,11 +42,54 @@ describe("CopilotKitProvider async headers", () => {
       </CopilotKitProvider>,
     );
     await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+    expect(view.queryByText("child")).not.toBeNull();
     expect(onError.mock.calls[0]?.[0]).toMatchObject({
       code: CopilotKitCoreErrorCode.HEADER_RESOLUTION_FAILED,
       error: original,
       context: { source: "headers", runtimeUrl: "https://runtime.example" },
     });
+  });
+
+  it("reconnects after an initial failure is replaced by a synchronous record", async () => {
+    const original = new Error("token unavailable");
+    const onError = vi.fn();
+    let source:
+      | Record<string, string>
+      | (() => Promise<Record<string, string>>) = () =>
+      Promise.reject(original);
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: "1", agents: {} }), {
+        status: 200,
+      }),
+    );
+    const view = render(
+      <CopilotKitProvider
+        runtimeUrl="https://runtime.example"
+        headers={source}
+        onError={onError}
+      >
+        <div>child</div>
+      </CopilotKitProvider>,
+    );
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    source = { Authorization: "Bearer recovered" };
+    view.rerender(
+      <CopilotKitProvider
+        runtimeUrl="https://runtime.example"
+        headers={source}
+        onError={onError}
+      >
+        <div>child</div>
+      </CopilotKitProvider>,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(
+      new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("Authorization"),
+    ).toBe("Bearer recovered");
+    view.unmount();
+    fetchMock.mockRestore();
   });
 
   it("keeps core nullish-value normalization for static records", async () => {

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.asyncHeaders.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.asyncHeaders.test.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CopilotKitProvider } from "../CopilotKitProvider";
+import { CopilotKitCoreErrorCode } from "@copilotkit/core";
+
+describe("CopilotKitProvider async headers", () => {
+  it("waits for the first concrete record before requesting /info", async () => {
+    let release!: (value: Record<string, string>) => void;
+    const source = () =>
+      new Promise<Record<string, string>>((resolve) => (release = resolve));
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ version: "1", agents: {} }), {
+        status: 200,
+      }),
+    );
+    const { queryByText } = render(
+      <CopilotKitProvider runtimeUrl="https://runtime.example" headers={source}>
+        <div>child</div>
+      </CopilotKitProvider>,
+    );
+    expect(queryByText("child")).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+    release({ Authorization: "Bearer resolved" });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect((fetchMock.mock.calls[0]?.[1] as RequestInit).headers).toEqual(
+      expect.objectContaining({ Authorization: "Bearer resolved" }),
+    );
+    fetchMock.mockRestore();
+  });
+
+  it("reports the original initial resolution error", async () => {
+    const original = new Error("token unavailable");
+    const onError = vi.fn();
+    render(
+      <CopilotKitProvider
+        runtimeUrl="https://runtime.example"
+        headers={() => Promise.reject(original)}
+        onError={onError}
+      >
+        <div>child</div>
+      </CopilotKitProvider>,
+    );
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({
+      code: CopilotKitCoreErrorCode.HEADER_RESOLUTION_FAILED,
+      error: original,
+      context: { source: "headers", runtimeUrl: "https://runtime.example" },
+    });
+  });
+});

--- a/packages/react-core/src/v2/providers/__tests__/header-readiness.test.ts
+++ b/packages/react-core/src/v2/providers/__tests__/header-readiness.test.ts
@@ -53,4 +53,12 @@ describe("HeaderReadinessBarrier", () => {
       Authorization: "Bearer refreshed",
     });
   });
+
+  it("rejects pending waiters when the provider is disposed", async () => {
+    const barrier = new HeaderReadinessBarrier();
+    const pending = barrier.wait();
+    const reason = new Error("provider unmounted");
+    barrier.dispose(reason);
+    await expect(pending).rejects.toBe(reason);
+  });
 });

--- a/packages/react-core/src/v2/providers/__tests__/header-readiness.test.ts
+++ b/packages/react-core/src/v2/providers/__tests__/header-readiness.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { HeaderReadinessBarrier } from "../header-readiness";
+
+describe("HeaderReadinessBarrier", () => {
+  it("releases pending callers when headers become ready", async () => {
+    const barrier = new HeaderReadinessBarrier();
+    let settled = false;
+    const pending = barrier.wait().then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    barrier.ready();
+    await pending;
+    expect(settled).toBe(true);
+  });
+
+  it("rejects pending callers with the original initial failure", async () => {
+    const barrier = new HeaderReadinessBarrier();
+    const original = new Error("token unavailable");
+    const pending = barrier.wait();
+    barrier.failed(original);
+    await expect(pending).rejects.toBe(original);
+    await expect(barrier.wait()).rejects.toBe(original);
+  });
+
+  it("reopens after a failed source is replaced", async () => {
+    const barrier = new HeaderReadinessBarrier();
+    barrier.failed(new Error("expired"));
+    barrier.pending();
+    const pending = barrier.waitForRecovery();
+    barrier.ready();
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it("publishes the latest concrete headers with readiness", () => {
+    const barrier = new HeaderReadinessBarrier();
+    const headers = { Authorization: "Bearer current" };
+    barrier.ready(headers);
+    expect(barrier.currentHeaders()).toBe(headers);
+  });
+});

--- a/packages/react-core/src/v2/providers/__tests__/header-readiness.test.ts
+++ b/packages/react-core/src/v2/providers/__tests__/header-readiness.test.ts
@@ -40,4 +40,17 @@ describe("HeaderReadinessBarrier", () => {
     barrier.ready(headers);
     expect(barrier.currentHeaders()).toBe(headers);
   });
+
+  it("reopens a settled barrier for a later failure and recovery", async () => {
+    const barrier = new HeaderReadinessBarrier();
+    barrier.ready({ Authorization: "Bearer current" });
+    barrier.failed(new Error("refresh failed"));
+    barrier.pending();
+    const pending = barrier.wait();
+    barrier.ready({ Authorization: "Bearer refreshed" });
+    await expect(pending).resolves.toBeUndefined();
+    expect(barrier.currentHeaders()).toEqual({
+      Authorization: "Bearer refreshed",
+    });
+  });
 });

--- a/packages/react-core/src/v2/providers/__tests__/use-header-source.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/use-header-source.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook, act } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
 import { useHeaderSource } from "../use-header-source";
 
 function deferred<T>() {
@@ -44,5 +45,71 @@ describe("useHeaderSource", () => {
     await act(async () => rejectRefresh(new Error("expired")));
     expect(result.current.headers).toEqual({ Authorization: "Bearer one" });
     expect(result.current.error?.message).toBe("expired");
+  });
+
+  it("refreshes exactly once when the source identity changes", async () => {
+    const first = deferred<Record<string, string>>();
+    const second = deferred<Record<string, string>>();
+    const firstSource = vi.fn(() => first.promise);
+    let source: () => Promise<Record<string, string>> = firstSource;
+    const { result, rerender } = renderHook(() => useHeaderSource(source));
+
+    expect(firstSource).toHaveBeenCalledTimes(1);
+    await act(async () => first.resolve({ Authorization: "Bearer one" }));
+    const replacement = () => second.promise;
+    source = replacement;
+    rerender();
+    rerender();
+    expect(firstSource).toHaveBeenCalledTimes(1);
+    expect(result.current.headers).toEqual({ Authorization: "Bearer one" });
+    await act(async () => second.resolve({ Authorization: "Bearer two" }));
+    expect(result.current.headers).toEqual({ Authorization: "Bearer two" });
+  });
+
+  it("ignores a stale result after a source replacement", async () => {
+    const first = deferred<Record<string, string>>();
+    const second = deferred<Record<string, string>>();
+    let source = () => first.promise;
+    const { result, rerender } = renderHook(() => useHeaderSource(source));
+    await act(async () => {
+      source = () => second.promise;
+      rerender();
+      second.resolve({ Authorization: "Bearer current" });
+      first.resolve({ Authorization: "Bearer stale" });
+    });
+    expect(result.current.headers).toEqual({ Authorization: "Bearer current" });
+  });
+
+  it("does not publish a pending result after unmount", async () => {
+    const pending = deferred<Record<string, string>>();
+    const { unmount } = renderHook(() =>
+      useHeaderSource(() => pending.promise),
+    );
+    unmount();
+    await act(async () => pending.resolve({ Authorization: "Bearer late" }));
+  });
+
+  it("keeps synchronous sources on the synchronous path", () => {
+    let calls = 0;
+    const source = () => {
+      calls += 1;
+      return { Authorization: `Bearer ${calls}` };
+    };
+    const { result, rerender } = renderHook(() => useHeaderSource(source));
+    rerender();
+    expect(calls).toBe(2);
+    expect(result.current.headers).toEqual({ Authorization: "Bearer 2" });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("does not duplicate a stable async evaluation in StrictMode", () => {
+    const pending = deferred<Record<string, string>>();
+    const source = vi.fn(() => pending.promise);
+    renderHook(() => useHeaderSource(source), {
+      wrapper: ({ children }) => (
+        <React.StrictMode>{children}</React.StrictMode>
+      ),
+    });
+    expect(source).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-core/src/v2/providers/__tests__/use-header-source.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/use-header-source.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useHeaderSource } from "../use-header-source";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("useHeaderSource", () => {
+  it("invokes a stable async source once across unrelated rerenders", async () => {
+    const pending = deferred<Record<string, string>>();
+    let calls = 0;
+    const source = () => {
+      calls += 1;
+      return pending.promise;
+    };
+    const { result, rerender } = renderHook(() => useHeaderSource(source));
+    for (let i = 0; i < 20; i += 1) rerender();
+    expect(calls).toBe(1);
+    expect(result.current.headers).toBeNull();
+    await act(async () => pending.resolve({ Authorization: "Bearer one" }));
+    expect(result.current.headers).toEqual({ Authorization: "Bearer one" });
+  });
+
+  it("retains the last good record when a refresh rejects", async () => {
+    const first: Promise<Record<string, string>> = Promise.resolve({
+      Authorization: "Bearer one",
+    });
+    let rejectRefresh!: (error: Error) => void;
+    const refresh = new Promise<Record<string, string>>((_, reject) => {
+      rejectRefresh = reject;
+    });
+    let source = () => first;
+    const { result, rerender } = renderHook(() => useHeaderSource(source));
+    await act(async () => first);
+    source = () => refresh;
+    rerender();
+    await act(async () => rejectRefresh(new Error("expired")));
+    expect(result.current.headers).toEqual({ Authorization: "Bearer one" });
+    expect(result.current.error?.message).toBe("expired");
+  });
+});

--- a/packages/react-core/src/v2/providers/__tests__/use-header-source.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/use-header-source.test.tsx
@@ -24,7 +24,7 @@ describe("useHeaderSource", () => {
     const { result, rerender } = renderHook(() => useHeaderSource(source));
     for (let i = 0; i < 20; i += 1) rerender();
     expect(calls).toBe(1);
-    expect(result.current.headers).toBeNull();
+    expect(result.current.headers).toEqual({});
     await act(async () => pending.resolve({ Authorization: "Bearer one" }));
     expect(result.current.headers).toEqual({ Authorization: "Bearer one" });
   });
@@ -37,7 +37,7 @@ describe("useHeaderSource", () => {
     const refresh = new Promise<Record<string, string>>((_, reject) => {
       rejectRefresh = reject;
     });
-    let source = () => first;
+    let source: () => Promise<Record<string, string>> = () => first;
     const { result, rerender } = renderHook(() => useHeaderSource(source));
     await act(async () => first);
     source = () => refresh;
@@ -66,6 +66,20 @@ describe("useHeaderSource", () => {
     expect(result.current.headers).toEqual({ Authorization: "Bearer two" });
   });
 
+  it("treats a settled function identity change as a refresh signal", async () => {
+    const first = Promise.resolve({ Authorization: "Bearer one" });
+    const second = deferred<Record<string, string>>();
+    let source: () => Promise<Record<string, string>> = () => first;
+    const { result, rerender } = renderHook(() => useHeaderSource(source));
+    await act(async () => first);
+
+    source = () => second.promise;
+    rerender();
+    expect(result.current.headers).toEqual({ Authorization: "Bearer one" });
+    await act(async () => second.resolve({ Authorization: "Bearer two" }));
+    expect(result.current.headers).toEqual({ Authorization: "Bearer two" });
+  });
+
   it("ignores a stale result after a source replacement", async () => {
     const first = deferred<Record<string, string>>();
     const second = deferred<Record<string, string>>();
@@ -87,7 +101,7 @@ describe("useHeaderSource", () => {
     );
     unmount();
     await act(async () => pending.resolve({ Authorization: "Bearer late" }));
-    expect(result.current.headers).toBeNull();
+    expect(result.current.headers).toEqual({});
     expect(result.current.error).toBeNull();
   });
 
@@ -113,6 +127,41 @@ describe("useHeaderSource", () => {
     expect(calls).toBe(2);
     expect(result.current.headers).toEqual({ Authorization: "Bearer 2" });
     expect(result.current.error).toBeNull();
+  });
+
+  it("reuses the canonical object for equal synchronous values", () => {
+    const source = () => ({ Authorization: "Bearer stable" });
+    const { result, rerender } = renderHook(() => useHeaderSource(source));
+    const first = result.current.headers;
+    rerender();
+    expect(result.current.headers).toBe(first);
+  });
+
+  it("keeps pending work when a source changes before settlement", async () => {
+    const first = deferred<Record<string, string>>();
+    const second = vi.fn(() => Promise.resolve({ Authorization: "second" }));
+    let source = () => first.promise;
+    const { result, rerender } = renderHook(() => useHeaderSource(source));
+
+    source = second;
+    rerender();
+    expect(second).not.toHaveBeenCalled();
+    await act(async () => first.resolve({ Authorization: "first" }));
+    expect(result.current.headers).toEqual({ Authorization: "second" });
+  });
+
+  it("warns once when pending async work is replaced by rerenders", () => {
+    const pending = deferred<Record<string, string>>();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let source = () => pending.promise;
+    const { rerender } = renderHook(() => useHeaderSource(source));
+    source = () => pending.promise;
+    rerender();
+    source = () => pending.promise;
+    rerender();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).not.toContain("Authorization");
+    warn.mockRestore();
   });
 
   it("does not duplicate a stable async evaluation in StrictMode", () => {

--- a/packages/react-core/src/v2/providers/__tests__/use-header-source.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/use-header-source.test.tsx
@@ -82,11 +82,24 @@ describe("useHeaderSource", () => {
 
   it("does not publish a pending result after unmount", async () => {
     const pending = deferred<Record<string, string>>();
-    const { unmount } = renderHook(() =>
+    const { result, unmount } = renderHook(() =>
       useHeaderSource(() => pending.promise),
     );
     unmount();
     await act(async () => pending.resolve({ Authorization: "Bearer late" }));
+    expect(result.current.headers).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("normalizes nullish values before publishing a settled record", async () => {
+    const { result } = renderHook(() =>
+      useHeaderSource((() =>
+        Promise.resolve({
+          Authorization: undefined,
+        })) as unknown as () => Promise<Record<string, string>>),
+    );
+    await act(async () => undefined);
+    expect(result.current.headers).toEqual({});
   });
 
   it("keeps synchronous sources on the synchronous path", () => {

--- a/packages/react-core/src/v2/providers/header-readiness.ts
+++ b/packages/react-core/src/v2/providers/header-readiness.ts
@@ -8,16 +8,25 @@ export interface HeaderReadiness {
   wait(): Promise<void>;
   waitForRecovery(): Promise<void>;
   currentHeaders(): HeaderRecord;
+  currentRuntimeUrl(): string | undefined;
   update(headers: HeaderRecord): void;
+  updateRuntimeUrl(runtimeUrl: string | undefined): void;
   pending(): void;
   ready(headers?: HeaderRecord): void;
+  recover(headers?: HeaderRecord): void;
   failed(error: unknown): void;
+  dispose(error: unknown): void;
 }
 
 export class HeaderReadinessBarrier implements HeaderReadiness {
   state: HeaderReadinessState = "pending";
   private headers: HeaderRecord = Object.freeze({}) as HeaderRecord;
   private hasCurrentHeaders = false;
+  private runtimeUrl: string | undefined;
+  private failure: unknown;
+  private ignoredFailure: unknown;
+  private manualRecovery = false;
+  private disposed = false;
   private deferred = this.createDeferred();
   private recovery = this.createDeferred();
 
@@ -37,35 +46,76 @@ export class HeaderReadinessBarrier implements HeaderReadiness {
     return this.headers;
   }
 
+  currentRuntimeUrl(): string | undefined {
+    return this.runtimeUrl;
+  }
+
   update(headers: HeaderRecord): void {
     this.headers = headers;
     this.hasCurrentHeaders = true;
   }
 
+  updateRuntimeUrl(runtimeUrl: string | undefined): void {
+    this.runtimeUrl = runtimeUrl;
+  }
+
   pending(): void {
+    if (this.disposed) return;
+    if (this.manualRecovery) return;
     if (this.state === "pending") return;
     this.state = "pending";
+    this.failure = undefined;
+    this.manualRecovery = false;
     this.deferred = this.createDeferred();
   }
 
   ready(headers?: HeaderRecord): void {
+    if (this.disposed) return;
     if (headers !== undefined && !this.hasCurrentHeaders) {
       this.headers = headers;
     }
+    this.ignoredFailure = undefined;
+    this.failure = undefined;
+    this.manualRecovery = false;
     if (this.state === "ready") return;
     this.state = "ready";
     this.deferred.resolve();
     this.recovery.resolve();
   }
 
+  recover(headers?: HeaderRecord): void {
+    if (headers !== undefined) this.update(headers);
+    const failure = this.failure;
+    this.manualRecovery = true;
+    this.ready();
+    this.manualRecovery = true;
+    this.ignoredFailure = failure;
+  }
+
   failed(error: unknown): void {
+    if (this.disposed || this.ignoredFailure === error) return;
+    this.manualRecovery = false;
     if (this.state === "ready") {
       this.deferred = this.createDeferred();
       this.recovery = this.createDeferred();
+    } else if (this.state === "failed" && this.failure !== error) {
+      this.deferred = this.createDeferred();
     }
     this.state = "failed";
+    this.failure = error;
     this.deferred.reject(error);
     this.deferred.promise.catch(() => {});
+  }
+
+  dispose(error: unknown): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.state = "failed";
+    this.failure = error;
+    this.deferred.reject(error);
+    this.recovery.reject(error);
+    this.deferred.promise.catch(() => {});
+    this.recovery.promise.catch(() => {});
   }
 
   private createDeferred(): {
@@ -126,4 +176,10 @@ export function headerReadinessHeadersFor(
   value: object,
 ): Record<string, string> | undefined {
   return headerReadinessFor(value)?.currentHeaders();
+}
+
+export function headerReadinessRuntimeUrlFor(
+  value: object,
+): string | undefined {
+  return headerReadinessFor(value)?.currentRuntimeUrl();
 }

--- a/packages/react-core/src/v2/providers/header-readiness.ts
+++ b/packages/react-core/src/v2/providers/header-readiness.ts
@@ -8,6 +8,7 @@ export interface HeaderReadiness {
   wait(): Promise<void>;
   waitForRecovery(): Promise<void>;
   currentHeaders(): HeaderRecord;
+  update(headers: HeaderRecord): void;
   pending(): void;
   ready(headers?: HeaderRecord): void;
   failed(error: unknown): void;
@@ -16,6 +17,7 @@ export interface HeaderReadiness {
 export class HeaderReadinessBarrier implements HeaderReadiness {
   state: HeaderReadinessState = "pending";
   private headers: HeaderRecord = Object.freeze({}) as HeaderRecord;
+  private hasCurrentHeaders = false;
   private deferred = this.createDeferred();
   private recovery = this.createDeferred();
 
@@ -35,6 +37,11 @@ export class HeaderReadinessBarrier implements HeaderReadiness {
     return this.headers;
   }
 
+  update(headers: HeaderRecord): void {
+    this.headers = headers;
+    this.hasCurrentHeaders = true;
+  }
+
   pending(): void {
     if (this.state === "pending") return;
     this.state = "pending";
@@ -42,7 +49,9 @@ export class HeaderReadinessBarrier implements HeaderReadiness {
   }
 
   ready(headers?: HeaderRecord): void {
-    if (headers !== undefined) this.headers = headers;
+    if (headers !== undefined && !this.hasCurrentHeaders) {
+      this.headers = headers;
+    }
     if (this.state === "ready") return;
     this.state = "ready";
     this.deferred.resolve();
@@ -50,6 +59,10 @@ export class HeaderReadinessBarrier implements HeaderReadiness {
   }
 
   failed(error: unknown): void {
+    if (this.state === "ready") {
+      this.deferred = this.createDeferred();
+      this.recovery = this.createDeferred();
+    }
     this.state = "failed";
     this.deferred.reject(error);
     this.deferred.promise.catch(() => {});

--- a/packages/react-core/src/v2/providers/header-readiness.ts
+++ b/packages/react-core/src/v2/providers/header-readiness.ts
@@ -1,0 +1,116 @@
+import type { CopilotKitCoreReact } from "../lib/react-core";
+
+export type HeaderReadinessState = "pending" | "ready" | "failed";
+type HeaderRecord = Record<string, string>;
+
+export interface HeaderReadiness {
+  state: HeaderReadinessState;
+  wait(): Promise<void>;
+  waitForRecovery(): Promise<void>;
+  currentHeaders(): HeaderRecord;
+  pending(): void;
+  ready(headers?: HeaderRecord): void;
+  failed(error: unknown): void;
+}
+
+export class HeaderReadinessBarrier implements HeaderReadiness {
+  state: HeaderReadinessState = "pending";
+  private headers: HeaderRecord = Object.freeze({}) as HeaderRecord;
+  private deferred = this.createDeferred();
+  private recovery = this.createDeferred();
+
+  wait(): Promise<void> {
+    return this.state === "ready"
+      ? Promise.resolve()
+      : this.state === "failed"
+        ? this.deferred.promise
+        : this.deferred.promise;
+  }
+
+  waitForRecovery(): Promise<void> {
+    return this.recovery.promise;
+  }
+
+  currentHeaders(): HeaderRecord {
+    return this.headers;
+  }
+
+  pending(): void {
+    if (this.state === "pending") return;
+    this.state = "pending";
+    this.deferred = this.createDeferred();
+  }
+
+  ready(headers?: HeaderRecord): void {
+    if (headers !== undefined) this.headers = headers;
+    if (this.state === "ready") return;
+    this.state = "ready";
+    this.deferred.resolve();
+    this.recovery.resolve();
+  }
+
+  failed(error: unknown): void {
+    this.state = "failed";
+    this.deferred.reject(error);
+    this.deferred.promise.catch(() => {});
+  }
+
+  private createDeferred(): {
+    promise: Promise<void>;
+    resolve: () => void;
+    reject: (error: unknown) => void;
+  } {
+    let resolve!: () => void;
+    let reject!: (error: unknown) => void;
+    const promise = new Promise<void>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
+}
+
+const coreBarriers = new WeakMap<object, HeaderReadiness>();
+const configBarriers = new WeakMap<object, HeaderReadiness>();
+const providerHeaderSync = new WeakSet<object>();
+
+export function bindHeaderReadiness(
+  core: CopilotKitCoreReact,
+  barrier: HeaderReadiness,
+): void {
+  coreBarriers.set(core, barrier);
+}
+
+export function headerReadinessFor(value: object): HeaderReadiness | undefined {
+  return coreBarriers.get(value) ?? configBarriers.get(value);
+}
+
+export function bindConfigHeaderReadiness(
+  config: object,
+  barrier: HeaderReadiness,
+): void {
+  configBarriers.set(config, barrier);
+}
+
+export function withProviderHeaderSync<T>(core: object, fn: () => T): T {
+  providerHeaderSync.add(core);
+  try {
+    return fn();
+  } finally {
+    providerHeaderSync.delete(core);
+  }
+}
+
+export function isProviderHeaderSync(core: object): boolean {
+  return providerHeaderSync.has(core);
+}
+
+export async function waitForHeaderReadiness(value: object): Promise<void> {
+  await headerReadinessFor(value)?.wait();
+}
+
+export function headerReadinessHeadersFor(
+  value: object,
+): Record<string, string> | undefined {
+  return headerReadinessFor(value)?.currentHeaders();
+}

--- a/packages/react-core/src/v2/providers/header-readiness.ts
+++ b/packages/react-core/src/v2/providers/header-readiness.ts
@@ -134,6 +134,7 @@ export class HeaderReadinessBarrier implements HeaderReadiness {
 }
 
 const coreBarriers = new WeakMap<object, HeaderReadiness>();
+const barrierCores = new WeakMap<object, CopilotKitCoreReact>();
 const configBarriers = new WeakMap<object, HeaderReadiness>();
 const providerHeaderSync = new WeakSet<object>();
 
@@ -142,6 +143,7 @@ export function bindHeaderReadiness(
   barrier: HeaderReadiness,
 ): void {
   coreBarriers.set(core, barrier);
+  barrierCores.set(barrier, core);
 }
 
 export function headerReadinessFor(value: object): HeaderReadiness | undefined {
@@ -182,4 +184,8 @@ export function headerReadinessRuntimeUrlFor(
   value: object,
 ): string | undefined {
   return headerReadinessFor(value)?.currentRuntimeUrl();
+}
+
+export function applyDeferredHeaderRuntimeUrl(barrier: HeaderReadiness): void {
+  barrierCores.get(barrier)?.syncDeferredRuntimeUrl();
 }

--- a/packages/react-core/src/v2/providers/use-header-source.ts
+++ b/packages/react-core/src/v2/providers/use-header-source.ts
@@ -1,0 +1,132 @@
+import { useEffect, useRef, useState } from "react";
+import type { MaybePromise } from "@copilotkit/shared";
+
+export type HeaderRecord = Record<string, string>;
+export type HeaderSource = HeaderRecord | (() => MaybePromise<HeaderRecord>);
+
+type Evaluation =
+  | { kind: "sync"; value: HeaderRecord }
+  | { kind: "async"; value: PromiseLike<HeaderRecord> }
+  | { kind: "error"; error: Error };
+
+const EMPTY: HeaderRecord = Object.freeze({}) as HeaderRecord;
+
+function isRecord(value: unknown): value is HeaderRecord {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.values(value).every((entry) => typeof entry === "string")
+  );
+}
+
+function errorFrom(value: unknown): Error {
+  return value instanceof Error ? value : new Error("Header resolution failed");
+}
+
+function evaluate(source: HeaderSource): Evaluation {
+  try {
+    const value = typeof source === "function" ? source() : source;
+    if (
+      (typeof value === "object" && value !== null) ||
+      typeof value === "function"
+    ) {
+      const then = (value as { then?: unknown }).then;
+      if (typeof then === "function") {
+        return { kind: "async", value: value as PromiseLike<HeaderRecord> };
+      }
+    }
+    return isRecord(value)
+      ? { kind: "sync", value }
+      : {
+          kind: "error",
+          error: new Error(
+            "Resolved request headers must be a record of strings",
+          ),
+        };
+  } catch (error) {
+    return { kind: "error", error: errorFrom(error) };
+  }
+}
+
+export function useHeaderSource(source: HeaderSource): {
+  headers: HeaderRecord | null;
+  error: Error | null;
+} {
+  const evaluationRef = useRef<{
+    source: HeaderSource;
+    value: Evaluation;
+  } | null>(null);
+  const previous = evaluationRef.current;
+  const evaluation =
+    previous && previous.source === source && previous.value.kind === "async"
+      ? previous.value
+      : evaluate(source);
+  if (
+    !previous ||
+    previous.source !== source ||
+    previous.value.kind !== "async"
+  ) {
+    evaluationRef.current = { source, value: evaluation };
+  }
+
+  const initial = evaluation.kind === "sync" ? evaluation.value : null;
+  const [state, setState] = useState<{
+    headers: HeaderRecord | null;
+    error: Error | null;
+  }>(() => ({
+    headers: initial,
+    error: evaluation.kind === "error" ? evaluation.error : null,
+  }));
+  const lastGood = useRef(initial ?? EMPTY);
+  const generation = useRef(0);
+
+  useEffect(() => {
+    const current = ++generation.current;
+    if (evaluation.kind === "sync") {
+      lastGood.current = evaluation.value;
+      setState({ headers: evaluation.value, error: null });
+      return;
+    }
+    if (evaluation.kind === "error") {
+      setState({
+        headers: lastGood.current === EMPTY ? null : lastGood.current,
+        error: evaluation.error,
+      });
+      return;
+    }
+    setState((previousState) => ({
+      headers: previousState.headers,
+      error: null,
+    }));
+    Promise.resolve(evaluation.value).then(
+      (headers) => {
+        if (current !== generation.current || !isRecord(headers)) {
+          if (current === generation.current && !isRecord(headers)) {
+            setState({
+              headers: lastGood.current === EMPTY ? null : lastGood.current,
+              error: new Error(
+                "Resolved request headers must be a record of strings",
+              ),
+            });
+          }
+          return;
+        }
+        lastGood.current = headers;
+        setState({ headers, error: null });
+      },
+      (error) => {
+        if (current !== generation.current) return;
+        setState({
+          headers: lastGood.current === EMPTY ? null : lastGood.current,
+          error: errorFrom(error),
+        });
+      },
+    );
+  }, [evaluation]);
+
+  return {
+    headers: evaluation.kind === "sync" ? evaluation.value : state.headers,
+    error: evaluation.kind === "error" ? evaluation.error : state.error,
+  };
+}

--- a/packages/react-core/src/v2/providers/use-header-source.ts
+++ b/packages/react-core/src/v2/providers/use-header-source.ts
@@ -16,7 +16,18 @@ function isRecord(value: unknown): value is HeaderRecord {
     typeof value === "object" &&
     value !== null &&
     !Array.isArray(value) &&
-    Object.values(value).every((entry) => typeof entry === "string")
+    Object.values(value).every(
+      (entry) => entry == null || typeof entry === "string",
+    )
+  );
+}
+
+function sameHeaders(left: HeaderRecord, right: HeaderRecord): boolean {
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every((key) => left[key] === right[key])
   );
 }
 
@@ -41,7 +52,7 @@ function evaluate(source: HeaderSource): Evaluation {
       : {
           kind: "error",
           error: new Error(
-            "Resolved request headers must be a record of strings",
+            "Resolved request headers must be a record of strings, null, or undefined",
           ),
         };
   } catch (error) {
@@ -69,7 +80,16 @@ export function useHeaderSource(source: HeaderSource): {
     previous.source !== source ||
     (previous.value.kind !== "async" && previous.value.kind !== "error")
   ) {
-    evaluationRef.current = { source, value: evaluation };
+    if (
+      previous?.source === source &&
+      previous.value.kind === "sync" &&
+      evaluation.kind === "sync" &&
+      sameHeaders(previous.value.value, evaluation.value)
+    ) {
+      evaluationRef.current = previous;
+    } else {
+      evaluationRef.current = { source, value: evaluation };
+    }
   }
 
   const initial = evaluation.kind === "sync" ? evaluation.value : null;
@@ -109,7 +129,7 @@ export function useHeaderSource(source: HeaderSource): {
             setState({
               headers: lastGood.current === EMPTY ? null : lastGood.current,
               error: new Error(
-                "Resolved request headers must be a record of strings",
+                "Resolved request headers must be a record of strings, null, or undefined",
               ),
             });
           }
@@ -133,7 +153,17 @@ export function useHeaderSource(source: HeaderSource): {
   }, [evaluation]);
 
   return {
-    headers: evaluation.kind === "sync" ? evaluation.value : state.headers,
-    error: evaluation.kind === "error" ? evaluation.error : state.error,
+    headers:
+      evaluation.kind === "sync"
+        ? evaluation.value
+        : lastGood.current === EMPTY
+          ? state.headers
+          : lastGood.current,
+    error:
+      evaluation.kind === "error"
+        ? evaluation.error
+        : evaluation.kind === "sync"
+          ? null
+          : state.error,
   };
 }

--- a/packages/react-core/src/v2/providers/use-header-source.ts
+++ b/packages/react-core/src/v2/providers/use-header-source.ts
@@ -228,8 +228,10 @@ export function useHeaderSource(source: HeaderSource): {
       canonicalEvaluation.kind === "sync"
         ? "ready"
         : canonicalEvaluation.kind === "error"
-          ? "failed"
-          : state.error
+          ? lastGood.current !== EMPTY
+            ? "ready"
+            : "failed"
+          : state.error && previous?.source === source
             ? lastGood.current !== EMPTY
               ? "ready"
               : "failed"

--- a/packages/react-core/src/v2/providers/use-header-source.ts
+++ b/packages/react-core/src/v2/providers/use-header-source.ts
@@ -72,22 +72,28 @@ function evaluate(source: HeaderSource): Evaluation {
 export function useHeaderSource(source: HeaderSource): {
   headers: HeaderRecord | null;
   error: Error | null;
+  status: "pending" | "ready" | "failed";
 } {
   const evaluationRef = useRef<{
     source: HeaderSource;
     value: Evaluation;
+    settled: boolean;
   } | null>(null);
   const previous = evaluationRef.current;
-  const evaluation =
-    previous &&
-    previous.source === source &&
-    (previous.value.kind === "async" || previous.value.kind === "error")
+  const holdPendingEvaluation =
+    previous?.value.kind === "async" && !previous.settled;
+  const evaluation = holdPendingEvaluation
+    ? previous.value
+    : previous &&
+        previous.source === source &&
+        (previous.value.kind === "async" || previous.value.kind === "error")
       ? previous.value
       : evaluate(source);
   if (
-    !previous ||
-    previous.source !== source ||
-    (previous.value.kind !== "async" && previous.value.kind !== "error")
+    !holdPendingEvaluation &&
+    (!previous ||
+      previous.source !== source ||
+      (previous.value.kind !== "async" && previous.value.kind !== "error"))
   ) {
     if (
       previous?.source === source &&
@@ -97,37 +103,60 @@ export function useHeaderSource(source: HeaderSource): {
     ) {
       evaluationRef.current = previous;
     } else {
-      evaluationRef.current = { source, value: evaluation };
+      evaluationRef.current = {
+        source,
+        value: evaluation,
+        settled: evaluation.kind !== "async",
+      };
     }
   }
 
   const generation = useRef(0);
-  const sourceIdentity = useRef(source);
-  if (sourceIdentity.current !== source) {
-    sourceIdentity.current = source;
+  const effectiveSource = evaluationRef.current!.source;
+  const sourceIdentity = useRef(effectiveSource);
+  if (sourceIdentity.current !== effectiveSource) {
+    sourceIdentity.current = effectiveSource;
     generation.current += 1;
   }
 
-  const initial = evaluation.kind === "sync" ? evaluation.value : null;
+  const canonicalEvaluation = evaluationRef.current!.value;
+  const initial =
+    canonicalEvaluation.kind === "sync" ? canonicalEvaluation.value : null;
   const [state, setState] = useState<{
     headers: HeaderRecord | null;
     error: Error | null;
   }>(() => ({
     headers: initial,
-    error: evaluation.kind === "error" ? evaluation.error : null,
+    error:
+      canonicalEvaluation.kind === "error" ? canonicalEvaluation.error : null,
   }));
   const lastGood = useRef(initial ?? EMPTY);
+  const warnedPendingReplacement = useRef(false);
+  const previousSource = useRef(source);
+  if (
+    previousSource.current !== source &&
+    canonicalEvaluation.kind === "async" &&
+    holdPendingEvaluation &&
+    !warnedPendingReplacement.current &&
+    process.env.NODE_ENV !== "production"
+  ) {
+    warnedPendingReplacement.current = true;
+    console.warn(
+      "[CopilotKit] An async headers source changed while the previous source was pending; the current pending evaluation remains authoritative until it settles. Memoize the source to refresh it only when intended.",
+    );
+  }
+  previousSource.current = source;
 
   useEffect(() => {
     const current = generation.current;
     let active = true;
-    if (evaluation.kind === "sync") {
-      lastGood.current = evaluation.value;
+    if (canonicalEvaluation.kind === "sync") {
+      lastGood.current = canonicalEvaluation.value;
       return () => {
         active = false;
       };
     }
-    if (evaluation.kind === "error") {
+    if (canonicalEvaluation.kind === "error") {
       return () => {
         active = false;
       };
@@ -137,8 +166,11 @@ export function useHeaderSource(source: HeaderSource): {
         ? previousState
         : { headers: previousState.headers, error: null },
     );
-    Promise.resolve(evaluation.value).then(
+    Promise.resolve(canonicalEvaluation.value).then(
       (headers) => {
+        if (evaluationRef.current?.value === canonicalEvaluation) {
+          evaluationRef.current.settled = true;
+        }
         if (!active || current !== generation.current || !isRecord(headers)) {
           if (active && current === generation.current && !isRecord(headers)) {
             setState({
@@ -153,9 +185,18 @@ export function useHeaderSource(source: HeaderSource): {
         const normalized = normalizeHeaders(headers);
         lastGood.current = normalized;
         if (!active || current !== generation.current) return;
-        setState({ headers: normalized, error: null });
+        setState((previousState) =>
+          previousState.error === null &&
+          previousState.headers !== null &&
+          sameHeaders(previousState.headers, normalized)
+            ? previousState
+            : { headers: normalized, error: null },
+        );
       },
       (error) => {
+        if (evaluationRef.current?.value === canonicalEvaluation) {
+          evaluationRef.current.settled = true;
+        }
         if (!active || current !== generation.current) return;
         setState({
           headers: lastGood.current === EMPTY ? null : lastGood.current,
@@ -166,22 +207,34 @@ export function useHeaderSource(source: HeaderSource): {
     return () => {
       active = false;
     };
-  }, [evaluation]);
+  }, [canonicalEvaluation]);
 
   return {
     headers:
-      evaluation.kind === "sync"
-        ? evaluation.value
+      canonicalEvaluation.kind === "sync"
+        ? canonicalEvaluation.value
         : lastGood.current === EMPTY
-          ? state.headers
+          ? (state.headers ?? EMPTY)
           : lastGood.current,
     error:
-      evaluation.kind === "error"
-        ? evaluation.error
-        : evaluation.kind === "sync"
+      canonicalEvaluation.kind === "error"
+        ? canonicalEvaluation.error
+        : canonicalEvaluation.kind === "sync"
           ? null
           : previous?.source === source
             ? state.error
             : null,
+    status:
+      canonicalEvaluation.kind === "sync"
+        ? "ready"
+        : canonicalEvaluation.kind === "error"
+          ? "failed"
+          : state.error
+            ? lastGood.current !== EMPTY
+              ? "ready"
+              : "failed"
+            : state.headers || lastGood.current !== EMPTY
+              ? "ready"
+              : "pending",
   };
 }

--- a/packages/react-core/src/v2/providers/use-header-source.ts
+++ b/packages/react-core/src/v2/providers/use-header-source.ts
@@ -59,13 +59,15 @@ export function useHeaderSource(source: HeaderSource): {
   } | null>(null);
   const previous = evaluationRef.current;
   const evaluation =
-    previous && previous.source === source && previous.value.kind === "async"
+    previous &&
+    previous.source === source &&
+    (previous.value.kind === "async" || previous.value.kind === "error")
       ? previous.value
       : evaluate(source);
   if (
     !previous ||
     previous.source !== source ||
-    previous.value.kind !== "async"
+    (previous.value.kind !== "async" && previous.value.kind !== "error")
   ) {
     evaluationRef.current = { source, value: evaluation };
   }
@@ -83,26 +85,27 @@ export function useHeaderSource(source: HeaderSource): {
 
   useEffect(() => {
     const current = ++generation.current;
+    let active = true;
     if (evaluation.kind === "sync") {
       lastGood.current = evaluation.value;
-      setState({ headers: evaluation.value, error: null });
-      return;
+      return () => {
+        active = false;
+      };
     }
     if (evaluation.kind === "error") {
-      setState({
-        headers: lastGood.current === EMPTY ? null : lastGood.current,
-        error: evaluation.error,
-      });
-      return;
+      return () => {
+        active = false;
+      };
     }
-    setState((previousState) => ({
-      headers: previousState.headers,
-      error: null,
-    }));
+    setState((previousState) =>
+      previousState.error === null
+        ? previousState
+        : { headers: previousState.headers, error: null },
+    );
     Promise.resolve(evaluation.value).then(
       (headers) => {
-        if (current !== generation.current || !isRecord(headers)) {
-          if (current === generation.current && !isRecord(headers)) {
+        if (!active || current !== generation.current || !isRecord(headers)) {
+          if (active && current === generation.current && !isRecord(headers)) {
             setState({
               headers: lastGood.current === EMPTY ? null : lastGood.current,
               error: new Error(
@@ -113,16 +116,20 @@ export function useHeaderSource(source: HeaderSource): {
           return;
         }
         lastGood.current = headers;
+        if (!active || current !== generation.current) return;
         setState({ headers, error: null });
       },
       (error) => {
-        if (current !== generation.current) return;
+        if (!active || current !== generation.current) return;
         setState({
           headers: lastGood.current === EMPTY ? null : lastGood.current,
           error: errorFrom(error),
         });
       },
     );
+    return () => {
+      active = false;
+    };
   }, [evaluation]);
 
   return {

--- a/packages/react-core/src/v2/providers/use-header-source.ts
+++ b/packages/react-core/src/v2/providers/use-header-source.ts
@@ -3,15 +3,16 @@ import type { MaybePromise } from "@copilotkit/shared";
 
 export type HeaderRecord = Record<string, string>;
 export type HeaderSource = HeaderRecord | (() => MaybePromise<HeaderRecord>);
+type HeaderInput = Record<string, string | null | undefined>;
 
 type Evaluation =
   | { kind: "sync"; value: HeaderRecord }
-  | { kind: "async"; value: PromiseLike<HeaderRecord> }
+  | { kind: "async"; value: PromiseLike<unknown> }
   | { kind: "error"; error: Error };
 
 const EMPTY: HeaderRecord = Object.freeze({}) as HeaderRecord;
 
-function isRecord(value: unknown): value is HeaderRecord {
+function isRecord(value: unknown): value is HeaderInput {
   return (
     typeof value === "object" &&
     value !== null &&
@@ -19,6 +20,14 @@ function isRecord(value: unknown): value is HeaderRecord {
     Object.values(value).every(
       (entry) => entry == null || typeof entry === "string",
     )
+  );
+}
+
+function normalizeHeaders(value: HeaderInput): HeaderRecord {
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string] => entry[1] != null,
+    ),
   );
 }
 
@@ -48,7 +57,7 @@ function evaluate(source: HeaderSource): Evaluation {
       }
     }
     return isRecord(value)
-      ? { kind: "sync", value }
+      ? { kind: "sync", value: normalizeHeaders(value) }
       : {
           kind: "error",
           error: new Error(
@@ -92,6 +101,13 @@ export function useHeaderSource(source: HeaderSource): {
     }
   }
 
+  const generation = useRef(0);
+  const sourceIdentity = useRef(source);
+  if (sourceIdentity.current !== source) {
+    sourceIdentity.current = source;
+    generation.current += 1;
+  }
+
   const initial = evaluation.kind === "sync" ? evaluation.value : null;
   const [state, setState] = useState<{
     headers: HeaderRecord | null;
@@ -101,10 +117,9 @@ export function useHeaderSource(source: HeaderSource): {
     error: evaluation.kind === "error" ? evaluation.error : null,
   }));
   const lastGood = useRef(initial ?? EMPTY);
-  const generation = useRef(0);
 
   useEffect(() => {
-    const current = ++generation.current;
+    const current = generation.current;
     let active = true;
     if (evaluation.kind === "sync") {
       lastGood.current = evaluation.value;
@@ -135,9 +150,10 @@ export function useHeaderSource(source: HeaderSource): {
           }
           return;
         }
-        lastGood.current = headers;
+        const normalized = normalizeHeaders(headers);
+        lastGood.current = normalized;
         if (!active || current !== generation.current) return;
-        setState({ headers, error: null });
+        setState({ headers: normalized, error: null });
       },
       (error) => {
         if (!active || current !== generation.current) return;
@@ -164,6 +180,8 @@ export function useHeaderSource(source: HeaderSource): {
         ? evaluation.error
         : evaluation.kind === "sync"
           ? null
-          : state.error,
+          : previous?.source === source
+            ? state.error
+            : null,
   };
 }


### PR DESCRIPTION
## Summary

Web CopilotKit providers accept Promise-returning header builders while keeping descendants mounted and containing outbound requests until initial headers are ready.

## Root cause

Header resolution was treated as a render-time value. That allowed unstable identity and stale async completions, withheld the provider subtree after an initial failure, and left direct request paths outside one readiness boundary.

## Changes

- Cache canonical normalized records for synchronous and equal async results, preserve stale-completion suppression, and warn once when a pending async source is replaced.
- Keep provider descendants mounted with concrete headers and use one private barrier for initial pending, initial failure, recovery, and last-good refresh behavior.
- Route `/info`, agent and suggestion operations, tasks, annotations, transcription, and direct MCP requests through that barrier, reading the current merged headers and runtime URL after readiness.
- Keep v1 and v2 on the same concrete record, scope the legacy error adapter to header-origin errors, and remove the production-path `Authorization` log.

## Backward compatibility

Static records and synchronous builders keep their existing values and timing. Async function identity remains the declarative refresh signal; callers can refresh credentials through `copilotkit.setHeaders()`.

## Scope

Web React/Core only. No public readiness API, React Native changes, runtime-client-gql changes, package metadata changes, or `runId` behavior changes.

## Related PRs and Issues

Closes #1937.

This extends the synchronous header behavior confirmed in https://github.com/CopilotKit/CopilotKit/issues/1937#issuecomment-5086936198.

## Test plan

- [x] Focused Vitest regressions: 37 tests across five resolver/provider, barrier, annotation, learning-container, and production-anchor files, plus two isolated v1 async-header tests.
- [x] React Core typecheck.
- [x] Scoped Oxfmt, scoped Oxlint with 0 errors, `git diff --check`, scope, and invariant-enumeration checks.
- [ ] CI green (`static / quality`, `test / unit` on Node 20/22/24).
