### PR TITLE
fix(react-core): preserve logical run identity across HITL resolve

### DIFF
--- a/packages/core/src/__tests__/core-follow-up.test.ts
+++ b/packages/core/src/__tests__/core-follow-up.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { CopilotKitCore } from "../core";
-import { FrontendTool } from "../types";
+import type { FrontendTool } from "../types";
 import {
   MockAgent,
   createAssistantMessage,
@@ -51,6 +51,43 @@ describe("CopilotKitCore.runAgent - Follow-up Logic", () => {
 
     expect(agent.runAgentCalls).toHaveLength(2);
     expect(result.newMessages).toContain(followUpMessage);
+  });
+
+  it("should preserve the originating run ID through a frontend follow-up", async () => {
+    const tool = createTool({
+      name: "runIdTool",
+      handler: vi.fn(async () => "Result"),
+      followUp: true,
+    });
+    copilotKitCore.addTool(tool);
+
+    const agent = new MockAgent({
+      newMessages: [createToolCallMessage("runIdTool")],
+    });
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "test",
+      agent: agent as any,
+    });
+    agent.runAgentCallback = (input) => {
+      if (agent.runAgentCalls.length === 2) {
+        agent.setNewMessages([createAssistantMessage({ content: "Done" })]);
+        expect(input.forwardedProps).toMatchObject({
+          __copilotkit_follow_up: true,
+        });
+      }
+      expect(input.runId).toBe("logical-hitl-run");
+    };
+
+    await copilotKitCore.runAgent({
+      agent: agent as any,
+      runId: "logical-hitl-run",
+    });
+
+    expect(agent.runAgentCalls).toHaveLength(2);
+    expect(agent.runAgentCalls.map((input) => input.runId)).toEqual([
+      "logical-hitl-run",
+      "logical-hitl-run",
+    ]);
   });
 
   it("should not trigger recursive call when tool.followUp is false", async () => {

--- a/packages/core/src/__tests__/core-follow-up.test.ts
+++ b/packages/core/src/__tests__/core-follow-up.test.ts
@@ -71,9 +71,9 @@ describe("CopilotKitCore.runAgent - Follow-up Logic", () => {
     agent.runAgentCallback = (input) => {
       if (agent.runAgentCalls.length === 2) {
         agent.setNewMessages([createAssistantMessage({ content: "Done" })]);
-        expect(input.forwardedProps).toMatchObject({
-          __copilotkit_follow_up: true,
-        });
+        expect(input.forwardedProps).not.toHaveProperty(
+          "__copilotkit_follow_up",
+        );
       }
       expect(input.runId).toBe("logical-hitl-run");
     };

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -422,7 +422,6 @@ describe("StateManager - Multiple Runs", () => {
 
   it("should preserve the supplied ID for an internal frontend follow-up", async () => {
     const runId = "internal-follow-up-run";
-    const forwardedProps = { __copilotkit_follow_up: true };
     const message = {
       id: "internal-follow-up-message",
       role: "assistant" as const,
@@ -431,12 +430,8 @@ describe("StateManager - Multiple Runs", () => {
 
     await agent.emitRunStarted(runId, { step: "paused" });
     await agent.emitRunFinished(runId, { step: "paused" });
-    await agent.emitRunStarted(
-      runId,
-      { step: "continued" },
-      undefined,
-      forwardedProps,
-    );
+    copilotKitCore.markNextRunAsContinuation("agent1");
+    await agent.emitRunStarted(runId, { step: "continued" });
     await agent.emitNewMessage(runId, message);
     await agent.emitRunFinished(runId, { step: "completed" });
 
@@ -449,6 +444,21 @@ describe("StateManager - Multiple Runs", () => {
     expect(copilotKitCore.getRunIdsForThread("agent1", "thread1")).toEqual([
       runId,
     ]);
+  });
+
+  it("does not treat a user forwardedProps marker as an internal continuation", async () => {
+    const runId = "collision-run";
+
+    await agent.emitRunStarted(runId, { step: "first" });
+    await agent.emitRunFinished(runId, { step: "first" });
+    await agent.emitRunStarted(runId, { step: "second" }, undefined, {
+      __copilotkit_follow_up: true,
+    });
+    await agent.emitRunFinished(runId, { step: "second" });
+
+    expect(copilotKitCore.getRunIdsForThread("agent1", "thread1")).toHaveLength(
+      2,
+    );
   });
 
   it("should isolate an ordinary same-ID run after a finished run", async () => {

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -436,7 +436,7 @@ describe("StateManager - Multiple Runs", () => {
           markNextRunAsContinuation: (
             agent: EventEmittingMockAgent,
             expectedRunId?: string,
-          ) => { cancel(): void };
+          ) => { cancel(): void; bind(input: object): void };
         };
       }
     ).stateManager.markNextRunAsContinuation(agent, runId);
@@ -455,7 +455,7 @@ describe("StateManager - Multiple Runs", () => {
     ]);
   });
 
-  it("does not consume an internal handoff for an interleaved run ID", async () => {
+  it("does not consume an internal handoff for a same-ID interleaving", async () => {
     const runId = "expected-follow-up-run";
     const handoff = (
       copilotKitCore as unknown as {
@@ -463,17 +463,52 @@ describe("StateManager - Multiple Runs", () => {
           markNextRunAsContinuation: (
             agent: EventEmittingMockAgent,
             expectedRunId?: string,
-          ) => { cancel(): void };
+          ) => { cancel(): void; bind(input: object): void };
         };
       }
     ).stateManager.markNextRunAsContinuation(agent, runId);
+    handoff.bind({});
 
-    await agent.emitRunStarted("interleaved-run", { step: "first" });
-    await agent.emitRunFinished("interleaved-run", { step: "first" });
+    await agent.emitRunStarted(runId, { step: "first" });
+    await agent.emitRunFinished(runId, { step: "first" });
+
+    await agent.emitRunStarted(runId, { step: "second" });
+    await agent.emitRunFinished(runId, { step: "second" });
     handoff.cancel();
 
-    await agent.emitRunStarted("interleaved-run", { step: "second" });
-    await agent.emitRunFinished("interleaved-run", { step: "second" });
+    expect(copilotKitCore.getRunIdsForThread("agent1", "thread1")).toHaveLength(
+      2,
+    );
+  });
+
+  it("cancels an internal handoff when detaching the follow-up fails", async () => {
+    const runId = "detach-failure-run";
+    await agent.emitRunStarted(runId, { step: "first" });
+    await agent.emitRunFinished(runId, { step: "first" });
+
+    const handoff = (
+      copilotKitCore as unknown as {
+        stateManager: {
+          markNextRunAsContinuation: (
+            agent: EventEmittingMockAgent,
+            expectedRunId?: string,
+          ) => { cancel(): void; bind(input: object): void };
+        };
+      }
+    ).stateManager.markNextRunAsContinuation(agent, runId);
+    handoff.bind({});
+    agent.detachActiveRun = vi
+      .fn()
+      .mockRejectedValue(new Error("detach failed"));
+
+    await expect(
+      copilotKitCore.runAgent({ agent: agent as any, runId }),
+    ).rejects.toThrow("detach failed");
+
+    agent.detachActiveRun = vi.fn().mockResolvedValue(undefined);
+    await agent.emitRunStarted(runId, { step: "second" });
+    await agent.emitRunFinished(runId, { step: "second" });
+    handoff.cancel();
 
     expect(copilotKitCore.getRunIdsForThread("agent1", "thread1")).toHaveLength(
       2,

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -454,41 +454,6 @@ describe("StateManager - Multiple Runs", () => {
     ]);
   });
 
-  it("should preserve the supplied ID for an internal frontend follow-up", async () => {
-    const runId = "internal-follow-up-run";
-    const message = {
-      id: "internal-follow-up-message",
-      role: "assistant" as const,
-      content: "completed",
-    };
-
-    await agent.emitRunStarted(runId, { step: "paused" });
-    await agent.emitRunFinished(runId, { step: "paused" });
-    (
-      copilotKitCore as unknown as {
-        stateManager: {
-          markNextRunAsContinuation: (
-            agent: EventEmittingMockAgent,
-            expectedRunId?: string,
-          ) => { cancel(): void; bind(input: object): void };
-        };
-      }
-    ).stateManager.markNextRunAsContinuation(agent, runId);
-    await agent.emitRunStarted(runId, { step: "continued" });
-    await agent.emitNewMessage(runId, message);
-    await agent.emitRunFinished(runId, { step: "completed" });
-
-    expect(copilotKitCore.getStateByRun("agent1", "thread1", runId)).toEqual({
-      step: "completed",
-    });
-    expect(
-      copilotKitCore.getRunIdForMessage("agent1", "thread1", message.id),
-    ).toBe(runId);
-    expect(copilotKitCore.getRunIdsForThread("agent1", "thread1")).toEqual([
-      runId,
-    ]);
-  });
-
   it("binds an internal handoff to the AbstractAgent lifecycle input", async () => {
     const runId = "abstract-agent-follow-up-run";
     await copilotKitCore.runAgent({ agent: agent as any, runId });
@@ -503,11 +468,55 @@ describe("StateManager - Multiple Runs", () => {
       }
     ).stateManager.markNextRunAsContinuation(agent, runId);
 
-    await copilotKitCore.runAgent({ agent: agent as any, runId });
+    await (
+      copilotKitCore as unknown as {
+        runHandler: {
+          runAgent(
+            params: { agent: EventEmittingMockAgent; runId: string },
+            handoff: { cancel(): void; bind(input: object): void },
+          ): Promise<unknown>;
+        };
+      }
+    ).runHandler.runAgent({ agent, runId }, handoff);
 
     expect(copilotKitCore.getRunIdsForThread("agent1", "thread1")).toEqual([
       runId,
     ]);
+    handoff.cancel();
+  });
+
+  it("does not consume an unbound handoff during detach", async () => {
+    const runId = "detach-interleaving-run";
+    await copilotKitCore.runAgent({ agent: agent as any, runId });
+
+    const handoff = (
+      copilotKitCore as unknown as {
+        stateManager: {
+          markNextRunAsContinuation: (
+            agent: EventEmittingMockAgent,
+            expectedRunId?: string,
+          ) => { cancel(): void; bind(input: object): void };
+        };
+      }
+    ).stateManager.markNextRunAsContinuation(agent, runId);
+    let releaseDetach!: () => void;
+    agent.detachActiveRun = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseDetach = resolve;
+        }),
+    );
+
+    const followUp = copilotKitCore.runAgent({ agent: agent as any, runId });
+    await Promise.resolve();
+    await agent.emitRunStarted(runId, { step: "interleaved" });
+    await agent.emitRunFinished(runId, { step: "interleaved" });
+    releaseDetach();
+    await followUp;
+
+    expect(copilotKitCore.getRunIdsForThread("agent1", "thread1")).toHaveLength(
+      2,
+    );
     handoff.cancel();
   });
 

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -430,7 +430,16 @@ describe("StateManager - Multiple Runs", () => {
 
     await agent.emitRunStarted(runId, { step: "paused" });
     await agent.emitRunFinished(runId, { step: "paused" });
-    copilotKitCore.markNextRunAsContinuation("agent1");
+    (
+      copilotKitCore as unknown as {
+        stateManager: {
+          markNextRunAsContinuation: (
+            agent: EventEmittingMockAgent,
+            expectedRunId?: string,
+          ) => { cancel(): void };
+        };
+      }
+    ).stateManager.markNextRunAsContinuation(agent, runId);
     await agent.emitRunStarted(runId, { step: "continued" });
     await agent.emitNewMessage(runId, message);
     await agent.emitRunFinished(runId, { step: "completed" });
@@ -444,6 +453,31 @@ describe("StateManager - Multiple Runs", () => {
     expect(copilotKitCore.getRunIdsForThread("agent1", "thread1")).toEqual([
       runId,
     ]);
+  });
+
+  it("does not consume an internal handoff for an interleaved run ID", async () => {
+    const runId = "expected-follow-up-run";
+    const handoff = (
+      copilotKitCore as unknown as {
+        stateManager: {
+          markNextRunAsContinuation: (
+            agent: EventEmittingMockAgent,
+            expectedRunId?: string,
+          ) => { cancel(): void };
+        };
+      }
+    ).stateManager.markNextRunAsContinuation(agent, runId);
+
+    await agent.emitRunStarted("interleaved-run", { step: "first" });
+    await agent.emitRunFinished("interleaved-run", { step: "first" });
+    handoff.cancel();
+
+    await agent.emitRunStarted("interleaved-run", { step: "second" });
+    await agent.emitRunFinished("interleaved-run", { step: "second" });
+
+    expect(copilotKitCore.getRunIdsForThread("agent1", "thread1")).toHaveLength(
+      2,
+    );
   });
 
   it("does not treat a user forwardedProps marker as an internal continuation", async () => {

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -29,7 +29,12 @@ class EventEmittingMockAgent extends AbstractAgent {
   }
 
   // Helper to emit run started event
-  public async emitRunStarted(runId: string, state: State = {}) {
+  public async emitRunStarted(
+    runId: string,
+    state: State = {},
+    resume?: RunAgentInput["resume"],
+    forwardedProps?: RunAgentInput["forwardedProps"],
+  ) {
     this.state = state;
     for (const sub of this.testSubscribers) {
       if (sub.onRunStartedEvent) {
@@ -42,14 +47,18 @@ class EventEmittingMockAgent extends AbstractAgent {
           messages: this.messages,
           state: this.state,
           agent: this,
-          input: this.createRunInput(runId),
+          input: this.createRunInput(runId, resume, forwardedProps),
         });
       }
     }
   }
 
   // Helper to emit run finished event
-  public async emitRunFinished(runId: string, state: State = {}) {
+  public async emitRunFinished(
+    runId: string,
+    state: State = {},
+    resume?: RunAgentInput["resume"],
+  ) {
     this.state = state;
     for (const sub of this.testSubscribers) {
       if (sub.onRunFinishedEvent) {
@@ -62,7 +71,7 @@ class EventEmittingMockAgent extends AbstractAgent {
           messages: this.messages,
           state: this.state,
           agent: this,
-          input: this.createRunInput(runId),
+          input: this.createRunInput(runId, resume),
         });
       }
     }
@@ -183,7 +192,11 @@ class EventEmittingMockAgent extends AbstractAgent {
     };
   }
 
-  private createRunInput(runId: string): RunAgentInput {
+  private createRunInput(
+    runId: string,
+    resume?: RunAgentInput["resume"],
+    forwardedProps?: RunAgentInput["forwardedProps"],
+  ): RunAgentInput {
     return {
       threadId: this.threadId,
       runId,
@@ -191,6 +204,8 @@ class EventEmittingMockAgent extends AbstractAgent {
       messages: this.messages,
       tools: [],
       context: [],
+      ...(resume !== undefined ? { resume } : {}),
+      ...(forwardedProps !== undefined ? { forwardedProps } : {}),
     };
   }
 }
@@ -338,6 +353,124 @@ describe("StateManager - Multiple Runs", () => {
     expect(copilotKitCore.getStateByRun("agent1", "thread1", "run3")).toEqual(
       run3State,
     );
+  });
+
+  it("should preserve the supplied ID for an explicit resume continuation", async () => {
+    const runId = "hitl-run";
+    const resume = [
+      { interruptId: "interrupt-1", status: "resolved" as const, payload: {} },
+    ];
+
+    await agent.emitRunStarted(runId, { step: "paused" });
+    await agent.emitRunFinished(runId, { step: "paused" });
+    await agent.emitRunStarted(runId, { step: "resumed" }, resume);
+    await agent.emitRunFinished(runId, { step: "completed" }, resume);
+
+    expect(copilotKitCore.getStateByRun("agent1", "thread1", runId)).toEqual({
+      step: "completed",
+    });
+    expect(copilotKitCore.getRunIdsForThread("agent1", "thread1")).toEqual([
+      runId,
+    ]);
+  });
+
+  it("should preserve the supplied ID for a legacy resume continuation", async () => {
+    const runId = "legacy-hitl-run";
+    const forwardedProps = {
+      command: { resume: { approved: true } },
+    };
+
+    await agent.emitRunStarted(runId, { step: "paused" });
+    await agent.emitRunFinished(runId, { step: "paused" });
+    await agent.emitRunStarted(
+      runId,
+      { step: "resumed" },
+      undefined,
+      forwardedProps,
+    );
+    await agent.emitRunFinished(runId, { step: "completed" });
+
+    expect(copilotKitCore.getStateByRun("agent1", "thread1", runId)).toEqual({
+      step: "completed",
+    });
+    expect(copilotKitCore.getRunIdsForThread("agent1", "thread1")).toEqual([
+      runId,
+    ]);
+  });
+
+  it("should preserve the supplied ID for a legacy resume with no payload", async () => {
+    const runId = "legacy-empty-resume-run";
+    const forwardedProps = { command: { resume: undefined } };
+
+    await agent.emitRunStarted(runId, { step: "paused" });
+    await agent.emitRunFinished(runId, { step: "paused" });
+    await agent.emitRunStarted(
+      runId,
+      { step: "resumed" },
+      undefined,
+      forwardedProps,
+    );
+    await agent.emitRunFinished(runId, { step: "completed" });
+
+    expect(copilotKitCore.getStateByRun("agent1", "thread1", runId)).toEqual({
+      step: "completed",
+    });
+    expect(copilotKitCore.getRunIdsForThread("agent1", "thread1")).toEqual([
+      runId,
+    ]);
+  });
+
+  it("should preserve the supplied ID for an internal frontend follow-up", async () => {
+    const runId = "internal-follow-up-run";
+    const forwardedProps = { __copilotkit_follow_up: true };
+    const message = {
+      id: "internal-follow-up-message",
+      role: "assistant" as const,
+      content: "completed",
+    };
+
+    await agent.emitRunStarted(runId, { step: "paused" });
+    await agent.emitRunFinished(runId, { step: "paused" });
+    await agent.emitRunStarted(
+      runId,
+      { step: "continued" },
+      undefined,
+      forwardedProps,
+    );
+    await agent.emitNewMessage(runId, message);
+    await agent.emitRunFinished(runId, { step: "completed" });
+
+    expect(copilotKitCore.getStateByRun("agent1", "thread1", runId)).toEqual({
+      step: "completed",
+    });
+    expect(
+      copilotKitCore.getRunIdForMessage("agent1", "thread1", message.id),
+    ).toBe(runId);
+    expect(copilotKitCore.getRunIdsForThread("agent1", "thread1")).toEqual([
+      runId,
+    ]);
+  });
+
+  it("should isolate an ordinary same-ID run after a finished run", async () => {
+    const runId = "reused-run";
+
+    await agent.emitRunStarted(runId, { step: "first" });
+    await agent.emitRunFinished(runId, { step: "first" });
+    await agent.emitRunStarted(runId, { step: "second" });
+    await agent.emitRunFinished(runId, { step: "second" });
+
+    const runIds = copilotKitCore.getRunIdsForThread("agent1", "thread1");
+    const isolatedRunId = runIds.find((candidate) => candidate !== runId);
+
+    expect(runIds).toHaveLength(2);
+    expect(runIds).toContain(runId);
+    expect(isolatedRunId).toBeDefined();
+    expect(
+      copilotKitCore.getStateByRun("agent1", "thread1", isolatedRunId!),
+    ).toEqual({ step: "second" });
+    expect(copilotKitCore.getStateByRun("agent1", "thread1", runId)).toEqual({
+      step: "first",
+    });
   });
 
   it("should list all run IDs for a thread", async () => {

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { CopilotKitCore } from "../core";
-import type { Message, State, RunAgentInput } from "@ag-ui/client";
+import type { BaseEvent, Message, State, RunAgentInput } from "@ag-ui/client";
 import { AbstractAgent, EventType } from "@ag-ui/client";
 import { randomUUID } from "@copilotkit/shared";
+import type { Observable } from "rxjs";
+import { defer } from "rxjs";
 
 /**
  * Mock agent that can emit events to test state management
@@ -18,9 +20,41 @@ class EventEmittingMockAgent extends AbstractAgent {
     });
   }
 
-  public run(input: RunAgentInput): any {
-    // Not used in these tests
-    throw new Error("run() should not be called in these tests");
+  public run(input: RunAgentInput): Observable<BaseEvent> {
+    return defer(async () => {
+      this.state = { step: "started" };
+      for (const sub of this.testSubscribers) {
+        await sub.onRunStartedEvent?.({
+          event: {
+            type: EventType.RUN_STARTED,
+            threadId: input.threadId,
+            runId: input.runId,
+          },
+          messages: this.messages,
+          state: this.state,
+          agent: this,
+          input,
+        });
+        await sub.onRunFinishedEvent?.({
+          event: {
+            type: EventType.RUN_FINISHED,
+            threadId: input.threadId,
+            runId: input.runId,
+            outcome: "success",
+          },
+          outcome: "success",
+          messages: this.messages,
+          state: this.state,
+          agent: this,
+          input,
+        });
+      }
+      return {
+        type: EventType.CUSTOM,
+        name: "test",
+        value: {},
+      } as BaseEvent;
+    });
   }
 
   // Expose subscribe for testing
@@ -453,6 +487,28 @@ describe("StateManager - Multiple Runs", () => {
     expect(copilotKitCore.getRunIdsForThread("agent1", "thread1")).toEqual([
       runId,
     ]);
+  });
+
+  it("binds an internal handoff to the AbstractAgent lifecycle input", async () => {
+    const runId = "abstract-agent-follow-up-run";
+    await copilotKitCore.runAgent({ agent: agent as any, runId });
+    const handoff = (
+      copilotKitCore as unknown as {
+        stateManager: {
+          markNextRunAsContinuation: (
+            agent: EventEmittingMockAgent,
+            expectedRunId?: string,
+          ) => { cancel(): void; bind(input: object): void };
+        };
+      }
+    ).stateManager.markNextRunAsContinuation(agent, runId);
+
+    await copilotKitCore.runAgent({ agent: agent as any, runId });
+
+    expect(copilotKitCore.getRunIdsForThread("agent1", "thread1")).toEqual([
+      runId,
+    ]);
+    handoff.cancel();
   });
 
   it("does not consume an internal handoff for a same-ID interleaving", async () => {

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -31,6 +31,7 @@ import type {
 import { RunHandler } from "./run-handler";
 import type { DebugConfig } from "@copilotkit/shared";
 import { StateManager } from "./state-manager";
+import type { CopilotKitCoreContinuationHandoff } from "./state-manager";
 import { ThreadStoreRegistry } from "./thread-store-registry";
 import type { ɵThreadStore } from "../threads";
 import { ɵcreateMemoryStore } from "../memory";
@@ -366,7 +367,12 @@ export interface CopilotKitCoreFriendsAccess {
    */
   waitForPendingFrameworkUpdates(): Promise<void>;
 
-  markNextRunAsContinuation(agentId: string): void;
+  readonly stateManager: {
+    markNextRunAsContinuation(
+      agent: AbstractAgent,
+      expectedRunId?: string,
+    ): CopilotKitCoreContinuationHandoff;
+  };
 }
 
 /**
@@ -1319,10 +1325,6 @@ export class CopilotKitCore {
     runId: string,
   ): State | undefined {
     return this.stateManager.getStateByRun(agentId, threadId, runId);
-  }
-
-  markNextRunAsContinuation(agentId: string): void {
-    this.stateManager.markNextRunAsContinuation(agentId);
   }
 
   getRunIdForMessage(

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -365,6 +365,8 @@ export interface CopilotKitCoreFriendsAccess {
    * See CopilotKitCore.waitForPendingFrameworkUpdates for details.
    */
   waitForPendingFrameworkUpdates(): Promise<void>;
+
+  markNextRunAsContinuation(agentId: string): void;
 }
 
 /**
@@ -1317,6 +1319,10 @@ export class CopilotKitCore {
     runId: string,
   ): State | undefined {
     return this.stateManager.getStateByRun(agentId, threadId, runId);
+  }
+
+  markNextRunAsContinuation(agentId: string): void {
+    this.stateManager.markNextRunAsContinuation(agentId);
   }
 
   getRunIdForMessage(

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -14,6 +14,8 @@ import { CopilotKitCoreErrorCode } from "./core";
 import { AgentThreadLockedError } from "../intelligence-agent";
 import type { FrontendTool } from "../types";
 
+const COPILOTKIT_FOLLOW_UP_MARKER = "__copilotkit_follow_up";
+
 export interface CopilotKitCoreRunAgentParams {
   agent: AbstractAgent;
   forwardedProps?: Record<string, unknown>;
@@ -490,6 +492,13 @@ export class RunHandler {
     this._runDepth++;
 
     try {
+      let logicalRunId = runId;
+      const agentSubscriber = this.createAgentErrorSubscriber(agent);
+      const onRunStartedEvent = agentSubscriber.onRunStartedEvent;
+      agentSubscriber.onRunStartedEvent = async (params) => {
+        logicalRunId = params.input.runId;
+        return onRunStartedEvent?.(params);
+      };
       const runAgentResult = await agent.runAgent(
         {
           forwardedProps: {
@@ -501,9 +510,13 @@ export class RunHandler {
           tools: this.buildFrontendTools(agent.agentId),
           context: this._internal.getContextForAgent(agent.agentId),
         },
-        this.createAgentErrorSubscriber(agent),
+        agentSubscriber,
       );
-      return await this.processAgentResult({ runAgentResult, agent });
+      return await this.processAgentResult({
+        runAgentResult,
+        agent,
+        runId: logicalRunId,
+      });
     } catch (error) {
       const runError =
         error instanceof Error ? error : new Error(String(error));
@@ -533,10 +546,12 @@ export class RunHandler {
   private async processAgentResult({
     runAgentResult,
     agent,
+    runId,
     executeFrontendTools = true,
   }: {
     runAgentResult: RunAgentResult;
     agent: AbstractAgent;
+    runId?: string;
     executeFrontendTools?: boolean;
   }): Promise<RunAgentResult> {
     const { newMessages } = runAgentResult;
@@ -645,7 +660,11 @@ export class RunHandler {
         // complete and write fresh values into the context store before runAgent
         // reads it. The base implementation is a no-op; React overrides this.
         await this._internal.waitForPendingFrameworkUpdates();
-        return await this.runAgent({ agent });
+        return await this.runAgent({
+          agent,
+          forwardedProps: { [COPILOTKIT_FOLLOW_UP_MARKER]: true },
+          ...(runId !== undefined ? { runId } : {}),
+        });
       }
     }
 

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -13,9 +13,12 @@ import type { CopilotKitCore, CopilotKitCoreFriendsAccess } from "./core";
 import { CopilotKitCoreErrorCode } from "./core";
 import { AgentThreadLockedError } from "../intelligence-agent";
 import type { FrontendTool } from "../types";
+import type { CopilotKitCoreContinuationHandoff } from "./state-manager";
 
 export interface CopilotKitCoreRunAgentParams {
   agent: AbstractAgent;
+  /** Internal StateManager handoff; never forwarded to the AG-UI agent. */
+  continuationHandoff?: CopilotKitCoreContinuationHandoff;
   forwardedProps?: Record<string, unknown>;
   /**
    * Optional caller-supplied run identifier forwarded to the underlying AG-UI
@@ -422,6 +425,7 @@ export class RunHandler {
    */
   async runAgent({
     agent,
+    continuationHandoff,
     forwardedProps,
     resume,
     runId,
@@ -492,8 +496,10 @@ export class RunHandler {
     try {
       let logicalRunId = runId;
       const agentSubscriber = this.createAgentErrorSubscriber(agent);
+      let started = false;
       const onRunStartedEvent = agentSubscriber.onRunStartedEvent;
       agentSubscriber.onRunStartedEvent = async (params) => {
+        started = true;
         logicalRunId = params.input.runId;
         return onRunStartedEvent?.(params);
       };
@@ -510,12 +516,16 @@ export class RunHandler {
         },
         agentSubscriber,
       );
+      if (!started) {
+        continuationHandoff?.cancel();
+      }
       return await this.processAgentResult({
         runAgentResult,
         agent,
         runId: logicalRunId,
       });
     } catch (error) {
+      continuationHandoff?.cancel();
       const runError =
         error instanceof Error ? error : new Error(String(error));
       const context: Record<string, any> = {};
@@ -658,9 +668,11 @@ export class RunHandler {
         // complete and write fresh values into the context store before runAgent
         // reads it. The base implementation is a no-op; React overrides this.
         await this._internal.waitForPendingFrameworkUpdates();
-        this._internal.markNextRunAsContinuation(agentId);
+        const continuationHandoff =
+          this._internal.stateManager.markNextRunAsContinuation(agent, runId);
         return await this.runAgent({
           agent,
+          continuationHandoff,
           ...(runId !== undefined ? { runId } : {}),
         });
       }

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -17,8 +17,6 @@ import type { CopilotKitCoreContinuationHandoff } from "./state-manager";
 
 export interface CopilotKitCoreRunAgentParams {
   agent: AbstractAgent;
-  /** Internal StateManager handoff; never forwarded to the AG-UI agent. */
-  continuationHandoff?: CopilotKitCoreContinuationHandoff;
   forwardedProps?: Record<string, unknown>;
   /**
    * Optional caller-supplied run identifier forwarded to the underlying AG-UI
@@ -423,13 +421,10 @@ export class RunHandler {
   /**
    * Run an agent
    */
-  async runAgent({
-    agent,
-    continuationHandoff,
-    forwardedProps,
-    resume,
-    runId,
-  }: CopilotKitCoreRunAgentParams): Promise<RunAgentResult> {
+  async runAgent(
+    { agent, forwardedProps, resume, runId }: CopilotKitCoreRunAgentParams,
+    continuationHandoff?: CopilotKitCoreContinuationHandoff,
+  ): Promise<RunAgentResult> {
     // Agent ID is guaranteed to be set by validateAndAssignAgentId
     if (agent.agentId) {
       void this._internal.suggestionEngine.clearSuggestions(agent.agentId);
@@ -454,7 +449,12 @@ export class RunHandler {
     // (ConnectNotImplementedError → EMPTY) always runs the finalize block,
     // so the completion promise now resolves reliably.
     if (agent.detachActiveRun) {
-      await agent.detachActiveRun();
+      try {
+        await agent.detachActiveRun();
+      } catch (error) {
+        continuationHandoff?.cancel();
+        throw error;
+      }
     }
 
     // Set up abort controller and agent.abortRun() intercept only for the
@@ -503,17 +503,19 @@ export class RunHandler {
         logicalRunId = params.input.runId;
         return onRunStartedEvent?.(params);
       };
-      const runAgentResult = await agent.runAgent(
-        {
-          forwardedProps: {
-            ...this._internal.properties,
-            ...forwardedProps,
-          },
-          ...(resume !== undefined ? { resume } : {}),
-          ...(runId !== undefined ? { runId } : {}),
-          tools: this.buildFrontendTools(agent.agentId),
-          context: this._internal.getContextForAgent(agent.agentId),
+      const agentRunInput = {
+        forwardedProps: {
+          ...this._internal.properties,
+          ...forwardedProps,
         },
+        ...(resume !== undefined ? { resume } : {}),
+        ...(runId !== undefined ? { runId } : {}),
+        tools: this.buildFrontendTools(agent.agentId),
+        context: this._internal.getContextForAgent(agent.agentId),
+      };
+      continuationHandoff?.bind(agentRunInput);
+      const runAgentResult = await agent.runAgent(
+        agentRunInput,
         agentSubscriber,
       );
       if (!started) {
@@ -670,11 +672,13 @@ export class RunHandler {
         await this._internal.waitForPendingFrameworkUpdates();
         const continuationHandoff =
           this._internal.stateManager.markNextRunAsContinuation(agent, runId);
-        return await this.runAgent({
-          agent,
+        return await this.runAgent(
+          {
+            agent,
+            ...(runId !== undefined ? { runId } : {}),
+          },
           continuationHandoff,
-          ...(runId !== undefined ? { runId } : {}),
-        });
+        );
       }
     }
 

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -498,6 +498,11 @@ export class RunHandler {
       const agentSubscriber = this.createAgentErrorSubscriber(agent);
       let started = false;
       const onRunStartedEvent = agentSubscriber.onRunStartedEvent;
+      const onRunInitialized = agentSubscriber.onRunInitialized;
+      agentSubscriber.onRunInitialized = async (params) => {
+        continuationHandoff?.bind(params.input);
+        return onRunInitialized?.(params);
+      };
       agentSubscriber.onRunStartedEvent = async (params) => {
         started = true;
         logicalRunId = params.input.runId;
@@ -513,7 +518,6 @@ export class RunHandler {
         tools: this.buildFrontendTools(agent.agentId),
         context: this._internal.getContextForAgent(agent.agentId),
       };
-      continuationHandoff?.bind(agentRunInput);
       const runAgentResult = await agent.runAgent(
         agentRunInput,
         agentSubscriber,

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -14,8 +14,6 @@ import { CopilotKitCoreErrorCode } from "./core";
 import { AgentThreadLockedError } from "../intelligence-agent";
 import type { FrontendTool } from "../types";
 
-const COPILOTKIT_FOLLOW_UP_MARKER = "__copilotkit_follow_up";
-
 export interface CopilotKitCoreRunAgentParams {
   agent: AbstractAgent;
   forwardedProps?: Record<string, unknown>;
@@ -660,9 +658,9 @@ export class RunHandler {
         // complete and write fresh values into the context store before runAgent
         // reads it. The base implementation is a no-op; React overrides this.
         await this._internal.waitForPendingFrameworkUpdates();
+        this._internal.markNextRunAsContinuation(agentId);
         return await this.runAgent({
           agent,
-          forwardedProps: { [COPILOTKIT_FOLLOW_UP_MARKER]: true },
           ...(runId !== undefined ? { runId } : {}),
         });
       }

--- a/packages/core/src/core/state-manager.ts
+++ b/packages/core/src/core/state-manager.ts
@@ -23,7 +23,6 @@ export interface CopilotKitCoreContinuationHandoff {
 }
 
 interface PendingContinuation extends CopilotKitCoreContinuationHandoff {
-  expectedRunId?: string;
   expectedInput?: object;
   active: boolean;
 }
@@ -64,7 +63,7 @@ export class StateManager {
 
   markNextRunAsContinuation(
     agent: AbstractAgent,
-    expectedRunId?: string,
+    _expectedRunId?: string,
   ): CopilotKitCoreContinuationHandoff {
     let pendingForAgent = this.pendingContinuations.get(agent);
     if (!pendingForAgent) {
@@ -73,7 +72,6 @@ export class StateManager {
     }
 
     const pending: PendingContinuation = {
-      expectedRunId,
       active: true,
       bind: (input) => {
         if (pending.active) pending.expectedInput = input;
@@ -137,11 +135,7 @@ export class StateManager {
         if (revoked) return;
         const pendingForAgent = this.pendingContinuations.get(agent);
         const internalContinuation = [...(pendingForAgent ?? [])].find(
-          (pending) =>
-            pending.expectedInput === input ||
-            (pending.expectedInput === undefined &&
-              (pending.expectedRunId === undefined ||
-                pending.expectedRunId === input.runId)),
+          (pending) => pending.expectedInput === input,
         );
         internalContinuation?.cancel();
         if (

--- a/packages/core/src/core/state-manager.ts
+++ b/packages/core/src/core/state-manager.ts
@@ -17,6 +17,15 @@ const isContinuation = (input: RunAgentInput): boolean =>
     "resume",
   );
 
+export interface CopilotKitCoreContinuationHandoff {
+  cancel(): void;
+}
+
+interface PendingContinuation extends CopilotKitCoreContinuationHandoff {
+  expectedRunId?: string;
+  active: boolean;
+}
+
 /**
  * Manages state and message tracking by run for CopilotKitCore.
  * Tracks agent state snapshots and message-to-run associations.
@@ -37,7 +46,10 @@ export class StateManager {
 
   // Internal follow-ups are marked in memory so the marker never reaches a
   // runtime or becomes user-controlled forwardedProps data.
-  private pendingContinuations = new Set<string>();
+  private pendingContinuations = new WeakMap<
+    AbstractAgent,
+    Set<PendingContinuation>
+  >();
 
   constructor(private core: CopilotKitCore) {}
 
@@ -48,8 +60,30 @@ export class StateManager {
     // Will be called when CopilotKitCore is initialized
   }
 
-  markNextRunAsContinuation(agentId: string): void {
-    this.pendingContinuations.add(agentId);
+  markNextRunAsContinuation(
+    agent: AbstractAgent,
+    expectedRunId?: string,
+  ): CopilotKitCoreContinuationHandoff {
+    let pendingForAgent = this.pendingContinuations.get(agent);
+    if (!pendingForAgent) {
+      pendingForAgent = new Set();
+      this.pendingContinuations.set(agent, pendingForAgent);
+    }
+
+    const pending: PendingContinuation = {
+      expectedRunId,
+      active: true,
+      cancel: () => {
+        if (!pending.active) return;
+        pending.active = false;
+        pendingForAgent!.delete(pending);
+        if (pendingForAgent!.size === 0) {
+          this.pendingContinuations.delete(agent);
+        }
+      },
+    };
+    pendingForAgent.add(pending);
+    return pending;
   }
 
   /**
@@ -96,7 +130,13 @@ export class StateManager {
     const { unsubscribe } = agent.subscribe({
       onRunStartedEvent: ({ input, state }) => {
         if (revoked) return;
-        const internalContinuation = this.pendingContinuations.delete(agentId);
+        const pendingForAgent = this.pendingContinuations.get(agent);
+        const internalContinuation = [...(pendingForAgent ?? [])].find(
+          (pending) =>
+            pending.expectedRunId === undefined ||
+            pending.expectedRunId === input.runId,
+        );
+        internalContinuation?.cancel();
         if (
           runFinished &&
           input.runId === subRunId &&
@@ -156,7 +196,7 @@ export class StateManager {
 
     this.agentSubscriptions.set(agentId, () => {
       revoked = true;
-      this.pendingContinuations.delete(agentId);
+      this.pendingContinuations.delete(agent);
       unsubscribe();
     });
   }

--- a/packages/core/src/core/state-manager.ts
+++ b/packages/core/src/core/state-manager.ts
@@ -10,17 +10,12 @@ import type {
 import { randomUUID } from "@ag-ui/client";
 import type { CopilotKitCore } from "./core";
 
-const COPILOTKIT_FOLLOW_UP_MARKER = "__copilotkit_follow_up";
-
 const isContinuation = (input: RunAgentInput): boolean =>
   input.resume !== undefined ||
   Object.prototype.hasOwnProperty.call(
     (input.forwardedProps as { command?: object } | undefined)?.command ?? {},
     "resume",
-  ) ||
-  (input.forwardedProps as Record<string, unknown> | undefined)?.[
-    COPILOTKIT_FOLLOW_UP_MARKER
-  ] === true;
+  );
 
 /**
  * Manages state and message tracking by run for CopilotKitCore.
@@ -40,6 +35,10 @@ export class StateManager {
   // Agent subscriptions for cleanup
   private agentSubscriptions: Map<string, () => void> = new Map();
 
+  // Internal follow-ups are marked in memory so the marker never reaches a
+  // runtime or becomes user-controlled forwardedProps data.
+  private pendingContinuations = new Set<string>();
+
   constructor(private core: CopilotKitCore) {}
 
   /**
@@ -47,6 +46,10 @@ export class StateManager {
    */
   initialize(): void {
     // Will be called when CopilotKitCore is initialized
+  }
+
+  markNextRunAsContinuation(agentId: string): void {
+    this.pendingContinuations.add(agentId);
   }
 
   /**
@@ -93,7 +96,13 @@ export class StateManager {
     const { unsubscribe } = agent.subscribe({
       onRunStartedEvent: ({ input, state }) => {
         if (revoked) return;
-        if (runFinished && input.runId === subRunId && !isContinuation(input)) {
+        const internalContinuation = this.pendingContinuations.delete(agentId);
+        if (
+          runFinished &&
+          input.runId === subRunId &&
+          !internalContinuation &&
+          !isContinuation(input)
+        ) {
           // A new logical run's events are arriving through this same (old)
           // subscription. This happens when the test emits events before
           // copilotkit.runAgent() has had a chance to set up the new pipeline:
@@ -147,6 +156,7 @@ export class StateManager {
 
     this.agentSubscriptions.set(agentId, () => {
       revoked = true;
+      this.pendingContinuations.delete(agentId);
       unsubscribe();
     });
   }

--- a/packages/core/src/core/state-manager.ts
+++ b/packages/core/src/core/state-manager.ts
@@ -10,6 +10,18 @@ import type {
 import { randomUUID } from "@ag-ui/client";
 import type { CopilotKitCore } from "./core";
 
+const COPILOTKIT_FOLLOW_UP_MARKER = "__copilotkit_follow_up";
+
+const isContinuation = (input: RunAgentInput): boolean =>
+  input.resume !== undefined ||
+  Object.prototype.hasOwnProperty.call(
+    (input.forwardedProps as { command?: object } | undefined)?.command ?? {},
+    "resume",
+  ) ||
+  (input.forwardedProps as Record<string, unknown> | undefined)?.[
+    COPILOTKIT_FOLLOW_UP_MARKER
+  ] === true;
+
 /**
  * Manages state and message tracking by run for CopilotKitCore.
  * Tracks agent state snapshots and message-to-run associations.
@@ -66,12 +78,9 @@ export class StateManager {
     //
     // 2. Run isolation within one subscription: in tests (and edge cases), a new
     //    run's events can arrive through the same subscription before the new
-    //    pipeline is set up. Concretely: the test emits RUN_STARTED for run2
-    //    before copilotkit.runAgent() has had a chance to set up the new
-    //    pipeline. At that point S1 is still active and sees run2's events with
-    //    input1.runId. To prevent both runs from sharing the same runId key, we
-    //    detect the "seen RUN_FINISHED, then RUN_STARTED again" pattern and
-    //    generate a fresh runId for the second logical run.
+    //    pipeline is set up. An explicit standard or legacy resume input is a
+    //    continuation, so only an ordinary new run gets a fresh ID after
+    //    RUN_FINISHED.
     let revoked = false;
     let subRunId: string | undefined; // runId assigned to the current logical run
     let runFinished = false; // true after RUN_FINISHED, reset on next RUN_STARTED
@@ -84,7 +93,7 @@ export class StateManager {
     const { unsubscribe } = agent.subscribe({
       onRunStartedEvent: ({ input, state }) => {
         if (revoked) return;
-        if (runFinished && input.runId === subRunId) {
+        if (runFinished && input.runId === subRunId && !isContinuation(input)) {
           // A new logical run's events are arriving through this same (old)
           // subscription. This happens when the test emits events before
           // copilotkit.runAgent() has had a chance to set up the new pipeline:

--- a/packages/core/src/core/state-manager.ts
+++ b/packages/core/src/core/state-manager.ts
@@ -19,10 +19,12 @@ const isContinuation = (input: RunAgentInput): boolean =>
 
 export interface CopilotKitCoreContinuationHandoff {
   cancel(): void;
+  bind(input: object): void;
 }
 
 interface PendingContinuation extends CopilotKitCoreContinuationHandoff {
   expectedRunId?: string;
+  expectedInput?: object;
   active: boolean;
 }
 
@@ -73,6 +75,9 @@ export class StateManager {
     const pending: PendingContinuation = {
       expectedRunId,
       active: true,
+      bind: (input) => {
+        if (pending.active) pending.expectedInput = input;
+      },
       cancel: () => {
         if (!pending.active) return;
         pending.active = false;
@@ -133,8 +138,10 @@ export class StateManager {
         const pendingForAgent = this.pendingContinuations.get(agent);
         const internalContinuation = [...(pendingForAgent ?? [])].find(
           (pending) =>
-            pending.expectedRunId === undefined ||
-            pending.expectedRunId === input.runId,
+            pending.expectedInput === input ||
+            (pending.expectedInput === undefined &&
+              (pending.expectedRunId === undefined ||
+                pending.expectedRunId === input.runId)),
         );
         internalContinuation?.cancel();
         if (

--- a/packages/react-core/src/hooks/__tests__/use-copilot-action.e2e.test.tsx
+++ b/packages/react-core/src/hooks/__tests__/use-copilot-action.e2e.test.tsx
@@ -1,0 +1,141 @@
+import React, { useState } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { AbstractAgent, EventType } from "@ag-ui/client";
+import type {
+  AgentSubscriber,
+  BaseEvent,
+  RunAgentInput,
+  RunAgentParameters,
+  RunAgentResult,
+} from "@ag-ui/client";
+import { EMPTY } from "rxjs";
+import type { Observable } from "rxjs";
+import { useCopilotAction } from "../use-copilot-action";
+import { useCopilotKit } from "../../v2/providers/CopilotKitProvider";
+import { CopilotChatToolCallsView } from "../../v2/components/chat/CopilotChatToolCallsView";
+import { CopilotKitProvider } from "../../v2/providers/CopilotKitProvider";
+import type { AssistantMessage } from "@ag-ui/core";
+
+const toolCallMessage: AssistantMessage = {
+  id: "legacy-hitl-assistant",
+  role: "assistant",
+  content: "",
+  toolCalls: [
+    {
+      id: "legacy-hitl-tool-call",
+      type: "function",
+      function: {
+        name: "legacyApproval",
+        arguments: "{}",
+      },
+    },
+  ],
+};
+
+class LegacyHITLAgent extends AbstractAgent {
+  readonly runInputs: RunAgentInput[] = [];
+  private runCount = 0;
+
+  constructor() {
+    super({ agentId: "default", threadId: "legacy-hitl-thread" });
+  }
+
+  override async runAgent(
+    parameters?: RunAgentParameters,
+    subscriber?: AgentSubscriber,
+  ): Promise<RunAgentResult> {
+    const input = this.prepareRunAgentInput(parameters);
+    this.runInputs.push(input);
+
+    await subscriber?.onRunStartedEvent?.({
+      event: {
+        type: EventType.RUN_STARTED,
+        threadId: input.threadId,
+        runId: input.runId,
+      },
+      input,
+      state: this.state,
+      messages: this.messages,
+      agent: this,
+    });
+
+    const newMessages = this.runCount === 0 ? [toolCallMessage] : [];
+    this.runCount += 1;
+    this.messages.push(...newMessages);
+    return { result: undefined, newMessages };
+  }
+
+  override run(_input: RunAgentInput): Observable<BaseEvent> {
+    return EMPTY;
+  }
+
+  override clone(): this {
+    return this;
+  }
+}
+
+describe("useCopilotAction legacy HITL follow-up", () => {
+  it("keeps the generated run ID through renderAndWaitForResponse", async () => {
+    const agent = new LegacyHITLAgent();
+
+    function Harness() {
+      const { copilotkit } = useCopilotKit();
+      const [started, setStarted] = useState(false);
+
+      useCopilotAction({
+        name: "legacyApproval",
+        description: "Approve the action",
+        renderAndWaitForResponse: ({ status, respond }) => {
+          if (status === "executing" && respond) {
+            return (
+              <button onClick={() => void respond({ approved: true })}>
+                Approve
+              </button>
+            );
+          }
+          return <span data-testid="legacy-hitl-status">{status}</span>;
+        },
+      });
+
+      return (
+        <>
+          <button
+            onClick={() => {
+              setStarted(true);
+              void copilotkit.runAgent({ agent });
+            }}
+          >
+            Start
+          </button>
+          {started && (
+            <CopilotChatToolCallsView
+              message={toolCallMessage}
+              messages={agent.messages}
+            />
+          )}
+        </>
+      );
+    }
+
+    render(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <Harness />
+      </CopilotKitProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Start" }));
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Approve" })).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+    await waitFor(() => {
+      expect(agent.runInputs).toHaveLength(2);
+    });
+    expect(agent.runInputs.map((input) => input.runId)).toEqual([
+      agent.runInputs[0].runId,
+      agent.runInputs[0].runId,
+    ]);
+  });
+});

--- a/packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useInterrupt } from "../use-interrupt";
 import { useCopilotKit } from "../../context";
 import { useAgent } from "../use-agent";
-import type { Interrupt } from "@ag-ui/client";
+import type { Interrupt, RunAgentInput } from "@ag-ui/client";
 
 vi.mock("../../context", () => ({
   useCopilotKit: vi.fn(),
@@ -17,9 +17,13 @@ vi.mock("../use-agent", () => ({
 const mockUseCopilotKit = useCopilotKit as ReturnType<typeof vi.fn>;
 const mockUseAgent = useAgent as ReturnType<typeof vi.fn>;
 
+type TestRunInput = Pick<RunAgentInput, "runId">;
+
 type RunFinishedParams =
-  | { outcome: "success"; result?: unknown }
-  | { outcome: "interrupt"; interrupts: Interrupt[] };
+  | ({ outcome: "success"; result?: unknown } & { input: TestRunInput })
+  | ({ outcome: "interrupt"; interrupts: Interrupt[] } & {
+      input: TestRunInput;
+    });
 
 type SubscriptionHandlers = {
   onCustomEvent?: (payload: {
@@ -27,7 +31,7 @@ type SubscriptionHandlers = {
   }) => void;
   onRunStartedEvent?: () => void;
   onRunFinishedEvent?: (params: RunFinishedParams) => void;
-  onRunFinalized?: () => void;
+  onRunFinalized?: (params: { input: TestRunInput }) => void;
   onRunFailed?: () => void;
 };
 
@@ -179,12 +183,16 @@ describe("useInterrupt", () => {
     return <div data-testid="manual-container" />;
   }
 
+  function finalizeRun(runId = "legacy-run") {
+    handlers.onRunFinalized?.({ input: { runId } });
+  }
+
   function emitInterrupt(value: unknown) {
     act(() => {
       handlers.onCustomEvent?.({
         event: { name: "on_interrupt", value },
       });
-      handlers.onRunFinalized?.();
+      finalizeRun();
     });
   }
 
@@ -208,7 +216,7 @@ describe("useInterrupt", () => {
       handlers.onCustomEvent?.({
         event: { name: "not_interrupt", value: "x" },
       });
-      handlers.onRunFinalized?.();
+      finalizeRun();
     });
 
     expect(screen.queryByTestId("interrupt")).toBeNull();
@@ -225,7 +233,7 @@ describe("useInterrupt", () => {
     expect(screen.queryByTestId("interrupt")).toBeNull();
 
     act(() => {
-      handlers.onRunFinalized?.();
+      finalizeRun();
     });
     expect(screen.getByTestId("interrupt").textContent).toContain("pending");
   });
@@ -262,6 +270,7 @@ describe("useInterrupt", () => {
     expect(runAgentMock).toHaveBeenCalledTimes(1);
     expect(runAgentMock).toHaveBeenCalledWith({
       agent: mockAgent,
+      runId: "legacy-run",
       forwardedProps: {
         command: {
           resume: { approved: true, value: "approve-me" },
@@ -404,7 +413,7 @@ describe("useInterrupt", () => {
         event: { name: "on_interrupt", value: "lost" },
       });
       handlers.onRunFailed?.();
-      handlers.onRunFinalized?.();
+      finalizeRun();
     });
 
     expect(screen.queryByTestId("interrupt")).toBeNull();
@@ -420,7 +429,7 @@ describe("useInterrupt", () => {
       handlers.onCustomEvent?.({
         event: { name: "on_interrupt", value: "second" },
       });
-      handlers.onRunFinalized?.();
+      finalizeRun();
     });
 
     expect(screen.getByTestId("interrupt").textContent).toContain("second");
@@ -468,7 +477,7 @@ describe("useInterrupt", () => {
       handlers.onCustomEvent?.({
         event: { name: "on_interrupt", value: "first" },
       });
-      handlers.onRunFinalized?.();
+      finalizeRun();
     });
 
     await waitFor(() => {
@@ -494,7 +503,7 @@ describe("useInterrupt", () => {
       handlers.onCustomEvent?.({
         event: { name: "on_interrupt", value: "second" },
       });
-      handlers.onRunFinalized?.();
+      finalizeRun();
     });
 
     // Force a parent re-render AFTER the 2nd interrupt published. This
@@ -804,17 +813,36 @@ describe("useInterrupt", () => {
       return <div data-testid="standard-container">{element}</div>;
     }
 
-    function fireStandardInterrupt(interrupts: Interrupt[]) {
-      (mockAgent as any).pendingInterrupts = interrupts;
+    function startStandardRun() {
       act(() => {
         handlers.onRunStartedEvent?.();
       });
+    }
+
+    function finishStandardInterrupt(interrupts: Interrupt[], runId: string) {
+      (mockAgent as any).pendingInterrupts = interrupts;
       act(() => {
-        handlers.onRunFinishedEvent?.({ outcome: "interrupt", interrupts });
+        handlers.onRunFinishedEvent?.({
+          outcome: "interrupt",
+          interrupts,
+          input: { runId },
+        });
       });
+    }
+
+    function finalizeStandardRun(runId: string) {
       act(() => {
-        handlers.onRunFinalized?.();
+        finalizeRun(runId);
       });
+    }
+
+    function fireStandardInterrupt(
+      interrupts: Interrupt[],
+      runId = "standard-run",
+    ) {
+      startStandardRun();
+      finishStandardInterrupt(interrupts, runId);
+      finalizeStandardRun(runId);
     }
 
     it("surfaces the primary interrupt and full list from outcome:interrupt", () => {
@@ -839,6 +867,7 @@ describe("useInterrupt", () => {
 
       expect(runAgentMock).toHaveBeenCalledWith({
         agent: mockAgent,
+        runId: "standard-run",
         resume: [
           { interruptId: "int-1", status: "resolved", payload: { ok: true } },
         ],
@@ -857,6 +886,7 @@ describe("useInterrupt", () => {
 
       expect(runAgentMock).toHaveBeenCalledWith({
         agent: mockAgent,
+        runId: "standard-run",
         resume: [{ interruptId: "int-1", status: "cancelled" }],
       });
     });
@@ -898,6 +928,7 @@ describe("useInterrupt", () => {
       );
       expect(runAgentMock).toHaveBeenCalledWith({
         agent: mockAgent,
+        runId: "standard-run",
         resume: [
           {
             interruptId: "int-1",
@@ -905,6 +936,124 @@ describe("useInterrupt", () => {
             payload: { approved: true },
           },
         ],
+      });
+    });
+
+    it("forwards the interrupting runId and suppresses duplicate resolves", async () => {
+      const events: string[] = [];
+      runAgentMock.mockImplementation(async () => {
+        events.push("resume");
+        return { result: undefined, newMessages: [] };
+      });
+      const TOOL_INT: Interrupt = {
+        id: "int-run-id",
+        reason: "tool_approval",
+        toolCallId: "tc-run-id",
+      };
+      const resolves: Array<
+        (payload: unknown, interruptId?: string) => Promise<unknown>
+      > = [];
+      const addMessage = mockAgent.addMessage as ReturnType<typeof vi.fn>;
+      addMessage.mockImplementation(() => {
+        events.push("persist");
+      });
+
+      function RunIdHarness() {
+        useInterrupt({
+          render: ({ resolve }) => {
+            resolves.push(resolve);
+            return <></>;
+          },
+        });
+        return null;
+      }
+
+      render(<RunIdHarness />);
+      fireStandardInterrupt([TOOL_INT], "run-original");
+
+      const resolve = resolves.at(-1)!;
+      await act(async () => {
+        await resolve({ approved: true }, "int-run-id");
+        await resolve({ approved: true }, "int-run-id");
+      });
+
+      expect(events).toEqual(["persist", "resume"]);
+      expect(addMessage).toHaveBeenCalledTimes(1);
+      expect(addMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          role: "tool",
+          toolCallId: "tc-run-id",
+          content: JSON.stringify({ approved: true }),
+        }),
+      );
+      expect(runAgentMock).toHaveBeenCalledTimes(1);
+      expect(runAgentMock).toHaveBeenCalledWith({
+        agent: mockAgent,
+        runId: "run-original",
+        resume: [
+          {
+            interruptId: "int-run-id",
+            status: "resolved",
+            payload: { approved: true },
+          },
+        ],
+      });
+    });
+
+    it("preserves each run ID when interrupt resolutions overlap", async () => {
+      let releaseRunAgent!: () => void;
+      const runAgentGate = new Promise<void>((resolve) => {
+        releaseRunAgent = resolve;
+      });
+      runAgentMock.mockImplementation(async () => {
+        await runAgentGate;
+        return { result: undefined, newMessages: [] };
+      });
+      const INT2: Interrupt = { id: "int-2", reason: "confirmation" };
+      const calls: any[] = [];
+      function ConcurrentHarness() {
+        useInterrupt({
+          render: ({ resolve }) => {
+            calls.push(resolve);
+            return <></>;
+          },
+        });
+        return null;
+      }
+
+      render(<ConcurrentHarness />);
+      startStandardRun();
+      finishStandardInterrupt([INT], "run-a");
+      finalizeStandardRun("run-a");
+      const resolveA = calls.at(-1)!;
+      const firstResume = resolveA({ a: 1 }, "int-1");
+      await Promise.resolve();
+
+      startStandardRun();
+      finishStandardInterrupt([INT2], "run-b");
+      finalizeStandardRun("run-b");
+      const resolveB = calls.at(-1)!;
+      const secondResume = resolveB({ b: 2 }, "int-2");
+      await Promise.resolve();
+
+      expect(runAgentMock).toHaveBeenCalledTimes(2);
+      expect(runAgentMock).toHaveBeenNthCalledWith(1, {
+        agent: mockAgent,
+        runId: "run-a",
+        resume: [
+          { interruptId: "int-1", status: "resolved", payload: { a: 1 } },
+        ],
+      });
+      expect(runAgentMock).toHaveBeenNthCalledWith(2, {
+        agent: mockAgent,
+        runId: "run-b",
+        resume: [
+          { interruptId: "int-2", status: "resolved", payload: { b: 2 } },
+        ],
+      });
+      await act(async () => {
+        releaseRunAgent();
+        await Promise.all([firstResume, secondResume]);
       });
     });
 
@@ -958,6 +1107,7 @@ describe("useInterrupt", () => {
       });
       expect(runAgentMock).toHaveBeenCalledWith({
         agent: mockAgent,
+        runId: "standard-run",
         resume: [
           { interruptId: "int-1", status: "resolved", payload: { a: 1 } },
           { interruptId: "int-2", status: "resolved", payload: { b: 2 } },
@@ -1041,15 +1191,53 @@ describe("useInterrupt", () => {
           event: { name: "on_interrupt", value: "q?" },
         }),
       );
-      act(() => handlers.onRunFinalized?.());
+      act(() => finalizeRun("legacy-run-id"));
 
       await act(async () => {
         await calls.at(-1)!.resolve({ approved: true });
       });
       expect(runAgentMock).toHaveBeenCalledWith({
         agent: mockAgent,
+        runId: "legacy-run-id",
         forwardedProps: {
           command: { resume: { approved: true }, interruptEvent: "q?" },
+        },
+      });
+    });
+
+    it("preserves the run ID when legacy resolve omits its payload", async () => {
+      runAgentMock.mockResolvedValue({ result: undefined, newMessages: [] });
+      const calls: Array<{
+        resolve: (payload?: unknown) => Promise<unknown>;
+      }> = [];
+      function LegacyEmptyPayloadHarness() {
+        useInterrupt({
+          render: ({ resolve }) => {
+            calls.push({ resolve });
+            return <></>;
+          },
+        });
+        return null;
+      }
+
+      render(<LegacyEmptyPayloadHarness />);
+      act(() => handlers.onRunStartedEvent?.());
+      act(() =>
+        handlers.onCustomEvent?.({
+          event: { name: "on_interrupt", value: "q?" },
+        }),
+      );
+      act(() => finalizeRun("legacy-empty-run-id"));
+
+      await act(async () => {
+        await calls.at(-1)!.resolve();
+      });
+
+      expect(runAgentMock).toHaveBeenCalledWith({
+        agent: mockAgent,
+        runId: "legacy-empty-run-id",
+        forwardedProps: {
+          command: { resume: undefined, interruptEvent: "q?" },
         },
       });
     });

--- a/packages/react-core/src/v2/hooks/use-interrupt.tsx
+++ b/packages/react-core/src/v2/hooks/use-interrupt.tsx
@@ -182,6 +182,8 @@ export function useInterrupt<
     useState<InterruptResult<any, TResult>>(null);
 
   const interruptStateRef = useRef(new ɵInterruptState());
+  const interruptRunIdsRef = useRef(new Map<string, string>());
+  const legacyRunIdRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
     const interruptState = interruptStateRef.current;
@@ -196,21 +198,28 @@ export function useInterrupt<
       },
       onRunFinishedEvent: (params) => {
         if (params.outcome === "interrupt") {
+          const runId = params.input.runId;
+          for (const interrupt of params.interrupts) {
+            interruptRunIdsRef.current.set(interrupt.id, runId);
+          }
           localStandard = params.interrupts;
         }
       },
       onRunStartedEvent: () => {
         localLegacy = null;
         localStandard = null;
+        interruptRunIdsRef.current.clear();
+        legacyRunIdRef.current = undefined;
         interruptState.clear();
         setPending(null);
       },
-      onRunFinalized: () => {
+      onRunFinalized: (params) => {
         // Standard wins if both somehow appear for one run.
         if (localStandard && localStandard.length > 0) {
           interruptState.setStandard(localStandard);
           setPending(interruptState.pending);
         } else if (localLegacy) {
+          legacyRunIdRef.current = params.input.runId;
           interruptState.setLegacy(localLegacy);
           setPending(interruptState.pending);
         }
@@ -220,6 +229,8 @@ export function useInterrupt<
       onRunFailed: () => {
         localLegacy = null;
         localStandard = null;
+        interruptRunIdsRef.current.clear();
+        legacyRunIdRef.current = undefined;
         interruptState.clear();
         setPending(null);
       },
@@ -247,9 +258,11 @@ export function useInterrupt<
       }
       const decision = interruptStateRef.current.resolve(payload, interruptId);
       if (decision.kind === "legacy-resume") {
+        const runId = legacyRunIdRef.current;
         try {
           return await copilotkit.runAgent({
             agent,
+            ...(runId !== undefined ? { runId } : {}),
             forwardedProps: {
               command: {
                 resume: decision.payload,
@@ -275,6 +288,9 @@ export function useInterrupt<
         return;
       }
       if (decision.kind !== "resume") return;
+      const runId = decision.resume
+        .map((entry) => interruptRunIdsRef.current.get(entry.interruptId))
+        .find((candidate): candidate is string => candidate !== undefined);
       for (const toolResult of decision.toolResults) {
         agent.addMessage({
           id: randomUUID(),
@@ -284,7 +300,11 @@ export function useInterrupt<
         } as Message);
       }
       try {
-        return await copilotkit.runAgent({ agent, resume: decision.resume });
+        return await copilotkit.runAgent({
+          agent,
+          resume: decision.resume,
+          ...(runId !== undefined ? { runId } : {}),
+        });
       } catch (err) {
         console.error(
           "[CopilotKit] useInterrupt resolve: runAgent rejected; clearing pending + rethrowing",
@@ -331,6 +351,9 @@ export function useInterrupt<
         return;
       }
       if (decision.kind !== "resume") return;
+      const runId = decision.resume
+        .map((entry) => interruptRunIdsRef.current.get(entry.interruptId))
+        .find((candidate): candidate is string => candidate !== undefined);
       for (const toolResult of decision.toolResults) {
         agent.addMessage({
           id: randomUUID(),
@@ -340,7 +363,11 @@ export function useInterrupt<
         } as Message);
       }
       try {
-        return await copilotkit.runAgent({ agent, resume: decision.resume });
+        return await copilotkit.runAgent({
+          agent,
+          resume: decision.resume,
+          ...(runId !== undefined ? { runId } : {}),
+        });
       } catch (err) {
         console.error(
           "[CopilotKit] useInterrupt resolve: runAgent rejected; clearing pending + rethrowing",


### PR DESCRIPTION
## Summary

Preserve the logical run ID when a legacy `useCopilotAction({ renderAndWaitForResponse })` frontend tool resolves and `processAgentResult` starts its recursive follow-up.

The run handler binds each internal continuation handoff to the exact follow-up invocation, cancels it when setup fails or no run starts, and keeps the handoff out of the public `CopilotKitCore.runAgent` contract. The public regression drives the legacy hook through its `useHumanInTheLoop` and `useFrontendTool` path, renders the approval control, resolves it, and verifies both agent calls use the same generated ID.

Closes https://github.com/CopilotKit/CopilotKit/issues/3456

## Changes

- Preserve the originating ID across recursive frontend-tool follow-up runs
- Keep the existing legacy HITL registration and response behavior unchanged
- Add core follow-up coverage and a public `useCopilotAction` regression
- Retain the existing standard/legacy interrupt and StateManager coverage from the earlier fix

## Test plan

- [x] `pnpm -C packages/react-core exec vitest run src/hooks/__tests__/use-copilot-action.e2e.test.tsx`
- [x] `pnpm -C packages/core exec vitest run src/__tests__/core-follow-up.test.ts`
- [x] `pnpm -C packages/react-core exec vitest run src/v2/hooks/__tests__/use-interrupt.test.tsx`
- [x] `pnpm -C packages/core exec vitest run src/__tests__/state-manager.test.ts`, 39 tests passed
- [x] `pnpm -C packages/react-core exec vitest run`, 123 files and 1475 tests passed
- [x] `pnpm -C packages/core exec vitest run`, 58 files and 625 tests passed
- [x] `pnpm -C packages/core run check-types`
- [x] `pnpm -C packages/react-core run check-types`
- [x] `pnpm exec oxfmt --check` on all eight changed source/test files
- [x] `pnpm exec oxlint` on all eight changed source/test files, 5 pre-existing warnings and 0 errors

