### PR TITLE
chore(channels): drop references to canceled OSS tickets in code comments

### DIFF
--- a/packages/channels-core/src/codec.ts
+++ b/packages/channels-core/src/codec.ts
@@ -12,10 +12,12 @@ import type { ChannelNode } from "@copilotkit/channels-ui";
  * excludes both — `renderEgress` is pure (IR → native payload); the actual
  * send happens in the Gateway with Intelligence-owned credentials.
  *
- * TODO(OSS-363): add `normalizeIngress(raw): NeutralEvent` once the pure Slack
- * ingress mapping (mention stripping, stable event-id derivation, real-user
- * filtering, field extraction) is extracted from the Bolt listener so both the
- * local adapter and Intelligence's webhook ingress consume the same logic.
+ * TODO (untracked): add `normalizeIngress(raw): NeutralEvent` so both the local
+ * adapter and Intelligence's webhook ingress consume the same logic. The stated
+ * precondition is already met — the pure Slack ingress mapping (mention stripping,
+ * stable event-id derivation, real-user filtering, field extraction) now lives in
+ * `channels-slack/src/ingress-normalize.ts`. The original tracking ticket (OSS-363)
+ * was canceled 2026-07-01, superseded by OSS-401 — re-file before acting.
  */
 export interface PlatformCodec {
   readonly platform: string;

--- a/packages/channels-intelligence/src/runtime.ts
+++ b/packages/channels-intelligence/src/runtime.ts
@@ -87,7 +87,9 @@ export function resolveChannelActivationEnv(
  * (the managed launcher does). A nameless Channel is a programming error and throws
  * rather than being silently filtered out of the activation set.
  *
- * TODO(OSS-377): add richer per-Channel capabilities once the framework Channel exposes them.
+ * TODO (untracked): add richer per-Channel capabilities once the framework Channel
+ * exposes them. The original tracking ticket (OSS-377) was canceled 2026-07-01,
+ * superseded by OSS-401's consolidated realtime foundation — re-file before acting.
  */
 export function buildChannelActivationMetadata(
   channels: readonly Channel[],

--- a/packages/channels-slack/src/ingress-normalize.ts
+++ b/packages/channels-slack/src/ingress-normalize.ts
@@ -1,5 +1,5 @@
 // Pure, Bolt-free Slack ingress semantics. Shared by the local Slack adapter's
-// Bolt listener AND the Intelligence-side webhook ingress (OSS-362), so the
+// Bolt listener AND the Intelligence-side webhook ingress, so the
 // platform-specific parsing (mention stripping, stable event-id derivation,
 // real-user-message filtering, field extraction) lives in ONE place instead of
 // being duplicated. No `@slack/bolt`, no Slack credentials, no network.


### PR DESCRIPTION
## What

Three comments in the channels packages point at Linear tickets that were **canceled on 2026-07-01** (superseded by OSS-401's consolidated realtime foundation). They read as live tracking pointers when nothing actually tracks the work.

| File | Reference | Ticket status |
|---|---|---|
| `packages/channels-core/src/codec.ts` | `TODO(OSS-363)` | Canceled |
| `packages/channels-intelligence/src/runtime.ts` | `TODO(OSS-377)` | Canceled |
| `packages/channels-slack/src/ingress-normalize.ts` | `(OSS-362)` provenance note | Canceled |

## How

The engineering intent is **preserved** in each case and re-marked as `TODO (untracked)` with a note that the original ticket was canceled — so a reader re-files rather than chasing a dead ticket. The `OSS-362` mention was a bare provenance parenthetical carrying no intent, so it is simply dropped.

`codec.ts` additionally records that the TODO's stated precondition is **already met**: the pure Slack ingress mapping (mention stripping, stable event-id derivation, real-user filtering, field extraction) now lives in `channels-slack/src/ingress-normalize.ts`. The remaining work is hoisting `normalizeIngress` onto the generic `PlatformCodec` — worth knowing for whoever picks it up.

## Why this came up

While grounding a Channels x AG-UI gap analysis, several `OSS-###` comments turned out to reference closed tickets — three canceled, two already done. The done ones (OSS-450 Teams managed, OSS-491 delivery terminal-signal) had already been cleaned out of `main` by subsequent work; these three canceled ones are what remain.

## Scope / notes

- **Comment-only. No behavior change.** `oxfmt --check` and `oxlint` both clean.
- Out of scope, flagged for a possible follow-up: `OSS-406` (`channels-intelligence/src/index.ts`) and `OSS-599` (`runtime/.../channel-manager.ts`, 5 references) are also canceled, but sit outside the channels packages surveyed here. Other referenced tickets (`OSS-96/162/476/566/568/621/623/641/670/691`) were not status-checked.