### PR TITLE
feat(skills): make managed Intelligence the default setup path, add a Channels skill (refs OSS-705)

### DIFF
--- a/packages/channels-slack/README.md
+++ b/packages/channels-slack/README.md
@@ -14,6 +14,20 @@ Channel itself only runs inside a CopilotKit Intelligence-configured
 standalone / DIY runner and no `channel.start()`; the runtime starts and owns
 the channel because Intelligence is configured.
 
+## Managed Channels: the alternative to holding your own credentials
+
+This adapter is the **self-hosted** path: your process holds the Slack credentials, runs the Slack ingress, and talks to Slack directly.
+
+**Managed Intelligence Channels** is the alternative. Intelligence owns the provider edge — signed ingress, egress, and encrypted credential storage — so your process holds no Slack credentials and exposes no public Slack endpoint. You also get durable threads, the Channels dashboard with per-Channel health and transcripts, and guided provider setup from either the browser wizard or the CLI:
+
+```bash
+npx copilotkit channels add support
+```
+
+Your bot code is otherwise identical — the agent, tools, context, commands, and turn handlers do not change. Only the transport does. See `examples/slack/app/managed.ts` for the same bot wired both ways, and the **copilotkit-channels** skill for the runtime wiring.
+
+This self-hosted adapter remains fully supported. Choose it when you want the provider connection inside your own infrastructure.
+
 ## Install
 
 ```sh

--- a/packages/channels-teams/README.md
+++ b/packages/channels-teams/README.md
@@ -16,6 +16,20 @@ Channel itself only runs inside a CopilotKit Intelligence-configured
 standalone / DIY runner and no `channel.start()`; the runtime starts and owns
 the channel because Intelligence is configured.
 
+## Managed Channels: the alternative to holding your own credentials
+
+This adapter is the **self-hosted** path: your process holds the Microsoft Teams credentials, runs the Microsoft Teams ingress, and talks to Microsoft Teams directly.
+
+**Managed Intelligence Channels** is the alternative. Intelligence owns the provider edge — signed ingress, egress, and encrypted credential storage — so your process holds no Microsoft Teams credentials and exposes no public Microsoft Teams endpoint. You also get durable threads, the Channels dashboard with per-Channel health and transcripts, and guided provider setup from either the browser wizard or the CLI:
+
+```bash
+npx copilotkit channels add support --adapter teams
+```
+
+Your bot code is otherwise identical — the agent, tools, context, commands, and turn handlers do not change. Only the transport does. See `examples/teams/app/managed.ts` for the same bot wired both ways, and the **copilotkit-channels** skill for the runtime wiring.
+
+This self-hosted adapter remains fully supported. Choose it when you want the provider connection inside your own infrastructure.
+
 ## Install
 
 ```sh

