### PR TITLE
fix(react-core): rerender activity messages after ACTIVITY_DELTA

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -35,6 +35,7 @@ import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 import type { SlotValue } from "../../lib/slots";
 import { renderSlot, useShallowStableRef } from "../../lib/slots";
+import { getContentMemoKey } from "./content-memo-key";
 import {
   transcribeAudio,
   TranscriptionError,
@@ -88,6 +89,7 @@ export type CopilotChatProps = Omit<
    */
   throttleMs?: number;
 };
+
 export function CopilotChat({
   agentId,
   threadId,
@@ -974,20 +976,9 @@ export function CopilotChat({
     ? "processing"
     : transcribeMode;
 
-  // Memoize messages array — only create a new reference when content changes.
-  // We build a lightweight fingerprint instead of JSON.stringify to avoid
-  // serializing large base64 attachment data on every render. The key captures:
-  //   - message id, role, content length (text streaming)
-  //   - content part count (multimodal additions)
-  //   - tool call ids + argument lengths (tool call streaming)
   const messagesMemoKey = agent.messages
     .map((m) => {
-      const contentKey =
-        typeof m.content === "string"
-          ? m.content.length
-          : Array.isArray(m.content)
-            ? m.content.length
-            : 0;
+      const contentKey = getContentMemoKey(m.content);
       const toolCallsKey =
         "toolCalls" in m && Array.isArray(m.toolCalls)
           ? m.toolCalls
@@ -996,7 +987,8 @@ export function CopilotChat({
               )
               .join(";")
           : "";
-      return `${m.id}:${m.role}:${contentKey}:${toolCallsKey}`;
+      const activityType = "activityType" in m ? m.activityType : "";
+      return `${m.id}:${m.role}:${activityType}:${contentKey}:${toolCallsKey}`;
     })
     .join(",");
   const messages = useMemo(

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatToolRerenders.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatToolRerenders.e2e.test.tsx
@@ -9,26 +9,28 @@ import {
 import { z } from "zod";
 import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
 import { CopilotChat } from "../CopilotChat";
-import {
-  AbstractAgent,
-  EventType,
-  type BaseEvent,
-  type RunAgentInput,
-} from "@ag-ui/client";
-import { Observable, Subject } from "rxjs";
-import { defineToolCallRenderer, ReactToolCallRenderer } from "../../../types";
+import { AbstractAgent, EventType } from "@ag-ui/client";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
+import type { Observable } from "rxjs";
+import { Subject } from "rxjs";
+import type { ReactToolCallRenderer } from "../../../types";
+import { defineToolCallRenderer } from "../../../types";
 import { ToolCallStatus } from "@copilotkit/core";
 import { CopilotChatMessageView } from "../CopilotChatMessageView";
-import { CopilotChatView, CopilotChatViewProps } from "../CopilotChatView";
+import type { CopilotChatViewProps } from "../CopilotChatView";
+import { CopilotChatView } from "../CopilotChatView";
 import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
-import { ActivityMessage, AssistantMessage, Message } from "@ag-ui/core";
-import {
+import type { ActivityMessage, AssistantMessage, Message } from "@ag-ui/core";
+import type {
   ReactActivityMessageRenderer,
   ReactCustomMessageRenderer,
 } from "../../../types";
-import CopilotChatInput, { CopilotChatInputProps } from "../CopilotChatInput";
+import { testId } from "../../../__tests__/utils/test-helpers";
+import type { CopilotChatInputProps } from "../CopilotChatInput";
+import CopilotChatInput from "../CopilotChatInput";
 import { CopilotChatSuggestionView } from "../CopilotChatSuggestionView";
 import { CopilotChatAssistantMessage } from "../CopilotChatAssistantMessage";
+import { basicCatalog } from "@copilotkit/a2ui-renderer";
 
 // A controllable streaming agent to step through events deterministically
 class MockStepwiseAgent extends AbstractAgent {
@@ -1230,6 +1232,323 @@ describe("Activity Message Re-render Prevention", () => {
       status: "Processing",
       percent: 50,
     });
+  });
+
+  it("should re-render retained activity content after an ACTIVITY_DELTA", async () => {
+    const agent = new MockStepwiseAgent();
+    const activityMessageId = testId("a2ui-activity");
+    const surfaceId = testId("a2ui-surface");
+    const messageListRefs: Message[][] = [];
+    const initialOperations = [
+      {
+        version: "v0.9",
+        createSurface: {
+          surfaceId,
+          catalogId: "https://a2ui.org/specification/v0_9/basic_catalog.json",
+        },
+      },
+      {
+        version: "v0.9",
+        updateComponents: {
+          surfaceId,
+          components: [
+            {
+              id: "root",
+              component: "Text",
+              text: { path: "/title" },
+              variant: "body",
+            },
+          ],
+        },
+      },
+      {
+        version: "v0.9",
+        updateDataModel: {
+          surfaceId,
+          path: "/title",
+          value: "Initial activity",
+        },
+      },
+    ];
+    const MessageListBoundary: React.FC<CopilotChatViewProps> = (props) => {
+      messageListRefs.push(props.messages ?? []);
+      return <CopilotChatView {...props} />;
+    };
+
+    render(
+      <CopilotKitProvider
+        agents__unsafe_dev_only={{ default: agent }}
+        a2ui={{ catalog: basicCatalog }}
+      >
+        <div style={{ height: 400 }}>
+          <CopilotChat
+            chatView={MessageListBoundary as typeof CopilotChatView}
+          />
+        </div>
+      </CopilotKitProvider>,
+    );
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, { target: { value: "Show me the activity" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Show me the activity")).toBeDefined();
+    });
+
+    agent.emit({
+      type: EventType.RUN_STARTED,
+      input: {
+        messages: [
+          {
+            id: activityMessageId,
+            role: "activity",
+            activityType: "a2ui-surface",
+            content: { a2ui_operations: initialOperations },
+          },
+        ],
+      },
+    } as BaseEvent);
+    agent.emit({
+      type: EventType.STEP_STARTED,
+      stepName: "render",
+    } as BaseEvent);
+
+    await waitFor(() => {
+      expect(screen.getByText("Initial activity")).toBeDefined();
+    });
+
+    const initialMessageList = messageListRefs.at(-1);
+    const initialActivityMessage = initialMessageList?.find(
+      (message) => message.id === activityMessageId,
+    );
+    expect(initialActivityMessage?.content).toEqual({
+      a2ui_operations: initialOperations,
+    });
+
+    agent.emit({
+      type: EventType.ACTIVITY_DELTA,
+      messageId: activityMessageId,
+      activityType: "a2ui-surface",
+      patch: [
+        {
+          op: "add",
+          path: "/a2ui_operations/-",
+          value: {
+            version: "v0.9",
+            updateComponents: {
+              surfaceId,
+              components: [
+                {
+                  id: "root",
+                  component: "Text",
+                  text: { path: "/title" },
+                  variant: "body",
+                },
+              ],
+            },
+          },
+        },
+        {
+          op: "add",
+          path: "/a2ui_operations/-",
+          value: {
+            version: "v0.9",
+            updateDataModel: {
+              surfaceId,
+              path: "/title",
+              value: "Updated activity",
+            },
+          },
+        },
+      ],
+    } as BaseEvent);
+
+    await waitFor(() => {
+      expect(screen.getByText("Updated activity")).toBeDefined();
+      const updatedActivityMessage = messageListRefs
+        .at(-1)
+        ?.find((message) => message.id === activityMessageId);
+      expect(updatedActivityMessage?.content).toEqual({
+        a2ui_operations: [
+          ...initialOperations,
+          {
+            version: "v0.9",
+            updateComponents: {
+              surfaceId,
+              components: [
+                {
+                  id: "root",
+                  component: "Text",
+                  text: { path: "/title" },
+                  variant: "body",
+                },
+              ],
+            },
+          },
+          {
+            version: "v0.9",
+            updateDataModel: {
+              surfaceId,
+              path: "/title",
+              value: "Updated activity",
+            },
+          },
+        ],
+      });
+    });
+
+    expect(messageListRefs.at(-1)).not.toBe(initialMessageList);
+
+    agent.emit({
+      type: EventType.STEP_FINISHED,
+      stepName: "render",
+    } as BaseEvent);
+    agent.emit({ type: EventType.RUN_FINISHED } as BaseEvent);
+  });
+
+  it("should switch a retained activity renderer when ACTIVITY_DELTA changes activityType", async () => {
+    const agent = new MockStepwiseAgent();
+    const activityMessageId = "retained-activity-type-1";
+    const renderActivityMessages: ReactActivityMessageRenderer<{
+      status: string;
+    }>[] = [
+      {
+        activityType: "progress",
+        content: z.object({ status: z.string() }),
+        render: ({ content }) => (
+          <div data-testid="retained-activity-type">
+            progress:{content.status}
+          </div>
+        ),
+      },
+      {
+        activityType: "complete",
+        content: z.object({ status: z.string() }),
+        render: ({ content }) => (
+          <div data-testid="retained-activity-type">
+            complete:{content.status}
+          </div>
+        ),
+      },
+    ];
+
+    render(
+      <CopilotKitProvider
+        agents__unsafe_dev_only={{ default: agent }}
+        renderActivityMessages={renderActivityMessages}
+      >
+        <CopilotChat />
+      </CopilotKitProvider>,
+    );
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, {
+      target: { value: "Show the retained activity" },
+    });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Show the retained activity")).toBeDefined();
+    });
+
+    agent.emit({
+      type: EventType.RUN_STARTED,
+      input: {
+        messages: [
+          {
+            id: activityMessageId,
+            role: "activity",
+            activityType: "progress",
+            content: { status: "Stable" },
+          },
+        ],
+      },
+    } as BaseEvent);
+    agent.emit({
+      type: EventType.STEP_STARTED,
+      stepName: "render",
+    } as BaseEvent);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("retained-activity-type").textContent).toBe(
+        "progress:Stable",
+      );
+    });
+
+    agent.emit({
+      type: EventType.ACTIVITY_DELTA,
+      messageId: activityMessageId,
+      activityType: "complete",
+      patch: [],
+    } as BaseEvent);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("retained-activity-type").textContent).toBe(
+        "complete:Stable",
+      );
+    });
+
+    agent.emit({
+      type: EventType.STEP_FINISHED,
+      stepName: "render",
+    } as BaseEvent);
+    agent.emit({ type: EventType.RUN_FINISHED } as BaseEvent);
+  });
+
+  it("keeps unchanged serializable activity content memoized at the CopilotChat boundary", async () => {
+    const agent = new MockStepwiseAgent();
+    const messageListRefs: Message[][] = [];
+    const MessageListBoundary = ({ messages }: CopilotChatViewProps) => {
+      messageListRefs.push(messages ?? []);
+      return <div data-testid="message-list-boundary" />;
+    };
+    const renderChat = () => (
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <CopilotChat chatView={MessageListBoundary as typeof CopilotChatView} />
+      </CopilotKitProvider>
+    );
+
+    const { rerender } = render(renderChat());
+    act(() => {
+      agent.addMessages([
+        {
+          id: "stable-activity-1",
+          role: "activity",
+          activityType: "stable-activity",
+          content: { nested: { b: 2, a: 1 }, status: "Stable" },
+        } as ActivityMessage,
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(messageListRefs.at(-1)?.[0]?.id).toBe("stable-activity-1");
+    });
+    const initialMessageList = messageListRefs.at(-1);
+    const initialBoundaryRenderCount = messageListRefs.length;
+
+    act(() => {
+      agent.setMessages([
+        {
+          id: "stable-activity-1",
+          role: "activity",
+          activityType: "stable-activity",
+          content: { status: "Stable", nested: { a: 1, b: 2 } },
+        } as ActivityMessage,
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(agent.messages[0]?.content).toEqual({
+        status: "Stable",
+        nested: { a: 1, b: 2 },
+      });
+    });
+
+    rerender(renderChat());
+
+    expect(messageListRefs.length).toBe(initialBoundaryRenderCount);
+    expect(messageListRefs.at(-1)).toBe(initialMessageList);
   });
 
   it("should re-render an activity message when its activityType changes", async () => {

--- a/packages/react-core/src/v2/components/chat/content-memo-key.ts
+++ b/packages/react-core/src/v2/components/chat/content-memo-key.ts
@@ -1,0 +1,115 @@
+export type ContentMemoKey = string | number;
+
+let unsupportedContentCounter = 0;
+
+type ContentHash = {
+  primary: number;
+  secondary: number;
+};
+
+function updateContentHash(hash: ContentHash, value: string): void {
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    hash.primary = Math.imul(hash.primary ^ code, 16777619) >>> 0;
+    hash.secondary = Math.imul(hash.secondary ^ code, 2246822519) >>> 0;
+  }
+}
+
+function hashStableContent(
+  value: unknown,
+  hash: ContentHash,
+  ancestors = new WeakSet<object>(),
+): void {
+  if (value === null) {
+    updateContentHash(hash, "null;");
+    return;
+  }
+
+  switch (typeof value) {
+    case "string":
+      updateContentHash(hash, `string:${value.length}:${value};`);
+      return;
+    case "number":
+      updateContentHash(
+        hash,
+        Number.isNaN(value) ? "number:NaN;" : `number:${String(value)};`,
+      );
+      return;
+    case "boolean":
+      updateContentHash(hash, `boolean:${value};`);
+      return;
+    case "object":
+      break;
+    default:
+      throw new TypeError("Unsupported content value");
+  }
+
+  if (ancestors.has(value)) {
+    throw new TypeError("Cannot hash cyclic content");
+  }
+  ancestors.add(value);
+
+  try {
+    if (Array.isArray(value)) {
+      updateContentHash(hash, `array:${value.length}:[`);
+      for (const item of value) hashStableContent(item, hash, ancestors);
+      updateContentHash(hash, "];");
+      return;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new TypeError("Unsupported content object");
+    }
+
+    const keys = Object.keys(value).sort();
+    updateContentHash(hash, `object:${keys.length}:{`);
+    for (const key of keys) {
+      updateContentHash(hash, `key:${key.length}:${key}=`);
+      hashStableContent(
+        (value as Record<string, unknown>)[key],
+        hash,
+        ancestors,
+      );
+    }
+    updateContentHash(hash, "};");
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+export function getContentMemoKey(content: unknown): ContentMemoKey {
+  switch (typeof content) {
+    case "string":
+      return content.length;
+    case "number":
+      return Number.isNaN(content) ? "number:NaN;" : `number:${content};`;
+    case "boolean":
+      return `boolean:${content};`;
+    case "object":
+      if (content === null) return "null;";
+      if (Array.isArray(content)) return content.length;
+      {
+        const hash: ContentHash = {
+          primary: 2166136261,
+          secondary: 2166136261,
+        };
+        try {
+          hashStableContent(content, hash);
+          return `${hash.primary.toString(16)}:${hash.secondary.toString(16)}`;
+        } catch {
+          // Unsupported or cyclic objects have no protocol-defined revision and
+          // can change without being hashable; return a fresh value each call
+          // so the memo key fails safe (re-renders) rather than freezing.
+          unsupportedContentCounter += 1;
+          return unsupportedContentCounter;
+        }
+      }
+    default:
+      if (content === undefined) return "undefined;";
+      // bigint, symbol, or function content has no stable shape; return a fresh
+      // value so the memo never collapses to a constant.
+      unsupportedContentCounter += 1;
+      return unsupportedContentCounter;
+  }
+}


### PR DESCRIPTION
## Summary

This fixes stale A2UI activity content in `CopilotChat` when `ACTIVITY_DELTA` updates an existing activity object without changing its message ID.

The `CopilotChat` message memo key now hashes object content and includes the activity type, so a retained-ID delta produces a new key and the memoized boundary re-renders. Existing string, array, role, message-ID, and tool-call grouping behavior stays intact. A2UI event handling and backend protocol behavior remain unchanged.

Fixes https://github.com/CopilotKit/CopilotKit/issues/6001

## Changes

- Hash object content and include `activityType` in the `CopilotChat` message memo key so a retained-ID `ACTIVITY_DELTA` invalidates the memoized messages array.
- `getContentMemoKey` returns a deterministic hash for serializable object content, a stable value for immutable primitives, and a fail-safe fresh value for unsupported or cyclic content, so the memo can always invalidate.
- Add end-to-end regressions for the retained-ID `ACTIVITY_DELTA` sequence, the retained activity-type switch, and unchanged-serializable-content memoization.
- Preserve existing text, array, and tool-call memoization behavior.
- Follow the current `release.config.json` and Nx release convention; no Changeset is included.

## Test Plan

- [x] `pnpm -C packages/react-core exec vitest run src/v2/components/chat/__tests__/CopilotChatToolRerenders.e2e.test.tsx`
- [x] `pnpm exec oxfmt --check packages/react-core/src/v2/components/chat/CopilotChat.tsx packages/react-core/src/v2/components/chat/content-memo-key.ts packages/react-core/src/v2/components/chat/__tests__/CopilotChatToolRerenders.e2e.test.tsx`
- [x] `pnpm exec oxlint packages/react-core/src/v2/components/chat/CopilotChat.tsx packages/react-core/src/v2/components/chat/content-memo-key.ts packages/react-core/src/v2/components/chat/__tests__/CopilotChatToolRerenders.e2e.test.tsx`
- [x] `pnpm -C packages/react-core exec tsc --noEmit`
- [x] `pnpm exec commitlint --from origin/main --to HEAD`
- [x] A retained-ID activity updates immediately after `ACTIVITY_DELTA`.
- [x] Existing string, array, and tool-call grouping tests remain green.
- [x] Release metadata remains aligned with `release.config.json` and Nx release; no Changeset is included.
