### PR TITLE
fix(core): keep exactly one tool result per tool call across message snapshots

### DIFF
--- a/packages/core/src/__tests__/state-manager-tool-result-history.test.ts
+++ b/packages/core/src/__tests__/state-manager-tool-result-history.test.ts
@@ -1,0 +1,378 @@
+import { describe, expect, it } from "vitest";
+import { AbstractAgent, EventType } from "@ag-ui/client";
+import type { BaseEvent, Message, RunAgentInput } from "@ag-ui/client";
+import { from, throwError } from "rxjs";
+import type { Observable } from "rxjs";
+import { CopilotKitCore } from "../core";
+
+const threadId = "thread-tool-history";
+const toolCallId = "call-weather";
+
+class ScriptedWeatherAgent extends AbstractAgent {
+  readonly inputs: RunAgentInput[] = [];
+  secondTurnError?: string;
+
+  constructor(
+    private readonly staleSnapshot = true,
+    private readonly failSecondTurnBeforeStart = false,
+  ) {
+    super({
+      agentId: "weather",
+      threadId,
+      initialMessages: [
+        { id: "user-1", role: "user", content: "What is the weather?" },
+      ],
+    });
+  }
+
+  run(input: RunAgentInput): Observable<BaseEvent> {
+    this.inputs.push(input);
+    if (this.inputs.length === 2) {
+      if (this.failSecondTurnBeforeStart) {
+        this.secondTurnError = "401 Unauthorized";
+        return throwError(() => new Error(this.secondTurnError));
+      }
+      if (
+        !input.messages.some(
+          (message) =>
+            message.role === "tool" && message.toolCallId === toolCallId,
+        )
+      ) {
+        this.secondTurnError =
+          "400 Bad Request: missing tool result for call-weather";
+        return throwError(() => new Error(this.secondTurnError));
+      }
+      return from([
+        { type: EventType.RUN_STARTED, threadId, runId: input.runId },
+        { type: EventType.RUN_FINISHED, threadId, runId: input.runId },
+      ] as BaseEvent[]);
+    }
+
+    const owner: Message = {
+      id: "assistant-weather",
+      role: "assistant",
+      content: "",
+      toolCalls: [
+        {
+          id: toolCallId,
+          type: "function",
+          function: { name: "get_weather", arguments: "{}" },
+        },
+      ],
+    };
+    const events: BaseEvent[] = [
+      { type: EventType.RUN_STARTED, threadId, runId: input.runId },
+      {
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: "get_weather",
+        parentMessageId: owner.id,
+      },
+      { type: EventType.TOOL_CALL_END, toolCallId },
+      {
+        type: EventType.TOOL_CALL_RESULT,
+        messageId: "result-weather",
+        toolCallId,
+        content: "72 degrees and sunny",
+        role: "tool",
+      },
+    ];
+    if (this.staleSnapshot) {
+      events.push({
+        type: EventType.MESSAGES_SNAPSHOT,
+        messages: [
+          { id: "user-1", role: "user", content: "What is the weather?" },
+          owner,
+        ],
+      });
+    }
+    events.push({ type: EventType.RUN_FINISHED, threadId, runId: input.runId });
+    return from(events);
+  }
+}
+
+class ScenarioAgent extends AbstractAgent {
+  constructor(
+    agentId: string,
+    initialMessages: Message[],
+    private readonly events: BaseEvent[],
+  ) {
+    super({ agentId, threadId: `${agentId}-thread`, initialMessages });
+  }
+
+  run(input: RunAgentInput): Observable<BaseEvent> {
+    return from(
+      this.events.map((event) =>
+        event.type === EventType.RUN_STARTED ||
+        event.type === EventType.RUN_FINISHED
+          ? { ...event, runId: input.runId, threadId: this.threadId }
+          : event,
+      ),
+    );
+  }
+}
+
+const owner = (id: string, callId: string) => ({
+  id,
+  role: "assistant" as const,
+  content: "",
+  toolCalls: [
+    {
+      id: callId,
+      type: "function" as const,
+      function: { name: "tool", arguments: "{}" },
+    },
+  ],
+});
+
+const result = (messageId: string, callId: string, content = "result") => ({
+  type: EventType.TOOL_CALL_RESULT as const,
+  messageId,
+  toolCallId: callId,
+  content,
+  role: "tool" as const,
+});
+
+async function addAgent(
+  core: CopilotKitCore,
+  agent: AbstractAgent,
+): Promise<void> {
+  core.addAgent__unsafe_dev_only({ id: agent.agentId!, agent });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("StateManager tool result history", () => {
+  it("preserves the result in a real runAgent second turn", async () => {
+    const agent = new ScriptedWeatherAgent();
+    const core = new CopilotKitCore({});
+    await addAgent(core, agent);
+
+    await core.runAgent({ agent });
+    await expect(core.runAgent({ agent })).resolves.toBeDefined();
+
+    expect(agent.secondTurnError).toBeUndefined();
+    expect(
+      agent.inputs[1]?.messages.filter(
+        (message) =>
+          message.role === "tool" && message.toolCallId === toolCallId,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("returns a terminal messages mutation through the real apply pipeline", async () => {
+    const seen: Message[][] = [];
+    const agent = new ScriptedWeatherAgent();
+    agent.subscribe({
+      onMessagesChanged: ({ messages }) => {
+        seen.push([...messages]);
+      },
+    });
+    const core = new CopilotKitCore({});
+    await addAgent(core, agent);
+
+    await core.runAgent({ agent });
+
+    expect(seen.at(-1)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "result-weather", toolCallId }),
+      ]),
+    );
+  });
+
+  it("preserves normal result delivery and removes duplicate identities", async () => {
+    const callId = "call-duplicate";
+    const agent = new ScenarioAgent(
+      "duplicate",
+      [owner("assistant-duplicate", callId)],
+      [
+        {
+          type: EventType.RUN_STARTED,
+          threadId: "duplicate-thread",
+          runId: "x",
+        },
+        result("result-a", callId, "a"),
+        result("result-a", callId, "a"),
+        {
+          type: EventType.RUN_FINISHED,
+          threadId: "duplicate-thread",
+          runId: "x",
+        },
+      ],
+    );
+    const core = new CopilotKitCore({});
+    await addAgent(core, agent);
+    await core.runAgent({ agent });
+
+    expect(
+      agent.messages.filter(
+        (message) => message.role === "tool" && message.toolCallId === callId,
+      ),
+    ).toEqual([expect.objectContaining({ id: "result-a", content: "a" })]);
+  });
+
+  it("replaces an already materialized frontend placeholder", async () => {
+    const callId = "call-placeholder";
+    const agent = new ScenarioAgent(
+      "placeholder",
+      [
+        owner("assistant-placeholder", callId),
+        {
+          id: "placeholder-result",
+          role: "tool",
+          toolCallId: callId,
+          content: "Forwarded to client",
+        },
+      ],
+      [
+        {
+          type: EventType.RUN_STARTED,
+          threadId: "placeholder-thread",
+          runId: "x",
+        },
+        result("canonical-result", callId, "canonical"),
+        {
+          type: EventType.RUN_FINISHED,
+          threadId: "placeholder-thread",
+          runId: "x",
+        },
+      ],
+    );
+    const core = new CopilotKitCore({});
+    await addAgent(core, agent);
+    await core.runAgent({ agent });
+
+    expect(
+      agent.messages.filter(
+        (message) => message.role === "tool" && message.toolCallId === callId,
+      ),
+    ).toEqual([
+      expect.objectContaining({ id: "canonical-result", content: "canonical" }),
+    ]);
+  });
+
+  it("reconciles a RUN_ERROR terminal and clears provenance at finalization", async () => {
+    const callId = "call-error";
+    const agent = new ScenarioAgent(
+      "error-terminal",
+      [owner("assistant-error", callId)],
+      [
+        {
+          type: EventType.RUN_STARTED,
+          threadId: "error-terminal-thread",
+          runId: "x",
+        },
+        result("error-result", callId, "recovered after error"),
+        {
+          type: EventType.MESSAGES_SNAPSHOT,
+          messages: [owner("assistant-error", callId)],
+        },
+        {
+          type: EventType.RUN_ERROR,
+          threadId: "error-terminal-thread",
+          runId: "x",
+          message: "backend failed",
+          code: "backend_error",
+        },
+      ],
+    );
+    const core = new CopilotKitCore({});
+    await addAgent(core, agent);
+    await core.runAgent({ agent });
+
+    expect(agent.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "error-result",
+          content: "recovered after error",
+        }),
+      ]),
+    );
+  });
+
+  it("does not add a StateManager-owned result without an assistant owner", async () => {
+    const callId = "call-ownerless";
+    const agent = new ScenarioAgent(
+      "ownerless",
+      [],
+      [
+        {
+          type: EventType.RUN_STARTED,
+          threadId: "ownerless-thread",
+          runId: "x",
+        },
+        result("ownerless-result", callId),
+        {
+          type: EventType.RUN_FINISHED,
+          threadId: "ownerless-thread",
+          runId: "x",
+        },
+      ],
+    );
+    const core = new CopilotKitCore({});
+    await addAgent(core, agent);
+    await core.runAgent({ agent });
+
+    expect(
+      agent.messages.filter((message) => message.id === "ownerless-result"),
+    ).toHaveLength(1);
+  });
+
+  it("keeps distinct result identities from one input and cleans provenance at finalization", async () => {
+    const callId = "call-repeated-a";
+    const secondCallId = "call-repeated-b";
+    const agent = new ScenarioAgent(
+      "repeated",
+      [
+        {
+          ...owner("assistant-repeated", callId),
+          toolCalls: [
+            ...owner("assistant-repeated", callId).toolCalls!,
+            ...owner("assistant-repeated-2", secondCallId).toolCalls!,
+          ],
+        },
+      ],
+      [
+        {
+          type: EventType.RUN_STARTED,
+          threadId: "repeated-thread",
+          runId: "x",
+        },
+        result("result-shared", callId, "one"),
+        result("result-shared", secondCallId, "two"),
+        {
+          type: EventType.MESSAGES_SNAPSHOT,
+          messages: [
+            {
+              ...owner("assistant-repeated", callId),
+              toolCalls: [
+                ...owner("assistant-repeated", callId).toolCalls!,
+                ...owner("assistant-repeated-2", secondCallId).toolCalls!,
+              ],
+            },
+          ],
+        },
+        {
+          type: EventType.RUN_FINISHED,
+          threadId: "repeated-thread",
+          runId: "x",
+        },
+      ],
+    );
+    const core = new CopilotKitCore({});
+    await addAgent(core, agent);
+    await core.runAgent({ agent });
+
+    expect(
+      agent.messages.filter((message) => message.role === "tool"),
+    ).toHaveLength(2);
+  });
+
+  it("uses the failed input when a run fails before RUN_STARTED", async () => {
+    const agent = new ScriptedWeatherAgent(false, true);
+    const core = new CopilotKitCore({});
+    await addAgent(core, agent);
+    await core.runAgent({ agent });
+    await expect(core.runAgent({ agent })).resolves.toBeDefined();
+    expect(agent.inputs[1]?.runId).toBeDefined();
+  });
+});

