### PR TITLE
feat(channels): add Channel Tasks

### DIFF
--- a/packages/channels-core/package.json
+++ b/packages/channels-core/package.json
@@ -61,14 +61,15 @@
     "@copilotkit/channels-ui": "workspace:~",
     "@copilotkit/core": "workspace:^",
     "@copilotkit/shared": "workspace:^",
+    "@tanstack/ai": "^0.42.0",
+    "zod": "^3.25.76",
     "zod-to-json-schema": "^3.24.1"
   },
   "devDependencies": {
     "@copilotkit/typescript-config": "workspace:^",
     "@types/node": "^22.10.0",
     "typescript": "^5.6.3",
-    "vitest": "^4.1.3",
-    "zod": "^3.25.76"
+    "vitest": "^4.1.3"
   },
   "peerDependencies": {
     "vitest": "^4.0.0"

--- a/packages/channels-core/src/channel-history.test.ts
+++ b/packages/channels-core/src/channel-history.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { createChannel } from "./create-channel.js";
+import type { ChannelHistoryAdapter } from "./channel-history.js";
+import { FakeAdapter } from "./testing/fake-adapter.js";
+import { toAgentToolDescriptors } from "./tools.js";
+
+describe("Channel provider history", () => {
+  it("binds the selected tool to the current trusted surface", async () => {
+    const read = vi.fn().mockResolvedValue({
+      messages: [],
+      nextCursor: null,
+    });
+    const adapter = new FakeAdapter({ messageEvents: true }) as FakeAdapter & {
+      channelHistory: ChannelHistoryAdapter;
+    };
+    adapter.channelHistory = { read };
+    const channel = createChannel({
+      name: "support",
+      identifyUser: "platform",
+      adapters: [adapter],
+    });
+    channel.tool(channel.readChannelMessagesTool);
+    let currentThread: unknown;
+    channel.onMessage(({ thread }) => {
+      currentThread = thread;
+    });
+
+    await channel.ɵruntime.start();
+    await adapter.getSink().onTurn({
+      conversationKey: "thread_support_01",
+      replyTarget: { delivery: { deliveryId: "dlv_123" } },
+      surfaceId: "surface_support_01",
+      userText: "What happened earlier?",
+      platform: "slack",
+      actor: { id: "U123", kind: "human" },
+    });
+    await channel.readChannelMessagesTool.handler(
+      { limit: 25, cursor: "opaque-cursor" },
+      {
+        thread: currentThread as never,
+        user: null,
+        actor: { id: "model-spoof", kind: "app" },
+        platform: "slack",
+      },
+    );
+
+    expect(read).toHaveBeenCalledWith(
+      {
+        surfaceId: "surface_support_01",
+        limit: 25,
+        cursor: "opaque-cursor",
+      },
+      expect.objectContaining({
+        replyTarget: { delivery: { deliveryId: "dlv_123" } },
+        actor: { id: "U123", kind: "human" },
+      }),
+    );
+    const descriptor = toAgentToolDescriptors([
+      channel.readChannelMessagesTool,
+    ])[0]!;
+    expect(descriptor.parameters).toMatchObject({
+      properties: { limit: expect.any(Object), cursor: expect.any(Object) },
+      additionalProperties: false,
+    });
+    expect(
+      Object.keys((descriptor.parameters as { properties: object }).properties),
+    ).toEqual(["limit", "cursor"]);
+  });
+});

--- a/packages/channels-core/src/channel-history.ts
+++ b/packages/channels-core/src/channel-history.ts
@@ -1,0 +1,40 @@
+import type { ChannelTaskOperationContext } from "./tasks.js";
+
+/** One provider message normalized for application-selected history reads. */
+export interface ChannelHistoryMessage {
+  id: string;
+  occurredAt: string;
+  actor: {
+    id: string;
+    kind: "human" | "bot" | "app" | "system" | "unknown";
+    displayName?: string;
+    handle?: string;
+  };
+  text: string;
+  position: "root" | "reply";
+}
+
+/** One bounded chronological provider-surface page. */
+export interface ChannelHistoryPage {
+  messages: ChannelHistoryMessage[];
+  nextCursor: string | null;
+}
+
+/** Caller-controlled paging fields; the current surface stays trusted. */
+export interface ReadChannelMessagesInput {
+  limit?: number;
+  cursor?: string;
+}
+
+/** Adapter request after core binds the current trusted surface. */
+export interface ChannelHistoryAdapterInput extends ReadChannelMessagesInput {
+  surfaceId: string;
+}
+
+/** Adapter-owned provider-history client. Managed Intelligence implements it. */
+export interface ChannelHistoryAdapter {
+  read(
+    input: ChannelHistoryAdapterInput,
+    context?: ChannelTaskOperationContext,
+  ): Promise<ChannelHistoryPage>;
+}

--- a/packages/channels-core/src/create-channel.ts
+++ b/packages/channels-core/src/create-channel.ts
@@ -9,6 +9,7 @@ import type {
   IncomingReaction,
   IncomingModalSubmit,
   IncomingModalClose,
+  IncomingScheduledTask,
   ModalSubmitResult,
 } from "./platform-adapter.js";
 import { ActionRegistry, ActionExpiredError } from "./action-registry.js";
@@ -23,6 +24,16 @@ import type { ChannelCommand, CommandContext } from "./commands.js";
 import { Thread } from "./thread.js";
 import type { ThreadDeps } from "./thread.js";
 import type { AbstractAgent } from "@ag-ui/client";
+import { selectChannelTask } from "./tasks.js";
+import type { ReadChannelMessagesInput } from "./channel-history.js";
+import type {
+  ChannelTask,
+  ChannelTaskCause,
+  ChannelTaskEvent,
+  ChannelTaskWhen,
+  ChannelTasksClient,
+  ChannelTasksConfig,
+} from "./tasks.js";
 import { sanitizeAgentEventStream } from "./sanitize-agent-events.js";
 import type {
   ChannelMessage,
@@ -47,11 +58,13 @@ import { resolveChannelUser } from "./identity.js";
 import type {
   ChannelIdentifyUser,
   ChannelIdentityContext,
+  IngressIdentityContext,
 } from "./identity.js";
 import type { StandardSchemaV1, InferSchemaOutput } from "./standard-schema.js";
 import { ChannelTelemetry } from "./telemetry/channel-telemetry.js";
 import { errorClass, normalizePlatform } from "./telemetry/sanitize-error.js";
 import { createRequire } from "node:module";
+import { z } from "zod";
 
 const pkg = createRequire(import.meta.url)("../package.json") as {
   name: string;
@@ -229,6 +242,13 @@ export type ChannelHandler<TState = unknown> = (ctx: {
   message: ChannelMessage;
 }) => void | Promise<void>;
 
+/** Handler for one matched event Task or live scheduled Task delivery. */
+export type ChannelTaskHandler<TState = unknown> = (ctx: {
+  task: ChannelTask;
+  cause: ChannelTaskCause;
+  thread: StatefulThread<TState>;
+}) => void | Promise<void>;
+
 /** Handler for a "conversation opened" lifecycle event (e.g. the Slack assistant pane). */
 export type ThreadStartHandler<TState = unknown> = (ctx: {
   thread: StatefulThread<TState>;
@@ -402,6 +422,8 @@ export interface CreateChannelOptions<
    */
   replyContinuation?: ReplyContinuationOptions;
   agent?: AbstractAgent | ((threadId: string) => AbstractAgent);
+  /** Optional Task matching configuration. Requires exactly one onTask handler. */
+  tasks?: ChannelTasksConfig;
   /**
    * Tolerate the AG-UI event streams real agents emit. On by default.
    *
@@ -451,6 +473,14 @@ export interface Channel<TState = unknown> {
   readonly replyContinuation?: ReplyContinuationOptions;
   /** Declared slash-command names (normalized). Surfaced for Channel activation metadata. */
   readonly commandNames: string[];
+  /** True when this Channel declares a Task model and exactly one handler. */
+  readonly tasksEnabled: boolean;
+  /** Programmatic Intelligence Task operations. */
+  readonly tasks: ChannelTasksClient;
+  /** Optional agent tool for provider-wide history on the current surface. */
+  readonly readChannelMessagesTool: ChannelTool;
+  /** Register the only Task handler for this Channel. */
+  onTask(handler: ChannelTaskHandler<TState>): void;
   onMention(h: ChannelHandler<TState>): void;
   onMessage(h: ChannelHandler<TState>): void;
   /** Welcome a newly installed or activated provider conversation. */
@@ -533,7 +563,7 @@ function identityContextFromIngress(
   event: {
     conversationKey?: string;
     actor?: ProviderActor;
-    identityContext?: import("./identity.js").IngressIdentityContext;
+    identityContext?: IngressIdentityContext;
   },
   trigger: string,
 ): ChannelIdentityContext {
@@ -632,14 +662,20 @@ export function createChannel<
   let registry: ActionRegistry | undefined;
   let telemetry: ChannelTelemetry | undefined;
 
+  // Applied here rather than at each call site so a developer never has to
+  // know the workaround exists. Idempotent, so reusing one agent instance
+  // across threads (or being handed an already-sanitized one) is fine.
+  const sanitizeConfiguredAgent =
+    opts.sanitizeAgentEvents === false
+      ? (agent: AbstractAgent) => agent
+      : sanitizeAgentEventStream;
+  const isolateConfiguredAgent = (
+    agent: AbstractAgent,
+    threadId: string,
+  ): AbstractAgent =>
+    sanitizeConfiguredAgent(isolateAgentInstance(agent, threadId));
+
   const agentFactory: (threadId: string) => AbstractAgent = (() => {
-    // Applied here rather than at each call site so a developer never has to
-    // know the workaround exists. Idempotent, so reusing one agent instance
-    // across threads (or being handed an already-sanitized one) is fine.
-    const sanitize =
-      opts.sanitizeAgentEvents === false
-        ? (agent: AbstractAgent) => agent
-        : sanitizeAgentEventStream;
     const a = opts.agent;
     if (!a) {
       return () => {
@@ -655,9 +691,9 @@ export function createChannel<
     // see `isolateAgentInstance`.
     if (typeof a === "function") {
       return (threadId: string) =>
-        sanitize(isolateAgentInstance(a(threadId), threadId));
+        isolateConfiguredAgent(a(threadId), threadId);
     }
-    return (threadId: string) => sanitize(isolateAgentInstance(a, threadId));
+    return (threadId: string) => isolateConfiguredAgent(a, threadId);
   })();
 
   /** Per-conversation serial turn queue (error-boundaried so one failure cannot poison the chain). */
@@ -686,6 +722,17 @@ export function createChannel<
 
   const mentionHandlers: ChannelHandler[] = [];
   const messageHandlers: ChannelHandler[] = [];
+  const taskHandlers: ChannelTaskHandler[] = [];
+  const taskToolScopes = new WeakMap<
+    Thread,
+    {
+      adapter: PlatformAdapter;
+      replyTarget: unknown;
+      surfaceId: string;
+      actor: ProviderActor | null;
+      user: ApplicationUser | null;
+    }
+  >();
   const welcomeHandlers: WelcomeHandler[] = [];
   const threadStartedHandlers: ThreadStartHandler[] = [];
   const interactionHandlers = new Map<
@@ -726,6 +773,7 @@ export function createChannel<
       user?: ApplicationUser | null;
       actor?: ProviderActor;
       interactionActionId?: string;
+      surfaceId?: string;
     },
   ): Thread {
     if (!backend || !registry || !telemetry) {
@@ -740,6 +788,7 @@ export function createChannel<
       conversationKey,
       registry,
       agentFactory,
+      isolateAgent: isolateConfiguredAgent,
       tools: toolMap,
       toolDescriptors,
       context,
@@ -757,7 +806,248 @@ export function createChannel<
       intelligenceMemoryAvailable,
       telemetry,
     };
-    return new Thread(deps);
+    const thread = new Thread(deps);
+    if (extras?.surfaceId) {
+      taskToolScopes.set(thread, {
+        adapter,
+        replyTarget,
+        surfaceId: extras.surfaceId,
+        actor: extras.actor ?? null,
+        user: extras.user ?? null,
+      });
+    }
+    return thread;
+  }
+
+  /** Resolve a managed Task adapter only when a Task operation is requested. */
+  function getTaskAdapter(): NonNullable<PlatformAdapter["channelTasks"]> {
+    const taskAdapters = adapters.flatMap((adapter) =>
+      adapter.channelTasks ? [adapter.channelTasks] : [],
+    );
+    if (taskAdapters.length !== 1) {
+      throw new Error(
+        taskAdapters.length === 0
+          ? "channel.tasks requires an Intelligence-backed Channel adapter"
+          : "channel.tasks requires exactly one Task-capable adapter",
+      );
+    }
+    return taskAdapters[0]!;
+  }
+
+  const taskWhenSchema = z.discriminatedUnion("kind", [
+    z
+      .object({
+        kind: z.literal("event"),
+        event: z.enum(["message", "reaction_added"]),
+        rule: z.string().trim().min(1).max(40_000),
+      })
+      .strict(),
+    z
+      .object({
+        kind: z.literal("schedule"),
+        cron: z
+          .string()
+          .trim()
+          .regex(/^\S+(?:\s+\S+){4}$/u),
+        timeZone: z.string().trim().min(1).max(128),
+      })
+      .strict(),
+  ]);
+
+  /** Read the trusted delivery scope bound to one current handler Thread. */
+  function taskToolScope(thread: unknown) {
+    const scope = taskToolScopes.get(thread as Thread);
+    if (!scope?.adapter.channelTasks) {
+      throw new Error(
+        "Channel Task tools require a current Intelligence delivery surface",
+      );
+    }
+    return { scope, client: scope.adapter.channelTasks };
+  }
+
+  const taskTools: ChannelTool[] = [
+    {
+      name: "create_channel_task",
+      description: "Create a Task on the current Channel surface.",
+      parameters: z
+        .object({
+          goal: z.string().trim().min(1).max(40_000),
+          when: taskWhenSchema,
+        })
+        .strict(),
+      async handler(args, ctx) {
+        const { scope, client } = taskToolScope(ctx.thread);
+        return client.create(
+          {
+            surfaceId: scope.surfaceId,
+            goal: args.goal as string,
+            when: args.when as ChannelTaskWhen,
+          },
+          scope,
+        );
+      },
+    },
+    {
+      name: "list_channel_tasks",
+      description: "List Tasks on the current Channel surface.",
+      parameters: z
+        .object({
+          event: z.enum(["message", "reaction_added"]).optional(),
+          enabled: z.boolean().optional(),
+        })
+        .strict(),
+      async handler(args, ctx) {
+        const { scope, client } = taskToolScope(ctx.thread);
+        return client.list(
+          {
+            surfaceId: scope.surfaceId,
+            ...(args.event
+              ? {
+                  event: args.event as "message" | "reaction_added",
+                }
+              : {}),
+            ...(args.enabled !== undefined
+              ? { enabled: args.enabled as boolean }
+              : {}),
+          },
+          scope,
+        );
+      },
+    },
+    {
+      name: "update_channel_task",
+      description: "Update a Task on the current Channel surface.",
+      parameters: z
+        .object({
+          taskId: z.string().min(1),
+          goal: z.string().trim().min(1).max(40_000).optional(),
+          when: taskWhenSchema.optional(),
+          enabled: z.boolean().optional(),
+        })
+        .strict(),
+      async handler(args, ctx) {
+        const { scope, client } = taskToolScope(ctx.thread);
+        return client.update(
+          {
+            taskId: args.taskId as string,
+            ...(args.goal !== undefined ? { goal: args.goal as string } : {}),
+            ...(args.when !== undefined
+              ? {
+                  when: args.when as ChannelTaskWhen,
+                }
+              : {}),
+            ...(args.enabled !== undefined
+              ? { enabled: args.enabled as boolean }
+              : {}),
+          },
+          scope,
+        );
+      },
+    },
+    {
+      name: "delete_channel_task",
+      description: "Delete a Task on the current Channel surface.",
+      parameters: z.object({ taskId: z.string().min(1) }).strict(),
+      async handler(args, ctx) {
+        const { scope, client } = taskToolScope(ctx.thread);
+        await client.delete({ taskId: args.taskId as string }, scope);
+        return { deletedTaskId: args.taskId };
+      },
+    },
+  ];
+
+  const readChannelMessagesTool: ChannelTool = {
+    name: "read_channel_messages",
+    description:
+      "Read a bounded chronological page from the current Channel surface.",
+    parameters: z
+      .object({
+        limit: z.number().int().positive().max(50).optional(),
+        cursor: z.string().min(1).max(4096).optional(),
+      })
+      .strict(),
+    async handler(args, ctx) {
+      const scope = taskToolScopes.get(ctx.thread as Thread);
+      if (!scope?.adapter.channelHistory) {
+        throw new Error(
+          "Channel history requires a current Intelligence delivery surface",
+        );
+      }
+      return scope.adapter.channelHistory.read(
+        {
+          surfaceId: scope.surfaceId,
+          ...(args.limit !== undefined
+            ? { limit: args.limit as ReadChannelMessagesInput["limit"] }
+            : {}),
+          ...(args.cursor !== undefined
+            ? { cursor: args.cursor as ReadChannelMessagesInput["cursor"] }
+            : {}),
+        },
+        scope,
+      );
+    },
+  };
+
+  /** Match one trusted event and run the Task handler when selected. */
+  async function dispatchEventTask(input: {
+    adapter: PlatformAdapter;
+    surfaceId: string | undefined;
+    event: ChannelTaskEvent;
+    thread: Thread;
+    actor: ProviderActor;
+    user: ApplicationUser | null;
+    replyTarget: unknown;
+  }): Promise<boolean> {
+    if (
+      !opts.tasks ||
+      taskHandlers.length !== 1 ||
+      !input.surfaceId ||
+      input.actor.kind === "system" ||
+      !input.adapter.channelTasks
+    ) {
+      return false;
+    }
+    let selected: ChannelTask | undefined;
+    try {
+      const candidates = (
+        await input.adapter.channelTasks.list(
+          {
+            surfaceId: input.surfaceId,
+            event: input.event.kind,
+            enabled: true,
+          },
+          {
+            replyTarget: input.replyTarget,
+            actor: input.actor,
+            user: input.user,
+          },
+        )
+      ).filter(
+        (candidate) =>
+          candidate.enabled &&
+          candidate.surfaceId === input.surfaceId &&
+          candidate.when.kind === "event" &&
+          candidate.when.event === input.event.kind,
+      );
+      selected = await selectChannelTask({
+        model: opts.tasks.model,
+        event: input.event,
+        candidates,
+      });
+    } catch (error) {
+      console.warn(
+        `[channel] Task matching failed for ${input.event.kind}; using the ordinary handler`,
+        error,
+      );
+      return false;
+    }
+    if (!selected) return false;
+    await taskHandlers[0]!({
+      task: selected,
+      cause: { kind: "event", event: input.event, actor: input.actor },
+      thread: input.thread,
+    });
+    return true;
   }
 
   /**
@@ -830,8 +1120,28 @@ export function createChannel<
           message,
           user,
           actor: identityContext.actor,
+          surfaceId: turn.surfaceId,
         },
       );
+      if (turn.operation.kind === "created") {
+        const matched = await dispatchEventTask({
+          adapter,
+          surfaceId: turn.surfaceId,
+          event: {
+            kind: "message",
+            text: turn.userText,
+            mentioned: turn.operation.mentioned,
+            messageId: turn.operation.logicalMessageId,
+            occurredAt:
+              turn.occurredAt ?? identityContext.event.occurredAt ?? "",
+          },
+          thread,
+          actor: identityContext.actor,
+          user,
+          replyTarget: turn.replyTarget,
+        });
+        if (matched) return;
+      }
       const handlers = turn.operation.mentioned
         ? mentionHandlers.length > 0
           ? mentionHandlers
@@ -885,6 +1195,43 @@ export function createChannel<
         }
         // "drop" or legacy callback — exclusive lock + drop/force.
         await processTurnWithLock(turn);
+      },
+      async onScheduledTask(evt: IncomingScheduledTask) {
+        if (!opts.tasks || taskHandlers.length !== 1) {
+          throw new Error(
+            `channel "${opts.name ?? "(unnamed)"}" received a scheduled Task without valid Task configuration`,
+          );
+        }
+        const platform = ingressPlatform(adapter, evt);
+        const identityContext = identityContextFromIngress(
+          platform,
+          evt,
+          "scheduled-task",
+        );
+        const user = await resolveChannelUser(
+          opts.identifyUser,
+          identityContext,
+        );
+        const thread = makeThread(
+          adapter,
+          evt.replyTarget,
+          evt.conversationKey,
+          {
+            platform,
+            user,
+            actor: identityContext.actor,
+            surfaceId: evt.surfaceId,
+          },
+        );
+        await taskHandlers[0]!({
+          task: evt.task,
+          cause: {
+            kind: "schedule",
+            scheduledAt: evt.scheduledAt,
+            actor: null,
+          },
+          thread,
+        });
       },
       async onInteraction(evt: InteractionEvent) {
         const platform = ingressPlatform(adapter, evt);
@@ -1108,6 +1455,7 @@ export function createChannel<
             platform: sourcePlatform,
             user,
             actor: identityContext.actor,
+            surfaceId: evt.surfaceId,
           },
         );
         // Prefer the adapter's update-capable ref; fall back to the bare id.
@@ -1125,6 +1473,32 @@ export function createChannel<
           adapter,
           raw: evt.raw,
         };
+        if (
+          evt.added &&
+          opts.tasks &&
+          taskHandlers.length === 1 &&
+          evt.surfaceId &&
+          identityContext.actor.kind !== "system" &&
+          adapter.channelTasks
+        ) {
+          const matched = await dispatchEventTask({
+            adapter,
+            surfaceId: evt.surfaceId,
+            event: {
+              kind: "reaction_added",
+              emoji: value,
+              rawEmoji: evt.rawEmoji,
+              messageId: evt.messageId,
+              occurredAt:
+                evt.occurredAt ?? identityContext.event.occurredAt ?? "",
+            },
+            thread,
+            actor: identityContext.actor,
+            user,
+            replyTarget: evt.replyTarget,
+          });
+          if (matched) return;
+        }
         for (const reg of reactionHandlers) {
           if (!reg.emojis || reg.emojis.has(value))
             await reg.handler(reactionEvt);
@@ -1220,6 +1594,25 @@ export function createChannel<
     get commandNames() {
       return [...commandHandlers.keys()];
     },
+    get tasksEnabled() {
+      return opts.tasks !== undefined && taskHandlers.length === 1;
+    },
+    tasks: {
+      tools: taskTools,
+      create(input) {
+        return getTaskAdapter().create(input);
+      },
+      list(input) {
+        return getTaskAdapter().list(input);
+      },
+      update(input) {
+        return getTaskAdapter().update(input);
+      },
+      delete(input) {
+        return getTaskAdapter().delete(input);
+      },
+    },
+    readChannelMessagesTool,
     get transcripts() {
       if (!transcripts) {
         throw new Error(
@@ -1246,12 +1639,28 @@ export function createChannel<
         // — with a MemoryStore that wipes all lock/dedup/transcript/action state,
         // and real adapters would connect/port-bind twice.
         if (started) return;
+        const hasTaskModel = opts.tasks !== undefined;
+        const hasTaskHandler = taskHandlers.length === 1;
+        if (hasTaskModel !== hasTaskHandler || taskHandlers.length > 1) {
+          throw new Error(
+            `channel "${opts.name ?? "(unnamed)"}" must configure both tasks.model and exactly one onTask handler`,
+          );
+        }
+        if (
+          hasTaskModel &&
+          adapters.filter((adapter) => adapter.channelTasks).length !== 1
+        ) {
+          throw new Error(
+            `channel "${opts.name ?? "(unnamed)"}" Task support requires exactly one Intelligence-backed Task adapter`,
+          );
+        }
         if (
           adapters.some(
             (adapter) => adapter.capabilities.supportsMessageEvents,
           ) &&
           mentionHandlers.length === 0 &&
-          messageHandlers.length === 0
+          messageHandlers.length === 0 &&
+          !hasTaskHandler
         ) {
           throw new Error(
             `channel "${opts.name ?? "(unnamed)"}" must register onMention or onMessage before activation`,
@@ -1483,6 +1892,9 @@ export function createChannel<
       // assignable to StatefulThread<TState> (its generic setState/state
       // satisfy the narrowed signatures), so the cast is sound.
       mentionHandlers.push(h as ChannelHandler);
+    },
+    onTask(handler) {
+      taskHandlers.push(handler as ChannelTaskHandler);
     },
     onMessage(h) {
       messageHandlers.push(h as ChannelHandler);

--- a/packages/channels-core/src/index.ts
+++ b/packages/channels-core/src/index.ts
@@ -17,6 +17,7 @@ export type {
   CreateChannelOptions,
   ReplyContinuationOptions,
   ChannelHandler,
+  ChannelTaskHandler,
   WelcomeHandler,
   ThreadStartHandler,
   ReactionEvent,
@@ -64,6 +65,7 @@ export type {
   IncomingReaction,
   IncomingModalSubmit,
   IncomingModalClose,
+  IncomingScheduledTask,
   ModalSubmitResult,
   SurfaceCapabilities,
   ReplyTarget,
@@ -77,6 +79,35 @@ export type {
   UserQuery,
   NativePayload,
 } from "./platform-adapter.js";
+
+// Intelligence Channel Tasks
+export { selectChannelTask } from "./tasks.js";
+export type {
+  ChannelTask,
+  ChannelScheduledTask,
+  ChannelTaskActor,
+  ChannelTaskCreator,
+  ChannelTaskWhen,
+  ChannelMessageEvent,
+  ChannelReactionAddedEvent,
+  ChannelTaskEvent,
+  ChannelTaskCause,
+  ChannelTasksConfig,
+  CreateChannelTaskInput,
+  ListChannelTasksInput,
+  UpdateChannelTaskInput,
+  DeleteChannelTaskInput,
+  ChannelTaskOperationContext,
+  ChannelTaskAdapter,
+  ChannelTasksClient,
+} from "./tasks.js";
+export type {
+  ChannelHistoryMessage,
+  ChannelHistoryPage,
+  ReadChannelMessagesInput,
+  ChannelHistoryAdapterInput,
+  ChannelHistoryAdapter,
+} from "./channel-history.js";
 
 // Slash commands
 export {

--- a/packages/channels-core/src/platform-adapter.test.ts
+++ b/packages/channels-core/src/platform-adapter.test.ts
@@ -9,6 +9,7 @@ describe("FakeAdapter", () => {
       onTurn: (t) => {
         got = t.userText;
       },
+      onScheduledTask: () => {},
       onInteraction: () => {},
       onWelcome: () => {},
       onCommand: () => {},
@@ -28,6 +29,7 @@ describe("FakeAdapter", () => {
     let id: string | undefined;
     await a.start({
       onTurn: () => {},
+      onScheduledTask: () => {},
       onInteraction: (e) => {
         id = e.id;
       },

--- a/packages/channels-core/src/platform-adapter.ts
+++ b/packages/channels-core/src/platform-adapter.ts
@@ -14,6 +14,8 @@ import type { ResolvedChannelMemory } from "./memory.js";
 import type { CommandSpec } from "./commands.js";
 import type { StateStore } from "./state/state-store.js";
 import type { AgentToolDescriptor, ContextEntry } from "./tools.js";
+import type { ChannelScheduledTask, ChannelTaskAdapter } from "./tasks.js";
+import type { ChannelHistoryAdapter } from "./channel-history.js";
 
 /** Opaque to the channel core — created by an adapter during ingress and passed back to post/createRunRenderer. */
 export type ReplyTarget = unknown;
@@ -163,6 +165,10 @@ export interface IncomingTurn extends IngressEventBase, IngressIds {
    */
   contentParts?: AgentContentPart[];
   platform: string;
+  /** Trusted Intelligence surface for Task candidate lookup. */
+  surfaceId?: string;
+  /** Trusted event time used by the normalized Task matcher input. */
+  occurredAt?: string;
 }
 
 export interface InteractionEvent extends IngressEventBase, IngressIds {
@@ -230,6 +236,18 @@ export interface IncomingReaction extends IngressEventBase {
   threadId?: string;
   /** Native payload. */
   raw: unknown;
+  /** Trusted Intelligence surface for Task candidate lookup. */
+  surfaceId?: string;
+  /** Trusted event time used by the normalized Task matcher input. */
+  occurredAt?: string;
+}
+
+/** One trusted live scheduled Task delivery. */
+export interface IncomingScheduledTask extends IngressEventBase, IngressIds {
+  platform: string;
+  surfaceId: string;
+  scheduledAt: string;
+  task: ChannelScheduledTask;
 }
 
 /** A modal submission. Adapters without modals never emit it. */
@@ -267,6 +285,8 @@ export interface ModalSubmitResult {
 
 export interface IngressSink {
   onTurn(turn: IncomingTurn): void | Promise<void>;
+  /** Invoke one already-selected managed scheduled Task. */
+  onScheduledTask?(evt: IncomingScheduledTask): void | Promise<void>;
   onInteraction(evt: InteractionEvent): void | Promise<void>;
   /** A provider installation or conversation activation became usable. */
   onWelcome(evt: IncomingWelcome): void | Promise<void>;
@@ -332,6 +352,10 @@ export interface PlatformAdapter {
   readonly platform: string;
   readonly capabilities: SurfaceCapabilities;
   readonly ackDeadlineMs: number;
+  /** Optional managed Task persistence client. */
+  readonly channelTasks?: ChannelTaskAdapter;
+  /** Optional managed provider-surface history client. */
+  readonly channelHistory?: ChannelHistoryAdapter;
   /** Return the trusted canonical Thread bound to an opaque reply target. */
   getCanonicalThreadId?(target: ReplyTarget): string;
   start(sink: IngressSink, ctx?: AdapterStartContext): Promise<void>;

--- a/packages/channels-core/src/tasks.test.ts
+++ b/packages/channels-core/src/tasks.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AnyTextAdapter } from "@tanstack/ai";
+import { createChannel } from "./create-channel.js";
+import type { ChannelTask, ChannelTaskAdapter } from "./tasks.js";
+import { FakeAdapter } from "./testing/fake-adapter.js";
+import { FakeAgent } from "./testing/fake-agent.js";
+
+const task: ChannelTask = {
+  id: "task_support_01",
+  surfaceId: "surface_support_01",
+  goal: "Escalate urgent support requests",
+  when: {
+    kind: "event",
+    event: "message",
+    rule: "The customer says the issue blocks production",
+  },
+  enabled: true,
+  createdBy: {
+    kind: "application",
+    applicationId: "runtime_support",
+  },
+  createdAt: "2026-08-01T10:00:00.000Z",
+  updatedAt: "2026-08-01T10:00:00.000Z",
+};
+
+function taskModel(selectedTaskId: string | null): {
+  model: AnyTextAdapter;
+  structuredOutput: ReturnType<typeof vi.fn>;
+} {
+  const structuredOutput = vi.fn().mockResolvedValue({
+    data: { taskId: selectedTaskId },
+    rawText: JSON.stringify({ taskId: selectedTaskId }),
+  });
+  return {
+    model: {
+      kind: "text",
+      name: "task-test",
+      model: "task-test",
+      structuredOutput,
+      chatStream: vi.fn(),
+      "~types": {},
+    } as unknown as AnyTextAdapter,
+    structuredOutput,
+  };
+}
+
+function adapterWithTasks(tasks: ChannelTask[]): {
+  adapter: FakeAdapter & { channelTasks: ChannelTaskAdapter };
+  list: ReturnType<typeof vi.fn>;
+  create: ReturnType<typeof vi.fn>;
+} {
+  const adapter = new FakeAdapter({ messageEvents: true }) as FakeAdapter & {
+    channelTasks: ChannelTaskAdapter;
+  };
+  const list = vi.fn().mockResolvedValue(tasks);
+  const create = vi.fn().mockResolvedValue(task);
+  adapter.channelTasks = {
+    create,
+    list,
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+  return { adapter, list, create };
+}
+
+const messageTurn = {
+  conversationKey: "thread_support_01",
+  replyTarget: {},
+  userText: "Production is down",
+  platform: "slack",
+  surfaceId: "surface_support_01",
+  occurredAt: "2026-08-01T10:01:00.000Z",
+  actor: { id: "U123", kind: "human" as const },
+  identityContext: {
+    tenant: { id: "T123" },
+    installation: { id: "installation_123" },
+    conversation: { id: "C123", kind: "channel" },
+    trigger: "message",
+    event: {
+      id: "evt_support_01",
+      occurredAt: "2026-08-01T10:01:00.000Z",
+    },
+    raw: {},
+  },
+  operation: {
+    kind: "created" as const,
+    logicalMessageId: "message_support_01",
+    revisionId: "revision_support_01",
+    mentioned: false,
+  },
+};
+
+describe("Channel Tasks", () => {
+  it("rejects startup when only the Task model or handler is configured", async () => {
+    const { model } = taskModel(null);
+    const modelOnly = createChannel({
+      identifyUser: "platform",
+      name: "support",
+      adapters: [new FakeAdapter()],
+      tasks: { model },
+    });
+    const handlerOnly = createChannel({
+      identifyUser: "platform",
+      name: "support",
+      adapters: [new FakeAdapter()],
+    });
+    handlerOnly.onTask(vi.fn());
+
+    await expect(modelOnly.ɵruntime.start()).rejects.toThrow(
+      "must configure both tasks.model and exactly one onTask handler",
+    );
+    await expect(handlerOnly.ɵruntime.start()).rejects.toThrow(
+      "must configure both tasks.model and exactly one onTask handler",
+    );
+  });
+
+  it("loads exact candidates, runs one structured match, and invokes only onTask", async () => {
+    const { model, structuredOutput } = taskModel(task.id);
+    const { adapter, list } = adapterWithTasks([task]);
+    const channel = createChannel({
+      identifyUser: "platform",
+      name: "support",
+      adapters: [adapter],
+      tasks: { model },
+    });
+    const ordinary = vi.fn();
+    const onTask = vi.fn();
+    channel.onMessage(ordinary);
+    channel.onTask(onTask);
+
+    await channel.ɵruntime.start();
+    await adapter.getSink().onTurn(messageTurn);
+
+    expect(list).toHaveBeenCalledWith(
+      { surfaceId: "surface_support_01", event: "message", enabled: true },
+      expect.objectContaining({ replyTarget: messageTurn.replyTarget }),
+    );
+    expect(structuredOutput).toHaveBeenCalledOnce();
+    expect(onTask).toHaveBeenCalledWith({
+      task,
+      cause: {
+        kind: "event",
+        actor: expect.objectContaining({ id: "U123", kind: "human" }),
+        event: expect.objectContaining({
+          kind: "message",
+          text: "Production is down",
+          mentioned: false,
+        }),
+      },
+      thread: expect.anything(),
+    });
+    expect(ordinary).not.toHaveBeenCalled();
+  });
+
+  it("skips the model with no candidates and falls back on matcher failure", async () => {
+    const noCandidatesModel = taskModel(null);
+    const noCandidatesAdapter = adapterWithTasks([]);
+    const noCandidates = createChannel({
+      identifyUser: "platform",
+      adapters: [noCandidatesAdapter.adapter],
+      tasks: { model: noCandidatesModel.model },
+    });
+    const noCandidatesOrdinary = vi.fn();
+    noCandidates.onMessage(noCandidatesOrdinary);
+    noCandidates.onTask(vi.fn());
+    await noCandidates.ɵruntime.start();
+    await noCandidatesAdapter.adapter.getSink().onTurn(messageTurn);
+
+    expect(noCandidatesModel.structuredOutput).not.toHaveBeenCalled();
+    expect(noCandidatesOrdinary).toHaveBeenCalledOnce();
+
+    const failingModel = taskModel(task.id);
+    failingModel.structuredOutput.mockRejectedValueOnce(new Error("offline"));
+    const failingAdapter = adapterWithTasks([task]);
+    const failing = createChannel({
+      identifyUser: "platform",
+      adapters: [failingAdapter.adapter],
+      tasks: { model: failingModel.model },
+    });
+    const failingOrdinary = vi.fn();
+    failing.onMessage(failingOrdinary);
+    failing.onTask(vi.fn());
+    await failing.ɵruntime.start();
+    await failingAdapter.adapter.getSink().onTurn(messageTurn);
+
+    expect(failingOrdinary).toHaveBeenCalledOnce();
+  });
+
+  it("does not match message updates or system-authored events", async () => {
+    const { model, structuredOutput } = taskModel(task.id);
+    const { adapter, list } = adapterWithTasks([task]);
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [adapter],
+      tasks: { model },
+    });
+    const ordinary = vi.fn();
+    channel.onMessage(ordinary);
+    channel.onTask(vi.fn());
+    await channel.ɵruntime.start();
+
+    await adapter.getSink().onTurn({
+      ...messageTurn,
+      operation: { ...messageTurn.operation, kind: "updated" },
+    });
+    await adapter.getSink().onTurn({
+      ...messageTurn,
+      actor: { id: "B123", kind: "system" },
+      operation: {
+        ...messageTurn.operation,
+        logicalMessageId: "message_support_02",
+        revisionId: "revision_support_02",
+      },
+    });
+
+    expect(list).not.toHaveBeenCalled();
+    expect(structuredOutput).not.toHaveBeenCalled();
+    expect(ordinary).toHaveBeenCalledTimes(2);
+  });
+
+  it("lets onTask choose an agent for only that run", async () => {
+    const { model } = taskModel(task.id);
+    const { adapter } = adapterWithTasks([task]);
+    const defaultAgent = new FakeAgent();
+    defaultAgent.agentId = "default-agent";
+    const taskAgent = new FakeAgent();
+    taskAgent.agentId = "task-agent";
+    const selectedAgentIds: string[] = [];
+    const getOrCreate = adapter.conversationStore.getOrCreate.bind(
+      adapter.conversationStore,
+    );
+    adapter.conversationStore.getOrCreate = async (key, target, makeAgent) => {
+      const session = await getOrCreate(key, target, makeAgent);
+      selectedAgentIds.push(session.agent.agentId ?? "");
+      return session;
+    };
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [adapter],
+      agent: defaultAgent,
+      tasks: { model },
+    });
+    channel.onTask(async ({ thread, task: selectedTask }) => {
+      await thread.runAgent({ agent: taskAgent, prompt: selectedTask.goal });
+    });
+
+    await channel.ɵruntime.start();
+    await adapter.getSink().onTurn(messageTurn);
+
+    expect(selectedAgentIds).toEqual(["task-agent"]);
+  });
+
+  it("Task tools use the current trusted surface instead of model scope", async () => {
+    const { model } = taskModel(task.id);
+    const { adapter, create } = adapterWithTasks([task]);
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [adapter],
+      tasks: { model },
+    });
+    let taskThread: unknown;
+    channel.onTask(({ thread }) => {
+      taskThread = thread;
+    });
+    await channel.ɵruntime.start();
+    await adapter.getSink().onTurn(messageTurn);
+
+    const tool = channel.tasks.tools.find(
+      (candidate) => candidate.name === "create_channel_task",
+    );
+    await tool?.handler(
+      {
+        goal: "Send a daily prompt",
+        when: {
+          kind: "schedule",
+          cron: "0 9 * * 1-5",
+          timeZone: "America/Los_Angeles",
+        },
+      },
+      {
+        thread: taskThread as never,
+        user: null,
+        actor: { id: "model-spoof", kind: "app" },
+        platform: "slack",
+      },
+    );
+
+    expect(create).toHaveBeenCalledWith(
+      {
+        surfaceId: "surface_support_01",
+        goal: "Send a daily prompt",
+        when: {
+          kind: "schedule",
+          cron: "0 9 * * 1-5",
+          timeZone: "America/Los_Angeles",
+        },
+      },
+      expect.objectContaining({
+        replyTarget: messageTurn.replyTarget,
+        actor: expect.objectContaining({ id: "U123" }),
+      }),
+    );
+  });
+
+  it("matches only reaction-added candidates and skips ordinary reactions", async () => {
+    const reactionTask: ChannelTask = {
+      ...task,
+      id: "task_reaction_01",
+      when: {
+        kind: "event",
+        event: "reaction_added",
+        rule: "The reaction is a warning",
+      },
+    };
+    const { model } = taskModel(reactionTask.id);
+    const { adapter, list } = adapterWithTasks([reactionTask]);
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [adapter],
+      tasks: { model },
+    });
+    const onTask = vi.fn();
+    const ordinary = vi.fn();
+    channel.onTask(onTask);
+    channel.onReaction(ordinary);
+    await channel.ɵruntime.start();
+
+    await adapter.getSink().onReaction({
+      conversationKey: "thread_support_01",
+      replyTarget: {},
+      platform: "slack",
+      surfaceId: "surface_support_01",
+      occurredAt: "2026-08-01T10:02:00.000Z",
+      rawEmoji: "warning",
+      added: true,
+      messageId: "message_support_01",
+      actor: { id: "U123", kind: "human" },
+      identityContext: messageTurn.identityContext,
+      raw: {},
+    });
+
+    expect(list).toHaveBeenCalledWith(
+      {
+        surfaceId: "surface_support_01",
+        event: "reaction_added",
+        enabled: true,
+      },
+      expect.anything(),
+    );
+    expect(onTask).toHaveBeenCalledOnce();
+    expect(ordinary).not.toHaveBeenCalled();
+  });
+});

--- a/packages/channels-core/src/tasks.ts
+++ b/packages/channels-core/src/tasks.ts
@@ -1,0 +1,208 @@
+import { chat } from "@tanstack/ai";
+import type { AnyTextAdapter, JSONSchema } from "@tanstack/ai";
+import type { ApplicationUser, ProviderActor } from "@copilotkit/channels-ui";
+import type { ReplyTarget } from "./platform-adapter.js";
+import type { ChannelTool } from "./tools.js";
+
+/** Minimal provider actor snapshot kept for Task audit context. */
+export interface ChannelTaskActor {
+  id: string;
+  kind: "human" | "bot" | "app";
+  displayName?: string;
+  handle?: string;
+}
+
+/** Audit context that grants no Task authority. */
+export type ChannelTaskCreator =
+  | { kind: "provider_actor"; actor: ChannelTaskActor }
+  | { kind: "application"; applicationId: string };
+
+/** Event or schedule condition for one Channel Task. */
+export type ChannelTaskWhen =
+  | {
+      kind: "event";
+      event: "message" | "reaction_added";
+      rule: string;
+    }
+  | {
+      kind: "schedule";
+      cron: string;
+      timeZone: string;
+    };
+
+/** Public Intelligence Channel Task. */
+export interface ChannelTask {
+  id: string;
+  surfaceId: string;
+  goal: string;
+  when: ChannelTaskWhen;
+  enabled: boolean;
+  createdBy: ChannelTaskCreator;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Enabled scheduled Task carried by one live scheduled delivery. */
+export type ChannelScheduledTask = ChannelTask & {
+  when: Extract<ChannelTaskWhen, { kind: "schedule" }>;
+  enabled: true;
+};
+
+/** Normalized new-message input sent to the Task matcher. */
+export interface ChannelMessageEvent {
+  kind: "message";
+  text: string;
+  mentioned: boolean;
+  messageId: string;
+  occurredAt: string;
+}
+
+/** Normalized reaction-added input sent to the Task matcher. */
+export interface ChannelReactionAddedEvent {
+  kind: "reaction_added";
+  emoji: string;
+  rawEmoji: string;
+  messageId: string;
+  occurredAt: string;
+}
+
+/** V1 event input eligible for Task matching. */
+export type ChannelTaskEvent = ChannelMessageEvent | ChannelReactionAddedEvent;
+
+/** Why one Task handler invocation ran. */
+export type ChannelTaskCause =
+  | {
+      kind: "event";
+      event: ChannelTaskEvent;
+      actor: ProviderActor;
+    }
+  | {
+      kind: "schedule";
+      scheduledAt: string;
+      actor: null;
+    };
+
+/** One TanStack AI text model used for event matching. */
+export interface ChannelTasksConfig {
+  model: AnyTextAdapter;
+}
+
+export interface CreateChannelTaskInput {
+  surfaceId: string;
+  goal: string;
+  when: ChannelTaskWhen;
+}
+
+export interface ListChannelTasksInput {
+  surfaceId: string;
+  event?: "message" | "reaction_added";
+  enabled?: boolean;
+}
+
+export interface UpdateChannelTaskInput {
+  taskId: string;
+  goal?: string;
+  when?: ChannelTaskWhen;
+  enabled?: boolean;
+}
+
+export interface DeleteChannelTaskInput {
+  taskId: string;
+}
+
+/** Trusted ingress context attached by Channels core to an adapter Task call. */
+export interface ChannelTaskOperationContext {
+  replyTarget?: ReplyTarget;
+  actor?: ProviderActor | null;
+  user?: ApplicationUser | null;
+}
+
+/** Adapter-owned Task persistence client. Managed Intelligence implements it. */
+export interface ChannelTaskAdapter {
+  create(
+    input: CreateChannelTaskInput,
+    context?: ChannelTaskOperationContext,
+  ): Promise<ChannelTask>;
+  list(
+    input: ListChannelTasksInput,
+    context?: ChannelTaskOperationContext,
+  ): Promise<ChannelTask[]>;
+  update(
+    input: UpdateChannelTaskInput,
+    context?: ChannelTaskOperationContext,
+  ): Promise<ChannelTask>;
+  delete(
+    input: DeleteChannelTaskInput,
+    context?: ChannelTaskOperationContext,
+  ): Promise<void>;
+}
+
+/** Programmatic Task operations exposed by one Channel. */
+export interface ChannelTasksClient {
+  /** Agent tools applications may opt into for trusted surface-scoped CRUD. */
+  readonly tools: readonly ChannelTool[];
+  create(input: CreateChannelTaskInput): Promise<ChannelTask>;
+  list(input: ListChannelTasksInput): Promise<ChannelTask[]>;
+  update(input: UpdateChannelTaskInput): Promise<ChannelTask>;
+  delete(input: DeleteChannelTaskInput): Promise<void>;
+}
+
+const TASK_SELECTION_SCHEMA: JSONSchema = {
+  type: "object",
+  properties: {
+    taskId: { type: ["string", "null"] },
+  },
+  required: ["taskId"],
+  additionalProperties: false,
+};
+
+/**
+ * Select at most one stored Task in one structured-output model call.
+ * Malformed or unknown output is treated as no selection.
+ */
+export async function selectChannelTask(input: {
+  model: AnyTextAdapter;
+  event: ChannelTaskEvent;
+  candidates: readonly ChannelTask[];
+}): Promise<ChannelTask | undefined> {
+  if (input.candidates.length === 0) return undefined;
+  const result: unknown = await chat({
+    adapter: input.model,
+    stream: false,
+    outputSchema: TASK_SELECTION_SCHEMA,
+    systemPrompts: [
+      "Select at most one candidate Task for this normalized Channel event. " +
+        "Return its exact stored taskId, or null when none match. Do not invent IDs.",
+    ],
+    messages: [
+      {
+        role: "user",
+        content: JSON.stringify({
+          event: input.event,
+          candidates: input.candidates.map((candidate) => ({
+            id: candidate.id,
+            goal: candidate.goal,
+            rule:
+              candidate.when.kind === "event" ? candidate.when.rule : undefined,
+          })),
+        }),
+      },
+    ],
+  });
+  if (!isTaskSelection(result)) return undefined;
+  if (result.taskId === null) return undefined;
+  return input.candidates.find((candidate) => candidate.id === result.taskId);
+}
+
+/** Return true only for the exact structured output accepted by the matcher. */
+function isTaskSelection(
+  value: unknown,
+): value is { readonly taskId: string | null } {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const keys = Object.keys(value);
+  if (keys.length !== 1 || keys[0] !== "taskId") return false;
+  const taskId = (value as { taskId?: unknown }).taskId;
+  return taskId === null || typeof taskId === "string";
+}

--- a/packages/channels-core/src/testing/fake-adapter.ts
+++ b/packages/channels-core/src/testing/fake-adapter.ts
@@ -24,6 +24,7 @@ import type {
   IncomingReaction,
   IncomingModalSubmit,
   IncomingModalClose,
+  IncomingScheduledTask,
   ModalSubmitResult,
 } from "../platform-adapter.js";
 import type { CommandSpec } from "../commands.js";
@@ -41,6 +42,9 @@ type FakeIngressSink = {
   ): void | Promise<void>;
   onInteraction(
     event: OptionalIdentity<InteractionEvent>,
+  ): void | Promise<void>;
+  onScheduledTask(
+    event: OptionalIdentity<IncomingScheduledTask>,
   ): void | Promise<void>;
   onCommand(event: OptionalIdentity<IncomingCommand>): void | Promise<void>;
   onThreadStarted(

--- a/packages/channels-core/src/thread.ts
+++ b/packages/channels-core/src/thread.ts
@@ -84,6 +84,8 @@ export interface ThreadDeps {
   conversationKey: string;
   registry: ActionRegistry;
   agentFactory: (threadId: string) => AbstractAgent;
+  /** Isolate one per-run agent without changing the Channel default. */
+  isolateAgent?: (agent: AbstractAgent, threadId: string) => AbstractAgent;
   tools: Map<string, ChannelTool>;
   toolDescriptors: AgentToolDescriptor[];
   context: ContextEntry[];
@@ -445,6 +447,8 @@ export class Thread implements ThreadInterface {
   }
 
   runAgent(input?: {
+    /** Agent override for this run only. */
+    agent?: AbstractAgent;
     context?: ContextEntry[];
     tools?: ChannelTool[];
     /**
@@ -627,15 +631,24 @@ export class Thread implements ThreadInterface {
     extra?: {
       context?: ContextEntry[];
       tools?: ChannelTool[];
+      agent?: AbstractAgent;
       prompt?: string | AgentContentPart[];
       transcript?: boolean | { limit?: number };
       memory?: ResolvedChannelMemory;
     },
   ): Promise<MessageRef | undefined> {
+    const runAgentFactory = extra?.agent
+      ? (threadId: string) => {
+          if (!this.deps.isolateAgent) {
+            throw new Error("Thread.runAgent agent override is unavailable");
+          }
+          return this.deps.isolateAgent(extra.agent as AbstractAgent, threadId);
+        }
+      : this.deps.agentFactory;
     const session = await this.deps.adapter.conversationStore.getOrCreate(
       this.deps.conversationKey,
       this.deps.replyTarget,
-      this.deps.agentFactory,
+      runAgentFactory,
     );
     try {
       // Inject an explicit user message when the input isn't in the adapter's

--- a/packages/channels-intelligence/src/channel-history.test.ts
+++ b/packages/channels-intelligence/src/channel-history.test.ts
@@ -1,0 +1,55 @@
+import { expect, test, vi } from "vitest";
+import { ChannelHistoryHttpClient } from "./channel-history.js";
+
+test("history client sends only trusted surface scope to App API", async () => {
+  const page = {
+    messages: [
+      {
+        id: "chmsg_123",
+        occurredAt: "2026-08-01T10:00:00.000Z",
+        actor: { id: "U123", kind: "human" as const },
+        text: "Earlier message",
+        position: "root" as const,
+      },
+    ],
+    nextCursor: "opaque-next",
+  };
+  const fetch = vi
+    .fn()
+    .mockResolvedValue(new Response(JSON.stringify(page), { status: 200 }));
+  const client = new ChannelHistoryHttpClient({
+    baseUrl: "https://api.example/",
+    apiKey: "cpk-runtime",
+    channelName: "support",
+    fetch,
+  });
+
+  await expect(
+    client.read(
+      {
+        surfaceId: "surface_model_spoof",
+        limit: 25,
+        cursor: "opaque-current",
+      },
+      {
+        replyTarget: {
+          delivery: {
+            deliveryId: "dlv_delivery_01",
+            surfaceId: "surface_support_01",
+          },
+        },
+      },
+    ),
+  ).resolves.toEqual(page);
+
+  expect(fetch).toHaveBeenCalledWith(
+    "https://api.example/api/channels/support/messages?surfaceId=surface_support_01&limit=25&cursor=opaque-current",
+    {
+      method: "GET",
+      headers: {
+        authorization: "Bearer cpk-runtime",
+        "x-cpki-channel-delivery-id": "dlv_delivery_01",
+      },
+    },
+  );
+});

--- a/packages/channels-intelligence/src/channel-history.ts
+++ b/packages/channels-intelligence/src/channel-history.ts
@@ -1,0 +1,100 @@
+import type {
+  ChannelHistoryAdapter,
+  ChannelHistoryAdapterInput,
+  ChannelHistoryPage,
+  ChannelTaskOperationContext,
+} from "@copilotkit/channels-core";
+
+export interface ChannelHistoryHttpClientOptions {
+  readonly baseUrl: string;
+  readonly apiKey: string;
+  readonly channelName: string;
+  readonly fetch?: typeof globalThis.fetch;
+}
+
+/** Runtime-authenticated client for one current Intelligence provider surface. */
+export class ChannelHistoryHttpClient implements ChannelHistoryAdapter {
+  private readonly baseUrl: string;
+  private readonly fetchFn: typeof globalThis.fetch;
+
+  constructor(private readonly options: ChannelHistoryHttpClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/u, "");
+    this.fetchFn = options.fetch ?? globalThis.fetch;
+  }
+
+  async read(
+    input: ChannelHistoryAdapterInput,
+    context?: ChannelTaskOperationContext,
+  ): Promise<ChannelHistoryPage> {
+    const trusted = trustedDeliveryContext(context);
+    const query = new URLSearchParams({ surfaceId: trusted.surfaceId });
+    if (input.limit !== undefined) query.set("limit", String(input.limit));
+    if (input.cursor !== undefined) query.set("cursor", input.cursor);
+    const response = await this.fetchFn(
+      `${this.baseUrl}/api/channels/${encodeURIComponent(this.options.channelName)}/messages?${query.toString()}`,
+      {
+        method: "GET",
+        headers: {
+          authorization: `Bearer ${this.options.apiKey}`,
+          "x-cpki-channel-delivery-id": trusted.deliveryId,
+        },
+      },
+    );
+    if (!response.ok) {
+      throw new Error(`Channel history request failed with ${response.status}`);
+    }
+    return readHistoryPage(await response.json());
+  }
+}
+
+/** Derive history scope from the managed reply target, never tool input. */
+function trustedDeliveryContext(
+  context: ChannelTaskOperationContext | undefined,
+): { deliveryId: string; surfaceId: string } {
+  const target = context?.replyTarget;
+  if (!isRecord(target) || !isRecord(target.delivery)) {
+    throw new TypeError("Channel history delivery context is invalid");
+  }
+  const { deliveryId, surfaceId } = target.delivery;
+  if (
+    typeof deliveryId !== "string" ||
+    !deliveryId.startsWith("dlv_") ||
+    typeof surfaceId !== "string" ||
+    !surfaceId.startsWith("surface_")
+  ) {
+    throw new TypeError("Channel history delivery context is invalid");
+  }
+  return { deliveryId, surfaceId };
+}
+
+/** Decode one normalized App API provider-history page. */
+function readHistoryPage(value: unknown): ChannelHistoryPage {
+  if (
+    !isRecord(value) ||
+    !Array.isArray(value.messages) ||
+    !(value.nextCursor === null || typeof value.nextCursor === "string") ||
+    !value.messages.every(isHistoryMessage)
+  ) {
+    throw new TypeError("Channel history response is invalid");
+  }
+  return value as unknown as ChannelHistoryPage;
+}
+
+/** Validate the stable fields required from one normalized history message. */
+function isHistoryMessage(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.occurredAt === "string" &&
+    isRecord(value.actor) &&
+    typeof value.actor.id === "string" &&
+    typeof value.actor.kind === "string" &&
+    typeof value.text === "string" &&
+    (value.position === "root" || value.position === "reply")
+  );
+}
+
+/** Narrow a JSON value to a non-array object. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/channels-intelligence/src/channel-tasks.test.ts
+++ b/packages/channels-intelligence/src/channel-tasks.test.ts
@@ -1,0 +1,77 @@
+import { expect, test, vi } from "vitest";
+import { ChannelTaskHttpClient } from "./channel-tasks.js";
+
+const task = {
+  id: "task_support_01",
+  surfaceId: "surface_support_01",
+  goal: "Triage production issues",
+  when: {
+    kind: "event" as const,
+    event: "message" as const,
+    rule: "The issue blocks production",
+  },
+  enabled: true,
+  createdBy: { kind: "application" as const, applicationId: "runtime_01" },
+  createdAt: "2026-08-01T10:00:00.000Z",
+  updatedAt: "2026-08-01T10:00:00.000Z",
+};
+
+test("Task client uses the trusted delivery surface and delivery id", async () => {
+  const fetch = vi
+    .fn()
+    .mockResolvedValueOnce(
+      new Response(JSON.stringify({ tasks: [task] }), { status: 200 }),
+    )
+    .mockResolvedValueOnce(
+      new Response(JSON.stringify({ task }), { status: 200 }),
+    );
+  const client = new ChannelTaskHttpClient({
+    baseUrl: "https://api.example/",
+    apiKey: "cpk-runtime",
+    channelName: "support",
+    fetch,
+  });
+  const context = {
+    replyTarget: {
+      delivery: {
+        deliveryId: "dlv_delivery_01",
+        surfaceId: "surface_support_01",
+      },
+    },
+  };
+
+  await expect(
+    client.list(
+      { surfaceId: "surface_support_01", event: "message", enabled: true },
+      context,
+    ),
+  ).resolves.toEqual([task]);
+  await expect(
+    client.update({ taskId: task.id, enabled: false }, context),
+  ).resolves.toEqual(task);
+
+  expect(fetch).toHaveBeenNthCalledWith(
+    1,
+    "https://api.example/api/channels/support/tasks?surfaceId=surface_support_01&event=message&enabled=true",
+    {
+      method: "GET",
+      headers: {
+        authorization: "Bearer cpk-runtime",
+        "x-cpki-channel-delivery-id": "dlv_delivery_01",
+      },
+    },
+  );
+  expect(fetch).toHaveBeenNthCalledWith(
+    2,
+    "https://api.example/api/channels/support/tasks/task_support_01?surfaceId=surface_support_01",
+    {
+      method: "PATCH",
+      headers: {
+        authorization: "Bearer cpk-runtime",
+        "content-type": "application/json",
+        "x-cpki-channel-delivery-id": "dlv_delivery_01",
+      },
+      body: JSON.stringify({ enabled: false }),
+    },
+  );
+});

--- a/packages/channels-intelligence/src/channel-tasks.ts
+++ b/packages/channels-intelligence/src/channel-tasks.ts
@@ -1,0 +1,185 @@
+import type {
+  ChannelTask,
+  ChannelTaskAdapter,
+  ChannelTaskOperationContext,
+  CreateChannelTaskInput,
+  DeleteChannelTaskInput,
+  ListChannelTasksInput,
+  UpdateChannelTaskInput,
+} from "@copilotkit/channels-core";
+
+export interface ChannelTaskHttpClientOptions {
+  readonly baseUrl: string;
+  readonly apiKey: string;
+  readonly channelName: string;
+  readonly fetch?: typeof globalThis.fetch;
+}
+
+interface TrustedDeliveryContext {
+  readonly deliveryId: string;
+  readonly surfaceId: string;
+}
+
+/** Runtime-authenticated client for one Intelligence Channel's Task routes. */
+export class ChannelTaskHttpClient implements ChannelTaskAdapter {
+  private readonly baseUrl: string;
+  private readonly fetchFn: typeof globalThis.fetch;
+
+  constructor(private readonly options: ChannelTaskHttpClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/u, "");
+    this.fetchFn = options.fetch ?? globalThis.fetch;
+  }
+
+  async create(
+    input: CreateChannelTaskInput,
+    context?: ChannelTaskOperationContext,
+  ): Promise<ChannelTask> {
+    const trusted = trustedDeliveryContext(context);
+    const surfaceId = trusted?.surfaceId ?? input.surfaceId;
+    const payload = await this.request(
+      "POST",
+      this.collectionPath(),
+      { surfaceId, goal: input.goal, when: input.when },
+      trusted,
+    );
+    return readTaskResponse(payload);
+  }
+
+  async list(
+    input: ListChannelTasksInput,
+    context?: ChannelTaskOperationContext,
+  ): Promise<ChannelTask[]> {
+    const trusted = trustedDeliveryContext(context);
+    const surfaceId = trusted?.surfaceId ?? input.surfaceId;
+    const query = new URLSearchParams({ surfaceId });
+    if (input.event !== undefined) query.set("event", input.event);
+    if (input.enabled !== undefined) {
+      query.set("enabled", String(input.enabled));
+    }
+    const payload = await this.request(
+      "GET",
+      `${this.collectionPath()}?${query.toString()}`,
+      undefined,
+      trusted,
+    );
+    if (!isRecord(payload) || !Array.isArray(payload.tasks)) {
+      throw new TypeError("Channel Task list response is invalid");
+    }
+    return payload.tasks.map(readTask);
+  }
+
+  async update(
+    input: UpdateChannelTaskInput,
+    context?: ChannelTaskOperationContext,
+  ): Promise<ChannelTask> {
+    const trusted = trustedDeliveryContext(context);
+    const query = trusted
+      ? `?surfaceId=${encodeURIComponent(trusted.surfaceId)}`
+      : "";
+    const payload = await this.request(
+      "PATCH",
+      `${this.collectionPath()}/${encodeURIComponent(input.taskId)}${query}`,
+      {
+        ...(input.goal !== undefined ? { goal: input.goal } : {}),
+        ...(input.when !== undefined ? { when: input.when } : {}),
+        ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
+      },
+      trusted,
+    );
+    return readTaskResponse(payload);
+  }
+
+  async delete(
+    input: DeleteChannelTaskInput,
+    context?: ChannelTaskOperationContext,
+  ): Promise<void> {
+    const trusted = trustedDeliveryContext(context);
+    const query = trusted
+      ? `?surfaceId=${encodeURIComponent(trusted.surfaceId)}`
+      : "";
+    await this.request(
+      "DELETE",
+      `${this.collectionPath()}/${encodeURIComponent(input.taskId)}${query}`,
+      undefined,
+      trusted,
+    );
+  }
+
+  private collectionPath(): string {
+    return `/api/channels/${encodeURIComponent(this.options.channelName)}/tasks`;
+  }
+
+  private async request(
+    method: "GET" | "POST" | "PATCH" | "DELETE",
+    path: string,
+    body: unknown,
+    trusted: TrustedDeliveryContext | undefined,
+  ): Promise<unknown> {
+    const headers: Record<string, string> = {
+      authorization: `Bearer ${this.options.apiKey}`,
+      ...(body !== undefined ? { "content-type": "application/json" } : {}),
+      ...(trusted ? { "x-cpki-channel-delivery-id": trusted.deliveryId } : {}),
+    };
+    const response = await this.fetchFn(`${this.baseUrl}${path}`, {
+      method,
+      headers,
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+    if (!response.ok) {
+      throw new Error(`Channel Task request failed with ${response.status}`);
+    }
+    return response.status === 204 ? undefined : response.json();
+  }
+}
+
+/** Derive Task authority from a managed reply target, never model input. */
+function trustedDeliveryContext(
+  context: ChannelTaskOperationContext | undefined,
+): TrustedDeliveryContext | undefined {
+  if (context?.replyTarget === undefined) return undefined;
+  const target = context.replyTarget;
+  if (!isRecord(target) || !isRecord(target.delivery)) {
+    throw new TypeError("Channel Task delivery context is invalid");
+  }
+  const { deliveryId, surfaceId } = target.delivery;
+  if (
+    typeof deliveryId !== "string" ||
+    !deliveryId.startsWith("dlv_") ||
+    typeof surfaceId !== "string" ||
+    !surfaceId.startsWith("surface_")
+  ) {
+    throw new TypeError("Channel Task delivery context is invalid");
+  }
+  return { deliveryId, surfaceId };
+}
+
+/** Decode the App API Task response envelope. */
+function readTaskResponse(value: unknown): ChannelTask {
+  if (!isRecord(value)) {
+    throw new TypeError("Channel Task response is invalid");
+  }
+  return readTask(value.task);
+}
+
+/** Validate the stable fields required from one App API Task. */
+function readTask(value: unknown): ChannelTask {
+  if (
+    !isRecord(value) ||
+    typeof value.id !== "string" ||
+    typeof value.surfaceId !== "string" ||
+    typeof value.goal !== "string" ||
+    typeof value.enabled !== "boolean" ||
+    !isRecord(value.when) ||
+    !isRecord(value.createdBy) ||
+    typeof value.createdAt !== "string" ||
+    typeof value.updatedAt !== "string"
+  ) {
+    throw new TypeError("Channel Task response is invalid");
+  }
+  return value as unknown as ChannelTask;
+}
+
+/** Narrow a JSON value to a non-array object. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/channels-intelligence/src/delivery-adapter-final.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-final.test.ts
@@ -24,6 +24,7 @@ function delivery(): PreparedChannelDelivery {
     deliveryExpiresAt: "2099-07-29T17:00:00.000Z",
     channelId: "channel_support",
     channelName: "support",
+    surfaceId: "surface_support_01",
     canonicalThreadId: "thread_teams_final",
     appUserId: "teams:user-1",
     adapter: "teams",

--- a/packages/channels-intelligence/src/delivery-adapter-postfile.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-postfile.test.ts
@@ -21,6 +21,7 @@ function prepared(): PreparedChannelDelivery {
     deliveryExpiresAt: "2099-07-29T17:00:00.000Z",
     channelId: "channel_postfile_01",
     channelName: "support",
+    surfaceId: "surface_support_01",
     canonicalThreadId: "thread_postfile",
     appUserId: "slack:T1:U1",
     adapter: "slack",

--- a/packages/channels-intelligence/src/delivery-adapter-slack-stream.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-slack-stream.test.ts
@@ -20,6 +20,7 @@ function preparedDelivery(): PreparedChannelDelivery {
     deliveryExpiresAt: "2099-07-29T17:00:00.000Z",
     channelId: "channel_support",
     channelName: "support",
+    surfaceId: "surface_support_01",
     canonicalThreadId: "thread_slack_stream",
     appUserId: "slack:T1:U1",
     adapter: "slack",

--- a/packages/channels-intelligence/src/delivery-adapter.concurrency.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.concurrency.test.ts
@@ -37,6 +37,7 @@ function prepared(deliveryId: string): PreparedChannelDelivery {
     deliveryExpiresAt: "2099-07-29T17:00:00.000Z",
     channelId: "channel_1",
     channelName: "support",
+    surfaceId: "surface_support_01",
     canonicalThreadId: "thread_shared",
     appUserId: "slack:T1:U1",
     adapter: "slack",

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -34,6 +34,8 @@ import type {
   UserQuery,
   ReplyContinuationOptions,
   ResolvedChannelMemory,
+  ChannelTaskAdapter,
+  ChannelHistoryAdapter,
 } from "@copilotkit/channels-core";
 import { ChannelDeliveryTerminatedError } from "@copilotkit/channels-core";
 import {
@@ -66,6 +68,8 @@ import type {
   ChannelDeliveryTranscript,
   ChannelTranscriptMessage,
 } from "./delivery-transcript.js";
+import { ChannelTaskHttpClient } from "./channel-tasks.js";
+import { ChannelHistoryHttpClient } from "./channel-history.js";
 
 interface DeliveryReplyTarget {
   claimedDelivery: ClaimedChannelDelivery;
@@ -130,6 +134,10 @@ export interface DeliveryAdapterOptions {
   showToolStatus?: boolean;
   /** Continuation-message tuning for long Slack replies. */
   replyContinuation?: ReplyContinuationOptions;
+  /** App API coordinates for Task CRUD and event candidate lookup. */
+  appApiBaseUrl?: string;
+  apiKey?: string;
+  appApiFetch?: typeof globalThis.fetch;
 }
 
 /** Managed Channels adapter backed by the dedicated delivery boundary. */
@@ -141,6 +149,8 @@ export class DeliveryAdapter implements PlatformAdapter {
   readonly injectInboundTurnOnce = true;
   readonly ackDeadlineMs = 0;
   readonly stateStore?: StateStore;
+  readonly channelTasks?: ChannelTaskAdapter;
+  readonly channelHistory?: ChannelHistoryAdapter;
   readonly capabilities: SurfaceCapabilities = {
     supportsMessageEvents: true,
     supportsModals: false,
@@ -215,6 +225,20 @@ export class DeliveryAdapter implements PlatformAdapter {
 
   constructor(private readonly options: DeliveryAdapterOptions) {
     this.stateStore = options.store;
+    if (options.appApiBaseUrl && options.apiKey) {
+      this.channelTasks = new ChannelTaskHttpClient({
+        baseUrl: options.appApiBaseUrl,
+        apiKey: options.apiKey,
+        channelName: options.channelName,
+        ...(options.appApiFetch ? { fetch: options.appApiFetch } : {}),
+      });
+      this.channelHistory = new ChannelHistoryHttpClient({
+        baseUrl: options.appApiBaseUrl,
+        apiKey: options.apiKey,
+        channelName: options.channelName,
+        ...(options.appApiFetch ? { fetch: options.appApiFetch } : {}),
+      });
+    }
   }
 
   /**
@@ -392,6 +416,8 @@ export class DeliveryAdapter implements PlatformAdapter {
         );
         await sink.onTurn({
           ...base,
+          surfaceId: delivery.surfaceId,
+          occurredAt: delivery.turn.receivedAt,
           userText: input.text ?? "",
           operation: input.operation,
           messageRef: inboundMessageRef(replyTarget, input.messageRef),
@@ -443,6 +469,8 @@ export class DeliveryAdapter implements PlatformAdapter {
       case "reaction":
         await sink.onReaction({
           ...base,
+          surfaceId: delivery.surfaceId,
+          occurredAt: delivery.turn.receivedAt,
           rawEmoji: input.rawEmoji,
           added: input.added,
           // Stable opaque correlation id for handler lookup; the delivery-scoped
@@ -450,6 +478,19 @@ export class DeliveryAdapter implements PlatformAdapter {
           messageId: input.messageId,
           messageRef: inboundMessageRef(replyTarget, input.messageRef),
           raw: input,
+        });
+        return;
+      case "scheduled_task":
+        if (!sink.onScheduledTask) {
+          throw new TypeError(
+            "Managed scheduled delivery requires a Task-capable Channel",
+          );
+        }
+        await sink.onScheduledTask({
+          ...base,
+          surfaceId: delivery.surfaceId,
+          scheduledAt: input.scheduledAt,
+          task: input.task,
         });
         return;
       default: {

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -83,6 +83,10 @@ const MANAGED_ASSET_ACTIVITY_TYPE = "copilotkit.managed-asset";
 const MANAGED_ASSET_HISTORY_ATTEMPTS = 3;
 const MANAGED_SLACK_TEXT_INTERVAL_MS = 600;
 
+/** Return the canonical Intelligence agent id owned by one Channel. */
+const canonicalChannelAgentId = (channelName: string): string =>
+  `channel:${channelName}`;
+
 /** Slack could not prove whether a managed file became visible. */
 export class ChannelFileDeliveryUnknownError extends ChannelDeliveryTerminatedError {
   readonly code = "unknown";
@@ -483,7 +487,7 @@ export class DeliveryAdapter implements PlatformAdapter {
       runId,
       userId: target.delivery.appUserId,
       memory: args.memory,
-      agentId: this.options.channelName,
+      agentId: canonicalChannelAgentId(this.options.channelName),
       tools: args.tools,
       context: args.context,
       persistedInputMessages,
@@ -852,7 +856,7 @@ export class DeliveryAdapter implements PlatformAdapter {
       threadId: target.delivery.canonicalThreadId,
       runId: mintId("run_"),
       userId: target.delivery.appUserId,
-      agentId: this.options.channelName,
+      agentId: canonicalChannelAgentId(this.options.channelName),
       tools: [],
       context: [],
       persistedInputMessages: [],

--- a/packages/channels-intelligence/src/delivery-channel-name.test.ts
+++ b/packages/channels-intelligence/src/delivery-channel-name.test.ts
@@ -6,7 +6,7 @@ import {
 } from "./delivery-test-gateway.js";
 import { startChannelsWithGatewayControl } from "./realtime-gateway-launcher.js";
 
-test("managed deliveries use the declared Channel name for canonical runs", async () => {
+test("managed deliveries use the canonical Channel agent id for runs", async () => {
   const gateway = new DeliveryTestGateway();
   const agent = new FakeAgent();
   const runCanonical = vi.fn(async (args) => args.execute({}));
@@ -84,7 +84,7 @@ test("managed deliveries use the declared Channel name for canonical runs", asyn
     );
 
     expect(runCanonical).toHaveBeenCalledOnce();
-    expect(runCanonical.mock.calls[0]![0].agentId).toBe("support");
+    expect(runCanonical.mock.calls[0]![0].agentId).toBe("channel:support");
     expect(runCanonical.mock.calls[0]![0].memory).toEqual({
       grant: { user: "read", project: "read-write" },
       user: {

--- a/packages/channels-intelligence/src/delivery-charge.test.ts
+++ b/packages/channels-intelligence/src/delivery-charge.test.ts
@@ -13,6 +13,7 @@ const delivery: PreparedChannelDelivery = {
   appUserId: "slack:T1:U1",
   channelId: "channel_charge",
   channelName: "support",
+  surfaceId: "surface_support_01",
   adapter: "slack",
   turn: {
     eventId: "evt_charge",

--- a/packages/channels-intelligence/src/delivery-history.test.ts
+++ b/packages/channels-intelligence/src/delivery-history.test.ts
@@ -12,6 +12,7 @@ const delivery: PreparedChannelDelivery = {
   deliveryExpiresAt: "2099-07-29T17:00:00.000Z",
   channelId: "channel_history_01",
   channelName: "support",
+  surfaceId: "surface_support_01",
   canonicalThreadId: "thread_history",
   appUserId: "slack:T1:U1",
   adapter: "slack",

--- a/packages/channels-intelligence/src/delivery-provider-elements.test.ts
+++ b/packages/channels-intelligence/src/delivery-provider-elements.test.ts
@@ -14,6 +14,7 @@ function delivery(adapter: "slack" | "teams"): PreparedChannelDelivery {
     deliveryExpiresAt: "2099-07-29T17:00:00.000Z",
     channelId: "channel_provider_element",
     channelName: "support",
+    surfaceId: "surface_support_01",
     canonicalThreadId: "thread_provider_element",
     appUserId: `${adapter}:tenant:user`,
     adapter,

--- a/packages/channels-intelligence/src/delivery-test-gateway.ts
+++ b/packages/channels-intelligence/src/delivery-test-gateway.ts
@@ -77,13 +77,25 @@ export class DeliveryTestGateway implements RealtimeGatewaySession {
   async deliver(delivery: PreparedChannelDelivery): Promise<void> {
     const expectedLeaves = this.leaves + 1;
     this.currentDelivery = delivery;
-    this.invitationHandler?.({
-      protocol: "channel_delivery_v1",
-      deliveryId: delivery.deliveryId,
-      canonicalThreadId: delivery.canonicalThreadId,
-      channelName: delivery.channelName,
-      adapter: delivery.adapter,
-    });
+    this.invitationHandler?.(
+      delivery.turn.input.kind === "scheduled_task"
+        ? {
+            protocol: "channel_delivery_v1",
+            kind: "scheduled_task",
+            deliveryId: delivery.deliveryId,
+            surfaceId: delivery.surfaceId,
+            channelName: delivery.channelName,
+            adapter: delivery.adapter,
+          }
+        : {
+            protocol: "channel_delivery_v1",
+            deliveryId: delivery.deliveryId,
+            canonicalThreadId: delivery.canonicalThreadId,
+            surfaceId: delivery.surfaceId,
+            channelName: delivery.channelName,
+            adapter: delivery.adapter,
+          },
+    );
     const deadline = Date.now() + 1_000;
     while (this.leaves !== expectedLeaves) {
       if (Date.now() >= deadline) {
@@ -142,6 +154,7 @@ export function preparedDelivery(
     appUserId: `app_user_${idSuffix}`,
     channelId: "channel_support",
     channelName: "support",
+    surfaceId: "surface_support_01",
     adapter,
     tenant: { id: `tenant_${idSuffix}` },
     installation: { id: `installation_${idSuffix}` },

--- a/packages/channels-intelligence/src/delivery-transcript.test.ts
+++ b/packages/channels-intelligence/src/delivery-transcript.test.ts
@@ -331,6 +331,7 @@ test("assistant transcript history stays plain while participant metadata stays 
     appUserId: "slack:T1:U1",
     channelId: "channel_transcript",
     channelName: "support",
+    surfaceId: "surface_support_01",
     adapter: "slack",
     turn: {
       eventId: "evt_transcript",
@@ -520,6 +521,7 @@ test("Teams transcript metadata and truncation labels name Teams, not Slack", as
     appUserId: "teams:T1:U1",
     channelId: "channel_teams_transcript",
     channelName: "support",
+    surfaceId: "surface_support_01",
     adapter: "teams",
     turn: {
       eventId: "evt_teams_transcript",

--- a/packages/channels-intelligence/src/delivery-transport.test.ts
+++ b/packages/channels-intelligence/src/delivery-transport.test.ts
@@ -19,6 +19,7 @@ function preparedDelivery() {
     deliveryExpiresAt: "2099-07-29T17:00:00.000Z",
     channelId: "channel_delivery_01",
     channelName: "support",
+    surfaceId: "surface_support_01",
     canonicalThreadId: "thread_01",
     appUserId: "slack:T1:U1",
     adapter: "slack" as const,
@@ -63,6 +64,7 @@ function invitation(
     deliveryId,
     canonicalThreadId,
     channelName: "support",
+    surfaceId: "surface_support_01",
     adapter,
   };
 }

--- a/packages/channels-intelligence/src/delivery-transport.ts
+++ b/packages/channels-intelligence/src/delivery-transport.ts
@@ -5,6 +5,7 @@ import {
 } from "@copilotkit/channels-core";
 import type { AgentContentPart } from "@copilotkit/channels-ui";
 import type { MessageOperation } from "@copilotkit/channels-ui";
+import type { ChannelScheduledTask } from "@copilotkit/channels-core";
 import type {
   RealtimeGatewayDeliveryChannel,
   RealtimeGatewaySession,
@@ -74,6 +75,11 @@ export type ChannelDeliveryTurnInput =
       kind: "file_consent";
       action: "accept" | "decline";
       fileHandle: string;
+    }
+  | {
+      kind: "scheduled_task";
+      scheduledAt: string;
+      task: ChannelScheduledTask;
     };
 
 export interface PreparedChannelDelivery {
@@ -85,6 +91,7 @@ export interface PreparedChannelDelivery {
   channelId: string;
   channelName: string;
   adapter: ChannelDeliveryAdapter;
+  surfaceId: string;
   tenant?: { id: string; name?: string };
   installation?: { id: string };
   conversation?: { id: string; kind?: string };
@@ -809,13 +816,22 @@ export class ChannelDeliveryTransport {
         this.active.size >=
         this.maxConcurrentDeliveries + this.maxPendingDeliveries
       ) {
-        this.reportCapacityOverflow(value.deliveryId, value.canonicalThreadId);
+        this.reportCapacityOverflow(
+          value.deliveryId,
+          "canonicalThreadId" in value
+            ? value.canonicalThreadId
+            : value.deliveryId,
+        );
         return;
       }
+      const admissionKey =
+        "canonicalThreadId" in value
+          ? value.canonicalThreadId
+          : value.deliveryId;
       const activeHandler = this.deliveryHandler;
       const signal = this.abortController.signal;
       const predecessor =
-        this.threadTails.get(value.canonicalThreadId) ?? Promise.resolve();
+        this.threadTails.get(admissionKey) ?? Promise.resolve();
       // Register into active before any await so stop() waits for this delivery.
       let running!: Promise<void>;
       running = this.claimAndHandle(
@@ -825,12 +841,12 @@ export class ChannelDeliveryTransport {
         predecessor,
       ).finally(() => {
         this.active.delete(value.deliveryId);
-        if (this.threadTails.get(value.canonicalThreadId) === running) {
-          this.threadTails.delete(value.canonicalThreadId);
+        if (this.threadTails.get(admissionKey) === running) {
+          this.threadTails.delete(admissionKey);
         }
       });
       this.active.set(value.deliveryId, running);
-      this.threadTails.set(value.canonicalThreadId, running);
+      this.threadTails.set(admissionKey, running);
     };
     this.options.session.on(INVITATION_EVENT, this.invitationHandler);
   }
@@ -1266,6 +1282,7 @@ const PREPARED_TURN_KINDS = new Set([
   "interaction",
   "welcome",
   "file_consent",
+  "scheduled_task",
 ]);
 const PREPARED_SURFACE_KINDS = new Set([
   "direct_message",
@@ -1297,6 +1314,7 @@ function assertPreparedDelivery(
         "canonicalThreadId",
         "appUserId",
         "adapter",
+        "surfaceId",
         "turn",
       ],
       ["tenant", "installation", "conversation", "surfaceKind"],
@@ -1312,6 +1330,7 @@ function assertPreparedDelivery(
     !isIsoDateTime(prepared.deliveryExpiresAt) ||
     !isChannelId(prepared.channelId) ||
     !isChannelName(prepared.channelName) ||
+    !isSurfaceId(prepared.surfaceId) ||
     !isSafeExternalId(prepared.canonicalThreadId) ||
     !isSafeAppUserId(prepared.appUserId) ||
     (prepared.adapter !== "slack" && prepared.adapter !== "teams") ||
@@ -1339,7 +1358,9 @@ function assertPreparedDelivery(
     !isRecord(prepared.turn.input) ||
     typeof prepared.turn.input.kind !== "string" ||
     !PREPARED_TURN_KINDS.has(prepared.turn.input.kind) ||
-    !isValidPreparedTurnInput(prepared.turn.input)
+    !isValidPreparedTurnInput(prepared.turn.input) ||
+    (prepared.turn.input.kind === "scheduled_task" &&
+      prepared.turn.input.task.surfaceId !== prepared.surfaceId)
   ) {
     throw new TypeError("Gateway returned an invalid prepared delivery");
   }
@@ -1396,6 +1417,12 @@ function isValidPreparedTurnInput(input: Record<string, unknown>): boolean {
         (input.action === "accept" || input.action === "decline") &&
         typeof input.fileHandle === "string" &&
         /^fileref_[A-Za-z0-9_-]+$/.test(input.fileHandle)
+      );
+    case "scheduled_task":
+      return (
+        hasExactFields(input, ["kind", "scheduledAt", "task"]) &&
+        isIsoDateTime(input.scheduledAt) &&
+        isScheduledTask(input.task)
       );
     default:
       return false;
@@ -1463,6 +1490,16 @@ function isChannelId(value: unknown): value is string {
   );
 }
 
+/** Validate one opaque Intelligence provider-surface identifier. */
+function isSurfaceId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length >= 12 &&
+    value.length <= 132 &&
+    /^surface_[A-Za-z0-9_-]+$/.test(value)
+  );
+}
+
 function isEventId(value: unknown): value is string {
   return (
     typeof value === "string" &&
@@ -1519,6 +1556,59 @@ function isPreparedActor(value: unknown): boolean {
     (value.handle === undefined || isBoundedString(value.handle, 1, 512)) &&
     (value.email === undefined || isBoundedString(value.email, 1, 512))
   );
+}
+
+/** Validate the exact scheduled Task snapshot accepted from Gateway. */
+function isScheduledTask(value: unknown): value is ChannelScheduledTask {
+  if (
+    !isRecord(value) ||
+    !hasExactFields(value, [
+      "id",
+      "surfaceId",
+      "goal",
+      "when",
+      "enabled",
+      "createdBy",
+      "createdAt",
+      "updatedAt",
+    ]) ||
+    typeof value.id !== "string" ||
+    !/^task_[A-Za-z0-9_-]+$/.test(value.id) ||
+    !isSurfaceId(value.surfaceId) ||
+    !isBoundedString(value.goal, 1, 40_000) ||
+    value.enabled !== true ||
+    !isIsoDateTime(value.createdAt) ||
+    !isIsoDateTime(value.updatedAt) ||
+    !isRecord(value.when) ||
+    !hasExactFields(value.when, ["kind", "cron", "timeZone"]) ||
+    value.when.kind !== "schedule" ||
+    typeof value.when.cron !== "string" ||
+    !/^\S+(?:\s+\S+){4}$/.test(value.when.cron) ||
+    !isBoundedString(value.when.timeZone, 1, 128) ||
+    !isRecord(value.createdBy)
+  ) {
+    return false;
+  }
+  if (value.createdBy.kind === "application") {
+    return (
+      hasExactFields(value.createdBy, ["kind", "applicationId"]) &&
+      isBoundedString(value.createdBy.applicationId, 1, 256)
+    );
+  }
+  if (value.createdBy.kind === "provider_actor") {
+    return (
+      hasExactFields(value.createdBy, ["kind", "actor"]) &&
+      isRecord(value.createdBy.actor) &&
+      hasExactFields(
+        value.createdBy.actor,
+        ["id", "kind"],
+        ["displayName", "handle"],
+      ) &&
+      isBoundedString(value.createdBy.actor.id, 1, 512) &&
+      ["human", "bot", "app"].includes(String(value.createdBy.actor.kind))
+    );
+  }
+  return false;
 }
 
 function isPreparedTenant(value: unknown): boolean {
@@ -1639,27 +1729,55 @@ function shouldSendGenericFailure(
   );
 }
 
-function isInvitation(value: unknown): value is {
-  protocol: typeof CHANNEL_DELIVERY_PROTOCOL;
-  deliveryId: string;
-  canonicalThreadId: string;
-  channelName: string;
-  adapter: ChannelDeliveryAdapter;
-} {
+type DeliveryInvitation =
+  | {
+      protocol: typeof CHANNEL_DELIVERY_PROTOCOL;
+      deliveryId: string;
+      canonicalThreadId: string;
+      surfaceId: string;
+      channelName: string;
+      adapter: ChannelDeliveryAdapter;
+    }
+  | {
+      protocol: typeof CHANNEL_DELIVERY_PROTOCOL;
+      kind: "scheduled_task";
+      deliveryId: string;
+      surfaceId: string;
+      channelName: string;
+      adapter: ChannelDeliveryAdapter;
+    };
+
+/** Validate either a normal Thread invitation or a scheduled Task invitation. */
+function isInvitation(value: unknown): value is DeliveryInvitation {
+  if (
+    !isRecord(value) ||
+    value.protocol !== CHANNEL_DELIVERY_PROTOCOL ||
+    !isDeliveryId(value.deliveryId) ||
+    !isSurfaceId(value.surfaceId) ||
+    !isChannelName(value.channelName) ||
+    (value.adapter !== "slack" && value.adapter !== "teams")
+  ) {
+    return false;
+  }
+  if (value.kind === "scheduled_task") {
+    return hasExactFields(value, [
+      "protocol",
+      "kind",
+      "deliveryId",
+      "surfaceId",
+      "channelName",
+      "adapter",
+    ]);
+  }
   return (
-    isRecord(value) &&
     hasExactFields(value, [
       "protocol",
       "deliveryId",
       "canonicalThreadId",
+      "surfaceId",
       "channelName",
       "adapter",
-    ]) &&
-    value.protocol === CHANNEL_DELIVERY_PROTOCOL &&
-    isDeliveryId(value.deliveryId) &&
-    isSafeExternalId(value.canonicalThreadId) &&
-    isChannelName(value.channelName) &&
-    (value.adapter === "slack" || value.adapter === "teams")
+    ]) && isSafeExternalId(value.canonicalThreadId)
   );
 }
 

--- a/packages/channels-intelligence/src/index.ts
+++ b/packages/channels-intelligence/src/index.ts
@@ -53,6 +53,10 @@ export type { IntelligenceStateStoreConfig } from "./intelligence-state-store.js
 export { ChannelDeliveryTranscriptError } from "./delivery-transcript.js";
 export { ChannelProviderMismatchError } from "./delivery-transport.js";
 export { ChannelFileDeliveryUnknownError } from "./delivery-adapter.js";
+export { ChannelTaskHttpClient } from "./channel-tasks.js";
+export type { ChannelTaskHttpClientOptions } from "./channel-tasks.js";
+export { ChannelHistoryHttpClient } from "./channel-history.js";
+export type { ChannelHistoryHttpClientOptions } from "./channel-history.js";
 export type {
   ChannelDeliveryTranscript,
   ChannelTranscriptActor,

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.ts
@@ -164,6 +164,9 @@ export async function startChannelsWithGatewayControl(
       ...(opts.log ? { log: opts.log } : {}),
       showToolStatus: opts.showToolStatus ?? channel.showToolStatus,
       replyContinuation: opts.replyContinuation ?? channel.replyContinuation,
+      ...(opts.appApiBaseUrl ? { appApiBaseUrl: opts.appApiBaseUrl } : {}),
+      ...(opts.apiKey ? { apiKey: opts.apiKey } : {}),
+      ...(opts.appApiFetch ? { appApiFetch: opts.appApiFetch } : {}),
     }),
   );
   await channel.ɵruntime.start();
@@ -309,8 +312,16 @@ export async function startChannelsOverRealtimeGateway(
         ? { maxConcurrentDeliveries: config.maxConcurrentDeliveries }
         : {}),
       channels: activation.declaredChannels.flatMap((channel) => [
-        { channelName: channel.channelName, adapter: "slack" },
-        { channelName: channel.channelName, adapter: "teams" },
+        {
+          channelName: channel.channelName,
+          adapter: "slack",
+          ...(channel.tasks ? { tasks: true as const } : {}),
+        },
+        {
+          channelName: channel.channelName,
+          adapter: "teams",
+          ...(channel.tasks ? { tasks: true as const } : {}),
+        },
       ]),
     },
     ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),

--- a/packages/channels-intelligence/src/realtime-gateway.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.test.ts
@@ -146,6 +146,7 @@ function makeFakeWebSocket(
                 deliveryId: "dlv_first_invitation",
                 canonicalThreadId: "thread_first_invitation",
                 channelName: "opentag",
+                surfaceId: "surface_support_01",
                 adapter: "slack",
               },
             ]),
@@ -260,6 +261,7 @@ describe("connectRealtimeGateway", () => {
         deliveryId: "dlv_first_invitation",
         canonicalThreadId: "thread_first_invitation",
         channelName: "opentag",
+        surfaceId: "surface_support_01",
         adapter: "slack",
       },
     ]);

--- a/packages/channels-intelligence/src/realtime-gateway.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.ts
@@ -48,6 +48,7 @@ export interface ConnectRealtimeGatewayOptions {
     channels: ReadonlyArray<{
       channelName: string;
       adapter: string;
+      tasks?: true;
     }>;
   };
   /** Per-push / join timeout in ms (default 10000). */

--- a/packages/channels-intelligence/src/runtime-tasks.test.ts
+++ b/packages/channels-intelligence/src/runtime-tasks.test.ts
@@ -1,0 +1,33 @@
+import { createChannel } from "@copilotkit/channels-core";
+import { expect, test, vi } from "vitest";
+import { buildChannelActivationMetadata } from "./runtime.js";
+
+test("declares Tasks only for a Channel with a model and handler", () => {
+  const model = {
+    kind: "text",
+    name: "test",
+    model: "test",
+    structuredOutput: vi.fn(),
+    chatStream: vi.fn(),
+    "~types": {},
+  } as never;
+  const tasks = createChannel({
+    identifyUser: "platform",
+    name: "task-channel",
+    tasks: { model },
+  });
+  tasks.onTask(vi.fn());
+  const ordinary = createChannel({
+    identifyUser: "platform",
+    name: "ordinary-channel",
+  });
+
+  const metadata = buildChannelActivationMetadata([tasks, ordinary], {
+    runtimeEnv: "test",
+  });
+
+  expect(metadata.declaredChannels).toEqual([
+    { channelName: "task-channel", commands: [], tasks: true },
+    { channelName: "ordinary-channel", commands: [] },
+  ]);
+});

--- a/packages/channels-intelligence/src/runtime.ts
+++ b/packages/channels-intelligence/src/runtime.ts
@@ -50,7 +50,11 @@ export interface ChannelActivationEnv {
 export interface ChannelActivationMetadata extends ChannelActivationEnv {
   declaredChannelNames: string[];
   /** Per-Channel declarations: name + declared slash-command names. */
-  declaredChannels: Array<{ channelName: string; commands: string[] }>;
+  declaredChannels: Array<{
+    channelName: string;
+    commands: string[];
+    tasks?: true;
+  }>;
 }
 
 /**
@@ -107,6 +111,7 @@ export function buildChannelActivationMetadata(
     declaredChannels: channels.map((c, i) => ({
       channelName: names[i]!,
       commands: c.commandNames,
+      ...(c.tasksEnabled ? { tasks: true as const } : {}),
     })),
   };
 }

--- a/packages/channels-intelligence/src/scheduled-task.test.ts
+++ b/packages/channels-intelligence/src/scheduled-task.test.ts
@@ -1,0 +1,102 @@
+import { createChannel } from "@copilotkit/channels-core";
+import { expect, test, vi } from "vitest";
+import { startChannelsWithGatewayControl } from "./realtime-gateway-launcher.js";
+import {
+  DeliveryTestGateway,
+  preparedDelivery,
+} from "./delivery-test-gateway.js";
+
+test("scheduled delivery invokes onTask with no actor and posts through the normal effect path", async () => {
+  const gateway = new DeliveryTestGateway();
+  const model = {
+    kind: "text",
+    name: "unused",
+    model: "unused",
+    structuredOutput: vi.fn(),
+    chatStream: vi.fn(),
+    "~types": {},
+  } as never;
+  const channel = createChannel({
+    identifyUser: "platform",
+    name: "support",
+    tasks: { model },
+  });
+  const handled = vi.fn();
+  channel.onTask(async ({ task, cause, thread }) => {
+    handled({ task, cause });
+    await thread.post(task.goal);
+  });
+  const appApiFetch = vi.fn(async () =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          charged: true,
+          metering: { mode: "unlimited", lifetimeUsed: 1 },
+        }),
+      ),
+    ),
+  );
+  const handle = await startChannelsWithGatewayControl([channel], {
+    session: gateway,
+    scope: { projectId: 7, channelName: "support" },
+    runtimeInstanceId: "rti_scheduled_01",
+    appApiBaseUrl: "https://api.example",
+    apiKey: "cpk-runtime",
+    appApiFetch,
+    runCanonical: async (args) => args.execute({}),
+    loadHistory: async () => [],
+  });
+  const task = {
+    id: "task_scheduled_01",
+    surfaceId: "surface_support_01",
+    goal: "Post the daily status prompt",
+    when: {
+      kind: "schedule" as const,
+      cron: "0 9 * * 1-5",
+      timeZone: "America/Los_Angeles",
+    },
+    enabled: true as const,
+    createdBy: {
+      kind: "application" as const,
+      applicationId: "runtime_01",
+    },
+    createdAt: "2026-08-01T10:00:00.000Z",
+    updatedAt: "2026-08-01T10:00:00.000Z",
+  };
+
+  await gateway.deliver({
+    ...preparedDelivery("scheduled_01", "slack", {
+      kind: "scheduled_task",
+      scheduledAt: "2026-08-01T16:00:00.000Z",
+      task,
+    }),
+    surfaceId: task.surfaceId,
+    turn: {
+      eventId: "evt_scheduled_01",
+      receivedAt: "2026-08-01T16:00:00.000Z",
+      input: {
+        kind: "scheduled_task",
+        scheduledAt: "2026-08-01T16:00:00.000Z",
+        task,
+      },
+    },
+  });
+
+  expect(handled).toHaveBeenCalledWith({
+    task,
+    cause: {
+      kind: "schedule",
+      scheduledAt: "2026-08-01T16:00:00.000Z",
+      actor: null,
+    },
+  });
+  expect(gateway.packets.map((packet) => packet.payload)).toContainEqual(
+    expect.objectContaining({
+      kind: "slack.message.create",
+      text: "Post the daily status prompt",
+    }),
+  );
+  expect(appApiFetch).toHaveBeenCalledOnce();
+
+  await handle.stop();
+});

--- a/packages/channels-intelligence/src/task-charging-e2e.test.ts
+++ b/packages/channels-intelligence/src/task-charging-e2e.test.ts
@@ -1,0 +1,112 @@
+import { createChannel, FakeAgent } from "@copilotkit/channels-core";
+import { expect, test, vi } from "vitest";
+import { startChannelsWithGatewayControl } from "./realtime-gateway-launcher.js";
+import {
+  DeliveryTestGateway,
+  preparedDelivery,
+} from "./delivery-test-gateway.js";
+
+const task = {
+  id: "task_charge_e2e_01",
+  surfaceId: "surface_support_01",
+  goal: "Run scheduled work",
+  when: {
+    kind: "schedule" as const,
+    cron: "0 9 * * 1-5",
+    timeZone: "America/Los_Angeles",
+  },
+  enabled: true as const,
+  createdBy: {
+    kind: "application" as const,
+    applicationId: "runtime_01",
+  },
+  createdAt: "2026-08-01T10:00:00.000Z",
+  updatedAt: "2026-08-01T10:00:00.000Z",
+};
+
+/** Run one controlled scheduled delivery and report its visible side effects. */
+async function runScheduledHandler(
+  mode: "noop" | "agent" | "effect",
+): Promise<{ chargeCalls: number; providerEffects: number }> {
+  const gateway = new DeliveryTestGateway();
+  const channel = createChannel({
+    identifyUser: "platform",
+    name: "support",
+    tasks: {
+      model: {
+        kind: "text",
+        name: "unused",
+        model: "unused",
+        structuredOutput: vi.fn(),
+        chatStream: vi.fn(),
+        "~types": {},
+      } as never,
+    },
+  });
+  channel.onTask(async ({ thread }) => {
+    if (mode === "agent") {
+      await thread.runAgent({ agent: new FakeAgent(), prompt: task.goal });
+    }
+    if (mode === "effect") await thread.post(task.goal);
+  });
+  const appApiFetch = vi.fn(async (_input: string | URL | Request) =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          charged: true,
+          metering: { mode: "unlimited", lifetimeUsed: 1 },
+        }),
+      ),
+    ),
+  );
+  const handle = await startChannelsWithGatewayControl([channel], {
+    session: gateway,
+    scope: { projectId: 7, channelName: "support" },
+    runtimeInstanceId: `rti_charge_${mode}_01`,
+    appApiBaseUrl: "https://api.example",
+    apiKey: "cpk-runtime",
+    appApiFetch,
+    runCanonical: async (args) => args.execute({}),
+    loadHistory: async () => [],
+  });
+
+  try {
+    await gateway.deliver({
+      ...preparedDelivery(`scheduled_charge_${mode}_01`, "slack", {
+        kind: "scheduled_task",
+        scheduledAt: "2026-08-01T16:00:00.000Z",
+        task,
+      }),
+      surfaceId: task.surfaceId,
+    });
+    return {
+      chargeCalls: appApiFetch.mock.calls.filter(([url]) =>
+        String(url).endsWith("/charge"),
+      ).length,
+      providerEffects: gateway.packets.filter(
+        (packet) => packet.payload.kind === "slack.message.create",
+      ).length,
+    };
+  } finally {
+    await handle.stop();
+  }
+}
+
+test("scheduled no-op handlers remain uncharged", async () => {
+  await expect(runScheduledHandler("noop")).resolves.toEqual({
+    chargeCalls: 0,
+    providerEffects: 0,
+  });
+});
+
+test("scheduled agent runs charge once before work", async () => {
+  await expect(runScheduledHandler("agent")).resolves.toMatchObject({
+    chargeCalls: 1,
+  });
+});
+
+test("scheduled provider effects charge once", async () => {
+  const result = await runScheduledHandler("effect");
+  expect(result.chargeCalls).toBe(1);
+  expect(result.providerEffects).toBeGreaterThan(0);
+});

--- a/packages/channels-intelligence/src/task-delivery-e2e.test.ts
+++ b/packages/channels-intelligence/src/task-delivery-e2e.test.ts
@@ -1,0 +1,165 @@
+import { createChannel } from "@copilotkit/channels-core";
+import { expect, test, vi } from "vitest";
+import { startChannelsWithGatewayControl } from "./realtime-gateway-launcher.js";
+import {
+  DeliveryTestGateway,
+  preparedDelivery,
+} from "./delivery-test-gateway.js";
+
+const eventTask = {
+  id: "task_event_e2e_01",
+  surfaceId: "surface_support_01",
+  goal: "Handle production blockers",
+  when: {
+    kind: "event" as const,
+    event: "message" as const,
+    rule: "The message says production is blocked",
+  },
+  enabled: true,
+  createdBy: {
+    kind: "application" as const,
+    applicationId: "runtime_01",
+  },
+  createdAt: "2026-08-01T10:00:00.000Z",
+  updatedAt: "2026-08-01T10:00:00.000Z",
+};
+
+const scheduledTask = {
+  ...eventTask,
+  id: "task_scheduled_e2e_01",
+  goal: "Post the daily status prompt",
+  when: {
+    kind: "schedule" as const,
+    cron: "0 9 * * 1-5",
+    timeZone: "America/Los_Angeles",
+  },
+  enabled: true as const,
+};
+
+test("event and scheduled Tasks share the managed delivery, effect, and canonical Thread paths", async () => {
+  const gateway = new DeliveryTestGateway();
+  const structuredOutput = vi.fn().mockResolvedValue({
+    data: { taskId: eventTask.id },
+    rawText: JSON.stringify({ taskId: eventTask.id }),
+  });
+  const model = {
+    kind: "text",
+    name: "task-e2e",
+    model: "task-e2e",
+    structuredOutput,
+    chatStream: vi.fn(),
+    "~types": {},
+  } as never;
+  const channel = createChannel({
+    identifyUser: "platform",
+    name: "support",
+    tasks: { model },
+  });
+  const taskRuns: Array<{
+    kind: "event" | "schedule";
+    actorId: string | null;
+    thread: string;
+  }> = [];
+  const ordinaryThreads: string[] = [];
+  channel.onTask(async ({ task, cause, thread }) => {
+    taskRuns.push({
+      kind: cause.kind,
+      actorId: cause.actor?.id ?? null,
+      thread: thread.conversationKey,
+    });
+    await thread.post(task.goal);
+  });
+  channel.onMessage(({ thread }) => {
+    ordinaryThreads.push(thread.conversationKey);
+  });
+  let taskListReads = 0;
+  const appApiFetch = vi.fn(async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes("/tasks?")) {
+      taskListReads += 1;
+      return new Response(
+        JSON.stringify({ tasks: taskListReads === 1 ? [eventTask] : [] }),
+      );
+    }
+    return new Response(
+      JSON.stringify({
+        charged: true,
+        metering: { mode: "unlimited", lifetimeUsed: 1 },
+      }),
+    );
+  });
+  const handle = await startChannelsWithGatewayControl([channel], {
+    session: gateway,
+    scope: { projectId: 7, channelName: "support" },
+    runtimeInstanceId: "rti_task_e2e_01",
+    appApiBaseUrl: "https://api.example",
+    apiKey: "cpk-runtime",
+    appApiFetch,
+    runCanonical: async (args) => args.execute({}),
+    loadHistory: async () => [],
+  });
+
+  try {
+    await gateway.deliver(
+      preparedDelivery("event_task_e2e_01", "slack", {
+        kind: "text",
+        text: "Production is blocked",
+      }),
+    );
+    const scheduled = {
+      ...preparedDelivery("scheduled_task_e2e_01", "slack", {
+        kind: "scheduled_task" as const,
+        scheduledAt: "2026-08-01T16:00:00.000Z",
+        task: scheduledTask,
+      }),
+      surfaceId: scheduledTask.surfaceId,
+    };
+    await gateway.deliver(scheduled);
+    await gateway.deliver({
+      ...preparedDelivery("scheduled_reply_e2e_01", "slack", {
+        kind: "text",
+        text: "Here is today's update",
+      }),
+      canonicalThreadId: scheduled.canonicalThreadId,
+    });
+
+    expect(structuredOutput).toHaveBeenCalledOnce();
+    expect(taskRuns).toEqual([
+      {
+        kind: "event",
+        actorId: "user_event_task_e2e_01",
+        thread: "thread_event_task_e2e_01",
+      },
+      {
+        kind: "schedule",
+        actorId: null,
+        thread: scheduled.canonicalThreadId,
+      },
+    ]);
+    expect(ordinaryThreads).toEqual([scheduled.canonicalThreadId]);
+    const scheduledCreates = gateway.packets.filter(
+      (packet) =>
+        packet.payload.kind === "slack.message.create" &&
+        packet.payload.text === scheduledTask.goal,
+    );
+    expect(scheduledCreates.length).toBeGreaterThan(0);
+    for (const packet of scheduledCreates) {
+      expect(packet.payload).not.toHaveProperty("threadTs");
+    }
+    expect(
+      appApiFetch.mock.calls.filter(([url]) => String(url).endsWith("/charge")),
+    ).toHaveLength(2);
+    expect(appApiFetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "/tasks?surfaceId=surface_support_01&event=message&enabled=true",
+      ),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-cpki-channel-delivery-id": expect.stringMatching(/^dlv_/u),
+        }),
+      }),
+    );
+  } finally {
+    await handle.stop();
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2542,6 +2542,12 @@ importers:
       '@copilotkit/shared':
         specifier: workspace:^
         version: link:../shared
+      '@tanstack/ai':
+        specifier: ^0.42.0
+        version: 0.42.0(@opentelemetry/api@1.9.0)
+      zod:
+        specifier: '>=3.22.3'
+        version: 3.25.76
       zod-to-json-schema:
         specifier: ^3.24.1
         version: 3.25.1(zod@3.25.76)
@@ -2558,9 +2564,6 @@ importers:
       vitest:
         specifier: ^4.1.3
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@22.19.11)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
-      zod:
-        specifier: '>=3.22.3'
-        version: 3.25.76
 
   packages/channels-discord:
     dependencies:

--- a/showcase/shell-docs/src/content/reference/channels/classes/Channel.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/classes/Channel.mdx
@@ -34,6 +34,7 @@ both Slack and Teams for this Channel and keeps each delivery provider-scoped.
 | `commands`       | `ChannelCommand[]`                                     | Declared commands for providers that support them.                                                                          |
 | `store`          | `StoreConfig`                                          | State schema, persistence, turn concurrency (`parallel` default), dedup, and optional transcript bridge.                    |
 | `adapters`       | `PlatformAdapter[]`                                    | Low-level direct transports. They may coexist with the managed Intelligence adapter on this Channel.                        |
+| `tasks`          | `{ model: AnyTextAdapter }`                            | Managed Task matcher model. Requires exactly one `onTask` handler.                                                          |
 
 One Channel may receive managed Slack and Teams deliveries. Names must be
 unique inside one `CopilotRuntime`.
@@ -116,6 +117,9 @@ release a lock only when the supplied token still owns it.
 | `adapters`       | `readonly PlatformAdapter[]` | Attached transport snapshot. Managed Channels start empty and receive the Intelligence adapter at activation. |
 | `commandNames`   | `string[]`                   | Normalized names declared through `commands` or `onCommand`.                                                  |
 | `transcripts`    | `Transcripts`                | Optional SDK transcript API. It is not the managed provider-history store.                                    |
+| `tasksEnabled`   | `boolean`                    | True when the Channel has a Task model and exactly one handler.                                               |
+| `tasks`          | `ChannelTasksClient`         | Programmatic Task CRUD and four opt-in management tools.                                                       |
+| `readChannelMessagesTool` | `ChannelTool`         | Separate opt-in tool for bounded provider history on the current managed surface.                              |
 
 The `transcripts` getter is only available after Channel activation and throws
 if it is read before the runtime listener starts the Channel.
@@ -172,6 +176,9 @@ channel.tool(getIncident);
 
 See [Tools and context for Slack](/slack/tools) or
 [Tools and context for Teams](/teams/tools).
+
+See [Channel Tasks](/reference/channels/sdk/tasks) for `onTask`, Task CRUD,
+management tools, scheduled work, and provider history.
 
 ## Runtime lifecycle
 

--- a/showcase/shell-docs/src/content/reference/channels/index.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/index.mdx
@@ -95,6 +95,8 @@ npm install --save-exact @copilotkit/channels@0.5.0 @copilotkit/runtime@1.64.2
 
 ### Provider SDKs
 
+- [`Channel Tasks`](/reference/channels/sdk/tasks) — event matching, scheduled
+  work, scoped management tools, and opt-in provider history
 - [`Direct provider adapters`](/reference/channels/sdk/direct-adapters) —
   public entry points, required options, and the boundary between managed and
   developer-operated delivery

--- a/showcase/shell-docs/src/content/reference/channels/sdk/tasks.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/sdk/tasks.mdx
@@ -1,0 +1,137 @@
+---
+title: Channel Tasks
+description: Match ambient Slack or Teams activity, run scheduled work, manage Tasks, and opt into provider-surface history.
+---
+
+Channel Tasks run application code for ambient Slack or Microsoft Teams events
+and scheduled work. They require a managed CopilotKit Intelligence Channel.
+Direct provider adapters do not support Tasks.
+
+## Configure Tasks
+
+Pass one TanStack AI text model and register exactly one `onTask` handler:
+
+```ts title="channel.ts"
+import { createChannel } from "@copilotkit/channels";
+import { taskMatcherModel } from "./models.js";
+import { chooseAgent, chooseTools } from "./task-policy.js";
+
+const channel = createChannel({
+  name: "support-agent",
+  identifyUser: "platform",
+  tasks: { model: taskMatcherModel },
+});
+
+channel.onTask(async ({ task, cause, thread }) => {
+  await thread.runAgent({
+    agent: chooseAgent({ task, actor: cause.actor }),
+    tools: chooseTools({ task, actor: cause.actor }),
+    prompt: task.goal,
+  });
+});
+```
+
+Startup fails if the Channel has only the model or only the handler. The
+matcher makes one structured-output model call for each eligible event that has
+candidates. It selects at most one stored Task. No match or matcher failure
+runs the normal message or reaction handler.
+
+Event Tasks accept new messages and added reactions. Edits, deletes, removed
+reactions, system events, and this Channel's own output do not enter matching.
+An event Task runs in the event's canonical Thread and exposes its provider
+actor through `cause.actor`.
+
+Scheduled Tasks use the same handler with `cause.kind === "schedule"` and
+`cause.actor === null`. `thread.post()` creates a fresh provider root. A later
+reply continues the canonical Thread bound to that root.
+
+## Task shape
+
+```ts
+type ChannelTask = {
+  id: string;
+  surfaceId: string;
+  goal: string;
+  when:
+    | {
+        kind: "event";
+        event: "message" | "reaction_added";
+        rule: string;
+      }
+    | {
+        kind: "schedule";
+        cron: string;
+        timeZone: string;
+      };
+  enabled: boolean;
+  createdBy:
+    | { kind: "provider_actor"; actor: ChannelTaskActor }
+    | { kind: "application"; applicationId: string };
+  createdAt: string;
+  updatedAt: string;
+};
+```
+
+Each Task belongs to one whole provider surface: a Slack channel or direct
+message, or a Teams channel or personal chat. `surfaceId` is an opaque
+Intelligence ID. It never contains a raw provider route or credential.
+
+## Programmatic Task management
+
+Programmatic calls accept the surface that the application selected:
+
+```ts
+const task = await channel.tasks.create({
+  surfaceId,
+  goal: "Triage requests that block production",
+  when: {
+    kind: "event",
+    event: "message",
+    rule: "The message says production is blocked",
+  },
+});
+
+await channel.tasks.list({ surfaceId });
+await channel.tasks.update({ taskId: task.id, enabled: false });
+await channel.tasks.delete({ taskId: task.id });
+```
+
+The four Task tools are opt-in. Add only the tools that the chosen agent may
+use:
+
+```ts
+for (const tool of channel.tasks.tools) channel.tool(tool);
+```
+
+The tools are named `create_channel_task`, `list_channel_tasks`,
+`update_channel_task`, and `delete_channel_task`. The model supplies Task fields
+and Task IDs. The runtime supplies the current project, Channel, provider actor,
+application identity, and surface. Model arguments cannot change that scope.
+
+## Provider-surface history
+
+Provider history is a separate opt-in tool:
+
+```ts
+channel.tool(channel.readChannelMessagesTool);
+```
+
+`read_channel_messages` accepts only a page `limit` and opaque `cursor`. It
+reads Slack roots and replies, Slack direct-message history, Teams channel
+roots and replies, or Teams personal-chat history from the current surface.
+It returns normalized messages in chronological order.
+
+The tool does not inject history into the Task prompt. The application must
+give the tool to the selected agent. Provider rate limits return a retryable
+error; Intelligence does not retry the provider call inside the request.
+
+## Delivery and charging
+
+Task matching, no-match results, cron ticks, wakes, claims, and no-op handlers
+do not consume a Channel turn. The delivery consumes one turn before its first
+agent run or requested provider effect. One agent run plus more provider
+effects in the same delivery still consumes one turn.
+
+Scheduled wakes are live and best effort. A disconnected runtime or failed
+wake loses that tick. Tasks do not add catch-up, run history, outcome records,
+or a recovery queue.

--- a/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
@@ -37,6 +37,7 @@ const channelReferenceFiles = {
   thread: "../../content/reference/channels/classes/Thread.mdx",
   callbacks: "../../content/reference/channels/types/JSXCallbacks.mdx",
   directAdapters: "../../content/reference/channels/sdk/direct-adapters.mdx",
+  tasks: "../../content/reference/channels/sdk/tasks.mdx",
   index: "../../content/reference/channels/index.mdx",
 } as const;
 
@@ -286,6 +287,7 @@ describe("Channels documentation journey", () => {
     expect(index).toContain("/reference/channels/components/Button");
     expect(index).toContain("/reference/channels/types/StateStore");
     expect(index).toContain("/reference/channels/sdk/direct-adapters");
+    expect(index).toContain("/reference/channels/sdk/tasks");
     expect(index).toContain(
       "[Connect and run your agent in Slack](/slack/connect)",
     );
@@ -311,6 +313,12 @@ describe("Channels documentation journey", () => {
     expect(directAdapters).toContain("ESM-only");
     expect(directAdapters).toContain("Message Content Intent");
     expect(directAdapters).toContain("Server Members Intent");
+
+    const tasks = referenceBodyFor("tasks");
+    expect(tasks).toContain("channel.onTask");
+    expect(tasks).toContain("channel.tasks.create");
+    expect(tasks).toContain("channel.readChannelMessagesTool");
+    expect(tasks).toContain("read_channel_messages");
   });
 
   it("keeps managed provider selection out of shared SDK declarations", () => {

--- a/showcase/shell-docs/src/lib/__tests__/reference-discovery.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/reference-discovery.test.ts
@@ -64,6 +64,7 @@ test("publishes the maintained Channels SDK reference in its original surface", 
       "channels/functions/createChannel",
       "channels/functions/defineChannelTool",
       "channels/sdk/direct-adapters",
+      "channels/sdk/tasks",
       "channels/types/JSXCallbacks",
       "channels/types/StateStore",
     ]),
@@ -72,7 +73,7 @@ test("publishes the maintained Channels SDK reference in its original surface", 
   expect(referenceOverview).toContain('href: referenceVersionHref("channels")');
 
   const navigationUrls = collectPageUrls(buildReferencePageTree("channels"));
-  expect(navigationUrls).toHaveLength(34);
+  expect(navigationUrls).toHaveLength(35);
   expect(navigationUrls).toEqual(
     expect.arrayContaining([
       "/reference/channels/classes/Channel",
@@ -87,6 +88,7 @@ test("publishes the maintained Channels SDK reference in its original surface", 
       "/reference/channels/functions/defineChannelCommand",
       "/reference/channels/functions/defineChannelTool",
       "/reference/channels/sdk/direct-adapters",
+      "/reference/channels/sdk/tasks",
       "/reference/channels/types/ActionStore",
       "/reference/channels/types/AgentContentPart",
       "/reference/channels/types/JSXCallbacks",


### PR DESCRIPTION
## Summary

- add Channel Task authoring, event matching, scheduling, and runtime delivery APIs
- hard-cut managed Channel agent IDs to the `channel:<name>` namespace
- preserve canonical Threads across scheduled roots and later provider replies
- add Channel Tasks reference docs in shell-docs

Intelligence storage, worker, Gateway, and deployment changes: https://github.com/CopilotKit/Intelligence/pull/719

## Contract

- event Tasks receive the real provider actor and surface through `onTask`
- scheduled Tasks start without provider actor data
- no-op Tasks do not charge; agent calls and provider effects charge once
- Task delivery tests use controlled provider doubles and the Intelligence delivery boundary

## Validation

- channels-core: `40` files, `264` tests; typecheck, build, and publint
- channels-intelligence: `25` files, `181` tests; typecheck, build, and publint
- shell-docs: `51` files, `351` tests; typecheck and production build (`223` pages)
