### PR TITLE
fix(channels): accept namespaced Teams app user IDs

### DIFF
--- a/packages/channels-intelligence/src/delivery-transport.test.ts
+++ b/packages/channels-intelligence/src/delivery-transport.test.ts
@@ -1480,6 +1480,44 @@ test("rejects extra prepared delivery and turn fields", async () => {
   });
 });
 
+test("accepts a namespaced Teams app user id longer than one external id", async () => {
+  const base = preparedDelivery();
+  const appUserId = `teams:00000000-0000-0000-0000-000000000000:29:${"a".repeat(87)}`;
+  const delivery = {
+    ...base,
+    adapter: "teams" as const,
+    appUserId,
+  };
+  const deliveryChannel = channel(delivery);
+  const control: RealtimeGatewaySession = {
+    push: vi.fn().mockResolvedValue(claimResult(delivery.deliveryId)),
+    on: vi.fn(),
+    join: vi.fn().mockResolvedValue(deliveryChannel),
+  };
+  const handler = vi.fn(async () => undefined);
+  const transport = new ChannelDeliveryTransport({
+    session: control,
+    runtimeInstanceId: "rti_runtime_01",
+  });
+  transport.start(handler);
+
+  expect(appUserId).toHaveLength(133);
+  const invitationHandler = vi.mocked(control.on).mock.calls[0]![1];
+  invitationHandler(
+    invitation(delivery.deliveryId, delivery.canonicalThreadId, "teams"),
+  );
+  await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce());
+  await transport.stop();
+});
+
+test("rejects a namespaced app user id over the composite bound", async () => {
+  const base = preparedDelivery();
+  await expectPreparedDeliveryRejected({
+    ...base,
+    appUserId: "a".repeat(2049),
+  });
+});
+
 test("rejects malformed managed mention-routing metadata", async () => {
   const base = preparedDelivery().turn.input;
   await expectPreparedInputRejected({

--- a/packages/channels-intelligence/src/delivery-transport.ts
+++ b/packages/channels-intelligence/src/delivery-transport.ts
@@ -1313,7 +1313,7 @@ function assertPreparedDelivery(
     !isChannelId(prepared.channelId) ||
     !isChannelName(prepared.channelName) ||
     !isSafeExternalId(prepared.canonicalThreadId) ||
-    !isSafeExternalId(prepared.appUserId) ||
+    !isSafeAppUserId(prepared.appUserId) ||
     (prepared.adapter !== "slack" && prepared.adapter !== "teams") ||
     (prepared.tenant !== undefined && !isPreparedTenant(prepared.tenant)) ||
     (prepared.installation !== undefined &&
@@ -1486,6 +1486,19 @@ function isSafeExternalId(value: unknown): value is string {
   return (
     typeof value === "string" &&
     /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/.test(value)
+  );
+}
+
+const APP_USER_ID_MAX_LENGTH = 2048;
+
+/**
+ * Check a server-generated app-user id composed from provider-scoped parts.
+ */
+function isSafeAppUserId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length <= APP_USER_ID_MAX_LENGTH &&
+    /^[A-Za-z0-9][A-Za-z0-9_.:-]*$/.test(value)
   );
 }
 


### PR DESCRIPTION
## Problem

Teams prepared deliveries compose the adapter, tenant, and provider user ID. A real personal-chat identity is 133 characters, but the SDK validates `appUserId` with the 128-character single-external-ID bound and rejects the delivery before `onMessage` runs.

## Why

The composed app-user ID contains several opaque provider-owned parts. It needs its own bounded validator; widening every external ID would weaken unrelated protocol fields.

## Fix

- Validate only `appUserId` with a 2,048-character composite bound.
- Keep the same safe character set and the 128-character bound for other external IDs.
- Add regression coverage for the observed 133-character Teams shape and the upper bound.

Paired Intelligence contract fix: https://github.com/CopilotKit/Intelligence/pull/720