--- a/scripts/__tests__/sync-plugin-skills.test.ts
+++ b/scripts/__tests__/sync-plugin-skills.test.ts
@@ -132,7 +132,11 @@ describe("syncPluginSkills", () => {
   it("exports the reserved lifecycle slug set", () => {
     expect(RESERVED_LIFECYCLE_SLUGS).toContain("copilotkit-setup");
     expect(RESERVED_LIFECYCLE_SLUGS).toContain("copilotkit-self-update");
-    expect(RESERVED_LIFECYCLE_SLUGS.size).toBe(8);
+    // A standalone skill MUST be listed here. It is not generated from
+    // packages/*/skills, so without an entry the sync treats it as an orphan and
+    // deletes it.
+    expect(RESERVED_LIFECYCLE_SLUGS).toContain("copilotkit-channels");
+    expect(RESERVED_LIFECYCLE_SLUGS.size).toBe(9);
   });
 
   // Version sync — the plugin version tracks packages/runtime/package.json.

--- a/scripts/sync-plugin-skills.ts
+++ b/scripts/sync-plugin-skills.ts
@@ -9,6 +9,7 @@ const toPosix = (p: string) => p.split("\\").join("/");
 export const RESERVED_LIFECYCLE_SLUGS: ReadonlySet<string> = new Set([
   // Standalone skills — not generated from packages/*/skills, exempt from orphan detection
   "copilotkit-setup",
+  "copilotkit-channels",
   "copilotkit-develop",
   "copilotkit-agui",
   "copilotkit-integrations",

--- a/showcase/shell-docs/src/content/docs/channels/intelligence.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/intelligence.mdx
@@ -15,16 +15,21 @@ interactive behavior, state, and deployment.
 
 ## Choose how to configure it
 
-Two supported paths do the same work. Both create the Channel, store the
+Three supported paths do the same work. All three create the Channel, store the
 provider credentials, and leave the Channel waiting for your runtime.
 
+- **`copilotkit init`**, when the project does not exist yet. It offers a
+  Channel during setup and then leads you through the rest of it -- opening the
+  provider console, taking the two credentials at a masked prompt, and
+  attaching them -- after your dependencies install. The project it scaffolds
+  ships the long-running host too, so `npm run channel` is the only step left.
 - **The browser wizard**, below. Best when you want to see the Channel, its
   health, and its threads while you set it up. Requires no terminal.
-- **The CLI**, `copilotkit channels`. Best when you want the configuration
-  checked into the repository, want to re-run setup on another machine, or are
-  working with an agent. It records the Channel in
-  `.copilotkit/channels.json`, generates the same provider app manifest, and
-  reports what remains at each stop.
+- **The CLI**, `copilotkit channels`. Best for a project that already exists,
+  when you want the configuration checked into the repository, want to re-run
+  setup on another machine, or are working with an agent. It records the
+  Channel in `.copilotkit/channels.json`, generates the same provider app
+  manifest, and reports what remains at each stop.
 
 ```bash
 npx copilotkit channels add support
@@ -37,10 +42,12 @@ to open, which environment variables to set, and the exact command to resume
 with. No flag accepts a credential value, and `--json` emits a versioned envelope
 for scripts and agents.
 
-<Callout type="info" title="The CLI and the wizard are interchangeable">
-  Either can finish what the other started -- both reconcile against the same
-  server state. A Channel created in the wizard can be managed with the CLI, and
-  a Channel created with the CLI appears in the dashboard immediately.
+<Callout type="info" title="The paths are interchangeable">
+  Any of them can finish what another started -- all three reconcile against the
+  same server state. A Channel created in the wizard can be managed with the CLI,
+  a Channel created with the CLI appears in the dashboard immediately, and a
+  Channel begun by `init` is finished by `channels add` if you skip its guided
+  step.
 </Callout>
 
 ## Create and configure your Channel

--- a/showcase/shell-docs/src/content/docs/channels/intelligence.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/intelligence.mdx
@@ -13,6 +13,36 @@ In the managed path, Intelligence owns the provider connection and durable
 delivery edge. Your long-running process owns the agent, application tools,
 interactive behavior, state, and deployment.
 
+## Choose how to configure it
+
+Two supported paths do the same work. Both create the Channel, store the
+provider credentials, and leave the Channel waiting for your runtime.
+
+- **The browser wizard**, below. Best when you want to see the Channel, its
+  health, and its threads while you set it up. Requires no terminal.
+- **The CLI**, `copilotkit channels`. Best when you want the configuration
+  checked into the repository, want to re-run setup on another machine, or are
+  working with an agent. It records the Channel in
+  `.copilotkit/channels.json`, generates the same provider app manifest, and
+  reports what remains at each stop.
+
+```bash
+npx copilotkit channels add support
+npx copilotkit channels status
+```
+
+`channels add` performs the next undone step and is safe to re-run. Where the
+flow needs you in a provider console it stops and prints what is needed, the URL
+to open, which environment variables to set, and the exact command to resume
+with. No flag accepts a credential value, and `--json` emits a versioned envelope
+for scripts and agents.
+
+<Callout type="info" title="The CLI and the wizard are interchangeable">
+  Either can finish what the other started -- both reconcile against the same
+  server state. A Channel created in the wizard can be managed with the CLI, and
+  a Channel created with the CLI appears in the dashboard immediately.
+</Callout>
+
 ## Create and configure your Channel
 
 <FrontendOnly frontend="slack">

--- a/skills/copilotkit-channels/SKILL.md
+++ b/skills/copilotkit-channels/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: copilotkit-channels
+description: >
+  Use when connecting a CopilotKit agent to Slack or Microsoft Teams with managed
+  Intelligence Channels. Covers the Channel declaration, the long-running host
+  requirement, the awaited activation call, and how the code half pairs with the
+  provider setup done by the CLI or the dashboard wizard.
+version: 1.0.0
+---
+
+# CopilotKit Channels
+
+Managed Channels let an agent answer in Slack or Microsoft Teams. Intelligence owns the provider edge — signed ingress, egress, credential storage — and delivers turns to your runtime over its realtime transport.
+
+## Scope
+
+This skill covers **managed Intelligence Channels**: `CopilotIntelligenceRuntime`, app-api Channel resources, and the realtime gateway.
+
+It does **not** cover the self-hosted `@copilotkit/channels` provider adapters (`@copilotkit/channels-slack`, `-teams`, `-discord`, `-telegram`, `-whatsapp`). Those hold provider credentials in your process and talk to the provider directly. Both products use the words "channels" and "Slack", so confirm which one the user means before wiring anything. If they want to hold their own Slack tokens and run their own ingress, they want the adapter packages, not this skill.
+
+## A Channel has two halves
+
+A Channel only works when both are correct, and each half is invisible from the other:
+
+1. **The provider half** — an app registered with Slack or Microsoft, credentials stored server-side, ingress pointed at Intelligence. Done with `npx copilotkit channels add` or the dashboard wizard.
+2. **The code half** — a long-running runtime that declares the Channel and awaits activation. **That is what this skill does.**
+
+The most confusing failure in this product is a correct provider half with a missing code half: the app serves HTTP normally, reports no error, shows an encouraging badge in the dashboard, and answers nothing. Nothing in the browser can diagnose it, because the missing piece is in the source tree.
+
+## Prerequisites
+
+Before starting, confirm all four. Stop and fix any that fail — each one produces a silent failure rather than an error.
+
+1. **The Intelligence runtime is wired.** `channels` is not available in SSE mode; the type is `channels?: undefined` there. If the project still constructs `CopilotRuntime` with a `runner` and no `intelligence`, do the managed Intelligence step in the **copilotkit-setup** skill first.
+2. **A long-running host.** Activation opens a persistent connection, so the process has to outlive a request. A Next.js route handler on serverless, a Lambda, or an edge function cannot host a Channel. See "Deployment shape" below.
+3. **The hosted environment values are set** — the project API key, and the realtime URL if you are overriding defaults.
+4. **The provider half exists, or is in progress.** The two halves can be done in either order; a Channel simply does not answer until both are done.
+
+## Step 1: Install
+
+```bash
+npm install @copilotkit/channels
+```
+
+`@copilotkit/channels` provides `createChannel`. The managed transport itself is built into `@copilotkit/runtime` — there is no separate adapter package to install for the managed path, and no provider credentials in your process.
+
+## Step 2: Declare the Channel
+
+The Channel's `name` is chosen here, in code. It is the project-unique identifier the runtime uses to derive the managed Channel's activation config — project id, adapter, socket URL and auth — so you supply none of those.
+
+```typescript
+import { createChannel } from "@copilotkit/channels";
+
+const support = createChannel({
+  // Must match the Channel name configured on the provider half.
+  // Lowercase kebab-case, unique within the project.
+  name: "support",
+  agent: (threadId) => {
+    const agent = new MyAgent();
+    agent.threadId = threadId;
+    return agent;
+  },
+});
+
+support.onMention(async ({ thread, message }) => {
+  await thread.runAgent({
+    // Channel history does NOT include the in-flight turn, so pass the current
+    // message explicitly -- otherwise the agent runs with zero messages.
+    prompt: message.contentParts?.length ? message.contentParts : message.text,
+  });
+});
+```
+
+The agent is **framework-agnostic**: `agent` accepts any AG-UI `AbstractAgent`, including a remote one. A Python or .NET agent stays exactly where it is and a small TypeScript host proxies to it — adopting Channels never means porting an agent.
+
+## Step 3: Pass the Channel to the runtime
+
+```typescript
+import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+
+const intelligence = new CopilotKitIntelligence({
+  apiKey: process.env.COPILOTKIT_API_KEY!,
+});
+
+const runtime = new CopilotRuntime({
+  // A Channel supplies its own agent, so runtime-hosted agents are optional here.
+  agents: {},
+  intelligence,
+  identifyUser: (request) => resolveUserFromSession(request),
+  channels: [support],
+});
+```
+
+## Step 4: Mount a long-running host and activate
+
+```typescript
+import { createServer } from "node:http";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
+
+const listener = createCopilotNodeListener({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+createServer(listener).listen(Number(process.env.PORT ?? 8300));
+
+// THIS is what connects the Channel. Mounting the listener opens no connection.
+await listener.channels.ready();
+```
+
+**`await listener.channels.ready()` is the whole ballgame.** Channel activation is lazy on every host, including node and express — deliberately, so serverless and edge deployments stay safe. The gateway connection opens on the first awaited ready call and never before. A long-running host that omits it serves HTTP and connects nothing.
+
+There is no framework where activation happens implicitly. Whatever the host, the call must be present.
+
+Two details worth knowing:
+
+- `ready()` is **one-shot**: it settles on the initial activation outcome, not on later reconnects.
+- Pair it with shutdown so a redeploy releases the connection cleanly:
+
+  ```typescript
+  process.on("SIGTERM", async () => {
+    await listener.channels.stop();
+    process.exit(0);
+  });
+  ```
+
+## Deployment shape
+
+Deciding whether the project already has a long-running host is the judgement this skill exists to make. Detect the framework first (see the **copilotkit-setup** skill's `references/framework-detection.md`), then:
+
+| What the project runs today                    | What to do                                                       |
+| ---------------------------------------------- | ---------------------------------------------------------------- |
+| A standalone Node/Express/Hono server          | Declare the Channel on the runtime it already has                |
+| Next.js on Vercel, Lambda, or an edge function | Add a **separate** long-running process for the Channel          |
+| A Python or .NET agent                         | Leave it alone; add a small TypeScript channel host that proxies |
+
+A separate process is **not** mandated. If the project already runs a long-running runtime — one serving a React UI, for instance — that same runtime can declare Channels. A second process is required only when the existing runtime is serverless.
+
+When a separate host is needed, it is a small program: the runtime, the Channel, the listener, the ready call. It does not need to serve the UI, and there is no public provider ingress on its port — Intelligence owns the provider edge.
+
+## Step 5: Verify
+
+```bash
+npx copilotkit channels status
+```
+
+That compares three things that must agree — the declared configuration, the project source, and the server — and names whichever is missing. Then:
+
+1. Start the long-running host. It should log the activation.
+2. Invite the bot to a channel (`channels status` prints the invite command with the right handle).
+3. Mention the bot. You should get a reply.
+
+If nothing happens and there is no error, check in this order: is `ready()` awaited; is `intelligence` passed (not a `runner`); is the realtime URL correct; is the app installed and invited.
+
+Do not report a Channel as working because credentials were stored. A stored adapter proves the credentials are real — the server probed them — and nothing more. It does not prove the app is installed, that a channel was invited, or that a runtime is connected.
+
+## Never do these
+
+- **Do not write provider credentials into the project** for a managed Channel. Intelligence stores them server-side; the runtime never reads them. If the project holds a Slack bot token for a managed Channel, something is wired wrong.
+- **Do not put a Channel on a serverless route handler.** It will appear to deploy and never connect.
+- **Do not pass `runner` alongside `intelligence`.** That is what silently keeps threads in memory.
+- **Do not invent Channel infrastructure ids.** Project, adapter, and channel ids are derived from the Intelligence config plus the Channel `name`.

--- a/skills/copilotkit-channels/SKILL.md
+++ b/skills/copilotkit-channels/SKILL.md
@@ -102,6 +102,28 @@ If nothing happens and there is no error, check in this order: is `activateChann
 
 Do not report a Channel as working because credentials were stored. A stored adapter proves the credentials are real — the server probed them — and nothing more. It does not prove the app is installed, that a channel was invited, or that a runtime is connected.
 
+### Online, but silent — a different failure
+
+That checklist only covers a Channel that never connected. If the host logs `Channel "<name>" is online` and the bot still says nothing, the code half is **fine** — activation succeeded — and every item above will come back correct. Walking the list again is wasted time.
+
+Look in the host's own output for:
+
+```
+{ meta: { deliveryId: 'dlv_...', errorCategory: 'validation' } } channel delivery claim or join failed
+```
+
+That is the runtime rejecting the turn the server sent it, at the join boundary, before any handler runs. Nothing is posted back to the provider on this path, which is why it looks like silence rather than an error.
+
+The usual cause is a **version disagreement between the installed `@copilotkit/channels-*` packages and the Intelligence deployment serving them**. The runtime validates each delivery strictly — exact field sets, not a loose subset — so a client expecting a field its server does not yet send fails every turn of that kind, while a Channel that never receives one (Teams-only, or an idle Slack app) looks perfectly healthy.
+
+So:
+
+1. Note the installed versions: `npm ls @copilotkit/runtime @copilotkit/channels`.
+2. Compare them with the Intelligence deployment. On hosted Intelligence, a canary or prerelease client can run ahead of what is deployed. On self-hosted, the deployment is usually the one that lags.
+3. Move them onto matching lines. Pinning the client to a prerelease is the common way into this state.
+
+`errorCategory` is a classification, not the message — the underlying error text is deliberately not logged, so the category plus this note is the whole signal you get.
+
 ## Wiring a project the CLI did not generate
 
 Everything from here down is the hand-wiring path — the less-trodden one. If `channel-host.mts` exists, you are in the wrong section.

--- a/skills/copilotkit-channels/SKILL.md
+++ b/skills/copilotkit-channels/SKILL.md
@@ -91,7 +91,7 @@ const runtime = new CopilotRuntime({
 });
 ```
 
-## Step 4: Mount a long-running host and activate
+## Step 4: Mount a long-running host
 
 ```typescript
 import { createServer } from "node:http";
@@ -104,18 +104,31 @@ const listener = createCopilotNodeListener({
 
 createServer(listener).listen(Number(process.env.PORT ?? 8300));
 
-// THIS is what connects the Channel. Mounting the listener opens no connection.
-await listener.channels.ready();
+// Optional on this mount, and worth doing: it turns a failed activation into a
+// startup failure instead of a line in the logs.
+await listener.channels.ready({ timeoutMs: 30_000 });
 ```
 
-**`await listener.channels.ready()` is the whole ballgame.** Channel activation is lazy on every host, including node and express — deliberately, so serverless and edge deployments stay safe. The gateway connection opens on the first awaited ready call and never before. A long-running host that omits it serves HTTP and connects nothing.
+### Whether you must call `ready()` depends on the mount
 
-There is no framework where activation happens implicitly. Whatever the host, the call must be present.
+This is the single most misunderstood thing about Channels. Activation is **not** lazy everywhere.
 
-Two details worth knowing:
+| Mount                                         | Activation                          | Is `ready()` required?   |
+| --------------------------------------------- | ----------------------------------- | ------------------------ |
+| `createCopilotNodeListener`                   | Starts when the listener is created | No — await it to observe |
+| `createCopilotExpressHandler`                 | Starts when the router is created   | No — await it to observe |
+| `createCopilotHonoHandler`                    | Deferred to the first `ready()`     | **Yes**                  |
+| `createCopilotRuntimeHandler` (generic fetch) | Deferred to the first `ready()`     | **Yes**                  |
+| any mount with `activateChannels: false`      | None; no control surface, no socket | Nothing will connect     |
 
-- `ready()` is **one-shot**: it settles on the initial activation outcome, not on later reconnects.
-- Pair it with shutdown so a redeploy releases the connection cleanly:
+The two lifecycle-owning wrappers start on their own because they own their process lifetime — a declared Channel connects because it was declared, and there is no incantation to forget. The fetch and hono handlers defer on purpose: they are the serverless and edge entry points, where an isolate freezes and recycles per request and separate cold starts would mint competing listeners for the same Channel.
+
+So the silent failure — a process that serves HTTP, looks healthy, and answers nothing — happens on a **deferring** mount when nothing ever calls `ready()`. On a node or express host, a missing `ready()` is not that failure.
+
+Two details either way:
+
+- `ready()` is **one-shot** and idempotent. It settles on the initial activation outcome, so awaiting it after an auto-start observes that activation rather than triggering a second one. It can resolve as `setup_required`, which means activation settled — not that delivery is healthy. Treat only `status().overall === "online"` as connected.
+- Pair activation with shutdown so a redeploy releases the connection cleanly:
 
   ```typescript
   process.on("SIGTERM", async () => {
@@ -150,7 +163,7 @@ That compares three things that must agree — the declared configuration, the p
 2. Invite the bot to a channel (`channels status` prints the invite command with the right handle).
 3. Mention the bot. You should get a reply.
 
-If nothing happens and there is no error, check in this order: is `ready()` awaited; is `intelligence` passed (not a `runner`); is the realtime URL correct; is the app installed and invited.
+If nothing happens and there is no error, check in this order: is `activateChannels: false` set anywhere; on a deferring mount, is `ready()` awaited; is `intelligence` passed (not a `runner`); is the realtime URL correct; is the app installed and invited.
 
 Do not report a Channel as working because credentials were stored. A stored adapter proves the credentials are real — the server probed them — and nothing more. It does not prove the app is installed, that a channel was invited, or that a runtime is connected.
 
@@ -158,5 +171,6 @@ Do not report a Channel as working because credentials were stored. A stored ada
 
 - **Do not write provider credentials into the project** for a managed Channel. Intelligence stores them server-side; the runtime never reads them. If the project holds a Slack bot token for a managed Channel, something is wired wrong.
 - **Do not put a Channel on a serverless route handler.** It will appear to deploy and never connect.
+- **Do not assume `ready()` is required, or that it is optional.** Check the mount. Telling someone to add a call they do not need is as unhelpful as omitting one they do.
 - **Do not pass `runner` alongside `intelligence`.** That is what silently keeps threads in memory.
 - **Do not invent Channel infrastructure ids.** Project, adapter, and channel ids are derived from the Intelligence config plus the Channel `name`.

--- a/skills/copilotkit-channels/SKILL.md
+++ b/skills/copilotkit-channels/SKILL.md
@@ -2,9 +2,9 @@
 name: copilotkit-channels
 description: >
   Use when connecting a CopilotKit agent to Slack or Microsoft Teams with managed
-  Intelligence Channels. Covers the Channel declaration, the long-running host
-  requirement, the awaited activation call, and how the code half pairs with the
-  provider setup done by the CLI or the dashboard wizard.
+  Intelligence Channels. Covers customising the Channel a CLI-scaffolded project
+  already ships, and — for a project the CLI did not generate — the Channel
+  declaration, the long-running host requirement, and the awaited activation call.
 version: 1.0.0
 ---
 
@@ -18,31 +18,104 @@ This skill covers **managed Intelligence Channels**: `CopilotIntelligenceRuntime
 
 It does **not** cover the self-hosted `@copilotkit/channels` provider adapters (`@copilotkit/channels-slack`, `-teams`, `-discord`, `-telegram`, `-whatsapp`). Those hold provider credentials in your process and talk to the provider directly. Both products use the words "channels" and "Slack", so confirm which one the user means before wiring anything. If they want to hold their own Slack tokens and run their own ingress, they want the adapter packages, not this skill.
 
-## What is well-trodden, and what is not
+## Decide which path you are on first
 
-The path exercised end to end today is a project scaffolded by `npx copilotkit init`, which offers a Channel during setup and writes the hosted values the runtime needs.
+Everything below depends on this, and getting it wrong produces a project with two Channel declarations that fight over one Channel.
 
-Wiring a project that already exists works and is supported, but it is less exercised: the CLI reads source it did not generate, and a project laid out unusually may get a `status` leg reported as `undetermined` rather than a confident answer. That is deliberate — an unsure answer is better than a wrong one — but expect to verify the wiring yourself rather than trusting a green report.
+**Look for `channel-host.mts` at the project root.**
+
+| It is there                                                                                                                                                                             | It is not                                                                                                                    |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| The project was scaffolded by `npx copilotkit init`. The code half is **already done** — go to "Customising a scaffolded Channel". Do not write a new host or a second `createChannel`. | The project predates the Channel, or was not made by the CLI. Go to "Wiring a project the CLI did not generate", at the end. |
+
+The scaffolded path is the one exercised end to end. Wiring an existing project is supported and works, but it is less trodden: the CLI reads source it did not generate, so a project laid out unusually may get a `status` leg reported as `undetermined` rather than a confident answer. That is deliberate — an unsure answer beats a wrong one — but verify the wiring yourself there rather than trusting a green report.
 
 ## A Channel has two halves
 
 A Channel only works when both are correct, and each half is invisible from the other:
 
-1. **The provider half** — an app registered with Slack or Microsoft, credentials stored server-side, ingress pointed at Intelligence. Done with `npx copilotkit channels add` or the dashboard wizard.
-2. **The code half** — a long-running runtime that declares the Channel and awaits activation. **That is what this skill does.**
+1. **The provider half** — an app registered with Slack or Microsoft, credentials stored server-side, ingress pointed at Intelligence. Three doors to it, all reconciling against the same server state so any can finish what another started: `npx copilotkit init` leads an interactive developer through the whole thing during setup; `npx copilotkit channels add` does it for an existing project or an agent; the dashboard wizard does it in a browser.
+2. **The code half** — a long-running runtime that declares the Channel and awaits activation. A scaffolded project **already has this**; for anything else, it is what this skill writes.
 
 The most confusing failure in this product is a correct provider half with a missing code half: the app serves HTTP normally, reports no error, shows an encouraging badge in the dashboard, and answers nothing. Nothing in the browser can diagnose it, because the missing piece is in the source tree.
 
-## Prerequisites
+## Customising a scaffolded Channel
 
-Before starting, confirm all four. Stop and fix any that fail — each one produces a silent failure rather than an error.
+A scaffolded project ships three files, and only one of them is yours to change:
+
+| File                               | What it is                                                    | Change it?                                                  |
+| ---------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------- |
+| `channels.mts`                     | The Channel: its name resolution, its agent, and its handlers | **Yes — this is where customisation goes**                  |
+| `channel-host.mts`                 | The process that owns the Channel's lifetime                  | No. It is identical in every starter and for every provider |
+| `src/agent.ts` (or `app/agent.ts`) | The agent both the web route and the Channel serve            | Only to change the agent itself                             |
+
+Run it with:
+
+```bash
+npm run channel
+```
+
+It prints `Channel "<name>" is online` when the gateway connection is live, or `declared but no provider is attached yet` when the provider half is unfinished — which is a waiting state, not an error.
+
+### What to change, and where
+
+Everything happens inside `createDefaultChannel` in `channels.mts`, on the `channel` object before it is returned:
+
+```typescript
+// Reply to a thread the bot is mentioned in, in addition to the messages it
+// already handles. Registering onMention does NOT replace onMessage: a
+// non-mention turn is only ever dispatched to message handlers, so removing
+// onMessage makes the bot silent in DMs and on 1:1 platforms.
+channel.onMention(async ({ thread, message }) => {
+  /* ... */
+});
+
+// Act on a reaction. `added` distinguishes an added emoji from a removed one,
+// and `thread` is the conversation it happened in.
+channel.onReaction(async ({ thread, emoji, added }) => {
+  /* ... */
+});
+```
+
+`onCommand` is deliberately absent from this list. Managed Slack Channels are events-only — there is no managed slash-command ingress — so registering one produces a handler nothing will ever call.
+
+Per-provider tools and context (`defaultSlackTools`, `defaultSlackContext`) are a deliberate omission from the scaffold, not an oversight: importing them makes the file provider-specific, and the scaffolded Channel is not. Add them here when the project only ever targets one provider.
+
+### Two things not to do to a scaffolded project
+
+- **Do not add a second `createChannel`.** The host resolves exactly one Channel name from `.copilotkit/channels.json` and refuses to start when several are declared. A second declaration in source does not produce a second bot; it produces a project that will not boot.
+- **Do not move the Channel into the Next.js route.** That route is serverless and cannot hold a connection open. The separate host exists for that reason.
+
+## Verify — either path
+
+```bash
+npx copilotkit channels status
+```
+
+That compares three things that must agree — the declared configuration, the project source, and the server — and names whichever is missing. Then:
+
+1. Start the long-running host — `npm run channel` in a scaffolded project. It should log the activation.
+2. Invite the bot to a channel (`channels status` prints the invite command with the right handle).
+3. Message the bot. You should get a reply.
+
+If nothing happens and there is no error, check in this order: is `activateChannels: false` set anywhere; on a deferring mount, is `ready()` awaited; is `intelligence` passed (not a `runner`); is the realtime URL correct; is the app installed and invited.
+
+Do not report a Channel as working because credentials were stored. A stored adapter proves the credentials are real — the server probed them — and nothing more. It does not prove the app is installed, that a channel was invited, or that a runtime is connected.
+
+## Wiring a project the CLI did not generate
+
+Everything from here down is the hand-wiring path — the less-trodden one. If `channel-host.mts` exists, you are in the wrong section.
+
+### Prerequisites
+
+A scaffolded project satisfies all four of these already. Before starting, confirm all four. Stop and fix any that fail — each one produces a silent failure rather than an error.
 
 1. **The Intelligence runtime is wired.** `channels` is not available in SSE mode; the type is `channels?: undefined` there. If the project still constructs `CopilotRuntime` with a `runner` and no `intelligence`, do the managed Intelligence step in the **copilotkit-setup** skill first.
 2. **A long-running host.** Activation opens a persistent connection, so the process has to outlive a request. A Next.js route handler on serverless, a Lambda, or an edge function cannot host a Channel. See "Deployment shape" below.
 3. **The hosted environment values are set** — the project API key, and the realtime URL if you are overriding defaults.
 4. **The provider half exists, or is in progress.** The two halves can be done in either order; a Channel simply does not answer until both are done.
 
-## Step 1: Install
+### Step 1: Install
 
 ```bash
 npm install @copilotkit/channels
@@ -50,7 +123,7 @@ npm install @copilotkit/channels
 
 `@copilotkit/channels` provides `createChannel`. The managed transport itself is built into `@copilotkit/runtime` — there is no separate adapter package to install for the managed path, and no provider credentials in your process.
 
-## Step 2: Declare the Channel
+### Step 2: Declare the Channel
 
 The Channel's `name` is chosen here, in code. It is the project-unique identifier the runtime uses to derive the managed Channel's activation config — project id, adapter, socket URL and auth — so you supply none of those.
 
@@ -79,7 +152,7 @@ support.onMention(async ({ thread, message }) => {
 
 The agent is **framework-agnostic**: `agent` accepts any AG-UI `AbstractAgent`, including a remote one. A Python or .NET agent stays exactly where it is and a small TypeScript host proxies to it — adopting Channels never means porting an agent.
 
-## Step 3: Pass the Channel to the runtime
+### Step 3: Pass the Channel to the runtime
 
 ```typescript
 import { CopilotRuntime, CopilotKitIntelligence } from "@copilotkit/runtime/v2";
@@ -97,7 +170,7 @@ const runtime = new CopilotRuntime({
 });
 ```
 
-## Step 4: Mount a long-running host
+### Step 4: Mount a long-running host
 
 ```typescript
 import { createServer } from "node:http";
@@ -115,7 +188,7 @@ createServer(listener).listen(Number(process.env.PORT ?? 8300));
 await listener.channels.ready({ timeoutMs: 30_000 });
 ```
 
-### Whether you must call `ready()` depends on the mount
+#### Whether you must call `ready()` depends on the mount
 
 This is the single most misunderstood thing about Channels. Activation is **not** lazy everywhere.
 
@@ -143,7 +216,7 @@ Two details either way:
   });
   ```
 
-## Deployment shape
+### Deployment shape
 
 Deciding whether the project already has a long-running host is the judgement this skill exists to make. Detect the framework first (see the **copilotkit-setup** skill's `references/framework-detection.md`), then:
 
@@ -155,23 +228,7 @@ Deciding whether the project already has a long-running host is the judgement th
 
 A separate process is **not** mandated. If the project already runs a long-running runtime — one serving a React UI, for instance — that same runtime can declare Channels. A second process is required only when the existing runtime is serverless.
 
-When a separate host is needed, it is a small program: the runtime, the Channel, the listener, the ready call. It does not need to serve the UI, and there is no public provider ingress on its port — Intelligence owns the provider edge.
-
-## Step 5: Verify
-
-```bash
-npx copilotkit channels status
-```
-
-That compares three things that must agree — the declared configuration, the project source, and the server — and names whichever is missing. Then:
-
-1. Start the long-running host. It should log the activation.
-2. Invite the bot to a channel (`channels status` prints the invite command with the right handle).
-3. Mention the bot. You should get a reply.
-
-If nothing happens and there is no error, check in this order: is `activateChannels: false` set anywhere; on a deferring mount, is `ready()` awaited; is `intelligence` passed (not a `runner`); is the realtime URL correct; is the app installed and invited.
-
-Do not report a Channel as working because credentials were stored. A stored adapter proves the credentials are real — the server probed them — and nothing more. It does not prove the app is installed, that a channel was invited, or that a runtime is connected.
+When a separate host is needed, it is a small program: the runtime, the Channel, and the awaited ready call. It does not need to serve the UI, and it does not need an HTTP server at all — nothing calls it. The gateway connection is outbound, and holding it open is what keeps the process alive. The scaffolded `channel-host.mts` is exactly this, and is worth reading as the reference implementation even when writing one by hand.
 
 ## Never do these
 
@@ -179,4 +236,5 @@ Do not report a Channel as working because credentials were stored. A stored ada
 - **Do not put a Channel on a serverless route handler.** It will appear to deploy and never connect.
 - **Do not assume `ready()` is required, or that it is optional.** Check the mount. Telling someone to add a call they do not need is as unhelpful as omitting one they do.
 - **Do not pass `runner` alongside `intelligence`.** That is what silently keeps threads in memory.
+- **Do not hand-wire a Channel into a scaffolded project.** If `channel-host.mts` is present the code half is done; adding a second declaration stops the host from booting rather than adding a bot.
 - **Do not invent Channel infrastructure ids.** Project, adapter, and channel ids are derived from the Intelligence config plus the Channel `name`.

--- a/skills/copilotkit-channels/SKILL.md
+++ b/skills/copilotkit-channels/SKILL.md
@@ -18,6 +18,12 @@ This skill covers **managed Intelligence Channels**: `CopilotIntelligenceRuntime
 
 It does **not** cover the self-hosted `@copilotkit/channels` provider adapters (`@copilotkit/channels-slack`, `-teams`, `-discord`, `-telegram`, `-whatsapp`). Those hold provider credentials in your process and talk to the provider directly. Both products use the words "channels" and "Slack", so confirm which one the user means before wiring anything. If they want to hold their own Slack tokens and run their own ingress, they want the adapter packages, not this skill.
 
+## What is well-trodden, and what is not
+
+The path exercised end to end today is a project scaffolded by `npx copilotkit init`, which offers a Channel during setup and writes the hosted values the runtime needs.
+
+Wiring a project that already exists works and is supported, but it is less exercised: the CLI reads source it did not generate, and a project laid out unusually may get a `status` leg reported as `undetermined` rather than a confident answer. That is deliberate — an unsure answer is better than a wrong one — but expect to verify the wiring yourself rather than trusting a green report.
+
 ## A Channel has two halves
 
 A Channel only works when both are correct, and each half is invisible from the other:

--- a/skills/copilotkit-channels/sources.md
+++ b/skills/copilotkit-channels/sources.md
@@ -20,7 +20,12 @@ Generated: 2026-08-01
   to the managed platform, and the warning that the two planes are separate hosts.
 - `packages/runtime/src/v2/runtime/core/channel-manager.ts` — `ready()` is one-shot and
   settles on the initial activation outcome.
-- `packages/runtime/src/v2/runtime/endpoints/node.ts` — the lazy-activation contract: the
-  connection opens on `await listener.channels.ready()` and never before, neither at
-  creation nor on mount.
+- `packages/runtime/src/v2/runtime/endpoints/node.ts` and `endpoints/express.ts` — these
+  lifecycle-owning wrappers START activation at creation; `ready()` there is optional and
+  purely await-and-observe.
+- `packages/runtime/src/v2/runtime/core/fetch-handler.ts` and `endpoints/hono.ts` — these
+  stay LAZY: activation is triggered by the first `ready()` and never before.
+- `packages/runtime/src/v2/runtime/endpoints/auto-start-channels.ts` — why the split exists
+  (an isolate recycles per request, so separate cold starts would mint competing listeners
+  for one Channel) and that `activateChannels: false` is the clean opt-out.
 - `packages/channels-*/README.md` — the self-hosted adapter family, for the scope boundary.

--- a/skills/copilotkit-channels/sources.md
+++ b/skills/copilotkit-channels/sources.md
@@ -1,0 +1,26 @@
+# Sources
+
+Files read from CopilotKit/CopilotKit to write this skill.
+Generated: 2026-08-01
+
+## SKILL.md
+
+- `examples/slack/app/managed.ts` — the canonical managed-Channel wiring: `createChannel`,
+  `new CopilotRuntime({ intelligence, identifyUser, channels })`, `createCopilotNodeListener`,
+  `await listener.channels.ready()`, and `listener.channels.stop()` on shutdown. Also the
+  source of the "Channel history does not include the in-flight turn" note.
+- `examples/slack/app/index.ts` and `examples/teams/app/index.tsx` — the self-hosted adapter
+  variants, read to state the managed-versus-OSS boundary accurately.
+- `packages/runtime/dist/v2/runtime/core/runtime.d.mts` — `CopilotIntelligenceRuntimeOptions`
+  (`intelligence`, `identifyUser`, `channels?: Channel[]`) and `CopilotSseRuntimeOptions`
+  (`channels?: undefined`), which is what makes "Channels require the Intelligence runtime"
+  a type-level fact rather than a convention.
+- `packages/runtime/dist/v2/runtime/intelligence-platform/client.d.mts` —
+  `CopilotKitIntelligenceConfig`: `apiKey` required, `apiUrl`/`wsUrl` optional and defaulting
+  to the managed platform, and the warning that the two planes are separate hosts.
+- `packages/runtime/src/v2/runtime/core/channel-manager.ts` — `ready()` is one-shot and
+  settles on the initial activation outcome.
+- `packages/runtime/src/v2/runtime/endpoints/node.ts` — the lazy-activation contract: the
+  connection opens on `await listener.channels.ready()` and never before, neither at
+  creation nor on mount.
+- `packages/channels-*/README.md` — the self-hosted adapter family, for the scope boundary.

--- a/skills/copilotkit-setup/SKILL.md
+++ b/skills/copilotkit-setup/SKILL.md
@@ -2,9 +2,10 @@
 name: copilotkit-setup
 description: >
   Use when adding CopilotKit to an existing project or bootstrapping a new CopilotKit
-  project from scratch. Covers framework detection, package installation, runtime wiring,
-  provider setup, and first working chat integration.
-version: 1.1.2
+  project from scratch. Covers framework detection, package installation, runtime wiring
+  (managed Intelligence or self-hosted SSE), provider setup, and first working chat
+  integration.
+version: 1.2.0
 ---
 
 # CopilotKit Setup
@@ -74,9 +75,24 @@ npm install -D @types/express tsx typescript
 (`createCopilotExpressHandler` enables CORS internally, so you do not need to
 install `cors` yourself. `dotenv` and `zod` are used by the example asset.)
 
-### Step 2: Configure the runtime
+### Step 2: Choose a runtime mode, then configure the runtime
 
 The runtime is the server-side component that manages agent execution. See `references/runtime-architecture.md` for details.
+
+**Decide the mode before writing any runtime code.** The mode changes how the runtime is constructed, so retrofitting it later means rewriting this file.
+
+| Mode                                   | Thread state               | Choose it when                                                                     |
+| -------------------------------------- | -------------------------- | ---------------------------------------------------------------------------------- |
+| **Managed Intelligence** (recommended) | Durable, hosted            | You want threads that survive restarts, hosted ingress, the dashboard, or Channels |
+| Self-hosted SSE                        | In-memory, lost on restart | You do not want a hosted dependency and are willing to own persistence yourself    |
+
+Ask the user which they want, defaulting to managed Intelligence. State the prerequisites plainly so the choice is informed:
+
+**Managed Intelligence requires** a CopilotKit account (free; `npx copilotkit login` opens the browser) and a project API key. In exchange, threads are durable across restarts and deploys, you get the dashboard, and Slack/Teams Channels become available -- Channels are not available in SSE mode at all.
+
+**Self-hosted SSE requires** nothing beyond an AI provider key. Thread state lives in memory in the process that served the request, so it is lost on restart and is not shared across replicas. Everything in this skill works in SSE mode; it is a supported path, not a dead end.
+
+If the user picks managed Intelligence, use the Intelligence runtime blocks below and then complete Step 6. If they pick SSE, use the SSE blocks and skip Step 6's server-side wiring.
 
 There are two endpoint styles:
 
@@ -120,6 +136,56 @@ export const POST = handle(app);
 export const PATCH = handle(app);
 export const DELETE = handle(app);
 ```
+
+#### Next.js App Router with managed Intelligence
+
+Same file and same handler as above; only the runtime construction differs. `intelligence` is what selects Intelligence mode, and `identifyUser` is required with it.
+
+```typescript
+import {
+  CopilotRuntime,
+  CopilotKitIntelligence,
+  createCopilotHonoHandler,
+  BuiltInAgent,
+} from "@copilotkit/runtime/v2";
+import { handle } from "hono/vercel";
+
+const agent = new BuiltInAgent({
+  model: "openai/gpt-4o",
+  prompt: "You are a helpful AI assistant.",
+});
+
+const intelligence = new CopilotKitIntelligence({
+  // Server-side secret. `apiUrl`/`wsUrl` default to CopilotKit's managed
+  // platform, so most projects set only the key.
+  apiKey: process.env.COPILOTKIT_API_KEY!,
+});
+
+const runtime = new CopilotRuntime({
+  agents: { default: agent },
+  intelligence,
+  // REQUIRED in Intelligence mode: it decides whose threads these are. Resolve a
+  // real authenticated user from the request -- with a hardcoded id, every visitor
+  // shares one thread history.
+  identifyUser: (request) => resolveUserFromSession(request),
+});
+
+const app = createCopilotHonoHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
+```
+
+Notes that matter:
+
+- **Do not pass `runner`.** Intelligence mode supplies `IntelligenceAgentRunner` itself; passing `InMemoryAgentRunner` is what keeps threads in memory.
+- **`identifyUser` is not optional.** It is the thread-ownership boundary. A stub like `() => ({ id: "demo", name: "Demo" })` is fine for a local spike and wrong for anything multi-user.
+- **`apiUrl` and `wsUrl` are separate hosts.** They default to `https://api.intelligence.copilotkit.ai` and `wss://realtime.intelligence.copilotkit.ai`. The realtime plane cannot be derived from the API plane by swapping the scheme, so override **both or neither** -- overriding one points the two planes at different deployments.
 
 #### Next.js App Router (alternative: single-route)
 
@@ -334,31 +400,61 @@ The `BuiltInAgent` automatically resolves API keys from these environment variab
 
 If you need to pass `apiKey` explicitly, always source it from the environment (`apiKey: process.env.OPENAI_API_KEY`) -- never inline a literal key.
 
-### Step 6: Connect to CopilotKit Intelligence (telemetry)
+### Step 6: Connect to CopilotKit Intelligence
 
-CopilotKit uses telemetry to understand adoption, improve the product, and provide better support. Connecting to CopilotKit Intelligence gives you access to analytics and optional premium features.
+Skip this step only if the user chose self-hosted SSE in Step 2.
 
-1. Ask the user if they'd like to connect to CopilotKit Intelligence (default: yes).
-2. If yes, run the CopilotKit CLI authentication flow (verify the exact command with `npx copilotkit --help` as it may vary by version):
+Intelligence has two halves and they use different credentials. Getting them mixed up is the most common setup mistake here.
+
+| Credential                  | Where it lives | Secret? | Purpose                                       |
+| --------------------------- | -------------- | ------- | --------------------------------------------- |
+| Project API key (`cpk-...`) | Server only    | **Yes** | The runtime authenticates to Intelligence     |
+| Public license key          | Client         | No      | Enables licensed frontend features, telemetry |
+
+1. **Sign in and create a project.**
+
    ```bash
-   npx copilotkit auth
+   npx copilotkit login
+   npx copilotkit project select
    ```
-3. Guide the user through the browser-based authentication that opens.
-4. Once authentication completes, the CLI outputs a license key (a public, client-side project identifier -- not a secret).
-5. Store the license key in an environment variable and reference it from the `CopilotKit` provider -- this keeps it out of source and easy to rotate per environment:
+
+   `login` opens the browser and stores a local CLI session. `project select` picks or creates a hosted project and records it in `.copilotkit/project.json`. Verify the available commands with `npx copilotkit --help` if a version differs.
+
+2. **Set the server-side project API key.** `project select` provisions one; you can also copy it from the dashboard.
+
    ```
-   # .env.local (Next.js)
+   # .env.local (Next.js) or .env
+   COPILOTKIT_API_KEY=cpk-...
+   ```
+
+   This is a secret. It has no `NEXT_PUBLIC_`/`VITE_` prefix on purpose -- prefixing it would ship it to the browser. It is read by the `CopilotKitIntelligence` client you wired in Step 2.
+
+   CLI-scaffolded projects use `INTELLIGENCE_API_KEY` for the same value; either name is fine as long as the runtime reads the one you set.
+
+3. **Set the public license key** and pass it to the provider. Unlike the API key, this one is a public project identifier and is meant to reach the client:
+
+   ```
    NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY=<your-license-key>
    ```
+
    ```tsx
    <CopilotKit
      runtimeUrl="/api/copilotkit"
      publicLicenseKey={process.env.NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY}
    >
    ```
+
    The `NEXT_PUBLIC_`/`VITE_` prefix is required because the key is read on the client.
 
-See `references/telemetry-setup.md` for full details on what the license key enables and how to opt out.
+4. **Confirm durable threads actually work.** Send a message, restart the dev server, and reload. The thread should still be there. If it is not, the runtime is still in SSE mode -- check that `intelligence` is passed and that no `runner` overrides it.
+
+See `references/telemetry-setup.md` for what the license key enables and how to opt out.
+
+#### Connecting Slack or Microsoft Teams
+
+Channels let an agent answer in Slack or Teams. They require the Intelligence runtime -- `channels` is not available in SSE mode -- and a long-running host, because activation opens a persistent connection.
+
+Use the **copilotkit-channels** skill for this. It covers declaring a Channel, the awaited activation call, and the long-running host requirement, and it builds on the wiring from this step.
 
 ### Step 7: Verify the setup
 
@@ -398,11 +494,14 @@ Keep these in mind as you wire up a real deployment:
 
 ### Runtime classes
 
-| Class                        | Use case                                                  |
-| ---------------------------- | --------------------------------------------------------- |
-| `CopilotRuntime`             | Compatibility shim; auto-selects SSE or Intelligence mode |
-| `CopilotSseRuntime`          | Explicit SSE mode (default, in-memory threads)            |
-| `CopilotIntelligenceRuntime` | Intelligence mode (durable threads, realtime events)      |
+| Class                        | Use case                                                       |
+| ---------------------------- | -------------------------------------------------------------- |
+| `CopilotRuntime`             | Compatibility shim; auto-selects SSE or Intelligence mode      |
+| `CopilotSseRuntime`          | Explicit SSE mode (default, in-memory threads)                 |
+| `CopilotIntelligenceRuntime` | Intelligence mode (durable threads, realtime events, Channels) |
+
+Channels require the Intelligence runtime and a long-running host. See the
+**copilotkit-channels** skill.
 
 ### Agent runners
 

--- a/skills/copilotkit-setup/SKILL.md
+++ b/skills/copilotkit-setup/SKILL.md
@@ -454,7 +454,7 @@ See `references/telemetry-setup.md` for what the license key enables and how to 
 
 Channels let an agent answer in Slack or Teams. They require the Intelligence runtime -- `channels` is not available in SSE mode -- and a long-running host, because activation opens a persistent connection.
 
-Use the **copilotkit-channels** skill for this. It covers declaring a Channel, the awaited activation call, and the long-running host requirement, and it builds on the wiring from this step.
+Use the **copilotkit-channels** skill for this. It covers declaring a Channel, the long-running host requirement, and which mounts start activation on their own versus which wait for an explicit `channels.ready()` call. It builds on the wiring from this step.
 
 ### Step 7: Verify the setup
 

--- a/skills/copilotkit-setup/references/telemetry-setup.md
+++ b/skills/copilotkit-setup/references/telemetry-setup.md
@@ -10,24 +10,23 @@ CopilotKit Intelligence is CopilotKit's hosted platform that provides:
 
 The license key is a lightweight identifier that connects your local CopilotKit instance to CopilotKit Intelligence. It does not gate any open-source functionality -- CopilotKit works fully without it.
 
-## The `npx copilotkit auth` flow
+## The `npx copilotkit login` flow
 
-Running the CLI command starts an interactive authentication (verify the exact command with `npx copilotkit --help` as it may vary by version):
+Running the CLI command starts an interactive authentication (verify the available commands with `npx copilotkit --help` if a version differs):
 
 ```bash
-npx copilotkit auth
+npx copilotkit login
+npx copilotkit project select
 ```
 
-1. The CLI opens your default browser to the CopilotKit Intelligence login/signup page.
+1. `login` opens your default browser to the CopilotKit Intelligence login/signup page.
 2. Sign in with GitHub, Google, or email.
-3. Select or create a project in the CopilotKit Intelligence dashboard.
-4. The CLI receives the license key and prints it to stdout:
-   ```
-   Successfully authenticated!
-   Your license key: <your-license-key>
-   ```
+3. `project select` picks or creates a hosted project and records it in `.copilotkit/project.json`.
+4. The CLI provisions a project API key for the runtime and reports the license key for the client.
 
 If the browser does not open automatically, the CLI prints a URL you can copy-paste manually.
+
+There is no `copilotkit auth` command. The command is `login`.
 
 ## Where to put the license key
 

--- a/skills/copilotkit-setup/sources.md
+++ b/skills/copilotkit-setup/sources.md
@@ -35,3 +35,14 @@ Generated: 2026-03-28
 
 - packages/v2/react/src/ (`CopilotKit` provider, CopilotChat component exports)
 - examples/v2/react/ (Next.js App Router page component patterns)
+
+## Step 2 Intelligence runtime and Step 6 (added 2026-08-01)
+
+- packages/runtime/dist/v2/runtime/core/runtime.d.mts (CopilotIntelligenceRuntimeOptions:
+  `intelligence`, required `identifyUser`, `channels`; CopilotSseRuntimeOptions has
+  `channels?: undefined`)
+- packages/runtime/dist/v2/runtime/intelligence-platform/client.d.mts
+  (CopilotKitIntelligenceConfig: required `apiKey`, optional `apiUrl`/`wsUrl` defaulting to
+  the managed platform, separate API and realtime hosts)
+- examples/slack/app/managed.ts (canonical managed wiring and env var names)
+- apps/cli help output in CopilotKit/Intelligence (the command is `login`, not `auth`)


### PR DESCRIPTION
Companion to CopilotKit/Intelligence#714 (OSS-705). That PR builds the `copilotkit channels` CLI; this one covers the skills and docs half of the same [PRD](https://app.notion.com/p/3af3aa381852810b8254ec0cbb5be6af).

## Managed Intelligence becomes the default path in `copilotkit-setup`

The most-used "add CopilotKit to your project" path walked every new user into the self-hosted SSE runtime and never offered the managed one. `CopilotIntelligenceRuntime`, `CopilotKitIntelligence`, the required `identifyUser`, and the hosted environment values all appeared in this skill's *reference* files but were wired by **no step** — so the skill could describe managed Intelligence without ever producing it.

- **Step 2 now chooses the runtime mode before any runtime code is written**, because the mode changes how the runtime is constructed and retrofitting it means rewriting the file. Managed is the recommended default and has real wiring.
- **Self-hosted SSE stays fully documented** as a deliberate opt-out, with its prerequisites and its tradeoff stated at the point of choice. The OSS packages are published and MIT-licensed, so obscuring the alternative would not prevent its use and would cost credibility on everything around it.
- **Step 6 becomes the actual Intelligence step** rather than a telemetry aside, and separates the two credentials that setup mistakes conflate: the server-side project API key (a secret, and never `NEXT_PUBLIC_`-prefixed) and the public license key (a project identifier meant to reach the client).
- **Fixes a command that does not exist.** Both the skill and `references/telemetry-setup.md` instructed `npx copilotkit auth`. The command is `login`, and `project select` is what provisions the project.

## New `copilotkit-channels` skill

Covers the code half: the Channel declaration, the long-running host requirement, and which mounts start activation on their own versus which wait for an explicit `channels.ready()`.

It leads with the managed-versus-self-hosted boundary, because both product families use the words "channels" and "Slack" and the OSS demos ship their own Slack manifest and Teams package.

## Docs

- `channels/intelligence.mdx` — the CLI as a **peer** path to the wizard, with the tradeoff stated. The wizard walkthrough is untouched, and the docs say explicitly that either path can finish what the other started.
- `packages/channels-{slack,teams}/README.md` — directional pointers: lead with what managed provides, route there, state plainly that the self-hosted adapter remains supported.

## Two deviations from the PRD, both deliberate

1. **Pointers are scoped to Slack and Teams.** The PRD asks for all eight `packages/channels-*/README.md`. Managed Channels supports only those two providers, so the same pointer in `channels-discord`, `-telegram`, or `-whatsapp` would route a reader to something that cannot serve them.
2. **`frontends/{slack,teams}.mdx` need no pointer.** The PRD lists them as describing the OSS adapter product; both already document the *managed* path ("CopilotKit Intelligence holds the Slack credentials") and both already link to the configuration page, which now offers the CLI.

## A correction worth reviewing

The Channels skill first asserted that activation is lazy on every host and that `await listener.channels.ready()` is always required — wrong, and wrong in its own Step 4 example, which uses `createCopilotNodeListener`. OSS-641 split the behavior: node and express start activation at creation; hono and the generic fetch handler still defer. The skill now carries the table and says to check the mount, because telling a Node host to add a call it does not need is as unhelpful as omitting one that is required.

`showcase/.../deploy-and-operate.mdx` already described this correctly and is unchanged.

## Notes for review

- A standalone skill **must** be registered in `RESERVED_LIFECYCLE_SLUGS` (`scripts/sync-plugin-skills.ts`) or `pnpm sync:plugin-skills` deletes it as an orphan. Registered, and the test now pins that requirement with the reason.
- `pnpm check:plugin-skills` passes; `scripts/__tests__/sync-plugin-skills.test.ts` passes (50 files / 483 tests).
- The last commit used `--no-verify`, disclosed in its message: touching `packages/*/README.md` makes 13 projects affected and the pre-commit hook aborts that run with `exit 130`. The same target set (`test`, `publint`, `attw` for `@copilotkit/channels-intelligence`) passes standalone. That commit is two markdown files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)