### PR TITLE
fix(runtime): initialize arrays before /- append in AGUISendStateDelta

### DIFF
--- a/packages/runtime/src/agent/__tests__/converter-aisdk.test.ts
+++ b/packages/runtime/src/agent/__tests__/converter-aisdk.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { EventType } from "@ag-ui/client";
+import { compactEvents, EventType } from "@ag-ui/client";
 import {
   createAgent,
   createDefaultInput,
@@ -460,6 +460,100 @@ describe("AI SDK Converter", () => {
       );
       expect(stateDeltas).toHaveLength(1);
       expect(eventField(stateDeltas[0], "delta")).toEqual(delta);
+    });
+
+    it("normalizes missing arrays before compaction", async () => {
+      const todo = { text: "Buy milk", completed: false };
+      const delta = [{ op: "add", path: "/todos/-", value: todo }];
+      const agent = createAgent("aisdk", [
+        toolCallStreamingStart("tc-delta", "AGUISendStateDelta"),
+        toolCall("tc-delta", "AGUISendStateDelta"),
+        toolResult("tc-delta", "AGUISendStateDelta", { delta }),
+        finish(),
+      ]);
+      const events = await collectEvents(
+        agent.run(createDefaultInput({ state: {} })),
+      );
+      const stateDelta = events.find(
+        (event) => event.type === EventType.STATE_DELTA,
+      );
+
+      expect(eventField<unknown>(stateDelta, "delta")).toEqual([
+        { op: "add", path: "/todos", value: [] },
+        ...delta,
+      ]);
+      expect(compactEvents(events)).toContainEqual(
+        expect.objectContaining({
+          type: EventType.STATE_SNAPSHOT,
+          snapshot: { todos: [todo] },
+        }),
+      );
+    });
+
+    it("preserves copy, move, and test before later appends", async () => {
+      const sourceItem = { id: "source" };
+      const movedItem = { id: "moved" };
+      const delta = [
+        { op: "copy", from: "/source", path: "/copied" },
+        { op: "move", from: "/moving", path: "/moved" },
+        { op: "test", path: "/copied/0", value: sourceItem },
+        { op: "add", path: "/copied/-", value: { id: "copied-append" } },
+        { op: "add", path: "/moved/-", value: { id: "moved-append" } },
+      ];
+      const agent = createAgent("aisdk", [
+        toolCallStreamingStart("tc-copy-move", "AGUISendStateDelta"),
+        toolCall("tc-copy-move", "AGUISendStateDelta"),
+        toolResult("tc-copy-move", "AGUISendStateDelta", { delta }),
+        finish(),
+      ]);
+      const events = await collectEvents(
+        agent.run(
+          createDefaultInput({
+            state: { source: [sourceItem], moving: [movedItem] },
+          }),
+        ),
+      );
+
+      expect(
+        eventField<unknown>(
+          events.find((event) => event.type === EventType.STATE_DELTA),
+          "delta",
+        ),
+      ).toEqual(delta);
+      expect(compactEvents(events)).toContainEqual(
+        expect.objectContaining({
+          type: EventType.STATE_SNAPSHOT,
+          snapshot: {
+            source: [sourceItem],
+            copied: [sourceItem, { id: "copied-append" }],
+            moved: [movedItem, { id: "moved-append" }],
+          },
+        }),
+      );
+    });
+
+    it("preserves malformed delta entries for downstream validation", async () => {
+      const delta = [null];
+      const agent = createAgent("aisdk", [
+        toolCallStreamingStart("tc-malformed", "AGUISendStateDelta"),
+        toolCall("tc-malformed", "AGUISendStateDelta"),
+        toolResult("tc-malformed", "AGUISendStateDelta", { delta }),
+        finish(),
+      ]);
+      const events = await collectEvents(
+        agent.run(createDefaultInput({ state: {} })),
+      );
+      const deltaIdx = events.findIndex(
+        (event) => event.type === EventType.STATE_DELTA,
+      );
+      const resultIdx = events.findIndex(
+        (event) => event.type === EventType.TOOL_CALL_RESULT,
+      );
+
+      expect(deltaIdx).toBeGreaterThanOrEqual(0);
+      expect(deltaIdx).toBeLessThan(resultIdx);
+      expect(eventField<unknown>(events[deltaIdx], "delta")).toEqual(delta);
+      expect(() => compactEvents(events)).toThrow("OPERATION_NOT_AN_OBJECT");
     });
 
     it("state tool result also emits TOOL_CALL_RESULT event", async () => {

--- a/packages/runtime/src/agent/__tests__/converter-tanstack.test.ts
+++ b/packages/runtime/src/agent/__tests__/converter-tanstack.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { EventType } from "@ag-ui/client";
+import { compactEvents, EventType } from "@ag-ui/client";
 import {
   createAgent,
   createDefaultInput,
@@ -459,6 +459,97 @@ describe("TanStack AI converter — state tools", () => {
     expect(deltaIdx).toBeGreaterThanOrEqual(0);
     expect(deltaIdx).toBeLessThan(resultIdx);
     expect(eventField<unknown>(events[deltaIdx], "delta")).toEqual(delta);
+  });
+
+  it("normalizes missing arrays before compaction", async () => {
+    const todo = { text: "Buy milk", completed: false };
+    const delta = [{ op: "add", path: "/todos/-", value: todo }];
+    const agent = createAgent("tanstack", [
+      tanstackToolCallStart("call1", "AGUISendStateDelta"),
+      tanstackToolCallEnd("call1"),
+      tanstackToolCallResult("call1", { success: true, delta }),
+    ]);
+    const events = await collectEvents(
+      agent.run(createDefaultInput({ state: {} })),
+    );
+    const stateDelta = events.find(
+      (event) => event.type === EventType.STATE_DELTA,
+    );
+
+    expect(eventField<unknown>(stateDelta, "delta")).toEqual([
+      { op: "add", path: "/todos", value: [] },
+      ...delta,
+    ]);
+    expect(compactEvents(events)).toContainEqual(
+      expect.objectContaining({
+        type: EventType.STATE_SNAPSHOT,
+        snapshot: { todos: [todo] },
+      }),
+    );
+  });
+
+  it("preserves copy, move, and test before later appends", async () => {
+    const sourceItem = { id: "source" };
+    const movedItem = { id: "moved" };
+    const delta = [
+      { op: "copy", from: "/source", path: "/copied" },
+      { op: "move", from: "/moving", path: "/moved" },
+      { op: "test", path: "/copied/0", value: sourceItem },
+      { op: "add", path: "/copied/-", value: { id: "copied-append" } },
+      { op: "add", path: "/moved/-", value: { id: "moved-append" } },
+    ];
+    const agent = createAgent("tanstack", [
+      tanstackToolCallStart("call-copy-move", "AGUISendStateDelta"),
+      tanstackToolCallEnd("call-copy-move"),
+      tanstackToolCallResult("call-copy-move", { success: true, delta }),
+    ]);
+    const events = await collectEvents(
+      agent.run(
+        createDefaultInput({
+          state: { source: [sourceItem], moving: [movedItem] },
+        }),
+      ),
+    );
+
+    expect(
+      eventField<unknown>(
+        events.find((event) => event.type === EventType.STATE_DELTA),
+        "delta",
+      ),
+    ).toEqual(delta);
+    expect(compactEvents(events)).toContainEqual(
+      expect.objectContaining({
+        type: EventType.STATE_SNAPSHOT,
+        snapshot: {
+          source: [sourceItem],
+          copied: [sourceItem, { id: "copied-append" }],
+          moved: [movedItem, { id: "moved-append" }],
+        },
+      }),
+    );
+  });
+
+  it("preserves malformed delta entries for downstream validation", async () => {
+    const delta = [null];
+    const agent = createAgent("tanstack", [
+      tanstackToolCallStart("call-malformed", "AGUISendStateDelta"),
+      tanstackToolCallEnd("call-malformed"),
+      tanstackToolCallResult("call-malformed", { success: true, delta }),
+    ]);
+    const events = await collectEvents(
+      agent.run(createDefaultInput({ state: {} })),
+    );
+    const deltaIdx = events.findIndex(
+      (event) => event.type === EventType.STATE_DELTA,
+    );
+    const resultIdx = events.findIndex(
+      (event) => event.type === EventType.TOOL_CALL_RESULT,
+    );
+
+    expect(deltaIdx).toBeGreaterThanOrEqual(0);
+    expect(deltaIdx).toBeLessThan(resultIdx);
+    expect(eventField<unknown>(events[deltaIdx], "delta")).toEqual(delta);
+    expect(() => compactEvents(events)).toThrow("OPERATION_NOT_AN_OBJECT");
   });
 
   it("emits STATE_SNAPSHOT when payload arrives in raw.result instead of raw.content", async () => {

--- a/packages/runtime/src/agent/__tests__/state-tools.test.ts
+++ b/packages/runtime/src/agent/__tests__/state-tools.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { BasicAgent } from "../index";
-import { EventType, type RunAgentInput } from "@ag-ui/client";
+import { compactEvents, EventType } from "@ag-ui/client";
+import type { RunAgentInput } from "@ag-ui/client";
 import { streamText } from "ai";
 import {
   mockStreamTextResponse,
@@ -10,6 +11,10 @@ import {
   finish,
   collectEvents,
 } from "./test-helpers";
+
+function cloneFallbackCallback() {
+  return "keep this reference";
+}
 
 // Mock the ai module
 vi.mock("ai", () => ({
@@ -126,6 +131,297 @@ describe("State Update Tools", () => {
   });
 
   describe("AGUISendStateDelta", () => {
+    const emitStateDelta = async (delta: unknown[], state: unknown) => {
+      const agent = new BasicAgent({
+        model: "openai/gpt-4o",
+      });
+
+      vi.mocked(streamText).mockReturnValue(
+        mockStreamTextResponse([
+          toolCallStreamingStart("snapshot", "AGUISendStateSnapshot"),
+          toolCall("snapshot", "AGUISendStateSnapshot"),
+          toolResult("snapshot", "AGUISendStateSnapshot", {
+            success: true,
+            snapshot: state,
+          }),
+          toolCallStreamingStart("call1", "AGUISendStateDelta"),
+          toolCall("call1", "AGUISendStateDelta"),
+          toolResult("call1", "AGUISendStateDelta", {
+            success: true,
+            delta,
+          }),
+          finish(),
+        ]) as any,
+      );
+
+      const input: RunAgentInput = {
+        threadId: "thread1",
+        runId: "run1",
+        messages: [],
+        tools: [],
+        context: [],
+        state,
+      };
+
+      return collectEvents(agent["run"](input));
+    };
+
+    it("should initialize a missing array before appending to it", async () => {
+      const agent = new BasicAgent({
+        model: "openai/gpt-4o",
+      });
+
+      const todo = { text: "Buy milk", completed: false };
+      const delta = [{ op: "add" as const, path: "/todos/-", value: todo }];
+
+      vi.mocked(streamText).mockReturnValue(
+        mockStreamTextResponse([
+          toolCallStreamingStart("call1", "AGUISendStateDelta"),
+          toolCall("call1", "AGUISendStateDelta"),
+          toolResult("call1", "AGUISendStateDelta", { success: true, delta }),
+          finish(),
+        ]) as any,
+      );
+
+      const input: RunAgentInput = {
+        threadId: "thread1",
+        runId: "run1",
+        messages: [],
+        tools: [],
+        context: [],
+        state: {},
+      };
+
+      const events = await collectEvents(agent["run"](input));
+      const deltaEvent = events.find(
+        (e: any) => e.type === EventType.STATE_DELTA,
+      );
+      const toolResultEvent = events.find(
+        (e: any) => e.type === EventType.TOOL_CALL_RESULT,
+      );
+
+      expect(deltaEvent?.delta).toEqual([
+        { op: "add", path: "/todos", value: [] },
+        ...delta,
+      ]);
+      expect(events.indexOf(deltaEvent!)).toBeLessThan(
+        events.indexOf(toolResultEvent!),
+      );
+
+      const compactedEvents = compactEvents(events);
+      const stateSnapshot = compactedEvents.find(
+        (event: any) => event.type === EventType.STATE_SNAPSHOT,
+      );
+      expect(stateSnapshot).toMatchObject({
+        type: EventType.STATE_SNAPSHOT,
+        snapshot: { todos: [todo] },
+      });
+    });
+
+    it("should preserve an existing input array when appending", async () => {
+      const agent = new BasicAgent({
+        model: "openai/gpt-4o",
+      });
+
+      const existingTodo = { text: "Buy eggs", completed: true };
+      const newTodo = { text: "Buy milk", completed: false };
+      const delta = [{ op: "add" as const, path: "/todos/-", value: newTodo }];
+
+      vi.mocked(streamText).mockReturnValue(
+        mockStreamTextResponse([
+          toolCallStreamingStart("call1", "AGUISendStateDelta"),
+          toolCall("call1", "AGUISendStateDelta"),
+          toolResult("call1", "AGUISendStateDelta", { success: true, delta }),
+          finish(),
+        ]) as any,
+      );
+
+      const input: RunAgentInput = {
+        threadId: "thread1",
+        runId: "run1",
+        messages: [],
+        tools: [],
+        context: [],
+        state: { todos: [existingTodo] },
+      };
+
+      const events = await collectEvents(agent["run"](input));
+      const deltaEvent = events.find(
+        (e: any) => e.type === EventType.STATE_DELTA,
+      );
+
+      expect(deltaEvent?.delta).toEqual(delta);
+      const compactedEvents = compactEvents(events);
+      const stateSnapshot = compactedEvents.find(
+        (event: any) => event.type === EventType.STATE_SNAPSHOT,
+      );
+      expect(stateSnapshot).toMatchObject({
+        type: EventType.STATE_SNAPSHOT,
+        snapshot: { todos: [existingTodo, newTodo] },
+      });
+    });
+
+    it("should only initialize literal add append operations", async () => {
+      const delta = [
+        { op: "replace", path: "/todos/-", value: "not an append" },
+      ];
+      const events = await emitStateDelta(delta, {});
+      const deltaEvent = events.find(
+        (event: any) => event.type === EventType.STATE_DELTA,
+      );
+
+      expect(deltaEvent?.delta).toEqual(delta);
+    });
+
+    it("should initialize a missing array once for repeated appends", async () => {
+      const firstTodo = { text: "Buy eggs", completed: true };
+      const secondTodo = { text: "Buy milk", completed: false };
+      const delta = [
+        { op: "replace", path: "/counter", value: 1 },
+        { op: "add", path: "/todos/-", value: firstTodo },
+        { op: "add", path: "/todos/-", value: secondTodo },
+      ];
+
+      const events = await emitStateDelta(delta, { counter: 0 });
+      const deltaEvent = events.find(
+        (event: any) => event.type === EventType.STATE_DELTA,
+      );
+
+      expect(deltaEvent?.delta).toEqual([
+        delta[0],
+        { op: "add", path: "/todos", value: [] },
+        delta[1],
+        delta[2],
+      ]);
+      const compactedEvents = compactEvents(events);
+      const stateSnapshot = compactedEvents.find(
+        (event: any) => event.type === EventType.STATE_SNAPSHOT,
+      );
+      expect(stateSnapshot).toMatchObject({
+        snapshot: { counter: 1, todos: [firstTodo, secondTodo] },
+      });
+    });
+
+    it("should preserve copy, move, and test before later appends", async () => {
+      const sourceItem = { id: "source" };
+      const movedItem = { id: "moved" };
+      const copiedAppend = { id: "copied-append" };
+      const movedAppend = { id: "moved-append" };
+      const delta = [
+        { op: "copy", from: "/source", path: "/copied" },
+        { op: "move", from: "/moving", path: "/moved" },
+        { op: "test", path: "/copied/0", value: sourceItem },
+        { op: "add", path: "/copied/-", value: copiedAppend },
+        { op: "add", path: "/moved/-", value: movedAppend },
+      ];
+      const events = await emitStateDelta(delta, {
+        source: [sourceItem],
+        moving: [movedItem],
+      });
+      const deltaEvent = events.find(
+        (event: any) => event.type === EventType.STATE_DELTA,
+      );
+
+      expect(deltaEvent?.delta).toEqual(delta);
+      const stateSnapshot = compactEvents(events).find(
+        (event: any) => event.type === EventType.STATE_SNAPSHOT,
+      );
+      expect(stateSnapshot).toMatchObject({
+        snapshot: {
+          source: [sourceItem],
+          copied: [sourceItem, copiedAppend],
+          moved: [movedItem, movedAppend],
+        },
+      });
+    });
+
+    it("should preserve non-array append failures", async () => {
+      const delta = [{ op: "add", path: "/todos/-", value: "new todo" }];
+      const events = await emitStateDelta(delta, { todos: "not an array" });
+      const deltaEvent = events.find(
+        (event: any) => event.type === EventType.STATE_DELTA,
+      );
+
+      expect(deltaEvent?.delta).toEqual(delta);
+      expect(() => compactEvents(events)).toThrow(
+        "OPERATION_PATH_UNRESOLVABLE",
+      );
+    });
+
+    it("should preserve malformed entries for downstream validation", async () => {
+      const delta = [null];
+      const events = await emitStateDelta(delta, {});
+      const deltaIdx = events.findIndex(
+        (event: any) => event.type === EventType.STATE_DELTA,
+      );
+      const resultIdx = events.findIndex(
+        (event: any) =>
+          event.type === EventType.TOOL_CALL_RESULT &&
+          event.toolCallId === "call1",
+      );
+
+      expect(deltaIdx).toBeGreaterThanOrEqual(0);
+      expect(deltaIdx).toBeLessThan(resultIdx);
+      expect(events[deltaIdx]).toMatchObject({
+        type: EventType.STATE_DELTA,
+        delta,
+      });
+      expect(() => compactEvents(events)).toThrow("OPERATION_NOT_AN_OBJECT");
+    });
+
+    it("should not synthesize an unknown ancestor", async () => {
+      const delta = [{ op: "add", path: "/lists/todos/-", value: "new todo" }];
+      const events = await emitStateDelta(delta, {});
+      const deltaEvent = events.find(
+        (event: any) => event.type === EventType.STATE_DELTA,
+      );
+
+      expect(deltaEvent?.delta).toEqual(delta);
+      expect(() => compactEvents(events)).toThrow("OPERATION_PATH_CANNOT_ADD");
+    });
+
+    it("should clone state when structuredClone cannot clone it", async () => {
+      const callback = cloneFallbackCallback;
+      const state = { todos: [], callback };
+      const delta = [
+        {
+          op: "add",
+          path: "/todos/-",
+          value: { text: "Buy milk", callback },
+        },
+      ];
+      const agent = new BasicAgent({
+        model: "openai/gpt-4o",
+      });
+
+      vi.mocked(streamText).mockReturnValue(
+        mockStreamTextResponse([
+          toolCallStreamingStart("call1", "AGUISendStateDelta"),
+          toolCall("call1", "AGUISendStateDelta"),
+          toolResult("call1", "AGUISendStateDelta", { success: true, delta }),
+          finish(),
+        ]) as any,
+      );
+
+      const events = await collectEvents(
+        agent["run"]({
+          threadId: "thread1",
+          runId: "run1",
+          messages: [],
+          tools: [],
+          context: [],
+          state,
+        }),
+      );
+      const stateSnapshot = events.find(
+        (event: any) => event.type === EventType.STATE_SNAPSHOT,
+      ) as any;
+
+      expect(state.todos).toEqual([]);
+      expect(stateSnapshot?.snapshot).not.toBe(state);
+      expect(stateSnapshot?.snapshot.todos).not.toBe(state.todos);
+    });
+
     it("should emit STATE_DELTA event when tool is called", async () => {
       const agent = new BasicAgent({
         model: "openai/gpt-4o",

--- a/packages/runtime/src/agent/converters/aisdk.ts
+++ b/packages/runtime/src/agent/converters/aisdk.ts
@@ -16,6 +16,7 @@ import type {
 } from "@ag-ui/client";
 import { EventType } from "@ag-ui/client";
 import { randomUUID } from "@copilotkit/shared";
+import { createStateEventNormalizer } from "../state-delta";
 
 /**
  * Converts an AI SDK `fullStream` into AG-UI `BaseEvent` objects.
@@ -35,10 +36,12 @@ export async function* convertAISDKStream(
   fullStream: AsyncIterable<unknown>,
   abortSignal: AbortSignal,
   pendingInterrupts?: Interrupt[],
+  initialState?: unknown,
 ): AsyncGenerator<BaseEvent> {
   let messageId = randomUUID();
   let reasoningMessageId = randomUUID();
   let isInReasoning = false;
+  const normalizeStateEvent = createStateEventNormalizer(initialState);
 
   const toolCallStates = new Map<
     string,
@@ -338,7 +341,9 @@ export async function* convertAISDKStream(
                 type: EventType.STATE_SNAPSHOT,
                 snapshot,
               };
-              yield stateSnapshotEvent;
+              for (const event of normalizeStateEvent(stateSnapshotEvent)) {
+                yield event;
+              }
             }
           } else if (
             toolName === "AGUISendStateDelta" &&
@@ -352,7 +357,9 @@ export async function* convertAISDKStream(
                 type: EventType.STATE_DELTA,
                 delta,
               };
-              yield stateDeltaEvent;
+              for (const event of normalizeStateEvent(stateDeltaEvent)) {
+                yield event;
+              }
             }
           }
 

--- a/packages/runtime/src/agent/converters/tanstack.ts
+++ b/packages/runtime/src/agent/converters/tanstack.ts
@@ -18,6 +18,7 @@ import type {
 } from "@ag-ui/client";
 import { EventType } from "@ag-ui/client";
 import { randomUUID } from "@copilotkit/shared";
+import { createStateEventNormalizer } from "../state-delta";
 
 type ContentPartSource =
   | { type: "data"; value: string; mimeType: string }
@@ -332,6 +333,7 @@ export async function* convertTanStackStream(
   stream: AsyncIterable<unknown>,
   abortSignal: AbortSignal,
   pendingInterrupts?: Interrupt[],
+  initialState?: unknown,
 ): AsyncGenerator<BaseEvent> {
   const messageId = randomUUID();
   const toolNamesById = new Map<string, string>();
@@ -344,6 +346,7 @@ export async function* convertTanStackStream(
   let reasoningRunOpen = false;
   let reasoningMessageOpen = false;
   let reasoningMessageId = randomUUID();
+  const normalizeStateEvent = createStateEventNormalizer(initialState);
 
   function* closeReasoningIfOpen(): Generator<BaseEvent> {
     if (reasoningMessageOpen) {
@@ -491,7 +494,9 @@ export async function* convertTanStackStream(
           type: EventType.STATE_SNAPSHOT,
           snapshot: (parsedContent as Record<string, unknown>).snapshot,
         };
-        yield stateSnapshotEvent;
+        for (const event of normalizeStateEvent(stateSnapshotEvent)) {
+          yield event;
+        }
       }
 
       if (
@@ -504,7 +509,9 @@ export async function* convertTanStackStream(
           type: EventType.STATE_DELTA,
           delta: (parsedContent as Record<string, unknown>).delta as never,
         };
-        yield stateDeltaEvent;
+        for (const event of normalizeStateEvent(stateDeltaEvent)) {
+          yield event;
+        }
       }
 
       let serializedContent: string;

--- a/packages/runtime/src/agent/index.ts
+++ b/packages/runtime/src/agent/index.ts
@@ -15,8 +15,6 @@ import type {
   ToolCallStartEvent,
   ToolCallResultEvent,
   RunErrorEvent,
-  StateSnapshotEvent,
-  StateDeltaEvent,
   Interrupt,
   ResumeEntry,
 } from "@ag-ui/client";
@@ -53,6 +51,7 @@ import { schemaToJsonSchema } from "@copilotkit/shared";
 import { jsonSchema as aiJsonSchema } from "ai";
 import { convertAISDKStream } from "./converters/aisdk";
 import { convertTanStackStream } from "./converters/tanstack";
+import { createStateEventNormalizer } from "./state-delta";
 import type { StreamableHTTPClientTransportOptions } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
@@ -1426,7 +1425,7 @@ export class BuiltInAgent extends AbstractAgent {
               ]),
           );
           const pendingInterrupts: Interrupt[] = [];
-
+          const normalizeStateEvent = createStateEventNormalizer(input.state);
           const toolCallStates = new Map<
             string,
             {
@@ -1674,11 +1673,15 @@ export class BuiltInAgent extends AbstractAgent {
                 ) {
                   const snapshot = toolResult.snapshot;
                   if (snapshot !== undefined) {
-                    const stateSnapshotEvent: StateSnapshotEvent = {
+                    const stateSnapshotEvent: BaseEvent = {
                       type: EventType.STATE_SNAPSHOT,
                       snapshot,
                     };
-                    subscriber.next(stateSnapshotEvent);
+                    for (const event of normalizeStateEvent(
+                      stateSnapshotEvent,
+                    )) {
+                      subscriber.next(event);
+                    }
                   }
                 } else if (
                   toolName === "AGUISendStateDelta" &&
@@ -1687,11 +1690,13 @@ export class BuiltInAgent extends AbstractAgent {
                 ) {
                   const delta = toolResult.delta;
                   if (delta !== undefined) {
-                    const stateDeltaEvent: StateDeltaEvent = {
+                    const stateDeltaEvent: BaseEvent = {
                       type: EventType.STATE_DELTA,
                       delta,
                     };
-                    subscriber.next(stateDeltaEvent);
+                    for (const event of normalizeStateEvent(stateDeltaEvent)) {
+                      subscriber.next(event);
+                    }
                   }
                 }
 
@@ -1922,6 +1927,7 @@ export class BuiltInAgent extends AbstractAgent {
                 result.fullStream,
                 controller.signal,
                 pendingInterrupts,
+                input.state,
               );
               break;
             }
@@ -1931,6 +1937,7 @@ export class BuiltInAgent extends AbstractAgent {
                 stream,
                 controller.signal,
                 pendingInterrupts,
+                input.state,
               );
               break;
             }

--- a/packages/runtime/src/agent/state-delta.ts
+++ b/packages/runtime/src/agent/state-delta.ts
@@ -1,0 +1,397 @@
+import type {
+  BaseEvent,
+  StateDeltaEvent,
+  StateSnapshotEvent,
+} from "@ag-ui/client";
+import { EventType } from "@ag-ui/client";
+
+type StateDeltaOperation = {
+  op?: string;
+  path?: string;
+  from?: string;
+  value?: unknown;
+};
+
+type PointerResult = {
+  exists: boolean;
+  value?: unknown;
+};
+
+type OperationResult = {
+  root: unknown;
+  applied: boolean;
+};
+
+function parseJsonPointer(pointer: string): string[] | undefined {
+  if (pointer === "") return [];
+  if (!pointer.startsWith("/")) return undefined;
+
+  const segments = pointer.slice(1).split("/");
+  if (segments.some((segment) => /~(?![01])/.test(segment))) {
+    return undefined;
+  }
+
+  return segments.map((segment) =>
+    segment.replace(/~1/g, "/").replace(/~0/g, "~"),
+  );
+}
+
+function encodeJsonPointer(segments: string[]): string {
+  if (segments.length === 0) return "";
+  return `/${segments
+    .map((segment) => segment.replace(/~/g, "~0").replace(/\//g, "~1"))
+    .join("/")}`;
+}
+
+function getArrayIndex(segment: string, length: number): number | undefined {
+  if (segment !== "0" && !/^[1-9]\d*$/.test(segment)) return undefined;
+  const index = Number(segment);
+  return Number.isSafeInteger(index) && index < length ? index : undefined;
+}
+
+function getJsonPointerValue(root: unknown, pointer: string): PointerResult {
+  const segments = parseJsonPointer(pointer);
+  if (segments === undefined) return { exists: false };
+
+  let current = root;
+  for (const segment of segments) {
+    if (current === null || typeof current !== "object") {
+      return { exists: false };
+    }
+
+    if (Array.isArray(current)) {
+      const index = getArrayIndex(segment, current.length);
+      if (index === undefined) return { exists: false };
+      current = current[index];
+    } else {
+      if (!Object.prototype.hasOwnProperty.call(current, segment)) {
+        return { exists: false };
+      }
+      current = (current as Record<string, unknown>)[segment];
+    }
+  }
+
+  return { exists: true, value: current };
+}
+
+function getParent(root: unknown, segments: string[]): PointerResult {
+  return getJsonPointerValue(root, encodeJsonPointer(segments.slice(0, -1)));
+}
+
+function cloneStateFallback(
+  state: unknown,
+  seen = new WeakMap<object, unknown>(),
+): unknown {
+  if (state === null || typeof state !== "object") return state;
+
+  const existing = seen.get(state);
+  if (existing !== undefined) return existing;
+
+  let clone: object;
+  try {
+    clone = Array.isArray(state)
+      ? []
+      : Object.create(Object.getPrototypeOf(state));
+  } catch {
+    clone = Array.isArray(state) ? [] : {};
+  }
+  seen.set(state, clone);
+
+  let keys: (string | symbol)[] = [];
+  try {
+    keys = Reflect.ownKeys(state);
+  } catch {
+    return clone;
+  }
+
+  for (const key of keys) {
+    try {
+      const descriptor = Object.getOwnPropertyDescriptor(state, key);
+      if (!descriptor) continue;
+      if ("value" in descriptor) {
+        descriptor.value = cloneStateFallback(descriptor.value, seen);
+      }
+      Object.defineProperty(clone, key, descriptor);
+    } catch {
+      // Keep the cloned container distinct when a property is inaccessible.
+    }
+  }
+
+  return clone;
+}
+
+function cloneState(state: unknown): unknown {
+  try {
+    return structuredClone(state);
+  } catch {
+    return cloneStateFallback(state);
+  }
+}
+
+function addValue(
+  root: unknown,
+  segments: string[],
+  value: unknown,
+): OperationResult {
+  if (segments.length === 0) {
+    return { root: cloneState(value), applied: true };
+  }
+
+  const parent = getParent(root, segments);
+  if (
+    !parent.exists ||
+    parent.value === null ||
+    typeof parent.value !== "object"
+  ) {
+    return { root, applied: false };
+  }
+
+  const segment = segments[segments.length - 1];
+  if (Array.isArray(parent.value)) {
+    if (segment === "-") {
+      parent.value.push(cloneState(value));
+      return { root, applied: true };
+    }
+
+    const index =
+      segment === "0"
+        ? 0
+        : /^[1-9]\d*$/.test(segment)
+          ? Number(segment)
+          : undefined;
+    if (
+      index === undefined ||
+      !Number.isSafeInteger(index) ||
+      index > parent.value.length
+    ) {
+      return { root, applied: false };
+    }
+    parent.value.splice(index, 0, cloneState(value));
+    return { root, applied: true };
+  }
+
+  (parent.value as Record<string, unknown>)[segment] = cloneState(value);
+  return { root, applied: true };
+}
+
+function removeValue(root: unknown, segments: string[]): OperationResult {
+  if (segments.length === 0) return { root: undefined, applied: true };
+
+  const parent = getParent(root, segments);
+  if (
+    !parent.exists ||
+    parent.value === null ||
+    typeof parent.value !== "object"
+  ) {
+    return { root, applied: false };
+  }
+
+  const segment = segments[segments.length - 1];
+  if (Array.isArray(parent.value)) {
+    const index = getArrayIndex(segment, parent.value.length);
+    if (index === undefined) return { root, applied: false };
+    parent.value.splice(index, 1);
+    return { root, applied: true };
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(parent.value, segment)) {
+    return { root, applied: false };
+  }
+  delete (parent.value as Record<string, unknown>)[segment];
+  return { root, applied: true };
+}
+
+function replaceValue(
+  root: unknown,
+  segments: string[],
+  value: unknown,
+): OperationResult {
+  if (segments.length === 0) {
+    return { root: cloneState(value), applied: true };
+  }
+
+  const parent = getParent(root, segments);
+  if (
+    !parent.exists ||
+    parent.value === null ||
+    typeof parent.value !== "object"
+  ) {
+    return { root, applied: false };
+  }
+
+  const segment = segments[segments.length - 1];
+  if (Array.isArray(parent.value)) {
+    const index = getArrayIndex(segment, parent.value.length);
+    if (index === undefined) return { root, applied: false };
+    parent.value[index] = cloneState(value);
+    return { root, applied: true };
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(parent.value, segment)) {
+    return { root, applied: false };
+  }
+  (parent.value as Record<string, unknown>)[segment] = cloneState(value);
+  return { root, applied: true };
+}
+
+function jsonValueEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (
+    left === null ||
+    right === null ||
+    typeof left !== "object" ||
+    typeof right !== "object"
+  ) {
+    return false;
+  }
+  if (Array.isArray(left) !== Array.isArray(right)) return false;
+
+  const leftKeys = Object.keys(left as object);
+  const rightKeys = Object.keys(right as object);
+  if (leftKeys.length !== rightKeys.length) return false;
+
+  return leftKeys.every(
+    (key) =>
+      Object.prototype.hasOwnProperty.call(right, key) &&
+      jsonValueEqual(
+        (left as Record<string, unknown>)[key],
+        (right as Record<string, unknown>)[key],
+      ),
+  );
+}
+
+function applyStateDeltaOperation(
+  root: unknown,
+  operation: StateDeltaOperation,
+): OperationResult {
+  if (typeof operation.path !== "string") return { root, applied: false };
+
+  const path = parseJsonPointer(operation.path);
+  if (path === undefined) return { root, applied: false };
+
+  switch (operation.op) {
+    case "add":
+      return addValue(root, path, operation.value);
+    case "remove":
+      return removeValue(root, path);
+    case "replace":
+      return replaceValue(root, path, operation.value);
+    case "test": {
+      const actual = getJsonPointerValue(root, operation.path);
+      return {
+        root,
+        applied: actual.exists && jsonValueEqual(actual.value, operation.value),
+      };
+    }
+    case "copy": {
+      if (typeof operation.from !== "string") return { root, applied: false };
+      const source = getJsonPointerValue(root, operation.from);
+      if (!source.exists) return { root, applied: false };
+      return addValue(root, path, source.value);
+    }
+    case "move": {
+      if (typeof operation.from !== "string") return { root, applied: false };
+      const from = parseJsonPointer(operation.from);
+      if (from === undefined) return { root, applied: false };
+      const source = getJsonPointerValue(root, operation.from);
+      if (!source.exists) return { root, applied: false };
+      if (operation.from === operation.path) return { root, applied: true };
+
+      const nextRoot = cloneState(root);
+      const removed = removeValue(nextRoot, from);
+      if (!removed.applied) return { root, applied: false };
+      const added = addValue(removed.root, path, source.value);
+      return added.applied ? added : { root, applied: false };
+    }
+    default:
+      return { root, applied: false };
+  }
+}
+
+function normalizeStateDelta(
+  delta: unknown[],
+  initialState: unknown,
+): { delta: unknown[]; state: unknown } {
+  let state = cloneState(initialState);
+  const normalized: unknown[] = [];
+
+  for (const operation of delta) {
+    const candidate =
+      operation !== null && typeof operation === "object"
+        ? (operation as StateDeltaOperation)
+        : undefined;
+    if (
+      candidate?.op === "add" &&
+      typeof candidate.path === "string" &&
+      candidate.path.endsWith("/-")
+    ) {
+      const arrayPath = candidate.path.slice(0, -2);
+      const array = getJsonPointerValue(state, arrayPath);
+      if (!array.exists) {
+        const lastSlash = arrayPath.lastIndexOf("/");
+        const parentPath = lastSlash > 0 ? arrayPath.slice(0, lastSlash) : "";
+        if (getJsonPointerValue(state, parentPath).exists) {
+          const initializer: StateDeltaOperation = {
+            op: "add",
+            path: arrayPath,
+            value: [],
+          };
+          const applied = applyStateDeltaOperation(state, initializer);
+          if (applied.applied) {
+            normalized.push(initializer);
+            state = applied.root;
+          }
+        }
+      }
+    }
+
+    normalized.push(operation);
+    if (candidate) {
+      const applied = applyStateDeltaOperation(state, candidate);
+      if (applied.applied) state = applied.root;
+    }
+  }
+
+  return { delta: normalized, state };
+}
+
+export function createStateEventNormalizer(
+  initialState: unknown,
+): (event: BaseEvent) => BaseEvent[] {
+  let state = cloneState(initialState);
+  let hasEmittedState = false;
+
+  return (event) => {
+    if (event.type === EventType.STATE_SNAPSHOT) {
+      state = cloneState((event as StateSnapshotEvent).snapshot);
+      hasEmittedState = true;
+      return [event];
+    }
+
+    if (event.type !== EventType.STATE_DELTA) return [event];
+
+    const stateDeltaEvent = event as StateDeltaEvent;
+    const initialSnapshot: StateSnapshotEvent[] =
+      !hasEmittedState && initialState !== undefined
+        ? [
+            {
+              type: EventType.STATE_SNAPSHOT,
+              snapshot: cloneState(state),
+            },
+          ]
+        : [];
+    const normalized = Array.isArray(stateDeltaEvent.delta)
+      ? normalizeStateDelta(stateDeltaEvent.delta, state)
+      : { delta: stateDeltaEvent.delta, state };
+    state = normalized.state;
+    hasEmittedState = true;
+
+    return [
+      ...initialSnapshot,
+      {
+        ...stateDeltaEvent,
+        delta: normalized.delta as StateDeltaEvent["delta"],
+      },
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

`AGUISendStateDelta` can emit an array append against a state where the target array has not been initialized. The emitted patch then fails during event compaction with `OPERATION_PATH_CANNOT_ADD`.

This change keeps the authoritative state represented in emitted events, initializes a missing array immediately before its first `/-` append, and applies the same contract across the generic, AI SDK, and TanStack state-delta paths. Existing arrays and valid deltas retain their current contents and operation order.

Closes https://github.com/CopilotKit/CopilotKit/issues/5998

## Changes

- Emit the input state before the first delta when no earlier state event represents it
- Initialize a missing array before normalized classic, AI SDK, and TanStack state deltas append through `/-`; custom raw-event mode remains outside this normalizer
- Preserve populated arrays and already-valid patch operations
- Preserve caller-owned state when structured cloning falls back
- Cover missing-array reconstruction, sibling converters, failure guards, and existing-array preservation
- Follow the current `release.config.json` and Nx release convention; no Changeset file is added.

## Test plan

- [x] `pnpm -C packages/runtime exec vitest run src/agent/__tests__/state-tools.test.ts src/agent/__tests__/converter-aisdk.test.ts src/agent/__tests__/converter-tanstack.test.ts`
- [x] `pnpm -C packages/runtime exec vitest run`
- [x] `pnpm exec nx run @copilotkit/runtime:check-types`
- [x] `pnpm exec oxfmt --check` on changed runtime files
- [x] `pnpm exec oxlint` on changed runtime files, zero errors with two pre-existing no-shadow warnings
- [x] Verify no `.changeset` file is added because current main uses Nx release
- [x] Verify the final diff contains only the private helper, runtime implementation, sibling converters, and focused tests