--- a/packages/core/src/__tests__/state-manager-tool-result-history.test.ts
+++ b/packages/core/src/__tests__/state-manager-tool-result-history.test.ts
@@ -210,6 +210,7 @@ describe("StateManager tool result history", () => {
       [owner("assistant-weather", callId)],
       [
         { type: EventType.RUN_STARTED, threadId: "x", runId: "x" },
+        result("72192d78-8458-4e31-a03f-eddbcc88ed58", callId, "72 and sunny"),
         {
           type: EventType.MESSAGES_SNAPSHOT,
           messages: [
@@ -222,7 +223,6 @@ describe("StateManager tool result history", () => {
             },
           ],
         },
-        result("72192d78-8458-4e31-a03f-eddbcc88ed58", callId, "72 and sunny"),
         { type: EventType.RUN_FINISHED, threadId: "x", runId: "x" },
       ],
     );

--- a/packages/core/src/__tests__/state-manager-tool-result-history.test.ts
+++ b/packages/core/src/__tests__/state-manager-tool-result-history.test.ts
@@ -294,7 +294,7 @@ describe("StateManager tool result history", () => {
     ).toBe(agent.inputs[0]?.runId);
   });
 
-  it("does not classify a real multi-part result as a frontend placeholder", async () => {
+  it("preserves a real multi-part result beside a distinct canonical result", async () => {
     const callId = "call-multipart";
     const agent = new ScenarioAgent(
       "multipart",
@@ -326,21 +326,34 @@ describe("StateManager tool result history", () => {
     );
     const core = new CopilotKitCore({});
     await addAgent(core, agent);
+    let deliveredToLaterSubscriber = 0;
+    agent.subscribe({
+      onToolCallResultEvent: () => {
+        deliveredToLaterSubscriber++;
+      },
+    });
     await core.runAgent({ agent });
 
     expect(
       agent.messages.filter(
         (message) => message.role === "tool" && message.toolCallId === callId,
       ),
-    ).toEqual([
-      expect.objectContaining({
-        id: "existing-multipart-result",
-        content: [
-          { type: "text", text: "Forwarded to client" },
-          " plus more",
-        ] as unknown as string,
-      }),
-    ]);
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "existing-multipart-result",
+          content: [
+            { type: "text", text: "Forwarded to client" },
+            " plus more",
+          ] as unknown as string,
+        }),
+        expect.objectContaining({
+          id: "multipart-result",
+          content: "canonical",
+        }),
+      ]),
+    );
+    expect(deliveredToLaterSubscriber).toBe(1);
   });
 
   it("reconciles a RUN_ERROR terminal and clears provenance at finalization", async () => {
@@ -415,38 +428,21 @@ describe("StateManager tool result history", () => {
   });
 
   it("keeps distinct result identities from one input and cleans provenance at finalization", async () => {
-    const callId = "call-repeated-a";
-    const secondCallId = "call-repeated-b";
+    const callId = "call-repeated";
     const agent = new ScenarioAgent(
       "repeated",
-      [
-        {
-          ...owner("assistant-repeated", callId),
-          toolCalls: [
-            ...owner("assistant-repeated", callId).toolCalls!,
-            ...owner("assistant-repeated-2", secondCallId).toolCalls!,
-          ],
-        },
-      ],
+      [owner("assistant-repeated", callId)],
       [
         {
           type: EventType.RUN_STARTED,
           threadId: "repeated-thread",
           runId: "x",
         },
-        result("result-shared", callId, "one"),
-        result("result-shared", secondCallId, "two"),
+        result("result-shared-1", callId, "one"),
+        result("result-shared-2", callId, "two"),
         {
           type: EventType.MESSAGES_SNAPSHOT,
-          messages: [
-            {
-              ...owner("assistant-repeated", callId),
-              toolCalls: [
-                ...owner("assistant-repeated", callId).toolCalls!,
-                ...owner("assistant-repeated-2", secondCallId).toolCalls!,
-              ],
-            },
-          ],
+          messages: [owner("assistant-repeated", callId)],
         },
         {
           type: EventType.RUN_FINISHED,
@@ -459,9 +455,12 @@ describe("StateManager tool result history", () => {
     await addAgent(core, agent);
     await core.runAgent({ agent });
 
-    expect(
-      agent.messages.filter((message) => message.role === "tool"),
-    ).toHaveLength(2);
+    expect(agent.messages.filter((message) => message.role === "tool")).toEqual(
+      [
+        expect.objectContaining({ id: "result-shared-1", content: "one" }),
+        expect.objectContaining({ id: "result-shared-2", content: "two" }),
+      ],
+    );
   });
 
   it("keeps the previous active run when a different input errors before RUN_STARTED", async () => {

--- a/packages/core/src/__tests__/state-manager-tool-result-history.test.ts
+++ b/packages/core/src/__tests__/state-manager-tool-result-history.test.ts
@@ -395,6 +395,44 @@ describe("StateManager tool result history", () => {
     );
   });
 
+  it("does not reconcile a finalized input's old result provenance", async () => {
+    const agent = new ScriptedWeatherAgent();
+    const core = new CopilotKitCore({});
+    await addAgent(core, agent);
+    await core.runAgent({ agent });
+
+    const stateManagerSubscriber = (
+      agent as unknown as {
+        subscribers: Array<{
+          onRunFinishedEvent?: (params: unknown) => unknown;
+          onRunFinalized?: (params: unknown) => unknown;
+        }>;
+      }
+    ).subscribers.find(
+      (subscriber) =>
+        subscriber.onRunFinishedEvent && subscriber.onRunFinalized,
+    );
+    expect(stateManagerSubscriber).toBeDefined();
+
+    const input = agent.inputs[0]!;
+    const messagesWithoutResult = agent.messages.filter(
+      (message) => message.id !== "result-weather",
+    );
+    const mutation = stateManagerSubscriber!.onRunFinishedEvent!({
+      input,
+      messages: messagesWithoutResult,
+      state: {},
+      agent,
+      event: {
+        type: EventType.RUN_FINISHED,
+        threadId,
+        runId: input.runId,
+      },
+    });
+
+    expect(mutation).toBeUndefined();
+  });
+
   it("does not add a StateManager-owned result without an assistant owner", async () => {
     const callId = "call-ownerless";
     const agent = new ScenarioAgent(

--- a/packages/core/src/__tests__/state-manager-tool-result-history.test.ts
+++ b/packages/core/src/__tests__/state-manager-tool-result-history.test.ts
@@ -92,6 +92,8 @@ class ScriptedWeatherAgent extends AbstractAgent {
 }
 
 class ScenarioAgent extends AbstractAgent {
+  readonly inputs: RunAgentInput[] = [];
+
   constructor(
     agentId: string,
     initialMessages: Message[],
@@ -101,6 +103,7 @@ class ScenarioAgent extends AbstractAgent {
   }
 
   run(input: RunAgentInput): Observable<BaseEvent> {
+    this.inputs.push(input);
     return from(
       this.events.map((event) =>
         event.type === EventType.RUN_STARTED ||
@@ -109,6 +112,37 @@ class ScenarioAgent extends AbstractAgent {
           : event,
       ),
     );
+  }
+}
+
+class PreStartRunErrorAgent extends AbstractAgent {
+  readonly inputs: RunAgentInput[] = [];
+
+  constructor() {
+    super({ agentId: "pre-start-error", threadId: "pre-start-thread" });
+  }
+
+  run(input: RunAgentInput): Observable<BaseEvent> {
+    this.inputs.push(input);
+    if (this.inputs.length === 1) {
+      return from([
+        {
+          type: EventType.RUN_STARTED,
+          threadId: this.threadId,
+          runId: input.runId,
+        },
+      ] as BaseEvent[]);
+    }
+
+    return from([
+      {
+        type: EventType.RUN_ERROR,
+        threadId: this.threadId,
+        runId: input.runId,
+        message: "failed before start",
+        code: "pre_start_failure",
+      },
+    ] as BaseEvent[]);
   }
 }
 
@@ -208,6 +242,9 @@ describe("StateManager tool result history", () => {
         (message) => message.role === "tool" && message.toolCallId === callId,
       ),
     ).toEqual([expect.objectContaining({ id: "result-a", content: "a" })]);
+    expect(
+      core.getRunIdForMessage("duplicate", "duplicate-thread", "result-a"),
+    ).toBe(agent.inputs[0]?.runId);
   });
 
   it("replaces an already materialized frontend placeholder", async () => {
@@ -247,6 +284,62 @@ describe("StateManager tool result history", () => {
       ),
     ).toEqual([
       expect.objectContaining({ id: "canonical-result", content: "canonical" }),
+    ]);
+    expect(
+      core.getRunIdForMessage(
+        "placeholder",
+        "placeholder-thread",
+        "canonical-result",
+      ),
+    ).toBe(agent.inputs[0]?.runId);
+  });
+
+  it("does not classify a real multi-part result as a frontend placeholder", async () => {
+    const callId = "call-multipart";
+    const agent = new ScenarioAgent(
+      "multipart",
+      [
+        owner("assistant-multipart", callId),
+        {
+          id: "existing-multipart-result",
+          role: "tool",
+          toolCallId: callId,
+          content: [
+            { type: "text", text: "Forwarded to client" },
+            " plus more",
+          ],
+        } as unknown as Message,
+      ],
+      [
+        {
+          type: EventType.RUN_STARTED,
+          threadId: "multipart-thread",
+          runId: "x",
+        },
+        result("multipart-result", callId, "canonical"),
+        {
+          type: EventType.RUN_FINISHED,
+          threadId: "multipart-thread",
+          runId: "x",
+        },
+      ],
+    );
+    const core = new CopilotKitCore({});
+    await addAgent(core, agent);
+    await core.runAgent({ agent });
+
+    expect(
+      agent.messages.filter(
+        (message) => message.role === "tool" && message.toolCallId === callId,
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        id: "existing-multipart-result",
+        content: [
+          { type: "text", text: "Forwarded to client" },
+          " plus more",
+        ] as unknown as string,
+      }),
     ]);
   });
 
@@ -302,6 +395,10 @@ describe("StateManager tool result history", () => {
         },
         result("ownerless-result", callId),
         {
+          type: EventType.MESSAGES_SNAPSHOT,
+          messages: [],
+        },
+        {
           type: EventType.RUN_FINISHED,
           threadId: "ownerless-thread",
           runId: "x",
@@ -314,7 +411,7 @@ describe("StateManager tool result history", () => {
 
     expect(
       agent.messages.filter((message) => message.id === "ownerless-result"),
-    ).toHaveLength(1);
+    ).toHaveLength(0);
   });
 
   it("keeps distinct result identities from one input and cleans provenance at finalization", async () => {
@@ -367,12 +464,24 @@ describe("StateManager tool result history", () => {
     ).toHaveLength(2);
   });
 
-  it("uses the failed input when a run fails before RUN_STARTED", async () => {
-    const agent = new ScriptedWeatherAgent(false, true);
+  it("keeps the previous active run when a different input errors before RUN_STARTED", async () => {
+    const agent = new PreStartRunErrorAgent();
     const core = new CopilotKitCore({});
     await addAgent(core, agent);
     await core.runAgent({ agent });
     await expect(core.runAgent({ agent })).resolves.toBeDefined();
-    expect(agent.inputs[1]?.runId).toBeDefined();
+
+    agent.addMessage({
+      id: "after-pre-start-error",
+      role: "user",
+      content: "still active",
+    });
+    expect(
+      core.getRunIdForMessage(
+        "pre-start-error",
+        "pre-start-thread",
+        "after-pre-start-error",
+      ),
+    ).toBe(agent.inputs[0]?.runId);
   });
 });

--- a/packages/core/src/__tests__/state-manager-tool-result-history.test.ts
+++ b/packages/core/src/__tests__/state-manager-tool-result-history.test.ts
@@ -213,6 +213,52 @@ describe("StateManager tool result history", () => {
     );
   });
 
+  it("keeps the checkpoint result when LangGraph uses divergent message ids", async () => {
+    const callId = "call_weather_1";
+    const checkpointId = "lc-tool-1";
+    const agent = new ScenarioAgent(
+      "langgraph",
+      [owner("assistant-weather", callId)],
+      [
+        { type: EventType.RUN_STARTED, threadId: "x", runId: "x" },
+        result("72192d78-8458-4e31-a03f-eddbcc88ed58", callId, "72 and sunny"),
+        {
+          type: EventType.MESSAGES_SNAPSHOT,
+          messages: [
+            owner("assistant-weather", callId),
+            {
+              id: checkpointId,
+              role: "tool",
+              toolCallId: callId,
+              content: "72 and sunny",
+            },
+          ],
+        },
+        { type: EventType.RUN_FINISHED, threadId: "x", runId: "x" },
+      ],
+    );
+    const core = new CopilotKitCore({});
+    await addAgent(core, agent);
+    await core.runAgent({ agent });
+    await core.runAgent({ agent });
+
+    expect(
+      agent.messages.filter(
+        (message) => message.role === "tool" && message.toolCallId === callId,
+      ),
+    ).toEqual([
+      expect.objectContaining({ id: checkpointId, content: "72 and sunny" }),
+    ]);
+    expect(
+      agent.inputs[1]?.messages.filter(
+        (message) => message.role === "tool" && message.toolCallId === callId,
+      ),
+    ).toHaveLength(1);
+    expect(
+      core.getRunIdForMessage("langgraph", "langgraph-thread", checkpointId),
+    ).toBe(agent.inputs[1]?.runId);
+  });
+
   it("preserves normal result delivery and removes duplicate identities", async () => {
     const callId = "call-duplicate";
     const agent = new ScenarioAgent(
@@ -225,7 +271,7 @@ describe("StateManager tool result history", () => {
           runId: "x",
         },
         result("result-a", callId, "a"),
-        result("result-a", callId, "a"),
+        result("result-b", callId, "b"),
         {
           type: EventType.RUN_FINISHED,
           threadId: "duplicate-thread",
@@ -235,6 +281,8 @@ describe("StateManager tool result history", () => {
     );
     const core = new CopilotKitCore({});
     await addAgent(core, agent);
+    let delivered = 0;
+    agent.subscribe({ onToolCallResultEvent: () => void delivered++ });
     await core.runAgent({ agent });
 
     expect(
@@ -245,6 +293,7 @@ describe("StateManager tool result history", () => {
     expect(
       core.getRunIdForMessage("duplicate", "duplicate-thread", "result-a"),
     ).toBe(agent.inputs[0]?.runId);
+    expect(delivered).toBe(2);
   });
 
   it("replaces an already materialized frontend placeholder", async () => {
@@ -294,7 +343,7 @@ describe("StateManager tool result history", () => {
     ).toBe(agent.inputs[0]?.runId);
   });
 
-  it("preserves a real multi-part result beside a distinct canonical result", async () => {
+  it("removes a placeholder beside an existing real result", async () => {
     const callId = "call-multipart";
     const agent = new ScenarioAgent(
       "multipart",
@@ -304,10 +353,7 @@ describe("StateManager tool result history", () => {
           id: "existing-multipart-result",
           role: "tool",
           toolCallId: callId,
-          content: [
-            { type: "text", text: "Forwarded to client" },
-            " plus more",
-          ],
+          content: "Forwarded to client",
         } as unknown as Message,
       ],
       [
@@ -316,7 +362,7 @@ describe("StateManager tool result history", () => {
           threadId: "multipart-thread",
           runId: "x",
         },
-        result("multipart-result", callId, "canonical"),
+        result("real-result", callId, "canonical"),
         {
           type: EventType.RUN_FINISHED,
           threadId: "multipart-thread",
@@ -326,34 +372,15 @@ describe("StateManager tool result history", () => {
     );
     const core = new CopilotKitCore({});
     await addAgent(core, agent);
-    let deliveredToLaterSubscriber = 0;
-    agent.subscribe({
-      onToolCallResultEvent: () => {
-        deliveredToLaterSubscriber++;
-      },
-    });
     await core.runAgent({ agent });
 
     expect(
       agent.messages.filter(
         (message) => message.role === "tool" && message.toolCallId === callId,
       ),
-    ).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: "existing-multipart-result",
-          content: [
-            { type: "text", text: "Forwarded to client" },
-            " plus more",
-          ] as unknown as string,
-        }),
-        expect.objectContaining({
-          id: "multipart-result",
-          content: "canonical",
-        }),
-      ]),
-    );
-    expect(deliveredToLaterSubscriber).toBe(1);
+    ).toEqual([
+      expect.objectContaining({ id: "real-result", content: "canonical" }),
+    ]);
   });
 
   it("reconciles a RUN_ERROR terminal and clears provenance at finalization", async () => {
@@ -395,44 +422,6 @@ describe("StateManager tool result history", () => {
     );
   });
 
-  it("does not reconcile a finalized input's old result provenance", async () => {
-    const agent = new ScriptedWeatherAgent();
-    const core = new CopilotKitCore({});
-    await addAgent(core, agent);
-    await core.runAgent({ agent });
-
-    const stateManagerSubscriber = (
-      agent as unknown as {
-        subscribers: Array<{
-          onRunFinishedEvent?: (params: unknown) => unknown;
-          onRunFinalized?: (params: unknown) => unknown;
-        }>;
-      }
-    ).subscribers.find(
-      (subscriber) =>
-        subscriber.onRunFinishedEvent && subscriber.onRunFinalized,
-    );
-    expect(stateManagerSubscriber).toBeDefined();
-
-    const input = agent.inputs[0]!;
-    const messagesWithoutResult = agent.messages.filter(
-      (message) => message.id !== "result-weather",
-    );
-    const mutation = stateManagerSubscriber!.onRunFinishedEvent!({
-      input,
-      messages: messagesWithoutResult,
-      state: {},
-      agent,
-      event: {
-        type: EventType.RUN_FINISHED,
-        threadId,
-        runId: input.runId,
-      },
-    });
-
-    expect(mutation).toBeUndefined();
-  });
-
   it("does not add a StateManager-owned result without an assistant owner", async () => {
     const callId = "call-ownerless";
     const agent = new ScenarioAgent(
@@ -465,23 +454,26 @@ describe("StateManager tool result history", () => {
     ).toHaveLength(0);
   });
 
-  it("keeps distinct result identities from one input and cleans provenance at finalization", async () => {
-    const callId = "call-repeated";
+  it("does not churn a live placeholder for a forwarded-to-client event", async () => {
+    const callId = "call-forwarded";
     const agent = new ScenarioAgent(
-      "repeated",
-      [owner("assistant-repeated", callId)],
+      "forwarded",
+      [
+        owner("assistant-forwarded", callId),
+        {
+          id: "placeholder",
+          role: "tool",
+          toolCallId: callId,
+          content: "Forwarded to client",
+        },
+      ],
       [
         {
           type: EventType.RUN_STARTED,
           threadId: "repeated-thread",
           runId: "x",
         },
-        result("result-shared-1", callId, "one"),
-        result("result-shared-2", callId, "two"),
-        {
-          type: EventType.MESSAGES_SNAPSHOT,
-          messages: [owner("assistant-repeated", callId)],
-        },
+        result("new-id", callId, "Forwarded to client"),
         {
           type: EventType.RUN_FINISHED,
           threadId: "repeated-thread",
@@ -493,12 +485,16 @@ describe("StateManager tool result history", () => {
     await addAgent(core, agent);
     await core.runAgent({ agent });
 
-    expect(agent.messages.filter((message) => message.role === "tool")).toEqual(
-      [
-        expect.objectContaining({ id: "result-shared-1", content: "one" }),
-        expect.objectContaining({ id: "result-shared-2", content: "two" }),
-      ],
-    );
+    expect(
+      agent.messages.filter(
+        (message) => message.role === "tool" && message.toolCallId === callId,
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        id: "placeholder",
+        content: "Forwarded to client",
+      }),
+    ]);
   });
 
   it("keeps the previous active run when a different input errors before RUN_STARTED", async () => {

--- a/packages/core/src/__tests__/state-manager-tool-result-history.test.ts
+++ b/packages/core/src/__tests__/state-manager-tool-result-history.test.ts
@@ -146,17 +146,56 @@ class PreStartRunErrorAgent extends AbstractAgent {
   }
 }
 
-const owner = (id: string, callId: string) => ({
+class ReusedRunErrorAgent extends AbstractAgent {
+  readonly inputs: RunAgentInput[] = [];
+
+  constructor() {
+    super({ agentId: "reused-run-error", threadId: "reused-run-thread" });
+  }
+
+  run(input: RunAgentInput): Observable<BaseEvent> {
+    this.inputs.push(input);
+    const events: BaseEvent[] =
+      this.inputs.length === 1
+        ? [
+            {
+              type: EventType.RUN_STARTED,
+              threadId: this.threadId,
+              runId: input.runId,
+            },
+            {
+              type: EventType.RUN_FINISHED,
+              threadId: this.threadId,
+              runId: input.runId,
+            },
+          ]
+        : [
+            {
+              type: EventType.RUN_STARTED,
+              threadId: this.threadId,
+              runId: input.runId,
+            },
+            {
+              type: EventType.RUN_ERROR,
+              threadId: this.threadId,
+              runId: input.runId,
+              message: "backend failed",
+              code: "backend_error",
+            },
+          ];
+    return from(events);
+  }
+}
+
+const owner = (id: string, ...callIds: string[]) => ({
   id,
   role: "assistant" as const,
   content: "",
-  toolCalls: [
-    {
-      id: callId,
-      type: "function" as const,
-      function: { name: "tool", arguments: "{}" },
-    },
-  ],
+  toolCalls: callIds.map((callId) => ({
+    id: callId,
+    type: "function" as const,
+    function: { name: "tool", arguments: "{}" },
+  })),
 });
 
 const result = (messageId: string, callId: string, content = "result") => ({
@@ -296,6 +335,45 @@ describe("StateManager tool result history", () => {
     expect(delivered).toBe(2);
   });
 
+  it("restores multiple tool results after their assistant owner", async () => {
+    const firstCallId = "call-first";
+    const secondCallId = "call-second";
+    const agent = new ScenarioAgent(
+      "siblings",
+      [owner("assistant-siblings", firstCallId, secondCallId)],
+      [
+        {
+          type: EventType.RUN_STARTED,
+          threadId: "siblings-thread",
+          runId: "x",
+        },
+        result("first-result", firstCallId, "first"),
+        result("second-result", secondCallId, "second"),
+        {
+          type: EventType.MESSAGES_SNAPSHOT,
+          messages: [owner("assistant-siblings", firstCallId, secondCallId)],
+        },
+        {
+          type: EventType.RUN_FINISHED,
+          threadId: "siblings-thread",
+          runId: "x",
+        },
+      ],
+    );
+    const core = new CopilotKitCore({});
+    await addAgent(core, agent);
+    await core.runAgent({ agent });
+
+    expect(
+      agent.messages
+        .filter((message) => message.role === "tool")
+        .map((message) => [message.toolCallId, message.content]),
+    ).toEqual([
+      [firstCallId, "first"],
+      [secondCallId, "second"],
+    ]);
+  });
+
   it("replaces an already materialized frontend placeholder", async () => {
     const callId = "call-placeholder";
     const agent = new ScenarioAgent(
@@ -420,6 +498,45 @@ describe("StateManager tool result history", () => {
         }),
       ]),
     );
+  });
+
+  it("clears the remapped active run after a reused-id RUN_ERROR", async () => {
+    const agent = new ReusedRunErrorAgent();
+    const core = new CopilotKitCore({});
+    await addAgent(core, agent);
+
+    await core.runAgent({ agent, runId: "reused-run" });
+    await core.runAgent({ agent, runId: "reused-run" });
+
+    agent.addMessage({
+      id: "after-reused-error",
+      role: "user",
+      content: "not assigned to the failed run",
+    });
+    expect(
+      core.getRunIdForMessage(
+        "reused-run-error",
+        "reused-run-thread",
+        "after-reused-error",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("reconciles and finalizes a local run failure", async () => {
+    const agent = new ScriptedWeatherAgent(false, true);
+    const core = new CopilotKitCore({});
+    await addAgent(core, agent);
+
+    await core.runAgent({ agent });
+    await expect(core.runAgent({ agent })).resolves.toBeDefined();
+    expect(agent.secondTurnError).toBe("401 Unauthorized");
+
+    expect(
+      agent.messages.filter(
+        (message) =>
+          message.role === "tool" && message.toolCallId === toolCallId,
+      ),
+    ).toHaveLength(1);
   });
 
   it("does not add a StateManager-owned result without an assistant owner", async () => {

--- a/packages/core/src/__tests__/state-manager-tool-result-history.test.ts
+++ b/packages/core/src/__tests__/state-manager-tool-result-history.test.ts
@@ -202,7 +202,7 @@ describe("StateManager tool result history", () => {
     );
   });
 
-  it("keeps one checkpoint result when LangGraph uses divergent message ids", async () => {
+  it("keeps one result when LangGraph uses divergent message ids", async () => {
     const callId = "call_weather_1";
     const checkpointId = "lc-tool-1";
     const agent = new ScenarioAgent(
@@ -217,6 +217,12 @@ describe("StateManager tool result history", () => {
             owner("assistant-weather", callId),
             {
               id: checkpointId,
+              role: "tool",
+              toolCallId: callId,
+              content: "72 and sunny",
+            },
+            {
+              id: "72192d78-8458-4e31-a03f-eddbcc88ed58",
               role: "tool",
               toolCallId: callId,
               content: "72 and sunny",
@@ -236,7 +242,10 @@ describe("StateManager tool result history", () => {
         (message) => message.role === "tool" && message.toolCallId === callId,
       ),
     ).toEqual([
-      expect.objectContaining({ id: checkpointId, content: "72 and sunny" }),
+      expect.objectContaining({
+        toolCallId: callId,
+        content: "72 and sunny",
+      }),
     ]);
     expect(
       agent.inputs[1]?.messages.filter(
@@ -246,6 +255,34 @@ describe("StateManager tool result history", () => {
     expect(
       core.getRunIdForMessage("langgraph", "langgraph-thread", checkpointId),
     ).toBe(agent.inputs[0]?.runId);
+  });
+
+  it("does not replay a prior result across server runs in one input", async () => {
+    const callId = "call-multirun";
+    const agent = new ScenarioAgent(
+      "multirun",
+      [owner("assistant-multirun", callId)],
+      [
+        { type: EventType.RUN_STARTED, threadId: "x", runId: "x" },
+        result("run-one-result", callId, "first run"),
+        { type: EventType.RUN_FINISHED, threadId: "x", runId: "x" },
+        { type: EventType.RUN_STARTED, threadId: "x", runId: "x" },
+        {
+          type: EventType.MESSAGES_SNAPSHOT,
+          messages: [owner("assistant-multirun", callId)],
+        },
+        { type: EventType.RUN_FINISHED, threadId: "x", runId: "x" },
+      ],
+    );
+    const core = new CopilotKitCore({});
+    await addAgent(core, agent);
+    await core.runAgent({ agent });
+
+    expect(
+      agent.messages.filter(
+        (message) => message.role === "tool" && message.toolCallId === callId,
+      ),
+    ).toHaveLength(0);
   });
 
   it("preserves normal result delivery and removes duplicate identities", async () => {

--- a/packages/core/src/__tests__/state-manager-tool-result-history.test.ts
+++ b/packages/core/src/__tests__/state-manager-tool-result-history.test.ts
@@ -115,11 +115,11 @@ class ScenarioAgent extends AbstractAgent {
   }
 }
 
-class PreStartRunErrorAgent extends AbstractAgent {
+class LocalFailureBeforeStartAgent extends AbstractAgent {
   readonly inputs: RunAgentInput[] = [];
 
   constructor() {
-    super({ agentId: "pre-start-error", threadId: "pre-start-thread" });
+    super({ agentId: "local-failure", threadId: "local-failure-thread" });
   }
 
   run(input: RunAgentInput): Observable<BaseEvent> {
@@ -133,57 +133,7 @@ class PreStartRunErrorAgent extends AbstractAgent {
         },
       ] as BaseEvent[]);
     }
-
-    return from([
-      {
-        type: EventType.RUN_ERROR,
-        threadId: this.threadId,
-        runId: input.runId,
-        message: "failed before start",
-        code: "pre_start_failure",
-      },
-    ] as BaseEvent[]);
-  }
-}
-
-class ReusedRunErrorAgent extends AbstractAgent {
-  readonly inputs: RunAgentInput[] = [];
-
-  constructor() {
-    super({ agentId: "reused-run-error", threadId: "reused-run-thread" });
-  }
-
-  run(input: RunAgentInput): Observable<BaseEvent> {
-    this.inputs.push(input);
-    const events: BaseEvent[] =
-      this.inputs.length === 1
-        ? [
-            {
-              type: EventType.RUN_STARTED,
-              threadId: this.threadId,
-              runId: input.runId,
-            },
-            {
-              type: EventType.RUN_FINISHED,
-              threadId: this.threadId,
-              runId: input.runId,
-            },
-          ]
-        : [
-            {
-              type: EventType.RUN_STARTED,
-              threadId: this.threadId,
-              runId: input.runId,
-            },
-            {
-              type: EventType.RUN_ERROR,
-              threadId: this.threadId,
-              runId: input.runId,
-              message: "backend failed",
-              code: "backend_error",
-            },
-          ];
-    return from(events);
+    return throwError(() => new Error("local failure before start"));
   }
 }
 
@@ -252,7 +202,7 @@ describe("StateManager tool result history", () => {
     );
   });
 
-  it("keeps the checkpoint result when LangGraph uses divergent message ids", async () => {
+  it("keeps one checkpoint result when LangGraph uses divergent message ids", async () => {
     const callId = "call_weather_1";
     const checkpointId = "lc-tool-1";
     const agent = new ScenarioAgent(
@@ -260,7 +210,6 @@ describe("StateManager tool result history", () => {
       [owner("assistant-weather", callId)],
       [
         { type: EventType.RUN_STARTED, threadId: "x", runId: "x" },
-        result("72192d78-8458-4e31-a03f-eddbcc88ed58", callId, "72 and sunny"),
         {
           type: EventType.MESSAGES_SNAPSHOT,
           messages: [
@@ -273,6 +222,7 @@ describe("StateManager tool result history", () => {
             },
           ],
         },
+        result("72192d78-8458-4e31-a03f-eddbcc88ed58", callId, "72 and sunny"),
         { type: EventType.RUN_FINISHED, threadId: "x", runId: "x" },
       ],
     );
@@ -295,7 +245,7 @@ describe("StateManager tool result history", () => {
     ).toHaveLength(1);
     expect(
       core.getRunIdForMessage("langgraph", "langgraph-thread", checkpointId),
-    ).toBe(agent.inputs[1]?.runId);
+    ).toBe(agent.inputs[0]?.runId);
   });
 
   it("preserves normal result delivery and removes duplicate identities", async () => {
@@ -421,6 +371,53 @@ describe("StateManager tool result history", () => {
     ).toBe(agent.inputs[0]?.runId);
   });
 
+  it("promotes a placeholder retained by a later snapshot", async () => {
+    const callId = "call-snapshot-placeholder";
+    const agent = new ScenarioAgent(
+      "snapshot-placeholder",
+      [owner("assistant-snapshot-placeholder", callId)],
+      [
+        {
+          type: EventType.RUN_STARTED,
+          threadId: "snapshot-placeholder-thread",
+          runId: "x",
+        },
+        result("snapshot-canonical", callId, "canonical"),
+        {
+          type: EventType.MESSAGES_SNAPSHOT,
+          messages: [
+            owner("assistant-snapshot-placeholder", callId),
+            {
+              id: "snapshot-placeholder-result",
+              role: "tool",
+              toolCallId: callId,
+              content: "Forwarded to client",
+            },
+          ],
+        },
+        {
+          type: EventType.RUN_FINISHED,
+          threadId: "snapshot-placeholder-thread",
+          runId: "x",
+        },
+      ],
+    );
+    const core = new CopilotKitCore({});
+    await addAgent(core, agent);
+    await core.runAgent({ agent });
+
+    expect(
+      agent.messages.filter(
+        (message) => message.role === "tool" && message.toolCallId === callId,
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        id: "snapshot-canonical",
+        content: "canonical",
+      }),
+    ]);
+  });
+
   it("removes a placeholder beside an existing real result", async () => {
     const callId = "call-multipart";
     const agent = new ScenarioAgent(
@@ -500,28 +497,6 @@ describe("StateManager tool result history", () => {
     );
   });
 
-  it("clears the remapped active run after a reused-id RUN_ERROR", async () => {
-    const agent = new ReusedRunErrorAgent();
-    const core = new CopilotKitCore({});
-    await addAgent(core, agent);
-
-    await core.runAgent({ agent, runId: "reused-run" });
-    await core.runAgent({ agent, runId: "reused-run" });
-
-    agent.addMessage({
-      id: "after-reused-error",
-      role: "user",
-      content: "not assigned to the failed run",
-    });
-    expect(
-      core.getRunIdForMessage(
-        "reused-run-error",
-        "reused-run-thread",
-        "after-reused-error",
-      ),
-    ).toBeUndefined();
-  });
-
   it("reconciles and finalizes a local run failure", async () => {
     const agent = new ScriptedWeatherAgent(false, true);
     const core = new CopilotKitCore({});
@@ -537,6 +512,28 @@ describe("StateManager tool result history", () => {
           message.role === "tool" && message.toolCallId === toolCallId,
       ),
     ).toHaveLength(1);
+  });
+
+  it("keeps active ownership through a pre-start local failure", async () => {
+    const agent = new LocalFailureBeforeStartAgent();
+    const core = new CopilotKitCore({});
+    await addAgent(core, agent);
+
+    await core.runAgent({ agent });
+    await expect(core.runAgent({ agent })).resolves.toBeDefined();
+
+    agent.addMessage({
+      id: "after-local-failure",
+      role: "user",
+      content: "still active",
+    });
+    expect(
+      core.getRunIdForMessage(
+        "local-failure",
+        "local-failure-thread",
+        "after-local-failure",
+      ),
+    ).toBe(agent.inputs[0]?.runId);
   });
 
   it("does not add a StateManager-owned result without an assistant owner", async () => {
@@ -612,26 +609,5 @@ describe("StateManager tool result history", () => {
         content: "Forwarded to client",
       }),
     ]);
-  });
-
-  it("keeps the previous active run when a different input errors before RUN_STARTED", async () => {
-    const agent = new PreStartRunErrorAgent();
-    const core = new CopilotKitCore({});
-    await addAgent(core, agent);
-    await core.runAgent({ agent });
-    await expect(core.runAgent({ agent })).resolves.toBeDefined();
-
-    agent.addMessage({
-      id: "after-pre-start-error",
-      role: "user",
-      content: "still active",
-    });
-    expect(
-      core.getRunIdForMessage(
-        "pre-start-error",
-        "pre-start-thread",
-        "after-pre-start-error",
-      ),
-    ).toBe(agent.inputs[0]?.runId);
   });
 });

--- a/packages/core/src/__tests__/tool-result-content.test.ts
+++ b/packages/core/src/__tests__/tool-result-content.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  FORWARDED_TO_CLIENT,
+  isForwardedToClientPlaceholder,
+  normalizeToolResultContent,
+} from "../core/tool-result-content";
+
+describe("tool result content", () => {
+  it.each([
+    FORWARDED_TO_CLIENT,
+    ` ${FORWARDED_TO_CLIENT} `,
+    ["Forwarded", { text: " to client " }],
+    { text: FORWARDED_TO_CLIENT },
+  ])("recognizes forwarded-to-client content: %j", (content) => {
+    expect(normalizeToolResultContent(content)).toBe(FORWARDED_TO_CLIENT);
+    expect(isForwardedToClientPlaceholder(content)).toBe(true);
+  });
+
+  it.each(["", "other", [], ["", { text: "" }], { text: "" }, 42, null])(
+    "does not recognize real or empty content: %j",
+    (content) => {
+      expect(isForwardedToClientPlaceholder(content)).toBe(false);
+    },
+  );
+});

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -14,6 +14,7 @@ import { CopilotKitCoreErrorCode } from "./core";
 import { AgentThreadLockedError } from "../intelligence-agent";
 import type { FrontendTool } from "../types";
 import type { CopilotKitCoreContinuationHandoff } from "./state-manager";
+import { isForwardedToClientPlaceholder } from "./tool-result-content";
 
 export interface CopilotKitCoreRunAgentParams {
   agent: AbstractAgent;
@@ -710,50 +711,9 @@ export class RunHandler {
   }
 
   private isFrontendPlaceholderResult(message: Message): boolean {
-    if (message.role !== "tool") {
-      return false;
-    }
-
-    const normalized = this.normalizeToolResultContent(message.content);
-    return normalized === "Forwarded to client";
-  }
-
-  private normalizeToolResultContent(content: unknown): string | null {
-    if (typeof content === "string") {
-      return content.trim();
-    }
-
-    if (Array.isArray(content)) {
-      const text = content
-        .flatMap((part) => {
-          if (typeof part === "string") {
-            return [part];
-          }
-          if (
-            part &&
-            typeof part === "object" &&
-            "text" in part &&
-            typeof (part as { text?: unknown }).text === "string"
-          ) {
-            return [(part as { text: string }).text];
-          }
-          return [];
-        })
-        .join("")
-        .trim();
-      return text.length > 0 ? text : null;
-    }
-
-    if (
-      content &&
-      typeof content === "object" &&
-      "text" in content &&
-      typeof (content as { text?: unknown }).text === "string"
-    ) {
-      return (content as { text: string }).text.trim();
-    }
-
-    return null;
+    return (
+      message.role === "tool" && isForwardedToClientPlaceholder(message.content)
+    );
   }
 
   /**

--- a/packages/core/src/core/state-manager.ts
+++ b/packages/core/src/core/state-manager.ts
@@ -12,6 +12,7 @@ import type {
 } from "@ag-ui/client";
 import { randomUUID, structuredClone_ } from "@ag-ui/client";
 import type { CopilotKitCore } from "./core";
+import { isForwardedToClientPlaceholder } from "./tool-result-content";
 
 const isContinuation = (input: RunAgentInput): boolean =>
   input.resume !== undefined ||
@@ -19,43 +20,6 @@ const isContinuation = (input: RunAgentInput): boolean =>
     (input.forwardedProps as { command?: object } | undefined)?.command ?? {},
     "resume",
   );
-
-const normalizeToolResultContent = (content: unknown): string | null => {
-  if (typeof content === "string") return content.trim();
-
-  if (Array.isArray(content)) {
-    const text = content
-      .flatMap((part) => {
-        if (typeof part === "string") return [part];
-        if (
-          part &&
-          typeof part === "object" &&
-          "text" in part &&
-          typeof (part as { text?: unknown }).text === "string"
-        ) {
-          return [(part as { text: string }).text];
-        }
-        return [];
-      })
-      .join("")
-      .trim();
-    return text.length > 0 ? text : null;
-  }
-
-  if (
-    content &&
-    typeof content === "object" &&
-    "text" in content &&
-    typeof (content as { text?: unknown }).text === "string"
-  ) {
-    return (content as { text: string }).text.trim();
-  }
-
-  return null;
-};
-
-const isForwardedToClientPlaceholder = (content: unknown): boolean =>
-  normalizeToolResultContent(content) === "Forwarded to client";
 
 export interface CopilotKitCoreContinuationHandoff {
   cancel(): void;
@@ -189,6 +153,7 @@ export class StateManager {
       if (!events) return undefined;
 
       const messages = [...historyMessages];
+      const insertedResultIds = new Set<string>();
       let changed = false;
 
       for (const event of events.values()) {
@@ -213,9 +178,6 @@ export class StateManager {
           },
           [],
         );
-        const exactIndex = matchingIndexes.find(
-          (index) => messages[index]?.id === event.messageId,
-        );
         const realIndex = matchingIndexes.find(
           (index) => !isForwardedToClientPlaceholder(messages[index]?.content),
         );
@@ -224,14 +186,7 @@ export class StateManager {
         );
         if (realIndex !== undefined && !realResultWasReconciled) {
           for (const duplicateIndex of matchingIndexes
-            .filter(
-              (candidateIndex) =>
-                candidateIndex !== exactIndex &&
-                (messages[candidateIndex]?.id === event.messageId ||
-                  isForwardedToClientPlaceholder(
-                    messages[candidateIndex]?.content,
-                  )),
-            )
+            .filter((candidateIndex) => candidateIndex !== realIndex)
             .sort((a, b) => b - a)) {
             messages.splice(duplicateIndex, 1);
             changed = true;
@@ -243,6 +198,15 @@ export class StateManager {
           isForwardedToClientPlaceholder(messages[index]?.content),
         );
         if (placeholderIndex !== undefined) {
+          if (isForwardedToClientPlaceholder(event.content)) {
+            for (const duplicateIndex of matchingIndexes
+              .slice(1)
+              .sort((a, b) => b - a)) {
+              messages.splice(duplicateIndex, 1);
+              changed = true;
+            }
+            continue;
+          }
           messages[placeholderIndex] = {
             ...messages[placeholderIndex],
             id: event.messageId,
@@ -272,6 +236,7 @@ export class StateManager {
         let insertIndex = ownerIndex + 1;
         while (messages[insertIndex]?.role === "tool") insertIndex++;
         messages.splice(insertIndex, 0, result);
+        insertedResultIds.add(result.id);
         changed = true;
       }
 

--- a/packages/core/src/core/state-manager.ts
+++ b/packages/core/src/core/state-manager.ts
@@ -7,6 +7,8 @@ import type {
   StateDeltaEvent,
   MessagesSnapshotEvent,
   TextMessageStartEvent,
+  ToolCallResultEvent,
+  ToolMessage,
 } from "@ag-ui/client";
 import { randomUUID, structuredClone_ } from "@ag-ui/client";
 import type { CopilotKitCore } from "./core";
@@ -17,6 +19,17 @@ const isContinuation = (input: RunAgentInput): boolean =>
     (input.forwardedProps as { command?: object } | undefined)?.command ?? {},
     "resume",
   );
+
+const isForwardedToClientPlaceholder = (content: unknown): boolean =>
+  content === "Forwarded to client" ||
+  (Array.isArray(content) &&
+    content.some(
+      (part) =>
+        typeof part === "object" &&
+        part !== null &&
+        "text" in part &&
+        (part as { text?: unknown }).text === "Forwarded to client",
+    ));
 
 export interface CopilotKitCoreContinuationHandoff {
   cancel(): void;
@@ -137,6 +150,115 @@ export class StateManager {
     let revoked = false;
     let subRunId: string | undefined; // runId assigned to the current logical run
     let runFinished = false; // true after RUN_FINISHED, reset on next RUN_STARTED
+    const pendingResults = new WeakMap<
+      RunAgentInput,
+      Map<string, ToolCallResultEvent>
+    >();
+
+    const reconcilePendingResults = (
+      historyMessages: readonly Message[],
+      input: RunAgentInput,
+    ): { messages: Message[] } | undefined => {
+      const events = pendingResults.get(input);
+      if (!events) return undefined;
+
+      const messages = [...historyMessages];
+      const insertedResultIds = new Set<string>();
+      let changed = false;
+
+      for (const event of events.values()) {
+        const ownerIndex = messages.findIndex(
+          (message) =>
+            message.role === "assistant" &&
+            message.toolCalls?.some(
+              (toolCall) => toolCall.id === event.toolCallId,
+            ),
+        );
+        if (ownerIndex < 0) continue;
+
+        const matchingIndexes = messages.reduce<number[]>(
+          (indexes, message, index) => {
+            if (
+              message.role === "tool" &&
+              message.toolCallId === event.toolCallId
+            ) {
+              indexes.push(index);
+            }
+            return indexes;
+          },
+          [],
+        );
+        const exactIndex = matchingIndexes.find(
+          (index) => messages[index]?.id === event.messageId,
+        );
+        if (exactIndex !== undefined) {
+          const duplicateIndexes = matchingIndexes.filter(
+            (index) => index !== exactIndex,
+          );
+          for (const index of duplicateIndexes.sort((a, b) => b - a)) {
+            messages.splice(index, 1);
+            changed = true;
+          }
+          continue;
+        }
+
+        const realIndex = matchingIndexes.find(
+          (index) => !isForwardedToClientPlaceholder(messages[index]?.content),
+        );
+        const realResultWasReconciled = matchingIndexes.some((index) =>
+          insertedResultIds.has(messages[index]?.id ?? ""),
+        );
+        if (realIndex !== undefined && !realResultWasReconciled) {
+          for (const duplicateIndex of matchingIndexes
+            .filter((candidateIndex) => candidateIndex !== realIndex)
+            .sort((a, b) => b - a)) {
+            messages.splice(duplicateIndex, 1);
+            changed = true;
+          }
+          continue;
+        }
+
+        const placeholderIndex = matchingIndexes[0];
+        if (placeholderIndex !== undefined) {
+          messages[placeholderIndex] = {
+            ...messages[placeholderIndex],
+            id: event.messageId,
+            content: event.content,
+          } as ToolMessage;
+          changed = true;
+          for (const duplicateIndex of matchingIndexes
+            .filter((candidateIndex) => candidateIndex !== placeholderIndex)
+            .sort((a, b) => b - a)) {
+            messages.splice(duplicateIndex, 1);
+          }
+          continue;
+        }
+
+        const result: ToolMessage = {
+          id: event.messageId,
+          role: "tool",
+          toolCallId: event.toolCallId,
+          content: event.content,
+        };
+        let insertIndex = ownerIndex + 1;
+        while (messages[insertIndex]?.role === "tool") insertIndex++;
+        messages.splice(insertIndex, 0, result);
+        insertedResultIds.add(result.id);
+        changed = true;
+        this.associateMessageWithRun(
+          agentId,
+          input.threadId,
+          result.id,
+          input.runId,
+        );
+      }
+
+      return changed ? { messages } : undefined;
+    };
+
+    const clearPendingResults = (input: RunAgentInput): void => {
+      pendingResults.delete(input);
+    };
 
     const effectiveInput = (input: RunAgentInput): RunAgentInput => ({
       ...input,
@@ -177,16 +299,39 @@ export class StateManager {
         runFinished = false;
         this.handleRunStarted(agent, effectiveInput(input), state);
       },
-      onRunFinishedEvent: ({ input, state }) => {
+      onRunFinishedEvent: ({ input, state, messages }) => {
         if (revoked) return;
         runFinished = true;
-        this.handleRunFinished(agent, effectiveInput(input), state);
+        const effective = effectiveInput(input);
+        const mutation = reconcilePendingResults(messages, input);
+        this.handleRunFinished(agent, effective, state);
+        return mutation;
       },
       // A run error terminates the run — treat identically to finished for cleanup
-      onRunErrorEvent: ({ input, state }) => {
+      onRunErrorEvent: ({ input, state, messages }) => {
         if (revoked) return;
         runFinished = true;
-        this.handleRunFinished(agent, effectiveInput(input), state);
+        const effective = effectiveInput(input);
+        const mutation = reconcilePendingResults(messages, input);
+        this.handleRunFinished(agent, effective, state);
+        return mutation;
+      },
+      onRunFailed: ({ input, messages }) => {
+        if (revoked) return;
+        return reconcilePendingResults(messages, input);
+      },
+      onRunFinalized: ({ input }) => {
+        if (revoked) return;
+        clearPendingResults(input);
+      },
+      onToolCallResultEvent: ({ event, input, messages }) => {
+        if (revoked) return;
+        let events = pendingResults.get(input);
+        if (!events) {
+          events = new Map();
+          pendingResults.set(input, events);
+        }
+        events.set(event.toolCallId, event);
       },
       onStateSnapshotEvent: ({ event, input, state }) => {
         if (revoked) return;
@@ -419,7 +564,7 @@ export class StateManager {
     agent: AbstractAgent,
     event: MessagesSnapshotEvent,
     input: RunAgentInput,
-    messages: readonly Message[],
+    _messages: readonly Message[],
   ): void {
     if (!agent.agentId) return;
 

--- a/packages/core/src/core/state-manager.ts
+++ b/packages/core/src/core/state-manager.ts
@@ -153,7 +153,6 @@ export class StateManager {
       if (!events) return undefined;
 
       const messages = [...historyMessages];
-      const insertedResultIds = new Set<string>();
       let changed = false;
 
       for (const event of events.values()) {
@@ -181,10 +180,7 @@ export class StateManager {
         const realIndex = matchingIndexes.find(
           (index) => !isForwardedToClientPlaceholder(messages[index]?.content),
         );
-        const realResultWasReconciled = matchingIndexes.some((index) =>
-          insertedResultIds.has(messages[index]?.id ?? ""),
-        );
-        if (realIndex !== undefined && !realResultWasReconciled) {
+        if (realIndex !== undefined) {
           for (const duplicateIndex of matchingIndexes
             .filter((candidateIndex) => candidateIndex !== realIndex)
             .sort((a, b) => b - a)) {
@@ -236,7 +232,6 @@ export class StateManager {
         let insertIndex = ownerIndex + 1;
         while (messages[insertIndex]?.role === "tool") insertIndex++;
         messages.splice(insertIndex, 0, result);
-        insertedResultIds.add(result.id);
         changed = true;
       }
 
@@ -291,6 +286,7 @@ export class StateManager {
         runFinished = true;
         const effective = effectiveInput(input);
         const mutation = reconcilePendingResults(messages, input);
+        clearPendingResults(input);
         this.handleRunFinished(agent, effective, state);
         return mutation;
       },

--- a/packages/core/src/core/state-manager.ts
+++ b/packages/core/src/core/state-manager.ts
@@ -189,7 +189,6 @@ export class StateManager {
       if (!events) return undefined;
 
       const messages = [...historyMessages];
-      const insertedResultIds = new Set<string>();
       let changed = false;
 
       for (const event of events.values()) {
@@ -225,7 +224,14 @@ export class StateManager {
         );
         if (realIndex !== undefined && !realResultWasReconciled) {
           for (const duplicateIndex of matchingIndexes
-            .filter((candidateIndex) => candidateIndex !== realIndex)
+            .filter(
+              (candidateIndex) =>
+                candidateIndex !== exactIndex &&
+                (messages[candidateIndex]?.id === event.messageId ||
+                  isForwardedToClientPlaceholder(
+                    messages[candidateIndex]?.content,
+                  )),
+            )
             .sort((a, b) => b - a)) {
             messages.splice(duplicateIndex, 1);
             changed = true;
@@ -233,14 +239,9 @@ export class StateManager {
           continue;
         }
 
-        if (
-          exactIndex !== undefined &&
-          insertedResultIds.has(messages[exactIndex]?.id ?? "")
-        ) {
-          continue;
-        }
-
-        const placeholderIndex = matchingIndexes[0];
+        const placeholderIndex = matchingIndexes.find((index) =>
+          isForwardedToClientPlaceholder(messages[index]?.content),
+        );
         if (placeholderIndex !== undefined) {
           messages[placeholderIndex] = {
             ...messages[placeholderIndex],
@@ -249,7 +250,13 @@ export class StateManager {
           } as ToolMessage;
           changed = true;
           for (const duplicateIndex of matchingIndexes
-            .filter((candidateIndex) => candidateIndex !== placeholderIndex)
+            .filter(
+              (candidateIndex) =>
+                candidateIndex !== placeholderIndex &&
+                isForwardedToClientPlaceholder(
+                  messages[candidateIndex]?.content,
+                ),
+            )
             .sort((a, b) => b - a)) {
             messages.splice(duplicateIndex, 1);
           }
@@ -265,7 +272,6 @@ export class StateManager {
         let insertIndex = ownerIndex + 1;
         while (messages[insertIndex]?.role === "tool") insertIndex++;
         messages.splice(insertIndex, 0, result);
-        insertedResultIds.add(result.id);
         changed = true;
       }
 
@@ -340,7 +346,7 @@ export class StateManager {
         if (revoked) return;
         clearPendingResults(input);
       },
-      onToolCallResultEvent: ({ event, input, messages }) => {
+      onToolCallResultEvent: ({ event, input }) => {
         if (revoked) return;
         let events = pendingResults.get(input);
         if (!events) {

--- a/packages/core/src/core/state-manager.ts
+++ b/packages/core/src/core/state-manager.ts
@@ -20,16 +20,42 @@ const isContinuation = (input: RunAgentInput): boolean =>
     "resume",
   );
 
+const normalizeToolResultContent = (content: unknown): string | null => {
+  if (typeof content === "string") return content.trim();
+
+  if (Array.isArray(content)) {
+    const text = content
+      .flatMap((part) => {
+        if (typeof part === "string") return [part];
+        if (
+          part &&
+          typeof part === "object" &&
+          "text" in part &&
+          typeof (part as { text?: unknown }).text === "string"
+        ) {
+          return [(part as { text: string }).text];
+        }
+        return [];
+      })
+      .join("")
+      .trim();
+    return text.length > 0 ? text : null;
+  }
+
+  if (
+    content &&
+    typeof content === "object" &&
+    "text" in content &&
+    typeof (content as { text?: unknown }).text === "string"
+  ) {
+    return (content as { text: string }).text.trim();
+  }
+
+  return null;
+};
+
 const isForwardedToClientPlaceholder = (content: unknown): boolean =>
-  content === "Forwarded to client" ||
-  (Array.isArray(content) &&
-    content.some(
-      (part) =>
-        typeof part === "object" &&
-        part !== null &&
-        "text" in part &&
-        (part as { text?: unknown }).text === "Forwarded to client",
-    ));
+  normalizeToolResultContent(content) === "Forwarded to client";
 
 export interface CopilotKitCoreContinuationHandoff {
   cancel(): void;
@@ -191,17 +217,6 @@ export class StateManager {
         const exactIndex = matchingIndexes.find(
           (index) => messages[index]?.id === event.messageId,
         );
-        if (exactIndex !== undefined) {
-          const duplicateIndexes = matchingIndexes.filter(
-            (index) => index !== exactIndex,
-          );
-          for (const index of duplicateIndexes.sort((a, b) => b - a)) {
-            messages.splice(index, 1);
-            changed = true;
-          }
-          continue;
-        }
-
         const realIndex = matchingIndexes.find(
           (index) => !isForwardedToClientPlaceholder(messages[index]?.content),
         );
@@ -215,6 +230,13 @@ export class StateManager {
             messages.splice(duplicateIndex, 1);
             changed = true;
           }
+          continue;
+        }
+
+        if (
+          exactIndex !== undefined &&
+          insertedResultIds.has(messages[exactIndex]?.id ?? "")
+        ) {
           continue;
         }
 
@@ -245,12 +267,6 @@ export class StateManager {
         messages.splice(insertIndex, 0, result);
         insertedResultIds.add(result.id);
         changed = true;
-        this.associateMessageWithRun(
-          agentId,
-          input.threadId,
-          result.id,
-          input.runId,
-        );
       }
 
       return changed ? { messages } : undefined;

--- a/packages/core/src/core/tool-result-content.ts
+++ b/packages/core/src/core/tool-result-content.ts
@@ -1,0 +1,43 @@
+/**
+ * Single authority for the forwarded-to-client sentinel used by StateManager
+ * and RunHandler.
+ */
+export const FORWARDED_TO_CLIENT = "Forwarded to client";
+
+export function normalizeToolResultContent(content: unknown): string | null {
+  if (typeof content === "string") return content.trim();
+
+  if (Array.isArray(content)) {
+    const text = content
+      .flatMap((part) => {
+        if (typeof part === "string") return [part];
+        if (
+          part &&
+          typeof part === "object" &&
+          "text" in part &&
+          typeof (part as { text?: unknown }).text === "string"
+        ) {
+          return [(part as { text: string }).text];
+        }
+        return [];
+      })
+      .join("")
+      .trim();
+    return text.length > 0 ? text : null;
+  }
+
+  if (
+    content &&
+    typeof content === "object" &&
+    "text" in content &&
+    typeof (content as { text?: unknown }).text === "string"
+  ) {
+    return (content as { text: string }).text.trim();
+  }
+
+  return null;
+}
+
+export function isForwardedToClientPlaceholder(content: unknown): boolean {
+  return normalizeToolResultContent(content) === FORWARDED_TO_CLIENT;
+}

--- a/packages/react-native/src/components/CopilotChat.tsx
+++ b/packages/react-native/src/components/CopilotChat.tsx
@@ -180,8 +180,8 @@ function objectContentKey(content: object): string {
  * before inserting the tool message. Non-string content is only reachable from a
  * producer that skipped that validation — restored thread history, a non-SSE
  * transport, or app code casting on `addMessage`. Core hedges against exactly
- * that case too (`normalizeToolResultContent` in run-handler accepts `unknown`
- * and handles arrays of text parts), so this must not answer it with `""`:
+ * that case too (core accepts `unknown` content and handles arrays of text
+ * parts), so this must not answer it with `""`:
  * an empty string is a LEGITIMATE tool result, which makes a dropped result
  * indistinguishable from an empty one. Serialise faithfully — the same
  * representation core uses for non-string results — and warn in dev.


### PR DESCRIPTION
# fix(core): keep exactly one tool result per tool call across message snapshots

## Summary

When an agent emits a MESSAGES_SNAPSHOT, AG-UI merges it by message id and can drop a tool message that TOOL_CALL_RESULT created. The next turn then sends an assistant tool call without its paired result, which providers reject.

This PR records observed tool results for the current input and repairs history through AG-UI's returned-messages mutation channel. It keeps one tool message per toolCallId and composes with current main's first-seen message provenance.

## Root cause

@ag-ui/client applies events against its own cloned messages array. TOOL_CALL_RESULT creates a tool message and inserts it after its assistant owner. A later MESSAGES_SNAPSHOT is a replace-by-id merge, so a missing tool entry can remove that result. packages/core had no record of the result event, so there was nothing to restore it from.

## What changed

- StateManager records one ToolCallResultEvent per toolCallId on the current RunAgentInput. Events keep flowing through AG-UI's normal path.
- At RUN_FINISHED, RUN_ERROR, and onRunFailed, reconciliation returns a fresh message array only when a repair is needed. AG-UI applies it through its normal mutation chain.
- Pending results are released at each finished server-run boundary and at finalization, so a later server run under one input cannot resurrect a result removed by its snapshot.
- The "Forwarded to client" sentinel classifier now lives in one internal module used by StateManager and run-handler.ts.

## The reconciliation rule

toolCallId is the decisive identity:

- No assistant owner for the call: do nothing.
- A real tool message already exists for the call under any message id: keep one result and remove duplicate same-call representations.
- Only placeholders exist: promote one to the canonical result and drop the rest.
- Nothing exists: insert the result after its assistant owner and its contiguous tool messages.

## On the LangGraph duplicate

LangGraph can represent one result with different streamed and checkpoint message ids. The regression fixture keeps the streamed result before the snapshot and places both representations in the snapshot. The final history and next-turn input contain one result for that toolCallId.

Two tool messages for one toolCallId are one malformed history class. Keying reconciliation by toolCallId makes that duplicate unrepresentable while preserving normal event delivery.

## What this does not do

- No direct agent.messages mutation, setMessages from a subscriber, or stopPropagation. AG-UI remains the owner of message application, ordering, and publication.
- Reconciliation does not infer or rewrite run identity. Current main's event-derived run identity and first-seen snapshot provenance remain intact.
- No message-to-run association is performed inside reconciliation.
- No public API change, export, version bump, or changeset.

## Relationship to #3884

Related to #3884, but not marked as closing it. The event sequence in that issue has no MESSAGES_SNAPSHOT, and it already produces a correct turn-2 history on current main. Snapshot-dropped results are a real bug worth fixing independently, while the reporter's case still needs a raw event trace.

## Test plan

All cases drive CopilotKitCore.runAgent() against real AbstractAgent subclasses.

- Two-turn reproduction: a snapshot omits the result, and the next turn receives exactly one result.
- LangGraph shape: differing message ids under one toolCallId produce one surviving tool message in real event-before-snapshot order.
- Repeated server runs under one input do not resurrect a result removed by a later snapshot.
- Terminal mutation, normal result propagation, duplicate results, placeholders, ownerless results, ordering, RUN_ERROR, local failure, and run ownership remain covered.
- The focused core tests pass 32/32. Core typecheck, build, formatting, lint, and diff checks pass. CI checkboxes remain for GitHub.
